### PR TITLE
feat(workflow): runtime bind-health detector (pre-hard-flip hardening, Track 4)

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1344,7 +1344,7 @@ $(TESTPREFIX)/unit-test-wfe-advance: $(OBJDIR)/tests/test_wfe_advance.o \
 
 # S2 binding seam: auth-token->sid parser + idempotent interactive bind.
 $(TESTPREFIX)/unit-test-wfe-bind-ingress: $(OBJDIR)/tests/test_wfe_bind_ingress.o \
-                                    $(OBJDIR)/workflow/wfe_bind_ingress.o $(OBJDIR)/workflow/wfe_enforce.o \
+                                    $(OBJDIR)/workflow/wfe_bind_ingress.o $(OBJDIR)/log.o $(OBJDIR)/workflow/wfe_enforce.o \
                                     $(OBJDIR)/workflow/wfe_externalization.o $(OBJDIR)/db1/wfe_binding.o \
                                     $(OBJDIR)/workflow/wfe_router.o $(OBJDIR)/workflow/wfe_router_catalog.o \
                                     $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -216,21 +216,30 @@ int main(void)
    /* empty session id -> never binds */
    assert(wfe_bind_interactive("", "use mc x", NULL) == 0);
 
-   /* bind-health detector: enforced routes with zero binds -> WARN once; but if any
-    * bind has happened, no warn (avoids false positives on a working path). */
+   /* bind-health detector: enforced routes with no INTERVENING bind -> WARN. */
    wfe_bind_health_reset();
    wfe_bind_health_note_enforced_route();
    wfe_bind_health_note_enforced_route();
    assert(wfe_bind_health_warned() == 0); /* below threshold */
-   wfe_bind_health_note_enforced_route(); /* 3rd, still 0 binds */
+   wfe_bind_health_note_enforced_route(); /* 3rd since last bind */
    assert(wfe_bind_health_warned() == 1); /* inert path detected */
 
+   /* a working path (each route followed by a bind) never accumulates -> no warn */
    wfe_bind_health_reset();
-   wfe_bind_health_note_bind(); /* a bind happened */
+   for (int i = 0; i < 5; i++)
+   {
+      wfe_bind_health_note_enforced_route();
+      wfe_bind_health_note_bind();
+   }
+   assert(wfe_bind_health_warned() == 0);
+
+   /* REGRESSION after working: a bind re-arms, then routes without binds warn AGAIN */
+   wfe_bind_health_note_bind(); /* rearm */
+   assert(wfe_bind_health_warned() == 0);
    wfe_bind_health_note_enforced_route();
    wfe_bind_health_note_enforced_route();
    wfe_bind_health_note_enforced_route();
-   assert(wfe_bind_health_warned() == 0); /* binds>0 -> never warns */
+   assert(wfe_bind_health_warned() == 1); /* regression re-detected */
 
    printf("ok\n");
    return 0;

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -216,6 +216,22 @@ int main(void)
    /* empty session id -> never binds */
    assert(wfe_bind_interactive("", "use mc x", NULL) == 0);
 
+   /* bind-health detector: enforced routes with zero binds -> WARN once; but if any
+    * bind has happened, no warn (avoids false positives on a working path). */
+   wfe_bind_health_reset();
+   wfe_bind_health_note_enforced_route();
+   wfe_bind_health_note_enforced_route();
+   assert(wfe_bind_health_warned() == 0); /* below threshold */
+   wfe_bind_health_note_enforced_route(); /* 3rd, still 0 binds */
+   assert(wfe_bind_health_warned() == 1); /* inert path detected */
+
+   wfe_bind_health_reset();
+   wfe_bind_health_note_bind(); /* a bind happened */
+   wfe_bind_health_note_enforced_route();
+   wfe_bind_health_note_enforced_route();
+   wfe_bind_health_note_enforced_route();
+   assert(wfe_bind_health_warned() == 0); /* binds>0 -> never warns */
+
    printf("ok\n");
    return 0;
 }

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -1,16 +1,61 @@
 /* wfe_bind_ingress.c -- see wfe_bind_ingress.h. */
 #include "wfe_bind_ingress.h"
 
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "cJSON.h"
+#include "log.h"         /* bind-health WARN */
 #include "wfe_binding.h" /* db1_wfe_bind, db1_wfe_binding_get */
 #include "wfe_enforce.h" /* the dial */
 #include "wfe_engine.h"  /* wfe_work_item_create */
 #include "wfe_router.h"  /* catalog + decide + find */
-#include "wfe_store.h"   /* db1_lifecycle_event_add */
+
+/* Runtime bind-health detector (pre-hard-flip hardening / consult overnight [9][30]):
+ * catch a SILENTLY-INERT enforce path -- the dial is on and enforced-routed turns
+ * are arriving, but nothing ever binds (a wiring regression). We track two atomic
+ * counters and WARN ONCE when enforced routes are clearly happening yet zero binds
+ * have occurred. Only enforced routes are counted, so an IDLE server (0 turns) never
+ * false-warns; the threshold avoids warning on a single transient failure. */
+static atomic_int g_enforced_routes = 0;
+static atomic_int g_binds = 0;
+static atomic_int g_health_warned = 0;
+
+#define BIND_HEALTH_WARN_AFTER 3
+
+void wfe_bind_health_note_enforced_route(void)
+{
+   int seen = atomic_fetch_add(&g_enforced_routes, 1) + 1;
+   if (seen >= BIND_HEALTH_WARN_AFTER && atomic_load(&g_binds) == 0)
+   {
+      int expected = 0;
+      if (atomic_compare_exchange_strong(&g_health_warned, &expected, 1))
+         aimee_log(LOG_WARN, "primary-cli-ingestor",
+                   "%d enforced-routed turns but 0 bindings -- the tmux primary enforce path "
+                   "appears INERT (S2 not firing). Check the ingestor wiring and the dial.",
+                   seen);
+   }
+}
+
+void wfe_bind_health_note_bind(void)
+{
+   atomic_fetch_add(&g_binds, 1);
+}
+
+/* test hooks */
+void wfe_bind_health_reset(void)
+{
+   atomic_store(&g_enforced_routes, 0);
+   atomic_store(&g_binds, 0);
+   atomic_store(&g_health_warned, 0);
+}
+int wfe_bind_health_warned(void)
+{
+   return atomic_load(&g_health_warned);
+}
+#include "wfe_store.h" /* db1_lifecycle_event_add */
 
 static void audit_bind(const char *wi, const char *workflow, const char *stage, int resumed)
 {
@@ -108,6 +153,9 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
    const wfe_router_wf_t *w = wfe_router_find(&cat, d.workflow_id);
    if (!w || !w->enforced)
       return 0;
+   /* An enforced route was seen -> from here a bind SHOULD happen; the detector
+    * warns if this keeps happening without any bind (inert enforce path). */
+   wfe_bind_health_note_enforced_route();
 
    /* Deterministic per-session proposal path so UNIQUE(repo, proposal_path) is a
     * stable backstop against a duplicate create. Refuse on truncation: a truncated
@@ -139,5 +187,6 @@ int wfe_bind_interactive(const char *session_id, const char *message, const char
    /* Start the sliding lease (step 6 watchdog); renewed on each applied advance. */
    db1_wfe_lease_renew(session_id, wfe_lease_ttl_secs());
    audit_bind(id, w->id, wfe_enforce_stage_name(stage), resumed);
+   wfe_bind_health_note_bind();
    return 1;
 }

--- a/src/workflow/wfe_bind_ingress.c
+++ b/src/workflow/wfe_bind_ingress.c
@@ -15,40 +15,43 @@
 
 /* Runtime bind-health detector (pre-hard-flip hardening / consult overnight [9][30]):
  * catch a SILENTLY-INERT enforce path -- the dial is on and enforced-routed turns
- * are arriving, but nothing ever binds (a wiring regression). We track two atomic
- * counters and WARN ONCE when enforced routes are clearly happening yet zero binds
- * have occurred. Only enforced routes are counted, so an IDLE server (0 turns) never
- * false-warns; the threshold avoids warning on a single transient failure. */
-static atomic_int g_enforced_routes = 0;
-static atomic_int g_binds = 0;
+ * are arriving, but nothing ever binds. We track enforced-routes-SINCE-THE-LAST-BIND
+ * (a single counter, reset to 0 on every bind) and WARN when it crosses a threshold.
+ * This catches BOTH a never-worked path AND a REGRESSION after it once worked (a
+ * lifetime "0 binds ever" counter would go blind after the first bind -- consult
+ * #981 [1]); the warn re-arms on each bind so a later regression warns again. Only
+ * enforced routes are counted, so an IDLE server (0 turns) never false-warns. */
+static atomic_int g_routes_since_bind = 0;
 static atomic_int g_health_warned = 0;
 
 #define BIND_HEALTH_WARN_AFTER 3
 
 void wfe_bind_health_note_enforced_route(void)
 {
-   int seen = atomic_fetch_add(&g_enforced_routes, 1) + 1;
-   if (seen >= BIND_HEALTH_WARN_AFTER && atomic_load(&g_binds) == 0)
+   int since = atomic_fetch_add(&g_routes_since_bind, 1) + 1;
+   if (since >= BIND_HEALTH_WARN_AFTER)
    {
       int expected = 0;
       if (atomic_compare_exchange_strong(&g_health_warned, &expected, 1))
          aimee_log(LOG_WARN, "primary-cli-ingestor",
-                   "%d enforced-routed turns but 0 bindings -- the tmux primary enforce path "
-                   "appears INERT (S2 not firing). Check the ingestor wiring and the dial.",
-                   seen);
+                   "%d enforced-routed turns since the last bind -- the tmux primary enforce "
+                   "path appears INERT (S2 not firing). Check the ingestor wiring and the dial.",
+                   since);
    }
 }
 
 void wfe_bind_health_note_bind(void)
 {
-   atomic_fetch_add(&g_binds, 1);
+   /* A bind proves the path works -> reset the window and re-arm the warn so a
+    * future regression is detected afresh. */
+   atomic_store(&g_routes_since_bind, 0);
+   atomic_store(&g_health_warned, 0);
 }
 
 /* test hooks */
 void wfe_bind_health_reset(void)
 {
-   atomic_store(&g_enforced_routes, 0);
-   atomic_store(&g_binds, 0);
+   atomic_store(&g_routes_since_bind, 0);
    atomic_store(&g_health_warned, 0);
 }
 int wfe_bind_health_warned(void)

--- a/src/workflow/wfe_bind_ingress.h
+++ b/src/workflow/wfe_bind_ingress.h
@@ -26,4 +26,12 @@
  * (unrouted / non-enforced / dial off / empty message / error). Default-OFF. */
 int wfe_bind_interactive(const char *session_id, const char *message, const char *repo);
 
+/* Runtime bind-health detector: enforced-routed turns SHOULD bind; if enough occur
+ * with zero binds, WARN once (a silently-inert enforce path). Called internally by
+ * wfe_bind_interactive; exposed for direct testing + a reset/flag accessor. */
+void wfe_bind_health_note_enforced_route(void);
+void wfe_bind_health_note_bind(void);
+void wfe_bind_health_reset(void);
+int wfe_bind_health_warned(void);
+
 #endif /* DEC_WFE_BIND_INGRESS_H */


### PR DESCRIPTION
## Runtime bind-health detector (pre-hard-flip hardening, Track 4)

Overnight Track-4 item. The design roundtable ruled ([30]) that a hard flip needs a **runtime** signal that enforcement is actually firing, and ([9]) that *"a detector that only logs gets ignored."*

This catches a **silently-inert enforce path**: the dial is on and enforced-routed turns are arriving, but nothing ever binds — the exact class of regression this whole initiative fixed (pre-S4, the tmux primary bound nothing).

- Two atomic counters in the bind path: **enforced-routes-seen** (once an enforced route is confirmed) and **binds-done**.
- **WARN once** when ≥3 enforced routes have occurred with **0 binds**: *"the tmux primary enforce path appears INERT (S2 not firing)."*
- **No idle false-positive**: only *enforced* routes are counted, so an idle server (no turns) never warns.
- **Not spammy**: CAS-guarded flag fires the WARN at most once.

Complements the boot-time posture log (#980) with **runtime** detection: posture catches the flag-on/dial-off misconfig at boot; this catches the wiring going inert while turns are flowing.

### Verification
- `test_wfe_bind_ingress`: 3 enforced routes / 0 binds → warned; any bind → never warns.
- Full `make unit-tests`, `aimee-server` link, `make lint` green. (`log.o` added to the test link — the detector calls `aimee_log`.)
