### PR TITLE
style(audit): clang-format S1 files (fix lint gate)

### DIFF
--- a/src/audit_action.c
+++ b/src/audit_action.c
@@ -30,10 +30,10 @@
 
 /* Bounds. Truncation markers and length prefixes are folded INTO the hash input
  * so the digest stays stable and verifiable when a limit is hit. */
-#define AUDIT_ARGS_MAX_INPUT (256 * 1024) /* skip parsing beyond this */
-#define AUDIT_VALUE_MAX_BYTES 8192        /* per allowlisted value */
-#define AUDIT_CANON_ALLOC (64 * 1024)     /* canon buffer allocation */
-#define AUDIT_CANON_LIMIT (AUDIT_CANON_ALLOC - 32) /* logical fill limit (marker reserve) */
+#define AUDIT_ARGS_MAX_INPUT  (256 * 1024)             /* skip parsing beyond this */
+#define AUDIT_VALUE_MAX_BYTES 8192                     /* per allowlisted value */
+#define AUDIT_CANON_ALLOC     (64 * 1024)              /* canon buffer allocation */
+#define AUDIT_CANON_LIMIT     (AUDIT_CANON_ALLOC - 32) /* logical fill limit (marker reserve) */
 
 /* Component separator. NOTE: canonical components are LENGTH-PREFIXED (see
  * canon_add), so injectivity does NOT depend on this byte being absent from a

--- a/src/headers/audit_action.h
+++ b/src/headers/audit_action.h
@@ -42,28 +42,28 @@ extern "C"
 /* "v1-" (3) + 64 hex + NUL. */
 #define AUDIT_ARGS_HASH_LEN 68
 
-/* Compute the args hash for (tool_name, args_json) into `out` (capacity
- * >= AUDIT_ARGS_HASH_LEN). `args_json` may be NULL/empty (hashes the tool name
- * only). Returns 0 on success.
- *
- * Best-effort: on any failure (key unavailable, allocation) it writes the stable
- * sentinel "v1-" followed by 64 '0' and returns -1. Callers audit best-effort
- * and MUST NOT block a tool on a non-zero return. */
-int audit_args_hash(const char *tool_name, const char *args_json, char *out, size_t out_sz);
+   /* Compute the args hash for (tool_name, args_json) into `out` (capacity
+    * >= AUDIT_ARGS_HASH_LEN). `args_json` may be NULL/empty (hashes the tool name
+    * only). Returns 0 on success.
+    *
+    * Best-effort: on any failure (key unavailable, allocation) it writes the stable
+    * sentinel "v1-" followed by 64 '0' and returns -1. Callers audit best-effort
+    * and MUST NOT block a tool on a non-zero return. */
+   int audit_args_hash(const char *tool_name, const char *args_json, char *out, size_t out_sz);
 
-/* Ensure the dedicated audit HMAC key exists at $AIMEE_HOME/.audit-key (0600, 32
- * random bytes), provisioning it atomically if absent (mirrors
- * wfe_approval_ensure_key). Call once at server startup so hash time always has
- * a real key. Returns 0 if the key exists or was created, -1 otherwise. */
-int audit_ensure_key(void);
+   /* Ensure the dedicated audit HMAC key exists at $AIMEE_HOME/.audit-key (0600, 32
+    * random bytes), provisioning it atomically if absent (mirrors
+    * wfe_approval_ensure_key). Call once at server startup so hash time always has
+    * a real key. Returns 0 if the key exists or was created, -1 otherwise. */
+   int audit_ensure_key(void);
 
-/* Test-only seam: the internal HMAC-SHA256 used by audit_args_hash, exposed so
- * unit tests can pin it against RFC 4231 known-answer vectors (validates the
- * ipad/opad construction, 64-byte block, and key>64 pre-hash path). Not part of
- * the public API — do not use in product code. Returns 0 on success, -1 on
- * failure (allocation / length overflow). */
-int audit_hmac_sha256_testonly(const unsigned char *key, size_t keylen, const unsigned char *msg,
-                               size_t mlen, unsigned char mac[32]);
+   /* Test-only seam: the internal HMAC-SHA256 used by audit_args_hash, exposed so
+    * unit tests can pin it against RFC 4231 known-answer vectors (validates the
+    * ipad/opad construction, 64-byte block, and key>64 pre-hash path). Not part of
+    * the public API — do not use in product code. Returns 0 on success, -1 on
+    * failure (allocation / length overflow). */
+   int audit_hmac_sha256_testonly(const unsigned char *key, size_t keylen, const unsigned char *msg,
+                                  size_t mlen, unsigned char mac[32]);
 
 #ifdef __cplusplus
 }

--- a/src/tests/test_audit_action.c
+++ b/src/tests/test_audit_action.c
@@ -75,7 +75,8 @@ static void test_allowlist_drops_extra_fields(void)
    char base[AUDIT_ARGS_HASH_LEN], with_secret[AUDIT_ARGS_HASH_LEN];
    hash_of("Write", "{\"file_path\":\"/x\",\"content\":\"c\"}", base);
    /* a non-allowlisted field (a token/PII) must NOT change the hash */
-   hash_of("Write", "{\"file_path\":\"/x\",\"content\":\"c\",\"authorization\":\"Bearer sk-secret\"}",
+   hash_of("Write",
+           "{\"file_path\":\"/x\",\"content\":\"c\",\"authorization\":\"Bearer sk-secret\"}",
            with_secret);
    assert(strcmp(base, with_secret) == 0);
 }


### PR DESCRIPTION
Follow-up to #947: applies clang-format to the S1 audit_action files, fixing the `lint` gate's clang-format violation (unwrapped long string in test_audit_action.c). No behavior change; tests still green.