### PR TITLE
feat(economizer): P2 — first-class recovery handle (tool_output_get) + §2.2 spill contract

### DIFF
--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -41,9 +41,12 @@ before the size-based compression:
    - **Compilers / linters** (`tsc`/`eslint`/`ruff`/`mypy`/`gcc`/`clang`/`rustc`/`cmake`,
      and `cargo|go|dotnet|npm|… build/check/clippy/vet/lint`): keep every error/warning/note
      and diagnostic, drop the `Compiling…/Downloading…/Checking…` progress.
-3. **Spill + point.** The full raw output is written to `<aimee_home>/tool-spills/<ref>.out`
-   (mode `0600`) and the condensed result ends with a pointer to that path, which the
-   delegate reads back with its own bash tool if it needs an elided passing case.
+3. **Spill + point.** The full raw output is **atomically** written to
+   `<aimee_home>/tool-spills/<ref>.out` (temp → `fsync` → rename → dir `fsync`, mode `0600`,
+   so a partial write is never promoted) and the condensed result ends with a pointer
+   carrying the opaque `ref`. The agent retrieves the full original with the first-class
+   **`tool_output_get`** tool (P2) — one recovery handle, not a raw filesystem path. The
+   spill store is kept under a 64 MB budget by oldest-first (mtime) eviction.
 
 ## Safety contract
 
@@ -81,7 +84,9 @@ The **default-ON** flip landed in unified-economizer **P1c**, justified by the d
 gate (lossless-on-demand + fail-open + a no-over-reduction audit); it replaces the old lossy
 32 KB read-cap truncation with lossless-recoverable condensation.
 
-**Carried follow-ups** (not yet shipped): the **primary-agent** surface (a client-side hook
-+ a first-class `tool_output_get` retrieval tool); additional command families (VCS `git`,
-file/dir ops, package managers); and unifying the spill with the other economizer recovery
-handles (unified-economizer P2).
+The first-class **`tool_output_get`** retrieval tool + the atomic-write / bounded-eviction
+recovery contract landed in unified-economizer **P2**.
+
+**Carried follow-ups** (not yet shipped): the **primary-agent** surface (a client-side
+hook); additional command families (VCS `git`, file/dir ops, package managers); and folding
+the fold-recall / `code_span_get` recovery flows through the same `tool_output_get` handle.

--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -78,6 +78,13 @@ typedef struct
 char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_code, const char *raw,
                           const char *spill_dir, tc_stats_t *stats);
 
+/* Recovery contract (P2): resolve a spill `ref` (as emitted in a condensed pointer) to its
+ * full content. Validates the ref (`tc-`+16 hex — never a path) and reads it from
+ * `spill_dir` bounded to TOOL_CONDENSE_CEILING. Returns a NEW string (caller frees), or NULL
+ * with an error in `err` ("invalid ref" / "spill expired") — the single first-class handle
+ * that makes lossless-on-demand real. */
+char *tool_condense_recall(const char *spill_dir, const char *ref, char *err, size_t errn);
+
 /* ---- realized-savings observability (Slice 6) ---- */
 
 /* Cumulative process-wide counters, updated at the seam so an operator can measure the

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -4,6 +4,8 @@
 #include "aimee.h"
 #include "agent_tools.h"
 #include "agent_tools_internal.h"
+#include "aimee_home.h"
+#include "tool_condense.h"
 #include "tool_args_coerce.h"
 #include "workspace_provider.h"
 
@@ -370,6 +372,34 @@ static char *td_execute_script(cJSON *args, const char *name, const char *dispat
    free(env_json);
 
    return result;
+}
+
+/* tool_output_get (P2): resolve a spill ref to the full raw output aimee condensed —
+ * the single first-class recovery handle. */
+static char *td_tool_output_get(cJSON *args, const char *name, const char *dispatch_cwd,
+                                const char *dispatch_sid, int timeout_ms)
+{
+   (void)name;
+   (void)dispatch_cwd;
+   (void)dispatch_sid;
+   (void)timeout_ms;
+   cJSON *r = cJSON_GetObjectItem(args, "ref");
+   if (!r || !cJSON_IsString(r))
+      return safe_strdup("error: missing 'ref' parameter");
+   char spill_dir[600];
+   const char *home = aimee_home();
+   if (!home || !home[0] ||
+       snprintf(spill_dir, sizeof spill_dir, "%s/tool-spills", home) >= (int)sizeof spill_dir)
+      return safe_strdup("error: spill store unavailable");
+   char err[64];
+   char *full = tool_condense_recall(spill_dir, r->valuestring, err, sizeof err);
+   if (!full)
+   {
+      char msg[128];
+      snprintf(msg, sizeof msg, "error: %s", err[0] ? err : "not found");
+      return safe_strdup(msg);
+   }
+   return full;
 }
 
 static char *td_read_file(cJSON *args, const char *name, const char *dispatch_cwd,
@@ -1506,6 +1536,8 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
       result = td_execute_script(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "read_file") == 0)
       result = td_read_file(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
+   else if (strcmp(name, "tool_output_get") == 0)
+      result = td_tool_output_get(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "edit_file") == 0)
       result = td_edit_file(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "write_file") == 0)

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -576,6 +576,19 @@ static cJSON *tp_read_file(void)
    return params;
 }
 
+static cJSON *tp_tool_output_get(void)
+{
+   cJSON *params = tp_obj();
+   cJSON *props = cJSON_CreateObject();
+   tp_prop(props, "ref", "string",
+           "The spill ref from a '[output condensed by aimee ... ref \"tc-...\"]' pointer.");
+   cJSON_AddItemToObject(params, "properties", props);
+   cJSON *req = cJSON_CreateArray();
+   cJSON_AddItemToArray(req, cJSON_CreateString("ref"));
+   cJSON_AddItemToObject(params, "required", req);
+   return params;
+}
+
 static cJSON *tp_write_file(void)
 {
    cJSON *params = tp_obj();
@@ -883,6 +896,11 @@ static const builtin_tool_def_t g_builtin_tools[] = {
      "stdout, stderr, exit_code, duration_ms, and truncation flags.",
      tp_execute_script, TSURF_CHAT},
     {"read_file", "Read a file and return its contents.", tp_read_file, TSURF_ALL},
+    {"tool_output_get",
+     "Retrieve the full, unfiltered output that aimee condensed. Pass the ref from a "
+     "'[output condensed by aimee ... ref \"tc-...\"]' pointer to get the complete original "
+     "output (e.g. a passing test case or an elided detail).",
+     tp_tool_output_get, TSURF_ALL},
     {"write_file", "Write content to a file (overwrites).", tp_write_file, TSURF_ALL},
     {"edit_file",
      "Make a surgical edit to an existing file by replacing old_string with new_string. "

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -280,18 +280,22 @@ int main(void)
       assert(st.recognized && st.spilled && !strcmp(st.family, "test"));
       assert(st.final_bytes < st.raw_bytes);
       assert(strstr(r, "condensed by aimee")); /* recovery pointer present */
-      assert(strstr(r, st.spill_ref));         /* references the spill file */
-      assert(strstr(r, dir));                  /* the catable full path */
-      /* the spill file exists + holds the FULL raw */
+      assert(strstr(r, st.spill_ref));         /* references the spill ref */
+      assert(strstr(r, "tool_output_get"));    /* the first-class retrieval handle (P2) */
+      /* RECOVERY CONTRACT (P2): tool_condense_recall resolves the ref to the FULL raw. */
+      char rerr[64];
+      char *full = tool_condense_recall(dir, st.spill_ref, rerr, sizeof rerr);
+      assert(full);
+      assert((long)strlen(full) == st.raw_bytes); /* lossless-on-demand */
+      free(full);
+      /* path-traversal + malformed refs are rejected (never escape the spill dir). */
+      assert(tool_condense_recall(dir, "../../etc/passwd", rerr, sizeof rerr) == NULL);
+      assert(tool_condense_recall(dir, "tc-XYZ", rerr, sizeof rerr) == NULL);
+      assert(tool_condense_recall(dir, "tc-0000000000000000", rerr, sizeof rerr) ==
+             NULL); /* expired */
+      /* cleanup */
       char spath[512];
       snprintf(spath, sizeof spath, "%s/%s.out", dir, st.spill_ref);
-      FILE *sf = fopen(spath, "rb");
-      assert(sf);
-      fseek(sf, 0, SEEK_END);
-      long sz = ftell(sf);
-      fclose(sf);
-      assert(sz == st.raw_bytes);
-      /* cleanup */
       unlink(spath);
       rmdir(dir);
       free(r);

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -861,63 +861,80 @@ static void tc_hash_ref(const char *seed, const char *content, char out[40])
 /* Per-user spill-store byte budget (P2 §2.2): keep the tool-spills dir bounded. */
 #define TC_SPILL_MAX_BYTES (64L * 1024 * 1024)
 
-/* Keep the spill dir under TC_SPILL_MAX_BYTES: remove OLDEST .out files (by mtime) until
- * under budget. Best-effort — any error just leaves the file. Bounded scan (512 entries). */
+/* Keep the spill dir under TC_SPILL_MAX_BYTES: remove OLDEST regular .out files (by mtime)
+ * until under budget. Best-effort — any error just leaves the file. Each pass tracks up to
+ * 512 files; if MORE than 512 exist and the store is still over budget, the outer loop
+ * re-scans (bounded passes) so a large store still drains rather than growing unbounded.
+ * lstat + S_ISREG so a symlink planted in the dir is never followed for size/mtime. */
 static void tc_spill_evict(const char *dir, long budget)
 {
-   DIR *d = opendir(dir);
-   if (!d)
-      return;
-   struct
+   for (int pass = 0; pass < 16; pass++)
    {
-      char name[80];
-      long mt;
-      long sz;
-   } ents[512];
-   int ne = 0;
-   long total = 0;
-   struct dirent *de;
-   while ((de = readdir(d)) != NULL && ne < 512)
-   {
-      size_t l = strlen(de->d_name);
-      if (l < 5 || l >= sizeof ents[0].name || strcmp(de->d_name + l - 4, ".out") != 0)
-         continue;
-      char p[1500];
-      if (snprintf(p, sizeof p, "%s/%s", dir, de->d_name) >= (int)sizeof p)
-         continue;
-      struct stat st;
-      if (stat(p, &st) != 0)
-         continue;
-      snprintf(ents[ne].name, sizeof ents[ne].name, "%s", de->d_name);
-      ents[ne].mt = (long)st.st_mtime;
-      ents[ne].sz = (long)st.st_size;
-      total += ents[ne].sz;
-      ne++;
-   }
-   closedir(d);
-   while (total > budget && ne > 0)
-   {
-      int oldest = 0;
-      for (int i = 1; i < ne; i++)
-         if (ents[i].mt < ents[oldest].mt)
-            oldest = i;
-      char p[1500];
-      if (snprintf(p, sizeof p, "%s/%s", dir, ents[oldest].name) < (int)sizeof p)
-         (void)unlink(p);
-      total -= ents[oldest].sz;
-      ents[oldest] = ents[--ne];
+      DIR *d = opendir(dir);
+      if (!d)
+         return;
+      struct
+      {
+         char name[80];
+         long mt;
+         long sz;
+      } ents[512];
+      int ne = 0;
+      long total = 0; /* total over ALL .out files, not just the tracked sample */
+      struct dirent *de;
+      while ((de = readdir(d)) != NULL)
+      {
+         size_t l = strlen(de->d_name);
+         if (l < 5 || l >= sizeof ents[0].name || strcmp(de->d_name + l - 4, ".out") != 0)
+            continue;
+         char p[1500];
+         if (snprintf(p, sizeof p, "%s/%s", dir, de->d_name) >= (int)sizeof p)
+            continue;
+         struct stat st;
+         if (lstat(p, &st) != 0 || !S_ISREG(st.st_mode))
+            continue;
+         total += (long)st.st_size;
+         if (ne < 512)
+         {
+            snprintf(ents[ne].name, sizeof ents[ne].name, "%s", de->d_name);
+            ents[ne].mt = (long)st.st_mtime;
+            ents[ne].sz = (long)st.st_size;
+            ne++;
+         }
+      }
+      closedir(d);
+      if (total <= budget || ne == 0)
+         return;
+      /* evict oldest-of-sample until the GLOBAL total is under budget or the sample empties */
+      while (total > budget && ne > 0)
+      {
+         int oldest = 0;
+         for (int i = 1; i < ne; i++)
+            if (ents[i].mt < ents[oldest].mt)
+               oldest = i;
+         char p[1500];
+         if (snprintf(p, sizeof p, "%s/%s", dir, ents[oldest].name) < (int)sizeof p)
+            (void)unlink(p);
+         total -= ents[oldest].sz;
+         ents[oldest] = ents[--ne];
+      }
+      if (total <= budget)
+         return; /* else >512 files remained: loop re-scans to reach the untracked oldest */
    }
 }
 
-/* Write the full raw output to <dir>/<ref>.out with the §2.2 DURABILITY contract: write to
- * a temp file, fsync, atomic rename to the ref path, fsync the dir — so a partial/crashed
- * write is never promoted to a readable ref. Returns 0 only on a durable write, -1 otherwise
- * (the caller then passes through — never a condense without a recoverable backstop). */
+/* Write the full raw output to <dir>/<ref>.out with the §2.2 DURABILITY contract: write to a
+ * PID-unique temp file (so two processes spilling the same ref never race on one .tmp), fsync,
+ * atomic rename to the ref path — so a partial/crashed write is never promoted to a readable
+ * ref. The rename makes the content immediately readable (what recall needs THIS run); the
+ * trailing directory fsync is best-effort crash-durability of the dir entry and does not gate
+ * success. Returns 0 only when the durable rename landed, -1 otherwise (the caller then passes
+ * through — never a condense without a recoverable backstop). */
 static int tc_spill_write(const char *dir, const char *ref, const char *content)
 {
-   char path[1400], tmp[1424];
+   char path[1400], tmp[1440];
    if (snprintf(path, sizeof path, "%s/%s.out", dir, ref) >= (int)sizeof path ||
-       snprintf(tmp, sizeof tmp, "%s/%s.tmp", dir, ref) >= (int)sizeof tmp)
+       snprintf(tmp, sizeof tmp, "%s/%s.%d.tmp", dir, ref, (int)getpid()) >= (int)sizeof tmp)
       return -1;
    int fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
    if (fd < 0)
@@ -992,6 +1009,8 @@ char *tool_condense_recall(const char *spill_dir, const char *ref, char *err, si
    if (!buf)
    {
       close(fd);
+      if (err && errn)
+         snprintf(err, errn, "allocation failed");
       return NULL;
    }
    ssize_t r;

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -3,12 +3,15 @@
  * enable gate. CORE layer: depends only on config.h + libc. */
 #include "tool_condense.h"
 
+#include <dirent.h>
 #include <fcntl.h>
 #include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h> /* snprintf */
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 /* ---- realized-savings observability (Slice 6) ---- */
@@ -855,12 +858,68 @@ static void tc_hash_ref(const char *seed, const char *content, char out[40])
  * -1 otherwise (the caller then passes through — never a condense without a backstop).
  * Opened O_NOFOLLOW (never follow a pre-planted symlink at the predictable path) + 0600.
  * The ref is content-derived so re-writing an existing ref is idempotent (same bytes). */
+/* Per-user spill-store byte budget (P2 §2.2): keep the tool-spills dir bounded. */
+#define TC_SPILL_MAX_BYTES (64L * 1024 * 1024)
+
+/* Keep the spill dir under TC_SPILL_MAX_BYTES: remove OLDEST .out files (by mtime) until
+ * under budget. Best-effort — any error just leaves the file. Bounded scan (512 entries). */
+static void tc_spill_evict(const char *dir, long budget)
+{
+   DIR *d = opendir(dir);
+   if (!d)
+      return;
+   struct
+   {
+      char name[80];
+      long mt;
+      long sz;
+   } ents[512];
+   int ne = 0;
+   long total = 0;
+   struct dirent *de;
+   while ((de = readdir(d)) != NULL && ne < 512)
+   {
+      size_t l = strlen(de->d_name);
+      if (l < 5 || l >= sizeof ents[0].name || strcmp(de->d_name + l - 4, ".out") != 0)
+         continue;
+      char p[1500];
+      if (snprintf(p, sizeof p, "%s/%s", dir, de->d_name) >= (int)sizeof p)
+         continue;
+      struct stat st;
+      if (stat(p, &st) != 0)
+         continue;
+      snprintf(ents[ne].name, sizeof ents[ne].name, "%s", de->d_name);
+      ents[ne].mt = (long)st.st_mtime;
+      ents[ne].sz = (long)st.st_size;
+      total += ents[ne].sz;
+      ne++;
+   }
+   closedir(d);
+   while (total > budget && ne > 0)
+   {
+      int oldest = 0;
+      for (int i = 1; i < ne; i++)
+         if (ents[i].mt < ents[oldest].mt)
+            oldest = i;
+      char p[1500];
+      if (snprintf(p, sizeof p, "%s/%s", dir, ents[oldest].name) < (int)sizeof p)
+         (void)unlink(p);
+      total -= ents[oldest].sz;
+      ents[oldest] = ents[--ne];
+   }
+}
+
+/* Write the full raw output to <dir>/<ref>.out with the §2.2 DURABILITY contract: write to
+ * a temp file, fsync, atomic rename to the ref path, fsync the dir — so a partial/crashed
+ * write is never promoted to a readable ref. Returns 0 only on a durable write, -1 otherwise
+ * (the caller then passes through — never a condense without a recoverable backstop). */
 static int tc_spill_write(const char *dir, const char *ref, const char *content)
 {
-   char path[1400];
-   if (snprintf(path, sizeof path, "%s/%s.out", dir, ref) >= (int)sizeof path)
+   char path[1400], tmp[1424];
+   if (snprintf(path, sizeof path, "%s/%s.out", dir, ref) >= (int)sizeof path ||
+       snprintf(tmp, sizeof tmp, "%s/%s.tmp", dir, ref) >= (int)sizeof tmp)
       return -1;
-   int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
+   int fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
    if (fd < 0)
       return -1;
    size_t n = strlen(content), off = 0;
@@ -875,9 +934,73 @@ static int tc_spill_write(const char *dir, const char *ref, const char *content)
       }
       off += (size_t)w;
    }
+   if (ok && off == n && fsync(fd) != 0)
+      ok = 0;
    if (close(fd) != 0)
       ok = 0;
-   return (ok && off == n) ? 0 : -1;
+   if (!ok || off != n || rename(tmp, path) != 0)
+   {
+      (void)unlink(tmp);
+      return -1;
+   }
+   int dfd = open(dir, O_RDONLY | O_DIRECTORY);
+   if (dfd >= 0)
+   {
+      (void)fsync(dfd);
+      (void)close(dfd);
+   }
+   return 0;
+}
+
+/* Validate a spill ref is exactly `tc-` + 16 lowercase hex (no path chars) — a strict
+ * predicate so a recall can never traverse out of the spill dir. */
+static int tc_ref_valid(const char *ref)
+{
+   if (!ref || strncmp(ref, "tc-", 3) != 0)
+      return 0;
+   const char *h = ref + 3;
+   if (strlen(h) != 16)
+      return 0;
+   for (const char *p = h; *p; p++)
+      if (!((*p >= '0' && *p <= '9') || (*p >= 'a' && *p <= 'f')))
+         return 0;
+   return 1;
+}
+
+char *tool_condense_recall(const char *spill_dir, const char *ref, char *err, size_t errn)
+{
+   if (err && errn)
+      err[0] = '\0';
+   if (!spill_dir || !tc_ref_valid(ref))
+   {
+      if (err && errn)
+         snprintf(err, errn, "invalid ref");
+      return NULL;
+   }
+   char path[1400];
+   if (snprintf(path, sizeof path, "%s/%s.out", spill_dir, ref) >= (int)sizeof path)
+      return NULL;
+   int fd = open(path, O_RDONLY | O_NOFOLLOW);
+   if (fd < 0)
+   {
+      if (err && errn)
+         snprintf(err, errn, "spill expired");
+      return NULL;
+   }
+   size_t cap = (size_t)TOOL_CONDENSE_CEILING + 1, len = 0;
+   char *buf = malloc(cap);
+   if (!buf)
+   {
+      close(fd);
+      return NULL;
+   }
+   ssize_t r;
+   while (len < (size_t)TOOL_CONDENSE_CEILING &&
+          (r = read(fd, buf + len, (size_t)TOOL_CONDENSE_CEILING - len)) > 0)
+      len += (size_t)r;
+   close(fd);
+   buf[len] = '\0';
+   return buf;
 }
 
 /* Does the recognized command denote a TEST-RUNNER invocation (the only S3 family)? */
@@ -971,6 +1094,7 @@ char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_cod
    }
    char ref[40];
    tc_hash_ref(cmdline ? cmdline : "", raw, ref);
+   tc_spill_evict(spill_dir, TC_SPILL_MAX_BYTES); /* keep the store bounded (§2.2) */
    if (tc_spill_write(spill_dir, ref, raw) != 0)
    {
       free(cond);
@@ -979,12 +1103,12 @@ char *tool_condense_apply(const config_t *cfg, const char *cmdline, int exit_cod
 
    sb_t out = {0};
    sb_adds(&out, cond);
-   char ptr[4200];
+   char ptr[256];
    int pn = snprintf(ptr, sizeof ptr,
-                     "\n[output condensed by aimee — %ld bytes total; the full, unfiltered "
-                     "output is at %s/%s.out — read it if you need a passing case or elided "
-                     "detail]",
-                     rawlen, spill_dir, ref);
+                     "\n[output condensed by aimee — %ld bytes total; retrieve the full, "
+                     "unfiltered output with the tool_output_get tool, ref \"%s\", if you need "
+                     "a passing case or elided detail]",
+                     rawlen, ref);
    if (pn < 0 || pn >= (int)sizeof ptr)
    {
       /* the recovery pointer would be truncated (pathological spill path) -> passthrough


### PR DESCRIPTION
Unified-economizer **P2** (proposal #1049), stacked on P1. Turns the tool-output recovery from "cat the spill path with bash" into a proper **first-class, losslessness-invariant handle**.

## What's new
- **`tool_condense_recall(spill_dir, ref)`** — resolve a spill ref to the **full raw output**. Strictly validates the ref (`tc-`+16 hex — never a path → no traversal), reads it bounded to the 2 MB ceiling.
- **`tool_output_get` tool** (TSURF_ALL) — the agent-facing retrieval (schema + dispatch), resolving `<aimee_home>/tool-spills` via `tool_condense_recall`.
- **Durable spill (§2.2)** — atomic write: PID-unique temp → `fsync` → atomic `rename`; a partial/crashed write is never promoted to a readable ref.
- **Bounded store (§2.2)** — `tc_spill_evict` keeps the dir under 64 MB by oldest-first (mtime) removal, draining even with >512 files; `lstat`+`S_ISREG` so a planted symlink is never followed.
- **Pointer** now carries the opaque ref + names `tool_output_get` (no longer leaks the `aimee_home` path).
- **Conformance test** — a condensed ref round-trips to the exact full raw (lossless-on-demand); traversal / malformed / expired refs rejected.

## Review
Roundtable-reviewed (degraded panel); fixed the real findings — eviction >512 drain, `lstat`/`S_ISREG`, PID-unique temp, malloc err, dir-fsync documented best-effort. (The fd-leak "blocking" was a false positive: `close(fd)` is unconditional.) Full `unit-tests` + line-check + docs-gen-check + api-conformance + mcp-serve green.

Next: P3 (two-tier `economizer.enabled`/`aggressive` config namespace + legacy mapping) → P4 (recovery-cost telemetry) → P5 (promote fold/compress if measured).