### PR TITLE
fix(audit): repair testing after S2 merge (clang-format-19 + test link)

### DIFF
--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -1194,7 +1194,7 @@ static int is_write_intent(const char *tool_name, cJSON *root)
 }
 
 int pre_tool_check_inner(const char *tool_name, const char *input_json, session_state_t *state,
-                   const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
+                         const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len)
 {
    if (!tool_name || !input_json || !state)
       return 0;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -30,7 +30,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/mcp_client.o $(OBJDIR)/server/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
-	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_action_audit.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
+	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_action_audit.o $(OBJDIR)/audit_action.o $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
                              $(OBJDIR)/branch_ownership.o \
                              $(OBJDIR)/dstr.o $(OBJDIR)/diff.o \
                              $(OBJDIR)/server/web_search.o \


### PR DESCRIPTION
#952 merged at 9f26222 (before the trailing fix commits), leaving `testing` red on **lint** (clang-format) and **unit-tests** (undefined `audit_args_hash`/`wfe_sha256_raw`).

- clang-format-19 the `pre_tool_check_inner` signature continuation (CI pins **clang-format-19**).
- Add `audit_action.o` + `workflow/wfe_canonical.o` to the `unit-test-agent` link list.

Verified locally with clang-format-19 and production builds of `unit-test-agent`, `unit-test-agent-apikey`, and `aimee-server`. Repairs testing.