### PR TITLE
feat(config): live-reload P1b — immediate effect on config set + SIGHUP reload

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -878,7 +878,6 @@ int econ_gateway_mutate_on(const config_t *cfg)
               : 0;
 }
 
-static int config_load_file(config_t *cfg);
 static int config_snapshot_live(void);
 
 /* Public config read. In the SERVER (once config_snapshot_init has seeded the live snapshot)
@@ -893,7 +892,7 @@ int config_load(config_t *cfg)
    return config_load_file(cfg);
 }
 
-static int config_load_file(config_t *cfg)
+int config_load_file(config_t *cfg)
 {
    config_set_defaults(cfg);
 
@@ -1500,15 +1499,14 @@ static config_t g_snap[2];
 static _Atomic unsigned g_snap_seq = 0;    /* seqlock: even = stable, odd = writing */
 static _Atomic unsigned g_snap_active = 0; /* index (0/1) of the live slot */
 static uint64_t g_snap_token = 0;          /* content-hash of the active snapshot */
-static int g_snap_inited = 0;
+static _Atomic int g_snap_inited = 0;      /* atomic so the config_load wrapper's read is visible */
 static pthread_mutex_t g_snap_wlock = PTHREAD_MUTEX_INITIALIZER;
 
 /* 1 once config_snapshot_init has seeded the live snapshot (server context). Read by the
- * config_load wrapper to decide snapshot-vs-file. Set under g_snap_wlock; the plain read is
- * a benign race (0 -> file read, 1 -> snapshot; both valid, and it only transitions 0->1). */
+ * config_load wrapper to decide snapshot-vs-file; only ever transitions 0 -> 1. */
 static int config_snapshot_live(void)
 {
-   return g_snap_inited;
+   return atomic_load_explicit(&g_snap_inited, memory_order_acquire);
 }
 
 /* FNV-1a over the POD bytes. config_t is memset to 0 before every load (below) so padding
@@ -1535,7 +1533,7 @@ static void config_snapshot_publish(const config_t *cfg)
    atomic_store_explicit(&g_snap_active, nxt, memory_order_release);
    g_snap_token = config_snapshot_token(cfg);
    atomic_store_explicit(&g_snap_seq, s + 2, memory_order_release); /* -> even (stable) */
-   g_snap_inited = 1;
+   atomic_store_explicit(&g_snap_inited, 1, memory_order_release);
 }
 
 void config_snapshot_init(const config_t *cfg)
@@ -1550,7 +1548,7 @@ void config_snapshot_init(const config_t *cfg)
 
 int config_snapshot_get(config_t *out)
 {
-   if (!out || !g_snap_inited)
+   if (!out || !atomic_load_explicit(&g_snap_inited, memory_order_acquire))
       return -1;
    for (;;)
    {
@@ -1588,7 +1586,7 @@ int config_reload(void)
       return -1; /* invalid -> keep the running snapshot (validate-or-keep) */
    }
    uint64_t tok = config_snapshot_token(&fresh);
-   if (g_snap_inited && tok == g_snap_token)
+   if (atomic_load_explicit(&g_snap_inited, memory_order_acquire) && tok == g_snap_token)
    {
       pthread_mutex_unlock(&g_snap_wlock);
       return 0; /* self-reload no-op guard: nothing logically changed */

--- a/src/config.c
+++ b/src/config.c
@@ -878,7 +878,22 @@ int econ_gateway_mutate_on(const config_t *cfg)
               : 0;
 }
 
+static int config_load_file(config_t *cfg);
+static int config_snapshot_live(void);
+
+/* Public config read. In the SERVER (once config_snapshot_init has seeded the live snapshot)
+ * this returns the current snapshot — a lock-free POD copy that reflects the last reload
+ * IMMEDIATELY (push-driven), with no file I/O or mtime-cache-miss wait. Everywhere else (CLI
+ * one-shots, and before startup seeds it) it reads the file. config_reload uses the from-file
+ * path directly so a reload always re-reads disk, never the snapshot it is about to replace. */
 int config_load(config_t *cfg)
+{
+   if (config_snapshot_live())
+      return config_snapshot_get(cfg);
+   return config_load_file(cfg);
+}
+
+static int config_load_file(config_t *cfg)
 {
    config_set_defaults(cfg);
 
@@ -1488,6 +1503,14 @@ static uint64_t g_snap_token = 0;          /* content-hash of the active snapsho
 static int g_snap_inited = 0;
 static pthread_mutex_t g_snap_wlock = PTHREAD_MUTEX_INITIALIZER;
 
+/* 1 once config_snapshot_init has seeded the live snapshot (server context). Read by the
+ * config_load wrapper to decide snapshot-vs-file. Set under g_snap_wlock; the plain read is
+ * a benign race (0 -> file read, 1 -> snapshot; both valid, and it only transitions 0->1). */
+static int config_snapshot_live(void)
+{
+   return g_snap_inited;
+}
+
 /* FNV-1a over the POD bytes. config_t is memset to 0 before every load (below) so padding
  * is deterministic and the token is stable for a given logical config. */
 static uint64_t config_snapshot_token(const config_t *c)
@@ -1552,8 +1575,8 @@ int config_reload(void)
     * snapshot), after which config_load is only reached here (serialized) + by CLI one-shots. */
    pthread_mutex_lock(&g_snap_wlock);
    config_t fresh;
-   memset(&fresh, 0, sizeof fresh); /* zero padding so the token is stable */
-   if (config_load(&fresh) != 0)
+   memset(&fresh, 0, sizeof fresh);   /* zero padding so the token is stable */
+   if (config_load_file(&fresh) != 0) /* always re-read DISK, never the snapshot we replace */
    {
       pthread_mutex_unlock(&g_snap_wlock);
       return -1; /* parse failure -> keep the running snapshot */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1766,6 +1766,10 @@ int config_load(config_t *cfg);
 void config_snapshot_init(const config_t *cfg);
 int config_snapshot_get(config_t *out);
 int config_reload(void);
+/* Force a read from DISK, bypassing the live snapshot. Use for a read-modify-save that must
+ * reflect the current on-disk file (e.g. config.set) so it never clobbers an external edit,
+ * and internally by config_reload. Ordinary readers should use config_load. */
+int config_load_file(config_t *cfg);
 
 /* Two-tier economizer resolution (P3) — compute EFFECTIVE lever states without mutating
  * config_t (so config_save always round-trips the raw user values). Precedence:

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -60,6 +60,9 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
+
+/* Defined in server_main.c; set by the SIGHUP handler, observed by the main loop (P1b). */
+extern volatile sig_atomic_t g_config_reload_requested;
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
@@ -2025,6 +2028,15 @@ int server_run(server_ctx_t *ctx)
       struct timespec ts = {.tv_sec = 1, .tv_nsec = 0};
       nanosleep(&ts, NULL);
       webuser_editor_reap_tick();
+      /* SIGHUP requested a config reload (live-config-reload P1b): do it here, off the
+       * signal path, since config_reload takes a mutex and does file I/O. */
+      if (g_config_reload_requested)
+      {
+         g_config_reload_requested = 0;
+         int rc = config_reload();
+         aimee_log(rc < 0 ? LOG_WARN : LOG_INFO, "config", "SIGHUP config reload: %s",
+                   rc > 0 ? "applied" : (rc == 0 ? "no change" : "rejected (kept running config)"));
+      }
    }
    return 0;
 }

--- a/src/server/server_config.c
+++ b/src/server/server_config.c
@@ -97,6 +97,10 @@ int handle_config_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (config_save(&cfg) != 0)
       return server_send_error(conn, "config: could not save configuration", NULL);
 
+   /* Push the change into the live snapshot NOW so it takes effect immediately for every
+    * config_load reader, instead of waiting for an mtime-cache miss (live-config-reload P1b). */
+   (void)config_reload();
+
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "key", key);
    cJSON_AddItemToObject(resp, "value", config_field_value_json(&cfg, f));

--- a/src/server/server_config.c
+++ b/src/server/server_config.c
@@ -87,8 +87,10 @@ int handle_config_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (!f)
       return server_send_error(conn, "config: unknown key", NULL);
 
+   /* Read from DISK (not the live snapshot) for the read-modify-save so a config.set never
+    * clobbers an external edit made to the file since the last reload (live-config-reload P1b). */
    config_t cfg;
-   if (config_load(&cfg) != 0)
+   if (config_load_file(&cfg) != 0)
       return server_send_error(conn, "config: could not load configuration", NULL);
 
    if (config_field_set_value(&cfg, f, value) != 0)

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -89,10 +89,21 @@ static void startup_notify(int fd, const char *message)
    close(fd);
 }
 
+/* Set by SIGHUP (async-signal-safe: just a flag); the server main loop observes it and calls
+ * config_reload() off the signal path (config_reload takes a mutex / does I/O). */
+volatile sig_atomic_t g_config_reload_requested = 0;
+
 #ifndef _WIN32
 static void signal_handler_info(int sig, siginfo_t *info, void *ucontext)
 {
    (void)ucontext;
+#ifdef SIGHUP
+   if (sig == SIGHUP)
+   {
+      g_config_reload_requested = 1; /* reload config, NOT shut down */
+      return;
+   }
+#endif
    (void)shutdown_forensics_record_signal("server", sig, info, g_ctx.start_time,
                                           g_ctx.active_sessions, 0, g_ctx.session_threads);
    g_ctx.running = 0;
@@ -163,7 +174,12 @@ static int run_server(const char *socket_path, log_level_t log_level)
    git_ops_register_session_isolation(session_isolation_target);
 
    config_t cfg;
+   memset(&cfg, 0, sizeof cfg); /* clean padding so the snapshot token is stable */
    config_load(&cfg);
+   /* Seed the live config snapshot (live-config-reload P1b): from here, every config_load in
+    * the server returns this snapshot, and config_reload (on config.set / SIGHUP) republishes
+    * it so changes take effect immediately instead of on the next mtime-cache miss. */
+   config_snapshot_init(&cfg);
 
    /* Bridge the autonomy config knobs to their AIMEE_AUTONOMY_* env vars as early as
     * possible — before any consumer (plugin discovery, the wfe engine) could read them

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1181,6 +1181,12 @@ int config_load(config_t *cfg)
    return 0;
 }
 
+int config_load_file(config_t *cfg)
+{
+   memset(cfg, 0, sizeof(*cfg));
+   return 0;
+}
+
 /* live-config-reload P1b: server_config.c / server.c call config_reload after a config.set
  * and on SIGHUP; stub it here (this test doesn't link the real config.o). */
 int config_reload(void)

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1181,6 +1181,13 @@ int config_load(config_t *cfg)
    return 0;
 }
 
+/* live-config-reload P1b: server_config.c / server.c call config_reload after a config.set
+ * and on SIGHUP; stub it here (this test doesn't link the real config.o). */
+int config_reload(void)
+{
+   return 0;
+}
+
 int config_save(const config_t *cfg)
 {
    (void)cfg;


### PR DESCRIPTION
**Live-config-reload P1b** (proposal #1056), stacked on P1a. Wires the reload core so **config changes take effect immediately** on the running server.

## Live-verified
- `config set economizer.aggressive true` → `config get` on the **same running server** returns **`true`** at once (before: stale until restart).
- **SIGHUP reloads instead of shutting the server down** (the server stays alive).

## What's wired
- **`config_load` is now a thin wrapper**: in the server (once `config_snapshot_init` seeded the snapshot) it returns the live snapshot — a lock-free POD copy reflecting the last reload immediately. CLI one-shots + pre-init read the file. `config_reload` uses the from-disk path. This also **resolves the pre-existing `g_config_cache` reader race** (in the server, the file path is reached only via `config_reload`, serialized).
- **Startup**: `config_snapshot_init(&cfg)` after the initial load.
- **config.set handler**: reads from **disk** (`config_load_file`) for the read-modify-save — so it never clobbers an external file edit — then `config_save` + `config_reload()`.
- **SIGHUP**: sets an async-signal-safe flag; the 1s main loop calls `config_reload()` off the signal path and logs applied/no-change/rejected. (SIGHUP=reload is the conventional daemon semantic; SIGTERM/SIGINT still shut down.)

## Review
Roundtable-reviewed; both blocking items fixed — **disk-fresh RMW** for config.set (no clobber) and **`g_snap_inited` made `_Atomic`** (acquire/release). config.set RMW *concurrency* is pre-existing (it was read-modify-save before P1b) and noted out of scope. Full `unit-tests` + line-check green; live smoke confirms immediate effect + SIGHUP-reload-not-shutdown.

Next: P2 (reload_class Live/Restart classification) → P3 (re-appliers: log level, bearer, autonomy, plugins) → P4 (TLS) → P5 (close-out).