### PR TITLE
Promote testing to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Focused references:
 | [Workflows](docs/WORKFLOWS.md) | The composable dev-lifecycle workflow engine, block catalog, and authoring |
 | [Workspace Management](docs/WORKSPACES.md) | Multi-repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
+| [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token — at rest, in transit to git, and in the in-browser editor; where exposure is and isn't closed |
 | [Benchmarks](docs/BENCHMARKS.md) | Latency measurements and performance budget |
 | [Compatibility](docs/COMPATIBILITY.md) | Supported OS, shell, and provider matrix |
 | [VS Code Integration](docs/VSCODE.md) | Wire aimee into VS Code via MCP tools or as an OpenAI-compatible model |

--- a/docs/WEBCHAT_GIT_SECURITY.md
+++ b/docs/WEBCHAT_GIT_SECURITY.md
@@ -1,0 +1,154 @@
+# Webchat git credential security model
+
+How aimee-webchat handles a webuser's git forge credentials — at rest, in transit
+to git, and inside the in-browser editor — and where exposure is and isn't
+closed. This is the reference for the `webchat git projects + in-browser VSCode`
+feature (proposal in `docs/proposals/done/webchat-git-projects-and-vscode.md`).
+
+## Threat model
+
+A webchat user (`webuser:<name>` principal) connects their own git credentials
+(HTTPS PAT/token, GitHub OAuth, or an SSH key) and performs git operations and
+in-browser editing on the server. The credentials are **theirs**, but aimee is
+multi-user and server-hosted, so the goals are:
+
+1. **At rest:** never plaintext on disk; encrypted per-principal.
+2. **Cross-tenant:** one webuser can never read another's credential or files.
+3. **In transit to git:** on the **API git paths** (clone/fetch/pull/push,
+   status/log/diff/branch, and PR creation) the token must not leak into a child
+   process's environment (`/proc/<pid>/environ`), argv, logs, or a named file —
+   where a co-located process could read it. The **in-browser editor is
+   explicitly out of scope for this invariant today** — see the editor section
+   for the one remaining (bounded) exposure and the socket-askpass fix that would
+   close it.
+4. **No server-secret bleed:** the editor must never see aimee-server's own
+   secrets (DB password, server token, provider keys).
+
+## At rest — the per-principal vault
+
+Credentials live only in the encrypted per-principal vault
+(`server_vault.c`, `vault_service.c`, `vault_store.c`), keyed by the
+`webuser:<name>` principal and sealed under the server master key
+(`.server-master.key`, dual-access wrap), so the co-located server can read them
+autonomously while they are never plaintext on disk and never returned to the
+browser. Intake routes (`/v1/git/credentials`, `/v1/git/sshkey`,
+`/v1/git/oauth/github/*`) are write-only. A `test_webchat_git_leak` check asserts
+the credential's plaintext appears in **no** file under `$AIMEE_HOME`, and that a
+second principal cannot read it (cross-principal denial).
+
+The credential-resolution precedence is centralized in **one** policy
+(`git_cred_inject_build_env_for_repo` / `git_cred_inject_resolve_token`); a lint
+gate (`git-cred-centralized-check`) forbids any caller from hand-rolling the
+ladder.
+
+## In transit to git — the token is out of `/proc/<pid>/environ`
+
+For **every API git path** (clone, fetch, pull, push, status/log/diff/branch, and
+PR creation), the forge token does **not** appear in any child process's
+environment:
+
+- **git operations + clone** use an **fd-fed askpass**. The resolved HTTPS token
+  is written to an anonymous **`memfd`** (MFD_CLOEXEC; never a named path). A
+  `safe_exec` variant `dup2`s it onto a fixed fd (`GIT_CRED_TOKEN_TARGET_FD`) in
+  the forked git child with CLOEXEC cleared; the env carries
+  `AIMEE_GIT_TOKEN_FD=<n>` (a *number*, not the secret) instead of `GH_TOKEN`.
+  The `GIT_ASKPASS` shim reads the token from `/proc/self/fd/<n>` (re-readable —
+  `cat` reopens the memfd at offset 0). The source memfd is CLOEXEC in the
+  parent, so a concurrent exec on another thread can't inherit it; `memfd_create`
+  failure fails **closed** (drops the token) rather than falling back to env.
+  Binding invariant — proven in `test_git_cred_inject`: a child run with this env
+  reads the token via `/proc/self/fd/<n>` but its `/proc/self/environ` contains
+  only the fd *number*, never the token.
+
+- **Opening a PR** is an **in-process GitHub REST call** (`git_pr_api.c`), not a
+  child exec: aimee-server POSTs to `/repos/{owner}/{repo}/pulls` with the token
+  in the `Authorization` header — in server memory only, wiped after the call,
+  never logged (the HTTP client logs host + byte counts, never headers). The
+  origin host is parsed **exactly** (rejects `evilgithub.com`,
+  `github.com.evil.com`, …); GitHub remotes only. (This replaced an earlier
+  `gh pr create`, which read `GH_TOKEN` from the child env.)
+
+- **SSH keys** are loaded into a per-user **in-memory `ssh-agent`** (`memfd`,
+  `RLIMIT_CORE=0`, `DUMPABLE=0`, key buffer zeroed after load); git uses it via
+  `SSH_AUTH_SOCK`. The agent socket lives under a **tmpfs-mandatory**,
+  fail-closed per-principal runtime dir (`webuser_runtime.c`); nothing touches
+  `~/.ssh`.
+
+## Cross-tenant isolation
+
+Every `/v1` workspace/git route resolves its target from the **attested**
+`webuser:` principal (never a client-supplied path) through `workspace_scope`
+(`realpath` + `openat`/`O_NOFOLLOW` containment), and rejects roots outside the
+caller's own tree. The git surface can be disabled wholesale with
+`AIMEE_WEBCHAT_GIT=0` (all git routes → 503); the editor independently with
+`AIMEE_WEBCHAT_EDITOR=0`. Both default on.
+
+## The in-browser editor (code-server) — residual exposure
+
+The editor process env is curated of the server's own secrets (e.g. `AIMEE_DB2_URL`,
+`AIMEE_SERVER_TOKEN`, provider keys) and hardened (`no_new_privs`,
+`DUMPABLE=0`, `RLIMIT_CORE=0`, loopback-only, behind the authed proxy, git's
+on-disk `credential.helper` disabled). **However**, unlike the API git paths, the
+editor still injects the HTTPS token as **`GH_TOKEN` in the code-server
+environment.** This is the one remaining spot the token is in a child's
+`/proc/<pid>/environ`. It is a **bounded** exposure — it is the user's *own*
+token, in their *own* editor — but it is readable by **any same-UID code-server
+descendant**: the extension host and its children (chiefly an extension the user
+installs), the integrated terminal, and any shell or git it spawns. It is not yet
+closed. Three pieces remain, and the key technical facts behind them were
+established empirically:
+
+### Why the editor can't use the fd-askpass (must use a socket)
+
+The fd-askpass that works for the API git paths does **not** work for the editor.
+Measured against a real code-server 4.126 / Node 24 on a test host:
+
+- VS Code's **SCM "Git" view** runs git in the **extension host** via
+  `child_process.spawn`, which **does** forward an inherited extra fd — so an
+  fd-askpass would work there.
+- The **integrated terminal** spawns its shell via **`node-pty`**, which **does
+  not** forward the inherited fd (the dup2'd fd is not open in the pty child — node-pty does not inherit it).
+
+So switching the editor to fd-mode would silently **break terminal git** (the
+askpass would find no fd and, with no `GH_TOKEN` to fall back to, fail auth). The
+correct fix is a **socket-fed askpass**: a per-principal unix-domain socket
+(0700, in the tmpfs runtime dir, like the ssh-agent) served from aimee-server's
+in-memory broker; the askpass connects and reads the token, which works
+regardless of fd inheritance. This is scoped but unimplemented.
+
+### Extension-host containment is not a selective env-strip
+
+The proposal's "strip `GIT_ASKPASS`/`SSH_AUTH_SOCK` from the extension host but
+keep them for the integrated terminal **and SCM**" is **internally
+contradictory**: VS Code's SCM Git provider *runs in the extension host*, so
+those are the same trust boundary — there is no knob to give the built-in Git
+extension the credential env while denying it to a third-party extension in the
+same host. The realistic mitigations are: the secret-free curated env (done — no server
+secrets reach any extension), an operational posture of Open-VSX-only with no
+preinstalled third-party extensions (a deployment policy, not code-enforced), and
+treating any extension the user installs as having access to the user's *own* git
+credential by design.
+
+### OS-jail (namespace / seccomp / cgroup) is future work
+
+The editor terminal currently runs as the server UID with the server `PATH`
+(`no_new_privs` already neuters setuid escalation such as `sudo`, and the
+non-root UID denies `docker`/`nsenter`). A stronger jail — a `bwrap`/`unshare`
+bind-mount namespace confining the terminal to the workspace subtree, a `seccomp`
+filter denying `mount`/`pivot_root`/`setns`, and cgroup CPU/mem limits — is
+future work; it requires `bubblewrap` in the image and iterative validation
+against a live editor.
+
+## Status summary
+
+| Surface | Token in `/proc/<pid>/environ`? | Mechanism |
+|---|---|---|
+| clone, fetch, pull, push, status/log/diff/branch | **No** | memfd fd-askpass |
+| open PR | **No** | in-process GitHub REST (`Authorization` header) |
+| SSH git | **No** | in-memory ssh-agent (`SSH_AUTH_SOCK`) |
+| in-browser editor (code-server) | **Yes** (bounded: user's own token) | `GH_TOKEN` in env — fix = socket-fed askpass (scoped) |
+
+**Remaining hardening** (all editor-scoped, all needing a live code-server to
+implement+validate): socket-fed askpass for the editor; the bwrap/seccomp/cgroup
+jail. Extension-host "containment" is resolved as a documented limitation rather
+than an (infeasible) selective env-strip.

--- a/docs/features/context-fold.md
+++ b/docs/features/context-fold.md
@@ -188,10 +188,55 @@ caching offers no read discount at all (`cache_read ≥ input`). Missing pricing
 | OpenAI / Responses | Automatic prefix caching — no explicit marker exists or is needed; the freeze's byte-identical ordering already satisfies the cache-hit criteria, and cache writes are free | No code; advisory only |
 | Gemini | `cachedContent` resource, created once per run for the system prompt | Existing; extending it to per-epoch message history is deferred (single per-request resource; recreating it per epoch is expensive for the small post-reduction prefix) |
 
-## Default-on candidacy
+## Default state
 
-Folding is a token/cost optimisation with an agentic-recovery cost (a folded body
-must be re-fetched if needed). Per aimee's off-reasons discipline, default-on is
-gated on the integration-test results (token reduction, cache-read share, and
-0-lost-coordinate fidelity on a captured long session). See the proposal close-out
-for the assessment.
+The unified **context economizer** (`reduce.*`) is **default-ON at the delegate
+seam**: `reduce.measure`, `reduce.delegate_seam`, `reduce.history_fold`,
+`reduce.compress`, and `compact.coord_closet` all default true, and the freeze cost
+guardrail (`reduce.freeze_guard`) is on. Concretely, every sub-agent (delegate) turn
+now folds old history and compresses oversized tool-result bodies, with the
+Coordinate Closet conserving the exact identifiers so the lossy reduction stays
+recoverable. `history_fold` auto-excludes the Responses/chatgpt builder at the call
+site (its synthetic-turn shape is unverified there); `compress` runs for every
+provider.
+
+**Recovery model (what "recoverable" means here).** This is a *lossy* reduction with
+**agentic recovery**, not lossless caching — be precise about the guarantee:
+- **Recent context is never touched.** Both levers only reduce messages *before* the
+  retained tail; the most recent `retained_msgs` (default 8) are byte-for-byte intact,
+  so the agent's working set is always full. `retained_msgs` follows the numeric-0 =
+  built-in-default convention (0 → 8), so the working-set floor is always ≥ 1 — it can
+  never be configured to zero; an explicit small value (e.g. 1) just narrows it.
+- **Identifiers are conserved, not bodies.** When an old tool-result body is elided,
+  the Coordinate Closet preserves the exact paths/ids/hashes it contained (plus the
+  body's head+tail excerpt), so references survive. The *omitted middle* of an old
+  body is not retained.
+- **Recovery is the agent re-issuing a tool call** (e.g. re-reading a conserved path)
+  — there is **no automatic inline re-fetch**. If a re-fetch fails, the agent handles
+  it as an ordinary tool error. This refetch is the accepted cost of default-on.
+- Coordinate fidelity (0 lost identifiers) was validated on a captured long session in
+  the deterministic-fold close-out.
+
+Operators who want the prior behavior opt out per lever, e.g.:
+
+```yaml
+reduce:
+  history_fold: false   # keep full history (no rolling skeleton)
+  compress: false       # keep full tool-result bodies
+  # delegate_seam: false  # disable the economizer on the delegate path entirely
+```
+
+**Config persistence convention.** A fresh default config writes **no** `reduce` or
+`compact.coord_closet` block at all — the defaults live in `config_set_defaults`
+(`src/config.c`). On save, *default-on* keys (`measure`, `delegate_seam`,
+`history_fold`, `compress`, `freeze_guard`, `coord_closet.enabled`) persist only their
+non-default **OFF** state; *default-off* keys (`gateway_seam`) persist only their
+non-default **ON** state. So an operator opt-out round-trips, and an unmodified config
+stays empty. Note `coord_closet.budget_bytes: 0` means **"use the built-in default"**,
+not "force a zero-byte closet" — to disable the closet, set `enabled: false`.
+
+**Not yet default-on:** the **gateway seam** (`reduce.gateway_seam`, the inbound /v1
+path that serves the primary agent) remains off — it is shadow-measure-only until its
+request-mutation path and 400-retry-from-pristine circuit breaker are built. The
+legacy standalone `fold.*` path also stays opt-in; the economizer supersedes it (when
+the economizer produces a reduced view, the legacy `build_fold_view` is skipped).

--- a/docs/features/context-fold.md
+++ b/docs/features/context-fold.md
@@ -144,6 +144,50 @@ close-out):
 - **Recall is hint-only.** Re-touch surfaces a hint pointing at the on-demand
   recovery tools; automatic inline body fetch is deferred.
 
+## Freeze cost guardrail and cross-provider cache placement
+
+The freeze pins the fold boundary so the reduced prefix stays byte-identical
+turn-to-turn, which keeps the provider prompt cache warm. But establishing a cache
+entry costs a one-time **cache-write**, and a boundary that keeps advancing can pay
+that write repeatedly — which, on a provider that bills cache writes at a premium,
+can make freezing cost *more* than it saves.
+
+The **freeze cost guardrail** (`reduce.freeze_guard`, default **on**; only acts when
+the economizer freeze is itself enabled, which is default-off) prices the decision
+before pinning a boundary. It compares the *marginal* cost of caching against the
+savings from reuse, using the same `token_tracker` rates as the rest of the cost
+story:
+
+- **Marginal write cost = the write _premium_**, `cache_write_rate − input_rate` —
+  not the full write rate. You pay the input rate to send the prefix on the first
+  turn regardless; caching only adds the difference. Providers with free cache
+  creation (OpenAI/Responses: `cache_write = 0`) have a premium ≤ 0, so freezing is
+  pure upside and is always kept on.
+- **Per-reuse saving = `input_rate − cache_read_rate`**, accrued over
+  `reduce.freeze_guard_horizon` expected reuses (default **1**, clamped to
+  `FREEZE_GUARD_MAX_HORIZON`).
+- Freeze is pinned when `horizon × per_reuse_saving ≥ write_premium`; otherwise the
+  turn re-derives the boundary without pinning (`reduce_result.freeze_guarded`).
+
+For every model aimee currently prices this keeps freeze **on** even at horizon 1
+(Anthropic has a small positive write premium that a single reuse's read discount
+already covers; OpenAI has no premium). The exact break-even is re-derived from the
+live pricing table by `test_freeze_guard`, so a future price change that would flip
+the verdict fails that test rather than silently drifting from this prose. The
+guardrail therefore changes no current behavior — its job is to encode
+the correct economics as a tested invariant and to disable freeze automatically only
+under *adverse* pricing (a write premium that outweighs the reuse savings), or when
+caching offers no read discount at all (`cache_read ≥ input`). Missing pricing
+**fails open** (freeze stays on, preserving prior behavior).
+
+### Per-provider cache placement
+
+| Provider | Mechanism | Status |
+|----------|-----------|--------|
+| Anthropic | `cache_control:{ephemeral}` on the stable system-prompt prefix | Existing (`cache_shaping_enabled`); a frozen-history breakpoint is possible future work but low value while reduction keeps the frozen prefix small |
+| OpenAI / Responses | Automatic prefix caching — no explicit marker exists or is needed; the freeze's byte-identical ordering already satisfies the cache-hit criteria, and cache writes are free | No code; advisory only |
+| Gemini | `cachedContent` resource, created once per run for the system prompt | Existing; extending it to per-epoch message history is deferred (single per-request resource; recreating it per epoch is expensive for the small post-reduction prefix) |
+
 ## Default-on candidacy
 
 Folding is a token/cost optimisation with an agentic-recovery cost (a folded body

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -163,7 +163,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 
 > **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `wfe_live_forge_enabled`
 
-## Config-file sections (50)
+## Config-file sections (51)
 
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`; a key shown as a bare name that is itself a nested object is noted in the section description (see *Coverage & limitations*).
 
@@ -204,6 +204,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
+- **`reduce`** — `delegate_seam`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (134)
+## CLI-settable keys (135)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -153,6 +153,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
 | `require_session_worktree` | bool | Fail closed on mutating ops outside an aimee-managed worktree (session-isolation guard; default off). |
+| `tool_output_max_bytes` | int | Per-result cap (bytes) on the model-visible tool output (read_file/bash/grep/glob/git_* results). 0 = built-in default (32768); any positive value is clamped to (0, 32768]. Set it lower to bound the bytes a single tool result adds to the prompt + history; the (default-off) context-economizer compresses older results to keep history bounded. |
 | `tsr_command` | string | TSR sidecar endpoint/command for structured-PDF table recognition (resolves like embedding_command; AIMEE_TSR_URL env fallback). |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -204,7 +204,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `delegate_seam`, `gateway_seam`, `history_fold`, `measure`
+- **`reduce`** — `compress`, `delegate_seam`, `gateway_seam`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -204,7 +204,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `delegate_seam`, `measure`
+- **`reduce`** — `delegate_seam`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -205,7 +205,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `compress`, `delegate_seam`, `gateway_seam`, `history_fold`, `measure`
+- **`reduce`** — `compress`, `delegate_seam`, `freeze_guard`, `freeze_guard_horizon`, `gateway_seam`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -204,7 +204,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `delegate_seam`, `history_fold`, `measure`
+- **`reduce`** — `delegate_seam`, `gateway_seam`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/docs/proposals/pending/economizer-gateway-mutation.md
+++ b/docs/proposals/pending/economizer-gateway-mutation.md
@@ -1,0 +1,286 @@
+# Proposal: Gateway mutation — primary-agent context reduction
+
+- **State:** PROPOSED — not started. Extends the unified context economizer
+  (`context_reduce`/`context_fold`/`compact_body`, now default-ON at the delegate seam).
+  Design roundtable-reviewed (3 rounds; all decisions D1–D6 + the
+  `should_apply`/snapshot/hard-bypass refinements incorporated below).
+- **Thesis:** the economizer reduces the **delegate** (sub-agent) turn loop, but the
+  inbound `/v1` **gateway** — the path that serves the **primary** agent (including
+  Claude-Code-through-aimee) — runs the economizer in **shadow** (`measure_only=1`
+  hardcoded: `anthropic_http.c:254`, `openai_chat.c:906`). It measures the primary
+  agent's reduction opportunity and records a forecast, but never applies it, so the
+  primary agent's tokens are not reduced. This proposal makes the gateway **apply** the
+  reduced messages to the live request — under a default-off flag, compress-only,
+  behind a per-session circuit breaker — so the primary agent reduces too.
+
+## Charter roles
+Reduce (the context economizer) extended to the **inbound** request-assembly seam. Reuses
+`context_reduce` unchanged, the per-format boundary invariants, `message_history_repair`,
+and the hard-bypass contract. No new reduction algorithm.
+
+## Goal
+Primary-agent context reduction that **cannot *persistently* break live client traffic
+without circuit-breaking subsequent turns**: a reduced request the provider rejects is
+caught (buffered: retried from the pristine original; streaming: the offending session is
+disabled for **subsequent** turns — the current stream completes as the upstream
+delivered it, per §7 R1), the working set is never elided, and the whole feature is
+default-off behind a flag with numeric `.254` validation gates before any default-on
+decision.
+
+## §0 Why this is higher-risk than the delegate seam
+The delegate seam mutates a sub-agent's request — a contained blast radius. The gateway
+mutates the **live client-serving** request (`/v1/messages`, `/v1/responses`). A reduction
+bug there surfaces to the end user. The design is therefore correctness-first and
+default-off, and treats streaming and buffered paths separately because their recovery
+options differ fundamentally (§2).
+
+## §1 Precondition (verified by recon)
+- **Buffered (`stream=0`):** the upstream HTTP status is known *before* any bytes are
+  sent to the client (`anthropic_http.c:424`; `openai_chat.c:981`). A 400-retry-from-
+  pristine is feasible.
+- **Streaming (`stream=1`):** `write_sse_headers()` commits HTTP 200 to the client
+  (`server_http.c:1188`/`:1178`) *before* the upstream status is known. Once streaming
+  starts, a mid-stream retry-from-pristine is **architecturally impossible**.
+- No existing gateway 400-retry (`http_retry_post_context` deliberately does not retry
+  4xx). Inbound headers are readable via `http_header()` (`server_http.c:1354`).
+- The provenance marker `reduce_state.reduced` already travels in-payload, so a request
+  crossing both the gateway and the delegate seam is not double-reduced.
+
+## §2 Design
+
+### §2.1 Decisions (roundtable D1–D6)
+- **D1 — Streaming mutates** under reduction-correctness guarantees + per-session disable;
+  **no mid-stream retry.** This is the same contract the delegate seam already operates
+  under (it mutates with no 400-from-pristine either — only hard-bypass + repair).
+- **D2 — New flag `reduce_gateway_mutate` (default OFF)**, separate from the existing
+  shadow `reduce_gateway_seam`. `mutate=1` implies `seam=1` (auto-enable + a single
+  startup WARN), so the shadow baseline the validation gates need always exists.
+- **D3 — Compress-only at the gateway in v1.** Fold is deferred to a follow-up
+  (`reduce_gateway_fold`) — its boundary edge-cases concentrate the mutation risk.
+  Compress-only captures ~30–50% of the saving with the smallest blast radius.
+- **D4 — Per-session disable** (in-process LRU, §2.4).
+- **D5 — No inbound header opt-in in v1** (`X-Aimee-Reduce` may be added later as an
+  additive filter).
+- **D6 — Provenance reuse** (`reduce_state.reduced`) is sufficient across the seam
+  boundary, subject to a CI verification gate (§2.6); **clear-on-restore is mandatory**.
+
+### §2.2 The mutation gate — `should_apply()` + hard-bypass
+`should_apply(reduced, pristine)` returns true **only if**: the reduce reported no internal
+error; the result is a genuine net shrink (a no-op reduce is not a mutation); a
+`message_history_repair` run on the reduced result reports no structural violation (no
+tool_use/tool_result split); and the replace installs cleanly. Otherwise the site
+**hard-bypasses** — forwards the pristine request, records the reason, and skips the
+restore path. Hard-bypass is not itself a disable trigger.
+
+The reduce **internal-error** enum is explicit and is the same set surfaced in
+`gateway_hard_bypass{reason}` and the §5 step-11 CI fixtures: `reduce_alloc_failed`,
+`reduce_parse_failed`, `reduce_internal_assertion`, `reduce_format_unsupported`. The
+non-error hard-bypass reasons are `no_op`, `structural_violation`, `snapshot_oom`, and
+`replace_failed` (where `replace_messages_for_upstream()` collapses allocation failure,
+unexpected-NULL content, size mismatch, and encoder error into the single `replace_failed`
+tag).
+
+**Construction-failure invariant (blocking).** The "never send an un-restorable reduced
+payload" rule extends *past* `should_apply`: **if any step after `should_apply` returns
+true fails before the upstream request is fully constructed and dispatched — OOM during
+header/body serialization, JSON-encode failure of the reduced body, transport setup error,
+any construction-time error — the gateway MUST fall back to the pristine snapshot and abort
+the mutation** (reason `construct_failed`). This is a §5 step-11 fixture that injects a
+failure between `should_apply` and dispatch and asserts pristine was sent.
+
+**Provenance ordering (blocking-adjacent).** `reduce_state.reduced` is set on the live
+payload **only after replace succeeds**, and is cleared on every hard-bypass path
+(`replace_failed`, `construct_failed`, `snapshot_oom`, `structural_violation`,
+`internal_error`, `no_op`). A partial-replace failure therefore never leaves a falsely
+`reduced=true` payload that the delegate seam would skip.
+
+### §2.3 Snapshot semantics
+`snapshot_messages()` is a **deep copy** in v1 (every message + content string independently
+allocated), so restoring pristine is independent of any retained references (reply framing,
+provider response objects). On allocation failure it returns NULL → the site hard-bypasses
+(**never send a reduced payload that cannot be restored**); **all partially-copied
+sub-objects are freed before returning NULL** (no leak on partial failure). Refcount/COW is
+a post-v1 optimization, gated on the §9 O2 benchmark.
+
+On the **streaming** path the snapshot exists *solely* to enforce the un-restorable
+invariant (it is held as a reference and freed after the reduce/replace decision; it is
+**never restored** — streaming recovery is disable-only). Its latency/memory cost is
+included in the §9 O2 benchmark, not just the buffered path.
+
+### §2.4 Per-session disable (D4)
+New module `msg_session_disable.{c,h}`:
+- **Mutation requires a resolvable per-identity session key.** The key is derived (ordered)
+  from: an inbound `aimee-session-id` header **validated against the auth identity**, else
+  `SHA-256(bearer_token)[16hex]`. **A request with neither a validated header nor a bearer
+  is NOT mutated** — it is a pristine passthrough, and **no disable state is written for
+  it.** This removes the process-global `_anonymous` bucket entirely, so one caller's
+  failure can never disable reduction for an unrelated caller (the §7 R5 cross-caller
+  denial-of-feature hazard).
+- **Header format + validation:** the `aimee-session-id` value MUST equal
+  `SHA-256(auth_identity)[16hex]` (lowercase hex, exactly 16 chars). Any other value —
+  mismatch, wrong length, non-hex, control chars — is treated as **absent** (fall through
+  to the bearer hash), with at most one WARN per 60 s per source IP. An attacker holding a
+  valid bearer therefore cannot forge another identity's session key.
+- **Storage:** bounded LRU (cap 10k, ~1 MB), value `{disabled, expires_at, reason}`. **Sweep
+  cadence:** on insert when size exceeds cap/2, plus a coarse wall-clock sweep every 60 s.
+- **TTL:** `reduce_gateway_session_disable_ttl_ms` (default 1 h). **Must be > 0** — `0` and
+  negative values are **rejected at config validation as startup-fatal** (a permanent-pin or
+  breaker-off knob on a live path is disproportionate runtime risk; the diagnostic
+  breaker-off mode, if ever needed, is a debug-only build flag, not a runtime knob).
+- **Scope:** process-local; no cross-process replication in v1.
+
+### §2.5 Path-by-path
+**Buffered (both providers):** `snapshot → reduce → should_apply → send`. On the upstream
+response of a **mutated** request:
+- **Any 4xx** (not just 400 — a reduction can alter serialization into 413/422/etc.):
+  restore pristine + `message_history_repair` (idempotent — the pristine is unmodified;
+  defense-in-depth only, no signal of pristine corruption) + **resend once** + disable the
+  session + clear `reduce_state.reduced`. Counter: `gateway_4xx_restore_resend`.
+- **5xx:** **disable the session only — do NOT resend** (provider state is uncertain after a
+  5xx; retrying from pristine is too speculative). Counter: `gateway_5xx_disable`. The 5xx is
+  forwarded to the client as the provider returned it; it is never silently un-classified.
+
+OpenAI adds a **new** `gateway_retry_post_with_reduction()` wrapper — it does **not** modify
+`http_retry_post_context` (whose 4xx semantics must not change).
+
+**Streaming (both providers):** `snapshot (un-restorable-invariant only) → reduce →
+should_apply → open stream`. Failure detection is at the **SSE decoder layer, not a raw
+read loop**: events are reassembled across TCP boundaries (a split frame is held in a
+single-event classification buffer — no full-response buffering, no rewrite of
+client-visible bytes), then forwarded as-is. Disposition of a **mutated** stream:
+- **Invalid-request-class error frame** (Anthropic `error.type` ∈ invalid_request /
+  embedded 4xx status; OpenAI `error.code` invalid-request) → disable the session for
+  **subsequent** turns. These correlate with a bad reduced payload.
+- **Unparseable / malformed frame, decoder-state error, or a non-SSE upstream failure after
+  the 200 commit** (TCP reset, mid-stream 5xx body) → **fail-safe: disable the session** and
+  forward whatever arrived; the current turn is already lost (200 committed).
+- **Rate-limit / content-filter / server-error frames** → forwarded **without** disabling
+  (they are not reduction bugs and must not false-positive the breaker).
+
+In all streaming cases the current turn completes as the upstream delivered it; only
+**subsequent** turns in the session are affected.
+
+### §2.6 Provenance across the seam (D6)
+| Scenario | `reduced` after gateway | Delegate seam | Correct? |
+|---|---|---|---|
+| Gateway reduced | `true` | skips | ✅ |
+| Gateway hard-bypassed | `false` | attempts | ✅ |
+| Gateway reduced → 400 → restored | **cleared** | attempts on the restored original | ✅ |
+| Session disabled | `false` | attempts | ✅ |
+
+CI verifies clear-on-restore, clear-on-hard-bypass, clear-on-OOM, and the
+gateway→delegate hand-off in both directions. If the in-payload marker does not survive
+the actual boundary in code, add an internal portable marker — verification is the gate,
+not assumption.
+
+## §3 Configuration
+```
+reduce_gateway_seam                    = 1        # existing — shadow/measure
+reduce_gateway_mutate                  = 0        # NEW — apply reduction; default OFF
+reduce_gateway_session_disable_ttl_ms  = 3600000  # NEW — 1 hour
+```
+`mutate=1` while `seam=0` is inconsistent → auto-enable seam **in memory only** (never
+modifies the config file) + one startup WARN; a config left at `seam=0, mutate=1` repeats
+the WARN each start until corrected. `reduce_gateway_session_disable_ttl_ms` **must be > 0**
+(0 / negative are startup-fatal config errors, per §2.4).
+
+## §4 Telemetry (the validation input)
+Counters/histogram on the gateway path: `gateway_mutate_attempted`, `…_applied`,
+`gateway_hard_bypass{reason}` (reasons per §2.2), `gateway_4xx_restore_resend`,
+`gateway_5xx_disable`, `gateway_stream_error_disable` (the streaming invalid-request +
+fail-safe disables), `gateway_session_disabled_set{reason}`,
+`gateway_session_disabled_blocks`, `gateway_token_delta_pre_post_sampled` (≤1% sample). The
+shadow baseline is produced **in parallel on every mutated request**: `measure_only` still
+runs on the pristine snapshot and forecasts what the shadow path would have done, so the
+mutated-vs-shadow comparison (§6) is on identical payloads, not a separate traffic window.
+
+## §5 Implementation plan
+Steps 1–5 + 10 ship behind `reduce_gateway_mutate=0` with **zero behavior change**; step 4
+is pure refactor. Steps 6–9 are the wiring; step 11 is the gate to `.254`.
+
+1. Config flags + startup consistency check.
+2. `msg_session_disable.{c,h}` (LRU, TTL, sweep).
+3. `session_id_resolve()` with header-vs-auth validation.
+4. Extract `snapshot_messages()` (OOM-aware), `snapshot_token_count()`,
+   `replace_messages_for_upstream()` helpers.
+5. `should_apply()` + `hard_bypass()`.
+6. Anthropic buffered: mutate + restore + resend + disable + clear-provenance.
+7. Anthropic streaming: mutate + SSE error-frame inspect-as-forward + disable.
+8. OpenAI buffered: `gateway_retry_post_with_reduction()` wrapper.
+9. OpenAI streaming: symmetric to Anthropic (separate review — provider framing differs).
+10. Telemetry.
+11. CI: snapshot/restore equivalence, OOM hard-bypass, repair idempotency, provenance
+    across the seam, disable-map TTL/sweep, header-vs-auth validation, SSE error-frame
+    detection.
+
+## §6 Validation gates (`.254`, before any default-on)
+≥7 days with `reduce_gateway_mutate=1`, ≥10k mutated requests per provider per stream mode:
+
+| Metric | Pass | On failure |
+|---|---|---|
+| Upstream 4xx, mutated vs shadow (same payloads) | within ±0.5% abs | reduce levers / roll back |
+| `gateway_5xx_disable` rate, mutated vs shadow | within ±0.5% abs | investigate / roll back |
+| `gateway_session_disabled_set` rate | < 5% of mutated sessions | reduce levers / roll back |
+| `gateway_hard_bypass` rate | < 1% of attempts | investigate reduce error paths |
+| `gateway_4xx_restore_resend` rate | < 2% of mutated requests | investigate boundary edges |
+| `gateway_stream_error_disable` rate | < 2% of mutated streams | investigate streaming detection |
+| user-visible stream-abort (after first byte, before `[DONE]`) | **zero** | hard rollback |
+| Pre→post token delta (sampled) | monotone reduction (never +5% vs shadow) | investigate regression |
+| Buffered p99 latency | < +10 ms vs shadow | benchmark snapshot cost |
+
+**Hard rollback:** any user-visible failure not contained by the per-session disable (incl.
+a non-disabling stream abort, or a 4xx/5xx that doesn't trip the breaker) → flip
+`reduce_gateway_mutate=0` pending investigation.
+
+## §7 Risks
+- **R1 — Streaming without retry is new ground.** Per-session disable is the only runtime
+  circuit breaker in v1; a global rolling-window flood-disable is designed and ready
+  (§9 O1) but deferred — reconsider after the first week of `.254` data.
+- **R2 — Snapshot cost on large contexts.** Deep copy at 1 M tokens is the open benchmark
+  (§9 O2); buffered p99 is a §6 gate. COW is a post-v1 optimization.
+- **R3 — `message_history_repair` after restore** — defense in depth; idempotency
+  CI-verified.
+- **R4 — OpenAI streaming framing parity** — separate review; the only provider-specific
+  catch in v1.
+- **R5 — Session-id spoofing + cross-caller denial-of-feature** — header-vs-auth validation
+  is mandatory; mutation requires a resolvable per-identity key and writes **no** disable
+  state for identity-less requests (no shared `_anonymous` bucket, §2.4), so one caller can
+  never disable another. Security review before `.254`.
+- **R6 — Default-ON** is a separate decision, out of scope for this proposal.
+
+## §8 Non-goals
+Mid-stream/SSE retry (architecturally blocked); recovery of the current streaming turn
+(only subsequent turns are protected); mutation of identity-less requests (pristine
+passthrough, no disable state); cross-process session-disable replication; new reduction
+algorithms; inbound-header opt-in; the fold lever on the gateway path; default-ON;
+refcount/COW snapshots (correctness-first); the global flood-disable (§9 O1).
+
+## §9 Open items
+- **O1 — Global rolling-window flood-disable** (second-order circuit breaker): a fixed
+  256-entry process-local ring buffer; if ≥ N disable events in M seconds, send everything
+  pristine until the window drains. Defaults N=5/M=300 s. ~50 LOC. **Deferred**; ratify
+  only if a model flap is a concern during validation.
+- **O2 — Snapshot benchmark** (200k/500k/1M tokens, deep-copy vs COW). Owned by perf;
+  must report before `.254`. Pass: p99 < +15 ms at 1 M tokens.
+
+## §10 Acceptance
+1. `reduce_gateway_mutate=0` → byte-identical to today (shadow if `seam=1`); proven by a
+   no-behavior-change test.
+2. Buffered mutate + 400-restore-resend + session-disable + clear-provenance, both providers.
+3. Streaming mutate + SSE error-frame disable, both providers; no mid-stream retry.
+4. `should_apply()` hard-bypasses on every failure class (incl. snapshot OOM) and never
+   sends an un-restorable reduced payload.
+5. Provenance CI gate (§2.6) green.
+6. The full economizer CI matrix + the new gateway tests green; default-OFF.
+7. `.254` validation (§6) met before any default-on proposal.
+
+```yaml acceptance
+- {id: 1, tier: mechanical, check: "make unit-tests TEST=test_msg_session_disable (LRU cap/eviction, sweep on insert>cap/2 + 60s wall-clock, TTL>0-required rejects 0/negative at config-validate; session-key = validated aimee-session-id (==SHA256(auth)[16hex]) -> hashed-bearer; identity-less request writes NO disable state; malformed/wrong-length/non-hex header treated as absent; cross-tenant: attacker bearer A + forged session-id B cannot disable B)"}
+- {id: 2, tier: mechanical, check: "make unit-tests TEST=test_gateway_mutate (should_apply: net-shrink + message_history_repair-clean + replace-ok; hard-bypass reasons reduce_alloc_failed/parse_failed/internal_assertion/format_unsupported/no_op/structural_violation/snapshot_oom/replace_failed/construct_failed each forward pristine; CONSTRUCTION-FAILURE fixture injects failure between should_apply=true and dispatch -> pristine sent; snapshot deep-copy independence + partial-alloc frees before NULL + OOM-never-sends-un-restorable; provenance set ONLY after replace succeeds + cleared on every hard-bypass/restore path)"}
+- {id: 3, tier: mechanical, check: "make build-integrity && make docs-gen-check && make schema-sync-check (reduce_gateway_mutate + reduce_gateway_session_disable_ttl_ms plumbed; default-off round-trips; mutate=1+seam=0 auto-enables seam in-memory + WARN; ttl<=0 startup-fatal)"}
+- {id: 4, tier: integration, check: "with reduce_gateway_mutate=0 the inbound /v1 request is byte-identical to today (shadow if seam=1) — no-behavior-change test for both providers, buffered + streaming"}
+- {id: 5, tier: integration, check: "buffered Anthropic + OpenAI: a mutated request that returns ANY upstream 4xx (400/413/422) restores the pristine original, resends once, disables the session, clears reduce_state.reduced (delegate seam re-attempts on the restored original); a mutated 5xx disables the session WITHOUT resend (gateway_5xx_disable) and forwards the 5xx"}
+- {id: 6, tier: integration, check: "streaming Anthropic + OpenAI: SSE decoder-layer detection with a SPLIT-FRAME fixture (error event straddling a TCP boundary is reassembled + caught); invalid-request error frame disables subsequent turns; unparseable frame / non-SSE post-200 failure (TCP reset) fail-safe disables; rate-limit/5xx error frames forwarded WITHOUT disabling; no full-response buffering, no client-byte rewrite, no mid-stream retry"}
+- {id: 7, tier: deployment, check: ".254 with reduce_gateway_mutate=1 over >=7 days, >=10k mutated requests/provider/stream-mode: upstream 4xx within +/-0.5% abs vs parallel shadow on same payloads, gateway_5xx_disable within +/-0.5%, session-disable <5%, hard_bypass <1%, 4xx-restore-resend <2%, stream_error_disable <2%, ZERO user-visible stream-aborts, sampled token delta monotone-reduction, buffered p99 <+10ms vs shadow"}
+- {id: 8, tier: hardware, check: "snapshot_messages() bench at 200k/500k/1M tokens (deep-copy vs COW), both providers AND both buffered + streaming snapshot paths: p99 <+15ms at 1M tokens vs no-snapshot baseline on target hardware (O2, before .254)"}
+```

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -152,6 +152,11 @@ CFG_KEY_DESC = {
     "ingress_max_raw_scans": "Max raw-content scans per ingress request.",
     "code_span_max_lines": "Max line span the code_span_get recovery resolver returns per call "
     "(default 400).",
+    "tool_output_max_bytes": "Per-result cap (bytes) on the model-visible tool output "
+    "(read_file/bash/grep/glob/git_* results). 0 = built-in default (32768); any positive value is "
+    "clamped to (0, 32768]. Set it lower to bound the bytes a single tool result adds to the "
+    "prompt + history; the (default-off) context-economizer compresses older results to keep "
+    "history bounded.",
     "require_session_worktree": "Fail closed on mutating ops outside an aimee-managed worktree "
     "(session-isolation guard; default off).",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",

--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
-            compact.c coord_closet.c fold_budget.c context_fold.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
+            compact.c coord_closet.c fold_budget.c context_fold.c context_reduce.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \

--- a/src/compact.c
+++ b/src/compact.c
@@ -177,10 +177,15 @@ static char *compact_plaintext(const char *raw, size_t raw_len, int head_bytes, 
    return out;
 }
 
-/* ------------------------------------------------------------------ public API */
+/* ------------------------------------------------------------------ shrink core */
 
-char *compact_tool_result(const char *raw, size_t raw_len, const compact_config_t *cfg,
-                          const char *tool_name, int context_used, int context_budget)
+/* Apply the three-strategy shrink and return a freshly heap-allocated result
+ * (caller frees). This is the byte-for-byte logic the public API used to expose
+ * directly; compact_body() wraps it into a caller-owned buffer. Kept as a static
+ * allocator so the well-tested strategy code (pass-through / JSON summary /
+ * head+tail) is unchanged — only the public ownership model moved. */
+static char *compact_shrink_alloc(const char *raw, size_t raw_len, const char *tool_name,
+                                  const compact_config_t *cfg)
 {
    if (!raw)
       return strdup("");
@@ -220,16 +225,6 @@ char *compact_tool_result(const char *raw, size_t raw_len, const compact_config_
    if (!enabled)
       return strdup(raw);
 
-   /* Dynamic budget adjustment: shrink threshold as context fills */
-   if (context_budget > 0 && context_used > 0)
-   {
-      int used_pct = (int)((long long)context_used * 100 / context_budget);
-      if (used_pct >= 80)
-         threshold = threshold / 2;
-      else if (used_pct >= 60)
-         threshold = threshold * 3 / 4;
-   }
-
    if (threshold < 64)
       threshold = 64; /* floor: never compact below 64 bytes */
 
@@ -246,4 +241,42 @@ char *compact_tool_result(const char *raw, size_t raw_len, const compact_config_
 
    /* Strategy 2: plain-text head + tail */
    return compact_plaintext(raw, raw_len, head_bytes, tail_bytes);
+}
+
+/* ------------------------------------------------------------------ public API */
+
+size_t compact_body(const char *raw, size_t raw_len, const char *tool_name,
+                    const compact_config_t *cfg, char *out, size_t out_cap)
+{
+   if (!out || out_cap == 0)
+      return 0;
+   if (!raw || raw_len == 0)
+   {
+      out[0] = '\0';
+      return 0;
+   }
+
+   char *s = compact_shrink_alloc(raw, raw_len, tool_name, cfg);
+   if (!s)
+   {
+      /* Allocation failure inside the shrink. Degrade to a bounded copy of the raw
+       * body rather than emitting an empty string — a non-empty body must never be
+       * silently dropped to "" (the caller's `compacted = out_len < raw_len` would
+       * otherwise treat OOM as a successful compaction). The caller still bounds the
+       * result (eager hard-cap; lazy net-shrink guard). */
+      size_t n = raw_len;
+      if (n > out_cap - 1)
+         n = out_cap - 1;
+      memcpy(out, raw, n);
+      out[n] = '\0';
+      return n;
+   }
+
+   size_t n = strlen(s);
+   if (n > out_cap - 1)
+      n = out_cap - 1; /* defensive: a correctly-sized buffer never truncates */
+   memcpy(out, s, n);
+   out[n] = '\0';
+   free(s);
+   return n;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -435,6 +435,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
    cfg->reduce_delegate_seam = 0;
    cfg->reduce_history_fold = 0;
+   cfg->reduce_gateway_seam = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -419,8 +419,10 @@ static void config_set_defaults(config_t *cfg)
    snprintf(cfg->db1_path, sizeof(cfg->db1_path), "%s", config_default_db1_path());
    snprintf(cfg->guardrail_mode, sizeof(cfg->guardrail_mode), "%s", MODE_APPROVE);
    snprintf(cfg->provider, sizeof(cfg->provider), "claude");
-   cfg->compact_enabled = 1;      /* default on; set before no-config early returns */
-   cfg->coord_closet_enabled = 0; /* fold §2: default-off */
+   cfg->compact_enabled = 1; /* default on; set before no-config early returns */
+   cfg->coord_closet_enabled =
+       1; /* fold §2: default-ON — conserves identifiers elided by the
+           * default-on compress/fold so lossy reduction stays recoverable */
    cfg->coord_closet_budget_bytes = 0;
    cfg->coord_closet_max_ratio_pct = 0;
    cfg->fold_enabled = 0; /* fold §1: default-off */
@@ -432,12 +434,23 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_freeze_tail_cap_msgs = 0;
    cfg->fold_recall_enabled = 0; /* fold §4: default-off */
    cfg->fold_recall_ttl_turns = 0;
-   cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
-   cfg->reduce_delegate_seam = 0;
-   cfg->reduce_history_fold = 0;
-   cfg->reduce_compress = 0;
+   /* Context economizer: DEFAULT-ON on the delegate seam (the implemented, tested
+    * reduction path). measure + delegate_seam + history_fold + compress all on.
+    * Lossy reduction stays recoverable: both levers only touch messages BEFORE the
+    * retained tail (the most recent retained_msgs stay full), and the Coordinate
+    * Closet (also default-on) conserves the exact identifiers so the agent can
+    * re-issue a tool call to recover an elided body. history_fold is converted to a
+    * live fold ONLY at agent_runtime.c (rcfg.history_fold = reduce_history_fold &&
+    * !chatgpt) — it reaches the Responses builder on ZERO paths; compress is
+    * shape-preserving and runs for all providers. */
+   cfg->reduce_measure_enabled = 1;
+   cfg->reduce_delegate_seam = 1;
+   cfg->reduce_history_fold = 1;
+   cfg->reduce_compress = 1;
+   /* GATEWAY seam (primary-agent /v1 path) stays off: shadow-only until its
+    * request-mutation + 400-retry-from-pristine circuit breaker are built. */
    cfg->reduce_gateway_seam = 0;
-   cfg->reduce_freeze_guard_enabled = 1; /* safety: on wherever the (default-off) freeze runs */
+   cfg->reduce_freeze_guard_enabled = 1; /* safety: on for the default-on economizer freeze */
    cfg->reduce_freeze_guard_horizon = 1; /* conservative break-even: one reuse pays the write */
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");

--- a/src/config.c
+++ b/src/config.c
@@ -437,6 +437,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_history_fold = 0;
    cfg->reduce_compress = 0;
    cfg->reduce_gateway_seam = 0;
+   cfg->reduce_freeze_guard_enabled = 1; /* safety: on wherever the (default-off) freeze runs */
+   cfg->reduce_freeze_guard_horizon = 1; /* conservative break-even: one reuse pays the write */
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -434,6 +434,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_recall_ttl_turns = 0;
    cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
    cfg->reduce_delegate_seam = 0;
+   cfg->reduce_history_fold = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;

--- a/src/config.c
+++ b/src/config.c
@@ -435,6 +435,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
    cfg->reduce_delegate_seam = 0;
    cfg->reduce_history_fold = 0;
+   cfg->reduce_compress = 0;
    cfg->reduce_gateway_seam = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");

--- a/src/config.c
+++ b/src/config.c
@@ -432,6 +432,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_freeze_tail_cap_msgs = 0;
    cfg->fold_recall_enabled = 0; /* fold §4: default-off */
    cfg->fold_recall_ttl_turns = 0;
+   cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
+   cfg->reduce_delegate_seam = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;
@@ -1039,6 +1041,7 @@ int config_load(config_t *cfg)
 
    config_parse_worktree_gc_section(cfg, root);
    config_parse_fold_section(cfg, root);
+   config_parse_reduce_section(cfg, root);
 
    config_parse_memory_section(cfg, root);
    config_apply_learning_settings(cfg, root);

--- a/src/config.c
+++ b/src/config.c
@@ -545,6 +545,9 @@ static void config_set_defaults(config_t *cfg)
    cfg->ingress_preinject_assembly_budget = 6144;
    cfg->ingress_max_raw_scans = 0;
    cfg->code_span_max_lines = 400;
+   /* 0 = use the built-in default AGENT_TOOL_OUTPUT_MAX (32768) for the
+    * per-result model-visible tool-output cap (see agent_tool_output_cap()). */
+   cfg->tool_output_max_bytes = 0;
    cfg->ingress_compress_min_chars = 80;
    cfg->require_session_worktree = 0;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
@@ -942,6 +945,10 @@ int config_load(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "code_span_max_lines");
    if (cJSON_IsNumber(item) && item->valuedouble > 0)
       cfg->code_span_max_lines = (int)item->valuedouble;
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "tool_output_max_bytes");
+   if (cJSON_IsNumber(item) && item->valuedouble >= 0)
+      cfg->tool_output_max_bytes = (int)item->valuedouble;
 
    item = cJSON_GetObjectItemCaseSensitive(root, "require_session_worktree");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -56,6 +56,7 @@ const config_field_t config_fields[] = {
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},
     {"code_span_max_lines", offsetof(config_t, code_span_max_lines), sizeof(int), 0, CFG_INT},
+    {"tool_output_max_bytes", offsetof(config_t, tool_output_max_bytes), sizeof(int), 0, CFG_INT},
     {"require_session_worktree", offsetof(config_t, require_session_worktree), sizeof(int), 0,
      CFG_BOOL},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -994,6 +994,16 @@ int config_save(const config_t *cfg)
       }
    }
 
+   /* Unified context economizer (only save if non-default) */
+   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam)
+   {
+      cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
+      if (cfg->reduce_measure_enabled)
+         cJSON_AddBoolToObject(reduce, "measure", cfg->reduce_measure_enabled);
+      if (cfg->reduce_delegate_seam)
+         cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
+   }
+
    /* Session/worktree cleanup policy (only save if non-default) */
    if (cfg->worktree_stale_secs || cfg->max_sessions || cfg->max_worktrees)
    {

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -282,6 +282,17 @@ static const char *config_save_default_db1_path(void)
    return path;
 }
 
+/* Does the unified context economizer hold any non-default value worth persisting?
+ * Centralized so each new reduce.* key is accounted for in exactly one place (the
+ * save gate + this predicate stay in sync). freeze_guard defaults ON and horizon
+ * defaults 1, so those count as non-default only when changed away from that. */
+static int reduce_has_non_default(const config_t *cfg)
+{
+   return cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
+          cfg->reduce_compress || cfg->reduce_gateway_seam || !cfg->reduce_freeze_guard_enabled ||
+          (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1);
+}
+
 int config_save(const config_t *cfg)
 {
    ensure_config_dir();
@@ -996,9 +1007,9 @@ int config_save(const config_t *cfg)
       }
    }
 
-   /* Unified context economizer (only save if non-default) */
-   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
-       cfg->reduce_compress || cfg->reduce_gateway_seam)
+   /* Unified context economizer (only save if non-default). freeze_guard defaults ON
+    * and horizon defaults 1, so they are emitted only when an operator changed them. */
+   if (reduce_has_non_default(cfg))
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
       if (cfg->reduce_measure_enabled)
@@ -1011,6 +1022,10 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(reduce, "compress", cfg->reduce_compress);
       if (cfg->reduce_gateway_seam)
          cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
+      if (!cfg->reduce_freeze_guard_enabled) /* default-on -> persist only when disabled */
+         cJSON_AddBoolToObject(reduce, "freeze_guard", 0);
+      if (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1)
+         cJSON_AddNumberToObject(reduce, "freeze_guard_horizon", cfg->reduce_freeze_guard_horizon);
    }
 
    /* Session/worktree cleanup policy (only save if non-default) */

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -996,7 +996,7 @@ int config_save(const config_t *cfg)
 
    /* Unified context economizer (only save if non-default) */
    if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
-       cfg->reduce_gateway_seam)
+       cfg->reduce_compress || cfg->reduce_gateway_seam)
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
       if (cfg->reduce_measure_enabled)
@@ -1005,6 +1005,8 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
       if (cfg->reduce_history_fold)
          cJSON_AddBoolToObject(reduce, "history_fold", cfg->reduce_history_fold);
+      if (cfg->reduce_compress)
+         cJSON_AddBoolToObject(reduce, "compress", cfg->reduce_compress);
       if (cfg->reduce_gateway_seam)
          cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
    }

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -995,13 +995,15 @@ int config_save(const config_t *cfg)
    }
 
    /* Unified context economizer (only save if non-default) */
-   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam)
+   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold)
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
       if (cfg->reduce_measure_enabled)
          cJSON_AddBoolToObject(reduce, "measure", cfg->reduce_measure_enabled);
       if (cfg->reduce_delegate_seam)
          cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
+      if (cfg->reduce_history_fold)
+         cJSON_AddBoolToObject(reduce, "history_fold", cfg->reduce_history_fold);
    }
 
    /* Session/worktree cleanup policy (only save if non-default) */

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -801,6 +801,8 @@ int config_save(const config_t *cfg)
                               cfg->ingress_preinject_assembly_budget);
    if (cfg->code_span_max_lines != 400)
       cJSON_AddNumberToObject(root, "code_span_max_lines", cfg->code_span_max_lines);
+   if (cfg->tool_output_max_bytes != 0)
+      cJSON_AddNumberToObject(root, "tool_output_max_bytes", cfg->tool_output_max_bytes);
    if (cfg->ingress_max_raw_scans != 0)
       cJSON_AddNumberToObject(root, "ingress_max_raw_scans", cfg->ingress_max_raw_scans);
    if (cfg->require_session_worktree)

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -995,7 +995,8 @@ int config_save(const config_t *cfg)
    }
 
    /* Unified context economizer (only save if non-default) */
-   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold)
+   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
+       cfg->reduce_gateway_seam)
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
       if (cfg->reduce_measure_enabled)
@@ -1004,6 +1005,8 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
       if (cfg->reduce_history_fold)
          cJSON_AddBoolToObject(reduce, "history_fold", cfg->reduce_history_fold);
+      if (cfg->reduce_gateway_seam)
+         cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
    }
 
    /* Session/worktree cleanup policy (only save if non-default) */

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -288,8 +288,8 @@ static const char *config_save_default_db1_path(void)
  * defaults 1, so those count as non-default only when changed away from that. */
 static int reduce_has_non_default(const config_t *cfg)
 {
-   return cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
-          cfg->reduce_compress || cfg->reduce_gateway_seam || !cfg->reduce_freeze_guard_enabled ||
+   return !cfg->reduce_measure_enabled || !cfg->reduce_delegate_seam || !cfg->reduce_history_fold ||
+          !cfg->reduce_compress || cfg->reduce_gateway_seam || !cfg->reduce_freeze_guard_enabled ||
           (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1);
 }
 
@@ -937,7 +937,7 @@ int config_save(const config_t *cfg)
 
    /* Tool result compaction (only save non-default values) */
    if (!cfg->compact_enabled || cfg->compact_threshold || cfg->compact_head_bytes ||
-       cfg->compact_tail_bytes || cfg->compact_per_tool_count || cfg->coord_closet_enabled ||
+       cfg->compact_tail_bytes || cfg->compact_per_tool_count || !cfg->coord_closet_enabled ||
        cfg->coord_closet_budget_bytes || cfg->coord_closet_max_ratio_pct ||
        cfg->coord_closet_denylist[0])
    {
@@ -961,8 +961,9 @@ int config_save(const config_t *cfg)
                cJSON_AddNumberToObject(pt, tool, thresh);
          }
       }
-      /* Coordinate Closet (fold §2), nested under "compact". */
-      if (cfg->coord_closet_enabled || cfg->coord_closet_budget_bytes ||
+      /* Coordinate Closet (fold §2), nested under "compact". Default-ON now, so the
+       * block is emitted only to record a non-default (disabled, or tuned budget). */
+      if (!cfg->coord_closet_enabled || cfg->coord_closet_budget_bytes ||
           cfg->coord_closet_max_ratio_pct || cfg->coord_closet_denylist[0])
       {
          cJSON *closet = cJSON_AddObjectToObject(cmpct, "coord_closet");
@@ -1012,14 +1013,17 @@ int config_save(const config_t *cfg)
    if (reduce_has_non_default(cfg))
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
-      if (cfg->reduce_measure_enabled)
-         cJSON_AddBoolToObject(reduce, "measure", cfg->reduce_measure_enabled);
-      if (cfg->reduce_delegate_seam)
-         cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
-      if (cfg->reduce_history_fold)
-         cJSON_AddBoolToObject(reduce, "history_fold", cfg->reduce_history_fold);
-      if (cfg->reduce_compress)
-         cJSON_AddBoolToObject(reduce, "compress", cfg->reduce_compress);
+      /* measure/delegate_seam/history_fold/compress default ON -> persist only the
+       * non-default OFF state so an operator opt-out round-trips. gateway_seam stays
+       * default-OFF -> persist only when enabled. */
+      if (!cfg->reduce_measure_enabled)
+         cJSON_AddBoolToObject(reduce, "measure", 0);
+      if (!cfg->reduce_delegate_seam)
+         cJSON_AddBoolToObject(reduce, "delegate_seam", 0);
+      if (!cfg->reduce_history_fold)
+         cJSON_AddBoolToObject(reduce, "history_fold", 0);
+      if (!cfg->reduce_compress)
+         cJSON_AddBoolToObject(reduce, "compress", 0);
       if (cfg->reduce_gateway_seam)
          cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
       if (!cfg->reduce_freeze_guard_enabled) /* default-on -> persist only when disabled */

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -71,6 +71,7 @@
 {"concurrency", SCHEMA_OBJECT, 0},
 {"search", SCHEMA_OBJECT, 0},
 {"compact", SCHEMA_OBJECT, 0},
+{"reduce", SCHEMA_OBJECT, 0},
 {"sessions", SCHEMA_OBJECT, 0},
 {"sandbox", SCHEMA_OBJECT, 0},
 {"ecomode", SCHEMA_BOOL, 0},

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -751,6 +751,9 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(reduce, "history_fold");
    if (cJSON_IsBool(item))
       cfg->reduce_history_fold = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_seam");
+   if (cJSON_IsBool(item))
+      cfg->reduce_gateway_seam = cJSON_IsTrue(item) ? 1 : 0;
 }
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -748,6 +748,9 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(reduce, "delegate_seam");
    if (cJSON_IsBool(item))
       cfg->reduce_delegate_seam = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "history_fold");
+   if (cJSON_IsBool(item))
+      cfg->reduce_history_fold = cJSON_IsTrue(item) ? 1 : 0;
 }
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -4,6 +4,7 @@
 #include "json_fluent.h"
 #include "config_internal.h"
 #include "config_sections.h"
+#include "context_reduce.h" /* FREEZE_GUARD_MAX_HORIZON — clamp freeze_guard_horizon at parse */
 #include "sandbox.h"
 #include "toolset.h"
 #include "cJSON.h"
@@ -757,6 +758,17 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_seam");
    if (cJSON_IsBool(item))
       cfg->reduce_gateway_seam = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard");
+   if (cJSON_IsBool(item))
+      cfg->reduce_freeze_guard_enabled = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard_horizon");
+   if (cJSON_IsNumber(item) && item->valuedouble > 0)
+   {
+      int h = (int)item->valuedouble;
+      if (h > FREEZE_GUARD_MAX_HORIZON)
+         h = FREEZE_GUARD_MAX_HORIZON; /* clamp at parse so on-disk == runtime */
+      cfg->reduce_freeze_guard_horizon = h;
+   }
 }
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -733,6 +733,23 @@ void config_parse_fold_section(config_t *cfg, cJSON *root)
    }
 }
 
+/* Unified context economizer (src/context_reduce.c). Orchestration gates for the
+ * single reduction subsystem. Only knobs the current code honors are parsed here;
+ * each lever / the gateway seam / min_gain is added by the slice that implements
+ * it, so an exposed flag is never silently inert. All default-off. */
+void config_parse_reduce_section(config_t *cfg, cJSON *root)
+{
+   cJSON *reduce = cJSON_GetObjectItemCaseSensitive(root, "reduce");
+   if (!cJSON_IsObject(reduce))
+      return;
+   cJSON *item = cJSON_GetObjectItemCaseSensitive(reduce, "measure");
+   if (cJSON_IsBool(item))
+      cfg->reduce_measure_enabled = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "delegate_seam");
+   if (cJSON_IsBool(item))
+      cfg->reduce_delegate_seam = cJSON_IsTrue(item) ? 1 : 0;
+}
+
 void config_parse_sessions_section(config_t *cfg, cJSON *root)
 {
    cJSON *item = NULL;

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -751,6 +751,9 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(reduce, "history_fold");
    if (cJSON_IsBool(item))
       cfg->reduce_history_fold = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "compress");
+   if (cJSON_IsBool(item))
+      cfg->reduce_compress = cJSON_IsTrue(item) ? 1 : 0;
    item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_seam");
    if (cJSON_IsBool(item))
       cfg->reduce_gateway_seam = cJSON_IsTrue(item) ? 1 : 0;

--- a/src/context_fold.c
+++ b/src/context_fold.c
@@ -2,6 +2,7 @@
  * See context_fold.h for the contract. Pure: cJSON + dstr + coord_closet only. */
 #include "context_fold.h"
 
+#include "compact.h" /* compact_body — the shared tool-result shrink core */
 #include "dstr.h"
 #include "fold_register.h"
 #include <stdlib.h>
@@ -229,13 +230,14 @@ void fold_result_free(fold_result_t *out)
 /* ---- Boundary-free tool-result body compression (economizer Slice 4) ---- */
 
 /* Compress one tool-result body living at `parent[key]` (a string, or any node we
- * serialize). `keep` is the head-excerpt size (also the threshold). Returns 1 if
- * the body was replaced (and accumulates its ORIGINAL byte length into *raw for the
- * closet ratio cap), 0 if it was below threshold, would not net-shrink, or on OOM.
- * Identifiers in the FULL body are nominated to `set` ONLY when we commit, so a
- * body left full never pollutes the closet. Deterministic. */
-static int compress_body_field(cJSON *parent, const char *key, int keep, int turn, coord_set_t *set,
-                               size_t *raw)
+ * serialize). `cc` carries the resolved shrink policy (threshold/head/tail) for the
+ * shared compact_body() core. Returns 1 if the body was replaced (and accumulates
+ * its ORIGINAL byte length into *raw for the closet ratio cap), 0 if it was below
+ * threshold, would not net-shrink, or on OOM. Identifiers in the FULL body are
+ * nominated to `set` ONLY when we commit, so a body left full never pollutes the
+ * closet. Deterministic. */
+static int compress_body_field(cJSON *parent, const char *key, const compact_config_t *cc, int turn,
+                               coord_set_t *set, size_t *raw)
 {
    cJSON *node = cJSON_GetObjectItem(parent, key);
    char *owned = NULL;
@@ -253,28 +255,32 @@ static int compress_body_field(cJSON *parent, const char *key, int keep, int tur
       return 0;
    }
    size_t blen = strlen(body);
-   if ((int)blen <= keep) /* below threshold -> keep verbatim */
+   if (cc->threshold > 0 && blen <= (size_t)cc->threshold) /* below threshold -> keep verbatim */
    {
       free(owned);
       return 0;
    }
 
-   /* Build the candidate (head excerpt + elision marker) and only commit when it
-    * is a genuine net shrink, so an over-threshold-but-tiny body never EXPANDS. */
-   dstr_t d;
-   dstr_init(&d);
-   append_excerpt(&d, body, keep);
-   dstr_appendf(&d, " (%zu bytes elided; identifiers conserved in Coordinate Closet)",
-                blen - (size_t)keep);
-   if (dstr_len(&d) >= blen)
+   /* Shrink via the shared core (JSON summary or head+tail), then commit only on a
+    * genuine net shrink so an over-threshold-but-tiny body never EXPANDS. The buffer
+    * is sized per the compact_body contract so no strategy is truncated. */
+   size_t cap = blen + COMPACT_JSON_SUMMARY_MAX + 1;
+   char *buf = malloc(cap);
+   if (!buf)
    {
-      dstr_free(&d);
+      free(owned);
+      return 0;
+   }
+   size_t n = compact_body(body, blen, NULL, cc, buf, cap);
+   if (n == 0 || n >= blen)
+   {
+      free(buf);
       free(owned);
       return 0;
    }
 
-   cJSON *repl = cJSON_CreateString(dstr_cstr(&d));
-   dstr_free(&d);
+   cJSON *repl = cJSON_CreateString(buf);
+   free(buf);
    if (!repl)
    {
       free(owned);
@@ -298,7 +304,8 @@ static int compress_body_field(cJSON *parent, const char *key, int keep, int tur
  * The shapes are mutually exclusive per message (an OpenAI tool result is a string
  * `content`; an Anthropic tool_result is a block inside an ARRAY `content`; a
  * Responses output is a top-level `output`), so no body is double-counted. */
-static int compress_message_bodies(cJSON *m, int keep, int turn, coord_set_t *set, size_t *raw)
+static int compress_message_bodies(cJSON *m, const compact_config_t *cc, int turn, coord_set_t *set,
+                                   size_t *raw)
 {
    int n = 0;
    const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(m, "role"));
@@ -306,7 +313,7 @@ static int compress_message_bodies(cJSON *m, int keep, int turn, coord_set_t *se
 
    /* (A) OpenAI / Gemini-as-openai tool result: role=="tool" with string content. */
    if (role && strcmp(role, "tool") == 0)
-      n += compress_body_field(m, "content", keep, turn, set, raw);
+      n += compress_body_field(m, "content", cc, turn, set, raw);
 
    /* (B) Anthropic tool_result content-block(s) inside a content ARRAY. (A role
     * "tool" message has a STRING content, so this branch never re-touches it.) */
@@ -318,13 +325,13 @@ static int compress_message_bodies(cJSON *m, int keep, int turn, coord_set_t *se
       {
          const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
          if (t && strcmp(t, "tool_result") == 0)
-            n += compress_body_field(b, "content", keep, turn, set, raw);
+            n += compress_body_field(b, "content", cc, turn, set, raw);
       }
    }
 
    /* (C) Responses (chatgpt) top-level function_call_output item: an `output` body. */
    if (itype && strcmp(itype, "function_call_output") == 0)
-      n += compress_body_field(m, "output", keep, turn, set, raw);
+      n += compress_body_field(m, "output", cc, turn, set, raw);
 
    return n;
 }
@@ -346,6 +353,21 @@ int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_
       return 0;                  /* nothing ahead of the retained tail */
    int limit = count - retained; /* messages [0, limit) are compression-eligible */
 
+   /* Resolve the shared shrink policy ONCE. `compact.*` knobs (mirrored into the
+    * fold config) are the single source of truth for head/tail, so this seam and the
+    * eager seam shrink identically. `keep` (the excerpt budget) is the compression
+    * threshold; the tail is capped to keep/2 so a small excerpt budget keeps the
+    * tail proportional instead of inheriting a large compact default (§2.4). */
+   compact_config_t cc;
+   memset(&cc, 0, sizeof(cc));
+   cc.enabled = 1;
+   cc.threshold = keep;
+   cc.head_bytes = cfg->compact_head_bytes; /* 0 -> compact.c default */
+   int tail_default =
+       cfg->compact_tail_bytes > 0 ? cfg->compact_tail_bytes : COMPACT_DEFAULT_TAIL_BYTES;
+   int tail_cap = keep / 2;
+   cc.tail_bytes = tail_cap > 0 && tail_cap < tail_default ? tail_cap : tail_default;
+
    /* Deep-copy the whole transcript, then shrink only oversized tool-result BODIES
     * in the eligible prefix in place. Every message slot, role/type, tool_use_id /
     * tool_call_id, and the ordering survive untouched, so the call/result pairing
@@ -362,7 +384,7 @@ int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_
    {
       cJSON *m = cJSON_GetArrayItem(arr, i);
       if (m)
-         compressed += compress_message_bodies(m, keep, i, &set, &compressed_raw);
+         compressed += compress_message_bodies(m, &cc, i, &set, &compressed_raw);
    }
 
    if (compressed == 0)

--- a/src/context_fold.c
+++ b/src/context_fold.c
@@ -226,6 +226,199 @@ void fold_result_free(fold_result_t *out)
    out->folded = 0;
 }
 
+/* ---- Boundary-free tool-result body compression (economizer Slice 4) ---- */
+
+/* Compress one tool-result body living at `parent[key]` (a string, or any node we
+ * serialize). `keep` is the head-excerpt size (also the threshold). Returns 1 if
+ * the body was replaced (and accumulates its ORIGINAL byte length into *raw for the
+ * closet ratio cap), 0 if it was below threshold, would not net-shrink, or on OOM.
+ * Identifiers in the FULL body are nominated to `set` ONLY when we commit, so a
+ * body left full never pollutes the closet. Deterministic. */
+static int compress_body_field(cJSON *parent, const char *key, int keep, int turn, coord_set_t *set,
+                               size_t *raw)
+{
+   cJSON *node = cJSON_GetObjectItem(parent, key);
+   char *owned = NULL;
+   const char *body = NULL;
+   if (cJSON_IsString(node))
+      body = node->valuestring;
+   else if (node)
+   {
+      owned = cJSON_PrintUnformatted(node);
+      body = owned;
+   }
+   if (!body)
+   {
+      free(owned);
+      return 0;
+   }
+   size_t blen = strlen(body);
+   if ((int)blen <= keep) /* below threshold -> keep verbatim */
+   {
+      free(owned);
+      return 0;
+   }
+
+   /* Build the candidate (head excerpt + elision marker) and only commit when it
+    * is a genuine net shrink, so an over-threshold-but-tiny body never EXPANDS. */
+   dstr_t d;
+   dstr_init(&d);
+   append_excerpt(&d, body, keep);
+   dstr_appendf(&d, " (%zu bytes elided; identifiers conserved in Coordinate Closet)",
+                blen - (size_t)keep);
+   if (dstr_len(&d) >= blen)
+   {
+      dstr_free(&d);
+      free(owned);
+      return 0;
+   }
+
+   cJSON *repl = cJSON_CreateString(dstr_cstr(&d));
+   dstr_free(&d);
+   if (!repl)
+   {
+      free(owned);
+      return 0;
+   }
+   coord_provenance_t prov = {COORD_LANE_AGENT, turn, -1, -1};
+   coord_closet_nominate(body, blen, &prov, set);
+   if (!cJSON_ReplaceItemInObjectCaseSensitive(parent, key, repl))
+   {
+      cJSON_Delete(repl);
+      free(owned);
+      return 0;
+   }
+   *raw += blen;
+   free(owned);
+   return 1;
+}
+
+/* Compress every oversized tool-result body carried by one message, across all
+ * three provider shapes. Returns the number of bodies compressed in this message.
+ * The shapes are mutually exclusive per message (an OpenAI tool result is a string
+ * `content`; an Anthropic tool_result is a block inside an ARRAY `content`; a
+ * Responses output is a top-level `output`), so no body is double-counted. */
+static int compress_message_bodies(cJSON *m, int keep, int turn, coord_set_t *set, size_t *raw)
+{
+   int n = 0;
+   const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(m, "role"));
+   const char *itype = cJSON_GetStringValue(cJSON_GetObjectItem(m, "type"));
+
+   /* (A) OpenAI / Gemini-as-openai tool result: role=="tool" with string content. */
+   if (role && strcmp(role, "tool") == 0)
+      n += compress_body_field(m, "content", keep, turn, set, raw);
+
+   /* (B) Anthropic tool_result content-block(s) inside a content ARRAY. (A role
+    * "tool" message has a STRING content, so this branch never re-touches it.) */
+   cJSON *content = cJSON_GetObjectItem(m, "content");
+   if (cJSON_IsArray(content))
+   {
+      cJSON *b;
+      cJSON_ArrayForEach(b, content)
+      {
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+         if (t && strcmp(t, "tool_result") == 0)
+            n += compress_body_field(b, "content", keep, turn, set, raw);
+      }
+   }
+
+   /* (C) Responses (chatgpt) top-level function_call_output item: an `output` body. */
+   if (itype && strcmp(itype, "function_call_output") == 0)
+      n += compress_body_field(m, "output", keep, turn, set, raw);
+
+   return n;
+}
+
+int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_result_t *out)
+{
+   if (!out)
+      return -1;
+   memset(out, 0, sizeof(*out));
+   out->closet_evict = COORD_EVICT_NONE;
+   if (!messages || !cJSON_IsArray((cJSON *)messages) || !cfg || !cfg->enabled)
+      return 0;
+
+   int count = cJSON_GetArraySize((cJSON *)messages);
+   int retained = cfg->retained_msgs > 0 ? cfg->retained_msgs : CONTEXT_FOLD_DEFAULT_RETAINED_MSGS;
+   int keep = cfg->reasoning_excerpt_bytes > 0 ? cfg->reasoning_excerpt_bytes
+                                               : CONTEXT_FOLD_DEFAULT_EXCERPT_BYTES;
+   if (count <= 0 || retained >= count)
+      return 0;                  /* nothing ahead of the retained tail */
+   int limit = count - retained; /* messages [0, limit) are compression-eligible */
+
+   /* Deep-copy the whole transcript, then shrink only oversized tool-result BODIES
+    * in the eligible prefix in place. Every message slot, role/type, tool_use_id /
+    * tool_call_id, and the ordering survive untouched, so the call/result pairing
+    * is byte-for-byte intact (zero orphans for message_history_repair). */
+   cJSON *arr = cJSON_Duplicate((cJSON *)messages, 1);
+   if (!arr)
+      return 0; /* OOM: caller uses the original transcript */
+
+   coord_set_t set;
+   coord_set_init(&set);
+   size_t compressed_raw = 0; /* total ORIGINAL bytes of compressed bodies (ratio-cap basis) */
+   int compressed = 0;
+   for (int i = 0; i < limit; i++)
+   {
+      cJSON *m = cJSON_GetArrayItem(arr, i);
+      if (m)
+         compressed += compress_message_bodies(m, keep, i, &set, &compressed_raw);
+   }
+
+   if (compressed == 0)
+   {
+      coord_set_free(&set); /* no body exceeded the threshold -> caller uses original */
+      cJSON_Delete(arr);
+      return 0;
+   }
+
+   /* Conserve any amputated identifiers in a Coordinate Closet, prepended as a
+    * synthetic user+assistant note pair (matching context_fold_view): a plain-text
+    * turn is valid input for every provider builder, and the PAIR keeps Anthropic
+    * role-alternation intact ahead of the (unchanged) original first turn. When the
+    * closet is disabled or empty, render returns NULL and we emit no note — the head
+    * excerpts still carry the leading bytes of each body. */
+   char *closet = coord_closet_render(&set, &cfg->closet, compressed_raw, &out->closet_evict);
+   coord_set_free(&set);
+   if (closet)
+   {
+      cJSON *note = cJSON_CreateObject();
+      cJSON *ack = cJSON_CreateObject();
+      if (note && ack)
+      {
+         dstr_t body;
+         dstr_init(&body);
+         dstr_appendf(&body,
+                      "[compressed %d oversized tool-result body(ies) above; full bodies remain "
+                      "in history — exact identifiers are conserved in the Coordinate Closet]\n\n",
+                      compressed);
+         dstr_append_str(&body, closet);
+         cJSON_AddStringToObject(note, "role", "user");
+         cJSON_AddStringToObject(note, "content", dstr_cstr(&body));
+         cJSON_AddStringToObject(ack, "role", "assistant");
+         cJSON_AddStringToObject(
+             ack, "content",
+             "Understood — identifiers from the compressed tool results are conserved above.");
+         dstr_free(&body);
+         /* insert ack first, then note before it, yielding [note, ack, ...original] */
+         cJSON_InsertItemInArray(arr, 0, ack);
+         cJSON_InsertItemInArray(arr, 0, note);
+      }
+      else
+      {
+         cJSON_Delete(note);
+         cJSON_Delete(ack);
+      }
+      free(closet);
+   }
+
+   out->messages = arr;
+   out->folded = 1; /* flag reused to mean "compressed" */
+   out->folded_msgs = compressed;
+   out->retained_msgs = retained;
+   return 0;
+}
+
 /* FNV-1a over the serialized bytes of messages[0..n); also returns the total
  * serialized size via *bytes. Detects prefix mutation for freeze reuse and bounds
  * the closet ratio cap in one pass. */

--- a/src/context_fold.c
+++ b/src/context_fold.c
@@ -9,7 +9,15 @@
 
 /* A "clean user turn": role=user and NOT a tool_result message. Folding only at
  * such a boundary guarantees a tool_use and its tool_result never split, and the
- * retained tail begins with a user message (valid alternation). */
+ * retained tail begins with a user message (valid alternation).
+ *
+ * Cross-provider safe: this only admits a boundary at role=="user" (and rejects an
+ * Anthropic tool_result-carrying user msg). In OpenAI/Gemini a tool result is a
+ * separate role=="tool" message and a role=="user" never interrupts an assistant
+ * tool_calls -> tool result pair; in Responses the function_call/function_call_output
+ * items are not role=="user" either. So folding at a user boundary never splits a
+ * call/result pair in ANY provider shape — the boundary logic needs no per-format
+ * branch. */
 static int is_clean_user_turn(const cJSON *m)
 {
    const char *role = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "role"));
@@ -72,6 +80,11 @@ static void skeleton_prefix(dstr_t *d, const char *role, const char *txt, int re
       dstr_appendf(d, "%s: ", role ? role : "?");
 }
 
+/* Format-aware skeleton emitter. A single message can carry MULTIPLE shapes
+ * depending on provider — e.g. an OpenAI assistant turn has BOTH a string
+ * `content` AND a separate top-level `tool_calls` array — so the extractors run
+ * additively (no early return) and the Coordinate Closet captures identifiers from
+ * EVERY provider's tool calls/results, not just Anthropic's. */
 static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, int register_on,
                              coord_set_t *set)
 {
@@ -79,6 +92,8 @@ static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, i
    cJSON *content = cJSON_GetObjectItem((cJSON *)m, "content");
    coord_provenance_t prov = {COORD_LANE_AGENT, turn, -1, -1};
 
+   /* (1) String content (OpenAI/Gemini text, or any plain turn). Emit it but DO
+    * NOT return: an OpenAI assistant turn also carries a top-level tool_calls. */
    if (cJSON_IsString(content))
    {
       const char *txt = content->valuestring;
@@ -89,61 +104,115 @@ static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, i
          append_excerpt(d, txt, excerpt);
          dstr_append_char(d, '\n');
       }
-      return;
    }
-   if (!cJSON_IsArray(content))
-      return;
-
-   cJSON *b;
-   cJSON_ArrayForEach(b, content)
+   /* (2) Anthropic content-block array (text / tool_use / tool_result). */
+   else if (cJSON_IsArray(content))
    {
-      const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
-      if (!t)
-         continue;
-      if (strcmp(t, "text") == 0)
+      cJSON *b;
+      cJSON_ArrayForEach(b, content)
       {
-         const char *txt = cJSON_GetStringValue(cJSON_GetObjectItem(b, "text"));
-         if (txt)
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+         if (!t)
+            continue;
+         if (strcmp(t, "text") == 0)
          {
-            coord_closet_nominate(txt, strlen(txt), &prov, set);
-            skeleton_prefix(d, role, txt, register_on);
-            append_excerpt(d, txt, excerpt);
+            const char *txt = cJSON_GetStringValue(cJSON_GetObjectItem(b, "text"));
+            if (txt)
+            {
+               coord_closet_nominate(txt, strlen(txt), &prov, set);
+               skeleton_prefix(d, role, txt, register_on);
+               append_excerpt(d, txt, excerpt);
+               dstr_append_char(d, '\n');
+            }
+         }
+         else if (strcmp(t, "tool_use") == 0)
+         {
+            const char *name = cJSON_GetStringValue(cJSON_GetObjectItem(b, "name"));
+            cJSON *input = cJSON_GetObjectItem(b, "input");
+            char *inp = input ? cJSON_PrintUnformatted(input) : NULL;
+            if (inp)
+               coord_closet_nominate(inp, strlen(inp), &prov, set);
+            dstr_appendf(d, "  $ %s ", name ? name : "tool");
+            append_excerpt(d, inp ? inp : "", excerpt);
             dstr_append_char(d, '\n');
+            free(inp);
+         }
+         else if (strcmp(t, "tool_result") == 0)
+         {
+            cJSON *c = cJSON_GetObjectItem(b, "content");
+            char *owned = NULL;
+            const char *cv = NULL;
+            if (cJSON_IsString(c))
+               cv = c->valuestring;
+            else if (c)
+            {
+               owned = cJSON_PrintUnformatted(c);
+               cv = owned;
+            }
+            if (cv)
+            {
+               coord_closet_nominate(cv, strlen(cv), &prov, set);
+               dstr_append_str(d, "    \xE2\x86\x92 "); /* arrow */
+               append_excerpt(d, cv, excerpt);
+               dstr_appendf(d, " (%zu bytes)\n", strlen(cv));
+            }
+            free(owned);
          }
       }
-      else if (strcmp(t, "tool_use") == 0)
+   }
+
+   /* (3) OpenAI / Gemini-as-openai assistant tool calls: a top-level `tool_calls`
+    * array. Each element's function.arguments is a JSON STRING. */
+   cJSON *tool_calls = cJSON_GetObjectItem((cJSON *)m, "tool_calls");
+   if (cJSON_IsArray(tool_calls))
+   {
+      cJSON *tc;
+      cJSON_ArrayForEach(tc, tool_calls)
       {
-         const char *name = cJSON_GetStringValue(cJSON_GetObjectItem(b, "name"));
-         cJSON *input = cJSON_GetObjectItem(b, "input");
-         char *inp = input ? cJSON_PrintUnformatted(input) : NULL;
-         if (inp)
-            coord_closet_nominate(inp, strlen(inp), &prov, set);
+         cJSON *fn = cJSON_GetObjectItem(tc, "function");
+         const char *name = cJSON_GetStringValue(cJSON_GetObjectItem(fn, "name"));
+         const char *args = cJSON_GetStringValue(cJSON_GetObjectItem(fn, "arguments"));
+         if (args)
+            coord_closet_nominate(args, strlen(args), &prov, set);
          dstr_appendf(d, "  $ %s ", name ? name : "tool");
-         append_excerpt(d, inp ? inp : "", excerpt);
+         append_excerpt(d, args ? args : "", excerpt);
          dstr_append_char(d, '\n');
-         free(inp);
       }
-      else if (strcmp(t, "tool_result") == 0)
+   }
+
+   /* (4) Responses (chatgpt) top-level items: a function_call or its
+    * function_call_output (mirror the tool_use / tool_result branches). */
+   const char *itype = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "type"));
+   if (itype && strcmp(itype, "function_call") == 0)
+   {
+      const char *name = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "name"));
+      const char *args = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "arguments"));
+      if (args)
+         coord_closet_nominate(args, strlen(args), &prov, set);
+      dstr_appendf(d, "  $ %s ", name ? name : "tool");
+      append_excerpt(d, args ? args : "", excerpt);
+      dstr_append_char(d, '\n');
+   }
+   else if (itype && strcmp(itype, "function_call_output") == 0)
+   {
+      cJSON *o = cJSON_GetObjectItem((cJSON *)m, "output");
+      char *owned = NULL;
+      const char *ov = NULL;
+      if (cJSON_IsString(o))
+         ov = o->valuestring;
+      else if (o)
       {
-         cJSON *c = cJSON_GetObjectItem(b, "content");
-         char *owned = NULL;
-         const char *cv = NULL;
-         if (cJSON_IsString(c))
-            cv = c->valuestring;
-         else if (c)
-         {
-            owned = cJSON_PrintUnformatted(c);
-            cv = owned;
-         }
-         if (cv)
-         {
-            coord_closet_nominate(cv, strlen(cv), &prov, set);
-            dstr_append_str(d, "    \xE2\x86\x92 "); /* arrow */
-            append_excerpt(d, cv, excerpt);
-            dstr_appendf(d, " (%zu bytes)\n", strlen(cv));
-         }
-         free(owned);
+         owned = cJSON_PrintUnformatted(o);
+         ov = owned;
       }
+      if (ov)
+      {
+         coord_closet_nominate(ov, strlen(ov), &prov, set);
+         dstr_append_str(d, "    \xE2\x86\x92 "); /* arrow */
+         append_excerpt(d, ov, excerpt);
+         dstr_appendf(d, " (%zu bytes)\n", strlen(ov));
+      }
+      free(owned);
    }
 }
 

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -118,6 +118,65 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
    int foldable_msgs = (n > retained) ? n - retained : 0;
    out->foldable_tokens = prefix_token_estimate(messages, foldable_msgs);
 
+   /* Reduction lever (Slice 2b): when history-fold is enabled and this is neither a
+    * measure-only nor an already-reduced pass, actually fold the prefix via the
+    * provider-agnostic context_fold_view. The fold NEVER mutates `messages` and
+    * NEVER touches `system_prompt` (the immutable prefix zone) — it returns a NEW
+    * array we transfer ownership of into out->messages. */
+   if (cfg->history_fold && !cfg->measure_only)
+   {
+      /* Net-gain pre-check: skip when the foldable opportunity is below the
+       * operator's round-trip recovery threshold (no mutation; ledger-auditable). */
+      if (cfg->min_gain_tokens > 0 && out->foldable_tokens < cfg->min_gain_tokens)
+      {
+         out->reason = REDUCE_REASON_SKIP_NO_GAIN;
+         out->mutated = 0;
+         out->messages = NULL;
+         return 0;
+      }
+
+      fold_config_t fc;
+      memset(&fc, 0, sizeof(fc));
+      fc.enabled = 1;
+      fc.retained_msgs = cfg->fold.retained_msgs;
+      fc.min_fold_msgs = cfg->fold.min_fold_msgs;
+      fc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
+      fc.register_enabled = cfg->fold.register_enabled;
+      fc.closet = cfg->fold.closet; /* zero -> module defaults; denylist borrowed for this call */
+
+      fold_result_t fr;
+      memset(&fr, 0, sizeof(fr));
+      if (context_fold_view(messages, &fc, st ? &st->freeze : NULL, &fr) != 0)
+      {
+         /* hard bypass: an internal fold error -> caller forwards the original. */
+         fold_result_free(&fr);
+         out->messages = NULL;
+         out->mutated = 0;
+         return 1;
+      }
+      if (fr.folded)
+      {
+         out->messages = fr.messages; /* transfer ownership */
+         fr.messages = NULL;          /* so fold_result_free does not delete it */
+         out->mutated = 1;
+         out->reason = REDUCE_REASON_REDUCED;
+         out->folded_msgs = fr.folded_msgs;
+         out->retained_msgs = fr.retained_msgs;
+         out->reused_boundary = fr.reused_boundary;
+         out->epochs = st ? st->freeze.epochs : 0;
+
+         int reduced = node_token_estimate(out->messages);
+         if (system_prompt && system_prompt[0])
+            reduced += (int)(strlen(system_prompt) / CHARS_PER_TOKEN_EST) + 1;
+         out->reduced_tokens = reduced;
+         out->removed_tokens = baseline > reduced ? baseline - reduced : 0;
+
+         if (st)
+            st->reduced = 1; /* provenance: a later seam re-measures, does not re-reduce */
+      }
+      fold_result_free(&fr); /* fr.messages is NULL when transferred; no-op otherwise */
+   }
+
    /* Cost forecast bracket. Basis = the realized saving (removed_tokens) once a
     * lever runs, or the foldable OPPORTUNITY in measure-only (removed==0 here).
     * floor prices the basis at the provider CACHE-READ rate (cache-warm), ceiling
@@ -139,8 +198,13 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
       }
    }
 
-   out->reason = REDUCE_REASON_MEASURED;
-   out->mutated = 0;
-   out->messages = NULL; /* no new array — caller uses its original */
+   /* Only the measure path falls through with reason still unset; a successful
+    * fold above already stamped REDUCED (and owns out->messages). */
+   if (out->reason == REDUCE_REASON_NONE)
+   {
+      out->reason = REDUCE_REASON_MEASURED;
+      out->mutated = 0;
+      out->messages = NULL; /* no new array — caller uses its original */
+   }
    return 0;
 }

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -1,0 +1,146 @@
+/* context_reduce.c: the unified context economizer orchestrator.
+ *
+ * Slice 1 is MEASURE-ONLY: it computes the caching-independent baseline context
+ * size and the foldable opportunity (the tokens in the fold-eligible prefix
+ * region), prices the opportunity as a forecast bracket, and NEVER mutates the
+ * messages. Later slices add the actual levers behind this same entry point; the
+ * design contracts (idempotence, immutable prefix zone, freeze-first ordering,
+ * per-format boundaries, hard bypass) live in context_reduce.h. */
+#include "context_reduce.h"
+#include "token_tracker.h" /* token_estimate_cost_ex, token_usage_t */
+#include <stdlib.h>
+#include <string.h>
+
+/* Bytes-per-token approximation shared by every estimate here. Matches the
+ * chars_to_tokens convention used elsewhere (session_compact). Forecast-grade. */
+#define CHARS_PER_TOKEN_EST 4
+
+/* chars/4 token estimate of a serialized cJSON node — the same approximation
+ * session_compact_estimate_tokens uses, inlined so context_reduce does not couple
+ * to the whole session_compact subsystem just to count bytes. Forecast-grade only
+ * (the invoice-quality number is realized provider on/off spend). */
+static int node_token_estimate(cJSON *node)
+{
+   if (!node)
+      return 0;
+   char *s = cJSON_PrintUnformatted(node);
+   int t = s ? (int)(strlen(s) / CHARS_PER_TOKEN_EST) : 0;
+   free(s);
+   return t;
+}
+
+void context_reduce_result_free(reduce_result_t *out)
+{
+   if (!out)
+      return;
+   if (out->mutated && out->messages)
+      cJSON_Delete(out->messages);
+   out->messages = NULL;
+   out->mutated = 0;
+}
+
+/* chars/4 token estimate of the first `count` items of an array — the fold-eligible
+ * prefix region. Provider-agnostic (counts serialized bytes), matching
+ * session_compact_estimate_tokens' chars_to_tokens convention. */
+static int prefix_token_estimate(cJSON *messages, int count)
+{
+   if (!messages || count <= 0)
+      return 0;
+   long total = 0;
+   int i = 0;
+   cJSON *it = NULL;
+   cJSON_ArrayForEach(it, messages)
+   {
+      if (i >= count)
+         break;
+      char *s = cJSON_PrintUnformatted(it);
+      if (s)
+      {
+         total += (long)strlen(s);
+         free(s);
+      }
+      i++;
+   }
+   return (int)(total / CHARS_PER_TOKEN_EST);
+}
+
+int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
+                   const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
+                   reduce_state_t *st, reduce_result_t *out)
+{
+   (void)session_id; /* used by the ledger writer, not the transform (Slice 1) */
+
+   if (!out)
+      return 1; /* hard bypass: caller forwards the original request */
+   memset(out, 0, sizeof(*out));
+
+   if (!messages || !cJSON_IsArray(messages))
+   {
+      out->reason = REDUCE_REASON_NONE;
+      return 0;
+   }
+
+   /* Per-seam gate: the economizer only engages at a seam the operator enabled.
+    * cfg == NULL or this seam disabled -> a true no-op (no measurement, no cost),
+    * honoring the header contract that gates actually gate. */
+   int seam_on = cfg && ((seam == REDUCE_SEAM_GATEWAY && cfg->gateway_seam) ||
+                         (seam == REDUCE_SEAM_DELEGATE && cfg->delegate_seam));
+   if (!seam_on)
+   {
+      out->reason = REDUCE_REASON_NONE;
+      return 0;
+   }
+
+   /* Baseline = assembled-context tokens (caching-independent). The system prompt
+    * is the immutable prefix zone — counted, never reduced. The +1 mirrors the
+    * existing request_prompt_token_estimate: a one-token allowance so a present
+    * (even tiny) system prompt is never estimated as zero. */
+   int baseline = node_token_estimate(messages);
+   if (system_prompt && system_prompt[0])
+      baseline += (int)(strlen(system_prompt) / CHARS_PER_TOKEN_EST) + 1;
+   out->baseline_tokens = baseline;
+   out->reduced_tokens = baseline; /* Slice 1: measure-only, nothing removed */
+   out->removed_tokens = 0;
+
+   /* Provenance: a request can cross both seams. If a prior seam already reduced,
+    * this seam re-measures the baseline but does NOT re-account the opportunity —
+    * that saving belongs to the seam that performed it (avoids double-counting). */
+   if (st && st->reduced)
+   {
+      out->reason = REDUCE_REASON_ALREADY;
+      return 0;
+   }
+
+   /* Foldable opportunity: tokens ahead of the retained tail (provider-agnostic). */
+   int retained =
+       (cfg->fold.retained_msgs > 0) ? cfg->fold.retained_msgs : CONTEXT_FOLD_DEFAULT_RETAINED_MSGS;
+   int n = cJSON_GetArraySize(messages);
+   int foldable_msgs = (n > retained) ? n - retained : 0;
+   out->foldable_tokens = prefix_token_estimate(messages, foldable_msgs);
+
+   /* Cost forecast bracket. Basis = the realized saving (removed_tokens) once a
+    * lever runs, or the foldable OPPORTUNITY in measure-only (removed==0 here).
+    * floor prices the basis at the provider CACHE-READ rate (cache-warm), ceiling
+    * at the FRESH input rate (cache-cold). Forecast only — the invoice-quality
+    * number is realized provider on/off spend, recorded separately by the ledger. */
+   int basis = out->removed_tokens > 0 ? out->removed_tokens : out->foldable_tokens;
+   if (model && model[0] && basis > 0)
+   {
+      int priced = 0;
+      token_usage_t floor_u = {0};
+      floor_u.cache_read_tokens = basis;
+      double floor_cost = token_estimate_cost_ex(model, &floor_u, &priced);
+      if (priced) /* same model -> ceiling is priced too; only emit $ when known */
+      {
+         out->est_saved_cost_floor = floor_cost;
+         token_usage_t ceil_u = {0};
+         ceil_u.input_tokens = basis;
+         out->est_saved_cost_ceiling = token_estimate_cost_ex(model, &ceil_u, NULL);
+      }
+   }
+
+   out->reason = REDUCE_REASON_MEASURED;
+   out->mutated = 0;
+   out->messages = NULL; /* no new array — caller uses its original */
+   return 0;
+}

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -29,6 +29,64 @@ static int node_token_estimate(cJSON *node)
    return t;
 }
 
+int reduce_freeze_favorable_rates(double input_cost, double write_cost, double read_cost,
+                                  int horizon)
+{
+   if (horizon <= 0)
+      horizon = 1; /* one future reuse is enough to justify one write */
+   if (horizon > FREEZE_GUARD_MAX_HORIZON)
+      horizon = FREEZE_GUARD_MAX_HORIZON;
+
+   /* Per-reuse saving = paying the cache-READ rate instead of the FRESH input rate.
+    * Checked FIRST: with no read discount (read >= input) caching can never pay,
+    * so skip the freeze REGARDLESS of write cost (a free write that yields no read
+    * benefit is still not worth pinning a boundary for). */
+   double per_reuse_saving = input_cost - read_cost;
+   if (per_reuse_saving <= 0)
+      return 0;
+
+   /* The MARGINAL cost of caching is the write PREMIUM over just sending the prefix
+    * fresh once (you pay the input rate on the first turn regardless) — NOT the full
+    * write cost. Providers with free cache creation (OpenAI: cache_write==0) have a
+    * premium <= 0, so freezing is pure upside -> always enable. */
+   double write_premium = write_cost - input_cost;
+   if (write_premium <= 0)
+      return 1;
+
+   return (double)horizon * per_reuse_saving >= write_premium ? 1 : 0;
+}
+
+int reduce_freeze_cost_favorable(const char *model, int prefix_tokens, int horizon)
+{
+   if (prefix_tokens <= 0)
+      return 1; /* nothing to cache -> no churn possible */
+   if (!model || !model[0])
+      return 1; /* fail-open: no model -> keep prior always-on freeze behavior */
+
+   /* Price each cache tier separately. token_estimate_cost_ex SUMS all populated
+    * token_usage_t buckets, so each struct sets EXACTLY ONE bucket to isolate that
+    * tier's cost. The decision is scale-INVARIANT in prefix_tokens (all three costs
+    * scale linearly with it, so it cancels in the rate comparison) — prefix_tokens
+    * therefore only gates the >0 "is there anything to cache" case above; any
+    * positive value yields the same verdict, so the exact cached-prefix size need
+    * not be known here. */
+   int priced = 0;
+   token_usage_t w = {0};
+   w.cache_write_tokens = prefix_tokens;
+   double write_cost = token_estimate_cost_ex(model, &w, &priced);
+   if (!priced)
+      return 1; /* fail-open: unpriced model -> do not regress onto it */
+
+   token_usage_t in = {0};
+   in.input_tokens = prefix_tokens;
+   double input_cost = token_estimate_cost_ex(model, &in, NULL);
+   token_usage_t rd = {0};
+   rd.cache_read_tokens = prefix_tokens;
+   double read_cost = token_estimate_cost_ex(model, &rd, NULL);
+
+   return reduce_freeze_favorable_rates(input_cost, write_cost, read_cost, horizon);
+}
+
 void context_reduce_result_free(reduce_result_t *out)
 {
    if (!out)
@@ -198,9 +256,21 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
          fc.register_enabled = cfg->fold.register_enabled;
          fc.closet = cfg->fold.closet; /* zero -> defaults; denylist borrowed for this call */
 
+         /* Freeze cost guardrail: pin the boundary only when the cache-read savings
+          * cover the cache-write churn (forecast via the prefix-region token estimate);
+          * otherwise pass NULL so this turn re-derives without pinning. Disabled or
+          * cost-favorable -> freeze as before. NULL state -> freeze already off. */
+         fold_freeze_t *freeze_arg = st ? &st->freeze : NULL;
+         if (freeze_arg && cfg->freeze_guard_enabled &&
+             !reduce_freeze_cost_favorable(model, out->foldable_tokens, cfg->freeze_guard_horizon))
+         {
+            freeze_arg = NULL;
+            out->freeze_guarded = 1;
+         }
+
          fold_result_t fr;
          memset(&fr, 0, sizeof(fr));
-         if (context_fold_view(work, &fc, st ? &st->freeze : NULL, &fr) != 0)
+         if (context_fold_view(work, &fc, freeze_arg, &fr) != 0)
          {
             /* hard bypass: an internal fold error -> caller forwards the original. */
             fold_result_free(&fr);

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -137,6 +137,8 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
       cc.enabled = 1;
       cc.retained_msgs = cfg->fold.retained_msgs;
       cc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
+      cc.compact_head_bytes = cfg->fold.compact_head_bytes; /* compact.* governs both seams */
+      cc.compact_tail_bytes = cfg->fold.compact_tail_bytes;
       cc.closet = cfg->fold.closet; /* zero -> module defaults; denylist borrowed for this call */
 
       fold_result_t cr;

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -118,63 +118,136 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
    int foldable_msgs = (n > retained) ? n - retained : 0;
    out->foldable_tokens = prefix_token_estimate(messages, foldable_msgs);
 
-   /* Reduction lever (Slice 2b): when history-fold is enabled and this is neither a
-    * measure-only nor an already-reduced pass, actually fold the prefix via the
-    * provider-agnostic context_fold_view. The fold NEVER mutates `messages` and
-    * NEVER touches `system_prompt` (the immutable prefix zone) — it returns a NEW
-    * array we transfer ownership of into out->messages. */
-   if (cfg->history_fold && !cfg->measure_only)
+   /* `work` is the current working view fed to each lever; it starts as the caller's
+    * (never-mutated) `messages` and becomes a lever-owned NEW array once a lever
+    * mutates. `compressed_owned` is the compress lever's array we own and must free
+    * unless it is published as out->messages or consumed as fold's input copy. */
+   cJSON *work = messages;
+   cJSON *compressed_owned = NULL;
+
+   /* Reduction lever (Slice 4): boundary-free tool-result BODY compression. Runs
+    * FIRST (ahead of fold) so the fold — when also enabled — sees the already-shrunk
+    * bodies. Unlike fold it needs no clean-user-turn boundary, so it engages on
+    * autonomous tool-loops where fold never can. Never mutates `messages`; returns a
+    * NEW array. */
+   if (cfg->compress && !cfg->measure_only)
    {
-      /* Net-gain pre-check: skip when the foldable opportunity is below the
-       * operator's round-trip recovery threshold (no mutation; ledger-auditable). */
-      if (cfg->min_gain_tokens > 0 && out->foldable_tokens < cfg->min_gain_tokens)
-      {
-         out->reason = REDUCE_REASON_SKIP_NO_GAIN;
-         out->mutated = 0;
-         out->messages = NULL;
-         return 0;
-      }
+      fold_config_t cc;
+      memset(&cc, 0, sizeof(cc));
+      cc.enabled = 1;
+      cc.retained_msgs = cfg->fold.retained_msgs;
+      cc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
+      cc.closet = cfg->fold.closet; /* zero -> module defaults; denylist borrowed for this call */
 
-      fold_config_t fc;
-      memset(&fc, 0, sizeof(fc));
-      fc.enabled = 1;
-      fc.retained_msgs = cfg->fold.retained_msgs;
-      fc.min_fold_msgs = cfg->fold.min_fold_msgs;
-      fc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
-      fc.register_enabled = cfg->fold.register_enabled;
-      fc.closet = cfg->fold.closet; /* zero -> module defaults; denylist borrowed for this call */
-
-      fold_result_t fr;
-      memset(&fr, 0, sizeof(fr));
-      if (context_fold_view(messages, &fc, st ? &st->freeze : NULL, &fr) != 0)
+      fold_result_t cr;
+      memset(&cr, 0, sizeof(cr));
+      if (context_compress_view(work, &cc, &cr) != 0)
       {
-         /* hard bypass: an internal fold error -> caller forwards the original. */
-         fold_result_free(&fr);
+         /* hard bypass: an internal compress error -> caller forwards the original. */
+         fold_result_free(&cr);
          out->messages = NULL;
          out->mutated = 0;
          return 1;
       }
-      if (fr.folded)
+      if (cr.folded)
       {
-         out->messages = fr.messages; /* transfer ownership */
-         fr.messages = NULL;          /* so fold_result_free does not delete it */
+         compressed_owned = cr.messages; /* transfer ownership; we may publish or free it */
+         cr.messages = NULL;             /* so fold_result_free does not delete it */
+         work = compressed_owned;        /* fold (below) compresses-then-folds this view */
          out->mutated = 1;
          out->reason = REDUCE_REASON_REDUCED;
-         out->folded_msgs = fr.folded_msgs;
-         out->retained_msgs = fr.retained_msgs;
-         out->reused_boundary = fr.reused_boundary;
-         out->epochs = st ? st->freeze.epochs : 0;
-
-         int reduced = node_token_estimate(out->messages);
-         if (system_prompt && system_prompt[0])
-            reduced += (int)(strlen(system_prompt) / CHARS_PER_TOKEN_EST) + 1;
-         out->reduced_tokens = reduced;
-         out->removed_tokens = baseline > reduced ? baseline - reduced : 0;
-
+         out->folded_msgs = cr.folded_msgs; /* bodies compressed (may be overwritten by fold) */
          if (st)
             st->reduced = 1; /* provenance: a later seam re-measures, does not re-reduce */
       }
-      fold_result_free(&fr); /* fr.messages is NULL when transferred; no-op otherwise */
+      fold_result_free(&cr); /* cr.messages is NULL when transferred; no-op otherwise */
+   }
+
+   /* Reduction lever (Slice 2b): when history-fold is enabled and this is neither a
+    * measure-only nor an already-reduced pass, actually fold the prefix via the
+    * provider-agnostic context_fold_view. The fold NEVER mutates its input and
+    * NEVER touches `system_prompt` (the immutable prefix zone) — it returns a NEW
+    * array we transfer ownership of into out->messages. It folds `work` (the
+    * possibly-compressed view), chaining the two levers. */
+   if (cfg->history_fold && !cfg->measure_only)
+   {
+      /* Net-gain pre-check: skip when the foldable opportunity is below the
+       * operator's round-trip recovery threshold (no mutation; ledger-auditable).
+       * When compress already mutated, we fall through to publish that result. */
+      if (cfg->min_gain_tokens > 0 && out->foldable_tokens < cfg->min_gain_tokens)
+      {
+         if (!compressed_owned)
+         {
+            out->reason = REDUCE_REASON_SKIP_NO_GAIN;
+            out->mutated = 0;
+            out->messages = NULL;
+            return 0;
+         }
+         /* compress mutated -> publish below; do not run fold */
+      }
+      else
+      {
+         fold_config_t fc;
+         memset(&fc, 0, sizeof(fc));
+         fc.enabled = 1;
+         fc.retained_msgs = cfg->fold.retained_msgs;
+         fc.min_fold_msgs = cfg->fold.min_fold_msgs;
+         fc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
+         fc.register_enabled = cfg->fold.register_enabled;
+         fc.closet = cfg->fold.closet; /* zero -> defaults; denylist borrowed for this call */
+
+         fold_result_t fr;
+         memset(&fr, 0, sizeof(fr));
+         if (context_fold_view(work, &fc, st ? &st->freeze : NULL, &fr) != 0)
+         {
+            /* hard bypass: an internal fold error -> caller forwards the original. */
+            fold_result_free(&fr);
+            if (compressed_owned)
+               cJSON_Delete(compressed_owned);
+            out->messages = NULL;
+            out->mutated = 0;
+            return 1;
+         }
+         if (fr.folded)
+         {
+            out->messages = fr.messages; /* transfer ownership */
+            fr.messages = NULL;          /* so fold_result_free does not delete it */
+            out->mutated = 1;
+            out->reason = REDUCE_REASON_REDUCED;
+            out->folded_msgs = fr.folded_msgs;
+            out->retained_msgs = fr.retained_msgs;
+            out->reused_boundary = fr.reused_boundary;
+            out->epochs = st ? st->freeze.epochs : 0;
+            if (st)
+               st->reduced = 1;   /* provenance: a later seam re-measures, does not re-reduce */
+            if (compressed_owned) /* fold built its own array from the compressed copy */
+            {
+               cJSON_Delete(compressed_owned);
+               compressed_owned = NULL;
+            }
+         }
+         fold_result_free(&fr); /* fr.messages is NULL when transferred; no-op otherwise */
+      }
+   }
+
+   /* Publish the compress-only result when fold was disabled or no-opped (fold sets
+    * out->messages itself and frees compressed_owned when it folds). */
+   if (compressed_owned && !out->messages)
+   {
+      out->messages = compressed_owned;
+      compressed_owned = NULL;
+   }
+
+   /* Recompute the reduced/removed token forecast once, over whatever reduced view
+    * a lever produced (compress and/or fold). The system prompt is the immutable
+    * prefix zone — counted, never reduced (mirrors the baseline). */
+   if (out->mutated && out->messages)
+   {
+      int reduced = node_token_estimate(out->messages);
+      if (system_prompt && system_prompt[0])
+         reduced += (int)(strlen(system_prompt) / CHARS_PER_TOKEN_EST) + 1;
+      out->reduced_tokens = reduced;
+      out->removed_tokens = baseline > reduced ? baseline - reduced : 0;
    }
 
    /* Cost forecast bracket. Basis = the realized saving (removed_tokens) once a

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -90,6 +90,12 @@ void agent_record_token_audit(const agent_result_t *result, const char *role, co
  * dropping them when the provider stream errors mid-flight. */
 void agent_record_token_audit_kind(const agent_result_t *result, const char *role,
                                    const char *source, const char *usage_kind);
+/* Record a context-economizer ledger row (usage_kind="avoided", FORECAST-only —
+ * see context_reduce.h). Forward-declared struct so this broad header need not
+ * pull in context_reduce.h; the caller includes it for the full type. */
+struct reduce_result_s;
+void agent_record_reduce_ledger(const struct reduce_result_s *r, const char *model,
+                                const char *agent_name, const char *role);
 /* Master gate (proposal §2/§7 rollout knob): returns 1 when
  * ingress_usage_accounting_enabled is set. The stateless ingress handlers call
  * this before writing their cost rows so ingress accounting can be flipped on

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -162,6 +162,26 @@ char *agent_load_project_contract(const char *project_root);
  * string bounded by AGENT_TOOL_OUTPUT_MAX; caller must free(). */
 char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *tool_name);
 
+/* Pure clamp half of agent_tool_output_cap(): map a configured
+ * tool_output_max_bytes value to an effective per-result cap. 0/negative ->
+ * AGENT_TOOL_OUTPUT_MAX (built-in default); any positive value is clamped to
+ * (0, AGENT_TOOL_OUTPUT_RAW_MAX]. Header-inline so it is the single source of
+ * truth for both the config-reading resolver and unit tests (zero linkage). */
+static inline size_t agent_tool_output_cap_clamp(int configured)
+{
+   if (configured <= 0)
+      return (size_t)AGENT_TOOL_OUTPUT_MAX;
+   if ((size_t)configured > (size_t)AGENT_TOOL_OUTPUT_RAW_MAX)
+      return (size_t)AGENT_TOOL_OUTPUT_RAW_MAX;
+   return (size_t)configured;
+}
+
+/* Resolve the per-result MODEL-VISIBLE tool-output cap (bytes). Reads
+ * tool_output_max_bytes from config (mtime-cached) and clamps via
+ * agent_tool_output_cap_clamp(). Single source of truth for every
+ * model-visible tool-result truncation site. */
+size_t agent_tool_output_cap(void);
+
 /* Self-correcting delegate loop
  *
  * Wraps agent_run in a quality-checking loop. After each iteration the agent

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -45,20 +45,29 @@ struct cJSON;
 #define AGENT_BACKEND_CLI_STDIO    "cli-stdio" /* legacy config alias */
 #define CLI_CMD_MAX                256
 #define AGENT_DEFAULT_MAX_PARALLEL 3
-#define AGENT_TOOL_OUTPUT_MAX      (4 * 1024)
-#define AGENT_TOOL_OUTPUT_RAW_MAX  (32 * 1024)
-#define AGENT_MAX_LIST_FILES       500
-#define AGENT_MAX_TOOL_CALLS       16
-#define AGENT_MAX_NET_HOSTS        64
-#define AGENT_MAX_NETWORKS         8
-#define AGENT_MAX_TUNNELS          8
-#define AGENT_CONTEXT_BUDGET       16000
-#define AGENT_CACHE_TTL_SECONDS    300
-#define AGENT_MAX_PLAN_STEPS       32
-#define AGENT_MAX_PLAN_DEPS        8
-#define AGENT_MAX_CHECKPOINTS      32
-#define AGENT_MAX_EVAL_TASKS       64
-#define AGENT_MAX_COORD_AGENTS     4
+/* Default per-result cap (bytes) on the MODEL-VISIBLE tool output. Raised to
+ * 32 KB (== AGENT_TOOL_OUTPUT_RAW_MAX) so full tool output flows to the model by
+ * default; the (default-off) context-economizer losslessly compresses OLD
+ * results to keep history bounded. Operators can LOWER the per-result cap via
+ * the `tool_output_max_bytes` config key (resolved by agent_tool_output_cap()).
+ * This constant is the resolver's fallback when the key is unset/0. */
+#define AGENT_TOOL_OUTPUT_MAX (32 * 1024)
+/* Raw capture safety buffer (bytes): the hard ceiling on bytes captured from a
+ * child process before any model-visible truncation. NOT operator-configurable
+ * and never exceeded by the resolved per-result cap. */
+#define AGENT_TOOL_OUTPUT_RAW_MAX (32 * 1024)
+#define AGENT_MAX_LIST_FILES      500
+#define AGENT_MAX_TOOL_CALLS      16
+#define AGENT_MAX_NET_HOSTS       64
+#define AGENT_MAX_NETWORKS        8
+#define AGENT_MAX_TUNNELS         8
+#define AGENT_CONTEXT_BUDGET      16000
+#define AGENT_CACHE_TTL_SECONDS   300
+#define AGENT_MAX_PLAN_STEPS      32
+#define AGENT_MAX_PLAN_DEPS       8
+#define AGENT_MAX_CHECKPOINTS     32
+#define AGENT_MAX_EVAL_TASKS      64
+#define AGENT_MAX_COORD_AGENTS    4
 
 /* Per-call HTTP timeout for one turn of the multi-turn tool loop.
  *   agent_timeout_ms  configured per-call timeout (also the per-call cap)

--- a/src/headers/anthropic_ingress.h
+++ b/src/headers/anthropic_ingress.h
@@ -43,6 +43,10 @@ struct cJSON *anthropic_messages_to_openai(const struct cJSON *messages, const c
  * usable tools. */
 struct cJSON *anthropic_tools_to_openai(const struct cJSON *anthropic_tools);
 
+/* Convert Anthropic tools to the OpenAI Responses API's flat function-tool
+ * shape: [{type:"function",name,description,parameters}]. */
+struct cJSON *anthropic_tools_to_responses(const struct cJSON *anthropic_tools);
+
 /* Build a non-streaming Anthropic Messages API response object from a parsed
  * provider reply. resp_id is the "msg_..." id; model echoes the request's
  * model string. Produces:

--- a/src/headers/compact.h
+++ b/src/headers/compact.h
@@ -10,6 +10,14 @@
 #define COMPACT_DEFAULT_TAIL_BYTES 1024 /* trailing bytes to keep in plain-text results */
 #define COMPACT_MAX_PER_TOOL       8    /* max per-tool threshold overrides */
 
+/* Upper bound on a JSON structural-summary body. A summary can be LARGER than a
+ * tiny raw input (the only way compact_body output exceeds raw_len), so callers
+ * sizing the output buffer must allow raw_len + this much headroom to guarantee
+ * the summary is never itself truncated. ENFORCED: compact_json_summary() builds
+ * into a fixed `char summary[2048]` with bounded snprintf, so its result is always
+ * < this value — keep these in sync, and see test_compact's json_summary_bounded. */
+#define COMPACT_JSON_SUMMARY_MAX 2048
+
 /* Per-tool threshold override.
  * Set threshold to -1 to disable compaction entirely for a specific tool. */
 typedef struct
@@ -28,22 +36,41 @@ typedef struct
    int per_tool_count;
 } compact_config_t;
 
-/* Compact a tool result string.
+/* compact_body: THE single tool-result body-shrink algorithm. Both reduction
+ * seams call it — the eager per-result path (agent_compress_tool_result) and the
+ * economizer's lazy whole-history lever (context_compress_view). It is a pure
+ * transformer over the caller's output buffer:
  *
- * Strategy:
- *   1. If content <= effective threshold, pass through unchanged.
- *   2. If content is valid JSON, emit a structural key/type summary.
- *   3. Otherwise, keep head_bytes + tail_bytes with a truncation notice in between.
+ *   - Never allocates `out`; the caller owns and frees it.
+ *   - Never retains a pointer into `raw` or `cfg` past return.
+ *   - Never writes past `out_cap` (always NUL-terminates when out_cap > 0).
+ *   - Never applies a hard cap and never touches the Coordinate Closet — those
+ *     are per-seam policy the callers own (the eager seam caps to
+ *     agent_tool_output_cap and nominates from the FULL raw; the lazy seam runs a
+ *     net-shrink guard and nominates from the full body). Nomination is gated on
+ *     each seam's own shrink-happened decision, which is why it lives in the
+ *     callers, not here.
+ *   - Output length is <= raw_len EXCEPT the JSON-summary path, which is bounded
+ *     by COMPACT_JSON_SUMMARY_MAX; size `out_cap >= raw_len + COMPACT_JSON_SUMMARY_MAX`
+ *     to guarantee no truncation of any strategy.
  *
- * Dynamic budget: if context_budget > 0 and context_used > 0, the threshold
- * is tightened when context is >60 % or >80 % full.
+ * Strategy, in order:
+ *   1. Pass-through: content <= effective threshold (or compaction disabled).
+ *   2. JSON structural summary: content parses as a JSON object/array.
+ *   3. Head+tail: keep head_bytes + tail_bytes with a truncation notice between.
  *
- * cfg may be NULL to use built-in defaults.
- * tool_name may be NULL to skip per-tool overrides.
- * context_used / context_budget may both be 0 to disable dynamic adjustment.
+ * cfg may be NULL to use built-in defaults. tool_name may be NULL to skip
+ * per-tool overrides (the lazy economizer seam passes NULL — it operates on
+ * deep-copied, mixed-origin history where a single tool identity does not apply;
+ * per-tool thresholds therefore govern the eager seam only). Returns the number of
+ * bytes written to `out` (0 for an empty body, which the caller treats as a
+ * pass-through). On an internal allocation failure the body is copied through
+ * (bounded by out_cap) rather than emptied, so a non-empty body is never dropped.
  *
- * Returns a heap-allocated string that the caller must free(). */
-char *compact_tool_result(const char *raw, size_t raw_len, const compact_config_t *cfg,
-                          const char *tool_name, int context_used, int context_budget);
+ * NOTE: the former context_used/context_budget dynamic-threshold parameters were
+ * removed with the move to this core — they were never passed non-zero by any
+ * production caller (dead capability), so eager output is byte-identical. */
+size_t compact_body(const char *raw, size_t raw_len, const char *tool_name,
+                    const compact_config_t *cfg, char *out, size_t out_cap);
 
 #endif /* COMPACT_H */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -907,6 +907,17 @@ typedef struct config
    int fold_recall_enabled;
    int fold_recall_ttl_turns;
 
+   /* Unified context economizer (src/context_reduce.c). The single reduction
+    * subsystem invoked at every request-assembly seam. All default-off. Knobs are
+    * added here as each slice implements them, so an exposed flag is always
+    * honored. Currently the measurement engine (delegate seam, measure-only):
+    * reduce_measure_enabled: collect baseline/opportunity ledger rows (no
+    *   mutation) — the shadow mode that powers the cost numbers.
+    * reduce_delegate_seam: enable the economizer at the delegate turn loop.
+    * (Per-lever gates, the gateway seam, and min_gain land in later slices.) */
+   int reduce_measure_enabled;
+   int reduce_delegate_seam;
+
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned
     *   (0 = use default: 14400 = 4 hours).

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -916,10 +916,15 @@ typedef struct config
     * reduce_delegate_seam: enable the economizer at the delegate turn loop.
     * reduce_history_fold: actually fold old history (rolling skeleton + Coordinate
     *   Closet) at the delegate seam — the first real reduction lever (default-off).
-    * (Other per-lever gates, the gateway seam, and min_gain land in later slices.) */
+    * reduce_gateway_seam: enable the economizer at the inbound /v1 gateway seam.
+    *   Shadow-mode only in this slice (measure_only is forced on at the gateway, so
+    *   it NEVER mutates the live client request) — collects baselines on live
+    *   ingress traffic with zero behavior change.
+    * (Other per-lever gates and min_gain land in later slices.) */
    int reduce_measure_enabled;
    int reduce_delegate_seam;
    int reduce_history_fold;
+   int reduce_gateway_seam;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -914,9 +914,12 @@ typedef struct config
     * reduce_measure_enabled: collect baseline/opportunity ledger rows (no
     *   mutation) — the shadow mode that powers the cost numbers.
     * reduce_delegate_seam: enable the economizer at the delegate turn loop.
-    * (Per-lever gates, the gateway seam, and min_gain land in later slices.) */
+    * reduce_history_fold: actually fold old history (rolling skeleton + Coordinate
+    *   Closet) at the delegate seam — the first real reduction lever (default-off).
+    * (Other per-lever gates, the gateway seam, and min_gain land in later slices.) */
    int reduce_measure_enabled;
    int reduce_delegate_seam;
+   int reduce_history_fold;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -353,6 +353,13 @@ typedef struct config
     * resolver will return in one call. Bounds the per-call recovery cost and a
     * model-supplied range. */
    int code_span_max_lines;
+   /* Operator cap (bytes) on the per-result MODEL-VISIBLE tool output (read_file,
+    * bash, grep, glob, git_* results). 0 = use the built-in default
+    * AGENT_TOOL_OUTPUT_MAX (32768). Any positive value is clamped to
+    * (0, AGENT_TOOL_OUTPUT_RAW_MAX=32768]; set it LOWER to bound the bytes a
+    * single tool result contributes to the prompt + history. Resolved by
+    * agent_tool_output_cap(); never exceeds the 32 KB raw capture buffer. */
+   int tool_output_max_bytes;
    /* ingress-compression master gate (§6.5 B8), default off. When on, code-search
     * hits are span-enriched (the matched line is located) and the ingress envelope
     * folds code entries into recoverable references; off keeps the search query,

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -932,12 +932,21 @@ typedef struct config
     *   Shadow-mode only in this slice (measure_only is forced on at the gateway, so
     *   it NEVER mutates the live client request) — collects baselines on live
     *   ingress traffic with zero behavior change.
+    * reduce_freeze_guard_enabled: freeze cost guardrail (Slice 5). Pin the fold
+    *   boundary (cache-warm reduced prefix) only when the estimated cache-read
+    *   savings over reduce_freeze_guard_horizon reuses cover the one-time cache-write
+    *   churn; otherwise re-derive without pinning. Default-ON, but only acts when the
+    *   (default-off) economizer freeze is live, so no default-path behavior change.
+    * reduce_freeze_guard_horizon: expected reuse turns for the break-even estimate
+    *   (0 -> 1; clamped to FREEZE_GUARD_MAX_HORIZON).
     * (Other per-lever gates and min_gain land in later slices.) */
    int reduce_measure_enabled;
    int reduce_delegate_seam;
    int reduce_history_fold;
    int reduce_compress;
    int reduce_gateway_seam;
+   int reduce_freeze_guard_enabled;
+   int reduce_freeze_guard_horizon;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -916,6 +916,11 @@ typedef struct config
     * reduce_delegate_seam: enable the economizer at the delegate turn loop.
     * reduce_history_fold: actually fold old history (rolling skeleton + Coordinate
     *   Closet) at the delegate seam — the first real reduction lever (default-off).
+    * reduce_compress: boundary-free tool-result BODY compression at the delegate
+    *   seam (Slice 4). Shrinks oversized tool-result bodies in place (identifiers
+    *   conserved in the Coordinate Closet) WITHOUT needing a clean-user-turn
+    *   boundary, so it engages on autonomous tool-loops where history_fold can't.
+    *   Provider-native output (valid for all builders incl. chatgpt). Default-off.
     * reduce_gateway_seam: enable the economizer at the inbound /v1 gateway seam.
     *   Shadow-mode only in this slice (measure_only is forced on at the gateway, so
     *   it NEVER mutates the live client request) — collects baselines on live
@@ -924,6 +929,7 @@ typedef struct config
    int reduce_measure_enabled;
    int reduce_delegate_seam;
    int reduce_history_fold;
+   int reduce_compress;
    int reduce_gateway_seam;
 
    /* Session/worktree cleanup policy.

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -21,6 +21,7 @@ void config_parse_kb_section(config_t *cfg, cJSON *root);
 void config_parse_memory_maintenance_section(config_t *cfg, cJSON *root);
 void config_parse_worktree_gc_section(config_t *cfg, cJSON *root);
 void config_parse_fold_section(config_t *cfg, cJSON *root);
+void config_parse_reduce_section(config_t *cfg, cJSON *root);
 void config_parse_memory_section(config_t *cfg, cJSON *root);
 void config_parse_cross_verify_section(config_t *cfg, cJSON *root);
 void config_parse_retry_section(config_t *cfg, cJSON *root);

--- a/src/headers/context_fold.h
+++ b/src/headers/context_fold.h
@@ -89,6 +89,39 @@ extern "C"
    int context_fold_view(const cJSON *messages, const fold_config_t *cfg, fold_freeze_t *freeze,
                          fold_result_t *out);
 
+   /* Boundary-free TOOL-RESULT body compression (§ economizer Slice 4).
+    *
+    * Unlike context_fold_view, this needs NO clean-user-turn boundary: it shrinks
+    * oversized tool-result BODIES IN PLACE while keeping the carrying message, its
+    * role/type, and its tool_use_id / tool_call_id — so a tool_use and its result
+    * are NEVER split and message_history_repair finds zero orphans. This is why it
+    * engages on autonomous tool-loops (one user turn, then assistant tool_calls +
+    * results forever) where the fold's boundary never appears.
+    *
+    * For every message at index < (count - retained_msgs) it walks all three
+    * provider tool-result shapes — Anthropic content-block type=="tool_result"
+    * (.content string|obj), OpenAI role=="tool" (.content string), Responses
+    * type=="function_call_output" (.output) — and, for each body whose serialized
+    * length exceeds cfg->reasoning_excerpt_bytes (0 -> CONTEXT_FOLD_DEFAULT_EXCERPT_BYTES)
+    * AND that would actually shrink, replaces it with a head excerpt + an elision
+    * marker. The exact identifiers in the full body are first nominated into a
+    * Coordinate Closet, which (when cfg->closet.enabled) is prepended as a synthetic
+    * user+assistant note pair (matching context_fold_view's closet emission) so
+    * conserved identifiers ride along. EVERYTHING else — role/type, ids, message
+    * ordering, all non-tool-result content — is byte-for-byte preserved.
+    *
+    * The input `messages` array is NEVER mutated: out->messages is a fresh
+    * deep-copied array the caller owns (fold_result_free). On success with at least
+    * one body compressed, out->folded = 1 (the flag is reused to mean "compressed")
+    * and out->folded_msgs = the count of bodies compressed. If nothing exceeded the
+    * threshold (or on OOM / disabled / too-short), out->folded = 0 and
+    * out->messages = NULL (the caller uses the original). Returns 0 on success
+    * (incl. no-op), -1 on bad args. Deterministic: identical (messages, cfg) ->
+    * byte-identical out->messages serialization (for freeze/cache warmth). Output
+    * is provider-native (only bodies shortened + a plain-text note pair), so it is
+    * valid input for ALL provider builders, including chatgpt/Responses. */
+   int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_result_t *out);
+
    /* Free any owned resources in *out. NULL-safe on a zeroed result and on a
     * no-fold result (out->messages == NULL), so callers may invoke it
     * unconditionally after any build path. */

--- a/src/headers/context_fold.h
+++ b/src/headers/context_fold.h
@@ -36,6 +36,13 @@ extern "C"
                                      */
       int register_enabled;         /* §6: annotate folded assistant lines with their register */
       coord_closet_config_t closet; /* identifier-conservation config (§2) */
+      /* Tool-result body shrink (context_compress_view) shares the eager seam's
+       * compact_body() core; these mirror the compact.* knobs so ONE shrink policy
+       * governs both seams. 0 -> compact.c built-in defaults. The effective tail is
+       * min(compact_tail_bytes, reasoning_excerpt_bytes/2) so a small excerpt budget
+       * keeps the tail proportional rather than inheriting a large default. */
+      int compact_head_bytes;
+      int compact_tail_bytes;
    } fold_config_t;
 
 #define CONTEXT_FOLD_DEFAULT_RETAINED_MSGS 8
@@ -103,8 +110,10 @@ extern "C"
     * (.content string|obj), OpenAI role=="tool" (.content string), Responses
     * type=="function_call_output" (.output) — and, for each body whose serialized
     * length exceeds cfg->reasoning_excerpt_bytes (0 -> CONTEXT_FOLD_DEFAULT_EXCERPT_BYTES)
-    * AND that would actually shrink, replaces it with a head excerpt + an elision
-    * marker. The exact identifiers in the full body are first nominated into a
+    * AND that would actually shrink, replaces it via the shared compact_body() core
+    * (JSON structural summary for JSON bodies, else head+tail truncation — the same
+    * algorithm the eager seam uses). The exact identifiers in the full body are first
+    * nominated into a
     * Coordinate Closet, which (when cfg->closet.enabled) is prepended as a synthetic
     * user+assistant note pair (matching context_fold_view's closet emission) so
     * conserved identifiers ride along. EVERYTHING else — role/type, ids, message

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -60,6 +60,7 @@ extern "C"
       /* Per-lever gates (all default-off). */
       int inject_compress; /* KB/code envelope + code->file:line compression */
       int history_fold;    /* rolling history skeleton + Coordinate Closet */
+      int compress;        /* boundary-free tool-result BODY compression (Slice 4) */
       int dedup;           /* merge consecutive same-role string turns */
       int freeze;          /* byte-identical reduced prefix across turns */
 

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -29,7 +29,10 @@
  *     inject-compress -> freeze-verify.
  *  5. Net-gain pre-check + freeze cost guardrail. Skip fold when foldable tokens
  *     are below the round-trip recovery threshold (ledger reason="skip_no_gain");
- *     disable freeze when estimated cache-write churn cost > saved cache-read.
+ *     disable freeze when the estimated cache-write PREMIUM is not recovered by the
+ *     cache-read savings over the reuse horizon (Slice 5 —
+ *     reduce_freeze_cost_favorable; freeze_guard config, default-on but inert until
+ *     the default-off freeze is enabled).
  *  6. Live-traffic safety. Per-lever + per-seam gates, a measure-only shadow mode,
  *     and a caller-side hard bypass: on ANY internal error context_reduce returns
  *     non-zero with out->messages == NULL so the caller forwards the ORIGINAL
@@ -77,8 +80,22 @@ extern "C"
        * the existing compact.c/tool-output caps are accounted for. */
       int min_gain_tokens;
 
+      /* Freeze cost guardrail (Slice 5). The freeze pins the fold boundary so the
+       * reduced prefix stays byte-identical (cache-warm) turn-to-turn — but a
+       * boundary that keeps advancing forces provider cache-WRITES (1.25-2x input
+       * rate) that can flip reduction net-negative. When enabled, freeze is pinned
+       * only when the estimated cache-read savings over `horizon` reuses cover the
+       * one-time cache-write cost; otherwise the turn re-derives without pinning.
+       * Default-on, but only acts when the (default-off) economizer freeze is live. */
+      int freeze_guard_enabled;
+      int freeze_guard_horizon; /* expected reuse turns for break-even (0 -> 1) */
+
       fold_config_t fold; /* history-fold sub-config (reused verbatim) */
    } reduce_config_t;
+
+/* Hard cap on the configured freeze-guard horizon, so a misconfigured long horizon
+ * cannot justify an unbounded cache-write bet on a single run. */
+#define FREEZE_GUARD_MAX_HORIZON 5
 
    /* Per-CONVERSATION reducer state, owned by the caller and persisted across
     * turns within one conversation (e.g. a stack local spanning the turn loop).
@@ -133,6 +150,7 @@ extern "C"
       int retained_msgs;
       int reused_boundary; /* 1 = freeze reused (cache-warm) */
       int epochs;
+      int freeze_guarded; /* 1 = the cost guardrail disabled freeze this turn */
    } reduce_result_t;
 
    /* Run the economizer for one request at one seam.
@@ -153,6 +171,32 @@ extern "C"
    int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
                       const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
                       reduce_state_t *st, reduce_result_t *out);
+
+   /* Freeze cost guardrail (Slice 5), exposed for unit testing. Returns 1 when
+    * pinning the freeze boundary is cost-favorable — i.e. the estimated cache-read
+    * savings over `horizon` reuses cover the one-time cache-WRITE PREMIUM. The guard
+    * gates the freeze pointer context_reduce hands context_fold_view: when it returns
+    * 0, context_reduce passes NULL, so the fold RE-DERIVES the boundary this turn
+    * WITHOUT persisting it (context_fold_view only reads/commits freeze state when the
+    * pointer is non-NULL). The persisted st->freeze is left as-is; a later non-guarded
+    * turn that reuses it is still protected by the prefix-digest check inside
+    * context_fold_view (a stale boundary fails the digest and re-epochs), so toggling
+    * the guard per-turn can never serve an obsolete cache-warm prefix.
+    *
+    * Conservative + fail-OPEN: returns 1 (freeze on) when prefix_tokens <= 0 (no
+    * churn), when model is NULL/unpriced (preserves prior always-on behavior). Returns
+    * 0 only when pricing is known AND either there is no read discount (cache_read >=
+    * input) OR the read savings provably do not cover the write premium. Pure: prices
+    * via token_estimate_cost_ex, no state. */
+   int reduce_freeze_cost_favorable(const char *model, int prefix_tokens, int horizon);
+
+   /* The scale-invariant arithmetic core of the guardrail, exposed so the disable
+    * branch (unreachable with currently-priced models) can be unit-tested with
+    * synthetic per-tier costs. horizon is clamped to [1, FREEZE_GUARD_MAX_HORIZON].
+    * No read discount (read >= input) -> 0; write premium (write - input) <= 0 -> 1;
+    * else 1 iff horizon * (input - read) >= (write - input). */
+   int reduce_freeze_favorable_rates(double input_cost, double write_cost, double read_cost,
+                                     int horizon);
 
    /* Free a NEW messages array produced by context_reduce. Safe on a zeroed/no-op
     * result (messages==NULL). Must run AFTER the request is serialized (the result

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -1,0 +1,165 @@
+/* context_reduce.h: the unified context economizer — ONE provider-agnostic
+ * reduction subsystem invoked at every request-assembly choke point (the
+ * inbound /v1 gateway AND the delegate turn loop), so it runs for every agent
+ * (primary + delegates) and every provider.
+ *
+ * It is a THIN ORCHESTRATOR over independent, individually-gated levers — it does
+ * not reimplement them:
+ *   - inject-compress  (ingress_preinject_*: KB/code envelope, code -> file:line)
+ *   - history-fold     (context_fold_view: rolling skeleton + Coordinate Closet)
+ *   - dedup/compact    (messages_compact_consecutive)
+ *   - freeze           (byte-identical reduced prefix for provider cache warmth)
+ * plus a measurement ledger that records what each request would save.
+ *
+ * DESIGN CONTRACTS (from the design-gate review — see the plan):
+ *  1. Idempotence / provenance. A single logical request can traverse BOTH seams
+ *     (gateway then delegate loop). `context_reduce` stamps reduce_state_t.reduced
+ *     once a seam mutates; a later seam that sees it set MUST NOT re-reduce (it
+ *     re-measures against what it actually received). The 400-fallback rebuilds
+ *     from the pristine original transcript, never from a prior reduced output.
+ *  2. Per-format structural boundaries. Fold boundary selection parses each
+ *     provider's native tool-call/tool-result structure (NOT detect_format(),
+ *     which is a router heuristic). Invariant: no assistant tool_call/tool_use is
+ *     ever separated from its result across a fold boundary.
+ *  3. Immutable prefix zone. The system prompt and any designated safety turns
+ *     are byte-identical post-reduction; no lossy lever touches them.
+ *  4. Fixed lever order, freeze-first. freeze digests the stable ORIGINAL bytes
+ *     BEFORE inject-compress mutates them, so a turn-varying envelope can never
+ *     silently bust the prompt cache. Order: freeze-capture -> dedup -> fold ->
+ *     inject-compress -> freeze-verify.
+ *  5. Net-gain pre-check + freeze cost guardrail. Skip fold when foldable tokens
+ *     are below the round-trip recovery threshold (ledger reason="skip_no_gain");
+ *     disable freeze when estimated cache-write churn cost > saved cache-read.
+ *  6. Live-traffic safety. Per-lever + per-seam gates, a measure-only shadow mode,
+ *     and a caller-side hard bypass: on ANY internal error context_reduce returns
+ *     non-zero with out->messages == NULL so the caller forwards the ORIGINAL
+ *     request unchanged.
+ *
+ * All levers default OFF. Measurement is itself a gate (measure_only) so baselines
+ * can be collected with zero behavior change. */
+#ifndef DEC_CONTEXT_REDUCE_H
+#define DEC_CONTEXT_REDUCE_H 1
+
+#include "context_fold.h" /* fold_config_t, fold_freeze_t (reused, not duplicated) */
+#include <cJSON.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Which seam is invoking the reducer (for provenance + per-seam gating). */
+   typedef enum
+   {
+      REDUCE_SEAM_DELEGATE = 0, /* the agent turn loop (provider-native messages) */
+      REDUCE_SEAM_GATEWAY = 1,  /* the inbound /v1 proxy (client wire-format) */
+   } reduce_seam_t;
+
+   typedef struct
+   {
+      /* Per-lever gates (all default-off). */
+      int inject_compress; /* KB/code envelope + code->file:line compression */
+      int history_fold;    /* rolling history skeleton + Coordinate Closet */
+      int dedup;           /* merge consecutive same-role string turns */
+      int freeze;          /* byte-identical reduced prefix across turns */
+
+      /* Per-seam enable (default-off): a lever only runs at a seam that is on. */
+      int gateway_seam;
+      int delegate_seam;
+
+      /* Shadow mode: compute the ledger but DO NOT mutate the messages. Lets the
+       * gateway/delegate path collect baselines on live traffic with zero risk. */
+      int measure_only;
+
+      /* Net-gain pre-check: skip fold when foldable tokens < this (0 -> default).
+       * Guards against routine net-negative folds once recovery round-trips and
+       * the existing compact.c/tool-output caps are accounted for. */
+      int min_gain_tokens;
+
+      fold_config_t fold; /* history-fold sub-config (reused verbatim) */
+   } reduce_config_t;
+
+   /* Per-CONVERSATION reducer state, owned by the caller and persisted across
+    * turns within one conversation (e.g. a stack local spanning the turn loop).
+    * NOT shared across agents/sessions (cross-session sharing would leak context).
+    * Zero-init before first use. */
+   typedef struct
+   {
+      fold_freeze_t freeze; /* §3 freeze boundary + 64-bit prefix digest */
+      int reduced;          /* provenance: set once a seam has reduced this request
+                             * set -> a second seam re-measures but does NOT re-reduce */
+      int turn;             /* current turn index (freeze residency + ledger) */
+   } reduce_state_t;
+
+   /* Why a request did/didn't reduce — recorded in the ledger for auditability. */
+   typedef enum
+   {
+      REDUCE_REASON_NONE = 0,     /* no lever enabled at this seam */
+      REDUCE_REASON_REDUCED,      /* reduction applied */
+      REDUCE_REASON_MEASURED,     /* measure_only: metrics computed, not mutated */
+      REDUCE_REASON_SKIP_NO_GAIN, /* foldable tokens below min_gain_tokens */
+      REDUCE_REASON_ALREADY,      /* provenance: a prior seam already reduced */
+   } reduce_reason_t;
+
+   typedef struct
+   {
+      /* Reduced view. When messages were mutated, `messages` is a NEW array the
+       * caller frees via context_reduce_result_free (mutated==1). When nothing
+       * changed, messages==NULL and the caller uses its original array. */
+      cJSON *messages;
+      int mutated;
+
+      reduce_reason_t reason;
+
+      /* Measurement (token COUNTS are caching-independent; chars/4 estimate, so
+       * forecast only — the invoice-quality number is realized on/off spend). */
+      int baseline_tokens; /* assembled-context tokens before reduction */
+      int reduced_tokens;  /* after reduction (== baseline when measure_only) */
+      int removed_tokens;  /* baseline - reduced (the saving, in tokens) */
+      int foldable_tokens; /* tokens in the fold-eligible prefix region */
+
+      /* Cost forecast bracket, priced via token_estimate_cost_ex on `model`. The
+       * basis is the realized saving (removed_tokens) once a lever runs, or the
+       * foldable OPPORTUNITY (foldable_tokens) in measure-only mode. floor prices
+       * the basis at the provider CACHE-READ rate (cache-warm); ceiling at the
+       * FRESH input rate (cache-cold). NEVER the headline — a forecast bracket;
+       * both 0 when the model is unpriced. */
+      double est_saved_cost_floor;
+      double est_saved_cost_ceiling;
+
+      /* Fold diagnostics (0 in measure-only; populated by the reduction slices). */
+      int folded_msgs;
+      int retained_msgs;
+      int reused_boundary; /* 1 = freeze reused (cache-warm) */
+      int epochs;
+   } reduce_result_t;
+
+   /* Run the economizer for one request at one seam.
+    *
+    *   messages       provider-native (delegate seam) or client-wire (gateway seam)
+    *                  cJSON array; NEVER mutated in place.
+    *   system_prompt  immutable prefix zone (never reduced).
+    *   model          billable model id, for the cost forecast (may be NULL).
+    *   session_id     conversation scope for state/ledger (may be NULL).
+    *   seam           which choke point is calling.
+    *   cfg            lever + seam gates (may be NULL -> all-off, no-op).
+    *   st             per-conversation state (may be NULL -> freeze disabled).
+    *   out            zeroed then populated; free with context_reduce_result_free.
+    *
+    * Returns 0 on success (including the deliberate no-op cases). Returns non-zero
+    * on an internal error with out->messages == NULL, so the caller can FORWARD
+    * THE ORIGINAL request unchanged (hard bypass — never break live traffic). */
+   int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
+                      const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
+                      reduce_state_t *st, reduce_result_t *out);
+
+   /* Free a NEW messages array produced by context_reduce. Safe on a zeroed/no-op
+    * result (messages==NULL). Must run AFTER the request is serialized (the result
+    * may hand out non-owning references into the original array). */
+   void context_reduce_result_free(reduce_result_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_CONTEXT_REDUCE_H */

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -138,7 +138,7 @@ extern "C"
     *
     *   messages       provider-native (delegate seam) or client-wire (gateway seam)
     *                  cJSON array; NEVER mutated in place.
-    *   system_prompt  immutable prefix zone (never reduced).
+    *   system_prompt  immutable prefix zone (never reduced); may be NULL.
     *   model          billable model id, for the cost forecast (may be NULL).
     *   session_id     conversation scope for state/ledger (may be NULL).
     *   seam           which choke point is calling.

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -101,7 +101,7 @@ extern "C"
       REDUCE_REASON_ALREADY,      /* provenance: a prior seam already reduced */
    } reduce_reason_t;
 
-   typedef struct
+   typedef struct reduce_result_s
    {
       /* Reduced view. When messages were mutated, `messages` is a NEW array the
        * caller frees via context_reduce_result_free (mutated==1). When nothing

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -862,6 +862,8 @@ native_provider_http:
             rcfg.compress = ecfg.reduce_compress;
             rcfg.measure_only =
                 !(rcfg.history_fold || rcfg.compress); /* a lever on -> mutate; else shadow */
+            rcfg.freeze_guard_enabled = ecfg.reduce_freeze_guard_enabled; /* Slice 5 guardrail */
+            rcfg.freeze_guard_horizon = ecfg.reduce_freeze_guard_horizon;
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
             rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
             rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -26,6 +26,7 @@
 #include "provider_cli_adapter.h"
 #include "config.h"
 #include "context_fold.h"
+#include "context_reduce.h"
 #include "fold_recall.h"
 #include "dstr.h"
 #include "cJSON.h"
@@ -824,6 +825,31 @@ native_provider_http:
          final_instruction_added = 1;
       }
       cJSON *active_tools = final_text_only_turn ? NULL : tools;
+
+      /* Context economizer (delegate seam, measure-only): record a baseline +
+       * foldable-opportunity ledger row when reduce.measure is enabled. Cheap
+       * (mtime-cached) config load keeps this dark by default. Measures the
+       * canonical pre-reduction `messages` so the baseline is provider-agnostic. */
+      {
+         config_t ecfg;
+         if (config_load(&ecfg) == 0 && ecfg.reduce_measure_enabled && ecfg.reduce_delegate_seam)
+         {
+            reduce_config_t rcfg;
+            memset(&rcfg, 0, sizeof(rcfg));
+            rcfg.delegate_seam = 1;
+            rcfg.measure_only = 1;
+            rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
+            reduce_result_t rres;
+            /* session_id param unused by the transform; the ledger writer resolves
+             * the session itself (a local `session_id[]` array shadows the fn here). */
+            if (context_reduce(messages, sys, fb_agent.model, NULL, REDUCE_SEAM_DELEGATE, &rcfg,
+                               NULL, &rres) == 0)
+            {
+               agent_record_reduce_ledger(&rres, fb_agent.model, agent->name, role);
+               context_reduce_result_free(&rres);
+            }
+         }
+      }
 
       /* Build request (use fb_agent which may have fallback model after turn 0) */
       cJSON *req;

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -844,7 +844,7 @@ native_provider_http:
       {
          config_t ecfg;
          if (config_load(&ecfg) == 0 && ecfg.reduce_delegate_seam &&
-             (ecfg.reduce_measure_enabled || ecfg.reduce_history_fold))
+             (ecfg.reduce_measure_enabled || ecfg.reduce_history_fold || ecfg.reduce_compress))
          {
             reduce_config_t rcfg;
             memset(&rcfg, 0, sizeof(rcfg));
@@ -856,7 +856,12 @@ native_provider_http:
              * Keep the Responses path measure-only here; fold it in a later slice
              * once verified live. */
             rcfg.history_fold = ecfg.reduce_history_fold && !chatgpt;
-            rcfg.measure_only = !rcfg.history_fold; /* fold on -> mutate; else shadow */
+            /* Compress only shrinks tool-result BODIES in place — the message
+             * shape (role/type, ids, typed items) is preserved — so its output is
+             * valid for ALL builders INCLUDING chatgpt/Responses. Not gated off. */
+            rcfg.compress = ecfg.reduce_compress;
+            rcfg.measure_only =
+                !(rcfg.history_fold || rcfg.compress); /* a lever on -> mutate; else shadow */
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
             rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
             rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -865,6 +865,8 @@ native_provider_http:
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
             rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
             rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;
+            rcfg.fold.compact_head_bytes = ecfg.compact_head_bytes; /* compact.* drives the */
+            rcfg.fold.compact_tail_bytes = ecfg.compact_tail_bytes; /* shared shrink core    */
             rcfg.fold.register_enabled = ecfg.fold_register_enabled;
             rcfg.fold.closet.enabled = ecfg.coord_closet_enabled;
             rcfg.fold.closet.budget_bytes = ecfg.coord_closet_budget_bytes;

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -667,6 +667,11 @@ native_provider_http:
     * fold_freeze_enabled; ignored otherwise. */
    fold_freeze_t agent_fold_freeze;
    memset(&agent_fold_freeze, 0, sizeof(agent_fold_freeze));
+   /* Context economizer (delegate seam): per-run reducer state persisted across
+    * turns so the §3 fold-freeze boundary stays byte-identical (warm provider
+    * cache). Honored only when reduce.delegate_seam is enabled. */
+   reduce_state_t agent_reduce_state;
+   memset(&agent_reduce_state, 0, sizeof(agent_reduce_state));
    /* §4 fold recall: per-run page table of folded-away coordinates, for re-touch
     * hints across turns. Honored only when fold_recall_enabled. */
    fold_recall_index_t agent_fold_recall;
@@ -826,52 +831,95 @@ native_provider_http:
       }
       cJSON *active_tools = final_text_only_turn ? NULL : tools;
 
-      /* Context economizer (delegate seam, measure-only): record a baseline +
-       * foldable-opportunity ledger row when reduce.measure is enabled. Cheap
-       * (mtime-cached) config load keeps this dark by default. Measures the
-       * canonical pre-reduction `messages` so the baseline is provider-agnostic. */
+      /* Context economizer (delegate seam): record a baseline + foldable-opportunity
+       * ledger row, and — when reduce.history_fold is on — ACTUALLY fold the prefix
+       * (provider-agnostic rolling skeleton + Coordinate Closet). The reduced view,
+       * when produced, replaces `messages` for the request build of every provider
+       * branch below and is freed after the request is serialized. Cheap
+       * (mtime-cached) config load keeps this dark by default; default-off is
+       * byte-identical to the prior behavior. */
+      reduce_result_t agent_reduce_result;
+      memset(&agent_reduce_result, 0, sizeof(agent_reduce_result));
+      int reduce_active = 0; /* 1 once a real reduction replaced the message array */
       {
          config_t ecfg;
-         if (config_load(&ecfg) == 0 && ecfg.reduce_measure_enabled && ecfg.reduce_delegate_seam)
+         if (config_load(&ecfg) == 0 && ecfg.reduce_delegate_seam &&
+             (ecfg.reduce_measure_enabled || ecfg.reduce_history_fold))
          {
             reduce_config_t rcfg;
             memset(&rcfg, 0, sizeof(rcfg));
             rcfg.delegate_seam = 1;
-            rcfg.measure_only = 1;
+            /* The synthetic fold turns are {role,content:string} — valid input for
+             * anthropic / openai / gemini builders, but the chatgpt Responses
+             * builder passes the array through unconverted and its API expects
+             * top-level typed items, so feeding it folded turns is unverified.
+             * Keep the Responses path measure-only here; fold it in a later slice
+             * once verified live. */
+            rcfg.history_fold = ecfg.reduce_history_fold && !chatgpt;
+            rcfg.measure_only = !rcfg.history_fold; /* fold on -> mutate; else shadow */
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
-            reduce_result_t rres;
+            rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
+            rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;
+            rcfg.fold.register_enabled = ecfg.fold_register_enabled;
+            rcfg.fold.closet.enabled = ecfg.coord_closet_enabled;
+            rcfg.fold.closet.budget_bytes = ecfg.coord_closet_budget_bytes;
+            rcfg.fold.closet.max_ratio_pct = ecfg.coord_closet_max_ratio_pct;
+            rcfg.fold.closet.denylist =
+                ecfg.coord_closet_denylist[0] ? ecfg.coord_closet_denylist : NULL;
+            /* Per-turn provenance: each loop turn is a distinct request at the single
+             * delegate seam, so clear the cross-seam `reduced` flag while preserving
+             * the across-turn freeze boundary in agent_reduce_state.freeze. */
+            agent_reduce_state.reduced = 0;
+            agent_reduce_state.turn = turn;
             /* session_id param unused by the transform; the ledger writer resolves
              * the session itself (a local `session_id[]` array shadows the fn here). */
             if (context_reduce(messages, sys, fb_agent.model, NULL, REDUCE_SEAM_DELEGATE, &rcfg,
-                               NULL, &rres) == 0)
+                               &agent_reduce_state, &agent_reduce_result) == 0)
             {
-               agent_record_reduce_ledger(&rres, fb_agent.model, agent->name, role);
-               context_reduce_result_free(&rres);
+               agent_record_reduce_ledger(&agent_reduce_result, fb_agent.model, agent->name, role);
+               if (agent_reduce_result.mutated && agent_reduce_result.messages)
+                  reduce_active = 1;
+            }
+            else
+            {
+               /* hard bypass: internal failure -> forward the original transcript */
+               context_reduce_result_free(&agent_reduce_result);
+               memset(&agent_reduce_result, 0, sizeof(agent_reduce_result));
             }
          }
       }
+      /* When the economizer produced a reduced view, every provider branch builds
+       * its request from it (and the Anthropic-only build_fold_view path is skipped
+       * to avoid double-folding). */
+      cJSON *eff_messages = reduce_active ? agent_reduce_result.messages : messages;
 
       /* Build request (use fb_agent which may have fallback model after turn 0) */
       cJSON *req;
       fold_result_t fold_view; /* §1 rolling fold; freed after req is serialized */
       memset(&fold_view, 0, sizeof(fold_view));
       if (chatgpt)
-         req = agent_build_request_responses(&fb_agent, messages, active_tools, sys);
+         req = agent_build_request_responses(&fb_agent, eff_messages, active_tools, sys);
       else if (anthropic)
       {
          /* Fold first so payload-rewrite tracking and the request both observe the
-          * actually-sent (possibly folded) message array. */
-         build_fold_view(messages, &agent_fold_freeze, &agent_fold_recall, turn, &fold_view);
-         cJSON *anth_msgs = fold_view.folded ? fold_view.messages : messages;
+          * actually-sent (possibly folded) message array. The economizer's reduced
+          * view takes precedence; otherwise fall back to the Anthropic build_fold_view. */
+         cJSON *anth_msgs = eff_messages;
+         if (!reduce_active)
+         {
+            build_fold_view(messages, &agent_fold_freeze, &agent_fold_recall, turn, &fold_view);
+            if (fold_view.folded)
+               anth_msgs = fold_view.messages;
+         }
          track_anthropic_payload_rewrite(driver, &fb_agent, anth_msgs, sys);
          req = agent_build_request_anthropic(&fb_agent, anth_msgs, active_tools, sys, tok,
                                              temperature);
       }
       else if (gemini)
-         req = agent_build_request_gemini(&fb_agent, messages, active_tools, sys, tok, temperature,
-                                          gemini_cache_name);
+         req = agent_build_request_gemini(&fb_agent, eff_messages, active_tools, sys, tok,
+                                          temperature, gemini_cache_name);
       else
-         req = agent_build_request_openai(&fb_agent, messages, active_tools, tok, temperature);
+         req = agent_build_request_openai(&fb_agent, eff_messages, active_tools, tok, temperature);
 
       /* Universal-gateway P4: run aimee's own outbound call through the same request
        * pipeline the proxy ingresses use, so a config-enabled tool-policing policy
@@ -885,15 +933,17 @@ native_provider_http:
          snprintf(out->error, sizeof(out->error), "gateway request pipeline failed");
          cJSON_Delete(req);
          fold_result_free(&fold_view);
+         context_reduce_result_free(&agent_reduce_result);
          break;
       }
 
       char *body = cJSON_PrintUnformatted(req);
       /* Order matters: req may hold a non-owning reference into fold_view.messages
-       * (agent_build_request_anthropic's AddItemReference fallback), so req must be
-       * deleted before the fold view is freed. */
+       * OR agent_reduce_result.messages (agent_build_request_anthropic's
+       * AddItemReference fallback), so req must be deleted before either is freed. */
       cJSON_Delete(req);
       fold_result_free(&fold_view);
+      context_reduce_result_free(&agent_reduce_result);
       if (!body)
       {
          snprintf(out->error, sizeof(out->error), "failed to build request");

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -44,6 +44,19 @@ static int bash_delegate_cancel_requested(void)
    return (job_id > 0 && db1_agent_job_is_cancelled && db1_agent_job_is_cancelled(job_id)) ||
           (agent_delegation_stop_requested && agent_delegation_stop_requested(NULL, 0));
 }
+/* Single source of truth for the per-result MODEL-VISIBLE tool-output cap.
+ * Reads tool_output_max_bytes from config (mtime-cached) and clamps it via the
+ * header-inline agent_tool_output_cap_clamp(): 0/unset -> the built-in
+ * AGENT_TOOL_OUTPUT_MAX default (32768); any positive value clamps to
+ * (0, AGENT_TOOL_OUTPUT_RAW_MAX]. Callers resolve ONCE per call into a local so
+ * the cap can't change mid-loop. */
+size_t agent_tool_output_cap(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) != 0)
+      return (size_t)AGENT_TOOL_OUTPUT_MAX;
+   return agent_tool_output_cap_clamp(cfg.tool_output_max_bytes);
+}
 static void bash_kill_child_tree(pid_t pid)
 {
    if (pid <= 0)
@@ -1105,7 +1118,8 @@ char *tool_read_file(const char *path, int offset, int limit)
       free(file_data);
       return safe_strdup(err_msg);
    }
-   char *buf = malloc(AGENT_TOOL_OUTPUT_MAX + 1);
+   size_t cap = agent_tool_output_cap();
+   char *buf = malloc(cap + 1);
    if (!buf)
    {
       fclose(f);
@@ -1124,12 +1138,12 @@ char *tool_read_file(const char *path, int offset, int limit)
       if (offset > 0 && line_num <= offset)
          continue;
       size_t len = strlen(line);
-      if (total + len >= AGENT_TOOL_OUTPUT_MAX)
+      if (total + len >= cap)
       {
-         size_t avail = AGENT_TOOL_OUTPUT_MAX - total;
+         size_t avail = cap - total;
          if (avail > 0)
             memcpy(buf + total, line, avail);
-         total = AGENT_TOOL_OUTPUT_MAX;
+         total = cap;
          break;
       }
       memcpy(buf + total, line, len);
@@ -1285,7 +1299,7 @@ char *tool_list_files(const char *path, const char *pattern)
          return safe_strdup("error: glob failed");
    }
 
-   size_t buf_size = AGENT_TOOL_OUTPUT_MAX;
+   size_t buf_size = agent_tool_output_cap();
    char *buf = malloc(buf_size + 1);
    if (!buf)
    {
@@ -1580,7 +1594,7 @@ char *tool_verify(const char *check_type, const char *target, const char *expect
                argv[j] = tokens[j];
             argv[tc] = NULL;
             char *output = NULL;
-            int rc = safe_exec_capture(argv, &output, AGENT_TOOL_OUTPUT_MAX);
+            int rc = safe_exec_capture(argv, &output, agent_tool_output_cap());
             int pass = (rc == 0);
             cJSON_AddBoolToObject(result, "pass", pass);
             cJSON_AddNumberToObject(result, "exit_code", rc);
@@ -1629,7 +1643,7 @@ char *tool_grep(const char *path, const char *pattern, int max_results)
    const char *argv[] = {"grep", "--binary-files=without-match", "-rn", "--exclude-dir=.git", "--exclude-dir=.aimee", "--exclude-dir=build", "--exclude-dir=dist", "--exclude-dir=node_modules", "-m", max_str, "--", pattern, actual_path, NULL};
    // clang-format on
    char *output = NULL;
-   int rc = safe_exec_capture(argv, &output, AGENT_TOOL_OUTPUT_MAX);
+   int rc = safe_exec_capture(argv, &output, agent_tool_output_cap());
 
    if (rc != 0 && rc != 1 && (!output || !output[0]))
    {
@@ -1663,7 +1677,7 @@ char *tool_git_diff(const char *repo_path, const char *ref)
 
    const workspace_provider_t *ws = workspace_provider_active();
    char *output = NULL;
-   int rc = ws->exec(ws, argv, &output, AGENT_TOOL_OUTPUT_MAX);
+   int rc = ws->exec(ws, argv, &output, agent_tool_output_cap());
    if (rc != 0 && (!output || !output[0]))
    {
       free(output);
@@ -1688,7 +1702,7 @@ char *tool_git_status(const char *repo_path)
    const char *argv[] = {"git", "-C", actual_path, "status", "--porcelain", NULL};
    const workspace_provider_t *ws = workspace_provider_active();
    char *output = NULL;
-   int rc = ws->exec(ws, argv, &output, AGENT_TOOL_OUTPUT_MAX);
+   int rc = ws->exec(ws, argv, &output, agent_tool_output_cap());
    if (rc != 0 && (!output || !output[0]))
    {
       free(output);
@@ -1797,7 +1811,7 @@ char *tool_git_log(const char *repo_path, int count)
 
    const char *argv[] = {"git", "-C", actual_path, "log", "--oneline", "-n", count_str, NULL};
    char *output = NULL;
-   int rc = safe_exec_capture(argv, &output, AGENT_TOOL_OUTPUT_MAX);
+   int rc = safe_exec_capture(argv, &output, agent_tool_output_cap());
 
    if (rc != 0 && (!output || !output[0]))
    {

--- a/src/server/agent_logging.c
+++ b/src/server/agent_logging.c
@@ -10,6 +10,7 @@
 #include "db1.h"    /* token_audit + agent_log inserts */
 #include "token_tracker.h"
 #include "request_context.h" /* per-request id / principal / idempotency */
+#include "context_reduce.h"  /* reduce_result_t for the economizer ledger */
 
 #include <pthread.h>
 #include <stdio.h>
@@ -314,6 +315,83 @@ void agent_record_token_audit_kind(const agent_result_t *result, const char *rol
     * inline insert when async is off or the ring is full. */
    if (!async || audit_async_enqueue(&row) != 0)
       (void)db1_token_audit_insert(&row);
+}
+
+/* Record a context-economizer ledger row as usage_kind="avoided" (excluded from
+ * realized spend). FORECAST-only: estimated_cost_usd carries the MODELED saving
+ * (cache-read floor) and is non-zero ONLY when a lever actually reduced the
+ * request; measure-only rows record 0 avoided-$ and keep the opportunity in
+ * metadata. The invoice-quality saving is the realized on/off spend delta,
+ * computed separately from the realized rows. Keyless row (empty idempotency_key)
+ * so the partial idem index never dedups per-turn rows. */
+void agent_record_reduce_ledger(const reduce_result_t *r, const char *model, const char *agent_name,
+                                const char *role)
+{
+   if (!r || r->reason == REDUCE_REASON_NONE)
+      return;
+
+   const request_context_t *rctx = request_context_get();
+   const char *eff_session = (rctx && rctx->session_key[0]) ? rctx->session_key : session_id();
+   const char *deleg_id = delegation_active_id();
+
+   const char *reason;
+   switch (r->reason)
+   {
+   case REDUCE_REASON_REDUCED:
+      reason = "reduced";
+      break;
+   case REDUCE_REASON_MEASURED:
+      reason = "measured";
+      break;
+   case REDUCE_REASON_SKIP_NO_GAIN:
+      reason = "skip_no_gain";
+      break;
+   case REDUCE_REASON_ALREADY:
+      reason = "already";
+      break;
+   default:
+      reason = "none";
+      break;
+   }
+
+   char meta[512];
+   snprintf(meta, sizeof(meta),
+            "{\"kind\":\"economizer_forecast\",\"reason\":\"%s\",\"baseline\":%d,\"reduced\":%d,"
+            "\"removed\":%d,\"foldable\":%d,\"floor\":%.6f,\"ceiling\":%.6f,\"folded_msgs\":%d,"
+            "\"reused_boundary\":%d}",
+            reason, r->baseline_tokens, r->reduced_tokens, r->removed_tokens, r->foldable_tokens,
+            r->est_saved_cost_floor, r->est_saved_cost_ceiling, r->folded_msgs, r->reused_boundary);
+
+   /* avoided-$ counts only an actual reduction's modeled saving (REASON_REDUCED);
+    * measure-only / skipped / already-reduced rows contribute 0 avoided-$. */
+   double avoided_cost = (r->reason == REDUCE_REASON_REDUCED) ? r->est_saved_cost_floor : 0.0;
+
+   db1_token_audit_row_t row = {
+       .session_id = eff_session,
+       .delegation_id = deleg_id ? deleg_id : "",
+       .project_name = "",
+       .tool_name = agent_name ? agent_name : "",
+       .role = role ? role : "",
+       .model = model ? model : "",
+       .source = "economizer",
+       .requested_model = "",
+       .stop_reason = "",
+       .usage_kind = "avoided",
+       .agent_log_id = g_agent_log_id,
+       .request_id = rctx ? rctx->request_id : "",
+       .idempotency_key = "",
+       .attempt = 0,
+       .principal = rctx ? rctx->principal : "",
+       .served_model = model ? model : "",
+       .duration_ms = 0,
+       .metadata = meta,
+       .prompt_tokens = r->removed_tokens,
+       .completion_tokens = 0,
+       .cache_write_tokens = 0,
+       .cache_read_tokens = 0,
+       .estimated_cost_usd = avoided_cost,
+   };
+   (void)db1_token_audit_insert(&row);
 }
 
 void agent_log_call(const agent_result_t *result, const char *role)

--- a/src/server/agent_policy.c
+++ b/src/server/agent_policy.c
@@ -1078,9 +1078,10 @@ static void compact_cfg_from_app_config(const config_t *app, compact_config_t *o
 }
 
 /* Wrapper around compact_tool_result() using application config.
- * Falls back to the AGENT_TOOL_OUTPUT_MAX hard cap so oversized results
- * are always bounded even if compaction produces a larger-than-expected
- * summary (e.g. malformed JSON that fails parsing).
+ * Falls back to the resolved per-result cap (agent_tool_output_cap_clamp;
+ * default AGENT_TOOL_OUTPUT_MAX) so oversized results are always bounded even
+ * if compaction produces a larger-than-expected summary (e.g. malformed JSON
+ * that fails parsing).
  *
  * tool_name may be NULL to skip per-tool overrides. */
 char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *tool_name)
@@ -1097,6 +1098,10 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
    else
       memset(&cfg, 0, sizeof(cfg)); /* use defaults on load failure */
 
+   /* Per-result model-visible cap (operator-configurable, default 32768).
+    * Resolved ONCE here so the closet budget and the hard cap below agree. */
+   size_t cap = agent_tool_output_cap_clamp(loaded ? app_cfg.tool_output_max_bytes : 0);
+
    char *out = compact_tool_result(raw, raw_len, &cfg, tool_name, 0, 0);
    if (!out)
       return strdup("");
@@ -1112,7 +1117,7 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
    /* Fold §2 — Coordinate Closet: when the result was compacted, conserve the
     * verbatim identifiers from the pre-truncation raw so they survive. Render the
     * closet first (it is byte-bounded), then reserve room for it under the hard
-    * cap so the combined result still never exceeds AGENT_TOOL_OUTPUT_MAX.
+    * cap so the combined result still never exceeds the resolved per-result cap.
     * Default-off; return-only wiring (no cross-turn persistence in P1). */
    char *closet = NULL;
    size_t closet_len = 0;
@@ -1129,8 +1134,10 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
       coord_provenance_t prov = {COORD_LANE_AGENT, -1, -1, -1};
       coord_closet_nominate(raw, raw_len, &prov, &set);
       /* Bound the closet budget so body + closet can never exceed the hard cap:
-       * closet <= AGENT_TOOL_OUTPUT_MAX - min-body, leaving room for the body. */
-      int hard_room = AGENT_TOOL_OUTPUT_MAX - 256;
+       * closet <= cap - min-body, leaving room for the body. */
+      int hard_room = (int)cap - 256;
+      if (hard_room < 0)
+         hard_room = 0; /* tiny operator cap: no room for a closet */
       int cb = app_cfg.coord_closet_budget_bytes;
       if (cb > hard_room)
          cb = hard_room;
@@ -1152,11 +1159,12 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
       coord_set_free(&set);
    }
 
-   /* Hard cap: ensure the result never exceeds AGENT_TOOL_OUTPUT_MAX regardless
-    * of what the compaction summary produced. Reserve closet bytes inside the cap. */
-   size_t body_cap = AGENT_TOOL_OUTPUT_MAX;
-   if (closet_len > 0 && closet_len + 1 < AGENT_TOOL_OUTPUT_MAX)
-      body_cap = AGENT_TOOL_OUTPUT_MAX - closet_len - 1;
+   /* Hard cap: ensure the result never exceeds the resolved per-result cap
+    * regardless of what the compaction summary produced. Reserve closet bytes
+    * inside the cap. */
+   size_t body_cap = cap;
+   if (closet_len > 0 && closet_len + 1 < cap)
+      body_cap = cap - closet_len - 1;
    if (out_len > body_cap)
    {
       out[body_cap] = '\0';

--- a/src/server/agent_policy.c
+++ b/src/server/agent_policy.c
@@ -1077,7 +1077,11 @@ static void compact_cfg_from_app_config(const config_t *app, compact_config_t *o
    }
 }
 
-/* Wrapper around compact_tool_result() using application config.
+/* Eager tool-result seam: shrink via the shared compact_body() core using
+ * application config, conserve identifiers in the Coordinate Closet, and bound
+ * the result to the per-result cap. This is the ONLY writer of compacted bodies
+ * into history; the economizer's lazy lever (context_compress_view) shares the
+ * same compact_body() core but operates on deep copies at request assembly.
  * Falls back to the resolved per-result cap (agent_tool_output_cap_clamp;
  * default AGENT_TOOL_OUTPUT_MAX) so oversized results are always bounded even
  * if compaction produces a larger-than-expected summary (e.g. malformed JSON
@@ -1102,11 +1106,15 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
     * Resolved ONCE here so the closet budget and the hard cap below agree. */
    size_t cap = agent_tool_output_cap_clamp(loaded ? app_cfg.tool_output_max_bytes : 0);
 
-   char *out = compact_tool_result(raw, raw_len, &cfg, tool_name, 0, 0);
+   /* Shrink via the single shared core. Size the buffer for the one strategy that
+    * can exceed raw_len (a JSON structural summary of a tiny body); every other
+    * path is <= raw_len, so this never truncates the shrink. The hard cap below is
+    * applied by THIS caller (per-seam policy), not the core. */
+   size_t out_cap = raw_len + COMPACT_JSON_SUMMARY_MAX + 1;
+   char *out = malloc(out_cap);
    if (!out)
       return strdup("");
-
-   size_t out_len = strlen(out);
+   size_t out_len = compact_body(raw, raw_len, tool_name, &cfg, out, out_cap);
    int compacted = (out_len < raw_len);
 
    /* Log compaction events for diagnostics */

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -16,6 +16,7 @@
 #include "aimee.h" /* size macros for agent_types.h */
 #include "agent_config.h"
 #include "agent_exec.h"
+#include "context_reduce.h"
 #include "agent_protocol.h"
 #include "agent_types.h"
 #include "anthropic_ingress.h"
@@ -226,8 +227,42 @@ static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *dr
    /* P5 (§2.3): opt-in to inject the envelope on the Anthropic-native passthrough.
     * Read config here so gw_stage_memory stays config-free. */
    config_t pcfg;
-   int allow_anthropic_inject =
-       (config_load(&pcfg) == 0 && pcfg.ingress_preinject_anthropic_enabled) ? 1 : 0;
+   int cfg_ok = (config_load(&pcfg) == 0);
+   int allow_anthropic_inject = (cfg_ok && pcfg.ingress_preinject_anthropic_enabled) ? 1 : 0;
+
+   /* Context economizer (gateway seam, SHADOW-MODE ONLY): when reduce.gateway_seam
+    * is on, measure this inbound /v1/messages request's baseline + foldable
+    * opportunity and record a forecast ledger row. measure_only is forced on here so
+    * the request is NEVER mutated — the client transcript is read for the baseline
+    * and the live `req` is forwarded byte-identical (we ignore res.messages, NULL in
+    * measure-only). Done BEFORE the request pipeline so the baseline reflects the
+    * pristine client request, not the memory-injected one. Fully guarded
+    * (config-load, array, free) and context_reduce hard-bypasses on any internal
+    * error, so this can never perturb the client response. Reuses the loaded pcfg;
+    * cheap mtime-cached load keeps it dark by default. */
+   if (cfg_ok && pcfg.reduce_gateway_seam)
+   {
+      cJSON *cmsgs = cJSON_GetObjectItemCaseSensitive(req, "messages");
+      if (cJSON_IsArray(cmsgs))
+      {
+         char *sys_text = anthropic_system_to_text(req); /* flatten string|array system */
+         const cJSON *cmodel = cJSON_GetObjectItemCaseSensitive(req, "model");
+         const char *model = (cmodel && cJSON_IsString(cmodel)) ? cmodel->valuestring : NULL;
+         reduce_config_t rcfg;
+         memset(&rcfg, 0, sizeof(rcfg));
+         rcfg.gateway_seam = 1;
+         rcfg.measure_only = 1; /* shadow mode: this slice never mutates the request */
+         rcfg.fold.retained_msgs = pcfg.fold_retained_msgs;
+         reduce_result_t gw_res;
+         memset(&gw_res, 0, sizeof(gw_res));
+         if (context_reduce(cmsgs, sys_text, model, NULL, REDUCE_SEAM_GATEWAY, &rcfg, NULL,
+                            &gw_res) == 0)
+            agent_record_reduce_ledger(&gw_res, model, "gateway", NULL);
+         context_reduce_result_free(&gw_res);
+         free(sys_text);
+      }
+   }
+
    gw_request_t r = {
        .raw = req,
        .driver = driver,

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -182,7 +182,10 @@ static void translate_request(const cJSON *req, const delegate_driver_t *driver,
    *out_messages =
        anthropic_messages_to_openai(cJSON_GetObjectItemCaseSensitive(req, "messages"),
                                     driver_consumes_system_prompt(driver, ag) ? NULL : *out_system);
-   *out_tools = anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
+   *out_tools = driver && strcmp(driver->name, "chatgpt") == 0
+                    ? anthropic_tools_to_responses(
+                          cJSON_GetObjectItemCaseSensitive(req, "tools"))
+                    : anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
 }
 
 /* ---- Gateway request pipeline (universal-gateway P2a) -------------------------

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -183,8 +183,7 @@ static void translate_request(const cJSON *req, const delegate_driver_t *driver,
        anthropic_messages_to_openai(cJSON_GetObjectItemCaseSensitive(req, "messages"),
                                     driver_consumes_system_prompt(driver, ag) ? NULL : *out_system);
    *out_tools = driver && strcmp(driver->name, "chatgpt") == 0
-                    ? anthropic_tools_to_responses(
-                          cJSON_GetObjectItemCaseSensitive(req, "tools"))
+                    ? anthropic_tools_to_responses(cJSON_GetObjectItemCaseSensitive(req, "tools"))
                     : anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
 }
 

--- a/src/server/anthropic_ingress.c
+++ b/src/server/anthropic_ingress.c
@@ -385,6 +385,41 @@ cJSON *anthropic_tools_to_openai(const cJSON *anthropic_tools)
    return out;
 }
 
+cJSON *anthropic_tools_to_responses(const cJSON *anthropic_tools)
+{
+   cJSON *chat_tools = anthropic_tools_to_openai(anthropic_tools);
+   cJSON *out, *tool;
+   if (!chat_tools)
+      return NULL;
+   out = cJSON_CreateArray();
+   cJSON_ArrayForEach(tool, chat_tools)
+   {
+      cJSON *fn = cJSON_GetObjectItemCaseSensitive(tool, "function");
+      cJSON *flat;
+      if (!cJSON_IsObject(fn))
+         continue;
+      flat = cJSON_CreateObject();
+      cJSON_AddStringToObject(flat, "type", "function");
+      cJSON *name = cJSON_GetObjectItemCaseSensitive(fn, "name");
+      cJSON *desc = cJSON_GetObjectItemCaseSensitive(fn, "description");
+      cJSON *params = cJSON_GetObjectItemCaseSensitive(fn, "parameters");
+      if (cJSON_IsString(name))
+         cJSON_AddStringToObject(flat, "name", name->valuestring);
+      if (cJSON_IsString(desc))
+         cJSON_AddStringToObject(flat, "description", desc->valuestring);
+      if (params)
+         cJSON_AddItemToObject(flat, "parameters", cJSON_Duplicate(params, 1));
+      cJSON_AddItemToArray(out, flat);
+   }
+   cJSON_Delete(chat_tools);
+   if (cJSON_GetArraySize(out) == 0)
+   {
+      cJSON_Delete(out);
+      return NULL;
+   }
+   return out;
+}
+
 cJSON *anthropic_response_from_parsed(const char *resp_id, const char *model,
                                       const parsed_response_t *parsed)
 {

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -28,6 +28,7 @@
 #include "config.h"                 /* config_t, config_load */
 #include "agent_config.h"
 #include "agent_exec.h"
+#include "context_reduce.h"
 #include "agent_protocol.h"  /* parsed_response_t, message_history_repair */
 #include "delegate_driver.h" /* single provider step for the Codex proxy */
 #include "http_retry.h"
@@ -885,6 +886,33 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
    memset(out, 0, sizeof(*out));
    if (!agent || !messages)
       return -1;
+
+   /* Context economizer (gateway seam, SHADOW-MODE ONLY): when reduce.gateway_seam
+    * is on, measure this inbound /v1/responses request's baseline + foldable
+    * opportunity and record a forecast ledger row. measure_only is forced on, so the
+    * client request — the `messages` (input) array + `system_prompt` (instructions)
+    * — is NEVER mutated (we ignore res.messages, NULL in measure-only) and is
+    * forwarded byte-identical. Done at ingress, before the gateway pipeline, so the
+    * baseline reflects the pristine client request. Fully guarded; context_reduce
+    * hard-bypasses on any internal error, so this can never perturb the response.
+    * Cheap mtime-cached config load keeps it dark by default. */
+   {
+      config_t ecfg;
+      if (config_load(&ecfg) == 0 && ecfg.reduce_gateway_seam && cJSON_IsArray(messages))
+      {
+         reduce_config_t rcfg;
+         memset(&rcfg, 0, sizeof(rcfg));
+         rcfg.gateway_seam = 1;
+         rcfg.measure_only = 1; /* shadow mode: this slice never mutates the request */
+         rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
+         reduce_result_t gw_res;
+         memset(&gw_res, 0, sizeof(gw_res));
+         if (context_reduce(messages, system_prompt, agent->model, NULL, REDUCE_SEAM_GATEWAY, &rcfg,
+                            NULL, &gw_res) == 0)
+            agent_record_reduce_ledger(&gw_res, agent->model, "gateway", NULL);
+         context_reduce_result_free(&gw_res);
+      }
+   }
 
    delegate_drivers_init();
    const delegate_driver_t *driver = delegate_driver_get(agent->provider);

--- a/src/server/token_tracker.c
+++ b/src/server/token_tracker.c
@@ -36,15 +36,23 @@ static const model_price_t pricing[] = {
     {"claude-3-sonnet", 3.00, 15.00, 3.75, 0.30},
     {"claude-3-haiku", 0.25, 1.25, 0.30, 0.03},
 
+    /* OpenAI GPT-4o + o-series support automatic prompt caching: cached input
+     * bills at ~0.5x the input rate and cache CREATION is free (no write
+     * premium), so cache_write stays 0 and cache_read = 0.5 x input. 0.5x is the
+     * documented baseline discount; some newer models cache cheaper (0.25x), so
+     * this conservatively UNDER-states the saving. Operator overrides
+     * (models.dev / g_registry_price_fn) refine per-model. gpt-4 classic /
+     * gpt-3.5 do not support prompt caching -> cache tiers stay 0 (they never
+     * report cache_read tokens, so 0 x anything = 0). */
     /* OpenAI GPT-4o family */
-    {"gpt-4o-mini", 0.15, 0.60, 0.0, 0.0},
-    {"gpt-4o", 2.50, 10.00, 0.0, 0.0},
+    {"gpt-4o-mini", 0.15, 0.60, 0.0, 0.075},
+    {"gpt-4o", 2.50, 10.00, 0.0, 1.25},
 
     /* OpenAI o-series */
-    {"o3-mini", 1.10, 4.40, 0.0, 0.0},
-    {"o3", 10.00, 40.00, 0.0, 0.0},
-    {"o1-mini", 1.10, 4.40, 0.0, 0.0},
-    {"o1", 15.00, 60.00, 0.0, 0.0},
+    {"o3-mini", 1.10, 4.40, 0.0, 0.55},
+    {"o3", 10.00, 40.00, 0.0, 5.00},
+    {"o1-mini", 1.10, 4.40, 0.0, 0.55},
+    {"o1", 15.00, 60.00, 0.0, 7.50},
 
     /* OpenAI GPT-4 classic */
     {"gpt-4-turbo", 10.00, 30.00, 0.0, 0.0},

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -17,7 +17,7 @@ TEST_RUN_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/n
 TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o $(OBJDIR)/config_mode.o $(OBJDIR)/config_fields.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                  $(OBJDIR)/platform_random.o $(PLATFORM_BASIC_OBJS) \
                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o \
-                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/fold_register.o $(OBJDIR)/fold_recall.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
+                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/context_reduce.o $(OBJDIR)/fold_register.o $(OBJDIR)/fold_recall.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
                  $(OBJDIR)/json_fluent.o $(OBJDIR)/markdown.o
 # Extended set for tests that need workspace/worktree/guardrails functions (pulls in agents).
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -946,6 +946,9 @@ $(TESTPREFIX)/unit-test-server-memory-benchmark: \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm
 
 $(TESTPREFIX)/unit-test-config: $(OBJDIR)/tests/test_config.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-config-economizer: $(OBJDIR)/tests/test_config_economizer.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-config-surface: $(OBJDIR)/tests/test_config_surface.o $(TEST_CORE_OBJS)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -220,6 +220,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-token-audit-load \
                $(TESTPREFIX)/unit-test-windows \
                $(TESTPREFIX)/unit-test-token-tracker \
+               $(TESTPREFIX)/unit-test-context-reduce \
                $(TESTPREFIX)/unit-test-model-pricing \
                $(TESTPREFIX)/unit-test-provider-client \
                $(TESTPREFIX)/unit-test-kb-curator-provider \
@@ -2046,6 +2047,10 @@ $(TESTPREFIX)/unit-test-session-compact: $(OBJDIR)/tests/test_session_compact.o 
 
 $(TESTPREFIX)/unit-test-token-tracker: $(OBJDIR)/tests/test_token_tracker.o \
                                $(OBJDIR)/server/token_tracker.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-context-reduce: $(OBJDIR)/tests/test_context_reduce.o \
+                               $(OBJDIR)/context_reduce.o $(OBJDIR)/server/token_tracker.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-reasoning-cap: $(OBJDIR)/tests/test_reasoning_cap.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1990,7 +1990,7 @@ $(TESTPREFIX)/unit-test-fold-budget: $(OBJDIR)/tests/test_fold_budget.o $(OBJDIR
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-context-fold: $(OBJDIR)/tests/test_context_fold.o $(OBJDIR)/context_fold.o $(OBJDIR)/fold_register.o \
-                                  $(OBJDIR)/coord_closet.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o \
+                                  $(OBJDIR)/coord_closet.o $(OBJDIR)/compact.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o \
                                   $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -949,6 +949,11 @@ $(TESTPREFIX)/unit-test-config: $(OBJDIR)/tests/test_config.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-config-surface: $(OBJDIR)/tests/test_config_surface.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Configurable tool-output cap: tests the header-inline clamp resolver
+# (agent_tool_output_cap_clamp). No extra objects — the clamp is pure.
+$(TESTPREFIX)/unit-test-tool-output-cap: $(OBJDIR)/tests/test_tool_output_cap.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # Learning detector replay (citation heuristics). Runs the real

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -220,6 +220,38 @@ void agent_record_token_audit_kind(const agent_result_t *result, const char *rol
    (void)source;
    (void)usage_kind;
 }
+/* Context economizer (gateway seam) is default-off and not under test here; the
+ * shadow-mode hook in messages_run_request_pipeline references these three, so stub
+ * them as no-ops to keep the minimal P2c link from pulling the economizer + its
+ * db1/token_tracker dependency chain. */
+#include "../headers/context_reduce.h"
+int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
+                   const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
+                   reduce_state_t *st, reduce_result_t *out)
+{
+   (void)messages;
+   (void)system_prompt;
+   (void)model;
+   (void)session_id;
+   (void)seam;
+   (void)cfg;
+   (void)st;
+   if (out)
+      memset(out, 0, sizeof(*out));
+   return 0;
+}
+void context_reduce_result_free(reduce_result_t *out)
+{
+   (void)out;
+}
+void agent_record_reduce_ledger(const struct reduce_result_s *r, const char *model,
+                                const char *agent_name, const char *role)
+{
+   (void)r;
+   (void)model;
+   (void)agent_name;
+   (void)role;
+}
 /* Enable accounting in this unit so the tap/record path is exercised. */
 int agent_ingress_accounting_enabled(void)
 {

--- a/src/tests/test_anthropic_http_streaming_p2c.c
+++ b/src/tests/test_anthropic_http_streaming_p2c.c
@@ -218,6 +218,38 @@ void agent_record_token_audit_kind(const agent_result_t *result, const char *rol
    (void)source;
    (void)usage_kind;
 }
+/* Context economizer (gateway seam) is default-off and not under test here; the
+ * shadow-mode hook in messages_run_request_pipeline references these three, so stub
+ * them as no-ops to keep the minimal P2c link from pulling the economizer + its
+ * db1/token_tracker dependency chain. */
+#include "../headers/context_reduce.h"
+int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
+                   const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
+                   reduce_state_t *st, reduce_result_t *out)
+{
+   (void)messages;
+   (void)system_prompt;
+   (void)model;
+   (void)session_id;
+   (void)seam;
+   (void)cfg;
+   (void)st;
+   if (out)
+      memset(out, 0, sizeof(*out));
+   return 0;
+}
+void context_reduce_result_free(reduce_result_t *out)
+{
+   (void)out;
+}
+void agent_record_reduce_ledger(const struct reduce_result_s *r, const char *model,
+                                const char *agent_name, const char *role)
+{
+   (void)r;
+   (void)model;
+   (void)agent_name;
+   (void)role;
+}
 int agent_ingress_accounting_enabled(void)
 {
    return 1;

--- a/src/tests/test_anthropic_ingress.c
+++ b/src/tests/test_anthropic_ingress.c
@@ -195,9 +195,27 @@ static void test_tools_empty(void)
 {
    cJSON *t = parse("[]");
    assert(anthropic_tools_to_openai(t) == NULL);
+   assert(anthropic_tools_to_responses(t) == NULL);
    cJSON_Delete(t);
    assert(anthropic_tools_to_openai(NULL) == NULL);
+   assert(anthropic_tools_to_responses(NULL) == NULL);
    PASS("tools_empty");
+}
+
+static void test_tools_responses_mapping(void)
+{
+   cJSON *t = parse("[{\"name\":\"Read\",\"description\":\"Read a file\","
+                    "\"input_schema\":{\"type\":\"object\",\"properties\":{}}}]");
+   cJSON *out = anthropic_tools_to_responses(t);
+   cJSON *tool = cJSON_GetArrayItem(out, 0);
+   assert(strcmp(ostr(tool, "type"), "function") == 0);
+   assert(strcmp(ostr(tool, "name"), "Read") == 0);
+   assert(strcmp(ostr(tool, "description"), "Read a file") == 0);
+   assert(cJSON_IsObject(cJSON_GetObjectItemCaseSensitive(tool, "parameters")));
+   assert(cJSON_GetObjectItemCaseSensitive(tool, "function") == NULL);
+   cJSON_Delete(out);
+   cJSON_Delete(t);
+   PASS("tools_responses_mapping");
 }
 
 /* --------------------------------------------------------------- responses */
@@ -704,6 +722,7 @@ int main(void)
    test_messages_image();
    test_tools_mapping();
    test_tools_empty();
+   test_tools_responses_mapping();
    test_response_text();
    test_response_tool_use();
    test_response_empty_gets_text_block();

--- a/src/tests/test_compact.c
+++ b/src/tests/test_compact.c
@@ -1,4 +1,4 @@
-/* test_compact.c: unit tests for tool-result compaction */
+/* test_compact.c: unit tests for tool-result compaction (the shared compact_body core) */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,12 +18,25 @@ static char *make_str(char c, size_t len)
    return s;
 }
 
+/* Drive the shared core into a heap string so these golden assertions read the
+ * same way the removed compact_tool_result() did. Sized per the compact_body
+ * contract (raw_len + COMPACT_JSON_SUMMARY_MAX) so no strategy is ever truncated. */
+static char *compact_str(const char *raw, size_t raw_len, const compact_config_t *cfg,
+                         const char *tool)
+{
+   size_t cap = raw_len + COMPACT_JSON_SUMMARY_MAX + 1;
+   char *buf = malloc(cap);
+   assert(buf);
+   compact_body(raw, raw_len, tool, cfg, buf, cap);
+   return buf;
+}
+
 /* ------------------------------------------------------------------ pass-through */
 
 static void test_small_passthrough(void)
 {
    const char *input = "hello world";
-   char *out = compact_tool_result(input, strlen(input), NULL, NULL, 0, 0);
+   char *out = compact_str(input, strlen(input), NULL, NULL);
    assert(out);
    assert(strcmp(out, input) == 0);
    free(out);
@@ -34,7 +47,7 @@ static void test_exactly_threshold_passthrough(void)
 {
    /* A string exactly at the default threshold (4096) should pass through */
    char *input = make_str('x', COMPACT_DEFAULT_THRESHOLD);
-   char *out = compact_tool_result(input, COMPACT_DEFAULT_THRESHOLD, NULL, NULL, 0, 0);
+   char *out = compact_str(input, COMPACT_DEFAULT_THRESHOLD, NULL, NULL);
    assert(out);
    assert(strlen(out) == COMPACT_DEFAULT_THRESHOLD);
    assert(memcmp(out, input, COMPACT_DEFAULT_THRESHOLD) == 0);
@@ -53,7 +66,7 @@ static void test_disabled_passthrough(void)
 
    char *big = make_str('z', COMPACT_DEFAULT_THRESHOLD * 2);
    size_t len = (size_t)(COMPACT_DEFAULT_THRESHOLD * 2);
-   char *out = compact_tool_result(big, len, &cfg, NULL, 0, 0);
+   char *out = compact_str(big, len, &cfg, NULL);
    assert(out);
    assert(strlen(out) == len);
    free(out);
@@ -74,7 +87,7 @@ static void test_per_tool_disabled(void)
 
    char *big = make_str('b', COMPACT_DEFAULT_THRESHOLD * 2);
    size_t len = (size_t)(COMPACT_DEFAULT_THRESHOLD * 2);
-   char *out = compact_tool_result(big, len, &cfg, "bash", 0, 0);
+   char *out = compact_str(big, len, &cfg, "bash");
    assert(out);
    assert(strlen(out) == len); /* not compacted */
    free(out);
@@ -95,7 +108,7 @@ static void test_per_tool_threshold_lower(void)
 
    /* 2 KB input: bigger than the 512-byte per-tool threshold */
    char *big = make_str('r', 2048);
-   char *out = compact_tool_result(big, 2048, &cfg, "read_file", 0, 0);
+   char *out = compact_str(big, 2048, &cfg, "read_file");
    assert(out);
    assert(strlen(out) < 2048); /* should have been compacted */
    free(out);
@@ -117,7 +130,7 @@ static void test_plaintext_contains_head_and_tail(void)
    memset(input + total - COMPACT_DEFAULT_TAIL_BYTES, 'T', COMPACT_DEFAULT_TAIL_BYTES);
    input[total] = '\0';
 
-   char *out = compact_tool_result(input, total, NULL, NULL, 0, 0);
+   char *out = compact_str(input, total, NULL, NULL);
    assert(out);
 
    /* Output should start with 'H' and end with 'T' */
@@ -150,7 +163,7 @@ static void test_custom_head_tail(void)
    memset(input + 180, 'Z', 20);
    input[200] = '\0';
 
-   char *out = compact_tool_result(input, 200, &cfg, NULL, 0, 0);
+   char *out = compact_str(input, 200, &cfg, NULL);
    assert(out);
    assert(out[0] == 'A');
    size_t out_len = strlen(out);
@@ -185,7 +198,7 @@ static void test_json_object_summary(void)
    json[prefix_len + pad + 2] = '\0';
    json_len = prefix_len + pad + 2;
 
-   char *out = compact_tool_result(json, json_len, NULL, NULL, 0, 0);
+   char *out = compact_str(json, json_len, NULL, NULL);
    assert(out);
    /* Should contain the compacted JSON summary marker */
    assert(strstr(out, "compacted JSON summary") != NULL || strstr(out, "status") != NULL ||
@@ -212,7 +225,7 @@ static void test_json_array_summary(void)
    json[prefix_len + pad] = ']';
    json[prefix_len + pad + 1] = '\0';
 
-   char *out = compact_tool_result(json, prefix_len + pad + 1, NULL, NULL, 0, 0);
+   char *out = compact_str(json, prefix_len + pad + 1, NULL, NULL);
    assert(out);
    assert(strlen(out) < prefix_len + pad + 1);
 
@@ -221,68 +234,71 @@ static void test_json_array_summary(void)
    PASS("json_array_summary");
 }
 
-/* ------------------------------------------------------------------ dynamic budget */
-
-static void test_dynamic_budget_tightens_threshold(void)
+/* The JSON structural summary is internally bounded to compact_json_summary's fixed
+ * summary[2048] buffer, so it stays < COMPACT_JSON_SUMMARY_MAX. This pins that
+ * invariant (the buffer-sizing formula out_cap = raw_len + COMPACT_JSON_SUMMARY_MAX
+ * + 1 relies on it) against a future compact.c refactor: a JSON object with thousands
+ * of keys would overflow any naive summary, yet must come back bounded and intact. */
+static void test_json_summary_bounded(void)
 {
-   /* With 80% context used, threshold halves.
-    * Create a string that is between the halved threshold and the full threshold. */
-   int base_threshold = COMPACT_DEFAULT_THRESHOLD; /* 4096 */
-   int halved = base_threshold / 2;                /* 2048 */
+   size_t cap_in = 200000;
+   char *json = malloc(cap_in);
+   assert(json);
+   size_t p = 0;
+   p += (size_t)snprintf(json + p, cap_in - p, "{");
+   for (int i = 0; i < 4000 && p < cap_in - 64; i++)
+      p += (size_t)snprintf(json + p, cap_in - p, "%s\"key_%d\":%d", i ? "," : "", i, i);
+   p += (size_t)snprintf(json + p, cap_in - p, "}");
+   size_t jl = p;
 
-   /* Input between halved and full threshold */
-   size_t input_len = (size_t)(halved + 100);
-   char *input = make_str('d', input_len);
-
-   /* With default threshold, this should pass through (input < 4096) */
-   char *out_no_pressure = compact_tool_result(input, input_len, NULL, NULL, 0, 0);
-   assert(out_no_pressure);
-   assert(strlen(out_no_pressure) == input_len); /* pass-through */
-   free(out_no_pressure);
-
-   /* With 80% context usage, threshold halves to 2048 — should now compact */
-   char *out_high_pressure = compact_tool_result(input, input_len, NULL, NULL, 80, 100);
-   assert(out_high_pressure);
-   assert(strlen(out_high_pressure) < input_len); /* compacted */
-   free(out_high_pressure);
-
-   free(input);
-   PASS("dynamic_budget_tightens_threshold");
+   size_t cap = jl + COMPACT_JSON_SUMMARY_MAX + 1; /* the formula both seams use */
+   char *buf = malloc(cap);
+   assert(buf);
+   size_t n = compact_body(json, jl, NULL, NULL, buf, cap);
+   assert(n > 0);
+   assert(n < COMPACT_JSON_SUMMARY_MAX); /* summary never exceeds the documented bound */
+   assert(buf[n] == '\0');               /* NUL-terminated, not truncated mid-write */
+   assert(strstr(buf, "compacted JSON summary") != NULL); /* JSON-summary path taken */
+   free(buf);
+   free(json);
+   PASS("json_summary_bounded");
 }
 
-static void test_dynamic_budget_moderate(void)
+/* ------------------------------------------------------------------ buffer contract */
+
+/* compact_body writes into a caller buffer and never exceeds out_cap-1. A tight
+ * buffer must still leave a valid NUL-terminated (truncated) result, never a
+ * write past the end. */
+static void test_buffer_cap_respected(void)
 {
-   /* With 60% context, threshold drops to 3/4 of 4096 = 3072 */
-   int base = COMPACT_DEFAULT_THRESHOLD; /* 4096 */
-   int reduced = base * 3 / 4;           /* 3072 */
-
-   /* Input between reduced and full threshold */
-   size_t input_len = (size_t)(reduced + 100); /* 3172 */
-   char *input = make_str('e', input_len);
-
-   char *out_no_pressure = compact_tool_result(input, input_len, NULL, NULL, 0, 0);
-   assert(out_no_pressure);
-   assert(strlen(out_no_pressure) == input_len); /* pass-through below 4096 */
-   free(out_no_pressure);
-
-   char *out_60pct = compact_tool_result(input, input_len, NULL, NULL, 60, 100);
-   assert(out_60pct);
-   assert(strlen(out_60pct) < input_len); /* compacted */
-   free(out_60pct);
-
+   char *input = make_str('q', COMPACT_DEFAULT_THRESHOLD + 1000);
+   size_t len = (size_t)(COMPACT_DEFAULT_THRESHOLD + 1000);
+   char small[64];
+   size_t n = compact_body(input, len, NULL, NULL, small, sizeof(small));
+   assert(n <= sizeof(small) - 1);
+   assert(small[n] == '\0');
    free(input);
-   PASS("dynamic_budget_moderate");
+   PASS("buffer_cap_respected");
 }
 
-/* ------------------------------------------------------------------ null input */
+/* ------------------------------------------------------------------ null / empty input */
 
 static void test_null_input(void)
 {
-   char *out = compact_tool_result(NULL, 0, NULL, NULL, 0, 0);
-   assert(out);
-   assert(strcmp(out, "") == 0);
-   free(out);
+   char buf[8] = {'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x'};
+   size_t n = compact_body(NULL, 0, NULL, NULL, buf, sizeof(buf));
+   assert(n == 0);
+   assert(buf[0] == '\0');
    PASS("null_input");
+}
+
+static void test_empty_body(void)
+{
+   char buf[8] = {'y'};
+   size_t n = compact_body("", 0, NULL, NULL, buf, sizeof(buf));
+   assert(n == 0);
+   assert(buf[0] == '\0');
+   PASS("empty_body");
 }
 
 /* ------------------------------------------------------------------ main */
@@ -292,6 +308,7 @@ int main(void)
    printf("compact:\n");
 
    test_null_input();
+   test_empty_body();
    test_small_passthrough();
    test_exactly_threshold_passthrough();
    test_disabled_passthrough();
@@ -301,8 +318,8 @@ int main(void)
    test_custom_head_tail();
    test_json_object_summary();
    test_json_array_summary();
-   test_dynamic_budget_tightens_threshold();
-   test_dynamic_budget_moderate();
+   test_json_summary_bounded();
+   test_buffer_cap_respected();
 
    printf("all compact tests passed\n");
    return 0;

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -335,6 +335,11 @@ int main(void)
                "--background-index");
       cfg.lsp_servers[0].extension_count = 1;
       snprintf(cfg.lsp_servers[0].extensions[0], sizeof(cfg.lsp_servers[0].extensions[0]), "c");
+      /* economizer freeze guardrail: default-on bool + default-1 horizon. Flip the
+       * bool OFF and the horizon to a non-default so both must round-trip (regression
+       * class: a default-on save-guard that emits only the non-default state). */
+      cfg.reduce_freeze_guard_enabled = 0;
+      cfg.reduce_freeze_guard_horizon = 3;
       config_save(&cfg);
 
       static config_t cfg2;
@@ -351,6 +356,8 @@ int main(void)
       assert(cfg2.server_api_rate_limit_per_min == 60);
       assert(cfg2.server_api_max_event_streams == 512);
       assert(strcmp(cfg2.server_api_client_transport, "http") == 0);
+      assert(cfg2.reduce_freeze_guard_enabled == 0); /* default-on bool persisted off */
+      assert(cfg2.reduce_freeze_guard_horizon == 3); /* non-default horizon persisted */
       /* regression: remote_writes used to be parsed but never written by config_save,
        * so any save silently reset it to off. */
       assert(cfg2.server_api_remote_writes == SERVER_REMOTE_WRITES_FULL);

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -1,0 +1,125 @@
+/* test_config_economizer.c: defaults + save/load round-trip for the context
+ * economizer (reduce.*) and Coordinate Closet config. Kept separate from
+ * test_config.c, which is at the build-integrity line-count limit. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "aimee.h"
+#include "config_sections.h"
+#include "aimee_home.h"
+#include "platform_path.h"
+#include "platform_test_util.h"
+
+int main(void)
+{
+   printf("config_economizer: ");
+
+   char tmpdir[512];
+   snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-test-econ-cfg-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(tmpdir) != NULL);
+   char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
+   char *old_aimee_home = getenv("AIMEE_HOME") ? strdup(getenv("AIMEE_HOME")) : NULL;
+   char *old_no_cache = getenv("AIMEE_NO_CACHE") ? strdup(getenv("AIMEE_NO_CACHE")) : NULL;
+   platform_setenv("HOME", tmpdir);
+   platform_unsetenv("AIMEE_HOME");
+   platform_setenv("AIMEE_NO_CACHE", "1");
+
+   /* --- defaults: economizer DEFAULT-ON on the delegate seam, gateway OFF --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg); /* missing file -> defaults */
+      assert(cfg.reduce_measure_enabled == 1);
+      assert(cfg.reduce_delegate_seam == 1);
+      assert(cfg.reduce_history_fold == 1);
+      assert(cfg.reduce_compress == 1);
+      assert(cfg.coord_closet_enabled == 1);
+      assert(cfg.reduce_gateway_seam == 0); /* primary path off pending mutation build */
+      assert(cfg.reduce_freeze_guard_enabled == 1);
+      assert(cfg.reduce_freeze_guard_horizon == 1);
+   }
+
+   /* --- bulk opt-out: every default-ON lever + closet flipped OFF must round-trip
+    * (config_save persists only the non-default OFF state) --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      cfg.reduce_measure_enabled = 0;
+      cfg.reduce_delegate_seam = 0;
+      cfg.reduce_history_fold = 0;
+      cfg.reduce_compress = 0;
+      cfg.coord_closet_enabled = 0;
+      cfg.reduce_freeze_guard_enabled = 0;
+      cfg.reduce_freeze_guard_horizon = 3;
+      assert(config_save(&cfg) == 0);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.reduce_measure_enabled == 0);
+      assert(cfg2.reduce_delegate_seam == 0);
+      assert(cfg2.reduce_history_fold == 0);
+      assert(cfg2.reduce_compress == 0);
+      assert(cfg2.coord_closet_enabled == 0);
+      assert(cfg2.reduce_freeze_guard_enabled == 0);
+      assert(cfg2.reduce_freeze_guard_horizon == 3);
+   }
+
+   /* --- partial opt-out + closet tuning: one lever OFF with siblings at default ON,
+    * closet ON but tuned (budget/ratio/denylist) must round-trip byte-equal --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      /* pin siblings ON deterministically (config_load reads the prior block's file) */
+      cfg.reduce_measure_enabled = 1;
+      cfg.reduce_delegate_seam = 1;
+      cfg.reduce_history_fold = 0; /* the single opt-out */
+      cfg.reduce_compress = 1;
+      cfg.reduce_freeze_guard_enabled = 1;
+      cfg.reduce_freeze_guard_horizon = 1;
+      cfg.coord_closet_enabled = 1;
+      cfg.coord_closet_budget_bytes = 4096;
+      cfg.coord_closet_max_ratio_pct = 15;
+      snprintf(cfg.coord_closet_denylist, sizeof(cfg.coord_closet_denylist), "secretword");
+      assert(config_save(&cfg) == 0);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.reduce_history_fold == 0);    /* the single opt-out survived */
+      assert(cfg2.reduce_measure_enabled == 1); /* siblings stayed on */
+      assert(cfg2.reduce_delegate_seam == 1);
+      assert(cfg2.reduce_compress == 1);
+      assert(cfg2.coord_closet_enabled == 1); /* closet on while tuned */
+      assert(cfg2.coord_closet_budget_bytes == 4096);
+      assert(cfg2.coord_closet_max_ratio_pct == 15);
+      assert(strcmp(cfg2.coord_closet_denylist, "secretword") == 0);
+   }
+
+   /* restore env */
+   if (old_home)
+   {
+      platform_setenv("HOME", old_home);
+      free(old_home);
+   }
+   if (old_aimee_home)
+   {
+      platform_setenv("AIMEE_HOME", old_aimee_home);
+      free(old_aimee_home);
+   }
+   else
+      platform_unsetenv("AIMEE_HOME");
+   if (old_no_cache)
+   {
+      platform_setenv("AIMEE_NO_CACHE", old_no_cache);
+      free(old_no_cache);
+   }
+   else
+      platform_unsetenv("AIMEE_NO_CACHE");
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -38,6 +38,7 @@ static const char *FIXTURE_A =
     "true\n"
     "ingress_preinject_assembly_budget: 1\n"
     "code_span_max_lines: 7\n"
+    "tool_output_max_bytes: 4096\n"
     "ingress_max_raw_scans: 3\nembedding_command: ZZA_val\nembedding_model: "
     "ZZA_val\nembedding_endpoint: ZZA_val\nembedding_dim: 1\nmemory_rerank_mode: "
     "ZZA_val\nmemory_rewrite:\n  enabled: true\n  hyde: true\n  decompose: true\n  max_subqueries: "
@@ -93,6 +94,7 @@ static const char *FIXTURE_B =
     "false\n"
     "ingress_preinject_assembly_budget: 4096\n"
     "code_span_max_lines: 4096\n"
+    "tool_output_max_bytes: 8192\n"
     "ingress_max_raw_scans: 4096\nembedding_command: ZZB_val\nembedding_model: "
     "ZZB_val\nembedding_endpoint: ZZB_val\nembedding_dim: 4096\nmemory_rerank_mode: "
     "ZZB_val\nmemory_rewrite:\n  enabled: false\n  hyde: false\n  decompose: false\n  "
@@ -178,6 +180,7 @@ int main(void)
    assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);
    assert(cfgA.code_span_max_lines != cfgB.code_span_max_lines);
+   assert(cfgA.tool_output_max_bytes != cfgB.tool_output_max_bytes);
    assert(cfgA.ingress_max_raw_scans != cfgB.ingress_max_raw_scans);
    assert(strcmp(cfgA.embedding_command, cfgB.embedding_command) != 0);
    assert(strcmp(cfgA.embedding_model, cfgB.embedding_model) != 0);
@@ -328,6 +331,6 @@ int main(void)
    assert(cfgA.ensemble_min_successful != cfgB.ensemble_min_successful);
    assert(cfgA.ensemble_max_cost_usd != cfgB.ensemble_max_cost_usd);
 
-   printf("all tests passed (145 parsed fields)\n");
+   printf("all tests passed (146 parsed fields)\n");
    return 0;
 }

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -373,6 +373,136 @@ static void test_register_annotation(void)
    PASS("register_annotation");
 }
 
+/* --- Cross-provider skeleton/no-split conformance (Slice 2b) --- */
+
+/* OpenAI assistant turn: a string `content` AND a separate top-level `tool_calls`
+ * array whose function.arguments is a JSON STRING. */
+static void add_openai_assistant_tool_call(cJSON *msgs, const char *call_id, const char *name,
+                                           const char *arguments_json)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "assistant");
+   cJSON_AddStringToObject(m, "content", "calling a tool now");
+   cJSON *tcs = cJSON_AddArrayToObject(m, "tool_calls");
+   cJSON *tc = cJSON_CreateObject();
+   cJSON_AddStringToObject(tc, "id", call_id);
+   cJSON_AddStringToObject(tc, "type", "function");
+   cJSON *fn = cJSON_AddObjectToObject(tc, "function");
+   cJSON_AddStringToObject(fn, "name", name);
+   cJSON_AddStringToObject(fn, "arguments", arguments_json); /* a STRING in OpenAI */
+   cJSON_AddItemToArray(tcs, tc);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+/* OpenAI tool result: a separate role:"tool" message (never a role:"user"). */
+static void add_openai_tool_result(cJSON *msgs, const char *call_id, const char *result)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "tool");
+   cJSON_AddStringToObject(m, "tool_call_id", call_id);
+   cJSON_AddStringToObject(m, "content", result);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+static void test_openai_shape_fold(void)
+{
+   cJSON *m = cJSON_CreateArray();
+   for (int i = 0; i < 7; i++) /* 7 rounds * 3 msgs = 21 messages */
+   {
+      char u[64], cid[32], args[64], res[64];
+      snprintf(u, sizeof(u), "round %d: please process the next file", i);
+      snprintf(cid, sizeof(cid), "call_%03d", i);
+      snprintf(args, sizeof(args), "{\"path\":\"/work/x/file_%03d.c\"}", i);
+      snprintf(res, sizeof(res), "processed file_%03d ok", i);
+      add_user_text(m, u);
+      add_openai_assistant_tool_call(m, cid, "read", args);
+      add_openai_tool_result(m, cid, res);
+   }
+   /* 21 msgs, retained default 8 -> desired split 13 (an assistant) -> backs down to
+    * the clean user turn at index 12; folds rounds 0..3 (file_000..file_003). */
+   fold_config_t cfg = {.enabled = 1, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &cfg, NULL, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL);
+
+   /* No-split invariant: the retained tail's first real item is a role:"user"
+    * message — no dangling role:"tool" was left at the boundary (an assistant
+    * tool_calls and its role:"tool" result were never separated). */
+   cJSON *tail0 = cJSON_GetArrayItem(r.messages, 2);
+   assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(tail0, "role")), "user") == 0);
+
+   const char *c0 =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
+   /* a path embedded in a folded tool_calls `arguments` is captured by the closet */
+   assert(contains(c0, "/work/x/file_002.c"));
+   /* the openai tool call appears in the skeleton */
+   assert(contains(c0, "$") && contains(c0, "read"));
+
+   /* original array untouched */
+   assert(cJSON_GetArraySize(m) == 21);
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("openai_shape_fold");
+}
+
+/* Responses (chatgpt) top-level function_call item; arguments is a STRING. */
+static void add_responses_function_call(cJSON *msgs, const char *call_id, const char *name,
+                                        const char *arguments_json)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "type", "function_call");
+   cJSON_AddStringToObject(m, "call_id", call_id);
+   cJSON_AddStringToObject(m, "name", name);
+   cJSON_AddStringToObject(m, "arguments", arguments_json);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+/* Responses top-level function_call_output item (mirror of a tool_result). */
+static void add_responses_function_call_output(cJSON *msgs, const char *call_id, const char *output)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "type", "function_call_output");
+   cJSON_AddStringToObject(m, "call_id", call_id);
+   cJSON_AddStringToObject(m, "output", output);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+static void test_responses_shape_fold(void)
+{
+   cJSON *m = cJSON_CreateArray();
+   for (int i = 0; i < 7; i++) /* 21 items */
+   {
+      char u[64], cid[32], args[64], out[64];
+      snprintf(u, sizeof(u), "round %d: handle the next item", i);
+      snprintf(cid, sizeof(cid), "fc_%03d", i);
+      snprintf(args, sizeof(args), "{\"path\":\"/resp/file_%03d.c\"}", i);
+      snprintf(out, sizeof(out), "wrote /resp/out/file_%03d.log", i);
+      add_user_text(m, u);
+      add_responses_function_call(m, cid, "read", args);
+      add_responses_function_call_output(m, cid, out);
+   }
+   fold_config_t cfg = {.enabled = 1, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &cfg, NULL, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL);
+
+   /* retained tail begins with a clean user turn (function_call /
+    * function_call_output items are not role:"user", so none was straddled). */
+   cJSON *tail0 = cJSON_GetArrayItem(r.messages, 2);
+   assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(tail0, "role")), "user") == 0);
+
+   const char *c0 =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
+   assert(contains(c0, "/resp/file_002.c"));       /* from a folded function_call arguments */
+   assert(contains(c0, "/resp/out/file_002.log")); /* from a folded function_call_output output */
+   assert(contains(c0, "$") && contains(c0, "read"));
+
+   assert(cJSON_GetArraySize(m) == 21);
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("responses_shape_fold");
+}
+
 int main(void)
 {
    printf("context_fold tests:\n");
@@ -386,6 +516,8 @@ int main(void)
    test_freeze_boundary_stable();
    test_freeze_prefix_mutation_breaks_reuse();
    test_register_annotation();
+   test_openai_shape_fold();
+   test_responses_shape_fold();
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -503,6 +503,216 @@ static void test_responses_shape_fold(void)
    PASS("responses_shape_fold");
 }
 
+/* ---- Boundary-free tool-result body compression (economizer Slice 4) ----
+ * Reuses add_openai_assistant_tool_call / add_openai_tool_result defined above. */
+
+/* Build a deterministic body well past the 160-byte excerpt threshold, with a
+ * unique path placed at the END so it is amputated from the head excerpt and must
+ * be recovered from the Coordinate Closet. Filler carries no identifiers. */
+static void make_big_body(char *buf, size_t bufsz, const char *path_tail)
+{
+   size_t pos = 0;
+   while (pos + 48 < bufsz - 96)
+      pos += (size_t)snprintf(buf + pos, bufsz - pos, "filler padding output text here and more; ");
+   snprintf(buf + pos, bufsz - pos, "trailing details recorded at %s end", path_tail);
+}
+
+/* (a) Single-user-turn OpenAI tool-loop: old tool-result bodies compress, the
+ *     latest `retained` stay full, every tool_call_id survives, and a path buried
+ *     past the excerpt window is conserved (Coordinate Closet). This is the proof
+ *     that compress engages where fold cannot (no user-turn boundary mid-loop). */
+static void test_compress_openai_tool_loop(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   add_user_text(msgs, "Do the autonomous task."); /* the ONLY user turn */
+   char body[700];
+   char id[32], path[64], args[48];
+   const int pairs = 12;
+   for (int k = 0; k < pairs; k++)
+   {
+      snprintf(id, sizeof(id), "call_%02d", k);
+      snprintf(args, sizeof(args), "{\"n\":%d}", k);
+      add_openai_assistant_tool_call(msgs, id, "read_file", args);
+      snprintf(path, sizeof(path), "/work/src/module_%d.c", k);
+      make_big_body(body, sizeof(body), path);
+      add_openai_tool_result(msgs, id, body);
+   }
+   int orig_count = cJSON_GetArraySize(msgs); /* 1 + 24 = 25 */
+
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 8, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_compress_view(msgs, &cfg, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL);
+   assert(r.folded_msgs > 0);
+
+   /* input untouched: the last tool result is still its full big body */
+   cJSON *last_in = cJSON_GetArrayItem(msgs, orig_count - 1);
+   assert(strlen(cJSON_GetStringValue(cJSON_GetObjectItem(last_in, "content"))) > 200);
+
+   /* output: a synthetic closet note pair was prepended, then every original
+    * message survives in order — no message dropped, every tool_call_id kept. */
+   int out_count = cJSON_GetArraySize(r.messages);
+   assert(out_count == orig_count + 2);
+   int in_tool = 0, out_tool = 0;
+   cJSON *it;
+   cJSON_ArrayForEach(it, msgs)
+   {
+      const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(it, "role"));
+      if (role && strcmp(role, "tool") == 0)
+         in_tool++;
+   }
+   /* an early result (in the eligible prefix) is compressed; the latest is full */
+   int compressed_seen = 0, full_seen = 0;
+   cJSON_ArrayForEach(it, r.messages)
+   {
+      const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(it, "role"));
+      if (!role || strcmp(role, "tool") != 0)
+         continue;
+      out_tool++;
+      const char *id_s = cJSON_GetStringValue(cJSON_GetObjectItem(it, "tool_call_id"));
+      const char *c = cJSON_GetStringValue(cJSON_GetObjectItem(it, "content"));
+      assert(id_s && c);
+      if (contains(c, "bytes elided"))
+         compressed_seen++;
+      else if (strlen(c) > 200)
+         full_seen++;
+   }
+   assert(in_tool == pairs && out_tool == pairs); /* none dropped */
+   assert(compressed_seen >= 1);                  /* old bodies shrank */
+   assert(full_seen >= 1);                        /* the retained tail stayed full */
+   assert(compressed_seen == r.folded_msgs);
+
+   /* every original tool_call_id still present in the output */
+   for (int k = 0; k < pairs; k++)
+   {
+      snprintf(id, sizeof(id), "call_%02d", k);
+      int found = 0;
+      cJSON_ArrayForEach(it, r.messages)
+      {
+         const char *id_s = cJSON_GetStringValue(cJSON_GetObjectItem(it, "tool_call_id"));
+         if (id_s && strcmp(id_s, id) == 0)
+            found = 1;
+      }
+      assert(found);
+   }
+
+   /* a path buried past the excerpt window in a COMPRESSED body survives via the
+    * Coordinate Closet note (it is NOT in the shrunk body's head excerpt). */
+   char *flat = cJSON_PrintUnformatted(r.messages);
+   assert(contains(flat, "/work/src/module_2.c"));
+   /* and the conserving note rode along */
+   const char *note0 =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
+   assert(contains(note0, "Coordinate Closet"));
+   free(flat);
+
+   fold_result_free(&r);
+   cJSON_Delete(msgs);
+   PASS("compress_openai_tool_loop");
+}
+
+/* (b) Anthropic tool_result content-block shape compresses in place. */
+static void test_compress_anthropic_shape(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   add_user_text(msgs, "start");
+   char body[700];
+   char id[32];
+   for (int k = 0; k < 10; k++)
+   {
+      snprintf(id, sizeof(id), "toolu_%02d", k);
+      add_assistant_tool_use(msgs, id, "grep", "pat");
+      char path[64];
+      snprintf(path, sizeof(path), "/repo/pkg/file_%d.go", k);
+      make_big_body(body, sizeof(body), path);
+      add_user_tool_result(msgs, id, body); /* Anthropic block: content string */
+   }
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 6, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_compress_view(msgs, &cfg, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL && r.folded_msgs >= 1);
+
+   /* find a compressed tool_result block in the output */
+   int compressed = 0;
+   cJSON *it;
+   cJSON_ArrayForEach(it, r.messages)
+   {
+      cJSON *content = cJSON_GetObjectItem(it, "content");
+      if (!cJSON_IsArray(content))
+         continue;
+      cJSON *b;
+      cJSON_ArrayForEach(b, content)
+      {
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+         if (t && strcmp(t, "tool_result") == 0)
+         {
+            const char *c = cJSON_GetStringValue(cJSON_GetObjectItem(b, "content"));
+            /* tool_use_id preserved on the block */
+            assert(cJSON_GetObjectItem(b, "tool_use_id") != NULL);
+            if (c && contains(c, "bytes elided"))
+               compressed++;
+         }
+      }
+   }
+   assert(compressed >= 1);
+   char *flat = cJSON_PrintUnformatted(r.messages);
+   assert(contains(flat, "/repo/pkg/file_1.go")); /* conserved in closet */
+   free(flat);
+   fold_result_free(&r);
+   cJSON_Delete(msgs);
+   PASS("compress_anthropic_shape");
+}
+
+/* (c) Determinism: identical input -> byte-identical output. */
+static void test_compress_deterministic(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   add_user_text(msgs, "go");
+   char body[700], id[32], path[64];
+   for (int k = 0; k < 12; k++)
+   {
+      snprintf(id, sizeof(id), "call_%02d", k);
+      add_openai_assistant_tool_call(msgs, id, "ls", "{}");
+      snprintf(path, sizeof(path), "/srv/data/blob_%d.bin", k);
+      make_big_body(body, sizeof(body), path);
+      add_openai_tool_result(msgs, id, body);
+   }
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 8, .closet = {.enabled = 1}};
+   fold_result_t r1, r2;
+   assert(context_compress_view(msgs, &cfg, &r1) == 0 && r1.folded == 1);
+   assert(context_compress_view(msgs, &cfg, &r2) == 0 && r2.folded == 1);
+   char *s1 = cJSON_PrintUnformatted(r1.messages);
+   char *s2 = cJSON_PrintUnformatted(r2.messages);
+   assert(s1 && s2 && strcmp(s1, s2) == 0);
+   free(s1);
+   free(s2);
+   fold_result_free(&r1);
+   fold_result_free(&r2);
+   cJSON_Delete(msgs);
+   PASS("compress_deterministic");
+}
+
+/* (d) No-op when every tool-result body is below the threshold. */
+static void test_compress_below_threshold_noop(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   add_user_text(msgs, "go");
+   char id[32];
+   for (int k = 0; k < 12; k++)
+   {
+      snprintf(id, sizeof(id), "call_%02d", k);
+      add_openai_assistant_tool_call(msgs, id, "ls", "{}");
+      add_openai_tool_result(msgs, id, "ok"); /* tiny body, far below 160 bytes */
+   }
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 8, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_compress_view(msgs, &cfg, &r) == 0);
+   assert(r.folded == 0 && r.messages == NULL); /* caller uses the original */
+   fold_result_free(&r);
+   cJSON_Delete(msgs);
+   PASS("compress_below_threshold_noop");
+}
+
 int main(void)
 {
    printf("context_fold tests:\n");
@@ -518,6 +728,10 @@ int main(void)
    test_register_annotation();
    test_openai_shape_fold();
    test_responses_shape_fold();
+   test_compress_openai_tool_loop();
+   test_compress_anthropic_shape();
+   test_compress_deterministic();
+   test_compress_below_threshold_noop();
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -506,15 +506,20 @@ static void test_responses_shape_fold(void)
 /* ---- Boundary-free tool-result body compression (economizer Slice 4) ----
  * Reuses add_openai_assistant_tool_call / add_openai_tool_result defined above. */
 
-/* Build a deterministic body well past the 160-byte excerpt threshold, with a
- * unique path placed at the END so it is amputated from the head excerpt and must
- * be recovered from the Coordinate Closet. Filler carries no identifiers. */
-static void make_big_body(char *buf, size_t bufsz, const char *path_tail)
+/* Build a deterministic body well past the compaction threshold, with a unique
+ * path placed in the MIDDLE so the shared head+tail compaction amputates it from
+ * BOTH ends and it must be recovered from the Coordinate Closet. Filler carries no
+ * identifiers. (The body must be large enough that head+tail genuinely shrinks it,
+ * since the merged seam uses compact.c's default 512-byte head.) */
+static void make_big_body(char *buf, size_t bufsz, const char *path_mid)
 {
+   size_t half = bufsz / 2;
    size_t pos = 0;
-   while (pos + 48 < bufsz - 96)
+   while (pos + 48 < half)
       pos += (size_t)snprintf(buf + pos, bufsz - pos, "filler padding output text here and more; ");
-   snprintf(buf + pos, bufsz - pos, "trailing details recorded at %s end", path_tail);
+   pos += (size_t)snprintf(buf + pos, bufsz - pos, " unique reference at %s here; ", path_mid);
+   while (pos + 48 < bufsz - 1)
+      pos += (size_t)snprintf(buf + pos, bufsz - pos, "more filler padding output text and on; ");
 }
 
 /* (a) Single-user-turn OpenAI tool-loop: old tool-result bodies compress, the
@@ -525,7 +530,7 @@ static void test_compress_openai_tool_loop(void)
 {
    cJSON *msgs = cJSON_CreateArray();
    add_user_text(msgs, "Do the autonomous task."); /* the ONLY user turn */
-   char body[700];
+   char body[4096];
    char id[32], path[64], args[48];
    const int pairs = 12;
    for (int k = 0; k < pairs; k++)
@@ -572,7 +577,7 @@ static void test_compress_openai_tool_loop(void)
       const char *id_s = cJSON_GetStringValue(cJSON_GetObjectItem(it, "tool_call_id"));
       const char *c = cJSON_GetStringValue(cJSON_GetObjectItem(it, "content"));
       assert(id_s && c);
-      if (contains(c, "bytes elided"))
+      if (contains(c, "omitted"))
          compressed_seen++;
       else if (strlen(c) > 200)
          full_seen++;
@@ -616,7 +621,7 @@ static void test_compress_anthropic_shape(void)
 {
    cJSON *msgs = cJSON_CreateArray();
    add_user_text(msgs, "start");
-   char body[700];
+   char body[4096];
    char id[32];
    for (int k = 0; k < 10; k++)
    {
@@ -649,7 +654,7 @@ static void test_compress_anthropic_shape(void)
             const char *c = cJSON_GetStringValue(cJSON_GetObjectItem(b, "content"));
             /* tool_use_id preserved on the block */
             assert(cJSON_GetObjectItem(b, "tool_use_id") != NULL);
-            if (c && contains(c, "bytes elided"))
+            if (c && contains(c, "omitted"))
                compressed++;
          }
       }
@@ -668,7 +673,7 @@ static void test_compress_deterministic(void)
 {
    cJSON *msgs = cJSON_CreateArray();
    add_user_text(msgs, "go");
-   char body[700], id[32], path[64];
+   char body[4096], id[32], path[64];
    for (int k = 0; k < 12; k++)
    {
       snprintf(id, sizeof(id), "call_%02d", k);

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -121,6 +121,53 @@ static void test_unpriced_model_no_cost(void)
    PASS("unpriced model: token opportunity without a $ forecast");
 }
 
+/* Slice 2b: history_fold on (not measure_only) actually folds the prefix. */
+static void test_history_fold_reduces(void)
+{
+   cJSON *m = make_messages(20); /* 40 messages */
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1; /* measure_only stays 0 -> real reduction */
+   cfg.fold.closet.enabled = 1;
+   reduce_state_t st = {0};
+   reduce_result_t out;
+   int rc = context_reduce(m, "system prompt here", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st,
+                           &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_REDUCED);
+   assert(out.mutated == 1 && out.messages != NULL); /* a NEW folded array */
+   assert(out.messages != m);                        /* not the original */
+   assert(out.folded_msgs > 0 && out.retained_msgs > 0);
+   assert(out.reduced_tokens < out.baseline_tokens); /* genuinely smaller */
+   assert(out.removed_tokens == out.baseline_tokens - out.reduced_tokens);
+   assert(st.reduced == 1); /* provenance stamped */
+   /* cost bracket priced on the realized saving (removed_tokens) */
+   assert(out.est_saved_cost_ceiling >= out.est_saved_cost_floor);
+   /* original array untouched (immutable prefix zone honored) */
+   assert(cJSON_GetArraySize(m) == 40);
+   context_reduce_result_free(&out); /* frees the new array */
+   cJSON_Delete(m);
+   PASS("history_fold reduces: new folded array, original untouched");
+}
+
+/* Net-gain pre-check: foldable below min_gain_tokens -> skip, no mutation. */
+static void test_history_fold_skip_no_gain(void)
+{
+   cJSON *m = make_messages(20);
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1;
+   cfg.min_gain_tokens = 1000000; /* unreachable -> always skip */
+   reduce_result_t out;
+   int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_SKIP_NO_GAIN);
+   assert(out.mutated == 0 && out.messages == NULL); /* original forwarded */
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("history_fold skip_no_gain: below min_gain, no mutation");
+}
+
 int main(void)
 {
    printf("context_reduce: unit tests\n");
@@ -130,6 +177,8 @@ int main(void)
    test_short_history_no_foldable();
    test_provenance_already_reduced();
    test_unpriced_model_no_cost();
+   test_history_fold_reduces();
+   test_history_fold_skip_no_gain();
    printf("All context_reduce tests passed.\n");
    return 0;
 }

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -299,6 +299,9 @@ static void test_compress_engages_where_fold_cannot(void)
       cfg.delegate_seam = 1;
       cfg.compress = 1;
       cfg.fold.closet.enabled = 1;
+      /* small head so the merged head+tail core net-shrinks these modest (~0.6 KB)
+       * tool bodies; also exercises the compact.* knob threading into the lever. */
+      cfg.fold.compact_head_bytes = 40;
       reduce_state_t st = {0};
       reduce_result_t out;
       int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st, &out);

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -231,6 +231,113 @@ static void test_history_fold_skip_no_gain(void)
    PASS("history_fold skip_no_gain: below min_gain, no mutation");
 }
 
+/* Build a single-user-turn OpenAI tool-loop: 1 user msg, then `pairs` of
+ * (assistant tool_calls + role:"tool" result with a big body). There is NO user
+ * turn mid-loop, so context_fold_view can never find a clean boundary — the proof
+ * surface for the boundary-free compress lever. */
+static cJSON *make_tool_loop(int pairs)
+{
+   cJSON *arr = cJSON_CreateArray();
+   cJSON *u = cJSON_CreateObject();
+   cJSON_AddStringToObject(u, "role", "user");
+   cJSON_AddStringToObject(u, "content", "Do the autonomous task.");
+   cJSON_AddItemToArray(arr, u);
+   for (int k = 0; k < pairs; k++)
+   {
+      char id[32];
+      snprintf(id, sizeof(id), "call_%02d", k);
+      cJSON *a = cJSON_CreateObject();
+      cJSON_AddStringToObject(a, "role", "assistant");
+      cJSON *tcs = cJSON_AddArrayToObject(a, "tool_calls");
+      cJSON *tc = cJSON_CreateObject();
+      cJSON_AddStringToObject(tc, "id", id);
+      cJSON_AddStringToObject(tc, "type", "function");
+      cJSON *fn = cJSON_AddObjectToObject(tc, "function");
+      cJSON_AddStringToObject(fn, "name", "read_file");
+      cJSON_AddStringToObject(fn, "arguments", "{}");
+      cJSON_AddItemToArray(tcs, tc);
+      cJSON_AddItemToArray(arr, a);
+
+      cJSON *t = cJSON_CreateObject();
+      cJSON_AddStringToObject(t, "role", "tool");
+      cJSON_AddStringToObject(t, "tool_call_id", id);
+      char body[700];
+      size_t pos = 0;
+      while (pos + 48 < sizeof(body) - 96)
+         pos +=
+             (size_t)snprintf(body + pos, sizeof(body) - pos, "filler output bytes here and on; ");
+      snprintf(body + pos, sizeof(body) - pos, "tail at /work/src/module_%d.c done", k);
+      cJSON_AddStringToObject(t, "content", body);
+      cJSON_AddItemToArray(arr, t);
+   }
+   return arr;
+}
+
+/* Compress engages on a tool-loop where fold cannot: fold-only no-ops (no clean
+ * boundary), but compress mutates and shrinks the old tool-result bodies. */
+static void test_compress_engages_where_fold_cannot(void)
+{
+   /* fold-only: must NOT mutate (no clean user-turn boundary in the loop) */
+   {
+      cJSON *m = make_tool_loop(12);
+      reduce_config_t cfg = {0};
+      cfg.delegate_seam = 1;
+      cfg.history_fold = 1;
+      cfg.fold.closet.enabled = 1;
+      reduce_result_t out;
+      int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+      assert(rc == 0);
+      assert(out.mutated == 0 && out.messages == NULL); /* fold found no boundary */
+      context_reduce_result_free(&out);
+      cJSON_Delete(m);
+   }
+   /* compress-only: mutates, shrinks, preserves every message + tool_call_id */
+   {
+      cJSON *m = make_tool_loop(12);
+      int orig_count = cJSON_GetArraySize(m);
+      reduce_config_t cfg = {0};
+      cfg.delegate_seam = 1;
+      cfg.compress = 1;
+      cfg.fold.closet.enabled = 1;
+      reduce_state_t st = {0};
+      reduce_result_t out;
+      int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st, &out);
+      assert(rc == 0);
+      assert(out.reason == REDUCE_REASON_REDUCED);
+      assert(out.mutated == 1 && out.messages != NULL && out.messages != m);
+      assert(out.folded_msgs > 0);
+      assert(out.reduced_tokens < out.baseline_tokens); /* genuinely smaller */
+      assert(out.removed_tokens == out.baseline_tokens - out.reduced_tokens);
+      assert(st.reduced == 1);
+      assert(cJSON_GetArraySize(m) == orig_count); /* original untouched */
+      /* a buried path is conserved (Coordinate Closet rode along) */
+      char *flat = cJSON_PrintUnformatted(out.messages);
+      assert(flat && strstr(flat, "/work/src/module_2.c"));
+      free(flat);
+      context_reduce_result_free(&out);
+      cJSON_Delete(m);
+   }
+}
+
+/* measure_only must suppress the compress mutation (shadow mode). */
+static void test_compress_measure_only_no_mutation(void)
+{
+   cJSON *m = make_tool_loop(12);
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.compress = 1;
+   cfg.measure_only = 1; /* shadow */
+   cfg.fold.closet.enabled = 1;
+   reduce_result_t out;
+   int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_MEASURED);
+   assert(out.mutated == 0 && out.messages == NULL);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("compress measure_only: shadow, no mutation");
+}
+
 int main(void)
 {
    printf("context_reduce: unit tests\n");
@@ -244,6 +351,8 @@ int main(void)
    test_unpriced_model_no_cost();
    test_history_fold_reduces();
    test_history_fold_skip_no_gain();
+   test_compress_engages_where_fold_cannot();
+   test_compress_measure_only_no_mutation();
    printf("All context_reduce tests passed.\n");
    return 0;
 }

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -1,0 +1,135 @@
+/* test_context_reduce.c: unit tests for the context economizer orchestrator
+ * (Slice 1 — measure-only: baseline + foldable opportunity + cost forecast, no
+ * mutation, hard-bypass contract). */
+#include "context_reduce.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#define PASS(name) printf("  %s: ok\n", name)
+
+/* Build a messages array of `rounds` user/assistant pairs with bulky content so
+ * the foldable prefix is non-trivial. */
+static cJSON *make_messages(int rounds)
+{
+   cJSON *arr = cJSON_CreateArray();
+   for (int i = 0; i < rounds; i++)
+   {
+      cJSON *u = cJSON_CreateObject();
+      cJSON_AddStringToObject(u, "role", "user");
+      cJSON_AddStringToObject(u, "content",
+                              "please read the file and summarize the relevant section in detail");
+      cJSON_AddItemToArray(arr, u);
+      cJSON *a = cJSON_CreateObject();
+      cJSON_AddStringToObject(a, "role", "assistant");
+      cJSON_AddStringToObject(
+          a, "content",
+          "here is a fairly long assistant turn that adds bytes to the transcript so the "
+          "fold-eligible prefix carries real token volume across many turns of the session");
+      cJSON_AddItemToArray(arr, a);
+   }
+   return arr;
+}
+
+static void test_hard_bypass_null_out(void)
+{
+   cJSON *m = make_messages(2);
+   int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, NULL, NULL, NULL);
+   assert(rc == 1); /* NULL out -> non-zero so caller forwards original */
+   cJSON_Delete(m);
+   PASS("hard bypass on NULL out");
+}
+
+static void test_null_messages(void)
+{
+   reduce_result_t out;
+   int rc = context_reduce(NULL, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, NULL, NULL, &out);
+   assert(rc == 0 && out.reason == REDUCE_REASON_NONE && out.messages == NULL);
+   context_reduce_result_free(&out); /* safe on no-op result */
+   PASS("null messages -> no-op");
+}
+
+static void test_measure_only_no_mutation(void)
+{
+   cJSON *m = make_messages(20); /* 40 messages */
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.measure_only = 1;
+   reduce_result_t out;
+   int rc = context_reduce(m, "system prompt here", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg,
+                           NULL, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_MEASURED);
+   assert(out.baseline_tokens > 0);
+   assert(out.reduced_tokens == out.baseline_tokens); /* measure-only: nothing removed */
+   assert(out.removed_tokens == 0);
+   assert(out.mutated == 0 && out.messages == NULL); /* original untouched */
+   /* 40 messages, retained default 8 -> foldable region is the first 32 -> > 0 */
+   assert(out.foldable_tokens > 0);
+   /* gpt-4o is priced -> opportunity bracket populated, ceiling (fresh) >= floor (cache-read) */
+   assert(out.est_saved_cost_ceiling >= out.est_saved_cost_floor);
+   assert(out.est_saved_cost_floor > 0.0);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("measure-only: baseline + foldable opportunity, no mutation");
+}
+
+static void test_short_history_no_foldable(void)
+{
+   cJSON *m = make_messages(2); /* 4 messages, < retained(8) */
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   reduce_result_t out;
+   context_reduce(m, NULL, "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+   assert(out.foldable_tokens == 0);        /* nothing ahead of the retained tail */
+   assert(out.est_saved_cost_floor == 0.0); /* no opportunity -> no forecast */
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("short history -> zero foldable opportunity");
+}
+
+static void test_provenance_already_reduced(void)
+{
+   cJSON *m = make_messages(20);
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   reduce_state_t st = {0};
+   st.reduced = 1; /* a prior seam already reduced this request */
+   reduce_result_t out;
+   context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st, &out);
+   assert(out.reason == REDUCE_REASON_ALREADY);
+   assert(out.baseline_tokens > 0);  /* still re-measured */
+   assert(out.foldable_tokens == 0); /* but no re-accounting of the opportunity */
+   assert(out.mutated == 0);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("provenance: second seam re-measures, does not re-reduce");
+}
+
+static void test_unpriced_model_no_cost(void)
+{
+   cJSON *m = make_messages(20);
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   reduce_result_t out;
+   context_reduce(m, "sys", "some-unknown-model-xyz", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+   assert(out.foldable_tokens > 0);         /* opportunity still measured (token-only) */
+   assert(out.est_saved_cost_floor == 0.0); /* but no $ for an unpriced model */
+   assert(out.est_saved_cost_ceiling == 0.0);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("unpriced model: token opportunity without a $ forecast");
+}
+
+int main(void)
+{
+   printf("context_reduce: unit tests\n");
+   test_hard_bypass_null_out();
+   test_null_messages();
+   test_measure_only_no_mutation();
+   test_short_history_no_foldable();
+   test_provenance_already_reduced();
+   test_unpriced_model_no_cost();
+   printf("All context_reduce tests passed.\n");
+   return 0;
+}

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -2,6 +2,7 @@
  * (Slice 1 — measure-only: baseline + foldable opportunity + cost forecast, no
  * mutation, hard-bypass contract). */
 #include "context_reduce.h"
+#include "token_tracker.h" /* token_usage_t, token_estimate_cost_ex — table-tethered guard test */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -341,9 +342,76 @@ static void test_compress_measure_only_no_mutation(void)
    PASS("compress measure_only: shadow, no mutation");
 }
 
+/* Slice 5 freeze cost guardrail. The guard prices ONE cache-write PREMIUM (over
+ * sending the prefix fresh once) against `horizon` reuses at the cache-read rate.
+ * Key regression: it must NOT disable freeze for real providers — both OpenAI (free
+ * cache writes) and Anthropic (small write premium, large read discount) pay off,
+ * even at the conservative default horizon of 1. The disable branch fires only under
+ * adverse pricing (write premium > horizon x per-reuse saving) that no model aimee
+ * currently prices satisfies. */
+static void test_freeze_guard(void)
+{
+   /* zero prefix -> no churn possible -> always favorable */
+   assert(reduce_freeze_cost_favorable("claude-3-5-sonnet", 0, 1) == 1);
+   /* NULL / empty / unpriced model -> fail-open (preserve prior always-on freeze) */
+   assert(reduce_freeze_cost_favorable(NULL, 100000, 1) == 1);
+   assert(reduce_freeze_cost_favorable("", 100000, 1) == 1);
+   assert(reduce_freeze_cost_favorable("totally-unknown-model-xyz", 100000, 1) == 1);
+   /* OpenAI: cache_write == 0 -> non-positive write premium -> always freeze */
+   assert(reduce_freeze_cost_favorable("gpt-4o", 100000, 1) == 1);
+   /* Anthropic at the default horizon=1: premium 0.75x vs per-reuse saving 2.70x ->
+    * favorable. This is the regression guard against the naive full-write-cost
+    * formula, which would wrongly disable Anthropic freeze here. */
+   assert(reduce_freeze_cost_favorable("claude-3-5-sonnet", 100000, 1) == 1);
+   assert(reduce_freeze_cost_favorable("claude-3-opus", 100000, 1) == 1);
+   /* horizon monotonic + clamp: more reuse never makes a favorable case unfavorable,
+    * and an out-of-range horizon is clamped (no crash, still favorable). */
+   assert(reduce_freeze_cost_favorable("claude-3-5-sonnet", 100000, 9999) == 1);
+   assert(reduce_freeze_cost_favorable("claude-3-5-sonnet", 100000, -5) == 1);
+
+   /* Table-tethered invariant: recompute the Anthropic premium/saving from the LIVE
+    * pricing table (not prose) so a future price change that flips the verdict fails
+    * HERE, not silently. write premium must be positive and a single reuse must cover
+    * it (this is exactly what the naive full-write-cost formula got wrong). */
+   {
+      const char *m = "claude-3-5-sonnet";
+      int n = 100000;
+      token_usage_t w = {0}, in = {0}, rd = {0};
+      w.cache_write_tokens = n;
+      in.input_tokens = n;
+      rd.cache_read_tokens = n;
+      double write_cost = token_estimate_cost_ex(m, &w, NULL);
+      double input_cost = token_estimate_cost_ex(m, &in, NULL);
+      double read_cost = token_estimate_cost_ex(m, &rd, NULL);
+      assert(write_cost > input_cost); /* a real write premium exists */
+      assert((input_cost - read_cost) >= (write_cost - input_cost)); /* 1 reuse covers it */
+   }
+
+   /* Disable branch — unreachable with currently-priced models, exercised here via
+    * the scale-invariant arithmetic core with SYNTHETIC per-tier costs. */
+   /* favorable (Anthropic-like: input 3, write 3.75, read 0.30) at H=1 */
+   assert(reduce_freeze_favorable_rates(3.0, 3.75, 0.30, 1) == 1);
+   /* free write but NO read discount (read == input) -> skip regardless of write
+    * (pins B1: per-reuse saving is checked BEFORE the write premium) */
+   assert(reduce_freeze_favorable_rates(1.0, 0.0, 1.0, 1) == 0);
+   /* free write WITH a read discount -> always favorable */
+   assert(reduce_freeze_favorable_rates(1.0, 0.0, 0.10, 1) == 1);
+   /* adverse: write premium (9) far exceeds per-reuse saving (0.9) at H=1 -> disable */
+   assert(reduce_freeze_favorable_rates(1.0, 10.0, 0.10, 1) == 0);
+   /* same adverse rates, but the horizon clamp (max 5) still cannot cover it -> disable
+    * (break-even needs H=10) */
+   assert(reduce_freeze_favorable_rates(1.0, 10.0, 0.10, 9999) == 0);
+   /* a milder premium that one reuse misses but several cover: premium 2.0, saving
+    * 0.9 -> H=1 disable, H=3 (2.7 >= 2.0) enable */
+   assert(reduce_freeze_favorable_rates(1.0, 3.0, 0.10, 1) == 0);
+   assert(reduce_freeze_favorable_rates(1.0, 3.0, 0.10, 3) == 1);
+   PASS("freeze cost guardrail: fail-open, real providers freeze, synthetic disable branch");
+}
+
 int main(void)
 {
    printf("context_reduce: unit tests\n");
+   test_freeze_guard();
    test_hard_bypass_null_out();
    test_null_messages();
    test_measure_only_no_mutation();

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -4,6 +4,7 @@
 #include "context_reduce.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define PASS(name) printf("  %s: ok\n", name)
@@ -72,6 +73,68 @@ static void test_measure_only_no_mutation(void)
    context_reduce_result_free(&out);
    cJSON_Delete(m);
    PASS("measure-only: baseline + foldable opportunity, no mutation");
+}
+
+/* Slice 3: the GATEWAY seam in shadow-mode (gateway_seam=1, measure_only=1, st=NULL)
+ * — the exact config the inbound /v1 gateway wiring uses. Asserts the baseline is
+ * computed, nothing is mutated, and the original array is byte-stable, so the live
+ * client request is safe to forward unchanged. */
+static void test_gateway_seam_measure_only(void)
+{
+   cJSON *m = make_messages(20); /* 40 messages */
+   int n_before = cJSON_GetArraySize(m);
+   char *before = cJSON_PrintUnformatted(m);
+   reduce_config_t cfg = {0};
+   cfg.gateway_seam = 1;
+   cfg.measure_only = 1; /* shadow mode: never mutate the live request */
+   cfg.fold.retained_msgs = 0;
+   reduce_result_t out;
+   int rc = context_reduce(m, "system prompt here", "claude-sonnet-4-5", "s1", REDUCE_SEAM_GATEWAY,
+                           &cfg, NULL /* st */, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_MEASURED);
+   assert(out.baseline_tokens > 0);
+   assert(out.reduced_tokens == out.baseline_tokens); /* nothing removed */
+   assert(out.removed_tokens == 0);
+   assert(out.mutated == 0 && out.messages == NULL); /* request untouched */
+   assert(out.foldable_tokens > 0);                  /* opportunity still measured */
+   /* original array is byte-identical -> the gateway forwards it unchanged */
+   char *after = cJSON_PrintUnformatted(m);
+   assert(cJSON_GetArraySize(m) == n_before);
+   assert(before && after && strcmp(before, after) == 0);
+   free(before);
+   free(after);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("gateway seam measure-only: baseline computed, request byte-identical");
+}
+
+static void test_gateway_seam_null_system_and_model(void)
+{
+   /* Live-gateway edge (roundtable): anthropic_system_to_text can return NULL and
+    * a request may carry no model — both reach context_reduce as NULL. It must not
+    * crash, must still measure (messages-only baseline, no $ forecast), and must
+    * leave the request byte-identical. */
+   cJSON *m = make_messages(20);
+   char *before = cJSON_PrintUnformatted(m);
+   reduce_config_t cfg = {0};
+   cfg.gateway_seam = 1;
+   cfg.measure_only = 1;
+   reduce_result_t out;
+   int rc = context_reduce(m, NULL /* system */, NULL /* model */, NULL, REDUCE_SEAM_GATEWAY, &cfg,
+                           NULL, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_MEASURED);
+   assert(out.baseline_tokens > 0);         /* messages-only baseline */
+   assert(out.est_saved_cost_floor == 0.0); /* NULL model -> no $ forecast */
+   assert(out.mutated == 0 && out.messages == NULL);
+   char *after = cJSON_PrintUnformatted(m);
+   assert(before && after && strcmp(before, after) == 0);
+   free(before);
+   free(after);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("gateway seam tolerates NULL system + NULL model, request byte-identical");
 }
 
 static void test_short_history_no_foldable(void)
@@ -174,6 +237,8 @@ int main(void)
    test_hard_bypass_null_out();
    test_null_messages();
    test_measure_only_no_mutation();
+   test_gateway_seam_measure_only();
+   test_gateway_seam_null_system_and_model();
    test_short_history_no_foldable();
    test_provenance_already_reduced();
    test_unpriced_model_no_cost();

--- a/src/tests/test_token_tracker.c
+++ b/src/tests/test_token_tracker.c
@@ -43,6 +43,31 @@ static void test_cache_tokens_anthropic(void)
    PASS("cost: cache tokens");
 }
 
+static void test_openai_cache_pricing(void)
+{
+   /* gpt-4o + o-series support automatic prompt caching: cached input bills at
+    * ~0.5x the input rate and cache creation is free (no write premium). This is
+    * the cost-story floor for OpenAI in the unified context economizer. */
+   token_usage_t r = {.cache_read_tokens = 1000000};
+   /* all six cache-eligible families = 0.5x their input rate */
+   assert(near_equal(token_estimate_cost("gpt-4o-2024-11-20", &r), 1.25)); /* 0.5 x 2.50 */
+   assert(near_equal(token_estimate_cost("gpt-4o-mini", &r), 0.075));      /* 0.5 x 0.15 */
+   assert(near_equal(token_estimate_cost("o1", &r), 7.50));                /* 0.5 x 15.00 */
+   assert(near_equal(token_estimate_cost("o1-mini", &r), 0.55));           /* 0.5 x 1.10 */
+   assert(near_equal(token_estimate_cost("o3", &r), 5.00));                /* 0.5 x 10.00 */
+   assert(near_equal(token_estimate_cost("o3-mini", &r), 0.55));           /* 0.5 x 1.10 */
+
+   /* OpenAI cache writes are free (automatic) -> cache_write priced at 0. */
+   token_usage_t w = {.cache_write_tokens = 1000000};
+   assert(near_equal(token_estimate_cost("gpt-4o", &w), 0.0));
+
+   /* The model is PRICED (cost authority owns the cached-token $), not unknown. */
+   int priced = -1;
+   double c = token_estimate_cost_ex("gpt-4o", &r, &priced);
+   assert(priced == 1 && c > 0.0);
+   PASS("cost: openai prompt-cache read priced (0.5x input), writes free");
+}
+
 static void test_openai_model(void)
 {
    /* gpt-4o: $2.50 input, $10.00 output per million */
@@ -332,6 +357,7 @@ int main(void)
 
    test_known_anthropic_model();
    test_cache_tokens_anthropic();
+   test_openai_cache_pricing();
    test_openai_model();
    test_unknown_model();
    test_priced_disambiguation();

--- a/src/tests/test_tool_output_cap.c
+++ b/src/tests/test_tool_output_cap.c
@@ -1,0 +1,67 @@
+/* test_tool_output_cap.c: unit tests for the configurable tool-output cap.
+ *
+ * Exercises agent_tool_output_cap_clamp() — the pure, header-inline clamp half
+ * of agent_tool_output_cap() that maps a configured tool_output_max_bytes value
+ * to an effective per-result MODEL-VISIBLE cap. This is the single source of
+ * truth for the clamp, so testing it pins the resolver semantics with zero
+ * linkage. */
+#include <assert.h>
+#include <stdio.h>
+#include "aimee.h"
+#include "agent_exec.h"
+
+#define PASS(name) printf("  PASS: %s\n", name)
+
+static void test_constants(void)
+{
+   /* Default raised to 32 KB; never exceeds the raw capture safety buffer. */
+   assert(AGENT_TOOL_OUTPUT_MAX == 32 * 1024);
+   assert(AGENT_TOOL_OUTPUT_RAW_MAX == 32 * 1024);
+   PASS("constants");
+}
+
+static void test_unset_is_default(void)
+{
+   /* 0 == unset -> built-in default (32768). */
+   assert(agent_tool_output_cap_clamp(0) == (size_t)AGENT_TOOL_OUTPUT_MAX);
+   assert(agent_tool_output_cap_clamp(0) == 32768);
+   PASS("unset_is_default");
+}
+
+static void test_negative_is_default(void)
+{
+   /* Defensive: a negative value also falls back to the default. */
+   assert(agent_tool_output_cap_clamp(-1) == 32768);
+   assert(agent_tool_output_cap_clamp(-100000) == 32768);
+   PASS("negative_is_default");
+}
+
+static void test_lower_value_honored(void)
+{
+   /* An operator may set the cap LOWER than the default. */
+   assert(agent_tool_output_cap_clamp(4096) == 4096);
+   assert(agent_tool_output_cap_clamp(16384) == 16384);
+   assert(agent_tool_output_cap_clamp(1) == 1);
+   PASS("lower_value_honored");
+}
+
+static void test_clamp_to_raw_max(void)
+{
+   /* A value above the 32 KB raw safety buffer clamps down to it. */
+   assert(agent_tool_output_cap_clamp(32768) == 32768);
+   assert(agent_tool_output_cap_clamp(32769) == 32768);
+   assert(agent_tool_output_cap_clamp(1000000) == (size_t)AGENT_TOOL_OUTPUT_RAW_MAX);
+   PASS("clamp_to_raw_max");
+}
+
+int main(void)
+{
+   printf("test_tool_output_cap:\n");
+   test_constants();
+   test_unset_is_default();
+   test_negative_is_default();
+   test_lower_value_honored();
+   test_clamp_to_raw_max();
+   printf("All tool-output-cap tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
## Promotion

Promote the current tested `testing` branch to `main`.

This includes the Anthropic ↔ OpenAI Responses tool-schema fix from #921:

- Chat Completions providers retain nested function tools
- Codex/OpenAI Responses receives flat function tools
- conversion, lint, roundtable, and CI validation passed on `testing`

After merge, the `main` container image will be deployed to the SmoothNAS gateway.
