### PR TITLE
feat(audit): S1 — args_hash_v1 keyed-HMAC argument digest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,7 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/config_save.c
     ${AIMEE_SRC_DIR}/util.c
     ${AIMEE_SRC_DIR}/util_url.c
+    ${AIMEE_SRC_DIR}/audit_action.c
     ${AIMEE_SRC_DIR}/report_enrichment.c
     ${AIMEE_SRC_DIR}/delivery_target.c
     ${AIMEE_SRC_DIR}/text.c

--- a/docs/proposals/pending/governance-decision-records-and-action-audit.plan.md
+++ b/docs/proposals/pending/governance-decision-records-and-action-audit.plan.md
@@ -1,0 +1,167 @@
+# Implementation Plan: governance decision records + per-action policy-verdict audit
+
+Companion to `governance-decision-records-and-action-audit.md` (merged to `testing`, PR #945).
+Grounded against the code 2026-07-02. **P2 (audit) ships before P1 (decision record)** per the
+proposal's reader-before-writer, lowest-risk-first sequencing.
+
+## Verification substrate (confirmed working)
+
+- **Inner loop — local unit tests.** `cc`/`gcc`/`make` + `cmake`/`ctest` present; `build/` exists;
+  `aimee-core` static lib + test targets build and run in seconds (verified: `test_util` passes).
+  35 ctest targets. This is the per-slice fast loop.
+- **Production build** — `make -C src ../aimee-server` (the CMake `aimee-server` target is
+  known-stale; do not rely on it — [[aimee-two-build-systems]]).
+- **Integration loop — PVE `root@192.168.1.253`.** CT 101 `aimee-docker` running; spin a fresh CT
+  for any slice that needs a live DB2/postgres + running server (S2 audit-file assertion, S4/S5/S6
+  decision_log DDL + recall). Watch the docker-lxc Env/PATH bug ([[lxc2docker-image-env-path-bug]]):
+  pass `-e PATH=...` when building in a non-login shell.
+- **CI gates** — no co-author trailers, no Claude attribution ([[aimee-ci-no-coauthor-trailers]],
+  [[no-claude-attribution-in-prs]]); schema/docs-gen/lint/Windows gates trip on C/DB changes
+  ([[aimee-pr-ci-gates]]).
+
+## Per-slice protocol
+
+Each slice: branch off `origin/testing` → implement → local ctest (+ .253 integration if it touches
+DB/server/audit-file) → **roundtable review the CODE** ([[always-roundtable-review-before-pr]]) →
+address findings → PR → merge to `testing`. Slices are independently shippable.
+
+## Grounded seams (exact)
+
+- `audit_log(event_type, fmt, …)` (`src/log.c:143`) writes `{"ts","event","detail"}` JSON to a
+  0600 rotated `audit.log`. **Add a sibling `audit_action_log(...)`** writing the enriched governed-
+  action row to the **same** `audit_fp` (single sink, same mutex/rotation) — existing callers
+  untouched.
+- `pre_tool_check()` (`src/guardrails_orchestrator.c:1196`) — block sites already call
+  `audit_log("<stable_key>", …)` (`read_before_write`:1783, `truncating_write`:1813,
+  `stale_edit`:1845, `subagent_blocked`:1615, `antipattern_blocked`:1673); allow terminal is
+  `return 0` (:1999). Verdict contract `0/1/2` (`src/headers/guardrails.h:134`).
+- `hmac_sha256()` + `wfe_sha256_raw()` (`src/workflow/wfe_approval.c:90`) — reuse for `args_hash`.
+- `decision_log` table (`src/db2/schema.sql:29`) + full API `db2_decision_log_insert/get/
+  set_outcome/list` + `db2_decision_log_row_t` (`src/db2/decision_log.h`) + client wrappers
+  (`kb_client_decision_log_*`). Extend additively.
+- `rel_types` table (`schema.sql:1067`) + `db2_rel_types_stage_provisional()`
+  (`src/db2/rel_types_store.c:132`) — runtime `INSERT`, no migration.
+- Recall expiry sweep — `memory_directive_sweep_expired()` in `recall_fill_reminders()`
+  (`src/memory_context.c:920`); client wrapper `kb_client_memory_directive_sweep_expired_json()`.
+  Periodic drain — `kb_curator_drain.c` `drain_thread_main` (`DRAIN_POLL_SECS=5`).
+
+---
+
+## P2 — Per-action audit (ship first)
+
+### S1 — `args_hash_v1` (pure helper + unit tests)
+- New `src/audit_action.{c,h}`: `audit_args_hash(const char *tool, const char *args_json, char out[…])`
+  → `"v1:<hex>"`. Keyed HMAC-SHA256 (reuse `wfe_sha256_raw`) over a **canonical projection**:
+  sorted-key JSON with a static volatile-field redaction allow-list (drop `timestamp`/`ts`/
+  `request_id`/`session_id`/ephemeral tokens). Version-pinned.
+- **Key source** — see Q1 (roundtable). Default assumption pending answer: a dedicated
+  `$AIMEE_HOME/.audit-key` (same 0600 provisioning as `.approval-key`), NOT the approval key, to
+  avoid coupling the audit digest to the approval trust root.
+- Tests: determinism; key-sensitivity (different key → different hash); volatile-field redaction;
+  key-order independence; empty/oversized args bounded.
+- Pure, no DB/server → **local ctest only**.
+
+### S2 — structured governed-action audit row + wire into `pre_tool_check`
+- `audit_action_log(actor, tool, args_hash, mode, reason_code, verdict, detail)` in `log.c` →
+  `{"ts","event":"tool_action","actor","tool","args_hash","mode","reason_code","verdict","detail"}`
+  to the same `audit.log`.
+- Wire: at each block site pass the existing stable key as `reason_code`, `verdict="block"` (or
+  `"approval_required"` where the prose prefix already distinguishes it); add ONE call on the allow
+  path (`return 0`) with `verdict="allow"`. `mode` = `guardrail_mode` enum value (stable id).
+  `reason_code`/prose split: **only the stable key is persisted**, never `msg_buf` prose.
+- **Fail-open invariant**: `audit_action_log` runs post-verdict, side-effect-only; a write/format
+  failure never mutates the returned `0/1/2`.
+- Rollout: emit behind a config flag; default-on only after S3's reader ships (reader-before-writer).
+- Tests: local — block→`verdict=block`+`reason_code`; allow→`verdict=allow`; a forced audit-emit
+  failure leaves the verdict unchanged. **.253 integration** — assert the JSON line lands in
+  `audit.log` under a live server driving a blocked Write.
+
+### S3 — `trajectory_export` reads `audit.log`
+- Extend `src/trajectory_export.c` with an optional reader parsing `audit.log` JSON lines,
+  interleaving `event:"tool_action"` rows by `ts` into the exported trajectory. Config-gated;
+  tolerate legacy/unknown lines (`{ts,event,detail}` and future kinds) — reader ships before the
+  writer defaults on.
+- Tests: a `tool_action` row round-trips into the export; a legacy `audit_log` line is ignored
+  without error.
+
+---
+
+## P1 — Decision record
+
+### S4 — `decision_log` governance columns + `rel_types`
+- Additive `ALTER TABLE decision_log ADD COLUMN IF NOT EXISTS` (match the repo's migration
+  convention — confirm whether `schema.sql` is apply-once `CREATE IF NOT EXISTS` + a migrations
+  path, or re-run idempotent): `status TEXT DEFAULT 'active'`, `revisit_when TEXT`,
+  `supersedes_id BIGINT`, `author TEXT`, `linked_policy_id BIGINT`. Extend `db2_decision_log_row_t`
+  + `insert`/`get`/`list` + client wrappers.
+- Register `rel_types` rows `supersedes`, `linked-policy`, `decided-by` via
+  `db2_rel_types_stage_provisional()` (runtime INSERT, no migration).
+- Tests: new columns round-trip through insert/get; rel_types rows present after registration.
+
+### S5 — decision write path + one-active-per-scope invariant
+- Write sets `status='active'`; when `supersedes_id` is set, flip the prior row to `'superseded'`
+  in the same transaction. `supersedes_id`+`status`+`created_at` give the version chain.
+- **Invariant**: at most one `active` decision per *scope* — see Q2 (roundtable) for the scope key.
+  Enforce via a partial unique index and/or the `memory_fact_gate` verdict path.
+- Tests: supersede deactivates prior + chain queryable; a second `active` for the same scope is
+  rejected.
+
+### S6 — `revisit_when` surfacing (no new scheduler)
+- Lazy-at-recall: extend the `memory_directive_sweep_expired()` path so a decision past
+  `revisit_when` flips to `status='revisit_due'` and surfaces on recall.
+- Periodic: add one per-poll scan block in `kb_curator_drain` for due decisions.
+- Tests: a decision past `revisit_when` surfaces as `revisit_due` on the next recall; the periodic
+  scan flips it without a recall.
+
+---
+
+## Decisions — RESOLVED by roundtable (2026-07-02, 5/7 healthy, verified=7, not degraded)
+
+1. **`args_hash` key source → dedicated `$AIMEE_HOME/.audit-key`.** Isolates the audit tamper-
+   evidence trust root from the `wfe_approval` authorization root (different threat model, different
+   rotation). Mirror `wfe_approval_ensure_key()` (atomic `O_EXCL` + `/dev/urandom`, 0600).
+   **Fail-closed at startup** (provision the key when the server starts); **fail-open at hash time**
+   (if the key is somehow absent, skip the audit row — never HMAC-over-empty "integrity theater",
+   and never block the tool).
+2. **Decision "scope" → `(subject, linked_policy_id)`** with an **explicit new `subject` column**
+   (do NOT overload `task_id`). NULL `linked_policy_id` handled by `COALESCE(linked_policy_id,-1)`
+   in the partial unique index (Postgres treats NULLs as distinct, which would silently void the
+   invariant for policy-less decisions).
+3. **`audit_action_log` → new sibling function** to the same `audit.log` (existing `audit_log`
+   callers untouched). Confirmed.
+4. **Default-on timing → flag-gated until S3 merges, then a dedicated flip slice (S7).** Confirmed.
+
+## Roundtable disposition — revisions folded into the slices above
+
+- **Migration (was BLOCKING) → resolved.** `schema.sql` is re-run idempotently with inline
+  `ALTER TABLE … ADD COLUMN IF NOT EXISTS` (precedent: `memories` at `schema.sql:224`, `terms` at
+  `:21`). S4 adds ALTERs to `schema.sql`; **no migrations dir, no separate migration file.**
+- **S1 redaction → INVERT to a per-tool allowlist** (denylist-by-omission would leak future
+  PII/secret fields into a tamper-evident append-only log). `args_hash` HMACs a per-tool allowlist
+  of decision-relevant fields (`file_path`/`command`/`old_string`/`new_string`/`url`…); an
+  **unknown tool hashes tool-name only** (never its values). Contract documented in the header.
+- **S1 bounds** — hard cap 64 KiB / bounded depth+key-count; oversize → HMAC a truncation marker +
+  bounded prefix (stable, verifiable). Reuse cJSON for parse; deterministic whitespace-free
+  sorted-key serializer as a small audited helper with golden vectors. Version tag `v1-`.
+- **S2 exactly-once emit → structural, not convention.** Refactor: rename the body to
+  `pre_tool_check_inner()` returning the verdict + a small `{verdict, reason_code}` out-struct set at
+  each block/allow site; a thin outer `pre_tool_check()` calls inner, emits **one**
+  `audit_action_log()` post-verdict, returns unchanged. Kills the "many `return 0` sites" bug the
+  verifier flagged. `guardrail_mode` is already a `pre_tool_check` param → in scope at the wrapper.
+- **S2/S3 shape discriminator → new top-level `"kind":"tool_action"`** (do NOT overload `event`);
+  legacy `audit_log` rows keep `event`. The audit row is **stand-alone — no FK to `decision_log`**
+  (so P2 ships before P1). Reader discriminates on `kind`.
+- **Config plumbing → owned by S1.** Define `audit.action_enabled` (default false) + one accessor;
+  S2 (writer) and S3 (reader) both read it. No independent config reach-ins.
+- **S3 rotation/ties** — read current + rotated logs for the window; deterministic tie-break by
+  (file order, byte offset). Rate-limited warn on unparseable lines (don't silently swallow).
+- **S6 → dedicated idempotent `decision_log_mark_revisit_due(now)`** owning the transition; called
+  by BOTH the recall site and the drain (do not overload `memory_directive_sweep_expired`, which is
+  named for a different row type). Index `revisit_when` (avoid O(N) scans every 5 s).
+- **S7 (NEW) — default-on flip.** After S3 merges: flip `audit.action_enabled` default to true;
+  verify on a live `.253`/`.254` server that `trajectory_export` consumes `tool_action` rows.
+  Prevents a silently-written, never-read dead feature.
+
+## Slice ledger
+- [ ] S1 args_hash_v1 + config knob · [ ] S2 inner/outer refactor + action-audit row · [ ] S3 export reader
+- [ ] S4 decision_log cols (+subject) + rel_types · [ ] S5 write path + partial-unique invariant · [ ] S6 revisit sweep API · [ ] S7 default-on flip + live verify

--- a/src/audit_action.c
+++ b/src/audit_action.c
@@ -13,7 +13,18 @@
 #include "aimee_home.h"
 #include "cJSON.h"
 #include "platform_path.h"
-#include "wfe_def.h" /* wfe_sha256_raw */
+#include "platform_random.h" /* platform_random_bytes (portable CSPRNG) */
+#include "wfe_def.h"         /* wfe_sha256_raw */
+
+/* O_NOFOLLOW / O_CLOEXEC are POSIX hardening flags absent on some toolchains
+ * (e.g. MinGW). Degrade to no-ops there — the audit key is server-side (POSIX);
+ * on Windows this build path is the client, where the flags do not apply. */
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW 0
+#endif
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
 
 #define AUDIT_KEY_LEN 32
 
@@ -96,17 +107,8 @@ int audit_ensure_key(void)
       /* Someone else created it concurrently — accept iff it now loads. */
       return audit_load_key(key) == 0 ? 0 : -1;
    }
-   FILE *r = fopen("/dev/urandom", "rb");
-   if (!r)
-   {
-      close(fd);
-      unlink(path);
-      return -1;
-   }
-   size_t got = fread(key, 1, AUDIT_KEY_LEN, r);
-   fclose(r);
    int ok = 0;
-   if (got == AUDIT_KEY_LEN)
+   if (platform_random_bytes(key, AUDIT_KEY_LEN) == 0)
    {
       ssize_t w = write(fd, key, AUDIT_KEY_LEN);
       ok = (w == (ssize_t)AUDIT_KEY_LEN);

--- a/src/audit_action.c
+++ b/src/audit_action.c
@@ -1,0 +1,305 @@
+/* audit_action.c: governed-action audit primitives. See audit_action.h for the
+ * args_hash contract. */
+#include "audit_action.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "aimee_home.h"
+#include "cJSON.h"
+#include "platform_path.h"
+#include "wfe_def.h" /* wfe_sha256_raw */
+
+#define AUDIT_KEY_LEN 32
+
+/* Bounds (fold truncation markers into the hash input so the digest stays
+ * stable and verifiable when a limit is hit). */
+#define AUDIT_ARGS_MAX_INPUT (256 * 1024) /* skip parsing beyond this */
+#define AUDIT_VALUE_MAX_BYTES 8192        /* per allowlisted value */
+#define AUDIT_CANON_MAX_BYTES (64 * 1024) /* total canonical form */
+
+/* Field separators kept out of ordinary JSON text so they cannot be forged from
+ * within a value. */
+#define SEP_FIELD "\x1f"  /* between fields */
+#define SEP_KV "\x1e"     /* between key and value */
+
+/* ---- per-tool allowlist -------------------------------------------------- */
+
+typedef struct
+{
+   const char *tool;
+   const char *fields[6]; /* NULL-terminated; decision-relevant args only */
+} tool_allowlist_t;
+
+/* Only decision-relevant fields per governed tool. A tool absent here hashes its
+ * NAME ONLY. Field order here IS the canonical order — do not reorder without
+ * bumping the version prefix. */
+static const tool_allowlist_t ALLOWLIST[] = {
+    {"Write", {"file_path", "content", NULL}},
+    {"Edit", {"file_path", "old_string", "new_string", NULL}},
+    {"NotebookEdit", {"notebook_path", "new_source", NULL}},
+    {"Read", {"file_path", NULL}},
+    {"Bash", {"command", NULL}},
+    {"execute_script", {"command", "script", NULL}},
+    {"WebFetch", {"url", NULL}},
+    {"WebSearch", {"query", NULL}},
+};
+
+static const tool_allowlist_t *allowlist_for(const char *tool)
+{
+   if (!tool)
+      return NULL;
+   for (size_t i = 0; i < sizeof(ALLOWLIST) / sizeof(ALLOWLIST[0]); i++)
+      if (strcmp(ALLOWLIST[i].tool, tool) == 0)
+         return &ALLOWLIST[i];
+   return NULL;
+}
+
+/* ---- key management (mirrors wfe_approval_ensure_key) --------------------- */
+
+static void audit_key_path(char *buf, size_t cap)
+{
+   snprintf(buf, cap, "%s/.audit-key", aimee_home());
+}
+
+static int audit_load_key(unsigned char key[AUDIT_KEY_LEN])
+{
+   char path[1024];
+   audit_key_path(path, sizeof path);
+   int fd = open(path, O_RDONLY | O_NOFOLLOW);
+   if (fd < 0)
+      return -1;
+   ssize_t n = read(fd, key, AUDIT_KEY_LEN);
+   close(fd);
+   return n == (ssize_t)AUDIT_KEY_LEN ? 0 : -1;
+}
+
+int audit_ensure_key(void)
+{
+   unsigned char key[AUDIT_KEY_LEN];
+   if (audit_load_key(key) == 0)
+      return 0;
+   char path[1024];
+   audit_key_path(path, sizeof path);
+   /* Atomic, 0600-from-creation, no-symlink-follow: no world-readable window and
+    * no first-run race corrupting the key. */
+   int fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0600);
+   if (fd < 0)
+   {
+      /* Someone else created it concurrently — accept iff it now loads. */
+      return audit_load_key(key) == 0 ? 0 : -1;
+   }
+   FILE *r = fopen("/dev/urandom", "rb");
+   if (!r)
+   {
+      close(fd);
+      unlink(path);
+      return -1;
+   }
+   size_t got = fread(key, 1, AUDIT_KEY_LEN, r);
+   fclose(r);
+   int ok = 0;
+   if (got == AUDIT_KEY_LEN)
+   {
+      ssize_t w = write(fd, key, AUDIT_KEY_LEN);
+      ok = (w == (ssize_t)AUDIT_KEY_LEN);
+   }
+   close(fd);
+   if (!ok)
+   {
+      unlink(path);
+      return -1;
+   }
+   platform_set_permissions(path, 0600);
+   return 0;
+}
+
+/* ---- HMAC-SHA256 over wfe_sha256_raw ------------------------------------- */
+
+static void hmac_sha256(const unsigned char *key, size_t keylen, const unsigned char *msg,
+                        size_t mlen, unsigned char mac[32])
+{
+   unsigned char k[64];
+   memset(k, 0, sizeof k);
+   if (keylen > 64)
+      wfe_sha256_raw(key, keylen, k);
+   else
+      memcpy(k, key, keylen);
+
+   unsigned char ipad[64], opad[64];
+   for (int i = 0; i < 64; i++)
+   {
+      ipad[i] = k[i] ^ 0x36;
+      opad[i] = k[i] ^ 0x5c;
+   }
+   /* inner = H(ipad || msg) */
+   unsigned char *inner_in = malloc(64 + mlen);
+   unsigned char inner[32];
+   if (!inner_in)
+   {
+      /* Degrade to unkeyed over the message length only; caller treats a hash
+       * failure as best-effort. Still deterministic. */
+      unsigned char lenbuf[8];
+      for (int i = 0; i < 8; i++)
+         lenbuf[i] = (unsigned char)((mlen >> (8 * i)) & 0xff);
+      wfe_sha256_raw(lenbuf, sizeof lenbuf, mac);
+      return;
+   }
+   memcpy(inner_in, ipad, 64);
+   memcpy(inner_in + 64, msg, mlen);
+   wfe_sha256_raw(inner_in, 64 + mlen, inner);
+   free(inner_in);
+   /* mac = H(opad || inner) */
+   unsigned char outer_in[64 + 32];
+   memcpy(outer_in, opad, 64);
+   memcpy(outer_in + 64, inner, 32);
+   wfe_sha256_raw(outer_in, 96, mac);
+}
+
+/* ---- canonical projection ------------------------------------------------ */
+
+/* Append `s` (len bytes) to canon[*pos], capped at AUDIT_CANON_MAX_BYTES. If the
+ * append would overflow, append a stable truncation marker once and stop. */
+static void canon_append(char *canon, size_t *pos, const char *s, size_t len)
+{
+   if (*pos >= AUDIT_CANON_MAX_BYTES)
+      return;
+   size_t room = AUDIT_CANON_MAX_BYTES - *pos;
+   if (len > room)
+   {
+      static const char mark[] = SEP_FIELD "<trunc>";
+      size_t mlen = sizeof(mark) - 1;
+      size_t take = room > mlen ? room - mlen : 0;
+      memcpy(canon + *pos, s, take);
+      *pos += take;
+      memcpy(canon + *pos, mark, room - take > mlen ? mlen : room - take);
+      *pos = AUDIT_CANON_MAX_BYTES; /* freeze */
+      return;
+   }
+   memcpy(canon + *pos, s, len);
+   *pos += len;
+}
+
+/* Serialize a cJSON value to a bounded string for the canonical form. Strings use
+ * their raw text; everything else uses compact JSON. Values are capped at
+ * AUDIT_VALUE_MAX_BYTES with a stable marker. */
+static void canon_append_value(char *canon, size_t *pos, const cJSON *v)
+{
+   char *owned = NULL;
+   const char *text;
+   size_t len;
+   char numbuf[64];
+   if (cJSON_IsString(v) && v->valuestring)
+   {
+      text = v->valuestring;
+      len = strlen(text);
+   }
+   else if (cJSON_IsNumber(v))
+   {
+      snprintf(numbuf, sizeof numbuf, "%.17g", v->valuedouble);
+      text = numbuf;
+      len = strlen(numbuf);
+   }
+   else if (cJSON_IsBool(v))
+   {
+      text = cJSON_IsTrue(v) ? "true" : "false";
+      len = strlen(text);
+   }
+   else if (cJSON_IsNull(v))
+   {
+      text = "null";
+      len = 4;
+   }
+   else
+   {
+      owned = cJSON_PrintUnformatted(v);
+      text = owned ? owned : "";
+      len = strlen(text);
+   }
+   if (len > AUDIT_VALUE_MAX_BYTES)
+   {
+      canon_append(canon, pos, text, AUDIT_VALUE_MAX_BYTES);
+      canon_append(canon, pos, SEP_KV "<vtrunc>", 9);
+   }
+   else
+   {
+      canon_append(canon, pos, text, len);
+   }
+   if (owned)
+      free(owned);
+}
+
+int audit_args_hash(const char *tool_name, const char *args_json, char *out, size_t out_sz)
+{
+   /* Stable sentinel for any failure path. */
+   if (out && out_sz >= AUDIT_ARGS_HASH_LEN)
+   {
+      memcpy(out, "v1-", 3);
+      memset(out + 3, '0', 64);
+      out[67] = '\0';
+   }
+   if (!out || out_sz < AUDIT_ARGS_HASH_LEN)
+      return -1;
+
+   unsigned char key[AUDIT_KEY_LEN];
+   if (audit_load_key(key) != 0)
+      return -1; /* no key -> caller skips the row (never HMAC-over-empty) */
+
+   char *canon = malloc(AUDIT_CANON_MAX_BYTES + 16);
+   if (!canon)
+      return -1;
+   size_t pos = 0;
+
+   /* Always lead with the tool name (name-only for unknown tools). */
+   canon_append(canon, &pos, tool_name ? tool_name : "", tool_name ? strlen(tool_name) : 0);
+
+   const tool_allowlist_t *al = allowlist_for(tool_name);
+   if (al && args_json && *args_json)
+   {
+      size_t jlen = strlen(args_json);
+      if (jlen > AUDIT_ARGS_MAX_INPUT)
+      {
+         /* Oversize input: fold a stable marker + length, skip parsing (DoS bound). */
+         char marker[64];
+         int n = snprintf(marker, sizeof marker, SEP_FIELD "<oversize:%zu>", jlen);
+         canon_append(canon, &pos, marker, (size_t)n);
+      }
+      else
+      {
+         cJSON *root = cJSON_Parse(args_json);
+         if (root)
+         {
+            for (const char *const *f = al->fields; *f; f++)
+            {
+               cJSON *item = cJSON_GetObjectItemCaseSensitive(root, *f);
+               if (!item)
+                  continue; /* absent field contributes nothing */
+               canon_append(canon, &pos, SEP_FIELD, 1);
+               canon_append(canon, &pos, *f, strlen(*f));
+               canon_append(canon, &pos, SEP_KV, 1);
+               canon_append_value(canon, &pos, item);
+            }
+            cJSON_Delete(root);
+         }
+         /* Unparseable JSON: hash tool-name only (values never guessed). */
+      }
+   }
+
+   unsigned char mac[32];
+   hmac_sha256(key, AUDIT_KEY_LEN, (const unsigned char *)canon, pos, mac);
+   free(canon);
+
+   static const char hx[] = "0123456789abcdef";
+   memcpy(out, "v1-", 3);
+   for (int i = 0; i < 32; i++)
+   {
+      out[3 + i * 2] = hx[(mac[i] >> 4) & 0xf];
+      out[3 + i * 2 + 1] = hx[mac[i] & 0xf];
+   }
+   out[67] = '\0';
+   return 0;
+}

--- a/src/audit_action.c
+++ b/src/audit_action.c
@@ -3,6 +3,7 @@
 #include "audit_action.h"
 
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,16 +17,18 @@
 
 #define AUDIT_KEY_LEN 32
 
-/* Bounds (fold truncation markers into the hash input so the digest stays
- * stable and verifiable when a limit is hit). */
+/* Bounds. Truncation markers and length prefixes are folded INTO the hash input
+ * so the digest stays stable and verifiable when a limit is hit. */
 #define AUDIT_ARGS_MAX_INPUT (256 * 1024) /* skip parsing beyond this */
 #define AUDIT_VALUE_MAX_BYTES 8192        /* per allowlisted value */
-#define AUDIT_CANON_MAX_BYTES (64 * 1024) /* total canonical form */
+#define AUDIT_CANON_ALLOC (64 * 1024)     /* canon buffer allocation */
+#define AUDIT_CANON_LIMIT (AUDIT_CANON_ALLOC - 32) /* logical fill limit (marker reserve) */
 
-/* Field separators kept out of ordinary JSON text so they cannot be forged from
- * within a value. */
-#define SEP_FIELD "\x1f"  /* between fields */
-#define SEP_KV "\x1e"     /* between key and value */
+/* Component separator. NOTE: canonical components are LENGTH-PREFIXED (see
+ * canon_add), so injectivity does NOT depend on this byte being absent from a
+ * value — a value may contain it (e.g. via a  JSON escape) without forging
+ * a boundary. The separator is retained only for readability of the hash input. */
+#define SEP "\x1f"
 
 /* ---- per-tool allowlist -------------------------------------------------- */
 
@@ -70,7 +73,7 @@ static int audit_load_key(unsigned char key[AUDIT_KEY_LEN])
 {
    char path[1024];
    audit_key_path(path, sizeof path);
-   int fd = open(path, O_RDONLY | O_NOFOLLOW);
+   int fd = open(path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
    if (fd < 0)
       return -1;
    ssize_t n = read(fd, key, AUDIT_KEY_LEN);
@@ -87,7 +90,7 @@ int audit_ensure_key(void)
    audit_key_path(path, sizeof path);
    /* Atomic, 0600-from-creation, no-symlink-follow: no world-readable window and
     * no first-run race corrupting the key. */
-   int fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0600);
+   int fd = open(path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0600);
    if (fd < 0)
    {
       /* Someone else created it concurrently — accept iff it now loads. */
@@ -120,13 +123,15 @@ int audit_ensure_key(void)
 
 /* ---- HMAC-SHA256 over wfe_sha256_raw ------------------------------------- */
 
-static void hmac_sha256(const unsigned char *key, size_t keylen, const unsigned char *msg,
-                        size_t mlen, unsigned char mac[32])
+/* Returns 0 on success, -1 on failure. On failure the caller MUST NOT emit a
+ * digest (never an unkeyed hash). */
+static int hmac_sha256(const unsigned char *key, size_t keylen, const unsigned char *msg,
+                       size_t mlen, unsigned char mac[32])
 {
    unsigned char k[64];
    memset(k, 0, sizeof k);
    if (keylen > 64)
-      wfe_sha256_raw(key, keylen, k);
+      wfe_sha256_raw(key, keylen, k); /* key = H(key): 32 bytes, rest zero */
    else
       memcpy(k, key, keylen);
 
@@ -136,58 +141,74 @@ static void hmac_sha256(const unsigned char *key, size_t keylen, const unsigned 
       ipad[i] = k[i] ^ 0x36;
       opad[i] = k[i] ^ 0x5c;
    }
-   /* inner = H(ipad || msg) */
+
+   if (mlen > SIZE_MAX - 64)
+      return -1; /* addition overflow guard */
    unsigned char *inner_in = malloc(64 + mlen);
-   unsigned char inner[32];
    if (!inner_in)
-   {
-      /* Degrade to unkeyed over the message length only; caller treats a hash
-       * failure as best-effort. Still deterministic. */
-      unsigned char lenbuf[8];
-      for (int i = 0; i < 8; i++)
-         lenbuf[i] = (unsigned char)((mlen >> (8 * i)) & 0xff);
-      wfe_sha256_raw(lenbuf, sizeof lenbuf, mac);
-      return;
-   }
+      return -1; /* hard fail — never fall back to an unkeyed digest */
    memcpy(inner_in, ipad, 64);
-   memcpy(inner_in + 64, msg, mlen);
+   if (mlen)
+      memcpy(inner_in + 64, msg, mlen);
+   unsigned char inner[32];
    wfe_sha256_raw(inner_in, 64 + mlen, inner);
    free(inner_in);
-   /* mac = H(opad || inner) */
-   unsigned char outer_in[64 + 32];
+
+   unsigned char outer_in[96]; /* opad(64) || inner(32) */
    memcpy(outer_in, opad, 64);
    memcpy(outer_in + 64, inner, 32);
    wfe_sha256_raw(outer_in, 96, mac);
+   return 0;
 }
 
-/* ---- canonical projection ------------------------------------------------ */
+int audit_hmac_sha256_testonly(const unsigned char *key, size_t keylen, const unsigned char *msg,
+                               size_t mlen, unsigned char mac[32])
+{
+   return hmac_sha256(key, keylen, msg, mlen, mac);
+}
 
-/* Append `s` (len bytes) to canon[*pos], capped at AUDIT_CANON_MAX_BYTES. If the
- * append would overflow, append a stable truncation marker once and stop. */
+/* ---- canonical projection (length-prefixed, injective) ------------------- */
+
+/* Append `len` bytes at canon[*pos], capped at AUDIT_CANON_LIMIT. On overflow,
+ * fold a stable "<trunc>" marker into the reserved slack (still within the
+ * allocation) and freeze so no later component is appended. */
 static void canon_append(char *canon, size_t *pos, const char *s, size_t len)
 {
-   if (*pos >= AUDIT_CANON_MAX_BYTES)
-      return;
-   size_t room = AUDIT_CANON_MAX_BYTES - *pos;
-   if (len > room)
+   if (*pos >= AUDIT_CANON_LIMIT)
+      return; /* frozen */
+   size_t room = AUDIT_CANON_LIMIT - *pos;
+   size_t take = len < room ? len : room;
+   memcpy(canon + *pos, s, take);
+   *pos += take;
+   if (take < len)
    {
-      static const char mark[] = SEP_FIELD "<trunc>";
-      size_t mlen = sizeof(mark) - 1;
-      size_t take = room > mlen ? room - mlen : 0;
-      memcpy(canon + *pos, s, take);
-      *pos += take;
-      memcpy(canon + *pos, mark, room - take > mlen ? mlen : room - take);
-      *pos = AUDIT_CANON_MAX_BYTES; /* freeze */
-      return;
+      static const char mark[] = SEP "<trunc>";
+      size_t mlen = sizeof(mark) - 1; /* fits in the ALLOC-LIMIT reserve */
+      memcpy(canon + *pos, mark, mlen);
+      *pos += mlen; /* now >= AUDIT_CANON_LIMIT -> frozen; marker IS hashed */
    }
-   memcpy(canon + *pos, s, len);
-   *pos += len;
 }
 
-/* Serialize a cJSON value to a bounded string for the canonical form. Strings use
- * their raw text; everything else uses compact JSON. Values are capped at
- * AUDIT_VALUE_MAX_BYTES with a stable marker. */
-static void canon_append_value(char *canon, size_t *pos, const cJSON *v)
+/* Append one length-prefixed component: SEP <declen> ":" <bytes>. The length
+ * precedes the bytes, so no in-value byte can forge a component boundary — the
+ * canonical form is injective over (tool, projected-fields) regardless of value
+ * content. */
+static void canon_add(char *canon, size_t *pos, char tag, const char *bytes, size_t len)
+{
+   char pre[40];
+   int n = snprintf(pre, sizeof pre, SEP "%c%zu:", tag, len);
+   if (n < 0)
+      n = 0;
+   if ((size_t)n > sizeof pre)
+      n = (int)sizeof pre;
+   canon_append(canon, pos, pre, (size_t)n);
+   canon_append(canon, pos, bytes, len);
+}
+
+/* Materialize a cJSON value to bounded bytes and append it length-prefixed. The
+ * 'T'/'F' tag records whether the value was truncated, so a capped 8 KiB value
+ * is distinct from an exact 8 KiB value. */
+static void canon_add_value(char *canon, size_t *pos, const cJSON *v)
 {
    char *owned = NULL;
    const char *text;
@@ -216,26 +237,26 @@ static void canon_append_value(char *canon, size_t *pos, const cJSON *v)
    }
    else
    {
+      /* Non-scalar (array/object): compact-print. Bounded by the parsed input
+       * (<= AUDIT_ARGS_MAX_INPUT); only AUDIT_VALUE_MAX_BYTES enter the hash. */
       owned = cJSON_PrintUnformatted(v);
       text = owned ? owned : "";
       len = strlen(text);
    }
+   char tag = 'F';
    if (len > AUDIT_VALUE_MAX_BYTES)
    {
-      canon_append(canon, pos, text, AUDIT_VALUE_MAX_BYTES);
-      canon_append(canon, pos, SEP_KV "<vtrunc>", 9);
+      len = AUDIT_VALUE_MAX_BYTES;
+      tag = 'T';
    }
-   else
-   {
-      canon_append(canon, pos, text, len);
-   }
+   canon_add(canon, pos, tag, text, len);
    if (owned)
       free(owned);
 }
 
 int audit_args_hash(const char *tool_name, const char *args_json, char *out, size_t out_sz)
 {
-   /* Stable sentinel for any failure path. */
+   /* Stable sentinel for any failure path (never a forgeable/unkeyed digest). */
    if (out && out_sz >= AUDIT_ARGS_HASH_LEN)
    {
       memcpy(out, "v1-", 3);
@@ -249,24 +270,23 @@ int audit_args_hash(const char *tool_name, const char *args_json, char *out, siz
    if (audit_load_key(key) != 0)
       return -1; /* no key -> caller skips the row (never HMAC-over-empty) */
 
-   char *canon = malloc(AUDIT_CANON_MAX_BYTES + 16);
+   char *canon = malloc(AUDIT_CANON_ALLOC);
    if (!canon)
       return -1;
    size_t pos = 0;
 
-   /* Always lead with the tool name (name-only for unknown tools). */
-   canon_append(canon, &pos, tool_name ? tool_name : "", tool_name ? strlen(tool_name) : 0);
+   /* Always lead with the (length-prefixed) tool name; name-only for unknown tools. */
+   canon_add(canon, &pos, 'N', tool_name ? tool_name : "", tool_name ? strlen(tool_name) : 0);
 
    const tool_allowlist_t *al = allowlist_for(tool_name);
    if (al && args_json && *args_json)
    {
-      size_t jlen = strlen(args_json);
+      size_t jlen = strnlen(args_json, AUDIT_ARGS_MAX_INPUT + 1);
       if (jlen > AUDIT_ARGS_MAX_INPUT)
       {
-         /* Oversize input: fold a stable marker + length, skip parsing (DoS bound). */
-         char marker[64];
-         int n = snprintf(marker, sizeof marker, SEP_FIELD "<oversize:%zu>", jlen);
-         canon_append(canon, &pos, marker, (size_t)n);
+         /* Oversize input: fold a stable marker, skip parsing (DoS bound). Uses
+          * strnlen so we never scan past the cap. */
+         canon_add(canon, &pos, 'O', "oversize", 8);
       }
       else
       {
@@ -278,20 +298,20 @@ int audit_args_hash(const char *tool_name, const char *args_json, char *out, siz
                cJSON *item = cJSON_GetObjectItemCaseSensitive(root, *f);
                if (!item)
                   continue; /* absent field contributes nothing */
-               canon_append(canon, &pos, SEP_FIELD, 1);
-               canon_append(canon, &pos, *f, strlen(*f));
-               canon_append(canon, &pos, SEP_KV, 1);
-               canon_append_value(canon, &pos, item);
+               canon_add(canon, &pos, 'K', *f, strlen(*f));
+               canon_add_value(canon, &pos, item);
             }
-            cJSON_Delete(root);
+            cJSON_Delete(root); /* cJSON_Delete(NULL) is a no-op; safe */
          }
-         /* Unparseable JSON: hash tool-name only (values never guessed). */
+         /* Unparseable JSON: tool-name only (values never guessed). */
       }
    }
 
    unsigned char mac[32];
-   hmac_sha256(key, AUDIT_KEY_LEN, (const unsigned char *)canon, pos, mac);
+   int hrc = hmac_sha256(key, AUDIT_KEY_LEN, (const unsigned char *)canon, pos, mac);
    free(canon);
+   if (hrc != 0)
+      return -1; /* keep the sentinel; never emit an unkeyed digest */
 
    static const char hx[] = "0123456789abcdef";
    memcpy(out, "v1-", 3);

--- a/src/headers/audit_action.h
+++ b/src/headers/audit_action.h
@@ -1,0 +1,64 @@
+/* audit_action.h: governed-action audit primitives (P2 of the governance
+ * decision-records + per-action-audit proposal).
+ *
+ * This slice (S1) provides the tamper-evident argument digest used by the
+ * per-action audit row. The row emitter (audit_action_log) and its wiring into
+ * pre_tool_check land in S2; the trajectory_export reader in S3.
+ *
+ * ---- args_hash contract (version "v1-") ------------------------------------
+ *
+ * The digest is HMAC-SHA256(audit-key, canon), rendered as "v1-<64 lowercase
+ * hex>". `canon` is a deterministic serialization of a PER-TOOL ALLOWLIST
+ * projection of the tool's JSON arguments:
+ *
+ *   - Only fields on the tool's allowlist contribute to the hash. Every other
+ *     field — including any field a future tool adds — is DROPPED and never
+ *     enters the hash. This is an allowlist BY CONSTRUCTION: a new tool, or a
+ *     new argument on an existing tool, can never silently leak a secret or PII
+ *     value into the append-only audit log.
+ *   - A tool with no allowlist entry hashes its NAME ONLY (no argument values).
+ *   - The canonical form fixes field order from the allowlist (not from the
+ *     input JSON), so it is independent of input key order and insignificant
+ *     whitespace without relying on a general sorted-key JSON serializer.
+ *   - Inputs are bounded: oversized input, oversized field values, and values
+ *     beyond the per-value cap are truncated with a stable marker folded INTO
+ *     the hash input, so the digest stays reproducible and verifiable.
+ *
+ * The digest is keyed (HMAC, not a bare hash) so low-entropy arguments cannot be
+ * recovered by dictionary/rainbow attack against the public audit log. The key
+ * is dedicated ($AIMEE_HOME/.audit-key) and MUST NOT be the wfe_approval key —
+ * the two have different threat models and rotation cadences.
+ */
+#ifndef AIMEE_AUDIT_ACTION_H
+#define AIMEE_AUDIT_ACTION_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* "v1-" (3) + 64 hex + NUL. */
+#define AUDIT_ARGS_HASH_LEN 68
+
+/* Compute the args hash for (tool_name, args_json) into `out` (capacity
+ * >= AUDIT_ARGS_HASH_LEN). `args_json` may be NULL/empty (hashes the tool name
+ * only). Returns 0 on success.
+ *
+ * Best-effort: on any failure (key unavailable, allocation) it writes the stable
+ * sentinel "v1-" followed by 64 '0' and returns -1. Callers audit best-effort
+ * and MUST NOT block a tool on a non-zero return. */
+int audit_args_hash(const char *tool_name, const char *args_json, char *out, size_t out_sz);
+
+/* Ensure the dedicated audit HMAC key exists at $AIMEE_HOME/.audit-key (0600, 32
+ * random bytes), provisioning it atomically if absent (mirrors
+ * wfe_approval_ensure_key). Call once at server startup so hash time always has
+ * a real key. Returns 0 if the key exists or was created, -1 otherwise. */
+int audit_ensure_key(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AIMEE_AUDIT_ACTION_H */

--- a/src/headers/audit_action.h
+++ b/src/headers/audit_action.h
@@ -57,6 +57,14 @@ int audit_args_hash(const char *tool_name, const char *args_json, char *out, siz
  * a real key. Returns 0 if the key exists or was created, -1 otherwise. */
 int audit_ensure_key(void);
 
+/* Test-only seam: the internal HMAC-SHA256 used by audit_args_hash, exposed so
+ * unit tests can pin it against RFC 4231 known-answer vectors (validates the
+ * ipad/opad construction, 64-byte block, and key>64 pre-hash path). Not part of
+ * the public API — do not use in product code. Returns 0 on success, -1 on
+ * failure (allocation / length overflow). */
+int audit_hmac_sha256_testonly(const unsigned char *key, size_t keylen, const unsigned char *msg,
+                               size_t mlen, unsigned char mac[32]);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_test(NAME test_context_engine COMMAND test_context_engine)
 set_tests_properties(test_context_engine PROPERTIES
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 aimee_add_test(test_util test_util.c)
+aimee_add_test(test_audit_action test_audit_action.c)
 aimee_add_test(test_db test_db.c)
 aimee_add_test(test_config test_config.c)
 aimee_add_test(test_cron_config test_cron_config.c ../config_trigger.c)

--- a/src/tests/test_audit_action.c
+++ b/src/tests/test_audit_action.c
@@ -135,6 +135,94 @@ static void test_missing_key_returns_sentinel(void)
    assert(is_sentinel(out)); /* never HMAC-over-empty; stable sentinel */
 }
 
+static void mac_hex(const unsigned char mac[32], char out[65])
+{
+   static const char hx[] = "0123456789abcdef";
+   for (int i = 0; i < 32; i++)
+   {
+      out[i * 2] = hx[(mac[i] >> 4) & 0xf];
+      out[i * 2 + 1] = hx[mac[i] & 0xf];
+   }
+   out[64] = '\0';
+}
+
+/* RFC 4231 known-answer vectors: independently validate the HMAC-SHA256
+ * construction (ipad/opad, 64-byte block, key>64 pre-hash), not just internal
+ * determinism. */
+static void test_hmac_rfc4231_vectors(void)
+{
+   unsigned char mac[32];
+   char hex[65];
+
+   /* Test Case 2: short key. */
+   assert(audit_hmac_sha256_testonly((const unsigned char *)"Jefe", 4,
+                                     (const unsigned char *)"what do ya want for nothing?", 28,
+                                     mac) == 0);
+   mac_hex(mac, hex);
+   assert(strcmp(hex, "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843") == 0);
+
+   /* Test Case 6: key longer than the 64-byte block -> exercises the pre-hash path. */
+   unsigned char longkey[131];
+   memset(longkey, 0xaa, sizeof longkey);
+   const char *data6 = "Test Using Larger Than Block-Size Key - Hash Key First";
+   assert(audit_hmac_sha256_testonly(longkey, sizeof longkey, (const unsigned char *)data6,
+                                     strlen(data6), mac) == 0);
+   mac_hex(mac, hex);
+   assert(strcmp(hex, "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54") == 0);
+}
+
+/* Separator bytes inside a value must not forge a component boundary: an
+ * attacker stuffing the length-prefix separator into old_string cannot collide
+ * with a differently-structured argument set. */
+static void test_separator_injection_no_collision(void)
+{
+   set_home_fresh();
+   assert(audit_ensure_key() == 0);
+   char a[AUDIT_ARGS_HASH_LEN], b[AUDIT_ARGS_HASH_LEN], b2[AUDIT_ARGS_HASH_LEN];
+   hash_of("Edit", "{\"file_path\":\"/f\",\"old_string\":\"b\",\"new_string\":\"c\"}", a);
+   /* old_string carries a literal 0x1f () + a fake "K10:new_string" prefix */
+   hash_of("Edit",
+           "{\"file_path\":\"/f\",\"old_string\":\"b\\u001fK10:new_string\",\"new_string\":\"c\"}",
+           b);
+   assert(strcmp(a, b) != 0); /* no collision: value bytes != structure */
+   /* and the injected-separator variant is itself deterministic */
+   hash_of("Edit",
+           "{\"file_path\":\"/f\",\"old_string\":\"b\\u001fK10:new_string\",\"new_string\":\"c\"}",
+           b2);
+   assert(strcmp(b, b2) == 0);
+}
+
+static void test_value_truncation_semantics(void)
+{
+   size_t cap = 8192; /* AUDIT_VALUE_MAX_BYTES */
+   char *exact = malloc(64 + cap);
+   char *trunc1 = malloc(64 + cap + 16);
+   char *trunc2 = malloc(64 + cap + 16);
+   assert(exact && trunc1 && trunc2);
+   /* content = cap 'A's exactly (not truncated, tag 'F') */
+   int off = snprintf(exact, 40, "{\"file_path\":\"/x\",\"content\":\"");
+   memset(exact + off, 'A', cap);
+   memcpy(exact + off + cap, "\"}", 3);
+   /* content = cap 'A's + "EXTRA" (truncated to cap, tag 'T') */
+   int o1 = snprintf(trunc1, 40, "{\"file_path\":\"/x\",\"content\":\"");
+   memset(trunc1 + o1, 'A', cap);
+   memcpy(trunc1 + o1 + cap, "EXTRA\"}", 8);
+   /* content = cap 'A's + "OTHER!" (also truncated to same cap 'A's) */
+   int o2 = snprintf(trunc2, 40, "{\"file_path\":\"/x\",\"content\":\"");
+   memset(trunc2 + o2, 'A', cap);
+   memcpy(trunc2 + o2 + cap, "OTHER!\"}", 9);
+
+   char he[AUDIT_ARGS_HASH_LEN], ht1[AUDIT_ARGS_HASH_LEN], ht2[AUDIT_ARGS_HASH_LEN];
+   hash_of("Write", exact, he);
+   hash_of("Write", trunc1, ht1);
+   hash_of("Write", trunc2, ht2);
+   assert(strcmp(he, ht1) != 0);  /* exact (F) != truncated (T) at the same prefix */
+   assert(strcmp(ht1, ht2) == 0); /* bytes beyond the cap don't affect the digest */
+   free(exact);
+   free(trunc1);
+   free(trunc2);
+}
+
 int main(void)
 {
    test_shape_and_determinism();
@@ -145,6 +233,9 @@ int main(void)
    test_oversize_is_bounded_and_stable();
    test_key_sensitivity();
    test_missing_key_returns_sentinel();
+   test_hmac_rfc4231_vectors();
+   test_separator_injection_no_collision();
+   test_value_truncation_semantics();
    printf("test_audit_action: all passed\n");
    return 0;
 }

--- a/src/tests/test_audit_action.c
+++ b/src/tests/test_audit_action.c
@@ -1,0 +1,150 @@
+/* test_audit_action.c: unit tests for the S1 args_hash primitive.
+ *
+ * Exercises the contract in audit_action.h: determinism, key-order and
+ * whitespace independence, per-tool allowlist projection (non-allowlisted fields
+ * dropped), unknown-tool name-only hashing, key-sensitivity, oversize bounding,
+ * and the best-effort failure sentinel. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "audit_action.h"
+
+static char g_home[512];
+
+static void set_home_fresh(void)
+{
+   /* A per-test temp AIMEE_HOME so .audit-key provisioning is isolated. */
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-audit-test-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   setenv("AIMEE_HOME", g_home, 1);
+}
+
+static void rm_key(void)
+{
+   char p[600];
+   snprintf(p, sizeof p, "%s/.audit-key", g_home);
+   unlink(p);
+}
+
+static int is_sentinel(const char *h)
+{
+   if (strncmp(h, "v1-", 3) != 0)
+      return 0;
+   for (int i = 3; i < 67; i++)
+      if (h[i] != '0')
+         return 0;
+   return h[67] == '\0';
+}
+
+static void hash_of(const char *tool, const char *args, char out[AUDIT_ARGS_HASH_LEN])
+{
+   int rc = audit_args_hash(tool, args, out, AUDIT_ARGS_HASH_LEN);
+   assert(rc == 0);
+   assert(strncmp(out, "v1-", 3) == 0);
+   assert(strlen(out) == 67);
+   assert(!is_sentinel(out)); /* a keyed hash is not the all-zero sentinel */
+}
+
+static void test_shape_and_determinism(void)
+{
+   set_home_fresh();
+   rm_key();
+   assert(audit_ensure_key() == 0);
+
+   char a[AUDIT_ARGS_HASH_LEN], b[AUDIT_ARGS_HASH_LEN];
+   hash_of("Write", "{\"file_path\":\"/x\",\"content\":\"hello\"}", a);
+   hash_of("Write", "{\"file_path\":\"/x\",\"content\":\"hello\"}", b);
+   assert(strcmp(a, b) == 0); /* deterministic */
+}
+
+static void test_key_order_and_whitespace_independent(void)
+{
+   char a[AUDIT_ARGS_HASH_LEN], b[AUDIT_ARGS_HASH_LEN];
+   hash_of("Edit", "{\"file_path\":\"/f\",\"old_string\":\"x\",\"new_string\":\"y\"}", a);
+   /* reordered keys + extra whitespace -> same projection -> same hash */
+   hash_of("Edit", "{ \"new_string\":\"y\" ,  \"file_path\":\"/f\", \"old_string\":\"x\" }", b);
+   assert(strcmp(a, b) == 0);
+}
+
+static void test_allowlist_drops_extra_fields(void)
+{
+   char base[AUDIT_ARGS_HASH_LEN], with_secret[AUDIT_ARGS_HASH_LEN];
+   hash_of("Write", "{\"file_path\":\"/x\",\"content\":\"c\"}", base);
+   /* a non-allowlisted field (a token/PII) must NOT change the hash */
+   hash_of("Write", "{\"file_path\":\"/x\",\"content\":\"c\",\"authorization\":\"Bearer sk-secret\"}",
+           with_secret);
+   assert(strcmp(base, with_secret) == 0);
+}
+
+static void test_distinct_actions_differ(void)
+{
+   char x[AUDIT_ARGS_HASH_LEN], y[AUDIT_ARGS_HASH_LEN];
+   hash_of("Write", "{\"file_path\":\"/a\",\"content\":\"c\"}", x);
+   hash_of("Write", "{\"file_path\":\"/b\",\"content\":\"c\"}", y);
+   assert(strcmp(x, y) != 0); /* different target -> different digest */
+}
+
+static void test_unknown_tool_hashes_name_only(void)
+{
+   char x[AUDIT_ARGS_HASH_LEN], y[AUDIT_ARGS_HASH_LEN], z[AUDIT_ARGS_HASH_LEN];
+   /* unknown tool: args are ignored entirely (name-only) */
+   hash_of("MysteryTool", "{\"anything\":\"1\"}", x);
+   hash_of("MysteryTool", "{\"totally\":\"different\"}", y);
+   assert(strcmp(x, y) == 0);
+   /* but a different tool name still differs */
+   hash_of("OtherTool", "{\"anything\":\"1\"}", z);
+   assert(strcmp(x, z) != 0);
+}
+
+static void test_oversize_is_bounded_and_stable(void)
+{
+   size_t n = 300 * 1024; /* beyond AUDIT_ARGS_MAX_INPUT */
+   char *big = malloc(n + 64);
+   assert(big);
+   int off = snprintf(big, 40, "{\"file_path\":\"/x\",\"content\":\"");
+   memset(big + off, 'A', n);
+   memcpy(big + off + n, "\"}", 3);
+   char a[AUDIT_ARGS_HASH_LEN], b[AUDIT_ARGS_HASH_LEN];
+   hash_of("Write", big, a);
+   hash_of("Write", big, b);
+   assert(strcmp(a, b) == 0); /* oversize path is deterministic, no crash */
+   free(big);
+}
+
+static void test_key_sensitivity(void)
+{
+   char k1[AUDIT_ARGS_HASH_LEN], k2[AUDIT_ARGS_HASH_LEN];
+   hash_of("Bash", "{\"command\":\"ls\"}", k1);
+   /* rotate the key: same input must produce a different digest */
+   rm_key();
+   assert(audit_ensure_key() == 0);
+   hash_of("Bash", "{\"command\":\"ls\"}", k2);
+   assert(strcmp(k1, k2) != 0);
+}
+
+static void test_missing_key_returns_sentinel(void)
+{
+   rm_key(); /* no key present, do NOT ensure */
+   char out[AUDIT_ARGS_HASH_LEN];
+   int rc = audit_args_hash("Bash", "{\"command\":\"ls\"}", out, sizeof out);
+   assert(rc == -1);
+   assert(is_sentinel(out)); /* never HMAC-over-empty; stable sentinel */
+}
+
+int main(void)
+{
+   test_shape_and_determinism();
+   test_key_order_and_whitespace_independent();
+   test_allowlist_drops_extra_fields();
+   test_distinct_actions_differ();
+   test_unknown_tool_hashes_name_only();
+   test_oversize_is_bounded_and_stable();
+   test_key_sensitivity();
+   test_missing_key_returns_sentinel();
+   printf("test_audit_action: all passed\n");
+   return 0;
+}


### PR DESCRIPTION
First slice of the per-action governance audit (P2) from the merged proposal (PR #945). Pure helper + the roundtable-approved implementation plan.

## What
- `src/audit_action.{c,h}` — `audit_args_hash()`: HMAC-SHA256 over a **per-tool allowlist** projection of a tool call's decision-relevant args, rendered `v1-<hex>`. Allowlist *by construction* — non-allowlisted (and future/unknown) fields never enter the tamper-evident log; unknown tools hash **name-only**. Dedicated `$AIMEE_HOME/.audit-key` (0600, atomic `O_EXCL`), isolating the audit trust root from `wfe_approval`. Best-effort/fail-open: missing key → stable sentinel + rc −1, **never** HMAC-over-empty, **never** blocks a tool.
- Canonical form is **injective** (length-prefixed components) and independent of input key order / whitespace, without a general sorted-key JSON serializer.
- Bounded input (256 KiB skip-parse) / value (8 KiB) / canon (64 KiB) with stable truncation markers folded into the hash.

## Tests (11 cases, local ctest green)
determinism · key-order/whitespace independence · allowlist-drops-secrets · distinct-action divergence · unknown-tool name-only · oversize bounding · key-sensitivity · missing-key sentinel · **RFC 4231 HMAC vectors (cases 2 & 6)** · separator-injection no-collision · value-truncation distinctness.

## Roundtable
Design pre-approved; the **code** was roundtabled (7 panelists). All 5 blocking findings fixed in the second commit: unkeyed-digest-on-malloc-failure → hard-fail; non-injective canon (`\u001f` escape boundary forgery) → length-prefixing; truncation-marker math; overflow guard; `O_CLOEXEC`. Added the requested RFC-vector + injection regression tests.

Config knob (`audit.action_enabled`) deferred to S2 (its first consumer) to keep its 4 config touch-points under one owner. No runtime behavior change yet — this slice only adds the primitive.