### PR TITLE
feat(economizer): tool-output condensation S3 — test-runner family + spill + apply

### DIFF
--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -39,6 +39,35 @@ typedef struct
  * Deterministic + allocation-free (fixed output buffers). */
 tc_reco_result_t tc_recognize(const char *cmdline);
 
+/* ---- family filters + the top-level apply (Slice 3) ---- */
+
+/* Test-runner family filter: keep the summary + every failure verbatim, drop passing-case
+ * transcripts. `exit_code` biases safety — a non-zero exit with NO recognizable failure
+ * lines returns NULL (verbatim passthrough, never hide the cause). Returns a NEW string
+ * (caller frees), or NULL to pass the raw output through unchanged. */
+char *tc_family_test_runner(int exit_code, const char *in);
+
+/* Per-condensation accounting for the economizer ledger. */
+typedef struct
+{
+   long raw_bytes;   /* input size */
+   long final_bytes; /* condensed size (== raw_bytes when passed through) */
+   int recognized;   /* the command was RECOGNIZED */
+   int spilled;      /* a full-output spill file was written */
+   char family[24];  /* "test", "" (none), … */
+   char spill_ref[40];
+} tc_stats_t;
+
+/* Top-level condensation entry (no seam wired yet — S4 calls this at the tool seam).
+ * Recognizes `cmdline`; if a family rule materially shrinks `raw`, writes the FULL raw
+ * output to a spill file under `spill_dir` and returns the condensed text with a trailing
+ * "… full output: <ref>" pointer (caller frees). Returns NULL to pass `raw` through
+ * unchanged (unrecognized / no gain / a filter or spill failure -> fail-open). `stats`
+ * (optional) is filled for the ledger. `spill_dir` NULL disables spilling (then a
+ * successful condense that would need a spill instead passes through — never lossy). */
+char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_code, const char *raw,
+                          const char *spill_dir, tc_stats_t *stats);
+
 /* Strip content-free noise, line-wise:
  *  - remove ANSI CSI escape sequences (ESC '[' … final-byte);
  *  - resolve carriage-return progress redraws (keep only the text after the last '\r'

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "config.h"
 #include "tool_condense.h"
@@ -175,6 +176,81 @@ int main(void)
       assert(r.outcome == TC_UNRECOGNIZED);
       r = RECO(NULL);
       assert(r.outcome == TC_UNRECOGNIZED);
+   }
+
+   /* ---- tc_family_test_runner (S3) ---- */
+   {
+      /* build 30 passing lines + a failure + summary */
+      char big[4096];
+      size_t off = 0;
+      off += (size_t)snprintf(big + off, sizeof big - off, "running 32 tests\n");
+      for (int k = 0; k < 30; k++)
+         off += (size_t)snprintf(big + off, sizeof big - off, "test suite::case_%02d ... ok\n", k);
+      off += (size_t)snprintf(big + off, sizeof big - off, "test suite::case_bad ... FAILED\n");
+      snprintf(big + off, sizeof big - off,
+               "failures:\n    suite::case_bad\ntest result: FAILED. 31 passed; 1 failed\n");
+
+      char *r = tc_family_test_runner(1, big);
+      assert(r);
+      assert(strstr(r, "FAILED"));          /* failure kept */
+      assert(strstr(r, "test result"));     /* summary kept */
+      assert(strstr(r, "lines elided"));    /* passes elided */
+      assert(strlen(r) < strlen(big));      /* shrank */
+      assert(!strstr(r, "case_05 ... ok")); /* a middle passing line dropped */
+      free(r);
+
+      /* non-zero exit with NO failure signal -> passthrough (NULL) */
+      char *r2 = tc_family_test_runner(1, "building...\nlinking...\nnothing useful here\n");
+      assert(r2 == NULL);
+   }
+
+   /* ---- tool_condense_apply (S3) ---- */
+   {
+      config_t cfg;
+      memset(&cfg, 0, sizeof cfg);
+
+      /* a big passing pytest run (exit 0) */
+      char big[8192];
+      size_t off = 0;
+      off +=
+          (size_t)snprintf(big + off, sizeof big - off, "============ test session starts ====\n");
+      for (int k = 0; k < 120; k++)
+         off += (size_t)snprintf(big + off, sizeof big - off,
+                                 "tests/test_mod.py::test_%03d PASSED\n", k);
+      snprintf(big + off, sizeof big - off, "==== 120 passed in 3.14s ====\n");
+
+      /* disabled -> passthrough */
+      assert(tool_condense_apply(&cfg, "pytest -q", 0, big, "/tmp", NULL) == NULL);
+
+      cfg.reduce_command_filter = 1;
+      /* unrecognized command -> passthrough */
+      assert(tool_condense_apply(&cfg, "frobnicate", 0, big, "/tmp", NULL) == NULL);
+      /* recognized but no spill dir -> passthrough (lossless: never condense without spill) */
+      assert(tool_condense_apply(&cfg, "pytest -q", 0, big, NULL, NULL) == NULL);
+
+      /* recognized test runner + a real spill dir -> condensed + spill written */
+      char dir[] = "/tmp/tc_test_XXXXXX";
+      assert(mkdtemp(dir));
+      tc_stats_t st;
+      char *r = tool_condense_apply(&cfg, "pytest -q", 0, big, dir, &st);
+      assert(r);
+      assert(st.recognized && st.spilled && !strcmp(st.family, "test"));
+      assert(st.final_bytes < st.raw_bytes);
+      assert(strstr(r, "tool_output_get")); /* retrieval pointer present */
+      assert(strstr(r, st.spill_ref));
+      /* the spill file exists + holds the FULL raw */
+      char spath[512];
+      snprintf(spath, sizeof spath, "%s/%s.out", dir, st.spill_ref);
+      FILE *sf = fopen(spath, "rb");
+      assert(sf);
+      fseek(sf, 0, SEEK_END);
+      long sz = ftell(sf);
+      fclose(sf);
+      assert(sz == st.raw_bytes);
+      /* cleanup */
+      unlink(spath);
+      rmdir(dir);
+      free(r);
    }
 
    printf("ok\n");

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -3,10 +3,12 @@
  * enable gate. CORE layer: depends only on config.h + libc. */
 #include "tool_condense.h"
 
+#include <fcntl.h>
 #include <stdint.h>
-#include <stdio.h> /* snprintf, fopen */
+#include <stdio.h> /* snprintf */
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 int tool_condense_enabled(const config_t *cfg)
 {
@@ -681,6 +683,8 @@ char *tc_family_test_runner(int exit_code, const char *in)
       return NULL;
    }
 
+   /* Always keep the first HEAD lines (banner/session start) and the last TAIL lines
+    * (the end-of-run summary lives here); drop passing transcripts in between. */
    const size_t HEAD = 2, TAIL = 6;
    sb_t s = {0};
    int first = 1;
@@ -746,20 +750,33 @@ static void tc_hash_ref(const char *seed, const char *content, char out[40])
    snprintf(out, 40, "tc-%016llx", (unsigned long long)h);
 }
 
-/* Write the full raw output to <dir>/<ref>.out. Returns 0 on a fully-durable write,
- * -1 otherwise (the caller then passes through — never a condense without a backstop). */
+/* Write the full raw output to <dir>/<ref>.out. Returns 0 iff every byte was written,
+ * -1 otherwise (the caller then passes through — never a condense without a backstop).
+ * Opened O_NOFOLLOW (never follow a pre-planted symlink at the predictable path) + 0600.
+ * The ref is content-derived so re-writing an existing ref is idempotent (same bytes). */
 static int tc_spill_write(const char *dir, const char *ref, const char *content)
 {
    char path[1400];
    if (snprintf(path, sizeof path, "%s/%s.out", dir, ref) >= (int)sizeof path)
       return -1;
-   FILE *f = fopen(path, "wb");
-   if (!f)
+   int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
+   if (fd < 0)
       return -1;
-   size_t n = strlen(content);
-   size_t w = fwrite(content, 1, n, f);
-   /* fflush+fclose success + full write == durable enough for the backstop. */
-   return (fclose(f) == 0 && w == n) ? 0 : -1;
+   size_t n = strlen(content), off = 0;
+   int ok = 1;
+   while (off < n)
+   {
+      ssize_t w = write(fd, content + off, n - off);
+      if (w <= 0)
+      {
+         ok = 0;
+         break;
+      }
+      off += (size_t)w;
+   }
+   if (close(fd) != 0)
+      ok = 0;
+   return (ok && off == n) ? 0 : -1;
 }
 
 /* Does the recognized command denote a TEST-RUNNER invocation (the only S3 family)? */

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -3,7 +3,8 @@
  * enable gate. CORE layer: depends only on config.h + libc. */
 #include "tool_condense.h"
 
-#include <stdio.h> /* snprintf */
+#include <stdint.h>
+#include <stdio.h> /* snprintf, fopen */
 #include <stdlib.h>
 #include <string.h>
 
@@ -587,4 +588,262 @@ char *tc_truncate_with_signal(const char *in, int head, int tail, const char *si
    free(lp);
    free(ll);
    return sb_finish(&s);
+}
+
+/* ---- test-runner family (Slice 3) ---- */
+
+/* case-insensitive substring test. */
+static int ci_contains(const char *hay, size_t haylen, const char *needle)
+{
+   size_t nl = strlen(needle);
+   if (nl == 0 || nl > haylen)
+      return 0;
+   for (size_t i = 0; i + nl <= haylen; i++)
+   {
+      size_t j = 0;
+      for (; j < nl; j++)
+      {
+         char a = hay[i + j], b = needle[j];
+         if (a >= 'A' && a <= 'Z')
+            a = (char)(a - 'A' + 'a');
+         if (b >= 'A' && b <= 'Z')
+            b = (char)(b - 'A' + 'a');
+         if (a != b)
+            break;
+      }
+      if (j == nl)
+         return 1;
+   }
+   return 0;
+}
+
+static int line_has_any(const char *line, size_t n, const char *const *sigs)
+{
+   for (int i = 0; sigs[i]; i++)
+      if (ci_contains(line, n, sigs[i]))
+         return 1;
+   return 0;
+}
+
+/* signals that mark a FAILURE (never elide these); used for the exit-code safety rule. */
+static const char *const TC_FAIL_SIGS[] = {
+    "fail", "error", "panic", "assert", "traceback", "exception", "not ok", "✗", "✖", "✘", NULL};
+/* additional signals worth keeping (the summary / counts / warnings). */
+static const char *const TC_KEEP_SIGS[] = {"test result", "result:", "====",     "collected",
+                                           "summary",     "warning", "warnings", NULL};
+
+char *tc_family_test_runner(int exit_code, const char *in)
+{
+   if (!in)
+      return NULL;
+   /* index lines */
+   size_t nlines = 0;
+   for (const char *p = in;;)
+   {
+      size_t n;
+      int has_nl;
+      const char *np = next_line(p, &n, &has_nl);
+      nlines++;
+      if (!has_nl)
+         break;
+      p = np;
+   }
+   const char **lp = calloc(nlines, sizeof(*lp));
+   size_t *ll = calloc(nlines, sizeof(*ll));
+   if (!lp || !ll)
+   {
+      free(lp);
+      free(ll);
+      return NULL;
+   }
+   size_t idx = 0;
+   int any_fail = 0;
+   for (const char *p = in;;)
+   {
+      size_t n;
+      int has_nl;
+      const char *np = next_line(p, &n, &has_nl);
+      lp[idx] = p;
+      ll[idx] = n;
+      if (line_has_any(p, n, TC_FAIL_SIGS))
+         any_fail = 1;
+      idx++;
+      if (!has_nl)
+         break;
+      p = np;
+   }
+   /* Safety: a non-zero exit with no recognizable failure line -> passthrough (never
+    * risk hiding the cause behind a passing-transcript filter). */
+   if (exit_code != 0 && !any_fail)
+   {
+      free(lp);
+      free(ll);
+      return NULL;
+   }
+
+   const size_t HEAD = 2, TAIL = 6;
+   sb_t s = {0};
+   int first = 1;
+   size_t elided = 0;
+   for (size_t i = 0; i < nlines; i++)
+   {
+      int keep = (i < HEAD) || (i + TAIL >= nlines) || line_has_any(lp[i], ll[i], TC_FAIL_SIGS) ||
+                 line_has_any(lp[i], ll[i], TC_KEEP_SIGS);
+      if (keep)
+      {
+         if (elided)
+         {
+            char mark[48];
+            snprintf(mark, sizeof mark, "... %zu lines elided ...", elided);
+            if (!first)
+               sb_addc(&s, '\n');
+            first = 0;
+            sb_adds(&s, mark);
+            elided = 0;
+         }
+         if (!first)
+            sb_addc(&s, '\n');
+         first = 0;
+         sb_add(&s, lp[i], ll[i]);
+      }
+      else
+      {
+         elided++;
+      }
+   }
+   if (elided && !s.oom)
+   {
+      char mark[48];
+      snprintf(mark, sizeof mark, "... %zu lines elided ...", elided);
+      if (!first)
+         sb_addc(&s, '\n');
+      sb_adds(&s, mark);
+   }
+   free(lp);
+   free(ll);
+   return sb_finish(&s);
+}
+
+/* ---- spill store + top-level apply (Slice 3) ---- */
+
+/* An opaque, deterministic spill ref = FNV-1a-64(cmdline || '\0' || raw), hex. Not a
+ * monotonic counter (not enumerable); deterministic so identical output dedups. */
+static void tc_hash_ref(const char *seed, const char *content, char out[40])
+{
+   uint64_t h = 1469598103934665603ULL;
+   for (const char *p = seed; p && *p; p++)
+   {
+      h ^= (unsigned char)*p;
+      h *= 1099511628211ULL;
+   }
+   h ^= 0;
+   h *= 1099511628211ULL;
+   for (const char *p = content; p && *p; p++)
+   {
+      h ^= (unsigned char)*p;
+      h *= 1099511628211ULL;
+   }
+   snprintf(out, 40, "tc-%016llx", (unsigned long long)h);
+}
+
+/* Write the full raw output to <dir>/<ref>.out. Returns 0 on a fully-durable write,
+ * -1 otherwise (the caller then passes through — never a condense without a backstop). */
+static int tc_spill_write(const char *dir, const char *ref, const char *content)
+{
+   char path[1400];
+   if (snprintf(path, sizeof path, "%s/%s.out", dir, ref) >= (int)sizeof path)
+      return -1;
+   FILE *f = fopen(path, "wb");
+   if (!f)
+      return -1;
+   size_t n = strlen(content);
+   size_t w = fwrite(content, 1, n, f);
+   /* fflush+fclose success + full write == durable enough for the backstop. */
+   return (fclose(f) == 0 && w == n) ? 0 : -1;
+}
+
+/* Does the recognized command denote a TEST-RUNNER invocation (the only S3 family)? */
+static int tc_is_test_invocation(const tc_reco_result_t *r)
+{
+   static const char *const runners[] = {"pytest", "jest", "vitest", "mocha", "ctest", NULL};
+   for (int i = 0; runners[i]; i++)
+      if (strcmp(r->cmd, runners[i]) == 0)
+         return 1;
+   static const char *const sub_runners[] = {"cargo", "go",     "npm",    "yarn", "pnpm",
+                                             "mvn",   "gradle", "dotnet", NULL};
+   for (int i = 0; sub_runners[i]; i++)
+      if (strcmp(r->cmd, sub_runners[i]) == 0 && strcmp(r->sub, "test") == 0)
+         return 1;
+   return 0;
+}
+
+char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_code, const char *raw,
+                          const char *spill_dir, tc_stats_t *stats)
+{
+   if (stats)
+   {
+      memset(stats, 0, sizeof *stats);
+      stats->raw_bytes = raw ? (long)strlen(raw) : 0;
+      stats->final_bytes = stats->raw_bytes;
+   }
+   if (!tool_condense_enabled(cfg) || !raw || !raw[0])
+      return NULL;
+   long rawlen = (long)strlen(raw);
+   if (rawlen > (1 << 20))
+      return NULL; /* over the input cap -> hand back to the size-based fallback */
+
+   tc_reco_result_t reco = tc_recognize(cmdline);
+   if (stats)
+      stats->recognized = (reco.outcome == TC_RECOGNIZED);
+   if (reco.outcome != TC_RECOGNIZED)
+      return NULL; /* OPAQUE / UNRECOGNIZED -> passthrough (S3 acts only on a family) */
+
+   char *cond = NULL;
+   const char *family = "";
+   if (tc_is_test_invocation(&reco))
+   {
+      cond = tc_family_test_runner(exit_code, raw);
+      family = "test";
+   }
+   if (!cond)
+      return NULL; /* no family match or the filter declined -> passthrough */
+
+   long condlen = (long)strlen(cond);
+   /* material-gain gate: require a real shrink, else it's not worth a spill round-trip. */
+   if (rawlen - condlen < 200 || condlen * 100 > rawlen * 85)
+   {
+      free(cond);
+      return NULL;
+   }
+   /* Lossless-on-demand: the condensed body only ships if the FULL raw is spilled. No
+    * spill dir, or a failed spill -> pass through (never a condensed body with no
+    * recoverable backstop). */
+   if (!spill_dir || !spill_dir[0])
+   {
+      free(cond);
+      return NULL;
+   }
+   char ref[40];
+   tc_hash_ref(cmdline ? cmdline : "", raw, ref);
+   if (tc_spill_write(spill_dir, ref, raw) != 0)
+   {
+      free(cond);
+      return NULL;
+   }
+
+   sb_t out = {0};
+   sb_adds(&out, cond);
+   char ptr[96];
+   snprintf(ptr, sizeof ptr, "\n... full output (%ld bytes): tool_output_get %s", rawlen, ref);
+   sb_adds(&out, ptr);
+   free(cond);
+   char *final = sb_finish(&out);
+   if (stats && final)
+   {
+      stats->final_bytes = (long)strlen(final);
+      stats->spilled = 1;
+      snprintf(stats->family, sizeof stats->family, "%s", family);
+      snprintf(stats->spill_ref, sizeof stats->spill_ref, "%s", ref);
+   }
+   return final;
 }


### PR DESCRIPTION
Third slice (proposal #1031), stacked on S2 (#1036). The condensation **engine** that S4 will call at the tool seam. **Still no seam wired — inert.**

## What lands
- **`tc_family_test_runner(exit, in)`** — keep the summary + every failure verbatim, drop passing transcripts (head/tail window + failure/structural signal match). **Safety**: a non-zero exit with *no* recognizable failure line → passthrough (never hide the cause). Per-test `PASSED`/`ok` lines are elided; the end-of-run summary survives via the tail.
- **Spill store** — `tc_hash_ref` (opaque deterministic FNV-1a-64) + `tc_spill_write` (`O_NOFOLLOW|O_CREAT|O_TRUNC`, `0600`, checked write loop; a partial/failed write → `-1`).
- **`tool_condense_apply(...)`** — recognize → test family → material-gain gate (≥200 B and ≤85%) → **spill the full raw** → return condensed + a `tool_output_get <ref>` pointer. **Lossless**: no spill dir or a failed spill → passthrough (never a condensed body without a recoverable backstop). 1 MiB input cap hands oversized bodies to the size-based fallback. Fills `tc_stats_t` for the ledger.

## Review
Roundtable-reviewed; fixed symlink-safe spill open + checked writes + named constants. (lp/ll-leak and hash-collision findings verified false — freed on all paths; colliding content spills identical bytes.) Full `unit-tests` + line-check green.

Next: S4 wires the delegate tool seam + the `tool_output_get` retrieval tool + the ledger, and adds the remaining families.