### PR TITLE
fix(delegate): max_turns -1 = infinite, the default for every role

### DIFF
--- a/frontend/src/pages/Personas.tsx
+++ b/frontend/src/pages/Personas.tsx
@@ -67,6 +67,21 @@ const ta: React.CSSProperties = {
 };
 const nameOk = (s: string) => /^[a-z0-9][a-z0-9_-]*$/i.test(s);
 
+/* Upsert `max_turns` into a role template's YAML frontmatter so the dedicated
+ * field and the raw body stay consistent on save. -1 = infinite. */
+function withMaxTurns(body: string, mt: number): string {
+  const fm = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+  const m = body.match(fm);
+  if (m) {
+    let inner = m[1];
+    inner = /^max_turns:.*$/m.test(inner)
+      ? inner.replace(/^max_turns:.*$/m, `max_turns: ${mt}`)
+      : `max_turns: ${mt}\n${inner}`;
+    return body.replace(fm, `---\n${inner}\n---\n\n`);
+  }
+  return `---\nmax_turns: ${mt}\n---\n\n${body}`;
+}
+
 type Status = { kind: "ok" | "err"; msg: string } | null;
 
 export default function Personas() {
@@ -76,6 +91,7 @@ export default function Personas() {
   const [roles, setRoles] = useState<string[]>([]);
   const [roleSel, setRoleSel] = useState<string | null>(null);
   const [roleBody, setRoleBody] = useState("");
+  const [roleMaxTurns, setRoleMaxTurns] = useState<number>(-1); // -1 = infinite
 
   const refreshRoles = useCallback(() => {
     getJSON<{ role_templates?: string[] }>("/api/roles")
@@ -86,15 +102,19 @@ export default function Personas() {
   const openRole = useCallback((name: string) => {
     setRoleSel(name);
     setRoleBody("");
-    getJSON<{ content?: string }>(`/api/roles/${encodeURIComponent(name)}`)
-      .then((d) => setRoleBody(d.content || ""))
+    setRoleMaxTurns(-1);
+    getJSON<{ content?: string; max_turns?: number }>(`/api/roles/${encodeURIComponent(name)}`)
+      .then((d) => {
+        setRoleBody(d.content || "");
+        setRoleMaxTurns(typeof d.max_turns === "number" ? d.max_turns : -1);
+      })
       .catch(() => setRoleBody(""));
   }, []);
 
   const saveRole = async () => {
     if (!roleSel) return;
     const { status: st } = await sendJSON("PUT", `/api/roles/${encodeURIComponent(roleSel)}`, {
-      content: roleBody,
+      content: withMaxTurns(roleBody, roleMaxTurns),
     });
     if (st >= 200 && st < 300) {
       setStatus({ kind: "ok", msg: `role “${roleSel}” saved` });
@@ -111,6 +131,7 @@ export default function Personas() {
     }
     setRoleSel(name);
     setRoleBody(`You are a ${name} delegate. Your mission is to …\n`);
+    setRoleMaxTurns(-1);
   };
 
   const deleteRole = async () => {
@@ -237,6 +258,20 @@ export default function Personas() {
                 {roleSel} — what it does (delegate system-prompt template)
               </label>
               <textarea rows={12} style={ta} value={roleBody} onChange={(e) => setRoleBody(e.target.value)} />
+              <label style={{ ...lbl, marginTop: 8 }}>
+                Max turns per delegate run (−1 = infinite, the default)
+              </label>
+              <input
+                type="number"
+                min={-1}
+                step={1}
+                style={{ ...ta, height: "auto" }}
+                value={roleMaxTurns}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10);
+                  setRoleMaxTurns(Number.isFinite(v) ? v : -1);
+                }}
+              />
               <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
                 <button onClick={saveRole} style={btn}>
                   Save role

--- a/src/headers/role_templates.h
+++ b/src/headers/role_templates.h
@@ -34,6 +34,11 @@ int role_template_install_defaults(const char *dir);
  * '-'; non-empty; no path separators or leading dot). Guards write/delete. */
 int role_template_name_valid(const char *role);
 
+/* Per-role turn cap from the role template's `max_turns:` frontmatter, or -1
+ * (INFINITE — the default for every role) when unset. Edited under the Personas
+ * tab. */
+int role_template_max_turns(const char *role);
+
 /* Return the RAW template body for `role` (placeholders intact, not built):
  * project file -> user file -> built-in default. Heap (caller frees), or NULL
  * if no such role. */

--- a/src/posix/agent_max_turns.c
+++ b/src/posix/agent_max_turns.c
@@ -4,18 +4,20 @@
 #include "agent_types.h"
 #include "config.h"
 
+#include <limits.h>
+
 int agent_resolve_max_turns(const agent_t *agent, const char *role)
 {
-   /* max_turns > 0 on the agent only caps delegate runs; primary sessions
-    * (role == NULL) are unlimited regardless of the configured value. */
+   /* An explicit positive per-agent cap (or a positive per-role cap the delegate
+    * policy stamped on) bounds a delegate run to that many turns. */
    if (agent->max_turns > 0 && role)
       return agent->max_turns;
-   if (agent->max_turns == 0)
-      return 1000;
+   /* Default is INFINITE. max_turns <= 0 (the default -1) means "no per-agent/role
+    * cap"; a run is unbounded UNLESS an operator set a global iteration cap
+    * (GUI-settable max_iterations[_delegate], 0/unset = no cap). This is the
+    * "-1 = infinite, for everything, by default" contract. */
    config_t iter_cfg;
    config_load(&iter_cfg);
-   if (role)
-      return iter_cfg.max_iterations_delegate > 0 ? iter_cfg.max_iterations_delegate
-                                                  : CONFIG_DEFAULT_MAX_ITERATIONS_DELEGATE;
-   return iter_cfg.max_iterations > 0 ? iter_cfg.max_iterations : 1000;
+   int cap = role ? iter_cfg.max_iterations_delegate : iter_cfg.max_iterations;
+   return cap > 0 ? cap : INT_MAX;
 }

--- a/src/role_templates.c
+++ b/src/role_templates.c
@@ -673,6 +673,10 @@ int role_template_install_defaults(const char *dir)
       FILE *f = fopen(path, "w");
       if (!f)
          return -1;
+      /* Seed a frontmatter block carrying the per-role turn cap so it is visible
+       * and editable under the Personas tab (edited via PUT /v1/role_templates/
+       * <role>). -1 = INFINITE, the default for every role. */
+      fputs("---\nmax_turns: -1\n---\n\n", f);
       fputs(g_defaults[i].content, f);
       fputc('\n', f);
       fclose(f);

--- a/src/role_templates.c
+++ b/src/role_templates.c
@@ -436,6 +436,56 @@ static char *str_replace_all(const char *haystack, const char *needle, const cha
    return result;
 }
 
+/* Strip a leading YAML frontmatter block (---\n ... \n---) in place, so role
+ * metadata (e.g. max_turns) in a template file never leaks into the built prompt.
+ * A template without frontmatter is left untouched. */
+static void rt_strip_frontmatter(char *s)
+{
+   if (!s || strncmp(s, "---", 3) != 0)
+      return;
+   if (s[3] != '\n' && !(s[3] == '\r' && s[4] == '\n'))
+      return; /* opening --- must be its own line */
+   char *close = strstr(s + 3, "\n---");
+   if (!close)
+      return;
+   char *p = close + 4; /* past "\n---" */
+   while (*p == '-')
+      p++;
+   while (*p == '\r' || *p == '\n')
+      p++;
+   memmove(s, p, strlen(p) + 1);
+}
+
+/* Read an optional `max_turns:` from a role template's leading frontmatter.
+ * Returns the configured value, or -1 (INFINITE — the default cap for every role)
+ * when there is no template, no frontmatter, or no max_turns key. Reads the
+ * user-level template (config_default_dir()/role_templates/<role>.md) — the file
+ * the Personas GUI edits. */
+int role_template_max_turns(const char *role)
+{
+   if (!role || !role[0])
+      return -1;
+   char path[ROLE_TEMPLATE_PATH_MAX];
+   snprintf(path, sizeof(path), "%s/role_templates/%s.md", config_default_dir(), role);
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return -1;
+   char buf[4096];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   if (strncmp(buf, "---", 3) != 0)
+      return -1;
+   char *close = strstr(buf + 3, "\n---");
+   char *limit = close ? close : buf + n;
+   for (char *p = buf; p < limit; p++)
+   {
+      if ((p == buf || p[-1] == '\n') && strncmp(p, "max_turns:", 10) == 0)
+         return atoi(p + 10);
+   }
+   return -1;
+}
+
 char *role_template_build(const char *project_root, const char *role, const char *task,
                           const char *context)
 {
@@ -476,6 +526,10 @@ char *role_template_build(const char *project_root, const char *role, const char
 
    if (!raw)
       return NULL;
+
+   /* Drop any leading frontmatter (role metadata like max_turns) before it can
+    * reach the prompt. */
+   rt_strip_frontmatter(raw);
 
    /* Substitute {{TASK}} */
    const char *task_val = (task && task[0]) ? task : "(see context)";

--- a/src/server/delegate_role.c
+++ b/src/server/delegate_role.c
@@ -1,4 +1,5 @@
 #include "delegate_role.h"
+#include "role_templates.h" /* role_template_max_turns (per-role cap) */
 
 #include <string.h>
 
@@ -106,13 +107,14 @@ void delegate_apply_max_turns_override(agent_config_t *cfg, int max_turns)
 
 int delegate_default_max_turns_for_role(const char *role)
 {
-   /* Every role defaults to -1 = INFINITE. Per-role turn caps are no longer
-    * hardcoded here: they are operator configuration, edited per-role under the
-    * Personas tab (persona role config), so an unconfigured role is unbounded.
-    * A configured positive value flows through delegate_apply_max_turns_policy as
-    * a cap; -1 leaves the role unbounded. */
-   (void)role;
-   return -1;
+   /* The per-role turn cap is operator configuration: the `max_turns:` frontmatter
+    * of the role template (edited under the Personas tab), defaulting to -1 =
+    * INFINITE. A configured positive value flows through
+    * delegate_apply_max_turns_policy as a cap; -1 leaves the role unbounded. No
+    * hardcoded per-role caps. */
+   if (!role || !role[0])
+      return -1;
+   return role_template_max_turns(delegate_role_canonicalize(role));
 }
 
 int delegate_final_after_turns_for_role(const char *role)

--- a/src/server/delegate_role.c
+++ b/src/server/delegate_role.c
@@ -106,16 +106,12 @@ void delegate_apply_max_turns_override(agent_config_t *cfg, int max_turns)
 
 int delegate_default_max_turns_for_role(const char *role)
 {
-   if (!role || !role[0])
-      return -1;
-
-   role = delegate_role_canonicalize(role);
-   if (strcmp(role, "review") == 0)
-      return 20;
-   if (strcmp(role, "validate") == 0 || strcmp(role, "search") == 0)
-      return 12;
-   if (strcmp(role, "diagnose") == 0)
-      return 16;
+   /* Every role defaults to -1 = INFINITE. Per-role turn caps are no longer
+    * hardcoded here: they are operator configuration, edited per-role under the
+    * Personas tab (persona role config), so an unconfigured role is unbounded.
+    * A configured positive value flows through delegate_apply_max_turns_policy as
+    * a cap; -1 leaves the role unbounded. */
+   (void)role;
    return -1;
 }
 

--- a/src/server/delegate_run_phases.c
+++ b/src/server/delegate_run_phases.c
@@ -79,7 +79,7 @@ void delegate_record_exit_learning(const char *sid, const char *role, const agen
    dlm.tool_calls = result->tool_calls;
    dlm.success = (rc == 0);
    dlm.error = result->error[0] ? result->error : NULL;
-   dlm.max_turns_limit = max_turns > 0 ? max_turns : 30;
+   dlm.max_turns_limit = max_turns > 0 ? max_turns : 0; /* 0 = unlimited (default -1) */
    dlm.write_enforce_fired = dlm.error && strstr(dlm.error, "write_enforce") ? 1 : 0;
    dlm.had_writes = dlm.write_enforce_fired ? (strstr(dlm.error, "no Write or Edit") ? 0 : 1)
                                             : (rc == 0 ? 1 : 0);

--- a/src/server/server_http_config_routes.c
+++ b/src/server/server_http_config_routes.c
@@ -244,6 +244,10 @@ int route_role_template_show(const char *name, char *resp, int cap)
    cJSON *o = cJSON_CreateObject();
    cJSON_AddStringToObject(o, "role", name);
    cJSON_AddStringToObject(o, "content", raw);
+   /* Surface the per-role turn cap structurally so the Personas tab can render it
+    * as a dedicated field (edited via the `max_turns:` frontmatter in `content`).
+    * -1 = infinite, the default. */
+   cJSON_AddNumberToObject(o, "max_turns", role_template_max_turns(name));
    free(raw);
    return emit(resp, cap, o);
 }

--- a/src/tests/test_agent_max_turns.c
+++ b/src/tests/test_agent_max_turns.c
@@ -1,5 +1,6 @@
 /* test_agent_max_turns.c: unit tests for agent_resolve_max_turns(). */
 #include <assert.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -30,7 +31,7 @@ static void test_primary_ignores_agent_max_turns(void)
 {
    agent_t a = make_agent(30);
    int t = agent_resolve_max_turns(&a, NULL);
-   assert(t == 1000); /* falls through to primary default */
+   assert(t == INT_MAX); /* primary ignores the cap; infinite by default */
    printf("  PASS: primary ignores agent->max_turns\n");
 }
 
@@ -45,13 +46,13 @@ static void test_primary_uses_config_max_iterations(void)
    printf("  PASS: primary uses config max_iterations\n");
 }
 
-/* Primary session: max_turns == -1, no config → 1000 */
+/* Primary session: max_turns == -1, no config → INFINITE */
 static void test_primary_unlimited_default(void)
 {
    agent_t a = make_agent(-1);
    int t = agent_resolve_max_turns(&a, NULL);
-   assert(t == 1000);
-   printf("  PASS: primary unlimited default is 1000\n");
+   assert(t == INT_MAX);
+   printf("  PASS: primary unlimited default is infinite\n");
 }
 
 /* Delegate: agent->max_turns > 0 is honoured */
@@ -74,22 +75,22 @@ static void test_delegate_falls_back_to_config(void)
    printf("  PASS: delegate falls back to config max_iterations_delegate\n");
 }
 
-/* Delegate: max_turns unset, no config → compile-time default */
-static void test_delegate_compile_time_default(void)
+/* Delegate: max_turns unset (-1), no config cap → INFINITE (the default) */
+static void test_delegate_default_is_infinite(void)
 {
    agent_t a = make_agent(-1);
    int t = agent_resolve_max_turns(&a, "code");
-   assert(t == CONFIG_DEFAULT_MAX_ITERATIONS_DELEGATE);
-   printf("  PASS: delegate compile-time default is %d\n", CONFIG_DEFAULT_MAX_ITERATIONS_DELEGATE);
+   assert(t == INT_MAX);
+   printf("  PASS: delegate default (-1) is infinite\n");
 }
 
-/* max_turns == 0 means unlimited (1000 safety cap), regardless of role */
+/* max_turns <= 0 means infinite, regardless of role, unless a config cap is set. */
 static void test_zero_means_unlimited(void)
 {
    agent_t a = make_agent(0);
-   assert(agent_resolve_max_turns(&a, NULL) == 1000);
-   assert(agent_resolve_max_turns(&a, "code") == 1000);
-   printf("  PASS: max_turns==0 means unlimited (1000) for both primary and delegate\n");
+   assert(agent_resolve_max_turns(&a, NULL) == INT_MAX);
+   assert(agent_resolve_max_turns(&a, "code") == INT_MAX);
+   printf("  PASS: max_turns<=0 means infinite for both primary and delegate\n");
 }
 
 int main(void)
@@ -101,7 +102,7 @@ int main(void)
    test_primary_unlimited_default();
    test_delegate_honours_agent_max_turns();
    test_delegate_falls_back_to_config();
-   test_delegate_compile_time_default();
+   test_delegate_default_is_infinite();
    test_zero_means_unlimited();
 
    printf("test_agent_max_turns: all tests passed\n");

--- a/src/tests/test_role_templates.c
+++ b/src/tests/test_role_templates.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include "../headers/role_templates.h"
+#include "../headers/config.h" /* config_default_dir */
 
 /* --- Helpers --- */
 
@@ -370,6 +371,36 @@ static void test_write_read_delete(void)
    assert(role_template_delete("triage") == 0);
 }
 
+static void test_role_max_turns_frontmatter(void)
+{
+   char dir[512];
+   snprintf(dir, sizeof(dir), "%s/role_templates", config_default_dir());
+   char mkcmd[600];
+   snprintf(mkcmd, sizeof(mkcmd), "mkdir -p '%s'", dir);
+   assert(system(mkcmd) == 0);
+
+   /* A max_turns frontmatter is read, and stripped from the built prompt. */
+   char path[600];
+   snprintf(path, sizeof(path), "%s/capped.md", dir);
+   write_file(path, "---\nmax_turns: 7\n---\n\nYou are a capped delegate. {{TASK}}\n");
+   assert(role_template_max_turns("capped") == 7);
+   char *built = role_template_build(NULL, "capped", "do it", NULL);
+   assert(built);
+   assert(strstr(built, "max_turns") == NULL); /* frontmatter stripped */
+   assert(strstr(built, "---") == NULL);
+   assert(strstr(built, "You are a capped delegate. do it") != NULL);
+   free(built);
+
+   /* No frontmatter => -1 (INFINITE, the default). */
+   snprintf(path, sizeof(path), "%s/plain.md", dir);
+   write_file(path, "You are a plain delegate. {{TASK}}\n");
+   assert(role_template_max_turns("plain") == -1);
+
+   /* Unknown role => -1. */
+   assert(role_template_max_turns("nonexistent_role_zzz") == -1);
+   printf("  test_role_max_turns_frontmatter: ok\n");
+}
+
 int main(void)
 {
    /* Isolate config_default_dir() so write/delete and user-dir scans do not
@@ -397,6 +428,7 @@ int main(void)
    test_install_defaults();
    test_install_defaults_null_dir();
    test_write_read_delete();
+   test_role_max_turns_frontmatter();
    printf("role_templates: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Problem
Delegates were silently turn-capped even when nothing was configured. `-1` (an agent that "declared nothing") did **not** mean infinite:
- `agent_resolve_max_turns` treated `max_turns <= 0` as a finite fallback (`0`→1000, `-1`→`CONFIG_DEFAULT_MAX_ITERATIONS_DELEGATE`=25).
- `delegate_default_max_turns_for_role` hardcoded per-role caps (review=20, validate/search=12, diagnose=16) and stamped them onto any `-1` agent via `delegate_apply_max_turns_policy`.

So e.g. a review delegate on an agent with `max_turns=-1` ran capped at 20.

## Fix — `-1` = infinite, the default for everything
- `agent_resolve_max_turns`: `max_turns <= 0` (default `-1`) ⇒ **INT_MAX (infinite)** unless an operator set a global cap (`max_iterations` / `max_iterations_delegate`, both already GUI-settable config fields).
- `delegate_default_max_turns_for_role`: returns `-1` for **every** role. Per-role caps are no longer hardcoded — they're operator configuration (to be edited per-role under the Personas tab).
- `delegate_run_phases` telemetry: an unlimited run reports `0`, not a fake `30`.

## Follow-on (same feature, separate PRs)
- Per-role `max_turns` in the persona/role config + the Personas GUI editing surface (default `-1`).
- (Provisioning verified: default personas + role templates ARE seeded on server startup — confirmed on the .254 deployment — so this is display/edit work, not a seeding fix.)