### PR TITLE
fix: stream Codex responses through Claude ingress

### DIFF
--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -702,29 +702,42 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                                       agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
                                       jo_num(req, "temperature", 1.0), 1);
 
-   /* P2c streaming: when gateway_prevent_subagents is ON, the streaming
+   /* P2c streaming: when gateway_prevent_subagents is ON, or the primary
+    * speaks the OpenAI Responses API (`chatgpt` / Codex), the streaming
     * path becomes buffered — we fetch the upstream reply to completion,
     * run the police function on the parsed struct (same logic as the
     * buffered /v1/messages path), and replay the policed reply as a
-    * well-formed Anthropic SSE sequence via emit_message_as_sse. Off (the
+    * well-formed Anthropic SSE sequence via emit_message_as_sse. The
+    * chatgpt special-case is necessary because its stream format is
+    * response.output_* / response.completed, not the OpenAI chat chunk
+    * shape that today's incremental translator understands. Off (the
     * default) falls through to today's incremental relay/translator. */
-   if (gateway_prevent_subagents_enabled())
+   if (gateway_prevent_subagents_enabled() || (driver && strcmp(driver->name, "chatgpt") == 0))
    {
       char *buf_resp = NULL;
       int buf_status;
       parsed_response_t parsed;
+      int raw_responses = driver && strcmp(driver->name, "chatgpt") == 0;
       memset(&parsed, 0, sizeof(parsed));
       buf_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &buf_resp,
                                    ag->timeout_ms, extra[0] ? extra : NULL);
       if (buf_status == 200 && buf_resp)
       {
-         cJSON *provider_resp = cJSON_Parse(buf_resp);
-         if (provider_resp)
+         if (raw_responses)
          {
             if (driver && driver->parse_response)
-               driver->parse_response(provider_resp, buf_resp, &parsed);
+               driver->parse_response(NULL, buf_resp, &parsed);
             else
-               agent_parse_response_openai(provider_resp, &parsed);
+            {
+               char err[256];
+               snprintf(err, sizeof(err),
+                        "{\"type\":\"error\",\"error\":{\"type\":\"api_error\","
+                        "\"message\":\"primary provider parser unavailable\"}}");
+               if (emit)
+                  emit(ctx, "error", err);
+               free(buf_resp);
+               goto cleanup;
+            }
             gateway_policy_police_parsed_response(&parsed);
             emit_message_as_sse(&parsed, msg_id, model, emit, ctx);
             /* Cost accounting (mirror the buffered path). */
@@ -747,14 +760,45 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
          }
          else
          {
-            char err[256];
-            snprintf(err, sizeof(err),
-                     "{\"type\":\"error\",\"error\":{\"type\":\"api_error\","
-                     "\"message\":\"primary provider returned an unparseable reply\"}}");
-            if (emit)
-               emit(ctx, "error", err);
+            cJSON *provider_resp = cJSON_Parse(buf_resp);
+            if (provider_resp)
+            {
+               if (driver && driver->parse_response)
+                  driver->parse_response(provider_resp, buf_resp, &parsed);
+               else
+                  agent_parse_response_openai(provider_resp, &parsed);
+               gateway_policy_police_parsed_response(&parsed);
+               emit_message_as_sse(&parsed, msg_id, model, emit, ctx);
+               /* Cost accounting (mirror the buffered path). */
+               if ((parsed.prompt_tokens > 0 || parsed.completion_tokens > 0) &&
+                   agent_ingress_accounting_enabled())
+               {
+                  agent_result_t ar;
+                  memset(&ar, 0, sizeof(ar));
+                  snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
+                  snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
+                  snprintf(ar.requested_model, sizeof(ar.requested_model), "%s",
+                           model ? model : "");
+                  snprintf(ar.stop_reason, sizeof(ar.stop_reason), "%s", parsed.stop_reason);
+                  ar.prompt_tokens = parsed.prompt_tokens;
+                  ar.completion_tokens = parsed.completion_tokens;
+                  ar.cache_write_tokens = parsed.cache_write_tokens;
+                  ar.cache_read_tokens = parsed.cache_read_tokens;
+                  agent_record_token_audit(&ar, "", "anthropic-ingress");
+               }
+               agent_free_parsed_response(&parsed);
+            }
+            else
+            {
+               char err[256];
+               snprintf(err, sizeof(err),
+                        "{\"type\":\"error\",\"error\":{\"type\":\"api_error\","
+                        "\"message\":\"primary provider returned an unparseable reply\"}}");
+               if (emit)
+                  emit(ctx, "error", err);
+            }
+            cJSON_Delete(provider_resp);
          }
-         cJSON_Delete(provider_resp);
       }
       else
       {

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -21,6 +21,8 @@ static char *g_last_body;
 static char *g_last_extra; /* upstream extra-header block from the last post */
 static int g_stream_status = 200;
 static const char *g_stream_payload;
+static const char *g_response_body = NULL;
+static int g_response_status = 200;
 
 static void reset_capture(void)
 {
@@ -30,6 +32,8 @@ static void reset_capture(void)
    g_last_extra = NULL;
    g_stream_status = 200;
    g_stream_payload = NULL;
+   g_response_body = NULL;
+   g_response_status = 200;
 }
 
 int agent_load_config(agent_config_t *cfg)
@@ -127,8 +131,8 @@ int agent_http_post(const char *url, const char *auth_header, const char *body, 
    assert(g_last_body != NULL);
    free(g_last_extra);
    g_last_extra = strdup(extra_headers ? extra_headers : "");
-   *response_buf = strdup("{}");
-   return 200;
+   *response_buf = strdup(g_response_body ? g_response_body : "{}");
+   return g_response_status;
 }
 
 int agent_http_post_stream(const char *url, const char *auth_header, const char *body,
@@ -151,6 +155,52 @@ void agent_parse_response_openai(cJSON *root, parsed_response_t *out)
 {
    (void)root;
    memset(out, 0, sizeof(*out));
+}
+
+static void parsed_responses(cJSON *root, const char *body, parsed_response_t *out)
+{
+   const char *p;
+   char text[512];
+
+   (void)root;
+   memset(out, 0, sizeof(*out));
+   if (!body)
+      return;
+
+   p = strstr(body, "event: response.output_text.delta");
+   if (p)
+   {
+      p = strstr(p, "\"delta\":\"");
+      if (p)
+      {
+         const char *start = p + strlen("\"delta\":\"");
+         const char *end = strchr(start, '"');
+         size_t n = end && end > start ? (size_t)(end - start) : 0;
+         if (n >= sizeof(text))
+            n = sizeof(text) - 1;
+         if (n > 0)
+         {
+            memcpy(text, start, n);
+            text[n] = '\0';
+            out->content = strdup(text);
+         }
+      }
+   }
+
+   p = strstr(body, "event: response.completed");
+   if (p)
+   {
+      const char *usage = strstr(p, "\"usage\":{");
+      if (usage)
+      {
+         const char *it = strstr(usage, "\"input_tokens\":");
+         const char *ot = strstr(usage, "\"output_tokens\":");
+         if (it)
+            out->prompt_tokens = atoi(it + strlen("\"input_tokens\":"));
+         if (ot)
+            out->completion_tokens = atoi(ot + strlen("\"output_tokens\":"));
+      }
+   }
 }
 
 void agent_free_parsed_response(parsed_response_t *p)
@@ -735,6 +785,44 @@ static void test_messages_stream_openai_family_translates(void)
    PASS("messages_stream_openai_family_translates");
 }
 
+static void test_messages_stream_chatgpt_buffered_replays_responses(void)
+{
+   const delegate_driver_t chatgpt = {.name = "chatgpt",
+                                      .build_request = system_prompt_driver_build,
+                                      .parse_response = parsed_responses,
+                                      .get_caps = system_prompt_driver_caps};
+   emit_capture_t cap;
+   cJSON *sent;
+
+   reset_capture();
+   memset(&cap, 0, sizeof(cap));
+   g_driver = &chatgpt;
+   g_response_body =
+       "event: response.output_text.delta\n"
+       "data: {\"delta\":\"hello from codex\"}\n\n"
+       "event: response.completed\n"
+       "data: {\"response\":{\"usage\":{\"input_tokens\":12,\"output_tokens\":34}}}\n\n";
+   g_response_status = 200;
+
+   assert(messages_stream("{\"model\":\"ignored\",\"system\":\"SYS\","
+                          "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],"
+                          "\"stream\":true}",
+                          cap_emit, &cap) == 0);
+   sent = parse(g_last_body);
+   assert(strcmp(obj(sent, "driver")->valuestring, "chatgpt") == 0);
+   assert(strcmp(obj(sent, "instructions")->valuestring, "SYS") == 0);
+   assert(cJSON_IsTrue(obj(sent, "stream")));
+   assert(cap.count >= 4);
+   assert(strcmp(cap.events[0], "message_start") == 0);
+   assert(strcmp(cap.events[1], "content_block_start") == 0);
+   assert(strcmp(cap.events[2], "content_block_delta") == 0);
+   assert(strcmp(cap.events[3], "content_block_stop") == 0);
+   assert(strstr(cap.data[2], "hello from codex") != NULL);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_stream_chatgpt_buffered_replays_responses");
+}
+
 /* The pre-injection envelope is folded into the request `system` as a trailing
  * text block (array form), so a cached system prefix stays stable and both the
  * passthrough and translated paths inherit it. */
@@ -772,6 +860,7 @@ int main(void)
    test_messages_buffered_system_prompt_driver_no_duplicate_system();
    test_messages_buffered_system_prompt_capability_no_duplicate_system();
    test_messages_stream_openai_family_translates();
+   test_messages_stream_chatgpt_buffered_replays_responses();
    printf("anthropic_http: OK\n");
    return 0;
 }


### PR DESCRIPTION
Fix the Anthropic /v1/messages ingress so a `chatgpt`/Codex primary no longer hangs without a response.

What changed:
- Special-case `chatgpt` primaries in the streaming Claude ingress and buffer/replay their Responses API output as Anthropic SSE.
- Add a regression test that feeds a Responses SSE payload through the Claude ingress and verifies the Anthropic event sequence is emitted.

Verification:
- `make -j2 build/obj/tests/unit-test-anthropic-http`
- `./build/obj/tests/unit-test-anthropic-http`