### PR TITLE
feat(server): wire S2 enforce-before-send into the tmux CLI TUI primary (S4) + revert claude-p orchestrator

### DIFF
--- a/src/headers/primary_cli_ingestor.h
+++ b/src/headers/primary_cli_ingestor.h
@@ -1,16 +1,18 @@
 /* primary_cli_ingestor.h -- primary-as-manager S2 enforcement seam for the
- * external-CLI primary (Claude Code driven over `-p --output-format stream-json`).
+ * Claude primary, which runs as a per-session tmux CLI TUI (cli_session): each
+ * aimee session gets its OWN persistent interactive Claude pane, 1:1, so sessions
+ * stay isolated and conversation history lives in the live pane. (`claude -p` is a
+ * dead end here -- one-shot print mode cannot isolate or persist per-session
+ * state, empirically confirmed.)
  *
- * Why this exists: the Claude primary MUST run as an external CLI. Its model
- * calls reach aimee out-of-band (a separate HTTP connection/thread from the turn
- * worker), so the in-process session-id publish never reaches gw_stage_router and
- * the S2 binding is INERT for the Claude primary. This adapter enforces at the
- * IN-PROCESS turn seam instead: BEFORE the turn is sent to the CLI it routes +
- * binds the session (S1/S2), so the primary is under management for the turn.
- *
- * Slice 2 scope: the gate + the enforce-before-send seam only. Driving the
- * agent_shell stream-json backend + rendering its events is a later slice. The
- * whole path is additive and DEFAULT-OFF (see primary_cli_ingestor_enabled). */
+ * Why this exists: the tmux Claude pane's model call reaches aimee out-of-band (a
+ * separate HTTP connection/thread from the turn worker), so the in-process
+ * session-id publish never reaches gw_stage_router and the S2 binding is INERT for
+ * the Claude primary. This seam enforces at the IN-PROCESS turn seam instead: the
+ * tmux turn is dispatched synchronously on the worker thread where the aimee
+ * session id IS in scope, so binding right BEFORE the turn is sent to the pane
+ * makes S1/S2 preventive for the turn. Additive + DEFAULT-OFF (see
+ * primary_cli_ingestor_enabled + the AIMEE_WORKFLOW_ENFORCE_STAGE dial). */
 #ifndef PRIMARY_CLI_INGESTOR_H
 #define PRIMARY_CLI_INGESTOR_H
 
@@ -30,35 +32,5 @@ int primary_cli_ingestor_enabled(void);
  * Returns 1 if the session is now bound (enforcement active this turn), else 0. */
 int primary_cli_ingestor_enforce_preturn(const char *session_id, const char *message,
                                          const char *repo);
-
-/* Result of one ingested primary turn. All heap fields are caller-owned; free via
- * primary_cli_turn_result_free. */
-typedef struct
-{
-   char *text;      /* accumulated assistant text (owned; NULL if none) */
-   char *session;   /* backend session id to resume the NEXT turn (owned; NULL if none) */
-   char error[256]; /* first error seen (empty if none) */
-   int bound;       /* 1 if this turn is under S2 management (enforced+routed) */
-   int tool_calls;  /* count of native CLI tool_start events observed (audit) */
-} primary_cli_turn_result_t;
-
-void primary_cli_turn_result_free(primary_cli_turn_result_t *r);
-
-/* Drive ONE primary turn through the agent_shell CLI backend (Slice 3), ingesting
- * its stream events into `out`. Enforcement (S1 route + S2 bind/guard) runs BEFORE
- * the turn is sent to the CLI, so it is preventive for the turn (out->bound reports
- * whether the session is now managed). Native CLI tool events are observed for
- * audit only (detective, not preventive -- the shell-tool bypass is a separate
- * track).
- *   session_id: aimee session id in scope on the turn worker thread (empty => the
- *               enforce step is a no-op, but the turn still runs unmanaged)
- *   driver_name: agent_shell driver ("claude" when NULL/empty)
- *   resume_id:  backend session id to resume (NULL for a fresh backend session)
- *   interrupted: optional cooperative-cancel flag (may be NULL)
- * Returns 0 on clean completion, -1 on error (out->error carries the message).
- * `out` must be non-NULL; it is fully overwritten and owned by the caller. */
-int primary_cli_ingestor_turn(const char *session_id, const char *message, const char *repo,
-                              const char *driver_name, const char *resume_id,
-                              primary_cli_turn_result_t *out, volatile int *interrupted);
 
 #endif /* PRIMARY_CLI_INGESTOR_H */

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -1,7 +1,8 @@
 /* server_compute.c: POSIX chat.send_stream worker for primary-agent streaming. */
 #include "aimee.h"
 #include "agent_adapter.h"
-#include "ingress_preinject.h" /* S2 binding: publish primary session id per turn */
+#include "ingress_preinject.h"    /* S2 binding: publish primary session id per turn */
+#include "primary_cli_ingestor.h" /* S2 binding: enforce-before-send on the tmux CLI TUI turn */
 #include "agent_config.h"
 #include "agent_exec.h"
 #include "agent_tools.h"   /* agent_tools_set_tool_event_cb — stream tool events */
@@ -760,6 +761,17 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
     * Save/restore around any outer turn on this thread. */
    int prev_error_grace = cli_session_get_error_grace_ms();
    cli_session_set_error_grace_ms(CLI_SESSION_DEFAULT_ERROR_GRACE_MS);
+
+   /* Primary-as-manager S2 (primary-CLI-ingestor): the Claude primary runs as a
+    * per-session tmux CLI TUI whose model call reaches the gateway OUT-OF-BAND, so
+    * the router never binds it. Enforce HERE -- on the worker thread, where the
+    * aimee session id is in scope and agent_run_with_tools dispatches the tmux turn
+    * synchronously -- BEFORE the turn is sent to the pane, so S1 route + S2
+    * bind/guard are preventive for the turn. Behind the ingestor opt-in flag AND
+    * the enforce dial (both default-off), so the hot path is untouched by default.
+    * A missing sid is a no-op (never a silent pretend-enforced). */
+   if (primary_cli_ingestor_enabled() && aimee_sid && aimee_sid[0])
+      primary_cli_ingestor_enforce_preturn(aimee_sid, message, use_cwd);
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));

--- a/src/server/primary_cli_ingestor.c
+++ b/src/server/primary_cli_ingestor.c
@@ -1,12 +1,9 @@
 /* primary_cli_ingestor.c -- see primary_cli_ingestor.h. */
 #include "primary_cli_ingestor.h"
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "agent_shell.h"
-#include "dstr.h"
 #include "wfe_bind_ingress.h"
 
 int primary_cli_ingestor_enabled(void)
@@ -33,124 +30,4 @@ int primary_cli_ingestor_enforce_preturn(const char *session_id, const char *mes
     * the external-CLI primary, whose out-of-band model call the gateway router
     * never sees with a session id attached. */
    return wfe_bind_interactive(session_id, message, repo);
-}
-
-/* Per-turn ingestion accumulator: the assistant text (streamed as TEXT_DELTA),
- * the backend session id (for next-turn resume), the first error, and a native
- * tool-call count (observed for audit only). */
-typedef struct
-{
-   dstr_t text;
-   char *session;
-   char error[256];
-   int tool_calls;
-} pci_ingest_ctx_t;
-
-static void pci_ingest_cb(agent_shell_event_t event, const char *data, void *user)
-{
-   pci_ingest_ctx_t *c = (pci_ingest_ctx_t *)user;
-   if (!c)
-      return;
-   switch (event)
-   {
-   case SHELL_EVENT_TEXT_DELTA:
-      if (data)
-         dstr_append_str(&c->text, data);
-      break;
-   case SHELL_EVENT_SESSION_ID:
-      /* A backend session id is short; ignore absurd values (bound the copy) and
-       * only replace the last-known id on a SUCCESSFUL dup -- never drop a valid id
-       * because a replacement alloc failed. */
-      if (data && data[0] && strlen(data) < 128)
-      {
-         char *dup = strdup(data);
-         if (dup)
-         {
-            free(c->session);
-            c->session = dup;
-         }
-      }
-      break;
-   case SHELL_EVENT_TOOL_START:
-      /* Native CLI tool use is observed post-hoc for audit; it is NOT gated here
-       * (the shell-tool bypass is a separate track -- consult [21]). */
-      c->tool_calls++;
-      break;
-   case SHELL_EVENT_ERROR:
-      if (data && data[0] && !c->error[0])
-         snprintf(c->error, sizeof c->error, "%s", data);
-      break;
-   case SHELL_EVENT_TOOL_COMPLETE:
-   case SHELL_EVENT_TURN_COMPLETE:
-      break;
-   }
-}
-
-void primary_cli_turn_result_free(primary_cli_turn_result_t *r)
-{
-   if (!r)
-      return;
-   free(r->text);
-   r->text = NULL;
-   free(r->session);
-   r->session = NULL;
-}
-
-int primary_cli_ingestor_turn(const char *session_id, const char *message, const char *repo,
-                              const char *driver_name, const char *resume_id,
-                              primary_cli_turn_result_t *out, volatile int *interrupted)
-{
-   if (!out)
-      return -1;
-   memset(out, 0, sizeof *out);
-
-   /* Enforce BEFORE send: S1 route + S2 bind/guard are preventive for the turn
-    * (consult [13]). A missing session id makes this a no-op (bound=0) but the
-    * turn still runs -- unmanaged, never a silent pretend-enforced. */
-   out->bound = primary_cli_ingestor_enforce_preturn(session_id, message, repo);
-
-   const agent_shell_driver_t *driver =
-       agent_shell_driver_get(driver_name && driver_name[0] ? driver_name : "claude");
-   if (!driver || !driver->open || !driver->send || !driver->recv || !driver->close)
-   {
-      snprintf(out->error, sizeof out->error, "no CLI backend driver '%s'",
-               driver_name && driver_name[0] ? driver_name : "claude");
-      return -1;
-   }
-
-   void *handle = driver->open(driver, resume_id);
-   if (!handle)
-   {
-      snprintf(out->error, sizeof out->error, "CLI backend open failed");
-      return -1;
-   }
-
-   pci_ingest_ctx_t ctx;
-   memset(&ctx, 0, sizeof ctx);
-   dstr_init(&ctx.text);
-
-   int rc = -1;
-   if (driver->send(handle, message ? message : "") != 0)
-   {
-      snprintf(out->error, sizeof out->error, "CLI backend send failed");
-      rc = -1;
-   }
-   else
-   {
-      rc = driver->recv(handle, pci_ingest_cb, &ctx, interrupted);
-   }
-   driver->close(handle);
-
-   /* Honor the header contract: a -1 return always carries a message. Prefer the
-    * driver's own error event; else a generic fallback (recv can fail without
-    * emitting SHELL_EVENT_ERROR). */
-   if (ctx.error[0] && !out->error[0])
-      snprintf(out->error, sizeof out->error, "%s", ctx.error);
-   if (rc != 0 && !out->error[0])
-      snprintf(out->error, sizeof out->error, "CLI backend turn failed (rc=%d)", rc);
-   out->text = (ctx.text.len && ctx.text.data) ? strdup(ctx.text.data) : NULL;
-   out->session = ctx.session; /* transfer ownership (already strdup'd) */
-   out->tool_calls = ctx.tool_calls;
-   dstr_free(&ctx.text);
-   return rc;
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1361,7 +1361,7 @@ $(TESTPREFIX)/unit-test-wfe-bind-ingress: $(OBJDIR)/tests/test_wfe_bind_ingress.
 # closure as unit-test-wfe-bind-ingress (it calls wfe_bind_interactive) + the
 # ingestor object.
 $(TESTPREFIX)/unit-test-primary-cli-ingestor: $(OBJDIR)/tests/test_primary_cli_ingestor.o \
-                                    $(OBJDIR)/server/primary_cli_ingestor.o $(OBJDIR)/server/agent_shell.o \
+                                    $(OBJDIR)/server/primary_cli_ingestor.o \
                                     $(OBJDIR)/workflow/wfe_bind_ingress.o $(OBJDIR)/workflow/wfe_enforce.o \
                                     $(OBJDIR)/workflow/wfe_externalization.o $(OBJDIR)/db1/wfe_binding.o \
                                     $(OBJDIR)/workflow/wfe_router.o $(OBJDIR)/workflow/wfe_router_catalog.o \

--- a/src/tests/test_primary_cli_ingestor.c
+++ b/src/tests/test_primary_cli_ingestor.c
@@ -9,82 +9,10 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#include "agent_shell.h"
 #include "db1.h"
 #include "primary_cli_ingestor.h"
 #include "wfe_binding.h"
 #include "wfe_engine.h"
-
-/* --- stub agent_shell driver: records the open/send/recv/close call sequence,
- * captures whether the session was already S2-bound at send() time (proving
- * enforce-BEFORE-send), and emits a synthetic stream for the ingestor. --- */
-static int g_open, g_send, g_recv, g_close;
-static int g_bound_at_send;
-static char g_check_sid[80];
-
-static void *stub_open(const agent_shell_driver_t *d, const char *resume_id)
-{
-   (void)d;
-   (void)resume_id;
-   g_open++;
-   return (void *)0x1; /* non-NULL opaque handle */
-}
-static int stub_send(void *h, const char *msg)
-{
-   (void)h;
-   (void)msg;
-   g_send++;
-   char wi[80] = "";
-   g_bound_at_send = (db1_wfe_binding_get(g_check_sid, wi, sizeof wi, NULL, 0) == 1 && wi[0]);
-   return 0;
-}
-static int stub_recv(void *h, agent_shell_cb_t cb, void *user, volatile int *interrupted)
-{
-   (void)h;
-   (void)interrupted;
-   g_recv++;
-   cb(SHELL_EVENT_TEXT_DELTA, "hello ", user);
-   cb(SHELL_EVENT_TEXT_DELTA, "world", user);
-   cb(SHELL_EVENT_TOOL_START, "Bash", user);
-   cb(SHELL_EVENT_TOOL_COMPLETE, NULL, user);
-   cb(SHELL_EVENT_SESSION_ID, "claude-sess-1", user);
-   cb(SHELL_EVENT_TURN_COMPLETE, NULL, user);
-   return 0;
-}
-static void stub_close(void *h)
-{
-   (void)h;
-   g_close++;
-}
-static const agent_shell_driver_t STUB_DRIVER = {.name = "stubcli",
-                                                 .open = stub_open,
-                                                 .send = stub_send,
-                                                 .recv = stub_recv,
-                                                 .close = stub_close};
-
-/* a driver whose recv fails WITHOUT emitting SHELL_EVENT_ERROR (contract check). */
-static int stub_recv_fail(void *h, agent_shell_cb_t cb, void *user, volatile int *interrupted)
-{
-   (void)h;
-   (void)cb;
-   (void)user;
-   (void)interrupted;
-   return -1;
-}
-static const agent_shell_driver_t FAIL_DRIVER = {.name = "failcli",
-                                                 .open = stub_open,
-                                                 .send = stub_send,
-                                                 .recv = stub_recv_fail,
-                                                 .close = stub_close};
-
-/* Link shims: agent_shell.o's agent_shell_drivers_init() references these built-in
- * drivers (defined in the heavy per-CLI driver objects). This test never calls
- * drivers_init -- it registers only STUB_DRIVER -- so zero-initialized stand-ins
- * satisfy the linker without pulling in the real fork/exec CLI machinery. */
-agent_shell_driver_t claude_shell_driver;
-agent_shell_driver_t claude_pty_shell_driver;
-agent_shell_driver_t codex_shell_driver;
-agent_shell_driver_t gemini_shell_driver;
 
 /* enforced managed workflow "mc" (valid manager shape w/ terminal gate.deliver). */
 static const char *WF_MC = "name: mc\n"
@@ -202,48 +130,6 @@ int main(void)
    const char *SID2 = "beefcafe";
    assert(primary_cli_ingestor_enforce_preturn(SID2, "hello there", NULL) == 0);
    assert(!bound(SID2));
-
-   /* Slice 3: the turn orchestrator drives the agent_shell backend + ingests its
-    * stream, enforcing BEFORE send. */
-   agent_shell_driver_register(&STUB_DRIVER);
-   const char *SID3 = "cafed00d";
-   snprintf(g_check_sid, sizeof g_check_sid, "%s", SID3);
-   g_open = g_send = g_recv = g_close = g_bound_at_send = 0;
-
-   primary_cli_turn_result_t r;
-   int rc = primary_cli_ingestor_turn(SID3, "use mc do the thing", NULL, "stubcli", NULL, &r, NULL);
-   assert(rc == 0);
-   assert(g_open == 1 && g_send == 1 && g_recv == 1 && g_close == 1); /* full lifecycle */
-   assert(r.bound == 1);                                 /* enforced-routed turn is managed */
-   assert(g_bound_at_send == 1);                         /* ENFORCE RAN BEFORE SEND (preventive) */
-   assert(r.text && strcmp(r.text, "hello world") == 0); /* text deltas ingested */
-   assert(r.session && strcmp(r.session, "claude-sess-1") == 0); /* backend sid captured */
-   assert(r.tool_calls == 1);                                    /* native tool observed (audit) */
-   assert(!r.error[0]);
-   primary_cli_turn_result_free(&r);
-
-   /* a converse turn still runs but is NOT bound (unmanaged, not pretend-enforced) */
-   const char *SID4 = "0ddba11";
-   snprintf(g_check_sid, sizeof g_check_sid, "%s", SID4);
-   g_bound_at_send = 1; /* poison: must be reset to 0 by the check */
-   primary_cli_turn_result_t r2;
-   assert(primary_cli_ingestor_turn(SID4, "hello there", NULL, "stubcli", NULL, &r2, NULL) == 0);
-   assert(r2.bound == 0 && g_bound_at_send == 0); /* not bound at send */
-   assert(r2.text && strcmp(r2.text, "hello world") == 0);
-   primary_cli_turn_result_free(&r2);
-
-   /* an unknown driver -> clean error, no crash, no result leak */
-   primary_cli_turn_result_t r3;
-   assert(primary_cli_ingestor_turn(SID3, "hi", NULL, "no-such-driver", NULL, &r3, NULL) == -1);
-   assert(r3.error[0] && !r3.text && !r3.session);
-   primary_cli_turn_result_free(&r3);
-
-   /* contract: recv failing WITHOUT an error event still yields -1 + a message */
-   agent_shell_driver_register(&FAIL_DRIVER);
-   primary_cli_turn_result_t r4;
-   assert(primary_cli_ingestor_turn(SID3, "hi", NULL, "failcli", NULL, &r4, NULL) == -1);
-   assert(r4.error[0]); /* fallback message set even though the driver emitted none */
-   primary_cli_turn_result_free(&r4);
 
    printf("ok\n");
    return 0;


### PR DESCRIPTION
## Wire S2 enforce-before-send into the tmux CLI TUI primary (Slice 4) + revert the `claude -p` orchestrator

**Corrected transport.** The Claude primary runs as a **per-session tmux CLI TUI** (`cli_session`) — each aimee session gets its own persistent interactive Claude pane, 1:1, which is **mandatory for session isolation**. `claude -p` is a dead end (one-shot print mode can't isolate or persist per-session state — empirically confirmed that `claude -p --resume` is *not* stateful across separate processes). Slice 3's `agent_shell`/`claude -p` turn orchestrator was the **wrong transport** and is **reverted** here; `primary_cli_ingestor` is back to the gate + enforce-before-send seam only.

The real fix is transport-simple: the tmux turn is dispatched **synchronously on the worker thread** (`chat_stream_worker_agent → agent_run_with_tools("code") → cli_session`), where the aimee session id **is** in scope. So enforce right there, before the turn is sent to the pane:

```c
if (primary_cli_ingestor_enabled() && aimee_sid && aimee_sid[0])
    primary_cli_ingestor_enforce_preturn(aimee_sid, message, use_cwd);
```

This binds the session (S1 route + S2 bind/guard) **before** the turn is sent — preventive for the tmux primary, whose out-of-band model call the gateway router never sees with a session id. **No transport change, no new driver.**

### Safety
- Double default-off: the ingestor opt-in flag `AIMEE_PRIMARY_CLI_INGESTOR` **and** the `AIMEE_WORKFLOW_ENFORCE_STAGE` dial — the hot path is untouched unless both are set.
- A missing/empty sid is a no-op (never a silent pretend-enforced — the S2 trust boundary).
- `enforce_preturn` binds only an enforced-*routed* turn; converse/research stay unbound.

### Verification
- `test_primary_cli_ingestor` (the seam: gate + enforce-before-send, dial-off inert, no-sid no-op) green.
- Full `make unit-tests` (incl. every `server_compute.o`-linking test — the new `primary_cli_ingestor → wfe_bind_ingress` symbol chain resolves), `aimee-server` link, `make lint` (clang-format-19, module-boundary, schema-sync, docs-gen) all green.

### Scope
Enforcement (binding) is now live for the tmux primary when enabled. The full **ingest-tmux-turn→IR** goal (if pursued) would take the tmux CLI TUI's own structured output as its source — never `claude -p`.
