### PR TITLE
Promote testing to main

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -82,18 +82,24 @@ jobs:
           # the 0.6b embedder + 400m reranker.
           - { name: aimee-embedder-4b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1" }
           # The unified aimee-kb container (one Vulkan llama.cpp + the gateway serving
-          # embed+rerank+synth, models baked in). THREE tiers differ only by the SYNTH
+          # embed+rerank+synth, models baked in). FOUR tiers differ only by the SYNTH
           # model + its runtime profile (embed/rerank identical within a class):
           #   aimee-kb-cpu       defaults: 0.6B emb + ettin-68m + gemma-4-E4B (CPU)
-          #   aimee-kb-gpu-small 4B/400m + Gemma-4-12B qat-UD-Q4_K_XL (dense, FA+K8V4)
+          #   aimee-kb-gpu-small 4B/400m + Gemma-4-12B qat-UD-Q4_K_XL (dense, FA+K8V4; 16GB)
           #   aimee-kb-gpu-mid   4B/400m + Gemma-4-26B-A4B qat-UD-Q4_K_XL (MoE, 4B active,
           #                      FA+K8V4; ~14GB fits 24GB fully-resident → N_CPU_MOE=0;
-          #                      GGUF pinned by HF rev+sha256)
-          # gpu-small/gpu-mid share the 2560-dim embedder so a KB is portable across the
+          #                      GGUF pinned by HF rev+sha256; SLOTS=2 → deploy 2×128K)
+          #   aimee-kb-gpu-large IDENTICAL to gpu-mid (same 26B-A4B GGUF/profile) but
+          #                      SLOTS=4 for 32GB cards → deploy 4×256K (each agent the
+          #                      full native 262144 window; Gemma's windowed KV keeps
+          #                      even 4×256K under ~28.5GiB, validated vs the 24GB mid card)
+          # gpu-small/mid/large share the 2560-dim embedder so a KB is portable across the
           # synth swap. amd64 GPU host runs the x64 Vulkan binary; NGL set at deploy.
           - { name: aimee-kb-cpu, dockerfile: Dockerfile.aimee-llm }
           - { name: aimee-kb-gpu-small, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF\nSYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=9586f3257bc62bd179767241c7ec0f66bc2a314a\nSYNTH_SHA256=cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165\nSYNTH_FA=on" }
           - { name: aimee-kb-gpu-mid, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF\nSYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c\nSYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=0\nSYNTH_SLOTS=2" }
+          # gpu-large: same GGUF as gpu-mid, only SYNTH_SLOTS=4 (24GB→32GB card headroom).
+          - { name: aimee-kb-gpu-large, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF\nSYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c\nSYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=0\nSYNTH_SLOTS=4" }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -154,10 +160,10 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        # aimee-kb-gpu-mid (Gemma-4-26B-A4B, ~14GB) is amd64-only: arm64 would bake a
-        # non-runnable x64 Vulkan binary and double the build/disk cost. Skip it on arm64
+        # aimee-kb-gpu-mid/large (Gemma-4-26B-A4B, ~14GB) are amd64-only: arm64 would bake a
+        # non-runnable x64 Vulkan binary and double the build/disk cost. Skip them on arm64
         # -> the merge job emits a single-arch amd64 manifest (it tolerates count>=1).
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context || '.' }}
@@ -174,8 +180,8 @@ jobs:
           # layer cache. Same exclusion for the aimee-kb-* tiers: they BAKE multi-GB
           # GGUFs (Qwen3-Embedding + gemma) into the image, so caching those layers
           # would likewise blow the 10 GB GHA budget and evict the C-image caches.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-kb-gpu-large' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-kb-gpu-large' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
@@ -200,13 +206,13 @@ jobs:
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.image.name }}-${{ matrix.platform.arch }}"
 
       - name: Upload digest
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
         uses: actions/upload-artifact@v4
         with:
           name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}
@@ -221,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-kb-cpu, aimee-kb-gpu-small, aimee-kb-gpu-mid, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-kb-cpu, aimee-kb-gpu-small, aimee-kb-gpu-mid, aimee-kb-gpu-large, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/.github/workflows/publish-llm-testing.yml
+++ b/.github/workflows/publish-llm-testing.yml
@@ -10,10 +10,10 @@
 # server-code push would be wasteful. So it triggers ONLY on the aimee-kb
 # sources (the Dockerfile + the gateway/supervisor scripts).
 #
-# Tiers built every push: aimee-kb-cpu + aimee-kb-gpu-small (Gemma). The
-# aimee-kb-gpu-mid (Gemma-4-26B-A4B, ~14GB) is dispatch-only. amd64 only (the .254
-# deploy target); the release pipeline owns
-# multi-arch.
+# Tiers built every push: aimee-kb-cpu + aimee-kb-gpu-small (Gemma). The big MoE
+# tiers aimee-kb-gpu-mid and aimee-kb-gpu-large (both Gemma-4-26B-A4B, ~14GB; they
+# differ ONLY in baked SYNTH_SLOTS, 2 vs 4) are dispatch-only. amd64 only (the .254
+# deploy target); the release pipeline owns multi-arch.
 name: Publish testing aimee-llm
 
 on:
@@ -28,7 +28,11 @@ on:
   workflow_dispatch:
     inputs:
       build_kb_gpu_mid:
-        description: "Also build the aimee-kb-gpu-mid (Gemma-4-26B-A4B synth, ~14GB)"
+        description: "Also build the aimee-kb-gpu-mid (Gemma-4-26B-A4B synth, ~14GB, SLOTS=2)"
+        type: boolean
+        default: false
+      build_kb_gpu_large:
+        description: "Also build the aimee-kb-gpu-large (same 26B-A4B synth, ~14GB, SLOTS=4, 32GB card)"
         type: boolean
         default: false
 
@@ -175,3 +179,76 @@ jobs:
           tags: |
             ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing
             ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing-${{ env.SHA7 }}
+
+  # aimee-kb-gpu-large (Gemma-4-26B-A4B synth, ~14GB MoE): byte-identical to gpu-mid
+  # except baked SYNTH_SLOTS=4 (24GB→32GB card headroom; deploy at 4×256K). Same
+  # dispatch-only + /mnt-relocation + df pre-flight rationale as build-kb-gpu-mid.
+  build-kb-gpu-large:
+    if: github.event_name == 'workflow_dispatch' && inputs.build_kb_gpu_large
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize owner + short sha
+        run: |
+          echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+          echo "SHA7=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Reclaim toolchains AND relocate docker's data-root to the larger /mnt disk
+      # BEFORE buildx is created, so buildkit writes the ~14GB model layers there
+      # (mirrors publish-images.yml's aimee-kb-leg fix, commit f26cf76).
+      - name: Free disk + move docker storage to /mnt
+        run: |
+          echo "before:"; df -h / /mnt
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
+          sudo docker image prune --all --force || true
+          sudo systemctl stop docker docker.socket || true
+          sudo mkdir -p /mnt/docker
+          printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker || true
+          echo "after:"; df -h / /mnt
+
+      # Fail fast if /mnt can't hold the image's transient footprint instead of dying
+      # mid-build with ENOSPC after the model download.
+      - name: Pre-flight disk check
+        run: |
+          avail=$(df --output=avail -BG /mnt | tail -1 | tr -dc '0-9')
+          echo "/mnt available: ${avail}GB"
+          if [ "${avail:-0}" -lt 80 ]; then
+            echo "::error::/mnt has only ${avail}GB free; need >=80GB for the kb-gpu-large build"; exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push aimee-kb-gpu-large:testing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.aimee-llm
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          build-args: |
+            EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF
+            EMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf
+            RERANK_REPO=cross-encoder/ettin-reranker-400m-v1
+            SYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF
+            SYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
+            SYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c
+            SYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e
+            SYNTH_FA=on
+            SYNTH_MOE=1
+            SYNTH_N_CPU_MOE=0
+            SYNTH_SLOTS=4
+          tags: |
+            ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-large:testing
+            ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-large:testing-${{ env.SHA7 }}

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -5,7 +5,8 @@
 # Two published images (operator-directed: models baked in, not runtime-fetched —
 # turnkey, reproducible, no HF dependency at run time):
 #   aimee-kb-cpu       (defaults): Qwen3-Embedding-0.6B + ettin-68m + gemma-4-E4B
-#   aimee-kb-gpu-small/mid (build args): 4B + ettin-400m + gemma-4-12B OR gemma-4-26B-A4B
+#   aimee-kb-gpu-small/mid/large (build args): 4B + ettin-400m + gemma-4-12B (small,
+#     16GB) OR gemma-4-26B-A4B (mid=24GB SLOTS=2 / large=32GB SLOTS=4 — same GGUF)
 # The llama.cpp binary is the VENDOR-AGNOSTIC Vulkan build (one binary for AMD/
 # Nvidia/Intel); GPU is selected at runtime by AIMEE_LLM_NGL (CPU image defaults 0).
 #

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1421,7 +1421,8 @@ the server. Four compose files ship, built from three images: `aimee-server`
 bundles a CPU inference gateway (embeddings, reranking, and synthesis) from the
 `aimee-kb` image family, so embedding and reranking work with nothing external.
 The CPU tier serves Qwen3-Embedding-0.6B at 1024 dims; the GPU tiers
-(`aimee-kb-gpu-small`, `aimee-kb-gpu-mid`) serve Qwen3-Embedding-4B at 2560 dims.
+(`aimee-kb-gpu-small` 16 GB, `aimee-kb-gpu-mid` 24 GB, `aimee-kb-gpu-large` 32 GB)
+serve Qwen3-Embedding-4B at 2560 dims.
 To run a standalone embedder or curator LLM instead of the bundled gateway, use
 the `external-llm` compose profile. Backends and tiers:
 [KB_LLM_BACKENDS.md](docs/KB_LLM_BACKENDS.md) and

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ back instead of raw content, so you save twice, on the delegate and on the prima
 context. aimee also compresses what each turn sends upstream, so even your main model's bill
 drops. It tracks cost and success per delegate and routes better over time.
 
+**Tokens cut on both ends.** A context economizer works in two tiers. The safe tier
+runs by default: it deterministically condenses tool output (keeps the failing test,
+elides the passing ones; keeps compiler errors, drops progress spam), compresses oversized
+results, and folds stale turn history into a rolling skeleton, with the full output spilled
+to disk for recovery. The aggressive tier is opt in: it applies the same reduction to the
+live primary request so your main model's own bill drops too, compress only, behind a per
+session circuit breaker that never dispatches anything it cannot restore. See
+[Settings](docs/SETTINGS.md).
+
+**A tamper evident record of every action.** Each governed tool call runs through one choke
+point that decides allow, rewrite, or block, and writes that verdict to an append only,
+mode-0600, rotated audit ledger: who acted, which tool, the mode, a stable reason code, and
+a keyed HMAC digest of the arguments, keyed so a low entropy argument cannot be recovered
+from the log and allowlisted so a new tool can never leak a secret into it. Human sign off
+gates are HMAC-SHA256 signed and non forgeable. Decision records capture what you decided,
+why, what it supersedes, and when to revisit it, one active per scope. See
+[Security Model](docs/SECURITY.md) and [KB Console](docs/KB_CONSOLE.md).
+
 **Run the models yourself.** aimee ships a self hosted inference stack: embeddings,
 reranking, and synthesis baked into one CPU or GPU container. The knowledge base curates entirely
 on your hardware with no outside API calls, and the same local model doubles as a free
@@ -58,6 +76,24 @@ reviews the work, and the delegates do the building. See
 configs are blocked before the AI can touch them. Known anti patterns raise warnings.
 Planning mode freezes every write until you are ready. Each session runs in its own git
 worktree, so two sessions never step on each other.
+
+**A browser workspace, not just a backend.** aimee ships its own browser UI, `aimee-webchat`:
+chat, a live view of your code as a graph, a git project manager that clones repos and holds
+per host tokens, a full in app VS Code editor, and dashboards over what the server is doing.
+No terminal required. See [Dashboard & Logs](docs/DASHBOARD.md).
+
+**Ready for a team.** Multi user accounts with scoped tokens, OIDC single sign on, optional
+mutual TLS client identity, and a per principal encrypted credential vault so one user's git
+token or provider key is never readable by another. See [Security Model](docs/SECURITY.md).
+
+**Documents become evidence.** Ingest a PDF and every retrieved snippet carries the page and
+bounding box it came from, so an answer traces back to the exact spot on the page. Table
+cells, figure crops, and OCR of scanned pages layer on top. See
+[Structured PDF](docs/STRUCTURED_PDF.md).
+
+**A roundtable of models.** Fan a task out to a panel and synthesize one answer, or run a
+bounded multi round draft-or-review where several models critique and converge. The same
+mechanism staffs the reviews in autonomous development. See [Personas](docs/personas.md).
 
 ## The problem
 
@@ -116,11 +152,70 @@ graph instead of reading the files over again. The graph is cross repo: one depe
 repository you work across, so a change in a shared library shows its blast radius in the
 services that consume it. See [Code intelligence](docs/CODE_INTELLIGENCE.md).
 
+### Documents as coordinate anchored evidence
+
+aimee-kb can ingest a PDF as coordinate anchored evidence instead of a flat blob of text.
+Every retrieved snippet carries the page number and bounding box it came from, so an answer
+is traceable to the exact place on the page rather than to an unlocatable paraphrase. On top
+of that spine the KB optionally recognises table cells (structured `{row, col, text}`
+lookups), renders visual crops of figures, tables, and pages into a content addressed store,
+and OCRs scanned or image only pages back through the same citation path. Each layer is its
+own opt in and degrades cleanly to the one below when its dependency is absent, and every
+read surface honours the same document level access control as the text spine. See
+[Structured PDF](docs/STRUCTURED_PDF.md).
+
 ### Guardrails
 
 Before every edit, aimee classifies the target. Sensitive files like `.env`, credentials,
 and private keys are blocked before the AI touches them. Known anti patterns trigger
 warnings. Planning mode locks all writes until you are ready.
+
+### Governance and a tamper evident action ledger
+
+Every governed tool call passes through one choke point (`pre_tool_check`) that computes an
+allow, rewrite, or block verdict and records that verdict to a single append only,
+mode-0600, rotated audit ledger: `{ts, actor, tool, mode, reason_code, verdict, args_hash}`.
+The `reason_code` is a stable event key, never free form prose, so nothing user bearing is
+persisted. `args_hash` is a keyed HMAC-SHA256 over a per tool allowlist projection of the
+arguments: keyed so low entropy arguments cannot be recovered from the public log by
+dictionary attack, allowlisted by construction so a new tool or a new argument can never
+silently leak a secret or PII value into an append only log, and versioned. Auditing is
+**fail open by construction** — the log write happens after the verdict is decided, so a
+logging failure can never flip an allow to a block. The ledger is replayable:
+`trajectory_export` interleaves the governed actions back into the session timeline by
+timestamp, and the operator console exposes the feed at `/v1/audit/actions`.
+
+Alongside the action ledger, aimee keeps **decision records** — governable "we decided X
+because Y" entries carrying status, rationale, alternatives, a revisit date, what they
+supersede, the author, and the policy they bind. At most one decision is active per scope
+(enforced by a database unique index, not just by the writer), superseding one flips the
+prior in the same transaction, and a decision past its revisit date resurfaces on the
+existing recall and curator sweeps rather than rotting silently. Human sign off gates on
+sensitive actions are HMAC-SHA256 signed and non forgeable. Both surfaces are live in the
+[KB Console](docs/KB_CONSOLE.md) (`/v1/decisions`, `/v1/audit/actions`).
+
+Retrieval has a parallel, opt in audit chain: every KB grounded answer is reconstructible —
+which sources grounded it, at which content hashed version, and whether the answer is
+entailed by that evidence — read back through `/v1/audit/{trace,provenance,fidelity}`.
+
+### The context economizer
+
+aimee runs a context economizer over both the delegate turn loop and, optionally, the live
+primary `/v1` path, gated by a master switch and split into two tiers. The **safe tier**
+is default on: deterministic tool output condensation (keep the failing test, elide the
+passing ones; keep compiler diagnostics, drop progress), size based compression of oversized
+tool results, and folding old turn history into a rolling skeleton — recent context is never
+touched, and the full output is spilled to disk for recovery. A measurement ledger records
+the reduction opportunity even when a lever is off, so the master switch off state provably
+reduces to zero.
+
+The **aggressive tier** is opt in and off by default: it applies the reduction to the live
+inbound request so the primary agent's own tokens shrink too. It is compress only, and
+guarded by a per session circuit breaker — if a reduced request draws an error the session
+falls back to the pristine payload and disables reduction for its remaining turns, so one bad
+reduction can never persistently break live traffic. aimee never dispatches a reduced payload
+it cannot restore to the byte identical original. See [Settings](docs/SETTINGS.md) and
+[Tool output condensation](docs/features/tool-output-condensation.md).
 
 ### Delegation that cuts your bill
 
@@ -135,6 +230,18 @@ the primary model's bill on top of the delegate savings.
 ```bash
 aimee delegate review "Review this PR"     # routes to cheapest capable delegate
 aimee delegate code --tools "Add tests"    # delegate with file read/write access
+```
+
+When one model is not enough, run a **roundtable**: fan a task out to a panel and have an
+aggregator synthesize a single answer (`aimee delegate aggregate`), or run a bounded
+multi round draft-or-review where several models critique each other and converge, with cost
+and round caps (`aimee delegate roundtable --mode draft|review`). This is the same panel that
+staffs the reviews in autonomous development, and it composes from your configured
+[personas](docs/personas.md).
+
+```bash
+aimee delegate aggregate "Design an idempotent retry scheme"     # Mixture-of-Agents fan-out + synthesis
+aimee delegate roundtable "Review this design" --mode review     # bounded multi-round critique
 ```
 
 ### Run your own inference
@@ -173,6 +280,30 @@ Provider config is in the
 [Manual](MANUAL.md#25-integrations). The memory, guardrails, and delegation are the same on
 every front end, because they live in the server and kb, not the tool.
 
+### A browser workspace
+
+aimee ships its own browser UI, `aimee-webchat`, so you never need a terminal to use it. It
+is a thin, stateless client that proxies to `aimee-server`, with one tab per tool: **Chat**
+against any configured model; a **Graph** explorer that renders your indexed code as a live
+symbol and call graph; **Projects** to clone git repos over HTTPS or SSH form URLs; a full
+in app **VS Code editor** (a per user `code-server` the server supervises and reverse proxies)
+opened on the selected project; **Workflow Actions** to author a proposal and watch it run
+autonomously; and a **Dashboard** plus a **Logs** tab that show the server's delegations, tool
+calls, token spend, guardrail verdicts, and active sessions at a glance. See
+[Dashboard & Logs](docs/DASHBOARD.md) and [Workspace Management](docs/WORKSPACES.md).
+
+### Built for a team
+
+aimee is single user on a laptop and multi user on a server without changing the model.
+Clients enroll as accounts with **scoped tokens** (a request outside a token's grant is
+denied with `403`); the browser console authenticates with **OIDC single sign on**; the
+remote `/v1` path can require **mutual TLS** client identity; and every user's git tokens,
+provider keys, and OAuth credentials live only in a **per principal encrypted vault**, sealed
+by a server master key so one tenant can never read another's secret or files. The vault's
+master key rotates through an operator gated, offline runbook. See
+[Security Model](docs/SECURITY.md), [KB Console](docs/KB_CONSOLE.md), and
+[Webchat git security](docs/WEBCHAT_GIT_SECURITY.md).
+
 ## Works with what you already use
 
 | Tool | Integration | Run on any model | Setup |
@@ -194,12 +325,18 @@ works the same way. Switch tools any time. Your memory and context stay.
   compound into a knowledge base.
 - **No lock-in.** Run any turn on any provider's model, or your own, and switch with one
   command.
-- **Lower bills.** Cheapest capable delegate routing keeps the primary's context small,
-  upstream compression trims every turn, and local and subscription delegates cost nothing
-  extra.
+- **Lower bills.** Cheapest capable delegate routing keeps the primary's context small, the
+  context economizer trims every turn on both the delegate and the primary path, and local
+  and subscription delegates cost nothing extra.
 - **Fewer mistakes.** Sensitive file blocking, anti pattern warnings, and planning mode
   catch problems before the AI writes them.
-- **Team knowledge.** One shared kb distills what your whole organization knows.
+- **Provable and governable.** Every governed action lands in a tamper evident, keyed-HMAC
+  audit ledger, decisions are recorded with rationale and a revisit trigger, and KB grounded
+  answers are reconstructible back to their sources.
+- **Team knowledge.** One shared kb distills what your whole organization knows, behind
+  scoped accounts, OIDC sign on, and a per principal encrypted vault.
+- **A UI when you want one.** A browser workspace with chat, a code graph explorer, git
+  project management, an in app VS Code editor, and server dashboards — no terminal required.
 - **Yours to run.** C services, single digit millisecond hot paths, and an inference stack
   you can run entirely on your own hardware.
 
@@ -274,6 +411,8 @@ Focused references:
 | [Workflow Actions](docs/WORKFLOW_ACTIONS.md) | The web page to author a proposal, run it autonomously, and watch its status/history |
 | [Dashboard & Logs](docs/DASHBOARD.md) | The web Dashboard's server-incurred metric panels, customization, the Logs (tool-action audit) tab, and the panel data architecture |
 | [Settings](docs/SETTINGS.md) | The web page for the server's typed runtime config — economizer levers, autonomous-dev knobs, tool-output condensation, and how each maps to `aimee.yaml` |
+| [Context economizer](docs/features/context-fold.md) | The two-tier token-reduction pipeline: history fold, tool-output condensation, size compression, the freeze cost guardrail, and the live-primary gateway mutation with its per-session circuit breaker |
+| [KB Console](docs/KB_CONSOLE.md) | The operator console's trust model and surfaces — Accounts (enroll/revoke/scopes/OIDC) and Governance (decision records, the policy-verdict action audit) |
 | [Workspace Management](docs/WORKSPACES.md) | Multi repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
 | [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token at rest, in transit to git, and in the in browser editor, and where exposure is and is not closed |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ configs are blocked before the AI can touch them. Known anti patterns raise warn
 Planning mode freezes every write until you are ready. Each session runs in its own git
 worktree, so two sessions never step on each other.
 
-**A browser workspace, not just a backend.** aimee ships its own browser UI, `aimee-webchat`:
+**A browser workspace.** aimee ships its own browser UI, `aimee-webchat`:
 chat, a live view of your code as a graph, a git project manager that clones repos and holds
 per host tokens, a full in app VS Code editor, and dashboards over what the server is doing.
 No terminal required. See [Dashboard & Logs](docs/DASHBOARD.md).
@@ -160,7 +160,7 @@ is traceable to the exact place on the page rather than to an unlocatable paraph
 of that spine the KB optionally recognises table cells (structured `{row, col, text}`
 lookups), renders visual crops of figures, tables, and pages into a content addressed store,
 and OCRs scanned or image only pages back through the same citation path. Each layer is its
-own opt in and degrades cleanly to the one below when its dependency is absent, and every
+own opt in and degrades to the one below when its dependency is absent, and every
 read surface honours the same document level access control as the text spine. See
 [Structured PDF](docs/STRUCTURED_PDF.md).
 
@@ -178,14 +178,14 @@ mode-0600, rotated audit ledger: `{ts, actor, tool, mode, reason_code, verdict, 
 The `reason_code` is a stable event key, never free form prose, so nothing user bearing is
 persisted. `args_hash` is a keyed HMAC-SHA256 over a per tool allowlist projection of the
 arguments: keyed so low entropy arguments cannot be recovered from the public log by
-dictionary attack, allowlisted by construction so a new tool or a new argument can never
+dictionary attack, allowlisted so a new tool or a new argument can never
 silently leak a secret or PII value into an append only log, and versioned. Auditing is
-**fail open by construction** — the log write happens after the verdict is decided, so a
+fail open: the log write happens after the verdict is decided, so a
 logging failure can never flip an allow to a block. The ledger is replayable:
 `trajectory_export` interleaves the governed actions back into the session timeline by
 timestamp, and the operator console exposes the feed at `/v1/audit/actions`.
 
-Alongside the action ledger, aimee keeps **decision records** — governable "we decided X
+Alongside the action ledger, aimee keeps **decision records**: governable "we decided X
 because Y" entries carrying status, rationale, alternatives, a revisit date, what they
 supersede, the author, and the policy they bind. At most one decision is active per scope
 (enforced by a database unique index, not just by the writer), superseding one flips the
@@ -194,9 +194,9 @@ existing recall and curator sweeps rather than rotting silently. Human sign off 
 sensitive actions are HMAC-SHA256 signed and non forgeable. Both surfaces are live in the
 [KB Console](docs/KB_CONSOLE.md) (`/v1/decisions`, `/v1/audit/actions`).
 
-Retrieval has a parallel, opt in audit chain: every KB grounded answer is reconstructible —
-which sources grounded it, at which content hashed version, and whether the answer is
-entailed by that evidence — read back through `/v1/audit/{trace,provenance,fidelity}`.
+Retrieval has a parallel, opt in audit chain: every KB grounded answer is reconstructible.
+Read back which sources grounded it, at which content hashed version, and whether the answer
+is entailed by that evidence, through `/v1/audit/{trace,provenance,fidelity}`.
 
 ### The context economizer
 
@@ -204,14 +204,14 @@ aimee runs a context economizer over both the delegate turn loop and, optionally
 primary `/v1` path, gated by a master switch and split into two tiers. The **safe tier**
 is default on: deterministic tool output condensation (keep the failing test, elide the
 passing ones; keep compiler diagnostics, drop progress), size based compression of oversized
-tool results, and folding old turn history into a rolling skeleton — recent context is never
+tool results, and folding old turn history into a rolling skeleton. Recent context is never
 touched, and the full output is spilled to disk for recovery. A measurement ledger records
 the reduction opportunity even when a lever is off, so the master switch off state provably
 reduces to zero.
 
 The **aggressive tier** is opt in and off by default: it applies the reduction to the live
 inbound request so the primary agent's own tokens shrink too. It is compress only, and
-guarded by a per session circuit breaker — if a reduced request draws an error the session
+guarded by a per session circuit breaker. If a reduced request draws an error, the session
 falls back to the pristine payload and disables reduction for its remaining turns, so one bad
 reduction can never persistently break live traffic. aimee never dispatches a reduced payload
 it cannot restore to the byte identical original. See [Settings](docs/SETTINGS.md) and
@@ -336,7 +336,7 @@ works the same way. Switch tools any time. Your memory and context stay.
 - **Team knowledge.** One shared kb distills what your whole organization knows, behind
   scoped accounts, OIDC sign on, and a per principal encrypted vault.
 - **A UI when you want one.** A browser workspace with chat, a code graph explorer, git
-  project management, an in app VS Code editor, and server dashboards — no terminal required.
+  project management, an in app VS Code editor, and server dashboards. No terminal required.
 - **Yours to run.** C services, single digit millisecond hot paths, and an inference stack
   you can run entirely on your own hardware.
 
@@ -410,9 +410,9 @@ Focused references:
 | [Workflows](docs/WORKFLOWS.md) | The composable dev lifecycle workflow engine, block catalog, and authoring |
 | [Workflow Actions](docs/WORKFLOW_ACTIONS.md) | The web page to author a proposal, run it autonomously, and watch its status/history |
 | [Dashboard & Logs](docs/DASHBOARD.md) | The web Dashboard's server-incurred metric panels, customization, the Logs (tool-action audit) tab, and the panel data architecture |
-| [Settings](docs/SETTINGS.md) | The web page for the server's typed runtime config — economizer levers, autonomous-dev knobs, tool-output condensation, and how each maps to `aimee.yaml` |
+| [Settings](docs/SETTINGS.md) | The web page for the server's typed runtime config: economizer levers, autonomous-dev knobs, tool-output condensation, and how each maps to `aimee.yaml` |
 | [Context economizer](docs/features/context-fold.md) | The two-tier token-reduction pipeline: history fold, tool-output condensation, size compression, the freeze cost guardrail, and the live-primary gateway mutation with its per-session circuit breaker |
-| [KB Console](docs/KB_CONSOLE.md) | The operator console's trust model and surfaces — Accounts (enroll/revoke/scopes/OIDC) and Governance (decision records, the policy-verdict action audit) |
+| [KB Console](docs/KB_CONSOLE.md) | The operator console's trust model and surfaces: Accounts (enroll/revoke/scopes/OIDC) and Governance (decision records, the policy-verdict action audit) |
 | [Workspace Management](docs/WORKSPACES.md) | Multi repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
 | [Webchat git security](docs/WEBCHAT_GIT_SECURITY.md) | How webchat handles a webuser's git forge token at rest, in transit to git, and in the in browser editor, and where exposure is and is not closed |

--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ aimee delegate roundtable "Review this design" --mode review     # bounded multi
 aimee ships the retrieval and synthesis stack as one container: a Vulkan llama.cpp runtime
 serving embeddings, reranking, and synthesis from models baked into the image. Run it on a
 GPU and the knowledge base curates locally with no API calls, and the local model registers
-as a free delegate the roundtable and the primary can call. Three tiers cover the range: a
-CPU build for retrieval on any host, and two GPU builds whose synth model you pick with a
-single image swap, no re-embed. See [kb LLM backends](docs/KB_LLM_BACKENDS.md) and
+as a free delegate the roundtable and the primary can call. Four tiers cover the range: a
+CPU build for retrieval on any host, and three GPU builds (for 16, 24, and 32 GB cards) whose
+synth model you pick with a single image swap, no re-embed. See [kb LLM backends](docs/KB_LLM_BACKENDS.md) and
 [synth tiers](docs/AIMEE_KB_SYNTH_TIERS.md).
 
 ### Session isolation

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # aimee
 
-**Your AI has no memory, no map of your code, and no brakes. Every session it starts blind,
-bills you to relearn your repo, and can still overwrite your `.env`.**
+aimee has two parts.
 
-**aimee fixes all of it, and goes further.** One memory across every tool. Your whole
-codebase as a live graph. Any model, any provider. Cheap delegates for the grunt work.
-Guardrails it cannot write past. Hand it a proposal and it ships the change itself: design,
-build, review, PR. Your context follows you anywhere. Nothing locks you in.
+**aimee-kb** is a general purpose knowledge base for a whole corpus of knowledge, whether
+that's a specific genre of knowledge, a company knowledge base, or a team's knowledge base.
+
+**aimee-server** is an assistant to a human. It learns how to work best with that human,
+learns and understands their expectations, and follows them. It is a general purpose
+assistant. It started as a coding assistant, and coding is still what it does best. It is
+*very strong* there, especially on multi-repo and large-repo work.
+
+**Your AI has no memory, no map of your work, and no brakes. Every session it starts blind,
+bills you to catch it up again, and can still overwrite your `.env`.**
+
+**aimee fixes all of it, and goes further.** One memory across every tool. Your knowledge and
+your code as one live graph. Any model, any provider. Cheap delegates for the grunt work.
+Guardrails it cannot write past. Workflows that run a whole job start to finish, with review
+panels and your sign-off built in. Your context follows you anywhere. Nothing locks you in.
 
 The memory and the code index are a **hybrid vector-graph**: vector recall fused with a typed
 knowledge graph and your code's call graph, ranked together. That is why it surfaces what the
@@ -67,9 +77,10 @@ on your hardware with no outside API calls, and the same local model doubles as 
 delegate. Swap the model tier with a single image, or run the CPU build for retrieval on any
 box. See [kb LLM backends](docs/KB_LLM_BACKENDS.md).
 
-**Autonomous development.** Hand aimee a written proposal and it runs the job unattended:
-design, plan, implement, review, open the PR. The primary agent manages, a panel of models
-reviews the work, and the delegates do the building. See
+**Workflows.** Compose a job out of typed steps and aimee runs it start to finish: the
+delegates do the work, review panels check it, and it parks at a human gate wherever you want
+the final say. The `build` workflow ships as the default, taking a written proposal all the
+way to a PR, and you can edit it or author your own. See [Workflows](docs/WORKFLOWS.md) and
 [Autonomous Development](docs/AUTONOMOUS_DEVELOPMENT.md).
 
 **Guardrails and isolation.** Sensitive files like `.env`, private keys, and production

--- a/benchmarks/kb/dynamic-alpha/README.md
+++ b/benchmarks/kb/dynamic-alpha/README.md
@@ -1,0 +1,50 @@
+# Dynamic-alpha fusion benchmark
+
+Measures whether the `dynamic_alpha` fusion mode improves retrieval over the
+`rrf` baseline (and `static_alpha`) on a labelled query set — reporting the
+**per-shape better/worse split**, not a single average, because dynamic alpha is
+expected to be a *mixed* result: win on lexical/identifier queries without
+regressing semantic ones.
+
+## Run
+
+```sh
+# against a live aimee-kb (POST /v1/search); no third-party deps
+python3 run.py --endpoint http://127.0.0.1:8741 --project aimee --k 5 --out report.json
+
+# remote KB over the LAN
+python3 run.py --endpoint http://192.168.1.254:8741 --project aimee
+# add --bearer <token> if the endpoint requires one
+```
+
+Exit code is non-zero if `dynamic_alpha` regresses a `false_positive_guard` /
+`regression` fixture versus `rrf` — so it can gate CI once a stable corpus exists.
+
+## Files
+
+- `fixtures.json` — the charter query set (3 `positive`, 2 `false_positive_guard`,
+  2 `regression`), each with an `expected_top_path_substring`.
+- `run.py` — the A/B runner (this harness).
+- `before_report.json` / `after_report.json` — the 2026-05-03 spike run.
+
+## Known limitations before this yields a verdict
+
+The 2026-05-03 closeout ("gate not met, default stays `rrf`") was made on **empty
+data** (Qdrant D-state, no corpus). Re-running today surfaced two blockers to fix
+before the harness produces a real go/no-go:
+
+1. **Corpus health.** `POST /v1/search` is the fusion path (`kb_search_fused`), and
+   it applies the mode correctly (`fusion_mode_used` reflects the request). But on
+   a KB whose doc-embed/curator drain has been wedged, doc embeddings are
+   incomplete and retrieval is undiscriminative (flat ~0.03 scores, one artifact
+   dominating) — every fixture misses in every mode. Run only against a KB whose
+   curator has fully drained (see the curator-drain lease fix).
+2. **Doc-only surface vs. code fixtures.** `/v1/search` ranks `doc_chunk`s from
+   `kb_documents`; three fixtures (`lexical_*`) expect **code** files
+   (`config_learning.c`, `kb.c`) that live in `code_embeddings`, not the doc
+   corpus, so they can never match here. Either point those fixtures at
+   proposal/doc targets that exist in the doc corpus, or add a code-search variant
+   of the harness against `/v1/code/*`.
+
+Until (1) is cleared on the target KB, treat an all-miss result as
+*inconclusive*, not as evidence against dynamic alpha.

--- a/benchmarks/kb/dynamic-alpha/run.py
+++ b/benchmarks/kb/dynamic-alpha/run.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Dynamic-alpha fusion A/B benchmark.
+
+Runs each fixture query against a live aimee-kb `POST /v1/search` in one or more
+fusion modes (rrf / static_alpha / dynamic_alpha), scores the ranked hits against
+`expected_top_path_substring`, and reports — per query and per fixture *shape* —
+whether dynamic_alpha helped, hurt, or was neutral versus the rrf baseline.
+
+The whole point (per the charter fixtures) is that dynamic alpha is expected to be
+a *mixed* result: it should win on `positive` (lexical/identifier) queries without
+regressing the `false_positive_guard` (semantic) and `regression` canaries. This
+harness measures exactly that split instead of a single average.
+
+Usage:
+    python3 run.py --endpoint http://127.0.0.1:8741 --project aimee
+    python3 run.py --endpoint http://192.168.1.254:8741 --k 5 --out report.json
+
+No third-party deps (urllib only), so it runs anywhere python3 does — the .254
+host, CI, or a laptop with LAN access to the KB.
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+MODES = ["rrf", "static_alpha", "dynamic_alpha"]
+BASELINE = "rrf"
+
+
+def search(endpoint, project, query, mode, k, bearer=None, timeout=45):
+    """POST /v1/search; return (ordered list of hit paths, fusion_mode_used, alpha)."""
+    body = json.dumps(
+        {"query": query, "project": project, "max_results": k, "fusion_mode": mode}
+    ).encode()
+    req = urllib.request.Request(
+        endpoint.rstrip("/") + "/v1/search", data=body, method="POST"
+    )
+    req.add_header("Content-Type", "application/json")
+    if bearer:
+        req.add_header("Authorization", "Bearer " + bearer)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            data = json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        return None, "http_%d" % e.code, None
+    except Exception as e:  # noqa: BLE001 — a bad query shouldn't abort the sweep
+        return None, "error:%s" % e, None
+    hits = data.get("hits") or data.get("results") or []
+    paths = [
+        (h.get("artifact_id") or h.get("path") or h.get("file") or h.get("node_key") or "")
+        for h in hits
+    ]
+    return paths, data.get("fusion_mode_used", mode), data.get("fusion_alpha")
+
+
+def first_rank(paths, needle):
+    """1-based rank of the first hit whose path contains needle, or None."""
+    for i, p in enumerate(paths):
+        if needle and needle in p:
+            return i + 1
+    return None
+
+
+def verdict(base_rank, cand_rank):
+    """Compare a candidate mode's rank against the baseline's (lower rank = better)."""
+    if base_rank is None and cand_rank is None:
+        return "both_miss"
+    if cand_rank is None:
+        return "worse"  # baseline found it, candidate didn't
+    if base_rank is None:
+        return "better"  # candidate found it, baseline didn't
+    if cand_rank < base_rank:
+        return "better"
+    if cand_rank > base_rank:
+        return "worse"
+    return "same"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Dynamic-alpha fusion A/B benchmark")
+    here = os.path.dirname(os.path.abspath(__file__))
+    ap.add_argument("--endpoint", default="http://127.0.0.1:8741",
+                    help="aimee-kb base URL (POST /v1/search)")
+    ap.add_argument("--project", default="aimee", help="KB project scope")
+    ap.add_argument("--fixtures", default=os.path.join(here, "fixtures.json"))
+    ap.add_argument("--k", type=int, default=5, help="cutoff for P@k / hit@k")
+    ap.add_argument("--modes", default=",".join(MODES),
+                    help="comma-separated fusion modes to run")
+    ap.add_argument("--bearer", default=os.environ.get("AIMEE_KB_BEARER"),
+                    help="optional bearer token for the KB endpoint")
+    ap.add_argument("--out", default=None, help="write the full JSON report here")
+    args = ap.parse_args()
+
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+    with open(args.fixtures) as f:
+        fixtures = json.load(f)["fixtures"]
+
+    per_fixture = []
+    agg = {m: {"hit1": 0, "hitk": 0, "mrr": 0.0, "used": None} for m in modes}
+    for fx in fixtures:
+        q, needle, shape = fx["query"], fx.get("expected_top_path_substring", ""), fx.get("shape", "")
+        row = {"id": fx["id"], "shape": shape, "query": q, "expected": needle, "modes": {}}
+        for m in modes:
+            paths, used, alpha = search(args.endpoint, args.project, q, m, args.k, args.bearer)
+            rank = first_rank(paths or [], needle)
+            agg[m]["used"] = used
+            if rank == 1:
+                agg[m]["hit1"] += 1
+            if rank is not None and rank <= args.k:
+                agg[m]["hitk"] += 1
+                agg[m]["mrr"] += 1.0 / rank
+            row["modes"][m] = {"rank": rank, "used": used, "alpha": alpha,
+                               "top": (paths or [])[:3]}
+        # dynamic-vs-baseline verdict, if both present
+        if BASELINE in row["modes"] and "dynamic_alpha" in row["modes"]:
+            row["dynamic_vs_rrf"] = verdict(row["modes"][BASELINE]["rank"],
+                                            row["modes"]["dynamic_alpha"]["rank"])
+        per_fixture.append(row)
+
+    n = len(fixtures)
+    report = {
+        "endpoint": args.endpoint, "project": args.project, "k": args.k,
+        "n_fixtures": n,
+        "aggregate": {
+            m: {"p_at_1": round(agg[m]["hit1"] / n, 3) if n else 0.0,
+                "p_at_k": round(agg[m]["hitk"] / n, 3) if n else 0.0,
+                "mrr": round(agg[m]["mrr"] / n, 3) if n else 0.0,
+                "fusion_mode_used": agg[m]["used"]}
+            for m in modes
+        },
+        "fixtures": per_fixture,
+    }
+
+    # Per-shape dynamic-vs-rrf split — the mixed-result picture.
+    by_shape = {}
+    for row in per_fixture:
+        v = row.get("dynamic_vs_rrf")
+        if v is None:
+            continue
+        by_shape.setdefault(row["shape"], {"better": 0, "worse": 0, "same": 0, "both_miss": 0})
+        by_shape[row["shape"]][v] += 1
+    report["dynamic_vs_rrf_by_shape"] = by_shape
+
+    # --- human summary ---
+    print("Dynamic-alpha fusion A/B — %s (project=%s, k=%d, n=%d)"
+          % (args.endpoint, args.project, args.k, n))
+    print("\nAggregate (P@1 / P@k / MRR):")
+    for m in modes:
+        a = report["aggregate"][m]
+        print("  %-14s P@1=%.3f  P@%d=%.3f  MRR=%.3f  (used=%s)"
+              % (m, a["p_at_1"], args.k, a["p_at_k"], a["mrr"], a["fusion_mode_used"]))
+    print("\ndynamic_alpha vs rrf, by fixture shape:")
+    for shape, c in by_shape.items():
+        print("  %-22s better=%d worse=%d same=%d both_miss=%d"
+              % (shape, c["better"], c["worse"], c["same"], c["both_miss"]))
+    print("\nPer fixture (rank in each mode; lower is better, - = miss):")
+    for row in per_fixture:
+        ranks = "  ".join("%s=%s" % (m, row["modes"][m]["rank"] if row["modes"][m]["rank"] else "-")
+                          for m in modes)
+        print("  [%-22s %-20s] %s  -> %s"
+              % (row["shape"], row["id"], ranks, row.get("dynamic_vs_rrf", "")))
+
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(report, f, indent=2)
+        print("\nwrote %s" % args.out)
+
+    # Non-zero exit if dynamic hurt a guard/regression fixture (a real signal for CI).
+    hurt_guards = sum(
+        1 for row in per_fixture
+        if row["shape"] in ("false_positive_guard", "regression")
+        and row.get("dynamic_vs_rrf") == "worse"
+    )
+    return 1 if hurt_guards else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/compose/aimee.gpu.yaml
+++ b/deploy/compose/aimee.gpu.yaml
@@ -18,6 +18,12 @@ services:
       # sliding-window attention (5 local layers windowed to 1024 : 1 global), so the
       # 128K KV is dominated by the few global layers (~2-3GB), not all-layers-x-128K —
       # well under 24GB. 256K would still fit with KV-cache quantization if ever needed.
+      #
+      # Tier picks (override AIMEE_LLM_IMAGE + AIMEE_LLM_SYNTH_CTX per card):
+      #   gpu-small (16GB): ...-gpu-small,  CTX 131072  (1 × 128K)
+      #   gpu-mid   (24GB): ...-gpu-mid,    CTX 262144   (2 × 128K, SLOTS=2)
+      #   gpu-large (32GB): ...-gpu-large,  CTX 1048576  (4 × 256K, SLOTS=4) — each of
+      #     4 agents gets the full native 256K window; ~28.5GiB used, ~3.5GB headroom.
       AIMEE_LLM_SYNTH_CTX: ${AIMEE_LLM_SYNTH_CTX:-131072}
     devices:
       - "/dev/dri:/dev/dri"

--- a/deploy/container/webchat-lib.sh
+++ b/deploy/container/webchat-lib.sh
@@ -31,23 +31,63 @@ WEBCHAT_GROUP="${AIMEE_WEBCHAT_GROUP:-aimee}"
 # logins against a real OS user, so without this no one can sign in. Unset
 # credentials are tolerated: webchat still serves (login page up), it just has no
 # account until an operator provisions one.
+# Provision (create or update) a single PAM login user in the webchat group.
+# Idempotent: re-runs every start, so accounts persist across container rebuilds
+# without a manual `useradd` (which lives only in the ephemeral container fs).
+webchat_provision_user() {
+    _pu_user="$1"
+    _pu_pass="$2"
+    [ -n "$_pu_user" ] && [ -n "$_pu_pass" ] || return 0
+    getent group "$WEBCHAT_GROUP" >/dev/null 2>&1 || groupadd --system "$WEBCHAT_GROUP"
+    if id "$_pu_user" >/dev/null 2>&1; then
+        # Existing user (e.g. the service account): just ensure group membership.
+        usermod --append --groups "$WEBCHAT_GROUP" "$_pu_user" 2>/dev/null || true
+    else
+        webchat_log "creating login user '$_pu_user'"
+        useradd --create-home --shell /usr/sbin/nologin --groups "$WEBCHAT_GROUP" "$_pu_user"
+    fi
+    printf '%s:%s\n' "$_pu_user" "$_pu_pass" | chpasswd
+    webchat_log "login user '$_pu_user' ready (group $WEBCHAT_GROUP)"
+}
+
+# Additional persistent logins from AIMEE_WEBCHAT_USERS: a list of "user:password"
+# entries separated by commas and/or newlines. Only the FIRST ':' splits, so a
+# password may contain ':' — but not a comma or newline (those delimit entries).
+# Provisioned on every start just like the primary account, so operators can add
+# durable browser logins (e.g. "admin:s3cret") that survive a container rebuild.
+webchat_bootstrap_extra_users() {
+    [ -n "${AIMEE_WEBCHAT_USERS:-}" ] || return 0
+    # Normalize commas to newlines, then provision one entry per line. The pipe
+    # runs the loop in a subshell, which is fine: provisioning mutates the OS
+    # (useradd/chpasswd), not shell state.
+    printf '%s\n' "$AIMEE_WEBCHAT_USERS" | tr ',' '\n' | while IFS= read -r _eu_entry; do
+        _eu_entry="$(printf '%s' "$_eu_entry" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+        [ -n "$_eu_entry" ] || continue
+        case "$_eu_entry" in
+            *:*) : ;;
+            *)
+                webchat_log "AIMEE_WEBCHAT_USERS: skipping malformed entry (expected user:password)"
+                continue
+                ;;
+        esac
+        webchat_provision_user "${_eu_entry%%:*}" "${_eu_entry#*:}"
+    done
+}
+
+# Create (or update) the bootstrap login accounts from env. PAM authenticates
+# browser logins against real OS users, so without at least one no one can sign
+# in. The primary account (AIMEE_WEBCHAT_USER/PASSWORD) is optional — unset is
+# tolerated (login page still serves) — and AIMEE_WEBCHAT_USERS adds any number
+# of extra persistent accounts.
 webchat_bootstrap_user() {
     _wc_user="${AIMEE_WEBCHAT_USER:-}"
     _wc_pass="${AIMEE_WEBCHAT_PASSWORD:-}"
     if [ -z "$_wc_user" ] || [ -z "$_wc_pass" ]; then
-        webchat_log "AIMEE_WEBCHAT_USER/AIMEE_WEBCHAT_PASSWORD unset; skipping login bootstrap (no account can sign in until one is provisioned)"
-        return 0
-    fi
-    getent group "$WEBCHAT_GROUP" >/dev/null 2>&1 || groupadd --system "$WEBCHAT_GROUP"
-    if id "$_wc_user" >/dev/null 2>&1; then
-        # Existing user (e.g. the service account): just ensure group membership.
-        usermod --append --groups "$WEBCHAT_GROUP" "$_wc_user" 2>/dev/null || true
+        webchat_log "AIMEE_WEBCHAT_USER/AIMEE_WEBCHAT_PASSWORD unset; skipping primary login bootstrap (AIMEE_WEBCHAT_USERS may still provision accounts)"
     else
-        webchat_log "creating login user '$_wc_user'"
-        useradd --create-home --shell /usr/sbin/nologin --groups "$WEBCHAT_GROUP" "$_wc_user"
+        webchat_provision_user "$_wc_user" "$_wc_pass"
     fi
-    printf '%s:%s\n' "$_wc_user" "$_wc_pass" | chpasswd
-    webchat_log "login user '$_wc_user' ready (group $WEBCHAT_GROUP)"
+    webchat_bootstrap_extra_users
 }
 
 # Falsy test for the disable toggle: 0/false/no/off (any case) turns the browser

--- a/deploy/smoothnas/aimee-llm.plugin.yaml
+++ b/deploy/smoothnas/aimee-llm.plugin.yaml
@@ -36,7 +36,10 @@ services:
       #   aimee-kb-gpu-small  Gemma-4-12B synth (dense; fits 16GB+)
       #   aimee-kb-gpu-mid    Gemma-4-26B-A4B synth (MoE, 4B active; ~14GB fits a 24GB
       #                       card fully GPU-resident, baked AIMEE_LLM_SYNTH_N_CPU_MOE=0)
+      #   aimee-kb-gpu-large  SAME 26B-A4B GGUF as gpu-mid but baked SYNTH_SLOTS=4 for a
+      #                       32GB card — deploy AIMEE_LLM_SYNTH_CTX=1048576 (4 × 256K)
       # aimee-kb-cpu is the CPU tier (1024-dim; NGL=0). See docs/AIMEE_KB_SYNTH_TIERS.md.
+      # This .254 plugin stays on gpu-mid (its card is 24GB); gpu-large is for 32GB hosts.
       image: ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest
     container:
       restartPolicy: unless-stopped

--- a/deploy/smoothnas/aimee-server.plugin.yaml
+++ b/deploy/smoothnas/aimee-server.plugin.yaml
@@ -90,6 +90,16 @@ services:
         default: ""
         secret: true
         description: PAM login password for the browser UI (set alongside the user).
+      # Optional: additional persistent browser logins beyond the primary above.
+      # Comma- and/or newline-separated "user:password" entries (only the first
+      # ':' splits, so a password may contain ':' but not a comma/newline). Each
+      # is provisioned on every start, so extra accounts survive a plugin update.
+      - key: AIMEE_WEBCHAT_USERS
+        type: string
+        label: Additional webchat logins
+        default: ""
+        secret: true
+        description: 'Extra PAM logins as "user:password" entries, comma-separated (e.g. admin:s3cret,laura:pw).'
       # Optional: point the kb synthesis / curator passes at an OpenAI-compatible
       # endpoint. Blank = disabled.
       - key: LLM_ENDPOINT

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -2,7 +2,7 @@ services:
   # Shared Postgres store for the proxy replicas. A single aimee binary
   # can run against SQLite or Postgres; this compose file demonstrates
   # the two-replica Postgres deployment described in
-  # docs/proposals/accepted/three-db-split-user-shared-vectors.md.
+  # docs/STORAGE_TIERS.md.
   postgres:
     image: postgres:16-alpine
     environment:

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -1,6 +1,6 @@
 # aimee-kb image synth tiers
 
-The `aimee-kb-*` image is the unified Vulkan llama.cpp stack — one runtime serving
+The `aimee-kb-*` image is the unified Vulkan llama.cpp stack: one runtime serving
 **embeddings** (`/embed`), **reranking** (`/rerank`), and **synthesis**
 (`/v1/chat/completions`) from baked-in GGUFs. Three published tiers differ only in the
 **synth model** (and its runtime profile); embed + rerank are identical within a
@@ -8,24 +8,23 @@ CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
 
 | Image | Embed / Rerank | Synth | Runtime |
 |---|---|---|---|
-| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B — **Tier A only** | CPU (`NGL=0`) |
+| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) |
 | `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 |
 | `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident |
 
 `gpu-small` and `gpu-mid` share the **same embedder + reranker** (2560-dim), so a KB
-embedded on one is byte-compatible with the other — switching the synth tier is a
+embedded on one is byte-compatible with the other. Switching the synth tier is a
 plugin **image swap**, no re-embed.
 
 ## Tier-A vs Tier-B synthesis
 
 The curator synthesizes in two tiers:
 
-- **Tier A** — mechanical extract/index passes (extract docs, chunk, tag, index).
-- **Tier B** — the reasoning passes: judge, resolve entities, reconcile contradictions,
+- **Tier A**: mechanical extract/index passes (extract docs, chunk, tag, index).
+- **Tier B**, the reasoning passes: judge, resolve entities, reconcile contradictions,
   synthesize, promote.
 
-`aimee-kb-cpu` runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider
-— a weak model would poison the graph — so a CPU-only deployment gets retrieval + Tier-A
+`aimee-kb-cpu` runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider (a weak model would poison the graph), so a CPU-only deployment gets retrieval + Tier-A
 synthesis and nothing more. **Tier B needs a GPU tier (`gpu-small` / `gpu-mid`) or an
 external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
 config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
@@ -34,9 +33,9 @@ config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
 
 Two image families share the `aimee-kb` prefix. Keep them straight:
 
-- **`aimee-kb`** (no suffix) — the KB service (DB2 + curator). Runs no model; it calls one
+- **`aimee-kb`** (no suffix): the KB service (DB2 + curator). Runs no model; it calls one
   over HTTP. See [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
-- **`aimee-kb-{cpu,gpu-small,gpu-mid}`** — the inference tiers in this doc (embed + rerank +
+- **`aimee-kb-{cpu,gpu-small,gpu-mid}`**: the inference tiers in this doc (embed + rerank +
   synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm` plugin.
 
 Retired names: `aimee-llm-cpu`/`aimee-llm-gpu` were the old tier names (now
@@ -45,20 +44,20 @@ standalone torch embedder, now baked into the tiers.
 
 ## Deploy: one plugin image swap
 
-The synth tier is chosen by which image the SmoothNAS `aimee-llm` plugin references —
+The synth tier is chosen by which image the SmoothNAS `aimee-llm` plugin references,
 e.g. `ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest` for Gemma 4 26B-A4B. No separate synth
 container, no `SYNTH_LOCAL` juggling: the tier *is* the synth.
 
 ### Two consumers of the gateway synth (`/v1/chat/completions`)
 
 The gateway (`http://<runtime-gw>:8742/v1`, model alias `aimee-synth`) is used by two
-independent callers — one automatic, one an explicit operator step:
+independent callers, one automatic, one an explicit operator step:
 
-1. **KB curator synthesis — automatic.** The `aimee-kb` plugin points `LLM_ENDPOINT` /
+1. **KB curator synthesis (automatic).** The `aimee-kb` plugin points `LLM_ENDPOINT` /
    `LLM_MODEL` at the gateway, so the curator's `tier_a`/`tier_b` use the synth tier the
    moment the image is deployed. Swapping tiers needs no KB change.
 
-2. **aimee-server delegate — an explicit runtime registration (NOT automatic).** To make
+2. **aimee-server delegate, an explicit runtime registration (NOT automatic).** To make
    the local synth usable as an `aimee` delegate (roundtable / fallback), register it once
    against the server (endpoint is model-neutral, so the registration survives synth-tier
    swaps):
@@ -85,10 +84,10 @@ independent callers — one automatic, one an explicit operator step:
 
 ### Tuning `N_CPU_MOE` on gpu-mid (Gemma 4 26B-A4B, ~14 GB synth)
 
-The mid tier is **Gemma 4 26B-A4B** — a MoE with only **4B active parameters/token** at
+The mid tier is **Gemma 4 26B-A4B**, a MoE with only **4B active parameters/token** at
 `qat-UD-Q4_K_XL` (~14 GB). Unlike a 22 GB synth, it **co-fits embed+rerank (~7 GB) on a
 24 GB card fully resident** (~21 GB + Gemma's cheap sliding-window KV), so the default is
-`N_CPU_MOE=0` — no expert offload, fully GPU-resident.
+`N_CPU_MOE=0`: no expert offload, fully GPU-resident.
 
 | Card | Suggested `N_CPU_MOE` | Notes |
 |---|---|---|
@@ -102,7 +101,7 @@ offload costs less here than on a dense synth of the same size.
 ### Flash-attention / K8V4
 
 K8V4 (`q8_0` K / `q4_0` V) is verified working on RADV/gfx1100 (7900 XTX). FA is
-enforced structurally — llama.cpp refuses a quantized V-cache without it — so a
+enforced structurally (llama.cpp refuses a quantized V-cache without it), so a
 healthy container proves FA engaged. If a backend genuinely can't do FA, set
 `AIMEE_LLM_SYNTH_KV_V=f16` (K8V8 does **not** help; any quantized V needs FA).
 
@@ -111,9 +110,9 @@ healthy container proves FA engaged. If a backend genuinely can't do FA, set
 The GPU tiers are based on `debian:trixie-slim` (Mesa 25) on purpose: its RADV exposes
 `VK_KHR_cooperative_matrix` on RDNA3 (gfx1100), so llama.cpp uses the card's WMMA matrix
 cores. On an older Mesa without coopmat (bookworm's 22.3.6) llama.cpp falls back to scalar
-shaders — the synth goes compute-bound, the memory bus sits idle, and generation crawls.
+shaders. The synth goes compute-bound, the memory bus sits idle, and generation crawls.
 
 Measured on the 7900 XTX, gpu-mid resident: **~1265 tok/s prompt, ~62–95 tok/s generation**
 with coopmat; ~33–76 / ~30 without it. If a GPU tier is slow, check the base image is
-trixie (Mesa ≥ 24.1) and that `mem_busy` climbs under load — a pegged GPU with an idle
+trixie (Mesa ≥ 24.1) and that `mem_busy` climbs under load. A pegged GPU with an idle
 memory bus means the matrix cores aren't in play.

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -6,12 +6,12 @@ The `aimee-kb-*` image is the unified Vulkan llama.cpp stack: one runtime servin
 **synth model** (and its runtime profile); embed + rerank are identical within a
 CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
 
-| Image | Embed / Rerank | Synth | Runtime |
-|---|---|---|---|
-| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) |
-| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB |
-| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB |
-| `aimee-kb-gpu-large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `gpu-mid`, 4 slots — 32 GB |
+| Image | Embed / Rerank | Synth | Runtime (target card) | Pull size |
+|---|---|---|---|---|
+| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) | ~6.5 GB |
+| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB | ~11.4 GB |
+| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB | ~17.8 GB |
+| `aimee-kb-gpu-large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `gpu-mid`, 4 slots — 32 GB | ~17.8 GB |
 
 `gpu-large` is byte-identical to `gpu-mid` (same synth GGUF/revision/SHA + MoE/FA profile);
 it only bakes `SYNTH_SLOTS=4` instead of `2`, so a 32 GB card runs **4 concurrent agents**
@@ -21,6 +21,12 @@ so even 4×256 K KV stays ~28.5 GiB — validated against the 24 GB `gpu-mid` ca
 22.4/24 GiB). `gpu-small`, `gpu-mid`, and `gpu-large` share the **same embedder + reranker**
 (2560-dim), so a KB embedded on one is byte-compatible with the others — switching the synth
 tier is a plugin **image swap**, no re-embed.
+
+**Image size** (amd64, compressed pull from ghcr): `cpu` ~6.5 GB, `gpu-small` ~11.4 GB,
+`gpu-mid` / `gpu-large` **~17.8 GB**. The mid/large image bakes ~19.3 GB of GGUFs
+(embed 4.28 GB + rerank 0.79 GB + synth 14.25 GB) → ~20 GB uncompressed on disk. `gpu-large`
+carries the *same* layers as `gpu-mid` (only the `SYNTH_SLOTS=4` env differs), so it is the
+same size — allow ~20 GB free disk on the host per GPU image, plus transient build headroom.
 
 ## Tier-A vs Tier-B synthesis
 

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -2,19 +2,25 @@
 
 The `aimee-kb-*` image is the unified Vulkan llama.cpp stack: one runtime serving
 **embeddings** (`/embed`), **reranking** (`/rerank`), and **synthesis**
-(`/v1/chat/completions`) from baked-in GGUFs. Three published tiers differ only in the
+(`/v1/chat/completions`) from baked-in GGUFs. Four published tiers differ only in the
 **synth model** (and its runtime profile); embed + rerank are identical within a
 CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
 
 | Image | Embed / Rerank | Synth | Runtime |
 |---|---|---|---|
 | `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) |
-| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 |
-| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident |
+| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB |
+| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB |
+| `aimee-kb-gpu-large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `gpu-mid`, 4 slots — 32 GB |
 
-`gpu-small` and `gpu-mid` share the **same embedder + reranker** (2560-dim), so a KB
-embedded on one is byte-compatible with the other. Switching the synth tier is a
-plugin **image swap**, no re-embed.
+`gpu-large` is byte-identical to `gpu-mid` (same synth GGUF/revision/SHA + MoE/FA profile);
+it only bakes `SYNTH_SLOTS=4` instead of `2`, so a 32 GB card runs **4 concurrent agents**
+each with the model's full native **256 K** window (deploy `AIMEE_LLM_SYNTH_CTX=1048576`).
+Gemma-4 uses interleaved sliding-window attention (only 5 of 30 layers are full-attention),
+so even 4×256 K KV stays ~28.5 GiB — validated against the 24 GB `gpu-mid` card (2×128 K =
+22.4/24 GiB). `gpu-small`, `gpu-mid`, and `gpu-large` share the **same embedder + reranker**
+(2560-dim), so a KB embedded on one is byte-compatible with the others — switching the synth
+tier is a plugin **image swap**, no re-embed.
 
 ## Tier-A vs Tier-B synthesis
 
@@ -25,8 +31,8 @@ The curator synthesizes in two tiers:
   synthesize, promote.
 
 `aimee-kb-cpu` runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider (a weak model would poison the graph), so a CPU-only deployment gets retrieval + Tier-A
-synthesis and nothing more. **Tier B needs a GPU tier (`gpu-small` / `gpu-mid`) or an
-external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
+synthesis and nothing more. **Tier B needs a GPU tier (`gpu-small` / `gpu-mid` / `gpu-large`)
+or an external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
 config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
 
 ## Package names
@@ -35,8 +41,8 @@ Two image families share the `aimee-kb` prefix. Keep them straight:
 
 - **`aimee-kb`** (no suffix): the KB service (DB2 + curator). Runs no model; it calls one
   over HTTP. See [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
-- **`aimee-kb-{cpu,gpu-small,gpu-mid}`**: the inference tiers in this doc (embed + rerank +
-  synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm` plugin.
+- **`aimee-kb-{cpu,gpu-small,gpu-mid,gpu-large}`**: the inference tiers in this doc (embed +
+  rerank + synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm` plugin.
 
 Retired names: `aimee-llm-cpu`/`aimee-llm-gpu` were the old tier names (now
 `aimee-kb-cpu`/`aimee-kb-gpu-small`); `aimee-embedder`/`aimee-embedder-4b` were the
@@ -75,8 +81,8 @@ independent callers, one automatic, one an explicit operator step:
 
 | Env | Default (per tier) | Meaning |
 |---|---|---|
-| `AIMEE_LLM_SYNTH_CTX` | 32768 baked; the gpu-mid plugin sets `262144` (2 × 128 K) | synth context window |
-| `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on gpu-mid) | `--parallel` concurrent slots |
+| `AIMEE_LLM_SYNTH_CTX` | 32768 baked; gpu-mid deploys `262144` (2 × 128 K), gpu-large `1048576` (4 × 256 K) | synth context window (total across slots) |
+| `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on gpu-mid, 4 on gpu-large) | `--parallel` concurrent slots |
 | `AIMEE_LLM_SYNTH_FA` | `off` cpu / `on` gpu | flash-attention (required for quantized V-cache) |
 | `AIMEE_LLM_SYNTH_KV_K` / `_KV_V` | `q8_0` / `q4_0` (K8V4) | KV cache quant on the gpu tiers |
 | `AIMEE_LLM_SYNTH_MOE` | `1` on gpu-mid | enable the `--n-cpu-moe` expert-offload knob |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,7 +250,7 @@ Key properties:
   serializes heavyweight inference to bound resource use.
 - **Transport.** Clients reach the server over its `/v1` HTTP surface: the
   always-on `~/.config/aimee/aimee-http.sock` Unix socket, plus an optional
-  localhost TCP listener. Dispatch methods use first-class `/v1` routes; the
+  localhost TCP listener. Dispatch methods use dedicated `/v1` routes; the
   generic `POST /v1/rpc` endpoint is retired. Streaming chat uses
   `POST /v1/chat/stream`, whose body is a sequence of newline-delimited aimee
   events terminated by a final status object. (The legacy newline-delimited
@@ -352,7 +352,7 @@ It is a thin client: it holds no database and proxies everything to
 ## 8a. The kb console service
 
 `aimee-kb-console` (`kb-console/*.go` + the second `frontend/` SPA) is a standalone
-Go thin-client for administering a **shared/company `aimee-kb`** — dashboard,
+Go thin-client for administering a **shared/company `aimee-kb`**: dashboard,
 accounts (client enrollment, certificate revocation, scopes, OIDC config), and
 governance (decision records, the policy-verdict action audit). Unlike webchat it
 fronts the **kb `/v1` directly** (so it works with no colocated `aimee-server`) and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,7 +129,7 @@ Key consequences of the split:
   appropriate for the KB scope is reflected or promoted from DB1/server flows
   into DB2.
 - **The vector tier is inside DB2.** It was originally a separate Qdrant sidecar
-  (informally "DB3") and was folded into Postgres as the `vector` (pgvector)
+  and was folded into Postgres as the `vector` (pgvector)
   extension. Vectors share the same connection and transaction domain as the
   rows they embed, no separate service.
 - **The boundary is compile-enforced.** `aimee-server` is built with

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -223,7 +223,7 @@ auto-retried without new input (a CI log or a roundtable verdict).
 
 ## Current limitations
 
-Honest scope of the current implementation (the design allows for more):
+Scope of the current implementation (the design allows for more):
 
 - **Submit takes `proposal_md`, `workflow`, `repo` only.** Per-run `limits` and
   gate **preauthorization** are not yet accepted at `/v1/dev/submit`; gates are
@@ -256,7 +256,7 @@ Honest scope of the current implementation (the design allows for more):
 | autonomy driver (`wfe_autonomy`) | advances machine gates, parks at human gates, never forges approval |
 | turn registry / server-owned turns | a run survives client disconnect (the foundation) |
 
-**Invariants** (by construction): aimee never self-initiates; the primary manages
+**Invariants**: aimee never self-initiates; the primary manages
 while delegates do the work; rejected work is re-delegated; **all** autonomous
 action flows through the workflow engine, there is no side-channel that takes an
 autonomous action outside the engine's gates, budget, and audit.

--- a/docs/CODE_INTELLIGENCE.md
+++ b/docs/CODE_INTELLIGENCE.md
@@ -55,7 +55,7 @@ A thin client needs a configured remote and an indexed project for this. Plain
 
 ## How the AI uses it
 
-The graph is a tool surface for the primary agent and its delegates, not just a CLI. Before
+The graph is a tool surface for the primary agent and its delegates, not only a CLI. Before
 an edit the AI looks up callers and blast radius, and it fetches exact code spans by symbol
 instead of loading whole files into context. That is what lets it work from your code, keep
 its context small, and stop rediscovering the codebase on every session. Code search is a

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -162,7 +162,7 @@ Useful flags:
     bearer `aimee-local-dev`. Connecting with it (`aimee remote set <url>
     aimee-local-dev`) auto-runs enrollment: the server mints a strong random
     per-deployment bearer (`api.rotate_bearer`), the client adopts it in
-    `remote.conf`, and the bootstrap token immediately stops working — so the
+    `remote.conf`, and the bootstrap token immediately stops working, so the
     shared default is never a standing credential. `aimee remote enroll` forces a
     fresh rotation on the configured remote at any time. To skip the bootstrap
     entirely, set `AIMEE_API_BEARER_TOKEN` on the server (secret store) to pin your

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -7,13 +7,13 @@ holds no state and proxies to `aimee-server` over its `/v1` HTTP surface.
 
 ## Design principle: server-incurred metrics only
 
-The dashboard shows **things aimee-server incurs** — its delegations, tool
+The dashboard shows **things aimee-server incurs**: its delegations, tool
 calls, token spend, guardrail verdicts, configured agents, active sessions, and
 readiness. It deliberately does **not** monitor `aimee-kb`-internal events
 (memory-curation audits, KB decision logs). **`aimee-kb` has its own dashboard**
 for those; duplicating them here would blur the boundary between the two
-services. The one exception is a state overview the server relies on — the
-**Memory** panel (tier counts) — which is available but off by default.
+services. The one exception is a state overview the server relies on, the
+**Memory** panel (tier counts), which is available but off by default.
 
 A field is "server-incurred" if the server's own agents/workflows produce it,
 even when the record is physically stored behind the KB (e.g. delegate token
@@ -28,7 +28,7 @@ clean 3-column layout; you add more from a catalog via **⚙ Customize**.
 
 ### Logs (`/logs`)
 
-The server's **tool-action audit ledger** — one row per tool call the agent
+The server's **tool-action audit ledger**: one row per tool call the agent
 makes, with the guardrail **verdict** (`allow` / `block` / `rewrite` /
 `approval_required`), the actor (`primary` / `delegate`), the tool, mode, and
 reason. Filter by verdict, actor, or tool name. This is `aimee-server`'s own
@@ -38,11 +38,11 @@ KB's logs.
 ## Panels
 
 Every panel is derived from data the server incurs. Panels marked *default* are
-shown out of the box; the rest are opt-in via **⚙ Customize**.
+shown by default; the rest are opt-in via **⚙ Customize**.
 
 | Panel | Default | Source |
 |-------|:------:|--------|
-| Readiness | ✓ | Synthesized health report (`onboard`) — DB/agents/delegations/LSP |
+| Readiness | ✓ | Synthesized health report (`onboard`): DB/agents/delegations/LSP |
 | Agents | ✓ | Configured provider roster (`agents`) |
 | Active Sessions | ✓ | Live webchat sessions (injected by webchat) |
 | Delegations | ✓ | Recent delegations (`delegations`) with human-formatted latency |
@@ -59,7 +59,7 @@ shown out of the box; the rest are opt-in via **⚙ Customize**.
 | Failures | — | Recent unsuccessful delegations (from `delegations`) |
 | Provider Mix | — | Configured agents grouped by provider (from `agents`) |
 | Confidence | — | Average delegate confidence per role (from `delegations`) |
-| Memory | — | Memory tier/kind counts (`memory_stats.tier_kinds`) — a KB state overview |
+| Memory | — | Memory tier/kind counts (`memory_stats.tier_kinds`), a KB state overview |
 | LSP Health | — | LSP diagnostics summary (`lsp`) |
 
 Latency is rendered human-readably (`482ms`, `4.7s`, `2m 7s`), not raw

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -122,7 +122,7 @@ aimee agent probe gemma
 ```
 
 > **Registering the deployment's own `aimee-kb-*` synth:** use the gateway port and the
-> `aimee-synth` alias, not a raw GGUF filename —
+> `aimee-synth` alias, not a raw GGUF filename:
 > `aimee agent local local-synth http://<gw>:8742/v1 --model aimee-synth --provider openai`.
 > The gateway runs auth-off on the internal bridge (`auth_type: none`). See
 > [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
@@ -461,7 +461,7 @@ Practical notes:
   aimee config set provider claude                          # use it as the primary
   ```
 
-  (`aimee agent setup` is reserved for the four first-class providers, `openai`,
+  (`aimee agent setup` is reserved for the four built-in providers, `openai`,
   `anthropic`, `codex-oauth`, `claude-oauth`, so add a tmux-cli claude with
   `agent add --provider claude`.) The thin-client routing is automatic when the
   workspace is `detached`.

--- a/docs/KB_CONSOLE.md
+++ b/docs/KB_CONSOLE.md
@@ -33,14 +33,14 @@ not merely "semi-trusted".
   `/v1/config/oidc`, `/v1/scopes`, `/v1/decisions` (+ sub-actions), and
   `/v1/audit/actions`. A compromised console is bounded to that allowlist. It may
   mint client enrollments, but the kb **refuses to mint an owner or privileged
-  scope for a console-admin caller** — the requested scope must be a proper
-  `<kind>:<id>` and the kind may not be `owner`/`console-admin`/`curator` — so the
+  scope for a console-admin caller**: the requested scope must be a proper
+  `<kind>:<id>` and the kind may not be `owner`/`console-admin`/`curator`, so the
   console cannot escalate by minting. `/v1/review` is **not** in the set: review
   accept/reject is a separate `curator` scope. (The console is on the kb's compose
   network, so other services on it can reach the console port, but every action
-  still requires a valid console session — OIDC or break-glass.)
+  still requires a valid console session: OIDC or break-glass.)
 - **Deny-by-default proxy.** `/api/*` maps 1:1 to the allowlisted `/v1` routes and
-  re-checks the same allowlist in Go (`acl.go`) before forwarding — defence in
+  re-checks the same allowlist in Go (`acl.go`) before forwarding, defence in
   depth with the kb's server-side check. The browser's own token is never
   forwarded; only the console-admin bearer, server-side.
 - **Login = OIDC primary.** The console verifies a browser-presented OIDC JWT
@@ -56,9 +56,9 @@ not merely "semi-trusted".
 - **Sessions + CSRF.** Cookies are `HttpOnly; Secure; SameSite=Strict`; every
   mutating `/api/*` call requires the per-session CSRF token in an `X-CSRF-Token`
   header, compared server-side to the session's stored token (a synchronizer-token
-  pattern — the `SameSite=Strict` cookie is the primary CSRF defence, the header is
+  pattern: the `SameSite=Strict` cookie is the primary CSRF defence, the header is
   defence-in-depth). Login is rate-limited per source IP. A
-  session is bound to `(iss, sub)` — not `sub` alone — so it is not portable
+  session is bound to `(iss, sub)`, not `sub` alone, so it is not portable
   across IdPs, and revoking a principal's enrollment invalidates its sessions.
   Idle (30 min) and absolute (8 h) timeouts apply. The SQLite session DB is mode
   0600.
@@ -76,7 +76,7 @@ not merely "semi-trusted".
 ## Certificate revocation semantics (S2a)
 
 Revoking an enrollment (`POST /v1/enrollments/{id}/revoke`) sets `revoked_at` in
-DB2 — the **source of truth** — and the mTLS seam rejects a revoked client cert on
+DB2 (the **source of truth**) and the mTLS seam rejects a revoked client cert on
 its next request (matched by the sha256 fingerprint of the cert DER). Two deliberate
 trade-offs:
 
@@ -87,7 +87,7 @@ trade-offs:
   checked before the DB. Every fail-open is logged (throttled) as a `WARN`.
 - **Single-instance cache.** The is-revoked cache is per-process with a 30 s TTL; a
   revoke is reflected immediately in the process that served it. Running multiple kb
-  instances means a revoke can take up to the TTL to be seen by the others — run a
+  instances means a revoke can take up to the TTL to be seen by the others. Run a
   single kb instance, or shorten the TTL, for a tight revocation window.
 
 Certs issued before S2a (no enrollment row) are **backfilled** as `legacy` rows on
@@ -111,12 +111,12 @@ JSON
 kb-console -kb https://aimee-kb:8741 -cred console.cred -oidc oidc.json
 ```
 
-Without an OIDC file the console runs **break-glass-only** — create
+Without an OIDC file the console runs **break-glass-only**: create
 `$KB_CONSOLE_HOME/.break_glass` (0600) to enable the recovery login.
 
 ## Deploy (compose)
 
-The console is a **default-off** compose service under the `console` profile — a
+The console is a **default-off** compose service under the `console` profile. A
 stock `docker compose up` never starts it. To enable it:
 
 ```bash
@@ -143,7 +143,7 @@ is **not** exposed by the console: it is a **curator-scope** action, and folding
 into the console-admin credential would break the separation of duties (a
 console-admin could self-approve changes to the very config it administers). The
 kb's built-in verifier derives scope from the single configured bearer, so a
-distinct curator scope only exists over **mTLS** today — there is no clean
+distinct curator scope only exists over **mTLS** today. There is no clean
 curator-credential path over the console's HTTP+bearer transport.
 
 Until the kb gains multiple scoped bearers, work the review queue directly with a
@@ -158,4 +158,4 @@ curl -fsS -X POST --cert curator.pem --key curator.key \
 ```
 
 A console **OIDC config** change (Accounts → OIDC login config) applies on the
-next **console restart** — there is no live reload.
+next **console restart**. There is no live reload.

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -7,22 +7,24 @@ How to point `aimee-kb` at the model backend that does its **embedding**,
 
 `aimee-kb` is a thin DB2 / curator service. It **never** runs an LLM or embedder
 in-process. It *calls* one over HTTP. Inference lives in a separate **`aimee-kb-*`
-tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid`, the unified
-Vulkan llama.cpp stack, deployed as the SmoothNAS `aimee-llm` plugin) or any external
+tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid` / `aimee-kb-gpu-large`,
+the unified Vulkan llama.cpp stack, deployed as the SmoothNAS `aimee-llm` plugin) or any external
 OpenAI-compatible endpoint. You only ever give the kb a **URL**. The tiers themselves are
 documented in [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 
 ## Tiers: what each backend provides
 
-| Backend | Embedding / reranking | Synthesis | Embedding dim |
-| --- | --- | --- | --- |
-| **`aimee-kb-cpu`** (default) | Qwen3-Emb-0.6B + ettin-68m | **Tier-A** only (gemma-4-E4B, CPU) | **1024** |
-| **`aimee-kb-gpu-small`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 12B) | **2560** (set explicitly) |
-| **`aimee-kb-gpu-mid`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 26B-A4B) | **2560** (set explicitly) |
-| **External LLM** | per the endpoint | per the endpoint | per the endpoint |
+| Backend | Embedding / reranking | Synthesis | Embedding dim | Pull size |
+| --- | --- | --- | --- | --- |
+| **`aimee-kb-cpu`** (default) | Qwen3-Emb-0.6B + ettin-68m | **Tier-A** only (gemma-4-E4B, CPU) | **1024** | ~6.5 GB |
+| **`aimee-kb-gpu-small`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 12B) | **2560** (set explicitly) | ~11.4 GB |
+| **`aimee-kb-gpu-mid`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 26B-A4B, 24 GB card, 2 slots) | **2560** (set explicitly) | ~17.8 GB |
+| **`aimee-kb-gpu-large`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (same 26B-A4B, 32 GB card, 4 slots × 256 K) | **2560** (set explicitly) | ~17.8 GB |
+| **External LLM** | per the endpoint | per the endpoint | per the endpoint | — |
 
-`gpu-small` and `gpu-mid` share the 2560-dim embedder, so a KB moves between them with no
-re-embed. Pick by synth need, not by the KB.
+`gpu-small`, `gpu-mid`, and `gpu-large` share the 2560-dim embedder, so a KB moves between them
+with no re-embed. `gpu-large` is byte-identical to `gpu-mid` bar `SYNTH_SLOTS=4` (4 concurrent
+agents for a 32 GB card). Pick by synth need + card size, not by the KB.
 
 *Tier-A* = mechanical extract/index passes. *Tier-B* = reasoning passes (judge,
 resolve-entities, contradictions, **synthesize**, promote). A small CPU model is

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -6,13 +6,13 @@ How to point `aimee-kb` at the model backend that does its **embedding**,
 ## Principle: the kb runs no model
 
 `aimee-kb` is a thin DB2 / curator service. It **never** runs an LLM or embedder
-in-process — it *calls* one over HTTP. Inference lives in a separate **`aimee-kb-*`
-tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid` — the unified
+in-process. It *calls* one over HTTP. Inference lives in a separate **`aimee-kb-*`
+tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid`, the unified
 Vulkan llama.cpp stack, deployed as the SmoothNAS `aimee-llm` plugin) or any external
 OpenAI-compatible endpoint. You only ever give the kb a **URL**. The tiers themselves are
 documented in [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 
-## Tiers — what each backend provides
+## Tiers: what each backend provides
 
 | Backend | Embedding / reranking | Synthesis | Embedding dim |
 | --- | --- | --- | --- |
@@ -22,7 +22,7 @@ documented in [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 | **External LLM** | per the endpoint | per the endpoint | per the endpoint |
 
 `gpu-small` and `gpu-mid` share the 2560-dim embedder, so a KB moves between them with no
-re-embed — pick by synth need, not by the KB.
+re-embed. Pick by synth need, not by the KB.
 
 *Tier-A* = mechanical extract/index passes. *Tier-B* = reasoning passes (judge,
 resolve-entities, contradictions, **synthesize**, promote). A small CPU model is
@@ -33,12 +33,12 @@ when you point the kb at a capable container via `AIMEE_LLM_URL`.
 ## Zero-config default
 
 If **no** LLM is configured, the kb deployment brings up a **CPU `aimee-kb-cpu`
-container beside it** and points itself at it — embedding, reranking, and Tier-A
-synthesis work out of the box with nothing to set. The operator only opts *up*:
+container beside it** and points itself at it: embedding, reranking, and Tier-A
+synthesis work with nothing to set. The operator only opts *up*:
 configure a GPU container or an external LLM and the CPU sibling is not started.
 
 > The default CPU sibling is owned by the **deploy unit** (the smoothnas plugin /
-> compose), not the kb process — the kb never touches a container runtime.
+> compose), not the kb process. The kb never touches a container runtime.
 
 ## Config surface
 
@@ -60,7 +60,7 @@ then `AIMEE_LLM_URL`, then the zero-config CPU default.
   curator. Give the base URL **without** `/v1` (a trailing `/v1` or `/` is
   tolerated).
 - **Split a service out** by setting `AIMEE_EMBEDDER_URL` and/or
-  `AIMEE_RERANKER_URL` — they override `AIMEE_LLM_URL` for just that service.
+  `AIMEE_RERANKER_URL`. They override `AIMEE_LLM_URL` for just that service.
 - **Auth:** the kb sends **no bearer** on the embed/rerank/synth path, so the
   container must run **auth-off** (empty `AIMEE_LLM_AUTH_TOKEN`). This is safe on
   the internal deployment network (the `aimee-llm` gateway is not exposed
@@ -70,7 +70,7 @@ then `AIMEE_LLM_URL`, then the zero-config CPU default.
 
 The dim is **explicit**, not auto-detected:
 
-- **Unset → 1024** — the CPU / Qwen3-0.6B tier.
+- **Unset → 1024**: the CPU / Qwen3-0.6B tier.
 - **GPU / 4B tier → set `AIMEE_EMBEDDING_DIM=2560`.**
 
 Changing the dim against a **populated** kb is a **drop-and-rebuild re-embed**:
@@ -102,6 +102,6 @@ retrieval + Tier-A synthesis work at 1024-dim with no configuration.
 
 The `aimee-kb` smoothnas plugin and the compose topologies expose `AIMEE_LLM_URL`
 / `AIMEE_EMBEDDER_URL` / `AIMEE_RERANKER_URL` / `AIMEE_EMBEDDING_DIM` as config.
-The kb image carries **no** baked embedder/LLM endpoint defaults — an unset
+The kb image carries **no** baked embedder/LLM endpoint defaults. An unset
 backend falls back to the 384-dim builtin embedder (test/shim only), so a real
 deployment either relies on the default CPU sibling or sets one of the URLs above.

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -164,7 +164,7 @@ aimee agent list                              # configured delegates + slots
 | Speed | Sub-10ms session start and hook checks |
 
 See the [Architecture](ARCHITECTURE.md) for how `aimee-server` (hot path, DB1) and
-`aimee-kb` (knowledge, DB2/DB3) split this work, and the [Manual](../MANUAL.md) for
+`aimee-kb` (knowledge, DB2) split this work, and the [Manual](../MANUAL.md) for
 the day-to-day commands.
 
 ---

--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -8,7 +8,7 @@ section does not imply global priority.
 | State | Folder | Count |
 | --- | --- | --- |
 | Shipped | [`proposals/done/`](proposals/done/) | 65 |
-| Pending | [`proposals/pending/`](proposals/pending/) | 4 |
+| Pending | [`proposals/pending/`](proposals/pending/) | 10 |
 | Accepted (locked, unimplemented) | `proposals/accepted/` | 0 |
 | Deferred | `proposals/deferred/` | 0 |
 | Rejected | `proposals/rejected/` | 0 |
@@ -50,7 +50,7 @@ realized in code and enforced in review; their standalone proposal documents are
 
 ## Pending
 
-The genuinely open work — four proposals, none yet implemented.
+The genuinely open work — ten proposals, none yet implemented.
 
 - [Learning-to-rank weight fitting](proposals/pending/learning-to-rank-weight-fitting.md)
   — the KB-hybrid ranker (`kb_ranker.c`) infers with a learned linear model but
@@ -72,6 +72,37 @@ The genuinely open work — four proposals, none yet implemented.
   — the thin client's SessionStart falls back to a recall-only remote path and
   emits nothing when recall is empty; make `/v1/hooks/session_start` first-class so
   a thin client gets the full server-assembled brief. Companion to the memory split.
+- [LLM-sidecar productionization — curator extraction + idle reflection](proposals/pending/llm-sidecar-productionization-curator-and-reflection.md)
+  — two intelligence steps ship as full scaffolding but stub the LLM call: curator
+  extraction (all stages present; only the Phase-0 embedding sidecar exists behind
+  `kb_curator_sidecar`) and the idle-reflection scheduler (`kb_reflection.c` runs
+  fully; its own header notes LLM candidate generation is stubbed). Graduate both
+  onto one versioned sidecar contract behind a shadow → canary → default gate on the
+  shipped calibration + bandit rails. **Extract / Synthesize / Judge / Reflect /
+  Gate-Promote.**
+- [Org-data connectors + source ingestion](proposals/pending/org-data-connectors-and-source-ingestion.md)
+  — the missing ingest front door for the every-domain KB: a uniform connector
+  contract plus a first adapter set (issue tracker / chat / doc-wiki / email),
+  incremental sync with supersession, and ingest-time auth + scope + PII/poison
+  enforcement, all feeding the existing Normalize → staged-pipeline → curator path.
+  **Extract (Normalize) / Classify-Score / Enforce / Gate-Promote.**
+- [First-class operator-audit activity surface](proposals/pending/operator-audit-activity-surface.md)
+  — every shareable DB2 row already carries `operator_id` / `content_hash` /
+  timestamps and a WORM ledger records privileged actions, but there is no legible
+  way to read "who did what, in which scope, when"; add an operator-facing audit
+  activity surface over the existing provenance.
+- [Proposal-supersession hygiene](proposals/pending/proposal-supersession-hygiene.md)
+  — `pending/` is only signal if finished or superseded proposals leave it; adds a
+  same-commit move convention plus a documented supersession rule and the reconcile
+  drift class to enforce it.
+- [Standing LoCoMo / LongMemEval benchmark cadence](proposals/pending/standing-benchmark-cadence.md)
+  — acceptance criteria cite absolute retrieval/memory parity numbers but nothing
+  runs the full benchmarks on a schedule; adds a standing benchmark cadence beyond
+  the PR-only `bench-smoke`.
+- [Close out platform phase 7 — v1 API stability tag + distributed-mode validation](proposals/pending/v1-stability-and-distributed-validation.md)
+  — the aimee-kb platform arc landed phases 1–6; phase 7 (distributed-mode
+  validation + a v1 API stability tag) is the one remaining piece with no closing
+  artifact.
 
 ## Done (65)
 

--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -1,483 +1,197 @@
 # Proposals
 
-This index reflects the current proposal tree under
-[`docs/proposals/`](proposals/). The pending section is organized by
-the layers of the
-Architecture Charter,
-which is the single umbrella contract every intelligence-surface
-proposal inherits from, whether neural, symbolic, statistical,
-planning, or deterministic. Ordering within a layer does not imply a strict global
-priority.
+This index reflects the actual proposal tree under
+[`docs/proposals/`](proposals/). The authoritative state is the directory
+listing itself; this file is a navigable summary of it. Ordering within a
+section does not imply global priority.
 
-For state folders other than `pending/`, see the authoritative
-directory listing:
+| State | Folder | Count |
+| --- | --- | --- |
+| Shipped | [`proposals/done/`](proposals/done/) | 65 |
+| Pending | [`proposals/pending/`](proposals/pending/) | 4 |
+| Accepted (locked, unimplemented) | `proposals/accepted/` | 0 |
+| Deferred | `proposals/deferred/` | 0 |
+| Rejected | `proposals/rejected/` | 0 |
+| Review notes | `proposals/reviews/` | 0 |
 
-- [`proposals/accepted/`](proposals/accepted/): locked but not yet
-  implemented
-- [`proposals/done/`](proposals/done/): shipped (17 proposals)
-- [`proposals/rejected/`](proposals/rejected/): considered and
-  declined
-- [`proposals/deferred/`](proposals/deferred/): parked for later
-- [`proposals/reviews/`](proposals/reviews/): review notes
+> **Reconciliation note (2026-07-07).** A prior version of this index described a
+> ~40-item "charter-spine" roadmap (curator, corpus stages, cross-source learning,
+> statistical decision systems, MDL synthesis, Bayesian calibration, contextual
+> bandits, planning/MCTS/SMT, the skills library, the hermes-agent intake) and
+> claimed `done/` held 17 proposals. An audit confirmed that roadmap was **real and
+> is now shipped in code** — its proposal files were removed from the tree and the
+> index was never regenerated, so it drifted into describing an empty `accepted/`
+> folder and undercounting `done/` by ~48. This rewrite restores the index to the
+> tree. Orphaned design docs cited by shipped code are tracked under
+> [Documentation integrity](#documentation-integrity).
 
-## Shared vision
+## Governing contracts
 
-Aimee is converging on a single architecture, written down in one
-umbrella document plus two platform-wide contracts.
+Three platform-wide contracts govern every intelligence-surface change. They are
+realized in code and enforced in review; their standalone proposal documents are
+**not currently in the tree** (see [Documentation integrity](#documentation-integrity)):
 
-1. **Architecture Charter.** Fixes role division across neural,
-   symbolic, statistical, planning, and deterministic passes
-   (Recall / Rerank / Rewrite / Extract / Synthesize / Judge / Reflect /
-   Classify-Score / Plan-Search / Reason / Rank-Fuse / Calibrate /
-   Detect-Cluster / Constrain-Verify / Evaluate-Optimize /
-   Gate-Promote / Enforce), one artifact schema, one audit schema, one
-   retroactive-review UX, the sidecar protocol, the service topology,
-   versioning, storage allocation, evaluation discipline, and
-   calibration discipline. Every intelligence-surface proposal
-   inherits from it. A new proposal in that scope that does not name
-   its charter role(s) and cite the charter is not ready for review.
-2. **Two-DB Split.** The locked DB1 (sqlite) and DB2 (postgres + pgvector)
-   storage topology, with a tier-pinned Data Access Layer rule that keeps
-   each tier's backend knowledge inside that tier directory. Storage-boundary
-   enforcement is the scaffold every other proposal lands on top of. (The
-   original split shipped a separate DB3 Qdrant tier; it was folded into
-   DB2 as a pgvector extension in #1575.)
-3. **Memory Public Contract.** The caller-facing contract (scope,
-   filters, typed mutation verbs, profile packs, and stable `--explain`)
-   shared identically across CLI, MCP, and the aimee-kb `/v1/` API.
+1. **Architecture Charter** — fixes role division across neural, symbolic,
+   statistical, planning, and deterministic passes (Recall / Rerank / Rewrite /
+   Extract / Synthesize / Judge / Reflect / Classify-Score / Plan-Search / Reason /
+   Rank-Fuse / Calibrate / Detect-Cluster / Constrain-Verify / Evaluate-Optimize /
+   Gate-Promote / Enforce), one artifact schema, one audit schema, the sidecar
+   protocol, and evaluation/calibration discipline. Any new intelligence-surface
+   proposal must name its charter role(s).
+2. **Two-DB Split** — DB1 (SQLite, local user store) and DB2 (Postgres, shared
+   knowledge store) with a tier-pinned Data Access Layer; the boundary is
+   compile-enforced. The vector tier lives **inside DB2** as a pgvector extension
+   (folded in from a former Qdrant sidecar in #1575) — vectors share the same
+   connection and transaction domain as the rows they embed. See
+   [`STORAGE_TIERS.md`](STORAGE_TIERS.md).
+3. **Memory Public Contract** — the caller-facing memory contract (scope, filters,
+   typed mutation verbs, profile packs, stable `--explain`) shared across CLI, MCP,
+   and the aimee-kb `/v1/` API.
 
 ## Pending
 
-### Evidence pipeline: aimee-kb + curator + learning + ingest
+The genuinely open work — four proposals, none yet implemented.
 
-These proposals together implement the charter's one data pipeline.
-The Document Corpus Intelligence Pipeline
-umbrella maps the document side's stages and tables onto this cluster
-and routes the genuine gaps to four new siblings. Platform and curator
-split the doc + code side; cross-source-learning owns the session /
-feedback / workflow side; ingest-lab is the Normalize stage feeding the
-curator; approximate-sketches sits between normalization and dense
-recall.
+- [Learning-to-rank weight fitting](proposals/pending/learning-to-rank-weight-fitting.md)
+  — the KB-hybrid ranker (`kb_ranker.c`) infers with a learned linear model but
+  nothing ever *fits* it; weights are hand-set `{0.6, 0.4}` defaults and the two
+  sketch weights ship pinned at `0.0`. Adds a fitter sidecar over
+  `feature_rows ⋈ retrieval_outcome`, promotion-gated and benchmark-gated.
+  **Rank-Fuse / Calibrate / Evaluate-Optimize / Gate-Promote.**
+- [Agentic supervised SWE-bench](proposals/pending/agentic-supervised-swebench.md)
+  — a true tool-using, iterating agentic SWE-bench harness so the "beats Reddit's
+  −75.5% supervisor-token reduction at no wall-clock penalty" claim is
+  apples-to-apples; official Docker grader as the sole resolution source; a
+  public-claim gate that fails closed (issue #987, builds on PR #986).
+  **Reason / Execute / Persist / Calibrate / Review.**
+- [Memory architecture — db1 = user, db2 = org](proposals/pending/memory-db1-db2-architecture.md)
+  — retire the `.md`/harness-memory subsystem; split durable memory by scope
+  (db1 = user identity/preferences/commitments, db2 = org rules/conventions/facts/
+  code graph); session-start recall merges both; ingestion routes by scope.
+- [Remote-first session-start](proposals/pending/remote-first-session-start.md)
+  — the thin client's SessionStart falls back to a recall-only remote path and
+  emits nothing when recall is empty; make `/v1/hooks/session_start` first-class so
+  a thin client gets the full server-assembled brief. Companion to the memory split.
 
-- Document Corpus Intelligence Pipeline:
-  umbrella for the document side; maps the 13-stage / 15-table corpus
-  design onto the charter spine + shipped work; sets the CPU-first
-  curator profile and the size-adaptive vector-index strategy.
-  Introduces the four siblings below. **Done.**
-- aimee-kb Service and Public `/v1/` API:
-  service topology; install-today profile picker; OpenAPI v1; SDKs;
-  auth; corpus staging and release gating; reflection HTTP surface.
-  Phase 1 shipped, `/v1/health`, `/v1/version`, `/v1/capabilities`; bearer-token
-  auth; `kb.api.http_port` config; OpenAPI v1 spec. Phases 2+ require dogfood.
-- aimee-kb Service Split and Headless Containerization:
-  `src/kb/` / `src/server/` source split; Docker packaging; `/v1/`-only
-  access (retiring the legacy `kb.*` RPC); headless completeness so a
-  remote container is fully consumable from another host. **New.**
-- Distributed-Mode Auth: Zero-Config Enrollment and Pluggable Verifier:
-  the remote aimee-server ↔ aimee-kb trust boundary the service proposal
-  deferred ("distributed-mode auth"); one-string container enrollment
-  (CA-pinned TLS + one-time token), automated mTLS with auto-rotation,
-  and a pluggable `Verifier` (kb-token default, BYO OIDC/JWT).
-  Container-per-owner by default; single-container multi-tenant is
-  opt-in. **New.**
-- Deep Curator: Doc and Code Extraction:
-  Extract / Synthesize / Judge on docs and code; entity graph;
-  doc↔code bridge via `implements`; contradictions; synthesis;
-  semantic code indexing and search. Runs inside the aimee-kb service.
-  **Accepted. Phase 0 shipped, `scripts/embed-minilm.py` MiniLM-L6-v2 sidecar.**
-- Cross-Source Learning Pipeline: Candidate Generation, Promotion Rollout, and Review:
-  Continuation of the now-done Cross-Source Learning Substrate. Carries the
-  model-assisted / infra-bound remainder, candidate generation, pgvector
-  neighbourhood retrieval, synthesis, the rest of the promotion surfaces,
-  cross-surface review, and version-bump replay. **New.**
-- Ingest Lab and Strategy-Aware Chunking:
-  Normalize stage; document-kind-aware chunking; operator-facing
-  debug surface; quality / staging recommendations for the curator's
-  release gate. **Accepted. Phase 0 shipped, `aimee kb lab` command with chunk preview,
-  quality signals, and stage recommendations.**
-- Ingest Restoration and Bounded-Hallucination Recall Contract:
-  restoration-candidate queueing outside `kb_lab`, single-pass
-  curator fusion with provenance and `[unknown]`, and per-result
-  verbatim vs synthesised recall evidence mode. **Done.**
-- Approximate Sketches for Ingest Pre-Filtering:
-  Bloom / MinHash-LSH / Count-Min / HyperLogLog layer between
-  Normalize and dense recall; cheap dedupe, near-dup clustering,
-  distinct-source counts; feeds `sketch.*` features into the feature
-  view. **Done.** Shipped, all four algorithms + DB2 persistence,
-  Bloom exact skip, MinHash-LSH near-dup skip and supersession proposals,
-  Count-Min / HLL `sketch.*` features, and fixture-backed sketch tests.
-- Corpus Staged Processing Pipeline:
-  per-document resumable stage machine (`corpus_processing_jobs`) that
-  conducts the existing per-kind job queues. Fills the design's central
-  gap. **Done.** Shipped, DB2 job/event/version tables, doc-ingest
-  seeding, deterministic drain handlers, and `aimee kb pipeline`.
-- Corpus Structural Analysis:
-  stages 1 / 2 / 5, doc-type classification, `document_sections`,
-  `document_references` + staleness. **Done.** Shipped, deterministic
-  doc classification, Markdown section trees, document references, and
-  reference staleness helpers.
-- Corpus Terminology and Gap Detection:
-  stages 6 / 12, `term_mapping` and `gap` artifact kinds; corpus gaps
-  feed the memory-side curiosity surface. **New.**
-- Corpus Vector Index Strategy:
-  pgvector HNSW by default, pgvectorscale diskann as an opt-in scale-up;
-  memory vectors stay HNSW. **New.**
+## Done (65)
 
-### Retrieval (Recall / Rerank / Rank-Fuse)
+The [`proposals/done/`](proposals/done/) directory holds 65 shipped proposals.
+Grouped by theme:
 
-- Dynamic Alpha Fusion for KB Hybrid Retrieval:
-  score-aware lexical / dense blending shipped as an opt-in fusion mode on
-  `POST /v1/search`; benchmark gate did not justify a default flip, so `rrf`
-  remains default. **Done, bench-only / no rollout.**
-- Cross-repo dependency graph:
-  precise, confidence-tiered inter-repo dependency edges over the multi-repo
-  corpus; corroboration-gated resolver (import/include resolution + export
-  downgrade signal), corpus-derived distinctiveness, signature-aware
-  multiplicity, AMBIGUOUS review queue; query-first (read API + CLI). Engine
-  (S1–S9) shipped; precision + recall hardened via two follow-up proposals;
-  `--reverse`/`--dry-run` built; §9 gates reconciled. **Done** (see
-  `done/cross-repo-dependency-graph.md`). Extends code-graph intelligence.
+- **Universal gateway, ingress & protocol.**
+  [universal LLM gateway](proposals/done/aimee-universal-gateway.md),
+  [canonical IR](proposals/done/aimee-canonical-ir.md),
+  [Anthropic ingress `/v1/messages`](proposals/done/anthropic-ingress.md),
+  [Codex ingress `/v1/responses`](proposals/done/codex-frontend-ingress.md),
+  [context pre-injection + confidence-gated retrieval for ingresses](proposals/done/context-preinjection-ingress.md),
+  [envelope compression + cache-prefix alignment](proposals/done/ingress-compression-and-cache-alignment.md),
+  [ingress cost accounting + request optimizations](proposals/done/ingress-cost-accounting-and-optimizations.md),
+  [`/v1` dispatch migration](proposals/done/v1-dispatch-migration.md) (+ [finish](proposals/done/v1-dispatch-migration-finish.md)),
+  [server-owned turn lifecycle](proposals/done/server-owned-turn-lifecycle.md).
+- **Economizer & context reduction.**
+  [gateway mutation / primary-agent context reduction](proposals/done/economizer-gateway-mutation.md),
+  [unified economizer with two-tier safety](proposals/done/unified-economizer-two-tier-safety.md),
+  [deterministic context folding](proposals/done/deterministic-context-folding.md),
+  [deterministic tool-output condensation](proposals/done/deterministic-tool-output-condensation.md),
+  [optimization surface](proposals/done/optimization-surface.md) (+ [residual](proposals/done/optimization-surface-residual.md)).
+- **Thin client, server, TLS & credentials.**
+  [self-sufficient thin client](proposals/done/self-sufficient-thin-client.md) (+ [data plane](proposals/done/self-sufficient-thin-client-data-plane.md)),
+  [native TLS thin-client backends](proposals/done/native-tls-thin-client-backends.md),
+  [mTLS client identity](proposals/done/mtls-client-identity.md),
+  [server-hosted OAuth CLI agents](proposals/done/server-hosted-oauth-cli-agents.md),
+  [auto vault provisioning at server standup](proposals/done/auto-vault-provisioning-at-server-standup.md),
+  [credential-vault consolidation](proposals/done/cred-vault-consolidation.md),
+  [delegate refactor — async + credential vault](proposals/done/delegate-refactor-async-and-credential-vault.md),
+  [live config reload](proposals/done/live-config-reload.md).
+- **Autonomous development, workflows & delegation.**
+  [autonomous-dev execution substrate](proposals/done/autonomous-dev-execution-substrate.md),
+  [full autonomous development](proposals/done/full-autonomous-development.md),
+  [aimee workflows — autonomy-first dev engine](proposals/done/aimee-dev-lifecycle-workflow.md),
+  [config-extensible workflow blocks](proposals/done/workflow-config-blocks.md),
+  [primary-as-manager enforced workflows](proposals/done/primary-as-manager-enforced-workflows.md),
+  [on-demand delegate execution](proposals/done/delegate-ondemand-execution.md),
+  [four-part harness taxonomy](proposals/done/four-part-harness-taxonomy.md).
+- **Roundtable, review & verification.**
+  [agent roundtable — collaborative drafting](proposals/done/agent-roundtable-collaborative-drafting.md)
+  (+ [residual](proposals/done/agent-roundtable-collaborative-drafting-residual.md),
+  [authoring pipeline](proposals/done/agent-roundtable-authoring-pipeline.md)),
+  [agent-directed PR review](proposals/done/agent-directed-pr-review.md),
+  [roundtable panel composition](proposals/done/roundtable-panel-composition.md),
+  [roundtable reliability](proposals/done/roundtable-reliability.md),
+  [replayable-evidence verification + deepening sweep](proposals/done/replayable-verification-and-deepening-sweep.md).
+- **Code-graph intelligence.**
+  [code-graph intelligence](proposals/done/code-graph-intelligence.md),
+  [graph-derived code-health audit](proposals/done/code-health-audit.md),
+  [cross-repo dependency graph](proposals/done/cross-repo-dependency-graph.md)
+  (+ [precision hardening](proposals/done/cross-repo-precision-hardening.md),
+  [recall recovery](proposals/done/cross-repo-recall-recovery.md)),
+  [C++ class/method extraction](proposals/done/cpp-class-method-extraction.md),
+  [CSS migration assistant](proposals/done/css-migration-assistant.md),
+  [graph feedback — self-audit + learning](proposals/done/graph-feedback-self-audit-and-learning.md).
+- **Knowledge base, curator & retrieval.**
+  [auditable correctness for the KB](proposals/done/auditable-correctness-for-the-kb.md),
+  [pluggable curator LLM backend](proposals/done/curator-llm-backend.md),
+  [aimee-kb LLM endpoints + default CPU container](proposals/done/kb-llm-endpoints-and-default-cpu.md),
+  [aimee-kb web console](proposals/done/kb-web-console.md),
+  [embedder runtime fetch + auto-dimension](proposals/done/embedder-runtime-fetch-autodim.md),
+  [ingest restoration + recall contract](proposals/done/ingest-restoration-and-recall-contract.md),
+  [recall economy progressive disclosure](proposals/done/recall-economy-progressive-disclosure.md),
+  [recall abstention confidence gate](proposals/done/retrieval-abstention-confidence-gate.md),
+  [typed-fact knowledge layer](proposals/done/typed-fact-knowledge-layer.md),
+  [generalise the `memory.benchmark` RPC](proposals/done/memory-benchmark-suite-generalisation.md).
+- **Structured PDF & evidence.**
+  [structured PDF ingestion + coordinate-anchored evidence](proposals/done/structured-pdf-ingestion-and-evidence-layer.md),
+  [structured-PDF tables → typed facts, visual evidence, OCR](proposals/done/structured-pdf-tables-visual-and-ocr.md).
+- **Governance, audit & memory interception.**
+  [governance — decision records + per-action policy-verdict audit](proposals/done/governance-decision-records-and-action-audit.md),
+  [per-service auditable WORM metrics/logs store](proposals/done/auditable-worm-audit-store.md),
+  [central agent-memory interception](proposals/done/central-agent-memory-interception.md).
+- **LLM container & UI.**
+  [one unified `aimee-llm` container](proposals/done/unified-llm-container.md),
+  [webchat git projects + in-browser VSCode](proposals/done/webchat-git-projects-and-vscode.md),
+  [dedicated Proposals web page](proposals/done/proposals-ui-page.md).
 
-### Synthesis tie-break (Synthesize / Calibrate)
-
-- MDL-Guided Synthesis Selection:
-  minimum-description-length tie-break over N-attempt-agreed
-  synthesis candidates; emits `mdl.*` features; prompt-bump drift
-  guardrail.
-
-### Reasoning (Reason / Constrain-Verify / Case Recall)
-
-- Graph Reasoning, Case-Based Recall, and Contradiction Logic:
-  Datalog-over-DB2 rule engine; case library as promotion target;
-  deterministic temporal / provenance contradiction checks; shared
-  symbolic substrate consumed by curator, learning, and guardrails.
-  **Done.** All 6 acceptance criteria complete, enforcing contradiction demotion, case recall (composite kNN+Datalog), 3 surfaces wired (deep-curator/learning/guardrails).
-
-### Ranking, Calibration, Detection (Rank-Fuse / Calibrate / Detect-Cluster)
-
-- Statistical Decision Systems for Ranking and Detection:
-  shared feature view; learning-to-rank substrate; clustering /
-  anomaly / drift detection; emits `drift_signal` evidence.
-- Bayesian Calibration of Promotion Thresholds:
-  per-`(target_surface, kind, scope)` Beta-binomial posteriors with
-  conformal abstention floor; replaces static `threshold.*` config
-  values with fitted `calibration_profile` artifacts.
-  **Done.** Includes narrowest-scope fallback, Beta-binomial + conformal
-  sidecar fitting, per-surface tau config, dynamic surface discovery,
-  working-profile gate consumption, prompt/model version keyed refits,
-  fixture-backed calibration tests, and benchmark requests.
-- Outcome-Driven Demotion and Poison Resilience:
-  per-row retrieval-outcome attribution via `retrieval_event_id`;
-  demotion driven by observed downstream outcomes rather than declared
-  trust metadata; poison-slice benchmark with a release-blocking
-  clean-vs-adversarial delta gate. **Done.**
-
-### Recall evaluation
-
-- Unified Benchmark Suite: Target Adapters, Pinned Judge, Memory + Coding + Reasoning:
-  language-neutral target-adapter contract; pinned open-weights
-  judge; catalog across memory (LoCoMo, LongMemEval-S/M/L, MSC, DMR,
-  BEAM, MRCR, RULER, L-Eval), coding (HumanEval, MBPP+, BigCodeBench,
-  LiveCodeBench, Aider polyglot, SWE-bench Lite/Verified, RepoBench,
-  TerminalBench), and reasoning (GSM8K, MATH-500, AIME, GPQA, ARC-AGI-2,
-  BBH, MMLU-Pro, HLE, FrontierMath, DROP, LogiQA); `model_only` and
-  `small_agent` (Qwen3 ~3B CPU) reference targets; `direct` / `llm`
-  tracks; token-efficiency gates and 1M-scale production suite.
-  **Accepted. Phase PR1 shipped, `benchmarks/catalog.toml`, `benchmarks/targets/aimee/adapter.py`,
-  provenance schema extensions, and `benchmarks/suite/` dispatch scripts.
-  PR2-PR8 require dogfood and calibration study.**
-
-### Session working-set and outbound payload
-
-Two sibling proposals: one owns the compacted session context, the other
-owns the transport-time decision to preserve prompt-cache prefixes.
-
-- Virtual Context Assembly and Recoverable Tool-Chain Paging:
-  session-local prompt working-set management; tool-chain stubs;
-  budget-aware assembly in `aimee-server`. Phase 1+2 shipped; Phase 3-4 require dogfood.
-- Prompt-Cache-Aware Deferred Payload Rewrite:
-  cache-preserving outbound payload policy; decouples compaction
-  epoch from provider-facing payload rewrites. Done.
-
-### Safety (Classify-Score)
-
-- Neural-Assisted Guardrails and Semantic Risk Scoring:
-  multi-head semantic risk scoring in `pre_tool_check`; advisor to
-  deterministic policy; exemplar clustering via the charter promotion
-  pipeline. Phase 0/1 shipped, sidecar mechanism, shadow dry_run mode, DB1 `guardrail_events` table, score-band policy mapping, `aimee guardrails review` CLI, and `scripts/guardrails-semantic.py` reference sidecar. Phases 2+ require dogfood.
-
-### Planning & Execution (Plan-Search / Constrain-Verify)
-
-- Deliberate Planning, MCTS Search, and SMT Constraint Execution:
-  `plan_candidate` / `plan_template` artifacts; MCTS-seeded bounded
-  plan search; SMT-sidecar hard-constraint validation; case-based
-  plan repair; opt-in gate per task shape.
-
-### Deterministic verify gate (Constrain-Verify)
-
-- Incremental Verify: Change-Scoped Step Selection and Command Scoping:
-  skip verify steps whose declared `paths:` saw no change since the last
-  passing tree in `.aimee/.last-verify`, plus opt-in per-step command
-  scoping to the changed-file set; conservative invalidation
-  (`always_run_globs`, undeclared / new steps) so a tree is never reported
-  passing that a full run would fail. Extends the shipped
-  session-safety verify gate. **Done.**
-
-### Experimentation & Policy (Evaluate-Optimize)
-
-- Contextual Bandits and Counterfactual Replay:
-  Thompson sampling over sidecar / ranker / prompt variants;
-  synthetic-control + IPW attribution over `audit_outcome` evidence;
-  `policy_arm` artifacts flipped through the charter promotion
-  pipeline. **Done.** Five decision points wired (`kb_fusion_mode`, `kb_max_results`, `kb_result_format`, `kb_result_count`, `kb_memory_retrieval_limit`); exploration-budget Gate via `db2_bandit_explore_stats` + `is_exploration` column; replay attribution recorded as `benchmark_trace` artifacts through `POST /v1/intelligence/bandit/replay-record` (`aimee kb bandit --record-replay`); `tools/bandit_fixture_replay.py` 6/6 fixtures green.
-
-### Operational Validation Cycles
-
-Two proposals that exist purely to close acceptance items from
-shipped code on a real calendar. Same pattern: shipped plumbing +
-unshipped operational artifacts + explicit close-by deadline.
-
-- Working-Profile Operational Validation Cycle:
-  first end-to-end test of the charter's promotion +
-  retroactive-review loop; proving ground before the pattern
-  generalizes.
-- Dogfood Autolabel Operational Cycle:
-  operational loop for the dogfood classifier; first monthly review
-  artefact and cross-session reminder demo.
-
-### Imported from the hermes-agent intake
-
-Eleven candidates drafted from the
-hermes-agent concept intake
-(survey of `nousresearch/hermes-agent`). Each cites its charter role(s)
-and the shipped aimee work it builds on. Listed by the intake's priority.
-
-Safety / reliability (P1-P2):
-
-- MCP Supply-Chain Malware Gate:
-  OSV `MAL-*` check before launching `npx`/`uvx`-backed MCP servers;
-  fail-open; DB1 cache; allowlist. **Enforce. Done.**
-- API Error Taxonomy and Failover Classifier:
-  typed `failover_reason_t` + recovery routing (retry / rotate / fallback /
-  compress / abort), replacing scattered status matching in `http_retry.c`.
-  **Classify-Score → Enforce. Done.**
-- Multi-Credential Pool and Rate-Limit Failover:
-  per-provider key pool, `x-ratelimit-*` capture, rotation on the
-  classifier's rate-limit/billing reason. **Enforce / Calibrate. Done.**
-- Model Capability Registry and Capability-Aware Routing:
-  offline-first `models.dev` metadata behind the catalog; capability-gated
-  delegate routing. **Rank-Fuse / Calibrate. Done.**
-- Session Search Agent Tool:
-  zero-LLM agent-callable FTS over DB1 sessions (discovery / scroll /
-  browse + bookends). **Recall.**
-- Shutdown and Crash Forensics:
-  non-blocking signal-time context capture (signal, sender, in-flight
-  state) across daemons; surfaced by `aimee doctor`.
-
-Capability / coordination / research (P3):
-
-- Mixture-of-Agents Ensemble Delegate Mode:
-  opt-in quality-up ensemble (diverse references → aggregator synthesis)
-  over the delegate fabric. **Synthesize / Rank-Fuse. Marked Done; the P0 repair
-  (#131) makes it actually work.** _History: the feature shipped unreachable,
-  `delegate_ensemble_run` had no caller in any shipped binary (its only caller,
-  `cmd_agent_delegate.c`, is lint-only), so `aimee delegate aggregate` ran an
-  ordinary single-agent delegate, and even the engine fan-out routed every
-  reference to the one default agent. PR #131 fixes both: a first-class
-  `POST /v1/delegate/aggregate` entry point and per-task agent routing (plus the
-  temperature/`srand`/clone fixes). The original done-proposal file is absent from
-  this tree; the analysis lives in the Agent Roundtable proposal below._
-- [Agent Roundtable, Round-Robin Collaborative Drafting and Review](proposals/done/agent-roundtable-collaborative-drafting.md):
-  first makes the shipped-but-dead ensemble actually work, wires an entry point
-  (no shipped binary calls it today) and fixes the unrouted-references bug (every
-  "participant" is the same default agent), then generalizes it into a bounded
-  multi-round roundtable: real participant routing, draft/review modes,
-  deterministic convergence, keep-best, preflight cost limits.
-  **Draft / Review / Reason. Done.**
-- [Agent-Directed PR Review](proposals/done/agent-directed-pr-review.md):
-  lets an agent call in the roundtable's review mode against a code change and
-  direct it with a brief (focus areas, fixes made, invariants, questions), with
-  an open mandate so direction reorders priority without suppressing findings.
-  Adds an optional `brief` threaded through `build_round_prompt`, returns the
-  structured review items (not just prose) plus answered questions, and exposes a
-  `CAP_DELEGATE`-gated `ensemble_review` MCP tool. Strictly additive on the
-  roundtable. **Review / Reason. Done.**
-- Composable Named Toolsets:
-  one composable toolset object shared by roles, delegates, gateway
-  channels, and the scripted-RPC allow-list. **Done.**
-- Computer-Use as a Guarded Capability:
-  browser/GUI control via an OSV-gated, sandboxed external MCP server with
-  per-action risk bands + approval-required enforcement.
-  **Classify-Score / Enforce. Done.**
-- Kanban Board over the Work Queue:
-  shipped board view over the existing `cmd_work.c` queue.
-- Kanban Lanes and Claim Hardening:
-  lane claim model + concurrency hardening over the existing queue.
-- Trajectory Capture and Compression:
-  redacted, compressed, replayable trajectories from the DB1 event log for
-  offline eval/training. **Evaluate-Optimize. Done.**
-
-### Skills methodology and capability surface
-
-aimee shipped a complete skill *engine*
-(`skill-context-injection`,
-`agent-self-improvement-skill-lifecycle`)
-but ships no skill *content* and has no proactive dispatcher for the
-primary agent. Four sibling proposals adapt the methodology layer of
-[`obra/superpowers`](https://github.com/obra/superpowers) (MIT) onto
-that engine and expose aimee's own capabilities through the same
-surface. Methodology skills *teach*; the deterministic gates
-(`tdd-enforcement`, `structured-code-review`) still *enforce*, the
-two are defense in depth.
-
-- Bundled Methodology Skill Library:
-  curated default skills (TDD, systematic-debugging,
-  verification-before-completion, condition-based-waiting, …) seeded at
-  install; bundled discovery tier; directory `SKILL.md` format. Loads
-  the empty engine.
-- Proactive Skill Dispatch:
-  SessionStart skill-index injection + dispatch directive + opt-in
-  deterministic PreToolUse advisory; prompt-cache-safe. Charter roles
-  Classify-Score / Gate-Promote. The "reach for the right skill"
-  mechanism the engine lacks.
-- Skill Authoring Discipline and Compliance Eval:
-  `writing-skills` meta-skill + before/after compliance eval gating
-  `skill_change` promotion; `aimee skill lint`. Closes the quality hole
-  in the lifecycle proposal. Charter roles Evaluate-Optimize /
-  Gate-Promote.
-- Capability Skills: Expose aimee's Native Subsystems:
-  thin trigger-activated skills routing to `find_symbol`,
-  `search_memory`, `search_docs`, `delegate` so agents reach for
-  aimee's tooling over grep/re-asking. Charter role Classify-Score.
-
-## Accepted
-
-- Unified Benchmark Suite: Target Adapters, Pinned Judge, Memory + Coding + Reasoning:
-  PR1 shipped, `benchmarks/catalog.toml`, `benchmarks/targets/aimee/adapter.py` (wraps AimeeHarness
-  behind the stdio JSON protocol), provenance fields in `result_schema.py`, judge-profile / dataset-hash
-  refusal check in `verify_scores.py`, and `benchmarks/suite/` dispatch scripts.
-  PR2 (pinned open-weights judge) and PR3+ require dogfood and calibration study.
-- aimee-kb Service and Public `/v1/` API:
-  Phase 1 shipped, `/v1/health`, `/v1/version`, `/v1/capabilities` HTTP endpoints;
-  bearer-token auth middleware; `kb.api.http_port` / `kb_api_bearer_token` config; `--http-port=N`
-  CLI arg; OpenAPI 3.1 spec at `api/openapi-v1.yaml`. Phases 2+ require dogfood.
-- Virtual Context Assembly and Recoverable Tool-Chain Paging:
-  Phase 1+2 shipped, DB1 schema, tool-chain events, deterministic stubs, three MCP inspection tools, `conv_ctx_assemble` budget-aware assembly injected into delegate context. Phases 3-4 require dogfood and benchmark validation.
-- Prompt-Cache-Aware Deferred Payload Rewrite:
-  Done, metadata/observability, opt-in deferral, proxy/delegate transport
-  coverage, and adaptive context refresh gating shipped.
-- Neural-Assisted Guardrails and Semantic Risk Scoring:
-  Phase 0/1 shipped, sidecar mechanism, shadow dry_run mode, DB1 `guardrail_events` table, score-band policy mapping, `aimee guardrails review` CLI, and `scripts/guardrails-semantic.py` reference sidecar. Phases 2+ require dogfood.
-## Done
-
-The [`proposals/done/`](proposals/done/) directory holds 17 shipped
-proposals. Recent highlights by theme:
-
-- **Architecture / platform contracts.** Architecture Charter (umbrella
-  role-division contract for all intelligence-surface proposals),
-  three-DB split + pin-backends + tier-pinned DAL, memory public
-  contract (typed mutation verbs, profile packs, stable `--explain`,
-  thin-client shape), retrieval-ranker-must-not-consume-confidence
-  boundary rule.
-- **Safety / integrity.** Ingest poison gate (Layer 1 deterministic
-  pattern gate; five threat categories; obfuscation-aware normaliser;
-  shadow mode; benchmark fixture sets).
-- **Session / UX.** Conversation branching and thread exploration,
-  live provider catalog and low-context delegate guards,
-  learning-signals router phase 2 fixtures and implicit heuristics.
-- **Retrieval / memory quality.** Memory quality pillars, cross-encoder
-  reranker, embedding model upgrade, HyDE and query decomposition,
-  scene clustering two-stage retrieval, adaptive query routing (plus
-  eval + graph-and-stage-pruning follow-ups), aggregation-aware
-  routing, answer-time citation enforcement, conversational-retrieval
-  tuning bundle (entity/signal + rerank/hard-negatives + temporal
-  resolution), two-lane retrieval with summary and atomic-fact lanes,
-  graph PageRank (context pruning + eval + LongMemEval
-  lift report), information-theoretic salience, memory surprise
-  scoring, recall economy progressive disclosure (bounded ingress
-  envelopes, memory previews with `memory:<id>` pull-handles,
-  shadow-mode retrieval shortcuts, and additive use-case intent
-  search).
-- **Knowledge base.** KB vector collection and retrieval (originally
-  shipped against Qdrant; folded into pgvector inside DB2 in #1575),
-  vector benchmark rollout, vector index sync and cutover, vector
-  observability, vector schema versioning, vector service lifecycle,
-  vector write path, LLM-driven cognification, async cognification
-  pipeline (+ benchmark + job execution / recovery), codebase
-  conventions ingestion, coreference resolution (+ audit + LLM
-  bindings), entity profile cards, episodic vs semantic memory split,
-  memory unit shape and retrieval planner, negation and absence
-  memory, online re-embed and dual-index rollover, memory lifecycle
-  states and alerts, memory-kind cognifier and procedural merge,
-  memory retrieval golden corpus, memory scope lattice (+ rollout),
-  memory semantic dedupe and supersession, typed knowledge graph
-  ontology.
-- **Agent / identity / learning.** Persistent personal agent core,
-  personal agent phases 1-4 (foundations / recall / curiosity /
-  identity), curiosity engine, genome and phenotype identity,
-  disposition traits (+ config / scoped overrides), epistemic
-  directives, functional memory hierarchy, learning-signals router
-  (+ phase 2), prospective memory and triggered recall, retrieval
-  failure detection, scheduled memory maintenance cycles, dogfood
-  operational closeout, project-scoped workflow learning.
-- **Guardrails / safety / edit control.** AI slop detection, bash
-  command guard, branch ownership enforcement, sandboxed tool
-  execution (Linux namespace isolation), session safety (verify gate
-  / merged-PR enforcement / worktree rewrite), TDD enforcement in
-  guardrails, orchestrator self-discipline, structural budgets and
-  ownership guards, autonomous-mode skip-permissions, policy
-  scripting.
-- **Execution / orchestration.** Agent infrastructure context
-  awareness, agent loop middleware, agent streamlining, autonomous
-  pipeline, background process management, concurrent tool execution,
-  collaborative agent rules, delegate role prompts, delegate token
-  budget, delegate web search tool, delegation error recovery,
-  session-templated multi-agent workflows (+ channel / programmatic
-  surfaces), coordinated parallel execution, configurable iteration
-  limits, graceful cancellation, delegate loop guards.
-- **Service / ops / platform.** Doctor command + webchat dashboard,
-  event notification hooks, Fedora / RHEL compatibility, guided
-  onboarding and operator console, multi-provider routing, secret
-  store auto-migration (+ Windows backend), self-update notifier,
-  Windows OS support, worktree remaining fixes, MCP externalization,
-  MCP session-aware git, MCP git context match, lean refactor audit,
-  shared logic library transition, stack-detecting init.
-- **CLI / UX / session.** Slash commands, persistent input history,
-  session history CLI and webchat browser, line editor with vim
-  keybindings, channel message SSE broadcast, investigation notes.
-- **Benchmarking / eval.** Benchmark comparative baselines (BM25 +
-  dense + mem0), benchmark harness v2 (+ derived metrics), density-
-  based context assembly.
-
-For the full chronological list, see the directory listing or
+For the full chronological record, see the directory listing or
 `git log -- docs/proposals/done/`.
 
-## Rejected
+## Documentation integrity
 
-- Adoption and Onboarding
-- DRY Refactoring
-- Idempotent Tool Caching
-- Operations Runbook
-- Project-Scoped Memory
-- Relocate Session State Out of the Repository
-- Split CLI / Hooks / Chat
-- Split cmd / Agent
-- Split DB and Memory
-- Split Webchat
+Cleanup surfaced while regenerating this index:
+
+- **`three-db-split` fully purged (this change).** The former three-tier framing
+  (DB1 / DB2 / DB3-Qdrant) is gone: the vector tier is a pgvector extension inside
+  DB2, full stop. All `docs/proposals/{accepted,pending,done}/three-db-*.md`
+  citations and `DB3` / `db3` mentions in source comments and docs were repointed
+  to [`STORAGE_TIERS.md`](STORAGE_TIERS.md) or reworded to the DB1/DB2 vocabulary.
+- **Empty state folders.** `accepted/`, `deferred/`, `rejected/`, and `reviews/`
+  contain no proposals (only `.gitkeep`). Prior index prose describing rejected /
+  deferred items and an Accepted queue has been removed as unbacked.
+- **Orphaned design docs cited by shipped, verified code.** Source headers cite
+  `docs/proposals/accepted/*.md` documents absent from the tree, even though the
+  code they describe is demonstrably shipped and tested. Verified examples:
+  - **Contextual bandits** — `db2/bandit.c` + `kb/kb_bandit.c` (789 LOC),
+    `bandit_decisions` table (`db2/schema.sql`), `test_bandit.c` +
+    `tools/bandit_replay.py`, endpoints `/v1/intelligence/bandit/{export,replay-record,sample}`.
+  - **Statistical decision systems** — `kb_ranker.c`, `kb_features.c`,
+    `kb_detect.c`, `db2/feature_rows.c` (the [pending LTR proposal](proposals/pending/learning-to-rank-weight-fitting.md)
+    completes the one unshipped half).
+  - **Graph reasoning / case recall** — `kb_reasoning.c` (474 LOC), `db2/cases.sql`.
+  - **MDL-guided synthesis** — `kb_mdl.c` (239 LOC).
+  - **Deliberate planning** — `kb_planner.c` + `scripts/mcts-planner.py`.
+  - Plus `neural-assisted-guardrails`, `ingest-poison-gate` (`integrity_gate.c`),
+    `prompt-cache-aware-deferred-payload-rewrite`, `memory-public-contract`
+    (`memory_effective.c`), `aimee-kb-service-and-public-api`,
+    `aimee-unified-presence`, and the placeholder `example.md` (cited by two tests).
+  - *Stale-but-present:* `agent-roundtable-authoring-pipeline.md` exists in `done/`;
+    its `See docs/proposals/accepted/…` header just needs repointing to `done/`.
+  - Recommended follow-up: restore the orphaned design docs to `done/` as post-hoc
+    records of shipped work, or replace each header comment with the shipped
+    filename. Tracked separately from this index refresh.
 
 ## Notes
 
-- The pending list is small by design. Near-duplicates are merged or
-  split at the boundaries where review concerns differ.
-- `docs/proposals/done/`, `accepted/`, `pending/`, `deferred/`,
-  `rejected/`, and `reviews/` remain the authoritative state folders.
-  Proposals that have shipped move to `done/`.
-- The Architecture Charter
-  is the single review gate for any new intelligence-surface proposal,
-  whether neural, symbolic, statistical, planning, or deterministic. A
-  new proposal in that scope that does not name its charter role(s) and
-  cite the charter is not ready for review.
-- The Memory Public Contract
-  is the review gate for any new caller-facing memory surface, whether
-  a CLI flag, MCP tool shape, or HTTP endpoint. New surfaces align with
-  the contract or explicitly justify a deviation.
+- The pending list is small by design. Proposals that ship move to `done/`.
+- The Architecture Charter is the review gate for any new intelligence-surface
+  proposal (neural, symbolic, statistical, planning, or deterministic): it must
+  name its charter role(s). The Memory Public Contract is the review gate for any
+  new caller-facing memory surface (CLI flag, MCP tool shape, or HTTP endpoint).

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -156,7 +156,7 @@ it downloads a portable Temurin JRE and the pinned `openapi-generator-cli` jar
 into `~/.cache/aimee-sdkgen` (no root required). Regenerating from an unchanged
 spec is a **byte-for-byte no-op**, so regeneration is deterministic.
 
-Two gates keep SDKs honest:
+Two gates guard the SDKs:
 
 - `scripts/check-sdk-parity.py`: every `operationId` in the spec is covered by
   every generated SDK (`make sdk-parity-check`). Run after `make gen-sdks` in the
@@ -193,7 +193,7 @@ KB_BEARER_TOKEN=<token-if-remote> \
   src/tests/test_v1_third_party.sh
 ```
 
-It skips gracefully (exit 0, SKIP) when no service is reachable, so it is safe
+It skips (exit 0, SKIP) when no service is reachable, so it is safe
 in CI; point it at a deployed aimee-kb to validate the stability contract.
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -35,9 +35,9 @@ By default this brings up **two** services. The browser webchat runs *inside* th
 |---------|-----------|------|
 | `aimee-server-kb` | Both aimee binaries (server and kb), the browser webchat UI, and a bundled CPU inference gateway (embed, rerank, synth) in one container | `8743` (server `/v1`, native TLS self signed; plaintext `8740` loopback only), `8741` (kb `/v1`), `8443` (webchat HTTPS, self signed) |
 | `postgres` | `pgvector/pgvector:pg16`, DB2 (`aimee_shared`) for knowledge and vectors | internal |
-| `llm` *(optional)* | Standalone curator LLM sidecar (Gemma 3n E4B via `llama.cpp`). Off by default — the bundled gateway already serves embed, rerank, and synth. Enable it with `--profile external-llm` for a lean `WITH_LLM=0` image, or to bring your own curator GGUF (point `LLM_ENDPOINT` at it). | internal |
+| `llm` *(optional)* | Standalone curator LLM sidecar (Gemma 3n E4B via `llama.cpp`). Off by default, since the bundled gateway already serves embed, rerank, and synth. Enable it with `--profile external-llm` for a lean `WITH_LLM=0` image, or to bring your own curator GGUF (point `LLM_ENDPOINT` at it). | internal |
 
-The kb auto-applies its DB2 schema (tables plus the `pg_trgm` and `vector` extensions) on first boot. The first `--build` takes a few minutes to compile the binaries; the CPU inference model weights are pulled in prebuilt (baked into the image), not downloaded at boot, so later starts are fast. To also run the standalone curator LLM sidecar — for a lean `WITH_LLM=0` image or a custom curator GGUF — add the profile: `docker compose -f compose.combined.yaml --profile external-llm up --build -d`.
+The kb auto-applies its DB2 schema (tables plus the `pg_trgm` and `vector` extensions) on first boot. The first `--build` takes a few minutes to compile the binaries; the CPU inference model weights are pulled in prebuilt (baked into the image), not downloaded at boot, so later starts are fast. To also run the standalone curator LLM sidecar (for a lean `WITH_LLM=0` image or a custom curator GGUF), add the profile: `docker compose -f compose.combined.yaml --profile external-llm up --build -d`.
 
 ### 1.2 Verify it's healthy
 
@@ -56,7 +56,7 @@ If the server endpoints return `200` and `kb/status` reports the DB and vector s
 
 ### 1.3 Browser webchat
 
-The browser UI is a first-class surface and is **on by default**. Open **https://localhost:8443** (accept the self-signed cert) and log in with the default account `aimee` / `aimee-local-dev`. Change `AIMEE_WEBCHAT_USER` / `AIMEE_WEBCHAT_PASSWORD` for anything beyond local dev, or set `AIMEE_WEBCHAT_ENABLED=0` in the compose file to turn it off.
+The browser UI is **on by default**. Open **https://localhost:8443** (accept the self-signed cert) and log in with the default account `aimee` / `aimee-local-dev`. Change `AIMEE_WEBCHAT_USER` / `AIMEE_WEBCHAT_PASSWORD` for anything beyond local dev, or set `AIMEE_WEBCHAT_ENABLED=0` in the compose file to turn it off.
 
 > Webchat is built into the image by default, from both published images and a from-source `docker compose build`, its frontend dependency (`@rakuensoftware/smoothgui`) is vendored in-repo, so the build needs no credentials. Build with `--build-arg WITH_WEBCHAT=0` to ship the server+kb services only.
 
@@ -358,7 +358,7 @@ Every supported client now speaks `https://`, each using its platform's native t
 | macOS, prebuilt `aimee-macos-universal` or source build | Yes | Secure Transport, Keychain |
 | Windows, prebuilt or `install.ps1` build | Yes | Schannel, Windows certificate store |
 
-For per-client cryptographic identity (not just a shared bearer), the server also supports **mTLS client certificates**, clients present a cert from `<aimee_home>/tls/client.{crt,key}` and the server maps it to a `cert:<CN>` principal. Issue and manage them with the `aimee cert` CLI (`/v1/cert/issue|list|revoke`); see the [Manual](../MANUAL.md) for setup.
+For per-client cryptographic identity (beyond a shared bearer), the server also supports **mTLS client certificates**, clients present a cert from `<aimee_home>/tls/client.{crt,key}` and the server maps it to a `cert:<CN>` principal. Issue and manage them with the `aimee cert` CLI (`/v1/cert/issue|list|revoke`); see the [Manual](../MANUAL.md) for setup.
 
 ## Next steps
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -157,7 +157,7 @@ owner when someone is ready to pick it up.
   pluggable-db proposal sitting in `pending/` after being deleted by
   its successor is how `pending/` becomes stale signal. Worth a short
   `CONTRIBUTING.md` addition alongside the PR template.
-- **First-class operator audit surface:** the data is all there
+- **Dedicated operator audit surface:** the data is all there
   (`operator_id` on every shareable row, `content_hash`, timestamps),
   but a CLI verb rendering per-operator / per-scope activity in a
   legible way does not exist. Flagged as a known gap in the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,8 +27,8 @@ retroactive-review pattern the curator depends on.
 
 ### Storage-boundary enforcement
 
-The original three-tier split (DB1 sqlite / DB2 postgres / DB3 qdrant)
-landed; the DB3 vector tier was then folded into DB2 as a pgvector
+The DB1 sqlite / DB2 postgres storage split landed; the vector tier,
+originally a separate Qdrant sidecar, was folded into DB2 as a pgvector
 extension (#1575) so vectors live in the same Postgres instance as the
 rest of DB2 knowledge. The active work is no longer subsystem migration
 planning; it is boundary enforcement and cleanup. Each storage tier
@@ -160,8 +160,8 @@ owner when someone is ready to pick it up.
 - **First-class operator audit surface:** the data is all there
   (`operator_id` on every shareable row, `content_hash`, timestamps),
   but a CLI verb rendering per-operator / per-scope activity in a
-  legible way does not exist. Flagged in the three-db-split
-  Known Weaknesses section.
+  legible way does not exist. Flagged as a known gap in the
+  DB1/DB2 storage-boundary work.
 - **Distributed-mode auth design:** the deep-curator token lifecycle
   is deliberately minimum-viable (opaque bearer, config-file seeded,
   per-token audit). OIDC, short-lived tokens with refresh, per-user

--- a/docs/SANITIZER_CALL_SITES.md
+++ b/docs/SANITIZER_CALL_SITES.md
@@ -16,7 +16,7 @@ kind guards it. It is enforced by `scripts/check-sanitizer-callsites.py` (run fr
   agent-visible string, via `sanitize_for_prompt`. No ad-hoc escaping elsewhere.
 - **Two layers.** Structured kinds (`SANITIZE_FILE_PATH`, `SANITIZE_SYMBOL_LABEL`,
   `SANITIZE_SOURCE_LOCATION`, `SANITIZE_COMMUNITY_NAME`) are strict-validated and
-  **rejected** on control/markup — a caller must fail closed on `SANITIZE_REJECTED`.
+  **rejected** on control/markup. A caller must fail closed on `SANITIZE_REJECTED`.
   Free-text kinds are defanged in place and never rejected.
 - **Status is load-bearing.** A security-sensitive renderer must branch on the
   returned `sanitize_status_t` (`OK` / `TRUNCATED` / `REJECTED`), not ignore it.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -2,7 +2,7 @@
 
 The **Settings** page (aimee web UI, left nav → ⚙️ Settings, route `/settings`) is a typed
 editor over the server's runtime configuration. It exposes **every allowlisted config
-field** — the same `config.show` / `config.set` surface the `aimee config` CLI uses — as a
+field** (the same `config.show` / `config.set` surface the `aimee config` CLI uses) as a
 grouped, filterable form with per-field **Save** and **Reset**.
 
 It is a thin surface over machinery that already exists: each control maps 1:1 to a
@@ -17,7 +17,7 @@ request), unless noted otherwise below.
   /api/config/set {key,value}` → `config.set` (the server validates the key against
   `config_fields` and persists `aimee.yaml`). The webchat proxy (`webchat/config_api.go`)
   is the only network hop; there are no server changes per field.
-- **Control inference:** the control type is inferred from the value's JSON type — a
+- **Control inference:** the control type is inferred from the value's JSON type: a
   **boolean → toggle**, a **number → number field**, a **string → text field**. Grouping is
   by the dotted key prefix (e.g. everything under `reduce.` forms one section).
 - **Quick panel:** a smaller gear dropdown in the top bar (`SettingsPanel`) surfaces the
@@ -25,7 +25,7 @@ request), unless noted otherwise below.
   iterations). The full page is the comprehensive home for everything else.
 
 > **Allowlist, not raw config.** The page can only read/write keys in `config_fields`.
-> Sensitive values — endpoints, `*_key_cmd`, `db2_url`, and **secrets** — are deliberately
+> Sensitive values (endpoints, `*_key_cmd`, `db2_url`, and **secrets**) are deliberately
 > *not* in that allowlist and never appear here. In particular the CI-webhook secret
 > (`AIMEE_CI_WEBHOOK_SECRET`) is an environment secret, not a Settings field.
 
@@ -33,7 +33,7 @@ request), unless noted otherwise below.
 
 ## Option groups added recently
 
-### Context economizer — two-tier switches (`economizer.*`) + levers (`reduce.*`)
+### Context economizer: two-tier switches (`economizer.*`) + levers (`reduce.*`)
 
 The economizer has two **tier switches** that gate the individual `reduce.*` levers, plus the
 levers themselves. All are booleans except the two numeric tuning knobs. Defaults in
@@ -42,8 +42,8 @@ parentheses.
 | Setting | Default | What it does |
 | --- | --- | --- |
 | **`economizer.enabled`** | **on** | **Master switch.** Off = one kill-switch: every reducer is forced off (measurement keeps running and reports zero, proving the kill). The safe tier stays on under it by the levers' own defaults. |
-| `economizer.aggressive` | off | **Opt-in ceiling for the aggressive tier** (live **primary** `/v1` mutation). `reduce.gateway_mutate` activates only with **`economizer.enabled` AND `economizer.aggressive` AND** the lever itself — the aggressive flag alone never turns on a live-traffic mutator. |
-| **`reduce.command_filter`** | **on** | **Tool-output condensation** — deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
+| `economizer.aggressive` | off | **Opt-in ceiling for the aggressive tier** (live **primary** `/v1` mutation). `reduce.gateway_mutate` activates only with **`economizer.enabled` AND `economizer.aggressive` AND** the lever itself; the aggressive flag alone never turns on a live-traffic mutator. |
+| **`reduce.command_filter`** | **on** | **Tool-output condensation**: deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
 | `reduce.gateway_mutate` | off | Apply the economizer to the live inbound `/v1` request so the **primary** agent's tokens are reduced too. See [Economizer gateway mutation](features/economizer-gateway-mutation.md). |
 | `reduce.compress` | on | Size-based compression of oversized tool-result bodies. |
 | `reduce.history_fold` | on | Fold old turn history into a rolling skeleton. |
@@ -53,10 +53,10 @@ parentheses.
 | `reduce.gateway_session_disable_ttl_ms` | 3600000 | Gateway-mutation circuit-breaker window (ms). Must be > 0. |
 | `reduce.freeze_guard_horizon` | 1 | Expected reuse turns for the freeze break-even estimate. |
 
-`reduce.gateway_seam` is intentionally **not** on the page — it is synthesized from
+`reduce.gateway_seam` is intentionally **not** on the page. It is synthesized from
 `gateway_mutate` and its persistence is explicit-gated; toggle `gateway_mutate` instead.
 
-### Autonomous-development pipeline — `autonomy.*`
+### Autonomous-development pipeline: `autonomy.*`
 
 The autonomous-development knobs were historically environment-only (`AIMEE_AUTONOMY_*`).
 They are now typed config fields on the Settings page. A `config` value is **bridged to the
@@ -99,8 +99,8 @@ behavior, safety contract, and observability.
 
 ## When a change takes effect
 
-- **Immediately (next turn):** the economizer `reduce.*` levers and most other fields — the
+- **Immediately (next turn):** the economizer `reduce.*` levers and most other fields. The
   server reloads config per request.
-- **On next server start:** the `autonomy.*` knobs — they are bridged to `AIMEE_AUTONOMY_*`
+- **On next server start:** the `autonomy.*` knobs: they are bridged to `AIMEE_AUTONOMY_*`
   environment variables at startup so the workflow engine (which reads them across a module
   boundary) sees them; an explicitly-set env var always wins.

--- a/docs/STORAGE_TIERS.md
+++ b/docs/STORAGE_TIERS.md
@@ -21,6 +21,6 @@ shared by multiple servers. Shared deployments should receive only information
 appropriate for that shared scope, through the memory, learning, reflection, and
 KB APIs that promote or reflect local server evidence into durable knowledge.
 
-The vector tier was originally a separate Qdrant sidecar (DB3); it was folded
+The vector tier was originally a separate Qdrant sidecar; it was folded
 into DB2 as a pgvector extension in #1575, vectors live in the same Postgres
 instance as the rest of DB2 and need no separate connection or service.

--- a/docs/STRUCTURED_PDF.md
+++ b/docs/STRUCTURED_PDF.md
@@ -4,8 +4,8 @@ aimee-kb can ingest a PDF as **coordinate-anchored evidence** instead of a flat
 blob of text. Every retrieved snippet carries the page and bounding box it came
 from, so an answer can be traced back to the exact place on the page. On top of
 that spine the KB optionally recognises **table cells**, renders **visual crops**
-of figures/tables/pages, and **OCRs scanned pages** — each behind its own
-capability flag, each degrading cleanly to the layer below when its dependency is
+of figures/tables/pages, and **OCRs scanned pages**, each behind its own
+capability flag, each degrading to the layer below when its dependency is
 absent.
 
 Everything here lives entirely in **aimee-kb** (the personal `aimee-server` holds only
@@ -27,8 +27,8 @@ separate opt-in.
 
 Every read surface honours the **same access control** as the spine
 (`document_key`-level check + quarantine), and table cells / crops are gated at read
-time by a join to the authoritative document — never by a cached flag. Structured-PDF
-content is reachable **only** through these `pdf_*` tools — it is deliberately kept out
+time by a join to the authoritative document, never by a cached flag. Structured-PDF
+content is reachable **only** through these `pdf_*` tools. It is deliberately kept out
 of the general `/v1/search` (both the vector path and the convention/derived-artifact
 sweeps), so a PDF cannot leak into an unscoped search.
 
@@ -39,9 +39,9 @@ sweeps), so a PDF cannot leak into an unscoped search.
 Each capability is a config flag (set with `aimee config set <key> <value>` or in
 `aimee.yaml`); the recognition layers also need a local sidecar or poppler binary.
 **Defaults are off.** Two kinds of dependency: the **poppler binaries**
-(`pdftotext`, `pdftoppm`) are *hard* — if a flag that needs one is on but the binary
+(`pdftotext`, `pdftoppm`) are *hard*: if a flag that needs one is on but the binary
 is missing, that step **errors** (e.g. a PDF upload returns an extraction error)
-rather than silently degrading; the **sidecars/embedder** are *soft* — when absent
+rather than silently degrading; the **sidecars/embedder** are *soft*: when absent
 the feature degrades to the layer below (see [Degradation](#degradation)).
 
 ```bash
@@ -77,12 +77,12 @@ sidecars, with `pdftotext` + `pdftoppm` installed in the aimee-kb image.
 ### The sidecars
 
 TSR and OCR are **optional local HTTP sidecars**, deployed the same way as the
-embedder/reranker — a service aimee-kb POSTs to. Despite the `_command` suffix
+embedder/reranker, a service aimee-kb POSTs to. Despite the `_command` suffix
 (inherited from `embedding_command`), `tsr_command` / `ocr_command` take the
 sidecar's **HTTP URL**, not a binary path (the `AIMEE_TSR_URL` / `AIMEE_OCR_URL`
 env vars are the fallback).
 
-These sidecars must be **deployed inside the KB trust perimeter** — the operator runs
+These sidecars must be **deployed inside the KB trust perimeter**: the operator runs
 them with no external network and no document-content retention. That is a deploy-time
 obligation, not something aimee enforces at runtime: aimee-kb hands the sidecar
 document-derived content (page text/geometry, or a rendered page image), so a sidecar
@@ -91,15 +91,15 @@ that egresses or retains is a data-exposure path. aimee never links or bundles t
 `pdftotext` and `pdftoppm` are operator-installed poppler binaries run as hardened
 subprocesses (separate process, `RLIMIT_CPU/AS/FSIZE`, a wall-clock deadline + output
 byte-cap, `setsid` + process-group kill on timeout, and `0600` scratch unlinked on
-every path — `RLIMIT_AS` is what bounds an image/decompression-bomb before output is
+every path. `RLIMIT_AS` is what bounds an image/decompression-bomb before output is
 written). aimee never links or bundles them either.
 
 ---
 
 ## Uploading
 
-`POST /v1/kb/docs` (multipart) with `file`, a `scope` (project), and — **required** for
-a PDF under `kb_pdf_ingest_enabled` — a `sensitivity_class` of `public`, `internal`, or
+`POST /v1/kb/docs` (multipart) with `file`, a `scope` (project), and (**required** for
+a PDF under `kb_pdf_ingest_enabled`) a `sensitivity_class` of `public`, `internal`, or
 `restricted` (a PDF upload with a missing/invalid class is a 400, no rows written). A
 `.pdf` whose bytes are not a real PDF (no `%PDF-` header) is rejected. A document's
 identity is `(scope, document_key)` where `document_key` is its file path, so
@@ -128,7 +128,7 @@ The upload response reports what was ingested, including the §D status:
 - `text_layer` ∈ `native` (real text layer) | `ocr` (recovered by the OCR sidecar) |
   `none` (scanned, no text recovered).
 - `asset_only` is `true` when a scanned PDF yielded **no text** but **did** yield
-  visual crops — so an operator is never misled into thinking a scanned contract is
+  visual crops, so an operator is never misled into thinking a scanned contract is
   text-searchable. Re-uploading once OCR is deployed upgrades it in place.
 
 ---
@@ -146,18 +146,18 @@ are withheld).
 | `pdf_open_neighbors` | `GET /v1/pdf/neighbors` | The prev/next reading-order chunks of a hit |
 | `pdf_inspect_structure` | `GET /v1/pdf/structure` | The document's chunk/page outline |
 | `pdf_lookup_table` | `GET /v1/pdf/lookup_table` | Recognised table cells `{row, col, text, tsr_confidence}` + a `tsr_status` marker (`ran` \| `not_a_table` \| `unavailable`) |
-| `pdf_list_assets` | `GET /v1/pdf/assets` | A document's visual crops — each an **opaque `asset_id`** + page/bbox/kind/caption |
+| `pdf_list_assets` | `GET /v1/pdf/assets` | A document's visual crops, each an **opaque `asset_id`** + page/bbox/kind/caption |
 | `pdf_open_asset` | `GET /v1/pdf/open_asset` | One crop's image bytes (base64) for an opaque `asset_id` |
 | — | `POST /v1/pdf/quarantine` | Owner-only: confirm (release) or reject (purge) a pending restricted document |
 
 ### Answerability
 
-`pdf_search_chunks` returns a per-query-over-corpus **answerability** judgment —
-"given *this* query, how well can the KB answer it" — as a `score ∈ [0,1]` plus a
+`pdf_search_chunks` returns a per-query-over-corpus **answerability** judgment
+("given *this* query, how well can the KB answer it") as a `score ∈ [0,1]` plus a
 `label ∈ {NONE, LOW, MEDIUM, HIGH}` (default cutoffs `<0.15`→NONE, `<0.40`→LOW,
 `<0.66`→MEDIUM, else HIGH; config-overridable). It is a **KB-side shared signal**,
 deliberately a
-*distinct field* from any server-side per-user confidence tier — clients must not
+*distinct field* from any server-side per-user confidence tier. Clients must not
 conflate the two. The combiner is a documented deterministic function of query-scoped
 inputs (top relevance, query-term coverage, hit saturation) so the same `(query,
 corpus state)` always yields the same score.
@@ -172,13 +172,13 @@ corpus state)` always yields the same score.
   scope; the `document_key` is the access unit.
 - **PDF vectors are structurally isolated.** PDF chunk embeddings live in a
   **dedicated `kb_pdf_embeddings` relation that the general `/v1/search` transport
-  never reads** — isolation by schema/module boundary, not a runtime `WHERE` filter
+  never reads**: isolation by schema/module boundary, not a runtime `WHERE` filter
   (which would be a classification, not an access, boundary). A `quarantine_state`
   predicate rides inside the PDF surface as defense-in-depth.
 - **Table cells and crops gate on the live document.** `lookup_table`,
   `open_asset`, and the asset list resolve through a join to the authoritative
   `kb_documents` row (`doc_kind='pdf'` + quarantine + project, bound to the real
-  `file_path`) — a guessed/foreign/withheld key returns empty, never the cached
+  `file_path`). A guessed/foreign/withheld key returns empty, never the cached
   denormalised value.
 - **The blob store never exposes the hash.** Crops are content-addressed by sha256
   (free dedup), but the sha is a **KB-internal identifier**: never returned to a
@@ -187,7 +187,7 @@ corpus state)` always yields the same score.
   row id** (never the hash), which applies the document ACL and writes a structured
   access audit log entry (allowed/denied) before streaming bytes. (Today that entry
   is a structured log line; a durable/WORM, hash-chained audit store is a tracked
-  enhancement — see the limits below.) Content-addressed dedup never widens access —
+  enhancement; see the limits below.) Content-addressed dedup never widens access. The
   gating is on the per-document asset row, not the shared bytes.
 - **Sidecars are not an egress path.** TSR/OCR and `pdftoppm` run inside the
   perimeter with no external network and no content retention.
@@ -212,7 +212,7 @@ errors that step.
 | `kb_pdf_assets_enabled` off | No visual crops; text retrieval unaffected |
 | `kb_pdf_assets_enabled` on, `pdftoppm` **absent** | No crops are produced (rendering fails best-effort); text/ingest unaffected (hard dep, but non-fatal here) |
 | `kb_pdf_ocr_enabled` off (or OCR sidecar unreachable) on a scanned PDF | Ingested **asset-only** if crops were rendered (`text_layer='none'`, `asset_only=true`); otherwise text-less with no crops (`text_layer='none'`, `asset_only=false`) |
-| `kb_pdf_ocr_enabled` on, sidecar recovers text | Text + geometry ingest transparently — same chunks/regions/citations as native text (`text_layer='ocr'`) |
+| `kb_pdf_ocr_enabled` on, sidecar recovers text | Text + geometry ingest transparently, same chunks/regions/citations as native text (`text_layer='ocr'`) |
 
 ---
 

--- a/docs/WEBCHAT_GIT_SECURITY.md
+++ b/docs/WEBCHAT_GIT_SECURITY.md
@@ -1,7 +1,7 @@
 # Webchat git credential security model
 
-How aimee-webchat handles a webuser's git forge credentials — at rest, in transit
-to git, and inside the in-browser editor — and where exposure is and isn't
+How aimee-webchat handles a webuser's git forge credentials (at rest, in transit
+to git, and inside the in-browser editor) and where exposure is and isn't
 closed. This is the reference for the `webchat git projects + in-browser VSCode`
 feature (proposal in `docs/proposals/done/webchat-git-projects-and-vscode.md`).
 
@@ -16,15 +16,15 @@ multi-user and server-hosted, so the goals are:
 2. **Cross-tenant:** one webuser can never read another's credential or files.
 3. **In transit to git:** on the **API git paths** (clone/fetch/pull/push,
    status/log/diff/branch, and PR creation) the token must not leak into a child
-   process's environment (`/proc/<pid>/environ`), argv, logs, or a named file —
+   process's environment (`/proc/<pid>/environ`), argv, logs, or a named file,
    where a co-located process could read it. The **in-browser editor is
-   explicitly out of scope for this invariant today** — see the editor section
+   explicitly out of scope for this invariant today**; see the editor section
    for the one remaining (bounded) exposure and the socket-askpass fix that would
    close it.
 4. **No server-secret bleed:** the editor must never see aimee-server's own
    secrets (DB password, server token, provider keys).
 
-## At rest — the per-principal vault
+## At rest: the per-principal vault
 
 Credentials live only in the encrypted per-principal vault
 (`server_vault.c`, `vault_service.c`, `vault_store.c`), keyed by the
@@ -41,7 +41,7 @@ The credential-resolution precedence is centralized in **one** policy
 gate (`git-cred-centralized-check`) forbids any caller from hand-rolling the
 ladder.
 
-## In transit to git — the token is out of `/proc/<pid>/environ`
+## In transit to git: the token is out of `/proc/<pid>/environ`
 
 For **every API git path** (clone, fetch, pull, push, status/log/diff/branch, and
 PR creation), the forge token does **not** appear in any child process's
@@ -52,17 +52,17 @@ environment:
   `safe_exec` variant `dup2`s it onto a fixed fd (`GIT_CRED_TOKEN_TARGET_FD`) in
   the forked git child with CLOEXEC cleared; the env carries
   `AIMEE_GIT_TOKEN_FD=<n>` (a *number*, not the secret) instead of `GH_TOKEN`.
-  The `GIT_ASKPASS` shim reads the token from `/proc/self/fd/<n>` (re-readable —
+  The `GIT_ASKPASS` shim reads the token from `/proc/self/fd/<n>` (re-readable,
   `cat` reopens the memfd at offset 0). The source memfd is CLOEXEC in the
   parent, so a concurrent exec on another thread can't inherit it; `memfd_create`
   failure fails **closed** (drops the token) rather than falling back to env.
-  Binding invariant — proven in `test_git_cred_inject`: a child run with this env
+  Binding invariant, proven in `test_git_cred_inject`: a child run with this env
   reads the token via `/proc/self/fd/<n>` but its `/proc/self/environ` contains
   only the fd *number*, never the token.
 
 - **Opening a PR** is an **in-process GitHub REST call** (`git_pr_api.c`), not a
   child exec: aimee-server POSTs to `/repos/{owner}/{repo}/pulls` with the token
-  in the `Authorization` header — in server memory only, wiped after the call,
+  in the `Authorization` header, in server memory only, wiped after the call,
   never logged (the HTTP client logs host + byte counts, never headers). The
   origin host is parsed **exactly** (rejects `evilgithub.com`,
   `github.com.evil.com`, …); GitHub remotes only. (This replaced an earlier
@@ -83,7 +83,7 @@ caller's own tree. The git surface can be disabled wholesale with
 `AIMEE_WEBCHAT_GIT=0` (all git routes → 503); the editor independently with
 `AIMEE_WEBCHAT_EDITOR=0`. Both default on.
 
-## The in-browser editor (code-server) — residual exposure
+## The in-browser editor (code-server): residual exposure
 
 The editor process env is curated of the server's own secrets (e.g. `AIMEE_DB2_URL`,
 `AIMEE_SERVER_TOKEN`, provider keys) and hardened (`no_new_privs`,
@@ -91,8 +91,8 @@ The editor process env is curated of the server's own secrets (e.g. `AIMEE_DB2_U
 on-disk `credential.helper` disabled). **However**, unlike the API git paths, the
 editor still injects the HTTPS token as **`GH_TOKEN` in the code-server
 environment.** This is the one remaining spot the token is in a child's
-`/proc/<pid>/environ`. It is a **bounded** exposure — it is the user's *own*
-token, in their *own* editor — but it is readable by **any same-UID code-server
+`/proc/<pid>/environ`. It is a **bounded** exposure: it is the user's *own*
+token, in their *own* editor, but it is readable by **any same-UID code-server
 descendant**: the extension host and its children (chiefly an extension the user
 installs), the integrated terminal, and any shell or git it spawns. It is not yet
 closed. Three pieces remain, and the key technical facts behind them were
@@ -104,10 +104,10 @@ The fd-askpass that works for the API git paths does **not** work for the editor
 Measured against a real code-server 4.126 / Node 24 on a test host:
 
 - VS Code's **SCM "Git" view** runs git in the **extension host** via
-  `child_process.spawn`, which **does** forward an inherited extra fd — so an
+  `child_process.spawn`, which **does** forward an inherited extra fd, so an
   fd-askpass would work there.
 - The **integrated terminal** spawns its shell via **`node-pty`**, which **does
-  not** forward the inherited fd (the dup2'd fd is not open in the pty child — node-pty does not inherit it).
+  not** forward the inherited fd (the dup2'd fd is not open in the pty child; node-pty does not inherit it).
 
 So switching the editor to fd-mode would silently **break terminal git** (the
 askpass would find no fd and, with no `GH_TOKEN` to fall back to, fail auth). The
@@ -121,9 +121,9 @@ regardless of fd inheritance. This is scoped but unimplemented.
 The proposal's "strip `GIT_ASKPASS`/`SSH_AUTH_SOCK` from the extension host but
 keep them for the integrated terminal **and SCM**" is **internally
 contradictory**: VS Code's SCM Git provider *runs in the extension host*, so
-those are the same trust boundary — there is no knob to give the built-in Git
+those are the same trust boundary. There is no knob to give the built-in Git
 extension the credential env while denying it to a third-party extension in the
-same host. The realistic mitigations are: the secret-free curated env (done — no server
+same host. The realistic mitigations are: the secret-free curated env (done, no server
 secrets reach any extension), an operational posture of Open-VSX-only with no
 preinstalled third-party extensions (a deployment policy, not code-enforced), and
 treating any extension the user installs as having access to the user's *own* git
@@ -133,9 +133,9 @@ credential by design.
 
 The editor terminal currently runs as the server UID with the server `PATH`
 (`no_new_privs` already neuters setuid escalation such as `sudo`, and the
-non-root UID denies `docker`/`nsenter`). A stronger jail — a `bwrap`/`unshare`
+non-root UID denies `docker`/`nsenter`). A stronger jail (a `bwrap`/`unshare`
 bind-mount namespace confining the terminal to the workspace subtree, a `seccomp`
-filter denying `mount`/`pivot_root`/`setns`, and cgroup CPU/mem limits — is
+filter denying `mount`/`pivot_root`/`setns`, and cgroup CPU/mem limits) is
 future work; it requires `bubblewrap` in the image and iterative validation
 against a live editor.
 
@@ -146,7 +146,7 @@ against a live editor.
 | clone, fetch, pull, push, status/log/diff/branch | **No** | memfd fd-askpass |
 | open PR | **No** | in-process GitHub REST (`Authorization` header) |
 | SSH git | **No** | in-memory ssh-agent (`SSH_AUTH_SOCK`) |
-| in-browser editor (code-server) | **Yes** (bounded: user's own token) | `GH_TOKEN` in env — fix = socket-fed askpass (scoped) |
+| in-browser editor (code-server) | **Yes** (bounded: user's own token) | `GH_TOKEN` in env; fix = socket-fed askpass (scoped) |
 
 **Remaining hardening** (all editor-scoped, all needing a live code-server to
 implement+validate): socket-fed askpass for the editor; the bwrap/seccomp/cgroup

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -12,7 +12,7 @@ credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).
 
 - **Dashboard overhaul + Logs tab**: the web UI **Dashboard** is now a customizable
-  grid of **server-incurred** metric panels — delegations, per-role metrics, token/cost,
+  grid of **server-incurred** metric panels: delegations, per-role metrics, token/cost,
   guardrail actions, agents, active sessions, readiness, plus opt-in panels (success by
   agent, latency percentiles, top tools, cache efficiency, failures, provider mix,
   confidence). Toggle/reorder panels via **⚙ Customize** (persisted per-browser); latency
@@ -21,16 +21,16 @@ credentials live in the server's **sealed vault**; see
   ledger (`aimee-kb` keeps its own dashboard for KB-internal events). See
   [DASHBOARD.md](DASHBOARD.md).
 - **Web Settings page for the full typed config**: the web UI **⚙️ Settings** page
-  (`/settings`) edits every allowlisted runtime config field — grouped, filterable, with
-  per-field save/reset — over the same `config.show`/`config.set` surface as the CLI. Newly
+  (`/settings`) edits every allowlisted runtime config field (grouped, filterable, with
+  per-field save/reset) over the same `config.show`/`config.set` surface as the CLI. Newly
   exposed groups: the context-economizer levers (`reduce.*`) and the autonomous-development
   pipeline knobs (`autonomy.*`, previously environment-only; a change applies on the next
   server start, and an exported `AIMEE_AUTONOMY_*` still overrides). Secrets and endpoints
   are deliberately not in the allowlist. See [SETTINGS.md](SETTINGS.md).
 - **Tool-output condensation** (default-ON, `reduce.command_filter`): a deterministic,
   command-aware context-economizer lever that condenses recognized command output at the
-  delegate tool seam — test-runner failures and compiler diagnostics kept, passing
-  transcripts and build progress dropped — with the full output spilled for lossless
+  delegate tool seam (test-runner failures and compiler diagnostics kept, passing
+  transcripts and build progress dropped), with the full output spilled for lossless
   recovery. Fail-open and byte-identical when off. Toggle it in the web Settings page. See
   [features/tool-output-condensation.md](features/tool-output-condensation.md).
 - **Self-hosted GPU inference tiers**: the `aimee-kb` inference image ships three tiers you
@@ -51,7 +51,7 @@ credentials live in the server's **sealed vault**; see
   figure/table/page crops into a content-addressed blob store served by the
   access-gated, audited `pdf_open_asset` (`kb_pdf_assets_enabled`), and OCR
   scanned PDFs through the same citation path with an asset-only fallback
-  (`kb_pdf_ocr_enabled`). Each layer degrades cleanly when its sidecar/binary is
+  (`kb_pdf_ocr_enabled`). Each layer degrades when its sidecar/binary is
   absent. See [STRUCTURED_PDF.md](STRUCTURED_PDF.md).
 
 - **Server-sealed credential vault (single store)**: agent/delegate API keys and
@@ -103,7 +103,7 @@ credentials live in the server's **sealed vault**; see
 
 Delegation defaults and the roundtable, see [DELEGATES.md](DELEGATES.md).
 
-- **Delegates work out of the box**: a default agent roster, the ensemble panel,
+- **Delegates work by default**: a default agent roster, the ensemble panel,
   and `remote_writes=full` ship seeded, so `aimee delegate …` and the roundtable
   run on a fresh install with no setup.
 - **Roundtable runs through the delegate core**: `aimee delegate aggregate`

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -33,12 +33,14 @@ credentials live in the server's **sealed vault**; see
   transcripts and build progress dropped), with the full output spilled for lossless
   recovery. Fail-open and byte-identical when off. Toggle it in the web Settings page. See
   [features/tool-output-condensation.md](features/tool-output-condensation.md).
-- **Self-hosted GPU inference tiers**: the `aimee-kb` inference image ships three tiers you
-  swap with one plugin image. `aimee-kb-cpu` runs retrieval on any host, `aimee-kb-gpu-small`
-  bakes a Gemma 4 12B synth, and `aimee-kb-gpu-mid` bakes a Gemma 4 26B-A4B synth that fits a
-  24 GB card fully resident. The GPU tiers build on a Mesa 25 base so RADV uses the RDNA3
-  matrix cores. The local synth also registers as a free delegate. See
-  [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
+- **Self-hosted GPU inference tiers**: the `aimee-kb` inference image ships four tiers you
+  swap with one plugin image. `aimee-kb-cpu` runs retrieval on any host (~6.5 GB image),
+  `aimee-kb-gpu-small` bakes a Gemma 4 12B synth (~11.4 GB, 16 GB card), `aimee-kb-gpu-mid`
+  bakes a Gemma 4 26B-A4B synth that fits a 24 GB card fully resident (~17.8 GB, 2 slots),
+  and `aimee-kb-gpu-large` reuses that same synth on a 32 GB card with 4 concurrent agents at
+  the full 256 K window (same ~17.8 GB image, only `SYNTH_SLOTS=4`). The GPU tiers build on a
+  Mesa 25 base so RADV uses the RDNA3 matrix cores. The local synth also registers as a free
+  delegate. See [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 - **Cross-repo code graph**: the symbol and call graph resolves dependency edges across the
   repositories in your workspace, so blast radius and caller lookups cross repo boundaries.
   Ask in three directions: what a project depends on, what depends on it, or both. See

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -15,9 +15,12 @@ human approval gates.
 > tested, and reachable: `POST /v1/dev/submit` seeds a proposal, creates an
 > autonomous work item on the chosen workflow (default `build`), and the
 > scheduler drives it server-side. See
-> [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md). What's still missing is a
-> general per-workflow trigger: no `aimee workflow run` command and no Run button
-> for an arbitrary (non-`build`) run. See [Limitations](#current-limitations).
+> [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md). The chosen `workflow` is
+> authoritative, so **any** saved workflow starts this way, not only `build`.
+> What's still missing is a trigger *outside* the proposal path: no
+> `aimee workflow run` command and no Run button on **Edit Workflows** to start a
+> saved workflow without submitting a proposal. See
+> [Limitations](#current-limitations).
 
 ## Mental model
 
@@ -236,20 +239,21 @@ the API):
 
 These are real today and worth knowing before you lean on workflows:
 
-1. **Only the autonomous-development trigger is wired.** `POST /v1/dev/submit`
-   creates and starts a run via `wfe_work_item_create` + the scheduler (see
-   [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)). There is still no general
-   per-workflow trigger, no `aimee workflow run` command and no Run button to kick
-   off an arbitrary saved workflow from the UI. You can author, validate, save, and
-   inspect any workflow; only `build`-style autonomous runs (submitted from the
-   Workflow Actions tab) start today.
+1. **Runs start only from the proposal-submit path.** `POST /v1/dev/submit` (the
+   **Workflow Actions** tab) resolves the workflow and starts a run through the
+   scheduler (see [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)). The
+   `workflow` field is authoritative, so **any** saved workflow starts this way, not
+   just `build` — the tab's picker is populated from every saved definition
+   (`GET /api/workflow/defs`). What's missing is a trigger *outside* that path: no
+   `aimee workflow run <name>` command and no Run button on the **Edit Workflows**
+   page, and every run is still framed as a proposal (`proposal_md` is required).
 2. **Run-in-a-specific-project isn't wired.** A work-item has a `repo` field, but
    the per-step blocks resolve their working directory from
    `$AIMEE_WORKFLOW_REPO`/cwd rather than the work-item's `repo`, so binding a run
    to a UI-selected project is incomplete.
 3. **Composer ergonomics.** New steps are added disconnected; you wire order in
-   the inspector. There is no run/visualize-progress view because runs can't be
-   started from the UI yet.
+   the inspector. The **Edit Workflows** page has no live run/progress view — you
+   start and watch runs on the separate **Workflow Actions** tab.
 
 ## See also
 

--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -3,7 +3,7 @@
 The **Workflow Actions** page (aimee web UI, left nav → 📝 Workflow Actions) carries a change from
 an empty editor to a merged PR: **author** a proposal (from scratch or
 delegate-drafted), hand it to the **autonomous-development** engine to implement, and
-**watch** it — a scrollable status/history you can scroll back through to see
+**watch** it, a scrollable status/history you can scroll back through to see
 everything that happened.
 
 It is deliberately a thin surface over machinery that already exists: the wfe
@@ -21,19 +21,19 @@ proposal is still just *markdown + a `lifecycle_work_item`*; its history *is* th
 
 ## User flow
 
-1. **Author** — click **+ New proposal**. Fill in a title, a Markdown body (a
+1. **Author**: click **+ New proposal**. Fill in a title, a Markdown body (a
    Goal / Motivation / Approach / Risks / Tests scaffold is pre-filled), pick a
    workflow (the picker is populated from the saved workflow definitions,
    `GET /api/workflow/defs`; it defaults to `build`, the standard end-to-end
    proposal→PR→merge workflow), and optionally a repo. Optionally click
    **✨ Draft with a delegate** to have a delegate expand your title + notes into a
    polished proposal, previewed for you to accept.
-2. **Submit** — posts the proposal to the autonomous-development intake. The page
+2. **Submit**: posts the proposal to the autonomous-development intake. The page
    switches to the new run's status view.
-3. **Watch** — the detail view shows the current stage, a lifecycle badge, cumulative
+3. **Watch**: the detail view shows the current stage, a lifecycle badge, cumulative
    vs. cap cost, a PR link, and a **scrollable timeline** of every lifecycle event.
    It polls while the run is active and stops at a terminal state.
-4. **Decide** — when the run parks at a human gate, **Approve / Reject** in place.
+4. **Decide**: when the run parks at a human gate, **Approve / Reject** in place.
 
 ---
 
@@ -50,7 +50,7 @@ browser ──/api/*──▶ webchat (Go)  ──/v1/*, UDS──▶ aimee-serv
 - The Go webchat proxies each `/api/*` call to the C server's `/v1/*` HTTP surface
   over a trusted unix socket, asserting the caller's identity with the
   `X-Aimee-Webuser` header + `server.token` bearer (`v1RequestWebuser`). This is how
-  the C server resolves the caller's `webuser:<subject>` principal — which the
+  the C server resolves the caller's `webuser:<subject>` principal, which the
   read endpoints use for ownership scoping (below).
 - The C server owns all state. Submitting writes the proposal markdown to
   `$AIMEE_HOME/edit-workflows/workflow-actions/wi-*.md` and a `lifecycle_work_item` row; the wfe
@@ -79,13 +79,13 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
   stage, state, mode, pause_reason, repo`) plus additive `proposal_name`, `pr_ref`,
   `submitter`, `cum_cost_usd`, `work_item_max_cost_usd`, `override_count`. Additive
   only, so the Edit Workflows page (which reads the same endpoint) is unaffected.
-- **Timeline** — `{events:[{id, stage, kind, actor, detail, cost_usd, created_at}],
+- **Timeline**: `{events:[{id, stage, kind, actor, detail, cost_usd, created_at}],
   next_after}`, oldest-first, paginated by `?after=<event id>&limit=<n≤200>`
   (default 200). `next_after` is the id of the **last returned** event, so the page
   fetches the tail once and polls with `after=next_after` to append only new events.
   Correctness rests on the scheduler being single-writer-per-item (concurrency 1) and
-  event ids being monotonic — so `id > after` never skips or duplicates a row.
-- **Proposal read-back** — `{proposal_md, truncated}`. The file is read **race-free**:
+  event ids being monotonic, so `id > after` never skips or duplicates a row.
+- **Proposal read-back**: `{proposal_md, truncated}`. The file is read **race-free**:
   the fixed proposals dir is opened, then `openat(dirfd, basename, O_NOFOLLOW)`. Since
   `proposal_path` is a flat, server-minted file in one directory, there are no
   mid-path components to race and no symlink is followed (`ELOOP → 403`). Non-regular
@@ -101,14 +101,14 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
 - Request `{prompt, model?}`; response `{text, agent}` where `text` is the generated
   proposal markdown and `agent` is the **name of the configured delegate** that
   produced it (the caller's `model` preference if it named a usable non-CLI delegate,
-  otherwise the default or first eligible one — surfaced so the operator can see who
+  otherwise the default or first eligible one, surfaced so the operator can see who
   drafted it). `handle_agent_draft` (`server_agent.c`) runs one **tool-free** LLM
   completion via `agent_generate` (below) and returns the text.
   `CAP_DELEGATE` is satisfied by the `agent.*` capability prefix
   (`src/server/server_auth.c`).
 - The call is **synchronous**: there is no async job to orphan. A worker thread runs
   the single completion to completion (bounded by the model and the draft token cap)
-  and returns — if the browser gives up, the worker still finishes that one
+  and returns. If the browser gives up, the worker still finishes that one
   completion; nothing lingers as a pollable job. Because an LLM completion can exceed
   the webchat default 10 s timeout, the proxy uses `v1RequestWebuserT` (a
   timeout-parameterized variant of `v1RequestWebuser`, `webchat/vault.go`) with a 95 s
@@ -134,7 +134,7 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
   must string-equal the caller's `server_http_identity_principal()` (`webuser:<subj>`).
   A NULL/empty `submitter` (CLI/legacy/system rows) is owned by nobody, so those reads
   fail closed. This is why the Go proxies use `v1RequestWebuser` (not the un-attested
-  `v1Request`) — otherwise the principal would be empty and every read would 403.
+  `v1Request`), otherwise the principal would be empty and every read would 403.
 - **List scoping.** `GET /v1/workflow/items` returns only the caller's own rows; the
   unscoped operator view is a separate route, `GET /v1/workflow/items/all`, statically
   gated by `CAP_WORKFLOW_ADMIN`. The `/all` route is deliberately *not* owner-filtered,
@@ -143,24 +143,24 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
 - **How capabilities are acquired.** Browser users authenticate to the webchat; the
   webchat→server hop is over the filesystem-trusted UDS, and the C server treats that
   channel as the operator (this is the established single-trusted-operator webchat
-  model — the same one that guards the vault and the workflow gate). The per-route
+  model, the same one that guards the vault and the workflow gate). The per-route
   `CAP_*` values are the transport/route gates; the *per-user* narrowing that matters
   for this feature is the in-handler ownership check on `submitter`, which is why the
   proxies must forward the webuser identity.
 - **Path confinement.** The proposal read-back is dirfd + `openat(O_NOFOLLOW)` on a
-  server-minted basename — no traversal, no symlink follow, no TOCTOU (details above).
+  server-minted basename: no traversal, no symlink follow, no TOCTOU (details above).
 - **Delegate drafting is tool-free.** `agent_generate` (`src/server/agent_runtime.c`)
   selects a single **non-CLI** (HTTP-provider) delegate and calls the plain-completion
   **`agent_execute()` directly**. The tool-execution loop lives only in the *separate*
-  `agent_execute_with_tools_for_role()`, which `agent_generate` never calls — so a
+  `agent_execute_with_tools_for_role()`, which `agent_generate` never calls, so a
   draft returns text and nothing else, regardless of the agent's `tools_enabled`: no
   tools, no worktree, no writes, no repo access. It refuses if only CLI (agentic)
   agents exist. The user's title/notes are the *subject*, framed by a fixed system
   prompt that tells the model to treat them as data. **Residual risk (bounded, not
   zero):** because there are no tools there is no *server-side* side effect, but the
   model can still produce misleading or malicious *markdown* (e.g. a phishing link) in
-  the draft. That draft is shown as a preview and the user must explicitly accept it —
-  the human reviewer owns the same trust judgment they would for any hand-written
+  the draft. That draft is shown as a preview and the user must explicitly accept it.
+  The human reviewer owns the same trust judgment they would for any hand-written
   proposal. The rendered preview cannot inject script (it goes through the escaping
   `renderMd`, below), and an accepted draft only becomes a normal proposal the user
   then submits.
@@ -168,7 +168,7 @@ All C routes are in `src/server/server_http_routes.inc`; handlers in
   there is *no* `CAP_WORKFLOW_ADMIN` override for `/events`, `/proposal`, or the
   single-item GET. An admin's extra reach is the `/all` *list* only (item rows, which
   do not include event `detail` or the proposal body). Consequently
-  **`lifecycle_event.detail`** — served verbatim, not sanitized in v1 — is visible only
+  **`lifecycle_event.detail`** (served verbatim, not sanitized in v1) is visible only
   to the **owner** of the item. (Cross-user admin inspection of another user's timeline
   or proposal is deliberately deferred; use the CLI/DB for that.)
 
@@ -185,9 +185,9 @@ basenames are opened.
 - **Timeline polling.** Keyed on the selected id alone; each tick appends only events
   past the cursor (idempotent: it filters `id > lastId`), and the interval self-stops
   once the item reaches a **terminal** `state`. The terminal set is exactly the
-  non-`active` values of the authoritative work-item `state` enum —
+  non-`active` values of the authoritative work-item `state` enum:
   `active | accepted | rejected | abandoned` (`db1_work_item_t`; see
-  [`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)) — i.e. `accepted`,
+  [`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)), i.e. `accepted`,
   `rejected`, `abandoned`. A **parked** run is *not* a separate state: it stays
   `active` with a non-empty `pause_reason` (`pending_human`, `failed`,
   `budget_exceeded`, …), so the page keeps polling it every ~4 s (an operator can still
@@ -200,13 +200,13 @@ basenames are opened.
   the shared `renderMd`. It is not a general HTML sanitizer: it escapes the raw source
   (`&`, `<`, `>`) and then emits only a fixed, closed set of tags (headings,
   paragraphs, lists, blockquotes, inline emphasis/code, fenced code, and `<a>` links
-  restricted to `http(s)` targets) — so no author-supplied HTML, event handler, or
+  restricted to `http(s)` targets), so no author-supplied HTML, event handler, or
   `javascript:`/SVG payload reaches the DOM. Practically: LLM- or user-authored
   markdown cannot inject script into the page.
 - **Composer draft.** The in-progress draft is persisted in `localStorage`
   (`aimee_proposal_draft`), restored on mount, and cleared on a successful submit and
   on logout (`App.tsx`). `localStorage` is origin-wide, so a draft persists on the
-  device until one of those clears runs — the cross-account protection is "logout
+  device until one of those clears runs. The cross-account protection is "logout
   clears it," not per-user isolation. A server-side per-user draft store is a noted
   non-goal.
 - **Draft-with-a-delegate** shows the result as a **preview**; the body is replaced
@@ -222,17 +222,17 @@ basenames are opened.
 
 Built slice-by-slice, each design-and-code roundtable-reviewed before merge:
 
-- **Slice 0 — backend read surfaces** (PR #954): the timeline/proposal/enriched-item
+- **Slice 0: backend read surfaces** (PR #954): the timeline/proposal/enriched-item
   endpoints + owner scoping. Behavioral unit tests in `test_wfe_webapi.c`
   (ownership allow+deny, pagination cursor, proposal read-back, symlink→403,
   `/all` enrichment).
-- **Slice 1 — Workflow Actions page + Edit Workflows de-scope** (PR #956): the list + status/
+- **Slice 1: Workflow Actions page + Edit Workflows de-scope** (PR #956): the list + status/
   history detail; removes the Runs/Run-state/gate panels from Edit Workflows.
-- **Slice 2 — author-from-scratch composer** (PR #959): the composer + client-side
+- **Slice 2: author-from-scratch composer** (PR #959): the composer + client-side
   draft; removes the Submit-proposal panel from Edit Workflows. (This PR also repaired
-  pre-existing `testing` breakage from an unrelated merge — a clang-format violation
+  pre-existing `testing` breakage from an unrelated merge, a clang-format violation
   and an `audit_args_hash`/`wfe_sha256_raw` test-link `undefined reference`.)
-- **Slice 3 — delegate-assisted drafting** (PR #963): `agent_generate` + `/v1/agent/draft`
+- **Slice 3: delegate-assisted drafting** (PR #963): `agent_generate` + `/v1/agent/draft`
   + the composer's Draft button.
 
 PRs (github.com/RakuenSoftware/aimee): [#954](https://github.com/RakuenSoftware/aimee/pull/954),
@@ -254,10 +254,10 @@ The page is read/UI only; the behavior it drives is governed by existing config:
 - **Autonomous execution** is governed by the wfe engine
   ([`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). Notably the **live forge
   is default-off** (`wfe_live_forge_enabled`): with it off, a run advances and parks at
-  gates without pushing a real PR — which is the safe default for exercising the page.
+  gates without pushing a real PR, which is the safe default for exercising the page.
 - **Submit** is bounded by the intake's existing caps (a 1 MB proposal body cap and the
   intake-auth per-principal rate/concurrency limits); the user-supplied `repo` is
-  handled by the same `/v1/dev/submit` intake that the CLI uses — its validation and
+  handled by the same `/v1/dev/submit` intake that the CLI uses; its validation and
   authorization are the intake's concern, unchanged by this feature.
 - **To exercise it end to end** on a running instance: open `/workflow-actions`, **+ New
   proposal**, optionally **Draft with a delegate**, **Submit**, then watch the timeline

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -104,12 +104,12 @@ the KB scan succeeds.
 ### Verification discipline
 
 1. **Red before green.** To claim something's broken, show the failure in the
-   stock, unmodified system first — a red baseline. No red baseline, no saying
+   stock, unmodified system first, a red baseline. No red baseline, no saying
    "broken." A passing test of your fix is not admissible as evidence the original
    failed; that's treatment, not control.
 2. **The deciding test can't be the one you skipped.** When the true end-to-end is
    unrunnable (e.g. a live Moonlight session), that's a stop. Downgrade to
-   "hypothesis, unverified" — explicitly, in those words — and do not open a
+   "hypothesis, unverified", explicitly, in those words, and do not open a
    PR-as-fix or write a root cause as fact. The thing you couldn't verify is
    exactly the thing you're most likely wrong about.
 3. **Code outranks your repro.** When the system's own source contradicts your

--- a/docs/dev/fold-pipeline-order.md
+++ b/docs/dev/fold-pipeline-order.md
@@ -13,26 +13,26 @@ slice.
 Six steps per turn in `agent_execute_with_tools_internal()`
 (`src/posix/agent_runtime.c`); step 1 is pre-stage input, steps 2–6 are actions:
 
-1. **raw DB1 transcript** — append-only `messages` cJSON array (never mutated).
-2. **session compaction** — `maybe_compact_before_request()` (≈`agent_runtime.c:677`).
-3. **[FOLD PASS — P2]** — runtime calls `context_fold_view(messages, sys, &budget,
+1. **raw DB1 transcript**: append-only `messages` cJSON array (never mutated).
+2. **session compaction**: `maybe_compact_before_request()` (≈`agent_runtime.c:677`).
+3. **[FOLD PASS, P2]**: runtime calls `context_fold_view(messages, sys, &budget,
    cfg, &out)`, which **produces and returns** the synthetic skeleton pair +
    Coordinate Closet (§2) as a view, non-destructively (`messages` untouched), then
    exits. The fold function does not touch prefix state.
-4. **provider-shape normalization** — runtime renders the step-3 view into the active
+4. **provider-shape normalization**: runtime renders the step-3 view into the active
    provider shape (Anthropic content blocks / OpenAI `tool_calls` / Gemini `parts`)
    into a **runtime-owned byte buffer**, with the **atomic tool-pair** rule (a
    `tool_use`+`tool_result` fold together or not at all; folded regions are plain
    non-tool text). This is a deterministic 1:1 render, not a semantic rewrite.
-5. **cache-prefix registration + single hash** — runtime registers the step-4
+5. **cache-prefix registration + single hash**: runtime registers the step-4
    buffer `(ptr,len)` via `payload_rewrite_register_span()`, then the canonical
    prefix-hash wrapper (`track_anthropic_payload_rewrite()` and its
    `track_{openai,gemini}_payload_rewrite` siblings, all delegating into
    `payload_rewrite.c`, ≈`agent_runtime.c:698`) hashes the registered spans **once**.
-6. **request build** — `agent_build_request_*()` (≈`agent_runtime.c:699`).
+6. **request build**: `agent_build_request_*()` (≈`agent_runtime.c:699`).
 
 Invariant: step 3's output is **semantically frozen**; step 4 is a deterministic
-1:1 render; the exact post-step-4 bytes are what step 5 registers and hashes — no
+1:1 render; the exact post-step-4 bytes are what step 5 registers and hashes: no
 semantic change *and* no byte change is permitted between steps 4 and 5. "Rewrite"
 means semantic mutation; rendering at step 4 is not a rewrite. The fold pass MUST
 sit at step 3 (after compaction, before the step-5 hash).
@@ -60,12 +60,12 @@ void payload_rewrite_spans_reset(payload_rewrite_state_t *st);
 
 - `fnv1a_update` stays `static` in `payload_rewrite.c`.
 - The registered span is the **post-step-4** (provider-shape-normalized) serialized
-  bytes — exactly what is sent — so the hash matches what the provider caches.
+  bytes (exactly what is sent) so the hash matches what the provider caches.
   `agent_runtime.c` owns that buffer; the fold (step 3) only produces a view and
   exits. Lifetime: register after step 4, hash at step 5, `spans_reset()` at the top
-  of the next turn — no use-after-free / double-free.
+  of the next turn. No use-after-free / double-free.
 - The pending `ingress-compression-and-cache-alignment` work registers the envelope
-  span through the same API — **serialized convergence**: the shared span-registry
+  span through the same API, **serialized convergence**: the shared span-registry
   PR lands first, then the fold and ingress features layer on it. Never two writers.
 
 ## CI single-owner enforcement

--- a/docs/features/context-fold.md
+++ b/docs/features/context-fold.md
@@ -1,7 +1,7 @@
 # Deterministic context folding
 
 Sustain long agent sessions inside a fixed context window by **deterministically
-folding old conversation turns** — no LLM summarization call — while conserving the
+folding old conversation turns** (no LLM summarization call) while conserving the
 exact identifiers an agent needs, and keeping the provider prompt cache warm.
 
 **Status:** shipped on `testing`, **default-off** end to end. Each layer is gated by
@@ -18,45 +18,45 @@ once a conversation grows past `retained_msgs` (default 8) trailing messages and
 least `min_fold_msgs` (default 4) older turns are eligible, a contiguous prefix of
 older turns is replaced by a single synthetic summary:
 
-- **Rolling fold (§1)** — one skeleton line per turn / tool call (`assistant: …`,
+- **Rolling fold (§1)**: one skeleton line per turn / tool call (`assistant: …`,
   `  $ tool …`, `    → result (N bytes)`), plus a budgeted reasoning excerpt.
-- **Coordinate Closet (§2)** — the exact identifiers from the folded region (uuids,
+- **Coordinate Closet (§2)**: the exact identifiers from the folded region (uuids,
   commit shas, paths, digit-bearing `key=value`, issue/PR refs, `handle:`/`memory:`
   tokens) are conserved verbatim in a labelled block so truncation can never
-  amputate them. Secrets are redacted; user-pasted content is *quarantined* —
+  amputate them. Secrets are redacted; user-pasted content is *quarantined*,
   conserved in a separate lane, rendered with an `(untrusted)` marker under a
   divider, and never allowed to mint an agent-trusted label (a prompt-injection
   guard).
-- **Fold-freeze (§3)** — the fold boundary is *pinned* across turns, so the folded
+- **Fold-freeze (§3)**: the fold boundary is *pinned* across turns, so the folded
   prefix stays byte-identical turn-to-turn and the provider cache stays warm; the
   boundary only advances at an "epoch" when the un-folded tail outgrows its cap.
-- **Register grammar (§6)** — folded assistant lines are annotated with their
+- **Register grammar (§6)**: folded assistant lines are annotated with their
   register (verdict / hazard / executing / blocked / in-progress) so the summary
   preserves which turns were settled conclusions.
-- **Fold recall (§4)** — if a later turn re-references a folded-away coordinate, a
+- **Fold recall (§4)**: if a later turn re-references a folded-away coordinate, a
   recall hint is surfaced so the body can be paged back in on demand via the
   existing `code_span_get` / `memory_get` tools.
 
 Two more building blocks ship as tested libraries (storage binding is future work,
 see [Limitations](#limitations-and-deferred-work)):
 
-- **Sealed episodes (§5)** — a replayable checkpoint (conclusion + file inventory)
+- **Sealed episodes (§5)**: a replayable checkpoint (conclusion + file inventory)
   with a file-touch auto-recall predicate (`src/episode_seal.{c,h}`).
-- **Task rail (§8)** — a portable plan FSM serialisable outside the prompt
+- **Task rail (§8)**: a portable plan FSM serialisable outside the prompt
   (`src/task_rail.{c,h}`).
 
 A seventh piece underpins the rest:
 
-- **Per-model budget resolver (§7)** — `src/fold_budget.{c,h}`, a *pure* function
+- **Per-model budget resolver (§7)**: `src/fold_budget.{c,h}`, a *pure* function
   that turns a model id into the fold's token budgets. It has **no user-facing
   config surface** (the operator knobs below are message-count/byte based); it is
   listed here only so the §1–§8 map is complete and so operators understand fold
   output may legitimately differ across model identities.
 
-Everything is **deterministic** — no LLM-summarisation call, no wall-clock input,
-no randomness — so identical input yields byte-identical output, which is what makes
+Everything is **deterministic** (no LLM-summarisation call, no wall-clock input,
+no randomness), so identical input yields byte-identical output, which is what makes
 the freeze and the cache benefit possible. (Model *identity* is an input via §7, so
-switching models is treated as a prefix change — see the freeze invariant.)
+switching models is treated as a prefix change; see the freeze invariant.)
 
 ## Enabling it
 
@@ -65,7 +65,7 @@ All knobs live under the `fold` and `compact.coord_closet` config sections
 **Numeric** keys use **0 as a sentinel** that resolves to a built-in module default:
 `retained_msgs`→8, `min_fold_msgs`→4, `excerpt_bytes`→160, `budget_bytes`→2048,
 `max_ratio_pct`→100, `tail_cap_msgs`→24, `ttl_turns`→4. The snippet below is an
-**all-on reference** — see the staged rollout after it for the recommended order.
+**all-on reference**; see the staged rollout after it for the recommended order.
 
 ```yaml
 fold:
@@ -90,17 +90,17 @@ compact:
 ```
 
 Recommended order to turn on (each is independently safe):
-1. `compact.coord_closet.enabled` — conserve identifiers in tool-result compaction
+1. `compact.coord_closet.enabled`: conserve identifiers in tool-result compaction
    (works even without the transcript fold).
-2. `fold.enabled` (+ `register_enabled`) — the transcript fold itself.
-3. `fold.freeze.enabled` — once folding is on, freeze keeps the cache warm.
-4. `fold.recall.enabled` — re-touch hints.
+2. `fold.enabled` (+ `register_enabled`): the transcript fold itself.
+3. `fold.freeze.enabled`: once folding is on, freeze keeps the cache warm.
+4. `fold.recall.enabled`: re-touch hints.
 
 ## How it behaves (invariants)
 
 - **No silent coordinate loss.** Conserved identifiers are rendered verbatim when
   they fit; a nominated identifier that cannot fit the closet budget is explicitly
-  signalled (`COORD_EVICT_FAIL`) and rendered as a `(partial — … omitted)` marker —
+  signalled (`COORD_EVICT_FAIL`) and rendered as a `(partial — … omitted)` marker,
   never silently dropped.
 - **Atomic tool pairs.** The fold boundary is always a *clean user turn*, so a
   `tool_use` and its `tool_result` are never split, and the retained tail always
@@ -111,10 +111,10 @@ Recommended order to turn on (each is independently safe):
   while it is pinned; a mid-run prefix mutation (e.g. compaction) is detected by a
   digest and forces a clean epoch rather than a false cache claim. A model-identity
   change (different §7 budget) likewise shifts the prefix, so it is handled the same
-  way — a fresh epoch, not a stale cache-warm claim.
-- **Secrets are redacted before render** by the implemented detectors —
+  way: a fresh epoch, not a stale cache-warm claim.
+- **Secrets are redacted before render** by the implemented detectors:
   `ghp_`/`sk-`/`AKIA…`/JWT/PEM token shapes, credential-bearing paths, and sensitive
-  label names — plus any substrings added via `compact.coord_closet.denylist`. The
+  label names, plus any substrings added via `compact.coord_closet.denylist`. The
   detector set is extensible, not exhaustive: it is a strong filter, not an absolute
   guarantee against every possible secret shape.
 
@@ -126,7 +126,7 @@ on closet eviction. `fold_result_t.reused_boundary` reports cache-warm reuse.
 
 ## Limitations and deferred work
 
-The fold is **default-off** and these are the honest gaps (tracked in the proposal
+The fold is **default-off** and these are the known gaps (tracked in the proposal
 close-out):
 
 - **Delegate path only.** The fold targets aimee's own agent loop, which already
@@ -149,7 +149,7 @@ close-out):
 The freeze pins the fold boundary so the reduced prefix stays byte-identical
 turn-to-turn, which keeps the provider prompt cache warm. But establishing a cache
 entry costs a one-time **cache-write**, and a boundary that keeps advancing can pay
-that write repeatedly — which, on a provider that bills cache writes at a premium,
+that write repeatedly, which, on a provider that bills cache writes at a premium,
 can make freezing cost *more* than it saves.
 
 The **freeze cost guardrail** (`reduce.freeze_guard`, default **on**; only acts when
@@ -158,7 +158,7 @@ before pinning a boundary. It compares the *marginal* cost of caching against th
 savings from reuse, using the same `token_tracker` rates as the rest of the cost
 story:
 
-- **Marginal write cost = the write _premium_**, `cache_write_rate − input_rate` —
+- **Marginal write cost = the write _premium_**, `cache_write_rate − input_rate`,
   not the full write rate. You pay the input rate to send the prefix on the first
   turn regardless; caching only adds the difference. Providers with free cache
   creation (OpenAI/Responses: `cache_write = 0`) have a premium ≤ 0, so freezing is
@@ -174,7 +174,7 @@ For every model aimee currently prices this keeps freeze **on** even at horizon 
 already covers; OpenAI has no premium). The exact break-even is re-derived from the
 live pricing table by `test_freeze_guard`, so a future price change that would flip
 the verdict fails that test rather than silently drifting from this prose. The
-guardrail therefore changes no current behavior — its job is to encode
+guardrail therefore changes no current behavior. Its job is to encode
 the correct economics as a tested invariant and to disable freeze automatically only
 under *adverse* pricing (a write premium that outweighs the reuse savings), or when
 caching offers no read discount at all (`cache_read ≥ input`). Missing pricing
@@ -185,7 +185,7 @@ caching offers no read discount at all (`cache_read ≥ input`). Missing pricing
 | Provider | Mechanism | Status |
 |----------|-----------|--------|
 | Anthropic | `cache_control:{ephemeral}` on the stable system-prompt prefix | Existing (`cache_shaping_enabled`); a frozen-history breakpoint is possible future work but low value while reduction keeps the frozen prefix small |
-| OpenAI / Responses | Automatic prefix caching — no explicit marker exists or is needed; the freeze's byte-identical ordering already satisfies the cache-hit criteria, and cache writes are free | No code; advisory only |
+| OpenAI / Responses | Automatic prefix caching, no explicit marker exists or is needed; the freeze's byte-identical ordering already satisfies the cache-hit criteria, and cache writes are free | No code; advisory only |
 | Gemini | `cachedContent` resource, created once per run for the system prompt | Existing; extending it to per-epoch message history is deferred (single per-request resource; recreating it per epoch is expensive for the small post-reduction prefix) |
 
 ## Default state
@@ -201,18 +201,17 @@ site (its synthetic-turn shape is unverified there); `compress` runs for every
 provider.
 
 **Recovery model (what "recoverable" means here).** This is a *lossy* reduction with
-**agentic recovery**, not lossless caching — be precise about the guarantee:
+**agentic recovery**, not lossless caching. Be precise about the guarantee:
 - **Recent context is never touched.** Both levers only reduce messages *before* the
   retained tail; the most recent `retained_msgs` (default 8) are byte-for-byte intact,
   so the agent's working set is always full. `retained_msgs` follows the numeric-0 =
-  built-in-default convention (0 → 8), so the working-set floor is always ≥ 1 — it can
+  built-in-default convention (0 → 8), so the working-set floor is always ≥ 1. It can
   never be configured to zero; an explicit small value (e.g. 1) just narrows it.
 - **Identifiers are conserved, not bodies.** When an old tool-result body is elided,
   the Coordinate Closet preserves the exact paths/ids/hashes it contained (plus the
   body's head+tail excerpt), so references survive. The *omitted middle* of an old
   body is not retained.
-- **Recovery is the agent re-issuing a tool call** (e.g. re-reading a conserved path)
-  — there is **no automatic inline re-fetch**. If a re-fetch fails, the agent handles
+- **Recovery is the agent re-issuing a tool call** (e.g. re-reading a conserved path). There is **no automatic inline re-fetch**. If a re-fetch fails, the agent handles
   it as an ordinary tool error. This refetch is the accepted cost of default-on.
 - Coordinate fidelity (0 lost identifiers) was validated on a captured long session in
   the deterministic-fold close-out.
@@ -227,16 +226,16 @@ reduce:
 ```
 
 **Config persistence convention.** A fresh default config writes **no** `reduce` or
-`compact.coord_closet` block at all — the defaults live in `config_set_defaults`
+`compact.coord_closet` block at all. The defaults live in `config_set_defaults`
 (`src/config.c`). On save, *default-on* keys (`measure`, `delegate_seam`,
 `history_fold`, `compress`, `freeze_guard`, `coord_closet.enabled`) persist only their
 non-default **OFF** state; *default-off* keys (`gateway_seam`) persist only their
 non-default **ON** state. So an operator opt-out round-trips, and an unmodified config
 stays empty. Note `coord_closet.budget_bytes: 0` means **"use the built-in default"**,
-not "force a zero-byte closet" — to disable the closet, set `enabled: false`.
+not "force a zero-byte closet". To disable the closet, set `enabled: false`.
 
 **Not yet default-on:** the **gateway seam** (`reduce.gateway_seam`, the inbound /v1
-path that serves the primary agent) remains off — it is shadow-measure-only until its
+path that serves the primary agent) remains off. It is shadow-measure-only until its
 request-mutation path and 400-retry-from-pristine circuit breaker are built. The
 legacy standalone `fold.*` path also stays opt-in; the economizer supersedes it (when
 the economizer produces a reduced view, the legacy `build_fold_view` is skipped).

--- a/docs/features/economizer-gateway-mutation.md
+++ b/docs/features/economizer-gateway-mutation.md
@@ -1,8 +1,8 @@
 # Economizer gateway mutation (primary-agent context reduction)
 
 The context economizer reduces the **delegate** (sub-agent) turn loop by default. The
-inbound `/v1` **gateway** — the path that serves the **primary** agent, including
-Claude-Code-through-aimee and Codex-through-aimee — historically ran the economizer in
+inbound `/v1` **gateway** (the path that serves the **primary** agent, including
+Claude-Code-through-aimee and Codex-through-aimee) historically ran the economizer in
 **shadow** (`measure_only`): it measured the reduction opportunity but never applied it.
 
 **Gateway mutation** makes the gateway *apply* the reduced messages to the live request,
@@ -19,7 +19,7 @@ reduce:
   gateway_session_disable_ttl_ms: 3600000  # NEW: circuit-breaker window (1h). MUST be > 0.
 ```
 
-- `gateway_mutate: true` **implies** `gateway_seam` — config load auto-enables the shadow
+- `gateway_mutate: true` **implies** `gateway_seam`: config load auto-enables the shadow
   seam **in memory** (never rewriting your file) and logs one WARN, so the shadow baseline
   the validation gates compare against always exists.
 - `gateway_session_disable_ttl_ms` **must be > 0**. `0`/negative is a **startup-fatal**
@@ -35,11 +35,11 @@ reduce:
 - **Streaming** (`/v1/messages` stream:true): the HTTP 200 is committed to the client on
   the first byte, so there is **no mid-stream retry**. The reduced stream is sent; if an
   **invalid-request-class** SSE error frame (`invalid_request_error` / `request_too_large`)
-  is seen — inspected at the SSE decoder layer and forwarded unchanged — the session is
+  is seen (inspected at the SSE decoder layer and forwarded unchanged), the session is
   disabled for **subsequent** turns. Rate-limit / overloaded / auth frames are forwarded
   **without** disabling. The current turn always completes as the upstream delivered it.
 - **OpenAI `/v1/responses` streaming** buffers upstream (via the same buffered path) then
-  replays as SSE, so it inherits the **buffered** treatment — including the 4xx
+  replays as SSE, so it inherits the **buffered** treatment, including the 4xx
   restore-resend. aimee has no true token-by-token upstream streaming for the OpenAI
   primary path, so there is no OpenAI-specific streaming disable-only code.
 
@@ -48,7 +48,7 @@ reduce:
 Mutation is attempted only for a **resolvable per-identity session key**, derived (in
 order) from a validated `aimee-session-id` header (`== SHA-256(auth_identity)[0..16)`),
 else `SHA-256(bearer)[0..16)`. A request with **neither** is a pristine passthrough that
-writes **no** disable state — so one caller's failure can never disable reduction for an
+writes **no** disable state, so one caller's failure can never disable reduction for an
 unrelated caller. Disable state is a bounded (10k), TTL'd, process-local set.
 
 ## Safety contract

--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -1,17 +1,17 @@
 # Tool-output condensation (deterministic command-aware)
 
-Tool output — test-runner logs, compiler/linter dumps, build progress — is the largest and
+Tool output (test-runner logs, compiler/linter dumps, build progress) is the largest and
 most signal-sparse contributor to a coding agent's context. Most of that volume is not
 signal: progress bars, passing-test transcripts, boilerplate, repeated lines.
 
 **Tool-output condensation** is a context-economizer lever that condenses **recognized**
 command output at the tool-execution seam, using **deterministic, command-aware rules** (no
 LLM, so it is ~free). It knows that a test runner's value is its *failures*, a compiler's is
-its *diagnostics*, and drops the rest — **losslessly**: the full raw output is spilled to
+its *diagnostics*, and drops the rest, **losslessly**: the full raw output is spilled to
 disk and a recovery pointer is left in the condensed result, so nothing is destroyed.
 
-It is **default-ON** (unified-economizer P1c — a safe-tier lever: lossless-on-demand,
-fail-open, no-over-reduction) and complements — does not replace — the size-based
+It is **default-ON** (unified-economizer P1c, a safe-tier lever: lossless-on-demand,
+fail-open, no-over-reduction) and complements (does not replace) the size-based
 `reduce.compress`, which stays the fallback for unrecognized output. Set
 `reduce.command_filter=false` to opt out.
 
@@ -23,7 +23,7 @@ reduce:
 ```
 
 Turn it on from the web UI (**⚙️ Settings → `reduce.command_filter`**, see
-[SETTINGS.md](../SETTINGS.md)) or the config above. When off, tool output is **byte-identical to today** — the seam falls through to the size-based `reduce.compress`.
+[SETTINGS.md](../SETTINGS.md)) or the config above. When off, tool output is **byte-identical to today**: the seam falls through to the size-based `reduce.compress`.
 
 ## What it does
 
@@ -33,7 +33,7 @@ before the size-based compression:
 1. **Recognize** the command. Compound/piped/substituted lines and unknown commands pass
    through unchanged (fail-open). Common wrappers are unwrapped (`env`, `sudo`, `time`,
    `npx`, `uv run`, `poetry run`, `pnpm exec`, …). `xargs`, `make`, shell scripts, and **any
-   path-prefixed invocation** (`./git`, `/tmp/cargo`) are treated as opaque — a family rule
+   path-prefixed invocation** (`./git`, `/tmp/cargo`) are treated as opaque. A family rule
    only ever applies to a bare command name.
 2. **Condense** by family:
    - **Test runners** (`pytest`/`jest`/`vitest`/`ctest`/`cargo|go|npm|… test`): keep the
@@ -44,8 +44,8 @@ before the size-based compression:
 3. **Spill + point.** The full raw output is **atomically** written to
    `<aimee_home>/tool-spills/<ref>.out` (temp → `fsync` → rename → dir `fsync`, mode `0600`,
    so a partial write is never promoted) and the condensed result ends with a pointer
-   carrying the opaque `ref`. The agent retrieves the full original with the first-class
-   **`tool_output_get`** tool (P2) — one recovery handle, not a raw filesystem path. The
+   carrying the opaque `ref`. The agent retrieves the full original with the dedicated
+   **`tool_output_get`** tool (P2): one recovery handle, not a raw filesystem path. The
    spill store is kept under a 64 MB budget by oldest-first (mtime) eviction.
 
 ## Safety contract
@@ -57,7 +57,7 @@ before the size-based compression:
 - **Never hide a failure.** A test runner or build with a **non-zero exit and no recognized
   failure line** passes through verbatim rather than risk eliding the cause.
 - **Fail-open everywhere.** An unrecognized command, an over-ceiling body (> 2 MB), or any
-  filter error degrades to the size-based `reduce.compress` — never a crash or a dropped
+  filter error degrades to the size-based `reduce.compress`, never a crash or a dropped
   result.
 - **No masquerade.** A path-prefixed command whose basename matches a known tool (`./git`)
   never inherits that tool's family filter.
@@ -71,19 +71,19 @@ before the size-based compression:
 Process-wide counters accumulate realized savings **and recovery cost** on live traffic
 ([`tool_condense_stats_snapshot`](../../src/tool_condense.c)): `recognized`, `applied`,
 `applied_raw` vs `applied_final` bytes, per-family (`test`, `diag`) counts, and the
-**recovery-cost** side — `recovered` (successful `tool_output_get` page-backs) and
+**recovery-cost** side: `recovered` (successful `tool_output_get` page-backs) and
 `recovered_bytes` (bytes re-injected). Two derived fields make the promotion-gate metric
 explicit:
 
 - `saved_bytes` = `applied_raw − applied_final` (gross condensation saving);
 - **`net_saved_bytes`** = `saved_bytes − recovered_bytes` (**net of recovery**).
 
-`net_saved_bytes` is the honest measure: if the agent keeps paging spilled output back in,
-`recovered_bytes` rises toward `saved_bytes` and the net collapses — the signal that the
+`net_saved_bytes` is the net after recovery: if the agent keeps paging spilled output back in,
+`recovered_bytes` rises toward `saved_bytes` and the net collapses, the signal that the
 lever is not net-saving on that workload. Each condensation logs its `raw→final` delta and
 each recall logs `tool_output_get recovered N bytes` under the `tool_condense` module, so the
 two sides are greppable together. (This precise per-call channel exists because
-`tool_output_get` is the single first-class recovery handle from P2; `history_fold`/`compress`
+`tool_output_get` is the single dedicated recovery handle from P2; `history_fold`/`compress`
 recovery via fold-recall remains best-effort, not byte-exact.)
 
 ## Scope & rollout
@@ -97,7 +97,7 @@ The **default-ON** flip landed in unified-economizer **P1c**, justified by the d
 gate (lossless-on-demand + fail-open + a no-over-reduction audit); it replaces the old lossy
 32 KB read-cap truncation with lossless-recoverable condensation.
 
-The first-class **`tool_output_get`** retrieval tool + the atomic-write / bounded-eviction
+The dedicated **`tool_output_get`** retrieval tool + the atomic-write / bounded-eviction
 recovery contract landed in unified-economizer **P2**.
 
 **Carried follow-ups** (not yet shipped): the **primary-agent** surface (a client-side

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (139)
+## CLI-settable keys (141)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -92,6 +92,8 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `kb_api_bearer_token` | string | Bearer token for the aimee-kb API. |
 | `kb_api_http_port` | int | HTTP port the aimee-kb API listens on. |
 | `kb_evidence_emit_enabled` | bool | Emit evidence records from KB ingest. |
+| `kb_fusion_mode` | string | KB retrieval fusion mode: rrf (default), static_alpha, or dynamic_alpha. |
+| `kb_fusion_static_alpha` | float | Lexical/dense blend weight (0-1) for the static_alpha fusion mode. |
 | `kb_mining_enabled` | bool | Enable background KB mining. |
 | `kb_mining_min_poll_s` | int | Minimum interval (s) between KB mining polls. |
 | `kb_pdf_assets_enabled` | bool | Render structured-PDF figure/table crops to the content-addressed blob store + kb_doc_assets at ingest, served via open_asset (default off; needs pdftoppm). |

--- a/docs/proposals/pending/learning-to-rank-weight-fitting.md
+++ b/docs/proposals/pending/learning-to-rank-weight-fitting.md
@@ -1,0 +1,199 @@
+# Proposal: Learning-to-rank weight fitting — close the loop on the KB-hybrid ranker
+
+- **State:** PENDING — design only. Completes the one unshipped half of the
+  statistical ranking substrate: the ranker *infers* with a learned linear model
+  today, but nothing ever *fits* it from data.
+- **Author:** JBailes
+- **Date:** 2026-07-07
+- **Charter roles:** Rank-Fuse (learned lexical/dense/recency/sketch blend
+  replacing hand-set weights), Calibrate (fit weights from observed retrieval
+  outcomes, not declared priors), Evaluate-Optimize (offline fit + benchmark gate
+  before any default flip), Gate-Promote (the fitted model lands as a
+  promotion-gated `ranker_model` artifact, never a live-edited constant).
+
+## Thesis
+
+The KB-hybrid ranker is built as a *learned* linear model and shipped with every
+part of the loop **except the learning**:
+
+- **Inference is live.** `kb_ranker_rerank_with_sketch` (`src/kb/kb_ranker.c:53`)
+  scores each candidate as
+  `w_dense·dense + w_lex·lex + w_recency·recency + w_sketch_frequency·f + w_sketch_distinct·d`
+  and reorders. The model is a `ranker_model` artifact
+  (`kind='ranker_model'`, `target_surface='kb_hybrid'`, `feature_set_version='v1'`,
+  `model_kind='linear'`) loaded by `kb_ranker_model_load` and persisted by
+  `kb_ranker_model_write` (`src/kb/kb_ranker.c:107,158`), promoted through the
+  ordinary `proposed → committed` artifact state machine.
+- **Features are computed and persisted.** `kb_features_upsert_with_sketch`
+  (`src/kb_features.h`) writes a `feature_rows` row per candidate with
+  `dense.cos`, `lex.cos`, `temp.recency`, `sketch.frequency_kind_scope`,
+  `sketch.distinct_sources_hll` (feature set `v1`), plus `mdl.*` on synthesis
+  candidates.
+- **Labels are captured.** The `retrieval_event` / `retrieval_outcome` tables
+  (shipped by *Outcome-Driven Demotion and Poison Resilience*) already attribute
+  downstream outcomes back to the rows a query surfaced, keyed by
+  `retrieval_event_id`.
+
+What is missing is the single arrow that connects them: **no code reads
+`feature_rows ⋈ retrieval_outcome` and fits `w_*`.** The weights are the hand-set
+literals `{w_dense=0.6, w_lex=0.4, w_recency=0, w_sketch_frequency=0,
+w_sketch_distinct=0}` (`src/kb/kb_ranker.c:32`); `kb_ranker_model_load` even
+*re-hardcodes* those same defaults before reading the artifact
+(`src/kb/kb_ranker.c:188`). `kb_ranker_model_write` accepts a `weights_json` blob
+from a caller that does not exist. The two sketch weights ship pinned at `0.0`, so
+the frequency/distinct-source features are computed, stored — and never used.
+
+This is the *Calibrate* half of the statistical decision substrate, exactly
+analogous to *Bayesian Calibration of Promotion Thresholds* (which replaced static
+`threshold.*` config with fitted `calibration_profile` artifacts). Here we replace
+static `ranker_model` weights with **fitted** `ranker_model` artifacts.
+
+## Goal
+
+A promotion-gated fitting loop that turns accumulated `feature_rows` +
+`retrieval_outcome` into a `ranker_model` artifact — measurably better than the
+`{0.6, 0.4}` default on the benchmark suite, or it does not promote.
+
+1. A **fitter sidecar** that reads the joined feature/outcome view and emits a
+   `weights_json` for `kb_ranker_model_write`.
+2. **Promotion discipline:** the fitted model enters `proposed`, is benchmark-gated,
+   and only a passing model is `committed` — the same gate every other artifact
+   crosses. Default weights remain the fallback when no committed model beats them.
+3. **Honest rollout:** ship fitting behind a flag, prove lift on the benchmark
+   suite before the loaded model is allowed to displace the default. If it does not
+   beat `{0.6, 0.4}`, it stays bench-only — the precedent set by *Dynamic Alpha
+   Fusion* (shipped, `rrf` never flipped to default).
+
+## §0 What already exists (so we don't rebuild it)
+
+| Piece | Where | Status |
+| --- | --- | --- |
+| Linear inference + reorder | `kb_ranker_rerank_with_sketch` | shipped |
+| Model artifact write/load | `kb_ranker_model_write` / `_load` | shipped |
+| `ranker_model` artifact schema + promotion states | `db2_artifact_write`, `proposed`/`committed` | shipped |
+| Per-candidate feature rows | `kb_features_upsert_with_sketch`, `feature_rows` | shipped |
+| Feature-set versioning | `KB_FEATURE_SET_VERSION="v1"` | shipped |
+| Outcome labels + attribution | `retrieval_event` / `retrieval_outcome`, `retrieval_event_id` | shipped |
+| Benchmark harness + suite | `benchmarks/suite/`, `benchmarks/catalog.toml` | shipped |
+| Python-sidecar pattern | `scripts/embed-minilm.py`, `scripts/mcts-planner.py`, `scripts/guardrails-semantic.py` | shipped |
+
+The fitter is the only new moving part; everything it consumes and everything that
+consumes *it* is already in place.
+
+## §1 The training view
+
+Define a read-only join the fitter consumes, one row per (query, candidate):
+
+- **features:** the `v1` vector from `feature_rows` for the candidate
+  (`dense.cos`, `lex.cos`, `temp.recency`, `sketch.frequency_kind_scope`,
+  `sketch.distinct_sources_hll`).
+- **label:** derived from `retrieval_outcome` for the row's `retrieval_event_id`
+  (used-in-answer / cited / positively-attributed = 1, surfaced-but-unused = 0;
+  a pairwise variant orders within a query by outcome strength).
+- **grouping key:** `retrieval_event_id` (the query), so pairwise/listwise
+  objectives respect query boundaries.
+
+The join is materialized in SQL (no model code touches raw tables); the sidecar
+receives it as a JSON batch on stdin, mirroring the existing sidecars' stdio
+contract.
+
+## §2 The fitter sidecar
+
+`scripts/rank-fit.py` (name TBD), same stdio-JSON shape as the other sidecars:
+
+- **input:** `{feature_set_version, objective, rows:[{features, label, group}]}`.
+- **fit:** start with **pointwise logistic / ridge** on the five `v1` features
+  (matches `model_kind='linear'`; interpretable; no new inference code needed).
+  Pairwise (LambdaMART-style) is a later objective behind the same
+  `objective` field — the artifact schema already carries `"objective":"pointwise"`.
+- **output:** `{weights:{"dense.cos":…, "lex.cos":…, "temp.recency":…,
+  "sketch.frequency_kind_scope":…, "sketch.distinct_sources_hll":…},
+  fit_metrics:{…}}` — feature-keyed exactly as `kb_ranker_model_load` parses.
+- **discipline:** refuse to emit when the feature-set version in the batch does not
+  match `KB_FEATURE_SET_VERSION`, or when fewer than a floor number of
+  labelled groups exist (avoid overfitting a thin log). Refusal → keep the
+  default; never silently ship a garbage model.
+
+The sidecar is CPU-only and dependency-light (numpy/scikit or a hand-rolled
+closed-form ridge), consistent with the CPU-first curator profile.
+
+## §3 The fit → promote command
+
+A `aimee kb ranker fit` CLI (and matching `/v1/intelligence/ranker/fit` for the
+service) that:
+
+1. materializes the §1 view,
+2. runs the §2 sidecar,
+3. writes the result via `kb_ranker_model_write` (lands `proposed`),
+4. runs the benchmark suite's recall track against the proposed model,
+5. **commits only on lift** over the current committed model (or the `{0.6,0.4}`
+   default when none is committed), recording the delta as a `benchmark_trace`
+   artifact — the same evidence trail *Contextual Bandits* uses for replay.
+
+Refit is keyed on `feature_set_version` and re-triggered on a feature-set bump,
+mirroring the prompt/model-version-keyed refit in *Bayesian Calibration*.
+
+## Phasing (each independently shippable; behavioural steps default-off)
+
+1. **View + read path.** Materialize the §1 training view and a
+   `aimee kb ranker export-view` dump. No model change. Pure observability into
+   whether enough labelled data exists to fit at all.
+2. **Fitter sidecar + `fit` command, proposed-only.** Produce `ranker_model`
+   artifacts in `proposed`; never auto-commit. Operator inspects.
+3. **Benchmark-gated commit.** Wire the recall track as the promotion gate;
+   commit on lift, record the `benchmark_trace`. Default weights still win when no
+   proposed model beats them.
+4. **Scheduled refit + feature-set-bump invalidation.** Fold into the existing
+   scheduled-maintenance cycle; refit on `v1 → v2` feature bumps.
+
+## Non-goals
+
+- No new features. This fits weights over the **existing** `v1` feature set; adding
+  features is a feature-set version bump, out of scope here.
+- No new inference engine. `score_candidate` stays a linear dot product;
+  non-linear models would be a separate `model_kind` and are not proposed.
+- No default flip by fiat. If fitting does not beat `{0.6, 0.4}` on the suite, the
+  ranker keeps the default and this ships bench-only — that is an acceptable
+  outcome, not a failure to paper over.
+
+## Risks / honest limits
+
+- **Thin-log overfit.** Early on there may be too few labelled groups to fit
+  responsibly; §2's floor + refusal is the guardrail, but it means the loop may sit
+  idle (correctly) for a while. This is a validation-pending property until real
+  outcome volume exists.
+- **Outcome-label bias.** `retrieval_outcome` labels are themselves downstream of
+  the *current* ranking (position bias). Pointwise fitting inherits that bias; the
+  pairwise/IPW-corrected objective is the mitigation and is deferred to a later
+  phase, not claimed now.
+- **Feature staleness.** `feature_rows` are written at retrieval time; a refit over
+  a mixed-version corpus must filter on `feature_set_version` (enforced in §2).
+
+## Tests
+
+- Fixture-backed fitter: a synthetic `feature_rows ⋈ retrieval_outcome` batch with
+  a known-separable signal → asserts fitted weights recover the planted ordering
+  and that `kb_ranker_model_load` round-trips the emitted `weights_json`.
+- Refusal paths: version mismatch and below-floor group count both return the
+  default, not a model.
+- Promotion gate: a proposed model that loses on the benchmark fixture is **not**
+  committed; one that wins is, and a `benchmark_trace` is recorded.
+
+## Open questions for the roundtable
+
+- Pointwise-first vs. pairwise-first — is position bias severe enough at our scale
+  to justify the harder objective in phase 2 rather than phase 4?
+- Should the two sketch weights (pinned `0.0` today) be unlocked only once a fitted
+  model exists, or is a hand-set nonzero prior worth trying independently as a
+  cheaper bench experiment?
+- Reuse `/v1/intelligence/*` namespace and the bandit `replay-record` evidence
+  path, or a dedicated ranker surface?
+
+## Provenance note
+
+The shipped headers `src/kb/kb_ranker.c:3` and `src/kb_features.h` both cite
+`docs/proposals/accepted/statistical-decision-systems-for-ranking-calibration-and-experiments.md`,
+which is **absent from the tree** (`docs/proposals/accepted/` is empty). This
+proposal is the fitting half of that missing design, re-derived from the shipped
+code rather than the lost document. Reconciling the dangling `accepted/` references
+is tracked in the `docs/PROPOSALS.md` refresh, not here.

--- a/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
+++ b/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
@@ -1,0 +1,205 @@
+# Proposal: LLM-sidecar productionization — graduate curator extraction and idle reflection from stub to production
+
+- **State:** PENDING — design only, no code in this PR. Finalises two
+  scaffolded-but-stubbed intelligence steps that ride the shared
+  `kb_curator_sidecar` mechanism. Adds no
+  new subsystem: it wires the existing curator extract/synthesize/judge stages and
+  the existing idle-reflection scheduler onto a production sidecar, behind a
+  calibrated gate. Continuation of **Deep Curator: Doc and Code Extraction**
+  (Accepted, Phase 0 shipped — `scripts/embed-minilm.py` MiniLM-L6-v2 embedding
+  sidecar) and the **Cross-Source Learning** substrate (Done). Does **not**
+  re-propose the curator stage machine, the reflection scheduler, the promotion
+  pipeline, calibration, or the sidecar-invocation shim — all shipped; it makes the
+  LLM step they were built around real.
+- **Author:** JBailes
+- **Date:** 2026-07-07
+- **Charter roles:** Extract (structured entity/fact/decision/relationship
+  extraction from docs and code), Synthesize (reflection candidate generation +
+  higher-order knowledge), Judge (quality gate before durable), Reflect
+  (idle-time consolidation), Calibrate (per-surface promotion thresholds already
+  fitted — this feeds them real candidates), Gate-Promote (staged rollout of the
+  sidecar's output), Evaluate-Optimize (shadow → canary → default via the bandit
+  substrate). Cites the Architecture Charter; this proposal lives entirely inside
+  the charter's Extract/Synthesize/Judge/Reflect spine.
+
+## Thesis
+
+The knowledge base's "it learns, not just stores" story (KNOWLEDGE.md §1, §3) rests
+on two steps that are **scaffolded but stubbed today**:
+
+1. **Curator extraction.** Every curator stage exists as shipped code —
+   `kb_curator_extract.c`, `kb_curator_extract_code.c`, `kb_curator_judge.c`,
+   `kb_curator_synthesize.c`, `kb_curator_resolve_entities.c`,
+   `kb_curator_link_artifacts.c`, `kb_curator_contradictions.c`,
+   `kb_curator_grounding.c`, `kb_curator_index_narrative.c`,
+   `kb_curator_index_claims.c`, `kb_curator_promote.c` — draining
+   `corpus_processing_jobs` through the staged pipeline (`aimee kb pipeline`). But
+   the LLM extraction they exist to run reaches the model through
+   `kb_curator_sidecar_run(cmd, json_input, …)` (`kb_curator_sidecar.c`), and the
+   only sidecar shipped so far is the **Phase 0 embedding** sidecar. Entity / fact
+   / decision extraction and the doc↔code `implements` bridge do not yet run
+   against a production extractor.
+
+2. **Idle reflection.** `kb_reflection.c` ships a full idle-triggered scheduler
+   (fires when `now − last_session_rpc_ts > review_idle_trigger_minutes`, over
+   unreflected `session_summary` artifacts older than
+   `review_session_cooldown_hours`, stamping `reflected_at`, deduplicating). Its
+   own header states the gap verbatim: *"LLM candidate generation is stubbed
+   pending charter sidecar integration; the scheduler infrastructure and
+   deduplication run fully."* So aimee reflects **structurally** today; it does not
+   yet **synthesize**.
+
+Both stubs share one dependency: a production LLM sidecar with a stable contract.
+This proposal defines that contract once, graduates both consumers onto it behind
+a calibrated shadow→canary→default gate, and closes the two operational-validation
+items those stages left open. When it lands, the §1/§3 claims become true in the
+build, not just in the architecture.
+
+## Goal
+
+1. **One production sidecar contract** — a versioned, JSON-in/JSON-out request/
+   response schema (`sidecar_contract_version`) shared by curator extraction and
+   reflection synthesis, invoked through the existing `kb_curator_sidecar_run`
+   shim, with a CPU-first reference implementation that installs today.
+2. **Curator extraction runs it** — the extract/judge/synthesize stages produce
+   real entities, facts, decisions, relationships, and the doc↔code `implements`
+   bridge, gated by the shipped judge stage.
+3. **Reflection synthesizes** — the reflection scheduler's stubbed candidate
+   generation calls the same sidecar and emits synthesis candidates into the
+   shipped promotion pipeline.
+4. **Gated rollout, never a silent flip** — every sidecar output lands in shadow
+   first, is scored against a held-out fixture set, and is promoted to default only
+   through the shipped Bayesian-calibration + bandit machinery.
+5. **Close the open operational items** — the two Operational Validation Cycle
+   proposals (Working-Profile, Dogfood Autolabel) get their first real
+   candidate stream from this, closing their "unshipped operational artifacts"
+   remainder on a real calendar.
+
+## §0 What already exists (so we don't rebuild it)
+
+- **Sidecar shim.** `kb_curator_sidecar_run(cmd, json_input, out_cap, errbuf,
+  errlen)` (`src/kb/kb_curator_sidecar.c`) — spawns a configured command, pipes
+  JSON in, reads JSON out, fails closed with an error string. Backend-agnostic.
+- **Curator stage machine.** All stages listed in the Thesis, plus
+  `kb_curator_queue.c` / `kb_curator_drain.c` (queueing + deterministic drain),
+  `kb_curator_version.c` (prompt/model version keying), `kb_curator_llm.c` (LLM
+  call plumbing), `kb_curator_notify.c`. Driven by `corpus_processing_jobs`
+  (`aimee kb pipeline`) — the resumable per-document stage machine (Done).
+- **Curator config.** `src/config_kb_curator.c` + `src/curator_profile.c` — the
+  CPU-first curator profile and sidecar command configuration.
+- **Reflection scheduler.** `kb_reflection.c` — idle trigger, cooldown, dedup,
+  `reflected_at` stamping; surfaced as `reflection-scheduler` in
+  `kb_service_workers.c`. Everything but LLM candidate generation runs.
+- **Promotion + calibration.** The charter promotion pipeline, **Bayesian
+  Calibration of Promotion Thresholds** (Done — per-`(surface, kind, scope)`
+  Beta-binomial posteriors, conformal abstention floor, working-profile gate
+  consumption), and **Contextual Bandits and Counterfactual Replay** (Done — five
+  decision points wired, exploration-budget gate, replay attribution). These are
+  the rollout rails; today they have no real curator/reflection candidate stream to
+  rank.
+- **Embedding sidecar (Phase 0).** `scripts/embed-minilm.py` (MiniLM-L6-v2) — the
+  pattern this proposal generalizes from embeddings to extraction/synthesis.
+- **Judge stage.** `kb_curator_judge.c` — the quality gate every candidate already
+  passes before becoming durable.
+
+## §1 The sidecar contract (`sidecar_contract_version`)
+
+One versioned JSON contract, shared by both consumers, invoked through the existing
+shim. A request carries `{contract_version, task, profile, inputs[], budget}`;
+`task ∈ {extract_doc, extract_code, synthesize_reflection}`. A response carries
+`{contract_version, candidates[], usage, abstained[]}` where each candidate is a
+typed artifact (entity / fact / decision / relationship / synthesis) with
+provenance spans and a self-reported confidence — **never** a durable write; the
+judge stage (§2) and promotion gate (§4) decide durability.
+
+- **Version-keyed.** `contract_version` composes with the shipped prompt/model
+  version keying (`kb_curator_version.c`) so a bump replays cleanly and calibration
+  refits (already keyed on prompt/model version).
+- **Fails closed.** A malformed or empty sidecar response is a *defer* (retry),
+  never a false success — matching the typed-fact write-gate discipline and the
+  existing `_extract.c` `pending`/`failed` attempt accounting.
+- **Backend-pluggable.** The reference implementation is CPU-first (small local
+  model, consistent with the curator profile); an operator can point
+  `kb.curator.sidecar_cmd` / a new `kb.reflection.sidecar_cmd` at any command
+  honoring the contract. No cloud dependency required to install.
+
+## §2 Curator extraction on the real sidecar
+
+- Wire `kb_curator_extract.c` / `_extract_code.c` to emit `task=extract_doc` /
+  `extract_code` requests and route responses into the existing
+  resolve-entities → link-artifacts → contradictions → judge → promote path. No new
+  stages.
+- Land the **doc↔code `implements` bridge** (Deep Curator's headline edge) as a
+  relationship candidate kind produced by `extract_code` and validated by the
+  typed-fact ontology gate — reusing the shipped `rel_types` machinery, not a new
+  one.
+- Contradictions and grounding stages already exist; they now receive real
+  candidates instead of Phase-0 embeddings.
+
+## §3 Reflection synthesis on the real sidecar
+
+- Replace the stubbed candidate generator in `kb_reflection.c` with a
+  `task=synthesize_reflection` call over the unreflected-`session_summary` batch
+  the scheduler already assembles.
+- Emit synthesis candidates into the same promotion pipeline curator output uses —
+  one durability path, one judge, one calibration surface.
+- Keep every shipped guardrail: idle trigger, cooldown, dedup, `reflected_at`
+  stamping stay exactly as-is; only the "what runs at the fire point" changes.
+
+## §4 Gated rollout — shadow → canary → default
+
+No silent flip. Sidecar output graduates through the shipped rails:
+
+1. **Shadow.** Candidates are generated and scored but not promoted; logged as
+   evidence. Mirrors the semantic-guardrails `dry_run` shadow mode already in the
+   tree.
+2. **Fixture gate.** A held-out extraction/synthesis fixture set (built like the
+   sketch and bandit fixtures already in the repo) gates promotion: precision on
+   entities/facts and a synthesis-usefulness proxy must clear a threshold before
+   canary.
+3. **Canary → default.** Promotion thresholds come from the fitted
+   `calibration_profile` artifacts (Bayesian calibration, Done), and the
+   default-flip decision is a bandit arm (`sidecar_extraction_mode`,
+   `reflection_synthesis_mode`) flipped through the shipped
+   `POST /v1/intelligence/bandit/replay-record` path — attribution recorded as
+   `benchmark_trace` artifacts, exactly as the five existing decision points do.
+
+## §5 Closes the open operational items
+
+The two **Operational Validation Cycle** proposals (Working-Profile, Dogfood
+Autolabel) exist to close acceptance items from shipped plumbing on a real
+calendar; both were blocked on having a live candidate stream. This proposal
+produces that stream — the first end-to-end pass of the promotion + retroactive-
+review loop is a curator/reflection candidate cohort moving shadow→default. Their
+close-by deadlines become achievable, not hypothetical.
+
+## Acceptance criteria
+
+1. **Contract.** `sidecar_contract_version` schema documented; both consumers emit
+   it through `kb_curator_sidecar_run`; malformed response ⇒ defer (proven by a
+   fixture that feeds garbage and asserts retry, not durable write).
+2. **Curator.** `extract_doc` / `extract_code` produce entities, facts, decisions,
+   relationships, and at least one `implements` doc↔code edge on a fixture corpus,
+   all passing the shipped judge stage; contradictions stage exercised.
+3. **Reflection.** An idle fire over a fixture `session_summary` batch produces
+   synthesis candidates into the promotion pipeline; `reflected_at` stamped;
+   dedup holds across two consecutive fires.
+4. **Gate.** Shadow mode emits scored-but-unpromoted candidates; the fixture gate
+   blocks a deliberately-poor sidecar from canary; the default flip is a recorded
+   bandit decision, not a config edit.
+5. **CPU-first install.** A reference sidecar honoring the contract runs with no
+   cloud dependency and installs via the existing curator-profile path.
+6. **Validation-pending, stated as such.** Real-corpus precision/usefulness numbers
+   are a dogfood deliverable (§5); this proposal ships the plumbing + fixtures and
+   reports corpus-scale quality as *validation-pending*, not done.
+
+## Explicitly out of scope / does not re-propose
+
+- The curator stage machine, queue/drain, versioning, judge, promotion, and
+  calibration/bandit rails — all shipped; reused verbatim.
+- Non-file source ingestion (Jira/Slack/email/Drive/…) — that on-ramp is the
+  sibling proposal `org-data-connectors-and-source-ingestion.md`; this proposal
+  makes extraction real, that one makes the corpus wide. They compose but ship
+  independently.
+- Any change to the typed-fact ontology or write gate — relationship candidates
+  ride the existing `rel_types` gate unchanged.

--- a/docs/proposals/pending/operator-audit-activity-surface.md
+++ b/docs/proposals/pending/operator-audit-activity-surface.md
@@ -1,0 +1,69 @@
+# Proposal: First-class operator-audit activity surface
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+Every shareable row in DB2 already carries the provenance needed to answer "who
+did what, in which scope, when" — `operator_id`, `content_hash`, timestamps — and
+a WORM audit ledger records privileged actions. But there is **no legible way to
+read it out.** The `aimee audit` verb only *verifies/checkpoints* the WORM store's
+integrity; it cannot render per-operator or per-scope activity. So the data is
+audit-*able* but not audit-*ed*: answering "what has operator X written to project
+Y this week?" means hand-writing SQL against DB2. The three-db-split Known
+Weaknesses section flagged this; it is still unbuilt.
+
+## Goal
+
+An operator can run one command (and one `/v1` call) to get a legible,
+scoped activity report — per operator, per scope (project / workspace / global),
+over a time window — sourced from the provenance columns and the WORM ledger that
+already exist, with no new write path.
+
+## §0 What already exists
+
+- **Provenance columns.** `operator_id` is on shareable rows across
+  `src/db2/` (`fidelity.c`, `corpus_structural.c`, `artifacts.c`, memory rows,
+  …), alongside `content_hash` + timestamps.
+- **WORM ledger.** `src/audit_ledger.c` + `src/db2/kb_audit_worm.c` record
+  privileged/append-only actions with a verify chain.
+- **The CLI verb exists but is integrity-only.** `cmd_audit`
+  (`{"audit", "Verify/checkpoint the WORM audit store …"}`) has `verify` +
+  `checkpoint` subcommands — nothing that reports activity.
+
+Everything needed to *read* is present; only the read surface is missing.
+
+## §1 DB2 read API: scoped activity query
+
+Add a read-only DB2 accessor (in the owning `src/db2/` module, behind the KB
+service — server/CLI must not touch DB2 directly per the storage boundary) that
+aggregates activity by `(operator_id, scope, action, day)` over a time window,
+unioning the provenance columns and the WORM ledger. Read-only; no new table.
+
+## §2 `/v1/audit/activity` endpoint
+
+Expose it as `GET /v1/audit/activity?operator=&scope=&since=&until=` on aimee-kb,
+returning the scoped rollup. Add it to the OpenAPI surface + `v1-method-coverage`
+so it is a first-class, conformance-tested route rather than a side door. Gate it
+behind the same admin capability the other privileged `/v1/audit/*` operations
+use.
+
+## §3 `aimee audit activity` subcommand
+
+Add an `activity` subcommand to the existing `audit` verb that calls the route and
+renders a legible table (operator × scope × action counts, most-recent activity,
+optional `--json`). Keep `verify`/`checkpoint` unchanged. This is the surface the
+Known Weaknesses note asked for.
+
+## §4 (optional) Anomaly summary
+
+A `--anomalies` flag that surfaces the obvious ones the rollup makes cheap:
+writes by an operator with no prior activity in a scope, a spike vs. that
+operator's trailing median, or a WORM-chain gap. Not intrusion detection — just
+making the legible data legible.
+
+## Non-goals
+
+No new capture (the data is already recorded), no tamper-evidence changes (the
+WORM chain stays as-is), and no multi-tenant policy engine — this is a *read*
+surface over provenance we already keep.

--- a/docs/proposals/pending/org-data-connectors-and-source-ingestion.md
+++ b/docs/proposals/pending/org-data-connectors-and-source-ingestion.md
@@ -1,0 +1,189 @@
+# Proposal: Org-data connectors — the source-ingestion on-ramp for the every-domain KB
+
+- **State:** PENDING — design only, no code in this PR. Adds the missing
+  *front door* to the existing ingest pipeline: a connector layer that pulls
+  documents from the systems where an
+  organization's non-code knowledge actually lives (issue trackers, chat, email,
+  doc stores, wikis) and hands them to the existing Normalize → curator →
+  promote pipeline. Builds on **Ingest Lab and Strategy-Aware Chunking** (Accepted,
+  Phase 0 shipped — `aimee kb lab`), the **Corpus Staged Processing Pipeline**
+  (Done — `corpus_processing_jobs`, `aimee kb pipeline`), **Structured PDF
+  Ingestion** (Done), and the credential vault (**cred-vault-consolidation**,
+  `git_host_cred.c`, `git_oauth_github.c` — Done). Does **not** re-propose ingest,
+  chunking, the stage machine, or extraction — it feeds them.
+- **Author:** JBailes
+- **Date:** 2026-07-07
+- **Charter roles:** Extract (Normalize/Ingest stage — the connector is the source
+  half of Normalize), Classify-Score (source-kind + document-kind classification at
+  intake), Enforce (per-connector auth, PII, and scope gating on the ingest hot
+  path — fail closed), Gate-Promote (staging → release gating per source, reusing
+  the curator's release gate), Persist (durable per-source sync cursors and
+  provenance). Cites the Architecture Charter; the connector output enters the
+  charter's one data pipeline at Normalize.
+
+## Thesis
+
+KNOWLEDGE.md's premise is a *whole-company* knowledge base — §1 promises aimee
+ingests "prose, code, API specs, runbooks, design docs, tickets, meeting notes, and
+policies" across "engineering, product, sales, support, operations, legal, and
+finance," and §4's cross-domain reasoning ("connect a **support** pattern to the
+**engineering** root cause, or a **sales** commitment to the **roadmap**") only
+works if support tickets, sales notes, and roadmap docs are all *in the graph*.
+
+Today there is **no way to get that data in**. The shipped ingest surface is
+file-, PDF-, and code-oriented: Ingest Lab normalizes and chunks *what is handed
+to it*, the corpus pipeline drains *documents already seeded* into
+`corpus_processing_jobs`, but **nothing pulls from a source system**. A grep of the
+tree confirms it: Jira, Confluence, Slack, Gmail, Google Drive, Zendesk, and Notion
+appear only in prose, never in code — there is no connector, no incremental sync,
+no per-source auth wiring, and no proposal that owns this gap.
+
+The result is a real capability with an empty corpus for every non-file domain. The
+mechanism (one graph, hybrid recall, cross-domain synthesis) is built; the on-ramp
+is not. This proposal is that on-ramp: a small, uniform **connector contract** plus
+a first set of adapters, incremental sync, and ingest-time enforcement — routing
+everything into the pipeline that already exists downstream.
+
+## Goal
+
+1. **One connector contract** — a uniform adapter interface (`connector_kind`,
+   `list_since(cursor)`, `fetch(ref)`, `to_document()`) so every source looks
+   identical to the Normalize stage, and a new source is a small adapter, not a
+   pipeline change.
+2. **A first adapter set** that covers the domains §1 names: an issue tracker, a
+   chat source, a doc/wiki store, and email — chosen for breadth of domain
+   coverage, not vendor completeness.
+3. **Incremental sync** — durable per-source cursors so re-runs pull only new/
+   changed items, with supersession (not duplication) on edited source records.
+4. **Ingest-time enforcement** — per-connector auth from the existing vault, a
+   source→scope mapping (which shared/`workspace` scope a source lands in), and PII
+   / poison gating on the intake path before anything reaches the curator.
+5. **Zero new downstream** — connector output enters at Normalize and rides the
+   shipped chunking → staged pipeline → curator → promotion path unchanged.
+
+## §0 What already exists (so we don't rebuild it)
+
+- **Normalize + chunking.** Ingest Lab (`aimee kb lab`) — document-kind-aware
+  chunking, quality signals, stage recommendations (Phase 0 shipped). This is the
+  stage a connector feeds.
+- **Staged pipeline.** `corpus_processing_jobs` + `aimee kb pipeline` — the
+  resumable per-document stage machine with doc-ingest seeding and deterministic
+  drain (Done). Connectors seed it.
+- **Structured document intake.** Structured PDF ingestion + evidence layer, corpus
+  structural analysis (`document_sections`, `document_references`, staleness) —
+  Done. Applies to connector-sourced docs the same way.
+- **Credential vault + OAuth.** The server vault (`git_host_cred.c`), GitHub OAuth
+  device flow (`git_oauth_github.c`), and cred-vault-consolidation (Done) — the
+  auth-storage substrate connectors reuse for per-source tokens; the device-flow
+  pattern generalizes to per-connector OAuth.
+- **Ingest safety.** The **Ingest poison gate** (Done — Layer-1 deterministic
+  pattern gate, five threat categories, obfuscation-aware normalizer, shadow mode)
+  and the typed-fact PII sensitivity tiers — the enforcement this proposal wires
+  onto the connector intake path.
+- **Scope lattice.** `global > workspace > project > user` with the audited public
+  access contract (Memory Public Contract, Done) — the destination scopes a
+  source→scope mapping targets.
+
+## §1 The connector contract
+
+A connector is a small adapter implementing one interface; the pipeline never knows
+which source it came from:
+
+- `connector_kind` — stable id (`jira`, `slack`, `confluence`, `imap`, …).
+- `list_since(cursor) → [ref, …]` — enumerate items changed since the durable
+  cursor (§3); no full re-scan on re-run.
+- `fetch(ref) → raw` — pull one item's content + metadata.
+- `to_document(raw) → document` — map to the pipeline's document shape (body,
+  source metadata, author, timestamps, stable `source_uri`), so Normalize and every
+  downstream stage treat it identically to a file or PDF.
+
+The adapter is intentionally thin: no extraction, no chunking, no dedup — those are
+downstream and shipped. This keeps "add a source" cheap and keeps all intelligence
+in one place (the curator), per the charter's single-pipeline rule.
+
+## §2 First adapter set (domain breadth, not vendor completeness)
+
+Four adapters, each covering a domain §1 names that has no on-ramp today:
+
+- **Issue tracker** (e.g. Jira/GitHub Issues) — product/engineering tickets and
+  their decisions.
+- **Chat** (e.g. Slack) — operations/support tacit knowledge; thread-aware
+  `to_document` so a thread is one document, not N fragments.
+- **Doc / wiki** (e.g. Confluence/Notion) — policies, runbooks, design docs.
+- **Email** (IMAP) — sales/legal/finance correspondence; the lowest-common-
+  denominator source, provable without a vendor account.
+
+Selection criterion is **domain coverage** so §4's cross-domain examples become
+demonstrable end-to-end; additional vendors are later adapters against the same
+contract, not new proposals.
+
+## §3 Incremental sync + supersession
+
+- **Durable cursor per source** (`connector_sync_cursors` in DB2) — last-seen
+  watermark (timestamp or opaque token) so `list_since` pulls only the delta.
+- **Supersession, not duplication** — an edited source record maps to the same
+  `source_uri`; re-ingest supersedes the prior document (reusing the corpus
+  pipeline's existing supersession/versioning), so recall doesn't accumulate stale
+  copies. Aligns with the MinHash-LSH near-dup / supersession machinery already in
+  the sketch layer (Done).
+- **Resumable** — a sync run is itself a job so an interrupted pull resumes, matching
+  the corpus pipeline's resumability discipline.
+
+## §4 Ingest-time enforcement (fail closed)
+
+Every connector item passes three gates *before* the curator sees it:
+
+1. **Auth** — per-connector credentials from the server vault; OAuth via the shipped
+   device-flow pattern where the source supports it. No plaintext tokens outside the
+   vault.
+2. **Source → scope mapping** — an operator declares which scope a source lands in
+   (e.g. a support Slack channel → `workspace`; a personal mailbox → `user`).
+   Unmapped source ⇒ most-restrictive scope by default, never `global`. This is the
+   privacy boundary the multi-tenant KB depends on (cf. the db1/db2 scope-correctness
+   rule in `memory-db1-db2-architecture.md`).
+3. **PII + poison** — the shipped ingest poison gate runs on connector intake in
+   shadow first, then enforcing; PII sensitivity tiers apply so a connector can be
+   pinned to withhold personal facts from shared scopes. Unknown/learned relations
+   fail closed to the restrictive tier, as the typed-fact layer already does.
+
+## §5 Operator surface
+
+- `aimee kb connect <kind> …` — register a source (auth + source→scope mapping),
+  stored like a git-host credential.
+- `aimee kb sync <source>` — run/refresh a pull; `--dry-run` previews the delta and
+  enforcement decisions through Ingest Lab without seeding the pipeline.
+- `aimee kb sources` — list configured sources, cursors, last-sync, item counts.
+- A `sync` can be scheduled by the existing routine/cron surface — no new scheduler.
+
+## Acceptance criteria
+
+1. **Contract.** The connector interface is documented; two adapters from §2
+   implement it with no pipeline change beyond registration.
+2. **End-to-end.** A fixture source (e.g. a local IMAP/maildir and a canned issue
+   export) ingests through connector → Normalize → staged pipeline → curator, and
+   the items are recallable, with `source_uri`/provenance intact.
+3. **Incremental.** A second sync over an unchanged source pulls zero items; an
+   edited item supersedes (not duplicates) its prior document.
+4. **Enforcement.** An unmapped source lands in the restrictive scope, never
+   `global`; the poison gate blocks a planted adversarial item; a PII-tiered fact
+   is withheld from a shared-scope recall in a fixture test.
+5. **Auth hygiene.** Credentials live only in the vault; a `--dry-run` never writes
+   to the pipeline.
+6. **Cross-domain demo (validation-pending).** With an issue-tracker source and a
+   code corpus both ingested, a §4-style query ("connect this support/issue pattern
+   to the code that implements it") returns a citation-backed cross-source answer.
+   Real-org quality is a dogfood deliverable and reported as *validation-pending*,
+   not done — this proposal ships the on-ramp and fixtures.
+
+## Explicitly out of scope / does not re-propose
+
+- Normalize/chunking, the staged pipeline, extraction, promotion, PII tiers, poison
+  gate, and the vault — all shipped; reused verbatim.
+- Making curator extraction/reflection actually synthesize over this wider corpus —
+  that is the sibling proposal
+  `llm-sidecar-productionization-curator-and-reflection.md`. This proposal makes the
+  corpus *wide*; that one makes extraction *real*. They compose but ship
+  independently, and both are needed before §4's whole-company reasoning is true in
+  the build.
+- Vendor-exhaustive connector coverage — beyond the first four, each new source is a
+  thin adapter against the §1 contract, not a new proposal.

--- a/docs/proposals/pending/proposal-supersession-hygiene.md
+++ b/docs/proposals/pending/proposal-supersession-hygiene.md
@@ -1,0 +1,57 @@
+# Proposal: Proposal-supersession hygiene — same-commit move + a documented rule
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+`docs/proposals/pending/` is only useful as signal if a finished or superseded
+proposal *leaves* it. `check-proposal-reconcile.py` already catches one drift
+class — a pending/accepted proposal that has actually shipped (classified
+"terminal-done"). But the specific drift the roadmap flagged is different and
+still unguarded: a PR that **supersedes** a proposal (deletes/replaces its
+subject) without moving the old file, so a dead proposal lingers in `pending/`
+(the roadmap cites the pluggable-db proposal doing exactly this). And there is **no
+`CONTRIBUTING.md`** stating the rule, so contributors have no norm to follow —
+only a lint that fires after the fact on one of two failure modes.
+
+## Goal
+
+The supersession-move becomes both a written rule and an enforced one: the PR that
+supersedes a proposal moves the old one (to `rejected/` / `deferred/` / `done/`)
+**in the same commit**, and a lint catches the case where it didn't.
+
+## §0 What already exists
+
+- `scripts/check-proposal-reconcile.py` (`proposal-reconcile-check`, in `lint`)
+  flags a `pending/`|`accepted/` proposal classified terminal-done.
+- `scripts/check-proposal-links.py` (`proposal-links-check`) validates links.
+- **No `CONTRIBUTING.md`** at repo root or `docs/`.
+- No check for "superseded-but-not-moved" (a live `pending/` file whose subject a
+  later PR removed/replaced).
+
+## §1 Document the rule
+
+Add `CONTRIBUTING.md` with a short "Proposals" section: proposals live under
+`docs/proposals/{pending,accepted,done,rejected,deferred}/`; the PR that lands,
+rejects, defers, or **supersedes** a proposal moves the file to its terminal state
+**in the same commit**; supersession notes the successor in the moved file's
+header. Reference the PR template so it is seen at author time, not review time.
+
+## §2 Extend the reconcile check for supersession
+
+Teach `check-proposal-reconcile.py` a second failure mode: a `pending/`/`accepted/`
+proposal whose declared subject/anchor no longer resolves (the code, doc, or
+sibling proposal it proposes has been removed or replaced) is "superseded, not
+moved" → fail with the remediation ("move it to rejected/ or deferred/"). Keep the
+existing `--plant-test` self-check so the guard itself stays honest.
+
+## §3 One-time sweep
+
+Reconcile today's `pending/` against reality (this proposal set is part of that
+pass) and move any already-superseded stragglers. A clean `pending/` is the
+precondition for the rule to mean anything.
+
+## Non-goals
+
+Not a workflow engine and not auto-moving files in CI (moves stay author-driven,
+reviewed) — just a written norm plus a lint that makes violating it visible.

--- a/docs/proposals/pending/standing-benchmark-cadence.md
+++ b/docs/proposals/pending/standing-benchmark-cadence.md
@@ -1,0 +1,75 @@
+# Proposal: Standing LoCoMo / LongMemEval benchmark cadence
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+Acceptance criteria across the codebase cite retrieval/memory parity in absolute
+terms — "within ±0.005 of baseline", "P@5 ≥ 0.45", "no regression vs. mem0" —
+but **nothing runs the full benchmarks on a schedule**. `bench-smoke.yml` fires
+only on `pull_request`, and it runs the harness *unit tests* + a provisioning
+coverage gate + **mini** fixtures (`locomo-mini.json`, `longmemeval-mini.json`),
+not the real datasets. So the numbers those criteria are measured against are
+computed by hand, ad hoc, and then quietly go stale. As the roadmap says: either
+put the benchmarks on a cadence, or stop citing parity criteria nobody measures.
+
+## Goal
+
+A scheduled job runs the **full** LoCoMo + LongMemEval (and the memory /
+code-vector suites) against `testing` on a fixed cadence, persists the scored
+results with a retention policy, and fails loudly on a drift beyond the parity
+band that acceptance criteria already cite — so "±0.005 of baseline" becomes a
+measured, enforceable fact instead of a hope.
+
+## §0 What already exists
+
+- **Harness is complete.** `benchmarks/locomo/bench_aimee_direct.py`,
+  `bench_aimee_llm.py`, and the comparison baselines (`bench_bm25_llm.py`,
+  `bench_mem0_llm.py`, `bench_rag_chromadb_llm.py`); `benchmarks/longmemeval/`;
+  `benchmarks/memory/`; `benchmarks/code-vector-graph/`. Results docs
+  (`BENCHMARK_RESULTS.md`, `EVAL_CONFIG.md`) exist per suite.
+- **Make targets exist:** `bench`, `bench-check`, `bench-baseline`,
+  `memory-retrieval-eval-check`, `curator-eval-check`.
+- **CI runs none of the full datasets.** `.github/workflows/bench-smoke.yml` is
+  PR-triggered and mini-only; `benchmarks/check_provisioning.py` gates coverage
+  but scores nothing.
+
+The pieces to *run* a benchmark exist; the missing thing is a scheduler, a
+results store, and a drift gate.
+
+## §1 Scheduled full-suite workflow
+
+Add `.github/workflows/bench-nightly.yml` (`on: schedule:` — nightly for the
+cheap suites, weekly for the LLM-graded ones, plus `workflow_dispatch`). It
+provisions the real datasets (gated behind a repo secret / self-hosted runner
+where the datasets or an LLM endpoint are needed), runs the full `bench_*`
+scripts, and writes scored JSON. Keep it OFF the PR path — PRs keep the fast
+smoke; the full run is a cadence, not a blocker.
+
+## §2 Results store + retention
+
+Persist each run's scored JSON as a dated artifact (retention policy, e.g. 90
+days for raw runs, indefinitely for the committed baseline). Commit a single
+rolling `benchmarks/BASELINE.json` (per suite, per metric) that the parity checks
+read, updated only by an explicit "accept new baseline" step — never silently by
+a run.
+
+## §3 Drift gate wired to existing criteria
+
+A `benchmarks/check_drift.py` compares the latest scored run against
+`BASELINE.json` and fails when any cited metric moves beyond its declared band
+(P@5, LoCoMo/LongMemEval accuracy, memory parity ±0.005). Wire it into the
+nightly workflow and expose it as a `bench-drift-check` make target so it can run
+locally. Acceptance criteria stop citing an unmeasured number.
+
+## §4 Make the criteria honest
+
+Sweep the acceptance criteria that cite a parity band and either (a) point them at
+`BASELINE.json` + the drift gate, or (b) delete the citation. A criterion that
+references a number no job measures is debt, not a spec.
+
+## Non-goals
+
+Not changing what the benchmarks measure or adding new datasets — this is purely
+about *running the ones we have on a cadence and holding the line*. New suites
+ride their own proposals.

--- a/docs/proposals/pending/user-selectable-fusion-mode.md
+++ b/docs/proposals/pending/user-selectable-fusion-mode.md
@@ -1,0 +1,88 @@
+# Proposal: User-selectable retrieval fusion mode + a benchmark users run to choose it
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+There is no universally-best retrieval fusion mode. `rrf` is a safe rank-blend;
+`static_alpha` fixes a lexical/dense weight; `dynamic_alpha` predicts that weight
+per query (high alpha → boost the lexical leg for identifier/exact-token queries,
+low alpha → favour dense for prose). Which wins is **corpus- and query-mix-
+dependent** — dynamic alpha helps identifier lookups and can hurt purely semantic
+questions. The right design is therefore not "pick a default and flip it," but:
+make the mode **user-selectable**, and give the user a **benchmark they run on
+their own data** to see the tradeoff and choose — including choosing per-scope
+defaults. The engine for that benchmark now exists (`benchmarks/kb/dynamic-alpha/
+run.py`); this proposal wires it into a product surface.
+
+## Goal
+
+An operator can (1) switch the KB fusion mode among `rrf` / `static_alpha` /
+`dynamic_alpha` from the GUI, (2) run a fusion A/B benchmark against their own KB
+and query set from the same surface, and (3) see a per-shape better/worse split
+that recommends a default — set with one click. No code change to try a mode; no
+guesswork to pick one.
+
+## §0 What already exists
+
+- **All three modes are implemented + applied.** `kb_search_fused` (`kb.c:1535`)
+  honours a `fusion_mode_override` and falls back to config `kb_fusion_mode`;
+  `POST /v1/search` (`kb_http.c:1048`) reads `fusion_mode` from the request and
+  returns `fusion_mode_used`. Verified live: `rrf` vs `dynamic_alpha` produce
+  different scoring. `dynamic_alpha`'s `predict_alpha` is unit-tested
+  (`unit-test-kb-fusion`).
+- **Config field exists.** `kb_fusion_mode` (default `rrf`) + `kb_fusion_static_alpha`
+  in `config_learning.c`; `config.set` persists `aimee.yaml`.
+- **Benchmark engine exists** (this PR): `run.py` runs any labelled query set in
+  all modes against a live KB and reports the per-shape better/worse split.
+- **Settings surface exists but is typed bool/int only.** `webchat/settings.go`
+  (`settingsAllow`) + `/api/settings` + `/api/config/set` → `/v1/config/set`.
+
+The pieces are present; they are not connected into a selectable, measurable
+surface.
+
+## §1 Selectable mode (all three) in the GUI
+
+Extend the webchat settings model with an `enum` field type (options + current
+value); render it as a `<select>`. Add `kb_fusion_mode` as an allowlisted enum
+(`rrf` / `static_alpha` / `dynamic_alpha`). `config.set` already persists it, and
+the search default already reads it — so selection takes effect on the next query
+with no restart. Expose `kb_fusion_static_alpha` as a companion numeric when
+`static_alpha` is chosen.
+
+## §2 User-facing benchmark
+
+Surface the engine two ways:
+
+- **CLI:** `aimee kb fusion-bench [--fixtures FILE] [--k N]` — routes to the KB,
+  runs the modes, prints the report. `--fixtures` defaults to the charter set but
+  accepts the operator's own labelled queries (the format is a small JSON: query +
+  `expected_top_path_substring` + `shape`), so it runs on **their** corpus.
+- **GUI:** a "Tune retrieval" panel that runs the same benchmark against the
+  active KB and renders the per-shape table + aggregate P@k, with the operator's
+  saved query set (editable in the panel).
+
+## §3 Data-driven default (and per-scope defaults)
+
+The benchmark already computes which mode wins by shape; add a recommendation:
+"dynamic_alpha wins N positives, regresses 0 guards → recommend as default" (or
+the converse). Offer a one-click "set as default." Because DB2 knowledge is
+project/scope-partitioned, allow a per-scope override (`kb_fusion_mode:<scope>`)
+so a code-heavy project can run `dynamic_alpha` while a prose corpus stays `rrf`.
+
+## §4 Precondition: corpus health + a code-search variant
+
+Two honest gates (documented in the benchmark README):
+
+- The benchmark is only meaningful against a KB whose curator/doc-embed drain has
+  fully drained — on a degraded corpus every query misses in every mode
+  (inconclusive, not evidence). Gate the GUI panel on a corpus-health check.
+- `/v1/search` ranks `doc_chunk`s; identifier→code fixtures need a code-search
+  variant against `/v1/code/*`. Ship the doc benchmark first; add the code variant
+  when the code-search path grows a fusion knob.
+
+## Non-goals
+
+Not changing the fusion algorithms, and not auto-flipping a default without the
+operator's confirmation — the whole point is to put the choice, and the evidence
+for it, in the operator's hands.

--- a/docs/proposals/pending/v1-stability-and-distributed-validation.md
+++ b/docs/proposals/pending/v1-stability-and-distributed-validation.md
@@ -1,0 +1,77 @@
+# Proposal: Close out platform phase 7 — v1 API stability tag + distributed-mode validation
+
+- **State:** proposed (pending — not started)
+
+## Thesis
+
+The aimee-kb platform arc (roadmap "aimee-kb service + public API") landed phases
+1–6: the service split, OpenAPI + SDKs, ingest, corpus staging, the retrieval
+surface, and reflection HTTP all exist and are conformance-checked. **Phase 7 —
+"distributed-mode validation + v1 API stability tag" — is the one piece with no
+evidence it happened.** The `/v1` surface is exercised piecemeal by a dozen
+conformance/coverage checks, and distributed mode *works in the field* (aimee-kb
+runs remotely with thin clients today), but there is no single test that stands up
+the split topology end-to-end, and no declared, enforced "v1 is stable — breaking
+it is a versioned event" contract. Until that exists, v1 is *de facto* stable and
+*de jure* undefined.
+
+## Goal
+
+1. A **v1 stability contract**: a machine-checkable declaration of the frozen v1
+   surface, with a CI gate that fails a PR that changes it without an explicit
+   version bump.
+2. A **distributed-mode integration test**: one harness that runs aimee-kb as a
+   remote service with ≥2 concurrent thin clients against it, exercising the real
+   `/v1` paths (ingest → curate → retrieve, auth, per-operator scoping) — the
+   topology we actually ship, tested as a unit.
+
+## §0 What already exists
+
+- **Broad but piecemeal conformance.** `api-conformance-check`,
+  `server-api-conformance-check`, `v1-method-coverage-check`,
+  `cli-v1-routes-check`, `kb-v1-coverage-check`, `sdk-parity-check`,
+  `v1-third-party-test`, `v1-sdk-smoke`, `v1-ws-test` — plus OpenAPI at
+  `docs/gen/api-v1.md` and `gen-sdks`.
+- **Distributed mode runs in production.** aimee-kb as a remote plugin, thin
+  clients over `/v1` (the `.254` deployment) — but validated only by usage, not
+  a committed test.
+- **No frozen-surface gate + no topology test.** Nothing declares "this is v1,
+  frozen" or stands up server+clients together in CI.
+
+Phase 7 is the *closeout*, not new construction.
+
+## §1 v1 surface snapshot + stability gate
+
+Generate a canonical, sorted snapshot of the v1 contract (routes + methods +
+request/response schema, derived from the same source the conformance checks read)
+into `docs/gen/v1-surface.lock`. Add a `v1-stability-check` make target + CI job
+that regenerates and diffs it: any change fails unless the PR also bumps the
+declared `API_VERSION` / adds a `v1.<n>` compatibility note. Additive-only changes
+(new optional field, new route) pass with a changelog line; removals/renames
+require the version event. This turns "don't break v1" from a norm into a gate.
+
+## §2 Distributed-mode integration harness
+
+Add `make v1-distributed-test`: bring up aimee-kb (its own DB2) as a detached
+service, point ≥2 thin clients at it, and run a scripted end-to-end —
+enroll/auth, `POST /v1/docs` + code scan from client A, curate, `POST /v1/search`
++ `/v1/code/*` from client B, and assert per-operator scoping isolates A's and B's
+writes. Run it in CI (the same runner that already builds the split images).
+
+## §3 Concurrency + isolation assertions
+
+The harness is also where the boundary claims get teeth: two clients writing the
+same project concurrently must not corrupt provenance; a client with scope X must
+not read scope Y; the KB pool must not wedge under concurrent ingest (see the
+curator-drain lease work). Encode these as explicit assertions, not incidental.
+
+## §4 Tag + document
+
+Once §1–§3 are green, tag the v1 surface stable in `docs/gen/api-v1.md` and record
+the versioning policy (additive vs. breaking, deprecation window) next to it, so
+downstream SDK/thin-client authors have a contract, not folklore.
+
+## Non-goals
+
+Not redesigning auth (that is its own deferred multi-tenant item) and not adding
+API surface — this freezes and validates what phases 1–6 already shipped.

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -14,8 +14,8 @@ keyword gap or a repo boundary that plain vector search would miss.
 
 ## The embedder
 
-Embedding and reranking are baked into the `aimee-kb-*` tier images — Qwen3-Embedding + an
-Ettin cross-encoder reranker — and served over HTTP (`/embed`, `/embed_batch`, `/rerank` on
+Embedding and reranking are baked into the `aimee-kb-*` tier images (Qwen3-Embedding + an
+Ettin cross-encoder reranker) and served over HTTP (`/embed`, `/embed_batch`, `/rerank` on
 the gateway `:8742`). The KB calls them; it runs no model. See
 [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md) for the tiers and
 [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md) for pointing the KB at one. (The reranker emits a
@@ -30,7 +30,7 @@ Two embedding widths ship:
 
 The 4B/2560 tier has better recall on large or meaning-heavy corpora; the 0.6B/1024 tier is
 the low-footprint default. The retrieval pipeline (hybrid search, reranking, fusion) is
-identical either way — only the model sizes differ.
+identical either way. Only the model sizes differ.
 
 ### Switching tiers
 
@@ -44,7 +44,7 @@ AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
 Both GPU tiers are 2560-dim, so moving between `gpu-small` and `gpu-mid` needs no re-embed.
 Moving between 1024 and 2560 is a model-identity **and** width change: on an **empty** DB
 just set the dim; on a **populated** one it's a drop-and-rebuild re-embed (the `halfvec`
-columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces — see
+columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces. See
 [Switching embedders on an existing database](#switching-embedders-on-an-existing-database).
 
 ## Configuration

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -26,7 +26,7 @@ Two embedding widths ship:
 | Tier | Embedder (`embedding_dim`) | Reranker |
 |------|----------------------------|----------|
 | `aimee-kb-cpu` | Qwen3-Embedding-0.6B (`1024`) | ettin-68m |
-| `aimee-kb-gpu-small` / `-gpu-mid` | Qwen3-Embedding-4B (`2560`) | ettin-400m |
+| `aimee-kb-gpu-small` / `-gpu-mid` / `-gpu-large` | Qwen3-Embedding-4B (`2560`) | ettin-400m |
 
 The 4B/2560 tier has better recall on large or meaning-heavy corpora; the 0.6B/1024 tier is
 the low-footprint default. The retrieval pipeline (hybrid search, reranking, fusion) is
@@ -41,7 +41,7 @@ the width to match:
 AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
 ```
 
-Both GPU tiers are 2560-dim, so moving between `gpu-small` and `gpu-mid` needs no re-embed.
+All GPU tiers are 2560-dim, so moving between `gpu-small`, `gpu-mid`, and `gpu-large` needs no re-embed.
 Moving between 1024 and 2560 is a model-identity **and** width change: on an **empty** DB
 just set the dim; on a **populated** one it's a drop-and-rebuild re-embed (the `halfvec`
 columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces. See
@@ -201,7 +201,7 @@ unchanged, since the dimension has not moved.
 
 An optional cross-encoder reranker refines the top-k of a recall before it is
 returned. It is baked into the same tier image and sized to match the embedder: the GPU tiers
-(`aimee-kb-gpu-small` / `-gpu-mid`) bake `cross-encoder/ettin-reranker-400m-v1`; the CPU
+(`aimee-kb-gpu-small` / `-gpu-mid` / `-gpu-large`) bake `cross-encoder/ettin-reranker-400m-v1`; the CPU
 tier bakes ettin-68m. Build-time override: `--build-arg RERANK_REPO=<hf id>`.
 
 It is configured independently of the embedder dimension:

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -1,6 +1,6 @@
 # Runbook: cut over to the unified `aimee-llm` container
 
-The unified-llm-container migration (P7). **Operator-gated** — the production flip
+The unified-llm-container migration (P7). **Operator-gated**: the production flip
 (deploy + corpus re-embed) is a deliberate maintenance op, never automatic. P1–P6 ship the
 pieces; this runbook is the order of operations + the gates.
 
@@ -11,19 +11,19 @@ head)+`/v1/chat/completions`, and offload to the AMD 7900 XTX via Vulkan (`-ngl 
 > **Naming update (post-cutover):** the images built here were renamed
 > `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small`, and a third GPU
 > tier `aimee-kb-gpu-mid` (Gemma 4 26B-A4B) was added; `aimee-llm` is now only the plugin
-> name. The steps below keep the original names as a record — for the current tiers and
+> name. The steps below keep the original names as a record, for the current tiers and
 > build-args see [../AIMEE_KB_SYNTH_TIERS.md](../AIMEE_KB_SYNTH_TIERS.md).
 
 ## 0. What changes
 
 - **From:** torch `aimee-embedder` (pplx-embed + ettin via sentence-transformers) + the
   stock `llm` llama.cpp container (gemma synth).
-- **To:** one `aimee-llm` image (CPU or GPU tier) — Vulkan llama.cpp serving embed
+- **To:** one `aimee-llm` image (CPU or GPU tier): Vulkan llama.cpp serving embed
   (Qwen3-Embedding) + rerank (ettin encoder + the gateway Dense head) + synth (gemma),
   models baked in.
 - **Corpus re-embed required:** `pplx-embed` → `Qwen3-Embedding` is a **`model_id` change**
   (and 0.6B→1024 / 4B→2560 a possible **dim** change), so the `kb_meta` drift guard (P1,
-  now activated — `db2_set_embedder_model_id`) will **refuse** to serve the new embedder
+  now activated, `db2_set_embedder_model_id`) will **refuse** to serve the new embedder
   against the old corpus. The re-embed is the controlled drop-and-rebuild below.
 
 ## 1. Pre-cutover ship-floor gate (staging, BEFORE the production flip)
@@ -40,13 +40,13 @@ release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollb
 CI builds + publishes both tiers as part of the normal release cycle:
 - **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds
   `aimee-kb-cpu` + `aimee-kb-gpu-small` + `aimee-kb-gpu-mid` on every release and tags them
-  `:<version>` + `:latest`. They are in both the `build` and the `merge` matrices — the
+  `:<version>` + `:latest`. They are in both the `build` and the `merge` matrices; the
   merge step applies the tags, so a build that pushes only by digest leaves `tags:null`.
   (`gpu-mid` is amd64-only.)
 - **testing:** `.github/workflows/publish-llm-testing.yml` builds `cpu` + `gpu-small` on
   `testing` pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts,
   tagged `:testing` (+ `:testing-<sha>`, amd64). `gpu-mid` is dispatch-only
-  (`build_kb_gpu_mid=true`) — a tested-but-unreleased image for `.254`.
+  (`build_kb_gpu_mid=true`): a tested-but-unreleased image for `.254`.
 
 To build out-of-band (e.g. on a PVE CT with docker):
 
@@ -60,7 +60,7 @@ docker build -f Dockerfile.aimee-llm -t aimee-kb-gpu-small \
   --build-arg SYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf \
   --build-arg SYNTH_FA=on .
 ```
-(gpu-mid swaps the synth args to Gemma 4 26B-A4B — see the tiers doc for the exact pins.)
+(gpu-mid swaps the synth args to Gemma 4 26B-A4B; see the tiers doc for the exact pins.)
 
 ## 3. Deploy to `.254` (tierd / LXC, GPU)
 
@@ -69,27 +69,27 @@ Vulkan/RADV render path (**not** ROCm/`kfd`). Deploy the GPU image as a tierd pl
 (manifest-swap, per the `.254` deploy memory) + `AIMEE_LLM_NGL=99`. The in-repo manifest is
 `deploy/smoothnas/aimee-llm.plugin.yaml` (pin its image to `:testing` for staging,
 `:latest`/`:<version>` for production). GPU passthrough uses the **built-in `gpu-amd`
-profile** (compiled into tierd — the one Wolf/Steam use), so there is no custom profile to
+profile** (compiled into tierd, the one Wolf/Steam use), so there is no custom profile to
 install and no node path to pin; verified on .254 the container enumerates `Vulkan0 : AMD
 Radeon Graphics (RADV GFX1100)` and offloads to VRAM. The gateway is host-published on
-**:8742** (NOT :8080 — Wolf's WolfLeash UI host-publishes 8080, and two plugins on one host
+**:8742** (NOT :8080, since Wolf's WolfLeash UI host-publishes 8080, and two plugins on one host
 port silently collide: the runtime DNATs both, one wins and the other is unreachable though
 "running"). Point the kb at it: `AIMEE_EMBEDDER_URL=http://10.100.0.1:8742` (the gateway preserves the
 `/embed`+`/embed_batch`+`/rerank` contract, so `embed-remote.py`/`rerank-remote.py` are
 untouched). Set the kb's `embedding_model` to the new identity (activates the P1 guard) and
 `embedding_dim` to the tier's dim (2560 for the 4B GPU tier). **Verify the URL actually
-serves the named model before re-embedding** — a misrouted `AIMEE_EMBEDDER_URL` (still
+serves the named model before re-embedding**: a misrouted `AIMEE_EMBEDDER_URL` (still
 pointing at the old embedder) would silently embed under the new identity and the guard
 would not catch it (it checks identity-vs-corpus, not URL-vs-identity). **Auth on the embed
 path:** the kb embeds/reranks with NO bearer (`memory_embed_http_post` sends a NULL auth
-header), so when this gateway backs `AIMEE_EMBEDDER_URL` it MUST run **auth-off** — leave
+header), so when this gateway backs `AIMEE_EMBEDDER_URL` it MUST run **auth-off**: leave
 `AIMEE_LLM_AUTH_TOKEN` empty/unset. The gateway treats an empty token as "auth disabled,"
 acceptable here because it is `expose:false` (internal bridge only; deployment network is the
 boundary). Only set `AIMEE_LLM_AUTH_TOKEN` when the gateway serves *only* bearer-capable
 callers (e.g. curator `tier_b` synth); if so it comes from the secret store (vault / Docker
 secret / `.gitignore`d per-host `.env`), **never a checked-in plaintext value**.
 
-## 4. Corpus re-embed (controlled drop-and-rebuild — the `maintenance` window)
+## 4. Corpus re-embed (controlled drop-and-rebuild, the `maintenance` window)
 
 In-place `halfvec` type changes against a live kb are forbidden. The migration:
 
@@ -100,10 +100,10 @@ In-place `halfvec` type changes against a live kb are forbidden. The migration:
    identity on the fresh `kb_meta`).
 4. **Replay** the source rows through the new embedder (bounded batch).
 5. **Parity gate:** pre-drop vs post-backfill counts must match **and** a sampled
-   value-check must pass (row counts alone miss silent corruption — wrong rows re-embedded,
+   value-check must pass (row counts alone miss silent corruption: wrong rows re-embedded,
    off-by-one batch, wrong prompt template, a dim swap). Over a held-out sample (≥1% or 10k
    rows, whichever is larger): every vector has the expected `array_length`, no NaN/all-zero
-   rows, and — where a stable subset is re-embeddable from the snapshot — cosine vs the
+   rows, and, where a stable subset is re-embeddable from the snapshot, cosine vs the
    snapshot is within tolerance for the *same* model (and `kb_meta.schema_embedder_model_id`
    is the new identity). Any divergence → `degraded`, hold. On parity → lift `maintenance`.
 
@@ -119,7 +119,7 @@ restoring the prior dim-sized `halfvec` from the §4 snapshot, CI round-tripped 
 cutover). This is a gated maintenance op, not an instant toggle. Once the first
 post-cutover release is validated, no prior tag contains pplx/ettin and rollback is no
 longer deploy-tag-based; retain the prior tag in the registry for a defined window (e.g. 6
-months). **Snapshot retention ≥ tag retention** — the §4 snapshot is the only rollback
+months). **Snapshot retention ≥ tag retention**: the §4 snapshot is the only rollback
 input once the tag ages out, so it must outlive the tag, with a checksum and an expiry
 review. Pre-cutover checklist (all must be true before §3): snapshot present + checksum
 verified; reverse-migration **rehearsed in staging** (round-trips to the prior dim/identity);
@@ -129,7 +129,7 @@ ship-floor gate green.
 
 After validation: remove `Dockerfile.embedder` + the `embedder`/`llm` compose/deploy
 services + the `codex-auth`/pplx-ettin references. (Kept until here so the prior tag is a
-working rollback target — §5.)
+working rollback target, §5.)
 
 ## Gates summary
 

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -9,9 +9,10 @@ the images build, serve `/embed`+`/rerank`(ettin encoder + gateway
 head)+`/v1/chat/completions`, and offload to the AMD 7900 XTX via Vulkan (`-ngl 99`).
 
 > **Naming update (post-cutover):** the images built here were renamed
-> `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small`, and a third GPU
-> tier `aimee-kb-gpu-mid` (Gemma 4 26B-A4B) was added; `aimee-llm` is now only the plugin
-> name. The steps below keep the original names as a record, for the current tiers and
+> `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small`, and two more GPU
+> tiers were added — `aimee-kb-gpu-mid` (Gemma 4 26B-A4B, 24 GB card) and `aimee-kb-gpu-large`
+> (same synth, 32 GB card, `SYNTH_SLOTS=4`); `aimee-llm` is now only the plugin name. The
+> steps below keep the original names as a record, for the current tiers, image sizes, and
 > build-args see [../AIMEE_KB_SYNTH_TIERS.md](../AIMEE_KB_SYNTH_TIERS.md).
 
 ## 0. What changes
@@ -39,14 +40,14 @@ release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollb
 
 CI builds + publishes both tiers as part of the normal release cycle:
 - **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds
-  `aimee-kb-cpu` + `aimee-kb-gpu-small` + `aimee-kb-gpu-mid` on every release and tags them
-  `:<version>` + `:latest`. They are in both the `build` and the `merge` matrices; the
-  merge step applies the tags, so a build that pushes only by digest leaves `tags:null`.
-  (`gpu-mid` is amd64-only.)
+  `aimee-kb-cpu` + `aimee-kb-gpu-small` + `aimee-kb-gpu-mid` + `aimee-kb-gpu-large` on every
+  release and tags them `:<version>` + `:latest`. They are in both the `build` and the `merge`
+  matrices; the merge step applies the tags, so a build that pushes only by digest leaves
+  `tags:null`. (`gpu-mid` and `gpu-large` are amd64-only.)
 - **testing:** `.github/workflows/publish-llm-testing.yml` builds `cpu` + `gpu-small` on
   `testing` pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts,
-  tagged `:testing` (+ `:testing-<sha>`, amd64). `gpu-mid` is dispatch-only
-  (`build_kb_gpu_mid=true`): a tested-but-unreleased image for `.254`.
+  tagged `:testing` (+ `:testing-<sha>`, amd64). `gpu-mid` and `gpu-large` are dispatch-only
+  (`build_kb_gpu_mid=true` / `build_kb_gpu_large=true`): tested-but-unreleased images for `.254`.
 
 To build out-of-band (e.g. on a PVE CT with docker):
 

--- a/docs/runbooks/vault-master-key-rotation.md
+++ b/docs/runbooks/vault-master-key-rotation.md
@@ -2,7 +2,7 @@
 
 Rotate the server-sealed master key that protects the credential vault (D13 of the
 [cred-vault-consolidation](../proposals/done/cred-vault-consolidation.md) proposal).
-**Operator-gated, offline maintenance op** — never automatic.
+**Operator-gated, offline maintenance op**: never automatic.
 
 ## 0. What this does (and does not)
 
@@ -11,7 +11,7 @@ The 32-byte `.server-master.key` lives `0600` beside the vault at
 wraps every server-decryptable credential's data-encryption key (DEK):
 
 - the **server principal** (`server`) holds the server KEK as its **primary** wrap
-  (`wrapped_dek`) — these are the shared delegate keys (minimax/mistral/glm/codex…);
+  (`wrapped_dek`). These are the shared delegate keys (minimax/mistral/glm/codex…);
 - every **user principal** that has a dual-access entry holds it in `wrapped_dek_server`.
 
 Rotation mints a fresh master key and **re-wraps** those DEKs from the old server KEK to the
@@ -27,7 +27,7 @@ Trust boundary is unchanged: the new master key is still a `0600` file on the se
 ## 1. Why it is offline
 
 `aimee-server` caches one process-wide server KEK. A *live* rotation would leave autonomous
-decrypts failing for the window between re-wrapping a credential and swapping the key — every
+decrypts failing for the window between re-wrapping a credential and swapping the key. Every
 delegate would 401 mid-rotation. So rotation runs with the **server stopped**, against the
 on-disk vault, and exits.
 
@@ -35,10 +35,10 @@ on-disk vault, and exits.
 
 - **Server stopped.** `--rotate-master-key` refuses to run if an `aimee-server` instance is
   live for the default socket (the server caches the old KEK and could write a credential
-  under it during the re-wrap window — see §1). Stop the server first.
+  under it during the re-wrap window; see §1). Stop the server first.
 - **`AIMEE_HOME` permissions.** The pre-rotation backup is written under `AIMEE_HOME` as a
   `0700` directory of `0600` files, but it inherits the *parent* directory's reachability.
-  Ensure `AIMEE_HOME` is writable only by the server's runtime UID — otherwise the backup
+  Ensure `AIMEE_HOME` is writable only by the server's runtime UID; otherwise the backup
   (which holds old-key ciphertext) sits in a directory others can traverse.
 
 ## 3. Procedure
@@ -70,7 +70,7 @@ rm -rf /var/lib/aimee/.vault.rotate-bak.12345
 - **Atomic + reversible.** The entire `.vault/` is copied to `.vault.rotate-bak.<pid>` (0700)
   **before** any mutation. If any principal's re-wrap fails (wrong key / tamper) **or** the
   new master key cannot be persisted, the vault is **restored from that backup** and the
-  command aborts non-zero with the vault unchanged — never a new-wrapped vault under an old
+  command aborts non-zero with the vault unchanged, never a new-wrapped vault under an old
   master, nor the reverse.
 - **Crash mid-run.** The new master key is written **last** (atomic tmp+rename+fsync), only
   after every re-wrap has succeeded. A crash before that leaves the old master + old wraps

--- a/docs/v1-op-parity-buildout.md
+++ b/docs/v1-op-parity-buildout.md
@@ -1,7 +1,7 @@
 # `/v1` op-parity buildout: route→method map and wave plan
 
 > Working tracker for **P1 / WP1.x / WP1.fin** of the aimee `/v1` hub-migration plan.
-> Goal: **every NDJSON RPC method gets a first-class `/v1` HTTP route** (or a
+> Goal: **every NDJSON RPC method gets a dedicated `/v1` HTTP route** (or a
 > documented, deliberate exclusion). The generic `POST /v1/rpc` passthrough is
 > retired; this buildout gave each method a dedicated, self-documenting,
 > OpenAPI-listed route.
@@ -9,7 +9,7 @@
 ## Mechanism (already landed: WP0.2, #2531)
 
 The `/v1` surface is a declarative table in
-`src/server/server_http_routes.inc`. Adding a first-class route is:
+`src/server/server_http_routes.inc`. Adding a dedicated route is:
 
 1. **One table row.** For a single-response method that takes a **JSON-object
    body**, the row is `{"POST", "/v1/<family>/<verb>", NULL, RM_EXACT,
@@ -43,13 +43,13 @@ The `/v1` surface is a declarative table in
   `GET /v1/models`, `GET /v1/kb/status`, backed by `route_json_provider`) are a
   *different* curated surface and coexist with the per-method routes below.
 
-## Deliberate exclusions (NOT given a first-class route)
+## Deliberate exclusions (NOT given a dedicated route)
 
 | Method(s) | Why |
 |---|---|
-| `hooks.pre`, `hooks.post`, `hooks.session_start` | Internal harness lifecycle hooks; now first-class privileged routes at `/v1/hooks/*`, gated by `CAP_TOOL_EXECUTE`. |
-| `runner.poll`, `runner.respond` | Already first-class (`/v1/runner/*`, workspace detached reverse channel). |
-| `primary.get/set/clear` | Already first-class via `/v1/sessions/{id}/primary`. |
+| `hooks.pre`, `hooks.post`, `hooks.session_start` | Internal harness lifecycle hooks; now dedicated privileged routes at `/v1/hooks/*`, gated by `CAP_TOOL_EXECUTE`. |
+| `runner.poll`, `runner.respond` | Already dedicated (`/v1/runner/*`, workspace detached reverse channel). |
+| `primary.get/set/clear` | Already dedicated via `/v1/sessions/{id}/primary`. |
 | `tool.execute` | Internal tool-execution path at `/v1/tools/execute` (workspace plane); gated by `CAP_TOOL_EXECUTE`, not a public verb. |
 
 > **Inline-dispatch latency budget.** Dispatch-op routes run inline on the
@@ -61,7 +61,7 @@ The `/v1` surface is a declarative table in
 > they are routed **async** via `rh_dispatch_op_async`: the POST returns a
 > queued run handle and a detached worker drives the loopback RPC to completion;
 > poll status/result at `GET /v1/runs/{id}`. So they keep the listener free
-> while still being first-class `/v1` routes.
+> while still being dedicated `/v1` routes.
 
 `server.health`/`server.info` and `model.list` overlap the existing
 `/v1/health`, `/v1/version`, `/v1/models` read-views; the owning wave maps them
@@ -69,7 +69,7 @@ to the existing route (no duplicate) and notes it.
 
 ## Family → wave map
 
-Counts are methods needing a *new* first-class route (after exclusions). Each
+Counts are methods needing a *new* dedicated route (after exclusions). Each
 wave is one delegated packet (`aimee delegate code --persona engineer --verify
 "cd src && make server-api-conformance-check && make unit-tests"`), with the
 registry + handler files + `--files` preloaded. **Waves are serialized** (each

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,15 +1,25 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SettingsMenu } from '@rakuensoftware/smoothgui';
 import type { SettingField } from '@rakuensoftware/smoothgui';
 
 /* A gear button in the top bar that opens a dropdown of aimee runtime settings
- * (autonomous mode, etc.). The dropdown UI is the generic smoothgui
- * <SettingsMenu>; this adapter supplies the aimee-specific data + persistence
- * (the allowlisted server config via /api/settings). Changes take effect on the
- * next turn. */
+ * (autonomous mode, etc.). Bool/int fields render via the generic smoothgui
+ * <SettingsMenu>; enum fields (e.g. the KB retrieval fusion mode) render here as
+ * a native <select> so the choice works regardless of the smoothgui version.
+ * This adapter supplies the aimee-specific data + persistence (the allowlisted
+ * server config via /api/settings). Changes take effect on the next turn. */
+
+type AimeeField = {
+  key: string;
+  label: string;
+  type: string;
+  help?: string;
+  options?: string[];
+  value?: unknown;
+};
 
 export default function SettingsPanel() {
-  const [fields, setFields] = useState<SettingField[]>([]);
+  const [fields, setFields] = useState<AimeeField[]>([]);
   const [busy, setBusy] = useState('');
   const [err, setErr] = useState('');
   const [loaded, setLoaded] = useState(false);
@@ -18,9 +28,12 @@ export default function SettingsPanel() {
     if (loaded) return;
     fetch('/api/settings', { headers: { 'X-CSRF-Token': window._csrf || '' } })
       .then(r => r.json())
-      .then((d: { fields?: SettingField[] }) => { setFields(d.fields || []); setLoaded(true); })
+      .then((d: { fields?: AimeeField[] }) => { setFields(d.fields || []); setLoaded(true); })
       .catch(() => setErr('Failed to load settings'));
   }
+
+  // Load once on mount so enum controls are populated without opening the menu.
+  useEffect(load, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function setField(key: string, value: unknown) {
     setBusy(key); setErr('');
@@ -40,15 +53,34 @@ export default function SettingsPanel() {
     }
   }
 
+  const enumFields = fields.filter(f => f.type === 'enum');
+  const menuFields = fields.filter(f => f.type !== 'enum');
+
   return (
-    <SettingsMenu
-      title="Runtime settings"
-      fields={fields}
-      onChange={setField}
-      onOpen={load}
-      loading={!loaded}
-      error={err}
-      busyKey={busy}
-    />
+    <div className="aimee-settings">
+      <SettingsMenu
+        title="Runtime settings"
+        fields={menuFields as unknown as SettingField[]}
+        onChange={setField}
+        onOpen={load}
+        loading={!loaded}
+        error={err}
+        busyKey={busy}
+      />
+      {enumFields.map(f => (
+        <label key={f.key} className="aimee-setting-enum" title={f.help}>
+          <span>{f.label}</span>
+          <select
+            value={String(f.value ?? '')}
+            disabled={busy === f.key}
+            onChange={e => setField(f.key, e.target.value)}
+          >
+            {(f.options ?? []).map(o => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        </label>
+      ))}
+    </div>
   );
 }

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -39,8 +39,10 @@ case "${AIMEE_LLM_STUB:-}" in
     # synth MODEL + its runtime profile is baked per TIER (build-args -> ENV):
     #   aimee-kb-cpu       gemma-4-E4B     (dense, CPU)
     #   aimee-kb-gpu-small gemma-4-12B     (dense, GPU, FA+K8V4)
-    #   aimee-kb-gpu-mid   Qwen3.6-35B-A3B (MoE, GPU, FA+K8V4 + static --n-cpu-moe
-    #                      expert-offload so the 22GB synth co-fits embed+rerank on 24GB)
+    #   aimee-kb-gpu-mid   gemma-4-26B-A4B (MoE, GPU, FA+K8V4, fully resident on 24GB;
+    #                      SYNTH_SLOTS=2 -> deploy 2x128K)
+    #   aimee-kb-gpu-large gemma-4-26B-A4B (SAME GGUF/profile as mid, SYNTH_SLOTS=4 for
+    #                      32GB cards -> deploy 4x256K; Gemma windowed KV keeps ~28.5GiB)
     # The gemma tiers leave FA/MoE unset -> identical to prior behaviour. AIMEE_LLM_
     # SYNTH_LOCAL=0 still lets an operator disable the local synth and forward via
     # AIMEE_LLM_SYNTH_URL instead.

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -181,6 +181,8 @@ CFG_KEY_DESC = {
     "kb_api_bearer_token": "Bearer token for the aimee-kb API.",
     "kb_api_http_port": "HTTP port the aimee-kb API listens on.",
     "kb_evidence_emit_enabled": "Emit evidence records from KB ingest.",
+    "kb_fusion_mode": "KB retrieval fusion mode: rrf (default), static_alpha, or dynamic_alpha.",
+    "kb_fusion_static_alpha": "Lexical/dense blend weight (0-1) for the static_alpha fusion mode.",
     "kb_pdf_ingest_enabled": "Route PDF uploads through the structured geometry extractor "
     "(kb_doc_pdf) instead of plain pdftotext (default off).",
     "kb_pdf_vector_enabled": "Embed structured-PDF chunks into the isolated kb_pdf_embeddings "

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,7 +94,7 @@ C_FLAGS = -Os -flto -ffunction-sections -fdata-sections -Wl,--gc-sections -s -Wa
 
 # DB2 client flags are discovered with pkg-config because provider headers are
 # not always installed under the compiler default include path. See
-# docs/proposals/accepted/three-db-split-user-shared-vectors.md.
+# docs/STORAGE_TIERS.md.
 PQ_CFLAGS := $(shell pkg-config --cflags libpq 2>$(NULLDEV))
 PQ_LIB    := $(shell pkg-config --libs libpq 2>$(NULLDEV))
 ifeq ($(strip $(PQ_LIB)),)
@@ -299,7 +299,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 
 # --- Layer 0b: DB1 (user-local tier) ---
-# See docs/proposals/accepted/three-db-pin-backends.md. Files in src/db1/
+# See docs/STORAGE_TIERS.md. Files in src/db1/
 # are the only ones that include <sqlite3.h> for DB1; callers in the rest
 # of the tree call typed domain functions declared in db1/*.h and never
 # see a handle. db1/*_mock.c are alternative implementations linked by

--- a/src/cmd_core.c
+++ b/src/cmd_core.c
@@ -29,7 +29,7 @@
 
 /* Bootstrap the DB2 postgres connection during `aimee init`. This is the
  * non-interactive "is the database reachable + healthy" gate documented
- * in docs/proposals/pending/three-db-pin-backends.md. We do not provision
+ * in docs/STORAGE_TIERS.md. We do not provision
  * a postgres role/database here (those typically need superuser privileges
  * and platform-specific commands); we only run db2_init against the
  * configured db2_url and report a clear remediation if it fails.

--- a/src/cmd_memory.c
+++ b/src/cmd_memory.c
@@ -2,7 +2,7 @@
  * subcommand family. Individual subcommand handlers live in:
  *   cmd_memory_core.c   — CRUD, stats, task/decide, link/tag
  *   cmd_memory_embed.c  — embed, reembed, diagnose, answer, eval suite
- *   db3/cmd_memory_vector.c — reindex/repair/rebuild/reconcile/verify + workflows
+ *   cmd_memory_vector.c — reindex/repair/rebuild/reconcile/verify + workflows
  */
 #include "aimee.h"
 #include "cmd_review.h"

--- a/src/cmd_memory_internal.h
+++ b/src/cmd_memory_internal.h
@@ -1,5 +1,5 @@
 /* cmd_memory_internal.h: shared among the cmd_memory_* translation units
- * (cmd_memory.c + cmd_memory_core.c + cmd_memory_embed.c + db3/cmd_memory_vector.c).
+ * (cmd_memory.c + cmd_memory_core.c + cmd_memory_embed.c + cmd_memory_vector.c).
  * Not a public API. */
 #ifndef DEC_CMD_MEMORY_INTERNAL_H
 #define DEC_CMD_MEMORY_INTERNAL_H 1
@@ -97,7 +97,7 @@ void mem_audit(app_ctx_t *ctx, int argc, char **argv);
 void mem_calibrate(app_ctx_t *ctx, int argc, char **argv);
 void mem_benchmark(app_ctx_t *ctx, int argc, char **argv);
 
-/* db3/cmd_memory_vector.c — reindex/repair/rebuild/reconcile/verify + workflows */
+/* cmd_memory_vector.c — reindex/repair/rebuild/reconcile/verify + workflows */
 void mem_reindex(app_ctx_t *ctx, int argc, char **argv);
 void mem_repair(app_ctx_t *ctx, int argc, char **argv);
 void mem_reconcile(app_ctx_t *ctx, int argc, char **argv);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -99,6 +99,13 @@ const config_field_t config_fields[] = {
      sizeof(((config_t *)0)->memory_query_expansion_mode), 0, CFG_STRING},
     {"memory_query_expansion_k", offsetof(config_t, memory_query_expansion_k), sizeof(int), 0,
      CFG_INT},
+    /* KB retrieval fusion: rrf (default) | static_alpha | dynamic_alpha. Settable so
+     * an operator can pick a mode from the GUI/CLI; kb_search_fused reads it as the
+     * default when no per-request fusion_mode override is supplied. */
+    {"kb_fusion_mode", offsetof(config_t, kb_fusion_mode), sizeof(((config_t *)0)->kb_fusion_mode),
+     0, CFG_STRING},
+    {"kb_fusion_static_alpha", offsetof(config_t, kb_fusion_static_alpha), sizeof(double), 0,
+     CFG_FLOAT},
     {"autonomous", offsetof(config_t, autonomous), sizeof(int), 1, CFG_BOOL},
     {"cross_verify", offsetof(config_t, cross_verify), sizeof(int), 1, CFG_BOOL},
     {"ecomode", offsetof(config_t, ecomode), sizeof(int), 1, CFG_BOOL},

--- a/src/db1/db_schema.c
+++ b/src/db1/db_schema.c
@@ -1,7 +1,6 @@
 /* DB1 (SQLite) idempotent schema bootstrap — single CREATE-IF-NOT-EXISTS
  * pass called at DB1 open time. The DB2 half of the split lives in
- * db2/db_schema.c. See
- * docs/proposals/accepted/three-db-split-user-shared-vectors.md. */
+ * db2/db_schema.c. See docs/STORAGE_TIERS.md. */
 
 #include "db_schema.h"
 

--- a/src/db1/db_schema.h
+++ b/src/db1/db_schema.h
@@ -3,8 +3,7 @@
 
 /* DB1 (SQLite) idempotent schema bootstrap. Single CREATE-IF-NOT-EXISTS
  * pass; safe to call on an already-initialized database. The DB2 half
- * lives in db2/db_schema.h. See
- * docs/proposals/accepted/three-db-split-user-shared-vectors.md. */
+ * lives in db2/db_schema.h. See docs/STORAGE_TIERS.md. */
 
 #include <stddef.h>
 

--- a/src/db1/decisions.h
+++ b/src/db1/decisions.h
@@ -4,8 +4,8 @@
  * by memory_scan. Each row references a window_id from the `windows`
  * table. DB1 owns both sides of that relationship.
  *
- * The task-keyed `decision_log` table moved to DB2 per the accepted
- * three-db split proposal. See db2/decision_log.h.
+ * The task-keyed `decision_log` table moved to DB2 per the DB1/DB2
+ * storage split. See db2/decision_log.h.
  *
  * Pure domain API. No backend types or handles in any signature. */
 #ifndef DEC_DB1_DECISIONS_H

--- a/src/db2/db_postgres.c
+++ b/src/db2/db_postgres.c
@@ -1,5 +1,5 @@
 /* libpq-backed implementation for DB2, the shared knowledge tier. See
- * docs/proposals/accepted/three-db-split-user-shared-vectors.md. */
+ * docs/STORAGE_TIERS.md. */
 
 #include "db_postgres.h"
 #include <ctype.h>

--- a/src/db2/db_schema.c
+++ b/src/db2/db_schema.c
@@ -1,5 +1,5 @@
 /* DB2 (Postgres) idempotent schema bootstrap.
- * See docs/proposals/accepted/three-db-split-user-shared-vectors.md. */
+ * See docs/STORAGE_TIERS.md. */
 
 #include "db_schema.h"
 #include "db_postgres.h"

--- a/src/db2/db_schema.h
+++ b/src/db2/db_schema.h
@@ -2,8 +2,7 @@
 #define DEC_DB2_DB_SCHEMA_H 1
 
 /* DB2 (Postgres) idempotent schema bootstrap. The DB1 (SQLite) half
- * of the split lives in db1/db_schema.h. See
- * docs/proposals/accepted/three-db-split-user-shared-vectors.md. */
+ * of the split lives in db1/db_schema.h. See docs/STORAGE_TIERS.md. */
 
 #include <stddef.h>
 

--- a/src/db2/decision_log.h
+++ b/src/db2/decision_log.h
@@ -1,6 +1,6 @@
 /* db2/decision_log.h: task-keyed decision log — DB2 subsystem.
  *
- * Per the accepted three-db split proposal, decision_log lives in DB2
+ * Per the DB1/DB2 storage split, decision_log lives in DB2
  * alongside notes and shareable task state. The per-window `decisions`
  * audit table remains in DB1 (db1/decisions.h).
  *

--- a/src/db2/kb_payload.c
+++ b/src/db2/kb_payload.c
@@ -275,6 +275,59 @@ int db2_kb_documents_hll_sources_for_hash(const char *project, const char *file_
    return n;
 }
 
+int db2_kb_documents_fts_search(const char *project, const char *query, int64_t *ids,
+                                double *scores, int max)
+{
+   if (!ids || !scores || max <= 0)
+      return -1;
+   if (!query || !query[0])
+      return 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   /* True lexical (term/FTS) leg over the generated 'simple'-config tsvector
+    * (schema.sql: kb_fts_tsv = to_tsvector('simple', content || heading_path),
+    * GIN-indexed as kb_fts_gin). This is deliberately NOT the dense pgvector
+    * search: the two legs must diverge so alpha fusion has a real lexical-vs-
+    * semantic signal to arbitrate. websearch_to_tsquery handles quoted phrases /
+    * operators, so quoted/identifier queries lean on exact term match. */
+   const int filter_project = (project && project[0]) ? 1 : 0;
+   static const char *sql_proj =
+       "SELECT id, ts_rank(kb_fts_tsv, websearch_to_tsquery('simple', ?1)) AS r"
+       " FROM kb_documents"
+       " WHERE kb_fts_tsv @@ websearch_to_tsquery('simple', ?1) AND project = ?2"
+       " ORDER BY r DESC LIMIT ?3";
+   static const char *sql_all =
+       "SELECT id, ts_rank(kb_fts_tsv, websearch_to_tsquery('simple', ?1)) AS r"
+       " FROM kb_documents"
+       " WHERE kb_fts_tsv @@ websearch_to_tsquery('simple', ?1)"
+       " ORDER BY r DESC LIMIT ?2";
+   char err[KBP_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn, filter_project ? sql_proj : sql_all, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", query);
+   if (filter_project)
+   {
+      aimee_pg_bind_text(st, "?2", project);
+      aimee_pg_bind_int(st, "?3", max);
+   }
+   else
+      aimee_pg_bind_int(st, "?2", max);
+
+   int n = 0;
+   while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      ids[n] = aimee_pg_column_int64(st, 0);
+      scores[n] = aimee_pg_column_double(st, 1);
+      n++;
+   }
+   aimee_pg_finalize(st);
+   return n;
+}
+
 int db2_kb_async_enqueue(const char *kind, int64_t document_id, const char *project)
 {
    if (!kind || !*kind || document_id <= 0)

--- a/src/db2/kb_payload.h
+++ b/src/db2/kb_payload.h
@@ -106,7 +106,7 @@ extern "C"
 
    /* List up to |max| kb_documents.id values that belong to
     * (project, file_path). Caller materializes the ids before issuing
-    * follow-up writes (db3 point deletes + the bulk DELETE) because
+    * follow-up writes (pgvector point deletes + the bulk DELETE) because
     * libpq only supports one active result per connection. Returns
     * count written (0 on miss / no DB2). */
    int db2_kb_documents_list_chunk_ids_for_file(const char *project, const char *file_path,
@@ -114,7 +114,7 @@ extern "C"
 
    /* DELETE FROM kb_documents WHERE project = ? AND file_path = ?.
     * Best-effort; no return. Caller is responsible for any
-    * accompanying db3 point deletes — those run on the materialized
+    * accompanying pgvector point deletes — those run on the materialized
     * id list returned by db2_kb_documents_list_chunk_ids_for_file. */
    void db2_kb_documents_delete_for_file(const char *project, const char *file_path);
 

--- a/src/db2/kb_payload.h
+++ b/src/db2/kb_payload.h
@@ -76,6 +76,13 @@ extern "C"
    int db2_kb_documents_hll_sources_for_hash(const char *project, const char *file_hash,
                                              sketch_hll_t *out);
 
+   /* Lexical (FTS) retrieval over kb_documents.kb_fts_tsv — the term-matching
+    * leg for kb_search_fused, distinct from the dense pgvector leg. Fills ids +
+    * ts_rank scores (best first, up to max), scoped by project when non-empty.
+    * Returns the count, 0 for no matches / empty query, -1 on SQL / conn error. */
+   int db2_kb_documents_fts_search(const char *project, const char *query, int64_t *ids,
+                                   double *scores, int max);
+
    /* INSERT OR IGNORE a kb_async_jobs row: (kind, document_id, project,
     * status='pending'). Used by kb_build to enqueue an async embedding
     * job for a freshly-inserted chunk. Returns 0 on success, -1 on

--- a/src/gen_schema.py
+++ b/src/gen_schema.py
@@ -4,7 +4,7 @@
 Emits one static const char * per schema file so each tier's db_schema.c
 can apply its schema directly through a single idempotent
 CREATE-IF-NOT-EXISTS pass. See
-docs/proposals/accepted/three-db-split-user-shared-vectors.md.
+docs/STORAGE_TIERS.md.
 """
 import json
 import sys

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -233,9 +233,8 @@ typedef struct
 
 /* Database connection settings for the explicit two-store architecture:
  * DB1 = local user store (sqlite), DB2 = shared knowledge store (postgres
- * + pgvector). See docs/proposals/done/three-db-split-user-shared-vectors.md
- * for the original split; the DB3 vector tier was folded into DB2 via
- * pgvector in #1575. */
+ * + pgvector). See docs/STORAGE_TIERS.md. (The vector tier was folded
+ * into DB2 as pgvector in #1575.) */
 #define CONFIG_DB2_URL_LEN 512
 
 typedef struct config

--- a/src/headers/kb_ingest_workers.h
+++ b/src/headers/kb_ingest_workers.h
@@ -3,7 +3,7 @@
 
 /* kb_ingest_workers.h: aimee-kb's in-process KB ingest driver.
  *
- * aimee-kb owns DB2/DB3 directly, so it claims ingest jobs from the DB2
+ * aimee-kb owns DB2 directly, so it claims ingest jobs from the DB2
  * queue itself (db2_kb_ingest_queue_claim_next) and runs the full build
  * in-process (kb_build + canonical_index_scan_project) — no RPC round-trip
  * back to a server-side compute pool. This replaces the former

--- a/src/headers/util_url.h
+++ b/src/headers/util_url.h
@@ -1,7 +1,7 @@
 /* util_url.h: canonical URL handling for project/workspace identity.
  *
- * Implements the URL normalization pipeline from the three-DB split proposal
- * (docs/proposals/accepted/three-db-split-user-shared-vectors.md). The goal
+ * Implements the URL normalization pipeline from the DB1/DB2 storage split
+ * (docs/STORAGE_TIERS.md). The goal
  * is that two clones of the same repo on different machines — via different
  * transports, with different casing, and with or without a trailing .git —
  * resolve to the same canonical string.

--- a/src/headers/vault_capability.h
+++ b/src/headers/vault_capability.h
@@ -46,6 +46,20 @@ extern "C"
     * holds vault:write:server. The single source of truth for the gate. */
    int vault_capability_server_write_allowed(attested_transport_t transport, const char *principal);
 
+   /* May a connection with this attested transport seal an agent's OWN api key into
+    * the shared server vault (`agent add`/`agent set --key`)? A delegate defined in
+    * agents.json is SHARED server config whose key resolves from the server vault at
+    * run time (agent_config.c agent_vault_get), so it must land there for the agent
+    * to work for every connection and autonomous turn — a per-user vault entry can't
+    * serve those and is LOCKED on a fresh install. Sealing a delegate's OWN key is
+    * no broader than adding the delegate (both shared-config writes the same request
+    * performs), so this needs NO vault:write:server grant — deliberately WIDER than
+    * vault_capability_server_write_allowed, which still gates the arbitrary-cred
+    * `vault set --server`. Returns 1 for native-TLS bearer, mTLS client,
+    * server.token-trusted webchat, and local UDS; 0 for plaintext TCP bearer (D2b:
+    * never mint a server credential over an unencrypted channel) and un-attested. */
+   int vault_agent_key_server_seal_allowed(attested_transport_t transport);
+
    /* Test seam: override the store path (NULL resets to the default). */
    void vault_capability_set_path_for_test(const char *path);
 

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -1137,16 +1137,15 @@ static int kb_fetch_doc_row(int64_t id, const char *project, kb_result_t *out)
  * RRF merge in kb_search_gather degenerates to a re-rank of one input
  * list — still a valid combined score.  Future work: add a sparse / BM25
  * vector index and route this leg through it for true hybrid retrieval. */
-static int lexical_search_via_vector(const char *project, const char *query,
-                                     const char *embedding_cmd, kb_result_t *out, int max)
+/* Lexical (FTS/term-match) retrieval leg for kb_search_fused. This is a genuine
+ * term search over kb_documents.kb_fts_tsv, NOT another dense search: previously
+ * it embedded the query and called the same pgvector search as vec_search, so the
+ * two legs were byte-for-byte identical and alpha_merge collapsed to the identity
+ * (rrf/static_alpha/dynamic_alpha all produced the same ranking). With a real
+ * lexical leg the two signals diverge and the fusion modes become meaningful. */
+static int lexical_search_fts(const char *project, const char *query, kb_result_t *out, int max)
 {
-   if (!project || !query || !query[0] || !out || max <= 0)
-      return 0;
-   const char *effective_cmd = kb_effective_embedding_cmd(embedding_cmd);
-
-   float qvec[EMBED_MAX_DIM];
-   int qdim = memory_embed_text(query, effective_cmd, qvec, EMBED_MAX_DIM);
-   if (qdim <= 0)
+   if (!query || !query[0] || !out || max <= 0)
       return 0;
 
    int64_t ids[MAX_LEXICAL_RESULTS * 2];
@@ -1154,8 +1153,7 @@ static int lexical_search_via_vector(const char *project, const char *query,
    int cap = (int)(sizeof(ids) / sizeof(ids[0]));
    if (max * 2 < cap)
       cap = max * 2;
-   int n_hits = pgvec_kb_vector_search_project(project, qvec, qdim, cap, ids, scores,
-                                               (int)(sizeof(ids) / sizeof(ids[0])));
+   int n_hits = db2_kb_documents_fts_search(project, query, ids, scores, cap);
    if (n_hits <= 0)
       return 0;
 
@@ -1611,7 +1609,7 @@ static char *kb_search_gather(const char *project, const char *query, const char
       return safe_strdup("error: out of memory");
    }
 
-   int n_lex = lexical_search_via_vector(proj, query, effective_cmd, lex_res, MAX_LEXICAL_RESULTS);
+   int n_lex = lexical_search_fts(proj, query, lex_res, MAX_LEXICAL_RESULTS);
 
    /* Dense search is mandatory; the lexical vector leg complements it. */
    float qvec[EMBED_MAX_DIM];

--- a/src/kb/kb_evidence_embed.c
+++ b/src/kb/kb_evidence_embed.c
@@ -11,6 +11,7 @@
 
 #include "aimee.h"
 #include "cJSON.h"
+#include "db2/db2.h" /* db2_lease_release_idle */
 #include "db2/artifacts.h"
 #include "db2/evidence_vectors.h"
 #include "log.h"
@@ -125,6 +126,10 @@ int kb_evidence_embed_one(const char *embed_cmd)
       return 1;
    }
 
+   /* Drop the pool lease before the embedder round-trip so the evidence-embed
+    * drain can't pin a connection past the 300s stuck-lease ceiling (see
+    * kb_curator_extract_code / kb_service_code_embed). No-op in a lease scope. */
+   db2_lease_release_idle();
    float vec[EVIDENCE_EMBED_DIM];
    int dim = memory_embed_text(content, model, vec, EVIDENCE_EMBED_DIM);
    if (dim != EVIDENCE_EMBED_DIM)

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -214,10 +214,24 @@ static void *kbiw_worker_thread(void *arg)
        * a DB2 lease so the pooled connection is returned to the pool between
        * bursts (WP-C) instead of held for the worker thread's life. */
       db2_lease_begin();
+      long lease_started = (long)time(NULL);
       while (kbiw_claim_and_process() == 1)
       {
          if (ctx->ingest_stop)
             break;
+         /* A cold-start (or post-restart) drain can be thousands of docs, each an
+          * embed — a single burst then pins one pooled connection for minutes and
+          * trips the pool's 300s stuck-lease ceiling (observed: `member N leased
+          * >300000ms` while the corpus re-embeds). Return the connection to the
+          * pool periodically mid-drain so no single lease outlives the ceiling.
+          * Safe between items: each kbiw_claim_and_process commits its own unit,
+          * and pool connections carry no cross-lease state (DISCARD ALL on return). */
+         if ((long)time(NULL) - lease_started >= 120)
+         {
+            db2_lease_end();
+            db2_lease_begin();
+            lease_started = (long)time(NULL);
+         }
       }
       db2_lease_end();
    }

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -1,6 +1,6 @@
 /* kb_ingest_workers.c: aimee-kb's in-process KB ingest driver.
  *
- * aimee-kb owns DB2/DB3, so it claims ingest jobs straight off the DB2 queue
+ * aimee-kb owns DB2, so it claims ingest jobs straight off the DB2 queue
  * (db2_kb_ingest_queue_claim_next, which uses FOR UPDATE SKIP LOCKED and is
  * safe for concurrent claimers) and runs the full build in-process —
  * kb_build() (compute + store) then canonical_index_scan_project(). No RPC

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -24,6 +24,7 @@
 #include "log.h"
 #include "workspace.h"
 
+#include "db2/db2.h" /* db2_lease_release_idle */
 #include "db2/canonical_index.h"
 #include "db2/kb_runtime_state.h"
 #include "db2/kb_service_backend.h"
@@ -555,6 +556,11 @@ int kb_ingest_doc_content(const char *project, const char *source_path, const ch
       char embed_text[4096];
       kb_async_make_embed_text(chunks[ci].heading_path, chunks[ci].content, embed_text,
                                sizeof(embed_text));
+      /* Drop the pool lease before the (slow) embedder round-trip so a long
+       * doc-ingest loop can't pin a connection past the 300s stuck-lease ceiling
+       * and wedge the drain. No-op inside an explicit lease scope; DB writes below
+       * re-acquire lazily. See kb_curator_extract_code / kb_service_code_embed. */
+      db2_lease_release_idle();
       float vec[EMBED_MAX_DIM];
       int dim = memory_embed_text(embed_text, effective_cmd, vec, EMBED_MAX_DIM);
       if (dim > 0)
@@ -709,6 +715,10 @@ int kb_doc_embed_backfill(const char *project, const char *embedding_cmd, int ma
    {
       char embed_text[4096];
       kb_async_make_embed_text(rows[i].heading, rows[i].content, embed_text, sizeof(embed_text));
+      /* Drop the pool lease before the embedder round-trip (see above): this
+       * backfill loop embeds up to max_chunks per project across every project,
+       * so holding the lease across it trips the stuck-lease ceiling. */
+      db2_lease_release_idle();
       float vec[EMBED_MAX_DIM];
       int dim = memory_embed_text(embed_text, effective_cmd, vec, EMBED_MAX_DIM);
       if (dim > 0 && sync_vector_embedding(rows[i].id, vec, dim) == 0)

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -7,6 +7,7 @@
 #include "kb_service_code_embed.h"
 #include "aimee.h" /* EMBED_MAX_DIM */
 #include "db2/code_index_ops.h"
+#include "db2/kb_runtime_state.h" /* db2_kb_runtime_state_get/set — change short-circuit */
 #include "../db2/db2_internal.h"
 #include "../db2/db_postgres.h"
 #include "../db2/entity_nodes.h"
@@ -315,6 +316,54 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
       return 0;
    }
 
+   /* Per-project change short-circuit for the default "changed_files" pass. The
+    * drain calls this for EVERY project EVERY poll; without a cheap early-out it
+    * loads all files and checks each against the vector store — thousands of ops
+    * per poll, holding a pool connection long enough to trip the stuck-lease
+    * reaper (the "flapping" pool member) and starving the deep curator. The
+    * git-SHA short-circuit in the scan handler is never recorded for detached
+    * (thin-client) workspaces, so nothing else stops the re-scan. Compute a
+    * signature over the project's files + the active embed dim and skip the whole
+    * pass when it matches the last fully-embedded signature. Only for the implicit
+    * changed_files scope (paths==NULL); explicit path lists / "all" always run. */
+   char sig_now[160] = "";
+   if (!paths && !dry_run && strcmp(out->scope, "changed_files") == 0)
+   {
+      int sc_dim = db2_embedding_dim();
+      if (sc_dim <= 0 || sc_dim > CE_EMBED_MAX_DIM)
+         sc_dim = 1024;
+      static const char *sig_sql = "SELECT count(*), coalesce(md5(string_agg(id::text || ':' || "
+                                   "hash, ',' ORDER BY id)), '') "
+                                   "FROM files WHERE project_id = ?1";
+      aimee_pg_stmt_t *sst = aimee_pg_prepare(conn, sig_sql, err, sizeof(err));
+      if (sst)
+      {
+         aimee_pg_bind_int64(sst, "?1", proj_id);
+         if (aimee_pg_step(sst, err, sizeof(err)) == AIMEE_PG_ROW)
+         {
+            int64_t fcount = aimee_pg_column_int64(sst, 0);
+            const char *fhash = aimee_pg_column_text(sst, 1);
+            snprintf(sig_now, sizeof(sig_now), "%lld:%d:%s", (long long)fcount, sc_dim,
+                     fhash ? fhash : "");
+         }
+         aimee_pg_finalize(sst);
+      }
+      if (sig_now[0])
+      {
+         char sig_key[320];
+         snprintf(sig_key, sizeof(sig_key), "code_embed_sig:%s", project);
+         char stored_sig[160] = "";
+         if (db2_kb_runtime_state_get(sig_key, stored_sig, sizeof(stored_sig)) == 0 &&
+             strcmp(stored_sig, sig_now) == 0)
+         {
+            /* Nothing changed since the last fully-embedded pass — skip entirely. */
+            out->accepted = 1;
+            snprintf(out->job_id, sizeof(out->job_id), "code-embeddings:%s:0", project);
+            return 0;
+         }
+      }
+   }
+
    /* Collect files to embed. */
    static const char *files_sql = "SELECT id, path, hash FROM files WHERE project_id = ?1";
    st = aimee_pg_prepare(conn, files_sql, err, sizeof(err));
@@ -402,6 +451,18 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
 
    for (int i = 0; i < row_count && embedded < effective_max; i++)
    {
+      /* Return the pool lease at the top of every iteration so this loop never
+       * pins a connection across more than one file's work. Two shapes would
+       * otherwise trip the pool's 300s stuck-lease ceiling and wedge the drain:
+       *  - the embed round-trip (memory_embed_text below), one slow network call
+       *    per file on a fresh ingest; and
+       *  - the STEADY STATE, where every file is already embedded so the loop only
+       *    computes node_key + checks exists-by-hash and `continue`s — thousands of
+       *    checks per poll, every poll, all under one held lease.
+       * The per-file DB lookups re-acquire lazily via db2_conn(); no-op inside an
+       * explicit lease scope. Mirrors kb_curator_extract_code's guard. */
+      db2_lease_release_idle();
+
       char node_key[GRAPH_ENDPOINT_MAX];
       if (db2_entity_node_key_file(project, rows[i].path, node_key, sizeof(node_key)) != 0)
          continue;
@@ -479,6 +540,17 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
          embedded++;
          batch_num++;
       }
+   }
+
+   /* Record the fully-embedded signature so the next poll skips this project when
+    * nothing changed — but only when the WHOLE file set was loaded this pass. A
+    * load capped at effective_max leaves files unprocessed, so it must re-run
+    * (and its signature stays unrecorded / stale until it fully catches up). */
+   if (sig_now[0] && row_count < effective_max)
+   {
+      char sig_key[320];
+      snprintf(sig_key, sizeof(sig_key), "code_embed_sig:%s", project);
+      db2_kb_runtime_state_set(sig_key, sig_now);
    }
 
    free(rows);

--- a/src/kb/kb_service_workers.c
+++ b/src/kb/kb_service_workers.c
@@ -1,5 +1,5 @@
 /* kb_service_workers.c: kb_service socket init/shutdown.
- * aimee-kb owns DB2/DB3 and now drives KB ingest in-process via the worker
+ * aimee-kb owns DB2 and now drives KB ingest in-process via the worker
  * pool in kb_ingest_workers.c, alongside its KB maintenance, reflection,
  * curation, and mining background loops. */
 

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -10,9 +10,9 @@
 #include "cJSON.h"
 #include "json_fluent.h" /* jo_ok */
 #include "log.h"
-#include "vault_service.h"    /* vault_service_set / set_server, VAULT_API_KEY_CRED */
-#include "vault_capability.h" /* vault_capability_server_write_allowed (single server-write gate) */
-#include "server_cli_oauth.h" /* server-hosted OAuth CLI agent setup */
+#include "vault_service.h"    /* vault_service_set_server, VAULT_API_KEY_CRED */
+#include "vault_capability.h" /* vault_agent_key_server_seal_allowed (agent-key server-vault gate) */
+#include "server_cli_oauth.h"     /* server-hosted OAuth CLI agent setup */
 #include "provider_cli_adapter.h" /* provider_cli_adapter_get: declared CLI caps */
 #include "config.h"               /* config_load / config_t */
 #include <pthread.h>
@@ -632,46 +632,23 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
       else
       {
-         /* Where the client-supplied key lands depends on whether the conn may mint
-          * a SHARED server credential (vault_capability_server_write_allowed — the
-          * single gate handle_vault_set_server also uses):
-          *  - authorized to server-write (native-TLS+bearer, OR a capability-granted
-          *    principal: an attested webchat webuser:/UDS uid: holding
-          *    vault:write:server) -> the server-owned vault, so the key works for
-          *    ALL connections/delegate turns automatically. This is how an attested
-          *    webchat user provisions a delegate key over the HTTPS GUI without the
-          *    /v1 bearer ever entering webchat — the grant is the audited, revocable
-          *    authority.
-          *  - any other per-user principal (UDS uid: / webchat webuser: WITHOUT the
-          *    grant) -> the caller's own dual-access vault (requires it unlocked).
-          *  - no principal and not server-write-authorized (plaintext TCP, or an
-          *    un-attested conn e.g. UDS uid 0) -> REFUSED (D2b); never write the
-          *    secret to agents.json. */
-         const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
+         /* A delegate's key is SHARED server config: seal it into the server vault
+          * (see vault_agent_key_server_seal_allowed) so it works for every connection and
+          * every autonomous turn from a default install — no unlock, no grant. Only
+          * an un-attested / plaintext-TCP conn is refused (D2b). */
          attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
-         int server_write = vault_capability_server_write_allowed(transport, principal);
-         if (!server_write && !principal)
+         if (!vault_agent_key_server_seal_allowed(transport))
             return server_send_error(
                 conn,
                 "vault: `agent add --key` over a plaintext connection cannot store a credential; "
                 "use a native-TLS (https) connection, or an attested local/webchat connection",
                 NULL);
-         vault_status_t vst = server_write
-                                  ? vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key)
-                                  : vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key,
-                                                      (long)time(NULL));
+         vault_status_t vst = vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
          if (vst != VAULT_OK)
-         {
-            if (vst == VAULT_ERR_LOCKED)
-               return server_send_error(
-                   conn, "vault locked: run `aimee vault unlock` before adding a key", NULL);
             return server_send_error(conn, "could not store credential in the vault", NULL);
-         }
          /* A server-vault write (shared credential) is a minting event: audit it
-          * identically to handle_vault_set_server so it is never silent. A per-user
-          * dual-access write is the caller's own vault. */
-         if (server_write)
-            vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
+          * identically to handle_vault_set_server so it is never silent. */
+         vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
          ag->api_key[0] = '\0';      /* the secret lives only in the vault */
          ag->api_key_disk[0] = '\0'; /* and nothing goes to agents.json */
       }
@@ -1101,27 +1078,20 @@ int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
       else
       {
-         const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
+         /* Re-keying a delegate: seal into the shared server vault exactly as
+          * `agent add` does (vault_agent_key_server_seal_allowed), so a default install
+          * works with no unlock/grant. Only un-attested / plaintext-TCP is refused. */
          attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
-         int server_write = vault_capability_server_write_allowed(transport, principal);
-         if (!server_write && !principal)
+         if (!vault_agent_key_server_seal_allowed(transport))
             return server_send_error(
                 conn,
                 "vault: `agent set --key` over a plaintext connection cannot store a credential; "
                 "use a native-TLS (https) or attested local/webchat connection",
                 NULL);
-         vault_status_t vst = server_write
-                                  ? vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key)
-                                  : vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key,
-                                                      (long)time(NULL));
+         vault_status_t vst = vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
          if (vst != VAULT_OK)
-            return server_send_error(conn,
-                                     vst == VAULT_ERR_LOCKED
-                                         ? "vault locked: run `aimee vault unlock` before re-keying"
-                                         : "could not store credential in the vault",
-                                     NULL);
-         if (server_write)
-            vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
+            return server_send_error(conn, "could not store credential in the vault", NULL);
+         vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
       }
    }
 

--- a/src/server/vault_capability.c
+++ b/src/server/vault_capability.c
@@ -250,6 +250,17 @@ int vault_capability_server_write_allowed(attested_transport_t transport, const 
    return attested && vault_capability_has(principal);
 }
 
+int vault_agent_key_server_seal_allowed(attested_transport_t transport)
+{
+   /* See the header for the rationale: an agent's OWN key is shared server config,
+    * so ANY attested confidential channel may seal it — no per-principal grant, and
+    * so no store lookup here. Wider than the server-write gate above (which still
+    * requires a grant for UDS/webchat) and also admits a verified mTLS client. Only
+    * a plaintext TCP bearer (D2b) and an un-attested conn are refused. */
+   return transport == ATTEST_TLS_BEARER || transport == ATTEST_MTLS_CLIENT ||
+          transport == ATTEST_WEBCHAT_TRUSTED || transport == ATTEST_UDS_PEERCRED;
+}
+
 int vault_capability_has(const char *principal)
 {
    if (!principal_valid(principal))

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -856,7 +856,7 @@ _group_integ() {
     # The CLI client (aimee) is a DB-free thin wrapper — no DB libraries allowed.
     # aimee-webchat is now a full HTTP server process with its own SQLite session
     # store (PAM auth sessions, rate-limit state); it may link sqlite but must not
-    # contain aimee DB1/DB2/DB3 API strings (aimee_db_, kb_client, etc.).
+    # contain aimee DB1/DB2 API strings (aimee_db_, kb_client, etc.).
     storage_string_leaks=""
     for bin in "$INTEG_BINARY"; do
         leaks=$(strings "$bin" 2>/dev/null | \

--- a/src/tests/test_vault_capability.c
+++ b/src/tests/test_vault_capability.c
@@ -48,6 +48,17 @@ int main(void)
    assert(vault_capability_server_write_allowed(ATTEST_UDS_PEERCRED, "uid:1000") == 0);
    assert(vault_capability_server_write_allowed(ATTEST_UDS_PEERCRED, "") == 0);
 
+   /* the agent-key server-seal gate: purely transport-based, NO grant needed
+    * (deliberately wider than the server-write gate above), so a default install
+    * seals a GUI/CLI-added delegate key without provisioning a capability first.
+    * uid:1000 is NOT granted, yet its UDS transport is still allowed here. */
+   assert(vault_agent_key_server_seal_allowed(ATTEST_TLS_BEARER) == 1);
+   assert(vault_agent_key_server_seal_allowed(ATTEST_MTLS_CLIENT) == 1);
+   assert(vault_agent_key_server_seal_allowed(ATTEST_WEBCHAT_TRUSTED) == 1); /* the HTTPS GUI */
+   assert(vault_agent_key_server_seal_allowed(ATTEST_UDS_PEERCRED) == 1);    /* local CLI */
+   assert(vault_agent_key_server_seal_allowed(ATTEST_TCP_BEARER) == 0);      /* D2b: plaintext */
+   assert(vault_agent_key_server_seal_allowed(ATTEST_NONE) == 0);
+
    /* validation: empty / NULL / multi-line principals are rejected */
    assert(vault_capability_grant("") == -1);
    assert(vault_capability_grant(NULL) == -1);
@@ -56,6 +67,7 @@ int main(void)
 
    vault_capability_set_path_for_test(NULL);
    unlink(path);
-   printf("PASS: vault_capability grant/revoke/has/list + whole-line + validation\n");
+   printf("PASS: vault_capability grant/revoke/has/list + whole-line + validation + "
+          "agent-key server-seal gate\n");
    return 0;
 }

--- a/tests/proxy_postgres_smoke.sh
+++ b/tests/proxy_postgres_smoke.sh
@@ -5,7 +5,7 @@
 #
 # Satisfies the two-replica acceptance criterion from the DB2 Postgres
 # design tracked in
-# docs/proposals/accepted/three-db-split-user-shared-vectors.md.
+# docs/STORAGE_TIERS.md.
 #
 # Requires docker + docker compose on PATH. Not run by `make test` —
 # invoke manually or from CI where docker is available.

--- a/webchat/settings.go
+++ b/webchat/settings.go
@@ -13,10 +13,11 @@ import (
 // aimee.yaml and take effect on the next turn (the server reloads config per
 // request).
 type settingField struct {
-	Key   string `json:"key"`
-	Label string `json:"label"`
-	Type  string `json:"type"` // "bool" | "int"
-	Help  string `json:"help,omitempty"`
+	Key     string   `json:"key"`
+	Label   string   `json:"label"`
+	Type    string   `json:"type"` // "bool" | "int" | "enum"
+	Help    string   `json:"help,omitempty"`
+	Options []string `json:"options,omitempty"` // allowed values when Type=="enum"
 }
 
 var settingsAllow = []settingField{
@@ -30,6 +31,9 @@ var settingsAllow = []settingField{
 		Help: "Lower reasoning effort on simple turns."},
 	{Key: "max_iterations", Label: "Max iterations", Type: "int",
 		Help: "Tool-use loop ceiling per turn (0 = default)."},
+	{Key: "kb_fusion_mode", Label: "Retrieval fusion mode", Type: "enum",
+		Options: []string{"rrf", "static_alpha", "dynamic_alpha"},
+		Help:    "How lexical + dense KB search results are blended. dynamic_alpha adapts the weight per query (boost exact-token queries); rrf is the safe default."},
 }
 
 func settingAllowed(key string) bool {


### PR DESCRIPTION
Promote the current `testing` branch to `main`, cutting a release.

Includes (17 commits):
- fix(server): seal GUI/CLI-added delegate keys into the shared server vault by default (#1121)
- docs(workflows): correct the stale "current limitations" (#1127)
- docs: strip AI-isms / match house voice across README + user-facing docs (#1128)
- feat(gui): selectable KB retrieval fusion mode (rrf/static_alpha/dynamic)
- plus kb ingest/lease fixes, webchat multi-user, and other merged work.

On merge, `auto-release.yml` tags the next patch version and publishes `:latest`
images. Deploy target: .254 (aimee-server plugin pulls the new `:latest`).