### PR TITLE
feat(webui): edit all agent aspects via a modal; read-only delegates base screen

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -2104,6 +2104,11 @@ paths:
       summary: Set the personas an agent may be dispatched as ("all" = every persona)
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Agent personas updated, content: { application/json: { schema: { type: object } } } } }
+  /agent/set:
+    post:
+      summary: Surgically patch only the provided fields of an existing agent (model, endpoint, provider, cost_tier, max_turns, max_parallel, context_window, tools, roles, personas, enabled, key)
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: Updated agent record, content: { application/json: { schema: { type: object } } } } }
   /agent/probe:
     post:
       summary: Probe an agent/provider

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -86,6 +86,10 @@ export default function Agents() {
     null,
   );
   const [showAdd, setShowAdd] = useState(false);
+  // The agent currently open in the Edit modal (null = closed). ALL mutations —
+  // config fields, roles/personas binding, enable, remove — happen there; the base
+  // list is read-only so a binding can never change from a stray click.
+  const [editing, setEditing] = useState<AgentCfg | null>(null);
   // The known role + persona vocabularies, offered (with "all") when assigning
   // an agent's roles/personas so they match what personas declare.
   const [knownRoles, setKnownRoles] = useState<string[]>([]);
@@ -112,26 +116,6 @@ export default function Agents() {
         .catch(() => setStats({})),
     ]).finally(() => setLoading(false));
   }, []);
-
-  // Persist an agent's roles / personas via the surgical ops; refresh on success.
-  const saveAgentField = useCallback(
-    async (name: string, field: "roles" | "personas", values: string[]) => {
-      try {
-        const res = await postArgs<{ error?: string }>(`/api/agents/${field}`, [
-          name,
-          values.join(","),
-        ]);
-        if (res.error) setStatus({ kind: "err", msg: res.error });
-        else {
-          setStatus({ kind: "ok", msg: `${name} ${field} saved` });
-          refresh();
-        }
-      } catch {
-        setStatus({ kind: "err", msg: `failed to save ${field}` });
-      }
-    },
-    [refresh],
-  );
 
   useEffect(() => {
     refresh();
@@ -165,39 +149,13 @@ export default function Agents() {
     for (const a of agents) void probe(a.name);
   }, [agents, probe]);
 
-  const setEnabled = useCallback(
-    async (name: string, enabled: boolean) => {
-      setStatus(null);
-      try {
-        const res = await postArgs<{ error?: string }>(
-          enabled ? "/api/agents/enable" : "/api/agents/disable",
-          [name],
-        );
-        if (res.error) setStatus({ kind: "err", msg: res.error });
-        else setStatus({ kind: "ok", msg: `${name} ${enabled ? "enabled" : "disabled"}` });
-      } catch {
-        setStatus({ kind: "err", msg: `failed to ${enabled ? "enable" : "disable"} ${name}` });
-      }
-      refresh();
-    },
-    [refresh],
-  );
-
-  const remove = useCallback(
-    async (name: string) => {
-      if (!confirm(`Remove delegate “${name}”? This edits agents.json.`)) return;
-      setStatus(null);
-      try {
-        const res = await postArgs<{ error?: string }>("/api/agents/remove", [name]);
-        if (res.error) setStatus({ kind: "err", msg: res.error });
-        else setStatus({ kind: "ok", msg: `removed ${name}` });
-      } catch {
-        setStatus({ kind: "err", msg: `failed to remove ${name}` });
-      }
-      refresh();
-    },
-    [refresh],
-  );
+  // Keep the modal's view of the agent in sync after a save-triggered refresh so
+  // it reflects the persisted record (and closes cleanly if the agent was removed).
+  useEffect(() => {
+    if (!editing) return;
+    const fresh = agents.find((a) => a.name === editing.name);
+    if (fresh && fresh !== editing) setEditing(fresh);
+  }, [agents, editing]);
 
   return (
     <div style={{ padding: 16, fontFamily: "system-ui", height: "100%", overflow: "auto" }}>
@@ -254,43 +212,40 @@ export default function Agents() {
             stats={stats[a.name]}
             probe={probes[a.name]}
             onProbe={() => probe(a.name)}
-            onToggle={() => setEnabled(a.name, !a.enabled)}
-            onRemove={() => remove(a.name)}
-            knownRoles={knownRoles}
-            knownPersonas={knownPersonas}
-            onSaveRoles={(v) => saveAgentField(a.name, "roles", v)}
-            onSavePersonas={(v) => saveAgentField(a.name, "personas", v)}
+            onEdit={() => setEditing(a)}
           />
         ))}
       </div>
+
+      {editing && (
+        <AgentEditModal
+          agent={editing}
+          knownRoles={knownRoles}
+          knownPersonas={knownPersonas}
+          onClose={() => setEditing(null)}
+          onSaved={refresh}
+          onStatus={(msg, ok) => setStatus({ kind: ok ? "ok" : "err", msg })}
+        />
+      )}
     </div>
   );
 }
 
-/* ---- one delegate: config + availability + stats ---- */
+/* ---- one delegate: READ-ONLY overview (config + availability + stats). All
+   mutations live in the Edit modal, so no binding can change from this list. ---- */
 
 function AgentCard({
   agent,
   stats,
   probe,
   onProbe,
-  onToggle,
-  onRemove,
-  knownRoles,
-  knownPersonas,
-  onSaveRoles,
-  onSavePersonas,
+  onEdit,
 }: {
   agent: AgentCfg;
   stats?: AgentStats;
   probe?: ProbeState;
   onProbe: () => void;
-  onToggle: () => void;
-  onRemove: () => void;
-  knownRoles: string[];
-  knownPersonas: string[];
-  onSaveRoles: (v: string[]) => void;
-  onSavePersonas: (v: string[]) => void;
+  onEdit: () => void;
 }) {
   const pstate = probe?.status || "idle";
   const dot =
@@ -310,43 +265,32 @@ function AgentCard({
   return (
     <Panel title={agent.name}>
       <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "flex-start" }}>
-        {/* left: configuration */}
+        {/* left: configuration (read-only) */}
         <div style={{ flex: "1 1 260px", minWidth: 240 }}>
-          <Field k="provider" v={agent.provider || "—"} />
-          <Field k="model" v={agent.model || "—"} />
-          <Field k="endpoint" v={agent.endpoint || "(cli / none)"} mono />
-          <div style={{ display: "flex", alignItems: "center", gap: 6, margin: "4px 0" }}>
-            <span style={{ color: "#888", fontSize: 13 }}>enabled</span>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, margin: "2px 0 4px" }}>
             <Badge
               label={agent.enabled ? "enabled" : "disabled"}
               variant={agent.enabled ? "success" : "neutral"}
             />
-            <button onClick={onToggle} style={btnSmall}>
-              {agent.enabled ? "disable" : "enable"}
-            </button>
           </div>
+          <Field k="provider" v={agent.provider || "—"} />
+          <Field k="model" v={agent.model || "—"} />
+          <Field k="endpoint" v={agent.endpoint || "(cli / none)"} mono />
           {typeof agent.cost_tier === "number" && (
             <Field k="cost tier" v={String(agent.cost_tier)} />
           )}
           {typeof agent.max_parallel === "number" && agent.max_parallel > 0 && (
             <Field k="max parallel" v={String(agent.max_parallel)} />
           )}
+          {typeof agent.max_turns === "number" && agent.max_turns >= 0 && (
+            <Field k="max turns" v={String(agent.max_turns)} />
+          )}
           {agent.context_window ? (
             <Field k="context" v={`${agent.context_window.toLocaleString()} tok`} />
           ) : null}
-          <ChipEditor
-            label="roles"
-            selected={agent.roles || []}
-            options={knownRoles}
-            onSave={onSaveRoles}
-          />
-          <ChipEditor
-            label="personas"
-            selected={agent.personas || []}
-            options={knownPersonas}
-            emptyHint="(none set = all)"
-            onSave={onSavePersonas}
-          />
+          <Field k="tools" v={agent.tools_enabled ? "enabled" : "disabled"} />
+          <StaticChips label="roles" values={agent.roles || []} />
+          <StaticChips label="personas" values={agent.personas || []} emptyHint="(none = all)" />
         </div>
 
         {/* middle: availability */}
@@ -413,13 +357,250 @@ function AgentCard({
 
       <div style={{ marginTop: 8, borderTop: "1px solid #eee", paddingTop: 8 }}>
         <button
-          onClick={onRemove}
-          style={{ ...btnSmall, color: "#c00", borderColor: "#e0a0a0" }}
+          onClick={onEdit}
+          style={{ ...btnSmall, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
         >
-          Remove delegate
+          Edit
         </button>
       </div>
     </Panel>
+  );
+}
+
+/* ---- per-agent Edit modal: edit ALL aspects; the one place binding changes are
+   made. Saves via a single surgical POST /api/agents/set. ---- */
+
+function AgentEditModal({
+  agent,
+  knownRoles,
+  knownPersonas,
+  onClose,
+  onSaved,
+  onStatus,
+}: {
+  agent: AgentCfg;
+  knownRoles: string[];
+  knownPersonas: string[];
+  onClose: () => void;
+  onSaved: () => void;
+  onStatus: (msg: string, ok: boolean) => void;
+}) {
+  const [provider, setProvider] = useState(agent.provider || "openai");
+  const [model, setModel] = useState(agent.model || "");
+  const [endpoint, setEndpoint] = useState(agent.endpoint || "");
+  const [costTier, setCostTier] = useState(String(agent.cost_tier ?? 0));
+  const [maxTurns, setMaxTurns] = useState(String(agent.max_turns ?? -1));
+  const [maxParallel, setMaxParallel] = useState(String(agent.max_parallel ?? 0));
+  const [contextWindow, setContextWindow] = useState(String(agent.context_window ?? 0));
+  const [tools, setTools] = useState(!!agent.tools_enabled);
+  const [enabled, setEnabled] = useState(!!agent.enabled);
+  const [roles, setRoles] = useState<string[]>(agent.roles || []);
+  const [personas, setPersonas] = useState<string[]>(agent.personas || []);
+  const [apiKey, setApiKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  const cliProvider = provider === "claude" || provider === "claude-code";
+
+  // Esc closes the modal.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const save = async () => {
+    setBusy(true);
+    setErr("");
+    // One surgical set carrying every editable field. The server patches only what
+    // is passed; roles empty resets to the default set, personas empty resets to "all".
+    const args = [
+      agent.name,
+      "--provider", provider,
+      "--model", model.trim(),
+      "--endpoint", endpoint.trim(),
+      "--cost-tier", costTier || "0",
+      "--max-turns", maxTurns || "-1",
+      "--max-parallel", maxParallel || "0",
+      "--context-window", contextWindow || "0",
+      "--tools", tools ? "on" : "off",
+      "--enabled", enabled ? "true" : "false",
+      "--roles", roles.join(","),
+      "--personas", personas.join(","),
+    ];
+    if (apiKey.trim()) args.push("--key", apiKey.trim());
+    try {
+      const res = await postArgs<{ error?: string }>("/api/agents/set", args);
+      if (res.error) setErr(res.error);
+      else {
+        onStatus(`${agent.name} saved`, true);
+        onSaved();
+        onClose();
+      }
+    } catch {
+      setErr("save failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!confirm(`Remove delegate “${agent.name}”? This edits agents.json.`)) return;
+    setBusy(true);
+    setErr("");
+    try {
+      const res = await postArgs<{ error?: string }>("/api/agents/remove", [agent.name]);
+      if (res.error) setErr(res.error);
+      else {
+        onStatus(`removed ${agent.name}`, true);
+        onSaved();
+        onClose();
+      }
+    } catch {
+      setErr("remove failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 30,
+        background: "rgba(0,0,0,0.35)",
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        padding: 24,
+        overflow: "auto",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "#fff",
+          borderRadius: 8,
+          maxWidth: 640,
+          width: "100%",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.25)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "12px 16px",
+            borderBottom: "1px solid #eee",
+            position: "sticky",
+            top: 0,
+            background: "#fff",
+            borderRadius: "8px 8px 0 0",
+          }}
+        >
+          <strong style={{ fontSize: 15 }}>Edit delegate</strong>
+          <span style={{ fontSize: 13, color: "#667", fontFamily: "monospace" }}>{agent.name}</span>
+          <button onClick={onClose} style={{ ...btn, marginLeft: "auto" }}>
+            Close
+          </button>
+        </div>
+
+        <div style={{ padding: 16 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+            <L label="provider">
+              <select value={provider} onChange={(e) => setProvider(e.target.value)} style={inp} disabled={busy}>
+                {(PROVIDERS.includes(provider) ? PROVIDERS : [provider, ...PROVIDERS]).map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </L>
+            <L label="model">
+              <input value={model} onChange={(e) => setModel(e.target.value)} style={inp} disabled={busy} />
+            </L>
+            <L label={cliProvider ? "endpoint (optional for CLI)" : "endpoint"}>
+              <input
+                value={endpoint}
+                onChange={(e) => setEndpoint(e.target.value)}
+                style={inp}
+                placeholder="https://host:port/v1"
+                disabled={busy}
+              />
+            </L>
+            <L label="cost tier">
+              <input type="number" value={costTier} onChange={(e) => setCostTier(e.target.value)} style={inp} min={0} disabled={busy} />
+            </L>
+            <L label="max turns (-1 = default)">
+              <input type="number" value={maxTurns} onChange={(e) => setMaxTurns(e.target.value)} style={inp} disabled={busy} />
+            </L>
+            <L label="max parallel">
+              <input type="number" value={maxParallel} onChange={(e) => setMaxParallel(e.target.value)} style={inp} min={0} disabled={busy} />
+            </L>
+            <L label="context window (tok, 0 = auto)">
+              <input type="number" value={contextWindow} onChange={(e) => setContextWindow(e.target.value)} style={inp} min={0} disabled={busy} />
+            </L>
+            <L label="API key (blank = keep current)">
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                style={inp}
+                placeholder="sk-…  or  $ENV_VAR"
+                disabled={busy}
+              />
+            </L>
+          </div>
+
+          <div style={{ display: "flex", gap: 20, marginTop: 10 }}>
+            <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}>
+              <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} disabled={busy} />
+              enabled
+            </label>
+            <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}>
+              <input type="checkbox" checked={tools} onChange={(e) => setTools(e.target.checked)} disabled={busy} />
+              tools enabled
+            </label>
+          </div>
+
+          <ChipSelect label="roles" selected={roles} options={knownRoles} onChange={setRoles} />
+          <ChipSelect
+            label="personas"
+            selected={personas}
+            options={knownPersonas}
+            onChange={setPersonas}
+            emptyHint="(none set = all)"
+          />
+
+          {err && <div style={{ fontSize: 12, color: "#c00", marginTop: 8 }}>{err}</div>}
+
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 14 }}>
+            <button
+              onClick={() => void save()}
+              disabled={busy}
+              style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+            >
+              {busy ? "Saving…" : "Save"}
+            </button>
+            <button onClick={onClose} disabled={busy} style={btn}>
+              Cancel
+            </button>
+            <button
+              onClick={() => void remove()}
+              disabled={busy}
+              style={{ ...btn, marginLeft: "auto", background: "#fff5f5", color: "#c00", borderColor: "#e6b3b3" }}
+            >
+              Remove delegate
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -536,47 +717,40 @@ function AddDelegate({ onDone }: { onDone: (msg: string, ok: boolean) => void })
 
 /* ---- small presentational helpers ---- */
 
-// Editable multi-select of tokens (roles or personas) as toggleable chips. The
-// "all" wildcard is always offered; free selection from the known vocabulary
-// keeps agents matched to what personas declare. Save appears only when dirty.
-function ChipEditor({
+// Editable multi-select of tokens (roles or personas) as toggleable chips, fully
+// controlled by the parent (the Edit modal saves the whole set on Save). The "all"
+// wildcard is always offered; free selection keeps agents matched to what personas
+// declare.
+function ChipSelect({
   label,
   selected,
   options,
+  onChange,
   emptyHint,
-  onSave,
 }: {
   label: string;
   selected: string[];
   options: string[];
+  onChange: (v: string[]) => void;
   emptyHint?: string;
-  onSave: (v: string[]) => void;
 }) {
-  const [sel, setSel] = useState<string[]>(selected);
-  useEffect(() => setSel(selected), [selected.join(",")]); // resync after a save/refresh
   const all = useMemo(() => {
     const s = new Set<string>(["all", ...options, ...selected]);
     return Array.from(s);
   }, [options.join(","), selected.join(",")]);
-  const dirty = sel.slice().sort().join(",") !== selected.slice().sort().join(",");
   const toggle = (r: string) =>
-    setSel((cur) => (cur.includes(r) ? cur.filter((x) => x !== r) : [...cur, r]));
+    onChange(selected.includes(r) ? selected.filter((x) => x !== r) : [...selected, r]);
   return (
-    <div style={{ margin: "6px 0" }}>
+    <div style={{ margin: "10px 0 2px" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
         <span style={{ color: "#888", fontSize: 12 }}>{label}</span>
-        {dirty && (
-          <button onClick={() => onSave(sel)} style={{ ...btnSmall, padding: "1px 8px" }}>
-            save
-          </button>
-        )}
-        {sel.length === 0 && emptyHint && (
+        {selected.length === 0 && emptyHint && (
           <span style={{ color: "#aaa", fontSize: 11 }}>{emptyHint}</span>
         )}
       </div>
       <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 3 }}>
         {all.map((r) => {
-          const on = sel.includes(r);
+          const on = selected.includes(r);
           return (
             <button
               key={r}
@@ -593,6 +767,36 @@ function ChipEditor({
             </button>
           );
         })}
+      </div>
+    </div>
+  );
+}
+
+// Read-only chips for the base card (roles/personas shown, not editable here).
+function StaticChips({ label, values, emptyHint }: { label: string; values: string[]; emptyHint?: string }) {
+  return (
+    <div style={{ margin: "6px 0" }}>
+      <span style={{ color: "#888", fontSize: 12 }}>{label}</span>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 3 }}>
+        {values.length === 0 ? (
+          <span style={{ color: "#aaa", fontSize: 11 }}>{emptyHint || "—"}</span>
+        ) : (
+          values.map((r) => (
+            <span
+              key={r}
+              style={{
+                fontSize: 12,
+                padding: "1px 7px",
+                borderRadius: 4,
+                border: "1px solid #dfe6ef",
+                background: "#f4f7fb",
+                color: "#556",
+              }}
+            >
+              {r}
+            </span>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -574,6 +574,7 @@ static const struct
     {"agent.probe", "POST", "/v1/agent/probe"},
     {"agent.remove", "POST", "/v1/agent/remove"},
     {"agent.roles", "POST", "/v1/agent/roles"},
+    {"agent.set", "POST", "/v1/agent/set"},
     {"agent.setup", "POST", "/v1/agent/setup"},
     {"agent.setup_poll", "POST", "/v1/agent/setup_poll"},
     {"agent.stats", "GET", "/v1/agent/stats"},

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -453,6 +453,7 @@ int handle_agent_remove(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_enable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_roles(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_personas(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_disable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_probe(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1337,6 +1337,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"agent.enable", handle_agent_enable},
     {"agent.roles", handle_agent_roles},
     {"agent.personas", handle_agent_personas},
+    {"agent.set", handle_agent_set},
     {"agent.disable", handle_agent_disable},
     {"agent.probe", handle_agent_probe},
     {"agent.stats", handle_agent_stats},

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -1026,6 +1026,110 @@ int handle_agent_personas(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, resp);
 }
 
+/* agent.set — surgically patch ONLY the fields the caller passed on an existing
+ * agent, preserving everything else (unlike agent.add, which resets the whole
+ * record). Backs the Web GUI's per-agent Edit modal. Args are CLI-style:
+ *   set <name> [--model M] [--endpoint E] [--provider P] [--cost-tier N]
+ *       [--max-turns N] [--max-parallel N] [--context-window N] [--tools on|off]
+ *       [--roles csv] [--personas csv] [--enabled true|false] [--key K]
+ * A flag that is absent leaves that field untouched. */
+int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   char *argv[SERVER_AGENT_MAX_ARGS];
+   int argc = server_agent_args(req, argv, (int)(sizeof(argv) / sizeof(argv[0])));
+   if (argc < 1 || !argv[0][0])
+      return server_send_error(conn, "agent.set requires name", NULL);
+   /* All --flags carry a value (no bool flags), so each is present iff opt_get
+    * returns non-NULL — that presence check is what makes the patch surgical. */
+   static const char *bool_flags[] = {NULL};
+   opt_parsed_t opts;
+   opt_parse(argc - 1, argv + 1, bool_flags, &opts);
+
+   agent_config_t cfg;
+   if (agent_load_config(&cfg) != 0)
+      return server_send_error(conn, "agents.json not found or invalid", NULL);
+   agent_t *ag = agent_find(&cfg, argv[0]);
+   if (!ag)
+      return server_send_error(conn, "agent not found", NULL);
+
+   char old_model[MAX_MODEL_LEN];
+   snprintf(old_model, sizeof(old_model), "%s", ag->model);
+
+   const char *v;
+   if ((v = opt_get(&opts, "model")) && v[0])
+      snprintf(ag->model, sizeof(ag->model), "%s", v);
+   if ((v = opt_get(&opts, "endpoint")) != NULL)
+      snprintf(ag->endpoint, sizeof(ag->endpoint), "%s", v);
+   if ((v = opt_get(&opts, "provider")) && v[0])
+      snprintf(ag->provider, sizeof(ag->provider), "%s", v);
+   if ((v = opt_get(&opts, "cost-tier")) != NULL)
+      ag->cost_tier = atoi(v);
+   if ((v = opt_get(&opts, "max-turns")) != NULL)
+      ag->max_turns = atoi(v);
+   if ((v = opt_get(&opts, "max-parallel")) != NULL)
+      ag->max_parallel = atoi(v);
+   if ((v = opt_get(&opts, "context-window")) != NULL || (v = opt_get(&opts, "ctx")) != NULL)
+      ag->middleware.context_window = atoi(v);
+   if ((v = opt_get(&opts, "tools")) != NULL)
+   {
+      ag->tools_enabled = (strcmp(v, "on") == 0 || strcmp(v, "true") == 0 || strcmp(v, "1") == 0);
+      ag->inject_respond_tool = ag->tools_enabled ? 1 : 0;
+   }
+   if ((v = opt_get(&opts, "enabled")) != NULL)
+      ag->enabled = (strcmp(v, "true") == 0 || strcmp(v, "1") == 0 || strcmp(v, "on") == 0);
+   if ((v = opt_get(&opts, "roles")) != NULL)
+      server_agent_set_roles_csv(
+          ag,
+          v[0] ? v : "code,review,explain,refactor,draft,execute,summarize,format,reason,search");
+   if ((v = opt_get(&opts, "personas")) != NULL)
+      server_agent_set_personas_csv(ag, v[0] ? v : "all");
+
+   /* An optional re-key vaults the secret exactly like agent.add (never persisted
+    * to agents.json), gated by the same server-write capability check. */
+   const char *key = opt_get(&opts, "key");
+   if (key && key[0])
+   {
+      if (key[0] == '$')
+      {
+         snprintf(ag->api_key, sizeof(ag->api_key), "%s", key);
+         snprintf(ag->api_key_disk, sizeof(ag->api_key_disk), "%s", key);
+      }
+      else
+      {
+         const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
+         attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
+         if (!principal && !vault_capability_server_write_allowed(transport, NULL))
+            return server_send_error(
+                conn,
+                "vault: `agent set --key` over a plaintext connection cannot store a credential; "
+                "use a native-TLS (https) or attested local/webchat connection",
+                NULL);
+         vault_status_t vst =
+             principal
+                 ? vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key, (long)time(NULL))
+                 : vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
+         if (vst != VAULT_OK)
+            return server_send_error(conn,
+                                     vst == VAULT_ERR_LOCKED
+                                         ? "vault locked: run `aimee vault unlock` before re-keying"
+                                         : "could not store credential in the vault",
+                                     NULL);
+      }
+   }
+
+   if (agent_save_config(&cfg) != 0)
+      return server_send_error(conn, "could not save agents.json", NULL);
+   if (ag->max_parallel > 0)
+      (void)server_agent_set_model_concurrency(ag->model, ag->max_parallel);
+   if (old_model[0] && strcmp(old_model, ag->model) != 0)
+      (void)server_agent_clear_model_concurrency_if_unused(&cfg, old_model);
+
+   cJSON *resp = server_agent_to_json(ag);
+   cJSON_AddStringToObject(resp, "status", "ok");
+   return server_send_ok(conn, resp);
+}
+
 int handle_agent_probe(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -2065,6 +2065,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/agent/enable", NULL, RM_EXACT, "agent.enable", 0, rh_dispatch_op},
     {"POST", "/v1/agent/roles", NULL, RM_EXACT, "agent.roles", 0, rh_dispatch_op},
     {"POST", "/v1/agent/personas", NULL, RM_EXACT, "agent.personas", 0, rh_dispatch_op},
+    {"POST", "/v1/agent/set", NULL, RM_EXACT, "agent.set", 0, rh_dispatch_op},
     {"POST", "/v1/agent/disable", NULL, RM_EXACT, "agent.disable", 0, rh_dispatch_op},
     {"POST", "/v1/agent/probe", NULL, RM_EXACT, "agent.probe", 0, rh_dispatch_op},
     {"GET", "/v1/agent/stats", NULL, RM_EXACT, "agent.stats", 0, rh_dispatch_op},

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1063,6 +1063,10 @@ int handle_agent_personas(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "agent.personas");
 }
+int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "agent.set");
+}
 int handle_agent_disable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "agent.disable");

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -92,6 +92,7 @@ var methodRoutes = map[string]methodRoute{
 	"agent.enable":             {http.MethodPost, "/v1/agent/enable"},
 	"agent.disable":            {http.MethodPost, "/v1/agent/disable"},
 	"agent.probe":              {http.MethodPost, "/v1/agent/probe"},
+	"agent.set":                {http.MethodPost, "/v1/agent/set"},
 	"collab_rules.list":        {http.MethodGet, "/v1/collab_rules"},
 	"collab_rules.list_active": {http.MethodGet, "/v1/collab_rules/active"},
 	// Mutations + arg-bearing calls (POST, body carries the args; the server

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -226,6 +226,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/agents/probe", s.requireAuth(s.agentOpHandler("agent.probe")))
 	mux.HandleFunc("POST /api/agents/roles", s.requireAuth(s.agentOpHandler("agent.roles")))
 	mux.HandleFunc("POST /api/agents/personas", s.requireAuth(s.agentOpHandler("agent.personas")))
+	mux.HandleFunc("POST /api/agents/set", s.requireAuth(s.agentOpHandler("agent.set")))
 	// Role registry (the shared vocabulary matched between personas and agents).
 	mux.HandleFunc("/api/roles", s.requireAuth(s.handleRoles))
 	mux.HandleFunc("/api/roles/", s.requireAuth(s.handleRoleItem))


### PR DESCRIPTION
## What

Fixes two problems on the Agents ("delegates") page:
1. **Couldn't edit all aspects** — the base list inline-edited only roles/personas/enable/remove; model, endpoint, provider, cost_tier, max_turns, max_parallel, context_window, tools were display-only, and the backend had no general edit op.
2. **Binding changes from the base screen** — roles/personas (the routing binding) plus enable/disable/remove mutated inline with one click.

## Backend — new surgical `agent.set` op
Patches **only the fields passed**, preserving the rest (unlike `agent.add`, which `memset`s the whole record).
- `handle_agent_set` (`server_agent.c`) + prototype + dispatch registration; reuses `server_agent_set_roles_csv`/`_personas_csv` and the `agent.add` vault-key path.
- `POST /v1/agent/set` route + `/agent/set` OpenAPI entry + regenerated `cli_v1_routes`.
- Inherits `CAP_DELEGATE` via the `agent.*` capability wildcard → **local-only over plaintext TCP, parity with `agent.add`**.
- Proxied through aimee-webchat (`/api/agents/set` → `agent.set`).
- `test_server_dispatch`: stub the new handler alongside the other agent stubs.

## Frontend (`Agents.tsx`)
- **Base cards read-only** — config + stats + Probe + an **Edit** button. No roles/personas/enable/remove on the list, so no binding changes from a stray click. "+ Add delegate" stays.
- **Per-agent Edit modal** edits every aspect (provider, model, endpoint, cost_tier, max_turns, max_parallel, context_window, tools, enabled, roles, personas, optional re-key) and saves via one atomic `agent.set`. Remove lives in the modal behind a confirm; Esc/Cancel/overlay closes.

## Testing
- Builds clean: aimee-server (`-Werror`), frontend (tsc + vite), webchat (`go build`).
- Gates: line-check (2499/2500), server-api-conformance, cli-v1-routes, v1-method-coverage, clang-format.
- Unit tests: `server_http`, `server_dispatch`, `agent`.
- e2e over UDS: `agent.set` changing model/cost_tier/roles left personas/endpoint/provider/enabled **preserved**; enabled/tools/endpoint/max_turns/max_parallel/context_window all patch correctly; `set` on a missing agent errors cleanly.