### PR TITLE
docs(proposal): config changes take effect immediately (live reload)

### DIFF
--- a/docs/proposals/pending/live-config-reload.md
+++ b/docs/proposals/pending/live-config-reload.md
@@ -1,0 +1,152 @@
+# Proposal: Config changes take effect immediately (live reload)
+
+- **State:** proposed — design (pending review). A config change made via `aimee config set`
+  or the web **Settings** page should take effect **immediately** on the running server, not
+  "on the next server start." Where a setting genuinely cannot be re-applied live, the server
+  says so **explicitly** at change time instead of silently deferring to a restart.
+- **Thesis:** aimee's effective config behaviour today is **mixed and unsurfaced**.
+  `config_load` is mtime-cached, so consumers that read it **per request** (the economizer
+  `reduce.*` levers, and similar) *do* pick up a change on their next request — that path is
+  already live. But a large, important class of settings is **bound once at server startup**
+  and needs a restart: the inbound `/v1` listener (`aimee.api.http_port` / `tls_port` /
+  `bearer_token`), the `autonomy.*` knobs (bridged to env once via `autonomy_config_to_env`),
+  plugin extensions (`config_load_plugin_extensions`), log level, and the vault. The user
+  can't tell which class a given knob is in, so the safe mental model became "restart to be
+  sure." This proposal makes the default **immediate**, adds a **push** signal so a change
+  doesn't wait for a cache miss, and makes the **restart-required** minority explicit.
+
+## §0 The current model (verified)
+
+| Path | How it reads config | Effect of a change |
+| --- | --- | --- |
+| Economizer `reduce.*`, per-request `config_load` callers | mtime-cached `config_load` each request | **Live** on the next request once the mtime changes |
+| `aimee.api.*` listener (port/TLS/bearer) | `server_http_start(cfg…)` once at startup | **Restart** — the socket/cert/token are bound at listen time |
+| `autonomy.*` | `autonomy_config_to_env(&cfg)` once at startup (setenv, no-overwrite) | **Restart** — the wfe library reads env at process start |
+| Plugin extensions | `config_load_plugin_extensions(&cfg)` once | **Restart** |
+| Log level | bound at startup | **Restart** |
+| Vault / master key | opened at startup | **Restart** (by design) |
+
+Two gaps: (1) even the *live* path waits for the mtime cache to miss (no push), and the
+same-second write/read can return stale; (2) the *startup-bound* class silently needs a
+restart with no signal to the user.
+
+## §1 Goals / non-goals
+- **Goal:** a `config set` / Settings save takes effect immediately for every setting that
+  *can* be re-applied live, and returns a clear **"needs restart"** for the few that can't.
+- **Goal:** no polling — the running server is *told* to reload, so effect is immediate.
+- **Non-goal:** hot-swapping things that are genuinely unsafe to change live — the listen
+  **socket path**, the **vault master key**. These stay restart-required, surfaced honestly.
+- **Non-goal:** a new config format or schema — this is about *when* changes apply.
+
+## §2 Design
+
+0. **Precondition (verified): `config_t` is a flat POD.** It holds only ints and fixed
+   `char[]` arrays — no heap pointers — which is why `config_load` already `memcpy`s the whole
+   struct into/out of `g_config_cache` and callers pass their *own* `config_t` buffer and get
+   a **value copy**. So the reader contract is *already* copy-out (no caller holds a pointer
+   into the cache across a call), and the struct is trivially double-bufferable. P1
+   carries an audit confirming no consumer stashes a `config_t*` (or a `char*` into one) past
+   the `config_load` call.
+1. **One reload entrypoint — `config_reload()`.** Re-reads the file, validates it (the same
+   `config_reduce_validate`-style gate, so a bad config is *rejected* and the live config
+   kept), and publishes a new snapshot into a **double buffer** (two fixed `config_t` slots —
+   no malloc, no free, no grace period) guarded by a **seqlock**: the writer fills the
+   inactive slot, bumps a version counter odd, points the active index at it, bumps even;
+   readers load the counter (acquire), copy the active slot, re-load the counter, and **retry
+   if it is odd or changed** — so a reader always gets one coherent snapshot with no
+   per-request lock and nothing to free. `config_reload()` returns the set of keys that
+   changed (semantic diff, see §2.5).
+2. **Push, not poll — `/v1` primary, signal secondary.** The **primary** trigger is a
+   first-class `/v1` `config.reload` op that `config set` and the Settings save handler call,
+   so effect is immediate and works under every supervisor and in headless/cron runs.
+   `SIGHUP` is a **best-effort secondary** (only acts when the process is the direct signal
+   recipient; swallowed/misrouted under systemd/docker/runit multi-process — documented per
+   supervisor, with a debug log on every SIGHUP received). No consumer waits for a cache miss.
+3. **Re-applier registry.** Consumers that hold *derived or bound* state register a re-apply
+   hook keyed by the config sections they depend on; `config_reload()` invokes the hooks
+   whose keys changed. Concrete re-appliers:
+   - **`autonomy.*`** — stop bridging to env at startup only; re-apply on reload (or, better,
+     have the wfe bridge read the live snapshot each run so no env round-trip is needed).
+   - **log level** — set the live logger threshold.
+   - **`aimee.api.bearer_token`** — rotate the accepted bearer live (no re-bind needed).
+   - **TLS cert/key** — reload the cert into the live listener (SNI/ctx swap) without dropping
+     the socket.
+   - **plugin extensions** — re-parse.
+4. **Classification is data, not tribal knowledge.** Each config field carries a
+   **reload class** — `hot` (per-request), `reappliable` (has a hook), or `restart` — in the
+   field table (`config_fields[]`). `config set` / Settings uses it to tell the user exactly
+   what happened: *"applied live"* vs *"needs a restart to take effect."*
+5. **Cache correctness = a content-hash change-token.** Drop mtime-alone (same-second writes
+   are invisible) and sidecar/xattr schemes (atomicity + portability failure modes). The
+   change-token is a **hash of the parsed, normalized config struct** (semantic, not textual).
+   This makes (file, token) consistent *by construction*, is consistent by construction, and gives a
+   free **self-reload no-op guard**: if a reload would produce the same *logical* state as the
+   current snapshot (e.g. `config_save` re-normalized whitespace/key-order), the token is
+   unchanged → skip the swap and skip re-appliers, so a normalizing save never re-runs an
+   expensive re-applier (plugin re-parse). `st_size`+`st_mtim` may be kept only as a fast-path
+   hint before hashing.
+6. **Two-stage commit + per-section failure semantics.** Reload is a *prepare-then-publish*:
+   (a) build a **candidate** `config_t` from the validated file; (b) run each changed
+   section's re-applier against the candidate — a re-applier that **fails writes the section's
+   PRIOR values back into the candidate** (revert-in-place) and records a per-section error;
+   (c) only the *resolved* candidate is published via the seqlock swap. So readers only ever
+   see old → resolved-new, never an intermediate. A validation failure at (a) publishes
+   nothing (running config untouched). A re-applier failure at (b) flips an operator-visible
+   **degraded** flag for that section but the reload **still succeeds for unrelated sections**
+   — a bad cert never downs the server or blocks a log-level change in the same save.
+   Crucially, the stored change-token reflects the **resolved live state** (with reverts), not
+   the file — so a still-broken section differs from the file's logical state and is
+   **retried on the next reload** rather than suppressed as "already seen."
+7. **One process, many threads — no fan-out needed.** aimee's server is a single process with
+   a pthread pool (agent-parallel, compute-pool, HTTP workers) — **not** a prefork/multi-process
+   model, and there is **no cross-host shared config** (each host is independent). So the
+   double-buffer + seqlock live in **ordinary process memory**: every reader thread shares it,
+   a single writer's swap is seen by all, and there is no shared-memory segment, no IPC
+   fan-out, and no cross-process/cross-host coherence problem to solve. (This also drops the
+   segment-perms/secret-exposure concern — there is no second process to leak to.)
+
+## §3 UX
+- `aimee config set K V` prints: `applied live` | `applied live (took effect on N in-flight
+  consumers on next request)` | `saved — needs a server restart to take effect` per the key's
+  reload class.
+- The web **Settings** page shows a per-row badge (**Live** / **Restart**) and, on save,
+  a toast reflecting what actually happened.
+- `aimee config reload` (and `SIGHUP`) force a full reload on demand.
+
+## §4 Phased plan (each roundtable-gated + shippable)
+- **P1 — the reload core.** `config_reload()` + seqlock in-process double-buffer + content-hash
+  token + self-reload guard + validate-or-keep + the `/v1` `config.reload` op (+ best-effort
+  `SIGHUP`); `config set` triggers it. Fixes the *hot* path's push + same-second staleness for
+  all reader threads. No behaviour change for startup-bound keys yet.
+  *Tests:* (a) N concurrent `config_set` + `config_load` under load → no reader sees a torn
+  snapshot (seqlock retry exercised); (b) `kill -9` between `config_save` and the reload
+  signal → next reader/reload recovers a coherent config; (c) an **invalid** written config →
+  reload rejected, the running config unchanged; (d) a normalizing re-save → token unchanged →
+  no-op (re-appliers not re-run).
+- **P2 — reload classification.** Add `reload_class` (`hot`/`reappliable`/`restart`) to
+  `config_fields[]`; surface Live/Restart in `config set` + Settings. Honest immediately, even
+  before every re-applier exists. *Tests:* each field has a class; `config set` prints the
+  right verdict for one field of each class.
+- **P3 — re-appliers, highest-value first.** log level; `aimee.api.bearer_token` rotation;
+  plugin re-parse; and **`autonomy.*`** in two sub-steps: **P3a** a wfe-call-site shim that
+  reads the live snapshot and pushes env at each call (feature-flagged) with a **regression
+  test that changes a knob and observes a behaviour change WITHOUT restart**; **P3b** drop the
+  startup env bridge only *after* confirming the wfe library does not cache env at init (if it
+  does, P3a's live-read gives false confidence — the shim must re-push per call). *Tests:* one
+  reload-and-observe test per re-applier; a re-applier-failure test (one section fails → it
+  reverts + degraded, others still apply).
+- **P4 — TLS live reload.** cert/key swap into the live listener (ctx/SNI swap) without
+  dropping the socket. *Tests:* reload a new cert → new connections use it, in-flight
+  connections unaffected; a bad cert → section reverts, listener stays up on the old cert.
+- **P5 — close-out.** Only the socket **path** and the **vault master key** remain
+  restart-required, documented as deliberate.
+
+## §5 Open items (for roundtable)
+1. The P1 pointer audit (§0): enumerate `config_load` call sites and confirm none retains a
+   `config_t*`/`char*` into the cache past the call (the signature forces copy-out, so this is
+   expected to be clean — but confirm, and consider an opaque-handle guard to keep it clean).
+2. The wfe env-caching question (§P3a/P3b) needs a concrete probe before P3b commits — does the
+   wfe library read env per call or cache it at init?
+3. Seqlock reader cost: `config_load` is called per-request on hot paths; confirm the
+   copy-the-struct-under-seqlock cost is negligible vs today's mtime-cached memcpy (it should
+   be — same memcpy, plus two relaxed counter loads).


### PR DESCRIPTION
Your directive after the economizer close-out: **options should take effect immediately, not "on next server start."**

## The problem (verified)
aimee's effective-config behaviour is **mixed and unsurfaced**. `config_load` is mtime-cached, so per-request consumers (the economizer `reduce.*` levers) *do* hot-reload — but a large class is **bound once at startup** and needs a restart: the `/v1` listener (port/TLS/bearer), `autonomy.*` (env-bridged), plugins, log level, vault. And `config set` doesn't *push* to the running server. So the safe mental model became "restart to be sure."

## The design
- **One `config_reload()`** — re-read + validate-or-keep + publish to an **in-process double-buffer** behind a **seqlock**. (`config_t` is a verified flat POD; `config_load` already copies-out, so value-copy is the existing reader contract — no pointer dangle, no malloc/grace-period.)
- **Push, not poll** — a `/v1` `config.reload` op is the primary trigger from `config set`/Settings; `SIGHUP` is best-effort secondary.
- **Content-hash change-token** (not mtime) + a self-reload no-op guard (a normalizing save doesn't re-run expensive re-appliers).
- **Re-applier registry** — log level, bearer rotation, TLS cert swap, `autonomy.*` live-read, plugin re-parse — via a **two-stage candidate commit**: a failing re-applier reverts its section in place + flips a degraded flag, and the reload still succeeds for unrelated sections.
- **`reload_class`** (`hot`/`reappliable`/`restart`) per field, surfaced to the user as **Live / Restart** — honesty instead of silent deferral.

**Single-process, multi-threaded server** — threads share the double-buffer, so no shared-memory segment, no fan-out, and no cross-host config (you confirmed there's none). Non-goals: the listen **socket path** and **vault master key** stay restart-required, surfaced honestly.

## Review
Design roundtabled over 2 rounds; both blocking items resolved (`config_t` POD value-copy contract; the two-stage commit state machine), then further simplified by your no-shared-config correction. Phased **P1–P5** with per-phase test plans (concurrency / kill-9 / invalid / no-op). `proposal-links-check` green.

Ready to implement P1 (the reload core) slice-by-slice on approval.