### PR TITLE
ci(images): build aimee-delegate amd64-only with /mnt disk headroom

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -127,7 +127,7 @@ jobs:
         # The combined (aimee-server-kb) image now bundles the aimee-llm CPU
         # runtime + ~5.5 GB of baked GGUFs (COPYd from aimee-llm-cpu), so it needs
         # the same disk headroom as the llm legs.
-        if: startsWith(matrix.image.name, 'aimee-llm') || matrix.image.name == 'aimee-server-kb'
+        if: startsWith(matrix.image.name, 'aimee-llm') || startsWith(matrix.image.name, 'aimee-delegate') || matrix.image.name == 'aimee-server-kb'
         run: |
           echo "before:"; df -h / /mnt
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
@@ -138,7 +138,7 @@ jobs:
           echo "after:"; df -h /
 
       - name: Move docker storage to /mnt (aimee-llm + combined legs)
-        if: startsWith(matrix.image.name, 'aimee-llm') || matrix.image.name == 'aimee-server-kb'
+        if: startsWith(matrix.image.name, 'aimee-llm') || startsWith(matrix.image.name, 'aimee-delegate') || matrix.image.name == 'aimee-server-kb'
         run: |
           sudo systemctl stop docker docker.socket || true
           sudo mkdir -p /mnt/docker
@@ -152,6 +152,11 @@ jobs:
 
       - name: Build and push by digest
         id: build
+        # aimee-delegate is amd64-only: the baked llama.cpp runtime is the x64 Vulkan
+        # binary (an arm64 image would embed a non-runnable binary), and the 22GB mid
+        # tier would double release cost + disk for a leg nobody can run. Skip it on
+        # arm64 -> the merge job produces a single-arch (amd64) manifest for these.
+        if: ${{ !(startsWith(matrix.image.name, 'aimee-delegate') && matrix.platform.arch == 'arm64') }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context || '.' }}
@@ -194,11 +199,13 @@ jobs:
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        if: ${{ !(startsWith(matrix.image.name, 'aimee-delegate') && matrix.platform.arch == 'arm64') }}
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.image.name }}-${{ matrix.platform.arch }}"
 
       - name: Upload digest
+        if: ${{ !(startsWith(matrix.image.name, 'aimee-delegate') && matrix.platform.arch == 'arm64') }}
         uses: actions/upload-artifact@v4
         with:
           name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}


### PR DESCRIPTION
Prereq for promoting the delegate work to main. The delegate matrix entries (from #928) would break the release build: the 22GB `delegate-mid` overruns `/` (the `/mnt` data-root move was scoped to `aimee-llm` legs only), and the multi-arch build would bake the x64 Vulkan binary into a non-runnable arm64 image + double the 22GB cost.

- Extend both disk steps (`/mnt` move + free-space) to `aimee-delegate*`.
- Skip delegate `build`/`export`/`upload` on arm64 → the merge job emits a single-arch **amd64** manifest (it already tolerates `count>=1`).

Not exercised by PR CI (`publish-images.yml` runs on tags only); validated by YAML parse + review. Real test is the release build after promotion.