### PR TITLE
feat(webui): delegates management page

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1761,6 +1761,10 @@ paths:
       summary: Probe an agent/provider
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Probe result, content: { application/json: { schema: { type: object } } } } }
+  /agent/stats:
+    get:
+      summary: Per-delegate run statistics
+      responses: { "200": { description: Per-delegate run stats, content: { application/json: { schema: { type: object } } } } }
   /agent/setup:
     post:
       summary: Set up an agent (async)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Toast } from '@rakuensoftware/smoothgui';
 import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
 import Workflows from './pages/Workflows';
+import Delegates from './pages/Delegates';
 import Projects from './pages/Projects';
 import Graph from './pages/Graph';
 import Editor from './pages/Editor';
@@ -63,6 +64,7 @@ const NAV_ITEMS: Tab[] = [
   { label: 'Chat', icon: '💬', route: '/chat' },
   { label: 'Dashboard', icon: '📊', route: '/dashboard' },
   { label: 'Workflows', icon: '🔀', route: '/workflows' },
+  { label: 'Delegates', icon: '🤝', route: '/delegates' },
   { label: 'Projects', icon: '📁', route: '/projects' },
   { label: 'Graph', icon: '🕸️', route: '/graph' },
   { label: 'Editor', icon: '🖥️', route: '/editor' },
@@ -233,6 +235,7 @@ export default function App() {
                 <Route path="/chat" element={<Chat />} />
                 <Route path="/dashboard" element={<Dashboard />} />
                 <Route path="/workflows" element={<Workflows />} />
+                <Route path="/delegates" element={<Delegates />} />
                 <Route path="/projects" element={<Projects />} />
                 <Route path="/graph" element={<Graph />} />
                 <Route path="/editor" element={<Editor />} />

--- a/frontend/src/pages/Delegates.tsx
+++ b/frontend/src/pages/Delegates.tsx
@@ -1,0 +1,539 @@
+import { useEffect, useState, useCallback } from "react";
+import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
+
+/* ---- API types ---- */
+
+// GET /api/agents -> one entry per configured delegate (server_agent_to_json).
+interface AgentCfg {
+  name: string;
+  endpoint: string;
+  model: string;
+  auth_type?: string;
+  provider: string;
+  cost_tier?: number;
+  enabled: boolean;
+  tools_enabled?: boolean;
+  max_turns?: number;
+  max_parallel?: number;
+  context_window?: number;
+  roles?: string[];
+}
+
+// GET /api/agents/stats -> per-delegate run stats (agent_log JOIN token_audit).
+interface AgentStats {
+  name: string;
+  total_calls: number;
+  successful_calls: number;
+  failed_calls: number;
+  success_rate: number; // 0..1
+  avg_latency_ms: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cache_write_tokens: number;
+  cache_read_tokens: number;
+  estimated_cost_usd: number;
+}
+
+// POST /api/agents/probe -> live reachability of one delegate.
+interface ProbeResult {
+  name: string;
+  execution_ok?: boolean;
+  model_available?: boolean;
+  latency_ms?: number;
+  execution_message?: string;
+  error?: string;
+}
+
+type ProbeState = {
+  status: "idle" | "probing" | "ok" | "down";
+  latency_ms?: number;
+  msg?: string;
+};
+
+async function getJSON<T>(url: string): Promise<T> {
+  const r = await fetch(url, { headers: { "X-CSRF-Token": window._csrf || "" } });
+  return (await r.json()) as T;
+}
+async function postArgs<T>(url: string, args: string[]): Promise<T> {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": window._csrf || "",
+    },
+    body: JSON.stringify({ args }),
+  });
+  return (await r.json()) as T;
+}
+
+const PROVIDERS = [
+  "openai",
+  "anthropic",
+  "chatgpt",
+  "claude",
+  "claude-code",
+  "gemini",
+  "mistral",
+];
+
+export default function Delegates() {
+  const [agents, setAgents] = useState<AgentCfg[]>([]);
+  const [stats, setStats] = useState<Record<string, AgentStats>>({});
+  const [probes, setProbes] = useState<Record<string, ProbeState>>({});
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<{ kind: "ok" | "err"; msg: string } | null>(
+    null,
+  );
+  const [showAdd, setShowAdd] = useState(false);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    Promise.all([
+      getJSON<{ agents: AgentCfg[] }>("/api/agents")
+        .then((d) => setAgents(d.agents || []))
+        .catch(() => setAgents([])),
+      getJSON<{ stats: AgentStats[] }>("/api/agents/stats")
+        .then((d) => {
+          const map: Record<string, AgentStats> = {};
+          for (const s of d.stats || []) map[s.name] = s;
+          setStats(map);
+        })
+        .catch(() => setStats({})),
+    ]).finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const probe = useCallback(async (name: string) => {
+    setProbes((p) => ({ ...p, [name]: { status: "probing" } }));
+    try {
+      const res = await postArgs<ProbeResult>("/api/agents/probe", [name]);
+      if (res.error) {
+        setProbes((p) => ({ ...p, [name]: { status: "down", msg: res.error } }));
+        return;
+      }
+      // A live "Respond with ok." run is the strongest availability signal;
+      // fall back to /models reachability when the run was skipped.
+      const up = res.execution_ok ?? res.model_available ?? false;
+      setProbes((p) => ({
+        ...p,
+        [name]: {
+          status: up ? "ok" : "down",
+          latency_ms: res.latency_ms,
+          msg: res.execution_message,
+        },
+      }));
+    } catch {
+      setProbes((p) => ({ ...p, [name]: { status: "down", msg: "probe failed" } }));
+    }
+  }, []);
+
+  const probeAll = useCallback(() => {
+    for (const a of agents) void probe(a.name);
+  }, [agents, probe]);
+
+  const setEnabled = useCallback(
+    async (name: string, enabled: boolean) => {
+      setStatus(null);
+      try {
+        const res = await postArgs<{ error?: string }>(
+          enabled ? "/api/agents/enable" : "/api/agents/disable",
+          [name],
+        );
+        if (res.error) setStatus({ kind: "err", msg: res.error });
+        else setStatus({ kind: "ok", msg: `${name} ${enabled ? "enabled" : "disabled"}` });
+      } catch {
+        setStatus({ kind: "err", msg: `failed to ${enabled ? "enable" : "disable"} ${name}` });
+      }
+      refresh();
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (name: string) => {
+      if (!confirm(`Remove delegate “${name}”? This edits agents.json.`)) return;
+      setStatus(null);
+      try {
+        const res = await postArgs<{ error?: string }>("/api/agents/remove", [name]);
+        if (res.error) setStatus({ kind: "err", msg: res.error });
+        else setStatus({ kind: "ok", msg: `removed ${name}` });
+      } catch {
+        setStatus({ kind: "err", msg: `failed to remove ${name}` });
+      }
+      refresh();
+    },
+    [refresh],
+  );
+
+  return (
+    <div style={{ padding: 16, fontFamily: "system-ui", height: "100%", overflow: "auto" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+        <strong style={{ fontSize: 18 }}>Delegates</strong>
+        <Badge label={`${agents.length}`} variant="neutral" />
+        <button onClick={refresh} style={btn}>
+          Refresh
+        </button>
+        <button onClick={probeAll} style={btn} disabled={!agents.length}>
+          Probe all
+        </button>
+        <button
+          onClick={() => setShowAdd((v) => !v)}
+          style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+        >
+          {showAdd ? "Close" : "+ Add delegate"}
+        </button>
+        <Spinner loading={loading} text="loading…" />
+        {status && (
+          <span
+            style={{
+              fontSize: 13,
+              color: status.kind === "err" ? "#c00" : "#070",
+            }}
+          >
+            {status.msg}
+          </span>
+        )}
+      </div>
+
+      {showAdd && (
+        <AddDelegate
+          onDone={(msg, ok) => {
+            setStatus({ kind: ok ? "ok" : "err", msg });
+            if (ok) {
+              setShowAdd(false);
+              refresh();
+            }
+          }}
+        />
+      )}
+
+      <div style={{ display: "grid", gap: 10, marginTop: 12 }}>
+        {agents.length === 0 && !loading && (
+          <div style={{ color: "#888", fontSize: 14 }}>
+            No delegates configured. Add one to get started.
+          </div>
+        )}
+        {agents.map((a) => (
+          <DelegateCard
+            key={a.name}
+            agent={a}
+            stats={stats[a.name]}
+            probe={probes[a.name]}
+            onProbe={() => probe(a.name)}
+            onToggle={() => setEnabled(a.name, !a.enabled)}
+            onRemove={() => remove(a.name)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ---- one delegate: config + availability + stats ---- */
+
+function DelegateCard({
+  agent,
+  stats,
+  probe,
+  onProbe,
+  onToggle,
+  onRemove,
+}: {
+  agent: AgentCfg;
+  stats?: AgentStats;
+  probe?: ProbeState;
+  onProbe: () => void;
+  onToggle: () => void;
+  onRemove: () => void;
+}) {
+  const pstate = probe?.status || "idle";
+  const dot =
+    pstate === "ok"
+      ? { c: "#22a06b", t: "available" }
+      : pstate === "down"
+        ? { c: "#d4564f", t: "unavailable" }
+        : pstate === "probing"
+          ? { c: "#e0a800", t: "probing…" }
+          : { c: "#bbb", t: "unknown" };
+
+  const successPct =
+    stats && stats.total_calls > 0
+      ? `${Math.round(stats.success_rate * 100)}%`
+      : "—";
+
+  return (
+    <Panel title={agent.name}>
+      <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "flex-start" }}>
+        {/* left: configuration */}
+        <div style={{ flex: "1 1 260px", minWidth: 240 }}>
+          <Field k="provider" v={agent.provider || "—"} />
+          <Field k="model" v={agent.model || "—"} />
+          <Field k="endpoint" v={agent.endpoint || "(cli / none)"} mono />
+          <div style={{ display: "flex", alignItems: "center", gap: 6, margin: "4px 0" }}>
+            <span style={{ color: "#888", fontSize: 13 }}>enabled</span>
+            <Badge
+              label={agent.enabled ? "enabled" : "disabled"}
+              variant={agent.enabled ? "success" : "neutral"}
+            />
+            <button onClick={onToggle} style={btnSmall}>
+              {agent.enabled ? "disable" : "enable"}
+            </button>
+          </div>
+          {typeof agent.cost_tier === "number" && (
+            <Field k="cost tier" v={String(agent.cost_tier)} />
+          )}
+          {typeof agent.max_parallel === "number" && agent.max_parallel > 0 && (
+            <Field k="max parallel" v={String(agent.max_parallel)} />
+          )}
+          {agent.context_window ? (
+            <Field k="context" v={`${agent.context_window.toLocaleString()} tok`} />
+          ) : null}
+          {agent.roles && agent.roles.length > 0 && (
+            <div style={{ margin: "4px 0", display: "flex", flexWrap: "wrap", gap: 4 }}>
+              {agent.roles.map((r) => (
+                <Badge key={r} label={r} variant="info" />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* middle: availability */}
+        <div style={{ flex: "0 0 180px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span
+              style={{
+                width: 9,
+                height: 9,
+                borderRadius: "50%",
+                background: dot.c,
+                display: "inline-block",
+              }}
+            />
+            <span style={{ fontSize: 13, color: "#444" }}>{dot.t}</span>
+          </div>
+          {probe?.latency_ms != null && pstate === "ok" && (
+            <div style={{ fontSize: 12, color: "#888", marginTop: 2 }}>
+              {probe.latency_ms} ms
+            </div>
+          )}
+          {probe?.msg && pstate === "down" && (
+            <div
+              style={{ fontSize: 11, color: "#c66", marginTop: 2, wordBreak: "break-word" }}
+              title={probe.msg}
+            >
+              {probe.msg.slice(0, 80)}
+            </div>
+          )}
+          <button
+            onClick={onProbe}
+            style={{ ...btnSmall, marginTop: 6 }}
+            disabled={pstate === "probing"}
+          >
+            {pstate === "probing" ? "probing…" : "Probe"}
+          </button>
+        </div>
+
+        {/* right: run stats */}
+        <div style={{ flex: "1 1 220px", minWidth: 200 }}>
+          <div style={{ fontSize: 12, color: "#999", marginBottom: 2 }}>run stats</div>
+          {stats && stats.total_calls > 0 ? (
+            <>
+              <Field k="runs" v={String(stats.total_calls)} />
+              <Field
+                k="ok / failed"
+                v={`${stats.successful_calls} / ${stats.failed_calls}`}
+              />
+              <Field k="success" v={successPct} />
+              <Field k="avg latency" v={`${stats.avg_latency_ms} ms`} />
+              <Field
+                k="tokens (in/out)"
+                v={`${fmt(stats.prompt_tokens)} / ${fmt(stats.completion_tokens)}`}
+              />
+              {stats.estimated_cost_usd > 0 && (
+                <Field k="est. cost" v={`$${stats.estimated_cost_usd.toFixed(4)}`} />
+              )}
+            </>
+          ) : (
+            <div style={{ fontSize: 13, color: "#aaa" }}>no runs recorded yet</div>
+          )}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 8, borderTop: "1px solid #eee", paddingTop: 8 }}>
+        <button
+          onClick={onRemove}
+          style={{ ...btnSmall, color: "#c00", borderColor: "#e0a0a0" }}
+        >
+          Remove delegate
+        </button>
+      </div>
+    </Panel>
+  );
+}
+
+/* ---- add-delegate form: builds the `aimee agent add` argv ---- */
+
+function AddDelegate({ onDone }: { onDone: (msg: string, ok: boolean) => void }) {
+  const [name, setName] = useState("");
+  const [endpoint, setEndpoint] = useState("");
+  const [model, setModel] = useState("");
+  const [provider, setProvider] = useState("openai");
+  const [roles, setRoles] = useState("summarize,format,draft");
+  const [apiKey, setApiKey] = useState("");
+  const [costTier, setCostTier] = useState("0");
+  const [disabled, setDisabled] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  // CLI-backed providers (claude/claude-code) run a local CLI, not an HTTP
+  // endpoint, so the endpoint field is optional for them (server ignores it).
+  const cliProvider = provider === "claude" || provider === "claude-code";
+
+  const submit = async () => {
+    if (!name.trim() || !model.trim() || (!cliProvider && !endpoint.trim())) {
+      onDone("name, endpoint and model are required", false);
+      return;
+    }
+    // Mirror `aimee agent add <name> <endpoint> <model> [--flags]`. Endpoint is a
+    // required positional; pass "-" as a placeholder for CLI providers.
+    const args = [name.trim(), cliProvider ? "-" : endpoint.trim(), model.trim()];
+    if (provider) args.push("--provider", provider);
+    if (roles.trim()) args.push("--roles", roles.trim());
+    if (apiKey.trim()) args.push("--key", apiKey.trim());
+    if (costTier && costTier !== "0") args.push("--cost-tier", costTier);
+    if (disabled) args.push("--disabled");
+
+    setBusy(true);
+    try {
+      const res = await postArgs<{ error?: string; name?: string }>(
+        "/api/agents/add",
+        args,
+      );
+      if (res.error) onDone(res.error, false);
+      else onDone(`added ${res.name || name}`, true);
+    } catch {
+      onDone("add failed", false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Panel title="Add delegate">
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+        <L label="name">
+          <input value={name} onChange={(e) => setName(e.target.value)} style={inp} placeholder="my-delegate" />
+        </L>
+        <L label="provider">
+          <select value={provider} onChange={(e) => setProvider(e.target.value)} style={inp}>
+            {PROVIDERS.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </L>
+        <L label={cliProvider ? "endpoint (optional for CLI)" : "endpoint"}>
+          <input
+            value={endpoint}
+            onChange={(e) => setEndpoint(e.target.value)}
+            style={inp}
+            placeholder="https://host:port/v1"
+            disabled={cliProvider}
+          />
+        </L>
+        <L label="model">
+          <input value={model} onChange={(e) => setModel(e.target.value)} style={inp} placeholder="gpt-5" />
+        </L>
+        <L label="roles (comma-separated)">
+          <input value={roles} onChange={(e) => setRoles(e.target.value)} style={inp} />
+        </L>
+        <L label="cost tier">
+          <input
+            type="number"
+            value={costTier}
+            onChange={(e) => setCostTier(e.target.value)}
+            style={inp}
+            min={0}
+          />
+        </L>
+        <L label="API key (optional — stored in vault)">
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            style={inp}
+            placeholder="sk-…  or  $ENV_VAR"
+          />
+        </L>
+        <L label="start disabled">
+          <input type="checkbox" checked={disabled} onChange={(e) => setDisabled(e.target.checked)} />
+        </L>
+      </div>
+      <div style={{ marginTop: 10 }}>
+        <button
+          onClick={submit}
+          disabled={busy}
+          style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+        >
+          {busy ? "Adding…" : "Add delegate"}
+        </button>
+      </div>
+    </Panel>
+  );
+}
+
+/* ---- small presentational helpers ---- */
+
+function Field({ k, v, mono }: { k: string; v: string; mono?: boolean }) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", gap: 8, fontSize: 13, padding: "2px 0" }}>
+      <span style={{ color: "#888" }}>{k}</span>
+      <span
+        style={{
+          fontFamily: mono ? "monospace" : undefined,
+          textAlign: "right",
+          wordBreak: "break-all",
+        }}
+      >
+        {v}
+      </span>
+    </div>
+  );
+}
+
+function L({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: "block", fontSize: 12 }}>
+      <span style={{ color: "#888", display: "block", marginBottom: 2 }}>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+/* ---- inline styles (match the Workflows page) ---- */
+const btn: React.CSSProperties = {
+  fontSize: 13,
+  padding: "4px 10px",
+  border: "1px solid #ccc",
+  borderRadius: 4,
+  background: "#fff",
+  cursor: "pointer",
+};
+const btnSmall: React.CSSProperties = { ...btn, padding: "2px 8px", fontSize: 12 };
+const inp: React.CSSProperties = {
+  fontSize: 13,
+  padding: "4px 6px",
+  border: "1px solid #ccc",
+  borderRadius: 4,
+  width: "100%",
+  boxSizing: "border-box",
+};

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -28,6 +28,7 @@ static const struct
     {"agent.remove", "POST", "/v1/agent/remove"},
     {"agent.setup", "POST", "/v1/agent/setup"},
     {"agent.setup_poll", "POST", "/v1/agent/setup_poll"},
+    {"agent.stats", "GET", "/v1/agent/stats"},
     {"api.disable", "POST", "/v1/api/disable"},
     {"api.enable", "POST", "/v1/api/enable"},
     {"api.status", "GET", "/v1/api/status"},

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -439,6 +439,7 @@ int handle_agent_remove(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_enable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_disable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_probe(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_agent_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_setup(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_setup_poll(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_cli_oauth_start(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1064,6 +1064,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"agent.enable", handle_agent_enable},
     {"agent.disable", handle_agent_disable},
     {"agent.probe", handle_agent_probe},
+    {"agent.stats", handle_agent_stats},
     {"agent.setup", handle_agent_setup},
     {"agent.setup_poll", handle_agent_setup_poll},
     {"agent.cli_oauth_start", handle_agent_cli_oauth_start},

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -449,6 +449,61 @@ int handle_agent_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, resp);
 }
 
+/* Per-delegate run statistics from the agent_log JOIN token_audit aggregate
+ * (db1_agent_log_agent_stats via agent_get_stats). An optional first positional
+ * arg filters to one delegate; with no args, every delegate that has recorded a
+ * call is returned (ordered by call count DESC). success_rate is 0..1; we also
+ * surface derived successful/failed counts so the UI needn't recompute them. */
+int handle_agent_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   char *argv[SERVER_AGENT_MAX_ARGS];
+   int argc = server_agent_args(req, argv, (int)(sizeof(argv) / sizeof(argv[0])));
+   const char *name = (argc >= 1 && argv[0][0]) ? argv[0] : NULL;
+
+   agent_stats_t stats[MAX_AGENTS]; /* MAX_AGENTS==16: a few KB on the stack */
+   int n = agent_get_stats(name, stats, MAX_AGENTS);
+   if (n < 0) /* DB/query failure returns a negative sentinel; emit no rows */
+      n = 0;
+
+   cJSON *resp = jo_ok();
+   cJSON *arr = cJSON_CreateArray();
+   for (int i = 0; i < n; i++)
+   {
+      int total = stats[i].total_calls;
+      if (total < 0)
+         total = 0;
+      /* success_rate is the DB aggregate over all recorded calls; clamp to [0,1]
+       * defensively (a corrupt aggregate must not yield negative/overflow counts)
+       * and derive whole counts so successful+failed == total. */
+      double sr = stats[i].success_rate;
+      if (!(sr >= 0.0))
+         sr = 0.0; /* also catches NaN */
+      else if (sr > 1.0)
+         sr = 1.0;
+      int successful = (int)(total * sr + 0.5);
+      if (successful > total)
+         successful = total;
+      int failed = total - successful;
+
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddStringToObject(o, "name", stats[i].name);
+      cJSON_AddNumberToObject(o, "total_calls", total);
+      cJSON_AddNumberToObject(o, "successful_calls", successful);
+      cJSON_AddNumberToObject(o, "failed_calls", failed);
+      cJSON_AddNumberToObject(o, "success_rate", sr);
+      cJSON_AddNumberToObject(o, "avg_latency_ms", stats[i].avg_latency_ms);
+      cJSON_AddNumberToObject(o, "prompt_tokens", stats[i].total_prompt_tokens);
+      cJSON_AddNumberToObject(o, "completion_tokens", stats[i].total_completion_tokens);
+      cJSON_AddNumberToObject(o, "cache_write_tokens", stats[i].total_cache_write_tokens);
+      cJSON_AddNumberToObject(o, "cache_read_tokens", stats[i].total_cache_read_tokens);
+      cJSON_AddNumberToObject(o, "estimated_cost_usd", stats[i].total_estimated_cost_usd);
+      cJSON_AddItemToArray(arr, o);
+   }
+   cJSON_AddItemToObject(resp, "stats", arr);
+   return server_send_ok(conn, resp);
+}
+
 int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1726,6 +1726,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/agent/enable", NULL, RM_EXACT, "agent.enable", 0, rh_dispatch_op},
     {"POST", "/v1/agent/disable", NULL, RM_EXACT, "agent.disable", 0, rh_dispatch_op},
     {"POST", "/v1/agent/probe", NULL, RM_EXACT, "agent.probe", 0, rh_dispatch_op},
+    {"GET", "/v1/agent/stats", NULL, RM_EXACT, "agent.stats", 0, rh_dispatch_op},
     {"POST", "/v1/agent/setup", NULL, RM_EXACT, "agent.setup", 0, rh_dispatch_op},
     {"POST", "/v1/agent/setup_poll", NULL, RM_EXACT, "agent.setup_poll", 0, rh_dispatch_op},
     {"POST", "/v1/agent/cli_oauth_start", NULL, RM_EXACT, "agent.cli_oauth_start", 0,

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1021,6 +1021,10 @@ int handle_agent_probe(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "agent.probe");
 }
+int handle_agent_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "agent.stats");
+}
 int handle_agent_setup(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "agent.setup");

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -85,6 +85,12 @@ var methodRoutes = map[string]methodRoute{
 	"plugin.enable":            {http.MethodPost, "/v1/plugins/enable"},
 	"plugin.disable":           {http.MethodPost, "/v1/plugins/disable"},
 	"agent.list":               {http.MethodGet, "/v1/agent/list"},
+	"agent.stats":              {http.MethodGet, "/v1/agent/stats"},
+	"agent.add":                {http.MethodPost, "/v1/agent/add"},
+	"agent.remove":             {http.MethodPost, "/v1/agent/remove"},
+	"agent.enable":             {http.MethodPost, "/v1/agent/enable"},
+	"agent.disable":            {http.MethodPost, "/v1/agent/disable"},
+	"agent.probe":              {http.MethodPost, "/v1/agent/probe"},
 	"collab_rules.list":        {http.MethodGet, "/v1/collab_rules"},
 	"collab_rules.list_active": {http.MethodGet, "/v1/collab_rules/active"},
 	// Mutations + arg-bearing calls (POST, body carries the args; the server
@@ -157,6 +163,55 @@ func (s *server) handleAgents(w http.ResponseWriter, r *http.Request) {
 	json.Unmarshal(agents, &arr)
 	count := len(arr)
 	json.NewEncoder(w).Encode(map[string]any{"agents": arr, "count": count})
+}
+
+// handleAgentStats proxies GET /api/agents/stats -> RPC agent.stats, returning
+// the per-delegate run stats array ({stats:[{name,total_calls,successful_calls,
+// failed_calls,success_rate,avg_latency_ms,tokens,cost}]}). Never errors hard:
+// an empty roster or a stats-less server yields {"stats":[]} so the page renders.
+func (s *server) handleAgentStats(w http.ResponseWriter, r *http.Request) {
+	resp, err := s.socketCallForRequest(r, map[string]any{"method": "agent.stats"})
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil || resp == nil {
+		fmt.Fprint(w, `{"stats":[]}`)
+		return
+	}
+	if stats, ok := resp["stats"]; ok {
+		// Re-encode through the JSON writer (not string concatenation) so the
+		// envelope is always well-formed for the page's getJSON parser.
+		_ = json.NewEncoder(w).Encode(map[string]json.RawMessage{"stats": stats})
+		return
+	}
+	fmt.Fprint(w, `{"stats":[]}`)
+}
+
+// agentOpHandler proxies a roster mutation (add/remove/enable/disable/probe) to
+// its RPC method. The browser POSTs a CLI-style {"args":[...]} body mirroring the
+// `aimee agent <op>` argv (e.g. add -> [name,endpoint,model,"--provider","openai",
+// "--roles","summarize,format"]; remove/enable/disable/probe -> [name]). The
+// server's dispatch envelope is returned verbatim so the UI sees the same
+// {status|error,...} shape the CLI would.
+func (s *server) agentOpHandler(method string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Args []string `json:"args"`
+		}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&body)
+		}
+		req := map[string]any{"method": method}
+		if body.Args != nil {
+			req["args"] = body.Args
+		}
+		resp, err := s.socketCallForRequest(r, req)
+		w.Header().Set("Content-Type", "application/json")
+		if err != nil {
+			writeJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		// resp is map[string]json.RawMessage; the values marshal back verbatim.
+		_ = json.NewEncoder(w).Encode(resp)
+	}
 }
 
 func (s *server) handleDelegations(w http.ResponseWriter, r *http.Request) {

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -206,6 +206,12 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 
 	// Live endpoints backed by aimee-server socket
 	mux.HandleFunc("/api/agents", s.requireAuth(s.handleAgents))
+	mux.HandleFunc("GET /api/agents/stats", s.requireAuth(s.handleAgentStats))
+	mux.HandleFunc("POST /api/agents/add", s.requireAuth(s.agentOpHandler("agent.add")))
+	mux.HandleFunc("POST /api/agents/remove", s.requireAuth(s.agentOpHandler("agent.remove")))
+	mux.HandleFunc("POST /api/agents/enable", s.requireAuth(s.agentOpHandler("agent.enable")))
+	mux.HandleFunc("POST /api/agents/disable", s.requireAuth(s.agentOpHandler("agent.disable")))
+	mux.HandleFunc("POST /api/agents/probe", s.requireAuth(s.agentOpHandler("agent.probe")))
 	mux.HandleFunc("/api/rules", s.requireAuth(s.handleCollabRulesList))
 	mux.HandleFunc("/api/rules/active", s.requireAuth(s.handleCollabRulesActive))
 	mux.HandleFunc("POST /api/rules/{id}/{action}", s.requireAuth(s.handleCollabRuleAction))


### PR DESCRIPTION
## What

A new **Delegates** page in the aimee web UI (left nav → 🤝 Delegates):

- **Configured**: one card per delegate — provider, model, endpoint/backend, roles, cost tier, max-parallel, context window.
- **Availability**: status dot + per-delegate **Probe** button and **Probe all** (on-demand — a live `agent.probe`; no requests until you ask).
- **Stats**: total runs, ok/failed, success %, avg latency, tokens in/out, estimated cost.
- **Manage**: enable/disable toggle, **Add delegate** form (name, endpoint, model, provider, roles, cost tier, optional vault-stored API key), and **Remove** (with confirm).

## How

The browser's `/api/*` proxy didn't expose these operations; the C server already had them.

- **C**: new RPC `agent.stats` (`handle_agent_stats`) serializing the existing `agent_get_stats` aggregate (derives ok/failed from `success_rate`), plus `GET /v1/agent/stats`. Regenerated `cli_v1_routes_gen.inc`, documented the route in `openapi-server-v1.yaml`, added the dispatch stub in `test_server_dispatch.c`.
- **Go**: `GET /api/agents/stats` and `POST /api/agents/{add,remove,enable,disable,probe}` forwarding to the existing RPCs.
- **Frontend**: `frontend/src/pages/Delegates.tsx` + nav/route.

The existing rich `/api/agents` config fields (provider/model/enabled/roles/…) are now actually read by the page.

## Scope note

Ships real, already-tracked stats + an on-demand availability probe. True "uptime %" is **deferred** — nothing tracks delegate online-history server-side today; it'd need a heartbeat/probe-history table. Easy to layer on later.

## Roundtable review

Ran an aimee roundtable review on the code (5 panelists, 1 healthy-degraded). Triaged all findings against the source:

**Fixed:**
- C `handle_agent_stats`: clamp `success_rate` to `[0,1]` (guards NaN/negative/>1 → no negative `successful`/`failed`); treat a negative `agent_get_stats` sentinel as zero rows.
- Go `handleAgentStats`: build the envelope via the JSON encoder instead of string concatenation.
- Frontend: added `claude-code` to the provider list (it was in the CLI-provider branch but unselectable — dead branch); wrapped enable/disable/remove in try/catch so a transport error surfaces a status message.

**Verified false / not applicable** (panel lacked these facts):
- "Unbounded stack allocation `stats[MAX_AGENTS]`" — `MAX_AGENTS==16`, a few KB; `handle_agent_list` already stacks a far larger `agent_config_t`.
- "`argv[0]` NULL deref" — `server_agent_args` yields `""` (never NULL) for non-string args; `req==NULL` is handled by cJSON.
- "`total_calls` INT_MAX overflow" — already `int` upstream in the DB aggregate, not narrowed here.

**Security — reviewed, consistent with existing model (not a regression):**
- Mutating routes use `requireAuth`, exactly like the existing `/api/vault/{unlock,credentials}`, `/api/chat/personas`, `/api/workflow/save`, and `/api/plugins/*/toggle`. Webchat has a single trusted-operator auth tier (no role split), and adding a delegate is less sensitive than the vault routes already behind the same gate.
- Endpoint SSRF and the `--key` value crossing the stack are pre-existing behaviors of the `/v1/agent/{add,probe}` RPCs (and the `agent add` CLI); the key is vaulted server-side and never persisted. Any tightening (endpoint allowlist) belongs in the C add/probe path and applies equally to the CLI — out of scope here.

## Verification

- C server builds (`-Werror`); Go `build`+`vet`+`gofmt` clean; frontend `tsc -b && vite build` clean.
- Unit tests `server-dispatch` + `server-http` pass; conformance gates pass (dispatch-caps, v1-method-coverage, cli-v1-routes, api/server-api-conformance, docs-gen, schema-sync, line-check).

Not yet clicked through against a live server (none running locally); the flow is statically verified end-to-end.