### PR TITLE
test(client): lock in the full client-hook set + persona selectability (SessionStart regression)

### DIFF
--- a/src/tests/test_client_integrations.c
+++ b/src/tests/test_client_integrations.c
@@ -124,6 +124,35 @@ static int hook_event_has_cmd(cJSON *hooks, const char *event, const char *needl
    return 0;
 }
 
+/* Assert ensure_claude_code_hooks registered EVERY hook aimee relies on. This
+ * required set is INDEPENDENT of the production code's registration order/table
+ * on purpose -- so if any registration is ever dropped (as the SessionStart hook
+ * silently was, leaving the primary with no aimee session brief: the configured
+ * persona [default `engineer`, but operator-selectable via AIMEE_MODE / the mode
+ * file] + MCP-skill index + Rules + Key Facts, rendered by `aimee session-start`
+ * -> session_start_emit -> build_session_context), this fails. Adding a new client
+ * hook means adding it here too. Each entry: {settings.json event, the
+ * `aimee <subcommand>` it invokes}. Asserted for BOTH the fresh-settings and the
+ * add-to-an-existing-settings.json paths (the latter is the exact shape of the
+ * live regression: a settings.json that already had the other hooks but not
+ * SessionStart). */
+static void assert_required_hooks_present(cJSON *hooks)
+{
+   static const struct
+   {
+      const char *event;
+      const char *subcommand;
+   } required[] = {
+       {"SessionStart", "session-start"},          /* session brief: persona + skills + rules */
+       {"UserPromptSubmit", "user-prompt-submit"}, /* per-turn recall envelope */
+       {"PreCompact", "pre-compact"},              /* post-compact recall re-prime */
+       {"PreToolUse", "attention-guard"},          /* per-file attention + destructive-op guard */
+       {"PostToolUse", "hooks post"},              /* post-edit hook */
+   };
+   for (size_t i = 0; i < sizeof(required) / sizeof(required[0]); i++)
+      assert(hook_event_has_cmd(hooks, required[i].event, required[i].subcommand));
+}
+
 /* --- Test read_json_file --- */
 
 static void test_read_json_file_missing(void)
@@ -330,14 +359,8 @@ static void test_claude_hooks_create_post_hook_on_fresh_settings(void)
    }
    assert(found);
 
-   /* Regression: the SessionStart hook MUST be registered -- it is the seam that
-    * delivers aimee's session brief (persona principles/brief + MCP-skill index +
-    * Rules + Key Facts via `aimee session-start`). Its absence left the primary
-    * agent with no aimee persona/skills/rules context. The per-turn context hooks
-    * are registered alongside it. */
-   assert(hook_event_has_cmd(hooks, "SessionStart", "session-start"));
-   assert(hook_event_has_cmd(hooks, "UserPromptSubmit", "user-prompt-submit"));
-   assert(hook_event_has_cmd(hooks, "PreCompact", "pre-compact"));
+   /* Regression: from an empty settings.json, EVERY required hook is registered. */
+   assert_required_hooks_present(hooks);
    cJSON_Delete(root);
 
    char cmd[512];
@@ -376,6 +399,11 @@ static void test_claude_hooks_patch_existing_matcher(void)
    assert(strstr(matcher->valuestring, "Edit|Write|MultiEdit") != NULL);
    assert(strstr(matcher->valuestring, "EnterWorktree") != NULL);
    assert(strstr(matcher->valuestring, "ExitWorktree") != NULL);
+
+   /* Regression (the live shape of the SessionStart bug): a settings.json that
+    * already had SOME hooks must still get the MISSING ones added -- SessionStart
+    * in particular. Merging into an existing file must not skip a hook. */
+   assert_required_hooks_present(hooks);
    cJSON_Delete(root);
 
    char cmd[512];

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1873,6 +1873,34 @@ int main(void)
          platform_unsetenv("AIMEE_MODE");
    }
 
+   /* --- config_current_persona: the persona injected into the session-start
+    * brief is the CONFIGURED one, not a hardcoded 'engineer'. `engineer` is only
+    * the DEFAULT; it must be operator-selectable via AIMEE_MODE (or the mode
+    * file), including ARBITRARY/custom persona names (not just the built-in enum).
+    * Guards the persona-selection side of the session brief from regressing to
+    * engineer-only. */
+   {
+      char *old_mode = getenv("AIMEE_MODE");
+      char *saved = old_mode ? strdup(old_mode) : NULL;
+      char p[64];
+      platform_setenv("AIMEE_MODE", "reviewer");
+      config_current_persona(p, sizeof(p));
+      assert(strcmp(p, "reviewer") == 0); /* a non-default built-in persona */
+      platform_setenv("AIMEE_MODE", "my-custom-persona");
+      config_current_persona(p, sizeof(p));
+      assert(strcmp(p, "my-custom-persona") == 0); /* arbitrary name, verbatim */
+      platform_setenv("AIMEE_MODE", "engineer");
+      config_current_persona(p, sizeof(p));
+      assert(strcmp(p, "engineer") == 0); /* the default is selectable explicitly too */
+      if (saved)
+      {
+         platform_setenv("AIMEE_MODE", saved);
+         free(saved);
+      }
+      else
+         platform_unsetenv("AIMEE_MODE");
+   }
+
    /* --- AIMEE_DB2_URL env overrides a cached config-file db2_url ---
     * Regression for the kb IP-drift outage: when Postgres is recreated on a new
     * bridge IP the runtime injects the current address via AIMEE_DB2_URL, which


### PR DESCRIPTION
## Regression tests: SessionStart hook + persona selectability

Follow-up to #1025 (which restored the missing `SessionStart` hook). These tests guard the whole class of bug so it can't silently return.

### The failure class
An aimee client-hook *handler* can exist and be dispatched by `cli_main` (as `aimee session-start` was) yet be **silently never registered** into `~/.claude/settings.json` by `ensure_claude_code_hooks` — leaving the primary with no aimee session brief (the configured persona + MCP-skill index + Rules + Key Facts).

### What's added (test-only; no production change)
- **`test_client_integrations`** — `assert_required_hooks_present()` asserts an **independent** required set `{SessionStart, UserPromptSubmit, PreCompact, PreToolUse, PostToolUse}` is registered. It's deliberately *not* derived from the production registration list, so dropping any one **fails the test**. Asserted for **both** paths:
  - fresh/empty `settings.json` (registers all from scratch), and
  - an **existing** `settings.json` already carrying the other hooks but missing `SessionStart` — the exact shape of the live regression.
  - **Proven:** temporarily removing the `SessionStart` registration aborts the assertion (exit 134); restored, it passes.
- **`test_config`** — new `config_current_persona` coverage: the persona injected into the brief is the **configured** one — default `engineer`, but operator-selectable via `AIMEE_MODE` / the mode file, **including arbitrary custom persona names** — not hardcoded to engineer. Guards the persona-*selection* side from regressing to engineer-only.

### Verification
Full `make unit-tests` green; `make lint` green (line-check + clang-format-19). Test-only — production `client_integrations.c` is unchanged.
