### PR TITLE
sync testing to main

### DIFF
--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -500,7 +500,6 @@ static void parse_responses_output_item(cJSON *item, parsed_response_t *out)
    cJSON *type = cJSON_GetObjectItem(item, "type");
    if (!type || !cJSON_IsString(type))
       return;
-
    if (strcmp(type->valuestring, "function_call") == 0)
    {
       out->is_tool_call = 1;
@@ -628,17 +627,26 @@ static const char *responses_sse_field_value(const char *line, size_t line_len, 
    *value_len = line_len - off;
    return line + off;
 }
+static const char *responses_text_value(cJSON *value)
+{
+   if (cJSON_IsString(value))
+      return value->valuestring;
+   if (!cJSON_IsObject(value))
+      return NULL;
+   cJSON *nested = cJSON_GetObjectItem(value, "text");
+   if (!cJSON_IsString(nested))
+      nested = cJSON_GetObjectItem(value, "value");
+   return cJSON_IsString(nested) ? nested->valuestring : NULL;
+}
 static void responses_handle_sse_event(const char *event, const char *data, parsed_response_t *out,
                                        cJSON *collected_output, char **delta_text, char **done_text,
                                        char **part_text, cJSON **completed_response)
 {
    if (!event || !event[0] || !data || !data[0])
       return;
-
    cJSON *ev = cJSON_Parse(data);
    if (!ev)
       return;
-
    if (strcmp(event, "response.output_item.done") == 0)
    {
       cJSON *item = cJSON_GetObjectItem(ev, "item");
@@ -652,32 +660,15 @@ static void responses_handle_sse_event(const char *event, const char *data, pars
    }
    else if (strcmp(event, "response.output_text.delta") == 0)
    {
-      cJSON *delta = cJSON_GetObjectItem(ev, "delta");
-      const char *text = NULL;
-      if (cJSON_IsString(delta))
-         text = delta->valuestring;
-      else if (cJSON_IsObject(delta))
-      {
-         cJSON *v;
-         if ((v = cJSON_GetObjectItem(delta, "text")) && cJSON_IsString(v))
-            text = v->valuestring;
-         else if ((v = cJSON_GetObjectItem(delta, "value")) && cJSON_IsString(v))
-            text = v->valuestring;
-      }
+      const char *text = responses_text_value(cJSON_GetObjectItem(ev, "delta"));
       if (text)
          (void)append_text(delta_text, text);
    }
    else if (strcmp(event, "response.output_text.done") == 0)
    {
-      cJSON *text = cJSON_GetObjectItem(ev, "text");
-      if (cJSON_IsString(text))
-         (void)append_text(done_text, text->valuestring);
-      else if (cJSON_IsObject(text))
-      {
-         cJSON *v = cJSON_GetObjectItem(text, "text");
-         if (cJSON_IsString(v))
-            (void)append_text(done_text, v->valuestring);
-      }
+      const char *text = responses_text_value(cJSON_GetObjectItem(ev, "text"));
+      if (text)
+         (void)append_text(done_text, text);
    }
    else if (strcmp(event, "response.content_part.done") == 0)
    {
@@ -722,7 +713,6 @@ static void responses_parse_sse_events(const char *body, parsed_response_t *out,
       {
          p = line + line_len;
       }
-
       if (line_len == 0)
       {
          responses_handle_sse_event(event, data, out, collected_output, delta_text, done_text,
@@ -733,7 +723,6 @@ static void responses_parse_sse_events(const char *body, parsed_response_t *out,
             data[0] = '\0';
          continue;
       }
-
       size_t value_len = 0;
       const char *value = responses_sse_field_value(line, line_len, "event", 5, &value_len);
       if (value)
@@ -755,16 +744,13 @@ static void responses_parse_sse_events(const char *body, parsed_response_t *out,
 void agent_parse_response_responses(const char *body, parsed_response_t *out)
 {
    memset(out, 0, sizeof(*out));
-
    if (!body)
       return;
-
    cJSON *collected_output = cJSON_CreateArray();
    char *delta_text = NULL;
    char *done_text = NULL;
    char *part_text = NULL;
    cJSON *completed_resp = NULL;
-
    responses_parse_sse_events(body, out, collected_output, &delta_text, &done_text, &part_text,
                               &completed_resp);
    responses_take_longer_content(out, &part_text);
@@ -779,7 +765,6 @@ void agent_parse_response_responses(const char *body, parsed_response_t *out)
          resp = cJSON_Duplicate(completed_resp, 1);
       else
          resp = cJSON_Parse(body);
-
       if (resp)
       {
          cJSON *output = cJSON_GetObjectItem(resp, "output");
@@ -792,7 +777,6 @@ void agent_parse_response_responses(const char *body, parsed_response_t *out)
          cJSON_Delete(resp);
       }
    }
-
    /* Collect usage from response.completed */
    if (completed_resp)
    {
@@ -814,7 +798,6 @@ void agent_parse_response_responses(const char *body, parsed_response_t *out)
       }
    }
    cJSON_Delete(completed_resp);
-
    /* For multi-turn tool use, store collected output items as assistant_message */
    if (out->is_tool_call)
       out->assistant_message = collected_output;

--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -653,14 +653,31 @@ static void responses_handle_sse_event(const char *event, const char *data, pars
    else if (strcmp(event, "response.output_text.delta") == 0)
    {
       cJSON *delta = cJSON_GetObjectItem(ev, "delta");
+      const char *text = NULL;
       if (cJSON_IsString(delta))
-         (void)append_text(delta_text, delta->valuestring);
+         text = delta->valuestring;
+      else if (cJSON_IsObject(delta))
+      {
+         cJSON *v;
+         if ((v = cJSON_GetObjectItem(delta, "text")) && cJSON_IsString(v))
+            text = v->valuestring;
+         else if ((v = cJSON_GetObjectItem(delta, "value")) && cJSON_IsString(v))
+            text = v->valuestring;
+      }
+      if (text)
+         (void)append_text(delta_text, text);
    }
    else if (strcmp(event, "response.output_text.done") == 0)
    {
       cJSON *text = cJSON_GetObjectItem(ev, "text");
       if (cJSON_IsString(text))
          (void)append_text(done_text, text->valuestring);
+      else if (cJSON_IsObject(text))
+      {
+         cJSON *v = cJSON_GetObjectItem(text, "text");
+         if (cJSON_IsString(v))
+            (void)append_text(done_text, v->valuestring);
+      }
    }
    else if (strcmp(event, "response.content_part.done") == 0)
    {

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -646,6 +646,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    anthropic_stream_xlate_t *xl;
    prov_stream_ctx_t pc;
    int input_est;
+   int responses_wire = 0;
 
    mint_msg_id(msg_id, sizeof(msg_id));
 
@@ -690,6 +691,10 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
       goto cleanup;
+   /* The Responses replay path is keyed off the actual upstream shape, not the
+    * provider label, so Codex aliases that still resolve to /responses stay in
+    * the buffered replay path too. */
+   responses_wire = strstr(url, "/responses") != NULL;
    if (parity)
       build_anthropic_parity_headers(extra, sizeof(extra));
    else
@@ -712,12 +717,12 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
     * response.output_* / response.completed, not the OpenAI chat chunk
     * shape that today's incremental translator understands. Off (the
     * default) falls through to today's incremental relay/translator. */
-   if (gateway_prevent_subagents_enabled() || (driver && strcmp(driver->name, "chatgpt") == 0))
+   if (gateway_prevent_subagents_enabled() || responses_wire)
    {
       char *buf_resp = NULL;
       int buf_status;
       parsed_response_t parsed;
-      int raw_responses = driver && strcmp(driver->name, "chatgpt") == 0;
+      int raw_responses = responses_wire;
       memset(&parsed, 0, sizeof(parsed));
       buf_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &buf_resp,
                                    ag->timeout_ms, extra[0] ? extra : NULL);

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -81,7 +81,10 @@ int delegate_build_url(const delegate_driver_t *driver, const agent_t *agent, ch
 {
    (void)driver;
    (void)agent;
-   snprintf(url, url_len, "https://example.invalid/v1/messages");
+   if (g_driver && g_driver->name && strcmp(g_driver->name, "chatgpt") == 0)
+      snprintf(url, url_len, "https://example.invalid/v1/responses");
+   else
+      snprintf(url, url_len, "https://example.invalid/v1/messages");
    return 0;
 }
 


### PR DESCRIPTION
Promote the Codex ingress replay fix from `testing` to `main`.

This carries forward PR #925, which broadens the Anthropic ingress replay gate to the actual Responses API shape and hardens the Responses parser against payload variants.
