### PR TITLE
feat(config): live-reload P3 — re-applier registry (foundation)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1502,6 +1502,19 @@ static uint64_t g_snap_token = 0;          /* content-hash of the active snapsho
 static _Atomic int g_snap_inited = 0;      /* atomic so the config_load wrapper's read is visible */
 static pthread_mutex_t g_snap_wlock = PTHREAD_MUTEX_INITIALIZER;
 
+/* Re-applier registry (P3): hooks run after a reload publishes, under g_snap_wlock. */
+#define CONFIG_MAX_REAPPLIERS 16
+static config_reapplier_fn g_reappliers[CONFIG_MAX_REAPPLIERS];
+static int g_reapplier_count = 0;
+
+void config_reload_register_reapplier(config_reapplier_fn fn)
+{
+   pthread_mutex_lock(&g_snap_wlock);
+   if (fn && g_reapplier_count < CONFIG_MAX_REAPPLIERS)
+      g_reappliers[g_reapplier_count++] = fn;
+   pthread_mutex_unlock(&g_snap_wlock);
+}
+
 /* 1 once config_snapshot_init has seeded the live snapshot (server context). Read by the
  * config_load wrapper to decide snapshot-vs-file; only ever transitions 0 -> 1. */
 static int config_snapshot_live(void)
@@ -1591,7 +1604,13 @@ int config_reload(void)
       pthread_mutex_unlock(&g_snap_wlock);
       return 0; /* self-reload no-op guard: nothing logically changed */
    }
+   /* capture the OLD snapshot (if any) so re-appliers can diff their section, then publish. */
+   config_t old;
+   int have_old =
+       atomic_load_explicit(&g_snap_inited, memory_order_acquire) && config_snapshot_get(&old) == 0;
    config_snapshot_publish(&fresh);
+   for (int i = 0; i < g_reapplier_count; i++)
+      g_reappliers[i](have_old ? &old : &fresh, &fresh);
    pthread_mutex_unlock(&g_snap_wlock);
    return 1; /* a new snapshot was published */
 }

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1766,6 +1766,13 @@ int config_load(config_t *cfg);
 void config_snapshot_init(const config_t *cfg);
 int config_snapshot_get(config_t *out);
 int config_reload(void);
+
+/* Re-applier registry (live-config-reload P3): a hook invoked after config_reload publishes a
+ * new snapshot, receiving the OLD and NEW config so it can push bound state (env bridge, log
+ * level, TLS, …) live when the section it owns changed. Register once at startup. Re-appliers
+ * run under the reload writer lock: they must be quick and must NOT call config_reload. */
+typedef void (*config_reapplier_fn)(const config_t *old_cfg, const config_t *new_cfg);
+void config_reload_register_reapplier(config_reapplier_fn fn);
 /* Force a read from DISK, bypassing the live snapshot. Use for a read-modify-save that must
  * reflect the current on-disk file (e.g. config.set) so it never clobbers an external edit,
  * and internally by config_reload. Ordinary readers should use config_load. */

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -180,7 +180,6 @@ static int run_server(const char *socket_path, log_level_t log_level)
     * the server returns this snapshot, and config_reload (on config.set / SIGHUP) republishes
     * it so changes take effect immediately instead of on the next mtime-cache miss. */
    config_snapshot_init(&cfg);
-
    /* Bridge the autonomy config knobs to their AIMEE_AUTONOMY_* env vars as early as
     * possible — before any consumer (plugin discovery, the wfe engine) could read them
     * via getenv. An explicitly-set env var still overrides (setenv no-overwrite). */

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -65,9 +65,11 @@ static void test_two_tier_resolution(void)
 static void test_reload_class(void)
 {
    const config_field_t *hot = config_field_lookup("economizer.aggressive");
-   const config_field_t *rst = config_field_lookup("autonomy.skeptics");
+   const config_field_t *rst = config_field_lookup("db2_url");           /* startup: pg pool */
+   const config_field_t *aut = config_field_lookup("autonomy.skeptics"); /* env-bridged: restart */
    assert(hot && hot->reload_class == RELOAD_HOT);
    assert(rst && rst->reload_class == RELOAD_RESTART);
+   assert(aut && aut->reload_class == RELOAD_RESTART);
    assert(strstr(config_field_reload_verdict(rst), "restart"));
    assert(strcmp(config_field_reload_verdict(hot), "applied live") == 0);
 }

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -8,8 +8,19 @@
 #include <string.h>
 
 #include "aimee.h"
+#include "config_sections.h"
 #include "platform_path.h"
 #include "platform_test_util.h"
+
+/* P3 re-applier probe. */
+static _Atomic int g_reapply_calls = 0;
+static int g_last_agg = -1;
+static void probe_reapplier(const config_t *o, const config_t *n)
+{
+   (void)o;
+   g_last_agg = n->economizer_aggressive;
+   atomic_fetch_add_explicit(&g_reapply_calls, 1, memory_order_relaxed);
+}
 
 /* Author a config file with a MARKER PAIR (aggressive, budget) via config_save so reload
  * observes a real change. The pair is what the torn-read check keys on. */
@@ -107,10 +118,24 @@ int main(void)
       assert(got.coord_closet_budget_bytes == 2222); /* still the last GOOD snapshot */
    }
 
+   /* --- P3 re-applier registry: a hook fires after a changed reload, with the NEW config --- */
+   {
+      config_reload_register_reapplier(probe_reapplier);
+      int before = atomic_load_explicit(&g_reapply_calls, memory_order_relaxed);
+      write_marker(1, 1111); /* change back to aggressive=1 */
+      assert(config_reload() == 1);
+      assert(atomic_load_explicit(&g_reapply_calls, memory_order_relaxed) == before + 1);
+      assert(g_last_agg == 1); /* re-applier saw the NEW value */
+      /* a no-op reload does NOT fire the re-applier */
+      int mid = atomic_load_explicit(&g_reapply_calls, memory_order_relaxed);
+      assert(config_reload() == 0);
+      assert(atomic_load_explicit(&g_reapply_calls, memory_order_relaxed) == mid);
+   }
+
    /* --- concurrent torn-read stress: readers spin while the writer toggles + reloads --- */
    {
       platform_unsetenv("AIMEE_NO_CACHE"); /* exercise the real cached read path under threads */
-      write_marker(1, 1111);
+      write_marker(0, 2222);               /* a real change vs the prior block's {1,1111} */
       assert(config_reload() == 1);
       pthread_t th[4];
       for (int i = 0; i < 4; i++)


### PR DESCRIPTION
**Live-config-reload P3** (proposal #1056), stacked on P1+P2. Ships the **re-applier registry** — the foundation for making bound (non-per-request) config live — and documents a real thread-safety finding that kept `autonomy.*` at RESTART.

## What's new
- **`config_reload_register_reapplier(fn)`** — a bounded hook registry. `config_reload` captures the **OLD** snapshot (lock-free seqlock read) before publishing, then invokes each `hook(old, new)` under the writer lock, **only on a real change** (the no-op guard skips it). Contract: re-appliers must be quick and must not call `config_reload`.
- Test: the registry fires with the NEW config on a changed reload and is skipped on a no-op.

## Why no autonomy re-applier (reverted, correctly)
The first attempt re-`setenv`'d `AIMEE_AUTONOMY_*` on reload. The roundtable flagged — rightly — that **`setenv` is a POSIX/glibc data race** against the wfe worker threads that `getenv` those vars per run (torn `environ` read / crash). The process environment is an **unsafe cross-thread transport**, and wfe uses env as a *deliberately decoupled* config boundary (it doesn't link `config.h`). So `autonomy.*` stays `RELOAD_RESTART`; making it live safely needs wfe to read a **thread-safe** config source (the snapshot) instead of env — a wfe-boundary redesign, carried as a follow-up. **No unsafe `setenv` ships.**

## Review
Roundtable blocking (setenv thread-safety) addressed by reverting the unsafe re-applier; the registry itself is correct + probe-tested. Full `unit-tests` + line-check green.

Next: P4 — TLS cert live reload (a clean, thread-safe consumer of this registry) → P5 close-out. Carried: autonomy-live via a thread-safe wfe config source.