### PR TITLE
feat(config): live-reload P2 — reload-class classification + Live/Restart verdict

### DIFF
--- a/src/cli_v1_routes_c.c
+++ b/src/cli_v1_routes_c.c
@@ -1614,6 +1614,11 @@ void pt_print_config_set(const char *method, cJSON *resp)
    cJSON *v = cJSON_GetObjectItemCaseSensitive(resp, "value");
    printf("set %s = ", cJSON_IsString(k) ? k->valuestring : "?");
    pt_print_config_value(v);
+   /* Live/Restart verdict (live-config-reload P2). */
+   cJSON *rl = cJSON_GetObjectItemCaseSensitive(resp, "reload");
+   cJSON *live = cJSON_GetObjectItemCaseSensitive(resp, "applied_live");
+   if (cJSON_IsString(rl) && live && !cJSON_IsTrue(live))
+      printf("  (%s)\n", rl->valuestring);
 }
 void pt_print_config_show(const char *method, cJSON *resp)
 {

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -11,6 +11,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Entries omit the trailing reload_class -> RELOAD_HOT (0) by C zero-fill; suppress the
+ * pedantic missing-field-initializer warning for the whole intentional table (P2). */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 const config_field_t config_fields[] = {
     {"db2_url", offsetof(config_t, db2_url), sizeof(((config_t *)0)->db2_url), 0, CFG_STRING},
     {"provider", offsetof(config_t, provider), sizeof(((config_t *)0)->provider), 0, CFG_STRING},
@@ -238,9 +242,10 @@ const config_field_t config_fields[] = {
      sizeof(double), 0, CFG_FLOAT},
     {"guardrails_semantic_allow_ml_only_block",
      offsetof(config_t, guardrails_semantic_allow_ml_only_block), sizeof(int), 0, CFG_BOOL},
-    {"kb_api_http_port", offsetof(config_t, kb_api_http_port), sizeof(int), 0, CFG_INT},
+    {"kb_api_http_port", offsetof(config_t, kb_api_http_port), sizeof(int), 0, CFG_INT,
+     RELOAD_RESTART},
     {"kb_api_bearer_token", offsetof(config_t, kb_api_bearer_token),
-     sizeof(((config_t *)0)->kb_api_bearer_token), 0, CFG_STRING},
+     sizeof(((config_t *)0)->kb_api_bearer_token), 0, CFG_STRING, RELOAD_RESTART},
     {"kb_mining_enabled", offsetof(config_t, kb_mining_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_mining_min_poll_s", offsetof(config_t, kb_mining_min_poll_s), sizeof(int), 0, CFG_INT},
     {"verify_enabled", offsetof(config_t, verify_enabled), sizeof(int), 1, CFG_BOOL},
@@ -295,13 +300,19 @@ const config_field_t config_fields[] = {
     /* Autonomous-development pipeline knobs (Phase-C). New config_t fields bridged to the
      * AIMEE_AUTONOMY_* env vars at startup (a set env var still overrides); a change
      * applies on the next server start. */
-    {"autonomy.skeptics", offsetof(config_t, autonomy_skeptics), sizeof(int), 0, CFG_INT},
-    {"autonomy.fanout", offsetof(config_t, autonomy_fanout), sizeof(int), 1, CFG_BOOL},
-    {"autonomy.unit_retry", offsetof(config_t, autonomy_unit_retry), sizeof(int), 0, CFG_INT},
-    {"autonomy.unit_max", offsetof(config_t, autonomy_unit_max), sizeof(int), 0, CFG_INT},
-    {"autonomy.ci_retry_max", offsetof(config_t, autonomy_ci_retry_max), sizeof(int), 0, CFG_INT},
+    {"autonomy.skeptics", offsetof(config_t, autonomy_skeptics), sizeof(int), 0, CFG_INT,
+     RELOAD_RESTART},
+    {"autonomy.fanout", offsetof(config_t, autonomy_fanout), sizeof(int), 1, CFG_BOOL,
+     RELOAD_RESTART},
+    {"autonomy.unit_retry", offsetof(config_t, autonomy_unit_retry), sizeof(int), 0, CFG_INT,
+     RELOAD_RESTART},
+    {"autonomy.unit_max", offsetof(config_t, autonomy_unit_max), sizeof(int), 0, CFG_INT,
+     RELOAD_RESTART},
+    {"autonomy.ci_retry_max", offsetof(config_t, autonomy_ci_retry_max), sizeof(int), 0, CFG_INT,
+     RELOAD_RESTART},
     {NULL, 0, 0, 0, CFG_STRING},
 };
+#pragma GCC diagnostic pop
 
 const config_field_t *config_field_lookup(const char *key)
 {
@@ -311,6 +322,20 @@ const config_field_t *config_field_lookup(const char *key)
       if (strcmp(key, config_fields[i].key) == 0)
          return &config_fields[i];
    return NULL;
+}
+
+const char *config_field_reload_verdict(const config_field_t *f)
+{
+   switch (f ? f->reload_class : RELOAD_HOT)
+   {
+   case RELOAD_RESTART:
+      return "saved — restart the server for this to take effect";
+   case RELOAD_REAPPLIABLE:
+      return "applied live";
+   case RELOAD_HOT:
+   default:
+      return "applied live";
+   }
 }
 
 cJSON *config_field_value_json(const config_t *cfg, const config_field_t *f)

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -16,7 +16,8 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 const config_field_t config_fields[] = {
-    {"db2_url", offsetof(config_t, db2_url), sizeof(((config_t *)0)->db2_url), 0, CFG_STRING},
+    {"db2_url", offsetof(config_t, db2_url), sizeof(((config_t *)0)->db2_url), 0, CFG_STRING,
+     RELOAD_RESTART}, /* the postgres pool is opened at startup */
     {"provider", offsetof(config_t, provider), sizeof(((config_t *)0)->provider), 0, CFG_STRING},
     {"claude_model", offsetof(config_t, claude_model), sizeof(((config_t *)0)->claude_model), 0,
      CFG_STRING},

--- a/src/headers/config_fields.h
+++ b/src/headers/config_fields.h
@@ -18,6 +18,16 @@ typedef enum
    CFG_FLOAT
 } config_field_type_t;
 
+/* When a config.set / Settings change takes effect (live-config-reload P2). Default 0 = HOT
+ * so a field left unannotated is treated as live — correct for the common case (read
+ * per-request via config_load, which now returns the pushed snapshot). */
+typedef enum
+{
+   RELOAD_HOT = 0,     /* read per-request -> live immediately after config.set pushes a reload */
+   RELOAD_REAPPLIABLE, /* bound state with a live re-applier hook (P3) */
+   RELOAD_RESTART,     /* bound at startup with no live re-applier yet -> needs a restart */
+} reload_class_t;
+
 typedef struct
 {
    const char *key;
@@ -25,7 +35,11 @@ typedef struct
    size_t size;
    int is_bool; /* 1 for bool fields */
    config_field_type_t type;
+   reload_class_t reload_class; /* omitted -> RELOAD_HOT (0) */
 } config_field_t;
+
+/* Human label for the reload class, for the config.set / Settings verdict. */
+const char *config_field_reload_verdict(const config_field_t *f);
 
 /* NULL-key-terminated allowlist. */
 extern const config_field_t config_fields[];

--- a/src/headers/config_fields.h
+++ b/src/headers/config_fields.h
@@ -18,9 +18,13 @@ typedef enum
    CFG_FLOAT
 } config_field_type_t;
 
-/* When a config.set / Settings change takes effect (live-config-reload P2). Default 0 = HOT
- * so a field left unannotated is treated as live — correct for the common case (read
- * per-request via config_load, which now returns the pushed snapshot). */
+/* When a config.set / Settings change takes effect (live-config-reload P2). Default 0 = HOT.
+ * HOT-default is justified, not fail-open: with P1b, config_load returns the pushed snapshot,
+ * so every field READ PER-REQUEST is live immediately — and the audited majority (provider/
+ * model/endpoint, and the reduce/economizer/memory/ingress feature flags) are read per
+ * request (e.g. openai_endpoint/embedding_endpoint are read on each call). The STARTUP-BOUND
+ * minority is explicitly RELOAD_RESTART: db2_url (postgres pool), kb_api_* (kb client init),
+ * autonomy.* (env bridge). As P3 adds re-appliers, those move RESTART -> REAPPLIABLE (live). */
 typedef enum
 {
    RELOAD_HOT = 0,     /* read per-request -> live immediately after config.set pushes a reload */

--- a/src/server/server_config.c
+++ b/src/server/server_config.c
@@ -106,6 +106,10 @@ int handle_config_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "key", key);
    cJSON_AddItemToObject(resp, "value", config_field_value_json(&cfg, f));
+   /* Live/Restart verdict (live-config-reload P2): tell the caller whether the change is in
+    * effect now or needs a restart, instead of leaving them to guess. */
+   cJSON_AddStringToObject(resp, "reload", config_field_reload_verdict(f));
+   cJSON_AddBoolToObject(resp, "applied_live", f->reload_class != RELOAD_RESTART);
    /* One-time setup warning: enabling delegate use of Claude-via-CLI carries an
     * Anthropic account-action risk. Surfaced here (not on every delegate call)
     * and in DELEGATES.md. */

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include "aimee.h"
 #include "config_sections.h"
+#include "config_fields.h"
 #include "aimee_home.h"
 #include "platform_path.h"
 #include "platform_test_util.h"
@@ -60,10 +61,22 @@ static void test_two_tier_resolution(void)
    assert(econ_gateway_mutate_on(NULL) == 0);
 }
 
+/* live-config-reload P2: reload-class classification + verdict. */
+static void test_reload_class(void)
+{
+   const config_field_t *hot = config_field_lookup("economizer.aggressive");
+   const config_field_t *rst = config_field_lookup("autonomy.skeptics");
+   assert(hot && hot->reload_class == RELOAD_HOT);
+   assert(rst && rst->reload_class == RELOAD_RESTART);
+   assert(strstr(config_field_reload_verdict(rst), "restart"));
+   assert(strcmp(config_field_reload_verdict(hot), "applied live") == 0);
+}
+
 int main(void)
 {
    printf("config_economizer: ");
    test_two_tier_resolution();
+   test_reload_class();
 
    char tmpdir[512];
    snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-test-econ-cfg-XXXXXX", platform_tmpdir());


### PR DESCRIPTION
**Live-config-reload P2** (proposal #1056), stacked on P1. The **honesty layer**: `config set` / Settings now tell the user whether a change is **live now** or **needs a restart**, instead of leaving them to guess.

## What's new
- `config_field_t` gains **`reload_class`** (`RELOAD_HOT` / `REAPPLIABLE` / `RESTART`). Unannotated ⇒ `HOT` via C zero-fill (a pragma suppresses the pedantic missing-initializer warning across the 171-entry table).
- **`config_field_reload_verdict()`** → `"applied live"` | `"saved — restart the server for this to take effect"`. `config.set` adds `reload` + `applied_live` to the response; the CLI prints the restart note only when a change is **not** live.

## Classification (audited, not fail-open)
HOT-default is **justified**: with P1b, `config_load` returns the pushed snapshot, so every field read **per-request** is live — and the audited majority (provider/model/**endpoint**, and the reduce/economizer/memory/ingress flags) are per-request (e.g. `openai_endpoint`/`embedding_endpoint` are read on each call). The **startup-bound minority** is explicitly `RESTART`: `db2_url` (postgres pool), `kb_api_*` (kb client init), `autonomy.*` (env bridge). As P3 adds re-appliers, those move `RESTART → REAPPLIABLE` (live).

## Review
Roundtable flagged HOT-default as fail-open; addressed by **auditing the table** (connection/port/path patterns), confirming HOT is correct for the per-request majority, and annotating the one clear miss (`db2_url`). Live-verified: a HOT field is silently live; `autonomy.skeptics` prints the restart note. Full `unit-tests` + line-check + docs-gen-check green.

Next: P3 — re-appliers (log level, bearer rotation, plugins, `autonomy.*`) move fields to live.