### PR TITLE
feat(config): live-reload P1a — config snapshot (double-buffer + seqlock) + config_reload()

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1544,15 +1544,27 @@ int config_snapshot_get(config_t *out)
 
 int config_reload(void)
 {
+   /* Hold the writer lock across the WHOLE reload (load + validate + token + publish) so two
+    * concurrent config_reload callers cannot race each other's config_load on the shared
+    * g_config_cache. NOTE: config_load's g_config_cache is a pre-existing benign racy cache
+    * shared with per-request config_load callers that are NOT under this lock; P1b removes
+    * that exposure by moving the server's hot readers to config_snapshot_get (this seqlock
+    * snapshot), after which config_load is only reached here (serialized) + by CLI one-shots. */
+   pthread_mutex_lock(&g_snap_wlock);
    config_t fresh;
    memset(&fresh, 0, sizeof fresh); /* zero padding so the token is stable */
    if (config_load(&fresh) != 0)
+   {
+      pthread_mutex_unlock(&g_snap_wlock);
       return -1; /* parse failure -> keep the running snapshot */
+   }
    char err[256];
    if (config_reduce_validate(&fresh, err, sizeof err) != 0)
+   {
+      pthread_mutex_unlock(&g_snap_wlock);
       return -1; /* invalid -> keep the running snapshot (validate-or-keep) */
+   }
    uint64_t tok = config_snapshot_token(&fresh);
-   pthread_mutex_lock(&g_snap_wlock);
    if (g_snap_inited && tok == g_snap_token)
    {
       pthread_mutex_unlock(&g_snap_wlock);

--- a/src/config.c
+++ b/src/config.c
@@ -3,7 +3,10 @@
  * The on-disk format is YAML; the in-memory model is still cJSON. The
  * yaml.c shim handles parse/emit so this file's schema-extraction code
  * never sees the format change. */
+#include <pthread.h>
 #include <stdarg.h>
+#include <stdatomic.h>
+#include <stdint.h>
 #include "aimee.h"
 #include "json_fluent.h"
 #include "aimee_home.h"
@@ -1469,4 +1472,93 @@ int config_load(config_t *cfg)
    }
 
    return 0;
+}
+
+/* ---- live config snapshot: double-buffer + seqlock (live-config-reload P1a) ----
+ *
+ * A single writer (config_reload, serialized by g_snap_wlock) publishes a fresh config_t
+ * into the inactive slot of a two-slot double buffer and flips the active index; readers
+ * copy the active slot under a seqlock and retry if a publish raced them. config_t is a
+ * flat POD, so the copy is a plain struct assignment. Additive in P1a — NOT yet wired into
+ * config_load or any push trigger (that is P1b); the infra is here + unit-tested first. */
+static config_t g_snap[2];
+static _Atomic unsigned g_snap_seq = 0;    /* seqlock: even = stable, odd = writing */
+static _Atomic unsigned g_snap_active = 0; /* index (0/1) of the live slot */
+static uint64_t g_snap_token = 0;          /* content-hash of the active snapshot */
+static int g_snap_inited = 0;
+static pthread_mutex_t g_snap_wlock = PTHREAD_MUTEX_INITIALIZER;
+
+/* FNV-1a over the POD bytes. config_t is memset to 0 before every load (below) so padding
+ * is deterministic and the token is stable for a given logical config. */
+static uint64_t config_snapshot_token(const config_t *c)
+{
+   const unsigned char *p = (const unsigned char *)c;
+   uint64_t h = 1469598103934665603ULL;
+   for (size_t i = 0; i < sizeof *c; i++)
+   {
+      h ^= p[i];
+      h *= 1099511628211ULL;
+   }
+   return h;
+}
+
+/* Publish `cfg` into the inactive slot and flip. Caller holds g_snap_wlock (single writer). */
+static void config_snapshot_publish(const config_t *cfg)
+{
+   unsigned s = atomic_load_explicit(&g_snap_seq, memory_order_relaxed);
+   atomic_store_explicit(&g_snap_seq, s + 1, memory_order_release); /* -> odd (writing) */
+   unsigned nxt = atomic_load_explicit(&g_snap_active, memory_order_relaxed) ^ 1u;
+   g_snap[nxt] = *cfg; /* fill the slot no reader is on */
+   atomic_store_explicit(&g_snap_active, nxt, memory_order_release);
+   g_snap_token = config_snapshot_token(cfg);
+   atomic_store_explicit(&g_snap_seq, s + 2, memory_order_release); /* -> even (stable) */
+   g_snap_inited = 1;
+}
+
+void config_snapshot_init(const config_t *cfg)
+{
+   if (!cfg)
+      return;
+   pthread_mutex_lock(&g_snap_wlock);
+   g_snap_token = 0; /* force the first publish */
+   config_snapshot_publish(cfg);
+   pthread_mutex_unlock(&g_snap_wlock);
+}
+
+int config_snapshot_get(config_t *out)
+{
+   if (!out || !g_snap_inited)
+      return -1;
+   for (;;)
+   {
+      unsigned s0 = atomic_load_explicit(&g_snap_seq, memory_order_acquire);
+      if (s0 & 1u)
+         continue; /* a publish is in progress */
+      unsigned act = atomic_load_explicit(&g_snap_active, memory_order_acquire);
+      *out = g_snap[act]; /* POD copy */
+      unsigned s1 = atomic_load_explicit(&g_snap_seq, memory_order_acquire);
+      if (s0 == s1)
+         return 0; /* stable — no publish raced the copy */
+   }
+}
+
+int config_reload(void)
+{
+   config_t fresh;
+   memset(&fresh, 0, sizeof fresh); /* zero padding so the token is stable */
+   if (config_load(&fresh) != 0)
+      return -1; /* parse failure -> keep the running snapshot */
+   char err[256];
+   if (config_reduce_validate(&fresh, err, sizeof err) != 0)
+      return -1; /* invalid -> keep the running snapshot (validate-or-keep) */
+   uint64_t tok = config_snapshot_token(&fresh);
+   pthread_mutex_lock(&g_snap_wlock);
+   if (g_snap_inited && tok == g_snap_token)
+   {
+      pthread_mutex_unlock(&g_snap_wlock);
+      return 0; /* self-reload no-op guard: nothing logically changed */
+   }
+   config_snapshot_publish(&fresh);
+   pthread_mutex_unlock(&g_snap_wlock);
+   return 1; /* a new snapshot was published */
 }

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -740,6 +740,19 @@ void config_parse_fold_section(config_t *cfg, cJSON *root)
  * it, so an exposed flag is never silently inert. All default-off. */
 void config_parse_reduce_section(config_t *cfg, cJSON *root)
 {
+   /* Two-tier economizer switches (P3), colocated `economizer:` block — parsed FIRST, before
+    * the reduce early-return, so a config that sets economizer.* but no reduce.* is honored. */
+   cJSON *econ = cJSON_GetObjectItemCaseSensitive(root, "economizer");
+   if (cJSON_IsObject(econ))
+   {
+      cJSON *e = cJSON_GetObjectItemCaseSensitive(econ, "enabled");
+      if (cJSON_IsBool(e))
+         cfg->economizer_enabled = cJSON_IsTrue(e) ? 1 : 0;
+      e = cJSON_GetObjectItemCaseSensitive(econ, "aggressive");
+      if (cJSON_IsBool(e))
+         cfg->economizer_aggressive = cJSON_IsTrue(e) ? 1 : 0;
+   }
+
    cJSON *reduce = cJSON_GetObjectItemCaseSensitive(root, "reduce");
    if (!cJSON_IsObject(reduce))
       return;
@@ -784,18 +797,6 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
       if (h > FREEZE_GUARD_MAX_HORIZON)
          h = FREEZE_GUARD_MAX_HORIZON; /* clamp at parse so on-disk == runtime */
       cfg->reduce_freeze_guard_horizon = h;
-   }
-
-   /* Two-tier economizer switches (P3), colocated `economizer:` block. */
-   cJSON *econ = cJSON_GetObjectItemCaseSensitive(root, "economizer");
-   if (cJSON_IsObject(econ))
-   {
-      item = cJSON_GetObjectItemCaseSensitive(econ, "enabled");
-      if (cJSON_IsBool(item))
-         cfg->economizer_enabled = cJSON_IsTrue(item) ? 1 : 0;
-      item = cJSON_GetObjectItemCaseSensitive(econ, "aggressive");
-      if (cJSON_IsBool(item))
-         cfg->economizer_aggressive = cJSON_IsTrue(item) ? 1 : 0;
    }
 }
 

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1755,6 +1755,18 @@ static inline int config_issue(const char *fmt, ...)
  * In strict mode, returns -1 on validation errors. */
 int config_load(config_t *cfg);
 
+/* Live config snapshot (live-config-reload P1a) — a double-buffer + seqlock holding the
+ * current config for immediate, push-driven reload. config_t is a flat POD, so reads are a
+ * lock-free struct copy. Additive in P1a: not yet wired into config_load or a push trigger.
+ *   config_snapshot_init  — seed the snapshot from a loaded config (once, at startup).
+ *   config_snapshot_get   — copy the live snapshot into `out` (seqlock read). -1 if uninit.
+ *   config_reload         — re-read the file, VALIDATE-or-keep, and publish only if the
+ *                           content-hash token changed (self-reload no-op guard).
+ *                           Returns 1 = published, 0 = no-op (unchanged), -1 = kept (bad). */
+void config_snapshot_init(const config_t *cfg);
+int config_snapshot_get(config_t *out);
+int config_reload(void);
+
 /* Two-tier economizer resolution (P3) — compute EFFECTIVE lever states without mutating
  * config_t (so config_save always round-trips the raw user values). Precedence:
  * master-kill (economizer.enabled) > aggressive-tier ceiling > individual reduce.* default. */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-snapshot $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -976,6 +976,9 @@ $(TESTPREFIX)/unit-test-config: $(OBJDIR)/tests/test_config.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-config-economizer: $(OBJDIR)/tests/test_config_economizer.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-config-snapshot: $(OBJDIR)/tests/test_config_snapshot.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-msg-session-disable: $(OBJDIR)/tests/test_msg_session_disable.o \

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -1,0 +1,140 @@
+/* test_config_snapshot: the live config snapshot (double-buffer + seqlock) — init/get,
+ * no-op vs changed reload, validate-or-keep, and a concurrent torn-read stress. */
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aimee.h"
+#include "platform_path.h"
+#include "platform_test_util.h"
+
+/* Author a config file with a MARKER PAIR (aggressive, budget) via config_save so reload
+ * observes a real change. The pair is what the torn-read check keys on. */
+static void write_marker(int aggressive, int budget)
+{
+   static config_t c;
+   memset(&c, 0, sizeof c);
+   config_load(&c);
+   /* keep the config VALID regardless of what a prior (deliberately-invalid) test left on
+    * disk, so config_reload's validate-or-keep never rejects a marker write. */
+   c.reduce_gateway_session_disable_ttl_ms = 3600000;
+   c.economizer_aggressive = aggressive;
+   c.coord_closet_budget_bytes = budget;
+   assert(config_save(&c) == 0);
+}
+
+static _Atomic int g_stop = 0;
+static _Atomic long g_reads = 0, g_torn = 0;
+
+/* The two configs written by the writer are {agg=1,budget=1111} and {agg=0,budget=2222};
+ * a reader must never observe a mismatched pair (that would be a torn cross-slot read). */
+static void *reader_thread(void *arg)
+{
+   (void)arg;
+   while (!atomic_load_explicit(&g_stop, memory_order_relaxed))
+   {
+      config_t c;
+      if (config_snapshot_get(&c) != 0)
+         continue;
+      atomic_fetch_add_explicit(&g_reads, 1, memory_order_relaxed);
+      int a = (c.economizer_aggressive == 1 && c.coord_closet_budget_bytes == 1111);
+      int b = (c.economizer_aggressive == 0 && c.coord_closet_budget_bytes == 2222);
+      if (!a && !b)
+         atomic_fetch_add_explicit(&g_torn, 1, memory_order_relaxed);
+   }
+   return NULL;
+}
+
+int main(void)
+{
+   printf("config_snapshot: ");
+   char tmpdir[512];
+   snprintf(tmpdir, sizeof tmpdir, "%s/aimee-test-snap-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(tmpdir) != NULL);
+   char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
+   platform_setenv("HOME", tmpdir);
+   platform_unsetenv("AIMEE_HOME");
+   platform_setenv("AIMEE_NO_CACHE", "1"); /* deterministic file reads for the functional part */
+
+   /* --- get before init -> -1 --- */
+   {
+      config_t c;
+      assert(config_snapshot_get(&c) == -1);
+   }
+
+   /* --- init + get roundtrip --- */
+   write_marker(1, 1111);
+   {
+      static config_t c0;
+      memset(&c0, 0, sizeof c0);
+      config_load(&c0);
+      config_snapshot_init(&c0);
+      config_t got;
+      assert(config_snapshot_get(&got) == 0);
+      assert(got.economizer_aggressive == 1);
+      assert(got.coord_closet_budget_bytes == 1111);
+   }
+
+   /* --- reload with NO change -> no-op (0) --- */
+   assert(config_reload() == 0);
+
+   /* --- reload after a real change -> published (1), snapshot reflects it --- */
+   write_marker(0, 2222);
+   assert(config_reload() == 1);
+   {
+      config_t got;
+      assert(config_snapshot_get(&got) == 0);
+      assert(got.economizer_aggressive == 0);
+      assert(got.coord_closet_budget_bytes == 2222);
+   }
+   /* reloading the same file again is a no-op */
+   assert(config_reload() == 0);
+
+   /* --- validate-or-keep: an INVALID file -> reload -1, snapshot unchanged --- */
+   {
+      const char *path = config_default_path();
+      FILE *fp = fopen(path, "w");
+      assert(fp);
+      /* ttl <= 0 is startup-fatal per config_reduce_validate */
+      fputs("reduce:\n  gateway_session_disable_ttl_ms: 0\n", fp);
+      fclose(fp);
+      assert(config_reload() == -1); /* kept */
+      config_t got;
+      assert(config_snapshot_get(&got) == 0);
+      assert(got.coord_closet_budget_bytes == 2222); /* still the last GOOD snapshot */
+   }
+
+   /* --- concurrent torn-read stress: readers spin while the writer toggles + reloads --- */
+   {
+      platform_unsetenv("AIMEE_NO_CACHE"); /* exercise the real cached read path under threads */
+      write_marker(1, 1111);
+      assert(config_reload() == 1);
+      pthread_t th[4];
+      for (int i = 0; i < 4; i++)
+         assert(pthread_create(&th[i], NULL, reader_thread, NULL) == 0);
+      for (int i = 0; i < 400; i++)
+      {
+         if (i & 1)
+            write_marker(0, 2222);
+         else
+            write_marker(1, 1111);
+         config_reload();
+      }
+      atomic_store_explicit(&g_stop, 1, memory_order_relaxed);
+      for (int i = 0; i < 4; i++)
+         pthread_join(th[i], NULL);
+      assert(atomic_load_explicit(&g_reads, memory_order_relaxed) > 0); /* readers ran */
+      assert(atomic_load_explicit(&g_torn, memory_order_relaxed) == 0); /* no torn reads */
+   }
+
+   if (old_home)
+   {
+      platform_setenv("HOME", old_home);
+      free(old_home);
+   }
+   printf("ok\n");
+   return 0;
+}


### PR DESCRIPTION
First slice of the **live-config-reload** initiative (proposal #1056). Additive infrastructure — **not yet wired** into `config_load` or a push trigger (that's P1b) — plus a real P3 bug this slice's test caught.

## What's new
- **`config_snapshot_init` / `config_snapshot_get` / `config_reload`** — a two-slot **double-buffer guarded by a seqlock**: the writer bumps a version counter odd, fills the inactive slot, flips the active index, bumps even; readers copy the active slot and retry if the counter is odd or changed. `config_t` is a flat POD, so the read is a **lock-free struct copy**.
- `config_reload` = re-read + **validate-or-keep** (`config_reduce_validate`; a bad config keeps the running snapshot) + a **content-hash (FNV-1a) token no-op guard** (a normalizing save that changes nothing doesn't republish). The whole reload runs under a single writer mutex.

## Bug fix (pre-existing P3, caught by this test)
`config_parse_reduce_section` **early-returned when a config had no `reduce:` block** — but the `economizer.enabled/aggressive` parse was at the *end* of that function, so a config that set `economizer.*` but no `reduce.*` was **silently ignored**. Moved the economizer parse *before* the early-return.

## Test
`test_config_snapshot`: init/get roundtrip, no-op vs changed reload, validate-or-keep (invalid file kept), and a **4-thread concurrent torn-read stress** toggling a marker pair through 400 reloads — asserts no reader ever sees a cross-slot torn config.

## Review
Roundtable-reviewed; the **verification pass rejected 17 items** (seqlock design, token stability, parse-move all confirmed sound). The one real blocking — `config_load` called before the lock — fixed by serializing the whole reload under `g_snap_wlock`; the pre-existing `g_config_cache` reader race is documented as resolved in P1b (readers move to `config_snapshot_get`). Full `unit-tests` + line-check green.

Next: P1b — wire `config_snapshot_init` at startup, the `/v1 config.reload` push from `config set`/Settings, and switch the server's hot readers to `config_snapshot_get`.