### PR TITLE
feat(webui): Proposals page + de-scope Workflows (slice 1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Toast } from '@rakuensoftware/smoothgui';
 import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
 import Workflows from './pages/Workflows';
+import Proposals from './pages/Proposals';
 import Delegates from './pages/Delegates';
 import Projects from './pages/Projects';
 import Graph from './pages/Graph';
@@ -64,6 +65,7 @@ const NAV_ITEMS: Tab[] = [
   { label: 'Chat', icon: '💬', route: '/chat' },
   { label: 'Dashboard', icon: '📊', route: '/dashboard' },
   { label: 'Workflows', icon: '🔀', route: '/workflows' },
+  { label: 'Proposals', icon: '📝', route: '/proposals' },
   { label: 'Delegates', icon: '🤝', route: '/delegates' },
   { label: 'Projects', icon: '📁', route: '/projects' },
   { label: 'Graph', icon: '🕸️', route: '/graph' },
@@ -235,6 +237,7 @@ export default function App() {
                 <Route path="/chat" element={<Chat />} />
                 <Route path="/dashboard" element={<Dashboard />} />
                 <Route path="/workflows" element={<Workflows />} />
+                <Route path="/proposals" element={<Proposals />} />
                 <Route path="/delegates" element={<Delegates />} />
                 <Route path="/projects" element={<Projects />} />
                 <Route path="/graph" element={<Graph />} />

--- a/frontend/src/pages/Proposals.tsx
+++ b/frontend/src/pages/Proposals.tsx
@@ -1,0 +1,451 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
+import type { BadgeVariant } from "@rakuensoftware/smoothgui";
+import { renderMd } from "./chat/markdown";
+
+/* ---- API types (mirror the enriched /api/workflow/items* envelopes) ---- */
+
+interface Item {
+  id: string;
+  workflow: string;
+  version: string;
+  stage: string;
+  state: string; // active | accepted | rejected | abandoned
+  mode: string;
+  pause_reason: string;
+  repo: string;
+  proposal_name?: string;
+  pr_ref?: string;
+  submitter?: string;
+  cum_cost_usd?: number;
+  work_item_max_cost_usd?: number;
+  override_count?: number;
+}
+interface WfEvent {
+  id: number;
+  stage: string;
+  kind: string;
+  actor: string;
+  detail: string;
+  cost_usd: number;
+  created_at: string;
+}
+
+const POLL_MS = 4000;
+
+async function getJSON<T>(url: string): Promise<T> {
+  const r = await fetch(url, { headers: { "X-CSRF-Token": window._csrf || "" } });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return (await r.json()) as T;
+}
+async function postJSON<T>(url: string, body: unknown): Promise<{ status: number; data: T }> {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-CSRF-Token": window._csrf || "" },
+    body: JSON.stringify(body),
+  });
+  let data = {} as T;
+  try {
+    data = (await r.json()) as T;
+  } catch {
+    /* empty body ok */
+  }
+  return { status: r.status, data };
+}
+
+const isTerminal = (s: string) => s === "accepted" || s === "rejected" || s === "abandoned";
+
+// A human status label + tone from the row's state + pause_reason + stage. Derived
+// strictly from the documented enums — no invented "drafting" state.
+function statusOf(it: Item): { label: string; variant: BadgeVariant } {
+  if (it.state === "accepted") return { label: "merged (accepted)", variant: "success" };
+  if (it.state === "rejected") return { label: "rejected", variant: "error" };
+  if (it.state === "abandoned") return { label: "abandoned", variant: "neutral" };
+  // active:
+  switch (it.pause_reason) {
+    case "pending_human":
+      return { label: `awaiting approval · ${it.stage}`, variant: "warning" };
+    case "ci_pending":
+      return { label: "CI running", variant: "running" };
+    case "merge_pending":
+      return { label: "merging", variant: "running" };
+    case "panel_degraded":
+    case "panel_unreachable":
+      return { label: `parked · ${it.pause_reason}`, variant: "warning" };
+    case "budget_exceeded":
+      return { label: "parked · budget exceeded", variant: "error" };
+    case "failed":
+      return { label: "parked · failed", variant: "error" };
+    case "max_attempts":
+      return { label: "parked · max attempts", variant: "error" };
+    default:
+      return { label: `running · ${it.stage}`, variant: "running" };
+  }
+}
+
+// A lifecycle event kind → a compact human verb for the timeline.
+const KIND_LABEL: Record<string, string> = {
+  create: "created",
+  advance: "advanced",
+  loop: "looped back",
+  pause: "paused",
+  failed: "failed",
+  terminal: "completed",
+  resume: "resumed",
+  approve: "approved",
+  reject: "rejected",
+  reject_retry: "rejected (retry)",
+  override: "overridden",
+  rejected: "rejected",
+};
+
+// pr_ref is opaque (a PR number or a URL). Render a link when it looks like one.
+function prHref(pr: string): string | null {
+  if (/^https?:\/\//.test(pr)) return pr;
+  return null;
+}
+
+export default function Proposals() {
+  const [items, setItems] = useState<Item[]>([]);
+  const [showAll, setShowAll] = useState(false);
+  const [selId, setSelId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<Item | null>(null);
+  const [events, setEvents] = useState<WfEvent[]>([]);
+  const [proposalMd, setProposalMd] = useState<string>("");
+  const [proposalTrunc, setProposalTrunc] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
+  const [gateMsg, setGateMsg] = useState("");
+  const afterRef = useRef(0); // events pagination cursor for the open proposal
+  const reqRef = useRef(0); // monotonic open token: stale async loads (older selection) no-op
+
+  const refreshList = useCallback(() => {
+    getJSON<{ items: Item[] }>(showAll ? "/api/workflow/items/all" : "/api/workflow/items")
+      .then((d) => setItems(d.items || []))
+      .catch((e) =>
+        setStatus({ kind: "err", msg: showAll ? `list all failed: ${e.message}` : "list failed" }),
+      );
+  }, [showAll]);
+
+  useEffect(() => {
+    refreshList();
+  }, [refreshList]);
+
+  // Load a proposal's full detail: the item row, its source markdown, and the head
+  // of its event timeline (resetting the pagination cursor).
+  const openProposal = useCallback((id: string) => {
+    const myReq = ++reqRef.current; // invalidates any still-in-flight prior load
+    const live = () => myReq === reqRef.current;
+    setSelId(id);
+    setLoading(true);
+    setEvents([]);
+    afterRef.current = 0;
+    setGateMsg("");
+    Promise.all([
+      getJSON<Item>(`/api/workflow/items/${encodeURIComponent(id)}`)
+        .then((d) => live() && setDetail(d))
+        .catch(() => live() && setDetail(null)),
+      getJSON<{ proposal_md: string; truncated: boolean }>(
+        `/api/workflow/items/${encodeURIComponent(id)}/proposal`,
+      )
+        .then((d) => {
+          if (!live()) return;
+          setProposalMd(d.proposal_md || "");
+          setProposalTrunc(!!d.truncated);
+        })
+        .catch(() => {
+          if (!live()) return;
+          setProposalMd("");
+          setProposalTrunc(false);
+        }),
+      getJSON<{ events: WfEvent[]; next_after: number }>(
+        `/api/workflow/items/${encodeURIComponent(id)}/events?limit=200`,
+      )
+        .then((d) => {
+          if (!live()) return;
+          setEvents(d.events || []);
+          afterRef.current = d.next_after || 0;
+        })
+        .catch(() => {}),
+    ]).finally(() => {
+      if (live()) setLoading(false);
+    });
+  }, []);
+
+  // Poll the open proposal while it's active: refresh the row and append only new
+  // events (after=cursor, so no re-fetch/dup). Keyed on selId alone (not detail) so
+  // it isn't torn down every tick; the interval self-stops once the item reaches a
+  // terminal state, and cleans up on unmount / selection change.
+  useEffect(() => {
+    if (!selId) return;
+    let cancelled = false;
+    const iv = window.setInterval(async () => {
+      try {
+        const it = await getJSON<Item>(`/api/workflow/items/${encodeURIComponent(selId)}`);
+        if (cancelled) return;
+        setDetail(it);
+        setItems((prev) => prev.map((p) => (p.id === it.id ? it : p)));
+        const d = await getJSON<{ events: WfEvent[]; next_after: number }>(
+          `/api/workflow/items/${encodeURIComponent(selId)}/events?after=${afterRef.current}&limit=200`,
+        );
+        if (cancelled) return;
+        if (d.events && d.events.length) {
+          // Idempotent append: keep only events past the last one we hold, so no
+          // race (re-open, overlapping tick) can duplicate a row.
+          setEvents((prev) => {
+            const lastId = prev.length ? prev[prev.length - 1].id : 0;
+            const fresh = d.events.filter((e) => e.id > lastId);
+            return fresh.length ? [...prev, ...fresh] : prev;
+          });
+          afterRef.current = d.next_after || afterRef.current;
+        }
+        if (isTerminal(it.state)) window.clearInterval(iv);
+      } catch {
+        /* transient; next tick retries */
+      }
+    }, POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(iv);
+    };
+  }, [selId]);
+
+  const decideGate = useCallback(
+    async (decision: "approve" | "reject") => {
+      if (!selId) return;
+      setGateMsg("");
+      const { status: st, data } = await postJSON<{ error?: string }>(
+        `/api/workflow/items/${encodeURIComponent(selId)}/gate`,
+        { decision },
+      );
+      if (st >= 200 && st < 300) {
+        setGateMsg(decision === "approve" ? "Approved — resuming." : "Rejected.");
+        openProposal(selId); // refresh detail + events after the decision
+      } else {
+        setGateMsg(data.error || `failed (HTTP ${st})`);
+      }
+    },
+    [selId, openProposal],
+  );
+
+  const canDecide = !!detail && detail.pause_reason === "pending_human";
+
+  return (
+    <div style={{ display: "flex", height: "100%", fontFamily: "system-ui" }}>
+      {/* left rail: proposal list */}
+      <div
+        style={{
+          width: 300,
+          flexShrink: 0,
+          borderRight: "1px solid #eee",
+          overflowY: "auto",
+          padding: 12,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+          <strong style={{ fontSize: 16 }}>Proposals</strong>
+          <Badge label={`${items.length}`} variant="neutral" />
+          <button onClick={refreshList} style={btn}>
+            Refresh
+          </button>
+        </div>
+        <label style={{ fontSize: 12, color: "#666", display: "flex", alignItems: "center", gap: 6 }}>
+          <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
+          Show all (operator)
+        </label>
+        {status && (
+          <div style={{ fontSize: 12, color: status.kind === "err" ? "#c00" : "#070", marginTop: 6 }}>
+            {status.msg}
+          </div>
+        )}
+        <div style={{ marginTop: 8 }}>
+          {items.length === 0 && (
+            <div style={{ color: "#999", fontSize: 13 }}>No proposals yet.</div>
+          )}
+          {items.map((it) => {
+            const s = statusOf(it);
+            return (
+              <div
+                key={it.id}
+                onClick={() => openProposal(it.id)}
+                style={{
+                  padding: "8px 8px",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  marginBottom: 4,
+                  background: selId === it.id ? "#eef4ff" : "transparent",
+                  border: "1px solid",
+                  borderColor: selId === it.id ? "#bcd4ff" : "#f0f0f0",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 6 }}>
+                  <span style={{ fontWeight: 600, fontSize: 13, wordBreak: "break-all" }}>
+                    {it.proposal_name || it.id}
+                  </span>
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4 }}>
+                  <Badge label={s.label} variant={s.variant} />
+                  <span style={{ fontSize: 11, color: "#999" }}>{it.workflow}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* main: selected proposal detail */}
+      <div style={{ flex: 1, minWidth: 0, overflowY: "auto", padding: 16 }}>
+        {!detail && (
+          <div style={{ color: "#888", fontSize: 14, marginTop: 20 }}>
+            Select a proposal to see its status and history.
+            <Spinner loading={loading} text="loading…" />
+          </div>
+        )}
+        {detail && (
+          <>
+            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 4 }}>
+              <strong style={{ fontSize: 18 }}>{detail.proposal_name || detail.id}</strong>
+              <Badge label={statusOf(detail).label} variant={statusOf(detail).variant} />
+              <Spinner loading={loading} text="" />
+            </div>
+            <StatusHeader item={detail} />
+
+            {canDecide && (
+              <Panel title={`Human gate · ${detail.stage}`}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <button onClick={() => void decideGate("approve")} style={btn}>
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => void decideGate("reject")}
+                    style={{ ...btn, background: "#fbeaea", color: "#a33", borderColor: "#e0a0a0" }}
+                  >
+                    Reject
+                  </button>
+                  {gateMsg && <span style={{ fontSize: 12, color: "#667" }}>{gateMsg}</span>}
+                </div>
+              </Panel>
+            )}
+
+            <Panel title={`History · ${events.length} events`}>
+              <Timeline events={events} />
+            </Panel>
+
+            <Panel title="Proposal">
+              {proposalTrunc && (
+                <div style={{ fontSize: 12, color: "#a60", marginBottom: 6 }}>
+                  ⚠ Proposal truncated (over the size cap); showing the first part.
+                </div>
+              )}
+              {proposalMd ? (
+                <div
+                  style={{ fontSize: 13, lineHeight: 1.5, overflowWrap: "anywhere" }}
+                  dangerouslySetInnerHTML={{ __html: renderMd(proposalMd) }}
+                />
+              ) : (
+                <div style={{ color: "#999", fontSize: 13 }}>No proposal markdown.</div>
+              )}
+            </Panel>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusHeader({ item }: { item: Item }) {
+  const pr = item.pr_ref ? prHref(item.pr_ref) : null;
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))",
+        gap: "2px 16px",
+        fontSize: 13,
+        margin: "6px 0 10px",
+      }}
+    >
+      <Field k="stage" v={item.stage} />
+      <Field k="workflow" v={`${item.workflow} · v${(item.version || "").slice(0, 8)}`} />
+      {item.repo ? <Field k="repo" v={item.repo} /> : null}
+      {typeof item.cum_cost_usd === "number" && (
+        <Field
+          k="cost"
+          v={
+            item.work_item_max_cost_usd
+              ? `$${item.cum_cost_usd.toFixed(4)} / $${item.work_item_max_cost_usd.toFixed(2)}`
+              : `$${item.cum_cost_usd.toFixed(4)}`
+          }
+        />
+      )}
+      {item.pr_ref ? (
+        <div style={{ display: "flex", gap: 8 }}>
+          <span style={{ color: "#888" }}>PR</span>
+          {pr ? (
+            <a href={pr} target="_blank" rel="noreferrer" style={{ color: "#2563eb" }}>
+              {item.pr_ref}
+            </a>
+          ) : (
+            <span style={{ fontFamily: "monospace" }}>{item.pr_ref}</span>
+          )}
+        </div>
+      ) : null}
+      {item.override_count ? <Field k="overrides" v={String(item.override_count)} /> : null}
+      {item.submitter ? <Field k="submitter" v={item.submitter} /> : null}
+    </div>
+  );
+}
+
+function Timeline({ events }: { events: WfEvent[] }) {
+  if (!events.length) return <div style={{ color: "#999", fontSize: 13 }}>No events yet.</div>;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+      {events.map((e) => (
+        <div
+          key={e.id}
+          style={{
+            display: "flex",
+            gap: 10,
+            padding: "6px 0",
+            borderBottom: "1px solid #f3f3f3",
+            fontSize: 13,
+          }}
+        >
+          <span style={{ color: "#aaa", fontSize: 11, width: 130, flexShrink: 0 }}>
+            {e.created_at}
+          </span>
+          <span style={{ flexShrink: 0, width: 120 }}>
+            <Badge label={KIND_LABEL[e.kind] || e.kind} variant="neutral" />
+          </span>
+          <span style={{ flex: 1, minWidth: 0 }}>
+            <span style={{ color: "#555" }}>{e.stage}</span>
+            {e.detail ? <span style={{ color: "#888" }}> — {e.detail}</span> : null}
+            <span style={{ color: "#bbb", fontSize: 11 }}>
+              {" "}
+              ({e.actor}
+              {e.cost_usd ? `, $${e.cost_usd.toFixed(4)}` : ""})
+            </span>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Field({ k, v }: { k: string; v: string }) {
+  return (
+    <div style={{ display: "flex", gap: 8 }}>
+      <span style={{ color: "#888" }}>{k}</span>
+      <span style={{ overflowWrap: "anywhere" }}>{v}</span>
+    </div>
+  );
+}
+
+const btn: React.CSSProperties = {
+  fontSize: 13,
+  padding: "4px 10px",
+  border: "1px solid #ccc",
+  borderRadius: 4,
+  background: "#fff",
+  cursor: "pointer",
+};

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -48,17 +48,6 @@ interface DefResponse {
   def: GraphDef;
   error?: string;
 }
-interface RunItem {
-  id: string;
-  workflow: string;
-  version: string;
-  stage: string;
-  state: string;
-  mode: string;
-  pause_reason: string;
-  repo: string;
-}
-
 /* ---- personas + delegates (the per-step assignment options) ---- */
 
 interface PersonaInfo {
@@ -306,7 +295,6 @@ async function sendJSON<T>(
 export default function Workflows() {
   const [defs, setDefs] = useState<DefRow[]>([]);
   const [blocks, setBlocks] = useState<BlockDef[]>([]);
-  const [items, setItems] = useState<RunItem[]>([]);
   const [graph, setGraph] = useState<GraphDef | null>(null);
   const [version, setVersion] = useState("");
   const [pos, setPos] = useState<Record<string, { x: number; y: number }>>({});
@@ -315,16 +303,15 @@ export default function Workflows() {
     kind: "ok" | "err" | "info";
     msg: string;
   } | null>(null);
-  const [runItem, setRunItem] = useState<RunItem | null>(null);
   const [loading, setLoading] = useState(false);
   const [personas, setPersonas] = useState<PersonaInfo[]>([]);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [managePersonas, setManagePersonas] = useState(false);
   // Autonomous-development intake (submit a proposal -> a run on the chosen workflow).
+  // Run/status tracking lives on the Proposals page now; this page only submits.
   const [proposalMd, setProposalMd] = useState("");
   const [submitMsg, setSubmitMsg] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [gateMsg, setGateMsg] = useState("");
   // This tab's selected project (per-tab project space). Held so the workflow
   // context can scope to it; execution-in-project flows through a chat session's
   // cwd today, so this primarily persists the selection + offers clone here.
@@ -334,9 +321,6 @@ export default function Workflows() {
   const refreshLists = useCallback(() => {
     getJSON<{ defs: DefRow[] }>("/api/workflow/defs")
       .then((d) => setDefs(d.defs || []))
-      .catch(() => {});
-    getJSON<{ items: RunItem[] }>("/api/workflow/items")
-      .then((d) => setItems(d.items || []))
       .catch(() => {});
   }, []);
 
@@ -369,30 +353,6 @@ export default function Workflows() {
       setSubmitting(false);
     }
   }, [proposalMd, graph, refreshLists]);
-
-  // Approve / reject the human gate the selected run is parked at. Operator-only
-  // server-side (CAP_WORKFLOW_ADMIN); the scheduler resumes the run on approve.
-  const decideGate = useCallback(
-    async (decision: "approve" | "reject") => {
-      if (!runItem) return;
-      setGateMsg("");
-      try {
-        const { status, data } = await postJSON<{ error?: string }>(
-          `/api/workflow/items/${encodeURIComponent(runItem.id)}/gate`,
-          { decision },
-        );
-        if (status >= 200 && status < 300) {
-          setGateMsg(decision === "approve" ? "Approved — resuming." : "Rejected.");
-          refreshLists();
-        } else {
-          setGateMsg(data.error || `failed (HTTP ${status})`);
-        }
-      } catch {
-        setGateMsg("failed");
-      }
-    },
-    [runItem, refreshLists],
-  );
 
   // The persona list feeds both the per-step persona pickers and the manager;
   // refreshed after any persona create/edit/delete.
@@ -427,7 +387,6 @@ export default function Workflows() {
         setVersion(d.version);
         setPos(autoLayout(d.def));
         setSelected(null);
-        setRunItem(null);
         setStatus(d.valid ? null : { kind: "err", msg: d.error || "invalid" });
       })
       .finally(() => setLoading(false));
@@ -579,20 +538,6 @@ export default function Workflows() {
   }, []);
 
   const sel = graph?.nodes.find((n) => n.id === selected) || null;
-  // The editor shows the CURRENT on-disk def. A run is pinned to a specific
-  // version; only when that matches the open def does the graph truly depict
-  // what the run is executing — so only then do we highlight the current stage.
-  const runMatchesOpenDef = !!(
-    runItem &&
-    graph &&
-    runItem.workflow === graph.name &&
-    !!version &&
-    runItem.version === version
-  );
-  const activeStage =
-    runMatchesOpenDef && graph?.nodes.some((n) => n.id === runItem!.stage)
-      ? runItem!.stage
-      : null;
 
   const center = (id: string) => {
     const p = pos[id];
@@ -702,32 +647,6 @@ export default function Workflows() {
               <span style={{ fontSize: 11, color: "#667" }}>{submitMsg}</span>
             )}
           </div>
-        </Panel>
-        <Panel title="Runs" count={items.length}>
-          {items.map((it) => (
-            <div
-              key={it.id}
-              onClick={() => {
-                setRunItem(it);
-                if (it.workflow !== graph?.name) openDef(it.workflow);
-              }}
-              style={{ ...row, fontWeight: runItem?.id === it.id ? 600 : 400 }}
-            >
-              <span>
-                {it.workflow}/{it.stage}
-              </span>
-              <Badge
-                label={it.state}
-                variant={
-                  it.state === "accepted"
-                    ? "success"
-                    : it.state === "active"
-                      ? "running"
-                      : "neutral"
-                }
-              />
-            </div>
-          ))}
         </Panel>
         <Panel title="Personas" count={personas.length}>
           <button onClick={() => setManagePersonas(true)} style={btn}>
@@ -865,7 +784,6 @@ export default function Workflows() {
             {graph?.nodes.map((n) => {
               const p = pos[n.id] || { x: 0, y: 0 };
               const isSel = n.id === selected;
-              const isActive = n.id === activeStage;
               return (
                 <g
                   key={n.id}
@@ -878,9 +796,9 @@ export default function Workflows() {
                     width={NODE_W}
                     height={NODE_H}
                     rx={6}
-                    fill={isActive ? "#fff7e0" : "#fff"}
-                    stroke={isSel ? "#2563eb" : isActive ? "#e0a800" : "#ccc"}
-                    strokeWidth={isSel || isActive ? 2 : 1}
+                    fill="#fff"
+                    stroke={isSel ? "#2563eb" : "#ccc"}
+                    strokeWidth={isSel ? 2 : 1}
                   />
                   <text x={8} y={20} fontSize={13} fontWeight={600} fill="#222">
                     {nodeTitle(n)}
@@ -921,42 +839,6 @@ export default function Workflows() {
             />
           )}
         </Panel>
-        {runItem && (
-          <Panel title="Run state">
-            <Field k="workflow" v={runItem.workflow} />
-            <Field k="stage" v={runItem.stage} />
-            <Field k="state" v={runItem.state} />
-            <Field k="pause" v={runItem.pause_reason || "—"} />
-            <Field k="version" v={runItem.version.slice(0, 12)} />
-            {runItem.pause_reason === "pending_human" && (
-              <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 8 }}>
-                <button onClick={() => void decideGate("approve")} style={btn}>
-                  Approve
-                </button>
-                <button
-                  onClick={() => void decideGate("reject")}
-                  style={{ ...btn, background: "#fbeaea", color: "#a33" }}
-                >
-                  Reject
-                </button>
-                {gateMsg && <span style={{ fontSize: 11, color: "#667" }}>{gateMsg}</span>}
-              </div>
-            )}
-            {graph &&
-              runItem.workflow === graph.name &&
-              runItem.version &&
-              version &&
-              runItem.version !== version && (
-                <div style={{ color: "#c80", fontSize: 12, marginTop: 6 }}>
-                  ⚠ This run is pinned to version {runItem.version.slice(0, 12)}
-                  , but the editor is showing the <b>current</b> def (
-                  {version.slice(0, 12)}). The graph may not match what the run
-                  is executing, so the stage highlight is hidden until they
-                  match.
-                </div>
-              )}
-          </Panel>
-        )}
       </div>
 
       {managePersonas && (


### PR DESCRIPTION
Slice 1 of the **Proposals page** initiative (proposal + plan under `docs/proposals/pending/`, both roundtable-approved). Builds on Slice 0's backend read surfaces (#954, merged). Frontend-only.

## What
A dedicated **Proposals** page (left nav → 📝 Proposals):
- **List** — the caller's own proposals (submitter-scoped), with an operator **"show all"** toggle (`/api/workflow/items/all`). Each row shows a lifecycle badge derived from `state`+`pause_reason`+`stage`.
- **Status / history detail** — a scrollable **lifecycle timeline** (from `/events`, polled incrementally by cursor and self-stopping once the item is terminal), the rendered **source proposal markdown**, a status header (stage, cost vs cap, PR link, submitter), and in-context **Approve/Reject** when parked at a human gate.

## Workflows de-scope
Workflows becomes the **def/graph editor only**: the Runs list, Run-state inspector, gate Approve/Reject, and all `runItem`/`decideGate`/`activeStage`/`RunItem` state are removed — the run/status capability **relocates** to Proposals (no capability lost). The Submit-proposal panel stays for now (removed in Slice 2, when Proposals gains its own composer).

## Review
Roundtable-reviewed. Applied: guard `openProposal`'s async loads with a monotonic request token (a rapid re-selection can't let a stale fetch clobber the current proposal — the poll loop was already guarded by a `cancelled` flag), and make the incremental event append idempotent (`id > lastId`) so no poll/re-open race can duplicate a timeline row. Verified `renderMd` escapes HTML (the proposal markdown is user-authored → rendered via `dangerouslySetInnerHTML` safely, same renderer Chat uses for untrusted output).

`tsc -b && vite build` clean. Live end-to-end (submit → watch the timeline advance/park → decide a gate) will be exercised on pve now that the endpoints are on `testing`.