### PR TITLE
feat(kb-console): S1 — dashboard overview aggregate + UI

### DIFF
--- a/frontend/src/console/pages/ConsoleDashboard.tsx
+++ b/frontend/src/console/pages/ConsoleDashboard.tsx
@@ -1,34 +1,88 @@
 import { useEffect, useState } from 'react';
 import { apiGet } from '../api';
 
-// S0 placeholder. S1 replaces this with the /v1/console/overview panels
-// (Pipeline / Knowledge / Health / Version) rendered from the aggregate.
-interface Overview {
-  schema?: string;
-  degraded?: boolean;
-  components?: unknown[];
+interface Component {
+  name: string;
+  ok: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
 }
 
+interface Overview {
+  schema?: string;
+  generated_at?: string;
+  degraded?: boolean;
+  components?: Component[];
+}
+
+// S1 dashboard: renders the /v1/console/overview aggregate. The kb fans the
+// telemetry read models in-process into a versioned, timestamped envelope with a
+// per-component {ok, data|error}; this page renders each component as a card and
+// surfaces the overall degraded state.
 export default function ConsoleDashboard() {
   const [ov, setOv] = useState<Overview | null>(null);
   const [err, setErr] = useState('');
 
+  async function refresh() {
+    try {
+      setOv(await apiGet<Overview>('/v1/console/overview'));
+      setErr('');
+    } catch (e) {
+      setErr(String(e));
+    }
+  }
+
   useEffect(() => {
-    apiGet<Overview>('/v1/console/overview')
-      .then(setOv)
-      .catch((e) => setErr(String(e)));
+    refresh();
+    const t = setInterval(refresh, 15000);
+    return () => clearInterval(t);
   }, []);
 
   return (
     <section>
-      <h2>Dashboard</h2>
+      <header className="kbc-dash-head">
+        <h2>Dashboard</h2>
+        {ov?.degraded && <span className="kbc-badge kbc-badge-warn">degraded</span>}
+        {ov?.generated_at && <span className="kbc-ts">as of {ov.generated_at}</span>}
+        <button onClick={refresh}>Refresh</button>
+      </header>
       {err && <p className="kbc-error">overview unavailable: {err}</p>}
-      {ov && (
-        <p>
-          connected — schema <code>{ov.schema}</code>, {ov.components?.length ?? 0} components
-          {ov.degraded ? ' (degraded)' : ''}. Panels land in S1.
-        </p>
-      )}
+      <div className="kbc-cards">
+        {(ov?.components ?? []).map((c) => (
+          <ComponentCard key={c.name} c={c} />
+        ))}
+      </div>
     </section>
+  );
+}
+
+function ComponentCard({ c }: { c: Component }) {
+  return (
+    <div className={`kbc-card ${c.ok ? '' : 'kbc-card-err'}`}>
+      <div className="kbc-card-head">
+        <span className="kbc-card-title">{c.name}</span>
+        <span className={`kbc-badge ${c.ok ? 'kbc-badge-ok' : 'kbc-badge-err'}`}>
+          {c.ok ? 'ok' : 'error'}
+        </span>
+      </div>
+      {c.ok ? <DataGrid data={c.data ?? {}} /> : <p className="kbc-error">{c.error}</p>}
+    </div>
+  );
+}
+
+// DataGrid renders a flat object as label/value tiles; nested values are shown
+// compactly as JSON so any component shape stays legible without a bespoke panel.
+function DataGrid({ data }: { data: Record<string, unknown> }) {
+  const entries = Object.entries(data);
+  if (entries.length === 0) return <p className="kbc-muted">no data</p>;
+  return (
+    <dl className="kbc-kv">
+      {entries.map(([k, v]) => (
+        <div key={k} className="kbc-kv-row">
+          <dt>{k}</dt>
+          <dd>{typeof v === 'object' && v !== null ? JSON.stringify(v) : String(v)}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }

--- a/src/kb/http/kb_http_console.c
+++ b/src/kb/http/kb_http_console.c
@@ -3,8 +3,17 @@
  * route ACL (kb_route_acl.c) has already authorized. */
 #include "kb_http_console.h"
 
+#include "aimee.h" /* now_utc */
+#include "cJSON.h"
+#include "kb_service.h"             /* kb_service_workers_json, kb_service_ctx_t */
+#include "kb_service_kb.h"          /* kb_service_health_json */
+#include "db2/kb_service_backend.h" /* async queue status */
+
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+extern kb_service_ctx_t *g_kb_ctx;
 
 /* Compare path to route, tolerating a single trailing slash (matching the route
  * ACL's normalization so the ACL and the handler agree on which path is which). */
@@ -14,6 +23,131 @@ static int route_is(const char *path, const char *route)
    if (n > 1 && path[n - 1] == '/')
       n--;
    return strlen(route) == n && strncmp(path, route, n) == 0;
+}
+
+/* Attach a component {name, ok, data|error} to the overview array. `json` is an
+ * owned JSON string (parsed + freed here) or NULL for an error component. */
+static void add_component(cJSON *arr, const char *name, char *json, const char *err)
+{
+   cJSON *c = cJSON_CreateObject();
+   cJSON_AddStringToObject(c, "name", name);
+   if (json)
+   {
+      cJSON *data = cJSON_Parse(json);
+      free(json);
+      if (data)
+      {
+         cJSON_AddBoolToObject(c, "ok", 1);
+         cJSON_AddItemToObject(c, "data", data);
+      }
+      else
+      {
+         cJSON_AddBoolToObject(c, "ok", 0);
+         cJSON_AddStringToObject(c, "error", "malformed component json");
+      }
+   }
+   else
+   {
+      cJSON_AddBoolToObject(c, "ok", 0);
+      cJSON_AddStringToObject(c, "error", err ? err : "unavailable");
+   }
+   cJSON_AddItemToArray(arr, c);
+}
+
+/* Attach a component whose data is an already-built cJSON object (ownership
+ * transferred). Used for components assembled directly, so values are JSON-
+ * escaped and never round-trip through a fixed-size printf buffer. */
+static void add_component_obj(cJSON *arr, const char *name, cJSON *data)
+{
+   cJSON *c = cJSON_CreateObject();
+   cJSON_AddStringToObject(c, "name", name);
+   cJSON_AddBoolToObject(c, "ok", 1);
+   cJSON_AddItemToObject(c, "data", data);
+   cJSON_AddItemToArray(arr, c);
+}
+
+/* GET /v1/console/overview — the dashboard aggregate. Fans in the kb telemetry
+ * read models IN-PROCESS (direct backend calls, not HTTP — so the console-admin
+ * ACL, which does not allow the underlying telemetry routes, is not self-denied).
+ * Each component carries {name, ok, data|error}; the envelope is versioned +
+ * timestamped and marks degraded when any component failed. */
+static int console_overview(char *out_buf, int out_cap)
+{
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"overview alloc failed\"}");
+      return 500;
+   }
+   cJSON_AddStringToObject(root, "schema", "console.overview.v1");
+   char ts[32];
+   now_utc(ts, sizeof(ts));
+   cJSON_AddStringToObject(root, "generated_at", ts);
+   cJSON *comps = cJSON_AddArrayToObject(root, "components");
+
+   /* Pipeline (async queue depth) — built directly as cJSON (no printf buffer). */
+   db2_kb_service_async_queue_stats_t qs;
+   if (db2_kb_service_async_queue_status(&qs) == 0)
+   {
+      cJSON *d = cJSON_CreateObject();
+      cJSON_AddNumberToObject(d, "pending", qs.pending);
+      cJSON_AddNumberToObject(d, "running", qs.running);
+      cJSON_AddNumberToObject(d, "done", qs.done);
+      cJSON_AddNumberToObject(d, "failed", qs.failed);
+      cJSON_AddNumberToObject(d, "total", qs.total);
+      add_component_obj(comps, "pipeline", d);
+   }
+   else
+      add_component(comps, "pipeline", NULL, "queue unavailable");
+
+   /* Workers — the backend hands back its own JSON string, parsed as-is. */
+   if (g_kb_ctx)
+      add_component(comps, "workers", kb_service_workers_json(g_kb_ctx), NULL);
+   else
+      add_component(comps, "workers", NULL, "workers unavailable");
+
+   /* Health. */
+   add_component(comps, "health", kb_service_health_json(), NULL);
+
+   /* Version — cJSON escapes AIMEE_VERSION, so an odd version string stays valid. */
+   {
+      cJSON *d = cJSON_CreateObject();
+      cJSON_AddStringToObject(d, "version", AIMEE_VERSION);
+      cJSON_AddStringToObject(d, "service", "aimee-kb");
+      add_component_obj(comps, "version", d);
+   }
+
+   /* degraded = any component not ok (ok is a real JSON boolean, so cJSON_IsTrue
+    * matches — verified against cJSON_AddBoolToObject/cJSON_CreateBool). */
+   int degraded = 0;
+   cJSON *it = NULL;
+   cJSON_ArrayForEach(it, comps)
+   {
+      if (!cJSON_IsTrue(cJSON_GetObjectItem(it, "ok")))
+      {
+         degraded = 1;
+         break;
+      }
+   }
+   cJSON_AddBoolToObject(root, "degraded", degraded);
+
+   char *s = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!s)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"overview render failed\"}");
+      return 500;
+   }
+   /* Never emit a truncated (invalid-JSON) body with a 200. */
+   if (strlen(s) >= (size_t)out_cap)
+   {
+      free(s);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"overview too large\"}");
+      return 500;
+   }
+   snprintf(out_buf, (size_t)out_cap, "%s", s);
+   free(s);
+   return 200;
 }
 
 int kb_http_console_route(const char *method, const char *path, char *out_buf, int out_cap)
@@ -26,12 +160,5 @@ int kb_http_console_route(const char *method, const char *path, char *out_buf, i
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
       return 405;
    }
-
-   /* S0 stub. The real dashboard aggregate — an in-process fan-in over the kb
-    * telemetry read models with per-source + global deadlines and per-component
-    * {ok,degraded,data|error,fetched_at} — lands in S1. The envelope shape is
-    * fixed now so the console has a real ACL'd route to gate against. */
-   snprintf(out_buf, (size_t)out_cap,
-            "{\"schema\":\"console.overview.v1\",\"components\":[],\"degraded\":false}");
-   return 200;
+   return console_overview(out_buf, out_cap);
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3595,6 +3595,7 @@ $(TESTPREFIX)/unit-test-kb-http-routes: $(OBJDIR)/tests/test_kb_http_routes.o \
                      $(OBJDIR)/kb/http/kb_http_search.o \
                      $(OBJDIR)/kb/http/kb_route_acl.o \
                      $(OBJDIR)/kb/http/kb_http_console.o \
+                     $(OBJDIR)/util.o \
                      $(OBJDIR)/kb/kb_scope.o \
                      $(OBJDIR)/kb/verifier.o \
                      $(OBJDIR)/kb/enroll.o \

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1236,6 +1236,25 @@ static void test_capabilities(void)
    assert(strstr(buf, "memory") != NULL);
 }
 
+static void test_console_overview(void)
+{
+   /* The dashboard aggregate returns a versioned, timestamped envelope with a
+    * components[] array even when individual sources are unavailable (partial
+    * failure is reported per-component, not a whole-request error). */
+   char buf[65536];
+   int status =
+       kb_http_route_ex("GET", "/v1/console/overview", NULL, NULL, NULL, NULL, 0, buf, sizeof(buf));
+   assert(status == 200);
+   assert(strstr(buf, "\"schema\":\"console.overview.v1\"") != NULL);
+   assert(strstr(buf, "\"components\"") != NULL);
+   assert(strstr(buf, "\"generated_at\"") != NULL);
+   /* Wrong method is rejected. */
+   char b2[256];
+   int s2 =
+       kb_http_route_ex("POST", "/v1/console/overview", NULL, NULL, NULL, NULL, 0, b2, sizeof(b2));
+   assert(s2 == 405);
+}
+
 static void test_intelligence_calibration_readiness(void)
 {
    char buf[512];
@@ -3729,6 +3748,7 @@ int main(void)
    test_health_status_mode();
    test_version();
    test_capabilities();
+   test_console_overview();
    test_intelligence_calibration_readiness();
    test_intelligence_demotion_check();
    test_intelligence_bandit_export();


### PR DESCRIPTION
Slice S1 of the aimee-kb web console (S0 = #1065).

Fills **`GET /v1/console/overview`**: the kb handler fans the telemetry read models **in-process** — async queue depth, workers, health, version — into a **versioned, timestamped envelope** with per-component `{name, ok, data|error}` and a `degraded` flag. In-process (direct backend calls, not HTTP) so the console-admin route ACL isn't self-denied. Plus a React **dashboard** rendering component cards + degraded state, a C dispatch test, and the `util.o` test-link dep (for `now_utc`).

Roundtable-reviewed; findings folded in:
- Components built directly as cJSON (JSON-escaped `AIMEE_VERSION`, no fixed-buffer round-trip).
- **Truncation guard** — never returns 200 with an invalid/truncated body (500 instead).
- Explicit `<stdlib.h>`, root-alloc guard.
- Verified the `cJSON_IsTrue`/`AddBool` degraded check against cJSON internals (a panel false-positive).

Local: `make ../aimee-kb` + `unit-test-kb-http-routes` (with the new overview assertion) pass; `build:console` compiles; clang-format + conformance checks (module-boundary/v1-coverage/target-isolation/container-packaging) clean.