### PR TITLE
fix(e2e): enroll the bootstrap bearer before probing (fixes e2e-docker)

### DIFF
--- a/scripts/aimee-combined-docker-smoke.sh
+++ b/scripts/aimee-combined-docker-smoke.sh
@@ -104,6 +104,21 @@ if [[ "$DO_UP" == 1 ]]; then
   done
 fi
 
+# Bootstrap-bearer enrollment: the image seeds `aimee-local-dev`, which the server
+# now honours ONLY for POST /v1/api/rotate_bearer. Rotate once to the strong token
+# and use it for every check below (mirrors a real client's first connect).
+if [[ "$BEARER" == "aimee-local-dev" ]]; then
+  bold "==> Enrolling: rotate the one-time bootstrap bearer"
+  rotated="$(curl -fsS -k --max-time 20 "${AUTH[@]}" -X POST "${SERVER_URL}/v1/api/rotate_bearer" -d '{}' 2>/dev/null \
+             | sed -n 's/.*"bearer_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  if [[ -n "$rotated" ]]; then
+    BEARER="$rotated"; AUTH=(-H "Authorization: Bearer ${BEARER}")
+    green "    enrolled: bootstrap bearer rotated to a strong per-deployment token"
+  else
+    red "    FAIL  enrollment: could not rotate the bootstrap bearer"; FAIL=$((FAIL + 1))
+  fi
+fi
+
 bold "==> Server-native surface at ${SERVER_URL}"
 check "GET /v1/health"  '"service":"aimee-server"' "${SERVER_URL}/v1/health"
 check "GET /v1/version" 'version'                  "${SERVER_URL}/v1/version"

--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -132,6 +132,23 @@ if [[ "$DO_UP" == 1 ]]; then
   done
 fi
 
+# Bootstrap-bearer enrollment. The image seeds `aimee-local-dev`, which the server
+# now honours ONLY for POST /v1/api/rotate_bearer (trust-on-first-use enrollment).
+# Rotate once to the strong per-deployment bearer and use it for every check below
+# — exactly what a real client's first connect does. Skips when an operator pinned
+# a non-bootstrap BEARER.
+if [[ "$BEARER" == "aimee-local-dev" ]]; then
+  bold "==> Enrolling: rotate the one-time bootstrap bearer"
+  rotated="$(curl -fsS -k --max-time 20 "${AUTH[@]}" -X POST "${SERVER_URL}/v1/api/rotate_bearer" -d '{}' 2>/dev/null \
+             | sed -n 's/.*"bearer_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  if [[ -n "$rotated" ]]; then
+    BEARER="$rotated"; AUTH=(-H "Authorization: Bearer ${BEARER}")
+    green "    enrolled: bootstrap bearer rotated to a strong per-deployment token"
+  else
+    red "    FAIL  enrollment: could not rotate the bootstrap bearer"; FAIL=$((FAIL + 1))
+  fi
+fi
+
 bold "==> Server-native surface at ${SERVER_URL}"
 check "GET /v1/health"   '"service":"aimee-server"' "${SERVER_URL}/v1/health"
 check "GET /v1/version"  'version'                  "${SERVER_URL}/v1/version"

--- a/scripts/aimee-server-standalone-docker-smoke.sh
+++ b/scripts/aimee-server-standalone-docker-smoke.sh
@@ -94,6 +94,21 @@ if [[ "$DO_UP" == 1 ]]; then
   done
 fi
 
+# Bootstrap-bearer enrollment: the image seeds `aimee-local-dev`, which the server
+# now honours ONLY for POST /v1/api/rotate_bearer. Rotate once to the strong token
+# and use it for every check below (mirrors a real client's first connect).
+if [[ "$BEARER" == "aimee-local-dev" ]]; then
+  bold "==> Enrolling: rotate the one-time bootstrap bearer"
+  rotated="$(curl -fsS -k --max-time 20 "${AUTH[@]}" -X POST "${SERVER_URL}/v1/api/rotate_bearer" -d '{}' 2>/dev/null \
+             | sed -n 's/.*"bearer_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  if [[ -n "$rotated" ]]; then
+    BEARER="$rotated"; AUTH=(-H "Authorization: Bearer ${BEARER}")
+    green "    enrolled: bootstrap bearer rotated to a strong per-deployment token"
+  else
+    red "    FAIL  enrollment: could not rotate the bootstrap bearer"; FAIL=$((FAIL + 1))
+  fi
+fi
+
 bold "==> Server-native DB1 surface at ${SERVER_URL}"
 check "GET /v1/health"  '"service":"aimee-server"' "${SERVER_URL}/v1/health"
 check "GET /v1/version" 'version'                  "${SERVER_URL}/v1/version"


### PR DESCRIPTION
The bootstrap-bearer trust-on-first-use enforcement (#1138) makes the image-seeded `aimee-local-dev` bearer valid **only** for `POST /v1/api/rotate_bearer` — every other route returns 401 until rotated. The T2/T3/T4 docker smokes hit `/v1/health`, `/v1/version`, `/v1/kb/*` with `aimee-local-dev` directly, so they've been red since #1138 (`curl -f` → 'no response / curl error'). This is the `e2e-docker` failure flagged on the promote.

**Fix:** after the container reports healthy, each server smoke now rotates the bootstrap bearer to the strong per-deployment token and uses it for every subsequent check — exactly what a real client's first connect does. Skips when an operator pinned a non-bootstrap `BEARER`. Applied to all three server smokes (`aimee-server-docker-smoke`, `-standalone-`, `-combined-`); the kb-only T1 smoke is unaffected (kb has no bootstrap gate).

Verified: `bash -n` clean on all three; the rotate→extract flow matches the server's `{"bearer_token":"..."}` response (validated the sed). The `e2e-docker` check on this PR is the end-to-end confirmation.