### PR TITLE
docs(kb): correct synth-tier delegate wiring (curator auto vs server delegate explicit)

### DIFF
--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -19,10 +19,31 @@ plugin **image swap**, no re-embed.
 ## Deploy: one plugin image swap
 
 The synth tier is chosen by which image the SmoothNAS `aimee-llm` plugin references —
-e.g. `ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest` for Gemma 4 26B-A4B. No separate delegate
-container, no `SYNTH_LOCAL` juggling: the tier *is* the synth. The gateway's
-`/v1/chat/completions` is what the server/curator use, so the delegate wiring is
-automatic once the image is deployed.
+e.g. `ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest` for Gemma 4 26B-A4B. No separate synth
+container, no `SYNTH_LOCAL` juggling: the tier *is* the synth.
+
+### Two consumers of the gateway synth (`/v1/chat/completions`)
+
+The gateway (`http://<runtime-gw>:8742/v1`, model alias `aimee-synth`) is used by two
+independent callers — one automatic, one an explicit operator step:
+
+1. **KB curator synthesis — automatic.** The `aimee-kb` plugin points `LLM_ENDPOINT` /
+   `LLM_MODEL` at the gateway, so the curator's `tier_a`/`tier_b` use the synth tier the
+   moment the image is deployed. Swapping tiers needs no KB change.
+
+2. **aimee-server delegate — an explicit runtime registration (NOT automatic).** To make
+   the local synth usable as an `aimee` delegate (roundtable / fallback), register it once
+   against the server (endpoint is model-neutral, so the registration survives synth-tier
+   swaps):
+
+   ```sh
+   aimee agent local local-synth http://<runtime-gw>:8742/v1 \
+       --model aimee-synth --provider openai --slots <SYNTH_SLOTS>
+   ```
+
+   The gateway runs auth-off on the internal bridge, so the agent uses `auth_type: none`.
+   This lives in the server's `agents.json` (runtime/per-deployment state, not baked into
+   the image). On `.254` this is registered as `local-synth` and sits in `fallback_chain`.
 
 ## Synth runtime knobs (baked per tier; overridable via plugin env)
 


### PR DESCRIPTION
## What
Fixes an inaccuracy in `docs/AIMEE_KB_SYNTH_TIERS.md` and captures the one piece of the recent Gemma/coopmat rollout that had no repo footprint: the **aimee-server delegate registration**.

## Why
The doc said *"the delegate wiring is automatic once the image is deployed."* That's true for the **KB curator** (auto via the `aimee-kb` plugin's `LLM_ENDPOINT`/`LLM_MODEL`), but **false for the aimee-server delegate** — exposing the local synth as an `aimee` delegate (roundtable/fallback) is an explicit `aimee agent local` registration that lives in the server's runtime `agents.json`, not the image.

On `.254` that registration (`local-synth` → `…:8742/v1` / `aimee-synth`, in `fallback_chain`) was done live and had no source-of-truth. This documents the exact step (model-neutral endpoint so it survives synth-tier swaps; `auth_type: none` on the internal bridge) so it's reproducible.

## Note
The container/image/build side of the Gemma-4-26B-A4B + Mesa-25/coopmat work is already in #943 (merged to testing); this is the doc/runtime-wiring companion. The delegate registration itself is per-deployment runtime state by design (endpoints/creds), so it's documented rather than baked.