### PR TITLE
fix(agent): register codex-oauth as a direct-HTTP chatgpt agent, not tmux-cli

### DIFF
--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -1311,7 +1311,45 @@ int handle_agent_cli_oauth_code(server_ctx_t *ctx, server_conn_t *conn, cJSON *r
    return server_send_ok(conn, jo_ok());
 }
 
-/* Register the now-authenticated vendor CLI as a server-side tmux-CLI agent. */
+/* Configure an authenticated codex vendor as a DIRECT-HTTP `chatgpt` agent — the
+ * Responses-wire driver, authenticating with the vaulted, auto-refreshing
+ * codex-oauth token — rather than a tmux-CLI agent. Only claude runs the vendor
+ * CLI over tmux; codex is HTTP and needs no tmux session. Endpoint/model/
+ * provider/auth are single-sourced from the codex direct adapter (agent_adapter.c)
+ * so this stays in lockstep with the `agent add --provider codex` shape. */
+static void sagent_configure_http_codex_agent(agent_t *ag, const char *name)
+{
+   const agent_adapter_t *ad = agent_adapter_for_name("codex");
+   memset(ag, 0, sizeof(*ag));
+   snprintf(ag->name, MAX_AGENT_NAME, "%s", name);
+   snprintf(ag->provider, sizeof(ag->provider), "%s", ad ? ad->provider : "chatgpt");
+   snprintf(ag->auth_type, sizeof(ag->auth_type), "%s", ad ? ad->auth_type : "codex-oauth");
+   snprintf(ag->endpoint, sizeof(ag->endpoint), "%s",
+            (ad && ad->default_endpoint) ? ad->default_endpoint
+                                         : "https://chatgpt.com/backend-api/codex");
+   snprintf(ag->model, sizeof(ag->model), "%s",
+            (ad && ad->default_model) ? ad->default_model : "gpt-5.5");
+   ag->backend[0] = '\0'; /* HTTP: no CLI/tmux backend */
+   ag->cost_tier = 0;     /* codex subscription */
+   ag->max_tokens = AGENT_DEFAULT_MAX_TOKENS;
+   ag->timeout_ms = 600000;
+   ag->enabled = 1;
+   ag->tools_enabled = 1;
+   ag->max_turns = -1;
+   ag->max_parallel = AGENT_DEFAULT_MAX_PARALLEL;
+   /* gpt-5.5/codex is absent from the model capability table, so an auto-detect
+    * would resolve 0 and drop this agent from min-context fleets (e.g. review).
+    * Pin the real gpt-5-codex window explicitly (the middleware field capability
+    * routing and the agent listing both read). */
+   ag->middleware.context_window = 272000;
+   /* Full capable delegate role set (matches `agent add` default): a coding
+    * delegate must take code/execute work, not just summarize/format/draft. */
+   server_agent_set_roles_csv(
+       ag, "code,review,explain,refactor,draft,execute,summarize,format,reason,search");
+}
+
+/* Register the now-authenticated vendor: codex as a direct-HTTP `chatgpt` agent
+ * (vaulted codex-oauth token), claude as a server-side tmux-CLI agent. */
 static void sagent_cli_oauth_register(cli_oauth_vendor_t v)
 {
    agent_config_t acfg;
@@ -1325,9 +1363,14 @@ static void sagent_cli_oauth_register(cli_oauth_vendor_t v)
          return;
       ag = &acfg.agents[acfg.agent_count++];
    }
-   /* cli_kind/cli_cmd run the server-installed CLI over tmux (no HTTP endpoint).
-    * cost_tier 0 for codex (subscription), 1 for claude. */
-   sagent_configure_tmux_cli_agent(ag, name, name, name, name, v == CLI_OAUTH_CODEX ? 0 : 1);
+   /* codex authenticates over HTTP with the vaulted codex-oauth token (the
+    * Responses-wire `chatgpt` driver); only claude runs the vendor CLI over tmux.
+    * Filing both as tmux-CLI (the prior behavior) left codex trying to open a
+    * tmux session it never needs — "failed to create tmux session for codex". */
+   if (v == CLI_OAUTH_CODEX)
+      sagent_configure_http_codex_agent(ag, name);
+   else
+      sagent_configure_tmux_cli_agent(ag, name, name, name, name, 1);
    ag->is_server_hosted = 1; /* distinct from a client-only claude (panel gate) */
    agent_save_config(&acfg);
 }

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -643,6 +643,17 @@ static void test_agent_adapter_registry(void)
    assert(agent_adapter_supports(codex, AGENT_ADAPTER_CAP_PRIMARY_CONVERSATION));
    assert(agent_adapter_supports(codex, AGENT_ADAPTER_CAP_DIRECT_HTTP));
 
+   /* Regression guard (codex-oauth was registered as a tmux-CLI agent instead of
+    * HTTP): the OAuth-CLI register path shapes the codex agent from THIS adapter,
+    * so its HTTP fields must stay populated — otherwise the registered agent has
+    * no reachable endpoint and degrades to the tmux/CLI backend, which then masks
+    * local HTTP synth delegates at the same tier (see
+    * test_local_synth_not_masked_by_tmux_codex). */
+   assert(codex->default_endpoint && codex->default_endpoint[0]);
+   assert(strstr(codex->default_endpoint, "codex") != NULL);
+   assert(codex->default_model && codex->default_model[0]);
+   assert(codex->auth_type && strcmp(codex->auth_type, "codex-oauth") == 0);
+
    const agent_adapter_t *mistral = agent_adapter_for_provider("mistral");
    assert(mistral != NULL);
    assert(strcmp(mistral->name, "mistral") == 0);
@@ -657,6 +668,94 @@ static void test_agent_adapter_registry(void)
 
    snprintf(ag.backend, sizeof(ag.backend), "%s", AGENT_BACKEND_PROVIDER_CLI);
    assert(agent_adapter_agent_is_direct(&ag) == 0);
+}
+
+/* Regression guard for the codex-tmux misregistration that hid the local synth
+ * delegate. agent_route() prefers a tmux-CLI backend over HTTP peers at the
+ * cheapest tier (the "has_tmux" filter, mirrored in agent_route_with_caps_inner).
+ * When codex was wrongly filed as a tmux-CLI agent at cost_tier 0, that filter
+ * excluded the local HTTP synth delegate (gpu-mid) from every default route, so
+ * it was never used. Case A reproduces the mask; Case B proves that codex in its
+ * correct HTTP (chatgpt) shape leaves the local synth routable. */
+static void test_local_synth_not_masked_by_tmux_codex(void)
+{
+   /* Fake `tmux` and `codex` on PATH so a codex tmux-CLI agent is genuinely
+    * available_for_routing (tmux availability requires both binaries on PATH). */
+   char fake_bin[MAX_PATH_LEN];
+   snprintf(fake_bin, sizeof(fake_bin), "%s/aimee-test-route-bin-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(fake_bin) != NULL);
+   const char *fakes[] = {"tmux", "codex"};
+   for (size_t i = 0; i < sizeof(fakes) / sizeof(fakes[0]); i++)
+   {
+      char p[MAX_PATH_LEN];
+      snprintf(p, sizeof(p), "%s/%s", fake_bin, fakes[i]);
+      FILE *f = fopen(p, "w");
+      assert(f != NULL);
+      fputs("#!/bin/sh\nexit 0\n", f);
+      fclose(f);
+      assert(chmod(p, 0700) == 0);
+   }
+   const char *old_path_env = getenv("PATH");
+   char *old_path = old_path_env ? strdup(old_path_env) : NULL;
+   size_t path_len = strlen(fake_bin) + 2 + (old_path ? strlen(old_path) : 0);
+   char *new_path = malloc(path_len);
+   assert(new_path != NULL);
+   snprintf(new_path, path_len, "%s:%s", fake_bin, old_path ? old_path : "");
+   setenv("PATH", new_path, 1);
+   free(new_path);
+
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 2;
+   snprintf(cfg.default_agent, sizeof(cfg.default_agent), "gpu-mid");
+
+   /* Local HTTP synth delegate at the cheapest tier. Empty provider => keyless =>
+    * available_for_routing, matching a no-auth local endpoint. */
+   agent_t *synth = &cfg.agents[0];
+   snprintf(synth->name, sizeof(synth->name), "gpu-mid");
+   snprintf(synth->roles[0], sizeof(synth->roles[0]), "execute");
+   synth->role_count = 1;
+   synth->cost_tier = 0;
+   synth->enabled = 1;
+   synth->tools_enabled = 1;
+
+   /* Peer codex at the same cheapest tier. */
+   agent_t *codex = &cfg.agents[1];
+   snprintf(codex->name, sizeof(codex->name), "codex");
+   snprintf(codex->roles[0], sizeof(codex->roles[0]), "execute");
+   codex->role_count = 1;
+   codex->cost_tier = 0;
+   codex->enabled = 1;
+   codex->tools_enabled = 1;
+
+   /* Case A — the bug: codex mis-filed as tmux-CLI. has_tmux fires at tier 0 and
+    * excludes the HTTP synth entirely, so the router can only pick the tmux peer. */
+   snprintf(codex->backend, sizeof(codex->backend), "%s", AGENT_BACKEND_TMUX_CLI);
+   snprintf(codex->cli_kind, sizeof(codex->cli_kind), "codex");
+   snprintf(codex->cli_cmd, sizeof(codex->cli_cmd), "codex");
+   assert(agent_is_available_for_routing(synth) == 1);
+   assert(agent_is_available_for_routing(codex) == 1); /* tmux + codex on PATH */
+   agent_t *routed_a = agent_route(&cfg, "execute");
+   assert(routed_a == codex); /* synth masked by the tmux peer */
+   assert(routed_a != synth);
+
+   /* Case B — the fix: codex in its correct HTTP (chatgpt) shape. No tmux backend
+    * at the cheapest tier, so the local synth (the default agent) is routable. */
+   codex->backend[0] = '\0';
+   codex->cli_kind[0] = '\0';
+   codex->cli_cmd[0] = '\0';
+   snprintf(codex->provider, sizeof(codex->provider), "chatgpt");
+   snprintf(codex->auth_type, sizeof(codex->auth_type), "codex-oauth");
+   assert(agent_route(&cfg, "execute") == synth);
+
+   if (old_path)
+   {
+      setenv("PATH", old_path, 1);
+      free(old_path);
+   }
+   else
+      unsetenv("PATH");
+   printf("  PASS: test_local_synth_not_masked_by_tmux_codex\n");
 }
 
 static void test_provider_cli_shell_exec_uses_argv_not_shell(void)
@@ -2208,6 +2307,7 @@ int main(void)
    test_agent_config_provider_cli_roundtrip();
    test_tools_enabled_capability_default();
    test_agent_adapter_registry();
+   test_local_synth_not_masked_by_tmux_codex();
    test_provider_cli_shell_exec_uses_argv_not_shell();
    test_provider_cli_shell_timeout_covers_prompt_write();
    test_codex_oauth_auth_resolution();


### PR DESCRIPTION
## Problem
`codex-oauth` setup registered codex as a **tmux-CLI** agent (`backend=tmux-cli`, `provider=codex`, `auth=none`, no endpoint) instead of a direct-HTTP `chatgpt` agent. Two consequences:

1. `--via codex` delegates failed with `failed to create tmux session for codex` — codex authenticates over HTTP with the vaulted, auto-refreshing codex-oauth token; it has no tmux/CLI to drive.
2. The delegate router prefers a tmux-CLI backend over HTTP peers at the cheapest tier (the `has_tmux` filter in `agent_route` / `agent_route_with_caps_inner`). A tmux codex at `cost_tier 0` **masked the local HTTP synth delegate (`gpu-mid`) from every default route** — so the local synth model was never used.

## Fix
`sagent_cli_oauth_register` now shapes codex from the existing codex direct adapter (`agent_adapter.c`): `provider=chatgpt`, `endpoint=https://chatgpt.com/backend-api/codex`, `model=gpt-5.5`, `auth_type=codex-oauth`, HTTP backend, full delegate role set. **Claude stays tmux-cli.** The vaulted token is untouched.

## Tests
- `test_local_synth_not_masked_by_tmux_codex` — deterministic repro (fake `tmux`/`codex` on PATH): codex-as-tmux masks the local HTTP synth at the cheapest tier; codex-as-HTTP leaves it routable. **Red-before-green verified** (neutralizing the real `has_tmux` filter aborts the test).
- `test_agent_adapter_registry` — now locks the codex adapter's HTTP `endpoint`/`model`/`auth_type` the register path reads from.

## Verified on the live .254 stack
- Rewrote the codex record to the HTTP shape; `--via codex` delegate returns cleanly, no tmux.
- Default routing now selects the local synth delegate again — 6/6 default delegates routed to `gpu-mid`.