### PR TITLE
feat(workflow): primary-as-manager S2 step 5 — templated enforcement surfacing

### DIFF
--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -1666,13 +1666,19 @@ int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
     * unset -> ALLOW); soft warns + allows; hard refuses. The decision is audited
     * inside the guard. Runs before every dispatch branch so it also covers the
     * workflow-tool and git_ externalization paths. */
-   if (wfe_mcp_toolcall_action(sid, tool) == WFE_TC_DENY)
    {
-      if (owns_jargs)
-         cJSON_Delete(jargs);
-      return server_send_error(
-          conn, "refused: this action externalizes work before the review/delivery gate has passed",
-          NULL);
+      char deny_msg[256] = "";
+      if (wfe_mcp_toolcall_action(sid, tool, deny_msg, sizeof deny_msg) == WFE_TC_DENY)
+      {
+         if (owns_jargs)
+            cJSON_Delete(jargs);
+         return server_send_error(
+             conn,
+             deny_msg[0]
+                 ? deny_msg
+                 : "refused: this action externalizes work before the review/delivery gate has passed",
+             NULL);
+      }
    }
 
    if (strcmp(tool, "delegate") == 0)

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -1672,12 +1672,11 @@ int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       {
          if (owns_jargs)
             cJSON_Delete(jargs);
-         return server_send_error(
-             conn,
-             deny_msg[0]
-                 ? deny_msg
-                 : "refused: this action externalizes work before the review/delivery gate has passed",
-             NULL);
+         return server_send_error(conn,
+                                  deny_msg[0] ? deny_msg
+                                              : "refused: this action externalizes work before the "
+                                                "review/delivery gate has passed",
+                                  NULL);
       }
    }
 

--- a/src/tests/test_wfe_block_resolve.c
+++ b/src/tests/test_wfe_block_resolve.c
@@ -154,26 +154,46 @@ int main(void)
 
    /* --- the guard --- */
    unsetenv("AIMEE_WORKFLOW_ENFORCE_STAGE");
-   assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_ALLOW); /* dial off */
+   assert(wfe_mcp_toolcall_action(SID, "pr.open", NULL, 0) == WFE_TC_ALLOW); /* dial off */
 
    setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "hard", 1);
-   assert(wfe_mcp_toolcall_action(SID, "read_file") == WFE_TC_ALLOW);    /* not externalization */
-   assert(wfe_mcp_toolcall_action("nobody", "pr.open") == WFE_TC_ALLOW); /* truly unbound */
-   assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_DENY); /* pre-delivery externalize */
-   assert(wfe_mcp_toolcall_action(SID, "git_push") == WFE_TC_DENY);
+   assert(wfe_mcp_toolcall_action(SID, "read_file", NULL, 0) ==
+          WFE_TC_ALLOW); /* not externalization */
+   assert(wfe_mcp_toolcall_action("nobody", "pr.open", NULL, 0) ==
+          WFE_TC_ALLOW); /* truly unbound */
+   assert(wfe_mcp_toolcall_action(SID, "pr.open", NULL, 0) ==
+          WFE_TC_DENY); /* pre-delivery externalize */
+   assert(wfe_mcp_toolcall_action(SID, "git_push", NULL, 0) == WFE_TC_DENY);
    assert(audit_count(id) == 2); /* the two denials were audited */
+
+   /* step 5: a DENY fills a TEMPLATED user message -- names the gate + work-item id,
+    * never echoes the attempted tool name (pr.open). */
+   {
+      char msg[256] = "";
+      assert(wfe_mcp_toolcall_action(SID, "pr.open", msg, sizeof msg) == WFE_TC_DENY);
+      assert(msg[0]);
+      assert(strstr(msg, "gate.deliver") != NULL);
+      assert(strstr(msg, id) != NULL);        /* the work-item id is surfaced */
+      assert(strstr(msg, "pr.open") == NULL); /* the attempted tool is NOT echoed */
+      /* ALLOW clears the buffer */
+      msg[0] = 'x';
+      msg[1] = '\0';
+      assert(wfe_mcp_toolcall_action(SID, "read_file", msg, sizeof msg) == WFE_TC_ALLOW);
+      assert(msg[0] == '\0');
+   }
+   assert(audit_count(id) == 3); /* the message-check DENY added one more audit row */
 
    /* soft dial: warn + allow (still audited) */
    setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "soft", 1);
-   assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_WARN);
-   assert(audit_count(id) == 3);
+   assert(wfe_mcp_toolcall_action(SID, "pr.open", NULL, 0) == WFE_TC_WARN);
+   assert(audit_count(id) == 4);
 
    /* once delivered (gate.deliver -> accepted), the guard lifts */
    setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "hard", 1);
    assert(db1_work_item_set_terminal(id, "accepted") == 0);
    assert(wfe_block_resolve(SID, &ctx) == 1 && ctx.delivered == 1);
-   assert(wfe_mcp_toolcall_action(SID, "pr.open") == WFE_TC_ALLOW);
-   assert(audit_count(id) == 3); /* no new denial */
+   assert(wfe_mcp_toolcall_action(SID, "pr.open", NULL, 0) == WFE_TC_ALLOW);
+   assert(audit_count(id) == 4); /* no new denial */
 
    /* a NON-enforced bound run is not externalization-guarded (delivered==accepted
     * would not be a sound gate proxy there, and it made no enforcement promise) */
@@ -182,7 +202,7 @@ int main(void)
                                sizeof err) == 0);
    assert(db1_wfe_bind("sess-U", id_u, "advisory") == 0);
    assert(wfe_block_resolve("sess-U", &ctx) == 1 && ctx.enforced == 0);
-   assert(wfe_mcp_toolcall_action("sess-U", "pr.open") ==
+   assert(wfe_mcp_toolcall_action("sess-U", "pr.open", NULL, 0) ==
           WFE_TC_ALLOW); /* hard, but not enforced */
 
    /* BOUND-but-unresolvable (binding references a vanished work-item): an
@@ -191,9 +211,10 @@ int main(void)
    assert(db1_wfe_bind("sess-G", "wi_ghost0000", "advisory") == 0);
    assert(wfe_block_resolve("sess-G", &ctx) == 0); /* cannot resolve */
    setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "hard", 1);
-   assert(wfe_mcp_toolcall_action("sess-G", "pr.open") == WFE_TC_DENY); /* fail closed */
+   assert(wfe_mcp_toolcall_action("sess-G", "pr.open", NULL, 0) == WFE_TC_DENY); /* fail closed */
    setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "soft", 1);
-   assert(wfe_mcp_toolcall_action("sess-G", "pr.open") == WFE_TC_ALLOW); /* soft: observe */
+   assert(wfe_mcp_toolcall_action("sess-G", "pr.open", NULL, 0) ==
+          WFE_TC_ALLOW); /* soft: observe */
 
    printf("ok\n");
    return 0;

--- a/src/workflow/wfe_block_resolve.c
+++ b/src/workflow/wfe_block_resolve.c
@@ -80,8 +80,16 @@ wfe_toolcall_action_t wfe_toolcall_decide(wfe_enforce_stage_t stage, int policy_
    return WFE_TC_ALLOW; /* advisory / off: observe only */
 }
 
-wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char *tool_name)
+/* The externalization gate the guard surfaces (templated; a stable label, never a
+ * client-supplied value) -- delivery is what the run must earn before externalizing. */
+#define WFE_GUARD_GATE "gate.deliver"
+
+wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char *tool_name,
+                                              char *msg, size_t msg_n)
 {
+   if (msg && msg_n)
+      msg[0] = '\0';
+
    wfe_enforce_stage_t stage = wfe_enforce_stage_parse(getenv("AIMEE_WORKFLOW_ENFORCE_STAGE"));
    if (stage == WFE_ENFORCE_OFF || !tool_name || !tool_name[0])
       return WFE_TC_ALLOW;
@@ -110,6 +118,8 @@ wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char
                   act == WFE_TC_DENY ? "deny" : "warn", wfe_enforce_stage_name(stage));
          db1_lifecycle_event_add(ctx.work_item_id, ctx.stage, "toolcall_guard", "enforce-s2",
                                  detail, "", 0);
+         /* Step 5: templated surfacing -- gate + work-item id only, no tool/arg echo. */
+         wfe_enforce_user_message(stage, WFE_GUARD_GATE, ctx.work_item_id, msg, msg_n);
       }
       return act;
    }
@@ -128,5 +138,6 @@ wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char
    db1_lifecycle_event_add(
        wi, "", "toolcall_guard", "enforce-s2",
        "{\"guard\":\"externalization\",\"action\":\"deny\",\"reason\":\"unresolved\"}", "", 0);
+   wfe_enforce_user_message(stage, WFE_GUARD_GATE, wi, msg, msg_n);
    return WFE_TC_DENY;
 }

--- a/src/workflow/wfe_block_resolve.h
+++ b/src/workflow/wfe_block_resolve.h
@@ -55,7 +55,13 @@ wfe_toolcall_action_t wfe_toolcall_decide(wfe_enforce_stage_t stage, int policy_
 /* The dispatch-time guard, composed: resolve `session_id`, and if the enforcement
  * dial is on and `tool_name` is an externalization primitive that this run has not
  * yet earned (gate.deliver not passed), return WARN/DENY per the dial; otherwise
- * ALLOW. Reads the dial from AIMEE_WORKFLOW_ENFORCE_STAGE (default OFF -> ALLOW). */
-wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char *tool_name);
+ * ALLOW. Reads the dial from AIMEE_WORKFLOW_ENFORCE_STAGE (default OFF -> ALLOW).
+ *
+ * On a non-ALLOW decision, fills `msg`/`msg_n` (when non-NULL) with a TEMPLATED
+ * user/primary-facing refusal (step 5): the gate name + work-item id only, NEVER
+ * the attempted tool name or args (echo/injection vector, consult Q3). `msg` is set
+ * to "" on ALLOW. */
+wfe_toolcall_action_t wfe_mcp_toolcall_action(const char *session_id, const char *tool_name,
+                                              char *msg, size_t msg_n);
 
 #endif /* DEC_WFE_BLOCK_RESOLVE_H */


### PR DESCRIPTION
## Primary-as-manager S2 step 5 — templated enforcement surfacing

`wfe_enforce_user_message` (the sub-slice-1 templated refusal — **gate name + work-item id only, never the attempted tool/args**) had **no callers**. Step 5 wires it into the dispatch guard so a denied externalization returns a consistent, injection-safe user/primary-facing message instead of a hardcoded string.

### What's here
- **`wfe_mcp_toolcall_action`** gains `(msg, msg_n)`: on a non-ALLOW decision it fills a templated refusal via `wfe_enforce_user_message` (naming `gate.deliver` + the resolved work-item id); `""` on ALLOW. Covers both the resolved-DENY and the bound-but-unresolvable fail-closed paths.
- **`handle_mcp_call`** surfaces that message as the refusal content (falls back to the prior constant if empty).

### Verification
- Test asserts the message **names the gate + work-item** and does **not** echo the attempted tool (`pr.open`); ALLOW clears the buffer. Regressions green; production `aimee-server` links.
- **Default-OFF**: the guard returns ALLOW when the dial is off, so no message is produced.

### Note
The `gate.deliver` terminal-executor surface event is a small follow-on (needs an engine-failure-path test); this slice lands the primary-facing **guard** surfacing, which is the path the primary actually hits when it attempts a pre-delivery externalization.
