### PR TITLE
fix(ci): resilient apt install + config.h self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,12 @@ jobs:
           echo "::endgroup::"
       - name: Install clang-format
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q clang-format-19
       - name: Check formatting
         run: cd src && make lint
@@ -75,7 +80,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -115,7 +125,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -163,7 +178,12 @@ jobs:
             "$img"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev postgresql-client
@@ -192,7 +212,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -394,7 +419,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -419,7 +449,12 @@ jobs:
           echo "::endgroup::"
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
             libpq-dev
@@ -517,7 +552,12 @@ jobs:
           df -h / | tail -1
       - name: Install dependencies
         run: |
-          sudo apt-get update -q
+          # GitHub runners preinstall third-party apt repos (e.g. packages.microsoft.com)
+          # that intermittently serve invalid/unsigned metadata and fail `apt-get update`
+          # hard — though none of our packages come from them. Drop them, then retry
+          # update with backoff so a transient mirror hiccup doesn't fail the job.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
           sudo apt-get install -y -q gcc make git \
             libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libpq-dev
       - name: Build + run the opt-in tree-sitter test

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -3,6 +3,9 @@
 
 #include "sandbox.h"
 #include "prompts.h" /* aimee_mode_t */
+#include <stdint.h>  /* int64_t (used below) — keep config.h self-contained so any
+                      * includer (e.g. cli_remote.c on MinGW) compiles regardless of
+                      * include order. */
 #include <stdlib.h>
 #if !defined(_WIN32) && !defined(_WIN64)
 #include <unistd.h>


### PR DESCRIPTION
Two CI failures surfaced on the v0.2.175 promote run — one genuinely flaky, one a real regression. Both fixed.

## Flaky (Linux `build` / `init-migrate-service-test` / `bench-check`)
`apt-get update` failed hard because the runner's preinstalled `packages.microsoft.com` repo served invalid signing metadata (`Clearsigned file isn't valid, got 'NOSPLIT'`) — a transient, external repo none of our packages come from. `build-integrity` (identical step) passed, confirming non-determinism.

**Fix:** drop the unneeded third-party repos and retry `apt-get update` with backoff (mirrors the existing Postgres-pull-retry pattern). Applied to all 8 install steps via one change.

## Real (Windows / MinGW `windows-build` + `windows-cmake`)
`config.h:1682: error: unknown type name 'int64_t'`. `config.h` uses `int64_t` but never included `<stdint.h>` — it only compiled by luck of include order. The bootstrap-bearer fix (#1138) made `cli_remote.c` `#include "config.h"`, which exposed the latent bug on MinGW.

**Fix:** add `#include <stdint.h>` to `config.h` so it's self-contained for every includer.

## Verified
- `server` + `aimee` build clean under `-Werror`; `unit-test-server-http` passes.
- Windows compile fix is the correct root-cause change (can't run MinGW locally; CI on this PR confirms).

Follows the newly-recorded rule: fix flaky tests at the root, don't just re-run to green.