### PR TITLE
feat(memory): retire agent file-memory into aimee by default

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (138)
+## CLI-settable keys (139)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -128,6 +128,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `memory_kb_neighbour_expand` | bool | Expand recall to KB neighbours. |
 | `memory_maintenance_trigger_inserts` | int | Inserts before a maintenance cycle triggers. |
 | `memory_maintenance_trigger_secs` | int | Seconds before a maintenance cycle triggers. |
+| `memory_md_retire` | bool | Retire the agent file-memory surface into aimee (default on): a Write under ~/.claude/projects/<slug>/memory/<name>.md is intercepted into aimee's db1 and the .md is never materialized; session-start skips .md hydration. Set false for the legacy re-materialized .md mirrors. |
 | `memory_negation_enabled` | bool | Detect/handle negation in memory. |
 | `memory_profile_cards_enabled` | bool | Maintain profile cards from observations. |
 | `memory_profile_cards_min_obs` | int | Min observations before a profile card forms. |
@@ -233,7 +234,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 145 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 144 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -431,7 +432,7 @@ The binaries read 145 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_MEMORY_MD_RETIRE`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -106,6 +106,7 @@ CFG_KEY_DESC = {
     "cache_shaping_enabled": "Enable prompt cache-shaping.",
     "claude_cli_delegate_enabled": "Allow delegating to the local Claude CLI agent.",
     "delegate_graph_context_enabled": "Prepend a structural code-graph context block (callers/dependencies of files a delegate task references) to the delegate prompt (advisory, fail-open, default off).",
+    "memory_md_retire": "Retire the agent file-memory surface into aimee (default on): a Write under ~/.claude/projects/<slug>/memory/<name>.md is intercepted into aimee's db1 and the .md is never materialized; session-start skips .md hydration. Set false for the legacy re-materialized .md mirrors.",
     "claude_model": "Default Claude model (empty = CLI default).",
     "gateway_prevent_subagents": "Gateway strips subagent-spawning tools (Task/Agent/etc.) from proxied requests so the served model cannot spawn subagents. Default off.",
     "gateway_pin_model": "Gateway forces the proxied /v1/messages served model to the configured primary's model, overriding the client-requested model. Default off (the passthrough honors the client model); enable for single-model Anthropic-compatible shims.",

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -113,6 +113,39 @@ static cJSON *ss_retry_post(const char *endpoint, const char *bearer, const char
    return NULL;
 }
 
+/* memory_md_retire config flag, fetched from the server via config.get (the thin
+ * CLI does not link the config module). Defaults to 1 (retire on -> skip .md
+ * hydration) whenever the server is unreachable or the value is absent, so a
+ * fresh/offline session never re-materializes memory files. */
+static int session_start_md_retire(void)
+{
+   cJSON *req = cJSON_CreateObject();
+   if (!req)
+      return 1;
+   cJSON_AddStringToObject(req, "method", "config.get");
+   cJSON_AddStringToObject(req, "key", "memory_md_retire");
+   cJSON *resp = cli_v1_dispatch(req, 3000); /* remote-aware; NULL on any failure */
+   cJSON_Delete(req);                        /* caller owns req (see cli_v1_dispatch_local usage) */
+   if (!resp)
+   {
+      /* Not silent: a memory_md_retire=false (legacy) operator should see why
+       * hydration was skipped when the config is momentarily unreadable. */
+      fprintf(stderr, "aimee: memory_md_retire unknown (config.get unavailable); "
+                      "defaulting to retire-on, skipping .md hydration\n");
+      return 1;
+   }
+   int retire = 1;
+   cJSON *v = cJSON_GetObjectItemCaseSensitive(resp, "value");
+   if (cJSON_IsBool(v))
+      retire = cJSON_IsTrue(v);
+   else if (cJSON_IsNumber(v))
+      retire = (v->valuedouble != 0.0);
+   else if (cJSON_IsString(v) && v->valuestring)
+      retire = !(strcmp(v->valuestring, "false") == 0 || strcmp(v->valuestring, "0") == 0);
+   cJSON_Delete(resp);
+   return retire;
+}
+
 static int handle_session_start_remote(void)
 {
    char *endpoint = cli_v1_client_endpoint();
@@ -363,20 +396,24 @@ int handle_session_start(int json_output)
     * in the environment of the claude subprocess it forks. */
    int nonblocking = (getenv("AIMEE_SESSION_ID") != NULL);
 
+   const char *sock = cli_ensure_server_for_method("hooks.session_start");
+
    /* P4: surface this project's central memory into the local memory dir so a
     * fresh session/agent sees it (best-effort; never blocks session-start).
-    * Skipped under the .md retirement (AIMEE_MEMORY_MD_RETIRE): memory is not
-    * re-materialized as .md files — the agent uses aimee memory recall/search
-    * (the session brief steers it there) instead. */
+    * Skipped under the .md retirement (config memory_md_retire, default-on):
+    * memory is not re-materialized as .md files — the agent uses aimee memory
+    * recall/search (the session brief steers it there) instead. The thin CLI
+    * does not link the config module, so the flag is read from the server via
+    * config.get. This runs AFTER cli_ensure_server_for_method so a co-located
+    * server is up when queried (a legacy memory_md_retire=false operator gets a
+    * reliable answer instead of the unreachable-server fallback); the remote path
+    * reaches the configured remote endpoint. */
    {
-      const char *mr = getenv("AIMEE_MEMORY_MD_RETIRE");
-      int md_retire = mr && (mr[0] == '1' || mr[0] == 't' || mr[0] == 'T' || mr[0] == 'y');
       char hcwd[4096];
-      if (!md_retire && getcwd(hcwd, sizeof(hcwd)))
+      if (!session_start_md_retire() && getcwd(hcwd, sizeof(hcwd)))
          harness_memory_hydrate(hcwd);
    }
 
-   const char *sock = cli_ensure_server_for_method("hooks.session_start");
    if (!sock)
    {
       /* No co-located server. If a remote /v1 endpoint is configured, the thin

--- a/src/cmd_hooks.c
+++ b/src/cmd_hooks.c
@@ -401,7 +401,8 @@ void cmd_hooks(app_ctx_t *ctx, int argc, char **argv)
             if (cJSON_IsString(hpj) && hpj->valuestring && hpj->valuestring[0])
                hp = hpj->valuestring;
             char mr_msg[1024] = "";
-            int mr = memory_redirect_check(tool_name, ti, cwd, hp, mr_msg, sizeof(mr_msg));
+            int mr = memory_redirect_check(tool_name, ti, cwd, hp, cfg.memory_md_retire, mr_msg,
+                                           sizeof(mr_msg));
             cJSON_Delete(ti);
             if (mr == 2)
             {

--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -228,7 +228,7 @@ static char *build_session_context(const char *client_cwd)
     * agent to aimee memory commands rather than a native store. The generic
     * reminder is always on (operator directive). The stronger '.md files are
     * intercepted / not persisted' claim is only accurate under the retirement
-    * flag (AIMEE_MEMORY_MD_RETIRE), so it is gated on it. */
+    * flag (config memory_md_retire, default-on), so it is gated on it. */
    pos += (size_t)snprintf(
        buf + pos, cap - pos,
        "# Memory (use aimee, not your own store)\n"
@@ -237,8 +237,9 @@ static char *build_session_context(const char *client_cwd)
        "`aimee memory identity <key> <value>` and `aimee memory prefer <key> <value>`.\n"
        "- Retrieve prior context with `aimee memory search <terms>` or `aimee memory recall`.\n");
    {
-      const char *mr = getenv("AIMEE_MEMORY_MD_RETIRE");
-      if (mr && (mr[0] == '1' || mr[0] == 't' || mr[0] == 'T' || mr[0] == 'y'))
+      config_t mr_cfg;
+      config_load(&mr_cfg);
+      if (mr_cfg.memory_md_retire)
          pos +=
              (size_t)snprintf(buf + pos, cap - pos,
                               "- Memory `.md` files are RETIRED: a `.md` write UNDER YOUR MEMORY "

--- a/src/config.c
+++ b/src/config.c
@@ -790,6 +790,9 @@ static void config_set_defaults(config_t *cfg)
    cfg->audit_action_enabled = 1;    /* default-ON: the trajectory_export reader (S3)
                                         shipped, so the passive per-action audit row
                                         is on by default; set false to opt out */
+   cfg->memory_md_retire = 1;        /* default-ON: agent file-memory is retired into
+                                        aimee (no local .md mirrors); set false for
+                                        the legacy re-materialized .md behavior */
    snprintf(cfg->css_render_command, sizeof(cfg->css_render_command), "%s",
             CONFIG_DEFAULT_CSS_RENDER_COMMAND); /* default-on render backend (inert
                                                    until the sidecar is up); set empty
@@ -1115,6 +1118,10 @@ int config_load_file(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "audit_action_enabled");
    if (cJSON_IsBool(item))
       cfg->audit_action_enabled = cJSON_IsTrue(item);
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "memory_md_retire");
+   if (cJSON_IsBool(item))
+      cfg->memory_md_retire = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "css_render_command");
    if (cJSON_IsString(item) && item->valuestring)

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -84,6 +84,7 @@ const config_field_t config_fields[] = {
     {"wfe_live_forge_enabled", offsetof(config_t, wfe_live_forge_enabled), sizeof(int), 0,
      CFG_BOOL},
     {"audit_action_enabled", offsetof(config_t, audit_action_enabled), sizeof(int), 0, CFG_BOOL},
+    {"memory_md_retire", offsetof(config_t, memory_md_retire), sizeof(int), 0, CFG_BOOL},
     {"audit_worm_enabled", offsetof(config_t, audit_worm_enabled), sizeof(int), 0, CFG_BOOL},
     {"css_render_command", offsetof(config_t, css_render_command),
      sizeof(((config_t *)0)->css_render_command), 0, CFG_STRING},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -852,6 +852,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 1);
    if (!cfg->audit_action_enabled) /* default-on: persist only the opt-out (disable) */
       cJSON_AddBoolToObject(root, "audit_action_enabled", 0);
+   if (!cfg->memory_md_retire) /* default-on: persist only the opt-out (disable) */
+      cJSON_AddBoolToObject(root, "memory_md_retire", 0);
    /* default-on render backend: persist only a non-default value (a custom command
     * OR an empty string to disable) so both round-trip; the default isn't written. */
    if (strcmp(cfg->css_render_command, CONFIG_DEFAULT_CSS_RENDER_COMMAND) != 0)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -311,6 +311,15 @@ typedef struct config
     * passive, fail-open, and never changes an enforcement verdict. Set false to
     * opt out. */
    int audit_action_enabled;
+   /* memory_md_retire: retire the agent file-memory surface into aimee. When on,
+    * a Write under ~/.claude/projects/<slug>/memory/<name>.md is intercepted into
+    * aimee's db1 (kind='archive', non-recallable) and the .md is NEVER
+    * materialized; Edit/MultiEdit/MEMORY.md/Bash-writes to the memory dir are
+    * rejected with guidance; and session-start skips .md hydration. Retrieval is
+    * via `aimee memory search` (the session brief steers there). Fail-open (spill
+    * for reconcile) on a store outage. Default-ON: aimee is the single memory of
+    * record. Set false to keep the legacy re-materialized .md mirrors. */
+   int memory_md_retire;
    /* audit_worm_enabled: dual-write each governed-action audit row into the
     * per-service WORM store (append-only, hash-chained SQLite) alongside the
     * legacy audit.log. Default-OFF (S0 of the WORM audit-store proposal); the

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -261,7 +261,7 @@ int memory_redirect_bash_targets_memory(const char *client, const char *command,
 }
 
 int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, const char *project_hint,
-                          char *msg, size_t msg_len)
+                          int md_retire, char *msg, size_t msg_len)
 {
    if (!root)
       return 0;
@@ -327,14 +327,13 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, const 
       return 0; /* can't identify the project — fail open */
    }
 
-   /* .md retirement (default-off; AIMEE_MEMORY_MD_RETIRE): push the intercepted
-    * write into aimee's db1 memory as a private, non-recallable archive row and
-    * do NOT re-materialize the .md — the file never exists, content lives only
-    * in aimee. The agent retrieves via `aimee memory search` and is steered to
-    * `aimee memory` by the session brief. Fail-open (spill) on store outage. */
+   /* .md retirement (config flag memory_md_retire, default-on): push the
+    * intercepted write into aimee's db1 memory as a private, non-recallable
+    * archive row and do NOT re-materialize the .md — the file never exists,
+    * content lives only in aimee. The agent retrieves via `aimee memory search`
+    * and is steered to `aimee memory` by the session brief. Fail-open (spill) on
+    * store outage. */
    {
-      const char *mr = getenv("AIMEE_MEMORY_MD_RETIRE");
-      int md_retire = mr && (mr[0] == '1' || mr[0] == 't' || mr[0] == 'T' || mr[0] == 'y');
       if (md_retire)
       {
          /* Project-qualified: identically-named memories from different projects

--- a/src/memory_redirect.h
+++ b/src/memory_redirect.h
@@ -54,9 +54,14 @@ extern "C"
     * the caller (the thin client, where the real cwd / git repo / AIMEE_PROJECT_ID
     * live). This is REQUIRED for a remote server, whose filesystem has neither the
     * client's cwd nor its git repo; when NULL/empty the project is resolved from
-    * cwd as a local-server fallback. */
+    * cwd as a local-server fallback.
+    *
+    * md_retire: when non-zero, the intercepted memory write is stored into aimee's
+    * db1 archive and the .md is NOT re-materialized (the file never exists); when
+    * zero, the legacy behavior stores + re-materializes a local .md mirror. Sourced
+    * from the config flag memory_md_retire by the caller. */
    int memory_redirect_check(const char *tool, cJSON *root, const char *cwd,
-                             const char *project_hint, char *msg, size_t msg_len);
+                             const char *project_hint, int md_retire, char *msg, size_t msg_len);
 
    /* Re-materialize a memory file with aimee's own I/O (atomic temp+rename on
     * POSIX), confined under <home>/<projects_root>/ via realpath so a symlinked

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -829,14 +829,15 @@ static int server_memory_intercept(const char *tool, const char *tool_input, con
       return 0;
    }
 
-   /* .md retirement (AIMEE_MEMORY_MD_RETIRE, default-off): store the intercepted
+   /* .md retirement (config memory_md_retire, default-on): store the intercepted
     * write into db1 as a private, non-recallable archive row (kind='archive',
     * tier L1 — outside the recall selectors) and do NOT re-materialize the .md —
     * the file never exists; content lives only in aimee. The agent is steered to
     * `aimee memory` by the session brief. Server owns db1, so write directly. */
    {
-      const char *mr = getenv("AIMEE_MEMORY_MD_RETIRE");
-      if (mr && (mr[0] == '1' || mr[0] == 't' || mr[0] == 'T' || mr[0] == 'y'))
+      config_t mr_cfg;
+      config_load(&mr_cfg);
+      if (mr_cfg.memory_md_retire)
       {
          /* Project-qualified so identically-named memories from different
           * projects don't collide under this user's UNIQUE(kind,key). */


### PR DESCRIPTION
## What & why

Make **aimee the single memory of record at the aimee layer** — no ad-hoc harness hooks. This promotes the existing `.md`-retirement mode from an env-only gate (`AIMEE_MEMORY_MD_RETIRE`, default-off) to a first-class aimee config flag **`memory_md_retire`, default-ON**, config-only (env removed).

When on (now the default): an agent's file-memory Write under `~/.claude/projects/<slug>/memory/<name>.md` is intercepted into aimee's db1 (`kind='archive'`, non-recallable) and **the `.md` is never created**; Edit/MultiEdit/MEMORY.md/Bash-writes to the memory dir are rejected with guidance; and session-start **skips `.md` hydration**. Retrieval is via `aimee memory search` (the session brief steers there). **Fail-open** (spill for reconcile; the local write is allowed on a store outage) so memory is never lost.

Because prevention is at write-time, there's no `.md` to "detect and delete" — the file is never created. This replaces the need for harness-side ingest/delete hooks.

## Changes
- **config**: `memory_md_retire` flag (default 1) — parse + fields-table + save (persist opt-out only), mirroring `audit_action_enabled`.
- **memory_redirect.c/.h**: gate on a threaded `md_retire` arg instead of `getenv`; `cmd_hooks.c` passes `cfg.memory_md_retire` (already-loaded cfg → no extra cost).
- **server/server.c** + **cmd_session_lifecycle.c**: read `cfg.memory_md_retire` (server.c only on the memory-write branch).
- **cli_session_start.c**: the thin CLI doesn't link the config module, so it reads the flag from the server via `config.get` (`session_start_md_retire`), **run after the server is ensured** so a co-located server is up when queried; defaults to retire-on (with a non-silent stderr note) if unreachable.
- env gate `AIMEE_MEMORY_MD_RETIRE` removed (config-only; confirmed zero remaining references tree-wide).
- docs: `CFG_KEY_DESC` entry.

## Verification
- `aimee-server` / `aimee` / `aimee-kb` all build.
- **Live**: booted a local server — `aimee config get memory_md_retire` → `true` (default); `set false` → `get` → `false`, over the same `/v1/config/get` route the CLI hydrate-gate queries.

## Review
Single-persona security review (aimee delegate). One valid finding fixed: the config.get query originally ran *before* `cli_ensure_server_for_method`, so a legacy (`memory_md_retire=false`) thin-CLI user could silently skip hydration even in a healthy setup — moved the query+hydrate after the server is ensured, and made the fallback non-silent. Other findings triaged as refuted against the code: no double-free (`cli_v1_dispatch` is caller-owns, matching the existing `cli_v1_dispatch_local` usage), no data-loss (store-outage path fails open and allows the local write), and no surviving env reads.
