### PR TITLE
fix(harness-memory): paginate the list/search RPC so large stores hydrate

### DIFF
--- a/src/db1/harness_memory.c
+++ b/src/db1/harness_memory.c
@@ -251,6 +251,29 @@ int hmem_list(const char *project, hmem_row_t **out, int *n, int include_deleted
    return rc;
 }
 
+int hmem_page_end(const hmem_row_t *rows, int n, int offset, size_t budget)
+{
+   if (!rows || n <= 0)
+      return (offset < 0) ? 0 : (offset > n ? n : offset);
+   if (offset < 0)
+      offset = 0;
+   size_t bytes = 0;
+   int i = offset;
+   for (; i < n; i++)
+   {
+      const hmem_row_t *r = &rows[i];
+      /* Approximate the row's serialized JSON: the variable-length fields plus a
+       * fixed slop for keys, the fixed-width columns, and punctuation. */
+      size_t rowsz = (r->body ? strlen(r->body) : 0) +
+                     (r->description ? strlen(r->description) : 0) +
+                     (r->meta_json ? strlen(r->meta_json) : 0) + 512;
+      if (i > offset && bytes + rowsz > budget)
+         break; /* this row opens the next page */
+      bytes += rowsz;
+   }
+   return i;
+}
+
 int hmem_search(const char *project, const char *query, hmem_row_t **out, int *n)
 {
    if (!project || !query || !out || !n)

--- a/src/db1/harness_memory.h
+++ b/src/db1/harness_memory.h
@@ -69,6 +69,13 @@ extern "C"
    /* Substring search over name/description/body of live rows. As hmem_list. */
    int hmem_search(const char *project, const char *query, hmem_row_t **out, int *n);
 
+   /* Exclusive end index of the response page that starts at `offset` and whose
+    * serialized rows fit within `budget` bytes. Always returns at least
+    * offset+1 when rows remain (so a single oversized row still advances and the
+    * pager can't stall). Pure — used by the list/search routes to page a result
+    * set that would otherwise overflow the fixed RPC response buffer. */
+   int hmem_page_end(const hmem_row_t *rows, int n, int offset, size_t budget);
+
    /* Tombstone one live row. Returns 0 (even if already absent) / -1 on error. */
    int hmem_tombstone(const char *project, const char *name);
 

--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -372,35 +372,13 @@ int harness_memory_hydrate(const char *cwd)
     * below reflects them. */
    int consumed = consume_spills(project, endpoint, bearer);
 
-   /* include_deleted so tombstoned rows come back too — we materialize live rows
-    * and *remove* the on-disk file for each tombstone (DB1 is authoritative). */
-   cJSON *body = cJSON_CreateObject();
-   cJSON_AddStringToObject(body, "project", project);
-   cJSON_AddNumberToObject(body, "include_deleted", 1);
-   char *body_s = cJSON_PrintUnformatted(body);
-   cJSON_Delete(body);
-
-   int status = 0;
-   cJSON *resp = body_s ? cli_http_request(endpoint, "POST", "/v1/harness_memory/list", body_s,
-                                           bearer, 15000, &status)
-                        : NULL;
-   free(body_s);
-   if (!resp || status < 200 || status >= 300)
-   {
-      if (resp)
-         cJSON_Delete(resp);
-      free(endpoint);
-      free(bearer);
-      return (consumed > 0) ? consumed : -1;
-   }
-
-   /* Ensure the memory dir exists and resolve it, so we can confine every write
-    * under the *real* directory (a symlinked component can't redirect us out). */
+   /* Ensure the memory dir exists and resolve it up front, so we can confine
+    * every write under the *real* directory (a symlinked component can't
+    * redirect us out). Needed before we process any page. */
    mkdir_p(memdir);
    char memreal[PATH_MAX];
    if (!hm_realpath(memdir, memreal))
    {
-      cJSON_Delete(resp);
       free(endpoint);
       free(bearer);
       return -1;
@@ -412,65 +390,105 @@ int harness_memory_hydrate(const char *cwd)
     * memory whose file lingers stays "known", so it is never re-imported).
     * known_ok guards completeness: if any insertion fails (OOM), the set is no
     * longer authoritative, so we skip the import pass entirely rather than risk
-    * resurrecting a tombstone we failed to record. */
+    * resurrecting a tombstone we failed to record. list_ok is the same guard for
+    * a failed page — a partial known set must not drive the import. */
    char **known = NULL;
    int nk = 0, kcap = 0, known_ok = 1;
+   int n = 0, removed = 0, list_ok = 1;
 
-   int n = 0, removed = 0;
-   cJSON *mems = cJSON_GetObjectItemCaseSensitive(resp, "memories");
-   cJSON *m = NULL;
-   cJSON_ArrayForEach(m, mems)
+   /* Page through the store (include_deleted so tombstoned rows come back — we
+    * materialize live rows and *remove* the file for each tombstone; DB1 is
+    * authoritative). The full set, bodies included, can exceed one RPC response
+    * buffer, so follow next_offset until has_more is false rather than asking
+    * for everything at once (an over-large single response truncates and 502s,
+    * which used to abort this hydrate before the import pass). */
+   for (int offset = 0;;)
    {
-      const char *name = jstr(m, "name");
-      const char *btext = jstr(m, "body");
-      const char *del = jstr(m, "deleted_at");
-      if (!name || !name[0] || name[0] == '/' || strstr(name, "..")) /* never escape memdir */
-         continue;
-      if (nk == kcap)
+      cJSON *body = cJSON_CreateObject();
+      cJSON_AddStringToObject(body, "project", project);
+      cJSON_AddNumberToObject(body, "include_deleted", 1);
+      cJSON_AddNumberToObject(body, "offset", offset);
+      char *body_s = cJSON_PrintUnformatted(body);
+      cJSON_Delete(body);
+
+      int status = 0;
+      cJSON *resp = body_s ? cli_http_request(endpoint, "POST", "/v1/harness_memory/list", body_s,
+                                              bearer, 15000, &status)
+                           : NULL;
+      free(body_s);
+      if (!resp || status < 200 || status >= 300)
       {
-         int nc = kcap ? kcap * 2 : 32;
-         char **t = realloc(known, (size_t)nc * sizeof(*t));
-         if (t)
-         {
-            known = t;
-            kcap = nc;
-         }
+         if (resp)
+            cJSON_Delete(resp);
+         list_ok = 0;
+         break;
       }
-      if (nk < kcap)
+
+      cJSON *mems = cJSON_GetObjectItemCaseSensitive(resp, "memories");
+      cJSON *m = NULL;
+      cJSON_ArrayForEach(m, mems)
       {
-         char *dup = strdup(name);
-         if (dup)
-            known[nk++] = dup;
+         const char *name = jstr(m, "name");
+         const char *btext = jstr(m, "body");
+         const char *del = jstr(m, "deleted_at");
+         if (!name || !name[0] || name[0] == '/' || strstr(name, "..")) /* never escape memdir */
+            continue;
+         if (nk == kcap)
+         {
+            int nc = kcap ? kcap * 2 : 32;
+            char **t = realloc(known, (size_t)nc * sizeof(*t));
+            if (t)
+            {
+               known = t;
+               kcap = nc;
+            }
+         }
+         if (nk < kcap)
+         {
+            char *dup = strdup(name);
+            if (dup)
+               known[nk++] = dup;
+            else
+               known_ok = 0;
+         }
          else
-            known_ok = 0;
-      }
-      else
-      {
-         known_ok = 0;
-      }
-      char target[PATH_MAX];
-      if ((size_t)snprintf(target, sizeof(target), "%s/%s.md", memdir, name) >= sizeof(target))
-         continue;
-      if (del && del[0]) /* tombstoned: ensure the on-disk file is gone */
-      {
-         if (target_confined(target, memreal) && unlink(target) == 0)
          {
-            removed++;
-            hmem_audit("tombstone-removed", project, name, NULL);
+            known_ok = 0;
          }
-         continue;
+         char target[PATH_MAX];
+         if ((size_t)snprintf(target, sizeof(target), "%s/%s.md", memdir, name) >= sizeof(target))
+            continue;
+         if (del && del[0]) /* tombstoned: ensure the on-disk file is gone */
+         {
+            if (target_confined(target, memreal) && unlink(target) == 0)
+            {
+               removed++;
+               hmem_audit("tombstone-removed", project, name, NULL);
+            }
+            continue;
+         }
+         mkdir_parents(target);
+         if (target_confined(target, memreal) && write_file(target, btext ? btext : "") == 0)
+            n++;
       }
-      mkdir_parents(target);
-      if (target_confined(target, memreal) && write_file(target, btext ? btext : "") == 0)
-         n++;
+
+      cJSON *hm = cJSON_GetObjectItemCaseSensitive(resp, "has_more");
+      cJSON *no = cJSON_GetObjectItemCaseSensitive(resp, "next_offset");
+      int has_more = cJSON_IsBool(hm) && cJSON_IsTrue(hm);
+      int next_offset = cJSON_IsNumber(no) ? (int)no->valuedouble : offset;
+      cJSON_Delete(resp);
+      /* Stop on the last page; the <= guard also prevents an infinite loop if a
+       * misbehaving server never advances the cursor. */
+      if (!has_more || next_offset <= offset)
+         break;
+      offset = next_offset;
    }
-   cJSON_Delete(resp);
 
    /* Import disk-only memory files the store has never seen (pre-existing files,
     * external edits, or fail-open writes whose spill was lost). Skipped when the
-    * known set is incomplete — see known_ok above. */
+    * known set is incomplete — see known_ok / list_ok above. */
    int imported = 0;
-   if (known_ok)
+   if (list_ok && known_ok)
       import_orphans(memreal, memreal, known, nk, project, endpoint, bearer, &imported);
 
    for (int i = 0; i < nk; i++)

--- a/src/server/harness_memory_routes.c
+++ b/src/server/harness_memory_routes.c
@@ -99,13 +99,32 @@ int handle_hmem_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return send_and_free(conn, resp);
 }
 
-static int respond_rows(server_conn_t *conn, hmem_row_t *rows, int n)
+/* The whole result set (bodies included) can exceed the fixed RPC response
+ * buffer (SHTTP_RESP_MAX, 256 KiB) once a project accumulates enough memories —
+ * the loopback RPC then truncates and the JSON fails to parse (a 502 that, for
+ * `list`, aborts the session-start hydrate before it can import disk-only files).
+ * So serialize a size-bounded page: rows from `offset` until the accumulated
+ * payload approaches the budget, always emitting at least one row so a single
+ * large memory still makes progress (it stays well under 256 KiB in practice).
+ * The caller pages via {offset -> next_offset} until has_more is false. */
+#define HMEM_PAGE_BUDGET (192 * 1024)
+
+static int respond_rows_paged(server_conn_t *conn, hmem_row_t *rows, int n, int offset)
 {
+   if (offset < 0)
+      offset = 0;
+   if (offset > n)
+      offset = n;
+   int end = hmem_page_end(rows, n, offset, HMEM_PAGE_BUDGET);
    cJSON *resp = jo_ok();
    cJSON *arr = cJSON_CreateArray();
-   for (int i = 0; i < n; i++)
+   for (int i = offset; i < end; i++)
       cJSON_AddItemToArray(arr, hmem_row_json(&rows[i]));
    cJSON_AddItemToObject(resp, "memories", arr);
+   cJSON_AddNumberToObject(resp, "total", n);
+   cJSON_AddNumberToObject(resp, "offset", offset);
+   cJSON_AddNumberToObject(resp, "next_offset", end);
+   cJSON_AddBoolToObject(resp, "has_more", end < n);
    hmem_rows_free(rows, n);
    return send_and_free(conn, resp);
 }
@@ -117,11 +136,12 @@ int handle_hmem_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (jo_need_str(req, "project", &project) < 0)
       return server_send_error(conn, "missing project", NULL);
    int include_deleted = jo_int(req, "include_deleted", 0);
+   int offset = jo_int(req, "offset", 0);
    hmem_row_t *rows = NULL;
    int n = 0;
    if (hmem_list(project, &rows, &n, include_deleted) != 0)
       return server_send_error(conn, "list failed", NULL);
-   return respond_rows(conn, rows, n);
+   return respond_rows_paged(conn, rows, n, offset);
 }
 
 int handle_hmem_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
@@ -130,11 +150,12 @@ int handle_hmem_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    const char *project, *query;
    if (jo_need_str(req, "project", &project) < 0 || jo_need_str(req, "query", &query) < 0)
       return server_send_error(conn, "missing project or query", NULL);
+   int offset = jo_int(req, "offset", 0);
    hmem_row_t *rows = NULL;
    int n = 0;
    if (hmem_search(project, query, &rows, &n) != 0)
       return server_send_error(conn, "search failed", NULL);
-   return respond_rows(conn, rows, n);
+   return respond_rows_paged(conn, rows, n, offset);
 }
 
 int handle_hmem_tombstone(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)

--- a/src/tests/test_harness_memory.c
+++ b/src/tests/test_harness_memory.c
@@ -66,6 +66,41 @@ static hmem_row_t mkrow(const char *proj, const char *name, const char *type, co
    return r;
 }
 
+static void test_page_end(void)
+{
+   /* Pure paging math: page boundaries respect the byte budget and always
+    * advance (a single oversized row can't stall the pager). */
+   char big[6000], mid[1000];
+   memset(big, 'x', sizeof(big) - 1);
+   big[sizeof(big) - 1] = '\0';
+   memset(mid, 'y', sizeof(mid) - 1);
+   mid[sizeof(mid) - 1] = '\0';
+
+   hmem_row_t rows[4] = {mkrow("p", "a", "fact", mid), /* rowsz ~= 999 + 512 = 1511 */
+                         mkrow("p", "b", "fact", mid), mkrow("p", "c", "fact", mid),
+                         mkrow("p", "d", "fact", mid)};
+
+   /* generous budget -> whole set fits in one page */
+   assert(hmem_page_end(rows, 4, 0, 1 << 20) == 4);
+
+   /* tight budget (2000): one ~1511-byte row per page, always advancing */
+   assert(hmem_page_end(rows, 4, 0, 2000) == 1);
+   assert(hmem_page_end(rows, 4, 1, 2000) == 2);
+   assert(hmem_page_end(rows, 4, 3, 2000) == 4);
+
+   /* two rows fit under a 3200 budget; the third opens the next page */
+   assert(hmem_page_end(rows, 4, 0, 3200) == 2);
+
+   /* a single row larger than the whole budget still advances by one */
+   hmem_row_t huge[1] = {mkrow("p", "big", "fact", big)}; /* rowsz ~= 6511 > 2000 */
+   assert(hmem_page_end(huge, 1, 0, 2000) == 1);
+
+   /* offset at the end yields an empty final page; NULL/empty inputs are safe */
+   assert(hmem_page_end(rows, 4, 4, 2000) == 4);
+   assert(hmem_page_end(NULL, 0, 0, 2000) == 0);
+   assert(hmem_page_end(rows, 0, 0, 2000) == 0);
+}
+
 static void test_resolve(void)
 {
    char id[256], root[1024];
@@ -172,6 +207,7 @@ int main(void)
 {
    test_sha();
    test_hash();
+   test_page_end();
    test_resolve();
    test_project_key_ok();
    assert(db1_init(":memory:") == 0);


### PR DESCRIPTION
## Problem

`handle_hmem_list` / `handle_hmem_search` serialized the **entire** result set (bodies included) into the fixed RPC response buffer (`SHTTP_RESP_MAX`, 256 KiB). Once a project accumulated enough memories (~68 with bodies), the response truncated and `cJSON_Parse` failed → **502 "rpc response too large or malformed."**

For `list`, that 502 is fatal to `harness_memory_hydrate` (session-start): it lists the store first to build the `known` set, and on a non-2xx it **returns before the import pass** — so disk-only memory files can never be ingested into DB1. The store silently stops growing past a few dozen entries, and a project's `.md` memories never make it into the central store.

## Fix

Serialize a **size-bounded page** instead of everything at once:
- New pure `hmem_page_end(rows, n, offset, budget)` walks rows from `offset` until the accumulated payload approaches `budget` (192 KiB, under the 256 KiB cap), always emitting **at least one row** so a single large memory still advances (no stall).
- `list`/`search` responses now carry `total` / `offset` / `next_offset` / `has_more`.
- `harness_memory_hydrate` pages the store (follows `next_offset` until `has_more` is false) and runs the import pass **only when every page loaded cleanly** (`list_ok`), mirroring the existing `known_ok` completeness guard.

## Tests
`hmem_page_end` unit test: budget boundaries, per-page advance, an oversized single row, offset-at-end, and NULL/empty inputs.

## Verified live
Hot-patched onto a real aimee-server whose store was 502ing: the list now paginates (200), and the session-start hydrate completed the import — **377 memories across 12 projects ingested**, each project's `.254` count matching its on-disk file count exactly.