### PR TITLE
feat(webui): arg-free command preview in Logs audit detail

### DIFF
--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -8,6 +8,7 @@ const DETAIL_FIELDS: { key: keyof AuditRow; label: string }[] = [
   { key: 'verdict', label: 'Verdict' },
   { key: 'actor', label: 'Actor' },
   { key: 'tool', label: 'Tool' },
+  { key: 'command', label: 'Command' },
   { key: 'kind', label: 'Kind' },
   { key: 'mode', label: 'Guardrail mode' },
   { key: 'reason_code', label: 'Reason code' },
@@ -22,6 +23,7 @@ interface AuditRow {
   kind: string;
   actor: string;        // primary | delegate
   tool: string;
+  command?: string;     // arg-free command preview (shell tools; program name only)
   args_hash?: string;
   mode?: string;        // guardrail mode
   reason_code?: string;
@@ -168,7 +170,10 @@ export default function Logs() {
                 >
                   <td style={{ ...td, whiteSpace: 'nowrap', color: '#888' }}>{esc(r.ts).replace('T', ' ').replace('Z', '')}</td>
                   <td style={td}>{esc(r.actor)}</td>
-                  <td style={{ ...td, fontFamily: 'monospace' }}>{esc(r.tool)}</td>
+                  <td style={{ ...td, fontFamily: 'monospace' }}>
+                    {esc(r.tool)}
+                    {r.command ? <span style={{ color: '#999' }}> · {esc(r.command)}</span> : null}
+                  </td>
                   <td style={td}><Badge label={esc(r.verdict)} variant={verdictVariant(r.verdict)} /></td>
                   <td style={{ ...td, color: '#888' }}>{esc(r.mode)}</td>
                   <td style={{ ...td, color: '#888' }}>{esc(r.reason_code)}</td>

--- a/src/Makefile
+++ b/src/Makefile
@@ -411,7 +411,13 @@ SERVER_KB_CLIENT_OBJS = $(KB_CLIENT_OBJS)
 # --- KB Service ---
 KB_SRCS = kb/kb_main.c kb/kb_background.c kb/kb_service.c kb/kb_service_workers.c kb/kb_ingest_workers.c kb/kb_service_kb.c kb/kb_service_memory.c kb/kb_service_css.c kb/kb_service_agent.c kb/kb_service_graph.c kb/kb_rrf.c kb/kb_graph_analytics.c kb/lessons_cite_tracker.c kb/lessons_capture.c kb/lessons_reflect.c kb/lessons_actuate.c kb/lessons_session_capture.c kb/prompt_sanitizer.c kb/kb_surprising_judge.c kb/kb_service_artifacts.c kb/kb_service_roadmap.c kb/kb_intel_payload.c kb/kb_bandit_registry.c kb/kb_reflection.c kb/kb_curator_queue.c kb/kb_curator_extract.c kb/kb_curator_extract_code.c kb/kb_curator_grounding.c kb/kb_curator_drain.c kb/kb_curator_resolve_entities.c kb/kb_curator_sidecar.c kb/kb_curator_llm.c kb/kb_curator_judge.c kb/kb_curator_synthesize.c kb/kb_curator_promote.c kb/kb_curator_index_narrative.c kb/kb_curator_index_claims.c kb/kb_curator_contradictions.c kb/kb_curator_index_code_unit.c kb/kb_curator_link_artifacts.c kb/kb_curator_serve.c kb/kb_evidence_embed.c kb/kb_learning_synth.c kb/kb_learning_version.c kb/kb_curator_version.c kb/kb_curator_notify.c kb/kb_mining.c kb/http/kb_http.c kb/http/kb_tls.c kb/http/kb_tls_serve.c kb/http/kb_http_conn.c kb/http/kb_http_ws.c kb/http/kb_http_search.c kb/http/kb_route_acl.c kb/http/kb_http_console.c kb/http/kb_http_accounts.c kb/http/kb_http_governance.c kb/kb_scope.c kb/http/kb_http_code.c kb/http/kb_http_code_graphfb.c kb/http/kb_http_pdf.c kb/http/kb_http_ingest.c kb/http/kb_http_jobs.c kb/kb_doc_hash.c kb/kb_doc_pdf.c kb/kb_tsr_sidecar.c kb/kb_blob_store.c kb/kb_blob_reconcile.c kb/kb_ocr_sidecar.c kb/http/kb_http_releases.c kb/http/kb_http_reflections.c kb/kb_ingest_normalize.c kb/kb_service_code_embed.c kb/kb_memory_embed.c kb/kb_memory_facts.c kb/memory_rewrite_llm.c kb/enroll.c kb/verifier.c kb/auth_oidc.c kb/pki.c
 KB_OBJS = $(KB_SRCS:%.c=$(OBJDIR)/%.o)
-KB_CORE_SRCS = $(filter-out db1/%,$(CORE_SRCS))
+# audit_worm.c is the aimee-server SQLite WORM store (#include <sqlite3.h>); the
+# kb is DB2/Postgres-only and MUST stay sqlite-free (see the boundary integrity
+# check below), using its own db2/kb_audit_worm.c. Its SQLite API has no kb-side
+# callers (guardrails_action_audit.c / cmd_audit.c / server_state.c are server/
+# CLI only), while the shared audit_worm_chain.c is pure hashing (no sqlite) and
+# stays. Excluding it keeps the kb-only/split image build from needing sqlite3.h.
+KB_CORE_SRCS = $(filter-out db1/% audit_worm.c,$(CORE_SRCS))
 KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)

--- a/src/audit_action.c
+++ b/src/audit_action.c
@@ -325,3 +325,357 @@ int audit_args_hash(const char *tool_name, const char *args_json, char *out, siz
    out[67] = '\0';
    return 0;
 }
+
+/* ---- arg-free command preview (human-readable audit row field) ----------- */
+
+#define AUDIT_CMDNAME_MAX  64 /* per emitted program basename */
+#define AUDIT_PREVIEW_CMDS 8  /* max programs surfaced per command line */
+
+/* A shell control operator: the token after one is again in COMMAND position.
+ * A newline is deliberately NOT here: it is treated as plain whitespace (a token
+ * separator, not a command separator) so that a heredoc / multi-line DATA body —
+ * whose lines are arguments, not commands — can never place a data token in
+ * command position and leak it. Parentheses are deliberately NOT here either:
+ * treating `(` as a command boundary let a `NAME=(v1 v2)` array-assignment VALUE
+ * reach command position; leaving them out folds the whole `NAME=(...)` into one
+ * env-assignment token (which is skipped), while a genuine subshell `(cmd ...)`
+ * still surfaces its command via the leading-paren strip in emit_cmd_basename.
+ * Real multi-command lines still split on the explicit ; | & operators. */
+static int is_cmd_delim(char c)
+{
+   return c == '|' || c == '&' || c == ';';
+}
+
+/* Whitespace between tokens: spaces, tabs, and newlines/CR (see is_cmd_delim on
+ * why a newline is a separator, not a command boundary). */
+static int is_cmd_space(char c)
+{
+   return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
+
+/* Characters we are willing to surface in a program name. A crafted `command`
+ * value can therefore never inject whitespace, quotes, or control bytes into the
+ * audit row: an out-of-set byte simply ends the emitted name. */
+static int is_cmdname_char(unsigned char c)
+{
+   return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' ||
+          c == '_' || c == '-' || c == '+' || c == '$' || c == '@' || c == ':';
+}
+
+/* True if tok[0..len) is a leading env-assignment (NAME=...): NAME is
+ * [A-Za-z_][A-Za-z0-9_]* followed by '='. Such a token in command position is an
+ * assignment (its VALUE may be a secret, e.g. AWS_SECRET=...) and is redacted:
+ * the command is the first NON-assignment token. */
+static int is_env_assignment(const char *tok, size_t len)
+{
+   if (len == 0 ||
+       !((tok[0] >= 'A' && tok[0] <= 'Z') || (tok[0] >= 'a' && tok[0] <= 'z') || tok[0] == '_'))
+      return 0;
+   size_t j = 0;
+   while (j < len && ((tok[j] >= 'A' && tok[j] <= 'Z') || (tok[j] >= 'a' && tok[j] <= 'z') ||
+                      (tok[j] >= '0' && tok[j] <= '9') || tok[j] == '_'))
+      j++;
+   if (j < len && tok[j] == '+') /* append-assignment NAME+=... (arrays/strings) */
+      j++;
+   return j < len && tok[j] == '=';
+}
+
+/* Classify a shell reserved word / compound-command keyword at command position.
+ * These are never programs, so they are skipped (never emitted); the return value
+ * says what the NEXT token is:
+ *   RW_COMMAND (1): a command follows (if/then/do/... ) -> STAY at command
+ *      position so the real governed command surfaces (`if grep x; then rm y; fi`
+ *      -> "grep ; rm", not "if ; then ; fi").
+ *   RW_OPERAND (2): a NON-command operand follows -> DROP to argument position so
+ *      it is never emitted. This is the security-critical class: after `case`
+ *      the next token is the SUBJECT (which may be a literal value, e.g. a PII
+ *      bareword); after `for`/`select` it is the loop variable; after `function`
+ *      it is the function name. None are programs and none may leak.
+ *   0: not a reserved word.
+ * Case PATTERNS are separately kept out of command position (the `;;` terminator
+ * is not a command boundary), so no pattern value can be emitted either. */
+enum
+{
+   RW_NONE = 0,
+   RW_COMMAND = 1,
+   RW_OPERAND = 2
+};
+static int reserved_word_kind(const char *tok, size_t len)
+{
+   static const char *const RW_CMD[] = {"if",    "then", "elif", "else", "fi", "while",
+                                        "until", "do",   "done", "esac", "in", "time",
+                                        "!",     "{",    "}",    NULL};
+   /* `case` is handled explicitly (case-depth suppression), not here. */
+   static const char *const RW_OPD[] = {"for", "select", "function", NULL};
+   for (const char *const *w = RW_OPD; *w; w++)
+      if (strlen(*w) == len && memcmp(tok, *w, len) == 0)
+         return RW_OPERAND;
+   for (const char *const *w = RW_CMD; *w; w++)
+      if (strlen(*w) == len && memcmp(tok, *w, len) == 0)
+         return RW_COMMAND;
+   return RW_NONE;
+}
+
+/* True if tok[0..len) is all ASCII digits (a leading file-descriptor number on a
+ * redirection, e.g. the `2` in `2>err.log`) — skipped so it is neither emitted
+ * nor mistaken for the command. */
+static int is_all_digits(const char *tok, size_t len)
+{
+   if (len == 0)
+      return 0;
+   for (size_t k = 0; k < len; k++)
+      if (tok[k] < '0' || tok[k] > '9')
+         return 0;
+   return 1;
+}
+
+/* Append the sanitized basename of the command-position token tok[0..len) to
+ * out (" ; "-separated). Only is_cmdname_char bytes after the last '/' are
+ * copied, bounded to AUDIT_CMDNAME_MAX; an empty result emits nothing. */
+static void emit_cmd_basename(const char *tok, size_t len, char *out, size_t *op, size_t out_sz)
+{
+   /* A token beginning with '(' is an opaque subshell/group span (e.g.
+    * `(cd /x && make)`); its interior is a command LIST, not a single program, and
+    * taking a basename across it would surface an inner path segment. Suppress it
+    * rather than dive in — commands outside the group still surface. */
+   if (len > 0 && tok[0] == '(')
+      return;
+   size_t bstart = 0; /* start of the basename (past the last '/') */
+   for (size_t k = 0; k < len; k++)
+      if (tok[k] == '/')
+         bstart = k + 1;
+   /* Skip leading non-name bytes (e.g. an opening quote on "\"/usr/bin/x\""). */
+   while (bstart < len && !is_cmdname_char((unsigned char)tok[bstart]))
+      bstart++;
+   char name[AUDIT_CMDNAME_MAX + 1];
+   size_t np = 0;
+   size_t k = bstart;
+   for (; k < len && np < AUDIT_CMDNAME_MAX; k++)
+   {
+      unsigned char ch = (unsigned char)tok[k];
+      if (!is_cmdname_char(ch))
+         break;
+      name[np++] = (char)ch;
+   }
+   if (np == 0)
+      return;
+   /* A name glued directly to '(' is a function DEFINITION (`name() {...}`) or a
+    * command substitution / arithmetic glued to the name (`$(...)`, `$((...))`),
+    * not a program invocation. Suppress it so a function/def name — which is not
+    * a governed command — is never emitted. */
+   if (k < len && tok[k] == '(')
+      return;
+   const char *sep = *op > 0 ? " ; " : "";
+   size_t seplen = strlen(sep);
+   if (*op + seplen + np + 1 >= out_sz)
+      return; /* out of room: drop this (and, implicitly, later) commands */
+   memcpy(out + *op, sep, seplen);
+   *op += seplen;
+   memcpy(out + *op, name, np);
+   *op += np;
+   out[*op] = '\0';
+}
+
+/* Scan a shell command line, emitting the basename of each command-position
+ * program (skipping env-assignments; dropping all arguments and redirect
+ * targets). Best-effort parse: quotes are opaque spans; the arg-free invariant
+ * holds regardless because only command-position tokens are ever emitted. */
+static void extract_shell_commands(const char *s, char *out, size_t out_sz)
+{
+   size_t op = 0;
+   int at_cmd = 1;     /* start of line is a command position */
+   int case_depth = 0; /* >0 while inside a case…esac (all emission suppressed) */
+   int ncmds = 0;
+   size_t i = 0;
+   while (s[i])
+   {
+      char c = s[i];
+      if (is_cmd_space(c))
+      {
+         i++;
+         continue;
+      }
+      /* A `#` at a word start begins a comment: the rest of the line is free-form
+       * text (potentially data), not commands — skip it. (`#` inside a word, e.g.
+       * `foo#bar`, is handled by the token reader, not here.) */
+      if (c == '#')
+      {
+         while (s[i] && s[i] != '\n')
+            i++;
+         continue;
+      }
+      /* `;;` terminates a case branch: the NEXT token is a case PATTERN, not a
+       * command, so it must NOT become a command position (else a pattern value
+       * could be emitted). A single `;` is an ordinary command separator. */
+      if (c == ';' && s[i + 1] == ';')
+      {
+         at_cmd = 0;
+         i += 2;
+         continue;
+      }
+      if (is_cmd_delim(c))
+      {
+         at_cmd = 1;
+         i++;
+         continue;
+      }
+      /* Heredoc (`<<` / `<<-`, but NOT the `<<<` here-string): its BODY is
+       * free-form data on subsequent lines and can contain any shell operator, so
+       * no position heuristic can keep body content out of command position. Stop
+       * scanning entirely — commands before the heredoc are already emitted; we
+       * refuse to parse past it rather than risk leaking a body value. */
+      if (c == '<' && s[i + 1] == '<' && s[i + 2] != '<')
+         break;
+      /* Redirection: consume '>' / '>>' / '<' plus an optional '&fd' and the
+       * target word so the (arg) target is never mistaken for a command. Command
+       * position is left unchanged. */
+      if (c == '<' || c == '>')
+      {
+         i++;
+         if (s[i] == '>' || s[i] == '<')
+            i++;
+         while (is_cmd_space(s[i]))
+            i++;
+         if (s[i] == '&')
+            i++;
+         while (s[i] && !is_cmd_space(s[i]) && !is_cmd_delim(s[i]) && s[i] != '<' && s[i] != '>')
+            i++;
+         continue;
+      }
+      /* Read a token, treating quoted spans as opaque. */
+      size_t start = i;
+      int quoted = 0;
+      char q = 0;
+      while (s[i])
+      {
+         char ch = s[i];
+         /* A backslash escapes the next byte, keeping it — and any otherwise
+          * word-breaking metacharacter (`\;` `\|` `\ `) or an in-quote `\"` — part
+          * of THIS token, so a data value like `echo foo\;DATA` or
+          * `echo "a\"; DATA"` stays one argument and never reaches command
+          * position. Checked before the quote toggle and applied in every context:
+          * over-escaping only ever pulls MORE into the current token (a possible
+          * missed command), never LESS (which is what could leak). */
+         if (ch == '\\')
+         {
+            i++;
+            if (s[i])
+               i++;
+            continue;
+         }
+         if (quoted)
+         {
+            if (ch == q)
+               quoted = 0;
+            i++;
+            continue;
+         }
+         if (ch == '\'' || ch == '"')
+         {
+            quoted = 1;
+            q = ch;
+            i++;
+            continue;
+         }
+         /* Any unquoted parenthesis group is an opaque balanced span: array
+          * assignments `NAME=(v1 v2 v3)`, command substitution `$(...)`,
+          * arithmetic `$((...))`, and subshells `(a; b)`. Consuming it whole keeps
+          * a space inside from splitting its data (array elements, subst args)
+          * into a token that reaches command position. A leading-`(` subshell
+          * still surfaces its FIRST command via emit_cmd_basename's paren strip. */
+         if (ch == '(')
+         {
+            i++;
+            int depth = 1;
+            while (s[i] && depth)
+            {
+               if (s[i] == '(')
+                  depth++;
+               else if (s[i] == ')')
+                  depth--;
+               i++;
+            }
+            continue;
+         }
+         /* Backtick command substitution: opaque until the closing backtick. */
+         if (ch == '`')
+         {
+            i++;
+            while (s[i] && s[i] != '`')
+               i++;
+            if (s[i])
+               i++;
+            continue;
+         }
+         if (is_cmd_space(ch) || ch == '<' || ch == '>' || is_cmd_delim(ch))
+            break;
+         i++;
+      }
+      size_t tok_len = i - start;
+      int is_case = tok_len == 4 && memcmp(s + start, "case", 4) == 0;
+      int is_esac = tok_len == 4 && memcmp(s + start, "esac", 4) == 0;
+      /* Inside a case…esac, every token — the subject, the patterns (including
+       * `a|b` alternations and the `)` that closes them) and the branch bodies —
+       * is suppressed. case pattern grammar cannot be parsed safely enough to
+       * distinguish a pattern VALUE from a command, so nothing inside is emitted;
+       * we only track nesting until the matching esac. */
+      if (case_depth > 0)
+      {
+         if (is_case)
+            case_depth++;
+         else if (is_esac)
+            case_depth--;
+         continue;
+      }
+      if (!at_cmd)
+         continue; /* an argument: redacted (never emitted) */
+      if (is_env_assignment(s + start, tok_len))
+         continue; /* leading assignment: redacted, still awaiting the command */
+      /* A leading file-descriptor on a redirection (the `2` in `2>err`): the '>'
+       * broke the token, so `s[i]` is the redirect. Skip the fd; stay awaiting
+       * the real command (which the redirect branch will pass through to). */
+      if (is_all_digits(s + start, tok_len) && (s[i] == '<' || s[i] == '>'))
+         continue;
+      if (is_case)
+      {
+         case_depth = 1; /* open a case: suppress everything through its esac */
+         continue;
+      }
+      int rw = reserved_word_kind(s + start, tok_len);
+      if (rw == RW_OPERAND)
+      {
+         at_cmd = 0; /* keyword's operand (loop var / func name) is not a command
+                        and must never be emitted */
+         continue;
+      }
+      if (rw == RW_COMMAND)
+         continue; /* keyword, not a program: skip but stay at command position */
+      if (ncmds < AUDIT_PREVIEW_CMDS)
+         emit_cmd_basename(s + start, tok_len, out, &op, out_sz);
+      ncmds++;
+      at_cmd = 0;
+   }
+}
+
+void audit_command_preview(const char *tool_name, const char *args_json, char *out, size_t out_sz)
+{
+   if (out && out_sz)
+      out[0] = '\0';
+   if (!out || out_sz < 2 || !tool_name)
+      return;
+   /* Only shell tools carry a command line. Every other tool's action is named
+    * by the row's `tool` field; its arguments are never surfaced. */
+   if (strcmp(tool_name, "Bash") != 0 && strcmp(tool_name, "execute_script") != 0)
+      return;
+   if (!args_json || !*args_json)
+      return;
+   if (strnlen(args_json, AUDIT_ARGS_MAX_INPUT + 1) > AUDIT_ARGS_MAX_INPUT)
+      return; /* oversize: skip parsing (DoS bound) */
+   cJSON *root = cJSON_Parse(args_json);
+   if (!root)
+      return;
+   cJSON *cmd = cJSON_GetObjectItemCaseSensitive(root, "command");
+   if (cJSON_IsString(cmd) && cmd->valuestring)
+      extract_shell_commands(cmd->valuestring, out, out_sz);
+   cJSON_Delete(root);
+}

--- a/src/guardrails_action_audit.c
+++ b/src/guardrails_action_audit.c
@@ -104,8 +104,13 @@ static void emit_action_audit(const char *tool_name, const char *input_json,
    char args_hash[AUDIT_ARGS_HASH_LEN];
    snprintf(args_hash, sizeof args_hash, "v1-");
    audit_args_hash(tool_name, input_json, args_hash, sizeof args_hash);
+   /* Arg-free command preview (shell tools only; "" otherwise). Safe-by-
+    * construction — only program basenames, never an argument value — so it
+    * rides on the same audit_action_enabled gate with no extra PII surface. */
+   char command[288];
+   audit_command_preview(tool_name, input_json, command, sizeof command);
    long long task_id = state ? (long long)state->active_task_id : 0;
-   audit_action_log(actor, tool_name, args_hash, mode, reason, verdict, task_id);
+   audit_action_log(actor, tool_name, args_hash, command, mode, reason, verdict, task_id);
    emit_worm_row(actor, tool_name, args_hash, mode, reason, verdict, task_id);
 }
 

--- a/src/headers/audit_action.h
+++ b/src/headers/audit_action.h
@@ -51,6 +51,23 @@ extern "C"
     * and MUST NOT block a tool on a non-zero return. */
    int audit_args_hash(const char *tool_name, const char *args_json, char *out, size_t out_sz);
 
+   /* Build an ARG-FREE command preview for the audit row's human-readable
+    * "command" field, into `out` (capacity out_sz; always NUL-terminated).
+    *
+    * For a shell tool (Bash / execute_script) it extracts the program basename(s)
+    * invoked from the `command` argument — skipping leading env-assignments and
+    * DROPPING every argument, redirect target, and quoted value — joined with
+    * " ; " (e.g. `cd /x && rm -rf /secret` -> "cd ; rm"). Every emitted token is
+    * filtered through a program-name charset and length-capped, so NO argument
+    * value (path, token, PII, file content) can ever enter the audit log: the
+    * preview is safe-by-construction, not merely redacted.
+    *
+    * For any other tool it writes "" — the row's `tool` field already names the
+    * action and the arguments are never surfaced. Best-effort: on any failure
+    * (unparseable JSON, oversize input, no room) it writes "". */
+   void audit_command_preview(const char *tool_name, const char *args_json, char *out,
+                              size_t out_sz);
+
    /* Ensure the dedicated audit HMAC key exists at $AIMEE_HOME/.audit-key (0600, 32
     * random bytes), provisioning it atomically if absent (mirrors
     * wfe_approval_ensure_key). Call once at server startup so hash time always has

--- a/src/headers/log.h
+++ b/src/headers/log.h
@@ -32,13 +32,16 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
 void audit_log(const char *event_type, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
 /* Governed-action audit row (per-tool-call). Writes a single structured line
- * {"ts","kind":"tool_action","actor","tool","args_hash","mode","reason_code",
- * "verdict","task_id"} to the SAME audit.log as audit_log (single sink), sharing
- * its mutex + rotation. Distinguished from audit_log rows by the top-level
- * "kind" key. Best-effort/side-effect-only: callers use this off the enforcement
- * path and never gate on it. Any string arg may be NULL (rendered as ""). */
-void audit_action_log(const char *actor, const char *tool, const char *args_hash, const char *mode,
-                      const char *reason_code, const char *verdict, long long task_id);
+ * {"ts","kind":"tool_action","actor","tool","args_hash","command","mode",
+ * "reason_code","verdict","task_id"} to the SAME audit.log as audit_log (single
+ * sink), sharing its mutex + rotation. Distinguished from audit_log rows by the
+ * top-level "kind" key. `command` is the arg-free human-readable command preview
+ * (see audit_command_preview) — never an argument value. Best-effort/
+ * side-effect-only: callers use this off the enforcement path and never gate on
+ * it. Any string arg may be NULL (rendered as ""). */
+void audit_action_log(const char *actor, const char *tool, const char *args_hash,
+                      const char *command, const char *mode, const char *reason_code,
+                      const char *verdict, long long task_id);
 
 /* Last audit event key set by audit_log() on this thread (empty if none since
  * the last reset). Used to derive a governed-action reason_code. */

--- a/src/log.c
+++ b/src/log.c
@@ -216,16 +216,18 @@ static void audit_maybe_rotate_locked(void)
    }
 }
 
-void audit_action_log(const char *actor, const char *tool, const char *args_hash, const char *mode,
-                      const char *reason_code, const char *verdict, long long task_id)
+void audit_action_log(const char *actor, const char *tool, const char *args_hash,
+                      const char *command, const char *mode, const char *reason_code,
+                      const char *verdict, long long task_id)
 {
    char ts[32];
    format_timestamp(ts, sizeof(ts));
 
-   char e_actor[128], e_tool[128], e_hash[96], e_mode[64], e_reason[96], e_verdict[32];
+   char e_actor[128], e_tool[128], e_hash[96], e_cmd[320], e_mode[64], e_reason[96], e_verdict[32];
    audit_json_escape(e_actor, sizeof e_actor, actor);
    audit_json_escape(e_tool, sizeof e_tool, tool);
    audit_json_escape(e_hash, sizeof e_hash, args_hash);
+   audit_json_escape(e_cmd, sizeof e_cmd, command);
    audit_json_escape(e_mode, sizeof e_mode, mode);
    audit_json_escape(e_reason, sizeof e_reason, reason_code);
    audit_json_escape(e_verdict, sizeof e_verdict, verdict);
@@ -238,9 +240,9 @@ void audit_action_log(const char *actor, const char *tool, const char *args_hash
    {
       fprintf(audit_fp,
               "{\"ts\":\"%s\",\"kind\":\"tool_action\",\"actor\":\"%s\",\"tool\":\"%s\","
-              "\"args_hash\":\"%s\",\"mode\":\"%s\",\"reason_code\":\"%s\",\"verdict\":\"%s\","
-              "\"task_id\":%lld}\n",
-              ts, e_actor, e_tool, e_hash, e_mode, e_reason, e_verdict, task_id);
+              "\"args_hash\":\"%s\",\"command\":\"%s\",\"mode\":\"%s\",\"reason_code\":\"%s\","
+              "\"verdict\":\"%s\",\"task_id\":%lld}\n",
+              ts, e_actor, e_tool, e_hash, e_cmd, e_mode, e_reason, e_verdict, task_id);
       fflush(audit_fp);
       audit_maybe_rotate_locked();
    }

--- a/src/tests/test_audit_action.c
+++ b/src/tests/test_audit_action.c
@@ -224,6 +224,178 @@ static void test_value_truncation_semantics(void)
    free(trunc2);
 }
 
+/* ---- audit_command_preview: arg-free command surfacing ------------------- */
+
+static const char *preview(const char *tool, const char *args, char out[256])
+{
+   audit_command_preview(tool, args, out, 256);
+   return out;
+}
+
+static void test_preview_basic_bash(void)
+{
+   char o[256];
+   assert(strcmp(preview("Bash", "{\"command\":\"ls -la /home\"}", o), "ls") == 0);
+   /* absolute path -> basename only (no leaking the containing directory) */
+   assert(strcmp(preview("Bash", "{\"command\":\"/usr/bin/git status\"}", o), "git") == 0);
+   /* ./relative script -> basename */
+   assert(strcmp(preview("Bash", "{\"command\":\"./scripts/deploy.sh --prod\"}", o), "deploy.sh") ==
+          0);
+}
+
+static void test_preview_drops_all_args(void)
+{
+   char o[256];
+   /* the filename argument (potential PII) must never appear */
+   assert(strcmp(preview("Bash", "{\"command\":\"rm /home/virant/.secret_token\"}", o), "rm") == 0);
+   assert(strstr(o, "secret") == NULL);
+   assert(strstr(o, "virant") == NULL);
+   /* a value passed as an arg is dropped, not surfaced */
+   assert(strcmp(preview("Bash", "{\"command\":\"echo hunter2\"}", o), "echo") == 0);
+   assert(strstr(o, "hunter2") == NULL);
+}
+
+static void test_preview_env_assignment_redacted(void)
+{
+   char o[256];
+   /* a leading secret env-assignment is skipped; the real command surfaces */
+   assert(strcmp(preview("Bash", "{\"command\":\"AWS_SECRET_ACCESS_KEY=abc123 aws s3 ls\"}", o),
+                 "aws") == 0);
+   assert(strstr(o, "abc123") == NULL);
+   assert(strstr(o, "AWS_SECRET") == NULL);
+}
+
+static void test_preview_compound_and_pipeline(void)
+{
+   char o[256];
+   assert(strcmp(preview("Bash", "{\"command\":\"cd /x && rm -rf /secret\"}", o), "cd ; rm") == 0);
+   assert(strstr(o, "secret") == NULL);
+   assert(strcmp(preview("Bash", "{\"command\":\"cat /etc/passwd | grep root\"}", o),
+                 "cat ; grep") == 0);
+   /* redirect target (a path arg) is consumed, never surfaced */
+   assert(strcmp(preview("Bash", "{\"command\":\"curl example.com > /tmp/out.bin\"}", o), "curl") ==
+          0);
+   assert(strstr(o, "out.bin") == NULL);
+}
+
+static void test_preview_heredoc_and_newlines(void)
+{
+   char o[256];
+   /* A heredoc/multi-line DATA body must never surface a body token as a command:
+    * a newline is a token separator, not a command boundary. */
+   assert(strcmp(preview("Bash",
+                         "{\"command\":\"cat <<EOF\\njohn.doe@example.com is admin\\nEOF\"}", o),
+                 "cat") == 0);
+   assert(strstr(o, "john") == NULL);
+   assert(strstr(o, "example.com") == NULL);
+   assert(strstr(o, "EOF") == NULL);
+   /* Explicit operators still split commands across line breaks. */
+   assert(strcmp(preview("Bash", "{\"command\":\"ls &&\\n grep x\"}", o), "ls ; grep") == 0);
+}
+
+static void test_preview_compound_constructs(void)
+{
+   char o[256];
+   /* Nothing inside a case…esac is emitted — subject, patterns (incl. `a|b`
+    * alternation), and bodies are all suppressed — so no pattern value can leak.
+    * Commands before and after the case still surface. */
+   assert(
+       strcmp(preview("Bash",
+                      "{\"command\":\"ls; case $x in a|secret_pat_9) c1;; esac; rm -rf /t\"}", o),
+              "ls ; rm") == 0);
+   assert(strstr(o, "secret_pat_9") == NULL);
+   /* reserved words are skipped so the real governed commands surface */
+   assert(strcmp(preview("Bash", "{\"command\":\"if grep x file; then rm /tmp/y; fi\"}", o),
+                 "grep ; rm") == 0);
+   /* a leading file-descriptor on a redirect is not mistaken for the command */
+   assert(strcmp(preview("Bash", "{\"command\":\"2>/tmp/err.log grep needle file\"}", o), "grep") ==
+          0);
+   /* a for-loop's list values (potential PII paths) are never surfaced */
+   audit_command_preview("Bash",
+                         "{\"command\":\"for f in /secret/a.key /secret/b.key; do rm $f; done\"}",
+                         o, sizeof o);
+   assert(strstr(o, "secret") == NULL);
+   assert(strstr(o, "a.key") == NULL);
+   assert(strstr(o, "rm") != NULL);
+   /* keyword OPERANDS are non-commands and must never leak: the case SUBJECT (a
+    * literal value), the loop variable, the function name. */
+   audit_command_preview("Bash", "{\"command\":\"case CUSTOMER_SSN_123 in x) echo ok;; esac\"}", o,
+                         sizeof o);
+   assert(strstr(o, "CUSTOMER_SSN_123") == NULL); /* case subject (a value) never leaks */
+   audit_command_preview("Bash", "{\"command\":\"function SECRET_NAME { echo ok; }\"}", o,
+                         sizeof o);
+   assert(strstr(o, "SECRET_NAME") == NULL);
+   audit_command_preview("Bash", "{\"command\":\"for SECRET_VAR in a; do ls; done\"}", o, sizeof o);
+   assert(strstr(o, "SECRET_VAR") == NULL);
+   assert(strstr(o, "ls") != NULL);
+}
+
+static void test_preview_expansions_and_defs(void)
+{
+   char o[256];
+   /* heredoc body — even with a shell operator on a body line — never leaks;
+    * scanning stops at the `<<`, so the leading command is still shown. */
+   assert(strcmp(preview("Bash", "{\"command\":\"cat <<EOF\\n;CUSTOMER_SSN_123\\nEOF\"}", o),
+                 "cat") == 0);
+   assert(strstr(o, "CUSTOMER_SSN_123") == NULL);
+   /* array-assignment VALUES are data, folded into the skipped assignment token */
+   assert(strcmp(preview("Bash", "{\"command\":\"arr=(CUSTOMER_SSN_123); echo ok\"}", o), "echo") ==
+          0);
+   assert(strstr(o, "CUSTOMER_SSN_123") == NULL);
+   /* function-definition name (`name() {...}`) is not a command and must not leak */
+   audit_command_preview("Bash", "{\"command\":\"SECRET_FUNCTION_NAME() { echo ok; }\"}", o,
+                         sizeof o);
+   assert(strstr(o, "SECRET_FUNCTION_NAME") == NULL);
+   /* a subshell/group is opaque and suppressed (its interior is a command list,
+    * not a program); commands outside it still surface, and no inner path segment
+    * leaks (e.g. the `x` in `/etc/x`) */
+   assert(strcmp(preview("Bash", "{\"command\":\"(rm /etc/SECRET_X && make) ; echo done\"}", o),
+                 "echo") == 0);
+   assert(strstr(o, "SECRET_X") == NULL && strstr(o, "make") == NULL);
+   /* multi-element array assignment values never leak (all inside the paren span) */
+   assert(strcmp(preview("Bash", "{\"command\":\"arr=(SSN_1 SSN_2 SSN_3); ls\"}", o), "ls") == 0);
+   assert(strstr(o, "SSN_") == NULL);
+   audit_command_preview("Bash", "{\"command\":\"$(SECRET_SUB) arg\"}", o, sizeof o);
+   assert(strstr(o, "SECRET_SUB") == NULL);
+   /* command substitution is opaque: a space inside `$(...)` must not split its
+    * data into a command-position token (a bug found by the adversarial battery) */
+   audit_command_preview("Bash", "{\"command\":\"x=$(cat /etc/CUSTOMER_SSN_123); echo ok\"}", o,
+                         sizeof o);
+   assert(strstr(o, "CUSTOMER_SSN_123") == NULL);
+   assert(strstr(o, "echo") != NULL);
+   /* a backslash-escaped metacharacter keeps the data in the argument word */
+   assert(strcmp(preview("Bash", "{\"command\":\"echo foo\\\\;CUSTOMER_SSN_123\"}", o), "echo") ==
+          0);
+   assert(strstr(o, "CUSTOMER_SSN_123") == NULL);
+   /* a word-start comment is free-form text, never a command */
+   assert(strcmp(preview("Bash", "{\"command\":\"echo ok; #CUSTOMER_SSN_123\"}", o), "echo") == 0);
+   assert(strstr(o, "CUSTOMER_SSN_123") == NULL);
+   /* an escaped quote inside a double-quoted arg does not end the arg word, so a
+    * `;` inside it stays data and the trailing value never reaches command pos.
+    * (== "echo" also guards against a malformed literal parsing to empty.) */
+   assert(strcmp(preview("Bash", "{\"command\":\"echo \\\"a\\\\\\\"b; CUSTOMER_SSN_123\\\"\"}", o),
+                 "echo") == 0);
+   assert(strstr(o, "CUSTOMER_SSN_123") == NULL);
+}
+
+static void test_preview_non_shell_and_edge(void)
+{
+   char o[256];
+   /* non-shell tools surface nothing (the row's tool field names the action) */
+   assert(strcmp(preview("Write", "{\"file_path\":\"/x\",\"content\":\"hi\"}", o), "") == 0);
+   assert(strcmp(preview("Read", "{\"file_path\":\"/x\"}", o), "") == 0);
+   /* execute_script IS a shell tool; only its command field is read, not script */
+   assert(
+       strcmp(preview("execute_script", "{\"command\":\"bash\",\"script\":\"rm -rf /secret\"}", o),
+              "bash") == 0);
+   assert(strstr(o, "secret") == NULL);
+   /* best-effort failure paths write "" and never crash */
+   assert(strcmp(preview("Bash", "not json", o), "") == 0);
+   assert(strcmp(preview("Bash", "{\"command\":\"\"}", o), "") == 0);
+   audit_command_preview(NULL, "{}", o, sizeof o);
+   assert(o[0] == '\0');
+}
+
 int main(void)
 {
    test_shape_and_determinism();
@@ -237,6 +409,14 @@ int main(void)
    test_hmac_rfc4231_vectors();
    test_separator_injection_no_collision();
    test_value_truncation_semantics();
+   test_preview_basic_bash();
+   test_preview_drops_all_args();
+   test_preview_env_assignment_redacted();
+   test_preview_compound_and_pipeline();
+   test_preview_heredoc_and_newlines();
+   test_preview_compound_constructs();
+   test_preview_expansions_and_defs();
+   test_preview_non_shell_and_edge();
    printf("test_audit_action: all passed\n");
    return 0;
 }

--- a/src/tests/test_audit_action_log.c
+++ b/src/tests/test_audit_action_log.c
@@ -39,7 +39,8 @@ static void test_row_format(void)
 {
    set_home();
    audit_log_open();
-   audit_action_log("primary", "Write", "v1-abc123", "approve", "read_before_write", "block", 42);
+   audit_action_log("primary", "Write", "v1-abc123", "", "approve", "read_before_write", "block",
+                    42);
    audit_log_close();
 
    char *log = read_audit_log();
@@ -47,6 +48,7 @@ static void test_row_format(void)
    assert(strstr(log, "\"actor\":\"primary\""));
    assert(strstr(log, "\"tool\":\"Write\""));
    assert(strstr(log, "\"args_hash\":\"v1-abc123\""));
+   assert(strstr(log, "\"command\":\"\"")); /* non-shell tool: no command surfaced */
    assert(strstr(log, "\"mode\":\"approve\""));
    assert(strstr(log, "\"reason_code\":\"read_before_write\""));
    assert(strstr(log, "\"verdict\":\"block\""));
@@ -58,7 +60,7 @@ static void test_json_escaping(void)
    set_home();
    audit_log_open();
    /* a tool name carrying a quote + backslash must be escaped, not break JSON */
-   audit_action_log("primary", "We\"ird\\Tool", "v1-0", "approve", "blocked", "block", 0);
+   audit_action_log("primary", "We\"ird\\Tool", "v1-0", "", "approve", "blocked", "block", 0);
    audit_log_close();
 
    char *log = read_audit_log();
@@ -72,11 +74,12 @@ static void test_null_fields_render_empty(void)
 {
    set_home();
    audit_log_open();
-   audit_action_log(NULL, "Read", NULL, NULL, NULL, "allow", 7);
+   audit_action_log(NULL, "Read", NULL, NULL, NULL, NULL, "allow", 7);
    audit_log_close();
 
    char *log = read_audit_log();
    assert(strstr(log, "\"actor\":\"\""));
+   assert(strstr(log, "\"command\":\"\"")); /* NULL command renders as "" */
    assert(strstr(log, "\"reason_code\":\"\""));
    assert(strstr(log, "\"verdict\":\"allow\""));
    assert(strstr(log, "\"tool\":\"Read\""));
@@ -91,7 +94,7 @@ static void test_control_char_escaping(void)
    audit_action_log("primary",
                     "a\tb\rc\x01"
                     "d",
-                    "v1-0", "approve", "blocked", "block", 0);
+                    "v1-0", "", "approve", "blocked", "block", 0);
    audit_log_close();
 
    char *log = read_audit_log();


### PR DESCRIPTION
## What & why

The Logs audit-detail modal showed only `args_hash` (a keyed HMAC), so an operator opening a blocked/allowed row could not tell **what** actually ran — only that the tool was e.g. "Bash". The ledger deliberately never stores plaintext arguments (secrets/PII must never land in the append-only audit log), so there was nothing richer to surface.

This adds a new **arg-free `command`** field to the `tool_action` audit row and shows it in the Logs detail modal (and as an inline `Tool · command` hint in the table). For shell tools (`Bash`/`execute_script`) it surfaces the **program basename(s)** invoked and *nothing else*:

```
ls -la /home                      -> ls
/usr/bin/git status               -> git        (basename only)
AWS_SECRET=... aws s3 ls           -> aws        (leading assignment redacted)
cd /x && rm -rf /secret            -> cd ; rm
curl x > /tmp/out                  -> curl       (redirect target dropped)
if grep x; then rm y; fi           -> grep ; rm  (reserved words skipped)
find . | xargs grep foo | sort     -> find ; xargs ; sort
```

Non-shell tools surface `""` — the row's `tool` field already names the action. Because the preview carries no argument data it rides on the existing `audit_action_enabled` gate (no new config knob).

## Safe-by-construction

The security invariant is that **no argument/data/PII value** (path, token, file content, case subject/pattern, heredoc body, array element, redirect target, comment text, quoted content) can *ever* enter the audit log — only command-position program names. The extractor is deliberately conservative: it emits only at unambiguous command positions and **bails/suppresses on anything it can't safely reason about** rather than trying to fully parse shell.

Handled: env-assignments incl. `NAME=(arrays)`; `;;`, newlines and parentheses are not command boundaries; `<<` heredocs stop the scan; `case…esac` fully suppressed; `for/select/function` operands dropped; function-definition names and `$(...)`/backtick substitutions suppressed/opaque; numeric-fd redirect prefixes; word-start `#` comments; and a **universal backslash escape** in the tokenizer so quoted/escaped args stay one word.

## Review

Reviewed adversarially over five rounds (aimee `delegate review --persona security`). Rounds 1–4 each surfaced real leak vectors — heredoc bodies, `case` patterns/subject, keyword operands, fd-prefix, reserved-word noise, array-assignment values, function-def names, backslash-escaped metacharacters — **all fixed with regression tests**. Additional self-audit via two adversarial batteries (~50 crafted inputs) closed unquoted `$()`/array-element and subshell-path-segment leaks. Final state: **0 leaks** across the battery; the common case stays useful.

## Known limitations (safe, documented)

- Subshell interiors show only nothing/first command (opaque); `case…esac` internals are not shown.
- Wrapper prefixes (`sudo`, `env`, `xargs`) show the wrapper, not the wrapped command (flag handling would add fragility).
- These are usefulness trade-offs in favor of the zero-leak invariant, never correctness/safety gaps.

## Tests

`test_audit_action` (extractor: arg/heredoc/case/array/funcdef/redirect/comment/quote no-leak assertions), `test_audit_action_log` (row now carries `command`), `test_audit_ledger` — all green. `aimee-core` compiles cleanly with the new `audit_action_log` signature (sole caller `guardrails_action_audit.c` updated; co-exists with testing's WORM dual-write after rebase).
