### PR TITLE
feat(audit): S3 — Logs/dashboard reads from the WORM store

### DIFF
--- a/src/audit_worm.c
+++ b/src/audit_worm.c
@@ -723,6 +723,57 @@ int audit_worm_verify(char *err, size_t errlen, long *head_seq, long *last_ckpt_
    return (ckpt >= head) ? AUDIT_WORM_VERIFY_GREEN : AUDIT_WORM_VERIFY_AMBER;
 }
 
+cJSON *audit_worm_read_page(long offset, long limit, long *total)
+{
+   if (total)
+      *total = 0;
+   if (limit <= 0)
+      limit = 500;
+   if (offset < 0)
+      offset = 0;
+   cJSON *arr = cJSON_CreateArray();
+   pthread_mutex_lock(&g_worm_mu);
+   if (!g_worm_db && worm_open_locked_default() != 0)
+   {
+      pthread_mutex_unlock(&g_worm_mu);
+      return arr;
+   }
+   if (total)
+   {
+      sqlite3_stmt *c = NULL;
+      if (sqlite3_prepare_v2(g_worm_db, "SELECT COUNT(*) FROM audit_event", -1, &c, NULL) ==
+              SQLITE_OK &&
+          sqlite3_step(c) == SQLITE_ROW)
+         *total = (long)sqlite3_column_int64(c, 0);
+      sqlite3_finalize(c);
+   }
+   sqlite3_stmt *q = NULL;
+   if (sqlite3_prepare_v2(g_worm_db,
+                          "SELECT seq, ts, actor_role, actor_principal, action, subject, verdict,"
+                          " detail, key_id FROM audit_event ORDER BY seq DESC LIMIT ? OFFSET ?",
+                          -1, &q, NULL) == SQLITE_OK)
+   {
+      sqlite3_bind_int64(q, 1, limit);
+      sqlite3_bind_int64(q, 2, offset);
+      while (sqlite3_step(q) == SQLITE_ROW)
+      {
+         cJSON *o = cJSON_CreateObject();
+         cJSON_AddNumberToObject(o, "seq", (double)sqlite3_column_int64(q, 0));
+         const char *cols[] = {"ts",      "actor_role", "actor_principal", "action",
+                               "subject", "verdict",    "detail",          "key_id"};
+         for (int i = 0; i < 8; i++)
+         {
+            const unsigned char *v = sqlite3_column_text(q, i + 1);
+            cJSON_AddStringToObject(o, cols[i], v ? (const char *)v : "");
+         }
+         cJSON_AddItemToArray(arr, o);
+      }
+   }
+   sqlite3_finalize(q);
+   pthread_mutex_unlock(&g_worm_mu);
+   return arr;
+}
+
 long audit_worm_count(void)
 {
    pthread_mutex_lock(&g_worm_mu);

--- a/src/headers/audit_worm.h
+++ b/src/headers/audit_worm.h
@@ -95,6 +95,12 @@ extern "C"
     * Returns 0 on a sealed snapshot, -1 on failure. */
    int audit_worm_seal(char *out_path, size_t out_cap, int *out_immutable);
 
+   /* A page of the newest audit rows (seq DESC) as a cJSON array (caller owns);
+    * fills *total with the full row count. Backs the WORM-sourced Logs/dashboard
+    * read that supersedes the flat audit.log reader. */
+   struct cJSON;
+   struct cJSON *audit_worm_read_page(long offset, long limit, long *total);
+
    /* Number of rows currently in the store (test/introspection). -1 on error. */
    long audit_worm_count(void);
 

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -2165,11 +2165,29 @@ int handle_dashboard_audit(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    int offset = (int)dashboard_query_long("offset", 0);
    if (offset < 0)
       offset = 0;
-   int total = 0;
-   cJSON *page = dashboard_audit_page(offset, limit, &total);
    cJSON *resp = jo_ok();
-   cJSON_AddItemToObject(resp, "data", page);
-   cJSON_AddNumberToObject(resp, "total", total);
+   /* When the WORM store is enabled it is the tamper-evident source of truth for
+    * the Logs view: read the indexed audit_event rows directly (superseding the
+    * flat audit.log reader from #1092). Fall back to the file reader otherwise. */
+   config_t wcfg;
+   memset(&wcfg, 0, sizeof wcfg);
+   config_load(&wcfg);
+   if (wcfg.audit_worm_enabled)
+   {
+      long wtotal = 0;
+      cJSON *wpage = audit_worm_read_page(offset, limit, &wtotal);
+      cJSON_AddItemToObject(resp, "data", wpage);
+      cJSON_AddNumberToObject(resp, "total", (double)wtotal);
+      cJSON_AddStringToObject(resp, "source", "worm");
+   }
+   else
+   {
+      int total = 0;
+      cJSON *page = dashboard_audit_page(offset, limit, &total);
+      cJSON_AddItemToObject(resp, "data", page);
+      cJSON_AddNumberToObject(resp, "total", total);
+      cJSON_AddStringToObject(resp, "source", "audit.log");
+   }
    cJSON_AddNumberToObject(resp, "offset", offset);
    cJSON_AddNumberToObject(resp, "limit", limit);
    return send_and_free(conn, resp);

--- a/src/tests/test_audit_worm.c
+++ b/src/tests/test_audit_worm.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include "audit_worm.h"
+#include "cJSON.h"
 
 static char g_dir[256];
 
@@ -230,9 +231,38 @@ static void test_sealed_snapshot_tamper_detected(void)
    printf("  test_sealed_snapshot_tamper_detected: ok (%s)\n", err);
 }
 
+/* The WORM-backed Logs read returns the newest rows (seq DESC), paginated. */
+static void test_read_page(void)
+{
+   char path[300];
+   snprintf(path, sizeof path, "%s/page.db", g_dir);
+   setenv("AIMEE_HOME", g_dir, 1);
+   assert(audit_worm_init_at(path) == 0);
+   for (int i = 0; i < 5; i++)
+   {
+      char s[16];
+      snprintf(s, sizeof s, "v1-%d", i);
+      assert(audit_worm_append("primary", "u", "tool.read", s, "allow", "{}") == 0);
+   }
+   long total = 0;
+   cJSON *page = audit_worm_read_page(0, 2, &total);
+   assert(total == 5);
+   assert(cJSON_GetArraySize(page) == 2);
+   cJSON *r0 = cJSON_GetArrayItem(page, 0); /* newest first: seq 5 */
+   assert((int)cJSON_GetNumberValue(cJSON_GetObjectItem(r0, "seq")) == 5);
+   assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(r0, "subject")), "v1-4") == 0);
+   cJSON_Delete(page);
+   cJSON *page2 = audit_worm_read_page(2, 2, &total); /* offset: seq 3 then 2 */
+   assert((int)cJSON_GetNumberValue(cJSON_GetObjectItem(cJSON_GetArrayItem(page2, 0), "seq")) == 3);
+   cJSON_Delete(page2);
+   audit_worm_close();
+   printf("  test_read_page: ok\n");
+}
+
 int main(void)
 {
    mk_tmpdir();
+   test_read_page();
    test_append_and_chain();
    test_worm_triggers_block_mutation();
    test_cross_store_determinism();


### PR DESCRIPTION
Fourth slice of the WORM audit-store proposal (#1095), on S2 (#1101).

## What
When `audit_worm_enabled`, the WORM store becomes the tamper-evident source for the Logs view:
- **`audit_worm_read_page(offset, limit, *total)`** — an indexed page of the newest rows (`ORDER BY seq DESC LIMIT/OFFSET`) as a cJSON array + full count.
- **`handle_dashboard_audit`** reads from the WORM store when the flag is on (response tagged `source:"worm"`), else falls back to the flat `audit.log` reader — **superseding the O(N)-reparse / ring-buffer band-aid from #1092**.

## Live-validated
`config set audit_worm_enabled true` → `audit checkpoint` → `GET /v1/dashboard/audit` returns `source:"worm"` with the checkpoint row (including its MAC) and the correct `total`.

## Test
`test_read_page` — newest-first ordering, pagination offset, total count.

## Scope
This is the **read half** of proposal S3. Broadening *capture* to more governed action types (agent config mutations, delegate dispatch, gate/approval) beyond S0's tool-action dual-write, plus the capture-completeness **inventory + lint guard**, is a noted follow-up.