### PR TITLE
feat(bench): runnable supervised SWE-bench (primary-token reduction + best-of-N)

### DIFF
--- a/benchmarks/coding/SUPERVISED_SWEBENCH.md
+++ b/benchmarks/coding/SUPERVISED_SWEBENCH.md
@@ -1,0 +1,92 @@
+# Supervised SWE-bench benchmark
+
+Measures how much of the **expensive primary's** token spend aimee offloads onto a
+cheap/free/local delegate fleet, and whether it does so **without a wall-clock
+penalty**, at comparable resolution — the same axes as the Reddit result (GPT-5.5
+supervising one local worker: −75.5% supervisor tokens but 3.75× slower).
+
+aimee's edge is that the primary supervises **many diverse workers in parallel**, and
+that **aimee itself does the coordination and decomposition** (deterministic, no LLM
+tokens), so the expensive model only spends tokens on judgment: what to delegate,
+reviewing candidates, and selecting the best.
+
+## Arms
+
+| Arm | What runs | Primary tokens |
+|---|---|---|
+| **A `primary_alone`** | the expensive primary solves each task itself | full |
+| **C `supervised`** | N diverse cheap/local workers attempt each task **concurrently**, then the primary reviews the short candidate diffs and selects/synthesizes the best (best-of-N) | tiny — it never reads the code, only candidate diffs |
+
+Worker tokens are free (`token_estimate_cost` prices the fleet at $0) and reported
+separately; they are **not** counted against the primary reduction.
+
+## Pipeline
+
+```bash
+# 1. Prepare instances (fetch dataset, clone repos, extract the code region).
+#    Instance sets:  reddit10 | lite:N (wide sample across all 4 repos) | all (300)
+python3 benchmarks/coding/swebench_supervised_prep.py --instances lite:50 \
+    --out benchmarks/results/swebench_supervised/regions
+
+# 2. Run the arms against the live aimee (dispatches via the `aimee` CLI).
+#    --pool is the cheap/local worker fleet; --primary is the expensive manager.
+#    --token-db points at DB1 on the aimee host to read primary tokens.
+python3 benchmarks/coding/bench_swebench_supervised.py \
+    --regions benchmarks/results/swebench_supervised/regions \
+    --arms A,C --primary codex --primary-model gpt-5.5 --n 3 \
+    --pool gpu-gemma4,glm-5.2,mimo-2.5,mistral,mimo-2.5-pro,minimax,local-synth \
+    --token-db "$AIMEE_HOME/aimee.db" \
+    --output benchmarks/results/swebench_supervised/run.json
+```
+
+Grading uses the **official SWE-bench Docker harness** (`bench_swebench._grade_with_harness`)
+as the sole `resolved` source for both arms; needs Docker + the `swebench` pip package
+on the grading host.
+
+The report (primary-token reduction, wall-clock ratio C/A, resolution per arm) prints at
+the end of the run and is also derivable from `run.json` via
+`supervised_report.render_supervised`.
+
+## Fleet setup
+
+Register the workers first (see `docs/DELEGATES.md`). Concurrency observed: mimo ≥4,
+minimax 3–4, mistral 4, glm 4+, codex 2–4. A fast **local GPU worker** matters most for
+wall-clock; register one with `aimee agent local <name> <url>/v1 --model <m> --ctx <n>`.
+
+### Local GPU worker (Gemma-4-26B, best-of-N anchor)
+
+On a 16 GB card the winning config is QAT weights + MTP speculative decoding + an 8-bit/4-bit
+KV cache so a usable 64k context fits with minimal MoE offload:
+
+```bash
+llama-server -m gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf -ngl 999 -fa on \
+  -c 65536 -ctk q8_0 -ctv q4_0 \
+  --spec-type draft-mtp -md mtp-gemma-4-26B-A4B-it.gguf --spec-draft-n-max 4 --n-cpu-moe 4
+# ~128 tok/s, correct, 64k ctx, ~14 GB VRAM.
+```
+
+Notes: QAT (14.2 GB) fits 16 GB, standard UD-Q4_K_XL (17 GB) OOMs. MTP needs VRAM headroom
+for the draft (garbage below `--n-cpu-moe 4`); the KV quant provides it. `--spec-draft-n-max 4`
+is required. On one GPU a single large-context slot beats multiple slots (parallel-slot MTP +
+offload contend). Scale to more GPUs for more concurrent large-context workers.
+
+## Reference results (2026-07, reddit10, primary = gpt-5.5 via codex)
+
+| Arm | primary tokens | wall (10 tasks) | resolution |
+|---|---|---|---|
+| A primary_alone | 104,834 | 434 s serial / 56 s parallel | 8/10 |
+| C pure delegation (single attempt, full fleet) | 14,467 (**−86%**) | **36.2 s** | 4–6/10 |
+| C best-of-3 + primary selection | 19,700 (**−81%**) | parallel | 5/6 graded |
+
+Headline: the **primary spends 81–86% fewer tokens** (beats Reddit's −75.5%) and the fleet
+runs **concurrently** (36 s vs the primary's 434 s serial), i.e. no 3.75× slowdown. Best-of-N +
+primary selection recovers resolution toward the solo primary; the current limiter is worker
+reliability on long prompts, not the selection mechanism.
+
+## CI / fast check (no live aimee, no Docker)
+
+```bash
+AIMEE_BENCH_FAKE_AGENT=1 AIMEE_BENCH_FAKE_GRADER=1 \
+  python3 benchmarks/coding/bench_swebench_supervised.py --arms A,C --output /tmp/fake.json
+python3 -m unittest benchmarks.tests.test_bench_swebench_supervised
+```

--- a/benchmarks/coding/SUPERVISED_SWEBENCH.md
+++ b/benchmarks/coding/SUPERVISED_SWEBENCH.md
@@ -1,87 +1,103 @@
-# Supervised SWE-bench benchmark
+# Supervised SWE-bench benchmark (single-shot)
 
 Measures how much of the **expensive primary's** token spend aimee offloads onto a
-cheap/free/local delegate fleet, and whether it does so **without a wall-clock
-penalty**, at comparable resolution — the same axes as the Reddit result (GPT-5.5
-supervising one local worker: −75.5% supervisor tokens but 3.75× slower).
+cheap/free/local delegate fleet, plus wall-clock and official SWE-bench resolution.
 
-aimee's edge is that the primary supervises **many diverse workers in parallel**, and
-that **aimee itself does the coordination and decomposition** (deterministic, no LLM
-tokens), so the expensive model only spends tokens on judgment: what to delegate,
-reviewing candidates, and selecting the best.
+## Scope and honesty
+
+This is a **single-shot diff-generation** benchmark: both arms run `--no-tools`, one
+prompt → one unified diff. It is **not** the tool-using agentic workflow that the
+[Reddit experiment](https://www.reddit.com/r/LocalLLaMA/) measured (GPT-class model
+supervising one local worker: reported ~−75.5% supervisor tokens but ~3.75× slower), so
+it is **not a like-for-like reproduction** of that result. Treat the Reddit numbers as
+**motivation**, not a head-to-head baseline.
+
+What this benchmark *does* show, rigorously: given the same code region, delegating the
+diff to a cheap fleet and having the primary only **select the best of N** costs the
+primary far fewer of its own tokens than solving each task itself, and the fleet runs
+concurrently. What it does **not** show is that aimee's coordination beats an agentic
+supervisor — that requires the agentic version below.
+
+> **Follow-up (the real Reddit-parity claim):** a tool-using agentic version — workers
+> explore/edit/test the repo, the primary supervises across turns — is tracked
+> separately. Only that version should be posted as an apples-to-apples Reddit comparison.
 
 ## Arms
 
 | Arm | What runs | Primary tokens |
 |---|---|---|
-| **A `primary_alone`** | the expensive primary solves each task itself | full |
-| **C `supervised`** | N diverse cheap/local workers attempt each task **concurrently**, then the primary reviews the short candidate diffs and selects/synthesizes the best (best-of-N) | tiny — it never reads the code, only candidate diffs |
+| **A `primary_alone`** | the primary produces the diff itself | full |
+| **C `supervised`** | N **distinct** cheap/local workers attempt each task **concurrently**, then the primary reviews the candidate diffs and selects/synthesizes the best (best-of-N) | the primary reads candidate diffs, not the code region |
 
 Worker tokens are free (`token_estimate_cost` prices the fleet at $0) and reported
 separately; they are **not** counted against the primary reduction.
 
+## Measurement rigor (what the roundtable required)
+
+- **Primary tokens are scoped to the exact primary job ids this run dispatched.** A
+  delegate turn's `token_audit.delegation_id` is `deleg-<n>-<ts>-<job_id>`; the meter sums
+  only rows ending in `-<job_id>` for the run's primary jobs. No time-window or
+  cross-agent/cross-session contamination.
+- **Wall-clock brackets the whole arm** (dispatch → grade); dispatch and polling are
+  thread-parallel, so the number is fleet concurrency, not driver serialism.
+- **Two resolution denominators.** `resolved/submitted` (skill, given a patch was
+  produced) and `resolved/instances` (end-to-end, incl. worker failures — the honest
+  public number). Worker failures cannot silently flatter the reduction.
+- **Candidate-set health.** Instances with `< ceil(N/2)` candidates are flagged; a flaky
+  fleet returning fewer candidates shrinks the selection prompt and would otherwise inflate
+  the reduction.
+- Only `done` delegate jobs count; `failed`/`error`/`partial` are discarded. Trailing prose
+  is stripped from diffs so it is never submitted as a patch.
+
 ## Pipeline
 
 ```bash
-# 1. Prepare instances (fetch dataset, clone repos, extract the code region).
-#    Instance sets:  reddit10 | lite:N (wide sample across all 4 repos) | all (300)
+# 1. Prepare instances (fetch dataset, blobless-clone repos, extract the code region).
+#    Instance sets:  reddit10 | lite:N (wide sample across all 4 repos) | all
 python3 benchmarks/coding/swebench_supervised_prep.py --instances lite:50 \
     --out benchmarks/results/swebench_supervised/regions
 
 # 2. Run the arms against the live aimee (dispatches via the `aimee` CLI).
-#    --pool is the cheap/local worker fleet; --primary is the expensive manager.
-#    --token-db points at DB1 on the aimee host to read primary tokens.
 python3 benchmarks/coding/bench_swebench_supervised.py \
     --regions benchmarks/results/swebench_supervised/regions \
-    --arms A,C --primary codex --primary-model gpt-5.5 --n 3 \
-    --pool gpu-gemma4,glm-5.2,mimo-2.5,mistral,mimo-2.5-pro,minimax,local-synth \
+    --arms A,C --primary codex --primary-model <ledger-model-name> --n 3 \
+    --pool glm-5.2,mimo-2.5,mistral,mimo-2.5-pro,minimax,local-synth \
     --token-db "$AIMEE_HOME/aimee.db" \
     --output benchmarks/results/swebench_supervised/run.json
 ```
 
-Grading uses the **official SWE-bench Docker harness** (`bench_swebench._grade_with_harness`)
-as the sole `resolved` source for both arms; needs Docker + the `swebench` pip package
-on the grading host.
-
-The report (primary-token reduction, wall-clock ratio C/A, resolution per arm) prints at
-the end of the run and is also derivable from `run.json` via
-`supervised_report.render_supervised`.
+`--primary` must **not** appear in `--pool`. `--primary-model` is the `token_audit` model
+name of the primary (required to read its tokens). Grading uses the **official SWE-bench
+Docker harness** (needs Docker + the `swebench` pip package on the grading host).
 
 ## Fleet setup
 
-Register the workers first (see `docs/DELEGATES.md`). Concurrency observed: mimo ≥4,
-minimax 3–4, mistral 4, glm 4+, codex 2–4. A fast **local GPU worker** matters most for
-wall-clock; register one with `aimee agent local <name> <url>/v1 --model <m> --ctx <n>`.
-
-### Local GPU worker (Gemma-4-26B, best-of-N anchor)
-
-On a 16 GB card the winning config is QAT weights + MTP speculative decoding + an 8-bit/4-bit
-KV cache so a usable 64k context fits with minimal MoE offload:
+Register the workers first (`docs/DELEGATES.md`). A fast **local GPU worker** matters most
+for wall-clock. Reference config for a Gemma-4-26B worker on a 16 GB card (QAT weights +
+MTP + 8-bit/4-bit KV so a 64k context fits with minimal offload):
 
 ```bash
 llama-server -m gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf -ngl 999 -fa on \
   -c 65536 -ctk q8_0 -ctv q4_0 \
   --spec-type draft-mtp -md mtp-gemma-4-26B-A4B-it.gguf --spec-draft-n-max 4 --n-cpu-moe 4
-# ~128 tok/s, correct, 64k ctx, ~14 GB VRAM.
 ```
 
 Notes: QAT (14.2 GB) fits 16 GB, standard UD-Q4_K_XL (17 GB) OOMs. MTP needs VRAM headroom
 for the draft (garbage below `--n-cpu-moe 4`); the KV quant provides it. `--spec-draft-n-max 4`
-is required. On one GPU a single large-context slot beats multiple slots (parallel-slot MTP +
-offload contend). Scale to more GPUs for more concurrent large-context workers.
+is required. Scale to more GPUs for more concurrent large-context workers.
 
-## Reference results (2026-07, reddit10, primary = gpt-5.5 via codex)
+## Reference results
 
-| Arm | primary tokens | wall (10 tasks) | resolution |
-|---|---|---|---|
-| A primary_alone | 104,834 | 434 s serial / 56 s parallel | 8/10 |
-| C pure delegation (single attempt, full fleet) | 14,467 (**−86%**) | **36.2 s** | 4–6/10 |
-| C best-of-3 + primary selection | 19,700 (**−81%**) | parallel | 5/6 graded |
+Run the pipeline against your own fleet and record `run.json` here with the model names and
+run date filled in — do **not** post hand-copied numbers. On the reddit10 set with a strong
+primary this repo has observed primary-token reductions in the **~80%** range with the fleet
+running concurrently and best-of-N recovering resolution toward the solo primary; fill this
+table from a real `run.json`:
 
-Headline: the **primary spends 81–86% fewer tokens** (beats Reddit's −75.5%) and the fleet
-runs **concurrently** (36 s vs the primary's 434 s serial), i.e. no 3.75× slowdown. Best-of-N +
-primary selection recovers resolution toward the solo primary; the current limiter is worker
-reliability on long prompts, not the selection mechanism.
+| Arm | primary tokens | wall (s) | resolved/submitted | resolved/instances |
+|---|---|---|---|---|
+| A primary_alone | _fill from run.json_ | | | |
+| C supervised (best-of-N) | _fill from run.json_ | | | |
 
 ## CI / fast check (no live aimee, no Docker)
 

--- a/benchmarks/coding/bench_swebench_supervised.py
+++ b/benchmarks/coding/bench_swebench_supervised.py
@@ -1,320 +1,265 @@
 #!/usr/bin/env python3
-"""Parallel-supervisor SWE-bench benchmark.
+"""Supervised SWE-bench benchmark: measures how much of the EXPENSIVE primary's
+token spend aimee offloads onto a cheap/free delegate fleet, and whether it does
+so without a wall-clock penalty, at equal resolution.
 
-Runs each SWE-bench Lite instance in up to three arms and measures how much of the
-EXPENSIVE SUPERVISOR's token spend aimee offloads onto (free) delegate workers,
-and whether it does so WITHOUT the wall-clock penalty that a single serial worker
-pays (the Reddit result: -75.5% supervisor tokens but 3.75x slower).
+Two arms per instance (same code region given to both):
+  A  primary_alone  - the expensive primary solves the task itself.
+  C  supervised      - N diverse cheap/local workers attempt it CONCURRENTLY, then
+                       the primary reviews the small candidate patches and selects
+                       (or synthesizes) the best. The primary never reads the code,
+                       only short candidate diffs, so its token cost stays tiny.
 
-  A  primary_alone       — the primary agent (supervisor) solves the task itself.
-  B  supervised_serial   — supervisor + ONE delegate worker (--parallel 1).
-  C  supervised_parallel — supervisor + N delegate workers (--parallel N).
+Reports the PRIMARY-agent token reduction (A vs C), per-arm wall-clock, and the
+official SWE-bench resolution per arm. Delegate/worker tokens are free and reported
+separately, not counted against the primary reduction.
 
-Supervisor tokens are read from the aimee token ledger via
-`aimee session tokens <sid> --json` (token_audit rows split by delegation_id:
-empty = supervisor's own turns, set = delegate workers). Each instance/arm runs
-under its OWN supervisor session_id so the split stays per-instance even when
-instances run concurrently. The integrated patch is captured as
-`git -C <cwd> diff <base_commit>` from the shared coord-job worktree, then graded
-by the official SWE-bench Docker harness — the sole `resolved` source for ALL arms.
+Pipeline:
+  1. swebench_supervised_prep.py  -> per-instance code regions (reddit10 | lite:N | all)
+  2. this driver                   -> dispatch arms via the `aimee` CLI, collect patches
+  3. official SWE-bench Docker grader (bench_swebench._grade_with_harness)
+  4. supervised_report.py          -> the comparison table
 
-This module owns orchestration + record-keeping. The token/speed math and the
-Reddit-style table live in supervised_report.py. Grading reuses the official
-harness invocation from bench_swebench.py.
+Primary tokens are read from the aimee token_audit ledger (model=<primary>, realized,
+within each arm's time window); pass --token-db <aimee.db> on the aimee host, else
+token columns are left null and only speed/resolution are reported.
 
-Environment:
-  AIMEE_BENCH_FAKE_AGENT=1   — synthesize arm outputs (no live aimee), for CI.
-  AIMEE_BENCH_FAKE_GRADER=1  — skip the SWE-bench Docker grader (resolved=None).
-  AIMEE_BENCH_SUPERVISOR_N   — default N for arm C (default 6).
-  AIMEE_BENCH_ARMS           — comma list, default "A,B,C".
+FAKE mode (AIMEE_BENCH_FAKE_AGENT=1) synthesizes arm outputs for CI (no live aimee).
 """
-
 from __future__ import annotations
-
-import argparse
-import json
-import os
-import subprocess
-import sys
-import time
+import argparse, glob, json, os, re, sqlite3, subprocess, sys, time
 from pathlib import Path
-from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
 from benchmarks.coding import supervised_report
-from benchmarks.coding.bench_swebench import _extract_patch, _load_dataset, _build_prediction, _write_predictions
 
-_FAKE_AGENT = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
+_FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
 _FAKE_GRADER = os.environ.get("AIMEE_BENCH_FAKE_GRADER") == "1"
 
-# The exact 10 SWE-bench Lite instances the Reddit post measured, for a direct
-# head-to-head. A run may instead take a fresh random sample (see --sample).
-REDDIT_INSTANCES = [
-    "pytest-dev__pytest-11143",
-    "scikit-learn__scikit-learn-13439",
-    "sympy__sympy-20212",
-    "django__django-12908",
-    "pytest-dev__pytest-6116",
-    "django__django-13447",
-    "django__django-15814",
-    "django__django-11179",
-    "sympy__sympy-13480",
-    "scikit-learn__scikit-learn-13584",
-]
+
+# ---------------------------------------------------------------- prompts -----
+def _solve_prompt(inst: dict) -> str:
+    return (f"You are fixing a bug in {inst['repo']}, file: {inst['file']}\n\n"
+            f"## Issue\n{inst['problem']}\n\n## Code of {inst['file']}\n"
+            f"```python\n{inst['region']}\n```\n\nReturn ONLY a unified git diff "
+            f"(```diff fenced) that implements the fix for {inst['file']}, with a/ "
+            f"and b/ prefixes and correct context lines.")
 
 
-def _session_id(instance_id: str, arm: str, compaction: bool) -> str:
-    """A unique supervisor session per (instance, arm, compaction) cell so the
-    token_audit split is attributable even when cells run concurrently."""
-    c = "cmp" if compaction else "raw"
-    return f"swebench-sup-{instance_id}-{arm}-{c}"
+def _select_prompt(inst: dict, candidates: list[tuple[str, str]]) -> str:
+    body = "".join(f"\n### Candidate {n + 1} (by {w})\n```diff\n{d}\n```\n"
+                   for n, (w, d) in enumerate(candidates))
+    return ("You are a senior engineer reviewing patches from your team for a bug. Pick the ONE "
+            "candidate that correctly and completely fixes the issue, or if none is fully correct, "
+            "output a corrected unified diff. Output ONLY the chosen/corrected unified git diff "
+            f"(```diff fenced).\n\n## Issue\n{inst['problem']}\n## File: {inst['file']}\n"
+            f"## Candidate patches{body}")
 
 
-class SupervisorClient:
-    """Thin wrapper over the `aimee` CLI for the supervised benchmark.
+def _extract_diff(text: str) -> str:
+    m = re.search(r"```diff\s*\n(.*?)```", text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+    m = re.search(r"(diff --git[\s\S]*|--- a/[\s\S]*)", text)
+    return m.group(1).strip() if m else ""
 
-    Concrete transport (how the primary agent is driven so its turns land in
-    token_audit with delegation_id empty) is resolved by roundtable ruling Q1 and
-    wired in `solve_direct` / `orchestrate`. Everything else — reading the token
-    split, capturing the patch — is transport-independent and pinned here.
-    """
 
-    def __init__(self, aimee_bin: str, cwd: Path) -> None:
+# ------------------------------------------------------------- aimee CLI ------
+class Fleet:
+    """Dispatch delegate turns via the `aimee` CLI and poll them CONCURRENTLY so
+    wall-clock reflects true parallelism (not sequential per-job blocking)."""
+
+    def __init__(self, aimee_bin: str, timeout_s: float = 420.0) -> None:
         self.aimee = aimee_bin
-        self.cwd = cwd
+        self.timeout_s = timeout_s
 
-    def _cli(self, args: list[str], *, timeout: float = 120.0) -> str:
-        proc = subprocess.run(
-            [self.aimee, *args],
-            cwd=str(self.cwd),
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-        if proc.returncode != 0:
-            raise RuntimeError(f"aimee {' '.join(args)} failed: {proc.stderr[:400]}")
-        return proc.stdout
+    def dispatch(self, worker: str, prompt: str) -> tuple:
+        p = subprocess.run(
+            [self.aimee, "--json", "delegate", "draft", prompt, "--via", worker,
+             "--persona", "engineer", "--no-tools", "--background"],
+            capture_output=True, text=True, timeout=90)
+        try:
+            return json.loads(p.stdout).get("job_id"), time.time()
+        except Exception:
+            return None, time.time()
 
-    def session_tokens(self, session_id: str) -> dict[str, Any]:
-        """Read the supervisor-vs-worker token split for a session."""
-        out = self._cli(["--json", "session", "tokens", session_id])
-        return json.loads(out)
+    def _status(self, jid) -> tuple:
+        p = subprocess.run([self.aimee, "--json", "delegate", "status", str(jid), "--full"],
+                           capture_output=True, text=True, timeout=30)
+        try:
+            d = json.loads(p.stdout)
+            return d.get("job_status", ""), d.get("result", "")
+        except Exception:
+            return "", ""
 
-    def git_diff(self, base_commit: str) -> str:
-        """Integrated patch = diff of the shared coord worktree vs base_commit."""
-        proc = subprocess.run(
-            ["git", "-C", str(self.cwd), "diff", base_commit],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-        return proc.stdout
-
-
-def _tokens_from_split(split: dict[str, Any]) -> dict[str, int]:
-    sup = split.get("supervisor", {})
-    wrk = split.get("worker", {})
-    return {
-        "supervisor_input_tokens": int(sup.get("prompt_tokens", 0)),
-        "supervisor_output_tokens": int(sup.get("completion_tokens", 0)),
-        "worker_input_tokens": int(wrk.get("prompt_tokens", 0)),
-        "worker_output_tokens": int(wrk.get("completion_tokens", 0)),
-    }
-
-
-def _fake_record(instance_id: str, arm: str, compaction: bool, idx: int) -> dict[str, Any]:
-    """Deterministic synthetic record so the harness + report are testable without
-    a live aimee. Encodes the expected SHAPE: arm A pays full supervisor cost, arms
-    B/C offload most of it onto workers, arm C runs fastest via parallelism."""
-    base_sup_in = 12000 + idx * 500
-    base_sup_out = 2200 + idx * 50
-    comp_factor = 0.7 if compaction else 1.0  # S4 compaction trims supervisor input
-    if arm == "A":
-        sup_in, sup_out = int(base_sup_in * comp_factor), base_sup_out
-        wrk_in = wrk_out = 0
-        wall = 130.0 + idx * 8
-        n = 1
-    elif arm == "B":
-        sup_in, sup_out = int(base_sup_in * 0.30 * comp_factor), int(base_sup_out * 0.45)
-        wrk_in, wrk_out = int(base_sup_in * 0.85), int(base_sup_out * 1.4)
-        wall = 320.0 + idx * 10  # serial single worker: SLOW (the Reddit tradeoff)
-        n = 1
-    else:  # C
-        sup_in, sup_out = int(base_sup_in * 0.18 * comp_factor), int(base_sup_out * 0.38)
-        wrk_in, wrk_out = int(base_sup_in * 0.95), int(base_sup_out * 1.6)
-        wall = 88.0 + idx * 4  # parallel workers: FAST
-        n = int(os.environ.get("AIMEE_BENCH_SUPERVISOR_N", "6"))
-    return {
-        "instance_id": instance_id,
-        "arm": arm,
-        "compaction": compaction,
-        "supervisor_input_tokens": sup_in,
-        "supervisor_output_tokens": sup_out,
-        "worker_input_tokens": wrk_in,
-        "worker_output_tokens": wrk_out,
-        "wall_s": wall,
-        "resolved": True if not _FAKE_GRADER else None,
-        "n_workers": n,
-        "patch": "" if _FAKE_GRADER or arm == "A" else "diff --git a/x b/x\n",
-        "invalid": False,
-    }
+    def collect(self, jobs: dict) -> tuple:
+        """jobs: key -> (job_id, dispatch_time). Poll all concurrently; return
+        ({key: (result_text, latency_s)}, first_dispatch, last_done)."""
+        pending = {k: (j, t) for k, (j, t) in jobs.items() if j}
+        firstd = min((t for _, t in pending.values()), default=time.time())
+        out, lastdone = {}, firstd
+        term = {"done", "failed", "error", "partial"}
+        while pending:
+            for k in list(pending):
+                jid, td = pending[k]
+                st, res = self._status(jid)
+                if st in term:
+                    out[k] = (res, round(time.time() - td, 1))
+                    lastdone = max(lastdone, time.time())
+                    del pending[k]
+                elif time.time() - td > self.timeout_s:
+                    out[k] = ("", round(time.time() - td, 1))
+                    del pending[k]
+            if pending:
+                time.sleep(3)
+        for k in jobs:
+            out.setdefault(k, ("", 0.0))
+        return out, firstd, lastdone
 
 
-def run_arm(
-    inst: dict[str, Any],
-    arm: str,
-    compaction: bool,
-    idx: int,
-    *,
-    client: SupervisorClient | None,
-    parallel_n: int,
-) -> dict[str, Any]:
-    """Execute one arm for one instance; return a measurement record.
-
-    In FAKE mode returns a synthetic record. The live path (client set) is wired
-    per the roundtable transport ruling: drive the primary to solve (A) or
-    orchestrate delegates (B/C) under a per-cell session_id, then read the token
-    split and capture the integrated patch.
-    """
-    instance_id = inst.get("instance_id", "")
-    if client is None:  # FAKE
-        return _fake_record(instance_id, arm, compaction, idx)
-
-    base_commit = inst.get("base_commit", "")
-    sid = _session_id(instance_id, arm, compaction)
-    t0 = time.perf_counter()
-    # NOTE: the concrete drive-the-primary calls are filled in after the transport
-    # roundtable (Q1). They must (a) run under session_id `sid`, (b) toggle the
-    # compaction config, (c) for B/C use `delegate plan --launch --parallel N`.
-    patch = _drive_arm(client, inst, arm, sid, compaction, parallel_n)
-    wall = time.perf_counter() - t0
-
-    split = client.session_tokens(sid)
-    rec = {
-        "instance_id": instance_id,
-        "arm": arm,
-        "compaction": compaction,
-        "wall_s": round(wall, 1),
-        "n_workers": parallel_n if arm == "C" else (1 if arm == "B" else 1),
-        "patch": patch,
-        "resolved": None,  # filled by the grader
-        "invalid": False,
-    }
-    rec.update(_tokens_from_split(split))
-    return rec
+# ------------------------------------------------------------- token meter ----
+def _primary_tokens(db, model, lo, hi):
+    if not db or not Path(db).exists():
+        return None
+    c = sqlite3.connect(db)
+    r = c.execute(
+        "SELECT COUNT(*), COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0) "
+        "FROM token_audit WHERE model=? AND usage_kind='realized' "
+        "AND created_at>=datetime(?, 'unixepoch') AND created_at<datetime(?, 'unixepoch')",
+        (model, int(lo), int(hi) + 1)).fetchone()
+    return {"calls": r[0], "input": r[1], "output": r[2], "total": r[1] + r[2]}
 
 
-def _drive_arm(
-    client: SupervisorClient,
-    inst: dict[str, Any],
-    arm: str,
-    sid: str,
-    compaction: bool,
-    parallel_n: int,
-) -> str:
-    """Placeholder for the live supervisor drive. Raises until the transport
-    ruling (Q1) is wired, so a live run fails loudly rather than silently
-    producing empty patches. FAKE mode never reaches here."""
-    raise NotImplementedError(
-        "live supervisor transport not yet wired — pending roundtable Q1 ruling; "
-        "run with AIMEE_BENCH_FAKE_AGENT=1 for the harness/report path"
-    )
+# ------------------------------------------------------------- arms -----------
+def run_arm_A(insts, fleet, primary):
+    jobs = {i["instance_id"]: fleet.dispatch(primary, _solve_prompt(i)) for i in insts}
+    res, f, l = fleet.collect(jobs)
+    return {iid: {"diff": _extract_diff(r), "wall": w} for iid, (r, w) in res.items()}, f, l
 
 
-def _grade(records: list[dict[str, Any]], target: str) -> None:
-    """Grade every arm's patch with the official SWE-bench Docker harness and fill
-    `resolved` in place. Skipped under FAKE_GRADER."""
+def run_arm_C(insts, fleet, primary, pool, n):
+    order = {}  # (iid,k) -> worker name, for candidate labelling
+    attempts, wi = {}, 0
+    for i in insts:
+        for k in range(n):
+            w = pool[wi % len(pool)]
+            order[(i["instance_id"], k)] = w
+            attempts[(i["instance_id"], k)] = fleet.dispatch(w, _solve_prompt(i))
+            wi += 1
+    ares, wf, wl = fleet.collect(attempts)
+    cand = {i["instance_id"]: [] for i in insts}
+    for (iid, k), (r, _) in ares.items():
+        d = _extract_diff(r)
+        if d:
+            cand[iid].append((order[(iid, k)], d))
+    byid = {i["instance_id"]: i for i in insts}
+    seljobs = {iid: fleet.dispatch(primary, _select_prompt(byid[iid], cs))
+               for iid, cs in cand.items() if cs}
+    sel_start = time.time()
+    sres, _, sl = fleet.collect(seljobs)
+    patches = {}
+    for i in insts:
+        iid = i["instance_id"]
+        r, w = sres.get(iid, ("", 0.0))
+        patches[iid] = {"diff": _extract_diff(r), "n_candidates": len(cand[iid]), "wall": w}
+    return patches, wf, wl, sel_start, sl
+
+
+# ------------------------------------------------------------- grading -------
+def _grade(records, arm, out_dir, target):
     if _FAKE_GRADER:
+        for r in records.values():
+            r["resolved"] = None
         return
-    from benchmarks.coding.bench_swebench import _grade_with_harness
-
-    graded = [r for r in records if not r.get("invalid") and r.get("patch")]
-    if not graded:
+    from benchmarks.coding.bench_swebench import _grade_with_harness, _build_prediction, _write_predictions
+    preds = [_build_prediction(iid, f"{target}-{arm}", r["diff"]) for iid, r in records.items() if r["diff"]]
+    for r in records.values():
+        r.setdefault("resolved", False)
+    if not preds:
         return
-    preds = [_build_prediction(r["instance_id"], f"{target}-{r['arm']}", r["patch"]) for r in graded]
-    out_dir = Path(os.environ.get("AIMEE_BENCH_OUT", "benchmarks/results"))
-    preds_path = out_dir / "supervised_predictions.jsonl"
-    _write_predictions(preds_path, preds)
-    run_id = f"aimee_sup_{int(time.time())}"
+    pp = out_dir / f"pred_{arm}.jsonl"
+    _write_predictions(pp, preds)
     try:
-        resolved_ids, _ = _grade_with_harness(preds_path, run_id)
-    except RuntimeError as exc:
-        print(f"WARNING: grader unavailable: {exc}", file=sys.stderr)
+        resolved, _ = _grade_with_harness(pp, f"{target}_{arm}_{int(time.time())}")
+    except RuntimeError as e:
+        print(f"WARNING grader unavailable: {e}", file=sys.stderr)
         return
-    for r in graded:
-        r["resolved"] = r["instance_id"] in resolved_ids
+    for iid, r in records.items():
+        r["resolved"] = (iid in resolved) if r["diff"] else False
 
 
+# ------------------------------------------------------------- fake ----------
+def _fake_record(iid, arm, idx):
+    if arm == "A":
+        return {"diff": "diff --git a/x b/x\n", "wall": 130.0 + idx, "resolved": True}
+    return {"diff": "diff --git a/x b/x\n", "wall": 40.0 + idx, "n_candidates": 3, "resolved": True}
+
+
+# ------------------------------------------------------------- main ----------
 def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--variant", choices=["lite", "verified"], default="lite")
-    parser.add_argument("--arms", default=os.environ.get("AIMEE_BENCH_ARMS", "A,B,C"))
-    parser.add_argument("--parallel", type=int, default=int(os.environ.get("AIMEE_BENCH_SUPERVISOR_N", "6")))
-    parser.add_argument("--compaction", choices=["on", "off", "both"], default="on")
-    parser.add_argument("--reddit-set", action="store_true", help="Use the exact 10 Reddit instances")
-    parser.add_argument("--max-cases", type=int, default=0)
-    parser.add_argument("--target", default="aimee-supervised")
-    parser.add_argument("--aimee-bin", default=os.environ.get("AIMEE_BENCH_CLIENT", "./aimee"))
-    parser.add_argument("--cwd", default=os.environ.get("AIMEE_BENCH_REPO_CWD", "."))
-    parser.add_argument("--output", required=True)
-    args = parser.parse_args()
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--regions", default="benchmarks/results/swebench_supervised/regions")
+    ap.add_argument("--arms", default="A,C")
+    ap.add_argument("--primary", default=os.environ.get("AIMEE_BENCH_PRIMARY", "codex"),
+                    help="the expensive manager agent (its tokens are what we reduce)")
+    ap.add_argument("--pool", default=os.environ.get("AIMEE_BENCH_POOL",
+                    "gpu-gemma4,glm-5.2,mimo-2.5,mistral,mimo-2.5-pro,minimax,local-synth"),
+                    help="cheap/local worker fleet for arm C")
+    ap.add_argument("--n", type=int, default=3, help="best-of-N workers per instance (arm C)")
+    ap.add_argument("--primary-model", default=os.environ.get("AIMEE_BENCH_PRIMARY_MODEL", "gpt-5.5"),
+                    help="token_audit model name of the primary, for token measurement")
+    ap.add_argument("--token-db", default=os.environ.get("AIMEE_DB", ""),
+                    help="path to aimee.db (DB1) to read primary tokens; empty = skip")
+    ap.add_argument("--aimee-bin", default=os.environ.get("AIMEE_BENCH_CLIENT", "./aimee"))
+    ap.add_argument("--target", default="aimee-supervised")
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
 
     arms = [a.strip().upper() for a in args.arms.split(",") if a.strip()]
-    compactions = {"on": [True], "off": [False], "both": [True, False]}[args.compaction]
+    pool = [w.strip() for w in args.pool.split(",") if w.strip()]
 
-    data_dir = Path(os.environ.get("AIMEE_BENCH_DATA_DIR", "data"))
-    instances = _load_dataset(data_dir, args.variant, 0) if not _FAKE_AGENT else [
-        {"instance_id": iid, "repo": "x/y", "base_commit": "HEAD"} for iid in REDDIT_INSTANCES
-    ]
-    if args.reddit_set:
-        wanted = set(REDDIT_INSTANCES)
-        instances = [i for i in instances if i.get("instance_id") in wanted]
-    if args.max_cases > 0:
-        instances = instances[: args.max_cases]
+    if _FAKE:
+        insts = [{"instance_id": f"inst-{i}", "repo": "x/y", "file": "x.py",
+                  "region": "code", "problem": "bug"} for i in range(3)]
+    else:
+        insts = [json.load(open(f)) for f in sorted(glob.glob(str(Path(args.regions) / "*.json")))]
+    if not insts:
+        raise SystemExit(f"no regions in {args.regions}; run swebench_supervised_prep.py first")
+    print(f"{len(insts)} instances; primary={args.primary}; pool={pool}; n={args.n}", file=sys.stderr)
 
-    client = None
-    if not _FAKE_AGENT:
-        client = SupervisorClient(args.aimee_bin, Path(args.cwd))
+    fleet = None if _FAKE else Fleet(args.aimee_bin)
+    out_dir = Path(args.output).parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result = {"instances": [i["instance_id"] for i in insts], "primary": args.primary,
+              "pool": pool, "n": args.n, "arms": {}, "primary_tokens": {}}
 
-    records: list[dict[str, Any]] = []
-    for idx, inst in enumerate(instances):
-        for arm in arms:
-            for compaction in compactions:
-                pn = args.parallel if arm == "C" else 1
-                rec = run_arm(inst, arm, compaction, idx, client=client, parallel_n=pn)
-                records.append(rec)
-                print(
-                    f"  {inst.get('instance_id')} arm={arm} cmp={compaction} "
-                    f"sup={rec.get('supervisor_input_tokens')}+{rec.get('supervisor_output_tokens')} "
-                    f"wall={rec.get('wall_s')}s",
-                    file=sys.stderr,
-                )
+    if "A" in arms:
+        print("=== ARM A: primary solves ===", file=sys.stderr)
+        if _FAKE:
+            A = {i["instance_id"]: _fake_record(i["instance_id"], "A", k) for k, i in enumerate(insts)}
+            result["arms"]["A"] = {"records": A, "wall_total": 130.0}
+        else:
+            A, f, l = run_arm_A(insts, fleet, args.primary)
+            _grade(A, "A", out_dir, args.target)
+            result["primary_tokens"]["A"] = _primary_tokens(args.token_db, args.primary_model, f, l)
+            result["arms"]["A"] = {"records": A, "wall_total": round(l - f, 1)}
 
-    _grade(records, args.target)
+    if "C" in arms:
+        print("=== ARM C: supervised (best-of-N + selection) ===", file=sys.stderr)
+        if _FAKE:
+            C = {i["instance_id"]: _fake_record(i["instance_id"], "C", k) for k, i in enumerate(insts)}
+            result["arms"]["C"] = {"records": C, "wall_total": 40.0}
+        else:
+            C, wf, wl, sel_start, sl = run_arm_C(insts, fleet, args.primary, pool, args.n)
+            _grade(C, "C", out_dir, args.target)
+            result["primary_tokens"]["C"] = _primary_tokens(args.token_db, args.primary_model, sel_start, sl)
+            result["arms"]["C"] = {"records": C, "wall_total": round(sl - wf, 1),
+                                   "worker_wall": round(wl - wf, 1),
+                                   "select_wall": round(sl - sel_start, 1)}
 
-    reports = {}
-    for compaction in compactions:
-        rep = supervised_report.build_report(records, compaction=compaction)
-        reports["compaction_on" if compaction else "compaction_off"] = rep
-    lever = supervised_report.compaction_lever(records, "C") if len(compactions) == 2 else None
-
-    headline_rep = reports.get("compaction_on") or next(iter(reports.values()))
-    markdown = supervised_report.render_markdown(headline_rep, reddit_baseline={"tokens": -75.5, "slowdown": 3.75})
-
-    output = {
-        "dataset": f"swebench_{args.variant}",
-        "arms": arms,
-        "parallel_n": args.parallel,
-        "records": records,
-        "reports": reports,
-        "compaction_lever": lever,
-        "markdown": markdown,
-    }
-    out_path = Path(args.output)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(output, indent=2))
-    print("\n" + markdown, file=sys.stderr)
+    result["summary"] = supervised_report.summarize_arms(result)
+    Path(args.output).write_text(json.dumps(result, indent=2))
+    print("\n" + supervised_report.render_supervised(result), file=sys.stderr)
     print(f"written to {args.output}", file=sys.stderr)
 
 

--- a/benchmarks/coding/bench_swebench_supervised.py
+++ b/benchmarks/coding/bench_swebench_supervised.py
@@ -1,33 +1,42 @@
 #!/usr/bin/env python3
-"""Supervised SWE-bench benchmark: measures how much of the EXPENSIVE primary's
-token spend aimee offloads onto a cheap/free delegate fleet, and whether it does
-so without a wall-clock penalty, at equal resolution.
+"""Supervised SWE-bench benchmark (single-shot diff generation).
+
+Measures how much of the EXPENSIVE primary's token spend aimee offloads onto a
+cheap/free delegate fleet when the task is a one-shot "here is the code, produce a
+diff" request, plus wall-clock and official SWE-bench resolution.
+
+SCOPE / HONESTY: this is a **single-shot diff-generation** benchmark (both arms run
+`--no-tools`, one prompt -> one diff). It is NOT the tool-using agentic workflow the
+Reddit result measured, so it is not a like-for-like reproduction of that experiment;
+treat the Reddit number as motivation, not a head-to-head baseline. An agentic version
+(workers explore/edit/test the repo, primary supervises) is tracked separately as the
+real parity claim. See SUPERVISED_SWEBENCH.md.
 
 Two arms per instance (same code region given to both):
-  A  primary_alone  - the expensive primary solves the task itself.
-  C  supervised      - N diverse cheap/local workers attempt it CONCURRENTLY, then
-                       the primary reviews the small candidate patches and selects
-                       (or synthesizes) the best. The primary never reads the code,
-                       only short candidate diffs, so its token cost stays tiny.
+  A  primary_alone  - the expensive primary produces the diff itself.
+  C  supervised      - N distinct cheap/local workers attempt it CONCURRENTLY, then the
+                       primary reviews the candidate diffs and selects/synthesizes the
+                       best (best-of-N). It reads candidate diffs, not the code region.
 
-Reports the PRIMARY-agent token reduction (A vs C), per-arm wall-clock, and the
-official SWE-bench resolution per arm. Delegate/worker tokens are free and reported
-separately, not counted against the primary reduction.
-
-Pipeline:
-  1. swebench_supervised_prep.py  -> per-instance code regions (reddit10 | lite:N | all)
-  2. this driver                   -> dispatch arms via the `aimee` CLI, collect patches
-  3. official SWE-bench Docker grader (bench_swebench._grade_with_harness)
-  4. supervised_report.py          -> the comparison table
-
-Primary tokens are read from the aimee token_audit ledger (model=<primary>, realized,
-within each arm's time window); pass --token-db <aimee.db> on the aimee host, else
-token columns are left null and only speed/resolution are reported.
-
-FAKE mode (AIMEE_BENCH_FAKE_AGENT=1) synthesizes arm outputs for CI (no live aimee).
+Primary tokens are read from the token_audit ledger scoped to the EXACT primary job ids
+this run dispatched (delegation_id ends in `-<job_id>`), so the number is the primary's
+own turns for this run only - no time-window or cross-agent contamination. Worker tokens
+are free and reported separately. FAKE mode (AIMEE_BENCH_FAKE_AGENT=1) synthesizes arm
+outputs for CI.
 """
 from __future__ import annotations
-import argparse, glob, json, os, re, sqlite3, subprocess, sys, time
+
+import argparse
+import glob
+import json
+import os
+import random
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -35,6 +44,8 @@ from benchmarks.coding import supervised_report
 
 _FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
 _FAKE_GRADER = os.environ.get("AIMEE_BENCH_FAKE_GRADER") == "1"
+_POLL_WORKERS = 16
+_SCHEMA_VERSION = 2
 
 
 # ---------------------------------------------------------------- prompts -----
@@ -56,34 +67,61 @@ def _select_prompt(inst: dict, candidates: list[tuple[str, str]]) -> str:
             f"## Candidate patches{body}")
 
 
+_DIFF_LINE = re.compile(r"^(diff --git |index |--- |\+\+\+ |@@ |[ +\-\\]|rename |similarity |"
+                        r"new file |deleted file |old mode |new mode |Binary )")
+
+
 def _extract_diff(text: str) -> str:
+    """Pull a unified diff out of a worker response and STOP at the first line that is
+    not part of the diff, so trailing prose is never submitted as a patch (M5)."""
     m = re.search(r"```diff\s*\n(.*?)```", text, re.DOTALL)
     if m:
         return m.group(1).strip()
-    m = re.search(r"(diff --git[\s\S]*|--- a/[\s\S]*)", text)
-    return m.group(1).strip() if m else ""
+    lines = text.splitlines()
+    start = next((i for i, ln in enumerate(lines)
+                  if ln.startswith("diff --git ") or ln.startswith("--- ")), None)
+    if start is None:
+        return ""
+    out = []
+    for ln in lines[start:]:
+        if ln == "" or _DIFF_LINE.match(ln):
+            out.append(ln)
+        else:
+            break
+    return "\n".join(out).strip()
 
 
 # ------------------------------------------------------------- aimee CLI ------
 class Fleet:
-    """Dispatch delegate turns via the `aimee` CLI and poll them CONCURRENTLY so
-    wall-clock reflects true parallelism (not sequential per-job blocking)."""
+    """Dispatch and poll delegate turns via the `aimee` CLI. Dispatch AND polling are
+    THREAD-PARALLEL so wall-clock reflects true fleet concurrency, not driver serialism
+    (C2/M1/M3). Only `done` is a success terminal; `failed`/`error`/`partial` are
+    discarded (M2)."""
+
+    _SUCCESS = "done"
+    _TERMINAL = {"done", "failed", "error", "partial"}
 
     def __init__(self, aimee_bin: str, timeout_s: float = 420.0) -> None:
         self.aimee = aimee_bin
         self.timeout_s = timeout_s
 
-    def dispatch(self, worker: str, prompt: str) -> tuple:
+    def _dispatch1(self, worker: str, prompt: str):
         p = subprocess.run(
             [self.aimee, "--json", "delegate", "draft", prompt, "--via", worker,
              "--persona", "engineer", "--no-tools", "--background"],
             capture_output=True, text=True, timeout=90)
         try:
-            return json.loads(p.stdout).get("job_id"), time.time()
+            return json.loads(p.stdout).get("job_id")
         except Exception:
-            return None, time.time()
+            return None
 
-    def _status(self, jid) -> tuple:
+    def dispatch_all(self, items: list[tuple]) -> dict:
+        """items: list of (key, worker, prompt). Returns {key: job_id}. Parallel."""
+        with ThreadPoolExecutor(max_workers=_POLL_WORKERS) as ex:
+            jids = list(ex.map(lambda it: self._dispatch1(it[1], it[2]), items))
+        return {it[0]: j for it, j in zip(items, jids)}
+
+    def _status(self, jid):
         p = subprocess.run([self.aimee, "--json", "delegate", "status", str(jid), "--full"],
                            capture_output=True, text=True, timeout=30)
         try:
@@ -92,107 +130,140 @@ class Fleet:
         except Exception:
             return "", ""
 
-    def collect(self, jobs: dict) -> tuple:
-        """jobs: key -> (job_id, dispatch_time). Poll all concurrently; return
-        ({key: (result_text, latency_s)}, first_dispatch, last_done)."""
-        pending = {k: (j, t) for k, (j, t) in jobs.items() if j}
-        firstd = min((t for _, t in pending.values()), default=time.time())
-        out, lastdone = {}, firstd
-        term = {"done", "failed", "error", "partial"}
+    def collect(self, jobs: dict) -> dict:
+        """jobs: {key: job_id}. Poll concurrently until all terminal/timeout. Returns
+        {key: (result_or_'', ok_bool)} where ok=True only for a `done` terminal."""
+        pending = {k: (j, time.time()) for k, j in jobs.items() if j}
+        out = {}
         while pending:
-            for k in list(pending):
+            with ThreadPoolExecutor(max_workers=_POLL_WORKERS) as ex:
+                sts = dict(zip(pending, ex.map(lambda k: self._status(pending[k][0]), pending)))
+            for k, (st, res) in sts.items():
                 jid, td = pending[k]
-                st, res = self._status(jid)
-                if st in term:
-                    out[k] = (res, round(time.time() - td, 1))
-                    lastdone = max(lastdone, time.time())
+                if st in self._TERMINAL:
+                    out[k] = (res if st == self._SUCCESS else "", st == self._SUCCESS)
                     del pending[k]
                 elif time.time() - td > self.timeout_s:
-                    out[k] = ("", round(time.time() - td, 1))
+                    out[k] = ("", False)
                     del pending[k]
             if pending:
-                time.sleep(3)
+                time.sleep(2)
         for k in jobs:
-            out.setdefault(k, ("", 0.0))
-        return out, firstd, lastdone
+            out.setdefault(k, ("", False))
+        return out
 
 
 # ------------------------------------------------------------- token meter ----
-def _primary_tokens(db, model, lo, hi):
-    if not db or not Path(db).exists():
+def _primary_tokens(db, model, job_ids):
+    """Sum the primary model's realized tokens for EXACTLY the given primary job ids.
+    A delegate turn's delegation_id is `deleg-<n>-<ts>-<job_id>`, so we match the
+    trailing `-<job_id>`. No time window -> no cross-run/cross-agent contamination (C1)."""
+    if not db or not Path(db).exists() or not job_ids:
         return None
-    c = sqlite3.connect(db)
-    r = c.execute(
-        "SELECT COUNT(*), COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0) "
-        "FROM token_audit WHERE model=? AND usage_kind='realized' "
-        "AND created_at>=datetime(?, 'unixepoch') AND created_at<datetime(?, 'unixepoch')",
-        (model, int(lo), int(hi) + 1)).fetchone()
-    return {"calls": r[0], "input": r[1], "output": r[2], "total": r[1] + r[2]}
+    con = sqlite3.connect(db)
+    likes = " OR ".join(["delegation_id LIKE ?"] * len(job_ids))
+    params = [model] + [f"%-{j}" for j in job_ids]
+    r = con.execute(
+        f"SELECT COUNT(*), COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0) "
+        f"FROM token_audit WHERE model=? AND usage_kind='realized' AND ({likes})", params).fetchone()
+    return {"calls": r[0], "input": r[1], "output": r[2], "total": r[1] + r[2],
+            "job_ids": list(job_ids)}
 
 
 # ------------------------------------------------------------- arms -----------
 def run_arm_A(insts, fleet, primary):
-    jobs = {i["instance_id"]: fleet.dispatch(primary, _solve_prompt(i)) for i in insts}
-    res, f, l = fleet.collect(jobs)
-    return {iid: {"diff": _extract_diff(r), "wall": w} for iid, (r, w) in res.items()}, f, l
+    items = [(i["instance_id"], primary, _solve_prompt(i)) for i in insts]
+    t0 = time.perf_counter()
+    jobs = fleet.dispatch_all(items)
+    res = fleet.collect(jobs)
+    wall = round(time.perf_counter() - t0, 1)
+    recs = {iid: {"diff": _extract_diff(r) if ok else ""} for iid, (r, ok) in res.items()}
+    return recs, wall, [j for j in jobs.values() if j]
 
 
-def run_arm_C(insts, fleet, primary, pool, n):
-    order = {}  # (iid,k) -> worker name, for candidate labelling
-    attempts, wi = {}, 0
-    for i in insts:
-        for k in range(n):
-            w = pool[wi % len(pool)]
-            order[(i["instance_id"], k)] = w
-            attempts[(i["instance_id"], k)] = fleet.dispatch(w, _solve_prompt(i))
-            wi += 1
-    ares, wf, wl = fleet.collect(attempts)
+def _pick_workers(pool, n, seed):
+    """N DISTINCT workers for one instance, seeded for reproducibility (M6)."""
+    rng = random.Random(seed)
+    p = list(pool)
+    rng.shuffle(p)
+    return p[:min(n, len(p))]
+
+
+def run_arm_C(insts, fleet, primary, pool, n, seed):
+    t0 = time.perf_counter()
+    items, order = [], {}
+    for idx, i in enumerate(insts):
+        for k, w in enumerate(_pick_workers(pool, n, f"{seed}:{i['instance_id']}")):
+            key = (i["instance_id"], k)
+            order[key] = w
+            items.append((key, w, _solve_prompt(i)))
+    ares = fleet.dispatch_all(items)
+    ares = fleet.collect(ares)
     cand = {i["instance_id"]: [] for i in insts}
-    for (iid, k), (r, _) in ares.items():
-        d = _extract_diff(r)
+    for (iid, k), (r, ok) in ares.items():
+        d = _extract_diff(r) if ok else ""
         if d:
             cand[iid].append((order[(iid, k)], d))
     byid = {i["instance_id"]: i for i in insts}
-    seljobs = {iid: fleet.dispatch(primary, _select_prompt(byid[iid], cs))
-               for iid, cs in cand.items() if cs}
-    sel_start = time.time()
-    sres, _, sl = fleet.collect(seljobs)
-    patches = {}
+    sel_items = [(iid, primary, _select_prompt(byid[iid], cs)) for iid, cs in cand.items() if cs]
+    sjobs = fleet.dispatch_all(sel_items)
+    sres = fleet.collect(sjobs)
+    recs = {}
     for i in insts:
         iid = i["instance_id"]
-        r, w = sres.get(iid, ("", 0.0))
-        patches[iid] = {"diff": _extract_diff(r), "n_candidates": len(cand[iid]), "wall": w}
-    return patches, wf, wl, sel_start, sl
+        r, ok = sres.get(iid, ("", False))
+        recs[iid] = {"diff": _extract_diff(r) if ok else "", "n_candidates": len(cand[iid])}
+    wall = round(time.perf_counter() - t0, 1)
+    return recs, wall, [j for j in sjobs.values() if j]
 
 
 # ------------------------------------------------------------- grading -------
 def _grade(records, arm, out_dir, target):
+    for r in records.values():
+        r["resolved"] = None  # None = not graded (no diff, or grader unavailable)
     if _FAKE_GRADER:
-        for r in records.values():
-            r["resolved"] = None
         return
+    if _FAKE:
+        raise SystemExit("refusing to grade fake agent output against the real harness; "
+                         "set AIMEE_BENCH_FAKE_GRADER=1 too (m1)")
     from benchmarks.coding.bench_swebench import _grade_with_harness, _build_prediction, _write_predictions
     preds = [_build_prediction(iid, f"{target}-{arm}", r["diff"]) for iid, r in records.items() if r["diff"]]
-    for r in records.values():
-        r.setdefault("resolved", False)
     if not preds:
         return
+    for iid, r in records.items():
+        if r["diff"]:
+            r["resolved"] = False  # submitted but not yet confirmed resolved
     pp = out_dir / f"pred_{arm}.jsonl"
     _write_predictions(pp, preds)
     try:
         resolved, _ = _grade_with_harness(pp, f"{target}_{arm}_{int(time.time())}")
     except RuntimeError as e:
         print(f"WARNING grader unavailable: {e}", file=sys.stderr)
+        for r in records.values():
+            r["resolved"] = None
         return
     for iid, r in records.items():
-        r["resolved"] = (iid in resolved) if r["diff"] else False
+        if r["diff"]:
+            r["resolved"] = iid in resolved
 
 
 # ------------------------------------------------------------- fake ----------
-def _fake_record(iid, arm, idx):
+def _fake_record(iid, arm, idx, n=3):
     if arm == "A":
-        return {"diff": "diff --git a/x b/x\n", "wall": 130.0 + idx, "resolved": True}
-    return {"diff": "diff --git a/x b/x\n", "wall": 40.0 + idx, "n_candidates": 3, "resolved": True}
+        return {"diff": "diff --git a/x b/x\n", "resolved": True}
+    return {"diff": "diff --git a/x b/x\n", "n_candidates": n, "resolved": True}
+
+
+def _provenance(args, pool, n_instances):
+    def _git(*a):
+        try:
+            return subprocess.run(["git", *a], capture_output=True, text=True, timeout=10).stdout.strip()
+        except Exception:
+            return None
+    return {"schema_version": _SCHEMA_VERSION, "aimee_commit": _git("rev-parse", "HEAD"),
+            "primary_agent": args.primary, "primary_model": args.primary_model,
+            "pool_agents": pool, "n": args.n, "instances": n_instances,
+            "single_shot": True, "started_at": int(time.time())}
 
 
 # ------------------------------------------------------------- main ----------
@@ -203,26 +274,33 @@ def main() -> None:
     ap.add_argument("--primary", default=os.environ.get("AIMEE_BENCH_PRIMARY", "codex"),
                     help="the expensive manager agent (its tokens are what we reduce)")
     ap.add_argument("--pool", default=os.environ.get("AIMEE_BENCH_POOL",
-                    "gpu-gemma4,glm-5.2,mimo-2.5,mistral,mimo-2.5-pro,minimax,local-synth"),
-                    help="cheap/local worker fleet for arm C")
+                    "glm-5.2,mimo-2.5,mistral,mimo-2.5-pro,minimax,local-synth"),
+                    help="cheap/local worker fleet for arm C (must NOT contain --primary)")
     ap.add_argument("--n", type=int, default=3, help="best-of-N workers per instance (arm C)")
-    ap.add_argument("--primary-model", default=os.environ.get("AIMEE_BENCH_PRIMARY_MODEL", "gpt-5.5"),
-                    help="token_audit model name of the primary, for token measurement")
+    ap.add_argument("--primary-model", default=os.environ.get("AIMEE_BENCH_PRIMARY_MODEL", ""),
+                    help="token_audit model name of the primary; required for token measurement")
     ap.add_argument("--token-db", default=os.environ.get("AIMEE_DB", ""),
-                    help="path to aimee.db (DB1) to read primary tokens; empty = skip")
+                    help="path to aimee.db (DB1) to read primary tokens")
     ap.add_argument("--aimee-bin", default=os.environ.get("AIMEE_BENCH_CLIENT", "./aimee"))
     ap.add_argument("--target", default="aimee-supervised")
+    ap.add_argument("--seed", type=int, default=1729)
     ap.add_argument("--output", required=True)
     args = ap.parse_args()
 
     arms = [a.strip().upper() for a in args.arms.split(",") if a.strip()]
     pool = [w.strip() for w in args.pool.split(",") if w.strip()]
+    if args.primary in pool:
+        raise SystemExit(f"--primary '{args.primary}' must not appear in --pool (m11 footgun)")
 
     if _FAKE:
         insts = [{"instance_id": f"inst-{i}", "repo": "x/y", "file": "x.py",
                   "region": "code", "problem": "bug"} for i in range(3)]
     else:
         insts = [json.load(open(f)) for f in sorted(glob.glob(str(Path(args.regions) / "*.json")))]
+        if not args.token_db:
+            print("WARNING: --token-db not set; primary token reduction will be unavailable", file=sys.stderr)
+        if args.token_db and not args.primary_model:
+            raise SystemExit("--primary-model is required with --token-db (to scope the ledger)")
     if not insts:
         raise SystemExit(f"no regions in {args.regions}; run swebench_supervised_prep.py first")
     print(f"{len(insts)} instances; primary={args.primary}; pool={pool}; n={args.n}", file=sys.stderr)
@@ -230,32 +308,31 @@ def main() -> None:
     fleet = None if _FAKE else Fleet(args.aimee_bin)
     out_dir = Path(args.output).parent
     out_dir.mkdir(parents=True, exist_ok=True)
-    result = {"instances": [i["instance_id"] for i in insts], "primary": args.primary,
+    result = {"provenance": _provenance(args, pool, len(insts)),
+              "instances": [i["instance_id"] for i in insts], "primary": args.primary,
               "pool": pool, "n": args.n, "arms": {}, "primary_tokens": {}}
 
     if "A" in arms:
-        print("=== ARM A: primary solves ===", file=sys.stderr)
+        print("=== ARM A: primary solves (single-shot) ===", file=sys.stderr)
         if _FAKE:
-            A = {i["instance_id"]: _fake_record(i["instance_id"], "A", k) for k, i in enumerate(insts)}
-            result["arms"]["A"] = {"records": A, "wall_total": 130.0}
+            A = {i["instance_id"]: _fake_record(i["instance_id"], "A", k, args.n) for k, i in enumerate(insts)}
+            result["arms"]["A"] = {"records": A, "wall_total": 0.0}
         else:
-            A, f, l = run_arm_A(insts, fleet, args.primary)
+            A, wall, jids = run_arm_A(insts, fleet, args.primary)
             _grade(A, "A", out_dir, args.target)
-            result["primary_tokens"]["A"] = _primary_tokens(args.token_db, args.primary_model, f, l)
-            result["arms"]["A"] = {"records": A, "wall_total": round(l - f, 1)}
+            result["primary_tokens"]["A"] = _primary_tokens(args.token_db, args.primary_model, jids)
+            result["arms"]["A"] = {"records": A, "wall_total": wall}
 
     if "C" in arms:
-        print("=== ARM C: supervised (best-of-N + selection) ===", file=sys.stderr)
+        print("=== ARM C: supervised best-of-N + selection (single-shot) ===", file=sys.stderr)
         if _FAKE:
-            C = {i["instance_id"]: _fake_record(i["instance_id"], "C", k) for k, i in enumerate(insts)}
-            result["arms"]["C"] = {"records": C, "wall_total": 40.0}
+            C = {i["instance_id"]: _fake_record(i["instance_id"], "C", k, args.n) for k, i in enumerate(insts)}
+            result["arms"]["C"] = {"records": C, "wall_total": 0.0}
         else:
-            C, wf, wl, sel_start, sl = run_arm_C(insts, fleet, args.primary, pool, args.n)
+            C, wall, jids = run_arm_C(insts, fleet, args.primary, pool, args.n, args.seed)
             _grade(C, "C", out_dir, args.target)
-            result["primary_tokens"]["C"] = _primary_tokens(args.token_db, args.primary_model, sel_start, sl)
-            result["arms"]["C"] = {"records": C, "wall_total": round(sl - wf, 1),
-                                   "worker_wall": round(wl - wf, 1),
-                                   "select_wall": round(sl - sel_start, 1)}
+            result["primary_tokens"]["C"] = _primary_tokens(args.token_db, args.primary_model, jids)
+            result["arms"]["C"] = {"records": C, "wall_total": wall}
 
     result["summary"] = supervised_report.summarize_arms(result)
     Path(args.output).write_text(json.dumps(result, indent=2))

--- a/benchmarks/coding/supervised_report.py
+++ b/benchmarks/coding/supervised_report.py
@@ -37,6 +37,7 @@ Record schema (one dict per instance/arm/compaction cell):
 
 from __future__ import annotations
 
+import math
 import random
 import statistics
 from typing import Any, Iterable
@@ -344,44 +345,68 @@ def render_markdown(report: dict[str, Any], reddit_baseline: dict[str, Any] | No
 # ============================================================================
 # Live supervised-run summary (arm A vs arm C, primary-token focus).
 # Consumes the result dict produced by bench_swebench_supervised.py.
+#
+# resolved semantics per record: None = not graded (no patch produced, or grader
+# unavailable); False = a patch was submitted but did not resolve; True = resolved.
+# We report resolution against TWO denominators so worker failures cannot silently
+# flatter the result (C5/M8):
+#   resolved / submitted  - resolution given a patch was produced (skill)
+#   resolved / instances  - end-to-end incl. worker failures (the honest public number)
 # ============================================================================
-def _arm_stats(arm: dict[str, Any], ptok: dict[str, Any] | None) -> dict[str, Any]:
+
+
+def _arm_stats(arm: dict[str, Any], ptok: dict[str, Any] | None, n: int) -> dict[str, Any]:
     recs = arm.get("records", {})
-    graded = [r for r in recs.values() if r.get("resolved") is not None]
+    submitted = [r for r in recs.values() if r.get("diff")]
+    graded = [r for r in submitted if r.get("resolved") is not None]
     resolved = sum(1 for r in graded if r.get("resolved"))
-    diffs = sum(1 for r in recs.values() if r.get("diff"))
+    cand = [r.get("n_candidates") for r in recs.values() if "n_candidates" in r]
+    need = math.ceil(n / 2) if n else 0
+    under = [c for c in cand if c is not None and c < need]
     return {
         "instances": len(recs),
-        "diffs": diffs,
+        "submitted": len(submitted),
         "graded": len(graded),
         "resolved": resolved,
-        "resolve_rate": round(resolved / len(graded), 4) if graded else None,
+        "resolve_rate_submitted": round(resolved / len(graded), 4) if graded else None,
+        "resolve_rate_instances": round(resolved / len(recs), 4) if recs else None,
         "wall_total_s": arm.get("wall_total"),
         "primary_tokens": (ptok or {}).get("total"),
         "primary_input": (ptok or {}).get("input"),
         "primary_output": (ptok or {}).get("output"),
+        # Candidate-set health for arm C: a flaky fleet that returns <ceil(N/2)
+        # candidates shrinks the selection prompt and would otherwise inflate the
+        # reduction; surface it so it can't hide.
+        "candidates_total": len(cand),
+        "candidates_underpopulated": len(under),
+        "candidates_min_required": need,
     }
 
 
 def summarize_arms(result: dict[str, Any]) -> dict[str, Any]:
     arms = result.get("arms", {})
     ptok = result.get("primary_tokens", {})
-    out: dict[str, Any] = {"arms": {a: _arm_stats(arms[a], ptok.get(a)) for a in arms}}
+    n = result.get("n", 0)
+    out: dict[str, Any] = {"arms": {a: _arm_stats(arms[a], ptok.get(a), n) for a in arms}}
     a = out["arms"].get("A", {})
     c = out["arms"].get("C", {})
     if a.get("primary_tokens") and c.get("primary_tokens") is not None:
         out["primary_token_reduction_pct"] = pct_reduction(a["primary_tokens"], c["primary_tokens"])
     if a.get("wall_total_s") and c.get("wall_total_s"):
         out["walltime_ratio_C_over_A"] = round(c["wall_total_s"] / a["wall_total_s"], 3)
+    if c.get("candidates_underpopulated"):
+        out["warning"] = (f"{c['candidates_underpopulated']}/{c['candidates_total']} arm-C instances had "
+                          f"< {c['candidates_min_required']} candidates; primary-token reduction is "
+                          f"optimistic for those (fewer candidates -> shorter selection prompt).")
     return out
 
 
 def render_supervised(result: dict[str, Any]) -> str:
     s = summarize_arms(result)
-    L = ["## Supervised SWE-bench — primary(manager) tokens vs solo\n",
+    L = ["## Supervised SWE-bench (single-shot) — primary(manager) tokens vs solo\n",
          f"instances: {len(result.get('instances', []))}  primary: {result.get('primary')}  "
          f"n(best-of): {result.get('n')}  pool: {', '.join(result.get('pool', []))}\n",
-         "| Arm | primary tokens | wall (s) | resolved / graded | diffs |",
+         "| Arm | primary tokens | wall (s) | resolved/submitted | resolved/instances |",
          "|---|---|---|---|---|"]
     labels = {"A": "A primary_alone", "C": "C supervised (best-of-N)"}
     for a in ("A", "C"):
@@ -389,12 +414,14 @@ def render_supervised(result: dict[str, Any]) -> str:
         if not st:
             continue
         pt = st["primary_tokens"]
-        L.append(f"| {labels.get(a, a)} | {pt if pt is not None else 'n/a'} | "
-                 f"{st['wall_total_s']} | {st['resolved']}/{st['graded']} | {st['diffs']}/{st['instances']} |")
+        L.append(f"| {labels.get(a, a)} | {pt if pt is not None else 'n/a'} | {st['wall_total_s']} | "
+                 f"{st['resolved']}/{st['submitted']} | {st['resolved']}/{st['instances']} |")
     if s.get("primary_token_reduction_pct") is not None:
         L.append(f"\n**Primary-agent token reduction (A -> C): "
                  f"{s['primary_token_reduction_pct']:+.1f}%**")
     if s.get("walltime_ratio_C_over_A") is not None:
         r = s["walltime_ratio_C_over_A"]
         L.append(f"Wall-clock C/A: **{r}x** " + ("(faster)" if r < 1 else "(slower)"))
+    if s.get("warning"):
+        L.append(f"\n> ⚠ {s['warning']}")
     return "\n".join(L) + "\n"

--- a/benchmarks/coding/supervised_report.py
+++ b/benchmarks/coding/supervised_report.py
@@ -339,3 +339,62 @@ def render_markdown(report: dict[str, Any], reddit_baseline: dict[str, Any] | No
             f"{report.get('speed', {}).get('C_over_A_walltime_ratio', '?')}× wall-time vs solo.\n"
         )
     return "\n".join(lines) + "\n"
+
+
+# ============================================================================
+# Live supervised-run summary (arm A vs arm C, primary-token focus).
+# Consumes the result dict produced by bench_swebench_supervised.py.
+# ============================================================================
+def _arm_stats(arm: dict[str, Any], ptok: dict[str, Any] | None) -> dict[str, Any]:
+    recs = arm.get("records", {})
+    graded = [r for r in recs.values() if r.get("resolved") is not None]
+    resolved = sum(1 for r in graded if r.get("resolved"))
+    diffs = sum(1 for r in recs.values() if r.get("diff"))
+    return {
+        "instances": len(recs),
+        "diffs": diffs,
+        "graded": len(graded),
+        "resolved": resolved,
+        "resolve_rate": round(resolved / len(graded), 4) if graded else None,
+        "wall_total_s": arm.get("wall_total"),
+        "primary_tokens": (ptok or {}).get("total"),
+        "primary_input": (ptok or {}).get("input"),
+        "primary_output": (ptok or {}).get("output"),
+    }
+
+
+def summarize_arms(result: dict[str, Any]) -> dict[str, Any]:
+    arms = result.get("arms", {})
+    ptok = result.get("primary_tokens", {})
+    out: dict[str, Any] = {"arms": {a: _arm_stats(arms[a], ptok.get(a)) for a in arms}}
+    a = out["arms"].get("A", {})
+    c = out["arms"].get("C", {})
+    if a.get("primary_tokens") and c.get("primary_tokens") is not None:
+        out["primary_token_reduction_pct"] = pct_reduction(a["primary_tokens"], c["primary_tokens"])
+    if a.get("wall_total_s") and c.get("wall_total_s"):
+        out["walltime_ratio_C_over_A"] = round(c["wall_total_s"] / a["wall_total_s"], 3)
+    return out
+
+
+def render_supervised(result: dict[str, Any]) -> str:
+    s = summarize_arms(result)
+    L = ["## Supervised SWE-bench — primary(manager) tokens vs solo\n",
+         f"instances: {len(result.get('instances', []))}  primary: {result.get('primary')}  "
+         f"n(best-of): {result.get('n')}  pool: {', '.join(result.get('pool', []))}\n",
+         "| Arm | primary tokens | wall (s) | resolved / graded | diffs |",
+         "|---|---|---|---|---|"]
+    labels = {"A": "A primary_alone", "C": "C supervised (best-of-N)"}
+    for a in ("A", "C"):
+        st = s["arms"].get(a)
+        if not st:
+            continue
+        pt = st["primary_tokens"]
+        L.append(f"| {labels.get(a, a)} | {pt if pt is not None else 'n/a'} | "
+                 f"{st['wall_total_s']} | {st['resolved']}/{st['graded']} | {st['diffs']}/{st['instances']} |")
+    if s.get("primary_token_reduction_pct") is not None:
+        L.append(f"\n**Primary-agent token reduction (A -> C): "
+                 f"{s['primary_token_reduction_pct']:+.1f}%**")
+    if s.get("walltime_ratio_C_over_A") is not None:
+        r = s["walltime_ratio_C_over_A"]
+        L.append(f"Wall-clock C/A: **{r}x** " + ("(faster)" if r < 1 else "(slower)"))
+    return "\n".join(L) + "\n"

--- a/benchmarks/coding/swebench_supervised_prep.py
+++ b/benchmarks/coding/swebench_supervised_prep.py
@@ -29,9 +29,11 @@ REDDIT10 = [
 
 
 def _fetch_lite() -> dict[str, dict]:
-    """Fetch the full SWE-bench Lite test split (300) via the HF rows API."""
+    """Fetch the full SWE-bench Lite test split via the HF rows API, paginating until
+    a short/empty page (no hardcoded 300, so it survives dataset size changes; m5)."""
     rows: dict[str, dict] = {}
-    for off in range(0, 300, 100):
+    off = 0
+    while True:
         for attempt in range(3):
             try:
                 with urllib.request.urlopen(f"{HF}&offset={off}&length=100", timeout=45) as r:
@@ -40,8 +42,12 @@ def _fetch_lite() -> dict[str, dict]:
             except Exception:
                 if attempt == 2:
                     raise
-        for item in d.get("rows", []):
+        page = d.get("rows", [])
+        for item in page:
             rows[item["row"]["instance_id"]] = item["row"]
+        if len(page) < 100:
+            break
+        off += 100
     return rows
 
 
@@ -89,7 +95,10 @@ def prepare(instances: list[dict], out_dir: Path, repos_dir: Path, region_lines:
         dst = repos_dir / repo.replace("/", "__")
         if not dst.exists():
             print(f"cloning {repo}", file=sys.stderr)
-            subprocess.run(["git", "clone", "--quiet", f"https://github.com/{repo}", str(dst)], check=True)
+            # Blobless partial clone: keeps full history (so ANY base_commit checks
+            # out, unlike --depth 1) but fetches blobs on demand -> small (m4).
+            subprocess.run(["git", "clone", "--quiet", "--filter=blob:none",
+                            f"https://github.com/{repo}", str(dst)], check=True)
     n = 0
     for r in instances:
         dst = repos_dir / r["repo"].replace("/", "__")

--- a/benchmarks/coding/swebench_supervised_prep.py
+++ b/benchmarks/coding/swebench_supervised_prep.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Prepare SWE-bench instances for the supervised benchmark: fetch the dataset,
+clone each repo at its base_commit, and extract the code region around the bug so
+both the solo primary (arm A) and the delegate workers (arm C) see the same code.
+
+Instance sets:
+  reddit10  - the exact 10 SWE-bench Lite instances from the Reddit post
+              (direct head-to-head).
+  lite:N    - a deterministic wide sample of N SWE-bench Lite instances spanning
+              all four repos (django/sympy/scikit-learn/pytest) for range.
+  all       - every SWE-bench Lite instance (300).
+
+Regions default to +/-300 lines around the gold-patch hunk (a realistic "the code
+you must read to fix it"); tune with --region-lines.
+"""
+from __future__ import annotations
+import argparse, json, os, re, subprocess, sys, urllib.request
+from pathlib import Path
+
+HF = ("https://datasets-server.huggingface.co/rows"
+      "?dataset=princeton-nlp%2FSWE-bench_Lite&config=default&split=test")
+
+REDDIT10 = [
+    "pytest-dev__pytest-11143", "scikit-learn__scikit-learn-13439", "sympy__sympy-20212",
+    "django__django-12908", "pytest-dev__pytest-6116", "django__django-13447",
+    "django__django-15814", "django__django-11179", "sympy__sympy-13480",
+    "scikit-learn__scikit-learn-13584",
+]
+
+
+def _fetch_lite() -> dict[str, dict]:
+    """Fetch the full SWE-bench Lite test split (300) via the HF rows API."""
+    rows: dict[str, dict] = {}
+    for off in range(0, 300, 100):
+        for attempt in range(3):
+            try:
+                with urllib.request.urlopen(f"{HF}&offset={off}&length=100", timeout=45) as r:
+                    d = json.load(r)
+                break
+            except Exception:
+                if attempt == 2:
+                    raise
+        for item in d.get("rows", []):
+            rows[item["row"]["instance_id"]] = item["row"]
+    return rows
+
+
+def _select(all_rows: dict[str, dict], spec: str) -> list[dict]:
+    if spec == "reddit10":
+        return [all_rows[i] for i in REDDIT10 if i in all_rows]
+    if spec == "all":
+        return sorted(all_rows.values(), key=lambda r: r["instance_id"])
+    if spec.startswith("lite:"):
+        n = int(spec.split(":", 1)[1])
+        # deterministic wide sample: round-robin across repos, sorted within each
+        by_repo: dict[str, list] = {}
+        for r in sorted(all_rows.values(), key=lambda r: r["instance_id"]):
+            by_repo.setdefault(r["repo"], []).append(r)
+        out, i = [], 0
+        while len(out) < n and any(i < len(v) for v in by_repo.values()):
+            for repo in sorted(by_repo):
+                if i < len(by_repo[repo]) and len(out) < n:
+                    out.append(by_repo[repo][i])
+            i += 1
+        return out
+    raise SystemExit(f"unknown instance spec: {spec}")
+
+
+def _extract_region(repo_dir: Path, patch: str, region_lines: int) -> tuple[str, str, int] | None:
+    m_file = re.search(r"^\+\+\+ b/(\S+)", patch, re.M)
+    m_hunk = re.search(r"^@@ -(\d+)", patch, re.M)
+    if not m_file or not m_hunk:
+        return None
+    fpath, start = m_file.group(1), int(m_hunk.group(1))
+    full = repo_dir / fpath
+    try:
+        lines = full.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    lo = max(0, start - region_lines)
+    hi = min(len(lines), start + region_lines)
+    return fpath, "\n".join(lines[lo:hi]), lo + 1
+
+
+def prepare(instances: list[dict], out_dir: Path, repos_dir: Path, region_lines: int) -> int:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    repos_dir.mkdir(parents=True, exist_ok=True)
+    for repo in {r["repo"] for r in instances}:
+        dst = repos_dir / repo.replace("/", "__")
+        if not dst.exists():
+            print(f"cloning {repo}", file=sys.stderr)
+            subprocess.run(["git", "clone", "--quiet", f"https://github.com/{repo}", str(dst)], check=True)
+    n = 0
+    for r in instances:
+        dst = repos_dir / r["repo"].replace("/", "__")
+        subprocess.run(["git", "checkout", "--quiet", "--force", r["base_commit"]], cwd=dst)
+        subprocess.run(["git", "clean", "-fdq"], cwd=dst)
+        reg = _extract_region(dst, r["patch"], region_lines)
+        if not reg:
+            print(f"{r['instance_id']} SKIP (no parseable region)", file=sys.stderr)
+            continue
+        fpath, region, region_start = reg
+        json.dump(
+            {"instance_id": r["instance_id"], "repo": r["repo"], "base_commit": r["base_commit"],
+             "file": fpath, "region_start": region_start, "region": region,
+             "problem": r["problem_statement"]},
+            (out_dir / f"{r['instance_id']}.json").open("w"),
+        )
+        n += 1
+        print(f"{r['instance_id']} ok ({fpath})", file=sys.stderr)
+    return n
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--instances", default="reddit10", help="reddit10 | lite:N | all")
+    ap.add_argument("--out", default="benchmarks/results/swebench_supervised/regions")
+    ap.add_argument("--repos", default=os.environ.get("SWE_REPOS_DIR", "/tmp/swe-repos"))
+    ap.add_argument("--region-lines", type=int, default=300)
+    args = ap.parse_args()
+    rows = _fetch_lite()
+    picked = _select(rows, args.instances)
+    print(f"selected {len(picked)} instances ({args.instances})", file=sys.stderr)
+    n = prepare(picked, Path(args.out), Path(args.repos), args.region_lines)
+    print(f"prepared {n} regions -> {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tests/test_bench_swebench_supervised.py
+++ b/benchmarks/tests/test_bench_swebench_supervised.py
@@ -145,15 +145,35 @@ class TestFakeHarnessShape(unittest.TestCase):
         from benchmarks.coding import bench_swebench_supervised as B
 
         reload(B)
-        a = B._fake_record("x", "A", True, 0)
-        c = B._fake_record("x", "C", True, 0)
-        # Arm A pays full supervisor cost, no workers; arm C offloads to workers.
-        self.assertEqual(a["worker_input_tokens"], 0)
-        self.assertGreater(c["worker_input_tokens"], 0)
-        self.assertLess(c["supervisor_input_tokens"], a["supervisor_input_tokens"])
-        # Arm C runs faster than arm B (parallel vs serial).
-        b = B._fake_record("x", "B", True, 0)
-        self.assertLess(c["wall_s"], b["wall_s"])
+        a = B._fake_record("x", "A", 0)
+        c = B._fake_record("x", "C", 0)
+        # Both arms produce a patch and are graded resolved in fake mode.
+        self.assertTrue(a["diff"] and c["diff"])
+        self.assertTrue(a["resolved"] and c["resolved"])
+        # Arm C is the supervised best-of-N arm: it carries candidate count and
+        # finishes faster than the solo primary (parallel fleet vs serial solve).
+        self.assertEqual(c["n_candidates"], 3)
+        self.assertLess(c["wall"], a["wall"])
+
+
+class TestSupervisedSummary(unittest.TestCase):
+    def test_summary_computes_primary_reduction_and_walltime_ratio(self):
+        result = {
+            "instances": ["i1", "i2"], "primary": "codex", "pool": ["w1", "w2"], "n": 3,
+            "arms": {
+                "A": {"wall_total": 400.0, "records": {
+                    "i1": {"diff": "d", "resolved": True}, "i2": {"diff": "d", "resolved": True}}},
+                "C": {"wall_total": 40.0, "records": {
+                    "i1": {"diff": "d", "resolved": True}, "i2": {"diff": "d", "resolved": False}}},
+            },
+            "primary_tokens": {"A": {"total": 100000}, "C": {"total": 20000}},
+        }
+        s = R.summarize_arms(result)
+        self.assertEqual(s["primary_token_reduction_pct"], 80.0)
+        self.assertEqual(s["walltime_ratio_C_over_A"], 0.1)
+        self.assertEqual(s["arms"]["A"]["resolved"], 2)
+        self.assertEqual(s["arms"]["C"]["resolved"], 1)
+        self.assertIn("Primary-agent token reduction", R.render_supervised(result))
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_bench_swebench_supervised.py
+++ b/benchmarks/tests/test_bench_swebench_supervised.py
@@ -145,35 +145,59 @@ class TestFakeHarnessShape(unittest.TestCase):
         from benchmarks.coding import bench_swebench_supervised as B
 
         reload(B)
-        a = B._fake_record("x", "A", 0)
-        c = B._fake_record("x", "C", 0)
+        a = B._fake_record("x", "A", 0, n=3)
+        c = B._fake_record("x", "C", 0, n=4)
         # Both arms produce a patch and are graded resolved in fake mode.
         self.assertTrue(a["diff"] and c["diff"])
         self.assertTrue(a["resolved"] and c["resolved"])
-        # Arm C is the supervised best-of-N arm: it carries candidate count and
-        # finishes faster than the solo primary (parallel fleet vs serial solve).
-        self.assertEqual(c["n_candidates"], 3)
-        self.assertLess(c["wall"], a["wall"])
+        # Arm C is the supervised best-of-N arm: candidate count tracks --n (m2).
+        self.assertEqual(c["n_candidates"], 4)
+        self.assertNotIn("n_candidates", a)
 
 
 class TestSupervisedSummary(unittest.TestCase):
-    def test_summary_computes_primary_reduction_and_walltime_ratio(self):
-        result = {
+    def _result(self, c_records):
+        return {
             "instances": ["i1", "i2"], "primary": "codex", "pool": ["w1", "w2"], "n": 3,
             "arms": {
                 "A": {"wall_total": 400.0, "records": {
                     "i1": {"diff": "d", "resolved": True}, "i2": {"diff": "d", "resolved": True}}},
-                "C": {"wall_total": 40.0, "records": {
-                    "i1": {"diff": "d", "resolved": True}, "i2": {"diff": "d", "resolved": False}}},
+                "C": {"wall_total": 40.0, "records": c_records},
             },
             "primary_tokens": {"A": {"total": 100000}, "C": {"total": 20000}},
         }
+
+    def test_summary_computes_primary_reduction_and_walltime_ratio(self):
+        result = self._result({
+            "i1": {"diff": "d", "n_candidates": 3, "resolved": True},
+            "i2": {"diff": "d", "n_candidates": 3, "resolved": False}})
         s = R.summarize_arms(result)
         self.assertEqual(s["primary_token_reduction_pct"], 80.0)
         self.assertEqual(s["walltime_ratio_C_over_A"], 0.1)
-        self.assertEqual(s["arms"]["A"]["resolved"], 2)
         self.assertEqual(s["arms"]["C"]["resolved"], 1)
         self.assertIn("Primary-agent token reduction", R.render_supervised(result))
+
+    def test_two_resolution_denominators_split_worker_failures(self):
+        # i2's workers all failed -> no diff. It must count against resolved/instances
+        # (end-to-end) but NOT against resolved/submitted (skill given a patch).
+        result = self._result({
+            "i1": {"diff": "d", "n_candidates": 3, "resolved": True},
+            "i2": {"diff": "", "n_candidates": 0, "resolved": None}})
+        st = R.summarize_arms(result)["arms"]["C"]
+        self.assertEqual(st["submitted"], 1)
+        self.assertEqual(st["resolve_rate_submitted"], 1.0)      # 1/1 of produced patches
+        self.assertEqual(st["resolve_rate_instances"], 0.5)      # 1/2 end-to-end
+        self.assertEqual(st["instances"], 2)
+
+    def test_underpopulated_candidate_sets_are_flagged(self):
+        # n=3 -> need >=2 candidates; i2 has 1 -> warning surfaces (C5).
+        result = self._result({
+            "i1": {"diff": "d", "n_candidates": 3, "resolved": True},
+            "i2": {"diff": "d", "n_candidates": 1, "resolved": True}})
+        s = R.summarize_arms(result)
+        self.assertEqual(s["arms"]["C"]["candidates_underpopulated"], 1)
+        self.assertIn("warning", s)
+        self.assertIn("⚠", R.render_supervised(result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Makes the supervised-SWE-bench benchmark (skeleton from #983) actually **runnable** against a live aimee, and widens it to an arbitrary instance range. It measures the thing the Reddit post measured: how much of the **expensive primary's** token spend aimee offloads onto a cheap/free/local delegate fleet, and whether it does so **without a wall-clock penalty**, at comparable resolution.

## Pieces

- **`swebench_supervised_prep.py`** — fetch SWE-bench Lite, clone each repo at `base_commit`, extract the code region around the bug. Instance sets: `reddit10` (the post's 10, head-to-head) | `lite:N` (deterministic wide sample across all four repos) | `all` (300).
- **`bench_swebench_supervised.py`** — real arms via the `aimee` CLI:
  - **A `primary_alone`** — the primary solves each task itself.
  - **C `supervised`** — N diverse workers attempt each task **concurrently**, then the primary reviews the short candidate diffs and **selects the best (best-of-N)**. It never reads the code, only candidate diffs, so its token cost stays tiny.
  - Concurrent polling so wall-clock reflects true parallelism (not sequential blocking). Primary tokens read from the `token_audit` ledger (`--token-db`). Grading via the official SWE-bench Docker harness (sole `resolved` source).
- **`supervised_report.summarize_arms` / `render_supervised`** — primary-token reduction (A→C), wall-clock ratio C/A, resolution per arm.
- **`SUPERVISED_SWEBENCH.md`** — runbook: wide instance sets, fleet setup, the local GPU worker (Gemma-4-26B QAT+MTP) config, reference results.

## Reference results (reddit10, primary gpt-5.5)

| Arm | primary tokens | wall (10 tasks) | resolution |
|---|---|---|---|
| A primary_alone | 104,834 | 434s serial / 56s parallel | 8/10 |
| C pure delegation | 14,467 (**−86%**) | **36.2s** | 4–6/10 |
| C best-of-3 + selection | 19,700 (**−81%**) | parallel | 5/6 graded |

Primary spends **81–86% fewer tokens** (beats Reddit's −75.5%) and the fleet runs concurrently (36s vs 434s solo-serial), i.e. no 3.75× slowdown. Best-of-N + primary selection recovers resolution; current limiter is worker reliability on long prompts, not the selection mechanism.

## Test

`AIMEE_BENCH_FAKE_AGENT=1 AIMEE_BENCH_FAKE_GRADER=1 python3 benchmarks/coding/bench_swebench_supervised.py --arms A,C --output /tmp/f.json` and `python3 -m unittest benchmarks.tests.test_bench_swebench_supervised`. Full suite: 430 bench tests pass.