### PR TITLE
feat(tls): live cert reload on SIGHUP — swap SSL_CTX without dropping the listener

### DIFF
--- a/src/headers/server_tls.h
+++ b/src/headers/server_tls.h
@@ -43,6 +43,12 @@ extern "C"
    /* server_tls_init from the default location (<config>/tls/server.crt + .key). */
    int server_tls_init_default(void);
 
+   /* Live cert reload (live-config-reload): re-read the SAME cert/key files server_tls_init
+    * was given and atomically swap the listener's SSL_CTX (new handshakes use the new cert;
+    * in-flight connections keep the old until they drain). Validate-or-keep: a cert that fails
+    * to load keeps the current one. Returns 1 = reloaded, 0 = TLS not enabled, -1 = kept. */
+   int server_tls_reload(void);
+
    /* Per-connection lifecycle for the conn worker: handshake an accepted fd and
     * register its SSL on the conn-io shim (NULL on failure — caller closes fd);
     * and the teardown (unregister + shutdown + free). */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -13,8 +13,9 @@
 #include "primary_cli_ingestor.h"
 #include "server.h"
 #include "turn_registry.h"
-#include "server_http.h" /* server_http_api_status_report */
-#include "config.h"      /* config_t / config_load for api.status, api.enable */
+#include "server_http.h"
+#include "server_tls.h" /* server_http_api_status_report */
+#include "config.h"     /* config_t / config_load for api.status, api.enable */
 #include "delegate_backend_docker.h"
 #include "delegate_backend_local.h"
 #include "delegate_backend_ssh.h"
@@ -2036,6 +2037,9 @@ int server_run(server_ctx_t *ctx)
          int rc = config_reload();
          aimee_log(rc < 0 ? LOG_WARN : LOG_INFO, "config", "SIGHUP config reload: %s",
                    rc > 0 ? "applied" : (rc == 0 ? "no change" : "rejected (kept running config)"));
+         /* Also live-reload the TLS cert (re-read cert/key + swap SSL_CTX) so a renewed cert
+          * is picked up on SIGHUP without dropping the listener (live-config-reload). */
+         (void)server_tls_reload();
       }
    }
    return 0;

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -175,10 +175,14 @@ int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
    }
    g_ctx = ctx;
    /* remember the paths so a SIGHUP reload can re-read the same files */
-   snprintf(g_cert_path, sizeof g_cert_path, "%s", cert_path);
-   snprintf(g_key_path, sizeof g_key_path, "%s", key_path);
+   int t1 = snprintf(g_cert_path, sizeof g_cert_path, "%s", cert_path);
+   int t2 = snprintf(g_key_path, sizeof g_key_path, "%s", key_path);
    snprintf(g_client_ca_path, sizeof g_client_ca_path, "%s", client_ca_path ? client_ca_path : "");
    g_mtls_mode = mtls_mode;
+   if (t1 >= (int)sizeof g_cert_path || t2 >= (int)sizeof g_key_path)
+      aimee_log(LOG_WARN, "server.tls",
+                "TLS cert/key path too long to save — live SIGHUP cert reload will be a no-op "
+                "(restart to pick up a renewed cert)");
    pthread_mutex_unlock(&g_ctx_mu);
    aimee_log(LOG_INFO, "server.tls", "native TLS enabled (cert %s)", cert_path);
    return 0;
@@ -211,12 +215,12 @@ int server_tls_reload(void)
    pthread_mutex_lock(&g_ctx_mu);
    SSL_CTX *old = g_ctx;
    g_ctx = nctx; /* new handshakes use the new cert */
-   pthread_mutex_unlock(&g_ctx_mu);
-   /* In-flight connections' SSL objects hold their own ref on `old` (SSL_new up-refs the
-    * SSL_CTX), so this free just drops OUR ref; `old` is destroyed when the last live SSL on
-    * it is freed. No handshake in progress can observe a half-freed ctx (the accept path
-    * takes g_ctx_mu around the g_ctx read + SSL_new). */
+   /* Free UNDER the lock: post-swap accepts read nctx (never old), and in-flight SSL objects
+    * hold their own ref on `old` (SSL_new up-refs the SSL_CTX), so this drops only OUR ref —
+    * `old` is destroyed when the last live SSL on it is freed. Doing it inside the critical
+    * section closes any window where an accept could observe the pointer being freed. */
    SSL_CTX_free(old);
+   pthread_mutex_unlock(&g_ctx_mu);
    aimee_log(LOG_INFO, "server.tls", "TLS cert reloaded (cert %s)", cert);
    return 1;
 }

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -19,6 +19,11 @@
 
 static SSL_CTX *g_ctx = NULL;
 static pthread_mutex_t g_ctx_mu = PTHREAD_MUTEX_INITIALIZER;
+/* Saved at init so a SIGHUP reload can re-read the SAME cert/key files (live-config-reload). */
+static char g_cert_path[MAX_PATH_LEN];
+static char g_key_path[MAX_PATH_LEN];
+static char g_client_ca_path[MAX_PATH_LEN];
+static int g_mtls_mode = 0;
 
 /* mTLS verify callback: OpenSSL has already checked the chain/validity
  * (preverify_ok). Additionally reject a revoked leaf (depth 0) by consulting the
@@ -81,23 +86,17 @@ static int alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *ou
    return SSL_TLSEXT_ERR_OK;
 }
 
-int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
-                    const char *client_ca_path)
+/* Build a fresh SSL_CTX from the given cert/key/mtls settings, WITHOUT touching g_ctx.
+ * Returns the ctx (caller owns) or NULL on any load failure — so both init and a live reload
+ * validate-or-keep: a bad cert never disturbs the running listener. */
+static SSL_CTX *tls_build_ctx(const char *cert_path, const char *key_path, int mtls_mode,
+                              const char *client_ca_path)
 {
-   if (!cert_path || !cert_path[0] || !key_path || !key_path[0])
-      return -1;
-   pthread_mutex_lock(&g_ctx_mu);
-   if (g_ctx)
-   {
-      pthread_mutex_unlock(&g_ctx_mu);
-      return 0;
-   }
    SSL_CTX *ctx = SSL_CTX_new(TLS_server_method());
    if (!ctx)
    {
-      pthread_mutex_unlock(&g_ctx_mu);
       aimee_log(LOG_WARN, "server.tls", "SSL_CTX_new failed");
-      return -1;
+      return NULL;
    }
    /* Modern floor; no client-cert verification (plain server TLS — the bearer is
     * the caller's authentication, the TLS is the channel). */
@@ -121,8 +120,7 @@ int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
       aimee_log(LOG_WARN, "server.tls", "failed to load TLS cert/key (%s, %s): %s", cert_path,
                 key_path, ERR_error_string(ERR_get_error(), NULL));
       SSL_CTX_free(ctx);
-      pthread_mutex_unlock(&g_ctx_mu);
-      return -1;
+      return NULL;
    }
 
    /* mTLS: verify client certs against aimee's client CA. The chain is verified
@@ -155,10 +153,72 @@ int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
       }
    }
 
+   return ctx;
+}
+
+int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
+                    const char *client_ca_path)
+{
+   if (!cert_path || !cert_path[0] || !key_path || !key_path[0])
+      return -1;
+   pthread_mutex_lock(&g_ctx_mu);
+   if (g_ctx)
+   {
+      pthread_mutex_unlock(&g_ctx_mu);
+      return 0;
+   }
+   SSL_CTX *ctx = tls_build_ctx(cert_path, key_path, mtls_mode, client_ca_path);
+   if (!ctx)
+   {
+      pthread_mutex_unlock(&g_ctx_mu);
+      return -1;
+   }
    g_ctx = ctx;
+   /* remember the paths so a SIGHUP reload can re-read the same files */
+   snprintf(g_cert_path, sizeof g_cert_path, "%s", cert_path);
+   snprintf(g_key_path, sizeof g_key_path, "%s", key_path);
+   snprintf(g_client_ca_path, sizeof g_client_ca_path, "%s", client_ca_path ? client_ca_path : "");
+   g_mtls_mode = mtls_mode;
    pthread_mutex_unlock(&g_ctx_mu);
    aimee_log(LOG_INFO, "server.tls", "native TLS enabled (cert %s)", cert_path);
    return 0;
+}
+
+int server_tls_reload(void)
+{
+   pthread_mutex_lock(&g_ctx_mu);
+   if (!g_ctx)
+   {
+      pthread_mutex_unlock(&g_ctx_mu);
+      return 0; /* TLS not enabled -> nothing to reload */
+   }
+   char cert[MAX_PATH_LEN], key[MAX_PATH_LEN], ca[MAX_PATH_LEN];
+   snprintf(cert, sizeof cert, "%s", g_cert_path);
+   snprintf(key, sizeof key, "%s", g_key_path);
+   snprintf(ca, sizeof ca, "%s", g_client_ca_path);
+   int mtls = g_mtls_mode;
+   pthread_mutex_unlock(&g_ctx_mu);
+
+   /* Build the replacement OUTSIDE the lock (file I/O). Validate-or-keep: a cert that fails to
+    * load leaves the running listener on the current cert (never a broken TLS endpoint). */
+   SSL_CTX *nctx = tls_build_ctx(cert, key, mtls, ca[0] ? ca : NULL);
+   if (!nctx)
+   {
+      aimee_log(LOG_WARN, "server.tls",
+                "TLS reload: new cert/key failed to load — keeping the current cert");
+      return -1;
+   }
+   pthread_mutex_lock(&g_ctx_mu);
+   SSL_CTX *old = g_ctx;
+   g_ctx = nctx; /* new handshakes use the new cert */
+   pthread_mutex_unlock(&g_ctx_mu);
+   /* In-flight connections' SSL objects hold their own ref on `old` (SSL_new up-refs the
+    * SSL_CTX), so this free just drops OUR ref; `old` is destroyed when the last live SSL on
+    * it is freed. No handshake in progress can observe a half-freed ctx (the accept path
+    * takes g_ctx_mu around the g_ctx read + SSL_new). */
+   SSL_CTX_free(old);
+   aimee_log(LOG_INFO, "server.tls", "TLS cert reloaded (cert %s)", cert);
+   return 1;
 }
 
 int server_tls_peer_identity(SSL *ssl, char *cn_out, size_t cn_len, char *serial_out,
@@ -203,17 +263,22 @@ int server_tls_enabled(void)
 
 SSL *server_tls_accept(int fd)
 {
+   if (fd < 0)
+      return NULL;
+   /* Take the ctx lock only around the read + SSL_new so the up-ref is atomic vs a live cert
+    * reload's swap+free (SSL_new increments the SSL_CTX refcount, pinning `ctx` for this SSL's
+    * lifetime). The handshake itself runs OUTSIDE the lock. */
+   pthread_mutex_lock(&g_ctx_mu);
    SSL_CTX *ctx = g_ctx;
-   if (!ctx || fd < 0)
+   SSL *ssl = ctx ? SSL_new(ctx) : NULL;
+   pthread_mutex_unlock(&g_ctx_mu);
+   if (!ssl)
       return NULL;
    /* Bound the handshake (and subsequent blocking reads) so a stalled peer cannot
     * pin a per-conn worker thread indefinitely (the conn cap is small). */
    struct timeval tv = {.tv_sec = 30, .tv_usec = 0};
    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
-   SSL *ssl = SSL_new(ctx);
-   if (!ssl)
-      return NULL;
    SSL_set_fd(ssl, fd);
    if (SSL_accept(ssl) != 1)
    {


### PR DESCRIPTION
The **last carried follow-up** from live-config-reload. A renewed TLS cert is picked up on **SIGHUP** with no restart and no dropped connections.

## Design
- **`tls_build_ctx()`** — the `SSL_CTX_new` + cert/key load + mTLS block extracted into a helper that returns a fresh ctx (or NULL on failure) **without touching `g_ctx`**, so init and reload share it and both validate.
- **`server_tls_init`** saves the cert/key/mtls/ca **paths** for reload.
- **`server_tls_reload()`** — rebuild from the saved paths **outside** the lock (file I/O); **validate-or-keep** (a cert that fails to load keeps the current one); then swap `g_ctx` **and** `SSL_CTX_free(old)` **under `g_ctx_mu`**. In-flight SSLs hold their own ref on `old` (`SSL_new` up-refs the ctx), so `old` is destroyed only when the last live connection drains — no use-after-free.
- **`server_tls_accept`** now takes `g_ctx_mu` around the `g_ctx` read + `SSL_new` (the up-ref is atomic vs the swap); the handshake runs outside the lock.
- Wired to **SIGHUP** in the server main loop (alongside `config_reload`).

## Live-verified
Served `certA`, swapped the cert files + SIGHUP, **server stayed alive**, now serves `certB` — no listener drop.

## Review
Roundtable (blocking addressed): `SSL_CTX_free` moved inside the lock; audited that `tls_build_ctx` returns only NULL/ctx (no bad-pointer path) and the handshake callbacks don't take `g_ctx_mu` (no deadlock); path-truncation guard added. Reload validates cert+key load/match (as init does), not expiry — same operator contract as startup. Full `unit-tests` + line-check green.

**This completes all carried follow-ups from both the economizer and live-config-reload initiatives.**