### PR TITLE
feat(economizer): S1 — gateway-mutation config flags + startup consistency

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -207,7 +207,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `compress`, `delegate_seam`, `freeze_guard`, `freeze_guard_horizon`, `gateway_seam`, `history_fold`, `measure`
+- **`reduce`** — `compress`, `delegate_seam`, `freeze_guard`, `freeze_guard_horizon`, `gateway_mutate`, `gateway_seam`, `gateway_session_disable_ttl_ms`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/src/config.c
+++ b/src/config.c
@@ -562,6 +562,11 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_gateway_seam = 0;
    cfg->reduce_freeze_guard_enabled = 1; /* safety: on for the default-on economizer freeze */
    cfg->reduce_freeze_guard_horizon = 1; /* conservative break-even: one reuse pays the write */
+   /* Gateway MUTATION (primary-agent reduction) is the whole feature default-OFF; the
+    * session-disable TTL is a live-path breaker window (1h) that must stay > 0. */
+   cfg->reduce_gateway_mutate = 0;
+   cfg->reduce_gateway_session_disable_ttl_ms = 3600000;
+   cfg->reduce_gateway_seam_explicit = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;
@@ -1184,6 +1189,7 @@ int config_load(config_t *cfg)
    config_parse_worktree_gc_section(cfg, root);
    config_parse_fold_section(cfg, root);
    config_parse_reduce_section(cfg, root);
+   config_apply_reduce_consistency(cfg); /* mutate=1 -> auto-enable shadow seam in memory + WARN */
 
    config_parse_memory_section(cfg, root);
    config_apply_learning_settings(cfg, root);

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -289,8 +289,13 @@ static const char *config_save_default_db1_path(void)
 static int reduce_has_non_default(const config_t *cfg)
 {
    return !cfg->reduce_measure_enabled || !cfg->reduce_delegate_seam || !cfg->reduce_history_fold ||
-          !cfg->reduce_compress || cfg->reduce_gateway_seam || !cfg->reduce_freeze_guard_enabled ||
-          (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1);
+          !cfg->reduce_compress ||
+          (cfg->reduce_gateway_seam && cfg->reduce_gateway_seam_explicit) ||
+          !cfg->reduce_freeze_guard_enabled ||
+          (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1) ||
+          cfg->reduce_gateway_mutate ||
+          (cfg->reduce_gateway_session_disable_ttl_ms != 3600000 &&
+           cfg->reduce_gateway_session_disable_ttl_ms > 0);
 }
 
 int config_save(const config_t *cfg)
@@ -1026,12 +1031,23 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(reduce, "history_fold", 0);
       if (!cfg->reduce_compress)
          cJSON_AddBoolToObject(reduce, "compress", 0);
-      if (cfg->reduce_gateway_seam)
+      /* gateway_seam: persist ONLY when the operator set it explicitly, never when
+       * config_load synthesized it from gateway_mutate=1 (that stays an in-memory
+       * normalization, re-applied each load). */
+      if (cfg->reduce_gateway_seam && cfg->reduce_gateway_seam_explicit)
          cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
       if (!cfg->reduce_freeze_guard_enabled) /* default-on -> persist only when disabled */
          cJSON_AddBoolToObject(reduce, "freeze_guard", 0);
       if (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1)
          cJSON_AddNumberToObject(reduce, "freeze_guard_horizon", cfg->reduce_freeze_guard_horizon);
+      /* gateway_mutate defaults OFF -> persist only when enabled. TTL defaults 1h ->
+       * persist only a non-default positive override (a bad <=0 is never written). */
+      if (cfg->reduce_gateway_mutate)
+         cJSON_AddBoolToObject(reduce, "gateway_mutate", cfg->reduce_gateway_mutate);
+      if (cfg->reduce_gateway_session_disable_ttl_ms != 3600000 &&
+          cfg->reduce_gateway_session_disable_ttl_ms > 0)
+         cJSON_AddNumberToObject(reduce, "gateway_session_disable_ttl_ms",
+                                 cfg->reduce_gateway_session_disable_ttl_ms);
    }
 
    /* Session/worktree cleanup policy (only save if non-default) */

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -766,7 +766,11 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
       cfg->reduce_gateway_mutate = cJSON_IsTrue(item) ? 1 : 0;
    item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_session_disable_ttl_ms");
    if (cJSON_IsNumber(item))
-      cfg->reduce_gateway_session_disable_ttl_ms = (int)item->valuedouble;
+      /* Use cJSON's pre-narrowed valueint (clamped to INT_MIN..INT_MAX at parse) —
+       * casting an out-of-range valuedouble to int is UB, and a fractional value
+       * truncates. A resulting <=0 (incl. a truncated 0.x) is caught startup-fatal
+       * by config_reduce_validate(). */
+      cfg->reduce_gateway_session_disable_ttl_ms = item->valueint;
    item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard");
    if (cJSON_IsBool(item))
       cfg->reduce_freeze_guard_enabled = cJSON_IsTrue(item) ? 1 : 0;
@@ -783,14 +787,18 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
 /* Normalize economizer gateway-mutation invariants IN MEMORY after parse. mutate=1
  * requires the shadow seam so the validation gates always have a same-payload
  * baseline: auto-enable reduce_gateway_seam in memory (never rewriting the file)
- * and WARN once per (uncached) load. A config left at seam=0,mutate=1 repeats the
- * WARN each start until corrected. Does NOT touch reduce_gateway_seam_explicit, so
- * config_save still omits the synthesized seam. */
+ * and WARN. config_load is mtime-cached, so this runs (and warns) once per uncached
+ * load; a config left at seam=0,mutate=1 repeats the WARN each fresh start until
+ * corrected. Synthesizing the seam also FORCES reduce_gateway_seam_explicit=0 so
+ * config_save never persists the synthesized value — even when the file explicitly
+ * set gateway_seam:false alongside mutate:true (mutate wins in memory, but the
+ * operator's on-disk false is not silently rewritten to true). */
 void config_apply_reduce_consistency(config_t *cfg)
 {
    if (cfg->reduce_gateway_mutate && !cfg->reduce_gateway_seam)
    {
       cfg->reduce_gateway_seam = 1;
+      cfg->reduce_gateway_seam_explicit = 0; /* synthesized -> not persistable */
       fprintf(stderr,
               "aimee: config warning: reduce.gateway_mutate=1 requires reduce.gateway_seam; "
               "auto-enabling the shadow seam in memory (set reduce.gateway_seam: true to "

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -757,7 +757,16 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
       cfg->reduce_compress = cJSON_IsTrue(item) ? 1 : 0;
    item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_seam");
    if (cJSON_IsBool(item))
+   {
       cfg->reduce_gateway_seam = cJSON_IsTrue(item) ? 1 : 0;
+      cfg->reduce_gateway_seam_explicit = 1; /* operator set it -> config_save may persist it */
+   }
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_mutate");
+   if (cJSON_IsBool(item))
+      cfg->reduce_gateway_mutate = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_session_disable_ttl_ms");
+   if (cJSON_IsNumber(item))
+      cfg->reduce_gateway_session_disable_ttl_ms = (int)item->valuedouble;
    item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard");
    if (cJSON_IsBool(item))
       cfg->reduce_freeze_guard_enabled = cJSON_IsTrue(item) ? 1 : 0;
@@ -769,6 +778,42 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
          h = FREEZE_GUARD_MAX_HORIZON; /* clamp at parse so on-disk == runtime */
       cfg->reduce_freeze_guard_horizon = h;
    }
+}
+
+/* Normalize economizer gateway-mutation invariants IN MEMORY after parse. mutate=1
+ * requires the shadow seam so the validation gates always have a same-payload
+ * baseline: auto-enable reduce_gateway_seam in memory (never rewriting the file)
+ * and WARN once per (uncached) load. A config left at seam=0,mutate=1 repeats the
+ * WARN each start until corrected. Does NOT touch reduce_gateway_seam_explicit, so
+ * config_save still omits the synthesized seam. */
+void config_apply_reduce_consistency(config_t *cfg)
+{
+   if (cfg->reduce_gateway_mutate && !cfg->reduce_gateway_seam)
+   {
+      cfg->reduce_gateway_seam = 1;
+      fprintf(stderr,
+              "aimee: config warning: reduce.gateway_mutate=1 requires reduce.gateway_seam; "
+              "auto-enabling the shadow seam in memory (set reduce.gateway_seam: true to "
+              "silence this)\n");
+   }
+}
+
+/* Startup-fatal validation for the live gateway-mutation path (see config.h). The
+ * disable-window TTL must be > 0; 0/negative would make a circuit-broken session a
+ * permanent pin (or, negative, an immediately-expired no-op breaker) on live client
+ * traffic, which the design rejects rather than silently clamps. */
+int config_reduce_validate(const config_t *cfg, char *err, size_t errlen)
+{
+   if (cfg->reduce_gateway_session_disable_ttl_ms <= 0)
+   {
+      if (err && errlen)
+         snprintf(err, errlen,
+                  "reduce.gateway_session_disable_ttl_ms must be > 0 (got %d); 0/negative is a "
+                  "permanent-pin/disabled breaker on the live /v1 path",
+                  cfg->reduce_gateway_session_disable_ttl_ms);
+      return 1;
+   }
+   return 0;
 }
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -945,6 +945,17 @@ typedef struct config
     *   (default-off) economizer freeze is live, so no default-path behavior change.
     * reduce_freeze_guard_horizon: expected reuse turns for the break-even estimate
     *   (0 -> 1; clamped to FREEZE_GUARD_MAX_HORIZON).
+    * reduce_gateway_mutate: APPLY the reduction to the live inbound /v1 request (the
+    *   primary-agent path) instead of only measuring it — compress-only, behind a
+    *   per-session circuit breaker (msg_session_disable), buffered 4xx-restore-resend +
+    *   streaming disable-subsequent-turns. Default-OFF (the whole gateway-mutation
+    *   feature). mutate=1 implies gateway_seam=1: config_load auto-enables the shadow
+    *   seam IN MEMORY (never rewriting the file) + logs one WARN, so the shadow baseline
+    *   the validation gates compare against always exists.
+    * reduce_gateway_session_disable_ttl_ms: how long a circuit-broken session stays
+    *   disabled (default 3600000 = 1h). MUST be > 0 — 0/negative is a startup-fatal
+    *   config error (a permanent-pin/breaker-off knob on a live path is disproportionate
+    *   runtime risk); validated by config_reduce_validate() at server startup.
     * (Other per-lever gates and min_gain land in later slices.) */
    int reduce_measure_enabled;
    int reduce_delegate_seam;
@@ -953,6 +964,12 @@ typedef struct config
    int reduce_gateway_seam;
    int reduce_freeze_guard_enabled;
    int reduce_freeze_guard_horizon;
+   int reduce_gateway_mutate;
+   int reduce_gateway_session_disable_ttl_ms;
+   /* Runtime-only (NOT parsed as a key, NOT persisted): 1 iff the operator set the
+    * reduce.gateway_seam key explicitly. Lets config_save persist gateway_seam only
+    * when the user chose it, never when config_load synthesized it from mutate=1. */
+   int reduce_gateway_seam_explicit;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned
@@ -1699,6 +1716,15 @@ static inline int config_issue(const char *fmt, ...)
 /* Load config from default path. Returns defaults if missing.
  * In strict mode, returns -1 on validation errors. */
 int config_load(config_t *cfg);
+
+/* Validate the economizer gateway-mutation invariants that are STARTUP-FATAL (as
+ * opposed to the in-memory normalizations config_load already applied). Currently:
+ * reduce_gateway_session_disable_ttl_ms must be > 0. Returns 0 if valid, non-zero
+ * if the live gateway-mutation path must not start; on failure writes a human
+ * message into err (when err != NULL). Called at server startup so a bad value
+ * refuses to bring up the live /v1 path, without breaking unrelated CLI callers
+ * of config_load. Pure (reads cfg only). */
+int config_reduce_validate(const config_t *cfg, char *err, size_t errlen);
 
 /* Resolve the effective operating mode (engineer/novel) for the running
  * process. Precedence: the AIMEE_MODE environment variable (the propagation

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -22,6 +22,7 @@ void config_parse_memory_maintenance_section(config_t *cfg, cJSON *root);
 void config_parse_worktree_gc_section(config_t *cfg, cJSON *root);
 void config_parse_fold_section(config_t *cfg, cJSON *root);
 void config_parse_reduce_section(config_t *cfg, cJSON *root);
+void config_apply_reduce_consistency(config_t *cfg);
 void config_parse_memory_section(config_t *cfg, cJSON *root);
 void config_parse_cross_verify_section(config_t *cfg, cJSON *root);
 void config_parse_retry_section(config_t *cfg, cJSON *root);

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -164,6 +164,19 @@ static int run_server(const char *socket_path, log_level_t log_level)
    config_t cfg;
    config_load(&cfg);
 
+   /* Startup-fatal validation for the live gateway-mutation path: an invalid
+    * session-disable TTL (<=0) must refuse to bring up the /v1 server rather than
+    * pin/disable the breaker on live client traffic. Scoped to server startup so
+    * unrelated CLI callers of config_load are unaffected. */
+   {
+      char cfg_err[256];
+      if (config_reduce_validate(&cfg, cfg_err, sizeof(cfg_err)) != 0)
+      {
+         fprintf(stderr, "aimee: fatal config error: %s\n", cfg_err);
+         return 1;
+      }
+   }
+
    /* Remote aimee-kb: when a kb_client_url is configured (this host uses a
     * remote kb rather than a local sidecar), export it into our own env so the
     * env-based kb_client transport (kb_client_v1_base_url / auth_header)

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -176,6 +176,15 @@ int main(void)
       cfg.reduce_gateway_seam = 0;
       config_apply_reduce_consistency(&cfg);
       assert(cfg.reduce_gateway_seam == 0);
+      /* seam:false + mutate:true — synthesis must CLEAR explicit so config_save
+       * never rewrites the operator's on-disk false to true. */
+      memset(&cfg, 0, sizeof(cfg));
+      cfg.reduce_gateway_mutate = 1;
+      cfg.reduce_gateway_seam = 0;
+      cfg.reduce_gateway_seam_explicit = 1; /* operator wrote gateway_seam: false */
+      config_apply_reduce_consistency(&cfg);
+      assert(cfg.reduce_gateway_seam == 1);          /* mutate wins in memory */
+      assert(cfg.reduce_gateway_seam_explicit == 0); /* but not persistable */
    }
 
    /* --- startup-fatal TTL validation: <=0 rejected, >0 accepted --- */

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -99,6 +99,98 @@ int main(void)
       assert(strcmp(cfg2.coord_closet_denylist, "secretword") == 0);
    }
 
+   /* --- gateway mutation: defaults --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      assert(cfg.reduce_gateway_mutate == 0);
+      assert(cfg.reduce_gateway_session_disable_ttl_ms == 3600000);
+      assert(cfg.reduce_gateway_seam_explicit == 0);
+   }
+
+   /* --- mutate=1 auto-enables the shadow seam IN MEMORY + does NOT persist the
+    * synthesized gateway_seam: save {mutate:1} (no seam), reload, and confirm seam
+    * was re-synthesized (==1) while seam_explicit stayed 0 (proving the key was not
+    * written to disk — a persisted key would set explicit on parse). --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      cfg.reduce_gateway_mutate = 1;
+      cfg.reduce_gateway_seam = 0;
+      cfg.reduce_gateway_seam_explicit = 0;
+      assert(config_save(&cfg) == 0);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.reduce_gateway_mutate == 1);        /* mutate persisted */
+      assert(cfg2.reduce_gateway_seam == 1);          /* auto-enabled in memory */
+      assert(cfg2.reduce_gateway_seam_explicit == 0); /* synthesized, NOT persisted */
+   }
+
+   /* --- an explicitly-set gateway_seam DOES persist (and carries explicit=1) --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      cfg.reduce_gateway_mutate = 0;
+      cfg.reduce_gateway_seam = 1;
+      cfg.reduce_gateway_seam_explicit = 1;
+      assert(config_save(&cfg) == 0);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.reduce_gateway_seam == 1);
+      assert(cfg2.reduce_gateway_seam_explicit == 1);
+   }
+
+   /* --- non-default disable TTL round-trips; default (1h) is not persisted --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      cfg.reduce_gateway_session_disable_ttl_ms = 7200000; /* 2h override */
+      assert(config_save(&cfg) == 0);
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.reduce_gateway_session_disable_ttl_ms == 7200000);
+   }
+
+   /* --- consistency hook is a pure in-memory normalization --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      cfg.reduce_gateway_mutate = 1;
+      cfg.reduce_gateway_seam = 0;
+      cfg.reduce_gateway_seam_explicit = 0;
+      config_apply_reduce_consistency(&cfg);
+      assert(cfg.reduce_gateway_seam == 1);
+      assert(cfg.reduce_gateway_seam_explicit == 0);
+      /* idempotent + no downgrade when mutate is off */
+      memset(&cfg, 0, sizeof(cfg));
+      cfg.reduce_gateway_mutate = 0;
+      cfg.reduce_gateway_seam = 0;
+      config_apply_reduce_consistency(&cfg);
+      assert(cfg.reduce_gateway_seam == 0);
+   }
+
+   /* --- startup-fatal TTL validation: <=0 rejected, >0 accepted --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      char err[256];
+      cfg.reduce_gateway_session_disable_ttl_ms = 3600000;
+      assert(config_reduce_validate(&cfg, err, sizeof(err)) == 0);
+      cfg.reduce_gateway_session_disable_ttl_ms = 0;
+      assert(config_reduce_validate(&cfg, err, sizeof(err)) != 0);
+      cfg.reduce_gateway_session_disable_ttl_ms = -5;
+      assert(config_reduce_validate(&cfg, err, sizeof(err)) != 0);
+   }
+
    /* restore env */
    if (old_home)
    {


### PR DESCRIPTION
Slice 1 of the **economizer gateway mutation** proposal (`docs/proposals/pending/economizer-gateway-mutation.md`, step 1). Adds the default-OFF config surface so later slices can wire the actual reduction. **Zero behavior change at defaults.**

## What
- `reduce.gateway_mutate` (default `0`) — apply reduction to the live inbound `/v1` request (the primary-agent path).
- `reduce.gateway_session_disable_ttl_ms` (default `3600000` = 1h) — per-session circuit-breaker window.
- `mutate=1` auto-enables the shadow `gateway_seam` **in memory** + one `WARN` (`config_apply_reduce_consistency`); never rewrites the file. A new runtime-only `reduce_gateway_seam_explicit` flag stops `config_save` from persisting the synthesized seam (only an operator-set `gateway_seam` round-trips; a `gateway_seam:false` + `gateway_mutate:true` file is not silently flipped to `true`).
- `ttl<=0` is **startup-fatal on the live path**: `config_reduce_validate()` is checked at server startup (`run_server`), so a bad value refuses to bring up `/v1` without breaking unrelated CLI callers of `config_load`.
- `config_save` round-trips all keys; `docs/gen/configuration.md` regenerated.

## Tests
`tests/test_config_economizer.c`: defaults; mutate auto-enable **not** persisted; explicit-seam persists; `seam:false`+`mutate:true` synthesis clears explicit; TTL round-trip; consistency-hook idempotence; `ttl<=0` rejected.

## Review
Roundtable-reviewed (non-degraded panel). Fixed: synthesized-seam-explicit-clear (prevents `config_save` overriding an operator's on-disk `gateway_seam:false`); TTL parsed via `valueint` to avoid out-of-range `(int)double` UB.

Part of a slice series; each slice default-OFF and independently reviewed.