### PR TITLE
feat(gui): selectable KB retrieval fusion mode (rrf/static_alpha/dynamic_alpha)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (139)
+## CLI-settable keys (141)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -92,6 +92,8 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `kb_api_bearer_token` | string | Bearer token for the aimee-kb API. |
 | `kb_api_http_port` | int | HTTP port the aimee-kb API listens on. |
 | `kb_evidence_emit_enabled` | bool | Emit evidence records from KB ingest. |
+| `kb_fusion_mode` | string | KB retrieval fusion mode: rrf (default), static_alpha, or dynamic_alpha. |
+| `kb_fusion_static_alpha` | float | Lexical/dense blend weight (0-1) for the static_alpha fusion mode. |
 | `kb_mining_enabled` | bool | Enable background KB mining. |
 | `kb_mining_min_poll_s` | int | Minimum interval (s) between KB mining polls. |
 | `kb_pdf_assets_enabled` | bool | Render structured-PDF figure/table crops to the content-addressed blob store + kb_doc_assets at ingest, served via open_asset (default off; needs pdftoppm). |

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,15 +1,25 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SettingsMenu } from '@rakuensoftware/smoothgui';
 import type { SettingField } from '@rakuensoftware/smoothgui';
 
 /* A gear button in the top bar that opens a dropdown of aimee runtime settings
- * (autonomous mode, etc.). The dropdown UI is the generic smoothgui
- * <SettingsMenu>; this adapter supplies the aimee-specific data + persistence
- * (the allowlisted server config via /api/settings). Changes take effect on the
- * next turn. */
+ * (autonomous mode, etc.). Bool/int fields render via the generic smoothgui
+ * <SettingsMenu>; enum fields (e.g. the KB retrieval fusion mode) render here as
+ * a native <select> so the choice works regardless of the smoothgui version.
+ * This adapter supplies the aimee-specific data + persistence (the allowlisted
+ * server config via /api/settings). Changes take effect on the next turn. */
+
+type AimeeField = {
+  key: string;
+  label: string;
+  type: string;
+  help?: string;
+  options?: string[];
+  value?: unknown;
+};
 
 export default function SettingsPanel() {
-  const [fields, setFields] = useState<SettingField[]>([]);
+  const [fields, setFields] = useState<AimeeField[]>([]);
   const [busy, setBusy] = useState('');
   const [err, setErr] = useState('');
   const [loaded, setLoaded] = useState(false);
@@ -18,9 +28,12 @@ export default function SettingsPanel() {
     if (loaded) return;
     fetch('/api/settings', { headers: { 'X-CSRF-Token': window._csrf || '' } })
       .then(r => r.json())
-      .then((d: { fields?: SettingField[] }) => { setFields(d.fields || []); setLoaded(true); })
+      .then((d: { fields?: AimeeField[] }) => { setFields(d.fields || []); setLoaded(true); })
       .catch(() => setErr('Failed to load settings'));
   }
+
+  // Load once on mount so enum controls are populated without opening the menu.
+  useEffect(load, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function setField(key: string, value: unknown) {
     setBusy(key); setErr('');
@@ -40,15 +53,34 @@ export default function SettingsPanel() {
     }
   }
 
+  const enumFields = fields.filter(f => f.type === 'enum');
+  const menuFields = fields.filter(f => f.type !== 'enum');
+
   return (
-    <SettingsMenu
-      title="Runtime settings"
-      fields={fields}
-      onChange={setField}
-      onOpen={load}
-      loading={!loaded}
-      error={err}
-      busyKey={busy}
-    />
+    <div className="aimee-settings">
+      <SettingsMenu
+        title="Runtime settings"
+        fields={menuFields as unknown as SettingField[]}
+        onChange={setField}
+        onOpen={load}
+        loading={!loaded}
+        error={err}
+        busyKey={busy}
+      />
+      {enumFields.map(f => (
+        <label key={f.key} className="aimee-setting-enum" title={f.help}>
+          <span>{f.label}</span>
+          <select
+            value={String(f.value ?? '')}
+            disabled={busy === f.key}
+            onChange={e => setField(f.key, e.target.value)}
+          >
+            {(f.options ?? []).map(o => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+      ))}
+    </div>
   );
 }

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -181,6 +181,8 @@ CFG_KEY_DESC = {
     "kb_api_bearer_token": "Bearer token for the aimee-kb API.",
     "kb_api_http_port": "HTTP port the aimee-kb API listens on.",
     "kb_evidence_emit_enabled": "Emit evidence records from KB ingest.",
+    "kb_fusion_mode": "KB retrieval fusion mode: rrf (default), static_alpha, or dynamic_alpha.",
+    "kb_fusion_static_alpha": "Lexical/dense blend weight (0-1) for the static_alpha fusion mode.",
     "kb_pdf_ingest_enabled": "Route PDF uploads through the structured geometry extractor "
     "(kb_doc_pdf) instead of plain pdftotext (default off).",
     "kb_pdf_vector_enabled": "Embed structured-PDF chunks into the isolated kb_pdf_embeddings "

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -99,6 +99,13 @@ const config_field_t config_fields[] = {
      sizeof(((config_t *)0)->memory_query_expansion_mode), 0, CFG_STRING},
     {"memory_query_expansion_k", offsetof(config_t, memory_query_expansion_k), sizeof(int), 0,
      CFG_INT},
+    /* KB retrieval fusion: rrf (default) | static_alpha | dynamic_alpha. Settable so
+     * an operator can pick a mode from the GUI/CLI; kb_search_fused reads it as the
+     * default when no per-request fusion_mode override is supplied. */
+    {"kb_fusion_mode", offsetof(config_t, kb_fusion_mode), sizeof(((config_t *)0)->kb_fusion_mode),
+     0, CFG_STRING},
+    {"kb_fusion_static_alpha", offsetof(config_t, kb_fusion_static_alpha), sizeof(double), 0,
+     CFG_FLOAT},
     {"autonomous", offsetof(config_t, autonomous), sizeof(int), 1, CFG_BOOL},
     {"cross_verify", offsetof(config_t, cross_verify), sizeof(int), 1, CFG_BOOL},
     {"ecomode", offsetof(config_t, ecomode), sizeof(int), 1, CFG_BOOL},

--- a/webchat/settings.go
+++ b/webchat/settings.go
@@ -13,10 +13,11 @@ import (
 // aimee.yaml and take effect on the next turn (the server reloads config per
 // request).
 type settingField struct {
-	Key   string `json:"key"`
-	Label string `json:"label"`
-	Type  string `json:"type"` // "bool" | "int"
-	Help  string `json:"help,omitempty"`
+	Key     string   `json:"key"`
+	Label   string   `json:"label"`
+	Type    string   `json:"type"` // "bool" | "int" | "enum"
+	Help    string   `json:"help,omitempty"`
+	Options []string `json:"options,omitempty"` // allowed values when Type=="enum"
 }
 
 var settingsAllow = []settingField{
@@ -30,6 +31,9 @@ var settingsAllow = []settingField{
 		Help: "Lower reasoning effort on simple turns."},
 	{Key: "max_iterations", Label: "Max iterations", Type: "int",
 		Help: "Tool-use loop ceiling per turn (0 = default)."},
+	{Key: "kb_fusion_mode", Label: "Retrieval fusion mode", Type: "enum",
+		Options: []string{"rrf", "static_alpha", "dynamic_alpha"},
+		Help:    "How lexical + dense KB search results are blended. dynamic_alpha adapts the weight per query (boost exact-token queries); rrf is the safe default."},
 }
 
 func settingAllowed(key string) bool {


### PR DESCRIPTION
Implements §1 of the `user-selectable-fusion-mode` proposal (#1123): make the KB fusion mode an operator-selectable setting instead of a hidden config only reachable by hand-editing `aimee.yaml`.

## Layers

- **`config_fields.c`** — register `kb_fusion_mode` (`CFG_STRING`) + `kb_fusion_static_alpha` (`CFG_FLOAT`) as settable fields, so `aimee config set kb_fusion_mode dynamic_alpha` and `/v1/config/{get,set}` accept them. `kb_search_fused` already reads `kb_fusion_mode` as the default when no per-request `fusion_mode` override is given, so a change takes effect on the **next query, no restart**.
- **`webchat/settings.go`** — add an `enum` field type (with `Options`) to the settings allowlist and expose `kb_fusion_mode` as `rrf | static_alpha | dynamic_alpha` via `/api/settings` → `/v1/config/{get,set}`.
- **`SettingsPanel.tsx`** — render enum fields as a native `<select>` (loaded on mount) so the toggle works regardless of the smoothgui `<SettingsMenu>` version; bool/int fields still render via `<SettingsMenu>`.

## Verification

- C compiles clean under `-Werror` (`config_fields.o`); clang-format clean.
- Go `go build ./...` clean; gofmt clean.
- **Frontend tsc is validation-pending** — a fresh worktree has no `frontend/node_modules`, so I could not run `tsc` locally; CI builds it. The enum-render is written defensively (its own `<select>`, no dependency on smoothgui supporting enum) precisely so it can't silently no-op if that lib lacks the type.

## Follow-ups (in the proposal, not this PR)
§2 the user-facing benchmark (`aimee kb fusion-bench` + "Tune retrieval" panel) and §3 the data-driven default recommendation. The benchmark **engine** already landed in #1123.