### PR TITLE
fix(delegate): verify flash-attn structurally, not by log-scrape

### DIFF
--- a/docs/AIMEE_DELEGATE_TUNING.md
+++ b/docs/AIMEE_DELEGATE_TUNING.md
@@ -37,18 +37,27 @@ surfaces as a failing container rather than silent slow throughput.
 Free system RAM needed ≈ `N/40 × 22 GB` for the offloaded experts (e.g. `N=24` →
 ~13 GB). Make sure the host has it free alongside other LXC/containers.
 
+**Measured baseline (7900 XTX, RADV, b9775).** Smoke-tested standalone on `.254` with
+`N_CPU_MOE=40` (all experts on CPU — the *worst case*) + 16K ctx: ~**12 tok/s** generation,
+~25 tok/s prompt, +2.6 GB GPU footprint. That's the floor; the shipped `N_CPU_MOE=24`
+keeps ~16 expert layers resident and is meaningfully faster. Use this as the low-water
+mark when sizing.
+
 ## Flash-attention / KV cache: `AIMEE_DELEGATE_KV_V`
 
-K8V4 (`KV_K=q8_0`, `KV_V=q4_0`) is the default. Quantized **V**-cache requires working
-flash-attention on the Vulkan backend. The entrypoint parses the server startup log
-and, if FA did **not** engage, logs:
+K8V4 (`KV_K=q8_0`, `KV_V=q4_0`) is the default and is **verified working on RADV/gfx1100**
+(7900 XTX, llama.cpp b9775) — the delegate loads and serves with it.
 
-```
-CRITICAL: flash-attention did NOT engage ... Set AIMEE_DELEGATE_KV_V=q8_0 (K8V8) and redeploy.
-```
+FA is enforced **structurally, not by log-scraping**: llama.cpp refuses to create a
+context with a quantized V-cache unless flash-attention is active (`-fa off` +
+`--cache-type-v q4_0` dies with *"V cache quantization requires flash_attn"*). The
+entrypoint always passes `-fa on`, so **a healthy container already proves FA engaged** —
+if a backend can't do FA, `llama-server` never starts and the container never goes
+healthy (fail-loud). There is nothing to grep.
 
-and trips the healthcheck. If you hit that on your RADV/driver combo, set
-`AIMEE_DELEGATE_KV_V=q8_0` (K8V8 — larger KV, no FA dependency) and redeploy.
+If you ever run on a backend that genuinely can't do FA, note that **K8V8 (`q8_0` V) does
+NOT help — *any* quantized V-cache requires FA.** The only FA-free fallback is an
+**unquantized V-cache**: set `AIMEE_DELEGATE_KV_V=f16` (larger KV, no FA dependency).
 
 ## Wiring into aimee
 

--- a/scripts/aimee-delegate-entrypoint.sh
+++ b/scripts/aimee-delegate-entrypoint.sh
@@ -117,16 +117,19 @@ log "llama-server ready on :$PORT"
 
 verify_startup() {
   local bad=0                                     # 0 = healthy (shell success); 1 = degraded
-  # (a) flash-attention engaged?  llama.cpp logs "flash_attn = 1" (or "enabled").
-  if grep -qiE 'flash[_ ]?att.*(= *1|enabled|: *1|on)' "$LOG"; then
-    log "verified: flash-attention ENGAGED"
-  elif grep -qiE 'flash[_ ]?att.*(= *0|disabled|not supported)' "$LOG"; then
-    log "CRITICAL: flash-attention did NOT engage on this backend, but KV V-cache=$KV_V was requested"
-    log "CRITICAL:   -> quantized V-cache without FA hits a slow dequant path. Set AIMEE_DELEGATE_KV_V=q8_0 (K8V8) and redeploy."
-    bad=1
-  else
-    log "WARN: could not determine flash-attention state from server log (continuing)"
-  fi
+  # (a) Flash-attention. VERIFIED LIVE on RADV/gfx1100 (b9775): the Vulkan build logs
+  #     NO flash_attn state (neither the server log nor /props expose it), so grepping
+  #     for it is futile. Instead FA is guaranteed STRUCTURALLY: llama.cpp refuses to
+  #     create a context with a quantized V-cache unless FA is active -- confirmed
+  #     empirically: `-fa off --cache-type-v q4_0` dies with
+  #     "V cache quantization requires flash_attn". We always pass `-fa on`, so a server
+  #     that reached /health with a quantized V-cache has FA engaged by construction; if
+  #     a backend can't do FA, llama-server never starts (loud) and this container never
+  #     becomes healthy. Nothing to grep, nothing to assert.
+  case "$KV_V" in
+    f16|f32|"") log "note: V-cache=${KV_V:-default} is unquantized; FA still requested via -fa on" ;;
+    *)          log "flash-attention ENGAGED (server reached /health with quantized V-cache=$KV_V, which llama.cpp refuses without FA)" ;;
+  esac
   # (b) MoE residency. NOTE: llama.cpp does NOT reliably emit an 'out of memory' string
   #     for SILENT expert CPU-fallback under VRAM pressure (panel code-review [1]) --
   #     it just prints per-device buffer sizes. So we (1) still fail on an EXPLICIT


### PR DESCRIPTION
## What
Corrects the delegate entrypoint's flash-attention verification based on a **live smoke test** on the 7900 XTX (`.254`, RADV, llama.cpp b9775).

## Live test results (standalone, non-invasive — live `aimee-llm` untouched)
- ✅ `aimee-delegate-mid:testing` (Qwen 3.6 35B-A3B, 22 GB) pulls, loads, and serves `/v1/chat/completions` on the card.
- ✅ **Flash-attention proven engaged** via negative control: `-fa off --cache-type-v q4_0` dies with *"V cache quantization requires flash_attn"*, so the smoke run (which used `-fa on --cache-type-v q4_0` **and generated**) had FA on. **K8V4 validated on RADV/gfx1100.**
- ✅ Non-invasive: +2.6 GB GPU only; live `aimee-llm` stayed healthy (no device-lost).
- 📊 Worst-case throughput (`N_CPU_MOE=40`, all experts on CPU): ~12 tok/s gen / ~25 tok/s prompt. Shipped `N_CPU_MOE=24` is faster.

## The fix
The test showed b9775's Vulkan build logs **no** flash_attn state (nor does `/props`), so the entrypoint's log-scrape only ever hit the "could not determine" WARN — exactly what code-review findings [1]/[5] predicted. Replace it with the accurate model: FA is enforced **structurally** (quantized V-cache won't start without it + we always pass `-fa on`), so a healthy container proves FA by construction; an FA-incapable backend fails loudly at startup. Also fix the tuning doc — **K8V8 is not an FA-free fallback** (any quantized V needs FA); only `f16` V is — and record the measured baseline.

Empirically grounded; no behavioral change to the happy path (the check was already a no-op WARN on b9775).
