### PR TITLE
feat(economizer): tool-output condensation S6 — realized-savings observability

### DIFF
--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -87,9 +87,12 @@ typedef struct
    long long family_diag;   /* applied condensations tagged "diag" */
 } tool_condense_totals_t;
 
-/* Snapshot the counters (thread-safe). */
+/* Snapshot the counters. Each field is read atomically, but the six are NOT a single
+ * transactional point-in-time view (a concurrent condensation may land between reads) —
+ * fine for monotonic metrics; don't assert cross-counter invariants on a live snapshot. */
 void tool_condense_stats_snapshot(tool_condense_totals_t *out);
-/* Reset the counters (tests). */
+/* Reset the counters. TEST-ONLY: it races lost-updates with live traffic, so call it only
+ * when no condensation is in flight (the unit test does). */
 void tool_condense_stats_reset(void);
 
 /* Strip content-free noise, line-wise:

--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -73,6 +73,25 @@ typedef struct
 char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_code, const char *raw,
                           const char *spill_dir, tc_stats_t *stats);
 
+/* ---- realized-savings observability (Slice 6) ---- */
+
+/* Cumulative process-wide counters, updated at the seam so an operator can measure the
+ * lever's REALIZED savings on real traffic before any default-on decision. */
+typedef struct
+{
+   long long recognized;    /* recognized commands seen by tool_condense_apply */
+   long long applied;       /* condensations that shrank + spilled (a family fired) */
+   long long applied_raw;   /* total input bytes over APPLIED condensations */
+   long long applied_final; /* total output bytes over APPLIED condensations */
+   long long family_test;   /* applied condensations tagged "test" */
+   long long family_diag;   /* applied condensations tagged "diag" */
+} tool_condense_totals_t;
+
+/* Snapshot the counters (thread-safe). */
+void tool_condense_stats_snapshot(tool_condense_totals_t *out);
+/* Reset the counters (tests). */
+void tool_condense_stats_reset(void);
+
 /* Strip content-free noise, line-wise:
  *  - remove ANSI CSI escape sequences (ESC '[' … final-byte);
  *  - resolve carriage-return progress redraws (keep only the text after the last '\r'

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -316,6 +316,42 @@ int main(void)
       free(r);
    }
 
+   /* ---- realized-savings observability (S6) ---- */
+   {
+      tool_condense_stats_reset();
+      config_t cfg;
+      memset(&cfg, 0, sizeof cfg);
+      cfg.reduce_command_filter = 1;
+      char big[8192];
+      size_t off = 0;
+      off += (size_t)snprintf(big + off, sizeof big - off, "==== session ====\n");
+      for (int k = 0; k < 120; k++)
+         off += (size_t)snprintf(big + off, sizeof big - off, "t::case_%03d PASSED\n", k);
+      snprintf(big + off, sizeof big - off, "==== 120 passed ====\n");
+      char dir[] = "/tmp/tc_s6_XXXXXX";
+      assert(mkdtemp(dir));
+      tc_stats_t st;
+      char *r = tool_condense_apply(&cfg, "pytest -q", 0, big, dir, &st);
+      assert(r);
+      /* an UNRECOGNIZED command must not touch the counters */
+      assert(tool_condense_apply(&cfg, "frobnicate", 0, big, dir, NULL) == NULL);
+
+      tool_condense_totals_t t;
+      tool_condense_stats_snapshot(&t);
+      assert(t.recognized == 1); /* only pytest counted; frobnicate did not */
+      assert(t.applied == 1);
+      assert(t.family_test == 1 && t.family_diag == 0);
+      assert(t.applied_raw > t.applied_final); /* realized savings */
+      assert(t.applied_raw == st.raw_bytes);
+
+      char spath[512];
+      snprintf(spath, sizeof spath, "%s/%s.out", dir, st.spill_ref);
+      unlink(spath);
+      rmdir(dir);
+      free(r);
+      tool_condense_stats_reset();
+   }
+
    printf("ok\n");
    return 0;
 }

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -4,11 +4,38 @@
 #include "tool_condense.h"
 
 #include <fcntl.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h> /* snprintf */
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+/* ---- realized-savings observability (Slice 6) ---- */
+static atomic_llong g_tc_recognized, g_tc_applied, g_tc_applied_raw, g_tc_applied_final,
+    g_tc_family_test, g_tc_family_diag;
+
+void tool_condense_stats_snapshot(tool_condense_totals_t *out)
+{
+   if (!out)
+      return;
+   out->recognized = atomic_load_explicit(&g_tc_recognized, memory_order_relaxed);
+   out->applied = atomic_load_explicit(&g_tc_applied, memory_order_relaxed);
+   out->applied_raw = atomic_load_explicit(&g_tc_applied_raw, memory_order_relaxed);
+   out->applied_final = atomic_load_explicit(&g_tc_applied_final, memory_order_relaxed);
+   out->family_test = atomic_load_explicit(&g_tc_family_test, memory_order_relaxed);
+   out->family_diag = atomic_load_explicit(&g_tc_family_diag, memory_order_relaxed);
+}
+
+void tool_condense_stats_reset(void)
+{
+   atomic_store_explicit(&g_tc_recognized, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_tc_applied, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_tc_applied_raw, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_tc_applied_final, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_tc_family_test, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_tc_family_diag, 0, memory_order_relaxed);
+}
 
 int tool_condense_enabled(const config_t *cfg)
 {
@@ -877,6 +904,7 @@ char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_cod
       stats->recognized = (reco.outcome == TC_RECOGNIZED);
    if (reco.outcome != TC_RECOGNIZED)
       return NULL; /* OPAQUE / UNRECOGNIZED -> passthrough (S3 acts only on a family) */
+   atomic_fetch_add_explicit(&g_tc_recognized, 1, memory_order_relaxed);
 
    char *cond = NULL;
    const char *family = "";
@@ -934,12 +962,24 @@ char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_cod
    sb_adds(&out, ptr);
    free(cond);
    char *final = sb_finish(&out);
-   if (stats && final)
+   if (final)
    {
-      stats->final_bytes = (long)strlen(final);
-      stats->spilled = 1;
-      snprintf(stats->family, sizeof stats->family, "%s", family);
-      snprintf(stats->spill_ref, sizeof stats->spill_ref, "%s", ref);
+      long finallen = (long)strlen(final);
+      if (stats)
+      {
+         stats->final_bytes = finallen;
+         stats->spilled = 1;
+         snprintf(stats->family, sizeof stats->family, "%s", family);
+         snprintf(stats->spill_ref, sizeof stats->spill_ref, "%s", ref);
+      }
+      /* realized-savings accounting (Slice 6) */
+      atomic_fetch_add_explicit(&g_tc_applied, 1, memory_order_relaxed);
+      atomic_fetch_add_explicit(&g_tc_applied_raw, rawlen, memory_order_relaxed);
+      atomic_fetch_add_explicit(&g_tc_applied_final, finallen, memory_order_relaxed);
+      if (strcmp(family, "test") == 0)
+         atomic_fetch_add_explicit(&g_tc_family_test, 1, memory_order_relaxed);
+      else if (strcmp(family, "diag") == 0)
+         atomic_fetch_add_explicit(&g_tc_family_diag, 1, memory_order_relaxed);
    }
    return final;
 }


### PR DESCRIPTION
Sixth slice (proposal #1031), stacked on S5 (#1041). The **measure-before-default-on** enabler; default-off, no change to the condensation logic.

## What lands
- Process-wide **C11 atomic counters** updated at the seam by `tool_condense_apply`: `recognized`, `applied`, `applied_raw`, `applied_final`, and per-family (`family_test`, `family_diag`). `tool_condense_stats_snapshot()` reads them; `tool_condense_stats_reset()` is test-only.
- Lets an operator quantify the lever's **realized savings on real traffic** before any default-on decision (which remains an operator gate).

## Review
Roundtable-reviewed, **no blocking**. Added docs: a snapshot is per-counter atomic but not transactional; `reset` is test-only. (The "family use-after-free" finding is false — `family` is a string-literal pointer, not derived from the freed buffer.) Full `unit-tests` + line-check green.

Remaining: **S7** (primary-agent hook + first-class retrieval tool). The default-**on** flip is an operator gate; VCS/file-ops/pkg-mgr families are a follow-up.