### PR TITLE
fix(workflow): unwedge autonomous items stuck at a looping author stage

### DIFF
--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -14,6 +14,11 @@ nodes:
     params:
       with_user: true
     next: proposal_gate
+    # author.proposal LOOPS when its delegate can't produce the artifact; a
+    # loopable node needs an on_fail edge or the engine hard-errors ("looped with
+    # no on_fail edge") and the run wedges. Self-loop so a failed author retries,
+    # bounded by the engine's max-attempts backstop, then parks (surfaced).
+    on_fail: draft
   - id: proposal_gate
     block: gate.roundtable
     in:
@@ -48,6 +53,7 @@ nodes:
     in:
       proposal: draft.out
     next: plan_gate
+    on_fail: plan # author.plan loops on delegate failure; self-loop (see draft)
   - id: plan_gate
     block: gate.roundtable
     in:

--- a/config/workflows/manual-review.yaml
+++ b/config/workflows/manual-review.yaml
@@ -13,6 +13,9 @@ nodes:
     params:
       with_user: false
     next: review
+    # Self-loop: author.proposal loops on delegate failure and needs an on_fail
+    # edge, else the engine hard-errors and the run wedges (see build.yaml draft).
+    on_fail: draft
   - id: review
     block: gate.human
     in:

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -106,7 +106,14 @@ function statusOf(it: Item): { label: string; variant: BadgeVariant } {
       return { label: "parked · failed", variant: "error" };
     case "max_attempts":
       return { label: "parked · max attempts", variant: "error" };
+    case "stuck":
+      // The engine can't advance this stage (unresolvable stage / no executor);
+      // it needs a human to fix + resume or abandon. Never shown as "running".
+      return { label: `stuck at ${it.stage}`, variant: "error" };
     default:
+      // Any other non-empty pause_reason still means parked — never render a
+      // paused item as "running". Only a truly un-paused active item is running.
+      if (it.pause_reason) return { label: `parked · ${it.pause_reason}`, variant: "warning" };
       return { label: `running · ${it.stage}`, variant: "running" };
   }
 }

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -231,6 +231,35 @@ int main(void)
       unsetenv("AIMEE_AUTONOMY_USD_PER_SEC");
    }
 
+   /* A9: an UNRECOVERABLE advance failure (current_stage is not a node in the
+    * workflow — e.g. an orphaned stage after a rename, or the same class as a
+    * looped node with no on_fail edge) parks the item 'stuck' instead of the
+    * scheduler retry-failing it forever while the UI shows "running". A re-sweep
+    * is a no-op: still stuck, no new lifecycle event (no spam). */
+   {
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("auto", "stuck1", "stuck1", "autonomous", id, err, sizeof err) ==
+             0);
+      /* orphan the stage: "ghoststage" is not a node in the "auto" workflow. */
+      assert(db1_work_item_set_stage(id, "ghoststage", "") == 0);
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "active") == 0);
+      assert(strcmp(wi.pause_reason, "stuck") == 0);
+
+      db1_lifecycle_event_t *evs = NULL;
+      int before = db1_lifecycle_event_list(id, &evs);
+      free(evs);
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* re-sweep: early-out */
+      evs = NULL;
+      int after = db1_lifecycle_event_list(id, &evs);
+      free(evs);
+      assert(after == before); /* no re-park spam */
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "stuck") == 0);
+   }
+
    printf("ok\n");
    return 0;
 }

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -66,6 +66,28 @@ static int wfe_autonomy_park_budget(const char *work_item_id, const char *why)
    return 0;
 }
 
+/* Park an active autonomous work item 'stuck' after an UNRECOVERABLE advance
+ * failure — its current_stage is not a node in the workflow (an orphaned stage
+ * after a rename), the stage's block has no executor, or a looped node has no
+ * on_fail edge to retry into. Such a failure never self-resolves, so without
+ * parking the scheduler retry-fails the item on every backstop sweep while the
+ * UI still shows it "running" (the symptom that surfaced this). Mirrors
+ * wfe_autonomy_park_budget: audits the reason once and never overwrites an
+ * existing pause. Returns 0 on a clean park, 1 if already parked (no re-audit, so
+ * a re-sweep can't spam the event log), -1 if the row could not be read. */
+static int wfe_autonomy_park_stuck(const char *work_item_id, const char *why)
+{
+   db1_work_item_t wi;
+   if (db1_work_item_get(work_item_id, &wi) != 1)
+      return -1;
+   if (wi.pause_reason[0])
+      return 1; /* already parked (incl. a prior 'stuck'): leave it, don't spam */
+   db1_work_item_set_pause(work_item_id, "stuck", wi.current_stage);
+   db1_lifecycle_event_add(work_item_id, wi.current_stage, "pause", "engine",
+                           (why && why[0]) ? why : "unrecoverable advance failure", "", 0);
+   return 0;
+}
+
 /* Is this paused node a human gate the driver may auto-satisfy in autonomous
  * mode? (policy preauthorized, or optional:true). */
 static int human_gate_auto_ok(const wfe_node_t *node)
@@ -99,6 +121,17 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
    long max_wall = wfe_env_long("AIMEE_AUTONOMY_MAX_WALL_SECS", 1800);
    struct timespec ts0;
    clock_gettime(CLOCK_MONOTONIC, &ts0); /* monotonic: immune to NTP/clock jumps */
+
+   /* An item already parked 'stuck' cannot advance without human intervention
+    * (its stage is unresolvable / has no executor). Skip it so the backstop
+    * sweep doesn't re-attempt the doomed advance every cycle; a human resume
+    * clears the pause and lets the next sweep retry. */
+   {
+      db1_work_item_t wi0;
+      if (db1_work_item_get(work_item_id, &wi0) == 1 && strcmp(wi0.pause_reason, "stuck") == 0)
+         return 0;
+   }
+
    for (int i = 0; i < 10000; i++)
    {
       db1_lifecycle_event_t *evs = NULL;
@@ -128,7 +161,16 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
 
       wfe_advance_result_t r;
       if (wfe_engine_advance(work_item_id, &r, err, errlen) != 0)
-         return -1;
+      {
+         /* A structural advance failure (current_stage not a workflow node, the
+          * block has no executor, or a looped node with no on_fail edge) will
+          * never self-resolve. Park it 'stuck' so it surfaces in the UI and the
+          * scheduler stops retry-failing it every sweep; the error is preserved
+          * in the audit event. */
+         if (wfe_autonomy_park_stuck(work_item_id, err) < 0)
+            return -1; /* row unreadable — surface the original advance error */
+         return 0;
+      }
       if (r.terminal)
       {
          wfe_autonomy_cleanup_worktree(work_item_id);


### PR DESCRIPTION
## Symptom

A Workflow Actions item showed **"running · draft"** indefinitely and never progressed.

## Root cause (confirmed on the live .254 item)

The item is autonomous and the scheduler *is* sweeping it every 30s, but `wfe_engine_advance` fails each time with:

```
wfe-sched: autonomy run wi_…: node 'draft' looped with no on_fail edge
```

The build workflow's **author** nodes (`draft`=`author.proposal`, `plan`=`author.plan`) have `next:` but **no `on_fail:`**, while every gate node has one. `author.proposal` returns **LOOPED** when its delegate can't produce the artifact (the architect delegate is failing on .254). With no `on_fail` edge the engine's `max_attempts` backstop can't engage, so it hard-errors → `-1` → the scheduler logs a WARN and retries forever, never advancing, never parking. `statusOf()` then falls through to `running · ${stage}`.

Only `create` + `submit` events exist on the item; `updated_at` is frozen at creation — i.e. the engine has never moved it.

## Fix

1. **`config/workflows/{build,manual-review}.yaml`** — give the author nodes an `on_fail` **self-loop**. A failed author now retries, bounded by `WFE_MAX_ATTEMPTS`, then parks (surfaced) instead of hard-erroring. (`advance` short-circuits an already-paused item, so a re-sweep doesn't re-dispatch the delegate.)
2. **`src/workflow/wfe_autonomy.c`** — when `wfe_engine_advance` fails structurally (unresolvable stage / no executor / looped-with-no-`on_fail`), **park the item `stuck`** instead of returning `-1` into the scheduler's silent 30s retry-loop; an early-out skips re-advancing an already-`stuck` item (no loop, no event spam). Mirrors the existing `park_budget` helper.
3. **`frontend/.../WorkflowActions.tsx` `statusOf()`** — add a `stuck` case, and make the default truthful: any non-empty `pause_reason` renders `parked · …`, **never** `running`.

## Tests

- New `test_wfe_autonomy` case: an unresolvable stage parks `stuck`; a re-sweep is a no-op (still stuck, no new event). `unit-test-wfe-autonomy` + `unit-test-wfe-scheduler` pass; `clang-format-19` clean; frontend `tsc` clean.
- Roundtable-reviewed (engineer persona): logic confirmed, including the max-attempts/re-sweep interaction.

## Note on the live item

After deploy, the wedged item will loop its author up to `WFE_MAX_ATTEMPTS` then park `pending_human` (surfaced) instead of lying "running". The *underlying* reason it loops — the **architect delegate failing on .254** — is an operational/delegate-health issue (see the known .254 agent-health state), separate from this code fix. This change makes that failure **visible and bounded** rather than an invisible forever-loop.