### PR TITLE
fix(memory): pass md_retire to the cli_main.c memory guard (build fix)

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -763,8 +763,8 @@ static int handle_hooks(int argc, char **argv, int json_output)
             cJSON *hpj = cJSON_GetObjectItemCaseSensitive(json, "harness_project");
             const char *hp = (cJSON_IsString(hpj) && hpj->valuestring[0]) ? hpj->valuestring : NULL;
             char mr_msg[1024] = "";
-            if (memory_redirect_check(tn->valuestring, tin, hook_cwd, hp, mr_msg, sizeof(mr_msg)) ==
-                2)
+            if (memory_redirect_check(tn->valuestring, tin, hook_cwd, hp, cli_memory_md_retire(),
+                                      mr_msg, sizeof(mr_msg)) == 2)
             {
                if (cli_hook_client_uses_pretool_json())
                   emit_pretool_deny_json(mr_msg);

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -116,8 +116,9 @@ static cJSON *ss_retry_post(const char *endpoint, const char *bearer, const char
 /* memory_md_retire config flag, fetched from the server via config.get (the thin
  * CLI does not link the config module). Defaults to 1 (retire on -> skip .md
  * hydration) whenever the server is unreachable or the value is absent, so a
- * fresh/offline session never re-materializes memory files. */
-static int session_start_md_retire(void)
+ * fresh/offline session never re-materializes memory files. Shared with the
+ * cli_main.c remote-only memory guard (declared in cli_session_start.h). */
+int cli_memory_md_retire(void)
 {
    cJSON *req = cJSON_CreateObject();
    if (!req)
@@ -410,7 +411,7 @@ int handle_session_start(int json_output)
     * reaches the configured remote endpoint. */
    {
       char hcwd[4096];
-      if (!session_start_md_retire() && getcwd(hcwd, sizeof(hcwd)))
+      if (!cli_memory_md_retire() && getcwd(hcwd, sizeof(hcwd)))
          harness_memory_hydrate(hcwd);
    }
 

--- a/src/headers/cli_session_start.h
+++ b/src/headers/cli_session_start.h
@@ -9,6 +9,13 @@
 char *read_stdin(void);
 int client_hook_payload_session_id(const cJSON *hook_json, char *out, size_t out_len);
 
+/* memory_md_retire config flag, fetched from the server via config.get (the thin
+ * CLI does not link the config module). Returns 1 (retire on) by default and
+ * whenever the server is unreachable, so a fresh/offline session never
+ * re-materializes memory files. Defined in cli_session_start.c; used by the
+ * session-start hydrate gate and the cli_main.c remote-only memory guard. */
+int cli_memory_md_retire(void);
+
 /* `aimee session-start` SessionStart-hook entry (cli_session_start.c). Reads the
  * host hook JSON from stdin and either forwards hooks.session_start to a
  * co-located server or, against a remote /v1 endpoint, emits proactive recall


### PR DESCRIPTION
Urgent build fix: `testing` currently does not compile.

#1110 (config-driven .md retirement) added an `md_retire` param to `memory_redirect_check`; #1085 (remote-only memory guard) concurrently added a second caller in `cli_main.c`. Both were individually green but collide when combined — `cli_main.c:766` still uses the old 6-arg signature (`too few arguments`), breaking the build.

Fix: share the thin-CLI md_retire helper (`session_start_md_retire` → `cli_memory_md_retire`, in `cli_session_start.h`) and pass it at the cli_main.c call site. The remote-only guard queries the remote endpoint it already uses, defaulting to retire-on if unreachable.

Verified: aimee / aimee-server / aimee-kb all build from the merged tree; all three call sites now pass the flag; clang-format clean.