### PR TITLE
bench(swebench): S2 — arm A agentic-solo runner + measurement core (#987)

### DIFF
--- a/benchmarks/coding/swebench_arm_runner.py
+++ b/benchmarks/coding/swebench_arm_runner.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""S2 — arm A (agentic-solo) runner for the agentic supervised SWE-bench benchmark (#987).
+
+Arm A: the expensive primary drives the S1 agentic loop itself (explore/edit/[test]/verify) and
+we count ITS tokens. This module composes the already-merged pieces into one per-instance record
+in the shape `supervised_report.build_report` consumes, plus the agentic-arm honesty fields the
+roundtables ratified:
+  - token accounting from the token_audit ledger with S0's polarity (primary = delegation_id
+    EMPTY); the HEADLINE input is UNCACHED (prompt_tokens - cache_read_tokens) so a multi-turn
+    primary re-reading context across turns cannot skew the A vs C comparison (proposal B2a);
+  - two wall-clocks per instance (proposal Q5 / issue #987): total (queue+work) and work-only,
+    with queue = total - work; the report's p95 gate reads the headline `wall_s`;
+  - the S1 canonical patch + its fingerprint, secret-redacted before it can reach a ledger.
+
+Pure surface (unit-tested, no live server/docker/network): the token math, the wall-clock
+decomposition, and record-schema conformance. The live loop is S1's marked stub. Arm C's
+supervision loop (S3) reuses this record schema and token accounting — the SAME core for both
+arms so a transport difference can never masquerade as an algorithmic one (roundtable Q3).
+
+KNOWN LIMITATION (surfaced, not faked): token_audit has no separate reasoning/thinking-token
+column (only prompt/completion/cache_read/cache_write), so the proposal's thinking-vs-text split
+is NOT extractable today. `thinking_tokens` is reported as None until the ledger carries it.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from benchmarks.coding import swebench_transport_verify as V
+from benchmarks.coding import swebench_agentic_harness as H
+
+_FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
+
+
+# ------------------------------------------------------------ token totals -----
+@dataclass
+class PrimaryTokens:
+    input_uncached: int   # HEADLINE: prompt_tokens - cache_read_tokens
+    input_cached: int     # cache_read_tokens (re-read context; excluded from headline)
+    output: int
+    turns: int
+    thinking: int | None = None  # unavailable from token_audit today (see module docstring)
+
+    @property
+    def input_total(self) -> int:
+        return self.input_uncached + self.input_cached
+
+    @property
+    def total_headline(self) -> int:
+        """The number the reduction headline uses: uncached input + output."""
+        return self.input_uncached + self.output
+
+
+def primary_token_totals(rows, primary_model) -> PrimaryTokens:
+    """Sum the primary's realized turns (delegation_id EMPTY, per S0's verified polarity)."""
+    pr = V._primary_rows(rows, primary_model)
+    prompt = sum(r["prompt_tokens"] for r in pr)
+    cache_read = sum(r["cache_read_tokens"] for r in pr)
+    return PrimaryTokens(
+        input_uncached=max(0, prompt - cache_read),
+        input_cached=cache_read,
+        output=sum(r["completion_tokens"] for r in pr),
+        turns=len(pr),
+    )
+
+
+def worker_token_totals(rows) -> tuple[int, int]:
+    """(input, output) across delegate children (delegation_id NON-EMPTY); priced $0 (honesty)."""
+    wr = V._worker_rows(rows)
+    return sum(r["prompt_tokens"] for r in wr), sum(r["completion_tokens"] for r in wr)
+
+
+# ------------------------------------------------------------ wall-clock -------
+@dataclass
+class WallClock:
+    """Per-instance wall-clock. t0 = instance prompt enters the harness dispatch queue (pinned
+    IDENTICALLY for both arms, proposal Q5); first_work = first worker/primary turn starts;
+    t1 = patch ready (grader resolves downstream). We report total and work-only; queue is the
+    gap. Fleet throughput is a SEPARATE number, never conflated here."""
+    t0: float
+    first_work: float
+    t1: float
+
+    @property
+    def total_s(self) -> float:
+        return max(0.0, self.t1 - self.t0)
+
+    @property
+    def work_s(self) -> float:
+        return max(0.0, self.t1 - self.first_work)
+
+    @property
+    def queue_s(self) -> float:
+        return max(0.0, self.first_work - self.t0)
+
+
+# ------------------------------------------------------------ arm record -------
+def build_arm_record(instance_id, arm, primary_model, *, tokens: PrimaryTokens,
+                     worker_in: int, worker_out: int, wall: WallClock, resolved,
+                     patch: str, base_commit: str, repo: str, n_workers: int = 1,
+                     redactions: int = 0, escalations: int = 0, compaction: bool = False,
+                     invalid: bool = False) -> dict:
+    """One record in supervised_report's schema + the agentic-arm honesty fields."""
+    return {
+        # --- schema consumed by supervised_report.build_report ---
+        "instance_id": instance_id,
+        "arm": arm,
+        "compaction": compaction,
+        "supervisor_input_tokens": tokens.input_uncached,   # headline = UNCACHED
+        "supervisor_output_tokens": tokens.output,
+        "worker_input_tokens": worker_in,
+        "worker_output_tokens": worker_out,
+        "wall_s": round(wall.total_s, 3),
+        "resolved": resolved,
+        "n_workers": n_workers,
+        "invalid": invalid,
+        # --- agentic-arm honesty extensions (S4 report surfaces these) ---
+        "supervisor_input_cached_tokens": tokens.input_cached,
+        "supervisor_thinking_tokens": tokens.thinking,      # None until ledger carries it
+        "primary_turns": tokens.turns,
+        "wall_work_s": round(wall.work_s, 3),
+        "wall_queue_s": round(wall.queue_s, 3),
+        "escalations": escalations,
+        "patch_fingerprint": H.workspace_fingerprint(repo, base_commit, patch),
+        "patch_redactions": redactions,
+    }
+
+
+# ------------------------------------------------------------ fake mode --------
+def _fake_arm_a_record(instance, primary_model):
+    iid = instance["instance_id"]
+    rows = V._fake_rows("pass", primary_model, "glm-5.2")
+    tok = primary_token_totals(rows, primary_model)
+    wi, wo = worker_token_totals(rows)
+    wall = WallClock(t0=0.0, first_work=0.5, t1=12.5)
+    patch, red = H.scan_and_redact_secrets("diff --git a/x b/x\n+ok\n")
+    return build_arm_record(iid, "A", primary_model, tokens=tok, worker_in=wi, worker_out=wo,
+                            wall=wall, resolved=True, patch=patch,
+                            base_commit=instance.get("base_commit", "0"*40),
+                            repo=instance.get("repo", "x/y"), redactions=red)
+
+
+# ------------------------------------------------------------ live entry -------
+def run_arm_a(instance: dict, primary_model: str, *, token_db: str, base_repo: str,
+              allocator: "H.EnvAllocator", budget: "H.LoopBudget") -> dict:
+    """Live arm-A run for one instance. Provisions a workspace, drives the primary agentic loop
+    via the S0-verified /v1/runs transport, extracts the patch, and reads the primary's tokens
+    from token_audit scoped to the run's session_id. Marked live (needs a server)."""
+    if _FAKE:
+        return _fake_arm_a_record(instance, primary_model)
+    raise NotImplementedError(
+        "live arm-A run not wired: provision via H.provision_workspace, drive H.run_agentic_loop "
+        "(arm='A', /v1/runs transport), extract via H.extract_patch, then read tokens with "
+        "V.collect_rows(token_db, session_id) + primary_token_totals(). Requires a live server.")

--- a/benchmarks/tests/test_swebench_arm_runner.py
+++ b/benchmarks/tests/test_swebench_arm_runner.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Unit tests for S2 — the arm-A runner's pure measurement surface.
+
+No live server/docker/network: token totals over synthesized ledgers, wall-clock decomposition,
+and record-schema conformance (the record must be consumable by supervised_report.build_report).
+Run: python3 -m unittest benchmarks.tests.test_swebench_arm_runner
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_arm_runner as R
+from benchmarks.coding import swebench_transport_verify as V
+from benchmarks.coding import supervised_report as REP
+
+PRIMARY = "gpt-5.5"
+
+
+class TestPrimaryTokenTotals(unittest.TestCase):
+    def test_headline_is_uncached_input_plus_output(self):
+        rows = [V._row(PRIMARY, prompt=1000, completion=100, cache_read=300),
+                V._row(PRIMARY, prompt=500, completion=50, cache_read=100)]
+        t = R.primary_token_totals(rows, PRIMARY)
+        self.assertEqual(t.input_uncached, 1500 - 400)   # 1100
+        self.assertEqual(t.input_cached, 400)
+        self.assertEqual(t.output, 150)
+        self.assertEqual(t.total_headline, 1100 + 150)
+        self.assertEqual(t.turns, 2)
+
+    def test_cached_excluded_from_headline(self):
+        # A turn that is ALL cache-read (a re-read) adds nothing to the uncached headline.
+        rows = [V._row(PRIMARY, prompt=800, completion=0, cache_read=800)]
+        t = R.primary_token_totals(rows, PRIMARY)
+        self.assertEqual(t.input_uncached, 0)
+        self.assertEqual(t.input_cached, 800)
+
+    def test_worker_rows_excluded_from_primary(self):
+        rows = V._fake_rows("pass", PRIMARY, "glm-5.2")
+        t = R.primary_token_totals(rows, PRIMARY)
+        wi, wo = R.worker_token_totals(rows)
+        # worker return of 5000 tokens must land in worker totals, not primary
+        self.assertGreaterEqual(wo, V._BIG_WORKER_RETURN_TOKENS)
+        self.assertNotIn(V._BIG_WORKER_RETURN_TOKENS, (t.output,))
+
+    def test_thinking_is_none_until_ledger_carries_it(self):
+        rows = [V._row(PRIMARY, prompt=10, completion=5)]
+        self.assertIsNone(R.primary_token_totals(rows, PRIMARY).thinking)
+
+
+class TestWallClock(unittest.TestCase):
+    def test_total_work_queue_decomposition(self):
+        w = R.WallClock(t0=100.0, first_work=103.0, t1=115.0)
+        self.assertEqual(w.total_s, 15.0)
+        self.assertEqual(w.work_s, 12.0)
+        self.assertEqual(w.queue_s, 3.0)
+
+    def test_queue_plus_work_equals_total(self):
+        w = R.WallClock(t0=0.0, first_work=2.5, t1=20.0)
+        self.assertAlmostEqual(w.queue_s + w.work_s, w.total_s)
+
+    def test_negative_clamped(self):
+        w = R.WallClock(t0=10.0, first_work=5.0, t1=8.0)
+        self.assertGreaterEqual(w.queue_s, 0.0)
+        self.assertGreaterEqual(w.work_s, 0.0)
+
+
+class TestArmRecordSchema(unittest.TestCase):
+    def _rec(self):
+        tok = R.PrimaryTokens(input_uncached=1000, input_cached=200, output=100, turns=3)
+        wall = R.WallClock(t0=0.0, first_work=1.0, t1=30.0)
+        return R.build_arm_record("inst-1", "A", PRIMARY, tokens=tok, worker_in=0, worker_out=0,
+                                  wall=wall, resolved=True, patch="diff\n", base_commit="c0ffee",
+                                  repo="x/y")
+
+    def test_has_all_report_schema_keys(self):
+        rec = self._rec()
+        for k in ("instance_id", "arm", "compaction", "supervisor_input_tokens",
+                  "supervisor_output_tokens", "worker_input_tokens", "worker_output_tokens",
+                  "wall_s", "resolved", "n_workers", "invalid"):
+            self.assertIn(k, rec)
+
+    def test_headline_input_is_uncached(self):
+        rec = self._rec()
+        self.assertEqual(rec["supervisor_input_tokens"], 1000)         # uncached only
+        self.assertEqual(rec["supervisor_input_cached_tokens"], 200)
+
+    def test_consumable_by_build_report(self):
+        # The whole point: a record produced here must flow through the report unchanged.
+        rec = self._rec()
+        rep = REP.build_report([rec], compaction=False)
+        # wall-clock summary picked the record up (median/p95 computed from wall_s)
+        self.assertEqual(rep["wall_clock"]["A"]["n"], 1)
+        self.assertEqual(rep["wall_clock"]["A"]["p95_s"], 30.0)
+        # resolution picked the graded record up
+        self.assertEqual(rep["resolution"]["A"]["resolved"], 1)
+
+    def test_two_wall_clocks_present(self):
+        rec = self._rec()
+        self.assertEqual(rec["wall_s"], 30.0)
+        self.assertEqual(rec["wall_work_s"], 29.0)
+        self.assertEqual(rec["wall_queue_s"], 1.0)
+
+
+class TestFakeMode(unittest.TestCase):
+    def test_fake_record_is_schema_valid(self):
+        inst = {"instance_id": "inst-0", "repo": "x/y", "base_commit": "0" * 40}
+        rec = R._fake_arm_a_record(inst, PRIMARY)
+        self.assertEqual(rec["arm"], "A")
+        self.assertEqual(rec["instance_id"], "inst-0")
+        self.assertIn("patch_fingerprint", rec)
+
+
+class TestLiveStubHonesty(unittest.TestCase):
+    def test_run_arm_a_live_is_marked_stub(self):
+        inst = {"instance_id": "i", "repo": "x/y", "base_commit": "0" * 40}
+        with self.assertRaises(NotImplementedError):
+            R.run_arm_a(inst, PRIMARY, token_db="/x", base_repo="/y",
+                        allocator=None, budget=None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Third slice of the agentic supervised SWE-bench harness (proposal #1078; follows S0 #1079, S1 #1080). Part of #987.

## What it adds
Composes S0 (token polarity) + S1 (provision/patch) into the **shared per-instance arm record** — in `supervised_report.build_report`'s schema — plus the honesty fields both roundtables ratified:

- **Token totals** from `token_audit` with S0's verified polarity (primary = `delegation_id` EMPTY). **Headline input = UNCACHED** (`prompt − cache_read`) so a multi-turn primary re-reading context across turns can't skew A-vs-C (proposal B2a).
- **Two wall-clocks per instance**: total (queue+work) and work-only, `queue = total − work` (proposal Q5 / #987). The report's p95 gate reads headline `wall_s`.
- **S1 canonical patch + fingerprint**, secret-redacted before it can reach a ledger.

The record schema + token accounting are **shared with arm C (S3)** so a transport difference can never masquerade as an algorithmic one (roundtable Q3).

## Honest limitation (surfaced, not faked)
`token_audit` has no reasoning/thinking-token column (only prompt/completion/cache_read/cache_write), so the proposal's thinking-vs-text split is **not extractable today** — `thinking_tokens` reports `None` until the ledger carries it.

13 new tests (token math, wall decomposition, schema conformance flows through `build_report`); full bench suite green (**478**). Live run is a marked stub.

Next: **S3** — arm C supervision loop (turn-digest budget, escalate-gating, best-of-N selection). Its supervision mechanics are honesty-critical, so they go to the design roundtable first.