### PR TITLE
graph-feedback S4: frontmatter-insensitive doc hashing (cache-correctness)

### DIFF
--- a/src/headers/kb_doc_hash.h
+++ b/src/headers/kb_doc_hash.h
@@ -4,3 +4,16 @@
 #define KB_DOC_HASH_HEX_LEN 64
 
 void kb_doc_content_hash(const char *bytes, int nbytes, char out[KB_DOC_HASH_HEX_LEN + 1]);
+
+/* Frontmatter-insensitive content hash for Markdown/MDX (graph-feedback §5): hashes
+ * the document body plus its YAML frontmatter with an explicit allowlist of
+ * IGNORABLE keys removed (status, reviewed, tags, date — and their multi-line
+ * values), so a metadata-only edit doesn't re-bill extraction while a title or
+ * body edit always does. A doc without a leading `---` frontmatter block hashes
+ * identically to kb_doc_content_hash. Same 64-hex output. */
+void kb_doc_content_hash_md(const char *bytes, int nbytes, char out[KB_DOC_HASH_HEX_LEN + 1]);
+
+/* Dispatch by extension: a Markdown/MDX path uses the frontmatter-insensitive
+ * hash; everything else uses the exact content hash. NULL/unknown path → exact. */
+void kb_doc_content_hash_for_path(const char *path, const char *bytes, int nbytes,
+                                  char out[KB_DOC_HASH_HEX_LEN + 1]);

--- a/src/kb/http/kb_http_ingest.c
+++ b/src/kb/http/kb_http_ingest.c
@@ -151,7 +151,7 @@ int handle_post_docs(const char *body, int body_len, char *out_buf, int out_cap)
    }
 
    char content_hash[KB_DOC_HASH_HEX_LEN + 1];
-   kb_doc_content_hash(file_content, file_len, content_hash);
+   kb_doc_content_hash_for_path(filename, file_content, file_len, content_hash);
 
    /* structured-PDF routing (Phase 1b): when enabled, a `.pdf` upload is owned by the
     * structured extractor (kb_documents + kb_doc_regions), NOT the legacy flat pdftotext

--- a/src/kb/kb_doc_hash.c
+++ b/src/kb/kb_doc_hash.c
@@ -85,7 +85,6 @@ void kb_doc_content_hash_md(const char *bytes, int nbytes, char out[KB_DOC_HASH_
       while (clen && (line[clen - 1] == '\n' || line[clen - 1] == '\r'))
          clen--;
 
-      int is_delim = (clen == 3 && line[0] == '-' && line[1] == '-' && line[2] == '-');
       if (in_fm == 0)
       {
          in_fm = 1; /* the opening --- */
@@ -95,6 +94,7 @@ void kb_doc_content_hash_md(const char *bytes, int nbytes, char out[KB_DOC_HASH_
       }
       if (in_fm == 1)
       {
+         int is_delim = (clen == 3 && line[0] == '-' && line[1] == '-' && line[2] == '-');
          if (is_delim)
          {
             in_fm = 2; /* closing --- */

--- a/src/kb/kb_doc_hash.c
+++ b/src/kb/kb_doc_hash.c
@@ -2,6 +2,15 @@
 
 #include <openssl/sha.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void hex_digest(const unsigned char *digest, char out[KB_DOC_HASH_HEX_LEN + 1])
+{
+   for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
+      snprintf(out + i * 2, 3, "%02x", digest[i]);
+   out[KB_DOC_HASH_HEX_LEN] = '\0';
+}
 
 void kb_doc_content_hash(const char *bytes, int nbytes, char out[KB_DOC_HASH_HEX_LEN + 1])
 {
@@ -14,7 +23,138 @@ void kb_doc_content_hash(const char *bytes, int nbytes, char out[KB_DOC_HASH_HEX
       nbytes = 0;
 
    SHA256((const unsigned char *)(bytes ? bytes : ""), (size_t)nbytes, digest);
-   for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
-      snprintf(out + i * 2, 3, "%02x", digest[i]);
-   out[KB_DOC_HASH_HEX_LEN] = '\0';
+   hex_digest(digest, out);
+}
+
+/* The frontmatter keys whose changes must NOT invalidate the extraction cache. */
+static int fm_key_is_ignorable(const char *line, size_t len)
+{
+   static const char *keys[] = {"status", "reviewed", "tags", "date"};
+   /* key = leading run of non-space, non-':' chars at column 0 (top-level key). */
+   size_t k = 0;
+   while (k < len && line[k] != ':' && line[k] != ' ' && line[k] != '\t' && line[k] != '\n' &&
+          line[k] != '\r')
+      k++;
+   if (k == 0 || k >= len || line[k] != ':')
+      return 0; /* not a "key:" line */
+   for (size_t i = 0; i < sizeof(keys) / sizeof(keys[0]); i++)
+      if (strlen(keys[i]) == k && strncmp(line, keys[i], k) == 0)
+         return 1;
+   return 0;
+}
+
+void kb_doc_content_hash_md(const char *bytes, int nbytes, char out[KB_DOC_HASH_HEX_LEN + 1])
+{
+   if (!out)
+      return;
+   if (!bytes || nbytes < 0)
+      nbytes = 0;
+
+   /* No leading `---` frontmatter → identical to the plain content hash. The block
+    * delimiter is exactly "---" on the first line (optionally with a CR). */
+   size_t n = (size_t)nbytes;
+   int has_fm = (n >= 3 && bytes[0] == '-' && bytes[1] == '-' && bytes[2] == '-' &&
+                 (n == 3 || bytes[3] == '\n' || bytes[3] == '\r'));
+   if (!has_fm)
+   {
+      kb_doc_content_hash(bytes, nbytes, out);
+      return;
+   }
+
+   char *buf = malloc(n + 1);
+   if (!buf)
+   {
+      kb_doc_content_hash(bytes, nbytes, out); /* fail safe: exact hash */
+      return;
+   }
+   size_t w = 0;
+   size_t i = 0;
+   int in_fm = 0;    /* 0=before first ---, 1=inside frontmatter, 2=body */
+   int skipping = 0; /* dropping an ignorable key's line + its indented continuation */
+   while (i < n)
+   {
+      size_t start = i;
+      while (i < n && bytes[i] != '\n')
+         i++;
+      if (i < n)
+         i++; /* include the newline in [start,i) */
+      const char *line = bytes + start;
+      size_t llen = i - start;
+      /* trim a trailing CR for the "---" comparison */
+      size_t clen = llen;
+      while (clen && (line[clen - 1] == '\n' || line[clen - 1] == '\r'))
+         clen--;
+
+      int is_delim = (clen == 3 && line[0] == '-' && line[1] == '-' && line[2] == '-');
+      if (in_fm == 0)
+      {
+         in_fm = 1; /* the opening --- */
+         memcpy(buf + w, line, llen);
+         w += llen;
+         continue;
+      }
+      if (in_fm == 1)
+      {
+         if (is_delim)
+         {
+            in_fm = 2; /* closing --- */
+            memcpy(buf + w, line, llen);
+            w += llen;
+            continue;
+         }
+         int indented = (llen > 0 && (line[0] == ' ' || line[0] == '\t'));
+         if (indented)
+         {
+            if (skipping)
+               continue; /* drop a continuation of an ignorable key */
+         }
+         else
+         {
+            skipping = fm_key_is_ignorable(line, clen);
+            if (skipping)
+               continue; /* drop the ignorable key line */
+         }
+         memcpy(buf + w, line, llen);
+         w += llen;
+         continue;
+      }
+      /* body */
+      memcpy(buf + w, line, llen);
+      w += llen;
+   }
+
+   unsigned char digest[SHA256_DIGEST_LENGTH];
+   SHA256((const unsigned char *)buf, w, digest);
+   free(buf);
+   hex_digest(digest, out);
+}
+
+/* Case-insensitive suffix test. */
+static int ends_with_ci(const char *s, const char *suffix)
+{
+   size_t ls = strlen(s), lx = strlen(suffix);
+   if (lx > ls)
+      return 0;
+   const char *p = s + (ls - lx);
+   for (size_t i = 0; i < lx; i++)
+   {
+      char a = p[i], b = suffix[i];
+      if (a >= 'A' && a <= 'Z')
+         a = (char)(a - 'A' + 'a');
+      if (b >= 'A' && b <= 'Z')
+         b = (char)(b - 'A' + 'a');
+      if (a != b)
+         return 0;
+   }
+   return 1;
+}
+
+void kb_doc_content_hash_for_path(const char *path, const char *bytes, int nbytes,
+                                  char out[KB_DOC_HASH_HEX_LEN + 1])
+{
+   if (path &&
+       (ends_with_ci(path, ".md") || ends_with_ci(path, ".mdx") || ends_with_ci(path, ".markdown")))
+      kb_doc_content_hash_md(bytes, nbytes, out);
+   else
+      kb_doc_content_hash(bytes, nbytes, out);
 }

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -524,7 +524,7 @@ int kb_ingest_doc_content(const char *project, const char *source_path, const ch
    const char *effective_cmd = kb_effective_embedding_cmd(embedding_cmd);
 
    char hash[KB_DOC_HASH_HEX_LEN + 1];
-   kb_doc_content_hash(content, (int)len, hash);
+   kb_doc_content_hash_for_path(source_path, content, (int)len, hash);
 
    char stored[KB_DOC_HASH_HEX_LEN + 1] = "";
    if (db2_kb_documents_get_stored_hash(project, source_path, stored, sizeof(stored)) == 1 &&

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -157,7 +157,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-kb-client-memory \
                $(TESTPREFIX)/unit-test-kb-graph \
                $(TESTPREFIX)/unit-test-kb-rrf \
-               $(TESTPREFIX)/unit-test-kb-graph-analytics $(TESTPREFIX)/unit-test-lessons-cite-tracker $(TESTPREFIX)/unit-test-lessons-reflect $(TESTPREFIX)/unit-test-lessons-actuate \
+               $(TESTPREFIX)/unit-test-kb-graph-analytics $(TESTPREFIX)/unit-test-lessons-cite-tracker $(TESTPREFIX)/unit-test-lessons-reflect $(TESTPREFIX)/unit-test-lessons-actuate $(TESTPREFIX)/unit-test-kb-doc-hash \
                $(TESTPREFIX)/unit-test-prompt-sanitizer \
                $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
@@ -1744,6 +1744,10 @@ $(TESTPREFIX)/unit-test-lessons-reflect: $(OBJDIR)/tests/test_lessons_reflect.o 
 $(TESTPREFIX)/unit-test-lessons-actuate: $(OBJDIR)/tests/test_lessons_actuate.o \
                                          $(OBJDIR)/kb/lessons_actuate.o
 	$(TESTLINK) -o $@ $^ $(L_CORE)
+
+$(TESTPREFIX)/unit-test-kb-doc-hash: $(OBJDIR)/tests/test_kb_doc_hash.o \
+                                     $(OBJDIR)/kb/kb_doc_hash.o
+	$(TESTLINK) -o $@ $^ $(L_CORE) -lcrypto
 
 # Render-boundary prompt sanitizer (graph-feedback §4 / P0). Pure: no DB.
 $(TESTPREFIX)/unit-test-prompt-sanitizer: $(OBJDIR)/tests/test_prompt_sanitizer.o \

--- a/src/tests/test_kb_doc_hash.c
+++ b/src/tests/test_kb_doc_hash.c
@@ -84,9 +84,73 @@ static void test_prefix_not_ignorable(void)
    printf("  test_prefix_not_ignorable: ok\n");
 }
 
+/* The path dispatcher: .md/.mdx/.markdown → frontmatter-aware; else exact. */
+static void test_for_path_dispatch(void)
+{
+   const char *doc = "---\ntitle: T\nstatus: a\n---\nbody\n";
+   const char *doc2 = "---\ntitle: T\nstatus: b\n---\nbody\n";
+   char md1[KB_DOC_HASH_HEX_LEN + 1], md2[KB_DOC_HASH_HEX_LEN + 1];
+   char tx1[KB_DOC_HASH_HEX_LEN + 1], tx2[KB_DOC_HASH_HEX_LEN + 1];
+   /* Markdown path → status edit is invisible. */
+   kb_doc_content_hash_for_path("notes/x.MD", doc, (int)strlen(doc), md1);
+   kb_doc_content_hash_for_path("notes/x.mdx", doc2, (int)strlen(doc2), md2);
+   assert(strcmp(md1, md2) == 0);
+   /* Non-markdown path → exact hash → status edit changes it. */
+   kb_doc_content_hash_for_path("x.txt", doc, (int)strlen(doc), tx1);
+   kb_doc_content_hash_for_path("x.txt", doc2, (int)strlen(doc2), tx2);
+   assert(strcmp(tx1, tx2) != 0);
+   /* NULL path → exact. */
+   char n1[KB_DOC_HASH_HEX_LEN + 1], p1[KB_DOC_HASH_HEX_LEN + 1];
+   kb_doc_content_hash_for_path(NULL, doc, (int)strlen(doc), n1);
+   kb_doc_content_hash(doc, (int)strlen(doc), p1);
+   assert(strcmp(n1, p1) == 0);
+   printf("  test_for_path_dispatch: ok\n");
+}
+
+/* CRLF line endings + a malformed (never-closed) frontmatter both hash without
+ * crashing and stay ignorable-key-insensitive. */
+static void test_crlf_and_malformed(void)
+{
+   const char *v1 = "---\r\ntitle: T\r\nstatus: a\r\n---\r\nbody\r\n";
+   const char *v2 = "---\r\ntitle: T\r\nstatus: b\r\n---\r\nbody\r\n";
+   char a[KB_DOC_HASH_HEX_LEN + 1], b[KB_DOC_HASH_HEX_LEN + 1];
+   md(v1, a);
+   md(v2, b);
+   assert(strcmp(a, b) == 0); /* CRLF: status edit still invisible */
+
+   /* Missing closing --- : the whole rest is treated as frontmatter; ignorable
+    * keys are still dropped, non-ignorable kept — no crash, deterministic. */
+   const char *m1 = "---\ntitle: T\nstatus: a\n";
+   const char *m2 = "---\ntitle: T\nstatus: b\n";
+   const char *m3 = "---\ntitle: X\nstatus: a\n";
+   char h1[KB_DOC_HASH_HEX_LEN + 1], h2[KB_DOC_HASH_HEX_LEN + 1], h3[KB_DOC_HASH_HEX_LEN + 1];
+   md(m1, h1);
+   md(m2, h2);
+   md(m3, h3);
+   assert(strcmp(h1, h2) == 0); /* status change invisible */
+   assert(strcmp(h1, h3) != 0); /* title change visible */
+   printf("  test_crlf_and_malformed: ok\n");
+}
+
+/* NULL / empty inputs to the _md variant are inert (no crash). */
+static void test_md_null_empty(void)
+{
+   char a[KB_DOC_HASH_HEX_LEN + 1], b[KB_DOC_HASH_HEX_LEN + 1];
+   kb_doc_content_hash_md(NULL, 0, a);
+   kb_doc_content_hash(NULL, 0, b);
+   assert(strcmp(a, b) == 0);
+   kb_doc_content_hash_md("", 0, a);
+   kb_doc_content_hash("", 0, b);
+   assert(strcmp(a, b) == 0);
+   printf("  test_md_null_empty: ok\n");
+}
+
 int main(void)
 {
    printf("test_kb_doc_hash:\n");
+   test_for_path_dispatch();
+   test_crlf_and_malformed();
+   test_md_null_empty();
    test_no_frontmatter_equals_plain();
    test_ignorable_key_edit_stable();
    test_multiline_ignorable();

--- a/src/tests/test_kb_doc_hash.c
+++ b/src/tests/test_kb_doc_hash.c
@@ -1,0 +1,98 @@
+/* test_kb_doc_hash.c: frontmatter-insensitive Markdown content hashing
+ * (graph-feedback §5 / S4). A metadata-only frontmatter edit (status/reviewed/
+ * tags/date) must NOT change the hash; a title or body edit always must. Pure. */
+#include "kb_doc_hash.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void md(const char *s, char out[KB_DOC_HASH_HEX_LEN + 1])
+{
+   kb_doc_content_hash_md(s, (int)strlen(s), out);
+}
+
+/* No leading frontmatter → identical to the plain content hash. */
+static void test_no_frontmatter_equals_plain(void)
+{
+   const char *doc = "# Title\n\nsome body text\n";
+   char a[KB_DOC_HASH_HEX_LEN + 1], b[KB_DOC_HASH_HEX_LEN + 1];
+   md(doc, a);
+   kb_doc_content_hash(doc, (int)strlen(doc), b);
+   assert(strcmp(a, b) == 0);
+   printf("  test_no_frontmatter_equals_plain: ok\n");
+}
+
+/* An ignorable-key edit (status/reviewed/tags/date) does NOT change the hash. */
+static void test_ignorable_key_edit_stable(void)
+{
+   const char *v1 = "---\ntitle: My Doc\nstatus: draft\ndate: 2026-01-01\n---\n\nbody\n";
+   const char *v2 = "---\ntitle: My Doc\nstatus: published\ndate: 2026-07-03\n---\n\nbody\n";
+   char a[KB_DOC_HASH_HEX_LEN + 1], b[KB_DOC_HASH_HEX_LEN + 1];
+   md(v1, a);
+   md(v2, b);
+   assert(strcmp(a, b) == 0); /* only ignorable keys changed */
+   printf("  test_ignorable_key_edit_stable: ok\n");
+}
+
+/* A multi-line ignorable value (tags list) is skipped wholesale. */
+static void test_multiline_ignorable(void)
+{
+   const char *v1 = "---\ntitle: T\ntags:\n  - a\n  - b\nreviewed: no\n---\nbody\n";
+   const char *v2 = "---\ntitle: T\ntags:\n  - x\n  - y\n  - z\nreviewed: yes\n---\nbody\n";
+   char a[KB_DOC_HASH_HEX_LEN + 1], b[KB_DOC_HASH_HEX_LEN + 1];
+   md(v1, a);
+   md(v2, b);
+   assert(strcmp(a, b) == 0);
+   printf("  test_multiline_ignorable: ok\n");
+}
+
+/* A title (non-ignorable frontmatter) edit DOES change the hash. */
+static void test_title_edit_changes(void)
+{
+   const char *v1 = "---\ntitle: Old\nstatus: draft\n---\nbody\n";
+   const char *v2 = "---\ntitle: New\nstatus: draft\n---\nbody\n";
+   char a[KB_DOC_HASH_HEX_LEN + 1], b[KB_DOC_HASH_HEX_LEN + 1];
+   md(v1, a);
+   md(v2, b);
+   assert(strcmp(a, b) != 0);
+   printf("  test_title_edit_changes: ok\n");
+}
+
+/* A body edit DOES change the hash even if frontmatter is identical. */
+static void test_body_edit_changes(void)
+{
+   const char *v1 = "---\ntitle: T\nstatus: draft\n---\nold body\n";
+   const char *v2 = "---\ntitle: T\nstatus: draft\n---\nnew body\n";
+   char a[KB_DOC_HASH_HEX_LEN + 1], b[KB_DOC_HASH_HEX_LEN + 1];
+   md(v1, a);
+   md(v2, b);
+   assert(strcmp(a, b) != 0);
+   printf("  test_body_edit_changes: ok\n");
+}
+
+/* A key that merely CONTAINS an ignorable name (e.g. "status_note") is NOT
+ * ignorable — exact key match only. */
+static void test_prefix_not_ignorable(void)
+{
+   const char *v1 = "---\nstatus_note: a\n---\nbody\n";
+   const char *v2 = "---\nstatus_note: b\n---\nbody\n";
+   char a[KB_DOC_HASH_HEX_LEN + 1], b[KB_DOC_HASH_HEX_LEN + 1];
+   md(v1, a);
+   md(v2, b);
+   assert(strcmp(a, b) != 0); /* status_note is a real content key */
+   printf("  test_prefix_not_ignorable: ok\n");
+}
+
+int main(void)
+{
+   printf("test_kb_doc_hash:\n");
+   test_no_frontmatter_equals_plain();
+   test_ignorable_key_edit_stable();
+   test_multiline_ignorable();
+   test_title_edit_changes();
+   test_body_edit_changes();
+   test_prefix_not_ignorable();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Graph-feedback — PR 9 of N: S4 (cache-correctness, §5 optional hardening)

A **metadata-only Markdown edit no longer re-bills extraction**, while a title or
body edit always does.

- **`kb_doc_content_hash_md()`**: hashes a Markdown/MDX doc's body plus its YAML
  frontmatter with an explicit allowlist of **ignorable keys removed** (`status`,
  `reviewed`, `tags`, `date` — incl. their multi-line indented values). A doc with
  no leading `---` block hashes **identically** to `kb_doc_content_hash`. Exact key
  match only (`status_note` stays significant).
- **`kb_doc_content_hash_for_path()`**: dispatches by extension → frontmatter-aware
  for `.md/.mdx/.markdown`, exact otherwise. Wired into **both doc-ingest hash
  paths** so the cache-hit decision is frontmatter-insensitive; blob-store /
  code-span / content-version callers keep the exact hash.
- **6 unit tests** (no-frontmatter==plain, ignorable-key stable, multi-line
  ignorable, title/body change, prefix-not-ignorable).

### Scope note (§5 is *optional hardening*)
The other two refinements are **already substantially in place**:
- doc-**conversion** cache is version-namespaced via
  `docs.converter_version` (`UNIQUE(content_hash, converter, converter_version, scope)`);
- the **structural** projection is version-stamped via
  `code_projection_generations.extractor_version` (added in S2).

The remaining full-contract **semantic-cache** namespacing (embedding / model /
prompt versions) touches the embedding cache hot path and is a focused follow-up
best done with a live embedding testbed.

### Validation
`aimee-kb` + `aimee-server` link; `kb-doc-hash` tests green; `make lint` green.
Persona-reviewed.