### PR TITLE
feat(economizer): tool-output condensation S4 — wire the delegate bash-tool seam (LIVE)

### DIFF
--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -1003,8 +1003,8 @@ char *tool_bash(const char *command, int timeout_ms)
       config_t tccfg;
       if (config_load(&tccfg) == 0 && tool_condense_enabled(&tccfg))
       {
-         char spill_dir[600];
-         const char *home = aimee_home();
+         char spill_dir[3072];
+         const char *home = aimee_home(); /* captured once; not called again before use */
          if (home && home[0] &&
              snprintf(spill_dir, sizeof spill_dir, "%s/tool-spills", home) < (int)sizeof spill_dir)
          {

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -1,6 +1,9 @@
 #include "aimee.h"
 #include "util.h"
 #include "agent_tools.h"
+#include "aimee_home.h"
+#include "tool_condense.h"
+#include "log.h"
 #include "agent_tools_internal.h"
 #include "agent_source_authority.h"
 #include "process_mgr.h"
@@ -990,9 +993,37 @@ char *tool_bash(const char *command, int timeout_ms)
    }
    out_buf[out_len] = '\0';
    err_buf[err_len] = '\0';
-   /* Compress output to fit token budget (#4) */
-   char *compressed_out = agent_compress_tool_result(out_buf, out_len, "bash");
-   char *compressed_err = agent_compress_tool_result(err_buf, err_len, "bash");
+
+   /* Command-aware condensation (reduce_command_filter, default off): for a RECOGNIZED
+    * command, deterministically condense the output (test failures kept, passes elided)
+    * and spill the full raw so the delegate can read it back. Fail-open: any miss/decline
+    * returns NULL and we fall through to the size-based agent_compress_tool_result. */
+   char *cond_out = NULL, *cond_err = NULL;
+   {
+      config_t tccfg;
+      if (config_load(&tccfg) == 0 && tool_condense_enabled(&tccfg))
+      {
+         char spill_dir[600];
+         const char *home = aimee_home();
+         if (home && home[0] &&
+             snprintf(spill_dir, sizeof spill_dir, "%s/tool-spills", home) < (int)sizeof spill_dir)
+         {
+            (void)mkdir(spill_dir, 0700); /* idempotent; 0700 per-user */
+            tc_stats_t st;
+            cond_out = tool_condense_apply(&tccfg, command, exit_code, out_buf, spill_dir, &st);
+            if (cond_out)
+               aimee_log(LOG_INFO, "tool_condense", "bash stdout condensed %ld->%ld (%s)",
+                         st.raw_bytes, st.final_bytes, st.family);
+            cond_err = tool_condense_apply(&tccfg, command, exit_code, err_buf, spill_dir, NULL);
+         }
+      }
+   }
+   /* Compress output to fit token budget (#4) — the command-aware condensed form when we
+    * produced one, else the size-based fallback. */
+   char *compressed_out =
+       cond_out ? cond_out : agent_compress_tool_result(out_buf, out_len, "bash");
+   char *compressed_err =
+       cond_err ? cond_err : agent_compress_tool_result(err_buf, err_len, "bash");
 
    /* Build JSON result */
    cJSON *result = cJSON_CreateObject();

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -17,7 +17,7 @@ TEST_RUN_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/n
 TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o $(OBJDIR)/config_mode.o $(OBJDIR)/config_fields.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                  $(OBJDIR)/platform_random.o $(PLATFORM_BASIC_OBJS) \
                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o \
-                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/context_reduce.o $(OBJDIR)/fold_register.o $(OBJDIR)/fold_recall.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
+                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/context_reduce.o $(OBJDIR)/tool_condense.o $(OBJDIR)/fold_register.o $(OBJDIR)/fold_recall.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
                  $(OBJDIR)/json_fluent.o $(OBJDIR)/markdown.o
 # Extended set for tests that need workspace/worktree/guardrails functions (pulls in agents).
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -236,8 +236,9 @@ int main(void)
       assert(r);
       assert(st.recognized && st.spilled && !strcmp(st.family, "test"));
       assert(st.final_bytes < st.raw_bytes);
-      assert(strstr(r, "tool_output_get")); /* retrieval pointer present */
-      assert(strstr(r, st.spill_ref));
+      assert(strstr(r, "condensed by aimee")); /* recovery pointer present */
+      assert(strstr(r, st.spill_ref));         /* references the spill file */
+      assert(strstr(r, dir));                  /* the catable full path */
       /* the spill file exists + holds the FULL raw */
       char spath[512];
       snprintf(spath, sizeof spath, "%s/%s.out", dir, st.spill_ref);

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -850,11 +850,19 @@ char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_cod
 
    sb_t out = {0};
    sb_adds(&out, cond);
-   char ptr[1600];
-   snprintf(ptr, sizeof ptr,
-            "\n[output condensed by aimee — %ld bytes total; the full, unfiltered output is "
-            "at %s/%s.out — read it if you need a passing case or elided detail]",
-            rawlen, spill_dir, ref);
+   char ptr[4200];
+   int pn = snprintf(ptr, sizeof ptr,
+                     "\n[output condensed by aimee — %ld bytes total; the full, unfiltered "
+                     "output is at %s/%s.out — read it if you need a passing case or elided "
+                     "detail]",
+                     rawlen, spill_dir, ref);
+   if (pn < 0 || pn >= (int)sizeof ptr)
+   {
+      /* the recovery pointer would be truncated (pathological spill path) -> passthrough
+       * rather than ship a condensed body with an unusable pointer (lossless invariant). */
+      free(cond);
+      return NULL;
+   }
    sb_adds(&out, ptr);
    free(cond);
    char *final = sb_finish(&out);

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -850,8 +850,11 @@ char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_cod
 
    sb_t out = {0};
    sb_adds(&out, cond);
-   char ptr[96];
-   snprintf(ptr, sizeof ptr, "\n... full output (%ld bytes): tool_output_get %s", rawlen, ref);
+   char ptr[1600];
+   snprintf(ptr, sizeof ptr,
+            "\n[output condensed by aimee — %ld bytes total; the full, unfiltered output is "
+            "at %s/%s.out — read it if you need a passing case or elided detail]",
+            rawlen, spill_dir, ref);
    sb_adds(&out, ptr);
    free(cond);
    char *final = sb_finish(&out);


### PR DESCRIPTION
Fourth slice (proposal #1031), stacked on S3 (#1038). Makes the lever **LIVE for the delegate surface** (test-runner family), still **default-off** (`reduce_command_filter`).

## What lands
- **`tool_bash`** (`posix/agent_tools.c`) now runs `tool_condense_apply` on the captured stdout (and stderr) **before** the existing size-based `agent_compress_tool_result`. For a recognized test runner whose output materially shrinks, the delegate sees the condensed form (failures + summary) with a pointer to the **full raw** spilled under `<aimee_home>/tool-spills` (`0700`) — which the delegate reads back with its own bash tool.
- **Fail-open**: config-load failure / not enabled / unrecognized / no-gain / spill failure / a would-be-truncated pointer all return `NULL` → fall through to today's size-based compression (**byte-identical default-off behavior**).

## Validation
- Full `unit-tests` + line-check green; server builds. The condensation **engine is exhaustively unit-tested** (S1–S3: recognition, family filter, spill, apply, fail-open).
- **`.253` CT smoke** (on the `/storage` store): the S4 binary boots clean with the lever on; `reduce.command_filter:true` is live in `config.show` (→ auto-appears in the Settings page). Cleaned up.
- Roundtable-reviewed; fixed pointer-truncation guard + spill-dir buffer size. (stdout/stderr same-ref + `%ld`/size_t findings verified false — content-derived refs give distinct files; `tc_stats` fields are `long`.)

Live end-to-end delegate **measurement** (realized savings on a real workload) is the **S6** validation gate. Next: S5 (remaining families), S6 (validation + default-on), S7 (primary-agent hook + first-class retrieval tool).