### PR TITLE
docs: match house voice across README + user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ configs are blocked before the AI can touch them. Known anti patterns raise warn
 Planning mode freezes every write until you are ready. Each session runs in its own git
 worktree, so two sessions never step on each other.
 
-**A browser workspace, not just a backend.** aimee ships its own browser UI, `aimee-webchat`:
+**A browser workspace.** aimee ships its own browser UI, `aimee-webchat`:
 chat, a live view of your code as a graph, a git project manager that clones repos and holds
 per host tokens, a full in app VS Code editor, and dashboards over what the server is doing.
 No terminal required. See [Dashboard & Logs](docs/DASHBOARD.md).
@@ -178,14 +178,14 @@ mode-0600, rotated audit ledger: `{ts, actor, tool, mode, reason_code, verdict, 
 The `reason_code` is a stable event key, never free form prose, so nothing user bearing is
 persisted. `args_hash` is a keyed HMAC-SHA256 over a per tool allowlist projection of the
 arguments: keyed so low entropy arguments cannot be recovered from the public log by
-dictionary attack, allowlisted by construction so a new tool or a new argument can never
+dictionary attack, allowlisted so a new tool or a new argument can never
 silently leak a secret or PII value into an append only log, and versioned. Auditing is
-**fail open by construction** — the log write happens after the verdict is decided, so a
+fail open: the log write happens after the verdict is decided, so a
 logging failure can never flip an allow to a block. The ledger is replayable:
 `trajectory_export` interleaves the governed actions back into the session timeline by
 timestamp, and the operator console exposes the feed at `/v1/audit/actions`.
 
-Alongside the action ledger, aimee keeps **decision records** — governable "we decided X
+Alongside the action ledger, aimee keeps **decision records**: governable "we decided X
 because Y" entries carrying status, rationale, alternatives, a revisit date, what they
 supersede, the author, and the policy they bind. At most one decision is active per scope
 (enforced by a database unique index, not just by the writer), superseding one flips the
@@ -194,9 +194,9 @@ existing recall and curator sweeps rather than rotting silently. Human sign off 
 sensitive actions are HMAC-SHA256 signed and non forgeable. Both surfaces are live in the
 [KB Console](docs/KB_CONSOLE.md) (`/v1/decisions`, `/v1/audit/actions`).
 
-Retrieval has a parallel, opt in audit chain: every KB grounded answer is reconstructible —
-which sources grounded it, at which content hashed version, and whether the answer is
-entailed by that evidence — read back through `/v1/audit/{trace,provenance,fidelity}`.
+Retrieval has a parallel, opt in audit chain: every KB grounded answer is reconstructible.
+Read back which sources grounded it, at which content hashed version, and whether the answer
+is entailed by that evidence, through `/v1/audit/{trace,provenance,fidelity}`.
 
 ### The context economizer
 
@@ -204,14 +204,14 @@ aimee runs a context economizer over both the delegate turn loop and, optionally
 primary `/v1` path, gated by a master switch and split into two tiers. The **safe tier**
 is default on: deterministic tool output condensation (keep the failing test, elide the
 passing ones; keep compiler diagnostics, drop progress), size based compression of oversized
-tool results, and folding old turn history into a rolling skeleton — recent context is never
+tool results, and folding old turn history into a rolling skeleton. Recent context is never
 touched, and the full output is spilled to disk for recovery. A measurement ledger records
 the reduction opportunity even when a lever is off, so the master switch off state provably
 reduces to zero.
 
 The **aggressive tier** is opt in and off by default: it applies the reduction to the live
 inbound request so the primary agent's own tokens shrink too. It is compress only, and
-guarded by a per session circuit breaker — if a reduced request draws an error the session
+guarded by a per session circuit breaker. If a reduced request draws an error, the session
 falls back to the pristine payload and disables reduction for its remaining turns, so one bad
 reduction can never persistently break live traffic. aimee never dispatches a reduced payload
 it cannot restore to the byte identical original. See [Settings](docs/SETTINGS.md) and
@@ -336,7 +336,7 @@ works the same way. Switch tools any time. Your memory and context stay.
 - **Team knowledge.** One shared kb distills what your whole organization knows, behind
   scoped accounts, OIDC sign on, and a per principal encrypted vault.
 - **A UI when you want one.** A browser workspace with chat, a code graph explorer, git
-  project management, an in app VS Code editor, and server dashboards — no terminal required.
+  project management, an in app VS Code editor, and server dashboards. No terminal required.
 - **Yours to run.** C services, single digit millisecond hot paths, and an inference stack
   you can run entirely on your own hardware.
 
@@ -410,9 +410,9 @@ Focused references:
 | [Workflows](docs/WORKFLOWS.md) | The composable dev lifecycle workflow engine, block catalog, and authoring |
 | [Workflow Actions](docs/WORKFLOW_ACTIONS.md) | The web page to author a proposal, run it autonomously, and watch its status/history |
 | [Dashboard & Logs](docs/DASHBOARD.md) | The web Dashboard's server-incurred metric panels, customization, the Logs (tool-action audit) tab, and the panel data architecture |
-| [Settings](docs/SETTINGS.md) | The web page for the server's typed runtime config — economizer levers, autonomous-dev knobs, tool-output condensation, and how each maps to `aimee.yaml` |
+| [Settings](docs/SETTINGS.md) | The web page for the server's typed runtime config: economizer levers, autonomous-dev knobs, tool-output condensation, and how each maps to `aimee.yaml` |
 | [Context economizer](docs/features/context-fold.md) | The two-tier token-reduction pipeline: history fold, tool-output condensation, size compression, the freeze cost guardrail, and the live-primary gateway mutation with its per-session circuit breaker |
-| [KB Console](docs/KB_CONSOLE.md) | The operator console's trust model and surfaces — Accounts (enroll/revoke/scopes/OIDC) and Governance (decision records, the policy-verdict action audit) |
+| [KB Console](docs/KB_CONSOLE.md) | The operator console's trust model and surfaces: Accounts (enroll/revoke/scopes/OIDC) and Governance (decision records, the policy-verdict action audit) |
 | [Workspace Management](docs/WORKSPACES.md) | Multi repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
 | [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token at rest, in transit to git, and in the in browser editor, and where exposure is and is not closed |

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ is traceable to the exact place on the page rather than to an unlocatable paraph
 of that spine the KB optionally recognises table cells (structured `{row, col, text}`
 lookups), renders visual crops of figures, tables, and pages into a content addressed store,
 and OCRs scanned or image only pages back through the same citation path. Each layer is its
-own opt in and degrades cleanly to the one below when its dependency is absent, and every
+own opt in and degrades to the one below when its dependency is absent, and every
 read surface honours the same document level access control as the text spine. See
 [Structured PDF](docs/STRUCTURED_PDF.md).
 

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -1,6 +1,6 @@
 # aimee-kb image synth tiers
 
-The `aimee-kb-*` image is the unified Vulkan llama.cpp stack — one runtime serving
+The `aimee-kb-*` image is the unified Vulkan llama.cpp stack: one runtime serving
 **embeddings** (`/embed`), **reranking** (`/rerank`), and **synthesis**
 (`/v1/chat/completions`) from baked-in GGUFs. Three published tiers differ only in the
 **synth model** (and its runtime profile); embed + rerank are identical within a
@@ -8,24 +8,23 @@ CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
 
 | Image | Embed / Rerank | Synth | Runtime |
 |---|---|---|---|
-| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B — **Tier A only** | CPU (`NGL=0`) |
+| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) |
 | `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 |
 | `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident |
 
 `gpu-small` and `gpu-mid` share the **same embedder + reranker** (2560-dim), so a KB
-embedded on one is byte-compatible with the other — switching the synth tier is a
+embedded on one is byte-compatible with the other. Switching the synth tier is a
 plugin **image swap**, no re-embed.
 
 ## Tier-A vs Tier-B synthesis
 
 The curator synthesizes in two tiers:
 
-- **Tier A** — mechanical extract/index passes (extract docs, chunk, tag, index).
-- **Tier B** — the reasoning passes: judge, resolve entities, reconcile contradictions,
+- **Tier A**: mechanical extract/index passes (extract docs, chunk, tag, index).
+- **Tier B**, the reasoning passes: judge, resolve entities, reconcile contradictions,
   synthesize, promote.
 
-`aimee-kb-cpu` runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider
-— a weak model would poison the graph — so a CPU-only deployment gets retrieval + Tier-A
+`aimee-kb-cpu` runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider (a weak model would poison the graph), so a CPU-only deployment gets retrieval + Tier-A
 synthesis and nothing more. **Tier B needs a GPU tier (`gpu-small` / `gpu-mid`) or an
 external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
 config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
@@ -34,9 +33,9 @@ config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
 
 Two image families share the `aimee-kb` prefix. Keep them straight:
 
-- **`aimee-kb`** (no suffix) — the KB service (DB2 + curator). Runs no model; it calls one
+- **`aimee-kb`** (no suffix): the KB service (DB2 + curator). Runs no model; it calls one
   over HTTP. See [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
-- **`aimee-kb-{cpu,gpu-small,gpu-mid}`** — the inference tiers in this doc (embed + rerank +
+- **`aimee-kb-{cpu,gpu-small,gpu-mid}`**: the inference tiers in this doc (embed + rerank +
   synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm` plugin.
 
 Retired names: `aimee-llm-cpu`/`aimee-llm-gpu` were the old tier names (now
@@ -45,20 +44,20 @@ standalone torch embedder, now baked into the tiers.
 
 ## Deploy: one plugin image swap
 
-The synth tier is chosen by which image the SmoothNAS `aimee-llm` plugin references —
+The synth tier is chosen by which image the SmoothNAS `aimee-llm` plugin references,
 e.g. `ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest` for Gemma 4 26B-A4B. No separate synth
 container, no `SYNTH_LOCAL` juggling: the tier *is* the synth.
 
 ### Two consumers of the gateway synth (`/v1/chat/completions`)
 
 The gateway (`http://<runtime-gw>:8742/v1`, model alias `aimee-synth`) is used by two
-independent callers — one automatic, one an explicit operator step:
+independent callers, one automatic, one an explicit operator step:
 
-1. **KB curator synthesis — automatic.** The `aimee-kb` plugin points `LLM_ENDPOINT` /
+1. **KB curator synthesis (automatic).** The `aimee-kb` plugin points `LLM_ENDPOINT` /
    `LLM_MODEL` at the gateway, so the curator's `tier_a`/`tier_b` use the synth tier the
    moment the image is deployed. Swapping tiers needs no KB change.
 
-2. **aimee-server delegate — an explicit runtime registration (NOT automatic).** To make
+2. **aimee-server delegate, an explicit runtime registration (NOT automatic).** To make
    the local synth usable as an `aimee` delegate (roundtable / fallback), register it once
    against the server (endpoint is model-neutral, so the registration survives synth-tier
    swaps):
@@ -85,10 +84,10 @@ independent callers — one automatic, one an explicit operator step:
 
 ### Tuning `N_CPU_MOE` on gpu-mid (Gemma 4 26B-A4B, ~14 GB synth)
 
-The mid tier is **Gemma 4 26B-A4B** — a MoE with only **4B active parameters/token** at
+The mid tier is **Gemma 4 26B-A4B**, a MoE with only **4B active parameters/token** at
 `qat-UD-Q4_K_XL` (~14 GB). Unlike a 22 GB synth, it **co-fits embed+rerank (~7 GB) on a
 24 GB card fully resident** (~21 GB + Gemma's cheap sliding-window KV), so the default is
-`N_CPU_MOE=0` — no expert offload, fully GPU-resident.
+`N_CPU_MOE=0`: no expert offload, fully GPU-resident.
 
 | Card | Suggested `N_CPU_MOE` | Notes |
 |---|---|---|
@@ -102,7 +101,7 @@ offload costs less here than on a dense synth of the same size.
 ### Flash-attention / K8V4
 
 K8V4 (`q8_0` K / `q4_0` V) is verified working on RADV/gfx1100 (7900 XTX). FA is
-enforced structurally — llama.cpp refuses a quantized V-cache without it — so a
+enforced structurally (llama.cpp refuses a quantized V-cache without it), so a
 healthy container proves FA engaged. If a backend genuinely can't do FA, set
 `AIMEE_LLM_SYNTH_KV_V=f16` (K8V8 does **not** help; any quantized V needs FA).
 
@@ -111,9 +110,9 @@ healthy container proves FA engaged. If a backend genuinely can't do FA, set
 The GPU tiers are based on `debian:trixie-slim` (Mesa 25) on purpose: its RADV exposes
 `VK_KHR_cooperative_matrix` on RDNA3 (gfx1100), so llama.cpp uses the card's WMMA matrix
 cores. On an older Mesa without coopmat (bookworm's 22.3.6) llama.cpp falls back to scalar
-shaders — the synth goes compute-bound, the memory bus sits idle, and generation crawls.
+shaders. The synth goes compute-bound, the memory bus sits idle, and generation crawls.
 
 Measured on the 7900 XTX, gpu-mid resident: **~1265 tok/s prompt, ~62–95 tok/s generation**
 with coopmat; ~33–76 / ~30 without it. If a GPU tier is slow, check the base image is
-trixie (Mesa ≥ 24.1) and that `mem_busy` climbs under load — a pegged GPU with an idle
+trixie (Mesa ≥ 24.1) and that `mem_busy` climbs under load. A pegged GPU with an idle
 memory bus means the matrix cores aren't in play.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,7 +250,7 @@ Key properties:
   serializes heavyweight inference to bound resource use.
 - **Transport.** Clients reach the server over its `/v1` HTTP surface: the
   always-on `~/.config/aimee/aimee-http.sock` Unix socket, plus an optional
-  localhost TCP listener. Dispatch methods use first-class `/v1` routes; the
+  localhost TCP listener. Dispatch methods use dedicated `/v1` routes; the
   generic `POST /v1/rpc` endpoint is retired. Streaming chat uses
   `POST /v1/chat/stream`, whose body is a sequence of newline-delimited aimee
   events terminated by a final status object. (The legacy newline-delimited
@@ -352,7 +352,7 @@ It is a thin client: it holds no database and proxies everything to
 ## 8a. The kb console service
 
 `aimee-kb-console` (`kb-console/*.go` + the second `frontend/` SPA) is a standalone
-Go thin-client for administering a **shared/company `aimee-kb`** — dashboard,
+Go thin-client for administering a **shared/company `aimee-kb`**: dashboard,
 accounts (client enrollment, certificate revocation, scopes, OIDC config), and
 governance (decision records, the policy-verdict action audit). Unlike webchat it
 fronts the **kb `/v1` directly** (so it works with no colocated `aimee-server`) and

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -256,7 +256,7 @@ Honest scope of the current implementation (the design allows for more):
 | autonomy driver (`wfe_autonomy`) | advances machine gates, parks at human gates, never forges approval |
 | turn registry / server-owned turns | a run survives client disconnect (the foundation) |
 
-**Invariants** (by construction): aimee never self-initiates; the primary manages
+**Invariants**: aimee never self-initiates; the primary manages
 while delegates do the work; rejected work is re-delegated; **all** autonomous
 action flows through the workflow engine, there is no side-channel that takes an
 autonomous action outside the engine's gates, budget, and audit.

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -223,7 +223,7 @@ auto-retried without new input (a CI log or a roundtable verdict).
 
 ## Current limitations
 
-Honest scope of the current implementation (the design allows for more):
+Scope of the current implementation (the design allows for more):
 
 - **Submit takes `proposal_md`, `workflow`, `repo` only.** Per-run `limits` and
   gate **preauthorization** are not yet accepted at `/v1/dev/submit`; gates are

--- a/docs/CODE_INTELLIGENCE.md
+++ b/docs/CODE_INTELLIGENCE.md
@@ -55,7 +55,7 @@ A thin client needs a configured remote and an indexed project for this. Plain
 
 ## How the AI uses it
 
-The graph is a tool surface for the primary agent and its delegates, not just a CLI. Before
+The graph is a tool surface for the primary agent and its delegates, not only a CLI. Before
 an edit the AI looks up callers and blast radius, and it fetches exact code spans by symbol
 instead of loading whole files into context. That is what lets it work from your code, keep
 its context small, and stop rediscovering the codebase on every session. Code search is a

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -162,7 +162,7 @@ Useful flags:
     bearer `aimee-local-dev`. Connecting with it (`aimee remote set <url>
     aimee-local-dev`) auto-runs enrollment: the server mints a strong random
     per-deployment bearer (`api.rotate_bearer`), the client adopts it in
-    `remote.conf`, and the bootstrap token immediately stops working — so the
+    `remote.conf`, and the bootstrap token immediately stops working, so the
     shared default is never a standing credential. `aimee remote enroll` forces a
     fresh rotation on the configured remote at any time. To skip the bootstrap
     entirely, set `AIMEE_API_BEARER_TOKEN` on the server (secret store) to pin your

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -7,13 +7,13 @@ holds no state and proxies to `aimee-server` over its `/v1` HTTP surface.
 
 ## Design principle: server-incurred metrics only
 
-The dashboard shows **things aimee-server incurs** — its delegations, tool
+The dashboard shows **things aimee-server incurs**: its delegations, tool
 calls, token spend, guardrail verdicts, configured agents, active sessions, and
 readiness. It deliberately does **not** monitor `aimee-kb`-internal events
 (memory-curation audits, KB decision logs). **`aimee-kb` has its own dashboard**
 for those; duplicating them here would blur the boundary between the two
-services. The one exception is a state overview the server relies on — the
-**Memory** panel (tier counts) — which is available but off by default.
+services. The one exception is a state overview the server relies on, the
+**Memory** panel (tier counts), which is available but off by default.
 
 A field is "server-incurred" if the server's own agents/workflows produce it,
 even when the record is physically stored behind the KB (e.g. delegate token
@@ -28,7 +28,7 @@ clean 3-column layout; you add more from a catalog via **⚙ Customize**.
 
 ### Logs (`/logs`)
 
-The server's **tool-action audit ledger** — one row per tool call the agent
+The server's **tool-action audit ledger**: one row per tool call the agent
 makes, with the guardrail **verdict** (`allow` / `block` / `rewrite` /
 `approval_required`), the actor (`primary` / `delegate`), the tool, mode, and
 reason. Filter by verdict, actor, or tool name. This is `aimee-server`'s own
@@ -38,11 +38,11 @@ KB's logs.
 ## Panels
 
 Every panel is derived from data the server incurs. Panels marked *default* are
-shown out of the box; the rest are opt-in via **⚙ Customize**.
+shown by default; the rest are opt-in via **⚙ Customize**.
 
 | Panel | Default | Source |
 |-------|:------:|--------|
-| Readiness | ✓ | Synthesized health report (`onboard`) — DB/agents/delegations/LSP |
+| Readiness | ✓ | Synthesized health report (`onboard`): DB/agents/delegations/LSP |
 | Agents | ✓ | Configured provider roster (`agents`) |
 | Active Sessions | ✓ | Live webchat sessions (injected by webchat) |
 | Delegations | ✓ | Recent delegations (`delegations`) with human-formatted latency |
@@ -59,7 +59,7 @@ shown out of the box; the rest are opt-in via **⚙ Customize**.
 | Failures | — | Recent unsuccessful delegations (from `delegations`) |
 | Provider Mix | — | Configured agents grouped by provider (from `agents`) |
 | Confidence | — | Average delegate confidence per role (from `delegations`) |
-| Memory | — | Memory tier/kind counts (`memory_stats.tier_kinds`) — a KB state overview |
+| Memory | — | Memory tier/kind counts (`memory_stats.tier_kinds`), a KB state overview |
 | LSP Health | — | LSP diagnostics summary (`lsp`) |
 
 Latency is rendered human-readably (`482ms`, `4.7s`, `2m 7s`), not raw

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -122,7 +122,7 @@ aimee agent probe gemma
 ```
 
 > **Registering the deployment's own `aimee-kb-*` synth:** use the gateway port and the
-> `aimee-synth` alias, not a raw GGUF filename —
+> `aimee-synth` alias, not a raw GGUF filename:
 > `aimee agent local local-synth http://<gw>:8742/v1 --model aimee-synth --provider openai`.
 > The gateway runs auth-off on the internal bridge (`auth_type: none`). See
 > [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -461,7 +461,7 @@ Practical notes:
   aimee config set provider claude                          # use it as the primary
   ```
 
-  (`aimee agent setup` is reserved for the four first-class providers, `openai`,
+  (`aimee agent setup` is reserved for the four built-in providers, `openai`,
   `anthropic`, `codex-oauth`, `claude-oauth`, so add a tmux-cli claude with
   `agent add --provider claude`.) The thin-client routing is automatic when the
   workspace is `detached`.

--- a/docs/KB_CONSOLE.md
+++ b/docs/KB_CONSOLE.md
@@ -33,14 +33,14 @@ not merely "semi-trusted".
   `/v1/config/oidc`, `/v1/scopes`, `/v1/decisions` (+ sub-actions), and
   `/v1/audit/actions`. A compromised console is bounded to that allowlist. It may
   mint client enrollments, but the kb **refuses to mint an owner or privileged
-  scope for a console-admin caller** — the requested scope must be a proper
-  `<kind>:<id>` and the kind may not be `owner`/`console-admin`/`curator` — so the
+  scope for a console-admin caller**: the requested scope must be a proper
+  `<kind>:<id>` and the kind may not be `owner`/`console-admin`/`curator`, so the
   console cannot escalate by minting. `/v1/review` is **not** in the set: review
   accept/reject is a separate `curator` scope. (The console is on the kb's compose
   network, so other services on it can reach the console port, but every action
-  still requires a valid console session — OIDC or break-glass.)
+  still requires a valid console session: OIDC or break-glass.)
 - **Deny-by-default proxy.** `/api/*` maps 1:1 to the allowlisted `/v1` routes and
-  re-checks the same allowlist in Go (`acl.go`) before forwarding — defence in
+  re-checks the same allowlist in Go (`acl.go`) before forwarding, defence in
   depth with the kb's server-side check. The browser's own token is never
   forwarded; only the console-admin bearer, server-side.
 - **Login = OIDC primary.** The console verifies a browser-presented OIDC JWT
@@ -56,9 +56,9 @@ not merely "semi-trusted".
 - **Sessions + CSRF.** Cookies are `HttpOnly; Secure; SameSite=Strict`; every
   mutating `/api/*` call requires the per-session CSRF token in an `X-CSRF-Token`
   header, compared server-side to the session's stored token (a synchronizer-token
-  pattern — the `SameSite=Strict` cookie is the primary CSRF defence, the header is
+  pattern: the `SameSite=Strict` cookie is the primary CSRF defence, the header is
   defence-in-depth). Login is rate-limited per source IP. A
-  session is bound to `(iss, sub)` — not `sub` alone — so it is not portable
+  session is bound to `(iss, sub)`, not `sub` alone, so it is not portable
   across IdPs, and revoking a principal's enrollment invalidates its sessions.
   Idle (30 min) and absolute (8 h) timeouts apply. The SQLite session DB is mode
   0600.
@@ -76,7 +76,7 @@ not merely "semi-trusted".
 ## Certificate revocation semantics (S2a)
 
 Revoking an enrollment (`POST /v1/enrollments/{id}/revoke`) sets `revoked_at` in
-DB2 — the **source of truth** — and the mTLS seam rejects a revoked client cert on
+DB2 (the **source of truth**) and the mTLS seam rejects a revoked client cert on
 its next request (matched by the sha256 fingerprint of the cert DER). Two deliberate
 trade-offs:
 
@@ -87,7 +87,7 @@ trade-offs:
   checked before the DB. Every fail-open is logged (throttled) as a `WARN`.
 - **Single-instance cache.** The is-revoked cache is per-process with a 30 s TTL; a
   revoke is reflected immediately in the process that served it. Running multiple kb
-  instances means a revoke can take up to the TTL to be seen by the others — run a
+  instances means a revoke can take up to the TTL to be seen by the others. Run a
   single kb instance, or shorten the TTL, for a tight revocation window.
 
 Certs issued before S2a (no enrollment row) are **backfilled** as `legacy` rows on
@@ -111,12 +111,12 @@ JSON
 kb-console -kb https://aimee-kb:8741 -cred console.cred -oidc oidc.json
 ```
 
-Without an OIDC file the console runs **break-glass-only** — create
+Without an OIDC file the console runs **break-glass-only**: create
 `$KB_CONSOLE_HOME/.break_glass` (0600) to enable the recovery login.
 
 ## Deploy (compose)
 
-The console is a **default-off** compose service under the `console` profile — a
+The console is a **default-off** compose service under the `console` profile. A
 stock `docker compose up` never starts it. To enable it:
 
 ```bash
@@ -143,7 +143,7 @@ is **not** exposed by the console: it is a **curator-scope** action, and folding
 into the console-admin credential would break the separation of duties (a
 console-admin could self-approve changes to the very config it administers). The
 kb's built-in verifier derives scope from the single configured bearer, so a
-distinct curator scope only exists over **mTLS** today — there is no clean
+distinct curator scope only exists over **mTLS** today. There is no clean
 curator-credential path over the console's HTTP+bearer transport.
 
 Until the kb gains multiple scoped bearers, work the review queue directly with a
@@ -158,4 +158,4 @@ curl -fsS -X POST --cert curator.pem --key curator.key \
 ```
 
 A console **OIDC config** change (Accounts → OIDC login config) applies on the
-next **console restart** — there is no live reload.
+next **console restart**. There is no live reload.

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -6,13 +6,13 @@ How to point `aimee-kb` at the model backend that does its **embedding**,
 ## Principle: the kb runs no model
 
 `aimee-kb` is a thin DB2 / curator service. It **never** runs an LLM or embedder
-in-process — it *calls* one over HTTP. Inference lives in a separate **`aimee-kb-*`
-tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid` — the unified
+in-process. It *calls* one over HTTP. Inference lives in a separate **`aimee-kb-*`
+tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid`, the unified
 Vulkan llama.cpp stack, deployed as the SmoothNAS `aimee-llm` plugin) or any external
 OpenAI-compatible endpoint. You only ever give the kb a **URL**. The tiers themselves are
 documented in [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 
-## Tiers — what each backend provides
+## Tiers: what each backend provides
 
 | Backend | Embedding / reranking | Synthesis | Embedding dim |
 | --- | --- | --- | --- |
@@ -22,7 +22,7 @@ documented in [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 | **External LLM** | per the endpoint | per the endpoint | per the endpoint |
 
 `gpu-small` and `gpu-mid` share the 2560-dim embedder, so a KB moves between them with no
-re-embed — pick by synth need, not by the KB.
+re-embed. Pick by synth need, not by the KB.
 
 *Tier-A* = mechanical extract/index passes. *Tier-B* = reasoning passes (judge,
 resolve-entities, contradictions, **synthesize**, promote). A small CPU model is
@@ -33,12 +33,12 @@ when you point the kb at a capable container via `AIMEE_LLM_URL`.
 ## Zero-config default
 
 If **no** LLM is configured, the kb deployment brings up a **CPU `aimee-kb-cpu`
-container beside it** and points itself at it — embedding, reranking, and Tier-A
-synthesis work out of the box with nothing to set. The operator only opts *up*:
+container beside it** and points itself at it: embedding, reranking, and Tier-A
+synthesis work with nothing to set. The operator only opts *up*:
 configure a GPU container or an external LLM and the CPU sibling is not started.
 
 > The default CPU sibling is owned by the **deploy unit** (the smoothnas plugin /
-> compose), not the kb process — the kb never touches a container runtime.
+> compose), not the kb process. The kb never touches a container runtime.
 
 ## Config surface
 
@@ -60,7 +60,7 @@ then `AIMEE_LLM_URL`, then the zero-config CPU default.
   curator. Give the base URL **without** `/v1` (a trailing `/v1` or `/` is
   tolerated).
 - **Split a service out** by setting `AIMEE_EMBEDDER_URL` and/or
-  `AIMEE_RERANKER_URL` — they override `AIMEE_LLM_URL` for just that service.
+  `AIMEE_RERANKER_URL`. They override `AIMEE_LLM_URL` for just that service.
 - **Auth:** the kb sends **no bearer** on the embed/rerank/synth path, so the
   container must run **auth-off** (empty `AIMEE_LLM_AUTH_TOKEN`). This is safe on
   the internal deployment network (the `aimee-llm` gateway is not exposed
@@ -70,7 +70,7 @@ then `AIMEE_LLM_URL`, then the zero-config CPU default.
 
 The dim is **explicit**, not auto-detected:
 
-- **Unset → 1024** — the CPU / Qwen3-0.6B tier.
+- **Unset → 1024**: the CPU / Qwen3-0.6B tier.
 - **GPU / 4B tier → set `AIMEE_EMBEDDING_DIM=2560`.**
 
 Changing the dim against a **populated** kb is a **drop-and-rebuild re-embed**:
@@ -102,6 +102,6 @@ retrieval + Tier-A synthesis work at 1024-dim with no configuration.
 
 The `aimee-kb` smoothnas plugin and the compose topologies expose `AIMEE_LLM_URL`
 / `AIMEE_EMBEDDER_URL` / `AIMEE_RERANKER_URL` / `AIMEE_EMBEDDING_DIM` as config.
-The kb image carries **no** baked embedder/LLM endpoint defaults — an unset
+The kb image carries **no** baked embedder/LLM endpoint defaults. An unset
 backend falls back to the 384-dim builtin embedder (test/shim only), so a real
 deployment either relies on the default CPU sibling or sets one of the URLs above.

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -156,7 +156,7 @@ it downloads a portable Temurin JRE and the pinned `openapi-generator-cli` jar
 into `~/.cache/aimee-sdkgen` (no root required). Regenerating from an unchanged
 spec is a **byte-for-byte no-op**, so regeneration is deterministic.
 
-Two gates keep SDKs honest:
+Two gates guard the SDKs:
 
 - `scripts/check-sdk-parity.py`: every `operationId` in the spec is covered by
   every generated SDK (`make sdk-parity-check`). Run after `make gen-sdks` in the
@@ -193,7 +193,7 @@ KB_BEARER_TOKEN=<token-if-remote> \
   src/tests/test_v1_third_party.sh
 ```
 
-It skips gracefully (exit 0, SKIP) when no service is reachable, so it is safe
+It skips (exit 0, SKIP) when no service is reachable, so it is safe
 in CI; point it at a deployed aimee-kb to validate the stability contract.
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -35,9 +35,9 @@ By default this brings up **two** services. The browser webchat runs *inside* th
 |---------|-----------|------|
 | `aimee-server-kb` | Both aimee binaries (server and kb), the browser webchat UI, and a bundled CPU inference gateway (embed, rerank, synth) in one container | `8743` (server `/v1`, native TLS self signed; plaintext `8740` loopback only), `8741` (kb `/v1`), `8443` (webchat HTTPS, self signed) |
 | `postgres` | `pgvector/pgvector:pg16`, DB2 (`aimee_shared`) for knowledge and vectors | internal |
-| `llm` *(optional)* | Standalone curator LLM sidecar (Gemma 3n E4B via `llama.cpp`). Off by default — the bundled gateway already serves embed, rerank, and synth. Enable it with `--profile external-llm` for a lean `WITH_LLM=0` image, or to bring your own curator GGUF (point `LLM_ENDPOINT` at it). | internal |
+| `llm` *(optional)* | Standalone curator LLM sidecar (Gemma 3n E4B via `llama.cpp`). Off by default, since the bundled gateway already serves embed, rerank, and synth. Enable it with `--profile external-llm` for a lean `WITH_LLM=0` image, or to bring your own curator GGUF (point `LLM_ENDPOINT` at it). | internal |
 
-The kb auto-applies its DB2 schema (tables plus the `pg_trgm` and `vector` extensions) on first boot. The first `--build` takes a few minutes to compile the binaries; the CPU inference model weights are pulled in prebuilt (baked into the image), not downloaded at boot, so later starts are fast. To also run the standalone curator LLM sidecar — for a lean `WITH_LLM=0` image or a custom curator GGUF — add the profile: `docker compose -f compose.combined.yaml --profile external-llm up --build -d`.
+The kb auto-applies its DB2 schema (tables plus the `pg_trgm` and `vector` extensions) on first boot. The first `--build` takes a few minutes to compile the binaries; the CPU inference model weights are pulled in prebuilt (baked into the image), not downloaded at boot, so later starts are fast. To also run the standalone curator LLM sidecar (for a lean `WITH_LLM=0` image or a custom curator GGUF), add the profile: `docker compose -f compose.combined.yaml --profile external-llm up --build -d`.
 
 ### 1.2 Verify it's healthy
 
@@ -56,7 +56,7 @@ If the server endpoints return `200` and `kb/status` reports the DB and vector s
 
 ### 1.3 Browser webchat
 
-The browser UI is a first-class surface and is **on by default**. Open **https://localhost:8443** (accept the self-signed cert) and log in with the default account `aimee` / `aimee-local-dev`. Change `AIMEE_WEBCHAT_USER` / `AIMEE_WEBCHAT_PASSWORD` for anything beyond local dev, or set `AIMEE_WEBCHAT_ENABLED=0` in the compose file to turn it off.
+The browser UI is **on by default**. Open **https://localhost:8443** (accept the self-signed cert) and log in with the default account `aimee` / `aimee-local-dev`. Change `AIMEE_WEBCHAT_USER` / `AIMEE_WEBCHAT_PASSWORD` for anything beyond local dev, or set `AIMEE_WEBCHAT_ENABLED=0` in the compose file to turn it off.
 
 > Webchat is built into the image by default, from both published images and a from-source `docker compose build`, its frontend dependency (`@rakuensoftware/smoothgui`) is vendored in-repo, so the build needs no credentials. Build with `--build-arg WITH_WEBCHAT=0` to ship the server+kb services only.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -358,7 +358,7 @@ Every supported client now speaks `https://`, each using its platform's native t
 | macOS, prebuilt `aimee-macos-universal` or source build | Yes | Secure Transport, Keychain |
 | Windows, prebuilt or `install.ps1` build | Yes | Schannel, Windows certificate store |
 
-For per-client cryptographic identity (not just a shared bearer), the server also supports **mTLS client certificates**, clients present a cert from `<aimee_home>/tls/client.{crt,key}` and the server maps it to a `cert:<CN>` principal. Issue and manage them with the `aimee cert` CLI (`/v1/cert/issue|list|revoke`); see the [Manual](../MANUAL.md) for setup.
+For per-client cryptographic identity (beyond a shared bearer), the server also supports **mTLS client certificates**, clients present a cert from `<aimee_home>/tls/client.{crt,key}` and the server maps it to a `cert:<CN>` principal. Issue and manage them with the `aimee cert` CLI (`/v1/cert/issue|list|revoke`); see the [Manual](../MANUAL.md) for setup.
 
 ## Next steps
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -157,7 +157,7 @@ owner when someone is ready to pick it up.
   pluggable-db proposal sitting in `pending/` after being deleted by
   its successor is how `pending/` becomes stale signal. Worth a short
   `CONTRIBUTING.md` addition alongside the PR template.
-- **First-class operator audit surface:** the data is all there
+- **Dedicated operator audit surface:** the data is all there
   (`operator_id` on every shareable row, `content_hash`, timestamps),
   but a CLI verb rendering per-operator / per-scope activity in a
   legible way does not exist. Flagged as a known gap in the

--- a/docs/SANITIZER_CALL_SITES.md
+++ b/docs/SANITIZER_CALL_SITES.md
@@ -16,7 +16,7 @@ kind guards it. It is enforced by `scripts/check-sanitizer-callsites.py` (run fr
   agent-visible string, via `sanitize_for_prompt`. No ad-hoc escaping elsewhere.
 - **Two layers.** Structured kinds (`SANITIZE_FILE_PATH`, `SANITIZE_SYMBOL_LABEL`,
   `SANITIZE_SOURCE_LOCATION`, `SANITIZE_COMMUNITY_NAME`) are strict-validated and
-  **rejected** on control/markup — a caller must fail closed on `SANITIZE_REJECTED`.
+  **rejected** on control/markup. A caller must fail closed on `SANITIZE_REJECTED`.
   Free-text kinds are defanged in place and never rejected.
 - **Status is load-bearing.** A security-sensitive renderer must branch on the
   returned `sanitize_status_t` (`OK` / `TRUNCATED` / `REJECTED`), not ignore it.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -2,7 +2,7 @@
 
 The **Settings** page (aimee web UI, left nav → ⚙️ Settings, route `/settings`) is a typed
 editor over the server's runtime configuration. It exposes **every allowlisted config
-field** — the same `config.show` / `config.set` surface the `aimee config` CLI uses — as a
+field** (the same `config.show` / `config.set` surface the `aimee config` CLI uses) as a
 grouped, filterable form with per-field **Save** and **Reset**.
 
 It is a thin surface over machinery that already exists: each control maps 1:1 to a
@@ -17,7 +17,7 @@ request), unless noted otherwise below.
   /api/config/set {key,value}` → `config.set` (the server validates the key against
   `config_fields` and persists `aimee.yaml`). The webchat proxy (`webchat/config_api.go`)
   is the only network hop; there are no server changes per field.
-- **Control inference:** the control type is inferred from the value's JSON type — a
+- **Control inference:** the control type is inferred from the value's JSON type: a
   **boolean → toggle**, a **number → number field**, a **string → text field**. Grouping is
   by the dotted key prefix (e.g. everything under `reduce.` forms one section).
 - **Quick panel:** a smaller gear dropdown in the top bar (`SettingsPanel`) surfaces the
@@ -25,7 +25,7 @@ request), unless noted otherwise below.
   iterations). The full page is the comprehensive home for everything else.
 
 > **Allowlist, not raw config.** The page can only read/write keys in `config_fields`.
-> Sensitive values — endpoints, `*_key_cmd`, `db2_url`, and **secrets** — are deliberately
+> Sensitive values (endpoints, `*_key_cmd`, `db2_url`, and **secrets**) are deliberately
 > *not* in that allowlist and never appear here. In particular the CI-webhook secret
 > (`AIMEE_CI_WEBHOOK_SECRET`) is an environment secret, not a Settings field.
 
@@ -33,7 +33,7 @@ request), unless noted otherwise below.
 
 ## Option groups added recently
 
-### Context economizer — two-tier switches (`economizer.*`) + levers (`reduce.*`)
+### Context economizer: two-tier switches (`economizer.*`) + levers (`reduce.*`)
 
 The economizer has two **tier switches** that gate the individual `reduce.*` levers, plus the
 levers themselves. All are booleans except the two numeric tuning knobs. Defaults in
@@ -42,8 +42,8 @@ parentheses.
 | Setting | Default | What it does |
 | --- | --- | --- |
 | **`economizer.enabled`** | **on** | **Master switch.** Off = one kill-switch: every reducer is forced off (measurement keeps running and reports zero, proving the kill). The safe tier stays on under it by the levers' own defaults. |
-| `economizer.aggressive` | off | **Opt-in ceiling for the aggressive tier** (live **primary** `/v1` mutation). `reduce.gateway_mutate` activates only with **`economizer.enabled` AND `economizer.aggressive` AND** the lever itself — the aggressive flag alone never turns on a live-traffic mutator. |
-| **`reduce.command_filter`** | **on** | **Tool-output condensation** — deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
+| `economizer.aggressive` | off | **Opt-in ceiling for the aggressive tier** (live **primary** `/v1` mutation). `reduce.gateway_mutate` activates only with **`economizer.enabled` AND `economizer.aggressive` AND** the lever itself; the aggressive flag alone never turns on a live-traffic mutator. |
+| **`reduce.command_filter`** | **on** | **Tool-output condensation**: deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
 | `reduce.gateway_mutate` | off | Apply the economizer to the live inbound `/v1` request so the **primary** agent's tokens are reduced too. See [Economizer gateway mutation](features/economizer-gateway-mutation.md). |
 | `reduce.compress` | on | Size-based compression of oversized tool-result bodies. |
 | `reduce.history_fold` | on | Fold old turn history into a rolling skeleton. |
@@ -53,10 +53,10 @@ parentheses.
 | `reduce.gateway_session_disable_ttl_ms` | 3600000 | Gateway-mutation circuit-breaker window (ms). Must be > 0. |
 | `reduce.freeze_guard_horizon` | 1 | Expected reuse turns for the freeze break-even estimate. |
 
-`reduce.gateway_seam` is intentionally **not** on the page — it is synthesized from
+`reduce.gateway_seam` is intentionally **not** on the page. It is synthesized from
 `gateway_mutate` and its persistence is explicit-gated; toggle `gateway_mutate` instead.
 
-### Autonomous-development pipeline — `autonomy.*`
+### Autonomous-development pipeline: `autonomy.*`
 
 The autonomous-development knobs were historically environment-only (`AIMEE_AUTONOMY_*`).
 They are now typed config fields on the Settings page. A `config` value is **bridged to the
@@ -99,8 +99,8 @@ behavior, safety contract, and observability.
 
 ## When a change takes effect
 
-- **Immediately (next turn):** the economizer `reduce.*` levers and most other fields — the
+- **Immediately (next turn):** the economizer `reduce.*` levers and most other fields. The
   server reloads config per request.
-- **On next server start:** the `autonomy.*` knobs — they are bridged to `AIMEE_AUTONOMY_*`
+- **On next server start:** the `autonomy.*` knobs: they are bridged to `AIMEE_AUTONOMY_*`
   environment variables at startup so the workflow engine (which reads them across a module
   boundary) sees them; an explicitly-set env var always wins.

--- a/docs/STRUCTURED_PDF.md
+++ b/docs/STRUCTURED_PDF.md
@@ -4,8 +4,8 @@ aimee-kb can ingest a PDF as **coordinate-anchored evidence** instead of a flat
 blob of text. Every retrieved snippet carries the page and bounding box it came
 from, so an answer can be traced back to the exact place on the page. On top of
 that spine the KB optionally recognises **table cells**, renders **visual crops**
-of figures/tables/pages, and **OCRs scanned pages** — each behind its own
-capability flag, each degrading cleanly to the layer below when its dependency is
+of figures/tables/pages, and **OCRs scanned pages**, each behind its own
+capability flag, each degrading to the layer below when its dependency is
 absent.
 
 Everything here lives entirely in **aimee-kb** (the personal `aimee-server` holds only
@@ -27,8 +27,8 @@ separate opt-in.
 
 Every read surface honours the **same access control** as the spine
 (`document_key`-level check + quarantine), and table cells / crops are gated at read
-time by a join to the authoritative document — never by a cached flag. Structured-PDF
-content is reachable **only** through these `pdf_*` tools — it is deliberately kept out
+time by a join to the authoritative document, never by a cached flag. Structured-PDF
+content is reachable **only** through these `pdf_*` tools. It is deliberately kept out
 of the general `/v1/search` (both the vector path and the convention/derived-artifact
 sweeps), so a PDF cannot leak into an unscoped search.
 
@@ -39,9 +39,9 @@ sweeps), so a PDF cannot leak into an unscoped search.
 Each capability is a config flag (set with `aimee config set <key> <value>` or in
 `aimee.yaml`); the recognition layers also need a local sidecar or poppler binary.
 **Defaults are off.** Two kinds of dependency: the **poppler binaries**
-(`pdftotext`, `pdftoppm`) are *hard* — if a flag that needs one is on but the binary
+(`pdftotext`, `pdftoppm`) are *hard*: if a flag that needs one is on but the binary
 is missing, that step **errors** (e.g. a PDF upload returns an extraction error)
-rather than silently degrading; the **sidecars/embedder** are *soft* — when absent
+rather than silently degrading; the **sidecars/embedder** are *soft*: when absent
 the feature degrades to the layer below (see [Degradation](#degradation)).
 
 ```bash
@@ -77,12 +77,12 @@ sidecars, with `pdftotext` + `pdftoppm` installed in the aimee-kb image.
 ### The sidecars
 
 TSR and OCR are **optional local HTTP sidecars**, deployed the same way as the
-embedder/reranker — a service aimee-kb POSTs to. Despite the `_command` suffix
+embedder/reranker, a service aimee-kb POSTs to. Despite the `_command` suffix
 (inherited from `embedding_command`), `tsr_command` / `ocr_command` take the
 sidecar's **HTTP URL**, not a binary path (the `AIMEE_TSR_URL` / `AIMEE_OCR_URL`
 env vars are the fallback).
 
-These sidecars must be **deployed inside the KB trust perimeter** — the operator runs
+These sidecars must be **deployed inside the KB trust perimeter**: the operator runs
 them with no external network and no document-content retention. That is a deploy-time
 obligation, not something aimee enforces at runtime: aimee-kb hands the sidecar
 document-derived content (page text/geometry, or a rendered page image), so a sidecar
@@ -91,15 +91,15 @@ that egresses or retains is a data-exposure path. aimee never links or bundles t
 `pdftotext` and `pdftoppm` are operator-installed poppler binaries run as hardened
 subprocesses (separate process, `RLIMIT_CPU/AS/FSIZE`, a wall-clock deadline + output
 byte-cap, `setsid` + process-group kill on timeout, and `0600` scratch unlinked on
-every path — `RLIMIT_AS` is what bounds an image/decompression-bomb before output is
+every path. `RLIMIT_AS` is what bounds an image/decompression-bomb before output is
 written). aimee never links or bundles them either.
 
 ---
 
 ## Uploading
 
-`POST /v1/kb/docs` (multipart) with `file`, a `scope` (project), and — **required** for
-a PDF under `kb_pdf_ingest_enabled` — a `sensitivity_class` of `public`, `internal`, or
+`POST /v1/kb/docs` (multipart) with `file`, a `scope` (project), and (**required** for
+a PDF under `kb_pdf_ingest_enabled`) a `sensitivity_class` of `public`, `internal`, or
 `restricted` (a PDF upload with a missing/invalid class is a 400, no rows written). A
 `.pdf` whose bytes are not a real PDF (no `%PDF-` header) is rejected. A document's
 identity is `(scope, document_key)` where `document_key` is its file path, so
@@ -128,7 +128,7 @@ The upload response reports what was ingested, including the §D status:
 - `text_layer` ∈ `native` (real text layer) | `ocr` (recovered by the OCR sidecar) |
   `none` (scanned, no text recovered).
 - `asset_only` is `true` when a scanned PDF yielded **no text** but **did** yield
-  visual crops — so an operator is never misled into thinking a scanned contract is
+  visual crops, so an operator is never misled into thinking a scanned contract is
   text-searchable. Re-uploading once OCR is deployed upgrades it in place.
 
 ---
@@ -146,18 +146,18 @@ are withheld).
 | `pdf_open_neighbors` | `GET /v1/pdf/neighbors` | The prev/next reading-order chunks of a hit |
 | `pdf_inspect_structure` | `GET /v1/pdf/structure` | The document's chunk/page outline |
 | `pdf_lookup_table` | `GET /v1/pdf/lookup_table` | Recognised table cells `{row, col, text, tsr_confidence}` + a `tsr_status` marker (`ran` \| `not_a_table` \| `unavailable`) |
-| `pdf_list_assets` | `GET /v1/pdf/assets` | A document's visual crops — each an **opaque `asset_id`** + page/bbox/kind/caption |
+| `pdf_list_assets` | `GET /v1/pdf/assets` | A document's visual crops, each an **opaque `asset_id`** + page/bbox/kind/caption |
 | `pdf_open_asset` | `GET /v1/pdf/open_asset` | One crop's image bytes (base64) for an opaque `asset_id` |
 | — | `POST /v1/pdf/quarantine` | Owner-only: confirm (release) or reject (purge) a pending restricted document |
 
 ### Answerability
 
-`pdf_search_chunks` returns a per-query-over-corpus **answerability** judgment —
-"given *this* query, how well can the KB answer it" — as a `score ∈ [0,1]` plus a
+`pdf_search_chunks` returns a per-query-over-corpus **answerability** judgment
+("given *this* query, how well can the KB answer it") as a `score ∈ [0,1]` plus a
 `label ∈ {NONE, LOW, MEDIUM, HIGH}` (default cutoffs `<0.15`→NONE, `<0.40`→LOW,
 `<0.66`→MEDIUM, else HIGH; config-overridable). It is a **KB-side shared signal**,
 deliberately a
-*distinct field* from any server-side per-user confidence tier — clients must not
+*distinct field* from any server-side per-user confidence tier. Clients must not
 conflate the two. The combiner is a documented deterministic function of query-scoped
 inputs (top relevance, query-term coverage, hit saturation) so the same `(query,
 corpus state)` always yields the same score.
@@ -172,13 +172,13 @@ corpus state)` always yields the same score.
   scope; the `document_key` is the access unit.
 - **PDF vectors are structurally isolated.** PDF chunk embeddings live in a
   **dedicated `kb_pdf_embeddings` relation that the general `/v1/search` transport
-  never reads** — isolation by schema/module boundary, not a runtime `WHERE` filter
+  never reads**: isolation by schema/module boundary, not a runtime `WHERE` filter
   (which would be a classification, not an access, boundary). A `quarantine_state`
   predicate rides inside the PDF surface as defense-in-depth.
 - **Table cells and crops gate on the live document.** `lookup_table`,
   `open_asset`, and the asset list resolve through a join to the authoritative
   `kb_documents` row (`doc_kind='pdf'` + quarantine + project, bound to the real
-  `file_path`) — a guessed/foreign/withheld key returns empty, never the cached
+  `file_path`). A guessed/foreign/withheld key returns empty, never the cached
   denormalised value.
 - **The blob store never exposes the hash.** Crops are content-addressed by sha256
   (free dedup), but the sha is a **KB-internal identifier**: never returned to a
@@ -187,7 +187,7 @@ corpus state)` always yields the same score.
   row id** (never the hash), which applies the document ACL and writes a structured
   access audit log entry (allowed/denied) before streaming bytes. (Today that entry
   is a structured log line; a durable/WORM, hash-chained audit store is a tracked
-  enhancement — see the limits below.) Content-addressed dedup never widens access —
+  enhancement; see the limits below.) Content-addressed dedup never widens access. The
   gating is on the per-document asset row, not the shared bytes.
 - **Sidecars are not an egress path.** TSR/OCR and `pdftoppm` run inside the
   perimeter with no external network and no content retention.
@@ -212,7 +212,7 @@ errors that step.
 | `kb_pdf_assets_enabled` off | No visual crops; text retrieval unaffected |
 | `kb_pdf_assets_enabled` on, `pdftoppm` **absent** | No crops are produced (rendering fails best-effort); text/ingest unaffected (hard dep, but non-fatal here) |
 | `kb_pdf_ocr_enabled` off (or OCR sidecar unreachable) on a scanned PDF | Ingested **asset-only** if crops were rendered (`text_layer='none'`, `asset_only=true`); otherwise text-less with no crops (`text_layer='none'`, `asset_only=false`) |
-| `kb_pdf_ocr_enabled` on, sidecar recovers text | Text + geometry ingest transparently — same chunks/regions/citations as native text (`text_layer='ocr'`) |
+| `kb_pdf_ocr_enabled` on, sidecar recovers text | Text + geometry ingest transparently, same chunks/regions/citations as native text (`text_layer='ocr'`) |
 
 ---
 

--- a/docs/WEBCHAT_GIT_SECURITY.md
+++ b/docs/WEBCHAT_GIT_SECURITY.md
@@ -1,7 +1,7 @@
 # Webchat git credential security model
 
-How aimee-webchat handles a webuser's git forge credentials — at rest, in transit
-to git, and inside the in-browser editor — and where exposure is and isn't
+How aimee-webchat handles a webuser's git forge credentials (at rest, in transit
+to git, and inside the in-browser editor) and where exposure is and isn't
 closed. This is the reference for the `webchat git projects + in-browser VSCode`
 feature (proposal in `docs/proposals/done/webchat-git-projects-and-vscode.md`).
 
@@ -16,15 +16,15 @@ multi-user and server-hosted, so the goals are:
 2. **Cross-tenant:** one webuser can never read another's credential or files.
 3. **In transit to git:** on the **API git paths** (clone/fetch/pull/push,
    status/log/diff/branch, and PR creation) the token must not leak into a child
-   process's environment (`/proc/<pid>/environ`), argv, logs, or a named file —
+   process's environment (`/proc/<pid>/environ`), argv, logs, or a named file,
    where a co-located process could read it. The **in-browser editor is
-   explicitly out of scope for this invariant today** — see the editor section
+   explicitly out of scope for this invariant today**; see the editor section
    for the one remaining (bounded) exposure and the socket-askpass fix that would
    close it.
 4. **No server-secret bleed:** the editor must never see aimee-server's own
    secrets (DB password, server token, provider keys).
 
-## At rest — the per-principal vault
+## At rest: the per-principal vault
 
 Credentials live only in the encrypted per-principal vault
 (`server_vault.c`, `vault_service.c`, `vault_store.c`), keyed by the
@@ -41,7 +41,7 @@ The credential-resolution precedence is centralized in **one** policy
 gate (`git-cred-centralized-check`) forbids any caller from hand-rolling the
 ladder.
 
-## In transit to git — the token is out of `/proc/<pid>/environ`
+## In transit to git: the token is out of `/proc/<pid>/environ`
 
 For **every API git path** (clone, fetch, pull, push, status/log/diff/branch, and
 PR creation), the forge token does **not** appear in any child process's
@@ -52,17 +52,17 @@ environment:
   `safe_exec` variant `dup2`s it onto a fixed fd (`GIT_CRED_TOKEN_TARGET_FD`) in
   the forked git child with CLOEXEC cleared; the env carries
   `AIMEE_GIT_TOKEN_FD=<n>` (a *number*, not the secret) instead of `GH_TOKEN`.
-  The `GIT_ASKPASS` shim reads the token from `/proc/self/fd/<n>` (re-readable —
+  The `GIT_ASKPASS` shim reads the token from `/proc/self/fd/<n>` (re-readable,
   `cat` reopens the memfd at offset 0). The source memfd is CLOEXEC in the
   parent, so a concurrent exec on another thread can't inherit it; `memfd_create`
   failure fails **closed** (drops the token) rather than falling back to env.
-  Binding invariant — proven in `test_git_cred_inject`: a child run with this env
+  Binding invariant, proven in `test_git_cred_inject`: a child run with this env
   reads the token via `/proc/self/fd/<n>` but its `/proc/self/environ` contains
   only the fd *number*, never the token.
 
 - **Opening a PR** is an **in-process GitHub REST call** (`git_pr_api.c`), not a
   child exec: aimee-server POSTs to `/repos/{owner}/{repo}/pulls` with the token
-  in the `Authorization` header — in server memory only, wiped after the call,
+  in the `Authorization` header, in server memory only, wiped after the call,
   never logged (the HTTP client logs host + byte counts, never headers). The
   origin host is parsed **exactly** (rejects `evilgithub.com`,
   `github.com.evil.com`, …); GitHub remotes only. (This replaced an earlier
@@ -83,7 +83,7 @@ caller's own tree. The git surface can be disabled wholesale with
 `AIMEE_WEBCHAT_GIT=0` (all git routes → 503); the editor independently with
 `AIMEE_WEBCHAT_EDITOR=0`. Both default on.
 
-## The in-browser editor (code-server) — residual exposure
+## The in-browser editor (code-server): residual exposure
 
 The editor process env is curated of the server's own secrets (e.g. `AIMEE_DB2_URL`,
 `AIMEE_SERVER_TOKEN`, provider keys) and hardened (`no_new_privs`,
@@ -91,8 +91,8 @@ The editor process env is curated of the server's own secrets (e.g. `AIMEE_DB2_U
 on-disk `credential.helper` disabled). **However**, unlike the API git paths, the
 editor still injects the HTTPS token as **`GH_TOKEN` in the code-server
 environment.** This is the one remaining spot the token is in a child's
-`/proc/<pid>/environ`. It is a **bounded** exposure — it is the user's *own*
-token, in their *own* editor — but it is readable by **any same-UID code-server
+`/proc/<pid>/environ`. It is a **bounded** exposure: it is the user's *own*
+token, in their *own* editor, but it is readable by **any same-UID code-server
 descendant**: the extension host and its children (chiefly an extension the user
 installs), the integrated terminal, and any shell or git it spawns. It is not yet
 closed. Three pieces remain, and the key technical facts behind them were
@@ -104,10 +104,10 @@ The fd-askpass that works for the API git paths does **not** work for the editor
 Measured against a real code-server 4.126 / Node 24 on a test host:
 
 - VS Code's **SCM "Git" view** runs git in the **extension host** via
-  `child_process.spawn`, which **does** forward an inherited extra fd — so an
+  `child_process.spawn`, which **does** forward an inherited extra fd, so an
   fd-askpass would work there.
 - The **integrated terminal** spawns its shell via **`node-pty`**, which **does
-  not** forward the inherited fd (the dup2'd fd is not open in the pty child — node-pty does not inherit it).
+  not** forward the inherited fd (the dup2'd fd is not open in the pty child; node-pty does not inherit it).
 
 So switching the editor to fd-mode would silently **break terminal git** (the
 askpass would find no fd and, with no `GH_TOKEN` to fall back to, fail auth). The
@@ -121,9 +121,9 @@ regardless of fd inheritance. This is scoped but unimplemented.
 The proposal's "strip `GIT_ASKPASS`/`SSH_AUTH_SOCK` from the extension host but
 keep them for the integrated terminal **and SCM**" is **internally
 contradictory**: VS Code's SCM Git provider *runs in the extension host*, so
-those are the same trust boundary — there is no knob to give the built-in Git
+those are the same trust boundary. There is no knob to give the built-in Git
 extension the credential env while denying it to a third-party extension in the
-same host. The realistic mitigations are: the secret-free curated env (done — no server
+same host. The realistic mitigations are: the secret-free curated env (done, no server
 secrets reach any extension), an operational posture of Open-VSX-only with no
 preinstalled third-party extensions (a deployment policy, not code-enforced), and
 treating any extension the user installs as having access to the user's *own* git
@@ -133,9 +133,9 @@ credential by design.
 
 The editor terminal currently runs as the server UID with the server `PATH`
 (`no_new_privs` already neuters setuid escalation such as `sudo`, and the
-non-root UID denies `docker`/`nsenter`). A stronger jail — a `bwrap`/`unshare`
+non-root UID denies `docker`/`nsenter`). A stronger jail (a `bwrap`/`unshare`
 bind-mount namespace confining the terminal to the workspace subtree, a `seccomp`
-filter denying `mount`/`pivot_root`/`setns`, and cgroup CPU/mem limits — is
+filter denying `mount`/`pivot_root`/`setns`, and cgroup CPU/mem limits) is
 future work; it requires `bubblewrap` in the image and iterative validation
 against a live editor.
 
@@ -146,7 +146,7 @@ against a live editor.
 | clone, fetch, pull, push, status/log/diff/branch | **No** | memfd fd-askpass |
 | open PR | **No** | in-process GitHub REST (`Authorization` header) |
 | SSH git | **No** | in-memory ssh-agent (`SSH_AUTH_SOCK`) |
-| in-browser editor (code-server) | **Yes** (bounded: user's own token) | `GH_TOKEN` in env — fix = socket-fed askpass (scoped) |
+| in-browser editor (code-server) | **Yes** (bounded: user's own token) | `GH_TOKEN` in env; fix = socket-fed askpass (scoped) |
 
 **Remaining hardening** (all editor-scoped, all needing a live code-server to
 implement+validate): socket-fed askpass for the editor; the bwrap/seccomp/cgroup

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -51,7 +51,7 @@ credentials live in the server's **sealed vault**; see
   figure/table/page crops into a content-addressed blob store served by the
   access-gated, audited `pdf_open_asset` (`kb_pdf_assets_enabled`), and OCR
   scanned PDFs through the same citation path with an asset-only fallback
-  (`kb_pdf_ocr_enabled`). Each layer degrades cleanly when its sidecar/binary is
+  (`kb_pdf_ocr_enabled`). Each layer degrades when its sidecar/binary is
   absent. See [STRUCTURED_PDF.md](STRUCTURED_PDF.md).
 
 - **Server-sealed credential vault (single store)**: agent/delegate API keys and

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -12,7 +12,7 @@ credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).
 
 - **Dashboard overhaul + Logs tab**: the web UI **Dashboard** is now a customizable
-  grid of **server-incurred** metric panels — delegations, per-role metrics, token/cost,
+  grid of **server-incurred** metric panels: delegations, per-role metrics, token/cost,
   guardrail actions, agents, active sessions, readiness, plus opt-in panels (success by
   agent, latency percentiles, top tools, cache efficiency, failures, provider mix,
   confidence). Toggle/reorder panels via **⚙ Customize** (persisted per-browser); latency
@@ -21,16 +21,16 @@ credentials live in the server's **sealed vault**; see
   ledger (`aimee-kb` keeps its own dashboard for KB-internal events). See
   [DASHBOARD.md](DASHBOARD.md).
 - **Web Settings page for the full typed config**: the web UI **⚙️ Settings** page
-  (`/settings`) edits every allowlisted runtime config field — grouped, filterable, with
-  per-field save/reset — over the same `config.show`/`config.set` surface as the CLI. Newly
+  (`/settings`) edits every allowlisted runtime config field (grouped, filterable, with
+  per-field save/reset) over the same `config.show`/`config.set` surface as the CLI. Newly
   exposed groups: the context-economizer levers (`reduce.*`) and the autonomous-development
   pipeline knobs (`autonomy.*`, previously environment-only; a change applies on the next
   server start, and an exported `AIMEE_AUTONOMY_*` still overrides). Secrets and endpoints
   are deliberately not in the allowlist. See [SETTINGS.md](SETTINGS.md).
 - **Tool-output condensation** (default-ON, `reduce.command_filter`): a deterministic,
   command-aware context-economizer lever that condenses recognized command output at the
-  delegate tool seam — test-runner failures and compiler diagnostics kept, passing
-  transcripts and build progress dropped — with the full output spilled for lossless
+  delegate tool seam (test-runner failures and compiler diagnostics kept, passing
+  transcripts and build progress dropped), with the full output spilled for lossless
   recovery. Fail-open and byte-identical when off. Toggle it in the web Settings page. See
   [features/tool-output-condensation.md](features/tool-output-condensation.md).
 - **Self-hosted GPU inference tiers**: the `aimee-kb` inference image ships three tiers you
@@ -103,7 +103,7 @@ credentials live in the server's **sealed vault**; see
 
 Delegation defaults and the roundtable, see [DELEGATES.md](DELEGATES.md).
 
-- **Delegates work out of the box**: a default agent roster, the ensemble panel,
+- **Delegates work by default**: a default agent roster, the ensemble panel,
   and `remote_writes=full` ship seeded, so `aimee delegate …` and the roundtable
   run on a fresh install with no setup.
 - **Roundtable runs through the delegate core**: `aimee delegate aggregate`

--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -3,7 +3,7 @@
 The **Workflow Actions** page (aimee web UI, left nav → 📝 Workflow Actions) carries a change from
 an empty editor to a merged PR: **author** a proposal (from scratch or
 delegate-drafted), hand it to the **autonomous-development** engine to implement, and
-**watch** it — a scrollable status/history you can scroll back through to see
+**watch** it, a scrollable status/history you can scroll back through to see
 everything that happened.
 
 It is deliberately a thin surface over machinery that already exists: the wfe
@@ -21,19 +21,19 @@ proposal is still just *markdown + a `lifecycle_work_item`*; its history *is* th
 
 ## User flow
 
-1. **Author** — click **+ New proposal**. Fill in a title, a Markdown body (a
+1. **Author**: click **+ New proposal**. Fill in a title, a Markdown body (a
    Goal / Motivation / Approach / Risks / Tests scaffold is pre-filled), pick a
    workflow (the picker is populated from the saved workflow definitions,
    `GET /api/workflow/defs`; it defaults to `build`, the standard end-to-end
    proposal→PR→merge workflow), and optionally a repo. Optionally click
    **✨ Draft with a delegate** to have a delegate expand your title + notes into a
    polished proposal, previewed for you to accept.
-2. **Submit** — posts the proposal to the autonomous-development intake. The page
+2. **Submit**: posts the proposal to the autonomous-development intake. The page
    switches to the new run's status view.
-3. **Watch** — the detail view shows the current stage, a lifecycle badge, cumulative
+3. **Watch**: the detail view shows the current stage, a lifecycle badge, cumulative
    vs. cap cost, a PR link, and a **scrollable timeline** of every lifecycle event.
    It polls while the run is active and stops at a terminal state.
-4. **Decide** — when the run parks at a human gate, **Approve / Reject** in place.
+4. **Decide**: when the run parks at a human gate, **Approve / Reject** in place.
 
 ---
 
@@ -50,7 +50,7 @@ browser ──/api/*──▶ webchat (Go)  ──/v1/*, UDS──▶ aimee-serv
 - The Go webchat proxies each `/api/*` call to the C server's `/v1/*` HTTP surface
   over a trusted unix socket, asserting the caller's identity with the
   `X-Aimee-Webuser` header + `server.token` bearer (`v1RequestWebuser`). This is how
-  the C server resolves the caller's `webuser:<subject>` principal — which the
+  the C server resolves the caller's `webuser:<subject>` principal, which the
   read endpoints use for ownership scoping (below).
 - The C server owns all state. Submitting writes the proposal markdown to
   `$AIMEE_HOME/edit-workflows/workflow-actions/wi-*.md` and a `lifecycle_work_item` row; the wfe
@@ -79,13 +79,13 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
   stage, state, mode, pause_reason, repo`) plus additive `proposal_name`, `pr_ref`,
   `submitter`, `cum_cost_usd`, `work_item_max_cost_usd`, `override_count`. Additive
   only, so the Edit Workflows page (which reads the same endpoint) is unaffected.
-- **Timeline** — `{events:[{id, stage, kind, actor, detail, cost_usd, created_at}],
+- **Timeline**: `{events:[{id, stage, kind, actor, detail, cost_usd, created_at}],
   next_after}`, oldest-first, paginated by `?after=<event id>&limit=<n≤200>`
   (default 200). `next_after` is the id of the **last returned** event, so the page
   fetches the tail once and polls with `after=next_after` to append only new events.
   Correctness rests on the scheduler being single-writer-per-item (concurrency 1) and
-  event ids being monotonic — so `id > after` never skips or duplicates a row.
-- **Proposal read-back** — `{proposal_md, truncated}`. The file is read **race-free**:
+  event ids being monotonic, so `id > after` never skips or duplicates a row.
+- **Proposal read-back**: `{proposal_md, truncated}`. The file is read **race-free**:
   the fixed proposals dir is opened, then `openat(dirfd, basename, O_NOFOLLOW)`. Since
   `proposal_path` is a flat, server-minted file in one directory, there are no
   mid-path components to race and no symlink is followed (`ELOOP → 403`). Non-regular
@@ -101,14 +101,14 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
 - Request `{prompt, model?}`; response `{text, agent}` where `text` is the generated
   proposal markdown and `agent` is the **name of the configured delegate** that
   produced it (the caller's `model` preference if it named a usable non-CLI delegate,
-  otherwise the default or first eligible one — surfaced so the operator can see who
+  otherwise the default or first eligible one, surfaced so the operator can see who
   drafted it). `handle_agent_draft` (`server_agent.c`) runs one **tool-free** LLM
   completion via `agent_generate` (below) and returns the text.
   `CAP_DELEGATE` is satisfied by the `agent.*` capability prefix
   (`src/server/server_auth.c`).
 - The call is **synchronous**: there is no async job to orphan. A worker thread runs
   the single completion to completion (bounded by the model and the draft token cap)
-  and returns — if the browser gives up, the worker still finishes that one
+  and returns. If the browser gives up, the worker still finishes that one
   completion; nothing lingers as a pollable job. Because an LLM completion can exceed
   the webchat default 10 s timeout, the proxy uses `v1RequestWebuserT` (a
   timeout-parameterized variant of `v1RequestWebuser`, `webchat/vault.go`) with a 95 s
@@ -134,7 +134,7 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
   must string-equal the caller's `server_http_identity_principal()` (`webuser:<subj>`).
   A NULL/empty `submitter` (CLI/legacy/system rows) is owned by nobody, so those reads
   fail closed. This is why the Go proxies use `v1RequestWebuser` (not the un-attested
-  `v1Request`) — otherwise the principal would be empty and every read would 403.
+  `v1Request`), otherwise the principal would be empty and every read would 403.
 - **List scoping.** `GET /v1/workflow/items` returns only the caller's own rows; the
   unscoped operator view is a separate route, `GET /v1/workflow/items/all`, statically
   gated by `CAP_WORKFLOW_ADMIN`. The `/all` route is deliberately *not* owner-filtered,
@@ -143,24 +143,24 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
 - **How capabilities are acquired.** Browser users authenticate to the webchat; the
   webchat→server hop is over the filesystem-trusted UDS, and the C server treats that
   channel as the operator (this is the established single-trusted-operator webchat
-  model — the same one that guards the vault and the workflow gate). The per-route
+  model, the same one that guards the vault and the workflow gate). The per-route
   `CAP_*` values are the transport/route gates; the *per-user* narrowing that matters
   for this feature is the in-handler ownership check on `submitter`, which is why the
   proxies must forward the webuser identity.
 - **Path confinement.** The proposal read-back is dirfd + `openat(O_NOFOLLOW)` on a
-  server-minted basename — no traversal, no symlink follow, no TOCTOU (details above).
+  server-minted basename: no traversal, no symlink follow, no TOCTOU (details above).
 - **Delegate drafting is tool-free.** `agent_generate` (`src/server/agent_runtime.c`)
   selects a single **non-CLI** (HTTP-provider) delegate and calls the plain-completion
   **`agent_execute()` directly**. The tool-execution loop lives only in the *separate*
-  `agent_execute_with_tools_for_role()`, which `agent_generate` never calls — so a
+  `agent_execute_with_tools_for_role()`, which `agent_generate` never calls, so a
   draft returns text and nothing else, regardless of the agent's `tools_enabled`: no
   tools, no worktree, no writes, no repo access. It refuses if only CLI (agentic)
   agents exist. The user's title/notes are the *subject*, framed by a fixed system
   prompt that tells the model to treat them as data. **Residual risk (bounded, not
   zero):** because there are no tools there is no *server-side* side effect, but the
   model can still produce misleading or malicious *markdown* (e.g. a phishing link) in
-  the draft. That draft is shown as a preview and the user must explicitly accept it —
-  the human reviewer owns the same trust judgment they would for any hand-written
+  the draft. That draft is shown as a preview and the user must explicitly accept it.
+  The human reviewer owns the same trust judgment they would for any hand-written
   proposal. The rendered preview cannot inject script (it goes through the escaping
   `renderMd`, below), and an accepted draft only becomes a normal proposal the user
   then submits.
@@ -168,7 +168,7 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
   there is *no* `CAP_WORKFLOW_ADMIN` override for `/events`, `/proposal`, or the
   single-item GET. An admin's extra reach is the `/all` *list* only (item rows, which
   do not include event `detail` or the proposal body). Consequently
-  **`lifecycle_event.detail`** — served verbatim, not sanitized in v1 — is visible only
+  **`lifecycle_event.detail`** (served verbatim, not sanitized in v1) is visible only
   to the **owner** of the item. (Cross-user admin inspection of another user's timeline
   or proposal is deliberately deferred; use the CLI/DB for that.)
 
@@ -185,9 +185,9 @@ basenames are opened.
 - **Timeline polling.** Keyed on the selected id alone; each tick appends only events
   past the cursor (idempotent: it filters `id > lastId`), and the interval self-stops
   once the item reaches a **terminal** `state`. The terminal set is exactly the
-  non-`active` values of the authoritative work-item `state` enum —
+  non-`active` values of the authoritative work-item `state` enum:
   `active | accepted | rejected | abandoned` (`db1_work_item_t`; see
-  [`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)) — i.e. `accepted`,
+  [`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)), i.e. `accepted`,
   `rejected`, `abandoned`. A **parked** run is *not* a separate state: it stays
   `active` with a non-empty `pause_reason` (`pending_human`, `failed`,
   `budget_exceeded`, …), so the page keeps polling it every ~4 s (an operator can still
@@ -200,13 +200,13 @@ basenames are opened.
   the shared `renderMd`. It is not a general HTML sanitizer: it escapes the raw source
   (`&`, `<`, `>`) and then emits only a fixed, closed set of tags (headings,
   paragraphs, lists, blockquotes, inline emphasis/code, fenced code, and `<a>` links
-  restricted to `http(s)` targets) — so no author-supplied HTML, event handler, or
+  restricted to `http(s)` targets), so no author-supplied HTML, event handler, or
   `javascript:`/SVG payload reaches the DOM. Practically: LLM- or user-authored
   markdown cannot inject script into the page.
 - **Composer draft.** The in-progress draft is persisted in `localStorage`
   (`aimee_proposal_draft`), restored on mount, and cleared on a successful submit and
   on logout (`App.tsx`). `localStorage` is origin-wide, so a draft persists on the
-  device until one of those clears runs — the cross-account protection is "logout
+  device until one of those clears runs. The cross-account protection is "logout
   clears it," not per-user isolation. A server-side per-user draft store is a noted
   non-goal.
 - **Draft-with-a-delegate** shows the result as a **preview**; the body is replaced
@@ -222,17 +222,17 @@ basenames are opened.
 
 Built slice-by-slice, each design-and-code roundtable-reviewed before merge:
 
-- **Slice 0 — backend read surfaces** (PR #954): the timeline/proposal/enriched-item
+- **Slice 0: backend read surfaces** (PR #954): the timeline/proposal/enriched-item
   endpoints + owner scoping. Behavioral unit tests in `test_wfe_webapi.c`
   (ownership allow+deny, pagination cursor, proposal read-back, symlink→403,
   `/all` enrichment).
-- **Slice 1 — Workflow Actions page + Edit Workflows de-scope** (PR #956): the list + status/
+- **Slice 1: Workflow Actions page + Edit Workflows de-scope** (PR #956): the list + status/
   history detail; removes the Runs/Run-state/gate panels from Edit Workflows.
-- **Slice 2 — author-from-scratch composer** (PR #959): the composer + client-side
+- **Slice 2: author-from-scratch composer** (PR #959): the composer + client-side
   draft; removes the Submit-proposal panel from Edit Workflows. (This PR also repaired
-  pre-existing `testing` breakage from an unrelated merge — a clang-format violation
+  pre-existing `testing` breakage from an unrelated merge, a clang-format violation
   and an `audit_args_hash`/`wfe_sha256_raw` test-link `undefined reference`.)
-- **Slice 3 — delegate-assisted drafting** (PR #963): `agent_generate` + `/v1/agent/draft`
+- **Slice 3: delegate-assisted drafting** (PR #963): `agent_generate` + `/v1/agent/draft`
   + the composer's Draft button.
 
 PRs (github.com/RakuenSoftware/aimee): [#954](https://github.com/RakuenSoftware/aimee/pull/954),
@@ -254,10 +254,10 @@ The page is read/UI only; the behavior it drives is governed by existing config:
 - **Autonomous execution** is governed by the wfe engine
   ([`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). Notably the **live forge
   is default-off** (`wfe_live_forge_enabled`): with it off, a run advances and parks at
-  gates without pushing a real PR — which is the safe default for exercising the page.
+  gates without pushing a real PR, which is the safe default for exercising the page.
 - **Submit** is bounded by the intake's existing caps (a 1 MB proposal body cap and the
   intake-auth per-principal rate/concurrency limits); the user-supplied `repo` is
-  handled by the same `/v1/dev/submit` intake that the CLI uses — its validation and
+  handled by the same `/v1/dev/submit` intake that the CLI uses; its validation and
   authorization are the intake's concern, unchanged by this feature.
 - **To exercise it end to end** on a running instance: open `/workflow-actions`, **+ New
   proposal**, optionally **Draft with a delegate**, **Submit**, then watch the timeline

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -104,12 +104,12 @@ the KB scan succeeds.
 ### Verification discipline
 
 1. **Red before green.** To claim something's broken, show the failure in the
-   stock, unmodified system first — a red baseline. No red baseline, no saying
+   stock, unmodified system first, a red baseline. No red baseline, no saying
    "broken." A passing test of your fix is not admissible as evidence the original
    failed; that's treatment, not control.
 2. **The deciding test can't be the one you skipped.** When the true end-to-end is
    unrunnable (e.g. a live Moonlight session), that's a stop. Downgrade to
-   "hypothesis, unverified" — explicitly, in those words — and do not open a
+   "hypothesis, unverified", explicitly, in those words, and do not open a
    PR-as-fix or write a root cause as fact. The thing you couldn't verify is
    exactly the thing you're most likely wrong about.
 3. **Code outranks your repro.** When the system's own source contradicts your

--- a/docs/dev/fold-pipeline-order.md
+++ b/docs/dev/fold-pipeline-order.md
@@ -13,26 +13,26 @@ slice.
 Six steps per turn in `agent_execute_with_tools_internal()`
 (`src/posix/agent_runtime.c`); step 1 is pre-stage input, steps 2–6 are actions:
 
-1. **raw DB1 transcript** — append-only `messages` cJSON array (never mutated).
-2. **session compaction** — `maybe_compact_before_request()` (≈`agent_runtime.c:677`).
-3. **[FOLD PASS — P2]** — runtime calls `context_fold_view(messages, sys, &budget,
+1. **raw DB1 transcript**: append-only `messages` cJSON array (never mutated).
+2. **session compaction**: `maybe_compact_before_request()` (≈`agent_runtime.c:677`).
+3. **[FOLD PASS, P2]**: runtime calls `context_fold_view(messages, sys, &budget,
    cfg, &out)`, which **produces and returns** the synthetic skeleton pair +
    Coordinate Closet (§2) as a view, non-destructively (`messages` untouched), then
    exits. The fold function does not touch prefix state.
-4. **provider-shape normalization** — runtime renders the step-3 view into the active
+4. **provider-shape normalization**: runtime renders the step-3 view into the active
    provider shape (Anthropic content blocks / OpenAI `tool_calls` / Gemini `parts`)
    into a **runtime-owned byte buffer**, with the **atomic tool-pair** rule (a
    `tool_use`+`tool_result` fold together or not at all; folded regions are plain
    non-tool text). This is a deterministic 1:1 render, not a semantic rewrite.
-5. **cache-prefix registration + single hash** — runtime registers the step-4
+5. **cache-prefix registration + single hash**: runtime registers the step-4
    buffer `(ptr,len)` via `payload_rewrite_register_span()`, then the canonical
    prefix-hash wrapper (`track_anthropic_payload_rewrite()` and its
    `track_{openai,gemini}_payload_rewrite` siblings, all delegating into
    `payload_rewrite.c`, ≈`agent_runtime.c:698`) hashes the registered spans **once**.
-6. **request build** — `agent_build_request_*()` (≈`agent_runtime.c:699`).
+6. **request build**: `agent_build_request_*()` (≈`agent_runtime.c:699`).
 
 Invariant: step 3's output is **semantically frozen**; step 4 is a deterministic
-1:1 render; the exact post-step-4 bytes are what step 5 registers and hashes — no
+1:1 render; the exact post-step-4 bytes are what step 5 registers and hashes: no
 semantic change *and* no byte change is permitted between steps 4 and 5. "Rewrite"
 means semantic mutation; rendering at step 4 is not a rewrite. The fold pass MUST
 sit at step 3 (after compaction, before the step-5 hash).
@@ -60,12 +60,12 @@ void payload_rewrite_spans_reset(payload_rewrite_state_t *st);
 
 - `fnv1a_update` stays `static` in `payload_rewrite.c`.
 - The registered span is the **post-step-4** (provider-shape-normalized) serialized
-  bytes — exactly what is sent — so the hash matches what the provider caches.
+  bytes (exactly what is sent) so the hash matches what the provider caches.
   `agent_runtime.c` owns that buffer; the fold (step 3) only produces a view and
   exits. Lifetime: register after step 4, hash at step 5, `spans_reset()` at the top
-  of the next turn — no use-after-free / double-free.
+  of the next turn. No use-after-free / double-free.
 - The pending `ingress-compression-and-cache-alignment` work registers the envelope
-  span through the same API — **serialized convergence**: the shared span-registry
+  span through the same API, **serialized convergence**: the shared span-registry
   PR lands first, then the fold and ingress features layer on it. Never two writers.
 
 ## CI single-owner enforcement

--- a/docs/features/context-fold.md
+++ b/docs/features/context-fold.md
@@ -1,7 +1,7 @@
 # Deterministic context folding
 
 Sustain long agent sessions inside a fixed context window by **deterministically
-folding old conversation turns** — no LLM summarization call — while conserving the
+folding old conversation turns** (no LLM summarization call) while conserving the
 exact identifiers an agent needs, and keeping the provider prompt cache warm.
 
 **Status:** shipped on `testing`, **default-off** end to end. Each layer is gated by
@@ -18,45 +18,45 @@ once a conversation grows past `retained_msgs` (default 8) trailing messages and
 least `min_fold_msgs` (default 4) older turns are eligible, a contiguous prefix of
 older turns is replaced by a single synthetic summary:
 
-- **Rolling fold (§1)** — one skeleton line per turn / tool call (`assistant: …`,
+- **Rolling fold (§1)**: one skeleton line per turn / tool call (`assistant: …`,
   `  $ tool …`, `    → result (N bytes)`), plus a budgeted reasoning excerpt.
-- **Coordinate Closet (§2)** — the exact identifiers from the folded region (uuids,
+- **Coordinate Closet (§2)**: the exact identifiers from the folded region (uuids,
   commit shas, paths, digit-bearing `key=value`, issue/PR refs, `handle:`/`memory:`
   tokens) are conserved verbatim in a labelled block so truncation can never
-  amputate them. Secrets are redacted; user-pasted content is *quarantined* —
+  amputate them. Secrets are redacted; user-pasted content is *quarantined*,
   conserved in a separate lane, rendered with an `(untrusted)` marker under a
   divider, and never allowed to mint an agent-trusted label (a prompt-injection
   guard).
-- **Fold-freeze (§3)** — the fold boundary is *pinned* across turns, so the folded
+- **Fold-freeze (§3)**: the fold boundary is *pinned* across turns, so the folded
   prefix stays byte-identical turn-to-turn and the provider cache stays warm; the
   boundary only advances at an "epoch" when the un-folded tail outgrows its cap.
-- **Register grammar (§6)** — folded assistant lines are annotated with their
+- **Register grammar (§6)**: folded assistant lines are annotated with their
   register (verdict / hazard / executing / blocked / in-progress) so the summary
   preserves which turns were settled conclusions.
-- **Fold recall (§4)** — if a later turn re-references a folded-away coordinate, a
+- **Fold recall (§4)**: if a later turn re-references a folded-away coordinate, a
   recall hint is surfaced so the body can be paged back in on demand via the
   existing `code_span_get` / `memory_get` tools.
 
 Two more building blocks ship as tested libraries (storage binding is future work,
 see [Limitations](#limitations-and-deferred-work)):
 
-- **Sealed episodes (§5)** — a replayable checkpoint (conclusion + file inventory)
+- **Sealed episodes (§5)**: a replayable checkpoint (conclusion + file inventory)
   with a file-touch auto-recall predicate (`src/episode_seal.{c,h}`).
-- **Task rail (§8)** — a portable plan FSM serialisable outside the prompt
+- **Task rail (§8)**: a portable plan FSM serialisable outside the prompt
   (`src/task_rail.{c,h}`).
 
 A seventh piece underpins the rest:
 
-- **Per-model budget resolver (§7)** — `src/fold_budget.{c,h}`, a *pure* function
+- **Per-model budget resolver (§7)**: `src/fold_budget.{c,h}`, a *pure* function
   that turns a model id into the fold's token budgets. It has **no user-facing
   config surface** (the operator knobs below are message-count/byte based); it is
   listed here only so the §1–§8 map is complete and so operators understand fold
   output may legitimately differ across model identities.
 
-Everything is **deterministic** — no LLM-summarisation call, no wall-clock input,
-no randomness — so identical input yields byte-identical output, which is what makes
+Everything is **deterministic** (no LLM-summarisation call, no wall-clock input,
+no randomness), so identical input yields byte-identical output, which is what makes
 the freeze and the cache benefit possible. (Model *identity* is an input via §7, so
-switching models is treated as a prefix change — see the freeze invariant.)
+switching models is treated as a prefix change; see the freeze invariant.)
 
 ## Enabling it
 
@@ -65,7 +65,7 @@ All knobs live under the `fold` and `compact.coord_closet` config sections
 **Numeric** keys use **0 as a sentinel** that resolves to a built-in module default:
 `retained_msgs`→8, `min_fold_msgs`→4, `excerpt_bytes`→160, `budget_bytes`→2048,
 `max_ratio_pct`→100, `tail_cap_msgs`→24, `ttl_turns`→4. The snippet below is an
-**all-on reference** — see the staged rollout after it for the recommended order.
+**all-on reference**; see the staged rollout after it for the recommended order.
 
 ```yaml
 fold:
@@ -90,17 +90,17 @@ compact:
 ```
 
 Recommended order to turn on (each is independently safe):
-1. `compact.coord_closet.enabled` — conserve identifiers in tool-result compaction
+1. `compact.coord_closet.enabled`: conserve identifiers in tool-result compaction
    (works even without the transcript fold).
-2. `fold.enabled` (+ `register_enabled`) — the transcript fold itself.
-3. `fold.freeze.enabled` — once folding is on, freeze keeps the cache warm.
-4. `fold.recall.enabled` — re-touch hints.
+2. `fold.enabled` (+ `register_enabled`): the transcript fold itself.
+3. `fold.freeze.enabled`: once folding is on, freeze keeps the cache warm.
+4. `fold.recall.enabled`: re-touch hints.
 
 ## How it behaves (invariants)
 
 - **No silent coordinate loss.** Conserved identifiers are rendered verbatim when
   they fit; a nominated identifier that cannot fit the closet budget is explicitly
-  signalled (`COORD_EVICT_FAIL`) and rendered as a `(partial — … omitted)` marker —
+  signalled (`COORD_EVICT_FAIL`) and rendered as a `(partial — … omitted)` marker,
   never silently dropped.
 - **Atomic tool pairs.** The fold boundary is always a *clean user turn*, so a
   `tool_use` and its `tool_result` are never split, and the retained tail always
@@ -111,10 +111,10 @@ Recommended order to turn on (each is independently safe):
   while it is pinned; a mid-run prefix mutation (e.g. compaction) is detected by a
   digest and forces a clean epoch rather than a false cache claim. A model-identity
   change (different §7 budget) likewise shifts the prefix, so it is handled the same
-  way — a fresh epoch, not a stale cache-warm claim.
-- **Secrets are redacted before render** by the implemented detectors —
+  way: a fresh epoch, not a stale cache-warm claim.
+- **Secrets are redacted before render** by the implemented detectors:
   `ghp_`/`sk-`/`AKIA…`/JWT/PEM token shapes, credential-bearing paths, and sensitive
-  label names — plus any substrings added via `compact.coord_closet.denylist`. The
+  label names, plus any substrings added via `compact.coord_closet.denylist`. The
   detector set is extensible, not exhaustive: it is a strong filter, not an absolute
   guarantee against every possible secret shape.
 
@@ -126,7 +126,7 @@ on closet eviction. `fold_result_t.reused_boundary` reports cache-warm reuse.
 
 ## Limitations and deferred work
 
-The fold is **default-off** and these are the honest gaps (tracked in the proposal
+The fold is **default-off** and these are the known gaps (tracked in the proposal
 close-out):
 
 - **Delegate path only.** The fold targets aimee's own agent loop, which already
@@ -149,7 +149,7 @@ close-out):
 The freeze pins the fold boundary so the reduced prefix stays byte-identical
 turn-to-turn, which keeps the provider prompt cache warm. But establishing a cache
 entry costs a one-time **cache-write**, and a boundary that keeps advancing can pay
-that write repeatedly — which, on a provider that bills cache writes at a premium,
+that write repeatedly, which, on a provider that bills cache writes at a premium,
 can make freezing cost *more* than it saves.
 
 The **freeze cost guardrail** (`reduce.freeze_guard`, default **on**; only acts when
@@ -158,7 +158,7 @@ before pinning a boundary. It compares the *marginal* cost of caching against th
 savings from reuse, using the same `token_tracker` rates as the rest of the cost
 story:
 
-- **Marginal write cost = the write _premium_**, `cache_write_rate − input_rate` —
+- **Marginal write cost = the write _premium_**, `cache_write_rate − input_rate`,
   not the full write rate. You pay the input rate to send the prefix on the first
   turn regardless; caching only adds the difference. Providers with free cache
   creation (OpenAI/Responses: `cache_write = 0`) have a premium ≤ 0, so freezing is
@@ -174,7 +174,7 @@ For every model aimee currently prices this keeps freeze **on** even at horizon 
 already covers; OpenAI has no premium). The exact break-even is re-derived from the
 live pricing table by `test_freeze_guard`, so a future price change that would flip
 the verdict fails that test rather than silently drifting from this prose. The
-guardrail therefore changes no current behavior — its job is to encode
+guardrail therefore changes no current behavior. Its job is to encode
 the correct economics as a tested invariant and to disable freeze automatically only
 under *adverse* pricing (a write premium that outweighs the reuse savings), or when
 caching offers no read discount at all (`cache_read ≥ input`). Missing pricing
@@ -185,7 +185,7 @@ caching offers no read discount at all (`cache_read ≥ input`). Missing pricing
 | Provider | Mechanism | Status |
 |----------|-----------|--------|
 | Anthropic | `cache_control:{ephemeral}` on the stable system-prompt prefix | Existing (`cache_shaping_enabled`); a frozen-history breakpoint is possible future work but low value while reduction keeps the frozen prefix small |
-| OpenAI / Responses | Automatic prefix caching — no explicit marker exists or is needed; the freeze's byte-identical ordering already satisfies the cache-hit criteria, and cache writes are free | No code; advisory only |
+| OpenAI / Responses | Automatic prefix caching, no explicit marker exists or is needed; the freeze's byte-identical ordering already satisfies the cache-hit criteria, and cache writes are free | No code; advisory only |
 | Gemini | `cachedContent` resource, created once per run for the system prompt | Existing; extending it to per-epoch message history is deferred (single per-request resource; recreating it per epoch is expensive for the small post-reduction prefix) |
 
 ## Default state
@@ -201,18 +201,17 @@ site (its synthetic-turn shape is unverified there); `compress` runs for every
 provider.
 
 **Recovery model (what "recoverable" means here).** This is a *lossy* reduction with
-**agentic recovery**, not lossless caching — be precise about the guarantee:
+**agentic recovery**, not lossless caching. Be precise about the guarantee:
 - **Recent context is never touched.** Both levers only reduce messages *before* the
   retained tail; the most recent `retained_msgs` (default 8) are byte-for-byte intact,
   so the agent's working set is always full. `retained_msgs` follows the numeric-0 =
-  built-in-default convention (0 → 8), so the working-set floor is always ≥ 1 — it can
+  built-in-default convention (0 → 8), so the working-set floor is always ≥ 1. It can
   never be configured to zero; an explicit small value (e.g. 1) just narrows it.
 - **Identifiers are conserved, not bodies.** When an old tool-result body is elided,
   the Coordinate Closet preserves the exact paths/ids/hashes it contained (plus the
   body's head+tail excerpt), so references survive. The *omitted middle* of an old
   body is not retained.
-- **Recovery is the agent re-issuing a tool call** (e.g. re-reading a conserved path)
-  — there is **no automatic inline re-fetch**. If a re-fetch fails, the agent handles
+- **Recovery is the agent re-issuing a tool call** (e.g. re-reading a conserved path). There is **no automatic inline re-fetch**. If a re-fetch fails, the agent handles
   it as an ordinary tool error. This refetch is the accepted cost of default-on.
 - Coordinate fidelity (0 lost identifiers) was validated on a captured long session in
   the deterministic-fold close-out.
@@ -227,16 +226,16 @@ reduce:
 ```
 
 **Config persistence convention.** A fresh default config writes **no** `reduce` or
-`compact.coord_closet` block at all — the defaults live in `config_set_defaults`
+`compact.coord_closet` block at all. The defaults live in `config_set_defaults`
 (`src/config.c`). On save, *default-on* keys (`measure`, `delegate_seam`,
 `history_fold`, `compress`, `freeze_guard`, `coord_closet.enabled`) persist only their
 non-default **OFF** state; *default-off* keys (`gateway_seam`) persist only their
 non-default **ON** state. So an operator opt-out round-trips, and an unmodified config
 stays empty. Note `coord_closet.budget_bytes: 0` means **"use the built-in default"**,
-not "force a zero-byte closet" — to disable the closet, set `enabled: false`.
+not "force a zero-byte closet". To disable the closet, set `enabled: false`.
 
 **Not yet default-on:** the **gateway seam** (`reduce.gateway_seam`, the inbound /v1
-path that serves the primary agent) remains off — it is shadow-measure-only until its
+path that serves the primary agent) remains off. It is shadow-measure-only until its
 request-mutation path and 400-retry-from-pristine circuit breaker are built. The
 legacy standalone `fold.*` path also stays opt-in; the economizer supersedes it (when
 the economizer produces a reduced view, the legacy `build_fold_view` is skipped).

--- a/docs/features/economizer-gateway-mutation.md
+++ b/docs/features/economizer-gateway-mutation.md
@@ -1,8 +1,8 @@
 # Economizer gateway mutation (primary-agent context reduction)
 
 The context economizer reduces the **delegate** (sub-agent) turn loop by default. The
-inbound `/v1` **gateway** — the path that serves the **primary** agent, including
-Claude-Code-through-aimee and Codex-through-aimee — historically ran the economizer in
+inbound `/v1` **gateway** (the path that serves the **primary** agent, including
+Claude-Code-through-aimee and Codex-through-aimee) historically ran the economizer in
 **shadow** (`measure_only`): it measured the reduction opportunity but never applied it.
 
 **Gateway mutation** makes the gateway *apply* the reduced messages to the live request,
@@ -19,7 +19,7 @@ reduce:
   gateway_session_disable_ttl_ms: 3600000  # NEW: circuit-breaker window (1h). MUST be > 0.
 ```
 
-- `gateway_mutate: true` **implies** `gateway_seam` — config load auto-enables the shadow
+- `gateway_mutate: true` **implies** `gateway_seam`: config load auto-enables the shadow
   seam **in memory** (never rewriting your file) and logs one WARN, so the shadow baseline
   the validation gates compare against always exists.
 - `gateway_session_disable_ttl_ms` **must be > 0**. `0`/negative is a **startup-fatal**
@@ -35,11 +35,11 @@ reduce:
 - **Streaming** (`/v1/messages` stream:true): the HTTP 200 is committed to the client on
   the first byte, so there is **no mid-stream retry**. The reduced stream is sent; if an
   **invalid-request-class** SSE error frame (`invalid_request_error` / `request_too_large`)
-  is seen — inspected at the SSE decoder layer and forwarded unchanged — the session is
+  is seen (inspected at the SSE decoder layer and forwarded unchanged), the session is
   disabled for **subsequent** turns. Rate-limit / overloaded / auth frames are forwarded
   **without** disabling. The current turn always completes as the upstream delivered it.
 - **OpenAI `/v1/responses` streaming** buffers upstream (via the same buffered path) then
-  replays as SSE, so it inherits the **buffered** treatment — including the 4xx
+  replays as SSE, so it inherits the **buffered** treatment, including the 4xx
   restore-resend. aimee has no true token-by-token upstream streaming for the OpenAI
   primary path, so there is no OpenAI-specific streaming disable-only code.
 
@@ -48,7 +48,7 @@ reduce:
 Mutation is attempted only for a **resolvable per-identity session key**, derived (in
 order) from a validated `aimee-session-id` header (`== SHA-256(auth_identity)[0..16)`),
 else `SHA-256(bearer)[0..16)`. A request with **neither** is a pristine passthrough that
-writes **no** disable state — so one caller's failure can never disable reduction for an
+writes **no** disable state, so one caller's failure can never disable reduction for an
 unrelated caller. Disable state is a bounded (10k), TTL'd, process-local set.
 
 ## Safety contract

--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -1,17 +1,17 @@
 # Tool-output condensation (deterministic command-aware)
 
-Tool output — test-runner logs, compiler/linter dumps, build progress — is the largest and
+Tool output (test-runner logs, compiler/linter dumps, build progress) is the largest and
 most signal-sparse contributor to a coding agent's context. Most of that volume is not
 signal: progress bars, passing-test transcripts, boilerplate, repeated lines.
 
 **Tool-output condensation** is a context-economizer lever that condenses **recognized**
 command output at the tool-execution seam, using **deterministic, command-aware rules** (no
 LLM, so it is ~free). It knows that a test runner's value is its *failures*, a compiler's is
-its *diagnostics*, and drops the rest — **losslessly**: the full raw output is spilled to
+its *diagnostics*, and drops the rest, **losslessly**: the full raw output is spilled to
 disk and a recovery pointer is left in the condensed result, so nothing is destroyed.
 
-It is **default-ON** (unified-economizer P1c — a safe-tier lever: lossless-on-demand,
-fail-open, no-over-reduction) and complements — does not replace — the size-based
+It is **default-ON** (unified-economizer P1c, a safe-tier lever: lossless-on-demand,
+fail-open, no-over-reduction) and complements (does not replace) the size-based
 `reduce.compress`, which stays the fallback for unrecognized output. Set
 `reduce.command_filter=false` to opt out.
 
@@ -23,7 +23,7 @@ reduce:
 ```
 
 Turn it on from the web UI (**⚙️ Settings → `reduce.command_filter`**, see
-[SETTINGS.md](../SETTINGS.md)) or the config above. When off, tool output is **byte-identical to today** — the seam falls through to the size-based `reduce.compress`.
+[SETTINGS.md](../SETTINGS.md)) or the config above. When off, tool output is **byte-identical to today**: the seam falls through to the size-based `reduce.compress`.
 
 ## What it does
 
@@ -33,7 +33,7 @@ before the size-based compression:
 1. **Recognize** the command. Compound/piped/substituted lines and unknown commands pass
    through unchanged (fail-open). Common wrappers are unwrapped (`env`, `sudo`, `time`,
    `npx`, `uv run`, `poetry run`, `pnpm exec`, …). `xargs`, `make`, shell scripts, and **any
-   path-prefixed invocation** (`./git`, `/tmp/cargo`) are treated as opaque — a family rule
+   path-prefixed invocation** (`./git`, `/tmp/cargo`) are treated as opaque. A family rule
    only ever applies to a bare command name.
 2. **Condense** by family:
    - **Test runners** (`pytest`/`jest`/`vitest`/`ctest`/`cargo|go|npm|… test`): keep the
@@ -45,7 +45,7 @@ before the size-based compression:
    `<aimee_home>/tool-spills/<ref>.out` (temp → `fsync` → rename → dir `fsync`, mode `0600`,
    so a partial write is never promoted) and the condensed result ends with a pointer
    carrying the opaque `ref`. The agent retrieves the full original with the first-class
-   **`tool_output_get`** tool (P2) — one recovery handle, not a raw filesystem path. The
+   **`tool_output_get`** tool (P2): one recovery handle, not a raw filesystem path. The
    spill store is kept under a 64 MB budget by oldest-first (mtime) eviction.
 
 ## Safety contract
@@ -57,7 +57,7 @@ before the size-based compression:
 - **Never hide a failure.** A test runner or build with a **non-zero exit and no recognized
   failure line** passes through verbatim rather than risk eliding the cause.
 - **Fail-open everywhere.** An unrecognized command, an over-ceiling body (> 2 MB), or any
-  filter error degrades to the size-based `reduce.compress` — never a crash or a dropped
+  filter error degrades to the size-based `reduce.compress`, never a crash or a dropped
   result.
 - **No masquerade.** A path-prefixed command whose basename matches a known tool (`./git`)
   never inherits that tool's family filter.
@@ -71,15 +71,15 @@ before the size-based compression:
 Process-wide counters accumulate realized savings **and recovery cost** on live traffic
 ([`tool_condense_stats_snapshot`](../../src/tool_condense.c)): `recognized`, `applied`,
 `applied_raw` vs `applied_final` bytes, per-family (`test`, `diag`) counts, and the
-**recovery-cost** side — `recovered` (successful `tool_output_get` page-backs) and
+**recovery-cost** side: `recovered` (successful `tool_output_get` page-backs) and
 `recovered_bytes` (bytes re-injected). Two derived fields make the promotion-gate metric
 explicit:
 
 - `saved_bytes` = `applied_raw − applied_final` (gross condensation saving);
 - **`net_saved_bytes`** = `saved_bytes − recovered_bytes` (**net of recovery**).
 
-`net_saved_bytes` is the honest measure: if the agent keeps paging spilled output back in,
-`recovered_bytes` rises toward `saved_bytes` and the net collapses — the signal that the
+`net_saved_bytes` is the net after recovery: if the agent keeps paging spilled output back in,
+`recovered_bytes` rises toward `saved_bytes` and the net collapses, the signal that the
 lever is not net-saving on that workload. Each condensation logs its `raw→final` delta and
 each recall logs `tool_output_get recovered N bytes` under the `tool_condense` module, so the
 two sides are greppable together. (This precise per-call channel exists because

--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -44,7 +44,7 @@ before the size-based compression:
 3. **Spill + point.** The full raw output is **atomically** written to
    `<aimee_home>/tool-spills/<ref>.out` (temp → `fsync` → rename → dir `fsync`, mode `0600`,
    so a partial write is never promoted) and the condensed result ends with a pointer
-   carrying the opaque `ref`. The agent retrieves the full original with the first-class
+   carrying the opaque `ref`. The agent retrieves the full original with the dedicated
    **`tool_output_get`** tool (P2): one recovery handle, not a raw filesystem path. The
    spill store is kept under a 64 MB budget by oldest-first (mtime) eviction.
 
@@ -83,7 +83,7 @@ explicit:
 lever is not net-saving on that workload. Each condensation logs its `raw→final` delta and
 each recall logs `tool_output_get recovered N bytes` under the `tool_condense` module, so the
 two sides are greppable together. (This precise per-call channel exists because
-`tool_output_get` is the single first-class recovery handle from P2; `history_fold`/`compress`
+`tool_output_get` is the single dedicated recovery handle from P2; `history_fold`/`compress`
 recovery via fold-recall remains best-effort, not byte-exact.)
 
 ## Scope & rollout
@@ -97,7 +97,7 @@ The **default-ON** flip landed in unified-economizer **P1c**, justified by the d
 gate (lossless-on-demand + fail-open + a no-over-reduction audit); it replaces the old lossy
 32 KB read-cap truncation with lossless-recoverable condensation.
 
-The first-class **`tool_output_get`** retrieval tool + the atomic-write / bounded-eviction
+The dedicated **`tool_output_get`** retrieval tool + the atomic-write / bounded-eviction
 recovery contract landed in unified-economizer **P2**.
 
 **Carried follow-ups** (not yet shipped): the **primary-agent** surface (a client-side

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -14,8 +14,8 @@ keyword gap or a repo boundary that plain vector search would miss.
 
 ## The embedder
 
-Embedding and reranking are baked into the `aimee-kb-*` tier images — Qwen3-Embedding + an
-Ettin cross-encoder reranker — and served over HTTP (`/embed`, `/embed_batch`, `/rerank` on
+Embedding and reranking are baked into the `aimee-kb-*` tier images (Qwen3-Embedding + an
+Ettin cross-encoder reranker) and served over HTTP (`/embed`, `/embed_batch`, `/rerank` on
 the gateway `:8742`). The KB calls them; it runs no model. See
 [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md) for the tiers and
 [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md) for pointing the KB at one. (The reranker emits a
@@ -30,7 +30,7 @@ Two embedding widths ship:
 
 The 4B/2560 tier has better recall on large or meaning-heavy corpora; the 0.6B/1024 tier is
 the low-footprint default. The retrieval pipeline (hybrid search, reranking, fusion) is
-identical either way — only the model sizes differ.
+identical either way. Only the model sizes differ.
 
 ### Switching tiers
 
@@ -44,7 +44,7 @@ AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
 Both GPU tiers are 2560-dim, so moving between `gpu-small` and `gpu-mid` needs no re-embed.
 Moving between 1024 and 2560 is a model-identity **and** width change: on an **empty** DB
 just set the dim; on a **populated** one it's a drop-and-rebuild re-embed (the `halfvec`
-columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces — see
+columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces. See
 [Switching embedders on an existing database](#switching-embedders-on-an-existing-database).
 
 ## Configuration

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -1,6 +1,6 @@
 # Runbook: cut over to the unified `aimee-llm` container
 
-The unified-llm-container migration (P7). **Operator-gated** — the production flip
+The unified-llm-container migration (P7). **Operator-gated**: the production flip
 (deploy + corpus re-embed) is a deliberate maintenance op, never automatic. P1–P6 ship the
 pieces; this runbook is the order of operations + the gates.
 
@@ -11,19 +11,19 @@ head)+`/v1/chat/completions`, and offload to the AMD 7900 XTX via Vulkan (`-ngl 
 > **Naming update (post-cutover):** the images built here were renamed
 > `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small`, and a third GPU
 > tier `aimee-kb-gpu-mid` (Gemma 4 26B-A4B) was added; `aimee-llm` is now only the plugin
-> name. The steps below keep the original names as a record — for the current tiers and
+> name. The steps below keep the original names as a record, for the current tiers and
 > build-args see [../AIMEE_KB_SYNTH_TIERS.md](../AIMEE_KB_SYNTH_TIERS.md).
 
 ## 0. What changes
 
 - **From:** torch `aimee-embedder` (pplx-embed + ettin via sentence-transformers) + the
   stock `llm` llama.cpp container (gemma synth).
-- **To:** one `aimee-llm` image (CPU or GPU tier) — Vulkan llama.cpp serving embed
+- **To:** one `aimee-llm` image (CPU or GPU tier): Vulkan llama.cpp serving embed
   (Qwen3-Embedding) + rerank (ettin encoder + the gateway Dense head) + synth (gemma),
   models baked in.
 - **Corpus re-embed required:** `pplx-embed` → `Qwen3-Embedding` is a **`model_id` change**
   (and 0.6B→1024 / 4B→2560 a possible **dim** change), so the `kb_meta` drift guard (P1,
-  now activated — `db2_set_embedder_model_id`) will **refuse** to serve the new embedder
+  now activated, `db2_set_embedder_model_id`) will **refuse** to serve the new embedder
   against the old corpus. The re-embed is the controlled drop-and-rebuild below.
 
 ## 1. Pre-cutover ship-floor gate (staging, BEFORE the production flip)
@@ -40,13 +40,13 @@ release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollb
 CI builds + publishes both tiers as part of the normal release cycle:
 - **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds
   `aimee-kb-cpu` + `aimee-kb-gpu-small` + `aimee-kb-gpu-mid` on every release and tags them
-  `:<version>` + `:latest`. They are in both the `build` and the `merge` matrices — the
+  `:<version>` + `:latest`. They are in both the `build` and the `merge` matrices; the
   merge step applies the tags, so a build that pushes only by digest leaves `tags:null`.
   (`gpu-mid` is amd64-only.)
 - **testing:** `.github/workflows/publish-llm-testing.yml` builds `cpu` + `gpu-small` on
   `testing` pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts,
   tagged `:testing` (+ `:testing-<sha>`, amd64). `gpu-mid` is dispatch-only
-  (`build_kb_gpu_mid=true`) — a tested-but-unreleased image for `.254`.
+  (`build_kb_gpu_mid=true`): a tested-but-unreleased image for `.254`.
 
 To build out-of-band (e.g. on a PVE CT with docker):
 
@@ -60,7 +60,7 @@ docker build -f Dockerfile.aimee-llm -t aimee-kb-gpu-small \
   --build-arg SYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf \
   --build-arg SYNTH_FA=on .
 ```
-(gpu-mid swaps the synth args to Gemma 4 26B-A4B — see the tiers doc for the exact pins.)
+(gpu-mid swaps the synth args to Gemma 4 26B-A4B; see the tiers doc for the exact pins.)
 
 ## 3. Deploy to `.254` (tierd / LXC, GPU)
 
@@ -69,27 +69,27 @@ Vulkan/RADV render path (**not** ROCm/`kfd`). Deploy the GPU image as a tierd pl
 (manifest-swap, per the `.254` deploy memory) + `AIMEE_LLM_NGL=99`. The in-repo manifest is
 `deploy/smoothnas/aimee-llm.plugin.yaml` (pin its image to `:testing` for staging,
 `:latest`/`:<version>` for production). GPU passthrough uses the **built-in `gpu-amd`
-profile** (compiled into tierd — the one Wolf/Steam use), so there is no custom profile to
+profile** (compiled into tierd, the one Wolf/Steam use), so there is no custom profile to
 install and no node path to pin; verified on .254 the container enumerates `Vulkan0 : AMD
 Radeon Graphics (RADV GFX1100)` and offloads to VRAM. The gateway is host-published on
-**:8742** (NOT :8080 — Wolf's WolfLeash UI host-publishes 8080, and two plugins on one host
+**:8742** (NOT :8080, since Wolf's WolfLeash UI host-publishes 8080, and two plugins on one host
 port silently collide: the runtime DNATs both, one wins and the other is unreachable though
 "running"). Point the kb at it: `AIMEE_EMBEDDER_URL=http://10.100.0.1:8742` (the gateway preserves the
 `/embed`+`/embed_batch`+`/rerank` contract, so `embed-remote.py`/`rerank-remote.py` are
 untouched). Set the kb's `embedding_model` to the new identity (activates the P1 guard) and
 `embedding_dim` to the tier's dim (2560 for the 4B GPU tier). **Verify the URL actually
-serves the named model before re-embedding** — a misrouted `AIMEE_EMBEDDER_URL` (still
+serves the named model before re-embedding**: a misrouted `AIMEE_EMBEDDER_URL` (still
 pointing at the old embedder) would silently embed under the new identity and the guard
 would not catch it (it checks identity-vs-corpus, not URL-vs-identity). **Auth on the embed
 path:** the kb embeds/reranks with NO bearer (`memory_embed_http_post` sends a NULL auth
-header), so when this gateway backs `AIMEE_EMBEDDER_URL` it MUST run **auth-off** — leave
+header), so when this gateway backs `AIMEE_EMBEDDER_URL` it MUST run **auth-off**: leave
 `AIMEE_LLM_AUTH_TOKEN` empty/unset. The gateway treats an empty token as "auth disabled,"
 acceptable here because it is `expose:false` (internal bridge only; deployment network is the
 boundary). Only set `AIMEE_LLM_AUTH_TOKEN` when the gateway serves *only* bearer-capable
 callers (e.g. curator `tier_b` synth); if so it comes from the secret store (vault / Docker
 secret / `.gitignore`d per-host `.env`), **never a checked-in plaintext value**.
 
-## 4. Corpus re-embed (controlled drop-and-rebuild — the `maintenance` window)
+## 4. Corpus re-embed (controlled drop-and-rebuild, the `maintenance` window)
 
 In-place `halfvec` type changes against a live kb are forbidden. The migration:
 
@@ -100,10 +100,10 @@ In-place `halfvec` type changes against a live kb are forbidden. The migration:
    identity on the fresh `kb_meta`).
 4. **Replay** the source rows through the new embedder (bounded batch).
 5. **Parity gate:** pre-drop vs post-backfill counts must match **and** a sampled
-   value-check must pass (row counts alone miss silent corruption — wrong rows re-embedded,
+   value-check must pass (row counts alone miss silent corruption: wrong rows re-embedded,
    off-by-one batch, wrong prompt template, a dim swap). Over a held-out sample (≥1% or 10k
    rows, whichever is larger): every vector has the expected `array_length`, no NaN/all-zero
-   rows, and — where a stable subset is re-embeddable from the snapshot — cosine vs the
+   rows, and, where a stable subset is re-embeddable from the snapshot, cosine vs the
    snapshot is within tolerance for the *same* model (and `kb_meta.schema_embedder_model_id`
    is the new identity). Any divergence → `degraded`, hold. On parity → lift `maintenance`.
 
@@ -119,7 +119,7 @@ restoring the prior dim-sized `halfvec` from the §4 snapshot, CI round-tripped 
 cutover). This is a gated maintenance op, not an instant toggle. Once the first
 post-cutover release is validated, no prior tag contains pplx/ettin and rollback is no
 longer deploy-tag-based; retain the prior tag in the registry for a defined window (e.g. 6
-months). **Snapshot retention ≥ tag retention** — the §4 snapshot is the only rollback
+months). **Snapshot retention ≥ tag retention**: the §4 snapshot is the only rollback
 input once the tag ages out, so it must outlive the tag, with a checksum and an expiry
 review. Pre-cutover checklist (all must be true before §3): snapshot present + checksum
 verified; reverse-migration **rehearsed in staging** (round-trips to the prior dim/identity);
@@ -129,7 +129,7 @@ ship-floor gate green.
 
 After validation: remove `Dockerfile.embedder` + the `embedder`/`llm` compose/deploy
 services + the `codex-auth`/pplx-ettin references. (Kept until here so the prior tag is a
-working rollback target — §5.)
+working rollback target, §5.)
 
 ## Gates summary
 

--- a/docs/runbooks/vault-master-key-rotation.md
+++ b/docs/runbooks/vault-master-key-rotation.md
@@ -2,7 +2,7 @@
 
 Rotate the server-sealed master key that protects the credential vault (D13 of the
 [cred-vault-consolidation](../proposals/done/cred-vault-consolidation.md) proposal).
-**Operator-gated, offline maintenance op** — never automatic.
+**Operator-gated, offline maintenance op**: never automatic.
 
 ## 0. What this does (and does not)
 
@@ -11,7 +11,7 @@ The 32-byte `.server-master.key` lives `0600` beside the vault at
 wraps every server-decryptable credential's data-encryption key (DEK):
 
 - the **server principal** (`server`) holds the server KEK as its **primary** wrap
-  (`wrapped_dek`) — these are the shared delegate keys (minimax/mistral/glm/codex…);
+  (`wrapped_dek`). These are the shared delegate keys (minimax/mistral/glm/codex…);
 - every **user principal** that has a dual-access entry holds it in `wrapped_dek_server`.
 
 Rotation mints a fresh master key and **re-wraps** those DEKs from the old server KEK to the
@@ -27,7 +27,7 @@ Trust boundary is unchanged: the new master key is still a `0600` file on the se
 ## 1. Why it is offline
 
 `aimee-server` caches one process-wide server KEK. A *live* rotation would leave autonomous
-decrypts failing for the window between re-wrapping a credential and swapping the key — every
+decrypts failing for the window between re-wrapping a credential and swapping the key. Every
 delegate would 401 mid-rotation. So rotation runs with the **server stopped**, against the
 on-disk vault, and exits.
 
@@ -35,10 +35,10 @@ on-disk vault, and exits.
 
 - **Server stopped.** `--rotate-master-key` refuses to run if an `aimee-server` instance is
   live for the default socket (the server caches the old KEK and could write a credential
-  under it during the re-wrap window — see §1). Stop the server first.
+  under it during the re-wrap window; see §1). Stop the server first.
 - **`AIMEE_HOME` permissions.** The pre-rotation backup is written under `AIMEE_HOME` as a
   `0700` directory of `0600` files, but it inherits the *parent* directory's reachability.
-  Ensure `AIMEE_HOME` is writable only by the server's runtime UID — otherwise the backup
+  Ensure `AIMEE_HOME` is writable only by the server's runtime UID; otherwise the backup
   (which holds old-key ciphertext) sits in a directory others can traverse.
 
 ## 3. Procedure
@@ -70,7 +70,7 @@ rm -rf /var/lib/aimee/.vault.rotate-bak.12345
 - **Atomic + reversible.** The entire `.vault/` is copied to `.vault.rotate-bak.<pid>` (0700)
   **before** any mutation. If any principal's re-wrap fails (wrong key / tamper) **or** the
   new master key cannot be persisted, the vault is **restored from that backup** and the
-  command aborts non-zero with the vault unchanged — never a new-wrapped vault under an old
+  command aborts non-zero with the vault unchanged, never a new-wrapped vault under an old
   master, nor the reverse.
 - **Crash mid-run.** The new master key is written **last** (atomic tmp+rename+fsync), only
   after every re-wrap has succeeded. A crash before that leaves the old master + old wraps

--- a/docs/v1-op-parity-buildout.md
+++ b/docs/v1-op-parity-buildout.md
@@ -1,7 +1,7 @@
 # `/v1` op-parity buildout: route→method map and wave plan
 
 > Working tracker for **P1 / WP1.x / WP1.fin** of the aimee `/v1` hub-migration plan.
-> Goal: **every NDJSON RPC method gets a first-class `/v1` HTTP route** (or a
+> Goal: **every NDJSON RPC method gets a dedicated `/v1` HTTP route** (or a
 > documented, deliberate exclusion). The generic `POST /v1/rpc` passthrough is
 > retired; this buildout gave each method a dedicated, self-documenting,
 > OpenAPI-listed route.
@@ -9,7 +9,7 @@
 ## Mechanism (already landed: WP0.2, #2531)
 
 The `/v1` surface is a declarative table in
-`src/server/server_http_routes.inc`. Adding a first-class route is:
+`src/server/server_http_routes.inc`. Adding a dedicated route is:
 
 1. **One table row.** For a single-response method that takes a **JSON-object
    body**, the row is `{"POST", "/v1/<family>/<verb>", NULL, RM_EXACT,
@@ -43,13 +43,13 @@ The `/v1` surface is a declarative table in
   `GET /v1/models`, `GET /v1/kb/status`, backed by `route_json_provider`) are a
   *different* curated surface and coexist with the per-method routes below.
 
-## Deliberate exclusions (NOT given a first-class route)
+## Deliberate exclusions (NOT given a dedicated route)
 
 | Method(s) | Why |
 |---|---|
-| `hooks.pre`, `hooks.post`, `hooks.session_start` | Internal harness lifecycle hooks; now first-class privileged routes at `/v1/hooks/*`, gated by `CAP_TOOL_EXECUTE`. |
-| `runner.poll`, `runner.respond` | Already first-class (`/v1/runner/*`, workspace detached reverse channel). |
-| `primary.get/set/clear` | Already first-class via `/v1/sessions/{id}/primary`. |
+| `hooks.pre`, `hooks.post`, `hooks.session_start` | Internal harness lifecycle hooks; now dedicated privileged routes at `/v1/hooks/*`, gated by `CAP_TOOL_EXECUTE`. |
+| `runner.poll`, `runner.respond` | Already dedicated (`/v1/runner/*`, workspace detached reverse channel). |
+| `primary.get/set/clear` | Already dedicated via `/v1/sessions/{id}/primary`. |
 | `tool.execute` | Internal tool-execution path at `/v1/tools/execute` (workspace plane); gated by `CAP_TOOL_EXECUTE`, not a public verb. |
 
 > **Inline-dispatch latency budget.** Dispatch-op routes run inline on the
@@ -61,7 +61,7 @@ The `/v1` surface is a declarative table in
 > they are routed **async** via `rh_dispatch_op_async`: the POST returns a
 > queued run handle and a detached worker drives the loopback RPC to completion;
 > poll status/result at `GET /v1/runs/{id}`. So they keep the listener free
-> while still being first-class `/v1` routes.
+> while still being dedicated `/v1` routes.
 
 `server.health`/`server.info` and `model.list` overlap the existing
 `/v1/health`, `/v1/version`, `/v1/models` read-views; the owning wave maps them
@@ -69,7 +69,7 @@ to the existing route (no duplicate) and notes it.
 
 ## Family → wave map
 
-Counts are methods needing a *new* first-class route (after exclusions). Each
+Counts are methods needing a *new* dedicated route (after exclusions). Each
 wave is one delegated packet (`aimee delegate code --persona engineer --verify
 "cd src && make server-api-conformance-check && make unit-tests"`), with the
 registry + handler files + `--files` preloaded. **Waves are serialized** (each


### PR DESCRIPTION
## What

A voice pass over the README and the ~30 user-facing docs for house voice.

## Scope

- **In:** `README.md` + `docs/*.md` + `docs/features/`, `docs/dev/`, `docs/runbooks/`, `docs/observability/` (markdown only).
- **Out (deliberately):** `docs/gen/*` (generated — editing breaks `docs-gen-check`), `docs/proposals/*` (historical design records), and `docs/PROPOSALS.md` (reconciled index of those proposals).

## Verification

`grep '—'` across every in-scope `.md` returns only the intentional placeholders/literals above; a broad tell-sweep (`honest|cleanly|gracefully|out of the box|first-class|...`) comes back clean.