### PR TITLE
fix(delegate): anthropic driver targets /v1/messages for path-prefixed bases

### DIFF
--- a/src/server/delegate_openai.c
+++ b/src/server/delegate_openai.c
@@ -201,7 +201,26 @@ static void delegate_payload_rewrite_track(cJSON *messages, const char *system_p
 
 static int anthropic_build_url(const agent_t *agent, char *url, size_t url_len)
 {
-   return openai_join_endpoint(agent->endpoint, "/messages", url, url_len);
+   /* The Anthropic Messages API always lives at <base>/v1/messages. Unlike the
+    * OpenAI join, the /v1 version segment is part of the operation path rather
+    * than the caller-supplied base, so we insert it for ANY base that does not
+    * already carry it — not only bare host roots (which is all
+    * openai_join_endpoint would handle). This lets anthropic-compatible
+    * gateways be registered with a path-prefixed base (e.g.
+    * https://api.minimax.io/anthropic) without hand-baking /v1 into the
+    * endpoint; without it the join produced .../anthropic/messages -> 404. */
+   char base[MAX_ENDPOINT_LEN];
+
+   trim_trailing_slashes(agent->endpoint, base, sizeof(base));
+   if (!base[0])
+      return -1;
+   if (url_has_suffix(base, "/messages")) /* already a full messages URL */
+      snprintf(url, url_len, "%s", base);
+   else if (url_has_suffix(base, "/v1")) /* base already carries the version */
+      snprintf(url, url_len, "%s/messages", base);
+   else
+      snprintf(url, url_len, "%s/v1/messages", base);
+   return 0;
 }
 
 static cJSON *anthropic_build_request(const agent_t *agent, cJSON *messages, cJSON *tools,

--- a/src/tests/test_delegate_driver.c
+++ b/src/tests/test_delegate_driver.c
@@ -108,6 +108,27 @@ static void test_build_url(void)
    assert(strcmp(url, "https://api.anthropic.com/v1/messages") == 0);
    assert(strstr(url, "messages") != NULL);
 
+   /* Anthropic host root normalizes to /v1/messages */
+   snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.anthropic.com");
+   assert(delegate_build_url(d, &agent, url, sizeof(url)) == 0);
+   assert(strcmp(url, "https://api.anthropic.com/v1/messages") == 0);
+
+   /* Anthropic-compatible gateway with a path-prefixed base: /v1 must still be
+    * inserted (regression: this previously produced .../anthropic/messages -> 404). */
+   snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.minimax.io/anthropic");
+   assert(delegate_build_url(d, &agent, url, sizeof(url)) == 0);
+   assert(strcmp(url, "https://api.minimax.io/anthropic/v1/messages") == 0);
+
+   /* A path-prefixed base that already carries /v1 stays idempotent (no double /v1). */
+   snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.minimax.io/anthropic/v1");
+   assert(delegate_build_url(d, &agent, url, sizeof(url)) == 0);
+   assert(strcmp(url, "https://api.minimax.io/anthropic/v1/messages") == 0);
+
+   /* An endpoint already pointing at .../messages is left untouched. */
+   snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.minimax.io/anthropic/v1/messages");
+   assert(delegate_build_url(d, &agent, url, sizeof(url)) == 0);
+   assert(strcmp(url, "https://api.minimax.io/anthropic/v1/messages") == 0);
+
    /* ChatGPT: .../responses */
    snprintf(agent.endpoint, sizeof(agent.endpoint), "https://api.openai.com/v1");
    d = delegate_driver_get("chatgpt");


### PR DESCRIPTION
## Problem

`anthropic_build_url` (`src/server/delegate_openai.c`) reused `openai_join_endpoint`, which only inserts the `/v1` version segment when the endpoint is a **bare host root**. An anthropic-compatible gateway registered with a **path-prefixed** base builds the wrong URL:

- endpoint `https://api.minimax.io/anthropic` → built `.../anthropic/messages` → **404**
- correct path is `.../anthropic/v1/messages`

This broke the newly-added **`mimo-v2.5-pro`** and **`MiniMax-M3`** delegates (both `provider: anthropic`, base ending in `/anthropic`). **`GLM-5.2`** was unaffected because it's an OpenAI-provider delegate whose `/chat/completions` path appends to its full base.

Verified against the live providers: `POST /anthropic/messages` → `404`, `POST /anthropic/v1/messages` → `401` (auth challenge = correct path).

## Fix

Give the anthropic driver its own join that inserts `/v1` for any base that doesn't already carry it, staying **idempotent**:

| endpoint | built URL |
|---|---|
| `https://api.anthropic.com` (host root) | `.../v1/messages` |
| `https://api.anthropic.com/v1` | `.../v1/messages` |
| `https://api.minimax.io/anthropic` | `.../anthropic/v1/messages` |
| `https://api.minimax.io/anthropic/v1` | `.../anthropic/v1/messages` |
| `.../anthropic/v1/messages` | unchanged |

## Test

Extends `test_build_url` in `test_delegate_driver.c` with the path-prefixed, host-root, already-`/v1`, and already-`/messages` anthropic cases. `unit-test-delegate-driver` passes.

## Validation

With the equivalent endpoint fix applied live, all three delegates probe `execution: ok` and complete real `aimee delegate draft --via <name>` jobs end-to-end (mimo, minimax, GLM).