### PR TITLE
feat(hooks): enforce the memory-file guard on a remote-only host

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,6 +798,10 @@ set(CLI_SRCS
     # the macOS/Windows CMake link fails with undefined hmem_* symbols.
     ${AIMEE_SRC_DIR}/harness_memory_common.c
     ${AIMEE_SRC_DIR}/harness_memory_scope.c
+    # cli_main's remote-only hooks-pre path calls memory_redirect_check; the CLI
+    # doesn't link aimee-core, so its definer must build in directly (make links it
+    # via CLIENT_SUPPORT_OBJS). Without it the CLI link fails undefined.
+    ${AIMEE_SRC_DIR}/memory_redirect.c
     ${AIMEE_SRC_DIR}/harness_memory_audit.c
     ${AIMEE_SRC_DIR}/harness_memory_spill.c
     ${AIMEE_SRC_DIR}/cli_attention_guard.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -368,7 +368,7 @@ CLIENT_PLATFORM_OBJS = $(filter %/platform_ipc.o %/platform_net.o %/platform_pat
 # with full flags; --gc-sections trims the unused remainder). util.o supplies
 # run_cmd/run_cmd_set_cwd for the provider exec_shell op the runner now serves.
 CLIENT_RUNNER_OBJS = $(OBJDIR)/server/workspace_provider_detached.o $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/posix/util.o $(OBJDIR)/util.o
-CLIENT_SUPPORT_OBJS = $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o $(OBJDIR)/aimee_home.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o $(OBJDIR)/code_collect.o $(OBJDIR)/codex_auth.o $(OBJDIR)/yaml.o $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_def.o $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o $(CLIENT_PLATFORM_OBJS) $(CLIENT_RUNNER_OBJS)
+CLIENT_SUPPORT_OBJS = $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o $(OBJDIR)/aimee_home.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o $(OBJDIR)/code_collect.o $(OBJDIR)/codex_auth.o $(OBJDIR)/yaml.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_def.o $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o $(CLIENT_PLATFORM_OBJS) $(CLIENT_RUNNER_OBJS)
 CLIENT_COMPILE_OBJS = $(CLI_OBJS) $(CLIENT_PLATFORM_OBJS) $(OBJDIR)/dstr.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o
 $(CLIENT_COMPILE_OBJS): C_FLAGS := $(CLIENT_C_FLAGS)
 

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -25,6 +25,7 @@
 #include "platform_path.h"
 #include "platform_process.h"
 #include "cJSON.h"
+#include "memory_redirect.h"
 #include <ctype.h>
 #include <signal.h>
 #include <stdio.h>
@@ -744,6 +745,41 @@ static int handle_hooks(int argc, char **argv, int json_output)
    if (!sock)
    {
       int deny = client_failopen_subagent_deny(phase, tool_name);
+      /* No co-located server, but a remote store is configured: the full
+       * pre_tool_check needs local session state, yet the memory-file guard can
+       * still run against the remote (memory_redirect captures there). Enforce
+       * it so an agent can't own its own memory bytes even on a remote-only host
+       * (session-start has the analogous handle_session_start_remote path). */
+      if (deny < 0 && strcmp(phase, "pre") == 0 && cli_v1_has_remote_endpoint() && json)
+      {
+         /* memory_redirect_check captures to the configured remote endpoint and
+          * denies the raw write (fail-open spill if the store is unreachable).
+          * pre_tool_check is skipped — it needs local session state. */
+         int rc = 0;
+         cJSON *tn = cJSON_GetObjectItemCaseSensitive(json, "tool_name");
+         cJSON *tin = cJSON_GetObjectItemCaseSensitive(json, "tool_input");
+         if (cJSON_IsString(tn) && tn->valuestring[0] && cJSON_IsObject(tin))
+         {
+            cJSON *hpj = cJSON_GetObjectItemCaseSensitive(json, "harness_project");
+            const char *hp = (cJSON_IsString(hpj) && hpj->valuestring[0]) ? hpj->valuestring : NULL;
+            char mr_msg[1024] = "";
+            if (memory_redirect_check(tn->valuestring, tin, hook_cwd, hp, mr_msg, sizeof(mr_msg)) ==
+                2)
+            {
+               if (cli_hook_client_uses_pretool_json())
+                  emit_pretool_deny_json(mr_msg);
+               else
+               {
+                  fprintf(stderr, "aimee: %s\n", mr_msg);
+                  rc = 2;
+               }
+            }
+         }
+         free(stdin_data);
+         cJSON_Delete(json);
+         free(tool_input_heap);
+         return rc;
+      }
       if (deny < 0)
          fprintf(stderr, "aimee: hooks %s: server unavailable — tool call allowed\n", phase);
       free(stdin_data);

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -362,13 +362,15 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, const 
             if (r)
                cJSON_Delete(r);
             int sp = hmem_spill_write(project, name, "archive", content);
-            hmem_audit(sp == 0 ? "spill" : "spill-failed", project, name, "db1 store unreachable");
+            /* Storage-neutral wording: this file links into the DB-free client,
+             * whose build-integrity boundary forbids db1/db2 string leaks. */
+            hmem_audit(sp == 0 ? "spill" : "spill-failed", project, name, "store unreachable");
             fprintf(stderr, "aimee: memory store unavailable (status %d); %s\n", st,
                     sp == 0 ? "spilled for reconcile" : "spill FAILED — allowing local write");
             return 0; /* fail-open: allow the local write this once */
          }
          cJSON_Delete(r);
-         hmem_audit("redirect-db1", project, name, NULL);
+         hmem_audit("redirect-store", project, name, NULL);
          /* No re-materialize: the .md is retired and never created. */
          snprintf(msg, msg_len,
                   "Saved to aimee memory. Memory files are retired — retrieve with "


### PR DESCRIPTION
## Problem

The PreToolUse **memory-file guard** (`memory_redirect_check` — capture an agent's memory write into the central store, deny the raw write, re-materialize the file) only fires when a **co-located aimee-server** answers `cli_ensure_server_for_method`. On a **remote-only** host — memory store on a remote `/v1` endpoint, no local server — `handle_hooks` falls straight through to the fail-open path (`"server unavailable — tool call allowed"`). So the agent keeps full ownership of its on-disk memory and **nothing is captured**. `session-start` already has an analogous remote fallback (`handle_session_start_remote`); `hooks pre` did not.

## Fix

In `handle_hooks`, when there's no local server **but a remote endpoint is configured**, run just the memory redirect — `memory_redirect_check` already POSTs the capture to the configured endpoint (`cli_http_request`) and spills on failure — and emit the client-appropriate deny channel. `pre_tool_check` / session-state passes still require the local server and are skipped (only the memory guard is remote-safe).

`memory_redirect.o` is linked into the CLI via `CLIENT_SUPPORT_OBJS`; its deps (`cli_http_request` + the `harness_memory_*` helpers) are already client-side, so no server code is pulled in.

## Verified live (remote store)
- memory `.md` Write → **denied + captured** (`"Saved to aimee memory (id=…). The file now reflects your content"`) + **re-materialized** on disk.
- normal `Bash` / non-memory `Write` → pass through unchanged.

Pairs with #1081 (the list-RPC pagination fix that unblocked the ingest); together they make remote-only harness memory fully functional (capture at write-time + reconcile at session-start).