### PR TITLE
feat(kb): switch aimee-kb-gpu-mid synth to Gemma 4 26B-A4B (from Qwen 3.6 35B-A3B)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -86,13 +86,14 @@ jobs:
           # model + its runtime profile (embed/rerank identical within a class):
           #   aimee-kb-cpu       defaults: 0.6B emb + ettin-68m + gemma-4-E4B (CPU)
           #   aimee-kb-gpu-small 4B/400m + Gemma-4-12B qat-UD-Q4_K_XL (dense, FA+K8V4)
-          #   aimee-kb-gpu-mid   4B/400m + Qwen3.6-35B-A3B UD-Q4_K_XL (MoE, FA+K8V4 +
-          #                      static --n-cpu-moe; GGUF pinned by HF rev+sha256)
+          #   aimee-kb-gpu-mid   4B/400m + Gemma-4-26B-A4B qat-UD-Q4_K_XL (MoE, 4B active,
+          #                      FA+K8V4; ~14GB fits 24GB fully-resident → N_CPU_MOE=0;
+          #                      GGUF pinned by HF rev+sha256)
           # gpu-small/gpu-mid share the 2560-dim embedder so a KB is portable across the
           # synth swap. amd64 GPU host runs the x64 Vulkan binary; NGL set at deploy.
           - { name: aimee-kb-cpu, dockerfile: Dockerfile.aimee-llm }
           - { name: aimee-kb-gpu-small, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF\nSYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=9586f3257bc62bd179767241c7ec0f66bc2a314a\nSYNTH_SHA256=cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165\nSYNTH_FA=on" }
-          - { name: aimee-kb-gpu-mid, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/Qwen3.6-35B-A3B-GGUF\nSYNTH_FILE=Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf\nSYNTH_REVISION=56b9b6695c1d341398ea990cf2172ba4311647d8\nSYNTH_SHA256=707a55a8a4397ecde44de0c499d3e68c1ad1d240d1da65826b4949d1043f4450\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=20\nSYNTH_SLOTS=1" }
+          - { name: aimee-kb-gpu-mid, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF\nSYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c\nSYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=0\nSYNTH_SLOTS=2" }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -153,9 +154,9 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        # aimee-kb-gpu-mid (Qwen, 22GB) is amd64-only: arm64 would bake a non-runnable
-        # x64 Vulkan binary and double the 22GB build/disk cost. Skip it on arm64 -> the
-        # merge job emits a single-arch amd64 manifest (it tolerates count>=1).
+        # aimee-kb-gpu-mid (Gemma-4-26B-A4B, ~14GB) is amd64-only: arm64 would bake a
+        # non-runnable x64 Vulkan binary and double the build/disk cost. Skip it on arm64
+        # -> the merge job emits a single-arch amd64 manifest (it tolerates count>=1).
         if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/publish-llm-testing.yml
+++ b/.github/workflows/publish-llm-testing.yml
@@ -10,9 +10,9 @@
 # server-code push would be wasteful. So it triggers ONLY on the aimee-kb
 # sources (the Dockerfile + the gateway/supervisor scripts).
 #
-# Tiers built every push: aimee-kb-cpu + aimee-kb-gpu-small (Gemma). The Qwen
-# aimee-kb-gpu-mid (22GB) is dispatch-only. amd64 only (the .254 deploy target); the
-# release pipeline owns
+# Tiers built every push: aimee-kb-cpu + aimee-kb-gpu-small (Gemma). The
+# aimee-kb-gpu-mid (Gemma-4-26B-A4B, ~14GB) is dispatch-only. amd64 only (the .254
+# deploy target); the release pipeline owns
 # multi-arch.
 name: Publish testing aimee-llm
 
@@ -28,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       build_kb_gpu_mid:
-        description: "Also build the 22GB aimee-kb-gpu-mid (Qwen 3.6 35B-A3B synth)"
+        description: "Also build the aimee-kb-gpu-mid (Gemma-4-26B-A4B synth, ~14GB)"
         type: boolean
         default: false
 
@@ -48,8 +48,8 @@ jobs:
       matrix:
         # cpu tier = Dockerfile defaults (0.6B emb + ettin-68m + gemma-4-E4B).
         # gpu-small overrides to the 4B/400m + Gemma-4-12B qat-UD synth (FA+K8V4).
-        # gpu-mid (Qwen 22GB synth) is the dispatch-only job below — a 22GB uncached
-        # build every push is near-zero-signal (model + llama.cpp rarely change).
+        # gpu-mid (Gemma-4-26B-A4B synth, ~14GB) is the dispatch-only job below — an
+        # uncached build every push is near-zero-signal (model + llama.cpp rarely change).
         tier:
           - { name: aimee-kb-cpu, dockerfile: Dockerfile.aimee-llm, extra_args: "" }
           - { name: aimee-kb-gpu-small, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF\nSYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=9586f3257bc62bd179767241c7ec0f66bc2a314a\nSYNTH_SHA256=cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165\nSYNTH_FA=on" }
@@ -99,12 +99,12 @@ jobs:
             ghcr.io/${{ env.OWNER }}/${{ matrix.tier.name }}:testing
             ghcr.io/${{ env.OWNER }}/${{ matrix.tier.name }}:testing-${{ env.SHA7 }}
 
-  # aimee-kb-gpu-mid (Qwen 3.6 35B-A3B synth, 22.4GB MoE): NOT built on every push —
-  # the model + llama.cpp rarely change, so a ~22GB uncached download+build per push is
+  # aimee-kb-gpu-mid (Gemma-4-26B-A4B synth, ~14GB MoE): NOT built on every push —
+  # the model + llama.cpp rarely change, so an uncached download+build per push is
   # near-zero-signal (option (d), 2026-07-01 follow-up roundtable). Runs ONLY on a
-  # manual workflow_dispatch with build_kb_gpu_mid=true. Needs the docker data-root on
-  # /mnt (~65GB) — the ~22GB image's transient build footprint overruns / — plus a df
-  # pre-flight that fails fast rather than dying mid-build with 'no space left'.
+  # manual workflow_dispatch with build_kb_gpu_mid=true. Keeps the docker data-root on
+  # /mnt — the image's transient build footprint overruns / — plus a df pre-flight
+  # that fails fast rather than dying mid-build with 'no space left'.
   build-kb-gpu-mid:
     if: github.event_name == 'workflow_dispatch' && inputs.build_kb_gpu_mid
     runs-on: ubuntu-latest
@@ -124,7 +124,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Reclaim toolchains AND relocate docker's data-root to the larger /mnt disk
-      # BEFORE buildx is created, so buildkit writes the 22GB model layers there
+      # BEFORE buildx is created, so buildkit writes the ~14GB model layers there
       # (mirrors publish-images.yml's aimee-kb-leg fix, commit f26cf76).
       - name: Free disk + move docker storage to /mnt
         run: |
@@ -138,14 +138,15 @@ jobs:
           sudo systemctl start docker || true
           echo "after:"; df -h / /mnt
 
-      # Fail fast if /mnt can't hold the 22GB image's transient footprint (~50-70GB)
-      # instead of dying mid-build with ENOSPC after a 22GB download.
+      # Fail fast if /mnt can't hold the image's transient footprint instead of dying
+      # mid-build with ENOSPC after the model download. (Threshold left at 80GB for
+      # ample headroom; the ~14GB Gemma synth needs less than the prior 22GB Qwen.)
       - name: Pre-flight disk check
         run: |
           avail=$(df --output=avail -BG /mnt | tail -1 | tr -dc '0-9')
           echo "/mnt available: ${avail}GB"
           if [ "${avail:-0}" -lt 80 ]; then
-            echo "::error::/mnt has only ${avail}GB free; need >=80GB for the 22GB kb-gpu-mid build"; exit 1
+            echo "::error::/mnt has only ${avail}GB free; need >=80GB for the kb-gpu-mid build"; exit 1
           fi
 
       - name: Set up Docker Buildx
@@ -163,14 +164,14 @@ jobs:
             EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF
             EMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf
             RERANK_REPO=cross-encoder/ettin-reranker-400m-v1
-            SYNTH_REPO=unsloth/Qwen3.6-35B-A3B-GGUF
-            SYNTH_FILE=Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf
-            SYNTH_REVISION=56b9b6695c1d341398ea990cf2172ba4311647d8
-            SYNTH_SHA256=707a55a8a4397ecde44de0c499d3e68c1ad1d240d1da65826b4949d1043f4450
+            SYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF
+            SYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
+            SYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c
+            SYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e
             SYNTH_FA=on
             SYNTH_MOE=1
-            SYNTH_N_CPU_MOE=20
-            SYNTH_SLOTS=1
+            SYNTH_N_CPU_MOE=0
+            SYNTH_SLOTS=2
           tags: |
             ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing
             ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing-${{ env.SHA7 }}

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -5,7 +5,7 @@
 # Two published images (operator-directed: models baked in, not runtime-fetched —
 # turnkey, reproducible, no HF dependency at run time):
 #   aimee-kb-cpu       (defaults): Qwen3-Embedding-0.6B + ettin-68m + gemma-4-E4B
-#   aimee-kb-gpu-small/mid (build args): 4B + ettin-400m + gemma-12B OR Qwen3.6-35B-A3B
+#   aimee-kb-gpu-small/mid (build args): 4B + ettin-400m + gemma-4-12B OR gemma-4-26B-A4B
 # The llama.cpp binary is the VENDOR-AGNOSTIC Vulkan build (one binary for AMD/
 # Nvidia/Intel); GPU is selected at runtime by AIMEE_LLM_NGL (CPU image defaults 0).
 #
@@ -27,7 +27,7 @@ ARG SYNTH_FILE=gemma-4-E4B-it-Q4_K_M.gguf
 ARG SYNTH_REVISION=main
 ARG SYNTH_SHA256=
 # Per-tier synth runtime profile (baked -> ENV; the supervisor reads these). Defaults
-# = the CPU/gemma tier (dense, no FA/MoE). The gpu-mid (Qwen MoE) tier overrides them.
+# = the CPU/gemma tier (dense, no FA/MoE). The gpu-mid (gemma-4-26B-A4B MoE) tier overrides.
 ARG SYNTH_FA=off
 ARG SYNTH_KV_K=q8_0
 ARG SYNTH_KV_V=q4_0
@@ -79,7 +79,7 @@ np.savez("/out/rerank-head/head.npz", W2=W2, W4=d4["linear.weight"], b4=d4["line
 print("head.npz written")
 PY
 # Embedder + synth GGUFs. Synth is pinned by revision (default main) with retries so
-# a transient blip on the 22GB mid-tier pull doesn't kill the build, then sha256-
+# a transient blip on the large mid-tier pull doesn't kill the build, then sha256-
 # verified when SYNTH_SHA256 is set (build fails on a compromised/MITM'd upload).
 RUN wget -q -O /out/embed.gguf  "https://huggingface.co/${EMBED_REPO}/resolve/main/${EMBED_FILE}" \
     && wget -q -c --tries=5 --timeout=30 --waitretry=10 -O /out/synth.gguf \

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -90,11 +90,17 @@ RUN wget -q -O /out/embed.gguf  "https://huggingface.co/${EMBED_REPO}/resolve/ma
        fi
 
 # ---- stage 2: runtime — Vulkan llama.cpp + the gateway ----
-FROM debian:bookworm-slim AS runtime
+# Base is Debian TRIXIE (Mesa 25.x): its RADV exposes VK_KHR_cooperative_matrix on
+# RDNA3 (gfx1100), so the prebuilt llama.cpp Vulkan binary uses the 7900 XTX WMMA
+# matrix cores. Bookworm's Mesa 22.3.6 predates RADV coopmat (added in Mesa 24.1) →
+# llama.cpp fell back to scalar shaders (compute-bound, ~5% mem-bus use, ~14-60 t/s).
+# Verified on the card: Mesa 25.0.7 → cooperativeMatrix=true on RADV NAVI31.
+# NOTE: trixie's 64-bit time_t transition renames libcurl4 -> libcurl4t64.
+FROM debian:trixie-slim AS runtime
 ARG LLAMA_TAG
 ARG EMBED_POOLING
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl wget libgomp1 libcurl4 libvulkan1 mesa-vulkan-drivers \
+        ca-certificates curl wget libgomp1 libcurl4t64 libvulkan1 mesa-vulkan-drivers \
         python3 python3-numpy \
     && rm -rf /var/lib/apt/lists/*
 # llama.cpp vendor-agnostic Vulkan release (one binary for AMD/Nvidia/Intel)

--- a/deploy/smoothnas/aimee-llm.plugin.yaml
+++ b/deploy/smoothnas/aimee-llm.plugin.yaml
@@ -10,7 +10,7 @@ metadata:
     GGUFs. Replaces the torch aimee-embedder + the standalone llama.cpp `llm`
     container. The aimee-kb plugin points AIMEE_EMBEDDER_URL at this service.
     GPU tier (.254): Qwen3-Embedding-4B (2560-dim) + ettin-reranker-400m +
-    gemma-4-12B, offloaded to the AMD 7900 XTX via Vulkan/RADV (AIMEE_LLM_NGL=99).
+    gemma-4-26B-A4B, offloaded to the AMD 7900 XTX via Vulkan/RADV (AIMEE_LLM_NGL=99).
   vendor: RakuenSoftware
   homepage: https://github.com/RakuenSoftware/aimee
 profiles:
@@ -34,20 +34,20 @@ services:
       # SYNTH TIER = which image you reference (embed+rerank identical on the GPU
       # tiers, so switching is an image swap, no KB re-embed):
       #   aimee-kb-gpu-small  Gemma-4-12B synth (dense; fits 16GB+)
-      #   aimee-kb-gpu-mid    Qwen 3.6 35B-A3B synth (MoE; 24GB+, experts offload to
-      #                       RAM via the baked AIMEE_LLM_SYNTH_N_CPU_MOE, default 20)
+      #   aimee-kb-gpu-mid    Gemma-4-26B-A4B synth (MoE, 4B active; ~14GB fits a 24GB
+      #                       card fully GPU-resident, baked AIMEE_LLM_SYNTH_N_CPU_MOE=0)
       # aimee-kb-cpu is the CPU tier (1024-dim; NGL=0). See docs/AIMEE_KB_SYNTH_TIERS.md.
       image: ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest
     container:
       restartPolicy: unless-stopped
     env:
       # Offload all layers to the GPU (the 7900 XTX has the VRAM for the 4B embed +
-      # the synth tier). The CPU image defaults this to 0. On gpu-mid (Qwen) the synth
-      # additionally spills MoE experts to RAM per the baked AIMEE_LLM_SYNTH_N_CPU_MOE;
-      # lower it toward 0 on a 32GB card for more speed, or raise it if VRAM is tight.
+      # the ~14GB gemma-4-26B-A4B synth, fully resident). The CPU image defaults NGL to 0.
       AIMEE_LLM_NGL: "99"
-      # Qwen serves a bigger context than the 32K default; raise it here.
-      AIMEE_LLM_SYNTH_CTX: "131072"
+      # gpu-mid bakes SYNTH_SLOTS=2, so ctx-size is split 2 × 128K. Gemma's sliding-window
+      # KV is cheap; 262144 (256K total) fits alongside the resident synth on 24GB. Lower
+      # this (or raise the baked N_CPU_MOE) only if the container logs a VRAM alloc failure.
+      AIMEE_LLM_SYNTH_CTX: "262144"
       # Gateway port. 8742 (aimee's 874x range: server 8740, kb 8741) — NOT 8080,
       # which Wolf's WolfLeash UI host-publishes. A hostExpose port is published on
       # the HOST, so two plugins on the same port silently collide (the runtime

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -10,7 +10,7 @@ CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
 |---|---|---|---|
 | `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B | CPU (`NGL=0`) |
 | `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 |
-| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Qwen 3.6 35B-A3B** `UD-Q4_K_XL` | GPU, MoE, FA+K8V4 + `--n-cpu-moe` |
+| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident |
 
 `gpu-small` and `gpu-mid` share the **same embedder + reranker** (2560-dim), so a KB
 embedded on one is byte-compatible with the other — switching the synth tier is a
@@ -19,7 +19,7 @@ plugin **image swap**, no re-embed.
 ## Deploy: one plugin image swap
 
 The synth tier is chosen by which image the SmoothNAS `aimee-llm` plugin references —
-e.g. `ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest` for Qwen. No separate delegate
+e.g. `ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest` for Gemma 4 26B-A4B. No separate delegate
 container, no `SYNTH_LOCAL` juggling: the tier *is* the synth. The gateway's
 `/v1/chat/completions` is what the server/curator use, so the delegate wiring is
 automatic once the image is deployed.
@@ -29,26 +29,33 @@ automatic once the image is deployed.
 | Env | Default (per tier) | Meaning |
 |---|---|---|
 | `AIMEE_LLM_SYNTH_CTX` | 32768 (raise on GPU) | synth context window |
-| `AIMEE_LLM_SYNTH_SLOTS` | 1 | `--parallel` concurrent slots |
+| `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on gpu-mid) | `--parallel` concurrent slots |
 | `AIMEE_LLM_SYNTH_FA` | `off` cpu / `on` gpu | flash-attention (required for quantized V-cache) |
 | `AIMEE_LLM_SYNTH_KV_K` / `_KV_V` | `q8_0` / `q4_0` (K8V4) | KV cache quant on the gpu tiers |
-| `AIMEE_LLM_SYNTH_MOE` | `1` on gpu-mid | enable MoE expert-offload |
-| `AIMEE_LLM_SYNTH_N_CPU_MOE` | ~20 on gpu-mid | **the tune knob** — MoE layers whose experts live in system RAM (clamped `[0,40]`) |
+| `AIMEE_LLM_SYNTH_MOE` | `1` on gpu-mid | enable the `--n-cpu-moe` expert-offload knob |
+| `AIMEE_LLM_SYNTH_N_CPU_MOE` | `0` on gpu-mid | MoE layers whose experts live in system RAM (0 = fully GPU-resident) |
 
-### Tuning `N_CPU_MOE` on gpu-mid (Qwen, 22 GB synth)
+### Tuning `N_CPU_MOE` on gpu-mid (Gemma 4 26B-A4B, ~14 GB synth)
 
-On a 24 GB card the 22 GB synth can't fully co-fit embed+rerank (~5.5 GB), so some
-experts spill to RAM. Higher `N` = less VRAM, more RAM traffic, slower. Because the
-mid image bakes Qwen *as the synth* (no gemma alongside), Qwen gets ~18.5 GB of the
-card → most experts stay resident:
+The mid tier is **Gemma 4 26B-A4B** — a MoE with only **4B active parameters/token** at
+`qat-UD-Q4_K_XL` (~14 GB). Unlike a 22 GB synth, it **co-fits embed+rerank (~7 GB) on a
+24 GB card fully resident** (~21 GB + Gemma's cheap sliding-window KV), so the default is
+`N_CPU_MOE=0` — **no expert offload, no CPU/RAM path in the hot loop.** That is the whole
+point of this tier vs. a larger dense/MoE synth: it stays on the GPU and runs fast.
 
 | Card | Suggested `N_CPU_MOE` | Notes |
 |---|---|---|
-| 24 GB | ~20 (default) | ~half experts resident; safe margin |
-| 32 GB | ~4–8 | nearly all resident, fastest |
+| 24 GB | `0` (default) | fully resident; fastest. Drop `SYNTH_CTX` or offload a few layers only if VRAM is tight with 2 slots × 128 K |
+| 16 GB | ~24–32 | ~14 GB synth won't co-fit ~7 GB retrieval; spill most experts to RAM (slow but works) |
 
-Free system RAM needed ≈ `N/40 × 22 GB`. Raise `N` if the container logs an
-allocation failure; lower it (or drop `SYNTH_CTX`) for more speed.
+Raise `N_CPU_MOE` only if the container logs a VRAM allocation failure; each offloaded
+layer frees GPU memory at the cost of RAM-path latency. Because only 4B params are active,
+even a modest offload stays far faster than a 22 GB synth with the same offload.
+
+> **Why Gemma 4 26B-A4B over Qwen 3.6 35B-A3B here:** the 22 GB Qwen synth could not
+> co-fit the 7 GB retrieval stack on a 24 GB card, forcing ~half its MoE experts onto the
+> CPU/RAM path (`N_CPU_MOE≈20`) → ~14 tok/s generation regardless of the GPU. Gemma 4
+> 26B-A4B (~14 GB, 4B active) fits resident, eliminating the offload bottleneck.
 
 ### Flash-attention / K8V4
 


### PR DESCRIPTION
## What
Repoints the `aimee-kb-gpu-mid` tier's baked synth model from **Qwen 3.6 35B-A3B** (22 GB) to **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` (~14 GB, 4B active/token), and switches the runtime profile to **fully GPU-resident** (`N_CPU_MOE=0`) + 2 slots.

## Why
On a 24 GB 7900 XTX the 22 GB Qwen synth could not co-fit the ~7 GB embed+rerank stack, forcing ~half its MoE experts onto the CPU/RAM path (`N_CPU_MOE≈20`) → **~14 tok/s regardless of the GPU**. Gemma 4 26B-A4B fits resident alongside retrieval (~21 GB + Gemma's cheap sliding-window KV), eliminating the offload bottleneck.

## Measured live on .254 (7900 XTX, aimee-kb-gpu-mid:testing built from this branch)
- Fully resident: `-ngl 99 --n-cpu-moe 0 -fa on` K8V4, 2 slots × 128K (`--parallel 2 --ctx-size 262144`); **VRAM 22.6/24.5 GB, no OOM.**
- **~60 tok/s idle** (vs Qwen's flat 14); ~30 tok/s per-stream under heavy concurrent curator load.
- Curator now runs ~64 synths/min (≈4–6× the Qwen rate) → code-graph queue drains far faster.
- Embedder unchanged (2560-dim) → KBs stay byte-portable; embed/rerank/search verified; delegate probe `execution_ok` at 812 ms (was 11.7 s on Qwen).

## Changes
- `publish-images.yml` + `publish-llm-testing.yml`: gpu-mid build-args → `unsloth/gemma-4-26B-A4B-it-qat-GGUF` (`gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf`, rev+sha256 pinned), `SYNTH_N_CPU_MOE=0`, `SYNTH_SLOTS=2`.
- `Dockerfile.aimee-llm`: comments only (build-arg driven; arch confirmed loadable in b9775).
- `deploy/smoothnas/aimee-llm.plugin.yaml`: `SYNTH_CTX` 131072→262144.
- `docs/AIMEE_KB_SYNTH_TIERS.md`: mid-tier table + N_CPU_MOE tuning rewrite.