### PR TITLE
fix(webui): size workflow canvas to node extents so it scrolls fully

### DIFF
--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -599,6 +599,22 @@ export default function Workflows() {
     return p ? { x: p.x + NODE_W / 2, y: p.y + NODE_H / 2 } : { x: 0, y: 0 };
   };
 
+  // Size the SVG to the actual node extents (plus a margin) so the overflow box
+  // can scroll to every node. A fixed 1600×1000 canvas clipped the scroll region,
+  // so deep workflows (x grows ~230px/depth) or nodes dragged right/down became
+  // unreachable. Keep a floor so a small graph still fills the viewport.
+  const CANVAS_PAD = 80;
+  let canvasW = 1600;
+  let canvasH = 1000;
+  if (graph) {
+    for (const n of graph.nodes) {
+      const p = pos[n.id];
+      if (!p) continue;
+      canvasW = Math.max(canvasW, p.x + NODE_W + CANVAS_PAD);
+      canvasH = Math.max(canvasH, p.y + NODE_H + CANVAS_PAD);
+    }
+  }
+
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <ProjectPicker
@@ -787,7 +803,7 @@ export default function Workflows() {
           }}
           onClick={() => setSelected(null)}
         >
-          <svg width={1600} height={1000} style={{ display: "block" }}>
+          <svg width={canvasW} height={canvasH} style={{ display: "block" }}>
             <defs>
               <marker
                 id="arrow"


### PR DESCRIPTION
## Problem

On the Workflows page, a workflow that is long horizontally cannot be fully scrolled into view — nodes past the right (or bottom) edge are unreachable.

The graph is an SVG inside a container that scrolls via `overflow: auto`, but the SVG was hard-coded to `width={1600} height={1000}`. The scrollable region is exactly the SVG's size, so anything beyond that box is clipped away. `autoLayout` places nodes at `x = 40 + depth*230`, so a workflow ~7+ blocks deep already runs past 1600px; dragging a node right/down has the same effect.

## Fix

Compute the SVG `width`/`height` from the actual node positions (`pos[n.id].x + NODE_W + pad`), keeping the original 1600×1000 as a floor so small graphs still fill the viewport. Because it reads live `pos`, this covers both the deep auto-layout case and manually dragged nodes.

Single-file change in `frontend/src/pages/Workflows.tsx`. `tsc --noEmit` passes.