### PR TITLE
feat(config): autonomy.* live — wfe reads the thread-safe snapshot (no restart, no setenv)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -232,7 +232,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 147 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 144 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -430,7 +430,7 @@ The binaries read 147 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CI_RETRY_MAX`, `AIMEE_AUTONOMY_FANOUT`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SKEPTICS`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/config.c
+++ b/src/config.c
@@ -1583,31 +1583,47 @@ int config_autonomy_lookup(const char *env_name, long *out)
    /* Operator override wins: an explicitly-exported env var (getenv is a safe read now that
     * nothing setenv's these). Otherwise the LIVE snapshot — so a config.set on autonomy.*
     * takes effect on the next workflow with no restart and no cross-thread setenv. */
-   const char *e = getenv(env_name);
    config_t c;
    int have = config_snapshot_get(&c) == 0;
-#define TC_AUT(name, field, boolish)                                                               \
-   if (strcmp(env_name, name) == 0)                                                                \
-   {                                                                                               \
-      if (e && e[0])                                                                               \
-      {                                                                                            \
-         *out = (boolish) ? (e[0] == '1' ? 1 : 0) : atol(e);                                       \
-         return 1;                                                                                 \
-      }                                                                                            \
-      if (have)                                                                                    \
-      {                                                                                            \
-         *out = c.field;                                                                           \
-         return 1;                                                                                 \
-      }                                                                                            \
-      return 0;                                                                                    \
+   long snap = 0;
+   int boolish = 0, is_autonomy = 1;
+   if (strcmp(env_name, "AIMEE_AUTONOMY_SKEPTICS") == 0)
+      snap = have ? c.autonomy_skeptics : 0;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_FANOUT") == 0)
+      snap = have ? c.autonomy_fanout : 0, boolish = 1;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_UNIT_RETRY") == 0)
+      snap = have ? c.autonomy_unit_retry : 0;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_UNIT_MAX") == 0)
+      snap = have ? c.autonomy_unit_max : 0;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_CI_RETRY_MAX") == 0)
+      snap = have ? c.autonomy_ci_retry_max : 0;
+   else
+      is_autonomy = 0;
+   if (!is_autonomy)
+      return 0; /* not a config-backed autonomy var (e.g. MAX_TURNS) -> caller falls back */
+
+   const char *e = getenv(env_name);
+   if (e && e[0]) /* operator override — VALIDATED (a garbage value falls through to snapshot) */
+   {
+      if (boolish)
+      {
+         *out = (e[0] == '1') ? 1 : 0;
+         return 1;
+      }
+      char *end = NULL;
+      long v = strtol(e, &end, 10);
+      if (end && *end == '\0')
+      {
+         *out = v;
+         return 1;
+      }
    }
-   TC_AUT("AIMEE_AUTONOMY_SKEPTICS", autonomy_skeptics, 0)
-   TC_AUT("AIMEE_AUTONOMY_FANOUT", autonomy_fanout, 1)
-   TC_AUT("AIMEE_AUTONOMY_UNIT_RETRY", autonomy_unit_retry, 0)
-   TC_AUT("AIMEE_AUTONOMY_UNIT_MAX", autonomy_unit_max, 0)
-   TC_AUT("AIMEE_AUTONOMY_CI_RETRY_MAX", autonomy_ci_retry_max, 0)
-#undef TC_AUT
-   return 0; /* not a config-backed autonomy var (e.g. MAX_TURNS) -> caller falls back to env */
+   if (have)
+   {
+      *out = snap; /* live snapshot value */
+      return 1;
+   }
+   return 0;
 }
 
 int config_reload(void)

--- a/src/config.c
+++ b/src/config.c
@@ -1576,6 +1576,40 @@ int config_snapshot_get(config_t *out)
    }
 }
 
+int config_autonomy_lookup(const char *env_name, long *out)
+{
+   if (!env_name || !out)
+      return 0;
+   /* Operator override wins: an explicitly-exported env var (getenv is a safe read now that
+    * nothing setenv's these). Otherwise the LIVE snapshot — so a config.set on autonomy.*
+    * takes effect on the next workflow with no restart and no cross-thread setenv. */
+   const char *e = getenv(env_name);
+   config_t c;
+   int have = config_snapshot_get(&c) == 0;
+#define TC_AUT(name, field, boolish)                                                               \
+   if (strcmp(env_name, name) == 0)                                                                \
+   {                                                                                               \
+      if (e && e[0])                                                                               \
+      {                                                                                            \
+         *out = (boolish) ? (e[0] == '1' ? 1 : 0) : atol(e);                                       \
+         return 1;                                                                                 \
+      }                                                                                            \
+      if (have)                                                                                    \
+      {                                                                                            \
+         *out = c.field;                                                                           \
+         return 1;                                                                                 \
+      }                                                                                            \
+      return 0;                                                                                    \
+   }
+   TC_AUT("AIMEE_AUTONOMY_SKEPTICS", autonomy_skeptics, 0)
+   TC_AUT("AIMEE_AUTONOMY_FANOUT", autonomy_fanout, 1)
+   TC_AUT("AIMEE_AUTONOMY_UNIT_RETRY", autonomy_unit_retry, 0)
+   TC_AUT("AIMEE_AUTONOMY_UNIT_MAX", autonomy_unit_max, 0)
+   TC_AUT("AIMEE_AUTONOMY_CI_RETRY_MAX", autonomy_ci_retry_max, 0)
+#undef TC_AUT
+   return 0; /* not a config-backed autonomy var (e.g. MAX_TURNS) -> caller falls back to env */
+}
+
 int config_reload(void)
 {
    /* Hold the writer lock across the WHOLE reload (load + validate + token + publish) so two

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -301,16 +301,11 @@ const config_field_t config_fields[] = {
     /* Autonomous-development pipeline knobs (Phase-C). New config_t fields bridged to the
      * AIMEE_AUTONOMY_* env vars at startup (a set env var still overrides); a change
      * applies on the next server start. */
-    {"autonomy.skeptics", offsetof(config_t, autonomy_skeptics), sizeof(int), 0, CFG_INT,
-     RELOAD_RESTART},
-    {"autonomy.fanout", offsetof(config_t, autonomy_fanout), sizeof(int), 1, CFG_BOOL,
-     RELOAD_RESTART},
-    {"autonomy.unit_retry", offsetof(config_t, autonomy_unit_retry), sizeof(int), 0, CFG_INT,
-     RELOAD_RESTART},
-    {"autonomy.unit_max", offsetof(config_t, autonomy_unit_max), sizeof(int), 0, CFG_INT,
-     RELOAD_RESTART},
-    {"autonomy.ci_retry_max", offsetof(config_t, autonomy_ci_retry_max), sizeof(int), 0, CFG_INT,
-     RELOAD_RESTART},
+    {"autonomy.skeptics", offsetof(config_t, autonomy_skeptics), sizeof(int), 0, CFG_INT},
+    {"autonomy.fanout", offsetof(config_t, autonomy_fanout), sizeof(int), 1, CFG_BOOL},
+    {"autonomy.unit_retry", offsetof(config_t, autonomy_unit_retry), sizeof(int), 0, CFG_INT},
+    {"autonomy.unit_max", offsetof(config_t, autonomy_unit_max), sizeof(int), 0, CFG_INT},
+    {"autonomy.ci_retry_max", offsetof(config_t, autonomy_ci_retry_max), sizeof(int), 0, CFG_INT},
     {NULL, 0, 0, 0, CFG_STRING},
 };
 #pragma GCC diagnostic pop

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -841,19 +841,9 @@ void config_parse_autonomy_section(config_t *cfg, cJSON *root)
  * arg is 0 — it sets the var ONLY when unset, so an explicitly-exported env var (a
  * deployment override) always wins over the config value. Call once at server startup;
  * a Settings change to these knobs therefore applies on the next server start. */
-void autonomy_config_to_env(const config_t *cfg)
-{
-   char buf[16]; /* an int is at most 11 chars + sign + NUL = 13 <= 16 */
-   snprintf(buf, sizeof buf, "%d", cfg->autonomy_skeptics);
-   setenv("AIMEE_AUTONOMY_SKEPTICS", buf, 0);
-   setenv("AIMEE_AUTONOMY_FANOUT", cfg->autonomy_fanout ? "1" : "0", 0);
-   snprintf(buf, sizeof buf, "%d", cfg->autonomy_unit_retry);
-   setenv("AIMEE_AUTONOMY_UNIT_RETRY", buf, 0);
-   snprintf(buf, sizeof buf, "%d", cfg->autonomy_unit_max);
-   setenv("AIMEE_AUTONOMY_UNIT_MAX", buf, 0);
-   snprintf(buf, sizeof buf, "%d", cfg->autonomy_ci_retry_max);
-   setenv("AIMEE_AUTONOMY_CI_RETRY_MAX", buf, 0);
-}
+/* NOTE: autonomy_config_to_env (the startup setenv bridge) was REMOVED — wfe now reads
+ * autonomy.* live from the config snapshot via config_autonomy_lookup (thread-safe), so there
+ * is no cross-thread setenv. An operator-exported AIMEE_AUTONOMY_* still overrides. */
 
 /* Normalize economizer gateway-mutation invariants IN MEMORY after parse. mutate=1
  * requires the shadow seam so the validation gates always have a same-payload

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1773,6 +1773,13 @@ int config_reload(void);
  * run under the reload writer lock: they must be quick and must NOT call config_reload. */
 typedef void (*config_reapplier_fn)(const config_t *old_cfg, const config_t *new_cfg);
 void config_reload_register_reapplier(config_reapplier_fn fn);
+
+/* Live autonomy.* accessor (thread-safe) for wfe: for an AIMEE_AUTONOMY_* env NAME that maps
+ * to a config field, write the effective value to *out and return 1 — preferring an operator-
+ * exported env var, else the live config snapshot. Returns 0 for a non-config autonomy var
+ * (e.g. MAX_TURNS) so the caller falls back to its own getenv default. Replaces the unsafe
+ * setenv env-bridge for live reload: no cross-thread setenv, wfe reads the seqlock snapshot. */
+int config_autonomy_lookup(const char *env_name, long *out);
 /* Force a read from DISK, bypassing the live snapshot. Use for a read-modify-save that must
  * reflect the current on-disk file (e.g. config.set) so it never clobbers an external edit,
  * and internally by config_reload. Ordinary readers should use config_load. */

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -23,7 +23,6 @@ void config_parse_worktree_gc_section(config_t *cfg, cJSON *root);
 void config_parse_fold_section(config_t *cfg, cJSON *root);
 void config_parse_reduce_section(config_t *cfg, cJSON *root);
 void config_parse_autonomy_section(config_t *cfg, cJSON *root);
-void autonomy_config_to_env(const config_t *cfg);
 void config_apply_reduce_consistency(config_t *cfg);
 void config_parse_memory_section(config_t *cfg, cJSON *root);
 void config_parse_cross_verify_section(config_t *cfg, cJSON *root);

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -180,10 +180,10 @@ static int run_server(const char *socket_path, log_level_t log_level)
     * the server returns this snapshot, and config_reload (on config.set / SIGHUP) republishes
     * it so changes take effect immediately instead of on the next mtime-cache miss. */
    config_snapshot_init(&cfg);
-   /* Bridge the autonomy config knobs to their AIMEE_AUTONOMY_* env vars as early as
-    * possible — before any consumer (plugin discovery, the wfe engine) could read them
-    * via getenv. An explicitly-set env var still overrides (setenv no-overwrite). */
-   autonomy_config_to_env(&cfg);
+   /* NOTE: the autonomy.* env bridge (autonomy_config_to_env) is intentionally NOT called —
+    * wfe now reads autonomy.* LIVE from the config snapshot via config_autonomy_lookup (an
+    * operator-exported AIMEE_AUTONOMY_* still overrides), so a config.set applies without a
+    * restart and without an unsafe cross-thread setenv. */
 
    /* Startup-fatal validation for the live gateway-mutation path: an invalid
     * session-disable TTL (<=0) must refuse to bring up the /v1 server rather than

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1319,7 +1319,7 @@ $(TESTPREFIX)/unit-test-wfe-engine: $(OBJDIR)/tests/test_wfe_engine.o \
 
 # Workflow engine W3: block executors (freeze is real git; others integration-gated).
 $(TESTPREFIX)/unit-test-wfe-blocks: $(OBJDIR)/tests/test_wfe_blocks.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                     $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
@@ -1385,7 +1385,7 @@ $(TESTPREFIX)/unit-test-wfe-bind-ingress: $(OBJDIR)/tests/test_wfe_bind_ingress.
                                     $(OBJDIR)/workflow/wfe_bind_ingress.o $(OBJDIR)/log.o $(OBJDIR)/workflow/wfe_enforce.o \
                                     $(OBJDIR)/workflow/wfe_externalization.o $(OBJDIR)/db1/wfe_binding.o \
                                     $(OBJDIR)/workflow/wfe_router.o $(OBJDIR)/workflow/wfe_router_catalog.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/workflow/wfe_manager_artifacts.o $(OBJDIR)/workflow/wfe_deliver.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
@@ -1403,7 +1403,7 @@ $(TESTPREFIX)/unit-test-primary-cli-ingestor: $(OBJDIR)/tests/test_primary_cli_i
                                     $(OBJDIR)/workflow/wfe_bind_ingress.o $(OBJDIR)/workflow/wfe_enforce.o \
                                     $(OBJDIR)/workflow/wfe_externalization.o $(OBJDIR)/db1/wfe_binding.o \
                                     $(OBJDIR)/workflow/wfe_router.o $(OBJDIR)/workflow/wfe_router_catalog.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/workflow/wfe_manager_artifacts.o $(OBJDIR)/workflow/wfe_deliver.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
@@ -1417,7 +1417,7 @@ $(TESTPREFIX)/unit-test-primary-cli-ingestor: $(OBJDIR)/tests/test_primary_cli_i
 $(TESTPREFIX)/unit-test-wfe-block-resolve: $(OBJDIR)/tests/test_wfe_block_resolve.o \
                                     $(OBJDIR)/workflow/wfe_block_resolve.o $(OBJDIR)/workflow/wfe_enforce.o \
                                     $(OBJDIR)/workflow/wfe_externalization.o $(OBJDIR)/db1/wfe_binding.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/workflow/wfe_manager_artifacts.o $(OBJDIR)/workflow/wfe_deliver.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
@@ -1432,7 +1432,7 @@ $(TESTPREFIX)/unit-test-wfe-advance-exec: $(OBJDIR)/tests/test_wfe_advance_exec.
                                     $(OBJDIR)/workflow/wfe_advance_exec.o $(OBJDIR)/workflow/wfe_advance.o \
                                     $(OBJDIR)/workflow/wfe_enforce.o $(OBJDIR)/workflow/wfe_externalization.o \
                                     $(OBJDIR)/db1/wfe_binding.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/workflow/wfe_manager_artifacts.o $(OBJDIR)/workflow/wfe_deliver.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
@@ -1516,7 +1516,7 @@ $(TESTPREFIX)/unit-test-wfe-router-catalog: $(OBJDIR)/tests/test_wfe_router_cata
 
 # Integration: the manager executors driven through the real engine (DB1-backed).
 $(TESTPREFIX)/unit-test-wfe-manager-flow: $(OBJDIR)/tests/test_wfe_manager_flow.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/workflow/wfe_manager_artifacts.o $(OBJDIR)/workflow/wfe_deliver.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
@@ -1529,7 +1529,7 @@ $(TESTPREFIX)/unit-test-wfe-manager-flow: $(OBJDIR)/tests/test_wfe_manager_flow.
 
 # Config-extensible blocks + safety blocks share the blocks/engine/registry deps.
 $(TESTPREFIX)/unit-test-wfe-custom: $(OBJDIR)/tests/test_wfe_custom.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                     $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
@@ -1540,7 +1540,7 @@ $(TESTPREFIX)/unit-test-wfe-custom: $(OBJDIR)/tests/test_wfe_custom.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-wfe-safety: $(OBJDIR)/tests/test_wfe_safety.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                     $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
@@ -1555,7 +1555,7 @@ $(TESTPREFIX)/unit-test-wfe-failure-taxonomy: $(OBJDIR)/tests/test_wfe_failure_t
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm
 
 $(TESTPREFIX)/unit-test-wfe-delegate-seam: $(OBJDIR)/tests/test_wfe_delegate_seam.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                     $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
@@ -1568,7 +1568,7 @@ $(TESTPREFIX)/unit-test-wfe-delegate-seam: $(OBJDIR)/tests/test_wfe_delegate_sea
 $(TESTPREFIX)/unit-test-wfe-scheduler: $(OBJDIR)/tests/test_wfe_scheduler.o \
                                     $(OBJDIR)/server/wfe_scheduler.o $(OBJDIR)/workflow/wfe_autonomy.o \
                                     $(OBJDIR)/tests/support/log_stub.o \
-                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                     $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
@@ -3407,6 +3407,9 @@ $(OBJDIR)/tests/support/mock_agent_http.o: tests/support/mock_agent_http.c tests
 	@mkdir -p $(dir $@) && $(CC) $(TEST_C_FLAGS) -o $@ -c $<
 
 $(OBJDIR)/tests/support/ir_ingress_stubs.o: tests/support/ir_ingress_stubs.c
+	@mkdir -p $(dir $@) && $(CC) $(TEST_C_FLAGS) -o $@ -c $<
+
+$(OBJDIR)/tests/support/config_autonomy_stub.o: tests/support/config_autonomy_stub.c
 	@mkdir -p $(dir $@) && $(CC) $(TEST_C_FLAGS) -o $@ -c $<
 
 $(OBJDIR)/tests/support/router_advise_stub.o: tests/support/router_advise_stub.c

--- a/src/tests/support/config_autonomy_stub.c
+++ b/src/tests/support/config_autonomy_stub.c
@@ -1,0 +1,16 @@
+/* Shared stub for wfe tests that link wfe_blocks.o (which reads autonomy.* via
+ * config_autonomy_lookup) but not config.o. Mimics production's OPERATOR-ENV path (there is
+ * no config snapshot in these tests): return the env value if set, else 0 so the caller falls
+ * back to its own default. This preserves the tests' setenv-driven behavior. */
+#include <stdlib.h>
+#include <string.h>
+int config_autonomy_lookup(const char *env_name, long *out)
+{
+   if (!env_name || !out)
+      return 0;
+   const char *e = getenv(env_name);
+   if (!e || !e[0])
+      return 0;
+   *out = strstr(env_name, "FANOUT") ? (e[0] == '1' ? 1 : 0) : atol(e);
+   return 1;
+}

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -65,11 +65,12 @@ static void test_two_tier_resolution(void)
 static void test_reload_class(void)
 {
    const config_field_t *hot = config_field_lookup("economizer.aggressive");
-   const config_field_t *rst = config_field_lookup("db2_url");           /* startup: pg pool */
-   const config_field_t *aut = config_field_lookup("autonomy.skeptics"); /* env-bridged: restart */
+   const config_field_t *rst = config_field_lookup("db2_url"); /* startup: pg pool */
+   const config_field_t *aut =
+       config_field_lookup("autonomy.skeptics"); /* live via snapshot: HOT */
    assert(hot && hot->reload_class == RELOAD_HOT);
    assert(rst && rst->reload_class == RELOAD_RESTART);
-   assert(aut && aut->reload_class == RELOAD_RESTART);
+   assert(aut && aut->reload_class == RELOAD_HOT);
    assert(strstr(config_field_reload_verdict(rst), "restart"));
    assert(strcmp(config_field_reload_verdict(hot), "applied live") == 0);
 }

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -132,6 +132,28 @@ int main(void)
       assert(atomic_load_explicit(&g_reapply_calls, memory_order_relaxed) == mid);
    }
 
+   /* --- autonomy-live: config_autonomy_lookup (operator env override > live snapshot,
+    * non-config var -> fall back) --- */
+   {
+      long v;
+      /* a non-config autonomy var -> 0 so the caller uses its own env/default */
+      platform_unsetenv("AIMEE_AUTONOMY_MAX_TURNS");
+      assert(config_autonomy_lookup("AIMEE_AUTONOMY_MAX_TURNS", &v) == 0);
+      /* operator env override wins */
+      platform_setenv("AIMEE_AUTONOMY_SKEPTICS", "7");
+      assert(config_autonomy_lookup("AIMEE_AUTONOMY_SKEPTICS", &v) == 1 && v == 7);
+      /* no env -> the LIVE snapshot value (write skeptics=9, reload, look up) */
+      platform_unsetenv("AIMEE_AUTONOMY_SKEPTICS");
+      static config_t sc;
+      memset(&sc, 0, sizeof sc);
+      config_load(&sc); /* snapshot base */
+      sc.reduce_gateway_session_disable_ttl_ms = 3600000;
+      sc.autonomy_skeptics = 9;
+      assert(config_save(&sc) == 0);
+      assert(config_reload() == 1);
+      assert(config_autonomy_lookup("AIMEE_AUTONOMY_SKEPTICS", &v) == 1 && v == 9);
+   }
+
    /* --- concurrent torn-read stress: readers spin while the writer toggles + reloads --- */
    {
       platform_unsetenv("AIMEE_NO_CACHE"); /* exercise the real cached read path under threads */

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include "aimee_home.h"
+#include "config.h" /* config_autonomy_lookup: live autonomy.* (snapshot) instead of setenv */
 #include "cJSON.h"
 #include "util.h"
 #include "wfe_deliver.h" /* gate.deliver verdict-graph re-verify (Q4) */
@@ -357,22 +358,12 @@ static int wfe_judge_refuted(const char *workdir, const char *lens)
 
 int wfe_implement_adversarial_ok(const char *workdir)
 {
-   const char *sv = getenv("AIMEE_AUTONOMY_SKEPTICS");
+   /* LIVE value (operator env override > config snapshot); config-backed so a config.set on
+    * autonomy.skeptics applies without a restart. */
    long k = 0;
-   if (sv && sv[0])
-   {
-      char *e = NULL;
-      long v = strtol(sv, &e, 10);
-      if (e && *e == '\0' && v >= 0)
-         k = v;
-      else
-         /* A set-but-invalid value on a SAFETY knob silently disables the tier
-          * (fail-open) if we default to 0 quietly — warn so the operator sees it. */
-         fprintf(stderr,
-                 "wfe: invalid AIMEE_AUTONOMY_SKEPTICS '%s' — adversarial tier "
-                 "stays OFF\n",
-                 sv);
-   }
+   long lv;
+   if (config_autonomy_lookup("AIMEE_AUTONOMY_SKEPTICS", &lv) && lv >= 0)
+      k = lv;
    if (k <= 0)
       return 1; /* tier OFF (default) -> unchanged behavior */
    if (!g_judge || !g_judge->judge)
@@ -519,6 +510,11 @@ static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
 /* A positive-long env with a default (0/garbage/negative -> default). */
 static long wfe_env_pos(const char *name, long def)
 {
+   /* live-config-reload: for a config-backed AIMEE_AUTONOMY_* var, take the LIVE value
+    * (operator env override > snapshot) so a config.set applies without a restart. */
+   long lv;
+   if (config_autonomy_lookup(name, &lv))
+      return lv > 0 ? lv : def;
    const char *v = getenv(name);
    if (!v || !v[0])
       return def;
@@ -676,7 +672,9 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
    char commit[64] = "";
    double cost = 0.0;
 
-   if (getenv("AIMEE_AUTONOMY_FANOUT") && getenv("AIMEE_AUTONOMY_FANOUT")[0] == '1')
+   long fanout_on = 0;
+   (void)config_autonomy_lookup("AIMEE_AUTONOMY_FANOUT", &fanout_on); /* live: env > snapshot */
+   if (fanout_on)
    {
       /* Manager loop (PC3b): decompose -> fan out engineer per unit -> per-unit verify
        * + retry-different. A unit that never passes parks pending_human via DEGRADED
@@ -936,15 +934,10 @@ static wfe_step_result_t exec_gate_ci(wfe_ctx *ctx, const wfe_node_t *node)
        * input, bounded per-work-item by AIMEE_AUTONOMY_CI_RETRY_MAX (default 2,
        * counted from the recorded ci_event failures). On exhaustion, park for a human
        * via the PC1 DEGRADED class rather than spinning the loop. */
-      const char *cv = getenv("AIMEE_AUTONOMY_CI_RETRY_MAX");
       long cap = 2;
-      if (cv && cv[0])
-      {
-         char *e = NULL;
-         long v = strtol(cv, &e, 10);
-         if (e && *e == '\0' && v > 0)
-            cap = v;
-      }
+      long lv; /* live: operator env override > config snapshot */
+      if (config_autonomy_lookup("AIMEE_AUTONOMY_CI_RETRY_MAX", &lv) && lv > 0)
+         cap = lv;
       if (fail_count >= cap)
          return wfe_step_failed_class(WFE_FAIL_DEGRADED, 0); /* park pending_human */
       /* Poll-only path (no webhook events): record this failure so the per-work-item


### PR DESCRIPTION
Completes the carried follow-up from live-config-reload P3: **`autonomy.*` now takes effect on the next workflow with no restart** — the *safe* version of the re-applier that was reverted (setenv-vs-getenv was a data race). Moves `autonomy.*` from RESTART to **HOT**.

## Design
- **`config_autonomy_lookup(env_name, out)`** — for an `AIMEE_AUTONOMY_*` name mapping to a config field, prefer an **operator-exported env var** (getenv, a safe read now that nothing `setenv`s these), else the **live config snapshot** (thread-safe seqlock POD copy). Numeric env values are **strtol-validated** (garbage falls through to the snapshot). Returns 0 for a non-config var (e.g. `MAX_TURNS`) so the caller falls back.
- `wfe_blocks.c` reads the 5 config-backed autonomy vars through it (`wfe_env_pos` + the 3 direct sites). wfe already coupled to `aimee_home.h`; this adds `config.h`.
- **Removed** the startup `autonomy_config_to_env` **setenv bridge** — no cross-thread `setenv`; wfe reads the snapshot live.
- `autonomy.*`: RESTART → **HOT**.

## Why this is safe (the earlier revert)
The P3 re-applier `setenv`'d these on reload — a POSIX/glibc data race against wfe's per-run `getenv`. This version has wfe **read** the thread-safe snapshot instead; reads are lock-free (seqlock), there is no `setenv`. **Audited the whole tree**: the only `setenv` was the (now-removed) bridge; only wfe + tests read these.

## Review
Roundtable (no blocking): tree-wide audit done, `strtol` validation restored, dead bridge removed. Live-verified: `config set autonomy.skeptics 3` → "set autonomy.skeptics = 3" (no restart note). Shared `tests/support/config_autonomy_stub.o` for the 10 wfe tests. Full `unit-tests` + line-check green.