### PR TITLE
fix(webui): paginate the audit Logs + full-ledger guardrail summary

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -100,15 +100,15 @@ interface Session {
   last_active: string;
 }
 
-// Server-incurred guardrail audit: a verdict on every tool action the agent takes.
-interface AuditRow {
-  ts: string;
-  actor: string;   // primary | delegate
-  tool: string;
-  mode?: string;
-  reason_code?: string;
-  verdict: string; // allow | block | rewrite | approval_required
-  task_id?: number;
+// Verdict-mix counts over the WHOLE audit ledger (server-aggregated in
+// dashboard.all as `audit_summary`), so the Guardrail pane is not sample-capped.
+interface AuditSummary {
+  total: number;
+  allow: number;
+  block: number;
+  rewrite: number;
+  approval_required: number;
+  other: number;
 }
 
 interface OnboardStep {
@@ -140,7 +140,7 @@ interface DashData {
   tokenAudit: TokenAudit[];
   decisions: Decision[];
   sessions: Session[];
-  audit: AuditRow[];
+  auditSummary: AuditSummary;
 }
 
 /* The server (`dashboard.all`) returns some fields in shapes the panels can't
@@ -166,7 +166,7 @@ interface RawDashboard {
   token_audit?: TokenAudit[];
   decisions?: Decision[];
   sessions?: Session[];
-  audit?: AuditRow[];
+  audit_summary?: AuditSummary;
 }
 
 /* ---- Helpers ---- */
@@ -244,7 +244,9 @@ export function toDashData(raw: RawDashboard | null | undefined): DashData {
     tokenAudit: arr<TokenAudit>(r.token_audit),
     decisions: arr<Decision>(r.decisions),
     sessions: arr<Session>(r.sessions),
-    audit: arr<AuditRow>(r.audit),
+    auditSummary: r.audit_summary || {
+      total: 0, allow: 0, block: 0, rewrite: 0, approval_required: 0, other: 0,
+    },
   };
 }
 
@@ -693,16 +695,17 @@ function percentile(sorted: number[], p: number): number {
 }
 
 /* Guardrail Actions — verdict mix over the server's tool-action audit. */
-function GuardrailPanel({ data }: { data: AuditRow[] }) {
-  const counts: Record<string, number> = { allow: 0, block: 0, rewrite: 0, approval_required: 0 };
-  for (const r of data) counts[r.verdict] = (counts[r.verdict] || 0) + 1;
+function GuardrailPanel({ data }: { data: AuditSummary }) {
+  const counts: Record<string, number> = {
+    allow: data.allow, block: data.block, rewrite: data.rewrite, approval_required: data.approval_required,
+  };
   const max = Math.max(1, ...Object.values(counts));
   const colors: Record<string, string> = {
     allow: '#22c55e', block: '#ef4444', rewrite: '#f59e0b', approval_required: '#3b82f6',
   };
   return (
-    <Panel title="Guardrail Actions" count={data.length}>
-      {data.length === 0 ? emptyBody('No tool-action audit yet') : (
+    <Panel title="Guardrail Actions" count={data.total}>
+      {data.total === 0 ? emptyBody('No tool-action audit yet') : (
         <div style={{ padding: '8px 0' }}>
           {Object.keys(counts).map(v => (
             <BarRow key={v} label={v} value={counts[v]} max={max} right={String(counts[v])} color={colors[v] || '#888'} />
@@ -917,7 +920,7 @@ const PANELS: PanelDef[] = [
   { id: 'delegations', title: 'Delegations',      defaultOn: true,  render: d => <DelegationsPanel data={d.delegations} /> },
   { id: 'metrics',     title: 'Metrics',          defaultOn: true,  render: d => <MetricsPanel data={d.metrics} /> },
   { id: 'cost',        title: 'Cost / Tokens',    defaultOn: true,  render: d => <CostPanel data={d.tokenAudit} /> },
-  { id: 'guardrail',   title: 'Guardrail Actions',defaultOn: true,  render: d => <GuardrailPanel data={d.audit} /> },
+  { id: 'guardrail',   title: 'Guardrail Actions',defaultOn: true,  render: d => <GuardrailPanel data={d.auditSummary} /> },
   { id: 'plans',       title: 'Execution Plans',  defaultOn: true,  render: d => <PlansPanel data={d.plans} /> },
   { id: 'traces',      title: 'Traces',           defaultOn: true,  render: d => <TracesPanel data={d.traces} /> },
   // Available to add:

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -52,9 +52,13 @@ const selectStyle: React.CSSProperties = {
   color: '#444', fontSize: 12,
 };
 
+const PAGE = 500; // rows per request (matches the server's dashboard.audit page size)
+
 export default function Logs() {
   const [rows, setRows] = useState<AuditRow[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [verdict, setVerdict] = useState('all');
   const [actor, setActor] = useState('all');
   const [q, setQ] = useState('');
@@ -68,17 +72,27 @@ export default function Logs() {
     return () => window.removeEventListener('keydown', onKey);
   }, [selected]);
 
-  const load = useCallback(async () => {
-    setLoading(true);
+  // Paginated fetch (most-recent first). offset=0 replaces; offset>0 appends the
+  // next older page. The audit ledger can be very large, so it is never loaded in
+  // one shot — the Logs page pulls pages of PAGE rows via "Load more".
+  const fetchPage = useCallback(async (offset: number) => {
+    const setBusy = offset === 0 ? setLoading : setLoadingMore;
+    setBusy(true);
     try {
-      const data = await fetch('/api/audit').then(r => (r.status === 401 ? [] : r.json()));
-      setRows(Array.isArray(data) ? data : []);
+      const r = await fetch(`/api/audit?limit=${PAGE}&offset=${offset}`);
+      const d = r.status === 401 ? { data: [], total: 0 } : await r.json();
+      const page: AuditRow[] = Array.isArray(d?.data) ? d.data : Array.isArray(d) ? d : [];
+      setTotal(typeof d?.total === 'number' ? d.total : page.length);
+      setRows(prev => (offset === 0 ? page : [...prev, ...page]));
     } catch {
-      setRows([]);
+      if (offset === 0) { setRows([]); setTotal(0); }
     } finally {
-      setLoading(false);
+      setBusy(false);
     }
   }, []);
+
+  const load = useCallback(() => fetchPage(0), [fetchPage]);
+  const loadMore = useCallback(() => fetchPage(rows.length), [fetchPage, rows.length]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -103,6 +117,9 @@ export default function Logs() {
       }}>
         <span style={{ fontSize: 14, fontWeight: 600, color: '#555' }}>Logs</span>
         <span style={{ fontSize: 12, color: '#999' }}>tool-action audit</span>
+        <span style={{ fontSize: 12, color: '#999' }}>
+          loaded {rows.length.toLocaleString()} of {total.toLocaleString()}
+        </span>
         <div style={{ display: 'flex', gap: 6, marginLeft: 8 }}>
           {(['allow', 'block', 'rewrite', 'approval_required'] as const).map(v => (
             <span key={v} style={{ fontSize: 11, color: '#777' }}>
@@ -160,6 +177,17 @@ export default function Logs() {
               ))}
             </tbody>
           </table>
+        )}
+        {rows.length < total && (
+          <div style={{ padding: 12, textAlign: 'center' }}>
+            <button
+              onClick={loadMore}
+              disabled={loadingMore}
+              style={{ ...selectStyle, cursor: 'pointer', padding: '6px 16px' }}
+            >
+              {loadingMore ? 'Loading…' : `Load ${Math.min(PAGE, total - rows.length).toLocaleString()} more`}
+            </button>
+          </div>
         )}
       </div>
 

--- a/src/audit_ledger.c
+++ b/src/audit_ledger.c
@@ -33,10 +33,13 @@ static int ts_in_window(const char *ts, const char *from_ts, const char *to_ts)
    return 1;
 }
 
-/* Read one file's tool_action rows into rows[] (bounded). file_rank orders files
- * chronologically (older first). Returns the number of unparseable lines seen;
- * sets *truncated if the LEDGER_MAX_ROWS cap was hit. */
-static int read_file(const char *path, int file_rank, ledger_row_t *rows, int *nrows,
+/* Read one file's tool_action rows into the `rows[]` RING of size LEDGER_MAX_ROWS.
+ * file_rank orders files chronologically (older first) and the overall read is
+ * chronological, so once `*written` exceeds the ring size each new row overwrites
+ * the OLDEST slot (rows[*written % cap]) — keeping the most-recent LEDGER_MAX_ROWS
+ * rows rather than the oldest. Returns the number of unparseable lines seen; sets
+ * *truncated once the cap is first exceeded (older rows are being dropped). */
+static int read_file(const char *path, int file_rank, ledger_row_t *rows, long *written,
                      const char *from_ts, const char *to_ts, int *truncated)
 {
    FILE *f = fopen(path, "r");
@@ -70,12 +73,6 @@ static int read_file(const char *path, int file_rank, ledger_row_t *rows, int *n
          line[--len] = '\0';
       if (len == 0)
          continue;
-      /* Cap check BEFORE parsing, so a parsed object can never be orphaned. */
-      if (*nrows >= LEDGER_MAX_ROWS)
-      {
-         *truncated = 1;
-         break;
-      }
       /* Strict parse: require the whole line be consumed (require_null_terminated),
        * so trailing garbage or a JSON prefix in a fragment is rejected, not accepted. */
       cJSON *obj = cJSON_ParseWithOpts(line, NULL, 1);
@@ -97,11 +94,21 @@ static int read_file(const char *path, int file_rank, ledger_row_t *rows, int *n
          cJSON_Delete(obj);
          continue;
       }
-      ledger_row_t *r = &rows[(*nrows)++];
+      /* Ring write: overwrite the oldest slot once full so the NEWEST cap rows are
+       * kept. Free the displaced object only now (we have a valid replacement), so
+       * a parse/skip above never orphans a slot. */
+      int pos = (int)(*written % LEDGER_MAX_ROWS);
+      if (*written >= LEDGER_MAX_ROWS)
+      {
+         *truncated = 1;
+         cJSON_Delete(rows[pos].obj);
+      }
+      ledger_row_t *r = &rows[pos];
       r->obj = obj;
       snprintf(r->ts, sizeof r->ts, "%s", ts->valuestring);
       r->file_rank = file_rank;
       r->line_seq = this_seq;
+      (*written)++;
    }
    fclose(f);
    return bad;
@@ -132,7 +139,7 @@ cJSON *audit_ledger_read(const char *from_ts, const char *to_ts)
       cJSON_Delete(out);
       return NULL;
    }
-   int nrows = 0;
+   long written = 0; /* total rows seen; the ring keeps the most-recent MAX of them */
    int bad = 0;
    int truncated = 0;
 
@@ -141,16 +148,18 @@ cJSON *audit_ledger_read(const char *from_ts, const char *to_ts)
 
    /* Chronological order (oldest first): audit.log.N .. audit.log.0, then the
     * current audit.log. file_rank increases with recency so equal-ts rows keep
-    * their chronological order. */
+    * their chronological order. The ring in read_file drops the OLDEST rows on
+    * overflow, so the newest LEDGER_MAX_ROWS always survive. */
    int rank = 0;
    for (int i = LEDGER_MAX_ROTATED; i >= 0; i--)
    {
       snprintf(path, sizeof path, "%s/audit.log.%d", dir, i);
-      bad += read_file(path, rank++, rows, &nrows, from_ts, to_ts, &truncated);
+      bad += read_file(path, rank++, rows, &written, from_ts, to_ts, &truncated);
    }
    snprintf(path, sizeof path, "%s/audit.log", dir);
-   bad += read_file(path, rank, rows, &nrows, from_ts, to_ts, &truncated);
+   bad += read_file(path, rank, rows, &written, from_ts, to_ts, &truncated);
 
+   int nrows = written < LEDGER_MAX_ROWS ? (int)written : LEDGER_MAX_ROWS;
    qsort(rows, (size_t)nrows, sizeof *rows, cmp_row);
    for (int i = 0; i < nrows; i++)
       cJSON_AddItemToArray(out, rows[i].obj); /* transfers ownership (steals the pointer) */

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -3,8 +3,9 @@
 #include "aimee.h"
 #include "server.h"
 #include "dashboard.h"
-#include "render.h"       /* decision_to_json + db2_decision_log_list */
-#include "audit_ledger.h" /* audit_ledger_read — server-incurred tool-action audit */
+#include "render.h"               /* decision_to_json + db2_decision_log_list */
+#include "audit_ledger.h"         /* audit_ledger_read — server-incurred tool-action audit */
+#include "server_http_identity.h" /* server_http_identity_query — audit pagination params */
 #include "lsp.h"
 #include "platform_path.h"
 #include "workspace.h"
@@ -1884,18 +1885,87 @@ static char *dashboard_decisions_json(void)
    return json ? json : strdup("[]");
 }
 
-/* Server-incurred tool-action audit (guardrail verdicts), most-recent first, capped. */
-static cJSON *dashboard_audit_array(int limit)
+/* Parse an unsigned-long query param ("k=v&…") from the current request's query
+ * string; returns `dflt` when absent or unparseable. Used for audit pagination —
+ * the /v1 GET route carries ?limit=&offset=, captured via the identity query. */
+static long dashboard_query_long(const char *key, long dflt)
+{
+   const char *q = server_http_identity_query();
+   size_t klen = strlen(key);
+   for (const char *p = q; p && *p;)
+   {
+      const char *amp = strchr(p, '&');
+      if (strncmp(p, key, klen) == 0 && p[klen] == '=')
+      {
+         char *end = NULL;
+         long v = strtol(p + klen + 1, &end, 10);
+         if (end != p + klen + 1)
+            return v;
+         return dflt;
+      }
+      if (!amp)
+         break;
+      p = amp + 1;
+   }
+   return dflt;
+}
+
+/* A page of the tool-action audit, most-recent first: `limit` rows starting
+ * `offset` rows back from newest. Sets *total to the full ledger row count so the
+ * client can paginate. Bounded so the serialized page always fits SHTTP_RESP_MAX. */
+static cJSON *dashboard_audit_page(int offset, int limit, int *total)
 {
    cJSON *all = audit_ledger_read(NULL, NULL);
-   if (!all)
-      return cJSON_CreateArray();
-   int n = cJSON_GetArraySize(all);
    cJSON *out = cJSON_CreateArray();
-   for (int i = n - 1; i >= 0 && (limit <= 0 || cJSON_GetArraySize(out) < limit); i--)
+   if (!all)
+   {
+      *total = 0;
+      return out;
+   }
+   int n = cJSON_GetArraySize(all);
+   *total = n;
+   for (int i = n - 1 - offset; i >= 0 && cJSON_GetArraySize(out) < limit; i--)
       cJSON_AddItemToArray(out, cJSON_DetachItemFromArray(all, i));
    cJSON_Delete(all);
    return out;
+}
+
+/* One ledger read → the guardrail verdict-mix SUMMARY (counts over EVERY action,
+ * so the Dashboard pane is no longer capped at a sample). Returns
+ * {total,allow,block,rewrite,approval_required,other}. */
+static cJSON *dashboard_audit_summary(void)
+{
+   cJSON *o = cJSON_CreateObject();
+   int total = 0, allow = 0, block = 0, rewrite = 0, approval = 0, other = 0;
+   cJSON *all = audit_ledger_read(NULL, NULL);
+   if (all)
+   {
+      cJSON *r = NULL;
+      cJSON_ArrayForEach(r, all)
+      {
+         cJSON *v = cJSON_GetObjectItemCaseSensitive(r, "verdict");
+         const char *s = (v && cJSON_IsString(v)) ? v->valuestring : "";
+         total++;
+         if (strcmp(s, "allow") == 0)
+            allow++;
+         else if (strcmp(s, "block") == 0)
+            block++;
+         else if (strcmp(s, "rewrite") == 0)
+            rewrite++;
+         else if (strcmp(s, "approval_required") == 0)
+            approval++;
+         else
+            other++;
+      }
+      cJSON_Delete(all);
+   }
+   cJSON_AddNumberToObject(o, "total", total);
+   cJSON_AddNumberToObject(o, "allow", allow);
+   cJSON_AddNumberToObject(o, "block", block);
+   cJSON_AddNumberToObject(o, "rewrite", rewrite);
+   cJSON_AddNumberToObject(o, "approval_required", approval);
+   cJSON_AddNumberToObject(o, "other", other);
+   return o;
 }
 
 static void readiness_add_step(cJSON *steps, const char *step, const char *status,
@@ -2073,18 +2143,34 @@ int handle_dashboard_all(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
    cJSON_AddItemToObject(resp, "onboard", dashboard_readiness(resp));
 
-   cJSON_AddItemToObject(resp, "audit", dashboard_audit_array(300));
+   /* Verdict-mix counts over the WHOLE ledger (the Guardrail Actions pane), so it
+    * is no longer limited to a capped sample. The full row list is served,
+    * paginated, by dashboard.audit for the Logs page. */
+   cJSON_AddItemToObject(resp, "audit_summary", dashboard_audit_summary());
 
    return send_and_free(conn, resp);
 }
 
-/* dashboard.audit: the server's tool-action audit ledger for the Logs page. */
+/* dashboard.audit: the server's tool-action audit ledger for the Logs page,
+ * PAGINATED (?limit=&offset=, most-recent first) so an arbitrarily large ledger
+ * never overflows the response buffer. Returns {data:[page], total, offset, limit}. */
 int handle_dashboard_audit(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
    (void)req;
+   int limit = (int)dashboard_query_long("limit", 500);
+   if (limit <= 0 || limit > 1000)
+      limit = 500; /* 1000 rows ≈ 180 KB, safely under SHTTP_RESP_MAX */
+   int offset = (int)dashboard_query_long("offset", 0);
+   if (offset < 0)
+      offset = 0;
+   int total = 0;
+   cJSON *page = dashboard_audit_page(offset, limit, &total);
    cJSON *resp = jo_ok();
-   cJSON_AddItemToObject(resp, "data", dashboard_audit_array(5000));
+   cJSON_AddItemToObject(resp, "data", page);
+   cJSON_AddNumberToObject(resp, "total", total);
+   cJSON_AddNumberToObject(resp, "offset", offset);
+   cJSON_AddNumberToObject(resp, "limit", limit);
    return send_and_free(conn, resp);
 }
 

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -216,6 +216,29 @@ func (s *server) agentOpHandler(method string) http.HandlerFunc {
 	}
 }
 
+// handleAudit proxies GET /api/audit -> the PAGINATED dashboard.audit route,
+// forwarding sanitized limit/offset query params and passing the server's
+// {status,data,total,offset,limit} envelope straight through so the Logs page can
+// page an arbitrarily large ledger (the response never overflows the server's
+// per-request buffer).
+func (s *server) handleAudit(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	path := "/v1/dashboard/audit"
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+	if limit > 0 || offset > 0 {
+		path = fmt.Sprintf("%s?limit=%d&offset=%d", path, limit, offset)
+	}
+	st, data, err := s.v1Request(ctx, http.MethodGet, path, nil)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil || st != http.StatusOK || len(data) == 0 {
+		fmt.Fprint(w, `{"data":[],"total":0,"offset":0,"limit":0}`)
+		return
+	}
+	w.Write(data)
+}
+
 func (s *server) handleDelegations(w http.ResponseWriter, r *http.Request) {
 	resp, err := s.socketCallForRequest(r, map[string]any{"method": "dashboard.delegations"})
 	w.Header().Set("Content-Type", "application/json")

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -178,7 +178,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 
 	// Aggregate dashboard endpoint — all panels in one server round-trip
 	mux.HandleFunc("/api/dashboard", s.requireAuth(s.handleDashboardAll))
-	mux.HandleFunc("/api/audit", s.requireAuth(s.dataArrayHandler("dashboard.audit")))
+	mux.HandleFunc("/api/audit", s.requireAuth(s.handleAudit))
 
 	// Code-graph visualization (§8): read-only views via aimee-server's index_graph_* MCP tools.
 	mux.HandleFunc("/api/graph/hubs", s.requireAuth(s.handleGraphHubs))


### PR DESCRIPTION
## Symptoms
- The **Logs** page rendered empty.
- The **Guardrail Actions** dashboard pane was capped at 300 actions.

## Root cause (one problem, both symptoms)
The server's per-request response buffer is 256 KB (`SHTTP_RESP_MAX`). `dashboard.audit` returned up to **5000 rows (~1 MB)** in one shot → overflowed the buffer → `loopback_rpc` truncated the JSON mid-object → parse failed → **502 "response too large"** → Logs empty. The Guardrail pane's **300 cap existed solely to keep `dashboard.all` under that same buffer**.

A second bug compounded it: `audit_ledger_read` read oldest-first and hard-capped at `LEDGER_MAX_ROWS`, so past 20k rows it kept the **oldest** and dropped the **newest** — recent actions stopped appearing entirely.

## Fix (pagination, no buffer bloat)
- **`audit_ledger_read`**: keep the **newest** `LEDGER_MAX_ROWS` via a ring buffer (overwrite the oldest slot on overflow).
- **`dashboard.audit`**: paginated — `?limit=&offset=` (most-recent first), returns `{data,total,offset,limit}`; each page fits well under the buffer.
- **`dashboard.all`**: replace the 300-row `audit` sample with **`audit_summary`** — verdict counts over the **whole** ledger from a single read, so the Guardrail pane is no longer sample-capped and the payload stays tiny.
- **webchat**: `handleAudit` forwards sanitized `limit`/`offset` and passes the paged envelope through.
- **frontend**: Logs page gets **"Load more"** + "loaded X of Y"; `GuardrailPanel` renders the `audit_summary` counts.

## Testing
- Builds: aimee-server (`-Werror`), webchat (`go build`), frontend (tsc + vite); clang-format + line-check pass.
- Unit tests: `audit_ledger`, `server_dispatch`.
- e2e with a 20,500-row ledger: page 1's newest row is now `tool_20499` (previously dropped), pages continue correctly, out-of-range offset returns `{rows:0,total}` safely, guardrail summary counts the full ledger.