### PR TITLE
feat(economizer): tool-output condensation S2 — command recognition + wrapper unwrapping

### DIFF
--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -14,6 +14,31 @@
 /* 1 iff the command-filter lever is enabled (reduce_command_filter). */
 int tool_condense_enabled(const config_t *cfg);
 
+/* ---- command recognition (Slice 2) ---- */
+
+/* The recognition outcome for a shell command line. Drives whether/how the output is
+ * condensed and the ledger's recognized/unrecognized accounting. */
+typedef enum
+{
+   TC_UNRECOGNIZED = 0, /* not a command we handle (or a compound/piped line) -> passthrough */
+   TC_OPAQUE,           /* multiplexer/make/script: only a generic fallback may ever apply */
+   TC_RECOGNIZED, /* a command we intend to condense; the FAMILY is resolved in later slices */
+} tc_reco_t;
+
+typedef struct
+{
+   tc_reco_t outcome;
+   char cmd[64]; /* normalized inner command basename (after wrapper unwrapping), or "" */
+   char sub[64]; /* the subcommand token (git <sub>, cargo <sub>, npm <sub>, …), or "" */
+} tc_reco_result_t;
+
+/* Recognize a shell command line: reject compound/piped/substituted lines (fail-open ->
+ * UNRECOGNIZED), strip known single-command wrappers (env VAR=…, sudo, nice, time, npx,
+ * bun x, pnpm/npm/yarn exec, uv/poetry/pipenv run), and classify the inner command.
+ * xargs and make and scripts (./x, bash x, sh -c) are OPAQUE (never a family rule).
+ * Deterministic + allocation-free (fixed output buffers). */
+tc_reco_result_t tc_recognize(const char *cmdline);
+
 /* Strip content-free noise, line-wise:
  *  - remove ANSI CSI escape sequences (ESC '[' … final-byte);
  *  - resolve carriage-return progress redraws (keep only the text after the last '\r'

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -108,6 +108,70 @@ int main(void)
       free(r);
    }
 
+   /* ---- tc_recognize (S2) ---- */
+#define RECO(line) tc_recognize(line)
+   {
+      tc_reco_result_t r;
+      /* plain recognized commands + subcommand extraction */
+      r = RECO("git status");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "git") && !strcmp(r.sub, "status"));
+      r = RECO("cargo test --all");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "cargo") && !strcmp(r.sub, "test"));
+      r = RECO("pytest tests/");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "pytest"));
+      /* subcommand skips leading options */
+      r = RECO("git -C /repo status");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.sub, "status"));
+
+      /* wrapper unwrapping */
+      r = RECO("npx tsc --noEmit");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "tsc"));
+      r = RECO("uv run pytest -q");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "pytest"));
+      r = RECO("poetry run pytest");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "pytest"));
+      r = RECO("time cargo build");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "cargo"));
+      r = RECO("env FOO=bar RUST_LOG=info cargo test");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "cargo"));
+      r = RECO("FOO=bar cargo test");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "cargo"));
+      r = RECO("sudo -u ci npm run build");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "npm") && !strcmp(r.sub, "run"));
+      r = RECO("pnpm exec eslint .");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "eslint"));
+
+      /* full path to a known command still resolves by basename */
+      r = RECO("/usr/bin/git log");
+      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "git"));
+
+      /* OPAQUE: multiplexers, make, scripts, interpreters */
+      r = RECO("make test");
+      assert(r.outcome == TC_OPAQUE && !strcmp(r.cmd, "make"));
+      r = RECO("xargs rm");
+      assert(r.outcome == TC_OPAQUE);
+      r = RECO("./run.sh --ci");
+      assert(r.outcome == TC_OPAQUE);
+      r = RECO("bash scripts/build.sh");
+      assert(r.outcome == TC_OPAQUE);
+      r = RECO("/opt/tools/custom_runner");
+      assert(r.outcome == TC_OPAQUE);
+
+      /* UNRECOGNIZED: unknown command + any compound/piped/substituted line */
+      r = RECO("frobnicate --now");
+      assert(r.outcome == TC_UNRECOGNIZED);
+      r = RECO("cargo test | grep FAIL");
+      assert(r.outcome == TC_UNRECOGNIZED); /* pipe -> passthrough */
+      r = RECO("git status && cargo build");
+      assert(r.outcome == TC_UNRECOGNIZED); /* chain -> passthrough */
+      r = RECO("echo $(git rev-parse HEAD)");
+      assert(r.outcome == TC_UNRECOGNIZED); /* substitution -> passthrough */
+      r = RECO("");
+      assert(r.outcome == TC_UNRECOGNIZED);
+      r = RECO(NULL);
+      assert(r.outcome == TC_UNRECOGNIZED);
+   }
+
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -141,9 +141,14 @@ int main(void)
       r = RECO("pnpm exec eslint .");
       assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "eslint"));
 
-      /* full path to a known command still resolves by basename */
+      /* a path-prefixed invocation is OPAQUE even if the basename is a known command —
+       * `/tmp/git` / `./git` must NOT inherit the git family filter (masquerade guard). */
       r = RECO("/usr/bin/git log");
-      assert(r.outcome == TC_RECOGNIZED && !strcmp(r.cmd, "git"));
+      assert(r.outcome == TC_OPAQUE);
+      r = RECO("./git status");
+      assert(r.outcome == TC_OPAQUE);
+      r = RECO("/tmp/cargo test");
+      assert(r.outcome == TC_OPAQUE);
 
       /* OPAQUE: multiplexers, make, scripts, interpreters */
       r = RECO("make test");

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -12,6 +12,238 @@ int tool_condense_enabled(const config_t *cfg)
    return cfg && cfg->reduce_command_filter ? 1 : 0;
 }
 
+/* ---- command recognition (Slice 2) ---- */
+
+#define TC_MAXTOK 24
+
+/* Tokenize a simple command line into argv (whitespace-separated, single/double quotes
+ * honored + stripped). Returns the token count, or -1 if the line contains a shell
+ * COMPOUND operator (| ; & newline), a command substitution ($( or backtick), or a
+ * glob/redirect we won't reason about — the caller then treats the line as UNRECOGNIZED
+ * (fail-open passthrough). Redirect operators end token collection (the command name is
+ * before them). Tokens are copied into `store` (a caller buffer of >= TC_MAXTOK*64). */
+static int tc_tokenize(const char *s, char *tok[TC_MAXTOK], char *store, size_t storecap)
+{
+   int n = 0;
+   size_t used = 0;
+   while (*s)
+   {
+      while (*s == ' ' || *s == '\t')
+         s++;
+      if (!*s)
+         break;
+      /* compound operators / substitution / newline -> bail (compound line) */
+      if (*s == '|' || *s == ';' || *s == '&' || *s == '\n' || *s == '`')
+         return -1;
+      if (*s == '$' && s[1] == '(')
+         return -1;
+      /* a redirect ends the command portion — argv[0..] already captured */
+      if (*s == '<' || *s == '>')
+         break;
+      if (n >= TC_MAXTOK)
+         break; /* enough tokens to recognize the command */
+      /* accumulate one token, honoring '…' and "…" quoting */
+      char *out = store + used;
+      size_t tlen = 0;
+      while (*s && *s != ' ' && *s != '\t' && *s != '|' && *s != ';' && *s != '&' && *s != '<' &&
+             *s != '>' && *s != '\n')
+      {
+         char q = 0;
+         if (*s == '\'' || *s == '"')
+         {
+            q = *s++;
+            while (*s && *s != q)
+            {
+               if (used + tlen + 2 >= storecap)
+                  return -1;
+               out[tlen++] = *s++;
+            }
+            if (*s == q)
+               s++;
+            continue;
+         }
+         if (used + tlen + 2 >= storecap)
+            return -1;
+         out[tlen++] = *s++;
+      }
+      out[tlen] = '\0';
+      used += tlen + 1;
+      tok[n++] = out;
+   }
+   return n;
+}
+
+/* basename of a path token (after the last '/'). */
+static const char *tc_base(const char *p)
+{
+   const char *b = strrchr(p, '/');
+   return b ? b + 1 : p;
+}
+
+/* A known single-command wrapper that takes the inner command as its trailing args.
+ * Returns the number of leading tokens to skip to reach the inner command, or 0 if `t`
+ * is not such a wrapper. `next` is the following token (may be NULL) for 2-word forms. */
+static int tc_wrapper_skip(const char *t, const char *next)
+{
+   /* prefix-only wrappers: <wrapper> <inner…> */
+   static const char *const one[] = {"time", "nice", "nohup", "stdbuf", "npx", NULL};
+   for (int i = 0; one[i]; i++)
+      if (strcmp(t, one[i]) == 0)
+         return 1;
+   /* two-word runners: <a> <b> <inner…> */
+   if (next)
+   {
+      if ((strcmp(t, "uv") == 0 || strcmp(t, "poetry") == 0 || strcmp(t, "pipenv") == 0) &&
+          strcmp(next, "run") == 0)
+         return 2;
+      if (strcmp(t, "bun") == 0 && strcmp(next, "x") == 0)
+         return 2;
+      if ((strcmp(t, "pnpm") == 0 || strcmp(t, "npm") == 0 || strcmp(t, "yarn") == 0) &&
+          strcmp(next, "exec") == 0)
+         return 2;
+   }
+   return 0;
+}
+
+/* Is `c` a command whose output we intend to condense (a family lands in a later slice)? */
+static int tc_is_recognized_cmd(const char *c)
+{
+   static const char *const known[] = {
+       "git",    "cargo",  "go",    "pytest",  "jest",  "vitest", "mocha",  "ctest", "mvn",
+       "gradle", "dotnet", "tsc",   "eslint",  "ruff",  "mypy",   "flake8", "rustc", "gcc",
+       "g++",    "cc",     "clang", "clang++", "ls",    "grep",   "rg",     "find",  "npm",
+       "yarn",   "pnpm",   "pip",   "pip3",    "cmake", NULL};
+   for (int i = 0; known[i]; i++)
+      if (strcmp(c, known[i]) == 0)
+         return 1;
+   return 0;
+}
+
+/* Is `t` a leading `VAR=VALUE` environment assignment (identifier before the first '=',
+ * not an option, not a path)? */
+static int tc_is_var_assign(const char *t)
+{
+   const char *eq = strchr(t, '=');
+   if (!eq || eq == t || t[0] == '-' || strchr(t, '/'))
+      return 0;
+   for (const char *p = t; p < eq; p++)
+      if (!((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') || (*p >= '0' && *p <= '9') ||
+            *p == '_'))
+         return 0;
+   return 1;
+}
+
+/* A subcommand-bearing command whose 2nd token is meaningful for family routing. */
+static int tc_has_subcommand(const char *c)
+{
+   static const char *const subc[] = {"git",  "cargo", "go",  "dotnet", "npm",
+                                      "yarn", "pnpm",  "pip", "pip3",   NULL};
+   for (int i = 0; subc[i]; i++)
+      if (strcmp(c, subc[i]) == 0)
+         return 1;
+   return 0;
+}
+
+tc_reco_result_t tc_recognize(const char *cmdline)
+{
+   tc_reco_result_t r;
+   r.outcome = TC_UNRECOGNIZED;
+   r.cmd[0] = '\0';
+   r.sub[0] = '\0';
+   if (!cmdline)
+      return r;
+
+   char *tok[TC_MAXTOK];
+   char store[TC_MAXTOK * 64];
+   int n = tc_tokenize(cmdline, tok, store, sizeof store);
+   if (n <= 0)
+      return r; /* empty or compound -> UNRECOGNIZED (passthrough) */
+
+   int i = 0;
+   /* strip a leading VAR=VALUE prefix, `env` + its assignments, sudo, and chained
+    * single-command wrappers, until we reach the real inner command. */
+   int guard = 0;
+   while (i < n && guard++ < TC_MAXTOK)
+   {
+      /* bare `VAR=VALUE cmd` prefix */
+      if (tc_is_var_assign(tok[i]))
+      {
+         i++;
+         continue;
+      }
+      const char *b = tc_base(tok[i]);
+      if (strcmp(b, "env") == 0)
+      {
+         i++;
+         while (i < n && tc_is_var_assign(tok[i]))
+            i++;
+         continue;
+      }
+      if (strcmp(b, "sudo") == 0)
+      {
+         i++;
+         while (i < n && tok[i][0] == '-')
+         {
+            /* sudo short options that take a separate argument (best-effort): consume
+             * both the option and its value (e.g. `-u ci`). --opt=val is self-contained. */
+            const char *o = tok[i];
+            int takes_arg = (o[1] && strchr("ugpCrtTURhDP", o[1]) && o[2] == '\0');
+            i++;
+            if (takes_arg && i < n)
+               i++;
+         }
+         continue;
+      }
+      int skip = tc_wrapper_skip(b, (i + 1 < n) ? tok[i + 1] : NULL);
+      if (skip)
+      {
+         i += skip;
+         continue;
+      }
+      break;
+   }
+   if (i >= n)
+      return r;
+
+   const char *cmd = tc_base(tok[i]);
+   snprintf(r.cmd, sizeof r.cmd, "%s", cmd);
+
+   /* multiplexers, make, and shell interpreters are always OPAQUE (arbitrary output —
+    * only a generic fallback may ever apply, never a family rule). */
+   if (strcmp(cmd, "xargs") == 0 || strcmp(cmd, "make") == 0 || strcmp(cmd, "bash") == 0 ||
+       strcmp(cmd, "sh") == 0 || strcmp(cmd, "zsh") == 0)
+   {
+      r.outcome = TC_OPAQUE;
+      return r;
+   }
+   /* a `./script` or a path to something whose basename we don't know is OPAQUE too;
+    * but a full path to a KNOWN command (e.g. /usr/bin/git) still resolves by basename. */
+   if ((tok[i][0] == '.' || strchr(tok[i], '/')) && !tc_is_recognized_cmd(cmd))
+   {
+      r.outcome = TC_OPAQUE;
+      return r;
+   }
+
+   if (tc_is_recognized_cmd(cmd))
+   {
+      r.outcome = TC_RECOGNIZED;
+      if (tc_has_subcommand(cmd) && i + 1 < n)
+      {
+         /* A subcommand (status/test/run/install/…) is a bare word: skip options ('-…')
+          * and option-arguments (paths with '/', or KEY=VALUE with '=') — best-effort;
+          * the family rule in a later slice re-parses precisely. */
+         for (int j = i + 1; j < n; j++)
+            if (tok[j][0] != '-' && !strchr(tok[j], '/') && !strchr(tok[j], '='))
+            {
+               snprintf(r.sub, sizeof r.sub, "%s", tok[j]);
+               break;
+            }
+      }
+      return r;
+   }
+   return r; /* UNRECOGNIZED */
+}
+
 /* ---- a minimal growable string builder (self-contained so the unit test links only
  * this TU + config) ---- */
 typedef struct

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -216,9 +216,11 @@ tc_reco_result_t tc_recognize(const char *cmdline)
       r.outcome = TC_OPAQUE;
       return r;
    }
-   /* a `./script` or a path to something whose basename we don't know is OPAQUE too;
-    * but a full path to a KNOWN command (e.g. /usr/bin/git) still resolves by basename. */
-   if ((tok[i][0] == '.' || strchr(tok[i], '/')) && !tc_is_recognized_cmd(cmd))
+   /* ANY path-prefixed invocation is OPAQUE — we only apply a family rule to a BARE
+    * command name (resolved by the shell against $PATH). Honoring the basename of a
+    * path would let `./git` / `/tmp/git` (a script or binary that merely shares a known
+    * name) inherit that command's family filter; treat all such as opaque. */
+   if (tok[i][0] == '.' || strchr(tok[i], '/'))
    {
       r.outcome = TC_OPAQUE;
       return r;


### PR DESCRIPTION
Second slice of the deterministic command-aware tool-output condensation lever (proposal #1031). Stacks on S1 (#1035). **Still no tool seam wired — inert.**

## `tc_recognize(cmdline) → {outcome, cmd, sub}`
- **Conservative tokenizer**: a compound/piped/substituted line (`| ; & \` $(`) → `UNRECOGNIZED` (fail-open passthrough); redirects end the command portion; quotes honored. Fixed buffers, no allocation.
- **Wrapper unwrapping** to the inner command: `VAR=VAL` prefix, `env VAR=…`, `sudo [-u user…]` (arg-taking short options consumed), and `time`/`nice`/`nohup`/`stdbuf`/`npx` + two-word `uv|poetry|pipenv run` / `bun x` / `pnpm|npm|yarn exec`.
- **Classification**: `xargs`/`make`/shell-interpreters/`./scripts`/**any path-prefixed token** → `OPAQUE` (never a family rule — masquerade guard); a known bare command → `RECOGNIZED` with a best-effort subcommand hint; else `UNRECOGNIZED`.

**Safety property**: every mis-parse falls to `UNRECOGNIZED` → passthrough, so it can never route to the *wrong* family and hide output.

## Review
Roundtable-reviewed; the one verified blocking item (path-prefixed basename collision, e.g. `./git`) is fixed — all path-prefixed invocations are now `OPAQUE`. Subcommand option-arg misreads are a documented safe-by-design limitation (family rules re-parse; spill backs up). Full `unit-tests` + line-check green.

The family rules that consume this recognition land in S3 (delegate seam + test-runner family).