### PR TITLE
feat(workflow): primary-as-manager S2 step 6 (inc. 1) — sliding-lease staleness tracking

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -229,7 +229,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 138 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 139 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -427,7 +427,7 @@ The binaries read 138 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_OCR_URL`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`
+`AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_OCR_URL`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/db1/wfe_binding.c
+++ b/src/db1/wfe_binding.c
@@ -131,6 +131,9 @@ int db1_wfe_lease_renew(const char *session_id, int ttl_secs)
    sqlite3_bind_text(stmt, 3, mod, -1, SQLITE_TRANSIENT);
    int rc = (sqlite3_step(stmt) == SQLITE_DONE) ? 0 : -1;
    sqlite3_finalize(stmt);
+   /* No matching binding -> -1 per the contract (the UPDATE succeeds with 0 rows). */
+   if (rc == 0 && sqlite3_changes(db) == 0)
+      rc = -1;
    return rc;
 }
 
@@ -168,6 +171,8 @@ int db1_wfe_lease_stale_work_items(char (*out)[80], int max)
    if (!db)
       return -1;
    sqlite3_stmt *stmt = NULL;
+   /* lease_expiry is NOT NULL DEFAULT '' (schema.sql), so '' reliably means
+    * "never leased" (not stale) and the != '' filter needs no NULL handling. */
    static const char *sql =
        "SELECT work_item_id FROM workflow_binding "
        "WHERE lease_expiry != '' AND lease_expiry < datetime('now') ORDER BY lease_expiry ASC";

--- a/src/db1/wfe_binding.c
+++ b/src/db1/wfe_binding.c
@@ -107,6 +107,83 @@ int db1_wfe_binding_get(const char *session_id, char *wi_out, size_t wi_n, char 
    return found;
 }
 
+int db1_wfe_lease_renew(const char *session_id, int ttl_secs)
+{
+   if (!session_id || !session_id[0])
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+   sqlite3_stmt *stmt = NULL;
+   /* ttl==0 -> clear the lease (store '', never stale); else lease_expiry :=
+    * now + ttl_secs. A negative ttl sets a PAST expiry (immediately stale) -- used
+    * to force expiry (tests / an explicit orphan). Modifier built in C so the value
+    * is a bound param, not string-concatenated SQL. */
+   char mod[32];
+   snprintf(mod, sizeof mod, "%+d seconds", ttl_secs);
+   static const char *sql = "UPDATE workflow_binding SET lease_expiry="
+                            "CASE WHEN ?2 = 0 THEN '' ELSE datetime('now', ?3) END "
+                            "WHERE aimee_session_id=?1";
+   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(stmt, 1, session_id, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_int(stmt, 2, ttl_secs);
+   sqlite3_bind_text(stmt, 3, mod, -1, SQLITE_TRANSIENT);
+   int rc = (sqlite3_step(stmt) == SQLITE_DONE) ? 0 : -1;
+   sqlite3_finalize(stmt);
+   return rc;
+}
+
+int db1_wfe_lease_expiry_get(const char *session_id, char *out, size_t n)
+{
+   if (out && n)
+      out[0] = '\0';
+   if (!session_id || !session_id[0])
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+   sqlite3_stmt *stmt = NULL;
+   static const char *sql = "SELECT lease_expiry FROM workflow_binding WHERE aimee_session_id=?1";
+   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(stmt, 1, session_id, -1, SQLITE_TRANSIENT);
+   int found = 0;
+   if (sqlite3_step(stmt) == SQLITE_ROW)
+   {
+      found = 1;
+      const char *e = (const char *)sqlite3_column_text(stmt, 0);
+      if (out && n)
+         snprintf(out, n, "%s", e ? e : "");
+   }
+   sqlite3_finalize(stmt);
+   return found;
+}
+
+int db1_wfe_lease_stale_work_items(char (*out)[80], int max)
+{
+   if (!out || max <= 0)
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+   sqlite3_stmt *stmt = NULL;
+   static const char *sql =
+       "SELECT work_item_id FROM workflow_binding "
+       "WHERE lease_expiry != '' AND lease_expiry < datetime('now') ORDER BY lease_expiry ASC";
+   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+      return -1;
+   int n = 0;
+   while (n < max && sqlite3_step(stmt) == SQLITE_ROW)
+   {
+      const char *wi = (const char *)sqlite3_column_text(stmt, 0);
+      snprintf(out[n], 80, "%s", wi ? wi : "");
+      n++;
+   }
+   sqlite3_finalize(stmt);
+   return n;
+}
+
 int db1_wfe_unbind(const char *session_id)
 {
    if (!session_id || !session_id[0])

--- a/src/db1/wfe_binding.h
+++ b/src/db1/wfe_binding.h
@@ -27,6 +27,26 @@ extern "C"
     * error. */
    int db1_wfe_unbind(const char *session_id);
 
+   /* ---- sliding-window lease (S2 step 6 watchdog) ----
+    * The lease tracks freshness so a work-item bound but idle (no MEANINGFUL
+    * advance) can be detected. lease_expiry is set forward on bind and renewed on
+    * each applied advance; a binding whose lease_expiry has passed is "stale". */
+
+   /* Renew the session's lease: lease_expiry := now + ttl_secs. Called on bind and
+    * on each applied advance (meaningful progress) -- NOT on trivial turn traffic.
+    * ttl_secs == 0 clears the lease (never stale); a NEGATIVE ttl sets a past expiry
+    * (immediately stale -- forces expiry). Returns 0, -1 on error / no binding. */
+   int db1_wfe_lease_renew(const char *session_id, int ttl_secs);
+
+   /* Read a session's lease_expiry into `out` ("" if unset). Returns 1 if the
+    * binding exists, 0 if not, -1 on error. */
+   int db1_wfe_lease_expiry_get(const char *session_id, char *out, size_t n);
+
+   /* Fill `out` (each [80]) with the work-item ids of bindings whose lease has
+    * lapsed (lease_expiry set AND < now). Returns the count written (<= max), or -1
+    * on error. Detection only -- the caller decides what to do (warn/reclaim). */
+   int db1_wfe_lease_stale_work_items(char (*out)[80], int max);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/tests/test_wfe_binding.c
+++ b/src/tests/test_wfe_binding.c
@@ -46,6 +46,7 @@ int main(void)
    assert(db1_wfe_lease_expiry_get("sess3", exp, sizeof exp) == 1);
    assert(exp[0] == '\0');
    assert(db1_wfe_lease_expiry_get("nobody", exp, sizeof exp) == 0); /* unbound */
+   assert(db1_wfe_lease_renew("nobody", 3600) == -1); /* no binding -> -1 per contract */
 
    char stale[4][80];
    /* renew forward -> has an expiry, not stale */

--- a/src/tests/test_wfe_binding.c
+++ b/src/tests/test_wfe_binding.c
@@ -40,6 +40,33 @@ int main(void)
    assert(db1_wfe_binding_get("sess1", wi, sizeof wi, st, sizeof st) == 0);
    assert(db1_wfe_bind("sess3", "wi_A", "soft") == 0); /* wi_A free -> reclaim ok */
 
+   /* ---- sliding lease (step 6 watchdog) ---- */
+   char exp[32] = "";
+   /* a fresh bind carries no lease until renewed */
+   assert(db1_wfe_lease_expiry_get("sess3", exp, sizeof exp) == 1);
+   assert(exp[0] == '\0');
+   assert(db1_wfe_lease_expiry_get("nobody", exp, sizeof exp) == 0); /* unbound */
+
+   char stale[4][80];
+   /* renew forward -> has an expiry, not stale */
+   assert(db1_wfe_lease_renew("sess3", 3600) == 0);
+   assert(db1_wfe_lease_expiry_get("sess3", exp, sizeof exp) == 1 && exp[0]);
+   assert(db1_wfe_lease_stale_work_items(stale, 4) == 0);
+
+   /* force a PAST expiry -> stale; the sweep query surfaces the work-item */
+   assert(db1_wfe_lease_renew("sess3", -60) == 0);
+   assert(db1_wfe_lease_stale_work_items(stale, 4) == 1);
+   assert(strcmp(stale[0], "wi_A") == 0);
+
+   /* renew forward again -> no longer stale */
+   assert(db1_wfe_lease_renew("sess3", 3600) == 0);
+   assert(db1_wfe_lease_stale_work_items(stale, 4) == 0);
+
+   /* clearing the lease (ttl 0) -> never stale even while bound */
+   assert(db1_wfe_lease_renew("sess3", 0) == 0);
+   assert(db1_wfe_lease_expiry_get("sess3", exp, sizeof exp) == 1 && exp[0] == '\0');
+   assert(db1_wfe_lease_stale_work_items(stale, 4) == 0);
+
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_wfe_enforce.c
+++ b/src/tests/test_wfe_enforce.c
@@ -2,6 +2,7 @@
  * per-block tool surface, surface allow-check (with the delivery gate), and the
  * rollout fail-class split. */
 #include <assert.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -94,6 +95,19 @@ int main(void)
    assert(wfe_advance_cas_ok("implement", "implement") == 1);  /* match -> advance */
    assert(wfe_advance_cas_ok("understand", "implement") == 0); /* stale -> reject */
    assert(wfe_advance_cas_ok(NULL, "implement") == -1 && wfe_advance_cas_ok("implement", "") == -1);
+
+   /* --- sliding-lease TTL (step 6) --- */
+   unsetenv("AIMEE_WORKFLOW_LEASE_TTL_SECS");
+   assert(wfe_lease_ttl_secs() == 3600); /* default */
+   setenv("AIMEE_WORKFLOW_LEASE_TTL_SECS", "120", 1);
+   assert(wfe_lease_ttl_secs() == 120);
+   setenv("AIMEE_WORKFLOW_LEASE_TTL_SECS", "0", 1);
+   assert(wfe_lease_ttl_secs() == 0); /* disable */
+   setenv("AIMEE_WORKFLOW_LEASE_TTL_SECS", "garbage", 1);
+   assert(wfe_lease_ttl_secs() == 3600); /* bad value -> default */
+   setenv("AIMEE_WORKFLOW_LEASE_TTL_SECS", "99999999", 1);
+   assert(wfe_lease_ttl_secs() == 3600); /* out of range -> default */
+   unsetenv("AIMEE_WORKFLOW_LEASE_TTL_SECS");
 
    printf("ok\n");
    return 0;

--- a/src/workflow/wfe_advance_exec.c
+++ b/src/workflow/wfe_advance_exec.c
@@ -189,6 +189,9 @@ int wfe_advance_request_run(const char *session_id, const char *args_json, char 
       return 0;
    }
 
+   /* Meaningful advance -> renew the sliding lease (step 6). Renewing ONLY here (not
+    * on refusals/replays) is deliberate: trivial turns must not hold the lease. */
+   db1_wfe_lease_renew(session_id, wfe_lease_ttl_secs());
    audit(bound_wi, actual_stage, "ok", &a, res.next_stage);
 
    cJSON *r = result_obj("ok", bound_wi);

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -70,6 +70,8 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
    if (db1_wfe_bind(session_id, id, wfe_enforce_stage_name(stage)) != 0)
       return 0;
 
+   /* Start the sliding lease (step 6 watchdog); renewed on each applied advance. */
+   db1_wfe_lease_renew(session_id, wfe_lease_ttl_secs());
    audit_bind(id, w->id, wfe_enforce_stage_name(stage));
    return 1;
 }

--- a/src/workflow/wfe_enforce.c
+++ b/src/workflow/wfe_enforce.c
@@ -3,6 +3,7 @@
 
 #include <ctype.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "wfe_externalization.h" /* wfe_is_deliver_primitive */
@@ -193,4 +194,17 @@ void wfe_enforce_user_message(wfe_enforce_stage_t stage, const char *gate, const
                verb, g, work_item_id);
    else
       snprintf(buf, n, "This change %s: it must pass %s before it can be delivered.", verb, g);
+}
+
+int wfe_lease_ttl_secs(void)
+{
+   const char *v = getenv("AIMEE_WORKFLOW_LEASE_TTL_SECS");
+   if (v && v[0])
+   {
+      char *end = NULL;
+      long n = strtol(v, &end, 10);
+      if (end && *end == '\0' && n >= 0 && n <= 604800) /* clamp to <= 7 days */
+         return (int)n;
+   }
+   return 3600; /* default: 1h idle-to-stale */
 }

--- a/src/workflow/wfe_enforce.h
+++ b/src/workflow/wfe_enforce.h
@@ -77,6 +77,12 @@ int wfe_enforce_stage_restricts(wfe_enforce_stage_t s);
 /* 1 if a denied action must be REFUSED (hard only); soft/advisory/off allow it. */
 int wfe_enforce_stage_refuses(wfe_enforce_stage_t s);
 
+/* The sliding-lease TTL in seconds (S2 step 6 watchdog): a bound work-item is
+ * "stale" once this long has elapsed since its last MEANINGFUL advance. Read from
+ * AIMEE_WORKFLOW_LEASE_TTL_SECS (a positive integer); defaults to 3600. A value of
+ * 0 disables the lease (never stale). */
+int wfe_lease_ttl_secs(void);
+
 /* Compare-and-swap guard for an interactive advance_request (consult Q1). The
  * primary's advance carries the stage it OBSERVED; the engine advances only if
  * that still matches the work-item's ACTUAL current stage. Prevents a duplicate


### PR DESCRIPTION
## Primary-as-manager S2 step 6 (increment 1) — sliding-lease staleness tracking

First increment of the step-6 lifecycle watchdog: track a bound work-item's **freshness** so one that's bound but idle (no **meaningful advance**) can be detected. Reuses the `workflow_binding.lease_expiry` column that sub-slice 2 already provisioned — **no schema change**.

### What's here
- **`db1_wfe_lease_renew(session, ttl)`**: `lease_expiry := now + ttl` (`ttl==0` clears → never stale; a **negative** ttl forces a past/stale expiry, for reclaim/tests). Plus `db1_wfe_lease_expiry_get` and `db1_wfe_lease_stale_work_items(out, max)` (surfaces lapsed leases — **detection only**).
- **`wfe_lease_ttl_secs()`** (pure): `AIMEE_WORKFLOW_LEASE_TTL_SECS`, default 3600, `0` = disabled, clamped ≤ 7d.
- **Renew on BIND** (`wfe_bind_ingress`) and on each **applied advance** (`wfe_advance_exec`) — **not** on refusals/replays, so trivial turns can't hold the lease (consult #12: slide on *meaningful* advance, not turn traffic).

### Scope / safety
- **Detection layer only.** The sweep surfaces stale work-items; **auto-reclaim** (which would fail *open* by unbinding a session) + **resume-with-auth** + **reject-scope-add** are increment 2.
- **Default-off**: no lease exists unless a session binds, which requires the dial.

### Verification
- Unit tests: lease renew / expiry / stale-query (real DB1) + the TTL parser (pure). Regressions green; production `aimee-server` links; full `make lint` clean (docs/gen regenerated for the new env var).
