### PR TITLE
feat(delegate): --workdir/cwd for delegate launch (target a server-side repo)

### DIFF
--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -230,6 +230,19 @@ static cJSON *marshal_delegate_launch(int argc, char **argv)
    int parallel = rpc_get_int(&opts, "parallel", 3);
    if (parallel > 0)
       cJSON_AddNumberToObject(req, "parallel", parallel);
+
+   /* Anchor the coord launch worktree. handle_delegate_launch reads "cwd" as the
+    * git-root anchor (resolution order: caller-supplied cwd first), under which it
+    * creates the .aimee/worktrees/<id> the delegates write into. --workdir lets a
+    * caller target a repo the SERVER can see (e.g. a benchmark checkout on the
+    * remote host) instead of the client's own cwd; default to getcwd() so ordinary
+    * local use is unchanged. */
+   const char *workdir = rpc_get(&opts, "workdir");
+   char cwd_buf[4096];
+   if (workdir && workdir[0])
+      cJSON_AddStringToObject(req, "cwd", workdir);
+   else if (getcwd(cwd_buf, sizeof(cwd_buf)))
+      cJSON_AddStringToObject(req, "cwd", cwd_buf);
    return req;
 }
 


### PR DESCRIPTION
`handle_delegate_launch` already reads `req["cwd"]` as the coord-launch git-root anchor (under which it creates the `.aimee/worktrees/<id>` that launched delegates write into), but the launch marshaller (`marshal_delegate_launch`) never sent it — so a coord launch always anchored at the server's startup cwd, with no way to target a specific repo.

This sends `cwd` from the launch marshaller: `--workdir` overrides, else `getcwd()` (ordinary local use unchanged). It lets a caller run a coord launch against a repo **the server can see** — e.g. a benchmark checkout on the remote host.

## Why
The agentic supervised SWE-bench harness (#987) drives write-capable workers against per-instance repos. Aimee's write-guard only permits delegate writes inside a coord-created `.aimee/worktrees/<id>`; that worktree is anchored at the launch `cwd`. Without sending `cwd`, there was no way to point it at an external repo.

## Live-verified (.254 fleet)
`delegate launch <plan> --workdir /var/lib/aimee/<repo>` →
- coord created `.aimee/worktrees/deleg-…/…` under the repo,
- the code delegate edited `app.py` there (write-guard satisfied),
- the patch extracted cleanly via `git diff <base_commit> -- . ':!.aimee'` (SWE-bench `model_patch` shape),
- `delegation_spawns` + `token_audit` (realized) attributed the spend by `delegation_id`.

Default behaviour is unchanged (getcwd()); `--workdir` is additive.