### PR TITLE
feat(webui): Settings page for all typed Aimee config options

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import EditWorkflows from './pages/EditWorkflows';
 import WorkflowActions from './pages/WorkflowActions';
 import Agents from './pages/Agents';
 import Personas from './pages/Personas';
+import Settings from './pages/Settings';
 import Projects from './pages/Projects';
 import Graph from './pages/Graph';
 import Editor from './pages/Editor';
@@ -72,6 +73,7 @@ const NAV_ITEMS: Tab[] = [
   { label: 'Projects', icon: '📁', route: '/projects' },
   { label: 'Graph', icon: '🕸️', route: '/graph' },
   { label: 'Editor', icon: '🖥️', route: '/editor' },
+  { label: 'Settings', icon: '⚙️', route: '/settings' },
 ];
 
 /* Top bar: one tab per session. A session bundles a chat + the project it runs
@@ -247,6 +249,7 @@ export default function App() {
                 <Route path="/projects" element={<Projects />} />
                 <Route path="/graph" element={<Graph />} />
                 <Route path="/editor" element={<Editor />} />
+                <Route path="/settings" element={<Settings />} />
                 <Route path="*" element={<Navigate to="/chat" replace />} />
               </Routes>
             </ErrorBoundary>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Panel, Badge } from "@rakuensoftware/smoothgui";
+
+/* Settings page: every typed Aimee config option (the config_fields allowlist,
+ * e.g. typed_facts_enabled, kb_pdf_*, memory_*, autonomous). Values come from
+ * GET /api/config (config.show); a change persists to aimee.yaml via POST
+ * /api/config/set and takes effect on the next turn. The control is inferred
+ * from the value's JSON type: boolean → toggle, number → number field, string →
+ * text field. */
+
+type Val = boolean | number | string;
+
+async function getJSON<T>(url: string): Promise<T> {
+  const r = await fetch(url, { headers: { "X-CSRF-Token": window._csrf || "" } });
+  return (await r.json()) as T;
+}
+async function postJSON<T>(url: string, body: unknown): Promise<{ status: number; data: T }> {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-CSRF-Token": window._csrf || "" },
+    body: JSON.stringify(body),
+  });
+  let data = {} as T;
+  try {
+    data = (await r.json()) as T;
+  } catch {
+    /* empty */
+  }
+  return { status: r.status, data };
+}
+
+// Friendly label from a snake_case key: "typed_facts_enabled" → "Typed facts enabled".
+function humanize(key: string): string {
+  const s = key.replace(/_/g, " ").trim();
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// Group a key into a settings section. Heuristic prefix map + an "Other" catch-all;
+// the search box covers anything the grouping misses.
+function category(key: string): string {
+  const rules: [RegExp, string][] = [
+    [/^kb_pdf/, "Knowledge — PDF ingest"],
+    [/^(kb_|typed_facts)/, "Knowledge base"],
+    [/^memory/, "Memory"],
+    [/^(ingress|gateway|tool_output|code_span|context|fold|compact)/, "Gateway & context"],
+    [/^(audit|governance|decision|guardrail)/, "Audit & governance"],
+    [/^(provider|openai|anthropic|model|delegate|agent|roundtable)/, "Providers & delegates"],
+    [/^(autonomous|cross_verify|ecomode|max_iterations|reasoning|verify|autopilot|trigger)/, "Agent behavior"],
+    [/^(learning|intelligence|calibrat|bandit)/, "Learning & intelligence"],
+    [/^(kb_curator|curator|synth|embed|rerank|extract|index)/, "Knowledge curation"],
+  ];
+  for (const [re, name] of rules) if (re.test(key)) return name;
+  return "Other";
+}
+
+const btn: React.CSSProperties = {
+  padding: "3px 10px",
+  fontSize: 12,
+  borderRadius: 6,
+  border: "1px solid #ccc",
+  background: "#fff",
+  cursor: "pointer",
+};
+const input: React.CSSProperties = {
+  fontFamily: "ui-monospace, monospace",
+  fontSize: 12,
+  padding: "3px 6px",
+  borderRadius: 6,
+  border: "1px solid #ccc",
+  boxSizing: "border-box",
+};
+
+export default function Settings() {
+  const [values, setValues] = useState<Record<string, Val>>({});
+  const [draft, setDraft] = useState<Record<string, Val>>({});
+  const [loaded, setLoaded] = useState(false);
+  const [filter, setFilter] = useState("");
+  const [status, setStatus] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
+
+  const refresh = useCallback(() => {
+    getJSON<{ config?: Record<string, Val> }>("/api/config")
+      .then((d) => {
+        setValues(d.config || {});
+        setDraft(d.config || {});
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const save = useCallback(
+    async (key: string) => {
+      const { status: st, data } = await postJSON<{ error?: string; notice?: string; value?: Val }>(
+        "/api/config/set",
+        { key, value: draft[key] },
+      );
+      if (st >= 200 && st < 300 && !data.error) {
+        const v = data.value !== undefined ? data.value : draft[key];
+        setValues((p) => ({ ...p, [key]: v }));
+        setDraft((p) => ({ ...p, [key]: v }));
+        setStatus({ kind: "ok", msg: data.notice ? data.notice : `${key} saved` });
+      } else {
+        setStatus({ kind: "err", msg: data.error || `save failed (${st})` });
+      }
+    },
+    [draft],
+  );
+
+  // Group + filter the fields for rendering.
+  const groups = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    const keys = Object.keys(values)
+      .filter((k) => !q || k.toLowerCase().includes(q) || humanize(k).toLowerCase().includes(q))
+      .sort();
+    const byCat: Record<string, string[]> = {};
+    for (const k of keys) (byCat[category(k)] ||= []).push(k);
+    return Object.entries(byCat).sort(([a], [b]) => a.localeCompare(b));
+  }, [values, filter]);
+
+  return (
+    <div style={{ padding: 16, fontFamily: "system-ui", height: "100%", overflow: "auto" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12, flexWrap: "wrap" }}>
+        <strong style={{ fontSize: 18 }}>Settings</strong>
+        <Badge label={`${Object.keys(values).length}`} variant="neutral" />
+        <input
+          placeholder="filter settings…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          style={{ ...input, fontFamily: "system-ui", minWidth: 220 }}
+        />
+        <button onClick={refresh} style={btn}>
+          Reload
+        </button>
+        {status && (
+          <span
+            style={{
+              fontSize: 12,
+              color: status.kind === "err" ? "#b00" : "#080",
+              maxWidth: 620,
+            }}
+          >
+            {status.msg}
+          </span>
+        )}
+      </div>
+      <p style={{ fontSize: 12, color: "#666", margin: "0 0 12px" }}>
+        Changes persist to <code>aimee.yaml</code> and take effect on the next turn.
+      </p>
+
+      {!loaded && <div style={{ color: "#888" }}>loading…</div>}
+      {loaded && Object.keys(values).length === 0 && (
+        <div style={{ color: "#888" }}>No configurable options available (aimee-server unreachable?).</div>
+      )}
+
+      <div style={{ display: "grid", gap: 12 }}>
+        {groups.map(([cat, keys]) => (
+          <Panel key={cat} title={cat} count={keys.length}>
+            <div style={{ display: "grid", gap: 6 }}>
+              {keys.map((k) => (
+                <SettingRow
+                  key={k}
+                  fieldKey={k}
+                  value={draft[k]}
+                  dirty={draft[k] !== values[k]}
+                  onChange={(v) => setDraft((p) => ({ ...p, [k]: v }))}
+                  onSave={() => save(k)}
+                  onReset={() => setDraft((p) => ({ ...p, [k]: values[k] }))}
+                />
+              ))}
+            </div>
+          </Panel>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SettingRow({
+  fieldKey,
+  value,
+  dirty,
+  onChange,
+  onSave,
+  onReset,
+}: {
+  fieldKey: string;
+  value: Val;
+  dirty: boolean;
+  onChange: (v: Val) => void;
+  onSave: () => void;
+  onReset: () => void;
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+      <label style={{ flex: "1 1 260px", minWidth: 200, fontSize: 13 }} title={fieldKey}>
+        {humanize(fieldKey)}
+        <span style={{ color: "#aaa", fontSize: 11, marginLeft: 6 }}>{fieldKey}</span>
+      </label>
+      <div style={{ flex: "0 0 auto", display: "flex", alignItems: "center", gap: 6 }}>
+        {typeof value === "boolean" ? (
+          <button
+            onClick={() => onChange(!value)}
+            style={{
+              ...btn,
+              minWidth: 44,
+              background: value ? "#1f7a3d" : "#fff",
+              color: value ? "#fff" : "#555",
+            }}
+          >
+            {value ? "on" : "off"}
+          </button>
+        ) : typeof value === "number" ? (
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => onChange(e.target.value === "" ? 0 : Number(e.target.value))}
+            style={{ ...input, width: 120 }}
+          />
+        ) : (
+          <input
+            value={value ?? ""}
+            onChange={(e) => onChange(e.target.value)}
+            style={{ ...input, width: 220, fontFamily: "system-ui" }}
+          />
+        )}
+        {dirty && (
+          <>
+            <button onClick={onSave} style={{ ...btn, borderColor: "#2563eb", color: "#2563eb" }}>
+              save
+            </button>
+            <button onClick={onReset} style={btn} title="discard change">
+              ↺
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webchat/config_api.go
+++ b/webchat/config_api.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// handleConfigAll proxies GET /v1/config (config.show) — every typed config
+// field and its current value — for the full Settings page. Degrades to an
+// empty object so the page renders when aimee-server is unreachable.
+func (s *server) handleConfigAll(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	st, data, err := s.v1Request(ctx, http.MethodGet, "/v1/config", nil)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil || st != http.StatusOK {
+		fmt.Fprintf(w, `{"config":{}}`)
+		return
+	}
+	w.Write(data)
+}
+
+// handleConfigSet proxies POST /api/config/set {key,value} -> /v1/config/set.
+// The server validates the key against config_fields and persists aimee.yaml;
+// the response may include a "notice" (e.g. the claude-CLI-delegate warning).
+func (s *server) handleConfigSet(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	const maxBody = 1 << 16
+	body, _ := io.ReadAll(io.LimitReader(r.Body, maxBody+1))
+	if len(body) > maxBody {
+		writeJSONError(w, http.StatusRequestEntityTooLarge, "request too large")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	st, data, err := s.v1Request(ctx, http.MethodPost, "/v1/config/set", body)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "config service unreachable")
+		return
+	}
+	w.WriteHeader(st)
+	w.Write(data)
+}

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -154,6 +154,9 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/chat/personas/", s.requireAuth(s.handleChatPersonaItem))
 	mux.HandleFunc("/api/chat/persona", s.requireAuth(s.handleChatPersona))
 	mux.HandleFunc("/api/settings", s.requireAuth(s.handleSettings))
+	// Full typed config surface for the Settings page.
+	mux.HandleFunc("/api/config", s.requireAuth(s.handleConfigAll))
+	mux.HandleFunc("/api/config/set", s.requireAuth(s.handleConfigSet))
 	mux.HandleFunc("/api/chat/attach", s.requireAuth(s.handleChatAttach))
 	mux.HandleFunc("/api/chat/detach", s.requireAuth(s.handleChatDetach))
 	mux.HandleFunc("/api/chat/session-events", s.requireAuth(s.handleChatSessionEvents))


### PR DESCRIPTION
A full **Settings** tab exposing every typed Aimee config option (the `config_fields.c` allowlist — 135 fields incl. `typed_facts_enabled`, `kb_pdf_*`, `memory_*`, `autonomous`, `provider`, …), replacing the need to shell into `aimee config set`. The existing 5-field quick panel stays.

## No server changes — reuses the config API
- `GET /api/config` → `config.show` (all fields + current values)
- `POST /api/config/set {key,value}` → `config.set` (the server validates the key against `config_fields` and persists `aimee.yaml`; the response `notice` is surfaced, e.g. the Claude-CLI-delegate warning).

## Frontend (`Settings.tsx`)
- Control inferred from the value's JSON type: **boolean → toggle, number → number field, string → text field**.
- Fields grouped into sections (Knowledge base, Memory, Gateway & context, Agent behavior, Providers & delegates, …) with a **live filter** and per-field **save / reset**.
- Nav tab ⚙️ at `/settings`.
- Changes persist to `aimee.yaml` and take effect on the next turn.

## Build
`webchat` go build / vet / test + gofmt clean; frontend `tsc` + `vite` clean. (`webchat/config.go` untouched — the proxies live in a new `config_api.go`.)