### PR TITLE
feat(economizer): P1a — keep the failure detail block in command_filter (no-over-reduction)

### DIFF
--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -223,6 +223,28 @@ int main(void)
       assert(!strstr(r3, "TestPass30"));            /* middle passes still dropped */
       assert(strlen(r3) < strlen(gt));              /* still materially shrank */
       free(r3);
+
+      /* multi-line detail block (pytest-style traceback BELOW the failure line) — every
+       * line of the block survives, not just the first. */
+      char py[8192];
+      size_t p = 0;
+      for (int k = 0; k < 50; k++)
+         p += (size_t)snprintf(py + p, sizeof py - p, "test_mod.py::test_ok%02d PASSED\n", k);
+      snprintf(py + p, sizeof py - p,
+               "test_mod.py::test_div FAILED\n"
+               "=================== FAILURES ===================\n"
+               "    def test_div():\n"
+               ">       assert divide(1, 0) == 1\n"
+               "E       ZeroDivisionError: division by zero\n"
+               "test_mod.py:7: ZeroDivisionError\n"
+               "=========== 1 failed, 50 passed ===========\n");
+      char *r4 = tc_family_test_runner(1, py);
+      assert(r4);
+      assert(strstr(r4, "test_div FAILED"));
+      assert(strstr(r4, "ZeroDivisionError: division by zero")); /* the assertion cause */
+      assert(strstr(r4, "assert divide(1, 0)"));                 /* the asserting line */
+      assert(!strstr(r4, "test_ok20 PASSED"));                   /* passes dropped */
+      free(r4);
    }
 
    /* ---- tool_condense_apply (S3) ---- */

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -202,6 +202,27 @@ int main(void)
       /* non-zero exit with NO failure signal -> passthrough (NULL) */
       char *r2 = tc_family_test_runner(1, "building...\nlinking...\nnothing useful here\n");
       assert(r2 == NULL);
+
+      /* NO-OVER-REDUCTION (P1a): the failure DETAIL (a separate line from its `--- FAIL:`
+       * marker, `go test` style) must survive in the CONDENSED output, not just the spill.
+       * 60 passes + a failure whose message is the line ABOVE the marker. */
+      char gt[8192];
+      size_t o = 0;
+      for (int k = 0; k < 60; k++)
+      {
+         o += (size_t)snprintf(gt + o, sizeof gt - o, "=== RUN   TestPass%02d\n", k);
+         o += (size_t)snprintf(gt + o, sizeof gt - o, "--- PASS: TestPass%02d (0.00s)\n", k);
+      }
+      o += (size_t)snprintf(gt + o, sizeof gt - o, "=== RUN   TestBoom\n");
+      o += (size_t)snprintf(gt + o, sizeof gt - o, "    x_test.go:63: boom: expected 5 got 4\n");
+      snprintf(gt + o, sizeof gt - o, "--- FAIL: TestBoom (0.00s)\nFAIL\n");
+      char *r3 = tc_family_test_runner(1, gt);
+      assert(r3);
+      assert(strstr(r3, "--- FAIL: TestBoom"));     /* the marker */
+      assert(strstr(r3, "boom: expected 5 got 4")); /* the DETAIL — must NOT be elided */
+      assert(!strstr(r3, "TestPass30"));            /* middle passes still dropped */
+      assert(strlen(r3) < strlen(gt));              /* still materially shrank */
+      free(r3);
    }
 
    /* ---- tool_condense_apply (S3) ---- */

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -669,7 +669,7 @@ static const char *const TC_KEEP_SIGS[] = {"test result", "result:", "====",    
  * or NULL (OOM / the safety passthrough). */
 static char *tc_signal_filter(int exit_code, const char *in, const char *const *fail_sigs,
                               const char *const *keep_sigs, int require_fail_nonzero, size_t head,
-                              size_t tail)
+                              size_t tail, size_t ctx_before, size_t ctx_after)
 {
    if (!in)
       return NULL;
@@ -715,14 +715,36 @@ static char *tc_signal_filter(int exit_code, const char *in, const char *const *
       return NULL;
    }
 
+   /* Pre-pass: mark which lines to keep. A fail-signal line drags in its DETAIL BLOCK —
+    * ctx_before lines above + ctx_after below — so a failure's message (a separate line
+    * from its marker, e.g. `x_test.go:63: expected 5 got 4` above `--- FAIL:`) is never
+    * elided while its marker survives. head/tail and keep-signals are kept as before. */
+   char *keep = calloc(nlines, 1);
+   if (!keep)
+   {
+      free(lp);
+      free(ll);
+      return NULL;
+   }
+   for (size_t i = 0; i < nlines; i++)
+   {
+      if (i < head || i + tail >= nlines || line_has_any(lp[i], ll[i], keep_sigs))
+         keep[i] = 1;
+      if (line_has_any(lp[i], ll[i], fail_sigs))
+      {
+         size_t lo = (i > ctx_before) ? i - ctx_before : 0;
+         size_t hi = (i + ctx_after < nlines) ? i + ctx_after : nlines - 1;
+         for (size_t j = lo; j <= hi; j++)
+            keep[j] = 1;
+      }
+   }
+
    sb_t s = {0};
    int first = 1;
    size_t elided = 0;
    for (size_t i = 0; i < nlines; i++)
    {
-      int keep = (i < head) || (i + tail >= nlines) || line_has_any(lp[i], ll[i], fail_sigs) ||
-                 line_has_any(lp[i], ll[i], keep_sigs);
-      if (keep)
+      if (keep[i])
       {
          if (elided)
          {
@@ -752,6 +774,7 @@ static char *tc_signal_filter(int exit_code, const char *in, const char *const *
          sb_addc(&s, '\n');
       sb_adds(&s, mark);
    }
+   free(keep);
    free(lp);
    free(ll);
    return sb_finish(&s);
@@ -759,7 +782,8 @@ static char *tc_signal_filter(int exit_code, const char *in, const char *const *
 
 char *tc_family_test_runner(int exit_code, const char *in)
 {
-   return tc_signal_filter(exit_code, in, TC_FAIL_SIGS, TC_KEEP_SIGS, 1, 2, 6);
+   /* ctx 2/3: keep each failure's detail block (the message line is separate from its marker). */
+   return tc_signal_filter(exit_code, in, TC_FAIL_SIGS, TC_KEEP_SIGS, 1, 2, 6, 2, 3);
 }
 
 /* Compiler / linter diagnostics (Slice 5): keep every error/warning/note + file:line
@@ -793,7 +817,9 @@ static const char *const TC_DIAG_KEEP_SIGS[] = {"warning", "warn:",   "note:",  
  * warnings is still condensed. */
 char *tc_family_diagnostics(int exit_code, const char *in)
 {
-   return tc_signal_filter(exit_code, in, TC_DIAG_FAIL_SIGS, TC_DIAG_KEEP_SIGS, 1, 2, 4);
+   /* ctx 0/0: a compiler diagnostic line is self-contained (file:line:col + message);
+    * the source-echo/caret below it is redundant (the model has the file:line). */
+   return tc_signal_filter(exit_code, in, TC_DIAG_FAIL_SIGS, TC_DIAG_KEEP_SIGS, 1, 2, 4, 0, 0);
 }
 
 /* ---- spill store + top-level apply (Slice 3) ---- */

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -780,10 +780,17 @@ static char *tc_signal_filter(int exit_code, const char *in, const char *const *
    return sb_finish(&s);
 }
 
+/* Context window kept around each failure marker (P1a): a few lines before (go-test puts
+ * the message above the marker) + a wider span after (pytest/jest/rust/java multi-line
+ * tracebacks fall below it). A pathological traceback longer than TC_TEST_CTX_AFTER
+ * overflows the window but is fully preserved in the spill (recoverable). */
+#define TC_TEST_CTX_BEFORE 3
+#define TC_TEST_CTX_AFTER  8
+
 char *tc_family_test_runner(int exit_code, const char *in)
 {
-   /* ctx 2/3: keep each failure's detail block (the message line is separate from its marker). */
-   return tc_signal_filter(exit_code, in, TC_FAIL_SIGS, TC_KEEP_SIGS, 1, 2, 6, 2, 3);
+   return tc_signal_filter(exit_code, in, TC_FAIL_SIGS, TC_KEEP_SIGS, 1, 2, 6, TC_TEST_CTX_BEFORE,
+                           TC_TEST_CTX_AFTER);
 }
 
 /* Compiler / linter diagnostics (Slice 5): keep every error/warning/note + file:line


### PR DESCRIPTION
First slice of the **unified-economizer** P1 (proposal #1049). Makes `command_filter` pass the **deterministic no-over-reduction gate** so it can move to the safe/default-on tier.

## The gap (caught by deterministic measurement)
On a real `go test` run, the RTK test-runner filter kept the `--- FAIL:` **marker** but **elided the failure's detail line** (`x_test.go:63: expected 5 got 4`) — the most useful line for fixing the test. Recoverable from the spill, but hiding the "why" forces a recovery round-trip, which is what kept the lever *out* of the safe tier.

## Fix
- `tc_signal_filter` gains `ctx_before`/`ctx_after`: a fail-signal line drags in its **detail block** (lines above + a wider span below), so a failure's message/traceback survives in the **condensed** output, not just the spill. Two-pass `keep[]` array.
- Test-runner: **3 before / 8 after** (covers go-test detail-above and pytest/jest/rust/java multi-line tracebacks below); diagnostics: **0/0** (self-contained lines).
- Deterministic **no-over-reduction tests**: a single-line go-test detail *and* a multi-line pytest traceback both fully survive; middle passes still dropped; still materially shrinks.

## Review
Roundtable-reviewed, no blocking; widened the window + named constants + multi-line test per feedback. Full `unit-tests` + line-check green.

Next: P1b (front the tool-output cap with lossless condense+spill), P1c (default it on).