### PR TITLE
fix(server): enforce bootstrap /v1 bearer rotation on first use

### DIFF
--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -8,6 +8,7 @@
 #include "cli_remote.h"
 #include "aimee_client.h"
 #include "aimee_home.h"
+#include "config.h" /* AIMEE_BOOTSTRAP_BEARER */
 #include "cJSON.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -97,14 +98,31 @@ static int read_remote_conf(char *url, size_t url_sz, char *token, size_t token_
    return url[0] != '\0';
 }
 
+/* remote_enroll is defined below; forward-declare for the load-time auto-enroll. */
+static int remote_enroll(const char *url, char *out, size_t out_sz, int json_output);
+
 void cli_remote_load_persisted(void)
 {
    /* A --server flag or AIMEE_SERVER_URL already wins; don't override it. */
    if (aimee_client_remote_active(NULL, 0))
       return;
    char url[512], token[256];
-   if (read_remote_conf(url, sizeof(url), token, sizeof(token)) && url[0])
-      aimee_client_set_remote(url, token[0] ? token : NULL);
+   if (!read_remote_conf(url, sizeof(url), token, sizeof(token)) || !url[0])
+      return;
+   aimee_client_set_remote(url, token[0] ? token : NULL);
+
+   /* Trust-on-first-use: if the persisted token is still the one-time bootstrap
+    * bearer, rotate it to a strong per-deployment token and persist it NOW —
+    * before any command transacts real work — so the pre-set default is never
+    * used for a real operation. The server enforces the same rule (bootstrap can
+    * only call rotate_bearer), so this keeps the client seamless. Best-effort +
+    * quiet; on failure the bootstrap stays and the next invocation retries. Only
+    * runs while the bootstrap is held, so the cost is one-time. */
+   if (strcmp(token, AIMEE_BOOTSTRAP_BEARER) == 0)
+   {
+      char strong[256];
+      remote_enroll(url, strong, sizeof(strong), 1 /* quiet */);
+   }
 }
 
 static void remote_ca_path(char *out, size_t out_sz)
@@ -158,11 +176,9 @@ static int remote_pin_cert(const char *url, int json_output)
    return 0;
 }
 
-/* The well-known /v1 bearer baked into the aimee-server image. It is a ONE-TIME
- * bootstrap: the first client to connect with it calls api.rotate_bearer to mint
- * a strong per-deployment token, which the server then requires exclusively (the
- * bootstrap stops working the instant it is rotated). See docs/COMMANDS.md. */
-#define AIMEE_BOOTSTRAP_BEARER "aimee-local-dev"
+/* AIMEE_BOOTSTRAP_BEARER (the well-known one-time bootstrap /v1 bearer) is shared
+ * from config.h — the server enforces that it can only rotate itself. See
+ * docs/COMMANDS.md. */
 
 /* Enrollment: over the already-pinned/verified remote (authenticated with the
  * current — normally bootstrap — bearer), ask the server to rotate to a fresh

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -23,6 +23,13 @@
 /* Server execution pool defaults */
 #define CONFIG_DEFAULT_BACKGROUND_THREADS 2
 #define CONFIG_DEFAULT_SESSION_THREADS    4
+/* The well-known /v1 bearer baked into the aimee-server image — a ONE-TIME
+ * bootstrap, never a standing credential. While the live listener bearer still
+ * equals this value the server refuses every TCP /v1 route except
+ * POST /v1/api/rotate_bearer, so the pre-set token can only mint the strong
+ * per-deployment bearer and never perform a real operation. Shared by the server
+ * (enforcement) and the thin client (auto-enroll). */
+#define AIMEE_BOOTSTRAP_BEARER "aimee-local-dev"
 /* Raised from 2 -> 4 now that DB2 connections are bounded by the connection pool
  * (db2_connection_pool_size), not 1:1 with worker threads. */
 #define CONFIG_DEFAULT_KB_WORKER_THREADS 4

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -53,6 +53,16 @@ extern "C"
    int server_http_authorize(int is_tcp, const char *bearer_cfg, const char *auth_header,
                              const char *api_key_header, int has_session_key);
 
+   /* Trust-on-first-use gate (pure — unit-testable). Returns 1 when an authorized
+    * TCP request must be REFUSED because the live listener bearer is still the
+    * one-time bootstrap default (AIMEE_BOOTSTRAP_BEARER) and the route is not the
+    * rotation endpoint — so the pre-set bearer can only mint the strong token and
+    * never perform a real operation. Returns 0 (allow) for UDS, once the bearer
+    * has been rotated (live_bearer != bootstrap), for the rotate_bearer route
+    * itself, or when the operator pinned AIMEE_API_BEARER_TOKEN (TOFU opt-out). */
+   int server_http_bootstrap_gate(int is_tcp, const char *live_bearer, const char *method,
+                                  const char *path);
+
    /* Fixed-window per-bearer rate limiter (pure — unit-testable). State is a
     * single 60s window the caller owns. limit_per_min <= 0 disables limiting
     * (always returns 0). `now` is epoch seconds. Returns 0 when the request is

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -264,6 +264,19 @@ int server_http_authorize(int is_tcp, const char *bearer_cfg, const char *auth_h
    return 0;
 }
 
+int server_http_bootstrap_gate(int is_tcp, const char *live_bearer, const char *method,
+                               const char *path)
+{
+   if (!is_tcp || !live_bearer || strcmp(live_bearer, AIMEE_BOOTSTRAP_BEARER) != 0)
+      return 0; /* UDS, or already rotated to a strong token -> gate off */
+   const char *pin = getenv("AIMEE_API_BEARER_TOKEN");
+   if (pin && pin[0])
+      return 0; /* operator pinned the bearer -> opted out of TOFU */
+   if (method && path && strcmp(method, "POST") == 0 && strcmp(path, "/v1/api/rotate_bearer") == 0)
+      return 0; /* the one route the bootstrap may reach: mint the strong token */
+   return 1;    /* refuse: enrollment required */
+}
+
 #define SHTTP_RATE_WINDOW_SECS 60
 
 int server_http_rate_check(server_http_rate_state_t *st, int limit_per_min, long now)
@@ -1463,6 +1476,26 @@ void handle_conn(int fd, int is_tcp)
                                        "configured bearer token\",\"type\":\"server_error\"}}";
          send_response(fd, az, msg, request_id);
          LOG_INFO("server.http", "%s %s -> %d req_id=%s", method, path, az, request_id);
+         return;
+      }
+
+      /* Trust-on-first-use enforcement: while the live /v1 bearer is still the
+       * well-known image-seeded bootstrap, the ONLY route permitted on the TCP
+       * listener is rotating it to a strong per-deployment token. Auth already
+       * passed, so the caller presented the bootstrap; refuse every other route
+       * so the pre-set default can never perform a real operation — it exists
+       * solely to mint the real bearer, after which g_bearer no longer equals the
+       * bootstrap and this gate self-disables. Closes the "a network-published
+       * server keeps accepting the public default bearer" hole. */
+      if (server_http_bootstrap_gate(is_tcp, g_bearer, method, path))
+      {
+         send_response(fd, 401,
+                       "{\"error\":{\"message\":\"the one-time bootstrap bearer must be rotated "
+                       "before use: POST /v1/api/rotate_bearer (aimee remote enroll)\",\"type\":"
+                       "\"enrollment_required\"}}",
+                       request_id);
+         LOG_INFO("server.http", "%s %s -> 401 (enrollment_required) req_id=%s", method, path,
+                  request_id);
          return;
       }
    }

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -544,6 +544,27 @@ int main(void)
       assert(server_http_authorize(0, "secret", NULL, NULL, 1) == 0);
    }
 
+   /* --- server_http_bootstrap_gate: the one-time bootstrap bearer may ONLY
+    *     rotate itself; every other TCP route is refused until it is rotated. --- */
+   {
+      unsetenv("AIMEE_API_BEARER_TOKEN"); /* TOFU active */
+      const char *BOOT = "aimee-local-dev";
+      /* Bootstrap still live: real routes refused (1), rotate_bearer allowed (0). */
+      assert(server_http_bootstrap_gate(1, BOOT, "GET", "/v1/config") == 1);
+      assert(server_http_bootstrap_gate(1, BOOT, "POST", "/v1/config/set") == 1);
+      assert(server_http_bootstrap_gate(1, BOOT, "POST", "/v1/api/rotate_bearer") == 0);
+      /* GET on the rotate path is not the rotate op -> still refused. */
+      assert(server_http_bootstrap_gate(1, BOOT, "GET", "/v1/api/rotate_bearer") == 1);
+      /* UDS is exempt (local trust). */
+      assert(server_http_bootstrap_gate(0, BOOT, "GET", "/v1/config") == 0);
+      /* Once rotated to a strong bearer, the gate is off for every route. */
+      assert(server_http_bootstrap_gate(1, "deadbeef-strong-token", "GET", "/v1/config") == 0);
+      /* Operator-pinned bearer opts out of TOFU even if it equals the bootstrap. */
+      setenv("AIMEE_API_BEARER_TOKEN", BOOT, 1);
+      assert(server_http_bootstrap_gate(1, BOOT, "GET", "/v1/config") == 0);
+      unsetenv("AIMEE_API_BEARER_TOKEN");
+   }
+
    /* --- typed SSE framing: embedded newlines become repeated data: lines --- */
    {
       char frame[256];


### PR DESCRIPTION
## The hole
The image-seeded `aimee-local-dev` /v1 bearer was a **standing credential**. TOFU rotation was purely client-driven (only `aimee remote set/enroll` ever called `rotate_bearer`), so any client — or anyone on the network of a published, `remote_writes=full` deploy — could keep using the public default for full control. The front door stayed open after init.

## The fix (server-enforced)
While the live listener bearer is still the bootstrap default, the **only** TCP `/v1` route permitted is `POST /v1/api/rotate_bearer` — every other route returns `401 enrollment_required`. So the pre-set token can **never perform a real operation**; it exists solely to mint the strong per-deployment bearer, after which `g_bearer` no longer equals the bootstrap and the gate **self-disables**. Operator-pinned `AIMEE_API_BEARER_TOKEN` opts out.

- **`server_http.c`** — `server_http_bootstrap_gate()` (pure, unit-tested) + request-path enforcement.
- **`config.h`** — share `AIMEE_BOOTSTRAP_BEARER` so server and client agree.
- **`cli_remote.c`** — on startup, if the persisted token is still the bootstrap, auto-rotate + persist **before any command runs**, so the client stays seamless against the enforcing server (no manual enroll).
- **`test_server_http.c`** — gate truth table.

## Validated end-to-end (local server)
| Step | Result |
|---|---|
| bootstrap → real op (`GET /v1/config`) | **401 enrollment_required** |
| bootstrap → `POST /v1/api/rotate_bearer` | **200 + strong 64-hex token** |
| strong token → real op | **200** |
| bootstrap after rotation | **401 (dead)** |
| `aimee config get` holding bootstrap | **auto-rotated transparently**, remote.conf now holds the strong token, command succeeded |

`server`+`kb`+`aimee` build clean under `-Werror`; `unit-test-server-http` passes.

## Rollout note
After this ships and `.254` redeploys, the `.254` bearer is still `aimee-local-dev` on disk. On the **first** connect it will rotate to a strong token (server-enforced; updated clients adopt automatically). Any client on an **old** binary using `aimee-local-dev` will get `enrollment_required` and must update or run `aimee remote enroll`. Recovery is always available host-side (read the rotated token from `aimee.yaml`, or pin `AIMEE_API_BEARER_TOKEN`).