### PR TITLE
feat(economizer): S8 — sampled token-delta telemetry + no-behavior-change test + docs

### DIFF
--- a/docs/features/economizer-gateway-mutation.md
+++ b/docs/features/economizer-gateway-mutation.md
@@ -1,0 +1,77 @@
+# Economizer gateway mutation (primary-agent context reduction)
+
+The context economizer reduces the **delegate** (sub-agent) turn loop by default. The
+inbound `/v1` **gateway** — the path that serves the **primary** agent, including
+Claude-Code-through-aimee and Codex-through-aimee — historically ran the economizer in
+**shadow** (`measure_only`): it measured the reduction opportunity but never applied it.
+
+**Gateway mutation** makes the gateway *apply* the reduced messages to the live request,
+so the primary agent's tokens are reduced too. It is **compress-only**, **default-OFF**,
+and guarded by a per-session circuit breaker so a bad reduction cannot *persistently*
+break live client traffic.
+
+## Configuration
+
+```yaml
+reduce:
+  gateway_seam: true                       # existing: shadow / measure on /v1 (baseline)
+  gateway_mutate: false                    # NEW: apply the reduction. DEFAULT OFF.
+  gateway_session_disable_ttl_ms: 3600000  # NEW: circuit-breaker window (1h). MUST be > 0.
+```
+
+- `gateway_mutate: true` **implies** `gateway_seam` — config load auto-enables the shadow
+  seam **in memory** (never rewriting your file) and logs one WARN, so the shadow baseline
+  the validation gates compare against always exists.
+- `gateway_session_disable_ttl_ms` **must be > 0**. `0`/negative is a **startup-fatal**
+  config error (the server refuses to start): a permanent-pin / disabled breaker on the
+  live path is disproportionate runtime risk.
+
+## What it does, per path
+
+- **Buffered** (`/v1/messages` stream:false, `/v1/responses`): snapshot the pristine
+  messages → reduce → apply. On **any upstream 4xx** the gateway restores the pristine
+  original, repairs it, **resends once**, and disables the session for subsequent turns.
+  On **5xx** it disables the session **without** resending and forwards the 5xx as-is.
+- **Streaming** (`/v1/messages` stream:true): the HTTP 200 is committed to the client on
+  the first byte, so there is **no mid-stream retry**. The reduced stream is sent; if an
+  **invalid-request-class** SSE error frame (`invalid_request_error` / `request_too_large`)
+  is seen — inspected at the SSE decoder layer and forwarded unchanged — the session is
+  disabled for **subsequent** turns. Rate-limit / overloaded / auth frames are forwarded
+  **without** disabling. The current turn always completes as the upstream delivered it.
+- **OpenAI `/v1/responses` streaming** buffers upstream (via the same buffered path) then
+  replays as SSE, so it inherits the **buffered** treatment — including the 4xx
+  restore-resend. aimee has no true token-by-token upstream streaming for the OpenAI
+  primary path, so there is no OpenAI-specific streaming disable-only code.
+
+## The per-session circuit breaker
+
+Mutation is attempted only for a **resolvable per-identity session key**, derived (in
+order) from a validated `aimee-session-id` header (`== SHA-256(auth_identity)[0..16)`),
+else `SHA-256(bearer)[0..16)`. A request with **neither** is a pristine passthrough that
+writes **no** disable state — so one caller's failure can never disable reduction for an
+unrelated caller. Disable state is a bounded (10k), TTL'd, process-local set.
+
+## Safety contract
+
+- `reduce_gateway_mutate: false` ⇒ the inbound request is **byte-identical** to today.
+- The gateway **never dispatches a reduced payload it cannot restore** to the pristine
+  original (snapshot-first; OOM ⇒ hard-bypass).
+- A reduction that does not net-shrink, would split a tool_use/tool_result pair, or the
+  reducer errored on ⇒ **hard-bypass** (forward pristine), recorded in
+  `gateway_hard_bypass{reason}`.
+- Provenance (`reduce_state.reduced`) is set only after the reduced payload is installed
+  and cleared on every hard-bypass / restore / OOM path.
+
+## Telemetry (validation input)
+
+`gw_stat_dump` emits (Prometheus-ish): `gateway_mutate_attempted`, `…_applied`,
+`gateway_hard_bypass{reason}`, `gateway_4xx_restore_resend`, `gateway_5xx_disable`,
+`gateway_stream_error_disable`, `gateway_session_disabled_set{reason}`,
+`gateway_session_disabled_blocks`, and the sampled `gateway_token_delta_*` sums.
+
+## Rollout & rollback
+
+Enable `reduce_gateway_mutate` on a validation host, watch the counters, and roll back by
+flipping it to `false` (the circuit breaker also self-limits per session). The
+default-**ON** decision, the ≥7-day `.254` validation campaign, and the snapshot-cost
+benchmark are **out of scope for this feature** and gate that separate decision.

--- a/docs/features/economizer-gateway-mutation.md
+++ b/docs/features/economizer-gateway-mutation.md
@@ -69,9 +69,15 @@ unrelated caller. Disable state is a bounded (10k), TTL'd, process-local set.
 `gateway_stream_error_disable`, `gateway_session_disabled_set{reason}`,
 `gateway_session_disabled_blocks`, and the sampled `gateway_token_delta_*` sums.
 
+The token-delta is sampled **deterministically at 1-in-100** applied mutations
+(`gateway_token_delta_sample_count`, `…_baseline_sum`, `…_reduced_sum`). The `.254`
+net-shrink gate checks that the sampled `reduced_sum < baseline_sum` (sampled mean
+reduced below mean baseline); the sums are published before the count so a scrape never
+sees a count ahead of its sums.
+
 ## Rollout & rollback
 
-Enable `reduce_gateway_mutate` on a validation host, watch the counters, and roll back by
+Enable `reduce.gateway_mutate` on a validation host, watch the counters, and roll back by
 flipping it to `false` (the circuit breaker also self-limits per session). The
 default-**ON** decision, the ≥7-day `.254` validation campaign, and the snapshot-cost
 benchmark are **out of scope for this feature** and gate that separate decision.

--- a/src/headers/gw_mutate_stats.h
+++ b/src/headers/gw_mutate_stats.h
@@ -41,6 +41,17 @@ extern "C"
    void gw_stat_inc_reason(const char *group, const char *reason);
    uint64_t gw_stat_get_reason(const char *group, const char *reason);
 
+   /* Sampled pre/post token-delta (§4 gateway_token_delta_pre_post_sampled). Called on
+    * every APPLIED mutation with the reducer's baseline + reduced token counts; a
+    * deterministic 1-in-GW_STAT_TOKEN_SAMPLE_N sample is accumulated (sum of baseline,
+    * sum of reduced, sample count) so the §6 "monotone reduction" gate can check that
+    * the sampled mean reduced < mean baseline. Cheap: one relaxed-atomic counter gates
+    * the sample, and the three accumulators are relaxed atomics. */
+   void gw_stat_record_token_delta(int baseline_tokens, int reduced_tokens);
+   uint64_t gw_stat_token_sample_count(void);
+   uint64_t gw_stat_token_baseline_sum(void);
+   uint64_t gw_stat_token_reduced_sum(void);
+
    /* Human-readable dump of every non-zero counter, one `name value` per line
     * (Prometheus-ish), for a /metrics-style endpoint or diagnostics. */
    void gw_stat_dump(FILE *out);

--- a/src/headers/gw_mutate_stats.h
+++ b/src/headers/gw_mutate_stats.h
@@ -44,9 +44,10 @@ extern "C"
    /* Sampled pre/post token-delta (§4 gateway_token_delta_pre_post_sampled). Called on
     * every APPLIED mutation with the reducer's baseline + reduced token counts; a
     * deterministic 1-in-GW_STAT_TOKEN_SAMPLE_N sample is accumulated (sum of baseline,
-    * sum of reduced, sample count) so the §6 "monotone reduction" gate can check that
-    * the sampled mean reduced < mean baseline. Cheap: one relaxed-atomic counter gates
-    * the sample, and the three accumulators are relaxed atomics. */
+    * sum of reduced, sample count) so the §6 net-shrink gate can check that the sampled
+    * mean reduced < sampled mean baseline. Cheap: one relaxed-atomic counter gates the
+    * sample; the sums are published before the count so a concurrent dump never sees a
+    * count ahead of its sums. */
    void gw_stat_record_token_delta(int baseline_tokens, int reduced_tokens);
    uint64_t gw_stat_token_sample_count(void);
    uint64_t gw_stat_token_baseline_sum(void);

--- a/src/server/gateway_mutate_wire.c
+++ b/src/server/gateway_mutate_wire.c
@@ -111,13 +111,15 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
       context_reduce_result_free(&res); /* res.messages still owned by res -> freed here */
       return;
    }
-   res.messages = NULL; /* ownership moved into container */
+   res.messages = NULL;                    /* ownership moved into container */
+   int baseline_tok = res.baseline_tokens; /* capture the token counts before freeing res */
+   int reduced_tok = res.reduced_tokens;
    context_reduce_result_free(&res);
 
    gw_provenance_mark_reduced(&ctx->st); /* mark ONLY after replace succeeds */
    ctx->mutated = 1;
    gw_stat_inc(GW_STAT_MUTATE_APPLIED);
-   gw_stat_record_token_delta(res.baseline_tokens, res.reduced_tokens); /* sampled §4 */
+   gw_stat_record_token_delta(baseline_tok, reduced_tok); /* sampled §4 */
 }
 
 gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int http_status,

--- a/src/server/gateway_mutate_wire.c
+++ b/src/server/gateway_mutate_wire.c
@@ -117,6 +117,7 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    gw_provenance_mark_reduced(&ctx->st); /* mark ONLY after replace succeeds */
    ctx->mutated = 1;
    gw_stat_inc(GW_STAT_MUTATE_APPLIED);
+   gw_stat_record_token_delta(res.baseline_tokens, res.reduced_tokens); /* sampled §4 */
 }
 
 gw_post_action_t gw_buffered_after_status(cJSON *container, const char *key, int http_status,

--- a/src/server/gw_mutate_stats.c
+++ b/src/server/gw_mutate_stats.c
@@ -112,10 +112,13 @@ void gw_stat_record_token_delta(int baseline_tokens, int reduced_tokens)
    uint64_t n = atomic_fetch_add_explicit(&g_token_seen, 1, memory_order_relaxed);
    if (n % GW_STAT_TOKEN_SAMPLE_N != 0)
       return;
-   atomic_fetch_add_explicit(&g_token_sample_count, 1, memory_order_relaxed);
+   /* Publish the sums BEFORE the count so a concurrent gw_stat_dump that reads count
+    * then sums never sees a count ahead of its sums (at worst the sums are momentarily
+    * ahead — a conservative mean, never a torn over-count). */
    atomic_fetch_add_explicit(&g_token_baseline_sum, (uint64_t)baseline_tokens,
                              memory_order_relaxed);
    atomic_fetch_add_explicit(&g_token_reduced_sum, (uint64_t)reduced_tokens, memory_order_relaxed);
+   atomic_fetch_add_explicit(&g_token_sample_count, 1, memory_order_relaxed);
 }
 
 uint64_t gw_stat_token_sample_count(void)

--- a/src/server/gw_mutate_stats.c
+++ b/src/server/gw_mutate_stats.c
@@ -23,6 +23,13 @@ static reason_entry_t g_reasons[GW_STAT_REASON_MAX];
 static int g_reason_n;
 static pthread_mutex_t g_reason_lock = PTHREAD_MUTEX_INITIALIZER;
 
+/* Sampled token-delta accumulators (1-in-N deterministic sample). */
+#define GW_STAT_TOKEN_SAMPLE_N 100
+static _Atomic uint64_t g_token_seen;         /* applied mutations seen (for the sample gate) */
+static _Atomic uint64_t g_token_sample_count; /* samples actually recorded */
+static _Atomic uint64_t g_token_baseline_sum;
+static _Atomic uint64_t g_token_reduced_sum;
+
 void gw_stat_inc(gw_stat_t which)
 {
    if (which < 0 || which >= GW_STAT__COUNT)
@@ -97,6 +104,33 @@ uint64_t gw_stat_get_reason(const char *group, const char *reason)
    return v;
 }
 
+void gw_stat_record_token_delta(int baseline_tokens, int reduced_tokens)
+{
+   if (baseline_tokens < 0 || reduced_tokens < 0)
+      return;
+   /* Deterministic 1-in-N sample: only every Nth applied mutation is accumulated. */
+   uint64_t n = atomic_fetch_add_explicit(&g_token_seen, 1, memory_order_relaxed);
+   if (n % GW_STAT_TOKEN_SAMPLE_N != 0)
+      return;
+   atomic_fetch_add_explicit(&g_token_sample_count, 1, memory_order_relaxed);
+   atomic_fetch_add_explicit(&g_token_baseline_sum, (uint64_t)baseline_tokens,
+                             memory_order_relaxed);
+   atomic_fetch_add_explicit(&g_token_reduced_sum, (uint64_t)reduced_tokens, memory_order_relaxed);
+}
+
+uint64_t gw_stat_token_sample_count(void)
+{
+   return atomic_load_explicit(&g_token_sample_count, memory_order_relaxed);
+}
+uint64_t gw_stat_token_baseline_sum(void)
+{
+   return atomic_load_explicit(&g_token_baseline_sum, memory_order_relaxed);
+}
+uint64_t gw_stat_token_reduced_sum(void)
+{
+   return atomic_load_explicit(&g_token_reduced_sum, memory_order_relaxed);
+}
+
 static const char *g_flat_names[GW_STAT__COUNT] = {
     "gateway_mutate_attempted", "gateway_mutate_applied",       "gateway_4xx_restore_resend",
     "gateway_5xx_disable",      "gateway_stream_error_disable", "gateway_session_disabled_blocks",
@@ -111,6 +145,15 @@ void gw_stat_dump(FILE *out)
       uint64_t v = gw_stat_get((gw_stat_t)i);
       if (v)
          fprintf(out, "%s %llu\n", g_flat_names[i], (unsigned long long)v);
+   }
+   uint64_t sc = gw_stat_token_sample_count();
+   if (sc)
+   {
+      fprintf(out, "gateway_token_delta_sample_count %llu\n", (unsigned long long)sc);
+      fprintf(out, "gateway_token_delta_baseline_sum %llu\n",
+              (unsigned long long)gw_stat_token_baseline_sum());
+      fprintf(out, "gateway_token_delta_reduced_sum %llu\n",
+              (unsigned long long)gw_stat_token_reduced_sum());
    }
    pthread_mutex_lock(&g_reason_lock);
    for (int i = 0; i < g_reason_n; i++)
@@ -140,6 +183,10 @@ void gw_stat_reset(void)
 {
    for (int i = 0; i < GW_STAT__COUNT; i++)
       atomic_store_explicit(&g_flat[i], 0, memory_order_relaxed);
+   atomic_store_explicit(&g_token_seen, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_token_sample_count, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_token_baseline_sum, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_token_reduced_sum, 0, memory_order_relaxed);
    pthread_mutex_lock(&g_reason_lock);
    memset(g_reasons, 0, sizeof(g_reasons));
    g_reason_n = 0;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -992,7 +992,8 @@ $(TESTPREFIX)/unit-test-gateway-mutate-wire: $(OBJDIR)/tests/test_gateway_mutate
                      $(OBJDIR)/server/gateway_mutate_wire.o $(OBJDIR)/server/gateway_mutate.o \
                      $(OBJDIR)/server/msg_session_disable.o $(OBJDIR)/server/gw_mutate_stats.o \
                      $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/session_compact.o \
-                     $(OBJDIR)/server/tool_call_args.o $(OBJDIR)/harness_memory_common.o \
+                     $(OBJDIR)/server/tool_call_args.o $(OBJDIR)/server/token_tracker.o \
+                     $(OBJDIR)/harness_memory_common.o \
                      $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm -lpthread
 

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -234,7 +234,8 @@ static void test_token_delta_sampling(void)
 static void test_no_behavior_change_when_off(void)
 {
    /* With reduce_gateway_mutate off (default config in this test's HOME), the buffered
-    * mutate must be a byte-identical no-op even given a resolvable-looking identity. */
+    * mutate short-circuits at the flag gate BEFORE inspecting the payload, so the
+    * container is a byte-identical no-op for ANY input regardless of size/shape. */
    cJSON *c = container_with("payload");
    char *before = cJSON_PrintUnformatted(c);
    gw_mutate_ctx_t ctx;

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -209,6 +209,46 @@ static void test_stream_error_classify(void)
    assert(gw_status_is_invalid_request(200) == 0);
 }
 
+static void test_token_delta_sampling(void)
+{
+   gw_stat_reset();
+   /* 1-in-100 deterministic sample: the 1st call (n=0) is sampled; the next 99 are not. */
+   gw_stat_record_token_delta(1000, 500);
+   assert(gw_stat_token_sample_count() == 1);
+   assert(gw_stat_token_baseline_sum() == 1000);
+   assert(gw_stat_token_reduced_sum() == 500);
+   for (int i = 0; i < 99; i++)
+      gw_stat_record_token_delta(2000, 1900);
+   assert(gw_stat_token_sample_count() == 1); /* none of n=1..99 sampled */
+   gw_stat_record_token_delta(4000, 1000);    /* n=100 -> sampled */
+   assert(gw_stat_token_sample_count() == 2);
+   assert(gw_stat_token_baseline_sum() == 5000);
+   assert(gw_stat_token_reduced_sum() == 1500);
+   /* the §6 monotone-reduction property: sampled reduced sum < baseline sum */
+   assert(gw_stat_token_reduced_sum() < gw_stat_token_baseline_sum());
+   /* negatives ignored */
+   gw_stat_record_token_delta(-1, 5);
+   assert(gw_stat_token_baseline_sum() == 5000);
+}
+
+static void test_no_behavior_change_when_off(void)
+{
+   /* With reduce_gateway_mutate off (default config in this test's HOME), the buffered
+    * mutate must be a byte-identical no-op even given a resolvable-looking identity. */
+   cJSON *c = container_with("payload");
+   char *before = cJSON_PrintUnformatted(c);
+   gw_mutate_ctx_t ctx;
+   gw_buffered_mutate(c, "messages", "model", "sys", "0011223344556677", "bearer", "identity",
+                      &ctx);
+   char *after = cJSON_PrintUnformatted(c);
+   assert(before && after && strcmp(before, after) == 0);
+   assert(ctx.mutated == 0);
+   free(before);
+   free(after);
+   gw_mutate_ctx_free(&ctx);
+   cJSON_Delete(c);
+}
+
 int main(void)
 {
    printf("gateway_mutate_wire: ");
@@ -227,6 +267,8 @@ int main(void)
    test_dark_default_and_identityless();
    test_stream_disable();
    test_stream_error_classify();
+   test_token_delta_sampling();
+   test_no_behavior_change_when_off();
    printf("ok\n");
    return 0;
 }


### PR DESCRIPTION
Slice 8 (final code slice) of the **economizer gateway mutation** proposal (step 10 + telemetry/docs), **default-OFF**.

## Telemetry
`gw_stat_record_token_delta` — a deterministic **1-in-100** sample of the reducer's baseline vs reduced token counts (sum + count, relaxed atomics; sums published before the count so a scrape never sees a count ahead of its sums). Wired into `gw_buffered_mutate` on **apply**; emitted by `gw_stat_dump`; reset in `gw_stat_reset`. This feeds the `.254` net-shrink gate (sampled `reduced_sum < baseline_sum`).

## Tests (`test_gateway_mutate_wire.c`)
- token-delta sampling: the 1-in-100 cadence, the net-shrink property, negatives ignored.
- **no-behavior-change**: with `mutate` off, `gw_buffered_mutate` is **byte-identical** on the container (the flag gate short-circuits before payload inspection) even with a resolvable-looking identity.

Provenance §2.6 matrix is covered across `test_gateway_mutate` (mark/clear) + `test_gateway_mutate_wire` (4xx/5xx clear) + `test_context_reduce` (gateway→delegate hand-off).

## Docs
`docs/features/economizer-gateway-mutation.md` — operator guide: flags, per-path contract (buffered restore-resend / streaming disable-only), the per-session breaker, the safety contract, telemetry (incl. the 1-in-100 sampling), and rollout/rollback. Records the verified finding that OpenAI `/v1/responses` streaming inherits the buffered treatment (no true upstream streaming), so there is no OpenAI-specific streaming code (**S7 subsumed by S6**).

## Review
Roundtable-reviewed (non-degraded). Fixed: publish-sums-before-count; capture token counts before the reduce-result free; doc sampling note + key-spelling. Full `unit-tests` green.

This completes the economizer gateway-mutation **code**. Remaining (carried, gate the separate default-ON decision): the `.254` ≥7-day live validation (AC#7) and the snapshot-cost benchmark (AC#8).