### PR TITLE
feat(wfe): PC3b-1 — live adversarial judge provider (makes PC3a functional)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -230,7 +230,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 146 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 147 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -428,7 +428,7 @@ The binaries read 146 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CI_RETRY_MAX`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SKEPTICS`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CI_RETRY_MAX`, `AIMEE_AUTONOMY_FANOUT`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SKEPTICS`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -279,6 +279,103 @@ static int wfe_live_verify_run(const char *workdir, char *out_verdict, size_t n)
 
 static const wfe_verify_provider_t WFE_LIVE_VERIFY = {wfe_live_verify_run};
 
+/* Live judge provider (PC3): dispatch a reviewer/skeptic delegate to READ-ONLY judge
+ * the change in `workdir` and emit a {"refuted":bool} verdict. The delegate runs with
+ * tools (it can `git diff` + read files) but we do NOT commit — this is a judgment,
+ * not a producing step. Fail-closed: any dispatch error / a response that does not
+ * carry an explicit `"refuted": false` is treated as REFUTED, so the adversarial gate
+ * can never advance on an ambiguous verdict. */
+static int wfe_live_judge_run(const char *workdir, const char *lens, char *out_verdict, size_t n)
+{
+   if (out_verdict && n)
+      out_verdict[0] = '\0';
+   if (!workdir || !workdir[0])
+      return -1;
+   int is_skeptic = (lens && strcmp(lens, "skeptic") == 0);
+   /* reviewer -> the reviewer persona; skeptic -> the (adversarial) security persona,
+    * with the REFUTE framing carried by the prompt (lens diversity). */
+   const char *persona = is_skeptic ? "security" : "reviewer";
+
+   char prompt[2048];
+   if (is_skeptic)
+      snprintf(
+          prompt, sizeof prompt,
+          "You are an ADVERSARIAL skeptic reviewing an autonomous code change. Inspect the "
+          "change in this git worktree (e.g. `git diff HEAD~5..HEAD` and read the touched "
+          "files). Try HARD to REFUTE it: find a correctness bug, a broken or missing test, an "
+          "unmet requirement, or a security regression. Do NOT edit files. End your reply with "
+          "EXACTLY one JSON line and nothing after it: {\"refuted\": true, \"reason\": \"<the "
+          "flaw>\"} if you found a real flaw, or {\"refuted\": false} only if you genuinely "
+          "cannot refute it.");
+   else
+      snprintf(
+          prompt, sizeof prompt,
+          "Review the autonomous code change in this git worktree (e.g. `git diff "
+          "HEAD~5..HEAD` and read the touched files) for correctness and quality. Do NOT edit "
+          "files. End your reply with EXACTLY one JSON line and nothing after it: {\"refuted\": "
+          "false} if the change is sound, or {\"refuted\": true, \"reason\": \"<why>\"} if it "
+          "is flawed.");
+
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   if (agent_load_config(&acfg) != 0)
+      return -1;
+   char *sys_prompt = persona_compose_delegate_prompt(persona, workdir, "");
+   persona_t pinfo;
+   memset(&pinfo, 0, sizeof pinfo);
+   persona_load(NULL, persona, &pinfo);
+
+   run_cmd_set_cwd(workdir);
+   agent_result_t res;
+   memset(&res, 0, sizeof(res));
+   agent_t *chosen = NULL;
+   const char *chosen_role = NULL;
+   int best_tier = 0;
+   for (int ri = 0; ri < pinfo.roles_count && !chosen; ri++)
+   {
+      const char *r = delegate_role_canonicalize(pinfo.roles[ri]);
+      for (int ai = 0; ai < acfg.agent_count; ai++)
+      {
+         agent_t *ag = &acfg.agents[ai];
+         if (!ag->enabled || !agent_has_role(ag, r) || !agent_supports_persona(ag, persona) ||
+             !agent_is_available_for_routing(ag))
+            continue;
+         if (provider_catalog_get_health(ag->name) == CATALOG_HEALTH_DOWN)
+            continue;
+         if (!chosen || ag->cost_tier < best_tier)
+         {
+            chosen = ag;
+            chosen_role = r;
+            best_tier = ag->cost_tier;
+         }
+      }
+   }
+   int rc = -1;
+   if (chosen)
+      rc = agent_execute_with_tools_for_role(chosen, &acfg.network, chosen_role,
+                                             sys_prompt ? sys_prompt : "", prompt,
+                                             AGENT_DEFAULT_MAX_TOKENS, 0.2, &res);
+   run_cmd_set_cwd(NULL);
+   free(sys_prompt);
+   persona_free(&pinfo);
+
+   int refuted = 1; /* fail-closed default */
+   if (rc == 0 && res.response && res.response[0])
+   {
+      /* Accept ONLY on an explicit refuted:false; everything else -> refuted. */
+      if (strstr(res.response, "\"refuted\": false") || strstr(res.response, "\"refuted\":false"))
+         refuted = 0;
+   }
+   free(res.response);
+   if (rc != 0 && !chosen)
+      snprintf(out_verdict, n, "{\"refuted\":true,\"reason\":\"no judge agent available\"}");
+   else
+      snprintf(out_verdict, n, "{\"refuted\":%s}", refuted ? "true" : "false");
+   return 0; /* a verdict was produced (even a fail-closed one) */
+}
+
+static const wfe_judge_provider_t WFE_LIVE_JUDGE = {wfe_live_judge_run};
+
 void wfe_autonomy_register(void)
 {
    /* Full engine executor set so a work item can run end-to-end server-side. */
@@ -289,6 +386,10 @@ void wfe_autonomy_register(void)
     * that passes verification). */
    wfe_set_delegate_provider(&WFE_LIVE_DELEGATE);
    wfe_set_verify_provider(&WFE_LIVE_VERIFY);
+   /* The live adversarial judge (PC3): reviewer + skeptic verdicts for the implement
+    * adversarial gate. Inert unless AIMEE_AUTONOMY_SKEPTICS>0 (default off), so
+    * registration alone changes nothing. */
+   wfe_set_judge_provider(&WFE_LIVE_JUDGE);
    /* The live forge (F4): registers a real push+PR+merge provider ONLY if the
     * operator enabled wfe_live_forge_enabled (default OFF). While off, the engine
     * keeps its fail-closed forge stub, so pr.open re-loops and merge parks. */

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -325,6 +325,21 @@ static int wfe_live_judge_run(const char *workdir, const char *lens, char *out_v
    memset(&pinfo, 0, sizeof pinfo);
    persona_load(NULL, persona, &pinfo);
 
+   /* Read-only enforcement (defense in depth): capture the pre-judge HEAD so we can
+    * hard-reset the worktree afterwards — the judge is instructed not to edit, but we
+    * do not rely on instruction-following; any edit it makes is discarded. */
+   char pre_head[64] = "";
+   {
+      const char *argv[] = {"git", "-C", workdir, "rev-parse", "HEAD", NULL};
+      char *o = NULL;
+      if (safe_exec_capture(argv, &o, 256) == 0 && o)
+      {
+         chomp(o);
+         snprintf(pre_head, sizeof pre_head, "%s", o);
+      }
+      free(o);
+   }
+
    run_cmd_set_cwd(workdir);
    agent_result_t res;
    memset(&res, 0, sizeof(res));
@@ -359,12 +374,47 @@ static int wfe_live_judge_run(const char *workdir, const char *lens, char *out_v
    free(sys_prompt);
    persona_free(&pinfo);
 
+   /* Discard anything the judge changed: hard-reset to the pre-judge HEAD + clean
+    * untracked. This makes the read-only property enforced, not merely requested. */
+   if (pre_head[0])
+   {
+      const char *reset[] = {"reset", "--hard", pre_head};
+      (void)git_run(workdir, reset, 3);
+      const char *clean[] = {"clean", "-fd"};
+      (void)git_run(workdir, clean, 2);
+   }
+
    int refuted = 1; /* fail-closed default */
    if (rc == 0 && res.response && res.response[0])
    {
-      /* Accept ONLY on an explicit refuted:false; everything else -> refuted. */
-      if (strstr(res.response, "\"refuted\": false") || strstr(res.response, "\"refuted\":false"))
-         refuted = 0;
+      /* Parse ONLY the LAST non-empty line as the verdict JSON (the delegate is told
+       * to emit exactly one JSON line at the end). A substring scan of the whole
+       * response would false-ACCEPT on a skeptic's reasoning that quotes
+       * {"refuted": false}. Accept only on an explicit boolean refuted:false; anything
+       * that doesn't parse to that is REFUTED (fail closed). */
+      const char *r = res.response;
+      size_t len = strlen(r);
+      while (len > 0 &&
+             (r[len - 1] == '\n' || r[len - 1] == '\r' || r[len - 1] == ' ' || r[len - 1] == '\t'))
+         len--;
+      size_t start = len;
+      while (start > 0 && r[start - 1] != '\n')
+         start--;
+      size_t llen = len - start;
+      char line[512];
+      if (llen > 0 && llen < sizeof line)
+      {
+         memcpy(line, r + start, llen);
+         line[llen] = '\0';
+         cJSON *doc = cJSON_Parse(line);
+         if (doc)
+         {
+            const cJSON *rf = cJSON_GetObjectItemCaseSensitive(doc, "refuted");
+            if (rf && cJSON_IsFalse(rf))
+               refuted = 0;
+            cJSON_Delete(doc);
+         }
+      }
    }
    free(res.response);
    if (rc != 0 && !chosen)

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -516,31 +516,160 @@ static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
  * artifact. A failed dispatch loops (retry); fails closed if the repo is
  * unavailable. With no provider installed it preserves the prior freeze-only
  * behavior so the engine remains drivable without a live delegate. */
+/* A positive-long env with a default (0/garbage/negative -> default). */
+static long wfe_env_pos(const char *name, long def)
+{
+   const char *v = getenv(name);
+   if (!v || !v[0])
+      return def;
+   char *e = NULL;
+   long n = strtol(v, &e, 10);
+   return (e && *e == '\0' && n > 0) ? n : def;
+}
+
+/* Read `.aimee/units.json` (a JSON array of unit-task strings the coordinator wrote)
+ * from `wd`. Returns a NEW cJSON array (caller frees) or NULL if absent/invalid. */
+static cJSON *read_units_json(const char *wd)
+{
+   char path[1200];
+   if (snprintf(path, sizeof path, "%s/.aimee/units.json", wd) >= (int)sizeof path)
+      return NULL;
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   fseek(f, 0, SEEK_END);
+   long len = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   if (len <= 0 || len > (1 << 20))
+   {
+      fclose(f);
+      return NULL;
+   }
+   char *buf = malloc((size_t)len + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t rd = fread(buf, 1, (size_t)len, f);
+   fclose(f);
+   buf[rd] = '\0';
+   cJSON *doc = cJSON_Parse(buf);
+   free(buf);
+   if (!doc)
+      return NULL;
+   /* accept either a bare array or {"units":[...]} */
+   cJSON *arr = cJSON_IsArray(doc) ? doc : cJSON_GetObjectItemCaseSensitive(doc, "units");
+   if (!cJSON_IsArray(arr))
+   {
+      cJSON_Delete(doc);
+      return NULL;
+   }
+   if (arr == doc)
+      return doc;
+   cJSON *detached = cJSON_Duplicate(arr, 1);
+   cJSON_Delete(doc);
+   return detached;
+}
+
+/* Engine-level fan-out (PC3b/Q2), gated by AIMEE_AUTONOMY_FANOUT. Decompose the plan
+ * into units via a coordinator delegate, then implement each unit SEQUENTIALLY (the
+ * scheduler is concurrency=1) with a per-unit mechanical verify and retry on a
+ * DIFFERENT delegate (bounded by AIMEE_AUTONOMY_UNIT_RETRY). Units land as sequential
+ * commits on the one work-item branch (the patch-coordinator merge is implicit). A
+ * decompose that yields nothing falls back to a SINGLE unit (the whole plan) — which
+ * still runs the mandatory per-unit + aggregate tiers (no verification bypass).
+ * Returns 0 if every unit passed its per-unit verify (caller then runs the mandatory
+ * aggregate gate), -1 if any unit permanently failed (caller parks — NO silent partial
+ * advance). *cost accumulates every dispatch. */
+static int run_fanout_units(const char *wd, const wfe_node_t *node, double *cost)
+{
+   /* 1. Decompose (coordinator writes .aimee/units.json + commits; do not implement). */
+   char c[64] = "";
+   (void)wfe_delegate_dispatch(
+       wd, "architect", "$random",
+       "Decompose the approved plan into a SMALL number of INDEPENDENT implementation units. "
+       "Write ONLY a JSON array of concise imperative unit-task strings to .aimee/units.json in "
+       "the repo root, then commit that file. Do NOT implement anything else.",
+       NULL, c, cost);
+
+   cJSON *units = read_units_json(wd);
+   cJSON *fallback = NULL;
+   int n_units = units ? cJSON_GetArraySize(units) : 0;
+   if (n_units <= 0)
+   {
+      /* single-unit fallback = the whole plan (still fully verified below). */
+      fallback = cJSON_CreateArray();
+      cJSON_AddItemToArray(fallback, cJSON_CreateString("Implement the entire approved plan."));
+      units = fallback;
+      n_units = 1;
+   }
+
+   long retry_max = wfe_env_pos("AIMEE_AUTONOMY_UNIT_RETRY", 2);
+   int failed = 0;
+   for (int i = 0; i < n_units && !failed; i++)
+   {
+      const cJSON *u = cJSON_GetArrayItem(units, i);
+      const char *utext = (cJSON_IsString(u) && u->valuestring) ? u->valuestring : "";
+      char prompt[2048];
+      snprintf(prompt, sizeof prompt,
+               "Implement ONLY this unit of the approved plan on the work-item branch, run "
+               "`aimee git verify`, fix any failures, then commit. UNIT: %s",
+               utext);
+      int ok = 0;
+      for (long attempt = 0; attempt <= retry_max && !ok; attempt++)
+      {
+         /* retry-DIFFERENT-delegate: the first attempt uses the pinned delegate;
+          * retries use $random so a fresh perspective takes over (Q2). */
+         const char *deleg = (attempt == 0) ? node_delegate(node) : "$random";
+         char uc[64] = "";
+         if (wfe_delegate_dispatch(wd, "engineer", deleg, prompt, NULL, uc, cost) < 0)
+            continue; /* dispatch failed -> next attempt */
+         if (wfe_implement_verify_ok(wd))
+            ok = 1;
+      }
+      if (!ok)
+         failed = 1; /* this unit could not be made to pass -> park (no partial advance) */
+   }
+   cJSON_Delete(units == fallback ? fallback : units);
+   return failed ? -1 : 0;
+}
+
 static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
 {
    char wd[1024];
    resolve_workdir(ctx, wd, sizeof wd);
    char commit[64] = "";
    double cost = 0.0;
-   if (wfe_delegate_dispatch(
-           wd, "engineer", node_delegate(node),
-           "Implement the approved plan on the work-item branch: split into units, delegate each, "
-           "VERIFY each with `aimee git verify` and fix any failures, then commit the accepted "
-           "work.",
-           NULL, commit, &cost) < 0)
+
+   if (getenv("AIMEE_AUTONOMY_FANOUT") && getenv("AIMEE_AUTONOMY_FANOUT")[0] == '1')
+   {
+      /* Manager loop (PC3b): decompose -> fan out engineer per unit -> per-unit verify
+       * + retry-different. A unit that never passes parks pending_human via DEGRADED
+       * (NO silent partial advance); the mandatory aggregate gate still runs below. */
+      if (run_fanout_units(wd, node, &cost) < 0)
+         return with_cost(wfe_step_failed_class(WFE_FAIL_DEGRADED, 0), cost);
+   }
+   else if (wfe_delegate_dispatch(
+                wd, "engineer", node_delegate(node),
+                "Implement the approved plan on the work-item branch: split into units, delegate "
+                "each, VERIFY each with `aimee git verify` and fix any failures, then commit the "
+                "accepted work.",
+                NULL, commit, &cost) < 0)
       return with_cost(wfe_step_looped(), cost);
+
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
       return with_cost(wfe_step_failed_class(WFE_FAIL_CORRUPTION, 0), cost); /* worktree/git */
-   /* Mechanical verify gate (WP-1b): a unit only advances if it PASSES. A failed
-    * verdict loops back to implement (the engine bounds the retries via
-    * stage_attempt and parks max_attempts on exhaustion); a re-dispatched fresh
-    * engineer delegate has the verify tool to see + fix the findings. */
+   /* MANDATORY aggregate mechanical verify (WP-1b): the whole merged change must PASS
+    * (integration breakage from independently-verified units cannot advance). A failed
+    * verdict loops back (the engine bounds retries via stage_attempt, parks
+    * max_attempts on exhaustion); a re-dispatched fresh engineer sees + fixes findings. */
    if (!wfe_implement_verify_ok(wd))
       return with_cost(wfe_step_looped(), cost);
-   /* Adversarial gate (PC3/Q2): with AIMEE_AUTONOMY_SKEPTICS>0, a reviewer + N skeptic
-    * judgments must not refute the change. A refute loops back to implement (bounded
-    * like the mechanical gate). Tier OFF by default -> unchanged behavior. */
+   /* MANDATORY aggregate adversarial gate (PC3/Q2): with AIMEE_AUTONOMY_SKEPTICS>0, a
+    * reviewer + N skeptic judgments must not refute the merged change. A refute loops
+    * back (bounded). Tier OFF by default -> unchanged behavior. */
    if (!wfe_implement_adversarial_ok(wd))
       return with_cost(wfe_step_looped(), cost);
    char handle[80];

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -537,10 +537,13 @@ static cJSON *read_units_json(const char *wd)
    FILE *f = fopen(path, "rb");
    if (!f)
       return NULL;
-   fseek(f, 0, SEEK_END);
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
    long len = ftell(f);
-   fseek(f, 0, SEEK_SET);
-   if (len <= 0 || len > (1 << 20))
+   if (len <= 0 || len > (1 << 20) || fseek(f, 0, SEEK_SET) != 0)
    {
       fclose(f);
       return NULL;
@@ -582,18 +585,37 @@ static cJSON *read_units_json(const char *wd)
  * Returns 0 if every unit passed its per-unit verify (caller then runs the mandatory
  * aggregate gate), -1 if any unit permanently failed (caller parks — NO silent partial
  * advance). *cost accumulates every dispatch. */
+/* Copy `src` into `dst` stripping control bytes (< 0x20) to a printable space and
+ * hard-capping the length, so untrusted coordinator-generated unit text cannot smuggle
+ * newline-delimited prompt-injection directives into a privileged engineer prompt. */
+static void sanitize_unit(const char *src, char *dst, size_t cap)
+{
+   size_t o = 0;
+   for (const char *p = src; *p && o + 1 < cap; p++)
+   {
+      unsigned char ch = (unsigned char)*p;
+      dst[o++] = (ch < 0x20 || ch == 0x7f) ? ' ' : (char)ch;
+   }
+   dst[o] = '\0';
+}
+
 static int run_fanout_units(const char *wd, const wfe_node_t *node, double *cost)
 {
-   /* 1. Decompose (coordinator writes .aimee/units.json + commits; do not implement). */
-   char c[64] = "";
-   (void)wfe_delegate_dispatch(
-       wd, "architect", "$random",
-       "Decompose the approved plan into a SMALL number of INDEPENDENT implementation units. "
-       "Write ONLY a JSON array of concise imperative unit-task strings to .aimee/units.json in "
-       "the repo root, then commit that file. Do NOT implement anything else.",
-       NULL, c, cost);
-
+   /* 1. Decompose — but ONLY if a prior loop hasn't already produced units (the file
+    * is committed, so a re-driven implement reuses the established unit list instead of
+    * re-decomposing every loop). Coordinator writes .aimee/units.json; does NOT implement. */
    cJSON *units = read_units_json(wd);
+   if (!units)
+   {
+      char c[64] = "";
+      (void)wfe_delegate_dispatch(
+          wd, "architect", "$random",
+          "Decompose the approved plan into a SMALL number of INDEPENDENT implementation units. "
+          "Write ONLY a JSON array of concise imperative unit-task strings to .aimee/units.json in "
+          "the repo root, then commit that file. Do NOT implement anything else.",
+          NULL, c, cost);
+      units = read_units_json(wd);
+   }
    cJSON *fallback = NULL;
    int n_units = units ? cJSON_GetArraySize(units) : 0;
    if (n_units <= 0)
@@ -604,14 +626,26 @@ static int run_fanout_units(const char *wd, const wfe_node_t *node, double *cost
       units = fallback;
       n_units = 1;
    }
+   /* Bound the fan-out: a pathological/hostile decomposition (thousands of units) would
+    * fan out thousands of dispatches. Cap it; an over-cap decomposition is itself a
+    * coordinator failure -> DEGRADED park. */
+   long unit_max = wfe_env_pos("AIMEE_AUTONOMY_UNIT_MAX", 16);
+   if (n_units > unit_max)
+   {
+      cJSON_Delete(units);
+      return -1;
+   }
 
    long retry_max = wfe_env_pos("AIMEE_AUTONOMY_UNIT_RETRY", 2);
    int failed = 0;
    for (int i = 0; i < n_units && !failed; i++)
    {
       const cJSON *u = cJSON_GetArrayItem(units, i);
-      const char *utext = (cJSON_IsString(u) && u->valuestring) ? u->valuestring : "";
-      char prompt[2048];
+      if (!cJSON_IsString(u) || !u->valuestring || !u->valuestring[0])
+         continue; /* skip an empty/non-string entry (no work to dispatch) */
+      char utext[512];
+      sanitize_unit(u->valuestring, utext, sizeof utext);
+      char prompt[1024];
       snprintf(prompt, sizeof prompt,
                "Implement ONLY this unit of the approved plan on the work-item branch, run "
                "`aimee git verify`, fix any failures, then commit. UNIT: %s",
@@ -631,7 +665,7 @@ static int run_fanout_units(const char *wd, const wfe_node_t *node, double *cost
       if (!ok)
          failed = 1; /* this unit could not be made to pass -> park (no partial advance) */
    }
-   cJSON_Delete(units == fallback ? fallback : units);
+   cJSON_Delete(units); /* whether the real list or the fallback; fallback aliases units */
    return failed ? -1 : 0;
 }
 
@@ -667,9 +701,9 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
     * max_attempts on exhaustion); a re-dispatched fresh engineer sees + fixes findings. */
    if (!wfe_implement_verify_ok(wd))
       return with_cost(wfe_step_looped(), cost);
-   /* MANDATORY aggregate adversarial gate (PC3/Q2): with AIMEE_AUTONOMY_SKEPTICS>0, a
-    * reviewer + N skeptic judgments must not refute the merged change. A refute loops
-    * back (bounded). Tier OFF by default -> unchanged behavior. */
+   /* Aggregate adversarial gate (PC3/Q2), OPT-IN via AIMEE_AUTONOMY_SKEPTICS>0 (default
+    * off -> a pass-through, unchanged behavior). When enabled, a reviewer + N skeptic
+    * judgments of the merged change must not refute; a refute loops back (bounded). */
    if (!wfe_implement_adversarial_ok(wd))
       return with_cost(wfe_step_looped(), cost);
    char handle[80];


### PR DESCRIPTION
Phase-C depth for **full-autonomous-development**. Registers a **live** `wfe_judge_provider` so the PC3a adversarial implement gate works in production (previously the seam existed but had no live provider, so enabling `AIMEE_AUTONOMY_SKEPTICS` fail-closed).

## `wfe_live_judge_run`
- Dispatches a **reviewer** (reviewer persona) or **skeptic** (security persona + REFUTE framing) delegate to judge the change in the work-item worktree, and parses a `{"refuted":bool}` verdict.
- **Read-only enforced** (not just requested): captures HEAD before the dispatch and `git reset --hard` + `git clean -fd` after, so any edit a misbehaving/injected judge makes is discarded (the committed change is preserved).
- **Verdict parse**: only the **last non-empty line** is parsed as JSON; accepts only an explicit boolean `refuted:false`. A whole-response substring scan could false-accept on a skeptic quoting the token in its reasoning.
- **Fail-closed**: any dispatch error / no eligible agent / an unparseable verdict → refuted.
- Reuses the delegate-dispatch primitives without touching the merged `wfe_live_delegate_run`. Registered in `wfe_autonomy_register`; **inert unless `AIMEE_AUTONOMY_SKEPTICS>0`** (default off).

## Review
Roundtable-reviewed. Fixed: last-line verdict parse (no false-accept), enforced read-only worktree reset. Integration-gated like the live delegate/verify providers (validated by the CT smoke; server links clean).

Part of PC3b; the decompose/fan-out/patch-coordinator manager loop is PC3b-2.