### PR TITLE
feat(smoothnas): compose-native aimee split plugins (llm/kb/server)

### DIFF
--- a/deploy/smoothnas/aimee-kb.compose.yaml
+++ b/deploy/smoothnas/aimee-kb.compose.yaml
@@ -1,0 +1,52 @@
+# aimee-kb — SmoothNAS compose-native plugin (split topology): the shared/vector
+# KB (DB2 + pgvector) with its own Postgres, standalone. postgres<->kb talk over
+# the compose network by name; the LLM is EXTERNAL — set AIMEE_LLM_URL to the host
+# running the aimee-llm plugin (its published :8742). (A compose plugin has its own
+# project network, so cross-plugin comms use host-published ports, not the runtime
+# bridge the manifest used.) Migrated from aimee-kb.plugin.yaml.
+name: aimee-kb
+services:
+  postgres:
+    restart: unless-stopped
+    image: pgvector/pgvector:pg17
+    user: "1000:1000"
+    environment:
+      POSTGRES_DB: aimee_shared
+      POSTGRES_USER: aimee
+      POSTGRES_PASSWORD: aimee
+    volumes:
+      - aimee-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aimee -d aimee_shared"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  aimee-kb:
+    restart: unless-stopped
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
+    ulimits:
+      stack: 67108864
+    environment:
+      AIMEE_HOME: /var/lib/aimee
+      AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
+      # EXTERNAL aimee-llm plugin — set to the host running it, e.g. http://192.168.0.254:8742
+      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://127.0.0.1:8742}
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-2560}
+      AIMEE_KB_HTTP_BIND: "1"
+    command: ["--http-port=8741"]
+    ports:
+      - "8741:8741"
+    depends_on:
+      postgres: { condition: service_healthy }
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - aimee-kb-home:/var/lib/aimee
+volumes:
+  aimee-postgres:
+    x-smoothnas: { tier: aimee-data }
+  aimee-kb-home:
+    x-smoothnas: { tier: aimee-data }

--- a/deploy/smoothnas/aimee-llm.compose.yaml
+++ b/deploy/smoothnas/aimee-llm.compose.yaml
@@ -1,0 +1,25 @@
+# aimee-llm — SmoothNAS compose-native plugin (split topology): the unified
+# Vulkan llama.cpp backend (embed + rerank + synth), standalone. GPU tier via
+# /dev/dri (LXC2Docker adds the cgroup allow). No cross-plugin deps — the kb
+# plugin points AIMEE_LLM_URL at this host's published :8742. Baked GGUFs, so no
+# tiered volume. Migrated from aimee-llm.plugin.yaml (gpu-amd profile).
+name: aimee-llm
+services:
+  aimee-llm:
+    restart: unless-stopped
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:gpu}
+    environment:
+      AIMEE_LLM_PORT: "8742"
+      AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-99}
+      AIMEE_LLM_SYNTH_CTX: ${AIMEE_LLM_SYNTH_CTX:-131072}
+      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+    devices:
+      - "/dev/dri:/dev/dri"
+    ports:
+      - "8742:8742"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 600s

--- a/deploy/smoothnas/aimee-server.compose.yaml
+++ b/deploy/smoothnas/aimee-server.compose.yaml
@@ -1,0 +1,37 @@
+# aimee-server — SmoothNAS compose-native plugin (split topology): the /v1 API +
+# webchat, standalone. The KB is EXTERNAL — set AIMEE_KB_API_URL to the host
+# running the aimee-kb plugin (its published :8741). Tiered home + workspaces.
+# Migrated from aimee-server.plugin.yaml (default-limits + aimee-stack profiles).
+name: aimee-server
+services:
+  aimee-server:
+    restart: unless-stopped
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
+    ulimits:
+      stack: 67108864
+    environment:
+      AIMEE_HOME: /var/lib/aimee
+      AIMEE_DB1_URL: sqlite:///var/lib/aimee/aimee.db
+      # EXTERNAL aimee-kb plugin — set to the host running it, e.g. http://192.168.0.254:8741
+      AIMEE_KB_API_URL: ${AIMEE_KB_API_URL:-http://127.0.0.1:8741}
+      AIMEE_SERVER_HTTP_BIND: "1"
+      AIMEE_WEBCHAT_ENABLED: "1"
+      AIMEE_WEBCHAT_USER: ${AIMEE_WEBCHAT_USER:-aimee}
+      AIMEE_WEBCHAT_PASSWORD: ${AIMEE_WEBCHAT_PASSWORD:-aimee-local-dev}
+    ports:
+      - "8743:8743"
+      - "8443:8443"
+    healthcheck:
+      test: ["CMD-SHELL",
+             "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - aimee-server-home:/var/lib/aimee
+      - aimee-server-workspaces:/var/lib/aimee-workspaces
+volumes:
+  aimee-server-home:
+    x-smoothnas: { tier: aimee-data }
+  aimee-server-workspaces:
+    x-smoothnas: { tier: aimee-data }


### PR DESCRIPTION
Completes the aimee plugin migration alongside the combined `aimee.compose.yaml` (#934): the three split manifests as compose-native plugins for multi-host deploys.

- `aimee-llm.compose.yaml` — standalone GPU backend (`/dev/dri`, no deps)
- `aimee-kb.compose.yaml` — postgres+kb (compose-DNS internally); **external** LLM via `AIMEE_LLM_URL`
- `aimee-server.compose.yaml` — API+webchat; **external** KB via `AIMEE_KB_API_URL`

Each compose plugin has its own project network (not the runtime bridge the manifests used), so cross-plugin comms are host-published ports the operator sets (default 127.0.0.1). Tiered volumes via `x-smoothnas`; `ulimits.stack`/`user: 1000:1000` preserved. Single-box deploys should prefer the combined `aimee.compose.yaml`. All three validated.