### PR TITLE
docs: reconcile aimee-kb package docs with the current tier family

### DIFF
--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -8,13 +8,40 @@ CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
 
 | Image | Embed / Rerank | Synth | Runtime |
 |---|---|---|---|
-| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B | CPU (`NGL=0`) |
+| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B — **Tier A only** | CPU (`NGL=0`) |
 | `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 |
 | `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident |
 
 `gpu-small` and `gpu-mid` share the **same embedder + reranker** (2560-dim), so a KB
 embedded on one is byte-compatible with the other — switching the synth tier is a
 plugin **image swap**, no re-embed.
+
+## Tier-A vs Tier-B synthesis
+
+The curator synthesizes in two tiers:
+
+- **Tier A** — mechanical extract/index passes (extract docs, chunk, tag, index).
+- **Tier B** — the reasoning passes: judge, resolve entities, reconcile contradictions,
+  synthesize, promote.
+
+`aimee-kb-cpu` runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider
+— a weak model would poison the graph — so a CPU-only deployment gets retrieval + Tier-A
+synthesis and nothing more. **Tier B needs a GPU tier (`gpu-small` / `gpu-mid`) or an
+external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
+config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
+
+## Package names
+
+Two image families share the `aimee-kb` prefix. Keep them straight:
+
+- **`aimee-kb`** (no suffix) — the KB service (DB2 + curator). Runs no model; it calls one
+  over HTTP. See [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
+- **`aimee-kb-{cpu,gpu-small,gpu-mid}`** — the inference tiers in this doc (embed + rerank +
+  synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm` plugin.
+
+Retired names: `aimee-llm-cpu`/`aimee-llm-gpu` were the old tier names (now
+`aimee-kb-cpu`/`aimee-kb-gpu-small`); `aimee-embedder`/`aimee-embedder-4b` were the
+standalone torch embedder, now baked into the tiers.
 
 ## Deploy: one plugin image swap
 
@@ -49,7 +76,7 @@ independent callers — one automatic, one an explicit operator step:
 
 | Env | Default (per tier) | Meaning |
 |---|---|---|
-| `AIMEE_LLM_SYNTH_CTX` | 32768 (raise on GPU) | synth context window |
+| `AIMEE_LLM_SYNTH_CTX` | 32768 baked; the gpu-mid plugin sets `262144` (2 × 128 K) | synth context window |
 | `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on gpu-mid) | `--parallel` concurrent slots |
 | `AIMEE_LLM_SYNTH_FA` | `off` cpu / `on` gpu | flash-attention (required for quantized V-cache) |
 | `AIMEE_LLM_SYNTH_KV_K` / `_KV_V` | `q8_0` / `q4_0` (K8V4) | KV cache quant on the gpu tiers |
@@ -61,8 +88,7 @@ independent callers — one automatic, one an explicit operator step:
 The mid tier is **Gemma 4 26B-A4B** — a MoE with only **4B active parameters/token** at
 `qat-UD-Q4_K_XL` (~14 GB). Unlike a 22 GB synth, it **co-fits embed+rerank (~7 GB) on a
 24 GB card fully resident** (~21 GB + Gemma's cheap sliding-window KV), so the default is
-`N_CPU_MOE=0` — **no expert offload, no CPU/RAM path in the hot loop.** That is the whole
-point of this tier vs. a larger dense/MoE synth: it stays on the GPU and runs fast.
+`N_CPU_MOE=0` — no expert offload, fully GPU-resident.
 
 | Card | Suggested `N_CPU_MOE` | Notes |
 |---|---|---|
@@ -70,13 +96,8 @@ point of this tier vs. a larger dense/MoE synth: it stays on the GPU and runs fa
 | 16 GB | ~24–32 | ~14 GB synth won't co-fit ~7 GB retrieval; spill most experts to RAM (slow but works) |
 
 Raise `N_CPU_MOE` only if the container logs a VRAM allocation failure; each offloaded
-layer frees GPU memory at the cost of RAM-path latency. Because only 4B params are active,
-even a modest offload stays far faster than a 22 GB synth with the same offload.
-
-> **Why Gemma 4 26B-A4B over Qwen 3.6 35B-A3B here:** the 22 GB Qwen synth could not
-> co-fit the 7 GB retrieval stack on a 24 GB card, forcing ~half its MoE experts onto the
-> CPU/RAM path (`N_CPU_MOE≈20`) → ~14 tok/s generation regardless of the GPU. Gemma 4
-> 26B-A4B (~14 GB, 4B active) fits resident, eliminating the offload bottleneck.
+layer frees GPU memory at the cost of RAM-path latency. Only 4B params are active, so
+offload costs less here than on a dense synth of the same size.
 
 ### Flash-attention / K8V4
 
@@ -84,3 +105,15 @@ K8V4 (`q8_0` K / `q4_0` V) is verified working on RADV/gfx1100 (7900 XTX). FA is
 enforced structurally — llama.cpp refuses a quantized V-cache without it — so a
 healthy container proves FA engaged. If a backend genuinely can't do FA, set
 `AIMEE_LLM_SYNTH_KV_V=f16` (K8V8 does **not** help; any quantized V needs FA).
+
+### GPU runtime: Mesa 25 / cooperative matrix
+
+The GPU tiers are based on `debian:trixie-slim` (Mesa 25) on purpose: its RADV exposes
+`VK_KHR_cooperative_matrix` on RDNA3 (gfx1100), so llama.cpp uses the card's WMMA matrix
+cores. On an older Mesa without coopmat (bookworm's 22.3.6) llama.cpp falls back to scalar
+shaders — the synth goes compute-bound, the memory bus sits idle, and generation crawls.
+
+Measured on the 7900 XTX, gpu-mid resident: **~1265 tok/s prompt, ~62–95 tok/s generation**
+with coopmat; ~33–76 / ~30 without it. If a GPU tier is slow, check the base image is
+trixie (Mesa ≥ 24.1) and that `mem_busy` climbs under load — a pegged GPU with an idle
+memory bus means the matrix cores aren't in play.

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -121,6 +121,12 @@ aimee agent local gemma http://192.168.1.103:8080 \
 aimee agent probe gemma
 ```
 
+> **Registering the deployment's own `aimee-kb-*` synth:** use the gateway port and the
+> `aimee-synth` alias, not a raw GGUF filename —
+> `aimee agent local local-synth http://<gw>:8742/v1 --model aimee-synth --provider openai`.
+> The gateway runs auth-off on the internal bridge (`auth_type: none`). See
+> [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
+
 Each delegate entry records:
 
 - endpoint

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -6,17 +6,23 @@ How to point `aimee-kb` at the model backend that does its **embedding**,
 ## Principle: the kb runs no model
 
 `aimee-kb` is a thin DB2 / curator service. It **never** runs an LLM or embedder
-in-process — it *calls* one over HTTP. Inference lives in a separate **`aimee-llm`
-container** (the unified Vulkan llama.cpp image, CPU or GPU tier) or any external
-OpenAI-compatible endpoint. You only ever give the kb a **URL**.
+in-process — it *calls* one over HTTP. Inference lives in a separate **`aimee-kb-*`
+tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid` — the unified
+Vulkan llama.cpp stack, deployed as the SmoothNAS `aimee-llm` plugin) or any external
+OpenAI-compatible endpoint. You only ever give the kb a **URL**. The tiers themselves are
+documented in [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 
 ## Tiers — what each backend provides
 
 | Backend | Embedding / reranking | Synthesis | Embedding dim |
 | --- | --- | --- | --- |
-| **CPU `aimee-llm`** (default) | yes (Qwen3-0.6B + ettin) | **Tier-A** only (small model) | **1024** |
-| **GPU `aimee-llm`** | yes, higher quality (Qwen3-4B) | **Tier-A + Tier-B** | **2560** (set explicitly) |
+| **`aimee-kb-cpu`** (default) | Qwen3-Emb-0.6B + ettin-68m | **Tier-A** only (gemma-4-E4B, CPU) | **1024** |
+| **`aimee-kb-gpu-small`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 12B) | **2560** (set explicitly) |
+| **`aimee-kb-gpu-mid`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 26B-A4B) | **2560** (set explicitly) |
 | **External LLM** | per the endpoint | per the endpoint | per the endpoint |
+
+`gpu-small` and `gpu-mid` share the 2560-dim embedder, so a KB moves between them with no
+re-embed — pick by synth need, not by the KB.
 
 *Tier-A* = mechanical extract/index passes. *Tier-B* = reasoning passes (judge,
 resolve-entities, contradictions, **synthesize**, promote). A small CPU model is
@@ -26,7 +32,7 @@ when you point the kb at a capable container via `AIMEE_LLM_URL`.
 
 ## Zero-config default
 
-If **no** LLM is configured, the kb deployment brings up a **CPU `aimee-llm`
+If **no** LLM is configured, the kb deployment brings up a **CPU `aimee-kb-cpu`
 container beside it** and points itself at it — embedding, reranking, and Tier-A
 synthesis work out of the box with nothing to set. The operator only opts *up*:
 configure a GPU container or an external LLM and the CPU sibling is not started.
@@ -89,7 +95,7 @@ AIMEE_EMBEDDER_URL=https://embed.internal  # pin embedding elsewhere
 AIMEE_EMBEDDING_DIM=<that model's dim>
 ```
 
-**Default (nothing set):** the deploy brings up the CPU `aimee-llm` sibling;
+**Default (nothing set):** the deploy brings up the CPU `aimee-kb-cpu` sibling;
 retrieval + Tier-A synthesis work at 1024-dim with no configuration.
 
 ## Notes for plugin / compose operators

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -7,63 +7,38 @@ sized to that model's output dimension.
 
 ## The embedder
 
-The embedder is any command that reads text on stdin and writes a JSON float
-array on stdout (`scripts/embedder-server.py` provides an HTTP sidecar wrapper
-for the HuggingFace / sentence-transformers stack). It ships in two tiers, one
-embedder and a cross-encoder reranker sized to the same tier, baked into one
-image. (The reranker emits a scalar score, so its size is a quality choice, not
-a dimension constraint.)
+Embedding and reranking are baked into the `aimee-kb-*` tier images — Qwen3-Embedding + an
+Ettin cross-encoder reranker — and served over HTTP (`/embed`, `/embed_batch`, `/rerank` on
+the gateway `:8742`). The KB calls them; it runs no model. See
+[AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md) for the tiers and
+[KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md) for pointing the KB at one. (The reranker emits a
+scalar score, so its size is a quality choice, not a dimension constraint.)
 
-| Image | Embedder (`embedding_dim`) | Reranker |
-|-------|----------------------------|----------|
-| `aimee-embedder` (default) | `pplx-embed-v1-0.6b` (`1024`) | `ettin-reranker-400m` |
-| `aimee-embedder-4b` | `pplx-embed-v1-4b` (`2560`) | `ettin-reranker-1b` |
+Two embedding widths ship:
 
-### Choosing a tier
+| Tier | Embedder (`embedding_dim`) | Reranker |
+|------|----------------------------|----------|
+| `aimee-kb-cpu` | Qwen3-Embedding-0.6B (`1024`) | ettin-68m |
+| `aimee-kb-gpu-small` / `-gpu-mid` | Qwen3-Embedding-4B (`2560`) | ettin-400m |
 
-Run one tier per deployment. The 0.6b/400m image is the default; the 4b/1b
-image is the higher-fidelity alternate for hosts with RAM to spare.
-
-**0.6b + 400m (default).** The low-latency tier, and the right default for most
-deployments.
-- ~2 GB of weights (embedder + reranker), a couple of GB resident, embeds in
-  ~0.2 s, roughly 5x faster than the 4b on a CPU host. Fast to pull, fast to
-  re-embed.
-- In practice the cross-encoder reranker dominates recall latency, not the
-  embedder, so the larger embedder buys less end-to-end than its size suggests.
-- Recall is slightly weaker than the 4b on large or noisy corpora and on
-  meaning-heavy queries, but fine for most workloads.
-
-**4b + 1b (higher fidelity).** Pick it when the host has the RAM and you want
-the best recall/ranking on large or noisy corpora.
-- Recall and ranking are noticeably better on meaning-over-keyword queries.
-- Costs: the model weights are several GB (slower image pull and first build),
-  the image holds ~20 GB resident in fp32 (~16 GB embedder + ~4 GB reranker),
-  and a CPU embed runs ~1–2 s versus the 0.6b's ~0.2 s. None of that is in the
-  request hot path, embedding happens at ingest and on the query, not per
-  token, but it sets a RAM floor and slows a cold re-embed of a large corpus.
-
-Rule of thumb: default to 0.6b/400m; step up to 4b/1b only when you have the RAM
-and need the extra recall. The retrieval pipeline (hybrid search, reranking,
-fusion) is identical either way, only the model sizes differ.
+The 4B/2560 tier has better recall on large or meaning-heavy corpora; the 0.6B/1024 tier is
+the low-footprint default. The retrieval pipeline (hybrid search, reranking, fusion) is
+identical either way — only the model sizes differ.
 
 ### Switching tiers
 
-The default `aimee-embedder` image bakes the 0.6b + 400m. To run the
-higher-fidelity tier, point at the `aimee-embedder-4b` image and set the
-dimension to match:
+Switch by deploying a different `aimee-kb-*` tier (the `aimee-llm` plugin image) and setting
+the width to match:
 
 ```bash
-AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-4b:latest
 AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
 ```
 
-No rebuild needed, both images are published. On an **empty** database that's
-all it takes. On a **populated** one the dimension change needs a re-embed (the
-`halfvec` columns are sized to `embedding_dim`, so 1024 and 2560 vectors can't
-share a column), see [Switching embedders on an existing
-database](#switching-embedders-on-an-existing-database) below. Build a custom
-pairing with `--build-arg EMBEDDER_MODEL=… --build-arg RERANKER_MODEL=…`.
+Both GPU tiers are 2560-dim, so moving between `gpu-small` and `gpu-mid` needs no re-embed.
+Moving between 1024 and 2560 is a model-identity **and** width change: on an **empty** DB
+just set the dim; on a **populated** one it's a drop-and-rebuild re-embed (the `halfvec`
+columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces — see
+[Switching embedders on an existing database](#switching-embedders-on-an-existing-database).
 
 ## Configuration
 
@@ -218,12 +193,9 @@ unchanged, since the dimension has not moved.
 ## Reranking
 
 An optional cross-encoder reranker refines the top-k of a recall before it is
-returned. It is served by the same embedder sidecar, sized to match the embedder
-tier: the default `aimee-embedder` image bakes the **1B** Ettin reranker
-(`cross-encoder/ettin-reranker-1b-v1`) alongside the 4B embedder; the
-`aimee-embedder-0.6b` image bakes the **400M** reranker
-(`cross-encoder/ettin-reranker-400m-v1`) alongside the 0.6B embedder. Build-time
-override: `--build-arg RERANKER_MODEL=<hf id>`.
+returned. It is baked into the same tier image and sized to match the embedder: the GPU tiers
+(`aimee-kb-gpu-small` / `-gpu-mid`) bake `cross-encoder/ettin-reranker-400m-v1`; the CPU
+tier bakes ettin-68m. Build-time override: `--build-arg RERANK_REPO=<hf id>`.
 
 It is configured independently of the embedder dimension:
 

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -5,8 +5,14 @@ The unified-llm-container migration (P7). **Operator-gated** — the production 
 pieces; this runbook is the order of operations + the gates.
 
 Validated before this runbook (`.253`/`.254`, see `benchmarks/results/unified-llm/`):
-the `aimee-llm:cpu`/`:gpu` images build, serve `/embed`+`/rerank`(ettin encoder + gateway
+the images build, serve `/embed`+`/rerank`(ettin encoder + gateway
 head)+`/v1/chat/completions`, and offload to the AMD 7900 XTX via Vulkan (`-ngl 99`).
+
+> **Naming update (post-cutover):** the images built here were renamed
+> `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small`, and a third GPU
+> tier `aimee-kb-gpu-mid` (Gemma 4 26B-A4B) was added; `aimee-llm` is now only the plugin
+> name. The steps below keep the original names as a record — for the current tiers and
+> build-args see [../AIMEE_KB_SYNTH_TIERS.md](../AIMEE_KB_SYNTH_TIERS.md).
 
 ## 0. What changes
 
@@ -33,24 +39,28 @@ release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollb
 
 CI builds + publishes both tiers as part of the normal release cycle:
 - **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds
-  `aimee-llm-cpu` + `aimee-llm-gpu` on every release and tags them `:<version>` + `:latest`
-  (multi-arch). They are in both the `build` and the `merge` matrices — the merge step is
-  what applies the tags, so a build that pushes only by digest leaves `tags:null`.
-- **testing:** `.github/workflows/publish-llm-testing.yml` builds both tiers on `testing`
-  pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts, tagged
-  `:testing` (+ `:testing-<sha>`, amd64) — a tested-but-unreleased image for `.254`.
+  `aimee-kb-cpu` + `aimee-kb-gpu-small` + `aimee-kb-gpu-mid` on every release and tags them
+  `:<version>` + `:latest`. They are in both the `build` and the `merge` matrices — the
+  merge step applies the tags, so a build that pushes only by digest leaves `tags:null`.
+  (`gpu-mid` is amd64-only.)
+- **testing:** `.github/workflows/publish-llm-testing.yml` builds `cpu` + `gpu-small` on
+  `testing` pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts,
+  tagged `:testing` (+ `:testing-<sha>`, amd64). `gpu-mid` is dispatch-only
+  (`build_kb_gpu_mid=true`) — a tested-but-unreleased image for `.254`.
 
 To build out-of-band (e.g. on a PVE CT with docker):
 
 ```
-docker build -f Dockerfile.aimee-llm -t aimee-llm:cpu .
-docker build -f Dockerfile.aimee-llm -t aimee-llm:gpu \
+docker build -f Dockerfile.aimee-llm -t aimee-kb-cpu .
+docker build -f Dockerfile.aimee-llm -t aimee-kb-gpu-small \
   --build-arg EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF \
   --build-arg EMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf \
   --build-arg RERANK_REPO=cross-encoder/ettin-reranker-400m-v1 \
-  --build-arg SYNTH_REPO=unsloth/gemma-4-12b-it-GGUF \
-  --build-arg SYNTH_FILE=gemma-4-12b-it-Q4_K_M.gguf .
+  --build-arg SYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF \
+  --build-arg SYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf \
+  --build-arg SYNTH_FA=on .
 ```
+(gpu-mid swaps the synth args to Gemma 4 26B-A4B — see the tiers doc for the exact pins.)
 
 ## 3. Deploy to `.254` (tierd / LXC, GPU)
 


### PR DESCRIPTION
Reviews and corrects the embed/rerank/synth package docs after the 3-tier rename, the Gemma-4-26B-A4B gpu-mid synth, and the trixie/Mesa-25 coopmat base. An Explore pass audited every package doc against current reality; the aimee roundtable then reviewed the edits.

- **AIMEE_KB_SYNTH_TIERS.md** (the package reference): package-name taxonomy (`aimee-kb` service vs `aimee-kb-*` tiers, retired `aimee-llm-*`/`aimee-embedder*` names); a **Tier-A vs Tier-B synthesis** section — cpu does Tier-A only, Tier-B needs a GPU tier or external LLM; the Mesa-25/coopmat GPU-runtime note with measured numbers.
- **KB_LLM_BACKENDS.md**: 2-tier CPU/GPU table → 3 named tiers with synth models; drop the old `aimee-llm` image naming.
- **retrieval-stack.md**: replace the retired standalone torch embedder (`aimee-embedder`/pplx-embed) with the baked Qwen3-Embedding + ettin tiers; fix the contradictory reranker paragraph.
- **unified-llm-cutover.md**: rename note + fix the build example (image names, qat quant).
- **DELEGATES.md**: register-the-local-synth example against the `:8742` gateway.

Roundtable: applied its brevity signal (trimmed the gpu-mid tuning prose, cut the Qwen-vs-Gemma rationale from the package doc, clarified the gpu-mid ctx default). Rejected its style suggestions that pushed vivid plain English toward corporate phrasing, and its 7 replay-rejected false positives.