### PR TITLE
Promote testing → main: enforce bootstrap /v1 bearer rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,12 @@ jobs:
           echo "::endgroup::"
       - name: Install clang-format
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q clang-format-19
       - name: Check formatting
         run: cd src && make lint
@@ -75,7 +80,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -115,7 +125,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -163,7 +178,12 @@ jobs:
             "$img"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev postgresql-client
@@ -192,7 +212,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -394,7 +419,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -419,7 +449,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -517,7 +552,12 @@ jobs:
           df -h / | tail -1
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make git \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libpq-dev
       - name: Build + run the opt-in tree-sitter test

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -197,7 +197,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`ingress`** — _Ingress (proxy frontends) behavior._ Keys: `audit_async`, `trusted_proxy_secret`, `usage_accounting_enabled`
 - **`integrity`** — _Integrity gate._ Keys: `dry_run`, `enabled`
 - **`intelligence`** — _Intelligence subsystems (bandit, planner, ranking, reasoning) + their external commands; most children are nested objects._ Keys: `bandit`, `bandit_optimize_command`, `calibrate`, `constraint_solver_command`, `demotion`, `kb`, `planner`, `planner_search_command`, `ranker_fuse_command`, `ranking`, `reasoning`, `reasoning_datalog_command`, `synthesize`
-- **`kb`** — _Knowledge-base client + curator / evidence / maintenance / mining (nested objects)._ Keys: `api`, `background_ingest`, `code_hybrid`, `connection_pool_size`, `connection_workers`, `curator`, `evidence`, `maintenance`, `mining`, `reembed_on_dim_change`, `search_max_results`, `worker_count`
+- **`kb`** — _Knowledge-base client + curator / evidence / maintenance / mining (nested objects)._ Keys: `api`, `background_ingest`, `code_hybrid`, `connection_pool_size`, `connection_workers`, `curator`, `evidence`, `maintenance`, `mining`, `reembed_on_dim_change`, `search_max_results`, `typed_facts`, `worker_count`
 - **`learning`** — _Learning subsystem (router, implicit, embed, synthesize; nested objects)._ Keys: `embed`, `implicit`, `router`, `synthesize`
 - **`lsp_servers`** — _LSP server definitions (array of objects)._ Keys: `args`, `command`, `extensions`, `name`
 - **`mcp`** — _MCP integration (e.g. OSV)._ Keys: `osv`

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -236,7 +236,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 145 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 144 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -262,7 +262,6 @@ The binaries read 145 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_API_ENDPOINT` | Override the `/v1` API endpoint used by the client RPC layer. |
 | `AIMEE_ATTACH_ID` | Presence attach id used when joining an existing session. |
 | `AIMEE_EFFORT` | Reasoning-effort hint for the session/model. |
-| `AIMEE_GUARD` | Attention-guard control; set to bypass the guard hook. |
 | `AIMEE_HOOK_CLIENT` | Identifies the calling hook client (e.g. claude/codex) for hook routing. |
 | `AIMEE_MODE` | Operating-mode override (e.g. interactive / autonomous). |
 | `AIMEE_MODEL` | Override the primary model for the session. |

--- a/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
+++ b/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
@@ -265,20 +265,27 @@ override exposed in §8, never a prerequisite.
 
 The KB console today is a single `/v1/console/overview` (`kb_http_console.c`). Add
 a **Typed Facts** panel, KB-served and backed entirely by KB config —
-aimee-server renders and knows nothing:
+aimee-server renders and knows nothing. Scoped to a shippable **core** now, with a
+richer surface deferred:
 
-- **Observe.** Durable vs provisional facts; the live ontology (seed + learned);
-  promotion candidates with their supporting evidence; drain throughput and lag.
-- **Fine-tune.** Promotion threshold, confidence floor, ontology extensions and
-  relation aliases.
-- **Alter behaviour.** Enable/disable; reconciliation mode
-  (`constrain-extractor` / `auto-promote` / `both` / `off`); ontology auto-growth
-  on/off.
-- **Act.** Promote, map, or reject a provisional relation by hand.
+**Core (this PR):**
+- **Observe** (`GET /v1/console/typed_facts`) — the KB-owned config (enabled,
+  auto_promote, promote_threshold) plus the provisional-relation promotion review
+  queue (each candidate's observation count, ready-flag, status).
+- **Alter behaviour + fine-tune** (`POST /v1/console/typed_facts/config`) —
+  `enabled`, `auto_promote`, `promote_threshold`, round-tripped through
+  `kb.typed_facts.*` and equally settable headless (same keys, no GUI required).
+- **Act** (`POST /v1/console/typed_facts/relation`) — promote / map / reject a
+  provisional relation by hand (the shipped ontology-evolution verbs), with the
+  relation/target validated to the canonical `rel_type` form at the route boundary.
 
-Every control round-trips through `kb.typed_facts.*` KB config and is equally
-settable headless (same keys, no GUI required). aimee-server is not in the loop
-for any of it.
+**Deferred (follow-on PR):** durable-vs-provisional fact counts, the live ontology
+listing + per-candidate supporting evidence, and drain throughput/lag on the
+observe surface; and the additional `kb.typed_facts.*` knobs (reconciliation mode,
+confidence floor, ontology extensions/aliases, ontology auto-growth). These extend
+the same routes and config section; nothing about aimee-server changes.
+
+aimee-server is not in the loop for any of it.
 
 ## Acceptance criteria
 
@@ -307,9 +314,11 @@ for any of it.
    fact commits with a canonical (or auto-promoted) relation as an **active** edge
    and is returned by recall — proven end-to-end on the .254 stack, not merely
    "N facts logged." (This is the exact failure §7 fixes.)
-9. **KB console.** The Typed Facts panel observes durable/provisional facts and the
-   ontology, and its fine-tune / alter / act controls round-trip through
-   `kb.typed_facts.*`; aimee-server has no equivalent surface.
+9. **KB console (core).** The Typed Facts panel observes the KB-owned config +
+   promotion review queue, and its enable / auto_promote / promote_threshold / act
+   (approve, map, reject) controls round-trip through `kb.typed_facts.*`;
+   aimee-server has no equivalent surface. (Richer observe metrics + the extra
+   knobs are the deferred follow-on in §8.)
 
 ## Explicitly out of scope / does not re-propose
 

--- a/frontend/src/pages/Personas.tsx
+++ b/frontend/src/pages/Personas.tsx
@@ -67,6 +67,21 @@ const ta: React.CSSProperties = {
 };
 const nameOk = (s: string) => /^[a-z0-9][a-z0-9_-]*$/i.test(s);
 
+/* Upsert `max_turns` into a role template's YAML frontmatter so the dedicated
+ * field and the raw body stay consistent on save. -1 = infinite. */
+function withMaxTurns(body: string, mt: number): string {
+  const fm = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+  const m = body.match(fm);
+  if (m) {
+    let inner = m[1];
+    inner = /^max_turns:.*$/m.test(inner)
+      ? inner.replace(/^max_turns:.*$/m, `max_turns: ${mt}`)
+      : `max_turns: ${mt}\n${inner}`;
+    return body.replace(fm, `---\n${inner}\n---\n\n`);
+  }
+  return `---\nmax_turns: ${mt}\n---\n\n${body}`;
+}
+
 type Status = { kind: "ok" | "err"; msg: string } | null;
 
 export default function Personas() {
@@ -76,6 +91,7 @@ export default function Personas() {
   const [roles, setRoles] = useState<string[]>([]);
   const [roleSel, setRoleSel] = useState<string | null>(null);
   const [roleBody, setRoleBody] = useState("");
+  const [roleMaxTurns, setRoleMaxTurns] = useState<number>(-1); // -1 = infinite
 
   const refreshRoles = useCallback(() => {
     getJSON<{ role_templates?: string[] }>("/api/roles")
@@ -86,15 +102,19 @@ export default function Personas() {
   const openRole = useCallback((name: string) => {
     setRoleSel(name);
     setRoleBody("");
-    getJSON<{ content?: string }>(`/api/roles/${encodeURIComponent(name)}`)
-      .then((d) => setRoleBody(d.content || ""))
+    setRoleMaxTurns(-1);
+    getJSON<{ content?: string; max_turns?: number }>(`/api/roles/${encodeURIComponent(name)}`)
+      .then((d) => {
+        setRoleBody(d.content || "");
+        setRoleMaxTurns(typeof d.max_turns === "number" ? d.max_turns : -1);
+      })
       .catch(() => setRoleBody(""));
   }, []);
 
   const saveRole = async () => {
     if (!roleSel) return;
     const { status: st } = await sendJSON("PUT", `/api/roles/${encodeURIComponent(roleSel)}`, {
-      content: roleBody,
+      content: withMaxTurns(roleBody, roleMaxTurns),
     });
     if (st >= 200 && st < 300) {
       setStatus({ kind: "ok", msg: `role “${roleSel}” saved` });
@@ -111,6 +131,7 @@ export default function Personas() {
     }
     setRoleSel(name);
     setRoleBody(`You are a ${name} delegate. Your mission is to …\n`);
+    setRoleMaxTurns(-1);
   };
 
   const deleteRole = async () => {
@@ -237,6 +258,20 @@ export default function Personas() {
                 {roleSel} — what it does (delegate system-prompt template)
               </label>
               <textarea rows={12} style={ta} value={roleBody} onChange={(e) => setRoleBody(e.target.value)} />
+              <label style={{ ...lbl, marginTop: 8 }}>
+                Max turns per delegate run (−1 = infinite, the default)
+              </label>
+              <input
+                type="number"
+                min={-1}
+                step={1}
+                style={{ ...ta, height: "auto" }}
+                value={roleMaxTurns}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10);
+                  setRoleMaxTurns(Number.isFinite(v) ? v : -1);
+                }}
+              />
               <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
                 <button onClick={saveRole} style={btn}>
                   Save role

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -506,7 +506,6 @@ ENV_DESC = {
     "AIMEE_PROFILE": ("Client & session", "Active working-profile name."),
     "AIMEE_ACTIVE_TOOLSET": ("Client & session", "Active toolset (tool allowlist) for the session."),
     "AIMEE_SESSION_START_VERBOSE": ("Client & session", "Verbose logging during session start."),
-    "AIMEE_GUARD": ("Client & session", "Attention-guard control; set to bypass the guard hook."),
     # Server runtime
     "AIMEE_SERVER_HTTP_BIND": ("Server runtime", "TCP bind address for the server `/v1` HTTP listener (else UDS-only)."),
     "AIMEE_SERVER_STARTUP_FD": ("Server runtime", "Inherited fd for startup-readiness signalling (service launch)."),

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -10,8 +10,9 @@
  * set to a positive cap, in which case a session may run that many recursive
  * raw scans before further ones are redirected toward Aimee's indexed
  * exploration tools. With no cap configured (the default, and what a thin-client
- * host with no aimee.yaml sees) raw scans are never blocked. AIMEE_GUARD=0
- * disables the guard entirely.
+ * host with no aimee.yaml sees) raw scans are never blocked. The guard has no
+ * env-var off switch: disabling it is a deliberate operator config action
+ * (require_session_worktree: false), never something the guarded agent can do.
  */
 #include "cli_attention_guard.h"
 #include "cli_session_start.h" /* read_stdin */
@@ -563,14 +564,19 @@ static void attn_lexical_normalize(const char *path, char *out, size_t out_n)
    }
 }
 
-/* Returns 1 iff `norm` (an already lexically-normalized path) is inside an
- * aimee-managed worktree. Matches ONLY the canonical managed location
- * "/.aimee/worktrees/" — deliberately NOT the looser "/.aimee-" prefix that
- * is_aimee_worktree_path() also accepts, which would false-match unrelated
- * dirs like "/home/u/.aimee-notes/...". */
+/* Returns 1 iff `norm` (an already lexically-normalized path) is inside a
+ * managed session worktree. Matches the two canonical managed locations:
+ *   "/.aimee/worktrees/"  — aimee's own launcher + delegate worktrees
+ *   "/.claude/worktrees/" — Claude Code's native worktrees (EnterWorktree)
+ * Both are isolated worktrees on a branch off the default branch — the exact
+ * isolation this guard requires — so a Claude Code session working in its own
+ * worktree is honoured, not blocked. Deliberately the full "/worktrees/" path,
+ * NOT the looser "/.aimee-" / "/.claude" prefixes, which would false-match
+ * unrelated dirs like "/home/u/.aimee-notes/..." or "~/.claude/". */
 static int attn_path_in_managed_worktree(const char *norm)
 {
-   return norm && strstr(norm, "/.aimee/worktrees/") != NULL;
+   return norm && (strstr(norm, "/.aimee/worktrees/") != NULL ||
+                   strstr(norm, "/.claude/worktrees/") != NULL);
 }
 
 /* Pure decision for the session-isolation guard (testable in isolation).
@@ -600,10 +606,11 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
 
 int handle_attention_guard(void)
 {
-   const char *bypass = getenv("AIMEE_GUARD");
-   if (bypass && strcmp(bypass, "0") == 0)
-      return 0;
-
+   /* No env-var bypass. The guard must not be disableable by the agent it
+    * guards — an LLM can trivially set an env var on any command, so a would-be
+    * bypass has to be a deliberate OPERATOR action in config
+    * (require_session_worktree: false / ingress_max_raw_scans), not an env var.
+    * (Removed the former AIMEE_GUARD=0 escape hatch.) */
    char *stdin_data = read_stdin();
    cJSON *hook = stdin_data ? cJSON_Parse(stdin_data) : NULL;
    if (!hook)
@@ -636,12 +643,13 @@ int handle_attention_guard(void)
       if (attn_session_isolation_blocked(op, fp, cwd))
       {
          fprintf(stderr,
-                 "aimee attention-guard: refusing a mutating op outside an aimee session "
-                 "worktree. This session is operating in '%s', which is not an aimee-managed "
-                 "worktree (.aimee/worktrees/...). aimee requires each mutating session to run "
-                 "in an isolated worktree+branch off the default branch; provision one with "
-                 "`aimee session-start` (or restart the client so its SessionStart hook does). "
-                 "Set require_session_worktree:false in aimee.yaml or AIMEE_GUARD=0 to bypass.\n",
+                 "aimee attention-guard: refusing a mutating op outside a session worktree. "
+                 "This session is operating in '%s', which is not a managed worktree "
+                 "(.aimee/worktrees/... or .claude/worktrees/...). aimee requires each mutating "
+                 "session to run in an isolated worktree+branch off the default branch: create "
+                 "one (Claude Code: EnterWorktree; aimee: launch `aimee`, which materializes a "
+                 "worktree and chdirs into it). An operator may set require_session_worktree: "
+                 "false in aimee.yaml to disable this — there is no env-var bypass.\n",
                  cwd[0] ? cwd : "(unknown cwd)");
          cJSON_Delete(hook);
          free(stdin_data);
@@ -671,7 +679,7 @@ int handle_attention_guard(void)
                     "aimee attention-guard: this session has hit its raw-scan cap (%d). Aimee "
                     "indexes this repo — explore through it instead: find_symbol, "
                     "ast_grep_search, search_graph, or get_context_block. Raise "
-                    "ingress_max_raw_scans (or set AIMEE_GUARD=0) to bypass.\n",
+                    "ingress_max_raw_scans in aimee.yaml to raise or lift the cap.\n",
                     ingress_max_raw_scans);
             exit_code = 2;
          }

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -465,20 +465,25 @@ static int attn_parse_require_session_worktree(const char *buf, int *out)
 
 static int attn_config_require_session_worktree(void)
 {
+   /* Default ON: session-worktree isolation is required unless an operator
+    * explicitly sets `require_session_worktree: false`. Two aimee sessions
+    * sharing one checkout collide on a single git HEAD — one session's
+    * `git checkout <branch>` moves the branch the other is mutating, cross-
+    * contaminating commits. Failing closed to isolation (each session in its own
+    * `.aimee/worktrees/...` worktree+branch) is the only safe default. */
    const char *home = aimee_home();
    if (!home || !home[0])
-      return 0;
+      return 1; /* no resolvable home -> fail closed to isolation */
 
    char path[1024];
    snprintf(path, sizeof(path), "%s/aimee.yaml", home);
 
    char *buf = NULL;
    if (!attn_read_file(path, &buf))
-      return 0;
+      return 1; /* no config file -> default ON */
 
-   int value = 0;
-   if (!attn_parse_require_session_worktree(buf, &value))
-      value = 0;
+   int value = 1; /* default ON; only an explicit key overrides */
+   (void)attn_parse_require_session_worktree(buf, &value);
    free(buf);
    return value;
 }

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -8,6 +8,7 @@
 #include "cli_remote.h"
 #include "aimee_client.h"
 #include "aimee_home.h"
+#include "config.h" /* AIMEE_BOOTSTRAP_BEARER */
 #include "cJSON.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -97,14 +98,31 @@ static int read_remote_conf(char *url, size_t url_sz, char *token, size_t token_
    return url[0] != '\0';
 }
 
+/* remote_enroll is defined below; forward-declare for the load-time auto-enroll. */
+static int remote_enroll(const char *url, char *out, size_t out_sz, int json_output);
+
 void cli_remote_load_persisted(void)
 {
    /* A --server flag or AIMEE_SERVER_URL already wins; don't override it. */
    if (aimee_client_remote_active(NULL, 0))
       return;
    char url[512], token[256];
-   if (read_remote_conf(url, sizeof(url), token, sizeof(token)) && url[0])
-      aimee_client_set_remote(url, token[0] ? token : NULL);
+   if (!read_remote_conf(url, sizeof(url), token, sizeof(token)) || !url[0])
+      return;
+   aimee_client_set_remote(url, token[0] ? token : NULL);
+
+   /* Trust-on-first-use: if the persisted token is still the one-time bootstrap
+    * bearer, rotate it to a strong per-deployment token and persist it NOW —
+    * before any command transacts real work — so the pre-set default is never
+    * used for a real operation. The server enforces the same rule (bootstrap can
+    * only call rotate_bearer), so this keeps the client seamless. Best-effort +
+    * quiet; on failure the bootstrap stays and the next invocation retries. Only
+    * runs while the bootstrap is held, so the cost is one-time. */
+   if (strcmp(token, AIMEE_BOOTSTRAP_BEARER) == 0)
+   {
+      char strong[256];
+      remote_enroll(url, strong, sizeof(strong), 1 /* quiet */);
+   }
 }
 
 static void remote_ca_path(char *out, size_t out_sz)
@@ -158,11 +176,9 @@ static int remote_pin_cert(const char *url, int json_output)
    return 0;
 }
 
-/* The well-known /v1 bearer baked into the aimee-server image. It is a ONE-TIME
- * bootstrap: the first client to connect with it calls api.rotate_bearer to mint
- * a strong per-deployment token, which the server then requires exclusively (the
- * bootstrap stops working the instant it is rotated). See docs/COMMANDS.md. */
-#define AIMEE_BOOTSTRAP_BEARER "aimee-local-dev"
+/* AIMEE_BOOTSTRAP_BEARER (the well-known one-time bootstrap /v1 bearer) is shared
+ * from config.h — the server enforces that it can only rotate itself. See
+ * docs/COMMANDS.md. */
 
 /* Enrollment: over the already-pinned/verified remote (authenticated with the
  * current — normally bootstrap — bearer), ask the server to rotate to a fresh

--- a/src/config.c
+++ b/src/config.c
@@ -700,7 +700,11 @@ static void config_set_defaults(config_t *cfg)
     * per-result model-visible tool-output cap (see agent_tool_output_cap()). */
    cfg->tool_output_max_bytes = 0;
    cfg->ingress_compress_min_chars = 80;
-   cfg->require_session_worktree = 0;
+   /* Default ON: each mutating session must run in its own isolated worktree+branch
+    * (.aimee/worktrees/...), never the shared primary checkout. Concurrent aimee
+    * sessions sharing one checkout collide on a single git HEAD. Explicit
+    * `require_session_worktree: false` bypasses (see cli_attention_guard.c). */
+   cfg->require_session_worktree = 1;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
     * gate (make virtual-context-eval-check) passes on synthetic and real
     * tool-heavy session fixtures. Rollback: set session.virtual_context.enabled

--- a/src/config.c
+++ b/src/config.c
@@ -866,7 +866,14 @@ static int model_is_cpu_only(const char *model)
 static void config_apply_inference_backend_defaults(config_t *cfg, const cJSON *root)
 {
    int accel = !model_is_cpu_only(cfg->kb_curator_provider_model);
-   if (!cJSON_GetObjectItemCaseSensitive((cJSON *)root, "typed_facts_enabled"))
+   /* typed_facts_enabled is now KB-owned (kb.typed_facts.enabled). Only apply the
+    * accel-derived default when it is set by NEITHER the KB section nor the legacy
+    * root key — otherwise this would clobber the operator's explicit value. */
+   const cJSON *kb = cJSON_GetObjectItemCaseSensitive((cJSON *)root, "kb");
+   const cJSON *kb_tf = kb ? cJSON_GetObjectItemCaseSensitive(kb, "typed_facts") : NULL;
+   int tf_explicit = cJSON_GetObjectItemCaseSensitive((cJSON *)root, "typed_facts_enabled") ||
+                     (kb_tf && cJSON_GetObjectItemCaseSensitive(kb_tf, "enabled"));
+   if (!tf_explicit)
       cfg->typed_facts_enabled = accel;
    if (!cJSON_GetObjectItemCaseSensitive((cJSON *)root, "memory_rewrite") &&
        !cJSON_GetObjectItemCaseSensitive((cJSON *)root, "memory_rewrite_enabled"))

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -507,7 +507,8 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
          /* KB-owned master gate — the sole persisted home for typed_facts_enabled
           * (the legacy root-level emit is removed in config_save.c). */
          cJSON_AddBoolToObject(tf, "enabled", cfg->typed_facts_enabled ? 1 : 0);
-         cJSON_AddBoolToObject(tf, "auto_promote", cfg->kb_typed_facts_auto_promote_enabled ? 1 : 0);
+         cJSON_AddBoolToObject(tf, "auto_promote",
+                               cfg->kb_typed_facts_auto_promote_enabled ? 1 : 0);
          if (cfg->kb_typed_facts_promote_threshold != 3)
             cJSON_AddNumberToObject(tf, "promote_threshold", cfg->kb_typed_facts_promote_threshold);
       }

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -31,6 +31,10 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_extract_prompt_version[0] = '\0';
    cfg->kb_curator_embed_model_version[0] = '\0';
    cfg->kb_curator_invalidation_notify_socket[0] = '\0';
+   /* kb.typed_facts.* autonomous reconciliation (§7.2): auto-promote recurrent
+    * provisional relations by default so novel-tail facts become durable. */
+   cfg->kb_typed_facts_auto_promote_enabled = 1;
+   cfg->kb_typed_facts_promote_threshold = 3;
    cfg->kb_curator_extract_code_enabled = 1;
    cfg->kb_curator_resolve_entities_enabled = 1;
    cfg->kb_curator_index_narrative_enabled = 1;
@@ -122,6 +126,27 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
       return 0;
    if (!cJSON_IsObject(kb))
       return config_issue("\"kb\" expected object, got %s", jo_type_name(kb));
+
+   /* kb.typed_facts.* — KB-owned autonomous reconciliation knobs (§7.2/§8). Parsed
+    * before the kb.curator early-return so it applies even without a curator block. */
+   const cJSON *tf = cJSON_GetObjectItemCaseSensitive(kb, "typed_facts");
+   if (tf)
+   {
+      if (!cJSON_IsObject(tf))
+         return config_issue("\"kb.typed_facts\" expected object, got %s", jo_type_name(tf));
+      /* KB-owned master gate: kb.typed_facts.enabled aliases typed_facts_enabled so
+       * the whole layer is enabled/disabled from the KB config surface (and the
+       * console), keeping aimee-server out of the loop. */
+      const cJSON *en = cJSON_GetObjectItemCaseSensitive(tf, "enabled");
+      if (en && cJSON_IsBool(en))
+         cfg->typed_facts_enabled = cJSON_IsTrue(en) ? 1 : 0;
+      const cJSON *ap = cJSON_GetObjectItemCaseSensitive(tf, "auto_promote");
+      if (ap && cJSON_IsBool(ap))
+         cfg->kb_typed_facts_auto_promote_enabled = cJSON_IsTrue(ap) ? 1 : 0;
+      const cJSON *pt = cJSON_GetObjectItemCaseSensitive(tf, "promote_threshold");
+      if (pt && cJSON_IsNumber(pt) && pt->valueint > 0)
+         cfg->kb_typed_facts_promote_threshold = pt->valueint;
+   }
 
    const cJSON *curator = cJSON_GetObjectItemCaseSensitive(kb, "curator");
    if (!curator)
@@ -460,7 +485,9 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_cross_repo_review_queue_max != 5000;
    curator_any = curator_any || cross_repo_nondefault;
    int evidence_any = !cfg->kb_evidence_embed_enabled || cfg->kb_evidence_embed_batch != 32;
-   if (!curator_any && !evidence_any)
+   int typed_facts_any = cfg->typed_facts_enabled || !cfg->kb_typed_facts_auto_promote_enabled ||
+                         cfg->kb_typed_facts_promote_threshold != 3;
+   if (!curator_any && !evidence_any && !typed_facts_any)
       return;
 
    cJSON *kb = cJSON_GetObjectItemCaseSensitive(root, "kb");
@@ -468,6 +495,23 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
       kb = cJSON_AddObjectToObject(root, "kb");
    if (!kb)
       return;
+
+   /* kb.typed_facts.* — autonomous reconciliation knobs (§7.2/§8). auto_promote is
+    * default-on, so emit it whenever anything here is non-default; promote_threshold
+    * only when it differs from the built-in, so a clean install writes nothing. */
+   if (typed_facts_any)
+   {
+      cJSON *tf = cJSON_AddObjectToObject(kb, "typed_facts");
+      if (tf)
+      {
+         /* KB-owned master gate — the sole persisted home for typed_facts_enabled
+          * (the legacy root-level emit is removed in config_save.c). */
+         cJSON_AddBoolToObject(tf, "enabled", cfg->typed_facts_enabled ? 1 : 0);
+         cJSON_AddBoolToObject(tf, "auto_promote", cfg->kb_typed_facts_auto_promote_enabled ? 1 : 0);
+         if (cfg->kb_typed_facts_promote_threshold != 3)
+            cJSON_AddNumberToObject(tf, "promote_threshold", cfg->kb_typed_facts_promote_threshold);
+      }
+   }
 
    if (curator_any)
    {

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -821,8 +821,10 @@ int config_save(const config_t *cfg)
       cJSON_AddNumberToObject(root, "tool_output_max_bytes", cfg->tool_output_max_bytes);
    if (cfg->ingress_max_raw_scans != 0)
       cJSON_AddNumberToObject(root, "ingress_max_raw_scans", cfg->ingress_max_raw_scans);
-   if (cfg->require_session_worktree)
-      cJSON_AddBoolToObject(root, "require_session_worktree", 1);
+   /* Default-on: persist only the non-default (disabled) state, writing the real
+    * value so an explicit opt-out survives save+reload. */
+   if (!cfg->require_session_worktree)
+      cJSON_AddBoolToObject(root, "require_session_worktree", 0);
    if (cfg->typed_facts_enabled)
       cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
    if (cfg->kb_pdf_ingest_enabled) /* default-off: persist only when enabled */

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -825,8 +825,8 @@ int config_save(const config_t *cfg)
     * value so an explicit opt-out survives save+reload. */
    if (!cfg->require_session_worktree)
       cJSON_AddBoolToObject(root, "require_session_worktree", 0);
-   if (cfg->typed_facts_enabled)
-      cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
+   /* typed_facts_enabled is KB-owned: persisted as kb.typed_facts.enabled by
+    * config_save_kb_curator (still parsed at root for backward compat). */
    if (cfg->kb_pdf_ingest_enabled) /* default-off: persist only when enabled */
       cJSON_AddBoolToObject(root, "kb_pdf_ingest_enabled", 1);
    if (cfg->kb_pdf_vector_enabled) /* default-off: persist only when enabled */

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -69,8 +69,8 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
  * (2 = block a hard-destructive op on a high-attention file, or — only when a
  * positive ingress_max_raw_scans cap is configured — block a raw recursive scan
  * once that per-session cap is exhausted; 0 = allow). With no cap configured
- * (the default) raw scans are never blocked. Never blocks on read/soft ops. Set
- * AIMEE_GUARD=0 to bypass. */
+ * (the default) raw scans are never blocked. Never blocks on read/soft ops.
+ * There is no env-var bypass; disabling it is an operator config action. */
 int handle_attention_guard(void);
 
 #endif /* DEC_CLI_ATTENTION_GUARD_H */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -3,6 +3,9 @@
 
 #include "sandbox.h"
 #include "prompts.h" /* aimee_mode_t */
+#include <stdint.h>  /* int64_t (used below) — keep config.h self-contained so any
+                      * includer (e.g. cli_remote.c on MinGW) compiles regardless of
+                      * include order. */
 #include <stdlib.h>
 #if !defined(_WIN32) && !defined(_WIN64)
 #include <unistd.h>

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -23,6 +23,13 @@
 /* Server execution pool defaults */
 #define CONFIG_DEFAULT_BACKGROUND_THREADS 2
 #define CONFIG_DEFAULT_SESSION_THREADS    4
+/* The well-known /v1 bearer baked into the aimee-server image — a ONE-TIME
+ * bootstrap, never a standing credential. While the live listener bearer still
+ * equals this value the server refuses every TCP /v1 route except
+ * POST /v1/api/rotate_bearer, so the pre-set token can only mint the strong
+ * per-deployment bearer and never perform a real operation. Shared by the server
+ * (enforcement) and the thin client (auto-enroll). */
+#define AIMEE_BOOTSTRAP_BEARER "aimee-local-dev"
 /* Raised from 2 -> 4 now that DB2 connections are bounded by the connection pool
  * (db2_connection_pool_size), not 1:1 with worker threads. */
 #define CONFIG_DEFAULT_KB_WORKER_THREADS 4

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -421,6 +421,9 @@ typedef struct config
     * this so an arbitrary client model name is not forwarded and rejected upstream. */
    int gateway_pin_model;
    int typed_facts_enabled;         /* typed-fact knowledge layer master gate (default off) */
+   /* kb.typed_facts.* — KB-owned autonomous reconciliation knobs (proposal §7.2/§8). */
+   int kb_typed_facts_auto_promote_enabled; /* default on: auto-promote recurrent provisional relations */
+   int kb_typed_facts_promote_threshold;    /* observations before auto-promote (default 3) */
    int kb_pdf_ingest_enabled;       /* structured-pdf: route PDF uploads through the geometry
                                        extractor (kb_doc_pdf) instead of plain pdftotext (default off) */
    int kb_pdf_vector_enabled;       /* structured-pdf Phase A: embed PDF chunks into the isolated

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -45,6 +45,10 @@ int kb_client_health(kb_health_t *out);
  * is unreachable or returns non-2xx. Used by `aimee kb curator status` to read
  * the curator block (richer than the flat kb_health_t snapshot). */
 char *kb_client_health_json(void);
+
+/* Cached read of the KB's advertised typed-facts state (proposal §8). aimee-server
+ * gates per-turn fact injection on this instead of owning typed_facts_enabled. */
+int kb_client_typed_facts_enabled(void);
 /* §2c: POST /v1/reembed; raw response JSON (caller frees) or NULL on transport
  * failure; *status_out (optional) gets the HTTP status. target_dim>0 pins the
  * reset target (bypasses the embedder probe); clear_maintenance!=0 instead just

--- a/src/headers/kb_http_console.h
+++ b/src/headers/kb_http_console.h
@@ -8,6 +8,7 @@
 
 /* Handle a console route under /v1/console. Returns the HTTP status if (method,
  * path) is a console route, or -1 if it is not (so the caller continues). */
-int kb_http_console_route(const char *method, const char *path, char *out_buf, int out_cap);
+int kb_http_console_route(const char *method, const char *path, const char *body, char *out_buf,
+                          int out_cap);
 
 #endif /* KB_HTTP_CONSOLE_H */

--- a/src/headers/role_templates.h
+++ b/src/headers/role_templates.h
@@ -34,6 +34,11 @@ int role_template_install_defaults(const char *dir);
  * '-'; non-empty; no path separators or leading dot). Guards write/delete. */
 int role_template_name_valid(const char *role);
 
+/* Per-role turn cap from the role template's `max_turns:` frontmatter, or -1
+ * (INFINITE — the default for every role) when unset. Edited under the Personas
+ * tab. */
+int role_template_max_turns(const char *role);
+
 /* Return the RAW template body for `role` (placeholders intact, not built):
  * project file -> user file -> built-in default. Heap (caller frees), or NULL
  * if no such role. */

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -53,6 +53,16 @@ extern "C"
    int server_http_authorize(int is_tcp, const char *bearer_cfg, const char *auth_header,
                              const char *api_key_header, int has_session_key);
 
+   /* Trust-on-first-use gate (pure — unit-testable). Returns 1 when an authorized
+    * TCP request must be REFUSED because the live listener bearer is still the
+    * one-time bootstrap default (AIMEE_BOOTSTRAP_BEARER) and the route is not the
+    * rotation endpoint — so the pre-set bearer can only mint the strong token and
+    * never perform a real operation. Returns 0 (allow) for UDS, once the bearer
+    * has been rotated (live_bearer != bootstrap), for the rotate_bearer route
+    * itself, or when the operator pinned AIMEE_API_BEARER_TOKEN (TOFU opt-out). */
+   int server_http_bootstrap_gate(int is_tcp, const char *live_bearer, const char *method,
+                                  const char *path);
+
    /* Fixed-window per-bearer rate limiter (pure — unit-testable). State is a
     * single 60s window the caller owns. limit_per_min <= 0 disables limiting
     * (always returns 0). `now` is epoch seconds. Returns 0 when the request is

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -708,7 +708,7 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
     * zeroed = owner, consistent with everything open.) */
    if (!vr.scope_kind[0] || strcmp(vr.scope_kind, KB_SCOPE_KIND_CONSOLE_ADMIN) == 0)
    {
-      int cr = kb_http_console_route(method, path, out_buf, out_cap);
+      int cr = kb_http_console_route(method, path, body, out_buf, out_cap);
       if (cr >= 0)
          return cr;
       int ar = kb_http_accounts_route(method, path, query_string, body, out_buf, out_cap);

--- a/src/kb/http/kb_http_console.c
+++ b/src/kb/http/kb_http_console.c
@@ -5,9 +5,12 @@
 
 #include "aimee.h" /* now_utc */
 #include "cJSON.h"
+#include "config.h"                 /* config_load / config_save (§8 tune) */
 #include "kb_service.h"             /* kb_service_workers_json, kb_service_ctx_t */
 #include "kb_service_kb.h"          /* kb_service_health_json */
 #include "db2/kb_service_backend.h" /* async queue status */
+#include "db2/ontology_evolution.h" /* db2_ontology_* (§8 observe + act) */
+#include "rel_types.h"              /* REL_TYPE_NAME_MAX */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -150,15 +153,234 @@ static int console_overview(char *out_buf, int out_cap)
    return 200;
 }
 
-int kb_http_console_route(const char *method, const char *path, char *out_buf, int out_cap)
+/* GET /v1/console/typed_facts — the Typed Facts panel's observe surface (§8):
+ * the KB-owned config knobs plus the provisional-relation promotion review queue
+ * (what the §7.2 auto-promote sweep will act on, and what an operator can act on
+ * by hand). Read-only. */
+static int console_typed_facts(char *out_buf, int out_cap)
 {
-   if (!route_is(path, "/v1/console/overview"))
-      return -1; /* not a console route — caller continues dispatch */
+   config_t cfg;
+   config_load(&cfg);
+   int thr =
+       cfg.kb_typed_facts_promote_threshold > 0 ? cfg.kb_typed_facts_promote_threshold : 3;
 
-   if (strcmp(method, "GET") != 0)
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
    {
-      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
-      return 405;
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"typed_facts alloc failed\"}");
+      return 500;
    }
-   return console_overview(out_buf, out_cap);
+   cJSON_AddStringToObject(root, "schema", "console.typed_facts.v1");
+   char ts[32];
+   now_utc(ts, sizeof(ts));
+   cJSON_AddStringToObject(root, "generated_at", ts);
+
+   cJSON *c = cJSON_AddObjectToObject(root, "config");
+   cJSON_AddBoolToObject(c, "typed_facts_enabled", cfg.typed_facts_enabled ? 1 : 0);
+   cJSON_AddBoolToObject(c, "auto_promote", cfg.kb_typed_facts_auto_promote_enabled ? 1 : 0);
+   cJSON_AddNumberToObject(c, "promote_threshold", thr);
+
+   /* Promotion review queue: every pending provisional relation (threshold 1 lists
+    * the whole queue), with its observation count and whether it has cleared the
+    * auto-promote bar. */
+   cJSON *cands = cJSON_AddArrayToObject(root, "promotion_candidates");
+   char names[32][REL_TYPE_NAME_MAX];
+   int nc = db2_ontology_eval_candidates(1, names, 32);
+   for (int i = 0; i < nc && cands; i++)
+   {
+      cJSON *o = cJSON_CreateObject();
+      if (!o)
+         continue;
+      cJSON_AddStringToObject(o, "relation", names[i]);
+      long cnt = db2_ontology_eval_count(names[i]);
+      cJSON_AddNumberToObject(o, "observations", cnt < 0 ? 0 : (double)cnt);
+      cJSON_AddBoolToObject(o, "ready", (cnt >= thr) ? 1 : 0);
+      char st[32] = "";
+      db2_ontology_eval_status(names[i], st, sizeof(st));
+      cJSON_AddStringToObject(o, "status", st);
+      cJSON_AddItemToArray(cands, o);
+   }
+   cJSON_AddNumberToObject(root, "candidate_count", nc < 0 ? 0 : nc);
+
+   char *s = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!s)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"typed_facts render failed\"}");
+      return 500;
+   }
+   if (strlen(s) >= (size_t)out_cap)
+   {
+      free(s);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"typed_facts too large\"}");
+      return 500;
+   }
+   snprintf(out_buf, (size_t)out_cap, "%s", s);
+   free(s);
+   return 200;
+}
+
+/* POST /v1/console/typed_facts/config — fine-tune / alter behaviour (§8):
+ * {auto_promote?: bool, promote_threshold?: int}. Persists to KB config so the
+ * drain picks it up on its next poll. */
+static int console_typed_facts_config(const char *body, char *out_buf, int out_cap)
+{
+   cJSON *req = (body && body[0]) ? cJSON_Parse(body) : NULL;
+   if (!req || !cJSON_IsObject(req))
+   {
+      cJSON_Delete(req);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"invalid request body\"}");
+      return 400;
+   }
+   config_t cfg;
+   config_load(&cfg);
+   /* KB-owned master enable/disable for the whole typed-facts layer. */
+   const cJSON *en = cJSON_GetObjectItemCaseSensitive(req, "enabled");
+   if (en && cJSON_IsBool(en))
+      cfg.typed_facts_enabled = cJSON_IsTrue(en) ? 1 : 0;
+   const cJSON *ap = cJSON_GetObjectItemCaseSensitive(req, "auto_promote");
+   if (ap && cJSON_IsBool(ap))
+      cfg.kb_typed_facts_auto_promote_enabled = cJSON_IsTrue(ap) ? 1 : 0;
+   const cJSON *pt = cJSON_GetObjectItemCaseSensitive(req, "promote_threshold");
+   if (pt && cJSON_IsNumber(pt) && pt->valueint > 0)
+      cfg.kb_typed_facts_promote_threshold = pt->valueint;
+   cJSON_Delete(req);
+   if (config_save(&cfg) != 0)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"config save failed\"}");
+      return 500;
+   }
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddBoolToObject(resp, "ok", 1);
+   cJSON_AddBoolToObject(resp, "enabled", cfg.typed_facts_enabled ? 1 : 0);
+   cJSON_AddBoolToObject(resp, "auto_promote", cfg.kb_typed_facts_auto_promote_enabled ? 1 : 0);
+   cJSON_AddNumberToObject(resp, "promote_threshold", cfg.kb_typed_facts_promote_threshold);
+   char *s = cJSON_PrintUnformatted(resp);
+   cJSON_Delete(resp);
+   if (!s || strlen(s) >= (size_t)out_cap)
+   {
+      free(s);
+      snprintf(out_buf, (size_t)out_cap, "{\"ok\":true}");
+      return 200;
+   }
+   snprintf(out_buf, (size_t)out_cap, "%s", s);
+   free(s);
+   return 200;
+}
+
+/* A relation name is safe iff it is a non-empty lower snake_case token within
+ * REL_TYPE_NAME_MAX (the ontology's canonical form). Rejects oversized/malformed
+ * input at the route boundary before it reaches the ontology helpers. */
+static int tf_relation_name_ok(const char *s)
+{
+   if (!s || !s[0])
+      return 0;
+   size_t n = strlen(s);
+   if (n >= REL_TYPE_NAME_MAX)
+      return 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      char c = s[i];
+      if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_'))
+         return 0;
+   }
+   return 1;
+}
+
+/* POST /v1/console/typed_facts/relation — operator action on a provisional
+ * relation (§8): {action: "approve"|"map"|"reject", relation, target?}. Wires to
+ * the shipped ontology-evolution verbs. */
+static int console_typed_facts_relation(const char *body, char *out_buf, int out_cap)
+{
+   cJSON *req = (body && body[0]) ? cJSON_Parse(body) : NULL;
+   const char *action =
+       req ? cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(req, "action")) : NULL;
+   const char *rel =
+       req ? cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(req, "relation")) : NULL;
+   const char *target =
+       req ? cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(req, "target")) : NULL;
+   if (!action || !rel || !rel[0])
+   {
+      cJSON_Delete(req);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"action and relation are required\"}");
+      return 400;
+   }
+   if (!tf_relation_name_ok(rel) || (target && target[0] && !tf_relation_name_ok(target)))
+   {
+      cJSON_Delete(req);
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"relation/target must be lower snake_case within REL_TYPE_NAME_MAX\"}");
+      return 400;
+   }
+   int rc;
+   const char *did;
+   if (strcmp(action, "approve") == 0)
+   {
+      rc = db2_ontology_approve(rel);
+      did = "approved";
+   }
+   else if (strcmp(action, "reject") == 0)
+   {
+      rc = db2_ontology_reject(rel);
+      did = "rejected";
+   }
+   else if (strcmp(action, "map") == 0)
+   {
+      if (!target || !target[0])
+      {
+         cJSON_Delete(req);
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"map action requires a target\"}");
+         return 400;
+      }
+      rc = db2_ontology_map(rel, target);
+      did = "mapped";
+   }
+   else
+   {
+      cJSON_Delete(req);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"action must be approve, map, or reject\"}");
+      return 400;
+   }
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddBoolToObject(resp, "ok", rc == 0 ? 1 : 0);
+   cJSON_AddStringToObject(resp, "action", did);
+   cJSON_AddStringToObject(resp, "relation", rel);
+   cJSON_Delete(req);
+   char *s = cJSON_PrintUnformatted(resp);
+   cJSON_Delete(resp);
+   int status = rc == 0 ? 200 : 500;
+   if (!s || strlen(s) >= (size_t)out_cap)
+   {
+      free(s);
+      snprintf(out_buf, (size_t)out_cap, rc == 0 ? "{\"ok\":true}" : "{\"ok\":false}");
+      return status;
+   }
+   snprintf(out_buf, (size_t)out_cap, "%s", s);
+   free(s);
+   return status;
+}
+
+/* Reject a non-matching method for a matched route with a 405. */
+static int console_method_not_allowed(char *out_buf, int out_cap)
+{
+   snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
+   return 405;
+}
+
+int kb_http_console_route(const char *method, const char *path, const char *body, char *out_buf,
+                          int out_cap)
+{
+   if (route_is(path, "/v1/console/overview"))
+      return strcmp(method, "GET") == 0 ? console_overview(out_buf, out_cap)
+                                        : console_method_not_allowed(out_buf, out_cap);
+   if (route_is(path, "/v1/console/typed_facts"))
+      return strcmp(method, "GET") == 0 ? console_typed_facts(out_buf, out_cap)
+                                        : console_method_not_allowed(out_buf, out_cap);
+   if (route_is(path, "/v1/console/typed_facts/config"))
+      return strcmp(method, "POST") == 0 ? console_typed_facts_config(body, out_buf, out_cap)
+                                         : console_method_not_allowed(out_buf, out_cap);
+   if (route_is(path, "/v1/console/typed_facts/relation"))
+      return strcmp(method, "POST") == 0 ? console_typed_facts_relation(body, out_buf, out_cap)
+                                         : console_method_not_allowed(out_buf, out_cap);
+   return -1; /* not a console route — caller continues dispatch */
 }

--- a/src/kb/http/kb_http_console.c
+++ b/src/kb/http/kb_http_console.c
@@ -161,8 +161,7 @@ static int console_typed_facts(char *out_buf, int out_cap)
 {
    config_t cfg;
    config_load(&cfg);
-   int thr =
-       cfg.kb_typed_facts_promote_threshold > 0 ? cfg.kb_typed_facts_promote_threshold : 3;
+   int thr = cfg.kb_typed_facts_promote_threshold > 0 ? cfg.kb_typed_facts_promote_threshold : 3;
 
    cJSON *root = cJSON_CreateObject();
    if (!root)

--- a/src/kb/http/kb_route_acl.c
+++ b/src/kb/http/kb_route_acl.c
@@ -17,6 +17,9 @@ struct acl_entry
 
 static const struct acl_entry CONSOLE_ADMIN_ACL[] = {
     {"GET", "/v1/console/overview"},
+    {"GET", "/v1/console/typed_facts"},
+    {"POST", "/v1/console/typed_facts/config"},
+    {"POST", "/v1/console/typed_facts/relation"},
     {"POST", "/v1/enroll"},
     {"GET", "/v1/enrollments"},
     {"POST", "/v1/enrollments/{id}/revoke"},

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -59,7 +59,7 @@
  * active once it has recurred at least this many times (default; operator override
  * kb.typed_facts.promote_threshold). BATCH bounds promotions per poll. */
 #define KB_ONTO_PROMOTE_DEFAULT_THRESHOLD 3
-#define KB_ONTO_PROMOTE_BATCH 32
+#define KB_ONTO_PROMOTE_BATCH             32
 
 /* Rebuild the corpus-derived cross-repo precision metadata (precision-hardening
  * H0/H1): the H0c repo-identity index, the H0d inter-repo structural-route
@@ -225,8 +225,8 @@ static void *drain_thread_main(void *arg)
                   continue;
                if (db2_ontology_approve(cands[i]) == 0)
                   aimee_log(LOG_INFO, "kb.ontology.promote",
-                            "auto-promoted relation '%s' to active (>= %d observations)",
-                            cands[i], thr);
+                            "auto-promoted relation '%s' to active (>= %d observations)", cands[i],
+                            thr);
             }
          }
       }

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -15,6 +15,7 @@
 #include "db2/cross_repo_route.h"    /* db2_cross_repo_rebuild_routes (H0d) */
 #include "db2/cross_repo_build.h"    /* db2_cross_repo_rebuild_build_deps (recall R2) */
 #include "db2/cross_repo_stats.h"    /* db2_cross_repo_recompute_blocked_symbols */
+#include "db2/ontology_evolution.h"  /* db2_ontology_eval_candidates/_approve (§7.2 auto-promote) */
 #include "kb_curator_drain.h"
 #include "kb_curator_extract.h"
 #include "kb_curator_resolve_entities.h"
@@ -53,6 +54,12 @@
  * starve the synth stages to one job per poll. Bounded so the catch-up + config
  * reload still get a turn each poll (both progress). */
 #define CURATOR_DRAIN_BATCH 16
+
+/* §7.2 autonomous ontology promotion: a provisional relation is auto-promoted to
+ * active once it has recurred at least this many times (default; operator override
+ * kb.typed_facts.promote_threshold). BATCH bounds promotions per poll. */
+#define KB_ONTO_PROMOTE_DEFAULT_THRESHOLD 3
+#define KB_ONTO_PROMOTE_BATCH 32
 
 /* Rebuild the corpus-derived cross-repo precision metadata (precision-hardening
  * H0/H1): the H0c repo-identity index, the H0d inter-repo structural-route
@@ -193,6 +200,35 @@ static void *drain_thread_main(void *arg)
          int n = kb_memory_facts_drain(&cfg, 8);
          if (n > 0)
             aimee_log(LOG_DEBUG, "kb.memory.facts", "drained %d memory_facts job(s)", n);
+
+         /* §7.2 autonomous ontology reconciliation: promote provisional relations
+          * (novel predicates the extractor's "other" fallback staged) to active
+          * once they have recurred >= threshold times across sources, so facts
+          * using them become durable/recallable WITHOUT a human approving each.
+          * Default-on with typed facts; the threshold is operator-tunable via
+          * kb.typed_facts.promote_threshold (§8), falling back to the built-in. */
+         if (cfg.kb_typed_facts_auto_promote_enabled)
+         {
+            int thr = cfg.kb_typed_facts_promote_threshold > 0
+                          ? cfg.kb_typed_facts_promote_threshold
+                          : KB_ONTO_PROMOTE_DEFAULT_THRESHOLD;
+            char cands[KB_ONTO_PROMOTE_BATCH][REL_TYPE_NAME_MAX];
+            int nc = db2_ontology_eval_candidates(thr, cands, KB_ONTO_PROMOTE_BATCH);
+            for (int i = 0; i < nc; i++)
+            {
+               /* Never promote a generic catch-all bucket to active: it would make
+                * low-quality "misc" facts durable and can't be reconciled to a
+                * real predicate. The extractor is instructed not to emit these,
+                * but exclude them defensively. */
+               if (strcmp(cands[i], "other") == 0 || strcmp(cands[i], "unknown") == 0 ||
+                   strcmp(cands[i], "misc") == 0 || strcmp(cands[i], "unspecified") == 0)
+                  continue;
+               if (db2_ontology_approve(cands[i]) == 0)
+                  aimee_log(LOG_INFO, "kb.ontology.promote",
+                            "auto-promoted relation '%s' to active (>= %d observations)",
+                            cands[i], thr);
+            }
+         }
       }
 
       /* Code-vector embed drain — pipeline stage 2 (the 0.6B embedder), runs

--- a/src/kb/kb_memory_facts.c
+++ b/src/kb/kb_memory_facts.c
@@ -39,15 +39,17 @@
  * from the seed ontology (rel_types.c) at run time — this is the autonomous
  * reconciliation step (proposal §7): the model is bound to relations the write
  * gate already treats as durable, so an extracted fact commits ACTIVE and
- * recallable instead of being stranded as a provisional Class-C edge. Relations
- * outside the list fall to "other" and are left for the auto-promote tail. */
+ * recallable instead of being stranded as a provisional Class-C edge. When no
+ * seed relation fits, the model emits its own concise predicate (never a generic
+ * catch-all), which stays a distinguishable provisional candidate for §7.2. */
 #define MF_SYSTEM_PROMPT_TMPL                                                                      \
    "You extract durable facts from a single remembered note. Return ONLY a JSON "                  \
    "object: {\"facts\":[{\"subject\":\"\",\"relation\":\"\",\"object\":\"\","                      \
    "\"confidence\":0.0}]}. Each fact is a stable subject-relation-object triple "                  \
-   "grounded strictly in the note. relation MUST be exactly one of these canonical "               \
-   "predicates — choose the single nearest fit for each fact: %s. Use \"other\" "                  \
-   "ONLY when no listed predicate is a reasonable fit. subject is the entity the "                 \
+   "grounded strictly in the note. For relation, choose the single nearest fit "                   \
+   "from these canonical predicates when one reasonably applies: %s. If NONE fits, "                \
+   "emit a concise snake_case predicate of your own (e.g. drives, founded, mentors) "               \
+   "— NEVER a generic catch-all such as \"other\"/\"unknown\"/\"misc\". subject is the entity the " \
    "fact is about (use \"user\" for the note's author when it is first-person). "                  \
    "confidence is 0..1. Extract only durable, generalizable facts; skip transient "                \
    "state, feelings, plans, and one-off events. If the note asserts no durable "                   \

--- a/src/kb/kb_memory_facts.c
+++ b/src/kb/kb_memory_facts.c
@@ -47,10 +47,11 @@
    "object: {\"facts\":[{\"subject\":\"\",\"relation\":\"\",\"object\":\"\","                      \
    "\"confidence\":0.0}]}. Each fact is a stable subject-relation-object triple "                  \
    "grounded strictly in the note. For relation, choose the single nearest fit "                   \
-   "from these canonical predicates when one reasonably applies: %s. If NONE fits, "                \
-   "emit a concise snake_case predicate of your own (e.g. drives, founded, mentors) "               \
-   "— NEVER a generic catch-all such as \"other\"/\"unknown\"/\"misc\". subject is the entity the " \
-   "fact is about (use \"user\" for the note's author when it is first-person). "                  \
+   "from these canonical predicates when one reasonably applies: %s. If NONE fits, "               \
+   "emit a concise snake_case predicate of your own (e.g. drives, founded, "                       \
+   "mentors) — NEVER a generic catch-all such as "                                                 \
+   "\"other\"/\"unknown\"/\"misc\". subject is the entity the fact is about "                      \
+   "(use \"user\" for the note's author when it is first-person). "                                \
    "confidence is 0..1. Extract only durable, generalizable facts; skip transient "                \
    "state, feelings, plans, and one-off events. If the note asserts no durable "                   \
    "fact, return an empty list. No prose, no markdown."

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -407,6 +407,11 @@ static cJSON *kb_service_health_object(void)
 
    cJSON_AddBoolToObject(resp, "maintenance_enabled", cfg.kb_maintenance_enabled);
 
+   /* Typed-facts capability (proposal §8): the KB advertises its own typed-facts
+    * state so aimee-server can gate per-turn fact injection on it WITHOUT owning
+    * the config. The server never reads typed_facts_enabled itself. */
+   cJSON_AddBoolToObject(resp, "typed_facts_enabled", cfg.typed_facts_enabled ? 1 : 0);
+
    return resp;
 }
 

--- a/src/posix/agent_max_turns.c
+++ b/src/posix/agent_max_turns.c
@@ -4,18 +4,20 @@
 #include "agent_types.h"
 #include "config.h"
 
+#include <limits.h>
+
 int agent_resolve_max_turns(const agent_t *agent, const char *role)
 {
-   /* max_turns > 0 on the agent only caps delegate runs; primary sessions
-    * (role == NULL) are unlimited regardless of the configured value. */
+   /* An explicit positive per-agent cap (or a positive per-role cap the delegate
+    * policy stamped on) bounds a delegate run to that many turns. */
    if (agent->max_turns > 0 && role)
       return agent->max_turns;
-   if (agent->max_turns == 0)
-      return 1000;
+   /* Default is INFINITE. max_turns <= 0 (the default -1) means "no per-agent/role
+    * cap"; a run is unbounded UNLESS an operator set a global iteration cap
+    * (GUI-settable max_iterations[_delegate], 0/unset = no cap). This is the
+    * "-1 = infinite, for everything, by default" contract. */
    config_t iter_cfg;
    config_load(&iter_cfg);
-   if (role)
-      return iter_cfg.max_iterations_delegate > 0 ? iter_cfg.max_iterations_delegate
-                                                  : CONFIG_DEFAULT_MAX_ITERATIONS_DELEGATE;
-   return iter_cfg.max_iterations > 0 ? iter_cfg.max_iterations : 1000;
+   int cap = role ? iter_cfg.max_iterations_delegate : iter_cfg.max_iterations;
+   return cap > 0 ? cap : INT_MAX;
 }

--- a/src/role_templates.c
+++ b/src/role_templates.c
@@ -436,6 +436,56 @@ static char *str_replace_all(const char *haystack, const char *needle, const cha
    return result;
 }
 
+/* Strip a leading YAML frontmatter block (---\n ... \n---) in place, so role
+ * metadata (e.g. max_turns) in a template file never leaks into the built prompt.
+ * A template without frontmatter is left untouched. */
+static void rt_strip_frontmatter(char *s)
+{
+   if (!s || strncmp(s, "---", 3) != 0)
+      return;
+   if (s[3] != '\n' && !(s[3] == '\r' && s[4] == '\n'))
+      return; /* opening --- must be its own line */
+   char *close = strstr(s + 3, "\n---");
+   if (!close)
+      return;
+   char *p = close + 4; /* past "\n---" */
+   while (*p == '-')
+      p++;
+   while (*p == '\r' || *p == '\n')
+      p++;
+   memmove(s, p, strlen(p) + 1);
+}
+
+/* Read an optional `max_turns:` from a role template's leading frontmatter.
+ * Returns the configured value, or -1 (INFINITE — the default cap for every role)
+ * when there is no template, no frontmatter, or no max_turns key. Reads the
+ * user-level template (config_default_dir()/role_templates/<role>.md) — the file
+ * the Personas GUI edits. */
+int role_template_max_turns(const char *role)
+{
+   if (!role || !role[0])
+      return -1;
+   char path[ROLE_TEMPLATE_PATH_MAX];
+   snprintf(path, sizeof(path), "%s/role_templates/%s.md", config_default_dir(), role);
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return -1;
+   char buf[4096];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   if (strncmp(buf, "---", 3) != 0)
+      return -1;
+   char *close = strstr(buf + 3, "\n---");
+   char *limit = close ? close : buf + n;
+   for (char *p = buf; p < limit; p++)
+   {
+      if ((p == buf || p[-1] == '\n') && strncmp(p, "max_turns:", 10) == 0)
+         return atoi(p + 10);
+   }
+   return -1;
+}
+
 char *role_template_build(const char *project_root, const char *role, const char *task,
                           const char *context)
 {
@@ -476,6 +526,10 @@ char *role_template_build(const char *project_root, const char *role, const char
 
    if (!raw)
       return NULL;
+
+   /* Drop any leading frontmatter (role metadata like max_turns) before it can
+    * reach the prompt. */
+   rt_strip_frontmatter(raw);
 
    /* Substitute {{TASK}} */
    const char *task_val = (task && task[0]) ? task : "(see context)";
@@ -619,6 +673,10 @@ int role_template_install_defaults(const char *dir)
       FILE *f = fopen(path, "w");
       if (!f)
          return -1;
+      /* Seed a frontmatter block carrying the per-role turn cap so it is visible
+       * and editable under the Personas tab (edited via PUT /v1/role_templates/
+       * <role>). -1 = INFINITE, the default for every role. */
+      fputs("---\nmax_turns: -1\n---\n\n", f);
       fputs(g_defaults[i].content, f);
       fputc('\n', f);
       fclose(f);

--- a/src/server/delegate_openai.c
+++ b/src/server/delegate_openai.c
@@ -201,7 +201,26 @@ static void delegate_payload_rewrite_track(cJSON *messages, const char *system_p
 
 static int anthropic_build_url(const agent_t *agent, char *url, size_t url_len)
 {
-   return openai_join_endpoint(agent->endpoint, "/messages", url, url_len);
+   /* The Anthropic Messages API always lives at <base>/v1/messages. Unlike the
+    * OpenAI join, the /v1 version segment is part of the operation path rather
+    * than the caller-supplied base, so we insert it for ANY base that does not
+    * already carry it — not only bare host roots (which is all
+    * openai_join_endpoint would handle). This lets anthropic-compatible
+    * gateways be registered with a path-prefixed base (e.g.
+    * https://api.minimax.io/anthropic) without hand-baking /v1 into the
+    * endpoint; without it the join produced .../anthropic/messages -> 404. */
+   char base[MAX_ENDPOINT_LEN];
+
+   trim_trailing_slashes(agent->endpoint, base, sizeof(base));
+   if (!base[0])
+      return -1;
+   if (url_has_suffix(base, "/messages")) /* already a full messages URL */
+      snprintf(url, url_len, "%s", base);
+   else if (url_has_suffix(base, "/v1")) /* base already carries the version */
+      snprintf(url, url_len, "%s/messages", base);
+   else
+      snprintf(url, url_len, "%s/v1/messages", base);
+   return 0;
 }
 
 static cJSON *anthropic_build_request(const agent_t *agent, cJSON *messages, cJSON *tools,

--- a/src/server/delegate_role.c
+++ b/src/server/delegate_role.c
@@ -1,4 +1,5 @@
 #include "delegate_role.h"
+#include "role_templates.h" /* role_template_max_turns (per-role cap) */
 
 #include <string.h>
 
@@ -106,17 +107,14 @@ void delegate_apply_max_turns_override(agent_config_t *cfg, int max_turns)
 
 int delegate_default_max_turns_for_role(const char *role)
 {
+   /* The per-role turn cap is operator configuration: the `max_turns:` frontmatter
+    * of the role template (edited under the Personas tab), defaulting to -1 =
+    * INFINITE. A configured positive value flows through
+    * delegate_apply_max_turns_policy as a cap; -1 leaves the role unbounded. No
+    * hardcoded per-role caps. */
    if (!role || !role[0])
       return -1;
-
-   role = delegate_role_canonicalize(role);
-   if (strcmp(role, "review") == 0)
-      return 20;
-   if (strcmp(role, "validate") == 0 || strcmp(role, "search") == 0)
-      return 12;
-   if (strcmp(role, "diagnose") == 0)
-      return 16;
-   return -1;
+   return role_template_max_turns(delegate_role_canonicalize(role));
 }
 
 int delegate_final_after_turns_for_role(const char *role)

--- a/src/server/delegate_run_phases.c
+++ b/src/server/delegate_run_phases.c
@@ -79,7 +79,7 @@ void delegate_record_exit_learning(const char *sid, const char *role, const agen
    dlm.tool_calls = result->tool_calls;
    dlm.success = (rc == 0);
    dlm.error = result->error[0] ? result->error : NULL;
-   dlm.max_turns_limit = max_turns > 0 ? max_turns : 30;
+   dlm.max_turns_limit = max_turns > 0 ? max_turns : 0; /* 0 = unlimited (default -1) */
    dlm.write_enforce_fired = dlm.error && strstr(dlm.error, "write_enforce") ? 1 : 0;
    dlm.had_writes = dlm.write_enforce_fired ? (strstr(dlm.error, "no Write or Edit") ? 0 : 1)
                                             : (rc == 0 ? 1 : 0);

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -443,12 +443,13 @@ char *ingress_preinject_build(const char *query, int request_disabled)
 
    config_t cfg;
    config_load(&cfg);
-   /* The envelope carries two independently-gated layers: the code/memory
-    * preview block (ingress_preinject_enabled, aimed at coding agents) and the
-    * typed-fact block (typed_facts_enabled). Build if EITHER is on, so typed
-    * facts surface in turns without requiring the heavier preview machinery. */
+   /* The envelope carries two independently-gated layers: the code/memory preview
+    * block (ingress_preinject_enabled, aimed at coding agents) and the typed-fact
+    * block. Typed facts are KB-OWNED (proposal §8): aimee-server does NOT read its
+    * own typed_facts_enabled — it asks the KB (cached capability) so the KB is the
+    * single source of truth. Build if EITHER layer is on. */
    int preview_on = cfg.ingress_preinject_enabled;
-   int facts_on = cfg.typed_facts_enabled;
+   int facts_on = kb_client_typed_facts_enabled();
    if (!preview_on && !facts_on)
       return NULL;
    int configured_budget = cfg.ingress_preinject_assembly_budget > 0

--- a/src/server/kb_client.c
+++ b/src/server/kb_client.c
@@ -130,6 +130,38 @@ char *kb_client_health_json(void)
    return body;
 }
 
+/* Cached read of the KB's advertised typed-facts capability (proposal §8).
+ * aimee-server gates per-turn fact injection on THIS instead of owning
+ * typed_facts_enabled itself — the KB is the single source of truth. Short TTL so
+ * a facts-off deployment does not fetch /v1/health every turn; a console/config
+ * change is picked up within the TTL. Benign cross-thread race on the cache (worst
+ * case: a couple of extra fetches). On transport failure the last-known value (or
+ * off) is kept, so a briefly-unreachable KB never spuriously injects. */
+int kb_client_typed_facts_enabled(void)
+{
+   static int cached = -1; /* -1 = never fetched */
+   static time_t fetched_at = 0;
+   const int TTL_S = 15;
+   time_t now = time(NULL);
+   if (cached >= 0 && (now - fetched_at) < TTL_S)
+      return cached;
+   int v = cached >= 0 ? cached : 0;
+   char *h = kb_client_health_json();
+   if (h)
+   {
+      cJSON *j = cJSON_Parse(h);
+      free(h);
+      if (j)
+      {
+         v = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(j, "typed_facts_enabled")) ? 1 : 0;
+         cJSON_Delete(j);
+      }
+   }
+   cached = v;
+   fetched_at = now;
+   return v;
+}
+
 /* §2c: POST /v1/reembed {confirm, force, dry_run} — the dim-change reset. Returns
  * the raw response JSON (caller frees), or NULL on transport failure; *status_out
  * (optional) gets the HTTP status. A long timeout covers the DROP + schema re-apply. */

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -264,6 +264,19 @@ int server_http_authorize(int is_tcp, const char *bearer_cfg, const char *auth_h
    return 0;
 }
 
+int server_http_bootstrap_gate(int is_tcp, const char *live_bearer, const char *method,
+                               const char *path)
+{
+   if (!is_tcp || !live_bearer || strcmp(live_bearer, AIMEE_BOOTSTRAP_BEARER) != 0)
+      return 0; /* UDS, or already rotated to a strong token -> gate off */
+   const char *pin = getenv("AIMEE_API_BEARER_TOKEN");
+   if (pin && pin[0])
+      return 0; /* operator pinned the bearer -> opted out of TOFU */
+   if (method && path && strcmp(method, "POST") == 0 && strcmp(path, "/v1/api/rotate_bearer") == 0)
+      return 0; /* the one route the bootstrap may reach: mint the strong token */
+   return 1;    /* refuse: enrollment required */
+}
+
 #define SHTTP_RATE_WINDOW_SECS 60
 
 int server_http_rate_check(server_http_rate_state_t *st, int limit_per_min, long now)
@@ -1463,6 +1476,26 @@ void handle_conn(int fd, int is_tcp)
                                        "configured bearer token\",\"type\":\"server_error\"}}";
          send_response(fd, az, msg, request_id);
          LOG_INFO("server.http", "%s %s -> %d req_id=%s", method, path, az, request_id);
+         return;
+      }
+
+      /* Trust-on-first-use enforcement: while the live /v1 bearer is still the
+       * well-known image-seeded bootstrap, the ONLY route permitted on the TCP
+       * listener is rotating it to a strong per-deployment token. Auth already
+       * passed, so the caller presented the bootstrap; refuse every other route
+       * so the pre-set default can never perform a real operation — it exists
+       * solely to mint the real bearer, after which g_bearer no longer equals the
+       * bootstrap and this gate self-disables. Closes the "a network-published
+       * server keeps accepting the public default bearer" hole. */
+      if (server_http_bootstrap_gate(is_tcp, g_bearer, method, path))
+      {
+         send_response(fd, 401,
+                       "{\"error\":{\"message\":\"the one-time bootstrap bearer must be rotated "
+                       "before use: POST /v1/api/rotate_bearer (aimee remote enroll)\",\"type\":"
+                       "\"enrollment_required\"}}",
+                       request_id);
+         LOG_INFO("server.http", "%s %s -> 401 (enrollment_required) req_id=%s", method, path,
+                  request_id);
          return;
       }
    }

--- a/src/server/server_http_config_routes.c
+++ b/src/server/server_http_config_routes.c
@@ -244,6 +244,10 @@ int route_role_template_show(const char *name, char *resp, int cap)
    cJSON *o = cJSON_CreateObject();
    cJSON_AddStringToObject(o, "role", name);
    cJSON_AddStringToObject(o, "content", raw);
+   /* Surface the per-role turn cap structurally so the Personas tab can render it
+    * as a dedicated field (edited via the `max_turns:` frontmatter in `content`).
+    * -1 = infinite, the default. */
+   cJSON_AddNumberToObject(o, "max_turns", role_template_max_turns(name));
    free(raw);
    return emit(resp, cap, o);
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1297,6 +1297,7 @@ $(TESTPREFIX)/unit-test-server-jobs-aux: $(OBJDIR)/tests/test_server_jobs_aux.o 
                                $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                $(OBJDIR)/db1/agent_jobs.o $(OBJDIR)/db1/execution_plans.o \
                                $(OBJDIR)/db1/coord_jobs.o $(OBJDIR)/server/delegate_role.o \
+                               $(OBJDIR)/role_templates.o \
                                $(OBJDIR)/json_fluent.o \
                                $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -2128,6 +2129,7 @@ $(TESTPREFIX)/unit-test-cmd-cancel: $(OBJDIR)/tests/test_cmd_cancel.o \
 
 $(TESTPREFIX)/unit-test-cmd-delegate: $(OBJDIR)/tests/test_cmd_delegate.o \
                              $(OBJDIR)/server/delegate_depth.o $(OBJDIR)/server/delegate_role.o \
+                             $(OBJDIR)/role_templates.o \
                              $(OBJDIR)/server/delegate_prompt.o $(OBJDIR)/server/delegate_routing.o \
                              $(OBJDIR)/server/delegate_checkout.o $(OBJDIR)/cJSON.o \
                              $(OBJDIR)/util.o $(OBJDIR)/posix/platform_process.o $(OBJDIR)/posix/util.o
@@ -2138,7 +2140,7 @@ $(TESTPREFIX)/unit-test-delegate-plan: $(OBJDIR)/tests/test_delegate_plan.o \
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-delegate-role: $(OBJDIR)/tests/test_delegate_role.o \
-                             $(OBJDIR)/server/delegate_role.o
+                             $(OBJDIR)/server/delegate_role.o $(OBJDIR)/role_templates.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-trigger: $(OBJDIR)/tests/test_trigger.o $(OBJDIR)/cJSON.o

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -2148,9 +2148,10 @@ static void test_session_isolation_guard(void)
    const char *primary = "/some/repo/src/x.c";
    const char *worktree = "/some/repo/.aimee/worktrees/ab12/main/src/x.c";
 
-   /* (1) Default off (no aimee.yaml): never blocks, even on the primary checkout. */
+   /* (1) Default ON (no aimee.yaml): a primary-checkout target is blocked, since
+    *     session-worktree isolation is required by default. */
    remove(cfg);
-   assert(agent_tools_session_isolation_blocks(primary, NULL) == 0);
+   assert(agent_tools_session_isolation_blocks(primary, NULL) == 1);
 
    /* (2) Explicit false: still no block. */
    FILE *f = fopen(cfg, "w");

--- a/src/tests/test_agent_max_turns.c
+++ b/src/tests/test_agent_max_turns.c
@@ -1,5 +1,6 @@
 /* test_agent_max_turns.c: unit tests for agent_resolve_max_turns(). */
 #include <assert.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -30,7 +31,7 @@ static void test_primary_ignores_agent_max_turns(void)
 {
    agent_t a = make_agent(30);
    int t = agent_resolve_max_turns(&a, NULL);
-   assert(t == 1000); /* falls through to primary default */
+   assert(t == INT_MAX); /* primary ignores the cap; infinite by default */
    printf("  PASS: primary ignores agent->max_turns\n");
 }
 
@@ -45,13 +46,13 @@ static void test_primary_uses_config_max_iterations(void)
    printf("  PASS: primary uses config max_iterations\n");
 }
 
-/* Primary session: max_turns == -1, no config → 1000 */
+/* Primary session: max_turns == -1, no config → INFINITE */
 static void test_primary_unlimited_default(void)
 {
    agent_t a = make_agent(-1);
    int t = agent_resolve_max_turns(&a, NULL);
-   assert(t == 1000);
-   printf("  PASS: primary unlimited default is 1000\n");
+   assert(t == INT_MAX);
+   printf("  PASS: primary unlimited default is infinite\n");
 }
 
 /* Delegate: agent->max_turns > 0 is honoured */
@@ -74,22 +75,22 @@ static void test_delegate_falls_back_to_config(void)
    printf("  PASS: delegate falls back to config max_iterations_delegate\n");
 }
 
-/* Delegate: max_turns unset, no config → compile-time default */
-static void test_delegate_compile_time_default(void)
+/* Delegate: max_turns unset (-1), no config cap → INFINITE (the default) */
+static void test_delegate_default_is_infinite(void)
 {
    agent_t a = make_agent(-1);
    int t = agent_resolve_max_turns(&a, "code");
-   assert(t == CONFIG_DEFAULT_MAX_ITERATIONS_DELEGATE);
-   printf("  PASS: delegate compile-time default is %d\n", CONFIG_DEFAULT_MAX_ITERATIONS_DELEGATE);
+   assert(t == INT_MAX);
+   printf("  PASS: delegate default (-1) is infinite\n");
 }
 
-/* max_turns == 0 means unlimited (1000 safety cap), regardless of role */
+/* max_turns <= 0 means infinite, regardless of role, unless a config cap is set. */
 static void test_zero_means_unlimited(void)
 {
    agent_t a = make_agent(0);
-   assert(agent_resolve_max_turns(&a, NULL) == 1000);
-   assert(agent_resolve_max_turns(&a, "code") == 1000);
-   printf("  PASS: max_turns==0 means unlimited (1000) for both primary and delegate\n");
+   assert(agent_resolve_max_turns(&a, NULL) == INT_MAX);
+   assert(agent_resolve_max_turns(&a, "code") == INT_MAX);
+   printf("  PASS: max_turns<=0 means infinite for both primary and delegate\n");
 }
 
 int main(void)
@@ -101,7 +102,7 @@ int main(void)
    test_primary_unlimited_default();
    test_delegate_honours_agent_max_turns();
    test_delegate_falls_back_to_config();
-   test_delegate_compile_time_default();
+   test_delegate_default_is_infinite();
    test_zero_means_unlimited();
 
    printf("test_agent_max_turns: all tests passed\n");

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -155,9 +155,10 @@ static void test_guard_enforcement(void)
    assert(handle_attention_guard() == 0); /* used 1 -> allow, count 2 */
    assert(handle_attention_guard() == 2); /* used 2 >= cap -> block */
 
-   /* (4) AIMEE_GUARD=0 bypasses even with a cap hit. */
+   /* (4) The removed AIMEE_GUARD env bypass no longer disables the guard: an
+    * agent cannot set an env var to escape the cap. Still blocked at the cap. */
    setenv("AIMEE_GUARD", "0", 1);
-   assert(handle_attention_guard() == 0);
+   assert(handle_attention_guard() == 2);
    unsetenv("AIMEE_GUARD");
 
    rm_path(logpath);
@@ -192,6 +193,15 @@ static void test_session_isolation_decision(void)
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", primary_cwd) == 1);
    assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, wt_cwd) == 0);
    assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, primary_cwd) == 1);
+
+   /* Claude Code's native worktrees (/.claude/worktrees/) are equally isolated
+    * branches and are honoured too (target path OR cwd). */
+   const char *cc_wt = "/home/u/repo/.claude/worktrees/feat/src/x.c";
+   const char *cc_wt_cwd = "/home/u/repo/.claude/worktrees/feat";
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, cc_wt, primary_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, cc_wt_cwd) == 0);
+   /* The loose "/.claude" prefix (e.g. ~/.claude/) is NOT a managed worktree. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "/home/u/.claude/x.c", primary_cwd) == 1);
 
    /* The loose "/.aimee-" prefix is NOT treated as a managed worktree (only the
     * canonical "/.aimee/worktrees/" counts) — avoids false-matching e.g. a
@@ -256,10 +266,11 @@ static void test_isolation_enforcement(void)
    g_stdin_json = READ_PRIMARY_HOOK;
    assert(handle_attention_guard() == 0);
 
-   /* (6) AIMEE_GUARD=0 bypasses even a blockable mutating op. */
+   /* (6) The AIMEE_GUARD env bypass was removed: setting it does NOT disable the
+    * guard, so an agent cannot escape isolation via an env var. Still blocked. */
    setenv("AIMEE_GUARD", "0", 1);
    g_stdin_json = EDIT_PRIMARY_HOOK;
-   assert(handle_attention_guard() == 0);
+   assert(handle_attention_guard() == 2);
    unsetenv("AIMEE_GUARD");
 
    rm_path(cfgpath);

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -233,12 +233,14 @@ static void test_isolation_enforcement(void)
    "{\"session_id\":\"isotest\",\"tool_name\":\"Read\","                                           \
    "\"tool_input\":{\"file_path\":\"/home/u/repo/src/x.c\"}}"
 
-   /* (1) Inert by default: no config -> mutating op on the primary checkout allowed. */
+   /* (1) Default ON: with no config, a mutating op on the primary checkout is
+    *     BLOCKED — session-worktree isolation is required by default so two aimee
+    *     sessions cannot collide on one shared git HEAD. */
    rm_path(cfgpath);
    g_stdin_json = EDIT_PRIMARY_HOOK;
-   assert(handle_attention_guard() == 0);
+   assert(handle_attention_guard() == 2);
 
-   /* (2) Explicit false also disabled. */
+   /* (2) Explicit false disables the guard (opt-out). */
    write_config("require_session_worktree: false\n");
    assert(handle_attention_guard() == 0);
 

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -14,6 +14,36 @@
 #include "provider_cli_adapter.h"
 #include "cJSON.h"
 
+/* role_template_max_turns() (via delegate_role.o, reached by the max-turns policy)
+ * reads the role_templates dir under config_default_dir() and parses `max_turns:`
+ * frontmatter (-1 when absent). Point it at a temp dir and lay down the templates
+ * the policy assertions expect (note: the "test" role canonicalizes to validate). */
+static char g_roles_dir[256];
+const char *config_default_dir(void)
+{
+   return g_roles_dir;
+}
+static void write_role_template(const char *canonical, int max_turns)
+{
+   char path[512];
+   snprintf(path, sizeof(path), "%s/role_templates/%s.md", g_roles_dir, canonical);
+   FILE *f = fopen(path, "w");
+   assert(f);
+   fprintf(f, "---\nmax_turns: %d\n---\nbody\n", max_turns);
+   fclose(f);
+}
+static void setup_role_templates(void)
+{
+   snprintf(g_roles_dir, sizeof(g_roles_dir), "/tmp/aimee-test-cmddel-XXXXXX");
+   assert(mkdtemp(g_roles_dir));
+   char sub[512];
+   snprintf(sub, sizeof(sub), "%s/role_templates", g_roles_dir);
+   assert(mkdir(sub, 0700) == 0);
+   write_role_template("review", 20);
+   write_role_template("validate", 12); /* "test" -> validate */
+   write_role_template("diagnose", 16);
+}
+
 /* Pull in only the declarations we need. */
 int delegate_check_chain_depth(int max_depth, char *errbuf, size_t errbuf_sz);
 
@@ -1122,6 +1152,7 @@ static void test_inline_acp_agent_no_args_and_guards(void)
 int main(void)
 {
    printf("test_cmd_delegate\n");
+   setup_role_templates();
    test_depth_zero_when_env_unset();
    test_depth_increments_from_env();
    test_depth_blocked_at_limit();

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -46,6 +46,9 @@ int main(void)
       memset(&cfg, 0, sizeof(cfg));
       config_load(&cfg);
       assert(strcmp(cfg.provider, "claude") == 0);
+      /* kb.typed_facts.* autonomous reconciliation defaults (§7.2/§8). */
+      assert(cfg.kb_typed_facts_auto_promote_enabled == 1);
+      assert(cfg.kb_typed_facts_promote_threshold == 3);
       assert(strcmp(cfg.guardrail_mode, "approve") == 0);
       /* §5 hybrid RRF weights + rank constant default to equal weights / k=60,
        * and the §7 blast-radius advisory is opt-in (off). */
@@ -199,6 +202,11 @@ int main(void)
       cfg.kb_curator_promote_min_sources = 5;
       cfg.kb_curator_synthesize_enabled = 1;
       cfg.kb_curator_synthesize_k = 4;
+      /* kb.typed_facts.* (§8): non-default values must round-trip (auto_promote
+       * defaults on, so set it off; promote_threshold defaults 3, so set 7). */
+      cfg.kb_typed_facts_auto_promote_enabled = 0;
+      cfg.kb_typed_facts_promote_threshold = 7;
+      cfg.typed_facts_enabled = 1; /* KB-owned master gate: persisted as kb.typed_facts.enabled */
       snprintf(cfg.kb_curator_judge_command, sizeof(cfg.kb_curator_judge_command), "judge --json");
       snprintf(cfg.kb_curator_synthesize_command, sizeof(cfg.kb_curator_synthesize_command),
                "synth --json");
@@ -428,6 +436,9 @@ int main(void)
       assert(cfg2.kb_curator_promote_min_sources == 5);
       assert(cfg2.kb_curator_synthesize_enabled == 1);
       assert(cfg2.kb_curator_synthesize_k == 4);
+      assert(cfg2.kb_typed_facts_auto_promote_enabled == 0);
+      assert(cfg2.kb_typed_facts_promote_threshold == 7);
+      assert(cfg2.typed_facts_enabled == 1);
       assert(strcmp(cfg2.kb_curator_judge_command, "judge --json") == 0);
       assert(strcmp(cfg2.kb_curator_synthesize_command, "synth --json") == 0);
       assert(strcmp(cfg2.kb_curator_provider_base_url, "http://curator:8080/v1") == 0);

--- a/src/tests/test_delegate_driver.c
+++ b/src/tests/test_delegate_driver.c
@@ -108,6 +108,27 @@ static void test_build_url(void)
    assert(strcmp(url, "https://api.anthropic.com/v1/messages") == 0);
    assert(strstr(url, "messages") != NULL);
 
+   /* Anthropic host root normalizes to /v1/messages */
+   snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.anthropic.com");
+   assert(delegate_build_url(d, &agent, url, sizeof(url)) == 0);
+   assert(strcmp(url, "https://api.anthropic.com/v1/messages") == 0);
+
+   /* Anthropic-compatible gateway with a path-prefixed base: /v1 must still be
+    * inserted (regression: this previously produced .../anthropic/messages -> 404). */
+   snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.minimax.io/anthropic");
+   assert(delegate_build_url(d, &agent, url, sizeof(url)) == 0);
+   assert(strcmp(url, "https://api.minimax.io/anthropic/v1/messages") == 0);
+
+   /* A path-prefixed base that already carries /v1 stays idempotent (no double /v1). */
+   snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.minimax.io/anthropic/v1");
+   assert(delegate_build_url(d, &agent, url, sizeof(url)) == 0);
+   assert(strcmp(url, "https://api.minimax.io/anthropic/v1/messages") == 0);
+
+   /* An endpoint already pointing at .../messages is left untouched. */
+   snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.minimax.io/anthropic/v1/messages");
+   assert(delegate_build_url(d, &agent, url, sizeof(url)) == 0);
+   assert(strcmp(url, "https://api.minimax.io/anthropic/v1/messages") == 0);
+
    /* ChatGPT: .../responses */
    snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.openai.com/v1");
    d = delegate_driver_get("chatgpt");

--- a/src/tests/test_delegate_role.c
+++ b/src/tests/test_delegate_role.c
@@ -4,6 +4,40 @@
 #include <string.h>
 #include "delegate_role.h"
 #include "agent_types.h"
+#include <stdlib.h>   /* mkdtemp */
+#include <sys/stat.h> /* mkdir */
+
+/* role_template_max_turns() (reached via delegate_default_max_turns_for_role) reads
+ * <config_default_dir()>/role_templates/<canonical-role>.md and parses `max_turns:`
+ * from its frontmatter, returning -1 when the file is absent. Stub config_default_dir
+ * at a temp dir and lay down the templates the inspection-policy assertions expect
+ * (note: the "test" role canonicalizes to "validate"). */
+static char g_roles_dir[256];
+const char *config_default_dir(void)
+{
+   return g_roles_dir;
+}
+static void write_role_template(const char *canonical, int max_turns)
+{
+   char path[512];
+   snprintf(path, sizeof(path), "%s/role_templates/%s.md", g_roles_dir, canonical);
+   FILE *f = fopen(path, "w");
+   assert(f);
+   fprintf(f, "---\nmax_turns: %d\n---\nbody\n", max_turns);
+   fclose(f);
+}
+static void setup_role_templates(void)
+{
+   snprintf(g_roles_dir, sizeof(g_roles_dir), "/tmp/aimee-test-roles-XXXXXX");
+   assert(mkdtemp(g_roles_dir));
+   char sub[512];
+   snprintf(sub, sizeof(sub), "%s/role_templates", g_roles_dir);
+   assert(mkdir(sub, 0700) == 0);
+   write_role_template("review", 20);
+   write_role_template("validate", 12); /* "test" -> validate */
+   write_role_template("diagnose", 16);
+   /* no code.md -> role_template_max_turns returns -1 for "code" */
+}
 
 static void test_canonical_roles_unchanged(void)
 {
@@ -234,6 +268,7 @@ static void test_auto_tools_policy(void)
 int main(void)
 {
    printf("test_delegate_role\n");
+   setup_role_templates();
    test_canonical_roles_unchanged();
    test_implement_maps_to_code();
    test_build_maps_to_code();

--- a/src/tests/test_gw_stage_memory.c
+++ b/src/tests/test_gw_stage_memory.c
@@ -41,6 +41,13 @@ char *kb_client_memory_facts(const char *query)
    (void)query;
    return NULL;
 }
+
+/* Typed-facts gate stub (typed_facts feature added this call to ingress_preinject.c;
+ * the test link needs the symbol). Off -> the builder's facts path stays inert. */
+int kb_client_typed_facts_enabled(void)
+{
+   return 0;
+}
 int kb_client_memory_diagnose(const char *query, int limit, memory_diagnostic_t *out, int max)
 {
    (void)query;

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -26,6 +26,14 @@ char *kb_client_memory_facts(const char *query)
    (void)query;
    return NULL;
 }
+
+/* Typed-facts gate stub: off, so the builder's facts path stays inert here
+ * (kb_client_memory_facts above already returns NULL). ingress_preinject.c gained
+ * this call with the typed_facts feature; the test link needs the symbol. */
+int kb_client_typed_facts_enabled(void)
+{
+   return 0;
+}
 int kb_client_memory_diagnose(const char *query, int limit, memory_diagnostic_t *out, int max)
 {
    (void)query;

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -11,6 +11,7 @@
 #include "kb_http.h"
 #include "kb/kb_surprising_judge.h" /* §4 judge stub seam (kb_surprising_verdict_t) */
 #include "db2/lifecycle.h"          /* §2c: db2_reembed_* / db2_dim_change_reset stub types */
+#include "rel_types.h"              /* REL_TYPE_NAME_MAX for the db2_ontology_* stubs below */
 #include "kb_service.h"
 #include "kb_bandit.h"
 #include "kb_service_backend.h"
@@ -360,6 +361,50 @@ int db2_curator_invalidations_since(int64_t since_id, void *out, int max)
    (void)since_id;
    (void)out;
    (void)max;
+   return 0;
+}
+
+/* Ontology-console db2 stubs + config_save: the typed_facts ontology console added
+ * these refs into kb_http_console.o; the real defs pull the whole db2/config stack,
+ * so stub them link-only (this test exercises routing, not the ontology backend). */
+long db2_ontology_eval_count(const char *rel_type)
+{
+   (void)rel_type;
+   return 0;
+}
+int db2_ontology_eval_status(const char *rel_type, char *out, size_t out_len)
+{
+   (void)rel_type;
+   if (out && out_len)
+      out[0] = '\0';
+   return 0;
+}
+int db2_ontology_eval_candidates(int threshold, char (*out)[REL_TYPE_NAME_MAX], int max)
+{
+   (void)threshold;
+   (void)out;
+   (void)max;
+   return 0;
+}
+int db2_ontology_approve(const char *rel_type)
+{
+   (void)rel_type;
+   return 0;
+}
+int db2_ontology_map(const char *novel, const char *target)
+{
+   (void)novel;
+   (void)target;
+   return 0;
+}
+int db2_ontology_reject(const char *rel_type)
+{
+   (void)rel_type;
+   return 0;
+}
+int config_save(const config_t *cfg)
+{
+   (void)cfg;
    return 0;
 }
 

--- a/src/tests/test_role_templates.c
+++ b/src/tests/test_role_templates.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include "../headers/role_templates.h"
+#include "../headers/config.h" /* config_default_dir */
 
 /* --- Helpers --- */
 
@@ -370,6 +371,36 @@ static void test_write_read_delete(void)
    assert(role_template_delete("triage") == 0);
 }
 
+static void test_role_max_turns_frontmatter(void)
+{
+   char dir[512];
+   snprintf(dir, sizeof(dir), "%s/role_templates", config_default_dir());
+   char mkcmd[600];
+   snprintf(mkcmd, sizeof(mkcmd), "mkdir -p '%s'", dir);
+   assert(system(mkcmd) == 0);
+
+   /* A max_turns frontmatter is read, and stripped from the built prompt. */
+   char path[600];
+   snprintf(path, sizeof(path), "%s/capped.md", dir);
+   write_file(path, "---\nmax_turns: 7\n---\n\nYou are a capped delegate. {{TASK}}\n");
+   assert(role_template_max_turns("capped") == 7);
+   char *built = role_template_build(NULL, "capped", "do it", NULL);
+   assert(built);
+   assert(strstr(built, "max_turns") == NULL); /* frontmatter stripped */
+   assert(strstr(built, "---") == NULL);
+   assert(strstr(built, "You are a capped delegate. do it") != NULL);
+   free(built);
+
+   /* No frontmatter => -1 (INFINITE, the default). */
+   snprintf(path, sizeof(path), "%s/plain.md", dir);
+   write_file(path, "You are a plain delegate. {{TASK}}\n");
+   assert(role_template_max_turns("plain") == -1);
+
+   /* Unknown role => -1. */
+   assert(role_template_max_turns("nonexistent_role_zzz") == -1);
+   printf("  test_role_max_turns_frontmatter: ok\n");
+}
+
 int main(void)
 {
    /* Isolate config_default_dir() so write/delete and user-dir scans do not
@@ -397,6 +428,7 @@ int main(void)
    test_install_defaults();
    test_install_defaults_null_dir();
    test_write_read_delete();
+   test_role_max_turns_frontmatter();
    printf("role_templates: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -544,6 +544,27 @@ int main(void)
       assert(server_http_authorize(0, "secret", NULL, NULL, 1) == 0);
    }
 
+   /* --- server_http_bootstrap_gate: the one-time bootstrap bearer may ONLY
+    *     rotate itself; every other TCP route is refused until it is rotated. --- */
+   {
+      unsetenv("AIMEE_API_BEARER_TOKEN"); /* TOFU active */
+      const char *BOOT = "aimee-local-dev";
+      /* Bootstrap still live: real routes refused (1), rotate_bearer allowed (0). */
+      assert(server_http_bootstrap_gate(1, BOOT, "GET", "/v1/config") == 1);
+      assert(server_http_bootstrap_gate(1, BOOT, "POST", "/v1/config/set") == 1);
+      assert(server_http_bootstrap_gate(1, BOOT, "POST", "/v1/api/rotate_bearer") == 0);
+      /* GET on the rotate path is not the rotate op -> still refused. */
+      assert(server_http_bootstrap_gate(1, BOOT, "GET", "/v1/api/rotate_bearer") == 1);
+      /* UDS is exempt (local trust). */
+      assert(server_http_bootstrap_gate(0, BOOT, "GET", "/v1/config") == 0);
+      /* Once rotated to a strong bearer, the gate is off for every route. */
+      assert(server_http_bootstrap_gate(1, "deadbeef-strong-token", "GET", "/v1/config") == 0);
+      /* Operator-pinned bearer opts out of TOFU even if it equals the bootstrap. */
+      setenv("AIMEE_API_BEARER_TOKEN", BOOT, 1);
+      assert(server_http_bootstrap_gate(1, BOOT, "GET", "/v1/config") == 0);
+      unsetenv("AIMEE_API_BEARER_TOKEN");
+   }
+
    /* --- typed SSE framing: embedded newlines become repeated data: lines --- */
    {
       char frame[256];

--- a/src/tests/test_server_jobs_aux.c
+++ b/src/tests/test_server_jobs_aux.c
@@ -7,6 +7,31 @@
 #include "server.h"
 #include "cJSON.h"
 
+#include <sys/stat.h> /* mkdir */
+/* agent_job_to_json() serializes default_max_turns = delegate_default_max_turns_for_role
+ * (role_template_max_turns), which reads the role_templates dir under
+ * config_default_dir() (-1 when absent). The handler tests assert default_max_turns==20
+ * for a review job, so point config_default_dir at a temp dir and lay down the template. */
+static char g_roles_dir[256];
+const char *config_default_dir(void)
+{
+   return g_roles_dir;
+}
+static void setup_role_templates(void)
+{
+   snprintf(g_roles_dir, sizeof(g_roles_dir), "/tmp/aimee-test-jobsaux-XXXXXX");
+   assert(mkdtemp(g_roles_dir));
+   char sub[512];
+   snprintf(sub, sizeof(sub), "%s/role_templates", g_roles_dir);
+   assert(mkdir(sub, 0700) == 0);
+   char path[600];
+   snprintf(path, sizeof(path), "%s/review.md", sub);
+   FILE *f = fopen(path, "w");
+   assert(f);
+   fprintf(f, "---\nmax_turns: 20\n---\nbody\n");
+   fclose(f);
+}
+
 static cJSON *g_last_response = NULL;
 static char g_last_error[256];
 
@@ -265,6 +290,7 @@ static void test_aux_handlers(void)
 
 int main(void)
 {
+   setup_role_templates();
    assert(db1_init(":memory:") == 0);
    printf("test_server_jobs_aux\n");
    test_jobs_handlers();


### PR DESCRIPTION
Promote to release the security fix #1138 (server-enforced bootstrap bearer rotation — closes the standing-credential hole where the image-seeded `aimee-local-dev` bearer stayed valid after init). Rebuilds aimee-server at the new version.