### PR TITLE
feat(delegate): CPU-only Qwen3.6-27B llama.cpp coding delegate + SmoothNAS plugin

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -9,6 +9,7 @@
 #   aimee-kb-cpu        (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-kb-cpu
 #   aimee-kb-gpu-small  (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-kb-gpu-small
 #   aimee-kb-gpu-mid    (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-kb-gpu-mid
+#   aimee-qwen-delegate (Dockerfile.aimee-qwen-delegate) ghcr.io/<owner>/aimee-qwen-delegate
 #   aimee-css-render (deploy/css-render/Dockerfile) ghcr.io/<owner>/aimee-css-render
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
@@ -93,6 +94,11 @@ jobs:
           - { name: aimee-kb-cpu, dockerfile: Dockerfile.aimee-llm }
           - { name: aimee-kb-gpu-small, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF\nSYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=9586f3257bc62bd179767241c7ec0f66bc2a314a\nSYNTH_SHA256=cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165\nSYNTH_FA=on" }
           - { name: aimee-kb-gpu-mid, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/Qwen3.6-35B-A3B-GGUF\nSYNTH_FILE=Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf\nSYNTH_REVISION=56b9b6695c1d341398ea990cf2172ba4311647d8\nSYNTH_SHA256=707a55a8a4397ecde44de0c499d3e68c1ad1d240d1da65826b4949d1043f4450\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=20\nSYNTH_SLOTS=1" }
+          # CPU-only single-model coding delegate: Qwen 3.6 27B UD-Q6_K_XL baked in
+          # (pinned by HF rev+sha256; the profile defaults live in the Dockerfile, so
+          # no extra_args). amd64-only (x64 llama.cpp binary); ~24GB image, so it needs
+          # the /mnt data-root move and skips the layer cache like the baked kb tiers.
+          - { name: aimee-qwen-delegate, dockerfile: Dockerfile.aimee-qwen-delegate }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -128,7 +134,7 @@ jobs:
         # The combined (aimee-server-kb) image now bundles the aimee-llm CPU
         # runtime + ~5.5 GB of baked GGUFs (COPYd from aimee-llm-cpu), so it needs
         # the same disk headroom as the llm legs.
-        if: startsWith(matrix.image.name, 'aimee-kb-') || matrix.image.name == 'aimee-server-kb'
+        if: startsWith(matrix.image.name, 'aimee-kb-') || matrix.image.name == 'aimee-server-kb' || matrix.image.name == 'aimee-qwen-delegate'
         run: |
           echo "before:"; df -h / /mnt
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
@@ -139,7 +145,7 @@ jobs:
           echo "after:"; df -h /
 
       - name: Move docker storage to /mnt (aimee-llm + combined legs)
-        if: startsWith(matrix.image.name, 'aimee-kb-') || matrix.image.name == 'aimee-server-kb'
+        if: startsWith(matrix.image.name, 'aimee-kb-') || matrix.image.name == 'aimee-server-kb' || matrix.image.name == 'aimee-qwen-delegate'
         run: |
           sudo systemctl stop docker docker.socket || true
           sudo mkdir -p /mnt/docker
@@ -153,10 +159,11 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        # aimee-kb-gpu-mid (Qwen, 22GB) is amd64-only: arm64 would bake a non-runnable
-        # x64 Vulkan binary and double the 22GB build/disk cost. Skip it on arm64 -> the
-        # merge job emits a single-arch amd64 manifest (it tolerates count>=1).
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        # aimee-kb-gpu-mid (Qwen, 22GB) and aimee-qwen-delegate (Qwen 27B, ~24GB) are
+        # amd64-only: arm64 would bake a non-runnable x64 llama.cpp binary and double
+        # the build/disk cost. Skip them on arm64 -> the merge job emits a single-arch
+        # amd64 manifest (it tolerates count>=1).
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-qwen-delegate') && matrix.platform.arch == 'arm64') }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context || '.' }}
@@ -173,8 +180,8 @@ jobs:
           # layer cache. Same exclusion for the aimee-kb-* tiers: they BAKE multi-GB
           # GGUFs (Qwen3-Embedding + gemma) into the image, so caching those layers
           # would likewise blow the 10 GB GHA budget and evict the C-image caches.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-qwen-delegate' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-qwen-delegate' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
@@ -199,13 +206,13 @@ jobs:
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-qwen-delegate') && matrix.platform.arch == 'arm64') }}
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.image.name }}-${{ matrix.platform.arch }}"
 
       - name: Upload digest
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-qwen-delegate') && matrix.platform.arch == 'arm64') }}
         uses: actions/upload-artifact@v4
         with:
           name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}
@@ -220,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-kb-cpu, aimee-kb-gpu-small, aimee-kb-gpu-mid, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-kb-cpu, aimee-kb-gpu-small, aimee-kb-gpu-mid, aimee-qwen-delegate, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/.github/workflows/publish-llm-testing.yml
+++ b/.github/workflows/publish-llm-testing.yml
@@ -31,6 +31,10 @@ on:
         description: "Also build the 22GB aimee-kb-gpu-mid (Qwen 3.6 35B-A3B synth)"
         type: boolean
         default: false
+      build_qwen_delegate:
+        description: "Also build the ~24GB aimee-qwen-delegate (Qwen 3.6 27B CPU coding delegate)"
+        type: boolean
+        default: false
 
 concurrency:
   group: publish-llm-testing-${{ github.ref }}
@@ -174,3 +178,61 @@ jobs:
           tags: |
             ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing
             ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing-${{ env.SHA7 }}
+
+  # aimee-qwen-delegate (Qwen 3.6 27B UD-Q6_K_XL, ~24GB CPU coding delegate): the
+  # baked model + llama.cpp rarely change, so like kb-gpu-mid it is NOT built on every
+  # push — dispatch-only (build_qwen_delegate=true). Same disk story: relocate docker's
+  # data-root to /mnt before buildx, plus a df pre-flight. amd64-only (x64 binary).
+  build-qwen-delegate:
+    if: github.event_name == 'workflow_dispatch' && inputs.build_qwen_delegate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize owner + short sha
+        run: |
+          echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+          echo "SHA7=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Free disk + move docker storage to /mnt
+        run: |
+          echo "before:"; df -h / /mnt
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
+          sudo docker image prune --all --force || true
+          sudo systemctl stop docker docker.socket || true
+          sudo mkdir -p /mnt/docker
+          printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker || true
+          echo "after:"; df -h / /mnt
+
+      - name: Pre-flight disk check
+        run: |
+          avail=$(df --output=avail -BG /mnt | tail -1 | tr -dc '0-9')
+          echo "/mnt available: ${avail}GB"
+          if [ "${avail:-0}" -lt 80 ]; then
+            echo "::error::/mnt has only ${avail}GB free; need >=80GB for the ~24GB qwen-delegate build"; exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push aimee-qwen-delegate:testing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.aimee-qwen-delegate
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          # No build-args: the model pins + runtime profile are the Dockerfile defaults.
+          tags: |
+            ghcr.io/${{ env.OWNER }}/aimee-qwen-delegate:testing
+            ghcr.io/${{ env.OWNER }}/aimee-qwen-delegate:testing-${{ env.SHA7 }}

--- a/Dockerfile.aimee-qwen-delegate
+++ b/Dockerfile.aimee-qwen-delegate
@@ -1,0 +1,98 @@
+# aimee-qwen-delegate: a single-model, OpenAI-compatible coding delegate served on
+# the CPU llama.cpp build. One baked GGUF (Qwen 3.6 27B), one `llama-server`, no GPU.
+#
+# Qwen 3.6 27B is a DENSE model with a Gated-DeltaNet HYBRID attention stack (64
+# layers = 16 blocks x [3 Gated-DeltaNet + 1 Gated-Attention]); only the 16 attention
+# layers keep a KV cache (the linear DeltaNet layers do not), so a large aggregate
+# context (this image defaults to 4 slots x 128K = 512K) stays affordable on system
+# RAM. Native context is 262K, so each 128K slot sits below native -> no RoPE/YaRN
+# scaling. It runs on the SAME llama.cpp release (b9775) that already serves its MoE
+# sibling (Qwen 3.6 35B-A3B) in aimee, so the architecture is supported.
+#
+# Model is baked in and pinned by HF revision OID + sha256 so a compromised/MITM'd
+# upload fails the BUILD, not production (matches the aimee-kb synth tiers). Register
+# the running container as an aimee delegate: `aimee agent local qwen3.6-27b
+# http://<host>:8744/v1 --model qwen3.6-27b --provider openai --slots 4 --ctx 131072`.
+
+ARG LLAMA_TAG=b9775
+
+# Model + supply-chain pins.
+ARG SYNTH_REPO=unsloth/Qwen3.6-27B-GGUF
+ARG SYNTH_FILE=Qwen3.6-27B-UD-Q6_K_XL.gguf
+ARG SYNTH_REVISION=82d411acf4a06cfb8d9b073a5211bf410bfc29bf
+ARG SYNTH_SHA256=8746881d40f280b1b6b858c656a347c754ed3d9cc8d2e1ad46b3635b87f611f8
+
+# ---- stage 1: fetch + integrity-verify the baked GGUF (fail build on mismatch) ---
+FROM debian:bookworm-slim AS modelprep
+ARG SYNTH_REPO
+ARG SYNTH_FILE
+ARG SYNTH_REVISION
+ARG SYNTH_SHA256
+RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /out
+# Pin by REVISION OID (not just :main) so the bytes can't shift under us, then verify
+# the recorded sha256 -- a compromised HF upload or MITM mirror fails here.
+# --tries/--timeout so a transient HF blip during the ~24GB pull doesn't
+# deterministically kill the build; -c resumes a partial file.
+RUN wget -q -c --tries=5 --timeout=30 --waitretry=10 -O /out/synth.gguf \
+        "https://huggingface.co/${SYNTH_REPO}/resolve/${SYNTH_REVISION}/${SYNTH_FILE}" \
+    && echo "${SYNTH_SHA256}  /out/synth.gguf" | sha256sum -c - \
+    && echo "${SYNTH_SHA256}  synth.gguf" > /out/synth.sha256
+
+# ---- stage 2: runtime — CPU llama.cpp + the delegate entrypoint ------------------
+FROM debian:bookworm-slim AS runtime
+ARG LLAMA_TAG
+# CPU-only runtime: no libvulkan1/mesa (this image never touches a GPU). libgomp1 is
+# OpenMP for the CPU backend; libcurl4 for llama-server's optional HTTP bits.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl wget libgomp1 libcurl4 \
+    && rm -rf /var/lib/apt/lists/*
+# CPU llama.cpp release (ubuntu-x64, NOT the -vulkan- build). amd64-only binary.
+RUN wget -q --tries=5 --timeout=30 --waitretry=10 -O /tmp/llama.tgz \
+        "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_TAG}/llama-${LLAMA_TAG}-bin-ubuntu-x64.tar.gz" \
+    && mkdir -p /opt/llama && tar -xzf /tmp/llama.tgz -C /opt/llama --strip-components=1 \
+    && rm /tmp/llama.tgz
+ENV LD_LIBRARY_PATH=/opt/llama/lib:/opt/llama PATH=/opt/llama:/opt/llama/bin:$PATH
+
+COPY scripts/aimee-qwen-delegate-entrypoint.sh /opt/aimee/entrypoint.sh
+COPY scripts/aimee-qwen-delegate-health.sh /opt/aimee/health.sh
+RUN chmod +x /opt/aimee/entrypoint.sh /opt/aimee/health.sh
+COPY --from=modelprep /out /models
+
+# Re-declare the pins in the runtime stage so they can be surfaced as image LABELs
+# (operator audit: what's actually baked).
+ARG SYNTH_REPO
+ARG SYNTH_FILE
+ARG SYNTH_REVISION
+ARG SYNTH_SHA256
+LABEL org.aimee.delegate.model="${SYNTH_REPO}/${SYNTH_FILE}" \
+      org.aimee.delegate.revision="${SYNTH_REVISION}" \
+      org.aimee.delegate.sha256="${SYNTH_SHA256}"
+
+# ---- runtime profile: baked as ENV, overridable at deploy (plugin config) ---------
+# Defaults implement the operator request: CPU-only, 4 slots x 128K = 512K aggregate,
+# q8_0 KV + flash-attention to keep the 512K KV affordable in system RAM. Flip to
+# AIMEE_DELEGATE_FA=off + AIMEE_DELEGATE_KV_K/V=f16 (no rebuild) if CPU FA misbehaves.
+ARG DELEGATE_CTX=524288
+ARG DELEGATE_SLOTS=4
+ARG DELEGATE_THREADS=16
+ARG DELEGATE_MODEL_ID=qwen3.6-27b
+ENV AIMEE_DELEGATE_PORT=8744 \
+    AIMEE_DELEGATE_CTX=${DELEGATE_CTX} \
+    AIMEE_DELEGATE_SLOTS=${DELEGATE_SLOTS} \
+    AIMEE_DELEGATE_THREADS=${DELEGATE_THREADS} \
+    AIMEE_DELEGATE_NGL=0 \
+    AIMEE_DELEGATE_FA=on \
+    AIMEE_DELEGATE_KV_K=q8_0 \
+    AIMEE_DELEGATE_KV_V=q8_0 \
+    AIMEE_DELEGATE_JINJA=1 \
+    AIMEE_DELEGATE_MODEL_ID=${DELEGATE_MODEL_ID}
+
+WORKDIR /opt/aimee
+EXPOSE 8744
+# Long start-period: cold-loading a ~24GB GGUF into RAM on CPU takes minutes; a short
+# gate would race the load and cause restart storms that re-read the file each time.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=600s --retries=3 \
+    CMD /opt/aimee/health.sh || exit 1
+ENTRYPOINT ["/opt/aimee/entrypoint.sh"]

--- a/deploy/smoothnas/aimee-qwen-delegate.plugin.yaml
+++ b/deploy/smoothnas/aimee-qwen-delegate.plugin.yaml
@@ -1,0 +1,72 @@
+apiVersion: smoothnas.io/v1
+kind: Plugin
+metadata:
+  name: aimee-qwen-delegate
+  version: 0.1.0
+  description: >-
+    aimee-qwen-delegate — a CPU-only, single-model OpenAI-compatible coding
+    delegate: one llama.cpp `llama-server` serving a baked Qwen 3.6 27B GGUF
+    (UD-Q6_K_XL), defaulting to 4 slots x 128K = 512K aggregate context with
+    q8_0 KV + flash-attention. Register it against aimee-server as a local
+    delegate (`aimee agent local qwen3.6-27b http://10.100.0.1:8744/v1 --model
+    qwen3.6-27b --provider openai --slots 4 --ctx 131072`). CPU-only: no GPU
+    profile, never touches the 7900 XTX used by the aimee-llm/Wolf stack.
+  vendor: RakuenSoftware
+  homepage: https://github.com/RakuenSoftware/aimee
+profiles:
+  # CPU-only: default-limits ONLY. Deliberately NO `gpu-amd` profile — this
+  # delegate runs entirely on the EPYC cores (AIMEE_DELEGATE_NGL=0) and must not
+  # claim the GPU that aimee-llm (embed/rerank/synth) and Wolf share.
+  - default-limits
+services:
+  - name: delegate
+    artifact:
+      type: oci-image
+      # The checked-in default is the stable released tag (owned by main /
+      # auto-release.yml -> publish-images.yml). To validate a tested-but-unreleased
+      # build, DON'T edit this file — pin the :testing image at deploy time via the
+      # tierd image override (`PUT /api/plugins/aimee-qwen-delegate/image
+      # {"image":"ghcr.io/rakuensoftware/aimee-qwen-delegate:testing"}`), which
+      # persists across manifest updates. Mirrors deploy/smoothnas/aimee-llm.plugin.yaml.
+      image: ghcr.io/rakuensoftware/aimee-qwen-delegate:latest
+    container:
+      restartPolicy: unless-stopped
+    env:
+      # --- runtime profile (baked defaults in the image; override here to retune
+      #     WITHOUT a rebuild) --------------------------------------------------
+      # 4 slots x 128K = 512K aggregate. CTX is the aggregate; each slot gets
+      # CTX/SLOTS (131072). Each slot stays below the 262K native ctx -> no RoPE
+      # scaling. Only the 16 Gated-Attention layers keep a KV cache.
+      AIMEE_DELEGATE_CTX: "524288"
+      AIMEE_DELEGATE_SLOTS: "4"
+      # Physical cores on the EPYC 7302P (16c/32t). Leave headroom for the GPU stack.
+      AIMEE_DELEGATE_THREADS: "16"
+      # CPU-only.
+      AIMEE_DELEGATE_NGL: "0"
+      # q8_0 KV + flash-attention keeps 512K of KV affordable in RAM. If CPU FA
+      # misbehaves on this llama.cpp build, flip to FA=off + f16 KV (higher RAM,
+      # guaranteed to run) and re-materialise — no image rebuild needed:
+      #   AIMEE_DELEGATE_FA: "off"
+      #   AIMEE_DELEGATE_KV_K: "f16"
+      #   AIMEE_DELEGATE_KV_V: "f16"
+      AIMEE_DELEGATE_FA: "on"
+      AIMEE_DELEGATE_KV_K: "q8_0"
+      AIMEE_DELEGATE_KV_V: "q8_0"
+      AIMEE_DELEGATE_MODEL_ID: "qwen3.6-27b"
+      AIMEE_DELEGATE_PORT: "8744"
+      # Bearer auth for /v1. Leave EMPTY/unset = auth-off ("deployment network is
+      # the boundary" — the port is hostExpose-only, reachable on the internal
+      # bridge, and aimee delegates register with auth_type:none). If you set one,
+      # provide it at deploy time from the secret store, never checked-in plaintext.
+      # AIMEE_LLM_AUTH_TOKEN: "<set-at-deploy-time-not-in-git>"
+    ports:
+      # OpenAI-compatible /v1 endpoint. hostExpose so aimee-server can reach it
+      # across the runtime bridge gateway at http://10.100.0.1:8744. 8744 avoids
+      # every other installed plugin's host port (8740 server / 8741 kb / 8742 llm
+      # / 8443 webchat / 8743 TLS / 8080 wolf) — a collision silently DNATs one
+      # winner and leaves the other unreachable though "running". Not exposed off-host.
+      - name: v1
+        port: 8744
+        protocol: tcp
+        expose: false
+        hostExpose: true

--- a/docs/AIMEE_QWEN_DELEGATE.md
+++ b/docs/AIMEE_QWEN_DELEGATE.md
@@ -1,0 +1,80 @@
+# aimee-qwen-delegate — CPU-only Qwen 3.6 27B coding delegate
+
+A dedicated, single-model, OpenAI-compatible **coding delegate** for aimee: one
+llama.cpp `llama-server` serving a baked **Qwen 3.6 27B** GGUF entirely on CPU, and
+registered against aimee-server as a local delegate. It is independent of the
+`aimee-llm` embed/rerank/synth stack and does not use the GPU.
+
+## Model
+
+| | |
+|---|---|
+| Repo / file | `unsloth/Qwen3.6-27B-GGUF` / `Qwen3.6-27B-UD-Q6_K_XL.gguf` |
+| Quant | Unsloth Dynamic 2.0, **Q6_K_XL** (UD) |
+| Size | ~23.9 GiB (25,636,485,344 bytes) |
+| HF revision | `82d411acf4a06cfb8d9b073a5211bf410bfc29bf` |
+| sha256 | `8746881d40f280b1b6b858c656a347c754ed3d9cc8d2e1ad46b3635b87f611f8` |
+
+The GGUF is **baked into the image** and pinned by revision OID + sha256 (verified at
+build time — a compromised/MITM'd upload fails the build, not production).
+
+## Why 4×128K is affordable on CPU
+
+Qwen 3.6 27B is a **dense** model but uses a **Gated-DeltaNet hybrid** attention stack:
+64 layers = 16 blocks × (3 Gated-DeltaNet + 1 Gated-Attention). The linear DeltaNet
+layers keep **no KV cache**, so only the **16 attention layers** cache KV. That makes a
+large aggregate context practical in system RAM.
+
+- Aggregate context defaults to **512K = 4 slots × 128K** (`--ctx-size 524288
+  --parallel 4`). Each slot gets `CTX/SLOTS = 131072`.
+- Native context is **262K**, so each 128K slot sits below native → **no RoPE/YaRN
+  scaling**.
+- KV defaults to **q8_0 + flash-attention** (`-fa on`), roughly halving KV RAM vs f16.
+
+Runs on llama.cpp **`b9775`**, the same release already serving the MoE sibling
+(Qwen 3.6 35B-A3B) in aimee — so the architecture is supported. CPU-only build
+(`llama-…-bin-ubuntu-x64`, not the Vulkan build); `-ngl 0`.
+
+## Tuning knobs (image ENV; override via plugin config, no rebuild)
+
+| Env | Default | Meaning |
+|---|---|---|
+| `AIMEE_DELEGATE_CTX` | `524288` | aggregate context across all slots |
+| `AIMEE_DELEGATE_SLOTS` | `4` | parallel slots (`--parallel`) |
+| `AIMEE_DELEGATE_THREADS` | `16` | `--threads` (physical cores) |
+| `AIMEE_DELEGATE_NGL` | `0` | GPU layers (0 = CPU-only) |
+| `AIMEE_DELEGATE_FA` | `on` | flash-attention (required for quantized KV) |
+| `AIMEE_DELEGATE_KV_K` / `_KV_V` | `q8_0` / `q8_0` | KV cache types |
+| `AIMEE_DELEGATE_MODEL_ID` | `qwen3.6-27b` | served model alias |
+| `AIMEE_DELEGATE_PORT` | `8744` | listen port |
+| `AIMEE_LLM_AUTH_TOKEN` | *(unset)* | bearer for `/v1`; empty = auth-off |
+
+**RAM fallback:** if flash-attention misbehaves on the CPU build, the server fails
+loudly at load (quantized KV requires FA). Set `AIMEE_DELEGATE_FA=off` +
+`AIMEE_DELEGATE_KV_K=f16` + `AIMEE_DELEGATE_KV_V=f16` and re-materialise — f16 KV is
+guaranteed to run, at higher RAM cost.
+
+## Deploy (SmoothNAS plugin, e.g. .254)
+
+1. Pre-pull the image via the runtime docker socket (ONE detached pull — concurrent
+   pulls of the same tag clobber under LXC2Docker/skopeo).
+2. Install the plugin `deploy/smoothnas/aimee-qwen-delegate.plugin.yaml` via the tierd
+   API (`POST /api/auth/login` → `POST /api/plugins/install` → `materialise` →
+   `start`).
+3. Register it as an aimee delegate (writes `agents.json` + `aimee.yaml` concurrency;
+   the running server mtime-reloads both):
+
+   ```
+   aimee agent local qwen3.6-27b http://10.100.0.1:8744/v1 \
+       --model qwen3.6-27b --provider openai --slots 4 --ctx 131072 \
+       --roles code,reason,execute --cost-tier 0
+   ```
+
+## Verify
+
+- `GET :8744/health` → 200 (allow minutes for the cold load of a ~24GB model on CPU).
+- `POST :8744/v1/chat/completions` (model `qwen3.6-27b`) returns a completion; with
+  `--jinja` the `<think>…</think>` reasoning block parses.
+- `GET :8744/slots` shows **4** slots.
+- `aimee agent probe qwen3.6-27b` → `model_available:true`, `detected_slots:4`,
+  `execution_ok:true`.

--- a/scripts/aimee-qwen-delegate-entrypoint.sh
+++ b/scripts/aimee-qwen-delegate-entrypoint.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# aimee-qwen-delegate: a single-model, OpenAI-compatible coding delegate server on the
+# CPU llama.cpp build. One baked GGUF (Qwen 3.6 27B, dense Gated-DeltaNet hybrid), one
+# `llama-server`, CPU-only (NGL=0). Defaults to 4 slots x 128K = 512K aggregate
+# context with q8_0 KV + flash-attention so the KV cache stays affordable in RAM.
+#
+# Register the running container as an aimee delegate:
+#   aimee agent local qwen3.6-27b http://<host>:8744/v1 \
+#       --model qwen3.6-27b --provider openai --slots 4 --ctx 131072 \
+#       --roles code,reason,execute --cost-tier 0
+set -u
+
+LLAMA=/opt/llama/llama-server
+MODEL=/models/synth.gguf
+LOG=/tmp/llama-server.log
+DEGRADED=/tmp/aimee-delegate-degraded          # sentinel read by the healthcheck
+
+# ---- runtime profile (baked as ENV per image; overridable at deploy) -------------
+PORT="${AIMEE_DELEGATE_PORT:-8744}"
+CTX="${AIMEE_DELEGATE_CTX:-524288}"            # aggregate across all slots
+SLOTS="${AIMEE_DELEGATE_SLOTS:-4}"            # 4 slots -> CTX/SLOTS = 128K each
+THREADS="${AIMEE_DELEGATE_THREADS:-16}"       # physical cores (EPYC 7302P = 16c/32t)
+NGL="${AIMEE_DELEGATE_NGL:-0}"                # 0 = CPU-only (this image ships no GPU libs)
+FA="${AIMEE_DELEGATE_FA:-on}"                 # flash-attention; required for quantized KV
+KV_K="${AIMEE_DELEGATE_KV_K:-q8_0}"
+KV_V="${AIMEE_DELEGATE_KV_V:-q8_0}"
+MODEL_ID="${AIMEE_DELEGATE_MODEL_ID:-qwen3.6-27b}"
+JINJA="${AIMEE_DELEGATE_JINJA:-1}"
+
+log(){ echo "aimee-qwen-delegate: $*" >&2; }
+rm -f "$DEGRADED"
+
+# ---- supply-chain note: the GGUF sha256 is verified at BUILD time (Dockerfile fails
+#      the build on mismatch). We only surface the recorded, build-verified hash here
+#      for operator audit; no ~24GB re-hash on every cold start.
+BAKED_SHA="$( [ -r /models/synth.sha256 ] && cut -d' ' -f1 </models/synth.sha256 || echo unknown )"
+log "model=$MODEL_ID sha256=$BAKED_SHA ctx=$CTX slots=$SLOTS threads=$THREADS ngl=$NGL fa=$FA kv=${KV_K}/${KV_V}"
+
+# ---- assemble llama-server args --------------------------------------------------
+# CPU-only: -ngl 0. Quantized KV cache REQUIRES flash-attention, so the cache-type
+# flags are only passed when FA is on; with FA off we fall back to the default f16 KV
+# (guaranteed to run everywhere, at higher RAM cost).
+args=( --host 0.0.0.0 --port "$PORT" -m "$MODEL" --alias "$MODEL_ID"
+       -ngl "$NGL" --ctx-size "$CTX" --parallel "$SLOTS" --threads "$THREADS" )
+if [ "$FA" = "on" ]; then
+  args+=( -fa on --cache-type-k "$KV_K" --cache-type-v "$KV_V" )
+else
+  log "WARN: flash-attention OFF -> using default f16 KV cache (higher RAM at ${CTX} ctx)"
+fi
+[ "$JINJA" = "1" ] && args+=( --jinja )
+
+# Auth: if a token is set, actually gate /v1 with it. Passing the token to the
+# container but never wiring --api-key would leave /v1 open on the Docker net while
+# operators assume it's protected. llama-server exempts /health from the key, so the
+# readiness/health curls below still work unauthenticated.
+[ -n "${AIMEE_LLM_AUTH_TOKEN:-}" ] && args+=( --api-key "$AIMEE_LLM_AUTH_TOKEN" )
+
+# ---- launch ----------------------------------------------------------------------
+log "starting llama-server: ${args[*]}"
+"$LLAMA" "${args[@]}" >"$LOG" 2>&1 &
+srv=$!
+
+# Graceful shutdown: forward TERM/INT to llama-server and exit 0 so an orchestrator-
+# initiated `docker stop` is NOT recorded as a crash. The EXIT trap is best-effort
+# cleanup for other exit paths.
+# Forward TERM/INT, wait up to ~25s for a graceful exit, then hard-kill so a stuck
+# server can't hang `docker stop` until the orchestrator SIGKILLs the whole container.
+term() {
+  log "received TERM/INT; stopping llama-server"
+  kill -TERM "$srv" 2>/dev/null
+  for _ in $(seq 1 25); do kill -0 "$srv" 2>/dev/null || break; sleep 1; done
+  kill -KILL "$srv" 2>/dev/null
+  exit 0
+}
+trap term TERM INT
+trap 'kill "$srv" 2>/dev/null' EXIT
+
+# ---- readiness wait --------------------------------------------------------------
+# Up to ~20min cold load: a ~24GB GGUF read into RAM plus KV allocation for 512K ctx.
+# Kept comfortably LONGER than the Docker HEALTHCHECK start-period (600s) so a slightly
+# slow first load reports unhealthy transiently rather than making the entrypoint exit
+# and trip a restart loop (restartPolicy restarts on process EXIT). If FA/quantized-KV
+# is unsupported on this CPU build, llama-server errors out at load here -> we surface
+# the tail and exit non-zero (loud failure, not a silent slow path).
+ready=0
+for _ in $(seq 1 1200); do
+  if ! kill -0 "$srv" 2>/dev/null; then
+    log "FATAL: llama-server exited during load; tail:"; tail -n 30 "$LOG" >&2; exit 1
+  fi
+  if curl -fsS --max-time 4 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then ready=1; break; fi
+  sleep 1
+done
+[ "$ready" = 1 ] || { log "FATAL: llama-server not ready within deadline"; tail -n 30 "$LOG" >&2; exit 1; }
+log "llama-server ready on :$PORT"
+
+# ---- post-launch verification (soft) ---------------------------------------------
+# When FA is requested, confirm it actually engaged: quantized KV without FA is a slow
+# dequant path. An EXPLICIT "flash disabled" while KV is quantized trips the degraded
+# sentinel (healthcheck reports unhealthy so the operator flips KV=f16/FA=off);
+# otherwise we only warn -- llama-server would have failed to load if the combo were
+# truly unsupported, so a healthy server is the real signal.
+verify_startup() {
+  local bad=0
+  [ "$FA" = "on" ] || return 0
+  if grep -qiE 'flash[_ ]?att.*(= *1|enabled|: *1|on)' "$LOG"; then
+    log "verified: flash-attention ENGAGED"
+  elif grep -qiE 'flash[_ ]?att.*(= *0|disabled|not supported)' "$LOG"; then
+    log "CRITICAL: flash-attention did NOT engage but KV=${KV_K}/${KV_V} is quantized"
+    log "CRITICAL:   -> set AIMEE_DELEGATE_FA=off + AIMEE_DELEGATE_KV_K/V=f16 and redeploy."
+    bad=1
+  else
+    log "WARN: could not determine flash-attention state from server log (continuing)"
+  fi
+  return $bad
+}
+if ! verify_startup; then
+  : > "$DEGRADED"
+  log "startup verification FAILED -> marked DEGRADED (container will report unhealthy)"
+fi
+
+wait "$srv"
+code=$?
+log "llama-server exited ($code)"
+exit "${code:-1}"

--- a/scripts/aimee-qwen-delegate-health.sh
+++ b/scripts/aimee-qwen-delegate-health.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Healthcheck for the aimee-qwen-delegate container: the model server must be up AND
+# the entrypoint's post-launch verification must not have tripped the degraded
+# sentinel (flash-attention no-op while KV is quantized). Reporting unhealthy on a
+# silent perf regression lets the operator notice a misconfigured KV/FA profile
+# instead of silently shipping degraded throughput.
+set -u
+PORT="${AIMEE_DELEGATE_PORT:-8744}"
+[ -f /tmp/aimee-delegate-degraded ] && { echo "degraded: startup verification failed (see logs)"; exit 1; }
+curl -fsS --max-time 4 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1 || { echo "llama-server /health failed"; exit 1; }
+exit 0


### PR DESCRIPTION
## What

A dedicated, single-model, OpenAI-compatible **coding delegate**: one CPU llama.cpp `llama-server` serving a **baked Qwen3.6-27B UD-Q6_K_XL** GGUF, defaulting to **4 slots × 128K = 512K aggregate** context with `q8_0` KV + flash-attention. Ships as a dedicated image + a **CPU-only SmoothNAS plugin**, to be registered against aimee-server as a local delegate.

## Why it works on CPU

Qwen3.6-27B is **dense** but uses a **Gated-DeltaNet hybrid** attention stack (64 layers = 16 blocks × [3 Gated-DeltaNet + 1 Gated-Attention]); only the **16 attention layers keep a KV cache**, so a 512K aggregate context is affordable in system RAM. Native ctx is **262K**, so each 128K slot sits below native → **no RoPE/YaRN scaling**. Runs on llama.cpp **`b9775`** — the same release already serving the MoE sibling (Qwen3.6-35B-A3B) live — using the CPU `ubuntu-x64` build with `-ngl 0`.

## Files

- `Dockerfile.aimee-qwen-delegate` — 2-stage; GGUF pinned by HF revision OID + sha256 (build fails on mismatch); CPU llama.cpp; runtime profile baked as ENV.
- `scripts/aimee-qwen-delegate-{entrypoint,health}.sh` — env-driven launch (`--ctx-size 524288 --parallel 4 --threads 16 -ngl 0 -fa on --cache-type-k/v q8_0 --jinja`), readiness wait (decoupled from the healthcheck start-period), bounded SIGTERM, degraded sentinel.
- `deploy/smoothnas/aimee-qwen-delegate.plugin.yaml` — CPU-only (no `gpu-amd` profile), `hostExpose` :8744, `:latest` default (pin `:testing` via the tierd image override at deploy time).
- `.github/workflows/publish-images.yml` — matrix + merge entry, `/mnt` data-root move + free-disk guards widened, amd64-only build/export/upload guards, layer-cache exclusion.
- `.github/workflows/publish-llm-testing.yml` — dispatch-only `build-qwen-delegate` job (mirrors the gpu-mid pattern: `/mnt` move + df pre-flight).
- `docs/AIMEE_QWEN_DELEGATE.md` — model/arch, 4×128K rationale, tuning knobs, deploy/register/verify runbook.

## Model pins

`unsloth/Qwen3.6-27B-GGUF` @ `82d411acf4a06cfb8d9b073a5211bf410bfc29bf`, `Qwen3.6-27B-UD-Q6_K_XL.gguf`, sha256 `8746881d40f280b1b6b858c656a347c754ed3d9cc8d2e1ad46b3635b87f611f8` (~23.9 GiB).

## Review

Code was run through the aimee roundtable before opening. Applied: manifest defaults to `:latest` (not `:testing`); readiness deadline decoupled from the healthcheck start-period; bounded SIGTERM wait; `AIMEE_DELEGATE_JINJA` declared. Verified out-of-band: the `llama-b9775-bin-ubuntu-x64.tar.gz` asset exists and extracts `llama-server` to `/opt/llama/llama-server` after `--strip-components=1`.

**Deliberately left consistent with the existing aimee llama.cpp images:** the `b9775` release tarball is pinned by (immutable) tag, not sha256 — matching `Dockerfile.aimee-llm`; a tarball-checksum hardening pass across all llama.cpp images could be a follow-up. Auth-off + `hostExpose` (internal bridge only) matches `aimee-llm.plugin.yaml`.

## Register

```
aimee agent local qwen3.6-27b http://10.100.0.1:8744/v1 \
    --model qwen3.6-27b --provider openai --slots 4 --ctx 131072 \
    --roles code,reason,execute --cost-tier 0
```