### PR TITLE
Release testing → main (v0.2.169)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -2104,6 +2104,11 @@ paths:
       summary: Set the personas an agent may be dispatched as ("all" = every persona)
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Agent personas updated, content: { application/json: { schema: { type: object } } } } }
+  /agent/set:
+    post:
+      summary: Surgically patch only the provided fields of an existing agent (model, endpoint, provider, cost_tier, max_turns, max_parallel, context_window, tools, roles, personas, enabled, key)
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: Updated agent record, content: { application/json: { schema: { type: object } } } } }
   /agent/probe:
     post:
       summary: Probe an agent/provider

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -459,6 +459,56 @@ paths:
           content:
             application/json:
               schema: { type: object }
+  /workflow/repo/tree:
+    get:
+      summary: List directories + .md files under the server's local project checkout (composer proposal browser), path-confined
+      parameters:
+        - name: path
+          in: query
+          required: false
+          schema: { type: string }
+          description: Relative path under the project root ("" = root); rejects .. / symlink escape
+      responses:
+        "200":
+          description: "{path, entries:[{name,type:dir|file}]}"
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Path escapes the project root
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Not a directory / not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/repo/file:
+    get:
+      summary: Read one .md file under the confined project root (composer proposal browser)
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+          description: Relative .md path under the project root; rejects .. / symlink escape
+      responses:
+        "200":
+          description: "{path, content, truncated}"
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Path escapes the project root or is not a .md file
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: File not found / not a regular file
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /workflow/items/{id}/events:
     get:
       summary: The item's lifecycle timeline (proposal history), owner-only, paginated by event id
@@ -528,6 +578,86 @@ paths:
               schema: { type: object }
         "404":
           description: Work item not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+    delete:
+      summary: Delete a run — auto-abandons an active run first, then removes its rows and proposal file (owner or operator)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: "{id, deleted:true}"
+          content:
+            application/json:
+              schema: { type: object }
+        "403":
+          description: Not the caller's work item
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Work item not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/items/{id}/pause:
+    post:
+      summary: Pause an active run (operator_paused) so the scheduler stops advancing it (owner or operator)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Updated work-item run-state
+          content:
+            application/json:
+              schema: { type: object }
+        "409":
+          description: Run already finished or already paused
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/items/{id}/resume:
+    post:
+      summary: Resume a paused run and wake the scheduler; refuses a run parked at a human gate (owner or operator)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Updated work-item run-state
+          content:
+            application/json:
+              schema: { type: object }
+        "409":
+          description: Run not paused, already finished, or parked at a human gate (use Approve/Reject)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/items/{id}/stop:
+    post:
+      summary: Stop a run (abandon it); the scheduler reclaims its worktree (owner or operator)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Updated work-item run-state
+          content:
+            application/json:
+              schema: { type: object }
+        "409":
+          description: Run already finished
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/benchmarks/coding/SUPERVISED_SWEBENCH.md
+++ b/benchmarks/coding/SUPERVISED_SWEBENCH.md
@@ -106,3 +106,65 @@ AIMEE_BENCH_FAKE_AGENT=1 AIMEE_BENCH_FAKE_GRADER=1 \
   python3 benchmarks/coding/bench_swebench_supervised.py --arms A,C --output /tmp/fake.json
 python3 -m unittest benchmarks.tests.test_bench_swebench_supervised
 ```
+
+---
+
+# Agentic variant (issue #987) — the true, tool-using, Reddit-parity claim
+
+The single-shot benchmark above delegates one diff and reviews it; it is **explicitly barred**
+from being posted as a Reddit head-to-head. The *agentic* variant makes both arms tool-using
+across turns and is the only one permitted to carry the public claim. Design + rulings:
+`docs/proposals/pending/agentic-supervised-swebench.md`. Built slice-by-slice, each
+roundtable-reviewed; every reproducibility-critical function is pure and unit-tested, with the
+live parts (server transport, per-worker container, official grading) as marked stubs.
+
+## Module map
+
+| module | slice | role |
+|---|---|---|
+| `swebench_transport_verify.py` | S0 | 5 token-attribution assertions (primary = `delegation_id` EMPTY; no cross-bill; cache split; primary tools billed) — the blocking transport gate |
+| `swebench_agentic_harness.py` | S1 | per-worker workspace provision at `base_commit`, per-worker OS-resource allocator, canonical secret-redacted patch (`git add -A` → `diff --cached`), loop bounds |
+| `swebench_arm_runner.py` | S2 | arm A runner + shared measurement core: **uncached** primary-token headline, two wall-clocks (total vs work) |
+| `swebench_supervision.py` | S3 | arm C honesty core: hard-capped leak-guarded digests, **deterministic** best-of-N, gated escalation, context fold, tool allowlist |
+| `supervised_report_panels.py` | S4 | BCa CI, Pareto, selection-skill (oracle vs actual), escalation exclusion, context drift, two-wall-clock, arm-parity |
+| `swebench_suite.py` | S5 | run-plan matrix, CT-101 grader lease, grader-retry + flip-detection, prediction dedup |
+| `swebench_claim_gate.py` | S6 | the fail-closed public-claim gate |
+
+## The fail-closed claim gate
+
+The public line ("beats Reddit's −75.5% at no wall-clock penalty") is emitted by
+`swebench_claim_gate.evaluate_claim_gate(b1, b2, independent_review=…)` **only if ALL** hold,
+under the official grader, on **both** Benchmark 1 (Reddit-10) **and** Benchmark 2 (held-out):
+
+1. **Token** — BCa-95 CI lower-bound of the primary-token reduction `> 0`, anchored on **N=1**.
+2. **Wall** — **p95** A→C wall-clock ratio CI upper-bound `≤ 1.0` (vs aimee's own arm-A time,
+   not Reddit's cross-harness minutes).
+3. **Resolution floor** — `resolved_C/total ≥ max(0.7 × resolved_A/total, 0.25)`.
+4. **K ≥ 10** repeats on Benchmark 1.
+5. **Not escalation-dominated** — the arm-C headline set's escalation-excluded fraction `≤ 0.40`.
+6. **Independent reviewer** sign-off (not the harness/worker author).
+
+The report is **published regardless** of the outcome; only the claim *line* is gated. When
+withheld, the summary still reports the honest number, e.g.
+`-78% primary tokens at 1.05x p95 wall-clock — CLAIM WITHHELD (B1[wall] …)`.
+
+## CI fast check (no live aimee, no Docker)
+
+```bash
+python3 -m unittest \
+  benchmarks.tests.test_swebench_transport_verify \
+  benchmarks.tests.test_swebench_agentic_harness \
+  benchmarks.tests.test_swebench_arm_runner \
+  benchmarks.tests.test_swebench_supervision \
+  benchmarks.tests.test_supervised_report_panels \
+  benchmarks.tests.test_swebench_suite \
+  benchmarks.tests.test_swebench_claim_gate
+```
+
+## Live run (needs the .254 fleet + CT 101 real docker)
+
+The live transport, per-worker container, and official grading are marked
+`NotImplementedError` stubs that print the exact wiring step. Wire them against the `.254`
+fleet (`run_agentic_loop`, `run_arm_a`, `run_arm_c_supervised`, `run_suite`) and grade on CT 101
+per the recipe above; feed the records through `supervised_report` + `supervised_report_panels`,
+then `swebench_claim_gate`.

--- a/benchmarks/coding/supervised_report_panels.py
+++ b/benchmarks/coding/supervised_report_panels.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""S4 — report panels for the agentic supervised SWE-bench benchmark (#987).
+
+The proposal + S1/S3 roundtables specified report surfaces the base `supervised_report` does not
+yet carry. These are the pure, composable aggregators that produce them; they compose onto a
+report dict without touching the already-tested base module. All deterministic (seeded), so a
+rerun on the same data yields identical output.
+
+Panels (each maps to a ratified ruling):
+  - bca_ci ....................... BCa-95 bootstrap CI for the token-reduction headline (proposal
+                                   S6 asked for BCa, not plain percentile).
+  - pareto_panel ................. dominance across (arm x N x reducers) configs over
+                                   (primary tokens, wall p95, resolution) — the single most
+                                   informative view for the claim.
+  - failure_mode_breakdown ....... per-arm counts of worker-dropout / wrong-diff / mis-selection
+                                   / grader-flake / environment, so a low resolution is
+                                   attributable to a cause, not left ambiguous.
+  - selection_skill .............. oracle-best-of-N vs actual-best-of-N + skill ratio (S3 Q3):
+                                   separates supervisor selection skill from worker diversity.
+  - escalation_split ............. partitions the headline from ESCALATION_DOMINATED runs
+                                   (>40% escalation tokens), which are excluded from the claim.
+  - context_size_distribution .... p50/p95/max of the supervisor context + the per-turn token
+                                   curve — context drift is where dishonest savings hide (S3 Q4).
+  - wall_two_clock ............... total (queue+work) vs work-only p50/p95/p99 (proposal Q5).
+  - check_arm_parity ............. the S1/S3 Q6 invariants: on a trivial input arm A and arm C
+                                   produce the same patch and token accounting differs in the
+                                   EXPECTED direction (C primary << A total; no escalation).
+"""
+from __future__ import annotations
+
+import math
+import random
+from typing import Any
+
+
+# ------------------------------------------------------------ percentiles ------
+def _pct(sorted_vals: list[float], q: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    i = min(len(sorted_vals) - 1, int(round(q * (len(sorted_vals) - 1))))
+    return sorted_vals[i]
+
+
+def dist(values: list[float]) -> dict[str, Any]:
+    """p50/p95/p99/max/mean/n over a list (empty -> zeros)."""
+    if not values:
+        return {"n": 0}
+    s = sorted(values)
+    return {"n": len(s), "p50": round(_pct(s, 0.50), 3), "p95": round(_pct(s, 0.95), 3),
+            "p99": round(_pct(s, 0.99), 3), "max": round(s[-1], 3),
+            "mean": round(sum(s) / len(s), 3)}
+
+
+# ------------------------------------------------------------ BCa CI -----------
+def _norm_cdf(z: float) -> float:
+    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))
+
+
+def _norm_ppf(p: float) -> float:
+    """Inverse normal CDF (Acklam's rational approximation). Good to ~1e-9."""
+    if p <= 0.0:
+        return -math.inf
+    if p >= 1.0:
+        return math.inf
+    a = [-3.969683028665376e+01, 2.209460984245205e+02, -2.759285104469687e+02,
+         1.383577518672690e+02, -3.066479806614716e+01, 2.506628277459239e+00]
+    b = [-5.447609879822406e+01, 1.615858368580409e+02, -1.556989798598866e+02,
+         6.680131188771972e+01, -1.328068155288572e+01]
+    c = [-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e+00,
+         -2.549732539343734e+00, 4.374664141464968e+00, 2.938163982698783e+00]
+    d = [7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e+00,
+         3.754408661907416e+00]
+    plow, phigh = 0.02425, 1 - 0.02425
+    if p < plow:
+        q = math.sqrt(-2 * math.log(p))
+        return (((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5]) / ((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1)
+    if p > phigh:
+        q = math.sqrt(-2 * math.log(1 - p))
+        return -(((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5]) / ((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1)
+    q = p - 0.5
+    r = q * q
+    return (((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r+a[5])*q / (((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r+1)
+
+
+def bca_ci(values: list[float], iters: int = 2000, alpha: float = 0.05,
+           seed: int = 42) -> tuple[float, float]:
+    """Bias-corrected accelerated (BCa) bootstrap CI for the mean. Deterministic (seeded).
+    Falls back to percentile bounds when acceleration is degenerate (all values equal)."""
+    if not values:
+        return (0.0, 0.0)
+    if len(values) == 1:
+        return (values[0], values[0])
+    n = len(values)
+    theta = sum(values) / n
+    rng = random.Random(seed)
+    boots = sorted(sum(values[rng.randrange(n)] for _ in range(n)) / n for _ in range(iters))
+    # bias-correction z0
+    n_less = sum(1 for b in boots if b < theta)
+    prop = n_less / iters
+    if prop <= 0 or prop >= 1:
+        return (round(boots[int((alpha / 2) * iters)], 3),
+                round(boots[int((1 - alpha / 2) * iters)], 3))
+    z0 = _norm_ppf(prop)
+    # acceleration via jackknife
+    jack = [(sum(values) - values[i]) / (n - 1) for i in range(n)]
+    jbar = sum(jack) / n
+    num = sum((jbar - j) ** 3 for j in jack)
+    den = 6.0 * (sum((jbar - j) ** 2 for j in jack) ** 1.5)
+    a = num / den if den else 0.0
+    zl, zh = _norm_ppf(alpha / 2), _norm_ppf(1 - alpha / 2)
+
+    def _adj(z):
+        return _norm_cdf(z0 + (z0 + z) / (1 - a * (z0 + z)))
+
+    lo_q, hi_q = _adj(zl), _adj(zh)
+    lo = boots[min(iters - 1, max(0, int(lo_q * iters)))]
+    hi = boots[min(iters - 1, max(0, int(hi_q * iters)))]
+    return (round(lo, 3), round(hi, 3))
+
+
+# ------------------------------------------------------------ pareto -----------
+def pareto_panel(configs: list[dict[str, Any]]) -> dict[str, Any]:
+    """configs: dicts with keys {name, primary_tokens, wall_p95, resolve_rate}. Marks each as
+    Pareto-optimal or dominated (minimize tokens, minimize wall, MAXIMIZE resolve). Returns the
+    annotated list + the optimal frontier names."""
+    def dominates(x, y):
+        better_or_eq = (x["primary_tokens"] <= y["primary_tokens"] and
+                        x["wall_p95"] <= y["wall_p95"] and
+                        x["resolve_rate"] >= y["resolve_rate"])
+        strictly = (x["primary_tokens"] < y["primary_tokens"] or
+                    x["wall_p95"] < y["wall_p95"] or
+                    x["resolve_rate"] > y["resolve_rate"])
+        return better_or_eq and strictly
+
+    annotated = []
+    for c in configs:
+        dominated_by = [o["name"] for o in configs if o is not c and dominates(o, c)]
+        annotated.append({**c, "pareto_optimal": not dominated_by,
+                          "dominated_by": dominated_by})
+    frontier = [c["name"] for c in annotated if c["pareto_optimal"]]
+    return {"configs": annotated, "frontier": frontier}
+
+
+# ------------------------------------------------------------ failure modes ----
+FAILURE_MODES = ("worker_dropout", "wrong_diff", "mis_selection", "grader_flake",
+                 "environment", "ok")
+
+
+def failure_mode_breakdown(records: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
+    """Per-arm counts of each failure mode (records carry an optional 'failure_mode' field;
+    a resolved record with no mode counts as 'ok')."""
+    out: dict[str, dict[str, int]] = {}
+    for r in records:
+        if r.get("invalid"):
+            continue
+        arm = r.get("arm", "?")
+        mode = r.get("failure_mode") or ("ok" if r.get("resolved") else "wrong_diff")
+        out.setdefault(arm, {m: 0 for m in FAILURE_MODES})
+        out[arm][mode] = out[arm].get(mode, 0) + 1
+    return out
+
+
+# ------------------------------------------------------------ selection skill --
+def selection_skill(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Oracle-best-of-N vs actual-best-of-N over arm-C records that carry the decomposition.
+    A record supplies 'oracle_resolved' (any candidate passes the grader) and 'actual_resolved'
+    (the SELECTED patch passes). skill_ratio = actual_rate / oracle_rate."""
+    rel = [r for r in records if r.get("arm") == "C" and not r.get("invalid")
+           and "oracle_resolved" in r and "actual_resolved" in r]
+    n = len(rel)
+    if not n:
+        return {"n": 0}
+    oracle = sum(1 for r in rel if r["oracle_resolved"])
+    actual = sum(1 for r in rel if r["actual_resolved"])
+    orate, arate = oracle / n, actual / n
+    return {"n": n, "oracle_pass_rate": round(orate, 4), "actual_pass_rate": round(arate, 4),
+            "selection_skill_ratio": round(arate / orate, 4) if orate else None,
+            "recoverable_gap": oracle - actual}
+
+
+# ------------------------------------------------------------ escalation split -
+def escalation_split(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Partition arm-C records into the headline set vs ESCALATION_DOMINATED (>40% escalation
+    tokens). The headline claim is computed over the non-dominated set only."""
+    c = [r for r in records if r.get("arm") == "C" and not r.get("invalid")]
+    dominated = [r["instance_id"] for r in c if r.get("escalation_dominated")]
+    headline = [r["instance_id"] for r in c if not r.get("escalation_dominated")]
+    return {"headline_n": len(headline), "escalation_dominated_n": len(dominated),
+            "escalation_dominated": dominated,
+            "excluded_frac": round(len(dominated) / len(c), 4) if c else 0.0}
+
+
+# ------------------------------------------------------------ context drift ----
+def context_size_distribution(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Distribution of the supervisor's peak context size across instances + the aggregate
+    per-turn token curve (records carry 'primary_context_tokens' and 'primary_tokens_by_turn')."""
+    peaks = [r["primary_context_tokens"] for r in records
+             if r.get("arm") == "C" and r.get("primary_context_tokens") is not None]
+    curves = [r["primary_tokens_by_turn"] for r in records
+              if r.get("arm") == "C" and r.get("primary_tokens_by_turn")]
+    max_turns = max((len(c) for c in curves), default=0)
+    by_turn = []
+    for t in range(max_turns):
+        vals = [c[t] for c in curves if t < len(c)]
+        by_turn.append(round(sum(vals) / len(vals), 1) if vals else 0.0)
+    return {"peak_context": dist(peaks), "mean_tokens_by_turn": by_turn}
+
+
+# ------------------------------------------------------------ two wall clocks --
+def wall_two_clock(records: list[dict[str, Any]], arm: str) -> dict[str, Any]:
+    """Total (queue+work) vs work-only wall-clock distributions for an arm (proposal Q5).
+    The claim gate reads the TOTAL p95; work-only is reported alongside for honesty."""
+    rel = [r for r in records if r.get("arm") == arm and not r.get("invalid")]
+    total = [float(r["wall_s"]) for r in rel if r.get("wall_s") is not None]
+    work = [float(r["wall_work_s"]) for r in rel if r.get("wall_work_s") is not None]
+    return {"arm": arm, "total": dist(total), "work": dist(work)}
+
+
+# ------------------------------------------------------------ arm parity -------
+def check_arm_parity(rec_a: dict[str, Any], rec_c: dict[str, Any],
+                     *, token_ratio_floor: int = 10) -> dict[str, Any]:
+    """S1/S3 Q6: on a trivial deterministic input, assert arm A and arm C are consistent.
+    Returns each invariant's pass/fail so a CI test can assert them all. A transport difference
+    must never masquerade as an algorithmic one."""
+    a_total = int(rec_a.get("supervisor_input_tokens", 0)) + int(rec_a.get("supervisor_output_tokens", 0)) \
+        + int(rec_a.get("worker_input_tokens", 0)) + int(rec_a.get("worker_output_tokens", 0))
+    c_primary = int(rec_c.get("supervisor_input_tokens", 0)) + int(rec_c.get("supervisor_output_tokens", 0))
+    same_patch = rec_a.get("patch_fingerprint") == rec_c.get("patch_fingerprint")
+    same_resolution = rec_a.get("resolved") == rec_c.get("resolved")
+    # C's primary spend should be an order of magnitude below A's total on a trivial task.
+    cheap = c_primary * token_ratio_floor <= a_total if a_total else c_primary == 0
+    no_escalation = int(rec_c.get("escalations", 0)) == 0
+    inv = {"same_patch": same_patch, "same_resolution": same_resolution,
+           "c_primary_much_cheaper": cheap, "no_escalation_on_trivial": no_escalation}
+    inv["all_pass"] = all(inv.values())
+    return inv
+
+
+# ------------------------------------------------------------ compose ----------
+def augment_report(report: dict[str, Any], records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Attach the S4 panels to a base report dict (from supervised_report.build_report)."""
+    report = dict(report)
+    report["failure_modes"] = failure_mode_breakdown(records)
+    report["selection_skill"] = selection_skill(records)
+    report["escalation"] = escalation_split(records)
+    report["context_drift"] = context_size_distribution(records)
+    report["wall_two_clock"] = {a: wall_two_clock(records, a)
+                                for a in sorted({r.get("arm") for r in records if r.get("arm")})}
+    return report

--- a/benchmarks/coding/swebench_agentic_harness.py
+++ b/benchmarks/coding/swebench_agentic_harness.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""S1 — per-worker agentic harness for the agentic supervised SWE-bench benchmark (#987).
+
+Provisions an isolated, editable repo workspace at a SWE-bench instance's `base_commit`,
+runs a BOUNDED agentic loop (explore/edit/[test]/verify) in it, and emits a canonical,
+byte-stable unified diff = the "model patch" the OFFICIAL SWE-bench Docker grader scores.
+Used by BOTH arms (A: the primary drives the loop; C: a fleet worker drives it while the
+primary supervises) — the pure loop core is shared so a transport difference can never be
+mistaken for an algorithmic one.
+
+This module is the S1 DESIGN-ROUNDTABLE's "pure surface" (2026-07-05, 5/7 panel): everything
+here is unit-testable with NO live server, NO docker, NO network. The reproducibility-critical
+logic lives here; the live parts (delegate transport, .254 workspace creation, per-worker
+container startup, official grading) are narrow, MARKED stubs that fail honestly.
+
+Ratified rulings baked in:
+  Q1  in-loop tests default OFF (option c): iterate on git_verify+build; the official grader
+      is the SOLE resolution source, run once at the end -> iteration is fully reproducible and
+      decoupled from the single grader host (CT 101). resolve_test_command() supports opt-in.
+  Q2  per-worker OS isolation: a per-worker Docker container is the DEFAULT isolation unit for
+      any worker that executes tests/builds; venv + a port/TMPDIR/HOME/cache allocation table is
+      the documented FALLBACK when Docker is unavailable (e.g. the .254 LXC2Docker shim). The
+      allocation TABLE is needed either way and is implemented + tested here.
+  Q3  workspaces live where the loop runs (arm C: server-side on .254; arm A: via /v1/runs);
+      patch = `git -C <ws> diff <base_commit>`. The provisioning + extraction logic is shared.
+  Q5  commit hygiene (forbid in-loop commits; assert HEAD==base_commit before diff), artifact
+      scrub, deterministic diff flags, submodule/LFS rejection, and a secret-scan+redact pass
+      over every emitted patch before it can reach a ledger/log.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ------------------------------------------------------------ resource table --
+# Q2: even when the default isolation unit is a container, the harness must hand each worker a
+# non-overlapping (port range, TMPDIR, HOME, cache dirs) tuple — inside the container these keep
+# a crashed worker from poisoning a sibling; in the venv fallback they ARE the isolation. The
+# allocation is deterministic per (instance, arm, worker) so a re-run reproduces byte-for-byte.
+_PORTS_PER_WORKER = 16  # a small block; SWE-bench tests rarely bind more than a couple
+
+
+@dataclass(frozen=True)
+class WorkerEnv:
+    key: str
+    port_base: int
+    port_count: int
+    workspace: str
+    tmpdir: str
+    home: str
+    cache_dir: str
+
+    def env(self) -> dict:
+        """The OS-resource env a worker's test/build commands run under (venv fallback path)."""
+        return {"TMPDIR": self.tmpdir, "HOME": self.home,
+                "XDG_CACHE_HOME": self.cache_dir, "PIP_CACHE_DIR": self.cache_dir,
+                "CONDA_PKGS_DIRS": self.cache_dir,
+                "AIMEE_BENCH_PORT_BASE": str(self.port_base)}
+
+
+class EnvAllocator:
+    """Hands out non-overlapping WorkerEnvs from a bounded port pool with explicit release and
+    range-exhaustion errors. Deterministic slot assignment keyed by (instance, arm, worker)."""
+
+    def __init__(self, root: str, base_port: int = 21000, max_workers: int = 256):
+        self.root = Path(root)
+        self.base_port = base_port
+        self.max_workers = max_workers
+        self._slots: dict[str, int] = {}
+        self._free: list[int] = []
+        self._next = 0
+
+    def _slot_for(self, key: str) -> int:
+        if key in self._slots:
+            return self._slots[key]
+        if self._free:
+            slot = self._free.pop()
+        elif self._next < self.max_workers:
+            slot = self._next
+            self._next += 1
+        else:
+            raise RuntimeError(f"port/worker pool exhausted (max_workers={self.max_workers})")
+        self._slots[key] = slot
+        return slot
+
+    def allocate(self, instance_id: str, arm: str, worker_idx: int) -> WorkerEnv:
+        key = f"{instance_id}:{arm}:{worker_idx}"
+        slot = self._slot_for(key)
+        base = self.root / key.replace(":", "__").replace("/", "_")
+        return WorkerEnv(
+            key=key,
+            port_base=self.base_port + slot * _PORTS_PER_WORKER,
+            port_count=_PORTS_PER_WORKER,
+            workspace=str(base / "ws"),
+            tmpdir=str(base / "tmp"),
+            home=str(base / "home"),
+            cache_dir=str(base / "cache"),
+        )
+
+    def release(self, instance_id: str, arm: str, worker_idx: int) -> None:
+        key = f"{instance_id}:{arm}:{worker_idx}"
+        slot = self._slots.pop(key, None)
+        if slot is not None:
+            self._free.append(slot)
+
+    def port_ranges(self) -> list[tuple[int, int]]:
+        """(start, end) inclusive for each live slot — used by tests to assert non-overlap."""
+        return sorted((self.base_port + s * _PORTS_PER_WORKER,
+                       self.base_port + s * _PORTS_PER_WORKER + _PORTS_PER_WORKER - 1)
+                      for s in self._slots.values())
+
+
+# ------------------------------------------------------------ test commands ----
+# Q1: default OFF, but when in-loop testing is opted in the command is resolved deterministically
+# from the repo (SWE-bench's four repo families). This is the repo's own runner, NOT the grader.
+_TEST_COMMANDS = {
+    "django/django": "python tests/runtests.py --parallel=1 --verbosity=0",
+    "sympy/sympy": "python -m pytest -q",
+    "scikit-learn/scikit-learn": "python -m pytest -q",
+    "pytest-dev/pytest": "python -m pytest -q",
+}
+
+
+def resolve_test_command(repo: str) -> str | None:
+    """The in-loop test command for a repo, or None if unknown (loop falls back to build/verify)."""
+    return _TEST_COMMANDS.get(repo)
+
+
+# ------------------------------------------------------------ provisioning -----
+class ProvisionError(RuntimeError):
+    pass
+
+
+def _git(ws, *args, check=True, capture=True):
+    return subprocess.run(["git", "-C", str(ws), *args], check=check,
+                          capture_output=capture, text=True)
+
+
+def assert_no_submodule_or_lfs(base_repo: str) -> None:
+    """Q5: reject submodule/LFS instances up front rather than silently mis-diffing them. The
+    four target repo families are pure-python (none), so this is a guard, not a common path."""
+    p = Path(base_repo)
+    if (p / ".gitmodules").exists():
+        raise ProvisionError(f"{base_repo}: has .gitmodules; submodule instances are rejected "
+                             "(use --submodule=diff handling before enabling)")
+    attrs = p / ".gitattributes"
+    if attrs.exists() and "filter=lfs" in attrs.read_text(errors="replace"):
+        raise ProvisionError(f"{base_repo}: uses git-lfs; LFS instances are rejected")
+
+
+def provision_workspace(base_repo: str, base_commit: str, dest: str) -> str:
+    """Create an isolated, editable checkout of base_repo at base_commit under dest.
+
+    Q5 hygiene: force a clean detached checkout at base_commit and scrub ALL untracked/ignored
+    state (`git checkout -f` + `git clean -fdx`) so no leftover build artifact or prior-run edit
+    can pollute the eventual diff. Returns the workspace path. Uses a local worktree off the base
+    clone (cheap, shares the object store) and asserts the result is exactly at base_commit.
+    """
+    assert_no_submodule_or_lfs(base_repo)
+    dest_p = Path(dest)
+    dest_p.parent.mkdir(parents=True, exist_ok=True)
+    if not dest_p.exists():
+        # A detached worktree off the base clone: isolated working tree, shared objects.
+        r = _git(base_repo, "worktree", "add", "--detach", "--force", str(dest_p), base_commit,
+                 check=False)
+        if r.returncode != 0:
+            raise ProvisionError(f"worktree add failed: {r.stderr.strip()}")
+    else:
+        _git(dest_p, "checkout", "-f", "--detach", base_commit)
+    _git(dest_p, "clean", "-fdx")
+    head = _git(dest_p, "rev-parse", "HEAD").stdout.strip()
+    if not head.startswith(base_commit) and not base_commit.startswith(head):
+        raise ProvisionError(f"workspace HEAD {head} != base_commit {base_commit}")
+    return str(dest_p)
+
+
+# ------------------------------------------------------------ patch extraction -
+# Q5: a canonical, byte-stable patch. `git add -A` stages tracked edits AND untracked NEW source
+# files (the agent's creations) while .gitignore keeps build artifacts out; `git diff --cached`
+# against base_commit then emits the full model patch. Deterministic flags kill host-dependent
+# ordering/renames/external-diff. Standard a/ b/ prefixes are KEPT (the grader applies with
+# `git apply`, which expects them). We assert HEAD==base_commit so an accidental in-loop commit
+# is caught rather than silently producing an empty/partial diff.
+_DIFF_FLAGS = ["--no-ext-diff", "--no-color", "--no-renames", "--submodule=diff",
+               "--src-prefix=a/", "--dst-prefix=b/"]
+
+
+class PatchError(RuntimeError):
+    pass
+
+
+def extract_patch(workspace: str, base_commit: str, *, redact_secrets: bool = True) -> tuple[str, int]:
+    """Return (canonical_patch, redaction_count) for all changes since base_commit.
+
+    Forbids in-loop commits (asserts HEAD==base_commit). Stages everything not gitignored, diffs
+    against base_commit with deterministic flags, then secret-scans+redacts before the patch can
+    reach any ledger/log."""
+    head = _git(workspace, "rev-parse", "HEAD").stdout.strip()
+    if not (head.startswith(base_commit) or base_commit.startswith(head)):
+        raise PatchError(f"HEAD {head} != base_commit {base_commit}: worker committed in-loop "
+                         "(forbidden — leave the tree dirty)")
+    _git(workspace, "add", "-A")
+    env = dict(os.environ, GIT_CONFIG_GLOBAL="/dev/null", GIT_CONFIG_SYSTEM="/dev/null")
+    r = subprocess.run(["git", "-C", str(workspace), "diff", "--cached", *_DIFF_FLAGS, base_commit],
+                       check=True, capture_output=True, text=True, env=env)
+    patch = r.stdout
+    n = 0
+    if redact_secrets:
+        patch, n = scan_and_redact_secrets(patch)
+    return patch, n
+
+
+# ------------------------------------------------------------ secret scan ------
+# Q5 security: agents edit config files and may paste credentials into source; the emitted patch
+# is persisted to the token_audit ledger / analysis artifacts. Redact known secret shapes and
+# high-entropy assignments with a STABLE marker (so the patch stays byte-stable) and count them.
+_SECRET_PATTERNS = [
+    re.compile(r"AKIA[0-9A-Z]{16}"),                                  # AWS access key id
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{36,}"),                        # GitHub tokens
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),                               # OpenAI-style keys
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),                      # Slack tokens
+]
+# KEY = "high-entropy value" assignments (env/config lines the agent might add).
+_ASSIGN_RE = re.compile(
+    r'((?:secret|token|password|passwd|api[_-]?key|access[_-]?key)\s*[=:]\s*["\']?)'
+    r'([A-Za-z0-9+/_\-]{16,})(["\']?)', re.IGNORECASE)
+_REDACTED = "AIMEE_REDACTED_SECRET"
+
+
+def _shannon_entropy(s: str) -> float:
+    if not s:
+        return 0.0
+    import math
+    counts = {c: s.count(c) for c in set(s)}
+    return -sum((n / len(s)) * math.log2(n / len(s)) for n in counts.values())
+
+
+def scan_and_redact_secrets(text: str) -> tuple[str, int]:
+    """Replace secret-shaped substrings with a stable marker; return (redacted_text, count)."""
+    count = 0
+
+    def _mark(_m):
+        nonlocal count
+        count += 1
+        return _REDACTED
+
+    out = text
+    for pat in _SECRET_PATTERNS:
+        out = pat.sub(_mark, out)
+
+    def _assign(m):
+        nonlocal count
+        val = m.group(2)
+        # Only redact if the value looks high-entropy (avoid nuking ordinary identifiers).
+        if _shannon_entropy(val) >= 3.2:
+            count += 1
+            return f"{m.group(1)}{_REDACTED}{m.group(3)}"
+        return m.group(0)
+
+    out = _ASSIGN_RE.sub(_assign, out)
+    return out, count
+
+
+# ------------------------------------------------------------ loop bounds ------
+@dataclass
+class LoopBudget:
+    """Bounds the agentic loop (mirrors the merged F1a/F1b turn/wall/USD caps at the bench level).
+    stop_on_verify_pass ends the loop as soon as the mechanical gate is green."""
+    max_turns: int = 12
+    max_wall_s: float = 900.0
+    max_usd: float = 1.0
+    stop_on_verify_pass: bool = True
+
+    def should_continue(self, *, turns: int, wall_s: float, usd: float, verify_passed: bool) -> bool:
+        if self.stop_on_verify_pass and verify_passed:
+            return False
+        return turns < self.max_turns and wall_s < self.max_wall_s and usd < self.max_usd
+
+    def stop_reason(self, *, turns: int, wall_s: float, usd: float, verify_passed: bool) -> str:
+        if self.stop_on_verify_pass and verify_passed:
+            return "verify_passed"
+        if turns >= self.max_turns:
+            return "max_turns"
+        if wall_s >= self.max_wall_s:
+            return "max_wall"
+        if usd >= self.max_usd:
+            return "max_usd"
+        return "running"
+
+
+# ------------------------------------------------------------ provenance -------
+def workspace_fingerprint(repo: str, base_commit: str, patch: str) -> str:
+    """A stable id for an emitted solution (repo + base_commit + canonical patch) for audit."""
+    h = hashlib.sha256()
+    h.update(f"{repo}\n{base_commit}\n".encode())
+    h.update(patch.encode())
+    return h.hexdigest()[:16]
+
+
+# ------------------------------------------------------------ LIVE stubs -------
+# The following need a live server / .254 workspace / container / grader and are NOT exercised in
+# CI. They fail honestly with the exact wiring to do, mirroring S0's stub discipline.
+def run_agentic_loop(instance: dict, env: WorkerEnv, budget: LoopBudget, *, arm: str,
+                     worker: str | None = None) -> str:
+    raise NotImplementedError(
+        "live agentic loop not wired. arm C: dispatch a tools-enabled `code`/`execute` delegate "
+        "against a server-side .254 workspace (Q3 option a), poll to a bounded terminal, extract "
+        "`git -C <ws> diff <base_commit>`. arm A: drive the same loop via the S0 /v1/runs "
+        "transport. In-loop tests default OFF (Q1 c); isolation via per-worker container or the "
+        "venv+EnvAllocator fallback (Q2).")

--- a/benchmarks/coding/swebench_arm_runner.py
+++ b/benchmarks/coding/swebench_arm_runner.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""S2 — arm A (agentic-solo) runner for the agentic supervised SWE-bench benchmark (#987).
+
+Arm A: the expensive primary drives the S1 agentic loop itself (explore/edit/[test]/verify) and
+we count ITS tokens. This module composes the already-merged pieces into one per-instance record
+in the shape `supervised_report.build_report` consumes, plus the agentic-arm honesty fields the
+roundtables ratified:
+  - token accounting from the token_audit ledger with S0's polarity (primary = delegation_id
+    EMPTY); the HEADLINE input is UNCACHED (prompt_tokens - cache_read_tokens) so a multi-turn
+    primary re-reading context across turns cannot skew the A vs C comparison (proposal B2a);
+  - two wall-clocks per instance (proposal Q5 / issue #987): total (queue+work) and work-only,
+    with queue = total - work; the report's p95 gate reads the headline `wall_s`;
+  - the S1 canonical patch + its fingerprint, secret-redacted before it can reach a ledger.
+
+Pure surface (unit-tested, no live server/docker/network): the token math, the wall-clock
+decomposition, and record-schema conformance. The live loop is S1's marked stub. Arm C's
+supervision loop (S3) reuses this record schema and token accounting — the SAME core for both
+arms so a transport difference can never masquerade as an algorithmic one (roundtable Q3).
+
+KNOWN LIMITATION (surfaced, not faked): token_audit has no separate reasoning/thinking-token
+column (only prompt/completion/cache_read/cache_write), so the proposal's thinking-vs-text split
+is NOT extractable today. `thinking_tokens` is reported as None until the ledger carries it.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from benchmarks.coding import swebench_transport_verify as V
+from benchmarks.coding import swebench_agentic_harness as H
+
+_FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
+
+
+# ------------------------------------------------------------ token totals -----
+@dataclass
+class PrimaryTokens:
+    input_uncached: int   # HEADLINE: prompt_tokens - cache_read_tokens
+    input_cached: int     # cache_read_tokens (re-read context; excluded from headline)
+    output: int
+    turns: int
+    thinking: int | None = None  # unavailable from token_audit today (see module docstring)
+
+    @property
+    def input_total(self) -> int:
+        return self.input_uncached + self.input_cached
+
+    @property
+    def total_headline(self) -> int:
+        """The number the reduction headline uses: uncached input + output."""
+        return self.input_uncached + self.output
+
+
+def primary_token_totals(rows, primary_model) -> PrimaryTokens:
+    """Sum the primary's realized turns (delegation_id EMPTY, per S0's verified polarity)."""
+    pr = V._primary_rows(rows, primary_model)
+    prompt = sum(r["prompt_tokens"] for r in pr)
+    cache_read = sum(r["cache_read_tokens"] for r in pr)
+    return PrimaryTokens(
+        input_uncached=max(0, prompt - cache_read),
+        input_cached=cache_read,
+        output=sum(r["completion_tokens"] for r in pr),
+        turns=len(pr),
+    )
+
+
+def worker_token_totals(rows) -> tuple[int, int]:
+    """(input, output) across delegate children (delegation_id NON-EMPTY); priced $0 (honesty)."""
+    wr = V._worker_rows(rows)
+    return sum(r["prompt_tokens"] for r in wr), sum(r["completion_tokens"] for r in wr)
+
+
+# ------------------------------------------------------------ wall-clock -------
+@dataclass
+class WallClock:
+    """Per-instance wall-clock. t0 = instance prompt enters the harness dispatch queue (pinned
+    IDENTICALLY for both arms, proposal Q5); first_work = first worker/primary turn starts;
+    t1 = patch ready (grader resolves downstream). We report total and work-only; queue is the
+    gap. Fleet throughput is a SEPARATE number, never conflated here."""
+    t0: float
+    first_work: float
+    t1: float
+
+    @property
+    def total_s(self) -> float:
+        return max(0.0, self.t1 - self.t0)
+
+    @property
+    def work_s(self) -> float:
+        return max(0.0, self.t1 - self.first_work)
+
+    @property
+    def queue_s(self) -> float:
+        return max(0.0, self.first_work - self.t0)
+
+
+# ------------------------------------------------------------ arm record -------
+def build_arm_record(instance_id, arm, primary_model, *, tokens: PrimaryTokens,
+                     worker_in: int, worker_out: int, wall: WallClock, resolved,
+                     patch: str, base_commit: str, repo: str, n_workers: int = 1,
+                     redactions: int = 0, escalations: int = 0, compaction: bool = False,
+                     invalid: bool = False) -> dict:
+    """One record in supervised_report's schema + the agentic-arm honesty fields."""
+    return {
+        # --- schema consumed by supervised_report.build_report ---
+        "instance_id": instance_id,
+        "arm": arm,
+        "compaction": compaction,
+        "supervisor_input_tokens": tokens.input_uncached,   # headline = UNCACHED
+        "supervisor_output_tokens": tokens.output,
+        "worker_input_tokens": worker_in,
+        "worker_output_tokens": worker_out,
+        "wall_s": round(wall.total_s, 3),
+        "resolved": resolved,
+        "n_workers": n_workers,
+        "invalid": invalid,
+        # --- agentic-arm honesty extensions (S4 report surfaces these) ---
+        "supervisor_input_cached_tokens": tokens.input_cached,
+        "supervisor_thinking_tokens": tokens.thinking,      # None until ledger carries it
+        "primary_turns": tokens.turns,
+        "wall_work_s": round(wall.work_s, 3),
+        "wall_queue_s": round(wall.queue_s, 3),
+        "escalations": escalations,
+        "patch_fingerprint": H.workspace_fingerprint(repo, base_commit, patch),
+        "patch_redactions": redactions,
+    }
+
+
+# ------------------------------------------------------------ fake mode --------
+def _fake_arm_a_record(instance, primary_model):
+    iid = instance["instance_id"]
+    rows = V._fake_rows("pass", primary_model, "glm-5.2")
+    tok = primary_token_totals(rows, primary_model)
+    wi, wo = worker_token_totals(rows)
+    wall = WallClock(t0=0.0, first_work=0.5, t1=12.5)
+    patch, red = H.scan_and_redact_secrets("diff --git a/x b/x\n+ok\n")
+    return build_arm_record(iid, "A", primary_model, tokens=tok, worker_in=wi, worker_out=wo,
+                            wall=wall, resolved=True, patch=patch,
+                            base_commit=instance.get("base_commit", "0"*40),
+                            repo=instance.get("repo", "x/y"), redactions=red)
+
+
+# ------------------------------------------------------------ live entry -------
+def run_arm_a(instance: dict, primary_model: str, *, token_db: str, base_repo: str,
+              allocator: "H.EnvAllocator", budget: "H.LoopBudget") -> dict:
+    """Live arm-A run for one instance. Provisions a workspace, drives the primary agentic loop
+    via the S0-verified /v1/runs transport, extracts the patch, and reads the primary's tokens
+    from token_audit scoped to the run's session_id. Marked live (needs a server)."""
+    if _FAKE:
+        return _fake_arm_a_record(instance, primary_model)
+    raise NotImplementedError(
+        "live arm-A run not wired: provision via H.provision_workspace, drive H.run_agentic_loop "
+        "(arm='A', /v1/runs transport), extract via H.extract_patch, then read tokens with "
+        "V.collect_rows(token_db, session_id) + primary_token_totals(). Requires a live server.")

--- a/benchmarks/coding/swebench_claim_gate.py
+++ b/benchmarks/coding/swebench_claim_gate.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""S6 — the fail-closed public-claim gate (agentic supervised SWE-bench, #987).
+
+The honesty capstone. The public line — "beats Reddit's -75.5% supervisor tokens at no
+wall-clock penalty" — may be emitted ONLY if EVERY criterion below holds, under the official
+grader, on BOTH Benchmark 1 (Reddit-10) AND Benchmark 2 (held-out). Otherwise the report is
+STILL published (publish-regardless), but with the claim withheld and an honest partial summary
+(e.g. "-78% primary tokens at 1.05x p95 wall-clock — claim withheld"). Fail closed: any missing
+metric, any unmet criterion, or a benchmark disagreement withholds the claim.
+
+Criteria (proposal S6 + S3 rulings), all anchored on N=1 for the public claim:
+  C1 token   : BCa-95 CI lower-bound of primary-token reduction > 0.
+  C2 wall    : p95 A->C wall-clock ratio upper-bound <= 1.0 (gate on p95, not median;
+               computed against aimee's OWN arm-A time, not Reddit's cross-harness minutes).
+  C3 resolve : resolved_C/total >= max(0.7 * resolved_A/total, 0.25) — without this floor a
+               token+wall win at ~0% resolution would be dishonest.
+  C4 both    : C1-C3 hold on Benchmark 1 AND Benchmark 2; a divergence withholds.
+  C5 stats   : Benchmark 1 ran K>=10 repeats (the public-claim benchmark).
+  C6 clean   : the arm-C headline set is not ESCALATION_DOMINATED (escalation-excluded fraction
+               below the cap) — the win must come from supervision, not the primary digging in.
+  C7 review  : an independent reviewer (not the harness/worker author) signed off (recorded).
+
+This module is pure and unit-tested; it decides, it does not run anything.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+ESCALATION_EXCLUDED_CAP = 0.40   # >40% of arm-C runs escalation-dominated => not "cheap supervision"
+MIN_ABS_RESOLUTION = 0.25
+RESOLUTION_PARITY_FRAC = 0.70
+MIN_K_PUBLIC = 10
+
+
+@dataclass
+class BenchmarkMetrics:
+    """The N=1 slice of one benchmark, as computed by supervised_report + _panels."""
+    name: str
+    token_reduction_ci: tuple[float, float]   # BCa-95 CI of (1 - sum_C/sum_A), fraction
+    wall_p95_ratio_ci: tuple[float, float]     # BCa-95 CI of p95(C)/p95(A)
+    resolved_c: int
+    resolved_a: int
+    total: int
+    k: int
+    escalation_excluded_frac: float = 0.0
+    n_anchor: int = 1
+
+
+def _crit_token(m: BenchmarkMetrics) -> tuple[bool, str]:
+    lo = m.token_reduction_ci[0]
+    return lo > 0, f"token-reduction CI lower-bound = {lo:+.3f} (need > 0)"
+
+
+def _crit_wall(m: BenchmarkMetrics) -> tuple[bool, str]:
+    hi = m.wall_p95_ratio_ci[1]
+    return hi <= 1.0, f"p95 wall A->C ratio CI upper-bound = {hi:.3f} (need <= 1.0)"
+
+
+def _crit_resolution(m: BenchmarkMetrics) -> tuple[bool, str]:
+    if m.total <= 0:
+        return False, "no graded instances"
+    rc, ra = m.resolved_c / m.total, m.resolved_a / m.total
+    floor = max(RESOLUTION_PARITY_FRAC * ra, MIN_ABS_RESOLUTION)
+    return rc >= floor, f"resolved_C/total = {rc:.3f} (need >= {floor:.3f} = max(0.7*{ra:.3f}, 0.25))"
+
+
+def _crit_k(m: BenchmarkMetrics) -> tuple[bool, str]:
+    return m.k >= MIN_K_PUBLIC, f"K = {m.k} (need >= {MIN_K_PUBLIC})"
+
+
+def _crit_anchor(m: BenchmarkMetrics) -> tuple[bool, str]:
+    return m.n_anchor == 1, f"N anchor = {m.n_anchor} (public claim must be N=1)"
+
+
+def _crit_escalation(m: BenchmarkMetrics) -> tuple[bool, str]:
+    ok = m.escalation_excluded_frac <= ESCALATION_EXCLUDED_CAP
+    return ok, f"escalation-dominated fraction = {m.escalation_excluded_frac:.3f} (need <= {ESCALATION_EXCLUDED_CAP})"
+
+
+def evaluate_benchmark(m: BenchmarkMetrics, *, require_k: bool) -> dict[str, Any]:
+    """Per-benchmark criteria. `require_k` only for the public-claim benchmark (B1)."""
+    crits = {
+        "token": _crit_token(m),
+        "wall": _crit_wall(m),
+        "resolution": _crit_resolution(m),
+        "anchor_n1": _crit_anchor(m),
+        "escalation_clean": _crit_escalation(m),
+    }
+    if require_k:
+        crits["k_adequate"] = _crit_k(m)
+    detail = {k: {"pass": ok, "why": why} for k, (ok, why) in crits.items()}
+    return {"name": m.name, "pass": all(v["pass"] for v in detail.values()), "criteria": detail}
+
+
+def evaluate_claim_gate(b1: BenchmarkMetrics, b2: BenchmarkMetrics,
+                        *, independent_review: bool = False) -> dict[str, Any]:
+    """The fail-closed gate. Returns the decision + per-benchmark detail + an honest summary.
+    The report is published regardless; only the CLAIM LINE is gated on `emit_claim`."""
+    e1 = evaluate_benchmark(b1, require_k=True)     # B1 is the public-claim benchmark
+    e2 = evaluate_benchmark(b2, require_k=False)
+    both_pass = e1["pass"] and e2["pass"]
+    reasons = []
+    if not e1["pass"]:
+        reasons += [f"B1[{k}] {v['why']}" for k, v in e1["criteria"].items() if not v["pass"]]
+    if not e2["pass"]:
+        reasons += [f"B2[{k}] {v['why']}" for k, v in e2["criteria"].items() if not v["pass"]]
+    if not independent_review:
+        reasons.append("independent reviewer sign-off missing (C7)")
+    emit = both_pass and independent_review
+    return {
+        "emit_claim": emit,
+        "benchmarks": {"b1": e1, "b2": e2},
+        "independent_review": independent_review,
+        "withheld_reasons": reasons,
+        "summary": _summary(b1, emit, reasons),
+    }
+
+
+def _summary(b1: BenchmarkMetrics, emit: bool, reasons: list[str]) -> str:
+    """The honest one-liner — always publishable, whether or not the claim is emitted."""
+    red = b1.token_reduction_ci
+    wall = b1.wall_p95_ratio_ci
+    red_pct = f"{100 * (red[0] + red[1]) / 2:.0f}%"
+    wall_x = f"{(wall[0] + wall[1]) / 2:.2f}x"
+    if emit:
+        return (f"Beats Reddit's -75.5%: -{red_pct} primary tokens at {wall_x} p95 wall-clock "
+                f"(both benchmarks, official grader, N=1, K>={MIN_K_PUBLIC}, independently reviewed).")
+    head = reasons[0] if reasons else "criteria unmet"
+    return f"-{red_pct} primary tokens at {wall_x} p95 wall-clock — CLAIM WITHHELD ({head})."

--- a/benchmarks/coding/swebench_live_attribution.py
+++ b/benchmarks/coding/swebench_live_attribution.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""S0-live — empirically-grounded token attribution for the agentic supervised SWE-bench harness.
+
+The pure S0 module (`swebench_transport_verify.py`) asserts a THEORETICAL polarity: a top-level
+primary turn carries `delegation_id` EMPTY and a delegate child carries it non-empty. Running the
+verification matrix against the live .254 fleet (2026-07-05) showed the DEPLOYMENT does not work
+that way, and this module encodes the corrected model so the live harness measures the right
+thing:
+
+  FINDING 1 — almost no EMPTY-delegation rows exist. On .254, ~all realized `token_audit` rows are
+    delegate turns with a NON-EMPTY `delegation_id` of the form `deleg-<sess>-<ns_ts>-<idx>`; the
+    aimee primary (a tmux Claude TUI whose /v1 proxy is stateless) does not reliably emit
+    EMPTY-delegation rows. => the bench runs the "primary" itself as a `codex`/gpt-5.5 DELEGATE,
+    and primary vs worker is distinguished by WHICH delegation_id the harness dispatched, not by
+    empty-vs-nonempty.
+  FINDING 2 — `delegation_spawns` is the attribution table: (delegation_id, parent_delegation_id,
+    session_id, depth, role). A dispatch creates one row; workers a primary spawns would be its
+    depth-2 children (parent_delegation_id = primary's). Today all dispatches are depth-1 siblings,
+    so the harness captures each dispatch's delegation_id from the newest spawn row for its session.
+  FINDING 3 — `usage_kind` filtering is load-bearing: a single agentic job produced 9 rows, 8 of
+    them `avoided` (economizer estimates) and 1 `realized`. Only `realized` is spend.
+  FINDING 4 — agentic `--tools` needs an ISOLATED worktree: a plain `delegate execute --tools`
+    hit the "parent worktree write guard ... sandbox fallback could not start" and no tool ran.
+    The worker's edit/test loop must dispatch with `--worktree` (S1 per-worker isolation is
+    therefore REQUIRED for tools to function at all, not merely for reproducibility).
+
+The attribution logic here is pure and unit-tested against an in-memory sqlite fixture mirroring
+`delegation_spawns` + `token_audit`; the SSH-based live runner is a marked stub.
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+
+# ------------------------------------------------------------ schema names -----
+# The two real tables (columns verified on .254 aimee.db, 2026-07-05).
+SPAWNS = "delegation_spawns"       # delegation_id, parent_delegation_id, session_id, depth, role, ...
+AUDIT = "token_audit"              # delegation_id, usage_kind, prompt/completion/cache_*_tokens, ...
+
+
+@dataclass
+class TokenTotals:
+    input_uncached: int
+    input_cached: int
+    output: int
+    rows: int
+
+    @property
+    def total_headline(self) -> int:
+        return self.input_uncached + self.output
+
+
+def capture_dispatch_delegation(con: sqlite3.Connection, session_id: str,
+                                after_spawn_id: int) -> str | None:
+    """Resolve the delegation_id of a just-dispatched job: the newest delegation_spawns row for
+    `session_id` with id > after_spawn_id (the id captured immediately BEFORE dispatch). Returns
+    None if the dispatch produced no spawn row (a failed/rejected dispatch)."""
+    r = con.execute(
+        f"SELECT delegation_id FROM {SPAWNS} WHERE session_id=? AND id>? "
+        f"ORDER BY id DESC LIMIT 1", (session_id, after_spawn_id)).fetchone()
+    return r[0] if r else None
+
+
+def child_delegations(con: sqlite3.Connection, parent_delegation_id: str) -> list[str]:
+    """The delegation_ids of workers a primary spawned (depth-2 children). Empty today (all
+    dispatches are depth-1 siblings) but correct once the primary spawns workers server-side."""
+    rows = con.execute(
+        f"SELECT delegation_id FROM {SPAWNS} WHERE parent_delegation_id=?",
+        (parent_delegation_id,)).fetchall()
+    return [r[0] for r in rows]
+
+
+def realized_totals(con: sqlite3.Connection, delegation_ids: list[str]) -> TokenTotals:
+    """Sum REALIZED token_audit rows over a set of delegation_ids. Headline input is UNCACHED
+    (prompt - cache_read); avoided/estimated rows are excluded (usage_kind='realized' only)."""
+    if not delegation_ids:
+        return TokenTotals(0, 0, 0, 0)
+    q = (f"SELECT COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(cache_read_tokens),0), "
+         f"COALESCE(SUM(completion_tokens),0), COUNT(*) FROM {AUDIT} "
+         f"WHERE usage_kind='realized' AND delegation_id IN ({','.join('?' * len(delegation_ids))})")
+    prompt, cache_read, completion, rows = con.execute(q, delegation_ids).fetchone()
+    return TokenTotals(input_uncached=max(0, prompt - cache_read), input_cached=cache_read,
+                       output=completion, rows=rows)
+
+
+def primary_worker_split(con: sqlite3.Connection, primary_did: str,
+                         worker_dids: list[str]) -> dict:
+    """The corrected primary-vs-worker split: primary tokens over the primary's delegation_id,
+    worker tokens over the workers' delegation_ids. This REPLACES the EMPTY-polarity model for the
+    live deployment."""
+    p = realized_totals(con, [primary_did])
+    w = realized_totals(con, worker_dids)
+    return {
+        "primary_did": primary_did,
+        "primary_input_uncached": p.input_uncached,
+        "primary_input_cached": p.input_cached,
+        "primary_output": p.output,
+        "primary_headline": p.total_headline,
+        "primary_rows": p.rows,
+        "worker_dids": worker_dids,
+        "worker_input": w.input_uncached + w.input_cached,
+        "worker_output": w.output,
+        "worker_rows": w.rows,
+    }
+
+
+# ------------------------------------------------------------ live assertions --
+def verify_live_attribution(con: sqlite3.Connection, primary_did: str,
+                            worker_dids: list[str]) -> dict:
+    """Re-express the S0 assertions over the REAL schema for a completed run:
+      L1 primary_measured  — the primary delegation has >=1 realized row with output.
+      L2 worker_attributed — every worker delegation is disjoint from the primary's id.
+      L3 no_cross_bill     — no worker delegation_id is counted under the primary total.
+      L4 realized_only     — (structural) totals exclude avoided/estimated rows (SQL enforces).
+    """
+    split = primary_worker_split(con, primary_did, worker_dids)
+    l1 = split["primary_rows"] >= 1 and split["primary_output"] >= 0
+    l2 = primary_did not in worker_dids
+    l3 = not (set(worker_dids) & {primary_did})
+    checks = {
+        "L1_primary_measured": (l1, f"{split['primary_rows']} realized primary rows"),
+        "L2_worker_disjoint": (l2, f"{len(worker_dids)} worker delegations, primary excluded"),
+        "L3_no_cross_bill": (l3, "no worker delegation_id under the primary total"),
+        "L4_realized_only": (True, "SQL filters usage_kind='realized' (avoided rows excluded)"),
+    }
+    out = {k: {"ok": ok, "detail": d} for k, (ok, d) in checks.items()}
+    out["passed"] = all(v["ok"] for v in out.values())
+    out["split"] = split
+    return out
+
+
+# ------------------------------------------------------------ live runner ------
+def run_live_matrix(*, ssh_host: str, db_path: str):
+    raise NotImplementedError(
+        "live matrix runner not wired for autonomous exec: it SSHes to `ssh_host`, copies/queries "
+        f"{db_path} (aimee.db) against delegation_spawns + token_audit, and for a dispatched "
+        "primary+workers run computes primary_worker_split()/verify_live_attribution(). On .254 "
+        "the DB is at /mnt/media/.plugins/aimee-server/server/home/aimee.db and readable over ssh "
+        "(BatchMode key auth). Also note FINDING 4: workers need `delegate ... --worktree` for "
+        "tools to run (the write guard blocks a plain --tools dispatch).")

--- a/benchmarks/coding/swebench_suite.py
+++ b/benchmarks/coding/swebench_suite.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""S5 — suite execution + grading orchestration (agentic supervised SWE-bench, #987).
+
+Runs the six-benchmark suite across factors and grades every emitted patch with the OFFICIAL
+SWE-bench Docker harness on CT 101. The parts that need the live .254 fleet + CT 101 are marked
+stubs; the reproducibility-critical orchestration is pure and unit-tested here:
+
+  - generate_run_plan .... deterministic run cells from the benchmark specs x factor grid
+                           (Benchmark 1 Reddit-10 head-to-head; 2 held-out Lite; 3 parallelism
+                           sweep; 4 best-of-N; 5 reducer lever; 6 worker-pool). K repeats.
+  - CT101Lease ........... the S1-Q1 contention control: CT 101 has two named tenants
+                           {grader, iteration_pool}; grading has strict priority and the two are
+                           mutually exclusive, so in-loop docker (if ever enabled) can never
+                           starve or add queue-noise to the sole final grader.
+  - GraderRetry .......... proposal S5: max 2 deterministic retries on a grader ERROR (not on a
+                           legitimate non-resolve); flip-detection flags instances whose
+                           resolution is unstable across the K repeats.
+  - build_predictions .... one prediction per instance per (arm, model, N, cmp) run_id, deduped
+                           by instance_id (the official harness dedupes by instance_id).
+  - aggregate_k .......... majority-vote resolution across K repeats + a flip flag.
+
+Grade only on the official harness; never let in-loop signal decide `resolved` (S1 Q1).
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ------------------------------------------------------------ benchmark specs --
+# Each spec: the instance set + the factor grid it crosses. K = repeats for variance.
+BENCHMARKS = {
+    "b1_reddit10": {"instances": "reddit10", "arms": ["A", "C"], "N": [1, 3],
+                    "reducers": [False], "primary": ["gpt-5.5", "claude"], "K": 10,
+                    "public_claim": True},
+    "b2_heldout": {"instances": "lite:28", "arms": ["A", "C"], "N": [1, 3],
+                   "reducers": [False], "primary": ["gpt-5.5"], "K": 3, "public_claim": True},
+    "b3_parallelism": {"instances": "reddit10", "arms": ["C"], "N": [1, 2, 4, 8],
+                       "reducers": [False], "primary": ["gpt-5.5"], "K": 3},
+    "b4_best_of_n": {"instances": "lite:28", "arms": ["C"], "N": [1, 2, 3],
+                     "reducers": [False], "primary": ["gpt-5.5"], "K": 3},
+    "b5_reducer": {"instances": "reddit10", "arms": ["C"], "N": [3],
+                   "reducers": [False, True], "primary": ["gpt-5.5"], "K": 3},
+    "b6_worker_pool": {"instances": "reddit10", "arms": ["C"], "N": [1],
+                       "reducers": [False], "primary": ["gpt-5.5"], "K": 3,
+                       "worker_pools": ["free_fleet", "gpu_gemma4"]},
+}
+
+
+@dataclass(frozen=True)
+class RunCell:
+    benchmark: str
+    arm: str
+    primary: str
+    n: int
+    reducers: bool
+    worker_pool: str
+    repeat: int
+    instances: str
+
+    @property
+    def run_id(self) -> str:
+        base = f"{self.benchmark}:{self.arm}:{self.primary}:N{self.n}:cmp{int(self.reducers)}:{self.worker_pool}:k{self.repeat}"
+        return f"aimee-sup-{hashlib.sha256(base.encode()).hexdigest()[:12]}"
+
+
+def generate_run_plan(benchmarks: dict = None, only: list[str] = None) -> list[RunCell]:
+    """Deterministic, fully-ordered run cells for the whole suite (or a subset via `only`)."""
+    benchmarks = benchmarks or BENCHMARKS
+    cells: list[RunCell] = []
+    for name in sorted(benchmarks):
+        if only and name not in only:
+            continue
+        spec = benchmarks[name]
+        pools = spec.get("worker_pools", ["free_fleet"])
+        for arm in spec["arms"]:
+            for primary in spec["primary"]:
+                for n in spec["N"]:
+                    for red in spec["reducers"]:
+                        for pool in pools:
+                            for k in range(spec.get("K", 1)):
+                                cells.append(RunCell(name, arm, primary, n, red, pool, k,
+                                                     spec["instances"]))
+    return cells
+
+
+# ------------------------------------------------------------ CT-101 lease ------
+class LeaseError(RuntimeError):
+    pass
+
+
+class CT101Lease:
+    """S1-Q1: CT 101 is the sole real-docker grader host. Two tenants {grader, iteration_pool}
+    are mutually exclusive; grader has strict priority (an iteration lease is refused while a
+    grade is pending or active). In-loop tests default OFF, so in practice this serializes grade
+    batches and guarantees the p95 wall-clock is never polluted by iteration docker on CT 101."""
+    GRADER = "grader"
+    ITERATION = "iteration_pool"
+
+    def __init__(self):
+        self._holder: str | None = None
+        self._grader_waiting = False
+
+    def request_grader(self) -> bool:
+        self._grader_waiting = True
+        if self._holder in (None, self.GRADER):
+            self._holder = self.GRADER
+            self._grader_waiting = False
+            return True
+        return False  # iteration holds it; caller waits (grader will get it next)
+
+    def request_iteration(self) -> bool:
+        # Grader priority: refuse iteration while a grade holds OR is waiting.
+        if self._holder is None and not self._grader_waiting:
+            self._holder = self.ITERATION
+            return True
+        return False
+
+    def release(self, tenant: str) -> None:
+        if self._holder != tenant:
+            raise LeaseError(f"{tenant} does not hold the CT101 lease (holder={self._holder})")
+        self._holder = None
+
+    @property
+    def holder(self) -> str | None:
+        return self._holder
+
+
+# ------------------------------------------------------------ grader retry ------
+@dataclass
+class GraderRetry:
+    """Proposal S5: retry a grader ERROR (harness crash/flake) up to `max_retries`, but NEVER
+    retry a legitimate non-resolve. `attempts` records the invocation count for the report."""
+    max_retries: int = 2
+    attempts: int = 0
+
+    def run(self, grade_fn) -> Any:
+        """grade_fn() -> ('ok', resolved_bool) | ('error', msg). Retries only on 'error'."""
+        last = None
+        for _ in range(self.max_retries + 1):
+            self.attempts += 1
+            status, payload = grade_fn()
+            if status == "ok":
+                return payload
+            last = payload
+        raise RuntimeError(f"grader failed after {self.attempts} attempts: {last}")
+
+
+def detect_flips(resolved_by_repeat: list[bool]) -> bool:
+    """True if an instance's resolution is UNSTABLE across the K repeats (some pass, some fail).
+    A flapping instance is flagged so grader-flake is not conflated with run noise."""
+    s = set(resolved_by_repeat)
+    return len(s) > 1
+
+
+def aggregate_k(resolved_by_repeat: list[bool]) -> dict[str, Any]:
+    """Majority-vote resolution across K repeats + the flip flag."""
+    if not resolved_by_repeat:
+        return {"resolved": None, "flipped": False, "k": 0}
+    n_true = sum(1 for r in resolved_by_repeat if r)
+    return {"resolved": n_true * 2 >= len(resolved_by_repeat), "flipped": detect_flips(resolved_by_repeat),
+            "k": len(resolved_by_repeat), "pass_count": n_true}
+
+
+# ------------------------------------------------------------ predictions ------
+def build_predictions(records: list[dict[str, Any]], run_id: str) -> list[dict[str, Any]]:
+    """One prediction per instance for a run_id, deduped by instance_id (the official harness
+    dedupes by instance_id, so duplicates would be silently dropped — we dedupe explicitly,
+    keeping the first non-empty patch)."""
+    seen: dict[str, dict] = {}
+    for r in records:
+        iid = r["instance_id"]
+        if not r.get("diff") and not r.get("patch"):
+            continue
+        if iid in seen:
+            continue
+        seen[iid] = {"instance_id": iid, "model_name_or_path": run_id,
+                     "model_patch": r.get("diff") or r.get("patch", "")}
+    return list(seen.values())
+
+
+# ------------------------------------------------------------ live stub --------
+def run_suite(only: list[str] = None, *, token_db: str, aimee_bin: str):
+    raise NotImplementedError(
+        "live suite execution not wired: for each RunCell from generate_run_plan(), dispatch arm "
+        "A (run_arm_a) or arm C (run_arm_c_supervised) on the .254 fleet, hold CT101Lease.GRADER "
+        "while grading each run_id's build_predictions() with the official swebench Docker harness "
+        "on CT 101 under GraderRetry, aggregate_k across repeats, then feed the records to "
+        "supervised_report + supervised_report_panels. Requires the live server + CT 101.")

--- a/benchmarks/coding/swebench_supervision.py
+++ b/benchmarks/coding/swebench_supervision.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""S3 — arm C supervision loop: the pure honesty core (agentic supervised SWE-bench, #987).
+
+Arm C: N cheap/local fleet workers each run the S1 agentic loop; the primary SUPERVISES across
+turns and we count only the primary's tokens. The public claim ("beats Reddit's -75.5% at no
+wall-clock penalty") is only honest if the primary supervises CHEAPLY — reading short, capped,
+leak-guarded digests and picking among candidate diffs, NEVER the raw code. This module is the
+reproducibility-critical machinery that MECHANICALLY enforces that, per the S3 design roundtable
+(2026-07-05, 6/7 panel). Everything here is a pure function — unit-testable with no live server,
+no LLM, no network. The only live parts (worker dispatch; an optional LLM-supervisor selection
+ablation) are marked stubs.
+
+Ratified rulings baked in:
+  Q1  the turn-digest is a CONSTRUCTED, allowlisted data product with HARD token caps, not a
+      prompt convention; a serializer leak-guard REJECTS any field carrying file-like/raw-source
+      content and neutralizes tool-call-looking syntax (anti prompt-injection).
+  Q2  a hard tool allowlist; escalation is gated (only on worker terminal-fail or deterministic
+      stuck), bounded, and separately attributed; a run whose escalation tokens exceed 40% of the
+      primary's input is marked ESCALATION_DOMINATED and excluded from the headline.
+  Q3  best-of-N selection is a DETERMINISTIC pure function over structured worker-reported signals
+      (never the official grader, never raw logs) — an LLM selector would be non-reproducible;
+      oracle-best-of-N (any candidate passes the grader) vs actual-best-of-N (the selected patch
+      passes) decompose supervisor skill from worker diversity.
+  Q4  context-drift is bounded by a sliding window of the last K digests + a deterministic
+      fold-then-evict of older turns to a one-line summary, under a hard total cap.
+  Q5  redirect defaults OFF for the public-claim set (PR#986's limiter was worker reliability,
+      not supervision); if enabled it is a bounded, attributed ablation.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+
+# ------------------------------------------------------------ enums ------------
+class VerifyEnum(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    ERROR = "ERROR"
+    NOT_RUN = "NOT_RUN"
+
+
+class WorkerState(str, Enum):
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    STUCK = "stuck"
+
+
+# ------------------------------------------------------------ caps -------------
+# Q1: hard caps low enough that supervision stays materially different from raw-code review.
+DIGEST_TOKEN_CAP = 2048       # per worker-turn digest (total)
+DIFF_TOKEN_SUBCAP = 512       # the unified-diff field within a digest
+CONTEXT_TOTAL_CAP = 16000     # whole supervisor context
+WINDOW_K = 3                  # sliding window: last K digests kept verbatim
+FOLD_TOKEN_CAP = 512          # the folded one-line summary of evicted turns
+ESCALATION_DOMINATED_FRAC = 0.40
+_TOK = 4                      # ~chars per token (deterministic estimate; no tokenizer dep)
+
+
+def est_tokens(s: str) -> int:
+    """Deterministic token estimate (chars/4) — no external tokenizer, so CI is hermetic."""
+    return (len(s) + _TOK - 1) // _TOK
+
+
+# ------------------------------------------------------------ leak guard -------
+# Q1: worker text/diffs are untrusted. Reject file-like/raw-source payloads and neutralize
+# tool-call-looking syntax so digest content can never invoke a supervisor tool or smuggle code.
+_SOURCE_MARKERS = (
+    re.compile(r"^\s*(?:def|class)\s+\w+", re.M),
+    re.compile(r"^\s*(?:import|from)\s+\w+", re.M),
+    re.compile(r"^\s*#include\b", re.M),
+    re.compile(r"</?\w+[^>]*>"),                      # markup / xml-ish
+)
+_TOOLCALL_RE = re.compile(r"<\s*(?:tool_use|tool_call|function_call|invoke)\b", re.I)
+
+
+def looks_like_source(text: str, *, min_hits: int = 2) -> bool:
+    """True if `text` looks like raw source (outside a unified-diff frame)."""
+    hits = sum(1 for r in _SOURCE_MARKERS if r.search(text))
+    return hits >= min_hits
+
+
+def neutralize_toolcalls(text: str) -> str:
+    """Defang tool-call-looking syntax so digest content can't be interpreted as a tool call."""
+    return _TOOLCALL_RE.sub("<neutralized-", text)
+
+
+# ------------------------------------------------------------ digest -----------
+@dataclass
+class WorkerTurn:
+    """The raw per-turn signal a worker emits (input to digest construction)."""
+    worker_id: str
+    turn_index: int
+    state: WorkerState
+    action_label: str
+    unified_diff: str
+    verify: VerifyEnum
+    rationale: str = ""
+    files_touched: tuple = ()
+    added: int = 0
+    deleted: int = 0
+
+
+@dataclass
+class Digest:
+    """The bounded, leak-guarded product the supervisor is allowed to see. NEVER raw code."""
+    worker_id: str
+    turn_index: int
+    state: str
+    action_label: str
+    verify: str
+    diff: str
+    files_touched: tuple
+    added: int
+    deleted: int
+    truncated: bool
+    rejected_fields: tuple = ()
+
+    def tokens(self) -> int:
+        return est_tokens(self.diff) + est_tokens(self.action_label) + est_tokens(str(self.files_touched)) + 8
+
+
+def _cap_diff(diff: str) -> tuple[str, bool]:
+    """Cap the diff to DIFF_TOKEN_SUBCAP with a deterministic truncation marker."""
+    max_chars = DIFF_TOKEN_SUBCAP * _TOK
+    if len(diff) <= max_chars:
+        return diff, False
+    return diff[:max_chars] + "\n... [AIMEE_DIGEST_TRUNCATED]\n", True
+
+
+def build_digest(turn: WorkerTurn) -> Digest:
+    """Construct a hard-capped, leak-guarded digest from a worker turn (Q1). A rationale that
+    looks like raw source is DROPPED (recorded in rejected_fields); the diff is capped; tool-call
+    syntax is neutralized. The result is guaranteed <= DIGEST_TOKEN_CAP."""
+    rejected = []
+    diff, tdiff = _cap_diff(turn.unified_diff)
+    diff = neutralize_toolcalls(diff)
+    # The action_label/rationale are metadata; if the rationale smuggles source, drop it.
+    if turn.rationale and looks_like_source(turn.rationale):
+        rejected.append("rationale")
+    action = neutralize_toolcalls(turn.action_label)[:200]
+    d = Digest(worker_id=turn.worker_id, turn_index=turn.turn_index, state=turn.state.value,
+               action_label=action, verify=turn.verify.value, diff=diff,
+               files_touched=tuple(turn.files_touched), added=turn.added, deleted=turn.deleted,
+               truncated=tdiff, rejected_fields=tuple(rejected))
+    # Final hard cap: if still over budget, truncate the diff further, deterministically.
+    while d.tokens() > DIGEST_TOKEN_CAP and d.diff:
+        d.diff = d.diff[: max(0, len(d.diff) - 512)] + "\n... [AIMEE_DIGEST_TRUNCATED]\n"
+        d.truncated = True
+    return d
+
+
+def serialize_supervisor_frame(digests: list[Digest]) -> tuple[str, int]:
+    """Render the digests the supervisor sees, running a final source-leak gate over the whole
+    frame. Returns (frame_text, rejected_count). Any digest whose diff STILL trips the source
+    guard after capping is replaced with a metadata-only stub (belt-and-suspenders)."""
+    rejected = 0
+    parts = []
+    for d in digests:
+        body = d.diff
+        # A capped unified diff is allowed; but if it reads as bare source (no diff frame), stub it.
+        if body and looks_like_source(body) and not body.lstrip().startswith(("diff --git", "---", "+++", "@@")):
+            body = "[REJECTED: non-diff source-like content]"
+            rejected += 1
+        parts.append(f"[{d.worker_id} t{d.turn_index} {d.state}/{d.verify} "
+                     f"+{d.added}-{d.deleted} {d.action_label}]\n{body}")
+    return "\n\n".join(parts), rejected
+
+
+# ------------------------------------------------------------ selection --------
+@dataclass
+class Candidate:
+    worker_id: str
+    diff: str
+    verify: VerifyEnum
+    turns: int
+
+    @property
+    def diff_size(self) -> int:
+        return self.diff.count("\n")
+
+    @property
+    def is_valid(self) -> bool:
+        return bool(self.diff.strip()) and self.verify != VerifyEnum.ERROR
+
+
+def select_best_of_n(candidates: list[Candidate]) -> Candidate | None:
+    """Q3: a DETERMINISTIC pure selector (no LLM -> reproducible). Tie-break order:
+    (1) prefer verify PASS, (2) fewer turns, (3) smaller diff, (4) worker_id lexicographic.
+    Returns None (no-op empty patch) when no valid candidate exists."""
+    valid = [c for c in candidates if c.is_valid]
+    if not valid:
+        return None
+    return min(valid, key=lambda c: (0 if c.verify == VerifyEnum.PASS else 1,
+                                     c.turns, c.diff_size, c.worker_id))
+
+
+# selection-skill decomposition (Q3): oracle vs actual, over official-grader outcomes.
+def oracle_pass(candidate_resolved: dict[str, bool]) -> bool:
+    """oracle-best-of-N: success if ANY candidate patch passes the official grader."""
+    return any(candidate_resolved.values())
+
+
+def actual_pass(selected_worker: str | None, candidate_resolved: dict[str, bool]) -> bool:
+    """actual-best-of-N: the supervisor-SELECTED patch passes the official grader."""
+    return bool(selected_worker) and candidate_resolved.get(selected_worker, False)
+
+
+def selection_skill_ratio(actual_rate: float, oracle_rate: float) -> float | None:
+    """How much of the achievable (oracle) resolution the deterministic selector captured."""
+    return round(actual_rate / oracle_rate, 4) if oracle_rate else None
+
+
+# ------------------------------------------------------------ escalation -------
+class EscalationTrigger(str, Enum):
+    NONE = "none"
+    ALL_WORKERS_FAILED = "all_workers_failed"
+    STUCK = "stuck"
+
+
+@dataclass
+class EscalationState:
+    """Q2: gated, bounded, separately-attributed escalation. Tokens spent while escalated are
+    tracked so a run that leans on escalation (primary digging into code) is caught, not hidden."""
+    stuck_turns: int = 0
+    stuck_limit: int = 3
+    escalation_tokens: int = 0
+    escalations: int = 0
+
+    def should_escalate(self, *, all_failed: bool, made_progress: bool) -> EscalationTrigger:
+        if made_progress:
+            self.stuck_turns = 0
+        else:
+            self.stuck_turns += 1
+        if all_failed:
+            return EscalationTrigger.ALL_WORKERS_FAILED
+        if self.stuck_turns >= self.stuck_limit:
+            return EscalationTrigger.STUCK
+        return EscalationTrigger.NONE
+
+    def record_escalation(self, tokens: int) -> None:
+        self.escalations += 1
+        self.escalation_tokens += max(0, tokens)
+
+
+def is_escalation_dominated(escalation_tokens: int, primary_input_tokens: int) -> bool:
+    """Q2/R3: >40% of the primary's input from escalation => excluded from the headline."""
+    if primary_input_tokens <= 0:
+        return escalation_tokens > 0
+    return escalation_tokens / primary_input_tokens > ESCALATION_DOMINATED_FRAC
+
+
+# ------------------------------------------------------------ context window ---
+@dataclass
+class ContextWindow:
+    """Q4: sliding window of the last K digests + a deterministic fold-then-evict of older turns
+    to a one-line summary (worker set, files, terminal states, counts — NO quoted content), under
+    a hard total cap. Exposes the per-turn token curve so drift can't hide savings."""
+    k: int = WINDOW_K
+    total_cap: int = CONTEXT_TOTAL_CAP
+    _recent: list = field(default_factory=list)
+    _fold_workers: set = field(default_factory=set)
+    _fold_files: set = field(default_factory=set)
+    _fold_turns: int = 0
+    _fold_pass: int = 0
+    _fold_fail: int = 0
+    token_curve: list = field(default_factory=list)
+
+    def add(self, d: Digest) -> None:
+        self._recent.append(d)
+        while len(self._recent) > self.k:
+            self._evict(self._recent.pop(0))
+        self.token_curve.append(self.tokens())
+
+    def _evict(self, d: Digest) -> None:
+        self._fold_workers.add(d.worker_id)
+        self._fold_files.update(d.files_touched)
+        self._fold_turns += 1
+        if d.verify == VerifyEnum.PASS.value:
+            self._fold_pass += 1
+        elif d.verify == VerifyEnum.FAIL.value:
+            self._fold_fail += 1
+
+    def fold_summary(self) -> str:
+        if not self._fold_turns:
+            return ""
+        s = (f"[folded {self._fold_turns} turns | workers={sorted(self._fold_workers)} | "
+             f"files={sorted(self._fold_files)} | pass={self._fold_pass} fail={self._fold_fail}]")
+        return s[: FOLD_TOKEN_CAP * _TOK]
+
+    def tokens(self) -> int:
+        return est_tokens(self.fold_summary()) + sum(d.tokens() for d in self._recent)
+
+    def within_cap(self) -> bool:
+        return self.tokens() <= self.total_cap
+
+
+# ------------------------------------------------------------ redirect ---------
+@dataclass
+class RedirectBudget:
+    """Q5: default OFF. If enabled, bounded (<=1 per worker) and small (<=cap tokens), classified
+    through the same code-free guard, and attributed. Redirect tokens are PRIMARY tokens."""
+    enabled: bool = False
+    per_worker_max: int = 1
+    token_cap: int = 256
+    _used: dict = field(default_factory=dict)
+    redirect_tokens: int = 0
+
+    def allow(self, worker_id: str) -> bool:
+        return self.enabled and self._used.get(worker_id, 0) < self.per_worker_max
+
+    def record(self, worker_id: str, text: str) -> str:
+        """Record a redirect (capped, defanged); returns the sanitized message."""
+        msg = neutralize_toolcalls(text)[: self.token_cap * _TOK]
+        self._used[worker_id] = self._used.get(worker_id, 0) + 1
+        self.redirect_tokens += est_tokens(msg)
+        return msg
+
+
+# ------------------------------------------------------------ tool allowlist ---
+ARM_C_TOOL_ALLOWLIST = frozenset({
+    "delegate", "select_best_of_n", "log_escalation", "gated_escalate",
+    "terminate_worker", "inspect_digest_metadata", "summarize_fold", "redirect",
+})
+# code-reading tools are NOT here; they are only reachable via gated_escalate.
+_CODE_TOOLS = frozenset({"read_file", "bash", "grep", "cat", "open", "edit_file"})
+
+
+def tool_allowed(tool: str, *, escalated: bool = False) -> bool:
+    """A code-reading tool is permitted ONLY while an escalation is active (Q2)."""
+    if tool in ARM_C_TOOL_ALLOWLIST:
+        return True
+    if tool in _CODE_TOOLS:
+        return escalated
+    return False
+
+
+# ------------------------------------------------------------ live stub --------
+def run_arm_c_supervised(instance: dict, *, workers: list[str], n: int, redirect: bool = False):
+    raise NotImplementedError(
+        "live arm-C supervision loop not wired: dispatch N tools-enabled workers on isolated "
+        "workspaces (S1), build capped leak-guarded digests each turn (build_digest), keep the "
+        "supervisor context bounded (ContextWindow), select deterministically (select_best_of_n), "
+        "escalate only on the gated triggers, and read primary tokens via the S0 polarity + S2 "
+        "arm-runner accounting. The optional LLM-supervisor selection is a separate ablation.")

--- a/benchmarks/coding/swebench_transport_verify.py
+++ b/benchmarks/coding/swebench_transport_verify.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""S0 — transport verification matrix for the AGENTIC supervised SWE-bench benchmark.
+
+BLOCKING gate (proposal `docs/proposals/pending/agentic-supervised-swebench.md`, S0).
+Before any graded agentic run we must PROVE that, for the multi-turn agentic loop, the
+`token_audit` ledger attributes tokens correctly — otherwise the primary-token-reduction
+headline is measuring the wrong thing. Single-turn scoping (PR #986) is necessary but not
+sufficient once both arms run tool-using loops across many turns.
+
+The ledger's contract (`src/db1/token_audit.h`): a row's `delegation_id` is EMPTY for a
+primary-agent turn and NON-EMPTY for a delegate child; `session_id` is shared by parent and
+child; `tool_name` names the turn's tool; `cache_read_tokens`/`cache_write_tokens` split the
+prompt-cache. This module submits a KNOWN multi-turn agentic loop through each candidate
+primary transport, then asserts FIVE properties over the resulting rows (scoped by the run's
+session_id). A transport is only sanctioned for arms A/C if it passes ALL five; if none pass,
+`main()` exits non-zero — fail closed.
+
+The five assertions (map to the roundtable's B2 leak-list + the polarity check):
+  P1 primary_captured     — the primary's OWN turns land with delegation_id EMPTY, model=
+                            primary, usage_kind='realized', count >= expected primary turns
+                            (proves the multi-turn primary loop is measured at all).
+  P2 worker_attributed    — worker turns land with delegation_id NON-EMPTY (so they are
+                            excluded from the primary bill and priced $0).
+  P3 no_cross_bill        — a large worker return (>=5k tokens) does NOT inflate the primary's
+                            prompt_tokens (B2b: worker tool-result content billed to worker).
+  P4 cache_split          — cached vs uncached primary tokens are separable, so the headline
+                            can use UNCACHED tokens (B2a: cache re-reads must not skew A/C).
+  P5 primary_tools_billed — the primary's own tool turns (non-empty tool_name) carry
+                            delegation_id EMPTY, i.e. they are billed to the primary and can be
+                            allowlist-gated (B2c: primary-side tools must not bypass the split).
+
+The assertions are pure functions over row dicts so CI exercises them in FAKE mode with
+synthesized ledgers (AIMEE_BENCH_FAKE_AGENT=1); the live path fills the rows from a real
+`token_audit` after driving each transport against a running server (the .254 fleet).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+_FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
+
+# A worker return at/above this size is the "big return" probe for P3.
+_BIG_WORKER_RETURN_TOKENS = 5000
+# The primary's prompt for the probe task is small; if its prompt_tokens exceed this the
+# worker's return has leaked into the primary bill. Generous so a real short loop passes.
+_PRIMARY_PROMPT_CEILING = 2500
+
+
+# ------------------------------------------------------------ ledger rows -----
+def _row(model, delegation_id="", tool_name="", prompt=0, completion=0,
+         cache_read=0, cache_write=0, usage_kind="realized", session_id="s0"):
+    """One token_audit row as a dict (the shape both the live query and FAKE mode produce)."""
+    return {"model": model, "delegation_id": delegation_id or "", "tool_name": tool_name or "",
+            "prompt_tokens": prompt, "completion_tokens": completion,
+            "cache_read_tokens": cache_read, "cache_write_tokens": cache_write,
+            "usage_kind": usage_kind, "session_id": session_id}
+
+
+def _primary_rows(rows, primary_model):
+    """Realized primary turns: delegation_id EMPTY (the ledger's primary-agent marker)."""
+    return [r for r in rows if r["model"] == primary_model
+            and not r["delegation_id"] and r["usage_kind"] == "realized"]
+
+
+def _worker_rows(rows):
+    """Realized delegate turns: delegation_id NON-EMPTY."""
+    return [r for r in rows if r["delegation_id"] and r["usage_kind"] == "realized"]
+
+
+# ------------------------------------------------------------ assertions ------
+# Each returns (ok: bool, detail: str). Pure — unit-tested without a server.
+def assert_primary_captured(rows, primary_model, min_turns) -> tuple[bool, str]:
+    pr = _primary_rows(rows, primary_model)
+    n = len(pr)
+    ok = n >= min_turns and any(r["completion_tokens"] > 0 for r in pr)
+    return ok, f"{n} primary (delegation_id EMPTY) realized turns; need >= {min_turns} with output"
+
+
+def assert_worker_attributed(rows, primary_model) -> tuple[bool, str]:
+    wr = _worker_rows(rows)
+    # Worker turns must exist AND none may be billed under the primary model with EMPTY
+    # delegation_id (that would be cross-attribution).
+    stray = [r for r in wr if r["model"] == primary_model]
+    ok = len(wr) >= 1 and not stray
+    return ok, (f"{len(wr)} worker (delegation_id NON-EMPTY) turns"
+                + (f"; {len(stray)} billed under primary model!" if stray else ""))
+
+
+def assert_no_cross_bill(rows, primary_model, big_return_tokens) -> tuple[bool, str]:
+    pr = _primary_rows(rows, primary_model)
+    max_primary_prompt = max((r["prompt_tokens"] for r in pr), default=0)
+    # If a >=5k worker return had leaked into the primary's context bill, the primary's
+    # per-turn prompt would jump by roughly big_return_tokens. It must stay under the ceiling.
+    ok = big_return_tokens >= _BIG_WORKER_RETURN_TOKENS and max_primary_prompt <= _PRIMARY_PROMPT_CEILING
+    return ok, (f"max primary prompt_tokens={max_primary_prompt} (ceiling {_PRIMARY_PROMPT_CEILING}); "
+                f"worker return was {big_return_tokens} tok")
+
+
+def assert_cache_split(rows, primary_model) -> tuple[bool, str]:
+    pr = _primary_rows(rows, primary_model)
+    cache_read = sum(r["cache_read_tokens"] for r in pr)
+    prompt = sum(r["prompt_tokens"] for r in pr)
+    # The columns must be present and the uncached headline (prompt - cache_read) must be
+    # computable and non-negative. A multi-turn primary re-reads context, so >0 cache_read
+    # is expected; we require the split to be SEPARABLE, not a specific hit rate.
+    uncached = prompt - cache_read
+    ok = all("cache_read_tokens" in r and "cache_write_tokens" in r for r in pr) and uncached >= 0
+    return ok, f"prompt={prompt} cache_read={cache_read} -> uncached headline={uncached}"
+
+
+def assert_primary_tools_billed(rows, primary_model) -> tuple[bool, str]:
+    tool_rows = [r for r in rows if r["tool_name"] and r["usage_kind"] == "realized"
+                 and r["model"] == primary_model]
+    # A primary-side tool turn MUST carry delegation_id EMPTY (billed to primary). Any
+    # primary-model tool turn with a NON-EMPTY delegation_id is a bypass of the split.
+    bypass = [r for r in tool_rows if r["delegation_id"]]
+    ok = len(tool_rows) >= 1 and not bypass
+    return ok, (f"{len(tool_rows)} primary tool turns"
+                + (f"; {len(bypass)} bypass the split (non-empty delegation_id)!" if bypass else ""))
+
+
+def verify_rows(rows, primary_model, expected_primary_turns, big_return_tokens) -> dict:
+    """Run all five assertions; return {name: {ok, detail}} plus an overall `passed`."""
+    checks = {
+        "P1_primary_captured": assert_primary_captured(rows, primary_model, expected_primary_turns),
+        "P2_worker_attributed": assert_worker_attributed(rows, primary_model),
+        "P3_no_cross_bill": assert_no_cross_bill(rows, primary_model, big_return_tokens),
+        "P4_cache_split": assert_cache_split(rows, primary_model),
+        "P5_primary_tools_billed": assert_primary_tools_billed(rows, primary_model),
+    }
+    out = {k: {"ok": ok, "detail": d} for k, (ok, d) in checks.items()}
+    out["passed"] = all(v["ok"] for v in out.values())
+    return out
+
+
+# ------------------------------------------------------------ live probe ------
+@dataclass
+class TransportProbe:
+    """A candidate primary transport and how to drive a short multi-turn agentic loop
+    through it. `invoke` returns the run's session_id (all turns share it)."""
+    name: str
+    invoke: Callable[["ProbeCtx"], str]
+    expected_primary_turns: int = 2
+
+
+@dataclass
+class ProbeCtx:
+    aimee_bin: str
+    worker: str
+    workdir: str
+    big_return_tokens: int = _BIG_WORKER_RETURN_TOKENS
+    extra: dict = field(default_factory=dict)
+
+
+# --- LIVE TRANSPORT WIRING IS PENDING (resolved against the running server) -------------
+# The five assertions above + their FAKE-mode tests are the CI-ready deliverable of S0.
+# Driving a real multi-turn agentic loop is the part that genuinely needs the .254 server,
+# and the entrypoint is NOT a CLI subcommand: `/v1/runs` is an OpenAI-compatible HTTP route
+# (see src/cli_v1_routes.c, test_openai_runs_store.c), and "agent_shell" is a server-side
+# execution mode, not `aimee run`. Rather than call a phantom CLI, each probe raises a
+# descriptive error so `run_matrix` records an honest FAIL with the exact wiring to do next.
+# When the live transport lands, replace the body with the real HTTP submit + poll and
+# return the run's session_id (all turns share it). The task must force >=2 primary turns
+# and one delegated worker turn whose return is padded to `big_return_tokens` (the P3 probe).
+_PROBE_TASK = ("Read PROBE.txt, delegate a summary of it to a worker, then write the "
+               "length of the worker's reply into PROBE_OUT.txt. Use tools.")
+
+
+def _invoke_v1_runs(ctx: ProbeCtx) -> str:
+    raise NotImplementedError(
+        "live /v1/runs probe not wired: POST an agentic run to /v1/runs on the server, poll "
+        "to completion, return its session_id. Task: " + _PROBE_TASK)
+
+
+def _invoke_agent_shell(ctx: ProbeCtx) -> str:
+    raise NotImplementedError(
+        "live agent_shell probe not wired: submit the probe task via the server-side "
+        "agent_shell execution mode and return its session_id. Task: " + _PROBE_TASK)
+
+
+DEFAULT_PROBES = [
+    TransportProbe("v1_runs", _invoke_v1_runs),
+    TransportProbe("agent_shell", _invoke_agent_shell),
+]
+
+
+_COLS = ("model", "delegation_id", "tool_name", "prompt_tokens", "completion_tokens",
+         "cache_read_tokens", "cache_write_tokens", "usage_kind", "session_id")
+
+
+def collect_rows(db: str, session_id: str) -> list[dict]:
+    """Read all token_audit rows for one run (scoped by the shared session_id)."""
+    if not db or not Path(db).exists() or not session_id:
+        return []
+    con = sqlite3.connect(db)
+    con.row_factory = sqlite3.Row
+    q = f"SELECT {', '.join(_COLS)} FROM token_audit WHERE session_id=?"
+    return [dict(r) for r in con.execute(q, (session_id,)).fetchall()]
+
+
+# ------------------------------------------------------------ fake ledgers ----
+def _fake_rows(scenario: str, primary="gpt-5.5", worker="glm-5.2"):
+    """Synthesize a token_audit for CI. 'pass' satisfies all five; the others each break
+    exactly one assertion so the tests prove the checks actually catch regressions."""
+    did = "deleg-1-1730000000-job42"
+    ok = [
+        _row(primary, prompt=800, completion=120, cache_read=200, tool_name="read_file"),
+        _row(primary, prompt=1400, completion=90, cache_read=600, tool_name="apply_patch"),
+        _row(worker, delegation_id=did, prompt=1200, completion=_BIG_WORKER_RETURN_TOKENS),
+    ]
+    if scenario == "pass":
+        return ok
+    if scenario == "no_primary":            # breaks P1
+        return [r for r in ok if r["model"] != primary]
+    if scenario == "no_worker":             # breaks P2
+        return [r for r in ok if not r["delegation_id"]]
+    if scenario == "worker_under_primary":  # breaks P2 (stray primary-model delegate)
+        return ok + [_row(primary, delegation_id=did, prompt=10, completion=10)]
+    if scenario == "cross_bill":            # breaks P3 (worker return leaked into primary)
+        return [_row(primary, prompt=_PRIMARY_PROMPT_CEILING + _BIG_WORKER_RETURN_TOKENS,
+                     completion=120, tool_name="read_file")] + ok[1:]
+    if scenario == "tool_bypass":           # breaks P5 (primary tool turn with delegation_id)
+        return [_row(primary, delegation_id=did, tool_name="bash", prompt=50, completion=5)] + ok
+    raise ValueError(scenario)
+
+
+# ------------------------------------------------------------ matrix ----------
+def run_matrix(db, primary_model, probes, ctx: ProbeCtx) -> dict:
+    results = {}
+    for pr in probes:
+        try:
+            sid = pr.invoke(ctx)
+            rows = collect_rows(db, sid)
+            v = verify_rows(rows, primary_model, pr.expected_primary_turns, ctx.big_return_tokens)
+            v["session_id"] = sid
+            v["n_rows"] = len(rows)
+        except Exception as e:  # a transport that errors is a FAIL, not a crash
+            v = {"passed": False, "error": f"{type(e).__name__}: {e}"}
+        results[pr.name] = v
+    return results
+
+
+def render(results: dict) -> str:
+    lines = ["transport verification matrix (S0):"]
+    for name, v in results.items():
+        verdict = "PASS" if v.get("passed") else "FAIL"
+        lines.append(f"  [{verdict}] {name}" + (f"  ({v['error']})" if v.get("error") else ""))
+        for k in ("P1_primary_captured", "P2_worker_attributed", "P3_no_cross_bill",
+                  "P4_cache_split", "P5_primary_tools_billed"):
+            if k in v:
+                mark = "ok" if v[k]["ok"] else "XX"
+                lines.append(f"      {mark} {k}: {v[k]['detail']}")
+    sanctioned = [n for n, v in results.items() if v.get("passed")]
+    lines.append(f"sanctioned transports: {sanctioned or 'NONE — blocked'}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="S0 transport verification matrix")
+    ap.add_argument("--token-db", default=os.environ.get("AIMEE_DB", ""))
+    ap.add_argument("--primary-model", default=os.environ.get("AIMEE_BENCH_PRIMARY_MODEL", "gpt-5.5"))
+    ap.add_argument("--worker", default=os.environ.get("AIMEE_BENCH_POOL", "glm-5.2").split(",")[0])
+    ap.add_argument("--aimee-bin", default=os.environ.get("AIMEE_BENCH_CLIENT", "./aimee"))
+    ap.add_argument("--workdir", default=".")
+    ap.add_argument("--output", default="")
+    args = ap.parse_args()
+
+    if _FAKE:
+        results = {p.name: {**verify_rows(_fake_rows("pass", args.primary_model, args.worker),
+                                          args.primary_model, p.expected_primary_turns,
+                                          _BIG_WORKER_RETURN_TOKENS),
+                            "session_id": "fake", "n_rows": 3} for p in DEFAULT_PROBES}
+    else:
+        if not args.token_db:
+            raise SystemExit("--token-db is required for the live matrix")
+        ctx = ProbeCtx(args.aimee_bin, args.worker, args.workdir)
+        results = run_matrix(args.token_db, args.primary_model, DEFAULT_PROBES, ctx)
+
+    print(render(results), file=sys.stderr)
+    if args.output:
+        Path(args.output).write_text(json.dumps(results, indent=2))
+    # Fail closed: exit non-zero unless at least one transport passes ALL assertions.
+    if not any(v.get("passed") for v in results.values()):
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/tests/test_supervised_report_panels.py
+++ b/benchmarks/tests/test_supervised_report_panels.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Unit tests for S4 — the supervised-report panels.
+
+Pure, deterministic. Covers BCa CI, Pareto dominance, failure-mode counts, selection-skill
+oracle-vs-actual, escalation exclusion, context-drift distribution, two-wall-clock, and the
+Q6 arm-parity invariants.
+Run: python3 -m unittest benchmarks.tests.test_supervised_report_panels
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import supervised_report_panels as P
+
+
+class TestBCaCI(unittest.TestCase):
+    def test_brackets_the_mean(self):
+        vals = [10, 12, 9, 11, 13, 8, 10, 12]
+        lo, hi = P.bca_ci(vals)
+        mean = sum(vals) / len(vals)
+        self.assertLessEqual(lo, mean)
+        self.assertGreaterEqual(hi, mean)
+
+    def test_deterministic(self):
+        vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+        self.assertEqual(P.bca_ci(vals), P.bca_ci(vals))
+
+    def test_degenerate_all_equal(self):
+        lo, hi = P.bca_ci([5.0, 5.0, 5.0, 5.0])
+        self.assertEqual((lo, hi), (5.0, 5.0))
+
+    def test_single_value(self):
+        self.assertEqual(P.bca_ci([7.0]), (7.0, 7.0))
+
+
+class TestNormPpf(unittest.TestCase):
+    def test_median_is_zero(self):
+        self.assertAlmostEqual(P._norm_ppf(0.5), 0.0, places=6)
+
+    def test_symmetry(self):
+        self.assertAlmostEqual(P._norm_ppf(0.975), -P._norm_ppf(0.025), places=4)
+        self.assertAlmostEqual(P._norm_ppf(0.975), 1.959964, places=4)
+
+
+class TestPareto(unittest.TestCase):
+    def test_frontier_excludes_dominated(self):
+        configs = [
+            {"name": "cheap_fast_good", "primary_tokens": 100, "wall_p95": 10, "resolve_rate": 0.9},
+            {"name": "dominated", "primary_tokens": 200, "wall_p95": 20, "resolve_rate": 0.5},
+            {"name": "tradeoff", "primary_tokens": 50, "wall_p95": 30, "resolve_rate": 0.95},
+        ]
+        out = P.pareto_panel(configs)
+        self.assertIn("cheap_fast_good", out["frontier"])
+        self.assertIn("tradeoff", out["frontier"])
+        self.assertNotIn("dominated", out["frontier"])
+
+    def test_dominated_records_its_dominator(self):
+        configs = [
+            {"name": "good", "primary_tokens": 100, "wall_p95": 10, "resolve_rate": 0.9},
+            {"name": "bad", "primary_tokens": 200, "wall_p95": 20, "resolve_rate": 0.5},
+        ]
+        out = P.pareto_panel(configs)
+        bad = next(c for c in out["configs"] if c["name"] == "bad")
+        self.assertEqual(bad["dominated_by"], ["good"])
+
+
+class TestFailureModes(unittest.TestCase):
+    def test_counts_by_arm_and_mode(self):
+        recs = [
+            {"arm": "C", "resolved": True},
+            {"arm": "C", "resolved": False, "failure_mode": "worker_dropout"},
+            {"arm": "C", "resolved": False, "failure_mode": "mis_selection"},
+            {"arm": "A", "resolved": True},
+        ]
+        out = P.failure_mode_breakdown(recs)
+        self.assertEqual(out["C"]["ok"], 1)
+        self.assertEqual(out["C"]["worker_dropout"], 1)
+        self.assertEqual(out["C"]["mis_selection"], 1)
+        self.assertEqual(out["A"]["ok"], 1)
+
+
+class TestSelectionSkill(unittest.TestCase):
+    def test_oracle_actual_and_ratio(self):
+        recs = [
+            {"arm": "C", "oracle_resolved": True, "actual_resolved": True},
+            {"arm": "C", "oracle_resolved": True, "actual_resolved": False},  # recoverable miss
+            {"arm": "C", "oracle_resolved": False, "actual_resolved": False},
+            {"arm": "C", "oracle_resolved": True, "actual_resolved": True},
+        ]
+        out = P.selection_skill(recs)
+        self.assertEqual(out["oracle_pass_rate"], 0.75)   # 3/4
+        self.assertEqual(out["actual_pass_rate"], 0.5)    # 2/4
+        self.assertEqual(out["selection_skill_ratio"], round(0.5 / 0.75, 4))
+        self.assertEqual(out["recoverable_gap"], 1)
+
+    def test_no_decomposition_records(self):
+        self.assertEqual(P.selection_skill([{"arm": "C"}])["n"], 0)
+
+
+class TestEscalationSplit(unittest.TestCase):
+    def test_excludes_dominated_from_headline(self):
+        recs = [
+            {"arm": "C", "instance_id": "i1"},
+            {"arm": "C", "instance_id": "i2", "escalation_dominated": True},
+            {"arm": "C", "instance_id": "i3"},
+        ]
+        out = P.escalation_split(recs)
+        self.assertEqual(out["headline_n"], 2)
+        self.assertEqual(out["escalation_dominated_n"], 1)
+        self.assertEqual(out["escalation_dominated"], ["i2"])
+
+
+class TestContextDrift(unittest.TestCase):
+    def test_peak_and_curve(self):
+        recs = [
+            {"arm": "C", "primary_context_tokens": 8000, "primary_tokens_by_turn": [100, 200, 300]},
+            {"arm": "C", "primary_context_tokens": 12000, "primary_tokens_by_turn": [150, 250]},
+        ]
+        out = P.context_size_distribution(recs)
+        self.assertEqual(out["peak_context"]["n"], 2)
+        self.assertEqual(out["peak_context"]["max"], 12000)
+        self.assertEqual(out["mean_tokens_by_turn"][0], 125.0)   # (100+150)/2
+        self.assertEqual(out["mean_tokens_by_turn"][2], 300.0)   # only first record has turn 3
+
+
+class TestWallTwoClock(unittest.TestCase):
+    def test_total_and_work_separate(self):
+        recs = [{"arm": "C", "wall_s": 30.0, "wall_work_s": 28.0},
+                {"arm": "C", "wall_s": 40.0, "wall_work_s": 35.0}]
+        out = P.wall_two_clock(recs, "C")
+        self.assertEqual(out["total"]["n"], 2)
+        self.assertEqual(out["work"]["max"], 35.0)
+        self.assertLessEqual(out["work"]["p95"], out["total"]["p95"] + 1)
+
+
+class TestArmParity(unittest.TestCase):
+    def _a(self, **kw):
+        base = {"supervisor_input_tokens": 100000, "supervisor_output_tokens": 4000,
+                "worker_input_tokens": 0, "worker_output_tokens": 0,
+                "patch_fingerprint": "abc", "resolved": True}
+        base.update(kw)
+        return base
+
+    def _c(self, **kw):
+        base = {"supervisor_input_tokens": 800, "supervisor_output_tokens": 100,
+                "patch_fingerprint": "abc", "resolved": True, "escalations": 0}
+        base.update(kw)
+        return base
+
+    def test_parity_all_pass_on_trivial(self):
+        inv = P.check_arm_parity(self._a(), self._c())
+        self.assertTrue(inv["all_pass"], inv)
+
+    def test_different_patch_fails(self):
+        inv = P.check_arm_parity(self._a(patch_fingerprint="x"), self._c(patch_fingerprint="y"))
+        self.assertFalse(inv["same_patch"])
+        self.assertFalse(inv["all_pass"])
+
+    def test_c_not_cheaper_fails(self):
+        # C primary spend not an order of magnitude below A total
+        inv = P.check_arm_parity(self._a(), self._c(supervisor_input_tokens=90000))
+        self.assertFalse(inv["c_primary_much_cheaper"])
+
+    def test_escalation_on_trivial_fails(self):
+        inv = P.check_arm_parity(self._a(), self._c(escalations=1))
+        self.assertFalse(inv["no_escalation_on_trivial"])
+
+
+class TestAugment(unittest.TestCase):
+    def test_attaches_panels(self):
+        recs = [{"arm": "C", "instance_id": "i1", "wall_s": 10.0, "resolved": True}]
+        rep = P.augment_report({"base": 1}, recs)
+        for k in ("failure_modes", "selection_skill", "escalation", "context_drift",
+                  "wall_two_clock"):
+            self.assertIn(k, rep)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_swebench_agentic_harness.py
+++ b/benchmarks/tests/test_swebench_agentic_harness.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Unit tests for S1 — the per-worker agentic harness pure core.
+
+No live server, docker, or network: provisioning + patch extraction run against a local temp
+git fixture; the resource table, secret scan, and loop bounds are pure. Mirrors S0's strictness
+— every reproducibility-critical behaviour has a test, and the roundtable's Q5 hygiene rulings
+are each pinned by a case.
+Run: python3 -m unittest benchmarks.tests.test_swebench_agentic_harness
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_agentic_harness as H
+
+
+def _git(cwd, *args):
+    return subprocess.run(["git", "-C", str(cwd), *args], check=True,
+                          capture_output=True, text=True)
+
+
+def _make_repo(root: Path) -> str:
+    """A tiny git repo with one tracked file + a .gitignore, committed. Returns base_commit."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+    (root / "mod.py").write_text("def f():\n    return 1\n")
+    (root / ".gitignore").write_text("build/\n*.pyc\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "base")
+    return _git(root, "rev-parse", "HEAD").stdout.strip()
+
+
+class TestEnvAllocator(unittest.TestCase):
+    def test_deterministic_same_key_same_env(self):
+        a = H.EnvAllocator("/r")
+        e1 = a.allocate("inst", "C", 0)
+        e2 = a.allocate("inst", "C", 0)
+        self.assertEqual(e1, e2)
+
+    def test_port_ranges_non_overlapping(self):
+        a = H.EnvAllocator("/r")
+        for i in range(5):
+            a.allocate("inst", "C", i)
+        ranges = a.port_ranges()
+        for (s1, e1), (s2, e2) in zip(ranges, ranges[1:]):
+            self.assertLess(e1, s2, f"ranges overlap: {(s1,e1)} vs {(s2,e2)}")
+
+    def test_release_frees_slot_for_reuse(self):
+        a = H.EnvAllocator("/r", max_workers=2)
+        a.allocate("i", "C", 0)
+        a.allocate("i", "C", 1)
+        with self.assertRaises(RuntimeError):
+            a.allocate("i", "C", 2)  # pool exhausted
+        a.release("i", "C", 0)
+        # now a fresh key can be allocated again
+        e = a.allocate("i", "C", 2)
+        self.assertIsInstance(e, H.WorkerEnv)
+
+    def test_env_dict_isolates_home_tmp_cache(self):
+        e = H.EnvAllocator("/r").allocate("i", "A", 0)
+        env = e.env()
+        self.assertTrue(env["TMPDIR"].endswith("tmp"))
+        self.assertEqual(env["XDG_CACHE_HOME"], env["PIP_CACHE_DIR"])
+        self.assertNotEqual(env["HOME"], env["TMPDIR"])
+
+
+class TestResolveTestCommand(unittest.TestCase):
+    def test_known_repos(self):
+        self.assertIn("runtests.py", H.resolve_test_command("django/django"))
+        self.assertIn("pytest", H.resolve_test_command("sympy/sympy"))
+
+    def test_unknown_repo_is_none(self):
+        self.assertIsNone(H.resolve_test_command("acme/widget"))
+
+
+class TestProvisionAndPatch(unittest.TestCase):
+    def test_provision_checks_out_base_commit_detached(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            base = _make_repo(root / "repo")
+            ws = H.provision_workspace(str(root / "repo"), base, str(root / "ws"))
+            head = _git(ws, "rev-parse", "HEAD").stdout.strip()
+            self.assertEqual(head, base)
+
+    def test_patch_includes_new_untracked_source_excludes_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            base = _make_repo(root / "repo")
+            ws = H.provision_workspace(str(root / "repo"), base, str(root / "ws"))
+            # agent edits tracked file, creates a NEW source file, and a build artifact (ignored)
+            (Path(ws) / "mod.py").write_text("def f():\n    return 2\n")
+            (Path(ws) / "new_mod.py").write_text("X = 1\n")
+            (Path(ws) / "build").mkdir()
+            (Path(ws) / "build" / "junk.o").write_text("artifact")
+            patch, n = H.extract_patch(ws, base)
+            self.assertIn("mod.py", patch)
+            self.assertIn("new_mod.py", patch)      # new source IS in the patch
+            self.assertNotIn("junk.o", patch)       # ignored artifact is NOT
+            self.assertIn("return 2", patch)
+
+    def test_patch_is_deterministic(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            base = _make_repo(root / "repo")
+            ws = H.provision_workspace(str(root / "repo"), base, str(root / "ws"))
+            (Path(ws) / "mod.py").write_text("def f():\n    return 2\n")
+            p1, _ = H.extract_patch(ws, base)
+            p2, _ = H.extract_patch(ws, base)
+            self.assertEqual(p1, p2)
+
+    def test_in_loop_commit_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            base = _make_repo(root / "repo")
+            ws = H.provision_workspace(str(root / "repo"), base, str(root / "ws"))
+            (Path(ws) / "mod.py").write_text("def f():\n    return 2\n")
+            _git(ws, "add", "-A")
+            _git(ws, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "oops")
+            with self.assertRaises(H.PatchError):
+                H.extract_patch(ws, base)
+
+    def test_submodule_repo_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            _make_repo(root / "repo")
+            (root / "repo" / ".gitmodules").write_text("[submodule \"x\"]\n")
+            with self.assertRaises(H.ProvisionError):
+                H.provision_workspace(str(root / "repo"), "HEAD", str(root / "ws"))
+
+
+class TestSecretScan(unittest.TestCase):
+    def test_redacts_aws_and_private_key(self):
+        text = ("+AKIAIOSFODNN7EXAMPLE\n"
+                "+-----BEGIN RSA PRIVATE KEY-----\n")
+        out, n = H.scan_and_redact_secrets(text)
+        self.assertGreaterEqual(n, 2)
+        self.assertNotIn("AKIAIOSFODNN7EXAMPLE", out)
+        self.assertIn(H._REDACTED, out)
+
+    def test_redacts_high_entropy_assignment(self):
+        out, n = H.scan_and_redact_secrets('api_key = "aB3xZ9qL7mN2pQ8rT5vW"\n')
+        self.assertEqual(n, 1)
+        self.assertNotIn("aB3xZ9qL7mN2pQ8rT5vW", out)
+
+    def test_leaves_ordinary_code_alone(self):
+        code = "def total(items):\n    return sum(items)\n"
+        out, n = H.scan_and_redact_secrets(code)
+        self.assertEqual(n, 0)
+        self.assertEqual(out, code)
+
+    def test_redaction_is_stable_byte_for_byte(self):
+        text = "+token = 'aB3xZ9qL7mN2pQ8rT5vW'\n"
+        self.assertEqual(H.scan_and_redact_secrets(text), H.scan_and_redact_secrets(text))
+
+
+class TestLoopBudget(unittest.TestCase):
+    def test_stops_on_verify_pass(self):
+        b = H.LoopBudget()
+        self.assertFalse(b.should_continue(turns=1, wall_s=1, usd=0, verify_passed=True))
+        self.assertEqual(b.stop_reason(turns=1, wall_s=1, usd=0, verify_passed=True), "verify_passed")
+
+    def test_stops_on_max_turns(self):
+        b = H.LoopBudget(max_turns=3)
+        self.assertFalse(b.should_continue(turns=3, wall_s=1, usd=0, verify_passed=False))
+        self.assertEqual(b.stop_reason(turns=3, wall_s=1, usd=0, verify_passed=False), "max_turns")
+
+    def test_continues_within_bounds(self):
+        b = H.LoopBudget(max_turns=5, max_wall_s=100, max_usd=1)
+        self.assertTrue(b.should_continue(turns=2, wall_s=10, usd=0.1, verify_passed=False))
+
+
+class TestFingerprint(unittest.TestCase):
+    def test_same_inputs_same_id(self):
+        a = H.workspace_fingerprint("r", "c0ffee", "patch body")
+        b = H.workspace_fingerprint("r", "c0ffee", "patch body")
+        self.assertEqual(a, b)
+
+    def test_different_patch_different_id(self):
+        self.assertNotEqual(H.workspace_fingerprint("r", "c", "x"),
+                            H.workspace_fingerprint("r", "c", "y"))
+
+
+class TestLiveStubHonesty(unittest.TestCase):
+    def test_run_agentic_loop_is_marked_stub(self):
+        with self.assertRaises(NotImplementedError):
+            H.run_agentic_loop({}, H.EnvAllocator("/r").allocate("i", "A", 0),
+                               H.LoopBudget(), arm="A")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_swebench_arm_runner.py
+++ b/benchmarks/tests/test_swebench_arm_runner.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Unit tests for S2 — the arm-A runner's pure measurement surface.
+
+No live server/docker/network: token totals over synthesized ledgers, wall-clock decomposition,
+and record-schema conformance (the record must be consumable by supervised_report.build_report).
+Run: python3 -m unittest benchmarks.tests.test_swebench_arm_runner
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_arm_runner as R
+from benchmarks.coding import swebench_transport_verify as V
+from benchmarks.coding import supervised_report as REP
+
+PRIMARY = "gpt-5.5"
+
+
+class TestPrimaryTokenTotals(unittest.TestCase):
+    def test_headline_is_uncached_input_plus_output(self):
+        rows = [V._row(PRIMARY, prompt=1000, completion=100, cache_read=300),
+                V._row(PRIMARY, prompt=500, completion=50, cache_read=100)]
+        t = R.primary_token_totals(rows, PRIMARY)
+        self.assertEqual(t.input_uncached, 1500 - 400)   # 1100
+        self.assertEqual(t.input_cached, 400)
+        self.assertEqual(t.output, 150)
+        self.assertEqual(t.total_headline, 1100 + 150)
+        self.assertEqual(t.turns, 2)
+
+    def test_cached_excluded_from_headline(self):
+        # A turn that is ALL cache-read (a re-read) adds nothing to the uncached headline.
+        rows = [V._row(PRIMARY, prompt=800, completion=0, cache_read=800)]
+        t = R.primary_token_totals(rows, PRIMARY)
+        self.assertEqual(t.input_uncached, 0)
+        self.assertEqual(t.input_cached, 800)
+
+    def test_worker_rows_excluded_from_primary(self):
+        rows = V._fake_rows("pass", PRIMARY, "glm-5.2")
+        t = R.primary_token_totals(rows, PRIMARY)
+        wi, wo = R.worker_token_totals(rows)
+        # worker return of 5000 tokens must land in worker totals, not primary
+        self.assertGreaterEqual(wo, V._BIG_WORKER_RETURN_TOKENS)
+        self.assertNotIn(V._BIG_WORKER_RETURN_TOKENS, (t.output,))
+
+    def test_thinking_is_none_until_ledger_carries_it(self):
+        rows = [V._row(PRIMARY, prompt=10, completion=5)]
+        self.assertIsNone(R.primary_token_totals(rows, PRIMARY).thinking)
+
+
+class TestWallClock(unittest.TestCase):
+    def test_total_work_queue_decomposition(self):
+        w = R.WallClock(t0=100.0, first_work=103.0, t1=115.0)
+        self.assertEqual(w.total_s, 15.0)
+        self.assertEqual(w.work_s, 12.0)
+        self.assertEqual(w.queue_s, 3.0)
+
+    def test_queue_plus_work_equals_total(self):
+        w = R.WallClock(t0=0.0, first_work=2.5, t1=20.0)
+        self.assertAlmostEqual(w.queue_s + w.work_s, w.total_s)
+
+    def test_negative_clamped(self):
+        w = R.WallClock(t0=10.0, first_work=5.0, t1=8.0)
+        self.assertGreaterEqual(w.queue_s, 0.0)
+        self.assertGreaterEqual(w.work_s, 0.0)
+
+
+class TestArmRecordSchema(unittest.TestCase):
+    def _rec(self):
+        tok = R.PrimaryTokens(input_uncached=1000, input_cached=200, output=100, turns=3)
+        wall = R.WallClock(t0=0.0, first_work=1.0, t1=30.0)
+        return R.build_arm_record("inst-1", "A", PRIMARY, tokens=tok, worker_in=0, worker_out=0,
+                                  wall=wall, resolved=True, patch="diff\n", base_commit="c0ffee",
+                                  repo="x/y")
+
+    def test_has_all_report_schema_keys(self):
+        rec = self._rec()
+        for k in ("instance_id", "arm", "compaction", "supervisor_input_tokens",
+                  "supervisor_output_tokens", "worker_input_tokens", "worker_output_tokens",
+                  "wall_s", "resolved", "n_workers", "invalid"):
+            self.assertIn(k, rec)
+
+    def test_headline_input_is_uncached(self):
+        rec = self._rec()
+        self.assertEqual(rec["supervisor_input_tokens"], 1000)         # uncached only
+        self.assertEqual(rec["supervisor_input_cached_tokens"], 200)
+
+    def test_consumable_by_build_report(self):
+        # The whole point: a record produced here must flow through the report unchanged.
+        rec = self._rec()
+        rep = REP.build_report([rec], compaction=False)
+        # wall-clock summary picked the record up (median/p95 computed from wall_s)
+        self.assertEqual(rep["wall_clock"]["A"]["n"], 1)
+        self.assertEqual(rep["wall_clock"]["A"]["p95_s"], 30.0)
+        # resolution picked the graded record up
+        self.assertEqual(rep["resolution"]["A"]["resolved"], 1)
+
+    def test_two_wall_clocks_present(self):
+        rec = self._rec()
+        self.assertEqual(rec["wall_s"], 30.0)
+        self.assertEqual(rec["wall_work_s"], 29.0)
+        self.assertEqual(rec["wall_queue_s"], 1.0)
+
+
+class TestFakeMode(unittest.TestCase):
+    def test_fake_record_is_schema_valid(self):
+        inst = {"instance_id": "inst-0", "repo": "x/y", "base_commit": "0" * 40}
+        rec = R._fake_arm_a_record(inst, PRIMARY)
+        self.assertEqual(rec["arm"], "A")
+        self.assertEqual(rec["instance_id"], "inst-0")
+        self.assertIn("patch_fingerprint", rec)
+
+
+class TestLiveStubHonesty(unittest.TestCase):
+    def test_run_arm_a_live_is_marked_stub(self):
+        inst = {"instance_id": "i", "repo": "x/y", "base_commit": "0" * 40}
+        with self.assertRaises(NotImplementedError):
+            R.run_arm_a(inst, PRIMARY, token_db="/x", base_repo="/y",
+                        allocator=None, budget=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_swebench_claim_gate.py
+++ b/benchmarks/tests/test_swebench_claim_gate.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Unit tests for S6 — the fail-closed public-claim gate.
+
+Pure. The gate must EMIT only when every criterion holds on BOTH benchmarks with an independent
+review, and must WITHHOLD (fail closed) on any single unmet criterion — while always producing an
+honest summary. Each criterion has a case that breaks it in isolation.
+Run: python3 -m unittest benchmarks.tests.test_swebench_claim_gate
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_claim_gate as G
+from benchmarks.coding.swebench_claim_gate import BenchmarkMetrics as M
+
+
+def _good(name, **kw):
+    base = dict(name=name, token_reduction_ci=(0.60, 0.72), wall_p95_ratio_ci=(0.7, 0.95),
+                resolved_c=8, resolved_a=9, total=10, k=10, escalation_excluded_frac=0.1,
+                n_anchor=1)
+    base.update(kw)
+    return M(**base)
+
+
+class TestPasses(unittest.TestCase):
+    def test_emits_when_all_hold(self):
+        d = G.evaluate_claim_gate(_good("b1"), _good("b2", k=3), independent_review=True)
+        self.assertTrue(d["emit_claim"], d["withheld_reasons"])
+        self.assertIn("Beats Reddit", d["summary"])
+
+
+class TestFailClosedPerCriterion(unittest.TestCase):
+    def test_token_ci_lo_not_positive_withholds(self):
+        d = G.evaluate_claim_gate(_good("b1", token_reduction_ci=(-0.01, 0.5)),
+                                  _good("b2", k=3), independent_review=True)
+        self.assertFalse(d["emit_claim"])
+        self.assertTrue(any("token" in r for r in d["withheld_reasons"]))
+
+    def test_wall_p95_over_one_withholds(self):
+        d = G.evaluate_claim_gate(_good("b1", wall_p95_ratio_ci=(0.9, 1.05)),
+                                  _good("b2", k=3), independent_review=True)
+        self.assertFalse(d["emit_claim"])
+        self.assertTrue(any("wall" in r for r in d["withheld_reasons"]))
+        self.assertIn("WITHHELD", d["summary"])
+
+    def test_resolution_floor_absolute(self):
+        # 2/10 = 0.2 < 0.25 absolute floor
+        d = G.evaluate_claim_gate(_good("b1", resolved_c=2, resolved_a=9),
+                                  _good("b2", k=3), independent_review=True)
+        self.assertFalse(d["emit_claim"])
+        self.assertTrue(any("resolution" in r for r in d["withheld_reasons"]))
+
+    def test_resolution_floor_parity(self):
+        # C=6/10=0.6, A=10/10=1.0, floor=0.7 -> 0.6<0.7 fails parity
+        d = G.evaluate_claim_gate(_good("b1", resolved_c=6, resolved_a=10),
+                                  _good("b2", k=3), independent_review=True)
+        self.assertFalse(d["emit_claim"])
+
+    def test_k_below_10_withholds_on_b1_only(self):
+        # B1 requires K>=10; B2 does not
+        d = G.evaluate_claim_gate(_good("b1", k=3), _good("b2", k=3), independent_review=True)
+        self.assertFalse(d["emit_claim"])
+        self.assertTrue(any("k_adequate" in r for r in d["withheld_reasons"]))
+
+    def test_escalation_dominated_withholds(self):
+        d = G.evaluate_claim_gate(_good("b1", escalation_excluded_frac=0.5),
+                                  _good("b2", k=3), independent_review=True)
+        self.assertFalse(d["emit_claim"])
+        self.assertTrue(any("escalation" in r for r in d["withheld_reasons"]))
+
+    def test_n_not_1_withholds(self):
+        d = G.evaluate_claim_gate(_good("b1", n_anchor=3), _good("b2", k=3),
+                                  independent_review=True)
+        self.assertFalse(d["emit_claim"])
+
+    def test_b2_failure_withholds_even_if_b1_passes(self):
+        d = G.evaluate_claim_gate(_good("b1"), _good("b2", k=3, token_reduction_ci=(-0.1, 0.1)),
+                                  independent_review=True)
+        self.assertFalse(d["emit_claim"])
+        self.assertTrue(any(r.startswith("B2") for r in d["withheld_reasons"]))
+
+    def test_missing_independent_review_withholds(self):
+        d = G.evaluate_claim_gate(_good("b1"), _good("b2", k=3), independent_review=False)
+        self.assertFalse(d["emit_claim"])
+        self.assertTrue(any("independent reviewer" in r for r in d["withheld_reasons"]))
+
+
+class TestHonestSummaryAlwaysPresent(unittest.TestCase):
+    def test_summary_present_when_withheld(self):
+        d = G.evaluate_claim_gate(_good("b1", wall_p95_ratio_ci=(1.1, 1.3)),
+                                  _good("b2", k=3), independent_review=True)
+        self.assertIn("WITHHELD", d["summary"])
+        self.assertIn("%", d["summary"])  # still reports the honest number
+
+    def test_zero_total_fails_closed(self):
+        d = G.evaluate_claim_gate(_good("b1", resolved_c=0, resolved_a=0, total=0),
+                                  _good("b2", k=3), independent_review=True)
+        self.assertFalse(d["emit_claim"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_swebench_live_attribution.py
+++ b/benchmarks/tests/test_swebench_live_attribution.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Unit tests for S0-live token attribution.
+
+Runs the real attribution SQL against an in-memory sqlite fixture that mirrors the .254
+`delegation_spawns` + `token_audit` schema (columns verified on the live DB). Proves the
+corrected primary-vs-worker split, the realized-only filter, and the disjointness assertions.
+Run: python3 -m unittest benchmarks.tests.test_swebench_live_attribution
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_live_attribution as A
+
+
+def _fixture() -> sqlite3.Connection:
+    con = sqlite3.connect(":memory:")
+    con.execute("CREATE TABLE delegation_spawns (id INTEGER PRIMARY KEY, delegation_id TEXT, "
+                "parent_delegation_id TEXT, session_id TEXT, depth INT, role TEXT)")
+    con.execute("CREATE TABLE token_audit (id INTEGER PRIMARY KEY, delegation_id TEXT, "
+                "usage_kind TEXT, prompt_tokens INT, completion_tokens INT, "
+                "cache_read_tokens INT, cache_write_tokens INT)")
+    S = "sess-1"
+    # primary dispatch (depth-1) + two worker dispatches (depth-1 siblings today)
+    con.executemany("INSERT INTO delegation_spawns VALUES (?,?,?,?,?,?)", [
+        (100, "deleg-P", "", S, 1, "execute"),
+        (101, "deleg-W1", "", S, 1, "code"),
+        (102, "deleg-W2", "", S, 1, "code"),
+    ])
+    con.executemany("INSERT INTO token_audit VALUES (?,?,?,?,?,?,?)", [
+        # primary: 1 realized (1000 prompt, 200 cache_read -> 800 uncached, 100 out) + 1 avoided
+        (1, "deleg-P", "realized", 1000, 100, 200, 0),
+        (2, "deleg-P", "avoided", 5000, 0, 0, 0),
+        # workers: big realized returns (priced $0 in reporting)
+        (3, "deleg-W1", "realized", 40000, 3000, 0, 0),
+        (4, "deleg-W2", "realized", 50000, 4000, 0, 0),
+        (5, "deleg-W2", "avoided", 9999, 0, 0, 0),
+    ])
+    con.commit()
+    return con
+
+
+class TestCapture(unittest.TestCase):
+    def test_capture_newest_spawn_after_marker(self):
+        con = _fixture()
+        # dispatched after id 100 -> newest is W2 (id 102)
+        self.assertEqual(A.capture_dispatch_delegation(con, "sess-1", 100), "deleg-W2")
+
+    def test_none_when_no_new_spawn(self):
+        con = _fixture()
+        self.assertIsNone(A.capture_dispatch_delegation(con, "sess-1", 999))
+
+
+class TestRealizedTotals(unittest.TestCase):
+    def test_uncached_headline_and_realized_only(self):
+        con = _fixture()
+        t = A.realized_totals(con, ["deleg-P"])
+        self.assertEqual(t.input_uncached, 800)   # 1000 - 200 cache_read
+        self.assertEqual(t.input_cached, 200)
+        self.assertEqual(t.output, 100)
+        self.assertEqual(t.rows, 1)                # the avoided row excluded
+        self.assertEqual(t.total_headline, 900)
+
+    def test_empty_delegation_set(self):
+        con = _fixture()
+        self.assertEqual(A.realized_totals(con, []).rows, 0)
+
+
+class TestPrimaryWorkerSplit(unittest.TestCase):
+    def test_split_is_by_delegation_ownership(self):
+        con = _fixture()
+        s = A.primary_worker_split(con, "deleg-P", ["deleg-W1", "deleg-W2"])
+        self.assertEqual(s["primary_headline"], 900)     # cheap primary
+        self.assertEqual(s["worker_output"], 7000)        # 3000 + 4000
+        self.assertEqual(s["worker_input"], 90000)        # 40000 + 50000, avoided excluded
+        self.assertEqual(s["primary_rows"], 1)
+
+    def test_child_delegations_when_tree_exists(self):
+        con = _fixture()
+        # promote W1 to a child of P
+        con.execute("UPDATE delegation_spawns SET parent_delegation_id='deleg-P', depth=2 "
+                    "WHERE delegation_id='deleg-W1'")
+        self.assertEqual(A.child_delegations(con, "deleg-P"), ["deleg-W1"])
+
+
+class TestVerifyLiveAttribution(unittest.TestCase):
+    def test_passes_on_clean_split(self):
+        con = _fixture()
+        v = A.verify_live_attribution(con, "deleg-P", ["deleg-W1", "deleg-W2"])
+        self.assertTrue(v["passed"], v)
+        self.assertTrue(v["L1_primary_measured"]["ok"])
+
+    def test_cross_bill_detected(self):
+        con = _fixture()
+        # a worker id equal to the primary id would be cross-billing
+        v = A.verify_live_attribution(con, "deleg-P", ["deleg-P"])
+        self.assertFalse(v["L2_worker_disjoint"]["ok"])
+        self.assertFalse(v["passed"])
+
+
+class TestLiveRunnerStub(unittest.TestCase):
+    def test_runner_is_marked_stub(self):
+        with self.assertRaises(NotImplementedError):
+            A.run_live_matrix(ssh_host="admin@x", db_path="/x/aimee.db")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_swebench_suite.py
+++ b/benchmarks/tests/test_swebench_suite.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Unit tests for S5 — the suite orchestration.
+
+Pure: run-plan generation, the CT-101 lease invariants, grader retry + flip detection, and
+prediction dedup. No live fleet/docker.
+Run: python3 -m unittest benchmarks.tests.test_swebench_suite
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_suite as Q
+
+
+class TestRunPlan(unittest.TestCase):
+    def test_deterministic_and_ordered(self):
+        self.assertEqual([c.run_id for c in Q.generate_run_plan()],
+                         [c.run_id for c in Q.generate_run_plan()])
+
+    def test_run_ids_unique_per_cell(self):
+        cells = Q.generate_run_plan()
+        ids = [c.run_id for c in cells]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_b1_crosses_arms_N_primary_K(self):
+        cells = Q.generate_run_plan(only=["b1_reddit10"])
+        # arms{A,C} x N{1,3} x primary{gpt-5.5,claude} x K=10 = 2*2*2*10 = 80
+        self.assertEqual(len(cells), 80)
+        self.assertTrue(all(c.benchmark == "b1_reddit10" for c in cells))
+
+    def test_b6_uses_worker_pools(self):
+        cells = Q.generate_run_plan(only=["b6_worker_pool"])
+        pools = {c.worker_pool for c in cells}
+        self.assertEqual(pools, {"free_fleet", "gpu_gemma4"})
+
+    def test_b3_parallelism_sweep(self):
+        cells = Q.generate_run_plan(only=["b3_parallelism"])
+        self.assertEqual({c.n for c in cells}, {1, 2, 4, 8})
+
+
+class TestCT101Lease(unittest.TestCase):
+    def test_grader_gets_lease(self):
+        L = Q.CT101Lease()
+        self.assertTrue(L.request_grader())
+        self.assertEqual(L.holder, "grader")
+
+    def test_iteration_refused_while_grader_holds(self):
+        L = Q.CT101Lease()
+        L.request_grader()
+        self.assertFalse(L.request_iteration())
+
+    def test_grader_priority_over_waiting_iteration(self):
+        L = Q.CT101Lease()
+        self.assertTrue(L.request_iteration())     # iteration holds
+        self.assertFalse(L.request_grader())        # grader must wait...
+        L.release("iteration_pool")
+        # ...and while grader is waiting, iteration cannot re-grab it
+        self.assertFalse(L.request_iteration())
+        self.assertTrue(L.request_grader())
+
+    def test_release_wrong_tenant_errors(self):
+        L = Q.CT101Lease()
+        L.request_grader()
+        with self.assertRaises(Q.LeaseError):
+            L.release("iteration_pool")
+
+
+class TestGraderRetry(unittest.TestCase):
+    def test_retries_on_error_then_succeeds(self):
+        calls = {"n": 0}
+
+        def grade():
+            calls["n"] += 1
+            return ("error", "flake") if calls["n"] < 2 else ("ok", True)
+
+        gr = Q.GraderRetry(max_retries=2)
+        self.assertTrue(gr.run(grade))
+        self.assertEqual(gr.attempts, 2)
+
+    def test_does_not_retry_a_legit_non_resolve(self):
+        gr = Q.GraderRetry(max_retries=2)
+        self.assertFalse(gr.run(lambda: ("ok", False)))
+        self.assertEqual(gr.attempts, 1)   # no retry on a valid False
+
+    def test_raises_after_exhausting_retries(self):
+        gr = Q.GraderRetry(max_retries=2)
+        with self.assertRaises(RuntimeError):
+            gr.run(lambda: ("error", "always down"))
+        self.assertEqual(gr.attempts, 3)
+
+
+class TestFlipDetection(unittest.TestCase):
+    def test_flip_flagged(self):
+        self.assertTrue(Q.detect_flips([True, False, True]))
+        self.assertFalse(Q.detect_flips([True, True, True]))
+        self.assertFalse(Q.detect_flips([False, False]))
+
+    def test_aggregate_majority_vote(self):
+        self.assertTrue(Q.aggregate_k([True, True, False])["resolved"])
+        self.assertFalse(Q.aggregate_k([True, False, False])["resolved"])
+        self.assertTrue(Q.aggregate_k([True, False])["flipped"])
+
+    def test_aggregate_empty(self):
+        self.assertEqual(Q.aggregate_k([])["resolved"], None)
+
+
+class TestPredictions(unittest.TestCase):
+    def test_dedup_by_instance_id(self):
+        recs = [{"instance_id": "i1", "diff": "d1"}, {"instance_id": "i1", "diff": "d2"},
+                {"instance_id": "i2", "diff": "d3"}]
+        preds = Q.build_predictions(recs, "run-x")
+        self.assertEqual(len(preds), 2)
+        self.assertEqual({p["instance_id"] for p in preds}, {"i1", "i2"})
+        self.assertTrue(all(p["model_name_or_path"] == "run-x" for p in preds))
+
+    def test_skips_empty_patches(self):
+        recs = [{"instance_id": "i1", "diff": ""}, {"instance_id": "i2", "patch": "x"}]
+        preds = Q.build_predictions(recs, "run-x")
+        self.assertEqual([p["instance_id"] for p in preds], ["i2"])
+
+
+class TestLiveStub(unittest.TestCase):
+    def test_run_suite_is_marked_stub(self):
+        with self.assertRaises(NotImplementedError):
+            Q.run_suite(token_db="/x", aimee_bin="./aimee")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_swebench_supervision.py
+++ b/benchmarks/tests/test_swebench_supervision.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit tests for S3 — the arm-C supervision honesty core.
+
+No live server/LLM/network. Every roundtable honesty ruling is pinned by a case: digests are
+hard-capped and leak-guarded, selection is deterministic, escalation is gated and dominance is
+detected, the context window folds under a cap, redirect is bounded, and the tool allowlist gates
+code-reading behind escalation.
+Run: python3 -m unittest benchmarks.tests.test_swebench_supervision
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_supervision as S
+from benchmarks.coding.swebench_supervision import (
+    WorkerTurn, WorkerState, VerifyEnum, Candidate)
+
+
+def _turn(wid="w1", ti=0, diff="diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n",
+          verify=VerifyEnum.FAIL, state=WorkerState.RUNNING, rationale="", action="edit"):
+    return WorkerTurn(worker_id=wid, turn_index=ti, state=state, action_label=action,
+                      unified_diff=diff, verify=verify, rationale=rationale)
+
+
+class TestDigestCapsAndLeakGuard(unittest.TestCase):
+    def test_digest_never_exceeds_hard_cap(self):
+        huge = "diff --git a/x b/x\n" + ("+line of code\n" * 5000)
+        d = S.build_digest(_turn(diff=huge))
+        self.assertLessEqual(d.tokens(), S.DIGEST_TOKEN_CAP)
+        self.assertTrue(d.truncated)
+
+    def test_source_like_rationale_dropped(self):
+        src = "def f():\n    import os\n    return os.getcwd()\n"
+        d = S.build_digest(_turn(rationale=src))
+        self.assertIn("rationale", d.rejected_fields)
+
+    def test_toolcall_syntax_neutralized(self):
+        d = S.build_digest(_turn(action="<tool_use name=bash>rm -rf</tool_use>"))
+        self.assertNotIn("<tool_use", d.action_label)
+
+    def test_frame_stubs_bare_source(self):
+        # A digest whose diff field is bare source (not a diff frame) is stubbed in the frame.
+        bad = S.Digest(worker_id="w", turn_index=0, state="running", action_label="x",
+                       verify="FAIL", diff="def g():\n    import sys\n    return 1\n",
+                       files_touched=(), added=0, deleted=0, truncated=False)
+        frame, rejected = S.serialize_supervisor_frame([bad])
+        self.assertEqual(rejected, 1)
+        self.assertIn("REJECTED", frame)
+
+    def test_real_diff_survives_frame(self):
+        d = S.build_digest(_turn())
+        frame, rejected = S.serialize_supervisor_frame([d])
+        self.assertEqual(rejected, 0)
+        self.assertIn("+b", frame)
+
+
+class TestDeterministicSelection(unittest.TestCase):
+    def test_prefers_verify_pass(self):
+        cands = [Candidate("w1", "d\n", VerifyEnum.FAIL, turns=1),
+                 Candidate("w2", "d\nd\nd\n", VerifyEnum.PASS, turns=3)]
+        self.assertEqual(S.select_best_of_n(cands).worker_id, "w2")
+
+    def test_tie_break_fewer_turns_then_smaller_diff(self):
+        cands = [Candidate("w1", "a\nb\nc\n", VerifyEnum.PASS, turns=2),
+                 Candidate("w2", "a\n", VerifyEnum.PASS, turns=2)]
+        self.assertEqual(S.select_best_of_n(cands).worker_id, "w2")  # smaller diff
+
+    def test_no_valid_candidate_returns_none(self):
+        cands = [Candidate("w1", "   ", VerifyEnum.FAIL, turns=1),
+                 Candidate("w2", "d\n", VerifyEnum.ERROR, turns=1)]
+        self.assertIsNone(S.select_best_of_n(cands))
+
+    def test_selection_is_deterministic(self):
+        cands = [Candidate("wb", "d\n", VerifyEnum.PASS, turns=1),
+                 Candidate("wa", "d\n", VerifyEnum.PASS, turns=1)]
+        self.assertEqual(S.select_best_of_n(cands).worker_id,
+                         S.select_best_of_n(cands).worker_id)  # stable
+        self.assertEqual(S.select_best_of_n(cands).worker_id, "wa")  # worker_id tie-break
+
+
+class TestSelectionSkill(unittest.TestCase):
+    def test_oracle_vs_actual(self):
+        resolved = {"w1": False, "w2": True}
+        self.assertTrue(S.oracle_pass(resolved))
+        self.assertTrue(S.actual_pass("w2", resolved))
+        self.assertFalse(S.actual_pass("w1", resolved))
+
+    def test_skill_ratio(self):
+        self.assertEqual(S.selection_skill_ratio(0.4, 0.8), 0.5)
+        self.assertIsNone(S.selection_skill_ratio(0.0, 0.0))
+
+
+class TestEscalationGating(unittest.TestCase):
+    def test_all_failed_triggers(self):
+        e = S.EscalationState()
+        self.assertEqual(e.should_escalate(all_failed=True, made_progress=False),
+                         S.EscalationTrigger.ALL_WORKERS_FAILED)
+
+    def test_stuck_triggers_after_limit(self):
+        e = S.EscalationState(stuck_limit=2)
+        self.assertEqual(e.should_escalate(all_failed=False, made_progress=False),
+                         S.EscalationTrigger.NONE)
+        self.assertEqual(e.should_escalate(all_failed=False, made_progress=False),
+                         S.EscalationTrigger.STUCK)
+
+    def test_progress_resets_stuck(self):
+        e = S.EscalationState(stuck_limit=2)
+        e.should_escalate(all_failed=False, made_progress=False)
+        e.should_escalate(all_failed=False, made_progress=True)  # reset
+        self.assertEqual(e.stuck_turns, 0)
+
+    def test_escalation_dominated(self):
+        self.assertTrue(S.is_escalation_dominated(500, 1000))    # 50% > 40%
+        self.assertFalse(S.is_escalation_dominated(300, 1000))   # 30%
+        self.assertTrue(S.is_escalation_dominated(1, 0))          # any escalation w/ no base
+
+
+class TestContextWindow(unittest.TestCase):
+    def test_window_keeps_last_k_and_folds_rest(self):
+        cw = S.ContextWindow(k=2)
+        for i in range(5):
+            cw.add(S.build_digest(_turn(wid=f"w{i}", ti=i)))
+        self.assertEqual(len(cw._recent), 2)
+        self.assertIn("folded 3 turns", cw.fold_summary())
+
+    def test_fold_summary_has_no_quoted_code(self):
+        cw = S.ContextWindow(k=1)
+        for i in range(3):
+            cw.add(S.build_digest(_turn(wid="w", ti=i, diff="diff\n+secret_code_here\n")))
+        self.assertNotIn("secret_code_here", cw.fold_summary())
+
+    def test_token_curve_recorded(self):
+        cw = S.ContextWindow(k=3)
+        for i in range(4):
+            cw.add(S.build_digest(_turn(ti=i)))
+        self.assertEqual(len(cw.token_curve), 4)
+
+
+class TestRedirect(unittest.TestCase):
+    def test_default_off(self):
+        rb = S.RedirectBudget()
+        self.assertFalse(rb.allow("w1"))
+
+    def test_bounded_per_worker(self):
+        rb = S.RedirectBudget(enabled=True, per_worker_max=1)
+        self.assertTrue(rb.allow("w1"))
+        rb.record("w1", "stay in the target file")
+        self.assertFalse(rb.allow("w1"))
+
+    def test_redirect_defangs_and_counts(self):
+        rb = S.RedirectBudget(enabled=True)
+        msg = rb.record("w1", "<tool_use>x</tool_use> focus")
+        self.assertNotIn("<tool_use>", msg)
+        self.assertGreater(rb.redirect_tokens, 0)
+
+
+class TestToolAllowlist(unittest.TestCase):
+    def test_supervisory_tools_allowed(self):
+        self.assertTrue(S.tool_allowed("select_best_of_n"))
+        self.assertTrue(S.tool_allowed("delegate"))
+
+    def test_code_tools_blocked_unless_escalated(self):
+        self.assertFalse(S.tool_allowed("read_file"))
+        self.assertFalse(S.tool_allowed("bash"))
+        self.assertTrue(S.tool_allowed("read_file", escalated=True))
+
+    def test_unknown_tool_blocked(self):
+        self.assertFalse(S.tool_allowed("exfiltrate"))
+
+
+class TestLiveStubHonesty(unittest.TestCase):
+    def test_run_arm_c_is_marked_stub(self):
+        with self.assertRaises(NotImplementedError):
+            S.run_arm_c_supervised({}, workers=["w1"], n=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_swebench_transport_verify.py
+++ b/benchmarks/tests/test_swebench_transport_verify.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Unit tests for S0 — the transport verification matrix.
+
+Exercises the five ledger-attribution assertions against synthesized token_audit rows
+(no live aimee/server). The point is to prove each check CATCHES its regression: for every
+assertion there is a fake ledger that breaks exactly that property and must fail.
+Run: python3 -m pytest benchmarks/tests/test_swebench_transport_verify.py
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_transport_verify as V
+
+PRIMARY = "gpt-5.5"
+WORKER = "glm-5.2"
+BIG = V._BIG_WORKER_RETURN_TOKENS
+
+
+def _verify(scenario):
+    rows = V._fake_rows(scenario, PRIMARY, WORKER)
+    return V.verify_rows(rows, PRIMARY, expected_primary_turns=2, big_return_tokens=BIG)
+
+
+class TestPassScenario(unittest.TestCase):
+    def test_pass_satisfies_all_five(self):
+        v = _verify("pass")
+        self.assertTrue(v["passed"], v)
+        for k in ("P1_primary_captured", "P2_worker_attributed", "P3_no_cross_bill",
+                  "P4_cache_split", "P5_primary_tools_billed"):
+            self.assertTrue(v[k]["ok"], f"{k} should pass: {v[k]['detail']}")
+
+
+class TestEachAssertionCatchesItsRegression(unittest.TestCase):
+    def test_no_primary_breaks_P1(self):
+        v = _verify("no_primary")
+        self.assertFalse(v["P1_primary_captured"]["ok"])
+        self.assertFalse(v["passed"])
+
+    def test_no_worker_breaks_P2(self):
+        v = _verify("no_worker")
+        self.assertFalse(v["P2_worker_attributed"]["ok"])
+        self.assertFalse(v["passed"])
+
+    def test_worker_under_primary_breaks_P2(self):
+        # A delegate turn billed under the primary model is cross-attribution.
+        v = _verify("worker_under_primary")
+        self.assertFalse(v["P2_worker_attributed"]["ok"])
+
+    def test_cross_bill_breaks_P3(self):
+        v = _verify("cross_bill")
+        self.assertFalse(v["P3_no_cross_bill"]["ok"])
+        self.assertFalse(v["passed"])
+
+    def test_tool_bypass_breaks_P5(self):
+        v = _verify("tool_bypass")
+        self.assertFalse(v["P5_primary_tools_billed"]["ok"])
+        self.assertFalse(v["passed"])
+
+
+class TestPrimaryTokenPolarity(unittest.TestCase):
+    def test_primary_rows_are_empty_delegation_only(self):
+        rows = V._fake_rows("pass", PRIMARY, WORKER)
+        pr = V._primary_rows(rows, PRIMARY)
+        self.assertTrue(all(not r["delegation_id"] for r in pr))
+        self.assertTrue(all(r["model"] == PRIMARY for r in pr))
+
+    def test_worker_rows_are_nonempty_delegation(self):
+        rows = V._fake_rows("pass", PRIMARY, WORKER)
+        wr = V._worker_rows(rows)
+        self.assertTrue(wr and all(r["delegation_id"] for r in wr))
+
+
+class TestCacheSplitHeadline(unittest.TestCase):
+    def test_uncached_headline_is_prompt_minus_cache_read(self):
+        rows = [V._row(PRIMARY, prompt=1000, completion=50, cache_read=300),
+                V._row(PRIMARY, prompt=500, completion=20, cache_read=100)]
+        ok, detail = V.assert_cache_split(rows, PRIMARY)
+        self.assertTrue(ok)
+        # prompt 1500 - cache_read 400 = 1100 uncached headline
+        self.assertIn("uncached headline=1100", detail)
+
+
+class TestNoCrossBillBoundary(unittest.TestCase):
+    def test_small_primary_prompt_passes(self):
+        rows = [V._row(PRIMARY, prompt=800, completion=100, tool_name="read_file")]
+        ok, _ = V.assert_no_cross_bill(rows, PRIMARY, BIG)
+        self.assertTrue(ok)
+
+    def test_leaked_worker_return_fails(self):
+        rows = [V._row(PRIMARY, prompt=V._PRIMARY_PROMPT_CEILING + BIG, completion=100,
+                       tool_name="read_file")]
+        ok, _ = V.assert_no_cross_bill(rows, PRIMARY, BIG)
+        self.assertFalse(ok)
+
+
+class TestMatrixFailClosed(unittest.TestCase):
+    def test_render_marks_sanctioned(self):
+        results = {"v1_runs": _verify("pass"), "agent_shell": _verify("cross_bill")}
+        out = V.render(results)
+        self.assertIn("[PASS] v1_runs", out)
+        self.assertIn("[FAIL] agent_shell", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/proposals/pending/agentic-supervised-swebench.md
+++ b/docs/proposals/pending/agentic-supervised-swebench.md
@@ -1,0 +1,501 @@
+# Proposal: Agentic supervised SWE-bench — a true, tool-using, Reddit-parity claim
+
+- **State:** PENDING — design only, no code in this PR; a net-new benchmark
+  harness built on existing substrate.
+  Directly resolves [issue #987](https://github.com/RakuenSoftware/aimee/issues/987)
+  and is the *only* variant permitted to carry a public
+  "beats Reddit's −75.5% supervisor-token reduction **at no wall-clock penalty**"
+  claim. Builds on **PR #986** (single-shot supervised SWE-bench: `token_audit`
+  job-id scoping, concurrent Fleet dispatch/poll, `swebench_supervised_prep.py`
+  instance-set prep, official-grader recipe) and reuses three already-merged
+  substrates rather than re-proposing them: the **autonomous-dev execution
+  substrate** (`git_verify format=json` mechanical verify gate, bounded
+  implement→verify loop — `done/autonomous-dev-execution-substrate.md`), the
+  **per-work-item git worktree isolation** (`aimee/wi/<id>`, flock-serialized —
+  `done/full-autonomous-development.md`, F2), and the **fleet delegate/gateway**
+  path (`gateway_delegate.c`, `delegate_launch.c`, encrypted vault, health probe +
+  circuit-breaker). It does **not** re-propose any of those; it composes them into
+  a graded, apples-to-apples *agentic* comparison.
+- **Author:** JBailes
+- **Date:** 2026-07-05
+- **Charter roles:** Reason (supervision-across-turns: review, redirect,
+  best-of-N selection), Execute (per-worker agentic explore/edit/test loop),
+  Persist (durable `token_audit` job-id-scoped ledger + per-instance run records),
+  Calibrate (aggregate `sum(A)/sum(C)`, bootstrap CIs, sensitivity over N),
+  Review (official SWE-bench Docker grader is the sole resolution source; a
+  public-claim gate that fails closed).
+
+## Thesis
+
+PR #986 proved the *trivial* half of the Reddit claim: if the expensive primary
+delegates a one-shot fix and only reviews the returned diff, it obviously spends
+fewer of its own tokens (we measured **−81% best-of-3 / −86% pure-delegation**
+primary tokens on the Reddit-10). The code roundtable (C6) correctly flagged that
+this is **not** a like-for-like reproduction: the Reddit experiment
+(`rndhouse/mixmod`) is a **tool-using agentic workflow** — GPT-5.5 supervising a
+local Qwen3.6-27B worker that *explores the repo, edits, runs tests, and iterates*
+across many turns. A single-shot `--no-tools` diff is a different, easier task.
+
+The Reddit result has two axes and it **won one, lost the other**:
+
+- **Won:** −75.5% supervisor tokens (−76.1% input, −51.4% output).
+- **Lost:** wall-clock. Mixmod took **85.7 min** vs **22.8 min** for GPT-5.5 alone
+  — **3.75× slower** — because it drove *one* local worker serially.
+
+Aimee's structural advantage is exactly the axis Reddit lost: a **fleet of many
+cheap/free/local workers running concurrently**. One supervisor fanning N agentic
+workers in parallel should reclaim the wall-clock **while keeping** the
+supervisor-token reduction. That is the claim worth making publicly — and it can
+only be made honestly from an **agentic** harness where *both* arms are tool-using
+across turns. This proposal builds that harness and the full benchmark suite that
+substantiates (or refutes) the claim.
+
+## Goal
+
+A graded, reproducible benchmark with two tool-using arms over identical
+SWE-bench Lite tasks:
+
+- **Arm A — agentic solo.** The primary drives the full agentic loop itself:
+  explore the repo, read files, edit, run tests, iterate to a fix. We count the
+  primary's own tokens.
+- **Arm C — agentic supervised.** Cheap/local/free **workers** each drive the
+  agentic loop (explore/edit/test/iterate) in an isolated repo workspace; the
+  **primary supervises across turns** — reviews compact progress summaries and
+  candidate diffs, redirects, digs into code *only on failure*, and selects
+  best-of-N. We count **only the primary's tokens**.
+
+We report three numbers per benchmark, each with the honesty caveats below:
+
+1. **Primary-token reduction A→C**, job-id scoped (as PR #986), aggregated
+   `sum(A)/sum(C)`, with bootstrap CIs.
+2. **Wall-clock**, per-instance median/p95 (t0 = prompt enters supervisor,
+   t1 = official grader resolves) — the axis Reddit lost. Target: **A→C wall-clock
+   ratio ≤ 1.0** (no penalty), ideally < 1.
+3. **Resolution parity** via the **official SWE-bench Docker grader**, reported
+   against **both** PR #986 denominators (resolved/attempted and resolved/total).
+
+Everything new ships as bench tooling and config; no production default changes.
+
+## Non-goals
+
+- **Not a new agent runtime.** Both arms run on the *existing* agentic substrate
+  (autonomous-dev implement→verify loop, worktree isolation, delegate tools). We
+  add a benchmark driver + metrics, not a new execution engine.
+- **Not a resolution-SOTA attempt.** The headline is the *token × wall-clock*
+  trade-off vs the Reddit baseline, not topping the SWE-bench leaderboard. We
+  report whatever resolution parity falls out, honestly.
+- **Not the single-shot benchmark.** PR #986 stays as the delegation-cost
+  micro-benchmark; this is its agentic superset. The single-shot number is
+  **explicitly barred** from being posted as a Reddit head-to-head (that
+  restriction is the whole reason for #987).
+- **Not a fleet-routing change.** We consume today's role→endpoint mapping and the
+  health/circuit-breaker signals; failover/cost-routing is owned by
+  `resilient-fleet-routing.md`.
+
+## Background — what exists today (do not rebuild)
+
+- **PR #986 (`bench/…`, merged to testing):** `swebench_supervised_prep.py`
+  (fetch Lite via HF datasets-server, clone at `base_commit`, extract regions;
+  instance sets `reddit10 | lite:N | all-300`), `bench_swebench_supervised.py`
+  (arms A/C, **concurrent** dispatch+poll — fixes the sequential-poll wall-clock
+  artifact — primary tokens from `token_audit --token-db`),
+  `supervised_report.py` (`summarize_arms` / `render_supervised`),
+  `SUPERVISED_SWEBENCH.md` runbook. **430 bench tests pass.** This proposal
+  *extends* these files; it does not fork them.
+- **Token accounting:** `db1/token_audit.{c,h}`. Supervisor tokens = rows with
+  `delegation_id` **EMPTY**, `usage_kind='realized'`, for the run's session_id.
+  Worker tokens = `delegation_id` **NON-EMPTY**, priced **$0** (free delegates via
+  `token_tracker.c` cost model). The `session tokens <sid> --json` CLI split
+  (supervisor vs worker) shipped with PR #983.
+- **Agentic execution substrate (merged):** the autonomous-dev implement→verify
+  loop — `exec_implement` advances a unit only when it passes the
+  `git_verify format=json` mechanical gate; bounded by `stage_attempt` / turn +
+  wall-clock caps; **per-work-item git worktree** `aimee/wi/<id>` (lazy,
+  flock-serialized, partial-state scrubbed). This is the natural per-worker
+  agentic harness the issue asks for.
+- **Delegate transport:** `delegate execute/draft --via <agent> --persona <p>`
+  (async `job_id` → poll `delegate status`) works against the remote **.254**
+  fleet. `code` role = **agentic file-editing** — needs a repo checked out in a
+  workspace, returns "no file changes detected" / "partial" when there's nothing
+  to edit.
+- **Fleet reality (.254):** 6–7/7 tier-0 workers healthy
+  (mistral / mimo-2.5 / -pro / glm-5.2 / codex[gpt-5.5] / local-synth); **minimax
+  "no content" dropout** is a known flaky. GPU-local **`gpu-gemma4`**
+  (Gemma-4-26B QAT, MTP, ~128 tok/s, 64k ctx) registered on CT109 / .253 5080 —
+  aimee's answer to Reddit's "local Qwen3.6-27B on a 3090".
+- **Grading recipe (established):** the official `swebench` Docker harness runs on
+  **CT 101 (real docker, python3.11, 64G optane)**. The `.253/.254` LXC2Docker
+  **shim mangles** stock images (`python:3.11` has no `/usr/bin/python`) and host
+  python 3.13 is too new for 2017 repos → grade on CT 101 only. Harness **dedupes
+  by `instance_id`**, so one prediction file per (arm, model, cmp) with a distinct
+  `run_id`.
+
+## The measurement problem the agentic arm introduces (and how we solve it)
+
+Single-shot was clean: one primary turn, one worker turn. The agentic arm is
+**multi-turn on both sides**, which creates several new measurement hazards
+(surfaced/sharpened by the 2026-07-05 roundtable). Each has a concrete control:
+
+1. **Worker turns must never bill the primary.** In arm C the workers run their
+   own multi-turn tool loops. Every worker turn must carry a **non-empty
+   `delegation_id`** so it is excluded from the supervisor total and priced $0.
+   *Control:* the **S0 verification matrix** submits a known agentic loop through
+   each candidate transport and asserts the resulting `token_audit` rows land with
+   the correct `delegation_id` polarity (empty for the primary's own turns,
+   non-empty for worker turns) **before** any graded run. Reusing PR #986's job-id
+   scoping is necessary but not sufficient — multi-turn must be re-verified.
+
+2. **The primary must not "cheat" by reading code in arm C.** The entire claim
+   depends on the supervisor reading **compact progress summaries and short
+   candidate diffs**, never the full source. If the primary opens files on every
+   turn, arm C degrades toward arm A. *Control:* a **supervision budget** — the
+   primary's per-turn context in arm C is a templated *turn digest* (worker's
+   last action, test delta, unified diff of the candidate) with a hard cap;
+   full-file reads are permitted **only** on an explicit `escalate` decision after
+   a worker fails, and every escalation is logged so the report can attribute how
+   much of arm-C's primary spend came from digging in. (This mirrors the PR #986
+   finding: savings appear only when the primary avoids reading real code.)
+
+3. **Wall-clock must be per-instance, not fleet-aggregate.** Reddit's 3.75× loss
+   is a *per-task latency* number. Running 10 instances concurrently and dividing
+   total wall by 10 would be a throughput number that flatters us dishonestly.
+   *Control:* pin **`t0` = instance prompt enters the harness dispatch queue —
+   identically for both arms** (not "enters supervisor", which is ambiguous for
+   arm C and would hide queue time); `t1` = grader resolves. Record and report
+   **both** total wall-clock (queue+work) and **work-only** (`t1 − first_worker_start`)
+   **per instance**, as **median AND p95** (the gate is on **p95**); fleet
+   throughput is reported separately and explicitly labeled. Discard the first
+   instance per run as **warmup** (worktree provisioning / model load) and report
+   its latency separately. Arm C's win must hold at the **per-instance p95** level.
+
+4. **Primary-side tool use must be mechanically blocked, not conventional.** The
+   "no reading code in arm C" discipline is enforced by a **hard tool allowlist**,
+   not by prompt convention: the arm-C primary may call only `delegate`,
+   `select_best_of_N`, supervisory meta-tools, and a **gated `escalate`** — code-
+   reading tools (`read_file`/`bash`/`grep`) are refused unless an escalate token
+   is spent, and every escalation is logged and attributed.
+
+5. **Multi-turn token attribution has three hidden leaks — S0 must assert all of
+   them.** (a) **Cached vs uncached:** arm A re-reads files across turns and hits
+   the prompt cache; cached and uncached primary tokens are split and the
+   **uncached** count is the headline denominator for both arms. (b) **Worker
+   content billed to primary:** large worker returns (diffs in turn digests) must
+   not count as primary input — S0 tests a 5k+-token worker return and asserts it
+   is excluded (or carries a `worker_ref` attribution). (c) **Thinking vs text:**
+   `primary_thinking` is split from `primary_text` and reported separately, since
+   supervisors may reason differently across arms.
+
+6. **Supervisor context drift.** Accumulated turn digests (workers × turns ×
+   tokens) grow the primary's per-turn context and erode late-run savings.
+   *Control:* cap accumulated supervisor context (sliding window / fold-reducer,
+   target ≤16k) and report the `primary_tokens_by_turn` curve so the erosion is
+   visible, not hidden in the aggregate.
+
+## Design
+
+### The per-worker agentic harness (arm C worker, and arm A primary)
+
+Both arms need the same loop; they differ only in *who* runs it and *who pays*.
+
+```
+provision workspace  → isolated worktree aimee/wi/<instance,arm,worker>
+                        at base_commit (reuses F2 worktree isolation)
+        │
+   ┌────▼─────────────────────────── agentic loop (bounded) ──────────────┐
+   │  explore: search/read within the workspace                          │
+   │  edit:    apply changes to files                                     │
+   │  test:    run the in-loop test command (worker's own signal)         │
+   │  verify:  git_verify format=json mechanical gate                     │
+   │  iterate until (tests green ∧ verify pass) ∨ turn/wall/USD cap        │
+   └──────────────────────────────────────────────────────────────────────┘
+        │
+   emit: unified diff (patch) = git -C <worktree> diff <base_commit>
+```
+
+- **Substrate reuse:** this *is* the autonomous-dev `exec_implement`→`git_verify`
+  loop with worktree isolation, driven by the bench with a fixed
+  `problem_statement` and a per-instance test command, and bounded by the existing
+  turn / wall-clock / USD caps (F1a/F1b). No new engine.
+- **⚠️ OS-resource isolation (roundtable BLOCKER B1):** F2 worktree isolation
+  covers **file state only** — concurrent arm-C workers still share OS resources
+  (TCP ports, temp dirs, package/import caches), so parallel runs interfere and
+  inject non-reproducible noise into the very p95 wall-clock the claim rests on.
+  S1 **must** add per-worker test-env isolation: a per-worker venv + a **port
+  allocation table** (default), with a **real-docker-per-worker dry-run** in S1 as
+  the gold-standard adequacy check. Without this the wall-clock numbers are not
+  reproducible.
+- **Worker prompt assembly lives in the harness, not the supervisor.** Assembling
+  a worker's prompt in the supervisor would bill those tokens to the primary and
+  erode the reduction; the harness owns prompt assembly (free). If the supervisor
+  ever contributes prompt text, those tokens are accounted to the primary. Validate
+  in S1.
+- **In-loop test execution vs official grade — kept strictly separate.** The
+  *in-loop* test command is the worker's iteration signal and may run in a
+  lightweight per-repo venv or the instance's own Docker image; it is **advisory**.
+  The **only** thing that decides `resolved` is the **official SWE-bench Docker
+  grader on CT 101**, run once at the end on the emitted patch. This prevents the
+  benchmark from grading itself. (Environment for in-loop tests on 2017-era repos
+  is the top design risk — see Risks R1.)
+- **Patch extraction is free:** the harness owns the worktree cwd, so the patch is
+  `git diff <base_commit>` directly — no new server command, same as PR #986's
+  integrated-cwd approach.
+
+### Arm A — agentic solo
+
+The **primary** runs the loop above, transported through a headless entrypoint
+that bills `token_audit` with **`delegation_id` EMPTY** (candidate: `/v1/runs` or
+`agent_shell`; **never Claude-Code**, which bypasses `token_audit`). The primary
+is the model under test — **swappable** between the aimee primary (Claude) and
+**gpt-5.5/codex** so we can run a **direct** head-to-head against Reddit's GPT-5.5
+solo baseline. Its full multi-turn spend (explore + edit + test-reading + iterate)
+is the A denominator.
+
+### Arm C — agentic supervised
+
+- **Workers** (free fleet + `gpu-gemma4` local) each run the loop in their own
+  worktree with **tools enabled** (this is the key difference from PR #986's
+  `--no-tools` single-shot). Worker tokens are $0 and excluded via
+  `delegation_id`.
+- **Supervisor loop (the primary):** across turns it (a) reads each worker's
+  **turn digest** (bounded template — never raw code), (b) **redirects** a worker
+  that is off-track with a short instruction, (c) on worker failure, optionally
+  **escalates** to read code / take over (logged), and (d) at the end **selects
+  best-of-N** by reviewing the short candidate diffs. Only these supervisor turns
+  bill the A-equivalent (primary) tokens for arm C.
+- **best-of-N** is a crossed factor (N ∈ {1, 2, 3}); N=1 is the "pure supervision,
+  no selection" floor.
+
+### Metrics recorded per (instance, arm, primary-model, N, compaction)
+
+| field | source |
+|---|---|
+| `primary_in`, `primary_out` | `token_audit`, `delegation_id` EMPTY, session-scoped |
+| `worker_tokens` | `token_audit`, `delegation_id` NON-EMPTY (honesty; $0) |
+| `wall_clock_s` | `t1 − t0`, per instance |
+| `resolved` | official SWE-bench Docker grader (CT 101) |
+| `turns`, `api_calls`, `escalations` | loop instrumentation |
+| `cost_usd` | primary priced; worker $0 |
+
+### Reporting (extends `supervised_report.py`)
+
+- **Headline:** primary-token reduction `1 − sum_C/sum_A`, split in/out, aggregated
+  `sum(A)/sum(C)` (**not** mean-of-ratios), with **bootstrap CIs** over instances.
+- **Wall-clock panel:** per-instance median/p95 for A and C; the A→C ratio; the
+  claim gate requires ratio ≤ 1.0. Fleet throughput reported separately, labeled.
+- **Resolution parity:** resolved/attempted **and** resolved/total (both
+  denominators), per arm.
+- **Honesty panel:** total-LLM tokens (primary + worker) A vs C — makes explicit
+  that arm C spends *more total* compute, just far less *of the expensive
+  primary's*.
+- **Reducer/compaction lever:** because arm C is now **multi-turn**, the economizer
+  / tool-output condensation / context-fold reducers **actually apply** here
+  (they did **not** in PR #986's single-turn arm — measured 0 avoided tokens).
+  This benchmark is the first place that lever can be shown paying off, so it is a
+  **crossed factor** (reducers on/off).
+- **Pareto panel:** plot every (arm × N × reducers) configuration over (primary
+  tokens, wall-clock p95, resolution) to show dominance relationships — the single
+  most informative view for the claim.
+- **Failure-mode taxonomy:** a per-arm breakdown column — worker dropout / wrong
+  diff / supervisor mis-selection / grader flake / environment issue — so a low
+  arm-C resolution is attributable to a *cause*, not left ambiguous between "harness
+  bug" and "genuine gap".
+- **Stability panel:** run-to-run variance across the K repeats + p99 wall-clock,
+  so tail behaviour and reproducibility are visible.
+
+## The full benchmark suite
+
+Fully-crossed where cheap, sampled where expensive. Temp = 0; **K ≥ 3** repeats
+for variance; report CIs.
+
+**Benchmark 1 — Reddit-10 head-to-head (the public claim).**
+The *exact* 10 SWE-bench Lite instances from the Reddit post
+(`pytest-11143`, `scikit-learn-13439`, `sympy-20212`, `django-12908`,
+`pytest-6116`, `django-13447`, `django-15814`, `django-11179`, `sympy-13480`,
+`scikit-learn-13584`). Primary = **gpt-5.5** for a like-for-like number; also run
+with the aimee primary (Claude) for the aimee-native number. Arms A vs C; N ∈
+{1,3}; reducers off. **This is the only benchmark whose numbers back the public
+"beats −75.5% at no wall-clock penalty" claim.**
+
+**Benchmark 2 — Held-out Lite sample (generalization).**
+~25–30 Lite instances sampled **wide across the four repos** (django / sympy /
+scikit-learn / pytest) plus a few others, disjoint from the Reddit-10. Same arms.
+Guards against over-fitting the claim to 10 cherry-picked tasks.
+
+**Benchmark 3 — Parallelism sensitivity (the wall-clock story).**
+Sweep concurrent-worker count / fleet width; show the A→C wall-clock ratio as a
+function of parallelism. This is the plot that visually kills Reddit's 3.75×: one
+serial worker (their regime) vs N concurrent workers (ours).
+
+**Benchmark 4 — best-of-N ablation.**
+N ∈ {1,2,3}. Shows the resolution-vs-token trade of selection: N=1 is cheapest
+but leans on worker reliability; higher N recovers resolution (PR #986 found the
+limiter was worker reliability on long prompts, **not** selection). Also report
+**oracle-best-of-N vs actual-best-of-N** — would selection-from-short-diffs pick
+the diff that actually resolves? The gap quantifies whether N>1 is real selection
+skill or just variance (the supervisor must pick from digests, not full code).
+
+**Benchmark 5 — Reducer lever ablation.**
+Reducers on/off over Benchmarks 1–2. First measurement of the multi-turn
+economizer lever on a real agentic loop (net-of-recovery per the unified-economizer
+telemetry).
+
+**Benchmark 6 — Worker-pool comparison.**
+Free-fleet workers vs GPU-local `gpu-gemma4` (Gemma-4-26B) — aimee's direct
+counter to "local Qwen3.6-27B on a 3090". Reports whether a single local GPU
+worker reproduces the token win (Reddit's regime) and how much the free-fleet
+breadth adds on wall-clock.
+
+**Optional stretch — Lite-300.** Full Lite if the fleet + grader throughput and
+budget allow; reported as a generalization ceiling, not required for the claim.
+
+## Build order (slices)
+
+Each slice is independently roundtable-reviewable and lands testable.
+
+- **S0 — Transport verification matrix (BLOCKING).** Submit a known **multi-turn
+  agentic** loop through each candidate primary entrypoint (`/v1/runs`,
+  `agent_shell`) and each worker dispatch, and assert the `token_audit` rows land
+  with correct `delegation_id` polarity. Ship as a bench test that must be green
+  before any graded run. *Resolves the Q1 blocker for the multi-turn case.*
+- **S1 — Per-worker agentic harness.** Wire the autonomous-dev implement→verify
+  loop + F2 worktree isolation into a bench-drivable per-instance runner:
+  provision workspace at `base_commit`, run bounded explore/edit/test/verify,
+  emit `git diff` patch. Includes the in-loop test-command resolution per repo
+  (R1).
+- **S2 — Arm A agentic-solo runner.** Primary drives the S1 loop headless via the
+  S0-verified transport; captures per-instance `t0/t1` + primary tokens. Primary
+  model swappable (Claude | gpt-5.5).
+- **S3 — Arm C supervision loop.** Turn-digest template + supervision budget +
+  redirect + escalate (logged) + best-of-N selection over the short diffs. Enforce
+  the "no raw code unless escalate" discipline in the harness, not just by
+  convention.
+- **S4 — Metrics + reporting.** Extend `supervised_report.py`: per-instance
+  wall-clock median/p95, agentic token split, two denominators, honesty panel,
+  reducer-lever and best-of-N factors, bootstrap CIs.
+- **S5 — Suite execution + grading.** Run Benchmarks 1–6 on .254 fleet + CT109 GPU;
+  grade all patches with the official Docker harness on CT 101 (one prediction
+  file per (arm, model, N, cmp), dedupe by `instance_id`). **Grader-retry policy:**
+  max 2 deterministic retries on first failure; log the grader invocation count and
+  **flag any instance whose resolution flips across the K repeats** — grader flake
+  must not be conflated with run noise. Produce the report artifact.
+- **S6 — Runbook + public-claim gate.** Rewrite `SUPERVISED_SWEBENCH.md` for the
+  agentic variant; add a **fail-closed, multi-criterion claim gate**. The public
+  "beats −75.5% at no wall-clock penalty" line is emitted **only if ALL** hold,
+  under the official grader, on **both Benchmark 1 (Reddit-10) AND Benchmark 2
+  (held-out)** — divergence between them withholds the claim (anti-cherry-pick):
+  1. **Token reduction:** BCa-95% CI lower-bound of primary-token reduction > 0,
+     anchored on **N=1** (best-of-N=3 numbers reported separately, never in the
+     headline — N>1 is an asymmetric arm-C advantage).
+  2. **Wall-clock:** **p95** A→C ratio upper-bound ≤ 1.0 (gate on p95, not median;
+     a hung-worker tail must not hide behind the median). Computed against
+     **aimee's own arm-A time**, not Reddit's 22.8 min (that is a cross-harness
+     number, reported only as external context).
+  3. **Resolution floor:** `resolved_C/total_C ≥ max(0.7 × resolved_A/total_A,
+     0.25)` — without this, arm C could satisfy token+wall gates at ~0% resolution
+     and the claim would be dishonest. Denominator is resolved/**total**.
+  Statistics: **K=10** repeats for Benchmark 1 (the public claim), K=3 for
+  ablations; **BCa 95% bootstrap CIs**. The pass/withhold decision is reviewed by
+  **at least one party who did not author the harness or worker code**
+  (anti-self-confirmation), and the full report is **published regardless of gate
+  outcome** (e.g. "−78% primary tokens at 1.05× p95 wall-clock — claim withheld").
+  A **secrets-leak scanner** (token-shape deny-list) over every emitted patch is a
+  precondition for any public write-up.
+
+## Risks / open questions
+
+- **R1 — In-loop test environment for 2017-era repos (top risk).** The worker's
+  iteration signal needs to *run tests* inside old repos where host python is too
+  new and the shim-docker mangles stock images. **Recommendation (firmed by the
+  roundtable): (a)** run in-loop tests inside each instance's official SWE-bench
+  Docker image on a real-docker CT, **with explicit throughput planning** since CT
+  101 is shared with grading and would bottleneck if both need real Docker
+  simultaneously; **(c)** make in-loop tests optional (iterate on `git_verify` +
+  build) as the fallback for repos whose image is too heavy or when CT 101 is
+  saturated. (b) a pinned per-repo venv is the middle option. Locked at S1.
+- **R2 — Worker reliability on long agentic prompts.** PR #986 found the limiter
+  was worker reliability at 64k prompts (minimax "no content", 401s), not
+  selection. Multi-turn loops are longer still. Mitigations: best-of-N,
+  circuit-breaker skip, and the reducer lever (Benchmark 5) shrinking per-turn
+  context. Report worker failure/dropout rate as a first-class metric, with a
+  **quantitative invalidation threshold: >30% worker dropout on a benchmark = that
+  run is invalid** (not silently averaged in).
+- **R3 — Supervision cost blow-up via escalation.** If failures force the primary
+  to read code often, arm C's token win erodes. The escalation log quantifies this;
+  if escalation dominates, that is a *real, reportable* finding (the claim is
+  workload-dependent), not something to hide. **Quantitative gate: >40% of arm-C
+  primary tokens originating from escalation = claim withheld** (the win came from
+  digging in, not supervising).
+- **R4 — Model × architecture confound.** "Claude solo vs gpt-5.5-supervised" mixes
+  two variables. Control: run the *same* primary model across A and C within each
+  benchmark; the gpt-5.5-across-both cut in Benchmark 1 is the clean Reddit
+  head-to-head.
+- **R5 — Contamination.** SWE-bench Lite is public and may be in training data for
+  both the primary and the workers. This affects *all* SWE-bench numbers including
+  Reddit's; note it as a shared caveat rather than a differential advantage.
+- **R6 — Fleet/grader capacity + cleanup.** Graded runs consume CT 101 docker,
+  .254 fleet keys, and CT109 GPU; prior runs left venv/image/clone scratch. S5
+  must budget throughput and own teardown (the cleanup debt from the PR #986 run
+  is documented in memory).
+
+## Roundtable review (2026-07-05) — adopted revisions
+
+Reviewed by the `.254` fleet panel (6/7 participants, 54 deduped findings; 2
+blocking). All load-bearing findings were **adopted** and folded into the sections
+above; recorded here for provenance.
+
+**Blockers (both adopted, now gating S0/S1):**
+- **B1 — OS-resource isolation.** F2 worktrees isolate file state only; concurrent
+  workers share ports/temp/caches → non-reproducible p95. → per-worker venv + port
+  table + real-docker-per-worker dry-run in S1 (see Design + R6).
+- **B2 — multi-turn token-attribution leaks.** cached-vs-uncached split, worker
+  content billed to primary, and primary-side tools bypassing `delegation_id`. →
+  S0 must assert all three; hard tool allowlist + uncached-headline denominator +
+  thinking/text split (see Measurement hazards 4–5).
+
+**Honesty-critical suggestions (adopted into the claim gate, S6):** resolution
+floor `resolved_C/total ≥ max(0.7×resolved_A/total, 0.25)`; gate on **p95** not
+median; anchor headline on **N=1**; must pass **both** Benchmark 1 **and** 2;
+**K=10** + BCa-95% CIs for the public claim; within-aimee wall-clock ratio (not vs
+Reddit's cross-harness 22.8 min); **independent** gate reviewer + **publish
+regardless of outcome**; secrets-leak scanner precondition.
+
+**Other adopted:** queue-vs-work t0 pinning + warmup discard; supervisor
+context-drift cap + per-turn token curve; harness-owns-prompt-assembly; grader
+retry/flip-flag; Pareto + failure-mode + stability panels; oracle-vs-actual
+best-of-N; quantitative R2/R3 invalidation thresholds; firmed R1 recommendation.
+
+**Not adopted / deferred:** cross-system literature anchoring and inlining the C6
+notes (nits — the write-up will cite external results at publication time, out of
+scope for the harness design).
+
+## Acceptance
+
+The executable shadow of the criteria above (mechanical → integration →
+deployment). The deployment-tier gates are the fail-closed public-claim gate (S6)
+and never auto-claimed.
+
+```yaml acceptance
+- {id: 1, tier: mechanical, check: "python3 -m unittest benchmarks.tests.test_swebench_transport_verify (S0 five ledger-attribution assertions pass in FAKE mode)"}
+- {id: 2, tier: mechanical, check: "python3 -m unittest discover -s benchmarks/tests -p 'test_*.py' (full bench suite green with the new S0 + agentic-arm tests)"}
+- {id: 3, tier: integration, check: "python3 benchmarks/coding/swebench_transport_verify.py --token-db <db> --primary-model gpt-5.5 exits 0 against the live .254 fleet (a transport passes all five assertions)"}
+- {id: 4, tier: integration, check: "S1 per-worker agentic harness provisions an isolated worktree with per-worker venv+port isolation (B1) and emits a git-diff patch for a probe instance"}
+- {id: 5, tier: deployment, check: "official SWE-bench Docker grader on CT 101 returns resolved verdicts for arm A and arm C patches across Benchmark 1 (Reddit-10)"}
+- {id: 6, tier: deployment, check: "S6 claim gate passes on BOTH Benchmark 1 and 2 under the official grader: token-reduction BCa-95 CI lower-bound > 0 (N=1), p95 wall-clock A->C ratio upper-bound <= 1.0, resolution floor resolved_C/total >= max(0.7*resolved_A/total, 0.25)"}
+```
+
+## Deliverables
+
+1. Extended `bench_swebench_supervised.py` (agentic arm A + arm C runners),
+   `swebench_supervised_prep.py` (unchanged instance sets), `supervised_report.py`
+   (agentic reporting), and a new per-worker agentic harness module.
+2. The S0 transport verification-matrix bench test (green-gate).
+3. A report artifact covering Benchmarks 1–6 with CIs, both denominators, and the
+   honesty panel.
+4. Rewritten `SUPERVISED_SWEBENCH.md` runbook + the fail-closed public-claim gate.
+5. A short public write-up **only if** the claim gate passes.
+
+---
+
+*Convention: roundtable-review the CODE (not just this design) before each slice's
+PR; grade only on the official SWE-bench Docker harness; aggregate `sum(A)/sum(C)`;
+never post the single-shot (#986) number as a Reddit head-to-head.*

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -86,6 +86,10 @@ export default function Agents() {
     null,
   );
   const [showAdd, setShowAdd] = useState(false);
+  // The agent currently open in the Edit modal (null = closed). ALL mutations —
+  // config fields, roles/personas binding, enable, remove — happen there; the base
+  // list is read-only so a binding can never change from a stray click.
+  const [editing, setEditing] = useState<AgentCfg | null>(null);
   // The known role + persona vocabularies, offered (with "all") when assigning
   // an agent's roles/personas so they match what personas declare.
   const [knownRoles, setKnownRoles] = useState<string[]>([]);
@@ -112,26 +116,6 @@ export default function Agents() {
         .catch(() => setStats({})),
     ]).finally(() => setLoading(false));
   }, []);
-
-  // Persist an agent's roles / personas via the surgical ops; refresh on success.
-  const saveAgentField = useCallback(
-    async (name: string, field: "roles" | "personas", values: string[]) => {
-      try {
-        const res = await postArgs<{ error?: string }>(`/api/agents/${field}`, [
-          name,
-          values.join(","),
-        ]);
-        if (res.error) setStatus({ kind: "err", msg: res.error });
-        else {
-          setStatus({ kind: "ok", msg: `${name} ${field} saved` });
-          refresh();
-        }
-      } catch {
-        setStatus({ kind: "err", msg: `failed to save ${field}` });
-      }
-    },
-    [refresh],
-  );
 
   useEffect(() => {
     refresh();
@@ -165,39 +149,13 @@ export default function Agents() {
     for (const a of agents) void probe(a.name);
   }, [agents, probe]);
 
-  const setEnabled = useCallback(
-    async (name: string, enabled: boolean) => {
-      setStatus(null);
-      try {
-        const res = await postArgs<{ error?: string }>(
-          enabled ? "/api/agents/enable" : "/api/agents/disable",
-          [name],
-        );
-        if (res.error) setStatus({ kind: "err", msg: res.error });
-        else setStatus({ kind: "ok", msg: `${name} ${enabled ? "enabled" : "disabled"}` });
-      } catch {
-        setStatus({ kind: "err", msg: `failed to ${enabled ? "enable" : "disable"} ${name}` });
-      }
-      refresh();
-    },
-    [refresh],
-  );
-
-  const remove = useCallback(
-    async (name: string) => {
-      if (!confirm(`Remove delegate “${name}”? This edits agents.json.`)) return;
-      setStatus(null);
-      try {
-        const res = await postArgs<{ error?: string }>("/api/agents/remove", [name]);
-        if (res.error) setStatus({ kind: "err", msg: res.error });
-        else setStatus({ kind: "ok", msg: `removed ${name}` });
-      } catch {
-        setStatus({ kind: "err", msg: `failed to remove ${name}` });
-      }
-      refresh();
-    },
-    [refresh],
-  );
+  // Keep the modal's view of the agent in sync after a save-triggered refresh so
+  // it reflects the persisted record (and closes cleanly if the agent was removed).
+  useEffect(() => {
+    if (!editing) return;
+    const fresh = agents.find((a) => a.name === editing.name);
+    if (fresh && fresh !== editing) setEditing(fresh);
+  }, [agents, editing]);
 
   return (
     <div style={{ padding: 16, fontFamily: "system-ui", height: "100%", overflow: "auto" }}>
@@ -254,43 +212,40 @@ export default function Agents() {
             stats={stats[a.name]}
             probe={probes[a.name]}
             onProbe={() => probe(a.name)}
-            onToggle={() => setEnabled(a.name, !a.enabled)}
-            onRemove={() => remove(a.name)}
-            knownRoles={knownRoles}
-            knownPersonas={knownPersonas}
-            onSaveRoles={(v) => saveAgentField(a.name, "roles", v)}
-            onSavePersonas={(v) => saveAgentField(a.name, "personas", v)}
+            onEdit={() => setEditing(a)}
           />
         ))}
       </div>
+
+      {editing && (
+        <AgentEditModal
+          agent={editing}
+          knownRoles={knownRoles}
+          knownPersonas={knownPersonas}
+          onClose={() => setEditing(null)}
+          onSaved={refresh}
+          onStatus={(msg, ok) => setStatus({ kind: ok ? "ok" : "err", msg })}
+        />
+      )}
     </div>
   );
 }
 
-/* ---- one delegate: config + availability + stats ---- */
+/* ---- one delegate: READ-ONLY overview (config + availability + stats). All
+   mutations live in the Edit modal, so no binding can change from this list. ---- */
 
 function AgentCard({
   agent,
   stats,
   probe,
   onProbe,
-  onToggle,
-  onRemove,
-  knownRoles,
-  knownPersonas,
-  onSaveRoles,
-  onSavePersonas,
+  onEdit,
 }: {
   agent: AgentCfg;
   stats?: AgentStats;
   probe?: ProbeState;
   onProbe: () => void;
-  onToggle: () => void;
-  onRemove: () => void;
-  knownRoles: string[];
-  knownPersonas: string[];
-  onSaveRoles: (v: string[]) => void;
-  onSavePersonas: (v: string[]) => void;
+  onEdit: () => void;
 }) {
   const pstate = probe?.status || "idle";
   const dot =
@@ -310,43 +265,32 @@ function AgentCard({
   return (
     <Panel title={agent.name}>
       <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "flex-start" }}>
-        {/* left: configuration */}
+        {/* left: configuration (read-only) */}
         <div style={{ flex: "1 1 260px", minWidth: 240 }}>
-          <Field k="provider" v={agent.provider || "—"} />
-          <Field k="model" v={agent.model || "—"} />
-          <Field k="endpoint" v={agent.endpoint || "(cli / none)"} mono />
-          <div style={{ display: "flex", alignItems: "center", gap: 6, margin: "4px 0" }}>
-            <span style={{ color: "#888", fontSize: 13 }}>enabled</span>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, margin: "2px 0 4px" }}>
             <Badge
               label={agent.enabled ? "enabled" : "disabled"}
               variant={agent.enabled ? "success" : "neutral"}
             />
-            <button onClick={onToggle} style={btnSmall}>
-              {agent.enabled ? "disable" : "enable"}
-            </button>
           </div>
+          <Field k="provider" v={agent.provider || "—"} />
+          <Field k="model" v={agent.model || "—"} />
+          <Field k="endpoint" v={agent.endpoint || "(cli / none)"} mono />
           {typeof agent.cost_tier === "number" && (
             <Field k="cost tier" v={String(agent.cost_tier)} />
           )}
           {typeof agent.max_parallel === "number" && agent.max_parallel > 0 && (
             <Field k="max parallel" v={String(agent.max_parallel)} />
           )}
+          {typeof agent.max_turns === "number" && agent.max_turns >= 0 && (
+            <Field k="max turns" v={String(agent.max_turns)} />
+          )}
           {agent.context_window ? (
             <Field k="context" v={`${agent.context_window.toLocaleString()} tok`} />
           ) : null}
-          <ChipEditor
-            label="roles"
-            selected={agent.roles || []}
-            options={knownRoles}
-            onSave={onSaveRoles}
-          />
-          <ChipEditor
-            label="personas"
-            selected={agent.personas || []}
-            options={knownPersonas}
-            emptyHint="(none set = all)"
-            onSave={onSavePersonas}
-          />
+          <Field k="tools" v={agent.tools_enabled ? "enabled" : "disabled"} />
+          <StaticChips label="roles" values={agent.roles || []} />
+          <StaticChips label="personas" values={agent.personas || []} emptyHint="(none = all)" />
         </div>
 
         {/* middle: availability */}
@@ -413,13 +357,250 @@ function AgentCard({
 
       <div style={{ marginTop: 8, borderTop: "1px solid #eee", paddingTop: 8 }}>
         <button
-          onClick={onRemove}
-          style={{ ...btnSmall, color: "#c00", borderColor: "#e0a0a0" }}
+          onClick={onEdit}
+          style={{ ...btnSmall, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
         >
-          Remove delegate
+          Edit
         </button>
       </div>
     </Panel>
+  );
+}
+
+/* ---- per-agent Edit modal: edit ALL aspects; the one place binding changes are
+   made. Saves via a single surgical POST /api/agents/set. ---- */
+
+function AgentEditModal({
+  agent,
+  knownRoles,
+  knownPersonas,
+  onClose,
+  onSaved,
+  onStatus,
+}: {
+  agent: AgentCfg;
+  knownRoles: string[];
+  knownPersonas: string[];
+  onClose: () => void;
+  onSaved: () => void;
+  onStatus: (msg: string, ok: boolean) => void;
+}) {
+  const [provider, setProvider] = useState(agent.provider || "openai");
+  const [model, setModel] = useState(agent.model || "");
+  const [endpoint, setEndpoint] = useState(agent.endpoint || "");
+  const [costTier, setCostTier] = useState(String(agent.cost_tier ?? 0));
+  const [maxTurns, setMaxTurns] = useState(String(agent.max_turns ?? -1));
+  const [maxParallel, setMaxParallel] = useState(String(agent.max_parallel ?? 0));
+  const [contextWindow, setContextWindow] = useState(String(agent.context_window ?? 0));
+  const [tools, setTools] = useState(!!agent.tools_enabled);
+  const [enabled, setEnabled] = useState(!!agent.enabled);
+  const [roles, setRoles] = useState<string[]>(agent.roles || []);
+  const [personas, setPersonas] = useState<string[]>(agent.personas || []);
+  const [apiKey, setApiKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  const cliProvider = provider === "claude" || provider === "claude-code";
+
+  // Esc closes the modal.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const save = async () => {
+    setBusy(true);
+    setErr("");
+    // One surgical set carrying every editable field. The server patches only what
+    // is passed; roles empty resets to the default set, personas empty resets to "all".
+    const args = [
+      agent.name,
+      "--provider", provider,
+      "--model", model.trim(),
+      "--endpoint", endpoint.trim(),
+      "--cost-tier", costTier || "0",
+      "--max-turns", maxTurns || "-1",
+      "--max-parallel", maxParallel || "0",
+      "--context-window", contextWindow || "0",
+      "--tools", tools ? "on" : "off",
+      "--enabled", enabled ? "true" : "false",
+      "--roles", roles.join(","),
+      "--personas", personas.join(","),
+    ];
+    if (apiKey.trim()) args.push("--key", apiKey.trim());
+    try {
+      const res = await postArgs<{ error?: string }>("/api/agents/set", args);
+      if (res.error) setErr(res.error);
+      else {
+        onStatus(`${agent.name} saved`, true);
+        onSaved();
+        onClose();
+      }
+    } catch {
+      setErr("save failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    if (!confirm(`Remove delegate “${agent.name}”? This edits agents.json.`)) return;
+    setBusy(true);
+    setErr("");
+    try {
+      const res = await postArgs<{ error?: string }>("/api/agents/remove", [agent.name]);
+      if (res.error) setErr(res.error);
+      else {
+        onStatus(`removed ${agent.name}`, true);
+        onSaved();
+        onClose();
+      }
+    } catch {
+      setErr("remove failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 30,
+        background: "rgba(0,0,0,0.35)",
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "center",
+        padding: 24,
+        overflow: "auto",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "#fff",
+          borderRadius: 8,
+          maxWidth: 640,
+          width: "100%",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.25)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "12px 16px",
+            borderBottom: "1px solid #eee",
+            position: "sticky",
+            top: 0,
+            background: "#fff",
+            borderRadius: "8px 8px 0 0",
+          }}
+        >
+          <strong style={{ fontSize: 15 }}>Edit delegate</strong>
+          <span style={{ fontSize: 13, color: "#667", fontFamily: "monospace" }}>{agent.name}</span>
+          <button onClick={onClose} style={{ ...btn, marginLeft: "auto" }}>
+            Close
+          </button>
+        </div>
+
+        <div style={{ padding: 16 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
+            <L label="provider">
+              <select value={provider} onChange={(e) => setProvider(e.target.value)} style={inp} disabled={busy}>
+                {(PROVIDERS.includes(provider) ? PROVIDERS : [provider, ...PROVIDERS]).map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </L>
+            <L label="model">
+              <input value={model} onChange={(e) => setModel(e.target.value)} style={inp} disabled={busy} />
+            </L>
+            <L label={cliProvider ? "endpoint (optional for CLI)" : "endpoint"}>
+              <input
+                value={endpoint}
+                onChange={(e) => setEndpoint(e.target.value)}
+                style={inp}
+                placeholder="https://host:port/v1"
+                disabled={busy}
+              />
+            </L>
+            <L label="cost tier">
+              <input type="number" value={costTier} onChange={(e) => setCostTier(e.target.value)} style={inp} min={0} disabled={busy} />
+            </L>
+            <L label="max turns (-1 = default)">
+              <input type="number" value={maxTurns} onChange={(e) => setMaxTurns(e.target.value)} style={inp} disabled={busy} />
+            </L>
+            <L label="max parallel">
+              <input type="number" value={maxParallel} onChange={(e) => setMaxParallel(e.target.value)} style={inp} min={0} disabled={busy} />
+            </L>
+            <L label="context window (tok, 0 = auto)">
+              <input type="number" value={contextWindow} onChange={(e) => setContextWindow(e.target.value)} style={inp} min={0} disabled={busy} />
+            </L>
+            <L label="API key (blank = keep current)">
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                style={inp}
+                placeholder="sk-…  or  $ENV_VAR"
+                disabled={busy}
+              />
+            </L>
+          </div>
+
+          <div style={{ display: "flex", gap: 20, marginTop: 10 }}>
+            <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}>
+              <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} disabled={busy} />
+              enabled
+            </label>
+            <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}>
+              <input type="checkbox" checked={tools} onChange={(e) => setTools(e.target.checked)} disabled={busy} />
+              tools enabled
+            </label>
+          </div>
+
+          <ChipSelect label="roles" selected={roles} options={knownRoles} onChange={setRoles} />
+          <ChipSelect
+            label="personas"
+            selected={personas}
+            options={knownPersonas}
+            onChange={setPersonas}
+            emptyHint="(none set = all)"
+          />
+
+          {err && <div style={{ fontSize: 12, color: "#c00", marginTop: 8 }}>{err}</div>}
+
+          <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 14 }}>
+            <button
+              onClick={() => void save()}
+              disabled={busy}
+              style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+            >
+              {busy ? "Saving…" : "Save"}
+            </button>
+            <button onClick={onClose} disabled={busy} style={btn}>
+              Cancel
+            </button>
+            <button
+              onClick={() => void remove()}
+              disabled={busy}
+              style={{ ...btn, marginLeft: "auto", background: "#fff5f5", color: "#c00", borderColor: "#e6b3b3" }}
+            >
+              Remove delegate
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -536,47 +717,40 @@ function AddDelegate({ onDone }: { onDone: (msg: string, ok: boolean) => void })
 
 /* ---- small presentational helpers ---- */
 
-// Editable multi-select of tokens (roles or personas) as toggleable chips. The
-// "all" wildcard is always offered; free selection from the known vocabulary
-// keeps agents matched to what personas declare. Save appears only when dirty.
-function ChipEditor({
+// Editable multi-select of tokens (roles or personas) as toggleable chips, fully
+// controlled by the parent (the Edit modal saves the whole set on Save). The "all"
+// wildcard is always offered; free selection keeps agents matched to what personas
+// declare.
+function ChipSelect({
   label,
   selected,
   options,
+  onChange,
   emptyHint,
-  onSave,
 }: {
   label: string;
   selected: string[];
   options: string[];
+  onChange: (v: string[]) => void;
   emptyHint?: string;
-  onSave: (v: string[]) => void;
 }) {
-  const [sel, setSel] = useState<string[]>(selected);
-  useEffect(() => setSel(selected), [selected.join(",")]); // resync after a save/refresh
   const all = useMemo(() => {
     const s = new Set<string>(["all", ...options, ...selected]);
     return Array.from(s);
   }, [options.join(","), selected.join(",")]);
-  const dirty = sel.slice().sort().join(",") !== selected.slice().sort().join(",");
   const toggle = (r: string) =>
-    setSel((cur) => (cur.includes(r) ? cur.filter((x) => x !== r) : [...cur, r]));
+    onChange(selected.includes(r) ? selected.filter((x) => x !== r) : [...selected, r]);
   return (
-    <div style={{ margin: "6px 0" }}>
+    <div style={{ margin: "10px 0 2px" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
         <span style={{ color: "#888", fontSize: 12 }}>{label}</span>
-        {dirty && (
-          <button onClick={() => onSave(sel)} style={{ ...btnSmall, padding: "1px 8px" }}>
-            save
-          </button>
-        )}
-        {sel.length === 0 && emptyHint && (
+        {selected.length === 0 && emptyHint && (
           <span style={{ color: "#aaa", fontSize: 11 }}>{emptyHint}</span>
         )}
       </div>
       <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 3 }}>
         {all.map((r) => {
-          const on = sel.includes(r);
+          const on = selected.includes(r);
           return (
             <button
               key={r}
@@ -593,6 +767,36 @@ function ChipEditor({
             </button>
           );
         })}
+      </div>
+    </div>
+  );
+}
+
+// Read-only chips for the base card (roles/personas shown, not editable here).
+function StaticChips({ label, values, emptyHint }: { label: string; values: string[]; emptyHint?: string }) {
+  return (
+    <div style={{ margin: "6px 0" }}>
+      <span style={{ color: "#888", fontSize: 12 }}>{label}</span>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 3 }}>
+        {values.length === 0 ? (
+          <span style={{ color: "#aaa", fontSize: 11 }}>{emptyHint || "—"}</span>
+        ) : (
+          values.map((r) => (
+            <span
+              key={r}
+              style={{
+                fontSize: 12,
+                padding: "1px 7px",
+                borderRadius: 4,
+                border: "1px solid #dfe6ef",
+                background: "#f4f7fb",
+                color: "#556",
+              }}
+            >
+              {r}
+            </span>
+          ))
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -2,6 +2,19 @@ import { useEffect, useState, useCallback, useMemo } from 'react';
 import { Badge } from '@rakuensoftware/smoothgui';
 import type { BadgeVariant } from '@rakuensoftware/smoothgui';
 
+/* All fields of an audit row, in display order, for the detail modal. */
+const DETAIL_FIELDS: { key: keyof AuditRow; label: string }[] = [
+  { key: 'ts', label: 'Timestamp' },
+  { key: 'verdict', label: 'Verdict' },
+  { key: 'actor', label: 'Actor' },
+  { key: 'tool', label: 'Tool' },
+  { key: 'kind', label: 'Kind' },
+  { key: 'mode', label: 'Guardrail mode' },
+  { key: 'reason_code', label: 'Reason code' },
+  { key: 'args_hash', label: 'Args hash' },
+  { key: 'task_id', label: 'Task id' },
+];
+
 /* The server's own tool-action audit ledger (guardrail verdict on every tool
  * call the agent makes). Server-incurred — distinct from the KB's own logs. */
 interface AuditRow {
@@ -45,6 +58,15 @@ export default function Logs() {
   const [verdict, setVerdict] = useState('all');
   const [actor, setActor] = useState('all');
   const [q, setQ] = useState('');
+  const [selected, setSelected] = useState<AuditRow | null>(null);
+
+  // Close the detail modal on Escape.
+  useEffect(() => {
+    if (!selected) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setSelected(null); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selected]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -119,7 +141,14 @@ export default function Logs() {
             </thead>
             <tbody>
               {filtered.map((r, i) => (
-                <tr key={i}>
+                <tr
+                  key={i}
+                  onClick={() => setSelected(r)}
+                  style={{ cursor: 'pointer' }}
+                  onMouseEnter={ev => (ev.currentTarget.style.background = '#f6f9ff')}
+                  onMouseLeave={ev => (ev.currentTarget.style.background = 'transparent')}
+                  title="Click for full detail"
+                >
                   <td style={{ ...td, whiteSpace: 'nowrap', color: '#888' }}>{esc(r.ts).replace('T', ' ').replace('Z', '')}</td>
                   <td style={td}>{esc(r.actor)}</td>
                   <td style={{ ...td, fontFamily: 'monospace' }}>{esc(r.tool)}</td>
@@ -133,6 +162,51 @@ export default function Logs() {
           </table>
         )}
       </div>
+
+      {selected && (
+        <div
+          onClick={() => setSelected(null)}
+          style={{
+            position: 'fixed', inset: 0, zIndex: 30, background: 'rgba(0,0,0,0.35)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16,
+          }}
+        >
+          <div
+            onClick={ev => ev.stopPropagation()}
+            style={{
+              background: '#fff', borderRadius: 8, maxWidth: 560, width: '100%',
+              maxHeight: '80vh', overflow: 'auto', boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+            }}
+          >
+            <div style={{
+              display: 'flex', alignItems: 'center', gap: 10, padding: '12px 16px',
+              borderBottom: '1px solid #eee', position: 'sticky', top: 0, background: '#fff',
+            }}>
+              <strong style={{ fontSize: 14 }}>Audit entry</strong>
+              <Badge label={esc(selected.verdict)} variant={verdictVariant(selected.verdict)} />
+              <button
+                onClick={() => setSelected(null)}
+                style={{ ...selectStyle, cursor: 'pointer', marginLeft: 'auto' }}
+              >
+                Close
+              </button>
+            </div>
+            <div style={{ padding: '8px 16px 16px' }}>
+              {DETAIL_FIELDS.map(f => {
+                const v = selected[f.key];
+                return (
+                  <div key={f.key} style={{ display: 'flex', gap: 12, padding: '7px 0', borderBottom: '1px solid #f4f4f4' }}>
+                    <span style={{ width: 130, flexShrink: 0, color: '#888', fontSize: 12 }}>{f.label}</span>
+                    <span style={{ fontSize: 13, fontFamily: 'monospace', overflowWrap: 'anywhere', minWidth: 0 }}>
+                      {v == null || v === '' ? <span style={{ color: '#bbb' }}>—</span> : String(v)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -81,6 +81,22 @@ async function postJSON<T>(url: string, body: unknown): Promise<{ status: number
   return { status: r.status, data };
 }
 
+// A bare method call (POST/DELETE) with no body — used for the lifecycle actions.
+// Returns the status + parsed body (best effort) like postJSON.
+async function sendAction<T>(url: string, method: "POST" | "DELETE"): Promise<{ status: number; data: T }> {
+  const r = await fetch(url, {
+    method,
+    headers: { "X-CSRF-Token": window._csrf || "" },
+  });
+  let data = {} as T;
+  try {
+    data = (await r.json()) as T;
+  } catch {
+    /* empty body ok */
+  }
+  return { status: r.status, data };
+}
+
 const isTerminal = (s: string) => s === "accepted" || s === "rejected" || s === "abandoned";
 
 // A human status label + tone from the row's state + pause_reason + stage. Derived
@@ -91,6 +107,8 @@ function statusOf(it: Item): { label: string; variant: BadgeVariant } {
   if (it.state === "abandoned") return { label: "abandoned", variant: "neutral" };
   // active:
   switch (it.pause_reason) {
+    case "operator_paused":
+      return { label: `paused · ${it.stage}`, variant: "warning" };
     case "pending_human":
       return { label: `awaiting approval · ${it.stage}`, variant: "warning" };
     case "ci_pending":
@@ -132,6 +150,7 @@ const KIND_LABEL: Record<string, string> = {
   reject_retry: "rejected (retry)",
   override: "overridden",
   rejected: "rejected",
+  abandon: "stopped",
 };
 
 // pr_ref is opaque (a PR number or a URL). Render a link when it looks like one.
@@ -330,7 +349,54 @@ export default function WorkflowActions() {
     [selId, openProposal],
   );
 
+  // Lifecycle control (pause / resume / stop / delete). On success we refresh the
+  // open proposal (or clear the selection after a delete).
+  const [actMsg, setActMsg] = useState("");
+  const [acting, setActing] = useState(false);
+  const doLifecycle = useCallback(
+    async (action: "pause" | "resume" | "stop" | "delete") => {
+      if (!selId || acting) return;
+      if (action === "stop" && !window.confirm("Stop this run? It will be abandoned and cannot be resumed."))
+        return;
+      if (action === "delete" && !window.confirm("Delete this run permanently? Its history and proposal file will be removed."))
+        return;
+      setActMsg("");
+      setActing(true);
+      try {
+        const isDel = action === "delete";
+        const { status: st, data } = await sendAction<{ error?: string }>(
+          isDel
+            ? `/api/workflow/items/${encodeURIComponent(selId)}`
+            : `/api/workflow/items/${encodeURIComponent(selId)}/${action}`,
+          isDel ? "DELETE" : "POST",
+        );
+        if (st >= 200 && st < 300) {
+          if (isDel) {
+            setSelId(null);
+            setDetail(null);
+            refreshList();
+          } else {
+            openProposal(selId); // refresh detail + events after the transition
+          }
+        } else {
+          setActMsg(data.error || `failed (HTTP ${st})`);
+        }
+      } catch {
+        setActMsg("action failed");
+      } finally {
+        setActing(false);
+      }
+    },
+    [selId, acting, refreshList, openProposal],
+  );
+
   const canDecide = !!detail && detail.pause_reason === "pending_human";
+  // Which lifecycle controls apply to the current item.
+  const term = !!detail && isTerminal(detail.state);
+  const paused = !!detail && !term && !!detail.pause_reason;
+  const canPause = !!detail && !term && !detail.pause_reason;
+  const canResume = paused && detail!.pause_reason !== "pending_human";
+  const canStop = !!detail && !term;
 
   return (
     <div style={{ display: "flex", height: "100%", fontFamily: "system-ui" }}>
@@ -435,6 +501,39 @@ export default function WorkflowActions() {
             </div>
             <StatusHeader item={detail} />
 
+            {/* Lifecycle controls: start (resume) / pause / stop / delete. Shown by
+                the item's current state; a run at a human gate uses Approve/Reject
+                (below) rather than resume. */}
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", margin: "4px 0 10px" }}>
+              {canResume && (
+                <button onClick={() => void doLifecycle("resume")} disabled={acting} style={btn}>
+                  ▶ Start
+                </button>
+              )}
+              {canPause && (
+                <button onClick={() => void doLifecycle("pause")} disabled={acting} style={btn}>
+                  ⏸ Pause
+                </button>
+              )}
+              {canStop && (
+                <button
+                  onClick={() => void doLifecycle("stop")}
+                  disabled={acting}
+                  style={{ ...btn, background: "#fbeaea", color: "#a33", borderColor: "#e0a0a0" }}
+                >
+                  ⏹ Stop
+                </button>
+              )}
+              <button
+                onClick={() => void doLifecycle("delete")}
+                disabled={acting}
+                style={{ ...btn, background: "#fff5f5", color: "#c00", borderColor: "#e6b3b3", marginLeft: "auto" }}
+              >
+                🗑 Delete
+              </button>
+              {actMsg && <span style={{ fontSize: 12, color: "#c00", flexBasis: "100%" }}>{actMsg}</span>}
+            </div>
+
             {canDecide && (
               <Panel title={`Human gate · ${detail.stage}`}>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -505,6 +604,61 @@ function Composer({
   const [preview, setPreview] = useState<string | null>(null);
   const [draftErr, setDraftErr] = useState("");
   const busy = drafting || submitting;
+
+  // "Load a proposal from the project": a read-only, path-confined browser over
+  // the server's local checkout. Picking a .md file previews its contents into the
+  // same accept-first preview panel used by the delegate draft, so it never
+  // silently clobbers the body.
+  const [browsing, setBrowsing] = useState(false);
+  const [browsePath, setBrowsePath] = useState("");
+  const [entries, setEntries] = useState<{ name: string; type: "dir" | "file" }[]>([]);
+  const [browseErr, setBrowseErr] = useState("");
+  const [browseLoading, setBrowseLoading] = useState(false);
+
+  const loadTree = async (path: string) => {
+    setBrowseErr("");
+    setBrowseLoading(true);
+    try {
+      const d = await getJSON<{ path: string; entries: { name: string; type: "dir" | "file" }[] }>(
+        `/api/workflow/repo/tree?path=${encodeURIComponent(path)}`,
+      );
+      setBrowsePath(d.path || "");
+      // Directories first, then files; each group alphabetical.
+      const es = (d.entries || []).slice().sort((a, b) =>
+        a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name),
+      );
+      setEntries(es);
+    } catch (e) {
+      setBrowseErr(`could not list: ${(e as Error).message}`);
+      setEntries([]);
+    } finally {
+      setBrowseLoading(false);
+    }
+  };
+  const openBrowser = () => {
+    setBrowsing(true);
+    void loadTree(browsePath || "docs/proposals");
+  };
+  const parentPath = (p: string) => {
+    const i = p.lastIndexOf("/");
+    return i > 0 ? p.slice(0, i) : "";
+  };
+  const pickFile = async (name: string) => {
+    const rel = browsePath ? `${browsePath}/${name}` : name;
+    setBrowseErr("");
+    setBrowseLoading(true);
+    try {
+      const d = await getJSON<{ content: string; truncated: boolean }>(
+        `/api/workflow/repo/file?path=${encodeURIComponent(rel)}`,
+      );
+      setPreview(d.content || "");
+      setBrowsing(false);
+    } catch (e) {
+      setBrowseErr(`could not read: ${(e as Error).message}`);
+    } finally {
+      setBrowseLoading(false);
+    }
+  };
 
   const generate = async () => {
     if (drafting) return; // re-entrancy guard (the button is also disabled while busy)
@@ -628,9 +782,80 @@ function Composer({
         <button onClick={() => void generate()} disabled={busy} style={btn}>
           {drafting ? "Drafting…" : "✨ Draft with a delegate"}
         </button>
+        <button onClick={() => (browsing ? setBrowsing(false) : openBrowser())} disabled={busy} style={btn}>
+          {browsing ? "Close browser" : "📂 Load from project"}
+        </button>
         {submitMsg && <span style={{ fontSize: 12, color: "#c00" }}>{submitMsg}</span>}
         {draftErr && <span style={{ fontSize: 12, color: "#c00" }}>{draftErr}</span>}
       </div>
+
+      {browsing && (
+        <div
+          style={{
+            border: "1px solid #d9e2ef",
+            background: "#fbfdff",
+            borderRadius: 6,
+            padding: 10,
+            marginTop: 10,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+            <strong style={{ fontSize: 13 }}>Project</strong>
+            <span style={{ fontSize: 12, color: "#667", fontFamily: "monospace", overflowWrap: "anywhere" }}>
+              /{browsePath}
+            </span>
+            {browseLoading && <span style={{ fontSize: 11, color: "#aaa" }}>loading…</span>}
+            <span style={{ marginLeft: "auto", fontSize: 11, color: "#888" }}>
+              Pick a .md file to load it as the proposal.
+            </span>
+          </div>
+          {browseErr && <div style={{ fontSize: 12, color: "#c00", marginBottom: 6 }}>{browseErr}</div>}
+          <div style={{ maxHeight: 280, overflow: "auto", border: "1px solid #eef2f7", borderRadius: 4 }}>
+            {browsePath && (
+              <BrowseRow icon="↩" label=".." onClick={() => void loadTree(parentPath(browsePath))} />
+            )}
+            {entries.length === 0 && !browseLoading && (
+              <div style={{ padding: "8px 10px", color: "#999", fontSize: 13 }}>
+                No sub-folders or .md files here.
+              </div>
+            )}
+            {entries.map((e) =>
+              e.type === "dir" ? (
+                <BrowseRow
+                  key={e.name}
+                  icon="📁"
+                  label={e.name}
+                  onClick={() => void loadTree(browsePath ? `${browsePath}/${e.name}` : e.name)}
+                />
+              ) : (
+                <BrowseRow key={e.name} icon="📄" label={e.name} onClick={() => void pickFile(e.name)} />
+              ),
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BrowseRow({ icon, label, onClick }: { icon: string; label: string; onClick: () => void }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "6px 10px",
+        cursor: "pointer",
+        borderBottom: "1px solid #f4f7fb",
+        fontSize: 13,
+      }}
+      onMouseEnter={(ev) => (ev.currentTarget.style.background = "#eef4ff")}
+      onMouseLeave={(ev) => (ev.currentTarget.style.background = "transparent")}
+    >
+      <span style={{ width: 16, textAlign: "center" }}>{icon}</span>
+      <span style={{ overflowWrap: "anywhere" }}>{label}</span>
     </div>
   );
 }

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -574,6 +574,7 @@ static const struct
     {"agent.probe", "POST", "/v1/agent/probe"},
     {"agent.remove", "POST", "/v1/agent/remove"},
     {"agent.roles", "POST", "/v1/agent/roles"},
+    {"agent.set", "POST", "/v1/agent/set"},
     {"agent.setup", "POST", "/v1/agent/setup"},
     {"agent.setup_poll", "POST", "/v1/agent/setup_poll"},
     {"agent.stats", "GET", "/v1/agent/stats"},

--- a/src/db1/harness_memory.c
+++ b/src/db1/harness_memory.c
@@ -251,6 +251,29 @@ int hmem_list(const char *project, hmem_row_t **out, int *n, int include_deleted
    return rc;
 }
 
+int hmem_page_end(const hmem_row_t *rows, int n, int offset, size_t budget)
+{
+   if (!rows || n <= 0)
+      return (offset < 0) ? 0 : (offset > n ? n : offset);
+   if (offset < 0)
+      offset = 0;
+   size_t bytes = 0;
+   int i = offset;
+   for (; i < n; i++)
+   {
+      const hmem_row_t *r = &rows[i];
+      /* Approximate the row's serialized JSON: the variable-length fields plus a
+       * fixed slop for keys, the fixed-width columns, and punctuation. */
+      size_t rowsz = (r->body ? strlen(r->body) : 0) +
+                     (r->description ? strlen(r->description) : 0) +
+                     (r->meta_json ? strlen(r->meta_json) : 0) + 512;
+      if (i > offset && bytes + rowsz > budget)
+         break; /* this row opens the next page */
+      bytes += rowsz;
+   }
+   return i;
+}
+
 int hmem_search(const char *project, const char *query, hmem_row_t **out, int *n)
 {
    if (!project || !query || !out || !n)

--- a/src/db1/harness_memory.h
+++ b/src/db1/harness_memory.h
@@ -69,6 +69,13 @@ extern "C"
    /* Substring search over name/description/body of live rows. As hmem_list. */
    int hmem_search(const char *project, const char *query, hmem_row_t **out, int *n);
 
+   /* Exclusive end index of the response page that starts at `offset` and whose
+    * serialized rows fit within `budget` bytes. Always returns at least
+    * offset+1 when rows remain (so a single oversized row still advances and the
+    * pager can't stall). Pure — used by the list/search routes to page a result
+    * set that would otherwise overflow the fixed RPC response buffer. */
+   int hmem_page_end(const hmem_row_t *rows, int n, int offset, size_t budget);
+
    /* Tombstone one live row. Returns 0 (even if already absent) / -1 on error. */
    int hmem_tombstone(const char *project, const char *name);
 

--- a/src/db1/wfe_store.c
+++ b/src/db1/wfe_store.c
@@ -425,6 +425,31 @@ int db1_work_item_clear_pause(const char *wi)
                             wi);
 }
 
+int db1_work_item_delete(const char *wi)
+{
+   if (!wi || !wi[0])
+      return -1;
+   /* No FK cascade: the three lifecycle tables are independent, so remove the
+    * item's rows from each under one transaction (all-or-nothing). Events and
+    * stage-attempts are deleted first, then the item row, so a partial failure
+    * never leaves an item row without its history or vice versa. */
+   if (db1_lifecycle_txn_begin() != 0)
+      return -1;
+   if (exec_bind1_update("DELETE FROM lifecycle_event WHERE work_item_id=?", wi) != 0 ||
+       exec_bind1_update("DELETE FROM lifecycle_stage_attempt WHERE work_item_id=?", wi) != 0 ||
+       exec_bind1_update("DELETE FROM lifecycle_work_item WHERE work_item_id=?", wi) != 0)
+   {
+      db1_lifecycle_txn_rollback();
+      return -1;
+   }
+   if (db1_lifecycle_txn_commit() != 0)
+   {
+      db1_lifecycle_txn_rollback();
+      return -1;
+   }
+   return 0;
+}
+
 int db1_work_item_add_cost(const char *wi, double cost)
 {
    sqlite3 *db = db1_conn();

--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -115,6 +115,14 @@ int db1_work_item_add_cost(const char *work_item_id, double cost);
 int db1_work_item_set_cost_cap(const char *work_item_id, double cap);
 int db1_work_item_inc_override(const char *work_item_id); /* returns new count, -1 err */
 
+/* Permanently delete a work item and all its history (lifecycle_event +
+ * lifecycle_stage_attempt + lifecycle_work_item rows) under one transaction.
+ * There is no FK cascade, so all three tables are cleared explicitly. Returns
+ * 0 on success (incl. an already-absent item — DELETE is idempotent), -1 on
+ * error. The caller is responsible for any out-of-DB artifacts (proposal file,
+ * worktree). */
+int db1_work_item_delete(const char *work_item_id);
+
 /* List work items (newest first). Caller frees *out. Returns count or -1. */
 int db1_work_item_list(db1_work_item_t **out);
 

--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -372,35 +372,13 @@ int harness_memory_hydrate(const char *cwd)
     * below reflects them. */
    int consumed = consume_spills(project, endpoint, bearer);
 
-   /* include_deleted so tombstoned rows come back too — we materialize live rows
-    * and *remove* the on-disk file for each tombstone (DB1 is authoritative). */
-   cJSON *body = cJSON_CreateObject();
-   cJSON_AddStringToObject(body, "project", project);
-   cJSON_AddNumberToObject(body, "include_deleted", 1);
-   char *body_s = cJSON_PrintUnformatted(body);
-   cJSON_Delete(body);
-
-   int status = 0;
-   cJSON *resp = body_s ? cli_http_request(endpoint, "POST", "/v1/harness_memory/list", body_s,
-                                           bearer, 15000, &status)
-                        : NULL;
-   free(body_s);
-   if (!resp || status < 200 || status >= 300)
-   {
-      if (resp)
-         cJSON_Delete(resp);
-      free(endpoint);
-      free(bearer);
-      return (consumed > 0) ? consumed : -1;
-   }
-
-   /* Ensure the memory dir exists and resolve it, so we can confine every write
-    * under the *real* directory (a symlinked component can't redirect us out). */
+   /* Ensure the memory dir exists and resolve it up front, so we can confine
+    * every write under the *real* directory (a symlinked component can't
+    * redirect us out). Needed before we process any page. */
    mkdir_p(memdir);
    char memreal[PATH_MAX];
    if (!hm_realpath(memdir, memreal))
    {
-      cJSON_Delete(resp);
       free(endpoint);
       free(bearer);
       return -1;
@@ -412,65 +390,105 @@ int harness_memory_hydrate(const char *cwd)
     * memory whose file lingers stays "known", so it is never re-imported).
     * known_ok guards completeness: if any insertion fails (OOM), the set is no
     * longer authoritative, so we skip the import pass entirely rather than risk
-    * resurrecting a tombstone we failed to record. */
+    * resurrecting a tombstone we failed to record. list_ok is the same guard for
+    * a failed page — a partial known set must not drive the import. */
    char **known = NULL;
    int nk = 0, kcap = 0, known_ok = 1;
+   int n = 0, removed = 0, list_ok = 1;
 
-   int n = 0, removed = 0;
-   cJSON *mems = cJSON_GetObjectItemCaseSensitive(resp, "memories");
-   cJSON *m = NULL;
-   cJSON_ArrayForEach(m, mems)
+   /* Page through the store (include_deleted so tombstoned rows come back — we
+    * materialize live rows and *remove* the file for each tombstone; DB1 is
+    * authoritative). The full set, bodies included, can exceed one RPC response
+    * buffer, so follow next_offset until has_more is false rather than asking
+    * for everything at once (an over-large single response truncates and 502s,
+    * which used to abort this hydrate before the import pass). */
+   for (int offset = 0;;)
    {
-      const char *name = jstr(m, "name");
-      const char *btext = jstr(m, "body");
-      const char *del = jstr(m, "deleted_at");
-      if (!name || !name[0] || name[0] == '/' || strstr(name, "..")) /* never escape memdir */
-         continue;
-      if (nk == kcap)
+      cJSON *body = cJSON_CreateObject();
+      cJSON_AddStringToObject(body, "project", project);
+      cJSON_AddNumberToObject(body, "include_deleted", 1);
+      cJSON_AddNumberToObject(body, "offset", offset);
+      char *body_s = cJSON_PrintUnformatted(body);
+      cJSON_Delete(body);
+
+      int status = 0;
+      cJSON *resp = body_s ? cli_http_request(endpoint, "POST", "/v1/harness_memory/list", body_s,
+                                              bearer, 15000, &status)
+                           : NULL;
+      free(body_s);
+      if (!resp || status < 200 || status >= 300)
       {
-         int nc = kcap ? kcap * 2 : 32;
-         char **t = realloc(known, (size_t)nc * sizeof(*t));
-         if (t)
-         {
-            known = t;
-            kcap = nc;
-         }
+         if (resp)
+            cJSON_Delete(resp);
+         list_ok = 0;
+         break;
       }
-      if (nk < kcap)
+
+      cJSON *mems = cJSON_GetObjectItemCaseSensitive(resp, "memories");
+      cJSON *m = NULL;
+      cJSON_ArrayForEach(m, mems)
       {
-         char *dup = strdup(name);
-         if (dup)
-            known[nk++] = dup;
+         const char *name = jstr(m, "name");
+         const char *btext = jstr(m, "body");
+         const char *del = jstr(m, "deleted_at");
+         if (!name || !name[0] || name[0] == '/' || strstr(name, "..")) /* never escape memdir */
+            continue;
+         if (nk == kcap)
+         {
+            int nc = kcap ? kcap * 2 : 32;
+            char **t = realloc(known, (size_t)nc * sizeof(*t));
+            if (t)
+            {
+               known = t;
+               kcap = nc;
+            }
+         }
+         if (nk < kcap)
+         {
+            char *dup = strdup(name);
+            if (dup)
+               known[nk++] = dup;
+            else
+               known_ok = 0;
+         }
          else
-            known_ok = 0;
-      }
-      else
-      {
-         known_ok = 0;
-      }
-      char target[PATH_MAX];
-      if ((size_t)snprintf(target, sizeof(target), "%s/%s.md", memdir, name) >= sizeof(target))
-         continue;
-      if (del && del[0]) /* tombstoned: ensure the on-disk file is gone */
-      {
-         if (target_confined(target, memreal) && unlink(target) == 0)
          {
-            removed++;
-            hmem_audit("tombstone-removed", project, name, NULL);
+            known_ok = 0;
          }
-         continue;
+         char target[PATH_MAX];
+         if ((size_t)snprintf(target, sizeof(target), "%s/%s.md", memdir, name) >= sizeof(target))
+            continue;
+         if (del && del[0]) /* tombstoned: ensure the on-disk file is gone */
+         {
+            if (target_confined(target, memreal) && unlink(target) == 0)
+            {
+               removed++;
+               hmem_audit("tombstone-removed", project, name, NULL);
+            }
+            continue;
+         }
+         mkdir_parents(target);
+         if (target_confined(target, memreal) && write_file(target, btext ? btext : "") == 0)
+            n++;
       }
-      mkdir_parents(target);
-      if (target_confined(target, memreal) && write_file(target, btext ? btext : "") == 0)
-         n++;
+
+      cJSON *hm = cJSON_GetObjectItemCaseSensitive(resp, "has_more");
+      cJSON *no = cJSON_GetObjectItemCaseSensitive(resp, "next_offset");
+      int has_more = cJSON_IsBool(hm) && cJSON_IsTrue(hm);
+      int next_offset = cJSON_IsNumber(no) ? (int)no->valuedouble : offset;
+      cJSON_Delete(resp);
+      /* Stop on the last page; the <= guard also prevents an infinite loop if a
+       * misbehaving server never advances the cursor. */
+      if (!has_more || next_offset <= offset)
+         break;
+      offset = next_offset;
    }
-   cJSON_Delete(resp);
 
    /* Import disk-only memory files the store has never seen (pre-existing files,
     * external edits, or fail-open writes whose spill was lost). Skipped when the
-    * known set is incomplete — see known_ok above. */
+    * known set is incomplete — see known_ok / list_ok above. */
    int imported = 0;
-   if (known_ok)
+   if (list_ok && known_ok)
       import_orphans(memreal, memreal, known, nk, project, endpoint, bearer, &imported);
 
    for (int i = 0; i < nk; i++)

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -453,6 +453,7 @@ int handle_agent_remove(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_enable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_roles(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_personas(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_disable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_probe(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_agent_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/headers/server_http_internal.h
+++ b/src/headers/server_http_internal.h
@@ -106,4 +106,16 @@ typedef int (*route_handler_fn)(const route_req_t *rq, char *resp, int cap);
 /* PC2: CI webhook route handler (defined in server_ci_route.c). */
 int rh_dev_ci_event(const route_req_t *rq, char *resp, int cap);
 
+/* Workflow Actions lifecycle + project-file-browser route adapters + the shared
+ * unsigned-long query-param helper — defined in server_http_config_routes.c
+ * (relocated out of server_http_routes.c to stay under the line-check ceiling).
+ * Referenced by the route table in server_http_routes.c. */
+long rh_query_long(const char *key, long dflt);
+int rh_wf_item_pause(const route_req_t *rq, char *resp, int cap);
+int rh_wf_item_resume(const route_req_t *rq, char *resp, int cap);
+int rh_wf_item_stop(const route_req_t *rq, char *resp, int cap);
+int rh_wf_item_delete(const route_req_t *rq, char *resp, int cap);
+int rh_wf_repo_tree(const route_req_t *rq, char *resp, int cap);
+int rh_wf_repo_file(const route_req_t *rq, char *resp, int cap);
+
 #endif /* SERVER_HTTP_INTERNAL_H */

--- a/src/server/harness_memory_routes.c
+++ b/src/server/harness_memory_routes.c
@@ -99,13 +99,32 @@ int handle_hmem_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return send_and_free(conn, resp);
 }
 
-static int respond_rows(server_conn_t *conn, hmem_row_t *rows, int n)
+/* The whole result set (bodies included) can exceed the fixed RPC response
+ * buffer (SHTTP_RESP_MAX, 256 KiB) once a project accumulates enough memories —
+ * the loopback RPC then truncates and the JSON fails to parse (a 502 that, for
+ * `list`, aborts the session-start hydrate before it can import disk-only files).
+ * So serialize a size-bounded page: rows from `offset` until the accumulated
+ * payload approaches the budget, always emitting at least one row so a single
+ * large memory still makes progress (it stays well under 256 KiB in practice).
+ * The caller pages via {offset -> next_offset} until has_more is false. */
+#define HMEM_PAGE_BUDGET (192 * 1024)
+
+static int respond_rows_paged(server_conn_t *conn, hmem_row_t *rows, int n, int offset)
 {
+   if (offset < 0)
+      offset = 0;
+   if (offset > n)
+      offset = n;
+   int end = hmem_page_end(rows, n, offset, HMEM_PAGE_BUDGET);
    cJSON *resp = jo_ok();
    cJSON *arr = cJSON_CreateArray();
-   for (int i = 0; i < n; i++)
+   for (int i = offset; i < end; i++)
       cJSON_AddItemToArray(arr, hmem_row_json(&rows[i]));
    cJSON_AddItemToObject(resp, "memories", arr);
+   cJSON_AddNumberToObject(resp, "total", n);
+   cJSON_AddNumberToObject(resp, "offset", offset);
+   cJSON_AddNumberToObject(resp, "next_offset", end);
+   cJSON_AddBoolToObject(resp, "has_more", end < n);
    hmem_rows_free(rows, n);
    return send_and_free(conn, resp);
 }
@@ -117,11 +136,12 @@ int handle_hmem_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (jo_need_str(req, "project", &project) < 0)
       return server_send_error(conn, "missing project", NULL);
    int include_deleted = jo_int(req, "include_deleted", 0);
+   int offset = jo_int(req, "offset", 0);
    hmem_row_t *rows = NULL;
    int n = 0;
    if (hmem_list(project, &rows, &n, include_deleted) != 0)
       return server_send_error(conn, "list failed", NULL);
-   return respond_rows(conn, rows, n);
+   return respond_rows_paged(conn, rows, n, offset);
 }
 
 int handle_hmem_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
@@ -130,11 +150,12 @@ int handle_hmem_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    const char *project, *query;
    if (jo_need_str(req, "project", &project) < 0 || jo_need_str(req, "query", &query) < 0)
       return server_send_error(conn, "missing project or query", NULL);
+   int offset = jo_int(req, "offset", 0);
    hmem_row_t *rows = NULL;
    int n = 0;
    if (hmem_search(project, query, &rows, &n) != 0)
       return server_send_error(conn, "search failed", NULL);
-   return respond_rows(conn, rows, n);
+   return respond_rows_paged(conn, rows, n, offset);
 }
 
 int handle_hmem_tombstone(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1337,6 +1337,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"agent.enable", handle_agent_enable},
     {"agent.roles", handle_agent_roles},
     {"agent.personas", handle_agent_personas},
+    {"agent.set", handle_agent_set},
     {"agent.disable", handle_agent_disable},
     {"agent.probe", handle_agent_probe},
     {"agent.stats", handle_agent_stats},

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -1026,6 +1026,110 @@ int handle_agent_personas(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, resp);
 }
 
+/* agent.set — surgically patch ONLY the fields the caller passed on an existing
+ * agent, preserving everything else (unlike agent.add, which resets the whole
+ * record). Backs the Web GUI's per-agent Edit modal. Args are CLI-style:
+ *   set <name> [--model M] [--endpoint E] [--provider P] [--cost-tier N]
+ *       [--max-turns N] [--max-parallel N] [--context-window N] [--tools on|off]
+ *       [--roles csv] [--personas csv] [--enabled true|false] [--key K]
+ * A flag that is absent leaves that field untouched. */
+int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   char *argv[SERVER_AGENT_MAX_ARGS];
+   int argc = server_agent_args(req, argv, (int)(sizeof(argv) / sizeof(argv[0])));
+   if (argc < 1 || !argv[0][0])
+      return server_send_error(conn, "agent.set requires name", NULL);
+   /* All --flags carry a value (no bool flags), so each is present iff opt_get
+    * returns non-NULL — that presence check is what makes the patch surgical. */
+   static const char *bool_flags[] = {NULL};
+   opt_parsed_t opts;
+   opt_parse(argc - 1, argv + 1, bool_flags, &opts);
+
+   agent_config_t cfg;
+   if (agent_load_config(&cfg) != 0)
+      return server_send_error(conn, "agents.json not found or invalid", NULL);
+   agent_t *ag = agent_find(&cfg, argv[0]);
+   if (!ag)
+      return server_send_error(conn, "agent not found", NULL);
+
+   char old_model[MAX_MODEL_LEN];
+   snprintf(old_model, sizeof(old_model), "%s", ag->model);
+
+   const char *v;
+   if ((v = opt_get(&opts, "model")) && v[0])
+      snprintf(ag->model, sizeof(ag->model), "%s", v);
+   if ((v = opt_get(&opts, "endpoint")) != NULL)
+      snprintf(ag->endpoint, sizeof(ag->endpoint), "%s", v);
+   if ((v = opt_get(&opts, "provider")) && v[0])
+      snprintf(ag->provider, sizeof(ag->provider), "%s", v);
+   if ((v = opt_get(&opts, "cost-tier")) != NULL)
+      ag->cost_tier = atoi(v);
+   if ((v = opt_get(&opts, "max-turns")) != NULL)
+      ag->max_turns = atoi(v);
+   if ((v = opt_get(&opts, "max-parallel")) != NULL)
+      ag->max_parallel = atoi(v);
+   if ((v = opt_get(&opts, "context-window")) != NULL || (v = opt_get(&opts, "ctx")) != NULL)
+      ag->middleware.context_window = atoi(v);
+   if ((v = opt_get(&opts, "tools")) != NULL)
+   {
+      ag->tools_enabled = (strcmp(v, "on") == 0 || strcmp(v, "true") == 0 || strcmp(v, "1") == 0);
+      ag->inject_respond_tool = ag->tools_enabled ? 1 : 0;
+   }
+   if ((v = opt_get(&opts, "enabled")) != NULL)
+      ag->enabled = (strcmp(v, "true") == 0 || strcmp(v, "1") == 0 || strcmp(v, "on") == 0);
+   if ((v = opt_get(&opts, "roles")) != NULL)
+      server_agent_set_roles_csv(
+          ag,
+          v[0] ? v : "code,review,explain,refactor,draft,execute,summarize,format,reason,search");
+   if ((v = opt_get(&opts, "personas")) != NULL)
+      server_agent_set_personas_csv(ag, v[0] ? v : "all");
+
+   /* An optional re-key vaults the secret exactly like agent.add (never persisted
+    * to agents.json), gated by the same server-write capability check. */
+   const char *key = opt_get(&opts, "key");
+   if (key && key[0])
+   {
+      if (key[0] == '$')
+      {
+         snprintf(ag->api_key, sizeof(ag->api_key), "%s", key);
+         snprintf(ag->api_key_disk, sizeof(ag->api_key_disk), "%s", key);
+      }
+      else
+      {
+         const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
+         attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
+         if (!principal && !vault_capability_server_write_allowed(transport, NULL))
+            return server_send_error(
+                conn,
+                "vault: `agent set --key` over a plaintext connection cannot store a credential; "
+                "use a native-TLS (https) or attested local/webchat connection",
+                NULL);
+         vault_status_t vst =
+             principal
+                 ? vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key, (long)time(NULL))
+                 : vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
+         if (vst != VAULT_OK)
+            return server_send_error(conn,
+                                     vst == VAULT_ERR_LOCKED
+                                         ? "vault locked: run `aimee vault unlock` before re-keying"
+                                         : "could not store credential in the vault",
+                                     NULL);
+      }
+   }
+
+   if (agent_save_config(&cfg) != 0)
+      return server_send_error(conn, "could not save agents.json", NULL);
+   if (ag->max_parallel > 0)
+      (void)server_agent_set_model_concurrency(ag->model, ag->max_parallel);
+   if (old_model[0] && strcmp(old_model, ag->model) != 0)
+      (void)server_agent_clear_model_concurrency_if_unused(&cfg, old_model);
+
+   cJSON *resp = server_agent_to_json(ag);
+   cJSON_AddStringToObject(resp, "status", "ok");
+   return server_send_ok(conn, resp);
+}
+
 int handle_agent_probe(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;

--- a/src/server/server_http_config_routes.c
+++ b/src/server/server_http_config_routes.c
@@ -30,6 +30,7 @@
 #include "request_context.h"
 #include "server_http_identity.h" /* WP-C.0 attested-identity capture/threading */
 #include "server_workflow_api.h"  /* W7: /v1/workflow read+author handlers */
+#include "wfe_scheduler.h"        /* wfe_scheduler_notify — resume the autonomy driver */
 #include "cJSON.h"
 #include <arpa/inet.h>
 #include <errno.h>
@@ -280,4 +281,122 @@ int route_role_template_remove(const char *name, char *resp, int cap)
    cJSON_AddStringToObject(o, "role", name);
    cJSON_AddBoolToObject(o, "deleted", 1);
    return emit(resp, cap, o);
+}
+
+/* ── query-param helpers + Workflow Actions route adapters ───────────────────
+ * Relocated here from server_http_routes.c (referenced by that TU's route table
+ * via server_http_internal.h) to keep that file under the line-check ceiling. */
+
+/* Parse an unsigned long query param ("k=v&…") from the request's query string;
+ * returns `dflt` when the key is absent or unparseable. */
+long rh_query_long(const char *key, long dflt)
+{
+   const char *q = server_http_identity_query();
+   size_t klen = strlen(key);
+   for (const char *p = q; p && *p;)
+   {
+      const char *amp = strchr(p, '&');
+      if (strncmp(p, key, klen) == 0 && p[klen] == '=')
+      {
+         char *end = NULL;
+         long v = strtol(p + klen + 1, &end, 10);
+         if (end != p + klen + 1)
+            return v;
+         return dflt;
+      }
+      if (!amp)
+         break;
+      p = amp + 1;
+   }
+   return dflt;
+}
+
+/* One hex digit → value, or -1. */
+static int rh_hex(char c)
+{
+   if (c >= '0' && c <= '9')
+      return c - '0';
+   if (c >= 'a' && c <= 'f')
+      return c - 'a' + 10;
+   if (c >= 'A' && c <= 'F')
+      return c - 'A' + 10;
+   return -1;
+}
+
+/* Read a percent-decoded string query param into `out` ("" if absent). A path may
+ * arrive percent-encoded (encodeURIComponent turns '/' into %2F), so %XX escapes
+ * are decoded; a malformed escape is copied literally. */
+static void rh_query_str(const char *key, char *out, size_t cap)
+{
+   if (cap)
+      out[0] = '\0';
+   const char *q = server_http_identity_query();
+   size_t klen = strlen(key);
+   for (const char *p = q; p && *p;)
+   {
+      const char *amp = strchr(p, '&');
+      if (strncmp(p, key, klen) == 0 && p[klen] == '=')
+      {
+         const char *v = p + klen + 1;
+         const char *end = amp ? amp : v + strlen(v);
+         size_t o = 0;
+         for (const char *s = v; s < end && cap && o + 1 < cap; s++)
+         {
+            int hi, lo;
+            if (*s == '%' && s + 2 < end && (hi = rh_hex(s[1])) >= 0 && (lo = rh_hex(s[2])) >= 0)
+            {
+               out[o++] = (char)((hi << 4) | lo);
+               s += 2;
+            }
+            else
+            {
+               out[o++] = *s;
+            }
+         }
+         if (cap)
+            out[o] = '\0';
+         return;
+      }
+      if (!amp)
+         break;
+      p = amp + 1;
+   }
+}
+
+/* Lifecycle mutations. The route cap (CAP_DASHBOARD_READ) admits owners; operator
+ * status (CAP_WORKFLOW_ADMIN on the connection) lifts the owner-only restriction
+ * inside the wf_api_* handler. */
+#define RH_WF_IS_OPERATOR() ((g_rpc_conn_caps & CAP_WORKFLOW_ADMIN) != 0)
+int rh_wf_item_pause(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_item_pause(rq->id, RH_WF_IS_OPERATOR(), resp, cap);
+}
+int rh_wf_item_resume(const route_req_t *rq, char *resp, int cap)
+{
+   int rc = wf_api_item_resume(rq->id, RH_WF_IS_OPERATOR(), resp, cap);
+   if (rc >= 200 && rc < 300)
+      wfe_scheduler_notify(); /* wake the driver so the resumed run advances now */
+   return rc;
+}
+int rh_wf_item_stop(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_item_stop(rq->id, RH_WF_IS_OPERATOR(), resp, cap);
+}
+int rh_wf_item_delete(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_item_delete(rq->id, RH_WF_IS_OPERATOR(), resp, cap);
+}
+int rh_wf_repo_tree(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   char path[4096];
+   rh_query_str("path", path, sizeof path);
+   return wf_api_repo_tree(path, resp, cap);
+}
+int rh_wf_repo_file(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   char path[4096];
+   rh_query_str("path", path, sizeof path);
+   return wf_api_repo_file(path, resp, cap);
 }

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -841,29 +841,8 @@ static int rh_wf_item(const route_req_t *rq, char *resp, int cap)
 {
    return wf_api_item(rq->id, resp, cap);
 }
-/* Parse an unsigned long query param ("k=v&…") from the request's query string;
- * returns `dflt` when the key is absent or unparseable. */
-static long rh_query_long(const char *key, long dflt)
-{
-   const char *q = server_http_identity_query();
-   size_t klen = strlen(key);
-   for (const char *p = q; p && *p;)
-   {
-      const char *amp = strchr(p, '&');
-      if (strncmp(p, key, klen) == 0 && p[klen] == '=')
-      {
-         char *end = NULL;
-         long v = strtol(p + klen + 1, &end, 10);
-         if (end != p + klen + 1)
-            return v;
-         return dflt;
-      }
-      if (!amp)
-         break;
-      p = amp + 1;
-   }
-   return dflt;
-}
+/* rh_query_long is declared in server_http_internal.h and defined in
+ * server_http_config_routes.c (moved there to keep this TU under the line cap). */
 static int rh_wf_events(const route_req_t *rq, char *resp, int cap)
 {
    long after = rh_query_long("after", 0);
@@ -874,6 +853,11 @@ static int rh_wf_proposal(const route_req_t *rq, char *resp, int cap)
 {
    return wf_api_proposal(rq->id, resp, cap);
 }
+
+/* The Workflow Actions lifecycle (rh_wf_item_pause/resume/stop/delete) and
+ * project-file-browser (rh_wf_repo_tree/file) route adapters are defined in
+ * server_http_config_routes.c (declared in server_http_internal.h) so this TU
+ * stays under the line-check ceiling; the route table below references them. */
 
 /* The POST /v1/rpc bridge was retired once every dispatch method gained a
  * first-class /v1 route (op-parity complete; check-v1-method-coverage reports 0
@@ -2318,7 +2302,21 @@ static const http_route_t g_v1_routes[] = {
     {"GET", "/v1/workflow/items/", "/events", RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_events},
     {"GET", "/v1/workflow/items/", "/proposal", RM_PREFIX, NULL, CAP_DASHBOARD_READ,
      rh_wf_proposal},
+    /* Lifecycle mutations. Route cap admits owners (CAP_DASHBOARD_READ); the
+     * handler additionally allows operators (CAP_WORKFLOW_ADMIN) and 403s a
+     * non-owner non-operator. Suffix rows precede the bare /<id> rows. */
+    {"POST", "/v1/workflow/items/", "/pause", RM_PREFIX, NULL, CAP_DASHBOARD_READ,
+     rh_wf_item_pause},
+    {"POST", "/v1/workflow/items/", "/resume", RM_PREFIX, NULL, CAP_DASHBOARD_READ,
+     rh_wf_item_resume},
+    {"POST", "/v1/workflow/items/", "/stop", RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item_stop},
     {"GET", "/v1/workflow/items/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item},
+    /* DELETE the bare /<id> — distinct from the GET row by verb; auto-stops an
+     * active run then removes it. */
+    {"DELETE", "/v1/workflow/items/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item_delete},
+    /* Composer project-file browser (read-only, confined to the local checkout). */
+    {"GET", "/v1/workflow/repo/tree", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_repo_tree},
+    {"GET", "/v1/workflow/repo/file", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_repo_file},
 
     {"GET", "/v1/sessions", NULL, RM_EXACT, NULL, CAP_SESSION_READ, rh_sessions_list},
     {"POST", "/v1/sessions/", "/attach", RM_PREFIX, NULL, CAP_SESSION_READ, rh_session_attach},

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -2065,6 +2065,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/agent/enable", NULL, RM_EXACT, "agent.enable", 0, rh_dispatch_op},
     {"POST", "/v1/agent/roles", NULL, RM_EXACT, "agent.roles", 0, rh_dispatch_op},
     {"POST", "/v1/agent/personas", NULL, RM_EXACT, "agent.personas", 0, rh_dispatch_op},
+    {"POST", "/v1/agent/set", NULL, RM_EXACT, "agent.set", 0, rh_dispatch_op},
     {"POST", "/v1/agent/disable", NULL, RM_EXACT, "agent.disable", 0, rh_dispatch_op},
     {"POST", "/v1/agent/probe", NULL, RM_EXACT, "agent.probe", 0, rh_dispatch_op},
     {"GET", "/v1/agent/stats", NULL, RM_EXACT, "agent.stats", 0, rh_dispatch_op},

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -14,6 +14,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h> /* PATH_MAX for the confined project-file browser */
 #include <unistd.h>
 #endif
 
@@ -782,6 +783,276 @@ int wf_api_proposal(const char *id, char *resp, int cap)
 
    cJSON *o = cJSON_CreateObject();
    cJSON_AddStringToObject(o, "proposal_md", buf);
+   cJSON_AddBoolToObject(o, "truncated", truncated);
+   free(buf);
+   return emit(o, resp, cap);
+}
+
+/* ── lifecycle mutations (start / pause / stop / delete) ─────────────────────
+ * All share the same access rule: the item's submitter OR an operator. */
+
+static int item_terminal(const db1_work_item_t *wi)
+{
+   return strcmp(wi->state, "accepted") == 0 || strcmp(wi->state, "rejected") == 0 ||
+          strcmp(wi->state, "abandoned") == 0;
+}
+
+/* The attested principal driving this mutation (for the audit event actor). */
+static const char *wf_actor(void)
+{
+   const char *p = server_http_identity_principal();
+   return (p && p[0]) ? p : "operator";
+}
+
+/* Resolve + owner/operator-gate an item for a mutation. On success fills `wi` and
+ * returns 0; otherwise writes an error envelope and returns the HTTP status. */
+static int wf_load_for_mutation(const char *id, int is_operator, db1_work_item_t *wi, char *resp,
+                                int cap)
+{
+   if (!id || !id[0])
+      return err(resp, cap, 400, "missing work item id");
+   if (db1_work_item_get(id, wi) != 1)
+      return err(resp, cap, 404, "work item not found");
+   if (!is_operator && !wf_owns(wi))
+      return err(resp, cap, 403, "not your work item");
+   return 0;
+}
+
+int wf_api_item_pause(const char *id, int is_operator, char *resp, int cap)
+{
+   db1_work_item_t wi;
+   int rc = wf_load_for_mutation(id, is_operator, &wi, resp, cap);
+   if (rc)
+      return rc;
+   if (item_terminal(&wi))
+      return err(resp, cap, 409, "run already finished");
+   if (wi.pause_reason[0])
+      return err(resp, cap, 409, "run is already paused");
+   if (db1_work_item_set_pause(id, "operator_paused", wi.current_stage) != 0)
+      return err(resp, cap, 500, "could not pause run");
+   db1_lifecycle_event_add(id, wi.current_stage, "pause", wf_actor(), "paused by operator", "", 0);
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 500, "paused but could not reload");
+   return emit(item_to_json(&wi), resp, cap);
+}
+
+int wf_api_item_resume(const char *id, int is_operator, char *resp, int cap)
+{
+   db1_work_item_t wi;
+   int rc = wf_load_for_mutation(id, is_operator, &wi, resp, cap);
+   if (rc)
+      return rc;
+   if (item_terminal(&wi))
+      return err(resp, cap, 409, "run already finished");
+   if (!wi.pause_reason[0])
+      return err(resp, cap, 409, "run is not paused");
+   /* A run parked at a human gate must be decided via Approve/Reject so the
+    * signed approval is recorded — never silently un-paused here. */
+   if (strcmp(wi.pause_reason, "pending_human") == 0)
+      return err(resp, cap, 409, "run is at a human gate — use Approve or Reject");
+   if (db1_work_item_clear_pause(id) != 0)
+      return err(resp, cap, 500, "could not resume run");
+   db1_lifecycle_event_add(id, wi.current_stage, "resume", wf_actor(), "resumed by operator", "",
+                           0);
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 500, "resumed but could not reload");
+   return emit(item_to_json(&wi), resp, cap);
+}
+
+int wf_api_item_stop(const char *id, int is_operator, char *resp, int cap)
+{
+   db1_work_item_t wi;
+   int rc = wf_load_for_mutation(id, is_operator, &wi, resp, cap);
+   if (rc)
+      return rc;
+   if (item_terminal(&wi))
+      return err(resp, cap, 409, "run already finished");
+   if (db1_work_item_set_terminal(id, "abandoned") != 0)
+      return err(resp, cap, 500, "could not stop run");
+   db1_lifecycle_event_add(id, wi.current_stage, "abandon", wf_actor(), "stopped by operator", "",
+                           0);
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 500, "stopped but could not reload");
+   return emit(item_to_json(&wi), resp, cap);
+}
+
+int wf_api_item_delete(const char *id, int is_operator, char *resp, int cap)
+{
+   db1_work_item_t wi;
+   int rc = wf_load_for_mutation(id, is_operator, &wi, resp, cap);
+   if (rc)
+      return rc;
+   /* Auto-stop an in-flight run first: mark it terminal so the scheduler's
+    * orphan-sweep reclaims its worktree before the row disappears. */
+   if (!item_terminal(&wi))
+      db1_work_item_set_terminal(id, "abandoned");
+
+   /* Best-effort unlink the server-minted proposal artifact, confined to
+    * $AIMEE_HOME/workflows/proposals via a dirfd + a slash-free basename (same
+    * race-free confinement as wf_api_proposal). A missing/odd file is ignored —
+    * the row removal is the operation of record. */
+   if (wi.proposal_path[0])
+   {
+      const char *base = path_basename(wi.proposal_path);
+      if (base[0] && !strchr(base, '/') && strcmp(base, ".") != 0 && strcmp(base, "..") != 0)
+      {
+         const char *home = aimee_home();
+         char dir[1024];
+         snprintf(dir, sizeof dir, "%s/workflows/proposals", home ? home : "/tmp");
+         int dfd = open(dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+         if (dfd >= 0)
+         {
+            unlinkat(dfd, base, 0); /* best effort */
+            close(dfd);
+         }
+      }
+   }
+
+   if (db1_work_item_delete(id) != 0)
+      return err(resp, cap, 500, "could not delete run");
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "id", id);
+   cJSON_AddBoolToObject(o, "deleted", 1);
+   return emit(o, resp, cap);
+}
+
+/* ── project file browser (composer "load a proposal from the project") ──────
+ * Read-only, confined to the server's local checkout root. */
+
+/* The project root the browser is rooted at: the workflow repo if configured,
+ * else the server's cwd. Returns the realpath'd root in `out` (>= PATH_MAX), or
+ * NULL on failure. */
+static char *wf_repo_root(char resolved[PATH_MAX])
+{
+   const char *root = getenv("AIMEE_WORKFLOW_REPO");
+   if (!root || !root[0])
+      root = ".";
+   return realpath(root, resolved);
+}
+
+/* Resolve `rel` under the project root and confirm the result stays inside it
+ * (blocks `..` and symlink escape). Writes the resolved absolute path to `out`
+ * and returns 0; on escape/nonexistence returns an HTTP status via `err`. */
+static int wf_resolve_confined(const char *rel, char out[PATH_MAX], char *resp, int cap)
+{
+   char root[PATH_MAX];
+   if (!wf_repo_root(root))
+      return err(resp, cap, 500, "project root unavailable");
+   char cand[PATH_MAX];
+   if (!rel || !rel[0])
+      snprintf(cand, sizeof cand, "%s", root);
+   else if ((int)snprintf(cand, sizeof cand, "%s/%s", root, rel) >= (int)sizeof cand)
+      return err(resp, cap, 400, "path too long");
+   if (!realpath(cand, out))
+      return err(resp, cap, 404, "path not found");
+   /* Confinement: `out` must equal root or sit strictly beneath it (root + '/'). */
+   size_t rl = strlen(root);
+   if (strncmp(out, root, rl) != 0 || (out[rl] != '\0' && out[rl] != '/'))
+      return err(resp, cap, 400, "path escapes project root");
+   return 0;
+}
+
+/* Relative path of `abs` beneath realpath'd `root` (for echoing back to the UI).
+ * "" at the root; never leading '/'. */
+static const char *wf_rel_of(const char *abs, const char *root)
+{
+   size_t rl = strlen(root);
+   if (strncmp(abs, root, rl) != 0)
+      return "";
+   const char *r = abs + rl;
+   while (*r == '/')
+      r++;
+   return r;
+}
+
+static int str_ends_with(const char *s, const char *suf)
+{
+   size_t ls = strlen(s), lf = strlen(suf);
+   return ls >= lf && strcmp(s + ls - lf, suf) == 0;
+}
+
+int wf_api_repo_tree(const char *rel, char *resp, int cap)
+{
+   char root[PATH_MAX];
+   if (!wf_repo_root(root))
+      return err(resp, cap, 500, "project root unavailable");
+   char abs[PATH_MAX];
+   int rc = wf_resolve_confined(rel, abs, resp, cap);
+   if (rc)
+      return rc;
+
+   DIR *d = opendir(abs);
+   if (!d)
+      return err(resp, cap, 404, "not a directory");
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "path", wf_rel_of(abs, root));
+   cJSON *arr = cJSON_AddArrayToObject(o, "entries");
+   struct dirent *e;
+   while ((e = readdir(d)) != NULL)
+   {
+      const char *name = e->d_name;
+      if (name[0] == '.')
+         continue; /* skip . / .. and hidden (incl. .git) */
+      if (strcmp(name, "node_modules") == 0)
+         continue;
+      char child[PATH_MAX];
+      if ((int)snprintf(child, sizeof child, "%s/%s", abs, name) >= (int)sizeof child)
+         continue;
+      struct stat stt;
+      if (stat(child, &stt) != 0)
+         continue;
+      int is_dir = S_ISDIR(stt.st_mode);
+      if (!is_dir && !str_ends_with(name, ".md"))
+         continue; /* files: markdown only */
+      cJSON *it = cJSON_CreateObject();
+      cJSON_AddStringToObject(it, "name", name);
+      cJSON_AddStringToObject(it, "type", is_dir ? "dir" : "file");
+      cJSON_AddItemToArray(arr, it);
+   }
+   closedir(d);
+   return emit(o, resp, cap);
+}
+
+int wf_api_repo_file(const char *rel, char *resp, int cap)
+{
+   char root[PATH_MAX];
+   if (!wf_repo_root(root))
+      return err(resp, cap, 500, "project root unavailable");
+   if (!rel || !rel[0])
+      return err(resp, cap, 400, "missing path");
+   if (!str_ends_with(rel, ".md"))
+      return err(resp, cap, 400, "only .md files are readable");
+   char abs[PATH_MAX];
+   int rc = wf_resolve_confined(rel, abs, resp, cap);
+   if (rc)
+      return rc;
+
+   int fd = open(abs, O_RDONLY | O_CLOEXEC);
+   if (fd < 0)
+      return err(resp, cap, 404, "file not found");
+   struct stat stt;
+   if (fstat(fd, &stt) != 0 || !S_ISREG(stt.st_mode))
+   {
+      close(fd);
+      return err(resp, cap, 404, "not a regular file");
+   }
+   char *buf = malloc(WF_PROPOSAL_MAX + 1);
+   if (!buf)
+   {
+      close(fd);
+      return err(resp, cap, 500, "out of memory");
+   }
+   size_t total = 0;
+   ssize_t r;
+   while (total < WF_PROPOSAL_MAX && (r = read(fd, buf + total, WF_PROPOSAL_MAX - total)) > 0)
+      total += (size_t)r;
+   close(fd);
+   buf[total] = '\0';
+   int truncated = (off_t)total < stt.st_size;
+
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "path", wf_rel_of(abs, root));
+   cJSON_AddStringToObject(o, "content", buf);
    cJSON_AddBoolToObject(o, "truncated", truncated);
    free(buf);
    return emit(o, resp, cap);

--- a/src/server/server_workflow_api.h
+++ b/src/server/server_workflow_api.h
@@ -60,4 +60,34 @@ int wf_api_events(const char *id, long after, int limit, char *resp, int cap);
  * Returns {proposal_md, truncated}; 404 if the file is missing. */
 int wf_api_proposal(const char *id, char *resp, int cap);
 
+/* Lifecycle mutations on one run. Access = the item's submitter OR an operator
+ * (is_operator, derived from the caller's CAP_WORKFLOW_ADMIN); else 403. Each
+ * returns the updated item row (or an error envelope). `is_operator` non-zero
+ * lifts the owner-only restriction. 404 unknown id, 409 on an invalid transition.
+ *
+ * pause  -- park an active, un-paused run with pause_reason=operator_paused so the
+ *           scheduler stops advancing it.
+ * resume -- clear the pause and (caller then wakes the scheduler). 409 if the run
+ *           is parked at pending_human (that must go through Approve/Reject).
+ * stop   -- set the run terminal (abandoned); the scheduler reclaims its worktree.
+ * delete -- if still active, abandon first, then permanently remove the run's rows
+ *           and best-effort unlink its proposal file. */
+int wf_api_item_pause(const char *id, int is_operator, char *resp, int cap);
+int wf_api_item_resume(const char *id, int is_operator, char *resp, int cap);
+int wf_api_item_stop(const char *id, int is_operator, char *resp, int cap);
+int wf_api_item_delete(const char *id, int is_operator, char *resp, int cap);
+
+/* GET /v1/workflow/repo/tree?path=<rel> -- list immediate directory entries under
+ * the server's local project checkout (root = $AIMEE_WORKFLOW_REPO, else cwd), for
+ * the composer's "load a proposal from the project" browser. Returns {path,
+ * entries:[{name,type:"dir"|"file"}]} with directories + `.md` files only; hidden
+ * dirs and node_modules are skipped. Path-confined via realpath (rejects `..` /
+ * symlink escape): 400 on escape, 404 on a missing dir. */
+int wf_api_repo_tree(const char *rel, char *resp, int cap);
+
+/* GET /v1/workflow/repo/file?path=<rel> -- read one `.md` file under the same
+ * confined project root. Returns {path, content, truncated} (size-capped like the
+ * proposal read). 400 on escape / non-.md, 404 if missing / not a regular file. */
+int wf_api_repo_file(const char *rel, char *resp, int cap);
+
 #endif /* DEC_SERVER_WORKFLOW_API_H */

--- a/src/tests/support/workflow_api_stub.c
+++ b/src/tests/support/workflow_api_stub.c
@@ -76,6 +76,40 @@ int wf_api_proposal(const char *id, char *resp, int cap)
    (void)id;
    return stub(resp, cap);
 }
+int wf_api_item_pause(const char *id, int is_operator, char *resp, int cap)
+{
+   (void)id;
+   (void)is_operator;
+   return stub(resp, cap);
+}
+int wf_api_item_resume(const char *id, int is_operator, char *resp, int cap)
+{
+   (void)id;
+   (void)is_operator;
+   return stub(resp, cap);
+}
+int wf_api_item_stop(const char *id, int is_operator, char *resp, int cap)
+{
+   (void)id;
+   (void)is_operator;
+   return stub(resp, cap);
+}
+int wf_api_item_delete(const char *id, int is_operator, char *resp, int cap)
+{
+   (void)id;
+   (void)is_operator;
+   return stub(resp, cap);
+}
+int wf_api_repo_tree(const char *rel, char *resp, int cap)
+{
+   (void)rel;
+   return stub(resp, cap);
+}
+int wf_api_repo_file(const char *rel, char *resp, int cap)
+{
+   (void)rel;
+   return stub(resp, cap);
+}
 
 /* Autonomous-development intake symbols referenced by rh_dev_submit in
  * server_http_routes.inc. Stubbed so tests that link server_http.o don't pull the

--- a/src/tests/test_harness_memory.c
+++ b/src/tests/test_harness_memory.c
@@ -66,6 +66,41 @@ static hmem_row_t mkrow(const char *proj, const char *name, const char *type, co
    return r;
 }
 
+static void test_page_end(void)
+{
+   /* Pure paging math: page boundaries respect the byte budget and always
+    * advance (a single oversized row can't stall the pager). */
+   char big[6000], mid[1000];
+   memset(big, 'x', sizeof(big) - 1);
+   big[sizeof(big) - 1] = '\0';
+   memset(mid, 'y', sizeof(mid) - 1);
+   mid[sizeof(mid) - 1] = '\0';
+
+   hmem_row_t rows[4] = {mkrow("p", "a", "fact", mid), /* rowsz ~= 999 + 512 = 1511 */
+                         mkrow("p", "b", "fact", mid), mkrow("p", "c", "fact", mid),
+                         mkrow("p", "d", "fact", mid)};
+
+   /* generous budget -> whole set fits in one page */
+   assert(hmem_page_end(rows, 4, 0, 1 << 20) == 4);
+
+   /* tight budget (2000): one ~1511-byte row per page, always advancing */
+   assert(hmem_page_end(rows, 4, 0, 2000) == 1);
+   assert(hmem_page_end(rows, 4, 1, 2000) == 2);
+   assert(hmem_page_end(rows, 4, 3, 2000) == 4);
+
+   /* two rows fit under a 3200 budget; the third opens the next page */
+   assert(hmem_page_end(rows, 4, 0, 3200) == 2);
+
+   /* a single row larger than the whole budget still advances by one */
+   hmem_row_t huge[1] = {mkrow("p", "big", "fact", big)}; /* rowsz ~= 6511 > 2000 */
+   assert(hmem_page_end(huge, 1, 0, 2000) == 1);
+
+   /* offset at the end yields an empty final page; NULL/empty inputs are safe */
+   assert(hmem_page_end(rows, 4, 4, 2000) == 4);
+   assert(hmem_page_end(NULL, 0, 0, 2000) == 0);
+   assert(hmem_page_end(rows, 0, 0, 2000) == 0);
+}
+
 static void test_resolve(void)
 {
    char id[256], root[1024];
@@ -172,6 +207,7 @@ int main(void)
 {
    test_sha();
    test_hash();
+   test_page_end();
    test_resolve();
    test_project_key_ok();
    assert(db1_init(":memory:") == 0);

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1063,6 +1063,10 @@ int handle_agent_personas(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "agent.personas");
 }
+int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "agent.set");
+}
 int handle_agent_disable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "agent.disable");

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -726,6 +726,17 @@ int main(void)
              CAP_DASHBOARD_READ);
       assert(server_http_route_caps("GET", "/v1/workflow/items/all") == CAP_WORKFLOW_ADMIN);
       assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x") == CAP_DASHBOARD_READ);
+      /* Lifecycle mutations: route cap admits owners (CAP_DASHBOARD_READ); the
+       * handler re-checks owner-or-operator. The suffix rows must win over the bare
+       * /<id> row, and DELETE /<id> is distinct from GET /<id> by verb. */
+      assert(server_http_route_caps("POST", "/v1/workflow/items/wi_x/pause") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("POST", "/v1/workflow/items/wi_x/resume") ==
+             CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("POST", "/v1/workflow/items/wi_x/stop") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("DELETE", "/v1/workflow/items/wi_x") == CAP_DASHBOARD_READ);
+      /* Composer project-file browser (read-only). */
+      assert(server_http_route_caps("GET", "/v1/workflow/repo/tree") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("GET", "/v1/workflow/repo/file") == CAP_DASHBOARD_READ);
       /* Presence is session-scoped; the streaming routes carry caps too. */
       assert(server_http_route_caps("GET", "/v1/sessions") == CAP_SESSION_READ);
       assert(server_http_route_caps("POST", "/v1/sessions/s1/attach") == CAP_SESSION_READ);

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -122,13 +122,16 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
    struct timespec ts0;
    clock_gettime(CLOCK_MONOTONIC, &ts0); /* monotonic: immune to NTP/clock jumps */
 
-   /* An item already parked 'stuck' cannot advance without human intervention
-    * (its stage is unresolvable / has no executor). Skip it so the backstop
-    * sweep doesn't re-attempt the doomed advance every cycle; a human resume
-    * clears the pause and lets the next sweep retry. */
+   /* An item parked 'stuck' cannot advance without human intervention (its stage
+    * is unresolvable / has no executor); an item parked 'operator_paused' was
+    * deliberately halted by an operator. Skip both so the backstop sweep doesn't
+    * re-attempt an advance every cycle; a human resume clears the pause and lets
+    * the next sweep retry. */
    {
       db1_work_item_t wi0;
-      if (db1_work_item_get(work_item_id, &wi0) == 1 && strcmp(wi0.pause_reason, "stuck") == 0)
+      if (db1_work_item_get(work_item_id, &wi0) == 1 &&
+          (strcmp(wi0.pause_reason, "stuck") == 0 ||
+           strcmp(wi0.pause_reason, "operator_paused") == 0))
          return 0;
    }
 

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -92,6 +92,7 @@ var methodRoutes = map[string]methodRoute{
 	"agent.enable":             {http.MethodPost, "/v1/agent/enable"},
 	"agent.disable":            {http.MethodPost, "/v1/agent/disable"},
 	"agent.probe":              {http.MethodPost, "/v1/agent/probe"},
+	"agent.set":                {http.MethodPost, "/v1/agent/set"},
 	"collab_rules.list":        {http.MethodGet, "/v1/collab_rules"},
 	"collab_rules.list_active": {http.MethodGet, "/v1/collab_rules/active"},
 	// Mutations + arg-bearing calls (POST, body carries the args; the server

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -226,6 +226,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/agents/probe", s.requireAuth(s.agentOpHandler("agent.probe")))
 	mux.HandleFunc("POST /api/agents/roles", s.requireAuth(s.agentOpHandler("agent.roles")))
 	mux.HandleFunc("POST /api/agents/personas", s.requireAuth(s.agentOpHandler("agent.personas")))
+	mux.HandleFunc("POST /api/agents/set", s.requireAuth(s.agentOpHandler("agent.set")))
 	// Role registry (the shared vocabulary matched between personas and agents).
 	mux.HandleFunc("/api/roles", s.requireAuth(s.handleRoles))
 	mux.HandleFunc("/api/roles/", s.requireAuth(s.handleRoleItem))


### PR DESCRIPTION
Promote `testing` to `main` for the v0.2.169 release.

## Included (11 commits)
**Agentic supervised SWE-bench harness (#987)** — proposal + S0–S6 + S0-live (PRs #1078–#1089): the full tool-using, multi-turn Reddit-parity benchmark harness. All bench-only Python under `benchmarks/coding/`, default-inert (live entrypoints are marked stubs); the reproducibility-critical surface is pure and unit-tested.
- **#1083** feat(webui): Workflow Actions lifecycle controls, Logs detail, in-project proposal picker
- **#1081** fix(harness-memory): paginate the list/search RPC so large stores hydrate

No production default changes from the SWE-bench work; #1081/#1083 are the substantive runtime changes and each passed its own CI on the way into `testing`.