### PR TITLE
feat(xrepo): implement 'aimee index deps --reverse' (direction=in/both)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1247,8 +1247,8 @@ paths:
       description: >-
         Proxies the kb cross-repo dependency query. Returns confidence-tiered
         edges with evidence + a version stamp, or the AMBIGUOUS review queue when
-        status=ambiguous. The canonical query is OUT-only today (S4a); direction
-        in/both is rejected with 400 until reverse traversal lands.
+        status=ambiguous. direction: out = deps OF the project (default), in =
+        repos that depend ON the project (--reverse), both = union.
       requestBody:
         required: true
         content:
@@ -1258,7 +1258,7 @@ paths:
               required: [project]
               properties:
                 project: { type: string }
-                direction: { type: string, enum: [out], default: out }
+                direction: { type: string, enum: [out, in, both], default: out }
                 min_tier: { type: string, enum: [high, medium, tentative] }
                 status: { type: string, enum: [ambiguous] }
       responses:

--- a/api/openapi-v1.yaml
+++ b/api/openapi-v1.yaml
@@ -1650,8 +1650,9 @@ paths:
           in: query
           required: false
           description: >-
-            Dependency direction. Only "out" is implemented today; "in"/"both"
-            return 501. Ignored when status=ambiguous.
+            Dependency direction: "out" = deps OF the project (default), "in" =
+            repos that depend ON the project (reverse), "both" = union. Ignored
+            when status=ambiguous.
           schema:
             type: string
             enum: [out, in, both]
@@ -1686,8 +1687,6 @@ paths:
           description: Unauthorized
         "413":
           description: Response too large; narrow the query
-        "501":
-          description: Requested direction not yet implemented
         "503":
           description: Canonical index unavailable
 

--- a/docs/gen/api-v1.md
+++ b/docs/gen/api-v1.md
@@ -115,7 +115,7 @@ Cross-repo dependency edges for a project (confidence-tiered, with evidence + ve
 | Name | In | Required | Type | Description |
 |------|----|----------|------|-------------|
 | `project` | query | yes | string |  |
-| `direction` | query | no | string (out, in, both) | Dependency direction. Only "out" is implemented today; "in"/"both" return 501. Ignored when status=ambiguous. |
+| `direction` | query | no | string (out, in, both) | Dependency direction: "out" = deps OF the project (default), "in" = repos that depend ON the project (reverse), "both" = union. Ignored when status=ambiguous. |
 | `min_tier` | query | no | string (high, medium, tentative) | Minimum confidence tier to emit. Ignored when status=ambiguous. |
 | `status` | query | no | string (ambiguous) | When "ambiguous", returns the AMBIGUOUS review queue for the project instead of edges (direction/min_tier are not applied in that mode). |
 
@@ -125,7 +125,6 @@ Responses:
 - `400` — Missing required parameters
 - `401` — Unauthorized
 - `413` — Response too large; narrow the query
-- `501` — Requested direction not yet implemented
 - `503` — Canonical index unavailable
 
 ### `GET /v1/code/find`

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -698,14 +698,14 @@ static cJSON *marshal_index_find_callers(int argc, char **argv)
    return req;
 }
 
-/* Marshal `aimee index deps <project> [--tier T] [--review]` (§B). --tier sets
- * the minimum emitted tier (high|medium|tentative); --review lists the AMBIGUOUS
- * queue (status=ambiguous). The kb canonical query is OUT-only today, so
- * --reverse (direction=in) and --dry-run (per-stage offline inspection) are
- * deferred to the slices that implement reverse traversal / candidate emission. */
+/* Marshal `aimee index deps <project> [--tier T] [--review] [--reverse]` (§B).
+ * --tier sets the minimum emitted tier (high|medium|tentative); --review lists the
+ * AMBIGUOUS queue (status=ambiguous); --reverse inverts direction to list repos
+ * that depend ON <project> (direction=in). --dry-run (per-stage offline
+ * inspection) is deferred to the candidate-emission slice. */
 static cJSON *marshal_index_deps(int argc, char **argv)
 {
-   static const char *bools[] = {"review", NULL};
+   static const char *bools[] = {"review", "reverse", NULL};
    rpc_opts_t opts;
    rpc_parse(argc, argv, bools, &opts);
 
@@ -717,6 +717,8 @@ static cJSON *marshal_index_deps(int argc, char **argv)
       cJSON_AddStringToObject(req, "min_tier", tier);
    if (rpc_get(&opts, "review"))
       cJSON_AddStringToObject(req, "status", "ambiguous");
+   if (rpc_get(&opts, "reverse"))
+      cJSON_AddStringToObject(req, "direction", "in");
    return req;
 }
 

--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -1004,7 +1004,7 @@ static int crd_compute_in(const char *target, const xrepo_deps_opts_t *opts, edg
                           int *trunc)
 {
    void *conn = db2_conn();
-   if (!conn || !target || !opts)
+   if (!conn || !target || !opts || !agg || !trunc)
       return -1;
 
    char callers[CRD_MAX_REPOS][128];
@@ -1059,7 +1059,13 @@ static int crd_compute_in(const char *target, const xrepo_deps_opts_t *opts, edg
       size_t n = 0;
       int t = 0;
       if (crd_compute_out(callers[i], &sub, &e, &n, &t) != 0)
+      {
+         /* A per-caller failure (transient DB/OOM) must not be silently swallowed:
+          * flag the result partial (§4.2) so a reverse read cannot masquerade as a
+          * complete "no dependents" answer when a caller was actually skipped. */
+         *trunc = 1;
          continue;
+      }
       if (t)
          *trunc = 1;
       for (size_t j = 0; j < n; j++)

--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -568,8 +568,12 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
       free((char *)defs[i].repo);
 }
 
-int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t *opts,
-                                    xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated)
+/* OUT-direction resolver: emit the cross-repo edges `project` -> D (deps OF
+ * `project`). This is the core engine; direction=IN/BOTH is layered on top by the
+ * public canonical_index_cross_repo_deps dispatcher, which reuses this per caller.
+ * opts->direction is IGNORED here (always computes OUT for the given project). */
+static int crd_compute_out(const char *project, const xrepo_deps_opts_t *opts,
+                           xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated)
 {
    if (out_edges)
       *out_edges = NULL;
@@ -585,11 +589,6 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
    config_load(&cfg);
    if (!cfg.kb_curator_cross_repo_graph_enabled)
       return 0; /* feature off: empty result, not an error */
-   /* S4a implements the OUT direction (deps OF `project`). Reverse/both
-    * (dependents) land with the CLI --reverse surface (S6); until then a
-    * non-OUT request returns empty rather than silently OUT-direction results. */
-   if (opts->direction != XREPO_DIR_OUT)
-      return 0;
 
    xrepo_distinct_cfg_t dcfg = {.k = cfg.kb_curator_cross_repo_k,
                                 .m = cfg.kb_curator_cross_repo_m,
@@ -972,5 +971,164 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
 
    *out_edges = acc.e;
    *out_n = acc.n;
+   return 0;
+}
+
+/* Append a full copy of one edge to an accumulator (used by the IN/BOTH merge;
+ * unlike edge_find_or_add it never merges — each reverse caller yields at most one
+ * edge to the target so duplicates cannot arise). Returns 0 on OOM. */
+static int agg_push(edge_acc_t *a, const xrepo_dep_edge_t *src)
+{
+   if (a->n == a->cap)
+   {
+      size_t nc = a->cap ? a->cap * 2 : 32;
+      xrepo_dep_edge_t *ne = realloc(a->e, nc * sizeof(*ne));
+      if (!ne)
+         return 0;
+      a->e = ne;
+      a->cap = nc;
+   }
+   a->e[a->n++] = *src;
+   return 1;
+}
+
+/* IN-direction resolver: emit the cross-repo edges A -> `target` (repos that
+ * depend ON `target`). Reuses crd_compute_out per candidate caller so a reverse
+ * edge is BYTE-IDENTICAL to the forward edge the OUT query would emit (symmetric
+ * consistency), inheriting every precision/recall/suppression rule. Candidate
+ * callers = the union of repos with a precomputed structural route into `target`
+ * (cross_repo_route) and repos that build-declare `target` (cross_repo_build_dep);
+ * this is a superset of the emitters, kept small so the per-caller fan-out stays
+ * bounded (§4.2). Edges are collected up to the candidate cap (then *trunc=1). */
+static int crd_compute_in(const char *target, const xrepo_deps_opts_t *opts, edge_acc_t *agg,
+                          int *trunc)
+{
+   void *conn = db2_conn();
+   if (!conn || !target || !opts)
+      return -1;
+
+   char callers[CRD_MAX_REPOS][128];
+   int nc = 0;
+   static const char *const caller_sql[2] = {
+       "SELECT DISTINCT caller_project FROM cross_repo_route WHERE definer_project = ?1",
+       "SELECT DISTINCT caller_project FROM cross_repo_build_dep WHERE definer_project = ?1"};
+   for (int q = 0; q < 2 && nc < CRD_MAX_REPOS; q++)
+   {
+      char err[CRD_ERR] = "";
+      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, caller_sql[q], err, sizeof(err));
+      if (!st)
+         continue;
+      aimee_pg_bind_text(st, "?1", target);
+      while (nc < CRD_MAX_REPOS && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         const char *c = aimee_pg_column_text(st, 0);
+         if (!c || !c[0] || strcmp(c, target) == 0) /* a repo is never its own dependent */
+            continue;
+         int dup = 0;
+         for (int i = 0; i < nc; i++)
+            if (strcmp(callers[i], c) == 0)
+            {
+               dup = 1;
+               break;
+            }
+         if (!dup)
+            snprintf(callers[nc++], sizeof(callers[0]), "%s", c);
+      }
+      aimee_pg_finalize(st);
+   }
+
+   config_t cfg;
+   config_load(&cfg);
+   int cap =
+       opts->max_candidates > 0 ? opts->max_candidates : cfg.kb_curator_cross_repo_max_candidates;
+
+   /* Per-caller OUT, keeping only edges whose definer IS the target. Force the OUT
+    * direction and suppress review-queue writes: a reverse query is a read, and its
+    * per-caller fan-out must not enqueue AMBIGUOUS candidates for other repos. */
+   xrepo_deps_opts_t sub = *opts;
+   sub.direction = XREPO_DIR_OUT;
+   sub.include_review = 0;
+   for (int i = 0; i < nc; i++)
+   {
+      if (cap > 0 && (int)agg->n >= cap)
+      {
+         *trunc = 1;
+         break; /* candidate cap reached — stop the per-caller fan-out early. */
+      }
+      xrepo_dep_edge_t *e = NULL;
+      size_t n = 0;
+      int t = 0;
+      if (crd_compute_out(callers[i], &sub, &e, &n, &t) != 0)
+         continue;
+      if (t)
+         *trunc = 1;
+      for (size_t j = 0; j < n; j++)
+      {
+         if (strcmp(e[j].definer_repo, target) != 0)
+            continue;
+         if (cap > 0 && (int)agg->n >= cap)
+         {
+            *trunc = 1;
+            break;
+         }
+         if (!agg_push(agg, &e[j]))
+         {
+            free(e);
+            return -1;
+         }
+      }
+      free(e);
+   }
+   return 0;
+}
+
+/* Public entry: dispatch on direction. OUT delegates to the core engine; IN and
+ * BOTH layer the reverse traversal (crd_compute_in) on top, reusing OUT per caller
+ * for symmetric consistency (§B --reverse, §4 direction=in|both). */
+int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t *opts,
+                                    xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated)
+{
+   if (out_edges)
+      *out_edges = NULL;
+   if (out_n)
+      *out_n = 0;
+   if (truncated)
+      *truncated = 0;
+   if (!project || !opts || !out_edges || !out_n)
+      return -1;
+
+   if (opts->direction == XREPO_DIR_OUT)
+      return crd_compute_out(project, opts, out_edges, out_n, truncated);
+
+   /* IN or BOTH: build a fresh accumulator. For BOTH, seed it with the forward
+    * (OUT) edges, then append the reverse (IN) edges. */
+   edge_acc_t agg = {0};
+   int trunc = 0;
+   if (opts->direction == XREPO_DIR_BOTH)
+   {
+      xrepo_dep_edge_t *oe = NULL;
+      size_t on = 0;
+      int ot = 0;
+      if (crd_compute_out(project, opts, &oe, &on, &ot) != 0)
+         return -1;
+      trunc |= ot;
+      for (size_t i = 0; i < on; i++)
+         if (!agg_push(&agg, &oe[i]))
+         {
+            free(oe);
+            free(agg.e);
+            return -1;
+         }
+      free(oe);
+   }
+   if (crd_compute_in(project, opts, &agg, &trunc) != 0)
+   {
+      free(agg.e);
+      return -1;
+   }
+   *out_edges = agg.e;
+   *out_n = agg.n;
+   if (truncated)
+      *truncated = trunc;
    return 0;
 }

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -637,16 +637,26 @@ int handle_get_code_cross_repo_deps(const char *query_string, char *out_buf, int
    if (strcmp(status_s, "ambiguous") == 0)
       return handle_get_code_cross_repo_review(project, out_buf, out_cap);
 
-   /* direction in/both (dependents) is documented in OpenAPI but not yet
-    * implemented (S4a is OUT-only) -> 501, not a misleading empty 200. */
-   if (strcmp(dir_s, "in") == 0 || strcmp(dir_s, "both") == 0)
+   /* direction: out (deps OF project, default), in (dependents, §B --reverse), or
+    * both. An unrecognized non-empty value is a client error, not a silent OUT. */
+   xrepo_direction_t dir = XREPO_DIR_OUT;
+   if (dir_s[0])
    {
-      snprintf(out_buf, (size_t)out_cap,
-               "{\"error\":\"direction '%s' not yet implemented\",\"code\":501}", dir_s);
-      return 501;
+      if (strcmp(dir_s, "out") == 0)
+         dir = XREPO_DIR_OUT;
+      else if (strcmp(dir_s, "in") == 0)
+         dir = XREPO_DIR_IN;
+      else if (strcmp(dir_s, "both") == 0)
+         dir = XREPO_DIR_BOTH;
+      else
+      {
+         snprintf(out_buf, (size_t)out_cap,
+                  "{\"error\":\"direction must be out, in, or both\",\"code\":400}");
+         return 400;
+      }
    }
    xrepo_deps_opts_t opts = {
-       .min_tier = crd_parse_min_tier(tier_s), .direction = XREPO_DIR_OUT, .include_review = 0};
+       .min_tier = crd_parse_min_tier(tier_s), .direction = dir, .include_review = 0};
 
    xrepo_dep_edge_t *edges = NULL;
    size_t n = 0;

--- a/src/server/server_state_index.c
+++ b/src/server/server_state_index.c
@@ -20,10 +20,9 @@ static int send_and_free(server_conn_t *conn, cJSON *resp)
  * rich (per-edge evidence + version stamp, or the AMBIGUOUS review queue when
  * status=ambiguous) so we forward it verbatim, same passthrough idiom as
  * handle_graph_explain. Inputs are validated at this public boundary so a direct
- * API client gets an actionable error rather than an opaque 502: the kb's
- * canonical query is OUT-only today (S4a), so direction=in/both is rejected here
- * instead of letting the kb 501 collapse into a bad-gateway. Validation runs
- * before any allocation, so the error paths cannot leak. */
+ * API client gets an actionable error rather than an opaque 502: direction must be
+ * out (default), in (dependents, --reverse), or both. Validation runs before any
+ * allocation, so the error paths cannot leak. */
 int handle_index_deps(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
@@ -33,9 +32,9 @@ int handle_index_deps(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       return server_send_error(conn, "missing project", NULL);
 
    const char *direction = jo_str(req, "direction", NULL);
-   if (direction && strcmp(direction, "out") != 0)
-      return server_send_error(
-          conn, "direction not supported (only 'out'); reverse traversal is a later slice", NULL);
+   if (direction && strcmp(direction, "out") != 0 && strcmp(direction, "in") != 0 &&
+       strcmp(direction, "both") != 0)
+      return server_send_error(conn, "direction must be 'out', 'in', or 'both'", NULL);
 
    const char *status = jo_str(req, "status", NULL);
    if (status && strcmp(status, "ambiguous") != 0)

--- a/src/tests/test_cross_repo_deps_orch.c
+++ b/src/tests/test_cross_repo_deps_orch.c
@@ -126,6 +126,43 @@ static void test_end_to_end(void)
    printf("ok\n");
 }
 
+/* Reverse traversal (§B --reverse / direction=in): querying the DEFINER lists the
+ * repos that depend ON it, and each reverse edge is byte-identical to the forward
+ * edge the OUT query emits. Runs immediately after test_end_to_end so the only
+ * seeded data is moonlight-qt -> moonlight-common-c (HIGH, import-corroborated). */
+static void test_reverse_direction(void)
+{
+   printf("test_reverse_direction... ");
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+
+   /* IN on the definer: exactly one dependent, moonlight-qt, same tier/evidence as OUT. */
+   xrepo_deps_opts_t in = {.direction = XREPO_DIR_IN, .min_tier = XREPO_TIER_MEDIUM};
+   int rc = canonical_index_cross_repo_deps("moonlight-common-c", &in, &edges, &n, &trunc);
+   assert(rc == 0 && n == 1);
+   assert(strcmp(edges[0].caller_repo, "moonlight-qt") == 0);
+   assert(strcmp(edges[0].definer_repo, "moonlight-common-c") == 0);
+   assert(edges[0].tier == XREPO_TIER_HIGH);
+   assert(edges[0].import_corroborated == 1);
+   assert(strcmp(edges[0].example_symbol, "LiStartConnection") == 0);
+   free(edges);
+
+   /* IN on the caller: nothing depends on moonlight-qt. */
+   rc = canonical_index_cross_repo_deps("moonlight-qt", &in, &edges, &n, &trunc);
+   assert(rc == 0 && n == 0);
+   free(edges);
+
+   /* BOTH on the caller: the forward OUT edge, no reverse edge -> exactly one. */
+   xrepo_deps_opts_t both = {.direction = XREPO_DIR_BOTH, .min_tier = XREPO_TIER_MEDIUM};
+   rc = canonical_index_cross_repo_deps("moonlight-qt", &both, &edges, &n, &trunc);
+   assert(rc == 0 && n == 1);
+   assert(strcmp(edges[0].caller_repo, "moonlight-qt") == 0);
+   assert(strcmp(edges[0].definer_repo, "moonlight-common-c") == 0);
+   free(edges);
+   printf("ok\n");
+}
+
 /* A symbol defined in two trusted repos that A imports NEITHER of, called in A:
  * multi-definer without corroboration -> AMBIGUOUS -> review queue (no edge). */
 static void test_ambiguous_to_review(void)
@@ -1035,6 +1072,7 @@ int main(void)
    db2_test_shim_open();
    test_empty_graceful();
    test_end_to_end();
+   test_reverse_direction();
    test_ambiguous_to_review();
    test_structural_edge_gate();
    test_cold_start_rebuild_to_gate();


### PR DESCRIPTION
## Summary
Implements `aimee index deps --reverse` (direction=in/both), closing the §B `--reverse` gap in the **cross-repo-dependency-graph** proposal. The resolver was OUT-only — `direction=in`/`both` returned empty (kb 501). Reverse traversal now lists the repos that depend **on** a project.

## Approach
Reverse edges are computed by **reusing the OUT engine per candidate caller**, so a reverse edge is byte-identical to the forward edge the OUT query emits (symmetric consistency), inheriting every precision/recall/suppression rule:
- Candidate callers = union of `cross_repo_route` + `cross_repo_build_dep` rows whose `definer_project` is the target (a bounded superset of the emitters).
- For each caller, run `crd_compute_out`, keep edges whose `definer == target`.
- `include_review=0` on the per-caller fan-out — a reverse query is a read and must not enqueue AMBIGUOUS candidates for other repos.
- `BOTH` = forward OUT ∪ reverse IN. Candidate cap honored with early-out; `truncated` propagated.

## Changes
- `db2/cross_repo_deps.c`: extract `crd_compute_out` core; add `crd_compute_in` + `agg_push`; dispatch on direction.
- `kb/http/kb_http_code.c`: map `direction` out|in|both (400 on unknown) instead of 501.
- `server/server_state_index.c` + `cli_v1_routes.inc`: accept in/both; add `--reverse` flag (direction=in).
- openapi (v1 + server-v1) + docs-gen refreshed.
- `tests/test_cross_repo_deps_orch.c`: reverse + both traversal coverage (all unit tests green).

## Testing
`unit-test-cross-repo-deps-orch` passes incl. new `test_reverse_direction`; kb + server binaries build clean.

## Review
Memory-safety reviewed: edge structs are POD → value-copy in `agg_push` is safe and freeing the per-caller source array cannot invalidate copies; the dispatcher frees `agg.e` on every error path. Roundtable/delegate code-review requested with the diff embedded (agents run sandboxed and cannot see the worktree directly).
