### PR TITLE
fix(workflow): persona-aware live delegate bridge + 'all' role/persona wildcards

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -617,7 +617,7 @@ Beyond the config store, aimee reads a few standalone JSON/policy files (paths u
 | `reconnect_delay` | Delay between reconnects (ms). |
 | `relay_key` | Relay auth key. |
 | `relay_ssh` | SSH relay config. |
-| `roles` | Roles this agent serves (review, plan, …). |
+| `roles` | Roles this agent serves (review, plan, …); `"all"` = every role. |
 | `session_reuse` | Reuse a session across calls. |
 | `ssh_entry` | SSH entry point (ssh backend). |
 | `ssh_key` | SSH key path (ssh backend). |

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -610,6 +610,7 @@ Beyond the config store, aimee reads a few standalone JSON/policy files (paths u
 | `name` | Agent identifier. |
 | `network` | Network mode (backend sandbox). |
 | `networks` | Allowed networks. |
+| `personas` | Personas this agent may be dispatched AS (engineer, architect, …); `"all"` or omitted = every persona. |
 | `port` | Target port (relay / tunnel). |
 | `provider` | Provider name. |
 | `recommended_sampling` | Provider-recommended sampling parameters. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -907,6 +907,7 @@ AGENT_FIELD_DESC = {
     "context_warn_pct": "Context % at which to warn.",
     "stall_threshold": "Stall-detection threshold.",
     "roles": "Roles this agent serves (review, plan, …).",
+    "personas": "Personas this agent may be dispatched AS (engineer, architect, …); `\"all\"` or omitted = every persona.",
     "exec_roles": "Roles this agent may execute with tools.",
     "exec_system_prompt": "System prompt for exec/tool runs.",
     "tools_enabled": "Allow tool use for this agent.",

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -906,7 +906,7 @@ AGENT_FIELD_DESC = {
     "auto_compact_pct": "Context % at which to auto-compact.",
     "context_warn_pct": "Context % at which to warn.",
     "stall_threshold": "Stall-detection threshold.",
-    "roles": "Roles this agent serves (review, plan, …).",
+    "roles": "Roles this agent serves (review, plan, …); `\"all\"` = every role.",
     "personas": "Personas this agent may be dispatched AS (engineer, architect, …); `\"all\"` or omitted = every persona.",
     "exec_roles": "Roles this agent may execute with tools.",
     "exec_system_prompt": "System prompt for exec/tool runs.",

--- a/src/cmd_agent_setup.c
+++ b/src/cmd_agent_setup.c
@@ -207,6 +207,12 @@ static void setup_api_provider(agent_config_t *cfg, const char *provider, const 
          snprintf(ag->roles[ag->role_count++], 32, "%s", defaults[i]);
    }
 
+   /* Personas the agent may be dispatched AS. Default to the "all" wildcard so a
+    * fresh agent can serve every delegate persona (engineer/architect/...); an
+    * operator can narrow this in agents.json. */
+   ag->persona_count = 0;
+   snprintf(ag->personas[ag->persona_count++], 32, "all");
+
    if (cfg->agent_count == 1 || !cfg->default_agent[0])
       snprintf(cfg->default_agent, MAX_AGENT_NAME, "%s", name_buf);
 

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -39,6 +39,7 @@ int agent_any_delegate_available(void);
 void agent_set_route_health_filter(int (*fn)(const char *agent_name));
 
 int agent_has_role(const agent_t *agent, const char *role);
+int agent_supports_persona(const agent_t *agent, const char *persona);
 int agent_is_exec_role(const agent_t *agent, const char *role);
 void agent_expand_env(const char *src, char *dst, size_t dst_len);
 int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len);

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -9,6 +9,7 @@ struct cJSON;
 
 #define MAX_AGENTS               16
 #define MAX_AGENT_ROLES          16
+#define MAX_AGENT_PERSONAS       16
 #define MAX_AGENT_NAME           64
 #define MAX_ENDPOINT_LEN         512
 #define MAX_MODEL_LEN            128
@@ -229,6 +230,11 @@ typedef struct
    char provider[16];
    char roles[MAX_AGENT_ROLES][32];
    int role_count;
+   /* Personas this agent may be dispatched AS (delegate identities: engineer,
+    * architect, reviewer, ...). The wildcard "all" (or an empty/absent list, for
+    * backward compatibility) means the agent may serve every persona. */
+   char personas[MAX_AGENT_PERSONAS][32];
+   int persona_count;
    int cost_tier;
    int max_tokens;
    int timeout_ms;

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1185,7 +1185,9 @@ int agent_has_role(const agent_t *agent, const char *role)
 {
    for (int i = 0; i < agent->role_count; i++)
    {
-      if (strcmp(agent->roles[i], role) == 0)
+      /* "all" is a wildcard: the agent serves every role (routing only — tool
+       * use is still governed by exec_roles / tools_enabled). */
+      if (strcmp(agent->roles[i], "all") == 0 || strcmp(agent->roles[i], role) == 0)
          return 1;
    }
    return 0;

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -751,6 +751,23 @@ int agent_load_config(agent_config_t *cfg)
             }
          }
 
+         /* Personas this agent may be dispatched AS (delegate identities). An
+          * absent/empty list means "all" (agent_supports_persona), so existing
+          * agents.json without this key keep serving every persona. */
+         cJSON *personas = cJSON_GetObjectItem(a, "personas");
+         if (personas && cJSON_IsArray(personas))
+         {
+            int pn = cJSON_GetArraySize(personas);
+            if (pn > MAX_AGENT_PERSONAS)
+               pn = MAX_AGENT_PERSONAS;
+            for (int j = 0; j < pn; j++)
+            {
+               cJSON *p = cJSON_GetArrayItem(personas, j);
+               if (cJSON_IsString(p))
+                  snprintf(ag->personas[ag->persona_count++], 32, "%s", p->valuestring);
+            }
+         }
+
          /* Middleware configuration (optional per-agent overrides) */
          cJSON *mw = cJSON_GetObjectItem(a, "middleware");
          if (mw && cJSON_IsObject(mw))
@@ -978,6 +995,15 @@ int agent_save_config(const agent_config_t *cfg)
          cJSON_AddItemToArray(roles, cJSON_CreateString(ag->roles[j]));
       cJSON_AddItemToObject(a, "roles", roles);
 
+      /* Only serialize personas when explicitly set (empty = "all" implicitly). */
+      if (ag->persona_count > 0)
+      {
+         cJSON *personas = cJSON_CreateArray();
+         for (int j = 0; j < ag->persona_count; j++)
+            cJSON_AddItemToArray(personas, cJSON_CreateString(ag->personas[j]));
+         cJSON_AddItemToObject(a, "personas", personas);
+      }
+
       cJSON_AddNumberToObject(a, "cost_tier", ag->cost_tier);
       cJSON_AddNumberToObject(a, "max_tokens", ag->max_tokens);
       cJSON_AddNumberToObject(a, "timeout_ms", ag->timeout_ms);
@@ -1160,6 +1186,24 @@ int agent_has_role(const agent_t *agent, const char *role)
    for (int i = 0; i < agent->role_count; i++)
    {
       if (strcmp(agent->roles[i], role) == 0)
+         return 1;
+   }
+   return 0;
+}
+
+/* 1 if the agent may be dispatched AS `persona`. An agent with no personas list
+ * (backward-compatible default) or one containing the "all" wildcard serves any
+ * persona; otherwise the persona must be listed. A NULL/empty persona is treated
+ * as unconstrained (routing then depends on role alone). */
+int agent_supports_persona(const agent_t *agent, const char *persona)
+{
+   if (!agent)
+      return 0;
+   if (!persona || !persona[0] || agent->persona_count == 0)
+      return 1;
+   for (int i = 0; i < agent->persona_count; i++)
+   {
+      if (strcmp(agent->personas[i], "all") == 0 || strcmp(agent->personas[i], persona) == 0)
          return 1;
    }
    return 0;

--- a/src/server/delegate_role.c
+++ b/src/server/delegate_role.c
@@ -26,7 +26,8 @@ static int delegate_agent_supports_role(const agent_t *agent, const char *role)
       return 0;
    for (int i = 0; i < agent->role_count; i++)
    {
-      if (strcmp(agent->roles[i], role) == 0)
+      /* "all" is a wildcard: the agent serves every role. */
+      if (strcmp(agent->roles[i], "all") == 0 || strcmp(agent->roles[i], role) == 0)
          return 1;
    }
    for (int i = 0; i < agent->exec_role_count; i++)

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -26,6 +26,7 @@
 #include "cJSON.h"
 #include "delegate_role.h"
 #include "persona.h"
+#include "provider_catalog.h"
 #include "headers/git_verify.h"
 #include "log.h"
 #include "util.h"
@@ -137,19 +138,31 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
    }
    else
    {
-      /* Route by the persona's allowed roles: pick the first role a healthy,
-       * persona-eligible agent can serve (agent_route already applies health +
-       * cost-tier), then run that agent AS the persona. */
+      /* Route by the persona's allowed roles (ordered by preference): for the
+       * first role that ANY healthy, persona-eligible agent serves, pick the
+       * lowest-cost-tier such agent. Scanning every agent per role (not just
+       * agent_route's single best) means a persona-ineligible best-tier agent
+       * can't shadow an eligible one that serves the same role. */
       agent_t *chosen = NULL;
       const char *chosen_role = NULL;
+      int best_tier = 0;
       for (int ri = 0; ri < pinfo.roles_count && !chosen; ri++)
       {
          const char *r = delegate_role_canonicalize(pinfo.roles[ri]);
-         agent_t *ag = agent_route(&acfg, r);
-         if (ag && agent_supports_persona(ag, persona))
+         for (int ai = 0; ai < acfg.agent_count; ai++)
          {
-            chosen = ag;
-            chosen_role = r;
+            agent_t *ag = &acfg.agents[ai];
+            if (!ag->enabled || !agent_has_role(ag, r) || !agent_supports_persona(ag, persona) ||
+                !agent_is_available_for_routing(ag))
+               continue;
+            if (provider_catalog_get_health(ag->name) == CATALOG_HEALTH_DOWN)
+               continue;
+            if (!chosen || ag->cost_tier < best_tier)
+            {
+               chosen = ag;
+               chosen_role = r;
+               best_tier = ag->cost_tier;
+            }
          }
       }
       if (!chosen)

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -24,6 +24,8 @@
 #include "agent_exec.h"
 #include "agent_types.h"
 #include "cJSON.h"
+#include "delegate_role.h"
+#include "persona.h"
 #include "headers/git_verify.h"
 #include "log.h"
 #include "util.h"
@@ -100,9 +102,20 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
       return -1;
    }
 
+   /* The producing blocks pass a PERSONA (engineer / architect / ...) — the
+    * delegate's IDENTITY — in this slot, NOT an agent routing role. (It was
+    * historically misused as a role, so no agent matched — author/implement
+    * looped forever.) Compose the persona's identity + principles as the system
+    * prompt, and route by a ROLE the persona is allowed to use that an eligible
+    * agent can serve. */
+   const char *persona = (role && role[0]) ? role : "engineer";
+   char *sys_prompt = persona_compose_delegate_prompt(persona, workdir, "");
+   persona_t pinfo;
+   memset(&pinfo, 0, sizeof pinfo);
+   persona_load(NULL, persona, &pinfo);
+
    /* Run WITH TOOLS, pinned to the work-item worktree, so file edits land there.
-    * A specific agent runs by name; otherwise route by role. max_tokens 0 =
-    * model-derived cap (never under-cap a reasoning delegate). */
+    * A specific agent runs by name; otherwise route by persona. */
    run_cmd_set_cwd(workdir);
    agent_result_t res;
    memset(&res, 0, sizeof(res));
@@ -113,17 +126,49 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
       if (!ag)
       {
          run_cmd_set_cwd(NULL);
+         free(sys_prompt);
+         persona_free(&pinfo);
          if (err && errlen)
             snprintf(err, errlen, "wfe live delegate: unknown delegate '%s'", agent_name);
          return -1;
       }
-      rc = agent_execute_with_tools(ag, NULL, "", prompt, AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
+      rc = agent_execute_with_tools(ag, &acfg.network, sys_prompt ? sys_prompt : "", prompt,
+                                    AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
    }
    else
    {
-      rc = agent_run_with_tools(&acfg, role, "", prompt, AGENT_DEFAULT_MAX_TOKENS, &res);
+      /* Route by the persona's allowed roles: pick the first role a healthy,
+       * persona-eligible agent can serve (agent_route already applies health +
+       * cost-tier), then run that agent AS the persona. */
+      agent_t *chosen = NULL;
+      const char *chosen_role = NULL;
+      for (int ri = 0; ri < pinfo.roles_count && !chosen; ri++)
+      {
+         const char *r = delegate_role_canonicalize(pinfo.roles[ri]);
+         agent_t *ag = agent_route(&acfg, r);
+         if (ag && agent_supports_persona(ag, persona))
+         {
+            chosen = ag;
+            chosen_role = r;
+         }
+      }
+      if (!chosen)
+      {
+         run_cmd_set_cwd(NULL);
+         free(sys_prompt);
+         persona_free(&pinfo);
+         if (err && errlen)
+            snprintf(err, errlen, "wfe live delegate: no enabled agent eligible for persona '%s'",
+                     persona);
+         return -1;
+      }
+      rc = agent_execute_with_tools_for_role(chosen, &acfg.network, chosen_role,
+                                             sys_prompt ? sys_prompt : "", prompt,
+                                             AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
    }
    run_cmd_set_cwd(NULL);
+   free(sys_prompt);
+   persona_free(&pinfo);
 
    if (rc != 0)
    {

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -123,6 +123,34 @@ static void test_agent_has_role(void)
    assert(agent_has_role(&agent, "summarize") == 0);
 }
 
+static void test_agent_supports_persona(void)
+{
+   agent_t agent;
+   memset(&agent, 0, sizeof(agent));
+
+   /* No personas listed -> supports every persona (backward compatible). */
+   assert(agent_supports_persona(&agent, "architect") == 1);
+   assert(agent_supports_persona(&agent, "engineer") == 1);
+
+   /* Explicit list gates by name. */
+   strcpy(agent.personas[0], "engineer");
+   agent.persona_count = 1;
+   assert(agent_supports_persona(&agent, "engineer") == 1);
+   assert(agent_supports_persona(&agent, "architect") == 0);
+
+   /* The "all" wildcard serves any persona. */
+   strcpy(agent.personas[0], "all");
+   agent.persona_count = 1;
+   assert(agent_supports_persona(&agent, "engineer") == 1);
+   assert(agent_supports_persona(&agent, "architect") == 1);
+   assert(agent_supports_persona(&agent, "anything") == 1);
+
+   /* NULL agent -> not supported; NULL/empty persona -> unconstrained. */
+   assert(agent_supports_persona(NULL, "engineer") == 0);
+   assert(agent_supports_persona(&agent, NULL) == 1);
+   assert(agent_supports_persona(&agent, "") == 1);
+}
+
 static void test_agent_find(void)
 {
    agent_config_t cfg;
@@ -2160,6 +2188,7 @@ int main(void)
    test_agent_name_valid();
    test_agent_expand_env();
    test_agent_has_role();
+   test_agent_supports_persona();
    test_agent_find();
    test_agent_route();
    test_agent_route_with_caps_honors_tools_enabled();

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -121,6 +121,13 @@ static void test_agent_has_role(void)
    assert(agent_has_role(&agent, "translate") == 0);
    agent.role_count = 0;
    assert(agent_has_role(&agent, "summarize") == 0);
+
+   /* The "all" wildcard role serves every role. */
+   strcpy(agent.roles[0], "all");
+   agent.role_count = 1;
+   assert(agent_has_role(&agent, "summarize") == 1);
+   assert(agent_has_role(&agent, "code") == 1);
+   assert(agent_has_role(&agent, "anything") == 1);
 }
 
 static void test_agent_supports_persona(void)


### PR DESCRIPTION
## Problem

Autonomous work items wedge at a producing stage (the "stuck at draft" symptom from #1000): the workflow's producing blocks dispatch a **persona** name — `"architect"`, `"engineer"`, `"reviewer"` (identities from `persona.c`) — but `wfe_live_delegate_run` used that string as a routing **role** (`agent_has_role`). No agent declares a role named `architect`/`engineer` (roles are `code`/`review`/`draft`/…), so routing failed, dispatch returned `-1`, and `author.proposal`/`implement` looped forever. The bridge also never applied the persona (empty system prompt).

**Role vs persona:** a *role* is the task kind (routing + write/tool/cache behavior); a *persona* is the delegate's identity (system prompt) with an allowed-role set. They compose — the CLI does `delegate <role> --persona <persona>`. The live bridge had neither the persona plumbing nor a valid role.

## Fix

- **Persona-aware bridge** (`wfe_live_delegate.c`): treat the block's value as a persona — compose its identity via `persona_compose_delegate_prompt`, resolve its allowed roles via `persona_load`, and route by the first allowed role a healthy, persona-eligible agent serves (scanning every eligible agent per role), running that agent **as** the persona.
- **`personas` field + `all` wildcard** (`agents.json`): `agent_supports_persona()` gates dispatch; absent/empty = all (backward-compatible, so existing fleets keep working), `"all"` = every persona. New agents seed `personas: ["all"]`.
- **`all` role wildcard** (symmetric): an agent with role `"all"` serves every role (`agent_has_role` / `delegate_agent_supports_role`; `exec_roles` stay explicit).

## Tests / build

- `test_agent`: `agent_supports_persona` (default/explicit/`all`/NULL) + `agent_has_role` `all` wildcard.
- Full `aimee-server` builds; `unit-test-agent` passes; `clang-format-19` clean; reference docs regenerated for both new fields.

## Roundtable

Reviewed by the glm persona. It flagged one real gap — routing only checked `agent_route`'s single best agent per role, so a persona-ineligible best-tier agent could shadow an eligible one — now fixed by scanning all eligible agents per role (final commit). (Its other note is moot: an unknown persona falls back to engineer's roles and still routes.)

## Relationship to #1000

#1000 made the wedge **visible and bounded** (on_fail + park-stuck + truthful UI). This makes autonomous dispatch **actually work**. Note: the deployed .254 agents have no `personas` key, so they default to `all` — routing will work on deploy without config changes.