### PR TITLE
bench(swebench): S3 — arm C supervision honesty core (#987)

### DIFF
--- a/benchmarks/coding/swebench_supervision.py
+++ b/benchmarks/coding/swebench_supervision.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""S3 — arm C supervision loop: the pure honesty core (agentic supervised SWE-bench, #987).
+
+Arm C: N cheap/local fleet workers each run the S1 agentic loop; the primary SUPERVISES across
+turns and we count only the primary's tokens. The public claim ("beats Reddit's -75.5% at no
+wall-clock penalty") is only honest if the primary supervises CHEAPLY — reading short, capped,
+leak-guarded digests and picking among candidate diffs, NEVER the raw code. This module is the
+reproducibility-critical machinery that MECHANICALLY enforces that, per the S3 design roundtable
+(2026-07-05, 6/7 panel). Everything here is a pure function — unit-testable with no live server,
+no LLM, no network. The only live parts (worker dispatch; an optional LLM-supervisor selection
+ablation) are marked stubs.
+
+Ratified rulings baked in:
+  Q1  the turn-digest is a CONSTRUCTED, allowlisted data product with HARD token caps, not a
+      prompt convention; a serializer leak-guard REJECTS any field carrying file-like/raw-source
+      content and neutralizes tool-call-looking syntax (anti prompt-injection).
+  Q2  a hard tool allowlist; escalation is gated (only on worker terminal-fail or deterministic
+      stuck), bounded, and separately attributed; a run whose escalation tokens exceed 40% of the
+      primary's input is marked ESCALATION_DOMINATED and excluded from the headline.
+  Q3  best-of-N selection is a DETERMINISTIC pure function over structured worker-reported signals
+      (never the official grader, never raw logs) — an LLM selector would be non-reproducible;
+      oracle-best-of-N (any candidate passes the grader) vs actual-best-of-N (the selected patch
+      passes) decompose supervisor skill from worker diversity.
+  Q4  context-drift is bounded by a sliding window of the last K digests + a deterministic
+      fold-then-evict of older turns to a one-line summary, under a hard total cap.
+  Q5  redirect defaults OFF for the public-claim set (PR#986's limiter was worker reliability,
+      not supervision); if enabled it is a bounded, attributed ablation.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+
+# ------------------------------------------------------------ enums ------------
+class VerifyEnum(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    ERROR = "ERROR"
+    NOT_RUN = "NOT_RUN"
+
+
+class WorkerState(str, Enum):
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    STUCK = "stuck"
+
+
+# ------------------------------------------------------------ caps -------------
+# Q1: hard caps low enough that supervision stays materially different from raw-code review.
+DIGEST_TOKEN_CAP = 2048       # per worker-turn digest (total)
+DIFF_TOKEN_SUBCAP = 512       # the unified-diff field within a digest
+CONTEXT_TOTAL_CAP = 16000     # whole supervisor context
+WINDOW_K = 3                  # sliding window: last K digests kept verbatim
+FOLD_TOKEN_CAP = 512          # the folded one-line summary of evicted turns
+ESCALATION_DOMINATED_FRAC = 0.40
+_TOK = 4                      # ~chars per token (deterministic estimate; no tokenizer dep)
+
+
+def est_tokens(s: str) -> int:
+    """Deterministic token estimate (chars/4) — no external tokenizer, so CI is hermetic."""
+    return (len(s) + _TOK - 1) // _TOK
+
+
+# ------------------------------------------------------------ leak guard -------
+# Q1: worker text/diffs are untrusted. Reject file-like/raw-source payloads and neutralize
+# tool-call-looking syntax so digest content can never invoke a supervisor tool or smuggle code.
+_SOURCE_MARKERS = (
+    re.compile(r"^\s*(?:def|class)\s+\w+", re.M),
+    re.compile(r"^\s*(?:import|from)\s+\w+", re.M),
+    re.compile(r"^\s*#include\b", re.M),
+    re.compile(r"</?\w+[^>]*>"),                      # markup / xml-ish
+)
+_TOOLCALL_RE = re.compile(r"<\s*(?:tool_use|tool_call|function_call|invoke)\b", re.I)
+
+
+def looks_like_source(text: str, *, min_hits: int = 2) -> bool:
+    """True if `text` looks like raw source (outside a unified-diff frame)."""
+    hits = sum(1 for r in _SOURCE_MARKERS if r.search(text))
+    return hits >= min_hits
+
+
+def neutralize_toolcalls(text: str) -> str:
+    """Defang tool-call-looking syntax so digest content can't be interpreted as a tool call."""
+    return _TOOLCALL_RE.sub("<neutralized-", text)
+
+
+# ------------------------------------------------------------ digest -----------
+@dataclass
+class WorkerTurn:
+    """The raw per-turn signal a worker emits (input to digest construction)."""
+    worker_id: str
+    turn_index: int
+    state: WorkerState
+    action_label: str
+    unified_diff: str
+    verify: VerifyEnum
+    rationale: str = ""
+    files_touched: tuple = ()
+    added: int = 0
+    deleted: int = 0
+
+
+@dataclass
+class Digest:
+    """The bounded, leak-guarded product the supervisor is allowed to see. NEVER raw code."""
+    worker_id: str
+    turn_index: int
+    state: str
+    action_label: str
+    verify: str
+    diff: str
+    files_touched: tuple
+    added: int
+    deleted: int
+    truncated: bool
+    rejected_fields: tuple = ()
+
+    def tokens(self) -> int:
+        return est_tokens(self.diff) + est_tokens(self.action_label) + est_tokens(str(self.files_touched)) + 8
+
+
+def _cap_diff(diff: str) -> tuple[str, bool]:
+    """Cap the diff to DIFF_TOKEN_SUBCAP with a deterministic truncation marker."""
+    max_chars = DIFF_TOKEN_SUBCAP * _TOK
+    if len(diff) <= max_chars:
+        return diff, False
+    return diff[:max_chars] + "\n... [AIMEE_DIGEST_TRUNCATED]\n", True
+
+
+def build_digest(turn: WorkerTurn) -> Digest:
+    """Construct a hard-capped, leak-guarded digest from a worker turn (Q1). A rationale that
+    looks like raw source is DROPPED (recorded in rejected_fields); the diff is capped; tool-call
+    syntax is neutralized. The result is guaranteed <= DIGEST_TOKEN_CAP."""
+    rejected = []
+    diff, tdiff = _cap_diff(turn.unified_diff)
+    diff = neutralize_toolcalls(diff)
+    # The action_label/rationale are metadata; if the rationale smuggles source, drop it.
+    if turn.rationale and looks_like_source(turn.rationale):
+        rejected.append("rationale")
+    action = neutralize_toolcalls(turn.action_label)[:200]
+    d = Digest(worker_id=turn.worker_id, turn_index=turn.turn_index, state=turn.state.value,
+               action_label=action, verify=turn.verify.value, diff=diff,
+               files_touched=tuple(turn.files_touched), added=turn.added, deleted=turn.deleted,
+               truncated=tdiff, rejected_fields=tuple(rejected))
+    # Final hard cap: if still over budget, truncate the diff further, deterministically.
+    while d.tokens() > DIGEST_TOKEN_CAP and d.diff:
+        d.diff = d.diff[: max(0, len(d.diff) - 512)] + "\n... [AIMEE_DIGEST_TRUNCATED]\n"
+        d.truncated = True
+    return d
+
+
+def serialize_supervisor_frame(digests: list[Digest]) -> tuple[str, int]:
+    """Render the digests the supervisor sees, running a final source-leak gate over the whole
+    frame. Returns (frame_text, rejected_count). Any digest whose diff STILL trips the source
+    guard after capping is replaced with a metadata-only stub (belt-and-suspenders)."""
+    rejected = 0
+    parts = []
+    for d in digests:
+        body = d.diff
+        # A capped unified diff is allowed; but if it reads as bare source (no diff frame), stub it.
+        if body and looks_like_source(body) and not body.lstrip().startswith(("diff --git", "---", "+++", "@@")):
+            body = "[REJECTED: non-diff source-like content]"
+            rejected += 1
+        parts.append(f"[{d.worker_id} t{d.turn_index} {d.state}/{d.verify} "
+                     f"+{d.added}-{d.deleted} {d.action_label}]\n{body}")
+    return "\n\n".join(parts), rejected
+
+
+# ------------------------------------------------------------ selection --------
+@dataclass
+class Candidate:
+    worker_id: str
+    diff: str
+    verify: VerifyEnum
+    turns: int
+
+    @property
+    def diff_size(self) -> int:
+        return self.diff.count("\n")
+
+    @property
+    def is_valid(self) -> bool:
+        return bool(self.diff.strip()) and self.verify != VerifyEnum.ERROR
+
+
+def select_best_of_n(candidates: list[Candidate]) -> Candidate | None:
+    """Q3: a DETERMINISTIC pure selector (no LLM -> reproducible). Tie-break order:
+    (1) prefer verify PASS, (2) fewer turns, (3) smaller diff, (4) worker_id lexicographic.
+    Returns None (no-op empty patch) when no valid candidate exists."""
+    valid = [c for c in candidates if c.is_valid]
+    if not valid:
+        return None
+    return min(valid, key=lambda c: (0 if c.verify == VerifyEnum.PASS else 1,
+                                     c.turns, c.diff_size, c.worker_id))
+
+
+# selection-skill decomposition (Q3): oracle vs actual, over official-grader outcomes.
+def oracle_pass(candidate_resolved: dict[str, bool]) -> bool:
+    """oracle-best-of-N: success if ANY candidate patch passes the official grader."""
+    return any(candidate_resolved.values())
+
+
+def actual_pass(selected_worker: str | None, candidate_resolved: dict[str, bool]) -> bool:
+    """actual-best-of-N: the supervisor-SELECTED patch passes the official grader."""
+    return bool(selected_worker) and candidate_resolved.get(selected_worker, False)
+
+
+def selection_skill_ratio(actual_rate: float, oracle_rate: float) -> float | None:
+    """How much of the achievable (oracle) resolution the deterministic selector captured."""
+    return round(actual_rate / oracle_rate, 4) if oracle_rate else None
+
+
+# ------------------------------------------------------------ escalation -------
+class EscalationTrigger(str, Enum):
+    NONE = "none"
+    ALL_WORKERS_FAILED = "all_workers_failed"
+    STUCK = "stuck"
+
+
+@dataclass
+class EscalationState:
+    """Q2: gated, bounded, separately-attributed escalation. Tokens spent while escalated are
+    tracked so a run that leans on escalation (primary digging into code) is caught, not hidden."""
+    stuck_turns: int = 0
+    stuck_limit: int = 3
+    escalation_tokens: int = 0
+    escalations: int = 0
+
+    def should_escalate(self, *, all_failed: bool, made_progress: bool) -> EscalationTrigger:
+        if made_progress:
+            self.stuck_turns = 0
+        else:
+            self.stuck_turns += 1
+        if all_failed:
+            return EscalationTrigger.ALL_WORKERS_FAILED
+        if self.stuck_turns >= self.stuck_limit:
+            return EscalationTrigger.STUCK
+        return EscalationTrigger.NONE
+
+    def record_escalation(self, tokens: int) -> None:
+        self.escalations += 1
+        self.escalation_tokens += max(0, tokens)
+
+
+def is_escalation_dominated(escalation_tokens: int, primary_input_tokens: int) -> bool:
+    """Q2/R3: >40% of the primary's input from escalation => excluded from the headline."""
+    if primary_input_tokens <= 0:
+        return escalation_tokens > 0
+    return escalation_tokens / primary_input_tokens > ESCALATION_DOMINATED_FRAC
+
+
+# ------------------------------------------------------------ context window ---
+@dataclass
+class ContextWindow:
+    """Q4: sliding window of the last K digests + a deterministic fold-then-evict of older turns
+    to a one-line summary (worker set, files, terminal states, counts — NO quoted content), under
+    a hard total cap. Exposes the per-turn token curve so drift can't hide savings."""
+    k: int = WINDOW_K
+    total_cap: int = CONTEXT_TOTAL_CAP
+    _recent: list = field(default_factory=list)
+    _fold_workers: set = field(default_factory=set)
+    _fold_files: set = field(default_factory=set)
+    _fold_turns: int = 0
+    _fold_pass: int = 0
+    _fold_fail: int = 0
+    token_curve: list = field(default_factory=list)
+
+    def add(self, d: Digest) -> None:
+        self._recent.append(d)
+        while len(self._recent) > self.k:
+            self._evict(self._recent.pop(0))
+        self.token_curve.append(self.tokens())
+
+    def _evict(self, d: Digest) -> None:
+        self._fold_workers.add(d.worker_id)
+        self._fold_files.update(d.files_touched)
+        self._fold_turns += 1
+        if d.verify == VerifyEnum.PASS.value:
+            self._fold_pass += 1
+        elif d.verify == VerifyEnum.FAIL.value:
+            self._fold_fail += 1
+
+    def fold_summary(self) -> str:
+        if not self._fold_turns:
+            return ""
+        s = (f"[folded {self._fold_turns} turns | workers={sorted(self._fold_workers)} | "
+             f"files={sorted(self._fold_files)} | pass={self._fold_pass} fail={self._fold_fail}]")
+        return s[: FOLD_TOKEN_CAP * _TOK]
+
+    def tokens(self) -> int:
+        return est_tokens(self.fold_summary()) + sum(d.tokens() for d in self._recent)
+
+    def within_cap(self) -> bool:
+        return self.tokens() <= self.total_cap
+
+
+# ------------------------------------------------------------ redirect ---------
+@dataclass
+class RedirectBudget:
+    """Q5: default OFF. If enabled, bounded (<=1 per worker) and small (<=cap tokens), classified
+    through the same code-free guard, and attributed. Redirect tokens are PRIMARY tokens."""
+    enabled: bool = False
+    per_worker_max: int = 1
+    token_cap: int = 256
+    _used: dict = field(default_factory=dict)
+    redirect_tokens: int = 0
+
+    def allow(self, worker_id: str) -> bool:
+        return self.enabled and self._used.get(worker_id, 0) < self.per_worker_max
+
+    def record(self, worker_id: str, text: str) -> str:
+        """Record a redirect (capped, defanged); returns the sanitized message."""
+        msg = neutralize_toolcalls(text)[: self.token_cap * _TOK]
+        self._used[worker_id] = self._used.get(worker_id, 0) + 1
+        self.redirect_tokens += est_tokens(msg)
+        return msg
+
+
+# ------------------------------------------------------------ tool allowlist ---
+ARM_C_TOOL_ALLOWLIST = frozenset({
+    "delegate", "select_best_of_n", "log_escalation", "gated_escalate",
+    "terminate_worker", "inspect_digest_metadata", "summarize_fold", "redirect",
+})
+# code-reading tools are NOT here; they are only reachable via gated_escalate.
+_CODE_TOOLS = frozenset({"read_file", "bash", "grep", "cat", "open", "edit_file"})
+
+
+def tool_allowed(tool: str, *, escalated: bool = False) -> bool:
+    """A code-reading tool is permitted ONLY while an escalation is active (Q2)."""
+    if tool in ARM_C_TOOL_ALLOWLIST:
+        return True
+    if tool in _CODE_TOOLS:
+        return escalated
+    return False
+
+
+# ------------------------------------------------------------ live stub --------
+def run_arm_c_supervised(instance: dict, *, workers: list[str], n: int, redirect: bool = False):
+    raise NotImplementedError(
+        "live arm-C supervision loop not wired: dispatch N tools-enabled workers on isolated "
+        "workspaces (S1), build capped leak-guarded digests each turn (build_digest), keep the "
+        "supervisor context bounded (ContextWindow), select deterministically (select_best_of_n), "
+        "escalate only on the gated triggers, and read primary tokens via the S0 polarity + S2 "
+        "arm-runner accounting. The optional LLM-supervisor selection is a separate ablation.")

--- a/benchmarks/tests/test_swebench_supervision.py
+++ b/benchmarks/tests/test_swebench_supervision.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit tests for S3 — the arm-C supervision honesty core.
+
+No live server/LLM/network. Every roundtable honesty ruling is pinned by a case: digests are
+hard-capped and leak-guarded, selection is deterministic, escalation is gated and dominance is
+detected, the context window folds under a cap, redirect is bounded, and the tool allowlist gates
+code-reading behind escalation.
+Run: python3 -m unittest benchmarks.tests.test_swebench_supervision
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_supervision as S
+from benchmarks.coding.swebench_supervision import (
+    WorkerTurn, WorkerState, VerifyEnum, Candidate)
+
+
+def _turn(wid="w1", ti=0, diff="diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n",
+          verify=VerifyEnum.FAIL, state=WorkerState.RUNNING, rationale="", action="edit"):
+    return WorkerTurn(worker_id=wid, turn_index=ti, state=state, action_label=action,
+                      unified_diff=diff, verify=verify, rationale=rationale)
+
+
+class TestDigestCapsAndLeakGuard(unittest.TestCase):
+    def test_digest_never_exceeds_hard_cap(self):
+        huge = "diff --git a/x b/x\n" + ("+line of code\n" * 5000)
+        d = S.build_digest(_turn(diff=huge))
+        self.assertLessEqual(d.tokens(), S.DIGEST_TOKEN_CAP)
+        self.assertTrue(d.truncated)
+
+    def test_source_like_rationale_dropped(self):
+        src = "def f():\n    import os\n    return os.getcwd()\n"
+        d = S.build_digest(_turn(rationale=src))
+        self.assertIn("rationale", d.rejected_fields)
+
+    def test_toolcall_syntax_neutralized(self):
+        d = S.build_digest(_turn(action="<tool_use name=bash>rm -rf</tool_use>"))
+        self.assertNotIn("<tool_use", d.action_label)
+
+    def test_frame_stubs_bare_source(self):
+        # A digest whose diff field is bare source (not a diff frame) is stubbed in the frame.
+        bad = S.Digest(worker_id="w", turn_index=0, state="running", action_label="x",
+                       verify="FAIL", diff="def g():\n    import sys\n    return 1\n",
+                       files_touched=(), added=0, deleted=0, truncated=False)
+        frame, rejected = S.serialize_supervisor_frame([bad])
+        self.assertEqual(rejected, 1)
+        self.assertIn("REJECTED", frame)
+
+    def test_real_diff_survives_frame(self):
+        d = S.build_digest(_turn())
+        frame, rejected = S.serialize_supervisor_frame([d])
+        self.assertEqual(rejected, 0)
+        self.assertIn("+b", frame)
+
+
+class TestDeterministicSelection(unittest.TestCase):
+    def test_prefers_verify_pass(self):
+        cands = [Candidate("w1", "d\n", VerifyEnum.FAIL, turns=1),
+                 Candidate("w2", "d\nd\nd\n", VerifyEnum.PASS, turns=3)]
+        self.assertEqual(S.select_best_of_n(cands).worker_id, "w2")
+
+    def test_tie_break_fewer_turns_then_smaller_diff(self):
+        cands = [Candidate("w1", "a\nb\nc\n", VerifyEnum.PASS, turns=2),
+                 Candidate("w2", "a\n", VerifyEnum.PASS, turns=2)]
+        self.assertEqual(S.select_best_of_n(cands).worker_id, "w2")  # smaller diff
+
+    def test_no_valid_candidate_returns_none(self):
+        cands = [Candidate("w1", "   ", VerifyEnum.FAIL, turns=1),
+                 Candidate("w2", "d\n", VerifyEnum.ERROR, turns=1)]
+        self.assertIsNone(S.select_best_of_n(cands))
+
+    def test_selection_is_deterministic(self):
+        cands = [Candidate("wb", "d\n", VerifyEnum.PASS, turns=1),
+                 Candidate("wa", "d\n", VerifyEnum.PASS, turns=1)]
+        self.assertEqual(S.select_best_of_n(cands).worker_id,
+                         S.select_best_of_n(cands).worker_id)  # stable
+        self.assertEqual(S.select_best_of_n(cands).worker_id, "wa")  # worker_id tie-break
+
+
+class TestSelectionSkill(unittest.TestCase):
+    def test_oracle_vs_actual(self):
+        resolved = {"w1": False, "w2": True}
+        self.assertTrue(S.oracle_pass(resolved))
+        self.assertTrue(S.actual_pass("w2", resolved))
+        self.assertFalse(S.actual_pass("w1", resolved))
+
+    def test_skill_ratio(self):
+        self.assertEqual(S.selection_skill_ratio(0.4, 0.8), 0.5)
+        self.assertIsNone(S.selection_skill_ratio(0.0, 0.0))
+
+
+class TestEscalationGating(unittest.TestCase):
+    def test_all_failed_triggers(self):
+        e = S.EscalationState()
+        self.assertEqual(e.should_escalate(all_failed=True, made_progress=False),
+                         S.EscalationTrigger.ALL_WORKERS_FAILED)
+
+    def test_stuck_triggers_after_limit(self):
+        e = S.EscalationState(stuck_limit=2)
+        self.assertEqual(e.should_escalate(all_failed=False, made_progress=False),
+                         S.EscalationTrigger.NONE)
+        self.assertEqual(e.should_escalate(all_failed=False, made_progress=False),
+                         S.EscalationTrigger.STUCK)
+
+    def test_progress_resets_stuck(self):
+        e = S.EscalationState(stuck_limit=2)
+        e.should_escalate(all_failed=False, made_progress=False)
+        e.should_escalate(all_failed=False, made_progress=True)  # reset
+        self.assertEqual(e.stuck_turns, 0)
+
+    def test_escalation_dominated(self):
+        self.assertTrue(S.is_escalation_dominated(500, 1000))    # 50% > 40%
+        self.assertFalse(S.is_escalation_dominated(300, 1000))   # 30%
+        self.assertTrue(S.is_escalation_dominated(1, 0))          # any escalation w/ no base
+
+
+class TestContextWindow(unittest.TestCase):
+    def test_window_keeps_last_k_and_folds_rest(self):
+        cw = S.ContextWindow(k=2)
+        for i in range(5):
+            cw.add(S.build_digest(_turn(wid=f"w{i}", ti=i)))
+        self.assertEqual(len(cw._recent), 2)
+        self.assertIn("folded 3 turns", cw.fold_summary())
+
+    def test_fold_summary_has_no_quoted_code(self):
+        cw = S.ContextWindow(k=1)
+        for i in range(3):
+            cw.add(S.build_digest(_turn(wid="w", ti=i, diff="diff\n+secret_code_here\n")))
+        self.assertNotIn("secret_code_here", cw.fold_summary())
+
+    def test_token_curve_recorded(self):
+        cw = S.ContextWindow(k=3)
+        for i in range(4):
+            cw.add(S.build_digest(_turn(ti=i)))
+        self.assertEqual(len(cw.token_curve), 4)
+
+
+class TestRedirect(unittest.TestCase):
+    def test_default_off(self):
+        rb = S.RedirectBudget()
+        self.assertFalse(rb.allow("w1"))
+
+    def test_bounded_per_worker(self):
+        rb = S.RedirectBudget(enabled=True, per_worker_max=1)
+        self.assertTrue(rb.allow("w1"))
+        rb.record("w1", "stay in the target file")
+        self.assertFalse(rb.allow("w1"))
+
+    def test_redirect_defangs_and_counts(self):
+        rb = S.RedirectBudget(enabled=True)
+        msg = rb.record("w1", "<tool_use>x</tool_use> focus")
+        self.assertNotIn("<tool_use>", msg)
+        self.assertGreater(rb.redirect_tokens, 0)
+
+
+class TestToolAllowlist(unittest.TestCase):
+    def test_supervisory_tools_allowed(self):
+        self.assertTrue(S.tool_allowed("select_best_of_n"))
+        self.assertTrue(S.tool_allowed("delegate"))
+
+    def test_code_tools_blocked_unless_escalated(self):
+        self.assertFalse(S.tool_allowed("read_file"))
+        self.assertFalse(S.tool_allowed("bash"))
+        self.assertTrue(S.tool_allowed("read_file", escalated=True))
+
+    def test_unknown_tool_blocked(self):
+        self.assertFalse(S.tool_allowed("exfiltrate"))
+
+
+class TestLiveStubHonesty(unittest.TestCase):
+    def test_run_arm_c_is_marked_stub(self):
+        with self.assertRaises(NotImplementedError):
+            S.run_arm_c_supervised({}, workers=["w1"], n=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fourth slice of the agentic supervised SWE-bench harness (proposal #1078; follows S0 #1079, S1 #1080, S2 #1082). Part of #987. Built on the **S3 design roundtable** (`.254`, 6/7, 40 findings, strongly converged).

## Why this slice matters
The public claim ("beats Reddit's −75.5% supervisor tokens at no wall-clock penalty") is only honest if the primary supervises **cheaply** — reading short, capped, leak-guarded digests and picking among candidate diffs, **never the raw code**. This module is the machinery that *mechanically* enforces that (not by prompt convention). Pure functions, unit-tested with no live server/LLM/network.

## Ratified rulings baked in
| Q | ruling |
|---|---|
| Q1 digest | constructed, **hard-capped** (2048 tok; 512-tok diff sub-cap), **leak-guarded** — serializer rejects raw-source/file-like fields, neutralizes tool-call syntax (anti prompt-injection) |
| Q2 tools/escalation | hard allowlist; code-reading tools reachable **only** via gated escalation (triggers: worker terminal-fail \| deterministic stuck); >40% escalation-token runs → `ESCALATION_DOMINATED`, excluded from headline |
| Q3 selection | **deterministic** pure selector (an LLM selector is non-reproducible); `oracle_pass` vs `actual_pass` + `selection_skill_ratio` separate supervisor skill from worker diversity |
| Q4 context drift | sliding window (K) + deterministic **fold-then-evict** to a code-free summary under 16k; per-turn token curve exposed |
| Q5 redirect | **default OFF** (PR#986's limiter was worker reliability, not supervision); bounded+attributed ablation if enabled |

The one panel "blocking" item was a malformed empty placeholder, not a real finding.

25 new tests (digest caps + leak guard, deterministic selection + tie-breaks, escalation gating + dominance, context fold, redirect budget, tool allowlist); full bench suite green (**503**). Live supervision loop is a marked stub.

Next: S4 (report extensions — Pareto/failure-mode/selection-skill/context-curve panels + the two-denominator resolution) and S5/S6 (live execution + fail-closed claim gate).