### PR TITLE
feat(audit): S2 — per-action policy-verdict audit row from pre_tool_check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,6 +574,7 @@ set(DATA_SRCS
     ${AIMEE_SRC_DIR}/working_profile.c
     ${AIMEE_SRC_DIR}/guardrails.c
     ${AIMEE_SRC_DIR}/guardrails_orchestrator.c
+    ${AIMEE_SRC_DIR}/guardrails_action_audit.c
     ${AIMEE_SRC_DIR}/guardrails_tdd.c
     ${AIMEE_SRC_DIR}/workflow_learn.c
     ${AIMEE_SRC_DIR}/session_state.c

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,10 +22,11 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (135)
+## CLI-settable keys (136)
 
 | Key | Type | Description |
 |-----|------|-------------|
+| `audit_action_enabled` | bool | — |
 | `autonomous` | bool | Run autonomously (auto-advance preauthorized gates) vs interactive. |
 | `cache_aware_rewrite_enabled` | bool | Rewrite prompts to align with the provider's prompt cache. |
 | `cache_min_chars` | int | Minimum prompt size (chars) before cache-shaping applies. |
@@ -162,7 +163,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 | `wfe_live_forge_enabled` | bool | — |
 
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `wfe_live_forge_enabled`
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `wfe_live_forge_enabled`
 
 ## Config-file sections (51)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -288,7 +288,7 @@ MCP_GIT_SRCS = mcp_git_query.c mcp_git_write.c mcp_git_branch.c mcp_git_pr.c git
 MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
-CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
+CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c audit_action.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
             compact.c coord_closet.c fold_budget.c context_fold.c context_reduce.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
@@ -321,7 +321,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = code_match.c rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c code_treesitter.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
-            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c guardrails_blast_radius.c gateway_policy.c gateway_pipeline.c gateway_delegate.c \
+            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_action_audit.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c guardrails_blast_radius.c gateway_policy.c gateway_pipeline.c gateway_delegate.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
             trajectory_export.c trajectory_batch.c \

--- a/src/cmd_hooks.c
+++ b/src/cmd_hooks.c
@@ -12,6 +12,7 @@
 #include "agent_coord.h"
 #include "agent_eval.h"
 #include "log.h"
+#include "audit_action.h"
 #include "trace_analysis.h"
 #include "workspace.h"
 #include "commands.h"
@@ -126,6 +127,7 @@ void cmd_hooks(app_ctx_t *ctx, int argc, char **argv)
    config_t cfg;
    config_load(&cfg);
    audit_log_open();
+   audit_ensure_key(); /* provision the per-action audit key (best-effort) */
 
    /* Read JSON from stdin -- hook input is small (tool name + args) */
    char input[65536];

--- a/src/config.c
+++ b/src/config.c
@@ -651,6 +651,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->wfe_live_forge_enabled = 0;  /* default-OFF (security): the autonomous live
                                         forge stays unregistered until an operator
                                         explicitly enables it (F4) */
+   cfg->audit_action_enabled = 0;    /* default-OFF: per-action audit row is enabled
+                                        only after the trajectory_export reader ships */
    snprintf(cfg->css_render_command, sizeof(cfg->css_render_command), "%s",
             CONFIG_DEFAULT_CSS_RENDER_COMMAND); /* default-on render backend (inert
                                                    until the sidecar is up); set empty
@@ -944,6 +946,10 @@ int config_load(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "wfe_live_forge_enabled");
    if (cJSON_IsBool(item))
       cfg->wfe_live_forge_enabled = cJSON_IsTrue(item);
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "audit_action_enabled");
+   if (cJSON_IsBool(item))
+      cfg->audit_action_enabled = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "css_render_command");
    if (cJSON_IsString(item) && item->valuestring)

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -78,6 +78,7 @@ const config_field_t config_fields[] = {
      CFG_BOOL},
     {"wfe_live_forge_enabled", offsetof(config_t, wfe_live_forge_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"audit_action_enabled", offsetof(config_t, audit_action_enabled), sizeof(int), 0, CFG_BOOL},
     {"css_render_command", offsetof(config_t, css_render_command),
      sizeof(((config_t *)0)->css_render_command), 0, CFG_STRING},
     {"kb_evidence_emit_enabled", offsetof(config_t, kb_evidence_emit_enabled), sizeof(int), 0,

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -845,6 +845,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "css_style_graph_enabled", 0);
    if (cfg->wfe_live_forge_enabled) /* default-off: persist only the opt-in (enable) */
       cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 1);
+   if (cfg->audit_action_enabled) /* default-off: persist only the opt-in (enable) */
+      cJSON_AddBoolToObject(root, "audit_action_enabled", 1);
    /* default-on render backend: persist only a non-default value (a custom command
     * OR an empty string to disable) so both round-trip; the default isn't written. */
    if (strcmp(cfg->css_render_command, CONFIG_DEFAULT_CSS_RENDER_COMMAND) != 0)

--- a/src/guardrails_action_audit.c
+++ b/src/guardrails_action_audit.c
@@ -1,0 +1,85 @@
+/* guardrails_action_audit.c: the per-action governed-action audit (P2 / S2).
+ *
+ * pre_tool_check is a thin wrapper around the verdict logic
+ * (pre_tool_check_inner in guardrails_orchestrator.c): it emits EXACTLY ONE
+ * audit row per call, AFTER the verdict is decided, so the many inner return
+ * paths cannot drift the emit count. The emit is strictly side-effect-only —
+ * any failure here (hashing, log write) leaves the verdict untouched (audit loss
+ * is acceptable, enforcement drift is not). Kept in its own file so the verdict
+ * logic stays within the source line budget. */
+#include <string.h>
+
+#include "aimee.h" /* MODE_APPROVE */
+#include "audit_action.h"
+#include "config.h"
+#include "guardrails.h"
+#include "log.h"
+
+/* Cached audit_action_enabled. Read once on first use; a config_load failure
+ * leaves the memset-zeroed flag at 0 (audit OFF), so the gate is fail-safe and
+ * the hot path costs one branch instead of a per-call config parse. Toggling the
+ * knob takes effect on restart — acceptable for a passive, default-off audit. */
+static int g_audit_action_enabled = -1;
+static int audit_action_is_enabled(void)
+{
+   if (g_audit_action_enabled < 0)
+   {
+      config_t cfg;
+      memset(&cfg, 0, sizeof cfg);
+      config_load(&cfg);
+      g_audit_action_enabled = cfg.audit_action_enabled ? 1 : 0;
+   }
+   return g_audit_action_enabled;
+}
+
+static void emit_action_audit(const char *tool_name, const char *input_json,
+                              const char *guardrail_mode, session_state_t *state, int rc,
+                              const char *msg_buf)
+{
+   if (!audit_action_is_enabled())
+      return;
+
+   /* reason_code = the stable key of the block site's existing audit_log() call,
+    * captured on this thread (see audit_last_event). Empty for allow/rewrite. */
+   const char *reason = audit_last_event();
+
+   const char *verdict;
+   if (rc == 2)
+   {
+      /* rc==2 covers hard block and computer-use approval-required. The block
+       * sites carry an audit key; computer-use uses an "APPROVAL_REQUIRED:"
+       * msg prefix (classification only — the prose is never persisted). */
+      int approval = (reason && strstr(reason, "approval")) ||
+                     (msg_buf && strncmp(msg_buf, "APPROVAL_REQUIRED", 17) == 0);
+      verdict = approval ? "approval_required" : "block";
+   }
+   else if (rc == 1 || rc == 3)
+      verdict = "rewrite";
+   else
+      verdict = rc == 0 ? "allow" : "unknown"; /* surface novel rc, don't hide it */
+
+   if (!reason || !reason[0])
+      reason = verdict;
+
+   const char *actor = (state && state->is_delegate) ? "delegate" : "primary";
+   const char *mode = guardrail_mode ? guardrail_mode : MODE_APPROVE;
+   /* Pre-init to the S1 sentinel so the wrapper is safe even if audit_args_hash
+    * changes behavior; audit_args_hash also writes the sentinel first. */
+   char args_hash[AUDIT_ARGS_HASH_LEN];
+   snprintf(args_hash, sizeof args_hash, "v1-");
+   audit_args_hash(tool_name, input_json, args_hash, sizeof args_hash);
+   long long task_id = state ? (long long)state->active_task_id : 0;
+   audit_action_log(actor, tool_name, args_hash, mode, reason, verdict, task_id);
+}
+
+int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
+                   const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
+{
+   /* Clear the last audit event before the verdict so a block site's key from a
+    * prior call cannot leak as this call's reason_code. */
+   audit_last_event_reset();
+   int rc =
+       pre_tool_check_inner(tool_name, input_json, state, guardrail_mode, cwd, msg_buf, msg_len);
+   emit_action_audit(tool_name, input_json, guardrail_mode, state, rc, msg_buf);
+   return rc;
+}

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -22,6 +22,7 @@
 #include "kb_reasoning.h"
 #endif
 #include "log.h"
+#include "audit_action.h"
 #include "platform_path.h"
 #include "slop_detect.h"
 #include <ctype.h>
@@ -1193,13 +1194,24 @@ static int is_write_intent(const char *tool_name, cJSON *root)
    return 0;
 }
 
-int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
-                   const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
+/* Per-call reason_code for the S2 governed-action audit row. Set at block sites
+ * that carry a stable key; the pre_tool_check wrapper reads it post-verdict.
+ * Thread-local so concurrent sessions do not clobber each other. */
+static __thread char g_audit_reason[48];
+static void audit_reason_set(const char *code)
+{
+   snprintf(g_audit_reason, sizeof g_audit_reason, "%s", code ? code : "");
+}
+
+static int pre_tool_check_inner(const char *tool_name, const char *input_json,
+                                session_state_t *state, const char *guardrail_mode, const char *cwd,
+                                char *msg_buf, size_t msg_len)
 {
    if (!tool_name || !input_json || !state)
       return 0;
 
    msg_buf[0] = '\0';
+   g_audit_reason[0] = '\0';
    const char *mode = guardrail_mode ? guardrail_mode : MODE_APPROVE;
 
    /* Increment hook invocation counter for diagnostics */
@@ -1225,6 +1237,8 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
          snprintf(msg_buf, msg_len, "%s: %s",
                   decision == COMPUTER_USE_DECISION_APPROVE ? "APPROVAL_REQUIRED" : "BLOCKED",
                   reason[0] ? reason : "computer-use action rejected by policy");
+         audit_reason_set(decision == COMPUTER_USE_DECISION_APPROVE ? "computer_use_approval"
+                                                                    : "computer_use_blocked");
          cJSON_Delete(root);
          return 2;
       }
@@ -1613,6 +1627,7 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
                "cost-tracked, see the shared memory + KB, and inherit this session's guardrails.");
       audit_log("subagent_blocked",
                 "provider sub-agent tool blocked — keep delegation inside aimee");
+      audit_reason_set("subagent_blocked");
       cJSON_Delete(root);
       return 2;
    }
@@ -1672,6 +1687,7 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
                      hits, label, (long long)matches[i].id);
             audit_log("antipattern_blocked", "(%dx, id=%lld): %s", hits, (long long)matches[i].id,
                       label);
+            audit_reason_set("antipattern_blocked");
             cJSON_Delete(root);
             return 2;
          }
@@ -1781,6 +1797,7 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
                      "with Edit, or rewrite with Write after reviewing the file.",
                      norm);
             audit_log("read_before_write", "blocked blind overwrite of %s", norm);
+            audit_reason_set("read_before_write");
             cJSON_Delete(root);
             return 2;
          }
@@ -1812,6 +1829,7 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
                      norm, (long long)st.st_size, new_len);
             audit_log("truncating_write", "blocked %zu-byte overwrite of %lld-byte file %s",
                       new_len, (long long)st.st_size, norm);
+            audit_reason_set("truncating_write");
             cJSON_Delete(root);
             return 2;
          }
@@ -1843,6 +1861,7 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
                      "making further edits.",
                      norm);
             audit_log("stale_edit", "blocked edit of changed file %s", norm);
+            audit_reason_set("stale_edit");
             cJSON_Delete(root);
             return 2;
          }
@@ -1997,4 +2016,34 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
           normalize_path(fp->valuestring, effective_cwd, norm, sizeof(norm)), msg_buf, msg_len);
    cJSON_Delete(root);
    return 0;
+}
+
+/* Emit exactly one governed-action audit row per pre_tool_check call, AFTER the
+ * verdict is decided. Config-gated (default off) and strictly side-effect-only:
+ * any failure here (config load, hashing, log write) leaves the verdict
+ * untouched — audit loss is acceptable, enforcement drift is not. */
+static void guardrails_emit_action_audit(const char *tool_name, const char *input_json,
+                                         const char *guardrail_mode, session_state_t *state, int rc)
+{
+   config_t cfg;
+   config_load(&cfg);
+   if (!cfg.audit_action_enabled)
+      return;
+   const char *verdict = rc == 2 ? "block" : (rc == 1 || rc == 3) ? "rewrite" : "allow";
+   const char *reason = g_audit_reason[0] ? g_audit_reason : (rc == 2 ? "blocked" : verdict);
+   const char *actor = (state && state->is_delegate) ? "delegate" : "primary";
+   const char *mode = guardrail_mode ? guardrail_mode : MODE_APPROVE;
+   char args_hash[AUDIT_ARGS_HASH_LEN];
+   audit_args_hash(tool_name, input_json, args_hash, sizeof args_hash);
+   long long task_id = state ? (long long)state->active_task_id : 0;
+   audit_action_log(actor, tool_name, args_hash, mode, reason, verdict, task_id);
+}
+
+int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
+                   const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
+{
+   int rc =
+       pre_tool_check_inner(tool_name, input_json, state, guardrail_mode, cwd, msg_buf, msg_len);
+   guardrails_emit_action_audit(tool_name, input_json, guardrail_mode, state, rc);
+   return rc;
 }

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -22,7 +22,6 @@
 #include "kb_reasoning.h"
 #endif
 #include "log.h"
-#include "audit_action.h"
 #include "platform_path.h"
 #include "slop_detect.h"
 #include <ctype.h>
@@ -1194,18 +1193,8 @@ static int is_write_intent(const char *tool_name, cJSON *root)
    return 0;
 }
 
-/* Per-call reason_code for the S2 governed-action audit row. Set at block sites
- * that carry a stable key; the pre_tool_check wrapper reads it post-verdict.
- * Thread-local so concurrent sessions do not clobber each other. */
-static __thread char g_audit_reason[48];
-static void audit_reason_set(const char *code)
-{
-   snprintf(g_audit_reason, sizeof g_audit_reason, "%s", code ? code : "");
-}
-
-static int pre_tool_check_inner(const char *tool_name, const char *input_json,
-                                session_state_t *state, const char *guardrail_mode, const char *cwd,
-                                char *msg_buf, size_t msg_len)
+int pre_tool_check_inner(const char *tool_name, const char *input_json, session_state_t *state,
+                   const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
 {
    if (!tool_name || !input_json || !state)
       return 0;
@@ -1236,8 +1225,6 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
          snprintf(msg_buf, msg_len, "%s: %s",
                   decision == COMPUTER_USE_DECISION_APPROVE ? "APPROVAL_REQUIRED" : "BLOCKED",
                   reason[0] ? reason : "computer-use action rejected by policy");
-         audit_reason_set(decision == COMPUTER_USE_DECISION_APPROVE ? "computer_use_approval"
-                                                                    : "computer_use_blocked");
          cJSON_Delete(root);
          return 2;
       }
@@ -1626,7 +1613,6 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
                "cost-tracked, see the shared memory + KB, and inherit this session's guardrails.");
       audit_log("subagent_blocked",
                 "provider sub-agent tool blocked — keep delegation inside aimee");
-      audit_reason_set("subagent_blocked");
       cJSON_Delete(root);
       return 2;
    }
@@ -1686,7 +1672,6 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
                      hits, label, (long long)matches[i].id);
             audit_log("antipattern_blocked", "(%dx, id=%lld): %s", hits, (long long)matches[i].id,
                       label);
-            audit_reason_set("antipattern_blocked");
             cJSON_Delete(root);
             return 2;
          }
@@ -1796,7 +1781,6 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
                      "with Edit, or rewrite with Write after reviewing the file.",
                      norm);
             audit_log("read_before_write", "blocked blind overwrite of %s", norm);
-            audit_reason_set("read_before_write");
             cJSON_Delete(root);
             return 2;
          }
@@ -1828,7 +1812,6 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
                      norm, (long long)st.st_size, new_len);
             audit_log("truncating_write", "blocked %zu-byte overwrite of %lld-byte file %s",
                       new_len, (long long)st.st_size, norm);
-            audit_reason_set("truncating_write");
             cJSON_Delete(root);
             return 2;
          }
@@ -1860,7 +1843,6 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
                      "making further edits.",
                      norm);
             audit_log("stale_edit", "blocked edit of changed file %s", norm);
-            audit_reason_set("stale_edit");
             cJSON_Delete(root);
             return 2;
          }
@@ -2015,63 +1997,4 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
           normalize_path(fp->valuestring, effective_cwd, norm, sizeof(norm)), msg_buf, msg_len);
    cJSON_Delete(root);
    return 0;
-}
-
-/* Cached audit_action_enabled. Read once on first use; a config_load failure
- * leaves the memset-zeroed flag at 0 (audit OFF), so the gate is fail-safe and
- * the hot path costs one branch instead of a per-call config parse. Toggling the
- * knob takes effect on restart — acceptable for a passive, default-off audit. */
-static int g_audit_action_enabled = -1;
-static int audit_action_is_enabled(void)
-{
-   if (g_audit_action_enabled < 0)
-   {
-      config_t cfg;
-      memset(&cfg, 0, sizeof cfg);
-      config_load(&cfg);
-      g_audit_action_enabled = cfg.audit_action_enabled ? 1 : 0;
-   }
-   return g_audit_action_enabled;
-}
-
-/* Emit exactly one governed-action audit row per pre_tool_check call, AFTER the
- * verdict is decided. Strictly side-effect-only: any failure here (hashing, log
- * write) leaves the verdict untouched — audit loss is acceptable, enforcement
- * drift is not. */
-static void guardrails_emit_action_audit(const char *tool_name, const char *input_json,
-                                         const char *guardrail_mode, session_state_t *state, int rc)
-{
-   if (!audit_action_is_enabled())
-      return;
-   const char *verdict;
-   if (rc == 2)
-      /* rc==2 covers both hard block and computer-use approval-required; the
-       * reason code distinguishes them. */
-      verdict = strstr(g_audit_reason, "approval") ? "approval_required" : "block";
-   else if (rc == 1 || rc == 3)
-      verdict = "rewrite";
-   else
-      verdict = rc == 0 ? "allow" : "unknown"; /* surface novel rc, don't hide it */
-   const char *reason = g_audit_reason[0] ? g_audit_reason : verdict;
-   const char *actor = (state && state->is_delegate) ? "delegate" : "primary";
-   const char *mode = guardrail_mode ? guardrail_mode : MODE_APPROVE;
-   /* Pre-init to the S1 sentinel so the wrapper is safe even if audit_args_hash
-    * changes behavior; audit_args_hash also writes the sentinel first. */
-   char args_hash[AUDIT_ARGS_HASH_LEN];
-   snprintf(args_hash, sizeof args_hash, "v1-");
-   audit_args_hash(tool_name, input_json, args_hash, sizeof args_hash);
-   long long task_id = state ? (long long)state->active_task_id : 0;
-   audit_action_log(actor, tool_name, args_hash, mode, reason, verdict, task_id);
-}
-
-int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
-                   const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
-{
-   /* Clear the reason BEFORE inner so a NULL-arg early return (or any path that
-    * sets no reason) cannot emit a stale reason_code from a prior call. */
-   g_audit_reason[0] = '\0';
-   int rc =
-       pre_tool_check_inner(tool_name, input_json, state, guardrail_mode, cwd, msg_buf, msg_len);
-   guardrails_emit_action_audit(tool_name, input_json, guardrail_mode, state, rc);
-   return rc;
 }

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -1211,7 +1211,6 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
       return 0;
 
    msg_buf[0] = '\0';
-   g_audit_reason[0] = '\0';
    const char *mode = guardrail_mode ? guardrail_mode : MODE_APPROVE;
 
    /* Increment hook invocation counter for diagnostics */
@@ -2018,22 +2017,48 @@ static int pre_tool_check_inner(const char *tool_name, const char *input_json,
    return 0;
 }
 
+/* Cached audit_action_enabled. Read once on first use; a config_load failure
+ * leaves the memset-zeroed flag at 0 (audit OFF), so the gate is fail-safe and
+ * the hot path costs one branch instead of a per-call config parse. Toggling the
+ * knob takes effect on restart — acceptable for a passive, default-off audit. */
+static int g_audit_action_enabled = -1;
+static int audit_action_is_enabled(void)
+{
+   if (g_audit_action_enabled < 0)
+   {
+      config_t cfg;
+      memset(&cfg, 0, sizeof cfg);
+      config_load(&cfg);
+      g_audit_action_enabled = cfg.audit_action_enabled ? 1 : 0;
+   }
+   return g_audit_action_enabled;
+}
+
 /* Emit exactly one governed-action audit row per pre_tool_check call, AFTER the
- * verdict is decided. Config-gated (default off) and strictly side-effect-only:
- * any failure here (config load, hashing, log write) leaves the verdict
- * untouched — audit loss is acceptable, enforcement drift is not. */
+ * verdict is decided. Strictly side-effect-only: any failure here (hashing, log
+ * write) leaves the verdict untouched — audit loss is acceptable, enforcement
+ * drift is not. */
 static void guardrails_emit_action_audit(const char *tool_name, const char *input_json,
                                          const char *guardrail_mode, session_state_t *state, int rc)
 {
-   config_t cfg;
-   config_load(&cfg);
-   if (!cfg.audit_action_enabled)
+   if (!audit_action_is_enabled())
       return;
-   const char *verdict = rc == 2 ? "block" : (rc == 1 || rc == 3) ? "rewrite" : "allow";
-   const char *reason = g_audit_reason[0] ? g_audit_reason : (rc == 2 ? "blocked" : verdict);
+   const char *verdict;
+   if (rc == 2)
+      /* rc==2 covers both hard block and computer-use approval-required; the
+       * reason code distinguishes them. */
+      verdict = strstr(g_audit_reason, "approval") ? "approval_required" : "block";
+   else if (rc == 1 || rc == 3)
+      verdict = "rewrite";
+   else
+      verdict = rc == 0 ? "allow" : "unknown"; /* surface novel rc, don't hide it */
+   const char *reason = g_audit_reason[0] ? g_audit_reason : verdict;
    const char *actor = (state && state->is_delegate) ? "delegate" : "primary";
    const char *mode = guardrail_mode ? guardrail_mode : MODE_APPROVE;
+   /* Pre-init to the S1 sentinel so the wrapper is safe even if audit_args_hash
+    * changes behavior; audit_args_hash also writes the sentinel first. */
    char args_hash[AUDIT_ARGS_HASH_LEN];
+   snprintf(args_hash, sizeof args_hash, "v1-");
    audit_args_hash(tool_name, input_json, args_hash, sizeof args_hash);
    long long task_id = state ? (long long)state->active_task_id : 0;
    audit_action_log(actor, tool_name, args_hash, mode, reason, verdict, task_id);
@@ -2042,6 +2067,9 @@ static void guardrails_emit_action_audit(const char *tool_name, const char *inpu
 int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
                    const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
 {
+   /* Clear the reason BEFORE inner so a NULL-arg early return (or any path that
+    * sets no reason) cannot emit a stale reason_code from a prior call. */
+   g_audit_reason[0] = '\0';
    int rc =
        pre_tool_check_inner(tool_name, input_json, state, guardrail_mode, cwd, msg_buf, msg_len);
    guardrails_emit_action_audit(tool_name, input_json, guardrail_mode, state, rc);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -305,6 +305,11 @@ typedef struct config
     * action (branch protection + scoped creds + break-glass) — never a code default,
     * per the security-roundtable deviation. */
    int wfe_live_forge_enabled;
+   /* audit_action_enabled: emit a per-tool-call governed-action row (kind=
+    * tool_action) to audit.log from pre_tool_check. Default-OFF until the
+    * trajectory_export reader ships (reader-before-writer); audit is passive and
+    * never changes an enforcement verdict. */
+   int audit_action_enabled;
    /* css_render_command: the render backend for the #4-full computed-style oracle.
     * A shell command (like embedding_command) that reads a {"html","css"} JSON
     * object on stdin and writes a computed-style snapshot JSON on stdout. It runs

--- a/src/headers/guardrails.h
+++ b/src/headers/guardrails.h
@@ -138,6 +138,13 @@ classification_t classify_path(const char *file_path);
 int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
                    const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len);
 
+/* The guardrail verdict logic. pre_tool_check is a thin wrapper (in
+ * guardrails_action_audit.c) that calls this and emits the per-action audit
+ * row. Same return contract as pre_tool_check. */
+int pre_tool_check_inner(const char *tool_name, const char *input_json, session_state_t *state,
+                         const char *guardrail_mode, const char *cwd, char *msg_buf,
+                         size_t msg_len);
+
 /* Normalize provider/internal tool names into guardrail-facing categories.
  * Provider-native sub-agent spawns (Task/Agent/spawn_agent/RemoteTrigger) map to
  * "Subagent" — callers test for that to detect a sub-agent call. */

--- a/src/headers/log.h
+++ b/src/headers/log.h
@@ -31,6 +31,15 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
  * Written to both stderr and the audit log file. */
 void audit_log(const char *event_type, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
+/* Governed-action audit row (per-tool-call). Writes a single structured line
+ * {"ts","kind":"tool_action","actor","tool","args_hash","mode","reason_code",
+ * "verdict","task_id"} to the SAME audit.log as audit_log (single sink), sharing
+ * its mutex + rotation. Distinguished from audit_log rows by the top-level
+ * "kind" key. Best-effort/side-effect-only: callers use this off the enforcement
+ * path and never gate on it. Any string arg may be NULL (rendered as ""). */
+void audit_action_log(const char *actor, const char *tool, const char *args_hash, const char *mode,
+                      const char *reason_code, const char *verdict, long long task_id);
+
 /* Convenience macros */
 #define LOG_ERROR(mod, ...) aimee_log(LOG_ERROR, mod, __VA_ARGS__)
 #define LOG_WARN(mod, ...)  aimee_log(LOG_WARN, mod, __VA_ARGS__)

--- a/src/headers/log.h
+++ b/src/headers/log.h
@@ -40,6 +40,11 @@ void audit_log(const char *event_type, const char *fmt, ...) __attribute__((form
 void audit_action_log(const char *actor, const char *tool, const char *args_hash, const char *mode,
                       const char *reason_code, const char *verdict, long long task_id);
 
+/* Last audit event key set by audit_log() on this thread (empty if none since
+ * the last reset). Used to derive a governed-action reason_code. */
+const char *audit_last_event(void);
+void audit_last_event_reset(void);
+
 /* Convenience macros */
 #define LOG_ERROR(mod, ...) aimee_log(LOG_ERROR, mod, __VA_ARGS__)
 #define LOG_WARN(mod, ...)  aimee_log(LOG_WARN, mod, __VA_ARGS__)

--- a/src/log.c
+++ b/src/log.c
@@ -140,27 +140,67 @@ void audit_log_close(void)
    }
 }
 
-/* JSON-escape src into dst (bounded). Mirrors the inline escaping in audit_log. */
+/* JSON-escape src into dst (bounded), RFC 8259 §7 compliant for control bytes so
+ * a model-controlled field (e.g. tool_name) cannot emit an invalid audit line.
+ * Reserves 6 bytes per iteration for the worst case (\uXXXX). */
 static void audit_json_escape(char *dst, size_t dstsz, const char *src)
 {
    size_t ep = 0;
    if (!src)
       src = "";
-   for (size_t i = 0; src[i] && ep < dstsz - 2; i++)
+   for (size_t i = 0; src[i] && ep + 6 < dstsz; i++)
    {
-      if (src[i] == '"' || src[i] == '\\')
+      unsigned char c = (unsigned char)src[i];
+      if (c == '"' || c == '\\')
+      {
          dst[ep++] = '\\';
-      if (src[i] == '\n')
+         dst[ep++] = (char)c;
+      }
+      else if (c == '\n')
       {
          dst[ep++] = '\\';
          dst[ep++] = 'n';
       }
+      else if (c == '\r')
+      {
+         dst[ep++] = '\\';
+         dst[ep++] = 'r';
+      }
+      else if (c == '\t')
+      {
+         dst[ep++] = '\\';
+         dst[ep++] = 't';
+      }
+      else if (c < 0x20)
+      {
+         ep += (size_t)snprintf(dst + ep, dstsz - ep, "\\u%04x", c);
+      }
       else
       {
-         dst[ep++] = src[i];
+         dst[ep++] = (char)c;
       }
    }
    dst[ep] = '\0';
+}
+
+/* Rotate audit.log if it has reached AUDIT_MAX_SIZE. Caller MUST hold log_mutex.
+ * Single source of truth for both audit_log and audit_action_log. */
+static void audit_maybe_rotate_locked(void)
+{
+   if (!audit_fp)
+      return;
+   char path[4096];
+   snprintf(path, sizeof(path), "%s/audit.log", config_default_dir());
+   struct stat st;
+   if (stat(path, &st) == 0 && st.st_size >= AUDIT_MAX_SIZE)
+   {
+      fclose(audit_fp);
+      audit_fp = NULL;
+      audit_rotate(path);
+      audit_fp = fopen(path, "a");
+      if (audit_fp)
+         platform_set_permissions(path, 0600);
+   }
 }
 
 void audit_action_log(const char *actor, const char *tool, const char *args_hash, const char *mode,
@@ -177,9 +217,9 @@ void audit_action_log(const char *actor, const char *tool, const char *args_hash
    audit_json_escape(e_reason, sizeof e_reason, reason_code);
    audit_json_escape(e_verdict, sizeof e_verdict, verdict);
 
+   /* No stderr mirror: tool_action fires on every governed call and would flood
+    * the server log. The row goes only to the audit file. */
    pthread_mutex_lock(&log_mutex);
-
-   fprintf(stderr, "%s AUDIT tool_action: %s %s %s\n", ts, e_verdict, e_tool, e_reason);
 
    if (audit_fp)
    {
@@ -189,19 +229,7 @@ void audit_action_log(const char *actor, const char *tool, const char *args_hash
               "\"task_id\":%lld}\n",
               ts, e_actor, e_tool, e_hash, e_mode, e_reason, e_verdict, task_id);
       fflush(audit_fp);
-
-      char path[4096];
-      snprintf(path, sizeof(path), "%s/audit.log", config_default_dir());
-      struct stat st;
-      if (stat(path, &st) == 0 && st.st_size >= AUDIT_MAX_SIZE)
-      {
-         fclose(audit_fp);
-         audit_fp = NULL;
-         audit_rotate(path);
-         audit_fp = fopen(path, "a");
-         if (audit_fp)
-            platform_set_permissions(path, 0600);
-      }
+      audit_maybe_rotate_locked();
    }
 
    pthread_mutex_unlock(&log_mutex);
@@ -248,20 +276,7 @@ void audit_log(const char *event_type, const char *fmt, ...)
       fprintf(audit_fp, "{\"ts\":\"%s\",\"event\":\"%s\",\"detail\":\"%s\"}\n", ts, event_type,
               escaped);
       fflush(audit_fp);
-
-      /* Check rotation after each write */
-      char path[4096];
-      snprintf(path, sizeof(path), "%s/audit.log", config_default_dir());
-      struct stat st;
-      if (stat(path, &st) == 0 && st.st_size >= AUDIT_MAX_SIZE)
-      {
-         fclose(audit_fp);
-         audit_fp = NULL;
-         audit_rotate(path);
-         audit_fp = fopen(path, "a");
-         if (audit_fp)
-            platform_set_permissions(path, 0600);
-      }
+      audit_maybe_rotate_locked();
    }
 
    pthread_mutex_unlock(&log_mutex);

--- a/src/log.c
+++ b/src/log.c
@@ -116,6 +116,19 @@ static void audit_rotate(const char *path)
    }
 }
 
+/* Last audit event key on this thread. Lets pre_tool_check derive a stable
+ * reason_code from a block site's existing audit_log("<key>",...) call without
+ * threading extra state through the guardrail function. */
+static __thread char g_last_audit_event[48];
+void audit_last_event_reset(void)
+{
+   g_last_audit_event[0] = '\0';
+}
+const char *audit_last_event(void)
+{
+   return g_last_audit_event;
+}
+
 void audit_log_open(void)
 {
    if (audit_fp)
@@ -237,6 +250,7 @@ void audit_action_log(const char *actor, const char *tool, const char *args_hash
 
 void audit_log(const char *event_type, const char *fmt, ...)
 {
+   snprintf(g_last_audit_event, sizeof g_last_audit_event, "%s", event_type ? event_type : "");
    char ts[32];
    format_timestamp(ts, sizeof(ts));
 

--- a/src/log.c
+++ b/src/log.c
@@ -140,6 +140,73 @@ void audit_log_close(void)
    }
 }
 
+/* JSON-escape src into dst (bounded). Mirrors the inline escaping in audit_log. */
+static void audit_json_escape(char *dst, size_t dstsz, const char *src)
+{
+   size_t ep = 0;
+   if (!src)
+      src = "";
+   for (size_t i = 0; src[i] && ep < dstsz - 2; i++)
+   {
+      if (src[i] == '"' || src[i] == '\\')
+         dst[ep++] = '\\';
+      if (src[i] == '\n')
+      {
+         dst[ep++] = '\\';
+         dst[ep++] = 'n';
+      }
+      else
+      {
+         dst[ep++] = src[i];
+      }
+   }
+   dst[ep] = '\0';
+}
+
+void audit_action_log(const char *actor, const char *tool, const char *args_hash, const char *mode,
+                      const char *reason_code, const char *verdict, long long task_id)
+{
+   char ts[32];
+   format_timestamp(ts, sizeof(ts));
+
+   char e_actor[128], e_tool[128], e_hash[96], e_mode[64], e_reason[96], e_verdict[32];
+   audit_json_escape(e_actor, sizeof e_actor, actor);
+   audit_json_escape(e_tool, sizeof e_tool, tool);
+   audit_json_escape(e_hash, sizeof e_hash, args_hash);
+   audit_json_escape(e_mode, sizeof e_mode, mode);
+   audit_json_escape(e_reason, sizeof e_reason, reason_code);
+   audit_json_escape(e_verdict, sizeof e_verdict, verdict);
+
+   pthread_mutex_lock(&log_mutex);
+
+   fprintf(stderr, "%s AUDIT tool_action: %s %s %s\n", ts, e_verdict, e_tool, e_reason);
+
+   if (audit_fp)
+   {
+      fprintf(audit_fp,
+              "{\"ts\":\"%s\",\"kind\":\"tool_action\",\"actor\":\"%s\",\"tool\":\"%s\","
+              "\"args_hash\":\"%s\",\"mode\":\"%s\",\"reason_code\":\"%s\",\"verdict\":\"%s\","
+              "\"task_id\":%lld}\n",
+              ts, e_actor, e_tool, e_hash, e_mode, e_reason, e_verdict, task_id);
+      fflush(audit_fp);
+
+      char path[4096];
+      snprintf(path, sizeof(path), "%s/audit.log", config_default_dir());
+      struct stat st;
+      if (stat(path, &st) == 0 && st.st_size >= AUDIT_MAX_SIZE)
+      {
+         fclose(audit_fp);
+         audit_fp = NULL;
+         audit_rotate(path);
+         audit_fp = fopen(path, "a");
+         if (audit_fp)
+            platform_set_permissions(path, 0600);
+      }
+   }
+
+   pthread_mutex_unlock(&log_mutex);
+}
+
 void audit_log(const char *event_type, const char *fmt, ...)
 {
    char ts[32];

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -21,6 +21,7 @@
 #include "events.h"
 #include "agent_exec.h"
 #include "log.h"
+#include "audit_action.h"
 #include "platform_path.h"
 #include "platform_process.h"
 #include "shutdown_forensics.h"
@@ -144,6 +145,7 @@ static int run_server(const char *socket_path, log_level_t log_level)
    /* Initialize logging */
    log_init(log_level);
    audit_log_open();
+   audit_ensure_key(); /* provision the per-action audit key (best-effort) */
 
    /* Activate the GitHub App installation-token provider for the server's forge
     * identity. Inert unless AIMEE_FORGE_APP_* is set (see forge_app_token.c). */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ set_tests_properties(test_context_engine PROPERTIES
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 aimee_add_test(test_util test_util.c)
 aimee_add_test(test_audit_action test_audit_action.c)
+aimee_add_test(test_audit_action_log test_audit_action_log.c)
 aimee_add_test(test_db test_db.c)
 aimee_add_test(test_config test_config.c)
 aimee_add_test(test_cron_config test_cron_config.c ../config_trigger.c)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -30,7 +30,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/mcp_client.o $(OBJDIR)/server/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
-	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
+	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_action_audit.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
                              $(OBJDIR)/branch_ownership.o \
                              $(OBJDIR)/dstr.o $(OBJDIR)/diff.o \
                              $(OBJDIR)/server/web_search.o \

--- a/src/tests/test_audit_action_log.c
+++ b/src/tests/test_audit_action_log.c
@@ -1,0 +1,92 @@
+/* test_audit_action_log.c: verifies the S2 governed-action audit row format —
+ * audit_action_log writes a single JSON line with kind=tool_action and the
+ * expected fields (with JSON escaping) to the shared audit.log. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "log.h"
+
+static char g_home[512];
+
+static void set_home(void)
+{
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-audit-log-test-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   setenv("AIMEE_HOME", g_home, 1);
+   char p[600];
+   snprintf(p, sizeof p, "%s/audit.log", g_home);
+   unlink(p); /* fresh file */
+}
+
+static char *read_audit_log(void)
+{
+   char p[600];
+   snprintf(p, sizeof p, "%s/audit.log", g_home);
+   FILE *f = fopen(p, "r");
+   assert(f);
+   static char buf[8192];
+   size_t n = fread(buf, 1, sizeof buf - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   return buf;
+}
+
+static void test_row_format(void)
+{
+   set_home();
+   audit_log_open();
+   audit_action_log("primary", "Write", "v1-abc123", "approve", "read_before_write", "block", 42);
+   audit_log_close();
+
+   char *log = read_audit_log();
+   assert(strstr(log, "\"kind\":\"tool_action\"")); /* discriminator, not "event" */
+   assert(strstr(log, "\"actor\":\"primary\""));
+   assert(strstr(log, "\"tool\":\"Write\""));
+   assert(strstr(log, "\"args_hash\":\"v1-abc123\""));
+   assert(strstr(log, "\"mode\":\"approve\""));
+   assert(strstr(log, "\"reason_code\":\"read_before_write\""));
+   assert(strstr(log, "\"verdict\":\"block\""));
+   assert(strstr(log, "\"task_id\":42"));
+}
+
+static void test_json_escaping(void)
+{
+   set_home();
+   audit_log_open();
+   /* a tool name carrying a quote + backslash must be escaped, not break JSON */
+   audit_action_log("primary", "We\"ird\\Tool", "v1-0", "approve", "blocked", "block", 0);
+   audit_log_close();
+
+   char *log = read_audit_log();
+   assert(strstr(log, "We\\\"ird\\\\Tool")); /* \" and \\ escaped in the row */
+   /* still a single well-formed line ending in }\n */
+   size_t len = strlen(log);
+   assert(len >= 2 && log[len - 1] == '\n' && log[len - 2] == '}');
+}
+
+static void test_null_fields_render_empty(void)
+{
+   set_home();
+   audit_log_open();
+   audit_action_log(NULL, "Read", NULL, NULL, NULL, "allow", 7);
+   audit_log_close();
+
+   char *log = read_audit_log();
+   assert(strstr(log, "\"actor\":\"\""));
+   assert(strstr(log, "\"reason_code\":\"\""));
+   assert(strstr(log, "\"verdict\":\"allow\""));
+   assert(strstr(log, "\"tool\":\"Read\""));
+}
+
+int main(void)
+{
+   test_row_format();
+   test_json_escaping();
+   test_null_fields_render_empty();
+   printf("test_audit_action_log: all passed\n");
+   return 0;
+}

--- a/src/tests/test_audit_action_log.c
+++ b/src/tests/test_audit_action_log.c
@@ -82,11 +82,28 @@ static void test_null_fields_render_empty(void)
    assert(strstr(log, "\"tool\":\"Read\""));
 }
 
+static void test_control_char_escaping(void)
+{
+   set_home();
+   audit_log_open();
+   /* a tool name with a tab, CR, and a raw control byte (0x01) must be escaped
+    * to valid JSON, not emitted raw (would break the S3 reader). */
+   audit_action_log("primary",
+                    "a\tb\rc\x01"
+                    "d",
+                    "v1-0", "approve", "blocked", "block", 0);
+   audit_log_close();
+
+   char *log = read_audit_log();
+   assert(strstr(log, "a\\tb\\rc\\u0001d")); /* \t \r and , no raw control bytes */
+}
+
 int main(void)
 {
    test_row_format();
    test_json_escaping();
    test_null_fields_render_empty();
+   test_control_char_escaping();
    printf("test_audit_action_log: all passed\n");
    return 0;
 }


### PR DESCRIPTION
Second slice of the per-action governance audit (P2), building on S1 (#947).

## What
- **`audit_action_log()`** (log.c) → one JSON line `{ts, kind:"tool_action", actor, tool, args_hash, mode, reason_code, verdict, task_id}` to the **same** `audit.log` (single sink, shared mutex + rotation), discriminated by top-level `kind`; **no FK** to decision_log (stands alone → P2 before P1).
- **Structural exactly-once emit**: `pre_tool_check` body → static `pre_tool_check_inner`; a thin wrapper emits one row post-verdict, so the ~28 inner return paths can't drift the count.
- **Fail-open**: emit is side-effect-only; a config/hash/log failure never changes the verdict.
- **`reason_code`** = the stable event key already at the 5 keyed block sites + computer-use; free-form `msg_buf` prose is never persisted. `args_hash` = S1 keyed digest.
- **`audit.action_enabled`** knob (default-OFF until the S3 reader ships); `audit_ensure_key()` provisioned at hook + server startup.

## Roundtable (7 panelists, 5 survived, verified=7)
All 3 blocking findings fixed in the follow-up commit: (1) config parse on the hot path + not fail-open → cached memset-safe flag; (2) `g_audit_reason` stale on NULL-arg early return → reset in the wrapper; (3) duplicated rotation → shared `audit_maybe_rotate_locked()`. Plus RFC-8259 control-char escaping, `approval_required` vs `block`, `unknown` for novel rc, dropped the high-frequency stderr mirror.

## Tests
`audit_action_log` row format, JSON escaping, control-char escaping, null-field rendering (green). Full `pre_tool_check` e2e needs a live server (the hook forwards to it) → covered by the **S7 live-verify** slice per the plan.