### PR TITLE
feat(workflow): custom delegate-block editor (Blocks + New)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -347,6 +347,14 @@ paths:
           content:
             application/json:
               schema: { type: object }
+  /workflow/blocks/{name}:
+    put:
+      summary: Create or edit a delegate custom block (blocks.yaml; command executors refused)
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: Updated block catalog, content: { application/json: { schema: { type: object } } } } }
+    delete:
+      summary: Delete a custom delegate block (command blocks are operator-only)
+      responses: { "200": { description: Updated block catalog, content: { application/json: { schema: { type: object } } } } }
   /workflow/defs:
     get:
       summary: List saved workflow definitions

--- a/frontend/src/pages/EditWorkflows.tsx
+++ b/frontend/src/pages/EditWorkflows.tsx
@@ -13,7 +13,24 @@ interface BlockDef {
   custom: boolean;
   requires_input: boolean;
   executor?: string;
+  // custom delegate blocks carry these (editable in the block editor):
+  consumes?: string;
+  persona?: string;
+  prompt?: string;
 }
+
+// Artifact types a custom block may consume/produce (mirrors ARTIFACT_NAMES).
+const ARTIFACT_TYPES = [
+  "none",
+  "proposal",
+  "plan",
+  "branch",
+  "frozen_diff",
+  "pr",
+  "verdict",
+  "approval",
+  "intent",
+];
 interface DefRow {
   name: string;
   valid: boolean;
@@ -256,6 +273,34 @@ async function postJSON<T>(
   });
   return { status: r.status, data: (await r.json()) as T };
 }
+async function sendJSON<T>(
+  method: "PUT" | "DELETE",
+  url: string,
+  body?: unknown,
+): Promise<{ status: number; data: T }> {
+  const r = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json", "X-CSRF-Token": window._csrf || "" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  let data = {} as T;
+  try {
+    data = (await r.json()) as T;
+  } catch {
+    /* empty bodies are fine */
+  }
+  return { status: r.status, data };
+}
+
+// A custom delegate block being created/edited in the block editor.
+interface BlockForm {
+  name: string;
+  consumes: string;
+  produces: string;
+  persona: string;
+  prompt: string;
+  isNew: boolean;
+}
 
 export default function EditWorkflows() {
   const [defs, setDefs] = useState<DefRow[]>([]);
@@ -270,6 +315,8 @@ export default function EditWorkflows() {
   } | null>(null);
   const [loading, setLoading] = useState(false);
   const [personas, setPersonas] = useState<PersonaInfo[]>([]);
+  const [editBlock, setEditBlock] = useState<BlockForm | null>(null);
+  const [blockStatus, setBlockStatus] = useState<string>("");
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   // This tab's selected project (per-tab project space). Held so the workflow
   // context can scope to it; execution-in-project flows through a chat session's
@@ -372,6 +419,79 @@ export default function EditWorkflows() {
     },
     [graph, mutate],
   );
+
+  // ---- custom block editor (delegate blocks; same CRUD pattern as personas) ----
+  const newBlock = useCallback(() => {
+    setBlockStatus("");
+    setEditBlock({
+      name: "",
+      consumes: "none",
+      produces: "branch",
+      persona: "",
+      prompt: "",
+      isNew: true,
+    });
+  }, []);
+
+  const editExistingBlock = useCallback((b: BlockDef) => {
+    setBlockStatus("");
+    setEditBlock({
+      name: b.name,
+      consumes: b.consumes || "none",
+      produces: b.produces || "branch",
+      persona: b.persona || "",
+      prompt: b.prompt || "",
+      isNew: false,
+    });
+  }, []);
+
+  const saveBlock = useCallback(async () => {
+    if (!editBlock) return;
+    const name = editBlock.name.trim();
+    if (!/^[a-z0-9][a-z0-9_.-]*$/i.test(name)) {
+      setBlockStatus("name must be alphanumeric, - _ or .");
+      return;
+    }
+    if (!editBlock.persona.trim() || !editBlock.prompt.trim()) {
+      setBlockStatus("a persona and a prompt are required");
+      return;
+    }
+    const { status: st } = await sendJSON(
+      "PUT",
+      `/api/workflow/blocks/${encodeURIComponent(name)}`,
+      {
+        consumes: editBlock.consumes,
+        produces: editBlock.produces,
+        persona: editBlock.persona,
+        prompt: editBlock.prompt,
+      },
+    );
+    if (st >= 200 && st < 300) {
+      setBlockStatus("");
+      setEditBlock(null);
+      refreshLists();
+    } else {
+      setBlockStatus(`save failed (${st})`);
+    }
+  }, [editBlock, refreshLists]);
+
+  const deleteBlock = useCallback(async () => {
+    if (!editBlock || editBlock.isNew) {
+      setEditBlock(null);
+      return;
+    }
+    if (!window.confirm(`Delete custom block “${editBlock.name}”?`)) return;
+    const { status: st } = await sendJSON(
+      "DELETE",
+      `/api/workflow/blocks/${encodeURIComponent(editBlock.name)}`,
+    );
+    if (st >= 200 && st < 300) {
+      setEditBlock(null);
+      refreshLists();
+    } else {
+      setBlockStatus(`delete failed (${st})`);
+    }
+  }, [editBlock, refreshLists]);
 
   const deleteNode = useCallback(
     (id: string) => {
@@ -545,21 +665,106 @@ export default function EditWorkflows() {
           </div>
         </Panel>
         <Panel title="Blocks" count={blocks.length}>
-          {blocks.map((b) => (
-            <div
-              key={b.name}
-              onClick={() => addNode(b)}
-              title={`produces ${b.produces}`}
-              style={row}
-            >
-              <span>{b.name}</span>
-              <Badge
-                label={b.custom ? "custom" : b.produces}
-                variant={b.custom ? "info" : "neutral"}
-              />
-            </div>
-          ))}
+          <button onClick={newBlock} style={btn}>
+            + New
+          </button>
+          <div style={{ marginTop: 6 }}>
+            {blocks.map((b) => (
+              <div
+                key={b.name}
+                onClick={() => addNode(b)}
+                title={`produces ${b.produces} — click to add to the canvas`}
+                style={row}
+              >
+                <span>{b.name}</span>
+                <span style={{ display: "flex", gap: 4, alignItems: "center" }}>
+                  {b.custom && b.executor === "delegate" && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        editExistingBlock(b);
+                      }}
+                      style={{ ...btnSmall, padding: "0 6px" }}
+                      title="edit this custom block"
+                    >
+                      ✎
+                    </button>
+                  )}
+                  <Badge
+                    label={b.custom ? "custom" : b.produces}
+                    variant={b.custom ? "info" : "neutral"}
+                  />
+                </span>
+              </div>
+            ))}
+          </div>
         </Panel>
+        {editBlock && (
+          <Panel title={editBlock.isNew ? "New custom block" : `Edit block: ${editBlock.name}`}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <label style={lbl}>
+                name
+                <input
+                  style={{ ...inp, width: "100%" }}
+                  value={editBlock.name}
+                  disabled={!editBlock.isNew}
+                  onChange={(e) => setEditBlock({ ...editBlock, name: e.target.value })}
+                />
+              </label>
+              <label style={lbl}>
+                consumes
+                <select
+                  style={{ ...inp, width: "100%" }}
+                  value={editBlock.consumes}
+                  onChange={(e) => setEditBlock({ ...editBlock, consumes: e.target.value })}
+                >
+                  {ARTIFACT_TYPES.map((a) => (
+                    <option key={a} value={a}>
+                      {a}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label style={lbl}>
+                produces
+                <select
+                  style={{ ...inp, width: "100%" }}
+                  value={editBlock.produces}
+                  onChange={(e) => setEditBlock({ ...editBlock, produces: e.target.value })}
+                >
+                  <option value="branch">branch</option>
+                  <option value="none">none</option>
+                </select>
+              </label>
+              <label style={lbl}>
+                persona
+                <input
+                  style={{ ...inp, width: "100%" }}
+                  list="wf-persona-opts"
+                  value={editBlock.persona}
+                  onChange={(e) => setEditBlock({ ...editBlock, persona: e.target.value })}
+                />
+              </label>
+              <label style={lbl}>
+                prompt
+                <textarea
+                  style={{ ...inp, width: "100%", minHeight: 80, fontFamily: "ui-monospace, monospace" }}
+                  value={editBlock.prompt}
+                  onChange={(e) => setEditBlock({ ...editBlock, prompt: e.target.value })}
+                />
+              </label>
+              <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                <button onClick={saveBlock} style={btn}>
+                  Save
+                </button>
+                <button onClick={deleteBlock} style={{ ...btn, color: "#b00" }}>
+                  {editBlock.isNew ? "Cancel" : "Delete"}
+                </button>
+                {blockStatus && <span style={{ fontSize: 12, color: "#b00" }}>{blockStatus}</span>}
+              </div>
+            </div>
+          </Panel>
+        )}
       </div>
 
       {/* center: canvas. minWidth:0 lets this flex item shrink below the 1600px

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -776,6 +776,14 @@ static int rh_wf_blocks(const route_req_t *rq, char *resp, int cap)
    (void)rq;
    return wf_api_blocks(resp, cap);
 }
+static int rh_wf_block_put(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_block_put(rq->id, rq->body, resp, cap);
+}
+static int rh_wf_block_delete(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_block_delete(rq->id, resp, cap);
+}
 static int rh_wf_list(const route_req_t *rq, char *resp, int cap)
 {
    (void)rq;
@@ -2255,6 +2263,9 @@ static const http_route_t g_v1_routes[] = {
      * read work-item run-state. Reads (incl. validate, which never mutates) are
      * dashboard-read; save is session-admin (authoring write). */
     {"GET", "/v1/workflow/blocks", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_blocks},
+    {"PUT", "/v1/workflow/blocks/", NULL, RM_PREFIX, NULL, CAP_SESSION_ADMIN, rh_wf_block_put},
+    {"DELETE", "/v1/workflow/blocks/", NULL, RM_PREFIX, NULL, CAP_SESSION_ADMIN,
+     rh_wf_block_delete},
     {"GET", "/v1/workflow/defs", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_list},
     {"GET", "/v1/workflow/defs/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_get},
     {"POST", "/v1/workflow/validate", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_validate},

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -21,6 +21,7 @@
 #include "cJSON.h"
 #include "server_http_identity.h" /* server_http_identity_principal — ownership scoping */
 #include "wfe_def.h"
+#include "yaml.h" /* yaml_emit — write blocks.yaml */
 #include "wfe_iface.h"
 #include "wfe_store.h"
 
@@ -184,9 +185,17 @@ int wf_api_blocks(char *resp, int cap)
       cJSON *b = cJSON_CreateObject();
       cJSON_AddStringToObject(b, "name", c->name);
       cJSON_AddStringToObject(b, "produces", wfe_artifact_name(c->produces));
+      cJSON_AddStringToObject(b, "consumes", wfe_artifact_name(c->consumes));
       cJSON_AddBoolToObject(b, "custom", 1);
       cJSON_AddStringToObject(b, "executor",
                               c->executor == WFE_EXEC_COMMAND ? "command" : "delegate");
+      /* delegate blocks carry the editable persona + prompt (the UI edits these);
+       * command blocks stay operator-only, so their argv is not surfaced. */
+      if (c->executor == WFE_EXEC_DELEGATE)
+      {
+         cJSON_AddStringToObject(b, "persona", c->persona);
+         cJSON_AddStringToObject(b, "prompt", c->prompt ? c->prompt : "");
+      }
       cJSON_AddBoolToObject(b, "requires_input", c->consumes != WFE_ART_NONE);
       cJSON *acc = cJSON_AddArrayToObject(b, "accepts");
       if (c->consumes != WFE_ART_NONE)
@@ -194,6 +203,194 @@ int wf_api_blocks(char *resp, int cap)
       cJSON_AddItemToArray(arr, b);
    }
    return emit(o, resp, cap);
+}
+
+/* ---- custom block editor (delegate-executor blocks only) ----------------------
+ * The web UI can create/edit reusable DELEGATE custom blocks (a persona + prompt
+ * step) the same way it edits personas/roles. It NEVER writes command-executor
+ * blocks: those run arbitrary argv and stay operator-only via the blocks.yaml
+ * file, so the editor cannot become a remote-code-execution surface. Existing
+ * command blocks are preserved verbatim on every write. */
+
+static int valid_artifact_name(const char *s)
+{
+   for (wfe_artifact_type_t a = WFE_ART_NONE; a < WFE_ART__COUNT; a++)
+      if (strcmp(wfe_artifact_name(a), s) == 0)
+         return 1;
+   return 0;
+}
+
+/* Serialize the current custom-block registry to a cJSON blocks array, preserving
+ * every block (including command blocks) so a write round-trips them untouched. */
+static cJSON *registry_blocks_json(void)
+{
+   char e[256] = "";
+   wfe_custom_registry_ensure(e, sizeof e);
+   cJSON *arr = cJSON_CreateArray();
+   for (int i = 0; i < wfe_custom_count(); i++)
+   {
+      const wfe_custom_block_t *c = wfe_custom_at(i);
+      if (!c)
+         continue;
+      cJSON *b = cJSON_CreateObject();
+      cJSON_AddStringToObject(b, "name", c->name);
+      cJSON_AddStringToObject(b, "consumes", wfe_artifact_name(c->consumes));
+      cJSON_AddStringToObject(b, "produces", wfe_artifact_name(c->produces));
+      if (c->executor == WFE_EXEC_COMMAND)
+      {
+         cJSON_AddStringToObject(b, "executor", "command");
+         cJSON *cmd = cJSON_AddArrayToObject(b, "command");
+         for (int j = 0; c->argv[j]; j++)
+            cJSON_AddItemToArray(cmd, cJSON_CreateString(c->argv[j]));
+      }
+      else
+      {
+         cJSON_AddStringToObject(b, "executor", "delegate");
+         cJSON_AddStringToObject(b, "persona", c->persona);
+         cJSON_AddStringToObject(b, "prompt", c->prompt ? c->prompt : "");
+      }
+      cJSON_AddItemToArray(arr, b);
+   }
+   return arr;
+}
+
+/* Emit {blocks: arr} to $AIMEE_HOME/workflows/blocks.yaml atomically (temp +
+ * rename, operator-owned 0600) and reload the registry. Returns 0 or -1+err. */
+static int write_blocks_and_reload(cJSON *arr, char *err_buf, size_t errlen)
+{
+   cJSON *root = cJSON_CreateObject();
+   /* Preserve the operator's top-level settings so a UI delegate-block write can't
+    * disable existing command blocks by dropping their gate. */
+   if (wfe_custom_commands_allowed())
+      cJSON_AddBoolToObject(root, "allow_command", 1);
+   cJSON_AddNumberToObject(root, "command_timeout_ms", wfe_custom_command_timeout_ms());
+   cJSON_AddItemToObject(root, "blocks", arr); /* takes ownership of arr */
+   char *yaml = yaml_emit(root);
+   cJSON_Delete(root);
+   if (!yaml)
+   {
+      snprintf(err_buf, errlen, "yaml emit failed");
+      return -1;
+   }
+   char dir[1024], path[1100], tmp[1160];
+   snprintf(dir, sizeof dir, "%s/workflows", aimee_home());
+   mkdir(dir, 0700);
+   snprintf(path, sizeof path, "%s/blocks.yaml", dir);
+   snprintf(tmp, sizeof tmp, "%s.tmp", path);
+   int fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
+   if (fd < 0)
+   {
+      free(yaml);
+      snprintf(err_buf, errlen, "cannot open blocks.yaml for write");
+      return -1;
+   }
+   size_t len = strlen(yaml);
+   ssize_t wr = write(fd, yaml, len);
+   close(fd);
+   free(yaml);
+   if (wr < 0 || (size_t)wr != len)
+   {
+      unlink(tmp);
+      snprintf(err_buf, errlen, "blocks.yaml write failed");
+      return -1;
+   }
+   if (rename(tmp, path) != 0)
+   {
+      unlink(tmp);
+      snprintf(err_buf, errlen, "blocks.yaml rename failed");
+      return -1;
+   }
+   return wfe_custom_registry_load(path, err_buf, errlen);
+}
+
+int wf_api_block_put(const char *name, const char *body, char *resp, int cap)
+{
+   if (!name || !name[0] || !safe_name(name))
+      return err(resp, cap, 400, "invalid block name");
+   if (wfe_block_from_name(name) != WFE_BLK_UNKNOWN)
+      return err(resp, cap, 409, "name shadows a built-in block");
+
+   cJSON *req = body ? cJSON_Parse(body) : NULL;
+   if (!req)
+      return err(resp, cap, 400, "invalid JSON body");
+   const cJSON *jc = cJSON_GetObjectItemCaseSensitive(req, "consumes");
+   const cJSON *jp = cJSON_GetObjectItemCaseSensitive(req, "produces");
+   const cJSON *jper = cJSON_GetObjectItemCaseSensitive(req, "persona");
+   const cJSON *jpr = cJSON_GetObjectItemCaseSensitive(req, "prompt");
+   const char *consumes = cJSON_IsString(jc) && jc->valuestring[0] ? jc->valuestring : "none";
+   const char *produces = cJSON_IsString(jp) && jp->valuestring[0] ? jp->valuestring : "none";
+   const char *persona = cJSON_IsString(jper) ? jper->valuestring : "";
+   const char *prompt = cJSON_IsString(jpr) ? jpr->valuestring : "";
+
+   int bad = 0;
+   const char *why = "";
+   if (strcmp(produces, "branch") != 0 && strcmp(produces, "none") != 0)
+   {
+      bad = 1;
+      why = "produces must be 'branch' or 'none'";
+   }
+   else if (!valid_artifact_name(consumes))
+   {
+      bad = 1;
+      why = "unknown consumes type";
+   }
+   else if (!persona[0] || !prompt[0])
+   {
+      bad = 1;
+      why = "delegate block needs a persona and a prompt";
+   }
+   if (bad)
+   {
+      cJSON_Delete(req);
+      return err(resp, cap, 400, why);
+   }
+
+   cJSON *arr = registry_blocks_json();
+   for (int i = cJSON_GetArraySize(arr) - 1; i >= 0; i--)
+   {
+      cJSON *b = cJSON_GetArrayItem(arr, i);
+      const cJSON *n = cJSON_GetObjectItemCaseSensitive(b, "name");
+      if (cJSON_IsString(n) && strcmp(n->valuestring, name) == 0)
+         cJSON_DeleteItemFromArray(arr, i);
+   }
+   cJSON *nb = cJSON_CreateObject();
+   cJSON_AddStringToObject(nb, "name", name);
+   cJSON_AddStringToObject(nb, "consumes", consumes);
+   cJSON_AddStringToObject(nb, "produces", produces);
+   cJSON_AddStringToObject(nb, "executor", "delegate");
+   cJSON_AddStringToObject(nb, "persona", persona);
+   cJSON_AddStringToObject(nb, "prompt", prompt);
+   cJSON_AddItemToArray(arr, nb);
+   cJSON_Delete(req);
+
+   char e[256] = "";
+   if (write_blocks_and_reload(arr, e, sizeof e) != 0)
+      return err(resp, cap, 500, e[0] ? e : "could not save block");
+   return wf_api_blocks(resp, cap);
+}
+
+int wf_api_block_delete(const char *name, char *resp, int cap)
+{
+   if (!name || !name[0] || !safe_name(name))
+      return err(resp, cap, 400, "invalid block name");
+   const wfe_custom_block_t *ex = wfe_custom_lookup(name);
+   if (!ex)
+      return err(resp, cap, 404, "custom block not found");
+   if (ex->executor == WFE_EXEC_COMMAND)
+      return err(resp, cap, 403, "command blocks are operator-managed (edit blocks.yaml)");
+
+   cJSON *arr = registry_blocks_json();
+   for (int i = cJSON_GetArraySize(arr) - 1; i >= 0; i--)
+   {
+      cJSON *b = cJSON_GetArrayItem(arr, i);
+      const cJSON *n = cJSON_GetObjectItemCaseSensitive(b, "name");
+      if (cJSON_IsString(n) && strcmp(n->valuestring, name) == 0)
+         cJSON_DeleteItemFromArray(arr, i);
+   }
+   char e[256] = "";
+   if (write_blocks_and_reload(arr, e, sizeof e) != 0)
+      return err(resp, cap, 500, e[0] ? e : "could not delete block");
+   return wf_api_blocks(resp, cap);
 }
 
 int wf_api_list(char *resp, int cap)

--- a/src/server/server_workflow_api.h
+++ b/src/server/server_workflow_api.h
@@ -10,6 +10,12 @@
  * config-defined custom registry) with each block's typed I/O for the palette. */
 int wf_api_blocks(char *resp, int cap);
 
+/* Create/edit a delegate custom block (blocks.yaml). body is JSON
+ * {consumes, produces, persona, prompt}; command executors are refused. */
+int wf_api_block_put(const char *name, const char *body, char *resp, int cap);
+/* Delete a custom delegate block (command blocks are operator-only). */
+int wf_api_block_delete(const char *name, char *resp, int cap);
+
 /* GET /v1/workflow/defs -- list saved workflow definitions under
  * $AIMEE_HOME/workflows (name + valid + version). */
 int wf_api_list(char *resp, int cap);

--- a/src/tests/support/workflow_api_stub.c
+++ b/src/tests/support/workflow_api_stub.c
@@ -17,6 +17,17 @@ int wf_api_blocks(char *resp, int cap)
 {
    return stub(resp, cap);
 }
+int wf_api_block_put(const char *name, const char *body, char *resp, int cap)
+{
+   (void)name;
+   (void)body;
+   return stub(resp, cap);
+}
+int wf_api_block_delete(const char *name, char *resp, int cap)
+{
+   (void)name;
+   return stub(resp, cap);
+}
 int wf_api_list(char *resp, int cap)
 {
    return stub(resp, cap);

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -369,6 +369,60 @@ int main(void)
       g_test_principal = "";
    }
 
+   /* --- custom delegate-block CRUD: write blocks.yaml + reload round-trip, and
+    * preserve an existing operator command block untouched --- */
+   {
+      char p[256];
+      snprintf(p, sizeof p, "%s/blocks.yaml", wfdir);
+      FILE *f = fopen(p, "wb");
+      assert(f);
+      fputs("allow_command: true\nblocks:\n  - name: lintcmd\n    consumes: branch\n"
+            "    produces: branch\n    executor: command\n    command:\n      - /bin/true\n",
+            f);
+      fclose(f);
+      chmod(p, 0600);
+      wfe_custom_registry_reset();
+
+      const char *body = "{\"consumes\":\"proposal\",\"produces\":\"branch\","
+                         "\"persona\":\"architect\",\"prompt\":\"Refine the proposal.\"}";
+      assert(wf_api_block_put("refine", body, buf, CAP) == 200);
+      assert(wf_api_blocks(buf, CAP) == 200);
+      {
+         cJSON *o = parse_resp(buf);
+         cJSON *blocks = cJSON_GetObjectItemCaseSensitive(o, "blocks");
+         cJSON *b = NULL, *found = NULL;
+         cJSON_ArrayForEach(b, blocks)
+         {
+            cJSON *n = cJSON_GetObjectItemCaseSensitive(b, "name");
+            if (cJSON_IsString(n) && strcmp(n->valuestring, "refine") == 0)
+               found = b;
+         }
+         assert(found);
+         assert(strcmp(cJSON_GetObjectItemCaseSensitive(found, "executor")->valuestring,
+                       "delegate") == 0);
+         assert(strcmp(cJSON_GetObjectItemCaseSensitive(found, "persona")->valuestring,
+                       "architect") == 0);
+         /* the operator's command block survived the write */
+         assert(has_block(blocks, "lintcmd", NULL));
+         cJSON_Delete(o);
+      }
+      /* validation: shadow a built-in → 409, missing persona/prompt → 400, bad name → 400 */
+      assert(wf_api_block_put("merge", body, buf, CAP) == 409);
+      assert(wf_api_block_put("bad", "{\"consumes\":\"none\"}", buf, CAP) == 400);
+      assert(wf_api_block_put("a/b", body, buf, CAP) == 400);
+      /* a UI delete of the command block is refused (operator-managed) */
+      assert(wf_api_block_delete("lintcmd", buf, CAP) == 403);
+      /* delete the delegate block */
+      assert(wf_api_block_delete("refine", buf, CAP) == 200);
+      assert(wf_api_blocks(buf, CAP) == 200);
+      {
+         cJSON *o = parse_resp(buf);
+         assert(!has_block(cJSON_GetObjectItemCaseSensitive(o, "blocks"), "refine", NULL));
+         assert(has_block(cJSON_GetObjectItemCaseSensitive(o, "blocks"), "lintcmd", NULL));
+         cJSON_Delete(o);
+      }
+   }
+
    free(buf);
    printf("ok\n");
    return 0;

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -182,6 +182,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 
 	// Workflow visual composer (W7): proxy to aimee-server /v1/workflow/*.
 	mux.HandleFunc("/api/workflow/blocks", s.requireAuth(s.handleWorkflowBlocks))
+	mux.HandleFunc("/api/workflow/blocks/", s.requireAuth(s.handleWorkflowBlockItem))
 	mux.HandleFunc("/api/workflow/defs", s.requireAuth(s.handleWorkflowDefs))
 	mux.HandleFunc("/api/workflow/defs/", s.requireAuth(s.handleWorkflowDefs))
 	mux.HandleFunc("/api/workflow/validate", s.requireAuth(s.handleWorkflowValidate))

--- a/webchat/workflow.go
+++ b/webchat/workflow.go
@@ -60,6 +60,46 @@ func (s *server) handleWorkflowBlocks(w http.ResponseWriter, r *http.Request) {
 	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/blocks", "")
 }
 
+// PUT/DELETE /api/workflow/blocks/<name> — create/edit or delete a custom
+// delegate block. proxyWorkflow forwards a body only for POST, so this item
+// handler forwards PUT bodies itself; seg-validated + body-capped, then handed
+// to the admin-gated /v1 route (which refuses command executors).
+func (s *server) handleWorkflowBlockItem(w http.ResponseWriter, r *http.Request) {
+	seg := strings.TrimPrefix(r.URL.Path, "/api/workflow/blocks/")
+	if seg == "" || strings.Contains(seg, "/") || strings.Contains(seg, "..") || strings.Contains(seg, "%") {
+		writeJSONError(w, http.StatusBadRequest, "bad block name")
+		return
+	}
+	var method string
+	var body []byte
+	switch r.Method {
+	case http.MethodPut:
+		method = http.MethodPut
+		const maxBody = 1 << 20
+		body, _ = io.ReadAll(io.LimitReader(r.Body, maxBody+1))
+		if len(body) > maxBody {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request too large")
+			return
+		}
+	case http.MethodDelete:
+		method = http.MethodDelete
+	default:
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	st, data, err := s.v1Request(ctx, method, "/v1/workflow/blocks/"+seg, body)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprintf(w, `{"error":"workflow service unreachable"}`)
+		return
+	}
+	w.WriteHeader(st)
+	w.Write(data)
+}
+
 // GET /api/workflow/defs        — list definitions
 // GET /api/workflow/defs/<name> — one definition (canonical + version + graph)
 func (s *server) handleWorkflowDefs(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Follow-up to #1005: the **Blocks "+ New"** in Edit Workflows now creates a real, editable custom block — the same list → +New → edit-fields → save pattern personas and roles use — instead of dropping a node on the canvas.

## Safe by construction
Custom blocks come in two executor kinds: **`delegate`** (runs a persona + prompt — safe) and **`command`** (arbitrary argv — RCE). The web UI **only ever writes `delegate` blocks**; command blocks stay operator-managed via the `blocks.yaml` file. So the editor adds no remote-code-execution surface:
- `wf_api_block_put` hardcodes `executor: delegate` and requires a persona + prompt; it never writes a command.
- `wf_api_block_delete` refuses to delete a command block (403).
- Every write **preserves** existing command blocks and the operator's top-level `allow_command` / `command_timeout_ms` verbatim.

## Backend
- `PUT`/`DELETE /v1/workflow/blocks/{name}` (`CAP_SESSION_ADMIN`) → upsert/delete a delegate block: build the block set from the registry, `yaml_emit` to `blocks.yaml` atomically (temp+rename, operator-owned `0600`), reload the registry (round-trips through the same parser). Validates: name safe + not shadowing a built-in, `produces ∈ {branch,none}`, known `consumes`, persona+prompt present.
- `wf_api_blocks` now surfaces `consumes`/`persona`/`prompt` for delegate blocks so the editor can populate.
- webchat proxies `/api/workflow/blocks/{name}` (PUT body-forwarded; seg-validated).

## Frontend (Edit Workflows → Blocks)
- **+ New** → an inline block editor (name, consumes, produces, persona picker, prompt) → Save/Delete.
- Custom delegate blocks get a ✎ edit affordance; clicking a block still adds it to the canvas; built-ins and command blocks stay read-only.

## Tests / build
New `test_wfe_webapi` case: create a delegate block → it round-trips through `blocks.yaml` + reload with persona/prompt; an operator command block is preserved; shadow-builtin→409, missing fields→400, bad name→400, delete-command→403. Full `aimee-server` + `webchat` build; frontend `tsc`+`vite`; `clang-format-19` + `make lint` (conformance/routes/openapi) clean.