### PR TITLE
fix(server): guard conn_update_events against NULL evloop (server crash-loop)

### DIFF
--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -77,6 +77,14 @@ static void ss_render_section(struct ss_sbuf *b, const char *title, cJSON *arr)
  * server-side hook (git pull --ff-only, session_state writes) need a co-located
  * server and are intentionally skipped here; proactive recall is the injectable
  * value. Always soft-fails (exit 0) so the host session is never blocked. */
+/* SessionStart recall retry policy. Total worst case ~= the old single 30s
+ * shot: SESSION_START_RECALL_ATTEMPTS * per-attempt timeout + linear backoff.
+ * Per-attempt timeout stays generous enough not to trip a slow-but-healthy
+ * server (a 12s recall on a cold provider still lands on the first attempt). */
+#define SESSION_START_RECALL_ATTEMPTS   3
+#define SESSION_START_RECALL_TIMEOUT_MS 15000
+#define SESSION_START_RECALL_BACKOFF_US 400000 /* multiplied by attempt: 0.4s, 0.8s */
+
 static int handle_session_start_remote(void)
 {
    char *endpoint = cli_v1_client_endpoint();
@@ -91,17 +99,35 @@ static int handle_session_start_remote(void)
    char *body_s = cJSON_PrintUnformatted(body);
    cJSON_Delete(body);
 
+   /* Retry a few times before giving up: session-start fires exactly once and
+    * soft-fails silently, so a single transient failure (a server restart gap,
+    * a cold connection that stalls to the timeout) would otherwise leave the
+    * session with no recall context at all. Bounded so a genuinely-down server
+    * never blocks the prompt for long. Only transport failures (resp==NULL) and
+    * 5xx are retried — a 4xx (bad bearer/body/route) is deterministic and won't
+    * change on retry, so give up immediately rather than burn the budget. */
    int status = 0;
-   cJSON *resp =
-       cli_http_request(endpoint, "POST", "/v1/memory/recall", body_s, bearer, 30000, &status);
+   cJSON *resp = NULL;
+   for (int attempt = 0; attempt < SESSION_START_RECALL_ATTEMPTS; attempt++)
+   {
+      if (attempt > 0)
+         usleep(SESSION_START_RECALL_BACKOFF_US * attempt);
+      status = 0;
+      resp = cli_http_request(endpoint, "POST", "/v1/memory/recall", body_s, bearer,
+                              SESSION_START_RECALL_TIMEOUT_MS, &status);
+      if (status == 200)
+         break; /* success: keep resp for rendering */
+      int retryable = (resp == NULL) || (status >= 500);
+      cJSON_Delete(resp);
+      resp = NULL;
+      if (!retryable)
+         break; /* deterministic client error — no point retrying */
+   }
    free(endpoint);
    free(bearer);
    free(body_s);
-   if (!resp || status != 200)
-   {
-      cJSON_Delete(resp);
+   if (!resp)
       return 0;
-   }
 
    cJSON *recall = cJSON_GetObjectItemCaseSensitive(resp, "recall");
    struct ss_sbuf b = {0};

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -125,9 +125,17 @@ void server_compute_budget_release(server_ctx_t *ctx, int granted)
    pthread_mutex_unlock(&ctx->compute_budget_mutex);
 }
 
-/* Update event loop registration: IN always, OUT when there's pending data */
+/* Update event loop registration: IN always, OUT when there's pending data.
+ *
+ * Only meaningful for connections owned by the epoll accept loop. The /v1 HTTP
+ * workers (server_http.c) run their own blocking per-connection loop and build
+ * a memset-zeroed server_conn_t whose evloop is NULL and whose fd was never
+ * registered with any epoll set; for them this is a no-op (dereferencing a NULL
+ * evloop here previously crashed the whole server on every buffered response). */
 static void conn_update_events(server_conn_t *conn)
 {
+   if (!conn->evloop)
+      return;
    uint32_t events = PLAT_EV_IN;
    if (conn->write_len > 0)
       events |= PLAT_EV_OUT;

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -130,9 +130,18 @@ int platform_evloop_del(platform_evloop_t *loop, int fd)
    return 0;
 }
 
+/* Instrumented so test_conn_update_events_null_evloop can assert the invariant
+ * that conn_update_events never hands a NULL loop to the event layer (a NULL
+ * loop here means epoll_ctl(loop->epoll_fd,...) would dereference NULL and
+ * crash the whole server — the /v1 HTTP-worker crash-loop regression). */
+int g_evloop_mod_null_loop = 0;
+int g_evloop_mod_nonnull_loop = 0;
 int platform_evloop_mod(platform_evloop_t *loop, int fd, uint32_t events)
 {
-   (void)loop;
+   if (loop)
+      g_evloop_mod_nonnull_loop = 1;
+   else
+      g_evloop_mod_null_loop = 1;
    (void)fd;
    (void)events;
    return 0;
@@ -1734,9 +1743,71 @@ static void test_hooks_pre_recovers_worktree_mapping_from_cwd(void)
    free(ctx);
 }
 
+/* Regression: the /v1 HTTP workers (server_http.c) build a memset-zeroed
+ * server_conn_t, so conn->evloop is NULL and its fd is never registered with
+ * any epoll set. Flushing a buffered response must NOT route that NULL loop
+ * into the event layer — conn_update_events used to call
+ * platform_evloop_mod(conn->evloop, ...) unconditionally, so epoll_ctl
+ * dereferenced NULL and segfaulted the whole server on every buffered /v1
+ * response (a crash-restart loop). conn_update_events now no-ops on NULL. */
+static void test_conn_update_events_null_evloop(void)
+{
+   int fds[2];
+   assert(pipe(fds) == 0);
+
+   /* Case 1: NULL evloop (the HTTP-worker shape). Preload pending bytes so
+    * server_send_response drains them via conn_flush, which is the path that
+    * calls conn_update_events. The event layer must never see the NULL loop. */
+   server_conn_t *conn = calloc(1, sizeof(*conn));
+   assert(conn != NULL);
+   conn->fd = fds[1];
+   conn->evloop = NULL;
+   memcpy(conn->write_buf, "hello", 5);
+   conn->write_len = 5;
+   conn->write_pos = 0;
+
+   g_evloop_mod_null_loop = 0;
+   g_evloop_mod_nonnull_loop = 0;
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   int rc = server_send_response(conn, resp);
+   cJSON_Delete(resp);
+   assert(rc == 0);                     /* response actually written */
+   assert(g_evloop_mod_null_loop == 0); /* the fix: NULL loop never used */
+   free(conn);
+
+   /* Case 2 (positive control): an epoll-registered conn (non-NULL evloop)
+    * must still have its interest set updated — the fix must not disable that
+    * for real event-loop connections. */
+   char marker;
+   conn = calloc(1, sizeof(*conn));
+   assert(conn != NULL);
+   conn->fd = fds[1];
+   conn->evloop = (platform_evloop_t *)&marker; /* non-NULL; stub never derefs */
+   memcpy(conn->write_buf, "world", 5);
+   conn->write_len = 5;
+   conn->write_pos = 0;
+
+   g_evloop_mod_null_loop = 0;
+   g_evloop_mod_nonnull_loop = 0;
+   resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   rc = server_send_response(conn, resp);
+   cJSON_Delete(resp);
+   assert(rc == 0);
+   assert(g_evloop_mod_null_loop == 0);
+   assert(g_evloop_mod_nonnull_loop == 1); /* registration still happens */
+   free(conn);
+
+   close(fds[0]);
+   close(fds[1]);
+   printf("test_conn_update_events_null_evloop: PASS\n");
+}
+
 int main(void)
 {
    test_invalid_json();
+   test_conn_update_events_null_evloop();
    test_missing_method();
    test_oversized_payload();
    test_large_delegate_payload_within_limit();


### PR DESCRIPTION
## Problem

`.254` aimee-server was in a **NULL-pointer segfault crash-restart loop** (~6 crashes / 20 min, triggered by `/v1/chat/stream` and other traffic). Every crash was `segfault at 0` (NULL read) at the same instruction — a deterministic bug.

**Root cause:** the `/v1` HTTP workers (`server_http.c` `handle_native_chat_stream`, and the socketpair bridge) build a `memset`-zeroed `server_conn_t`, so `conn->evloop == NULL` and the fd is never registered with any epoll set. `conn_update_events()` unconditionally did:

```c
platform_evloop_mod(conn->evloop, conn->fd, events);   // -> epoll_ctl(evloop->epoll_fd, ...)
```

so every **buffered** response on those connections dereferenced NULL and took the whole server down. Intermittent because only the buffered-flush path reaches `conn_update_events` (fully-immediate writes return early) — which is why some `/v1` requests returned 200 while others hung during a restart gap. Present on `testing`.

## Fix

- **`conn_update_events` no-ops when `evloop == NULL`.** Blocking HTTP-worker conns are not epoll-driven (their fd isn't in any epoll set), so registering interest was always meaningless for them.
- **Session-start hook resilience:** the thin-client `handle_session_start_remote` fires once and soft-fails silently, so a single transient failure (restart gap, cold-connection stall) left the session with no recall brief. It now retries `/v1/memory/recall` a bounded number of times with short backoff — **only** for transport failures and 5xx (a 4xx is deterministic and is not retried). Per-attempt timeout stays generous enough not to trip a slow-but-healthy server.

## Test

`test_conn_update_events_null_evloop` (in `test_server_dispatch.c`, runs under `make unit-tests`): instruments the `platform_evloop_mod` stub to record NULL-loop calls, then drives `server_send_response` on a memset-zeroed conn (the HTTP-worker shape) with preloaded pending bytes so the buffered-flush path reaches `conn_update_events`. Asserts the event layer never sees a NULL loop; positive control confirms a non-NULL evloop still gets updated. **Verified to abort against the pre-fix code.**

## Verification

- Built (glibc-2.36 match) and **hot-swapped onto .254**; **0 new segfaults across 4.5 min under active load** (vs ~6/20 min before).
- Roundtable-reviewed (7 participants); the flagged retry-policy points (don't retry 4xx, magic-number timeout) are addressed in this branch.

Note: the deployed .254 binary is an ephemeral hot-swap — this PR + image rebuild makes it permanent.
