### PR TITLE
chore(hooks): commit sub-agent ban PreToolUse hook + team-wide proposal

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,57 @@
+# Claude Code hooks (aimee)
+
+Committed PreToolUse hook scripts. `.claude/settings.json` / `settings.local.json`
+(which *wire* these hooks) are **gitignored**, so the scripts live here but each dev
+must wire them locally (or let `aimee`'s installer do it — see below).
+
+## `block_subagent.py` — sub-agent ban (delegate-only)
+
+Claude Code sub-agents (the `Agent`/`Task` tool) are **banned** in this repo; use
+**aimee delegates** instead (`aimee delegate <role> …`, `aimee delegate roundtable …`).
+
+Why the script is needed: aimee's own sub-agent ban lives in the runtime gateway
+(`src/gateway_policy.c` → `gateway_policy_strip_tools` → `is_subagent_tool_name`,
+canonicalizing `Task`/`Agent`/`spawn_agent` → `"Subagent"`). That only strips tools
+flowing **through aimee's `/v1` gateway** to model providers, so it governs *aimee's
+own* agents — it never sees Claude Code's harness-level `Agent`/`Task` tool. This
+PreToolUse hook closes that gap at the Claude Code layer: it exits 2 (blocks the
+tool) with a redirect-to-`aimee delegate` message.
+
+### Wire it (personal, per-dev — `settings.json` is gitignored)
+
+```jsonc
+// .claude/settings.local.json
+{
+  "permissions": { "deny": ["Task", "Agent"] },
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Agent|Task|Subagent|spawn_agent",
+      "hooks": [{ "type": "command",
+                  "command": "<repo>/.claude/hooks/block_subagent.py" }]
+    }]
+  }
+}
+```
+
+Verify without spawning a sub-agent:
+`echo '{"tool_name":"Agent"}' | .claude/hooks/block_subagent.py; echo $?`  → `2`.
+(Never "test" it by actually invoking `Agent` — that spawns the banned sub-agent if
+the settings watcher hasn't reloaded. Open `/hooks` once, or restart, to load it.)
+
+## PROPOSED: team-wide auto-install via aimee's installer
+
+Because settings are gitignored, the script alone isn't auto-enforced on a fresh
+clone. The idiomatic fix mirrors how aimee already installs `attention-guard` /
+`hooks post` (see `src/client_integrations.c: ensure_claude_code_hooks` →
+`ensure_aimee_event_hook`, which wires `aimee <subcommand>` PreToolUse hooks into
+every client's settings, location-independently via `resolved_aimee_bin_path()`):
+
+1. Add an `aimee subagent-guard` subcommand that reads the PreToolUse hook JSON on
+   stdin and denies the call when `guardrails_canonical_tool_name(tool) == "Subagent"`
+   — reusing the **exact** predicate the gateway ban uses, so both layers agree.
+2. In `ensure_claude_code_hooks`, add:
+   `ensure_aimee_event_hook(hooks, "PreToolUse", "subagent-guard", "Agent|Task|Subagent|spawn_agent", &dirty);`
+
+Then `aimee`'s standard client setup installs the ban for everyone, regardless of
+where the `aimee` binary lives, with no gitignored-settings dependency. This script
+remains the zero-dependency fallback that works straight from a checkout.

--- a/.claude/hooks/block_subagent.py
+++ b/.claude/hooks/block_subagent.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: hard-ban Claude Code SUB-AGENTS in the aimee repo.
+
+Root cause this closes: aimee's own sub-agent ban lives in the runtime gateway
+(src/gateway_policy.c: gateway_policy_strip_tools -> is_subagent_tool_name, which
+canonicalizes Task/Agent/spawn_agent -> "Subagent" and strips them). That ban only
+sees tools flowing THROUGH aimee's /v1 gateway to model providers, so it governs
+aimee's OWN agents. Claude Code's harness-level Agent/Task tool never traverses that
+gateway, so nothing at aimee's layer can strip it. This hook enforces the same
+policy at the Claude Code layer: any attempt to spawn a sub-agent is BLOCKED and
+redirected to aimee delegates.
+
+Wire-up (settings.json PreToolUse):
+  matcher: "Agent|Task|Subagent|spawn_agent"
+  command: <this file>
+
+Exit 2 from a PreToolUse hook blocks the tool call and feeds stderr back to the
+model, so the redirect message below is what the model sees instead of a sub-agent.
+"""
+import json
+import sys
+
+BANNED = {"agent", "task", "subagent", "spawn_agent"}
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    # Fail OPEN on malformed hook input: never wedge the session on a parse error.
+    sys.exit(0)
+
+tool = str(data.get("tool_name") or "").strip().lower()
+if tool in BANNED:
+    sys.stderr.write(
+        "Sub-agents are BANNED in the aimee repo (delegate-only policy). Do not use "
+        "the Agent/Task tool. Use an aimee delegate instead:\n"
+        '  - aimee delegate <role> "<task>" --persona <name>   '
+        "(roles: engineer / qa / security / reviewer / architect)\n"
+        '  - aimee delegate roundtable "<task>" --mode review --rounds 1   '
+        "(for code/design review)\n"
+        "For read-only reconnaissance, run the searches inline or delegate them; "
+        "never spawn a sub-agent.\n"
+    )
+    sys.exit(2)  # block the tool, show stderr to the model
+
+sys.exit(0)


### PR DESCRIPTION
Commits the sub-agent ban hook I used to close the enforcement gap that let a Claude Code `Agent` sub-agent run in this repo, plus a README documenting the wiring and a proposal for committed team-wide enforcement.

## Root cause
aimee's sub-agent ban lives in the **runtime gateway** (`src/gateway_policy.c` → `gateway_policy_strip_tools` → `is_subagent_tool_name`, canonicalizing `Task`/`Agent`/`spawn_agent` → `"Subagent"`). It only strips tools flowing **through aimee's `/v1` gateway** to model providers — i.e. it governs *aimee's own* agents. Claude Code's harness-level `Agent`/`Task` tool never traverses that gateway, so nothing at aimee's layer can strip it, and the Claude Code config had no `deny`/hook covering it.

## This PR
- **`.claude/hooks/block_subagent.py`** — PreToolUse hook (exit 2 + redirect to `aimee delegate`; fails open on malformed input). Zero-dependency; works straight from a checkout. Sits beside the existing `redirect_grep.py`.
- **`.claude/hooks/README.md`** — documents the per-dev wiring (`.claude/settings*.json` are gitignored, so the script can't be auto-wired by commit alone) **and proposes** the idiomatic team-wide fix.

## Proposed team-wide enforcement (not in this PR)
Mirror how aimee already installs `attention-guard`/`hooks post` (`src/client_integrations.c: ensure_claude_code_hooks` → `ensure_aimee_event_hook`, which wires `aimee <subcommand>` hooks into every client's settings, location-independently):
1. Add an `aimee subagent-guard` subcommand that denies a PreToolUse call when `guardrails_canonical_tool_name(tool) == "Subagent"` — **reusing the exact gateway predicate** so both layers agree.
2. `ensure_aimee_event_hook(hooks, "PreToolUse", "subagent-guard", "Agent|Task|Subagent|spawn_agent", &dirty);`

Then `aimee`'s client setup installs the ban for everyone automatically. Happy to implement in a follow-up if approved.