### PR TITLE
docs(proposals): proposals for the still-open ROADMAP gaps (benchmark cadence, operator audit, v1 phase-7 closeout, proposal hygiene)

### DIFF
--- a/docs/proposals/pending/operator-audit-activity-surface.md
+++ b/docs/proposals/pending/operator-audit-activity-surface.md
@@ -1,0 +1,69 @@
+# Proposal: First-class operator-audit activity surface
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+Every shareable row in DB2 already carries the provenance needed to answer "who
+did what, in which scope, when" — `operator_id`, `content_hash`, timestamps — and
+a WORM audit ledger records privileged actions. But there is **no legible way to
+read it out.** The `aimee audit` verb only *verifies/checkpoints* the WORM store's
+integrity; it cannot render per-operator or per-scope activity. So the data is
+audit-*able* but not audit-*ed*: answering "what has operator X written to project
+Y this week?" means hand-writing SQL against DB2. The three-db-split Known
+Weaknesses section flagged this; it is still unbuilt.
+
+## Goal
+
+An operator can run one command (and one `/v1` call) to get a legible,
+scoped activity report — per operator, per scope (project / workspace / global),
+over a time window — sourced from the provenance columns and the WORM ledger that
+already exist, with no new write path.
+
+## §0 What already exists
+
+- **Provenance columns.** `operator_id` is on shareable rows across
+  `src/db2/` (`fidelity.c`, `corpus_structural.c`, `artifacts.c`, memory rows,
+  …), alongside `content_hash` + timestamps.
+- **WORM ledger.** `src/audit_ledger.c` + `src/db2/kb_audit_worm.c` record
+  privileged/append-only actions with a verify chain.
+- **The CLI verb exists but is integrity-only.** `cmd_audit`
+  (`{"audit", "Verify/checkpoint the WORM audit store …"}`) has `verify` +
+  `checkpoint` subcommands — nothing that reports activity.
+
+Everything needed to *read* is present; only the read surface is missing.
+
+## §1 DB2 read API: scoped activity query
+
+Add a read-only DB2 accessor (in the owning `src/db2/` module, behind the KB
+service — server/CLI must not touch DB2 directly per the storage boundary) that
+aggregates activity by `(operator_id, scope, action, day)` over a time window,
+unioning the provenance columns and the WORM ledger. Read-only; no new table.
+
+## §2 `/v1/audit/activity` endpoint
+
+Expose it as `GET /v1/audit/activity?operator=&scope=&since=&until=` on aimee-kb,
+returning the scoped rollup. Add it to the OpenAPI surface + `v1-method-coverage`
+so it is a first-class, conformance-tested route rather than a side door. Gate it
+behind the same admin capability the other privileged `/v1/audit/*` operations
+use.
+
+## §3 `aimee audit activity` subcommand
+
+Add an `activity` subcommand to the existing `audit` verb that calls the route and
+renders a legible table (operator × scope × action counts, most-recent activity,
+optional `--json`). Keep `verify`/`checkpoint` unchanged. This is the surface the
+Known Weaknesses note asked for.
+
+## §4 (optional) Anomaly summary
+
+A `--anomalies` flag that surfaces the obvious ones the rollup makes cheap:
+writes by an operator with no prior activity in a scope, a spike vs. that
+operator's trailing median, or a WORM-chain gap. Not intrusion detection — just
+making the legible data legible.
+
+## Non-goals
+
+No new capture (the data is already recorded), no tamper-evidence changes (the
+WORM chain stays as-is), and no multi-tenant policy engine — this is a *read*
+surface over provenance we already keep.

--- a/docs/proposals/pending/proposal-supersession-hygiene.md
+++ b/docs/proposals/pending/proposal-supersession-hygiene.md
@@ -1,0 +1,57 @@
+# Proposal: Proposal-supersession hygiene — same-commit move + a documented rule
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+`docs/proposals/pending/` is only useful as signal if a finished or superseded
+proposal *leaves* it. `check-proposal-reconcile.py` already catches one drift
+class — a pending/accepted proposal that has actually shipped (classified
+"terminal-done"). But the specific drift the roadmap flagged is different and
+still unguarded: a PR that **supersedes** a proposal (deletes/replaces its
+subject) without moving the old file, so a dead proposal lingers in `pending/`
+(the roadmap cites the pluggable-db proposal doing exactly this). And there is **no
+`CONTRIBUTING.md`** stating the rule, so contributors have no norm to follow —
+only a lint that fires after the fact on one of two failure modes.
+
+## Goal
+
+The supersession-move becomes both a written rule and an enforced one: the PR that
+supersedes a proposal moves the old one (to `rejected/` / `deferred/` / `done/`)
+**in the same commit**, and a lint catches the case where it didn't.
+
+## §0 What already exists
+
+- `scripts/check-proposal-reconcile.py` (`proposal-reconcile-check`, in `lint`)
+  flags a `pending/`|`accepted/` proposal classified terminal-done.
+- `scripts/check-proposal-links.py` (`proposal-links-check`) validates links.
+- **No `CONTRIBUTING.md`** at repo root or `docs/`.
+- No check for "superseded-but-not-moved" (a live `pending/` file whose subject a
+  later PR removed/replaced).
+
+## §1 Document the rule
+
+Add `CONTRIBUTING.md` with a short "Proposals" section: proposals live under
+`docs/proposals/{pending,accepted,done,rejected,deferred}/`; the PR that lands,
+rejects, defers, or **supersedes** a proposal moves the file to its terminal state
+**in the same commit**; supersession notes the successor in the moved file's
+header. Reference the PR template so it is seen at author time, not review time.
+
+## §2 Extend the reconcile check for supersession
+
+Teach `check-proposal-reconcile.py` a second failure mode: a `pending/`/`accepted/`
+proposal whose declared subject/anchor no longer resolves (the code, doc, or
+sibling proposal it proposes has been removed or replaced) is "superseded, not
+moved" → fail with the remediation ("move it to rejected/ or deferred/"). Keep the
+existing `--plant-test` self-check so the guard itself stays honest.
+
+## §3 One-time sweep
+
+Reconcile today's `pending/` against reality (this proposal set is part of that
+pass) and move any already-superseded stragglers. A clean `pending/` is the
+precondition for the rule to mean anything.
+
+## Non-goals
+
+Not a workflow engine and not auto-moving files in CI (moves stay author-driven,
+reviewed) — just a written norm plus a lint that makes violating it visible.

--- a/docs/proposals/pending/standing-benchmark-cadence.md
+++ b/docs/proposals/pending/standing-benchmark-cadence.md
@@ -1,0 +1,75 @@
+# Proposal: Standing LoCoMo / LongMemEval benchmark cadence
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+Acceptance criteria across the codebase cite retrieval/memory parity in absolute
+terms — "within ±0.005 of baseline", "P@5 ≥ 0.45", "no regression vs. mem0" —
+but **nothing runs the full benchmarks on a schedule**. `bench-smoke.yml` fires
+only on `pull_request`, and it runs the harness *unit tests* + a provisioning
+coverage gate + **mini** fixtures (`locomo-mini.json`, `longmemeval-mini.json`),
+not the real datasets. So the numbers those criteria are measured against are
+computed by hand, ad hoc, and then quietly go stale. As the roadmap says: either
+put the benchmarks on a cadence, or stop citing parity criteria nobody measures.
+
+## Goal
+
+A scheduled job runs the **full** LoCoMo + LongMemEval (and the memory /
+code-vector suites) against `testing` on a fixed cadence, persists the scored
+results with a retention policy, and fails loudly on a drift beyond the parity
+band that acceptance criteria already cite — so "±0.005 of baseline" becomes a
+measured, enforceable fact instead of a hope.
+
+## §0 What already exists
+
+- **Harness is complete.** `benchmarks/locomo/bench_aimee_direct.py`,
+  `bench_aimee_llm.py`, and the comparison baselines (`bench_bm25_llm.py`,
+  `bench_mem0_llm.py`, `bench_rag_chromadb_llm.py`); `benchmarks/longmemeval/`;
+  `benchmarks/memory/`; `benchmarks/code-vector-graph/`. Results docs
+  (`BENCHMARK_RESULTS.md`, `EVAL_CONFIG.md`) exist per suite.
+- **Make targets exist:** `bench`, `bench-check`, `bench-baseline`,
+  `memory-retrieval-eval-check`, `curator-eval-check`.
+- **CI runs none of the full datasets.** `.github/workflows/bench-smoke.yml` is
+  PR-triggered and mini-only; `benchmarks/check_provisioning.py` gates coverage
+  but scores nothing.
+
+The pieces to *run* a benchmark exist; the missing thing is a scheduler, a
+results store, and a drift gate.
+
+## §1 Scheduled full-suite workflow
+
+Add `.github/workflows/bench-nightly.yml` (`on: schedule:` — nightly for the
+cheap suites, weekly for the LLM-graded ones, plus `workflow_dispatch`). It
+provisions the real datasets (gated behind a repo secret / self-hosted runner
+where the datasets or an LLM endpoint are needed), runs the full `bench_*`
+scripts, and writes scored JSON. Keep it OFF the PR path — PRs keep the fast
+smoke; the full run is a cadence, not a blocker.
+
+## §2 Results store + retention
+
+Persist each run's scored JSON as a dated artifact (retention policy, e.g. 90
+days for raw runs, indefinitely for the committed baseline). Commit a single
+rolling `benchmarks/BASELINE.json` (per suite, per metric) that the parity checks
+read, updated only by an explicit "accept new baseline" step — never silently by
+a run.
+
+## §3 Drift gate wired to existing criteria
+
+A `benchmarks/check_drift.py` compares the latest scored run against
+`BASELINE.json` and fails when any cited metric moves beyond its declared band
+(P@5, LoCoMo/LongMemEval accuracy, memory parity ±0.005). Wire it into the
+nightly workflow and expose it as a `bench-drift-check` make target so it can run
+locally. Acceptance criteria stop citing an unmeasured number.
+
+## §4 Make the criteria honest
+
+Sweep the acceptance criteria that cite a parity band and either (a) point them at
+`BASELINE.json` + the drift gate, or (b) delete the citation. A criterion that
+references a number no job measures is debt, not a spec.
+
+## Non-goals
+
+Not changing what the benchmarks measure or adding new datasets — this is purely
+about *running the ones we have on a cadence and holding the line*. New suites
+ride their own proposals.

--- a/docs/proposals/pending/v1-stability-and-distributed-validation.md
+++ b/docs/proposals/pending/v1-stability-and-distributed-validation.md
@@ -1,0 +1,77 @@
+# Proposal: Close out platform phase 7 — v1 API stability tag + distributed-mode validation
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+The aimee-kb platform arc (roadmap "aimee-kb service + public API") landed phases
+1–6: the service split, OpenAPI + SDKs, ingest, corpus staging, the retrieval
+surface, and reflection HTTP all exist and are conformance-checked. **Phase 7 —
+"distributed-mode validation + v1 API stability tag" — is the one piece with no
+evidence it happened.** The `/v1` surface is exercised piecemeal by a dozen
+conformance/coverage checks, and distributed mode *works in the field* (aimee-kb
+runs remotely with thin clients today), but there is no single test that stands up
+the split topology end-to-end, and no declared, enforced "v1 is stable — breaking
+it is a versioned event" contract. Until that exists, v1 is *de facto* stable and
+*de jure* undefined.
+
+## Goal
+
+1. A **v1 stability contract**: a machine-checkable declaration of the frozen v1
+   surface, with a CI gate that fails a PR that changes it without an explicit
+   version bump.
+2. A **distributed-mode integration test**: one harness that runs aimee-kb as a
+   remote service with ≥2 concurrent thin clients against it, exercising the real
+   `/v1` paths (ingest → curate → retrieve, auth, per-operator scoping) — the
+   topology we actually ship, tested as a unit.
+
+## §0 What already exists
+
+- **Broad but piecemeal conformance.** `api-conformance-check`,
+  `server-api-conformance-check`, `v1-method-coverage-check`,
+  `cli-v1-routes-check`, `kb-v1-coverage-check`, `sdk-parity-check`,
+  `v1-third-party-test`, `v1-sdk-smoke`, `v1-ws-test` — plus OpenAPI at
+  `docs/gen/api-v1.md` and `gen-sdks`.
+- **Distributed mode runs in production.** aimee-kb as a remote plugin, thin
+  clients over `/v1` (the `.254` deployment) — but validated only by usage, not
+  a committed test.
+- **No frozen-surface gate + no topology test.** Nothing declares "this is v1,
+  frozen" or stands up server+clients together in CI.
+
+Phase 7 is the *closeout*, not new construction.
+
+## §1 v1 surface snapshot + stability gate
+
+Generate a canonical, sorted snapshot of the v1 contract (routes + methods +
+request/response schema, derived from the same source the conformance checks read)
+into `docs/gen/v1-surface.lock`. Add a `v1-stability-check` make target + CI job
+that regenerates and diffs it: any change fails unless the PR also bumps the
+declared `API_VERSION` / adds a `v1.<n>` compatibility note. Additive-only changes
+(new optional field, new route) pass with a changelog line; removals/renames
+require the version event. This turns "don't break v1" from a norm into a gate.
+
+## §2 Distributed-mode integration harness
+
+Add `make v1-distributed-test`: bring up aimee-kb (its own DB2) as a detached
+service, point ≥2 thin clients at it, and run a scripted end-to-end —
+enroll/auth, `POST /v1/docs` + code scan from client A, curate, `POST /v1/search`
++ `/v1/code/*` from client B, and assert per-operator scoping isolates A's and B's
+writes. Run it in CI (the same runner that already builds the split images).
+
+## §3 Concurrency + isolation assertions
+
+The harness is also where the boundary claims get teeth: two clients writing the
+same project concurrently must not corrupt provenance; a client with scope X must
+not read scope Y; the KB pool must not wedge under concurrent ingest (see the
+curator-drain lease work). Encode these as explicit assertions, not incidental.
+
+## §4 Tag + document
+
+Once §1–§3 are green, tag the v1 surface stable in `docs/gen/api-v1.md` and record
+the versioning policy (additive vs. breaking, deprecation window) next to it, so
+downstream SDK/thin-client authors have a contract, not folklore.
+
+## Non-goals
+
+Not redesigning auth (that is its own deferred multi-tenant item) and not adding
+API surface — this freezes and validates what phases 1–6 already shipped.


### PR DESCRIPTION
## Context

Asked to find what we're still short on vs. `docs/ROADMAP.md`, I audited the roadmap threads against the actual code. **The roadmap is ~2.5 months stale (last revised 2026-04-29) and nearly all of its critical path has landed** — DB1/DB2 boundary + pgvector-in-DB2, all 7 aimee-kb platform phases (service split, OpenAPI+SDKs, profile picker, ingest/`POST /v1/docs`, corpus staging, retrieval endpoints, reflection HTTP), all curator stages (extract_doc/code, resolve_entities, index_code_unit, contradictions, synthesize, …), the Phase-0 embedder lift, and two "untracked gaps" that are now closed (`setup.sh`, `src/kb/auth_oidc.c`).

This PR adds proposals for the four gaps that are **genuinely still open**:

| Proposal | Gap |
|---|---|
| `standing-benchmark-cadence` | LoCoMo/LongMemEval harness exists but `bench-smoke.yml` runs only mini fixtures on PR — no scheduled full run, results store, or drift gate. Parity criteria ("±0.005 of baseline") are unmeasured. |
| `operator-audit-activity-surface` | `operator_id`/`content_hash`/timestamps + a WORM ledger exist, but the `audit` verb is integrity-only — no per-operator/per-scope activity read surface. |
| `v1-stability-and-distributed-validation` | Platform phase 7 closeout: a frozen-v1 stability gate + an end-to-end distributed-mode (server + ≥2 thin clients) integration test. Conformance is broad but piecemeal; no topology test, no version-freeze contract. |
| `proposal-supersession-hygiene` | `check-proposal-reconcile.py` catches terminal-done stragglers but not superseded-but-not-moved; no `CONTRIBUTING.md` documents the same-commit move rule. |

Deliberately **not** proposed: dynamic-alpha fusion (conditional, gated on a benchmark decision) and conversation branching (roadmap marks it dormant-by-choice). Also flagged in the review but out of scope here: the ROADMAP itself should be re-dated / finished-phases demoted, since it no longer reflects reality.

Passes `proposal-links-check` + `proposal-reconcile-check` (the one report-only note is the `bench-nightly.yml` the first proposal proposes to create).