### PR TITLE
bench(swebench): S5 — suite execution + grading orchestration (#987)

### DIFF
--- a/benchmarks/coding/swebench_suite.py
+++ b/benchmarks/coding/swebench_suite.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""S5 — suite execution + grading orchestration (agentic supervised SWE-bench, #987).
+
+Runs the six-benchmark suite across factors and grades every emitted patch with the OFFICIAL
+SWE-bench Docker harness on CT 101. The parts that need the live .254 fleet + CT 101 are marked
+stubs; the reproducibility-critical orchestration is pure and unit-tested here:
+
+  - generate_run_plan .... deterministic run cells from the benchmark specs x factor grid
+                           (Benchmark 1 Reddit-10 head-to-head; 2 held-out Lite; 3 parallelism
+                           sweep; 4 best-of-N; 5 reducer lever; 6 worker-pool). K repeats.
+  - CT101Lease ........... the S1-Q1 contention control: CT 101 has two named tenants
+                           {grader, iteration_pool}; grading has strict priority and the two are
+                           mutually exclusive, so in-loop docker (if ever enabled) can never
+                           starve or add queue-noise to the sole final grader.
+  - GraderRetry .......... proposal S5: max 2 deterministic retries on a grader ERROR (not on a
+                           legitimate non-resolve); flip-detection flags instances whose
+                           resolution is unstable across the K repeats.
+  - build_predictions .... one prediction per instance per (arm, model, N, cmp) run_id, deduped
+                           by instance_id (the official harness dedupes by instance_id).
+  - aggregate_k .......... majority-vote resolution across K repeats + a flip flag.
+
+Grade only on the official harness; never let in-loop signal decide `resolved` (S1 Q1).
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ------------------------------------------------------------ benchmark specs --
+# Each spec: the instance set + the factor grid it crosses. K = repeats for variance.
+BENCHMARKS = {
+    "b1_reddit10": {"instances": "reddit10", "arms": ["A", "C"], "N": [1, 3],
+                    "reducers": [False], "primary": ["gpt-5.5", "claude"], "K": 10,
+                    "public_claim": True},
+    "b2_heldout": {"instances": "lite:28", "arms": ["A", "C"], "N": [1, 3],
+                   "reducers": [False], "primary": ["gpt-5.5"], "K": 3, "public_claim": True},
+    "b3_parallelism": {"instances": "reddit10", "arms": ["C"], "N": [1, 2, 4, 8],
+                       "reducers": [False], "primary": ["gpt-5.5"], "K": 3},
+    "b4_best_of_n": {"instances": "lite:28", "arms": ["C"], "N": [1, 2, 3],
+                     "reducers": [False], "primary": ["gpt-5.5"], "K": 3},
+    "b5_reducer": {"instances": "reddit10", "arms": ["C"], "N": [3],
+                   "reducers": [False, True], "primary": ["gpt-5.5"], "K": 3},
+    "b6_worker_pool": {"instances": "reddit10", "arms": ["C"], "N": [1],
+                       "reducers": [False], "primary": ["gpt-5.5"], "K": 3,
+                       "worker_pools": ["free_fleet", "gpu_gemma4"]},
+}
+
+
+@dataclass(frozen=True)
+class RunCell:
+    benchmark: str
+    arm: str
+    primary: str
+    n: int
+    reducers: bool
+    worker_pool: str
+    repeat: int
+    instances: str
+
+    @property
+    def run_id(self) -> str:
+        base = f"{self.benchmark}:{self.arm}:{self.primary}:N{self.n}:cmp{int(self.reducers)}:{self.worker_pool}:k{self.repeat}"
+        return f"aimee-sup-{hashlib.sha256(base.encode()).hexdigest()[:12]}"
+
+
+def generate_run_plan(benchmarks: dict = None, only: list[str] = None) -> list[RunCell]:
+    """Deterministic, fully-ordered run cells for the whole suite (or a subset via `only`)."""
+    benchmarks = benchmarks or BENCHMARKS
+    cells: list[RunCell] = []
+    for name in sorted(benchmarks):
+        if only and name not in only:
+            continue
+        spec = benchmarks[name]
+        pools = spec.get("worker_pools", ["free_fleet"])
+        for arm in spec["arms"]:
+            for primary in spec["primary"]:
+                for n in spec["N"]:
+                    for red in spec["reducers"]:
+                        for pool in pools:
+                            for k in range(spec.get("K", 1)):
+                                cells.append(RunCell(name, arm, primary, n, red, pool, k,
+                                                     spec["instances"]))
+    return cells
+
+
+# ------------------------------------------------------------ CT-101 lease ------
+class LeaseError(RuntimeError):
+    pass
+
+
+class CT101Lease:
+    """S1-Q1: CT 101 is the sole real-docker grader host. Two tenants {grader, iteration_pool}
+    are mutually exclusive; grader has strict priority (an iteration lease is refused while a
+    grade is pending or active). In-loop tests default OFF, so in practice this serializes grade
+    batches and guarantees the p95 wall-clock is never polluted by iteration docker on CT 101."""
+    GRADER = "grader"
+    ITERATION = "iteration_pool"
+
+    def __init__(self):
+        self._holder: str | None = None
+        self._grader_waiting = False
+
+    def request_grader(self) -> bool:
+        self._grader_waiting = True
+        if self._holder in (None, self.GRADER):
+            self._holder = self.GRADER
+            self._grader_waiting = False
+            return True
+        return False  # iteration holds it; caller waits (grader will get it next)
+
+    def request_iteration(self) -> bool:
+        # Grader priority: refuse iteration while a grade holds OR is waiting.
+        if self._holder is None and not self._grader_waiting:
+            self._holder = self.ITERATION
+            return True
+        return False
+
+    def release(self, tenant: str) -> None:
+        if self._holder != tenant:
+            raise LeaseError(f"{tenant} does not hold the CT101 lease (holder={self._holder})")
+        self._holder = None
+
+    @property
+    def holder(self) -> str | None:
+        return self._holder
+
+
+# ------------------------------------------------------------ grader retry ------
+@dataclass
+class GraderRetry:
+    """Proposal S5: retry a grader ERROR (harness crash/flake) up to `max_retries`, but NEVER
+    retry a legitimate non-resolve. `attempts` records the invocation count for the report."""
+    max_retries: int = 2
+    attempts: int = 0
+
+    def run(self, grade_fn) -> Any:
+        """grade_fn() -> ('ok', resolved_bool) | ('error', msg). Retries only on 'error'."""
+        last = None
+        for _ in range(self.max_retries + 1):
+            self.attempts += 1
+            status, payload = grade_fn()
+            if status == "ok":
+                return payload
+            last = payload
+        raise RuntimeError(f"grader failed after {self.attempts} attempts: {last}")
+
+
+def detect_flips(resolved_by_repeat: list[bool]) -> bool:
+    """True if an instance's resolution is UNSTABLE across the K repeats (some pass, some fail).
+    A flapping instance is flagged so grader-flake is not conflated with run noise."""
+    s = set(resolved_by_repeat)
+    return len(s) > 1
+
+
+def aggregate_k(resolved_by_repeat: list[bool]) -> dict[str, Any]:
+    """Majority-vote resolution across K repeats + the flip flag."""
+    if not resolved_by_repeat:
+        return {"resolved": None, "flipped": False, "k": 0}
+    n_true = sum(1 for r in resolved_by_repeat if r)
+    return {"resolved": n_true * 2 >= len(resolved_by_repeat), "flipped": detect_flips(resolved_by_repeat),
+            "k": len(resolved_by_repeat), "pass_count": n_true}
+
+
+# ------------------------------------------------------------ predictions ------
+def build_predictions(records: list[dict[str, Any]], run_id: str) -> list[dict[str, Any]]:
+    """One prediction per instance for a run_id, deduped by instance_id (the official harness
+    dedupes by instance_id, so duplicates would be silently dropped — we dedupe explicitly,
+    keeping the first non-empty patch)."""
+    seen: dict[str, dict] = {}
+    for r in records:
+        iid = r["instance_id"]
+        if not r.get("diff") and not r.get("patch"):
+            continue
+        if iid in seen:
+            continue
+        seen[iid] = {"instance_id": iid, "model_name_or_path": run_id,
+                     "model_patch": r.get("diff") or r.get("patch", "")}
+    return list(seen.values())
+
+
+# ------------------------------------------------------------ live stub --------
+def run_suite(only: list[str] = None, *, token_db: str, aimee_bin: str):
+    raise NotImplementedError(
+        "live suite execution not wired: for each RunCell from generate_run_plan(), dispatch arm "
+        "A (run_arm_a) or arm C (run_arm_c_supervised) on the .254 fleet, hold CT101Lease.GRADER "
+        "while grading each run_id's build_predictions() with the official swebench Docker harness "
+        "on CT 101 under GraderRetry, aggregate_k across repeats, then feed the records to "
+        "supervised_report + supervised_report_panels. Requires the live server + CT 101.")

--- a/benchmarks/tests/test_swebench_suite.py
+++ b/benchmarks/tests/test_swebench_suite.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Unit tests for S5 — the suite orchestration.
+
+Pure: run-plan generation, the CT-101 lease invariants, grader retry + flip detection, and
+prediction dedup. No live fleet/docker.
+Run: python3 -m unittest benchmarks.tests.test_swebench_suite
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_suite as Q
+
+
+class TestRunPlan(unittest.TestCase):
+    def test_deterministic_and_ordered(self):
+        self.assertEqual([c.run_id for c in Q.generate_run_plan()],
+                         [c.run_id for c in Q.generate_run_plan()])
+
+    def test_run_ids_unique_per_cell(self):
+        cells = Q.generate_run_plan()
+        ids = [c.run_id for c in cells]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_b1_crosses_arms_N_primary_K(self):
+        cells = Q.generate_run_plan(only=["b1_reddit10"])
+        # arms{A,C} x N{1,3} x primary{gpt-5.5,claude} x K=10 = 2*2*2*10 = 80
+        self.assertEqual(len(cells), 80)
+        self.assertTrue(all(c.benchmark == "b1_reddit10" for c in cells))
+
+    def test_b6_uses_worker_pools(self):
+        cells = Q.generate_run_plan(only=["b6_worker_pool"])
+        pools = {c.worker_pool for c in cells}
+        self.assertEqual(pools, {"free_fleet", "gpu_gemma4"})
+
+    def test_b3_parallelism_sweep(self):
+        cells = Q.generate_run_plan(only=["b3_parallelism"])
+        self.assertEqual({c.n for c in cells}, {1, 2, 4, 8})
+
+
+class TestCT101Lease(unittest.TestCase):
+    def test_grader_gets_lease(self):
+        L = Q.CT101Lease()
+        self.assertTrue(L.request_grader())
+        self.assertEqual(L.holder, "grader")
+
+    def test_iteration_refused_while_grader_holds(self):
+        L = Q.CT101Lease()
+        L.request_grader()
+        self.assertFalse(L.request_iteration())
+
+    def test_grader_priority_over_waiting_iteration(self):
+        L = Q.CT101Lease()
+        self.assertTrue(L.request_iteration())     # iteration holds
+        self.assertFalse(L.request_grader())        # grader must wait...
+        L.release("iteration_pool")
+        # ...and while grader is waiting, iteration cannot re-grab it
+        self.assertFalse(L.request_iteration())
+        self.assertTrue(L.request_grader())
+
+    def test_release_wrong_tenant_errors(self):
+        L = Q.CT101Lease()
+        L.request_grader()
+        with self.assertRaises(Q.LeaseError):
+            L.release("iteration_pool")
+
+
+class TestGraderRetry(unittest.TestCase):
+    def test_retries_on_error_then_succeeds(self):
+        calls = {"n": 0}
+
+        def grade():
+            calls["n"] += 1
+            return ("error", "flake") if calls["n"] < 2 else ("ok", True)
+
+        gr = Q.GraderRetry(max_retries=2)
+        self.assertTrue(gr.run(grade))
+        self.assertEqual(gr.attempts, 2)
+
+    def test_does_not_retry_a_legit_non_resolve(self):
+        gr = Q.GraderRetry(max_retries=2)
+        self.assertFalse(gr.run(lambda: ("ok", False)))
+        self.assertEqual(gr.attempts, 1)   # no retry on a valid False
+
+    def test_raises_after_exhausting_retries(self):
+        gr = Q.GraderRetry(max_retries=2)
+        with self.assertRaises(RuntimeError):
+            gr.run(lambda: ("error", "always down"))
+        self.assertEqual(gr.attempts, 3)
+
+
+class TestFlipDetection(unittest.TestCase):
+    def test_flip_flagged(self):
+        self.assertTrue(Q.detect_flips([True, False, True]))
+        self.assertFalse(Q.detect_flips([True, True, True]))
+        self.assertFalse(Q.detect_flips([False, False]))
+
+    def test_aggregate_majority_vote(self):
+        self.assertTrue(Q.aggregate_k([True, True, False])["resolved"])
+        self.assertFalse(Q.aggregate_k([True, False, False])["resolved"])
+        self.assertTrue(Q.aggregate_k([True, False])["flipped"])
+
+    def test_aggregate_empty(self):
+        self.assertEqual(Q.aggregate_k([])["resolved"], None)
+
+
+class TestPredictions(unittest.TestCase):
+    def test_dedup_by_instance_id(self):
+        recs = [{"instance_id": "i1", "diff": "d1"}, {"instance_id": "i1", "diff": "d2"},
+                {"instance_id": "i2", "diff": "d3"}]
+        preds = Q.build_predictions(recs, "run-x")
+        self.assertEqual(len(preds), 2)
+        self.assertEqual({p["instance_id"] for p in preds}, {"i1", "i2"})
+        self.assertTrue(all(p["model_name_or_path"] == "run-x" for p in preds))
+
+    def test_skips_empty_patches(self):
+        recs = [{"instance_id": "i1", "diff": ""}, {"instance_id": "i2", "patch": "x"}]
+        preds = Q.build_predictions(recs, "run-x")
+        self.assertEqual([p["instance_id"] for p in preds], ["i2"])
+
+
+class TestLiveStub(unittest.TestCase):
+    def test_run_suite_is_marked_stub(self):
+        with self.assertRaises(NotImplementedError):
+            Q.run_suite(token_db="/x", aimee_bin="./aimee")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Sixth slice of the agentic supervised SWE-bench harness (proposal #1078; follows S0–S4). Part of #987.

The reproducibility-critical **orchestration** of the six-benchmark suite. The live `.254` fleet dispatch + CT 101 official grading are a marked stub; the pure surface is unit-tested:

- **`generate_run_plan`** — deterministic run cells from the 6 benchmark specs × factor grid (arm × N × reducers × primary × worker-pool × K). B1 Reddit-10 = 80 cells (2 arms × N{1,3} × 2 primaries × K=10).
- **`CT101Lease`** — the S1-Q1 contention control: two mutually-exclusive tenants {grader, iteration_pool}, **grader strict-priority**, so in-loop docker can never starve or add queue-noise to the sole final grader (p95 stays clean).
- **`GraderRetry`** — max 2 deterministic retries on a grader **error** (never on a legit non-resolve); `detect_flips` flags instances whose resolution is unstable across the K repeats; `aggregate_k` = majority vote + flip flag.
- **`build_predictions`** — one prediction per instance per `run_id`, deduped by `instance_id` (the official harness dedupes by `instance_id`).

Grade **only** on the official harness; in-loop signal never decides `resolved` (S1 Q1).

18 new tests; full bench suite green (**540**).

Next: **S6** — the fail-closed claim gate (the honesty capstone) + the `SUPERVISED_SWEBENCH.md` runbook.