### PR TITLE
feat(webui): server-incurred dashboard metrics, customization, and Logs page

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1223,7 +1223,15 @@ selects its own git **project** to operate on:
 - **Chat**, the agent conversation (streamed over SSE). The selected project
   becomes the agent's working directory; webchat scope-validates it to the
   signed-in user's own workspace.
-- **Dashboard**, memory, reminders, and onboarding panels.
+- **Dashboard**, a customizable grid of **server-incurred** metric panels
+  (delegations, metrics, token/cost, guardrail actions, agents, sessions,
+  readiness, and more). Toggle/reorder panels via **⚙ Customize**
+  (persisted per-browser). See [`docs/DASHBOARD.md`](docs/DASHBOARD.md).
+- **Logs**, the server's tool-action audit ledger — one row per tool call with
+  its guardrail verdict (`allow`/`block`/`rewrite`/`approval_required`),
+  filterable by verdict/actor/tool. (`aimee-kb` keeps its own dashboard for
+  KB-internal events.)
+- **Workflow Actions**, author and track [workflow](docs/WORKFLOWS.md) runs.
 - **Edit Workflows**, a visual composer for [workflow](docs/WORKFLOWS.md)
   definitions (blocks rail, graph canvas, per-step persona/delegate assignment,
   plus a persona manager). Validate/Save persist server-side.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Focused references:
 | [Personas](docs/personas.md) | Built in and custom agent identities, delegate policy, and how personas staff reviews |
 | [Workflows](docs/WORKFLOWS.md) | The composable dev lifecycle workflow engine, block catalog, and authoring |
 | [Workflow Actions](docs/WORKFLOW_ACTIONS.md) | The web page to author a proposal, run it autonomously, and watch its status/history |
+| [Dashboard & Logs](docs/DASHBOARD.md) | The web Dashboard's server-incurred metric panels, customization, the Logs (tool-action audit) tab, and the panel data architecture |
 | [Settings](docs/SETTINGS.md) | The web page for the server's typed runtime config — economizer levers, autonomous-dev knobs, tool-output condensation, and how each maps to `aimee.yaml` |
 | [Workspace Management](docs/WORKSPACES.md) | Multi repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -2096,6 +2096,10 @@ paths:
     get:
       summary: Full dashboard snapshot
       responses: { "200": { description: Dashboard, content: { application/json: { schema: { type: object } } } } }
+  /dashboard/audit:
+    get:
+      summary: Tool-action audit ledger (guardrail verdicts) for the Logs page
+      responses: { "200": { description: Audit, content: { application/json: { schema: { type: object } } } } }
   /dashboard/delegations:
     get:
       summary: Delegation dashboard

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,0 +1,136 @@
+# Dashboard & Logs (browser UI)
+
+The **Dashboard** and **Logs** tabs of [`aimee-webchat`](../MANUAL.md#23-webchat-and-the-browser-ui)
+give an operator an at-a-glance view of what **`aimee-server`** is doing. They
+are served by the webchat thin client (default `https://<host>:8443`) which
+holds no state and proxies to `aimee-server` over its `/v1` HTTP surface.
+
+## Design principle: server-incurred metrics only
+
+The dashboard shows **things aimee-server incurs** — its delegations, tool
+calls, token spend, guardrail verdicts, configured agents, active sessions, and
+readiness. It deliberately does **not** monitor `aimee-kb`-internal events
+(memory-curation audits, KB decision logs). **`aimee-kb` has its own dashboard**
+for those; duplicating them here would blur the boundary between the two
+services. The one exception is a state overview the server relies on — the
+**Memory** panel (tier counts) — which is available but off by default.
+
+A field is "server-incurred" if the server's own agents/workflows produce it,
+even when the record is physically stored behind the KB (e.g. delegate token
+spend). It is *not* server-incurred if the KB curator produces it.
+
+## Tabs
+
+### Dashboard (`/dashboard`)
+
+A customizable grid of metric panels. The default set fills the viewport in a
+clean 3-column layout; you add more from a catalog via **⚙ Customize**.
+
+### Logs (`/logs`)
+
+The server's **tool-action audit ledger** — one row per tool call the agent
+makes, with the guardrail **verdict** (`allow` / `block` / `rewrite` /
+`approval_required`), the actor (`primary` / `delegate`), the tool, mode, and
+reason. Filter by verdict, actor, or tool name. This is `aimee-server`'s own
+audit stream (`/var/lib/aimee/audit.log` via `audit_ledger_read`), **not** the
+KB's logs.
+
+## Panels
+
+Every panel is derived from data the server incurs. Panels marked *default* are
+shown out of the box; the rest are opt-in via **⚙ Customize**.
+
+| Panel | Default | Source |
+|-------|:------:|--------|
+| Readiness | ✓ | Synthesized health report (`onboard`) — DB/agents/delegations/LSP |
+| Agents | ✓ | Configured provider roster (`agents`) |
+| Active Sessions | ✓ | Live webchat sessions (injected by webchat) |
+| Delegations | ✓ | Recent delegations (`delegations`) with human-formatted latency |
+| Metrics | ✓ | Per-role totals/success/latency/tokens (`metrics`) |
+| Cost / Tokens | ✓ | Realized token spend rolled up per role (`token_audit`) |
+| Guardrail Actions | ✓ | Verdict mix over the tool-action audit (`audit`) |
+| Execution Plans | ✓ | Active execution plans (`plans`) |
+| Traces | ✓ | Recent tool-call traces (`traces`) |
+| Success by Agent | — | Success rate + volume per agent (from `delegations`) |
+| Latency by Role | — | p50 / p95 / max per role (from `delegations`) |
+| Top Tools | — | Most-invoked tools (from `traces`) |
+| Tokens by Agent | — | Token spend per agent (from `token_audit`) |
+| Cache Efficiency | — | Cache-read share of input tokens (from `token_audit`) |
+| Failures | — | Recent unsuccessful delegations (from `delegations`) |
+| Provider Mix | — | Configured agents grouped by provider (from `agents`) |
+| Confidence | — | Average delegate confidence per role (from `delegations`) |
+| Memory | — | Memory tier/kind counts (`memory_stats.tier_kinds`) — a KB state overview |
+| LSP Health | — | LSP diagnostics summary (`lsp`) |
+
+Latency is rendered human-readably (`482ms`, `4.7s`, `2m 7s`), not raw
+milliseconds; token counts are compact (`4.4M`); cost is USD with a sub-cent
+floor (`<$0.01`).
+
+## Customization
+
+Click **⚙ Customize** (top-right of the Dashboard) to toggle any panel on/off
+and reorder the enabled ones (↑/↓). **Reset** restores the defaults.
+
+The layout is persisted in the browser's `localStorage` under
+`aimee_dash_layout_v1` (an ordered list of panel ids). It is therefore
+**per-browser**, not per-user across devices; a server-persisted layout would be
+a future enhancement.
+
+## Layout & sizing
+
+The dashboard fills its pane **exactly** (`box-sizing: border-box`; no
+negative-margin hacks). The grid is `repeat(3, minmax(0, 1fr))` columns with
+`minmax(200px, 1fr)` rows, so:
+
+- it **never** scrolls horizontally;
+- with the default panel count it fits the viewport with no scrollbar;
+- if you add enough panels to exceed the viewport, only the grid scrolls
+  vertically.
+
+## Data architecture
+
+```
+browser ──/api/dashboard──> aimee-webchat ──dashboard.all──> aimee-server
+        <────── JSON ───────              <──── payload ─────
+browser ──/api/audit───────> aimee-webchat ──dashboard.audit─> aimee-server
+```
+
+### `dashboard.all` (the `/api/dashboard` payload)
+
+Built by `handle_dashboard_all` (`src/server/server_state.c`). Server-incurred
+fields: `delegations`, `metrics`, `traces`, `plans`, `agents`, `token_audit`,
+`decisions`, `memory_stats`, `lsp`, plus a synthesized `onboard` readiness
+report and a recent `audit` summary (last 300 tool-action rows). The webchat's
+`handleDashboardAll` then injects `sessions` (webchat-owned) before returning.
+
+### `dashboard.audit` (the `/api/audit` payload, Logs page)
+
+Backed by the `dashboard.audit` dispatch method → `/v1/dashboard/audit` route →
+`audit_ledger_read`, returning up to 5000 most-recent tool-action rows.
+
+### Frontend normalization contract
+
+The server returns some fields in shapes a panel cannot consume directly
+(`memory_stats` is an object whose rows live under `tier_kinds`; `onboard` may
+be an `{error}` stub; `agents` is the config roster). `toDashData` in
+`frontend/src/pages/Dashboard.tsx` normalizes the raw payload into the panel
+shapes. That contract is unit-tested against a **captured live payload** in
+`frontend/src/pages/Dashboard.test.ts` (run `npm test` in `frontend/`), so a
+server shape change that would blank a panel fails a test instead.
+
+## Adding a panel (developer note)
+
+Panels are a registry in `Dashboard.tsx`. To add one:
+
+1. Write a `function MyPanel({ data }: { data: T[] }) { … }` deriving its view
+   from an existing `DashData` field (prefer deriving over adding server
+   fields).
+2. Add an entry to the `PANELS` array: `{ id, title, defaultOn, render }`.
+3. If it needs a new server-incurred field, add it to `dashboard.all`
+   (`handle_dashboard_all`), thread it through `RawDashboard` + `DashData` +
+   `toDashData`, and extend the fixture/tests.
+
+Adding a new `/v1` route (as `dashboard.audit` did) also requires:
+`scripts/gen-cli-v1-routes.py` (regenerates `src/cli_v1_routes_d.c`) and an
+entry in `api/openapi-server-v1.yaml`; verify with
+`scripts/check-cli-v1-routes.py` and `scripts/check-api-conformance-server.py`.

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -11,6 +11,15 @@ Thin-client + credential hardening, the client owns the working tree; agent
 credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).
 
+- **Dashboard overhaul + Logs tab**: the web UI **Dashboard** is now a customizable
+  grid of **server-incurred** metric panels — delegations, per-role metrics, token/cost,
+  guardrail actions, agents, active sessions, readiness, plus opt-in panels (success by
+  agent, latency percentiles, top tools, cache efficiency, failures, provider mix,
+  confidence). Toggle/reorder panels via **⚙ Customize** (persisted per-browser); latency
+  and token counts are human-formatted; the grid fills the pane with no scrollbars. The
+  audit/log view moved to its own **Logs** tab backed by the server's tool-action audit
+  ledger (`aimee-kb` keeps its own dashboard for KB-internal events). See
+  [DASHBOARD.md](DASHBOARD.md).
 - **Web Settings page for the full typed config**: the web UI **⚙️ Settings** page
   (`/settings`) edits every allowlisted runtime config field — grouped, filterable, with
   per-field save/reset — over the same `config.show`/`config.set` surface as the CLI. Newly

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,8 @@
         "@vitejs/plugin-react": "^4.4.1",
         "typescript": "~5.8.3",
         "vite": "^6.3.1",
-        "vite-plugin-singlefile": "^2.0.1"
+        "vite-plugin-singlefile": "^2.0.1",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1087,6 +1088,12 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1127,6 +1134,22 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1170,6 +1193,121 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1249,6 +1387,15 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1294,6 +1441,12 @@
       "version": "1.5.376",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
       "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
+      "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true
     },
     "node_modules/esbuild": {
@@ -1344,6 +1497,24 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1446,6 +1617,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -1503,6 +1683,25 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1677,6 +1876,12 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1684,6 +1889,33 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1700,6 +1932,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -1850,6 +2091,111 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "build:console": "tsc -b && vite build --config vite.console.config.ts",
-    "check": "tsc -b"
+    "check": "tsc -b",
+    "test": "vitest run"
   },
   "dependencies": {
     "@rakuensoftware/smoothgui": "file:vendor/rakuensoftware-smoothgui-0.6.0.tgz",
@@ -21,6 +22,7 @@
     "@vitejs/plugin-react": "^4.4.1",
     "typescript": "~5.8.3",
     "vite": "^6.3.1",
-    "vite-plugin-singlefile": "^2.0.1"
+    "vite-plugin-singlefile": "^2.0.1",
+    "vitest": "^4.1.9"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Routes, Route, Navigate, NavLink, useLocation } from 'react-router-dom'
 import { Toast } from '@rakuensoftware/smoothgui';
 import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
+import Logs from './pages/Logs';
 import EditWorkflows from './pages/EditWorkflows';
 import WorkflowActions from './pages/WorkflowActions';
 import Agents from './pages/Agents';
@@ -66,6 +67,7 @@ type Tab = { label: string; icon: string; route: string };
 const NAV_ITEMS: Tab[] = [
   { label: 'Chat', icon: '💬', route: '/chat' },
   { label: 'Dashboard', icon: '📊', route: '/dashboard' },
+  { label: 'Logs', icon: '📜', route: '/logs' },
   { label: 'Edit Workflows', icon: '🔀', route: '/edit-workflows' },
   { label: 'Workflow Actions', icon: '📝', route: '/workflow-actions' },
   { label: 'Agents', icon: '🤝', route: '/agents' },
@@ -241,6 +243,7 @@ export default function App() {
               <Routes>
                 <Route path="/chat" element={<Chat />} />
                 <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/logs" element={<Logs />} />
                 <Route path="/edit-workflows" element={<EditWorkflows />} />
                 <Route path="/workflow-actions" element={<WorkflowActions />} />
                 <Route path="/agents" element={<Agents />} />

--- a/frontend/src/pages/Dashboard.test.ts
+++ b/frontend/src/pages/Dashboard.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { toDashData, fmtDuration, fmtCompact, fmtUsd } from './Dashboard';
+import live from './__fixtures__/dashboard-all.json';
+
+/**
+ * Regression guard for the dashboard data contract.
+ *
+ * The server (`dashboard.all`) returns several fields in shapes that do NOT
+ * match a panel's row type: `memory_stats` is an OBJECT whose per-kind rows
+ * live under `tier_kinds`, `agents` is the provider-config roster (not a live
+ * presence feed), and `onboard` is an `{error}` stub on the server-hosted
+ * webchat. Earlier the transform silently coerced these to empty, so the
+ * Memory and Agents panels rendered blank even though the server had data.
+ *
+ * These tests feed `toDashData` the REAL captured payload and assert the
+ * panels receive populated, correctly-shaped rows.
+ */
+describe('toDashData — server payload contract', () => {
+  const d = toDashData(live as unknown as Parameters<typeof toDashData>[0]);
+
+  it('populates Memory from the memory_stats object (tier_kinds), not the raw array', () => {
+    // memory_stats arrives as an object, but memory rows must be non-empty.
+    expect(Array.isArray(d.memory)).toBe(true);
+    expect(d.memory.length).toBeGreaterThan(0);
+    const row = d.memory[0];
+    expect(row).toHaveProperty('tier');
+    expect(row).toHaveProperty('kind');
+    expect(typeof row.count).toBe('number');
+    // Total recorded memories should be reflected, not dropped to zero.
+    const total = d.memory.reduce((n, r) => n + (r.count || 0), 0);
+    expect(total).toBeGreaterThan(0);
+  });
+
+  it('populates Agents from the config roster shape (provider/model/roles/enabled)', () => {
+    expect(d.agents.length).toBeGreaterThan(0);
+    const a = d.agents[0];
+    expect(a.name).toBeTruthy();
+    expect(a.provider).toBeTruthy();
+    expect(a.model).toBeTruthy();
+    expect(Array.isArray(a.roles)).toBe(true);
+    // The panel keys its status dot on `enabled`; the field must survive.
+    expect(typeof a.enabled).toBe('boolean');
+  });
+
+  it('keeps the panels that already matched populated', () => {
+    expect(d.delegations.length).toBeGreaterThan(0);
+    expect(d.metrics.length).toBeGreaterThan(0);
+    expect(d.traces.length).toBeGreaterThan(0);
+    expect(d.plans.length).toBeGreaterThan(0);
+  });
+
+  it('populates the new Cost / Tokens panel from token_audit', () => {
+    expect(d.tokenAudit.length).toBeGreaterThan(0);
+    const t = d.tokenAudit[0];
+    expect(t).toHaveProperty('role');
+    expect(typeof t.prompt_tokens).toBe('number');
+    expect(typeof t.estimated_cost_usd).toBe('number');
+  });
+
+  it('populates the new Governance panel from decisions', () => {
+    expect(d.decisions.length).toBeGreaterThan(0);
+    const dec = d.decisions[0];
+    expect(dec.chosen).toBeTruthy();
+    expect(dec).toHaveProperty('outcome');
+    expect(dec).toHaveProperty('rationale');
+  });
+
+  it('populates the guardrail audit (server-incurred tool-action verdicts)', () => {
+    expect(d.audit.length).toBeGreaterThan(0);
+    const a = d.audit[0];
+    expect(a).toHaveProperty('verdict');
+    expect(a).toHaveProperty('tool');
+    expect(a).toHaveProperty('actor');
+  });
+
+  it('populates the new Active Sessions panel', () => {
+    expect(Array.isArray(d.sessions)).toBe(true);
+    expect(d.sessions.length).toBeGreaterThan(0);
+    expect(d.sessions[0]).toHaveProperty('cwd');
+  });
+
+  it('surfaces a real readiness report (steps present, not the {error} stub)', () => {
+    expect(d.onboard).not.toBeNull();
+    expect(d.onboard?.steps.length).toBeGreaterThan(0);
+  });
+
+  it('normalizes the lsp object without throwing', () => {
+    expect(d.lsp).not.toBeUndefined();
+  });
+});
+
+describe('toDashData — defensive coercion', () => {
+  it('handles a null/empty payload without throwing', () => {
+    const d = toDashData(null);
+    expect(d.memory).toEqual([]);
+    expect(d.agents).toEqual([]);
+    expect(d.delegations).toEqual([]);
+    expect(d.onboard).toBeNull();
+    expect(d.lsp).toBeNull();
+    expect(d.tokenAudit).toEqual([]);
+    expect(d.decisions).toEqual([]);
+    expect(d.sessions).toEqual([]);
+  });
+
+  it('tolerates memory_stats delivered as a legacy flat array', () => {
+    const d = toDashData({ memory_stats: [{ tier: 'L0', kind: 'fact', count: 2 }] });
+    expect(d.memory).toHaveLength(1);
+    expect(d.memory[0].count).toBe(2);
+  });
+
+  it('accepts a real onboard report (with steps) instead of nulling it', () => {
+    const d = toDashData({
+      onboard: { version: '1', ready: true, elapsed_ms: 5, steps: [{ step: 'db', status: 'ok' }], next_actions: [] },
+    });
+    expect(d.onboard).not.toBeNull();
+    expect(d.onboard?.steps).toHaveLength(1);
+  });
+});
+
+describe('formatters', () => {
+  it('fmtDuration renders human-readable durations, not raw ms', () => {
+    expect(fmtDuration(482)).toBe('482ms');
+    expect(fmtDuration(4662)).toBe('4.7s');
+    expect(fmtDuration(42027)).toBe('42s');
+    expect(fmtDuration(127428)).toBe('2m 7s'); // the "ridiculous 127248ms" case
+    expect(fmtDuration(-1)).toBe('—');
+  });
+
+  it('fmtCompact abbreviates large token counts', () => {
+    expect(fmtCompact(240)).toBe('240');
+    expect(fmtCompact(6250)).toBe('6.3k');
+    expect(fmtCompact(4380809)).toBe('4.4M');
+  });
+
+  it('fmtUsd formats cost with a sub-cent floor', () => {
+    expect(fmtUsd(0)).toBe('$0.00');
+    expect(fmtUsd(0.001)).toBe('<$0.01');
+    expect(fmtUsd(4.21)).toBe('$4.21');
+  });
+});

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ interface Delegation {
   turns: number;
   tool_calls: number;
   latency_ms: number;
+  confidence?: number;
 }
 
 interface Metric {
@@ -29,6 +30,7 @@ interface Trace {
 
 interface MemoryStat {
   tier: string;
+  functional_name?: string;
   kind: string;
   count: number;
 }
@@ -56,32 +58,57 @@ interface LspStatus {
   active_servers: number;
 }
 
-interface PluginFailure {
-  timestamp: string;
-  phase: string;
-  hook: string;
-  rc: number;
-  detail: string;
-}
-
-interface PluginMetrics {
-  installed: number;
-  enabled: number;
-  hooks_total: number;
-  tools_total: number;
-  hook_runs_24h: number;
-  hook_failures_24h: number;
-  recent_failures: PluginFailure[];
-}
-
+// The server-hosted dashboard reports the configured agent roster (from
+// `server_agent_list_json`), not a live presence feed — so these are provider
+// config rows, keyed on `enabled`, not heartbeat/slot state.
 interface Agent {
   name: string;
-  family: string;
-  slot: number;
-  state: 'pending' | 'active' | 'idle' | 'offline';
+  provider?: string;
+  model?: string;
+  enabled?: boolean;
+  tools_enabled?: boolean;
+  roles?: string[];
+  personas?: string[];
+}
+
+interface TokenAudit {
+  tool_name: string;
   role: string;
-  registered_at: number;
-  last_heartbeat: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  cache_write_tokens: number;
+  cache_read_tokens: number;
+  estimated_cost_usd: number;
+  call_count: number;
+  last_seen: string;
+}
+
+interface Decision {
+  id: number;
+  options: string;
+  chosen: string;
+  rationale: string;
+  outcome: string;
+  created_at: string;
+}
+
+interface Session {
+  id: string;
+  title: string;
+  cwd: string;
+  created_at: string;
+  last_active: string;
+}
+
+// Server-incurred guardrail audit: a verdict on every tool action the agent takes.
+interface AuditRow {
+  ts: string;
+  actor: string;   // primary | delegate
+  tool: string;
+  mode?: string;
+  reason_code?: string;
+  verdict: string; // allow | block | rewrite | approval_required
+  task_id?: number;
 }
 
 interface OnboardStep {
@@ -107,10 +134,39 @@ interface DashData {
   memory: MemoryStat[];
   plans: Plan[];
   logs: LogEntry[];
-  plugins: PluginMetrics;
   lsp: LspStatus | null;
   agents: Agent[];
   onboard: OnboardReport | null;
+  tokenAudit: TokenAudit[];
+  decisions: Decision[];
+  sessions: Session[];
+  audit: AuditRow[];
+}
+
+/* The server (`dashboard.all`) returns some fields in shapes the panels can't
+ * consume directly: `memory_stats` is an object whose per-kind rows live under
+ * `tier_kinds`, `onboard` may be an `{error}` stub, and `agents` is the config
+ * roster. `RawDashboard` types that wire payload; `toDashData` normalizes it. */
+interface RawMemoryStats {
+  tier_kinds?: MemoryStat[];
+  tiers?: unknown;
+  scopes?: unknown;
+}
+
+interface RawDashboard {
+  delegations?: Delegation[];
+  metrics?: Metric[];
+  traces?: Trace[];
+  memory_stats?: RawMemoryStats | MemoryStat[];
+  plans?: Plan[];
+  logs?: LogEntry[];
+  lsp?: LspStatus;
+  agents?: Agent[];
+  onboard?: (OnboardReport & { error?: string }) | { error: string };
+  token_audit?: TokenAudit[];
+  decisions?: Decision[];
+  sessions?: Session[];
+  audit?: AuditRow[];
 }
 
 /* ---- Helpers ---- */
@@ -128,6 +184,68 @@ function planVariant(status: string): BadgeVariant {
   if (status === 'done') return 'success';
   if (status === 'failed') return 'error';
   return 'running';
+}
+
+/* Human-readable duration. Raw milliseconds (e.g. "127428ms") read as broken for
+ * multi-second LLM delegations, so format as ms / s / m+s. */
+export function fmtDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(s < 10 ? 1 : 0)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s - m * 60);
+  return `${m}m ${rem}s`;
+}
+
+/* Compact token / count formatting: 4380809 -> "4.4M", 6250 -> "6.3k". */
+export function fmtCompact(n: number): string {
+  if (!Number.isFinite(n)) return '0';
+  const abs = Math.abs(n);
+  if (abs >= 1e9) return `${(n / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `${(n / 1e6).toFixed(1)}M`;
+  if (abs >= 1e3) return `${(n / 1e3).toFixed(1)}k`;
+  return String(Math.round(n));
+}
+
+/* USD cost: sub-cent shows "<$0.01", else two decimals. */
+export function fmtUsd(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '$0.00';
+  if (n < 0.01) return '<$0.01';
+  return `$${n.toFixed(n < 100 ? 2 : 0)}`;
+}
+
+const arr = <T,>(v: unknown): T[] => (Array.isArray(v) ? (v as T[]) : []);
+
+/* Normalize the raw `dashboard.all` payload into the shapes the panels render.
+ * Exported so the contract (server shape -> panel shape) is unit-tested against
+ * a captured live payload — the panels themselves stay dumb over clean data. */
+export function toDashData(raw: RawDashboard | null | undefined): DashData {
+  const r = raw ?? {};
+  // `memory_stats` is an object with rows under `tier_kinds` (per tier+kind),
+  // but a legacy/plain array is tolerated too.
+  const memRaw = r.memory_stats;
+  const memory = Array.isArray(memRaw) ? memRaw : arr<MemoryStat>(memRaw?.tier_kinds);
+  // Only a real onboard report (with a `steps` array) is renderable; the
+  // server's `{error: …}` stub falls back to null.
+  const onboard = r.onboard;
+  return {
+    delegations: arr<Delegation>(r.delegations),
+    metrics: arr<Metric>(r.metrics),
+    traces: arr<Trace>(r.traces),
+    memory,
+    plans: arr<Plan>(r.plans),
+    logs: arr<LogEntry>(r.logs),
+    lsp: r.lsp ?? null,
+    agents: arr<Agent>(r.agents),
+    onboard: Array.isArray((onboard as OnboardReport | undefined)?.steps)
+      ? (onboard as OnboardReport)
+      : null,
+    tokenAudit: arr<TokenAudit>(r.token_audit),
+    decisions: arr<Decision>(r.decisions),
+    sessions: arr<Session>(r.sessions),
+    audit: arr<AuditRow>(r.audit),
+  };
 }
 
 /* ---- Shared table styles ---- */
@@ -148,15 +266,6 @@ const tdStyle: React.CSSProperties = {
 
 const numTd: React.CSSProperties = { ...tdStyle, textAlign: 'right', fontVariantNumeric: 'tabular-nums' };
 
-const filterButtonStyle: React.CSSProperties = {
-  padding: '2px 8px',
-  borderRadius: '999px',
-  border: '1px solid #ddd',
-  background: '#fff',
-  color: '#666',
-  cursor: 'pointer',
-  fontSize: '11px',
-};
 
 /* ---- Panels ---- */
 
@@ -181,7 +290,7 @@ function DelegationsPanel({ data }: { data: Delegation[] }) {
               </td>
               <td style={numTd}>{r.turns}</td>
               <td style={numTd}>{r.tool_calls}</td>
-              <td style={numTd}>{r.latency_ms}ms</td>
+              <td style={numTd} title={`${r.latency_ms}ms`}>{fmtDuration(r.latency_ms)}</td>
             </tr>
           ))}
         </tbody>
@@ -207,8 +316,8 @@ function MetricsPanel({ data }: { data: Metric[] }) {
               <td style={tdStyle}>{e(r.role)}</td>
               <td style={numTd}>{r.total}</td>
               <td style={numTd}>{r.successes}</td>
-              <td style={numTd}>{r.avg_latency_ms}ms</td>
-              <td style={numTd}>{r.tokens}</td>
+              <td style={numTd} title={`${r.avg_latency_ms}ms`}>{fmtDuration(r.avg_latency_ms)}</td>
+              <td style={numTd} title={`${r.tokens} tokens`}>{fmtCompact(r.tokens)}</td>
             </tr>
           ))}
         </tbody>
@@ -270,159 +379,124 @@ function TracesPanel({ data }: { data: Trace[] }) {
 function MemoryPanel({ data }: { data: MemoryStat[] }) {
   return (
     <Panel title="Memory">
-      <table style={tableStyle}>
-        <thead>
-          <tr>
-            {['Tier', 'Kind', 'Count'].map(h => <th key={h} style={thStyle}>{h}</th>)}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((r, i) => (
-            <tr key={i}>
-              <td style={tdStyle}>{e(r.tier)}</td>
-              <td style={tdStyle}>{e(r.kind)}</td>
-              <td style={numTd}>{r.count}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </Panel>
-  );
-}
-
-function PluginsPanel({
-  data,
-  onViewFailures,
-}: {
-  data: PluginMetrics;
-  onViewFailures: () => void;
-}) {
-  const failureColor = data.hook_failures_24h > 0 ? '#ff6b6b' : '#4caf50';
-
-  return (
-    <Panel title="Plugins" count={data.installed}>
-      <div style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: '10px', fontSize: '12px' }}>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
-          <div style={{ padding: '8px', border: '1px solid #eee', borderRadius: '6px', background: '#fafafa' }}>
-            <div style={{ color: '#888', fontSize: '11px' }}>Installed</div>
-            <div style={{ color: '#333', fontSize: '18px', fontWeight: 600 }}>{data.installed}</div>
-          </div>
-          <div style={{ padding: '8px', border: '1px solid #eee', borderRadius: '6px', background: '#fafafa' }}>
-            <div style={{ color: '#888', fontSize: '11px' }}>Enabled</div>
-            <div style={{ color: '#333', fontSize: '18px', fontWeight: 600 }}>{data.enabled}</div>
-          </div>
+      {data.length === 0 ? (
+        <div style={{ padding: '12px', color: '#aaa', fontSize: '12px' }}>
+          No memories recorded
         </div>
-        <table style={{ fontSize: '12px', width: '100%', borderCollapse: 'collapse' }}>
+      ) : (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              {['Tier', 'Kind', 'Count'].map(h => <th key={h} style={thStyle}>{h}</th>)}
+            </tr>
+          </thead>
           <tbody>
-            <tr>
-              <td style={{ color: '#888', padding: '2px 8px 2px 0' }}>Hooks registered</td>
-              <td style={{ color: '#ccc', textAlign: 'right' }}>{data.hooks_total}</td>
-            </tr>
-            <tr>
-              <td style={{ color: '#888', padding: '2px 8px 2px 0' }}>Tools registered</td>
-              <td style={{ color: '#ccc', textAlign: 'right' }}>{data.tools_total}</td>
-            </tr>
-            <tr>
-              <td style={{ color: '#888', padding: '2px 8px 2px 0' }}>Last 24h hook runs</td>
-              <td style={{ color: '#ccc', textAlign: 'right' }}>{data.hook_runs_24h}</td>
-            </tr>
-            <tr>
-              <td style={{ color: '#888', padding: '2px 8px 2px 0' }}>Last 24h failures</td>
-              <td style={{ color: failureColor, textAlign: 'right', fontWeight: 600 }}>{data.hook_failures_24h}</td>
-            </tr>
+            {data.map((r, i) => (
+              <tr key={i}>
+                <td style={tdStyle}>
+                  {e(r.tier)}
+                  {r.functional_name ? (
+                    <span style={{ color: '#aaa', marginLeft: '6px' }}>{e(r.functional_name)}</span>
+                  ) : null}
+                </td>
+                <td style={tdStyle}>{e(r.kind)}</td>
+                <td style={numTd}>{r.count}</td>
+              </tr>
+            ))}
           </tbody>
         </table>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px' }}>
-          <span style={{ color: failureColor, fontWeight: 600 }}>
-            {data.hook_failures_24h > 0 ? 'Hook failures need review' : 'Hooks look clean'}
-          </span>
-          <button
-            onClick={onViewFailures}
-            disabled={data.hook_failures_24h === 0}
-            style={{
-              ...filterButtonStyle,
-              opacity: data.hook_failures_24h === 0 ? 0.5 : 1,
-              cursor: data.hook_failures_24h === 0 ? 'not-allowed' : 'pointer',
-            }}
-          >
-            View failures
-          </button>
-        </div>
-        {data.recent_failures.length > 0 && (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-            {data.recent_failures.slice(0, 3).map((failure, index) => (
-              <div
-                key={`${failure.timestamp}-${index}`}
-                style={{ padding: '8px', borderRadius: '6px', background: '#fff3f3', border: '1px solid #ffd2d2' }}
-              >
-                <div style={{ color: '#c62828', fontWeight: 600 }}>
-                  {failure.phase || 'Hook'} rc={failure.rc}
-                </div>
-                <div
-                  style={{ color: '#666', fontSize: '11px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                  title={failure.hook}
-                >
-                  {e(failure.hook)}
-                </div>
-                <div style={{ color: '#888', fontSize: '11px' }}>{e(failure.timestamp)}</div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+      )}
     </Panel>
   );
 }
 
-function LogsPanel({
-  data,
-  filter,
-  onFilterChange,
-}: {
-  data: LogEntry[];
-  filter: string;
-  onFilterChange: (value: string) => void;
-}) {
-  const filtered = filter === 'all'
-    ? data
-    : data.filter(row => row.source === filter || row.who === filter || (row as LogEntry & { tag?: string }).tag === filter);
-
+/* Cost / Token spend — realized spend rolled up per role, plus a headline total. */
+function CostPanel({ data }: { data: TokenAudit[] }) {
+  const totalCost = data.reduce((n, r) => n + (r.estimated_cost_usd || 0), 0);
+  const totalTokens = data.reduce(
+    (n, r) => n + (r.prompt_tokens || 0) + (r.completion_tokens || 0), 0);
+  // Roll up per role so the table stays compact regardless of tool cardinality.
+  const byRole = new Map<string, { tokens: number; cost: number; calls: number }>();
+  for (const r of data) {
+    const key = r.role || r.tool_name || '—';
+    const cur = byRole.get(key) ?? { tokens: 0, cost: 0, calls: 0 };
+    cur.tokens += (r.prompt_tokens || 0) + (r.completion_tokens || 0);
+    cur.cost += r.estimated_cost_usd || 0;
+    cur.calls += r.call_count || 0;
+    byRole.set(key, cur);
+  }
+  const rows = [...byRole.entries()].sort((a, b) => b[1].tokens - a[1].tokens);
   return (
-    <Panel title="Logs" count={filtered.length}>
-      <div style={{ padding: '8px 10px', display: 'flex', gap: '6px', borderBottom: '1px solid #f0f0f0' }}>
-        <button onClick={() => onFilterChange('all')} style={filterButtonStyle}>All</button>
-        <button onClick={() => onFilterChange('audit')} style={filterButtonStyle}>Audit</button>
-        <button onClick={() => onFilterChange('plugin-hook')} style={filterButtonStyle}>Plugin hooks</button>
-      </div>
-      <table style={tableStyle}>
-        <thead>
-          <tr>
-            {['Time', 'Source', 'Who', 'What', 'Detail'].map(h => (
-              <th key={h} style={thStyle}>{h}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map((r, i) => (
-            <tr key={i}>
-              <td style={tdStyle}>{e(r.timestamp)}</td>
-              <td style={{ ...tdStyle, color: r.source === 'agent' ? '#4fc3f7' : '#ff9800' }}>
-                {e(r.source)}
-              </td>
-              <td style={tdStyle}>{e(r.who)}</td>
-              <td style={tdStyle}>{e(r.what)}</td>
-              <td
-                style={{ ...tdStyle, color: '#888', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                title={String(r.detail)}
-              >
-                {e(r.detail)}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <Panel title="Cost / Tokens" count={rows.length}>
+      {data.length === 0 ? (
+        <div style={{ padding: '12px', color: '#aaa', fontSize: '12px' }}>No realized spend recorded</div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px', padding: '8px 10px' }}>
+            <div style={{ padding: '8px', border: '1px solid #eee', borderRadius: '6px', background: '#fafafa' }}>
+              <div style={{ color: '#888', fontSize: '11px' }}>Total tokens</div>
+              <div style={{ color: '#333', fontSize: '18px', fontWeight: 600 }}>{fmtCompact(totalTokens)}</div>
+            </div>
+            <div style={{ padding: '8px', border: '1px solid #eee', borderRadius: '6px', background: '#fafafa' }}>
+              <div style={{ color: '#888', fontSize: '11px' }}>Realized cost</div>
+              <div style={{ color: '#333', fontSize: '18px', fontWeight: 600 }}>{fmtUsd(totalCost)}</div>
+            </div>
+          </div>
+          <div style={{ flex: 1, overflow: 'auto' }}>
+            <table style={tableStyle}>
+              <thead>
+                <tr>{['Role', 'Calls', 'Tokens', 'Cost'].map(h => <th key={h} style={thStyle}>{h}</th>)}</tr>
+              </thead>
+              <tbody>
+                {rows.map(([role, v]) => (
+                  <tr key={role}>
+                    <td style={tdStyle}>{e(role)}</td>
+                    <td style={numTd}>{v.calls}</td>
+                    <td style={numTd}>{fmtCompact(v.tokens)}</td>
+                    <td style={numTd}>{fmtUsd(v.cost)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
     </Panel>
   );
+}
+
+/* Active Sessions — live chat/agent sessions (title, working dir, last activity). */
+function SessionsPanel({ data }: { data: Session[] }) {
+  return (
+    <Panel title="Active Sessions" count={data.length}>
+      {data.length === 0 ? (
+        <div style={{ padding: '12px', color: '#aaa', fontSize: '12px' }}>No active sessions</div>
+      ) : (
+        <table style={tableStyle}>
+          <thead>
+            <tr>{['Title', 'Working dir', 'Last active'].map(h => <th key={h} style={thStyle}>{h}</th>)}</tr>
+          </thead>
+          <tbody>
+            {data.map((s, i) => (
+              <tr key={s.id ?? i}>
+                <td style={tdStyle}>{e(s.title || '(untitled)')}</td>
+                <td style={{ ...tdStyle, color: '#999', maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={s.cwd}>
+                  {e(shortenPath(s.cwd))}
+                </td>
+                <td style={{ ...tdStyle, whiteSpace: 'nowrap', color: '#999' }}>{e((s.last_active || '').replace('T', ' ').slice(0, 16))}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Panel>
+  );
+}
+
+function shortenPath(p: string): string {
+  if (!p) return '';
+  const parts = p.split('/').filter(Boolean);
+  return parts.length <= 2 ? p : '…/' + parts.slice(-2).join('/');
 }
 
 function LspPanel({ data }: { data: LspStatus }) {
@@ -470,25 +544,22 @@ function LspPanel({ data }: { data: LspStatus }) {
   );
 }
 
-function agentStateDot(state: Agent['state']): string {
-  if (state === 'active')  return '#22c55e';
-  if (state === 'idle')    return '#f59e0b';
-  if (state === 'pending') return '#3b82f6';
-  return '#9ca3af'; /* offline */
+function agentEnabledDot(enabled: boolean | undefined): string {
+  return enabled ? '#22c55e' : '#9ca3af';
 }
 
 function AgentsPanel({ data }: { data: Agent[] }) {
   return (
-    <Panel title="Agent Presence" count={data.length}>
+    <Panel title="Agents" count={data.length}>
       {data.length === 0 ? (
         <div style={{ padding: '12px', color: '#aaa', fontSize: '12px' }}>
-          No agents registered
+          No agents configured
         </div>
       ) : (
         <table style={tableStyle}>
           <thead>
             <tr>
-              {['', 'Name', 'Family', 'State', 'Role', 'Since'].map(h => (
+              {['', 'Name', 'Provider', 'Model', 'Roles'].map(h => (
                 <th key={h} style={thStyle}>{h}</th>
               ))}
             </tr>
@@ -496,18 +567,17 @@ function AgentsPanel({ data }: { data: Agent[] }) {
           <tbody>
             {data.map((a, i) => (
               <tr key={i}>
-                <td style={tdStyle}>
+                <td style={tdStyle} title={a.enabled ? 'enabled' : 'disabled'}>
                   <span style={{
                     display: 'inline-block', width: 8, height: 8,
-                    borderRadius: '50%', background: agentStateDot(a.state),
+                    borderRadius: '50%', background: agentEnabledDot(a.enabled),
                   }} />
                 </td>
                 <td style={tdStyle}>{e(a.name)}</td>
-                <td style={tdStyle}>{e(a.family)}</td>
-                <td style={tdStyle}>{e(a.state)}</td>
-                <td style={tdStyle}>{e(a.role) || '—'}</td>
-                <td style={numTd}>
-                  {new Date(a.registered_at * 1000).toLocaleTimeString()}
+                <td style={tdStyle}>{e(a.provider) || '—'}</td>
+                <td style={tdStyle}>{e(a.model) || '—'}</td>
+                <td style={tdStyle} title={(a.roles ?? []).join(', ')}>
+                  {a.roles && a.roles.length > 0 ? e(a.roles.join(', ')) : '—'}
                 </td>
               </tr>
             ))}
@@ -594,57 +664,364 @@ function OnboardPanel({ data }: { data: OnboardReport | null }) {
   );
 }
 
+/* ---- Derived-metric panels (all from server-incurred data) ---- */
+
+/* A labeled horizontal bar row for compact distributions. */
+function BarRow({ label, value, max, right, color }: {
+  label: string; value: number; max: number; right: string; color: string;
+}) {
+  const pct = max > 0 ? Math.max(2, Math.round((value / max) * 100)) : 0;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '3px 10px', fontSize: 12 }}>
+      <span style={{ width: 92, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: '#555' }} title={label}>{label}</span>
+      <div style={{ flex: 1, background: '#f0f0f0', borderRadius: 3, height: 10, overflow: 'hidden' }}>
+        <div style={{ width: `${pct}%`, background: color, height: '100%' }} />
+      </div>
+      <span style={{ width: 62, textAlign: 'right', color: '#666', fontVariantNumeric: 'tabular-nums' }}>{right}</span>
+    </div>
+  );
+}
+
+function emptyBody(msg: string) {
+  return <div style={{ padding: 12, color: '#aaa', fontSize: 12 }}>{msg}</div>;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+/* Guardrail Actions — verdict mix over the server's tool-action audit. */
+function GuardrailPanel({ data }: { data: AuditRow[] }) {
+  const counts: Record<string, number> = { allow: 0, block: 0, rewrite: 0, approval_required: 0 };
+  for (const r of data) counts[r.verdict] = (counts[r.verdict] || 0) + 1;
+  const max = Math.max(1, ...Object.values(counts));
+  const colors: Record<string, string> = {
+    allow: '#22c55e', block: '#ef4444', rewrite: '#f59e0b', approval_required: '#3b82f6',
+  };
+  return (
+    <Panel title="Guardrail Actions" count={data.length}>
+      {data.length === 0 ? emptyBody('No tool-action audit yet') : (
+        <div style={{ padding: '8px 0' }}>
+          {Object.keys(counts).map(v => (
+            <BarRow key={v} label={v} value={counts[v]} max={max} right={String(counts[v])} color={colors[v] || '#888'} />
+          ))}
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+/* Success by Agent — success rate + volume per delegate agent. */
+function SuccessByAgentPanel({ data }: { data: Delegation[] }) {
+  const by = new Map<string, { ok: number; total: number }>();
+  for (const d of data) {
+    const c = by.get(d.agent) ?? { ok: 0, total: 0 };
+    c.total++; if (d.success) c.ok++;
+    by.set(d.agent, c);
+  }
+  const rows = [...by.entries()].sort((a, b) => b[1].total - a[1].total);
+  const max = Math.max(1, ...rows.map(r => r[1].total));
+  return (
+    <Panel title="Success by Agent" count={rows.length}>
+      {rows.length === 0 ? emptyBody('No delegations') : (
+        <div style={{ padding: '8px 0' }}>
+          {rows.map(([agent, c]) => {
+            const rate = Math.round((c.ok / c.total) * 100);
+            return <BarRow key={agent} label={agent} value={c.ok} max={max}
+              right={`${rate}% · ${c.total}`} color={rate >= 80 ? '#22c55e' : rate >= 50 ? '#f59e0b' : '#ef4444'} />;
+          })}
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+/* Latency by Role — p50 / p95 / max per role (from delegation latencies). */
+function LatencyByRolePanel({ data }: { data: Delegation[] }) {
+  const by = new Map<string, number[]>();
+  for (const d of data) {
+    const a = by.get(d.role) ?? []; a.push(d.latency_ms); by.set(d.role, a);
+  }
+  const rows = [...by.entries()].map(([role, lats]) => {
+    const s = [...lats].sort((a, b) => a - b);
+    return { role, p50: percentile(s, 50), p95: percentile(s, 95), max: s[s.length - 1], n: s.length };
+  }).sort((a, b) => b.p95 - a.p95);
+  return (
+    <Panel title="Latency by Role" count={rows.length}>
+      {rows.length === 0 ? emptyBody('No delegations') : (
+        <table style={tableStyle}>
+          <thead><tr>{['Role', 'p50', 'p95', 'max'].map(h => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
+          <tbody>
+            {rows.map(r => (
+              <tr key={r.role}>
+                <td style={tdStyle}>{e(r.role)}</td>
+                <td style={numTd}>{fmtDuration(r.p50)}</td>
+                <td style={numTd}>{fmtDuration(r.p95)}</td>
+                <td style={numTd}>{fmtDuration(r.max)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Panel>
+  );
+}
+
+/* Top Tools — most-invoked tools from the tool-call trace stream. */
+function TopToolsPanel({ data }: { data: Trace[] }) {
+  const by = new Map<string, number>();
+  for (const t of data) { if (t.tool_name) by.set(t.tool_name, (by.get(t.tool_name) || 0) + 1); }
+  const rows = [...by.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12);
+  const max = Math.max(1, ...rows.map(r => r[1]));
+  return (
+    <Panel title="Top Tools" count={rows.length}>
+      {rows.length === 0 ? emptyBody('No tool calls traced') : (
+        <div style={{ padding: '8px 0' }}>
+          {rows.map(([tool, n]) => <BarRow key={tool} label={tool} value={n} max={max} right={String(n)} color="#6366f1" />)}
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+/* Cost by Agent — realized token spend rolled up per agent (token_audit.tool_name). */
+function CostByAgentPanel({ data }: { data: TokenAudit[] }) {
+  const by = new Map<string, number>();
+  for (const r of data) {
+    const k = r.tool_name || r.role || '—';
+    by.set(k, (by.get(k) || 0) + (r.prompt_tokens || 0) + (r.completion_tokens || 0));
+  }
+  const rows = [...by.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12);
+  const max = Math.max(1, ...rows.map(r => r[1]));
+  return (
+    <Panel title="Tokens by Agent" count={rows.length}>
+      {rows.length === 0 ? emptyBody('No spend recorded') : (
+        <div style={{ padding: '8px 0' }}>
+          {rows.map(([agent, tok]) => <BarRow key={agent} label={agent} value={tok} max={max} right={fmtCompact(tok)} color="#0ea5e9" />)}
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+/* Cache Efficiency — cache-read share of input tokens (higher = cheaper reuse). */
+function CachePanel({ data }: { data: TokenAudit[] }) {
+  const prompt = data.reduce((n, r) => n + (r.prompt_tokens || 0), 0);
+  const cacheRead = data.reduce((n, r) => n + (r.cache_read_tokens || 0), 0);
+  const cacheWrite = data.reduce((n, r) => n + (r.cache_write_tokens || 0), 0);
+  const denom = prompt + cacheRead;
+  const pct = denom > 0 ? Math.round((cacheRead / denom) * 100) : 0;
+  return (
+    <Panel title="Cache Efficiency">
+      <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 10, fontSize: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <span style={{ fontSize: 30, fontWeight: 700, color: pct >= 50 ? '#22c55e' : pct >= 20 ? '#f59e0b' : '#888' }}>{pct}%</span>
+          <span style={{ color: '#888' }}>cache-read share of input</span>
+        </div>
+        <div style={{ background: '#f0f0f0', borderRadius: 4, height: 12, overflow: 'hidden' }}>
+          <div style={{ width: `${pct}%`, background: '#22c55e', height: '100%' }} />
+        </div>
+        <table style={{ fontSize: 12, width: '100%' }}><tbody>
+          <tr><td style={{ color: '#888' }}>Cache reads</td><td style={{ textAlign: 'right' }}>{fmtCompact(cacheRead)}</td></tr>
+          <tr><td style={{ color: '#888' }}>Cache writes</td><td style={{ textAlign: 'right' }}>{fmtCompact(cacheWrite)}</td></tr>
+          <tr><td style={{ color: '#888' }}>Fresh prompt</td><td style={{ textAlign: 'right' }}>{fmtCompact(prompt)}</td></tr>
+        </tbody></table>
+      </div>
+    </Panel>
+  );
+}
+
+/* Failures — recent unsuccessful delegations. */
+function FailuresPanel({ data }: { data: Delegation[] }) {
+  const fails = data.filter(d => !d.success);
+  return (
+    <Panel title="Failures" count={fails.length}>
+      {fails.length === 0 ? emptyBody('No failed delegations 🎉') : (
+        <table style={tableStyle}>
+          <thead><tr>{['Agent', 'Role', 'Turns', 'Latency'].map(h => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
+          <tbody>
+            {fails.slice(0, 20).map((d, i) => (
+              <tr key={i}>
+                <td style={tdStyle}>{e(d.agent)}</td>
+                <td style={tdStyle}>{e(d.role)}</td>
+                <td style={numTd}>{d.turns}</td>
+                <td style={numTd}>{fmtDuration(d.latency_ms)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Panel>
+  );
+}
+
+/* Provider Mix — configured agents grouped by provider. */
+function ProviderMixPanel({ data }: { data: Agent[] }) {
+  const by = new Map<string, number>();
+  for (const a of data) by.set(a.provider || '—', (by.get(a.provider || '—') || 0) + 1);
+  const rows = [...by.entries()].sort((a, b) => b[1] - a[1]);
+  const max = Math.max(1, ...rows.map(r => r[1]));
+  return (
+    <Panel title="Provider Mix" count={rows.length}>
+      {rows.length === 0 ? emptyBody('No agents') : (
+        <div style={{ padding: '8px 0' }}>
+          {rows.map(([p, n]) => <BarRow key={p} label={p} value={n} max={max} right={String(n)} color="#8b5cf6" />)}
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+/* Confidence by Role — average delegate self-reported confidence per role. */
+function ConfidenceByRolePanel({ data }: { data: Delegation[] }) {
+  const by = new Map<string, { sum: number; n: number }>();
+  for (const d of data) {
+    if (typeof d.confidence !== 'number') continue;
+    const c = by.get(d.role) ?? { sum: 0, n: 0 };
+    c.sum += d.confidence; c.n++;
+    by.set(d.role, c);
+  }
+  const rows = [...by.entries()].map(([role, c]) => ({ role, avg: Math.round(c.sum / c.n), n: c.n }))
+    .sort((a, b) => b.avg - a.avg);
+  return (
+    <Panel title="Confidence" count={rows.length}>
+      {rows.length === 0 ? emptyBody('No confidence data') : (
+        <div style={{ padding: '8px 0' }}>
+          {rows.map(r => (
+            <BarRow key={r.role} label={r.role} value={r.avg} max={100}
+              right={`${r.avg}% · ${r.n}`} color={r.avg >= 70 ? '#22c55e' : r.avg >= 40 ? '#f59e0b' : '#ef4444'} />
+          ))}
+        </div>
+      )}
+    </Panel>
+  );
+}
+
 /* ---- Main Dashboard component ---- */
+
+/* Panel registry: id -> {title, render, defaultOn}. Users pick which panels show
+ * (persisted per-browser in localStorage), so the dashboard is customizable. */
+interface PanelDef {
+  id: string;
+  title: string;
+  defaultOn: boolean;
+  render: (d: DashData) => React.ReactNode;
+}
+
+const PANELS: PanelDef[] = [
+  { id: 'readiness',   title: 'Readiness',        defaultOn: true,  render: d => <OnboardPanel data={d.onboard} /> },
+  { id: 'agents',      title: 'Agents',           defaultOn: true,  render: d => <AgentsPanel data={d.agents} /> },
+  { id: 'sessions',    title: 'Active Sessions',  defaultOn: true,  render: d => <SessionsPanel data={d.sessions} /> },
+  { id: 'delegations', title: 'Delegations',      defaultOn: true,  render: d => <DelegationsPanel data={d.delegations} /> },
+  { id: 'metrics',     title: 'Metrics',          defaultOn: true,  render: d => <MetricsPanel data={d.metrics} /> },
+  { id: 'cost',        title: 'Cost / Tokens',    defaultOn: true,  render: d => <CostPanel data={d.tokenAudit} /> },
+  { id: 'guardrail',   title: 'Guardrail Actions',defaultOn: true,  render: d => <GuardrailPanel data={d.audit} /> },
+  { id: 'plans',       title: 'Execution Plans',  defaultOn: true,  render: d => <PlansPanel data={d.plans} /> },
+  { id: 'traces',      title: 'Traces',           defaultOn: true,  render: d => <TracesPanel data={d.traces} /> },
+  // Available to add:
+  { id: 'success',     title: 'Success by Agent', defaultOn: false, render: d => <SuccessByAgentPanel data={d.delegations} /> },
+  { id: 'latency',     title: 'Latency by Role',  defaultOn: false, render: d => <LatencyByRolePanel data={d.delegations} /> },
+  { id: 'toptools',    title: 'Top Tools',        defaultOn: false, render: d => <TopToolsPanel data={d.traces} /> },
+  { id: 'tokagent',    title: 'Tokens by Agent',  defaultOn: false, render: d => <CostByAgentPanel data={d.tokenAudit} /> },
+  { id: 'cache',       title: 'Cache Efficiency', defaultOn: false, render: d => <CachePanel data={d.tokenAudit} /> },
+  { id: 'failures',    title: 'Failures',         defaultOn: false, render: d => <FailuresPanel data={d.delegations} /> },
+  { id: 'provider',    title: 'Provider Mix',     defaultOn: false, render: d => <ProviderMixPanel data={d.agents} /> },
+  { id: 'confidence',  title: 'Confidence',       defaultOn: false, render: d => <ConfidenceByRolePanel data={d.delegations} /> },
+  { id: 'memory',      title: 'Memory',           defaultOn: false, render: d => <MemoryPanel data={d.memory} /> },
+  { id: 'lsp',         title: 'LSP Health',       defaultOn: false, render: d => <LspPanel data={d.lsp ?? { errors: 0, warnings: 0, active_servers: 0 }} /> },
+];
+
+const LAYOUT_KEY = 'aimee_dash_layout_v1';
+
+function defaultLayout(): string[] {
+  return PANELS.filter(p => p.defaultOn).map(p => p.id);
+}
+
+function loadLayout(): string[] {
+  try {
+    const raw = localStorage.getItem(LAYOUT_KEY);
+    if (!raw) return defaultLayout();
+    const ids = JSON.parse(raw) as string[];
+    const valid = ids.filter(id => PANELS.some(p => p.id === id));
+    return valid.length ? valid : defaultLayout();
+  } catch {
+    return defaultLayout();
+  }
+}
+
+const ctrlBtn: React.CSSProperties = {
+  padding: '4px 12px', background: '#fff', color: '#666',
+  border: '1px solid #ddd', borderRadius: 4, cursor: 'pointer', fontSize: 12,
+};
+
+/* Customize popover: toggle panels on/off and reorder the enabled ones. */
+function CustomizePopover({ layout, setLayout, onClose }: {
+  layout: string[]; setLayout: (l: string[]) => void; onClose: () => void;
+}) {
+  const enabled = new Set(layout);
+  const toggle = (id: string) => {
+    setLayout(enabled.has(id) ? layout.filter(x => x !== id) : [...layout, id]);
+  };
+  const move = (id: string, dir: -1 | 1) => {
+    const i = layout.indexOf(id);
+    const j = i + dir;
+    if (i < 0 || j < 0 || j >= layout.length) return;
+    const next = [...layout];
+    [next[i], next[j]] = [next[j], next[i]];
+    setLayout(next);
+  };
+  // Enabled first (in order), then the rest.
+  const ordered = [...layout, ...PANELS.map(p => p.id).filter(id => !enabled.has(id))];
+  return (
+    <>
+      <div onClick={onClose} style={{ position: 'fixed', inset: 0, zIndex: 20 }} />
+      <div style={{
+        position: 'absolute', top: 40, right: 12, zIndex: 21, width: 280, maxHeight: '70vh', overflow: 'auto',
+        background: '#fff', border: '1px solid #ddd', borderRadius: 8, boxShadow: '0 8px 24px rgba(0,0,0,0.15)', padding: 8,
+      }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: '#555', padding: '4px 6px 8px' }}>Customize panels</div>
+        {ordered.map(id => {
+          const p = PANELS.find(x => x.id === id)!;
+          const on = enabled.has(id);
+          return (
+            <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '3px 6px', borderRadius: 4 }}>
+              <input type="checkbox" checked={on} onChange={() => toggle(id)} />
+              <span style={{ flex: 1, fontSize: 13, color: on ? '#333' : '#999' }}>{p.title}</span>
+              {on && (
+                <>
+                  <button onClick={() => move(id, -1)} title="Move up" style={{ ...ctrlBtn, padding: '0 6px' }}>↑</button>
+                  <button onClick={() => move(id, 1)} title="Move down" style={{ ...ctrlBtn, padding: '0 6px' }}>↓</button>
+                </>
+              )}
+            </div>
+          );
+        })}
+        <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 6px 2px' }}>
+          <button onClick={() => setLayout(defaultLayout())} style={ctrlBtn}>Reset</button>
+          <button onClick={onClose} style={ctrlBtn}>Done</button>
+        </div>
+      </div>
+    </>
+  );
+}
 
 export default function Dashboard() {
   const [data, setData] = useState<DashData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [logFilter, setLogFilter] = useState('all');
+  const [layout, setLayoutState] = useState<string[]>(loadLayout);
+  const [customizing, setCustomizing] = useState(false);
+
+  const setLayout = useCallback((l: string[]) => {
+    setLayoutState(l);
+    try { localStorage.setItem(LAYOUT_KEY, JSON.stringify(l)); } catch { /* ignore */ }
+  }, []);
 
   const load = useCallback(async () => {
     try {
-      const all = await fetch('/api/dashboard').then(r => r.json()) as {
-        delegations?: Delegation[];
-        metrics?: Metric[];
-        traces?: Trace[];
-        memory_stats?: MemoryStat[];
-        plans?: Plan[];
-        logs?: LogEntry[];
-        plugins?: PluginMetrics;
-        lsp?: LspStatus;
-        agents?: Agent[];
-        onboard?: OnboardReport;
-      };
-      // The server-hosted webchat returns shapes the panels can't all consume:
-      // `onboard` may be an `{error}` stub (truthy, no `steps`) and
-      // `memory_stats` may be an object rather than a flat array. A plain `??`
-      // only guards null/undefined, so a wrong-typed-but-truthy value slips
-      // through and a panel's `.map`/`.steps.map` throws. Coerce every field to
-      // the shape its panel expects so a bad payload renders empty, never blank.
-      const arr = <T,>(v: unknown): T[] => (Array.isArray(v) ? (v as T[]) : []);
-      const plugins = all.plugins;
-      setData({
-        delegations: arr<Delegation>(all.delegations),
-        metrics: arr<Metric>(all.metrics),
-        traces: arr<Trace>(all.traces),
-        memory: arr<MemoryStat>(all.memory_stats),
-        plans: arr<Plan>(all.plans),
-        logs: arr<LogEntry>(all.logs),
-        plugins: {
-          installed: plugins?.installed ?? 0,
-          enabled: plugins?.enabled ?? 0,
-          hooks_total: plugins?.hooks_total ?? 0,
-          tools_total: plugins?.tools_total ?? 0,
-          hook_runs_24h: plugins?.hook_runs_24h ?? 0,
-          hook_failures_24h: plugins?.hook_failures_24h ?? 0,
-          recent_failures: arr<PluginFailure>(plugins?.recent_failures),
-        },
-        lsp: all.lsp ?? null,
-        agents: arr<Agent>(all.agents),
-        // Only accept a real onboard report (one that has a `steps` array);
-        // the server's `{error: …}` stub must fall back to null.
-        onboard: Array.isArray(all.onboard?.steps) ? (all.onboard as OnboardReport) : null,
-      });
+      const all = await fetch('/api/dashboard').then(r => r.json()) as RawDashboard;
+      setData(toDashData(all));
     } catch (err) {
       console.error('Dashboard load failed', err);
     } finally {
@@ -659,45 +1036,44 @@ export default function Dashboard() {
     return () => document.removeEventListener('visibilitychange', onVisible);
   }, [load]);
 
+  const shown = layout.map(id => PANELS.find(p => p.id === id)).filter(Boolean) as PanelDef[];
+
   return (
-    <div style={{ margin: '-24px', height: 'calc(100% + 48px)', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-      {/* Header row */}
+    // Fill the routed <main> EXACTLY (no negative-margin hack) so nothing overflows.
+    <div style={{
+      position: 'relative', height: '100%', width: '100%', boxSizing: 'border-box',
+      display: 'flex', flexDirection: 'column', overflow: 'hidden', background: '#f0f0f0',
+    }}>
       <div style={{
         padding: '8px 16px', background: '#fafafa', borderBottom: '1px solid #e0e0e0',
-        display: 'flex', alignItems: 'center', gap: '12px', flexShrink: 0,
+        display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0,
       }}>
-        <span style={{ fontSize: '14px', fontWeight: 600, color: '#555' }}>Dashboard</span>
-        <button
-          onClick={load}
-          style={{
-            padding: '4px 12px', background: '#fff', color: '#666',
-            border: '1px solid #ddd', borderRadius: '4px', cursor: 'pointer', fontSize: '12px',
-          }}
-        >
-          Refresh
-        </button>
-        {loading && <span style={{ fontSize: '12px', color: '#aaa' }}>Loading…</span>}
+        <span style={{ fontSize: 14, fontWeight: 600, color: '#555' }}>Dashboard</span>
+        <button onClick={load} style={ctrlBtn}>Refresh</button>
+        <button onClick={() => setCustomizing(v => !v)} style={{ ...ctrlBtn, marginLeft: 'auto' }}>⚙ Customize</button>
+        {loading && <span style={{ fontSize: 12, color: '#aaa' }}>Loading…</span>}
       </div>
 
-      {/* 3-column grid */}
+      {customizing && <CustomizePopover layout={layout} setLayout={setLayout} onClose={() => setCustomizing(false)} />}
+
+      {/* Grid: 3 columns that never overflow horizontally (minmax(0,1fr)); rows are
+          at least 200px and grow to fill. Few panels fill the viewport with no
+          scroll; many panels scroll vertically only. */}
       {data && (
-        <div style={{
-          flex: 1, display: 'grid',
-          gridTemplateColumns: '1fr 1fr 1fr',
-          gridAutoRows: '1fr',
-          gap: '8px', padding: '8px', overflow: 'hidden', background: '#f0f0f0',
-        }}>
-          <OnboardPanel data={data.onboard} />
-          <DelegationsPanel data={data.delegations} />
-          <MetricsPanel data={data.metrics} />
-          <PlansPanel data={data.plans} />
-          <TracesPanel data={data.traces} />
-          <MemoryPanel data={data.memory} />
-          <PluginsPanel data={data.plugins} onViewFailures={() => setLogFilter('plugin-hook')} />
-          <LogsPanel data={data.logs} filter={logFilter} onFilterChange={setLogFilter} />
-          {data.lsp && <LspPanel data={data.lsp} />}
-          <AgentsPanel data={data.agents} />
-        </div>
+        shown.length === 0 ? (
+          <div style={{ padding: 24, color: '#888', fontSize: 13 }}>
+            No panels selected — click <b>⚙ Customize</b> to add some.
+          </div>
+        ) : (
+          <div style={{
+            flex: 1, minHeight: 0, boxSizing: 'border-box',
+            display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+            gridAutoRows: 'minmax(200px, 1fr)', gap: 8, padding: 8,
+            overflowY: 'auto', overflowX: 'hidden',
+          }}>
+            {shown.map(p => <div key={p.id} style={{ minWidth: 0, minHeight: 0, overflow: 'hidden' }}>{p.render(data)}</div>)}
+          </div>
+        )
       )}
     </div>
   );

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { Badge } from '@rakuensoftware/smoothgui';
+import type { BadgeVariant } from '@rakuensoftware/smoothgui';
+
+/* The server's own tool-action audit ledger (guardrail verdict on every tool
+ * call the agent makes). Server-incurred — distinct from the KB's own logs. */
+interface AuditRow {
+  ts: string;
+  kind: string;
+  actor: string;        // primary | delegate
+  tool: string;
+  args_hash?: string;
+  mode?: string;        // guardrail mode
+  reason_code?: string;
+  verdict: string;      // allow | block | rewrite | approval_required | unknown
+  task_id?: number;
+}
+
+function verdictVariant(v: string): BadgeVariant {
+  if (v === 'allow') return 'success';
+  if (v === 'block') return 'error';
+  if (v === 'approval_required' || v === 'rewrite') return 'running';
+  return 'running';
+}
+
+function esc(s: unknown): string {
+  return s == null ? '' : String(s);
+}
+
+const th: React.CSSProperties = {
+  textAlign: 'left', padding: '6px 10px', borderBottom: '1px solid #e0e0e0',
+  color: '#666', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.3px',
+  position: 'sticky', top: 0, background: '#fafafa', zIndex: 1,
+};
+const td: React.CSSProperties = { padding: '5px 10px', borderBottom: '1px solid #f2f2f2', fontSize: 12 };
+
+const selectStyle: React.CSSProperties = {
+  padding: '4px 8px', borderRadius: 4, border: '1px solid #ddd', background: '#fff',
+  color: '#444', fontSize: 12,
+};
+
+export default function Logs() {
+  const [rows, setRows] = useState<AuditRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [verdict, setVerdict] = useState('all');
+  const [actor, setActor] = useState('all');
+  const [q, setQ] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetch('/api/audit').then(r => (r.status === 401 ? [] : r.json()));
+      setRows(Array.isArray(data) ? data : []);
+    } catch {
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const filtered = useMemo(() => rows.filter(r =>
+    (verdict === 'all' || r.verdict === verdict) &&
+    (actor === 'all' || r.actor === actor) &&
+    (q === '' || (r.tool || '').toLowerCase().includes(q.toLowerCase()))
+  ), [rows, verdict, actor, q]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { allow: 0, block: 0, rewrite: 0, approval_required: 0 };
+    for (const r of rows) c[r.verdict] = (c[r.verdict] || 0) + 1;
+    return c;
+  }, [rows]);
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column', overflow: 'hidden', boxSizing: 'border-box' }}>
+      {/* Header / controls */}
+      <div style={{
+        padding: '8px 16px', background: '#fafafa', borderBottom: '1px solid #e0e0e0',
+        display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', flexShrink: 0,
+      }}>
+        <span style={{ fontSize: 14, fontWeight: 600, color: '#555' }}>Logs</span>
+        <span style={{ fontSize: 12, color: '#999' }}>tool-action audit</span>
+        <div style={{ display: 'flex', gap: 6, marginLeft: 8 }}>
+          {(['allow', 'block', 'rewrite', 'approval_required'] as const).map(v => (
+            <span key={v} style={{ fontSize: 11, color: '#777' }}>
+              {v}: <b style={{ color: '#444' }}>{counts[v] || 0}</b>
+            </span>
+          ))}
+        </div>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8, alignItems: 'center' }}>
+          <input
+            value={q}
+            onChange={e => setQ(e.target.value)}
+            placeholder="filter tool…"
+            style={{ ...selectStyle, width: 120 }}
+          />
+          <select value={verdict} onChange={e => setVerdict(e.target.value)} style={selectStyle}>
+            {['all', 'allow', 'block', 'rewrite', 'approval_required'].map(v => <option key={v} value={v}>{v}</option>)}
+          </select>
+          <select value={actor} onChange={e => setActor(e.target.value)} style={selectStyle}>
+            {['all', 'primary', 'delegate'].map(a => <option key={a} value={a}>{a}</option>)}
+          </select>
+          <button onClick={load} style={{ ...selectStyle, cursor: 'pointer' }}>Refresh</button>
+          {loading && <span style={{ fontSize: 12, color: '#aaa' }}>Loading…</span>}
+        </div>
+      </div>
+
+      {/* Table (scrolls) */}
+      <div style={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+        {filtered.length === 0 ? (
+          <div style={{ padding: 16, color: '#aaa', fontSize: 13 }}>
+            {loading ? 'Loading…' : 'No audit rows'}
+          </div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>{['Time', 'Actor', 'Tool', 'Verdict', 'Mode', 'Reason', 'Task'].map(h => <th key={h} style={th}>{h}</th>)}</tr>
+            </thead>
+            <tbody>
+              {filtered.map((r, i) => (
+                <tr key={i}>
+                  <td style={{ ...td, whiteSpace: 'nowrap', color: '#888' }}>{esc(r.ts).replace('T', ' ').replace('Z', '')}</td>
+                  <td style={td}>{esc(r.actor)}</td>
+                  <td style={{ ...td, fontFamily: 'monospace' }}>{esc(r.tool)}</td>
+                  <td style={td}><Badge label={esc(r.verdict)} variant={verdictVariant(r.verdict)} /></td>
+                  <td style={{ ...td, color: '#888' }}>{esc(r.mode)}</td>
+                  <td style={{ ...td, color: '#888' }}>{esc(r.reason_code)}</td>
+                  <td style={{ ...td, textAlign: 'right', color: '#aaa' }}>{r.task_id || ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/__fixtures__/dashboard-all.json
+++ b/frontend/src/pages/__fixtures__/dashboard-all.json
@@ -1,0 +1,622 @@
+{
+  "agents": [
+    {
+      "name": "minimax",
+      "endpoint": "https://api.minimax.io/v1/chat/completions",
+      "model": "MiniMax-M3",
+      "auth_type": "bearer",
+      "provider": "minimax",
+      "cost_tier": 0,
+      "enabled": true,
+      "tools_enabled": true,
+      "max_turns": -1,
+      "max_parallel": 3,
+      "context_window": 200000,
+      "roles": [
+        "code",
+        "review",
+        "explain",
+        "refactor",
+        "draft",
+        "execute",
+        "summarize",
+        "format",
+        "reason",
+        "search"
+      ],
+      "personas": []
+    },
+    {
+      "name": "mistral",
+      "endpoint": "https://api.mistral.ai/v1/chat/completions",
+      "model": "mistral-medium-3.5",
+      "auth_type": "bearer",
+      "provider": "openai",
+      "cost_tier": 0,
+      "enabled": true,
+      "tools_enabled": true,
+      "max_turns": -1,
+      "max_parallel": 3,
+      "context_window": 131072,
+      "roles": [
+        "code",
+        "review",
+        "explain",
+        "refactor",
+        "draft",
+        "execute",
+        "summarize",
+        "format",
+        "reason",
+        "search"
+      ],
+      "personas": []
+    },
+    {
+      "name": "mimo-2.5",
+      "endpoint": "https://token-plan-ams.xiaomimimo.com/v1/chat/completions",
+      "model": "mimo-v2.5-pro",
+      "auth_type": "bearer",
+      "provider": "openai",
+      "cost_tier": 0,
+      "enabled": true,
+      "tools_enabled": true,
+      "max_turns": 14,
+      "max_parallel": 3,
+      "context_window": 131072,
+      "roles": [
+        "code",
+        "review",
+        "explain",
+        "refactor",
+        "draft",
+        "execute",
+        "summarize",
+        "format",
+        "diagnose",
+        "validate"
+      ],
+      "personas": []
+    },
+    {
+      "name": "codex",
+      "endpoint": "https://chatgpt.com/backend-api/codex",
+      "model": "gpt-5.5",
+      "auth_type": "codex-oauth",
+      "provider": "chatgpt",
+      "cost_tier": 0,
+      "enabled": true,
+      "tools_enabled": false,
+      "max_turns": -1,
+      "max_parallel": 3,
+      "roles": [
+        "code",
+        "review",
+        "explain",
+        "refactor",
+        "draft",
+        "execute",
+        "summarize",
+        "format",
+        "reason",
+        "search"
+      ],
+      "personas": []
+    },
+    {
+      "name": "claude",
+      "endpoint": "",
+      "model": "",
+      "auth_type": "none",
+      "provider": "claude",
+      "cost_tier": 1,
+      "enabled": true,
+      "tools_enabled": true,
+      "max_turns": -1,
+      "max_parallel": 3,
+      "context_window": 200000,
+      "roles": [
+        "code",
+        "review",
+        "explain",
+        "refactor",
+        "draft",
+        "execute"
+      ],
+      "personas": []
+    },
+    {
+      "name": "mimo-2.5-pro",
+      "endpoint": "https://token-plan-ams.xiaomimimo.com/v1/chat/completions",
+      "model": "mimo-v2.5-pro",
+      "auth_type": "bearer",
+      "provider": "openai",
+      "cost_tier": 0,
+      "enabled": true,
+      "tools_enabled": true,
+      "max_turns": -1,
+      "max_parallel": 3,
+      "context_window": 131072,
+      "roles": [
+        "code",
+        "review",
+        "explain",
+        "refactor",
+        "draft",
+        "execute",
+        "summarize",
+        "format",
+        "reason",
+        "search"
+      ],
+      "personas": []
+    },
+    {
+      "name": "glm-5.2",
+      "endpoint": "https://api.z.ai/api/coding/paas/v4/chat/completions",
+      "model": "glm-5.2",
+      "auth_type": "bearer",
+      "provider": "openai",
+      "cost_tier": 0,
+      "enabled": true,
+      "tools_enabled": true,
+      "max_turns": -1,
+      "max_parallel": 3,
+      "context_window": 131072,
+      "roles": [
+        "code",
+        "review",
+        "explain",
+        "refactor",
+        "draft",
+        "execute",
+        "summarize",
+        "format",
+        "reason",
+        "search"
+      ],
+      "personas": []
+    },
+    {
+      "name": "local-synth",
+      "endpoint": "http://10.100.0.1:8742/v1",
+      "model": "aimee-synth",
+      "auth_type": "none",
+      "provider": "openai",
+      "cost_tier": 0,
+      "enabled": true,
+      "tools_enabled": true,
+      "max_turns": -1,
+      "max_parallel": 4,
+      "context_window": 65536,
+      "roles": [
+        "code",
+        "review",
+        "explain",
+        "refactor",
+        "draft",
+        "execute",
+        "summarize",
+        "format",
+        "reason",
+        "search"
+      ],
+      "personas": []
+    }
+  ],
+  "delegations": [
+    {
+      "agent": "mistral",
+      "role": "execute",
+      "success": true,
+      "turns": 18,
+      "tool_calls": 18,
+      "latency_ms": 24004,
+      "confidence": 80,
+      "created_at": "2026-07-04 15:19:50"
+    },
+    {
+      "agent": "mimo-2.5-pro",
+      "role": "execute",
+      "success": true,
+      "turns": 1,
+      "tool_calls": 1,
+      "latency_ms": 3650,
+      "confidence": 80,
+      "created_at": "2026-07-04 15:15:30"
+    },
+    {
+      "agent": "mistral",
+      "role": "review",
+      "success": true,
+      "turns": 0,
+      "tool_calls": 0,
+      "latency_ms": 4662,
+      "confidence": 80,
+      "created_at": "2026-07-03 19:47:45"
+    },
+    {
+      "agent": "mimo-2.5-pro",
+      "role": "review",
+      "success": true,
+      "turns": 4,
+      "tool_calls": 8,
+      "latency_ms": 74515,
+      "confidence": 75,
+      "created_at": "2026-07-03 19:26:20"
+    },
+    {
+      "agent": "minimax",
+      "role": "review",
+      "success": true,
+      "turns": 13,
+      "tool_calls": 15,
+      "latency_ms": 69865,
+      "confidence": 65,
+      "created_at": "2026-07-03 19:10:42"
+    }
+  ],
+  "logs": [],
+  "lsp": {
+    "errors": 0,
+    "warnings": 0,
+    "active_servers": 0
+  },
+  "memory_stats": {
+    "tiers": [
+      {
+        "tier": "L0",
+        "functional_name": "Experience",
+        "count": 3
+      },
+      {
+        "tier": "L1",
+        "functional_name": "Experience",
+        "count": 50
+      },
+      {
+        "tier": "L2",
+        "functional_name": "Observation",
+        "count": 2
+      },
+      {
+        "tier": "L3",
+        "functional_name": "World",
+        "count": 0
+      },
+      {
+        "tier": "L4",
+        "functional_name": "MentalModel",
+        "count": 0
+      },
+      {
+        "tier": "L5",
+        "functional_name": "Pattern",
+        "count": 0
+      }
+    ],
+    "tier_kinds": [
+      {
+        "tier": "L0",
+        "functional_name": "Experience",
+        "kind": "fact",
+        "count": 3
+      },
+      {
+        "tier": "L1",
+        "functional_name": "Experience",
+        "kind": "episode",
+        "count": 50
+      },
+      {
+        "tier": "L2",
+        "functional_name": "Observation",
+        "kind": "fact",
+        "count": 1
+      },
+      {
+        "tier": "L2",
+        "functional_name": "Observation",
+        "kind": "preference",
+        "count": 1
+      }
+    ],
+    "scopes": [
+      {
+        "scope": "global",
+        "count": 39,
+        "conflicted_memories": 0
+      },
+      {
+        "scope": "workspace",
+        "count": 16,
+        "conflicted_memories": 0
+      },
+      {
+        "scope": "project",
+        "count": 0,
+        "conflicted_memories": 0
+      }
+    ]
+  },
+  "metrics": [
+    {
+      "role": "draft",
+      "total": 144,
+      "successes": 144,
+      "avg_latency_ms": 42027,
+      "tokens": 4380809,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0
+    },
+    {
+      "role": "review",
+      "total": 56,
+      "successes": 53,
+      "avg_latency_ms": 127428,
+      "tokens": 6250294,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0
+    },
+    {
+      "role": "execute",
+      "total": 21,
+      "successes": 17,
+      "avg_latency_ms": 34162,
+      "tokens": 816504,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 491840,
+      "estimated_cost_usd": 0
+    },
+    {
+      "role": "code",
+      "total": 9,
+      "successes": 9,
+      "avg_latency_ms": 39423,
+      "tokens": 259360,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0
+    },
+    {
+      "role": "summarize",
+      "total": 3,
+      "successes": 3,
+      "avg_latency_ms": 482,
+      "tokens": 2441,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0
+    },
+    {
+      "role": "reason",
+      "total": 3,
+      "successes": 3,
+      "avg_latency_ms": 199096,
+      "tokens": 51337,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0
+    },
+    {
+      "role": "validate",
+      "total": 1,
+      "successes": 1,
+      "avg_latency_ms": 46094,
+      "tokens": 29424,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0
+    },
+    {
+      "role": "diagnose",
+      "total": 1,
+      "successes": 0,
+      "avg_latency_ms": 116,
+      "tokens": 0,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0
+    }
+  ],
+  "onboard": {
+    "version": "1",
+    "ready": true,
+    "elapsed_ms": 0,
+    "next_actions": [],
+    "steps": [
+      {
+        "step": "database",
+        "status": "ok",
+        "message": "memory store reachable"
+      },
+      {
+        "step": "agents",
+        "status": "ok",
+        "message": "8 agents configured"
+      },
+      {
+        "step": "delegations",
+        "status": "ok",
+        "message": "delegate activity recorded"
+      },
+      {
+        "step": "lsp",
+        "status": "ok",
+        "message": "no code diagnostics"
+      }
+    ]
+  },
+  "plans": [
+    {
+      "id": 2,
+      "agent": "delegate-plan",
+      "task": "Fix add bug",
+      "status": "pending",
+      "created_at": "2026-07-03 07:08:32",
+      "total_steps": 1,
+      "done_steps": 0
+    },
+    {
+      "id": 1,
+      "agent": "delegate-plan",
+      "task": "Fix the add bug in calc",
+      "status": "pending",
+      "created_at": "2026-07-03 07:03:02",
+      "total_steps": 1,
+      "done_steps": 0
+    }
+  ],
+  "traces": [
+    {
+      "turn": 18,
+      "direction": "response",
+      "tool_name": null
+    },
+    {
+      "turn": 18,
+      "direction": "request",
+      "tool_name": null
+    },
+    {
+      "turn": 17,
+      "direction": "tool_call",
+      "tool_name": "bash"
+    },
+    {
+      "turn": 17,
+      "direction": "response",
+      "tool_name": null
+    },
+    {
+      "turn": 17,
+      "direction": "request",
+      "tool_name": null
+    }
+  ],
+  "token_audit": [
+    {
+      "tool_name": "delegate",
+      "role": "draft",
+      "prompt_tokens": 3800000,
+      "completion_tokens": 580000,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 4.21,
+      "usage_kind": "realized",
+      "call_count": 144,
+      "last_seen": "2026-07-04 15:19:50"
+    },
+    {
+      "tool_name": "delegate",
+      "role": "review",
+      "prompt_tokens": 5900000,
+      "completion_tokens": 350000,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 6.02,
+      "usage_kind": "realized",
+      "call_count": 56,
+      "last_seen": "2026-07-04 14:02:11"
+    },
+    {
+      "tool_name": "delegate",
+      "role": "execute",
+      "prompt_tokens": 780000,
+      "completion_tokens": 36000,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0.44,
+      "usage_kind": "realized",
+      "call_count": 21,
+      "last_seen": "2026-07-04 13:50:00"
+    },
+    {
+      "tool_name": "summarize",
+      "role": "summarize",
+      "prompt_tokens": 2200,
+      "completion_tokens": 240,
+      "cache_write_tokens": 0,
+      "cache_read_tokens": 0,
+      "estimated_cost_usd": 0.001,
+      "usage_kind": "realized",
+      "call_count": 3,
+      "last_seen": "2026-07-03 22:10:00"
+    }
+  ],
+  "decisions": [
+    {
+      "id": 3,
+      "task_id": 49,
+      "options": "accept | reject | revise",
+      "chosen": "accept",
+      "rationale": "Passed proposal gate with 2/2 approvals",
+      "assumptions": "",
+      "outcome": "success",
+      "created_at": "2026-07-04 10:22:31"
+    },
+    {
+      "id": 2,
+      "task_id": 48,
+      "options": "autonomous | manual",
+      "chosen": "manual",
+      "rationale": "Panel unreachable, fell back to manual review",
+      "assumptions": "",
+      "outcome": "pending",
+      "created_at": "2026-07-03 09:15:02"
+    },
+    {
+      "id": 1,
+      "task_id": 47,
+      "options": "merge | hold",
+      "chosen": "hold",
+      "rationale": "CI gate failed on lint",
+      "assumptions": "",
+      "outcome": "reject",
+      "created_at": "2026-07-02 18:40:12"
+    }
+  ],
+  "sessions": [
+    {
+      "id": "web-8c634ea6-a216-4987-96e9-096033c95df3",
+      "title": "Test",
+      "cwd": "/var/lib/aimee-workspaces/webusers/admin/aimee",
+      "created_at": "2026-07-03T17:06:07Z",
+      "last_active": "2026-07-03T17:06:07Z"
+    }
+  ],
+  "audit": [
+    {
+      "ts": "2026-07-04T15:19:45Z",
+      "kind": "tool_action",
+      "actor": "delegate",
+      "tool": "bash",
+      "mode": "approve",
+      "reason_code": "allow",
+      "verdict": "allow",
+      "task_id": 0
+    },
+    {
+      "ts": "2026-07-04T15:18:10Z",
+      "kind": "tool_action",
+      "actor": "primary",
+      "tool": "edit",
+      "mode": "approve",
+      "reason_code": "path_guard",
+      "verdict": "block",
+      "task_id": 0
+    },
+    {
+      "ts": "2026-07-04T15:17:02Z",
+      "kind": "tool_action",
+      "actor": "delegate",
+      "tool": "write",
+      "mode": "approve",
+      "reason_code": "rewrite",
+      "verdict": "rewrite",
+      "task_id": 0
+    }
+  ]
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -18,5 +18,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/pages/__fixtures__"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+// Vitest runs the dashboard data-contract tests. The React plugin transforms
+// the TSX modules under test; the environment is `node` because the tests
+// exercise the pure `toDashData` transform, not the DOM.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+});

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -612,6 +612,7 @@ static const struct
     {"curator.implements", "POST", "/v1/curator/implements"},
     {"curator.invalidated", "POST", "/v1/curator/invalidated"},
     {"dashboard.all", "GET", "/v1/dashboard/all"},
+    {"dashboard.audit", "GET", "/v1/dashboard/audit"},
     {"dashboard.delegations", "GET", "/v1/dashboard/delegations"},
     {"dashboard.logs", "GET", "/v1/dashboard/logs"},
     {"dashboard.memory_stats", "GET", "/v1/dashboard/memory_stats"},

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -375,6 +375,7 @@ int handle_dashboard_onboard(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 int handle_dashboard_memory_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_lsp_diagnostics_summary(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_dashboard_all(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_dashboard_audit(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 char *server_agent_list_json(void);
 int handle_workspace_context(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1438,6 +1438,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"dashboard.onboard", handle_dashboard_onboard},
     {"dashboard.memory_stats", handle_dashboard_memory_stats},
     {"dashboard.all", handle_dashboard_all},
+    {"dashboard.audit", handle_dashboard_audit},
     {"lsp.diagnostics_summary", handle_lsp_diagnostics_summary},
     {"workspace.context", handle_workspace_context},
     {"workspace.add", handle_workspace_add},

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -2116,6 +2116,7 @@ static const http_route_t g_v1_routes[] = {
     /* dashboard.* / insights.* / identity.* / dogfood.* / lsp.* (op-parity wave 4).
      * Dashboard surfaces are read views (GET). */
     {"GET", "/v1/dashboard/all", NULL, RM_EXACT, "dashboard.all", 0, rh_dispatch_op},
+    {"GET", "/v1/dashboard/audit", NULL, RM_EXACT, "dashboard.audit", 0, rh_dispatch_op},
     {"GET", "/v1/dashboard/delegations", NULL, RM_EXACT, "dashboard.delegations", 0,
      rh_dispatch_op},
     {"GET", "/v1/dashboard/logs", NULL, RM_EXACT, "dashboard.logs", 0, rh_dispatch_op},

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -3,6 +3,8 @@
 #include "aimee.h"
 #include "server.h"
 #include "dashboard.h"
+#include "render.h"       /* decision_to_json + db2_decision_log_list */
+#include "audit_ledger.h" /* audit_ledger_read — server-incurred tool-action audit */
 #include "lsp.h"
 #include "platform_path.h"
 #include "workspace.h"
@@ -1867,6 +1869,96 @@ static cJSON *parse_or_object(char *json)
    return v ? v : cJSON_CreateObject();
 }
 
+/* Recent governance decision records (decision_log via KB client), newest first. */
+static char *dashboard_decisions_json(void)
+{
+   db2_decision_log_row_t rows[50];
+   int n = kb_client_decision_log_list(NULL, 50, rows, 50);
+   if (n < 0)
+      n = 0;
+   cJSON *arr = cJSON_CreateArray();
+   for (int i = 0; i < n; i++)
+      cJSON_AddItemToArray(arr, decision_to_json(&rows[i]));
+   char *json = cJSON_PrintUnformatted(arr);
+   cJSON_Delete(arr);
+   return json ? json : strdup("[]");
+}
+
+/* Server-incurred tool-action audit (guardrail verdicts), most-recent first, capped. */
+static cJSON *dashboard_audit_array(int limit)
+{
+   cJSON *all = audit_ledger_read(NULL, NULL);
+   if (!all)
+      return cJSON_CreateArray();
+   int n = cJSON_GetArraySize(all);
+   cJSON *out = cJSON_CreateArray();
+   for (int i = n - 1; i >= 0 && (limit <= 0 || cJSON_GetArraySize(out) < limit); i--)
+      cJSON_AddItemToArray(out, cJSON_DetachItemFromArray(all, i));
+   cJSON_Delete(all);
+   return out;
+}
+
+static void readiness_add_step(cJSON *steps, const char *step, const char *status,
+                               const char *message)
+{
+   cJSON *s = cJSON_CreateObject();
+   cJSON_AddStringToObject(s, "step", step);
+   cJSON_AddStringToObject(s, "status", status);
+   if (message && message[0])
+      cJSON_AddStringToObject(s, "message", message);
+   cJSON_AddItemToArray(steps, s);
+}
+
+static int json_array_len(const cJSON *v)
+{
+   return cJSON_IsArray(v) ? cJSON_GetArraySize(v) : 0;
+}
+
+/* Real readiness report (onboard-report shape) from the already-gathered payload. */
+static cJSON *dashboard_readiness(const cJSON *resp)
+{
+   cJSON *report = cJSON_CreateObject();
+   cJSON_AddStringToObject(report, "version", "1");
+   cJSON *steps = cJSON_AddArrayToObject(report, "steps");
+   cJSON *next = cJSON_AddArrayToObject(report, "next_actions");
+   int ready = 1;
+
+   const cJSON *mem = cJSON_GetObjectItem(resp, "memory_stats");
+   const cJSON *tiers = mem ? cJSON_GetObjectItem(mem, "tier_kinds") : NULL;
+   if (json_array_len(tiers) > 0)
+      readiness_add_step(steps, "database", "ok", "memory store reachable");
+   else
+      readiness_add_step(steps, "database", "warn", "no memories recorded yet");
+
+   int agents = json_array_len(cJSON_GetObjectItem(resp, "agents"));
+   if (agents > 0)
+   {
+      char msg[64];
+      snprintf(msg, sizeof(msg), "%d agent%s configured", agents, agents == 1 ? "" : "s");
+      readiness_add_step(steps, "agents", "ok", msg);
+   }
+   else
+   {
+      ready = 0;
+      readiness_add_step(steps, "agents", "error", "no agents configured");
+      cJSON_AddItemToArray(next, cJSON_CreateString("Configure at least one delegate agent"));
+   }
+
+   if (json_array_len(cJSON_GetObjectItem(resp, "metrics")) > 0)
+      readiness_add_step(steps, "delegations", "ok", "delegate activity recorded");
+   else
+      readiness_add_step(steps, "delegations", "warn", "no delegate activity yet");
+
+   const cJSON *lsp = cJSON_GetObjectItem(resp, "lsp");
+   int lsp_err = lsp ? (int)cJSON_GetNumberValue(cJSON_GetObjectItem(lsp, "errors")) : 0;
+   readiness_add_step(steps, "lsp", lsp_err > 0 ? "warn" : "ok",
+                      lsp_err > 0 ? "diagnostics present" : "no code diagnostics");
+
+   cJSON_AddBoolToObject(report, "ready", ready);
+   cJSON_AddNumberToObject(report, "elapsed_ms", 0);
+   return report;
+}
+
 int handle_dashboard_traces(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
@@ -1964,8 +2056,8 @@ int handle_dashboard_all(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    ADD_ARRAY("plans", api_plans());
    ADD_ARRAY("logs", kb_client_dashboard_logs_json());
    ADD_ARRAY("agents", server_agent_list_json());
-   ADD_OBJECT("plugins", api_dashboard_plugins());
-   ADD_OBJECT("onboard", api_dashboard_onboard());
+   ADD_ARRAY("token_audit", api_token_audit());
+   ADD_ARRAY("decisions", dashboard_decisions_json());
    ADD_OBJECT("memory_stats", kb_client_dashboard_memory_stats_json());
 
 #undef ADD_ARRAY
@@ -1979,6 +2071,20 @@ int handle_dashboard_all(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    cJSON_AddNumberToObject(lsp, "active_servers", active_servers);
    cJSON_AddItemToObject(resp, "lsp", lsp);
 
+   cJSON_AddItemToObject(resp, "onboard", dashboard_readiness(resp));
+
+   cJSON_AddItemToObject(resp, "audit", dashboard_audit_array(300));
+
+   return send_and_free(conn, resp);
+}
+
+/* dashboard.audit: the server's tool-action audit ledger for the Logs page. */
+int handle_dashboard_audit(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   (void)req;
+   cJSON *resp = jo_ok();
+   cJSON_AddItemToObject(resp, "data", dashboard_audit_array(5000));
    return send_and_free(conn, resp);
 }
 

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -882,6 +882,10 @@ int handle_dashboard_all(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "dashboard.all");
 }
+int handle_dashboard_audit(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "dashboard.audit");
+}
 char *server_agent_list_json(void)
 {
    return strdup("[]");

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -73,6 +73,7 @@ type methodRoute struct {
 var methodRoutes = map[string]methodRoute{
 	// Dashboard read views (GET, no args).
 	"dashboard.all":            {http.MethodGet, "/v1/dashboard/all"},
+	"dashboard.audit":          {http.MethodGet, "/v1/dashboard/audit"},
 	"dashboard.delegations":    {http.MethodGet, "/v1/dashboard/delegations"},
 	"dashboard.metrics":        {http.MethodGet, "/v1/dashboard/metrics"},
 	"dashboard.logs":           {http.MethodGet, "/v1/dashboard/logs"},
@@ -419,6 +420,13 @@ func (s *server) handleDashboardAll(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		out[k] = v
+	}
+	// Active sessions are webchat-owned (not in the aimee-server dashboard.all),
+	// so inject the current user's sessions for the dashboard's Sessions panel.
+	if sessions, serr := s.listChatSessions(currentUser(r)); serr == nil {
+		if raw, merr := json.Marshal(sessions); merr == nil {
+			out["sessions"] = raw
+		}
 	}
 	json.NewEncoder(w).Encode(out)
 }

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -121,6 +121,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/", s.requireAuth(s.handleRoot))
 	mux.HandleFunc("/chat", s.requireAuth(s.handleSPA))
 	mux.HandleFunc("/dashboard", s.requireAuth(s.handleSPA))
+	mux.HandleFunc("/logs", s.requireAuth(s.handleSPA))
 	// Workflow surfaces: "Edit Workflows" (the def/graph editor) and "Workflow
 	// Actions" (author → autonomous-run → status/history). Both are SPA routes so a
 	// hard refresh / direct link serves index.html and React Router takes over.
@@ -177,6 +178,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 
 	// Aggregate dashboard endpoint — all panels in one server round-trip
 	mux.HandleFunc("/api/dashboard", s.requireAuth(s.handleDashboardAll))
+	mux.HandleFunc("/api/audit", s.requireAuth(s.dataArrayHandler("dashboard.audit")))
 
 	// Code-graph visualization (§8): read-only views via aimee-server's index_graph_* MCP tools.
 	mux.HandleFunc("/api/graph/hubs", s.requireAuth(s.handleGraphHubs))


### PR DESCRIPTION
Reworks the aimee-server web **Dashboard** around metrics the server actually incurs, makes the panel set **user-customizable**, and splits the audit/log view into its own **Logs** tab. `aimee-kb` keeps its own dashboard for KB-internal events.

### Highlights
- **Data-contract fixes**: Memory reads `memory_stats.tier_kinds` (was blank); Agents renders the config roster (was blank cols + "Invalid Date"); a real readiness report replaces the "unavailable" stub; the unpopulated Plugins panel is dropped.
- **Formatting**: human-readable latency (`127428ms` → `2m 7s`), compact tokens (`4.4M`), USD cost with a sub-cent floor.
- **New server-incurred panels**: Guardrail Actions, Cost/Tokens, Success by Agent, Latency by Role (p50/p95/max), Top Tools, Tokens by Agent, Cache Efficiency, Failures, Provider Mix, Confidence.
- **Customization**: a ⚙ Customize popover toggles/reorders panels, persisted per-browser (`localStorage`).
- **Overflow fix**: removes the negative-margin/calc hack so the grid fills its pane exactly — no horizontal scrollbar; vertical only if you add many panels.
- **Logs tab** (`/logs`): backed by the server's tool-action audit ledger — new `dashboard.audit` dispatch method, `/v1/dashboard/audit` route, webchat `/api/audit` + `/logs` SPA route.
- **Active sessions** (webchat-owned) injected into the dashboard payload.

### Design principle
The server dashboard shows only what **aimee-server incurs** (delegations, tool calls, token spend, guardrail verdicts, agents, sessions, readiness). KB-internal event monitoring stays on the KB's own dashboard. See `docs/DASHBOARD.md`.

### Tests / gates
- `frontend/`: `tsc -b` clean, `npm test` green (vitest contract tests over a captured live payload), `vite build` clean.
- Server builds clean (`make -C src ../aimee-server`); clang-format clean.
- Route gates pass: `gen-cli-v1-routes.py` regenerated `src/cli_v1_routes_d.c`; `/v1/dashboard/audit` documented in `api/openapi-server-v1.yaml`; `check-cli-v1-routes.py`, `check-api-conformance-server.py`, `check-v1-method-coverage.py` all ok.

### Docs
`docs/DASHBOARD.md` (new), MANUAL §23 nav list refreshed, README docs table + `docs/WHATS_NEW.md` updated.

Validated live on a running split deployment (server + webchat rebuilt): every panel populates or shows an honest empty state; `/logs` renders the audit ledger.