### PR TITLE
graph-feedback S5: Elixir tree-sitter grammar (Tier-1 5/6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ src/vendor/tree-sitter-css/
 src/vendor/tree-sitter-scala/
 src/vendor/tree-sitter-groovy/
 src/vendor/tree-sitter-objc/
+src/vendor/tree-sitter-elixir/

--- a/scripts/fetch-treesitter.sh
+++ b/scripts/fetch-treesitter.sh
@@ -53,6 +53,7 @@ fetch tree-sitter-css        https://github.com/tree-sitter/tree-sitter-css     
 fetch tree-sitter-scala      https://github.com/tree-sitter/tree-sitter-scala      4d081d98670ff6e98ca42c085294fc75eec15e1d
 fetch tree-sitter-groovy     https://github.com/murtaza64/tree-sitter-groovy       deb0dcf8c4544f07564060f6e9b9f6e4b0bfc27d
 fetch tree-sitter-objc       https://github.com/tree-sitter-grammars/tree-sitter-objc 181a81b8f23a2d593e7ab4259981f50122909fda
+fetch tree-sitter-elixir     https://github.com/elixir-lang/tree-sitter-elixir      c4f9f5a15ddad8635ba59a5b99c2e9124e74ad91
 
 echo "fetch-treesitter: done -> $VENDOR/tree-sitter*"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -457,7 +457,8 @@ TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o \
                  $(OBJDIR)/vendor/ts_css.o $(OBJDIR)/vendor/ts_css_scan.o \
                  $(OBJDIR)/vendor/ts_scala.o $(OBJDIR)/vendor/ts_scala_scan.o \
                  $(OBJDIR)/vendor/ts_groovy.o \
-                 $(OBJDIR)/vendor/ts_objc.o
+                 $(OBJDIR)/vendor/ts_objc.o \
+                 $(OBJDIR)/vendor/ts_elixir.o $(OBJDIR)/vendor/ts_elixir_scan.o
 $(OBJDIR)/kb/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
 # code_treesitter.c includes tree_sitter/api.h, which the fetch produces — so on a cold
 # checkout the fetch must run before this object compiles. Order-only: trigger the fetch
@@ -485,7 +486,8 @@ vendor/tree-sitter-dart/src/parser.c vendor/tree-sitter-dart/src/scanner.c \
 vendor/tree-sitter-css/src/parser.c vendor/tree-sitter-css/src/scanner.c \
 vendor/tree-sitter-scala/src/parser.c vendor/tree-sitter-scala/src/scanner.c \
 vendor/tree-sitter-groovy/src/parser.c \
-vendor/tree-sitter-objc/src/parser.c:
+vendor/tree-sitter-objc/src/parser.c \
+vendor/tree-sitter-elixir/src/parser.c vendor/tree-sitter-elixir/src/scanner.c:
 	../scripts/fetch-treesitter.sh
 $(OBJDIR)/vendor/ts_runtime.o: vendor/tree-sitter/lib/src/lib.c
 	@mkdir -p $(OBJDIR)/vendor
@@ -533,6 +535,8 @@ $(eval $(call ts_obj,scala,tree-sitter-scala/src,parser.c))
 $(eval $(call ts_obj,scala_scan,tree-sitter-scala/src,scanner.c))
 $(eval $(call ts_obj,groovy,tree-sitter-groovy/src,parser.c))
 $(eval $(call ts_obj,objc,tree-sitter-objc/src,parser.c))
+$(eval $(call ts_obj,elixir,tree-sitter-elixir/src,parser.c))
+$(eval $(call ts_obj,elixir_scan,tree-sitter-elixir/src,scanner.c))
 endif
 
 # --- Gateway ---

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -41,6 +41,7 @@ const TSLanguage *tree_sitter_css(void);
 const TSLanguage *tree_sitter_scala(void);
 const TSLanguage *tree_sitter_groovy(void);
 const TSLanguage *tree_sitter_objc(void);
+const TSLanguage *tree_sitter_elixir(void);
 
 typedef enum
 {
@@ -63,7 +64,8 @@ typedef enum
    TSL_CSS,
    TSL_SCALA,
    TSL_GROOVY,
-   TSL_OBJC
+   TSL_OBJC,
+   TSL_ELIXIR
 } ts_lang_t;
 
 static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
@@ -115,6 +117,8 @@ static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
         * target; a MATLAB .m simply won't parse cleanly and falls through). */
        {".m", TSL_OBJC, tree_sitter_objc},
        {".mm", TSL_OBJC, tree_sitter_objc},
+       {".ex", TSL_ELIXIR, tree_sitter_elixir},
+       {".exs", TSL_ELIXIR, tree_sitter_elixir},
    };
    for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); i++)
       if (strcmp(ext, map[i].ext) == 0)
@@ -602,7 +606,60 @@ static int classify_objc(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
-static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name_root)
+/* Elixir: def/defmodule are MACRO CALLS, not definition nodes. A `call` whose head
+ * identifier is def/defp/defmacro(p) defines a function; defmodule/defprotocol/defimpl
+ * defines a module (type). Unlike every other classifier this needs the source text
+ * (to read the macro keyword), so classify() threads `content` through to here. The
+ * defined name lives in the first `arguments` child: an alias for a module, a nested
+ * call's identifier for `def foo(x)`, or a bare identifier for a no-arg `def foo`. */
+static int classify_elixir(TSNode node, const char *content, const char **kind, TSNode *name_root)
+{
+   if (strcmp(ts_node_type(node), "call") != 0 || ts_node_named_child_count(node) == 0)
+      return 0;
+   TSNode head = ts_node_named_child(node, 0);
+   if (strcmp(ts_node_type(head), "identifier") != 0)
+      return 0;
+   char macro[16];
+   node_text(head, content, macro, (int)sizeof(macro));
+   int is_fn = strcmp(macro, "def") == 0 || strcmp(macro, "defp") == 0 ||
+               strcmp(macro, "defmacro") == 0 || strcmp(macro, "defmacrop") == 0;
+   int is_mod = strcmp(macro, "defmodule") == 0 || strcmp(macro, "defprotocol") == 0 ||
+                strcmp(macro, "defimpl") == 0;
+   if (!is_fn && !is_mod)
+      return 0;
+   TSNode args;
+   if (!child_of_type(node, "arguments", &args) || ts_node_named_child_count(args) == 0)
+      return 0;
+   TSNode first = ts_node_named_child(args, 0);
+   const char *ft = ts_node_type(first);
+   if (is_mod)
+   {
+      /* module name is an alias (Foo, Foo.Bar) */
+      *name_root = first;
+      *kind = "type";
+      return 1;
+   }
+   /* function: `def foo(x)` -> nested call whose first id is the name; `def foo` -> id */
+   if (strcmp(ft, "call") == 0)
+   {
+      if (ts_node_named_child_count(first) == 0)
+         return 0;
+      *name_root = ts_node_named_child(first, 0);
+   }
+   else if (strcmp(ft, "identifier") == 0)
+   {
+      *name_root = first;
+   }
+   else
+   {
+      return 0; /* guarded defs (when clauses) etc. — a known gap */
+   }
+   *kind = "function";
+   return 1;
+}
+
+static int classify(ts_lang_t lang, TSNode node, const char *content, const char **kind,
+                    TSNode *name_root)
 {
    switch (lang)
    {
@@ -645,6 +702,8 @@ static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name
       return classify_groovy(node, kind, name_root);
    case TSL_OBJC:
       return classify_objc(node, kind, name_root);
+   case TSL_ELIXIR:
+      return classify_elixir(node, content, kind, name_root);
    }
    return 0;
 }
@@ -682,7 +741,11 @@ static int is_descendable(const char *t)
        "closure",
        /* Objective-C: @interface/@implementation/@protocol bodies */
        "class_interface", "class_implementation", "implementation_definition",
-       "protocol_declaration", NULL};
+       "protocol_declaration",
+       /* Elixir: a module is a `call` (defmodule …) whose members live in its do_block;
+        * both must be descended. Safe: visit() halts on any matched function, so a
+        * `def`'s body (also a do_block) is never descended. */
+       "call", "do_block", NULL};
    for (int i = 0; set[i]; i++)
       if (strcmp(t, set[i]) == 0)
          return 1;
@@ -698,7 +761,7 @@ static void visit(ts_lang_t lang, TSNode node, const char *content, definition_t
       return;
    const char *kind = NULL;
    TSNode name_root;
-   int matched = classify(lang, node, &kind, &name_root);
+   int matched = classify(lang, node, content, &kind, &name_root);
    if (matched && !ts_node_is_null(name_root))
    {
       node_text(name_root, content, out[*count].name, (int)sizeof(out[*count].name));
@@ -832,14 +895,16 @@ static void walk_calls(ts_lang_t lang, TSNode node, const char *content, const c
    TSNode nm;
    const char *child_caller = caller;
    char buf[sizeof(out->caller)];
-   if (classify(lang, node, &kind, &nm) && kind && strcmp(kind, "function") == 0 &&
-       !ts_node_is_null(nm))
+   int is_def = classify(lang, node, content, &kind, &nm);
+   if (is_def && kind && strcmp(kind, "function") == 0 && !ts_node_is_null(nm))
    {
       node_text(nm, content, buf, (int)sizeof(buf));
       if (buf[0])
          child_caller = buf; /* calls in this subtree are attributed to this function */
    }
-   if (is_call_node(ts_node_type(node)))
+   /* !is_def: an Elixir `def foo` is itself a `call` node — never emit a definition as a
+    * call (its signature's inner call is skipped for the same reason). */
+   if (is_call_node(ts_node_type(node)) && !is_def)
    {
       char callee[sizeof(out->callee)];
       if (call_callee_name(node, content, callee, (int)sizeof(callee)) && callee[0])

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -54,10 +54,11 @@ int main(void)
    printf("test_code_treesitter:\n");
 
    /* availability gates the dispatch (a representative extension per language). */
-   const char *avail[] = {".c",     ".h",   ".cpp",    ".cc",     ".hpp",   ".cs", ".py",   ".go",
-                          ".js",    ".mjs", ".jsx",    ".ts",     ".tsx",   ".rs", ".java", ".rb",
-                          ".php",   ".lua", ".sh",     ".bash",   ".swift", ".kt", ".dart", ".css",
-                          ".scala", ".sc",  ".groovy", ".gradle", ".m",     ".mm", ".kts"};
+   const char *avail[] = {".c",    ".h",    ".cpp", ".cc",    ".hpp", ".cs",     ".py",
+                          ".go",   ".js",   ".mjs", ".jsx",   ".ts",  ".tsx",    ".rs",
+                          ".java", ".rb",   ".php", ".lua",   ".sh",  ".bash",   ".swift",
+                          ".kt",   ".dart", ".css", ".scala", ".sc",  ".groovy", ".gradle",
+                          ".m",    ".mm",   ".kts", ".ex",    ".exs"};
    for (size_t i = 0; i < sizeof(avail) / sizeof(avail[0]); i++)
       assert(code_treesitter_available(avail[i]));
    assert(!code_treesitter_available(".txt"));
@@ -267,6 +268,17 @@ int main(void)
    want(".m", objc, "helper", "function");  /* plain C function */
    want(".mm", "@protocol Drawable\n@end\n", "Drawable", "type");
 
+   /* --- Elixir (def/defmodule are MACRO CALLS): defmodule → type; def/defp →
+    * function; members live in the module's do_block. --- */
+   const char *elixir = "defmodule Foo do\n"
+                        "  def greet(x) do\n    IO.puts(x)\n  end\n"
+                        "  defp helper do\n    :ok\n  end\n"
+                        "end\n";
+   want(".ex", elixir, "Foo", "type");
+   want(".ex", elixir, "greet", "function");  /* def foo(x) — name from nested call */
+   want(".ex", elixir, "helper", "function"); /* defp foo — name is a bare identifier */
+   want(".exs", "defmodule S do\n  def run, do: :ok\nend\n", "run", "function");
+
    /* --- nested members: methods inside a type body are surfaced (the walk descends type
     * bodies but never function bodies), across the OO languages. --- */
    want(".cpp", "class C { void m(){} };\n", "m", "function");
@@ -308,6 +320,9 @@ int main(void)
    wantcall(".m", "@implementation W\n- (void)refresh { redraw(); }\n@end\n", "refresh", "redraw");
    wantcall(".m", "@implementation W\n- (void)refresh { [self redraw]; }\n@end\n", "refresh",
             "redraw");
+   /* Elixir: a body call attributes to the enclosing def; the `def` macro-call itself
+    * is NOT emitted as a call (the !is_def guard). */
+   wantcall(".ex", "defmodule M do\n  def run do\n    work()\n  end\nend\n", "run", "work");
    wantcall(".py", "def f():\n    obj.m()\n", "f", "m");
    wantcall(".js", "function f(){ g(); a.b.c(); }\n", "f", "g");
    wantcall(".js", "function f(){ a.b.c(); }\n", "f", "c"); /* chained -> last id */


### PR DESCRIPTION
## Graph-feedback — S5 PR 5 of 6: Elixir grammar (the hard case)

Adds **Elixir** (`.ex`/`.exs`). Unlike every other grammar, Elixir's `def`/`defmodule`
are **macro calls**, not definition nodes, so this needs custom handling.

- **`classify()` gains a `content` param** threaded to `classify_elixir` only (the
  sole classifier that must read source text — to distinguish the `def*` macro
  keyword). Every other classifier is unchanged.
- **`classify_elixir`**: a `call` whose head identifier is `def`/`defp`/`defmacro(p)`
  → function; `defmodule`/`defprotocol`/`defimpl` → module (type). The defined name
  is the first `arguments` child — an `alias` for a module, a nested call's
  identifier for `def foo(x)`, a bare identifier for a no-arg `def foo`
  (guard/`when` clauses are a documented gap). `call` + `do_block` added to
  `is_descendable` so a module's members (in its `do_block`) surface.
- **`walk_calls`**: `is_def = classify(...)` gates call emission on `!is_def`, so a
  `def foo` (itself a `call`) is never a spurious call edge; real body calls
  (`work()`, `IO.puts`) still attribute to the enclosing def.
- **Makefile**: `ts_elixir.o` + `ts_elixir_scan.o` (external scanner); fetch prereq; `ts_obj`.
- **fetch**: `elixir-lang/tree-sitter-elixir` `@c4f9f5a1`; `.gitignore` entry.
- **test**: `.ex`/`.exs` availability + `defmodule`/`def`/`defp` defs + a `run`→`work`
  call (proving the macro-call is not itself emitted as a call).

Under `#ifdef AIMEE_TREESITTER` (default build unchanged). Local `AIMEE_TREESITTER=1`
**ALL PASS** (no regression from the `call` descend); default `aimee-kb` links; `make lint` green. Persona-reviewed.
