### PR TITLE
feat(server): trust-on-first-use /v1 bearer enrollment (retire the aimee-local-dev standing credential)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -2238,6 +2238,11 @@ paths:
       summary: Enable the HTTP API
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Enabled, content: { application/json: { schema: { type: object } } } } }
+  /api/rotate_bearer:
+    post:
+      summary: Mint and hot-swap a fresh /v1 bearer (trust-on-first-use enrollment; retires the bootstrap token)
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: Rotated, content: { application/json: { schema: { type: object } } } } }
   /api/disable:
     post:
       summary: Disable the HTTP API

--- a/deploy/container/aimee-server.yaml
+++ b/deploy/container/aimee-server.yaml
@@ -12,8 +12,14 @@
 # the server auto-provisions a self-signed cert at $AIMEE_HOME/tls/server.{crt,key}
 # on first start. Mount your own cert there to override.
 #
-# This token is a development default — override it for any real deployment by
-# mounting your own aimee.yaml over /var/lib/aimee/aimee.yaml.
+# `bearer_token: aimee-local-dev` is a ONE-TIME BOOTSTRAP, not a standing
+# credential. The first thin client that connects (`aimee remote set <url>
+# aimee-local-dev`) automatically calls api.rotate_bearer, which mints a strong
+# random per-deployment bearer, hot-swaps it in, and persists it here — the
+# bootstrap token stops working the instant that happens. The exposure window is
+# only "deploy → first client enrolls". To skip the bootstrap entirely, pin your
+# own token out-of-band via the AIMEE_API_BEARER_TOKEN env (a secret store /
+# .gitignore'd per-host .env); an explicit env token disables the TOFU rotation.
 aimee:
   api:
     http_port: 8740

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -149,13 +149,24 @@ Useful flags:
 - `aimee server restart`: terminate the running server and spawn a fresh one.
 - `aimee server status` / `server health`: aliases for server health.
 - `aimee workspace add <path>`, `workspace list`, `workspace remove <path>`: manage indexed workspace roots.
-- `aimee remote set <url> [token]`, `remote status`, `remote clear`: point the thin
-  client at a remote `aimee-server` over TCP. `set` persists the target to
-  `<aimee_home>/remote.conf`; `status` shows the resolved transport plus a
-  `GET /v1/health` probe; `clear` reverts to the local Unix socket. Precedence:
-  `--server`/`--server-token=` flags > `AIMEE_SERVER_URL`/`AIMEE_SERVER_TOKEN`
-  env > persisted `remote.conf`. `https://` is supported on Linux/macOS (OpenSSL,
-  cert-verified; `AIMEE_TLS_INSECURE=1` to skip); Windows builds refuse it.
+- `aimee remote set <url> [token]`, `remote enroll`, `remote trust`, `remote status`,
+  `remote clear`: point the thin client at a remote `aimee-server` over TCP. `set`
+  persists the target to `<aimee_home>/remote.conf` and, for `https://`, pins the
+  server's self-signed cert (trust-on-first-use); `status` shows the resolved
+  transport plus a `GET /v1/health` probe; `trust` re-pins after a cert rotation;
+  `clear` reverts to the local Unix socket. Precedence: `--server`/`--server-token=`
+  flags > `AIMEE_SERVER_URL`/`AIMEE_SERVER_TOKEN` env > persisted `remote.conf`.
+  `https://` is supported on Linux/macOS (OpenSSL, cert-verified;
+  `AIMEE_TLS_INSECURE=1` to skip); Windows builds refuse it.
+  - **Bootstrap enrollment:** the aimee-server image seeds a well-known one-time
+    bearer `aimee-local-dev`. Connecting with it (`aimee remote set <url>
+    aimee-local-dev`) auto-runs enrollment: the server mints a strong random
+    per-deployment bearer (`api.rotate_bearer`), the client adopts it in
+    `remote.conf`, and the bootstrap token immediately stops working — so the
+    shared default is never a standing credential. `aimee remote enroll` forces a
+    fresh rotation on the configured remote at any time. To skip the bootstrap
+    entirely, set `AIMEE_API_BEARER_TOKEN` on the server (secret store) to pin your
+    own bearer; an explicit env token disables the auto-rotation.
 - `aimee worktree gc [--days N] [--force] [--dry-run]`: garbage-collect abandoned session worktrees.
 - `aimee work add`, `add-batch`, `claim`, `complete`, `fail`, `list`, `board`, `cancel`, `release`, `clear`, `gc`, `sync-proposals`, `stats`: manage the inter-session work queue.
 - `aimee jobs list [--limit N]`: list recent durable delegate jobs.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -234,7 +234,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 144 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 145 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -432,7 +432,7 @@ The binaries read 144 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -8,6 +8,7 @@
 #include "cli_remote.h"
 #include "aimee_client.h"
 #include "aimee_home.h"
+#include "cJSON.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -157,6 +158,60 @@ static int remote_pin_cert(const char *url, int json_output)
    return 0;
 }
 
+/* The well-known /v1 bearer baked into the aimee-server image. It is a ONE-TIME
+ * bootstrap: the first client to connect with it calls api.rotate_bearer to mint
+ * a strong per-deployment token, which the server then requires exclusively (the
+ * bootstrap stops working the instant it is rotated). See docs/COMMANDS.md. */
+#define AIMEE_BOOTSTRAP_BEARER "aimee-local-dev"
+
+/* Enrollment: over the already-pinned/verified remote (authenticated with the
+ * current — normally bootstrap — bearer), ask the server to rotate to a fresh
+ * strong bearer, persist it to remote.conf (replacing the old token), and adopt
+ * it for the rest of this process. Writes the new token into |out|. Returns 0 on
+ * success, -1 otherwise. Non-fatal to callers: on failure the prior token stays
+ * in place on disk and in effect. */
+static int remote_enroll(const char *url, char *out, size_t out_sz, int json_output)
+{
+   int st = 0;
+   char *body = aimee_client_request("POST", "/v1/api/rotate_bearer", "{}", &st);
+   if (!body || st != 200)
+   {
+      if (st == 401 && !json_output)
+         fprintf(stderr,
+                 "  enroll: the server rejected the bootstrap token (already enrolled by another "
+                 "client?).\n         Copy the strong bearer from the enrolled client into "
+                 "remote.conf, or re-seed the server.\n");
+      free(body);
+      return -1;
+   }
+   cJSON *root = cJSON_Parse(body);
+   free(body);
+   cJSON *tok = root ? cJSON_GetObjectItemCaseSensitive(root, "bearer_token") : NULL;
+   if (!cJSON_IsString(tok) || !tok->valuestring || !tok->valuestring[0])
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   snprintf(out, out_sz, "%s", tok->valuestring);
+   cJSON_Delete(root);
+
+   /* Persist url + the strong token, replacing the bootstrap token on disk, and
+    * adopt it for subsequent requests in this process. */
+   char path[512];
+   remote_conf_path(path, sizeof(path));
+   FILE *f = fopen(path, "w");
+   if (f)
+   {
+      fprintf(f, "%s\n%s\n", url, out);
+      fclose(f);
+   }
+   aimee_client_set_remote(url, out);
+   if (!json_output)
+      printf("  enrolled: rotated the one-time bootstrap token to a strong per-deployment "
+             "bearer\n            (the bootstrap token no longer works against this server).\n");
+   return 0;
+}
+
 static int remote_set(const char *url, const char *token, int json_output)
 {
    if (!url || !*url)
@@ -202,10 +257,22 @@ static int remote_set(const char *url, const char *token, int json_output)
       tls_insecure_restore(saved_insecure);
    }
 
+   /* Trust-on-first-use enrollment: if we connected with the well-known bootstrap
+    * bearer over a verified channel, immediately rotate to a strong per-deployment
+    * token so the shared default never remains a standing credential. Best-effort:
+    * a failure (older server without api.rotate_bearer, already enrolled) leaves the
+    * bootstrap token configured and is reported by remote_enroll. */
+   int enrolled = 0;
+   char strong_token[256] = "";
+   if (verified && token && strcmp(token, AIMEE_BOOTSTRAP_BEARER) == 0 &&
+       remote_enroll(url, strong_token, sizeof(strong_token), json_output) == 0)
+      enrolled = 1;
+
    if (json_output)
-      printf("{\"ok\":true,\"url\":\"%s\",\"token\":%s,\"pinned\":%s,\"verified\":%s}\n", url,
-             token && *token ? "true" : "false", pinned ? "true" : "false",
-             verified ? "true" : "false");
+      printf("{\"ok\":true,\"url\":\"%s\",\"token\":%s,\"pinned\":%s,\"verified\":%s,"
+             "\"enrolled\":%s}\n",
+             url, token && *token ? "true" : "false", pinned ? "true" : "false",
+             verified ? "true" : "false", enrolled ? "true" : "false");
    else
    {
       printf("Remote server set to %s%s\n", url, token && *token ? " (with token)" : "");
@@ -303,6 +370,31 @@ static int remote_status(int json_output)
    return reachable ? 0 : 1;
 }
 
+/* Force enrollment on the already-configured remote: rotate the server's /v1
+ * bearer to a fresh strong token and adopt it. Works whether the current token is
+ * the bootstrap default or an already-strong one (rotates regardless). */
+static int remote_enroll_cmd(int json_output)
+{
+   char url[512], token[256];
+   if (!read_remote_conf(url, sizeof(url), token, sizeof(token)) || !url[0])
+   {
+      fprintf(stderr, "aimee: no remote configured; run `aimee remote set <url> [token]` first\n");
+      return 2;
+   }
+   aimee_client_set_remote(url, token[0] ? token : NULL);
+   char strong[256] = "";
+   if (remote_enroll(url, strong, sizeof(strong), json_output) != 0)
+   {
+      if (!json_output)
+         fprintf(stderr, "aimee: enrollment failed (is the remote reachable and the current token "
+                         "valid?)\n");
+      return 1;
+   }
+   if (!json_output)
+      printf("Enrolled: this client now holds a strong per-deployment bearer.\n");
+   return 0;
+}
+
 int cli_remote_cmd(int argc, char **argv, int json_output)
 {
    const char *sub = argc > 0 ? argv[0] : "status";
@@ -312,8 +404,10 @@ int cli_remote_cmd(int argc, char **argv, int json_output)
       return remote_clear(json_output);
    if (strcmp(sub, "trust") == 0)
       return remote_trust(json_output);
+   if (strcmp(sub, "enroll") == 0)
+      return remote_enroll_cmd(json_output);
    if (strcmp(sub, "status") == 0)
       return remote_status(json_output);
-   fprintf(stderr, "usage: aimee remote <set <url> [token] | trust | status | clear>\n");
+   fprintf(stderr, "usage: aimee remote <set <url> [token] | enroll | trust | status | clear>\n");
    return 2;
 }

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -584,6 +584,7 @@ static const struct
     {"agent.stats", "GET", "/v1/agent/stats"},
     {"api.disable", "POST", "/v1/api/disable"},
     {"api.enable", "POST", "/v1/api/enable"},
+    {"api.rotate_bearer", "POST", "/v1/api/rotate_bearer"},
     {"api.status", "GET", "/v1/api/status"},
     {"attempt.list", "POST", "/v1/attempts/list"},
     {"attempt.record", "POST", "/v1/attempts/record"},

--- a/src/config_server_api.c
+++ b/src/config_server_api.c
@@ -92,4 +92,17 @@ void config_parse_server_api(config_t *cfg, const cJSON *root)
       else if (strcmp(rw_env, "off") == 0)
          cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_OFF;
    }
+
+   /* AIMEE_API_BEARER_TOKEN pins the /v1 bearer from the environment (deploy
+    * truth), overriding the config-file value even when it is absent / read-only
+    * / reseeded — e.g. a containerized server fed the token from a secret store.
+    * Providing an explicit token also opts OUT of trust-on-first-use enrollment:
+    * the operator is managing the bearer, so the client's bootstrap rotation is
+    * moot (the seeded `aimee-local-dev` bootstrap is never in effect). */
+   const char *bearer_env = getenv("AIMEE_API_BEARER_TOKEN");
+   if (bearer_env && bearer_env[0])
+   {
+      strncpy(cfg->server_api_bearer_token, bearer_env, sizeof(cfg->server_api_bearer_token) - 1);
+      cfg->server_api_bearer_token[sizeof(cfg->server_api_bearer_token) - 1] = '\0';
+   }
 }

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -133,6 +133,10 @@ extern "C"
    /* Stop the listener and close the socket. Safe if not started. */
    void server_http_stop(void);
 
+   /* Hot-swap the live TCP/TLS bearer without a restart. Call only from a /v1
+    * route handler (serialized on the listener thread). NULL/empty clears it. */
+   void server_http_set_bearer(const char *bearer);
+
    /* Default HTTP socket path: <config_default_dir>/aimee-http.sock. Returns a
     * pointer to a static buffer. */
    const char *server_http_default_path(void);

--- a/src/headers/server_internal.h
+++ b/src/headers/server_internal.h
@@ -5,6 +5,7 @@
 /* promoted cross-TU (former .inc statics) */
 int handle_api_disable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_api_enable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_api_rotate_bearer(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_api_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_eval_results(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_eval_run(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -287,9 +287,43 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
 {
    if (!cert_path || !cert_path[0] || !key_path || !key_path[0])
       return -1;
+
+   /* Desired SAN for this boot: CN (hostname) + AIMEE_TLS_EXTRA_SAN. Computed up
+    * front so it can be compared against what a previously-provisioned cert used. */
+   char cn[200];
+   if (gethostname(cn, sizeof(cn)) != 0 || !cn[0])
+      snprintf(cn, sizeof(cn), "aimee-server");
+   cn[sizeof(cn) - 1] = '\0';
+   char san[1024];
+   pki_build_server_san(cn, getenv("AIMEE_TLS_EXTRA_SAN"), san, sizeof(san));
+
+   char dir[MAX_PATH_LEN];
+   snprintf(dir, sizeof(dir), "%s/tls", config_default_dir());
+   char san_path[MAX_PATH_LEN];
+   snprintf(san_path, sizeof(san_path), "%s/server.san", dir);
+
    struct stat st;
    if (stat(cert_path, &st) == 0 && stat(key_path, &st) == 0)
-      return 0; /* operator- or previously-provisioned cert: never overwrite */
+   {
+      /* A cert already exists. Never touch an operator-mounted cert — identified
+       * by the ABSENCE of our server.san sidecar. For a cert WE provisioned
+       * (sidecar present), regenerate only when the desired SAN changed (e.g.
+       * AIMEE_TLS_EXTRA_SAN was set to add the LAN IP/hostname a thin client
+       * reaches us at) so pin+verify works without an operator manually deleting
+       * the cert. Unchanged SAN → keep it. */
+      FILE *sf = fopen(san_path, "r");
+      if (!sf)
+         return 0; /* operator / pre-sidecar cert: never overwrite */
+      char prev[1024] = "";
+      if (fgets(prev, sizeof(prev), sf))
+         prev[strcspn(prev, "\r\n")] = '\0';
+      fclose(sf);
+      if (strcmp(prev, san) == 0)
+         return 0; /* provisioned cert, SAN unchanged: keep it */
+      aimee_log(LOG_INFO, "pki", "server TLS SAN changed; regenerating self-signed cert (SAN=%s)",
+                san);
+      /* fall through: the O_TRUNC / "w" writes below overwrite the old cert+key */
+   }
 
    EVP_PKEY *key = gen_ec_key();
    if (!key)
@@ -302,12 +336,6 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
    }
    int rc = -1;
    char serial[64] = "";
-   char cn[200];
-   if (gethostname(cn, sizeof(cn)) != 0 || !cn[0])
-      snprintf(cn, sizeof(cn), "aimee-server");
-   cn[sizeof(cn) - 1] = '\0';
-   char san[1024];
-   pki_build_server_san(cn, getenv("AIMEE_TLS_EXTRA_SAN"), san, sizeof(san));
 
    X509_set_version(cert, 2);
    X509_NAME *name = X509_get_subject_name(cert);
@@ -330,8 +358,6 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
          free(cert_pem);
          goto done;
       }
-      char dir[MAX_PATH_LEN];
-      snprintf(dir, sizeof(dir), "%s/tls", config_default_dir());
       mkdir(dir, 0700);
       int ok = 0;
       int kfd = open(key_path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
@@ -361,6 +387,15 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
       if (ok)
       {
          rc = 0;
+         /* Record the SAN we baked in, marking this as a server-provisioned cert
+          * and enabling regeneration when AIMEE_TLS_EXTRA_SAN/hostname later change. */
+         FILE *snf = fopen(san_path, "w");
+         if (snf)
+         {
+            fputs(san, snf);
+            fputc('\n', snf);
+            fclose(snf);
+         }
          aimee_log(LOG_INFO, "pki", "generated self-signed server TLS cert (CN=%s) at %s", cn,
                    cert_path);
       }

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1308,6 +1308,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"server.health", handle_server_health},
     {"api.status", handle_api_status},
     {"api.enable", handle_api_enable},
+    {"api.rotate_bearer", handle_api_rotate_bearer},
     {"api.disable", handle_api_disable},
     {"insights.overview", handle_insights_overview},
     {"toolset.list", handle_toolset_list},

--- a/src/server/server_api_status.c
+++ b/src/server/server_api_status.c
@@ -107,6 +107,14 @@ static int handle_api_error(server_conn_t *conn, const char *message)
    return rc;
 }
 
+/* Mint a fresh 256-bit (64 hex-char) /v1 bearer into cfg->server_api_bearer_token.
+ * Returns 0 on success, -1 if the RNG failed. Shared by api.enable (mint-if-empty)
+ * and api.rotate_bearer (mint-unconditionally). */
+static int server_api_mint_bearer(config_t *cfg)
+{
+   return platform_random_hex(cfg->server_api_bearer_token, 64) == 0 ? 0 : -1;
+}
+
 /* api.enable: turn on the loopback /v1 listener. Picks a default port and rate
  * limit when unset, mints a bearer token if none is configured, persists the
  * aimee.api.* block, and returns a report that reveals the token once (the
@@ -135,7 +143,7 @@ int handle_api_enable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    int generated = 0;
    if (cfg.server_api_bearer_token[0] == '\0')
    {
-      if (platform_random_hex(cfg.server_api_bearer_token, 64) != 0)
+      if (server_api_mint_bearer(&cfg) != 0)
          return handle_api_error(conn, "failed to generate bearer token");
       generated = 1;
    }
@@ -172,6 +180,40 @@ int handle_api_enable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    cJSON_AddNumberToObject(resp, "rate_limit_per_min", cfg.server_api_rate_limit_per_min);
    cJSON_AddBoolToObject(resp, "vscode", with_vscode);
    cJSON_AddStringToObject(resp, "report", report);
+   int rc = server_send_response(conn, resp);
+   cJSON_Delete(resp);
+   return rc;
+}
+
+/* api.rotate_bearer: mint a FRESH /v1 bearer unconditionally (replacing any
+ * existing one — e.g. the image-seeded `aimee-local-dev` bootstrap), persist it,
+ * and HOT-SWAP the live listener so the new token authorizes immediately and the
+ * old one stops working at once — no restart, no dual-validity window. This is
+ * the server side of trust-on-first-use enrollment: a thin client connects once
+ * with the bootstrap bearer and calls this to obtain its strong per-deployment
+ * token, which it then uses exclusively. CAP_SESSION_ADMIN-gated (same as
+ * api.enable); reveals the new token once to the authorized caller. */
+int handle_api_rotate_bearer(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   (void)req;
+
+   config_t cfg;
+   config_load(&cfg);
+   if (server_api_mint_bearer(&cfg) != 0)
+      return handle_api_error(conn, "failed to generate bearer token");
+   if (config_save(&cfg) != 0)
+      return handle_api_error(conn, "failed to persist aimee.api config");
+
+   /* Hot-swap the running listener's bearer. This handler runs on the single
+    * listener thread that also reads the bearer for authorization, so the swap
+    * is serialized against auth checks and needs no lock. After this returns the
+    * bootstrap token no longer authorizes anything. */
+   server_http_set_bearer(cfg.server_api_bearer_token);
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "bearer_token", cfg.server_api_bearer_token);
    int rc = server_send_response(conn, resp);
    cJSON_Delete(resp);
    return rc;

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -21,6 +21,7 @@ const method_policy_t method_registry[] = {
     {"server.health", 0, "server health check"},
     {"api.status", CAP_SESSION_READ, "public /v1 API status"},
     {"api.enable", CAP_SESSION_ADMIN, "enable public /v1 API listener"},
+    {"api.rotate_bearer", CAP_SESSION_ADMIN, "rotate the public /v1 API bearer"},
     {"api.disable", CAP_SESSION_ADMIN, "disable public /v1 API listener"},
     {"init.run", CAP_TOOL_EXECUTE, "initialize local stores"},
     {"launch.run", CAP_TOOL_EXECUTE, "launch session"},

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -999,6 +999,17 @@ const char *server_http_default_path(void)
    return path;
 }
 
+/* Hot-swap the live TCP/TLS bearer without a restart. Callable only from a /v1
+ * route handler (e.g. api.rotate_bearer), which runs on the single listener
+ * thread that also reads g_bearer for authorization — so the write is serialized
+ * against auth reads and needs no lock. NULL/empty clears the bearer. */
+void server_http_set_bearer(const char *bearer)
+{
+   g_bearer[0] = '\0';
+   if (bearer && bearer[0])
+      snprintf(g_bearer, sizeof(g_bearer), "%s", bearer);
+}
+
 /* Write the whole buffer. Returns the bytes written, or -1 on a write error
  * (used by the live SSE path to detect a client disconnect). Existing callers
  * ignore the return value. */

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -45,7 +45,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdatomic.h>
-
 /* Route-handler deps used below but not needed by server_http.c's own body
  * (kept here, not in server_http.c, to respect its 2000-line limit). */
 #include "git_forge_vault.h"  /* GIT_FORGE_VAULT_AGENT/SSHKEY_CRED — per-webuser ssh-key vault */
@@ -2096,6 +2095,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/model/refresh", NULL, RM_EXACT, "model.refresh", 0, rh_dispatch_op},
     {"GET", "/v1/api/status", NULL, RM_EXACT, "api.status", 0, rh_dispatch_op},
     {"POST", "/v1/api/enable", NULL, RM_EXACT, "api.enable", 0, rh_dispatch_op},
+    {"POST", "/v1/api/rotate_bearer", NULL, RM_EXACT, "api.rotate_bearer", 0, rh_dispatch_op},
     {"POST", "/v1/api/disable", NULL, RM_EXACT, "api.disable", 0, rh_dispatch_op},
     /* dashboard/insights/identity/dogfood/lsp op-parity wave 4; read views are GET. */
     {"GET", "/v1/dashboard/all", NULL, RM_EXACT, "dashboard.all", 0, rh_dispatch_op},

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1847,7 +1847,8 @@ $(TESTPREFIX)/unit-test-aimee-client: $(OBJDIR)/tests/test_aimee_client.o $(OBJD
 
 $(TESTPREFIX)/unit-test-cli-remote: $(OBJDIR)/tests/test_cli_remote.o $(OBJDIR)/cli_remote.o \
                                     $(OBJDIR)/aimee_client.o $(OBJDIR)/posix/platform_net.o \
-                                    $(OBJDIR)/http_uds_client.o $(OBJDIR)/aimee_home.o $(TLS_OBJS)
+                                    $(OBJDIR)/http_uds_client.o $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o \
+                                    $(TLS_OBJS)
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL) $(TLS_LIBS)
 
 $(TESTPREFIX)/unit-test-util-url: $(OBJDIR)/tests/test_util_url.o $(OBJDIR)/util_url.o

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -2022,6 +2022,32 @@ int main(void)
       cJSON_Delete(root);
    }
 
+   /* AIMEE_API_BEARER_TOKEN env override (config_server_api.c): a deploy-supplied
+    * bearer wins over the config-file value and opts out of TOFU enrollment. */
+   {
+      extern void config_parse_server_api(config_t * cfg, const cJSON *root);
+      config_t c;
+      memset(&c, 0, sizeof c);
+      cJSON *root = cJSON_CreateObject(); /* no "api" block: env is the only source */
+
+      platform_setenv("AIMEE_API_BEARER_TOKEN", "env-strong-abc123");
+      config_parse_server_api(&c, root);
+      assert(strcmp(c.server_api_bearer_token, "env-strong-abc123") == 0);
+
+      /* Env overrides a pre-existing (e.g. seeded bootstrap) value too. */
+      snprintf(c.server_api_bearer_token, sizeof c.server_api_bearer_token, "aimee-local-dev");
+      config_parse_server_api(&c, root);
+      assert(strcmp(c.server_api_bearer_token, "env-strong-abc123") == 0);
+
+      /* Without the env, the existing value is left untouched. */
+      platform_unsetenv("AIMEE_API_BEARER_TOKEN");
+      snprintf(c.server_api_bearer_token, sizeof c.server_api_bearer_token, "file-value");
+      config_parse_server_api(&c, root);
+      assert(strcmp(c.server_api_bearer_token, "file-value") == 0);
+
+      cJSON_Delete(root);
+   }
+
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Problem
Every containerized `aimee-server` seeds a **well-known /v1 bearer `aimee-local-dev`** while the TLS listener binds `0.0.0.0` with `remote_writes: full`. So any network-published deployment is fully controllable (delegates/tools/roundtables) by anyone on the network who knows that default — a footgun every end user hits, not a misconfiguration. (Surfaced while deploying the split stack to `.254`.)

## Approach — trust-on-first-use enrollment
`aimee-local-dev` becomes a **one-time bootstrap**. The first client that connects mints a strong per-deployment bearer and the bootstrap immediately stops working. Built on the existing `handle_api_enable` mint/persist path and `remote.conf` machinery — no new token scheme.

- **Server** — `POST /v1/api/rotate_bearer` (`CAP_SESSION_ADMIN`): mints a 256-bit bearer, `config_save`-persists it, and **hot-swaps** the live listener (`server_http_set_bearer`) so the new token authorizes immediately and the bootstrap dies at once (no restart, no dual-validity window).
- **Client** — `aimee remote set <url> aimee-local-dev` auto-enrolls: pins the cert, rotates, adopts the strong token in `remote.conf`. `aimee remote enroll` forces re-rotation.
- **Env override** — `AIMEE_API_BEARER_TOKEN` pins an operator bearer (survives reseed/read-only config) and opts out of TOFU, for secret-store deploys.
- **Cert SAN footgun fix** — `pki_ensure_self_signed_server_cert` now regenerates the *server-provisioned* cert when `AIMEE_TLS_EXTRA_SAN`/hostname change (recorded in a `tls/server.san` sidecar), so adding the LAN-reachable SAN no longer needs a manual cert delete. Never touches an operator-mounted cert.

## Verification
- Clean `-Werror` builds (client + server + kb); clang-format clean.
- Conformance: `dispatch-caps-check`, `server-api-conformance-check`, `cli-v1-routes-check`, `v1-method-coverage-check`, `api-conformance-check` all green.
- Unit test: `AIMEE_API_BEARER_TOKEN` env override (test_config.c).
- End-to-end (local):
  - rotate → bootstrap **401**, new 64-hex token **200**, persisted to aimee.yaml.
  - `aimee remote set … aimee-local-dev` → `remote.conf` line 2 becomes a strong token, status 200, bootstrap 401.
  - `AIMEE_TLS_EXTRA_SAN` change → cert auto-regenerated (SAN + sidecar updated), unchanged SAN → cert kept.

## Follow-ups (separate SmoothNAS repo)
- tierd: auto-create `x-smoothnas` tiered-volume bind-source dirs (LXC abort we hit on aimee-kb).
- aimee-server plugin manifest: auto-fill `AIMEE_TLS_EXTRA_SAN` with the host's reachable IP; surface the enrolled bearer in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)