### PR TITLE
fix(server): seal GUI/CLI-added delegate keys into the shared server vault by default

### DIFF
--- a/src/headers/vault_capability.h
+++ b/src/headers/vault_capability.h
@@ -46,6 +46,20 @@ extern "C"
     * holds vault:write:server. The single source of truth for the gate. */
    int vault_capability_server_write_allowed(attested_transport_t transport, const char *principal);
 
+   /* May a connection with this attested transport seal an agent's OWN api key into
+    * the shared server vault (`agent add`/`agent set --key`)? A delegate defined in
+    * agents.json is SHARED server config whose key resolves from the server vault at
+    * run time (agent_config.c agent_vault_get), so it must land there for the agent
+    * to work for every connection and autonomous turn — a per-user vault entry can't
+    * serve those and is LOCKED on a fresh install. Sealing a delegate's OWN key is
+    * no broader than adding the delegate (both shared-config writes the same request
+    * performs), so this needs NO vault:write:server grant — deliberately WIDER than
+    * vault_capability_server_write_allowed, which still gates the arbitrary-cred
+    * `vault set --server`. Returns 1 for native-TLS bearer, mTLS client,
+    * server.token-trusted webchat, and local UDS; 0 for plaintext TCP bearer (D2b:
+    * never mint a server credential over an unencrypted channel) and un-attested. */
+   int vault_agent_key_server_seal_allowed(attested_transport_t transport);
+
    /* Test seam: override the store path (NULL resets to the default). */
    void vault_capability_set_path_for_test(const char *path);
 

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -10,9 +10,9 @@
 #include "cJSON.h"
 #include "json_fluent.h" /* jo_ok */
 #include "log.h"
-#include "vault_service.h"    /* vault_service_set / set_server, VAULT_API_KEY_CRED */
-#include "vault_capability.h" /* vault_capability_server_write_allowed (single server-write gate) */
-#include "server_cli_oauth.h" /* server-hosted OAuth CLI agent setup */
+#include "vault_service.h"    /* vault_service_set_server, VAULT_API_KEY_CRED */
+#include "vault_capability.h" /* vault_agent_key_server_seal_allowed (agent-key server-vault gate) */
+#include "server_cli_oauth.h"     /* server-hosted OAuth CLI agent setup */
 #include "provider_cli_adapter.h" /* provider_cli_adapter_get: declared CLI caps */
 #include "config.h"               /* config_load / config_t */
 #include <pthread.h>
@@ -632,46 +632,23 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
       else
       {
-         /* Where the client-supplied key lands depends on whether the conn may mint
-          * a SHARED server credential (vault_capability_server_write_allowed — the
-          * single gate handle_vault_set_server also uses):
-          *  - authorized to server-write (native-TLS+bearer, OR a capability-granted
-          *    principal: an attested webchat webuser:/UDS uid: holding
-          *    vault:write:server) -> the server-owned vault, so the key works for
-          *    ALL connections/delegate turns automatically. This is how an attested
-          *    webchat user provisions a delegate key over the HTTPS GUI without the
-          *    /v1 bearer ever entering webchat — the grant is the audited, revocable
-          *    authority.
-          *  - any other per-user principal (UDS uid: / webchat webuser: WITHOUT the
-          *    grant) -> the caller's own dual-access vault (requires it unlocked).
-          *  - no principal and not server-write-authorized (plaintext TCP, or an
-          *    un-attested conn e.g. UDS uid 0) -> REFUSED (D2b); never write the
-          *    secret to agents.json. */
-         const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
+         /* A delegate's key is SHARED server config: seal it into the server vault
+          * (see vault_agent_key_server_seal_allowed) so it works for every connection and
+          * every autonomous turn from a default install — no unlock, no grant. Only
+          * an un-attested / plaintext-TCP conn is refused (D2b). */
          attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
-         int server_write = vault_capability_server_write_allowed(transport, principal);
-         if (!server_write && !principal)
+         if (!vault_agent_key_server_seal_allowed(transport))
             return server_send_error(
                 conn,
                 "vault: `agent add --key` over a plaintext connection cannot store a credential; "
                 "use a native-TLS (https) connection, or an attested local/webchat connection",
                 NULL);
-         vault_status_t vst = server_write
-                                  ? vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key)
-                                  : vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key,
-                                                      (long)time(NULL));
+         vault_status_t vst = vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
          if (vst != VAULT_OK)
-         {
-            if (vst == VAULT_ERR_LOCKED)
-               return server_send_error(
-                   conn, "vault locked: run `aimee vault unlock` before adding a key", NULL);
             return server_send_error(conn, "could not store credential in the vault", NULL);
-         }
          /* A server-vault write (shared credential) is a minting event: audit it
-          * identically to handle_vault_set_server so it is never silent. A per-user
-          * dual-access write is the caller's own vault. */
-         if (server_write)
-            vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
+          * identically to handle_vault_set_server so it is never silent. */
+         vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
          ag->api_key[0] = '\0';      /* the secret lives only in the vault */
          ag->api_key_disk[0] = '\0'; /* and nothing goes to agents.json */
       }
@@ -1101,27 +1078,20 @@ int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
       else
       {
-         const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
+         /* Re-keying a delegate: seal into the shared server vault exactly as
+          * `agent add` does (vault_agent_key_server_seal_allowed), so a default install
+          * works with no unlock/grant. Only un-attested / plaintext-TCP is refused. */
          attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
-         int server_write = vault_capability_server_write_allowed(transport, principal);
-         if (!server_write && !principal)
+         if (!vault_agent_key_server_seal_allowed(transport))
             return server_send_error(
                 conn,
                 "vault: `agent set --key` over a plaintext connection cannot store a credential; "
                 "use a native-TLS (https) or attested local/webchat connection",
                 NULL);
-         vault_status_t vst = server_write
-                                  ? vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key)
-                                  : vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key,
-                                                      (long)time(NULL));
+         vault_status_t vst = vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
          if (vst != VAULT_OK)
-            return server_send_error(conn,
-                                     vst == VAULT_ERR_LOCKED
-                                         ? "vault locked: run `aimee vault unlock` before re-keying"
-                                         : "could not store credential in the vault",
-                                     NULL);
-         if (server_write)
-            vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
+            return server_send_error(conn, "could not store credential in the vault", NULL);
+         vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
       }
    }
 

--- a/src/server/vault_capability.c
+++ b/src/server/vault_capability.c
@@ -250,6 +250,17 @@ int vault_capability_server_write_allowed(attested_transport_t transport, const 
    return attested && vault_capability_has(principal);
 }
 
+int vault_agent_key_server_seal_allowed(attested_transport_t transport)
+{
+   /* See the header for the rationale: an agent's OWN key is shared server config,
+    * so ANY attested confidential channel may seal it — no per-principal grant, and
+    * so no store lookup here. Wider than the server-write gate above (which still
+    * requires a grant for UDS/webchat) and also admits a verified mTLS client. Only
+    * a plaintext TCP bearer (D2b) and an un-attested conn are refused. */
+   return transport == ATTEST_TLS_BEARER || transport == ATTEST_MTLS_CLIENT ||
+          transport == ATTEST_WEBCHAT_TRUSTED || transport == ATTEST_UDS_PEERCRED;
+}
+
 int vault_capability_has(const char *principal)
 {
    if (!principal_valid(principal))

--- a/src/tests/test_vault_capability.c
+++ b/src/tests/test_vault_capability.c
@@ -48,6 +48,17 @@ int main(void)
    assert(vault_capability_server_write_allowed(ATTEST_UDS_PEERCRED, "uid:1000") == 0);
    assert(vault_capability_server_write_allowed(ATTEST_UDS_PEERCRED, "") == 0);
 
+   /* the agent-key server-seal gate: purely transport-based, NO grant needed
+    * (deliberately wider than the server-write gate above), so a default install
+    * seals a GUI/CLI-added delegate key without provisioning a capability first.
+    * uid:1000 is NOT granted, yet its UDS transport is still allowed here. */
+   assert(vault_agent_key_server_seal_allowed(ATTEST_TLS_BEARER) == 1);
+   assert(vault_agent_key_server_seal_allowed(ATTEST_MTLS_CLIENT) == 1);
+   assert(vault_agent_key_server_seal_allowed(ATTEST_WEBCHAT_TRUSTED) == 1); /* the HTTPS GUI */
+   assert(vault_agent_key_server_seal_allowed(ATTEST_UDS_PEERCRED) == 1);    /* local CLI */
+   assert(vault_agent_key_server_seal_allowed(ATTEST_TCP_BEARER) == 0);      /* D2b: plaintext */
+   assert(vault_agent_key_server_seal_allowed(ATTEST_NONE) == 0);
+
    /* validation: empty / NULL / multi-line principals are rejected */
    assert(vault_capability_grant("") == -1);
    assert(vault_capability_grant(NULL) == -1);
@@ -56,6 +67,7 @@ int main(void)
 
    vault_capability_set_path_for_test(NULL);
    unlink(path);
-   printf("PASS: vault_capability grant/revoke/has/list + whole-line + validation\n");
+   printf("PASS: vault_capability grant/revoke/has/list + whole-line + validation + "
+          "agent-key server-seal gate\n");
    return 0;
 }


### PR DESCRIPTION
## Problem

Adding a delegate with a literal `--key` through the webchat GUI (or the local CLI) fails on a **default install** with:

> server: vault locked: run `aimee vault unlock` before adding a key

## Root cause

#1114 gated the shared server-vault write behind a `vault:write:server` capability grant that is **empty by default** (a deferred manual deploy step). With no grant, `handle_agent_add` fell through to the caller's **per-user** vault — locked on a fresh install. That fallback was also wrong on its own terms: a delegate in `agents.json` is shared server config whose key resolves from the **server** vault at run time (`agent_config.c:agent_vault_get`), so a per-user entry can never serve an autonomous or another-user delegate turn.

## Fix

New gate `vault_agent_key_server_seal_allowed(transport)`: `agent add`/`agent set --key` seal the key into the **shared server vault** for any *attested* connection (native-TLS bearer, mTLS, server.token-trusted webchat, or local UDS) — **no grant, no unlock**. The server vault is keyed off the server master key the process already holds, so a default install works out of the box. Only plaintext-TCP / un-attested is refused (D2b preserved).

Deliberately **wider** than `vault_capability_server_write_allowed`, which still gates `vault set --server` (minting arbitrary named server credentials). Sealing a delegate's *own* key is no broader a capability than adding the delegate itself — both are shared-config writes the same request already performs.

> **Security note for review:** this intentionally reverses #1114's opt-in posture — any authenticated webchat user can now seal a delegate's key into the shared server vault without a per-user grant. Rationale is documented in the `vault_capability.h` header.

## Changes

- `server_agent.c` — both `handle_agent_add` and `handle_agent_set` route literal keys to `vault_service_set_server` when the transport is attested; per-user path and the now-unreachable `VAULT_ERR_LOCKED` branch removed; all server-vault writes audited.
- `vault_capability.{c,h}` — add `vault_agent_key_server_seal_allowed`.
- `test_vault_capability.c` — pin the transport matrix.

## Verification (real red → green, fresh `AIMEE_HOME`, no `.vault`/grant)

- **RED** (stock binary): `agent add --key` → `vault locked: run aimee vault unlock…` (rc=1) — exactly the reported error.
- **GREEN** (fixed binary): `Delegate saved` (rc=0); `.vault` created holding the **server** vault file; no plaintext leak in `agents.json`.
- `aimee` + `aimee-server` build clean under `-Werror`; new unit test + 11 other vault/agent tests pass.

## Deploy follow-up

The live .254 stack runs the old `aimee-server` image; the deployed GUI won't reflect this until that plugin image is rebuilt/updated.