### PR TITLE
feat(server): primary-as-manager S2 binding-creation seam (live unblock)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/workflow/wfe_engine.c
     ${AIMEE_SRC_DIR}/workflow/wfe_advance_exec.c
     ${AIMEE_SRC_DIR}/workflow/wfe_block_resolve.c
+    ${AIMEE_SRC_DIR}/workflow/wfe_bind_ingress.c
     ${AIMEE_SRC_DIR}/workflow/wfe_blocks.c
     ${AIMEE_SRC_DIR}/workflow/wfe_approval.c
     ${AIMEE_SRC_DIR}/workflow/wfe_verdict.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -294,7 +294,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \
-            workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c workflow/wfe_manager_artifacts.c workflow/wfe_externalization.c workflow/wfe_enforce.c workflow/wfe_deliver.c workflow/wfe_advance.c workflow/wfe_advance_exec.c workflow/wfe_block_resolve.c workflow/wfe_router.c workflow/wfe_router_catalog.c \
+            workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c workflow/wfe_manager_artifacts.c workflow/wfe_externalization.c workflow/wfe_enforce.c workflow/wfe_deliver.c workflow/wfe_advance.c workflow/wfe_advance_exec.c workflow/wfe_block_resolve.c workflow/wfe_bind_ingress.c workflow/wfe_router.c workflow/wfe_router_catalog.c \
             harness_memory_common.c harness_memory_scope.c harness_memory_audit.c harness_memory_spill.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 

--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -149,4 +149,12 @@ void ingress_preinject_mint_turn_id(char *buf, size_t len);
 void ingress_preinject_set_turn_id(const char *turn_id);
 const char *ingress_preinject_turn_id(void);
 
+/* Per-turn aimee session id, recovered at HTTP ingress from the primary provider's
+ * "aimee-sess-<sid>" auth token (S2 binding seam). Like the turn id it is a
+ * per-request thread-local the HTTP layer sets (or "" to clear) on every request,
+ * so a reused worker thread never leaks one turn's session onto the next. "" when
+ * the request carries no aimee-session token (a non-primary / unidentified turn). */
+void ingress_preinject_set_session_id(const char *session_id);
+const char *ingress_preinject_session_id(void);
+
 #endif /* DEC_INGRESS_PREINJECT_H */

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -1,6 +1,7 @@
 /* server_compute.c: POSIX chat.send_stream worker for primary-agent streaming. */
 #include "aimee.h"
 #include "agent_adapter.h"
+#include "ingress_preinject.h" /* S2 binding: publish primary session id per turn */
 #include "agent_config.h"
 #include "agent_exec.h"
 #include "agent_tools.h"   /* agent_tools_set_tool_event_cb — stream tool events */
@@ -727,6 +728,10 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
       run_cmd_set_cwd(use_cwd);
    if (aimee_sid && aimee_sid[0])
       session_id_set_override(aimee_sid);
+   /* S2 binding seam: publish the primary session id for this turn so the gateway
+    * router (gw_stage_router, invoked synchronously on THIS thread by the agent
+    * below) can create + bind an enforced work-item. Cleared with the override. */
+   ingress_preinject_set_session_id(aimee_sid && aimee_sid[0] ? aimee_sid : "");
 
    stream_event(cctx, "turn_start", NULL, NULL);
    /* Surface mirror drift (client head vs server mirror) before the turn acts —
@@ -766,6 +771,7 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
    cli_session_set_stream_cb(prev_stream_cb, prev_stream_ud);
    agent_tools_set_tool_event_cb(NULL, NULL);
    session_id_clear_override();
+   ingress_preinject_set_session_id(""); /* don't leak this turn's session id */
    workspace_turn_unbind_active();
    run_cmd_set_cwd(NULL);
    free(system_prompt);

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -69,6 +69,21 @@ const char *ingress_preinject_turn_id(void)
    return g_turn_id;
 }
 
+static __thread char g_session_id[64] = "";
+
+void ingress_preinject_set_session_id(const char *session_id)
+{
+   if (session_id && session_id[0])
+      snprintf(g_session_id, sizeof(g_session_id), "%s", session_id);
+   else
+      g_session_id[0] = '\0';
+}
+
+const char *ingress_preinject_session_id(void)
+{
+   return g_session_id;
+}
+
 /* A stable, non-reversible fingerprint of the turn query (FNV-1a 64-bit, hex).
  * Recorded on the retrieval_event instead of the raw prompt so the audit row
  * correlates turns (same query → same fingerprint) without persisting user

--- a/src/server/primary_session_adapter.c
+++ b/src/server/primary_session_adapter.c
@@ -1,5 +1,6 @@
 /* primary_session_adapter.c: direct primary-agent conversation sessions. */
 #include "primary_session_adapter.h"
+#include "ingress_preinject.h" /* S2 binding: publish primary session id per turn */
 
 #include "agent_adapter.h"
 #include "agent_exec.h"
@@ -256,6 +257,10 @@ int primary_session_adapter_turn(const primary_session_request_t *req, agent_res
       run_cmd_set_cwd(req->cwd);
    if (effective_aimee_session_id[0])
       session_id_set_override(effective_aimee_session_id);
+   /* S2 binding seam: publish the primary session id so the gateway router can bind
+    * an enforced work-item for this turn (agent_execute below runs the provider on
+    * THIS thread). Cleared alongside the override after the turn. */
+   ingress_preinject_set_session_id(effective_aimee_session_id);
 
    cJSON *updated_messages = NULL;
    int max_tokens = req->max_tokens > 0 ? req->max_tokens : AGENT_DEFAULT_MAX_TOKENS;
@@ -265,6 +270,7 @@ int primary_session_adapter_turn(const primary_session_request_t *req, agent_res
                                              initial_messages, &updated_messages, out);
 
    session_id_clear_override();
+   ingress_preinject_set_session_id(""); /* don't leak this turn's session id */
    run_cmd_set_cwd(NULL);
    cJSON_Delete(initial_messages);
 

--- a/src/server/router_advise.c
+++ b/src/server/router_advise.c
@@ -25,6 +25,7 @@
 #include "gateway_pipeline.h"  /* gw_request_t — the shared gateway seam */
 #include "ingress_preinject.h" /* query-from-messages + per-turn id */
 #include "interaction_events.h"
+#include "wfe_bind_ingress.h"
 #include "wfe_enforce.h"
 #include "wfe_router.h"
 
@@ -163,6 +164,15 @@ int gw_stage_router(gw_request_t *r, void *ud)
       return 0;
    const char *tid = ingress_preinject_turn_id();
    router_advise_log((tid && tid[0]) ? tid : "ingress", query);
+
+   /* S2 binding seam: if this turn carries an aimee session id (recovered at HTTP
+    * ingress from the primary provider's "aimee-sess-<sid>" auth token) and the
+    * router picks an enforced workflow, create + bind a work-item so the dispatch
+    * guard + advance driver can fire. Idempotent per session; default-OFF via the
+    * dial. Non-primary turns (delegates) carry no aimee-session token -> no-op. */
+   const char *bsid = ingress_preinject_session_id();
+   if (bsid && bsid[0])
+      wfe_bind_interactive(bsid, query, NULL);
    free(query);
    return 0;
 }

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -25,6 +25,7 @@
 #include "aimee_version.h"
 #include "openai_shape.h"
 #include "ingress_preinject.h"
+#include "wfe_bind_ingress.h" /* aimee-sess-<sid> auth-token -> session id (S2 binding) */
 #include "openapi_server_data.h" /* AIMEE_OPENAPI_SERVER_YAML_STR (generated from api/openapi-server-v1.yaml) */
 #include "openai_runs_store.h"
 #include "roundtable_pipeline_capture.h" /* pipeline op-run capture seam (#18/#20) */
@@ -1451,6 +1452,19 @@ static void handle_conn(int fd, int is_tcp)
        * this reused worker thread; the OpenAI-family ingress dispatch mints a
        * fresh one below when evidence emission is on. */
       ingress_preinject_set_turn_id("");
+      /* S2 binding seam: recover the aimee session id from the primary provider's
+       * "aimee-sess-<sid>" auth token (Authorization or x-api-key). Identity, not
+       * auth (UDS still authorizes by filesystem); set every request so a reused
+       * worker thread never leaks one turn's session onto the next. "" when the
+       * request carries no aimee-session token. */
+      {
+         char bsid[64] = "";
+         if ((has_auth && wfe_session_id_from_auth(auth, bsid, sizeof bsid)) ||
+             (has_api_key && wfe_session_id_from_auth(api_key, bsid, sizeof bsid)))
+            ingress_preinject_set_session_id(bsid);
+         else
+            ingress_preinject_set_session_id("");
+      }
       anthropic_http_capture_request_headers(buf); /* parity: per-request anthropic-* hdrs */
       int az = server_http_authorize(is_tcp, g_bearer, has_auth ? auth : NULL,
                                      has_api_key ? api_key : NULL, has_skey);

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -25,7 +25,6 @@
 #include "aimee_version.h"
 #include "openai_shape.h"
 #include "ingress_preinject.h"
-#include "wfe_bind_ingress.h" /* aimee-sess-<sid> auth-token -> session id (S2 binding) */
 #include "openapi_server_data.h" /* AIMEE_OPENAPI_SERVER_YAML_STR (generated from api/openapi-server-v1.yaml) */
 #include "openai_runs_store.h"
 #include "roundtable_pipeline_capture.h" /* pipeline op-run capture seam (#18/#20) */
@@ -1452,19 +1451,6 @@ static void handle_conn(int fd, int is_tcp)
        * this reused worker thread; the OpenAI-family ingress dispatch mints a
        * fresh one below when evidence emission is on. */
       ingress_preinject_set_turn_id("");
-      /* S2 binding seam: recover the aimee session id from the primary provider's
-       * "aimee-sess-<sid>" auth token (Authorization or x-api-key). Identity, not
-       * auth (UDS still authorizes by filesystem); set every request so a reused
-       * worker thread never leaks one turn's session onto the next. "" when the
-       * request carries no aimee-session token. */
-      {
-         char bsid[64] = "";
-         if ((has_auth && wfe_session_id_from_auth(auth, bsid, sizeof bsid)) ||
-             (has_api_key && wfe_session_id_from_auth(api_key, bsid, sizeof bsid)))
-            ingress_preinject_set_session_id(bsid);
-         else
-            ingress_preinject_set_session_id("");
-      }
       anthropic_http_capture_request_headers(buf); /* parity: per-request anthropic-* hdrs */
       int az = server_http_authorize(is_tcp, g_bearer, has_auth ? auth : NULL,
                                      has_api_key ? api_key : NULL, has_skey);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -135,6 +135,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-wfe-advance \
                $(TESTPREFIX)/unit-test-wfe-advance-exec \
                $(TESTPREFIX)/unit-test-wfe-block-resolve \
+               $(TESTPREFIX)/unit-test-wfe-bind-ingress \
                $(TESTPREFIX)/unit-test-wfe-binding \
                $(TESTPREFIX)/unit-test-aimee-ir \
                $(TESTPREFIX)/unit-test-aimee-ir-metrics \
@@ -1335,6 +1336,21 @@ $(TESTPREFIX)/unit-test-wfe-enforce: $(OBJDIR)/tests/test_wfe_enforce.o \
 # S2 sub-slice 3: advance_request pure core (parser + CAS/replay decision; cJSON only).
 $(TESTPREFIX)/unit-test-wfe-advance: $(OBJDIR)/tests/test_wfe_advance.o \
                                     $(OBJDIR)/workflow/wfe_advance.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# S2 binding seam: auth-token->sid parser + idempotent interactive bind.
+$(TESTPREFIX)/unit-test-wfe-bind-ingress: $(OBJDIR)/tests/test_wfe_bind_ingress.o \
+                                    $(OBJDIR)/workflow/wfe_bind_ingress.o $(OBJDIR)/workflow/wfe_enforce.o \
+                                    $(OBJDIR)/workflow/wfe_externalization.o $(OBJDIR)/db1/wfe_binding.o \
+                                    $(OBJDIR)/workflow/wfe_router.o $(OBJDIR)/workflow/wfe_router_catalog.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_manager_artifacts.o $(OBJDIR)/workflow/wfe_deliver.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
+                                    $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # S2 sub-slice 4: per-block resolver + dispatch-time externalization guard.

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1055,6 +1055,7 @@ $(TESTPREFIX)/unit-test-workspace: $(OBJDIR)/tests/test_workspace.o \
 
 $(TESTPREFIX)/unit-test-primary-session-adapter: $(OBJDIR)/tests/test_primary_session_adapter.o \
                                $(OBJDIR)/server/primary_session_adapter.o $(OBJDIR)/server/agent_adapter.o \
+                               $(OBJDIR)/server/ingress_preinject.o \
                                $(OBJDIR)/server/session_compact.o $(OBJDIR)/server/compact_prune.o $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o \
                                $(OBJDIR)/server/agent_request_shaping.o \
                                $(OBJDIR)/server/context_engine.o \

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -1,0 +1,163 @@
+/* test_wfe_bind_ingress.c -- S2 binding seam: the auth-token->sid parser (pure)
+ * + the idempotent interactive bind (real DB1 + router + engine, stub executors).
+ * Asserts: only enforced-routed turns bind, dial-off is inert, binding is
+ * idempotent per session, and a bind lifecycle event is recorded. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "db1.h"
+#include "wfe_bind_ingress.h"
+#include "wfe_binding.h"
+#include "wfe_engine.h"
+#include "wfe_store.h"
+
+/* enforced managed workflow "mc" (valid manager shape w/ terminal gate.deliver). */
+static const char *WF_MC = "name: mc\n"
+                           "enforced: true\n"
+                           "start: understand\n"
+                           "nodes:\n"
+                           "  - id: understand\n"
+                           "    block: understand\n"
+                           "    next: split\n"
+                           "  - id: split\n"
+                           "    block: split\n"
+                           "    in:\n"
+                           "      intent: understand.out\n"
+                           "    next: implement\n"
+                           "  - id: implement\n"
+                           "    block: implement\n"
+                           "    in:\n"
+                           "      plan: split.out\n"
+                           "    next: freeze\n"
+                           "  - id: freeze\n"
+                           "    block: freeze\n"
+                           "    in:\n"
+                           "      branch: implement.out\n"
+                           "    next: review\n"
+                           "  - id: review\n"
+                           "    block: review\n"
+                           "    in:\n"
+                           "      src: freeze.out\n"
+                           "    params:\n"
+                           "      reviewer: contrarian\n"
+                           "    on_pass: rt\n"
+                           "    on_fail: split\n"
+                           "  - id: rt\n"
+                           "    block: gate.roundtable\n"
+                           "    in:\n"
+                           "      src: freeze.out\n"
+                           "    params:\n"
+                           "      panel:\n"
+                           "        required:\n"
+                           "          - security\n"
+                           "          - architect\n"
+                           "    on_pass: deliver\n"
+                           "    on_fail: split\n"
+                           "  - id: deliver\n"
+                           "    block: gate.deliver\n"
+                           "    in:\n"
+                           "      verdict: rt.out\n";
+
+static void setup_home(void)
+{
+   char tmpl[] = "/tmp/wfe_bind_home_XXXXXX";
+   char *dir = mkdtemp(tmpl);
+   assert(dir);
+   char wf[512];
+   snprintf(wf, sizeof wf, "%s/workflows", dir);
+   mkdir(wf, 0755);
+   char path[640];
+   snprintf(path, sizeof path, "%s/mc.yaml", wf);
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(WF_MC, f);
+   fclose(f);
+   setenv("AIMEE_HOME", dir, 1);
+   char repo[600];
+   snprintf(repo, sizeof repo, "%s/repo", dir);
+   mkdir(repo, 0755);
+   setenv("AIMEE_WORKFLOW_REPO", repo, 1);
+}
+
+static void test_parse(void)
+{
+   char sid[64];
+   assert(wfe_session_id_from_auth("aimee-sess-1a2b3c4d", sid, sizeof sid) == 1);
+   assert(strcmp(sid, "1a2b3c4d") == 0);
+   assert(wfe_session_id_from_auth("Bearer aimee-sess-deadbeef", sid, sizeof sid) == 1);
+   assert(strcmp(sid, "deadbeef") == 0);
+   /* not an aimee-session token */
+   assert(wfe_session_id_from_auth("sk-ant-whatever", sid, sizeof sid) == 0);
+   assert(wfe_session_id_from_auth("aimee-local", sid, sizeof sid) == 0);
+   assert(wfe_session_id_from_auth("", sid, sizeof sid) == 0);
+   assert(wfe_session_id_from_auth(NULL, sid, sizeof sid) == 0);
+   /* bad charset in the sid (injection guard) */
+   assert(wfe_session_id_from_auth("aimee-sess-a/b", sid, sizeof sid) == 0);
+   assert(wfe_session_id_from_auth("aimee-sess-", sid, sizeof sid) == 0);
+}
+
+static int binding_wi(const char *sid, char *out, size_t n)
+{
+   return db1_wfe_binding_get(sid, out, n, NULL, 0);
+}
+
+int main(void)
+{
+   printf("wfe-bind-ingress: ");
+   test_parse();
+
+   setup_home();
+   assert(db1_init(":memory:") == 0);
+   wfe_reset_block_executors();
+   wfe_register_stub_executors();
+
+   const char *SID = "1a2b3c4d";
+   char wi[80] = "";
+
+   /* dial OFF -> inert (no bind even for an enforced-routed message) */
+   unsetenv("AIMEE_WORKFLOW_ENFORCE_STAGE");
+   assert(wfe_bind_interactive(SID, "use mc fix the bug", NULL) == 0);
+   assert(binding_wi(SID, wi, sizeof wi) == 0);
+
+   setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "advisory", 1);
+
+   /* a non-enforced route (converse) does NOT bind */
+   assert(wfe_bind_interactive(SID, "hello there", NULL) == 0);
+   assert(binding_wi(SID, wi, sizeof wi) == 0);
+
+   /* an enforced route binds; a work-item is created + the session bound */
+   assert(wfe_bind_interactive(SID, "use mc fix the bug", NULL) == 1);
+   assert(binding_wi(SID, wi, sizeof wi) == 1);
+   assert(wi[0]);
+   char first_wi[80];
+   snprintf(first_wi, sizeof first_wi, "%s", wi);
+
+   /* the bind was audited */
+   db1_lifecycle_event_t *ev = NULL;
+   int ne = db1_lifecycle_event_list(first_wi, &ev);
+   int binds = 0;
+   for (int i = 0; i < ne; i++)
+      if (strcmp(ev[i].actor, "bind-s2") == 0 && strcmp(ev[i].kind, "bind") == 0)
+         binds++;
+   free(ev);
+   assert(binds == 1);
+
+   /* idempotent: a second enforced turn reuses the SAME work-item, creates nothing */
+   assert(wfe_bind_interactive(SID, "use mc keep going", NULL) == 1);
+   assert(binding_wi(SID, wi, sizeof wi) == 1);
+   assert(strcmp(wi, first_wi) == 0);
+   /* still exactly one work item overall */
+   db1_work_item_t *items = NULL;
+   int n_items = db1_work_item_list(&items);
+   free(items);
+   assert(n_items == 1);
+
+   /* empty session id -> never binds */
+   assert(wfe_bind_interactive("", "use mc x", NULL) == 0);
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -1,7 +1,7 @@
-/* test_wfe_bind_ingress.c -- S2 binding seam: the auth-token->sid parser (pure)
- * + the idempotent interactive bind (real DB1 + router + engine, stub executors).
- * Asserts: only enforced-routed turns bind, dial-off is inert, binding is
- * idempotent per session, and a bind lifecycle event is recorded. */
+/* test_wfe_bind_ingress.c -- S2 binding seam: the idempotent interactive bind
+ * (real DB1 + router + engine, stub executors). Asserts: only enforced-routed
+ * turns bind, dial-off is inert, binding is idempotent per session, and a bind
+ * lifecycle event is recorded. */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -82,23 +82,6 @@ static void setup_home(void)
    setenv("AIMEE_WORKFLOW_REPO", repo, 1);
 }
 
-static void test_parse(void)
-{
-   char sid[64];
-   assert(wfe_session_id_from_auth("aimee-sess-1a2b3c4d", sid, sizeof sid) == 1);
-   assert(strcmp(sid, "1a2b3c4d") == 0);
-   assert(wfe_session_id_from_auth("Bearer aimee-sess-deadbeef", sid, sizeof sid) == 1);
-   assert(strcmp(sid, "deadbeef") == 0);
-   /* not an aimee-session token */
-   assert(wfe_session_id_from_auth("sk-ant-whatever", sid, sizeof sid) == 0);
-   assert(wfe_session_id_from_auth("aimee-local", sid, sizeof sid) == 0);
-   assert(wfe_session_id_from_auth("", sid, sizeof sid) == 0);
-   assert(wfe_session_id_from_auth(NULL, sid, sizeof sid) == 0);
-   /* bad charset in the sid (injection guard) */
-   assert(wfe_session_id_from_auth("aimee-sess-a/b", sid, sizeof sid) == 0);
-   assert(wfe_session_id_from_auth("aimee-sess-", sid, sizeof sid) == 0);
-}
-
 static int binding_wi(const char *sid, char *out, size_t n)
 {
    return db1_wfe_binding_get(sid, out, n, NULL, 0);
@@ -107,7 +90,6 @@ static int binding_wi(const char *sid, char *out, size_t n)
 int main(void)
 {
    printf("wfe-bind-ingress: ");
-   test_parse();
 
    setup_home();
    assert(db1_init(":memory:") == 0);

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -1,0 +1,98 @@
+/* wfe_bind_ingress.c -- see wfe_bind_ingress.h. */
+#include "wfe_bind_ingress.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "wfe_binding.h" /* db1_wfe_bind, db1_wfe_binding_get */
+#include "wfe_enforce.h" /* the dial */
+#include "wfe_engine.h"  /* wfe_work_item_create */
+#include "wfe_router.h"  /* catalog + decide + find */
+#include "wfe_store.h"   /* db1_lifecycle_event_add */
+
+/* id-charset guard: [A-Za-z0-9_-], 1..cap-1 chars (the session-id mint format). */
+static int id_ok(const char *s, size_t cap)
+{
+   if (!s || !s[0])
+      return 0;
+   size_t l = 0;
+   for (const char *p = s; *p; p++, l++)
+   {
+      char c = *p;
+      if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+            c == '_' || c == '-'))
+         return 0;
+   }
+   return l < cap;
+}
+
+int wfe_session_id_from_auth(const char *auth_value, char *out, size_t n)
+{
+   if (out && n)
+      out[0] = '\0';
+   if (!auth_value || !out || !n)
+      return 0;
+   const char *v = auth_value;
+   if (strncmp(v, "Bearer ", 7) == 0)
+      v += 7;
+   size_t pfx = sizeof(WFE_SESSION_TOKEN_PREFIX) - 1;
+   if (strncmp(v, WFE_SESSION_TOKEN_PREFIX, pfx) != 0)
+      return 0;
+   const char *sid = v + pfx;
+   if (!id_ok(sid, n))
+      return 0;
+   snprintf(out, n, "%s", sid);
+   return 1;
+}
+
+int wfe_bind_interactive(const char *session_id, const char *message, const char *repo)
+{
+   if (!session_id || !session_id[0])
+      return 0;
+
+   /* Default-OFF: the dial gates binding creation entirely. */
+   wfe_enforce_stage_t stage = wfe_enforce_stage_parse(getenv("AIMEE_WORKFLOW_ENFORCE_STAGE"));
+   if (stage == WFE_ENFORCE_OFF)
+      return 0;
+
+   /* Idempotent: already bound -> reuse, create nothing. This short-circuits every
+    * turn after the first, so the create path runs at most once per session. */
+   char wi[80] = "";
+   if (db1_wfe_binding_get(session_id, wi, sizeof wi, NULL, 0) == 1 && wi[0])
+      return 1;
+
+   if (!message || !message[0])
+      return 0;
+
+   /* Route the turn (pure prefilter+decide, no LLM). Only ENFORCED workflows bind;
+    * converse/research/non-enforced turns stay unbound (a generic session). */
+   wfe_router_catalog_t cat;
+   char err[256];
+   if (wfe_router_catalog_load(&cat, err, sizeof err) != 0)
+      return 0;
+   wfe_route_decision_t d;
+   wfe_router_decide(message, &cat, NULL /* no classifier at bind time */, &d);
+   const wfe_router_wf_t *w = wfe_router_find(&cat, d.workflow_id);
+   if (!w || !w->enforced)
+      return 0;
+
+   /* Deterministic per-session proposal path so UNIQUE(repo, proposal_path) is a
+    * stable backstop against a duplicate create. */
+   char proposal[128];
+   snprintf(proposal, sizeof proposal, "interactive/%s", session_id);
+   char id[80] = "";
+   if (wfe_work_item_create(d.workflow_id, repo ? repo : "", proposal, "interactive", id, err,
+                            sizeof err) != 0)
+      return 0; /* create failed (incl. a rare UNIQUE collision after an unbind) */
+
+   /* Bind the session, stamping the dial stage (monotonic per session row). */
+   if (db1_wfe_bind(session_id, id, wfe_enforce_stage_name(stage)) != 0)
+      return 0;
+
+   char detail[128];
+   snprintf(detail, sizeof detail, "{\"workflow\":\"%s\",\"stage\":\"%s\"}", w->id,
+            wfe_enforce_stage_name(stage));
+   db1_lifecycle_event_add(id, "", "bind", "bind-s2", detail, "", 0);
+   return 1;
+}

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -5,45 +5,25 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cJSON.h"
 #include "wfe_binding.h" /* db1_wfe_bind, db1_wfe_binding_get */
 #include "wfe_enforce.h" /* the dial */
 #include "wfe_engine.h"  /* wfe_work_item_create */
 #include "wfe_router.h"  /* catalog + decide + find */
 #include "wfe_store.h"   /* db1_lifecycle_event_add */
 
-/* id-charset guard: [A-Za-z0-9_-], 1..cap-1 chars (the session-id mint format). */
-static int id_ok(const char *s, size_t cap)
+static void audit_bind(const char *wi, const char *workflow, const char *stage)
 {
-   if (!s || !s[0])
-      return 0;
-   size_t l = 0;
-   for (const char *p = s; *p; p++, l++)
-   {
-      char c = *p;
-      if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-            c == '_' || c == '-'))
-         return 0;
-   }
-   return l < cap;
-}
-
-int wfe_session_id_from_auth(const char *auth_value, char *out, size_t n)
-{
-   if (out && n)
-      out[0] = '\0';
-   if (!auth_value || !out || !n)
-      return 0;
-   const char *v = auth_value;
-   if (strncmp(v, "Bearer ", 7) == 0)
-      v += 7;
-   size_t pfx = sizeof(WFE_SESSION_TOKEN_PREFIX) - 1;
-   if (strncmp(v, WFE_SESSION_TOKEN_PREFIX, pfx) != 0)
-      return 0;
-   const char *sid = v + pfx;
-   if (!id_ok(sid, n))
-      return 0;
-   snprintf(out, n, "%s", sid);
-   return 1;
+   cJSON *d = cJSON_CreateObject();
+   if (!d)
+      return;
+   cJSON_AddStringToObject(d, "workflow", workflow ? workflow : "");
+   cJSON_AddStringToObject(d, "stage", stage ? stage : "");
+   char *s = cJSON_PrintUnformatted(d);
+   cJSON_Delete(d);
+   if (s)
+      db1_lifecycle_event_add(wi, "", "bind", "bind-s2", s, "", 0);
+   free(s);
 }
 
 int wfe_bind_interactive(const char *session_id, const char *message, const char *repo)
@@ -90,9 +70,6 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
    if (db1_wfe_bind(session_id, id, wfe_enforce_stage_name(stage)) != 0)
       return 0;
 
-   char detail[128];
-   snprintf(detail, sizeof detail, "{\"workflow\":\"%s\",\"stage\":\"%s\"}", w->id,
-            wfe_enforce_stage_name(stage));
-   db1_lifecycle_event_add(id, "", "bind", "bind-s2", detail, "", 0);
+   audit_bind(id, w->id, wfe_enforce_stage_name(stage));
    return 1;
 }

--- a/src/workflow/wfe_bind_ingress.h
+++ b/src/workflow/wfe_bind_ingress.h
@@ -1,0 +1,37 @@
+/* wfe_bind_ingress.h -- S2 binding-creation seam (the live unblock).
+ *
+ * The dispatch guard + advance_request driver (sub-slices 3/4) key on the aimee
+ * session id, but the live primary's chat turn reaches the /v1/messages gateway
+ * with NO session id (gw_request_t carries none). This module closes that gap: the
+ * client encodes the session id in the primary provider's auth token
+ * ("aimee-sess-<sid>"), the server extracts it at HTTP ingress, and on a routed
+ * ENFORCED turn creates + binds a work-item so enforcement can fire.
+ *
+ * PURE where it can be: the token parser has no deps; the bind path composes the
+ * existing router + work-item + binding APIs behind the enforcement dial.
+ * Default-OFF: with the dial unset nothing binds. */
+#ifndef DEC_WFE_BIND_INGRESS_H
+#define DEC_WFE_BIND_INGRESS_H 1
+
+#include <stddef.h>
+
+/* The auth-token identity prefix the client stamps on the primary provider so the
+ * gateway can recover the aimee session id from an otherwise-opaque request. */
+#define WFE_SESSION_TOKEN_PREFIX "aimee-sess-"
+
+/* Extract the aimee session id from a client auth value of the form
+ * "aimee-sess-<sid>" (a leading "Bearer " is tolerated). The recovered sid must be
+ * id-charset ([A-Za-z0-9_-], the mint format). Returns 1 and fills `out` on a
+ * match, 0 otherwise (not an aimee-session token / bad charset / overflow). Pure. */
+int wfe_session_id_from_auth(const char *auth_value, char *out, size_t n);
+
+/* On an interactive primary turn, ensure `session_id` is bound to a work-item for
+ * the workflow the router picks for `message` -- but ONLY if the routed workflow is
+ * enforced AND the enforcement dial is on. Idempotent per session: if already
+ * bound, returns 1 without creating anything (the work-item's UNIQUE(repo,
+ * proposal_path)=interactive/<sid> is a second backstop). `repo` may be NULL/empty.
+ * Returns 1 if the session is now bound (pre-existing or freshly created), 0 if not
+ * (unrouted / non-enforced / dial off / empty message / error). Default-OFF. */
+int wfe_bind_interactive(const char *session_id, const char *message, const char *repo);
+
+#endif /* DEC_WFE_BIND_INGRESS_H */

--- a/src/workflow/wfe_bind_ingress.h
+++ b/src/workflow/wfe_bind_ingress.h
@@ -1,29 +1,21 @@
 /* wfe_bind_ingress.h -- S2 binding-creation seam (the live unblock).
  *
  * The dispatch guard + advance_request driver (sub-slices 3/4) key on the aimee
- * session id, but the live primary's chat turn reaches the /v1/messages gateway
- * with NO session id (gw_request_t carries none). This module closes that gap: the
- * client encodes the session id in the primary provider's auth token
- * ("aimee-sess-<sid>"), the server extracts it at HTTP ingress, and on a routed
- * ENFORCED turn creates + binds a work-item so enforcement can fire.
+ * session id, but nothing created a session->work-item binding, so enforcement was
+ * dormant. This module closes that gap: on a routed ENFORCED primary turn it
+ * creates + binds a work-item, so the guard + driver can fire.
  *
- * PURE where it can be: the token parser has no deps; the bind path composes the
- * existing router + work-item + binding APIs behind the enforcement dial.
- * Default-OFF: with the dial unset nothing binds. */
+ * The session id reaches the gateway router via the per-turn thread-local
+ * ingress_preinject_session_id(), which the AUTHORITATIVE in-process primary turn
+ * publishes beside its existing session_id override (server_compute /
+ * primary_session_adapter). An additional client-stamped auth-token channel for the
+ * external-CLI /v1/messages proxy path is deliberately deferred: it needs an
+ * AUTHENTICATED per-session identity (an unauthenticated "aimee-sess-<sid>" token
+ * would let any caller bind an arbitrary session), so it is a separate follow-on.
+ *
+ * Default-OFF: with the enforcement dial unset nothing binds. */
 #ifndef DEC_WFE_BIND_INGRESS_H
 #define DEC_WFE_BIND_INGRESS_H 1
-
-#include <stddef.h>
-
-/* The auth-token identity prefix the client stamps on the primary provider so the
- * gateway can recover the aimee session id from an otherwise-opaque request. */
-#define WFE_SESSION_TOKEN_PREFIX "aimee-sess-"
-
-/* Extract the aimee session id from a client auth value of the form
- * "aimee-sess-<sid>" (a leading "Bearer " is tolerated). The recovered sid must be
- * id-charset ([A-Za-z0-9_-], the mint format). Returns 1 and fills `out` on a
- * match, 0 otherwise (not an aimee-session token / bad charset / overflow). Pure. */
-int wfe_session_id_from_auth(const char *auth_value, char *out, size_t n);
 
 /* On an interactive primary turn, ensure `session_id` is bound to a work-item for
  * the workflow the router picks for `message` -- but ONLY if the routed workflow is


### PR DESCRIPTION
## Primary-as-manager S2 — binding-creation seam (the live unblock)

The dispatch guard + advance_request driver (#941/#944) key on the aimee session id, but nothing created a session→work-item **binding**, so all enforcement was dormant. This threads the primary session id to the gateway router and binds there.

### What's here
- **`wfe_bind_ingress.{h,c}` — `wfe_bind_interactive(sid, message, repo)`**: on a routed **enforced** primary turn, create + bind a work-item (`proposal_path=interactive/<sid>`). Idempotent per session (`binding_get` short-circuits, so create runs at most once), only for enforced workflows, **default-OFF** via the dial. Bind is audited (`lifecycle_event`, cJSON-escaped).
- **Session id at the gateway** via a per-turn thread-local `ingress_preinject_session_id()`, published by the **authoritative in-process primary turn** (`chat_stream_worker_agent`, `primary_session_adapter_turn`) right beside its existing `session_id` override — which synchronously wraps the provider→gateway call. Cleared alongside the override, so a reused worker never leaks a turn's session. **Delegate turns never set it** (they use a different override site), so only the primary binds.
- **`gw_stage_router`** calls `wfe_bind_interactive` when a session id is present.

### Security posture (per roundtable)
- The originally-included **client auth-token channel** (`aimee-sess-<sid>` at `/v1/messages`) was **removed**: it was spoofable — any request carrying that token could bind an arbitrary session under an active dial. Binding now flows **only** from the authoritative in-process turn. The external-CLI proxy path is a documented follow-on that must carry an **authenticated** per-session identity.
- Default-OFF; binding grants only *enforcement* (restriction), is single-writer (`db1_wfe_bind` rejects a second session on the same work-item), and idempotent.

### Verification
- `test_wfe_bind_ingress` (real DB1 + router + engine): only enforced-routed turns bind, dial-off inert, idempotent (one work-item across turns), audited — green.
- Production `aimee-server` links; CMake thin-client links (`wfe_bind_ingress.c` in `SERVER_SRCS` only); lint gates pass.

### Deferred (documented)
The external-CLI `/v1/messages` proxy path (authenticated client-stamped identity) and live `.253→.254` verification. With the dial off this is inert; with it on, an enforced-routed built-in primary turn now binds → the guard + advance driver fire.
