### PR TITLE
feat(workflow): proposal read surfaces (Proposals page slice 0)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -435,13 +435,75 @@ paths:
               schema: { type: object }
   /workflow/items:
     get:
-      summary: List workflow work items (run-state rows)
+      summary: List the caller's own workflow work items (submitter-scoped run-state rows)
       responses:
         "200":
-          description: "{items:[{id,workflow,version,stage,state,mode,pause_reason,repo}]}"
+          description: "{items:[{id,workflow,version,stage,state,mode,pause_reason,repo,proposal_name,pr_ref,submitter,cum_cost_usd,work_item_max_cost_usd,override_count}]}"
           content:
             application/json:
               schema: { type: object }
+  /workflow/items/all:
+    get:
+      summary: List ALL work items regardless of submitter (operator view, CAP_WORKFLOW_ADMIN)
+      responses:
+        "200":
+          description: All work-item run-state rows
+          content:
+            application/json:
+              schema: { type: object }
+  /workflow/items/{id}/events:
+    get:
+      summary: The item's lifecycle timeline (proposal history), owner-only, paginated by event id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: after
+          in: query
+          required: false
+          schema: { type: integer }
+          description: Return events with id greater than this cursor (default 0)
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer }
+          description: Max events to return, clamped to [1,200] (default 200)
+      responses:
+        "200":
+          description: "{events:[{id,stage,kind,actor,detail,cost_usd,created_at}], next_after}"
+          content:
+            application/json:
+              schema: { type: object }
+        "403":
+          description: Not the caller's work item
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/items/{id}/proposal:
+    get:
+      summary: The source proposal markdown the run is executing (owner-only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: "{proposal_md, truncated}"
+          content:
+            application/json:
+              schema: { type: object }
+        "403":
+          description: Not the caller's work item
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Proposal file not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /workflow/items/{id}:
     get:
       summary: One work item's run-state

--- a/docs/proposals/pending/proposals-ui-page.md
+++ b/docs/proposals/pending/proposals-ui-page.md
@@ -1,0 +1,299 @@
+# Proposal: dedicated Proposals web page (author → autonomous implement → status/history)
+
+## Goal
+
+Give the aimee web UI a **Proposals** page, separate from Workflows, that carries a
+change from an empty editor to a merged PR:
+
+1. **Author** a proposal from scratch (markdown editor + scaffold; optional
+   delegate-assisted drafting/refinement).
+2. **Implement** it end-to-end by handing it to the existing autonomous-development
+   driver (submit → the wfe scheduler runs the `build` workflow: roundtable gate →
+   human approve → plan → impl → verify → PR → CI → merge), parking at human gates.
+3. **Watch** it: a per-proposal **status + history** view the user can scroll back
+   through to see everything that happened — every stage transition, gate decision,
+   pause reason, cost, and the resulting PR.
+
+The point is a single home for the whole proposal lifecycle. Workflows stays the
+*graph editor / def authoring* surface; Proposals is the *do-the-work* surface.
+
+## §0 What already exists (so we don't rebuild it)
+
+The autonomous-implementation backend is **already built and merged** (see
+`done/full-autonomous-development.md`, `done/autonomous-dev-execution-substrate.md`).
+This proposal is mostly a **read surface + UI** on top of it.
+
+- **Submit** — `POST /api/dev/submit {proposal_md, workflow?, repo?}` → Go
+  `handleDevSubmit` (`webchat/dev.go:12`) → `POST /v1/dev/submit` (`rh_dev_submit`,
+  `server_http_routes.inc:183`, `CAP_DELEGATE`). It writes the markdown to
+  `$AIMEE_HOME/workflows/proposals/wi-*.md`, calls `wfe_work_item_create` (one
+  `lifecycle_work_item` row + a `create` `lifecycle_event`), and
+  `wfe_scheduler_notify()`. Returns `{work_item_id, workflow, state}`.
+- **Data model** (`src/db1/schema.sql:119`, typed in `src/db1/wfe_store.h`):
+  - `lifecycle_work_item`: `work_item_id, repo, proposal_path, workflow_name,
+    workflow_version, current_stage, state, mode, pause_reason, pr_ref,
+    cum_cost_usd, work_item_max_cost_usd, override_count, submitter, created_at,
+    updated_at`. `state ∈ {active, accepted, rejected, abandoned}`;
+    `mode ∈ {interactive, autonomous}`; `pause_reason ∈ {"", pending_human,
+    panel_degraded, budget_exceeded, panel_unreachable, ci_pending, merge_pending,
+    failed, max_attempts}`.
+  - `lifecycle_event` (append-only): `work_item_id, stage, kind, actor, detail,
+    content_hash, cost_usd, created_at`. `kind ∈ {create, advance, loop, pause,
+    failed, terminal, resume, approve, reject, reject_retry, override, rejected}`.
+    This **is** the scrollable history — it just isn't served anywhere yet.
+- **The driver** — `wfe_scheduler` (`src/server/wfe_scheduler.c`, concurrency 1,
+  wakes on notify + 30s backstop) runs `wfe_autonomy_run` on every
+  `state=active && mode=autonomous` item; `wfe_engine_advance`
+  (`src/workflow/wfe_engine.c:192`) executes one node per lifecycle txn and records a
+  `lifecycle_event` per transition. Live forge stays **default-off** behind
+  `wfe_live_forge_enabled` (unchanged here).
+- **Gates** — `POST /v1/workflow/items/<id>/gate {decision, gate?}`
+  (`rh_workflow_gate`, `CAP_WORKFLOW_ADMIN`): gate read from the row's
+  `current_stage` (never trusted from the request), signed approval, TOCTOU-guarded
+  apply, reject-retry capped at 3. The Workflows page already calls this
+  (`/api/workflow/items/<id>/gate`).
+- **Run snapshot** — `GET /v1/workflow/items[/<id>]` (`wf_api_items`/`wf_api_item`,
+  `server_workflow_api.c`) returns the thin `RunItem`
+  `{id, workflow, version, stage, state, mode, pause_reason, repo}`.
+
+**We reuse all of the above.** We do **not** add a second work model, and we do
+**not** touch `work_queue` (`/v1/work/*`, the older CLI kanban) or
+`roundtable_pipeline_*` (CLI-only). A proposal remains *markdown + a work item*;
+its lifecycle *is* the work-item state machine.
+
+## §1 Exposed read surfaces (backend, additive, no new tables)
+
+Three thin, read-only additions — the load-bearing gap is that the timeline and
+rich fields exist in the DB but are never served.
+
+**Access model for the per-item reads (R1 — closes the IDOR).** `/events`,
+`/proposal`, and the enriched single-item GET are **ownership-scoped, not just
+`CAP_DASHBOARD_READ`**: the server compares the row's `submitter` to the caller's
+attested subject and serves only if they match, **or** the caller holds
+`CAP_WORKFLOW_ADMIN`. This is enforced in the C handler (the authoritative seam),
+not the UI. Fail-closed: a row with a NULL/empty `submitter` (CLI/legacy/system
+items) is visible **only** to `CAP_WORKFLOW_ADMIN`. Same rule scopes the list (§2).
+
+- **§1a — Timeline API.** New `GET /v1/workflow/items/<id>/events` →
+  `db1_lifecycle_event_list(id, &out)` (already implemented, oldest-first), serialized
+  as `{events:[{id, stage, kind, actor, detail, cost_usd, created_at}], next_after}`.
+  **Paginated** via `?after=<event_id>&limit=<n≤200>` (default 200): the page fetches
+  the tail once, then polls with `after=<last id>` to append only new events — so a
+  long/looping run never refetches its whole history. Go proxy
+  `GET /api/workflow/items/<id>/events`. Ownership-scoped as above.
+- **§1b — Richer item serialization.** Extend `item_to_json`
+  (`server_workflow_api.c:398`) to also emit **only cheap DB columns** —
+  `proposal_name` (basename of `proposal_path`, never the server FS path), `pr_ref`,
+  `cum_cost_usd`, `work_item_max_cost_usd`, `override_count`, `submitter`,
+  `created_at`, `updated_at`. Additive keys only (existing fields unchanged), so the
+  Workflows page — which reads the same endpoint via a strict TS interface that
+  ignores extra keys — is unaffected (verified by its build). **No `title`
+  derivation here** (see R1): computing an H1 would mean reading+parsing every
+  proposal file on every list/poll (O(N·P) synchronous IO in the request path). The
+  title is instead shown in the detail view, derived client-side from the §1c content
+  (one file read, only when a proposal is opened).
+- **§1c — Proposal content read-back.** New `GET /v1/workflow/items/<id>/proposal` →
+  serves the run's own `proposal_path` → `{proposal_md, truncated}`. `proposal_path`
+  is **server-minted** at submit (`wi-<time>-<pid>.md`), never caller-supplied, so the
+  base risk is low; still hardened defense-in-depth: `realpath()` the target and the
+  proposals dir and require the resolved path to sit under
+  `$AIMEE_HOME/workflows/proposals/` (rejects `..`, absolute, symlink escape,
+  null-byte); `open()` then `fstat()` the fd and re-check (no prefix→open TOCTOU);
+  refuse non-regular files; **cap the read** (submit already bounds the body at 1 MB;
+  the endpoint enforces the same cap and sets `truncated`). Missing file → 404. Go
+  proxy `/api/workflow/items/<id>/proposal`. Ownership-scoped as above.
+
+Note: `lifecycle_event.detail` is free-form operator-facing text. Access control
+(ownership scoping) is the containment; v1 does not additionally sanitize `detail`.
+
+## §2 Proposals list + status/history page (frontend)
+
+New page `frontend/src/pages/Proposals.tsx`, nav entry, route `/proposals`.
+
+- **List** — proposals = work items (`GET /api/workflow/items`, enriched by §1b),
+  **server-scoped to the caller's `submitter`** by default. A "show all" view exists
+  but is **gated server-side on `CAP_WORKFLOW_ADMIN`** (not a mere client toggle) —
+  the server filters, so a non-admin can never receive another user's rows (this,
+  with §1's per-item ownership check, closes the enumeration/IDOR path). Each row:
+  workflow, short id, stage, a lifecycle **badge derived strictly from
+  `state` + `pause_reason` + `current_stage`** (e.g. *active / awaiting human
+  approval / CI running / merging / merged (accepted) / rejected / parked:
+  panel_degraded|budget_exceeded|failed|…*), cost, updated-at. (No "drafting" badge —
+  an unsubmitted draft is a client-only state in §3; a submitted item is `active`.)
+- **Detail / status** — for a selected proposal:
+  - **Status header**: `current_stage`, lifecycle badge, cumulative vs. cap cost, PR
+    link (`pr_ref`), timestamps, and the title (H1 parsed client-side from the §1c
+    markdown).
+  - **Timeline** (§1a): a scrollable, oldest→newest feed of `lifecycle_event`s —
+    each entry shows stage, a human label for `kind`, actor, `detail`, cost, and
+    time. Fetched as a paginated tail, then extended incrementally on poll. This is
+    the "scroll back and find the history of what happened" surface.
+  - **Proposal** (§1c): the rendered source markdown.
+  - **Actions**: Approve / Reject are shown **only when `pause_reason ==
+    pending_human`** (the human-approval gate — distinct from a roundtable/CI/merge
+    park, which are read-only status), with the parked `current_stage` labeled so the
+    user knows *which* gate they're deciding. Reuses the existing gate endpoint; the
+    call requires `CAP_WORKFLOW_ADMIN` server-side, and the UI disables/annotates the
+    buttons when the caller lacks it rather than letting the call fail opaquely.
+  - Live refresh: poll the item + incremental events every ~4 s **while
+    `state == active`**, and stop once the item reaches a terminal `state`
+    (`accepted`/`rejected`/`abandoned`) — no polling of finished proposals.
+
+## §3 Author from scratch (frontend)
+
+- A **New proposal** composer: title + markdown body with a template scaffold
+  (Goal / Motivation / Approach / Risks / Tests), workflow picker (default `build`),
+  optional repo. Client-side **draft** persistence in localStorage, **keyed by the
+  authenticated user id and cleared on logout** (so a shared browser doesn't leak a
+  draft across accounts), size-capped, with a visible "draft saved locally on this
+  device" caveat (not cross-device; lost on browser-data clear). A server-side draft
+  store is explicitly deferred (see Non-goals).
+- **Submit** posts to `/api/dev/submit`; on success the page switches to the new
+  proposal's status view (§2), so authoring flows straight into watching it run.
+
+## §4 Delegate-assisted drafting (optional, later slice)
+
+A **Draft/refine with a delegate** action: send the working title + notes to a
+delegate (via the existing delegate/roundtable surface) to produce or improve the
+proposal markdown, returned into the editor for the user to edit before submit.
+Kept as its own slice so §2/§3 ship without it.
+
+## §5 Separate Workflows from Proposals (migration)
+
+Today the Workflows page (`frontend/src/pages/Workflows.tsx`) mixes two concerns:
+def authoring (defs list, blocks palette, graph canvas, node inspector, personas)
+**and** proposal/run concerns (a "Submit proposal" panel → `/api/dev/submit`, a
+"Runs" list, a "Run state" inspector panel, and the gate Approve/Reject). Those
+proposal/run concerns move to the Proposals page so each page owns one job:
+
+- **Workflows** becomes the **def/graph editor only** (author, validate, save
+  workflow definitions; assign personas to steps). It keeps `/api/workflow/{blocks,
+  defs,validate,save}`.
+- **Proposals** owns submission (`/api/dev/submit`), the run/work-item list, the
+  status/history detail, and gate decisions.
+
+**Sequencing to avoid any functionality gap** (each still an independent, shippable
+slice):
+- The **Runs list + Run-state panel + gate Approve/Reject** are removed from
+  Workflows in **Slice 1**, the same slice that introduces the richer Proposals
+  status view — so the capability never disappears, it relocates.
+- The **"Submit proposal" panel** is removed from Workflows in **Slice 2**, the same
+  slice that adds the Proposals composer — so submission is always reachable
+  somewhere.
+
+The `submitProposal`/`decideGate`/`runItem` state and their handlers are deleted from
+`Workflows.tsx` as those panels move; the Proposals page reimplements them against the
+same endpoints. No backend endpoint is removed (Workflows and Proposals share
+`/api/workflow/items` and the gate route).
+
+## Data model summary
+
+**No new tables, no new columns.** Everything reads existing `lifecycle_work_item` /
+`lifecycle_event` state. Ownership uses the existing `submitter` column (populated for
+webchat submits by the intake-auth path, `done/full-autonomous-development.md`;
+NULL/legacy rows are admin-only per §1). Title is parsed client-side from the proposal
+markdown in the detail view; drafts live client-side.
+
+## Surface
+
+New endpoints (all additive, read-only except the pre-existing gate/submit):
+- `GET /v1/workflow/items/<id>/events?after=<id>&limit=<n>` (paginated timeline),
+- `GET /v1/workflow/items/<id>/proposal` (source markdown, path-confined),
+- enriched `GET /v1/workflow/items[/<id>]` with a **`?scope=mine|all`** filter
+  (`all` requires `CAP_WORKFLOW_ADMIN`; default `mine` filters on `submitter`
+  server-side),
+
+each with a `/api/*` webchat proxy and all ownership-scoped (§1). New page
+`/proposals`. Reuses `POST /api/dev/submit` and
+`POST /api/workflow/items/<id>/gate` unchanged.
+
+## Phasing (each independently shippable + roundtable-approved + merged)
+
+- **Slice 0 — read surfaces (§1a/§1b/§1c):** backend only; verifiable via curl +
+  unit tests (dispatch/http/conformance). No UI. Ship first so the page has data.
+- **Slice 1 — Proposals list + status/history page (§2):** read-only over Slice 0 +
+  existing submit/gate. Delivers the "watch it end-to-end" value. **Also removes the
+  Runs/Run-state/gate panels from Workflows** (§5) — the capability relocates, not
+  disappears.
+- **Slice 2 — Author from scratch (§3):** the composer + client-side draft + submit.
+  **Also removes the "Submit proposal" panel from Workflows** (§5).
+- **Slice 3 — Delegate-assisted drafting (§4):** optional enhancement.
+
+## Flags
+
+The read surfaces are additive dashboard reads (no flag, like `agent.stats`). The
+page is additive UI. **Autonomous execution / live forge remains default-off behind
+`wfe_live_forge_enabled`** — this proposal does not change that; the page only drives
+what the operator has already enabled, and surfaces gate parks for human decision.
+
+## Non-goals
+
+- No second work model; no changes to `work_queue` or `roundtable_pipeline_*`.
+- No per-delegate drill-down inside a stage in v1: `agent_jobs`/`token_audit`/
+  `execution_trace` do **not** carry `work_item_id`, so stage-level events (with the
+  `detail`/`cost_usd` already on `lifecycle_event`) are the granularity. Threading
+  `work_item_id` through execution tables for deep drill-down is future work.
+- No server-side draft store in v1 (client-side only).
+- No new authoring of workflow *defs* — that stays on the Workflows page.
+
+## Risks / honest limits
+
+- **Timeline detail is only as rich as `lifecycle_event.detail`.** Some transitions
+  write terse details; the page shows what's there and won't fabricate more. `detail`
+  is served verbatim and is not sanitized in v1 — access is contained by ownership
+  scoping (§1), so only the owner or an admin sees it.
+- **Cost is cumulative at the item level** (`cum_cost_usd`), not per-delegate.
+- **The read endpoints are the main new attack surface.** Mitigated by: per-item
+  ownership scoping (§1), realpath/fstat path confinement + size cap on `/proposal`
+  (§1c), and events pagination bounding response size (§1a).
+- **Ownership rests on `submitter`.** Rows without it (CLI/legacy/system) are
+  admin-only, never shown to a scoped user — fail-closed, but it means the default
+  list omits non-webchat-submitted items unless viewed as admin.
+- **Gate actions require `CAP_WORKFLOW_ADMIN`** server-side; a non-admin user sees the
+  timeline/status but the Approve/Reject call is refused (the UI disables it).
+- **Polling, not push:** status refresh is interval-based (no websocket), matching the
+  existing dashboard pattern.
+
+## Tests
+
+- Slice 0: unit tests for the new routes — events list shape **+ pagination
+  (`after`/`limit`, `next_after`)**; proposal read-back **+ traversal/symlink/absolute
+  rejection + size cap**; **ownership scoping (owner allowed, non-owner denied, admin
+  allowed, NULL-submitter admin-only)**; `?scope=mine|all` filter (all requires admin);
+  `item_to_json` additive-fields snapshot; dispatch-caps / v1-method-coverage /
+  cli-v1-routes / server-api-conformance / openapi doc.
+- Slice 1–2: `tsc -b && vite build`; verify the Workflows page still builds against the
+  enriched item JSON (extra keys ignored); a live end-to-end on pve — submit a trivial
+  proposal against a test CT, watch it advance/park, decide a gate, confirm the
+  timeline renders and extends incrementally.
+
+## Review revisions (R1 — proposal roundtable)
+
+Roundtable review of this design (7 panelists, 4 survivors). Applied:
+
+- **Closed the IDOR** (findings on §1a/§1c/§2): the per-item reads (`/events`,
+  `/proposal`, enriched single-item) are now **ownership-scoped in the C handler**
+  (`submitter == caller` OR `CAP_WORKFLOW_ADMIN`), not just `CAP_DASHBOARD_READ`; the
+  list filter (`?scope=mine|all`) is **server-side** and `all` is admin-gated. NULL
+  `submitter` rows are admin-only (fail-closed).
+- **Hardened §1c path confinement**: realpath resolution + confine under the proposals
+  dir, reject `..`/absolute/symlink-escape/null-byte, open-then-`fstat` (no TOCTOU),
+  regular-file check, and an explicit size cap (`truncated` flag). Noted that
+  `proposal_path` is server-minted, so this is defense-in-depth.
+- **Removed the O(N·P) title derivation**: `item_to_json` now emits only cheap DB
+  columns; the H1 title is parsed **client-side in the detail view** from the §1c
+  content, so the list/poll path does no per-row file IO.
+- **Added events pagination** (`after`/`limit`/`next_after`) so a long/looping run's
+  timeline is fetched as a tail and extended incrementally, never refetched whole.
+- **Specified poll cadence** (~4 s while `active`, stop at terminal) and **gate
+  semantics** (Approve/Reject only for `pending_human`, with the parked stage labeled;
+  read-only for panel/CI/merge parks).
+- **Draft hygiene**: localStorage keyed to the authenticated user id, cleared on
+  logout, size-capped, with a device-local caveat.
+- **`show all` is admin-gated server-side**, not a client toggle.
+
+Triaged as **not-actionable / already-handled**: additive `item_to_json` keys don't
+break the Workflows page (TS structural typing ignores extra keys — kept, verified by
+its build); "drafting" badge removed (badge derives strictly from
+`state`+`pause_reason`+`current_stage`); per-delegate drill-down stays a Non-goal
+(execution tables lack `work_item_id`); server-side draft store deferred to Non-goals.

--- a/docs/proposals/pending/proposals-ui-page.plan.md
+++ b/docs/proposals/pending/proposals-ui-page.plan.md
@@ -1,0 +1,201 @@
+# Implementation plan: Proposals web page
+
+Companion to `proposals-ui-page.md` (approved). Slice-by-slice; each slice is
+roundtable-approved and merged before the next. Branches off `testing`.
+
+## Resolved seams (from a backend read)
+
+- **Caller identity**: `server_http_identity_principal()`
+  (`src/server/server_http_identity.c:111`) returns the attested principal — for
+  webchat it is `"webuser:<subject>"` (git handlers already scope per-user with it,
+  `server_http_routes.inc:1099`). This is the ownership key.
+- **`submitter`**: populated on webchat submits by the intake-auth path
+  (`db1_work_item_submit_capped`, `done/full-autonomous-development.md`). Slice 0
+  step 1 **verifies** `submitter == principal` at submit and adds a `submitter`
+  accessor on `db1_work_item_t` if not already surfaced.
+- **Event cursor**: `db1_lifecycle_event_t.id` is a `long` (`wfe_store.h:35`) —
+  monotonic per-item; use it for `after`/`next_after` pagination.
+- **Cap model — R-Q1 RESOLVED → Option B** (plan roundtable: the per-request caps
+  accessor's cross-request-bleed surface isn't worth it for v1). Caps are enforced
+  statically per route *before* the handler; `route_req_t` carries no caps and the
+  identity layer exposes no caps accessor — and we add **no new one**. Instead:
+  - **Per-item reads** (`/events`, `/proposal`, single-item GET) are **owner-only**:
+    route cap `CAP_DASHBOARD_READ`, handler enforces `wf_owns` (`strcmp(principal,
+    wi->submitter)==0`, both non-empty) → 403 otherwise. No admin bypass in v1.
+  - **Global list** is a **separate route** `GET /v1/workflow/items/all` with static
+    cap `CAP_WORKFLOW_ADMIN`; the default `GET /v1/workflow/items` is owner-scoped.
+  This adds zero core-security surface (no thread-local caps snapshot → no
+  privilege-bleed risk). Cost: an admin can't web-read a *non-owned* item's
+  events/proposal in v1 (CLI/DB, or a later Option-A follow-up if multi-operator
+  admin review is needed). For a single-operator deployment (owner == the gate
+  admin) this is a non-issue.
+- **Only consumer of `/v1/workflow/items`** is the webchat Workflows page
+  (`webchat/workflow.go:86`); no dashboard reads it — so re-scoping it to the caller
+  is regression-safe.
+
+---
+
+## Slice 0 — backend read surfaces (no UI)
+
+**Files:** `src/server/server_workflow_api.c` (handlers), `src/server/server.h`
+(decls), `src/server/server_http_routes.inc` (routes), `src/db1/wfe_store.h`
+(confirm `submitter` on `db1_work_item_t`), `webchat/workflow.go` + `webchat/api.go`
+(proxies + methodRoutes), `api/openapi-server-v1.yaml`, `src/cli_v1_routes_gen.inc`
+(regen), `src/tests/test_server_http.c` (+ a focused wf-api test). **No core identity
+change** (Option B).
+
+**Steps:**
+1. **Ownership helper** — static `wf_owns(const db1_work_item_t *wi)` in
+   server_workflow_api.c: `wi->submitter[0] && server_http_identity_principal()[0] &&
+   strcmp(principal, wi->submitter) == 0` (**string** compare; NULL/empty submitter →
+   NOT owned → owner-only reads refuse it, fail-closed). Confirm the submit path sets
+   `submitter = principal`; if `db1_work_item_t` lacks a `submitter` field, add the
+   accessor (read-only, no schema change).
+2. **Enrich `item_to_json`** (`:398`) — add cheap DB columns only:
+   `proposal_name` (basename of `proposal_path`; omitted when empty), `pr_ref`,
+   `cum_cost_usd`, `work_item_max_cost_usd`, `override_count`, `submitter`,
+   `created_at`, `updated_at`. Additive keys; existing keys unchanged.
+3. **List scoping** — `wf_api_items` filters to `wf_owns()` rows (owner-scoped). A
+   **separate** `wf_api_items_all` backs `GET /v1/workflow/items/all`
+   (cap `CAP_WORKFLOW_ADMIN`) returning all rows. No query param needed.
+4. **Timeline** — new `wf_api_events(id, after, limit, resp, cap)`:
+   `db1_work_item_get` → `wf_owns` (403 else) → `db1_lifecycle_event_list` →
+   keep events with `id > after`, take the first `min(limit,200)` (default 200) →
+   `{events:[{id,stage,kind,actor,detail,cost_usd,created_at}], next_after}` where
+   **`next_after` = the `id` of the LAST event actually returned** (post-limit), else
+   echoes `after` when none. Correctness: `lifecycle_event.id` is monotonic and, per
+   the scheduler (concurrency 1, `wfe_scheduler.c`), a work item has a **single
+   writer** — so `id > after` with `next_after`=last-returned neither skips nor
+   duplicates across polls even while new events append. (In-handler windowing over
+   the returned list; DB-side `WHERE id > ? LIMIT ?` is a later optimization — per-item
+   event counts are bounded.)
+5. **Proposal read-back** — new `wf_api_proposal(id, resp, cap)`:
+   `db1_work_item_get` → `wf_owns` (403). Then read the file **race-free via a
+   dirfd**, exploiting that `proposal_path` is a *flat* file in one fixed dir:
+   - take `base = basename(proposal_path)`; reject if it contains `/`, is empty, `.`,
+     or `..` (must be a simple filename);
+   - `dirfd = open("$AIMEE_HOME/workflows/proposals", O_DIRECTORY|O_RDONLY|O_CLOEXEC)`
+     (the dir is a fixed trusted constant — its own confinement);
+   - `fd = openat(dirfd, base, O_RDONLY|O_NOFOLLOW|O_CLOEXEC)` — `O_NOFOLLOW` guards
+     the only (final) component; there are **no mid-path components**, so no mid-path
+     symlink/TOCTOU exists;
+   - `fstat(fd)`: require a **regular file**; read up to 1 MB → `{proposal_md,
+     truncated}` with `truncated=true` iff the file exceeds the cap (**truncated, not
+     rejected**, so a huge file still renders with a banner). Missing file → 404;
+     non-regular / symlinked / bad basename → 403.
+6. **Routes** (`server_http_routes.inc`, RM_PREFIX for `<id>`): `GET
+   /v1/workflow/items/<id>/events`, `GET /v1/workflow/items/<id>/proposal` (cap
+   `CAP_DASHBOARD_READ`, ownership in-handler — comment this clearly for maintainers),
+   and `GET /v1/workflow/items/all` (cap `CAP_WORKFLOW_ADMIN`). Add `rh_wf_events` /
+   `rh_wf_proposal` / `rh_wf_items_all` wrappers extracting `rq->id` + query
+   (`after`, `limit`). Note: the `/all` route must be registered so it doesn't collide
+   with the `<id>` prefix matcher (exact match before prefix, or a distinct segment).
+7. **Go proxies** — `GET /api/workflow/items/<id>/events`, `/proposal`, and
+   `/api/workflow/items/all` in `webchat/workflow.go` (extend `handleWorkflowItems`
+   path parsing), + methodRoutes entries; pass the query string through.
+8. **Conformance** — regen `cli_v1_routes_gen.inc`; document all three routes
+   (incl. `/items/all` and the **owner-scoping semantic change** of `/items`) in
+   `openapi-server-v1.yaml`; run dispatch-caps / v1-method-coverage / cli-v1-routes /
+   server-api-conformance / docs-gen / schema-sync / line-check.
+9. **Tests** — wf-api unit test: enriched-fields snapshot; **events pagination
+   boundary** (limit truncates a larger set → `next_after` = last *returned* id →
+   next page with `after=next_after` continues with no gap/dup); proposal read-back
+   happy path + basename-with-`/` reject + symlinked-file reject (create a symlink in a
+   temp proposals dir) + non-regular reject + oversize → `truncated`; ownership (owner
+   200, non-owner 403, NULL-submitter 403); `/items/all` requires admin cap. Keep
+   `test_server_http` + `test_server_dispatch` green (stubs for any new dispatch
+   methods).
+
+**Verify:** builds (`-Werror`), Go build/vet/fmt, all conformance + unit tests. curl
+against a local/pve server: submit a proposal, GET its events + proposal, confirm a
+second principal gets 403 and the `/all` route needs admin.
+
+---
+
+## Slice 1 — Proposals list + status/history page; de-scope Workflows
+
+**Files:** new `frontend/src/pages/Proposals.tsx`; `frontend/src/App.tsx`
+(nav + route `/proposals`); `frontend/src/pages/Workflows.tsx` (remove Runs +
+Run-state + gate).
+
+**Proposals.tsx:**
+- List: `GET /api/workflow/items` (own scope) → rows (workflow, short id, stage,
+  lifecycle badge from `state`+`pause_reason`+`current_stage`, cost, updated-at).
+  Admin "show all" calls the `/api/workflow/items/all` route (admin-capped).
+- Detail: status header (stage, badge, cost vs cap, `pr_ref` link, timestamps, H1
+  title parsed client-side from the `/proposal` markdown); **timeline** from
+  `/events` (fetch tail, then poll `after=<last id>` every ~4 s while `state==active`,
+  stop at terminal, append-only); rendered proposal markdown (with a "truncated"
+  banner when `/proposal` returns `truncated:true`); Approve/Reject shown only for
+  `pause_reason==pending_human` (posts to the existing gate route). No client caps
+  introspection (Option B): if the server refuses with 403 (caller lacks
+  `CAP_WORKFLOW_ADMIN`), the UI surfaces that message rather than pre-disabling.
+- Reuse the Delegates/Workflows inline-style + `Panel`/`Badge`/`Spinner` idiom.
+
+**Workflows.tsx removals (§5):** delete the "Runs" `Panel`, the "Run state" inspector
+`Panel`, and the `runItem`/`decideGate`/`activeStage` state + handlers. Leave defs
+list, blocks palette, canvas, node inspector, personas, validate/save intact.
+
+**Verify:** `tsc -b && vite build`; Workflows still builds/renders as a pure def
+editor; **pve e2e** (see below).
+
+---
+
+## Slice 2 — Author from scratch; remove Submit-proposal from Workflows
+
+- Proposals.tsx composer: title + scaffolded markdown textarea + workflow picker
+  (default `build`) + optional repo; localStorage draft keyed by principal, cleared
+  on logout, size-capped, device-local caveat. Submit → `/api/dev/submit` → switch to
+  the new item's detail view.
+- Remove the "Submit proposal" `Panel` + `proposalMd`/`submitProposal` from
+  Workflows.tsx.
+- **Verify:** `tsc`+build; pve: author a proposal end-to-end, watch it run.
+
+## Slice 3 — Delegate-assisted drafting (optional)
+
+"Draft/refine with a delegate" action → a delegate call returning markdown into the
+editor. Trigger + endpoint chosen at that slice's plan; ships independently.
+
+---
+
+## pve test approach (Slices 1–2)
+
+Use the `.254` aimee-server (already running, TLS `:8743`) OR a throwaway CT if a
+clean DB is wanted. Flow: `./aimee` (or curl the webchat) to submit a trivial proposal
+against a test repo with `wfe_live_forge_enabled` **off** (so it parks at gates
+without pushing), observe the item advance/park via `/events`, decide a gate via the
+UI, confirm the timeline extends incrementally and the badge tracks state. Roundtable
+each slice's code (diff in the prompt) before its PR; merge after approval.
+
+## Resolved questions (plan roundtable)
+
+- **R-Q1 → Option B.** Owner-only per-item reads + a separate admin `/items/all`
+  route; **no** new per-request caps accessor (avoids the cross-request privilege-bleed
+  surface the panel flagged). Owner-or-admin per-item reads deferred to a future
+  Option-A follow-up if multi-operator admin review is needed.
+- **R-Q2 → re-scope `/items` to the caller.** Safe: the only consumer is the migrating
+  Workflows page; the semantic change is documented in the OpenAPI spec, and the admin
+  global view moves to `/items/all`.
+- **R-Q3 → in-handler windowing for v1.** Acceptable given single-writer-per-item +
+  bounded event counts; `next_after` = last *returned* id makes it correct. DB-side
+  `WHERE id > ? LIMIT ?` is a noted later optimization.
+
+## Plan review revisions (R1 — plan roundtable)
+
+7 panelists, 3 survivors. Applied:
+- **§1c path confinement → dirfd + `openat(O_NOFOLLOW)`** (Step 5): eliminates the
+  mid-path symlink/TOCTOU the panel flagged in `realpath`+prefix — `proposal_path` is a
+  flat file in one fixed dir, so `openat(dirfd, basename, O_NOFOLLOW)` with a basename
+  sanity check is race-free.
+- **Cap model → Option B** (Resolved seams; Steps 1/3/6): removes the new caps
+  thread-local and its privilege-bleed risk; owner-only reads + admin `/items/all`.
+- **Pagination contract tightened** (Step 4): `next_after` = last *returned* id;
+  documented single-writer + monotonic id ⇒ no skip/dup; added a boundary test.
+- **`wf_owns`**: `strcmp` (not pointer eq) + NULL/empty-submitter fail-closed
+  (Steps 1); `proposal_name` omitted when empty (Step 2).
+- **1 MB cap → truncate + flag, not reject** (Step 5) + a UI "truncated" banner
+  (Slice 1).
+- **OpenAPI** documents `/items/all` and the `/items` owner-scoping change (Step 8);
+  route-collision note for `/all` vs the `<id>` prefix matcher (Step 6).
+Triaged as acknowledged/deferred: in-handler windowing scale (bounded for v1; DB-side
+later); "Slice 1 is a major structural change" (intended — sequenced to avoid a gap).

--- a/src/headers/server_http_identity.h
+++ b/src/headers/server_http_identity.h
@@ -46,6 +46,13 @@ void server_http_identity_capture(int fd, int is_tcp, const char *buf);
  * capture and clear, i.e. during a route handler on the serving thread. */
 const char *server_http_identity_principal(void);
 
+/* The in-flight request's query string ("k=v&…", no '?'), or "" if none. Set by
+ * server_http_identity_set_query around the route call, cleared by _clear. Valid
+ * only during a route handler on the serving thread; points into the request
+ * buffer. Used by buffered handlers that read query params (e.g. events cursor). */
+void server_http_identity_set_query(const char *q);
+const char *server_http_identity_query(void);
+
 /* Copy the captured identity onto a (synthesized) connection — loopback_rpc's
  * hop 2. Safe to call with no prior capture: writes the un-attested defaults. */
 void server_http_identity_apply(server_conn_t *conn);

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1738,6 +1738,7 @@ static void handle_conn(int fd, int is_tcp)
     * loopback_rpc copies it into the synthesized conn. Cleared after the route so
     * a reused worker thread cannot leak it into the next request. */
    server_http_identity_capture(fd, is_tcp, buf);
+   server_http_identity_set_query(query); /* cleared by server_http_identity_clear */
    int status = server_http_route(method, path, body, body_len, resp, SHTTP_RESP_MAX);
    g_rpc_conn_caps = CAPS_READ_ONLY;
    server_http_identity_clear();

--- a/src/server/server_http_identity.c
+++ b/src/server/server_http_identity.c
@@ -26,6 +26,10 @@
 static _Thread_local long tl_peer_uid = -1;
 static _Thread_local attested_transport_t tl_transport = ATTEST_NONE;
 static _Thread_local char tl_principal[VAULT_PRINCIPAL_MAX] = "";
+/* Query string of the in-flight request ("k=v&…", no '?'); set around the route
+ * call, cleared with the rest. Points into the request buffer — read only within
+ * the handler. */
+static _Thread_local const char *tl_query = "";
 
 /* The shared secret that authenticates a webchat `webuser:` assertion is the
  * server.token file (0600, in AIMEE_HOME — the secret only the webchat backend
@@ -127,6 +131,17 @@ void server_http_identity_clear(void)
    tl_peer_uid = -1;
    tl_transport = ATTEST_NONE;
    tl_principal[0] = '\0';
+   tl_query = "";
+}
+
+void server_http_identity_set_query(const char *q)
+{
+   tl_query = q ? q : "";
+}
+
+const char *server_http_identity_query(void)
+{
+   return tl_query ? tl_query : "";
 }
 
 void http_error_json(char *resp, size_t cap, const char *msg)

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -767,9 +767,47 @@ static int rh_wf_items(const route_req_t *rq, char *resp, int cap)
    (void)rq;
    return wf_api_items(resp, cap);
 }
+static int rh_wf_items_all(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   return wf_api_items_all(resp, cap);
+}
 static int rh_wf_item(const route_req_t *rq, char *resp, int cap)
 {
    return wf_api_item(rq->id, resp, cap);
+}
+/* Parse an unsigned long query param ("k=v&…") from the request's query string;
+ * returns `dflt` when the key is absent or unparseable. */
+static long rh_query_long(const char *key, long dflt)
+{
+   const char *q = server_http_identity_query();
+   size_t klen = strlen(key);
+   for (const char *p = q; p && *p;)
+   {
+      const char *amp = strchr(p, '&');
+      if (strncmp(p, key, klen) == 0 && p[klen] == '=')
+      {
+         char *end = NULL;
+         long v = strtol(p + klen + 1, &end, 10);
+         if (end != p + klen + 1)
+            return v;
+         return dflt;
+      }
+      if (!amp)
+         break;
+      p = amp + 1;
+   }
+   return dflt;
+}
+static int rh_wf_events(const route_req_t *rq, char *resp, int cap)
+{
+   long after = rh_query_long("after", 0);
+   int limit = (int)rh_query_long("limit", 200);
+   return wf_api_events(rq->id, after, limit, resp, cap);
+}
+static int rh_wf_proposal(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_proposal(rq->id, resp, cap);
 }
 
 /* The POST /v1/rpc bridge was retired once every dispatch method gained a
@@ -2188,9 +2226,16 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/workflow/validate", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_validate},
     {"POST", "/v1/workflow/save", NULL, RM_EXACT, NULL, CAP_SESSION_ADMIN, rh_wf_save},
     {"GET", "/v1/workflow/items", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_items},
+    /* Operator view of ALL items (not submitter-scoped) — exact row precedes the
+     * /<id> prefix row so "all" isn't parsed as a work-item id. */
+    {"GET", "/v1/workflow/items/all", NULL, RM_EXACT, NULL, CAP_WORKFLOW_ADMIN, rh_wf_items_all},
     /* Operator-only: approve/reject the human gate a run is parked at. The
-     * suffix row precedes the bare /<id> row. */
+     * suffix rows precede the bare /<id> row. */
     {"POST", "/v1/workflow/items/", "/gate", RM_PREFIX, NULL, CAP_WORKFLOW_ADMIN, rh_workflow_gate},
+    /* Proposal read surfaces (ownership enforced in-handler, not by the route cap):
+     * the timeline and the source markdown, owner-scoped in wf_api_*. */
+    {"GET", "/v1/workflow/items/", "/events", RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_events},
+    {"GET", "/v1/workflow/items/", "/proposal", RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_proposal},
     {"GET", "/v1/workflow/items/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item},
 
     {"GET", "/v1/sessions", NULL, RM_EXACT, NULL, CAP_SESSION_READ, rh_sessions_list},

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -413,8 +413,7 @@ static const char *path_basename(const char *p)
 static int wf_owns(const db1_work_item_t *wi)
 {
    const char *principal = server_http_identity_principal();
-   return wi->submitter[0] && principal && principal[0] &&
-          strcmp(principal, wi->submitter) == 0;
+   return wi->submitter[0] && principal && principal[0] && strcmp(principal, wi->submitter) == 0;
 }
 
 /* shared: serialize one work-item row. The base keys (id..repo) are unchanged so

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -12,10 +12,14 @@
 
 #ifndef _WIN32
 #include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
 #endif
 
 #include "aimee_home.h"
 #include "cJSON.h"
+#include "server_http_identity.h" /* server_http_identity_principal — ownership scoping */
 #include "wfe_def.h"
 #include "wfe_iface.h"
 #include "wfe_store.h"
@@ -395,7 +399,26 @@ int wf_api_save(const char *body, char *resp, int cap)
    return emit(o, resp, cap);
 }
 
-/* shared: serialize one work-item row */
+/* The basename of a path (last '/'-segment), or the whole string if none. Used
+ * to expose proposal_name without leaking the server FS path. */
+static const char *path_basename(const char *p)
+{
+   const char *slash = p ? strrchr(p, '/') : NULL;
+   return slash ? slash + 1 : (p ? p : "");
+}
+
+/* Ownership: true iff the item's submitter equals the calling principal (string
+ * compare; both must be non-empty). A NULL/empty submitter (CLI/legacy/system
+ * rows) is owned by nobody, so owner-only reads refuse it — fail-closed. */
+static int wf_owns(const db1_work_item_t *wi)
+{
+   const char *principal = server_http_identity_principal();
+   return wi->submitter[0] && principal && principal[0] &&
+          strcmp(principal, wi->submitter) == 0;
+}
+
+/* shared: serialize one work-item row. The base keys (id..repo) are unchanged so
+ * existing consumers keep working; the rest are additive Proposals-page fields. */
 static cJSON *item_to_json(const db1_work_item_t *wi)
 {
    cJSON *o = cJSON_CreateObject();
@@ -407,19 +430,41 @@ static cJSON *item_to_json(const db1_work_item_t *wi)
    cJSON_AddStringToObject(o, "mode", wi->mode);
    cJSON_AddStringToObject(o, "pause_reason", wi->pause_reason);
    cJSON_AddStringToObject(o, "repo", wi->repo);
+   /* additive: Proposals status fields (cheap DB columns only — no file IO). */
+   if (wi->proposal_path[0])
+      cJSON_AddStringToObject(o, "proposal_name", path_basename(wi->proposal_path));
+   cJSON_AddStringToObject(o, "pr_ref", wi->pr_ref);
+   cJSON_AddStringToObject(o, "submitter", wi->submitter);
+   cJSON_AddNumberToObject(o, "cum_cost_usd", wi->cum_cost_usd);
+   cJSON_AddNumberToObject(o, "work_item_max_cost_usd", wi->work_item_max_cost_usd);
+   cJSON_AddNumberToObject(o, "override_count", wi->override_count);
    return o;
 }
 
-int wf_api_items(char *resp, int cap)
+/* Shared list builder: emit every row for which `keep` returns true. */
+static int wf_items_filtered(char *resp, int cap, int (*keep)(const db1_work_item_t *))
 {
    cJSON *o = cJSON_CreateObject();
    cJSON *arr = cJSON_AddArrayToObject(o, "items");
    db1_work_item_t *rows = NULL;
    int n = db1_work_item_list(&rows);
    for (int i = 0; i < n; i++)
-      cJSON_AddItemToArray(arr, item_to_json(&rows[i]));
+      if (!keep || keep(&rows[i]))
+         cJSON_AddItemToArray(arr, item_to_json(&rows[i]));
    free(rows);
    return emit(o, resp, cap);
+}
+
+int wf_api_items(char *resp, int cap)
+{
+   /* Owner-scoped: only the caller's own proposals (closes the list IDOR). */
+   return wf_items_filtered(resp, cap, wf_owns);
+}
+
+int wf_api_items_all(char *resp, int cap)
+{
+   /* Unscoped operator view; route-gated by CAP_WORKFLOW_ADMIN. */
+   return wf_items_filtered(resp, cap, NULL);
 }
 
 int wf_api_item(const char *id, char *resp, int cap)
@@ -429,5 +474,119 @@ int wf_api_item(const char *id, char *resp, int cap)
    db1_work_item_t wi;
    if (db1_work_item_get(id, &wi) != 1)
       return err(resp, cap, 404, "work item not found");
+   if (!wf_owns(&wi))
+      return err(resp, cap, 403, "not your work item");
    return emit(item_to_json(&wi), resp, cap);
+}
+
+int wf_api_events(const char *id, long after, int limit, char *resp, int cap)
+{
+   if (!id || !id[0])
+      return err(resp, cap, 400, "missing work item id");
+   db1_work_item_t wi;
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 404, "work item not found");
+   if (!wf_owns(&wi))
+      return err(resp, cap, 403, "not your work item");
+   if (limit <= 0 || limit > 200)
+      limit = 200;
+
+   db1_lifecycle_event_t *evs = NULL;
+   int n = db1_lifecycle_event_list(id, &evs);
+   if (n < 0)
+      return err(resp, cap, 500, "could not read events");
+
+   cJSON *o = cJSON_CreateObject();
+   cJSON *arr = cJSON_AddArrayToObject(o, "events");
+   /* Events are id-ascending; take the first `limit` with id>after. next_after is
+    * the id of the LAST event actually returned (so the next poll continues from
+    * there, never re-reading or skipping — the item has a single writer). */
+   long next_after = after;
+   int emitted = 0;
+   for (int i = 0; i < n && emitted < limit; i++)
+   {
+      if (evs[i].id <= after)
+         continue;
+      cJSON *e = cJSON_CreateObject();
+      cJSON_AddNumberToObject(e, "id", (double)evs[i].id);
+      cJSON_AddStringToObject(e, "stage", evs[i].stage);
+      cJSON_AddStringToObject(e, "kind", evs[i].kind);
+      cJSON_AddStringToObject(e, "actor", evs[i].actor);
+      cJSON_AddStringToObject(e, "detail", evs[i].detail);
+      cJSON_AddNumberToObject(e, "cost_usd", evs[i].cost_usd);
+      cJSON_AddStringToObject(e, "created_at", evs[i].created_at);
+      cJSON_AddItemToArray(arr, e);
+      next_after = evs[i].id;
+      emitted++;
+   }
+   free(evs);
+   cJSON_AddNumberToObject(o, "next_after", (double)next_after);
+   return emit(o, resp, cap);
+}
+
+/* Max proposal markdown served back (submit caps the body at 1 MB; we enforce the
+ * same and flag `truncated` rather than reject, so an oversized file still renders. */
+#define WF_PROPOSAL_MAX (1 * 1024 * 1024)
+
+int wf_api_proposal(const char *id, char *resp, int cap)
+{
+   if (!id || !id[0])
+      return err(resp, cap, 400, "missing work item id");
+   db1_work_item_t wi;
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 404, "work item not found");
+   if (!wf_owns(&wi))
+      return err(resp, cap, 403, "not your work item");
+   if (!wi.proposal_path[0])
+      return err(resp, cap, 404, "no proposal file");
+
+   /* proposal_path is a server-minted flat file in $AIMEE_HOME/workflows/proposals.
+    * Confine race-free: open the fixed dir, then openat the BASENAME with O_NOFOLLOW.
+    * A basename with any '/' (or . / ..) is rejected — there are no mid-path
+    * components to race, so this is TOCTOU/symlink safe. */
+   const char *base = path_basename(wi.proposal_path);
+   if (!base[0] || strchr(base, '/') || strcmp(base, ".") == 0 || strcmp(base, "..") == 0)
+      return err(resp, cap, 403, "unsafe proposal path");
+
+   const char *home = aimee_home();
+   char dir[1024];
+   snprintf(dir, sizeof dir, "%s/workflows/proposals", home ? home : "/tmp");
+   int dfd = open(dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+   if (dfd < 0)
+      return err(resp, cap, 404, "proposals dir unavailable");
+   int fd = openat(dfd, base, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+   int oerr = errno;
+   close(dfd);
+   if (fd < 0)
+      /* O_NOFOLLOW makes a symlinked entry fail ELOOP — refuse it as forbidden
+       * (never followed) rather than reporting a plain not-found. */
+      return err(resp, cap, oerr == ELOOP ? 403 : 404,
+                 oerr == ELOOP ? "proposal not a regular file" : "proposal file not found");
+
+   struct stat stt;
+   if (fstat(fd, &stt) != 0 || !S_ISREG(stt.st_mode))
+   {
+      close(fd);
+      return err(resp, cap, 403, "proposal not a regular file");
+   }
+
+   char *buf = malloc(WF_PROPOSAL_MAX + 1);
+   if (!buf)
+   {
+      close(fd);
+      return err(resp, cap, 500, "out of memory");
+   }
+   size_t total = 0;
+   ssize_t r;
+   while (total < WF_PROPOSAL_MAX && (r = read(fd, buf + total, WF_PROPOSAL_MAX - total)) > 0)
+      total += (size_t)r;
+   close(fd);
+   buf[total] = '\0';
+   int truncated = (off_t)total < stt.st_size;
+
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "proposal_md", buf);
+   cJSON_AddBoolToObject(o, "truncated", truncated);
+   free(buf);
+   return emit(o, resp, cap);
 }

--- a/src/server/server_workflow_api.h
+++ b/src/server/server_workflow_api.h
@@ -27,11 +27,31 @@ int wf_api_validate(const char *body, char *resp, int cap);
  * an empty prev_version and a non-existent file). 400 on invalid def/name. */
 int wf_api_save(const char *body, char *resp, int cap);
 
-/* GET /v1/workflow/items -- list work items (run-state rows). */
+/* GET /v1/workflow/items -- list work items OWNED BY the calling principal
+ * (run-state rows). Ownership = item.submitter == server_http_identity_principal().
+ * The Proposals page's default list. */
 int wf_api_items(char *resp, int cap);
 
-/* GET /v1/workflow/items/{id} -- one work item's run-state (workflow, pinned
- * version, current stage, state, pause reason). 404 if unknown. */
+/* GET /v1/workflow/items/all -- list ALL work items regardless of submitter.
+ * Route-gated by CAP_WORKFLOW_ADMIN (operator view). */
+int wf_api_items_all(char *resp, int cap);
+
+/* GET /v1/workflow/items/{id} -- one work item's run-state. Owner-only: 403 if
+ * the item's submitter is not the calling principal. 404 if unknown. */
 int wf_api_item(const char *id, char *resp, int cap);
+
+/* GET /v1/workflow/items/{id}/events?after=<id>&limit=<n> -- the append-only
+ * lifecycle timeline (proposal history), oldest-first, paginated by event id.
+ * Owner-only (403). Returns {events:[{id,stage,kind,actor,detail,cost_usd,
+ * created_at}], next_after}. `after` (default 0) returns events with id>after;
+ * `limit` is clamped to [1,200] (default 200); `next_after` is the id of the last
+ * event returned (echoes `after` when the page is empty). */
+int wf_api_events(const char *id, long after, int limit, char *resp, int cap);
+
+/* GET /v1/workflow/items/{id}/proposal -- the source proposal markdown the run is
+ * executing. Owner-only (403). Reads the item's server-minted proposal_path,
+ * confined to $AIMEE_HOME/workflows/proposals via a dirfd + openat(O_NOFOLLOW).
+ * Returns {proposal_md, truncated}; 404 if the file is missing. */
+int wf_api_proposal(const char *id, char *resp, int cap);
 
 #endif /* DEC_SERVER_WORKFLOW_API_H */

--- a/src/tests/support/workflow_api_stub.c
+++ b/src/tests/support/workflow_api_stub.c
@@ -40,7 +40,23 @@ int wf_api_items(char *resp, int cap)
 {
    return stub(resp, cap);
 }
+int wf_api_items_all(char *resp, int cap)
+{
+   return stub(resp, cap);
+}
 int wf_api_item(const char *id, char *resp, int cap)
+{
+   (void)id;
+   return stub(resp, cap);
+}
+int wf_api_events(const char *id, long after, int limit, char *resp, int cap)
+{
+   (void)id;
+   (void)after;
+   (void)limit;
+   return stub(resp, cap);
+}
+int wf_api_proposal(const char *id, char *resp, int cap)
 {
    (void)id;
    return stub(resp, cap);

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -722,7 +722,8 @@ int main(void)
        * /all exact row must win over the /<id> prefix row (else "all" is parsed as a
        * work-item id under CAP_DASHBOARD_READ). */
       assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x/events") == CAP_DASHBOARD_READ);
-      assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x/proposal") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x/proposal") ==
+             CAP_DASHBOARD_READ);
       assert(server_http_route_caps("GET", "/v1/workflow/items/all") == CAP_WORKFLOW_ADMIN);
       assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x") == CAP_DASHBOARD_READ);
       /* Presence is session-scoped; the streaming routes carry caps too. */

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -716,6 +716,15 @@ int main(void)
       assert(server_http_route_caps("POST", "/v1/personas") == CAP_SESSION_ADMIN);
       assert(server_http_route_caps("GET", "/v1/role_templates") == CAP_SESSION_READ);
       assert(server_http_route_caps("DELETE", "/v1/role_templates/qa") == CAP_SESSION_ADMIN);
+      /* Proposals read surfaces: the timeline + proposal-markdown reads share the
+       * dashboard-read cap (ownership is enforced in-handler, not by the route cap),
+       * while the operator "list all items" view requires CAP_WORKFLOW_ADMIN. The
+       * /all exact row must win over the /<id> prefix row (else "all" is parsed as a
+       * work-item id under CAP_DASHBOARD_READ). */
+      assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x/events") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x/proposal") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("GET", "/v1/workflow/items/all") == CAP_WORKFLOW_ADMIN);
+      assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x") == CAP_DASHBOARD_READ);
       /* Presence is session-scoped; the streaming routes carry caps too. */
       assert(server_http_route_caps("GET", "/v1/sessions") == CAP_SESSION_READ);
       assert(server_http_route_caps("POST", "/v1/sessions/s1/attach") == CAP_SESSION_READ);

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -321,7 +321,8 @@ int main(void)
       fclose(pf);
       assert(wf_api_proposal("wi_owned", buf, CAP) == 200);
       cJSON *o = parse_resp(buf);
-      assert(strstr(cJSON_GetObjectItemCaseSensitive(o, "proposal_md")->valuestring, "My proposal"));
+      assert(
+          strstr(cJSON_GetObjectItemCaseSensitive(o, "proposal_md")->valuestring, "My proposal"));
       assert(cJSON_IsFalse(cJSON_GetObjectItemCaseSensitive(o, "truncated")));
       cJSON_Delete(o);
 
@@ -330,7 +331,8 @@ int main(void)
       /* Events pagination: add three more events (id-ascending), page by 2. */
       (void)db1_lifecycle_event_add("wi_owned", "draft", "advance", "engine", "", "", 0.0);
       (void)db1_lifecycle_event_add("wi_owned", "impl", "advance", "engine", "", "", 0.0);
-      (void)db1_lifecycle_event_add("wi_owned", "impl", "pause", "engine", "pending_human", "", 0.0);
+      (void)db1_lifecycle_event_add("wi_owned", "impl", "pause", "engine", "pending_human", "",
+                                    0.0);
       assert(wf_api_events("wi_owned", 0, 2, buf, CAP) == 200);
       o = parse_resp(buf);
       cJSON *evs = cJSON_GetObjectItemCaseSensitive(o, "events");

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -8,11 +8,22 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include "cJSON.h"
 #include "db1.h"
 #include "server/server_workflow_api.h"
 #include "wfe_def.h"
+#include "wfe_store.h"
+
+/* Stub the one identity accessor server_workflow_api references (rather than link
+ * the full attestation stack). Test-controlled so we can drive both the non-owner
+ * (deny) and owner (allow) paths of the ownership check. */
+static const char *g_test_principal = "";
+const char *server_http_identity_principal(void)
+{
+   return g_test_principal;
+}
 
 #define CAP (64 * 1024)
 
@@ -60,6 +71,9 @@ int main(void)
    char wfdir[128];
    snprintf(wfdir, sizeof wfdir, "%s/workflows", home);
    mkdir(wfdir, 0755);
+   char pdir[160];
+   snprintf(pdir, sizeof pdir, "%s/workflows/proposals", home);
+   mkdir(pdir, 0755);
    setenv("AIMEE_HOME", home, 1);
    assert(db1_init(":memory:") == 0);
 
@@ -254,6 +268,104 @@ int main(void)
       cJSON_Delete(o);
    }
    assert(wf_api_item("no-such-item", buf, CAP) == 404);
+   assert(wf_api_events("no-such-item", 0, 200, buf, CAP) == 404);
+   assert(wf_api_proposal("no-such-item", buf, CAP) == 404);
+
+   /* --- ownership: a work item submitted by another principal is not readable ---
+    * The test runs with an un-attested (empty) principal, so an item whose submitter
+    * is set is owned by nobody-in-this-context: the per-item reads must 403 (the
+    * IDOR closure). The owner-allowed path + pagination + proposal read-back are
+    * exercised live (a request carrying the matching webuser principal). */
+   {
+      assert(db1_work_item_create("wi_owned", "", "wi_owned.md", "build", "v1", "draft",
+                                  "autonomous") == 0);
+      assert(db1_work_item_set_submitter("wi_owned", "webuser:someone-else") == 0);
+      (void)db1_lifecycle_event_add("wi_owned", "draft", "create", "user", "", "", 0.0);
+
+      assert(wf_api_item("wi_owned", buf, CAP) == 403);
+      assert(wf_api_events("wi_owned", 0, 200, buf, CAP) == 403);
+      assert(wf_api_proposal("wi_owned", buf, CAP) == 403);
+
+      /* The owner-scoped list must not leak the non-owned item... */
+      assert(wf_api_items(buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      cJSON *items = cJSON_GetObjectItemCaseSensitive(o, "items");
+      assert(cJSON_IsArray(items) && cJSON_GetArraySize(items) == 0);
+      cJSON_Delete(o);
+
+      /* ...but the operator "all" view returns it, enriched with the new fields. */
+      assert(wf_api_items_all(buf, CAP) == 200);
+      o = parse_resp(buf);
+      items = cJSON_GetObjectItemCaseSensitive(o, "items");
+      assert(cJSON_IsArray(items) && cJSON_GetArraySize(items) == 1);
+      cJSON *it = cJSON_GetArrayItem(items, 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(it, "submitter")->valuestring,
+                    "webuser:someone-else") == 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(it, "proposal_name")->valuestring,
+                    "wi_owned.md") == 0);
+      assert(cJSON_HasObjectItem(it, "cum_cost_usd") && cJSON_HasObjectItem(it, "pr_ref"));
+      cJSON_Delete(o);
+   }
+
+   /* --- owner-allowed path: events pagination + proposal read-back + symlink guard.
+    * Drive the stub principal to match the item's submitter so wf_owns permits. --- */
+   {
+      g_test_principal = "webuser:someone-else";
+
+      /* Proposal read-back: write the source file the item references. */
+      char pfile[256];
+      snprintf(pfile, sizeof pfile, "%s/wi_owned.md", pdir);
+      FILE *pf = fopen(pfile, "wb");
+      assert(pf);
+      fputs("# My proposal\n\nbody\n", pf);
+      fclose(pf);
+      assert(wf_api_proposal("wi_owned", buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      assert(strstr(cJSON_GetObjectItemCaseSensitive(o, "proposal_md")->valuestring, "My proposal"));
+      assert(cJSON_IsFalse(cJSON_GetObjectItemCaseSensitive(o, "truncated")));
+      cJSON_Delete(o);
+
+      assert(wf_api_item("wi_owned", buf, CAP) == 200); /* owner sees it now */
+
+      /* Events pagination: add three more events (id-ascending), page by 2. */
+      (void)db1_lifecycle_event_add("wi_owned", "draft", "advance", "engine", "", "", 0.0);
+      (void)db1_lifecycle_event_add("wi_owned", "impl", "advance", "engine", "", "", 0.0);
+      (void)db1_lifecycle_event_add("wi_owned", "impl", "pause", "engine", "pending_human", "", 0.0);
+      assert(wf_api_events("wi_owned", 0, 2, buf, CAP) == 200);
+      o = parse_resp(buf);
+      cJSON *evs = cJSON_GetObjectItemCaseSensitive(o, "events");
+      assert(cJSON_IsArray(evs) && cJSON_GetArraySize(evs) == 2);
+      long next_after = (long)cJSON_GetObjectItemCaseSensitive(o, "next_after")->valuedouble;
+      long last_id =
+          (long)cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(evs, 1), "id")->valuedouble;
+      assert(next_after == last_id); /* cursor = id of the LAST returned event */
+      cJSON_Delete(o);
+      /* Next page continues past the cursor with no gap/dup (4 events total). */
+      assert(wf_api_events("wi_owned", next_after, 200, buf, CAP) == 200);
+      o = parse_resp(buf);
+      evs = cJSON_GetObjectItemCaseSensitive(o, "events");
+      assert(cJSON_GetArraySize(evs) == 2);
+      assert((long)cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(evs, 0), "id")->valuedouble >
+             next_after);
+      cJSON_Delete(o);
+
+      /* Symlink guard: an item whose proposal file is a symlink (even to a readable
+       * file) is refused by openat(O_NOFOLLOW) → 403, never followed. */
+      char secret[256], link[256];
+      snprintf(secret, sizeof secret, "%s/secret.txt", home);
+      FILE *sf = fopen(secret, "wb");
+      assert(sf);
+      fputs("TOP SECRET\n", sf);
+      fclose(sf);
+      snprintf(link, sizeof link, "%s/wi_link.md", pdir);
+      assert(symlink(secret, link) == 0);
+      assert(db1_work_item_create("wi_link", "", "wi_link.md", "build", "v1", "draft",
+                                  "autonomous") == 0);
+      assert(db1_work_item_set_submitter("wi_link", "webuser:someone-else") == 0);
+      assert(wf_api_proposal("wi_link", buf, CAP) == 403); /* symlink not followed */
+
+      g_test_principal = "";
+   }
 
    free(buf);
    printf("ok\n");

--- a/webchat/workflow.go
+++ b/webchat/workflow.go
@@ -80,39 +80,76 @@ func (s *server) handleWorkflowSave(w http.ResponseWriter, r *http.Request) {
 	s.proxyWorkflow(w, r, http.MethodPost, "/v1/workflow/save", "")
 }
 
-// GET /api/workflow/items       — list work items (run-state)
-// GET /api/workflow/items/<id>  — one work item's run-state
+// Work-item run-state surface. Every call goes through v1RequestWebuser so the
+// aimee-server sees the caller's webuser: principal — the item read handlers scope
+// by ownership (submitter == principal), so the wrong identity would 403/empty.
+//
+//	GET  /api/workflow/items              — the caller's own work items
+//	GET  /api/workflow/items/all          — all items (operator view)
+//	GET  /api/workflow/items/<id>         — one item's run-state (owner-only)
+//	GET  /api/workflow/items/<id>/events  — lifecycle timeline (owner-only, ?after&limit)
+//	GET  /api/workflow/items/<id>/proposal— source markdown (owner-only)
+//	POST /api/workflow/items/<id>/gate    — approve/reject a parked human gate
 func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path == "/api/workflow/items" {
-		s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/items", "")
+	// Exact list routes (no <id> segment).
+	if r.URL.Path == "/api/workflow/items" && r.Method == http.MethodGet {
+		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items", nil)
 		return
 	}
-	// POST /api/workflow/items/<id>/gate -> operator approve/reject of a parked
-	// human gate. <id> must be one safe segment.
-	if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/gate") {
-		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/workflow/items/"), "/gate")
-		if id == "" || strings.ContainsAny(id, "/.%") {
-			http.Error(w, `{"error":"bad path"}`, http.StatusBadRequest)
-			return
-		}
+	if r.URL.Path == "/api/workflow/items/all" && r.Method == http.MethodGet {
+		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/all", nil)
+		return
+	}
+
+	// Sub-resource routes: /api/workflow/items/<id>[/events|/proposal|/gate].
+	rest := strings.TrimPrefix(r.URL.Path, "/api/workflow/items/")
+	id, suffix := rest, ""
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		id, suffix = rest[:i], rest[i:]
+	}
+	// <id> must be one safe segment (no separators/traversal/percent-encoding that
+	// could smuggle a '/' past this guard); the server's matcher is authoritative.
+	if id == "" || strings.ContainsAny(id, "/.%") {
+		http.Error(w, `{"error":"bad path"}`, http.StatusBadRequest)
+		return
+	}
+
+	switch {
+	case suffix == "/gate" && r.Method == http.MethodPost:
 		const maxBody = 1 << 20
 		body, _ := io.ReadAll(io.LimitReader(r.Body, maxBody+1))
 		if len(body) > maxBody {
 			http.Error(w, `{"error":"request too large"}`, http.StatusRequestEntityTooLarge)
 			return
 		}
-		ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
-		defer cancel()
-		st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost,
-			"/v1/workflow/items/"+id+"/gate", body)
-		if err != nil {
-			http.Error(w, `{"error":"aimee-server unavailable"}`, http.StatusBadGateway)
-			return
+		s.webuserPass(w, r, http.MethodPost, "/v1/workflow/items/"+id+"/gate", body)
+	case suffix == "/events" && r.Method == http.MethodGet:
+		path := "/v1/workflow/items/" + id + "/events"
+		if r.URL.RawQuery != "" { // forward ?after=&limit= to the paginating handler
+			path += "?" + r.URL.RawQuery
 		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(st)
-		_, _ = w.Write(data)
+		s.webuserPass(w, r, http.MethodGet, path, nil)
+	case suffix == "/proposal" && r.Method == http.MethodGet:
+		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/"+id+"/proposal", nil)
+	case suffix == "" && r.Method == http.MethodGet:
+		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/"+id, nil)
+	default:
+		http.Error(w, `{"error":"bad path"}`, http.StatusBadRequest)
+	}
+}
+
+// webuserPass proxies to an aimee-server /v1 path under the caller's webuser
+// identity (so ownership scoping resolves) and streams the envelope back verbatim.
+func (s *server) webuserPass(w http.ResponseWriter, r *http.Request, method, v1path string, body []byte) {
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), method, v1path, body)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = fmt.Fprintf(w, `{"error":"workflow service unreachable"}`)
 		return
 	}
-	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/items/", "/api/workflow/items/")
+	w.WriteHeader(st)
+	_, _ = w.Write(data)
 }


### PR DESCRIPTION
Slice 0 of the **Proposals web page** initiative (approved proposal + roundtabled plan included under `docs/proposals/pending/`). Backend read surfaces only — additive over the existing wfe work-item store, **no new tables**.

## Endpoints (all additive, read-only)
- `GET /v1/workflow/items/<id>/events` — append-only lifecycle **timeline** (proposal history), oldest-first, **paginated** by event id (`?after=&limit=`, `next_after` cursor).
- `GET /v1/workflow/items/<id>/proposal` — the **source proposal markdown**, read race-free via `dirfd + openat(basename, O_NOFOLLOW)` confined to `$AIMEE_HOME/workflows/proposals`; symlinks refused (`ELOOP → 403`), size-capped with a `truncated` flag.
- `GET /v1/workflow/items/all` — operator view of every item (`CAP_WORKFLOW_ADMIN`).
- Enriched `item_to_json` (`proposal_name`, `pr_ref`, `submitter`, `cum_cost_usd`, `work_item_max_cost_usd`, `override_count`) + **owner-scoped** `GET /v1/workflow/items`.

## Security
Per-item reads are **ownership-scoped in the C handler** (`submitter == caller's webuser principal`; NULL fail-closed), not just the route cap. The Go proxies switch to `v1RequestWebuser` so the principal actually resolves (the old `proxyWorkflow` used the un-attested identity — would have 403'd everything). A per-request query thread-local lives in `server_http_identity` (set around the route call, cleared with the rest).

## Tests / gates
`test_wfe_webapi` gains behavioral coverage: ownership deny **and** allow (test-controlled principal), pagination cursor correctness (no gap/dup across pages), proposal read-back, **symlink → 403**, and `/all` enrichment. Also route-cap assertions in `test_server_http`. Green: `-Werror` build, line-check, server-api/cli-routes/dispatch-caps conformance, OpenAPI documented, Go build/vet.

## Roundtable
Code roundtabled (7 panelists). Every flagged "blocking" item triaged as a **false positive** against source: the `dfd` is closed unconditionally before the `fd<0` check (no leak); `submitter` is a fixed `char[128]` (never NULL); Go suffix-split guards `i>=0`; pagination is unit-test-proven no-gap/dup; `/all` (exact) is ordered before `/<id>` (prefix) and asserted in the caps test. No code changes were warranted.

Part of a slice-by-slice series; Slice 1 (the Proposals page UI + Workflows de-scope) follows.