### PR TITLE
graph-feedback S5: Scala tree-sitter grammar (Tier-1 coverage, 1/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ src/vendor/tree-sitter-swift/
 src/vendor/tree-sitter-kotlin/
 src/vendor/tree-sitter-dart/
 src/vendor/tree-sitter-css/
+src/vendor/tree-sitter-scala/

--- a/scripts/fetch-treesitter.sh
+++ b/scripts/fetch-treesitter.sh
@@ -50,6 +50,7 @@ fetch tree-sitter-swift      https://github.com/alex-pinkus/tree-sitter-swift   
 fetch tree-sitter-kotlin     https://github.com/fwcd/tree-sitter-kotlin           c8ac3d2627240160b999a2c100de3babbdb8f419
 fetch tree-sitter-dart       https://github.com/UserNobody14/tree-sitter-dart      a9bdfa3db2fbc9b9f12c93450d04a671f33a5102
 fetch tree-sitter-css        https://github.com/tree-sitter/tree-sitter-css        dda5cfc5722c429eaba1c910ca32c2c0c5bb1a3f
+fetch tree-sitter-scala      https://github.com/tree-sitter/tree-sitter-scala      4d081d98670ff6e98ca42c085294fc75eec15e1d
 
 echo "fetch-treesitter: done -> $VENDOR/tree-sitter*"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -454,7 +454,8 @@ TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o \
                  $(OBJDIR)/vendor/ts_swift.o $(OBJDIR)/vendor/ts_swift_scan.o \
                  $(OBJDIR)/vendor/ts_kotlin.o $(OBJDIR)/vendor/ts_kotlin_scan.o \
                  $(OBJDIR)/vendor/ts_dart.o $(OBJDIR)/vendor/ts_dart_scan.o \
-                 $(OBJDIR)/vendor/ts_css.o $(OBJDIR)/vendor/ts_css_scan.o
+                 $(OBJDIR)/vendor/ts_css.o $(OBJDIR)/vendor/ts_css_scan.o \
+                 $(OBJDIR)/vendor/ts_scala.o $(OBJDIR)/vendor/ts_scala_scan.o
 $(OBJDIR)/kb/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
 # code_treesitter.c includes tree_sitter/api.h, which the fetch produces — so on a cold
 # checkout the fetch must run before this object compiles. Order-only: trigger the fetch
@@ -479,7 +480,8 @@ vendor/tree-sitter-bash/src/parser.c vendor/tree-sitter-bash/src/scanner.c \
 vendor/tree-sitter-swift/src/parser.c vendor/tree-sitter-swift/src/scanner.c \
 vendor/tree-sitter-kotlin/src/parser.c vendor/tree-sitter-kotlin/src/scanner.c \
 vendor/tree-sitter-dart/src/parser.c vendor/tree-sitter-dart/src/scanner.c \
-vendor/tree-sitter-css/src/parser.c vendor/tree-sitter-css/src/scanner.c:
+vendor/tree-sitter-css/src/parser.c vendor/tree-sitter-css/src/scanner.c \
+vendor/tree-sitter-scala/src/parser.c vendor/tree-sitter-scala/src/scanner.c:
 	../scripts/fetch-treesitter.sh
 $(OBJDIR)/vendor/ts_runtime.o: vendor/tree-sitter/lib/src/lib.c
 	@mkdir -p $(OBJDIR)/vendor
@@ -523,6 +525,8 @@ $(eval $(call ts_obj,dart,tree-sitter-dart/src,parser.c))
 $(eval $(call ts_obj,dart_scan,tree-sitter-dart/src,scanner.c))
 $(eval $(call ts_obj,css,tree-sitter-css/src,parser.c))
 $(eval $(call ts_obj,css_scan,tree-sitter-css/src,scanner.c))
+$(eval $(call ts_obj,scala,tree-sitter-scala/src,parser.c))
+$(eval $(call ts_obj,scala_scan,tree-sitter-scala/src,scanner.c))
 endif
 
 # --- Gateway ---

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -38,6 +38,7 @@ const TSLanguage *tree_sitter_swift(void);
 const TSLanguage *tree_sitter_kotlin(void);
 const TSLanguage *tree_sitter_dart(void);
 const TSLanguage *tree_sitter_css(void);
+const TSLanguage *tree_sitter_scala(void);
 
 typedef enum
 {
@@ -57,7 +58,8 @@ typedef enum
    TSL_SWIFT,
    TSL_KOTLIN,
    TSL_DART,
-   TSL_CSS
+   TSL_CSS,
+   TSL_SCALA
 } ts_lang_t;
 
 static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
@@ -101,6 +103,8 @@ static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
        {".kts", TSL_KOTLIN, tree_sitter_kotlin},
        {".dart", TSL_DART, tree_sitter_dart},
        {".css", TSL_CSS, tree_sitter_css},
+       {".scala", TSL_SCALA, tree_sitter_scala},
+       {".sc", TSL_SCALA, tree_sitter_scala},
    };
    for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); i++)
       if (strcmp(ext, map[i].ext) == 0)
@@ -511,6 +515,23 @@ static int classify_css(TSNode node, const char **kind, TSNode *name_root)
    return 1;
 }
 
+/* Scala: `def` → function; class/object/trait/type/enum → type. The name comes via
+ * name_node (the `name` field, else a direct identifier child). Members live in a
+ * template_body (descended below). */
+static int classify_scala(TSNode node, const char **kind, TSNode *name_root)
+{
+   const char *t = ts_node_type(node);
+   static const char *const fns[] = {"function_definition", "function_declaration", NULL};
+   static const char *const types[] = {"class_definition", "object_definition", "trait_definition",
+                                       "type_definition",  "enum_definition",   NULL};
+   if (kind_lookup(t, fns, types, kind))
+   {
+      *name_root = name_node(node);
+      return 1;
+   }
+   return 0;
+}
+
 static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name_root)
 {
    switch (lang)
@@ -548,6 +569,8 @@ static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name
       return classify_dart(node, kind, name_root);
    case TSL_CSS:
       return classify_css(node, kind, name_root);
+   case TSL_SCALA:
+      return classify_scala(node, kind, name_root);
    }
    return 0;
 }
@@ -578,7 +601,9 @@ static int is_descendable(const char *t)
        "class_definition", "class", "interface_declaration", "trait_item", "impl_item", "mod_item",
        "trait_declaration", "object_declaration", "protocol_declaration", "struct_declaration",
        "record_declaration", "mixin_declaration", "extension_declaration", "enum_declaration",
-       "enum_specifier", "enum_item", NULL};
+       "enum_specifier", "enum_item",
+       /* Scala: object/trait bodies + the shared template_body that holds members */
+       "object_definition", "trait_definition", "template_body", "enum_definition", NULL};
    for (int i = 0; set[i]; i++)
       if (strcmp(t, set[i]) == 0)
          return 1;

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -54,9 +54,10 @@ int main(void)
    printf("test_code_treesitter:\n");
 
    /* availability gates the dispatch (a representative extension per language). */
-   const char *avail[] = {".c",   ".h",   ".cpp", ".cc",   ".hpp",   ".cs", ".py",   ".go",
-                          ".js",  ".mjs", ".jsx", ".ts",   ".tsx",   ".rs", ".java", ".rb",
-                          ".php", ".lua", ".sh",  ".bash", ".swift", ".kt", ".dart", ".css"};
+   const char *avail[] = {".c",    ".h",    ".cpp", ".cc",    ".hpp", ".cs",   ".py",
+                          ".go",   ".js",   ".mjs", ".jsx",   ".ts",  ".tsx",  ".rs",
+                          ".java", ".rb",   ".php", ".lua",   ".sh",  ".bash", ".swift",
+                          ".kt",   ".dart", ".css", ".scala", ".sc"};
    for (size_t i = 0; i < sizeof(avail) / sizeof(avail[0]); i++)
       assert(code_treesitter_available(avail[i]));
    assert(!code_treesitter_available(".txt"));
@@ -224,6 +225,20 @@ int main(void)
    /* --- CSS (@keyframes name) --- */
    want(".css", "@keyframes spin { from {} to {} }\n.cls { color: red }\n", "spin", "type");
 
+   /* --- Scala (object/class/trait → type; def → function, incl. members in a
+    * template_body; def also works as a top-level .sc script member) --- */
+   const char *scala = "object M {\n  def greet(): Unit = println(\"hi\")\n}\n"
+                       "class C { def m(): Int = 1 }\n"
+                       "trait T { def t(): Unit }\n";
+   want(".scala", scala, "M", "type");
+   want(".scala", scala, "greet", "function");
+   want(".scala", scala, "C", "type");
+   want(".scala", scala, "m", "function");
+   want(".scala", scala, "T", "type");
+   want(".scala", "enum Color { case Red, Green }\n", "Color", "type"); /* Scala 3 enum */
+   want(".scala", "type Id = Int\n", "Id", "type");                     /* type_definition */
+   want(".sc", "def top(): Int = 1\n", "top", "function");              /* .sc script member */
+
    /* --- nested members: methods inside a type body are surfaced (the walk descends type
     * bodies but never function bodies), across the OO languages. --- */
    want(".cpp", "class C { void m(){} };\n", "m", "function");
@@ -258,6 +273,7 @@ int main(void)
    wantcall(".c", "void f(){ g(); obj->m(); }\n", "f", "g");
    wantcall(".c", "void f(){ obj->m(); }\n", "f", "m"); /* method call -> last id */
    wantcall(".py", "def f():\n    g()\n    obj.m()\n", "f", "g");
+   wantcall(".scala", "object M { def f(): Unit = { g() } }\n", "f", "g");
    wantcall(".py", "def f():\n    obj.m()\n", "f", "m");
    wantcall(".js", "function f(){ g(); a.b.c(); }\n", "f", "g");
    wantcall(".js", "function f(){ a.b.c(); }\n", "f", "c"); /* chained -> last id */


### PR DESCRIPTION
## Graph-feedback — S5 PR 1 of 6: Scala grammar

First of the §6a **Tier-1 coverage-expansion** grammars. Adds **Scala** (`.scala`/`.sc`)
to the opt-in tree-sitter extraction front-end — definitions + call edges.

- **`code_treesitter.c`**: `tree_sitter_scala` entry point, `TSL_SCALA`, ext map,
  **`classify_scala`** (`def`/`def`-declaration → function; class/object/trait/type/enum
  → type, via the shared `name` field), and `object_definition`/`trait_definition`/
  `template_body` added to `is_descendable` so members inside a type body surface.
  `call_expression` is already handled → Scala call edges work as-is.
- **`Makefile`**: `ts_scala.o` + `ts_scala_scan.o` (external scanner), fetch prereqs, `ts_obj`.
- **`fetch-treesitter.sh`**: `tree-sitter/tree-sitter-scala` pinned `@4d081d98`.
- **`test_code_treesitter.c`**: `.scala`/`.sc` availability + object/class/trait/def/method
  defs + an `f`→`g` call edge.

**Safety**: entirely under `#ifdef AIMEE_TREESITTER` — the default build is unchanged
(stub) and a missing grammar falls through to text-only, so nothing regresses.

**Validation**: local `AIMEE_TREESITTER=1` build → `unit-test-code-treesitter` **ALL PASS**;
default `aimee-kb` links; `make lint` green. The CI **treesitter** job fetches +
builds + tests it. Persona-reviewed.