### PR TITLE
graph-feedback S5: PowerShell tree-sitter grammar (Tier-1 6/6 — final)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ src/vendor/tree-sitter-scala/
 src/vendor/tree-sitter-groovy/
 src/vendor/tree-sitter-objc/
 src/vendor/tree-sitter-elixir/
+src/vendor/tree-sitter-powershell/

--- a/scripts/fetch-treesitter.sh
+++ b/scripts/fetch-treesitter.sh
@@ -54,6 +54,7 @@ fetch tree-sitter-scala      https://github.com/tree-sitter/tree-sitter-scala   
 fetch tree-sitter-groovy     https://github.com/murtaza64/tree-sitter-groovy       deb0dcf8c4544f07564060f6e9b9f6e4b0bfc27d
 fetch tree-sitter-objc       https://github.com/tree-sitter-grammars/tree-sitter-objc 181a81b8f23a2d593e7ab4259981f50122909fda
 fetch tree-sitter-elixir     https://github.com/elixir-lang/tree-sitter-elixir      c4f9f5a15ddad8635ba59a5b99c2e9124e74ad91
+fetch tree-sitter-powershell https://github.com/airbus-cert/tree-sitter-powershell d398441825243b00e317e87e1829b9d6a3e54ce0
 
 echo "fetch-treesitter: done -> $VENDOR/tree-sitter*"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -458,7 +458,8 @@ TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o \
                  $(OBJDIR)/vendor/ts_scala.o $(OBJDIR)/vendor/ts_scala_scan.o \
                  $(OBJDIR)/vendor/ts_groovy.o \
                  $(OBJDIR)/vendor/ts_objc.o \
-                 $(OBJDIR)/vendor/ts_elixir.o $(OBJDIR)/vendor/ts_elixir_scan.o
+                 $(OBJDIR)/vendor/ts_elixir.o $(OBJDIR)/vendor/ts_elixir_scan.o \
+                 $(OBJDIR)/vendor/ts_powershell.o $(OBJDIR)/vendor/ts_powershell_scan.o
 $(OBJDIR)/kb/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
 # code_treesitter.c includes tree_sitter/api.h, which the fetch produces — so on a cold
 # checkout the fetch must run before this object compiles. Order-only: trigger the fetch
@@ -487,7 +488,8 @@ vendor/tree-sitter-css/src/parser.c vendor/tree-sitter-css/src/scanner.c \
 vendor/tree-sitter-scala/src/parser.c vendor/tree-sitter-scala/src/scanner.c \
 vendor/tree-sitter-groovy/src/parser.c \
 vendor/tree-sitter-objc/src/parser.c \
-vendor/tree-sitter-elixir/src/parser.c vendor/tree-sitter-elixir/src/scanner.c:
+vendor/tree-sitter-elixir/src/parser.c vendor/tree-sitter-elixir/src/scanner.c \
+vendor/tree-sitter-powershell/src/parser.c vendor/tree-sitter-powershell/src/scanner.c:
 	../scripts/fetch-treesitter.sh
 $(OBJDIR)/vendor/ts_runtime.o: vendor/tree-sitter/lib/src/lib.c
 	@mkdir -p $(OBJDIR)/vendor
@@ -537,6 +539,8 @@ $(eval $(call ts_obj,groovy,tree-sitter-groovy/src,parser.c))
 $(eval $(call ts_obj,objc,tree-sitter-objc/src,parser.c))
 $(eval $(call ts_obj,elixir,tree-sitter-elixir/src,parser.c))
 $(eval $(call ts_obj,elixir_scan,tree-sitter-elixir/src,scanner.c))
+$(eval $(call ts_obj,powershell,tree-sitter-powershell/src,parser.c))
+$(eval $(call ts_obj,powershell_scan,tree-sitter-powershell/src,scanner.c))
 endif
 
 # --- Gateway ---

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -42,6 +42,7 @@ const TSLanguage *tree_sitter_scala(void);
 const TSLanguage *tree_sitter_groovy(void);
 const TSLanguage *tree_sitter_objc(void);
 const TSLanguage *tree_sitter_elixir(void);
+const TSLanguage *tree_sitter_powershell(void);
 
 typedef enum
 {
@@ -65,7 +66,8 @@ typedef enum
    TSL_SCALA,
    TSL_GROOVY,
    TSL_OBJC,
-   TSL_ELIXIR
+   TSL_ELIXIR,
+   TSL_POWERSHELL
 } ts_lang_t;
 
 static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
@@ -119,6 +121,8 @@ static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
        {".mm", TSL_OBJC, tree_sitter_objc},
        {".ex", TSL_ELIXIR, tree_sitter_elixir},
        {".exs", TSL_ELIXIR, tree_sitter_elixir},
+       {".ps1", TSL_POWERSHELL, tree_sitter_powershell},
+       {".psm1", TSL_POWERSHELL, tree_sitter_powershell},
    };
    for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); i++)
       if (strcmp(ext, map[i].ext) == 0)
@@ -153,7 +157,9 @@ static int is_identifier_type(const char *t)
    return strcmp(t, "identifier") == 0 || strcmp(t, "type_identifier") == 0 ||
           strcmp(t, "field_identifier") == 0 || strcmp(t, "simple_identifier") == 0 ||
           strcmp(t, "constant") == 0 || strcmp(t, "name") == 0 ||
-          strcmp(t, "property_identifier") == 0;
+          strcmp(t, "property_identifier") == 0 ||
+          /* PowerShell: the invoked command name behaves as the callee identifier */
+          strcmp(t, "command_name") == 0;
 }
 
 /* Pre-order DFS for the first descendant whose type is one of the identifier kinds — used
@@ -658,6 +664,34 @@ static int classify_elixir(TSNode node, const char *content, const char **kind, 
    return 1;
 }
 
+/* PowerShell: function_statement/class_method_definition → function, class_statement
+ * → type. The name is a specific child node type (function_name or simple_name), not a
+ * `name` field or a generic identifier, so pull it with child_of_type. Command
+ * invocations are calls (see is_call_node/is_identifier_type for command_name). */
+static int classify_powershell(TSNode node, const char **kind, TSNode *name_root)
+{
+   const char *t = ts_node_type(node);
+   const char *name_type;
+   if (strcmp(t, "function_statement") == 0)
+   {
+      *kind = "function";
+      name_type = "function_name";
+   }
+   else if (strcmp(t, "class_method_definition") == 0)
+   {
+      *kind = "function";
+      name_type = "simple_name";
+   }
+   else if (strcmp(t, "class_statement") == 0)
+   {
+      *kind = "type";
+      name_type = "simple_name";
+   }
+   else
+      return 0;
+   return child_of_type(node, name_type, name_root);
+}
+
 static int classify(ts_lang_t lang, TSNode node, const char *content, const char **kind,
                     TSNode *name_root)
 {
@@ -704,6 +738,8 @@ static int classify(ts_lang_t lang, TSNode node, const char *content, const char
       return classify_objc(node, kind, name_root);
    case TSL_ELIXIR:
       return classify_elixir(node, content, kind, name_root);
+   case TSL_POWERSHELL:
+      return classify_powershell(node, kind, name_root);
    }
    return 0;
 }
@@ -745,7 +781,10 @@ static int is_descendable(const char *t)
        /* Elixir: a module is a `call` (defmodule …) whose members live in its do_block;
         * both must be descended. Safe: visit() halts on any matched function, so a
         * `def`'s body (also a do_block) is never descended. */
-       "call", "do_block", NULL};
+       "call", "do_block",
+       /* PowerShell: top-level defs are wrapped in a statement_list under `program`;
+        * class bodies hold their method definitions */
+       "statement_list", "class_statement", NULL};
    for (int i = 0; set[i]; i++)
       if (strcmp(t, set[i]) == 0)
          return 1;
@@ -854,8 +893,9 @@ static int is_call_node(const char *t)
    return strcmp(t, "call_expression") == 0 || strcmp(t, "call") == 0 ||
           strcmp(t, "method_invocation") == 0 || strcmp(t, "invocation_expression") == 0 ||
           strcmp(t, "function_call") == 0 || strcmp(t, "juxt_function_call") == 0 ||
-          strcmp(t, "message_expression") == 0 || strcmp(t, "function_call_expression") == 0 ||
-          strcmp(t, "member_call_expression") == 0 || strcmp(t, "scoped_call_expression") == 0 ||
+          strcmp(t, "message_expression") == 0 || strcmp(t, "command") == 0 ||
+          strcmp(t, "function_call_expression") == 0 || strcmp(t, "member_call_expression") == 0 ||
+          strcmp(t, "scoped_call_expression") == 0 ||
           strcmp(t, "nullsafe_member_call_expression") == 0 || strcmp(t, "macro_invocation") == 0 ||
           strcmp(t, "object_creation_expression") == 0;
 }

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -58,7 +58,7 @@ int main(void)
                           ".go",   ".js",   ".mjs", ".jsx",   ".ts",  ".tsx",    ".rs",
                           ".java", ".rb",   ".php", ".lua",   ".sh",  ".bash",   ".swift",
                           ".kt",   ".dart", ".css", ".scala", ".sc",  ".groovy", ".gradle",
-                          ".m",    ".mm",   ".kts", ".ex",    ".exs"};
+                          ".m",    ".mm",   ".kts", ".ex",    ".exs", ".ps1",    ".psm1"};
    for (size_t i = 0; i < sizeof(avail) / sizeof(avail[0]); i++)
       assert(code_treesitter_available(avail[i]));
    assert(!code_treesitter_available(".txt"));
@@ -194,6 +194,11 @@ int main(void)
    const char *sh = "foo() { echo hi; }\nfunction bar { echo yo; }\n";
    want(".sh", sh, "foo", "function");
    want(".sh", sh, "bar", "function");
+   /* Bash also has `command`/`command_name`/`statement_list` node types (shared with
+    * PowerShell's additions), but bash defs stay clean (a command is not a def) and
+    * bash CALL extraction is gated off entirely (code_treesitter_calls returns -1 for
+    * TSL_BASH), so the PowerShell node-type additions do not affect bash. */
+   want(".sh", "foo() { helper arg; }\n", "foo", "function"); /* command != spurious def */
 
    /* --- Swift --- */
    const char *swift = "func f(){}\nclass C{}\nstruct S{}\nprotocol P{}\n";
@@ -279,6 +284,15 @@ int main(void)
    want(".ex", elixir, "helper", "function"); /* defp foo — name is a bare identifier */
    want(".exs", "defmodule S do\n  def run, do: :ok\nend\n", "run", "function");
 
+   /* --- PowerShell (function_statement → function; class → type; method → function;
+    * command invocations are the call form) --- */
+   const char *ps = "function Get-Thing {\n  param($x)\n  Write-Host $x\n}\n"
+                    "class Animal {\n  [void] Speak() { Write-Host 'hi' }\n}\n";
+   want(".ps1", ps, "Get-Thing", "function");
+   want(".ps1", ps, "Animal", "type");
+   want(".ps1", ps, "Speak", "function"); /* class method */
+   want(".psm1", "function Export-Data {}\n", "Export-Data", "function");
+
    /* --- nested members: methods inside a type body are surfaced (the walk descends type
     * bodies but never function bodies), across the OO languages. --- */
    want(".cpp", "class C { void m(){} };\n", "m", "function");
@@ -323,6 +337,8 @@ int main(void)
    /* Elixir: a body call attributes to the enclosing def; the `def` macro-call itself
     * is NOT emitted as a call (the !is_def guard). */
    wantcall(".ex", "defmodule M do\n  def run do\n    work()\n  end\nend\n", "run", "work");
+   /* PowerShell: a command invocation inside a function is a call to that command. */
+   wantcall(".ps1", "function Deploy {\n  Publish-Build\n}\n", "Deploy", "Publish-Build");
    wantcall(".py", "def f():\n    obj.m()\n", "f", "m");
    wantcall(".js", "function f(){ g(); a.b.c(); }\n", "f", "g");
    wantcall(".js", "function f(){ a.b.c(); }\n", "f", "c"); /* chained -> last id */


### PR DESCRIPTION
## Graph-feedback — S5 PR 6 of 6: PowerShell grammar (final Tier-1)

Adds **PowerShell** (`.ps1`/`.psm1`) — the **sixth and final** Tier-1 grammar,
completing the §6a coverage-expansion set (Scala, Groovy, Objective-C, Kotlin
Script, Elixir, PowerShell).

- **`classify_powershell`**: `function_statement` + `class_method_definition` →
  function; `class_statement` → type. The name is a specific child node type
  (`function_name` or `simple_name`), not a `name` field or generic identifier, so
  it's pulled with `child_of_type`.
- **Calls**: a command invocation is the call form → `command` added to
  `is_call_node`, and `command_name` to `is_identifier_type` so `call_callee_name`
  resolves the invoked command (e.g. `Publish-Build`).
- **`is_descendable`**: `statement_list` (top-level defs are wrapped in a
  `statement_list` under `program`) + `class_statement` (reach methods).
- **Makefile**: `ts_powershell.o` + `ts_powershell_scan.o` (external scanner); fetch; `ts_obj`.
- **fetch**: `airbus-cert/tree-sitter-powershell` `@d3984418`; `.gitignore` entry.
- **test**: `.ps1`/`.psm1` availability + function/class/method defs + a
  `Deploy`→`Publish-Build` command call.

Under `#ifdef AIMEE_TREESITTER` (default build unchanged). Local `AIMEE_TREESITTER=1`
**ALL PASS** (no regression); default `aimee-kb` links; `make lint` green. Persona-reviewed.
