### PR TITLE
fix: broaden Codex ingress replay

### DIFF
--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -653,14 +653,31 @@ static void responses_handle_sse_event(const char *event, const char *data, pars
    else if (strcmp(event, "response.output_text.delta") == 0)
    {
       cJSON *delta = cJSON_GetObjectItem(ev, "delta");
+      const char *text = NULL;
       if (cJSON_IsString(delta))
-         (void)append_text(delta_text, delta->valuestring);
+         text = delta->valuestring;
+      else if (cJSON_IsObject(delta))
+      {
+         cJSON *v;
+         if ((v = cJSON_GetObjectItem(delta, "text")) && cJSON_IsString(v))
+            text = v->valuestring;
+         else if ((v = cJSON_GetObjectItem(delta, "value")) && cJSON_IsString(v))
+            text = v->valuestring;
+      }
+      if (text)
+         (void)append_text(delta_text, text);
    }
    else if (strcmp(event, "response.output_text.done") == 0)
    {
       cJSON *text = cJSON_GetObjectItem(ev, "text");
       if (cJSON_IsString(text))
          (void)append_text(done_text, text->valuestring);
+      else if (cJSON_IsObject(text))
+      {
+         cJSON *v = cJSON_GetObjectItem(text, "text");
+         if (cJSON_IsString(v))
+            (void)append_text(done_text, v->valuestring);
+      }
    }
    else if (strcmp(event, "response.content_part.done") == 0)
    {

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -646,6 +646,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    anthropic_stream_xlate_t *xl;
    prov_stream_ctx_t pc;
    int input_est;
+   int responses_wire = 0;
 
    mint_msg_id(msg_id, sizeof(msg_id));
 
@@ -690,6 +691,10 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
       goto cleanup;
+   /* The Responses replay path is keyed off the actual upstream shape, not the
+    * provider label, so Codex aliases that still resolve to /responses stay in
+    * the buffered replay path too. */
+   responses_wire = strstr(url, "/responses") != NULL;
    if (parity)
       build_anthropic_parity_headers(extra, sizeof(extra));
    else
@@ -712,12 +717,12 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
     * response.output_* / response.completed, not the OpenAI chat chunk
     * shape that today's incremental translator understands. Off (the
     * default) falls through to today's incremental relay/translator. */
-   if (gateway_prevent_subagents_enabled() || (driver && strcmp(driver->name, "chatgpt") == 0))
+   if (gateway_prevent_subagents_enabled() || responses_wire)
    {
       char *buf_resp = NULL;
       int buf_status;
       parsed_response_t parsed;
-      int raw_responses = driver && strcmp(driver->name, "chatgpt") == 0;
+      int raw_responses = responses_wire;
       memset(&parsed, 0, sizeof(parsed));
       buf_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &buf_resp,
                                    ag->timeout_ms, extra[0] ? extra : NULL);

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -81,7 +81,10 @@ int delegate_build_url(const delegate_driver_t *driver, const agent_t *agent, ch
 {
    (void)driver;
    (void)agent;
-   snprintf(url, url_len, "https://example.invalid/v1/messages");
+   if (g_driver && g_driver->name && strcmp(g_driver->name, "chatgpt") == 0)
+      snprintf(url, url_len, "https://example.invalid/v1/responses");
+   else
+      snprintf(url, url_len, "https://example.invalid/v1/messages");
    return 0;
 }
 


### PR DESCRIPTION
Fix Claude `/v1/messages` when the configured primary is Codex.

What changed:
- Route the Anthropic streaming ingress through the buffered Responses replay whenever the upstream URL is `/responses`, not only when the driver name is `chatgpt`.
- Accept a couple of Responses SSE payload variants so `response.output_text.delta` / `.done` still parse when the payload nests the text field.
- Update the Anthropic ingress regression fixture so the Codex path exercises `/responses` like production.

Why:
- Claude was getting a spinner/footer but no answer because the streaming path only recognized a narrow driver label, while the actual Codex alias resolves to the Responses API.

Validation:
- `make -j2 build/obj/tests/unit-test-anthropic-http`
- `./build/obj/tests/unit-test-anthropic-http`
