### PR TITLE
fix(kb): cycle the ingest worker's DB2 lease mid-drain (residual stuck-lease)

### DIFF
--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -214,10 +214,24 @@ static void *kbiw_worker_thread(void *arg)
        * a DB2 lease so the pooled connection is returned to the pool between
        * bursts (WP-C) instead of held for the worker thread's life. */
       db2_lease_begin();
+      long lease_started = (long)time(NULL);
       while (kbiw_claim_and_process() == 1)
       {
          if (ctx->ingest_stop)
             break;
+         /* A cold-start (or post-restart) drain can be thousands of docs, each an
+          * embed — a single burst then pins one pooled connection for minutes and
+          * trips the pool's 300s stuck-lease ceiling (observed: `member N leased
+          * >300000ms` while the corpus re-embeds). Return the connection to the
+          * pool periodically mid-drain so no single lease outlives the ceiling.
+          * Safe between items: each kbiw_claim_and_process commits its own unit,
+          * and pool connections carry no cross-lease state (DISCARD ALL on return). */
+         if ((long)time(NULL) - lease_started >= 120)
+         {
+            db2_lease_end();
+            db2_lease_begin();
+            lease_started = (long)time(NULL);
+         }
       }
       db2_lease_end();
    }


### PR DESCRIPTION
## Context

Follow-up to #1117 (the curator-drain lease wedge). After deploying #1117 the severe wedge was gone — synthesis unblocked and drained (`done` 16 → 3000+) — but a **residual single-member stuck lease** appeared on a fresh KB: `member N leased >300000ms` (growing) while the drain progressed on the pool's other members.

## Root cause

The background ingest worker (`kbiw_ingest_thread`) wraps its **entire queue drain** in one lease scope:

```c
db2_lease_begin();
while (kbiw_claim_and_process() == 1) { ... }   // thousands of docs on a cold start, each an embed
db2_lease_end();
```

The comment intends "return the connection between bursts," but a cold-start / post-restart burst re-embeds the whole doc corpus, so a single burst pins one pooled connection for minutes → past the 300s stuck-lease ceiling. And because it's an explicit `db2_lease_begin` scope, `db2_lease_release_idle()` (the #1117 guard) is deliberately a no-op inside it, so #1117's per-embed release never reaches this path. Not a full wedge (the 16-member pool absorbs it), but it can slow-leak if bursts stack.

## Fix

Return the pooled connection every ~120s **mid-drain** (`db2_lease_end()` + `db2_lease_begin()`), so no single lease outlives the ceiling — keeping the burst-lease design. Safe between items: each `kbiw_claim_and_process` commits its own unit and pool connections carry no cross-lease state (`DISCARD ALL` on return).

Compiles + links clean (`-Werror`). `kb_mining.c`'s WP-C lease is a single bounded `run_once()` per 300s poll, not an unbounded drain — left as-is.