### PR TITLE
feat(economizer): P1b+P1c — front the tool-output cap + default command_filter ON

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -40,7 +40,7 @@ booleans except the two numeric tuning knobs. Defaults in parentheses.
 
 | Setting | Default | What it does |
 | --- | --- | --- |
-| **`reduce.command_filter`** | **off** | **Tool-output condensation** — deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
+| **`reduce.command_filter`** | **on** | **Tool-output condensation** — deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
 | `reduce.gateway_mutate` | off | Apply the economizer to the live inbound `/v1` request so the **primary** agent's tokens are reduced too. See [Economizer gateway mutation](features/economizer-gateway-mutation.md). |
 | `reduce.compress` | on | Size-based compression of oversized tool-result bodies. |
 | `reduce.history_fold` | on | Fold old turn history into a rolling skeleton. |

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -18,7 +18,7 @@ credentials live in the server's **sealed vault**; see
   pipeline knobs (`autonomy.*`, previously environment-only; a change applies on the next
   server start, and an exported `AIMEE_AUTONOMY_*` still overrides). Secrets and endpoints
   are deliberately not in the allowlist. See [SETTINGS.md](SETTINGS.md).
-- **Tool-output condensation** (default-off, `reduce.command_filter`): a deterministic,
+- **Tool-output condensation** (default-ON, `reduce.command_filter`): a deterministic,
   command-aware context-economizer lever that condenses recognized command output at the
   delegate tool seam — test-runner failures and compiler diagnostics kept, passing
   transcripts and build progress dropped — with the full output spilled for lossless

--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -10,19 +10,20 @@ LLM, so it is ~free). It knows that a test runner's value is its *failures*, a c
 its *diagnostics*, and drops the rest — **losslessly**: the full raw output is spilled to
 disk and a recovery pointer is left in the condensed result, so nothing is destroyed.
 
-It is **default-OFF** and complements — does not replace — the size-based
-`reduce.compress`, which stays the fallback for unrecognized output.
+It is **default-ON** (unified-economizer P1c — a safe-tier lever: lossless-on-demand,
+fail-open, no-over-reduction) and complements — does not replace — the size-based
+`reduce.compress`, which stays the fallback for unrecognized output. Set
+`reduce.command_filter=false` to opt out.
 
 ## Configuration
 
 ```yaml
 reduce:
-  command_filter: false   # DEFAULT OFF. The whole lever.
+  command_filter: true    # DEFAULT ON. Set false to opt out.
 ```
 
 Turn it on from the web UI (**⚙️ Settings → `reduce.command_filter`**, see
-[SETTINGS.md](../SETTINGS.md)) or the config above. When off, tool output is **byte-identical
-to today** — the seam falls through to the size-based `reduce.compress`.
+[SETTINGS.md](../SETTINGS.md)) or the config above. When off, tool output is **byte-identical to today** — the seam falls through to the size-based `reduce.compress`.
 
 ## What it does
 
@@ -52,7 +53,7 @@ before the size-based compression:
   recovery pointer all fall through to passthrough. Nothing is dropped without a backstop.
 - **Never hide a failure.** A test runner or build with a **non-zero exit and no recognized
   failure line** passes through verbatim rather than risk eliding the cause.
-- **Fail-open everywhere.** An unrecognized command, an over-cap body (> 1 MiB), or any
+- **Fail-open everywhere.** An unrecognized command, an over-ceiling body (> 2 MB), or any
   filter error degrades to the size-based `reduce.compress` — never a crash or a dropped
   result.
 - **No masquerade.** A path-prefixed command whose basename matches a known tool (`./git`)
@@ -71,11 +72,16 @@ condensation also logs its `raw→final` delta under the `tool_condense` module.
 
 ## Scope & rollout
 
-Shipped as the **delegate surface** (default-off). Enable it on a validation host, watch the
-savings counters, and roll back by flipping `reduce.command_filter` to `false`.
+Shipped as the **delegate surface**, **default-ON** (the safe-tier lever): when on, the
+delegate bash seam captures the full output (up to a 2 MB ceiling) so the lever sees all of
+it, condenses recognized families losslessly, and spills the raw for recovery. Opt out with
+`reduce.command_filter=false`; roll back the default by the same flag.
+
+The **default-ON** flip landed in unified-economizer **P1c**, justified by the deterministic
+gate (lossless-on-demand + fail-open + a no-over-reduction audit); it replaces the old lossy
+32 KB read-cap truncation with lossless-recoverable condensation.
 
 **Carried follow-ups** (not yet shipped): the **primary-agent** surface (a client-side hook
 + a first-class `tool_output_get` retrieval tool); additional command families (VCS `git`,
-file/dir ops, package managers); and the **operator default-ON** decision — a named gate
-(no-lost-signal audit + material realized savings + fail-safe, measured via the counters
-above), never a silent flip.
+file/dir ops, package managers); and unifying the spill with the other economizer recovery
+handles (unified-economizer P2).

--- a/src/config.c
+++ b/src/config.c
@@ -567,7 +567,12 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_gateway_mutate = 0;
    cfg->reduce_gateway_session_disable_ttl_ms = 3600000;
    cfg->reduce_gateway_seam_explicit = 0;
-   cfg->reduce_command_filter = 0; /* command-aware tool-output condensation: default off */
+   /* command-aware tool-output condensation: DEFAULT-ON (P1c). Safe-tier lever — it passes
+    * the deterministic gate: lossless-on-demand (full output spilled), fail-open (any
+    * miss/decline -> raw), and a no-over-reduction audit (failures/diagnostics + their
+    * detail block are kept in the condensed view, not just the spill). It replaces the old
+    * lossy 32 KB read-cap truncation with lossless-recoverable condensation. */
+   cfg->reduce_command_filter = 1;
    /* Autonomous-dev knobs — defaults match the historical AIMEE_AUTONOMY_* env defaults
     * (adversarial + fan-out tiers OFF; retry/unit caps at their wfe defaults). */
    cfg->autonomy_skeptics = 0;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -293,7 +293,7 @@ static int reduce_has_non_default(const config_t *cfg)
           (cfg->reduce_gateway_seam && cfg->reduce_gateway_seam_explicit) ||
           !cfg->reduce_freeze_guard_enabled ||
           (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1) ||
-          cfg->reduce_gateway_mutate ||
+          cfg->reduce_gateway_mutate || !cfg->reduce_command_filter /* default-ON (P1c) */ ||
           (cfg->reduce_gateway_session_disable_ttl_ms != 3600000 &&
            cfg->reduce_gateway_session_disable_ttl_ms > 0);
 }
@@ -1044,8 +1044,8 @@ int config_save(const config_t *cfg)
        * persist only a non-default positive override (a bad <=0 is never written). */
       if (cfg->reduce_gateway_mutate)
          cJSON_AddBoolToObject(reduce, "gateway_mutate", cfg->reduce_gateway_mutate);
-      if (cfg->reduce_command_filter)
-         cJSON_AddBoolToObject(reduce, "command_filter", cfg->reduce_command_filter);
+      if (!cfg->reduce_command_filter) /* default-ON (P1c) -> persist only the opt-out */
+         cJSON_AddBoolToObject(reduce, "command_filter", 0);
       if (cfg->reduce_gateway_session_disable_ttl_ms != 3600000 &&
           cfg->reduce_gateway_session_disable_ttl_ms > 0)
          cJSON_AddNumberToObject(reduce, "gateway_session_disable_ttl_ms",

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -966,10 +966,12 @@ typedef struct config
    int reduce_freeze_guard_horizon;
    int reduce_gateway_mutate;
    int reduce_gateway_session_disable_ttl_ms;
-   /* reduce_command_filter: deterministic command-aware tool-output condensation lever
-    * (proposal: deterministic-tool-output-condensation). Default OFF. S1 ships the
-    * primitives + this gate; the tool seam is wired in a later slice, so the flag is
-    * inert until then. */
+   /* reduce_command_filter: deterministic command-aware tool-output condensation lever.
+    * DEFAULT-ON (unified-economizer P1c): a safe-tier lever — lossless-on-demand (full
+    * output spilled), fail-open, and no-over-reduction (failures/diagnostics + their detail
+    * block kept in the condensed view). When on, tool_bash captures up to TOOL_CONDENSE_
+    * CEILING (2 MB) so the full output reaches the lever, replacing the old lossy 32 KB
+    * read-cap truncation. Set reduce.command_filter=false to opt out. */
    int reduce_command_filter;
    /* Runtime-only (NOT parsed as a key, NOT persisted): 1 iff the operator set the
     * reduce.gateway_seam key explicitly. Lets config_save persist gateway_seam only

--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -11,6 +11,11 @@
 
 #include "config.h"
 
+/* Last-resort ceiling (2 MB) for tool output when the command-filter lever is on: the seam
+ * captures up to this so the FULL output reaches the lever (condense + spill) instead of
+ * being truncated at the old 32 KB read cap, and it bounds fail-open blast radius. */
+#define TOOL_CONDENSE_CEILING (2 * 1024 * 1024)
+
 /* 1 iff the command-filter lever is enabled (reduce_command_filter). */
 int tool_condense_enabled(const config_t *cfg);
 

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -867,15 +867,21 @@ char *tool_bash(const char *command, int timeout_ms)
       }
       return safe_strdup("{\"stdout\":\"\",\"stderr\":\"fork failed\",\"exit_code\":-1}");
    }
-   /* command-aware condensation (P1b): when reduce_command_filter is on, capture the FULL
-    * output up to the 2 MB ceiling so tool_condense sees all of it (the old 32 KB read cap
-    * truncated the input before the lever could condense + spill it). Default-off keeps the
-    * 32 KB cap — byte-identical. Config loaded ONCE here and reused for the condense below. */
+   /* command-aware condensation (P1b): when reduce_command_filter is on, `rawcap` (the
+    * MAXIMUM we'll capture) rises to the 2 MB ceiling so tool_condense sees the FULL output
+    * (the old 32 KB read cap truncated the input before the lever could condense + spill it).
+    * Default-off keeps the 32 KB cap — byte-identical. Per-call config load, reused for both
+    * the cap and the condense step below (previously the load happened after allocation, so
+    * it could not influence the cap). Buffers start SMALL and grow toward rawcap only if the
+    * output actually overflows, so an `echo hi` costs ~32 KB, not 2 MB. */
    config_t tc_cfg;
    int tc_on = (config_load(&tc_cfg) == 0 && tool_condense_enabled(&tc_cfg));
    size_t rawcap = tc_on ? (size_t)TOOL_CONDENSE_CEILING : (size_t)AGENT_TOOL_OUTPUT_RAW_MAX;
-   char *out_buf = malloc(rawcap + 1);
-   char *err_buf = malloc(rawcap + 1);
+   size_t out_cap =
+       (rawcap < AGENT_TOOL_OUTPUT_RAW_MAX) ? rawcap : (size_t)AGENT_TOOL_OUTPUT_RAW_MAX;
+   size_t err_cap = out_cap;
+   char *out_buf = malloc(out_cap + 1);
+   char *err_buf = malloc(err_cap + 1);
    if (!out_buf || !err_buf)
    {
       free(out_buf);
@@ -952,23 +958,45 @@ char *tool_bash(const char *command, int timeout_ms)
       if (stdout_open && FD_ISSET(stdout_pipe[0], &rfds))
       {
          char discard[4096];
-         void *dst = out_len < rawcap ? out_buf + out_len : discard;
-         size_t cap = out_len < rawcap ? rawcap - out_len : sizeof(discard);
+         /* grow toward rawcap only when the buffer actually filled (small outputs stay
+          * cheap); a failed realloc just stops growing (we discard the excess, bounded). */
+         if (out_len == out_cap && out_cap < rawcap)
+         {
+            size_t ncap = out_cap * 2 > rawcap ? rawcap : out_cap * 2;
+            char *nb = realloc(out_buf, ncap + 1);
+            if (nb)
+            {
+               out_buf = nb;
+               out_cap = ncap;
+            }
+         }
+         void *dst = out_len < out_cap ? out_buf + out_len : discard;
+         size_t cap = out_len < out_cap ? out_cap - out_len : sizeof(discard);
          ssize_t n = read(stdout_pipe[0], dst, cap);
          if (n <= 0)
             stdout_open = 0;
-         else if (out_len < rawcap)
+         else if (out_len < out_cap)
             out_len += (size_t)n;
       }
       if (stderr_open && FD_ISSET(stderr_pipe[0], &rfds))
       {
          char discard[4096];
-         void *dst = err_len < rawcap ? err_buf + err_len : discard;
-         size_t cap = err_len < rawcap ? rawcap - err_len : sizeof(discard);
+         if (err_len == err_cap && err_cap < rawcap)
+         {
+            size_t ncap = err_cap * 2 > rawcap ? rawcap : err_cap * 2;
+            char *nb = realloc(err_buf, ncap + 1);
+            if (nb)
+            {
+               err_buf = nb;
+               err_cap = ncap;
+            }
+         }
+         void *dst = err_len < err_cap ? err_buf + err_len : discard;
+         size_t cap = err_len < err_cap ? err_cap - err_len : sizeof(discard);
          ssize_t n = read(stderr_pipe[0], dst, cap);
          if (n <= 0)
             stderr_open = 0;
-         else if (err_len < rawcap)
+         else if (err_len < err_cap)
             err_len += (size_t)n;
       }
    }

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -867,8 +867,15 @@ char *tool_bash(const char *command, int timeout_ms)
       }
       return safe_strdup("{\"stdout\":\"\",\"stderr\":\"fork failed\",\"exit_code\":-1}");
    }
-   char *out_buf = malloc(AGENT_TOOL_OUTPUT_RAW_MAX + 1);
-   char *err_buf = malloc(AGENT_TOOL_OUTPUT_RAW_MAX + 1);
+   /* command-aware condensation (P1b): when reduce_command_filter is on, capture the FULL
+    * output up to the 2 MB ceiling so tool_condense sees all of it (the old 32 KB read cap
+    * truncated the input before the lever could condense + spill it). Default-off keeps the
+    * 32 KB cap — byte-identical. Config loaded ONCE here and reused for the condense below. */
+   config_t tc_cfg;
+   int tc_on = (config_load(&tc_cfg) == 0 && tool_condense_enabled(&tc_cfg));
+   size_t rawcap = tc_on ? (size_t)TOOL_CONDENSE_CEILING : (size_t)AGENT_TOOL_OUTPUT_RAW_MAX;
+   char *out_buf = malloc(rawcap + 1);
+   char *err_buf = malloc(rawcap + 1);
    if (!out_buf || !err_buf)
    {
       free(out_buf);
@@ -945,25 +952,23 @@ char *tool_bash(const char *command, int timeout_ms)
       if (stdout_open && FD_ISSET(stdout_pipe[0], &rfds))
       {
          char discard[4096];
-         void *dst = out_len < AGENT_TOOL_OUTPUT_RAW_MAX ? out_buf + out_len : discard;
-         size_t cap = out_len < AGENT_TOOL_OUTPUT_RAW_MAX ? AGENT_TOOL_OUTPUT_RAW_MAX - out_len
-                                                          : sizeof(discard);
+         void *dst = out_len < rawcap ? out_buf + out_len : discard;
+         size_t cap = out_len < rawcap ? rawcap - out_len : sizeof(discard);
          ssize_t n = read(stdout_pipe[0], dst, cap);
          if (n <= 0)
             stdout_open = 0;
-         else if (out_len < AGENT_TOOL_OUTPUT_RAW_MAX)
+         else if (out_len < rawcap)
             out_len += (size_t)n;
       }
       if (stderr_open && FD_ISSET(stderr_pipe[0], &rfds))
       {
          char discard[4096];
-         void *dst = err_len < AGENT_TOOL_OUTPUT_RAW_MAX ? err_buf + err_len : discard;
-         size_t cap = err_len < AGENT_TOOL_OUTPUT_RAW_MAX ? AGENT_TOOL_OUTPUT_RAW_MAX - err_len
-                                                          : sizeof(discard);
+         void *dst = err_len < rawcap ? err_buf + err_len : discard;
+         size_t cap = err_len < rawcap ? rawcap - err_len : sizeof(discard);
          ssize_t n = read(stderr_pipe[0], dst, cap);
          if (n <= 0)
             stderr_open = 0;
-         else if (err_len < AGENT_TOOL_OUTPUT_RAW_MAX)
+         else if (err_len < rawcap)
             err_len += (size_t)n;
       }
    }
@@ -999,23 +1004,20 @@ char *tool_bash(const char *command, int timeout_ms)
     * and spill the full raw so the delegate can read it back. Fail-open: any miss/decline
     * returns NULL and we fall through to the size-based agent_compress_tool_result. */
    char *cond_out = NULL, *cond_err = NULL;
+   if (tc_on) /* reuse the config + gate resolved once at buffer-alloc (P1b) */
    {
-      config_t tccfg;
-      if (config_load(&tccfg) == 0 && tool_condense_enabled(&tccfg))
+      char spill_dir[3072];
+      const char *home = aimee_home(); /* captured once; not called again before use */
+      if (home && home[0] &&
+          snprintf(spill_dir, sizeof spill_dir, "%s/tool-spills", home) < (int)sizeof spill_dir)
       {
-         char spill_dir[3072];
-         const char *home = aimee_home(); /* captured once; not called again before use */
-         if (home && home[0] &&
-             snprintf(spill_dir, sizeof spill_dir, "%s/tool-spills", home) < (int)sizeof spill_dir)
-         {
-            (void)mkdir(spill_dir, 0700); /* idempotent; 0700 per-user */
-            tc_stats_t st;
-            cond_out = tool_condense_apply(&tccfg, command, exit_code, out_buf, spill_dir, &st);
-            if (cond_out)
-               aimee_log(LOG_INFO, "tool_condense", "bash stdout condensed %ld->%ld (%s)",
-                         st.raw_bytes, st.final_bytes, st.family);
-            cond_err = tool_condense_apply(&tccfg, command, exit_code, err_buf, spill_dir, NULL);
-         }
+         (void)mkdir(spill_dir, 0700); /* idempotent; 0700 per-user */
+         tc_stats_t st;
+         cond_out = tool_condense_apply(&tc_cfg, command, exit_code, out_buf, spill_dir, &st);
+         if (cond_out)
+            aimee_log(LOG_INFO, "tool_condense", "bash stdout condensed %ld->%ld (%s)",
+                      st.raw_bytes, st.final_bytes, st.family);
+         cond_err = tool_condense_apply(&tc_cfg, command, exit_code, err_buf, spill_dir, NULL);
       }
    }
    /* Compress output to fit token budget (#4) — the command-aware condensed form when we

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -929,7 +929,7 @@ char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_cod
    if (!tool_condense_enabled(cfg) || !raw || !raw[0])
       return NULL;
    long rawlen = (long)strlen(raw);
-   if (rawlen > (1 << 20))
+   if (rawlen > TOOL_CONDENSE_CEILING)
       return NULL; /* over the input cap -> hand back to the size-based fallback */
 
    tc_reco_result_t reco = tc_recognize(cmdline);


### PR DESCRIPTION
Completes the unified-economizer **P1** (proposal #1049), stacked on P1a (#1050). **Replaces today's lossy default (32 KB destructive read-cap truncation) with the lossless-recoverable `command_filter`, defaulted on.**

## P1b — front the cap
- `tool_bash` capped tool output at **read time** to 32 KB, so `command_filter` only ever saw the first 32 KB. When the lever is on it now captures the **full** output up to `TOOL_CONDENSE_CEILING` (2 MB) so the lever sees all of it (condense + spill). **Growable buffers**: start at 32 KB, grow toward the ceiling *only if output overflows* — an `echo hi` still costs ~32 KB, not 2 MB. Default-off is byte-identical.
- `tool_condense_apply` input cap raised 1 MiB → 2 MB (the shared last-resort ceiling).

## P1c — default ON
Justified by the **P1a deterministic gate** (lossless-on-demand + fail-open + no-over-reduction):
- `config.c` default `reduce_command_filter` 0 → 1.
- `config_save` inverted to persist the **opt-out** (`false`) so an explicit `false` round-trips (matches the other default-on `reduce` levers).
- Docs updated to default-ON with the opt-out (config.h, SETTINGS.md, feature doc, WHATS_NEW).

## Review
Roundtable-reviewed; the real concern — 4 MB per call under default-on — fixed with **growable buffers**. (The config-reuse "blocking" was a false positive: `tc_cfg` is a stack local unchanged between load and use.) Full `unit-tests` + line-check + docs-gen-check green.

This completes the first slice you confirmed. Next: P2 (unify the recovery handle) → P3 (two-tier config namespace) → P4 (recovery-cost telemetry) → P5 (promote fold/compress if measured).