### PR TITLE
feat(kb): add aimee-kb-gpu-large synth tier for 32GB cards

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -82,18 +82,24 @@ jobs:
           # the 0.6b embedder + 400m reranker.
           - { name: aimee-embedder-4b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1" }
           # The unified aimee-kb container (one Vulkan llama.cpp + the gateway serving
-          # embed+rerank+synth, models baked in). THREE tiers differ only by the SYNTH
+          # embed+rerank+synth, models baked in). FOUR tiers differ only by the SYNTH
           # model + its runtime profile (embed/rerank identical within a class):
           #   aimee-kb-cpu       defaults: 0.6B emb + ettin-68m + gemma-4-E4B (CPU)
-          #   aimee-kb-gpu-small 4B/400m + Gemma-4-12B qat-UD-Q4_K_XL (dense, FA+K8V4)
+          #   aimee-kb-gpu-small 4B/400m + Gemma-4-12B qat-UD-Q4_K_XL (dense, FA+K8V4; 16GB)
           #   aimee-kb-gpu-mid   4B/400m + Gemma-4-26B-A4B qat-UD-Q4_K_XL (MoE, 4B active,
           #                      FA+K8V4; ~14GB fits 24GB fully-resident → N_CPU_MOE=0;
-          #                      GGUF pinned by HF rev+sha256)
-          # gpu-small/gpu-mid share the 2560-dim embedder so a KB is portable across the
+          #                      GGUF pinned by HF rev+sha256; SLOTS=2 → deploy 2×128K)
+          #   aimee-kb-gpu-large IDENTICAL to gpu-mid (same 26B-A4B GGUF/profile) but
+          #                      SLOTS=4 for 32GB cards → deploy 4×256K (each agent the
+          #                      full native 262144 window; Gemma's windowed KV keeps
+          #                      even 4×256K under ~28.5GiB, validated vs the 24GB mid card)
+          # gpu-small/mid/large share the 2560-dim embedder so a KB is portable across the
           # synth swap. amd64 GPU host runs the x64 Vulkan binary; NGL set at deploy.
           - { name: aimee-kb-cpu, dockerfile: Dockerfile.aimee-llm }
           - { name: aimee-kb-gpu-small, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF\nSYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=9586f3257bc62bd179767241c7ec0f66bc2a314a\nSYNTH_SHA256=cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165\nSYNTH_FA=on" }
           - { name: aimee-kb-gpu-mid, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF\nSYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c\nSYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=0\nSYNTH_SLOTS=2" }
+          # gpu-large: same GGUF as gpu-mid, only SYNTH_SLOTS=4 (24GB→32GB card headroom).
+          - { name: aimee-kb-gpu-large, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF\nSYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c\nSYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=0\nSYNTH_SLOTS=4" }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -154,10 +160,10 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        # aimee-kb-gpu-mid (Gemma-4-26B-A4B, ~14GB) is amd64-only: arm64 would bake a
-        # non-runnable x64 Vulkan binary and double the build/disk cost. Skip it on arm64
+        # aimee-kb-gpu-mid/large (Gemma-4-26B-A4B, ~14GB) are amd64-only: arm64 would bake a
+        # non-runnable x64 Vulkan binary and double the build/disk cost. Skip them on arm64
         # -> the merge job emits a single-arch amd64 manifest (it tolerates count>=1).
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context || '.' }}
@@ -174,8 +180,8 @@ jobs:
           # layer cache. Same exclusion for the aimee-kb-* tiers: they BAKE multi-GB
           # GGUFs (Qwen3-Embedding + gemma) into the image, so caching those layers
           # would likewise blow the 10 GB GHA budget and evict the C-image caches.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-kb-gpu-large' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-kb-gpu-large' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
@@ -200,13 +206,13 @@ jobs:
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.image.name }}-${{ matrix.platform.arch }}"
 
       - name: Upload digest
-        if: ${{ !(matrix.image.name == 'aimee-kb-gpu-mid' && matrix.platform.arch == 'arm64') }}
+        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
         uses: actions/upload-artifact@v4
         with:
           name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}
@@ -221,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-kb-cpu, aimee-kb-gpu-small, aimee-kb-gpu-mid, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-kb-cpu, aimee-kb-gpu-small, aimee-kb-gpu-mid, aimee-kb-gpu-large, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/.github/workflows/publish-llm-testing.yml
+++ b/.github/workflows/publish-llm-testing.yml
@@ -10,10 +10,10 @@
 # server-code push would be wasteful. So it triggers ONLY on the aimee-kb
 # sources (the Dockerfile + the gateway/supervisor scripts).
 #
-# Tiers built every push: aimee-kb-cpu + aimee-kb-gpu-small (Gemma). The
-# aimee-kb-gpu-mid (Gemma-4-26B-A4B, ~14GB) is dispatch-only. amd64 only (the .254
-# deploy target); the release pipeline owns
-# multi-arch.
+# Tiers built every push: aimee-kb-cpu + aimee-kb-gpu-small (Gemma). The big MoE
+# tiers aimee-kb-gpu-mid and aimee-kb-gpu-large (both Gemma-4-26B-A4B, ~14GB; they
+# differ ONLY in baked SYNTH_SLOTS, 2 vs 4) are dispatch-only. amd64 only (the .254
+# deploy target); the release pipeline owns multi-arch.
 name: Publish testing aimee-llm
 
 on:
@@ -28,7 +28,11 @@ on:
   workflow_dispatch:
     inputs:
       build_kb_gpu_mid:
-        description: "Also build the aimee-kb-gpu-mid (Gemma-4-26B-A4B synth, ~14GB)"
+        description: "Also build the aimee-kb-gpu-mid (Gemma-4-26B-A4B synth, ~14GB, SLOTS=2)"
+        type: boolean
+        default: false
+      build_kb_gpu_large:
+        description: "Also build the aimee-kb-gpu-large (same 26B-A4B synth, ~14GB, SLOTS=4, 32GB card)"
         type: boolean
         default: false
 
@@ -175,3 +179,76 @@ jobs:
           tags: |
             ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing
             ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing-${{ env.SHA7 }}
+
+  # aimee-kb-gpu-large (Gemma-4-26B-A4B synth, ~14GB MoE): byte-identical to gpu-mid
+  # except baked SYNTH_SLOTS=4 (24GB→32GB card headroom; deploy at 4×256K). Same
+  # dispatch-only + /mnt-relocation + df pre-flight rationale as build-kb-gpu-mid.
+  build-kb-gpu-large:
+    if: github.event_name == 'workflow_dispatch' && inputs.build_kb_gpu_large
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Normalize owner + short sha
+        run: |
+          echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+          echo "SHA7=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Reclaim toolchains AND relocate docker's data-root to the larger /mnt disk
+      # BEFORE buildx is created, so buildkit writes the ~14GB model layers there
+      # (mirrors publish-images.yml's aimee-kb-leg fix, commit f26cf76).
+      - name: Free disk + move docker storage to /mnt
+        run: |
+          echo "before:"; df -h / /mnt
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
+          sudo docker image prune --all --force || true
+          sudo systemctl stop docker docker.socket || true
+          sudo mkdir -p /mnt/docker
+          printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker || true
+          echo "after:"; df -h / /mnt
+
+      # Fail fast if /mnt can't hold the image's transient footprint instead of dying
+      # mid-build with ENOSPC after the model download.
+      - name: Pre-flight disk check
+        run: |
+          avail=$(df --output=avail -BG /mnt | tail -1 | tr -dc '0-9')
+          echo "/mnt available: ${avail}GB"
+          if [ "${avail:-0}" -lt 80 ]; then
+            echo "::error::/mnt has only ${avail}GB free; need >=80GB for the kb-gpu-large build"; exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push aimee-kb-gpu-large:testing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.aimee-llm
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          build-args: |
+            EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF
+            EMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf
+            RERANK_REPO=cross-encoder/ettin-reranker-400m-v1
+            SYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF
+            SYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
+            SYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c
+            SYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e
+            SYNTH_FA=on
+            SYNTH_MOE=1
+            SYNTH_N_CPU_MOE=0
+            SYNTH_SLOTS=4
+          tags: |
+            ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-large:testing
+            ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-large:testing-${{ env.SHA7 }}

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -5,7 +5,8 @@
 # Two published images (operator-directed: models baked in, not runtime-fetched —
 # turnkey, reproducible, no HF dependency at run time):
 #   aimee-kb-cpu       (defaults): Qwen3-Embedding-0.6B + ettin-68m + gemma-4-E4B
-#   aimee-kb-gpu-small/mid (build args): 4B + ettin-400m + gemma-4-12B OR gemma-4-26B-A4B
+#   aimee-kb-gpu-small/mid/large (build args): 4B + ettin-400m + gemma-4-12B (small,
+#     16GB) OR gemma-4-26B-A4B (mid=24GB SLOTS=2 / large=32GB SLOTS=4 — same GGUF)
 # The llama.cpp binary is the VENDOR-AGNOSTIC Vulkan build (one binary for AMD/
 # Nvidia/Intel); GPU is selected at runtime by AIMEE_LLM_NGL (CPU image defaults 0).
 #

--- a/deploy/compose/aimee.gpu.yaml
+++ b/deploy/compose/aimee.gpu.yaml
@@ -18,6 +18,12 @@ services:
       # sliding-window attention (5 local layers windowed to 1024 : 1 global), so the
       # 128K KV is dominated by the few global layers (~2-3GB), not all-layers-x-128K —
       # well under 24GB. 256K would still fit with KV-cache quantization if ever needed.
+      #
+      # Tier picks (override AIMEE_LLM_IMAGE + AIMEE_LLM_SYNTH_CTX per card):
+      #   gpu-small (16GB): ...-gpu-small,  CTX 131072  (1 × 128K)
+      #   gpu-mid   (24GB): ...-gpu-mid,    CTX 262144   (2 × 128K, SLOTS=2)
+      #   gpu-large (32GB): ...-gpu-large,  CTX 1048576  (4 × 256K, SLOTS=4) — each of
+      #     4 agents gets the full native 256K window; ~28.5GiB used, ~3.5GB headroom.
       AIMEE_LLM_SYNTH_CTX: ${AIMEE_LLM_SYNTH_CTX:-131072}
     devices:
       - "/dev/dri:/dev/dri"

--- a/deploy/smoothnas/aimee-llm.plugin.yaml
+++ b/deploy/smoothnas/aimee-llm.plugin.yaml
@@ -36,7 +36,10 @@ services:
       #   aimee-kb-gpu-small  Gemma-4-12B synth (dense; fits 16GB+)
       #   aimee-kb-gpu-mid    Gemma-4-26B-A4B synth (MoE, 4B active; ~14GB fits a 24GB
       #                       card fully GPU-resident, baked AIMEE_LLM_SYNTH_N_CPU_MOE=0)
+      #   aimee-kb-gpu-large  SAME 26B-A4B GGUF as gpu-mid but baked SYNTH_SLOTS=4 for a
+      #                       32GB card — deploy AIMEE_LLM_SYNTH_CTX=1048576 (4 × 256K)
       # aimee-kb-cpu is the CPU tier (1024-dim; NGL=0). See docs/AIMEE_KB_SYNTH_TIERS.md.
+      # This .254 plugin stays on gpu-mid (its card is 24GB); gpu-large is for 32GB hosts.
       image: ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest
     container:
       restartPolicy: unless-stopped

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -2,19 +2,25 @@
 
 The `aimee-kb-*` image is the unified Vulkan llama.cpp stack: one runtime serving
 **embeddings** (`/embed`), **reranking** (`/rerank`), and **synthesis**
-(`/v1/chat/completions`) from baked-in GGUFs. Three published tiers differ only in the
+(`/v1/chat/completions`) from baked-in GGUFs. Four published tiers differ only in the
 **synth model** (and its runtime profile); embed + rerank are identical within a
 CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
 
 | Image | Embed / Rerank | Synth | Runtime |
 |---|---|---|---|
 | `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) |
-| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 |
-| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident |
+| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB |
+| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB |
+| `aimee-kb-gpu-large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `gpu-mid`, 4 slots — 32 GB |
 
-`gpu-small` and `gpu-mid` share the **same embedder + reranker** (2560-dim), so a KB
-embedded on one is byte-compatible with the other. Switching the synth tier is a
-plugin **image swap**, no re-embed.
+`gpu-large` is byte-identical to `gpu-mid` (same synth GGUF/revision/SHA + MoE/FA profile);
+it only bakes `SYNTH_SLOTS=4` instead of `2`, so a 32 GB card runs **4 concurrent agents**
+each with the model's full native **256 K** window (deploy `AIMEE_LLM_SYNTH_CTX=1048576`).
+Gemma-4 uses interleaved sliding-window attention (only 5 of 30 layers are full-attention),
+so even 4×256 K KV stays ~28.5 GiB — validated against the 24 GB `gpu-mid` card (2×128 K =
+22.4/24 GiB). `gpu-small`, `gpu-mid`, and `gpu-large` share the **same embedder + reranker**
+(2560-dim), so a KB embedded on one is byte-compatible with the others — switching the synth
+tier is a plugin **image swap**, no re-embed.
 
 ## Tier-A vs Tier-B synthesis
 
@@ -25,8 +31,8 @@ The curator synthesizes in two tiers:
   synthesize, promote.
 
 `aimee-kb-cpu` runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider (a weak model would poison the graph), so a CPU-only deployment gets retrieval + Tier-A
-synthesis and nothing more. **Tier B needs a GPU tier (`gpu-small` / `gpu-mid`) or an
-external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
+synthesis and nothing more. **Tier B needs a GPU tier (`gpu-small` / `gpu-mid` / `gpu-large`)
+or an external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
 config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
 
 ## Package names
@@ -35,8 +41,8 @@ Two image families share the `aimee-kb` prefix. Keep them straight:
 
 - **`aimee-kb`** (no suffix): the KB service (DB2 + curator). Runs no model; it calls one
   over HTTP. See [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
-- **`aimee-kb-{cpu,gpu-small,gpu-mid}`**: the inference tiers in this doc (embed + rerank +
-  synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm` plugin.
+- **`aimee-kb-{cpu,gpu-small,gpu-mid,gpu-large}`**: the inference tiers in this doc (embed +
+  rerank + synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm` plugin.
 
 Retired names: `aimee-llm-cpu`/`aimee-llm-gpu` were the old tier names (now
 `aimee-kb-cpu`/`aimee-kb-gpu-small`); `aimee-embedder`/`aimee-embedder-4b` were the
@@ -75,8 +81,8 @@ independent callers, one automatic, one an explicit operator step:
 
 | Env | Default (per tier) | Meaning |
 |---|---|---|
-| `AIMEE_LLM_SYNTH_CTX` | 32768 baked; the gpu-mid plugin sets `262144` (2 × 128 K) | synth context window |
-| `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on gpu-mid) | `--parallel` concurrent slots |
+| `AIMEE_LLM_SYNTH_CTX` | 32768 baked; gpu-mid deploys `262144` (2 × 128 K), gpu-large `1048576` (4 × 256 K) | synth context window (total across slots) |
+| `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on gpu-mid, 4 on gpu-large) | `--parallel` concurrent slots |
 | `AIMEE_LLM_SYNTH_FA` | `off` cpu / `on` gpu | flash-attention (required for quantized V-cache) |
 | `AIMEE_LLM_SYNTH_KV_K` / `_KV_V` | `q8_0` / `q4_0` (K8V4) | KV cache quant on the gpu tiers |
 | `AIMEE_LLM_SYNTH_MOE` | `1` on gpu-mid | enable the `--n-cpu-moe` expert-offload knob |

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -39,8 +39,10 @@ case "${AIMEE_LLM_STUB:-}" in
     # synth MODEL + its runtime profile is baked per TIER (build-args -> ENV):
     #   aimee-kb-cpu       gemma-4-E4B     (dense, CPU)
     #   aimee-kb-gpu-small gemma-4-12B     (dense, GPU, FA+K8V4)
-    #   aimee-kb-gpu-mid   Qwen3.6-35B-A3B (MoE, GPU, FA+K8V4 + static --n-cpu-moe
-    #                      expert-offload so the 22GB synth co-fits embed+rerank on 24GB)
+    #   aimee-kb-gpu-mid   gemma-4-26B-A4B (MoE, GPU, FA+K8V4, fully resident on 24GB;
+    #                      SYNTH_SLOTS=2 -> deploy 2x128K)
+    #   aimee-kb-gpu-large gemma-4-26B-A4B (SAME GGUF/profile as mid, SYNTH_SLOTS=4 for
+    #                      32GB cards -> deploy 4x256K; Gemma windowed KV keeps ~28.5GiB)
     # The gemma tiers leave FA/MoE unset -> identical to prior behaviour. AIMEE_LLM_
     # SYNTH_LOCAL=0 still lets an operator disable the local synth and forward via
     # AIMEE_LLM_SYNTH_URL instead.


### PR DESCRIPTION
## Summary

Adds a fourth GPU synth tier, **`aimee-kb-gpu-large`**, targeting 32 GB cards. It is **byte-identical to `gpu-mid`** — same Gemma-4-26B-A4B GGUF, revision, SHA256, and MoE/FA profile — differing by exactly one baked build-arg: `SYNTH_SLOTS=4` (mid is `2`). The larger context is deploy-time: recommended `AIMEE_LLM_SYNTH_CTX=1048576` (**4 × 256K**), giving 4 concurrent agents each the model's **full native 262144 window**.

`gpu-small`/`mid`/`large` share the 2560-dim embedder, so a KB stays byte-portable across the swap — it's an image swap, no re-embed.

## Why 4×256K fits 32 GB

Gemma-4 uses interleaved sliding-window attention: only **5 of 30 layers** are full-attention (2 KV-heads × 512 dim); the other **25 are windowed to 1024 tokens**, so their KV cache is context-independent. With K=q8_0/V=q4_0 only ~**8.3 KB per token of total context** scales (~2.0 GiB per 256K).

| Config | slots × ctx | total ctx | Est. VRAM | Headroom on 32 GB |
|---|---|---|---|---|
| gpu-mid (today) | 2 × 128K | 262K | 22.4 GiB | *(24 GB card: 2.1 GB)* |
| gpu-large option A | 4 × 128K | 512K | ~24.4 GiB | ~7.6 GB |
| **gpu-large (this PR)** | **4 × 256K** | **1024K** | **~28.5 GiB** | **~3.5 GB** |

The model was validated against the **live 24 GB `gpu-mid` card**: 2×128K uses 22405/24560 MiB, which my KV model reproduces. 5×256K was too tight (~1.3 GB headroom), so 4 agents is the ceiling.

## Changes

- **`.github/workflows/publish-images.yml`** — new `aimee-kb-gpu-large` build-matrix entry; added to merge list, cache-exclusion expressions, and the amd64-only arm64-skip guards.
- **`.github/workflows/publish-llm-testing.yml`** — dispatch-only `build-kb-gpu-large` job + `build_kb_gpu_large` input (mirrors the `build-kb-gpu-mid` pattern).
- **`Dockerfile.aimee-llm`**, **`scripts/aimee-llm-supervisor.sh`** — tier-comment updates (no build-logic change).
- **`docs/AIMEE_KB_SYNTH_TIERS.md`** — new tier row + slots/ctx knob table.
- **`deploy/compose/aimee.gpu.yaml`**, **`deploy/smoothnas/aimee-llm.plugin.yaml`** — tier-menu comments with the `4×256K` deploy value. **The `.254` plugin stays pinned to `gpu-mid`** (its card is 24 GB).

`gpu-small` and `gpu-mid` are untouched.

## Verification

- All changed YAML parses; `bash -n` clean on the supervisor script.
- VRAM fit is **analytical, validated against the live 24 GB card** but **hardware-unverified on a real 32 GB card** — the tier should be booted on 32 GB hardware to confirm the KV alloc before it's relied on in production.