### PR TITLE
graph-feedback S5: Objective-C/C++ tree-sitter grammar (Tier-1 3/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ src/vendor/tree-sitter-dart/
 src/vendor/tree-sitter-css/
 src/vendor/tree-sitter-scala/
 src/vendor/tree-sitter-groovy/
+src/vendor/tree-sitter-objc/

--- a/scripts/fetch-treesitter.sh
+++ b/scripts/fetch-treesitter.sh
@@ -52,6 +52,7 @@ fetch tree-sitter-dart       https://github.com/UserNobody14/tree-sitter-dart   
 fetch tree-sitter-css        https://github.com/tree-sitter/tree-sitter-css        dda5cfc5722c429eaba1c910ca32c2c0c5bb1a3f
 fetch tree-sitter-scala      https://github.com/tree-sitter/tree-sitter-scala      4d081d98670ff6e98ca42c085294fc75eec15e1d
 fetch tree-sitter-groovy     https://github.com/murtaza64/tree-sitter-groovy       deb0dcf8c4544f07564060f6e9b9f6e4b0bfc27d
+fetch tree-sitter-objc       https://github.com/tree-sitter-grammars/tree-sitter-objc 181a81b8f23a2d593e7ab4259981f50122909fda
 
 echo "fetch-treesitter: done -> $VENDOR/tree-sitter*"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -456,7 +456,8 @@ TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o \
                  $(OBJDIR)/vendor/ts_dart.o $(OBJDIR)/vendor/ts_dart_scan.o \
                  $(OBJDIR)/vendor/ts_css.o $(OBJDIR)/vendor/ts_css_scan.o \
                  $(OBJDIR)/vendor/ts_scala.o $(OBJDIR)/vendor/ts_scala_scan.o \
-                 $(OBJDIR)/vendor/ts_groovy.o
+                 $(OBJDIR)/vendor/ts_groovy.o \
+                 $(OBJDIR)/vendor/ts_objc.o
 $(OBJDIR)/kb/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
 # code_treesitter.c includes tree_sitter/api.h, which the fetch produces — so on a cold
 # checkout the fetch must run before this object compiles. Order-only: trigger the fetch
@@ -483,7 +484,8 @@ vendor/tree-sitter-kotlin/src/parser.c vendor/tree-sitter-kotlin/src/scanner.c \
 vendor/tree-sitter-dart/src/parser.c vendor/tree-sitter-dart/src/scanner.c \
 vendor/tree-sitter-css/src/parser.c vendor/tree-sitter-css/src/scanner.c \
 vendor/tree-sitter-scala/src/parser.c vendor/tree-sitter-scala/src/scanner.c \
-vendor/tree-sitter-groovy/src/parser.c:
+vendor/tree-sitter-groovy/src/parser.c \
+vendor/tree-sitter-objc/src/parser.c:
 	../scripts/fetch-treesitter.sh
 $(OBJDIR)/vendor/ts_runtime.o: vendor/tree-sitter/lib/src/lib.c
 	@mkdir -p $(OBJDIR)/vendor
@@ -530,6 +532,7 @@ $(eval $(call ts_obj,css_scan,tree-sitter-css/src,scanner.c))
 $(eval $(call ts_obj,scala,tree-sitter-scala/src,parser.c))
 $(eval $(call ts_obj,scala_scan,tree-sitter-scala/src,scanner.c))
 $(eval $(call ts_obj,groovy,tree-sitter-groovy/src,parser.c))
+$(eval $(call ts_obj,objc,tree-sitter-objc/src,parser.c))
 endif
 
 # --- Gateway ---

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -40,6 +40,7 @@ const TSLanguage *tree_sitter_dart(void);
 const TSLanguage *tree_sitter_css(void);
 const TSLanguage *tree_sitter_scala(void);
 const TSLanguage *tree_sitter_groovy(void);
+const TSLanguage *tree_sitter_objc(void);
 
 typedef enum
 {
@@ -61,7 +62,8 @@ typedef enum
    TSL_DART,
    TSL_CSS,
    TSL_SCALA,
-   TSL_GROOVY
+   TSL_GROOVY,
+   TSL_OBJC
 } ts_lang_t;
 
 static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
@@ -109,6 +111,10 @@ static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
        {".sc", TSL_SCALA, tree_sitter_scala},
        {".groovy", TSL_GROOVY, tree_sitter_groovy},
        {".gradle", TSL_GROOVY, tree_sitter_groovy},
+       /* .m is Objective-C here (also MATLAB's extension — ObjC is the intended
+        * target; a MATLAB .m simply won't parse cleanly and falls through). */
+       {".m", TSL_OBJC, tree_sitter_objc},
+       {".mm", TSL_OBJC, tree_sitter_objc},
    };
    for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); i++)
       if (strcmp(ext, map[i].ext) == 0)
@@ -561,6 +567,41 @@ static int classify_groovy(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
+/* Objective-C / Objective-C++: C function_definition (declarator-based, like C);
+ * a method_definition's selector is a direct identifier (simple methods; keyword/
+ * multi-arg selectors are a known gap); @interface/@implementation/@protocol name
+ * is the first identifier child (the superclass/category come after). Members live
+ * in the class/implementation body (descended below); ObjC message sends are
+ * handled as calls via message_expression's `method` field. */
+static int classify_objc(TSNode node, const char **kind, TSNode *name_root)
+{
+   const char *t = ts_node_type(node);
+   if (strcmp(t, "function_definition") == 0)
+   {
+      TSNode d = ts_node_child_by_field_name(node, "declarator", 10);
+      if (ts_node_is_null(d) || !first_identifier(d, name_root))
+         return 0;
+      *kind = "function";
+      return 1;
+   }
+   if (strcmp(t, "method_definition") == 0)
+   {
+      if (!direct_identifier(node, name_root))
+         return 0;
+      *kind = "function";
+      return 1;
+   }
+   if (strcmp(t, "class_interface") == 0 || strcmp(t, "class_implementation") == 0 ||
+       strcmp(t, "protocol_declaration") == 0)
+   {
+      if (!direct_identifier(node, name_root))
+         return 0;
+      *kind = "type";
+      return 1;
+   }
+   return 0;
+}
+
 static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name_root)
 {
    switch (lang)
@@ -602,6 +643,8 @@ static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name
       return classify_scala(node, kind, name_root);
    case TSL_GROOVY:
       return classify_groovy(node, kind, name_root);
+   case TSL_OBJC:
+      return classify_objc(node, kind, name_root);
    }
    return 0;
 }
@@ -636,7 +679,10 @@ static int is_descendable(const char *t)
        /* Scala: object/trait bodies + the shared template_body that holds members */
        "object_definition", "trait_definition", "template_body", "enum_definition",
        /* Groovy: class body is a closure */
-       "closure", NULL};
+       "closure",
+       /* Objective-C: @interface/@implementation/@protocol bodies */
+       "class_interface", "class_implementation", "implementation_definition",
+       "protocol_declaration", NULL};
    for (int i = 0; set[i]; i++)
       if (strcmp(t, set[i]) == 0)
          return 1;
@@ -745,8 +791,8 @@ static int is_call_node(const char *t)
    return strcmp(t, "call_expression") == 0 || strcmp(t, "call") == 0 ||
           strcmp(t, "method_invocation") == 0 || strcmp(t, "invocation_expression") == 0 ||
           strcmp(t, "function_call") == 0 || strcmp(t, "juxt_function_call") == 0 ||
-          strcmp(t, "function_call_expression") == 0 || strcmp(t, "member_call_expression") == 0 ||
-          strcmp(t, "scoped_call_expression") == 0 ||
+          strcmp(t, "message_expression") == 0 || strcmp(t, "function_call_expression") == 0 ||
+          strcmp(t, "member_call_expression") == 0 || strcmp(t, "scoped_call_expression") == 0 ||
           strcmp(t, "nullsafe_member_call_expression") == 0 || strcmp(t, "macro_invocation") == 0 ||
           strcmp(t, "object_creation_expression") == 0;
 }

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -54,10 +54,10 @@ int main(void)
    printf("test_code_treesitter:\n");
 
    /* availability gates the dispatch (a representative extension per language). */
-   const char *avail[] = {".c",    ".h",    ".cpp", ".cc",    ".hpp", ".cs",     ".py",
-                          ".go",   ".js",   ".mjs", ".jsx",   ".ts",  ".tsx",    ".rs",
-                          ".java", ".rb",   ".php", ".lua",   ".sh",  ".bash",   ".swift",
-                          ".kt",   ".dart", ".css", ".scala", ".sc",  ".groovy", ".gradle"};
+   const char *avail[] = {".c",     ".h",   ".cpp",    ".cc",     ".hpp",   ".cs", ".py",   ".go",
+                          ".js",    ".mjs", ".jsx",    ".ts",     ".tsx",   ".rs", ".java", ".rb",
+                          ".php",   ".lua", ".sh",     ".bash",   ".swift", ".kt", ".dart", ".css",
+                          ".scala", ".sc",  ".groovy", ".gradle", ".m",     ".mm"};
    for (size_t i = 0; i < sizeof(avail) / sizeof(avail[0]); i++)
       assert(code_treesitter_available(avail[i]));
    assert(!code_treesitter_available(".txt"));
@@ -248,6 +248,16 @@ int main(void)
    want(".groovy", groovy, "task", "function");    /* top-level def */
    want(".gradle", "def clean() {}\n", "clean", "function");
 
+   /* --- Objective-C (@interface/@implementation/@protocol → type; a C function and
+    * a simple method → function; members inside the @implementation body) --- */
+   const char *objc = "@interface Widget : NSObject\n@end\n"
+                      "@implementation Widget\n- (void)refresh { redraw(); }\n@end\n"
+                      "void helper(void) {}\n";
+   want(".m", objc, "Widget", "type");
+   want(".m", objc, "refresh", "function"); /* simple (no-arg) method selector */
+   want(".m", objc, "helper", "function");  /* plain C function */
+   want(".mm", "@protocol Drawable\n@end\n", "Drawable", "type");
+
    /* --- nested members: methods inside a type body are surfaced (the walk descends type
     * bodies but never function bodies), across the OO languages. --- */
    want(".cpp", "class C { void m(){} };\n", "m", "function");
@@ -284,6 +294,11 @@ int main(void)
    wantcall(".py", "def f():\n    g()\n    obj.m()\n", "f", "g");
    wantcall(".scala", "object M { def f(): Unit = { g() } }\n", "f", "g");
    wantcall(".groovy", "def f() { g() }\n", "f", "g");
+   /* ObjC: a C call and an ObjC message send [self redraw] both attribute to the
+    * enclosing method (message_expression callee via its `method` field). */
+   wantcall(".m", "@implementation W\n- (void)refresh { redraw(); }\n@end\n", "refresh", "redraw");
+   wantcall(".m", "@implementation W\n- (void)refresh { [self redraw]; }\n@end\n", "refresh",
+            "redraw");
    wantcall(".py", "def f():\n    obj.m()\n", "f", "m");
    wantcall(".js", "function f(){ g(); a.b.c(); }\n", "f", "g");
    wantcall(".js", "function f(){ a.b.c(); }\n", "f", "c"); /* chained -> last id */


### PR DESCRIPTION
## Graph-feedback — S5 PR 3 of 6: Objective-C / Objective-C++ grammar

Adds **Objective-C / Objective-C++** (`.m`/`.mm`) to the opt-in tree-sitter front-end.

- **`classify_objc`**: C `function_definition` (declarator-based, like C); a
  `method_definition` selector via `direct_identifier` (simple no-arg methods —
  keyword/multi-arg selectors a documented follow-up gap); `@interface`/`@implementation`/
  `@protocol` → type (name = first identifier child, before superclass/category). ObjC
  message sends `[obj msg]` → call edges via **`message_expression`** added to
  `is_call_node` (its `method` field is already handled by `call_callee_name`).
  The class/impl/protocol bodies are added to `is_descendable` so methods surface.
- **Makefile**: `ts_objc.o` (no external scanner), fetch prereq, `ts_obj`.
- **fetch-treesitter.sh**: `tree-sitter-grammars/tree-sitter-objc` `@181a81b8`; `.gitignore` entry.
- **test**: `.m`/`.mm` availability + class/method/C-function/protocol defs + a `refresh`→`redraw` call.

Under `#ifdef AIMEE_TREESITTER` (default build unchanged). Local `AIMEE_TREESITTER=1`
**ALL PASS**; default `aimee-kb` links; `make lint` green. CI `treesitter` validates. Persona-reviewed.