### PR TITLE
feat(kb-console): follow-up — admin_values JSON store + deferred-item dispositions

### DIFF
--- a/docs/KB_CONSOLE.md
+++ b/docs/KB_CONSOLE.md
@@ -135,3 +135,27 @@ binary, a slim runtime). Override `AIMEE_KB_CONSOLE_IMAGE` to pin a published ta
 Configure OIDC login through the **Accounts → OIDC login config** editor (stored in
 the kb's DB2); **restart the console** to apply. Until OIDC is configured the
 console is break-glass-only (drop `$KB_CONSOLE_HOME/.break_glass`, mode 0600).
+
+## The curator review queue (not in the console)
+
+The curator review queue (`GET /v1/review`, `POST /v1/review/{id}/accept|reject`)
+is **not** exposed by the console: it is a **curator-scope** action, and folding it
+into the console-admin credential would break the separation of duties (a
+console-admin could self-approve changes to the very config it administers). The
+kb's built-in verifier derives scope from the single configured bearer, so a
+distinct curator scope only exists over **mTLS** today — there is no clean
+curator-credential path over the console's HTTP+bearer transport.
+
+Until the kb gains multiple scoped bearers, work the review queue directly with a
+curator credential (an mTLS client cert whose CN is `curator:<id>`):
+
+```bash
+# list pending review items
+curl -fsS --cert curator.pem --key curator.key https://aimee-kb:8743/v1/review
+# accept / reject one
+curl -fsS -X POST --cert curator.pem --key curator.key \
+  https://aimee-kb:8743/v1/review/<id>/accept
+```
+
+A console **OIDC config** change (Accounts → OIDC login config) applies on the
+next **console restart** — there is no live reload.

--- a/docs/proposals/done/kb-web-console.md
+++ b/docs/proposals/done/kb-web-console.md
@@ -25,12 +25,31 @@ S2b) live-verified on real Postgres on a `.253` CT:
 - **S6** — enroll-a-client mint enablement, packaging (`Dockerfile.kb-console` +
   the default-off compose `console` profile), docs, and this close-out.
 
-**Deferred / follow-ups** (documented at their call sites): server-side
-JWKS-fetch/SSRF validation on `PUT /v1/config/oidc` (the console's own verifier
-validates at login; break-glass recovers); the curator review queue in the
-governance UI (needs a separate curator-scoped credential); a JSON-array store
-for `admin_values` (currently comma-separated, commas rejected); and the
-kb-side live-config-reload for OIDC (the console re-reads at restart).
+**Follow-up dispositions** (roundtabled 2026-07-05):
+
+- **`admin_values` JSON-array store — DONE.** Stored as a JSON array (with a
+  legacy comma-separated read fallback), so values containing commas round-trip;
+  per-value + total size caps on `PUT`.
+- **Server-side JWKS-fetch/SSRF validation on `PUT /v1/config/oidc` — DROPPED.**
+  The kb does not fetch the operator-supplied `jwks_url` today; adding a fetch
+  would create a persistent SSRF surface (re-fetched on key rotation) for only
+  marginal fail-fast value, while the console's own verifier already fetches +
+  validates the JWKS at login (https-only, no-redirect, body-cap) and break-glass
+  recovers a bad config. If preflight is ever wanted, the console should push a
+  console-validated JWKS bundle — not a kb-side fetch.
+- **Curator review-queue UI — DEFERRED (needs a kb primitive).** `/v1/review` is
+  curator-scope and deliberately **not** in the console-admin allowlist; adding it
+  would collapse the S0 separation-of-duties (a console-admin self-approving the
+  config it holds the keys to). The kb's built-in verifier derives scope from the
+  single configured bearer, so distinct scopes only exist over mTLS today — there
+  is no clean curator-credential path over the console's HTTP+bearer transport.
+  Revisit when the kb gains **multiple scoped bearers** (the clean primitive) or
+  the deployment adopts console→kb mTLS with a curator cert. Interim: work the
+  review queue directly against the kb with a curator credential (runbook in
+  `docs/KB_CONSOLE.md`).
+- **Live-reload of OIDC config — DROPPED.** OIDC changes are operator-rare and a
+  console restart applies them; a hot-reload path (atomic swap, in-flight drain)
+  is significant complexity for no operator-visible gain.
 
 The design text below is the historical record.
 

--- a/src/kb/http/kb_http_accounts.c
+++ b/src/kb/http/kb_http_accounts.c
@@ -186,6 +186,17 @@ static cJSON *csv_to_array(const char *csv)
    return arr;
 }
 
+/* admin_values is stored as a JSON array string; parse it back, falling back to
+ * the legacy comma-separated form so pre-F2 rows still decode. */
+static cJSON *admin_values_to_array(const char *stored)
+{
+   cJSON *parsed = stored && stored[0] ? cJSON_Parse(stored) : NULL;
+   if (cJSON_IsArray(parsed))
+      return parsed; /* transfers ownership */
+   cJSON_Delete(parsed);
+   return csv_to_array(stored ? stored : "");
+}
+
 static int oidc_config_to_json(const db2_console_oidc_t *c, char *out_buf, int out_cap, int status)
 {
    cJSON *root = cJSON_CreateObject();
@@ -193,11 +204,13 @@ static int oidc_config_to_json(const db2_console_oidc_t *c, char *out_buf, int o
    cJSON_AddStringToObject(root, "audience", c->audience);
    cJSON_AddStringToObject(root, "jwks_url", c->jwks_url);
    cJSON_AddStringToObject(root, "admin_claim", c->admin_claim);
-   cJSON_AddItemToObject(root, "admin_values", csv_to_array(c->admin_values));
+   cJSON *vals = admin_values_to_array(c->admin_values);
+   int have_vals = cJSON_GetArraySize(vals) > 0;
+   cJSON_AddItemToObject(root, "admin_values", vals);
    cJSON_AddStringToObject(root, "updated_at", c->updated_at);
    cJSON_AddBoolToObject(root, "configured",
                          c->issuer[0] && c->audience[0] && c->jwks_url[0] && c->admin_claim[0] &&
-                             c->admin_values[0]);
+                             have_vals);
    char *s = cJSON_PrintUnformatted(root);
    cJSON_Delete(root);
    if (!s || strlen(s) >= (size_t)out_cap)
@@ -262,18 +275,18 @@ static int put_oidc_config(const char *body, char *out_buf, int out_cap)
                "{\"error\":\"bad request: issuer and jwks_url must be https\"}");
       return 400;
    }
-   /* Every admin_values element must be a non-empty string with no comma (the
-    * store is comma-separated, so a comma would corrupt the round-trip). */
+   /* Every admin_values element must be a non-empty string (stored as a JSON
+    * array now, so commas within a value round-trip fine). */
    {
       const cJSON *vv = NULL;
       cJSON_ArrayForEach(vv, vals)
       {
-         if (!cJSON_IsString(vv) || !vv->valuestring[0] || strchr(vv->valuestring, ','))
+         if (!cJSON_IsString(vv) || !vv->valuestring[0] || strlen(vv->valuestring) > 128)
          {
             cJSON_Delete(req);
             snprintf(out_buf, (size_t)out_cap,
                      "{\"error\":\"bad request: each admin_values entry must be a non-empty string "
-                     "without commas\"}");
+                     "<= 128 chars\"}");
             return 400;
          }
       }
@@ -285,18 +298,23 @@ static int put_oidc_config(const char *body, char *out_buf, int out_cap)
    snprintf(c.audience, sizeof(c.audience), "%s", aud_s);
    snprintf(c.jwks_url, sizeof(c.jwks_url), "%s", jwks_s);
    snprintf(c.admin_claim, sizeof(c.admin_claim), "%s", claim->valuestring);
-   /* Join admin_values into the comma-separated store form. */
-   size_t vpos = 0;
-   const cJSON *v = NULL;
-   cJSON_ArrayForEach(v, vals)
+   /* Store admin_values as a compact JSON array string. */
+   char *vals_json = cJSON_PrintUnformatted(vals);
+   if (!vals_json)
    {
-      if (!cJSON_IsString(v))
-         continue;
-      int wrote = snprintf(c.admin_values + vpos, sizeof(c.admin_values) - vpos, "%s%s",
-                           vpos ? "," : "", v->valuestring);
-      if (wrote > 0 && (size_t)wrote < sizeof(c.admin_values) - vpos)
-         vpos += (size_t)wrote;
+      cJSON_Delete(req);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"internal error: serialize admin_values\"}");
+      return 500;
    }
+   if (strlen(vals_json) >= sizeof(c.admin_values))
+   {
+      free(vals_json);
+      cJSON_Delete(req);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"bad request: admin_values too large\"}");
+      return 400;
+   }
+   snprintf(c.admin_values, sizeof(c.admin_values), "%s", vals_json);
+   free(vals_json);
    cJSON_Delete(req);
 
    if (db2_console_oidc_put(&c) != 0)

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1555,13 +1555,16 @@ static void test_accounts_routes(void)
    /* PUT missing fields -> 400. */
    s = kb_http_route_ex("PUT", "/v1/config/oidc", NULL, NULL, NULL, "{}", 2, buf, sizeof(buf));
    assert(s == 400);
-   /* PUT with a comma in an admin value -> 400 (would corrupt the CSV store). */
+   /* PUT with a comma in an admin value -> now accepted (JSON store) and
+    * round-trips intact. */
    const char *comma =
        "{\"issuer\":\"https://idp\",\"audience\":\"kbc\",\"jwks_url\":\"https://idp/jwks\","
-       "\"admin_claim\":\"groups\",\"admin_values\":[\"a,b\"]}";
+       "\"admin_claim\":\"groups\",\"admin_values\":[\"team,alpha\"]}";
    s = kb_http_route_ex("PUT", "/v1/config/oidc", NULL, NULL, NULL, comma, (int)strlen(comma), buf,
                         sizeof(buf));
-   assert(s == 400);
+   assert(s == 200 && strstr(buf, "\"configured\":true"));
+   s = kb_http_route_ex("GET", "/v1/config/oidc", NULL, NULL, NULL, NULL, 0, buf, sizeof(buf));
+   assert(s == 200 && strstr(buf, "\"team,alpha\""));
    /* PUT missing audience -> 400. */
    const char *noaud =
        "{\"issuer\":\"https://idp\",\"jwks_url\":\"https://idp/jwks\",\"admin_claim\":\"groups\","


### PR DESCRIPTION
Follow-up work on the completed aimee-kb web console. I roundtabled the disposition of all four deferred items and acted on the outcome.

## F2 — `admin_values` JSON store (DONE)
Stores the OIDC `admin_values` as a **JSON array** instead of comma-separated, so a value containing a comma round-trips. `PUT` serializes to compact JSON (per-value 128-char cap + total-size cap; `NULL`-serialize → 500, oversize → 400) and drops the comma rejection; `GET` parses it back via `admin_values_to_array()` with a **legacy comma-separated read fallback** (migration-safe); the `configured` flag derives from the parsed count.

**Live-verified on real Postgres (`.253`, 4/4):** comma value round-trips, DB stores a JSON array, and a **legacy comma-separated row still parses** via the fallback. Plus dispatch unit tests, clang-format-19, full `make lint`. Roundtable code review: 1 finding folded in (distinguish serialize-failure 500 from too-large 400; 16 other findings rejected at verification).

## Dispositions of the other deferrals (roundtabled)
Recorded in `docs/proposals/done/kb-web-console.md` + `docs/KB_CONSOLE.md`:
- **F1 kb-side JWKS fetch/SSRF validation — DROPPED.** Would add a persistent SSRF surface (the kb doesn't fetch the operator URL today) for marginal fail-fast value; the console's own verifier already fetches + validates the JWKS at login, and break-glass recovers a bad config.
- **F3 curator review-queue UI — DEFERRED.** Adding `/v1/review` to the console-admin allowlist would collapse the S0 curator/admin separation-of-duties (a console-admin self-approving the config it holds the keys to). The kb derives scope from the single configured bearer, so a distinct curator scope only exists over mTLS today — no clean curator-credential path over HTTP+bearer. Needs kb **multiple-scoped-bearer** support; a runbook interim (curl + a curator mTLS cert) is documented.
- **F4 live OIDC reload — DROPPED.** OIDC changes are operator-rare; a console restart applies them — hot-reload isn't worth the complexity.