### PR TITLE
fix(roundtable): large task no longer collapses the panel to an empty result

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -818,7 +818,13 @@ static int run_convergence_tiebreak(agent_config_t *acfg, const char *task, cons
 static int summarize_forward(agent_config_t *acfg, const config_t *cfg, const char *task,
                              char **artifact, char **peer_notes, double *cost_usd)
 {
-   if (!artifact || !*artifact || !peer_notes || !*peer_notes)
+   /* Nothing to compress if there is no carryover. The `!*x` checks reject a NULL
+    * string pointer; the `!(*x)[0]` checks also reject an allocated-but-EMPTY
+    * string (round 1, before any artifact/peer notes exist) so a large task can
+    * never provoke a pointless summarize call. */
+   if (!artifact || !*artifact || !(*artifact)[0])
+      return -1;
+   if (!peer_notes || !*peer_notes || !(*peer_notes)[0])
       return -1;
    char *prompt = xasprintf3(
        "Summarize this roundtable context forward so the next participants can continue without "
@@ -1517,7 +1523,14 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
                       "observed cost is available",
                       out->cost_usd + preflight, cfg->ensemble_max_cost_usd);
       }
-      if (strlen(artifact) + strlen(peer_notes) + strlen(task) > 22000)
+      /* Compress only the ACCUMULATED CARRYOVER (artifact + peer_notes), never the
+       * task. The task is the fixed, incompressible review target / draft brief;
+       * counting it here made any single-shot review whose target exceeds ~22 KB
+       * trip summarize_forward on round 1 (carryover empty), which burned an
+       * aggregator call against the panel deadline, falsely flagged the run
+       * truncated+degraded, and starved the panelists into an empty (items:0)
+       * result. Carryover only, so a large task passes through to the panel intact. */
+      if (strlen(artifact) + strlen(peer_notes) > 22000)
       {
          if (summarize_forward(acfg, cfg, task, &artifact, &peer_notes, &out->cost_usd) == 0)
          {

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -574,6 +574,48 @@ static void test_ensemble_routes_to_distinct_agents(void)
    printf("  test_ensemble_routes_to_distinct_agents: ok\n");
 }
 
+/* Regression: a large review TARGET (the incompressible task) must not trip the
+ * carryover-compression path. Before the fix, `strlen(artifact)+strlen(peer_notes)
+ * +strlen(task) > 22000` counted the task, so any single-shot review whose target
+ * exceeded ~22 KB ran summarize_forward on round 1 (empty carryover) and flagged
+ * the whole run truncated+degraded (and starved the panel). The trigger now counts
+ * carryover only, so a big task passes through clean. */
+static void test_roundtable_large_task_no_size_degrade(void)
+{
+   reset_modes();
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   /* DRAFT mode isolates the SIZE path: the mock panel + aggregator succeed
+    * cleanly (they return a fixed "synthesized answer"), so the only thing a large
+    * task can change is whether the size-triggered summarize_forward at
+    * delegate_ensemble.c fires — which the mode-agnostic 22 KB check governs. */
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_DRAFT;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1; /* single-shot: no carryover to compress */
+   opts.converge_threshold = 0;
+   opts.deadline_ms = 0;
+
+   size_t n = 30000; /* > 22 KB, so the OLD code summarized + flagged truncated */
+   char *task = malloc(n + 1);
+   assert(task);
+   for (size_t i = 0; i < n; i++)
+      task[i] = (i % 64 == 63) ? '\n' : 'x';
+   task[n] = '\0';
+
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, task, &opts, &result);
+   free(task);
+   assert(rc == 0);
+   /* A large task alone (no carryover on round 1) must NOT trip the compression
+    * path, so the run is neither truncated nor degraded by size. */
+   assert(!result.truncated);
+   assert(!result.degraded);
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_large_task_no_size_degrade: ok\n");
+}
+
 static void test_roundtable_parallel_basic(void)
 {
    reset_modes();
@@ -1365,6 +1407,7 @@ int main(void)
    test_ensemble_min_successful_degradation();
    test_ensemble_routes_to_distinct_agents();
    test_roundtable_parallel_basic();
+   test_roundtable_large_task_no_size_degrade();
    test_roundtable_folds_cost_to_parent_session();
    test_roundtable_sequential_uses_named_agents();
    test_roundtable_degrades_on_min_success();


### PR DESCRIPTION
## Symptom
A review/draft roundtable whose task (review target / brief) exceeds ~22 KB comes back **empty** (`items:0`) + `degraded` + `truncated` — while the same content at ~13 KB works and single-persona `delegate review` handles it fine. This makes the roundtable unusable for real-sized proposals/diffs.

## Root cause (not agent health — the carryover-compression path)
`delegate_roundtable_run` gates `summarize_forward` on
`strlen(artifact) + strlen(peer_notes) + strlen(task) > 22000`, **counting the incompressible task**. So on round 1 (no carryover yet) any task over ~22 KB trips it. And `summarize_forward`'s guard `!*artifact || !*peer_notes` is a **NULL-pointer** check, not an empty-string one, so the round-1 empty-but-allocated carryover (`""` from `xstrdup0`) slips through and it runs anyway.

The effect: a pointless aggregator "summarize forward" call that (a) flags the run `truncated+degraded` and (b) burns time/cost against the panel deadline, so the real panelists get **starved and drop out → empty review**. (`.254` already runs a build with #992's parser fix, so this is a *separate*, residual bug — confirmed the boundary: 13 KB works, 27 KB fails, threshold 22000.)

## Fix
- Trigger `summarize_forward` on the **compressible carryover only** (`artifact + peer_notes`), never the fixed task — a large task passes through to the panel intact.
- Harden `summarize_forward` to no-op when the carryover is **empty** (check the first byte, not just the pointer).

## Test
`test_roundtable_large_task_no_size_degrade`: a 30 KB task must not mark the run `truncated`/`degraded`. Verified it **fails on the pre-fix code** (both the trigger and the guard reverted) and **passes** with the fix. Full `delegate_ensemble` suite green; server builds `-Werror`.

Deploying to the `.254` roundtable server (operator-gated rebuild) makes the live panel handle large prompts again.