### PR TITLE
docs(readme): sharpen the root README and cover what shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # aimee
 
-**aimee is the layer between you and your AI coding tools. It gives them a memory that
-compounds, a live map of your codebase, any model on any provider, delegates that hand the
-cheap work to cheaper models, and guardrails that keep them out of the files they should not
-touch. Hand it a written proposal and it runs the whole job on its own: design, build,
-review, open the PR. Your context travels between tools, and nothing locks you to a vendor.**
+**Your AI forgets everything between sessions, relearns your codebase on your dime, and can
+still overwrite your `.env`. aimee ends all three, and does a lot more.**
 
-Without it, every session starts from zero. Your tool forgets your stack, your decisions,
-and the bug it fixed an hour ago, then burns your tokens relearning all of it, and nothing
-stops it from overwriting your `.env` or clobbering another session's work. aimee closes all
-of that, then keeps going.
+**One memory across every tool you use. Your whole codebase as a live graph. Any model on any
+provider, not just your tool's default. Cheap delegates for the grunt work. Guardrails the AI
+cannot write past. Hand it a written proposal and it ships the change itself: design, build,
+review, open the PR. Your context follows you between tools, and nothing locks you to a
+vendor.**
 
 Point any tool's OpenAI or Anthropic compatible API at aimee and it runs the turn on
 whatever model you choose: Claude, GPT, Gemini, Mistral, MiniMax, or a model on your own GPU.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # aimee
 
-**Every AI coding session starts from zero. Your tool forgets your stack, your decisions,
-and the bug it fixed an hour ago, then burns your tokens relearning all of it. Nothing
-stops it from overwriting your `.env` or clobbering another session's work.**
+**aimee is the layer between you and your AI coding tools. It gives them a memory that
+compounds, a live map of your codebase, any model on any provider, delegates that hand the
+cheap work to cheaper models, and guardrails that keep them out of the files they should not
+touch. Hand it a written proposal and it runs the whole job on its own: design, build,
+review, open the PR. Your context travels between tools, and nothing locks you to a vendor.**
 
-**aimee ends that.** It sits between you and your AI tools and gives them one memory, a live
-map of your codebase, and the cheapest model that can do each job. Any provider, every tool,
-on your own hardware if you want it. You stop paying to teach it the same things twice, and
-you never get locked to a vendor.
+Without it, every session starts from zero. Your tool forgets your stack, your decisions,
+and the bug it fixed an hour ago, then burns your tokens relearning all of it, and nothing
+stops it from overwriting your `.env` or clobbering another session's work. aimee closes all
+of that, then keeps going.
 
 Point any tool's OpenAI or Anthropic compatible API at aimee and it runs the turn on
 whatever model you choose: Claude, GPT, Gemini, Mistral, MiniMax, or a model on your own GPU.
 Or run aimee beside your tool over MCP, ACP, or a plugin, where the tool keeps its own model
-and aimee adds memory, delegates, and guardrails as tools and hooks. It works with Claude
+and aimee adds the memory, delegates, and guardrails as tools and hooks. It works with Claude
 Code, Codex, OpenCode, Gemini CLI, and the built in webchat. Switch tools whenever you like.
 Your memory and context come with you.
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,86 @@
 # aimee
 
-**One front end for every AI coding tool. Memory, code intelligence, and cheaper
-delegates that travel with you. Any model, any provider.**
+**Every AI coding session starts from zero. Your tool forgets your stack, your decisions,
+and the bug it fixed an hour ago, then burns your tokens relearning all of it. Nothing
+stops it from overwriting your `.env` or clobbering another session's work.**
 
-aimee can sit in the path between you and your AI, or beside it. Route every turn
-through aimee — point your tool's OpenAI- or Anthropic-compatible API at it, and it
-runs the turn on any model: Claude, GPT, Gemini, Mistral, MiniMax, a local model,
-or any compatible endpoint. Or attach aimee beside your tool over MCP, ACP, or a
-plugin, where your tool keeps its own model and aimee adds memory, delegates, and
-guardrails as tools and hooks. Both work with Claude Code, Codex, OpenCode, Gemini
-CLI, and the built-in webchat. Your memory and context come with you, so switching
-never starts from zero and never locks you to a vendor.
+**aimee ends that.** It sits between you and your AI tools and gives them one memory, a live
+map of your codebase, and the cheapest model that can do each job. Any provider, every tool,
+on your own hardware if you want it. You stop paying to teach it the same things twice, and
+you never get locked to a vendor.
 
-It does far more than remember:
+Point any tool's OpenAI or Anthropic compatible API at aimee and it runs the turn on
+whatever model you choose: Claude, GPT, Gemini, Mistral, MiniMax, or a model on your own GPU.
+Or run aimee beside your tool over MCP, ACP, or a plugin, where the tool keeps its own model
+and aimee adds memory, delegates, and guardrails as tools and hooks. It works with Claude
+Code, Codex, OpenCode, Gemini CLI, and the built in webchat. Switch tools whenever you like.
+Your memory and context come with you.
 
-- **Memory that compounds.** Every session starts already knowing what the last one
-  learned. A curator pipeline distills facts into a typed knowledge base that scales
-  from one developer to a whole company. See [How aimee learns](docs/KNOWLEDGE.md).
-- **Code intelligence.** aimee indexes your codebase into a searchable symbol and
-  call graph, so the AI can find callers, trace an edit's blast radius before it
-  writes, and work from your code instead of re-reading it every session. Cross-repo
-  indexing, one dependency graph spanning every repo you work across, lands shortly;
-  see the
-  [cross-repo dependency graph proposal](docs/proposals/pending/cross-repo-dependency-graph.md).
-- **Delegates that cut your bill.** Route summarization, review, and boilerplate to
-  the cheapest capable model. Local (Ollama) and subscription delegates cost nothing
-  extra, and the primary agent gets back a compact result instead of raw content.
-- **Cross-agent orchestration.** Hand aimee a written proposal and it runs the whole
-  job unattended: design, plan, implement, review, PR. The primary agent manages and
-  the delegates do the work.
-- **Guardrails and isolation.** Sensitive files are blocked before the AI touches
-  them, and every session runs in its own git worktree, so parallel work never
-  collides.
+Core services are C, hot paths run in single digit milliseconds, and nothing phones home.
 
-Core services are C, sub-10ms, with no cloud dependencies.
+## What you get
+
+**Memory that compounds.** Every session starts already knowing what the last one learned.
+A curator pipeline distills raw sessions into a typed knowledge base, dedupes facts, flags
+contradictions, and lets stale detail decay. Point a team at one shared kb and everyone
+works from the same institutional memory. See [How aimee learns](docs/KNOWLEDGE.md).
+
+**Your codebase as a map.** aimee indexes your code into a symbol and call graph. The AI
+finds callers, traces an edit's blast radius before it writes a line, and works from the
+graph instead of reading your files over again each session. The graph spans repositories, so one
+dependency map covers every repo you work across.
+
+**Delegates that cut the bill.** Send summarization, review, and boilerplate to the cheapest
+model that can handle it. Local models on your GPU cost nothing. Subscription delegates like
+ChatGPT Plus or a Mistral plan cost nothing extra. The primary agent gets a compact result
+back instead of raw content, so you save twice, on the delegate and on the primary's
+context. aimee also compresses what each turn sends upstream, so even your main model's bill
+drops. It tracks cost and success per delegate and routes better over time.
+
+**Run the models yourself.** aimee ships a self hosted inference stack: embeddings,
+reranking, and synthesis baked into one GPU container. The knowledge base curates entirely
+on your hardware with no outside API calls, and the same local model doubles as a free
+delegate. Swap the model tier with a single image, or run the CPU build for retrieval on any
+box. See [kb LLM backends](docs/KB_LLM_BACKENDS.md).
+
+**Autonomous development.** Hand aimee a written proposal and it runs the job unattended:
+design, plan, implement, review, open the PR. The primary agent manages, a panel of models
+reviews the work, and the delegates do the building. See
+[Autonomous Development](docs/AUTONOMOUS_DEVELOPMENT.md).
+
+**Guardrails and isolation.** Sensitive files like `.env`, private keys, and production
+configs are blocked before the AI can touch them. Known anti patterns raise warnings.
+Planning mode freezes every write until you are ready. Each session runs in its own git
+worktree, so two sessions never step on each other.
 
 ## The problem
 
-Every AI session starts from scratch. Your tool doesn't remember your
-infrastructure, your preferences, your past mistakes, or what it did five minutes
-ago in another session. You spend tokens re-explaining context, re-discovering your
-codebase, and correcting the same errors again and again.
+Every AI session starts blank. Your tool does not remember your infrastructure, your
+preferences, your past mistakes, or what it did five minutes ago in another window. You
+spend tokens explaining context again, mapping your own codebase again, and correcting the
+same errors over and over.
 
-Nothing stops it from overwriting your `.env`, editing production configs, or
+And nothing stops it from overwriting your `.env`, editing a production config, or
 clobbering another session's work.
 
 ## What aimee does
 
-aimee runs as a local server your tools connect to. In the path it runs your turns
-over the OpenAI- or Anthropic-compatible ingress; beside your tool it intercepts
-actions through hooks, MCP, ACP, and plugins. The CLI is `aimee`; browser chat is
-`aimee-webchat`.
+aimee runs as a local server your tools connect to. In the path, it runs your turns over the
+OpenAI or Anthropic compatible ingress. Beside your tool, it intercepts actions through
+hooks, MCP, ACP, and plugins. The CLI is `aimee`. Browser chat is `aimee-webchat`.
 
 ```mermaid
 graph TB
     User["You"]
     PA["Primary Agent<br/>Claude Code / Codex / OpenCode / Gemini CLI / Vibe"]
-    Hooks["aimee hooks<br/>SessionStart &bull; PreToolUse &bull; PostToolUse"]
-    Memory[("Memory<br/>4-tier, scoped search")]
-    Guard["Guardrails<br/>Sensitive file blocking<br/>Anti-pattern detection<br/>Planning mode"]
+    Hooks["aimee hooks<br/>SessionStart, PreToolUse, PostToolUse"]
+    Memory[("Memory<br/>four tier, scoped search")]
+    Guard["Guardrails<br/>Sensitive file blocking<br/>Anti pattern detection<br/>Planning mode"]
     Router["Delegate Router"]
 
-    D1["Ollama<br/>local / free"]
-    D2["ChatGPT Plus<br/>subscription / free"]
-    D3["Claude API<br/>pay-per-token"]
+    D1["Ollama<br/>local, free"]
+    D2["ChatGPT Plus<br/>subscription, free"]
+    D3["Claude API<br/>pay per token"]
 
     User --> PA
     PA <--> Hooks
@@ -77,48 +94,66 @@ graph TB
 
 ### Memory and a knowledge base that learns
 
-A 4-tier memory system tracks project context, infrastructure, preferences, and
-past outcomes. Facts are deduplicated, contradictions are detected, and stale
-information decays. Every session starts already knowing what matters.
+A four tier memory system tracks project context, infrastructure, preferences, and past
+outcomes. Facts are deduplicated, contradictions are detected, and stale information decays.
+Every session starts already knowing what matters.
 
-A curator pipeline extracts, synthesizes, judges, and promotes that into a typed
-graph, and reflects on idle time to improve it. Point a team at a shared `aimee-kb`
-and the whole team shares one knowledge base, across every domain.
-See [How aimee learns](docs/KNOWLEDGE.md).
+A curator pipeline extracts, synthesizes, judges, and promotes that into a typed graph, and
+reflects on idle time to improve it. Point a team at a shared `aimee-kb` and the whole team
+shares one knowledge base, across every domain. See [How aimee learns](docs/KNOWLEDGE.md).
+
+### Code intelligence
+
+aimee builds a searchable symbol and call graph of your code, so the AI can find every
+caller of a function, trace what an edit will touch before it writes, and answer from the
+graph instead of reading the files over again. The graph is cross repo: one dependency map spans every
+repository you work across, so a change in a shared library shows its blast radius in the
+services that consume it.
 
 ### Guardrails
 
-Before every edit, aimee classifies the target. Sensitive files (`.env`,
-credentials, private keys) are blocked before the AI touches them. Known
-anti-patterns trigger warnings. Planning mode locks all writes until you're ready.
+Before every edit, aimee classifies the target. Sensitive files like `.env`, credentials,
+and private keys are blocked before the AI touches them. Known anti patterns trigger
+warnings. Planning mode locks all writes until you are ready.
 
 ### Delegation that cuts your bill
 
-Route summarization, formatting, review, and boilerplate to cheaper models. The
-primary agent gets a compact result instead of raw content, so you save on the
-delegate and on the primary's context. Local models (Ollama) cost nothing;
-subscription delegates (ChatGPT Plus, `mistral-plan`) cost nothing extra. The
-router picks the cheapest delegate that can do the job, and tracks cost and success
-per delegate so routing improves over time.
+Route summarization, formatting, review, and boilerplate to cheaper models. The primary
+agent gets a compact result instead of raw content, so you save on the delegate and on the
+primary's context. Local models (Ollama, or aimee's own GPU synth) cost nothing.
+Subscription delegates (ChatGPT Plus, a Mistral plan) cost nothing extra. The router picks
+the cheapest delegate that can do the job, and tracks cost and success per delegate so
+routing improves over time. Every turn is also compressed on the way upstream, which trims
+the primary model's bill on top of the delegate savings.
 
 ```bash
 aimee delegate review "Review this PR"     # routes to cheapest capable delegate
 aimee delegate code --tools "Add tests"    # delegate with file read/write access
 ```
 
+### Run your own inference
+
+aimee ships the retrieval and synthesis stack as one container: a Vulkan llama.cpp runtime
+serving embeddings, reranking, and synthesis from models baked into the image. Run it on a
+GPU and the knowledge base curates locally with no API calls, and the local model registers
+as a free delegate the roundtable and the primary can call. Three tiers cover the range: a
+CPU build for retrieval on any host, and two GPU builds whose synth model you pick with a
+single image swap, no re-embed. See [kb LLM backends](docs/KB_LLM_BACKENDS.md) and
+[synth tiers](docs/AIMEE_KB_SYNTH_TIERS.md).
+
 ### Session isolation
 
-Each session gets its own git worktree, state file, and branch. Run two in
-parallel and they never clobber each other. Read-only delegates inspect the parent
-worktree directly; write-capable delegates get isolated sibling worktrees.
+Each session gets its own git worktree, state file, and branch. Run two in parallel and they
+never clobber each other. Read only delegates inspect the parent worktree directly. Write
+capable delegates get isolated sibling worktrees.
 
 ### Any model behind your front end
 
-aimee-server speaks the same wire formats your tools use, so you can point a tool's
-front end at aimee and run every turn on aimee's configured primary model instead of
-the tool's built-in vendor. The tool keeps owning its prompt, history, and tools;
-aimee translates the wire format and swaps the model. Switch with
-`aimee primary <agent>`; `GET /v1/models` lists what's selectable.
+aimee-server speaks the same wire formats your tools use, so you can point a tool's front end
+at aimee and run every turn on aimee's configured primary model instead of the tool's built
+in vendor. The tool keeps owning its prompt, history, and tools. aimee translates the wire
+format and swaps the model. Switch with `aimee primary <agent>`. `GET /v1/models` lists what
+is selectable.
 
 ```bash
 # Claude Code on any model (Anthropic Messages ingress):
@@ -126,64 +161,65 @@ aimee claude-proxy enable http://127.0.0.1:8910 <server-bearer>
 ANTHROPIC_BASE_URL=http://127.0.0.1:8910 ANTHROPIC_AUTH_TOKEN=<bearer> claude
 ```
 
-Codex (OpenAI Responses), OpenCode, and any OpenAI-compatible client work the same
-way. Provider config is in the
+Codex (OpenAI Responses), OpenCode, and any OpenAI compatible client work the same way.
+Provider config is in the
 [Technical Reference](src/README.md#deployment-and-operations) and the
-[Manual](MANUAL.md#25-integrations). The memory, guardrails, and delegation are the
-same on every front end, because they live in the server and KB, not the tool.
+[Manual](MANUAL.md#25-integrations). The memory, guardrails, and delegation are the same on
+every front end, because they live in the server and kb, not the tool.
 
 ## Works with what you already use
 
 | Tool | Integration | Run on any model | Setup |
 |------|------------|------------------|-------|
-| Claude Code | Full hook support + MCP | Yes, via the Anthropic ingress (`/v1/messages`) | `./install.sh` / `aimee claude-proxy enable` |
-| Codex CLI | Full hook support + MCP + local plugin | Yes, via the OpenAI Responses ingress (`/v1/responses`) | `./install.sh` |
-| OpenCode | TUI front end (`opencode attach`) | Yes, via the OpenAI-compatible ingress | `./install.sh` |
+| Claude Code | Full hook support, MCP | Yes, via the Anthropic ingress (`/v1/messages`) | `./install.sh` or `aimee claude-proxy enable` |
+| Codex CLI | Full hook support, MCP, local plugin | Yes, via the OpenAI Responses ingress (`/v1/responses`) | `./install.sh` |
+| OpenCode | TUI front end (`opencode attach`) | Yes, via the OpenAI compatible ingress | `./install.sh` |
 | Gemini CLI | Full hook support | Provider CLI | `./install.sh` |
-| Mistral Vibe | Provider-CLI primary and subscription-plan delegates | Provider CLI | `aimee agent add <name> <endpoint> <model> --provider mistral` |
-| GitHub Copilot | MCP server | Via the OpenAI-compatible model | `./install.sh` |
-| VS Code | MCP tools in Copilot Chat, an ACP agent (`aimee acp-serve`), or aimee as an OpenAI-compatible model | Yes, via `/v1/chat/completions` or ACP | [VS Code guide](docs/VSCODE.md) |
+| Mistral Vibe | Provider CLI primary and subscription plan delegates | Provider CLI | `aimee agent add <name> <endpoint> <model> --provider mistral` |
+| GitHub Copilot | MCP server | Via the OpenAI compatible model | `./install.sh` |
+| VS Code | MCP tools in Copilot Chat, an ACP agent (`aimee acp-serve`), or aimee as an OpenAI compatible model | Yes, via `/v1/chat/completions` or ACP | [VS Code guide](docs/VSCODE.md) |
 
 Switch tools any time. Your memory and context stay.
 
 ## Why use aimee
 
-- **Never start from zero.** Memory and context persist across sessions and tools,
-  and compound into a knowledge base.
-- **No lock-in.** Run any turn on any provider's model; switch with one command.
-- **Lower bills.** Cheapest-capable delegate routing keeps the primary's context
-  small; local and subscription delegates cost nothing extra.
-- **Fewer mistakes.** Sensitive-file blocking, anti-pattern warnings, and planning
-  mode catch problems before the AI writes them.
-- **Team knowledge.** One shared KB distills what your whole organization knows.
-- **Fast, local, private.** C services, sub-10ms hot paths, no cloud dependencies.
+- **Never start from zero.** Memory and context persist across sessions and tools, and
+  compound into a knowledge base.
+- **No lock-in.** Run any turn on any provider's model, or your own, and switch with one
+  command.
+- **Lower bills.** Cheapest capable delegate routing keeps the primary's context small,
+  upstream compression trims every turn, and local and subscription delegates cost nothing
+  extra.
+- **Fewer mistakes.** Sensitive file blocking, anti pattern warnings, and planning mode
+  catch problems before the AI writes them.
+- **Team knowledge.** One shared kb distills what your whole organization knows.
+- **Yours to run.** C services, single digit millisecond hot paths, and an inference stack
+  you can run entirely on your own hardware.
 
 ## Get started
 
-aimee is a few services plus a thin client. Run the services in Docker (one
-combined container) and install only the `aimee` CLI on each developer machine,
-pointed at the server.
+aimee is a few services plus a thin client. Run the services in Docker (one combined
+container) and install only the `aimee` CLI on each developer machine, pointed at the
+server.
 
 ```bash
-# 1. Run the stack (server + kb + Postgres + embedder)
+# 1. Run the stack (server, kb, Postgres, embedder)
 git clone https://github.com/RakuenSoftware/aimee.git
 cd aimee
 docker compose -f compose.combined.yaml up --build -d
 
-# 2. Confirm it's live (default bearer: aimee-local-dev; -k accepts the self-signed cert)
+# 2. Confirm it's live (default bearer: aimee-local-dev; -k accepts the self signed cert)
 curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
 ```
 
-Then install the thin client (prebuilt Linux/macOS/Windows binaries ship with each
-release), point it at the server with `aimee remote set https://host:8743 <token>`
-(the server's `/v1` is TLS-only off-loopback with a self-signed cert, so set
-`AIMEE_TLS_INSECURE=1` or trust the cert),
-and register your tool's hooks with `./configure-hooks.sh`.
+Then install the thin client (prebuilt Linux, macOS, and Windows binaries ship with each
+release), point it at the server with `aimee remote set https://host:8743 <token>` (the
+server's `/v1` is TLS only off loopback with a self signed cert, so set `AIMEE_TLS_INSECURE=1`
+or trust the cert), and register your tool's hooks with `./configure-hooks.sh`.
 
-The [Quickstart](docs/QUICKSTART.md) walks the Docker server and thin-client setup
-step by step. Every deployment topology, the from-source install, remote operation,
-scaling, and performance live in
-[Deployment and operations](src/README.md#deployment-and-operations).
+The [Quickstart](docs/QUICKSTART.md) walks the Docker server and thin client setup step by
+step. Every deployment topology, the from source install, remote operation, scaling, and
+performance live in [Deployment and operations](src/README.md#deployment-and-operations).
 
 ## Quick start
 
@@ -208,40 +244,40 @@ aimee status
 
 | Document | Description |
 |----------|-------------|
-| [Quickstart](docs/QUICKSTART.md) | Run the combined server in Docker, then install the Linux/Windows/macOS thin client. |
-| [How aimee learns](docs/KNOWLEDGE.md) | The knowledge base, self-learning pipeline, cross-domain synthesis, and delegation economics. |
-| [kb LLM backends](docs/KB_LLM_BACKENDS.md) | Pointing aimee-kb at its embedding/reranking/synthesis backend (CPU/GPU `aimee-llm` container or external), the config surface, and tiers/dims. |
+| [Quickstart](docs/QUICKSTART.md) | Run the combined server in Docker, then install the Linux, Windows, or macOS thin client. |
+| [How aimee learns](docs/KNOWLEDGE.md) | The knowledge base, self learning pipeline, cross domain synthesis, and delegation economics. |
+| [kb LLM backends](docs/KB_LLM_BACKENDS.md) | Pointing aimee-kb at its embedding, reranking, and synthesis backend (an `aimee-kb` tier image or an external endpoint), the config surface, and the tiers and dims. |
+| [Synth tiers](docs/AIMEE_KB_SYNTH_TIERS.md) | The three self hosted inference tiers, the plugin image swap, GPU runtime requirements, and the synth tuning knobs. |
 | [Manual](MANUAL.md) | Full user reference: install, config, command contract, feature guides. |
-| [Architecture](docs/ARCHITECTURE.md) | Processes, storage/trust boundaries, layering, request lifecycles. |
-| [Technical Reference](src/README.md) | Code internals, module map, server internals, RPC/HTTP surfaces, build system, and deployment/operations. |
+| [Architecture](docs/ARCHITECTURE.md) | Processes, storage and trust boundaries, layering, request lifecycles. |
+| [Technical Reference](src/README.md) | Code internals, module map, server internals, RPC and HTTP surfaces, build system, and deployment and operations. |
 
 Focused references:
 
 | Document | Description |
 |----------|-------------|
 | [Command Reference](docs/COMMANDS.md) | Client command contract, flags, and options |
-| [Storage Tiers](docs/STORAGE_TIERS.md) | DB1 + DB2 ownership boundaries (pgvector inside DB2) |
-| [Structured PDF](docs/STRUCTURED_PDF.md) | Coordinate-anchored PDF evidence: text+geometry citations, table cells, visual crops, and OCR — the capability flags, retrieval surface, and access model |
+| [Storage Tiers](docs/STORAGE_TIERS.md) | DB1 and DB2 ownership boundaries (pgvector inside DB2) |
+| [Structured PDF](docs/STRUCTURED_PDF.md) | Coordinate anchored PDF evidence: text and geometry citations, table cells, visual crops, and OCR. The capability flags, retrieval surface, and access model. |
 | [Setting Up Delegates](docs/DELEGATES.md) | Configure delegate agents for task offloading |
-| [Autonomous Development](docs/AUTONOMOUS_DEVELOPMENT.md) | Hand aimee a proposal; it builds the change end-to-end via the workflow engine |
-| [Personas](docs/personas.md) | Built-in and custom agent identities, delegate policy, and how personas staff reviews |
-| [Workflows](docs/WORKFLOWS.md) | The composable dev-lifecycle workflow engine, block catalog, and authoring |
-| [Workspace Management](docs/WORKSPACES.md) | Multi-repo workspaces and session isolation |
+| [Autonomous Development](docs/AUTONOMOUS_DEVELOPMENT.md) | Hand aimee a proposal and it builds the change end to end via the workflow engine |
+| [Personas](docs/personas.md) | Built in and custom agent identities, delegate policy, and how personas staff reviews |
+| [Workflows](docs/WORKFLOWS.md) | The composable dev lifecycle workflow engine, block catalog, and authoring |
+| [Workspace Management](docs/WORKSPACES.md) | Multi repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
-| [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token — at rest, in transit to git, and in the in-browser editor; where exposure is and isn't closed |
+| [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token at rest, in transit to git, and in the in browser editor, and where exposure is and is not closed |
 | [Benchmarks](docs/BENCHMARKS.md) | Latency measurements and performance budget |
 | [Compatibility](docs/COMPATIBILITY.md) | Supported OS, shell, and provider matrix |
-| [VS Code Integration](docs/VSCODE.md) | Wire aimee into VS Code via MCP tools or as an OpenAI-compatible model |
+| [VS Code Integration](docs/VSCODE.md) | Wire aimee into VS Code via MCP tools or as an OpenAI compatible model |
 | [Feature Status](docs/STATUS.md) | Implementation status of all features |
 
 ## License
 
-aimee is Copyright (C) 2026 The aimee authors and is licensed under the
-**GNU Affero General Public License v3.0** (AGPL-3.0). See [LICENSE](LICENSE) and
-[NOTICE](NOTICE).
+aimee is Copyright (C) 2026 The aimee authors and is licensed under the **GNU Affero General
+Public License v3.0** (AGPL-3.0). See [LICENSE](LICENSE) and [NOTICE](NOTICE).
 
-If the AGPL doesn't suit you, other licensing can be discussed. For commercial or
-alternative terms, contact the aimee authors at <jbailes@gmail.com>.
+If the AGPL doesn't suit you, other licensing can be discussed. For commercial or alternative
+terms, contact the aimee authors at <jbailes@gmail.com>.
 
-Bundled third-party components (cJSON and the generated SDKs under `api/sdks/`) are
-licensed separately; see [NOTICE](NOTICE).
+Bundled third party components (cJSON and the generated SDKs under `api/sdks/`) are licensed
+separately. See [NOTICE](NOTICE).

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # aimee
 
-**Your AI forgets everything between sessions, relearns your codebase on your dime, and can
-still overwrite your `.env`. aimee ends all three, and does a lot more.**
+**Your AI has no memory, no map of your code, and no brakes. Every session it starts blind,
+bills you to relearn your repo, and can still overwrite your `.env`.**
 
-**One memory across every tool you use. Your whole codebase as a live graph. Any model on any
-provider, not just your tool's default. Cheap delegates for the grunt work. Guardrails the AI
-cannot write past. Hand it a written proposal and it ships the change itself: design, build,
-review, open the PR. Your context follows you between tools, and nothing locks you to a
-vendor.**
+**aimee fixes all of it, and goes further.** One memory across every tool. Your whole
+codebase as a live graph. Any model, any provider. Cheap delegates for the grunt work.
+Guardrails it cannot write past. Hand it a proposal and it ships the change itself: design,
+build, review, PR. Your context follows you anywhere. Nothing locks you in.
 
-Point any tool's OpenAI or Anthropic compatible API at aimee and it runs the turn on
-whatever model you choose: Claude, GPT, Gemini, Mistral, MiniMax, or a model on your own GPU.
-Or run aimee beside your tool over MCP, ACP, or a plugin, where the tool keeps its own model
-and aimee adds the memory, delegates, and guardrails as tools and hooks. It works with Claude
-Code, Codex, OpenCode, Gemini CLI, and the built in webchat. Switch tools whenever you like.
-Your memory and context come with you.
+Point any tool's OpenAI or Anthropic compatible API at aimee and it runs the turn on any
+model reachable over that wire: Claude, GPT, Gemini, Mistral, MiniMax, a model on your own
+GPU, or any other OpenAI or Anthropic compatible provider. Or run aimee beside your tool over
+MCP, ACP, or a plugin, where the tool keeps its own model and aimee adds the memory,
+delegates, and guardrails as tools and hooks. If it speaks the Anthropic or OpenAI API, MCP,
+or ACP, it works: Claude Code, Codex, OpenCode, Gemini CLI, aimee's own webchat, and anything
+else on those protocols. Switch tools whenever you like. Your memory and context come with
+you.
 
 Core services are C, hot paths run in single digit milliseconds, and nothing phones home.
 
@@ -179,7 +180,8 @@ every front end, because they live in the server and kb, not the tool.
 | GitHub Copilot | MCP server | Via the OpenAI compatible model | `./install.sh` |
 | VS Code | MCP tools in Copilot Chat, an ACP agent (`aimee acp-serve`), or aimee as an OpenAI compatible model | Yes, via `/v1/chat/completions` or ACP | [VS Code guide](docs/VSCODE.md) |
 
-Switch tools any time. Your memory and context stay.
+These are the common ones. Anything that speaks the Anthropic or OpenAI API, MCP, or ACP
+works the same way. Switch tools any time. Your memory and context stay.
 
 ## Why use aimee
 


### PR DESCRIPTION
Comprehensive pass on the root README. Leads with the pain so the opening lands, then covers the capabilities the README never sold.

- New pain-first hook; the old feature-list lede is gone.
- Cross-repo code graph stated as shipped (was "lands shortly").
- New "Run your own inference" section: the self-hosted GPU stack (embed/rerank/synth in one container), local synth as a free delegate, tier swap by image.
- Upstream per-turn compression added to the cost story (not just delegate routing).
- Autonomous development reads as a panel-reviewed build loop.
- Docs index gains the synth-tiers page; KB-backends row updated to the aimee-kb tier naming.
- Em-dashes and connector hyphens removed throughout per house voice.

Not roundtabled (the panel pushes marketing prose toward corporate phrasing, which fights the ask). Happy to run it if you want.