### PR TITLE
feat(governance): S5 — decision write path + one-active-per-scope invariant

### DIFF
--- a/src/db2/decision_log.c
+++ b/src/db2/decision_log.c
@@ -87,8 +87,8 @@ int db2_decision_log_record(const char *subject, const char *options, const char
                             const char *revisit_when, int64_t supersedes_id,
                             db2_decision_log_row_t *out)
 {
-   if (!subject || !options || !chosen)
-      return -1;
+   if (!subject || !subject[0] || !options || !chosen)
+      return -1; /* a real scope is required (empty subject would be one global slot) */
    void *conn = db2_conn();
    if (!conn)
       return -1;
@@ -98,20 +98,29 @@ int db2_decision_log_record(const char *subject, const char *options, const char
       return -1;
 
    /* Flip the decision this one replaces to 'superseded' in the same txn, so the
-    * new active decision does not collide with it on the scope invariant. */
+    * new active decision does not collide with it on the scope invariant. The
+    * UPDATE is constrained to an ACTIVE decision in the SAME scope, and must
+    * affect exactly one row — otherwise supersedes_id is stale/wrong-scope and
+    * the whole record is rejected (no silent supersede of nothing/unrelated). */
    if (supersedes_id > 0)
    {
-      aimee_pg_stmt_t *up = aimee_pg_prepare(
-          conn, "UPDATE decision_log SET status = 'superseded' WHERE id = ?1", err, sizeof(err));
+      aimee_pg_stmt_t *up = aimee_pg_prepare(conn,
+                                             "UPDATE decision_log SET status = 'superseded'"
+                                             " WHERE id = ?1 AND status = 'active' AND subject = ?2"
+                                             " AND linked_policy_id = ?3",
+                                             err, sizeof(err));
       if (!up)
       {
          aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
          return -1;
       }
       aimee_pg_bind_int64(up, "?1", supersedes_id);
+      aimee_pg_bind_text(up, "?2", subject);
+      aimee_pg_bind_int64(up, "?3", linked_policy_id);
       aimee_pg_step_t urc = aimee_pg_step(up, err, sizeof(err));
+      int changes = aimee_pg_stmt_changes(up);
       aimee_pg_finalize(up);
-      if (urc != AIMEE_PG_DONE)
+      if (urc != AIMEE_PG_DONE || changes != 1)
       {
          aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
          return -1;
@@ -128,6 +137,8 @@ int db2_decision_log_record(const char *subject, const char *options, const char
       aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
       return -1;
    }
+   /* Bind by explicit placeholder (?1..?8 = the INSERT column order above), which
+    * differs from the C parameter order — bind names, not positions. */
    aimee_pg_bind_text(st, "?1", options);
    aimee_pg_bind_text(st, "?2", chosen);
    aimee_pg_bind_text(st, "?3", rationale ? rationale : "");

--- a/src/db2/decision_log.c
+++ b/src/db2/decision_log.c
@@ -82,6 +82,85 @@ int db2_decision_log_insert(int64_t task_id, const char *options, const char *ch
    return 0;
 }
 
+int db2_decision_log_record(const char *subject, const char *options, const char *chosen,
+                            const char *rationale, const char *author, int64_t linked_policy_id,
+                            const char *revisit_when, int64_t supersedes_id,
+                            db2_decision_log_row_t *out)
+{
+   if (!subject || !options || !chosen)
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char err[256] = "";
+   if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
+      return -1;
+
+   /* Flip the decision this one replaces to 'superseded' in the same txn, so the
+    * new active decision does not collide with it on the scope invariant. */
+   if (supersedes_id > 0)
+   {
+      aimee_pg_stmt_t *up = aimee_pg_prepare(
+          conn, "UPDATE decision_log SET status = 'superseded' WHERE id = ?1", err, sizeof(err));
+      if (!up)
+      {
+         aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+         return -1;
+      }
+      aimee_pg_bind_int64(up, "?1", supersedes_id);
+      aimee_pg_step_t urc = aimee_pg_step(up, err, sizeof(err));
+      aimee_pg_finalize(up);
+      if (urc != AIMEE_PG_DONE)
+      {
+         aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+         return -1;
+      }
+   }
+
+   const char *sql =
+       "INSERT INTO decision_log (task_id, options, chosen, rationale, assumptions, created_at,"
+       " status, revisit_when, supersedes_id, subject, author, linked_policy_id)"
+       " VALUES (0, ?1, ?2, ?3, '', pg_now_text(), 'active', ?4, ?5, ?6, ?7, ?8) RETURNING id";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
+   }
+   aimee_pg_bind_text(st, "?1", options);
+   aimee_pg_bind_text(st, "?2", chosen);
+   aimee_pg_bind_text(st, "?3", rationale ? rationale : "");
+   aimee_pg_bind_text(st, "?4", revisit_when ? revisit_when : "");
+   aimee_pg_bind_int64(st, "?5", supersedes_id);
+   aimee_pg_bind_text(st, "?6", subject);
+   aimee_pg_bind_text(st, "?7", author ? author : "");
+   aimee_pg_bind_int64(st, "?8", linked_policy_id);
+
+   int64_t new_id = 0;
+   aimee_pg_step_t step = aimee_pg_step(st, err, sizeof(err));
+   if (step == AIMEE_PG_ROW)
+      new_id = aimee_pg_column_int64(st, 0);
+   aimee_pg_finalize(st);
+   if (step != AIMEE_PG_ROW)
+   {
+      /* Most likely idx_dl_active_scope rejected a second active decision for
+       * this (subject, linked_policy_id). */
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
+   }
+
+   if (aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
+   }
+
+   if (out)
+      return db2_decision_log_get(new_id, out);
+   return 0;
+}
+
 int db2_decision_log_get(int64_t id, db2_decision_log_row_t *out)
 {
    void *conn = db2_conn();

--- a/src/db2/decision_log.h
+++ b/src/db2/decision_log.h
@@ -42,6 +42,19 @@ extern "C"
                                const char *rationale, const char *assumptions,
                                const char *created_at, db2_decision_log_row_t *out);
 
+   /* Record a governance decision (P1). Writes an `active` decision for `subject`
+    * (scope key) with the given rationale/author/policy/revisit, and — atomically
+    * in one transaction — flips the decision `supersedes_id` (if >0) to
+    * `superseded`. The one-active-per-scope invariant is enforced by the DB
+    * (idx_dl_active_scope): a second active decision for the same
+    * (subject, linked_policy_id) is rejected. Returns 0 on success (row in `out`
+    * if non-NULL), -1 on any failure (including the invariant rejection), with
+    * the transaction rolled back so no partial write survives. */
+   int db2_decision_log_record(const char *subject, const char *options, const char *chosen,
+                               const char *rationale, const char *author, int64_t linked_policy_id,
+                               const char *revisit_when, int64_t supersedes_id,
+                               db2_decision_log_row_t *out);
+
    /* Load a task decision_log row by id. Returns 0 on success, -1 if the
     * row does not exist or DB2 is unavailable. */
    int db2_decision_log_get(int64_t id, db2_decision_log_row_t *out);

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -153,6 +153,11 @@ ALTER TABLE decision_log ADD COLUMN IF NOT EXISTS supersedes_id BIGINT NOT NULL 
 ALTER TABLE decision_log ADD COLUMN IF NOT EXISTS subject TEXT NOT NULL DEFAULT '';
 ALTER TABLE decision_log ADD COLUMN IF NOT EXISTS author TEXT NOT NULL DEFAULT '';
 ALTER TABLE decision_log ADD COLUMN IF NOT EXISTS linked_policy_id BIGINT NOT NULL DEFAULT 0;
+-- One-active-per-scope invariant: at most one active decision per (subject,
+-- linked_policy_id). linked_policy_id is NOT NULL DEFAULT 0 so no COALESCE is
+-- needed. Enforced at the DB layer (not just a check-then-insert race).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dl_active_scope ON decision_log(subject, linked_policy_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_dl_revisit ON decision_log(revisit_when) WHERE status = 'active' AND revisit_when != '';
 CREATE INDEX IF NOT EXISTS idx_agent_hints_lookup ON agent_hints(role, consumed);
 CREATE INDEX IF NOT EXISTS idx_memory_workspaces_workspace ON memory_workspaces(workspace);
 CREATE INDEX IF NOT EXISTS idx_memory_aliases_memory ON memory_aliases(memory_id);

--- a/src/db2/schema_sqlite.sql
+++ b/src/db2/schema_sqlite.sql
@@ -135,6 +135,8 @@ CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_id);
 CREATE INDEX IF NOT EXISTS idx_te_source ON task_edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_te_target ON task_edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_dl_task ON decision_log(task_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dl_active_scope ON decision_log(subject, linked_policy_id) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_dl_revisit ON decision_log(revisit_when) WHERE status = 'active' AND revisit_when != '';
 CREATE INDEX IF NOT EXISTS idx_agent_hints_lookup ON agent_hints(role, consumed);
 CREATE INDEX IF NOT EXISTS idx_memory_workspaces_workspace ON memory_workspaces(workspace);
 CREATE INDEX IF NOT EXISTS idx_memory_aliases_memory ON memory_aliases(memory_id);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -265,7 +265,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-embedding-dim \
                $(TESTPREFIX)/unit-test-ontology-evolution \
                $(TESTPREFIX)/unit-test-extract-patterns \
-               $(TESTPREFIX)/unit-test-fact-ingest \
+               $(TESTPREFIX)/unit-test-fact-ingest $(TESTPREFIX)/unit-test-decision-log \
                $(TESTPREFIX)/unit-test-fact-recall \
                $(TESTPREFIX)/unit-test-pii-gate \
                $(TESTPREFIX)/unit-test-sandbox \
@@ -2304,6 +2304,10 @@ $(TESTPREFIX)/unit-test-extract-patterns: $(OBJDIR)/tests/test_extract_patterns.
 
 # typed-fact P5: pattern-first ingest pipeline (§6 -> §1), shim.
 $(TESTPREFIX)/unit-test-fact-ingest: $(OBJDIR)/tests/test_fact_ingest.o \
+                               $(TEST_DATA_OBJS_MOCK)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-decision-log: $(OBJDIR)/tests/test_decision_log.o \
                                $(TEST_DATA_OBJS_MOCK)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_decision_log.c
+++ b/src/tests/test_decision_log.c
@@ -65,6 +65,29 @@ static void test_distinct_scopes_coexist(void)
    printf("  PASS: test_distinct_scopes_coexist\n");
 }
 
+/* Superseding a decision in a DIFFERENT scope (or a stale/nonexistent id) is
+ * rejected — the record fails and the unrelated decision is untouched. */
+static void test_supersede_wrong_scope_rejected(void)
+{
+   db2_decision_log_row_t a, a_after;
+   assert(db2_decision_log_record("alpha", "a", "a", "r", "op", 0, "", 0, &a) == 0);
+   /* try to supersede alpha's decision from a record in scope 'beta' */
+   int rc = db2_decision_log_record("beta", "b", "b", "r", "op", 0, "", a.id, NULL);
+   assert(rc != 0); /* wrong scope: UPDATE matches 0 rows -> rejected */
+   assert(db2_decision_log_get(a.id, &a_after) == 0);
+   assert(strcmp(a_after.status, "active") == 0); /* alpha untouched */
+   /* a stale/nonexistent supersedes_id is likewise rejected */
+   assert(db2_decision_log_record("gamma", "g", "g", "r", "op", 0, "", 999999, NULL) != 0);
+   printf("  PASS: test_supersede_wrong_scope_rejected\n");
+}
+
+/* An empty subject is rejected (would otherwise be a single global active slot). */
+static void test_empty_subject_rejected(void)
+{
+   assert(db2_decision_log_record("", "a", "a", "r", "op", 0, "", 0, NULL) != 0);
+   printf("  PASS: test_empty_subject_rejected\n");
+}
+
 int main(void)
 {
    db2_test_shim_open();
@@ -72,6 +95,8 @@ int main(void)
    test_supersede_flips_prior();
    test_one_active_per_scope();
    test_distinct_scopes_coexist();
+   test_supersede_wrong_scope_rejected();
+   test_empty_subject_rejected();
    db2_test_shim_close();
    printf("decision_log: all tests passed\n");
    return 0;

--- a/src/tests/test_decision_log.c
+++ b/src/tests/test_decision_log.c
@@ -1,0 +1,78 @@
+/* test_decision_log.c: the S5 governance decision write path + the
+ * one-active-per-scope invariant, exercised against the DB2 sqlite shim. */
+#include "../db2/db2_test_shim.h"
+#include "decision_log.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* A recorded decision is active and round-trips its governance fields. */
+static void test_record_is_active(void)
+{
+   db2_decision_log_row_t row;
+   int rc = db2_decision_log_record("deploy-window", "opt-a|opt-b", "opt-a", "lower risk",
+                                    "jbailes", 7, "2026-09-01", 0, &row);
+   assert(rc == 0);
+   assert(strcmp(row.status, "active") == 0);
+   assert(strcmp(row.subject, "deploy-window") == 0);
+   assert(strcmp(row.chosen, "opt-a") == 0);
+   assert(strcmp(row.author, "jbailes") == 0);
+   assert(strcmp(row.revisit_when, "2026-09-01") == 0);
+   assert(row.linked_policy_id == 7);
+   assert(row.id > 0);
+   printf("  PASS: test_record_is_active\n");
+}
+
+/* Superseding flips the prior decision to 'superseded' and the new one is active. */
+static void test_supersede_flips_prior(void)
+{
+   db2_decision_log_row_t a, b, a_after;
+   assert(db2_decision_log_record("retention", "keep|drop", "keep", "v1", "op", 0, "", 0, &a) == 0);
+   /* b supersedes a — same scope (subject=retention, policy=0) is fine because a
+    * is flipped to superseded in the same txn. */
+   assert(db2_decision_log_record("retention", "keep|drop", "drop", "v2", "op", 0, "", a.id, &b) ==
+          0);
+   assert(strcmp(b.status, "active") == 0);
+   assert(db2_decision_log_get(a.id, &a_after) == 0);
+   assert(strcmp(a_after.status, "superseded") == 0);
+   printf("  PASS: test_supersede_flips_prior\n");
+}
+
+/* A second active decision for the SAME (subject, linked_policy_id) is rejected
+ * by the invariant, and the first stays active (transaction rolled back). */
+static void test_one_active_per_scope(void)
+{
+   db2_decision_log_row_t first, first_after;
+   assert(db2_decision_log_record("budget", "a|b", "a", "r", "op", 42, "", 0, &first) == 0);
+   int rc = db2_decision_log_record("budget", "a|b", "b", "r", "op", 42, "", 0, NULL);
+   assert(rc != 0); /* rejected: an active decision already exists for this scope */
+   assert(db2_decision_log_get(first.id, &first_after) == 0);
+   assert(strcmp(first_after.status, "active") == 0); /* first untouched */
+   printf("  PASS: test_one_active_per_scope\n");
+}
+
+/* Different scopes may both be active concurrently. */
+static void test_distinct_scopes_coexist(void)
+{
+   db2_decision_log_row_t x, y;
+   assert(db2_decision_log_record("scope-x", "a", "a", "r", "op", 0, "", 0, &x) == 0);
+   assert(db2_decision_log_record("scope-y", "a", "a", "r", "op", 0, "", 0, &y) == 0);
+   /* same subject, different linked_policy_id -> different scope, both active */
+   db2_decision_log_row_t p1, p2;
+   assert(db2_decision_log_record("shared", "a", "a", "r", "op", 1, "", 0, &p1) == 0);
+   assert(db2_decision_log_record("shared", "a", "a", "r", "op", 2, "", 0, &p2) == 0);
+   printf("  PASS: test_distinct_scopes_coexist\n");
+}
+
+int main(void)
+{
+   db2_test_shim_open();
+   test_record_is_active();
+   test_supersede_flips_prior();
+   test_one_active_per_scope();
+   test_distinct_scopes_coexist();
+   db2_test_shim_close();
+   printf("decision_log: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
Second P1 slice. Adds the governance decision write path + the DB-enforced invariant.

- **`db2_decision_log_record()`**: writes an `active` decision for a `subject` scope and — atomically in one BEGIN/COMMIT — flips the `supersedes_id` prior to `superseded`. Any failure ROLLBACKs (no partial write).
- **One-active-per-scope**: `CREATE UNIQUE INDEX idx_dl_active_scope ON decision_log(subject, linked_policy_id) WHERE status='active'` (both schemas; no COALESCE needed since `linked_policy_id` is NOT NULL DEFAULT 0). DB-level enforcement, not a check-then-insert race. + `idx_dl_revisit` for S6.

**Tests (DB2 sqlite shim, all pass)**: record-is-active + field round-trip; supersede flips prior; second-active-same-scope rejected with first untouched; distinct scopes coexist. Production `aimee-kb`+`aimee-server` build + schema-sync/docs-gen/charter/clang-format-19 clean.