### PR TITLE
docs: name the hybrid vector-graph and lead with it as the value-add

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ context. aimee also compresses what each turn sends upstream, so even your main 
 drops. It tracks cost and success per delegate and routes better over time.
 
 **Run the models yourself.** aimee ships a self hosted inference stack: embeddings,
-reranking, and synthesis baked into one GPU container. The knowledge base curates entirely
+reranking, and synthesis baked into one CPU or GPU container. The knowledge base curates entirely
 on your hardware with no outside API calls, and the same local model doubles as a free
 delegate. Swap the model tier with a single image, or run the CPU build for retrieval on any
 box. See [kb LLM backends](docs/KB_LLM_BACKENDS.md).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ codebase as a live graph. Any model, any provider. Cheap delegates for the grunt
 Guardrails it cannot write past. Hand it a proposal and it ships the change itself: design,
 build, review, PR. Your context follows you anywhere. Nothing locks you in.
 
+The memory and the code index are a **hybrid vector-graph**: vector recall fused with a typed
+knowledge graph and your code's call graph, ranked together. That is why it surfaces what the
+plain vector search behind most AI memory misses, the caller three files away, the decision
+from another session, the constraint that never shared a keyword with your query.
+
 Point any tool's OpenAI or Anthropic compatible API at aimee and it runs the turn on any
 model reachable over that wire: Claude, GPT, Gemini, Mistral, MiniMax, a model on your own
 GPU, or any other OpenAI or Anthropic compatible provider. Or run aimee beside your tool over

--- a/docs/CODE_INTELLIGENCE.md
+++ b/docs/CODE_INTELLIGENCE.md
@@ -58,5 +58,8 @@ A thin client needs a configured remote and an indexed project for this. Plain
 The graph is a tool surface for the primary agent and its delegates, not just a CLI. Before
 an edit the AI looks up callers and blast radius, and it fetches exact code spans by symbol
 instead of loading whole files into context. That is what lets it work from your code, keep
-its context small, and stop rediscovering the codebase on every session. See
-[How aimee learns](KNOWLEDGE.md) for how this sits alongside memory and the curator.
+its context small, and stop rediscovering the codebase on every session. Code search is a
+hybrid vector-graph like memory: the call graph, vector similarity, and the cross-session
+knowledge graph are ranked together (`/v1/code/hybrid`, tuned by `code_hybrid_weight_graph`
+and `code_hybrid_weight_memory`), so a lookup follows structure and meaning, not just text.
+See [How aimee learns](KNOWLEDGE.md) for how this sits alongside memory and the curator.

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -92,9 +92,12 @@ time to consolidate what it has seen, without you asking.
 
 ## 4. Pattern recognition across all domains
 
-Everything aimee ingests lands in one typed knowledge graph. That is what lets it
-draw conclusions no single document states, by connecting entities, edges, and
-evidence that originated in different teams, formats, and domains.
+Everything aimee ingests lands in one typed knowledge graph. Recall is a **hybrid
+vector-graph**, not plain vector search: the embeddings, the graph's entities and relations,
+and a lexical signal are ranked together by reciprocal-rank fusion, so a query resolves
+through meaning, structure, and keywords at once. That is what lets it draw conclusions no
+single document states, by connecting entities, edges, and evidence that originated in
+different teams, formats, and domains.
 
 This is the core of the company-wide design. A product spec, the code that
 implements it, the support tickets about it, and the contract that governs it all

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -5,6 +5,13 @@ all share a **single embedder per deployment**. There is no two-tier (fast +
 deep) arrangement, one model embeds everything, and every vector column is
 sized to that model's output dimension.
 
+Retrieval is a **hybrid vector-graph**, not a vector store. Vector recall is fused with a
+typed knowledge graph (entities, relations, PageRank) and, for code, the call graph, plus a
+lexical BM25 signal, and the signals are combined by reciprocal-rank fusion (`memory_bm25_weight`,
+`semantic_weight`, and the `code_hybrid_weight_*` knobs). The embedder below feeds the vector
+half; the graph and lexical halves run beside it. That fusion is what lets recall cross a
+keyword gap or a repo boundary that plain vector search would miss.
+
 ## The embedder
 
 Embedding and reranking are baked into the `aimee-kb-*` tier images — Qwen3-Embedding + an


### PR DESCRIPTION
aimee's memory and code index fuse vector recall with a typed knowledge graph and the code call graph, plus lexical BM25, ranked by reciprocal-rank fusion (`memory_bm25_weight`, `semantic_weight`, `code_hybrid_weight_graph`, `code_hybrid_weight_memory`, the `/v1/code/hybrid` endpoint). The docs described the parts but never named the thing, and it is the clearest answer to "why is this better than a vector store."

- README opener: a value-add line right after the hook, framed against the pure-vector search behind most AI memory, with concrete examples of what the fusion surfaces.
- KNOWLEDGE, retrieval-stack, CODE_INTELLIGENCE: name it where the retrieval is described.

Follow-up to the docs refresh in #969. In your voice, zero em-dashes.