### PR TITLE
feat(xrepo): implement 'aimee index deps --dry-run' (acceptance #4)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1261,6 +1261,11 @@ paths:
                 direction: { type: string, enum: [out, in, both], default: out }
                 min_tier: { type: string, enum: [high, medium, tentative] }
                 status: { type: string, enum: [ambiguous] }
+                dry_run:
+                  type: boolean
+                  description: >-
+                    Offline candidate inspection — emit every band down to LOW plus
+                    inline AMBIGUOUS candidates, writing nothing (acceptance #4).
       responses:
         "200":
           description: Cross-repo dependency edges or ambiguous review queue

--- a/api/openapi-v1.yaml
+++ b/api/openapi-v1.yaml
@@ -1674,6 +1674,17 @@ paths:
           schema:
             type: string
             enum: [ambiguous]
+        - name: dry_run
+          in: query
+          required: false
+          description: >-
+            Offline candidate inspection: emit every confidence band (down to LOW,
+            overriding min_tier) plus the AMBIGUOUS candidates inline, and write
+            nothing (no review-queue rows). The response carries dry_run:true and an
+            additional `ambiguous` array alongside `deps`.
+          schema:
+            type: string
+            enum: ["1", "true"]
       responses:
         "200":
           description: Cross-repo dependency edges (or ambiguous review queue)

--- a/docs/gen/api-v1.md
+++ b/docs/gen/api-v1.md
@@ -118,6 +118,7 @@ Cross-repo dependency edges for a project (confidence-tiered, with evidence + ve
 | `direction` | query | no | string (out, in, both) | Dependency direction: "out" = deps OF the project (default), "in" = repos that depend ON the project (reverse), "both" = union. Ignored when status=ambiguous. |
 | `min_tier` | query | no | string (high, medium, tentative) | Minimum confidence tier to emit. Ignored when status=ambiguous. |
 | `status` | query | no | string (ambiguous) | When "ambiguous", returns the AMBIGUOUS review queue for the project instead of edges (direction/min_tier are not applied in that mode). |
+| `dry_run` | query | no | string (1, true) | Offline candidate inspection: emit every confidence band (down to LOW, overriding min_tier) plus the AMBIGUOUS candidates inline, and write nothing (no review-queue rows). The response carries dry_run:true and an additional `ambiguous` array alongside `deps`. |
 
 Responses:
 

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -698,14 +698,15 @@ static cJSON *marshal_index_find_callers(int argc, char **argv)
    return req;
 }
 
-/* Marshal `aimee index deps <project> [--tier T] [--review] [--reverse]` (§B).
- * --tier sets the minimum emitted tier (high|medium|tentative); --review lists the
- * AMBIGUOUS queue (status=ambiguous); --reverse inverts direction to list repos
- * that depend ON <project> (direction=in). --dry-run (per-stage offline
- * inspection) is deferred to the candidate-emission slice. */
+/* Marshal `aimee index deps <project> [--tier T] [--review] [--reverse] [--dry-run]`
+ * (§B). --tier sets the minimum emitted tier (high|medium|tentative); --review
+ * lists the AMBIGUOUS queue (status=ambiguous); --reverse inverts direction to list
+ * repos that depend ON <project> (direction=in); --dry-run emits every confidence
+ * band (down to LOW) plus the AMBIGUOUS candidates inline for offline inspection,
+ * writing nothing (acceptance #4). */
 static cJSON *marshal_index_deps(int argc, char **argv)
 {
-   static const char *bools[] = {"review", "reverse", NULL};
+   static const char *bools[] = {"review", "reverse", "dry-run", NULL};
    rpc_opts_t opts;
    rpc_parse(argc, argv, bools, &opts);
 
@@ -719,6 +720,8 @@ static cJSON *marshal_index_deps(int argc, char **argv)
       cJSON_AddStringToObject(req, "status", "ambiguous");
    if (rpc_get(&opts, "reverse"))
       cJSON_AddStringToObject(req, "direction", "in");
+   if (rpc_get(&opts, "dry-run"))
+      cJSON_AddBoolToObject(req, "dry_run", 1);
    return req;
 }
 
@@ -4918,24 +4921,34 @@ static void print_index_callers(cJSON *resp)
    }
 }
 
-/* S6: `aimee index deps`. Two response shapes: the AMBIGUOUS review queue
+/* Print the AMBIGUOUS candidate rows shared by the --review view and the --dry-run
+ * inline section. */
+static void print_index_deps_ambiguous(cJSON *amb)
+{
+   cJSON *a;
+   cJSON_ArrayForEach(a, amb)
+   {
+      cJSON *score = cJSON_GetObjectItemCaseSensitive(a, "evidence_score");
+      printf("  %s -> %s  [%s, score %.2f]  %s\n", json_str(a, "caller_repo"),
+             json_str(a, "candidate_definer"), json_str(a, "review_class"),
+             cJSON_IsNumber(score) ? score->valuedouble : 0.0, json_str(a, "symbol"));
+   }
+}
+
+/* S6: `aimee index deps`. Three response shapes: the AMBIGUOUS review queue
  * (--review / status=ambiguous) carries an `ambiguous` array + `overflow.dropped`;
- * the default carries a `deps` edge array + `truncated`. */
+ * --dry-run carries BOTH a `deps` array (down to LOW) and an inline `ambiguous`
+ * array with `dry_run:true`; the default carries a `deps` edge array + `truncated`. */
 static void print_index_deps(cJSON *resp)
 {
+   int dry_run = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(resp, "dry_run"));
    cJSON *amb = cJSON_GetObjectItemCaseSensitive(resp, "ambiguous");
-   if (cJSON_IsArray(amb))
+   /* --review view: an `ambiguous` array with no `deps` (dry-run has both). */
+   if (cJSON_IsArray(amb) && !dry_run)
    {
       if (cJSON_GetArraySize(amb) == 0)
          printf("No ambiguous candidates in the review queue.\n");
-      cJSON *a;
-      cJSON_ArrayForEach(a, amb)
-      {
-         cJSON *score = cJSON_GetObjectItemCaseSensitive(a, "evidence_score");
-         printf("  %s -> %s  [%s, score %.2f]  %s\n", json_str(a, "caller_repo"),
-                json_str(a, "candidate_definer"), json_str(a, "review_class"),
-                cJSON_IsNumber(score) ? score->valuedouble : 0.0, json_str(a, "symbol"));
-      }
+      print_index_deps_ambiguous(amb);
       cJSON *ov = cJSON_GetObjectItemCaseSensitive(resp, "overflow");
       cJSON *dropped = ov ? cJSON_GetObjectItemCaseSensitive(ov, "dropped") : NULL;
       if (cJSON_IsNumber(dropped) && dropped->valuedouble > 0)
@@ -4945,11 +4958,15 @@ static void print_index_deps(cJSON *resp)
       return;
    }
 
+   if (dry_run)
+      printf("[dry-run: candidate inspection — every band incl. LOW/AMBIGUOUS; nothing written]\n");
+
    cJSON *deps = cJSON_GetObjectItemCaseSensitive(resp, "deps");
    if (!cJSON_IsArray(deps) || cJSON_GetArraySize(deps) == 0)
    {
       printf("No cross-repo dependencies found.\n");
-      return;
+      if (!dry_run)
+         return;
    }
    cJSON *d;
    cJSON_ArrayForEach(d, deps)
@@ -4976,6 +4993,16 @@ static void print_index_deps(cJSON *resp)
    cJSON *trunc = cJSON_GetObjectItemCaseSensitive(resp, "truncated");
    if (cJSON_IsBool(trunc) && cJSON_IsTrue(trunc))
       printf("(results truncated; narrow the query)\n");
+
+   /* --dry-run: also print the AMBIGUOUS candidates the pipeline held back. */
+   if (dry_run && cJSON_IsArray(amb))
+   {
+      int na = cJSON_GetArraySize(amb);
+      printf("ambiguous candidates (%d):\n", na);
+      if (na == 0)
+         printf("  (none)\n");
+      print_index_deps_ambiguous(amb);
+   }
 }
 
 static void print_hud_status(cJSON *resp)

--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -300,6 +300,36 @@ static xrepo_dep_edge_t *edge_find_or_add(edge_acc_t *a, const char *caller, con
    return E;
 }
 
+/* In-memory sink for AMBIGUOUS candidates under --dry-run (parallels edge_acc_t).
+ * NULL cap means "not capturing" (normal operation routes to the review queue). */
+typedef struct
+{
+   xrepo_amb_cand_t *c;
+   size_t n, cap;
+} amb_acc_t;
+
+static int amb_push(amb_acc_t *a, const char *sym, const char *caller, const char *definer,
+                    const char *ev, double score)
+{
+   if (a->n == a->cap)
+   {
+      size_t nc = a->cap ? a->cap * 2 : 16;
+      xrepo_amb_cand_t *nn = realloc(a->c, nc * sizeof(*nn));
+      if (!nn)
+         return 0;
+      a->c = nn;
+      a->cap = nc;
+   }
+   xrepo_amb_cand_t *C = &a->c[a->n++];
+   memset(C, 0, sizeof(*C));
+   snprintf(C->symbol, sizeof(C->symbol), "%s", sym ? sym : "");
+   snprintf(C->caller_repo, sizeof(C->caller_repo), "%s", caller ? caller : "");
+   snprintf(C->candidate_definer, sizeof(C->candidate_definer), "%s", definer ? definer : "");
+   snprintf(C->evidence, sizeof(C->evidence), "%s", ev ? ev : "");
+   C->evidence_score = score;
+   return 1;
+}
+
 /* Find an existing edge without adding (recall R2c merge). NULL if absent. */
 static xrepo_dep_edge_t *edge_find(edge_acc_t *a, const char *caller, const char *definer)
 {
@@ -333,6 +363,8 @@ typedef struct
    int a_filecount;
    int include_review; /* write AMBIGUOUS candidates to the review queue (S4b) */
    int queue_max;      /* review-queue overflow cap */
+   int dry_run;        /* --dry-run: capture AMBIGUOUS in `amb`, write nothing */
+   amb_acc_t *amb;     /* in-memory AMBIGUOUS sink when dry_run (else NULL) */
 } crd_ctx_t;
 
 /* Bounds-safe route_seen lookup by repo name (H1 structural-edge gate). desc_index
@@ -499,7 +531,7 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
     * structural route exists to at least one definer (H1 invariant: no route =>
     * not a cross-repo relation at all, so not even review-worthy). The genuine
     * route-backed multi-definer collisions are H2's canonical pass. */
-   if (cl.tier == XREPO_TIER_AMBIGUOUS && ctx->include_review && any_route)
+   if (cl.tier == XREPO_TIER_AMBIGUOUS && any_route && (ctx->include_review || ctx->dry_run))
    {
       int routes = (c.corroboration != XREPO_CORROB_NONE) ? 1 : 0;
       double score = xrepo_evidence_score(distinctive ? definer_rc : 0, sites, routes);
@@ -517,8 +549,16 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
       snprintf(ev, sizeof(ev),
                "{\"symbol\":\"%s\",\"definers\":%d,\"sites\":%d,\"files\":%d,\"reason\":\"%s\"}",
                esym, ndef, sites, files, cl.reason ? cl.reason : "ambiguous");
-      db2_cross_repo_review_upsert(ctx->repo_set_hash, sym, ctx->project, defs[rep].repo, ev, score,
-                                   "ambiguous", 0, ctx->queue_max);
+      /* --dry-run captures the candidate in-memory for offline inspection and
+       * writes NOTHING; normal operation persists it to the review queue. */
+      if (ctx->dry_run)
+      {
+         if (ctx->amb)
+            amb_push(ctx->amb, sym, ctx->project, defs[rep].repo, ev, score);
+      }
+      else
+         db2_cross_repo_review_upsert(ctx->repo_set_hash, sym, ctx->project, defs[rep].repo, ev,
+                                      score, "ambiguous", 0, ctx->queue_max);
    }
 
    /* H1 structural-edge gate (precision-hardening §1): a non-LOW edge REQUIRES a
@@ -573,7 +613,8 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
  * public canonical_index_cross_repo_deps dispatcher, which reuses this per caller.
  * opts->direction is IGNORED here (always computes OUT for the given project). */
 static int crd_compute_out(const char *project, const xrepo_deps_opts_t *opts,
-                           xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated)
+                           xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated,
+                           amb_acc_t *amb)
 {
    if (out_edges)
       *out_edges = NULL;
@@ -597,7 +638,10 @@ static int crd_compute_out(const char *project, const xrepo_deps_opts_t *opts,
    xrepo_mult_cfg_t mcfg = {.dom_share_pct = 90, .runnerup_share_pct = 5, .runnerup_abs = 2};
    int cap =
        opts->max_candidates > 0 ? opts->max_candidates : cfg.kb_curator_cross_repo_max_candidates;
-   xrepo_tier_t min_tier = opts->min_tier ? opts->min_tier : XREPO_TIER_MEDIUM;
+   /* --dry-run emits every confidence band (down to LOW) for offline inspection;
+    * otherwise honor the requested min_tier (default MEDIUM). */
+   xrepo_tier_t min_tier =
+       opts->dry_run ? XREPO_TIER_LOW : (opts->min_tier ? opts->min_tier : XREPO_TIER_MEDIUM);
    int collision_c = cfg.kb_curator_cross_repo_caller_collision_c;
 
    desc_set_t descs;
@@ -704,8 +748,10 @@ static int crd_compute_out(const char *project, const xrepo_deps_opts_t *opts,
                     .distinctiveness_v = cfg.kb_curator_cross_repo_distinctiveness_v,
                     .bsv = bsv,
                     .a_filecount = a_filecount,
-                    .include_review = opts->include_review,
-                    .queue_max = cfg.kb_curator_cross_repo_review_queue_max};
+                    .include_review = opts->dry_run ? 0 : opts->include_review,
+                    .queue_max = cfg.kb_curator_cross_repo_review_queue_max,
+                    .dry_run = opts->dry_run,
+                    .amb = opts->dry_run ? amb : NULL};
 
    /* Single working-set query (no per-candidate N+1, per the S3 contract): one row
     * per (candidate symbol, definer repo) with per-symbol stats as correlated
@@ -1058,7 +1104,7 @@ static int crd_compute_in(const char *target, const xrepo_deps_opts_t *opts, edg
       xrepo_dep_edge_t *e = NULL;
       size_t n = 0;
       int t = 0;
-      if (crd_compute_out(callers[i], &sub, &e, &n, &t) != 0)
+      if (crd_compute_out(callers[i], &sub, &e, &n, &t, NULL) != 0)
       {
          /* A per-caller failure (transient DB/OOM) must not be silently swallowed:
           * flag the result partial (§4.2) so a reverse read cannot masquerade as a
@@ -1088,11 +1134,14 @@ static int crd_compute_in(const char *target, const xrepo_deps_opts_t *opts, edg
    return 0;
 }
 
-/* Public entry: dispatch on direction. OUT delegates to the core engine; IN and
- * BOTH layer the reverse traversal (crd_compute_in) on top, reusing OUT per caller
- * for symmetric consistency (§B --reverse, §4 direction=in|both). */
-int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t *opts,
-                                    xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated)
+/* Public entry (extended): dispatch on direction and, under --dry-run, also return
+ * the AMBIGUOUS candidates captured in-memory. OUT delegates to the core engine; IN
+ * and BOTH layer the reverse traversal (crd_compute_in) on top, reusing OUT per
+ * caller for symmetric consistency (§B --reverse, §4 direction=in|both). Ambiguous
+ * capture applies to the forward (OUT) computation only. */
+int canonical_index_cross_repo_deps_ex(const char *project, const xrepo_deps_opts_t *opts,
+                                       xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated,
+                                       xrepo_amb_cand_t **out_amb, size_t *out_amb_n)
 {
    if (out_edges)
       *out_edges = NULL;
@@ -1100,41 +1149,82 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
       *out_n = 0;
    if (truncated)
       *truncated = 0;
+   if (out_amb)
+      *out_amb = NULL;
+   if (out_amb_n)
+      *out_amb_n = 0;
    if (!project || !opts || !out_edges || !out_n)
       return -1;
 
-   if (opts->direction == XREPO_DIR_OUT)
-      return crd_compute_out(project, opts, out_edges, out_n, truncated);
+   /* Capture AMBIGUOUS candidates in-memory only when the caller wants them and
+    * we are in dry-run (forward computation). */
+   amb_acc_t amb = {0};
+   amb_acc_t *ambp = (out_amb && opts->dry_run) ? &amb : NULL;
 
-   /* IN or BOTH: build a fresh accumulator. For BOTH, seed it with the forward
-    * (OUT) edges, then append the reverse (IN) edges. */
-   edge_acc_t agg = {0};
-   int trunc = 0;
-   if (opts->direction == XREPO_DIR_BOTH)
+   int rc;
+   if (opts->direction == XREPO_DIR_OUT)
    {
-      xrepo_dep_edge_t *oe = NULL;
-      size_t on = 0;
-      int ot = 0;
-      if (crd_compute_out(project, opts, &oe, &on, &ot) != 0)
-         return -1;
-      trunc |= ot;
-      for (size_t i = 0; i < on; i++)
-         if (!agg_push(&agg, &oe[i]))
+      rc = crd_compute_out(project, opts, out_edges, out_n, truncated, ambp);
+   }
+   else
+   {
+      /* IN or BOTH: build a fresh accumulator. For BOTH, seed it with the forward
+       * (OUT) edges (capturing ambiguous), then append the reverse (IN) edges. */
+      edge_acc_t agg = {0};
+      int trunc = 0;
+      rc = 0;
+      if (opts->direction == XREPO_DIR_BOTH)
+      {
+         xrepo_dep_edge_t *oe = NULL;
+         size_t on = 0;
+         int ot = 0;
+         if (crd_compute_out(project, opts, &oe, &on, &ot, ambp) != 0)
          {
-            free(oe);
-            free(agg.e);
+            free(amb.c);
             return -1;
          }
-      free(oe);
+         trunc |= ot;
+         for (size_t i = 0; i < on; i++)
+            if (!agg_push(&agg, &oe[i]))
+            {
+               free(oe);
+               free(agg.e);
+               free(amb.c);
+               return -1;
+            }
+         free(oe);
+      }
+      if (crd_compute_in(project, opts, &agg, &trunc) != 0)
+      {
+         free(agg.e);
+         free(amb.c);
+         return -1;
+      }
+      *out_edges = agg.e;
+      *out_n = agg.n;
+      if (truncated)
+         *truncated = trunc;
    }
-   if (crd_compute_in(project, opts, &agg, &trunc) != 0)
+
+   if (rc != 0)
    {
-      free(agg.e);
-      return -1;
+      free(amb.c);
+      return rc;
    }
-   *out_edges = agg.e;
-   *out_n = agg.n;
-   if (truncated)
-      *truncated = trunc;
+   if (out_amb)
+   {
+      *out_amb = amb.c;
+      if (out_amb_n)
+         *out_amb_n = amb.n;
+   }
+   else
+      free(amb.c);
    return 0;
+}
+
+/* Public entry: edges only (ambiguous candidates ignored). */
+int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t *opts,
+                                    xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated)
+{
+   return canonical_index_cross_repo_deps_ex(project, opts, out_edges, out_n, truncated, NULL, NULL);
 }

--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -1226,5 +1226,6 @@ int canonical_index_cross_repo_deps_ex(const char *project, const xrepo_deps_opt
 int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t *opts,
                                     xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated)
 {
-   return canonical_index_cross_repo_deps_ex(project, opts, out_edges, out_n, truncated, NULL, NULL);
+   return canonical_index_cross_repo_deps_ex(project, opts, out_edges, out_n, truncated, NULL,
+                                             NULL);
 }

--- a/src/db2/cross_repo_deps.h
+++ b/src/db2/cross_repo_deps.h
@@ -63,7 +63,25 @@ typedef struct
    xrepo_tier_t min_tier; /* emit edges at >= this tier (default MEDIUM) */
    int max_candidates;    /* candidate cap (§4.2); <=0 uses the config default */
    int include_review;    /* 1 = also write AMBIGUOUS candidates to the review queue (S4b) */
+   /* --dry-run (§B, acceptance #4): offline candidate inspection. Emits ALL
+    * confidence bands down to LOW (not just >= min_tier) and captures the
+    * AMBIGUOUS candidates in-memory (via the _ex out params) instead of writing
+    * the review queue — so LOW/AMBIGUOUS surface only here, never in default
+    * output, and nothing is materialized. Forces include_review off. */
+   int dry_run;
 } xrepo_deps_opts_t;
+
+/* One candidate the resolver classified AMBIGUOUS (multiple corroboration-worthy
+ * definers, no dominant): surfaced inline only under --dry-run; in normal
+ * operation these route to the review queue (S4b) rather than being emitted. */
+typedef struct
+{
+   char symbol[128];
+   char caller_repo[128];
+   char candidate_definer[128]; /* deterministic representative definer */
+   double evidence_score;
+   char evidence[512]; /* JSON: {symbol, definers, sites, files, reason} */
+} xrepo_amb_cand_t;
 
 /* Parse a module/package id from a manifest file's content (pure; used to build
  * repo descriptors, and unit-tested directly). `basename` selects the format:
@@ -78,5 +96,14 @@ int xrepo_parse_module_id(const char *basename, const char *content, char *out, 
  * Returns 0 on success, -1 on error (out_edges set to NULL, out_n to 0). */
 int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t *opts,
                                     xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated);
+
+/* Extended form used by --dry-run: additionally returns the AMBIGUOUS candidates
+ * captured in-memory (heap array into *out_amb, count into *out_amb_n; caller frees
+ * with free()). Pass out_amb/out_amb_n as NULL to ignore (the plain
+ * canonical_index_cross_repo_deps forwards NULL). Ambiguous capture applies to the
+ * forward (OUT) computation; under direction=in it is not populated. */
+int canonical_index_cross_repo_deps_ex(const char *project, const xrepo_deps_opts_t *opts,
+                                       xrepo_dep_edge_t **out_edges, size_t *out_n, int *truncated,
+                                       xrepo_amb_cand_t **out_amb, size_t *out_amb_n);
 
 #endif /* AIMEE_CROSS_REPO_DEPS_H */

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -1072,9 +1072,12 @@ int kb_client_index_find_callers(const char *project, const char *symbol, caller
 /* S6: cross-repo dependency edges for `project` (required). `direction`
  * (out|in|both), `min_tier` (high|medium|tentative) may be NULL/empty for the kb
  * defaults; status_ambiguous!=0 requests the AMBIGUOUS review queue instead of
- * edges. Returns the raw kb JSON body (caller frees) or NULL if kb unreachable. */
+ * edges; dry_run!=0 requests offline candidate inspection (all bands + inline
+ * ambiguous, no writes). Returns the raw kb JSON body (caller frees) or NULL if kb
+ * unreachable. */
 char *kb_client_index_cross_repo_deps_json(const char *project, const char *direction,
-                                           const char *min_tier, int status_ambiguous);
+                                           const char *min_tier, int status_ambiguous,
+                                           int dry_run);
 
 /* S7: POST a per-repo trust change to the kb (project + trust required, actor +
  * request_id optional). Returns the raw kb JSON body on 2xx (caller frees); NULL

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -1076,8 +1076,7 @@ int kb_client_index_find_callers(const char *project, const char *symbol, caller
  * ambiguous, no writes). Returns the raw kb JSON body (caller frees) or NULL if kb
  * unreachable. */
 char *kb_client_index_cross_repo_deps_json(const char *project, const char *direction,
-                                           const char *min_tier, int status_ambiguous,
-                                           int dry_run);
+                                           const char *min_tier, int status_ambiguous, int dry_run);
 
 /* S7: POST a per-repo trust change to the kb (project + trust required, actor +
  * request_id optional). Returns the raw kb JSON body on 2xx (caller frees); NULL

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -627,12 +627,14 @@ static int handle_get_code_cross_repo_review(const char *project, char *out_buf,
 
 int handle_get_code_cross_repo_deps(const char *query_string, char *out_buf, int out_cap)
 {
-   char project[256] = "", dir_s[16] = "", tier_s[16] = "", status_s[16] = "";
+   char project[256] = "", dir_s[16] = "", tier_s[16] = "", status_s[16] = "", dry_s[8] = "";
    if (!code_qparam(query_string, "project", project, sizeof(project)) || !project[0])
       return code_scan_write_error(out_buf, out_cap, "missing project");
    code_qparam(query_string, "direction", dir_s, sizeof(dir_s));
    code_qparam(query_string, "min_tier", tier_s, sizeof(tier_s));
    code_qparam(query_string, "status", status_s, sizeof(status_s));
+   code_qparam(query_string, "dry_run", dry_s, sizeof(dry_s));
+   int dry_run = (strcmp(dry_s, "1") == 0 || strcmp(dry_s, "true") == 0);
 
    if (strcmp(status_s, "ambiguous") == 0)
       return handle_get_code_cross_repo_review(project, out_buf, out_cap);
@@ -655,13 +657,18 @@ int handle_get_code_cross_repo_deps(const char *query_string, char *out_buf, int
          return 400;
       }
    }
-   xrepo_deps_opts_t opts = {
-       .min_tier = crd_parse_min_tier(tier_s), .direction = dir, .include_review = 0};
+   xrepo_deps_opts_t opts = {.min_tier = crd_parse_min_tier(tier_s),
+                             .direction = dir,
+                             .include_review = 0,
+                             .dry_run = dry_run};
 
    xrepo_dep_edge_t *edges = NULL;
    size_t n = 0;
    int trunc = 0;
-   if (canonical_index_cross_repo_deps(project, &opts, &edges, &n, &trunc) != 0)
+   xrepo_amb_cand_t *amb = NULL;
+   size_t amb_n = 0;
+   if (canonical_index_cross_repo_deps_ex(project, &opts, &edges, &n, &trunc,
+                                          dry_run ? &amb : NULL, dry_run ? &amb_n : NULL) != 0)
    {
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"canonical index unavailable\"}");
       return 503;
@@ -669,6 +676,7 @@ int handle_get_code_cross_repo_deps(const char *query_string, char *out_buf, int
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
    {
+      free(amb);
       free(edges);
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
       return 500;
@@ -676,6 +684,8 @@ int handle_get_code_cross_repo_deps(const char *query_string, char *out_buf, int
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddStringToObject(resp, "project", project);
    cJSON_AddBoolToObject(resp, "truncated", trunc ? 1 : 0);
+   if (dry_run)
+      cJSON_AddBoolToObject(resp, "dry_run", 1);
    cJSON *arr = cJSON_AddArrayToObject(resp, "deps");
    for (size_t i = 0; arr && i < n; i++)
    {
@@ -712,6 +722,29 @@ int handle_get_code_cross_repo_deps(const char *query_string, char *out_buf, int
       cJSON_AddItemToArray(arr, e);
    }
    free(edges); /* cJSON has copied every field */
+
+   /* --dry-run: surface the AMBIGUOUS candidates the pipeline held back (would
+    * normally go to the review queue) so offline inspection sees every band. */
+   if (dry_run)
+   {
+      cJSON *aarr = cJSON_AddArrayToObject(resp, "ambiguous");
+      for (size_t i = 0; aarr && i < amb_n; i++)
+      {
+         cJSON *a = cJSON_CreateObject();
+         cJSON_AddStringToObject(a, "symbol", amb[i].symbol);
+         cJSON_AddStringToObject(a, "caller_repo", amb[i].caller_repo);
+         cJSON_AddStringToObject(a, "candidate_definer", amb[i].candidate_definer);
+         cJSON_AddStringToObject(a, "review_class", "ambiguous");
+         cJSON_AddNumberToObject(a, "evidence_score", amb[i].evidence_score);
+         cJSON *ev = cJSON_Parse(amb[i].evidence); /* embed as object, else raw string */
+         if (ev)
+            cJSON_AddItemToObject(a, "evidence", ev);
+         else
+            cJSON_AddStringToObject(a, "evidence", amb[i].evidence);
+         cJSON_AddItemToArray(aarr, a);
+      }
+   }
+   free(amb); /* cJSON has copied every field */
    return crd_emit(resp, out_buf, out_cap);
 }
 

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -667,8 +667,8 @@ int handle_get_code_cross_repo_deps(const char *query_string, char *out_buf, int
    int trunc = 0;
    xrepo_amb_cand_t *amb = NULL;
    size_t amb_n = 0;
-   if (canonical_index_cross_repo_deps_ex(project, &opts, &edges, &n, &trunc,
-                                          dry_run ? &amb : NULL, dry_run ? &amb_n : NULL) != 0)
+   if (canonical_index_cross_repo_deps_ex(project, &opts, &edges, &n, &trunc, dry_run ? &amb : NULL,
+                                          dry_run ? &amb_n : NULL) != 0)
    {
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"canonical index unavailable\"}");
       return 503;

--- a/src/server/kb_client_index.c
+++ b/src/server/kb_client_index.c
@@ -659,7 +659,7 @@ int kb_client_index_find_callers(const char *project, const char *symbol, caller
  * same passthrough idiom as kb_client_index_blast_radius_preview_json. Caller frees
  * the returned string; NULL means the kb was unreachable or returned no body. */
 char *kb_client_index_cross_repo_deps_json(const char *project, const char *direction,
-                                           const char *min_tier, int status_ambiguous)
+                                           const char *min_tier, int status_ambiguous, int dry_run)
 {
    if (!project || !project[0])
       return NULL;
@@ -677,7 +677,7 @@ char *kb_client_index_cross_repo_deps_json(const char *project, const char *dire
    }
 
    size_t path_len =
-       strlen("/v1/code/cross-repo-deps?project=&direction=&min_tier=&status=ambiguous") +
+       strlen("/v1/code/cross-repo-deps?project=&direction=&min_tier=&status=ambiguous&dry_run=1") +
        strlen(project_q) + (direction_q ? strlen(direction_q) : 0) +
        (min_tier_q ? strlen(min_tier_q) : 0) + 8;
    char *path = malloc(path_len);
@@ -688,10 +688,10 @@ char *kb_client_index_cross_repo_deps_json(const char *project, const char *dire
       free(min_tier_q);
       return NULL;
    }
-   snprintf(path, path_len, "/v1/code/cross-repo-deps?project=%s%s%s%s%s%s", project_q,
+   snprintf(path, path_len, "/v1/code/cross-repo-deps?project=%s%s%s%s%s%s%s", project_q,
             direction_q ? "&direction=" : "", direction_q ? direction_q : "",
             min_tier_q ? "&min_tier=" : "", min_tier_q ? min_tier_q : "",
-            status_ambiguous ? "&status=ambiguous" : "");
+            status_ambiguous ? "&status=ambiguous" : "", dry_run ? "&dry_run=1" : "");
    free(project_q);
    free(direction_q);
    free(min_tier_q);

--- a/src/server/server_state_index.c
+++ b/src/server/server_state_index.c
@@ -46,8 +46,11 @@ int handle_index_deps(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
        strcmp(min_tier, "tentative") != 0)
       return server_send_error(conn, "min_tier must be high, medium, or tentative", NULL);
 
-   char *json =
-       kb_client_index_cross_repo_deps_json(project, direction, min_tier, status_ambiguous);
+   cJSON *dr = cJSON_GetObjectItemCaseSensitive(req, "dry_run");
+   int dry_run = cJSON_IsTrue(dr);
+
+   char *json = kb_client_index_cross_repo_deps_json(project, direction, min_tier, status_ambiguous,
+                                                     dry_run);
    cJSON *resp = json ? cJSON_Parse(json) : NULL;
    free(json);
    if (!resp)

--- a/src/tests/test_cross_repo_deps_orch.c
+++ b/src/tests/test_cross_repo_deps_orch.c
@@ -211,6 +211,43 @@ static void test_ambiguous_to_review(void)
    printf("ok\n");
 }
 
+/* --dry-run (acceptance #4): the AMBIGUOUS candidate the pipeline holds back
+ * (AmbiguousThing, route-backed multi-definer, seeded by test_ambiguous_to_review)
+ * is captured in-memory via the _ex out params rather than written — offline
+ * inspection sees it inline while normal output never does. */
+static void test_dry_run_candidates(void)
+{
+   printf("test_dry_run_candidates... ");
+   xrepo_deps_opts_t opts = {
+       .direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_MEDIUM, .dry_run = 1};
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+   xrepo_amb_cand_t *amb = NULL;
+   size_t amb_n = 0;
+   assert(canonical_index_cross_repo_deps_ex("moonlight-qt", &opts, &edges, &n, &trunc, &amb,
+                                             &amb_n) == 0);
+   /* the ambiguous candidate is surfaced in-memory (not as an emitted edge). */
+   int found = 0;
+   for (size_t i = 0; i < amb_n; i++)
+      if (strcmp(amb[i].symbol, "AmbiguousThing") == 0 &&
+          strcmp(amb[i].caller_repo, "moonlight-qt") == 0)
+         found = 1;
+   assert(found);
+   /* AmbiguousThing is never an emitted edge, dry-run or not. */
+   for (size_t i = 0; i < n; i++)
+      assert(strcmp(edges[i].example_symbol, "AmbiguousThing") != 0);
+   free(edges);
+   free(amb);
+
+   /* the plain API ignores ambiguous candidates and never captures them. */
+   edges = NULL;
+   n = 0;
+   assert(canonical_index_cross_repo_deps("moonlight-qt", &opts, &edges, &n, &trunc) == 0);
+   free(edges);
+   printf("ok\n");
+}
+
 /* H1 structural-edge gate in isolation: an otherwise-HIGH candidate (distinctive,
  * single trusted definer, import + call) is NOT emitted while no cross_repo_route
  * exists; inserting the route flips it to an edge. The route is the ONLY variable. */
@@ -1074,6 +1111,7 @@ int main(void)
    test_end_to_end();
    test_reverse_direction();
    test_ambiguous_to_review();
+   test_dry_run_candidates();
    test_structural_edge_gate();
    test_cold_start_rebuild_to_gate();
    test_vendor_canonical_preference();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -97,6 +97,25 @@ int canonical_index_cross_repo_deps(const char *project, const void *opts, void 
    return 0;
 }
 
+int canonical_index_cross_repo_deps_ex(const char *project, const void *opts, void *out_edges,
+                                       size_t *out_n, int *truncated, void *out_amb,
+                                       size_t *out_amb_n)
+{
+   (void)project;
+   (void)opts;
+   if (out_edges)
+      *(void **)out_edges = NULL;
+   if (out_n)
+      *out_n = 0;
+   if (truncated)
+      *truncated = 0;
+   if (out_amb)
+      *(void **)out_amb = NULL;
+   if (out_amb_n)
+      *out_amb_n = 0;
+   return 0;
+}
+
 int db2_cross_repo_review_list(const char *caller_repo, const char *status, void *out, int max,
                                int64_t *overflow_dropped)
 {


### PR DESCRIPTION
## Summary
Implements `aimee index deps --dry-run` (acceptance #4) — offline candidate inspection for the cross-repo dependency resolver. Second closeout slice of the **cross-repo-dependency-graph** proposal (follows #937 `--reverse`).

## Behaviour
`--dry-run` emits **every confidence band down to LOW** (not just `>= min_tier`) and surfaces the **AMBIGUOUS candidates inline**, writing **nothing** (no review-queue rows). So LOW/AMBIGUOUS appear *only* under `--dry-run`, never in default output, and nothing is materialized. This makes `--dry-run` meaningfully distinct from `--tier tentative`: the query engine is already non-materializing, so dry-run's value is the full candidate set (incl. the AMBIGUOUS pipeline held back) for offline inspection.

## Approach
- `xrepo_deps_opts_t.dry_run` + new `xrepo_amb_cand_t`. `canonical_index_cross_repo_deps_ex()` returns the AMBIGUOUS candidates captured **in-memory** (an `amb_acc` sink appended in `crd_flush` instead of the review-queue write). The existing `canonical_index_cross_repo_deps()` forwards NULL amb params (API unchanged).
- `dry_run` forces `min_tier=LOW` and `include_review=0` (no writes).
- kb http parses `dry_run`, serializes `dry_run:true` + inline `ambiguous[]`. kb client + server op + CLI `--dry-run` flag + printer (deps down to LOW plus an ambiguous section).
- kb-http-routes test stub for the new `_ex` symbol (link-time gc-sections requirement).
- openapi (v1 + server-v1) + docs-gen refreshed.

## Testing
`test_dry_run_candidates` (ambiguous captured in-memory, never emitted as an edge; plain API ignores it) + full `unit-test-cross-repo-deps-orch` green; kb + server binaries build clean.
