### PR TITLE
feat(governance): S6 — revisit_when surfacing via the curator drain (no new scheduler)

### DIFF
--- a/src/db2/decision_log.c
+++ b/src/db2/decision_log.c
@@ -172,6 +172,28 @@ int db2_decision_log_record(const char *subject, const char *options, const char
    return 0;
 }
 
+int db2_decision_log_mark_revisit_due(void)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   char err[256] = "";
+   /* idx_dl_revisit backs this predicate. revisit_when and pg_now_text() are both
+    * ISO-8601, so the lexicographic <= is a correct time comparison; a date-only
+    * revisit_when is a prefix of the datetime (same-day sorts as due). */
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
+                                          "UPDATE decision_log SET status = 'revisit_due'"
+                                          " WHERE status = 'active' AND revisit_when != ''"
+                                          " AND revisit_when <= pg_now_text()",
+                                          err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   int changes = aimee_pg_stmt_changes(st);
+   aimee_pg_finalize(st);
+   return rc == AIMEE_PG_DONE ? changes : -1;
+}
+
 int db2_decision_log_get(int64_t id, db2_decision_log_row_t *out)
 {
    void *conn = db2_conn();

--- a/src/db2/decision_log.h
+++ b/src/db2/decision_log.h
@@ -59,6 +59,13 @@ extern "C"
     * row does not exist or DB2 is unavailable. */
    int db2_decision_log_get(int64_t id, db2_decision_log_row_t *out);
 
+   /* Flip active decisions whose revisit_when has elapsed to 'revisit_due' so
+    * they resurface for review (P1). Idempotent: only active rows with a due,
+    * non-empty revisit_when are touched, compared lexicographically against the
+    * current time (ISO-8601). Returns the number flipped this call, or -1 on
+    * error. Reuses the existing curator drain poll — no new scheduler. */
+   int db2_decision_log_mark_revisit_due(void);
+
    /* Update the outcome for a task decision_log row. */
    int db2_decision_log_set_outcome(int64_t id, const char *outcome);
 

--- a/src/db2/decision_log.h
+++ b/src/db2/decision_log.h
@@ -60,10 +60,19 @@ extern "C"
    int db2_decision_log_get(int64_t id, db2_decision_log_row_t *out);
 
    /* Flip active decisions whose revisit_when has elapsed to 'revisit_due' so
-    * they resurface for review (P1). Idempotent: only active rows with a due,
-    * non-empty revisit_when are touched, compared lexicographically against the
-    * current time (ISO-8601). Returns the number flipped this call, or -1 on
-    * error. Reuses the existing curator drain poll — no new scheduler. */
+    * they resurface for review (P1). Idempotent: only active rows are touched, so
+    * a row flips at most once (revisit_due is terminal for the sweep).
+    *
+    * CONTRACT: revisit_when MUST be an ISO-8601 UTC string (the writer's caller
+    * owns this). The comparison is a lexicographic <= against the current UTC
+    * time, which is a correct time compare for ISO-8601. A date-only value
+    * (YYYY-MM-DD) therefore surfaces at 00:00 UTC of that day (day granularity);
+    * store a full timestamp for finer control. A non-ISO/whitespace value sorts
+    * below any real time and flips once on the next sweep — malformed input, not
+    * a loop.
+    *
+    * Returns the number flipped this call, or -1 on error. Reuses the existing
+    * curator drain poll — no new scheduler. */
    int db2_decision_log_mark_revisit_due(void);
 
    /* Update the outcome for a task decision_log row. */

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -10,6 +10,7 @@
 #endif
 
 #include "db2/db2.h"
+#include "db2/decision_log.h"        /* db2_decision_log_mark_revisit_due (P1) */
 #include "db2/cross_repo_identity.h" /* db2_cross_repo_rebuild_identities (H0c) */
 #include "db2/cross_repo_route.h"    /* db2_cross_repo_rebuild_routes (H0d) */
 #include "db2/cross_repo_build.h"    /* db2_cross_repo_rebuild_build_deps (recall R2) */
@@ -168,6 +169,16 @@ static void *drain_thread_main(void *arg)
          int n = kb_evidence_embed_drain(cfg.kb_evidence_embed_batch, embed_cmd);
          if (n > 0)
             aimee_log(LOG_DEBUG, "kb.evidence.embed", "drained %d evidence op(s)", n);
+      }
+
+      /* Governance decision revisit sweep — runs every poll (P1). Flips active
+       * decisions past their revisit_when to 'revisit_due' so they resurface.
+       * Reuses this existing drain — no new scheduler. */
+      {
+         int due = db2_decision_log_mark_revisit_due();
+         if (due > 0)
+            aimee_log(LOG_DEBUG, "kb.decision.revisit", "flipped %d decision(s) to revisit_due",
+                      due);
       }
 
       /* Typed-fact extraction drain — runs every poll, independent of the

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -179,6 +179,9 @@ static void *drain_thread_main(void *arg)
          if (due > 0)
             aimee_log(LOG_DEBUG, "kb.decision.revisit", "flipped %d decision(s) to revisit_due",
                       due);
+         else if (due < 0)
+            aimee_log(LOG_WARN, "kb.decision.revisit",
+                      "revisit sweep failed this cycle (db2 unavailable?)");
       }
 
       /* Typed-fact extraction drain — runs every poll, independent of the

--- a/src/tests/test_decision_log.c
+++ b/src/tests/test_decision_log.c
@@ -88,6 +88,31 @@ static void test_empty_subject_rejected(void)
    printf("  PASS: test_empty_subject_rejected\n");
 }
 
+/* A decision past its revisit_when flips to 'revisit_due'; not-yet-due and
+ * no-revisit decisions stay active; the sweep is idempotent. */
+static void test_revisit_sweep(void)
+{
+   db2_decision_log_row_t due, future, none, after;
+   assert(db2_decision_log_record("rv-due", "a", "a", "r", "op", 0, "2000-01-01", 0, &due) == 0);
+   assert(db2_decision_log_record("rv-future", "a", "a", "r", "op", 0, "2999-01-01", 0, &future) ==
+          0);
+   assert(db2_decision_log_record("rv-none", "a", "a", "r", "op", 0, "", 0, &none) == 0);
+
+   int flipped = db2_decision_log_mark_revisit_due();
+   assert(flipped == 1); /* only the past-due one */
+
+   assert(db2_decision_log_get(due.id, &after) == 0);
+   assert(strcmp(after.status, "revisit_due") == 0);
+   assert(db2_decision_log_get(future.id, &after) == 0);
+   assert(strcmp(after.status, "active") == 0);
+   assert(db2_decision_log_get(none.id, &after) == 0);
+   assert(strcmp(after.status, "active") == 0);
+
+   /* Idempotent: a second sweep flips nothing new. */
+   assert(db2_decision_log_mark_revisit_due() == 0);
+   printf("  PASS: test_revisit_sweep\n");
+}
+
 int main(void)
 {
    db2_test_shim_open();
@@ -97,6 +122,7 @@ int main(void)
    test_distinct_scopes_coexist();
    test_supersede_wrong_scope_rejected();
    test_empty_subject_rejected();
+   test_revisit_sweep();
    db2_test_shim_close();
    printf("decision_log: all tests passed\n");
    return 0;


### PR DESCRIPTION
Third P1 slice. Surfaces decisions whose `revisit_when` has elapsed — reusing the existing drain, no new scheduler.

- **`db2_decision_log_mark_revisit_due()`**: idempotent `UPDATE ... SET status='revisit_due' WHERE status='active' AND revisit_when != '' AND revisit_when <= pg_now_text()` (ISO-8601 lexicographic compare, backed by `idx_dl_revisit`).
- Wired into the **existing** `kb_curator_drain` per-poll section (next to the other runs-every-poll DB2 maintenance) — no new thread/cron, and does not overload the memory_directive sweep.

**Tests**: past-due flips to `revisit_due`; future + no-revisit stay active; idempotent. Production `aimee-kb`+`aimee-server` build + clang-format-19/line-check clean.