### PR TITLE
feat(frontend): split Roles into its own tab (turn limits are role-only)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import EditWorkflows from './pages/EditWorkflows';
 import WorkflowActions from './pages/WorkflowActions';
 import Agents from './pages/Agents';
 import Personas from './pages/Personas';
+import Roles from './pages/Roles';
 import Settings from './pages/Settings';
 import Projects from './pages/Projects';
 import Graph from './pages/Graph';
@@ -72,6 +73,7 @@ const NAV_ITEMS: Tab[] = [
   { label: 'Workflow Actions', icon: '📝', route: '/workflow-actions' },
   { label: 'Agents', icon: '🤝', route: '/agents' },
   { label: 'Personas', icon: '🎭', route: '/personas' },
+  { label: 'Roles', icon: '🎬', route: '/roles' },
   { label: 'Projects', icon: '📁', route: '/projects' },
   { label: 'Graph', icon: '🕸️', route: '/graph' },
   { label: 'Editor', icon: '🖥️', route: '/editor' },
@@ -249,6 +251,7 @@ export default function App() {
                 <Route path="/agents" element={<Agents />} />
                 <Route path="/delegates" element={<Navigate to="/agents" replace />} />
                 <Route path="/personas" element={<Personas />} />
+                <Route path="/roles" element={<Roles />} />
                 <Route path="/projects" element={<Projects />} />
                 <Route path="/graph" element={<Graph />} />
                 <Route path="/editor" element={<Editor />} />

--- a/frontend/src/pages/Personas.tsx
+++ b/frontend/src/pages/Personas.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Panel, Badge } from "@rakuensoftware/smoothgui";
 
-/* Personas page: edit the shared ROLE vocabulary (name + what each role does) and
- * the PERSONA definitions (identity + the roles each persona may use). Roles are
- * the key that routing matches between personas and agents, so both are edited
- * here. Moved out of the Edit Workflows tab. */
+/* Personas page: edit the PERSONA definitions (identity + the roles each persona
+ * may use). Roles themselves — their bodies and per-role turn caps — live on the
+ * separate Roles tab; this page only reads the role list to offer them as routing
+ * chips. A persona never carries a turn limit. */
 
 async function getJSON<T>(url: string): Promise<T> {
   const r = await fetch(url, { headers: { "X-CSRF-Token": window._csrf || "" } });
@@ -67,84 +67,20 @@ const ta: React.CSSProperties = {
 };
 const nameOk = (s: string) => /^[a-z0-9][a-z0-9_-]*$/i.test(s);
 
-/* Upsert `max_turns` into a role template's YAML frontmatter so the dedicated
- * field and the raw body stay consistent on save. -1 = infinite. */
-function withMaxTurns(body: string, mt: number): string {
-  const fm = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
-  const m = body.match(fm);
-  if (m) {
-    let inner = m[1];
-    inner = /^max_turns:.*$/m.test(inner)
-      ? inner.replace(/^max_turns:.*$/m, `max_turns: ${mt}`)
-      : `max_turns: ${mt}\n${inner}`;
-    return body.replace(fm, `---\n${inner}\n---\n\n`);
-  }
-  return `---\nmax_turns: ${mt}\n---\n\n${body}`;
-}
-
 type Status = { kind: "ok" | "err"; msg: string } | null;
 
 export default function Personas() {
   const [status, setStatus] = useState<Status>(null);
 
-  // ---- roles registry ----
+  // Role names — read-only here, used only as routing chips. Roles are edited on
+  // the Roles tab.
   const [roles, setRoles] = useState<string[]>([]);
-  const [roleSel, setRoleSel] = useState<string | null>(null);
-  const [roleBody, setRoleBody] = useState("");
-  const [roleMaxTurns, setRoleMaxTurns] = useState<number>(-1); // -1 = infinite
 
   const refreshRoles = useCallback(() => {
     getJSON<{ role_templates?: string[] }>("/api/roles")
       .then((d) => setRoles((d.role_templates || []).slice().sort()))
       .catch(() => setRoles([]));
   }, []);
-
-  const openRole = useCallback((name: string) => {
-    setRoleSel(name);
-    setRoleBody("");
-    setRoleMaxTurns(-1);
-    getJSON<{ content?: string; max_turns?: number }>(`/api/roles/${encodeURIComponent(name)}`)
-      .then((d) => {
-        setRoleBody(d.content || "");
-        setRoleMaxTurns(typeof d.max_turns === "number" ? d.max_turns : -1);
-      })
-      .catch(() => setRoleBody(""));
-  }, []);
-
-  const saveRole = async () => {
-    if (!roleSel) return;
-    const { status: st } = await sendJSON("PUT", `/api/roles/${encodeURIComponent(roleSel)}`, {
-      content: withMaxTurns(roleBody, roleMaxTurns),
-    });
-    if (st >= 200 && st < 300) {
-      setStatus({ kind: "ok", msg: `role “${roleSel}” saved` });
-      refreshRoles();
-    } else setStatus({ kind: "err", msg: `save failed (${st})` });
-  };
-
-  const newRole = () => {
-    const name = window.prompt("New role name (letters, digits, - or _):")?.trim();
-    if (!name) return;
-    if (!nameOk(name)) {
-      setStatus({ kind: "err", msg: "invalid role name" });
-      return;
-    }
-    setRoleSel(name);
-    setRoleBody(`You are a ${name} delegate. Your mission is to …\n`);
-    setRoleMaxTurns(-1);
-  };
-
-  const deleteRole = async () => {
-    if (!roleSel) return;
-    if (!window.confirm(`Delete role “${roleSel}”? (built-ins reset to default)`)) return;
-    const { status: st } = await sendJSON("DELETE", `/api/roles/${encodeURIComponent(roleSel)}`);
-    if (st >= 200 && st < 300) {
-      setStatus({ kind: "ok", msg: `role “${roleSel}” deleted` });
-      setRoleSel(null);
-      setRoleBody("");
-      refreshRoles();
-    } else setStatus({ kind: "err", msg: `delete failed (${st})` });
-  };
 
   // ---- personas ----
   const [personas, setPersonas] = useState<PersonaInfo[]>([]);
@@ -225,69 +161,17 @@ export default function Personas() {
   return (
     <div style={{ padding: 16, fontFamily: "system-ui", height: "100%", overflow: "auto" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
-        <strong style={{ fontSize: 18 }}>Personas &amp; Roles</strong>
+        <strong style={{ fontSize: 18 }}>Personas</strong>
         {status && (
           <span style={{ fontSize: 13, color: status.kind === "err" ? "#b00" : "#080" }}>{status.msg}</span>
         )}
       </div>
 
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14, alignItems: "start" }}>
-        {/* Roles registry */}
-        <Panel title="Roles" count={roles.length}>
-          <p style={{ fontSize: 12, color: "#666", margin: "0 0 8px" }}>
-            The shared vocabulary. A role’s body describes what it does; personas and agents are matched on
-            these names (plus the <code>all</code> wildcard).
-          </p>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
-            {roles.map((r) => (
-              <button
-                key={r}
-                onClick={() => openRole(r)}
-                style={{ ...btn, background: roleSel === r ? "#e8eef9" : "#fff" }}
-              >
-                {r}
-              </button>
-            ))}
-            <button onClick={newRole} style={{ ...btn, borderStyle: "dashed" }}>
-              + New
-            </button>
-          </div>
-          {roleSel && (
-            <div>
-              <label style={lbl}>
-                {roleSel} — what it does (delegate system-prompt template)
-              </label>
-              <textarea rows={12} style={ta} value={roleBody} onChange={(e) => setRoleBody(e.target.value)} />
-              <label style={{ ...lbl, marginTop: 8 }}>
-                Max turns per delegate run (−1 = infinite, the default)
-              </label>
-              <input
-                type="number"
-                min={-1}
-                step={1}
-                style={{ ...ta, height: "auto" }}
-                value={roleMaxTurns}
-                onChange={(e) => {
-                  const v = parseInt(e.target.value, 10);
-                  setRoleMaxTurns(Number.isFinite(v) ? v : -1);
-                }}
-              />
-              <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-                <button onClick={saveRole} style={btn}>
-                  Save role
-                </button>
-                <button onClick={deleteRole} style={{ ...btn, color: "#b00" }}>
-                  Delete
-                </button>
-              </div>
-            </div>
-          )}
-        </Panel>
-
-        {/* Personas */}
+      <div style={{ maxWidth: 720 }}>
         <Panel title="Personas" count={personas.length}>
           <p style={{ fontSize: 12, color: "#666", margin: "0 0 8px" }}>
-            A persona is a delegate identity plus the roles it may use.
+            A persona is a delegate identity plus the roles it may use. Roles (and their per-role turn caps) are
+            edited on the <strong>Roles</strong> tab.
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
             {personas.map((p) => (
@@ -326,7 +210,7 @@ export default function Personas() {
                 />
               </div>
               <div>
-                <label style={lbl}>roles (routing key — click to toggle)</label>
+                <label style={lbl}>roles (routing key — click to toggle; edit roles on the Roles tab)</label>
                 <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
                   {roleOptions.map((r) => {
                     const on = (form.roles || []).includes(r);

--- a/frontend/src/pages/Roles.tsx
+++ b/frontend/src/pages/Roles.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useState } from "react";
+import { Panel } from "@rakuensoftware/smoothgui";
+
+/* Roles page: edit the shared ROLE vocabulary — each role's name, what it does
+ * (the delegate system-prompt template), and its per-role turn cap (max_turns,
+ * -1 = infinite, the default). Roles are the routing key personas and agents are
+ * matched on. Split out of the Personas tab so the turn cap reads as a role
+ * setting, never a persona one — personas never carry a turn limit. */
+
+async function getJSON<T>(url: string): Promise<T> {
+  const r = await fetch(url, { headers: { "X-CSRF-Token": window._csrf || "" } });
+  return (await r.json()) as T;
+}
+async function sendJSON<T>(
+  method: "PUT" | "DELETE" | "POST",
+  url: string,
+  body?: unknown,
+): Promise<{ status: number; data: T }> {
+  const r = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json", "X-CSRF-Token": window._csrf || "" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  let data = {} as T;
+  try {
+    data = (await r.json()) as T;
+  } catch {
+    /* empty bodies are fine */
+  }
+  return { status: r.status, data };
+}
+
+const btn: React.CSSProperties = {
+  padding: "4px 10px",
+  fontSize: 13,
+  borderRadius: 6,
+  border: "1px solid #ccc",
+  background: "#fff",
+  cursor: "pointer",
+};
+const lbl: React.CSSProperties = { fontSize: 12, color: "#666", display: "block", marginBottom: 2 };
+const ta: React.CSSProperties = {
+  width: "100%",
+  fontFamily: "ui-monospace, monospace",
+  fontSize: 12,
+  padding: 6,
+  borderRadius: 6,
+  border: "1px solid #ccc",
+  boxSizing: "border-box",
+};
+const nameOk = (s: string) => /^[a-z0-9][a-z0-9_-]*$/i.test(s);
+
+/* Upsert `max_turns` into a role template's YAML frontmatter so the dedicated
+ * field and the raw body stay consistent on save. -1 = infinite. */
+function withMaxTurns(body: string, mt: number): string {
+  const fm = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+  const m = body.match(fm);
+  if (m) {
+    let inner = m[1];
+    inner = /^max_turns:.*$/m.test(inner)
+      ? inner.replace(/^max_turns:.*$/m, `max_turns: ${mt}`)
+      : `max_turns: ${mt}\n${inner}`;
+    return body.replace(fm, `---\n${inner}\n---\n\n`);
+  }
+  return `---\nmax_turns: ${mt}\n---\n\n${body}`;
+}
+
+type Status = { kind: "ok" | "err"; msg: string } | null;
+
+export default function Roles() {
+  const [status, setStatus] = useState<Status>(null);
+  const [roles, setRoles] = useState<string[]>([]);
+  const [roleSel, setRoleSel] = useState<string | null>(null);
+  const [roleBody, setRoleBody] = useState("");
+  const [roleMaxTurns, setRoleMaxTurns] = useState<number>(-1); // -1 = infinite
+
+  const refreshRoles = useCallback(() => {
+    getJSON<{ role_templates?: string[] }>("/api/roles")
+      .then((d) => setRoles((d.role_templates || []).slice().sort()))
+      .catch(() => setRoles([]));
+  }, []);
+
+  const openRole = useCallback((name: string) => {
+    setRoleSel(name);
+    setRoleBody("");
+    setRoleMaxTurns(-1);
+    getJSON<{ content?: string; max_turns?: number }>(`/api/roles/${encodeURIComponent(name)}`)
+      .then((d) => {
+        setRoleBody(d.content || "");
+        setRoleMaxTurns(typeof d.max_turns === "number" ? d.max_turns : -1);
+      })
+      .catch(() => setRoleBody(""));
+  }, []);
+
+  const saveRole = async () => {
+    if (!roleSel) return;
+    const { status: st } = await sendJSON("PUT", `/api/roles/${encodeURIComponent(roleSel)}`, {
+      content: withMaxTurns(roleBody, roleMaxTurns),
+    });
+    if (st >= 200 && st < 300) {
+      setStatus({ kind: "ok", msg: `role “${roleSel}” saved` });
+      refreshRoles();
+    } else setStatus({ kind: "err", msg: `save failed (${st})` });
+  };
+
+  const newRole = () => {
+    const name = window.prompt("New role name (letters, digits, - or _):")?.trim();
+    if (!name) return;
+    if (!nameOk(name)) {
+      setStatus({ kind: "err", msg: "invalid role name" });
+      return;
+    }
+    setRoleSel(name);
+    setRoleBody(`You are a ${name} delegate. Your mission is to …\n`);
+    setRoleMaxTurns(-1);
+  };
+
+  const deleteRole = async () => {
+    if (!roleSel) return;
+    if (!window.confirm(`Delete role “${roleSel}”? (built-ins reset to default)`)) return;
+    const { status: st } = await sendJSON("DELETE", `/api/roles/${encodeURIComponent(roleSel)}`);
+    if (st >= 200 && st < 300) {
+      setStatus({ kind: "ok", msg: `role “${roleSel}” deleted` });
+      setRoleSel(null);
+      setRoleBody("");
+      refreshRoles();
+    } else setStatus({ kind: "err", msg: `delete failed (${st})` });
+  };
+
+  useEffect(() => {
+    refreshRoles();
+  }, [refreshRoles]);
+
+  return (
+    <div style={{ padding: 16, fontFamily: "system-ui", height: "100%", overflow: "auto" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
+        <strong style={{ fontSize: 18 }}>Roles</strong>
+        {status && (
+          <span style={{ fontSize: 13, color: status.kind === "err" ? "#b00" : "#080" }}>{status.msg}</span>
+        )}
+      </div>
+
+      <div style={{ maxWidth: 720 }}>
+        <Panel title="Roles" count={roles.length}>
+          <p style={{ fontSize: 12, color: "#666", margin: "0 0 8px" }}>
+            The shared vocabulary. A role’s body describes what it does; personas and agents are matched on
+            these names (plus the <code>all</code> wildcard). The turn cap is a <strong>role</strong> setting —
+            personas never carry one.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
+            {roles.map((r) => (
+              <button
+                key={r}
+                onClick={() => openRole(r)}
+                style={{ ...btn, background: roleSel === r ? "#e8eef9" : "#fff" }}
+              >
+                {r}
+              </button>
+            ))}
+            <button onClick={newRole} style={{ ...btn, borderStyle: "dashed" }}>
+              + New
+            </button>
+          </div>
+          {roleSel && (
+            <div>
+              <label style={lbl}>
+                {roleSel} — what it does (delegate system-prompt template)
+              </label>
+              <textarea rows={12} style={ta} value={roleBody} onChange={(e) => setRoleBody(e.target.value)} />
+              <label style={{ ...lbl, marginTop: 8 }}>
+                Max turns per delegate run (−1 = infinite, the default)
+              </label>
+              <input
+                type="number"
+                min={-1}
+                step={1}
+                style={{ ...ta, height: "auto" }}
+                value={roleMaxTurns}
+                onChange={(e) => {
+                  const v = parseInt(e.target.value, 10);
+                  setRoleMaxTurns(Number.isFinite(v) ? v : -1);
+                }}
+              />
+              <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+                <button onClick={saveRole} style={btn}>
+                  Save role
+                </button>
+                <button onClick={deleteRole} style={{ ...btn, color: "#b00" }}>
+                  Delete
+                </button>
+              </div>
+            </div>
+          )}
+        </Panel>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Splits the roles registry out of the **Personas** tab into a dedicated **Roles** tab.

## Why

Turn limits are a **role** setting and must never read as a persona one. The Personas tab hosted two editors (personas + roles), so the per-role `max_turns` field sat beside persona fields and could be misread as a persona-level limit. Personas never carry a turn limit.

## Change (frontend only, no backend)

- New `pages/Roles.tsx`: the role name/body editor + the per-role **Max turns (−1 = infinite, the default)** field, upserting the role template's `max_turns:` frontmatter via `/api/roles/<role>`.
- `pages/Personas.tsx`: drops the roles editor; keeps a **read-only** fetch of the role list purely to render the persona's routing-chip toggles. No `max_turns` anywhere on this page.
- `App.tsx`: adds the `Roles` nav item + `/roles` route.

## Verification

- `tsc -b` clean.
- `vitest run`: 14 pass; the one failure is a pre-existing `Dashboard.test.ts` guardrail-audit contract test, unrelated to this change (this PR touches only App/Personas/Roles).
- `dist/` is rebuilt in the image build (`npm run build` in Dockerfile.server), so source-only is sufficient.