### PR TITLE
feat(llm): split local synth/delegate into dedicated Vulkan tiers

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -86,6 +86,12 @@ jobs:
           # the same vendor-agnostic Vulkan binary runs CPU or GPU via AIMEE_LLM_NGL.
           - { name: aimee-llm-cpu, dockerfile: Dockerfile.aimee-llm }
           - { name: aimee-llm-gpu, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12b-it-GGUF\nSYNTH_FILE=gemma-4-12b-it-Q4_K_M.gguf" }
+          # SPLIT delegate tiers (2026-07-01 roundtable): synth/delegate models in their
+          # OWN image, isolated from embed+rerank. Each GGUF pinned by HF revision +
+          # sha256 (build fails on mismatch). small=Gemma4-12B (Dockerfile defaults);
+          # mid=Qwen3.6-35B-A3B (MoE overrides). Same x64 Vulkan binary; GPU-only at run.
+          - { name: aimee-delegate-small, dockerfile: Dockerfile.aimee-delegate }
+          - { name: aimee-delegate-mid, dockerfile: Dockerfile.aimee-delegate, extra_args: "SYNTH_REPO=unsloth/Qwen3.6-35B-A3B-GGUF\nSYNTH_FILE=Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf\nSYNTH_REVISION=56b9b6695c1d341398ea990cf2172ba4311647d8\nSYNTH_SHA256=707a55a8a4397ecde44de0c499d3e68c1ad1d240d1da65826b4949d1043f4450\nDELEGATE_CTX=262144\nDELEGATE_SLOTS=2\nDELEGATE_MOE=1\nDELEGATE_N_CPU_MOE=24\nDELEGATE_MODEL_ID=qwen3.6-35b-a3b" }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -162,8 +168,8 @@ jobs:
           # layer cache. Same exclusion for aimee-llm-cpu/-gpu: they BAKE multi-GB
           # GGUFs (Qwen3-Embedding + gemma) into the image, so caching those layers
           # would likewise blow the 10 GB GHA budget and evict the C-image caches.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-llm-cpu' && matrix.image.name != 'aimee-llm-gpu' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-llm-cpu' && matrix.image.name != 'aimee-llm-gpu' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-llm-cpu' && matrix.image.name != 'aimee-llm-gpu' && matrix.image.name != 'aimee-delegate-small' && matrix.image.name != 'aimee-delegate-mid' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-llm-cpu' && matrix.image.name != 'aimee-llm-gpu' && matrix.image.name != 'aimee-delegate-small' && matrix.image.name != 'aimee-delegate-mid' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
@@ -207,7 +213,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-llm-cpu, aimee-llm-gpu, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-llm-cpu, aimee-llm-gpu, aimee-delegate-small, aimee-delegate-mid, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/Dockerfile.aimee-delegate
+++ b/Dockerfile.aimee-delegate
@@ -1,0 +1,97 @@
+# aimee-delegate: a single-model OpenAI-compatible synth/delegate server on the
+# VENDOR-AGNOSTIC Vulkan llama.cpp build. Split OUT of the unified aimee-llm
+# (embed+rerank+gateway) per the 2026-07-01 design roundtable so the big delegate
+# model is isolated from the retrieval stack (crash + security + config isolation)
+# and the KB stays byte-portable on the `kb` image.
+#
+# Two published tiers (built via build-args; models baked in, pinned by HF revision
+# + sha256 so a compromised/MITM'd upload fails the BUILD, not production):
+#   aimee-delegate-small (16GB): Gemma 4 12B  qat-UD-Q4_K_XL (dense; 96K, 1 slot)
+#   aimee-delegate-mid   (24-32GB): Qwen 3.6 35B-A3B UD-Q4_K_XL (MoE; 256K=2x128K,
+#                                    static --n-cpu-moe expert-offload)
+#
+# The kb image (aimee-llm) points AIMEE_LLM_SYNTH_URL at this container's :PORT; the
+# gateway already proxies /v1/chat/completions to that upstream, so no gateway change.
+
+ARG LLAMA_TAG=b9775
+
+# Model + supply-chain pins (overridden per tier in CI). Defaults = the small tier.
+ARG SYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF
+ARG SYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf
+ARG SYNTH_REVISION=9586f3257bc62bd179767241c7ec0f66bc2a314a
+ARG SYNTH_SHA256=cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165
+
+# ---- stage 1: fetch + integrity-verify the baked GGUF (fail build on mismatch) ---
+FROM debian:bookworm-slim AS modelprep
+ARG SYNTH_REPO
+ARG SYNTH_FILE
+ARG SYNTH_REVISION
+ARG SYNTH_SHA256
+RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /out
+# Pin by REVISION OID (not just :main) so the bytes can't shift under us, then verify
+# the recorded sha256 -- a compromised HF upload or MITM mirror fails here (panel [9]).
+# --tries/--timeout so a transient HF blip during the 22GB mid-tier pull doesn't
+# deterministically kill the build (panel code-review [6]); -c resumes a partial file.
+RUN wget -q -c --tries=5 --timeout=30 --waitretry=10 -O /out/synth.gguf \
+        "https://huggingface.co/${SYNTH_REPO}/resolve/${SYNTH_REVISION}/${SYNTH_FILE}" \
+    && echo "${SYNTH_SHA256}  /out/synth.gguf" | sha256sum -c - \
+    && echo "${SYNTH_SHA256}  synth.gguf" > /out/synth.sha256
+
+# ---- stage 2: runtime — Vulkan llama.cpp + the delegate entrypoint ---------------
+FROM debian:bookworm-slim AS runtime
+ARG LLAMA_TAG
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl wget libgomp1 libcurl4 libvulkan1 mesa-vulkan-drivers \
+    && rm -rf /var/lib/apt/lists/*
+RUN wget -q --tries=5 --timeout=30 --waitretry=10 -O /tmp/llama.tgz \
+        "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_TAG}/llama-${LLAMA_TAG}-bin-ubuntu-vulkan-x64.tar.gz" \
+    && mkdir -p /opt/llama && tar -xzf /tmp/llama.tgz -C /opt/llama --strip-components=1 \
+    && rm /tmp/llama.tgz
+ENV LD_LIBRARY_PATH=/opt/llama/lib:/opt/llama PATH=/opt/llama:/opt/llama/bin:$PATH
+
+COPY scripts/aimee-delegate-entrypoint.sh /opt/aimee/entrypoint.sh
+COPY scripts/aimee-delegate-health.sh /opt/aimee/health.sh
+RUN chmod +x /opt/aimee/entrypoint.sh /opt/aimee/health.sh
+COPY --from=modelprep /out /models
+
+# Re-declare the pins in the runtime stage so they can be surfaced as image LABELs
+# (operator audit: what's actually baked) and echoed by the entrypoint / health.
+ARG SYNTH_REPO
+ARG SYNTH_FILE
+ARG SYNTH_REVISION
+ARG SYNTH_SHA256
+LABEL org.aimee.delegate.model="${SYNTH_REPO}/${SYNTH_FILE}" \
+      org.aimee.delegate.revision="${SYNTH_REVISION}" \
+      org.aimee.delegate.sha256="${SYNTH_SHA256}"
+
+# ---- tier runtime profile: baked per image via build-args (defaults = small/Gemma;
+#      CI passes mid/Qwen overrides) so each image runs correctly WITHOUT relying on
+#      compose to set MoE/ctx/slots (panel: don't let deploy config carry correctness).
+ARG DELEGATE_CTX=98304
+ARG DELEGATE_SLOTS=1
+ARG DELEGATE_MOE=0
+ARG DELEGATE_MOE_LAYERS=40
+ARG DELEGATE_N_CPU_MOE=0
+ARG DELEGATE_KV_V=q4_0
+ARG DELEGATE_MODEL_ID=aimee-synth
+ENV AIMEE_DELEGATE_PORT=8083 \
+    AIMEE_DELEGATE_CTX=${DELEGATE_CTX} \
+    AIMEE_DELEGATE_SLOTS=${DELEGATE_SLOTS} \
+    AIMEE_DELEGATE_NGL=999 \
+    AIMEE_DELEGATE_KV_K=q8_0 \
+    AIMEE_DELEGATE_KV_V=${DELEGATE_KV_V} \
+    AIMEE_DELEGATE_MOE=${DELEGATE_MOE} \
+    AIMEE_DELEGATE_MOE_LAYERS=${DELEGATE_MOE_LAYERS} \
+    AIMEE_DELEGATE_N_CPU_MOE=${DELEGATE_N_CPU_MOE} \
+    AIMEE_DELEGATE_MODEL_ID=${DELEGATE_MODEL_ID} \
+    AIMEE_DELEGATE_MIN_VRAM_MB=12000
+
+WORKDIR /opt/aimee
+EXPOSE 8083
+# Long start-period: the mid tier cold-loads a 22GB GGUF; a short gate would race the
+# load and cause restart storms that re-read 22GB each time (panel [13]).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=600s --retries=3 \
+    CMD /opt/aimee/health.sh || exit 1
+ENTRYPOINT ["/opt/aimee/entrypoint.sh"]

--- a/deploy/compose/aimee.delegate.yaml
+++ b/deploy/compose/aimee.delegate.yaml
@@ -1,0 +1,59 @@
+# SPLIT delegate overlay (2026-07-01 design roundtable): run the big synth/delegate
+# model in its OWN container, isolated from the embed+rerank+gateway (`aimee-llm`).
+# Layer this ON TOP of the base + GPU overlay:
+#
+#   docker compose -f deploy/compose/aimee.yaml \
+#                  -f deploy/compose/aimee.gpu.yaml \
+#                  -f deploy/compose/aimee.delegate.yaml up -d
+#
+# Wiring: aimee-llm's gateway proxies /v1/chat/completions to AIMEE_LLM_SYNTH_URL, so
+# we point that at aimee-delegate and tell aimee-llm NOT to load a local synth
+# (AIMEE_LLM_SYNTH_LOCAL=0). The kb's curator (LLM_ENDPOINT -> aimee-llm:8742/v1) then
+# flows kb -> aimee-llm gateway -> aimee-delegate transparently. To also expose the
+# delegate to the SERVER's roundtable/delegate router, register it once:
+#   ./aimee agent local delegate-mid http://aimee-delegate:8083/v1 \
+#       --model aimee-synth --roles code,reason,execute --cost-tier 0
+#
+# IMAGE SELECT: default is the mid tier (Qwen 3.6 35B-A3B). For a 16GB card use the
+# small tier (Gemma 4 12B) -- set AIMEE_DELEGATE_IMAGE=ghcr.io/rakuensoftware/aimee-delegate:small
+# and the small-tier ENV baked in the image applies (96K/1-slot/dense); drop the MoE
+# vars below.
+#
+# CO-RESIDENCY: on a SINGLE GPU shared with aimee-llm's embed+rerank (~5.5GB), the
+# static AIMEE_DELEGATE_N_CPU_MOE below must leave room for that stack + KV. On a
+# DEDICATED delegate card, lower it (more experts resident = faster). This is set
+# STATICALLY per deployment by design (no runtime auto-sizer) -- calibrate once with
+# `docs/AIMEE_DELEGATE_TUNING.md`.
+services:
+  aimee-llm:
+    environment:
+      # embed+rerank stay local on the GPU; synth is delegated out.
+      AIMEE_LLM_SYNTH_LOCAL: "0"
+      AIMEE_LLM_SYNTH_URL: ${AIMEE_LLM_SYNTH_URL:-http://aimee-delegate:8083}
+
+  aimee-delegate:
+    restart: unless-stopped
+    image: ${AIMEE_DELEGATE_IMAGE:-ghcr.io/rakuensoftware/aimee-delegate:mid}
+    environment:
+      # mid tier (Qwen 3.6 35B-A3B, MoE). These match the image's baked defaults and
+      # are restated here so an operator sees/tunes them at the deploy site.
+      AIMEE_DELEGATE_PORT: "8083"
+      AIMEE_DELEGATE_CTX: ${AIMEE_DELEGATE_CTX:-262144}      # 256K
+      AIMEE_DELEGATE_SLOTS: ${AIMEE_DELEGATE_SLOTS:-2}       # 2x128K
+      AIMEE_DELEGATE_MOE: "1"
+      AIMEE_DELEGATE_MOE_LAYERS: "40"
+      # STATIC expert-offload. Default sized for a 24GB card SHARED with embed+rerank;
+      # lower toward 0 on a 32GB / dedicated card. Calibrate per docs.
+      AIMEE_DELEGATE_N_CPU_MOE: ${AIMEE_DELEGATE_N_CPU_MOE:-24}
+      AIMEE_DELEGATE_KV_K: q8_0
+      AIMEE_DELEGATE_KV_V: ${AIMEE_DELEGATE_KV_V:-q4_0}      # K8V4; flip to q8_0 if the FA probe warns
+      AIMEE_DELEGATE_MODEL_ID: aimee-synth
+      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+    devices:
+      - "/dev/dri:/dev/dri"
+    healthcheck:
+      test: ["CMD", "/opt/aimee/health.sh"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 600s   # 22GB cold-load; must not race restarts (panel [13])

--- a/docs/AIMEE_DELEGATE_TUNING.md
+++ b/docs/AIMEE_DELEGATE_TUNING.md
@@ -1,0 +1,82 @@
+# Tuning the aimee-delegate tiers
+
+The `aimee-delegate` container runs one synth/delegate model (OpenAI `/v1`) on the
+vendor-agnostic **Vulkan** llama.cpp build, split out of the unified `aimee-llm`
+(embed+rerank+gateway) per the 2026-07-01 design roundtable. Two published tiers:
+
+| Image | Model | Card | Profile (baked defaults) |
+|---|---|---|---|
+| `aimee-delegate:small` | Gemma 4 12B `qat-UD-Q4_K_XL` (6.72 GB, dense) | 16 GB | 96K ctx, 1 slot, K8V4 |
+| `aimee-delegate:mid` | Qwen 3.6 35B-A3B `UD-Q4_K_XL` (22.4 GB, MoE) | 24–32 GB | 256K (2×128K), K8V4, static expert-offload |
+
+Both GGUFs are pinned by **HF revision + sha256** and verified at build time; the
+recorded hash is surfaced as an image `LABEL` (`org.aimee.delegate.sha256`) and echoed
+in the container log for audit.
+
+## The one knob you tune per card: `AIMEE_DELEGATE_N_CPU_MOE` (mid tier only)
+
+Expert offload is **static by design** — there is no runtime VRAM auto-sizer. `N` =
+how many of the 40 MoE layers keep their experts in **system RAM** instead of VRAM.
+Higher `N` → less VRAM, more RAM traffic, slower. Value is clamped to `[0, 40]`.
+
+Rules of thumb (Qwen mid tier, `UD-Q4_K_XL` ≈ 22 GB weights):
+
+| Situation | Suggested `N_CPU_MOE` | Notes |
+|---|---|---|
+| 24 GB card **shared** with `aimee-llm` embed+rerank (~7 GB) | ~24 (default) | leaves room for retrieval stack + KV |
+| 24 GB card **dedicated** to the delegate | ~16 | no retrieval reservation |
+| 32 GB card shared | ~8 | most experts resident |
+| 32 GB card dedicated | 0 | all experts on GPU, fastest |
+
+**Calibrate once:** start with the table value, watch the container log. On success
+you'll see `llama-server ready`. If you see `CRITICAL: allocation failure ... experts
+likely CPU-fell-back`, raise `N` by 4 and redeploy. The healthcheck reports
+**unhealthy** while a startup verification failure is latched, so a mis-sized `N`
+surfaces as a failing container rather than silent slow throughput.
+
+Free system RAM needed ≈ `N/40 × 22 GB` for the offloaded experts (e.g. `N=24` →
+~13 GB). Make sure the host has it free alongside other LXC/containers.
+
+## Flash-attention / KV cache: `AIMEE_DELEGATE_KV_V`
+
+K8V4 (`KV_K=q8_0`, `KV_V=q4_0`) is the default. Quantized **V**-cache requires working
+flash-attention on the Vulkan backend. The entrypoint parses the server startup log
+and, if FA did **not** engage, logs:
+
+```
+CRITICAL: flash-attention did NOT engage ... Set AIMEE_DELEGATE_KV_V=q8_0 (K8V8) and redeploy.
+```
+
+and trips the healthcheck. If you hit that on your RADV/driver combo, set
+`AIMEE_DELEGATE_KV_V=q8_0` (K8V8 — larger KV, no FA dependency) and redeploy.
+
+## Wiring into aimee
+
+Compose (`aimee.delegate.yaml`) points `aimee-llm`'s gateway synth upstream at the
+delegate and disables the kb's local synth:
+
+```
+AIMEE_LLM_SYNTH_LOCAL=0
+AIMEE_LLM_SYNTH_URL=http://aimee-delegate:8083
+```
+
+The kb curator (`LLM_ENDPOINT=http://aimee-llm:8742/v1`) then reaches the delegate
+through the gateway automatically. To also expose it to the server's delegate/round-
+table router, register it once:
+
+```
+./aimee agent local delegate-mid http://aimee-delegate:8083/v1 \
+    --model aimee-synth --roles code,reason,execute --cost-tier 0
+```
+
+## Selecting the small tier
+
+```
+AIMEE_DELEGATE_IMAGE=ghcr.io/rakuensoftware/aimee-delegate:small \
+docker compose -f deploy/compose/aimee.yaml -f deploy/compose/aimee.gpu.yaml \
+               -f deploy/compose/aimee.delegate.yaml up -d
+```
+
+The small image bakes dense/96K/1-slot defaults; drop the MoE env vars (they're
+ignored when `AIMEE_DELEGATE_MOE=0`). The 16 GB tier is **headless-only** — it leaves
+<1 GB free, so don't run it on a card also driving a display.

--- a/scripts/aimee-delegate-entrypoint.sh
+++ b/scripts/aimee-delegate-entrypoint.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# aimee-delegate: a single-model, OpenAI-compatible synth/delegate server (Vulkan
+# llama.cpp), split OUT of the unified aimee-llm (embed+rerank+gateway) per the
+# 2026-07-01 design roundtable. One baked GGUF, one `llama-server`, STATIC expert
+# offload (operator-set per card — no runtime VRAM auto-sizer, by design decision).
+#
+# Two published tiers differ only in the baked model + these ENV defaults:
+#   aimee-delegate-small (16GB): Gemma 4 12B  (dense; 96K, 1 slot)
+#   aimee-delegate-mid   (24-32GB): Qwen 3.6 35B-A3B (MoE; 256K = 2x128K, --n-cpu-moe)
+#
+# The embedder+reranker live on the SEPARATE `kb` image (aimee-llm), which points
+# its AIMEE_LLM_SYNTH_URL at this container. That keeps the KB byte-portable and this
+# tier swappable independently.
+set -u
+
+LLAMA=/opt/llama/llama-server
+MODEL=/models/synth.gguf
+LOG=/tmp/llama-server.log
+DEGRADED=/tmp/aimee-delegate-degraded          # sentinel read by the healthcheck
+
+# ---- tier runtime profile (baked as ENV per image; overridable at deploy) --------
+PORT="${AIMEE_DELEGATE_PORT:-8083}"
+CTX="${AIMEE_DELEGATE_CTX:-131072}"
+SLOTS="${AIMEE_DELEGATE_SLOTS:-1}"
+NGL="${AIMEE_DELEGATE_NGL:-999}"               # 999, not -1: some RADV/ROCm ignore -1
+KV_K="${AIMEE_DELEGATE_KV_K:-q8_0}"
+KV_V="${AIMEE_DELEGATE_KV_V:-q4_0}"            # K8V4 default (K is more quant-sensitive than V)
+IS_MOE="${AIMEE_DELEGATE_MOE:-0}"             # "1" on the Qwen MoE tier
+MOE_LAYERS="${AIMEE_DELEGATE_MOE_LAYERS:-40}" # Qwen 3.6 35B-A3B: MoE in all 40 blocks
+N_CPU_MOE="${AIMEE_DELEGATE_N_CPU_MOE:-0}"    # STATIC expert-offload count (operator-set per card)
+MODEL_ID="${AIMEE_DELEGATE_MODEL_ID:-aimee-synth}"
+MIN_VRAM_MB="${AIMEE_DELEGATE_MIN_VRAM_MB:-12000}"
+JINJA="${AIMEE_DELEGATE_JINJA:-1}"
+
+log(){ echo "aimee-delegate: $*" >&2; }
+rm -f "$DEGRADED"
+
+# ---- supply-chain note: the GGUF sha256 is verified at BUILD time (Dockerfile
+#      fails the build on mismatch). We only surface the recorded, build-verified
+#      hash here for /health + operator audit (panel finding [9]); no 22GB re-hash
+#      on every cold start.
+BAKED_SHA="$( [ -r /models/synth.sha256 ] && cut -d' ' -f1 </models/synth.sha256 || echo unknown )"
+log "model=$MODEL_ID sha256=$BAKED_SHA ctx=$CTX slots=$SLOTS ngl=$NGL kv=${KV_K}/${KV_V} moe=$IS_MOE"
+
+# ---- GPU guard: min-VRAM floor + discrete-GPU pick (panel [8]). Vulkan-only, so
+#      detect via kernel sysfs (no rocm-smi/vulkaninfo binary). Discrete AMD cards
+#      expose mem_info_vram_total; most iGPUs do not -> they're skipped, and an
+#      iGPU-only/APU host fails the floor instead of trying to load a big model into
+#      a 512MB device.
+best_mb=0
+for dev in /sys/class/drm/card*/device; do
+  [ -r "$dev/mem_info_vram_total" ] || continue
+  raw=$(cat "$dev/mem_info_vram_total" 2>/dev/null)
+  case "$raw" in ''|*[!0-9]*) continue;; esac      # skip empty/non-numeric (no arith crash)
+  mb=$(( raw / 1048576 ))
+  [ "$mb" -gt "$best_mb" ] && best_mb=$mb
+done
+if [ "$best_mb" -eq 0 ]; then
+  log "WARN: no discrete GPU VRAM readable via sysfs; proceeding (CPU/other backend or restricted /sys)"
+elif [ "$best_mb" -lt "$MIN_VRAM_MB" ]; then
+  log "FATAL: largest discrete GPU = ${best_mb}MB < floor ${MIN_VRAM_MB}MB; refusing to load $MODEL_ID"
+  exit 4
+else
+  log "GPU VRAM detected: ${best_mb}MB (floor ${MIN_VRAM_MB}MB)"
+fi
+
+# ---- assemble llama-server args --------------------------------------------------
+args=( --host 0.0.0.0 --port "$PORT" -m "$MODEL" --alias "$MODEL_ID"
+       -ngl "$NGL" --ctx-size "$CTX" --parallel "$SLOTS"
+       -fa on --cache-type-k "$KV_K" --cache-type-v "$KV_V" )
+[ "$JINJA" = "1" ] && args+=( --jinja )
+
+# Auth: if a token is set, actually gate /v1 with it. Passing the token to the
+# container but never wiring --api-key would leave /v1 open on the Docker net while
+# operators assume it's protected (panel code-review [3]). llama-server exempts
+# /health from the key, so the readiness/health curls below still work unauthenticated.
+[ -n "${AIMEE_LLM_AUTH_TOKEN:-}" ] && args+=( --api-key "$AIMEE_LLM_AUTH_TOKEN" )
+
+# STATIC MoE expert-offload, defensively clamped to [0, MOE_LAYERS] (panel [4]).
+if [ "$IS_MOE" = "1" ]; then
+  case "$N_CPU_MOE" in ''|*[!0-9]*) log "FATAL: AIMEE_DELEGATE_N_CPU_MOE='$N_CPU_MOE' not a non-negative integer"; exit 5;; esac
+  [ "$N_CPU_MOE" -gt "$MOE_LAYERS" ] && N_CPU_MOE=$MOE_LAYERS
+  args+=( --n-cpu-moe "$N_CPU_MOE" )
+  log "MoE expert-offload: --n-cpu-moe $N_CPU_MOE of $MOE_LAYERS layers on CPU"
+fi
+
+# ---- launch ----------------------------------------------------------------------
+log "starting llama-server: ${args[*]}"
+"$LLAMA" "${args[@]}" >"$LOG" 2>&1 &
+srv=$!
+
+# Graceful shutdown: forward TERM/INT to llama-server and exit 0 so an orchestrator-
+# initiated `docker stop` is NOT recorded as a crash (panel code-review [5]). The EXIT
+# trap is only a best-effort cleanup for other exit paths.
+term() { log "received TERM/INT; stopping llama-server"; kill -TERM "$srv" 2>/dev/null; wait "$srv" 2>/dev/null; exit 0; }
+trap term TERM INT
+trap 'kill "$srv" 2>/dev/null' EXIT
+
+# ---- readiness wait, then post-launch verification (panels [5] + [7]) ------------
+# We do NOT run a separate probe load (a 22GB double-read would worsen cold-start /
+# restart-storm risk, panel [13]). Instead we parse the real server's own startup log
+# once /health is up, and assert that (a) flash-attention actually engaged and (b) the
+# requested KV cache types were honored -- because on Vulkan, FA / quantized-V can
+# silently fall through to a slow dequant path, and llama.cpp can silently CPU-fall-
+# back MoE experts on OOM. A mismatch does NOT auto-relaunch (no 22GB re-read storm);
+# it logs CRITICAL and trips the healthcheck so the operator flips KV/offload envs.
+ready=0
+for _ in $(seq 1 600); do                      # up to ~10min cold load for the 22GB tier
+  if ! kill -0 "$srv" 2>/dev/null; then
+    log "FATAL: llama-server exited during load; tail:"; tail -n 30 "$LOG" >&2; exit 1
+  fi
+  if curl -fsS --max-time 4 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then ready=1; break; fi
+  sleep 1
+done
+[ "$ready" = 1 ] || { log "FATAL: llama-server not ready within deadline"; tail -n 30 "$LOG" >&2; exit 1; }
+log "llama-server ready on :$PORT"
+
+verify_startup() {
+  local bad=0                                     # 0 = healthy (shell success); 1 = degraded
+  # (a) flash-attention engaged?  llama.cpp logs "flash_attn = 1" (or "enabled").
+  if grep -qiE 'flash[_ ]?att.*(= *1|enabled|: *1|on)' "$LOG"; then
+    log "verified: flash-attention ENGAGED"
+  elif grep -qiE 'flash[_ ]?att.*(= *0|disabled|not supported)' "$LOG"; then
+    log "CRITICAL: flash-attention did NOT engage on this backend, but KV V-cache=$KV_V was requested"
+    log "CRITICAL:   -> quantized V-cache without FA hits a slow dequant path. Set AIMEE_DELEGATE_KV_V=q8_0 (K8V8) and redeploy."
+    bad=1
+  else
+    log "WARN: could not determine flash-attention state from server log (continuing)"
+  fi
+  # (b) MoE residency. NOTE: llama.cpp does NOT reliably emit an 'out of memory' string
+  #     for SILENT expert CPU-fallback under VRAM pressure (panel code-review [1]) --
+  #     it just prints per-device buffer sizes. So we (1) still fail on an EXPLICIT
+  #     allocation error if one is logged, and (2) surface the device buffer split for
+  #     the operator to eyeball against intent, rather than claim full auto-detection.
+  if [ "$IS_MOE" = "1" ]; then
+    if grep -qiE 'out of memory|failed to allocate|ErrorOutOfDeviceMemory|cannot allocate|alloc.*fail' "$LOG"; then
+      log "CRITICAL: allocation failure in server log -> raise AIMEE_DELEGATE_N_CPU_MOE and redeploy."
+      bad=1
+    fi
+    log "device buffer split (confirm experts landed as intended for N=$N_CPU_MOE):"
+    grep -iE 'model buffer size|KV .*buffer size|compute buffer size|CPU_Mapped|Vulkan[0-9]|offloD?ed .*layers' "$LOG" | tail -n 8 >&2 || true
+  fi
+  return $bad
+}
+if ! verify_startup; then
+  : > "$DEGRADED"                              # trip the healthcheck (see aimee-delegate-health.sh)
+  log "startup verification FAILED -> marked DEGRADED (container will report unhealthy)"
+fi
+
+wait "$srv"
+code=$?
+log "llama-server exited ($code)"
+exit "${code:-1}"

--- a/scripts/aimee-delegate-health.sh
+++ b/scripts/aimee-delegate-health.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Healthcheck for the aimee-delegate container: the model server must be up AND the
+# entrypoint's post-launch verification must not have tripped the degraded sentinel
+# (flash-attention no-op, or MoE experts CPU-fell-back past target). Reporting
+# unhealthy on a silent perf regression lets the orchestrator/operator notice a
+# misconfigured KV/offload profile instead of silently shipping degraded throughput.
+set -u
+PORT="${AIMEE_DELEGATE_PORT:-8083}"
+[ -f /tmp/aimee-delegate-degraded ] && { echo "degraded: startup verification failed (see logs)"; exit 1; }
+curl -fsS --max-time 4 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1 || { echo "llama-server /health failed"; exit 1; }
+exit 0

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -36,7 +36,11 @@ case "${AIMEE_LLM_STUB:-}" in
     # Reranker ENCODER: CLS pooling + flash-attn; the gateway applies the Dense head.
     start rerank 8082 -m /models/rerank-encoder.gguf --embeddings --pooling cls -fa on
     # Synth: OpenAI-compatible /v1/chat/completions (grammar/JSON via --jinja).
-    if [ -f /models/synth.gguf ]; then
+    # In the SPLIT topology (2026-07-01 roundtable) the big synth/delegate runs in a
+    # separate `aimee-delegate` container and AIMEE_LLM_SYNTH_URL points at it; set
+    # AIMEE_LLM_SYNTH_LOCAL=0 so this (kb) container does NOT also load a local synth
+    # and waste VRAM. Default 1 keeps the legacy unified behaviour.
+    if [ "${AIMEE_LLM_SYNTH_LOCAL:-1}" != "0" ] && [ -f /models/synth.gguf ]; then
       start synth 8083 -m /models/synth.gguf --ctx-size "$SYNTH_CTX" --jinja
     fi
     ;;


### PR DESCRIPTION
## What

Splits the local synth/delegate model out of the unified `aimee-llm` (embed+rerank+gateway) into a dedicated **`aimee-delegate`** image on the vendor-agnostic **Vulkan** llama.cpp build. Two tiers, chosen per card:

| Image | Model | Card | Profile |
|---|---|---|---|
| `aimee-delegate-small` | Gemma 4 12B `qat-UD-Q4_K_XL` (6.72 GB, dense) | 16 GB | 96K ctx, 1 slot, K8V4 |
| `aimee-delegate-mid` | Qwen 3.6 35B-A3B `UD-Q4_K_XL` (22.4 GB, MoE) | 24–32 GB | 256K (2×128K), K8V4, static `--n-cpu-moe` |

## Why (design)

Co-locating a 22 GB MoE with embed+rerank+gateway in one container was the root of a runtime VRAM auto-sizer, an FA probe, KV doubling, crash-coupling, and a security blast-radius. Splitting the synth out removes all of those cross-tier concerns, makes expert-offload a **static per-deployment** value, and *strengthens* KB portability — the embedder now lives only on the `kb` image, so swapping the delegate tier never touches KB dims.

## How it wires in

- `aimee-llm`'s gateway already proxies `/v1/chat/completions` → `AIMEE_LLM_SYNTH_URL`, so **no gateway code change**. The overlay points that at `aimee-delegate` and sets `AIMEE_LLM_SYNTH_LOCAL=0` so the kb image stops loading a local synth.
- Register with the server: `./aimee agent local delegate-mid http://aimee-delegate:8083/v1 --model aimee-synth --roles code,reason,execute --cost-tier 0`.

## Hardening (from the code roundtable)

- GGUFs **pinned by HF revision + sha256**, verified at build time (build fails on a compromised/MITM upload); hash surfaced as an image `LABEL`.
- Entrypoint: min-VRAM/discrete-GPU sysfs guard, clamped static offload `[0,40]`, `-fa`+K8V4 with a post-launch log-scrape that verifies flash-attention engaged and surfaces the device buffer split → trips a health sentinel (no 22 GB reload storm), graceful SIGTERM, curl `--max-time`, optional `--api-key` gating.
- Fixed an inverted return-polarity bug the panel caught (would have marked every healthy start as degraded).

## Testing / known gaps

- `bash -n` clean on all scripts; both YAML files parse.
- **`publish-images.yml` runs only on `v*` tags**, so the delegate build-matrix entry (and the 22 GB Dockerfile build) is **not exercised by PR CI**; validated here by review + parity with the existing `aimee-llm-gpu` build pattern. First real build happens at release.
- Runtime `-fa`/q4_0-V behaviour on RADV/gfx1100 is asserted at container start (falls back to K8V8 via env if it doesn't engage) — to be confirmed on the GPU box.
- Carried follow-ups: mirror into `publish-llm-testing.yml`; arm64 delegate leg bakes the x64 Vulkan binary (pre-existing `aimee-llm` wart).

Design and code both reviewed via the aimee roundtable.
