### PR TITLE
fix(kb): make the fusion lexical leg a real FTS search (was a duplicate dense search)

### DIFF
--- a/src/db2/kb_payload.c
+++ b/src/db2/kb_payload.c
@@ -275,6 +275,59 @@ int db2_kb_documents_hll_sources_for_hash(const char *project, const char *file_
    return n;
 }
 
+int db2_kb_documents_fts_search(const char *project, const char *query, int64_t *ids,
+                                double *scores, int max)
+{
+   if (!ids || !scores || max <= 0)
+      return -1;
+   if (!query || !query[0])
+      return 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   /* True lexical (term/FTS) leg over the generated 'simple'-config tsvector
+    * (schema.sql: kb_fts_tsv = to_tsvector('simple', content || heading_path),
+    * GIN-indexed as kb_fts_gin). This is deliberately NOT the dense pgvector
+    * search: the two legs must diverge so alpha fusion has a real lexical-vs-
+    * semantic signal to arbitrate. websearch_to_tsquery handles quoted phrases /
+    * operators, so quoted/identifier queries lean on exact term match. */
+   const int filter_project = (project && project[0]) ? 1 : 0;
+   static const char *sql_proj =
+       "SELECT id, ts_rank(kb_fts_tsv, websearch_to_tsquery('simple', ?1)) AS r"
+       " FROM kb_documents"
+       " WHERE kb_fts_tsv @@ websearch_to_tsquery('simple', ?1) AND project = ?2"
+       " ORDER BY r DESC LIMIT ?3";
+   static const char *sql_all =
+       "SELECT id, ts_rank(kb_fts_tsv, websearch_to_tsquery('simple', ?1)) AS r"
+       " FROM kb_documents"
+       " WHERE kb_fts_tsv @@ websearch_to_tsquery('simple', ?1)"
+       " ORDER BY r DESC LIMIT ?2";
+   char err[KBP_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn, filter_project ? sql_proj : sql_all, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", query);
+   if (filter_project)
+   {
+      aimee_pg_bind_text(st, "?2", project);
+      aimee_pg_bind_int(st, "?3", max);
+   }
+   else
+      aimee_pg_bind_int(st, "?2", max);
+
+   int n = 0;
+   while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      ids[n] = aimee_pg_column_int64(st, 0);
+      scores[n] = aimee_pg_column_double(st, 1);
+      n++;
+   }
+   aimee_pg_finalize(st);
+   return n;
+}
+
 int db2_kb_async_enqueue(const char *kind, int64_t document_id, const char *project)
 {
    if (!kind || !*kind || document_id <= 0)

--- a/src/db2/kb_payload.h
+++ b/src/db2/kb_payload.h
@@ -76,6 +76,13 @@ extern "C"
    int db2_kb_documents_hll_sources_for_hash(const char *project, const char *file_hash,
                                              sketch_hll_t *out);
 
+   /* Lexical (FTS) retrieval over kb_documents.kb_fts_tsv — the term-matching
+    * leg for kb_search_fused, distinct from the dense pgvector leg. Fills ids +
+    * ts_rank scores (best first, up to max), scoped by project when non-empty.
+    * Returns the count, 0 for no matches / empty query, -1 on SQL / conn error. */
+   int db2_kb_documents_fts_search(const char *project, const char *query, int64_t *ids,
+                                   double *scores, int max);
+
    /* INSERT OR IGNORE a kb_async_jobs row: (kind, document_id, project,
     * status='pending'). Used by kb_build to enqueue an async embedding
     * job for a freshly-inserted chunk. Returns 0 on success, -1 on

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -1137,16 +1137,15 @@ static int kb_fetch_doc_row(int64_t id, const char *project, kb_result_t *out)
  * RRF merge in kb_search_gather degenerates to a re-rank of one input
  * list — still a valid combined score.  Future work: add a sparse / BM25
  * vector index and route this leg through it for true hybrid retrieval. */
-static int lexical_search_via_vector(const char *project, const char *query,
-                                     const char *embedding_cmd, kb_result_t *out, int max)
+/* Lexical (FTS/term-match) retrieval leg for kb_search_fused. This is a genuine
+ * term search over kb_documents.kb_fts_tsv, NOT another dense search: previously
+ * it embedded the query and called the same pgvector search as vec_search, so the
+ * two legs were byte-for-byte identical and alpha_merge collapsed to the identity
+ * (rrf/static_alpha/dynamic_alpha all produced the same ranking). With a real
+ * lexical leg the two signals diverge and the fusion modes become meaningful. */
+static int lexical_search_fts(const char *project, const char *query, kb_result_t *out, int max)
 {
-   if (!project || !query || !query[0] || !out || max <= 0)
-      return 0;
-   const char *effective_cmd = kb_effective_embedding_cmd(embedding_cmd);
-
-   float qvec[EMBED_MAX_DIM];
-   int qdim = memory_embed_text(query, effective_cmd, qvec, EMBED_MAX_DIM);
-   if (qdim <= 0)
+   if (!query || !query[0] || !out || max <= 0)
       return 0;
 
    int64_t ids[MAX_LEXICAL_RESULTS * 2];
@@ -1154,8 +1153,7 @@ static int lexical_search_via_vector(const char *project, const char *query,
    int cap = (int)(sizeof(ids) / sizeof(ids[0]));
    if (max * 2 < cap)
       cap = max * 2;
-   int n_hits = pgvec_kb_vector_search_project(project, qvec, qdim, cap, ids, scores,
-                                               (int)(sizeof(ids) / sizeof(ids[0])));
+   int n_hits = db2_kb_documents_fts_search(project, query, ids, scores, cap);
    if (n_hits <= 0)
       return 0;
 
@@ -1611,7 +1609,7 @@ static char *kb_search_gather(const char *project, const char *query, const char
       return safe_strdup("error: out of memory");
    }
 
-   int n_lex = lexical_search_via_vector(proj, query, effective_cmd, lex_res, MAX_LEXICAL_RESULTS);
+   int n_lex = lexical_search_fts(proj, query, lex_res, MAX_LEXICAL_RESULTS);
 
    /* Dense search is mandatory; the lexical vector leg complements it. */
    float qvec[EMBED_MAX_DIM];


### PR DESCRIPTION
## The bug (code + live verified)

`kb_search_fused` blends a "lexical" leg (`lexical_search_via_vector`) and a dense leg (`vec_search`) and offers three fusion modes (`rrf` / `static_alpha` / `dynamic_alpha`). But **both legs called `pgvec_kb_vector_search_project` with the same query embedding** — the FTS index (`kb_documents.kb_fts_tsv`) was never queried. So the legs were byte-for-byte identical, `alpha_merge` collapsed to the identity (`(1-α)·x + α·x = x`), and all three modes produced identical rankings. Verified live on `.254`: **0/32 queries differentiated** across the modes. Dynamic-alpha — and the entire two-leg premise — could not function. (Full write-up: proposal `fusion-lexical-leg-is-duplicate-dense` in #1123.)

## The fix

Give the lexical leg a genuine term-match signal, so the two legs diverge:

- **`db2_kb_documents_fts_search`** (`kb_payload.c`/`.h`) — Postgres FTS over the generated `'simple'`-config `kb_fts_tsv` (GIN-indexed `kb_fts_gin`): `websearch_to_tsquery` + `ts_rank`, project-scoped, returns `(doc_id, rank)`. Mirrors the existing code-FTS path (`db2_code_index_code_search`).
- **`kb.c`** — `lexical_search_via_vector` → `lexical_search_fts`, now calling the FTS helper instead of re-running the dense pgvector search. `alpha_merge` / `rrf_merge` / `predict_alpha` are **unchanged** — they were correct, just fed two copies of one signal.

## Verification

- The FTS query runs on the live `.254` corpus (pg17) and returns **query-specific** docs the dense leg missed: "economizer gateway mutation" → `economizer-gateway-mutation.md` (0.63); "trust on first use bearer" → `COMMANDS.md` (dense returned `CMakeLists.txt`); "reciprocal rank fusion" → a fusion/graph proposal (dense returned `BENCHMARK_RESULTS.md`). The legs now diverge → the fusion modes differentiate.
- Compiles + links clean under `-Werror`; clang-format clean on the changed lines.
- **Validation-pending:** end-to-end mode A/B via `run.py` requires the image deploy — I'll rebuild `aimee-kb:testing`, re-pin `.254`, and re-run the harness to produce the first real rrf-vs-dynamic verdict.

Unblocks #1123 (harness/proposals) and #1125 (GUI mode toggle), which were scaffolding for a fusion that couldn't differ until now.