### PR TITLE
graph-feedback S-community: deterministic community detection

### DIFF
--- a/src/db2/code_projection.c
+++ b/src/db2/code_projection.c
@@ -195,6 +195,141 @@ int db2_code_projection_list_edges(const char *project, code_projection_edge_t *
    return n;
 }
 
+int db2_code_projection_list_edges_for_gen(int64_t gen_id, code_projection_edge_t *out, int max)
+{
+   if (gen_id <= 0 || !out || max <= 0)
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   /* Total order (source, target, relation) so that if the LIMIT boundary cuts
+    * through same-(source,target) edges the truncation is deterministic — the
+    * derived community partition can't depend on DB row ordering. */
+   static const char *sql = "SELECT source, relation, target"
+                            " FROM code_projection_edges"
+                            " WHERE generation_id = ?1"
+                            " ORDER BY source, target, relation"
+                            " LIMIT ?2";
+   char err[CP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_int64(st, "?1", gen_id);
+   aimee_pg_bind_int64(st, "?2", max);
+   int n = 0;
+   while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *src = aimee_pg_column_text(st, 0);
+      const char *rel = aimee_pg_column_text(st, 1);
+      const char *tgt = aimee_pg_column_text(st, 2);
+      snprintf(out[n].source, sizeof(out[n].source), "%s", src ? src : "");
+      snprintf(out[n].relation, sizeof(out[n].relation), "%s", rel ? rel : "");
+      snprintf(out[n].target, sizeof(out[n].target), "%s", tgt ? tgt : "");
+      out[n].structural_weight = structural_weight_for_relation(rel);
+      n++;
+   }
+   aimee_pg_finalize(st);
+   return n;
+}
+
+/* --- Community membership (graph-feedback S-community) --- */
+
+int db2_code_projection_communities_replace(int64_t gen_id, const char *project,
+                                            const code_projection_community_t *rows, int n)
+{
+   if (gen_id <= 0 || n < 0 || (n > 0 && !rows))
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char err[CP_ERRBUF] = "";
+   if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
+      return -1;
+
+   /* Clear any prior partition for this generation (recompute is idempotent). */
+   static const char *del_sql = "DELETE FROM code_projection_communities WHERE generation_id = ?1";
+   aimee_pg_stmt_t *del = aimee_pg_prepare(conn, del_sql, err, sizeof(err));
+   if (!del)
+      goto rollback;
+   aimee_pg_bind_int64(del, "?1", gen_id);
+   if (aimee_pg_step(del, err, sizeof(err)) != AIMEE_PG_DONE)
+   {
+      aimee_pg_finalize(del);
+      goto rollback;
+   }
+   aimee_pg_finalize(del);
+
+   if (n > 0)
+   {
+      static const char *ins_sql =
+          "INSERT INTO code_projection_communities"
+          " (generation_id, project, node_id, community_id) VALUES (?1, ?2, ?3, ?4)";
+      aimee_pg_stmt_t *ins = aimee_pg_prepare(conn, ins_sql, err, sizeof(err));
+      if (!ins)
+         goto rollback;
+      for (int i = 0; i < n; i++)
+      {
+         aimee_pg_reset(ins);
+         aimee_pg_bind_int64(ins, "?1", gen_id);
+         aimee_pg_bind_text(ins, "?2", project ? project : "");
+         aimee_pg_bind_text(ins, "?3", rows[i].node_id);
+         aimee_pg_bind_text(ins, "?4", rows[i].community_id);
+         if (aimee_pg_step(ins, err, sizeof(err)) != AIMEE_PG_DONE)
+         {
+            aimee_pg_finalize(ins);
+            goto rollback;
+         }
+      }
+      aimee_pg_finalize(ins);
+   }
+
+   if (aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
+      goto rollback;
+   return 0;
+
+rollback:
+   /* Best-effort: if COMMIT itself failed after the server already committed, this
+    * ROLLBACK is a no-op and the rows persist. Acceptable here — the caller treats
+    * community membership as a derived analytic and recomputes it idempotently on
+    * the next publish; a later slice needing atomic cross-generation swaps would
+    * revisit this. aimee_pg_in_transaction avoids a spurious "no transaction". */
+   if (aimee_pg_in_transaction(conn))
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+   return -1;
+}
+
+int db2_code_projection_communities_list(int64_t gen_id, code_projection_community_t *out, int max)
+{
+   if (gen_id <= 0 || !out || max <= 0)
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   static const char *sql = "SELECT node_id, community_id"
+                            " FROM code_projection_communities"
+                            " WHERE generation_id = ?1"
+                            " ORDER BY node_id"
+                            " LIMIT ?2";
+   char err[CP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_int64(st, "?1", gen_id);
+   aimee_pg_bind_int64(st, "?2", max);
+   int n = 0;
+   while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *node = aimee_pg_column_text(st, 0);
+      const char *comm = aimee_pg_column_text(st, 1);
+      snprintf(out[n].node_id, sizeof(out[n].node_id), "%s", node ? node : "");
+      snprintf(out[n].community_id, sizeof(out[n].community_id), "%s", comm ? comm : "");
+      n++;
+   }
+   aimee_pg_finalize(st);
+   return n;
+}
+
 int db2_code_projection_project_fingerprint(const char *project, char *out, size_t out_len)
 {
    if (!project || !*project || !out || out_len == 0)

--- a/src/db2/code_projection.h
+++ b/src/db2/code_projection.h
@@ -96,6 +96,32 @@ extern "C"
     * Used by graph analytics (§4 hub/centrality) — a read-only projection. */
    int db2_code_projection_list_edges(const char *project, code_projection_edge_t *out, int max);
 
+   /* List the edges of a SPECIFIC generation (any state) into out[] (up to max),
+    * ordered source,target. Returns the count written (0 if the generation has no
+    * edges), or -1 on error. Used to compute community membership for the
+    * just-published generation regardless of visible state. */
+   int db2_code_projection_list_edges_for_gen(int64_t gen_id, code_projection_edge_t *out, int max);
+
+   /* --- Community membership (graph-feedback S-community) --- */
+
+   /* One node's community assignment within a generation. */
+   typedef struct
+   {
+      char node_id[512];      /* graph node id (edge endpoint)              */
+      char community_id[512]; /* min-member node id (lex), generation-local */
+   } code_projection_community_t;
+
+   /* Replace the community membership for gen_id: delete any existing rows for the
+    * generation, then insert rows[0..n). Idempotent for a given (gen, partition).
+    * Returns 0 on success, -1 on error. */
+   int db2_code_projection_communities_replace(int64_t gen_id, const char *project,
+                                               const code_projection_community_t *rows, int n);
+
+   /* List the community rows of gen_id into out[] (up to max), ordered by node_id.
+    * Returns the count written (0 if none), or -1 on error. */
+   int db2_code_projection_communities_list(int64_t gen_id, code_projection_community_t *out,
+                                            int max);
+
    /* --- Full project sync --- */
 
    /* Sync all code-index facts for project into entity_edges under gen_id.

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -1336,6 +1336,23 @@ CREATE TABLE IF NOT EXISTS code_projection_edges (
 CREATE INDEX IF NOT EXISTS idx_cpe_project_triple
     ON code_projection_edges(project, source, relation, target);
 
+-- graph-feedback S-community: deterministic community membership per generation.
+-- Persisted for EVERY generated projection (keyed by generation_id, not only the
+-- visible one) so a later slice can diff arbitrary generations. community_id is
+-- the min-member node id (lex) and is GENERATION-LOCAL by contract (cross-gen
+-- stable remap is a later slice). Retention follows the generation cleanup
+-- schedule via ON DELETE CASCADE.
+CREATE TABLE IF NOT EXISTS code_projection_communities (
+    generation_id BIGINT NOT NULL REFERENCES code_projection_generations(id)
+        ON DELETE CASCADE,
+    project       TEXT NOT NULL,
+    node_id       TEXT NOT NULL,
+    community_id  TEXT NOT NULL,
+    PRIMARY KEY (generation_id, node_id)
+);
+CREATE INDEX IF NOT EXISTS idx_cpc_gen_community
+    ON code_projection_communities(generation_id, community_id);
+
 -- Phase 3: projection_generation_id on entity_edges links each code-origin
 -- edge to its owning generation so recall can filter by visible generation.
 ALTER TABLE entity_edges

--- a/src/db2/schema_sqlite.sql
+++ b/src/db2/schema_sqlite.sql
@@ -324,6 +324,8 @@ CREATE TABLE IF NOT EXISTS code_projection_generations (  id INTEGER PRIMARY KEY
 CREATE INDEX IF NOT EXISTS idx_cpg_project_state ON code_projection_generations(project, state);
 CREATE TABLE IF NOT EXISTS code_projection_edges (  generation_id INTEGER NOT NULL REFERENCES code_projection_generations(id) ON DELETE CASCADE,  project TEXT NOT NULL,  source TEXT NOT NULL,  relation TEXT NOT NULL,  target TEXT NOT NULL,  source_hash TEXT NOT NULL DEFAULT '',  PRIMARY KEY (generation_id, source, relation, target));
 CREATE INDEX IF NOT EXISTS idx_cpe_project_triple ON code_projection_edges(project, source, relation, target);
+CREATE TABLE IF NOT EXISTS code_projection_communities (  generation_id INTEGER NOT NULL REFERENCES code_projection_generations(id) ON DELETE CASCADE,  project TEXT NOT NULL,  node_id TEXT NOT NULL,  community_id TEXT NOT NULL,  PRIMARY KEY (generation_id, node_id));
+CREATE INDEX IF NOT EXISTS idx_cpc_gen_community ON code_projection_communities(generation_id, community_id);
 CREATE INDEX IF NOT EXISTS idx_ee_source_relation ON entity_edges(source, relation);
 CREATE INDEX IF NOT EXISTS idx_ee_target_relation ON entity_edges(target, relation);
 CREATE INDEX IF NOT EXISTS idx_ee_origin_source ON entity_edges(edge_origin, source);

--- a/src/kb/kb_graph_analytics.c
+++ b/src/kb/kb_graph_analytics.c
@@ -245,3 +245,308 @@ int kb_surprising_precision_suppress(int judged, int confirmed, int min_samples,
    double precision = (double)confirmed / (double)judged;
    return precision < floor ? 1 : 0;
 }
+
+/* ── S-community: deterministic community detection ─────────────────────────── */
+
+static int comm_str_cmp(const void *a, const void *b)
+{
+   return strcmp((const char *)a, (const char *)b);
+}
+
+/* Binary search for `name` in the lex-sorted names[] (n rows of KB_GRAPH_NODE_MAX
+ * bytes). Returns its index or -1. Names are unique + sorted, so this maps an
+ * edge endpoint to its node index deterministically. */
+static int comm_index_of(const char (*names)[KB_GRAPH_NODE_MAX], int n, const char *name)
+{
+   int lo = 0, hi = n - 1;
+   while (lo <= hi)
+   {
+      int mid = lo + (hi - lo) / 2;
+      int c = strcmp(names[mid], name);
+      if (c == 0)
+         return mid;
+      if (c < 0)
+         lo = mid + 1;
+      else
+         hi = mid - 1;
+   }
+   return -1;
+}
+
+int kb_graph_communities(const kb_graph_edge_t *edges, int n_edges, kb_graph_community_t *out,
+                         int max)
+{
+   if (!edges || n_edges < 0 || !out || max <= 0)
+      return -1;
+   if (n_edges == 0)
+      return 0;
+   if (n_edges > (INT_MAX / 2))
+      return -1;
+
+   /* 1. Collect distinct node names (non-empty endpoints), lex-sort + dedup so a
+    *    node's index equals its lex rank — the source of every tie-break's total
+    *    order and of permutation invariance. */
+   long long cap = (long long)n_edges * 2;
+   char(*raw)[KB_GRAPH_NODE_MAX] = malloc((size_t)cap * KB_GRAPH_NODE_MAX);
+   if (!raw)
+      return -1;
+   int nraw = 0;
+   for (int e = 0; e < n_edges; e++)
+   {
+      if (edges[e].source[0])
+         snprintf(raw[nraw++], KB_GRAPH_NODE_MAX, "%s", edges[e].source);
+      if (edges[e].target[0])
+         snprintf(raw[nraw++], KB_GRAPH_NODE_MAX, "%s", edges[e].target);
+   }
+   if (nraw == 0)
+   {
+      free(raw);
+      return 0;
+   }
+   qsort(raw, (size_t)nraw, KB_GRAPH_NODE_MAX, comm_str_cmp);
+   char(*names)[KB_GRAPH_NODE_MAX] = malloc((size_t)nraw * KB_GRAPH_NODE_MAX);
+   if (!names)
+   {
+      free(raw);
+      return -1;
+   }
+   int N = 0;
+   for (int i = 0; i < nraw; i++)
+      if (N == 0 || strcmp(names[N - 1], raw[i]) != 0)
+         snprintf(names[N++], KB_GRAPH_NODE_MAX, "%s", raw[i]);
+   free(raw);
+
+   /* 2. Build undirected weighted adjacency (CSR). Parallel edges are aggregated
+    *    by summation (kept as duplicate entries — the k_in accumulation sums
+    *    them); self-loops dropped; weight clamped to >= 0. All arithmetic is
+    *    integer, so summation order never affects the result. */
+   int *deg = calloc((size_t)N, sizeof(int));
+   long long *k = calloc((size_t)N, sizeof(long long)); /* weighted degree */
+   if (!deg || !k)
+   {
+      free(names);
+      free(deg);
+      free(k);
+      return -1;
+   }
+   /* First pass: per-node adjacency entry counts. */
+   for (int e = 0; e < n_edges; e++)
+   {
+      if (!edges[e].source[0] || !edges[e].target[0])
+         continue;
+      int si = comm_index_of(names, N, edges[e].source);
+      int ti = comm_index_of(names, N, edges[e].target);
+      if (si < 0 || ti < 0 || si == ti)
+         continue;
+      deg[si]++;
+      deg[ti]++;
+   }
+   long long total_adj = 0;
+   int *off = malloc((size_t)(N + 1) * sizeof(int));
+   if (!off)
+   {
+      free(names);
+      free(deg);
+      free(k);
+      return -1;
+   }
+   for (int i = 0; i < N; i++)
+   {
+      off[i] = (int)total_adj;
+      total_adj += deg[i];
+   }
+   off[N] = (int)total_adj;
+   int *nbr = total_adj ? malloc((size_t)total_adj * sizeof(int)) : malloc(1);
+   long long *ew = total_adj ? malloc((size_t)total_adj * sizeof(long long)) : malloc(1);
+   int *fill = calloc((size_t)N, sizeof(int));
+   if (!nbr || !ew || !fill)
+   {
+      free(names);
+      free(deg);
+      free(k);
+      free(off);
+      free(nbr);
+      free(ew);
+      free(fill);
+      return -1;
+   }
+   long long TWO_M = 0; /* sum of weighted degrees = 2 * total edge weight */
+   for (int e = 0; e < n_edges; e++)
+   {
+      if (!edges[e].source[0] || !edges[e].target[0])
+         continue;
+      int si = comm_index_of(names, N, edges[e].source);
+      int ti = comm_index_of(names, N, edges[e].target);
+      if (si < 0 || ti < 0 || si == ti)
+         continue;
+      long long w = edges[e].weight > 0 ? edges[e].weight : 0;
+      int ps = off[si] + fill[si]++;
+      nbr[ps] = ti;
+      ew[ps] = w;
+      int pt = off[ti] + fill[ti]++;
+      nbr[pt] = si;
+      ew[pt] = w;
+      k[si] += w;
+      k[ti] += w;
+      TWO_M += 2 * w;
+   }
+   free(deg);
+   free(fill);
+
+   /* Reject a graph whose total weight would overflow the exact-integer gain. */
+   if (TWO_M > KB_GRAPH_COMMUNITY_MAX_TWO_M)
+   {
+      free(names);
+      free(k);
+      free(off);
+      free(nbr);
+      free(ew);
+      return -1;
+   }
+
+   /* 3. Local moving. comm[i] = node i's community label (a node index). Degenerate
+    *    graph with no positive weight -> every node its own singleton. `seen` +
+    *    `visit` mark the per-node touched set without relying on acc==0 (which a
+    *    zero-weight edge would defeat, re-pushing a community + overflowing touched). */
+   int *comm = malloc((size_t)N * sizeof(int));
+   long long *sigma_tot = malloc((size_t)N * sizeof(long long));
+   int *comm_min = malloc((size_t)N * sizeof(int));
+   long long *acc = calloc((size_t)N, sizeof(long long));
+   int *touched = malloc((size_t)N * sizeof(int));
+   long long *seen = malloc((size_t)N * sizeof(long long));
+   if (!comm || !sigma_tot || !comm_min || !acc || !touched || !seen)
+   {
+      free(names);
+      free(k);
+      free(off);
+      free(nbr);
+      free(ew);
+      free(comm);
+      free(sigma_tot);
+      free(comm_min);
+      free(acc);
+      free(touched);
+      free(seen);
+      return -1;
+   }
+   for (int i = 0; i < N; i++)
+   {
+      comm[i] = i;
+      sigma_tot[i] = k[i];
+      seen[i] = -1;
+   }
+   long long visit = 0;
+
+   if (TWO_M > 0)
+   {
+      for (int pass = 0; pass < KB_GRAPH_COMMUNITY_MAX_PASSES; pass++)
+      {
+         /* Min-member of each community, recomputed from the deterministic comm[]
+          * at pass start — the tie-break's "min-member-id lex" (index == lex rank). */
+         for (int c = 0; c < N; c++)
+            comm_min[c] = N;
+         for (int i = 0; i < N; i++)
+            if (i < comm_min[comm[i]])
+               comm_min[comm[i]] = i;
+
+         int moved = 0;
+         for (int i = 0; i < N; i++)
+         {
+            int c_old = comm[i];
+            sigma_tot[c_old] -= k[i]; /* isolate i */
+
+            /* k_in per neighbouring community. Touched-list membership is stamped
+             * with the per-node `visit` (never acc==0), so a zero-weight edge
+             * cannot re-push a community and overflow `touched`. O(deg(i)). */
+            visit++;
+            int nt = 0;
+            for (int p = off[i]; p < off[i + 1]; p++)
+            {
+               int cc = comm[nbr[p]];
+               if (seen[cc] != visit)
+               {
+                  seen[cc] = visit;
+                  touched[nt++] = cc;
+               }
+               acc[cc] += ew[p];
+            }
+
+            /* Default: stay in the current community (gain 0). A neighbour lures i
+             * only on strictly positive gain; among positive-gain neighbours, ties
+             * break to the smaller pass-start min-member (deterministic +
+             * permutation-invariant). A zero-gain neighbour never displaces the
+             * stay option, so there is no gain-free churn. */
+            long long best_gain = 0;
+            int best_comm = c_old;
+            int best_min = 0; /* meaningful only once best_comm has left c_old */
+            for (int j = 0; j < nt; j++)
+            {
+               int cc = touched[j];
+               long long kin = acc[cc];
+               long long gain = TWO_M * kin - k[i] * sigma_tot[cc]; /* gamma = 1 */
+               if (gain > best_gain ||
+                   (gain == best_gain && best_comm != c_old && comm_min[cc] < best_min))
+               {
+                  best_gain = gain;
+                  best_comm = cc;
+                  best_min = comm_min[cc];
+               }
+            }
+            for (int j = 0; j < nt; j++)
+               acc[touched[j]] = 0;
+
+            sigma_tot[best_comm] += k[i];
+            comm[i] = best_comm;
+            if (best_comm != c_old)
+               moved = 1;
+         }
+         if (!moved)
+            break;
+      }
+   }
+
+   /* 4. Final community id = min-member node id (lex). rep[label] = smallest index
+    *    in that community; community string = names[rep]. */
+   int *rep = malloc((size_t)N * sizeof(int));
+   if (!rep)
+   {
+      free(names);
+      free(k);
+      free(off);
+      free(nbr);
+      free(ew);
+      free(comm);
+      free(sigma_tot);
+      free(comm_min);
+      free(acc);
+      free(touched);
+      free(seen);
+      return -1;
+   }
+   for (int c = 0; c < N; c++)
+      rep[c] = N;
+   for (int i = 0; i < N; i++)
+      if (i < rep[comm[i]])
+         rep[comm[i]] = i;
+
+   int w = N < max ? N : max;
+   for (int i = 0; i < w; i++)
+   {
+      snprintf(out[i].node, sizeof(out[i].node), "%s", names[i]);
+      snprintf(out[i].community, sizeof(out[i].community), "%s", names[rep[comm[i]]]);
+   }
+
+   free(names);
+   free(k);
+   free(off);
+   free(nbr);
+   free(ew);
+   free(comm);
+   free(sigma_tot);
+   free(comm_min);
+   free(acc);
+   free(touched);
+   free(seen);
+   free(rep);
+   return w;
+}

--- a/src/kb/kb_graph_analytics.h
+++ b/src/kb/kb_graph_analytics.h
@@ -93,4 +93,62 @@ int kb_graph_surprising(const kb_graph_edge_t *edges, int n_edges, const kb_grap
  * disabled (`floor` <= 0), or precision is at/above the floor. Pure. */
 int kb_surprising_precision_suppress(int judged, int confirmed, int min_samples, double floor);
 
+/* ── S-community: deterministic community detection (graph-feedback foundation) ── */
+
+/* One node's community assignment. `community` is the community id: the
+ * lexicographically-smallest member node id (see contract below). */
+typedef struct
+{
+   char node[KB_GRAPH_NODE_MAX];
+   char community[KB_GRAPH_NODE_MAX];
+} kb_graph_community_t;
+
+/* Cap on local-moving passes. Convergence is a no-move pass; this only bounds a
+ * pathological graph that never settles. */
+#define KB_GRAPH_COMMUNITY_MAX_PASSES 64
+
+/* Upper bound on 2m (the summed weighted degree). The exact-integer gain forms
+ * the products 2m*k_in and k_i*sigma_tot, each <= (2m)^2; keeping 2m below
+ * floor(sqrt(INT64_MAX)) guarantees they never overflow int64. A graph whose
+ * total weight exceeds this is rejected (-1). Real callers pass structural
+ * weights <= 3 over a few thousand edges — many orders of magnitude below it. */
+#define KB_GRAPH_COMMUNITY_MAX_TWO_M 3037000499LL
+
+/* Partition the nodes of `edges` into communities by deterministic modularity
+ * maximization, writing one row per distinct node into out[] (up to `max`, in
+ * node-ascending order). Returns the distinct-node count written (<= max), 0 if
+ * there are no usable edges, or -1 on a bad argument. Never allocates
+ * caller-visible memory; out[] is caller-owned.
+ *
+ * NORMALIZATION SPEC (fully pinned — single method, no fallback):
+ *   - Edges are treated UNDIRECTED.
+ *   - Parallel edges between the same pair are AGGREGATED by summed weight.
+ *   - Self-loops (source==target) are DROPPED.
+ *   - Edge weight = the edge's `weight` (structural trust), clamped to >= 0; a
+ *     0-weight edge is inert (present but exerts no pull).
+ *   - Objective: modularity with resolution gamma = 1.0.
+ *   - Method: single-level Louvain local moving. Every node starts in its own
+ *     singleton. Nodes are processed in a FIXED order (node id ascending) each
+ *     pass; a node stays in its current community unless a neighbouring community
+ *     offers STRICTLY positive modularity gain, in which case it moves to the
+ *     best such neighbour. The gain is EXACT INTEGER arithmetic (compared as
+ *     2m*k_in - k_i*sigma_tot, gamma=1) so it is permutation-invariant — no
+ *     floating point, no summation-order sensitivity. (A node only re-isolates at
+ *     initialization; a merged node staying by default keeps its current
+ *     community — standard single-level behaviour.)
+ *   - Iteration: repeat passes until a pass moves nothing (convergence) or
+ *     KB_GRAPH_COMMUNITY_MAX_PASSES is reached.
+ *   - Total-order tie-break among the positive-gain neighbours of equal gain:
+ *     pick the one whose min-member node id is lexicographically smallest, as
+ *     snapshotted at the start of the current pass (a deterministic key; at
+ *     convergence the snapshot equals the exact current min-member). A zero-gain
+ *     neighbour never displaces the stay option, so there is no gain-free churn.
+ *   - Community id = the min-member node id (lex). Ids are GENERATION-LOCAL by
+ *     contract; cross-generation stable remap is a later slice (S2).
+ *
+ * Determinism: for a fixed node/edge set the output is byte-identical regardless
+ * of the order edges are presented in. */
+int kb_graph_communities(const kb_graph_edge_t *edges, int n_edges, kb_graph_community_t *out,
+                         int max);
+
 #endif /* KB_GRAPH_ANALYTICS_H */

--- a/src/kb/kb_service_graph.c
+++ b/src/kb/kb_service_graph.c
@@ -11,6 +11,7 @@
 #include "db2/entity_edges.h"
 #include "db2/entity_nodes.h"
 #include "db2/kb_service_backend.h" /* db2_kb_service_code_audit_json */
+#include "kb_graph_analytics.h"     /* kb_graph_communities */
 
 #include <stdlib.h>
 #include <string.h>
@@ -31,6 +32,84 @@ const char *kb_graph_edge_provenance(const char *edge_origin, int structural_wei
    if (edge_origin && strcmp(edge_origin, "session") == 0)
       return "ambiguous";
    return "inferred";
+}
+
+/* Upper bound on edges pulled into the in-memory community computation. Matches
+ * the analytics read-out cap; a larger projection is truncated (deterministically,
+ * by the source,target ORDER BY of the edge read). */
+#define KB_GRAPH_COMMUNITY_MAX_EDGES 20000
+
+/* Compute + persist deterministic community membership for a just-published
+ * generation (graph-feedback S-community). Best-effort: a failure here does not
+ * unpublish the projection — communities are a derived analytic. Returns the
+ * number of nodes assigned, or -1 on error. */
+static int kb_graph_persist_communities(int64_t gen_id, const char *project)
+{
+   if (gen_id <= 0)
+      return -1;
+
+   code_projection_edge_t *cpe = malloc((size_t)KB_GRAPH_COMMUNITY_MAX_EDGES * sizeof(*cpe));
+   if (!cpe)
+      return -1;
+   int ne = db2_code_projection_list_edges_for_gen(gen_id, cpe, KB_GRAPH_COMMUNITY_MAX_EDGES);
+   if (ne < 0)
+   {
+      free(cpe);
+      return -1;
+   }
+   if (ne == 0)
+   {
+      /* No edges -> clear any stale membership for this generation. */
+      free(cpe);
+      return db2_code_projection_communities_replace(gen_id, project, NULL, 0);
+   }
+
+   kb_graph_edge_t *ge = malloc((size_t)ne * sizeof(*ge));
+   if (!ge)
+   {
+      free(cpe);
+      return -1;
+   }
+   for (int i = 0; i < ne; i++)
+   {
+      snprintf(ge[i].source, sizeof(ge[i].source), "%s", cpe[i].source);
+      snprintf(ge[i].target, sizeof(ge[i].target), "%s", cpe[i].target);
+      ge[i].weight = cpe[i].structural_weight;
+   }
+   free(cpe);
+
+   /* Distinct nodes are bounded by 2 per edge. */
+   long long max_nodes = (long long)ne * 2;
+   kb_graph_community_t *gc = malloc((size_t)max_nodes * sizeof(*gc));
+   if (!gc)
+   {
+      free(ge);
+      return -1;
+   }
+   int nc = kb_graph_communities(ge, ne, gc, (int)max_nodes);
+   free(ge);
+   if (nc < 0)
+   {
+      free(gc);
+      return -1;
+   }
+
+   code_projection_community_t *rows = nc > 0 ? malloc((size_t)nc * sizeof(*rows)) : NULL;
+   if (nc > 0 && !rows)
+   {
+      free(gc);
+      return -1;
+   }
+   for (int i = 0; i < nc; i++)
+   {
+      snprintf(rows[i].node_id, sizeof(rows[i].node_id), "%s", gc[i].node);
+      snprintf(rows[i].community_id, sizeof(rows[i].community_id), "%s", gc[i].community);
+   }
+   free(gc);
+
+   int rc = db2_code_projection_communities_replace(gen_id, project, rows, nc);
+   free(rows);
+   return rc == 0 ? nc : -1;
 }
 
 int64_t kb_graph_build_project_if_changed(const char *project, int *rebuilt)
@@ -63,6 +142,9 @@ int64_t kb_graph_build_project_if_changed(const char *project, int *rebuilt)
       db2_code_projection_generation_abort(gen, "publish failed");
       return -1;
    }
+   /* Derived analytic: deterministic community membership for this generation.
+    * Best-effort — a failure does not unpublish the projection. */
+   kb_graph_persist_communities(gen, project);
    if (rebuilt)
       *rebuilt = 1;
    return edges; /* >= 0 (a changed-but-empty project publishes 0 edges + its hash) */
@@ -94,6 +176,8 @@ int kb_handle_graph_sync_code(int fd, cJSON *req)
       db2_code_projection_generation_abort(gen, "publish failed");
       return kb_send_error(fd, "failed to publish projection generation");
    }
+   /* Derived analytic (best-effort, see kb_graph_build_project_if_changed). */
+   kb_graph_persist_communities(gen, project);
 
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "project", project);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1716,7 +1716,8 @@ $(OBJDIR)/tests/test_kb_graph_analytics.o: C_FLAGS += -Ikb
 $(OBJDIR)/tests/test_prompt_sanitizer.o: C_FLAGS += -Ikb
 
 $(TESTPREFIX)/unit-test-kb-graph: $(OBJDIR)/tests/test_kb_graph.o \
-                                  $(OBJDIR)/kb/kb_service_graph.o $(OBJDIR)/cJSON.o
+                                  $(OBJDIR)/kb/kb_service_graph.o \
+                                  $(OBJDIR)/kb/kb_graph_analytics.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_CORE)
 
 # Reciprocal Rank Fusion core (§5 hybrid retrieval scoring model). Pure: no DB.

--- a/src/tests/test_kb_graph.c
+++ b/src/tests/test_kb_graph.c
@@ -3,10 +3,12 @@
  * (skip-when-unchanged vs publish-a-new-generation) is driven deterministically
  * without a live Postgres. */
 #include "kb_service_graph.h"
+#include "db2/code_projection.h"
 
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* ---- controllable DB2 stubs ---- */
@@ -63,6 +65,40 @@ int db2_code_projection_generation_abort(int64_t gen, const char *err)
    (void)err;
    g_aborted++;
    return 0;
+}
+
+/* Controllable edge fixture + captured community persistence, for the
+ * kb_graph_persist_communities path that runs after a publish. */
+static const code_projection_edge_t *g_edges = NULL;
+static int g_n_edges = 0;
+static int64_t g_persist_gen = 0;
+static int g_persist_n = -1;
+static code_projection_community_t g_persist_rows[64];
+
+int db2_code_projection_list_edges_for_gen(int64_t gen, code_projection_edge_t *out, int max)
+{
+   (void)gen;
+   int n = g_n_edges < max ? g_n_edges : max;
+   for (int i = 0; i < n; i++)
+      out[i] = g_edges[i];
+   return n;
+}
+int db2_code_projection_communities_replace(int64_t gen, const char *project,
+                                            const code_projection_community_t *rows, int n)
+{
+   (void)project;
+   g_persist_gen = gen;
+   g_persist_n = n;
+   for (int i = 0; i < n && i < (int)(sizeof(g_persist_rows) / sizeof(g_persist_rows[0])); i++)
+      g_persist_rows[i] = rows[i];
+   return 0;
+}
+static const char *persisted_community_of(const char *node)
+{
+   for (int i = 0; i < g_persist_n; i++)
+      if (strcmp(g_persist_rows[i].node_id, node) == 0)
+         return g_persist_rows[i].community_id;
+   return NULL;
 }
 
 /* ---- link-only stubs for the rest of kb_service_graph.o (unused here) ---- */
@@ -150,11 +186,45 @@ static void test_idempotent_build(void)
    printf("  test_idempotent_build: ok\n");
 }
 
+/* After a publish, the derived community membership is computed from the
+ * generation's edges and persisted (keyed by generation id). Drives the real
+ * build path with a two-triangle fixture through the DB2 stubs. */
+static void test_community_persist(void)
+{
+   code_projection_edge_t edges[] = {
+       {"a", "calls", "b", 5}, {"b", "calls", "c", 5}, {"a", "calls", "c", 5},
+       {"x", "calls", "y", 5}, {"y", "calls", "z", 5}, {"x", "calls", "z", 5},
+       {"c", "calls", "x", 1},
+   };
+   g_edges = edges;
+   g_n_edges = 7;
+   g_persist_gen = 0;
+   g_persist_n = -1;
+
+   snprintf(g_fp, sizeof(g_fp), "aaa");
+   g_visible[0] = '\0'; /* first build -> rebuild + publish */
+   int rebuilt = -1;
+   int64_t r = kb_graph_build_project_if_changed("p", &rebuilt);
+   assert(r == 7 && rebuilt == 1);
+
+   assert(g_persist_gen == 42); /* keyed by the generation id */
+   assert(g_persist_n == 6);    /* six distinct nodes */
+   assert(strcmp(persisted_community_of("b"), "a") == 0);
+   assert(strcmp(persisted_community_of("c"), "a") == 0);
+   assert(strcmp(persisted_community_of("z"), "x") == 0);
+   assert(strcmp(persisted_community_of("a"), persisted_community_of("x")) != 0);
+
+   g_edges = NULL;
+   g_n_edges = 0;
+   printf("  test_community_persist: ok\n");
+}
+
 int main(void)
 {
    printf("test_kb_graph:\n");
    test_provenance();
    test_idempotent_build();
+   test_community_persist();
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_kb_graph_analytics.c
+++ b/src/tests/test_kb_graph_analytics.c
@@ -188,10 +188,167 @@ static void test_precision_suppress(void)
    printf("  test_precision_suppress: ok\n");
 }
 
+/* ── S-community: deterministic community detection ─────────────────────────── */
+
+static const char *commof(const kb_graph_community_t *c, int n, const char *node)
+{
+   for (int i = 0; i < n; i++)
+      if (strcmp(c[i].node, node) == 0)
+         return c[i].community;
+   return NULL;
+}
+
+/* Known-modular fixture: two triangles {a,b,c} and {x,y,z} joined by one weak
+ * bridge c-x. Each triangle is its own community; the bridge does not merge them.
+ * Community id = the lex-smallest member ("a" / "x"). Output is node-ascending. */
+static void test_community_two_cliques(void)
+{
+   kb_graph_edge_t edges[] = {
+       {"a", "b", 5}, {"b", "c", 5}, {"a", "c", 5}, {"x", "y", 5},
+       {"y", "z", 5}, {"x", "z", 5}, {"c", "x", 1},
+   };
+   kb_graph_community_t out[16];
+   int n = kb_graph_communities(edges, 7, out, 16);
+   assert(n == 6);
+   assert(strcmp(commof(out, n, "a"), commof(out, n, "b")) == 0);
+   assert(strcmp(commof(out, n, "a"), commof(out, n, "c")) == 0);
+   assert(strcmp(commof(out, n, "x"), commof(out, n, "y")) == 0);
+   assert(strcmp(commof(out, n, "x"), commof(out, n, "z")) == 0);
+   assert(strcmp(commof(out, n, "a"), commof(out, n, "x")) != 0);
+   assert(strcmp(commof(out, n, "b"), "a") == 0); /* community id = min-member lex */
+   assert(strcmp(commof(out, n, "z"), "x") == 0);
+   for (int i = 1; i < n; i++)
+      assert(strcmp(out[i - 1].node, out[i].node) < 0); /* node-ascending */
+   printf("  test_community_two_cliques: ok\n");
+}
+
+/* Determinism under input permutation: a shuffled + endpoint-swapped edge list
+ * yields a byte-identical partition (integer gain, fixed node order). */
+static void test_community_permutation_invariant(void)
+{
+   kb_graph_edge_t e1[] = {
+       {"a", "b", 5}, {"b", "c", 5}, {"a", "c", 5}, {"x", "y", 5},
+       {"y", "z", 5}, {"x", "z", 5}, {"c", "x", 1},
+   };
+   kb_graph_edge_t e2[] = {
+       {"c", "x", 1}, {"z", "x", 5}, {"c", "a", 5}, {"y", "z", 5},
+       {"b", "a", 5}, {"y", "x", 5}, {"c", "b", 5},
+   };
+   kb_graph_community_t o1[16], o2[16];
+   int n1 = kb_graph_communities(e1, 7, o1, 16);
+   int n2 = kb_graph_communities(e2, 7, o2, 16);
+   assert(n1 == 6 && n2 == 6);
+   for (int i = 0; i < n1; i++)
+   {
+      assert(strcmp(o1[i].node, o2[i].node) == 0);
+      assert(strcmp(o1[i].community, o2[i].community) == 0);
+   }
+   printf("  test_community_permutation_invariant: ok\n");
+}
+
+/* Disconnected components are separate communities. */
+static void test_community_disconnected(void)
+{
+   kb_graph_edge_t edges[] = {{"p", "q", 4}, {"m", "n", 4}};
+   kb_graph_community_t out[16];
+   int n = kb_graph_communities(edges, 2, out, 16);
+   assert(n == 4);
+   assert(strcmp(commof(out, n, "p"), commof(out, n, "q")) == 0);
+   assert(strcmp(commof(out, n, "m"), commof(out, n, "n")) == 0);
+   assert(strcmp(commof(out, n, "p"), commof(out, n, "m")) != 0);
+   printf("  test_community_disconnected: ok\n");
+}
+
+/* Self-loops are dropped; a zero-weight edge is inert (endpoints stay singletons). */
+static void test_community_degenerate(void)
+{
+   kb_graph_edge_t sl[] = {{"a", "a", 9}, {"a", "b", 3}};
+   kb_graph_community_t out[16];
+   int n = kb_graph_communities(sl, 2, out, 16);
+   assert(n == 2);
+   assert(strcmp(commof(out, n, "a"), commof(out, n, "b")) == 0);
+
+   kb_graph_edge_t zw[] = {{"a", "b", 0}};
+   int m = kb_graph_communities(zw, 1, out, 16);
+   assert(m == 2);
+   assert(strcmp(commof(out, m, "a"), "a") == 0);
+   assert(strcmp(commof(out, m, "b"), "b") == 0);
+   printf("  test_community_degenerate: ok\n");
+}
+
+/* Truncation + bad args. */
+static void test_community_bounds(void)
+{
+   kb_graph_edge_t edges[] = {{"a", "b", 5}, {"b", "c", 5}, {"c", "d", 5}};
+   kb_graph_community_t out[2];
+   int n = kb_graph_communities(edges, 3, out, 2);
+   assert(n == 2);
+   assert(strcmp(out[0].node, "a") == 0 && strcmp(out[1].node, "b") == 0);
+
+   assert(kb_graph_communities(NULL, 1, out, 2) == -1);
+   assert(kb_graph_communities(edges, -1, out, 2) == -1);
+   assert(kb_graph_communities(edges, 1, NULL, 2) == -1);
+   assert(kb_graph_communities(edges, 1, out, 0) == -1);
+   assert(kb_graph_communities(edges, 0, out, 2) == 0);
+   printf("  test_community_bounds: ok\n");
+}
+
+/* Many parallel zero-weight edges between the same pair must not overflow the
+ * touched-list (the sentinel is a per-node visit stamp, not acc==0). Regression
+ * for the review's zero-weight re-push finding. */
+static void test_community_zero_weight_parallel(void)
+{
+   kb_graph_edge_t edges[24];
+   int n = 0;
+   for (int i = 0; i < 20; i++)
+      edges[n++] = (kb_graph_edge_t){"a", "b", 0}; /* 20 parallel zero-weight */
+   edges[n++] = (kb_graph_edge_t){"c", "d", 3};
+   kb_graph_community_t out[8];
+   int r = kb_graph_communities(edges, n, out, 8);
+   assert(r == 4); /* a,b,c,d — no crash, no overflow */
+   /* zero-weight -> a,b stay singletons; c,d merge */
+   assert(strcmp(commof(out, r, "a"), "a") == 0);
+   assert(strcmp(commof(out, r, "b"), "b") == 0);
+   assert(strcmp(commof(out, r, "c"), commof(out, r, "d")) == 0);
+   printf("  test_community_zero_weight_parallel: ok\n");
+}
+
+/* Parallel positive edges aggregate by summed weight (two a-b edges pull a,b
+ * together strongly). */
+static void test_community_parallel_aggregate(void)
+{
+   kb_graph_edge_t edges[] = {{"a", "b", 2}, {"a", "b", 2}, {"c", "d", 4}};
+   kb_graph_community_t out[8];
+   int r = kb_graph_communities(edges, 3, out, 8);
+   assert(r == 4);
+   assert(strcmp(commof(out, r, "a"), commof(out, r, "b")) == 0);
+   assert(strcmp(commof(out, r, "c"), commof(out, r, "d")) == 0);
+   assert(strcmp(commof(out, r, "a"), commof(out, r, "c")) != 0);
+   printf("  test_community_parallel_aggregate: ok\n");
+}
+
+/* A total weight that would overflow the exact-integer gain is rejected (-1). */
+static void test_community_overflow_guard(void)
+{
+   /* Two edges of weight 1.5e9 -> 2m = 6e9 > KB_GRAPH_COMMUNITY_MAX_TWO_M. */
+   kb_graph_edge_t edges[] = {{"a", "b", 1500000000}, {"b", "c", 1500000000}};
+   kb_graph_community_t out[8];
+   assert(kb_graph_communities(edges, 2, out, 8) == -1);
+   printf("  test_community_overflow_guard: ok\n");
+}
+
 int main(void)
 {
    printf("test_kb_graph_analytics:\n");
    test_precision_suppress();
+   test_community_two_cliques();
+   test_community_permutation_invariant();
+   test_community_disconnected();
+   test_community_degenerate();
+   test_community_bounds();
+   test_community_zero_weight_parallel();
+   test_community_parallel_aggregate();
+   test_community_overflow_guard();
    test_hub_ranking();
    test_deterministic_tiebreak();
    test_self_loop();


### PR DESCRIPTION
## Graph-feedback initiative — S-community (foundation slice)

Partitions the code projection graph into communities, persisted per generation, so the later slices can build on it: **§1 low-cohesion audit** (conductance/modularity per community) and **§3 community-scoped lessons**. Sequenced after S0 (#988, merged) but independent of it.

### Pure core — `kb_graph_communities()` in `kb_graph_analytics.{c,h}`
Single fully-pinned method, **no fallback** (plan R1):
- Edges undirected; parallel edges aggregated by summed weight; self-loops dropped; weight = `structural_weight`; modularity resolution γ=1.0.
- Single-level Louvain local moving to a no-move pass (capped). **The move decision is exact integer arithmetic** (`2m·k_in − k_i·σ_tot`, γ=1) — so the partition is **byte-identical regardless of edge input order**: no float, no summation-order sensitivity.
- Community id = min-member node id (lex), **generation-local by contract** (cross-generation stable remap is a later slice, S2).

### Persistence — `db2/code_projection.{c,h}` + `schema.sql`/`schema_sqlite.sql`
- New `code_projection_communities(generation_id, project, node_id, community_id)`, keyed by generation for **every** generated projection (not just visible) so S2 can diff arbitrary generations; retention follows the generation cleanup schedule via `ON DELETE CASCADE`.
- `db2_code_projection_list_edges_for_gen` (per-gen edge read, total-order `source,target,relation` so LIMIT truncation is deterministic), `_communities_replace` (transactional delete+insert), `_communities_list`.
- Wired into `kb_graph_build_project_if_changed` and the `graph.sync_code` handler right after publish, **best-effort** (a failure does not unpublish the graph — communities are a derived analytic).

### Review
Roundtable code-review applied. Genuine findings fixed with regression tests:
- **Baseline** now defaults to *staying in the current community* (standard Louvain), not reusing the node's own label — the prior form could mislabel a re-merge as a singleton.
- **Touched-list sentinel** is a per-node visit stamp, not `acc==0` — a zero-weight parallel edge can no longer re-push a community and overflow the list.
- **int64 overflow guard** (`KB_GRAPH_COMMUNITY_MAX_TWO_M`) on the exact-integer gain; `comm_min` is a consistent pass-start snapshot; deterministic truncation order; post-COMMIT rollback limitation documented.

### Tests
`test_kb_graph_analytics.c` (pure): known-modular two-triangle fixture, permutation-invariance, zero-weight parallel edges, parallel aggregation, overflow guard, disconnected/degenerate/bounds. `test_kb_graph.c` (DB2 stub): the after-publish compute+persist path with captured membership. `make lint` + `schema-sync` green; `aimee-kb` links; all under `-Werror`, ASan/UBSan clean (incl. a 200-permutation fuzz recovering a 5-cluster graph byte-identically).