### PR TITLE
docs(proposals): finish-out proposals — curator/reflection sidecar + org-data connectors

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -122,6 +122,19 @@ recall.
 - Corpus Vector Index Strategy:
   pgvector HNSW by default, pgvectorscale diskann as an opt-in scale-up;
   memory vectors stay HNSW. **New.**
+- [LLM-Sidecar Productionization: Curator Extraction and Idle Reflection](proposals/pending/llm-sidecar-productionization-curator-and-reflection.md):
+  graduates the two shipped-but-stubbed intelligence steps — curator LLM
+  extraction (all stages ship; only the Phase-0 embedding sidecar exists) and
+  the idle-reflection scheduler (runs fully; LLM candidate generation stubbed) —
+  onto one versioned sidecar contract, behind a shadow → canary → default gate
+  on the shipped calibration + bandit rails. Extract / Synthesize / Judge /
+  Reflect / Gate-Promote. **New.**
+- [Org-Data Connectors and Source Ingestion](proposals/pending/org-data-connectors-and-source-ingestion.md):
+  the missing ingest front door for the every-domain KB — a uniform connector
+  contract plus a first adapter set (issue tracker / chat / doc-wiki / email),
+  incremental sync with supersession, and ingest-time auth + scope + PII/poison
+  enforcement, all feeding the shipped Normalize → staged-pipeline → curator
+  path. Extract (Normalize) / Classify-Score / Enforce / Gate-Promote. **New.**
 
 ### Retrieval (Recall / Rerank / Rank-Fuse)
 

--- a/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
+++ b/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
@@ -1,0 +1,204 @@
+# Proposal: LLM-sidecar productionization — graduate curator extraction and idle reflection from stub to production
+
+- **State:** PENDING — design only. Finishes two already-shipped-but-stubbed
+  intelligence steps that ride the shared `kb_curator_sidecar` mechanism. Adds no
+  new subsystem: it wires the existing curator extract/synthesize/judge stages and
+  the existing idle-reflection scheduler onto a production sidecar, behind a
+  calibrated gate. Continuation of **Deep Curator: Doc and Code Extraction**
+  (Accepted, Phase 0 shipped — `scripts/embed-minilm.py` MiniLM-L6-v2 embedding
+  sidecar) and the **Cross-Source Learning** substrate (Done). Does **not**
+  re-propose the curator stage machine, the reflection scheduler, the promotion
+  pipeline, calibration, or the sidecar-invocation shim — all shipped; it makes the
+  LLM step they were built around real.
+- **Author:** JBailes
+- **Date:** 2026-07-07
+- **Charter roles:** Extract (structured entity/fact/decision/relationship
+  extraction from docs and code), Synthesize (reflection candidate generation +
+  higher-order knowledge), Judge (quality gate before durable), Reflect
+  (idle-time consolidation), Calibrate (per-surface promotion thresholds already
+  fitted — this feeds them real candidates), Gate-Promote (staged rollout of the
+  sidecar's output), Evaluate-Optimize (shadow → canary → default via the bandit
+  substrate). Cites the Architecture Charter; this proposal lives entirely inside
+  the charter's Extract/Synthesize/Judge/Reflect spine.
+
+## Thesis
+
+The knowledge base's "it learns, not just stores" story (KNOWLEDGE.md §1, §3) rests
+on two steps that are **scaffolded but stubbed today**:
+
+1. **Curator extraction.** Every curator stage exists as shipped code —
+   `kb_curator_extract.c`, `kb_curator_extract_code.c`, `kb_curator_judge.c`,
+   `kb_curator_synthesize.c`, `kb_curator_resolve_entities.c`,
+   `kb_curator_link_artifacts.c`, `kb_curator_contradictions.c`,
+   `kb_curator_grounding.c`, `kb_curator_index_narrative.c`,
+   `kb_curator_index_claims.c`, `kb_curator_promote.c` — draining
+   `corpus_processing_jobs` through the staged pipeline (`aimee kb pipeline`). But
+   the LLM extraction they exist to run reaches the model through
+   `kb_curator_sidecar_run(cmd, json_input, …)` (`kb_curator_sidecar.c`), and the
+   only sidecar shipped so far is the **Phase 0 embedding** sidecar. Entity / fact
+   / decision extraction and the doc↔code `implements` bridge do not yet run
+   against a production extractor.
+
+2. **Idle reflection.** `kb_reflection.c` ships a full idle-triggered scheduler
+   (fires when `now − last_session_rpc_ts > review_idle_trigger_minutes`, over
+   unreflected `session_summary` artifacts older than
+   `review_session_cooldown_hours`, stamping `reflected_at`, deduplicating). Its
+   own header states the gap verbatim: *"LLM candidate generation is stubbed
+   pending charter sidecar integration; the scheduler infrastructure and
+   deduplication run fully."* So aimee reflects **structurally** today; it does not
+   yet **synthesize**.
+
+Both stubs share one dependency: a production LLM sidecar with a stable contract.
+This proposal defines that contract once, graduates both consumers onto it behind
+a calibrated shadow→canary→default gate, and closes the two operational-validation
+items those stages left open. When it lands, the §1/§3 claims become true in the
+build, not just in the architecture.
+
+## Goal
+
+1. **One production sidecar contract** — a versioned, JSON-in/JSON-out request/
+   response schema (`sidecar_contract_version`) shared by curator extraction and
+   reflection synthesis, invoked through the existing `kb_curator_sidecar_run`
+   shim, with a CPU-first reference implementation that installs today.
+2. **Curator extraction runs it** — the extract/judge/synthesize stages produce
+   real entities, facts, decisions, relationships, and the doc↔code `implements`
+   bridge, gated by the shipped judge stage.
+3. **Reflection synthesizes** — the reflection scheduler's stubbed candidate
+   generation calls the same sidecar and emits synthesis candidates into the
+   shipped promotion pipeline.
+4. **Gated rollout, never a silent flip** — every sidecar output lands in shadow
+   first, is scored against a held-out fixture set, and is promoted to default only
+   through the shipped Bayesian-calibration + bandit machinery.
+5. **Close the open operational items** — the two Operational Validation Cycle
+   proposals (Working-Profile, Dogfood Autolabel) get their first real
+   candidate stream from this, closing their "unshipped operational artifacts"
+   remainder on a real calendar.
+
+## §0 What already exists (so we don't rebuild it)
+
+- **Sidecar shim.** `kb_curator_sidecar_run(cmd, json_input, out_cap, errbuf,
+  errlen)` (`src/kb/kb_curator_sidecar.c`) — spawns a configured command, pipes
+  JSON in, reads JSON out, fails closed with an error string. Backend-agnostic.
+- **Curator stage machine.** All stages listed in the Thesis, plus
+  `kb_curator_queue.c` / `kb_curator_drain.c` (queueing + deterministic drain),
+  `kb_curator_version.c` (prompt/model version keying), `kb_curator_llm.c` (LLM
+  call plumbing), `kb_curator_notify.c`. Driven by `corpus_processing_jobs`
+  (`aimee kb pipeline`) — the resumable per-document stage machine (Done).
+- **Curator config.** `src/config_kb_curator.c` + `src/curator_profile.c` — the
+  CPU-first curator profile and sidecar command configuration.
+- **Reflection scheduler.** `kb_reflection.c` — idle trigger, cooldown, dedup,
+  `reflected_at` stamping; surfaced as `reflection-scheduler` in
+  `kb_service_workers.c`. Everything but LLM candidate generation runs.
+- **Promotion + calibration.** The charter promotion pipeline, **Bayesian
+  Calibration of Promotion Thresholds** (Done — per-`(surface, kind, scope)`
+  Beta-binomial posteriors, conformal abstention floor, working-profile gate
+  consumption), and **Contextual Bandits and Counterfactual Replay** (Done — five
+  decision points wired, exploration-budget gate, replay attribution). These are
+  the rollout rails; today they have no real curator/reflection candidate stream to
+  rank.
+- **Embedding sidecar (Phase 0).** `scripts/embed-minilm.py` (MiniLM-L6-v2) — the
+  pattern this proposal generalizes from embeddings to extraction/synthesis.
+- **Judge stage.** `kb_curator_judge.c` — the quality gate every candidate already
+  passes before becoming durable.
+
+## §1 The sidecar contract (`sidecar_contract_version`)
+
+One versioned JSON contract, shared by both consumers, invoked through the existing
+shim. A request carries `{contract_version, task, profile, inputs[], budget}`;
+`task ∈ {extract_doc, extract_code, synthesize_reflection}`. A response carries
+`{contract_version, candidates[], usage, abstained[]}` where each candidate is a
+typed artifact (entity / fact / decision / relationship / synthesis) with
+provenance spans and a self-reported confidence — **never** a durable write; the
+judge stage (§2) and promotion gate (§4) decide durability.
+
+- **Version-keyed.** `contract_version` composes with the shipped prompt/model
+  version keying (`kb_curator_version.c`) so a bump replays cleanly and calibration
+  refits (already keyed on prompt/model version).
+- **Fails closed.** A malformed or empty sidecar response is a *defer* (retry),
+  never a false success — matching the typed-fact write-gate discipline and the
+  existing `_extract.c` `pending`/`failed` attempt accounting.
+- **Backend-pluggable.** The reference implementation is CPU-first (small local
+  model, consistent with the curator profile); an operator can point
+  `kb.curator.sidecar_cmd` / a new `kb.reflection.sidecar_cmd` at any command
+  honoring the contract. No cloud dependency required to install.
+
+## §2 Curator extraction on the real sidecar
+
+- Wire `kb_curator_extract.c` / `_extract_code.c` to emit `task=extract_doc` /
+  `extract_code` requests and route responses into the existing
+  resolve-entities → link-artifacts → contradictions → judge → promote path. No new
+  stages.
+- Land the **doc↔code `implements` bridge** (Deep Curator's headline edge) as a
+  relationship candidate kind produced by `extract_code` and validated by the
+  typed-fact ontology gate — reusing the shipped `rel_types` machinery, not a new
+  one.
+- Contradictions and grounding stages already exist; they now receive real
+  candidates instead of Phase-0 embeddings.
+
+## §3 Reflection synthesis on the real sidecar
+
+- Replace the stubbed candidate generator in `kb_reflection.c` with a
+  `task=synthesize_reflection` call over the unreflected-`session_summary` batch
+  the scheduler already assembles.
+- Emit synthesis candidates into the same promotion pipeline curator output uses —
+  one durability path, one judge, one calibration surface.
+- Keep every shipped guardrail: idle trigger, cooldown, dedup, `reflected_at`
+  stamping stay exactly as-is; only the "what runs at the fire point" changes.
+
+## §4 Gated rollout — shadow → canary → default
+
+No silent flip. Sidecar output graduates through the shipped rails:
+
+1. **Shadow.** Candidates are generated and scored but not promoted; logged as
+   evidence. Mirrors the semantic-guardrails `dry_run` shadow mode already in the
+   tree.
+2. **Fixture gate.** A held-out extraction/synthesis fixture set (built like the
+   sketch and bandit fixtures already in the repo) gates promotion: precision on
+   entities/facts and a synthesis-usefulness proxy must clear a threshold before
+   canary.
+3. **Canary → default.** Promotion thresholds come from the fitted
+   `calibration_profile` artifacts (Bayesian calibration, Done), and the
+   default-flip decision is a bandit arm (`sidecar_extraction_mode`,
+   `reflection_synthesis_mode`) flipped through the shipped
+   `POST /v1/intelligence/bandit/replay-record` path — attribution recorded as
+   `benchmark_trace` artifacts, exactly as the five existing decision points do.
+
+## §5 Closes the open operational items
+
+The two **Operational Validation Cycle** proposals (Working-Profile, Dogfood
+Autolabel) exist to close acceptance items from shipped plumbing on a real
+calendar; both were blocked on having a live candidate stream. This proposal
+produces that stream — the first end-to-end pass of the promotion + retroactive-
+review loop is a curator/reflection candidate cohort moving shadow→default. Their
+close-by deadlines become achievable, not hypothetical.
+
+## Acceptance criteria
+
+1. **Contract.** `sidecar_contract_version` schema documented; both consumers emit
+   it through `kb_curator_sidecar_run`; malformed response ⇒ defer (proven by a
+   fixture that feeds garbage and asserts retry, not durable write).
+2. **Curator.** `extract_doc` / `extract_code` produce entities, facts, decisions,
+   relationships, and at least one `implements` doc↔code edge on a fixture corpus,
+   all passing the shipped judge stage; contradictions stage exercised.
+3. **Reflection.** An idle fire over a fixture `session_summary` batch produces
+   synthesis candidates into the promotion pipeline; `reflected_at` stamped;
+   dedup holds across two consecutive fires.
+4. **Gate.** Shadow mode emits scored-but-unpromoted candidates; the fixture gate
+   blocks a deliberately-poor sidecar from canary; the default flip is a recorded
+   bandit decision, not a config edit.
+5. **CPU-first install.** A reference sidecar honoring the contract runs with no
+   cloud dependency and installs via the existing curator-profile path.
+6. **Validation-pending, stated as such.** Real-corpus precision/usefulness numbers
+   are a dogfood deliverable (§5); this proposal ships the plumbing + fixtures and
+   reports corpus-scale quality as *validation-pending*, not done.
+
+## Explicitly out of scope / does not re-propose
+
+- The curator stage machine, queue/drain, versioning, judge, promotion, and
+  calibration/bandit rails — all shipped; reused verbatim.
+- Non-file source ingestion (Jira/Slack/email/Drive/…) — that on-ramp is the
+  sibling proposal `org-data-connectors-and-source-ingestion.md`; this proposal
+  makes extraction real, that one makes the corpus wide. They compose but ship
+  independently.
+- Any change to the typed-fact ontology or write gate — relationship candidates
+  ride the existing `rel_types` gate unchanged.

--- a/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
+++ b/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
@@ -1,7 +1,8 @@
 # Proposal: LLM-sidecar productionization — graduate curator extraction and idle reflection from stub to production
 
-- **State:** PENDING — design only. Finishes two already-shipped-but-stubbed
-  intelligence steps that ride the shared `kb_curator_sidecar` mechanism. Adds no
+- **State:** PENDING — design only, no code in this PR. Finalises two
+  scaffolded-but-stubbed intelligence steps that ride the shared
+  `kb_curator_sidecar` mechanism. Adds no
   new subsystem: it wires the existing curator extract/synthesize/judge stages and
   the existing idle-reflection scheduler onto a production sidecar, behind a
   calibrated gate. Continuation of **Deep Curator: Doc and Code Extraction**

--- a/docs/proposals/pending/org-data-connectors-and-source-ingestion.md
+++ b/docs/proposals/pending/org-data-connectors-and-source-ingestion.md
@@ -1,0 +1,188 @@
+# Proposal: Org-data connectors — the source-ingestion on-ramp for the every-domain KB
+
+- **State:** PENDING — design only. Adds the missing *front door* to the shipped
+  ingest pipeline: a connector layer that pulls documents from the systems where an
+  organization's non-code knowledge actually lives (issue trackers, chat, email,
+  doc stores, wikis) and hands them to the existing Normalize → curator →
+  promote pipeline. Builds on **Ingest Lab and Strategy-Aware Chunking** (Accepted,
+  Phase 0 shipped — `aimee kb lab`), the **Corpus Staged Processing Pipeline**
+  (Done — `corpus_processing_jobs`, `aimee kb pipeline`), **Structured PDF
+  Ingestion** (Done), and the credential vault (**cred-vault-consolidation**,
+  `git_host_cred.c`, `git_oauth_github.c` — Done). Does **not** re-propose ingest,
+  chunking, the stage machine, or extraction — it feeds them.
+- **Author:** JBailes
+- **Date:** 2026-07-07
+- **Charter roles:** Extract (Normalize/Ingest stage — the connector is the source
+  half of Normalize), Classify-Score (source-kind + document-kind classification at
+  intake), Enforce (per-connector auth, PII, and scope gating on the ingest hot
+  path — fail closed), Gate-Promote (staging → release gating per source, reusing
+  the curator's release gate), Persist (durable per-source sync cursors and
+  provenance). Cites the Architecture Charter; the connector output enters the
+  charter's one data pipeline at Normalize.
+
+## Thesis
+
+KNOWLEDGE.md's premise is a *whole-company* knowledge base — §1 promises aimee
+ingests "prose, code, API specs, runbooks, design docs, tickets, meeting notes, and
+policies" across "engineering, product, sales, support, operations, legal, and
+finance," and §4's cross-domain reasoning ("connect a **support** pattern to the
+**engineering** root cause, or a **sales** commitment to the **roadmap**") only
+works if support tickets, sales notes, and roadmap docs are all *in the graph*.
+
+Today there is **no way to get that data in**. The shipped ingest surface is
+file-, PDF-, and code-oriented: Ingest Lab normalizes and chunks *what is handed
+to it*, the corpus pipeline drains *documents already seeded* into
+`corpus_processing_jobs`, but **nothing pulls from a source system**. A grep of the
+tree confirms it: Jira, Confluence, Slack, Gmail, Google Drive, Zendesk, and Notion
+appear only in prose, never in code — there is no connector, no incremental sync,
+no per-source auth wiring, and no proposal that owns this gap.
+
+The result is a real capability with an empty corpus for every non-file domain. The
+mechanism (one graph, hybrid recall, cross-domain synthesis) is built; the on-ramp
+is not. This proposal is that on-ramp: a small, uniform **connector contract** plus
+a first set of adapters, incremental sync, and ingest-time enforcement — routing
+everything into the pipeline that already exists downstream.
+
+## Goal
+
+1. **One connector contract** — a uniform adapter interface (`connector_kind`,
+   `list_since(cursor)`, `fetch(ref)`, `to_document()`) so every source looks
+   identical to the Normalize stage, and a new source is a small adapter, not a
+   pipeline change.
+2. **A first adapter set** that covers the domains §1 names: an issue tracker, a
+   chat source, a doc/wiki store, and email — chosen for breadth of domain
+   coverage, not vendor completeness.
+3. **Incremental sync** — durable per-source cursors so re-runs pull only new/
+   changed items, with supersession (not duplication) on edited source records.
+4. **Ingest-time enforcement** — per-connector auth from the existing vault, a
+   source→scope mapping (which shared/`workspace` scope a source lands in), and PII
+   / poison gating on the intake path before anything reaches the curator.
+5. **Zero new downstream** — connector output enters at Normalize and rides the
+   shipped chunking → staged pipeline → curator → promotion path unchanged.
+
+## §0 What already exists (so we don't rebuild it)
+
+- **Normalize + chunking.** Ingest Lab (`aimee kb lab`) — document-kind-aware
+  chunking, quality signals, stage recommendations (Phase 0 shipped). This is the
+  stage a connector feeds.
+- **Staged pipeline.** `corpus_processing_jobs` + `aimee kb pipeline` — the
+  resumable per-document stage machine with doc-ingest seeding and deterministic
+  drain (Done). Connectors seed it.
+- **Structured document intake.** Structured PDF ingestion + evidence layer, corpus
+  structural analysis (`document_sections`, `document_references`, staleness) —
+  Done. Applies to connector-sourced docs the same way.
+- **Credential vault + OAuth.** The server vault (`git_host_cred.c`), GitHub OAuth
+  device flow (`git_oauth_github.c`), and cred-vault-consolidation (Done) — the
+  auth-storage substrate connectors reuse for per-source tokens; the device-flow
+  pattern generalizes to per-connector OAuth.
+- **Ingest safety.** The **Ingest poison gate** (Done — Layer-1 deterministic
+  pattern gate, five threat categories, obfuscation-aware normalizer, shadow mode)
+  and the typed-fact PII sensitivity tiers — the enforcement this proposal wires
+  onto the connector intake path.
+- **Scope lattice.** `global > workspace > project > user` with the audited public
+  access contract (Memory Public Contract, Done) — the destination scopes a
+  source→scope mapping targets.
+
+## §1 The connector contract
+
+A connector is a small adapter implementing one interface; the pipeline never knows
+which source it came from:
+
+- `connector_kind` — stable id (`jira`, `slack`, `confluence`, `imap`, …).
+- `list_since(cursor) → [ref, …]` — enumerate items changed since the durable
+  cursor (§3); no full re-scan on re-run.
+- `fetch(ref) → raw` — pull one item's content + metadata.
+- `to_document(raw) → document` — map to the pipeline's document shape (body,
+  source metadata, author, timestamps, stable `source_uri`), so Normalize and every
+  downstream stage treat it identically to a file or PDF.
+
+The adapter is intentionally thin: no extraction, no chunking, no dedup — those are
+downstream and shipped. This keeps "add a source" cheap and keeps all intelligence
+in one place (the curator), per the charter's single-pipeline rule.
+
+## §2 First adapter set (domain breadth, not vendor completeness)
+
+Four adapters, each covering a domain §1 names that has no on-ramp today:
+
+- **Issue tracker** (e.g. Jira/GitHub Issues) — product/engineering tickets and
+  their decisions.
+- **Chat** (e.g. Slack) — operations/support tacit knowledge; thread-aware
+  `to_document` so a thread is one document, not N fragments.
+- **Doc / wiki** (e.g. Confluence/Notion) — policies, runbooks, design docs.
+- **Email** (IMAP) — sales/legal/finance correspondence; the lowest-common-
+  denominator source, provable without a vendor account.
+
+Selection criterion is **domain coverage** so §4's cross-domain examples become
+demonstrable end-to-end; additional vendors are later adapters against the same
+contract, not new proposals.
+
+## §3 Incremental sync + supersession
+
+- **Durable cursor per source** (`connector_sync_cursors` in DB2) — last-seen
+  watermark (timestamp or opaque token) so `list_since` pulls only the delta.
+- **Supersession, not duplication** — an edited source record maps to the same
+  `source_uri`; re-ingest supersedes the prior document (reusing the corpus
+  pipeline's existing supersession/versioning), so recall doesn't accumulate stale
+  copies. Aligns with the MinHash-LSH near-dup / supersession machinery already in
+  the sketch layer (Done).
+- **Resumable** — a sync run is itself a job so an interrupted pull resumes, matching
+  the corpus pipeline's resumability discipline.
+
+## §4 Ingest-time enforcement (fail closed)
+
+Every connector item passes three gates *before* the curator sees it:
+
+1. **Auth** — per-connector credentials from the server vault; OAuth via the shipped
+   device-flow pattern where the source supports it. No plaintext tokens outside the
+   vault.
+2. **Source → scope mapping** — an operator declares which scope a source lands in
+   (e.g. a support Slack channel → `workspace`; a personal mailbox → `user`).
+   Unmapped source ⇒ most-restrictive scope by default, never `global`. This is the
+   privacy boundary the multi-tenant KB depends on (cf. the db1/db2 scope-correctness
+   rule in `memory-db1-db2-architecture.md`).
+3. **PII + poison** — the shipped ingest poison gate runs on connector intake in
+   shadow first, then enforcing; PII sensitivity tiers apply so a connector can be
+   pinned to withhold personal facts from shared scopes. Unknown/learned relations
+   fail closed to the restrictive tier, as the typed-fact layer already does.
+
+## §5 Operator surface
+
+- `aimee kb connect <kind> …` — register a source (auth + source→scope mapping),
+  stored like a git-host credential.
+- `aimee kb sync <source>` — run/refresh a pull; `--dry-run` previews the delta and
+  enforcement decisions through Ingest Lab without seeding the pipeline.
+- `aimee kb sources` — list configured sources, cursors, last-sync, item counts.
+- A `sync` can be scheduled by the existing routine/cron surface — no new scheduler.
+
+## Acceptance criteria
+
+1. **Contract.** The connector interface is documented; two adapters from §2
+   implement it with no pipeline change beyond registration.
+2. **End-to-end.** A fixture source (e.g. a local IMAP/maildir and a canned issue
+   export) ingests through connector → Normalize → staged pipeline → curator, and
+   the items are recallable, with `source_uri`/provenance intact.
+3. **Incremental.** A second sync over an unchanged source pulls zero items; an
+   edited item supersedes (not duplicates) its prior document.
+4. **Enforcement.** An unmapped source lands in the restrictive scope, never
+   `global`; the poison gate blocks a planted adversarial item; a PII-tiered fact
+   is withheld from a shared-scope recall in a fixture test.
+5. **Auth hygiene.** Credentials live only in the vault; a `--dry-run` never writes
+   to the pipeline.
+6. **Cross-domain demo (validation-pending).** With an issue-tracker source and a
+   code corpus both ingested, a §4-style query ("connect this support/issue pattern
+   to the code that implements it") returns a citation-backed cross-source answer.
+   Real-org quality is a dogfood deliverable and reported as *validation-pending*,
+   not done — this proposal ships the on-ramp and fixtures.
+
+## Explicitly out of scope / does not re-propose
+
+- Normalize/chunking, the staged pipeline, extraction, promotion, PII tiers, poison
+  gate, and the vault — all shipped; reused verbatim.
+- Making curator extraction/reflection actually synthesize over this wider corpus —
+  that is the sibling proposal
+  `llm-sidecar-productionization-curator-and-reflection.md`. This proposal makes the
+  corpus *wide*; that one makes extraction *real*. They compose but ship
+  independently, and both are needed before §4's whole-company reasoning is true in
+  the build.
+- Vendor-exhaustive connector coverage — beyond the first four, each new source is a
+  thin adapter against the §1 contract, not a new proposal.

--- a/docs/proposals/pending/org-data-connectors-and-source-ingestion.md
+++ b/docs/proposals/pending/org-data-connectors-and-source-ingestion.md
@@ -1,7 +1,8 @@
 # Proposal: Org-data connectors — the source-ingestion on-ramp for the every-domain KB
 
-- **State:** PENDING — design only. Adds the missing *front door* to the shipped
-  ingest pipeline: a connector layer that pulls documents from the systems where an
+- **State:** PENDING — design only, no code in this PR. Adds the missing
+  *front door* to the existing ingest pipeline: a connector layer that pulls
+  documents from the systems where an
   organization's non-code knowledge actually lives (issue trackers, chat, email,
   doc stores, wikis) and hands them to the existing Normalize → curator →
   promote pipeline. Builds on **Ingest Lab and Strategy-Aware Chunking** (Accepted,


### PR DESCRIPTION
## What

Two pending proposals that close the gaps between `docs/KNOWLEDGE.md`'s claims and what actually ships in the tree today.

### 1. LLM-Sidecar Productionization: Curator Extraction and Idle Reflection
Finishes two intelligence steps that ship as full scaffolding but stub the LLM call:
- **Curator extraction** — every stage ships (`kb_curator_extract.c`, `_judge`, `_synthesize`, `_link_artifacts`, `_contradictions`, …) but only the Phase-0 embedding sidecar exists behind `kb_curator_sidecar_run`.
- **Idle reflection** — `kb_reflection.c`'s scheduler runs fully; its own header states LLM candidate generation is *stubbed pending charter sidecar integration*.

Defines one versioned sidecar contract both consumers share, lands the doc↔code `implements` bridge through the existing `rel_types` gate, and rolls out via the **shipped** calibration + bandit rails (shadow → canary → default). Reuses the stage machine/promotion/calibration rather than re-proposing them.

### 2. Org-Data Connectors and Source Ingestion
The gap with no prior proposal: KNOWLEDGE.md §1/§4 promise a whole-company KB across tickets, chat, email, wikis — but nothing pulls from a source system (Jira/Slack/Gmail/Drive/Confluence appear only in prose). Adds a thin connector contract, a first adapter set (issue tracker / chat / doc-wiki / email), incremental sync with supersession, and ingest-time auth + scope + PII/poison enforcement — all feeding the shipped Normalize → staged-pipeline → curator path unchanged.

Both match the repo proposal format (Charter roles, Thesis, Goal, §0 What already exists, phased §§, acceptance criteria, explicit does-not-re-propose), are cross-linked as siblings, and are honest that corpus-scale quality is validation-pending. Registered in `PROPOSALS.md` under the evidence-pipeline cluster.

## Scope
Docs only — no code changes.