### PR TITLE
feat(bench): dynamic-alpha fusion A/B harness + user-selectable-fusion-mode proposal

### DIFF
--- a/benchmarks/kb/dynamic-alpha/README.md
+++ b/benchmarks/kb/dynamic-alpha/README.md
@@ -1,0 +1,50 @@
+# Dynamic-alpha fusion benchmark
+
+Measures whether the `dynamic_alpha` fusion mode improves retrieval over the
+`rrf` baseline (and `static_alpha`) on a labelled query set — reporting the
+**per-shape better/worse split**, not a single average, because dynamic alpha is
+expected to be a *mixed* result: win on lexical/identifier queries without
+regressing semantic ones.
+
+## Run
+
+```sh
+# against a live aimee-kb (POST /v1/search); no third-party deps
+python3 run.py --endpoint http://127.0.0.1:8741 --project aimee --k 5 --out report.json
+
+# remote KB over the LAN
+python3 run.py --endpoint http://192.168.1.254:8741 --project aimee
+# add --bearer <token> if the endpoint requires one
+```
+
+Exit code is non-zero if `dynamic_alpha` regresses a `false_positive_guard` /
+`regression` fixture versus `rrf` — so it can gate CI once a stable corpus exists.
+
+## Files
+
+- `fixtures.json` — the charter query set (3 `positive`, 2 `false_positive_guard`,
+  2 `regression`), each with an `expected_top_path_substring`.
+- `run.py` — the A/B runner (this harness).
+- `before_report.json` / `after_report.json` — the 2026-05-03 spike run.
+
+## Known limitations before this yields a verdict
+
+The 2026-05-03 closeout ("gate not met, default stays `rrf`") was made on **empty
+data** (Qdrant D-state, no corpus). Re-running today surfaced two blockers to fix
+before the harness produces a real go/no-go:
+
+1. **Corpus health.** `POST /v1/search` is the fusion path (`kb_search_fused`), and
+   it applies the mode correctly (`fusion_mode_used` reflects the request). But on
+   a KB whose doc-embed/curator drain has been wedged, doc embeddings are
+   incomplete and retrieval is undiscriminative (flat ~0.03 scores, one artifact
+   dominating) — every fixture misses in every mode. Run only against a KB whose
+   curator has fully drained (see the curator-drain lease fix).
+2. **Doc-only surface vs. code fixtures.** `/v1/search` ranks `doc_chunk`s from
+   `kb_documents`; three fixtures (`lexical_*`) expect **code** files
+   (`config_learning.c`, `kb.c`) that live in `code_embeddings`, not the doc
+   corpus, so they can never match here. Either point those fixtures at
+   proposal/doc targets that exist in the doc corpus, or add a code-search variant
+   of the harness against `/v1/code/*`.
+
+Until (1) is cleared on the target KB, treat an all-miss result as
+*inconclusive*, not as evidence against dynamic alpha.

--- a/benchmarks/kb/dynamic-alpha/run.py
+++ b/benchmarks/kb/dynamic-alpha/run.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Dynamic-alpha fusion A/B benchmark.
+
+Runs each fixture query against a live aimee-kb `POST /v1/search` in one or more
+fusion modes (rrf / static_alpha / dynamic_alpha), scores the ranked hits against
+`expected_top_path_substring`, and reports — per query and per fixture *shape* —
+whether dynamic_alpha helped, hurt, or was neutral versus the rrf baseline.
+
+The whole point (per the charter fixtures) is that dynamic alpha is expected to be
+a *mixed* result: it should win on `positive` (lexical/identifier) queries without
+regressing the `false_positive_guard` (semantic) and `regression` canaries. This
+harness measures exactly that split instead of a single average.
+
+Usage:
+    python3 run.py --endpoint http://127.0.0.1:8741 --project aimee
+    python3 run.py --endpoint http://192.168.1.254:8741 --k 5 --out report.json
+
+No third-party deps (urllib only), so it runs anywhere python3 does — the .254
+host, CI, or a laptop with LAN access to the KB.
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+MODES = ["rrf", "static_alpha", "dynamic_alpha"]
+BASELINE = "rrf"
+
+
+def search(endpoint, project, query, mode, k, bearer=None, timeout=45):
+    """POST /v1/search; return (ordered list of hit paths, fusion_mode_used, alpha)."""
+    body = json.dumps(
+        {"query": query, "project": project, "max_results": k, "fusion_mode": mode}
+    ).encode()
+    req = urllib.request.Request(
+        endpoint.rstrip("/") + "/v1/search", data=body, method="POST"
+    )
+    req.add_header("Content-Type", "application/json")
+    if bearer:
+        req.add_header("Authorization", "Bearer " + bearer)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            data = json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        return None, "http_%d" % e.code, None
+    except Exception as e:  # noqa: BLE001 — a bad query shouldn't abort the sweep
+        return None, "error:%s" % e, None
+    hits = data.get("hits") or data.get("results") or []
+    paths = [
+        (h.get("artifact_id") or h.get("path") or h.get("file") or h.get("node_key") or "")
+        for h in hits
+    ]
+    return paths, data.get("fusion_mode_used", mode), data.get("fusion_alpha")
+
+
+def first_rank(paths, needle):
+    """1-based rank of the first hit whose path contains needle, or None."""
+    for i, p in enumerate(paths):
+        if needle and needle in p:
+            return i + 1
+    return None
+
+
+def verdict(base_rank, cand_rank):
+    """Compare a candidate mode's rank against the baseline's (lower rank = better)."""
+    if base_rank is None and cand_rank is None:
+        return "both_miss"
+    if cand_rank is None:
+        return "worse"  # baseline found it, candidate didn't
+    if base_rank is None:
+        return "better"  # candidate found it, baseline didn't
+    if cand_rank < base_rank:
+        return "better"
+    if cand_rank > base_rank:
+        return "worse"
+    return "same"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Dynamic-alpha fusion A/B benchmark")
+    here = os.path.dirname(os.path.abspath(__file__))
+    ap.add_argument("--endpoint", default="http://127.0.0.1:8741",
+                    help="aimee-kb base URL (POST /v1/search)")
+    ap.add_argument("--project", default="aimee", help="KB project scope")
+    ap.add_argument("--fixtures", default=os.path.join(here, "fixtures.json"))
+    ap.add_argument("--k", type=int, default=5, help="cutoff for P@k / hit@k")
+    ap.add_argument("--modes", default=",".join(MODES),
+                    help="comma-separated fusion modes to run")
+    ap.add_argument("--bearer", default=os.environ.get("AIMEE_KB_BEARER"),
+                    help="optional bearer token for the KB endpoint")
+    ap.add_argument("--out", default=None, help="write the full JSON report here")
+    args = ap.parse_args()
+
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+    with open(args.fixtures) as f:
+        fixtures = json.load(f)["fixtures"]
+
+    per_fixture = []
+    agg = {m: {"hit1": 0, "hitk": 0, "mrr": 0.0, "used": None} for m in modes}
+    for fx in fixtures:
+        q, needle, shape = fx["query"], fx.get("expected_top_path_substring", ""), fx.get("shape", "")
+        row = {"id": fx["id"], "shape": shape, "query": q, "expected": needle, "modes": {}}
+        for m in modes:
+            paths, used, alpha = search(args.endpoint, args.project, q, m, args.k, args.bearer)
+            rank = first_rank(paths or [], needle)
+            agg[m]["used"] = used
+            if rank == 1:
+                agg[m]["hit1"] += 1
+            if rank is not None and rank <= args.k:
+                agg[m]["hitk"] += 1
+                agg[m]["mrr"] += 1.0 / rank
+            row["modes"][m] = {"rank": rank, "used": used, "alpha": alpha,
+                               "top": (paths or [])[:3]}
+        # dynamic-vs-baseline verdict, if both present
+        if BASELINE in row["modes"] and "dynamic_alpha" in row["modes"]:
+            row["dynamic_vs_rrf"] = verdict(row["modes"][BASELINE]["rank"],
+                                            row["modes"]["dynamic_alpha"]["rank"])
+        per_fixture.append(row)
+
+    n = len(fixtures)
+    report = {
+        "endpoint": args.endpoint, "project": args.project, "k": args.k,
+        "n_fixtures": n,
+        "aggregate": {
+            m: {"p_at_1": round(agg[m]["hit1"] / n, 3) if n else 0.0,
+                "p_at_k": round(agg[m]["hitk"] / n, 3) if n else 0.0,
+                "mrr": round(agg[m]["mrr"] / n, 3) if n else 0.0,
+                "fusion_mode_used": agg[m]["used"]}
+            for m in modes
+        },
+        "fixtures": per_fixture,
+    }
+
+    # Per-shape dynamic-vs-rrf split — the mixed-result picture.
+    by_shape = {}
+    for row in per_fixture:
+        v = row.get("dynamic_vs_rrf")
+        if v is None:
+            continue
+        by_shape.setdefault(row["shape"], {"better": 0, "worse": 0, "same": 0, "both_miss": 0})
+        by_shape[row["shape"]][v] += 1
+    report["dynamic_vs_rrf_by_shape"] = by_shape
+
+    # --- human summary ---
+    print("Dynamic-alpha fusion A/B — %s (project=%s, k=%d, n=%d)"
+          % (args.endpoint, args.project, args.k, n))
+    print("\nAggregate (P@1 / P@k / MRR):")
+    for m in modes:
+        a = report["aggregate"][m]
+        print("  %-14s P@1=%.3f  P@%d=%.3f  MRR=%.3f  (used=%s)"
+              % (m, a["p_at_1"], args.k, a["p_at_k"], a["mrr"], a["fusion_mode_used"]))
+    print("\ndynamic_alpha vs rrf, by fixture shape:")
+    for shape, c in by_shape.items():
+        print("  %-22s better=%d worse=%d same=%d both_miss=%d"
+              % (shape, c["better"], c["worse"], c["same"], c["both_miss"]))
+    print("\nPer fixture (rank in each mode; lower is better, - = miss):")
+    for row in per_fixture:
+        ranks = "  ".join("%s=%s" % (m, row["modes"][m]["rank"] if row["modes"][m]["rank"] else "-")
+                          for m in modes)
+        print("  [%-22s %-20s] %s  -> %s"
+              % (row["shape"], row["id"], ranks, row.get("dynamic_vs_rrf", "")))
+
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(report, f, indent=2)
+        print("\nwrote %s" % args.out)
+
+    # Non-zero exit if dynamic hurt a guard/regression fixture (a real signal for CI).
+    hurt_guards = sum(
+        1 for row in per_fixture
+        if row["shape"] in ("false_positive_guard", "regression")
+        and row.get("dynamic_vs_rrf") == "worse"
+    )
+    return 1 if hurt_guards else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/proposals/pending/user-selectable-fusion-mode.md
+++ b/docs/proposals/pending/user-selectable-fusion-mode.md
@@ -1,0 +1,88 @@
+# Proposal: User-selectable retrieval fusion mode + a benchmark users run to choose it
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+There is no universally-best retrieval fusion mode. `rrf` is a safe rank-blend;
+`static_alpha` fixes a lexical/dense weight; `dynamic_alpha` predicts that weight
+per query (high alpha → boost the lexical leg for identifier/exact-token queries,
+low alpha → favour dense for prose). Which wins is **corpus- and query-mix-
+dependent** — dynamic alpha helps identifier lookups and can hurt purely semantic
+questions. The right design is therefore not "pick a default and flip it," but:
+make the mode **user-selectable**, and give the user a **benchmark they run on
+their own data** to see the tradeoff and choose — including choosing per-scope
+defaults. The engine for that benchmark now exists (`benchmarks/kb/dynamic-alpha/
+run.py`); this proposal wires it into a product surface.
+
+## Goal
+
+An operator can (1) switch the KB fusion mode among `rrf` / `static_alpha` /
+`dynamic_alpha` from the GUI, (2) run a fusion A/B benchmark against their own KB
+and query set from the same surface, and (3) see a per-shape better/worse split
+that recommends a default — set with one click. No code change to try a mode; no
+guesswork to pick one.
+
+## §0 What already exists
+
+- **All three modes are implemented + applied.** `kb_search_fused` (`kb.c:1535`)
+  honours a `fusion_mode_override` and falls back to config `kb_fusion_mode`;
+  `POST /v1/search` (`kb_http.c:1048`) reads `fusion_mode` from the request and
+  returns `fusion_mode_used`. Verified live: `rrf` vs `dynamic_alpha` produce
+  different scoring. `dynamic_alpha`'s `predict_alpha` is unit-tested
+  (`unit-test-kb-fusion`).
+- **Config field exists.** `kb_fusion_mode` (default `rrf`) + `kb_fusion_static_alpha`
+  in `config_learning.c`; `config.set` persists `aimee.yaml`.
+- **Benchmark engine exists** (this PR): `run.py` runs any labelled query set in
+  all modes against a live KB and reports the per-shape better/worse split.
+- **Settings surface exists but is typed bool/int only.** `webchat/settings.go`
+  (`settingsAllow`) + `/api/settings` + `/api/config/set` → `/v1/config/set`.
+
+The pieces are present; they are not connected into a selectable, measurable
+surface.
+
+## §1 Selectable mode (all three) in the GUI
+
+Extend the webchat settings model with an `enum` field type (options + current
+value); render it as a `<select>`. Add `kb_fusion_mode` as an allowlisted enum
+(`rrf` / `static_alpha` / `dynamic_alpha`). `config.set` already persists it, and
+the search default already reads it — so selection takes effect on the next query
+with no restart. Expose `kb_fusion_static_alpha` as a companion numeric when
+`static_alpha` is chosen.
+
+## §2 User-facing benchmark
+
+Surface the engine two ways:
+
+- **CLI:** `aimee kb fusion-bench [--fixtures FILE] [--k N]` — routes to the KB,
+  runs the modes, prints the report. `--fixtures` defaults to the charter set but
+  accepts the operator's own labelled queries (the format is a small JSON: query +
+  `expected_top_path_substring` + `shape`), so it runs on **their** corpus.
+- **GUI:** a "Tune retrieval" panel that runs the same benchmark against the
+  active KB and renders the per-shape table + aggregate P@k, with the operator's
+  saved query set (editable in the panel).
+
+## §3 Data-driven default (and per-scope defaults)
+
+The benchmark already computes which mode wins by shape; add a recommendation:
+"dynamic_alpha wins N positives, regresses 0 guards → recommend as default" (or
+the converse). Offer a one-click "set as default." Because DB2 knowledge is
+project/scope-partitioned, allow a per-scope override (`kb_fusion_mode:<scope>`)
+so a code-heavy project can run `dynamic_alpha` while a prose corpus stays `rrf`.
+
+## §4 Precondition: corpus health + a code-search variant
+
+Two honest gates (documented in the benchmark README):
+
+- The benchmark is only meaningful against a KB whose curator/doc-embed drain has
+  fully drained — on a degraded corpus every query misses in every mode
+  (inconclusive, not evidence). Gate the GUI panel on a corpus-health check.
+- `/v1/search` ranks `doc_chunk`s; identifier→code fixtures need a code-search
+  variant against `/v1/code/*`. Ship the doc benchmark first; add the code variant
+  when the code-search path grows a fusion knob.
+
+## Non-goals
+
+Not changing the fusion algorithms, and not auto-flipping a default without the
+operator's confirmation — the whole point is to put the choice, and the evidence
+for it, in the operator's hands.


### PR DESCRIPTION
## Context

Following the roadmap audit: dynamic-alpha's earlier closeout ("gate not met") was made on **empty data** (the reports literally say Qdrant was D-state and no corpus existed). This PR builds the tooling to actually evaluate it — and frames the product feature around the fact that **no fusion mode is universally best**.

## What's here

**1. Benchmark engine — `benchmarks/kb/dynamic-alpha/run.py`** (committed, runnable now)
- Runs any labelled query set against a live `aimee-kb POST /v1/search` in `rrf` / `static_alpha` / `dynamic_alpha`.
- Scores P@1/P@k/MRR and — the point — the **per-shape better/worse split** vs the rrf baseline (positive / false_positive_guard / regression), so the mixed result is visible instead of averaged away.
- No third-party deps (urllib); `--fixtures` accepts the operator's **own** queries → self-service on their corpus; non-zero exit if dynamic regresses a guard (CI-gateable).

**2. Proposal — `user-selectable-fusion-mode.md`**
- All three modes toggleable in the GUI (needs a new `enum` settings type), the benchmark surfaced to end users (CLI `aimee kb fusion-bench` + a "Tune retrieval" GUI panel), a data-driven default recommendation with per-scope overrides, and a corpus-health gate.

## Honest status of a live verdict

Verified `/v1/search` **does** apply the mode (rrf ~0.03 normalized vs dynamic_alpha rescored to 1.0). But on `.254` right now **every charter fixture misses in every mode** because (a) the doc-embed/curator drain was wedged (fixed by #1117, deploying) so retrieval is undiscriminative, and (b) three fixtures target *code* files while `/v1/search` is doc-only. Both are documented in the README; treat today's all-miss as *inconclusive*. Re-run once #1117 is deployed and the corpus has drained.