### PR TITLE
feat(memory): harness-memory migration inventory + design (.md retirement Slice 1, read-only)

### DIFF
--- a/docs/proposals/pending/memory-db1-db2-architecture.md
+++ b/docs/proposals/pending/memory-db1-db2-architecture.md
@@ -252,3 +252,38 @@ Folded in:
 - **db1 schema decision pulled into Phase 1:** §4 explicit-capture commands can't ship on an undecided
   schema, so OQ1 (repurpose `harness_memory` vs new table) is **resolved as the first step of
   Phase 1**, before the commands.
+
+## Migration design (R3 — `.md` retirement, roundtabled)
+
+The `.md`-retirement migration (§2) was roundtabled (7 participants) before any code. Verdict: the
+migration **cannot be safely automated end-to-end** — it is operator-gated at every write/delete.
+
+**Hard conclusions (data-loss traps):**
+- **Scope is not mechanically derivable.** `harness_memory.type ∈ {fact,index,note,scratch}` carries
+  no user/org signal; the only signal is the `.md` frontmatter `metadata.type`
+  (project/feedback/reference/user), and it is advisory. Auto-defaulting is silent + irreversible:
+  default→db1 locks org-generalizable notes away; default→db2 leaks private notes org-wide.
+  **Classification MUST be operator-reviewed per memory.**
+- **Never bulk-load free-form `.md` into structured `user_memories`.** The `identity:`/`pref:` recall
+  selectors won't match arbitrary bodies → *stored-but-not-surfaced* = data-loss-by-inaccessibility.
+  Preserved documents need a **separate, non-recallable archival kind/table**, distinct from the
+  structured identity/preference store.
+- **The server db1 `harness_memory` table is canonical; the client `.md` files are a re-hydrated
+  (lossy) derivative.** Reconcile against the table, not the files; never hash hydrate's re-render.
+- **Define the replacement write path BEFORE removing interception.** Deleting
+  `memory_redirect`/PostToolUse before agents have a new memory target drops all NEW writes silently.
+- **Verification is content-hash + key-set reconciliation, not count-only**; keep the source
+  read-only until an explicit per-phase reversibility gate confirms the copy.
+
+**Sequenced slices (each gated, reversible):**
+1. **Slice 1 (shipped, read-only):** `scripts/harness-memory-inventory.py` — inventories the `.md`
+   store, surfaces per-memory scope-signals for classification, and (best-effort) reconciles against
+   the canonical server table. Writes nothing, deletes nothing.
+2. **Operator classification** — the operator labels each memory user(db1)/org(db2)/archive/drop
+   (no automated scope guess).
+3. **Migration writes** — copy per the classification into db1 (user), db2 (org), or a non-recallable
+   archival store; verify by content-hash + key-set; **source retained**.
+4. **Replacement write path** — new agent memory routes to db1/db2 (extends S2's capture) so
+   interception can be removed without dropping writes.
+5. **Subsystem removal** — delete `harness_memory_*`/`memory_redirect`/routes/tests/docs, gated on
+   (2)+(3)+(4) confirmed, after a read-only compatibility window.

--- a/scripts/harness-memory-inventory.py
+++ b/scripts/harness-memory-inventory.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Read-only inventory of the .md harness-memory store, for the db1/db2 memory
+migration (Proposal 2, memory-arch retirement — Slice 1).
+
+This is the ONLY zero-data-loss first increment of the .md retirement: it WRITES
+NOTHING and DELETES NOTHING. It produces the manifest the operator needs to
+classify each memory as user (-> db1) vs org (-> db2) before any migration runs,
+because — per the design roundtable — scope is NOT mechanically derivable from
+the legacy schema (harness_memory.type is {fact,index,note,scratch}, and
+auto-defaulting either way is a silent, irreversible leak-or-lockaway).
+
+It inventories the LOCAL .md files (their frontmatter `metadata.type` is the
+scope signal) and, best-effort, reconciles against the canonical server
+harness_memory table via the existing read-only /v1/harness_memory/list route,
+flagging drift (server-only / local-only / present-in-both). Reconciliation is
+by name; content divergence is left for operator spot-check (the exact
+content_hash is a length-prefixed server-side tuple not replicated here).
+
+Usage:
+  harness-memory-inventory.py [--memory-dir DIR] [--project KEY] [--json]
+
+Nothing here mutates state; safe to run repeatedly.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+
+
+def parse_frontmatter(text):
+    """Return (metadata_dict, first_content_line). Tolerant of the simple YAML
+    frontmatter aimee memories use (key: value, one nested `metadata:` block)."""
+    meta = {}
+    first_line = ""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        # No frontmatter: first non-empty line is the content lead.
+        for ln in lines:
+            if ln.strip():
+                first_line = ln.strip()
+                break
+        return meta, first_line
+    i = 1
+    in_metadata = False
+    while i < len(lines) and lines[i].strip() != "---":
+        raw = lines[i]
+        stripped = raw.strip()
+        if stripped == "metadata:":
+            in_metadata = True
+        elif in_metadata and raw[:1] in (" ", "\t") and ":" in stripped:
+            k, _, v = stripped.partition(":")
+            meta[k.strip()] = v.strip().strip('"')
+        elif ":" in stripped and not raw[:1].isspace():
+            in_metadata = False
+            k, _, v = stripped.partition(":")
+            meta.setdefault(k.strip(), v.strip().strip('"'))
+        i += 1
+    # First content line after the closing '---'
+    for ln in lines[i + 1:]:
+        if ln.strip():
+            first_line = ln.strip()
+            break
+    return meta, first_line
+
+
+def scope_signal(meta):
+    """Map a memory's frontmatter type to a scope SIGNAL (not a decision).
+    user/feedback -> likely user (db1); project/reference -> ambiguous (needs
+    operator review); anything else -> unknown."""
+    t = (meta.get("type") or "").lower()
+    if t in ("user", "feedback"):
+        return f"user? ({t})"
+    if t in ("project", "reference"):
+        return f"review ({t})"
+    return f"unknown ({t or 'no-type'})"
+
+
+def inventory_local(memory_dir):
+    rows = []
+    for root, _dirs, files in os.walk(memory_dir):
+        for f in sorted(files):
+            if not f.endswith(".md"):
+                continue
+            path = os.path.join(root, f)
+            rel = os.path.relpath(path, memory_dir)
+            name = rel[:-3]  # strip .md, matches harness_memory `name`
+            if name == "MEMORY":
+                continue  # the index, not a memory
+            try:
+                text = open(path, encoding="utf-8", errors="replace").read()
+            except OSError as e:
+                rows.append({"name": name, "error": str(e)})
+                continue
+            meta, first = parse_frontmatter(text)
+            rows.append({
+                "name": name,
+                "bytes": len(text.encode("utf-8")),
+                "scope_signal": scope_signal(meta),
+                "frontmatter_type": meta.get("type", ""),
+                "first_line": first[:100],
+            })
+    return rows
+
+
+def fetch_server_rows(project):
+    """Best-effort read of the canonical server harness_memory table via the
+    existing read-only /v1 route (through the aimee CLI). Returns a list of
+    {name, type, deleted_at, ...} or None if unavailable (never fatal)."""
+    args = ["./aimee", "memory", "harness-list", "--json"]
+    if project:
+        args += ["--project", project]
+    try:
+        out = subprocess.run(args, capture_output=True, text=True, timeout=30)
+        if out.returncode != 0:
+            return None
+        data = json.loads(out.stdout or "{}")
+        return data.get("rows") or data.get("memories") or None
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Read-only .md harness-memory inventory.")
+    ap.add_argument("--memory-dir", default=os.path.expanduser(
+        "~/.claude/projects/-home-virant-dev-aimee/memory"))
+    ap.add_argument("--project", default="")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+
+    if not os.path.isdir(a.memory_dir):
+        print(f"harness-memory-inventory: no memory dir at {a.memory_dir}", file=sys.stderr)
+        return 1
+
+    local = inventory_local(a.memory_dir)
+    server = fetch_server_rows(a.project)
+
+    # Name-based reconciliation (server is canonical; local is a derivative view).
+    recon = None
+    if server is not None:
+        local_names = {r["name"] for r in local if "name" in r}
+        server_names = {r.get("name") for r in server if r.get("name")}
+        recon = {
+            "server_total": len(server_names),
+            "local_total": len(local_names),
+            "in_both": sorted(local_names & server_names),
+            "server_only": sorted(server_names - local_names),
+            "local_only": sorted(local_names - server_names),
+        }
+
+    if a.json:
+        print(json.dumps({"local": local, "reconcile": recon,
+                          "server_available": server is not None}, indent=2))
+        return 0
+
+    by_scope = Counter(r.get("scope_signal", "?") for r in local if "scope_signal" in r)
+    print(f"=== .md harness-memory inventory ({a.memory_dir}) ===")
+    print(f"local .md memories: {sum(1 for r in local if 'name' in r and 'error' not in r)}")
+    print("scope signals (for operator classification — NOT a decision):")
+    for sig, n in by_scope.most_common():
+        print(f"  {n:4d}  {sig}")
+    if recon is None:
+        print("\nserver harness_memory table: UNAVAILABLE "
+              "(no `aimee memory harness-list` / server unreachable) — local view only.")
+    else:
+        print(f"\nreconcile vs server (canonical): in-both={len(recon['in_both'])} "
+              f"server-only={len(recon['server_only'])} local-only={len(recon['local_only'])}")
+        for label in ("server_only", "local_only"):
+            if recon[label]:
+                print(f"  DRIFT [{label}]: {', '.join(recon[label][:10])}"
+                      + (" …" if len(recon[label]) > 10 else ""))
+    print("\nNEXT: operator classifies each memory user(db1)/org(db2)/drop; "
+          "migration WRITES nothing until that classification exists. This tool is read-only.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The safe, **read-only** first increment of retiring the `.md` harness-memory subsystem (Proposal 2 memory-arch, "get rid of the .md garbage").

## Why read-only first

The migration was roundtabled (7 participants) before any code, and the verdict is decisive: **it cannot be safely automated end-to-end.**
- **Scope (user/org) is not mechanically derivable** — `harness_memory.type ∈ {fact,index,note,scratch}` carries no user/org signal; the only signal is advisory `.md` frontmatter. Auto-defaulting is silent + irreversible: default→db1 **locks org knowledge away**, default→db2 **leaks private notes org-wide**. Classification must be **operator-reviewed per memory**.
- **Never bulk-load free-form `.md` into structured `user_memories`** — the `identity:`/`pref:` selectors won't match → *stored-but-not-surfaced* = data-loss-by-inaccessibility. Preserved docs need a separate non-recallable archival store.
- **Server db1 table is canonical; local `.md` are a lossy re-hydrated derivative.**
- **Define the replacement write path before removing interception** or new agent writes drop silently.

So Slice 1 gives the operator the **manifest to classify**, and writes/deletes **nothing**.

## What ships

- **`scripts/harness-memory-inventory.py`** — read-only inventory of the `.md` store: per-memory scope-signal (from frontmatter `metadata.type`), size, first line; best-effort reconcile against the canonical server table via the existing read-only `/v1/harness_memory/list` route. Ran clean here: **259 local memories — 202 project / 31 feedback / 26 reference.**
- **Migration design recorded in the proposal (R3)** — the data-loss traps and the sequenced, gated, **reversible** slices (inventory → operator-classify → migrate+verify → replacement-write-path → subsystem removal).

## Next (operator-gated, not autonomous)

Slices 2–5 each require operator decisions (per-memory classification) and are gated/reversible. This PR is the zero-data-loss foundation; nothing downstream deletes anything until classification exists and content-hash verification passes.
