### PR TITLE
docs(kb): document aimee-kb-gpu-large tier and image sizes

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1421,7 +1421,8 @@ the server. Four compose files ship, built from three images: `aimee-server`
 bundles a CPU inference gateway (embeddings, reranking, and synthesis) from the
 `aimee-kb` image family, so embedding and reranking work with nothing external.
 The CPU tier serves Qwen3-Embedding-0.6B at 1024 dims; the GPU tiers
-(`aimee-kb-gpu-small`, `aimee-kb-gpu-mid`) serve Qwen3-Embedding-4B at 2560 dims.
+(`aimee-kb-gpu-small` 16 GB, `aimee-kb-gpu-mid` 24 GB, `aimee-kb-gpu-large` 32 GB)
+serve Qwen3-Embedding-4B at 2560 dims.
 To run a standalone embedder or curator LLM instead of the bundled gateway, use
 the `external-llm` compose profile. Backends and tiers:
 [KB_LLM_BACKENDS.md](docs/KB_LLM_BACKENDS.md) and

--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ aimee delegate roundtable "Review this design" --mode review     # bounded multi
 aimee ships the retrieval and synthesis stack as one container: a Vulkan llama.cpp runtime
 serving embeddings, reranking, and synthesis from models baked into the image. Run it on a
 GPU and the knowledge base curates locally with no API calls, and the local model registers
-as a free delegate the roundtable and the primary can call. Three tiers cover the range: a
-CPU build for retrieval on any host, and two GPU builds whose synth model you pick with a
-single image swap, no re-embed. See [kb LLM backends](docs/KB_LLM_BACKENDS.md) and
+as a free delegate the roundtable and the primary can call. Four tiers cover the range: a
+CPU build for retrieval on any host, and three GPU builds (for 16, 24, and 32 GB cards) whose
+synth model you pick with a single image swap, no re-embed. See [kb LLM backends](docs/KB_LLM_BACKENDS.md) and
 [synth tiers](docs/AIMEE_KB_SYNTH_TIERS.md).
 
 ### Session isolation

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -6,12 +6,12 @@ The `aimee-kb-*` image is the unified Vulkan llama.cpp stack: one runtime servin
 **synth model** (and its runtime profile); embed + rerank are identical within a
 CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
 
-| Image | Embed / Rerank | Synth | Runtime |
-|---|---|---|---|
-| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) |
-| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB |
-| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB |
-| `aimee-kb-gpu-large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `gpu-mid`, 4 slots — 32 GB |
+| Image | Embed / Rerank | Synth | Runtime (target card) | Pull size |
+|---|---|---|---|---|
+| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) | ~6.5 GB |
+| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB | ~11.4 GB |
+| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB | ~17.8 GB |
+| `aimee-kb-gpu-large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `gpu-mid`, 4 slots — 32 GB | ~17.8 GB |
 
 `gpu-large` is byte-identical to `gpu-mid` (same synth GGUF/revision/SHA + MoE/FA profile);
 it only bakes `SYNTH_SLOTS=4` instead of `2`, so a 32 GB card runs **4 concurrent agents**
@@ -21,6 +21,12 @@ so even 4×256 K KV stays ~28.5 GiB — validated against the 24 GB `gpu-mid` ca
 22.4/24 GiB). `gpu-small`, `gpu-mid`, and `gpu-large` share the **same embedder + reranker**
 (2560-dim), so a KB embedded on one is byte-compatible with the others — switching the synth
 tier is a plugin **image swap**, no re-embed.
+
+**Image size** (amd64, compressed pull from ghcr): `cpu` ~6.5 GB, `gpu-small` ~11.4 GB,
+`gpu-mid` / `gpu-large` **~17.8 GB**. The mid/large image bakes ~19.3 GB of GGUFs
+(embed 4.28 GB + rerank 0.79 GB + synth 14.25 GB) → ~20 GB uncompressed on disk. `gpu-large`
+carries the *same* layers as `gpu-mid` (only the `SYNTH_SLOTS=4` env differs), so it is the
+same size — allow ~20 GB free disk on the host per GPU image, plus transient build headroom.
 
 ## Tier-A vs Tier-B synthesis
 

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -7,22 +7,24 @@ How to point `aimee-kb` at the model backend that does its **embedding**,
 
 `aimee-kb` is a thin DB2 / curator service. It **never** runs an LLM or embedder
 in-process. It *calls* one over HTTP. Inference lives in a separate **`aimee-kb-*`
-tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid`, the unified
-Vulkan llama.cpp stack, deployed as the SmoothNAS `aimee-llm` plugin) or any external
+tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid` / `aimee-kb-gpu-large`,
+the unified Vulkan llama.cpp stack, deployed as the SmoothNAS `aimee-llm` plugin) or any external
 OpenAI-compatible endpoint. You only ever give the kb a **URL**. The tiers themselves are
 documented in [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 
 ## Tiers: what each backend provides
 
-| Backend | Embedding / reranking | Synthesis | Embedding dim |
-| --- | --- | --- | --- |
-| **`aimee-kb-cpu`** (default) | Qwen3-Emb-0.6B + ettin-68m | **Tier-A** only (gemma-4-E4B, CPU) | **1024** |
-| **`aimee-kb-gpu-small`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 12B) | **2560** (set explicitly) |
-| **`aimee-kb-gpu-mid`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 26B-A4B) | **2560** (set explicitly) |
-| **External LLM** | per the endpoint | per the endpoint | per the endpoint |
+| Backend | Embedding / reranking | Synthesis | Embedding dim | Pull size |
+| --- | --- | --- | --- | --- |
+| **`aimee-kb-cpu`** (default) | Qwen3-Emb-0.6B + ettin-68m | **Tier-A** only (gemma-4-E4B, CPU) | **1024** | ~6.5 GB |
+| **`aimee-kb-gpu-small`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 12B) | **2560** (set explicitly) | ~11.4 GB |
+| **`aimee-kb-gpu-mid`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 26B-A4B, 24 GB card, 2 slots) | **2560** (set explicitly) | ~17.8 GB |
+| **`aimee-kb-gpu-large`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (same 26B-A4B, 32 GB card, 4 slots × 256 K) | **2560** (set explicitly) | ~17.8 GB |
+| **External LLM** | per the endpoint | per the endpoint | per the endpoint | — |
 
-`gpu-small` and `gpu-mid` share the 2560-dim embedder, so a KB moves between them with no
-re-embed. Pick by synth need, not by the KB.
+`gpu-small`, `gpu-mid`, and `gpu-large` share the 2560-dim embedder, so a KB moves between them
+with no re-embed. `gpu-large` is byte-identical to `gpu-mid` bar `SYNTH_SLOTS=4` (4 concurrent
+agents for a 32 GB card). Pick by synth need + card size, not by the KB.
 
 *Tier-A* = mechanical extract/index passes. *Tier-B* = reasoning passes (judge,
 resolve-entities, contradictions, **synthesize**, promote). A small CPU model is

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -33,12 +33,14 @@ credentials live in the server's **sealed vault**; see
   transcripts and build progress dropped), with the full output spilled for lossless
   recovery. Fail-open and byte-identical when off. Toggle it in the web Settings page. See
   [features/tool-output-condensation.md](features/tool-output-condensation.md).
-- **Self-hosted GPU inference tiers**: the `aimee-kb` inference image ships three tiers you
-  swap with one plugin image. `aimee-kb-cpu` runs retrieval on any host, `aimee-kb-gpu-small`
-  bakes a Gemma 4 12B synth, and `aimee-kb-gpu-mid` bakes a Gemma 4 26B-A4B synth that fits a
-  24 GB card fully resident. The GPU tiers build on a Mesa 25 base so RADV uses the RDNA3
-  matrix cores. The local synth also registers as a free delegate. See
-  [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
+- **Self-hosted GPU inference tiers**: the `aimee-kb` inference image ships four tiers you
+  swap with one plugin image. `aimee-kb-cpu` runs retrieval on any host (~6.5 GB image),
+  `aimee-kb-gpu-small` bakes a Gemma 4 12B synth (~11.4 GB, 16 GB card), `aimee-kb-gpu-mid`
+  bakes a Gemma 4 26B-A4B synth that fits a 24 GB card fully resident (~17.8 GB, 2 slots),
+  and `aimee-kb-gpu-large` reuses that same synth on a 32 GB card with 4 concurrent agents at
+  the full 256 K window (same ~17.8 GB image, only `SYNTH_SLOTS=4`). The GPU tiers build on a
+  Mesa 25 base so RADV uses the RDNA3 matrix cores. The local synth also registers as a free
+  delegate. See [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 - **Cross-repo code graph**: the symbol and call graph resolves dependency edges across the
   repositories in your workspace, so blast radius and caller lookups cross repo boundaries.
   Ask in three directions: what a project depends on, what depends on it, or both. See

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -26,7 +26,7 @@ Two embedding widths ship:
 | Tier | Embedder (`embedding_dim`) | Reranker |
 |------|----------------------------|----------|
 | `aimee-kb-cpu` | Qwen3-Embedding-0.6B (`1024`) | ettin-68m |
-| `aimee-kb-gpu-small` / `-gpu-mid` | Qwen3-Embedding-4B (`2560`) | ettin-400m |
+| `aimee-kb-gpu-small` / `-gpu-mid` / `-gpu-large` | Qwen3-Embedding-4B (`2560`) | ettin-400m |
 
 The 4B/2560 tier has better recall on large or meaning-heavy corpora; the 0.6B/1024 tier is
 the low-footprint default. The retrieval pipeline (hybrid search, reranking, fusion) is
@@ -41,7 +41,7 @@ the width to match:
 AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
 ```
 
-Both GPU tiers are 2560-dim, so moving between `gpu-small` and `gpu-mid` needs no re-embed.
+All GPU tiers are 2560-dim, so moving between `gpu-small`, `gpu-mid`, and `gpu-large` needs no re-embed.
 Moving between 1024 and 2560 is a model-identity **and** width change: on an **empty** DB
 just set the dim; on a **populated** one it's a drop-and-rebuild re-embed (the `halfvec`
 columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces. See
@@ -201,7 +201,7 @@ unchanged, since the dimension has not moved.
 
 An optional cross-encoder reranker refines the top-k of a recall before it is
 returned. It is baked into the same tier image and sized to match the embedder: the GPU tiers
-(`aimee-kb-gpu-small` / `-gpu-mid`) bake `cross-encoder/ettin-reranker-400m-v1`; the CPU
+(`aimee-kb-gpu-small` / `-gpu-mid` / `-gpu-large`) bake `cross-encoder/ettin-reranker-400m-v1`; the CPU
 tier bakes ettin-68m. Build-time override: `--build-arg RERANK_REPO=<hf id>`.
 
 It is configured independently of the embedder dimension:

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -9,9 +9,10 @@ the images build, serve `/embed`+`/rerank`(ettin encoder + gateway
 head)+`/v1/chat/completions`, and offload to the AMD 7900 XTX via Vulkan (`-ngl 99`).
 
 > **Naming update (post-cutover):** the images built here were renamed
-> `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small`, and a third GPU
-> tier `aimee-kb-gpu-mid` (Gemma 4 26B-A4B) was added; `aimee-llm` is now only the plugin
-> name. The steps below keep the original names as a record, for the current tiers and
+> `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small`, and two more GPU
+> tiers were added — `aimee-kb-gpu-mid` (Gemma 4 26B-A4B, 24 GB card) and `aimee-kb-gpu-large`
+> (same synth, 32 GB card, `SYNTH_SLOTS=4`); `aimee-llm` is now only the plugin name. The
+> steps below keep the original names as a record, for the current tiers, image sizes, and
 > build-args see [../AIMEE_KB_SYNTH_TIERS.md](../AIMEE_KB_SYNTH_TIERS.md).
 
 ## 0. What changes
@@ -39,14 +40,14 @@ release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollb
 
 CI builds + publishes both tiers as part of the normal release cycle:
 - **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds
-  `aimee-kb-cpu` + `aimee-kb-gpu-small` + `aimee-kb-gpu-mid` on every release and tags them
-  `:<version>` + `:latest`. They are in both the `build` and the `merge` matrices; the
-  merge step applies the tags, so a build that pushes only by digest leaves `tags:null`.
-  (`gpu-mid` is amd64-only.)
+  `aimee-kb-cpu` + `aimee-kb-gpu-small` + `aimee-kb-gpu-mid` + `aimee-kb-gpu-large` on every
+  release and tags them `:<version>` + `:latest`. They are in both the `build` and the `merge`
+  matrices; the merge step applies the tags, so a build that pushes only by digest leaves
+  `tags:null`. (`gpu-mid` and `gpu-large` are amd64-only.)
 - **testing:** `.github/workflows/publish-llm-testing.yml` builds `cpu` + `gpu-small` on
   `testing` pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts,
-  tagged `:testing` (+ `:testing-<sha>`, amd64). `gpu-mid` is dispatch-only
-  (`build_kb_gpu_mid=true`): a tested-but-unreleased image for `.254`.
+  tagged `:testing` (+ `:testing-<sha>`, amd64). `gpu-mid` and `gpu-large` are dispatch-only
+  (`build_kb_gpu_mid=true` / `build_kb_gpu_large=true`): tested-but-unreleased images for `.254`.
 
 To build out-of-band (e.g. on a PVE CT with docker):
 


### PR DESCRIPTION
Follow-up to #1131 (the `aimee-kb-gpu-large` tier). Documents the new tier and the per-tier **image pull sizes** across all LLM docs, ahead of the release promote.

## Image sizes (amd64, compressed pull from ghcr, measured)

| Tier | Pull size | Notes |
|---|---|---|
| `aimee-kb-cpu` | ~6.5 GB | 1024-dim CPU retrieval |
| `aimee-kb-gpu-small` | ~11.4 GB | Gemma 4 12B, 16 GB card |
| `aimee-kb-gpu-mid` | ~17.8 GB | Gemma 4 26B-A4B, 24 GB card, 2 slots |
| `aimee-kb-gpu-large` | ~17.8 GB | **same layers as gpu-mid**, only `SYNTH_SLOTS=4` — 32 GB card, 4×256K |

The mid/large image bakes ~19.3 GB of GGUFs (embed 4.28 + rerank 0.79 + synth 14.25 GB) → ~20 GB uncompressed on disk.

## Files

- `docs/AIMEE_KB_SYNTH_TIERS.md` — added a **Pull size** column + an image-size note.
- `docs/KB_LLM_BACKENDS.md` — gpu-large row + pull-size column.
- `docs/retrieval-stack.md`, `MANUAL.md` — tier enumerations now include gpu-large.
- `docs/runbooks/unified-llm-cutover.md` — release/testing build lists + amd64-only + dispatch flags.
- `docs/WHATS_NEW.md`, `README.md` — "three tiers" → "four", with sizes.