### PR TITLE
feat(economizer): P4 — recovery-cost telemetry (net-of-recovery saving)

### DIFF
--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -66,12 +66,25 @@ before the size-based compression:
   spill. Spill files are per-user (`0700` directory) and excluded from log/trace exports by
   default.
 
-## Observability
+## Observability + recovery cost (P4)
 
-Process-wide counters accumulate realized savings on live traffic
+Process-wide counters accumulate realized savings **and recovery cost** on live traffic
 ([`tool_condense_stats_snapshot`](../../src/tool_condense.c)): `recognized`, `applied`,
-`applied_raw` vs `applied_final` bytes, and per-family (`test`, `diag`) counts. Each
-condensation also logs its `raw→final` delta under the `tool_condense` module.
+`applied_raw` vs `applied_final` bytes, per-family (`test`, `diag`) counts, and the
+**recovery-cost** side — `recovered` (successful `tool_output_get` page-backs) and
+`recovered_bytes` (bytes re-injected). Two derived fields make the promotion-gate metric
+explicit:
+
+- `saved_bytes` = `applied_raw − applied_final` (gross condensation saving);
+- **`net_saved_bytes`** = `saved_bytes − recovered_bytes` (**net of recovery**).
+
+`net_saved_bytes` is the honest measure: if the agent keeps paging spilled output back in,
+`recovered_bytes` rises toward `saved_bytes` and the net collapses — the signal that the
+lever is not net-saving on that workload. Each condensation logs its `raw→final` delta and
+each recall logs `tool_output_get recovered N bytes` under the `tool_condense` module, so the
+two sides are greppable together. (This precise per-call channel exists because
+`tool_output_get` is the single first-class recovery handle from P2; `history_fold`/`compress`
+recovery via fold-recall remains best-effort, not byte-exact.)
 
 ## Scope & rollout
 

--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -97,11 +97,18 @@ typedef struct
    long long applied_final; /* total output bytes over APPLIED condensations */
    long long family_test;   /* applied condensations tagged "test" */
    long long family_diag;   /* applied condensations tagged "diag" */
-   /* recovery-cost telemetry (P4): the page-back side of the ledger. */
+   /* recovery-cost telemetry (P4): the page-back side of the ledger. Best-effort monotonic
+    * counters (relaxed atomics); the snapshot is NOT a transactional point-in-time view, so
+    * the two DERIVED fields can be transiently inconsistent under concurrency — fine for an
+    * observability gate, do not drive a hard automated decision off a single live read.
+    * recovered_bytes is the on-disk spill byte count (== the re-injected string length for
+    * the text tool-output this lever handles). */
    long long recovered;       /* successful tool_output_get recalls (page-backs) */
    long long recovered_bytes; /* total bytes re-injected by those recalls */
    long long saved_bytes;     /* derived: applied_raw - applied_final (gross condense saving) */
-   long long net_saved_bytes; /* derived: saved_bytes - recovered_bytes (the gate metric) */
+   /* derived: saved_bytes - recovered_bytes. MEANINGFULLY negative when recovery exceeds the
+    * condensation saving — i.e. the lever is net-LOSS on this workload (do not clamp at 0). */
+   long long net_saved_bytes;
 } tool_condense_totals_t;
 
 /* Snapshot the counters. Each field is read atomically, but the six are NOT a single

--- a/src/headers/tool_condense.h
+++ b/src/headers/tool_condense.h
@@ -97,6 +97,11 @@ typedef struct
    long long applied_final; /* total output bytes over APPLIED condensations */
    long long family_test;   /* applied condensations tagged "test" */
    long long family_diag;   /* applied condensations tagged "diag" */
+   /* recovery-cost telemetry (P4): the page-back side of the ledger. */
+   long long recovered;       /* successful tool_output_get recalls (page-backs) */
+   long long recovered_bytes; /* total bytes re-injected by those recalls */
+   long long saved_bytes;     /* derived: applied_raw - applied_final (gross condense saving) */
+   long long net_saved_bytes; /* derived: saved_bytes - recovered_bytes (the gate metric) */
 } tool_condense_totals_t;
 
 /* Snapshot the counters. Each field is read atomically, but the six are NOT a single

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -5,6 +5,7 @@
 #include "agent_tools.h"
 #include "agent_tools_internal.h"
 #include "aimee_home.h"
+#include "log.h"
 #include "tool_condense.h"
 #include "tool_args_coerce.h"
 #include "workspace_provider.h"
@@ -399,6 +400,11 @@ static char *td_tool_output_get(cJSON *args, const char *name, const char *dispa
       snprintf(msg, sizeof msg, "error: %s", err[0] ? err : "not found");
       return safe_strdup(msg);
    }
+   /* recovery-cost telemetry (P4): each recall is a page-back — the counter is bumped inside
+    * tool_condense_recall; log the bytes so the net-of-recovery is greppable next to the
+    * "condensed X->Y" lines. */
+   aimee_log(LOG_INFO, "tool_condense", "tool_output_get recovered %zu bytes (%s)", strlen(full),
+             r->valuestring);
    return full;
 }
 

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -397,6 +397,20 @@ int main(void)
       assert(t.family_test == 1 && t.family_diag == 0);
       assert(t.applied_raw > t.applied_final); /* realized savings */
       assert(t.applied_raw == st.raw_bytes);
+      /* recovery-cost telemetry (P4): before any recall, net saving == gross saving */
+      assert(t.saved_bytes == t.applied_raw - t.applied_final);
+      assert(t.recovered == 0 && t.recovered_bytes == 0);
+      assert(t.net_saved_bytes == t.saved_bytes);
+
+      /* recall the spill -> a page-back is counted + the net saving drops by the bytes back */
+      char rerr[64];
+      char *back = tool_condense_recall(dir, st.spill_ref, rerr, sizeof rerr);
+      assert(back);
+      tool_condense_stats_snapshot(&t);
+      assert(t.recovered == 1);
+      assert(t.recovered_bytes == (long long)strlen(back));
+      assert(t.net_saved_bytes == t.saved_bytes - t.recovered_bytes); /* recovery erodes the net */
+      free(back);
 
       char spath[512];
       snprintf(spath, sizeof spath, "%s/%s.out", dir, st.spill_ref);

--- a/src/tool_condense.c
+++ b/src/tool_condense.c
@@ -14,9 +14,9 @@
 #include <time.h>
 #include <unistd.h>
 
-/* ---- realized-savings observability (Slice 6) ---- */
+/* ---- realized-savings observability (Slice 6) + recovery-cost telemetry (P4) ---- */
 static atomic_llong g_tc_recognized, g_tc_applied, g_tc_applied_raw, g_tc_applied_final,
-    g_tc_family_test, g_tc_family_diag;
+    g_tc_family_test, g_tc_family_diag, g_tc_recovered, g_tc_recovered_bytes;
 
 void tool_condense_stats_snapshot(tool_condense_totals_t *out)
 {
@@ -28,6 +28,13 @@ void tool_condense_stats_snapshot(tool_condense_totals_t *out)
    out->applied_final = atomic_load_explicit(&g_tc_applied_final, memory_order_relaxed);
    out->family_test = atomic_load_explicit(&g_tc_family_test, memory_order_relaxed);
    out->family_diag = atomic_load_explicit(&g_tc_family_diag, memory_order_relaxed);
+   out->recovered = atomic_load_explicit(&g_tc_recovered, memory_order_relaxed);
+   out->recovered_bytes = atomic_load_explicit(&g_tc_recovered_bytes, memory_order_relaxed);
+   /* net-of-recovery saving: bytes dropped by condensation MINUS bytes paged back via
+    * tool_output_get. This is the recovery-cost gate metric — if recovered approaches
+    * (raw-final), the lever is not net-saving on this workload. */
+   out->saved_bytes = out->applied_raw - out->applied_final;
+   out->net_saved_bytes = out->saved_bytes - out->recovered_bytes;
 }
 
 void tool_condense_stats_reset(void)
@@ -36,6 +43,8 @@ void tool_condense_stats_reset(void)
    atomic_store_explicit(&g_tc_applied, 0, memory_order_relaxed);
    atomic_store_explicit(&g_tc_applied_raw, 0, memory_order_relaxed);
    atomic_store_explicit(&g_tc_applied_final, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_tc_recovered, 0, memory_order_relaxed);
+   atomic_store_explicit(&g_tc_recovered_bytes, 0, memory_order_relaxed);
    atomic_store_explicit(&g_tc_family_test, 0, memory_order_relaxed);
    atomic_store_explicit(&g_tc_family_diag, 0, memory_order_relaxed);
 }
@@ -1020,6 +1029,10 @@ char *tool_condense_recall(const char *spill_dir, const char *ref, char *err, si
       len += (size_t)r;
    close(fd);
    buf[len] = '\0';
+   /* recovery-cost telemetry (P4): a successful recall is a page-back — count it + the bytes
+    * re-injected, so net-of-recovery saving is observable (the promotion-gate metric). */
+   atomic_fetch_add_explicit(&g_tc_recovered, 1, memory_order_relaxed);
+   atomic_fetch_add_explicit(&g_tc_recovered_bytes, (long long)len, memory_order_relaxed);
    return buf;
 }
 


### PR DESCRIPTION
Unified-economizer **P4** (proposal #1049). Closes the recovery-cost loop for the tool-output lever via the one **precisely-measurable** page-back channel — `tool_output_get` (the P2 first-class handle).

## What's new
- Two counters (`recovered`, `recovered_bytes`) bumped inside `tool_condense_recall` on a successful page-back.
- `tool_condense_totals_t` gains them plus two derived fields:
  - `saved_bytes` = `applied_raw − applied_final` (gross);
  - **`net_saved_bytes`** = `saved_bytes − recovered_bytes` — the honest promotion-gate metric. If the agent keeps paging spilled output back in, `recovered_bytes` rises toward `saved_bytes` and the net collapses (meaningfully **negative** = net-loss workload).
- `td_tool_output_get` logs `tool_output_get recovered N bytes` so the recovery side is greppable next to the `condensed X→Y` savings lines.
- Test: net == gross before any recall; after a recall the counters bump and `net_saved_bytes` drops by the bytes paged back.

## Review
Roundtable-reviewed, no blocking. Counter semantics documented honestly (best-effort monotonic, non-transactional snapshot, net legitimately negative). Noted that `history_fold`/`compress` recovery (fold-recall) stays best-effort — not byte-exact — since only `tool_output_get` is a definite per-call channel. Full `unit-tests` + line-check green.

Final phase: P5 (close-out — the levers are already default-on + now instrumented).