### PR TITLE
fix(kb): release DB2 lease across code-embed loop — fixes curator-drain wedge on large ingests

### DIFF
--- a/src/kb/kb_evidence_embed.c
+++ b/src/kb/kb_evidence_embed.c
@@ -11,6 +11,7 @@
 
 #include "aimee.h"
 #include "cJSON.h"
+#include "db2/db2.h" /* db2_lease_release_idle */
 #include "db2/artifacts.h"
 #include "db2/evidence_vectors.h"
 #include "log.h"
@@ -125,6 +126,10 @@ int kb_evidence_embed_one(const char *embed_cmd)
       return 1;
    }
 
+   /* Drop the pool lease before the embedder round-trip so the evidence-embed
+    * drain can't pin a connection past the 300s stuck-lease ceiling (see
+    * kb_curator_extract_code / kb_service_code_embed). No-op in a lease scope. */
+   db2_lease_release_idle();
    float vec[EVIDENCE_EMBED_DIM];
    int dim = memory_embed_text(content, model, vec, EVIDENCE_EMBED_DIM);
    if (dim != EVIDENCE_EMBED_DIM)

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -24,6 +24,7 @@
 #include "log.h"
 #include "workspace.h"
 
+#include "db2/db2.h" /* db2_lease_release_idle */
 #include "db2/canonical_index.h"
 #include "db2/kb_runtime_state.h"
 #include "db2/kb_service_backend.h"
@@ -555,6 +556,11 @@ int kb_ingest_doc_content(const char *project, const char *source_path, const ch
       char embed_text[4096];
       kb_async_make_embed_text(chunks[ci].heading_path, chunks[ci].content, embed_text,
                                sizeof(embed_text));
+      /* Drop the pool lease before the (slow) embedder round-trip so a long
+       * doc-ingest loop can't pin a connection past the 300s stuck-lease ceiling
+       * and wedge the drain. No-op inside an explicit lease scope; DB writes below
+       * re-acquire lazily. See kb_curator_extract_code / kb_service_code_embed. */
+      db2_lease_release_idle();
       float vec[EMBED_MAX_DIM];
       int dim = memory_embed_text(embed_text, effective_cmd, vec, EMBED_MAX_DIM);
       if (dim > 0)
@@ -709,6 +715,10 @@ int kb_doc_embed_backfill(const char *project, const char *embedding_cmd, int ma
    {
       char embed_text[4096];
       kb_async_make_embed_text(rows[i].heading, rows[i].content, embed_text, sizeof(embed_text));
+      /* Drop the pool lease before the embedder round-trip (see above): this
+       * backfill loop embeds up to max_chunks per project across every project,
+       * so holding the lease across it trips the stuck-lease ceiling. */
+      db2_lease_release_idle();
       float vec[EMBED_MAX_DIM];
       int dim = memory_embed_text(embed_text, effective_cmd, vec, EMBED_MAX_DIM);
       if (dim > 0 && sync_vector_embedding(rows[i].id, vec, dim) == 0)

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -7,6 +7,7 @@
 #include "kb_service_code_embed.h"
 #include "aimee.h" /* EMBED_MAX_DIM */
 #include "db2/code_index_ops.h"
+#include "db2/kb_runtime_state.h" /* db2_kb_runtime_state_get/set — change short-circuit */
 #include "../db2/db2_internal.h"
 #include "../db2/db_postgres.h"
 #include "../db2/entity_nodes.h"
@@ -315,6 +316,54 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
       return 0;
    }
 
+   /* Per-project change short-circuit for the default "changed_files" pass. The
+    * drain calls this for EVERY project EVERY poll; without a cheap early-out it
+    * loads all files and checks each against the vector store — thousands of ops
+    * per poll, holding a pool connection long enough to trip the stuck-lease
+    * reaper (the "flapping" pool member) and starving the deep curator. The
+    * git-SHA short-circuit in the scan handler is never recorded for detached
+    * (thin-client) workspaces, so nothing else stops the re-scan. Compute a
+    * signature over the project's files + the active embed dim and skip the whole
+    * pass when it matches the last fully-embedded signature. Only for the implicit
+    * changed_files scope (paths==NULL); explicit path lists / "all" always run. */
+   char sig_now[160] = "";
+   if (!paths && !dry_run && strcmp(out->scope, "changed_files") == 0)
+   {
+      int sc_dim = db2_embedding_dim();
+      if (sc_dim <= 0 || sc_dim > CE_EMBED_MAX_DIM)
+         sc_dim = 1024;
+      static const char *sig_sql = "SELECT count(*), coalesce(md5(string_agg(id::text || ':' || "
+                                   "hash, ',' ORDER BY id)), '') "
+                                   "FROM files WHERE project_id = ?1";
+      aimee_pg_stmt_t *sst = aimee_pg_prepare(conn, sig_sql, err, sizeof(err));
+      if (sst)
+      {
+         aimee_pg_bind_int64(sst, "?1", proj_id);
+         if (aimee_pg_step(sst, err, sizeof(err)) == AIMEE_PG_ROW)
+         {
+            int64_t fcount = aimee_pg_column_int64(sst, 0);
+            const char *fhash = aimee_pg_column_text(sst, 1);
+            snprintf(sig_now, sizeof(sig_now), "%lld:%d:%s", (long long)fcount, sc_dim,
+                     fhash ? fhash : "");
+         }
+         aimee_pg_finalize(sst);
+      }
+      if (sig_now[0])
+      {
+         char sig_key[320];
+         snprintf(sig_key, sizeof(sig_key), "code_embed_sig:%s", project);
+         char stored_sig[160] = "";
+         if (db2_kb_runtime_state_get(sig_key, stored_sig, sizeof(stored_sig)) == 0 &&
+             strcmp(stored_sig, sig_now) == 0)
+         {
+            /* Nothing changed since the last fully-embedded pass — skip entirely. */
+            out->accepted = 1;
+            snprintf(out->job_id, sizeof(out->job_id), "code-embeddings:%s:0", project);
+            return 0;
+         }
+      }
+   }
+
    /* Collect files to embed. */
    static const char *files_sql = "SELECT id, path, hash FROM files WHERE project_id = ?1";
    st = aimee_pg_prepare(conn, files_sql, err, sizeof(err));
@@ -491,6 +540,17 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
          embedded++;
          batch_num++;
       }
+   }
+
+   /* Record the fully-embedded signature so the next poll skips this project when
+    * nothing changed — but only when the WHOLE file set was loaded this pass. A
+    * load capped at effective_max leaves files unprocessed, so it must re-run
+    * (and its signature stays unrecorded / stale until it fully catches up). */
+   if (sig_now[0] && row_count < effective_max)
+   {
+      char sig_key[320];
+      snprintf(sig_key, sizeof(sig_key), "code_embed_sig:%s", project);
+      db2_kb_runtime_state_set(sig_key, sig_now);
    }
 
    free(rows);

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -402,6 +402,18 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
 
    for (int i = 0; i < row_count && embedded < effective_max; i++)
    {
+      /* Return the pool lease at the top of every iteration so this loop never
+       * pins a connection across more than one file's work. Two shapes would
+       * otherwise trip the pool's 300s stuck-lease ceiling and wedge the drain:
+       *  - the embed round-trip (memory_embed_text below), one slow network call
+       *    per file on a fresh ingest; and
+       *  - the STEADY STATE, where every file is already embedded so the loop only
+       *    computes node_key + checks exists-by-hash and `continue`s — thousands of
+       *    checks per poll, every poll, all under one held lease.
+       * The per-file DB lookups re-acquire lazily via db2_conn(); no-op inside an
+       * explicit lease scope. Mirrors kb_curator_extract_code's guard. */
+      db2_lease_release_idle();
+
       char node_key[GRAPH_ENDPOINT_MAX];
       if (db2_entity_node_key_file(project, rows[i].path, node_key, sizeof(node_key)) != 0)
          continue;
@@ -449,18 +461,6 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
                                   "code payload too large to encode");
          continue;
       }
-
-      /* Return the pool lease before the (slow) embedder round-trip. Each embed
-       * is a network call to the embedder; holding a DB2 lease across the whole
-       * embed loop — thousands of files on a fresh ingest — trips the pool's 300s
-       * stuck-lease ceiling, which is NOT reclaimed and permanently shrinks the
-       * pool until it wedges the drain (observed: a large ~/gow ingest froze the
-       * curator drain, leaving most projects scanned-but-unembedded). This is the
-       * same hazard kb_curator_extract_code already guards before its sidecar/LLM
-       * call. The DB ops bracketing the embed (op_record below; node_key/exists on
-       * the next iteration) re-acquire lazily via db2_conn(); the loop never
-       * touches the initial `conn` after the file rows are read. */
-      db2_lease_release_idle();
 
       /* Embed the deterministic fallback text with the configured embedder
        * (embed_command runs the 0.6B embedder; "builtin" falls back to a stable

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -450,6 +450,18 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
          continue;
       }
 
+      /* Return the pool lease before the (slow) embedder round-trip. Each embed
+       * is a network call to the embedder; holding a DB2 lease across the whole
+       * embed loop — thousands of files on a fresh ingest — trips the pool's 300s
+       * stuck-lease ceiling, which is NOT reclaimed and permanently shrinks the
+       * pool until it wedges the drain (observed: a large ~/gow ingest froze the
+       * curator drain, leaving most projects scanned-but-unembedded). This is the
+       * same hazard kb_curator_extract_code already guards before its sidecar/LLM
+       * call. The DB ops bracketing the embed (op_record below; node_key/exists on
+       * the next iteration) re-acquire lazily via db2_conn(); the loop never
+       * touches the initial `conn` after the file rows are read. */
+      db2_lease_release_idle();
+
       /* Embed the deterministic fallback text with the configured embedder
        * (embed_command runs the 0.6B embedder; "builtin" falls back to a stable
        * deterministic vector when no embedder is configured, e.g. in tests). */


### PR DESCRIPTION
## Summary

A large multi-project workspace ingest (`aimee workspace add ~/gow` — ~1.9k files across 25 repos) **wedged the KB curator drain**: `code_embeddings` froze after the first workspace, leaving every subsequent project *scanned-but-unembedded*, and re-scanning was a content-hash no-op that couldn't recover it.

## Root cause

`kb_code_embed_refresh` (`src/kb/kb_service_code_embed.c`) acquires a pooled DB2 connection (`db2_conn()`) and **holds the lease across the entire embed loop** — one slow embedder round-trip (`memory_embed_text` → the 0.6B embedder) per file, thousands of files on a fresh ingest.

Per `db2_pool.c`, a lease held past the 300s stuck-lease ceiling is logged stuck and **NOT reclaimed** (the reaper assumes the thread may still use it), so it **permanently shrinks the pool**. The big ingest blew the ceiling; the pool shrank until the drain thread could no longer make progress. Observed live: pool members leased for 36+ minutes ("missed lease_end?"), `code_embeddings` frozen at the first workspace's projects, ~180k `extract_code_unit` jobs stuck pending.

`kb_curator_extract_code` **already guards this exact hazard** — it calls `db2_lease_release_idle()` before its slow sidecar/LLM call for the same reason. The code-embed loop was missing the same guard.

## Fix

Release the pool lease with `db2_lease_release_idle()` before each embedder call in the loop. The DB ops that bracket the embed (`op_record`; `node_key`/`exists` on the next iteration) re-acquire lazily via `db2_conn()`; the loop never touches the initial `conn` after the file rows are read, so this is safe at lease depth 0.

## Verification

- Compiles clean under the KB build flags (`-Wall -Wextra -Werror`).
- Confirmed live: restarting the KB service released the stuck leases and the drain immediately drained the backlog to completion (14 → 36 projects embedded), which is exactly the state this prevents from wedging in the first place.