### PR TITLE
feat(economizer): tool-output condensation S5 — compilers/linters (diagnostics) family

### DIFF
--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -47,6 +47,11 @@ tc_reco_result_t tc_recognize(const char *cmdline);
  * (caller frees), or NULL to pass the raw output through unchanged. */
 char *tc_family_test_runner(int exit_code, const char *in);
 
+/* Compiler/linter diagnostics family (Slice 5): keep errors/warnings/notes + file:line
+ * diagnostics, drop progress chatter. A non-zero exit's error lines are always kept.
+ * Returns a NEW string (caller frees) or NULL to pass through. */
+char *tc_family_diagnostics(int exit_code, const char *in);
+
 /* Per-condensation accounting for the economizer ledger. */
 typedef struct
 {

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -284,6 +284,11 @@ int main(void)
       char *r2 = tc_family_diagnostics(0, warns);
       assert(r2 && strstr(r2, "unused variable") && strstr(r2, "lines elided"));
       free(r2);
+
+      /* SAFETY: a non-zero exit whose failure is in NO recognized format -> passthrough
+       * (never hide an unrecognized build failure). */
+      char *r3 = tc_family_diagnostics(1, "step one\nstep two\nsomething went sideways\n");
+      assert(r3 == NULL);
    }
 
    /* ---- diagnostics routing through tool_condense_apply (S5) ---- */

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -254,6 +254,63 @@ int main(void)
       free(r);
    }
 
+   /* ---- tc_family_diagnostics (S5) ---- */
+   {
+      char big[8192];
+      size_t off = 0;
+      for (int k = 0; k < 60; k++)
+         off += (size_t)snprintf(big + off, sizeof big - off,
+                                 "   Compiling crate_%02d v0.1.0 (/w/crate_%02d)\n", k, k);
+      off += (size_t)snprintf(big + off, sizeof big - off,
+                              "error[E0308]: mismatched types\n --> src/lib.rs:42:9\n");
+      snprintf(big + off, sizeof big - off, "error: aborting due to previous error\n");
+
+      char *r = tc_family_diagnostics(1, big);
+      assert(r);
+      assert(strstr(r, "E0308"));         /* the error kept */
+      assert(strstr(r, "src/lib.rs:42")); /* the diagnostic location kept */
+      assert(strstr(r, "lines elided"));  /* Compiling… progress elided */
+      assert(!strstr(r, "crate_30"));     /* a middle progress line dropped */
+      assert(strlen(r) < strlen(big));
+      free(r);
+
+      /* warnings on a clean (exit 0) build are still condensed (not gated on failure) */
+      char warns[4096];
+      off = 0;
+      for (int k = 0; k < 40; k++)
+         off += (size_t)snprintf(warns + off, sizeof warns - off, "   Compiling pkg_%02d\n", k);
+      snprintf(warns + off, sizeof warns - off,
+               "warning: unused variable `x`\n --> a.rs:1:5\nwarning: 1 warning emitted\n");
+      char *r2 = tc_family_diagnostics(0, warns);
+      assert(r2 && strstr(r2, "unused variable") && strstr(r2, "lines elided"));
+      free(r2);
+   }
+
+   /* ---- diagnostics routing through tool_condense_apply (S5) ---- */
+   {
+      config_t cfg;
+      memset(&cfg, 0, sizeof cfg);
+      cfg.reduce_command_filter = 1;
+      char big[8192];
+      size_t off = 0;
+      for (int k = 0; k < 80; k++)
+         off += (size_t)snprintf(big + off, sizeof big - off, "src/mod_%02d.ts building...\n", k);
+      snprintf(big + off, sizeof big - off,
+               "src/x.ts:10:3 - error TS2322: Type mismatch\nFound 1 error.\n");
+      char dir[] = "/tmp/tc_diag_XXXXXX";
+      assert(mkdtemp(dir));
+      tc_stats_t st;
+      char *r = tool_condense_apply(&cfg, "tsc --noEmit", 1, big, dir, &st);
+      assert(r);
+      assert(st.recognized && st.spilled && !strcmp(st.family, "diag"));
+      assert(strstr(r, "TS2322"));
+      char spath[512];
+      snprintf(spath, sizeof spath, "%s/%s.out", dir, st.spill_ref);
+      unlink(spath);
+      rmdir(dir);
+      free(r);
+   }
+
    printf("ok\n");
    return 0;
 }

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -634,11 +634,18 @@ static const char *const TC_FAIL_SIGS[] = {
 static const char *const TC_KEEP_SIGS[] = {"test result", "result:", "====",     "collected",
                                            "summary",     "warning", "warnings", NULL};
 
-char *tc_family_test_runner(int exit_code, const char *in)
+/* Generic "keep the signal, drop the noise" line filter shared by the families. Keeps the
+ * first `head` + last `tail` lines and every line matching `fail_sigs` or `keep_sigs`;
+ * drops the rest, collapsing runs to a "... N lines elided ..." marker. When
+ * `require_fail_nonzero` is set, a non-zero exit with NO `fail_sigs` line returns NULL
+ * (verbatim passthrough — never hide the cause behind the filter). Returns a NEW string
+ * or NULL (OOM / the safety passthrough). */
+static char *tc_signal_filter(int exit_code, const char *in, const char *const *fail_sigs,
+                              const char *const *keep_sigs, int require_fail_nonzero, size_t head,
+                              size_t tail)
 {
    if (!in)
       return NULL;
-   /* index lines */
    size_t nlines = 0;
    for (const char *p = in;;)
    {
@@ -667,32 +674,27 @@ char *tc_family_test_runner(int exit_code, const char *in)
       const char *np = next_line(p, &n, &has_nl);
       lp[idx] = p;
       ll[idx] = n;
-      if (line_has_any(p, n, TC_FAIL_SIGS))
+      if (line_has_any(p, n, fail_sigs))
          any_fail = 1;
       idx++;
       if (!has_nl)
          break;
       p = np;
    }
-   /* Safety: a non-zero exit with no recognizable failure line -> passthrough (never
-    * risk hiding the cause behind a passing-transcript filter). */
-   if (exit_code != 0 && !any_fail)
+   if (require_fail_nonzero && exit_code != 0 && !any_fail)
    {
       free(lp);
       free(ll);
       return NULL;
    }
 
-   /* Always keep the first HEAD lines (banner/session start) and the last TAIL lines
-    * (the end-of-run summary lives here); drop passing transcripts in between. */
-   const size_t HEAD = 2, TAIL = 6;
    sb_t s = {0};
    int first = 1;
    size_t elided = 0;
    for (size_t i = 0; i < nlines; i++)
    {
-      int keep = (i < HEAD) || (i + TAIL >= nlines) || line_has_any(lp[i], ll[i], TC_FAIL_SIGS) ||
-                 line_has_any(lp[i], ll[i], TC_KEEP_SIGS);
+      int keep = (i < head) || (i + tail >= nlines) || line_has_any(lp[i], ll[i], fail_sigs) ||
+                 line_has_any(lp[i], ll[i], keep_sigs);
       if (keep)
       {
          if (elided)
@@ -726,6 +728,26 @@ char *tc_family_test_runner(int exit_code, const char *in)
    free(lp);
    free(ll);
    return sb_finish(&s);
+}
+
+char *tc_family_test_runner(int exit_code, const char *in)
+{
+   return tc_signal_filter(exit_code, in, TC_FAIL_SIGS, TC_KEEP_SIGS, 1, 2, 6);
+}
+
+/* Compiler / linter diagnostics (Slice 5): keep every error/warning/note + file:line
+ * diagnostic, drop the progress chatter ("Compiling …", "Downloading …", "Checking …").
+ * Warnings on a zero exit are still condensed (require_fail_nonzero = 0); a non-zero exit's
+ * error lines are always kept by the fail-signals, so a build failure is never hidden. */
+static const char *const TC_DIAG_FAIL_SIGS[] = {"error",    "undefined", "cannot",  "expected",
+                                                "fatal",    "panicked",  "no such", "not found",
+                                                "conflict", NULL};
+static const char *const TC_DIAG_KEEP_SIGS[] = {"warning", "warn:",   "note:",     "help:", "-->",
+                                                "error[",  "::error", "::warning", "====",  NULL};
+
+char *tc_family_diagnostics(int exit_code, const char *in)
+{
+   return tc_signal_filter(exit_code, in, TC_DIAG_FAIL_SIGS, TC_DIAG_KEEP_SIGS, 0, 2, 4);
 }
 
 /* ---- spill store + top-level apply (Slice 3) ---- */
@@ -794,6 +816,28 @@ static int tc_is_test_invocation(const tc_reco_result_t *r)
    return 0;
 }
 
+/* Does the recognized command denote a COMPILER/LINTER invocation (Slice 5)? */
+static int tc_is_diagnostics_invocation(const tc_reco_result_t *r)
+{
+   static const char *const diag[] = {"tsc", "eslint", "ruff",    "mypy",  "flake8", "gcc", "g++",
+                                      "cc",  "clang",  "clang++", "rustc", "cmake",  NULL};
+   for (int i = 0; diag[i]; i++)
+      if (strcmp(r->cmd, diag[i]) == 0)
+         return 1;
+   if (strcmp(r->cmd, "cargo") == 0 &&
+       (strcmp(r->sub, "build") == 0 || strcmp(r->sub, "check") == 0 ||
+        strcmp(r->sub, "clippy") == 0))
+      return 1;
+   if (strcmp(r->cmd, "go") == 0 && (strcmp(r->sub, "build") == 0 || strcmp(r->sub, "vet") == 0))
+      return 1;
+   if (strcmp(r->cmd, "dotnet") == 0 && strcmp(r->sub, "build") == 0)
+      return 1;
+   if ((strcmp(r->cmd, "npm") == 0 || strcmp(r->cmd, "yarn") == 0 || strcmp(r->cmd, "pnpm") == 0) &&
+       (strcmp(r->sub, "build") == 0 || strcmp(r->sub, "lint") == 0))
+      return 1;
+   return 0;
+}
+
 char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_code, const char *raw,
                           const char *spill_dir, tc_stats_t *stats)
 {
@@ -821,6 +865,11 @@ char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_cod
    {
       cond = tc_family_test_runner(exit_code, raw);
       family = "test";
+   }
+   else if (tc_is_diagnostics_invocation(&reco))
+   {
+      cond = tc_family_diagnostics(exit_code, raw);
+      family = "diag";
    }
    if (!cond)
       return NULL; /* no family match or the filter declined -> passthrough */

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -739,15 +739,34 @@ char *tc_family_test_runner(int exit_code, const char *in)
  * diagnostic, drop the progress chatter ("Compiling …", "Downloading …", "Checking …").
  * Warnings on a zero exit are still condensed (require_fail_nonzero = 0); a non-zero exit's
  * error lines are always kept by the fail-signals, so a build failure is never hidden. */
-static const char *const TC_DIAG_FAIL_SIGS[] = {"error",    "undefined", "cannot",  "expected",
-                                                "fatal",    "panicked",  "no such", "not found",
-                                                "conflict", NULL};
+static const char *const TC_DIAG_FAIL_SIGS[] = {"error",
+                                                "undefined",
+                                                "cannot",
+                                                "expected",
+                                                "fatal",
+                                                "panicked",
+                                                "no such",
+                                                "not found",
+                                                "not a type",
+                                                "not a package",
+                                                "imported and",
+                                                "declared but not used",
+                                                "multiple definition",
+                                                "relocation",
+                                                "unresolved",
+                                                "syntaxerror",
+                                                "typeerror",
+                                                NULL};
 static const char *const TC_DIAG_KEEP_SIGS[] = {"warning", "warn:",   "note:",     "help:", "-->",
                                                 "error[",  "::error", "::warning", "====",  NULL};
 
+/* require_fail_nonzero = 1: a non-zero exit whose error format is NOT in the fail-signal
+ * set above falls back to verbatim passthrough, so an unrecognized build failure is never
+ * hidden (the same safeguard the test-runner family uses). A clean (exit 0) build with
+ * warnings is still condensed. */
 char *tc_family_diagnostics(int exit_code, const char *in)
 {
-   return tc_signal_filter(exit_code, in, TC_DIAG_FAIL_SIGS, TC_DIAG_KEEP_SIGS, 0, 2, 4);
+   return tc_signal_filter(exit_code, in, TC_DIAG_FAIL_SIGS, TC_DIAG_KEEP_SIGS, 1, 2, 4);
 }
 
 /* ---- spill store + top-level apply (Slice 3) ---- */


### PR DESCRIPTION
Fifth slice (proposal #1031), stacked on S4 (#1039). Extends coverage beyond test runners; default-off, LIVE at the delegate seam.

## What lands
- **Refactor**: the test-runner filter body → a generic `tc_signal_filter` (fail-signals + keep-signals + head/tail + the `require_fail_nonzero` safety rule). `tc_family_test_runner` is now a thin wrapper (behavior unchanged — S3 tests still pass).
- **`tc_family_diagnostics`** (compilers/linters): keep every error/warning/note + diagnostic, drop `Compiling…/Downloading…/Checking…` progress. **Safety**: `require_fail_nonzero=1` — a non-zero build whose error format is *not* recognized falls back to verbatim passthrough (never hides an unrecognized failure); a clean build's warnings are still condensed. Fail-signals cover Rust/C/C++/Go/ld/TS/py error shapes.
- `tool_condense_apply` routes `tsc/eslint/ruff/mypy/flake8/gcc/clang/rustc/cmake` + `cargo|go|dotnet|npm|yarn|pnpm build/check/clippy/vet/lint` to the diagnostics family (tag `diag`).

## Review
Roundtable-reviewed; the verified blocking item (unrecognized non-zero failure could be elided) fixed by flipping to `require_fail_nonzero=1` + broader signals + a safety-passthrough test. Full `unit-tests` + line-check green.

Remaining: S6 (validation + operator default-on gate), S7 (primary-agent hook + first-class retrieval tool). VCS/file-ops/pkg-mgr families are a follow-up.