### PR TITLE
docs: Web GUI Settings page + tool-output condensation + autonomy knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Focused references:
 | [Personas](docs/personas.md) | Built in and custom agent identities, delegate policy, and how personas staff reviews |
 | [Workflows](docs/WORKFLOWS.md) | The composable dev lifecycle workflow engine, block catalog, and authoring |
 | [Workflow Actions](docs/WORKFLOW_ACTIONS.md) | The web page to author a proposal, run it autonomously, and watch its status/history |
+| [Settings](docs/SETTINGS.md) | The web page for the server's typed runtime config — economizer levers, autonomous-dev knobs, tool-output condensation, and how each maps to `aimee.yaml` |
 | [Workspace Management](docs/WORKSPACES.md) | Multi repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
 | [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token at rest, in transit to git, and in the in browser editor, and where exposure is and is not closed |

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -173,6 +173,20 @@ Autonomous development is default-on; the guardrails are structural, not a toggl
   unit; transient errors are retried within the cap; degraded panels, budget
   breaches, and forge failures park.
 
+### Tuning (web Settings → `autonomy.*`)
+
+The pipeline knobs are typed config fields, editable in the web **⚙️ Settings** page
+(under `autonomy.`) or `aimee.yaml`; a change applies on the next server start (an
+exported `AIMEE_AUTONOMY_*` env var still overrides). See [SETTINGS.md](SETTINGS.md).
+
+| Knob | Default | Effect |
+| --- | --- | --- |
+| `autonomy.skeptics` | 0 (off) | N adversarial skeptics on the implement gate. |
+| `autonomy.fanout` | off | Engine-level fan-out manager loop vs a single implement dispatch. |
+| `autonomy.unit_retry` | 2 | Per-unit retry-different-delegate cap under fan-out. |
+| `autonomy.unit_max` | 16 | Max fan-out units (a larger decomposition parks). |
+| `autonomy.ci_retry_max` | 2 | Per-work-item red-CI retry cap before parking. |
+
 ## Observability
 
 - **Webchat Workflow Actions page**, live progress per work item: current stage, gate

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,103 @@
+# Settings (web page)
+
+The **Settings** page (aimee web UI, left nav → ⚙️ Settings, route `/settings`) is a typed
+editor over the server's runtime configuration. It exposes **every allowlisted config
+field** — the same `config.show` / `config.set` surface the `aimee config` CLI uses — as a
+grouped, filterable form with per-field **Save** and **Reset**.
+
+It is a thin surface over machinery that already exists: each control maps 1:1 to a
+`config_t` field in [`src/config_fields.c`](../src/config_fields.c). Adding a field to that
+table makes it appear here automatically; there is no per-field frontend code. Changes
+persist to `aimee.yaml` and take effect on the next turn (the server reloads config per
+request), unless noted otherwise below.
+
+- **Nav / route:** `/settings` (`frontend/src/App.tsx`), page
+  `frontend/src/pages/Settings.tsx`.
+- **Data path:** `GET /api/config` → `config.show` (all fields + values); `POST
+  /api/config/set {key,value}` → `config.set` (the server validates the key against
+  `config_fields` and persists `aimee.yaml`). The webchat proxy (`webchat/config_api.go`)
+  is the only network hop; there are no server changes per field.
+- **Control inference:** the control type is inferred from the value's JSON type — a
+  **boolean → toggle**, a **number → number field**, a **string → text field**. Grouping is
+  by the dotted key prefix (e.g. everything under `reduce.` forms one section).
+- **Quick panel:** a smaller gear dropdown in the top bar (`SettingsPanel`) surfaces the
+  five most-used toggles (autonomous mode, cross-verify, eco mode, reasoning cap, max
+  iterations). The full page is the comprehensive home for everything else.
+
+> **Allowlist, not raw config.** The page can only read/write keys in `config_fields`.
+> Sensitive values — endpoints, `*_key_cmd`, `db2_url`, and **secrets** — are deliberately
+> *not* in that allowlist and never appear here. In particular the CI-webhook secret
+> (`AIMEE_CI_WEBHOOK_SECRET`) is an environment secret, not a Settings field.
+
+---
+
+## Option groups added recently
+
+### Context economizer — `reduce.*`
+
+The unified context economizer's levers are now toggles on the Settings page. All are
+booleans except the two numeric tuning knobs. Defaults in parentheses.
+
+| Setting | Default | What it does |
+| --- | --- | --- |
+| **`reduce.command_filter`** | **off** | **Tool-output condensation** — deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
+| `reduce.gateway_mutate` | off | Apply the economizer to the live inbound `/v1` request so the **primary** agent's tokens are reduced too. See [Economizer gateway mutation](features/economizer-gateway-mutation.md). |
+| `reduce.compress` | on | Size-based compression of oversized tool-result bodies. |
+| `reduce.history_fold` | on | Fold old turn history into a rolling skeleton. |
+| `reduce.delegate_seam` | on | Run the economizer at the delegate turn loop. |
+| `reduce.measure` | on | Collect the baseline/opportunity token ledger. |
+| `reduce.freeze_guard` | on | Pin the fold boundary only when the cache-read savings beat the cache-write cost. |
+| `reduce.gateway_session_disable_ttl_ms` | 3600000 | Gateway-mutation circuit-breaker window (ms). Must be > 0. |
+| `reduce.freeze_guard_horizon` | 1 | Expected reuse turns for the freeze break-even estimate. |
+
+`reduce.gateway_seam` is intentionally **not** on the page — it is synthesized from
+`gateway_mutate` and its persistence is explicit-gated; toggle `gateway_mutate` instead.
+
+### Autonomous-development pipeline — `autonomy.*`
+
+The autonomous-development knobs were historically environment-only (`AIMEE_AUTONOMY_*`).
+They are now typed config fields on the Settings page. A `config` value is **bridged to the
+matching env var at server startup**, so an explicitly-exported `AIMEE_AUTONOMY_*`
+environment variable still **overrides** the config value, and **a Settings change to these
+knobs applies on the next server start** (they are deployment-level pipeline tuning, not
+per-turn toggles). Values are clamped to sane bounds.
+
+| Setting | Default | Bounds | What it does |
+| --- | --- | --- | --- |
+| `autonomy.skeptics` | 0 (off) | 0–32 | N adversarial skeptics on the implement gate (0 disables the tier). |
+| `autonomy.fanout` | off | — | Engine-level fan-out manager loop (vs a single implement dispatch). |
+| `autonomy.unit_retry` | 2 | 0–10 | Per-unit retry-different-delegate cap under fan-out. |
+| `autonomy.unit_max` | 16 | 1–256 | Maximum fan-out units (a larger decomposition parks for a human). |
+| `autonomy.ci_retry_max` | 2 | 0–20 | Per-work-item red-CI retry cap before parking. |
+
+---
+
+## Turning on tool-output condensation
+
+The most common new toggle. In the web UI:
+
+1. Open **⚙️ Settings** (left nav) and filter for `command_filter` (or scroll to the
+   **`reduce`** group).
+2. Flip **`reduce.command_filter`** **on** and **Save**.
+
+Or from the CLI / config file:
+
+```yaml
+reduce:
+  command_filter: true
+```
+
+When on, a delegate's recognized command output is condensed before it enters context, with
+the full output spilled under `<aimee_home>/tool-spills/` and a recovery pointer in the
+condensed result. When off, output is byte-identical to today (it falls through to the
+size-based `reduce.compress`). See
+[features/tool-output-condensation.md](features/tool-output-condensation.md) for the full
+behavior, safety contract, and observability.
+
+## When a change takes effect
+
+- **Immediately (next turn):** the economizer `reduce.*` levers and most other fields — the
+  server reloads config per request.
+- **On next server start:** the `autonomy.*` knobs — they are bridged to `AIMEE_AUTONOMY_*`
+  environment variables at startup so the workflow engine (which reads them across a module
+  boundary) sees them; an explicitly-set env var always wins.

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -11,6 +11,19 @@ Thin-client + credential hardening, the client owns the working tree; agent
 credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).
 
+- **Web Settings page for the full typed config**: the web UI **⚙️ Settings** page
+  (`/settings`) edits every allowlisted runtime config field — grouped, filterable, with
+  per-field save/reset — over the same `config.show`/`config.set` surface as the CLI. Newly
+  exposed groups: the context-economizer levers (`reduce.*`) and the autonomous-development
+  pipeline knobs (`autonomy.*`, previously environment-only; a change applies on the next
+  server start, and an exported `AIMEE_AUTONOMY_*` still overrides). Secrets and endpoints
+  are deliberately not in the allowlist. See [SETTINGS.md](SETTINGS.md).
+- **Tool-output condensation** (default-off, `reduce.command_filter`): a deterministic,
+  command-aware context-economizer lever that condenses recognized command output at the
+  delegate tool seam — test-runner failures and compiler diagnostics kept, passing
+  transcripts and build progress dropped — with the full output spilled for lossless
+  recovery. Fail-open and byte-identical when off. Toggle it in the web Settings page. See
+  [features/tool-output-condensation.md](features/tool-output-condensation.md).
 - **Self-hosted GPU inference tiers**: the `aimee-kb` inference image ships three tiers you
   swap with one plugin image. `aimee-kb-cpu` runs retrieval on any host, `aimee-kb-gpu-small`
   bakes a Gemma 4 12B synth, and `aimee-kb-gpu-mid` bakes a Gemma 4 26B-A4B synth that fits a

--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -1,0 +1,81 @@
+# Tool-output condensation (deterministic command-aware)
+
+Tool output — test-runner logs, compiler/linter dumps, build progress — is the largest and
+most signal-sparse contributor to a coding agent's context. Most of that volume is not
+signal: progress bars, passing-test transcripts, boilerplate, repeated lines.
+
+**Tool-output condensation** is a context-economizer lever that condenses **recognized**
+command output at the tool-execution seam, using **deterministic, command-aware rules** (no
+LLM, so it is ~free). It knows that a test runner's value is its *failures*, a compiler's is
+its *diagnostics*, and drops the rest — **losslessly**: the full raw output is spilled to
+disk and a recovery pointer is left in the condensed result, so nothing is destroyed.
+
+It is **default-OFF** and complements — does not replace — the size-based
+`reduce.compress`, which stays the fallback for unrecognized output.
+
+## Configuration
+
+```yaml
+reduce:
+  command_filter: false   # DEFAULT OFF. The whole lever.
+```
+
+Turn it on from the web UI (**⚙️ Settings → `reduce.command_filter`**, see
+[SETTINGS.md](../SETTINGS.md)) or the config above. When off, tool output is **byte-identical
+to today** — the seam falls through to the size-based `reduce.compress`.
+
+## What it does
+
+Applied at the **delegate bash-tool seam** ([`tool_bash`](../../src/posix/agent_tools.c)),
+before the size-based compression:
+
+1. **Recognize** the command. Compound/piped/substituted lines and unknown commands pass
+   through unchanged (fail-open). Common wrappers are unwrapped (`env`, `sudo`, `time`,
+   `npx`, `uv run`, `poetry run`, `pnpm exec`, …). `xargs`, `make`, shell scripts, and **any
+   path-prefixed invocation** (`./git`, `/tmp/cargo`) are treated as opaque — a family rule
+   only ever applies to a bare command name.
+2. **Condense** by family:
+   - **Test runners** (`pytest`/`jest`/`vitest`/`ctest`/`cargo|go|npm|… test`): keep the
+     summary + **every failure verbatim**, drop passing-case transcripts.
+   - **Compilers / linters** (`tsc`/`eslint`/`ruff`/`mypy`/`gcc`/`clang`/`rustc`/`cmake`,
+     and `cargo|go|dotnet|npm|… build/check/clippy/vet/lint`): keep every error/warning/note
+     and diagnostic, drop the `Compiling…/Downloading…/Checking…` progress.
+3. **Spill + point.** The full raw output is written to `<aimee_home>/tool-spills/<ref>.out`
+   (mode `0600`) and the condensed result ends with a pointer to that path, which the
+   delegate reads back with its own bash tool if it needs an elided passing case.
+
+## Safety contract
+
+- `reduce.command_filter: false` ⇒ tool output is **byte-identical** to today.
+- **Lossless-on-demand.** A condensed body is only ever produced when the full raw output
+  was **durably spilled** first; a failed spill, no spill dir, or a would-be-truncated
+  recovery pointer all fall through to passthrough. Nothing is dropped without a backstop.
+- **Never hide a failure.** A test runner or build with a **non-zero exit and no recognized
+  failure line** passes through verbatim rather than risk eliding the cause.
+- **Fail-open everywhere.** An unrecognized command, an over-cap body (> 1 MiB), or any
+  filter error degrades to the size-based `reduce.compress` — never a crash or a dropped
+  result.
+- **No masquerade.** A path-prefixed command whose basename matches a known tool (`./git`)
+  never inherits that tool's family filter.
+- **Not a redaction layer.** Condensation does not *widen* exposure beyond what the raw
+  tool result already showed the model, but it does not scrub secrets from the output or the
+  spill. Spill files are per-user (`0700` directory) and excluded from log/trace exports by
+  default.
+
+## Observability
+
+Process-wide counters accumulate realized savings on live traffic
+([`tool_condense_stats_snapshot`](../../src/tool_condense.c)): `recognized`, `applied`,
+`applied_raw` vs `applied_final` bytes, and per-family (`test`, `diag`) counts. Each
+condensation also logs its `raw→final` delta under the `tool_condense` module.
+
+## Scope & rollout
+
+Shipped as the **delegate surface** (default-off). Enable it on a validation host, watch the
+savings counters, and roll back by flipping `reduce.command_filter` to `false`.
+
+**Carried follow-ups** (not yet shipped): the **primary-agent** surface (a client-side hook
++ a first-class `tool_output_get` retrieval tool); additional command families (VCS `git`,
+file/dir ops, package managers); and the **operator default-ON** decision — a named gate
+(no-lost-signal audit + material realized savings + fail-safe, measured via the counters
+above), never a silent flip.


### PR DESCRIPTION
Documents the recent additions to the web UI, focused on the **Settings page**.

## New docs
- **`docs/SETTINGS.md`** — the web **⚙️ Settings** page (`/settings`): how it auto-renders every `config_fields[]` entry as a typed control (**boolean → toggle**), the `config.show`/`config.set` data path via the webchat proxy, the allowlist (secrets/endpoints excluded), and the newly-exposed option groups:
  - **Context economizer** (`reduce.*`) — including **`reduce.command_filter`** (tool-output condensation), with a step-by-step to turn it on.
  - **Autonomous-development** (`autonomy.*`) — previously env-only; a change applies on next server start, an exported `AIMEE_AUTONOMY_*` still overrides.
- **`docs/features/tool-output-condensation.md`** — the `reduce.command_filter` lever: per-family behavior, the lossless-spill / never-hide-a-failure / fail-open safety contract, observability counters, and carried follow-ups.

## Updated
- **README** docs index — added the Settings page row.
- **`WHATS_NEW.md`** (Unreleased) — the Settings page expansion + tool-output condensation.
- **`AUTONOMOUS_DEVELOPMENT.md`** — a Tuning section pointing at the `autonomy.*` Settings knobs.

Pure docs (no generated files / proposals touched); all internal links verified to resolve. Defaults and config keys cross-checked against `config.c` / `config_fields.c`.