### PR TITLE
fix(client): register the SessionStart hook for Claude Code (persona/skills brief never injected)

### DIFF
--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -1042,6 +1042,18 @@ static void ensure_claude_code_hooks(const char *settings_path)
       }
    }
 
+   /* Session-level injection: the SessionStart hook is what delivers aimee's
+    * session brief (`aimee session-start` -> session_start_emit -> the persona
+    * principles/brief, the MCP-skill index, Rules, and Key Facts via
+    * build_session_context) as additionalContext. Without it the primary agent
+    * starts with NO aimee persona/skills/rules context -- the per-turn
+    * UserPromptSubmit + PreCompact hooks only re-prime memory RECALL, not the
+    * brief, so this is the seam that establishes identity. No matcher: it fires
+    * on startup/resume/clear AND compact, so the brief is re-injected after a
+    * compaction (which PreCompact's recall-only re-prime does not restore).
+    * session_start_emit gates its heavy startup work (db check, worktree
+    * checkout) on is_startup, so the non-startup sources stay cheap. */
+   ensure_aimee_event_hook(hooks, "SessionStart", "session-start", NULL, &dirty);
    /* Context pre-injection hooks: the P1 per-turn UserPromptSubmit envelope and
     * the P3 PreCompact re-prime. Both fire with no matcher and soft-fail, so
     * they never block a turn. */

--- a/src/tests/test_client_integrations.c
+++ b/src/tests/test_client_integrations.c
@@ -105,6 +105,25 @@ static void test_mcp_config_uses_resolved_command(void)
    cJSON_Delete(server);
 }
 
+/* 1 if hooks[event] has an entry whose command contains `needle`. */
+static int hook_event_has_cmd(cJSON *hooks, const char *event, const char *needle)
+{
+   cJSON *arr = cJSON_GetObjectItemCaseSensitive(hooks, event);
+   if (!cJSON_IsArray(arr))
+      return 0;
+   for (int i = 0; i < cJSON_GetArraySize(arr); i++)
+   {
+      cJSON *ha = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(arr, i), "hooks");
+      for (int j = 0; cJSON_IsArray(ha) && j < cJSON_GetArraySize(ha); j++)
+      {
+         cJSON *c = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(ha, j), "command");
+         if (cJSON_IsString(c) && strstr(c->valuestring, needle))
+            return 1;
+      }
+   }
+   return 0;
+}
+
 /* --- Test read_json_file --- */
 
 static void test_read_json_file_missing(void)
@@ -310,6 +329,15 @@ static void test_claude_hooks_create_post_hook_on_fresh_settings(void)
          break;
    }
    assert(found);
+
+   /* Regression: the SessionStart hook MUST be registered -- it is the seam that
+    * delivers aimee's session brief (persona principles/brief + MCP-skill index +
+    * Rules + Key Facts via `aimee session-start`). Its absence left the primary
+    * agent with no aimee persona/skills/rules context. The per-turn context hooks
+    * are registered alongside it. */
+   assert(hook_event_has_cmd(hooks, "SessionStart", "session-start"));
+   assert(hook_event_has_cmd(hooks, "UserPromptSubmit", "user-prompt-submit"));
+   assert(hook_event_has_cmd(hooks, "PreCompact", "pre-compact"));
    cJSON_Delete(root);
 
    char cmd[512];


### PR DESCRIPTION
## Fix: Claude Code primaries never got aimee's SessionStart brief (persona / skills / rules)

### The bug
`ensure_claude_code_hooks()` (`src/client_integrations.c`) registers `UserPromptSubmit`, `PreCompact`, `PreToolUse`, and `PostToolUse` into `~/.claude/settings.json` — but **never `SessionStart`**. Yet the `aimee session-start` handler exists (`cli_main.c` / `cli_session_start.c`) and the code comments assume it's wired (*"settings.json wires it as `aimee session-start`"*, *"session-level identity/preferences/rules already land at SessionStart"*).

Consequence: for **every Claude Code primary session**, the aimee session brief that `session_start_emit` → `build_session_context` renders — the active persona's principles/brief (default **`engineer`**), the **MCP-skill index**, **Rules**, and **Key Facts** — was **never injected** as SessionStart `additionalContext`. The per-turn `UserPromptSubmit` + `PreCompact` hooks only re-prime memory *recall*, not the brief, so the primary agent started with **no aimee persona/skills/rules identity at all**. (`git log -S "session-start"` shows the string never existed in this file — never wired, not a regression.)

### The fix
Register `SessionStart → aimee session-start` alongside the other hooks. `NULL` matcher is intentional: it fires on startup/resume/clear **and compact**, so the full persona/skills brief is also **restored after a compaction** — which `PreCompact`'s recall-only re-prime does not do. `session_start_emit` gates its heavy startup work (db check, worktree checkout) on `is_startup`, so the non-startup sources stay cheap.

### Verification
- `test_client_integrations` now asserts `SessionStart` (+ `UserPromptSubmit`/`PreCompact`) are registered; passes.
- **E2E:** running the fixed `aimee doctor` against a scratch `HOME` writes a `settings.json` whose hooks include `SessionStart → "AIMEE_HOOK_CLIENT=claude <aimee> session-start"` (absent before the fix).
- Both build systems build clean `-Werror`; `make lint` green (line-check + clang-format-19).
- Roundtable-reviewed (non-degraded, **BLOCKING NONE**); the panel confirmed the compact-firing is beneficial (restores persona/skills that compact drops), not harmful.

### Operator note
This takes effect for a session once the fixed binary is deployed and `ensure_client_integrations` runs (next `aimee` command rewrites `settings.json`), then the **next** Claude Code session start. The currently-deployed binary already has the `session-start` handler — only the registration was missing — so even adding the hook to an existing `settings.json` would activate the brief on the next session.
