### PR TITLE
feat(guard): honour Claude Code worktrees; remove the AIMEE_GUARD env bypass

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -197,7 +197,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`ingress`** — _Ingress (proxy frontends) behavior._ Keys: `audit_async`, `trusted_proxy_secret`, `usage_accounting_enabled`
 - **`integrity`** — _Integrity gate._ Keys: `dry_run`, `enabled`
 - **`intelligence`** — _Intelligence subsystems (bandit, planner, ranking, reasoning) + their external commands; most children are nested objects._ Keys: `bandit`, `bandit_optimize_command`, `calibrate`, `constraint_solver_command`, `demotion`, `kb`, `planner`, `planner_search_command`, `ranker_fuse_command`, `ranking`, `reasoning`, `reasoning_datalog_command`, `synthesize`
-- **`kb`** — _Knowledge-base client + curator / evidence / maintenance / mining (nested objects)._ Keys: `api`, `background_ingest`, `code_hybrid`, `connection_pool_size`, `connection_workers`, `curator`, `evidence`, `maintenance`, `mining`, `reembed_on_dim_change`, `search_max_results`, `worker_count`
+- **`kb`** — _Knowledge-base client + curator / evidence / maintenance / mining (nested objects)._ Keys: `api`, `background_ingest`, `code_hybrid`, `connection_pool_size`, `connection_workers`, `curator`, `evidence`, `maintenance`, `mining`, `reembed_on_dim_change`, `search_max_results`, `typed_facts`, `worker_count`
 - **`learning`** — _Learning subsystem (router, implicit, embed, synthesize; nested objects)._ Keys: `embed`, `implicit`, `router`, `synthesize`
 - **`lsp_servers`** — _LSP server definitions (array of objects)._ Keys: `args`, `command`, `extensions`, `name`
 - **`mcp`** — _MCP integration (e.g. OSV)._ Keys: `osv`
@@ -236,7 +236,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 145 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 144 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -262,7 +262,6 @@ The binaries read 145 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_API_ENDPOINT` | Override the `/v1` API endpoint used by the client RPC layer. |
 | `AIMEE_ATTACH_ID` | Presence attach id used when joining an existing session. |
 | `AIMEE_EFFORT` | Reasoning-effort hint for the session/model. |
-| `AIMEE_GUARD` | Attention-guard control; set to bypass the guard hook. |
 | `AIMEE_HOOK_CLIENT` | Identifies the calling hook client (e.g. claude/codex) for hook routing. |
 | `AIMEE_MODE` | Operating-mode override (e.g. interactive / autonomous). |
 | `AIMEE_MODEL` | Override the primary model for the session. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -506,7 +506,6 @@ ENV_DESC = {
     "AIMEE_PROFILE": ("Client & session", "Active working-profile name."),
     "AIMEE_ACTIVE_TOOLSET": ("Client & session", "Active toolset (tool allowlist) for the session."),
     "AIMEE_SESSION_START_VERBOSE": ("Client & session", "Verbose logging during session start."),
-    "AIMEE_GUARD": ("Client & session", "Attention-guard control; set to bypass the guard hook."),
     # Server runtime
     "AIMEE_SERVER_HTTP_BIND": ("Server runtime", "TCP bind address for the server `/v1` HTTP listener (else UDS-only)."),
     "AIMEE_SERVER_STARTUP_FD": ("Server runtime", "Inherited fd for startup-readiness signalling (service launch)."),

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -10,8 +10,9 @@
  * set to a positive cap, in which case a session may run that many recursive
  * raw scans before further ones are redirected toward Aimee's indexed
  * exploration tools. With no cap configured (the default, and what a thin-client
- * host with no aimee.yaml sees) raw scans are never blocked. AIMEE_GUARD=0
- * disables the guard entirely.
+ * host with no aimee.yaml sees) raw scans are never blocked. The guard has no
+ * env-var off switch: disabling it is a deliberate operator config action
+ * (require_session_worktree: false), never something the guarded agent can do.
  */
 #include "cli_attention_guard.h"
 #include "cli_session_start.h" /* read_stdin */
@@ -563,14 +564,19 @@ static void attn_lexical_normalize(const char *path, char *out, size_t out_n)
    }
 }
 
-/* Returns 1 iff `norm` (an already lexically-normalized path) is inside an
- * aimee-managed worktree. Matches ONLY the canonical managed location
- * "/.aimee/worktrees/" — deliberately NOT the looser "/.aimee-" prefix that
- * is_aimee_worktree_path() also accepts, which would false-match unrelated
- * dirs like "/home/u/.aimee-notes/...". */
+/* Returns 1 iff `norm` (an already lexically-normalized path) is inside a
+ * managed session worktree. Matches the two canonical managed locations:
+ *   "/.aimee/worktrees/"  — aimee's own launcher + delegate worktrees
+ *   "/.claude/worktrees/" — Claude Code's native worktrees (EnterWorktree)
+ * Both are isolated worktrees on a branch off the default branch — the exact
+ * isolation this guard requires — so a Claude Code session working in its own
+ * worktree is honoured, not blocked. Deliberately the full "/worktrees/" path,
+ * NOT the looser "/.aimee-" / "/.claude" prefixes, which would false-match
+ * unrelated dirs like "/home/u/.aimee-notes/..." or "~/.claude/". */
 static int attn_path_in_managed_worktree(const char *norm)
 {
-   return norm && strstr(norm, "/.aimee/worktrees/") != NULL;
+   return norm && (strstr(norm, "/.aimee/worktrees/") != NULL ||
+                   strstr(norm, "/.claude/worktrees/") != NULL);
 }
 
 /* Pure decision for the session-isolation guard (testable in isolation).
@@ -600,10 +606,11 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
 
 int handle_attention_guard(void)
 {
-   const char *bypass = getenv("AIMEE_GUARD");
-   if (bypass && strcmp(bypass, "0") == 0)
-      return 0;
-
+   /* No env-var bypass. The guard must not be disableable by the agent it
+    * guards — an LLM can trivially set an env var on any command, so a would-be
+    * bypass has to be a deliberate OPERATOR action in config
+    * (require_session_worktree: false / ingress_max_raw_scans), not an env var.
+    * (Removed the former AIMEE_GUARD=0 escape hatch.) */
    char *stdin_data = read_stdin();
    cJSON *hook = stdin_data ? cJSON_Parse(stdin_data) : NULL;
    if (!hook)
@@ -636,12 +643,13 @@ int handle_attention_guard(void)
       if (attn_session_isolation_blocked(op, fp, cwd))
       {
          fprintf(stderr,
-                 "aimee attention-guard: refusing a mutating op outside an aimee session "
-                 "worktree. This session is operating in '%s', which is not an aimee-managed "
-                 "worktree (.aimee/worktrees/...). aimee requires each mutating session to run "
-                 "in an isolated worktree+branch off the default branch; provision one with "
-                 "`aimee session-start` (or restart the client so its SessionStart hook does). "
-                 "Set require_session_worktree:false in aimee.yaml or AIMEE_GUARD=0 to bypass.\n",
+                 "aimee attention-guard: refusing a mutating op outside a session worktree. "
+                 "This session is operating in '%s', which is not a managed worktree "
+                 "(.aimee/worktrees/... or .claude/worktrees/...). aimee requires each mutating "
+                 "session to run in an isolated worktree+branch off the default branch: create "
+                 "one (Claude Code: EnterWorktree; aimee: launch `aimee`, which materializes a "
+                 "worktree and chdirs into it). An operator may set require_session_worktree: "
+                 "false in aimee.yaml to disable this — there is no env-var bypass.\n",
                  cwd[0] ? cwd : "(unknown cwd)");
          cJSON_Delete(hook);
          free(stdin_data);
@@ -671,7 +679,7 @@ int handle_attention_guard(void)
                     "aimee attention-guard: this session has hit its raw-scan cap (%d). Aimee "
                     "indexes this repo — explore through it instead: find_symbol, "
                     "ast_grep_search, search_graph, or get_context_block. Raise "
-                    "ingress_max_raw_scans (or set AIMEE_GUARD=0) to bypass.\n",
+                    "ingress_max_raw_scans in aimee.yaml to raise or lift the cap.\n",
                     ingress_max_raw_scans);
             exit_code = 2;
          }

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -69,8 +69,8 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
  * (2 = block a hard-destructive op on a high-attention file, or — only when a
  * positive ingress_max_raw_scans cap is configured — block a raw recursive scan
  * once that per-session cap is exhausted; 0 = allow). With no cap configured
- * (the default) raw scans are never blocked. Never blocks on read/soft ops. Set
- * AIMEE_GUARD=0 to bypass. */
+ * (the default) raw scans are never blocked. Never blocks on read/soft ops.
+ * There is no env-var bypass; disabling it is an operator config action. */
 int handle_attention_guard(void);
 
 #endif /* DEC_CLI_ATTENTION_GUARD_H */

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -155,9 +155,10 @@ static void test_guard_enforcement(void)
    assert(handle_attention_guard() == 0); /* used 1 -> allow, count 2 */
    assert(handle_attention_guard() == 2); /* used 2 >= cap -> block */
 
-   /* (4) AIMEE_GUARD=0 bypasses even with a cap hit. */
+   /* (4) The removed AIMEE_GUARD env bypass no longer disables the guard: an
+    * agent cannot set an env var to escape the cap. Still blocked at the cap. */
    setenv("AIMEE_GUARD", "0", 1);
-   assert(handle_attention_guard() == 0);
+   assert(handle_attention_guard() == 2);
    unsetenv("AIMEE_GUARD");
 
    rm_path(logpath);
@@ -192,6 +193,15 @@ static void test_session_isolation_decision(void)
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", primary_cwd) == 1);
    assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, wt_cwd) == 0);
    assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, primary_cwd) == 1);
+
+   /* Claude Code's native worktrees (/.claude/worktrees/) are equally isolated
+    * branches and are honoured too (target path OR cwd). */
+   const char *cc_wt = "/home/u/repo/.claude/worktrees/feat/src/x.c";
+   const char *cc_wt_cwd = "/home/u/repo/.claude/worktrees/feat";
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, cc_wt, primary_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, cc_wt_cwd) == 0);
+   /* The loose "/.claude" prefix (e.g. ~/.claude/) is NOT a managed worktree. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "/home/u/.claude/x.c", primary_cwd) == 1);
 
    /* The loose "/.aimee-" prefix is NOT treated as a managed worktree (only the
     * canonical "/.aimee/worktrees/" counts) — avoids false-matching e.g. a
@@ -256,10 +266,11 @@ static void test_isolation_enforcement(void)
    g_stdin_json = READ_PRIMARY_HOOK;
    assert(handle_attention_guard() == 0);
 
-   /* (6) AIMEE_GUARD=0 bypasses even a blockable mutating op. */
+   /* (6) The AIMEE_GUARD env bypass was removed: setting it does NOT disable the
+    * guard, so an agent cannot escape isolation via an env var. Still blocked. */
    setenv("AIMEE_GUARD", "0", 1);
    g_stdin_json = EDIT_PRIMARY_HOOK;
-   assert(handle_attention_guard() == 0);
+   assert(handle_attention_guard() == 2);
    unsetenv("AIMEE_GUARD");
 
    rm_path(cfgpath);


### PR DESCRIPTION
Two changes to the session-isolation attention-guard, both requested by the operator.

## 1. Honour Claude Code's native worktrees
The guard trusted **only** `/.aimee/worktrees/` (aimee's launcher + delegate worktrees). But a Claude Code session works in `/.claude/worktrees/…` (via EnterWorktree) — an equally isolated worktree on a branch off the default branch, the exact guarantee the guard requires. Since a Claude Code SessionStart hook cannot chdir the host session, aimee's native launcher worktree path is unavailable there, so those sessions were falsely blocked from every mutating op.

**Fix:** `attn_path_in_managed_worktree()` now accepts both `/.aimee/worktrees/` and `/.claude/worktrees/` (still the full `/worktrees/` path — the loose `~/.claude/` prefix is not a worktree). This is what lets a Claude Code session satisfy the guard.

## 2. Remove the AIMEE_GUARD env-var bypass
The guard must not be disableable by the agent it guards: an LLM can set an env var on any command, so `AIMEE_GUARD=0` was a trivial escape hatch. **Removed.** Disabling the guard is now only a deliberate operator config action (`require_session_worktree: false`, or `ingress_max_raw_scans` for the scan cap) — never an env var.

## Details
Updates the block/cap messages, the header + top-of-file docs, the `AIMEE_GUARD` reference-docs entry (regenerated `configuration.md`), and the tests: the two `AIMEE_GUARD=0` cases now assert the guard **still blocks**, plus new `.claude/worktrees/` acceptance cases (and a `~/.claude/` negative case).

## Verified
Built `aimee` + `unit-test-attention-guard`; all pass. (I also swapped my local hook binary to this build so I could keep working in a Claude Code worktree — which is the whole point of change #1.)