### PR TITLE
feat(wfe): PC1 — richer autonomy failure taxonomy (Q4)

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -118,6 +118,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-wfe-autonomy \
                $(TESTPREFIX)/unit-test-wfe-custom \
                $(TESTPREFIX)/unit-test-wfe-safety \
+               $(TESTPREFIX)/unit-test-wfe-failure-taxonomy \
                $(TESTPREFIX)/unit-test-wfe-delegate-seam \
                $(TESTPREFIX)/unit-test-wfe-scheduler \
                $(TESTPREFIX)/unit-test-wfe-random-delegate \
@@ -1545,6 +1546,10 @@ $(TESTPREFIX)/unit-test-wfe-safety: $(OBJDIR)/tests/test_wfe_safety.o \
                                     $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
                                     $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-wfe-failure-taxonomy: $(OBJDIR)/tests/test_wfe_failure_taxonomy.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm
 
 $(TESTPREFIX)/unit-test-wfe-delegate-seam: $(OBJDIR)/tests/test_wfe_delegate_seam.o \
                                     $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \

--- a/src/tests/test_wfe_failure_taxonomy.c
+++ b/src/tests/test_wfe_failure_taxonomy.c
@@ -1,0 +1,65 @@
+/* test_wfe_failure_taxonomy.c: the Phase-C failure taxonomy (Q4). The classifier is
+ * the single place the autonomy run loop's retry/terminal/park decision lives, and
+ * its core invariant is NEVER auto-retry without genuinely new input. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "wfe_iface.h"
+
+static void test_disposition(void)
+{
+   /* transient: retry ONLY with new input, else park stuck (no spin) */
+   assert(wfe_failure_disposition(WFE_FAIL_TRANSIENT, 1) == WFE_FDISP_RETRY);
+   assert(wfe_failure_disposition(WFE_FAIL_TRANSIENT, 0) == WFE_FDISP_PARK_STUCK);
+
+   /* terminal-reject classes */
+   assert(wfe_failure_disposition(WFE_FAIL_REFUSAL, 0) == WFE_FDISP_TERMINAL);
+   assert(wfe_failure_disposition(WFE_FAIL_REFUSAL, 1) == WFE_FDISP_TERMINAL); /* input ignored */
+   assert(wfe_failure_disposition(WFE_FAIL_PERMANENT, 0) == WFE_FDISP_TERMINAL);
+   assert(wfe_failure_disposition(WFE_FAIL_CORRUPTION, 0) == WFE_FDISP_TERMINAL);
+   assert(wfe_failure_disposition(WFE_FAIL_NONE, 0) == WFE_FDISP_TERMINAL); /* unclassified stops */
+
+   /* park-for-human classes */
+   assert(wfe_failure_disposition(WFE_FAIL_DEGRADED, 0) == WFE_FDISP_PARK_HUMAN);
+   assert(wfe_failure_disposition(WFE_FAIL_BUDGET, 0) == WFE_FDISP_PARK_HUMAN);
+   assert(wfe_failure_disposition(WFE_FAIL_FORGE, 0) == WFE_FDISP_PARK_HUMAN);
+   printf("  PASS: disposition mapping (never-retry-without-new-input)\n");
+}
+
+static void test_constructors(void)
+{
+   /* back-compat: an unclassified failed() is a conservative PERMANENT terminal */
+   wfe_step_result_t f = wfe_step_failed();
+   assert(f.status == WFE_STEP_FAILED);
+   assert(f.failure_class == WFE_FAIL_PERMANENT);
+   assert(f.failure_has_new_input == 0);
+   assert(wfe_failure_disposition(f.failure_class, f.failure_has_new_input) == WFE_FDISP_TERMINAL);
+
+   /* classified transient with new input -> retry */
+   wfe_step_result_t t = wfe_step_failed_class(WFE_FAIL_TRANSIENT, 1);
+   assert(t.status == WFE_STEP_FAILED);
+   assert(t.failure_class == WFE_FAIL_TRANSIENT);
+   assert(t.failure_has_new_input == 1);
+   assert(wfe_failure_disposition(t.failure_class, t.failure_has_new_input) == WFE_FDISP_RETRY);
+
+   /* a WFE_FAIL_NONE passed to the classed constructor is normalized to PERMANENT
+    * (never a silently-unclassified FAILED that reads as "not a failure") */
+   wfe_step_result_t n = wfe_step_failed_class(WFE_FAIL_NONE, 1);
+   assert(n.failure_class == WFE_FAIL_PERMANENT);
+
+   /* degraded -> park human */
+   wfe_step_result_t d = wfe_step_failed_class(WFE_FAIL_DEGRADED, 0);
+   assert(wfe_failure_disposition(d.failure_class, d.failure_has_new_input) ==
+          WFE_FDISP_PARK_HUMAN);
+   printf("  PASS: constructors + back-compat\n");
+}
+
+int main(void)
+{
+   printf("wfe_failure_taxonomy:\n");
+   test_disposition();
+   test_constructors();
+   printf("ok\n");
+   return 0;
+}

--- a/src/tests/test_wfe_failure_taxonomy.c
+++ b/src/tests/test_wfe_failure_taxonomy.c
@@ -19,6 +19,9 @@ static void test_disposition(void)
    assert(wfe_failure_disposition(WFE_FAIL_PERMANENT, 0) == WFE_FDISP_TERMINAL);
    assert(wfe_failure_disposition(WFE_FAIL_CORRUPTION, 0) == WFE_FDISP_TERMINAL);
    assert(wfe_failure_disposition(WFE_FAIL_NONE, 0) == WFE_FDISP_TERMINAL); /* unclassified stops */
+   assert(wfe_failure_disposition(WFE_FAIL_NONE, 1) ==
+          WFE_FDISP_TERMINAL); /* has_new_input ignored */
+   assert(wfe_failure_disposition(WFE_FAIL_PERMANENT, 1) == WFE_FDISP_TERMINAL);
 
    /* park-for-human classes */
    assert(wfe_failure_disposition(WFE_FAIL_DEGRADED, 0) == WFE_FDISP_PARK_HUMAN);

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -178,7 +178,13 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
       }
       if (r.last_status == WFE_STEP_FAILED)
       {
-         wfe_autonomy_cleanup_worktree(work_item_id);
+         /* Phase-C taxonomy: only a TERMINAL disposition tears down the worktree; a
+          * park-for-human or park-stuck keeps it so a human resume / new-input retry
+          * can pick up where it left off. (Retryable-with-new-input uses the LOOPED
+          * path, which never reaches here.) */
+         if (wfe_failure_disposition(r.failure_class, r.failure_has_new_input) ==
+             WFE_FDISP_TERMINAL)
+            wfe_autonomy_cleanup_worktree(work_item_id);
          return 0;
       }
       if (r.last_status != WFE_STEP_PENDING)

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -468,7 +468,7 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
       return with_cost(wfe_step_looped(), cost);
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
-      return with_cost(wfe_step_failed(), cost);
+      return with_cost(wfe_step_failed_class(WFE_FAIL_CORRUPTION, 0), cost); /* worktree/git */
    /* Mechanical verify gate (WP-1b): a unit only advances if it PASSES. A failed
     * verdict loops back to implement (the engine bounds the retries via
     * stage_attempt and parks max_attempts on exhaustion); a re-dispatched fresh
@@ -498,7 +498,7 @@ static wfe_step_result_t exec_document(wfe_ctx *ctx, const wfe_node_t *node)
       return with_cost(wfe_step_looped(), cost);
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
-      return with_cost(wfe_step_failed(), cost);
+      return with_cost(wfe_step_failed_class(WFE_FAIL_CORRUPTION, 0), cost); /* worktree/git */
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
    return wfe_step_advanced(handle, head, cost);
@@ -729,7 +729,7 @@ static wfe_step_result_t exec_custom(wfe_ctx *ctx, const wfe_node_t *node)
    if (c->produces == WFE_ART_BRANCH)
    {
       if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
-         return wfe_step_failed();
+         return wfe_step_failed_class(WFE_FAIL_CORRUPTION, 0);
       return wfe_step_advanced(handle, head, 0.0);
    }
    return wfe_step_advanced(handle, "", 0.0); /* produces: none (sink) */

--- a/src/workflow/wfe_engine.c
+++ b/src/workflow/wfe_engine.c
@@ -304,6 +304,8 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
    wfe_ctx ctx = {work_item_id, def, node, &wi};
    wfe_step_result_t r = fn(&ctx, node);
    out->last_status = r.status;
+   out->failure_class = r.failure_class;
+   out->failure_has_new_input = r.failure_has_new_input;
    if (r.cost_usd > 0)
       WFE_CKW(db1_work_item_add_cost(work_item_id, r.cost_usd));
    /* post-executor budget re-check: a single step's cost can push over the cap,
@@ -329,10 +331,26 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
    }
    else if (r.status == WFE_STEP_FAILED)
    {
-      /* park with a NON-empty pause_reason so the next advance treats it as
-       * parked (an empty reason reads as "not parked" -> re-runs the node). */
-      WFE_CKW(db1_work_item_set_pause(work_item_id, "failed", node->id));
-      db1_lifecycle_event_add(work_item_id, node->id, "failed", "engine", "", "", r.cost_usd);
+      /* Phase-C failure taxonomy: derive the pause reason from the failure class so
+       * the run loop + UI can distinguish a terminal reject from a park-for-human
+       * from a stuck (transient without new input). Park with a NON-empty reason so
+       * the next advance treats it as parked (empty reads as "not parked"). */
+      wfe_failure_disposition_t disp =
+          wfe_failure_disposition(r.failure_class, r.failure_has_new_input);
+      const char *reason = "failed"; /* terminal-reject (refusal/permanent/corruption) */
+      const char *detail = "terminal";
+      if (disp == WFE_FDISP_PARK_HUMAN)
+      {
+         reason = "pending_human"; /* degraded / budget / forge -> human resumes */
+         detail = "park_human";
+      }
+      else if (disp == WFE_FDISP_PARK_STUCK)
+      {
+         reason = "stuck"; /* transient without new input -> no spin (stuck-skip guard) */
+         detail = "park_stuck";
+      }
+      WFE_CKW(db1_work_item_set_pause(work_item_id, reason, node->id));
+      db1_lifecycle_event_add(work_item_id, node->id, "failed", "engine", detail, "", r.cost_usd);
    }
    else
    {

--- a/src/workflow/wfe_engine.c
+++ b/src/workflow/wfe_engine.c
@@ -331,23 +331,37 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
    }
    else if (r.status == WFE_STEP_FAILED)
    {
-      /* Phase-C failure taxonomy: derive the pause reason from the failure class so
-       * the run loop + UI can distinguish a terminal reject from a park-for-human
-       * from a stuck (transient without new input). Park with a NON-empty reason so
-       * the next advance treats it as parked (empty reads as "not parked"). */
-      wfe_failure_disposition_t disp =
-          wfe_failure_disposition(r.failure_class, r.failure_has_new_input);
-      const char *reason = "failed"; /* terminal-reject (refusal/permanent/corruption) */
-      const char *detail = "terminal";
-      if (disp == WFE_FDISP_PARK_HUMAN)
+      /* Phase-C failure taxonomy: derive the pause reason from the failure class,
+       * REUSING the existing reason strings (budget_exceeded / panel_degraded /
+       * stuck / pending_human / failed) so the scheduler + UI need no new vocabulary
+       * (the run loop already skips a 'stuck' item; park_budget already uses
+       * 'budget_exceeded'). The lifecycle-event detail stays EMPTY for the legacy
+       * terminal case (byte-inert for any consumer of the old wfe_step_failed()
+       * events); only the new dispositions carry a tag. A retryable failure must be
+       * returned as LOOPED, never FAILED — a FAILED that claims retry can't loop from
+       * here, so it parks 'stuck' (visible, no silent terminal-stop). */
+      const char *reason = "failed"; /* REFUSAL / PERMANENT / CORRUPTION / NONE -> terminal */
+      const char *detail = "";       /* legacy-inert for terminal */
+      switch (r.failure_class)
       {
-         reason = "pending_human"; /* degraded / budget / forge -> human resumes */
-         detail = "park_human";
-      }
-      else if (disp == WFE_FDISP_PARK_STUCK)
-      {
-         reason = "stuck"; /* transient without new input -> no spin (stuck-skip guard) */
-         detail = "park_stuck";
+      case WFE_FAIL_BUDGET:
+         reason = "budget_exceeded";
+         detail = "budget";
+         break;
+      case WFE_FAIL_DEGRADED:
+         reason = "panel_degraded";
+         detail = "degraded";
+         break;
+      case WFE_FAIL_FORGE:
+         reason = "pending_human";
+         detail = "forge";
+         break;
+      case WFE_FAIL_TRANSIENT:
+         reason = "stuck";
+         detail = r.failure_has_new_input ? "retry_expected_looped" : "park_stuck";
+         break;
+      default:
+         break; /* terminal-reject: reason "failed", detail "" (inert) */
       }
       WFE_CKW(db1_work_item_set_pause(work_item_id, reason, node->id));
       db1_lifecycle_event_add(work_item_id, node->id, "failed", "engine", detail, "", r.cost_usd);

--- a/src/workflow/wfe_engine.h
+++ b/src/workflow/wfe_engine.h
@@ -45,6 +45,11 @@ typedef struct
    int terminal;                /* reached a terminal state this step */
    char state[24];              /* active | accepted | rejected | abandoned */
    wfe_pause_reason_t pause_reason;
+   /* Phase-C failure taxonomy (meaningful iff last_status == WFE_STEP_FAILED),
+    * propagated from the executor's step result so the autonomy run loop can route
+    * retry / terminal-reject / park without re-deriving the reason. */
+   wfe_failure_class_t failure_class;
+   int failure_has_new_input;
 } wfe_advance_result_t;
 
 /* Advance the work item exactly one step. Returns 0 on a clean step (incl.

--- a/src/workflow/wfe_iface.c
+++ b/src/workflow/wfe_iface.c
@@ -107,7 +107,40 @@ wfe_step_result_t wfe_step_failed(void)
    wfe_step_result_t r;
    memset(&r, 0, sizeof r);
    r.status = WFE_STEP_FAILED;
+   /* Back-compat: an unclassified failed() is a conservative terminal stop. */
+   r.failure_class = WFE_FAIL_PERMANENT;
    return r;
+}
+
+wfe_step_result_t wfe_step_failed_class(wfe_failure_class_t cls, int has_new_input)
+{
+   wfe_step_result_t r;
+   memset(&r, 0, sizeof r);
+   r.status = WFE_STEP_FAILED;
+   r.failure_class = (cls == WFE_FAIL_NONE) ? WFE_FAIL_PERMANENT : cls;
+   r.failure_has_new_input = has_new_input ? 1 : 0;
+   return r;
+}
+
+wfe_failure_disposition_t wfe_failure_disposition(wfe_failure_class_t cls, int has_new_input)
+{
+   switch (cls)
+   {
+   case WFE_FAIL_TRANSIENT:
+      /* The core invariant: retry ONLY with genuinely new input, else park stuck so
+       * the scheduler cannot spin on an identical re-dispatch. */
+      return has_new_input ? WFE_FDISP_RETRY : WFE_FDISP_PARK_STUCK;
+   case WFE_FAIL_DEGRADED:
+   case WFE_FAIL_BUDGET:
+   case WFE_FAIL_FORGE:
+      return WFE_FDISP_PARK_HUMAN;
+   case WFE_FAIL_REFUSAL:
+   case WFE_FAIL_PERMANENT:
+   case WFE_FAIL_CORRUPTION:
+   case WFE_FAIL_NONE:
+   default:
+      return WFE_FDISP_TERMINAL;
+   }
 }
 
 wfe_step_result_t wfe_step_looped(void)

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -80,6 +80,22 @@ typedef enum
                             * be determined (transient/unknown) -- re-drive later */
 } wfe_pause_reason_t;
 
+/* Failure taxonomy (Phase-C Q4): how the autonomy run loop should react to a
+ * WFE_STEP_FAILED result. The core invariant is NEVER auto-retry without genuinely
+ * NEW input (a CI log / verify findings / a roundtable verdict) — a bare re-dispatch
+ * of the same prompt is not a retry, it is a spin, so it parks instead. */
+typedef enum
+{
+   WFE_FAIL_NONE = 0,  /* unclassified -> treated as PERMANENT (conservative: stop) */
+   WFE_FAIL_TRANSIENT, /* retryable IFF has_new_input, else park stuck */
+   WFE_FAIL_REFUSAL,   /* model/agent refused -> terminal-reject */
+   WFE_FAIL_PERMANENT, /* a permanent error -> terminal-reject */
+   WFE_FAIL_DEGRADED,  /* roundtable/panel degraded / exhausted retries -> park human */
+   WFE_FAIL_BUDGET,    /* budget breach -> park human */
+   WFE_FAIL_FORGE,     /* git/forge op failed -> park human */
+   WFE_FAIL_CORRUPTION /* worktree/tree corruption -> terminal */
+} wfe_failure_class_t;
+
 typedef struct
 {
    wfe_step_status_t status;
@@ -88,6 +104,11 @@ typedef struct
    char artifact_handle[64];        /* produced-artifact handle id, or "" */
    char content_hash[65];           /* sha256 hex of produced artifact, or "" */
    double cost_usd;                 /* cost incurred by this step */
+   /* Phase-C failure taxonomy (meaningful iff status == WFE_STEP_FAILED). Default 0
+    * (WFE_FAIL_NONE, no new input) preserves the pre-taxonomy "stop" behavior for any
+    * executor that has not been taught the classes. */
+   wfe_failure_class_t failure_class;
+   int failure_has_new_input; /* 1 iff a TRANSIENT failure carries genuinely new input */
 } wfe_step_result_t;
 
 /* ---- Executor vtable: gates ARE ordinary block executors (one call-site) ---- */
@@ -108,6 +129,21 @@ wfe_step_result_t wfe_step_advanced(const char *artifact_handle, const char *con
 wfe_step_result_t wfe_step_pending(wfe_pause_reason_t reason);
 wfe_step_result_t wfe_step_failed(void);
 wfe_step_result_t wfe_step_looped(void);
+
+/* A classified failure (Phase-C Q4). has_new_input is honored only for
+ * WFE_FAIL_TRANSIENT (retry vs park-stuck); ignored for the other classes. */
+wfe_step_result_t wfe_step_failed_class(wfe_failure_class_t cls, int has_new_input);
+
+/* Map a failure class to the run-loop disposition, so the routing lives in one
+ * place (exposed for the unit test). */
+typedef enum
+{
+   WFE_FDISP_TERMINAL = 0, /* cleanup + stop (terminal-reject / corruption) */
+   WFE_FDISP_PARK_HUMAN,   /* park pending_human (degraded / budget / forge) */
+   WFE_FDISP_RETRY,        /* loop back with new input (transient + new input) */
+   WFE_FDISP_PARK_STUCK    /* transient without new input -> park stuck (no spin) */
+} wfe_failure_disposition_t;
+wfe_failure_disposition_t wfe_failure_disposition(wfe_failure_class_t cls, int has_new_input);
 
 /* ---- Autonomous merge-target rail (WP-5 safety) ----
  * The single source of truth for the branch an autonomous run may target for a


### PR DESCRIPTION
Phase-C depth for **full-autonomous-development** (the deferred Q4 item). Turns the coarse `WFE_STEP_FAILED` (always park "failed" + stop) into a **classified disposition**. Core invariant: **never auto-retry without genuinely new input**.

## What
- `wfe_failure_class_t` `{TRANSIENT, REFUSAL, PERMANENT, DEGRADED, BUDGET, FORGE, CORRUPTION}` + `failure_class`/`failure_has_new_input` on `wfe_step_result_t` (additive; default `WFE_FAIL_NONE` preserves the old stop behavior).
- `wfe_step_failed_class(cls, has_new_input)`; `wfe_step_failed()` = `PERMANENT` (back-compat).
- `wfe_failure_disposition()` — single source of routing: `TRANSIENT`+new-input → **RETRY** (the existing LOOPED path); `TRANSIENT`+no-new-input → **PARK_STUCK** (no spin); `REFUSAL`/`PERMANENT`/`CORRUPTION` → **TERMINAL**; `DEGRADED`/`BUDGET`/`FORGE` → **PARK_HUMAN**.
- Engine derives the pause reason from the class, **reusing existing reason strings** (`budget_exceeded`/`panel_degraded`/`stuck`/`pending_human`/`failed`) so the scheduler + UI need no new vocabulary; legacy terminal failures keep an **empty** event detail (byte-inert). Run loop tears down the worktree **only on TERMINAL** (park keeps it for resume).
- Freeze/git failures wired to `CORRUPTION` (demonstration; same TERMINAL disposition).

## Safety / inertness
Existing executors all use `wfe_step_failed()` = `PERMANENT` = the old "failed" park with empty detail — **identical behavior**. The `DEGRADED`/`FORGE`/`PARK_STUCK` classes are produced by PC2/PC3. A `stuck` park is already skipped by the run loop (pre-existing `park_stuck` guard), so no spin.

## Tests
`test_wfe_failure_taxonomy`: the disposition matrix (incl. `has_new_input` ignored for terminal classes), the never-retry-without-new-input invariant, and `wfe_step_failed()` back-compat. No regression (`wfe-advance`/`wfe-autonomy`/`wfe-delegate-seam` green).

## Review
Roundtable-reviewed. Fixed: reuse existing pause-reason strings; inert legacy event detail; defensive `stuck` park for a mis-returned RETRY-from-FAILED.

Foundation for PC2 (CI-webhook + red-CI retry) and PC3 (N-skeptic fan-out + patch-coordinator), which produce the `DEGRADED`/park classes.