### PR TITLE
docs(readme): document economizer, governance/audit, browser workspace, teams, PDF evidence, roundtable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ back instead of raw content, so you save twice, on the delegate and on the prima
 context. aimee also compresses what each turn sends upstream, so even your main model's bill
 drops. It tracks cost and success per delegate and routes better over time.
 
+**Tokens cut on both ends.** A context economizer works in two tiers. The safe tier
+runs by default: it deterministically condenses tool output (keeps the failing test,
+elides the passing ones; keeps compiler errors, drops progress spam), compresses oversized
+results, and folds stale turn history into a rolling skeleton, with the full output spilled
+to disk for recovery. The aggressive tier is opt in: it applies the same reduction to the
+live primary request so your main model's own bill drops too, compress only, behind a per
+session circuit breaker that never dispatches anything it cannot restore. See
+[Settings](docs/SETTINGS.md).
+
+**A tamper evident record of every action.** Each governed tool call runs through one choke
+point that decides allow, rewrite, or block, and writes that verdict to an append only,
+mode-0600, rotated audit ledger: who acted, which tool, the mode, a stable reason code, and
+a keyed HMAC digest of the arguments, keyed so a low entropy argument cannot be recovered
+from the log and allowlisted so a new tool can never leak a secret into it. Human sign off
+gates are HMAC-SHA256 signed and non forgeable. Decision records capture what you decided,
+why, what it supersedes, and when to revisit it, one active per scope. See
+[Security Model](docs/SECURITY.md) and [KB Console](docs/KB_CONSOLE.md).
+
 **Run the models yourself.** aimee ships a self hosted inference stack: embeddings,
 reranking, and synthesis baked into one CPU or GPU container. The knowledge base curates entirely
 on your hardware with no outside API calls, and the same local model doubles as a free
@@ -58,6 +76,24 @@ reviews the work, and the delegates do the building. See
 configs are blocked before the AI can touch them. Known anti patterns raise warnings.
 Planning mode freezes every write until you are ready. Each session runs in its own git
 worktree, so two sessions never step on each other.
+
+**A browser workspace, not just a backend.** aimee ships its own browser UI, `aimee-webchat`:
+chat, a live view of your code as a graph, a git project manager that clones repos and holds
+per host tokens, a full in app VS Code editor, and dashboards over what the server is doing.
+No terminal required. See [Dashboard & Logs](docs/DASHBOARD.md).
+
+**Ready for a team.** Multi user accounts with scoped tokens, OIDC single sign on, optional
+mutual TLS client identity, and a per principal encrypted credential vault so one user's git
+token or provider key is never readable by another. See [Security Model](docs/SECURITY.md).
+
+**Documents become evidence.** Ingest a PDF and every retrieved snippet carries the page and
+bounding box it came from, so an answer traces back to the exact spot on the page. Table
+cells, figure crops, and OCR of scanned pages layer on top. See
+[Structured PDF](docs/STRUCTURED_PDF.md).
+
+**A roundtable of models.** Fan a task out to a panel and synthesize one answer, or run a
+bounded multi round draft-or-review where several models critique and converge. The same
+mechanism staffs the reviews in autonomous development. See [Personas](docs/personas.md).
 
 ## The problem
 
@@ -116,11 +152,70 @@ graph instead of reading the files over again. The graph is cross repo: one depe
 repository you work across, so a change in a shared library shows its blast radius in the
 services that consume it. See [Code intelligence](docs/CODE_INTELLIGENCE.md).
 
+### Documents as coordinate anchored evidence
+
+aimee-kb can ingest a PDF as coordinate anchored evidence instead of a flat blob of text.
+Every retrieved snippet carries the page number and bounding box it came from, so an answer
+is traceable to the exact place on the page rather than to an unlocatable paraphrase. On top
+of that spine the KB optionally recognises table cells (structured `{row, col, text}`
+lookups), renders visual crops of figures, tables, and pages into a content addressed store,
+and OCRs scanned or image only pages back through the same citation path. Each layer is its
+own opt in and degrades cleanly to the one below when its dependency is absent, and every
+read surface honours the same document level access control as the text spine. See
+[Structured PDF](docs/STRUCTURED_PDF.md).
+
 ### Guardrails
 
 Before every edit, aimee classifies the target. Sensitive files like `.env`, credentials,
 and private keys are blocked before the AI touches them. Known anti patterns trigger
 warnings. Planning mode locks all writes until you are ready.
+
+### Governance and a tamper evident action ledger
+
+Every governed tool call passes through one choke point (`pre_tool_check`) that computes an
+allow, rewrite, or block verdict and records that verdict to a single append only,
+mode-0600, rotated audit ledger: `{ts, actor, tool, mode, reason_code, verdict, args_hash}`.
+The `reason_code` is a stable event key, never free form prose, so nothing user bearing is
+persisted. `args_hash` is a keyed HMAC-SHA256 over a per tool allowlist projection of the
+arguments: keyed so low entropy arguments cannot be recovered from the public log by
+dictionary attack, allowlisted by construction so a new tool or a new argument can never
+silently leak a secret or PII value into an append only log, and versioned. Auditing is
+**fail open by construction** — the log write happens after the verdict is decided, so a
+logging failure can never flip an allow to a block. The ledger is replayable:
+`trajectory_export` interleaves the governed actions back into the session timeline by
+timestamp, and the operator console exposes the feed at `/v1/audit/actions`.
+
+Alongside the action ledger, aimee keeps **decision records** — governable "we decided X
+because Y" entries carrying status, rationale, alternatives, a revisit date, what they
+supersede, the author, and the policy they bind. At most one decision is active per scope
+(enforced by a database unique index, not just by the writer), superseding one flips the
+prior in the same transaction, and a decision past its revisit date resurfaces on the
+existing recall and curator sweeps rather than rotting silently. Human sign off gates on
+sensitive actions are HMAC-SHA256 signed and non forgeable. Both surfaces are live in the
+[KB Console](docs/KB_CONSOLE.md) (`/v1/decisions`, `/v1/audit/actions`).
+
+Retrieval has a parallel, opt in audit chain: every KB grounded answer is reconstructible —
+which sources grounded it, at which content hashed version, and whether the answer is
+entailed by that evidence — read back through `/v1/audit/{trace,provenance,fidelity}`.
+
+### The context economizer
+
+aimee runs a context economizer over both the delegate turn loop and, optionally, the live
+primary `/v1` path, gated by a master switch and split into two tiers. The **safe tier**
+is default on: deterministic tool output condensation (keep the failing test, elide the
+passing ones; keep compiler diagnostics, drop progress), size based compression of oversized
+tool results, and folding old turn history into a rolling skeleton — recent context is never
+touched, and the full output is spilled to disk for recovery. A measurement ledger records
+the reduction opportunity even when a lever is off, so the master switch off state provably
+reduces to zero.
+
+The **aggressive tier** is opt in and off by default: it applies the reduction to the live
+inbound request so the primary agent's own tokens shrink too. It is compress only, and
+guarded by a per session circuit breaker — if a reduced request draws an error the session
+falls back to the pristine payload and disables reduction for its remaining turns, so one bad
+reduction can never persistently break live traffic. aimee never dispatches a reduced payload
+it cannot restore to the byte identical original. See [Settings](docs/SETTINGS.md) and
+[Tool output condensation](docs/features/tool-output-condensation.md).
 
 ### Delegation that cuts your bill
 
@@ -135,6 +230,18 @@ the primary model's bill on top of the delegate savings.
 ```bash
 aimee delegate review "Review this PR"     # routes to cheapest capable delegate
 aimee delegate code --tools "Add tests"    # delegate with file read/write access
+```
+
+When one model is not enough, run a **roundtable**: fan a task out to a panel and have an
+aggregator synthesize a single answer (`aimee delegate aggregate`), or run a bounded
+multi round draft-or-review where several models critique each other and converge, with cost
+and round caps (`aimee delegate roundtable --mode draft|review`). This is the same panel that
+staffs the reviews in autonomous development, and it composes from your configured
+[personas](docs/personas.md).
+
+```bash
+aimee delegate aggregate "Design an idempotent retry scheme"     # Mixture-of-Agents fan-out + synthesis
+aimee delegate roundtable "Review this design" --mode review     # bounded multi-round critique
 ```
 
 ### Run your own inference
@@ -173,6 +280,30 @@ Provider config is in the
 [Manual](MANUAL.md#25-integrations). The memory, guardrails, and delegation are the same on
 every front end, because they live in the server and kb, not the tool.
 
+### A browser workspace
+
+aimee ships its own browser UI, `aimee-webchat`, so you never need a terminal to use it. It
+is a thin, stateless client that proxies to `aimee-server`, with one tab per tool: **Chat**
+against any configured model; a **Graph** explorer that renders your indexed code as a live
+symbol and call graph; **Projects** to clone git repos over HTTPS or SSH form URLs; a full
+in app **VS Code editor** (a per user `code-server` the server supervises and reverse proxies)
+opened on the selected project; **Workflow Actions** to author a proposal and watch it run
+autonomously; and a **Dashboard** plus a **Logs** tab that show the server's delegations, tool
+calls, token spend, guardrail verdicts, and active sessions at a glance. See
+[Dashboard & Logs](docs/DASHBOARD.md) and [Workspace Management](docs/WORKSPACES.md).
+
+### Built for a team
+
+aimee is single user on a laptop and multi user on a server without changing the model.
+Clients enroll as accounts with **scoped tokens** (a request outside a token's grant is
+denied with `403`); the browser console authenticates with **OIDC single sign on**; the
+remote `/v1` path can require **mutual TLS** client identity; and every user's git tokens,
+provider keys, and OAuth credentials live only in a **per principal encrypted vault**, sealed
+by a server master key so one tenant can never read another's secret or files. The vault's
+master key rotates through an operator gated, offline runbook. See
+[Security Model](docs/SECURITY.md), [KB Console](docs/KB_CONSOLE.md), and
+[Webchat git security](docs/WEBCHAT_GIT_SECURITY.md).
+
 ## Works with what you already use
 
 | Tool | Integration | Run on any model | Setup |
@@ -194,12 +325,18 @@ works the same way. Switch tools any time. Your memory and context stay.
   compound into a knowledge base.
 - **No lock-in.** Run any turn on any provider's model, or your own, and switch with one
   command.
-- **Lower bills.** Cheapest capable delegate routing keeps the primary's context small,
-  upstream compression trims every turn, and local and subscription delegates cost nothing
-  extra.
+- **Lower bills.** Cheapest capable delegate routing keeps the primary's context small, the
+  context economizer trims every turn on both the delegate and the primary path, and local
+  and subscription delegates cost nothing extra.
 - **Fewer mistakes.** Sensitive file blocking, anti pattern warnings, and planning mode
   catch problems before the AI writes them.
-- **Team knowledge.** One shared kb distills what your whole organization knows.
+- **Provable and governable.** Every governed action lands in a tamper evident, keyed-HMAC
+  audit ledger, decisions are recorded with rationale and a revisit trigger, and KB grounded
+  answers are reconstructible back to their sources.
+- **Team knowledge.** One shared kb distills what your whole organization knows, behind
+  scoped accounts, OIDC sign on, and a per principal encrypted vault.
+- **A UI when you want one.** A browser workspace with chat, a code graph explorer, git
+  project management, an in app VS Code editor, and server dashboards — no terminal required.
 - **Yours to run.** C services, single digit millisecond hot paths, and an inference stack
   you can run entirely on your own hardware.
 
@@ -274,6 +411,8 @@ Focused references:
 | [Workflow Actions](docs/WORKFLOW_ACTIONS.md) | The web page to author a proposal, run it autonomously, and watch its status/history |
 | [Dashboard & Logs](docs/DASHBOARD.md) | The web Dashboard's server-incurred metric panels, customization, the Logs (tool-action audit) tab, and the panel data architecture |
 | [Settings](docs/SETTINGS.md) | The web page for the server's typed runtime config — economizer levers, autonomous-dev knobs, tool-output condensation, and how each maps to `aimee.yaml` |
+| [Context economizer](docs/features/context-fold.md) | The two-tier token-reduction pipeline: history fold, tool-output condensation, size compression, the freeze cost guardrail, and the live-primary gateway mutation with its per-session circuit breaker |
+| [KB Console](docs/KB_CONSOLE.md) | The operator console's trust model and surfaces — Accounts (enroll/revoke/scopes/OIDC) and Governance (decision records, the policy-verdict action audit) |
 | [Workspace Management](docs/WORKSPACES.md) | Multi repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
 | [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token at rest, in transit to git, and in the in browser editor, and where exposure is and is not closed |


### PR DESCRIPTION
## Summary

The root `README.md` described delegation, guardrails, and the model gateway but omitted several shipped, first-class capabilities. This adds prose sections, highlight bullets, and doc-table rows for them — no code changes.

Newly documented:

- **Context economizer** — two-tier (safe default-on / aggressive opt-in), live-primary gateway mutation with a per-session circuit breaker, deterministic tool-output condensation.
- **Governance + tamper-evident action ledger** — one choke-point verdict per governed tool call recorded to an append-only 0600 ledger with a keyed-HMAC `args_hash`, fail-open auditing, replay via `trajectory_export`; decision records (one active per scope, revisit sweep). Plus the opt-in KB retrieval audit chain (`/v1/audit/{trace,provenance,fidelity}`).
- **Browser workspace (`aimee-webchat`)** — chat, code graph explorer, git projects, in-app VS Code editor, Dashboard/Logs.
- **Team deployment** — scoped-token accounts, OIDC SSO, mutual TLS, per-principal encrypted credential vault.
- **Documents as coordinate-anchored evidence** — page/bbox PDF citations, table cells, figure crops, OCR.
- **Roundtable / Mixture-of-Agents** — `aimee delegate aggregate` and `delegate roundtable`.

## Provenance

Every claim, command, and endpoint is grounded in the shipped-feature record (`docs/STATUS.md`, the `done` proposals, `MANUAL.md`, `docs/SECURITY.md`, `docs/KB_CONSOLE.md`). Structured-PDF and the retrieval audit chain are framed as opt-in (their docs mark them default-off) to avoid overstating GA status.

## Verification

- All referenced `docs/*.md` links verified to resolve; a full-README link scan found no broken targets.
- Docs-only change; no build/test surface touched.