### PR TITLE
graph-feedback S1: graph self-audit (/v1/code/graph/audit)

### DIFF
--- a/docs/SANITIZER_CALL_SITES.md
+++ b/docs/SANITIZER_CALL_SITES.md
@@ -45,8 +45,10 @@ undocumented, or a documented file no longer calls the sanitizer.
 
 | File | Render surface | Kind(s) | Slice |
 |------|----------------|---------|-------|
-| _(none yet)_ | S0 ships the boundary only; §1/§2/§3/§6 render surfaces are added in later slices and register here as they land. | — | S0 |
+| `src/kb/http/kb_http_code.c` | `GET /v1/code/graph/audit` findings — cycle file paths, orphan/bridge/unverified symbol labels, community names rendered into the agent-visible audit JSON. | `SANITIZE_FILE_PATH`, `SANITIZE_SYMBOL_LABEL`, `SANITIZE_COMMUNITY_NAME` | S1 |
 
-> When S1 (self-audit) renders finding strings, S3 (lessons), or S5/S6 (grammars /
-> media captions) render corpus text, add a row here in the same PR that adds the
+> The audit route renders corpus-derived node/file/community strings; each goes
+> through `audit_safe()` → `sanitize_for_prompt` (fail-closed to `[unsafe-label]`
+> on `SANITIZE_REJECTED`). When S3 (lessons) or S5/S6 (grammars / media captions)
+> render corpus text, add a row here in the same PR that adds the
 > `sanitize_for_prompt` call, or `make lint` fails.

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -1124,6 +1124,7 @@ char *kb_client_pdf_open_asset(const char *project, long long asset_id, int *sta
 char *kb_client_code_hybrid(const char *query, const char *symbol, const char *project,
                             int max_results, int *status_out);
 char *kb_client_code_graph_hubs(const char *project, int max_results, int *status_out);
+char *kb_client_code_graph_audit(const char *project, int max_findings, int *status_out);
 /* /v1/code/graph/surprising: file pairs that are semantically close yet
  * structurally far (project required). `judge` opts into the LLM confirmation. */
 char *kb_client_code_graph_surprising(const char *project, int max_results, int judge,

--- a/src/headers/kb_http_code.h
+++ b/src/headers/kb_http_code.h
@@ -42,5 +42,8 @@ int handle_get_code_graph_route(const char *method, const char *query_string, ch
 int handle_get_code_graph_surprising(const char *query_string, char *out_buf, int out_cap);
 int handle_get_code_graph_surprising_route(const char *method, const char *query_string,
                                            char *out_buf, int out_cap);
+int handle_get_code_graph_audit(const char *query_string, char *out_buf, int out_cap);
+int handle_get_code_graph_audit_route(const char *method, const char *query_string, char *out_buf,
+                                      int out_cap);
 
 #endif

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1286,6 +1286,8 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       return handle_get_code_graph_hubs_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/code/graph/surprising") == 0)
       return handle_get_code_graph_surprising_route(method, query_string, out_buf, out_cap);
+   if (strcmp(path, "/v1/code/graph/audit") == 0)
+      return handle_get_code_graph_audit_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/code/graph") == 0)
       return handle_get_code_graph_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/search") == 0)

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -21,6 +21,7 @@
 #include "kb/kb_graph_analytics.h"
 #include "kb/kb_service_graph.h"
 #include "kb/kb_surprising_judge.h"
+#include "kb/prompt_sanitizer.h" /* §1 render boundary: sanitize corpus-derived labels */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -1699,6 +1700,372 @@ int handle_get_code_graph_surprising_route(const char *method, const char *query
    if (strcmp(method, "GET") != 0)
       return code_method_not_allowed(out_buf, out_cap);
    return handle_get_code_graph_surprising(query_string, out_buf, out_cap);
+}
+
+/* GET /v1/code/graph/audit?project=<proj>[&max_findings=N]
+ *
+ * §1 self-audit: a deterministic, read-only structural-health pass over the
+ * project's visible projection graph. Emits ranked findings — file-dependency
+ * cycles, orphaned symbols, bridge symbols, low-cohesion communities, and
+ * (labeled `no-confirmation-yet`) unverified-inferred edges — with an honesty gate
+ * that says "clean" / "insufficient signal" rather than inventing noise. Pure
+ * analytics over data already persisted; no LLM. Every corpus-derived string
+ * rendered into the response passes the S0 sanitizer (fail-closed per field). */
+#define AUDIT_MAX_EDGES         10000
+#define AUDIT_COHESION_MIN_SIZE 8
+#define AUDIT_UNVERIFIED_MIN    3 /* >= this many inferred-provenance incident edges */
+
+/* FNV-1a 32-bit over a string → 8 hex chars. Deterministic stable id for the
+ * §1↔§3 finding-outcome loop (a finding's id must not drift run-to-run). */
+static void audit_finding_id(const char *prefix, const char *key, char *out, size_t out_len)
+{
+   unsigned int h = 2166136261u;
+   for (const unsigned char *p = (const unsigned char *)key; p && *p; p++)
+   {
+      h ^= *p;
+      h *= 16777619u;
+   }
+   snprintf(out, out_len, "%s:%08x", prefix, h);
+}
+
+/* Sanitize a corpus-derived label into buf (returned). On SANITIZE_REJECTED — a
+ * structured field carrying control/injection markup — fail closed to a constant
+ * marker so the finding still renders but can't smuggle a payload into an agent. */
+static const char *audit_safe(const char *in, sanitize_kind_t kind, char *buf, size_t buflen)
+{
+   sanitize_reason_t reason;
+   sanitize_status_t st = sanitize_for_prompt(in ? in : "", kind, buf, buflen, &reason);
+   if (st == SANITIZE_REJECTED)
+      snprintf(buf, buflen, "[unsafe-label]");
+   return buf;
+}
+
+int handle_get_code_graph_audit(const char *query_string, char *out_buf, int out_cap)
+{
+   char project[256] = "";
+   if (!code_qparam(query_string, "project", project, sizeof(project)) || !project[0])
+      return code_scan_write_error(out_buf, out_cap, "missing project");
+
+   int max_f = 20;
+   char mf[16] = "";
+   if (code_qparam(query_string, "max_findings", mf, sizeof(mf)))
+      max_f = atoi(mf);
+   if (max_f < 1)
+      max_f = 1;
+   if (max_f > 200)
+      max_f = 200;
+
+   if (!db2_is_initialized())
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"knowledge service not initialized\"}");
+      return 503;
+   }
+
+   code_projection_edge_t *edges = calloc(AUDIT_MAX_EDGES, sizeof(*edges));
+   kb_graph_edge_t *gedges = calloc(AUDIT_MAX_EDGES, sizeof(*gedges));
+   kb_graph_reledge_t *redges = calloc(AUDIT_MAX_EDGES, sizeof(*redges));
+   if (!edges || !gedges || !redges)
+   {
+      free(edges);
+      free(gedges);
+      free(redges);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+
+   int ne = db2_code_projection_list_edges(project, edges, AUDIT_MAX_EDGES);
+   if (ne < 0)
+   {
+      free(edges);
+      free(gedges);
+      free(redges);
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"projection graph unavailable\",\"code\":\"no_projection\"}");
+      return 503;
+   }
+   for (int i = 0; i < ne; i++)
+   {
+      snprintf(gedges[i].source, sizeof(gedges[i].source), "%s", edges[i].source);
+      snprintf(gedges[i].target, sizeof(gedges[i].target), "%s", edges[i].target);
+      gedges[i].weight = edges[i].structural_weight;
+      snprintf(redges[i].source, sizeof(redges[i].source), "%s", edges[i].source);
+      snprintf(redges[i].relation, sizeof(redges[i].relation), "%s", edges[i].relation);
+      snprintf(redges[i].target, sizeof(redges[i].target), "%s", edges[i].target);
+   }
+
+   /* Community assignment for the visible generation (for cohesion + grouping). */
+   int64_t vgen = db2_code_projection_visible_id(project);
+   code_projection_community_t *crows = NULL;
+   kb_graph_community_t *comm = NULL;
+   int ncomm = 0;
+   if (vgen > 0)
+   {
+      crows = calloc(AUDIT_MAX_EDGES, sizeof(*crows));
+      comm = calloc(AUDIT_MAX_EDGES, sizeof(*comm));
+      if (crows && comm)
+      {
+         ncomm = db2_code_projection_communities_list(vgen, crows, AUDIT_MAX_EDGES);
+         if (ncomm < 0)
+            ncomm = 0;
+         for (int i = 0; i < ncomm; i++)
+         {
+            snprintf(comm[i].node, sizeof(comm[i].node), "%s", crows[i].node_id);
+            snprintf(comm[i].community, sizeof(comm[i].community), "%s", crows[i].community_id);
+         }
+      }
+   }
+   char source_hash[128] = "";
+   db2_code_projection_visible_source_hash(project, source_hash, sizeof(source_hash));
+
+   /* ── run the analytics ──────────────────────────────────────────────────── */
+   kb_graph_cycle_t *cycles = calloc((size_t)max_f, sizeof(*cycles));
+   kb_graph_hub_t *orphans = calloc((size_t)max_f, sizeof(*orphans));
+   kb_graph_bridge_t *bridges = calloc((size_t)max_f, sizeof(*bridges));
+   kb_graph_cohesion_t *cohesion = calloc((size_t)max_f, sizeof(*cohesion));
+   if (!cycles || !orphans || !bridges || !cohesion)
+   {
+      free(edges);
+      free(gedges);
+      free(redges);
+      free(crows);
+      free(comm);
+      free(cycles);
+      free(orphans);
+      free(bridges);
+      free(cohesion);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+
+   int cyc_trunc = 0, bridge_approx = 0;
+   int n_cyc = kb_graph_cycles(redges, ne, cycles, max_f, &cyc_trunc);
+   if (n_cyc < 0)
+      n_cyc = 0;
+   /* orphans: least-connected non-container nodes, degree <= 1 */
+   int n_orph_raw = kb_graph_hubs_ranked(gedges, ne, orphans, max_f, KB_HUB_BOTTOM_NOHUB);
+   if (n_orph_raw < 0)
+      n_orph_raw = 0;
+   int n_orph = 0;
+   for (int i = 0; i < n_orph_raw; i++)
+      if (orphans[i].degree <= 1)
+         orphans[n_orph++] = orphans[i];
+   int n_bridge = kb_graph_bridges(gedges, ne, bridges, max_f, &bridge_approx);
+   if (n_bridge < 0)
+      n_bridge = 0;
+   int n_cohesion =
+       kb_graph_cohesion(gedges, ne, comm, ncomm, AUDIT_COHESION_MIN_SIZE, cohesion, max_f);
+   if (n_cohesion < 0)
+      n_cohesion = 0;
+
+   /* unverified-inferred: per-node count of incident edges carrying inferred/
+    * ambiguous provenance (structural_weight == 0 is the only provenance signal on
+    * a projection edge). Ships labeled no-confirmation-yet, OUT of the roll-up —
+    * the confirmation signal arrives in S3. Reuses the orphan buffer's node list is
+    * unsafe; compute inline into a small ranked set. */
+   /* (kept minimal: count weight-0 incident edges per node, surface >= threshold) */
+
+   /* ── assemble response ──────────────────────────────────────────────────── */
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+   {
+      free(edges);
+      free(gedges);
+      free(redges);
+      free(crows);
+      free(comm);
+      free(cycles);
+      free(orphans);
+      free(bridges);
+      free(cohesion);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "project", project);
+   cJSON_AddNumberToObject(resp, "generation_id", (double)vgen);
+   if (source_hash[0])
+      cJSON_AddStringToObject(resp, "source_hash", source_hash); /* staleness echo (R1) */
+   cJSON_AddNumberToObject(resp, "edge_count", ne);
+   cJSON_AddBoolToObject(resp, "truncated", ne >= AUDIT_MAX_EDGES);
+
+   cJSON *findings = cJSON_AddObjectToObject(resp, "findings");
+   char fid[80];
+   char sbuf[KB_GRAPH_NODE_MAX + 16];
+
+   /* cycles */
+   cJSON *jc = findings ? cJSON_AddArrayToObject(findings, "cycles") : NULL;
+   for (int i = 0; jc && i < n_cyc; i++)
+   {
+      cJSON *f = cJSON_CreateObject();
+      if (!f)
+         continue;
+      audit_finding_id("cycle", cycles[i].files[0], fid, sizeof(fid));
+      cJSON_AddStringToObject(f, "finding_id", fid);
+      cJSON *arr = cJSON_AddArrayToObject(f, "files");
+      for (int p = 0; arr && p < cycles[i].len; p++)
+         cJSON_AddItemToArray(arr,
+                              cJSON_CreateString(audit_safe(cycles[i].files[p], SANITIZE_FILE_PATH,
+                                                            sbuf, sizeof(sbuf))));
+      cJSON_AddStringToObject(f, "why", "files form a circular dependency (collapsed call graph)");
+      cJSON_AddItemToArray(jc, f);
+   }
+   cJSON_AddBoolToObject(findings, "cycles_truncated", cyc_trunc != 0);
+
+   /* orphans */
+   cJSON *jo = findings ? cJSON_AddArrayToObject(findings, "orphans") : NULL;
+   for (int i = 0; jo && i < n_orph; i++)
+   {
+      cJSON *f = cJSON_CreateObject();
+      if (!f)
+         continue;
+      audit_finding_id("orphan", orphans[i].node, fid, sizeof(fid));
+      cJSON_AddStringToObject(f, "finding_id", fid);
+      cJSON_AddStringToObject(
+          f, "node", audit_safe(orphans[i].node, SANITIZE_SYMBOL_LABEL, sbuf, sizeof(sbuf)));
+      cJSON_AddNumberToObject(f, "degree", orphans[i].degree);
+      cJSON_AddStringToObject(f, "why",
+                              "weakly-connected symbol (dead code, missing edge, or "
+                              "undocumented entry point)");
+      cJSON_AddItemToArray(jo, f);
+   }
+
+   /* bridges */
+   cJSON *jb = findings ? cJSON_AddArrayToObject(findings, "bridges") : NULL;
+   for (int i = 0; jb && i < n_bridge; i++)
+   {
+      cJSON *f = cJSON_CreateObject();
+      if (!f)
+         continue;
+      audit_finding_id("bridge", bridges[i].node, fid, sizeof(fid));
+      cJSON_AddStringToObject(f, "finding_id", fid);
+      cJSON_AddStringToObject(
+          f, "node", audit_safe(bridges[i].node, SANITIZE_SYMBOL_LABEL, sbuf, sizeof(sbuf)));
+      cJSON_AddNumberToObject(f, "betweenness", bridges[i].betweenness);
+      cJSON_AddStringToObject(f, "why",
+                              "cross-cutting concern connecting otherwise-separate modules");
+      cJSON_AddItemToArray(jb, f);
+   }
+   cJSON_AddBoolToObject(findings, "bridges_approximate", bridge_approx != 0);
+
+   /* low-cohesion communities */
+   cJSON *jco = findings ? cJSON_AddArrayToObject(findings, "low_cohesion") : NULL;
+   for (int i = 0; jco && i < n_cohesion; i++)
+   {
+      cJSON *f = cJSON_CreateObject();
+      if (!f)
+         continue;
+      audit_finding_id("cohesion", cohesion[i].community, fid, sizeof(fid));
+      cJSON_AddStringToObject(f, "finding_id", fid);
+      cJSON_AddStringToObject(
+          f, "community",
+          audit_safe(cohesion[i].community, SANITIZE_COMMUNITY_NAME, sbuf, sizeof(sbuf)));
+      cJSON_AddNumberToObject(f, "conductance", cohesion[i].conductance);
+      cJSON_AddNumberToObject(f, "min_size_threshold", AUDIT_COHESION_MIN_SIZE);
+      cJSON_AddNumberToObject(f, "size", cohesion[i].size);
+      cJSON_AddStringToObject(f, "community_id_scope", "generation-local");
+      cJSON_AddStringToObject(f, "why",
+                              "high conductance: much of the module's edge weight leaves it "
+                              "(split candidate)");
+      cJSON_AddItemToArray(jco, f);
+   }
+
+   /* unverified-inferred: labeled no-confirmation-yet, excluded from the roll-up. */
+   cJSON *ju = findings ? cJSON_AddObjectToObject(findings, "unverified_inferred") : NULL;
+   if (ju)
+   {
+      cJSON_AddStringToObject(ju, "signal", "no-confirmation-yet");
+      cJSON *ua = cJSON_AddArrayToObject(ju, "nodes");
+      /* Count weight-0 incident edges per node; surface those at/above threshold.
+       * Emitted in edge-scan order (deterministic — list_edges is ORDER BY). */
+      int emitted = 0;
+      /* simple O(n^2)-bounded pass acceptable at AUDIT_MAX_EDGES cap for a labeled,
+       * roll-up-excluded finding; a hash index is a later optimization. */
+      for (int i = 0; ua && i < ne && emitted < max_f; i++)
+      {
+         const char *node = edges[i].source[0] ? edges[i].source : NULL;
+         if (!node || edges[i].structural_weight != 0)
+            continue;
+         /* skip if already emitted */
+         int dup = 0;
+         for (int j = 0; j < i; j++)
+            if (edges[j].structural_weight == 0 && strcmp(edges[j].source, node) == 0)
+            {
+               dup = 1;
+               break;
+            }
+         if (dup)
+            continue;
+         int cnt = 0;
+         for (int j = 0; j < ne; j++)
+            if (edges[j].structural_weight == 0 &&
+                (strcmp(edges[j].source, node) == 0 || strcmp(edges[j].target, node) == 0))
+               cnt++;
+         if (cnt < AUDIT_UNVERIFIED_MIN)
+            continue;
+         cJSON *f = cJSON_CreateObject();
+         if (!f)
+            continue;
+         audit_finding_id("unverified", node, fid, sizeof(fid));
+         cJSON_AddStringToObject(f, "finding_id", fid);
+         cJSON_AddStringToObject(f, "node",
+                                 audit_safe(node, SANITIZE_SYMBOL_LABEL, sbuf, sizeof(sbuf)));
+         cJSON_AddNumberToObject(f, "inferred_edges", cnt);
+         cJSON_AddItemToArray(ua, f);
+         emitted++;
+      }
+   }
+
+   /* honesty gate + roll-up summary (unverified-inferred excluded per R1). */
+   int total = n_cyc + n_orph + n_bridge + n_cohesion;
+   int clean = (total == 0);
+   int insufficient = (ne < 5); /* too sparse to trust orphan/cohesion signals */
+   cJSON_AddBoolToObject(resp, "clean", clean && !insufficient);
+   cJSON_AddBoolToObject(resp, "insufficient_signal", insufficient);
+   char summary[192];
+   snprintf(summary, sizeof(summary), "%d cycles, %d orphans, %d bridges, %d low-cohesion", n_cyc,
+            n_orph, n_bridge, n_cohesion);
+   cJSON_AddStringToObject(resp, "summary",
+                           insufficient ? "insufficient signal" : (clean ? "clean" : summary));
+
+   free(edges);
+   free(gedges);
+   free(redges);
+   free(crows);
+   free(comm);
+   free(cycles);
+   free(orphans);
+   free(bridges);
+   free(cohesion);
+
+   char *s = cJSON_PrintUnformatted(resp);
+   int status = 200;
+   if (!s)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      status = 500;
+   }
+   else if (strlen(s) >= (size_t)out_cap)
+   {
+      snprintf(
+          out_buf, (size_t)out_cap,
+          "{\"error\":\"result too large; reduce max_findings\",\"code\":\"result_too_large\"}");
+      status = 413;
+   }
+   else
+   {
+      snprintf(out_buf, (size_t)out_cap, "%s", s);
+   }
+   free(s);
+   cJSON_Delete(resp);
+   return status;
+}
+
+int handle_get_code_graph_audit_route(const char *method, const char *query_string, char *out_buf,
+                                      int out_cap)
+{
+   if (strcmp(method, "GET") != 0)
+      return code_method_not_allowed(out_buf, out_cap);
+   return handle_get_code_graph_audit(query_string, out_buf, out_cap);
 }
 
 int handle_get_code_graph_hubs_route(const char *method, const char *query_string, char *out_buf,

--- a/src/kb/kb_graph_analytics.c
+++ b/src/kb/kb_graph_analytics.c
@@ -32,38 +32,41 @@ static int hub_find(kb_graph_hub_t *acc, int nacc, const char *name)
    return -1;
 }
 
-int kb_graph_hubs(const kb_graph_edge_t *edges, int n_edges, kb_graph_hub_t *out, int max)
+/* Bottom view: degree ASC, then weighted_degree ASC, then node asc — the exact
+ * mirror of hub_cmp so the top and bottom of one degree distribution agree. */
+static int hub_cmp_bottom(const void *a, const void *b)
 {
-   if (!edges || n_edges < 0 || !out || max <= 0)
-      return -1;
-   if (n_edges == 0)
-      return 0;
-   /* Reject an absurd edge count up front: 2*n_edges (the distinct-node bound)
-    * must not overflow a 32-bit size_t on the calloc below. Real callers pass at
-    * most a few thousand edges. */
-   if (n_edges > (INT_MAX / 2))
-      return -1;
+   const kb_graph_hub_t *x = (const kb_graph_hub_t *)a;
+   const kb_graph_hub_t *y = (const kb_graph_hub_t *)b;
+   if (x->degree != y->degree)
+      return (x->degree > y->degree) - (x->degree < y->degree); /* lower first */
+   if (x->weighted_degree != y->weighted_degree)
+      return (x->weighted_degree > y->weighted_degree) - (x->weighted_degree < y->weighted_degree);
+   return strcmp(x->node, y->node);
+}
 
-   /* Upper bound on distinct nodes = 2 per edge (each edge adds at most a new
-    * source + a new target). acc is calloc'd, so every node field starts zeroed
-    * and is only ever written via snprintf — hub_cmp's strcmp is therefore safe. */
-   long long cap = (long long)n_edges * 2;
+/* Accumulate per-node in/out/weighted degree over the edge list into a fresh
+ * malloc'd array of *nacc distinct nodes (caller frees). Returns NULL only on OOM
+ * (callers validate args + emptiness first). Linear-scan lookup — O(n_edges *
+ * distinct); fine for the bounded edge counts the routes cap at. */
+static kb_graph_hub_t *hub_build(const kb_graph_edge_t *edges, int n_edges, int *nacc)
+{
+   *nacc = 0;
+   long long cap = (long long)n_edges * 2; /* <= 2 distinct nodes per edge */
    kb_graph_hub_t *acc = calloc((size_t)cap, sizeof(*acc));
    if (!acc)
-      return -1;
-   int nacc = 0;
-
+      return NULL;
+   int n = 0;
    for (int e = 0; e < n_edges; e++)
    {
-      const char *s = edges[e].source;
-      const char *t = edges[e].target;
+      const char *s = edges[e].source, *t = edges[e].target;
       int w = edges[e].weight > 0 ? edges[e].weight : 0;
       if (s[0])
       {
-         int idx = hub_find(acc, nacc, s);
+         int idx = hub_find(acc, n, s);
          if (idx < 0)
          {
-            idx = nacc++;
+            idx = n++;
             snprintf(acc[idx].node, sizeof(acc[idx].node), "%s", s);
          }
          acc[idx].out_degree++;
@@ -72,10 +75,10 @@ int kb_graph_hubs(const kb_graph_edge_t *edges, int n_edges, kb_graph_hub_t *out
       }
       if (t[0])
       {
-         int idx = hub_find(acc, nacc, t);
+         int idx = hub_find(acc, n, t);
          if (idx < 0)
          {
-            idx = nacc++;
+            idx = n++;
             snprintf(acc[idx].node, sizeof(acc[idx].node), "%s", t);
          }
          acc[idx].in_degree++;
@@ -83,14 +86,49 @@ int kb_graph_hubs(const kb_graph_edge_t *edges, int n_edges, kb_graph_hub_t *out
          acc[idx].weighted_degree += w;
       }
    }
+   *nacc = n;
+   return acc;
+}
 
-   qsort(acc, (size_t)nacc, sizeof(*acc), hub_cmp);
+int kb_graph_is_container(const char *node)
+{
+   if (!node)
+      return 0;
+   return strncmp(node, "project:", 8) == 0 || strncmp(node, "file:", 5) == 0;
+}
 
-   int w = nacc < max ? nacc : max;
-   for (int i = 0; i < w; i++)
-      out[i] = acc[i];
+int kb_graph_hubs_ranked(const kb_graph_edge_t *edges, int n_edges, kb_graph_hub_t *out, int max,
+                         kb_hub_mode_t mode)
+{
+   if (!edges || n_edges < 0 || !out || max <= 0)
+      return -1;
+   if (n_edges == 0)
+      return 0;
+   /* 2*n_edges (the distinct-node bound) must not overflow the calloc. */
+   if (n_edges > (INT_MAX / 2))
+      return -1;
+
+   int nacc = 0;
+   kb_graph_hub_t *acc = hub_build(edges, n_edges, &nacc);
+   if (!acc)
+      return -1;
+
+   qsort(acc, (size_t)nacc, sizeof(*acc), mode == KB_HUB_TOP ? hub_cmp : hub_cmp_bottom);
+
+   int w = 0;
+   for (int i = 0; i < nacc && w < max; i++)
+   {
+      if (mode == KB_HUB_BOTTOM_NOHUB && kb_graph_is_container(acc[i].node))
+         continue;
+      out[w++] = acc[i];
+   }
    free(acc);
    return w;
+}
+
+int kb_graph_hubs(const kb_graph_edge_t *edges, int n_edges, kb_graph_hub_t *out, int max)
+{
+   return kb_graph_hubs_ranked(edges, n_edges, out, max, KB_HUB_TOP);
 }
 
 /* ── §4 surprising links ───────────────────────────────────────────────────── */
@@ -548,5 +586,782 @@ int kb_graph_communities(const kb_graph_edge_t *edges, int n_edges, kb_graph_com
    free(touched);
    free(seen);
    free(rep);
+   return w;
+}
+
+/* ── S1 self-audit: file-level dependency cycles ──────────────────────────────
+ * The projection has no direct file→file edge, so collapse: `defines` edges
+ * (file→symbol) give each symbol its defining file; `calls` edges (symbol→symbol)
+ * become directed file→file edges (self-file calls dropped, parallels deduped).
+ * Iterative Tarjan SCC over that file graph — every non-trivial SCC (>= 2 files)
+ * is a circular-dependency cluster. For each, one representative simple cycle is
+ * extracted (from the lex-smallest member, DFS to a back-edge) and the SCC size
+ * reported. Deterministic: files lex-indexed, adjacency + SCC output in index
+ * order. Recursion-free (an explicit work stack) so a deep graph can't overflow. */
+
+/* Resolve a symbol to its defining file index via a lex-sorted (symbol→file) map
+ * built from the `defines` edges. On a symbol defined in multiple files the
+ * lex-min file wins (deterministic). Linear map lookup is fine for bounded input. */
+static int cyc_file_of(const char (*dsym)[KB_GRAPH_NODE_MAX], const int *dfile, int nd,
+                       const char *sym)
+{
+   int lo = 0, hi = nd - 1;
+   while (lo <= hi)
+   {
+      int mid = lo + (hi - lo) / 2;
+      int c = strcmp(dsym[mid], sym);
+      if (c == 0)
+         return dfile[mid];
+      if (c < 0)
+         lo = mid + 1;
+      else
+         hi = mid - 1;
+   }
+   return -1;
+}
+
+int kb_graph_cycles(const kb_graph_reledge_t *edges, int n_edges, kb_graph_cycle_t *out, int max,
+                    int *truncated)
+{
+   if (truncated)
+      *truncated = 0;
+   if (!edges || n_edges < 0 || !out || max <= 0)
+      return -1;
+   if (n_edges == 0)
+      return 0;
+   if (n_edges > (INT_MAX / 4))
+      return -1;
+
+   /* 1. Distinct file names, lex-sorted → file index. Files come from the `defines`
+    *    edge sources (a file that defines at least one symbol). */
+   char(*files)[KB_GRAPH_NODE_MAX] = malloc((size_t)n_edges * KB_GRAPH_NODE_MAX);
+   if (!files)
+      return -1;
+   int nf = 0;
+   for (int e = 0; e < n_edges; e++)
+      if (strcmp(edges[e].relation, "defines") == 0 && edges[e].source[0])
+         snprintf(files[nf++], KB_GRAPH_NODE_MAX, "%s", edges[e].source);
+   if (nf == 0)
+   {
+      free(files);
+      return 0; /* no defines edges → no file structure to collapse */
+   }
+   qsort(files, (size_t)nf, KB_GRAPH_NODE_MAX, comm_str_cmp);
+   int nfu = 0;
+   for (int i = 0; i < nf; i++)
+      if (nfu == 0 || strcmp(files[nfu - 1], files[i]) != 0)
+      {
+         if (nfu != i)
+            memcpy(files[nfu], files[i], KB_GRAPH_NODE_MAX);
+         nfu++;
+      }
+
+   /* 2. symbol→file map (lex-sorted by symbol, lex-min file kept). */
+   char(*dsym)[KB_GRAPH_NODE_MAX] = malloc((size_t)n_edges * KB_GRAPH_NODE_MAX);
+   int *dfile_tmp = malloc((size_t)n_edges * sizeof(int));
+   if (!dsym || !dfile_tmp)
+   {
+      free(files);
+      free(dsym);
+      free(dfile_tmp);
+      return -1;
+   }
+   /* collect (symbol, file-index) from defines, sort by symbol, dedup lex-min */
+   int nd0 = 0;
+   for (int e = 0; e < n_edges; e++)
+      if (strcmp(edges[e].relation, "defines") == 0 && edges[e].source[0] && edges[e].target[0])
+      {
+         int fi = comm_index_of((const char(*)[KB_GRAPH_NODE_MAX])files, nfu, edges[e].source);
+         if (fi < 0)
+            continue;
+         snprintf(dsym[nd0], KB_GRAPH_NODE_MAX, "%s", edges[e].target);
+         dfile_tmp[nd0] = fi;
+         nd0++;
+      }
+   /* index-sort dsym by symbol name (stable-ish via file-index tie-break) */
+   for (int i = 1; i < nd0; i++) /* insertion sort keeps memory simple; nd0 bounded */
+   {
+      char ks[KB_GRAPH_NODE_MAX];
+      snprintf(ks, sizeof(ks), "%s", dsym[i]);
+      int kf = dfile_tmp[i], j = i - 1;
+      while (j >= 0 && (strcmp(dsym[j], ks) > 0 || (strcmp(dsym[j], ks) == 0 && dfile_tmp[j] > kf)))
+      {
+         memcpy(dsym[j + 1], dsym[j], KB_GRAPH_NODE_MAX);
+         dfile_tmp[j + 1] = dfile_tmp[j];
+         j--;
+      }
+      snprintf(dsym[j + 1], KB_GRAPH_NODE_MAX, "%s", ks);
+      dfile_tmp[j + 1] = kf;
+   }
+   int nd = 0; /* dedup by symbol, keeping first (lex-min file due to sort) */
+   for (int i = 0; i < nd0; i++)
+      if (nd == 0 || strcmp(dsym[nd - 1], dsym[i]) != 0)
+      {
+         if (nd != i)
+         {
+            memcpy(dsym[nd], dsym[i], KB_GRAPH_NODE_MAX);
+            dfile_tmp[nd] = dfile_tmp[i];
+         }
+         nd++;
+      }
+
+   /* 3. Directed file→file adjacency from `calls`, deduped, in index order. Use an
+    *    nf×? — represent as an edge set then CSR. Bound edges by n_edges. */
+   int *ce_src = malloc((size_t)n_edges * sizeof(int));
+   int *ce_dst = malloc((size_t)n_edges * sizeof(int));
+   if (!ce_src || !ce_dst)
+   {
+      free(files);
+      free(dsym);
+      free(dfile_tmp);
+      free(ce_src);
+      free(ce_dst);
+      return -1;
+   }
+   int nce = 0;
+   for (int e = 0; e < n_edges; e++)
+   {
+      if (strcmp(edges[e].relation, "calls") != 0 || !edges[e].source[0] || !edges[e].target[0])
+         continue;
+      int fs = cyc_file_of(dsym, dfile_tmp, nd, edges[e].source);
+      int fd = cyc_file_of(dsym, dfile_tmp, nd, edges[e].target);
+      if (fs < 0 || fd < 0 || fs == fd)
+         continue;
+      ce_src[nce] = fs;
+      ce_dst[nce] = fd;
+      nce++;
+   }
+   free(dsym);
+   free(dfile_tmp);
+
+   /* CSR build over file nodes (0..nfu). */
+   int *deg = calloc((size_t)nfu, sizeof(int));
+   int *off = malloc((size_t)(nfu + 1) * sizeof(int));
+   if (!deg || !off)
+   {
+      free(files);
+      free(ce_src);
+      free(ce_dst);
+      free(deg);
+      free(off);
+      return -1;
+   }
+   for (int i = 0; i < nce; i++)
+      deg[ce_src[i]]++;
+   int tot = 0;
+   for (int i = 0; i < nfu; i++)
+   {
+      off[i] = tot;
+      tot += deg[i];
+   }
+   off[nfu] = tot;
+   int *adj = tot ? malloc((size_t)tot * sizeof(int)) : malloc(1);
+   int *fill = calloc((size_t)nfu, sizeof(int));
+   if (!adj || !fill)
+   {
+      free(files);
+      free(ce_src);
+      free(ce_dst);
+      free(deg);
+      free(off);
+      free(adj);
+      free(fill);
+      return -1;
+   }
+   for (int i = 0; i < nce; i++)
+      adj[off[ce_src[i]] + fill[ce_src[i]]++] = ce_dst[i];
+   free(fill);
+   free(ce_src);
+   free(ce_dst);
+   free(deg);
+
+   /* 4. Iterative Tarjan SCC. */
+   int *index = malloc((size_t)nfu * sizeof(int));
+   int *low = malloc((size_t)nfu * sizeof(int));
+   int *onstk = calloc((size_t)nfu, sizeof(int));
+   int *scc = malloc((size_t)nfu * sizeof(int)); /* SCC id per file, -1 = unassigned */
+   int *stk = malloc((size_t)nfu * sizeof(int));
+   int *wstk = malloc((size_t)nfu * sizeof(int));  /* DFS node stack */
+   int *witer = malloc((size_t)nfu * sizeof(int)); /* per-frame adj cursor */
+   if (!index || !low || !onstk || !scc || !stk || !wstk || !witer)
+   {
+      free(files);
+      free(off);
+      free(adj);
+      free(index);
+      free(low);
+      free(onstk);
+      free(scc);
+      free(stk);
+      free(wstk);
+      free(witer);
+      return -1;
+   }
+   for (int i = 0; i < nfu; i++)
+   {
+      index[i] = -1;
+      scc[i] = -1;
+   }
+   int idx_ctr = 0, sp = 0, nscc = 0;
+   for (int root = 0; root < nfu; root++)
+   {
+      if (index[root] != -1)
+         continue;
+      int wt = 0;
+      wstk[wt] = root;
+      witer[wt] = off[root];
+      index[root] = low[root] = idx_ctr++;
+      stk[sp++] = root;
+      onstk[root] = 1;
+      while (wt >= 0)
+      {
+         int v = wstk[wt];
+         if (witer[wt] < off[v + 1])
+         {
+            int w = adj[witer[wt]++];
+            if (index[w] == -1)
+            {
+               index[w] = low[w] = idx_ctr++;
+               stk[sp++] = w;
+               onstk[w] = 1;
+               wt++;
+               wstk[wt] = w;
+               witer[wt] = off[w];
+            }
+            else if (onstk[w] && index[w] < low[v])
+            {
+               low[v] = index[w];
+            }
+         }
+         else
+         {
+            if (low[v] == index[v]) /* v is an SCC root: pop */
+            {
+               int m;
+               do
+               {
+                  m = stk[--sp];
+                  onstk[m] = 0;
+                  scc[m] = nscc;
+               } while (m != v);
+               nscc++;
+            }
+            wt--;
+            if (wt >= 0 && low[v] < low[wstk[wt]])
+               low[wstk[wt]] = low[v];
+         }
+      }
+   }
+
+   /* 5. For each SCC with >= 2 members, emit a representative cycle. Members are
+    *    naturally in file-index (lex) order; the cycle path is found by a DFS from
+    *    the lex-smallest member back to itself, restricted to the SCC. */
+   int *scc_size = calloc((size_t)(nscc > 0 ? nscc : 1), sizeof(int));
+   if (!scc_size)
+   {
+      free(files);
+      free(off);
+      free(adj);
+      free(index);
+      free(low);
+      free(onstk);
+      free(scc);
+      free(stk);
+      free(wstk);
+      free(witer);
+      return -1;
+   }
+   for (int i = 0; i < nfu; i++)
+      scc_size[scc[i]]++;
+
+   /* reuse onstk as "in current DFS path" marker, index as parent-in-path */
+   int nout = 0;
+   for (int s = 0; s < nscc && nout < max; s++)
+   {
+      if (scc_size[s] < 2)
+         continue;
+      /* lex-smallest member = smallest file index in this SCC */
+      int start = -1;
+      for (int i = 0; i < nfu; i++)
+         if (scc[i] == s)
+         {
+            start = i;
+            break;
+         }
+      /* DFS from start restricted to SCC s, find first edge back to start → cycle */
+      for (int i = 0; i < nfu; i++)
+      {
+         onstk[i] = 0;
+         index[i] = -1;
+      }
+      int found = 0;
+      int dsp = 0;
+      wstk[dsp] = start;
+      witer[dsp] = off[start];
+      onstk[start] = 1;
+      while (dsp >= 0 && !found)
+      {
+         int v = wstk[dsp];
+         if (witer[dsp] < off[v + 1])
+         {
+            int w = adj[witer[dsp]++];
+            if (scc[w] != s)
+               continue;
+            if (w == start && dsp >= 1)
+            {
+               /* cycle = wstk[0..dsp] then back to start */
+               int len = dsp + 1;
+               if (len > KB_AUDIT_CYCLE_MAX_LEN)
+               {
+                  len = KB_AUDIT_CYCLE_MAX_LEN;
+                  if (truncated)
+                     *truncated = 1;
+               }
+               for (int p = 0; p < len; p++)
+                  snprintf(out[nout].files[p], KB_GRAPH_NODE_MAX, "%s", files[wstk[p]]);
+               out[nout].len = len;
+               nout++;
+               found = 1;
+            }
+            else if (!onstk[w])
+            {
+               onstk[w] = 1;
+               dsp++;
+               wstk[dsp] = w;
+               witer[dsp] = off[w];
+            }
+         }
+         else
+         {
+            onstk[v] = 0;
+            dsp--;
+         }
+      }
+      if (scc_size[s] > KB_AUDIT_CYCLE_MAX_LEN && truncated)
+         *truncated = 1;
+   }
+   if (nout >= max && truncated)
+      *truncated = 1;
+
+   free(files);
+   free(off);
+   free(adj);
+   free(index);
+   free(low);
+   free(onstk);
+   free(scc);
+   free(stk);
+   free(wstk);
+   free(witer);
+   free(scc_size);
+   return nout;
+}
+
+/* ── S1 self-audit: bridges (Brandes betweenness) ─────────────────────────────
+ * Unweighted, undirected betweenness over the symbol graph. Exact when node count
+ * <= KB_AUDIT_BRIDGE_EXACT_MAX; above it, estimated from a deterministic first-K
+ * lex source sample and scaled (marked approximate). Container/file-hub nodes are
+ * excluded from the output ranking (they still route paths). */
+
+static int bridge_cmp(const void *a, const void *b)
+{
+   const kb_graph_bridge_t *x = a, *y = b;
+   if (x->betweenness != y->betweenness)
+      return x->betweenness < y->betweenness ? 1 : -1; /* desc */
+   return strcmp(x->node, y->node);
+}
+
+int kb_graph_bridges(const kb_graph_edge_t *edges, int n_edges, kb_graph_bridge_t *out, int max,
+                     int *approximate)
+{
+   if (approximate)
+      *approximate = 0;
+   if (!edges || n_edges < 0 || !out || max <= 0)
+      return -1;
+   if (n_edges == 0)
+      return 0;
+   if (n_edges > (INT_MAX / 2))
+      return -1;
+
+   /* distinct nodes, lex-sorted → index */
+   long long cap = (long long)n_edges * 2;
+   char(*raw)[KB_GRAPH_NODE_MAX] = malloc((size_t)cap * KB_GRAPH_NODE_MAX);
+   if (!raw)
+      return -1;
+   int nr = 0;
+   for (int e = 0; e < n_edges; e++)
+   {
+      if (edges[e].source[0])
+         snprintf(raw[nr++], KB_GRAPH_NODE_MAX, "%s", edges[e].source);
+      if (edges[e].target[0])
+         snprintf(raw[nr++], KB_GRAPH_NODE_MAX, "%s", edges[e].target);
+   }
+   if (nr == 0)
+   {
+      free(raw);
+      return 0;
+   }
+   qsort(raw, (size_t)nr, KB_GRAPH_NODE_MAX, comm_str_cmp);
+   char(*names)[KB_GRAPH_NODE_MAX] = malloc((size_t)nr * KB_GRAPH_NODE_MAX);
+   if (!names)
+   {
+      free(raw);
+      return -1;
+   }
+   int N = 0;
+   for (int i = 0; i < nr; i++)
+      if (N == 0 || strcmp(names[N - 1], raw[i]) != 0)
+         snprintf(names[N++], KB_GRAPH_NODE_MAX, "%s", raw[i]);
+   free(raw);
+
+   /* undirected CSR (unweighted, dedup not required — parallel edges just add
+    * repeated neighbours, harmless for BFS shortest paths). */
+   int *deg = calloc((size_t)N, sizeof(int));
+   int *off = malloc((size_t)(N + 1) * sizeof(int));
+   if (!deg || !off)
+   {
+      free(names);
+      free(deg);
+      free(off);
+      return -1;
+   }
+   for (int e = 0; e < n_edges; e++)
+   {
+      if (!edges[e].source[0] || !edges[e].target[0])
+         continue;
+      int s = comm_index_of((const char(*)[KB_GRAPH_NODE_MAX])names, N, edges[e].source);
+      int t = comm_index_of((const char(*)[KB_GRAPH_NODE_MAX])names, N, edges[e].target);
+      if (s < 0 || t < 0 || s == t)
+         continue;
+      deg[s]++;
+      deg[t]++;
+   }
+   int tot = 0;
+   for (int i = 0; i < N; i++)
+   {
+      off[i] = tot;
+      tot += deg[i];
+   }
+   off[N] = tot;
+   int *adj = tot ? malloc((size_t)tot * sizeof(int)) : malloc(1);
+   int *fill = calloc((size_t)N, sizeof(int));
+   if (!adj || !fill)
+   {
+      free(names);
+      free(deg);
+      free(off);
+      free(adj);
+      free(fill);
+      return -1;
+   }
+   for (int e = 0; e < n_edges; e++)
+   {
+      if (!edges[e].source[0] || !edges[e].target[0])
+         continue;
+      int s = comm_index_of((const char(*)[KB_GRAPH_NODE_MAX])names, N, edges[e].source);
+      int t = comm_index_of((const char(*)[KB_GRAPH_NODE_MAX])names, N, edges[e].target);
+      if (s < 0 || t < 0 || s == t)
+         continue;
+      adj[off[s] + fill[s]++] = t;
+      adj[off[t] + fill[t]++] = s;
+   }
+   free(fill);
+   free(deg);
+
+   double *bc = calloc((size_t)N, sizeof(double));
+   double *delta = malloc((size_t)N * sizeof(double));
+   double *sigma = malloc((size_t)N * sizeof(double));
+   int *dist = malloc((size_t)N * sizeof(int));
+   int *order = malloc((size_t)N * sizeof(int)); /* BFS visit order (for reverse accumulation) */
+   int *bfsq = malloc((size_t)N * sizeof(int));
+   /* predecessor lists as CSR-of-edges is complex; use per-node pred via re-scan */
+   if (!bc || !delta || !sigma || !dist || !order || !bfsq)
+   {
+      free(names);
+      free(off);
+      free(adj);
+      free(bc);
+      free(delta);
+      free(sigma);
+      free(dist);
+      free(order);
+      free(bfsq);
+      return -1;
+   }
+
+   int sample = N;
+   double scale = 1.0;
+   if (N > KB_AUDIT_BRIDGE_EXACT_MAX)
+   {
+      sample = KB_AUDIT_BRIDGE_SAMPLE < N ? KB_AUDIT_BRIDGE_SAMPLE : N;
+      scale = (double)N / (double)sample; /* estimator scale */
+      if (approximate)
+         *approximate = 1;
+   }
+
+   for (int si = 0; si < sample; si++)
+   {
+      int s = si; /* deterministic: first `sample` lex nodes */
+      for (int i = 0; i < N; i++)
+      {
+         sigma[i] = 0.0;
+         dist[i] = -1;
+         delta[i] = 0.0;
+      }
+      sigma[s] = 1.0;
+      dist[s] = 0;
+      int qh = 0, qt = 0, no = 0;
+      bfsq[qt++] = s;
+      while (qh < qt)
+      {
+         int v = bfsq[qh++];
+         order[no++] = v;
+         for (int p = off[v]; p < off[v + 1]; p++)
+         {
+            int w = adj[p];
+            if (dist[w] < 0)
+            {
+               dist[w] = dist[v] + 1;
+               bfsq[qt++] = w;
+            }
+            if (dist[w] == dist[v] + 1)
+               sigma[w] += sigma[v];
+         }
+      }
+      /* reverse accumulation: for each w in reverse BFS order, push dependency to
+       * its predecessors (neighbours one hop closer to s). */
+      for (int i = no - 1; i >= 0; i--)
+      {
+         int w = order[i];
+         for (int p = off[w]; p < off[w + 1]; p++)
+         {
+            int v = adj[p];
+            if (dist[v] == dist[w] - 1 && sigma[w] > 0.0)
+               delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w]);
+         }
+         if (w != s)
+            bc[w] += delta[w];
+      }
+   }
+
+   int nb = 0;
+   kb_graph_bridge_t *cand = malloc((size_t)N * sizeof(*cand));
+   if (!cand)
+   {
+      free(names);
+      free(off);
+      free(adj);
+      free(bc);
+      free(delta);
+      free(sigma);
+      free(dist);
+      free(order);
+      free(bfsq);
+      return -1;
+   }
+   for (int i = 0; i < N; i++)
+   {
+      if (kb_graph_is_container(names[i]))
+         continue;
+      double b = bc[i] * scale / 2.0; /* undirected: each path counted twice */
+      if (b <= 0.0)
+         continue;
+      snprintf(cand[nb].node, KB_GRAPH_NODE_MAX, "%s", names[i]);
+      cand[nb].betweenness = b;
+      nb++;
+   }
+   qsort(cand, (size_t)nb, sizeof(*cand), bridge_cmp);
+   int w = nb < max ? nb : max;
+   for (int i = 0; i < w; i++)
+      out[i] = cand[i];
+
+   free(cand);
+   free(names);
+   free(off);
+   free(adj);
+   free(bc);
+   free(delta);
+   free(sigma);
+   free(dist);
+   free(order);
+   free(bfsq);
+   return w;
+}
+
+/* ── S1 self-audit: low-cohesion communities (conductance) ────────────────────
+ * conductance(C) = cut(C) / min(vol(C), 2m - vol(C)), where vol is summed weighted
+ * degree and cut is the weight leaving C. Gated at member count >= min_size.
+ * Higher = worse cohesion (a split candidate). */
+
+static int cohesion_cmp(const void *a, const void *b)
+{
+   const kb_graph_cohesion_t *x = a, *y = b;
+   if (x->conductance != y->conductance)
+      return x->conductance < y->conductance ? 1 : -1; /* desc */
+   return strcmp(x->community, y->community);
+}
+
+int kb_graph_cohesion(const kb_graph_edge_t *edges, int n_edges, const kb_graph_community_t *comm,
+                      int n_comm, int min_size, kb_graph_cohesion_t *out, int max)
+{
+   if (!edges || n_edges < 0 || !comm || n_comm < 0 || !out || max <= 0)
+      return -1;
+   if (n_edges == 0 || n_comm == 0)
+      return 0;
+   if (min_size < 1)
+      min_size = 1;
+
+   /* Sort a copy of the (node → community) assignment by node for binary lookup. */
+   kb_graph_community_t *asg = malloc((size_t)n_comm * sizeof(*asg));
+   if (!asg)
+      return -1;
+   memcpy(asg, comm, (size_t)n_comm * sizeof(*asg));
+   /* insertion sort by node (n_comm bounded); assignment is usually already sorted */
+   for (int i = 1; i < n_comm; i++)
+   {
+      kb_graph_community_t key = asg[i];
+      int j = i - 1;
+      while (j >= 0 && strcmp(asg[j].node, key.node) > 0)
+      {
+         asg[j + 1] = asg[j];
+         j--;
+      }
+      asg[j + 1] = key;
+   }
+
+   /* Distinct communities (lex-sorted) + per-community accumulators. */
+   char(*cnames)[KB_GRAPH_NODE_MAX] = malloc((size_t)n_comm * KB_GRAPH_NODE_MAX);
+   if (!cnames)
+   {
+      free(asg);
+      return -1;
+   }
+   for (int i = 0; i < n_comm; i++)
+      snprintf(cnames[i], KB_GRAPH_NODE_MAX, "%s", asg[i].community);
+   qsort(cnames, (size_t)n_comm, KB_GRAPH_NODE_MAX, comm_str_cmp);
+   int nc = 0;
+   for (int i = 0; i < n_comm; i++)
+      if (nc == 0 || strcmp(cnames[nc - 1], cnames[i]) != 0)
+      {
+         if (nc != i)
+            memcpy(cnames[nc], cnames[i], KB_GRAPH_NODE_MAX);
+         nc++;
+      }
+
+   long long *vol = calloc((size_t)nc, sizeof(long long));
+   long long *cut = calloc((size_t)nc, sizeof(long long));
+   int *csize = calloc((size_t)nc, sizeof(int));
+   if (!vol || !cut || !csize)
+   {
+      free(asg);
+      free(cnames);
+      free(vol);
+      free(cut);
+      free(csize);
+      return -1;
+   }
+   for (int i = 0; i < n_comm; i++)
+   {
+      int ci = comm_index_of((const char(*)[KB_GRAPH_NODE_MAX])cnames, nc, asg[i].community);
+      if (ci >= 0)
+         csize[ci]++;
+   }
+
+   long long two_m = 0;
+   for (int e = 0; e < n_edges; e++)
+   {
+      if (!edges[e].source[0] || !edges[e].target[0] ||
+          strcmp(edges[e].source, edges[e].target) == 0)
+         continue;
+      long long w = edges[e].weight > 0 ? edges[e].weight : 0;
+      /* community of each endpoint — binary search the node-sorted assignment */
+      int si = -1, ti = -1;
+      {
+         int lo = 0, hi = n_comm - 1;
+         while (lo <= hi)
+         {
+            int mid = lo + (hi - lo) / 2;
+            int c = strcmp(asg[mid].node, edges[e].source);
+            if (c == 0)
+            {
+               si = mid;
+               break;
+            }
+            if (c < 0)
+               lo = mid + 1;
+            else
+               hi = mid - 1;
+         }
+         lo = 0;
+         hi = n_comm - 1;
+         while (lo <= hi)
+         {
+            int mid = lo + (hi - lo) / 2;
+            int c = strcmp(asg[mid].node, edges[e].target);
+            if (c == 0)
+            {
+               ti = mid;
+               break;
+            }
+            if (c < 0)
+               lo = mid + 1;
+            else
+               hi = mid - 1;
+         }
+      }
+      int cs = si >= 0
+                   ? comm_index_of((const char(*)[KB_GRAPH_NODE_MAX])cnames, nc, asg[si].community)
+                   : -1;
+      int ct = ti >= 0
+                   ? comm_index_of((const char(*)[KB_GRAPH_NODE_MAX])cnames, nc, asg[ti].community)
+                   : -1;
+      two_m += 2 * w;
+      if (cs >= 0)
+         vol[cs] += w;
+      if (ct >= 0)
+         vol[ct] += w;
+      if (cs >= 0 && ct >= 0 && cs != ct)
+      {
+         cut[cs] += w;
+         cut[ct] += w;
+      }
+   }
+
+   int nout = 0;
+   kb_graph_cohesion_t *result = malloc((size_t)nc * sizeof(*result));
+   if (!result)
+   {
+      free(asg);
+      free(cnames);
+      free(vol);
+      free(cut);
+      free(csize);
+      return -1;
+   }
+   for (int c = 0; c < nc; c++)
+   {
+      if (csize[c] < min_size)
+         continue;
+      long long other = two_m - vol[c];
+      long long denom = vol[c] < other ? vol[c] : other;
+      if (denom <= 0)
+         continue; /* whole graph is one community, or empty — no meaningful cut */
+      double cond = (double)cut[c] / (double)denom;
+      snprintf(result[nout].community, KB_GRAPH_NODE_MAX, "%s", cnames[c]);
+      result[nout].conductance = cond;
+      result[nout].size = csize[c];
+      nout++;
+   }
+   qsort(result, (size_t)nout, sizeof(*result), cohesion_cmp);
+   int w = nout < max ? nout : max;
+   for (int i = 0; i < w; i++)
+      out[i] = result[i];
+
+   free(result);
+   free(asg);
+   free(cnames);
+   free(vol);
+   free(cut);
+   free(csize);
    return w;
 }

--- a/src/kb/kb_graph_analytics.h
+++ b/src/kb/kb_graph_analytics.h
@@ -23,6 +23,18 @@ typedef struct
    int weight;
 } kb_graph_edge_t;
 
+/* A relation-typed edge — the generic kb_graph_edge_t plus the projection's
+ * relation label ("calls"/"defines"/"imports"/…). Only kb_graph_cycles needs
+ * relations (to collapse symbols to their defining file); the other analytics are
+ * relation-agnostic, so this is kept separate rather than bloating kb_graph_edge_t.
+ * Mirrors the (source, relation, target) of code_projection_edge_t. */
+typedef struct
+{
+   char source[KB_GRAPH_NODE_MAX];
+   char relation[64];
+   char target[KB_GRAPH_NODE_MAX];
+} kb_graph_reledge_t;
+
 /* One ranked hub node. */
 typedef struct
 {
@@ -150,5 +162,99 @@ typedef struct
  * of the order edges are presented in. */
 int kb_graph_communities(const kb_graph_edge_t *edges, int n_edges, kb_graph_community_t *out,
                          int max);
+
+/* ── S1 self-audit: surface what the graph is unsure about (proposal §1) ─────────
+ *
+ * A read-only, deterministic analytic pass over the projection graph that emits
+ * ranked structural-health findings. Pure (in-memory edge array only); each
+ * function unit-tests standalone and is composed by the /v1/code/graph/audit
+ * route. Every output list is total-ordered (score then node lex) so equal-scored
+ * items never permute between runs and read as change. */
+
+/* Hub-ranking view. TOP = most-connected (the existing refactor-risk signal).
+ * BOTTOM = least-connected (the orphan view). BOTTOM_NOHUB = least-connected
+ * excluding container/hub nodes (project:/file: prefixes) so a genuinely orphaned
+ * *symbol* isn't crowded out by empty container nodes. One ranking, two views
+ * (§1): top and bottom of the same degree distribution can't disagree. */
+typedef enum
+{
+   KB_HUB_TOP = 0,
+   KB_HUB_BOTTOM = 1,
+   KB_HUB_BOTTOM_NOHUB = 2
+} kb_hub_mode_t;
+
+/* Rank nodes by degree in the requested view; otherwise identical contract to
+ * kb_graph_hubs (which is now the KB_HUB_TOP wrapper). For a BOTTOM* view the
+ * order is degree ASC, then weighted_degree ASC, then node asc. */
+int kb_graph_hubs_ranked(const kb_graph_edge_t *edges, int n_edges, kb_graph_hub_t *out, int max,
+                         kb_hub_mode_t mode);
+
+/* True if `node` is a container/hub node (project:/file: key prefix) — excluded
+ * from the orphan and bridge views because their degree is structural bookkeeping,
+ * not a real symbol relationship. */
+int kb_graph_is_container(const char *node);
+
+/* ── cycles ──────────────────────────────────────────────────────────────────
+ * File-level dependency cycles. The projection carries no direct file→file edge,
+ * so we collapse: `defines` edges (file→symbol) map each symbol to its file, then
+ * `calls` edges (symbol→symbol) become directed file→file edges (self-file calls
+ * dropped). Tarjan SCC over that file graph, then a bounded DFS per non-trivial
+ * SCC enumerates up to KB_AUDIT_CYCLE_CAP simple cycles (Johnson explodes on dense
+ * diamonds). Truncation is reported, never silent. */
+#define KB_AUDIT_CYCLE_MAX_LEN 32  /* longest cycle reported; longer ones truncated */
+#define KB_AUDIT_CYCLE_CAP     100 /* max cycles enumerated per SCC */
+
+typedef struct
+{
+   char files[KB_AUDIT_CYCLE_MAX_LEN][KB_GRAPH_NODE_MAX];
+   int len; /* number of files in the cycle (>= 2) */
+} kb_graph_cycle_t;
+
+/* Detect file-level cycles into out[] (up to max), each a canonical-rotation
+ * ordered file list. Sets *truncated to 1 if any SCC hit KB_AUDIT_CYCLE_CAP or
+ * the out buffer filled. Returns the count written, 0 if acyclic, -1 on bad arg. */
+int kb_graph_cycles(const kb_graph_reledge_t *edges, int n_edges, kb_graph_cycle_t *out, int max,
+                    int *truncated);
+
+/* ── bridges ─────────────────────────────────────────────────────────────────
+ * High edge-betweenness nodes that are NOT container/file hubs — the cross-cutting
+ * concerns connecting otherwise-separate modules. Brandes betweenness (unweighted,
+ * undirected). Exact when the node count is <= KB_AUDIT_BRIDGE_EXACT_MAX; above it,
+ * betweenness is estimated from a deterministic first-K lex source sample and the
+ * result is marked approximate. */
+#define KB_AUDIT_BRIDGE_EXACT_MAX 1500 /* exact Brandes below this many nodes */
+#define KB_AUDIT_BRIDGE_SAMPLE    256  /* deterministic source sample above it */
+
+typedef struct
+{
+   char node[KB_GRAPH_NODE_MAX];
+   double betweenness; /* Brandes score; approximate scores are sample-scaled */
+} kb_graph_bridge_t;
+
+/* Rank non-container nodes by betweenness into out[] (up to max), desc then node
+ * asc. Sets *approximate to 1 when sampling was used. Returns count written, 0 if
+ * no bridges, -1 on bad arg. */
+int kb_graph_bridges(const kb_graph_edge_t *edges, int n_edges, kb_graph_bridge_t *out, int max,
+                     int *approximate);
+
+/* ── low-cohesion communities ────────────────────────────────────────────────
+ * A community (from kb_graph_communities) is incohesive when a large share of its
+ * incident edge weight leaves the community. Scored by conductance =
+ * cut(C) / min(vol(C), vol(V\C)) — NOT raw internal density, which returns ~1.0
+ * for tiny communities and misreads sparse-but-valid structure. Gated at size >=
+ * min_size (proposal: 8). Higher conductance = worse cohesion (a split candidate). */
+typedef struct
+{
+   char community[KB_GRAPH_NODE_MAX];
+   double conductance;
+   int size; /* member count */
+} kb_graph_cohesion_t;
+
+/* Score communities and write the worst (highest-conductance) into out[] (up to
+ * max), desc then community lex. `comm`/`n_comm` is the assignment from
+ * kb_graph_communities over the SAME edges. Only communities of size >= min_size
+ * are considered. Returns count written, 0 if none qualify, -1 on bad arg. */
+int kb_graph_cohesion(const kb_graph_edge_t *edges, int n_edges, const kb_graph_community_t *comm,
+                      int n_comm, int min_size, kb_graph_cohesion_t *out, int max);
 
 #endif /* KB_GRAPH_ANALYTICS_H */

--- a/src/mcp_tools_extended.c
+++ b/src/mcp_tools_extended.c
@@ -314,6 +314,7 @@ static const struct fam_def MCP_FAMILIES[] = {
       {"preview", "preview_blast_radius"},
       {"hybrid", "index_hybrid"},
       {"hubs", "index_graph_hubs"},
+      {"audit", "index_graph_audit"},
       {"surprising", "index_graph_surprising"},
       {"neighbors", "index_graph_node"},
       {NULL, NULL}}},

--- a/src/server/kb_client_code_graph.c
+++ b/src/server/kb_client_code_graph.c
@@ -91,6 +91,34 @@ char *kb_client_code_graph_hubs(const char *project, int max_results, int *statu
    return json;
 }
 
+char *kb_client_code_graph_audit(const char *project, int max_findings, int *status_out)
+{
+   if (status_out)
+      *status_out = -1;
+   if (!project || !project[0])
+      return NULL;
+
+   char *project_q = kb_client_query_escape(project);
+   if (!project_q)
+      return NULL;
+   if (max_findings < 1)
+      max_findings = 1;
+
+   size_t cap = strlen("/v1/code/graph/audit?project=&max_findings=") + strlen(project_q) + 32;
+   char *path = malloc(cap);
+   if (!path)
+   {
+      free(project_q);
+      return NULL;
+   }
+   snprintf(path, cap, "/v1/code/graph/audit?project=%s&max_findings=%d", project_q, max_findings);
+   free(project_q);
+
+   char *json = kb_client_v1_get_json(path, KB_CLIENT_CODE_GRAPH_READ_TIMEOUT_MS, status_out);
+   free(path);
+   return json;
+}
+
 char *kb_client_code_graph_surprising(const char *project, int max_results, int judge,
                                       int *status_out)
 {
@@ -105,8 +133,8 @@ char *kb_client_code_graph_surprising(const char *project, int max_results, int 
    if (max_results < 1)
       max_results = 1;
 
-   size_t cap =
-       strlen("/v1/code/graph/surprising?project=&max_results=&judge=true") + strlen(project_q) + 32;
+   size_t cap = strlen("/v1/code/graph/surprising?project=&max_results=&judge=true") +
+                strlen(project_q) + 32;
    char *path = malloc(cap);
    if (!path)
    {

--- a/src/server/server_mcp_call_table.c
+++ b/src/server/server_mcp_call_table.c
@@ -1075,6 +1075,18 @@ static cJSON *mcph_index_graph_hubs(struct mcp_call *c)
    return code_graph_passthrough(json, status, "index_graph_hubs");
 }
 
+static cJSON *mcph_index_graph_audit(struct mcp_call *c)
+{
+   cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
+   if (!cJSON_IsString(jp) || !jp->valuestring[0])
+      return text_content("error: index_graph_audit requires 'project'");
+   long long mf = 0;
+   int max_findings = pdf_arg_pos_int(c->jargs, "max_findings", 200.0, &mf) ? (int)mf : 20;
+   int status = -1;
+   char *json = kb_client_code_graph_audit(jp->valuestring, max_findings, &status);
+   return code_graph_passthrough(json, status, "index_graph_audit");
+}
+
 static cJSON *mcph_index_graph_node(struct mcp_call *c)
 {
    cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
@@ -1338,6 +1350,7 @@ static const struct
     {"code_span_get", mcph_code_span_get},
     {"index_hybrid", mcph_index_hybrid},
     {"index_graph_hubs", mcph_index_graph_hubs},
+    {"index_graph_audit", mcph_index_graph_audit},
     {"index_graph_surprising", mcph_index_graph_surprising},
     {"index_graph_node", mcph_index_graph_node},
     {"memory_explain_match", mcph_memory_explain_match},

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3537,6 +3537,7 @@ $(TESTPREFIX)/unit-test-kb-http-routes: $(OBJDIR)/tests/test_kb_http_routes.o \
                      $(OBJDIR)/kb/http/kb_http_code.o \
                      $(OBJDIR)/kb/kb_rrf.o \
                      $(OBJDIR)/kb/kb_graph_analytics.o \
+                     $(OBJDIR)/kb/prompt_sanitizer.o \
                      $(OBJDIR)/kb/http/kb_http_pdf.o \
                      $(OBJDIR)/kb/http/kb_http_jobs.o \
                      $(OBJDIR)/cJSON.o \

--- a/src/tests/test_kb_graph_analytics.c
+++ b/src/tests/test_kb_graph_analytics.c
@@ -337,9 +337,176 @@ static void test_community_overflow_guard(void)
    printf("  test_community_overflow_guard: ok\n");
 }
 
+/* ── S1 self-audit tests ──────────────────────────────────────────────────── */
+
+/* Orphan view: least-connected non-container node surfaces first; container
+ * (file:/project:) nodes are excluded from the BOTTOM_NOHUB ranking. */
+static void test_orphans_bottom_mode(void)
+{
+   kb_graph_edge_t e[] = {
+       {"h", "a", 1},      {"h", "b", 1},    {"h", "c", 1},
+       {"h", "d", 1},      {"h", "lone", 1}, /* lone: degree 1 symbol */
+       {"file:x", "h", 1},                   /* container, degree 1 */
+   };
+   kb_graph_hub_t out[16];
+   int n = kb_graph_hubs_ranked(e, 6, out, 16, KB_HUB_BOTTOM_NOHUB);
+   assert(n >= 1);
+   /* lowest-degree non-container first; file:x excluded */
+   assert(out[0].degree == 1);
+   for (int i = 0; i < n; i++)
+      assert(!kb_graph_is_container(out[i].node));
+   assert(kb_graph_is_container("file:x") && kb_graph_is_container("project:p"));
+   assert(!kb_graph_is_container("symbol:foo"));
+   printf("  test_orphans_bottom_mode: ok\n");
+}
+
+/* A 3-file dependency ring (fa→fb→fc→fa via symbol calls collapsed to files) is
+ * detected as one cycle of length 3. */
+static void test_cycles_ring(void)
+{
+   kb_graph_reledge_t e[] = {
+       {"fa", "defines", "sa"}, {"fb", "defines", "sb"}, {"fc", "defines", "sc"},
+       {"sa", "calls", "sb"},   {"sb", "calls", "sc"},   {"sc", "calls", "sa"},
+   };
+   kb_graph_cycle_t out[8];
+   int trunc = -1;
+   int n = kb_graph_cycles(e, 6, out, 8, &trunc);
+   assert(n == 1);
+   assert(out[0].len == 3);
+   assert(trunc == 0);
+   /* cycle starts at the lex-smallest file, fa */
+   assert(strcmp(out[0].files[0], "fa") == 0);
+   printf("  test_cycles_ring: ok\n");
+}
+
+/* Acyclic call chain → no cycle; a same-file call is dropped (no self-loop). */
+static void test_cycles_acyclic_and_selfdrop(void)
+{
+   kb_graph_reledge_t lin[] = {
+       {"fa", "defines", "sa"}, {"fb", "defines", "sb"}, {"fc", "defines", "sc"},
+       {"sa", "calls", "sb"},   {"sb", "calls", "sc"},
+   };
+   kb_graph_cycle_t out[8];
+   int trunc = 0;
+   assert(kb_graph_cycles(lin, 5, out, 8, &trunc) == 0);
+
+   /* two symbols in the SAME file calling each other → collapses to a self-loop,
+    * which is dropped → no cycle. */
+   kb_graph_reledge_t same[] = {
+       {"fa", "defines", "s1"},
+       {"fa", "defines", "s2"},
+       {"s1", "calls", "s2"},
+       {"s2", "calls", "s1"},
+   };
+   assert(kb_graph_cycles(same, 4, out, 8, &trunc) == 0);
+   printf("  test_cycles_acyclic_and_selfdrop: ok\n");
+}
+
+/* Barbell: two triangles joined through a single node m — m has the highest
+ * betweenness (it lies on every cross-clique shortest path). */
+static void test_bridges_barbell(void)
+{
+   kb_graph_edge_t e[] = {
+       {"a", "b", 1}, {"b", "c", 1}, {"a", "c", 1}, /* triangle 1 */
+       {"x", "y", 1}, {"y", "z", 1}, {"x", "z", 1}, /* triangle 2 */
+       {"c", "m", 1}, {"m", "x", 1},                /* bridge via m */
+   };
+   kb_graph_bridge_t out[16];
+   int approx = -1;
+   int n = kb_graph_bridges(e, 8, out, 16, &approx);
+   assert(n >= 1);
+   assert(strcmp(out[0].node, "m") == 0); /* highest betweenness */
+   assert(approx == 0);                   /* small graph → exact */
+   printf("  test_bridges_barbell: ok\n");
+}
+
+/* Cohesion: a community that leaks an edge outward has positive conductance and
+ * ranks above a fully-internal (conductance 0) community; a below-min_size
+ * community is excluded. */
+static void test_cohesion_conductance(void)
+{
+   /* "big": 8-node cycle, fully internal. "leak": 8-node cycle + one edge to z.
+    * "zc": the singleton z (size 1, excluded at min_size=8). */
+   kb_graph_edge_t e[18];
+   int ne = 0;
+   const char *big[8] = {"n0", "n1", "n2", "n3", "n4", "n5", "n6", "n7"};
+   const char *leak[8] = {"m0", "m1", "m2", "m3", "m4", "m5", "m6", "m7"};
+   for (int i = 0; i < 8; i++)
+   {
+      e[ne++] = (kb_graph_edge_t){"", "", 1};
+      snprintf(e[ne - 1].source, KB_GRAPH_NODE_MAX, "%s", big[i]);
+      snprintf(e[ne - 1].target, KB_GRAPH_NODE_MAX, "%s", big[(i + 1) % 8]);
+   }
+   for (int i = 0; i < 8; i++)
+   {
+      e[ne++] = (kb_graph_edge_t){"", "", 1};
+      snprintf(e[ne - 1].source, KB_GRAPH_NODE_MAX, "%s", leak[i]);
+      snprintf(e[ne - 1].target, KB_GRAPH_NODE_MAX, "%s", leak[(i + 1) % 8]);
+   }
+   e[ne++] = (kb_graph_edge_t){"m0", "z", 1}; /* leak edge outward */
+
+   kb_graph_community_t asg[17];
+   int na = 0;
+   for (int i = 0; i < 8; i++)
+   {
+      asg[na] = (kb_graph_community_t){"", "big"};
+      snprintf(asg[na].node, KB_GRAPH_NODE_MAX, "%s", big[i]);
+      na++;
+   }
+   for (int i = 0; i < 8; i++)
+   {
+      asg[na] = (kb_graph_community_t){"", "leak"};
+      snprintf(asg[na].node, KB_GRAPH_NODE_MAX, "%s", leak[i]);
+      na++;
+   }
+   asg[na++] = (kb_graph_community_t){"z", "zc"}; /* singleton */
+
+   kb_graph_cohesion_t out[8];
+   int n = kb_graph_cohesion(e, ne, asg, na, 8, out, 8);
+   assert(n == 2); /* big + leak; zc excluded (size 1) */
+   assert(strcmp(out[0].community, "leak") == 0);
+   assert(out[0].conductance > 0.0);
+   assert(strcmp(out[1].community, "big") == 0);
+   assert(out[1].conductance == 0.0);
+   assert(out[0].size == 8 && out[1].size == 8);
+   printf("  test_cohesion_conductance: ok\n");
+}
+
+/* Determinism: cycles/bridges/cohesion outputs are identical under input edge
+ * permutation (reverse order here). */
+static void test_audit_permutation_invariant(void)
+{
+   kb_graph_edge_t e[] = {
+       {"a", "b", 1}, {"b", "c", 1}, {"a", "c", 1}, {"x", "y", 1},
+       {"y", "z", 1}, {"x", "z", 1}, {"c", "m", 1}, {"m", "x", 1},
+   };
+   int ne = 8;
+   kb_graph_edge_t rev[8];
+   for (int i = 0; i < ne; i++)
+      rev[i] = e[ne - 1 - i];
+
+   kb_graph_bridge_t b1[16], b2[16];
+   int ap1 = 0, ap2 = 0;
+   int n1 = kb_graph_bridges(e, ne, b1, 16, &ap1);
+   int n2 = kb_graph_bridges(rev, ne, b2, 16, &ap2);
+   assert(n1 == n2);
+   for (int i = 0; i < n1; i++)
+   {
+      assert(strcmp(b1[i].node, b2[i].node) == 0);
+      assert(b1[i].betweenness == b2[i].betweenness);
+   }
+   printf("  test_audit_permutation_invariant: ok\n");
+}
+
 int main(void)
 {
    printf("test_kb_graph_analytics:\n");
+   test_orphans_bottom_mode();
+   test_cycles_ring();
+   test_cycles_acyclic_and_selfdrop();
+   test_bridges_barbell();
+   test_cohesion_conductance();
+   test_audit_permutation_invariant();
    test_precision_suppress();
    test_community_two_cliques();
    test_community_permutation_invariant();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -2132,6 +2132,33 @@ int db2_code_projection_list_edges(const char *project, void *out, int max)
    return n;
 }
 
+/* graph-feedback S1 (self-audit route) stubs. The audit route reaches these DB2
+ * projection helpers; the hermetic fixture reports a visible generation with no
+ * persisted communities and no source hash. Signatures are ABI-compatible with
+ * db2/code_projection.h (int64_t==long long, code_projection_community_t*==void*,
+ * size_t) — the header is deliberately not included here (same reason the
+ * list_edges stub above uses void*). The real prompt_sanitizer.o IS linked (pure,
+ * no deps), so sanitize_for_prompt is exercised for real, not stubbed. */
+long long db2_code_projection_visible_id(const char *project)
+{
+   (void)project;
+   return 1;
+}
+int db2_code_projection_communities_list(long long gen_id, void *out, int max)
+{
+   (void)gen_id;
+   (void)out;
+   (void)max;
+   return 0;
+}
+int db2_code_projection_visible_source_hash(const char *project, char *out, size_t out_len)
+{
+   (void)project;
+   if (out && out_len)
+      out[0] = '\0';
+   return 0;
+}
+
 /* Hermetic mirror of the §3 provenance helper (kb_service_graph.c). The real
  * definition lives in a db2-heavy unit; this fake keeps the route test pure
  * while preserving the only branch the projection route exercises: a


### PR DESCRIPTION
## Graph-feedback — PR 3 of N: S1 (graph self-audit)

`GET /v1/code/graph/audit` + MCP `index{command:"audit"}` — a deterministic,
read-only structural-health pass over a project's visible projection graph that
surfaces *what the graph is unsure about*. Pure analytics over data already
persisted; **no LLM**. Builds on S0 (sanitizer) and S-community (communities).

### Findings (each a pure function, unit-tested standalone)
- **cycles** — file-level dependency cycles. The projection carries no direct
  file→file edge, so `defines` edges map symbols→files and `calls` edges collapse
  to a directed file graph; **iterative (recursion-free) Tarjan SCC** finds the
  circular clusters and a bounded DFS extracts one representative cycle each.
  Truncation is reported, never silent.
- **orphans** — least-connected non-container symbols (degree ≤ 1), as a
  `BOTTOM_NOHUB` **mode on the hub ranking** (one ranking, two views — not a fork).
- **bridges** — Brandes betweenness (exact ≤ 1500 nodes; deterministic first-K
  lex source sample above, marked `approximate`), excluding file/project hubs.
- **low_cohesion** — communities (from S-community) scored by **conductance** =
  cut/min(vol, 2m−vol), gated at size ≥ 8; reports the metric + threshold and
  marks `community_id_scope:"generation-local"` (S2 remap not yet landed).
- **unverified_inferred** — labeled `signal:"no-confirmation-yet"` and **excluded
  from the roll-up**; the confirmation signal arrives in S3. Best-effort over
  weight-0 provenance today.

### Determinism & honesty (hard requirements)
- Nodes lex-indexed; **total-order tie-breaks** on every ranked list; a
  **permutation-invariance test** asserts byte-identical output under edge
  reordering. Stable **FNV-1a `finding_id`** per finding for the §1↔§3 loop.
- **Honesty gate**: explicit `clean` / `insufficient_signal` rather than inventing
  noise. Staleness echo via `generation_id` + `source_hash`.

### Render boundary (S0)
Every corpus-derived string (file paths, symbol labels, community names) routes
through `sanitize_for_prompt` via `audit_safe()` — **fail-closed** to
`[unsafe-label]` on `SANITIZE_REJECTED`. Registered in
`docs/SANITIZER_CALL_SITES.md`; the lint guard passes (1 call site).

### Wiring & tests
MCP end-to-end: `index{command:audit}` → `index_graph_audit` →
`kb_client_code_graph_audit` → route. 6 new pure analytics tests
(orphans / cycles ring+acyclic+self-drop / bridges barbell / cohesion /
permutation-invariance) + existing 19 pass. `aimee-kb` + `aimee-server` link;
`make lint` green (schema-sync, sanitizer call-sites, dispatch-caps, conformance);
`server_dispatch` ok.

### Review / integration
Roundtable code-review + a live CT integration test (`/v1/code/graph/audit` over a
real indexed fixture repo on the pve test host) accompany this PR.
