### PR TITLE
fix(webui): forward Workflow Actions lifecycle mutations through the webchat proxy

### DIFF
--- a/webchat/workflow.go
+++ b/webchat/workflow.go
@@ -128,8 +128,12 @@ func (s *server) handleWorkflowSave(w http.ResponseWriter, r *http.Request) {
 //	GET  /api/workflow/items/all          — all items (operator view)
 //	GET  /api/workflow/items/<id>         — one item's run-state (owner-only)
 //	GET  /api/workflow/items/<id>/events  — lifecycle timeline (owner-only, ?after&limit)
-//	GET  /api/workflow/items/<id>/proposal— source markdown (owner-only)
-//	POST /api/workflow/items/<id>/gate    — approve/reject a parked human gate
+//	GET    /api/workflow/items/<id>/proposal— source markdown (owner-only)
+//	POST   /api/workflow/items/<id>/gate    — approve/reject a parked human gate
+//	POST   /api/workflow/items/<id>/pause   — operator-pause an active run
+//	POST   /api/workflow/items/<id>/resume  — resume an operator-paused run
+//	POST   /api/workflow/items/<id>/stop    — abandon (stop) an active run
+//	DELETE /api/workflow/items/<id>         — auto-stop then purge the run
 func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 	// Exact list routes (no <id> segment).
 	if r.URL.Path == "/api/workflow/items" && r.Method == http.MethodGet {
@@ -171,6 +175,12 @@ func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 		s.webuserPass(w, r, http.MethodGet, path, nil)
 	case suffix == "/proposal" && r.Method == http.MethodGet:
 		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/"+id+"/proposal", nil)
+	// Lifecycle mutations (body-less). The /v1 handlers enforce owner-or-operator
+	// and the legal state transitions; we just forward under the webuser identity.
+	case (suffix == "/pause" || suffix == "/resume" || suffix == "/stop") && r.Method == http.MethodPost:
+		s.webuserPass(w, r, http.MethodPost, "/v1/workflow/items/"+id+suffix, nil)
+	case suffix == "" && r.Method == http.MethodDelete:
+		s.webuserPass(w, r, http.MethodDelete, "/v1/workflow/items/"+id, nil)
 	case suffix == "" && r.Method == http.MethodGet:
 		s.webuserPass(w, r, http.MethodGet, "/v1/workflow/items/"+id, nil)
 	default:

--- a/webchat/workflow_test.go
+++ b/webchat/workflow_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The Workflow Actions lifecycle controls (Start/Pause/Stop/Delete) call
+// /api/workflow/items/<id>/{pause,resume,stop} (POST) and DELETE
+// /api/workflow/items/<id>. Regression: these once fell through the item proxy's
+// switch to the default "bad path" 400 because the switch predated the /v1
+// lifecycle routes. Each must reach its matching /v1 path under the webuser
+// identity, not be rejected.
+func TestWorkflowItemsLifecycleRouting(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  string
+		apiPath string
+		wantV1  string
+	}{
+		{"pause", http.MethodPost, "/api/workflow/items/wi123/pause", "/v1/workflow/items/wi123/pause"},
+		{"resume", http.MethodPost, "/api/workflow/items/wi123/resume", "/v1/workflow/items/wi123/resume"},
+		{"stop", http.MethodPost, "/api/workflow/items/wi123/stop", "/v1/workflow/items/wi123/stop"},
+		{"delete", http.MethodDelete, "/api/workflow/items/wi123", "/v1/workflow/items/wi123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath, gotWebuser string
+			var gotLen int64
+			mux := http.NewServeMux()
+			mux.HandleFunc(tc.wantV1, func(w http.ResponseWriter, r *http.Request) {
+				gotMethod, gotPath = r.Method, r.URL.Path
+				gotWebuser = r.Header.Get("X-Aimee-Webuser")
+				gotLen = r.ContentLength
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"status":"ok"}`))
+			})
+			cfg := startFakeV1(t, mux)
+			if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"),
+				[]byte("sekret-token\n"), 0600); err != nil {
+				t.Fatalf("write server.token: %v", err)
+			}
+			s := &server{cfg: cfg}
+
+			req := withUser(httptest.NewRequest(tc.method, tc.apiPath, nil), "alice")
+			rr := httptest.NewRecorder()
+			s.handleWorkflowItems(rr, req)
+
+			if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"status":"ok"`) {
+				t.Fatalf("%s: code=%d body=%q (regressed to bad path?)", tc.name, rr.Code, rr.Body.String())
+			}
+			if gotMethod != tc.method || gotPath != tc.wantV1 {
+				t.Fatalf("%s: proxied %s %s, want %s %s", tc.name, gotMethod, gotPath, tc.method, tc.wantV1)
+			}
+			if gotWebuser != "alice" {
+				t.Fatalf("%s: X-Aimee-Webuser = %q, want alice", tc.name, gotWebuser)
+			}
+			// Body-less mutations: nothing should be forwarded (v1RequestWebuser
+			// sends no body / no Content-Type when body==nil).
+			if gotLen > 0 {
+				t.Fatalf("%s: forwarded Content-Length=%d, want 0 (body-less)", tc.name, gotLen)
+			}
+		})
+	}
+}
+
+// Any (method, suffix) pair the item proxy doesn't map must be refused as
+// "bad path" rather than silently forwarded — including a wrong method on an
+// otherwise-known lifecycle suffix and a mutating method on the bare id path.
+// The fake /v1 backend has no handlers, so a forwarded request would surface as
+// a non-"bad path" response (proving nothing leaked through).
+func TestWorkflowItemsRejectsUnmapped(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  string
+		apiPath string
+	}{
+		{"post-unknown-suffix", http.MethodPost, "/api/workflow/items/wi123/bogus"},
+		{"delete-on-lifecycle-suffix", http.MethodDelete, "/api/workflow/items/wi123/pause"},
+		{"put-on-lifecycle-suffix", http.MethodPut, "/api/workflow/items/wi123/resume"},
+		{"get-on-lifecycle-suffix", http.MethodGet, "/api/workflow/items/wi123/stop"},
+		{"post-on-bare-id", http.MethodPost, "/api/workflow/items/wi123"},
+		{"put-on-bare-id", http.MethodPut, "/api/workflow/items/wi123"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &server{cfg: startFakeV1(t, http.NewServeMux())}
+			req := withUser(httptest.NewRequest(tc.method, tc.apiPath, nil), "alice")
+			rr := httptest.NewRecorder()
+			s.handleWorkflowItems(rr, req)
+			if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "bad path") {
+				t.Fatalf("%s: code=%d body=%q, want 400 bad path", tc.name, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

The Workflow Actions lifecycle controls (Start/Pause/Stop/Delete) return `{"error":"bad path"}` (HTTP 400) on the Web GUI. Operator-reported: Stop and Delete fail; Start (resume) too.

The frontend calls `POST /api/workflow/items/<id>/{pause,resume,stop}` and `DELETE /api/workflow/items/<id>`, and the C `/v1/workflow/items/...` routes exist — but the **webchat Go proxy** `handleWorkflowItems` predated those routes. Its `switch` only mapped `/gate`, `/events`, `/proposal`, and bare-GET, so every lifecycle mutation fell through to `default:` → `{"error":"bad path"}`. The lifecycle feature shipped without ever wiring the proxy layer between the frontend and the C server.

## Fix

Add the missing switch cases in `webchat/workflow.go`. pause/resume/stop (body-less POST) and bare-id DELETE forward via `webuserPass` under the caller's webuser identity, mirroring the existing read forwarding.

**Authorization unchanged** — the `/v1` handlers all run `wf_load_for_mutation` (owner-or-operator, fail-closed on empty submitter), same route cap (`CAP_DASHBOARD_READ`) as `/events`/`/proposal`. Verified in `src/server/server_workflow_api.c`.

## Tests

New `webchat/workflow_test.go`:
- `TestWorkflowItemsLifecycleRouting` — pause/resume/stop/delete each reach the correct `/v1` path with the `X-Aimee-Webuser` header and a body-less (Content-Length 0) forward.
- `TestWorkflowItemsRejectsUnmapped` — wrong method on a lifecycle suffix, and a mutating method on the bare id path, still return 400 "bad path".

Verified **red-before-green**: reverting the new cases reproduces exactly the reported `{"error":"bad path"}` 400. `go build`, `go vet`, full `go test ./...` pass.

## Roundtable

Reviewed via aimee roundtable (7 panelists, 0 failed). No blocking correctness bugs — its two "correctness" flags (DELETE case-ordering, nil-body handling) were rejected at verification as contradicted. Surviving suggestions addressed: verified C handler owner-or-operator enforcement out-of-diff; strengthened tests (body-less assertion + method-mismatch table).

## Scope / deploy

webchat-only change; the C server already has the `/v1` routes on testing. The webchat binary must be rebuilt/redeployed for the controls to work live.