### PR TITLE
feat(workflow): primary-as-manager S2 sub-slice 4 — per-block resolver + dispatch-time externalization guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -908,6 +908,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/server/server_session_start_stubs.c
     ${AIMEE_SRC_DIR}/workflow/wfe_engine.c
     ${AIMEE_SRC_DIR}/workflow/wfe_advance_exec.c
+    ${AIMEE_SRC_DIR}/workflow/wfe_block_resolve.c
     ${AIMEE_SRC_DIR}/workflow/wfe_blocks.c
     ${AIMEE_SRC_DIR}/workflow/wfe_approval.c
     ${AIMEE_SRC_DIR}/workflow/wfe_verdict.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -294,7 +294,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \
-            workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c workflow/wfe_manager_artifacts.c workflow/wfe_externalization.c workflow/wfe_enforce.c workflow/wfe_deliver.c workflow/wfe_advance.c workflow/wfe_advance_exec.c workflow/wfe_router.c workflow/wfe_router_catalog.c \
+            workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c workflow/wfe_manager_artifacts.c workflow/wfe_externalization.c workflow/wfe_enforce.c workflow/wfe_deliver.c workflow/wfe_advance.c workflow/wfe_advance_exec.c workflow/wfe_block_resolve.c workflow/wfe_router.c workflow/wfe_router_catalog.c \
             harness_memory_common.c harness_memory_scope.c harness_memory_audit.c harness_memory_spill.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -29,7 +29,8 @@
 #include "server_mcp_skill.h"
 #include "server_mcp_delegate.h"
 #include "server_mcp_workflows.h"
-#include "wfe_advance_exec.h" /* advance_request interactive-driver executor (S2) */
+#include "wfe_advance_exec.h"  /* advance_request interactive-driver executor (S2) */
+#include "wfe_block_resolve.h" /* per-block externalization guard (S2 sub-slice 4) */
 #include "server_mcp_gateway.h"
 #include "server_http.h"
 #include "server_pipeline.h" /* handle_pipeline_* for the pipeline.* MCP tools */
@@ -1655,6 +1656,23 @@ int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
       if (fd == 1)
          tool = fam_tool;
+   }
+
+   /* S2 sub-slice 4: pre-delivery externalization guard at the tool-DISPATCH seam.
+    * A bound enforced run whose gate.deliver has not passed may not call an
+    * externalization primitive (pr.open/merge, push, egress, ...) regardless of tool
+    * visibility -- this is the narrow run-state invariant behind the ingress surface
+    * strip ("tool visibility alone is not a security boundary"). Default-OFF (dial
+    * unset -> ALLOW); soft warns + allows; hard refuses. The decision is audited
+    * inside the guard. Runs before every dispatch branch so it also covers the
+    * workflow-tool and git_ externalization paths. */
+   if (wfe_mcp_toolcall_action(sid, tool) == WFE_TC_DENY)
+   {
+      if (owns_jargs)
+         cJSON_Delete(jargs);
+      return server_send_error(
+          conn, "refused: this action externalizes work before the review/delivery gate has passed",
+          NULL);
    }
 
    if (strcmp(tool, "delegate") == 0)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -134,6 +134,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-wfe-enforce \
                $(TESTPREFIX)/unit-test-wfe-advance \
                $(TESTPREFIX)/unit-test-wfe-advance-exec \
+               $(TESTPREFIX)/unit-test-wfe-block-resolve \
                $(TESTPREFIX)/unit-test-wfe-binding \
                $(TESTPREFIX)/unit-test-aimee-ir \
                $(TESTPREFIX)/unit-test-aimee-ir-metrics \
@@ -1334,6 +1335,20 @@ $(TESTPREFIX)/unit-test-wfe-enforce: $(OBJDIR)/tests/test_wfe_enforce.o \
 # S2 sub-slice 3: advance_request pure core (parser + CAS/replay decision; cJSON only).
 $(TESTPREFIX)/unit-test-wfe-advance: $(OBJDIR)/tests/test_wfe_advance.o \
                                     $(OBJDIR)/workflow/wfe_advance.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# S2 sub-slice 4: per-block resolver + dispatch-time externalization guard.
+$(TESTPREFIX)/unit-test-wfe-block-resolve: $(OBJDIR)/tests/test_wfe_block_resolve.o \
+                                    $(OBJDIR)/workflow/wfe_block_resolve.o $(OBJDIR)/workflow/wfe_enforce.o \
+                                    $(OBJDIR)/workflow/wfe_externalization.o $(OBJDIR)/db1/wfe_binding.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_manager_artifacts.o $(OBJDIR)/workflow/wfe_deliver.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
+                                    $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # S2 sub-slice 3: interactive-driver executor (binding + engine + audit).

--- a/src/tests/test_wfe_block_resolve.c
+++ b/src/tests/test_wfe_block_resolve.c
@@ -14,22 +14,71 @@
 #include "wfe_engine.h"
 #include "wfe_store.h"
 
-/* understand(READONLY) -> split(DELEGATE) -> implement(DELEGATE); stub executors. */
-static const char *WF = "name: t\n"
-                        "start: a\n"
-                        "nodes:\n"
-                        "  - id: a\n"
-                        "    block: understand\n"
-                        "    next: b\n"
-                        "  - id: b\n"
-                        "    block: split\n"
-                        "    in:\n"
-                        "      intent: a.out\n"
-                        "    next: c\n"
-                        "  - id: c\n"
-                        "    block: implement\n"
-                        "    in:\n"
-                        "      plan: a.out\n";
+/* ENFORCED workflow (terminal gate.deliver per I2), valid manager shape:
+ * understand(READONLY) -> split -> implement -> freeze -> review -> gate.roundtable
+ * -> gate.deliver(verdict). Stub executors. */
+static const char *WF_ENF = "name: t\n"
+                            "enforced: true\n"
+                            "start: understand\n"
+                            "nodes:\n"
+                            "  - id: understand\n"
+                            "    block: understand\n"
+                            "    next: split\n"
+                            "  - id: split\n"
+                            "    block: split\n"
+                            "    in:\n"
+                            "      intent: understand.out\n"
+                            "    next: implement\n"
+                            "  - id: implement\n"
+                            "    block: implement\n"
+                            "    in:\n"
+                            "      plan: split.out\n"
+                            "    next: freeze\n"
+                            "  - id: freeze\n"
+                            "    block: freeze\n"
+                            "    in:\n"
+                            "      branch: implement.out\n"
+                            "    next: review\n"
+                            "  - id: review\n"
+                            "    block: review\n"
+                            "    in:\n"
+                            "      src: freeze.out\n"
+                            "    params:\n"
+                            "      reviewer: contrarian\n"
+                            "    on_pass: rt\n"
+                            "    on_fail: split\n"
+                            "  - id: rt\n"
+                            "    block: gate.roundtable\n"
+                            "    in:\n"
+                            "      src: freeze.out\n"
+                            "    params:\n"
+                            "      panel:\n"
+                            "        required:\n"
+                            "          - security\n"
+                            "          - architect\n"
+                            "    on_pass: deliver\n"
+                            "    on_fail: split\n"
+                            "  - id: deliver\n"
+                            "    block: gate.deliver\n"
+                            "    in:\n"
+                            "      verdict: rt.out\n";
+
+/* NON-enforced workflow: the externalization guard must NOT apply. */
+static const char *WF_PLAIN = "name: u\n"
+                              "start: a\n"
+                              "nodes:\n"
+                              "  - id: a\n"
+                              "    block: understand\n";
+
+static void write_wf(const char *dir, const char *name, const char *body)
+{
+   char path[700];
+   snprintf(path, sizeof path, "%s/workflows/%s.yaml", dir, name);
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(body, f);
+   fclose(f);
+}
 
 static void setup_home(void)
 {
@@ -39,12 +88,8 @@ static void setup_home(void)
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);
    mkdir(wf, 0755);
-   char path[600];
-   snprintf(path, sizeof path, "%s/t.yaml", wf);
-   FILE *f = fopen(path, "wb");
-   assert(f);
-   fputs(WF, f);
-   fclose(f);
+   write_wf(dir, "t", WF_ENF);
+   write_wf(dir, "u", WF_PLAIN);
    setenv("AIMEE_HOME", dir, 1);
    char repo[600];
    snprintf(repo, sizeof repo, "%s/repo", dir);
@@ -98,13 +143,14 @@ int main(void)
 
    assert(db1_wfe_bind(SID, id, "advisory") == 0);
 
-   /* bound at understand: READONLY surface, not delivered, advanceable, stage a */
+   /* bound at understand: enforced, READONLY, not delivered, advanceable, stage a */
    assert(wfe_block_resolve(SID, &ctx) == 1);
    assert(ctx.bound == 1);
+   assert(ctx.enforced == 1);
    assert(ctx.surface == WFE_SURFACE_READONLY);
    assert(ctx.delivered == 0);
    assert(ctx.advanceable == 1);
-   assert(strcmp(ctx.stage, "a") == 0);
+   assert(strcmp(ctx.stage, "understand") == 0);
 
    /* --- the guard --- */
    unsetenv("AIMEE_WORKFLOW_ENFORCE_STAGE");
@@ -112,7 +158,7 @@ int main(void)
 
    setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "hard", 1);
    assert(wfe_mcp_toolcall_action(SID, "read_file") == WFE_TC_ALLOW);    /* not externalization */
-   assert(wfe_mcp_toolcall_action("nobody", "pr.open") == WFE_TC_ALLOW); /* unbound */
+   assert(wfe_mcp_toolcall_action("nobody", "pr.open") == WFE_TC_ALLOW); /* truly unbound */
    assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_DENY); /* pre-delivery externalize */
    assert(wfe_mcp_toolcall_action(SID, "git_push") == WFE_TC_DENY);
    assert(audit_count(id) == 2); /* the two denials were audited */
@@ -128,6 +174,26 @@ int main(void)
    assert(wfe_block_resolve(SID, &ctx) == 1 && ctx.delivered == 1);
    assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_ALLOW);
    assert(audit_count(id) == 3); /* no new denial */
+
+   /* a NON-enforced bound run is not externalization-guarded (delivered==accepted
+    * would not be a sound gate proxy there, and it made no enforcement promise) */
+   char id_u[80] = "";
+   assert(wfe_work_item_create("u", "git@github.com:x/u.git", "docs/u.md", "interactive", id_u, err,
+                               sizeof err) == 0);
+   assert(db1_wfe_bind("sess-U", id_u, "advisory") == 0);
+   assert(wfe_block_resolve("sess-U", &ctx) == 1 && ctx.enforced == 0);
+   assert(wfe_mcp_toolcall_action("sess-U", "pr.open") ==
+          WFE_TC_ALLOW); /* hard, but not enforced */
+
+   /* BOUND-but-unresolvable (binding references a vanished work-item): an
+    * instrumentation failure on a known-bound session must fail CLOSED under hard,
+    * NOT fail open. */
+   assert(db1_wfe_bind("sess-G", "wi_ghost0000", "advisory") == 0);
+   assert(wfe_block_resolve("sess-G", &ctx) == 0); /* cannot resolve */
+   setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "hard", 1);
+   assert(wfe_mcp_toolcall_action("sess-G", "pr.open") == WFE_TC_DENY); /* fail closed */
+   setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "soft", 1);
+   assert(wfe_mcp_toolcall_action("sess-G", "pr.open") == WFE_TC_ALLOW); /* soft: observe */
 
    printf("ok\n");
    return 0;

--- a/src/tests/test_wfe_block_resolve.c
+++ b/src/tests/test_wfe_block_resolve.c
@@ -1,0 +1,134 @@
+/* test_wfe_block_resolve.c -- S2 sub-slice 4: the per-block resolver + the
+ * dispatch-time externalization guard, against a real in-memory DB1 + engine
+ * (stub executors). Covers the pure decision table, the DB resolve, and the
+ * composed guard (default-off, deny/warn/allow, delivered lifts, audit). */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "db1.h"
+#include "wfe_binding.h"
+#include "wfe_block_resolve.h"
+#include "wfe_engine.h"
+#include "wfe_store.h"
+
+/* understand(READONLY) -> split(DELEGATE) -> implement(DELEGATE); stub executors. */
+static const char *WF = "name: t\n"
+                        "start: a\n"
+                        "nodes:\n"
+                        "  - id: a\n"
+                        "    block: understand\n"
+                        "    next: b\n"
+                        "  - id: b\n"
+                        "    block: split\n"
+                        "    in:\n"
+                        "      intent: a.out\n"
+                        "    next: c\n"
+                        "  - id: c\n"
+                        "    block: implement\n"
+                        "    in:\n"
+                        "      plan: a.out\n";
+
+static void setup_home(void)
+{
+   char tmpl[] = "/tmp/wfe_res_home_XXXXXX";
+   char *dir = mkdtemp(tmpl);
+   assert(dir);
+   char wf[512];
+   snprintf(wf, sizeof wf, "%s/workflows", dir);
+   mkdir(wf, 0755);
+   char path[600];
+   snprintf(path, sizeof path, "%s/t.yaml", wf);
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(WF, f);
+   fclose(f);
+   setenv("AIMEE_HOME", dir, 1);
+   char repo[600];
+   snprintf(repo, sizeof repo, "%s/repo", dir);
+   mkdir(repo, 0755);
+   setenv("AIMEE_WORKFLOW_REPO", repo, 1);
+}
+
+static void test_decide_pure(void)
+{
+   /* off / advisory never restrict; soft warns; hard denies -- only when policy
+    * actually blocks the call. */
+   assert(wfe_toolcall_decide(WFE_ENFORCE_OFF, 1) == WFE_TC_ALLOW);
+   assert(wfe_toolcall_decide(WFE_ENFORCE_ADVISORY, 1) == WFE_TC_ALLOW);
+   assert(wfe_toolcall_decide(WFE_ENFORCE_SOFT, 1) == WFE_TC_WARN);
+   assert(wfe_toolcall_decide(WFE_ENFORCE_HARD, 1) == WFE_TC_DENY);
+   assert(wfe_toolcall_decide(WFE_ENFORCE_HARD, 0) == WFE_TC_ALLOW);
+   assert(wfe_toolcall_decide(WFE_ENFORCE_SOFT, 0) == WFE_TC_ALLOW);
+}
+
+static int audit_count(const char *wi)
+{
+   db1_lifecycle_event_t *ev = NULL;
+   int ne = db1_lifecycle_event_list(wi, &ev);
+   int n = 0;
+   for (int i = 0; i < ne; i++)
+      if (strcmp(ev[i].actor, "enforce-s2") == 0 && strcmp(ev[i].kind, "toolcall_guard") == 0)
+         n++;
+   free(ev);
+   return n;
+}
+
+int main(void)
+{
+   printf("wfe-block-resolve: ");
+   test_decide_pure();
+
+   setup_home();
+   assert(db1_init(":memory:") == 0);
+   wfe_reset_block_executors();
+   wfe_register_stub_executors();
+
+   char id[80] = "", err[256] = "";
+   assert(wfe_work_item_create("t", "git@github.com:x/y.git", "docs/p.md", "interactive", id, err,
+                               sizeof err) == 0);
+   const char *SID = "sess-A";
+
+   /* unbound -> resolve returns 0 */
+   wfe_block_ctx_t ctx;
+   assert(wfe_block_resolve(SID, &ctx) == 0);
+   assert(ctx.bound == 0);
+
+   assert(db1_wfe_bind(SID, id, "advisory") == 0);
+
+   /* bound at understand: READONLY surface, not delivered, advanceable, stage a */
+   assert(wfe_block_resolve(SID, &ctx) == 1);
+   assert(ctx.bound == 1);
+   assert(ctx.surface == WFE_SURFACE_READONLY);
+   assert(ctx.delivered == 0);
+   assert(ctx.advanceable == 1);
+   assert(strcmp(ctx.stage, "a") == 0);
+
+   /* --- the guard --- */
+   unsetenv("AIMEE_WORKFLOW_ENFORCE_STAGE");
+   assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_ALLOW); /* dial off */
+
+   setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "hard", 1);
+   assert(wfe_mcp_toolcall_action(SID, "read_file") == WFE_TC_ALLOW);    /* not externalization */
+   assert(wfe_mcp_toolcall_action("nobody", "pr.open") == WFE_TC_ALLOW); /* unbound */
+   assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_DENY); /* pre-delivery externalize */
+   assert(wfe_mcp_toolcall_action(SID, "git_push") == WFE_TC_DENY);
+   assert(audit_count(id) == 2); /* the two denials were audited */
+
+   /* soft dial: warn + allow (still audited) */
+   setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "soft", 1);
+   assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_WARN);
+   assert(audit_count(id) == 3);
+
+   /* once delivered (gate.deliver -> accepted), the guard lifts */
+   setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "hard", 1);
+   assert(db1_work_item_set_terminal(id, "accepted") == 0);
+   assert(wfe_block_resolve(SID, &ctx) == 1 && ctx.delivered == 1);
+   assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_ALLOW);
+   assert(audit_count(id) == 3); /* no new denial */
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/workflow/wfe_block_resolve.c
+++ b/src/workflow/wfe_block_resolve.c
@@ -55,6 +55,7 @@ int wfe_block_resolve(const char *session_id, wfe_block_ctx_t *out)
    if (node)
    {
       out->bound = 1;
+      out->enforced = def->enforced;
       snprintf(out->work_item_id, sizeof out->work_item_id, "%s", wi);
       snprintf(out->stage, sizeof out->stage, "%s", item.current_stage);
       out->surface = wfe_block_default_surface(node->block);
@@ -90,22 +91,42 @@ wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char
       return WFE_TC_ALLOW;
 
    wfe_block_ctx_t ctx;
-   if (!wfe_block_resolve(session_id, &ctx))
-      return WFE_TC_ALLOW; /* unbound -> generic; binding failure is isolated */
-
-   int policy_blocks = !wfe_externalization_tool_permitted(tool_name, ctx.delivered);
-   wfe_toolcall_action_t act = wfe_toolcall_decide(stage, policy_blocks);
-
-   /* Audit the enforcement decision. Templated constant values only (action + dial
-    * stage names) -- never the raw tool name or args (echo/injection vector). */
-   if (act != WFE_TC_ALLOW)
+   if (wfe_block_resolve(session_id, &ctx))
    {
-      char detail[128];
-      snprintf(detail, sizeof detail,
-               "{\"guard\":\"externalization\",\"action\":\"%s\",\"stage\":\"%s\"}",
-               act == WFE_TC_DENY ? "deny" : "warn", wfe_enforce_stage_name(stage));
-      db1_lifecycle_event_add(ctx.work_item_id, ctx.stage, "toolcall_guard", "enforce-s2", detail,
-                              "", 0);
+      /* Only ENFORCED runs are externalization-guarded: for them I2 guarantees the
+       * terminal is gate.deliver, so delivered==accepted is a sound "gate passed"
+       * proxy. A non-enforced bound run is not gated (it made no such promise). */
+      if (!ctx.enforced)
+         return WFE_TC_ALLOW;
+      int policy_blocks = !wfe_externalization_tool_permitted(tool_name, ctx.delivered);
+      wfe_toolcall_action_t act = wfe_toolcall_decide(stage, policy_blocks);
+      /* Audit the enforcement decision. Templated constant values only (action + dial
+       * stage names) -- never the raw tool name or args (echo/injection vector). */
+      if (act != WFE_TC_ALLOW)
+      {
+         char detail[128];
+         snprintf(detail, sizeof detail,
+                  "{\"guard\":\"externalization\",\"action\":\"%s\",\"stage\":\"%s\"}",
+                  act == WFE_TC_DENY ? "deny" : "warn", wfe_enforce_stage_name(stage));
+         db1_lifecycle_event_add(ctx.work_item_id, ctx.stage, "toolcall_guard", "enforce-s2",
+                                 detail, "", 0);
+      }
+      return act;
    }
-   return act;
+
+   /* Resolve FAILED. Distinguish a truly UNBOUND session (no binding row -> a generic
+    * session, allow) from a BOUND session we could not resolve (vanished work-item /
+    * unloadable workflow). Per the Q5 rollout split, an INSTRUMENTATION failure on a
+    * KNOWN-bound session must NOT fail open for an externalization primitive under
+    * HARD -- it fails CLOSED (a bound session is potentially enforced; we refuse
+    * rather than let externalization slip through on a lookup error). */
+   char wi[80] = "";
+   if (db1_wfe_binding_get(session_id, wi, sizeof wi, NULL, 0) != 1 || !wi[0])
+      return WFE_TC_ALLOW; /* truly unbound */
+   if (!wfe_enforce_stage_refuses(stage))
+      return WFE_TC_ALLOW; /* soft / advisory: observe only */
+   db1_lifecycle_event_add(
+       wi, "", "toolcall_guard", "enforce-s2",
+       "{\"guard\":\"externalization\",\"action\":\"deny\",\"reason\":\"unresolved\"}", "", 0);
+   return WFE_TC_DENY;
 }

--- a/src/workflow/wfe_block_resolve.c
+++ b/src/workflow/wfe_block_resolve.c
@@ -1,0 +1,111 @@
+/* wfe_block_resolve.c -- see wfe_block_resolve.h. */
+#include "wfe_block_resolve.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "wfe_binding.h"         /* db1_wfe_binding_get */
+#include "wfe_def.h"             /* wfe_def_node, wfe_node_t */
+#include "wfe_engine.h"          /* wfe_load_workflow, wfe_def_free */
+#include "wfe_externalization.h" /* wfe_is_externalization_tool, _permitted */
+#include "wfe_iface.h"           /* wfe_block_type_t */
+#include "wfe_store.h"           /* db1_work_item_get */
+
+/* Gate blocks advance via their own satisfaction (roundtable verdict, human
+ * decision, CI, delivery) -- NOT via the primary's advance_request. Producing
+ * blocks (understand/split/review/implement/document/...) are advanceable. */
+static int block_is_gate(wfe_block_type_t b)
+{
+   switch (b)
+   {
+   case WFE_BLK_GATE_ROUNDTABLE:
+   case WFE_BLK_GATE_HUMAN:
+   case WFE_BLK_GATE_CI:
+   case WFE_BLK_CHECK_MERGEABLE:
+   case WFE_BLK_GATE_DELIVER:
+      return 1;
+   default:
+      return 0;
+   }
+}
+
+int wfe_block_resolve(const char *session_id, wfe_block_ctx_t *out)
+{
+   if (out)
+      memset(out, 0, sizeof *out);
+   if (!session_id || !session_id[0] || !out)
+      return 0;
+
+   char wi[80] = "";
+   if (db1_wfe_binding_get(session_id, wi, sizeof wi, NULL, 0) != 1 || !wi[0])
+      return 0; /* unbound */
+
+   db1_work_item_t item;
+   if (db1_work_item_get(wi, &item) != 1)
+      return 0; /* vanished work-item -> treat as unbound (no per-block restriction) */
+
+   char err[128] = "";
+   wfe_def_t *def = wfe_load_workflow(item.workflow_name, err, sizeof err);
+   if (!def)
+      return 0;
+
+   int ok = 0;
+   const wfe_node_t *node = wfe_def_node(def, item.current_stage);
+   if (node)
+   {
+      out->bound = 1;
+      snprintf(out->work_item_id, sizeof out->work_item_id, "%s", wi);
+      snprintf(out->stage, sizeof out->stage, "%s", item.current_stage);
+      out->surface = wfe_block_default_surface(node->block);
+      /* gate.deliver passing transitions the run to accepted; before that the run
+       * has not earned externalization. */
+      out->delivered = (strcmp(item.state, "accepted") == 0);
+      out->advanceable = !block_is_gate(node->block);
+      ok = 1;
+   }
+   wfe_def_free(def);
+   return ok;
+}
+
+wfe_toolcall_action_t wfe_toolcall_decide(wfe_enforce_stage_t stage, int policy_blocks)
+{
+   if (!policy_blocks)
+      return WFE_TC_ALLOW;
+   if (wfe_enforce_stage_refuses(stage)) /* hard */
+      return WFE_TC_DENY;
+   if (wfe_enforce_stage_restricts(stage)) /* soft */
+      return WFE_TC_WARN;
+   return WFE_TC_ALLOW; /* advisory / off: observe only */
+}
+
+wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char *tool_name)
+{
+   wfe_enforce_stage_t stage = wfe_enforce_stage_parse(getenv("AIMEE_WORKFLOW_ENFORCE_STAGE"));
+   if (stage == WFE_ENFORCE_OFF || !tool_name || !tool_name[0])
+      return WFE_TC_ALLOW;
+   /* Only externalization primitives are guarded here; everything else passes (the
+    * surface strip handles read/write visibility at ingress). */
+   if (!wfe_is_externalization_tool(tool_name))
+      return WFE_TC_ALLOW;
+
+   wfe_block_ctx_t ctx;
+   if (!wfe_block_resolve(session_id, &ctx))
+      return WFE_TC_ALLOW; /* unbound -> generic; binding failure is isolated */
+
+   int policy_blocks = !wfe_externalization_tool_permitted(tool_name, ctx.delivered);
+   wfe_toolcall_action_t act = wfe_toolcall_decide(stage, policy_blocks);
+
+   /* Audit the enforcement decision. Templated constant values only (action + dial
+    * stage names) -- never the raw tool name or args (echo/injection vector). */
+   if (act != WFE_TC_ALLOW)
+   {
+      char detail[128];
+      snprintf(detail, sizeof detail,
+               "{\"guard\":\"externalization\",\"action\":\"%s\",\"stage\":\"%s\"}",
+               act == WFE_TC_DENY ? "deny" : "warn", wfe_enforce_stage_name(stage));
+      db1_lifecycle_event_add(ctx.work_item_id, ctx.stage, "toolcall_guard", "enforce-s2", detail,
+                              "", 0);
+   }
+   return act;
+}

--- a/src/workflow/wfe_block_resolve.h
+++ b/src/workflow/wfe_block_resolve.h
@@ -1,0 +1,59 @@
+/* wfe_block_resolve.h -- S2 sub-slice 4: the per-block enforcement resolver + the
+ * dispatch-time externalization guard.
+ *
+ * A bound interactive session's tool surface is governed by whichever workflow
+ * block is currently active. This module resolves that context from AUTHORITATIVE
+ * DB state (binding -> work-item -> pinned workflow -> current node) and applies
+ * the pre-delivery externalization guard (Q3) at the tool-DISPATCH seam: a tool
+ * call in an enforced run whose gate.deliver has not passed is refused if it is an
+ * externalization primitive. Tool VISIBILITY (stripping the surface at ingress) is
+ * a separate, coarser layer; this is the narrow run-delivery-state invariant that
+ * a per-call check enforces even when a tool slips past visibility (consult Q2/Q3,
+ * "tool visibility alone is not a security boundary").
+ *
+ * Default-OFF: with the enforcement dial unset the guard is inert. Design per the
+ * S2 roundtable consult (2026-07-01). */
+#ifndef DEC_WFE_BLOCK_RESOLVE_H
+#define DEC_WFE_BLOCK_RESOLVE_H 1
+
+#include "wfe_enforce.h" /* wfe_tool_surface_t, wfe_enforce_stage_t */
+
+/* The per-block enforcement context for a session's current work-item. */
+typedef struct
+{
+   int bound;                  /* 1 if the session is bound to a resolvable work-item */
+   wfe_tool_surface_t surface; /* tool surface of the current block */
+   int delivered;              /* 1 if gate.deliver has passed for this run */
+   int advanceable;            /* 1 if the current block advances via advance_request
+                                  (a producing block, not a gate) */
+   char work_item_id[80];
+   char stage[64];
+} wfe_block_ctx_t;
+
+/* Resolve the per-block context for `session_id` from authoritative DB state. On an
+ * unbound session, a vanished work-item, or any load failure, zeroes `out` (bound=0)
+ * and returns 0 -- the caller then applies NO per-block restriction (non-bound
+ * sessions stay generic; a binding-layer failure is isolated). Returns 1 if bound +
+ * resolved. */
+int wfe_block_resolve(const char *session_id, wfe_block_ctx_t *out);
+
+/* The action a bound session's tool call should take. */
+typedef enum
+{
+   WFE_TC_ALLOW = 0, /* permitted (or dial off / unbound / non-externalization) */
+   WFE_TC_WARN,      /* soft dial: a pre-delivery externalization -- warn + allow */
+   WFE_TC_DENY       /* hard dial: a pre-delivery externalization -- refuse */
+} wfe_toolcall_action_t;
+
+/* PURE decision: given the dial stage and whether policy blocks this call (the
+ * session is bound and the tool is a pre-delivery externalization primitive), map
+ * to an action. advisory/off never restrict; soft warns; hard denies. */
+wfe_toolcall_action_t wfe_toolcall_decide(wfe_enforce_stage_t stage, int policy_blocks);
+
+/* The dispatch-time guard, composed: resolve `session_id`, and if the enforcement
+ * dial is on and `tool_name` is an externalization primitive that this run has not
+ * yet earned (gate.deliver not passed), return WARN/DENY per the dial; otherwise
+ * ALLOW. Reads the dial from AIMEE_WORKFLOW_ENFORCE_STAGE (default OFF -> ALLOW). */
+wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char *tool_name);
+
+#endif /* DEC_WFE_BLOCK_RESOLVE_H */

--- a/src/workflow/wfe_block_resolve.h
+++ b/src/workflow/wfe_block_resolve.h
@@ -22,6 +22,8 @@
 typedef struct
 {
    int bound;                  /* 1 if the session is bound to a resolvable work-item */
+   int enforced;               /* 1 if the pinned workflow is enforced (I2 => terminal
+                                  is gate.deliver, so delivered==accepted is sound) */
    wfe_tool_surface_t surface; /* tool surface of the current block */
    int delivered;              /* 1 if gate.deliver has passed for this run */
    int advanceable;            /* 1 if the current block advances via advance_request


### PR DESCRIPTION
## Primary-as-manager S2 sub-slice 4 — per-block resolver + dispatch-time externalization guard

Step 4 of the S2 build order (proposal §4/§6, consult Q2/Q3). Follows sub-slice 3 (#941). Reuses the sub-slice-1 policy cores (`wfe_surface_allows`, `wfe_block_default_surface`, `wfe_externalization_*`) — this slice is the **wiring**.

### What's here
- **`wfe_block_resolve.{h,c}`** — resolves a session's per-block enforcement context from **authoritative DB state** (binding → work-item → pinned workflow → current node): `{bound, surface, delivered, advanceable, stage}`. An unbound session, a vanished work-item, or any load failure → not bound / no restriction (a binding-layer failure is isolated, never fails the turn).
- **Dispatch-time externalization guard (Q3)** — the narrow run-state invariant *behind* tool visibility: a bound enforced run whose `gate.deliver` has not passed may **not** call an externalization primitive (`pr.open`/`merge`, `git_push`, `curl`, `post_comment`, …). Enforced at the MCP tool-**dispatch** seam (`handle_mcp_call`, keyed on the authoritative session id) so it covers the table / workflow-tool / `git_` paths alike — *"tool visibility alone is not a security boundary."*
  - Pure decision `wfe_toolcall_decide` (fully unit-tested) + composed `wfe_mcp_toolcall_action`.
  - Dial: advisory = observe, soft = warn+allow, hard = refuse. Every non-allow decision is **audited** to `lifecycle_event` (templated, no tool/arg echo). Delivery **lifts** the guard.

### Safety posture
- **Default-OFF** (`AIMEE_WORKFLOW_ENFORCE_STAGE` unset → ALLOW).
- Fail-open only for *availability* (binding lookup failure → generic, no restriction); the **policy** decision (pre-delivery externalization) fails **closed** under `hard`.

### Verification
- `test_wfe_block_resolve` (pure decision table + real DB1/engine resolve + the composed guard incl. deny/warn/allow, delivered-lifts, audit) — green.
- Production `aimee-server` links; local **CMake thin-client build clean** (`wfe_block_resolve.c` in `SERVER_SRCS` only, mirroring `wfe_advance_exec` so the Windows thin client doesn't compile it); lint gates pass.

### Deferred (documented, not missing)
The ingress tool-**visibility** strip feeding `gateway_policy_strip_tools` + `advance_request` per-block **injection** need a session id at the `/v1/messages` gateway seam (`gw_request_t` carries none) — the same session-identity/binding-creation seam. This slice lands the **structural dispatch-time guard**, which enforces even when visibility is bypassed. Live `.253→.254` verification also pending; default-off until then.
