### PR TITLE
fix(guard): require_session_worktree defaults ON — isolate every session

### DIFF
--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -465,20 +465,25 @@ static int attn_parse_require_session_worktree(const char *buf, int *out)
 
 static int attn_config_require_session_worktree(void)
 {
+   /* Default ON: session-worktree isolation is required unless an operator
+    * explicitly sets `require_session_worktree: false`. Two aimee sessions
+    * sharing one checkout collide on a single git HEAD — one session's
+    * `git checkout <branch>` moves the branch the other is mutating, cross-
+    * contaminating commits. Failing closed to isolation (each session in its own
+    * `.aimee/worktrees/...` worktree+branch) is the only safe default. */
    const char *home = aimee_home();
    if (!home || !home[0])
-      return 0;
+      return 1; /* no resolvable home -> fail closed to isolation */
 
    char path[1024];
    snprintf(path, sizeof(path), "%s/aimee.yaml", home);
 
    char *buf = NULL;
    if (!attn_read_file(path, &buf))
-      return 0;
+      return 1; /* no config file -> default ON */
 
-   int value = 0;
-   if (!attn_parse_require_session_worktree(buf, &value))
-      value = 0;
+   int value = 1; /* default ON; only an explicit key overrides */
+   (void)attn_parse_require_session_worktree(buf, &value);
    free(buf);
    return value;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -700,7 +700,11 @@ static void config_set_defaults(config_t *cfg)
     * per-result model-visible tool-output cap (see agent_tool_output_cap()). */
    cfg->tool_output_max_bytes = 0;
    cfg->ingress_compress_min_chars = 80;
-   cfg->require_session_worktree = 0;
+   /* Default ON: each mutating session must run in its own isolated worktree+branch
+    * (.aimee/worktrees/...), never the shared primary checkout. Concurrent aimee
+    * sessions sharing one checkout collide on a single git HEAD. Explicit
+    * `require_session_worktree: false` bypasses (see cli_attention_guard.c). */
+   cfg->require_session_worktree = 1;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
     * gate (make virtual-context-eval-check) passes on synthetic and real
     * tool-heavy session fixtures. Rollback: set session.virtual_context.enabled

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -821,8 +821,10 @@ int config_save(const config_t *cfg)
       cJSON_AddNumberToObject(root, "tool_output_max_bytes", cfg->tool_output_max_bytes);
    if (cfg->ingress_max_raw_scans != 0)
       cJSON_AddNumberToObject(root, "ingress_max_raw_scans", cfg->ingress_max_raw_scans);
-   if (cfg->require_session_worktree)
-      cJSON_AddBoolToObject(root, "require_session_worktree", 1);
+   /* Default-on: persist only the non-default (disabled) state, writing the real
+    * value so an explicit opt-out survives save+reload. */
+   if (!cfg->require_session_worktree)
+      cJSON_AddBoolToObject(root, "require_session_worktree", 0);
    if (cfg->typed_facts_enabled)
       cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
    if (cfg->kb_pdf_ingest_enabled) /* default-off: persist only when enabled */

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -2148,9 +2148,10 @@ static void test_session_isolation_guard(void)
    const char *primary = "/some/repo/src/x.c";
    const char *worktree = "/some/repo/.aimee/worktrees/ab12/main/src/x.c";
 
-   /* (1) Default off (no aimee.yaml): never blocks, even on the primary checkout. */
+   /* (1) Default ON (no aimee.yaml): a primary-checkout target is blocked, since
+    *     session-worktree isolation is required by default. */
    remove(cfg);
-   assert(agent_tools_session_isolation_blocks(primary, NULL) == 0);
+   assert(agent_tools_session_isolation_blocks(primary, NULL) == 1);
 
    /* (2) Explicit false: still no block. */
    FILE *f = fopen(cfg, "w");

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -233,12 +233,14 @@ static void test_isolation_enforcement(void)
    "{\"session_id\":\"isotest\",\"tool_name\":\"Read\","                                           \
    "\"tool_input\":{\"file_path\":\"/home/u/repo/src/x.c\"}}"
 
-   /* (1) Inert by default: no config -> mutating op on the primary checkout allowed. */
+   /* (1) Default ON: with no config, a mutating op on the primary checkout is
+    *     BLOCKED — session-worktree isolation is required by default so two aimee
+    *     sessions cannot collide on one shared git HEAD. */
    rm_path(cfgpath);
    g_stdin_json = EDIT_PRIMARY_HOOK;
-   assert(handle_attention_guard() == 0);
+   assert(handle_attention_guard() == 2);
 
-   /* (2) Explicit false also disabled. */
+   /* (2) Explicit false disables the guard (opt-out). */
    write_config("require_session_worktree: false\n");
    assert(handle_attention_guard() == 0);
 


### PR DESCRIPTION
## Problem
Two concurrent aimee sessions sharing one git checkout collide on a single `HEAD`. Observed live 2026-07-07: while one session was mid-work on its feature branch, a **second** aimee session ran `git checkout <its-branch>` **in the same primary checkout**, moving the branch the first session was mutating. A foundation commit landed on the wrong branch and the two features' commits cross-contaminated.

The attention-guard already has a session-isolation backstop (blocks mutating ops outside `.aimee/worktrees/…`), but it's gated on `require_session_worktree`, which **defaulted OFF** — so nothing forced sessions into separate worktrees.

## Fix
Flip `require_session_worktree` **ON by default**:
- `attn_config_require_session_worktree()` (the enforcing PreToolUse-hook reader): default ON; only an explicit `require_session_worktree: false` in aimee.yaml disables it. No config / no home ⇒ fail closed to isolation.
- `config.c`: `cfg->require_session_worktree = 1`.
- `config_save.c`: persist only the non-default (disabled) state so an explicit opt-out survives save+reload.

## Tests
- `test_attention_guard.c` + `test_agent.c`: the no-config default case now asserts **BLOCK** (was allow) — the regression guard for the new default.
- `config`, `attention-guard`, and `agent` suites all pass.

## Operational note
With this on, a session must run inside an isolated worktree+branch (provisioned by the SessionStart hook / `aimee session-start`). Mutating ops in the shared primary checkout are refused with a message explaining how to provision one; `AIMEE_GUARD=0` or an explicit `require_session_worktree: false` bypasses. If SessionStart doesn't already auto-provision a worktree in a given deployment, that provisioning must be wired for sessions to mutate — the guard fails closed by design.