### PR TITLE
docs(quickstart): fix stale embedder service/volume references

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -18,7 +18,7 @@ The **combined** image co-locates both aimee binaries in one container: the know
 ### Prerequisites
 
 - Docker Engine + the Docker Compose plugin (`docker compose`, v2).
-- ~4 GB free RAM and a few GB of disk for Postgres, the bundled models, and build layers.
+- ~8 GB free RAM and ~10 GB of disk. The combined image bakes in ~5.5 GB of CPU inference model weights (embed, rerank, synth) on top of Postgres data and build layers. (Build `--build-arg WITH_LLM=0` for a lean server+kb image that points at an external `AIMEE_LLM_URL` instead.)
 - No credentials or API keys are required for the default build.
 
 ### 1.1 Clone and start the stack
@@ -35,9 +35,9 @@ By default this brings up **two** services. The browser webchat runs *inside* th
 |---------|-----------|------|
 | `aimee-server-kb` | Both aimee binaries (server and kb), the browser webchat UI, and a bundled CPU inference gateway (embed, rerank, synth) in one container | `8743` (server `/v1`, native TLS self signed; plaintext `8740` loopback only), `8741` (kb `/v1`), `8443` (webchat HTTPS, self signed) |
 | `postgres` | `pgvector/pgvector:pg16`, DB2 (`aimee_shared`) for knowledge and vectors | internal |
-| `embedder`, `llm` *(optional)* | Standalone embedder and curator LLM sidecars. Off by default, since the combined image already bundles both. Split them out as separate services with `--profile external-llm`. | internal |
+| `llm` *(optional)* | Standalone curator LLM sidecar (Gemma 3n E4B via `llama.cpp`). Off by default — the bundled gateway already serves embed, rerank, and synth. Enable it with `--profile external-llm` for a lean `WITH_LLM=0` image, or to bring your own curator GGUF (point `LLM_ENDPOINT` at it). | internal |
 
-The kb auto-applies its DB2 schema (tables plus the `pg_trgm` and `vector` extensions) on first boot. The first `--build` takes a few minutes to compile the binaries and bake the CPU models into the image. Later starts are fast. To split the embedder and curator LLM into their own containers instead of the bundled gateway, add the profile: `docker compose -f compose.combined.yaml --profile external-llm up --build -d`.
+The kb auto-applies its DB2 schema (tables plus the `pg_trgm` and `vector` extensions) on first boot. The first `--build` takes a few minutes to compile the binaries; the CPU inference model weights are pulled in prebuilt (baked into the image), not downloaded at boot, so later starts are fast. To also run the standalone curator LLM sidecar — for a lean `WITH_LLM=0` image or a custom curator GGUF — add the profile: `docker compose -f compose.combined.yaml --profile external-llm up --build -d`.
 
 ### 1.2 Verify it's healthy
 
@@ -80,7 +80,7 @@ docker compose -f compose.combined.yaml pull && \
   docker compose -f compose.combined.yaml up -d --build         # update: rebuild and recreate
 ```
 
-Durable state lives in named volumes (`*-postgres`, `*-home`, `*-workspaces`, `*-embedder-models`), so `down` and recreate are safe; only `down -v` erases data.
+Durable state lives in named volumes (`*-postgres`, `*-home`, `*-workspaces`), so `down` and recreate are safe; only `down -v` erases data. (The CPU inference model weights are baked into the image, not a volume.)
 
 ---
 
@@ -346,7 +346,7 @@ As on the other platforms, `aimee chat` and `aimee launch` work against a remote
 |------|------|
 | `<aimee_home>/remote.conf` | Persisted thin-client remote target (`aimee remote set`). `aimee_home` is `~/.config/aimee` on Linux/macOS; `%LOCALAPPDATA%\aimee` on Windows. |
 | `aimee.yaml` | Server config (bearer, `remote_writes`, kb wiring, agents). In Docker this is inside the `*-home` volume at `/var/lib/aimee/aimee.yaml`. |
-| Named Docker volumes | `*-postgres` (DB2), `*-home` (server/kb state), `*-workspaces`, `*-embedder-models`. |
+| Named Docker volumes | `*-postgres` (DB2), `*-home` (server/kb state), `*-workspaces`. (The `--profile external-llm` sidecar adds `aimee-llm-models` for its GGUF cache.) |
 
 ## TLS support by build
 


### PR DESCRIPTION
## What

QUICKSTART still described a topology the combined stack no longer has. Fixes verified against `compose.combined.yaml` and `Dockerfile.combined`:

- **Service table** — the `--profile external-llm` row claimed it splits out a *standalone `embedder`* service. The profile defines **only** the curator `llm` sidecar; there is no `embedder` service in the compose. Rewrote the row to describe just the `llm` sidecar and when to use it (lean `WITH_LLM=0` image / BYO curator GGUF).
- **`*-embedder-models` volume** — removed from both volume lists ("Managing the stack" and "Where things live"). No such volume exists; the CPU inference weights are baked into the image. Noted the `external-llm` sidecar's own `aimee-llm-models` cache instead.
- **Prerequisites** — `~4 GB RAM` understated the bundled CPU inference gateway; bumped to ~8 GB RAM / ~10 GB disk with the ~5.5 GB baked-weights figure (from `Dockerfile.combined`) and the `WITH_LLM=0` lean-build escape hatch.
- **First-build note** — clarified the model weights are pulled in prebuilt (baked), not downloaded at boot.

## Validation

Roundtable review (`delegate roundtable --mode review`, non-degraded, 4 verified). Its verifiable flags — `external-llm` profile name, `aimee-llm-models` volume, `WITH_LLM`/`AIMEE_LLM_URL` names, and the ~5.5 GB figure — were each confirmed against the compose file and Dockerfile. Docs-only; no code paths touched.