### PR TITLE
feat(economizer): S5 — Anthropic streaming gateway mutation wiring

### DIFF
--- a/src/headers/gateway_mutate_wire.h
+++ b/src/headers/gateway_mutate_wire.h
@@ -88,6 +88,12 @@ extern "C"
     * disabling, so the breaker is not false-tripped). NULL/garbage-safe. */
    int gw_stream_anthropic_error_is_invalid_request(const char *data);
 
+   /* Whether an upstream HTTP status is the invalid-request class a bad reduced
+    * payload can produce (400/413/422). Used by the buffered-replay streaming path to
+    * disable ONLY on a payload-class 4xx — never on 401/403/404/429 (auth/rate-limit,
+    * which the streaming contract forwards without disabling). */
+   int gw_status_is_invalid_request(int http_status);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/gateway_mutate_wire.h
+++ b/src/headers/gateway_mutate_wire.h
@@ -72,6 +72,22 @@ extern "C"
    gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int http_status,
                                              gw_mutate_ctx_t *ctx);
 
+   /* Streaming disposition (§2.5 streaming): a mutated stream CANNOT restore/resend —
+    * the HTTP 200 is committed to the client before the upstream status is known, so
+    * only SUBSEQUENT turns are protected. gw_stream_disable circuit-breaks the session
+    * for subsequent turns (records gateway_stream_error_disable + the reason), clears
+    * provenance, and is idempotent within a turn (it flips ctx->mutated off so a second
+    * call no-ops). No-op for a non-mutated / keyless request. `reason` is a stable
+    * static label ("stream_invalid_request" | "stream_decoder_error"). */
+   void gw_stream_disable(gw_mutate_ctx_t *ctx, const char *reason);
+
+   /* Classify an Anthropic SSE error-frame `data` (the JSON body of an `event: error`
+    * frame). Returns 1 for an invalid-request-class error (invalid_request_error /
+    * request_too_large — a reduced-payload bug => disable), 0 for rate-limit /
+    * overloaded / api_error / auth frames (transient or unrelated => forward WITHOUT
+    * disabling, so the breaker is not false-tripped). NULL/garbage-safe. */
+   int gw_stream_anthropic_error_is_invalid_request(const char *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -960,11 +960,15 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                   buf_status);
          if (emit)
             emit(ctx, "error", err);
-         /* Buffered-replay streaming: a non-200 upstream on a mutated request
-          * circuit-breaks subsequent turns (4xx = the reduced payload, 5xx =
-          * fail-safe). No restore/resend — the 200 is already committed. */
-         gw_stream_disable(&gwmc, buf_status / 100 == 4 ? "stream_invalid_request"
-                                                        : "stream_decoder_error");
+         /* Buffered-replay streaming: circuit-break subsequent turns only when the
+          * non-200 indicates a bad reduced payload — an invalid-request-class 4xx
+          * (400/413/422) or, fail-safe, a 5xx. Auth / rate-limit / not-found
+          * (401/403/404/429) are NOT reduction bugs and are forwarded WITHOUT
+          * disabling. No restore/resend — the 200 is already committed. */
+         if (gw_status_is_invalid_request(buf_status))
+            gw_stream_disable(&gwmc, "stream_invalid_request");
+         else if (buf_status / 100 == 5)
+            gw_stream_disable(&gwmc, "stream_decoder_error");
       }
       free(buf_resp);
       goto cleanup;

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -597,6 +597,10 @@ typedef struct
    int output_tokens;
    int cache_write_tokens;
    int cache_read_tokens;
+   /* Gateway-mutation streaming breaker: when this stream carried a reduced payload
+    * (gwmc->mutated), an invalid-request error frame disables the session for
+    * subsequent turns (§2.5 streaming). NULL when the request was not mutated. */
+   gw_mutate_ctx_t *gwmc;
 } anthropic_relay_ctx_t;
 
 static int prov_line_cb(const char *line, size_t len, void *ud)
@@ -685,6 +689,13 @@ static void relay_flush(anthropic_relay_ctx_t *c)
       relay_capture_usage(c, event, c->data);
       c->emit(c->emit_ctx, event, c->data);
       c->emitted++;
+      /* Inspect-as-forward (§2.5 streaming): the frame is already forwarded above;
+       * if this MUTATED stream carried an invalid-request-class error frame, the
+       * reduced payload is the likely cause -> disable subsequent turns. Transient
+       * frames (rate-limit/overloaded) are forwarded WITHOUT disabling. */
+      if (c->gwmc && c->gwmc->mutated && strcmp(event, "error") == 0 &&
+          gw_stream_anthropic_error_is_invalid_request(c->data))
+         gw_stream_disable(c->gwmc, "stream_invalid_request");
    }
    c->event[0] = '\0';
    c->data_len = 0;
@@ -754,6 +765,8 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    prov_stream_ctx_t pc;
    int input_est;
    int responses_wire = 0;
+   gw_mutate_ctx_t gwmc;
+   gw_mutate_ctx_init(&gwmc);
 
    mint_msg_id(msg_id, sizeof(msg_id));
 
@@ -794,6 +807,20 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    /* Re-read `model`: the model-pin stage may have replaced req's "model" node, so
     * the pointer cached at the top of this function could now dangle. */
    model = jo_cstr(req, "model");
+
+   /* Economizer gateway MUTATION (streaming). Reduces req["messages"] in place before
+    * translate/build. Streaming CANNOT restore-resend (the 200 is committed on the
+    * first byte), so on a bad reduction only SUBSEQUENT turns are circuit-broken —
+    * via the SSE error-frame inspect-as-forward in relay_flush + the post-stream
+    * fail-safe below. Default-OFF dark no-op. */
+   if (gw_mutate_is_enabled())
+   {
+      char *mut_sys = anthropic_system_to_text(req);
+      gw_buffered_mutate(req, "messages", model, mut_sys, server_http_identity_session_hdr(),
+                         server_http_identity_bearer(), server_http_identity_principal(), &gwmc);
+      free(mut_sys);
+   }
+
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
@@ -933,6 +960,11 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                   buf_status);
          if (emit)
             emit(ctx, "error", err);
+         /* Buffered-replay streaming: a non-200 upstream on a mutated request
+          * circuit-breaks subsequent turns (4xx = the reduced payload, 5xx =
+          * fail-safe). No restore/resend — the 200 is already committed. */
+         gw_stream_disable(&gwmc, buf_status / 100 == 4 ? "stream_invalid_request"
+                                                        : "stream_decoder_error");
       }
       free(buf_resp);
       goto cleanup;
@@ -946,12 +978,18 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
       sse_parser_init(&relay.parser);
       relay.emit = emit;
       relay.emit_ctx = ctx;
+      relay.gwmc = &gwmc; /* enable the streaming breaker for a mutated stream */
       stream_status =
           agent_http_post_stream(url, auth, prov_body ? prov_body : "{}", anthropic_relay_chunk_cb,
                                  &relay, ag->timeout_ms, extra[0] ? extra : NULL);
       relay_flush(&relay);
       if (stream_status != 200)
+      {
          relay_emit_transport_error(&relay, stream_status);
+         /* Fail-safe (§2.5): a non-SSE post-200 upstream failure on a mutated stream
+          * disables subsequent turns (the current turn is already lost). */
+         gw_stream_disable(&gwmc, "stream_decoder_error");
+      }
       /* Cost accounting for the native Anthropic streaming ingress, from the
        * usage tapped off the relayed SSE. A clean 200 is realized spend; an
        * aborted stream that still observed usage is recorded as partial so the
@@ -986,6 +1024,12 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                                              &pc, ag->timeout_ms, extra[0] ? extra : NULL);
    sse_parser_free(&pc.parser);
 
+   /* OpenAI-via-translator streaming: this path lacks per-frame Anthropic error
+    * classification, so a non-200 upstream on a mutated request is a fail-safe
+    * disable of subsequent turns. */
+   if (xlate_status != 200)
+      gw_stream_disable(&gwmc, "stream_decoder_error");
+
    anthropic_stream_finish(xl);
 
    /* Cost accounting for the OpenAI-via-translator streaming ingress: tap the
@@ -1014,6 +1058,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    anthropic_stream_free(xl);
 
 cleanup:
+   gw_mutate_ctx_free(&gwmc);
    free(prov_body);
    free(system_text);
    cJSON_Delete(messages);

--- a/src/server/gateway_mutate_wire.c
+++ b/src/server/gateway_mutate_wire.c
@@ -157,3 +157,36 @@ gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int
    }
    return GW_POST_NONE;
 }
+
+void gw_stream_disable(gw_mutate_ctx_t *ctx, const char *reason)
+{
+   if (!ctx || !ctx->mutated || !ctx->have_key)
+      return;
+   msg_session_disable(ctx->skey, ctx->ttl_ms, reason ? reason : "stream");
+   gw_provenance_clear(&ctx->st);
+   gw_stat_inc(GW_STAT_STREAM_ERROR_DISABLE);
+   ctx->mutated = 0; /* one disable per turn; a later frame no-ops */
+}
+
+int gw_stream_anthropic_error_is_invalid_request(const char *data)
+{
+   if (!data || !data[0])
+      return 0;
+   cJSON *root = cJSON_Parse(data);
+   if (!root)
+      return 0;
+   int invalid = 0;
+   cJSON *err = cJSON_GetObjectItemCaseSensitive(root, "error");
+   cJSON *type = err ? cJSON_GetObjectItemCaseSensitive(err, "type") : NULL;
+   if (cJSON_IsString(type) && type->valuestring)
+   {
+      const char *t = type->valuestring;
+      /* Anthropic invalid-request class: invalid_request_error + request_too_large
+       * (the 413-equivalent a bad reduced serialization can produce). rate_limit /
+       * overloaded / api_error / authentication are NOT reduction bugs. */
+      if (strstr(t, "invalid_request") || strstr(t, "request_too_large"))
+         invalid = 1;
+   }
+   cJSON_Delete(root);
+   return invalid;
+}

--- a/src/server/gateway_mutate_wire.c
+++ b/src/server/gateway_mutate_wire.c
@@ -181,12 +181,22 @@ int gw_stream_anthropic_error_is_invalid_request(const char *data)
    if (cJSON_IsString(type) && type->valuestring)
    {
       const char *t = type->valuestring;
-      /* Anthropic invalid-request class: invalid_request_error + request_too_large
-       * (the 413-equivalent a bad reduced serialization can produce). rate_limit /
-       * overloaded / api_error / authentication are NOT reduction bugs. */
-      if (strstr(t, "invalid_request") || strstr(t, "request_too_large"))
+      /* Anthropic invalid-request class (error taxonomy as of 2024-2026):
+       * invalid_request_error + request_too_large (the 413-equivalent a bad reduced
+       * serialization can produce). EXACT match — not substring — so a future type
+       * that merely contains these words does not false-trip. rate_limit_error /
+       * overloaded_error / api_error / authentication_error are NOT reduction bugs. */
+      if (strcmp(t, "invalid_request_error") == 0 || strcmp(t, "request_too_large") == 0)
          invalid = 1;
    }
    cJSON_Delete(root);
    return invalid;
+}
+
+int gw_status_is_invalid_request(int http_status)
+{
+   /* The 4xx codes a bad reduced serialization can produce: 400 invalid_request,
+    * 413 request_too_large, 422 unprocessable. 401/403/404/429 are auth / rate-limit
+    * / not-found — NOT reduction bugs, so a streaming path must not disable on them. */
+   return http_status == 400 || http_status == 413 || http_status == 422;
 }

--- a/src/tests/support/ir_ingress_stubs.c
+++ b/src/tests/support/ir_ingress_stubs.c
@@ -61,6 +61,11 @@ __attribute__((weak)) int gw_stream_anthropic_error_is_invalid_request(const cha
    (void)data;
    return 0;
 }
+__attribute__((weak)) int gw_status_is_invalid_request(int http_status)
+{
+   (void)http_status;
+   return 0;
+}
 __attribute__((weak)) const char *server_http_identity_session_hdr(void)
 {
    return "";

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -140,6 +140,55 @@ static void test_dark_default_and_identityless(void)
    cJSON_Delete(c);
 }
 
+static void test_stream_disable(void)
+{
+   msg_session_reset();
+   gw_stat_reset();
+   cJSON *c;
+   gw_mutate_ctx_t ctx;
+   const char *skey = "aabbccddeeff0011";
+   make_mutated(&c, &ctx, skey);
+   cJSON_Delete(c); /* streaming holds no restore need */
+
+   /* an invalid-request frame disables; a second call is idempotent (mutated flips off) */
+   gw_stream_disable(&ctx, "stream_invalid_request");
+   assert(msg_session_is_disabled(skey) == 1);
+   assert(ctx.st.reduced == 0);
+   assert(ctx.mutated == 0);
+   assert(gw_stat_get(GW_STAT_STREAM_ERROR_DISABLE) == 1);
+   gw_stream_disable(&ctx, "stream_invalid_request"); /* no-op now */
+   assert(gw_stat_get(GW_STAT_STREAM_ERROR_DISABLE) == 1);
+   gw_mutate_ctx_free(&ctx);
+
+   /* a non-mutated ctx never disables */
+   gw_mutate_ctx_t idle;
+   gw_mutate_ctx_init(&idle);
+   gw_stream_disable(&idle, "stream_invalid_request");
+   assert(gw_stat_get(GW_STAT_STREAM_ERROR_DISABLE) == 1);
+   gw_mutate_ctx_free(&idle);
+}
+
+static void test_stream_error_classify(void)
+{
+   /* invalid-request class -> disable */
+   assert(gw_stream_anthropic_error_is_invalid_request(
+              "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"x\"}"
+              "}") == 1);
+   assert(gw_stream_anthropic_error_is_invalid_request(
+              "{\"error\":{\"type\":\"request_too_large\"}}") == 1);
+   /* transient / unrelated -> do NOT disable */
+   assert(gw_stream_anthropic_error_is_invalid_request(
+              "{\"error\":{\"type\":\"overloaded_error\"}}") == 0);
+   assert(gw_stream_anthropic_error_is_invalid_request(
+              "{\"error\":{\"type\":\"rate_limit_error\"}}") == 0);
+   assert(gw_stream_anthropic_error_is_invalid_request("{\"error\":{\"type\":\"api_error\"}}") ==
+          0);
+   /* garbage-safe */
+   assert(gw_stream_anthropic_error_is_invalid_request(NULL) == 0);
+   assert(gw_stream_anthropic_error_is_invalid_request("not json") == 0);
+   assert(gw_stream_anthropic_error_is_invalid_request("") == 0);
+}
+
 int main(void)
 {
    printf("gateway_mutate_wire: ");
@@ -156,6 +205,8 @@ int main(void)
    test_5xx_disable_no_resend();
    test_2xx_and_nonmutated_noop();
    test_dark_default_and_identityless();
+   test_stream_disable();
+   test_stream_error_classify();
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -183,10 +183,30 @@ static void test_stream_error_classify(void)
               "{\"error\":{\"type\":\"rate_limit_error\"}}") == 0);
    assert(gw_stream_anthropic_error_is_invalid_request("{\"error\":{\"type\":\"api_error\"}}") ==
           0);
+   /* auth outages are NOT invalid-request (no breaker) */
+   assert(gw_stream_anthropic_error_is_invalid_request(
+              "{\"error\":{\"type\":\"authentication_error\"}}") == 0);
+   /* EXACT match: a type that merely contains the words does not false-trip */
+   assert(gw_stream_anthropic_error_is_invalid_request(
+              "{\"error\":{\"type\":\"not_invalid_request_error\"}}") == 0);
+   assert(gw_stream_anthropic_error_is_invalid_request(
+              "{\"error\":{\"type\":\"request_too_large_retry\"}}") == 0);
    /* garbage-safe */
    assert(gw_stream_anthropic_error_is_invalid_request(NULL) == 0);
    assert(gw_stream_anthropic_error_is_invalid_request("not json") == 0);
    assert(gw_stream_anthropic_error_is_invalid_request("") == 0);
+
+   /* status classifier: only 400/413/422 are the payload class; auth/rate-limit/5xx
+    * are not (the buffered-replay path must not disable on them) */
+   assert(gw_status_is_invalid_request(400) == 1);
+   assert(gw_status_is_invalid_request(413) == 1);
+   assert(gw_status_is_invalid_request(422) == 1);
+   assert(gw_status_is_invalid_request(401) == 0);
+   assert(gw_status_is_invalid_request(403) == 0);
+   assert(gw_status_is_invalid_request(404) == 0);
+   assert(gw_status_is_invalid_request(429) == 0);
+   assert(gw_status_is_invalid_request(503) == 0);
+   assert(gw_status_is_invalid_request(200) == 0);
 }
 
 int main(void)


### PR DESCRIPTION
Slice 5 of the **economizer gateway mutation** proposal (step 7). Wires the mutation into the Anthropic `/v1/messages` **streaming** path (live SSE relay), **default-OFF**.

Streaming **cannot restore/resend** — the HTTP 200 is committed to the client before the upstream status is known (§1), so a bad reduced payload only **circuit-breaks SUBSEQUENT turns**; the current turn completes as the upstream delivered it.

## New (`gateway_mutate_wire`)
- `gw_stream_disable` — disable subsequent turns + `gateway_stream_error_disable` counter, no restore, idempotent per turn.
- `gw_stream_anthropic_error_is_invalid_request` — classify an Anthropic SSE error frame: **exact-match** `invalid_request_error` / `request_too_large` → disable; `rate_limit_error` / `overloaded_error` / `api_error` / `authentication_error` → **forward WITHOUT disabling** (no false-trip).
- `gw_status_is_invalid_request` (400/413/422) — the buffered-replay path disables only on a payload-class 4xx or (fail-safe) 5xx, never on 401/403/404/429.

## `anthropic_http.c` `messages_stream`
Pre-stream mutation (same `gw_buffered_mutate`). The relay carries the `gwmc` so `relay_flush` **inspects-as-forwards** each error frame at the SSE decoder layer (frames reassembled across TCP boundaries by `sse_parser`, forwarded unchanged). Post-stream fail-safe disable on a non-200 upstream (native relay + translator paths) and on the buffered-replay non-200 branch.

## Tests
`tests/test_gateway_mutate_wire.c`: `gw_stream_disable` idempotence + non-mutated no-op; error-frame classification incl. exact-match negatives (`authentication_error`, `not_invalid_request_error`, `request_too_large_retry`); the status-classifier matrix.

## Review
Roundtable-reviewed (non-degraded). Fixed: exact `strcmp` (not `strstr`); selective streaming disable so auth/rate-limit never trips the breaker.

Default-OFF; OpenAI (S6/S7) + telemetry/docs (S8) follow. The OpenAI-via-translator relay uses fail-safe-on-non-200 only (documented asymmetry; the real OpenAI `/v1/responses` path is S7).