### PR TITLE
docs: add official aimee Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,11 @@ Focused references:
 | [VS Code Integration](docs/VSCODE.md) | Wire aimee into VS Code via MCP tools or as an OpenAI compatible model |
 | [Feature Status](docs/STATUS.md) | Implementation status of all features |
 
+## Community
+
+Questions, help, and discussion happen on the **official aimee Discord**:
+<https://discord.gg/FjGjvcgAqz>.
+
 ## License
 
 aimee is Copyright (C) 2026 The aimee authors and is licensed under the **GNU Affero General

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -367,3 +367,4 @@ For per-client cryptographic identity (not just a shared bearer), the server als
 - **[Setting Up Delegates](DELEGATES.md)**, configure delegate agents and routing.
 - **[Architecture](ARCHITECTURE.md)**, processes, storage boundaries, and deployment topologies.
 - **Run on any model**, point Claude Code (`aimee claude-proxy enable`), Codex, or any OpenAI-compatible tool at aimee and run every turn on your chosen primary model; see the [README](../README.md#any-model-behind-your-front-end).
+- **Get help**, join the official aimee Discord at <https://discord.gg/FjGjvcgAqz> for questions and discussion.


### PR DESCRIPTION
Adds the official aimee Discord (https://discord.gg/FjGjvcgAqz) to the docs.

- **README.md**: new **Community** section above License.
- **docs/QUICKSTART.md**: a *Get help* bullet in Next steps.