### PR TITLE
bench(swebench): S0-live — corrected token attribution from live .254 verification (#987)

### DIFF
--- a/benchmarks/coding/swebench_live_attribution.py
+++ b/benchmarks/coding/swebench_live_attribution.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""S0-live — empirically-grounded token attribution for the agentic supervised SWE-bench harness.
+
+The pure S0 module (`swebench_transport_verify.py`) asserts a THEORETICAL polarity: a top-level
+primary turn carries `delegation_id` EMPTY and a delegate child carries it non-empty. Running the
+verification matrix against the live .254 fleet (2026-07-05) showed the DEPLOYMENT does not work
+that way, and this module encodes the corrected model so the live harness measures the right
+thing:
+
+  FINDING 1 — almost no EMPTY-delegation rows exist. On .254, ~all realized `token_audit` rows are
+    delegate turns with a NON-EMPTY `delegation_id` of the form `deleg-<sess>-<ns_ts>-<idx>`; the
+    aimee primary (a tmux Claude TUI whose /v1 proxy is stateless) does not reliably emit
+    EMPTY-delegation rows. => the bench runs the "primary" itself as a `codex`/gpt-5.5 DELEGATE,
+    and primary vs worker is distinguished by WHICH delegation_id the harness dispatched, not by
+    empty-vs-nonempty.
+  FINDING 2 — `delegation_spawns` is the attribution table: (delegation_id, parent_delegation_id,
+    session_id, depth, role). A dispatch creates one row; workers a primary spawns would be its
+    depth-2 children (parent_delegation_id = primary's). Today all dispatches are depth-1 siblings,
+    so the harness captures each dispatch's delegation_id from the newest spawn row for its session.
+  FINDING 3 — `usage_kind` filtering is load-bearing: a single agentic job produced 9 rows, 8 of
+    them `avoided` (economizer estimates) and 1 `realized`. Only `realized` is spend.
+  FINDING 4 — agentic `--tools` needs an ISOLATED worktree: a plain `delegate execute --tools`
+    hit the "parent worktree write guard ... sandbox fallback could not start" and no tool ran.
+    The worker's edit/test loop must dispatch with `--worktree` (S1 per-worker isolation is
+    therefore REQUIRED for tools to function at all, not merely for reproducibility).
+
+The attribution logic here is pure and unit-tested against an in-memory sqlite fixture mirroring
+`delegation_spawns` + `token_audit`; the SSH-based live runner is a marked stub.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+# ------------------------------------------------------------ schema names -----
+# The two real tables (columns verified on .254 aimee.db, 2026-07-05).
+SPAWNS = "delegation_spawns"       # delegation_id, parent_delegation_id, session_id, depth, role, ...
+AUDIT = "token_audit"              # delegation_id, usage_kind, prompt/completion/cache_*_tokens, ...
+
+
+@dataclass
+class TokenTotals:
+    input_uncached: int
+    input_cached: int
+    output: int
+    rows: int
+
+    @property
+    def total_headline(self) -> int:
+        return self.input_uncached + self.output
+
+
+def capture_dispatch_delegation(con: sqlite3.Connection, session_id: str,
+                                after_spawn_id: int) -> str | None:
+    """Resolve the delegation_id of a just-dispatched job: the newest delegation_spawns row for
+    `session_id` with id > after_spawn_id (the id captured immediately BEFORE dispatch). Returns
+    None if the dispatch produced no spawn row (a failed/rejected dispatch)."""
+    r = con.execute(
+        f"SELECT delegation_id FROM {SPAWNS} WHERE session_id=? AND id>? "
+        f"ORDER BY id DESC LIMIT 1", (session_id, after_spawn_id)).fetchone()
+    return r[0] if r else None
+
+
+def child_delegations(con: sqlite3.Connection, parent_delegation_id: str) -> list[str]:
+    """The delegation_ids of workers a primary spawned (depth-2 children). Empty today (all
+    dispatches are depth-1 siblings) but correct once the primary spawns workers server-side."""
+    rows = con.execute(
+        f"SELECT delegation_id FROM {SPAWNS} WHERE parent_delegation_id=?",
+        (parent_delegation_id,)).fetchall()
+    return [r[0] for r in rows]
+
+
+def realized_totals(con: sqlite3.Connection, delegation_ids: list[str]) -> TokenTotals:
+    """Sum REALIZED token_audit rows over a set of delegation_ids. Headline input is UNCACHED
+    (prompt - cache_read); avoided/estimated rows are excluded (usage_kind='realized' only)."""
+    if not delegation_ids:
+        return TokenTotals(0, 0, 0, 0)
+    q = (f"SELECT COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(cache_read_tokens),0), "
+         f"COALESCE(SUM(completion_tokens),0), COUNT(*) FROM {AUDIT} "
+         f"WHERE usage_kind='realized' AND delegation_id IN ({','.join('?' * len(delegation_ids))})")
+    prompt, cache_read, completion, rows = con.execute(q, delegation_ids).fetchone()
+    return TokenTotals(input_uncached=max(0, prompt - cache_read), input_cached=cache_read,
+                       output=completion, rows=rows)
+
+
+def primary_worker_split(con: sqlite3.Connection, primary_did: str,
+                         worker_dids: list[str]) -> dict:
+    """The corrected primary-vs-worker split: primary tokens over the primary's delegation_id,
+    worker tokens over the workers' delegation_ids. This REPLACES the EMPTY-polarity model for the
+    live deployment."""
+    p = realized_totals(con, [primary_did])
+    w = realized_totals(con, worker_dids)
+    return {
+        "primary_did": primary_did,
+        "primary_input_uncached": p.input_uncached,
+        "primary_input_cached": p.input_cached,
+        "primary_output": p.output,
+        "primary_headline": p.total_headline,
+        "primary_rows": p.rows,
+        "worker_dids": worker_dids,
+        "worker_input": w.input_uncached + w.input_cached,
+        "worker_output": w.output,
+        "worker_rows": w.rows,
+    }
+
+
+# ------------------------------------------------------------ live assertions --
+def verify_live_attribution(con: sqlite3.Connection, primary_did: str,
+                            worker_dids: list[str]) -> dict:
+    """Re-express the S0 assertions over the REAL schema for a completed run:
+      L1 primary_measured  — the primary delegation has >=1 realized row with output.
+      L2 worker_attributed — every worker delegation is disjoint from the primary's id.
+      L3 no_cross_bill     — no worker delegation_id is counted under the primary total.
+      L4 realized_only     — (structural) totals exclude avoided/estimated rows (SQL enforces).
+    """
+    split = primary_worker_split(con, primary_did, worker_dids)
+    l1 = split["primary_rows"] >= 1 and split["primary_output"] >= 0
+    l2 = primary_did not in worker_dids
+    l3 = not (set(worker_dids) & {primary_did})
+    checks = {
+        "L1_primary_measured": (l1, f"{split['primary_rows']} realized primary rows"),
+        "L2_worker_disjoint": (l2, f"{len(worker_dids)} worker delegations, primary excluded"),
+        "L3_no_cross_bill": (l3, "no worker delegation_id under the primary total"),
+        "L4_realized_only": (True, "SQL filters usage_kind='realized' (avoided rows excluded)"),
+    }
+    out = {k: {"ok": ok, "detail": d} for k, (ok, d) in checks.items()}
+    out["passed"] = all(v["ok"] for v in out.values())
+    out["split"] = split
+    return out
+
+
+# ------------------------------------------------------------ live runner ------
+def run_live_matrix(*, ssh_host: str, db_path: str):
+    raise NotImplementedError(
+        "live matrix runner not wired for autonomous exec: it SSHes to `ssh_host`, copies/queries "
+        f"{db_path} (aimee.db) against delegation_spawns + token_audit, and for a dispatched "
+        "primary+workers run computes primary_worker_split()/verify_live_attribution(). On .254 "
+        "the DB is at /mnt/media/.plugins/aimee-server/server/home/aimee.db and readable over ssh "
+        "(BatchMode key auth). Also note FINDING 4: workers need `delegate ... --worktree` for "
+        "tools to run (the write guard blocks a plain --tools dispatch).")

--- a/benchmarks/tests/test_swebench_live_attribution.py
+++ b/benchmarks/tests/test_swebench_live_attribution.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Unit tests for S0-live token attribution.
+
+Runs the real attribution SQL against an in-memory sqlite fixture that mirrors the .254
+`delegation_spawns` + `token_audit` schema (columns verified on the live DB). Proves the
+corrected primary-vs-worker split, the realized-only filter, and the disjointness assertions.
+Run: python3 -m unittest benchmarks.tests.test_swebench_live_attribution
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_live_attribution as A
+
+
+def _fixture() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.execute("CREATE TABLE delegation_spawns (id INTEGER PRIMARY KEY, delegation_id TEXT, "
+                "parent_delegation_id TEXT, session_id TEXT, depth INT, role TEXT)")
+    con.execute("CREATE TABLE token_audit (id INTEGER PRIMARY KEY, delegation_id TEXT, "
+                "usage_kind TEXT, prompt_tokens INT, completion_tokens INT, "
+                "cache_read_tokens INT, cache_write_tokens INT)")
+    S = "sess-1"
+    # primary dispatch (depth-1) + two worker dispatches (depth-1 siblings today)
+    con.executemany("INSERT INTO delegation_spawns VALUES (?,?,?,?,?,?)", [
+        (100, "deleg-P", "", S, 1, "execute"),
+        (101, "deleg-W1", "", S, 1, "code"),
+        (102, "deleg-W2", "", S, 1, "code"),
+    ])
+    con.executemany("INSERT INTO token_audit VALUES (?,?,?,?,?,?,?)", [
+        # primary: 1 realized (1000 prompt, 200 cache_read -> 800 uncached, 100 out) + 1 avoided
+        (1, "deleg-P", "realized", 1000, 100, 200, 0),
+        (2, "deleg-P", "avoided", 5000, 0, 0, 0),
+        # workers: big realized returns (priced $0 in reporting)
+        (3, "deleg-W1", "realized", 40000, 3000, 0, 0),
+        (4, "deleg-W2", "realized", 50000, 4000, 0, 0),
+        (5, "deleg-W2", "avoided", 9999, 0, 0, 0),
+    ])
+    con.commit()
+    return con
+
+
+class TestCapture(unittest.TestCase):
+    def test_capture_newest_spawn_after_marker(self):
+        con = _fixture()
+        # dispatched after id 100 -> newest is W2 (id 102)
+        self.assertEqual(A.capture_dispatch_delegation(con, "sess-1", 100), "deleg-W2")
+
+    def test_none_when_no_new_spawn(self):
+        con = _fixture()
+        self.assertIsNone(A.capture_dispatch_delegation(con, "sess-1", 999))
+
+
+class TestRealizedTotals(unittest.TestCase):
+    def test_uncached_headline_and_realized_only(self):
+        con = _fixture()
+        t = A.realized_totals(con, ["deleg-P"])
+        self.assertEqual(t.input_uncached, 800)   # 1000 - 200 cache_read
+        self.assertEqual(t.input_cached, 200)
+        self.assertEqual(t.output, 100)
+        self.assertEqual(t.rows, 1)                # the avoided row excluded
+        self.assertEqual(t.total_headline, 900)
+
+    def test_empty_delegation_set(self):
+        con = _fixture()
+        self.assertEqual(A.realized_totals(con, []).rows, 0)
+
+
+class TestPrimaryWorkerSplit(unittest.TestCase):
+    def test_split_is_by_delegation_ownership(self):
+        con = _fixture()
+        s = A.primary_worker_split(con, "deleg-P", ["deleg-W1", "deleg-W2"])
+        self.assertEqual(s["primary_headline"], 900)     # cheap primary
+        self.assertEqual(s["worker_output"], 7000)        # 3000 + 4000
+        self.assertEqual(s["worker_input"], 90000)        # 40000 + 50000, avoided excluded
+        self.assertEqual(s["primary_rows"], 1)
+
+    def test_child_delegations_when_tree_exists(self):
+        con = _fixture()
+        # promote W1 to a child of P
+        con.execute("UPDATE delegation_spawns SET parent_delegation_id='deleg-P', depth=2 "
+                    "WHERE delegation_id='deleg-W1'")
+        self.assertEqual(A.child_delegations(con, "deleg-P"), ["deleg-W1"])
+
+
+class TestVerifyLiveAttribution(unittest.TestCase):
+    def test_passes_on_clean_split(self):
+        con = _fixture()
+        v = A.verify_live_attribution(con, "deleg-P", ["deleg-W1", "deleg-W2"])
+        self.assertTrue(v["passed"], v)
+        self.assertTrue(v["L1_primary_measured"]["ok"])
+
+    def test_cross_bill_detected(self):
+        con = _fixture()
+        # a worker id equal to the primary id would be cross-billing
+        v = A.verify_live_attribution(con, "deleg-P", ["deleg-P"])
+        self.assertFalse(v["L2_worker_disjoint"]["ok"])
+        self.assertFalse(v["passed"])
+
+
+class TestLiveRunnerStub(unittest.TestCase):
+    def test_runner_is_marked_stub(self):
+        with self.assertRaises(NotImplementedError):
+            A.run_live_matrix(ssh_host="admin@x", db_path="/x/aimee.db")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The first step of the **live wiring** for #987 — running the S0 verification matrix against the real `.254` fleet + host-side `aimee.db`. It surfaced that the deployment does **not** match the pure S0 module's theoretical `delegation_id EMPTY = primary` polarity, so this lands the empirically-correct attribution model.

## What the live verification found
1. **~all realized `token_audit` rows are delegate turns** with a non-empty `delegation_id` (`deleg-<sess>-<ns_ts>-<idx>`) — only **3** EMPTY rows exist server-wide. The aimee primary (a tmux Claude TUI, stateless `/v1` proxy) doesn't reliably emit EMPTY rows. → the bench runs the **primary itself as a `codex`/gpt-5.5 delegate** and splits primary-vs-worker by **which `delegation_id` it dispatched**.
2. **`delegation_spawns`** `(delegation_id, parent_delegation_id, session_id, depth, role)` is the attribution table; capture each dispatch's id as the newest spawn row for the session. (All dispatches are depth-1 siblings today; workers become depth-2 children once the primary spawns them server-side.)
3. **`usage_kind` filtering is load-bearing** — one agentic job wrote 9 rows, **8 `avoided`** (economizer) + 1 `realized`. Only `realized` is spend.
4. **agentic `--tools` needs an isolated worktree** — a plain `delegate execute --tools` hit the *"parent worktree write guard … sandbox fallback could not start"* and no tool ran. So **S1 per-worker isolation is required for tools to function**, not merely for reproducibility.

## What this lands
Pure, fixture-tested attribution logic — `capture_dispatch_delegation`, `realized_totals` (uncached headline, realized-only), `primary_worker_split`, `verify_live_attribution` — against an in-memory sqlite mirroring the verified `.254` schema. The SSH live runner is a marked stub.

This **corrects** the merged S0's polarity assumption for the deployment; the merged `swebench_transport_verify.py` remains the idealized/pure model. 9 new tests; full bench suite green (**561**).