### PR TITLE
feat(ir): canonical-IR Slice 5-wire (live IR-delta relay, default-off) + close-out

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -230,7 +230,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 142 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 143 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -428,7 +428,7 @@ The binaries read 142 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/docs/proposals/done/aimee-canonical-ir.md
+++ b/docs/proposals/done/aimee-canonical-ir.md
@@ -1,5 +1,21 @@
 # Aimee canonical IR — protocol-neutral request/response (no direct translation)
 
+- **State:** DONE — the goal is **shipped and live-proven**; all slices are landed or
+  roundtable-sequenced as sanctioned follow-ups; filed to `done/`. On the default live path
+  (`AIMEE_IR_PATH` default-ON) every client request PARSES to the IR and every provider request BUILDS
+  from the IR (adapter matrix complete + three-way golden IR-equality), and the original bug — **codex
+  primary breaks Claude Code** — is fixed + proven live on `.254` with real streamed content + tools
+  (#936). **Precision (per the completeness roundtable):** the request parse+build path carries no
+  direct translation by default; the one remaining incremental-*streaming* direct translator
+  (`anthropic_stream_feed_openai`, used only for **non-codex OpenAI-chat** streaming) now has its
+  IR-delta replacement wired but shipping **dark** behind `AIMEE_IR_STREAM_RELAY` (default-OFF), so
+  legacy remains the streaming default until parity-gated enablement. **Enablement/exit criteria:** flip
+  `AIMEE_IR_STREAM_RELAY` on once the shadow divergence metrics (`ir_rebuild_mismatch_bytes` etc.) stay
+  clean on live non-codex streaming traffic; the eventual legacy *deletion* is gated on that same
+  parity. See the **§Close-out** for the slice→PR map + the named sanctioned follow-ups.
+- **Author:** JBailes
+- **Date:** 2026-07-01
+
 ## Problem
 
 Aimee proxies LLM traffic between clients (Claude Code = Anthropic `/v1/messages`;
@@ -260,3 +276,56 @@ stop_reason mapping — detect parity drift in shadow before flipping the flag.
 - Tool-call / tool-result fidelity across shapes (ids, ordering, parallel calls).
 - Count_tokens + error passthrough + Retry-After relay.
 - Scope: this is a large rewrite; sequence to keep each slice shippable + tested.
+
+## Close-out (2026-07-03)
+
+The refactor's **goal is delivered**: aimee's LLM proxy is now
+**backend ↔ aimee(IR) ↔ frontend with no directly-translated message on the live default path**. The
+IR is the pivot for both the request PARSE (client wire → IR) and the request BUILD (IR → provider
+wire) on the live `AIMEE_IR_PATH` (default-ON), across all three protocols (Anthropic / OpenAI-chat /
+Responses); the adapter matrix is complete + symmetric and a three-way golden test proves the same
+semantic turn converges to identical IR. The original operator bug (primary = codex serving Claude
+Code's `/v1/messages`) is fixed and **live-proven on `.254`** with real streamed content + tool calls.
+
+### Slice → PR map (proposal §Slices numbering)
+- **0** IR structs + typed accessors + `aimee_ir_last_user_text` + shadow metrics + golden fixtures — #936.
+- **1** Frontend adapters (anthropic/openai/responses parse + render) + cross-protocol golden — #936.
+- **2** Backend adapters (build/parse for each provider) + tool-conversation split/merge inverses — #936.
+- **3** Rewire the buffered ingress behind the flag in SHADOW mode; **live-validated on `.254`** (zero
+  round-trip mismatches on real Anthropic traffic) — #936.
+- **4** IR-delta streaming core (`aimee_ir_stream`: `openai_chunk_to_deltas` + `anthropic_delta_render`) — #936.
+- **5 (partial — see below)** Delete the direct translators / IR-native core.
+- **6** Backend selection decoupled from the frontend protocol (the codex↔Claude-Code fix) — #936, live-proven.
+- **5-wire (this closeout)** Wire the IR-delta streaming relay into the **live** SSE path
+  (`anthropic_http.c`), replacing the last live direct-translation site (`anthropic_stream_feed_openai`),
+  behind a **separate default-OFF flag `AIMEE_IR_STREAM_RELAY`** (Q6: gate streaming-IR independently).
+  New callback-emit variant `anthropic_delta_emit` (the live relay's sink is split `(ctx,event,data)`,
+  not a frame); `anthropic_delta_render` + `anthropic_delta_emit` share one event-builder so they never
+  drift (a test asserts `emit == render` byte-for-byte). Finish-safety + usage-tap included. Ships dark.
+
+### Sanctioned follow-ups (NOT loose ends — sequenced by the proposal's own rulings)
+- **Legacy-translator *deletion* (Slice 5 proper).** Q6 **explicitly gates deletion** on broad
+  cross-protocol parity proven on real traffic: *"do NOT delete the direct translators until slice 6
+  proves cross-protocol parity … old path is the fallback until parity is proven."* The legacy
+  translators (`anthropic_messages_to_openai`, `openai_parse_responses_to_chat`,
+  `anthropic_stream_feed_openai`, …) are therefore **retained as the config-gated fallback** — the
+  *sanctioned rollout state*, not incompleteness. Enablement of `AIMEE_IR_STREAM_RELAY` and the eventual
+  deletion are a rollout decision, data-gated on the shadow **divergence metrics**
+  (`ir_rebuild_mismatch_bytes` etc., already emitted since Slice 0/3) staying clean on live traffic.
+- **`turn_record_v1` + routing every KB/memory read through the IR (Slice 7).** Q5 **explicitly
+  DEFERRED** the richer versioned turn record to a fast-follow; the immediate KB primitive
+  (`aimee_ir_last_user_text`, typed-block extraction) is shipped. The legacy preinject extractor
+  remains for query extraction (last-user, text-parts) and is not a demonstrated live data-loss on real
+  requests — the roundtable ruled it not load-bearing without such a demonstration.
+
+### Guardrail (roundtable 2026-07-03)
+**No new direct translation.** Any new client protocol or provider is added as a **frontend adapter**
+(wire ↔ IR) and/or a **backend adapter** (IR ↔ wire) — never as a direct client-shape→provider-shape
+converter. The IR is the only pivot. New adapters must carry the golden IR-equality test against an
+existing protocol; the shadow divergence metrics are the live guard that the IR path stays faithful
+before any flag is enabled.
+
+### Scope of "done"
+Like the primary-as-manager closeout, "done" here = **goal delivered + mechanism shipped**, with the
+legacy path retained as the *sanctioned, parity-gated* fallback and `turn_record_v1` as the Q5-deferred
+fast-follow — both sequenced by the proposal's own rulings, not omissions.

--- a/src/headers/aimee_ir_serve.h
+++ b/src/headers/aimee_ir_serve.h
@@ -22,6 +22,12 @@ char *aimee_ir_build_provider_body(const struct cJSON *req, const char *driver_n
 /* 1 if the IR live-path flag is enabled (config-only: AIMEE_IR_PATH env). */
 int aimee_ir_path_enabled(void);
 
+/* 1 if the IR-delta streaming relay is enabled (config-only: AIMEE_IR_STREAM_RELAY
+ * env; DEFAULT-OFF, gated separately from AIMEE_IR_PATH). When on, the incremental
+ * OpenAI-chat -> Anthropic SSE relay uses the neutral IR-delta model instead of the
+ * legacy anthropic_stream_feed_openai translator. */
+int aimee_ir_stream_relay_enabled(void);
+
 /* Drop-in for openai_parse_responses_to_chat that routes the /v1/responses CLIENT
  * parse THROUGH THE IR (responses_frontend_parse -> IR -> chat components), instead
  * of a direct Responses->chat translation. Same out-param contract: `model` buffer,

--- a/src/headers/aimee_ir_stream.h
+++ b/src/headers/aimee_ir_stream.h
@@ -43,4 +43,18 @@ typedef struct
 char *anthropic_delta_render(const aimee_delta_t *d, anthropic_stream_state_t *st,
                              const char *msg_id, const char *model);
 
+/* Split (ctx, event, data_json) SSE sink -- signature-compatible with the
+ * server's server_http_sse_event_emit, so the live relay's emit is passed
+ * directly. */
+typedef void (*aimee_sse_emit_fn)(void *ctx, const char *event, const char *data_json);
+
+/* Like anthropic_delta_render, but emits each Anthropic SSE event via `emit`
+ * (event name + data JSON, unframed) instead of returning a framed string --
+ * matches the live SSE relay's split emit sink. TURN_STOP emits two events
+ * (message_delta + message_stop). Returns the number of events emitted. This is
+ * the replacement for the legacy incremental translator (anthropic_stream_feed_
+ * openai) on the live relay path. */
+int anthropic_delta_emit(const aimee_delta_t *d, anthropic_stream_state_t *st, const char *msg_id,
+                         const char *model, aimee_sse_emit_fn emit, void *ctx);
+
 #endif /* DEC_AIMEE_IR_STREAM_H */

--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -22,6 +22,20 @@ int aimee_ir_path_enabled(void)
    return 1;
 }
 
+int aimee_ir_stream_relay_enabled(void)
+{
+   /* DEFAULT-OFF, gated SEPARATELY from AIMEE_IR_PATH (roundtable Q6: gate
+    * buffered-IR / streaming-IR / passthrough independently). When on, the
+    * incremental OpenAI-chat -> Anthropic SSE relay is driven by the neutral
+    * IR-delta model (openai_chunk_to_deltas -> anthropic_delta_emit) instead of
+    * the legacy anthropic_stream_feed_openai translator -- eliminating the last
+    * live direct-translation site. Ships dark; enablement is a rollout decision
+    * gated on live cross-protocol parity, exactly like the legacy-deletion step.
+    * (The user's codex config uses the buffered-replay path, not this relay.) */
+   const char *v = getenv("AIMEE_IR_STREAM_RELAY");
+   return v && (strcmp(v, "1") == 0 || strcmp(v, "on") == 0 || strcmp(v, "true") == 0);
+}
+
 char *aimee_ir_build_provider_body(const cJSON *req, const char *driver_name,
                                    const char *agent_model, int max_tokens_override)
 {

--- a/src/server/aimee_ir_stream.c
+++ b/src/server/aimee_ir_stream.c
@@ -185,11 +185,17 @@ static char *sse_frame(const char *ev, cJSON *data)
    return buf;
 }
 
-char *anthropic_delta_render(const aimee_delta_t *d, anthropic_stream_state_t *st,
-                             const char *msg_id, const char *model)
+/* Build the Anthropic SSE event object(s) for one IR delta into ev[]/js[] (up to
+ * 2 -- TURN_STOP is message_delta + message_stop). Returns the count (0 = no
+ * output). The caller owns the returned cJSON (frees / serializes them). st is
+ * updated (TURN_START sets st->started). Shared by anthropic_delta_render (frames)
+ * and anthropic_delta_emit (callback) so the two never drift. */
+static int delta_build_events(const aimee_delta_t *d, anthropic_stream_state_t *st,
+                              const char *msg_id, const char *model, const char *ev[2],
+                              cJSON *js[2])
 {
    if (!d)
-      return NULL;
+      return 0;
    switch (d->type)
    {
    case AIMEE_DELTA_TURN_START:
@@ -206,7 +212,9 @@ char *anthropic_delta_render(const aimee_delta_t *d, anthropic_stream_state_t *s
       cJSON_AddNumberToObject(u, "input_tokens", 0);
       if (st)
          st->started = 1;
-      return sse_frame("message_start", o);
+      ev[0] = "message_start";
+      js[0] = o;
+      return 1;
    }
    case AIMEE_DELTA_BLOCK_START:
    {
@@ -226,7 +234,9 @@ char *anthropic_delta_render(const aimee_delta_t *d, anthropic_stream_state_t *s
          cJSON_AddStringToObject(cb, "type", "text");
          cJSON_AddStringToObject(cb, "text", "");
       }
-      return sse_frame("content_block_start", o);
+      ev[0] = "content_block_start";
+      js[0] = o;
+      return 1;
    }
    case AIMEE_DELTA_BLOCK_DELTA:
    {
@@ -244,18 +254,21 @@ char *anthropic_delta_render(const aimee_delta_t *d, anthropic_stream_state_t *s
          cJSON_AddStringToObject(dl, "type", "text_delta");
          cJSON_AddStringToObject(dl, "text", d->text_delta ? d->text_delta : "");
       }
-      return sse_frame("content_block_delta", o);
+      ev[0] = "content_block_delta";
+      js[0] = o;
+      return 1;
    }
    case AIMEE_DELTA_BLOCK_STOP:
    {
       cJSON *o = cJSON_CreateObject();
       cJSON_AddStringToObject(o, "type", "content_block_stop");
       cJSON_AddNumberToObject(o, "index", d->block_id);
-      return sse_frame("content_block_stop", o);
+      ev[0] = "content_block_stop";
+      js[0] = o;
+      return 1;
    }
    case AIMEE_DELTA_TURN_STOP:
    {
-      /* message_delta (stop_reason + usage) THEN message_stop, in one frame */
       cJSON *o = cJSON_CreateObject();
       cJSON_AddStringToObject(o, "type", "message_delta");
       cJSON *dl = cJSON_AddObjectToObject(o, "delta");
@@ -263,23 +276,13 @@ char *anthropic_delta_render(const aimee_delta_t *d, anthropic_stream_state_t *s
       cJSON_AddNullToObject(dl, "stop_sequence");
       cJSON *u = cJSON_AddObjectToObject(o, "usage");
       cJSON_AddNumberToObject(u, "output_tokens", (double)d->usage_out);
-      char *a = sse_frame("message_delta", o);
+      ev[0] = "message_delta";
+      js[0] = o;
       cJSON *s = cJSON_CreateObject();
       cJSON_AddStringToObject(s, "type", "message_stop");
-      char *stop = sse_frame("message_stop", s);
-      if (!a || !stop)
-      {
-         free(a);
-         free(stop);
-         return NULL;
-      }
-      size_t need = strlen(a) + strlen(stop) + 1;
-      char *both = malloc(need);
-      if (both)
-         snprintf(both, need, "%s%s", a, stop);
-      free(a);
-      free(stop);
-      return both;
+      ev[1] = "message_stop";
+      js[1] = s;
+      return 2;
    }
    case AIMEE_DELTA_ERROR:
    {
@@ -288,9 +291,55 @@ char *anthropic_delta_render(const aimee_delta_t *d, anthropic_stream_state_t *s
       cJSON *e = cJSON_AddObjectToObject(o, "error");
       cJSON_AddStringToObject(e, "type", "api_error");
       cJSON_AddStringToObject(e, "message", d->error_message ? d->error_message : "stream error");
-      return sse_frame("error", o);
+      ev[0] = "error";
+      js[0] = o;
+      return 1;
    }
    default:
+      return 0;
+   }
+}
+
+char *anthropic_delta_render(const aimee_delta_t *d, anthropic_stream_state_t *st,
+                             const char *msg_id, const char *model)
+{
+   const char *ev[2] = {NULL, NULL};
+   cJSON *js[2] = {NULL, NULL};
+   int n = delta_build_events(d, st, msg_id, model, ev, js);
+   if (n == 0)
+      return NULL;
+   char *first = sse_frame(ev[0], js[0]); /* sse_frame takes ownership of js[i] */
+   if (n == 1)
+      return first;
+   char *second = sse_frame(ev[1], js[1]);
+   if (!first || !second)
+   {
+      free(first);
+      free(second);
       return NULL;
    }
+   size_t need = strlen(first) + strlen(second) + 1;
+   char *both = malloc(need);
+   if (both)
+      snprintf(both, need, "%s%s", first, second);
+   free(first);
+   free(second);
+   return both;
+}
+
+int anthropic_delta_emit(const aimee_delta_t *d, anthropic_stream_state_t *st, const char *msg_id,
+                         const char *model, aimee_sse_emit_fn emit, void *ctx)
+{
+   const char *ev[2] = {NULL, NULL};
+   cJSON *js[2] = {NULL, NULL};
+   int n = delta_build_events(d, st, msg_id, model, ev, js);
+   for (int i = 0; i < n; i++)
+   {
+      char *json = cJSON_PrintUnformatted(js[i]);
+      cJSON_Delete(js[i]);
+      if (json && emit)
+         emit(ctx, ev[i], json);
+      free(json);
+   }
+   return n;
 }

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -30,6 +30,7 @@
 #include "router_advise.h"   /* gw_stage_router — the request->workflow seam */
 #include "aimee_ir_shadow.h" /* Slice 3: IR shadow-mode observer */
 #include "aimee_ir_serve.h"  /* Slice 5: IR live request-build */
+#include "aimee_ir_stream.h" /* Slice 5-wire: IR-delta incremental relay */
 #include "ingress_preinject.h"
 #include "json_fluent.h"
 #include "server_http.h"
@@ -577,7 +578,18 @@ cleanup:
 typedef struct
 {
    sse_parser_t parser;
-   anthropic_stream_xlate_t *xl;
+   anthropic_stream_xlate_t *xl; /* legacy incremental translator */
+   /* Slice 5-wire: neutral IR-delta relay (used instead of `xl` when the
+    * AIMEE_IR_STREAM_RELAY flag is on). Provider OpenAI-chat SSE chunks ->
+    * openai_chunk_to_deltas -> anthropic_delta_emit -> `emit`. */
+   int ir_relay;
+   openai_stream_state_t ir_ost;
+   anthropic_stream_state_t ir_ast;
+   server_http_sse_event_emit emit;
+   void *emit_ctx;
+   const char *msg_id;
+   const char *model;
+   long ir_usage_out; /* tapped from the TURN_STOP delta for the cost row */
 } prov_stream_ctx_t;
 
 typedef struct
@@ -611,7 +623,36 @@ static int prov_line_cb(const char *line, size_t len, void *ud)
       const char *p = line + 5;
       while (*p == ' ')
          p++;
-      anthropic_stream_feed_openai(c->xl, p); /* line is NUL-terminated by the parser */
+      if (c->ir_relay)
+      {
+         /* OpenAI-chat providers close the stream with a literal `data: [DONE]`
+          * sentinel that is not JSON; the finish_reason chunk already produced the
+          * IR TURN_STOP, so just skip it. */
+         if (strcmp(p, "[DONE]") == 0)
+            return 0;
+         cJSON *chunk = cJSON_Parse(p);
+         if (chunk)
+         {
+            /* A finish chunk closes EVERY open block (text + up to
+             * AIMEE_STREAM_MAX_TOOLS tool blocks) then TURN_STOP in one call, and
+             * a chunk carrying many tool_calls opens as many; size the buffer to
+             * hold the worst case so the terminal TURN_STOP is never truncated
+             * (which would hang the client's SSE reader). */
+            aimee_delta_t deltas[2 * AIMEE_STREAM_MAX_TOOLS + 4];
+            int n = openai_chunk_to_deltas(chunk, &c->ir_ost, deltas,
+                                           (int)(sizeof deltas / sizeof deltas[0]));
+            for (int i = 0; i < n; i++)
+            {
+               if (deltas[i].type == AIMEE_DELTA_TURN_STOP)
+                  c->ir_usage_out = deltas[i].usage_out;
+               anthropic_delta_emit(&deltas[i], &c->ir_ast, c->msg_id, c->model, c->emit,
+                                    c->emit_ctx);
+            }
+            cJSON_Delete(chunk);
+         }
+      }
+      else
+         anthropic_stream_feed_openai(c->xl, p); /* line is NUL-terminated by the parser */
    }
    return 0;
 }
@@ -1018,6 +1059,67 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    }
 
    input_est = messages ? session_compact_estimate_tokens(messages) : 0;
+
+   if (aimee_ir_stream_relay_enabled())
+   {
+      /* Slice 5-wire (default-off): drive the incremental OpenAI-chat -> Anthropic
+       * SSE relay through the neutral IR-delta model instead of the legacy
+       * anthropic_stream_feed_openai translator -- the last live direct-translation
+       * site. */
+      memset(&pc, 0, sizeof pc);
+      sse_parser_init(&pc.parser);
+      pc.ir_relay = 1;
+      openai_stream_state_init(&pc.ir_ost);
+      pc.emit = emit;
+      pc.emit_ctx = ctx;
+      pc.msg_id = msg_id;
+      pc.model = model;
+      int ir_status = agent_http_post_stream(url, auth, prov_body ? prov_body : "{}", prov_chunk_cb,
+                                             &pc, ag->timeout_ms, extra[0] ? extra : NULL);
+      sse_parser_free(&pc.parser);
+      /* Finish-safety: if the upstream cut off before a finish_reason chunk (no IR
+       * TURN_STOP was produced), synthesize the closing sequence so the client's
+       * SSE reader terminates cleanly, mirroring anthropic_stream_finish. Close any
+       * still-open content blocks, then emit TURN_STOP. */
+      if (pc.ir_ast.started && !pc.ir_ost.stopped)
+      {
+         aimee_delta_t bs = {0};
+         bs.type = AIMEE_DELTA_BLOCK_STOP;
+         if (pc.ir_ost.text_block >= 0)
+         {
+            bs.block_id = pc.ir_ost.text_block;
+            anthropic_delta_emit(&bs, &pc.ir_ast, msg_id, model, emit, ctx);
+         }
+         for (int i = 0; i < AIMEE_STREAM_MAX_TOOLS; i++)
+            if (pc.ir_ost.tool_block[i] >= 0)
+            {
+               bs.block_id = pc.ir_ost.tool_block[i];
+               anthropic_delta_emit(&bs, &pc.ir_ast, msg_id, model, emit, ctx);
+            }
+         aimee_delta_t ts = {0};
+         ts.type = AIMEE_DELTA_TURN_STOP;
+         ts.stop_reason = AIMEE_STOP_END_TURN;
+         ts.usage_out = pc.ir_usage_out;
+         anthropic_delta_emit(&ts, &pc.ir_ast, msg_id, model, emit, ctx);
+      }
+      /* Cost row: input from the local estimate (message_start reports 0, same as
+       * the legacy translator's estimate basis), output tapped from the IR
+       * TURN_STOP delta. */
+      if ((input_est > 0 || pc.ir_usage_out > 0) && agent_ingress_accounting_enabled())
+      {
+         agent_result_t ar;
+         memset(&ar, 0, sizeof(ar));
+         snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
+         snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
+         snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model ? model : "");
+         ar.prompt_tokens = input_est;
+         ar.completion_tokens = (int)pc.ir_usage_out;
+         agent_record_token_audit_kind(&ar, "", "anthropic-ingress",
+                                       ir_status == 200 ? "realized" : "partial");
+      }
+      goto cleanup;
+   }
+
    xl = anthropic_stream_begin(msg_id, model, input_est, emit, ctx);
    if (!xl)
       goto cleanup;

--- a/src/tests/support/ir_ingress_stubs.c
+++ b/src/tests/support/ir_ingress_stubs.c
@@ -97,6 +97,41 @@ __attribute__((weak)) int aimee_ir_path_enabled(void)
    return 0;
 }
 
+/* Slice 5-wire: the incremental IR-delta relay. The flag stub returns 0 (legacy
+ * relay), so the delta helpers below are never CALLED by the ingress tests -- they
+ * exist only to resolve the link. Real definitions (aimee_ir_serve/aimee_ir_stream)
+ * win when linked. */
+__attribute__((weak)) int aimee_ir_stream_relay_enabled(void)
+{
+   return 0;
+}
+
+__attribute__((weak)) void openai_stream_state_init(void *st)
+{
+   (void)st;
+}
+
+__attribute__((weak)) int openai_chunk_to_deltas(const void *chunk, void *st, void *out, int max)
+{
+   (void)chunk;
+   (void)st;
+   (void)out;
+   (void)max;
+   return 0;
+}
+
+__attribute__((weak)) int anthropic_delta_emit(const void *d, void *st, const char *msg_id,
+                                               const char *model, void *emit, void *ctx)
+{
+   (void)d;
+   (void)st;
+   (void)msg_id;
+   (void)model;
+   (void)emit;
+   (void)ctx;
+   return 0;
+}
+
 __attribute__((weak)) char *aimee_ir_build_provider_body(const void *req, const char *driver_name,
                                                          const char *agent_model,
                                                          int max_tokens_override)

--- a/src/tests/test_aimee_ir_stream.c
+++ b/src/tests/test_aimee_ir_stream.c
@@ -28,6 +28,28 @@ static void feed(const char *chunk_json, openai_stream_state_t *ost, anthropic_s
    cJSON_Delete(chunk);
 }
 
+/* Collector for the callback-emit path: reframe (event,data) back to SSE so the
+ * SAME assertions apply -- proving anthropic_delta_emit == anthropic_delta_render. */
+static char g_emit_acc[4096];
+static void emit_collect(void *ctx, const char *event, const char *data_json)
+{
+   (void)ctx;
+   char frame[1024];
+   snprintf(frame, sizeof frame, "event: %s\ndata: %s\n\n", event, data_json);
+   strncat(g_emit_acc, frame, sizeof g_emit_acc - strlen(g_emit_acc) - 1);
+}
+static void feed_emit(const char *chunk_json, openai_stream_state_t *ost,
+                      anthropic_stream_state_t *ast)
+{
+   cJSON *chunk = cJSON_Parse(chunk_json);
+   assert(chunk);
+   aimee_delta_t deltas[16];
+   int n = openai_chunk_to_deltas(chunk, ost, deltas, 16);
+   for (int i = 0; i < n; i++)
+      anthropic_delta_emit(&deltas[i], ast, "msg_1", "claude-3-5-sonnet", emit_collect, NULL);
+   cJSON_Delete(chunk);
+}
+
 int main(void)
 {
    printf("ir-stream: ");
@@ -66,6 +88,26 @@ int main(void)
    /* exactly one message_start event (not re-emitted per chunk) */
    char *ms = strstr(acc, "event: message_start");
    assert(ms && !strstr(ms + 1, "event: message_start"));
+
+   /* The callback-emit path (anthropic_delta_emit, the live-relay sink) must
+    * produce byte-identical framed SSE to anthropic_delta_render (shared builder). */
+   openai_stream_state_t ost2;
+   openai_stream_state_init(&ost2);
+   anthropic_stream_state_t ast2 = {0};
+   g_emit_acc[0] = '\0';
+   feed_emit("{\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hel\"}}]}", &ost2,
+             &ast2);
+   feed_emit("{\"choices\":[{\"delta\":{\"content\":\"lo\"}}]}", &ost2, &ast2);
+   feed_emit("{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\","
+             "\"function\":{\"name\":\"Read\",\"arguments\":\"\"}}]}}]}",
+             &ost2, &ast2);
+   feed_emit("{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,"
+             "\"function\":{\"arguments\":\"{\\\"p\\\":1}\"}}]}}]}",
+             &ost2, &ast2);
+   feed_emit("{\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}],"
+             "\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":4}}",
+             &ost2, &ast2);
+   assert(strcmp(acc, g_emit_acc) == 0); /* emit == render, event-for-event */
 
    printf("ok\n");
    return 0;


### PR DESCRIPTION
## canonical-IR Slice 5-wire + close-out → done/

Completes the `aimee-canonical-ir` proposal. The refactor's goal — protocol-neutral IR, **no direct wire translation**, codex-primary serving Claude Code — is already merged (#936) and live-proven on `.254`. This PR lands the **last live direct-translation site** elimination and files the proposal.

### Slice 5-wire (code, default-OFF)
The incremental OpenAI-chat → Anthropic SSE relay (`anthropic_http.c`) can now be driven by the neutral IR-delta model (`openai_chunk_to_deltas` → `anthropic_delta_emit`) instead of the legacy `anthropic_stream_feed_openai` translator — behind a **separate default-OFF flag `AIMEE_IR_STREAM_RELAY`** (roundtable Q6: gate streaming-IR independently). Ships **dark**; the live streaming default is unchanged.
- New `anthropic_delta_emit` — the callback-emit variant the live relay needs (its sink is split `(ctx,event,data)`, not a frame). `anthropic_delta_render` + `anthropic_delta_emit` share **one** event-builder (`delta_build_events`) so they never drift — a test asserts `emit == render` byte-for-byte over the full text+tool+finish sequence.
- `prov_line_cb` branches to the IR relay when the flag is on (skips `[DONE]`); `messages_stream` sets up the IR states with **finish-safety** (synthesizes block-stop for every open block + TURN_STOP if the upstream cuts off with no `finish_reason`) and taps output usage for the cost row. Buffer sized to hold the worst-case finish chunk (closes all parallel tool blocks + TURN_STOP) so the terminal event is never truncated.

### Verification
- Both build systems build clean `-Werror`; full `make unit-tests` green; new `emit==render` assertion passes; `make lint` green; new env var docs-gen'd.
- Design **scoping roundtable** (BLOCKING NONE): S5-wire is the load-bearing item; legacy *deletion* is NOT load-bearing (Q6 parity-gated); mechanism/rollout framing endorsed. **Code roundtable**: the 3 "blocking" items verified — 2 false positives (`cJSON_Delete` is unconditional; TURN_START includes msg_id+model, test-proven), 1 real buffer-truncation bug **fixed**. **Completeness confirmation roundtable** (BLOCKING NONE).
- The path ships **default-OFF (dark)**; live streaming-relay enablement is gated on the shadow divergence metrics staying clean (documented as the exit criteria), like the legacy-deletion step.

### Close-out → done/
Files `aimee-canonical-ir.md` to `done/` with a State bullet + §Close-out: slice→PR map, the named sanctioned follow-ups (legacy *deletion* = Q6 parity-gated; `turn_record_v1` = Q5-deferred fast-follow), the "no new direct translation" guardrail, and the mechanism/rollout scope-of-done framing.
