### PR TITLE
feat(webui): Settings options for the economizer + autonomy knobs

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -166,11 +166,12 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 
 > **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `wfe_live_forge_enabled`
 
-## Config-file sections (51)
+## Config-file sections (52)
 
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`; a key shown as a bare name that is itself a nested object is noted in the section description (see *Coverage & limitations*).
 
 - **`aimee`** — _Core API/runtime settings._ Keys: `api`
+- **`autonomy`** — `ci_retry_max`, `fanout`, `skeptics`, `unit_max`, `unit_retry`
 - **`auxiliary`** — _Auxiliary (cheap/background) model used for side tasks._ Keys: `default_max_tokens`, `default_model`, `default_provider`, `enabled`, `tasks`
 - **`cache_shaping`** — _Prompt-cache shaping._ Keys: `enabled`, `min_chars`
 - **`charter`** — _Operating charter: values, constraints, safety axioms, tone._ Keys: `hard_constraints`, `safety_axioms`, `tone_boundaries`, `values`, `working_profile_drift_limit`

--- a/src/config.c
+++ b/src/config.c
@@ -567,6 +567,13 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_gateway_mutate = 0;
    cfg->reduce_gateway_session_disable_ttl_ms = 3600000;
    cfg->reduce_gateway_seam_explicit = 0;
+   /* Autonomous-dev knobs — defaults match the historical AIMEE_AUTONOMY_* env defaults
+    * (adversarial + fan-out tiers OFF; retry/unit caps at their wfe defaults). */
+   cfg->autonomy_skeptics = 0;
+   cfg->autonomy_fanout = 0;
+   cfg->autonomy_unit_retry = 2;
+   cfg->autonomy_unit_max = 16;
+   cfg->autonomy_ci_retry_max = 2;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;
@@ -1190,6 +1197,7 @@ int config_load(config_t *cfg)
    config_parse_fold_section(cfg, root);
    config_parse_reduce_section(cfg, root);
    config_apply_reduce_consistency(cfg); /* mutate=1 -> auto-enable shadow seam in memory + WARN */
+   config_parse_autonomy_section(cfg, root);
 
    config_parse_memory_section(cfg, root);
    config_apply_learning_settings(cfg, root);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -273,6 +273,30 @@ const config_field_t config_fields[] = {
      offsetof(config_t, roundtable_pipeline_parked_releases_slot), sizeof(int), 1, CFG_BOOL},
     {"roundtable.pipeline_unknown_context_tokens",
      offsetof(config_t, roundtable_pipeline_unknown_context_tokens), sizeof(int), 0, CFG_INT},
+    /* Context economizer (context_reduce). Already config_t fields, parsed + saved under
+     * the "reduce" yaml object; exposed here so the typed config surface + web Settings
+     * can toggle them. gateway_seam is intentionally omitted (it is synthesized from
+     * gateway_mutate and its persistence is explicit-gated — gateway_mutate is the
+     * user-facing toggle). */
+    {"reduce.measure", offsetof(config_t, reduce_measure_enabled), sizeof(int), 1, CFG_BOOL},
+    {"reduce.delegate_seam", offsetof(config_t, reduce_delegate_seam), sizeof(int), 1, CFG_BOOL},
+    {"reduce.history_fold", offsetof(config_t, reduce_history_fold), sizeof(int), 1, CFG_BOOL},
+    {"reduce.compress", offsetof(config_t, reduce_compress), sizeof(int), 1, CFG_BOOL},
+    {"reduce.gateway_mutate", offsetof(config_t, reduce_gateway_mutate), sizeof(int), 1, CFG_BOOL},
+    {"reduce.gateway_session_disable_ttl_ms",
+     offsetof(config_t, reduce_gateway_session_disable_ttl_ms), sizeof(int), 0, CFG_INT},
+    {"reduce.freeze_guard", offsetof(config_t, reduce_freeze_guard_enabled), sizeof(int), 1,
+     CFG_BOOL},
+    {"reduce.freeze_guard_horizon", offsetof(config_t, reduce_freeze_guard_horizon), sizeof(int), 0,
+     CFG_INT},
+    /* Autonomous-development pipeline knobs (Phase-C). New config_t fields bridged to the
+     * AIMEE_AUTONOMY_* env vars at startup (a set env var still overrides); a change
+     * applies on the next server start. */
+    {"autonomy.skeptics", offsetof(config_t, autonomy_skeptics), sizeof(int), 0, CFG_INT},
+    {"autonomy.fanout", offsetof(config_t, autonomy_fanout), sizeof(int), 1, CFG_BOOL},
+    {"autonomy.unit_retry", offsetof(config_t, autonomy_unit_retry), sizeof(int), 0, CFG_INT},
+    {"autonomy.unit_max", offsetof(config_t, autonomy_unit_max), sizeof(int), 0, CFG_INT},
+    {"autonomy.ci_retry_max", offsetof(config_t, autonomy_ci_retry_max), sizeof(int), 0, CFG_INT},
     {NULL, 0, 0, 0, CFG_STRING},
 };
 

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1050,6 +1050,24 @@ int config_save(const config_t *cfg)
                                  cfg->reduce_gateway_session_disable_ttl_ms);
    }
 
+   /* Autonomous-dev knobs — persist only non-defaults (defaults: skeptics 0, fanout off,
+    * unit_retry 2, unit_max 16, ci_retry_max 2). */
+   if (cfg->autonomy_skeptics != 0 || cfg->autonomy_fanout != 0 || cfg->autonomy_unit_retry != 2 ||
+       cfg->autonomy_unit_max != 16 || cfg->autonomy_ci_retry_max != 2)
+   {
+      cJSON *autonomy = cJSON_AddObjectToObject(root, "autonomy");
+      if (cfg->autonomy_skeptics != 0)
+         cJSON_AddNumberToObject(autonomy, "skeptics", cfg->autonomy_skeptics);
+      if (cfg->autonomy_fanout != 0)
+         cJSON_AddBoolToObject(autonomy, "fanout", cfg->autonomy_fanout);
+      if (cfg->autonomy_unit_retry != 2)
+         cJSON_AddNumberToObject(autonomy, "unit_retry", cfg->autonomy_unit_retry);
+      if (cfg->autonomy_unit_max != 16)
+         cJSON_AddNumberToObject(autonomy, "unit_max", cfg->autonomy_unit_max);
+      if (cfg->autonomy_ci_retry_max != 2)
+         cJSON_AddNumberToObject(autonomy, "ci_retry_max", cfg->autonomy_ci_retry_max);
+   }
+
    /* Session/worktree cleanup policy (only save if non-default) */
    if (cfg->worktree_stale_secs || cfg->max_sessions || cfg->max_worktrees)
    {

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -784,30 +784,40 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    }
 }
 
+/* Clamp an integer to [lo, hi]. */
+static int clampi(int v, int lo, int hi)
+{
+   return v < lo ? lo : (v > hi ? hi : v);
+}
+
 /* Autonomous-development pipeline knobs (Phase-C). Historically env-only
  * (AIMEE_AUTONOMY_*); parsed here so they live in the typed config + web Settings, then
- * bridged to the env vars at startup (autonomy_config_to_env) for the wfe library. Only
- * non-negative values are accepted (a negative is ignored, leaving the default). */
+ * bridged to the env vars at startup (autonomy_config_to_env) for the wfe library.
+ * Out-of-range values are CLAMPED to sane bounds (not silently dropped) — this runs at
+ * config_load, so it also bounds a value a raw config.set persisted, before the startup
+ * bridge reads it: a fat-fingered skeptics=1000 can't fan out 1000 judge dispatches. The
+ * wfe consumers additionally fail-safe on <=0 (treat as off/default), so the low end is
+ * doubly safe. */
 void config_parse_autonomy_section(config_t *cfg, cJSON *root)
 {
    cJSON *autonomy = cJSON_GetObjectItemCaseSensitive(root, "autonomy");
    if (!cJSON_IsObject(autonomy))
       return;
    cJSON *item = cJSON_GetObjectItemCaseSensitive(autonomy, "skeptics");
-   if (cJSON_IsNumber(item) && item->valueint >= 0)
-      cfg->autonomy_skeptics = item->valueint;
+   if (cJSON_IsNumber(item))
+      cfg->autonomy_skeptics = clampi(item->valueint, 0, 32);
    item = cJSON_GetObjectItemCaseSensitive(autonomy, "fanout");
    if (cJSON_IsBool(item))
       cfg->autonomy_fanout = cJSON_IsTrue(item) ? 1 : 0;
    item = cJSON_GetObjectItemCaseSensitive(autonomy, "unit_retry");
-   if (cJSON_IsNumber(item) && item->valueint >= 0)
-      cfg->autonomy_unit_retry = item->valueint;
+   if (cJSON_IsNumber(item))
+      cfg->autonomy_unit_retry = clampi(item->valueint, 0, 10);
    item = cJSON_GetObjectItemCaseSensitive(autonomy, "unit_max");
-   if (cJSON_IsNumber(item) && item->valueint > 0)
-      cfg->autonomy_unit_max = item->valueint;
+   if (cJSON_IsNumber(item)) /* unit_max must be positive — 0 units is meaningless */
+      cfg->autonomy_unit_max = clampi(item->valueint, 1, 256);
    item = cJSON_GetObjectItemCaseSensitive(autonomy, "ci_retry_max");
-   if (cJSON_IsNumber(item) && item->valueint >= 0)
-      cfg->autonomy_ci_retry_max = item->valueint;
+   if (cJSON_IsNumber(item))
+      cfg->autonomy_ci_retry_max = clampi(item->valueint, 0, 20);
 }
 
 /* Bridge the autonomy config knobs to the AIMEE_AUTONOMY_* env vars the wfe library
@@ -817,7 +827,7 @@ void config_parse_autonomy_section(config_t *cfg, cJSON *root)
  * a Settings change to these knobs therefore applies on the next server start. */
 void autonomy_config_to_env(const config_t *cfg)
 {
-   char buf[16];
+   char buf[16]; /* an int is at most 11 chars + sign + NUL = 13 <= 16 */
    snprintf(buf, sizeof buf, "%d", cfg->autonomy_skeptics);
    setenv("AIMEE_AUTONOMY_SKEPTICS", buf, 0);
    setenv("AIMEE_AUTONOMY_FANOUT", cfg->autonomy_fanout ? "1" : "0", 0);

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -784,6 +784,51 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    }
 }
 
+/* Autonomous-development pipeline knobs (Phase-C). Historically env-only
+ * (AIMEE_AUTONOMY_*); parsed here so they live in the typed config + web Settings, then
+ * bridged to the env vars at startup (autonomy_config_to_env) for the wfe library. Only
+ * non-negative values are accepted (a negative is ignored, leaving the default). */
+void config_parse_autonomy_section(config_t *cfg, cJSON *root)
+{
+   cJSON *autonomy = cJSON_GetObjectItemCaseSensitive(root, "autonomy");
+   if (!cJSON_IsObject(autonomy))
+      return;
+   cJSON *item = cJSON_GetObjectItemCaseSensitive(autonomy, "skeptics");
+   if (cJSON_IsNumber(item) && item->valueint >= 0)
+      cfg->autonomy_skeptics = item->valueint;
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "fanout");
+   if (cJSON_IsBool(item))
+      cfg->autonomy_fanout = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "unit_retry");
+   if (cJSON_IsNumber(item) && item->valueint >= 0)
+      cfg->autonomy_unit_retry = item->valueint;
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "unit_max");
+   if (cJSON_IsNumber(item) && item->valueint > 0)
+      cfg->autonomy_unit_max = item->valueint;
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "ci_retry_max");
+   if (cJSON_IsNumber(item) && item->valueint >= 0)
+      cfg->autonomy_ci_retry_max = item->valueint;
+}
+
+/* Bridge the autonomy config knobs to the AIMEE_AUTONOMY_* env vars the wfe library
+ * reads via getenv (it cannot see config_t across the module boundary). setenv's third
+ * arg is 0 — it sets the var ONLY when unset, so an explicitly-exported env var (a
+ * deployment override) always wins over the config value. Call once at server startup;
+ * a Settings change to these knobs therefore applies on the next server start. */
+void autonomy_config_to_env(const config_t *cfg)
+{
+   char buf[16];
+   snprintf(buf, sizeof buf, "%d", cfg->autonomy_skeptics);
+   setenv("AIMEE_AUTONOMY_SKEPTICS", buf, 0);
+   setenv("AIMEE_AUTONOMY_FANOUT", cfg->autonomy_fanout ? "1" : "0", 0);
+   snprintf(buf, sizeof buf, "%d", cfg->autonomy_unit_retry);
+   setenv("AIMEE_AUTONOMY_UNIT_RETRY", buf, 0);
+   snprintf(buf, sizeof buf, "%d", cfg->autonomy_unit_max);
+   setenv("AIMEE_AUTONOMY_UNIT_MAX", buf, 0);
+   snprintf(buf, sizeof buf, "%d", cfg->autonomy_ci_retry_max);
+   setenv("AIMEE_AUTONOMY_CI_RETRY_MAX", buf, 0);
+}
+
 /* Normalize economizer gateway-mutation invariants IN MEMORY after parse. mutate=1
  * requires the shadow seam so the validation gates always have a same-payload
  * baseline: auto-enable reduce_gateway_seam in memory (never rewriting the file)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -971,6 +971,23 @@ typedef struct config
     * when the user chose it, never when config_load synthesized it from mutate=1. */
    int reduce_gateway_seam_explicit;
 
+   /* Autonomous-development pipeline knobs (Phase-C). These were env-var-only
+    * (AIMEE_AUTONOMY_*); the config values are bridged to those env vars at startup
+    * (autonomy_config_to_env) so the wfe library — which reads them via getenv across a
+    * module boundary — sees them, while an explicitly-set env var still overrides.
+    * Exposed here so they appear in the typed config surface + web Settings. Defaults
+    * match the historical env defaults; a change applies on the next server start.
+    * autonomy_skeptics: N adversarial skeptics on the implement gate (0 = off).
+    * autonomy_fanout: 1 = engine-level fan-out manager loop (0 = single-dispatch).
+    * autonomy_unit_retry: per-unit retry-different-delegate cap.
+    * autonomy_unit_max: max fan-out units (a larger decomposition parks).
+    * autonomy_ci_retry_max: per-work-item red-CI retry cap before parking. */
+   int autonomy_skeptics;
+   int autonomy_fanout;
+   int autonomy_unit_retry;
+   int autonomy_unit_max;
+   int autonomy_ci_retry_max;
+
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned
     *   (0 = use default: 14400 = 4 hours).

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -22,6 +22,8 @@ void config_parse_memory_maintenance_section(config_t *cfg, cJSON *root);
 void config_parse_worktree_gc_section(config_t *cfg, cJSON *root);
 void config_parse_fold_section(config_t *cfg, cJSON *root);
 void config_parse_reduce_section(config_t *cfg, cJSON *root);
+void config_parse_autonomy_section(config_t *cfg, cJSON *root);
+void autonomy_config_to_env(const config_t *cfg);
 void config_apply_reduce_consistency(config_t *cfg);
 void config_parse_memory_section(config_t *cfg, cJSON *root);
 void config_parse_cross_verify_section(config_t *cfg, cJSON *root);

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -3,6 +3,7 @@
 #include "cli_client.h"
 #include "commands.h"
 #include "config.h"
+#include "config_sections.h"
 #include "forge_app_token.h"
 #include "forge_credentials.h"
 #include "git_host_cred.h"
@@ -212,6 +213,10 @@ static int run_server(const char *socket_path, log_level_t log_level)
 
    /* Parse plugin extension config keys not covered by config_load(). */
    config_load_plugin_extensions(&cfg);
+
+   /* Bridge the autonomy config knobs to their AIMEE_AUTONOMY_* env vars before the wfe
+    * engine reads them (an explicitly-set env var still overrides — setenv no-overwrite). */
+   autonomy_config_to_env(&cfg);
 
    /* Register bundled context engine and discover plugins from all sources.
     * Must run after config_load so plugin_loader can read install prefix from env.

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -165,6 +165,11 @@ static int run_server(const char *socket_path, log_level_t log_level)
    config_t cfg;
    config_load(&cfg);
 
+   /* Bridge the autonomy config knobs to their AIMEE_AUTONOMY_* env vars as early as
+    * possible — before any consumer (plugin discovery, the wfe engine) could read them
+    * via getenv. An explicitly-set env var still overrides (setenv no-overwrite). */
+   autonomy_config_to_env(&cfg);
+
    /* Startup-fatal validation for the live gateway-mutation path: an invalid
     * session-disable TTL (<=0) must refuse to bring up the /v1 server rather than
     * pin/disable the breaker on live client traffic. Scoped to server startup so
@@ -213,10 +218,6 @@ static int run_server(const char *socket_path, log_level_t log_level)
 
    /* Parse plugin extension config keys not covered by config_load(). */
    config_load_plugin_extensions(&cfg);
-
-   /* Bridge the autonomy config knobs to their AIMEE_AUTONOMY_* env vars before the wfe
-    * engine reads them (an explicitly-set env var still overrides — setenv no-overwrite). */
-   autonomy_config_to_env(&cfg);
 
    /* Register bundled context engine and discover plugins from all sources.
     * Must run after config_load so plugin_loader can read install prefix from env.


### PR DESCRIPTION
Exposes the recently-shipped context-economizer + autonomous-dev knobs in the web **Settings page**. Everything that page shows is a `config_fields[]` entry (auto-rendered) — so the work is wiring these into that typed config surface.

## Economizer (already `config_t` fields, just added to `config_fields[]`)
`reduce.measure`, `.delegate_seam`, `.history_fold`, `.compress`, **`.gateway_mutate`** (the gateway-mutation toggle shipped this cycle), `.gateway_session_disable_ttl_ms`, `.freeze_guard`, `.freeze_guard_horizon`. (`gateway_seam` omitted — it's synthesized from `gateway_mutate` and its persistence is explicit-gated.)

## Autonomy (Phase-C — new plumbing; previously `AIMEE_AUTONOMY_*` env-only)
- New `config_t` fields `autonomy_{skeptics,fanout,unit_retry,unit_max,ci_retry_max}`, defaults matching the historical env defaults (0 / off / 2 / 16 / 2).
- `config_parse_autonomy_section` (yaml `autonomy`, **clamped** to sane bounds) + `config_save` non-default persistence + `config_fields[]`.
- **`autonomy_config_to_env()`** bridges the config values to the `AIMEE_AUTONOMY_*` env vars at startup via `setenv(no-overwrite)` — the wfe library reads them via `getenv` across a module boundary, and an explicitly-exported env var still overrides. A Settings change applies on the next server start.
- The CI webhook **secret is deliberately excluded** — secrets don't belong on the plaintext config settings surface.

## Notes
No frontend/webchat change (the Settings page auto-renders `config_fields[]`). Runtime round-trip verified (`config.show` lists all keys; set-over-socket persists to `aimee.yaml`). Roundtable-reviewed (clamps added, bridge moved before consumers). Full `unit-tests` + line-check + docs-gen-check + conformance green.