### PR TITLE
feat(audit): S7 — flip per-action audit default-ON (reader shipped)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -651,8 +651,9 @@ static void config_set_defaults(config_t *cfg)
    cfg->wfe_live_forge_enabled = 0;  /* default-OFF (security): the autonomous live
                                         forge stays unregistered until an operator
                                         explicitly enables it (F4) */
-   cfg->audit_action_enabled = 0;    /* default-OFF: per-action audit row is enabled
-                                        only after the trajectory_export reader ships */
+   cfg->audit_action_enabled = 1;    /* default-ON: the trajectory_export reader (S3)
+                                        shipped, so the passive per-action audit row
+                                        is on by default; set false to opt out */
    snprintf(cfg->css_render_command, sizeof(cfg->css_render_command), "%s",
             CONFIG_DEFAULT_CSS_RENDER_COMMAND); /* default-on render backend (inert
                                                    until the sidecar is up); set empty

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -845,8 +845,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "css_style_graph_enabled", 0);
    if (cfg->wfe_live_forge_enabled) /* default-off: persist only the opt-in (enable) */
       cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 1);
-   if (cfg->audit_action_enabled) /* default-off: persist only the opt-in (enable) */
-      cJSON_AddBoolToObject(root, "audit_action_enabled", 1);
+   if (!cfg->audit_action_enabled) /* default-on: persist only the opt-out (disable) */
+      cJSON_AddBoolToObject(root, "audit_action_enabled", 0);
    /* default-on render backend: persist only a non-default value (a custom command
     * OR an empty string to disable) so both round-trip; the default isn't written. */
    if (strcmp(cfg->css_render_command, CONFIG_DEFAULT_CSS_RENDER_COMMAND) != 0)

--- a/src/guardrails_action_audit.c
+++ b/src/guardrails_action_audit.c
@@ -18,7 +18,7 @@
 /* Cached audit_action_enabled. Read once on first use; a config_load failure
  * leaves the memset-zeroed flag at 0 (audit OFF), so the gate is fail-safe and
  * the hot path costs one branch instead of a per-call config parse. Toggling the
- * knob takes effect on restart — acceptable for a passive, default-off audit. */
+ * knob takes effect on restart — acceptable for a passive, default-on audit. */
 static int g_audit_action_enabled = -1;
 static int audit_action_is_enabled(void)
 {

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -306,9 +306,10 @@ typedef struct config
     * per the security-roundtable deviation. */
    int wfe_live_forge_enabled;
    /* audit_action_enabled: emit a per-tool-call governed-action row (kind=
-    * tool_action) to audit.log from pre_tool_check. Default-OFF until the
-    * trajectory_export reader ships (reader-before-writer); audit is passive and
-    * never changes an enforcement verdict. */
+    * tool_action) to audit.log from pre_tool_check. Default-ON (the
+    * trajectory_export reader shipped, so the rows are consumable); audit is
+    * passive, fail-open, and never changes an enforcement verdict. Set false to
+    * opt out. */
    int audit_action_enabled;
    /* css_render_command: the render backend for the #4-full computed-style oracle.
     * A shell command (like embedding_command) that reads a {"html","css"} JSON


### PR DESCRIPTION
Final slice of the per-action governance audit (P2). The trajectory_export ledger reader (S3, #962) is merged, so the passive `tool_action` rows are now consumable — flip `audit_action_enabled` default **0→1** per the plan's reader-before-writer rollout.

- `config.c`: default `0→1`; `config_save.c`: persist only the opt-**out**; comments updated (config.h, guardrails_action_audit.c).
- The cached gate stays fail-safe (a `config_load` failure leaves it off). Audit remains **passive, fail-open, off the enforcement path**.

**Operator-facing default change**: every governed tool call now writes one `tool_action` row to `audit.log` (rotated, 0600). Opt out with `audit_action_enabled=false`; trivially reverted.

Server builds; docs-gen-check + clang-format-19 clean. Live end-to-end verification steps handed off separately.