### PR TITLE
refactor(webui): rename Proposals→Workflow Actions, Workflows→Edit Workflows

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1223,7 +1223,7 @@ selects its own git **project** to operate on:
   becomes the agent's working directory; webchat scope-validates it to the
   signed-in user's own workspace.
 - **Dashboard**, memory, reminders, and onboarding panels.
-- **Workflows**, a visual composer for [workflow](docs/WORKFLOWS.md)
+- **Edit Workflows**, a visual composer for [workflow](docs/WORKFLOWS.md)
   definitions (blocks rail, graph canvas, per-step persona/delegate assignment,
   plus a persona manager). Validate/Save persist server-side.
 - **Projects**, connect git repositories. Clone over HTTPS *or* SSH-form URLs

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Focused references:
 | [Autonomous Development](docs/AUTONOMOUS_DEVELOPMENT.md) | Hand aimee a proposal and it builds the change end to end via the workflow engine |
 | [Personas](docs/personas.md) | Built in and custom agent identities, delegate policy, and how personas staff reviews |
 | [Workflows](docs/WORKFLOWS.md) | The composable dev lifecycle workflow engine, block catalog, and authoring |
+| [Workflow Actions](docs/WORKFLOW_ACTIONS.md) | The web page to author a proposal, run it autonomously, and watch its status/history |
 | [Workspace Management](docs/WORKSPACES.md) | Multi repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
 | [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token at rest, in transit to git, and in the in browser editor, and where exposure is and is not closed |

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -131,7 +131,7 @@ Autonomous does not mean unsupervised. The workflow reserves **human gates**
 - **never forges a human approval**, gate-override is a signed, human-only action
   capped at a small number of uses.
 
-Approve or reject a parked gate from the webchat Workflows tab's **Run state**
+Approve or reject a parked gate from the webchat **Workflow Actions** page's detail view
 panel, or via `POST /v1/workflow/items/<id>/gate {decision}`. The endpoint is
 **operator-gated** (`CAP_WORKFLOW_ADMIN`, outside the ordinary authenticated
 capability set), and approvals are HMAC-signed server-side with the operator key
@@ -175,7 +175,7 @@ Autonomous development is default-on; the guardrails are structural, not a toggl
 
 ## Observability
 
-- **Webchat Workflows tab**, live progress per work item: current stage, gate
+- **Webchat Workflow Actions page**, live progress per work item: current stage, gate
   verdicts, parked state, and the actionable approve/reject controls for human
   gates.
 - **Event stream**, a run publishes its full turn stream (text, tool calls,
@@ -194,7 +194,7 @@ resumes it automatically once the blocker clears:
 
 | pause reason | what it means | how it resumes |
 |--------------|---------------|----------------|
-| `pending_human` | waiting at a human gate (proposal approval / final pass-fail) | approve or reject in the webchat Workflows tab → the scheduler re-drives |
+| `pending_human` | waiting at a human gate (proposal approval / final pass-fail) | approve or reject in the webchat Workflow Actions page → the scheduler re-drives |
 | `panel_degraded` / `panel_unreachable` | the roundtable couldn't reach a quorum | retried on the next sweep; a human can approve to proceed |
 | `ci_pending` | the PR's CI hasn't concluded | re-checked on the next sweep |
 | `merge_pending` | the forge merge state is undeterminable | re-checked on the next sweep |
@@ -216,7 +216,7 @@ Honest scope of the current implementation (the design allows for more):
   handled interactively via the webchat, and the cost cap is a work-item field.
 - **No dedicated `resume`/`abort`/`audit` HTTP endpoints yet.** Resume is
   event-driven (gate approval + the scheduler sweep); drive and inspect runs via
-  the webchat Workflows tab and the `lifecycle_*` audit tables.
+  the webchat Workflow Actions page and the `lifecycle_*` audit tables.
 - **Scheduler concurrency is 1** (runs are driven sequentially) for now; the
   design's bounded-concurrency fan-out is a follow-on.
 - **`build.yaml` must be present** in `$AIMEE_HOME/workflows` (seeded at standup);

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -32,7 +32,7 @@ feature-tracking reference rather than a complete roadmap.
 | Standalone Go webchat | Done | `aimee-webchat` serves the browser UI, handles auth/session storage, and proxies live work to `aimee-server`. | webchat/, server.c |
 | Network inventory | Done | Loads configured network host inventory for delegate routing. | cmd_agent.c, agents.json |
 | Personas (8 built-in + custom) | Done | Named identity/voice + delegate policy, settable per session and used to staff roundtable panels and workflow steps. See [personas.md](personas.md). | persona.c, prompts.c |
-| Webchat top-nav + per-tab projects | Done | One tab per tool (Chat/Dashboard/Workflows/Projects/Editor); each tab selects its own git project. | frontend/src/App.tsx, frontend/src/components/ProjectPicker.tsx |
+| Webchat top-nav + per-tab projects | Done | One tab per tool (Chat/Dashboard/Edit Workflows/Workflow Actions/Delegates/Projects/Graph/Editor); each tab selects its own git project. | frontend/src/App.tsx, frontend/src/components/ProjectPicker.tsx |
 | Webchat git projects + per-host credentials | Done | Clone repos (HTTPS or SSH-form URLs normalized to HTTPS); per-host tokens + GitHub OAuth device flow stored in the server vault. | git_project.c, git_host_cred.c, git_oauth_github.c |
 | In-app VS Code editor | Done | Per-user `code-server` supervised by the server, reverse-proxied at `/vscode/`, opened on the selected project. Default-on. | webuser_editor.c, webchat/vscode.go |
 | Workflow engine (authoring + execution) | Partial | Block catalog, typed-graph validation, canonical versioning, advance/gates/roundtable/human-approval, and the webchat composer are done; **no user-facing run trigger yet**. See [WORKFLOWS.md](WORKFLOWS.md). | src/workflow/wfe_*.c |

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -7,15 +7,17 @@ you can clone and edit it or author your own. The engine that advances a
 workflow run is the same one that drives delegates, roundtable reviews, and
 human approval gates.
 
-> **Status (current):** authoring, validating, and inspecting workflows is fully
-> supported (CLI + the webchat **Workflows** tab). The execution engine,
+> **Status (current):** authoring and validating workflows is fully supported
+> (CLI + the webchat **Edit Workflows** tab); starting a run and watching its
+> status/history live on the **Workflow Actions** tab
+> ([`WORKFLOW_ACTIONS.md`](WORKFLOW_ACTIONS.md)). The execution engine,
 > stepping a run through its gates, roundtables, and approvals, is implemented,
 > tested, and reachable: `POST /v1/dev/submit` seeds a proposal, creates an
 > autonomous work item on the chosen workflow (default `build`), and the
 > scheduler drives it server-side. See
 > [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md). What's still missing is a
 > general per-workflow trigger: no `aimee workflow run` command and no Run button
-> in the Workflows tab for an arbitrary run. See [Limitations](#current-limitations).
+> for an arbitrary (non-`build`) run. See [Limitations](#current-limitations).
 
 ## Mental model
 
@@ -161,9 +163,12 @@ Workflow files live under `$AIMEE_HOME/workflows/`. `validate` runs the same
 type-checker the engine uses: it catches dangling edges, a step fed the wrong
 artifact type, or a missing required input.
 
-### Webchat Workflows tab
+### Webchat: Edit Workflows tab
 
-The browser **Workflows** tab is a visual composer over the same definitions:
+The browser **Edit Workflows** tab (route `/edit-workflows`) is a visual composer
+over the same definitions. Authoring a run, watching its status/history, and
+deciding human gates live on the separate **Workflow Actions** tab
+(`/workflow-actions`, see [`WORKFLOW_ACTIONS.md`](WORKFLOW_ACTIONS.md)):
 
 - A **blocks rail** to add steps, a **canvas** that lays the graph out
   left-to-right by depth with colored edges (solid = `next`, green = `on pass`,
@@ -173,11 +178,11 @@ The browser **Workflows** tab is a visual composer over the same definitions:
 - **Personas** can be created and edited from the same tab (it proxies
   `/api/chat/personas`).
 - **Validate** and **Save** persist the def server-side via `/api/workflow/*`.
-- Each top-nav tab (including Workflows) selects its own git **project**.
+- Each top-nav tab (including Edit Workflows) selects its own git **project**.
 
 > Note: adding a step from the blocks rail drops it onto the canvas
 > **disconnected**, you wire it into the sequence by selecting it and setting
-> its `next`/`on_pass`/`on_fail` in the inspector. There is no Run button yet.
+> its `next`/`on_pass`/`on_fail` in the inspector. To start and watch a run, use the Workflow Actions tab.
 
 ### Custom blocks
 
@@ -217,7 +222,7 @@ run-in-a-specific-project gap.
 
 ## Inspecting runs
 
-When work-items exist, they are readable (the Workflows tab "Run state" panel and
+When work-items exist, they are readable (the Workflow Actions tab (see [`WORKFLOW_ACTIONS.md`](WORKFLOW_ACTIONS.md)) and
 the API):
 
 - CLI: `aimee cancel <work-item-id>` cancels a run.
@@ -234,14 +239,14 @@ These are real today and worth knowing before you lean on workflows:
 1. **Only the autonomous-development trigger is wired.** `POST /v1/dev/submit`
    creates and starts a run via `wfe_work_item_create` + the scheduler (see
    [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)). There is still no general
-   per-workflow trigger, no `aimee workflow run` command and no Run button in the
-   Workflows tab to kick off an arbitrary saved workflow. You can author,
-   validate, save, and inspect any workflow; only `build`-style autonomous runs
-   start today.
+   per-workflow trigger, no `aimee workflow run` command and no Run button to kick
+   off an arbitrary saved workflow from the UI. You can author, validate, save, and
+   inspect any workflow; only `build`-style autonomous runs (submitted from the
+   Workflow Actions tab) start today.
 2. **Run-in-a-specific-project isn't wired.** A work-item has a `repo` field, but
    the per-step blocks resolve their working directory from
    `$AIMEE_WORKFLOW_REPO`/cwd rather than the work-item's `repo`, so binding a run
-   to the Workflows tab's selected project is incomplete.
+   to a UI-selected project is incomplete.
 3. **Composer ergonomics.** New steps are added disconnected; you wire order in
    the inspector. There is no run/visualize-progress view because runs can't be
    started from the UI yet.

--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -1,6 +1,6 @@
-# Proposals web page
+# Workflow Actions (web page)
 
-The **Proposals** page (aimee web UI, left nav → 📝 Proposals) carries a change from
+The **Workflow Actions** page (aimee web UI, left nav → 📝 Workflow Actions) carries a change from
 an empty editor to a merged PR: **author** a proposal (from scratch or
 delegate-drafted), hand it to the **autonomous-development** engine to implement, and
 **watch** it — a scrollable status/history you can scroll back through to see
@@ -11,11 +11,11 @@ autonomy engine (see [`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). 
 proposal is still just *markdown + a `lifecycle_work_item`*; its history *is* the
 `lifecycle_event` log. **No new database tables or columns were added.**
 
-- **Nav / route:** `/proposals` (`frontend/src/App.tsx`), page
-  `frontend/src/pages/Proposals.tsx`.
-- **Separation of concerns:** the **Workflows** page (`/workflows`) is now the
+- **Nav / route:** `/workflow-actions` (`frontend/src/App.tsx`), page
+  `frontend/src/pages/WorkflowActions.tsx`.
+- **Separation of concerns:** the **Edit Workflows** page (`/edit-workflows`) is now the
   workflow-*definition* editor only (author/validate/save graphs, assign personas).
-  All run/submit/status concerns live on **Proposals**.
+  All run/submit/status concerns live on **Workflow Actions**.
 
 ---
 
@@ -53,7 +53,7 @@ browser ──/api/*──▶ webchat (Go)  ──/v1/*, UDS──▶ aimee-serv
   the C server resolves the caller's `webuser:<subject>` principal — which the
   read endpoints use for ownership scoping (below).
 - The C server owns all state. Submitting writes the proposal markdown to
-  `$AIMEE_HOME/workflows/proposals/wi-*.md` and a `lifecycle_work_item` row; the wfe
+  `$AIMEE_HOME/edit-workflows/workflow-actions/wi-*.md` and a `lifecycle_work_item` row; the wfe
   scheduler drives that item through its workflow, appending a `lifecycle_event` per
   transition.
 
@@ -78,7 +78,7 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
 - **Enriched item** (`item_to_json`): the existing keys (`id, workflow, version,
   stage, state, mode, pause_reason, repo`) plus additive `proposal_name`, `pr_ref`,
   `submitter`, `cum_cost_usd`, `work_item_max_cost_usd`, `override_count`. Additive
-  only, so the Workflows page (which reads the same endpoint) is unaffected.
+  only, so the Edit Workflows page (which reads the same endpoint) is unaffected.
 - **Timeline** — `{events:[{id, stage, kind, actor, detail, cost_usd, created_at}],
   next_after}`, oldest-first, paginated by `?after=<event id>&limit=<n≤200>`
   (default 200). `next_after` is the id of the **last returned** event, so the page
@@ -180,7 +180,7 @@ basenames are opened.
 
 ---
 
-## Frontend behavior (`Proposals.tsx`)
+## Frontend behavior (`WorkflowActions.tsx`)
 
 - **Timeline polling.** Keyed on the selected id alone; each tick appends only events
   past the cursor (idempotent: it filters `id > lastId`), and the interval self-stops
@@ -226,10 +226,10 @@ Built slice-by-slice, each design-and-code roundtable-reviewed before merge:
   endpoints + owner scoping. Behavioral unit tests in `test_wfe_webapi.c`
   (ownership allow+deny, pagination cursor, proposal read-back, symlink→403,
   `/all` enrichment).
-- **Slice 1 — Proposals page + Workflows de-scope** (PR #956): the list + status/
-  history detail; removes the Runs/Run-state/gate panels from Workflows.
+- **Slice 1 — Workflow Actions page + Edit Workflows de-scope** (PR #956): the list + status/
+  history detail; removes the Runs/Run-state/gate panels from Edit Workflows.
 - **Slice 2 — author-from-scratch composer** (PR #959): the composer + client-side
-  draft; removes the Submit-proposal panel from Workflows. (This PR also repaired
+  draft; removes the Submit-proposal panel from Edit Workflows. (This PR also repaired
   pre-existing `testing` breakage from an unrelated merge — a clang-format violation
   and an `audit_args_hash`/`wfe_sha256_raw` test-link `undefined reference`.)
 - **Slice 3 — delegate-assisted drafting** (PR #963): `agent_generate` + `/v1/agent/draft`
@@ -239,7 +239,7 @@ PRs (github.com/RakuenSoftware/aimee): [#954](https://github.com/RakuenSoftware/
 [#956](https://github.com/RakuenSoftware/aimee/pull/956),
 [#959](https://github.com/RakuenSoftware/aimee/pull/959),
 [#963](https://github.com/RakuenSoftware/aimee/pull/963). The design proposal and
-implementation plan are under [`docs/proposals/`](proposals/) (`proposals-ui-page.md`,
+implementation plan are under [`docs/workflow-actions/`](proposals/) (`proposals-ui-page.md`,
 `proposals-ui-page.plan.md`).
 
 ---
@@ -259,7 +259,7 @@ The page is read/UI only; the behavior it drives is governed by existing config:
   intake-auth per-principal rate/concurrency limits); the user-supplied `repo` is
   handled by the same `/v1/dev/submit` intake that the CLI uses — its validation and
   authorization are the intake's concern, unchanged by this feature.
-- **To exercise it end to end** on a running instance: open `/proposals`, **+ New
+- **To exercise it end to end** on a running instance: open `/workflow-actions`, **+ New
   proposal**, optionally **Draft with a delegate**, **Submit**, then watch the timeline
   advance and (with live forge off) park at the first human gate, where **Approve**
   resumes it.

--- a/docs/proposals/done/proposals-ui-page.md
+++ b/docs/proposals/done/proposals-ui-page.md
@@ -3,7 +3,12 @@
 - **State:** done
 - **Completed:** 2026-07-02
 - **Moved from:** `docs/proposals/pending/proposals-ui-page.md`
-- **Feature doc:** [`docs/PROPOSALS_PAGE.md`](../../PROPOSALS_PAGE.md)
+- **Feature doc:** [`docs/WORKFLOW_ACTIONS.md`](../../WORKFLOW_ACTIONS.md)
+- **Renamed after ship (2026-07-02):** this design refers to the page as "Proposals"
+  and the def editor as "Workflows"; the shipped UI names them **"Workflow Actions"**
+  and **"Edit Workflows"** respectively (routes `/workflow-actions`, `/edit-workflows`).
+  The design text below keeps the original names as a historical record; the feature
+  doc above is authoritative for the current names.
 
 ## Goal
 
@@ -331,7 +336,7 @@ admin list) rather than a per-request caps accessor.
 
 **No new tables or columns.** A proposal remains markdown + a `lifecycle_work_item`.
 
-**Feature documentation:** [`docs/PROPOSALS_PAGE.md`](../../PROPOSALS_PAGE.md)
+**Feature documentation:** [`docs/WORKFLOW_ACTIONS.md`](../../WORKFLOW_ACTIONS.md)
 (roundtable-approved).
 
 **Carried as future work / known limits:** headless browser click-through of the live

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,8 @@ import { Routes, Route, Navigate, NavLink, useLocation } from 'react-router-dom'
 import { Toast } from '@rakuensoftware/smoothgui';
 import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
-import Workflows from './pages/Workflows';
-import Proposals from './pages/Proposals';
+import EditWorkflows from './pages/EditWorkflows';
+import WorkflowActions from './pages/WorkflowActions';
 import Delegates from './pages/Delegates';
 import Projects from './pages/Projects';
 import Graph from './pages/Graph';
@@ -64,8 +64,8 @@ type Tab = { label: string; icon: string; route: string };
 const NAV_ITEMS: Tab[] = [
   { label: 'Chat', icon: '💬', route: '/chat' },
   { label: 'Dashboard', icon: '📊', route: '/dashboard' },
-  { label: 'Workflows', icon: '🔀', route: '/workflows' },
-  { label: 'Proposals', icon: '📝', route: '/proposals' },
+  { label: 'Edit Workflows', icon: '🔀', route: '/edit-workflows' },
+  { label: 'Workflow Actions', icon: '📝', route: '/workflow-actions' },
   { label: 'Delegates', icon: '🤝', route: '/delegates' },
   { label: 'Projects', icon: '📁', route: '/projects' },
   { label: 'Graph', icon: '🕸️', route: '/graph' },
@@ -237,8 +237,8 @@ export default function App() {
               <Routes>
                 <Route path="/chat" element={<Chat />} />
                 <Route path="/dashboard" element={<Dashboard />} />
-                <Route path="/workflows" element={<Workflows />} />
-                <Route path="/proposals" element={<Proposals />} />
+                <Route path="/edit-workflows" element={<EditWorkflows />} />
+                <Route path="/workflow-actions" element={<WorkflowActions />} />
                 <Route path="/delegates" element={<Delegates />} />
                 <Route path="/projects" element={<Projects />} />
                 <Route path="/graph" element={<Graph />} />

--- a/frontend/src/pages/Delegates.tsx
+++ b/frontend/src/pages/Delegates.tsx
@@ -519,7 +519,7 @@ function fmt(n: number): string {
   return String(n);
 }
 
-/* ---- inline styles (match the Workflows page) ---- */
+/* ---- inline styles (match the Edit Workflows page) ---- */
 const btn: React.CSSProperties = {
   fontSize: 13,
   padding: "4px 10px",

--- a/frontend/src/pages/EditWorkflows.tsx
+++ b/frontend/src/pages/EditWorkflows.tsx
@@ -292,7 +292,7 @@ async function sendJSON<T>(
   return { status: r.status, data };
 }
 
-export default function Workflows() {
+export default function EditWorkflows() {
   const [defs, setDefs] = useState<DefRow[]>([]);
   const [blocks, setBlocks] = useState<BlockDef[]>([]);
   const [graph, setGraph] = useState<GraphDef | null>(null);

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -133,7 +133,7 @@ function prHref(pr: string): string | null {
   return null;
 }
 
-export default function Proposals() {
+export default function WorkflowActions() {
   const [items, setItems] = useState<Item[]>([]);
   const [showAll, setShowAll] = useState(false);
   const [selId, setSelId] = useState<string | null>(null);
@@ -338,7 +338,7 @@ export default function Proposals() {
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
-          <strong style={{ fontSize: 16 }}>Proposals</strong>
+          <strong style={{ fontSize: 16 }}>Workflow Actions</strong>
           <Badge label={`${items.length}`} variant="neutral" />
           <button onClick={refreshList} style={btn}>
             Refresh

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -121,7 +121,11 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/", s.requireAuth(s.handleRoot))
 	mux.HandleFunc("/chat", s.requireAuth(s.handleSPA))
 	mux.HandleFunc("/dashboard", s.requireAuth(s.handleSPA))
-	mux.HandleFunc("/workflows", s.requireAuth(s.handleSPA))
+	// Workflow surfaces: "Edit Workflows" (the def/graph editor) and "Workflow
+	// Actions" (author → autonomous-run → status/history). Both are SPA routes so a
+	// hard refresh / direct link serves index.html and React Router takes over.
+	mux.HandleFunc("/edit-workflows", s.requireAuth(s.handleSPA))
+	mux.HandleFunc("/workflow-actions", s.requireAuth(s.handleSPA))
 	mux.HandleFunc("/projects", s.requireAuth(s.handleSPA))
 	// Code-graph visualization (§8): a read-only SPA page backed by the /api/graph/*
 	// proxies (which forward aimee-server's index_graph_* MCP tools).


### PR DESCRIPTION
Renames the two workflow surfaces in the web GUI and across the documentation, per request:

- **Proposals → Workflow Actions** (author → autonomous-run → status/history)
- **Workflows → Edit Workflows** (the workflow-definition / graph editor)

## GUI
- **Nav labels** + in-page heading (`App.tsx`, `WorkflowActions.tsx`).
- **Routes:** `/proposals → /workflow-actions`, `/workflows → /edit-workflows` — React routes **and** the webchat SPA route registrations (`server.go`). This also **registers `/workflow-actions` as an SPA route**, which the old `/proposals` never was — so a hard refresh / direct link to the page previously 404'd and now serves the SPA.
- **Components:** `Proposals.tsx → WorkflowActions.tsx`, `Workflows.tsx → EditWorkflows.tsx` (+ exported names).

## Docs (full propagation)
- `docs/PROPOSALS_PAGE.md → docs/WORKFLOW_ACTIONS.md` (title, page/route names, references).
- `AUTONOMOUS_DEVELOPMENT.md`: gate approve/reject + live-progress now point to the **Workflow Actions** page (the Run-state/gate moved off the editor in the original slice work).
- `WORKFLOWS.md`: the editor tab is **Edit Workflows**; running/watching/gates live on the separate **Workflow Actions** tab (cross-linked); limitations reworded.
- `STATUS.md` nav list, `MANUAL.md` visual-composer name, `README.md` doc index (+ a Workflow Actions row).
- The archived `done/` proposal keeps its historical text with a rename note + fixed link.

## Deliberately unchanged
The **API paths** (`/api/workflow/*`, `/v1/workflow/*`, `/api/proposal/draft`, `/v1/agent/draft`) — this is a GUI page-name + route + docs rename only.

## Notes
- Roundtable-reviewed. The review flagged what looked like a large backend deletion — a stale-branch artifact (the branch predated recent `testing` merges); fixed by rebasing onto latest `testing`, so the diff is exactly the rename + doc updates.
- Old `/proposals` / `/workflows` bookmarks will 404 (intended — routes renamed; the feature is new so no established links).

Verified: frontend `tsc` + `vite build`, Go build/vet/fmt, `proposal-links-check`, `docs-gen-check`, and a full docs sweep for leftover old names/routes (none remain).