### PR TITLE
feat(server): boot-time enforcement-posture log for the primary-CLI-ingestor (capstone)

### DIFF
--- a/src/headers/primary_cli_ingestor.h
+++ b/src/headers/primary_cli_ingestor.h
@@ -33,4 +33,12 @@ int primary_cli_ingestor_enabled(void);
 int primary_cli_ingestor_enforce_preturn(const char *session_id, const char *message,
                                          const char *repo);
 
+/* Log the enforcement posture ONCE at server startup (observability, consult
+ * strategic-roundtable [51]: enforcement can ship "as enabled" while silently
+ * INERT, with no boot-time signal). When the ingestor flag is off this is a no-op
+ * (default, quiet). When on, it logs INFO with the dial stage if enforcement will
+ * actually fire, or WARN if the flag is on but the dial is off -- the exact
+ * silent-inert trap (flag set, dial forgotten -> the tmux primary never binds). */
+void primary_cli_ingestor_log_posture(void);
+
 #endif /* PRIMARY_CLI_INGESTOR_H */

--- a/src/server/primary_cli_ingestor.c
+++ b/src/server/primary_cli_ingestor.c
@@ -39,12 +39,13 @@ void primary_cli_ingestor_log_posture(void)
    if (!primary_cli_ingestor_enabled())
       return; /* default-off: stay quiet; the hot path is untouched */
 
+   /* Same source of truth as the enforce gate: wfe_bind_interactive parses this
+    * identical env var with the same parser (unset is treated as off). */
    wfe_enforce_stage_t stage = wfe_enforce_stage_parse(getenv("AIMEE_WORKFLOW_ENFORCE_STAGE"));
    if (stage == WFE_ENFORCE_OFF)
       aimee_log(LOG_WARN, "primary-cli-ingestor",
-                "AIMEE_PRIMARY_CLI_INGESTOR is on but AIMEE_WORKFLOW_ENFORCE_STAGE=off -> "
-                "enforcement is INERT: the tmux CLI primary will NOT bind. Set the dial to "
-                "advisory/soft/hard to activate.");
+                "AIMEE_PRIMARY_CLI_INGESTOR is on but AIMEE_WORKFLOW_ENFORCE_STAGE is off or unset "
+                "-> the tmux CLI primary will NOT bind. Set the dial to advisory/soft/hard.");
    else
       aimee_log(LOG_INFO, "primary-cli-ingestor",
                 "enforce-before-send ACTIVE for the tmux CLI primary (dial=%s)",

--- a/src/server/primary_cli_ingestor.c
+++ b/src/server/primary_cli_ingestor.c
@@ -4,7 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "log.h"
 #include "wfe_bind_ingress.h"
+#include "wfe_enforce.h"
 
 int primary_cli_ingestor_enabled(void)
 {
@@ -30,4 +32,21 @@ int primary_cli_ingestor_enforce_preturn(const char *session_id, const char *mes
     * the external-CLI primary, whose out-of-band model call the gateway router
     * never sees with a session id attached. */
    return wfe_bind_interactive(session_id, message, repo);
+}
+
+void primary_cli_ingestor_log_posture(void)
+{
+   if (!primary_cli_ingestor_enabled())
+      return; /* default-off: stay quiet; the hot path is untouched */
+
+   wfe_enforce_stage_t stage = wfe_enforce_stage_parse(getenv("AIMEE_WORKFLOW_ENFORCE_STAGE"));
+   if (stage == WFE_ENFORCE_OFF)
+      aimee_log(LOG_WARN, "primary-cli-ingestor",
+                "AIMEE_PRIMARY_CLI_INGESTOR is on but AIMEE_WORKFLOW_ENFORCE_STAGE=off -> "
+                "enforcement is INERT: the tmux CLI primary will NOT bind. Set the dial to "
+                "advisory/soft/hard to activate.");
+   else
+      aimee_log(LOG_INFO, "primary-cli-ingestor",
+                "enforce-before-send ACTIVE for the tmux CLI primary (dial=%s)",
+                wfe_enforce_stage_name(stage));
 }

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -9,6 +9,7 @@
 #include "harness_memory_scope.h"  /* hmem_scope_for_client */
 #include "json_fluent.h"           /* jo_ok */
 #include "memory_redirect.h"       /* memory_redirect_classify / _bash_targets / _rematerialize */
+#include "primary_cli_ingestor.h"
 #include "server.h"
 #include "turn_registry.h"
 #include "server_http.h" /* server_http_api_status_report */
@@ -1921,6 +1922,9 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * end-to-end server-side. Registration runs nothing on its own — a run begins
     * only when intake creates a work item and the autonomy driver advances it. */
    wfe_autonomy_register();
+   /* Boot-time enforcement-posture signal for the primary-CLI-ingestor: makes an
+    * "enabled but silently inert" misconfig (flag on, dial off) visible at startup. */
+   primary_cli_ingestor_log_posture();
    wfe_scheduler_init();
    /* Provision the delegate vault from operator-supplied secrets before serving,
     * so a freshly stood-up server's delegates/roundtables work without a manual

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1361,7 +1361,7 @@ $(TESTPREFIX)/unit-test-wfe-bind-ingress: $(OBJDIR)/tests/test_wfe_bind_ingress.
 # closure as unit-test-wfe-bind-ingress (it calls wfe_bind_interactive) + the
 # ingestor object.
 $(TESTPREFIX)/unit-test-primary-cli-ingestor: $(OBJDIR)/tests/test_primary_cli_ingestor.o \
-                                    $(OBJDIR)/server/primary_cli_ingestor.o \
+                                    $(OBJDIR)/server/primary_cli_ingestor.o $(OBJDIR)/log.o \
                                     $(OBJDIR)/workflow/wfe_bind_ingress.o $(OBJDIR)/workflow/wfe_enforce.o \
                                     $(OBJDIR)/workflow/wfe_externalization.o $(OBJDIR)/db1/wfe_binding.o \
                                     $(OBJDIR)/workflow/wfe_router.o $(OBJDIR)/workflow/wfe_router_catalog.o \

--- a/src/tests/test_primary_cli_ingestor.c
+++ b/src/tests/test_primary_cli_ingestor.c
@@ -131,6 +131,16 @@ int main(void)
    assert(primary_cli_ingestor_enforce_preturn(SID2, "hello there", NULL) == 0);
    assert(!bound(SID2));
 
+   /* posture log: safe (no crash) across all three branches -- off (no-op),
+    * on+dial-off (the inert-trap WARN), on+dial-on (active INFO). */
+   setenv("AIMEE_PRIMARY_CLI_INGESTOR", "0", 1);
+   primary_cli_ingestor_log_posture();
+   setenv("AIMEE_PRIMARY_CLI_INGESTOR", "1", 1);
+   unsetenv("AIMEE_WORKFLOW_ENFORCE_STAGE");
+   primary_cli_ingestor_log_posture();
+   setenv("AIMEE_WORKFLOW_ENFORCE_STAGE", "advisory", 1);
+   primary_cli_ingestor_log_posture();
+
    printf("ok\n");
    return 0;
 }


### PR DESCRIPTION
## Boot-time enforcement-posture log for the primary-CLI-ingestor (capstone)

Observability capstone for the primary-CLI-ingestor initiative. The strategic roundtable flagged ([51]) that enforcement can ship **"as enabled" while silently inert**, with no boot-time signal that the dial being on corresponds to the wiring being active — which is the exact failure class this whole initiative fixed (the tmux Claude primary was silently not binding).

At server startup (right after `wfe_autonomy_register`), when `AIMEE_PRIMARY_CLI_INGESTOR` is on:
- **dial off** → `LOG_WARN`: *"flag on but AIMEE_WORKFLOW_ENFORCE_STAGE=off → enforcement INERT: the tmux CLI primary will NOT bind"* — catches the flag-set-but-dial-forgotten trap.
- **dial on** → `LOG_INFO`: *"enforce-before-send ACTIVE for the tmux CLI primary (dial=X)"*.

When the flag is off it's a **no-op** (default, quiet; the hot path is untouched).

This complements the **live-verified** S4 wiring (#979) — S2 now demonstrably binds the tmux CLI primary (validated on .253: a `bind-s2` lifecycle_event on a real enforced turn) — and makes that posture visible **at boot** instead of only via a DB query.

### Verification
- `test_primary_cli_ingestor` exercises all three branches (off / inert-WARN / active-INFO) for no-crash; the active line was observed firing in the test run.
- Full `make unit-tests` (incl. every `server.o`-linking test — `server.c` now calls the new symbol), `aimee-server` link, `make lint` (clang-format-19, module-boundary, docs-gen) all green. (`log.o` added to the test link.)
