### PR TITLE
Promote testing → main: audit_worm_enabled persistence fix

### DIFF
--- a/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
+++ b/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
@@ -1,26 +1,38 @@
 # Proposal: LLM-sidecar productionization — graduate curator extraction and idle reflection from stub to production
 
-- **State:** PENDING — design only, no code in this PR. Finalises two
+- **State:** PENDING — design only, no code in this PR. Finalises three
   scaffolded-but-stubbed intelligence steps that ride the shared
-  `kb_curator_sidecar` mechanism. Adds no
-  new subsystem: it wires the existing curator extract/synthesize/judge stages and
-  the existing idle-reflection scheduler onto a production sidecar, behind a
-  calibrated gate. Continuation of **Deep Curator: Doc and Code Extraction**
+  `kb_curator_sidecar` / offline-extractor mechanism. Adds no new **durability**
+  subsystem: it wires the existing curator extract/synthesize/judge stages, the
+  existing idle-reflection scheduler, and the existing `memory_facts` drain onto a
+  production sidecar behind a calibrated gate, and reuses the shipped `rel_types`
+  write gate and ontology-evolution machinery for reconciliation. The one genuinely
+  new surface is the KB-owned Typed Facts console panel (§8). Continuation of
+  **Deep Curator: Doc and Code Extraction**
   (Accepted, Phase 0 shipped — `scripts/embed-minilm.py` MiniLM-L6-v2 embedding
   sidecar) and the **Cross-Source Learning** substrate (Done). Does **not**
   re-propose the curator stage machine, the reflection scheduler, the promotion
   pipeline, calibration, or the sidecar-invocation shim — all shipped; it makes the
-  LLM step they were built around real.
+  LLM step they were built around real. Extended (2026-07-07) to fold in the
+  **memory typed-fact path** (`kb_memory_facts.c`), which rides the same offline
+  extractor: move its extraction fully offline, default it on, add **autonomous
+  ontology reconciliation** so extracted facts actually become durable and
+  recallable (not just logged), and surface the whole subsystem — observe,
+  fine-tune, and alter behaviour — in **aimee-kb's web console**, backed by
+  **KB-owned config**. aimee-server owns none of it.
 - **Author:** JBailes
 - **Date:** 2026-07-07
 - **Charter roles:** Extract (structured entity/fact/decision/relationship
-  extraction from docs and code), Synthesize (reflection candidate generation +
-  higher-order knowledge), Judge (quality gate before durable), Reflect
-  (idle-time consolidation), Calibrate (per-surface promotion thresholds already
-  fitted — this feeds them real candidates), Gate-Promote (staged rollout of the
-  sidecar's output), Evaluate-Optimize (shadow → canary → default via the bandit
-  substrate). Cites the Architecture Charter; this proposal lives entirely inside
-  the charter's Extract/Synthesize/Judge/Reflect spine.
+  extraction from docs, code, and remembered notes), Reconcile (map free-form
+  extracted relations onto the canonical `rel_types` ontology, and auto-promote
+  the genuinely novel tail so facts become durable without a human), Synthesize
+  (reflection candidate generation + higher-order knowledge), Judge (quality gate
+  before durable), Reflect (idle-time consolidation), Calibrate (per-surface
+  promotion thresholds already fitted — this feeds them real candidates and drives
+  autonomous ontology promotion), Gate-Promote (staged rollout of the sidecar's
+  output), Evaluate-Optimize (shadow → canary → default via the bandit substrate).
+  Cites the Architecture Charter; this proposal lives entirely inside the charter's
+  Extract/Reconcile/Synthesize/Judge/Reflect spine.
 
 ## Thesis
 
@@ -49,11 +61,28 @@ on two steps that are **scaffolded but stubbed today**:
    deduplication run fully."* So aimee reflects **structurally** today; it does not
    yet **synthesize**.
 
-Both stubs share one dependency: a production LLM sidecar with a stable contract.
-This proposal defines that contract once, graduates both consumers onto it behind
-a calibrated shadow→canary→default gate, and closes the two operational-validation
-items those stages left open. When it lands, the §1/§3 claims become true in the
-build, not just in the architecture.
+3. **Memory typed-fact extraction — runs, but nothing lands.** The `memory_facts`
+   drain (`kb_memory_facts.c`, on `kb_curator_drain.c`) already runs the LLM
+   extractor (`kb_curator_llm_run`, `MF_SYSTEM_PROMPT`) offline over stored
+   memories. But two things keep it from being real: (a) a redundant *synchronous*
+   pattern pass still fires on the store/turn hot path (`db2_typed_fact_ingress` →
+   `db2_fact_ingest_text` in `kb_service_backend_memory.c` / `fact_ingest.c`); and
+   (b) the extractor emits **free-form** relations that miss the seed ontology, so
+   the write gate stages them provisional and **no durable, recallable fact is
+   written**. Validated on the .254 stack (2026-07-07): a note storing
+   `is_cto_of` / `drives` / `has_office_in` logged *"memory 7 → 3 typed facts"*
+   while `typed_facts` stayed empty, `rel_types` held all three as
+   `status=provisional`, and recall returned nothing. Extraction happens; usable
+   facts do not. And none of it is observable or tunable by an operator.
+
+These steps share one dependency: a production LLM extractor, run offline, whose
+output is **reconciled** to a canonical ontology before the promotion gate. This
+proposal defines the sidecar contract once, graduates all three consumers onto it
+behind a calibrated shadow→canary→default gate, makes the memory typed-fact path
+offline-and-default-on with autonomous reconciliation, surfaces the whole
+subsystem as **KB-owned** config + an aimee-kb console panel, and closes the two
+operational-validation items those stages left open. When it lands, the §1/§3
+claims become true in the build, not just in the architecture.
 
 ## Goal
 
@@ -74,6 +103,17 @@ build, not just in the architecture.
    proposals (Working-Profile, Dogfood Autolabel) get their first real
    candidate stream from this, closing their "unshipped operational artifacts"
    remainder on a real calendar.
+6. **Memory typed facts, offline and default-on** — extraction (pattern + LLM)
+   runs entirely on the `memory_facts` drain; the store/turn hot path keeps only
+   cheap Postgres retraction + recall. `typed_facts_enabled` defaults **on** on
+   every backend (including CPU-only E4B), because nothing is synchronous LLM.
+7. **Autonomous ontology reconciliation** — extracted relations are reconciled to
+   the canonical ontology (constrain-the-extractor + auto-promote the novel tail)
+   **by default**, so facts become durable and recallable with no operator action.
+8. **KB-owned, GUI-tunable** — every knob (enable, reconciliation mode, thresholds,
+   ontology) lives in **aimee-kb** config and its web console — observe, fine-tune,
+   and alter behaviour there. **aimee-server knows nothing about typed facts**; its
+   per-turn injection just asks the KB and renders whatever the KB returns.
 
 ## §0 What already exists (so we don't rebuild it)
 
@@ -173,6 +213,73 @@ produces that stream — the first end-to-end pass of the promotion + retroactiv
 review loop is a curator/reflection candidate cohort moving shadow→default. Their
 close-by deadlines become achievable, not hypothetical.
 
+## §6 Memory typed facts — offline, default-on, KB-owned
+
+- **Extraction fully offline.** The `memory_facts` drain already runs the LLM
+  extractor off the hot path; fold the remaining synchronous **pattern** pass
+  (`memory_extract_patterns` via `db2_fact_ingest_text`) into the drain too, so the
+  store/turn path (`kb_service_backend_memory.c`, `fact_ingest.c`) does **zero**
+  synchronous extraction — it only enqueues the `memory_facts` job. Retraction
+  stays synchronous (a cheap Postgres write, corrections take effect immediately);
+  recall stays synchronous (`db2_fact_recall_in_query`, a Postgres read). Penalty:
+  a fact stated in the current turn is recallable one drain-cycle later, not
+  same-turn — an accepted trade for a cross-turn memory.
+- **Default on, every backend.** `typed_facts_enabled` defaults **on** and is no
+  longer tied to the `accel` signal (`config_apply_inference_backend_defaults`):
+  since extraction is offline and recall is a DB read, there is no per-turn LLM
+  cost on CPU-only E4B/E2B either. HyDE query rewrite — genuine per-turn LLM work —
+  stays accel-gated and is untouched.
+- **KB-owned.** The flag and every reconciliation/tuning knob live in **aimee-kb**
+  config (a `kb.typed_facts.*` section) and the KB console (§8). aimee-server has
+  **no** typed-fact gate: `ingress_preinject` calls the KB facts endpoint
+  (`kb_client_memory_facts`), which returns facts or empty from the KB's own
+  config. (Validation 2026-07-07: enabling it on aimee-server did nothing because
+  the KB never saw the setting — this removes that split-brain by design.)
+
+## §7 Autonomous ontology reconciliation
+
+The write gate (`db2_fact_commit`, `rel_types_store.c`) only makes a fact durable
+and recallable when its relation is **active** in the ontology; a free-form
+relation is staged as a `provisional` `rel_type` plus a low-confidence Class-C
+edge in `entity_edges` and never surfaces on recall. The extractor
+(`MF_SYSTEM_PROMPT`) emits free-form snake_case, so on a bare system **every fact
+is provisional** (the .254 evidence above). A human cannot be the one mapping
+`is_cto_of → has_role`; aimee reconciles autonomously, **on by default**:
+
+1. **Constrain the extractor.** Pass the seed ontology (`SEED_ONTOLOGY[]`,
+   `rel_types.c`: `works_for`, `has_role`, `lives_in`, …) into the extraction
+   prompt and instruct the model to map to the **nearest canonical** relation,
+   using an `OTHER` fallback only when nothing fits. Most facts then commit
+   `ACCEPT` → active → recallable immediately, with no promotion wait.
+2. **Auto-promote the novel tail.** Genuinely out-of-ontology relations that recur
+   across sources are promoted `provisional → active` by the existing
+   ontology-evolution machinery, run **by default** on a calibrated threshold
+   (reuse the shipped Bayesian-calibration substrate, §0). The ontology grows
+   itself; the `OTHER`-bucket is drained over time rather than lost.
+
+The default path needs no operator input. Every parameter — the ontology set,
+the reconciliation mode, the promotion threshold, the confidence floor — is an
+override exposed in §8, never a prerequisite.
+
+## §8 aimee-kb console — observe, fine-tune, alter behaviour (KB-owned)
+
+The KB console today is a single `/v1/console/overview` (`kb_http_console.c`). Add
+a **Typed Facts** panel, KB-served and backed entirely by KB config —
+aimee-server renders and knows nothing:
+
+- **Observe.** Durable vs provisional facts; the live ontology (seed + learned);
+  promotion candidates with their supporting evidence; drain throughput and lag.
+- **Fine-tune.** Promotion threshold, confidence floor, ontology extensions and
+  relation aliases.
+- **Alter behaviour.** Enable/disable; reconciliation mode
+  (`constrain-extractor` / `auto-promote` / `both` / `off`); ontology auto-growth
+  on/off.
+- **Act.** Promote, map, or reject a provisional relation by hand.
+
+Every control round-trips through `kb.typed_facts.*` KB config and is equally
+settable headless (same keys, no GUI required). aimee-server is not in the loop
+for any of it.
+
 ## Acceptance criteria
 
 1. **Contract.** `sidecar_contract_version` schema documented; both consumers emit
@@ -192,6 +299,17 @@ close-by deadlines become achievable, not hypothetical.
 6. **Validation-pending, stated as such.** Real-corpus precision/usefulness numbers
    are a dogfood deliverable (§5); this proposal ships the plumbing + fixtures and
    reports corpus-scale quality as *validation-pending*, not done.
+7. **Offline + default-on (KB).** With `typed_facts_enabled` at its default, a
+   fresh KB on any backend (including CPU-only E4B) extracts with **zero**
+   synchronous LLM on the store/turn path (proven by timing a store), and
+   `aimee config` on aimee-server exposes no typed-fact knob at all.
+8. **Reconciliation yields recallable facts.** On a fixture note, an extracted
+   fact commits with a canonical (or auto-promoted) relation as an **active** edge
+   and is returned by recall — proven end-to-end on the .254 stack, not merely
+   "N facts logged." (This is the exact failure §7 fixes.)
+9. **KB console.** The Typed Facts panel observes durable/provisional facts and the
+   ontology, and its fine-tune / alter / act controls round-trip through
+   `kb.typed_facts.*`; aimee-server has no equivalent surface.
 
 ## Explicitly out of scope / does not re-propose
 
@@ -201,5 +319,10 @@ close-by deadlines become achievable, not hypothetical.
   sibling proposal `org-data-connectors-and-source-ingestion.md`; this proposal
   makes extraction real, that one makes the corpus wide. They compose but ship
   independently.
-- Any change to the typed-fact ontology or write gate — relationship candidates
-  ride the existing `rel_types` gate unchanged.
+- **A new ontology store or a rewrite of the write gate.** Reconciliation (§7)
+  reuses the existing `rel_types` gate (`db2_fact_commit`), the seed ontology
+  (`SEED_ONTOLOGY[]`), and the shipped ontology-evolution / calibration machinery
+  verbatim. What is new is *feeding* the gate canonical relations (extractor
+  constraint) and *running* provisional→active promotion on by default — the gate
+  and the durability contract themselves are unchanged. Free-form relations are no
+  longer silently stranded as provisional; that is the whole point.

--- a/src/config.c
+++ b/src/config.c
@@ -288,6 +288,8 @@ static const config_schema_entry_t config_schema[] = {
     {"gateway_prevent_subagents", SCHEMA_BOOL, 0},
     {"gateway_pin_model", SCHEMA_BOOL, 0},
     {"css_style_graph_enabled", SCHEMA_BOOL, 0},
+    {"audit_action_enabled", SCHEMA_BOOL, 0},
+    {"audit_worm_enabled", SCHEMA_BOOL, 0},
     {"css_render_command", SCHEMA_STRING, 0},
     {"typed_facts_enabled", SCHEMA_BOOL, 0},
     {"kb_pdf_ingest_enabled", SCHEMA_BOOL, 0},
@@ -1118,6 +1120,10 @@ int config_load_file(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "audit_action_enabled");
    if (cJSON_IsBool(item))
       cfg->audit_action_enabled = cJSON_IsTrue(item);
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "audit_worm_enabled");
+   if (cJSON_IsBool(item))
+      cfg->audit_worm_enabled = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "memory_md_retire");
    if (cJSON_IsBool(item))

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -852,6 +852,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 1);
    if (!cfg->audit_action_enabled) /* default-on: persist only the opt-out (disable) */
       cJSON_AddBoolToObject(root, "audit_action_enabled", 0);
+   if (cfg->audit_worm_enabled) /* default-off: persist only the opt-in (enable) */
+      cJSON_AddBoolToObject(root, "audit_worm_enabled", 1);
    if (!cfg->memory_md_retire) /* default-on: persist only the opt-out (disable) */
       cJSON_AddBoolToObject(root, "memory_md_retire", 0);
    /* default-on render backend: persist only a non-default value (a custom command

--- a/src/db2/fact_ingest.c
+++ b/src/db2/fact_ingest.c
@@ -52,19 +52,16 @@ int db2_typed_fact_ingress(const char *query, char *facts_out, size_t facts_cap)
 
    int requests_sensitive = memory_pii_turn_requests_sensitive(query);
 
+   /* §4: a retraction turn corrects rather than asserts — retract the named
+    * attribute about the user (a user retraction always wins; an imprecise attr
+    * safely no-ops). This stays synchronous: it is a cheap Postgres write, no LLM.
+    * Fact EXTRACTION is offline-only (the memory_facts drain runs pattern + LLM),
+    * so we do NOT run db2_fact_ingest_text() on the turn hot path. */
    if (memory_pattern_is_retraction(query))
    {
-      /* §4: a retraction turn corrects rather than asserts. Retract the named
-       * attribute about the user; a user retraction always wins. An imprecise attr
-       * safely no-ops (retract only affects facts that exist). */
       char attr[128];
       if (memory_pattern_possessive_attr(query, attr, sizeof(attr)))
          (void)db2_fact_retract("user", attr, NULL, FACT_AUTHORITY_USER);
-   }
-   else
-   {
-      /* §6 write: extract facts from the turn and route them through the gate. */
-      (void)db2_fact_ingest_text(query, FACT_AUTHORITY_USER, 1);
    }
 
    /* §7 read: the user's facts + facts about any entity named in the turn,

--- a/src/db2/kb_service_backend_memory.c
+++ b/src/db2/kb_service_backend_memory.c
@@ -1188,17 +1188,15 @@ cJSON *db2_kb_service_memory_insert_ex_json(const char *tier, const char *kind, 
    }
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddNumberToObject(resp, "id", (double)out.id);
-   /* typed-fact population on ingest (gated, best-effort): inline high-precision
-    * pattern write + a queued "memory_facts" job for the drain's LLM extractor. */
+   /* typed-fact population on ingest: enqueue a "memory_facts" job so the drain
+    * mines this memory offline (pattern + LLM). Extraction is offline-only — no
+    * synchronous fact work on the store hot path; the drain's pattern pass now
+    * captures the high-precision triples the old inline call did. */
    {
       config_t tf_cfg;
       config_load(&tf_cfg);
-      if (tf_cfg.typed_facts_enabled)
-      {
-         (void)db2_typed_fact_ingress(content ? content : "", NULL, 0);
-         if (out.id > 0)
-            (void)db2_kb_async_enqueue("memory_facts", out.id, "memory");
-      }
+      if (tf_cfg.typed_facts_enabled && out.id > 0)
+         (void)db2_kb_async_enqueue("memory_facts", out.id, "memory");
    }
    cJSON *obj = kbs_memory_row_to_json(&out);
    if (obj)

--- a/src/guardrails_action_audit.c
+++ b/src/guardrails_action_audit.c
@@ -36,7 +36,10 @@ static int audit_action_is_enabled(void)
 }
 
 /* Cached audit_worm_enabled (default-off). Same fail-safe read-once pattern as
- * audit_action_is_enabled: a config_load failure leaves the WORM dual-write OFF. */
+ * audit_action_is_enabled: a config_load failure leaves the WORM dual-write OFF.
+ * Persisted like audit_action (config.c load + config_save opt-in), so the value
+ * survives a restart; the reload reapplier below clears the cache so a live
+ * config.set / SIGHUP also takes effect without one. */
 static int g_audit_worm_enabled = -1;
 static int audit_worm_is_enabled(void)
 {
@@ -48,6 +51,22 @@ static int audit_worm_is_enabled(void)
       g_audit_worm_enabled = cfg.audit_worm_enabled ? 1 : 0;
    }
    return g_audit_worm_enabled;
+}
+
+/* Clear both cached gates so the next audit call re-reads config. Runs after a
+ * reload publishes the new snapshot (registered via config_reload_register_
+ * reapplier), so a config.set / SIGHUP applies live instead of needing a restart. */
+static void audit_gate_reload_reapplier(const config_t *old_cfg, const config_t *new_cfg)
+{
+   (void)old_cfg;
+   (void)new_cfg;
+   g_audit_action_enabled = -1;
+   g_audit_worm_enabled = -1;
+}
+
+void guardrails_action_audit_register_reload(void)
+{
+   config_reload_register_reapplier(audit_gate_reload_reapplier);
 }
 
 /* Dual-write the same governed-action row into the append-only WORM store. S0:

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -323,7 +323,9 @@ typedef struct config
     * per-service WORM store (append-only, hash-chained SQLite) alongside the
     * legacy audit.log. Default-OFF (S0 of the WORM audit-store proposal); the
     * WORM store is not yet authoritative, so a failed WORM append is recoverable
-    * audit loss, never an enforcement change. */
+    * audit loss, never an enforcement change. Persisted as an opt-in (config.c
+    * load + config_save), so an enabled deployment survives a restart; the global
+    * default stays OFF. */
    int audit_worm_enabled;
    /* css_render_command: the render backend for the #4-full computed-style oracle.
     * A shell command (like embedding_command) that reads a {"html","css"} JSON

--- a/src/headers/guardrails.h
+++ b/src/headers/guardrails.h
@@ -138,6 +138,11 @@ classification_t classify_path(const char *file_path);
 int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
                    const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len);
 
+/* Register a config-reload reapplier that clears the cached audit_action_enabled
+ * / audit_worm_enabled gates so a live config.set / SIGHUP takes effect without a
+ * restart. Call once at server startup. */
+void guardrails_action_audit_register_reload(void);
+
 /* The guardrail verdict logic. pre_tool_check is a thin wrapper (in
  * guardrails_action_audit.c) that calls this and emits the per-action audit
  * row. Same return contract as pre_tool_check. */

--- a/src/kb/kb_memory_facts.c
+++ b/src/kb/kb_memory_facts.c
@@ -14,6 +14,8 @@
 #include "db2/fact_lifecycle.h"  /* FACT_AUTHORITY_MODEL */
 #include "db2/memory_query.h"    /* db2_memory_get */
 #include "db2/rel_types_store.h" /* db2_fact_commit */
+#include "db2/fact_ingest.h"     /* db2_fact_ingest_text (offline pattern extraction) */
+#include "rel_types.h"           /* seed ontology: rel_types_seed_* (extractor constraint, §7) */
 #include "memory.h"              /* memory_t */
 #include "memory_ontology.h"     /* NODE_* */
 
@@ -33,16 +35,43 @@
  * facts -- not transient state, opinions, or one-off events. relation is a short
  * snake_case predicate; object is the value. Conservative by design: an empty
  * list is the right answer when the text asserts no durable fact. */
-#define MF_SYSTEM_PROMPT                                                                           \
+/* Extraction prompt template. The `%s` is filled with the canonical relation list
+ * from the seed ontology (rel_types.c) at run time — this is the autonomous
+ * reconciliation step (proposal §7): the model is bound to relations the write
+ * gate already treats as durable, so an extracted fact commits ACTIVE and
+ * recallable instead of being stranded as a provisional Class-C edge. Relations
+ * outside the list fall to "other" and are left for the auto-promote tail. */
+#define MF_SYSTEM_PROMPT_TMPL                                                                      \
    "You extract durable facts from a single remembered note. Return ONLY a JSON "                  \
    "object: {\"facts\":[{\"subject\":\"\",\"relation\":\"\",\"object\":\"\","                      \
    "\"confidence\":0.0}]}. Each fact is a stable subject-relation-object triple "                  \
-   "grounded strictly in the note. relation is a short snake_case predicate "                      \
-   "(e.g. works_as, lives_in, owns, prefers, is_a, born_in). subject is the "                      \
-   "entity the fact is about (use \"user\" for the note's author when it is "                      \
-   "first-person). confidence is 0..1. Extract only durable, generalizable "                       \
-   "facts; skip transient state, feelings, plans, and one-off events. If the "                     \
-   "note asserts no durable fact, return an empty list. No prose, no markdown."
+   "grounded strictly in the note. relation MUST be exactly one of these canonical "               \
+   "predicates — choose the single nearest fit for each fact: %s. Use \"other\" "                  \
+   "ONLY when no listed predicate is a reasonable fit. subject is the entity the "                 \
+   "fact is about (use \"user\" for the note's author when it is first-person). "                  \
+   "confidence is 0..1. Extract only durable, generalizable facts; skip transient "                \
+   "state, feelings, plans, and one-off events. If the note asserts no durable "                   \
+   "fact, return an empty list. No prose, no markdown."
+
+/* Build the extraction system prompt, binding the model to the canonical relation
+ * set (autonomous reconciliation, §7). Sourced from the seed ontology so it stays
+ * in lockstep with the write gate — no second copy of the relation list. */
+static void mf_build_system_prompt(char *buf, size_t cap)
+{
+   char rels[768];
+   size_t p = 0;
+   int n = rel_types_seed_count();
+   for (int i = 0; i < n && p < sizeof(rels) - 1; i++)
+   {
+      const rel_type_def_t *d = rel_types_seed_at(i);
+      if (!d || !d->rel_type || !d->rel_type[0])
+         continue;
+      p += (size_t)snprintf(rels + p, sizeof(rels) - p, "%s%s", p ? ", " : "", d->rel_type);
+   }
+   if (!p) /* defensive: an empty seed would leave the model unconstrained */
+      snprintf(rels, sizeof(rels), "works_for, has_role, lives_in, born_in");
+   snprintf(buf, cap, MF_SYSTEM_PROMPT_TMPL, rels);
+}
 
 typedef struct
 {
@@ -203,6 +232,12 @@ static int mf_process_one(const config_t *cfg, const mf_job_t *job)
       return 0;
    }
 
+   /* Deterministic pattern-first extraction, moved off the synchronous store/turn
+    * path to the drain: high-precision regex triples committed idempotently. Runs
+    * before the LLM pass so obvious facts ("my name is X") still land even if the
+    * LLM sidecar is unavailable or the job later exhausts its retries. */
+   (void)db2_fact_ingest_text(mem.content, FACT_AUTHORITY_USER, 1);
+
    cJSON *req = cJSON_CreateObject();
    if (!req)
       return -1;
@@ -212,9 +247,12 @@ static int mf_process_one(const config_t *cfg, const mf_job_t *job)
    if (!request_json)
       return -1;
 
+   char sys_prompt[2560];
+   mf_build_system_prompt(sys_prompt, sizeof(sys_prompt));
+
    char err[MF_ERRBUF] = "";
-   char *resp = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, MF_SYSTEM_PROMPT,
-                                   request_json, "", MF_LLM_OUT_CAP, err, sizeof(err));
+   char *resp = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, sys_prompt, request_json, "",
+                                   MF_LLM_OUT_CAP, err, sizeof(err));
    free(request_json);
    if (!resp)
    {

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -1311,7 +1311,45 @@ int handle_agent_cli_oauth_code(server_ctx_t *ctx, server_conn_t *conn, cJSON *r
    return server_send_ok(conn, jo_ok());
 }
 
-/* Register the now-authenticated vendor CLI as a server-side tmux-CLI agent. */
+/* Configure an authenticated codex vendor as a DIRECT-HTTP `chatgpt` agent — the
+ * Responses-wire driver, authenticating with the vaulted, auto-refreshing
+ * codex-oauth token — rather than a tmux-CLI agent. Only claude runs the vendor
+ * CLI over tmux; codex is HTTP and needs no tmux session. Endpoint/model/
+ * provider/auth are single-sourced from the codex direct adapter (agent_adapter.c)
+ * so this stays in lockstep with the `agent add --provider codex` shape. */
+static void sagent_configure_http_codex_agent(agent_t *ag, const char *name)
+{
+   const agent_adapter_t *ad = agent_adapter_for_name("codex");
+   memset(ag, 0, sizeof(*ag));
+   snprintf(ag->name, MAX_AGENT_NAME, "%s", name);
+   snprintf(ag->provider, sizeof(ag->provider), "%s", ad ? ad->provider : "chatgpt");
+   snprintf(ag->auth_type, sizeof(ag->auth_type), "%s", ad ? ad->auth_type : "codex-oauth");
+   snprintf(ag->endpoint, sizeof(ag->endpoint), "%s",
+            (ad && ad->default_endpoint) ? ad->default_endpoint
+                                         : "https://chatgpt.com/backend-api/codex");
+   snprintf(ag->model, sizeof(ag->model), "%s",
+            (ad && ad->default_model) ? ad->default_model : "gpt-5.5");
+   ag->backend[0] = '\0'; /* HTTP: no CLI/tmux backend */
+   ag->cost_tier = 0;     /* codex subscription */
+   ag->max_tokens = AGENT_DEFAULT_MAX_TOKENS;
+   ag->timeout_ms = 600000;
+   ag->enabled = 1;
+   ag->tools_enabled = 1;
+   ag->max_turns = -1;
+   ag->max_parallel = AGENT_DEFAULT_MAX_PARALLEL;
+   /* gpt-5.5/codex is absent from the model capability table, so an auto-detect
+    * would resolve 0 and drop this agent from min-context fleets (e.g. review).
+    * Pin the real gpt-5-codex window explicitly (the middleware field capability
+    * routing and the agent listing both read). */
+   ag->middleware.context_window = 272000;
+   /* Full capable delegate role set (matches `agent add` default): a coding
+    * delegate must take code/execute work, not just summarize/format/draft. */
+   server_agent_set_roles_csv(
+       ag, "code,review,explain,refactor,draft,execute,summarize,format,reason,search");
+}
+
+/* Register the now-authenticated vendor: codex as a direct-HTTP `chatgpt` agent
+ * (vaulted codex-oauth token), claude as a server-side tmux-CLI agent. */
 static void sagent_cli_oauth_register(cli_oauth_vendor_t v)
 {
    agent_config_t acfg;
@@ -1325,9 +1363,14 @@ static void sagent_cli_oauth_register(cli_oauth_vendor_t v)
          return;
       ag = &acfg.agents[acfg.agent_count++];
    }
-   /* cli_kind/cli_cmd run the server-installed CLI over tmux (no HTTP endpoint).
-    * cost_tier 0 for codex (subscription), 1 for claude. */
-   sagent_configure_tmux_cli_agent(ag, name, name, name, name, v == CLI_OAUTH_CODEX ? 0 : 1);
+   /* codex authenticates over HTTP with the vaulted codex-oauth token (the
+    * Responses-wire `chatgpt` driver); only claude runs the vendor CLI over tmux.
+    * Filing both as tmux-CLI (the prior behavior) left codex trying to open a
+    * tmux session it never needs — "failed to create tmux session for codex". */
+   if (v == CLI_OAUTH_CODEX)
+      sagent_configure_http_codex_agent(ag, name);
+   else
+      sagent_configure_tmux_cli_agent(ag, name, name, name, name, 1);
    ag->is_server_hosted = 1; /* distinct from a client-only claude (panel gate) */
    agent_save_config(&acfg);
 }

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -9,6 +9,7 @@
 #include "git_host_cred.h"
 #include "git_host_resolve.h"
 #include "git_ops.h"
+#include "guardrails.h"
 #include "workspace.h"
 #include "kb_client_cache.h"
 #include "kb_client_ws.h"
@@ -252,6 +253,10 @@ static int run_server(const char *socket_path, log_level_t log_level)
    context_engine_register_compactor();
    if (cfg.context_engine[0])
       context_engine_set_active(cfg.context_engine);
+
+   /* Clear the cached audit_action/audit_worm gates on config reload so a live
+    * config.set / SIGHUP toggles the audit + WORM dual-write without a restart. */
+   guardrails_action_audit_register_reload();
    {
       char perr[256] = {0};
       plugin_loader_discover_all(perr, sizeof(perr));

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -643,6 +643,17 @@ static void test_agent_adapter_registry(void)
    assert(agent_adapter_supports(codex, AGENT_ADAPTER_CAP_PRIMARY_CONVERSATION));
    assert(agent_adapter_supports(codex, AGENT_ADAPTER_CAP_DIRECT_HTTP));
 
+   /* Regression guard (codex-oauth was registered as a tmux-CLI agent instead of
+    * HTTP): the OAuth-CLI register path shapes the codex agent from THIS adapter,
+    * so its HTTP fields must stay populated — otherwise the registered agent has
+    * no reachable endpoint and degrades to the tmux/CLI backend, which then masks
+    * local HTTP synth delegates at the same tier (see
+    * test_local_synth_not_masked_by_tmux_codex). */
+   assert(codex->default_endpoint && codex->default_endpoint[0]);
+   assert(strstr(codex->default_endpoint, "codex") != NULL);
+   assert(codex->default_model && codex->default_model[0]);
+   assert(codex->auth_type && strcmp(codex->auth_type, "codex-oauth") == 0);
+
    const agent_adapter_t *mistral = agent_adapter_for_provider("mistral");
    assert(mistral != NULL);
    assert(strcmp(mistral->name, "mistral") == 0);
@@ -657,6 +668,94 @@ static void test_agent_adapter_registry(void)
 
    snprintf(ag.backend, sizeof(ag.backend), "%s", AGENT_BACKEND_PROVIDER_CLI);
    assert(agent_adapter_agent_is_direct(&ag) == 0);
+}
+
+/* Regression guard for the codex-tmux misregistration that hid the local synth
+ * delegate. agent_route() prefers a tmux-CLI backend over HTTP peers at the
+ * cheapest tier (the "has_tmux" filter, mirrored in agent_route_with_caps_inner).
+ * When codex was wrongly filed as a tmux-CLI agent at cost_tier 0, that filter
+ * excluded the local HTTP synth delegate (gpu-mid) from every default route, so
+ * it was never used. Case A reproduces the mask; Case B proves that codex in its
+ * correct HTTP (chatgpt) shape leaves the local synth routable. */
+static void test_local_synth_not_masked_by_tmux_codex(void)
+{
+   /* Fake `tmux` and `codex` on PATH so a codex tmux-CLI agent is genuinely
+    * available_for_routing (tmux availability requires both binaries on PATH). */
+   char fake_bin[MAX_PATH_LEN];
+   snprintf(fake_bin, sizeof(fake_bin), "%s/aimee-test-route-bin-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(fake_bin) != NULL);
+   const char *fakes[] = {"tmux", "codex"};
+   for (size_t i = 0; i < sizeof(fakes) / sizeof(fakes[0]); i++)
+   {
+      char p[MAX_PATH_LEN];
+      snprintf(p, sizeof(p), "%s/%s", fake_bin, fakes[i]);
+      FILE *f = fopen(p, "w");
+      assert(f != NULL);
+      fputs("#!/bin/sh\nexit 0\n", f);
+      fclose(f);
+      assert(chmod(p, 0700) == 0);
+   }
+   const char *old_path_env = getenv("PATH");
+   char *old_path = old_path_env ? strdup(old_path_env) : NULL;
+   size_t path_len = strlen(fake_bin) + 2 + (old_path ? strlen(old_path) : 0);
+   char *new_path = malloc(path_len);
+   assert(new_path != NULL);
+   snprintf(new_path, path_len, "%s:%s", fake_bin, old_path ? old_path : "");
+   setenv("PATH", new_path, 1);
+   free(new_path);
+
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 2;
+   snprintf(cfg.default_agent, sizeof(cfg.default_agent), "gpu-mid");
+
+   /* Local HTTP synth delegate at the cheapest tier. Empty provider => keyless =>
+    * available_for_routing, matching a no-auth local endpoint. */
+   agent_t *synth = &cfg.agents[0];
+   snprintf(synth->name, sizeof(synth->name), "gpu-mid");
+   snprintf(synth->roles[0], sizeof(synth->roles[0]), "execute");
+   synth->role_count = 1;
+   synth->cost_tier = 0;
+   synth->enabled = 1;
+   synth->tools_enabled = 1;
+
+   /* Peer codex at the same cheapest tier. */
+   agent_t *codex = &cfg.agents[1];
+   snprintf(codex->name, sizeof(codex->name), "codex");
+   snprintf(codex->roles[0], sizeof(codex->roles[0]), "execute");
+   codex->role_count = 1;
+   codex->cost_tier = 0;
+   codex->enabled = 1;
+   codex->tools_enabled = 1;
+
+   /* Case A — the bug: codex mis-filed as tmux-CLI. has_tmux fires at tier 0 and
+    * excludes the HTTP synth entirely, so the router can only pick the tmux peer. */
+   snprintf(codex->backend, sizeof(codex->backend), "%s", AGENT_BACKEND_TMUX_CLI);
+   snprintf(codex->cli_kind, sizeof(codex->cli_kind), "codex");
+   snprintf(codex->cli_cmd, sizeof(codex->cli_cmd), "codex");
+   assert(agent_is_available_for_routing(synth) == 1);
+   assert(agent_is_available_for_routing(codex) == 1); /* tmux + codex on PATH */
+   agent_t *routed_a = agent_route(&cfg, "execute");
+   assert(routed_a == codex); /* synth masked by the tmux peer */
+   assert(routed_a != synth);
+
+   /* Case B — the fix: codex in its correct HTTP (chatgpt) shape. No tmux backend
+    * at the cheapest tier, so the local synth (the default agent) is routable. */
+   codex->backend[0] = '\0';
+   codex->cli_kind[0] = '\0';
+   codex->cli_cmd[0] = '\0';
+   snprintf(codex->provider, sizeof(codex->provider), "chatgpt");
+   snprintf(codex->auth_type, sizeof(codex->auth_type), "codex-oauth");
+   assert(agent_route(&cfg, "execute") == synth);
+
+   if (old_path)
+   {
+      setenv("PATH", old_path, 1);
+      free(old_path);
+   }
+   else
+      unsetenv("PATH");
+   printf("  PASS: test_local_synth_not_masked_by_tmux_codex\n");
 }
 
 static void test_provider_cli_shell_exec_uses_argv_not_shell(void)
@@ -2208,6 +2307,7 @@ int main(void)
    test_agent_config_provider_cli_roundtrip();
    test_tools_enabled_capability_default();
    test_agent_adapter_registry();
+   test_local_synth_not_masked_by_tmux_codex();
    test_provider_cli_shell_exec_uses_argv_not_shell();
    test_provider_cli_shell_timeout_covers_prompt_write();
    test_codex_oauth_auth_resolution();

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -239,6 +239,10 @@ int main(void)
       /* css_style_graph now defaults on; set off to prove the opt-out round-trips
        * (default-on save-guard regression class). */
       cfg.css_style_graph_enabled = 0;
+      /* audit_worm_enabled defaults off; set on to prove the opt-in persists
+       * (regression: it was allowlist-settable but had no config_save/load path,
+       * so an enabled deployment silently reverted to off on restart). */
+      cfg.audit_worm_enabled = 1;
       /* css_render_command defaults non-empty; set empty to prove the disable
        * override round-trips (string default-on save-guard: save must emit the
        * non-default empty, not drop it and silently re-default on reload). */
@@ -449,6 +453,7 @@ int main(void)
       assert(fabs(cfg2.memory_improve_max_confidence - 0.42) < 0.0001);
       assert(cfg2.memory_directives_enabled == 0);
       assert(cfg2.css_style_graph_enabled == 0);  /* opt-out survives save/reload */
+      assert(cfg2.audit_worm_enabled == 1);       /* opt-in survives save/reload */
       assert(cfg2.css_render_command[0] == '\0'); /* disable (empty) survives save/reload */
       /* regression: kb.maintenance.* used to be parsed but never saved -> dropped on save. */
       assert(cfg2.kb_maintenance_enabled == 1);


### PR DESCRIPTION
Promote to cut the next release (auto-release → tag + publish-images).

**Headline:** `fix(config): persist audit_worm_enabled + reset audit gates on reload` (#1134) — makes the WORM audit dual-write gate durably enable-able (config load+save + reload gate reset). Global default stays OFF. Enables turning WORM audit logging on as a persistent `.254` setting.

Rebuilds `aimee-server` (+ all images) at the new version.