### PR TITLE
graph-feedback S5: lock down Kotlin Script (.kts) coverage (Tier-1 4/6)

### DIFF
--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -57,7 +57,7 @@ int main(void)
    const char *avail[] = {".c",     ".h",   ".cpp",    ".cc",     ".hpp",   ".cs", ".py",   ".go",
                           ".js",    ".mjs", ".jsx",    ".ts",     ".tsx",   ".rs", ".java", ".rb",
                           ".php",   ".lua", ".sh",     ".bash",   ".swift", ".kt", ".dart", ".css",
-                          ".scala", ".sc",  ".groovy", ".gradle", ".m",     ".mm"};
+                          ".scala", ".sc",  ".groovy", ".gradle", ".m",     ".mm", ".kts"};
    for (size_t i = 0; i < sizeof(avail) / sizeof(avail[0]); i++)
       assert(code_treesitter_available(avail[i]));
    assert(!code_treesitter_available(".txt"));
@@ -215,6 +215,15 @@ int main(void)
    want(".kt", kt, "shouldWork", "function");
    want(".kt", kt, "identity", "function");
    want(".kt", kt, "shout", "function");
+   /* Kotlin Script (.kts, incl. build.gradle.kts — the trailing .kts extension maps
+    * to the Kotlin grammar): top-level declarations extract even when interleaved
+    * with script-level statements (a val binding + a bare call). */
+   const char *kts = "val cfg = load()\nfun greet() = println(\"hi\")\n"
+                     "class Task { fun run() {} }\n";
+   want(".kts", kts, "greet", "function");
+   want(".kts", kts, "Task", "type");
+   want(".kts", kts, "run", "function"); /* method inside a script-level class */
+   wantcall(".kts", "fun deploy() { publish() }\n", "deploy", "publish");
 
    /* --- Dart (annotated mixin: name survives the leading annotation) --- */
    const char *dart = "void f(){}\nclass C{}\nenum E{a}\n@sealed mixin Foo {}\n";


### PR DESCRIPTION
## Graph-feedback — S5 PR 4 of 6: Kotlin Script

The Tier-1 list includes **Kotlin Script edge cases**. `.kts` **already maps to the
Kotlin grammar** in `code_treesitter.c` (and `build.gradle.kts` resolves to its
trailing `.kts`), so Kotlin Script is already extracted. This PR adds the
**regression coverage that proves and protects it** — no grammar/Makefile/fetch
change is needed.

- A `.kts` script fixture with a top-level `val` binding + a bare call interleaved
  with declarations still yields the top-level `fun`, the `class`, its method, and a
  `deploy`→`publish` call edge. `.kts` added to the availability set.

**Validation**: local `AIMEE_TREESITTER=1` **ALL PASS**; `make lint` green. The CI
`treesitter` job runs it. Test-only (1 file) — no code path changes.