### PR TITLE
feat(economizer): tool-output condensation S1 — config gate + primitives

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -208,7 +208,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `compress`, `delegate_seam`, `freeze_guard`, `freeze_guard_horizon`, `gateway_mutate`, `gateway_seam`, `gateway_session_disable_ttl_ms`, `history_fold`, `measure`
+- **`reduce`** — `command_filter`, `compress`, `delegate_seam`, `freeze_guard`, `freeze_guard_horizon`, `gateway_mutate`, `gateway_seam`, `gateway_session_disable_ttl_ms`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c audit_action.c audit_ledger.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
-            compact.c coord_closet.c fold_budget.c context_fold.c context_reduce.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
+            compact.c coord_closet.c fold_budget.c context_fold.c context_reduce.c tool_condense.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \

--- a/src/config.c
+++ b/src/config.c
@@ -567,6 +567,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_gateway_mutate = 0;
    cfg->reduce_gateway_session_disable_ttl_ms = 3600000;
    cfg->reduce_gateway_seam_explicit = 0;
+   cfg->reduce_command_filter = 0; /* command-aware tool-output condensation: default off */
    /* Autonomous-dev knobs — defaults match the historical AIMEE_AUTONOMY_* env defaults
     * (adversarial + fan-out tiers OFF; retry/unit caps at their wfe defaults). */
    cfg->autonomy_skeptics = 0;

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -283,6 +283,7 @@ const config_field_t config_fields[] = {
     {"reduce.history_fold", offsetof(config_t, reduce_history_fold), sizeof(int), 1, CFG_BOOL},
     {"reduce.compress", offsetof(config_t, reduce_compress), sizeof(int), 1, CFG_BOOL},
     {"reduce.gateway_mutate", offsetof(config_t, reduce_gateway_mutate), sizeof(int), 1, CFG_BOOL},
+    {"reduce.command_filter", offsetof(config_t, reduce_command_filter), sizeof(int), 1, CFG_BOOL},
     {"reduce.gateway_session_disable_ttl_ms",
      offsetof(config_t, reduce_gateway_session_disable_ttl_ms), sizeof(int), 0, CFG_INT},
     {"reduce.freeze_guard", offsetof(config_t, reduce_freeze_guard_enabled), sizeof(int), 1,

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1044,6 +1044,8 @@ int config_save(const config_t *cfg)
        * persist only a non-default positive override (a bad <=0 is never written). */
       if (cfg->reduce_gateway_mutate)
          cJSON_AddBoolToObject(reduce, "gateway_mutate", cfg->reduce_gateway_mutate);
+      if (cfg->reduce_command_filter)
+         cJSON_AddBoolToObject(reduce, "command_filter", cfg->reduce_command_filter);
       if (cfg->reduce_gateway_session_disable_ttl_ms != 3600000 &&
           cfg->reduce_gateway_session_disable_ttl_ms > 0)
          cJSON_AddNumberToObject(reduce, "gateway_session_disable_ttl_ms",

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -771,6 +771,9 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
        * truncates. A resulting <=0 (incl. a truncated 0.x) is caught startup-fatal
        * by config_reduce_validate(). */
       cfg->reduce_gateway_session_disable_ttl_ms = item->valueint;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "command_filter");
+   if (cJSON_IsBool(item))
+      cfg->reduce_command_filter = cJSON_IsTrue(item) ? 1 : 0;
    item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard");
    if (cJSON_IsBool(item))
       cfg->reduce_freeze_guard_enabled = cJSON_IsTrue(item) ? 1 : 0;

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -966,6 +966,11 @@ typedef struct config
    int reduce_freeze_guard_horizon;
    int reduce_gateway_mutate;
    int reduce_gateway_session_disable_ttl_ms;
+   /* reduce_command_filter: deterministic command-aware tool-output condensation lever
+    * (proposal: deterministic-tool-output-condensation). Default OFF. S1 ships the
+    * primitives + this gate; the tool seam is wired in a later slice, so the flag is
+    * inert until then. */
+   int reduce_command_filter;
    /* Runtime-only (NOT parsed as a key, NOT persisted): 1 iff the operator set the
     * reduce.gateway_seam key explicitly. Lets config_save persist gateway_seam only
     * when the user chose it, never when config_load synthesized it from mutate=1. */

--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -1,0 +1,36 @@
+/* tool_condense.h: deterministic command-aware tool-output condensation primitives
+ * (proposal: deterministic-tool-output-condensation), Slice 1.
+ *
+ * Pure, deterministic, no LLM. Each primitive returns a NEW malloc'd NUL-terminated
+ * string the caller frees, or NULL on allocation failure — a NULL is the caller's cue
+ * to fall back to the raw input (fail-open; condensation never loses the output). The
+ * primitives are the toolbox the per-command family rules (later slices) compose from;
+ * no tool seam is wired in this slice, so the lever is inert until then. */
+#ifndef AIMEE_TOOL_CONDENSE_H
+#define AIMEE_TOOL_CONDENSE_H
+
+#include "config.h"
+
+/* 1 iff the command-filter lever is enabled (reduce_command_filter). */
+int tool_condense_enabled(const config_t *cfg);
+
+/* Strip content-free noise, line-wise:
+ *  - remove ANSI CSI escape sequences (ESC '[' … final-byte);
+ *  - resolve carriage-return progress redraws (keep only the text after the last '\r'
+ *    on a line — the final rendered state);
+ *  - collapse a run of 2+ blank lines to a single blank line.
+ * Never drops a line that carries text. */
+char *tc_strip_noise(const char *in);
+
+/* Collapse a run of immediately-repeated identical lines to one line followed by
+ * "  (xN)" (N = the repeat count). Non-repeated lines pass through unchanged. */
+char *tc_dedup_lines(const char *in);
+
+/* Keep the first `head` and last `tail` lines, and — in between — every line that
+ * contains `signal` (case-sensitive substring; NULL = none forced). Each elided run is
+ * replaced by a single "... N lines elided ..." marker so the elision is explicit.
+ * head/tail < 0 are treated as 0. If the input already fits (head+tail >= line count),
+ * it is returned verbatim. */
+char *tc_truncate_with_signal(const char *in, int head, int tail, const char *signal);
+
+#endif /* AIMEE_TOOL_CONDENSE_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -2027,6 +2027,9 @@ $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
 
 $(TESTPREFIX)/unit-test-diff: $(OBJDIR)/tests/test_diff.o $(OBJDIR)/diff.o $(OBJDIR)/dstr.o \
                       $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-tool-condense: $(OBJDIR)/tests/test_tool_condense.o $(OBJDIR)/tool_condense.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-workspace-provider: $(OBJDIR)/tests/test_workspace_provider.o \

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -1,0 +1,113 @@
+/* test_tool_condense: the deterministic tool-output condensation primitives (S1). */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "config.h"
+#include "tool_condense.h"
+
+static void eq(const char *got, const char *want, const char *label)
+{
+   if (!got || strcmp(got, want) != 0)
+   {
+      fprintf(stderr, "\nFAIL %s:\n  got : %s\n  want: %s\n", label, got ? got : "(null)", want);
+      abort();
+   }
+}
+
+int main(void)
+{
+   printf("tool-condense: ");
+
+   /* ---- enable gate ---- */
+   {
+      config_t cfg;
+      memset(&cfg, 0, sizeof cfg);
+      assert(tool_condense_enabled(&cfg) == 0);
+      cfg.reduce_command_filter = 1;
+      assert(tool_condense_enabled(&cfg) == 1);
+      assert(tool_condense_enabled(NULL) == 0);
+   }
+
+   /* ---- tc_strip_noise: ANSI escapes removed ---- */
+   {
+      char *r = tc_strip_noise("\x1b[31mred\x1b[0m text");
+      eq(r, "red text", "strip ansi");
+      free(r);
+   }
+   /* CR redraw: keep text after the last '\r' */
+   {
+      char *r = tc_strip_noise("Downloading 10%\rDownloading 80%\rDone");
+      eq(r, "Done", "strip cr-redraw");
+      free(r);
+   }
+   /* collapse a run of blank lines to one, preserve content */
+   {
+      char *r = tc_strip_noise("a\n\n\n\nb");
+      eq(r, "a\n\nb", "collapse blanks");
+      free(r);
+   }
+   /* a line with only ANSI becomes blank and participates in blank-collapse */
+   {
+      char *r = tc_strip_noise("a\n\x1b[2K\n\nb");
+      eq(r, "a\n\nb", "ansi-only line -> blank");
+      free(r);
+   }
+
+   /* ---- tc_dedup_lines ---- */
+   {
+      char *r = tc_dedup_lines("x\nx\nx\ny\nx");
+      eq(r, "x  (x3)\ny\nx", "dedup consecutive");
+      free(r);
+   }
+   {
+      char *r = tc_dedup_lines("only");
+      eq(r, "only", "dedup single");
+      free(r);
+   }
+   {
+      char *r = tc_dedup_lines("a\nb\nc");
+      eq(r, "a\nb\nc", "dedup no-repeats");
+      free(r);
+   }
+
+   /* ---- tc_truncate_with_signal ---- */
+   /* head=1 tail=1, keep FAIL lines in the middle */
+   {
+      char *r = tc_truncate_with_signal("L0\nL1\nFAIL x\nL3\nL4\nL5", 1, 1, "FAIL");
+      eq(r, "L0\n... 1 lines elided ...\nFAIL x\n... 2 lines elided ...\nL5", "truncate+signal");
+      free(r);
+   }
+   /* already fits (head+tail >= lines) -> verbatim */
+   {
+      char *r = tc_truncate_with_signal("a\nb\nc", 2, 2, NULL);
+      eq(r, "a\nb\nc", "truncate fits");
+      free(r);
+   }
+   /* no signal, pure head/tail with a middle elision */
+   {
+      char *r = tc_truncate_with_signal("a\nb\nc\nd\ne", 1, 1, NULL);
+      eq(r, "a\n... 3 lines elided ...\ne", "truncate no-signal");
+      free(r);
+   }
+   /* signal matches nothing -> just head/tail */
+   {
+      char *r = tc_truncate_with_signal("a\nb\nc\nd", 1, 1, "ZZZ");
+      eq(r, "a\n... 2 lines elided ...\nd", "truncate signal-miss");
+      free(r);
+   }
+
+   /* ---- empty input round-trips (never NULL-as-OOM) ---- */
+   {
+      char *r = tc_strip_noise("");
+      assert(r && r[0] == '\0');
+      free(r);
+      r = tc_dedup_lines("");
+      assert(r && r[0] == '\0');
+      free(r);
+   }
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -3,6 +3,7 @@
  * enable gate. CORE layer: depends only on config.h + libc. */
 #include "tool_condense.h"
 
+#include <stdio.h> /* snprintf */
 #include <stdlib.h>
 #include <string.h>
 
@@ -108,12 +109,12 @@ static void emit_clean_line(sb_t *s, const char *line, size_t n)
    {
       if (start[i] == 0x1b && i + 1 < n && start[i + 1] == '[')
       {
-         /* CSI: ESC '[' params… final byte in 0x40..0x7e */
+         /* CSI: ESC '[' params (0x20..0x3f) then a final byte (0x40..0x7e). */
          size_t j = i + 2;
          while (j < n && (unsigned char)start[j] >= 0x20 && (unsigned char)start[j] < 0x40)
             j++;
-         if (j < n) /* skip the final byte too */
-            j++;
+         if (j < n && (unsigned char)start[j] >= 0x40 && (unsigned char)start[j] <= 0x7e)
+            j++; /* consume the valid final byte; a malformed/truncated CSI still drops */
          i = j;
          continue;
       }

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -1,0 +1,355 @@
+/* tool_condense.c: deterministic tool-output condensation primitives (Slice 1).
+ * See tool_condense.h. Pure string transforms — no I/O, no LLM, no config beyond the
+ * enable gate. CORE layer: depends only on config.h + libc. */
+#include "tool_condense.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+int tool_condense_enabled(const config_t *cfg)
+{
+   return cfg && cfg->reduce_command_filter ? 1 : 0;
+}
+
+/* ---- a minimal growable string builder (self-contained so the unit test links only
+ * this TU + config) ---- */
+typedef struct
+{
+   char *buf;
+   size_t len;
+   size_t cap;
+   int oom; /* sticky: 1 once an allocation failed */
+} sb_t;
+
+static void sb_ensure(sb_t *s, size_t extra)
+{
+   if (s->oom)
+      return;
+   if (s->len + extra + 1 <= s->cap)
+      return;
+   size_t ncap = s->cap ? s->cap * 2 : 256;
+   while (ncap < s->len + extra + 1)
+      ncap *= 2;
+   char *nb = realloc(s->buf, ncap);
+   if (!nb)
+   {
+      s->oom = 1;
+      return;
+   }
+   s->buf = nb;
+   s->cap = ncap;
+}
+
+static void sb_add(sb_t *s, const char *p, size_t n)
+{
+   sb_ensure(s, n);
+   if (s->oom)
+      return;
+   memcpy(s->buf + s->len, p, n);
+   s->len += n;
+   s->buf[s->len] = '\0';
+}
+
+static void sb_addc(sb_t *s, char c)
+{
+   sb_add(s, &c, 1);
+}
+
+static void sb_adds(sb_t *s, const char *p)
+{
+   sb_add(s, p, strlen(p));
+}
+
+/* Detach the buffer as a C string (or "" for an empty non-OOM result); NULL on OOM. */
+static char *sb_finish(sb_t *s)
+{
+   if (s->oom)
+   {
+      free(s->buf);
+      return NULL;
+   }
+   if (!s->buf)
+      return strdup(""); /* empty input -> empty output, never NULL-as-OOM */
+   return s->buf;
+}
+
+/* Call `line` on each line of `in` (without its terminator). `has_nl` says whether the
+ * source line ended with '\n' (the final line may not). Returns 0, or -1 if the callback
+ * signalled OOM (returned non-zero). */
+static const char *next_line(const char *p, size_t *out_len, int *has_nl)
+{
+   const char *nl = strchr(p, '\n');
+   if (nl)
+   {
+      *out_len = (size_t)(nl - p);
+      *has_nl = 1;
+      return nl + 1;
+   }
+   *out_len = strlen(p);
+   *has_nl = 0;
+   return p + *out_len; /* -> the terminating NUL */
+}
+
+/* ---- tc_strip_noise ---- */
+
+/* Copy `line` (length n) into `s`, dropping ANSI CSI escapes and resolving CR redraws
+ * (keep only the segment after the last '\r'). */
+static void emit_clean_line(sb_t *s, const char *line, size_t n)
+{
+   /* CR redraw: a terminal rewrites the line after each '\r'; the final state is the
+    * text after the LAST '\r'. */
+   const char *start = line;
+   for (size_t i = 0; i < n; i++)
+      if (line[i] == '\r')
+         start = line + i + 1;
+   n -= (size_t)(start - line);
+
+   for (size_t i = 0; i < n;)
+   {
+      if (start[i] == 0x1b && i + 1 < n && start[i + 1] == '[')
+      {
+         /* CSI: ESC '[' params… final byte in 0x40..0x7e */
+         size_t j = i + 2;
+         while (j < n && (unsigned char)start[j] >= 0x20 && (unsigned char)start[j] < 0x40)
+            j++;
+         if (j < n) /* skip the final byte too */
+            j++;
+         i = j;
+         continue;
+      }
+      sb_addc(s, start[i]);
+      i++;
+   }
+}
+
+char *tc_strip_noise(const char *in)
+{
+   if (!in)
+      return NULL;
+   sb_t s = {0};
+   const char *p = in;
+   int prev_blank = 0;
+   int first = 1;
+   while (*p || first)
+   {
+      size_t n;
+      int has_nl;
+      const char *np = next_line(p, &n, &has_nl);
+
+      /* Build the cleaned line into a scratch builder to test blank-ness. */
+      sb_t line = {0};
+      emit_clean_line(&line, p, n);
+      if (line.oom)
+      {
+         free(line.buf);
+         s.oom = 1;
+         break;
+      }
+      int is_blank = (line.len == 0);
+
+      if (is_blank && prev_blank)
+      {
+         /* collapse: skip this blank */
+         free(line.buf);
+      }
+      else
+      {
+         if (!first)
+            sb_addc(&s, '\n');
+         if (line.buf)
+            sb_add(&s, line.buf, line.len);
+         free(line.buf);
+         prev_blank = is_blank;
+      }
+      first = 0;
+      if (!has_nl)
+         break;
+      p = np;
+   }
+   return sb_finish(&s);
+}
+
+/* ---- tc_dedup_lines ---- */
+
+char *tc_dedup_lines(const char *in)
+{
+   if (!in)
+      return NULL;
+   sb_t s = {0};
+   const char *p = in;
+   int first = 1;
+
+   /* previous line (owned copy) + its run count */
+   char *prev = NULL;
+   size_t prev_len = 0;
+   long run = 0;
+
+   int done = 0;
+   while (!done)
+   {
+      size_t n;
+      int has_nl;
+      const char *np = next_line(p, &n, &has_nl);
+      int last = !has_nl;
+
+      int same = (prev && n == prev_len && memcmp(p, prev, n) == 0);
+      if (same)
+      {
+         run++;
+      }
+      else
+      {
+         /* flush the previous run */
+         if (prev)
+         {
+            if (!first)
+               sb_addc(&s, '\n');
+            first = 0;
+            sb_add(&s, prev, prev_len);
+            if (run > 1)
+            {
+               char tag[32];
+               snprintf(tag, sizeof tag, "  (x%ld)", run);
+               sb_adds(&s, tag);
+            }
+            free(prev);
+         }
+         prev = malloc(n + 1);
+         if (!prev)
+         {
+            s.oom = 1;
+            break;
+         }
+         memcpy(prev, p, n);
+         prev[n] = '\0';
+         prev_len = n;
+         run = 1;
+      }
+      if (last)
+         done = 1;
+      else
+         p = np;
+   }
+   /* flush the trailing run */
+   if (prev && !s.oom)
+   {
+      if (!first)
+         sb_addc(&s, '\n');
+      sb_add(&s, prev, prev_len);
+      if (run > 1)
+      {
+         char tag[32];
+         snprintf(tag, sizeof tag, "  (x%ld)", run);
+         sb_adds(&s, tag);
+      }
+   }
+   free(prev);
+   return sb_finish(&s);
+}
+
+/* ---- tc_truncate_with_signal ---- */
+
+char *tc_truncate_with_signal(const char *in, int head, int tail, const char *signal)
+{
+   if (!in)
+      return NULL;
+   if (head < 0)
+      head = 0;
+   if (tail < 0)
+      tail = 0;
+
+   /* Index the line offsets. */
+   size_t nlines = 0;
+   for (const char *p = in;;)
+   {
+      size_t n;
+      int has_nl;
+      const char *np = next_line(p, &n, &has_nl);
+      nlines++;
+      if (!has_nl)
+         break;
+      p = np;
+   }
+   if ((size_t)head + (size_t)tail >= nlines)
+      return strdup(in); /* already fits */
+
+   /* line pointers + lengths */
+   const char **lp = calloc(nlines, sizeof(*lp));
+   size_t *ll = calloc(nlines, sizeof(*ll));
+   if (!lp || !ll)
+   {
+      free(lp);
+      free(ll);
+      return NULL;
+   }
+   {
+      size_t i = 0;
+      for (const char *p = in;;)
+      {
+         size_t n;
+         int has_nl;
+         const char *np = next_line(p, &n, &has_nl);
+         lp[i] = p;
+         ll[i] = n;
+         i++;
+         if (!has_nl)
+            break;
+         p = np;
+      }
+   }
+
+   sb_t s = {0};
+   int first = 1;
+   size_t elided = 0;
+   for (size_t i = 0; i < nlines; i++)
+   {
+      int keep = (i < (size_t)head) || (i >= nlines - (size_t)tail);
+      if (!keep && signal && signal[0])
+      {
+         /* case-sensitive substring within the line */
+         char *tmp = malloc(ll[i] + 1);
+         if (!tmp)
+         {
+            s.oom = 1;
+            break;
+         }
+         memcpy(tmp, lp[i], ll[i]);
+         tmp[ll[i]] = '\0';
+         if (strstr(tmp, signal))
+            keep = 1;
+         free(tmp);
+      }
+      if (keep)
+      {
+         if (elided)
+         {
+            char mark[48];
+            snprintf(mark, sizeof mark, "... %zu lines elided ...", elided);
+            if (!first)
+               sb_addc(&s, '\n');
+            first = 0;
+            sb_adds(&s, mark);
+            elided = 0;
+         }
+         if (!first)
+            sb_addc(&s, '\n');
+         first = 0;
+         sb_add(&s, lp[i], ll[i]);
+      }
+      else
+      {
+         elided++;
+      }
+   }
+   if (elided && !s.oom)
+   {
+      char mark[48];
+      snprintf(mark, sizeof mark, "... %zu lines elided ...", elided);
+      if (!first)
+         sb_addc(&s, '\n');
+      sb_adds(&s, mark);
+   }
+   free(lp);
+   free(ll);
+   return sb_finish(&s);
+}


### PR DESCRIPTION
First slice of the **deterministic command-aware tool-output condensation** lever (proposal `deterministic-tool-output-condensation`, merged #1031), stacked on the config-surface Settings work (#1033). **No tool seam wired yet — the lever is inert.**

## What lands
- **`reduce_command_filter`** config flag (default **off**): `config_t` field + parse (`reduce.command_filter`) + save + `config_fields[]` → appears in the web Settings page automatically.
- **`src/tool_condense.{c,h}`** — the pure, deterministic, no-LLM primitives the later per-command family rules compose from. Each returns a fresh heap string; `NULL` = OOM → caller falls back to raw (**fail-open**):
  - `tc_strip_noise` — remove ANSI CSI escapes, resolve CR progress-redraws (keep the final rendered state), collapse blank-line runs.
  - `tc_dedup_lines` — collapse consecutive identical lines to `<line>  (xN)`.
  - `tc_truncate_with_signal` — head + tail + every line containing a signal substring; each elided run → an explicit `... N lines elided ...` marker.
- **`test_tool_condense`** — the gate + all three primitives incl. edge cases (ANSI-only line, already-fits, signal-miss, empty input never returns NULL-as-OOM).

## Review
Roundtable-reviewed; fixed explicit `<stdio.h>` + CSI final-byte range check. Full `unit-tests` + line-check + config-surface green; server builds with the module.

Next: S2 (recognition + wrapper unwrapping), then S3 (delegate seam + test-runner family).