### PR TITLE
fix(delegate): reviewers use the provided diff + aimee index, not the host filesystem

### DIFF
--- a/src/cmd_agent_delegate.c
+++ b/src/cmd_agent_delegate.c
@@ -685,6 +685,17 @@ void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
       role = canonical;
    }
 
+   /* A prompt supplied via --prompt-file/--prompt-stdin is the caller-provided
+    * review target (e.g. a diff): review THAT, not the delegate host's cwd. For
+    * review-type roles this also forces the index-only toolset so the delegate
+    * cannot fall back to filesystem reads of a worktree it does not have — it must
+    * use the inline diff plus aimee's branch index. */
+   int caller_provided_target = (prompt_file && prompt_file[0]) || prompt_stdin;
+   if (caller_provided_target && (!explicit_toolset || !explicit_toolset[0]) &&
+       (strcmp(role, "review") == 0 || strcmp(role, "validate") == 0 ||
+        strcmp(role, "diagnose") == 0))
+      explicit_toolset = "review_indexed";
+
    int force_tools = delegate_role_auto_tools_for_invocation(role, max_turns, explicit_tools);
    if (explicit_toolset && explicit_toolset[0])
    {
@@ -1159,8 +1170,8 @@ void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
       fatal("--worktree is only valid for write-capable delegates; read-only delegates must "
             "use the parent worktree");
    int delegate_needs_worktree = delegate_allows_writes;
-   effective_prompt =
-       delegate_maybe_append_validation_bundle(role, cwd_for_template, effective_prompt, prompt);
+   effective_prompt = delegate_maybe_append_validation_bundle(
+       role, cwd_for_template, effective_prompt, prompt, caller_provided_target);
    if (source_path_count > 0)
    {
       const char *base = effective_prompt ? effective_prompt : prompt;
@@ -1507,7 +1518,7 @@ void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
       delegate_check_file_drift(worktree_path, named_files, named_file_count);
    delegate_apply_review_evidence_guard(
        role, worktree_path[0] ? worktree_path : (original_cwd[0] ? original_cwd : cwd_for_template),
-       &rc, &result);
+       &rc, &result, caller_provided_target);
    delegate_handoff_validation_t handoff_validation;
    memset(&handoff_validation, 0, sizeof(handoff_validation));
    int handoff_checked = 0;

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -165,7 +165,7 @@ int delegate_check_named_file_drift(const char *const *paths, int path_count, co
  * Returns a heap-allocated string; caller must free.  Returns NULL on failure. */
 char *delegate_build_validation_bundle(const char *cwd);
 char *delegate_maybe_append_validation_bundle(const char *role, const char *cwd, char *owned_prompt,
-                                              const char *fallback_prompt);
+                                              const char *fallback_prompt, int target_provided);
 /* Validate Location-backed review snippets against the current checkout.
  * Returns 1 and fills errbuf when a fenced code block following a
  * `Location: `path:line`` marker does not match that file near the cited line,
@@ -173,7 +173,7 @@ char *delegate_maybe_append_validation_bundle(const char *role, const char *cwd,
 int delegate_check_review_evidence_drift(const char *response, const char *repo_root, char *errbuf,
                                          size_t errbuf_size);
 void delegate_apply_review_evidence_guard(const char *role, const char *repo_root, int *rc,
-                                          agent_result_t *result);
+                                          agent_result_t *result, int target_provided);
 
 /* Returns 1 if the worktree at wt_path has any tracked-file diff or
  * untracked-file (vs HEAD), 0 otherwise. Used by the no-op detector to

--- a/src/server/delegate_prompt.c
+++ b/src/server/delegate_prompt.c
@@ -1118,18 +1118,50 @@ char *delegate_build_validation_bundle(const char *cwd)
    return bundle;
 }
 
+/* Guidance appended when the CALLER supplied the review target in the prompt
+ * (--prompt-file / --prompt-stdin), e.g. a diff for an external code review. The
+ * target is the provided content — NOT the delegate host's working directory, which
+ * may be absent, on a different branch, or carry unrelated changes. For surrounding
+ * context the reviewer explores the DEFAULT BRANCH through aimee's own index/memory
+ * (code_search, find_symbol, search_memory, search_docs), which are branch-indexed
+ * and always available, rather than filesystem/git tools against a worktree it does
+ * not have. Returned string is heap-owned. */
+static char *delegate_build_provided_target_block(void)
+{
+   return strdup(
+       "\n\n---\n"
+       "## Review Target & Exploration\n"
+       "review_target: the diff / content provided in the prompt ABOVE is the sole subject of "
+       "this review. Base every finding on it.\n"
+       "no_local_worktree: do NOT run read_file/list_files/grep/git_diff/git_status against a "
+       "local checkout — this delegate has no such worktree for the target; that path is empty, "
+       "stale, or unrelated, and is not the review target.\n"
+       "explore_via_aimee: to inspect surrounding code, callers, or prior context on the DEFAULT "
+       "BRANCH, use aimee's own capabilities — code_search and find_symbol (branch-indexed code), "
+       "search_memory and search_docs (project memory/knowledge). These reflect the committed "
+       "default branch and are always available; prefer them over any filesystem tool.\n"
+       "absence_claims: only assert something is missing if a code_search/find_symbol query for "
+       "it returned no results; cite that query. Never infer absence from an unreadable worktree.\n"
+       "---\n");
+}
+
 char *delegate_maybe_append_validation_bundle(const char *role, const char *cwd, char *owned_prompt,
-                                              const char *fallback_prompt)
+                                              const char *fallback_prompt, int target_provided)
 {
    if (!role)
       return owned_prompt;
 
    const char *canonical_role = delegate_role_canonicalize(role);
-   if (strcmp(canonical_role, "review") != 0 && strcmp(canonical_role, "validate") != 0 &&
-       strcmp(canonical_role, "diagnose") != 0)
-      return owned_prompt;
+   int is_review_role = strcmp(canonical_role, "review") == 0 ||
+                        strcmp(canonical_role, "validate") == 0 ||
+                        strcmp(canonical_role, "diagnose") == 0;
 
-   char *bundle = delegate_build_validation_bundle(cwd);
+   /* Caller-supplied target (a diff via --prompt-file/--prompt-stdin) wins: the
+    * provided content is the review subject, so the host-cwd auto-diff bundle is
+    * suppressed (it would review the wrong tree) and the reviewer is pointed at
+    * aimee's branch-indexed capabilities for context instead of the filesystem. */
+   char *bundle = target_provided ? delegate_build_provided_target_block()
+                                  : (is_review_role ? delegate_build_validation_bundle(cwd) : NULL);
    if (!bundle)
       return owned_prompt;
 
@@ -1405,10 +1437,17 @@ static int delegate_response_claims_missing_parent_diff(const char *response)
 }
 
 void delegate_apply_review_evidence_guard(const char *role, const char *repo_root, int *rc,
-                                          agent_result_t *result)
+                                          agent_result_t *result, int target_provided)
 {
    if (!rc || *rc != 0 || !result || !result->response || !result->response[0] || !repo_root ||
        !repo_root[0])
+      return;
+
+   /* When the caller supplied the review target (a diff in the prompt), there is
+    * no host-cwd evidence to drift against — the provided content IS the evidence.
+    * Guarding against the local worktree here would penalize a correct review of
+    * the provided diff, so skip it. */
+   if (target_provided)
       return;
 
    if (!role || (strcmp(role, "review") != 0 && strcmp(role, "validate") != 0 &&

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1375,8 +1375,11 @@ void delegate_worker(void *arg)
    platform_setenv("AIMEE_ACTIVE_TOOLSET", saved_toolset_buf);
    if (parent_write_guard_active)
       agent_tools_parent_write_guard_clear();
+   /* Server-initiated delegates review their own worktree (target is not
+    * caller-supplied), so cwd-grounding applies. Threading a request-level
+    * caller-provided-target signal here is a follow-up. */
    delegate_apply_review_evidence_guard(
-       role, delegate_worktree_path[0] ? delegate_worktree_path : cwd, &rc, &result);
+       role, delegate_worktree_path[0] ? delegate_worktree_path : cwd, &rc, &result, 0);
    int delegate_applied_changes = -1;
    char delegate_apply_error[512] = "";
    char delegate_parent_root[MAX_PATH_LEN] = "";

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -377,12 +377,12 @@ static void test_prompt_plan_requires_prompt_source(void)
 static void test_validation_bundle_appended_for_review_roles(void)
 {
    char *code_prompt = strdup("base prompt");
-   char *unchanged = delegate_maybe_append_validation_bundle("code", ".", code_prompt, NULL);
+   char *unchanged = delegate_maybe_append_validation_bundle("code", ".", code_prompt, NULL, 0);
    assert(unchanged == code_prompt);
    free(unchanged);
 
    char *review_prompt =
-       delegate_maybe_append_validation_bundle("review", ".", NULL, "base prompt");
+       delegate_maybe_append_validation_bundle("review", ".", NULL, "base prompt", 0);
    assert(review_prompt != NULL);
    assert(strstr(review_prompt, "base prompt") == review_prompt);
    assert(strstr(review_prompt, "Validation Evidence Bundle") != NULL);
@@ -393,7 +393,7 @@ static void test_validation_bundle_appended_for_review_roles(void)
    free(review_prompt);
 
    char *diagnose_prompt =
-       delegate_maybe_append_validation_bundle("diagnose", ".", NULL, "base prompt");
+       delegate_maybe_append_validation_bundle("diagnose", ".", NULL, "base prompt", 0);
    assert(diagnose_prompt != NULL);
    assert(strstr(diagnose_prompt, "Validation Evidence Bundle") != NULL);
    assert(strstr(diagnose_prompt, "Directory layout claims") != NULL);
@@ -401,18 +401,42 @@ static void test_validation_bundle_appended_for_review_roles(void)
    free(diagnose_prompt);
 
    char *inspect_prompt =
-       delegate_maybe_append_validation_bundle("inspect", ".", NULL, "base prompt");
+       delegate_maybe_append_validation_bundle("inspect", ".", NULL, "base prompt", 0);
    assert(inspect_prompt != NULL);
    assert(strstr(inspect_prompt, "Validation Evidence Bundle") != NULL);
    assert(strstr(inspect_prompt, "whole relevant source tree") != NULL);
    free(inspect_prompt);
 
-   char *test_prompt = delegate_maybe_append_validation_bundle("test", ".", NULL, "base prompt");
+   char *test_prompt = delegate_maybe_append_validation_bundle("test", ".", NULL, "base prompt", 0);
    assert(test_prompt != NULL);
    assert(strstr(test_prompt, "Validation Evidence Bundle") != NULL);
    assert(strstr(test_prompt, "whole relevant source tree") != NULL);
    free(test_prompt);
    printf("  PASS: test_validation_bundle_appended_for_review_roles\n");
+}
+
+/* When the caller supplies the review target (target_provided=1, e.g. a diff via
+ * --prompt-file), the host-cwd "Validation Evidence Bundle" is suppressed and the
+ * reviewer is pointed at aimee's branch-indexed capabilities instead. */
+static void test_provided_target_suppresses_cwd_bundle(void)
+{
+   char *review =
+       delegate_maybe_append_validation_bundle("review", ".", NULL, "the diff to review", 1);
+   assert(review != NULL);
+   assert(strstr(review, "the diff to review") == review);
+   assert(strstr(review, "Review Target & Exploration") != NULL);
+   assert(strstr(review, "explore_via_aimee") != NULL);
+   assert(strstr(review, "code_search") != NULL);
+   /* the wrong-tree cwd bundle must NOT be present */
+   assert(strstr(review, "Validation Evidence Bundle") == NULL);
+   free(review);
+
+   /* Applies to any role, not just review roles, when a target is provided. */
+   char *coder = delegate_maybe_append_validation_bundle("code", ".", NULL, "base", 1);
+   assert(coder != NULL);
+   assert(strstr(coder, "Review Target & Exploration") != NULL);
+   free(coder);
+   printf("  PASS: test_provided_target_suppresses_cwd_bundle\n");
 }
 
 static void test_review_evidence_drift_detects_reversed_snippet(void)
@@ -563,7 +587,7 @@ static void test_review_evidence_guard_rejects_clean_claim_on_dirty_worktree(voi
    assert(result.response != NULL);
 
    int rc = 0;
-   delegate_apply_review_evidence_guard("review", root, &rc, &result);
+   delegate_apply_review_evidence_guard("review", root, &rc, &result, 0);
    assert(rc == 0);
    assert(result.error[0] == '\0');
    free(result.response);
@@ -581,7 +605,7 @@ static void test_review_evidence_guard_rejects_clean_claim_on_dirty_worktree(voi
    assert(result.response != NULL);
 
    rc = 0;
-   delegate_apply_review_evidence_guard("validate", root, &rc, &result);
+   delegate_apply_review_evidence_guard("validate", root, &rc, &result, 0);
    assert(rc == -1);
    assert(strstr(result.error, "delegate evidence drift") != NULL);
    free(result.response);
@@ -619,7 +643,7 @@ static void test_diagnose_evidence_guard_allows_nonreview_snippets(void)
    assert(result.response != NULL);
 
    int rc = 0;
-   delegate_apply_review_evidence_guard("diagnose", root, &rc, &result);
+   delegate_apply_review_evidence_guard("diagnose", root, &rc, &result, 0);
    assert(rc == 0);
    assert(result.error[0] == '\0');
    free(result.response);
@@ -1114,6 +1138,7 @@ int main(void)
    test_prompt_plan_prompt_and_file();
    test_prompt_plan_requires_prompt_source();
    test_validation_bundle_appended_for_review_roles();
+   test_provided_target_suppresses_cwd_bundle();
    test_review_evidence_drift_detects_reversed_snippet();
    test_review_evidence_drift_ignores_historical_diff_snippet();
    test_review_evidence_drift_ignores_inline_review_annotation();

--- a/src/tests/test_toolset.c
+++ b/src/tests/test_toolset.c
@@ -48,6 +48,27 @@ static void test_full_stack_resolves_union(void)
    printf("  code_roles_resolve_edit_file: ok\n");
 }
 
+/* review_indexed gives a reviewer aimee's branch-indexed capabilities and NO
+ * filesystem/git tools, so a caller-provided-diff review cannot fall back to
+ * reading a worktree it does not have. */
+static void test_review_indexed_excludes_filesystem(void)
+{
+   toolset_registry_t reg;
+   toolset_registry_init(&reg);
+   char tools[TOOLSET_MAX_TOOLS][TOOLSET_TOOL_MAX];
+   char err[TOOLSET_ERROR_MAX] = "";
+   int n = toolset_resolve(&reg, "review_indexed", tools, TOOLSET_MAX_TOOLS, err, sizeof(err));
+   assert(n > 0);
+   assert(has_tool(tools, n, "code_search"));
+   assert(has_tool(tools, n, "find_symbol"));
+   assert(has_tool(tools, n, "search_memory"));
+   assert(!has_tool(tools, n, "read_file"));
+   assert(!has_tool(tools, n, "list_files"));
+   assert(!has_tool(tools, n, "grep"));
+   assert(!has_tool(tools, n, "git_diff"));
+   printf("  review_indexed_excludes_filesystem: ok\n");
+}
+
 static void test_cycle_rejected(void)
 {
    char path[256];
@@ -191,6 +212,7 @@ int main(void)
 {
    printf("test_toolset:\n");
    test_full_stack_resolves_union();
+   test_review_indexed_excludes_filesystem();
    test_cycle_rejected();
    test_unknown_tool_dropped();
    test_core_edit_flows_to_include();

--- a/src/toolset.c
+++ b/src/toolset.c
@@ -34,6 +34,12 @@ static const builtin_toolset_t BUILTINS[] = {
       "run_background_process", "get_background_output", "kill_background_process",
       "list_background_processes", NULL}},
     {"review", {"readonly", NULL}, {"record_attempt", NULL}},
+    /* Index-only review: the reviewer works from the caller-provided diff (in the
+     * prompt) plus aimee's branch-indexed capabilities — NO filesystem/git tools,
+     * which point at a worktree a remote delegate cannot reach. */
+    {"review_indexed",
+     {NULL},
+     {"code_search", "find_symbol", "search_memory", "search_docs", "record_attempt", NULL}},
     {"script_rpc",
      {NULL},
      {"read_file", "list_files", "grep", "git_status", "git_log", "git_diff", "code_search",


### PR DESCRIPTION
## Bug
`aimee delegate review --prompt-file <diff>` **ignored the provided diff** and reviewed the delegate host's own working directory instead — returning findings about unrelated changes, or giving up because it couldn't `read_file` a worktree it has no access to.

## Root cause
For `review`/`validate`/`diagnose` roles, `delegate_maybe_append_validation_bundle` unconditionally appended a "Validation Evidence Bundle" built from `git -C <cwd> diff HEAD` + `origin/main...HEAD`, instructed the reviewer to *"base conclusions on diff_patch,"* and `delegate_apply_review_evidence_guard` penalized reviewing anything else. So a caller-supplied diff was overridden by the server cwd's changes, and the reviewer was handed `git -C <worktree_path>` / `read_file` it can't run.

## Fix (when the caller provides the target via `--prompt-file`/`--prompt-stdin`)
- **Suppress** the host-cwd auto-diff bundle + drift-guard — the provided content **is** the evidence.
- **Append** a "Review Target & Exploration" block: the provided diff is the sole subject; explore the **default branch via aimee's branch-indexed capabilities** (`code_search`, `find_symbol`, `search_memory`, `search_docs`).
- **Force an index-only toolset** (new `review_indexed` builtin — no `read_file`/`list_files`/`grep`/`git`) so the delegate *physically cannot* fall back to filesystem reads. Dogfooding proved prompt guidance alone was insufficient — the delegate still reached for `read_file`.

## Scope / validation
- Executes **server-side**, so live effect follows a `.254` redeploy (unit-tested here; live validation pending, same as roundtable #1094).
- Server-initiated delegate path (`server_compute.c`) keeps cwd-grounding for worktree self-reviews; threading a request-level signal there is a noted follow-up.

## Tests
`test_provided_target_suppresses_cwd_bundle` (cwd bundle gone, aimee-exploration block present, any role) and `test_review_indexed_excludes_filesystem` (no `read_file`/`grep`/`git` in the resolved toolset); existing bundle + drift tests updated and green. Server + CLI build `-Werror`, format + line-check clean.