### PR TITLE
feat(workflow): primary-as-manager S2 step 6 (inc. 2) — lease reclaim + resume-after-reclaim

### DIFF
--- a/src/db1/wfe_binding.c
+++ b/src/db1/wfe_binding.c
@@ -2,6 +2,7 @@
 #include "wfe_binding.h"
 
 #include "db1_internal.h"
+#include "wfe_store.h" /* db1_lifecycle_event_add — audit a reclaim */
 
 #include <sqlite3.h>
 #include <stdio.h>
@@ -161,6 +162,49 @@ int db1_wfe_lease_expiry_get(const char *session_id, char *out, size_t n)
    }
    sqlite3_finalize(stmt);
    return found;
+}
+
+int db1_wfe_lease_reclaim_stale(void)
+{
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+   /* Collect the stale bindings first (bounded per sweep), THEN act -- so we never
+    * mutate the table while stepping the SELECT. A caller re-runs until 0 to drain. */
+   char sids[64][128];
+   char wis[64][80];
+   int n = 0;
+   {
+      sqlite3_stmt *q = NULL;
+      static const char *sel =
+          "SELECT aimee_session_id, work_item_id FROM workflow_binding "
+          "WHERE lease_expiry != '' AND lease_expiry < datetime('now') LIMIT 64";
+      if (sqlite3_prepare_v2(db, sel, -1, &q, NULL) != SQLITE_OK)
+         return -1;
+      while (n < 64 && sqlite3_step(q) == SQLITE_ROW)
+      {
+         const char *sid = (const char *)sqlite3_column_text(q, 0);
+         const char *wi = (const char *)sqlite3_column_text(q, 1);
+         snprintf(sids[n], sizeof sids[n], "%s", sid ? sid : "");
+         snprintf(wis[n], sizeof wis[n], "%s", wi ? wi : "");
+         n++;
+      }
+      sqlite3_finalize(q);
+   }
+   int reclaimed = 0;
+   for (int i = 0; i < n; i++)
+   {
+      /* Reclaim = release the lease (the work-item persists, so the owner or a
+       * same-principal session can RESUME it on its next turn). Audit on the
+       * work-item. */
+      if (db1_wfe_unbind(sids[i]) == 0)
+      {
+         db1_lifecycle_event_add(wis[i], "", "lease_reclaimed", "watchdog-s2",
+                                 "{\"reason\":\"idle_lease_expired\"}", "", 0);
+         reclaimed++;
+      }
+   }
+   return reclaimed;
 }
 
 int db1_wfe_lease_stale_work_items(char (*out)[80], int max)

--- a/src/db1/wfe_binding.h
+++ b/src/db1/wfe_binding.h
@@ -47,6 +47,13 @@ extern "C"
     * on error. Detection only -- the caller decides what to do (warn/reclaim). */
    int db1_wfe_lease_stale_work_items(char (*out)[80], int max);
 
+   /* Reclaim (unbind) bindings whose lease has lapsed: delete the binding row and
+    * record a "lease_reclaimed" lifecycle_event on the work-item, freeing it for a
+    * fresh bind / resume. The work-item itself is NOT deleted, so the owner (or a
+    * same-principal session) resumes it on its next turn. Processes up to 64 per
+    * call (re-run to drain). Returns the number reclaimed, or -1 on error. */
+   int db1_wfe_lease_reclaim_stale(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/db1/wfe_store.c
+++ b/src/db1/wfe_store.c
@@ -92,6 +92,33 @@ int db1_work_item_get(const char *work_item_id, db1_work_item_t *out)
    return found;
 }
 
+int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, char *out, size_t n)
+{
+   if (out && n)
+      out[0] = '\0';
+   if (!proposal_path || !out || !n)
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+   static const char *sql =
+       "SELECT work_item_id FROM lifecycle_work_item WHERE repo = ? AND proposal_path = ?";
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(st, 1, repo ? repo : "", -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(st, 2, proposal_path, -1, SQLITE_TRANSIENT);
+   int found = 0;
+   if (sqlite3_step(st) == SQLITE_ROW)
+   {
+      const char *id = (const char *)sqlite3_column_text(st, 0);
+      snprintf(out, n, "%s", id ? id : "");
+      found = 1;
+   }
+   sqlite3_finalize(st);
+   return found;
+}
+
 static int exec_bind1_update(const char *sql, const char *wi)
 {
    sqlite3 *db = db1_conn();

--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -52,6 +52,12 @@ int db1_work_item_create(const char *work_item_id, const char *repo, const char 
 /* Fetch a work item by id. Returns 1 if found, 0 if not, -1 on error. */
 int db1_work_item_get(const char *work_item_id, db1_work_item_t *out);
 
+/* Resolve a work-item id by its unique (repo, proposal_path). Fills `out` (id-sized,
+ * >= 80). Returns 1 if found, 0 if not, -1 on error. Lets a caller that hit the
+ * UNIQUE(repo, proposal_path) create-collision recover + reuse the existing id
+ * (e.g. resume an interactive work-item after its lease was reclaimed). */
+int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, char *out, size_t n);
+
 /* Move to a new stage + update content_hash (state unchanged). */
 int db1_work_item_set_stage(const char *work_item_id, const char *stage, const char *content_hash);
 /* Record the forge PR ref opened for this work item (set when pr.open advances),

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1387,7 +1387,8 @@ $(TESTPREFIX)/unit-test-wfe-advance-exec: $(OBJDIR)/tests/test_wfe_advance_exec.
 
 # S2 session<->work-item binding (DB1-backed).
 $(TESTPREFIX)/unit-test-wfe-binding: $(OBJDIR)/tests/test_wfe_binding.o \
-                                    $(OBJDIR)/db1/wfe_binding.o $(OBJDIR)/db1/db1_init.o \
+                                    $(OBJDIR)/db1/wfe_binding.o $(OBJDIR)/db1/wfe_store.o \
+                                    $(OBJDIR)/db1/db1_init.o \
                                     $(OBJDIR)/db1/db1_write.o $(OBJDIR)/db1/db1_trigger.o \
                                     $(OBJDIR)/db1/db1_cron_jobs.o $(OBJDIR)/db1/model_catalog.o \
                                     $(OBJDIR)/db1/eval.o $(OBJDIR)/db2/db_schema.o $(TEST_CORE_OBJS)

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -160,6 +160,14 @@ int main(void)
    free(ev);
    assert(resumes == 1);
 
+   /* a session id long enough to truncate the proposal path is REFUSED (so it can
+    * never alias onto -- and hijack -- another session's work-item) */
+   char longsid[200];
+   memset(longsid, 'a', sizeof longsid - 1);
+   longsid[sizeof longsid - 1] = '\0';
+   assert(wfe_bind_interactive(longsid, "use mc long", NULL) == 0);
+   assert(binding_wi(longsid, wi, sizeof wi) == 0);
+
    /* empty session id -> never binds */
    assert(wfe_bind_interactive("", "use mc x", NULL) == 0);
 

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -137,6 +137,29 @@ int main(void)
    free(items);
    assert(n_items == 1);
 
+   /* resume-after-reclaim (step 6 inc 2): make the lease stale, reclaim it (unbinds
+    * SID; the work-item persists), then a fresh enforced turn RESUMES the same
+    * work-item (create collides on interactive/<sid> -> by-proposal lookup) rather
+    * than losing the work or refusing. */
+   assert(db1_wfe_lease_renew(SID, -60) == 0);                    /* force stale */
+   assert(db1_wfe_lease_reclaim_stale() == 1);                    /* reclaim -> SID unbound */
+   assert(binding_wi(SID, wi, sizeof wi) == 0);                   /* unbound */
+   assert(wfe_bind_interactive(SID, "use mc resume", NULL) == 1); /* resumes */
+   assert(binding_wi(SID, wi, sizeof wi) == 1);
+   assert(strcmp(wi, first_wi) == 0); /* SAME work-item */
+   db1_work_item_t *items2 = NULL;
+   assert(db1_work_item_list(&items2) == 1); /* no duplicate created */
+   free(items2);
+   /* the resume was audited as "resume" (not a fresh "bind") */
+   ev = NULL;
+   ne = db1_lifecycle_event_list(first_wi, &ev);
+   int resumes = 0;
+   for (int i = 0; i < ne; i++)
+      if (strcmp(ev[i].actor, "bind-s2") == 0 && strcmp(ev[i].kind, "resume") == 0)
+         resumes++;
+   free(ev);
+   assert(resumes == 1);
+
    /* empty session id -> never binds */
    assert(wfe_bind_interactive("", "use mc x", NULL) == 0);
 

--- a/src/tests/test_wfe_binding.c
+++ b/src/tests/test_wfe_binding.c
@@ -6,6 +6,7 @@
 
 #include "db1.h"
 #include "wfe_binding.h"
+#include "wfe_store.h" /* lifecycle_event list — assert the reclaim audit */
 
 int main(void)
 {
@@ -67,6 +68,22 @@ int main(void)
    assert(db1_wfe_lease_renew("sess3", 0) == 0);
    assert(db1_wfe_lease_expiry_get("sess3", exp, sizeof exp) == 1 && exp[0] == '\0');
    assert(db1_wfe_lease_stale_work_items(stale, 4) == 0);
+
+   /* ---- reclaim (step 6 inc 2): a stale lease is unbound + audited, work-item
+    * freed. sess3 is bound to wi_A; sess2 (wi_B) never leased -> not reclaimed. */
+   assert(db1_wfe_lease_renew("sess3", -60) == 0); /* make sess3 stale */
+   assert(db1_wfe_lease_reclaim_stale() == 1);
+   assert(db1_wfe_binding_get("sess3", wi, sizeof wi, st, sizeof st) == 0); /* unbound */
+   assert(db1_wfe_binding_get("sess2", wi, sizeof wi, st, sizeof st) == 1); /* untouched */
+   db1_lifecycle_event_t *ev = NULL;
+   int ne = db1_lifecycle_event_list("wi_A", &ev);
+   int reclaimed_events = 0;
+   for (int i = 0; i < ne; i++)
+      if (strcmp(ev[i].kind, "lease_reclaimed") == 0 && strcmp(ev[i].actor, "watchdog-s2") == 0)
+         reclaimed_events++;
+   free(ev);
+   assert(reclaimed_events == 1);
+   assert(db1_wfe_lease_reclaim_stale() == 0); /* nothing stale now */
 
    printf("ok\n");
    return 0;

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -12,7 +12,7 @@
 #include "wfe_router.h"  /* catalog + decide + find */
 #include "wfe_store.h"   /* db1_lifecycle_event_add */
 
-static void audit_bind(const char *wi, const char *workflow, const char *stage)
+static void audit_bind(const char *wi, const char *workflow, const char *stage, int resumed)
 {
    cJSON *d = cJSON_CreateObject();
    if (!d)
@@ -21,8 +21,9 @@ static void audit_bind(const char *wi, const char *workflow, const char *stage)
    cJSON_AddStringToObject(d, "stage", stage ? stage : "");
    char *s = cJSON_PrintUnformatted(d);
    cJSON_Delete(d);
+   /* "resume" when re-binding to an existing work-item after a lease reclaim. */
    if (s)
-      db1_lifecycle_event_add(wi, "", "bind", "bind-s2", s, "", 0);
+      db1_lifecycle_event_add(wi, "", resumed ? "resume" : "bind", "bind-s2", s, "", 0);
    free(s);
 }
 
@@ -35,6 +36,13 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
    wfe_enforce_stage_t stage = wfe_enforce_stage_parse(getenv("AIMEE_WORKFLOW_ENFORCE_STAGE"));
    if (stage == WFE_ENFORCE_OFF)
       return 0;
+
+   /* Opportunistic watchdog (step 6 inc 2): reclaim any idle-expired leases on each
+    * enforced turn -- self-healing, no separate scheduler. The lease slides only on
+    * a MEANINGFUL advance (not trivial turn traffic), so a session squatting a
+    * work-item without progress eventually lapses and is reclaimed here (consult
+    * #12). Cheap when nothing is stale (a bounded query returning no rows). */
+   db1_wfe_lease_reclaim_stale();
 
    /* Idempotent: already bound -> reuse, create nothing. This short-circuits every
     * turn after the first, so the create path runs at most once per session. */
@@ -62,9 +70,18 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
    char proposal[128];
    snprintf(proposal, sizeof proposal, "interactive/%s", session_id);
    char id[80] = "";
+   int resumed = 0;
    if (wfe_work_item_create(d.workflow_id, repo ? repo : "", proposal, "interactive", id, err,
                             sizeof err) != 0)
-      return 0; /* create failed (incl. a rare UNIQUE collision after an unbind) */
+   {
+      /* Create failed. The expected case is a UNIQUE(repo, proposal_path) collision
+       * after the session's lease was reclaimed (step 6) -- the work-item still
+       * exists, so RESUME it by binding to the existing id rather than losing the
+       * work. Any other failure (bad workflow, DB fault) leaves id empty -> refuse. */
+      if (db1_work_item_id_by_proposal(repo ? repo : "", proposal, id, sizeof id) != 1 || !id[0])
+         return 0;
+      resumed = 1;
+   }
 
    /* Bind the session, stamping the dial stage (monotonic per session row). */
    if (db1_wfe_bind(session_id, id, wfe_enforce_stage_name(stage)) != 0)
@@ -72,6 +89,6 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
 
    /* Start the sliding lease (step 6 watchdog); renewed on each applied advance. */
    db1_wfe_lease_renew(session_id, wfe_lease_ttl_secs());
-   audit_bind(id, w->id, wfe_enforce_stage_name(stage));
+   audit_bind(id, w->id, wfe_enforce_stage_name(stage), resumed);
    return 1;
 }

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -66,9 +66,14 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
       return 0;
 
    /* Deterministic per-session proposal path so UNIQUE(repo, proposal_path) is a
-    * stable backstop against a duplicate create. */
+    * stable backstop against a duplicate create. Refuse on truncation: a truncated
+    * path could alias two long same-prefix session ids onto ONE work-item, letting
+    * one session resume/bind another's (aimee ids are short, but this must not
+    * depend on that). */
    char proposal[128];
-   snprintf(proposal, sizeof proposal, "interactive/%s", session_id);
+   int pr = snprintf(proposal, sizeof proposal, "interactive/%s", session_id);
+   if (pr < 0 || (size_t)pr >= sizeof proposal)
+      return 0;
    char id[80] = "";
    int resumed = 0;
    if (wfe_work_item_create(d.workflow_id, repo ? repo : "", proposal, "interactive", id, err,


### PR DESCRIPTION
## Primary-as-manager S2 step 6 (increment 2) — lease reclaim + resume-after-reclaim

Acts on the stale leases increment 1 (#957) detects, and lets a session **resume** its work-item afterward. Also fixes a latent rebind bug in the binding seam.

### What's here
- **`db1_wfe_lease_reclaim_stale()`** — unbinds every lease whose expiry has lapsed and records a `lease_reclaimed` lifecycle_event on the work-item. The **work-item is not deleted**, so it frees up for a resume. Bounded (64/sweep, re-run to drain).
- **`db1_work_item_id_by_proposal(repo, proposal)`** — the missing getter that resolves the id behind a `UNIQUE(repo, proposal_path)` collision.
- **`wfe_bind_interactive` resume** — on a create-collision (`interactive/<sid>` already exists after a reclaim), it now **binds to the existing id** (audited `resume`, not `bind`) instead of returning 0. Fixes rebind-after-unbind.
- **Opportunistic reclaim** at the top of `wfe_bind_interactive` — self-healing per enforced turn, no scheduler. Since the lease slides only on a **meaningful advance**, a session squatting a work-item via trivial turns lapses and is reclaimed (anti-squat, consult #12).

### Fail-open safety
Reclaim runs at **turn ingress** (`gw_stage_router` → bind), *before* the model's tool calls, and only touches leases idle past the TTL (default 1h) — an active turn's lease is fresh. So a session is never left unbound mid-turn with tools in flight.

### Verification
- `test_wfe_binding`: reclaim unbinds the stale session + audits it; a never-leased binding is untouched; re-run returns 0.
- `test_wfe_bind_ingress`: resume-after-reclaim — same work-item, no duplicate created, audited as `resume`.
- Full local `make unit-tests` clean; production `aimee-server` links; `make lint` (clang-format-19) + schema-sync + docs-gen clean. **Default-off.**

### Deferred to increment 3
Cross-session **resume-with-auth** (needs the auth principal, consult #11) + explicit **reject-scope-add** surfacing.
