### PR TITLE
feat(audit): S3 — governed-action ledger reader + trajectory overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,7 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/util.c
     ${AIMEE_SRC_DIR}/util_url.c
     ${AIMEE_SRC_DIR}/audit_action.c
+    ${AIMEE_SRC_DIR}/audit_ledger.c
     ${AIMEE_SRC_DIR}/report_enrichment.c
     ${AIMEE_SRC_DIR}/delivery_target.c
     ${AIMEE_SRC_DIR}/text.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -288,7 +288,7 @@ MCP_GIT_SRCS = mcp_git_query.c mcp_git_write.c mcp_git_branch.c mcp_git_pr.c git
 MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
-CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c audit_action.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
+CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c audit_action.c audit_ledger.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
             compact.c coord_closet.c fold_budget.c context_fold.c context_reduce.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \

--- a/src/audit_ledger.c
+++ b/src/audit_ledger.c
@@ -1,0 +1,131 @@
+/* audit_ledger.c: read the governed-action audit ledger. See audit_ledger.h. */
+#include "audit_ledger.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "config.h"
+#include "log.h"
+
+/* Rotation depth mirrors log.c's AUDIT_MAX_FILES (audit.log.0 .. .N). Kept as a
+ * local upper bound so the reader tolerates however many rotated files exist. */
+#define LEDGER_MAX_ROTATED 8
+#define LEDGER_MAX_ROWS    20000
+#define LEDGER_LINE_MAX    8192
+
+typedef struct
+{
+   cJSON *obj;    /* the row object (borrowed until moved into the result) */
+   char ts[40];   /* sort key 1: ISO-8601 (lexicographic) */
+   int file_rank; /* sort key 2: older file first (chronological) */
+   long offset;   /* sort key 3: line order within a file */
+} ledger_row_t;
+
+static int ts_in_window(const char *ts, const char *from_ts, const char *to_ts)
+{
+   if (from_ts && from_ts[0] && strcmp(ts, from_ts) < 0)
+      return 0;
+   if (to_ts && to_ts[0] && strcmp(ts, to_ts) > 0)
+      return 0;
+   return 1;
+}
+
+/* Read one file's tool_action rows into rows[] (bounded). file_rank orders files
+ * chronologically (older first). Returns the number of unparseable lines seen. */
+static int read_file(const char *path, int file_rank, ledger_row_t *rows, int *nrows,
+                     const char *from_ts, const char *to_ts)
+{
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return 0;
+   int bad = 0;
+   long offset = 0;
+   char line[LEDGER_LINE_MAX];
+   while (*nrows < LEDGER_MAX_ROWS && fgets(line, sizeof line, f))
+   {
+      long this_off = offset;
+      offset++;
+      if (!line[0] || line[0] == '\n')
+         continue;
+      cJSON *obj = cJSON_Parse(line);
+      if (!obj)
+      {
+         bad++;
+         continue;
+      }
+      cJSON *kind = cJSON_GetObjectItemCaseSensitive(obj, "kind");
+      cJSON *ts = cJSON_GetObjectItemCaseSensitive(obj, "ts");
+      if (!cJSON_IsString(kind) || strcmp(kind->valuestring, "tool_action") != 0 ||
+          !cJSON_IsString(ts))
+      {
+         cJSON_Delete(obj); /* legacy {event,detail} rows and others: skip quietly */
+         continue;
+      }
+      if (!ts_in_window(ts->valuestring, from_ts, to_ts))
+      {
+         cJSON_Delete(obj);
+         continue;
+      }
+      ledger_row_t *r = &rows[(*nrows)++];
+      r->obj = obj;
+      snprintf(r->ts, sizeof r->ts, "%s", ts->valuestring);
+      r->file_rank = file_rank;
+      r->offset = this_off;
+   }
+   fclose(f);
+   return bad;
+}
+
+static int cmp_row(const void *a, const void *b)
+{
+   const ledger_row_t *ra = a, *rb = b;
+   int c = strcmp(ra->ts, rb->ts);
+   if (c)
+      return c;
+   if (ra->file_rank != rb->file_rank)
+      return ra->file_rank < rb->file_rank ? -1 : 1;
+   if (ra->offset != rb->offset)
+      return ra->offset < rb->offset ? -1 : 1;
+   return 0;
+}
+
+cJSON *audit_ledger_read(const char *from_ts, const char *to_ts)
+{
+   cJSON *out = cJSON_CreateArray();
+   if (!out)
+      return NULL;
+
+   ledger_row_t *rows = calloc(LEDGER_MAX_ROWS, sizeof *rows);
+   if (!rows)
+   {
+      cJSON_Delete(out);
+      return NULL;
+   }
+   int nrows = 0;
+   int bad = 0;
+
+   const char *dir = config_default_dir();
+   char path[4096];
+
+   /* Chronological order (oldest first): audit.log.N .. audit.log.0, then the
+    * current audit.log. file_rank increases with recency so equal-ts rows keep
+    * their chronological order. */
+   int rank = 0;
+   for (int i = LEDGER_MAX_ROTATED; i >= 0; i--)
+   {
+      snprintf(path, sizeof path, "%s/audit.log.%d", dir, i);
+      bad += read_file(path, rank++, rows, &nrows, from_ts, to_ts);
+   }
+   snprintf(path, sizeof path, "%s/audit.log", dir);
+   bad += read_file(path, rank, rows, &nrows, from_ts, to_ts);
+
+   qsort(rows, (size_t)nrows, sizeof *rows, cmp_row);
+   for (int i = 0; i < nrows; i++)
+      cJSON_AddItemToArray(out, rows[i].obj); /* transfers ownership */
+   free(rows);
+
+   if (bad > 0)
+      audit_log("audit_ledger", "skipped %d unparseable audit.log line(s)", bad);
+   return out;
+}

--- a/src/audit_ledger.c
+++ b/src/audit_ledger.c
@@ -13,13 +13,15 @@
 #define LEDGER_MAX_ROTATED 8
 #define LEDGER_MAX_ROWS    20000
 #define LEDGER_LINE_MAX    8192
+/* "YYYY-MM-DDThh:mm:ssZ" is 20 bytes; fractional/extended forms fit in 40. */
+#define LEDGER_TS_MAX 40
 
 typedef struct
 {
-   cJSON *obj;    /* the row object (borrowed until moved into the result) */
-   char ts[40];   /* sort key 1: ISO-8601 (lexicographic) */
-   int file_rank; /* sort key 2: older file first (chronological) */
-   long offset;   /* sort key 3: line order within a file */
+   cJSON *obj;             /* the row object (borrowed until moved into the result) */
+   char ts[LEDGER_TS_MAX]; /* sort key 1: ISO-8601 (lexicographic) */
+   int file_rank;          /* sort key 2: older file first (chronological) */
+   long line_seq;          /* sort key 3: logical-line order within a file */
 } ledger_row_t;
 
 static int ts_in_window(const char *ts, const char *from_ts, const char *to_ts)
@@ -32,23 +34,51 @@ static int ts_in_window(const char *ts, const char *from_ts, const char *to_ts)
 }
 
 /* Read one file's tool_action rows into rows[] (bounded). file_rank orders files
- * chronologically (older first). Returns the number of unparseable lines seen. */
+ * chronologically (older first). Returns the number of unparseable lines seen;
+ * sets *truncated if the LEDGER_MAX_ROWS cap was hit. */
 static int read_file(const char *path, int file_rank, ledger_row_t *rows, int *nrows,
-                     const char *from_ts, const char *to_ts)
+                     const char *from_ts, const char *to_ts, int *truncated)
 {
    FILE *f = fopen(path, "r");
    if (!f)
       return 0;
    int bad = 0;
-   long offset = 0;
+   long seq = 0;
    char line[LEDGER_LINE_MAX];
-   while (*nrows < LEDGER_MAX_ROWS && fgets(line, sizeof line, f))
+   while (fgets(line, sizeof line, f))
    {
-      long this_off = offset;
-      offset++;
-      if (!line[0] || line[0] == '\n')
+      size_t len = strlen(line);
+      /* A record with no trailing newline that isn't EOF was longer than the
+       * buffer: drain the rest of the physical line and count it ONCE as
+       * unparseable — never parse a fragment. */
+      if ((len == 0 || line[len - 1] != '\n') && !feof(f))
+      {
+         int c;
+         while ((c = fgetc(f)) != '\n' && c != EOF)
+         {
+         }
+         bad++;
+         seq++;
          continue;
-      cJSON *obj = cJSON_Parse(line);
+      }
+      long this_seq = seq++;
+      /* Strip the trailing line-ending/whitespace so the strict parse sees only
+       * the JSON value (require_null_terminated then rejects trailing garbage
+       * without tripping on the newline). */
+      while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r' || line[len - 1] == ' ' ||
+                         line[len - 1] == '\t'))
+         line[--len] = '\0';
+      if (len == 0)
+         continue;
+      /* Cap check BEFORE parsing, so a parsed object can never be orphaned. */
+      if (*nrows >= LEDGER_MAX_ROWS)
+      {
+         *truncated = 1;
+         break;
+      }
+      /* Strict parse: require the whole line be consumed (require_null_terminated),
+       * so trailing garbage or a JSON prefix in a fragment is rejected, not accepted. */
+      cJSON *obj = cJSON_ParseWithOpts(line, NULL, 1);
       if (!obj)
       {
          bad++;
@@ -71,7 +101,7 @@ static int read_file(const char *path, int file_rank, ledger_row_t *rows, int *n
       r->obj = obj;
       snprintf(r->ts, sizeof r->ts, "%s", ts->valuestring);
       r->file_rank = file_rank;
-      r->offset = this_off;
+      r->line_seq = this_seq;
    }
    fclose(f);
    return bad;
@@ -85,8 +115,8 @@ static int cmp_row(const void *a, const void *b)
       return c;
    if (ra->file_rank != rb->file_rank)
       return ra->file_rank < rb->file_rank ? -1 : 1;
-   if (ra->offset != rb->offset)
-      return ra->offset < rb->offset ? -1 : 1;
+   if (ra->line_seq != rb->line_seq)
+      return ra->line_seq < rb->line_seq ? -1 : 1;
    return 0;
 }
 
@@ -104,6 +134,7 @@ cJSON *audit_ledger_read(const char *from_ts, const char *to_ts)
    }
    int nrows = 0;
    int bad = 0;
+   int truncated = 0;
 
    const char *dir = config_default_dir();
    char path[4096];
@@ -115,17 +146,19 @@ cJSON *audit_ledger_read(const char *from_ts, const char *to_ts)
    for (int i = LEDGER_MAX_ROTATED; i >= 0; i--)
    {
       snprintf(path, sizeof path, "%s/audit.log.%d", dir, i);
-      bad += read_file(path, rank++, rows, &nrows, from_ts, to_ts);
+      bad += read_file(path, rank++, rows, &nrows, from_ts, to_ts, &truncated);
    }
    snprintf(path, sizeof path, "%s/audit.log", dir);
-   bad += read_file(path, rank, rows, &nrows, from_ts, to_ts);
+   bad += read_file(path, rank, rows, &nrows, from_ts, to_ts, &truncated);
 
    qsort(rows, (size_t)nrows, sizeof *rows, cmp_row);
    for (int i = 0; i < nrows; i++)
-      cJSON_AddItemToArray(out, rows[i].obj); /* transfers ownership */
+      cJSON_AddItemToArray(out, rows[i].obj); /* transfers ownership (steals the pointer) */
    free(rows);
 
    if (bad > 0)
       audit_log("audit_ledger", "skipped %d unparseable audit.log line(s)", bad);
+   if (truncated)
+      audit_log("audit_ledger", "row cap %d hit; older/overflow rows omitted", LEDGER_MAX_ROWS);
    return out;
 }

--- a/src/headers/audit_ledger.h
+++ b/src/headers/audit_ledger.h
@@ -1,0 +1,34 @@
+/* audit_ledger.h: read the governed-action audit ledger (S3 of the per-action
+ * governance audit).
+ *
+ * The audit.log written by audit_action_log() (kind="tool_action") is the
+ * canonical, tamper-evident governed-action ledger. This reader makes it
+ * replayable/inspectable — the "reader-before-writer" half of the rollout, so
+ * the rows are consumable before the writer is enabled by default (S7).
+ */
+#ifndef AIMEE_AUDIT_LEDGER_H
+#define AIMEE_AUDIT_LEDGER_H 1
+
+#include "cJSON.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Read all kind="tool_action" rows from audit.log and its rotated siblings
+    * (audit.log.0 .. audit.log.N), returned as a cJSON array (caller owns via
+    * cJSON_Delete), ordered deterministically by (ts, file recency, byte offset).
+    *
+    * `from_ts`/`to_ts` bound the ISO-8601 ts inclusively; NULL/empty means
+    * unbounded on that end. Non-JSON lines and non-tool_action rows are skipped;
+    * the count of unparseable lines is logged (rate-limited) so drift is visible.
+    * Returns NULL only on allocation failure (a missing audit.log yields an empty
+    * array, not NULL). */
+   cJSON *audit_ledger_read(const char *from_ts, const char *to_ts);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AIMEE_AUDIT_LEDGER_H */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ set_tests_properties(test_context_engine PROPERTIES
 aimee_add_test(test_util test_util.c)
 aimee_add_test(test_audit_action test_audit_action.c)
 aimee_add_test(test_audit_action_log test_audit_action_log.c)
+aimee_add_test(test_audit_ledger test_audit_ledger.c)
 aimee_add_test(test_db test_db.c)
 aimee_add_test(test_config test_config.c)
 aimee_add_test(test_cron_config test_cron_config.c ../config_trigger.c)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1647,16 +1647,17 @@ $(TESTPREFIX)/unit-test-interaction-events: $(OBJDIR)/tests/test_interaction_eve
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-trajectory: $(OBJDIR)/tests/test_trajectory.o \
-                               $(OBJDIR)/trajectory_export.o \
+                               $(OBJDIR)/trajectory_export.o $(OBJDIR)/audit_ledger.o \
                                $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                $(OBJDIR)/db1/maintenance.o $(OBJDIR)/db1/interaction_events.o \
                                $(OBJDIR)/posix/memory.o \
+                               $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o $(OBJDIR)/aimee_home.o \
                                $(OBJDIR)/log.o $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/cJSON.o \
                                $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-trajectory-batch: $(OBJDIR)/tests/test_trajectory_batch.o \
-                               $(OBJDIR)/trajectory_batch.o $(OBJDIR)/trajectory_export.o \
+                               $(OBJDIR)/trajectory_batch.o $(OBJDIR)/trajectory_export.o $(OBJDIR)/audit_ledger.o \
                                $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o \
                                $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                $(OBJDIR)/db1/maintenance.o $(OBJDIR)/db1/interaction_events.o \

--- a/src/tests/test_audit_ledger.c
+++ b/src/tests/test_audit_ledger.c
@@ -1,0 +1,120 @@
+/* test_audit_ledger.c: unit tests for the S3 governed-action ledger reader.
+ * Verifies tool_action extraction, ts ordering, window filtering, rotated-file
+ * chronology, and tolerance of legacy/malformed lines. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "audit_ledger.h"
+#include "cJSON.h"
+
+static char g_home[512];
+
+static void set_home(void)
+{
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-ledger-test-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   setenv("AIMEE_HOME", g_home, 1);
+}
+
+static void write_file(const char *name, const char *content)
+{
+   char p[600];
+   snprintf(p, sizeof p, "%s/%s", g_home, name);
+   FILE *f = fopen(p, "w");
+   assert(f);
+   fputs(content, f);
+   fclose(f);
+}
+
+static const char *row_ts(cJSON *arr, int i)
+{
+   cJSON *o = cJSON_GetArrayItem(arr, i);
+   cJSON *ts = cJSON_GetObjectItemCaseSensitive(o, "ts");
+   return ts && ts->valuestring ? ts->valuestring : "";
+}
+
+static const char *row_tool(cJSON *arr, int i)
+{
+   cJSON *o = cJSON_GetArrayItem(arr, i);
+   cJSON *t = cJSON_GetObjectItemCaseSensitive(o, "tool");
+   return t && t->valuestring ? t->valuestring : "";
+}
+
+static void test_extract_order_and_skip(void)
+{
+   set_home();
+   /* Out-of-order tool_action rows + a legacy {event,detail} row + a malformed
+    * line + a non-tool_action kind. Only tool_action rows survive, ts-ordered. */
+   write_file("audit.log",
+              "{\"ts\":\"2026-07-02T10:00:03Z\",\"kind\":\"tool_action\",\"tool\":\"C\"}\n"
+              "{\"ts\":\"2026-07-02T10:00:01Z\",\"kind\":\"tool_action\",\"tool\":\"A\"}\n"
+              "{\"ts\":\"2026-07-02T09:59:59Z\",\"event\":\"read_before_write\",\"detail\":\"x\"}\n"
+              "this is not json at all\n"
+              "{\"ts\":\"2026-07-02T10:00:02Z\",\"kind\":\"tool_action\",\"tool\":\"B\"}\n"
+              "{\"ts\":\"2026-07-02T10:00:05Z\",\"kind\":\"other_kind\",\"tool\":\"Z\"}\n");
+   cJSON *arr = audit_ledger_read(NULL, NULL);
+   assert(arr && cJSON_IsArray(arr));
+   assert(cJSON_GetArraySize(arr) == 3); /* A, B, C only */
+   assert(strcmp(row_tool(arr, 0), "A") == 0);
+   assert(strcmp(row_tool(arr, 1), "B") == 0);
+   assert(strcmp(row_tool(arr, 2), "C") == 0);
+   assert(strcmp(row_ts(arr, 0), "2026-07-02T10:00:01Z") == 0);
+   cJSON_Delete(arr);
+}
+
+static void test_window_filter(void)
+{
+   set_home();
+   write_file("audit.log",
+              "{\"ts\":\"2026-07-02T10:00:01Z\",\"kind\":\"tool_action\",\"tool\":\"A\"}\n"
+              "{\"ts\":\"2026-07-02T10:00:05Z\",\"kind\":\"tool_action\",\"tool\":\"B\"}\n"
+              "{\"ts\":\"2026-07-02T10:00:09Z\",\"kind\":\"tool_action\",\"tool\":\"C\"}\n");
+   cJSON *arr = audit_ledger_read("2026-07-02T10:00:03Z", "2026-07-02T10:00:07Z");
+   assert(cJSON_GetArraySize(arr) == 1); /* only B is in [03,07] */
+   assert(strcmp(row_tool(arr, 0), "B") == 0);
+   cJSON_Delete(arr);
+}
+
+static void test_rotated_chronology(void)
+{
+   set_home();
+   /* audit.log.0 is the most recent ROTATED file (older than current); audit.log
+    * is newest. Same-second rows must order older-file-first. */
+   write_file("audit.log.1",
+              "{\"ts\":\"2026-07-02T10:00:00Z\",\"kind\":\"tool_action\",\"tool\":\"oldest\"}\n");
+   write_file("audit.log.0",
+              "{\"ts\":\"2026-07-02T10:00:00Z\",\"kind\":\"tool_action\",\"tool\":\"mid\"}\n");
+   write_file("audit.log",
+              "{\"ts\":\"2026-07-02T10:00:00Z\",\"kind\":\"tool_action\",\"tool\":\"newest\"}\n");
+   cJSON *arr = audit_ledger_read(NULL, NULL);
+   assert(cJSON_GetArraySize(arr) == 3);
+   assert(strcmp(row_tool(arr, 0), "oldest") == 0);
+   assert(strcmp(row_tool(arr, 1), "mid") == 0);
+   assert(strcmp(row_tool(arr, 2), "newest") == 0);
+   cJSON_Delete(arr);
+}
+
+static void test_missing_log_is_empty_not_null(void)
+{
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-ledger-empty-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   setenv("AIMEE_HOME", g_home, 1);
+   cJSON *arr = audit_ledger_read(NULL, NULL);
+   assert(arr && cJSON_IsArray(arr));
+   assert(cJSON_GetArraySize(arr) == 0);
+   cJSON_Delete(arr);
+}
+
+int main(void)
+{
+   test_extract_order_and_skip();
+   test_window_filter();
+   test_rotated_chronology();
+   test_missing_log_is_empty_not_null();
+   printf("test_audit_ledger: all passed\n");
+   return 0;
+}

--- a/src/tests/test_audit_ledger.c
+++ b/src/tests/test_audit_ledger.c
@@ -18,6 +18,15 @@ static void set_home(void)
    snprintf(g_home, sizeof g_home, "/tmp/aimee-ledger-test-%d", (int)getpid());
    mkdir(g_home, 0700);
    setenv("AIMEE_HOME", g_home, 1);
+   /* Clear any audit.log* left by a prior test so cases stay isolated. */
+   char p[600];
+   snprintf(p, sizeof p, "%s/audit.log", g_home);
+   unlink(p);
+   for (int i = 0; i <= 8; i++)
+   {
+      snprintf(p, sizeof p, "%s/audit.log.%d", g_home, i);
+      unlink(p);
+   }
 }
 
 static void write_file(const char *name, const char *content)
@@ -109,12 +118,28 @@ static void test_missing_log_is_empty_not_null(void)
    cJSON_Delete(arr);
 }
 
+/* A line with a valid JSON prefix but trailing garbage must be rejected by the
+ * strict parse, not accepted as a row. */
+static void test_strict_parse_rejects_trailing_garbage(void)
+{
+   set_home();
+   write_file(
+       "audit.log",
+       "{\"ts\":\"2026-07-02T10:00:01Z\",\"kind\":\"tool_action\",\"tool\":\"A\"} trailing junk\n"
+       "{\"ts\":\"2026-07-02T10:00:02Z\",\"kind\":\"tool_action\",\"tool\":\"B\"}\n");
+   cJSON *arr = audit_ledger_read(NULL, NULL);
+   assert(cJSON_GetArraySize(arr) == 1); /* only the clean B row */
+   assert(strcmp(row_tool(arr, 0), "B") == 0);
+   cJSON_Delete(arr);
+}
+
 int main(void)
 {
    test_extract_order_and_skip();
    test_window_filter();
    test_rotated_chronology();
    test_missing_log_is_empty_not_null();
+   test_strict_parse_rejects_trailing_garbage();
    printf("test_audit_ledger: all passed\n");
    return 0;
 }

--- a/src/trajectory_export.c
+++ b/src/trajectory_export.c
@@ -1,4 +1,5 @@
 /* trajectory_export.c: DB1 interaction events -> replayable trajectory JSON. */
+#include "audit_ledger.h"
 #include "trajectory.h"
 
 #include "cJSON.h"
@@ -261,6 +262,16 @@ int trajectory_export(const char *selector, const trajectory_opts_t *opts, char 
    cJSON_AddNumberToObject(meta, "event_count", n);
    cJSON_AddStringToObject(meta, "started_at", rows[0].created_at);
    cJSON_AddStringToObject(meta, "ended_at", rows[n - 1].created_at);
+
+   /* Attach governed-action audit rows (S3) that fall within this trajectory's
+    * time window. audit.log ts and interaction_events.created_at share the same
+    * ISO-8601 UTC format, so the window bound is a lexicographic compare. NOTE:
+    * the audit ledger is not session-keyed, so a window that overlaps concurrent
+    * sessions may include their actions — a time-scoped overlay, not a strict
+    * per-session filter. Empty/absent when the writer (S7) is disabled. */
+   cJSON *governed = audit_ledger_read(rows[0].created_at, rows[n - 1].created_at);
+   if (governed)
+      cJSON_AddItemToObject(root, "governed_actions", governed);
 
    if (!opts || opts->redact)
    {


### PR DESCRIPTION
Third slice of the per-action governance audit (P2). Makes the `audit.log` governed-action rows replayable — the **reader-before-writer** half of the rollout, so rows are consumable before S7 enables the writer by default.

## What
- `audit_ledger.{c,h}` — `audit_ledger_read(from_ts,to_ts)`: reads `kind=tool_action` rows from `audit.log` + rotated siblings, ordered deterministically by `(ts, file recency, byte offset)`. Inclusive ISO-8601 window; legacy `{event,detail}`/malformed lines skipped (unparseable count logged, rate-limited); missing log → empty array (not NULL); bounded rows/line.
- `trajectory_export` attaches a time-windowed `governed_actions` array (audit `ts` and `interaction_events.created_at` share the ISO-8601 format). Documented as a **time-scoped overlay**, not a strict per-session filter (the ledger isn't session-keyed).

## Verified locally
4 ledger unit tests (extraction/order/skip-legacy+malformed, window filter, rotated-file chronology, missing-log-empty); trajectory + trajectory-batch tests still pass; **production `aimee-server` + `aimee-kb` build**; clang-format-19 clean. Registered in CMake + Makefile CORE and all trajectory test link lists.