### PR TITLE
graph-feedback S5: Groovy tree-sitter grammar (Tier-1 2/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ src/vendor/tree-sitter-kotlin/
 src/vendor/tree-sitter-dart/
 src/vendor/tree-sitter-css/
 src/vendor/tree-sitter-scala/
+src/vendor/tree-sitter-groovy/

--- a/scripts/fetch-treesitter.sh
+++ b/scripts/fetch-treesitter.sh
@@ -51,6 +51,7 @@ fetch tree-sitter-kotlin     https://github.com/fwcd/tree-sitter-kotlin         
 fetch tree-sitter-dart       https://github.com/UserNobody14/tree-sitter-dart      a9bdfa3db2fbc9b9f12c93450d04a671f33a5102
 fetch tree-sitter-css        https://github.com/tree-sitter/tree-sitter-css        dda5cfc5722c429eaba1c910ca32c2c0c5bb1a3f
 fetch tree-sitter-scala      https://github.com/tree-sitter/tree-sitter-scala      4d081d98670ff6e98ca42c085294fc75eec15e1d
+fetch tree-sitter-groovy     https://github.com/murtaza64/tree-sitter-groovy       deb0dcf8c4544f07564060f6e9b9f6e4b0bfc27d
 
 echo "fetch-treesitter: done -> $VENDOR/tree-sitter*"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -455,7 +455,8 @@ TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o \
                  $(OBJDIR)/vendor/ts_kotlin.o $(OBJDIR)/vendor/ts_kotlin_scan.o \
                  $(OBJDIR)/vendor/ts_dart.o $(OBJDIR)/vendor/ts_dart_scan.o \
                  $(OBJDIR)/vendor/ts_css.o $(OBJDIR)/vendor/ts_css_scan.o \
-                 $(OBJDIR)/vendor/ts_scala.o $(OBJDIR)/vendor/ts_scala_scan.o
+                 $(OBJDIR)/vendor/ts_scala.o $(OBJDIR)/vendor/ts_scala_scan.o \
+                 $(OBJDIR)/vendor/ts_groovy.o
 $(OBJDIR)/kb/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
 # code_treesitter.c includes tree_sitter/api.h, which the fetch produces — so on a cold
 # checkout the fetch must run before this object compiles. Order-only: trigger the fetch
@@ -481,7 +482,8 @@ vendor/tree-sitter-swift/src/parser.c vendor/tree-sitter-swift/src/scanner.c \
 vendor/tree-sitter-kotlin/src/parser.c vendor/tree-sitter-kotlin/src/scanner.c \
 vendor/tree-sitter-dart/src/parser.c vendor/tree-sitter-dart/src/scanner.c \
 vendor/tree-sitter-css/src/parser.c vendor/tree-sitter-css/src/scanner.c \
-vendor/tree-sitter-scala/src/parser.c vendor/tree-sitter-scala/src/scanner.c:
+vendor/tree-sitter-scala/src/parser.c vendor/tree-sitter-scala/src/scanner.c \
+vendor/tree-sitter-groovy/src/parser.c:
 	../scripts/fetch-treesitter.sh
 $(OBJDIR)/vendor/ts_runtime.o: vendor/tree-sitter/lib/src/lib.c
 	@mkdir -p $(OBJDIR)/vendor
@@ -527,6 +529,7 @@ $(eval $(call ts_obj,css,tree-sitter-css/src,parser.c))
 $(eval $(call ts_obj,css_scan,tree-sitter-css/src,scanner.c))
 $(eval $(call ts_obj,scala,tree-sitter-scala/src,parser.c))
 $(eval $(call ts_obj,scala_scan,tree-sitter-scala/src,scanner.c))
+$(eval $(call ts_obj,groovy,tree-sitter-groovy/src,parser.c))
 endif
 
 # --- Gateway ---

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -39,6 +39,7 @@ const TSLanguage *tree_sitter_kotlin(void);
 const TSLanguage *tree_sitter_dart(void);
 const TSLanguage *tree_sitter_css(void);
 const TSLanguage *tree_sitter_scala(void);
+const TSLanguage *tree_sitter_groovy(void);
 
 typedef enum
 {
@@ -59,7 +60,8 @@ typedef enum
    TSL_KOTLIN,
    TSL_DART,
    TSL_CSS,
-   TSL_SCALA
+   TSL_SCALA,
+   TSL_GROOVY
 } ts_lang_t;
 
 static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
@@ -105,6 +107,8 @@ static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
        {".css", TSL_CSS, tree_sitter_css},
        {".scala", TSL_SCALA, tree_sitter_scala},
        {".sc", TSL_SCALA, tree_sitter_scala},
+       {".groovy", TSL_GROOVY, tree_sitter_groovy},
+       {".gradle", TSL_GROOVY, tree_sitter_groovy},
    };
    for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); i++)
       if (strcmp(ext, map[i].ext) == 0)
@@ -532,6 +536,31 @@ static int classify_scala(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
+/* Groovy: function_definition/declaration → function, but the name is in the
+ * `function` field (a preceding `type` field would fool name_node). class_definition
+ * → type (its name is a plain `name` field). Class members live in a `closure` body
+ * (descended below). */
+static int classify_groovy(TSNode node, const char **kind, TSNode *name_root)
+{
+   const char *t = ts_node_type(node);
+   if (strcmp(t, "function_definition") == 0 || strcmp(t, "function_declaration") == 0)
+   {
+      TSNode fn = ts_node_child_by_field_name(node, "function", 8);
+      if (ts_node_is_null(fn))
+         return 0;
+      *name_root = fn;
+      *kind = "function";
+      return 1;
+   }
+   if (strcmp(t, "class_definition") == 0)
+   {
+      *kind = "type";
+      *name_root = name_node(node);
+      return 1;
+   }
+   return 0;
+}
+
 static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name_root)
 {
    switch (lang)
@@ -571,6 +600,8 @@ static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name
       return classify_css(node, kind, name_root);
    case TSL_SCALA:
       return classify_scala(node, kind, name_root);
+   case TSL_GROOVY:
+      return classify_groovy(node, kind, name_root);
    }
    return 0;
 }
@@ -603,7 +634,9 @@ static int is_descendable(const char *t)
        "record_declaration", "mixin_declaration", "extension_declaration", "enum_declaration",
        "enum_specifier", "enum_item",
        /* Scala: object/trait bodies + the shared template_body that holds members */
-       "object_definition", "trait_definition", "template_body", "enum_definition", NULL};
+       "object_definition", "trait_definition", "template_body", "enum_definition",
+       /* Groovy: class body is a closure */
+       "closure", NULL};
    for (int i = 0; set[i]; i++)
       if (strcmp(t, set[i]) == 0)
          return 1;
@@ -711,8 +744,9 @@ static int is_call_node(const char *t)
 {
    return strcmp(t, "call_expression") == 0 || strcmp(t, "call") == 0 ||
           strcmp(t, "method_invocation") == 0 || strcmp(t, "invocation_expression") == 0 ||
-          strcmp(t, "function_call") == 0 || strcmp(t, "function_call_expression") == 0 ||
-          strcmp(t, "member_call_expression") == 0 || strcmp(t, "scoped_call_expression") == 0 ||
+          strcmp(t, "function_call") == 0 || strcmp(t, "juxt_function_call") == 0 ||
+          strcmp(t, "function_call_expression") == 0 || strcmp(t, "member_call_expression") == 0 ||
+          strcmp(t, "scoped_call_expression") == 0 ||
           strcmp(t, "nullsafe_member_call_expression") == 0 || strcmp(t, "macro_invocation") == 0 ||
           strcmp(t, "object_creation_expression") == 0;
 }

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -54,10 +54,10 @@ int main(void)
    printf("test_code_treesitter:\n");
 
    /* availability gates the dispatch (a representative extension per language). */
-   const char *avail[] = {".c",    ".h",    ".cpp", ".cc",    ".hpp", ".cs",   ".py",
-                          ".go",   ".js",   ".mjs", ".jsx",   ".ts",  ".tsx",  ".rs",
-                          ".java", ".rb",   ".php", ".lua",   ".sh",  ".bash", ".swift",
-                          ".kt",   ".dart", ".css", ".scala", ".sc"};
+   const char *avail[] = {".c",    ".h",    ".cpp", ".cc",    ".hpp", ".cs",     ".py",
+                          ".go",   ".js",   ".mjs", ".jsx",   ".ts",  ".tsx",    ".rs",
+                          ".java", ".rb",   ".php", ".lua",   ".sh",  ".bash",   ".swift",
+                          ".kt",   ".dart", ".css", ".scala", ".sc",  ".groovy", ".gradle"};
    for (size_t i = 0; i < sizeof(avail) / sizeof(avail[0]); i++)
       assert(code_treesitter_available(avail[i]));
    assert(!code_treesitter_available(".txt"));
@@ -239,6 +239,15 @@ int main(void)
    want(".scala", "type Id = Int\n", "Id", "type");                     /* type_definition */
    want(".sc", "def top(): Int = 1\n", "top", "function");              /* .sc script member */
 
+   /* --- Groovy (name in the `function` field; class methods live in a closure
+    * body; .gradle build files share the grammar) --- */
+   const char *groovy = "class Build {\n  def compile() { javac() }\n}\n"
+                        "def task() { println 'hi' }\n";
+   want(".groovy", groovy, "Build", "type");
+   want(".groovy", groovy, "compile", "function"); /* method inside a class closure */
+   want(".groovy", groovy, "task", "function");    /* top-level def */
+   want(".gradle", "def clean() {}\n", "clean", "function");
+
    /* --- nested members: methods inside a type body are surfaced (the walk descends type
     * bodies but never function bodies), across the OO languages. --- */
    want(".cpp", "class C { void m(){} };\n", "m", "function");
@@ -274,6 +283,7 @@ int main(void)
    wantcall(".c", "void f(){ obj->m(); }\n", "f", "m"); /* method call -> last id */
    wantcall(".py", "def f():\n    g()\n    obj.m()\n", "f", "g");
    wantcall(".scala", "object M { def f(): Unit = { g() } }\n", "f", "g");
+   wantcall(".groovy", "def f() { g() }\n", "f", "g");
    wantcall(".py", "def f():\n    obj.m()\n", "f", "m");
    wantcall(".js", "function f(){ g(); a.b.c(); }\n", "f", "g");
    wantcall(".js", "function f(){ a.b.c(); }\n", "f", "c"); /* chained -> last id */


### PR DESCRIPTION
## Graph-feedback — S5 PR 2 of 6: Groovy grammar

Adds **Groovy** (`.groovy` + `.gradle` build files) to the opt-in tree-sitter front-end.

- **`classify_groovy`**: `function_definition`/`declaration` → function, name from the
  **`function` field** (a preceding `type` return-type field would fool the generic
  `name_node`); `class_definition` → type via its `name` field. Class methods live in a
  **`closure`** body → added to `is_descendable` (safe: `visit()` halts on matched
  functions, so method-body closures are never descended). **`juxt_function_call`** added
  to `is_call_node` for Groovy's parenthesis-free calls.
- **Makefile**: `ts_groovy.o` (no external scanner), fetch prereq, `ts_obj`.
- **fetch-treesitter.sh**: `murtaza64/tree-sitter-groovy` pinned `@deb0dcf8`; `.gitignore` entry.
- **test**: `.groovy`/`.gradle` availability + class / method-in-closure / top-level-def
  + an `f`→`g` call.

Under `#ifdef AIMEE_TREESITTER` (default build unchanged). Local `AIMEE_TREESITTER=1`
**ALL PASS**; default `aimee-kb` links; `make lint` green. CI `treesitter` job validates. Persona-reviewed.