### PR TITLE
feat(economizer): P3 — two-tier config namespace (economizer.enabled / economizer.aggressive)

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -33,13 +33,16 @@ request), unless noted otherwise below.
 
 ## Option groups added recently
 
-### Context economizer — `reduce.*`
+### Context economizer — two-tier switches (`economizer.*`) + levers (`reduce.*`)
 
-The unified context economizer's levers are now toggles on the Settings page. All are
-booleans except the two numeric tuning knobs. Defaults in parentheses.
+The economizer has two **tier switches** that gate the individual `reduce.*` levers, plus the
+levers themselves. All are booleans except the two numeric tuning knobs. Defaults in
+parentheses.
 
 | Setting | Default | What it does |
 | --- | --- | --- |
+| **`economizer.enabled`** | **on** | **Master switch.** Off = one kill-switch: every reducer is forced off (measurement keeps running and reports zero, proving the kill). The safe tier stays on under it by the levers' own defaults. |
+| `economizer.aggressive` | off | **Opt-in ceiling for the aggressive tier** (live **primary** `/v1` mutation). `reduce.gateway_mutate` activates only with **`economizer.enabled` AND `economizer.aggressive` AND** the lever itself — the aggressive flag alone never turns on a live-traffic mutator. |
 | **`reduce.command_filter`** | **on** | **Tool-output condensation** — deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
 | `reduce.gateway_mutate` | off | Apply the economizer to the live inbound `/v1` request so the **primary** agent's tokens are reduced too. See [Economizer gateway mutation](features/economizer-gateway-mutation.md). |
 | `reduce.compress` | on | Size-based compression of oversized tool-result bodies. |

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -166,7 +166,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 
 > **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `wfe_live_forge_enabled`
 
-## Config-file sections (52)
+## Config-file sections (53)
 
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`; a key shown as a bare name that is itself a nested object is noted in the section description (see *Coverage & limitations*).
 
@@ -185,6 +185,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`db2`** — _DB2 / vector store settings._ Keys: `vector`
 - **`dedup`** — _Response deduplication._ Keys: `enabled`, `window_seconds`
 - **`dogfood`** — _Session capture for dogfood data._ Keys: `commit_raw`, `enabled`, `inline_tagging`, `log_dir`
+- **`economizer`** — `aggressive`, `enabled`
 - **`ensemble`** — _Roundtable ensemble panel + aggregator._ Keys: `aggregator`, `max_cost_usd`, `min_successful`, `reference_models`, `reference_personas`
 - **`fold`** — `enabled`, `excerpt_bytes`, `freeze`, `min_fold_msgs`, `recall`, `register_enabled`, `retained_msgs`
 - **`guardrails`** — _Semantic guardrail policy._ Keys: `blast_radius`, `semantic`

--- a/src/config.c
+++ b/src/config.c
@@ -343,6 +343,7 @@ static const config_schema_entry_t config_schema[] = {
     {"compact", SCHEMA_OBJECT, 0},
     {"fold", SCHEMA_OBJECT, 0},
     {"reduce", SCHEMA_OBJECT, 0},
+    {"economizer", SCHEMA_OBJECT, 0},
     {"sessions", SCHEMA_OBJECT, 0},
     {"sandbox", SCHEMA_OBJECT, 0},
     {"ecomode", SCHEMA_BOOL, 0},
@@ -567,6 +568,10 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_gateway_mutate = 0;
    cfg->reduce_gateway_session_disable_ttl_ms = 3600000;
    cfg->reduce_gateway_seam_explicit = 0;
+   /* Two-tier economizer switches (P3): master ON (measure exempt), aggressive tier OFF. With
+    * these defaults every effective lever equals its pre-P3 value (back-compat). */
+   cfg->economizer_enabled = 1;
+   cfg->economizer_aggressive = 0;
    /* command-aware tool-output condensation: DEFAULT-ON (P1c). Safe-tier lever — it passes
     * the deterministic gate: lossless-on-demand (full output spilled), fail-open (any
     * miss/decline -> raw), and a no-over-reduction audit (failures/diagnostics + their
@@ -854,6 +859,20 @@ static void config_apply_inference_backend_defaults(config_t *cfg, const cJSON *
    if (!cJSON_GetObjectItemCaseSensitive((cJSON *)root, "memory_rewrite") &&
        !cJSON_GetObjectItemCaseSensitive((cJSON *)root, "memory_rewrite_enabled"))
       cfg->memory_rewrite_enabled = accel;
+}
+
+int econ_reduction_master_on(const config_t *cfg)
+{
+   return cfg && cfg->economizer_enabled ? 1 : 0;
+}
+
+int econ_gateway_mutate_on(const config_t *cfg)
+{
+   /* the live-primary mutator needs the master ON, the aggressive tier opted IN, AND the
+    * lever itself set — the aggressive flag alone never activates a live-traffic mutator. */
+   return cfg && cfg->economizer_enabled && cfg->economizer_aggressive && cfg->reduce_gateway_mutate
+              ? 1
+              : 0;
 }
 
 int config_load(config_t *cfg)

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -284,6 +284,8 @@ const config_field_t config_fields[] = {
     {"reduce.compress", offsetof(config_t, reduce_compress), sizeof(int), 1, CFG_BOOL},
     {"reduce.gateway_mutate", offsetof(config_t, reduce_gateway_mutate), sizeof(int), 1, CFG_BOOL},
     {"reduce.command_filter", offsetof(config_t, reduce_command_filter), sizeof(int), 1, CFG_BOOL},
+    {"economizer.enabled", offsetof(config_t, economizer_enabled), sizeof(int), 1, CFG_BOOL},
+    {"economizer.aggressive", offsetof(config_t, economizer_aggressive), sizeof(int), 1, CFG_BOOL},
     {"reduce.gateway_session_disable_ttl_ms",
      offsetof(config_t, reduce_gateway_session_disable_ttl_ms), sizeof(int), 0, CFG_INT},
     {"reduce.freeze_guard", offsetof(config_t, reduce_freeze_guard_enabled), sizeof(int), 1,

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1052,6 +1052,17 @@ int config_save(const config_t *cfg)
                                  cfg->reduce_gateway_session_disable_ttl_ms);
    }
 
+   /* Two-tier economizer switches (P3): enabled default-ON -> persist only the opt-out;
+    * aggressive default-OFF -> persist only when opted in. */
+   if (!cfg->economizer_enabled || cfg->economizer_aggressive)
+   {
+      cJSON *econ = cJSON_AddObjectToObject(root, "economizer");
+      if (!cfg->economizer_enabled)
+         cJSON_AddBoolToObject(econ, "enabled", 0);
+      if (cfg->economizer_aggressive)
+         cJSON_AddBoolToObject(econ, "aggressive", 1);
+   }
+
    /* Autonomous-dev knobs — persist only non-defaults (defaults: skeptics 0, fanout off,
     * unit_retry 2, unit_max 16, ci_retry_max 2). */
    if (cfg->autonomy_skeptics != 0 || cfg->autonomy_fanout != 0 || cfg->autonomy_unit_retry != 2 ||

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -785,6 +785,18 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
          h = FREEZE_GUARD_MAX_HORIZON; /* clamp at parse so on-disk == runtime */
       cfg->reduce_freeze_guard_horizon = h;
    }
+
+   /* Two-tier economizer switches (P3), colocated `economizer:` block. */
+   cJSON *econ = cJSON_GetObjectItemCaseSensitive(root, "economizer");
+   if (cJSON_IsObject(econ))
+   {
+      item = cJSON_GetObjectItemCaseSensitive(econ, "enabled");
+      if (cJSON_IsBool(item))
+         cfg->economizer_enabled = cJSON_IsTrue(item) ? 1 : 0;
+      item = cJSON_GetObjectItemCaseSensitive(econ, "aggressive");
+      if (cJSON_IsBool(item))
+         cfg->economizer_aggressive = cJSON_IsTrue(item) ? 1 : 0;
+   }
 }
 
 /* Clamp an integer to [lo, hi]. */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -978,6 +978,20 @@ typedef struct config
     * when the user chose it, never when config_load synthesized it from mutate=1. */
    int reduce_gateway_seam_explicit;
 
+   /* Unified-economizer TWO-TIER switches (P3). These GATE the individual reduce.* levers
+    * without mutating them (resolved by the econ_* accessors, never surprising config_save):
+    *   economizer.enabled   — MASTER for all reduction ACTIONS. DEFAULT-ON. false = one
+    *                          off-switch: every reducer is forced off, but measure/telemetry
+    *                          keeps running (reports zero — proving the kill works). The safe
+    *                          tier (delegate-seam: command_filter/history_fold/compress) is on
+    *                          under it by their own defaults.
+    *   economizer.aggressive — opt-in ceiling for the AGGRESSIVE tier (live PRIMARY /v1
+    *                          mutation: gateway_mutate). DEFAULT-OFF. gateway_mutate requires
+    *                          enabled && aggressive && reduce.gateway_mutate (all three) — the
+    *                          aggressive flag alone never activates a live-traffic mutator. */
+   int economizer_enabled;
+   int economizer_aggressive;
+
    /* Autonomous-development pipeline knobs (Phase-C). These were env-var-only
     * (AIMEE_AUTONOMY_*); the config values are bridged to those env vars at startup
     * (autonomy_config_to_env) so the wfe library — which reads them via getenv across a
@@ -1740,6 +1754,12 @@ static inline int config_issue(const char *fmt, ...)
 /* Load config from default path. Returns defaults if missing.
  * In strict mode, returns -1 on validation errors. */
 int config_load(config_t *cfg);
+
+/* Two-tier economizer resolution (P3) — compute EFFECTIVE lever states without mutating
+ * config_t (so config_save always round-trips the raw user values). Precedence:
+ * master-kill (economizer.enabled) > aggressive-tier ceiling > individual reduce.* default. */
+int econ_reduction_master_on(const config_t *cfg); /* economizer.enabled (measure is exempt) */
+int econ_gateway_mutate_on(const config_t *cfg);   /* enabled && aggressive && gateway_mutate */
 
 /* Validate the economizer gateway-mutation invariants that are STARTUP-FATAL (as
  * opposed to the in-memory normalizations config_load already applied). Currently:

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -855,11 +855,15 @@ native_provider_http:
              * top-level typed items, so feeding it folded turns is unverified.
              * Keep the Responses path measure-only here; fold it in a later slice
              * once verified live. */
-            rcfg.history_fold = ecfg.reduce_history_fold && !chatgpt;
+            /* P3 master-kill: economizer.enabled=false forces the MUTATING levers off but
+             * leaves the block reachable, so measure_only shadow accounting keeps running
+             * (reports zero reductions — proof the kill works, per the two-tier contract). */
+            int econ_master = econ_reduction_master_on(&ecfg);
+            rcfg.history_fold = econ_master && ecfg.reduce_history_fold && !chatgpt;
             /* Compress only shrinks tool-result BODIES in place — the message
              * shape (role/type, ids, typed items) is preserved — so its output is
              * valid for ALL builders INCLUDING chatgpt/Responses. Not gated off. */
-            rcfg.compress = ecfg.reduce_compress;
+            rcfg.compress = econ_master && ecfg.reduce_compress;
             rcfg.measure_only =
                 !(rcfg.history_fold || rcfg.compress); /* a lever on -> mutate; else shadow */
             rcfg.freeze_guard_enabled = ecfg.reduce_freeze_guard_enabled; /* Slice 5 guardrail */

--- a/src/server/gateway_mutate_wire.c
+++ b/src/server/gateway_mutate_wire.c
@@ -32,7 +32,8 @@ int gw_mutate_is_enabled(void)
    config_t cfg;
    if (config_load(&cfg) != 0)
       return 0;
-   return cfg.reduce_gateway_mutate ? 1 : 0;
+   /* aggressive tier (P3): live-primary mutation needs enabled && aggressive && the lever. */
+   return econ_gateway_mutate_on(&cfg);
 }
 
 void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
@@ -48,8 +49,8 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    config_t cfg;
    if (config_load(&cfg) != 0)
       return;
-   if (!cfg.reduce_gateway_mutate)
-      return; /* dark by default */
+   if (!econ_gateway_mutate_on(&cfg))
+      return; /* dark by default; needs enabled && aggressive && gateway_mutate (P3) */
    ctx->mutate_on = 1;
    ctx->ttl_ms = cfg.reduce_gateway_session_disable_ttl_ms;
 

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -183,6 +183,18 @@ static int run_server(const char *socket_path, log_level_t log_level)
       }
    }
 
+   /* P3: surface suppressed intent — an explicit lever the two-tier switches override, so an
+    * operator is never silently ignored (per the two-tier design's startup-WARN ruling). */
+   if (!cfg.economizer_enabled &&
+       (cfg.reduce_history_fold || cfg.reduce_compress || cfg.reduce_command_filter))
+      aimee_log(LOG_WARN, "economizer",
+                "economizer.enabled=false MASTER-KILL: all reduction is off (measure still "
+                "runs); individual reduce.* levers are suppressed");
+   if (cfg.reduce_gateway_mutate && !econ_gateway_mutate_on(&cfg))
+      aimee_log(LOG_WARN, "economizer",
+                "reduce.gateway_mutate=true is SUPPRESSED: the live-primary mutator needs "
+                "economizer.enabled && economizer.aggressive (both) to activate");
+
    /* Remote aimee-kb: when a kb_client_url is configured (this host uses a
     * remote kb rather than a local sidecar), export it into our own env so the
     * env-based kb_client transport (kb_client_v1_base_url / auth_header)

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -11,9 +11,59 @@
 #include "platform_path.h"
 #include "platform_test_util.h"
 
+/* Effective safe-tier lever (command_filter): master && individual. Mirrors
+ * tool_condense_enabled without pulling the CORE object into this test's link set. */
+static int cf_effective(const config_t *c)
+{
+   return c->economizer_enabled && c->reduce_command_filter;
+}
+
+/* P3 two-tier resolution: master-kill, aggressive ceiling, and BACK-COMPAT (default
+ * switches must reproduce pre-P3 effective values). Pure — no file I/O. */
+static void test_two_tier_resolution(void)
+{
+   config_t c;
+   memset(&c, 0, sizeof c);
+
+   /* back-compat: defaults (enabled=1, aggressive=0) => effective == raw individual */
+   c.economizer_enabled = 1;
+   c.economizer_aggressive = 0;
+   c.reduce_command_filter = 1;
+   c.reduce_history_fold = 1;
+   c.reduce_compress = 1;
+   c.reduce_gateway_mutate = 0;
+   assert(econ_reduction_master_on(&c) == 1);
+   assert(cf_effective(&c) == 1);           /* command_filter on, as pre-P3 */
+   assert(econ_gateway_mutate_on(&c) == 0); /* off, as pre-P3 */
+
+   /* master-kill: enabled=0 forces reduction off even with every lever set... */
+   c.economizer_enabled = 0;
+   c.reduce_gateway_mutate = 1;
+   c.economizer_aggressive = 1;
+   assert(econ_reduction_master_on(&c) == 0);
+   assert(cf_effective(&c) == 0);           /* command_filter suppressed */
+   assert(econ_gateway_mutate_on(&c) == 0); /* mutate suppressed by master */
+
+   /* aggressive ceiling: gateway_mutate needs ALL THREE (enabled && aggressive && lever) */
+   c.economizer_enabled = 1;
+   c.economizer_aggressive = 1;
+   c.reduce_gateway_mutate = 1;
+   assert(econ_gateway_mutate_on(&c) == 1);
+   c.economizer_aggressive = 0; /* aggressive off -> suppressed even though lever set */
+   assert(econ_gateway_mutate_on(&c) == 0);
+   c.economizer_aggressive = 1;
+   c.reduce_gateway_mutate = 0; /* aggressive on but lever off -> still off (no auto-enable) */
+   assert(econ_gateway_mutate_on(&c) == 0);
+
+   /* NULL-safe */
+   assert(econ_reduction_master_on(NULL) == 0);
+   assert(econ_gateway_mutate_on(NULL) == 0);
+}
+
 int main(void)
 {
    printf("config_economizer: ");
+   test_two_tier_resolution();
 
    char tmpdir[512];
    snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-test-econ-cfg-XXXXXX", platform_tmpdir());
@@ -198,6 +248,24 @@ int main(void)
       assert(config_reduce_validate(&cfg, err, sizeof(err)) != 0);
       cfg.reduce_gateway_session_disable_ttl_ms = -5;
       assert(config_reduce_validate(&cfg, err, sizeof(err)) != 0);
+   }
+
+   /* --- two-tier switches (P3): defaults + save/load round-trip --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      assert(cfg.economizer_enabled == 1);    /* master default ON */
+      assert(cfg.economizer_aggressive == 0); /* aggressive tier default OFF */
+      cfg.economizer_enabled = 0;             /* opt-out the master */
+      cfg.economizer_aggressive = 1;          /* opt-in the aggressive tier */
+      assert(config_save(&cfg) == 0);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.economizer_enabled == 0);    /* opt-out persisted */
+      assert(cfg2.economizer_aggressive == 1); /* opt-in persisted */
    }
 
    /* restore env */

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -27,7 +27,11 @@ int main(void)
       memset(&cfg, 0, sizeof cfg);
       assert(tool_condense_enabled(&cfg) == 0);
       cfg.reduce_command_filter = 1;
-      assert(tool_condense_enabled(&cfg) == 1);
+      assert(tool_condense_enabled(&cfg) == 0); /* P3 master (economizer.enabled) still off */
+      cfg.economizer_enabled = 1;
+      assert(tool_condense_enabled(&cfg) == 1); /* master + lever both on */
+      cfg.economizer_enabled = 0;               /* master-kill overrides the lever */
+      assert(tool_condense_enabled(&cfg) == 0);
       assert(tool_condense_enabled(NULL) == 0);
    }
 
@@ -266,6 +270,7 @@ int main(void)
       assert(tool_condense_apply(&cfg, "pytest -q", 0, big, "/tmp", NULL) == NULL);
 
       cfg.reduce_command_filter = 1;
+      cfg.economizer_enabled = 1; /* P3 master gate */
       /* unrecognized command -> passthrough */
       assert(tool_condense_apply(&cfg, "frobnicate", 0, big, "/tmp", NULL) == NULL);
       /* recognized but no spill dir -> passthrough (lossless: never condense without spill) */
@@ -343,6 +348,7 @@ int main(void)
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
       cfg.reduce_command_filter = 1;
+      cfg.economizer_enabled = 1; /* P3 master gate */
       char big[8192];
       size_t off = 0;
       for (int k = 0; k < 80; k++)
@@ -369,6 +375,7 @@ int main(void)
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
       cfg.reduce_command_filter = 1;
+      cfg.economizer_enabled = 1; /* P3 master gate */
       char big[8192];
       size_t off = 0;
       off += (size_t)snprintf(big + off, sizeof big - off, "==== session ====\n");

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -42,7 +42,8 @@ void tool_condense_stats_reset(void)
 
 int tool_condense_enabled(const config_t *cfg)
 {
-   return cfg && cfg->reduce_command_filter ? 1 : 0;
+   /* safe-tier lever, gated by the P3 master switch: economizer.enabled off = one kill. */
+   return cfg && cfg->economizer_enabled && cfg->reduce_command_filter ? 1 : 0;
 }
 
 /* ---- command recognition (Slice 2) ---- */


### PR DESCRIPTION
Unified-economizer **P3** (proposal #1049), stacked on P1+P2. Adds the two-tier safety switches that gate the individual `reduce.*` levers **without mutating them** (so `config_save` always round-trips raw user values).

## The tier mapping matches the code's real defaults
- **Safe tier (default-ON):** the delegate-seam reduction (`command_filter`/`history_fold`/`compress`, all already default-on + recoverable).
- **Aggressive tier (default-OFF):** the live-**primary** `gateway_mutate` path.

## Switches
- **`economizer.enabled`** (default ON) — **master kill** for reduction *actions*. `false` forces every reducer off, but **measurement keeps running** (`measure_only` shadow, reports zero — proving the kill; the reviewer's carve-out).
- **`economizer.aggressive`** (default OFF) — ceiling for the aggressive tier. `gateway_mutate` needs **`enabled` AND `aggressive` AND the lever** (all three) — the aggressive flag alone never activates a live-traffic mutator (security ruling).

## Implementation
Non-mutating accessors `econ_reduction_master_on` / `econ_gateway_mutate_on`, applied at the 5 seams (`tool_condense_enabled`, the delegate `rcfg` build, `gateway_mutate_wire`; the gateway shadow-measure seams stay exempt as pure measurement). Config field + parse (colocated `economizer:` block) + save (enabled persists opt-out, aggressive persists opt-in) + schema + startup **WARN** on suppressed intent.

## Review
Design + code roundtabled (no blocking). Confirmed: the delegate `rcfg` build is **single** (master-kill coverage complete — the "one provider branch" note was a false positive: that path *is* the delegate seam, chatgpt handled by `!chatgpt`); all four `{enabled,aggressive}` combos round-trip. Tests: pure two-tier resolution + **back-compat** (defaults reproduce pre-P3 effective values) + master-kill + aggressive-ceiling + save/load round-trip. Full `unit-tests` + line-check + docs-gen-check green.

Next: P4 (recovery-cost telemetry) → P5.