### PR TITLE
feat(webchat): seal GUI-added delegate keys into the shared server vault

### DIFF
--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -632,30 +632,34 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
       else
       {
-         /* Where the client-supplied key lands depends on the attested transport:
-          *  - a per-user principal (UDS uid: / webchat webuser:) -> the caller's own
-          *    vault (dual-access; requires the vault unlocked);
-          *  - a connection with no per-user identity -> the server-owned vault, so
-          *    the key works for ALL connections automatically (native-TLS
-          *    provisioning). Whether that is permitted is decided by the SAME gate
-          *    handle_vault_set_server uses (vault_capability_server_write_allowed),
-          *    so "who may mint a server credential" lives in exactly one place:
-          *    native-TLS+bearer is allowed; a plaintext TCP bearer is REFUSED (D2b)
-          *    — it must not silently mint a server credential over an unencrypted
-          *    channel — as is any un-attested conn (e.g. UDS uid 0).
-          * On any failure we REFUSE rather than write the secret to agents.json. */
+         /* Where the client-supplied key lands depends on whether the conn may mint
+          * a SHARED server credential (vault_capability_server_write_allowed — the
+          * single gate handle_vault_set_server also uses):
+          *  - authorized to server-write (native-TLS+bearer, OR a capability-granted
+          *    principal: an attested webchat webuser:/UDS uid: holding
+          *    vault:write:server) -> the server-owned vault, so the key works for
+          *    ALL connections/delegate turns automatically. This is how an attested
+          *    webchat user provisions a delegate key over the HTTPS GUI without the
+          *    /v1 bearer ever entering webchat — the grant is the audited, revocable
+          *    authority.
+          *  - any other per-user principal (UDS uid: / webchat webuser: WITHOUT the
+          *    grant) -> the caller's own dual-access vault (requires it unlocked).
+          *  - no principal and not server-write-authorized (plaintext TCP, or an
+          *    un-attested conn e.g. UDS uid 0) -> REFUSED (D2b); never write the
+          *    secret to agents.json. */
          const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
          attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
-         if (!principal && !vault_capability_server_write_allowed(transport, NULL))
+         int server_write = vault_capability_server_write_allowed(transport, principal);
+         if (!server_write && !principal)
             return server_send_error(
                 conn,
                 "vault: `agent add --key` over a plaintext connection cannot store a credential; "
                 "use a native-TLS (https) connection, or an attested local/webchat connection",
                 NULL);
-         vault_status_t vst =
-             principal
-                 ? vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key, (long)time(NULL))
-                 : vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
+         vault_status_t vst = server_write
+                                  ? vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key)
+                                  : vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key,
+                                                      (long)time(NULL));
          if (vst != VAULT_OK)
          {
             if (vst == VAULT_ERR_LOCKED)
@@ -663,10 +667,10 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                    conn, "vault locked: run `aimee vault unlock` before adding a key", NULL);
             return server_send_error(conn, "could not store credential in the vault", NULL);
          }
-         /* A server-principal write (no per-user principal) is a credential-minting
-          * event: audit it identically to handle_vault_set_server so it is never
-          * silent. A per-user dual-access write is the caller's own vault. */
-         if (!principal)
+         /* A server-vault write (shared credential) is a minting event: audit it
+          * identically to handle_vault_set_server so it is never silent. A per-user
+          * dual-access write is the caller's own vault. */
+         if (server_write)
             vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
          ag->api_key[0] = '\0';      /* the secret lives only in the vault */
          ag->api_key_disk[0] = '\0'; /* and nothing goes to agents.json */
@@ -1099,22 +1103,25 @@ int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       {
          const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
          attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
-         if (!principal && !vault_capability_server_write_allowed(transport, NULL))
+         int server_write = vault_capability_server_write_allowed(transport, principal);
+         if (!server_write && !principal)
             return server_send_error(
                 conn,
                 "vault: `agent set --key` over a plaintext connection cannot store a credential; "
                 "use a native-TLS (https) or attested local/webchat connection",
                 NULL);
-         vault_status_t vst =
-             principal
-                 ? vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key, (long)time(NULL))
-                 : vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
+         vault_status_t vst = server_write
+                                  ? vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key)
+                                  : vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key,
+                                                      (long)time(NULL));
          if (vst != VAULT_OK)
             return server_send_error(conn,
                                      vst == VAULT_ERR_LOCKED
                                          ? "vault locked: run `aimee vault unlock` before re-keying"
                                          : "could not store credential in the vault",
                                      NULL);
+         if (server_write)
+            vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
       }
    }
 

--- a/webchat/agent_add_test.go
+++ b/webchat/agent_add_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestArgsHaveLiteralKey(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"no key", []string{"d", "https://h/v1", "gpt-5", "--provider", "openai"}, false},
+		{"literal key spaced", []string{"d", "-", "m", "--key", "sk-abc123"}, true},
+		{"literal key equals", []string{"d", "-", "m", "--key=sk-abc123"}, true},
+		{"env ref spaced", []string{"d", "-", "m", "--key", "$OPENAI_KEY"}, false},
+		{"env ref equals", []string{"d", "-", "m", "--key=$OPENAI_KEY"}, false},
+		{"empty key value", []string{"d", "-", "m", "--key", ""}, false},
+		{"key flag last no value", []string{"d", "-", "m", "--key"}, false},
+		{"whitespace-only value", []string{"d", "-", "m", "--key", "   "}, false},
+		{"nil args", nil, false},
+	}
+	for _, c := range cases {
+		if got := argsHaveLiteralKey(c.args); got != c.want {
+			t.Errorf("%s: argsHaveLiteralKey(%v) = %v, want %v", c.name, c.args, got, c.want)
+		}
+	}
+}

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 type workflowSessionInfo struct {
@@ -214,6 +215,93 @@ func (s *server) agentOpHandler(method string) http.HandlerFunc {
 		// resp is map[string]json.RawMessage; the values marshal back verbatim.
 		_ = json.NewEncoder(w).Encode(resp)
 	}
+}
+
+// argsHaveLiteralKey reports whether a CLI-style `agent add` argv carries a
+// LITERAL --key secret (as opposed to a "$ENV" reference, which is not a secret).
+// Only a literal key must be sealed into the vault, so only then is the attested
+// forwarding path required. Handles both "--key VAL" and "--key=VAL".
+func argsHaveLiteralKey(args []string) bool {
+	for i, a := range args {
+		var val string
+		switch {
+		case a == "--key":
+			if i+1 < len(args) {
+				val = args[i+1]
+			}
+		case strings.HasPrefix(a, "--key="):
+			val = strings.TrimPrefix(a, "--key=")
+		default:
+			continue
+		}
+		if v := strings.TrimSpace(val); v != "" && !strings.HasPrefix(v, "$") {
+			return true
+		}
+	}
+	return false
+}
+
+// handleAgentAdd proxies POST /api/agents/add. It mirrors agentOpHandler's
+// {"args":[...]} body, but when the argv carries a LITERAL --key the secret must
+// be sealed server-side. A plain UDS hop authenticates only as the (root) webchat
+// process — an empty, un-writable vault principal — so the seal is refused. That
+// one case is forwarded over the attested webuser channel (v1RequestWebuser:
+// server.token + X-Aimee-Webuser) so aimee-server classifies the caller as
+// webuser:<user>; when that principal holds the vault:write:server capability the
+// key lands in the SHARED server vault. The /v1 bearer never enters webchat. A
+// keyless add / $VAR reference needs no attested identity and takes the plain path.
+func (s *server) handleAgentAdd(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Args []string `json:"args"`
+	}
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+	}
+	w.Header().Set("Content-Type", "application/json")
+
+	req := map[string]any{"method": "agent.add"}
+	if body.Args != nil {
+		req["args"] = body.Args
+	}
+
+	if !argsHaveLiteralKey(body.Args) {
+		resp, err := s.socketCallForRequest(r, req)
+		if err != nil {
+			writeJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	payload, err := json.Marshal(req)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "encode request")
+		return
+	}
+	st, data, err := s.v1RequestWebuser(r.Context(), currentUser(r), http.MethodPost, "/v1/agent/add", payload)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	var msg map[string]json.RawMessage
+	if len(data) > 0 {
+		if uerr := json.Unmarshal(data, &msg); uerr != nil {
+			writeJSONError(w, http.StatusBadGateway, "decode agent.add response")
+			return
+		}
+	}
+	// Surface the server's dispatch error (e.g. the vault refusal) to the UI as
+	// {"error": ...}; the Agents page reads res.error.
+	if rerr := rpcError(msg); rerr != nil {
+		writeJSONError(w, http.StatusBadGateway, rerr.Error())
+		return
+	}
+	if st != http.StatusOK {
+		writeJSONError(w, http.StatusBadGateway, fmt.Sprintf("agent add: status %d", st))
+		return
+	}
+	_ = json.NewEncoder(w).Encode(msg)
 }
 
 // handleAudit proxies GET /api/audit -> the PAGINATED dashboard.audit route,

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -219,7 +219,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	// Live endpoints backed by aimee-server socket
 	mux.HandleFunc("/api/agents", s.requireAuth(s.handleAgents))
 	mux.HandleFunc("GET /api/agents/stats", s.requireAuth(s.handleAgentStats))
-	mux.HandleFunc("POST /api/agents/add", s.requireAuth(s.agentOpHandler("agent.add")))
+	mux.HandleFunc("POST /api/agents/add", s.requireAuth(s.handleAgentAdd))
 	mux.HandleFunc("POST /api/agents/remove", s.requireAuth(s.agentOpHandler("agent.remove")))
 	mux.HandleFunc("POST /api/agents/enable", s.requireAuth(s.agentOpHandler("agent.enable")))
 	mux.HandleFunc("POST /api/agents/disable", s.requireAuth(s.agentOpHandler("agent.disable")))


### PR DESCRIPTION
## Problem

The Agents **"+ add delegate"** form already submits `--key`, but sealing the key was refused with:

> vault: `agent add --key` over a plaintext connection cannot store a credential…

That message is a catch-all. The real cause: **`aimee-webchat` runs as root**, so its UDS hop to `aimee-server` resolves (fail-closed, `vault_principal.c`) to an **empty, un-writable vault principal** — not the plaintext TCP the message implies. So keys could not be added over the web GUI at all.

## Fix (attested `webuser:` + capability grant — the `/v1` bearer never enters webchat)

- **webchat** (`api.go`, `server.go`): `handleAgentAdd` forwards a **literal-key** `agent.add` over the existing attested webuser channel (`v1RequestWebuser` = `server.token` + `X-Aimee-Webuser`), so the server classifies the caller as `webuser:<user>`. Keyless adds and `$VAR` references keep the plain UDS path. New `argsHaveLiteralKey` helper + unit test.
- **server** (`server_agent.c`): `agent add`/`agent set` seal the key into the **shared server vault** when the connection is authorized to server-write — native-TLS bearer **or** a **capability-granted** `webuser:`/`uid:` holding `vault:write:server` — else the caller's per-user vault, exactly as before. Server-vault writes are audited.

Considered and rejected: forwarding over `:8743` with `server_api_bearer_token` — that would embed the root-equivalent `/v1` bearer in webchat and let any web user mint server creds. This path keeps that bearer out of webchat; authority is the revocable, per-principal grant.

## Safety / blast radius

The `vault:write:server` grant list is **empty by default**, so every existing path — native-TLS provisioning, per-user vaults, and the plaintext refusal — behaves **unchanged**. Only an explicitly-granted principal gains the new shared-vault write.

## Verification

- `go build ./...` ✓, `go test` (incl. new `TestArgsHaveLiteralKey`) ✓
- `server_agent.c` syntax-checked with project CFLAGS ✓
- Frontend unchanged (the form already sends `--key`)

## Deploy step (operational, not code)

After rollout, grant the intended web user(s): add `webuser:<user>` to `<config>/.vault/server-write-grants` (0600, owned by the server user). Without a grant, a GUI key-add lands in that user's per-user vault (needs unlock); with it, it mints the shared server credential.
