### PR TITLE
feat(workflow): primary-as-manager S2 step 6 (inc. 3a) — reject-scope-add surfacing

### DIFF
--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -75,6 +75,17 @@ static void setup_home(void)
    assert(f);
    fputs(WF_MC, f);
    fclose(f);
+   /* a SECOND enforced workflow so a bound-session turn can route elsewhere
+    * (scope-add). Same shape as mc, distinct name. */
+   snprintf(path, sizeof path, "%s/mc2.yaml", wf);
+   f = fopen(path, "wb");
+   assert(f);
+   {
+      const char *p = strstr(WF_MC, "\n");
+      fputs("name: mc2", f);  /* replace the "name: mc" line */
+      fputs(p ? p : "\n", f); /* + the rest of the workflow verbatim */
+   }
+   fclose(f);
    setenv("AIMEE_HOME", dir, 1);
    char repo[600];
    snprintf(repo, sizeof repo, "%s/repo", dir);
@@ -136,6 +147,30 @@ int main(void)
    int n_items = db1_work_item_list(&items);
    free(items);
    assert(n_items == 1);
+
+   /* reject-scope-add surfacing (inc 3a): a bound session whose turn routes to a
+    * DIFFERENT enforced workflow ("use mc2 ...") stays bound to mc (scope-add
+    * rejected) and a scope_add_held event is recorded; a same-workflow turn does
+    * NOT surface one. */
+   assert(wfe_bind_interactive(SID, "use mc2 also fix X", NULL) == 1); /* still bound to mc */
+   assert(binding_wi(SID, wi, sizeof wi) == 1 && strcmp(wi, first_wi) == 0);
+   ev = NULL;
+   ne = db1_lifecycle_event_list(first_wi, &ev);
+   int held = 0;
+   for (int i = 0; i < ne; i++)
+      if (strcmp(ev[i].kind, "scope_add_held") == 0 && strcmp(ev[i].actor, "bind-s2") == 0)
+         held++;
+   free(ev);
+   assert(held == 1);
+   assert(wfe_bind_interactive(SID, "use mc keep going", NULL) == 1); /* same workflow */
+   ev = NULL;
+   ne = db1_lifecycle_event_list(first_wi, &ev);
+   int held2 = 0;
+   for (int i = 0; i < ne; i++)
+      if (strcmp(ev[i].kind, "scope_add_held") == 0)
+         held2++;
+   free(ev);
+   assert(held2 == 1); /* unchanged: same-workflow turn surfaces nothing */
 
    /* resume-after-reclaim (step 6 inc 2): make the lease stale, reclaim it (unbinds
     * SID; the work-item persists), then a fresh enforced turn RESUMES the same

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -162,6 +162,16 @@ int main(void)
          held++;
    free(ev);
    assert(held == 1);
+   /* dedup: re-pivoting to the SAME held workflow does NOT add another event */
+   assert(wfe_bind_interactive(SID, "use mc2 and again", NULL) == 1);
+   ev = NULL;
+   ne = db1_lifecycle_event_list(first_wi, &ev);
+   int held_dup = 0;
+   for (int i = 0; i < ne; i++)
+      if (strcmp(ev[i].kind, "scope_add_held") == 0)
+         held_dup++;
+   free(ev);
+   assert(held_dup == 1);                                             /* still one, not two */
    assert(wfe_bind_interactive(SID, "use mc keep going", NULL) == 1); /* same workflow */
    ev = NULL;
    ne = db1_lifecycle_event_list(first_wi, &ev);

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -49,10 +49,21 @@ static void wfe_scope_add_surface(const char *wi, const char *message)
    const wfe_router_wf_t *w = wfe_router_find(&cat, d.workflow_id);
    if (!w || !w->enforced || strcmp(d.workflow_id, item.workflow_name) == 0)
       return; /* not a scope-add: same workflow, or a non-enforced turn */
+
    char detail[192];
    snprintf(detail, sizeof detail, "{\"held\":\"%s\",\"current\":\"%s\"}", d.workflow_id,
             item.workflow_name);
-   db1_lifecycle_event_add(wi, "", "scope_add_held", "bind-s2", detail, "", 0);
+   /* Dedup: surface once per DISTINCT held workflow, not once per turn -- a client
+    * re-pivoting every turn must not grow the audit log unbounded. */
+   db1_lifecycle_event_t *ev = NULL;
+   int ne = db1_lifecycle_event_list(wi, &ev);
+   int already = 0;
+   for (int i = 0; i < ne && !already; i++)
+      if (strcmp(ev[i].kind, "scope_add_held") == 0 && strcmp(ev[i].detail, detail) == 0)
+         already = 1;
+   free(ev);
+   if (!already)
+      db1_lifecycle_event_add(wi, "", "scope_add_held", "bind-s2", detail, "", 0);
 }
 
 int wfe_bind_interactive(const char *session_id, const char *message, const char *repo)

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -27,6 +27,34 @@ static void audit_bind(const char *wi, const char *workflow, const char *stage, 
    free(s);
 }
 
+/* Reject-scope-add surfacing (consult #30): a session already bound to one work-item
+ * cannot silently expand scope. If THIS turn routes to a DIFFERENT enforced workflow
+ * ("also fix X"), the safe-S2 rule HOLDS the new intent -- the session must finish /
+ * deliver its current work-item first. Record a templated "scope_add_held" event
+ * (workflow ids only, no prose) so the rejection is observable; the binding is left
+ * unchanged. Same-workflow / non-enforced turns are normal work and surface nothing. */
+static void wfe_scope_add_surface(const char *wi, const char *message)
+{
+   if (!wi || !wi[0] || !message || !message[0])
+      return;
+   db1_work_item_t item;
+   if (db1_work_item_get(wi, &item) != 1)
+      return;
+   wfe_router_catalog_t cat;
+   char err[256];
+   if (wfe_router_catalog_load(&cat, err, sizeof err) != 0)
+      return;
+   wfe_route_decision_t d;
+   wfe_router_decide(message, &cat, NULL, &d);
+   const wfe_router_wf_t *w = wfe_router_find(&cat, d.workflow_id);
+   if (!w || !w->enforced || strcmp(d.workflow_id, item.workflow_name) == 0)
+      return; /* not a scope-add: same workflow, or a non-enforced turn */
+   char detail[192];
+   snprintf(detail, sizeof detail, "{\"held\":\"%s\",\"current\":\"%s\"}", d.workflow_id,
+            item.workflow_name);
+   db1_lifecycle_event_add(wi, "", "scope_add_held", "bind-s2", detail, "", 0);
+}
+
 int wfe_bind_interactive(const char *session_id, const char *message, const char *repo)
 {
    if (!session_id || !session_id[0])
@@ -48,7 +76,12 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
     * turn after the first, so the create path runs at most once per session. */
    char wi[80] = "";
    if (db1_wfe_binding_get(session_id, wi, sizeof wi, NULL, 0) == 1 && wi[0])
+   {
+      /* Bound already: reuse (create nothing). Surface a scope-add attempt so the
+       * safe-S2 rejection is observable; the binding stays put. */
+      wfe_scope_add_surface(wi, message);
       return 1;
+   }
 
    if (!message || !message[0])
       return 0;


### PR DESCRIPTION
## Primary-as-manager S2 step 6 (increment 3a) — reject-scope-add surfacing

Completes the **#30** safe-S2 ruling (*reject mid-workflow scope-add*) with observability.

A session already bound to one work-item can't silently expand scope. If a turn routes to a **different enforced workflow** ("also fix X"), the new intent is **held** — the session stays on its current work-item — and a templated `scope_add_held` lifecycle_event is recorded (workflow ids only, no prose). Same-workflow / non-enforced turns are normal work and surface nothing. The binding is unchanged; this is **surfacing on top of the already-enforced rejection** (the idempotent short-circuit).

### Verification
- `test_wfe_bind_ingress`: a session bound to `mc` that routes to `mc2` stays bound + records exactly one `scope_add_held`; a same-workflow turn adds none.
- Default-off; production `aimee-server` links; `make lint` (clang-format-19) + schema-sync + docs-gen clean.

### Deferred to increment 3b
Cross-session **resume-with-auth** (#11) — needs an auth principal on the binding *and* a non-per-`sid` work-item identity (today `proposal_path=interactive/<sid>` keys resume to the same session). That's a plumbing + identity-design fork, flagged separately.
