### PR TITLE
feat(webui): Workflow Actions lifecycle controls + webchat proxy fix

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -459,6 +459,56 @@ paths:
           content:
             application/json:
               schema: { type: object }
+  /workflow/repo/tree:
+    get:
+      summary: List directories + .md files under the server's local project checkout (composer proposal browser), path-confined
+      parameters:
+        - name: path
+          in: query
+          required: false
+          schema: { type: string }
+          description: Relative path under the project root ("" = root); rejects .. / symlink escape
+      responses:
+        "200":
+          description: "{path, entries:[{name,type:dir|file}]}"
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Path escapes the project root
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Not a directory / not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/repo/file:
+    get:
+      summary: Read one .md file under the confined project root (composer proposal browser)
+      parameters:
+        - name: path
+          in: query
+          required: true
+          schema: { type: string }
+          description: Relative .md path under the project root; rejects .. / symlink escape
+      responses:
+        "200":
+          description: "{path, content, truncated}"
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Path escapes the project root or is not a .md file
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: File not found / not a regular file
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /workflow/items/{id}/events:
     get:
       summary: The item's lifecycle timeline (proposal history), owner-only, paginated by event id
@@ -528,6 +578,86 @@ paths:
               schema: { type: object }
         "404":
           description: Work item not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+    delete:
+      summary: Delete a run — auto-abandons an active run first, then removes its rows and proposal file (owner or operator)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: "{id, deleted:true}"
+          content:
+            application/json:
+              schema: { type: object }
+        "403":
+          description: Not the caller's work item
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Work item not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/items/{id}/pause:
+    post:
+      summary: Pause an active run (operator_paused) so the scheduler stops advancing it (owner or operator)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Updated work-item run-state
+          content:
+            application/json:
+              schema: { type: object }
+        "409":
+          description: Run already finished or already paused
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/items/{id}/resume:
+    post:
+      summary: Resume a paused run and wake the scheduler; refuses a run parked at a human gate (owner or operator)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Updated work-item run-state
+          content:
+            application/json:
+              schema: { type: object }
+        "409":
+          description: Run not paused, already finished, or parked at a human gate (use Approve/Reject)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/items/{id}/stop:
+    post:
+      summary: Stop a run (abandon it); the scheduler reclaims its worktree (owner or operator)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Updated work-item run-state
+          content:
+            application/json:
+              schema: { type: object }
+        "409":
+          description: Run already finished
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -2,6 +2,19 @@ import { useEffect, useState, useCallback, useMemo } from 'react';
 import { Badge } from '@rakuensoftware/smoothgui';
 import type { BadgeVariant } from '@rakuensoftware/smoothgui';
 
+/* All fields of an audit row, in display order, for the detail modal. */
+const DETAIL_FIELDS: { key: keyof AuditRow; label: string }[] = [
+  { key: 'ts', label: 'Timestamp' },
+  { key: 'verdict', label: 'Verdict' },
+  { key: 'actor', label: 'Actor' },
+  { key: 'tool', label: 'Tool' },
+  { key: 'kind', label: 'Kind' },
+  { key: 'mode', label: 'Guardrail mode' },
+  { key: 'reason_code', label: 'Reason code' },
+  { key: 'args_hash', label: 'Args hash' },
+  { key: 'task_id', label: 'Task id' },
+];
+
 /* The server's own tool-action audit ledger (guardrail verdict on every tool
  * call the agent makes). Server-incurred — distinct from the KB's own logs. */
 interface AuditRow {
@@ -45,6 +58,15 @@ export default function Logs() {
   const [verdict, setVerdict] = useState('all');
   const [actor, setActor] = useState('all');
   const [q, setQ] = useState('');
+  const [selected, setSelected] = useState<AuditRow | null>(null);
+
+  // Close the detail modal on Escape.
+  useEffect(() => {
+    if (!selected) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setSelected(null); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selected]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -119,7 +141,14 @@ export default function Logs() {
             </thead>
             <tbody>
               {filtered.map((r, i) => (
-                <tr key={i}>
+                <tr
+                  key={i}
+                  onClick={() => setSelected(r)}
+                  style={{ cursor: 'pointer' }}
+                  onMouseEnter={ev => (ev.currentTarget.style.background = '#f6f9ff')}
+                  onMouseLeave={ev => (ev.currentTarget.style.background = 'transparent')}
+                  title="Click for full detail"
+                >
                   <td style={{ ...td, whiteSpace: 'nowrap', color: '#888' }}>{esc(r.ts).replace('T', ' ').replace('Z', '')}</td>
                   <td style={td}>{esc(r.actor)}</td>
                   <td style={{ ...td, fontFamily: 'monospace' }}>{esc(r.tool)}</td>
@@ -133,6 +162,51 @@ export default function Logs() {
           </table>
         )}
       </div>
+
+      {selected && (
+        <div
+          onClick={() => setSelected(null)}
+          style={{
+            position: 'fixed', inset: 0, zIndex: 30, background: 'rgba(0,0,0,0.35)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16,
+          }}
+        >
+          <div
+            onClick={ev => ev.stopPropagation()}
+            style={{
+              background: '#fff', borderRadius: 8, maxWidth: 560, width: '100%',
+              maxHeight: '80vh', overflow: 'auto', boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+            }}
+          >
+            <div style={{
+              display: 'flex', alignItems: 'center', gap: 10, padding: '12px 16px',
+              borderBottom: '1px solid #eee', position: 'sticky', top: 0, background: '#fff',
+            }}>
+              <strong style={{ fontSize: 14 }}>Audit entry</strong>
+              <Badge label={esc(selected.verdict)} variant={verdictVariant(selected.verdict)} />
+              <button
+                onClick={() => setSelected(null)}
+                style={{ ...selectStyle, cursor: 'pointer', marginLeft: 'auto' }}
+              >
+                Close
+              </button>
+            </div>
+            <div style={{ padding: '8px 16px 16px' }}>
+              {DETAIL_FIELDS.map(f => {
+                const v = selected[f.key];
+                return (
+                  <div key={f.key} style={{ display: 'flex', gap: 12, padding: '7px 0', borderBottom: '1px solid #f4f4f4' }}>
+                    <span style={{ width: 130, flexShrink: 0, color: '#888', fontSize: 12 }}>{f.label}</span>
+                    <span style={{ fontSize: 13, fontFamily: 'monospace', overflowWrap: 'anywhere', minWidth: 0 }}>
+                      {v == null || v === '' ? <span style={{ color: '#bbb' }}>—</span> : String(v)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -81,6 +81,22 @@ async function postJSON<T>(url: string, body: unknown): Promise<{ status: number
   return { status: r.status, data };
 }
 
+// A bare method call (POST/DELETE) with no body — used for the lifecycle actions.
+// Returns the status + parsed body (best effort) like postJSON.
+async function sendAction<T>(url: string, method: "POST" | "DELETE"): Promise<{ status: number; data: T }> {
+  const r = await fetch(url, {
+    method,
+    headers: { "X-CSRF-Token": window._csrf || "" },
+  });
+  let data = {} as T;
+  try {
+    data = (await r.json()) as T;
+  } catch {
+    /* empty body ok */
+  }
+  return { status: r.status, data };
+}
+
 const isTerminal = (s: string) => s === "accepted" || s === "rejected" || s === "abandoned";
 
 // A human status label + tone from the row's state + pause_reason + stage. Derived
@@ -91,6 +107,8 @@ function statusOf(it: Item): { label: string; variant: BadgeVariant } {
   if (it.state === "abandoned") return { label: "abandoned", variant: "neutral" };
   // active:
   switch (it.pause_reason) {
+    case "operator_paused":
+      return { label: `paused · ${it.stage}`, variant: "warning" };
     case "pending_human":
       return { label: `awaiting approval · ${it.stage}`, variant: "warning" };
     case "ci_pending":
@@ -132,6 +150,7 @@ const KIND_LABEL: Record<string, string> = {
   reject_retry: "rejected (retry)",
   override: "overridden",
   rejected: "rejected",
+  abandon: "stopped",
 };
 
 // pr_ref is opaque (a PR number or a URL). Render a link when it looks like one.
@@ -330,7 +349,54 @@ export default function WorkflowActions() {
     [selId, openProposal],
   );
 
+  // Lifecycle control (pause / resume / stop / delete). On success we refresh the
+  // open proposal (or clear the selection after a delete).
+  const [actMsg, setActMsg] = useState("");
+  const [acting, setActing] = useState(false);
+  const doLifecycle = useCallback(
+    async (action: "pause" | "resume" | "stop" | "delete") => {
+      if (!selId || acting) return;
+      if (action === "stop" && !window.confirm("Stop this run? It will be abandoned and cannot be resumed."))
+        return;
+      if (action === "delete" && !window.confirm("Delete this run permanently? Its history and proposal file will be removed."))
+        return;
+      setActMsg("");
+      setActing(true);
+      try {
+        const isDel = action === "delete";
+        const { status: st, data } = await sendAction<{ error?: string }>(
+          isDel
+            ? `/api/workflow/items/${encodeURIComponent(selId)}`
+            : `/api/workflow/items/${encodeURIComponent(selId)}/${action}`,
+          isDel ? "DELETE" : "POST",
+        );
+        if (st >= 200 && st < 300) {
+          if (isDel) {
+            setSelId(null);
+            setDetail(null);
+            refreshList();
+          } else {
+            openProposal(selId); // refresh detail + events after the transition
+          }
+        } else {
+          setActMsg(data.error || `failed (HTTP ${st})`);
+        }
+      } catch {
+        setActMsg("action failed");
+      } finally {
+        setActing(false);
+      }
+    },
+    [selId, acting, refreshList, openProposal],
+  );
+
   const canDecide = !!detail && detail.pause_reason === "pending_human";
+  // Which lifecycle controls apply to the current item.
+  const term = !!detail && isTerminal(detail.state);
+  const paused = !!detail && !term && !!detail.pause_reason;
+  const canPause = !!detail && !term && !detail.pause_reason;
+  const canResume = paused && detail!.pause_reason !== "pending_human";
+  const canStop = !!detail && !term;
 
   return (
     <div style={{ display: "flex", height: "100%", fontFamily: "system-ui" }}>
@@ -435,6 +501,39 @@ export default function WorkflowActions() {
             </div>
             <StatusHeader item={detail} />
 
+            {/* Lifecycle controls: start (resume) / pause / stop / delete. Shown by
+                the item's current state; a run at a human gate uses Approve/Reject
+                (below) rather than resume. */}
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", margin: "4px 0 10px" }}>
+              {canResume && (
+                <button onClick={() => void doLifecycle("resume")} disabled={acting} style={btn}>
+                  ▶ Start
+                </button>
+              )}
+              {canPause && (
+                <button onClick={() => void doLifecycle("pause")} disabled={acting} style={btn}>
+                  ⏸ Pause
+                </button>
+              )}
+              {canStop && (
+                <button
+                  onClick={() => void doLifecycle("stop")}
+                  disabled={acting}
+                  style={{ ...btn, background: "#fbeaea", color: "#a33", borderColor: "#e0a0a0" }}
+                >
+                  ⏹ Stop
+                </button>
+              )}
+              <button
+                onClick={() => void doLifecycle("delete")}
+                disabled={acting}
+                style={{ ...btn, background: "#fff5f5", color: "#c00", borderColor: "#e6b3b3", marginLeft: "auto" }}
+              >
+                🗑 Delete
+              </button>
+              {actMsg && <span style={{ fontSize: 12, color: "#c00", flexBasis: "100%" }}>{actMsg}</span>}
+            </div>
+
             {canDecide && (
               <Panel title={`Human gate · ${detail.stage}`}>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
@@ -505,6 +604,61 @@ function Composer({
   const [preview, setPreview] = useState<string | null>(null);
   const [draftErr, setDraftErr] = useState("");
   const busy = drafting || submitting;
+
+  // "Load a proposal from the project": a read-only, path-confined browser over
+  // the server's local checkout. Picking a .md file previews its contents into the
+  // same accept-first preview panel used by the delegate draft, so it never
+  // silently clobbers the body.
+  const [browsing, setBrowsing] = useState(false);
+  const [browsePath, setBrowsePath] = useState("");
+  const [entries, setEntries] = useState<{ name: string; type: "dir" | "file" }[]>([]);
+  const [browseErr, setBrowseErr] = useState("");
+  const [browseLoading, setBrowseLoading] = useState(false);
+
+  const loadTree = async (path: string) => {
+    setBrowseErr("");
+    setBrowseLoading(true);
+    try {
+      const d = await getJSON<{ path: string; entries: { name: string; type: "dir" | "file" }[] }>(
+        `/api/workflow/repo/tree?path=${encodeURIComponent(path)}`,
+      );
+      setBrowsePath(d.path || "");
+      // Directories first, then files; each group alphabetical.
+      const es = (d.entries || []).slice().sort((a, b) =>
+        a.type !== b.type ? (a.type === "dir" ? -1 : 1) : a.name.localeCompare(b.name),
+      );
+      setEntries(es);
+    } catch (e) {
+      setBrowseErr(`could not list: ${(e as Error).message}`);
+      setEntries([]);
+    } finally {
+      setBrowseLoading(false);
+    }
+  };
+  const openBrowser = () => {
+    setBrowsing(true);
+    void loadTree(browsePath || "docs/proposals");
+  };
+  const parentPath = (p: string) => {
+    const i = p.lastIndexOf("/");
+    return i > 0 ? p.slice(0, i) : "";
+  };
+  const pickFile = async (name: string) => {
+    const rel = browsePath ? `${browsePath}/${name}` : name;
+    setBrowseErr("");
+    setBrowseLoading(true);
+    try {
+      const d = await getJSON<{ content: string; truncated: boolean }>(
+        `/api/workflow/repo/file?path=${encodeURIComponent(rel)}`,
+      );
+      setPreview(d.content || "");
+      setBrowsing(false);
+    } catch (e) {
+      setBrowseErr(`could not read: ${(e as Error).message}`);
+    } finally {
+      setBrowseLoading(false);
+    }
+  };
 
   const generate = async () => {
     if (drafting) return; // re-entrancy guard (the button is also disabled while busy)
@@ -628,9 +782,80 @@ function Composer({
         <button onClick={() => void generate()} disabled={busy} style={btn}>
           {drafting ? "Drafting…" : "✨ Draft with a delegate"}
         </button>
+        <button onClick={() => (browsing ? setBrowsing(false) : openBrowser())} disabled={busy} style={btn}>
+          {browsing ? "Close browser" : "📂 Load from project"}
+        </button>
         {submitMsg && <span style={{ fontSize: 12, color: "#c00" }}>{submitMsg}</span>}
         {draftErr && <span style={{ fontSize: 12, color: "#c00" }}>{draftErr}</span>}
       </div>
+
+      {browsing && (
+        <div
+          style={{
+            border: "1px solid #d9e2ef",
+            background: "#fbfdff",
+            borderRadius: 6,
+            padding: 10,
+            marginTop: 10,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+            <strong style={{ fontSize: 13 }}>Project</strong>
+            <span style={{ fontSize: 12, color: "#667", fontFamily: "monospace", overflowWrap: "anywhere" }}>
+              /{browsePath}
+            </span>
+            {browseLoading && <span style={{ fontSize: 11, color: "#aaa" }}>loading…</span>}
+            <span style={{ marginLeft: "auto", fontSize: 11, color: "#888" }}>
+              Pick a .md file to load it as the proposal.
+            </span>
+          </div>
+          {browseErr && <div style={{ fontSize: 12, color: "#c00", marginBottom: 6 }}>{browseErr}</div>}
+          <div style={{ maxHeight: 280, overflow: "auto", border: "1px solid #eef2f7", borderRadius: 4 }}>
+            {browsePath && (
+              <BrowseRow icon="↩" label=".." onClick={() => void loadTree(parentPath(browsePath))} />
+            )}
+            {entries.length === 0 && !browseLoading && (
+              <div style={{ padding: "8px 10px", color: "#999", fontSize: 13 }}>
+                No sub-folders or .md files here.
+              </div>
+            )}
+            {entries.map((e) =>
+              e.type === "dir" ? (
+                <BrowseRow
+                  key={e.name}
+                  icon="📁"
+                  label={e.name}
+                  onClick={() => void loadTree(browsePath ? `${browsePath}/${e.name}` : e.name)}
+                />
+              ) : (
+                <BrowseRow key={e.name} icon="📄" label={e.name} onClick={() => void pickFile(e.name)} />
+              ),
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BrowseRow({ icon, label, onClick }: { icon: string; label: string; onClick: () => void }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "6px 10px",
+        cursor: "pointer",
+        borderBottom: "1px solid #f4f7fb",
+        fontSize: 13,
+      }}
+      onMouseEnter={(ev) => (ev.currentTarget.style.background = "#eef4ff")}
+      onMouseLeave={(ev) => (ev.currentTarget.style.background = "transparent")}
+    >
+      <span style={{ width: 16, textAlign: "center" }}>{icon}</span>
+      <span style={{ overflowWrap: "anywhere" }}>{label}</span>
     </div>
   );
 }

--- a/src/db1/wfe_store.c
+++ b/src/db1/wfe_store.c
@@ -425,6 +425,31 @@ int db1_work_item_clear_pause(const char *wi)
                             wi);
 }
 
+int db1_work_item_delete(const char *wi)
+{
+   if (!wi || !wi[0])
+      return -1;
+   /* No FK cascade: the three lifecycle tables are independent, so remove the
+    * item's rows from each under one transaction (all-or-nothing). Events and
+    * stage-attempts are deleted first, then the item row, so a partial failure
+    * never leaves an item row without its history or vice versa. */
+   if (db1_lifecycle_txn_begin() != 0)
+      return -1;
+   if (exec_bind1_update("DELETE FROM lifecycle_event WHERE work_item_id=?", wi) != 0 ||
+       exec_bind1_update("DELETE FROM lifecycle_stage_attempt WHERE work_item_id=?", wi) != 0 ||
+       exec_bind1_update("DELETE FROM lifecycle_work_item WHERE work_item_id=?", wi) != 0)
+   {
+      db1_lifecycle_txn_rollback();
+      return -1;
+   }
+   if (db1_lifecycle_txn_commit() != 0)
+   {
+      db1_lifecycle_txn_rollback();
+      return -1;
+   }
+   return 0;
+}
+
 int db1_work_item_add_cost(const char *wi, double cost)
 {
    sqlite3 *db = db1_conn();

--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -115,6 +115,14 @@ int db1_work_item_add_cost(const char *work_item_id, double cost);
 int db1_work_item_set_cost_cap(const char *work_item_id, double cap);
 int db1_work_item_inc_override(const char *work_item_id); /* returns new count, -1 err */
 
+/* Permanently delete a work item and all its history (lifecycle_event +
+ * lifecycle_stage_attempt + lifecycle_work_item rows) under one transaction.
+ * There is no FK cascade, so all three tables are cleared explicitly. Returns
+ * 0 on success (incl. an already-absent item — DELETE is idempotent), -1 on
+ * error. The caller is responsible for any out-of-DB artifacts (proposal file,
+ * worktree). */
+int db1_work_item_delete(const char *work_item_id);
+
 /* List work items (newest first). Caller frees *out. Returns count or -1. */
 int db1_work_item_list(db1_work_item_t **out);
 

--- a/src/headers/server_http_internal.h
+++ b/src/headers/server_http_internal.h
@@ -106,4 +106,16 @@ typedef int (*route_handler_fn)(const route_req_t *rq, char *resp, int cap);
 /* PC2: CI webhook route handler (defined in server_ci_route.c). */
 int rh_dev_ci_event(const route_req_t *rq, char *resp, int cap);
 
+/* Workflow Actions lifecycle + project-file-browser route adapters + the shared
+ * unsigned-long query-param helper — defined in server_http_config_routes.c
+ * (relocated out of server_http_routes.c to stay under the line-check ceiling).
+ * Referenced by the route table in server_http_routes.c. */
+long rh_query_long(const char *key, long dflt);
+int rh_wf_item_pause(const route_req_t *rq, char *resp, int cap);
+int rh_wf_item_resume(const route_req_t *rq, char *resp, int cap);
+int rh_wf_item_stop(const route_req_t *rq, char *resp, int cap);
+int rh_wf_item_delete(const route_req_t *rq, char *resp, int cap);
+int rh_wf_repo_tree(const route_req_t *rq, char *resp, int cap);
+int rh_wf_repo_file(const route_req_t *rq, char *resp, int cap);
+
 #endif /* SERVER_HTTP_INTERNAL_H */

--- a/src/server/server_http_config_routes.c
+++ b/src/server/server_http_config_routes.c
@@ -30,6 +30,7 @@
 #include "request_context.h"
 #include "server_http_identity.h" /* WP-C.0 attested-identity capture/threading */
 #include "server_workflow_api.h"  /* W7: /v1/workflow read+author handlers */
+#include "wfe_scheduler.h"        /* wfe_scheduler_notify — resume the autonomy driver */
 #include "cJSON.h"
 #include <arpa/inet.h>
 #include <errno.h>
@@ -280,4 +281,122 @@ int route_role_template_remove(const char *name, char *resp, int cap)
    cJSON_AddStringToObject(o, "role", name);
    cJSON_AddBoolToObject(o, "deleted", 1);
    return emit(resp, cap, o);
+}
+
+/* ── query-param helpers + Workflow Actions route adapters ───────────────────
+ * Relocated here from server_http_routes.c (referenced by that TU's route table
+ * via server_http_internal.h) to keep that file under the line-check ceiling. */
+
+/* Parse an unsigned long query param ("k=v&…") from the request's query string;
+ * returns `dflt` when the key is absent or unparseable. */
+long rh_query_long(const char *key, long dflt)
+{
+   const char *q = server_http_identity_query();
+   size_t klen = strlen(key);
+   for (const char *p = q; p && *p;)
+   {
+      const char *amp = strchr(p, '&');
+      if (strncmp(p, key, klen) == 0 && p[klen] == '=')
+      {
+         char *end = NULL;
+         long v = strtol(p + klen + 1, &end, 10);
+         if (end != p + klen + 1)
+            return v;
+         return dflt;
+      }
+      if (!amp)
+         break;
+      p = amp + 1;
+   }
+   return dflt;
+}
+
+/* One hex digit → value, or -1. */
+static int rh_hex(char c)
+{
+   if (c >= '0' && c <= '9')
+      return c - '0';
+   if (c >= 'a' && c <= 'f')
+      return c - 'a' + 10;
+   if (c >= 'A' && c <= 'F')
+      return c - 'A' + 10;
+   return -1;
+}
+
+/* Read a percent-decoded string query param into `out` ("" if absent). A path may
+ * arrive percent-encoded (encodeURIComponent turns '/' into %2F), so %XX escapes
+ * are decoded; a malformed escape is copied literally. */
+static void rh_query_str(const char *key, char *out, size_t cap)
+{
+   if (cap)
+      out[0] = '\0';
+   const char *q = server_http_identity_query();
+   size_t klen = strlen(key);
+   for (const char *p = q; p && *p;)
+   {
+      const char *amp = strchr(p, '&');
+      if (strncmp(p, key, klen) == 0 && p[klen] == '=')
+      {
+         const char *v = p + klen + 1;
+         const char *end = amp ? amp : v + strlen(v);
+         size_t o = 0;
+         for (const char *s = v; s < end && cap && o + 1 < cap; s++)
+         {
+            int hi, lo;
+            if (*s == '%' && s + 2 < end && (hi = rh_hex(s[1])) >= 0 && (lo = rh_hex(s[2])) >= 0)
+            {
+               out[o++] = (char)((hi << 4) | lo);
+               s += 2;
+            }
+            else
+            {
+               out[o++] = *s;
+            }
+         }
+         if (cap)
+            out[o] = '\0';
+         return;
+      }
+      if (!amp)
+         break;
+      p = amp + 1;
+   }
+}
+
+/* Lifecycle mutations. The route cap (CAP_DASHBOARD_READ) admits owners; operator
+ * status (CAP_WORKFLOW_ADMIN on the connection) lifts the owner-only restriction
+ * inside the wf_api_* handler. */
+#define RH_WF_IS_OPERATOR() ((g_rpc_conn_caps & CAP_WORKFLOW_ADMIN) != 0)
+int rh_wf_item_pause(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_item_pause(rq->id, RH_WF_IS_OPERATOR(), resp, cap);
+}
+int rh_wf_item_resume(const route_req_t *rq, char *resp, int cap)
+{
+   int rc = wf_api_item_resume(rq->id, RH_WF_IS_OPERATOR(), resp, cap);
+   if (rc >= 200 && rc < 300)
+      wfe_scheduler_notify(); /* wake the driver so the resumed run advances now */
+   return rc;
+}
+int rh_wf_item_stop(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_item_stop(rq->id, RH_WF_IS_OPERATOR(), resp, cap);
+}
+int rh_wf_item_delete(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_item_delete(rq->id, RH_WF_IS_OPERATOR(), resp, cap);
+}
+int rh_wf_repo_tree(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   char path[4096];
+   rh_query_str("path", path, sizeof path);
+   return wf_api_repo_tree(path, resp, cap);
+}
+int rh_wf_repo_file(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   char path[4096];
+   rh_query_str("path", path, sizeof path);
+   return wf_api_repo_file(path, resp, cap);
 }

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -841,29 +841,8 @@ static int rh_wf_item(const route_req_t *rq, char *resp, int cap)
 {
    return wf_api_item(rq->id, resp, cap);
 }
-/* Parse an unsigned long query param ("k=v&…") from the request's query string;
- * returns `dflt` when the key is absent or unparseable. */
-static long rh_query_long(const char *key, long dflt)
-{
-   const char *q = server_http_identity_query();
-   size_t klen = strlen(key);
-   for (const char *p = q; p && *p;)
-   {
-      const char *amp = strchr(p, '&');
-      if (strncmp(p, key, klen) == 0 && p[klen] == '=')
-      {
-         char *end = NULL;
-         long v = strtol(p + klen + 1, &end, 10);
-         if (end != p + klen + 1)
-            return v;
-         return dflt;
-      }
-      if (!amp)
-         break;
-      p = amp + 1;
-   }
-   return dflt;
-}
+/* rh_query_long is declared in server_http_internal.h and defined in
+ * server_http_config_routes.c (moved there to keep this TU under the line cap). */
 static int rh_wf_events(const route_req_t *rq, char *resp, int cap)
 {
    long after = rh_query_long("after", 0);
@@ -874,6 +853,11 @@ static int rh_wf_proposal(const route_req_t *rq, char *resp, int cap)
 {
    return wf_api_proposal(rq->id, resp, cap);
 }
+
+/* The Workflow Actions lifecycle (rh_wf_item_pause/resume/stop/delete) and
+ * project-file-browser (rh_wf_repo_tree/file) route adapters are defined in
+ * server_http_config_routes.c (declared in server_http_internal.h) so this TU
+ * stays under the line-check ceiling; the route table below references them. */
 
 /* The POST /v1/rpc bridge was retired once every dispatch method gained a
  * first-class /v1 route (op-parity complete; check-v1-method-coverage reports 0
@@ -2318,7 +2302,21 @@ static const http_route_t g_v1_routes[] = {
     {"GET", "/v1/workflow/items/", "/events", RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_events},
     {"GET", "/v1/workflow/items/", "/proposal", RM_PREFIX, NULL, CAP_DASHBOARD_READ,
      rh_wf_proposal},
+    /* Lifecycle mutations. Route cap admits owners (CAP_DASHBOARD_READ); the
+     * handler additionally allows operators (CAP_WORKFLOW_ADMIN) and 403s a
+     * non-owner non-operator. Suffix rows precede the bare /<id> rows. */
+    {"POST", "/v1/workflow/items/", "/pause", RM_PREFIX, NULL, CAP_DASHBOARD_READ,
+     rh_wf_item_pause},
+    {"POST", "/v1/workflow/items/", "/resume", RM_PREFIX, NULL, CAP_DASHBOARD_READ,
+     rh_wf_item_resume},
+    {"POST", "/v1/workflow/items/", "/stop", RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item_stop},
     {"GET", "/v1/workflow/items/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item},
+    /* DELETE the bare /<id> — distinct from the GET row by verb; auto-stops an
+     * active run then removes it. */
+    {"DELETE", "/v1/workflow/items/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item_delete},
+    /* Composer project-file browser (read-only, confined to the local checkout). */
+    {"GET", "/v1/workflow/repo/tree", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_repo_tree},
+    {"GET", "/v1/workflow/repo/file", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_repo_file},
 
     {"GET", "/v1/sessions", NULL, RM_EXACT, NULL, CAP_SESSION_READ, rh_sessions_list},
     {"POST", "/v1/sessions/", "/attach", RM_PREFIX, NULL, CAP_SESSION_READ, rh_session_attach},

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -14,6 +14,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h> /* PATH_MAX for the confined project-file browser */
 #include <unistd.h>
 #endif
 
@@ -782,6 +783,276 @@ int wf_api_proposal(const char *id, char *resp, int cap)
 
    cJSON *o = cJSON_CreateObject();
    cJSON_AddStringToObject(o, "proposal_md", buf);
+   cJSON_AddBoolToObject(o, "truncated", truncated);
+   free(buf);
+   return emit(o, resp, cap);
+}
+
+/* ── lifecycle mutations (start / pause / stop / delete) ─────────────────────
+ * All share the same access rule: the item's submitter OR an operator. */
+
+static int item_terminal(const db1_work_item_t *wi)
+{
+   return strcmp(wi->state, "accepted") == 0 || strcmp(wi->state, "rejected") == 0 ||
+          strcmp(wi->state, "abandoned") == 0;
+}
+
+/* The attested principal driving this mutation (for the audit event actor). */
+static const char *wf_actor(void)
+{
+   const char *p = server_http_identity_principal();
+   return (p && p[0]) ? p : "operator";
+}
+
+/* Resolve + owner/operator-gate an item for a mutation. On success fills `wi` and
+ * returns 0; otherwise writes an error envelope and returns the HTTP status. */
+static int wf_load_for_mutation(const char *id, int is_operator, db1_work_item_t *wi, char *resp,
+                                int cap)
+{
+   if (!id || !id[0])
+      return err(resp, cap, 400, "missing work item id");
+   if (db1_work_item_get(id, wi) != 1)
+      return err(resp, cap, 404, "work item not found");
+   if (!is_operator && !wf_owns(wi))
+      return err(resp, cap, 403, "not your work item");
+   return 0;
+}
+
+int wf_api_item_pause(const char *id, int is_operator, char *resp, int cap)
+{
+   db1_work_item_t wi;
+   int rc = wf_load_for_mutation(id, is_operator, &wi, resp, cap);
+   if (rc)
+      return rc;
+   if (item_terminal(&wi))
+      return err(resp, cap, 409, "run already finished");
+   if (wi.pause_reason[0])
+      return err(resp, cap, 409, "run is already paused");
+   if (db1_work_item_set_pause(id, "operator_paused", wi.current_stage) != 0)
+      return err(resp, cap, 500, "could not pause run");
+   db1_lifecycle_event_add(id, wi.current_stage, "pause", wf_actor(), "paused by operator", "", 0);
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 500, "paused but could not reload");
+   return emit(item_to_json(&wi), resp, cap);
+}
+
+int wf_api_item_resume(const char *id, int is_operator, char *resp, int cap)
+{
+   db1_work_item_t wi;
+   int rc = wf_load_for_mutation(id, is_operator, &wi, resp, cap);
+   if (rc)
+      return rc;
+   if (item_terminal(&wi))
+      return err(resp, cap, 409, "run already finished");
+   if (!wi.pause_reason[0])
+      return err(resp, cap, 409, "run is not paused");
+   /* A run parked at a human gate must be decided via Approve/Reject so the
+    * signed approval is recorded — never silently un-paused here. */
+   if (strcmp(wi.pause_reason, "pending_human") == 0)
+      return err(resp, cap, 409, "run is at a human gate — use Approve or Reject");
+   if (db1_work_item_clear_pause(id) != 0)
+      return err(resp, cap, 500, "could not resume run");
+   db1_lifecycle_event_add(id, wi.current_stage, "resume", wf_actor(), "resumed by operator", "",
+                           0);
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 500, "resumed but could not reload");
+   return emit(item_to_json(&wi), resp, cap);
+}
+
+int wf_api_item_stop(const char *id, int is_operator, char *resp, int cap)
+{
+   db1_work_item_t wi;
+   int rc = wf_load_for_mutation(id, is_operator, &wi, resp, cap);
+   if (rc)
+      return rc;
+   if (item_terminal(&wi))
+      return err(resp, cap, 409, "run already finished");
+   if (db1_work_item_set_terminal(id, "abandoned") != 0)
+      return err(resp, cap, 500, "could not stop run");
+   db1_lifecycle_event_add(id, wi.current_stage, "abandon", wf_actor(), "stopped by operator", "",
+                           0);
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 500, "stopped but could not reload");
+   return emit(item_to_json(&wi), resp, cap);
+}
+
+int wf_api_item_delete(const char *id, int is_operator, char *resp, int cap)
+{
+   db1_work_item_t wi;
+   int rc = wf_load_for_mutation(id, is_operator, &wi, resp, cap);
+   if (rc)
+      return rc;
+   /* Auto-stop an in-flight run first: mark it terminal so the scheduler's
+    * orphan-sweep reclaims its worktree before the row disappears. */
+   if (!item_terminal(&wi))
+      db1_work_item_set_terminal(id, "abandoned");
+
+   /* Best-effort unlink the server-minted proposal artifact, confined to
+    * $AIMEE_HOME/workflows/proposals via a dirfd + a slash-free basename (same
+    * race-free confinement as wf_api_proposal). A missing/odd file is ignored —
+    * the row removal is the operation of record. */
+   if (wi.proposal_path[0])
+   {
+      const char *base = path_basename(wi.proposal_path);
+      if (base[0] && !strchr(base, '/') && strcmp(base, ".") != 0 && strcmp(base, "..") != 0)
+      {
+         const char *home = aimee_home();
+         char dir[1024];
+         snprintf(dir, sizeof dir, "%s/workflows/proposals", home ? home : "/tmp");
+         int dfd = open(dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+         if (dfd >= 0)
+         {
+            unlinkat(dfd, base, 0); /* best effort */
+            close(dfd);
+         }
+      }
+   }
+
+   if (db1_work_item_delete(id) != 0)
+      return err(resp, cap, 500, "could not delete run");
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "id", id);
+   cJSON_AddBoolToObject(o, "deleted", 1);
+   return emit(o, resp, cap);
+}
+
+/* ── project file browser (composer "load a proposal from the project") ──────
+ * Read-only, confined to the server's local checkout root. */
+
+/* The project root the browser is rooted at: the workflow repo if configured,
+ * else the server's cwd. Returns the realpath'd root in `out` (>= PATH_MAX), or
+ * NULL on failure. */
+static char *wf_repo_root(char resolved[PATH_MAX])
+{
+   const char *root = getenv("AIMEE_WORKFLOW_REPO");
+   if (!root || !root[0])
+      root = ".";
+   return realpath(root, resolved);
+}
+
+/* Resolve `rel` under the project root and confirm the result stays inside it
+ * (blocks `..` and symlink escape). Writes the resolved absolute path to `out`
+ * and returns 0; on escape/nonexistence returns an HTTP status via `err`. */
+static int wf_resolve_confined(const char *rel, char out[PATH_MAX], char *resp, int cap)
+{
+   char root[PATH_MAX];
+   if (!wf_repo_root(root))
+      return err(resp, cap, 500, "project root unavailable");
+   char cand[PATH_MAX];
+   if (!rel || !rel[0])
+      snprintf(cand, sizeof cand, "%s", root);
+   else if ((int)snprintf(cand, sizeof cand, "%s/%s", root, rel) >= (int)sizeof cand)
+      return err(resp, cap, 400, "path too long");
+   if (!realpath(cand, out))
+      return err(resp, cap, 404, "path not found");
+   /* Confinement: `out` must equal root or sit strictly beneath it (root + '/'). */
+   size_t rl = strlen(root);
+   if (strncmp(out, root, rl) != 0 || (out[rl] != '\0' && out[rl] != '/'))
+      return err(resp, cap, 400, "path escapes project root");
+   return 0;
+}
+
+/* Relative path of `abs` beneath realpath'd `root` (for echoing back to the UI).
+ * "" at the root; never leading '/'. */
+static const char *wf_rel_of(const char *abs, const char *root)
+{
+   size_t rl = strlen(root);
+   if (strncmp(abs, root, rl) != 0)
+      return "";
+   const char *r = abs + rl;
+   while (*r == '/')
+      r++;
+   return r;
+}
+
+static int str_ends_with(const char *s, const char *suf)
+{
+   size_t ls = strlen(s), lf = strlen(suf);
+   return ls >= lf && strcmp(s + ls - lf, suf) == 0;
+}
+
+int wf_api_repo_tree(const char *rel, char *resp, int cap)
+{
+   char root[PATH_MAX];
+   if (!wf_repo_root(root))
+      return err(resp, cap, 500, "project root unavailable");
+   char abs[PATH_MAX];
+   int rc = wf_resolve_confined(rel, abs, resp, cap);
+   if (rc)
+      return rc;
+
+   DIR *d = opendir(abs);
+   if (!d)
+      return err(resp, cap, 404, "not a directory");
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "path", wf_rel_of(abs, root));
+   cJSON *arr = cJSON_AddArrayToObject(o, "entries");
+   struct dirent *e;
+   while ((e = readdir(d)) != NULL)
+   {
+      const char *name = e->d_name;
+      if (name[0] == '.')
+         continue; /* skip . / .. and hidden (incl. .git) */
+      if (strcmp(name, "node_modules") == 0)
+         continue;
+      char child[PATH_MAX];
+      if ((int)snprintf(child, sizeof child, "%s/%s", abs, name) >= (int)sizeof child)
+         continue;
+      struct stat stt;
+      if (stat(child, &stt) != 0)
+         continue;
+      int is_dir = S_ISDIR(stt.st_mode);
+      if (!is_dir && !str_ends_with(name, ".md"))
+         continue; /* files: markdown only */
+      cJSON *it = cJSON_CreateObject();
+      cJSON_AddStringToObject(it, "name", name);
+      cJSON_AddStringToObject(it, "type", is_dir ? "dir" : "file");
+      cJSON_AddItemToArray(arr, it);
+   }
+   closedir(d);
+   return emit(o, resp, cap);
+}
+
+int wf_api_repo_file(const char *rel, char *resp, int cap)
+{
+   char root[PATH_MAX];
+   if (!wf_repo_root(root))
+      return err(resp, cap, 500, "project root unavailable");
+   if (!rel || !rel[0])
+      return err(resp, cap, 400, "missing path");
+   if (!str_ends_with(rel, ".md"))
+      return err(resp, cap, 400, "only .md files are readable");
+   char abs[PATH_MAX];
+   int rc = wf_resolve_confined(rel, abs, resp, cap);
+   if (rc)
+      return rc;
+
+   int fd = open(abs, O_RDONLY | O_CLOEXEC);
+   if (fd < 0)
+      return err(resp, cap, 404, "file not found");
+   struct stat stt;
+   if (fstat(fd, &stt) != 0 || !S_ISREG(stt.st_mode))
+   {
+      close(fd);
+      return err(resp, cap, 404, "not a regular file");
+   }
+   char *buf = malloc(WF_PROPOSAL_MAX + 1);
+   if (!buf)
+   {
+      close(fd);
+      return err(resp, cap, 500, "out of memory");
+   }
+   size_t total = 0;
+   ssize_t r;
+   while (total < WF_PROPOSAL_MAX && (r = read(fd, buf + total, WF_PROPOSAL_MAX - total)) > 0)
+      total += (size_t)r;
+   close(fd);
+   buf[total] = '\0';
+   int truncated = (off_t)total < stt.st_size;
+
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "path", wf_rel_of(abs, root));
+   cJSON_AddStringToObject(o, "content", buf);
    cJSON_AddBoolToObject(o, "truncated", truncated);
    free(buf);
    return emit(o, resp, cap);

--- a/src/server/server_workflow_api.h
+++ b/src/server/server_workflow_api.h
@@ -60,4 +60,34 @@ int wf_api_events(const char *id, long after, int limit, char *resp, int cap);
  * Returns {proposal_md, truncated}; 404 if the file is missing. */
 int wf_api_proposal(const char *id, char *resp, int cap);
 
+/* Lifecycle mutations on one run. Access = the item's submitter OR an operator
+ * (is_operator, derived from the caller's CAP_WORKFLOW_ADMIN); else 403. Each
+ * returns the updated item row (or an error envelope). `is_operator` non-zero
+ * lifts the owner-only restriction. 404 unknown id, 409 on an invalid transition.
+ *
+ * pause  -- park an active, un-paused run with pause_reason=operator_paused so the
+ *           scheduler stops advancing it.
+ * resume -- clear the pause and (caller then wakes the scheduler). 409 if the run
+ *           is parked at pending_human (that must go through Approve/Reject).
+ * stop   -- set the run terminal (abandoned); the scheduler reclaims its worktree.
+ * delete -- if still active, abandon first, then permanently remove the run's rows
+ *           and best-effort unlink its proposal file. */
+int wf_api_item_pause(const char *id, int is_operator, char *resp, int cap);
+int wf_api_item_resume(const char *id, int is_operator, char *resp, int cap);
+int wf_api_item_stop(const char *id, int is_operator, char *resp, int cap);
+int wf_api_item_delete(const char *id, int is_operator, char *resp, int cap);
+
+/* GET /v1/workflow/repo/tree?path=<rel> -- list immediate directory entries under
+ * the server's local project checkout (root = $AIMEE_WORKFLOW_REPO, else cwd), for
+ * the composer's "load a proposal from the project" browser. Returns {path,
+ * entries:[{name,type:"dir"|"file"}]} with directories + `.md` files only; hidden
+ * dirs and node_modules are skipped. Path-confined via realpath (rejects `..` /
+ * symlink escape): 400 on escape, 404 on a missing dir. */
+int wf_api_repo_tree(const char *rel, char *resp, int cap);
+
+/* GET /v1/workflow/repo/file?path=<rel> -- read one `.md` file under the same
+ * confined project root. Returns {path, content, truncated} (size-capped like the
+ * proposal read). 400 on escape / non-.md, 404 if missing / not a regular file. */
+int wf_api_repo_file(const char *rel, char *resp, int cap);
+
 #endif /* DEC_SERVER_WORKFLOW_API_H */

--- a/src/tests/support/workflow_api_stub.c
+++ b/src/tests/support/workflow_api_stub.c
@@ -76,6 +76,40 @@ int wf_api_proposal(const char *id, char *resp, int cap)
    (void)id;
    return stub(resp, cap);
 }
+int wf_api_item_pause(const char *id, int is_operator, char *resp, int cap)
+{
+   (void)id;
+   (void)is_operator;
+   return stub(resp, cap);
+}
+int wf_api_item_resume(const char *id, int is_operator, char *resp, int cap)
+{
+   (void)id;
+   (void)is_operator;
+   return stub(resp, cap);
+}
+int wf_api_item_stop(const char *id, int is_operator, char *resp, int cap)
+{
+   (void)id;
+   (void)is_operator;
+   return stub(resp, cap);
+}
+int wf_api_item_delete(const char *id, int is_operator, char *resp, int cap)
+{
+   (void)id;
+   (void)is_operator;
+   return stub(resp, cap);
+}
+int wf_api_repo_tree(const char *rel, char *resp, int cap)
+{
+   (void)rel;
+   return stub(resp, cap);
+}
+int wf_api_repo_file(const char *rel, char *resp, int cap)
+{
+   (void)rel;
+   return stub(resp, cap);
+}
 
 /* Autonomous-development intake symbols referenced by rh_dev_submit in
  * server_http_routes.inc. Stubbed so tests that link server_http.o don't pull the

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -726,6 +726,17 @@ int main(void)
              CAP_DASHBOARD_READ);
       assert(server_http_route_caps("GET", "/v1/workflow/items/all") == CAP_WORKFLOW_ADMIN);
       assert(server_http_route_caps("GET", "/v1/workflow/items/wi_x") == CAP_DASHBOARD_READ);
+      /* Lifecycle mutations: route cap admits owners (CAP_DASHBOARD_READ); the
+       * handler re-checks owner-or-operator. The suffix rows must win over the bare
+       * /<id> row, and DELETE /<id> is distinct from GET /<id> by verb. */
+      assert(server_http_route_caps("POST", "/v1/workflow/items/wi_x/pause") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("POST", "/v1/workflow/items/wi_x/resume") ==
+             CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("POST", "/v1/workflow/items/wi_x/stop") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("DELETE", "/v1/workflow/items/wi_x") == CAP_DASHBOARD_READ);
+      /* Composer project-file browser (read-only). */
+      assert(server_http_route_caps("GET", "/v1/workflow/repo/tree") == CAP_DASHBOARD_READ);
+      assert(server_http_route_caps("GET", "/v1/workflow/repo/file") == CAP_DASHBOARD_READ);
       /* Presence is session-scoped; the streaming routes carry caps too. */
       assert(server_http_route_caps("GET", "/v1/sessions") == CAP_SESSION_READ);
       assert(server_http_route_caps("POST", "/v1/sessions/s1/attach") == CAP_SESSION_READ);

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -122,13 +122,16 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
    struct timespec ts0;
    clock_gettime(CLOCK_MONOTONIC, &ts0); /* monotonic: immune to NTP/clock jumps */
 
-   /* An item already parked 'stuck' cannot advance without human intervention
-    * (its stage is unresolvable / has no executor). Skip it so the backstop
-    * sweep doesn't re-attempt the doomed advance every cycle; a human resume
-    * clears the pause and lets the next sweep retry. */
+   /* An item parked 'stuck' cannot advance without human intervention (its stage
+    * is unresolvable / has no executor); an item parked 'operator_paused' was
+    * deliberately halted by an operator. Skip both so the backstop sweep doesn't
+    * re-attempt an advance every cycle; a human resume clears the pause and lets
+    * the next sweep retry. */
    {
       db1_work_item_t wi0;
-      if (db1_work_item_get(work_item_id, &wi0) == 1 && strcmp(wi0.pause_reason, "stuck") == 0)
+      if (db1_work_item_get(work_item_id, &wi0) == 1 &&
+          (strcmp(wi0.pause_reason, "stuck") == 0 ||
+           strcmp(wi0.pause_reason, "operator_paused") == 0))
          return 0;
    }
 

--- a/webchat/workflow.go
+++ b/webchat/workflow.go
@@ -128,8 +128,12 @@ func (s *server) handleWorkflowSave(w http.ResponseWriter, r *http.Request) {
 //	GET  /api/workflow/items/all          — all items (operator view)
 //	GET  /api/workflow/items/<id>         — one item's run-state (owner-only)
 //	GET  /api/workflow/items/<id>/events  — lifecycle timeline (owner-only, ?after&limit)
-//	GET  /api/workflow/items/<id>/proposal— source markdown (owner-only)
-//	POST /api/workflow/items/<id>/gate    — approve/reject a parked human gate
+//	GET    /api/workflow/items/<id>/proposal— source markdown (owner-only)
+//	POST   /api/workflow/items/<id>/gate    — approve/reject a parked human gate
+//	POST   /api/workflow/items/<id>/pause   — operator-pause an active run
+//	POST   /api/workflow/items/<id>/resume  — resume an operator-paused run
+//	POST   /api/workflow/items/<id>/stop    — abandon (stop) an active run
+//	DELETE /api/workflow/items/<id>         — auto-stop then purge the run
 func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 	// Exact list routes (no <id> segment).
 	if r.URL.Path == "/api/workflow/items" && r.Method == http.MethodGet {
@@ -171,6 +175,12 @@ func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 		s.webuserPass(w, r, http.MethodGet, path, nil)
 	case suffix == "/proposal" && r.Method == http.MethodGet:
 		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/"+id+"/proposal", nil)
+	// Lifecycle mutations (body-less). The /v1 handlers enforce owner-or-operator
+	// and the legal state transitions; we just forward under the webuser identity.
+	case (suffix == "/pause" || suffix == "/resume" || suffix == "/stop") && r.Method == http.MethodPost:
+		s.webuserPass(w, r, http.MethodPost, "/v1/workflow/items/"+id+suffix, nil)
+	case suffix == "" && r.Method == http.MethodDelete:
+		s.webuserPass(w, r, http.MethodDelete, "/v1/workflow/items/"+id, nil)
 	case suffix == "" && r.Method == http.MethodGet:
 		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/"+id, nil)
 	default:

--- a/webchat/workflow_test.go
+++ b/webchat/workflow_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The Workflow Actions lifecycle controls (Start/Pause/Stop/Delete) call
+// /api/workflow/items/<id>/{pause,resume,stop} (POST) and DELETE
+// /api/workflow/items/<id>. Regression: these once fell through the item proxy's
+// switch to the default "bad path" 400 because the switch predated the /v1
+// lifecycle routes. Each must reach its matching /v1 path under the webuser
+// identity, not be rejected.
+func TestWorkflowItemsLifecycleRouting(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  string
+		apiPath string
+		wantV1  string
+	}{
+		{"pause", http.MethodPost, "/api/workflow/items/wi123/pause", "/v1/workflow/items/wi123/pause"},
+		{"resume", http.MethodPost, "/api/workflow/items/wi123/resume", "/v1/workflow/items/wi123/resume"},
+		{"stop", http.MethodPost, "/api/workflow/items/wi123/stop", "/v1/workflow/items/wi123/stop"},
+		{"delete", http.MethodDelete, "/api/workflow/items/wi123", "/v1/workflow/items/wi123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath, gotWebuser string
+			var gotLen int64
+			mux := http.NewServeMux()
+			mux.HandleFunc(tc.wantV1, func(w http.ResponseWriter, r *http.Request) {
+				gotMethod, gotPath = r.Method, r.URL.Path
+				gotWebuser = r.Header.Get("X-Aimee-Webuser")
+				gotLen = r.ContentLength
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"status":"ok"}`))
+			})
+			cfg := startFakeV1(t, mux)
+			if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"),
+				[]byte("sekret-token\n"), 0600); err != nil {
+				t.Fatalf("write server.token: %v", err)
+			}
+			s := &server{cfg: cfg}
+
+			req := withUser(httptest.NewRequest(tc.method, tc.apiPath, nil), "alice")
+			rr := httptest.NewRecorder()
+			s.handleWorkflowItems(rr, req)
+
+			if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"status":"ok"`) {
+				t.Fatalf("%s: code=%d body=%q (regressed to bad path?)", tc.name, rr.Code, rr.Body.String())
+			}
+			if gotMethod != tc.method || gotPath != tc.wantV1 {
+				t.Fatalf("%s: proxied %s %s, want %s %s", tc.name, gotMethod, gotPath, tc.method, tc.wantV1)
+			}
+			if gotWebuser != "alice" {
+				t.Fatalf("%s: X-Aimee-Webuser = %q, want alice", tc.name, gotWebuser)
+			}
+			// Body-less mutations: nothing should be forwarded (v1RequestWebuser
+			// sends no body / no Content-Type when body==nil).
+			if gotLen > 0 {
+				t.Fatalf("%s: forwarded Content-Length=%d, want 0 (body-less)", tc.name, gotLen)
+			}
+		})
+	}
+}
+
+// Any (method, suffix) pair the item proxy doesn't map must be refused as
+// "bad path" rather than silently forwarded — including a wrong method on an
+// otherwise-known lifecycle suffix and a mutating method on the bare id path.
+// The fake /v1 backend has no handlers, so a forwarded request would surface as
+// a non-"bad path" response (proving nothing leaked through).
+func TestWorkflowItemsRejectsUnmapped(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  string
+		apiPath string
+	}{
+		{"post-unknown-suffix", http.MethodPost, "/api/workflow/items/wi123/bogus"},
+		{"delete-on-lifecycle-suffix", http.MethodDelete, "/api/workflow/items/wi123/pause"},
+		{"put-on-lifecycle-suffix", http.MethodPut, "/api/workflow/items/wi123/resume"},
+		{"get-on-lifecycle-suffix", http.MethodGet, "/api/workflow/items/wi123/stop"},
+		{"post-on-bare-id", http.MethodPost, "/api/workflow/items/wi123"},
+		{"put-on-bare-id", http.MethodPut, "/api/workflow/items/wi123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &server{cfg: startFakeV1(t, http.NewServeMux())}
+			req := withUser(httptest.NewRequest(tc.method, tc.apiPath, nil), "alice")
+			rr := httptest.NewRecorder()
+			s.handleWorkflowItems(rr, req)
+			if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "bad path") {
+				t.Fatalf("%s: code=%d body=%q, want 400 bad path", tc.name, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Two commits:

1. **`feat(webui)` (6f2b96f0)** — Workflow Actions lifecycle controls (Start/Pause/Stop/Delete), clickable Logs detail modal, and an in-project proposal picker. Adds `db1_work_item_delete`, `wf_api_item_{pause,resume,stop,delete}` + `/v1` routes, `wfe_autonomy` skip-when-`operator_paused`, and the read-only realpath-confined repo tree/file browser.

2. **`fix(webui)` (this branch)** — the lifecycle controls were dead on arrival: the frontend calls `POST /api/workflow/items/<id>/{pause,resume,stop}` and `DELETE /api/workflow/items/<id>`, and the C `/v1` routes exist, but the **webchat Go proxy** (`handleWorkflowItems`) predated those routes — its switch only mapped `/gate`, `/events`, `/proposal`, and bare-GET. Every lifecycle mutation fell through to `default:` → `{"error":"bad path"}` (HTTP 400). Operator-reported symptom: "bad path" on Stop/Delete (and Start).

## Fix

Add the missing switch cases. pause/resume/stop (body-less POST) and bare-id DELETE forward via `webuserPass` under the caller's webuser identity, mirroring the existing read forwarding. **Authorization unchanged** — the `/v1` handlers all run `wf_load_for_mutation` (owner-or-operator, fail-closed on empty submitter), same route cap (`CAP_DASHBOARD_READ`) as `/events`/`/proposal`.

## Tests

New `webchat/workflow_test.go`:
- `TestWorkflowItemsLifecycleRouting` — each of pause/resume/stop/delete reaches the correct `/v1` path with the `X-Aimee-Webuser` header and a body-less (Content-Length 0) forward.
- `TestWorkflowItemsRejectsUnmapped` — wrong method on a lifecycle suffix and a mutating method on the bare id path still return 400 "bad path".

Verified **red-before-green**: reverting the new cases reproduces exactly the reported `{"error":"bad path"}` 400. `go build`, `go vet`, and full `go test ./...` for webchat pass.

## Roundtable

Reviewed via aimee roundtable (7 panelists, 0 failed). No blocking correctness bugs — its two "correctness" flags (DELETE case-ordering, nil-body handling) were **rejected at verification** as contradicted. Surviving suggestions addressed: verified the C handler owner-or-operator enforcement out-of-diff, and strengthened the tests (body-less assertion + method-mismatch table).

## Deploy note

The C server already has the `/v1` routes; this fix is in the **webchat Go binary**, which must be rebuilt/redeployed for the controls to work live.