### PR TITLE
feat(webchat): per-tab tutorial overlays (slice 1)

### DIFF
--- a/docs/proposals/pending/proposal-setup-wizard-and-tab-tutorials.md
+++ b/docs/proposals/pending/proposal-setup-wizard-and-tab-tutorials.md
@@ -1,0 +1,244 @@
+# Proposal: aimee-server web GUI — first-run setup wizard + per-tab tutorials
+
+- **State:** proposed (pending — not started)
+- **Charter role(s):** none (product/UX surface; consumes existing config + readiness contracts, adds no intelligence pass)
+- **Surfaces:** `frontend/` (the aimee-server web GUI), `/api/config`, `/api/config/set`, `/api/git/*`, Dashboard readiness
+
+## Thesis
+
+A fresh aimee-server install drops the operator straight onto `/chat` with no
+guidance. Everything needed to make the instance *actually work* — pick a
+primary provider, wire an embedding backend, point at DB2, connect a git
+project — is reachable but never surfaced. It lives in the Settings tab as a
+flat, searchable list of ~80 config keys (`frontend/src/pages/Settings.tsx`,
+`settingsHelp.ts`), with no notion of "what do I set **first**, and in what
+order, to get from zero to a working turn." The Dashboard already computes a
+**Readiness** signal and **LSP Health** — but only *after* you've found the
+Dashboard tab and only as a display, not a fix-it flow.
+
+Two gaps, one theme (nobody tells the operator what to do):
+
+1. **No guided setup.** There is no wizard that detects what's unconfigured and
+   walks the operator through the minimum viable environment. The knowledge to
+   do it exists (every field has a plain-English line in `settingsHelp.ts`; the
+   restart-sensitive keys are enumerated in `RESTART_KEYS`) — it's just never
+   assembled into a path.
+2. **No per-tab orientation.** The eleven tools in the left nav
+   (`NAV_ITEMS` in `frontend/src/App.tsx`) are discoverable by clicking, but
+   each lands you in a working surface with no "what is this / how do I use it"
+   affordance. A new operator learns Workflow Actions vs Edit Workflows vs
+   Agents by trial and error.
+
+## Goal
+
+Two additions to the existing GUI, sharing one content store:
+
+- **A) A first-run setup wizard** that runs on an under-configured instance,
+  detects readiness, and walks the operator through the minimum path to a
+  working turn — writing every change through the *existing* `/api/config/set`
+  allowlist (no new mutation surface, no new secrets path).
+- **B) A per-tab tutorial layer** — a dismissible "how this tab works" overlay
+  on each of the eleven tabs, reusable as a "?" affordance after first run.
+
+Both are **additive and non-blocking**: an operator who knows the product can
+skip the wizard and never see a tutorial again. Nothing changes about how
+config, git, or turns actually execute.
+
+## §0 What already exists (do not rebuild)
+
+- **Settings tab** — `frontend/src/pages/Settings.tsx` reads `GET /api/config`
+  (`config.show`), writes `POST /api/config/set`, infers the control from the
+  value's JSON type, and groups keys into sections via `category()`.
+- **Plain-English help** — `frontend/src/pages/settingsHelp.ts`: `FIELD_HELP`
+  (one line per key, states the default), `SECTION_HELP` (one line per section),
+  and `RESTART_KEYS` (`db2_url`, `kb_api_http_port`, `kb_api_bearer_token` — the
+  only keys that need a restart rather than applying next turn). **The wizard's
+  copy comes from here; it is not rewritten.**
+- **Readiness + LSP Health** — the Dashboard (`frontend/src/pages/Dashboard.tsx`)
+  already renders "Readiness" and "LSP Health" cards. The wizard should consume
+  the *same* server signal, not invent a second definition of "ready."
+- **Git project connect** — `frontend/src/pages/Projects.tsx` already does clone,
+  per-host credential storage (sealed vault), and GitHub device-flow OAuth
+  (`/api/git/oauth/github/*`). The wizard's "connect a project" step **launches
+  this existing flow**, it does not reimplement it.
+- **Sessions** — a session bundles a chat + its project (`SessionContext.tsx`);
+  every tool operates on the active session's project.
+- **No wizard, no onboarding, no per-tab help.** Confirmed: `grep -rilE
+  'wizard|onboard|first.?run|getting.?started'` over `frontend/src` returns only
+  Dashboard/settings incidental matches. This is greenfield UX over an existing
+  config plane.
+
+## §1 The setup wizard
+
+### §1.1 Trigger
+
+On load, `App` already gates on `/api/chat/session`. Add a lightweight
+`GET /api/setup/state` that returns a **readiness summary** (reusing the
+Dashboard readiness computation server-side, not a new heuristic):
+
+```jsonc
+{
+  "ready": false,
+  "steps": {
+    "provider":  { "ok": true,  "detail": "claude" },
+    "embedding": { "ok": false, "detail": "built-in hash fallback (test-only)" },
+    "db2":       { "ok": true,  "detail": "connected" },
+    "kb_api":    { "ok": false, "detail": "disabled (port 0)" },
+    "project":   { "ok": false, "detail": "no project connected" }
+  },
+  "dismissed": false
+}
+```
+
+The wizard auto-opens when `ready === false && dismissed === false`. It is a
+modal *over* the app, never a separate route — the operator can close it and the
+app is fully usable. A persistent **"Setup — N steps left"** chip in the header
+re-opens it. Dismissal is per-user server state so it survives a new browser.
+
+### §1.2 Steps (minimum viable environment)
+
+Each step is one screen: the `settingsHelp.ts` line as the explanation, the live
+value, an input, and a **"Test"** button that validates before advancing. Order
+is the real dependency order for a working turn:
+
+1. **Primary provider** — `provider`, then the provider-specific keys it reveals
+   (`claude_model`; or `openai_endpoint` / `openai_model` / `openai_key_cmd`).
+   Test = a trivial provider ping. *Green already when Claude CLI is logged in.*
+2. **Embedding backend** — `embedding_command` **or** `embedding_endpoint`, plus
+   `embedding_model` / `embedding_dim`. The wizard must **loudly** flag the
+   built-in 384-dim hash as test-only (that copy already exists in
+   `FIELD_HELP.embedding_command`) — this is the #1 silent-degradation trap.
+   Test = embed a fixed string, assert the returned vector width equals
+   `embedding_dim`.
+3. **Shared store (DB2)** — `db2_url`. Flagged `RESTART` (in `RESTART_KEYS`).
+   Test = connection check. Wizard shows the "applies after restart" banner and
+   offers a restart-needed reminder rather than pretending it took effect.
+4. **Knowledge-base API (optional)** — `kb_api_http_port` + `kb_api_bearer_token`
+   (both `RESTART`). Presented as **optional/skippable** with a one-line "what
+   you lose if you skip" (no REST access to the KB).
+5. **Connect a project** — hands off to the existing `Projects` connect flow
+   (clone or GitHub OAuth). On return, the wizard confirms the session now has a
+   project bound.
+
+A final **summary screen** re-renders `/api/setup/state` so the operator sees
+green across the board (or exactly what remains + why), plus any pending-restart
+callout. "Finish" sets `dismissed`.
+
+### §1.3 Constraints (what the wizard is *not* allowed to do)
+
+- **No new write path.** Every set goes through `POST /api/config/set` — the same
+  allowlist Settings uses. The wizard cannot set a key Settings can't.
+- **No new secret handling.** `openai_key_cmd` stays a *command that prints the
+  key* (keeps the key out of config); git credentials stay in the sealed vault
+  via the existing `/api/git/*` path. The wizard never accepts a raw API key into
+  a config value.
+- **Honest about restarts.** Keys in `RESTART_KEYS` are labelled and the wizard
+  never reports them as live until a restart happens.
+
+## §2 Per-tab tutorials
+
+### §2.1 Mechanism
+
+A small `<TabTutorial tabId=… />` affordance rendered by each page (or once in
+`App` keyed on route). First visit to a tab auto-shows a **dismissible overlay**;
+after dismissal it collapses to a **"?"** button in the tab's top-right that
+re-opens it. Per-tab "seen" state lives in the same per-user store as wizard
+dismissal, so it's stable across browsers and a "Replay all tutorials" toggle in
+Settings resets it. Content is data (§3), not hard-coded JSX, so it's editable
+without a component change.
+
+### §2.2 Content — one tutorial per real tab
+
+Grounded in what each page actually does today (`frontend/src/pages/*`,
+`NAV_ITEMS` in `App.tsx`):
+
+- **💬 Chat** — the session's conversation with aimee; attach files, use
+  slash-commands, channels, and turn a reply into a proposal. "This is where a
+  turn runs; the active session's project is what it acts on."
+- **📊 Dashboard** — live health: Readiness, LSP Health, per-agent success/tokens,
+  latency by role, provider mix, cache efficiency, guardrail actions, traces.
+  "Start here when something feels wrong." (Cards are reorderable.)
+- **📜 Logs** — the audit trail; every row expands to a full-field detail modal.
+  "What did aimee do, when, and under whose identity."
+- **🔀 Edit Workflows** — *define* multi-step workflows (per-step task, persona,
+  delegate, role). The design surface.
+- **📝 Workflow Actions** — the *runtime* queue: pending items to **approve /
+  reject**. "This is the human-in-the-loop gate; Edit Workflows is where the
+  steps came from." (Explicitly disambiguates the two adjacent tabs — the #1
+  confusion.)
+- **🤝 Agents** — delegates and their run history/stats; edit a delegate's
+  persona + role. "Roles are the routing key matched between personas and agents."
+- **🎭 Personas** — the shared ROLE vocabulary + PERSONA definitions (identity +
+  allowed roles). "Edit *who* aimee can be and *what* each role means; Agents
+  binds them to work."
+- **📁 Projects** — connect a git repo, store per-host credentials (sealed vault),
+  run read + remote git ops. "Connect the code aimee works on; creds never reach
+  the browser."
+- **🕸️ Graph** — read-only code-projection explorer: rank hubs, expand
+  callers/callees/neighbours with provenance, spot "surprising links." "Understand
+  the codebase's shape; off the agent's hot path."
+- **🖥️ Editor** — in-app VS Code bound to the session's isolated worktree — the
+  same tree the agent edits. "See and hand-edit exactly what the agent sees."
+- **⚙️ Settings** — every typed config key with plain-English help; boolean→toggle,
+  number→field, string→text; restart-sensitive keys badged. "The full control
+  plane the wizard walked you through a slice of."
+
+Each tutorial is **3–5 lines max** + one "where this connects" pointer to a
+sibling tab. Long-form docs stay in `docs/`; the overlay links out, it doesn't
+duplicate.
+
+## §3 Where the content lives
+
+One content module, `frontend/src/help/tutorials.ts`, keyed by `tabId` and by
+wizard `stepId`:
+
+```ts
+export const TAB_TUTORIALS: Record<string, { title: string; body: string[]; seeAlso?: string }> = { … }
+export const WIZARD_STEPS: Array<{ id: string; keys: string[]; test?: TestSpec; optional?: boolean }> = { … }
+```
+
+- Wizard step **copy** reuses `FIELD_HELP` / `SECTION_HELP` verbatim — single
+  source of truth, so a config-help edit updates both surfaces (the existing
+  sync rule between `settingsHelp.ts` and `config.h` comments extends to cover
+  it).
+- Tab copy is authored fresh (the pages have no help strings today) but kept to
+  the length above and reviewed against the page's own header comment so it can't
+  drift silently.
+
+## §4 Rollout
+
+Ships in independent slices; each is useful alone:
+
+1. `GET /api/setup/state` + the header **Readiness chip** (no wizard yet) — makes
+   readiness visible without the Dashboard.
+2. Per-tab tutorial overlays (§2) — pure frontend, no new endpoint, lowest risk.
+3. The wizard modal (§1) over the existing `/api/config/set` — the largest slice.
+4. "Replay tutorials" / "Re-run setup" controls in Settings.
+
+## Non-goals
+
+- **Not a new config surface.** Zero new writable keys; the wizard is a *view*
+  over `/api/config/set`. If Settings can't set it, the wizard can't either.
+- **Not provisioning.** The wizard configures an aimee-server that is already
+  running; it does not install sidecars (OCR/TSR/rerank), stand up Postgres, or
+  deploy containers. Where a key needs a sidecar, it says so and links the doc.
+- **Not a replacement for Settings.** Settings stays the exhaustive plane; the
+  wizard is the curated first-mile through it.
+- **Not blocking.** A configured instance never forces the wizard; a returning
+  operator never re-sees a dismissed tutorial.
+
+## Acceptance criteria (validation-pending — this is a proposal)
+
+- On an instance with the built-in hash embedder and no project,
+  `GET /api/setup/state` returns `ready:false` with `embedding` and `project` red;
+  the wizard auto-opens.
+- Completing every step (test buttons green) flips `/api/setup/state` to
+  `ready:true`; a `RESTART_KEYS` change is reported as pending-restart, never as
+  live.
+- Every wizard write is observable as a `POST /api/config/set` — no other mutation
+  endpoint is introduced.
+- Each of the eleven `NAV_ITEMS` tabs shows its tutorial on first visit and a "?"
+  re-opener after; "Replay tutorials" resets the seen-state for all eleven.
+
+> These criteria are the exit test for implementation, not claims about current
+> behaviour — nothing here is built yet.

--- a/docs/proposals/pending/setup-wizard-and-tab-tutorials.plan.md
+++ b/docs/proposals/pending/setup-wizard-and-tab-tutorials.plan.md
@@ -1,0 +1,112 @@
+# Implementation plan: setup wizard + per-tab tutorials
+
+Companion to [`proposal-setup-wizard-and-tab-tutorials.md`](./proposal-setup-wizard-and-tab-tutorials.md).
+This plan is the concrete, sliced build-out. Each slice is independently
+shippable, **frontend-only**, and verifiable with `npm run check` + `npm test`
+(no C-server or Go-webchat rebuild required for the MVP).
+
+## Guiding decisions (design-for-implementability)
+
+1. **No new backend for the MVP.** The proposal floated a server-side
+   `GET /api/setup/state`. We defer it. Readiness is computed **client-side**
+   from the values already returned by `GET /api/config` (`config.show`), and
+   every wizard write goes through the **existing** `POST /api/config/set`
+   allowlist. This keeps the whole feature inside `frontend/` and testable
+   without a running server. A server-side readiness endpoint is a documented
+   follow-up (§Future), not a blocker.
+2. **Single mount point, not 11 edits.** Tutorials and the setup chip mount once
+   in `App.tsx`, keyed on `location.pathname` / global shell — we do **not** edit
+   each of the eleven page components. Content lives in data modules.
+3. **Persistence: `localStorage` for the MVP.** "Tutorial seen" and "wizard
+   dismissed" live in `localStorage` (per-browser). The proposal's per-user
+   server store is a follow-up; localStorage keeps slices frontend-only and is
+   the established pattern in this app (`aimee_chat_tabs`, `aimee_active_chat_tab`,
+   `aimee_proposal_draft` in `App.tsx`/`LogoutButton`). Trade-off noted for the
+   roundtable.
+4. **Pure, unit-testable core.** Readiness logic is a pure function over a config
+   object, tested with vitest — no network, no DOM. Same for the tutorial
+   content registry (shape-validated by a test).
+
+## Baseline (stock, before any change)
+
+- `npm run check` (`tsc -b`): **clean**.
+- `npm test` (vitest): **14 pass, 1 pre-existing failure** —
+  `Dashboard.test.ts` "populates the guardrail audit". This failure exists on
+  stock `testing` and is **out of scope**; no slice may touch Dashboard audit
+  logic, and our done-bar is "no *new* test failures", not "0 failures".
+
+## Roundtable outcome (converged, 2 rounds)
+
+Adopted: merge Slices 2+3 into one atomic PR (chip never lands without its wizard
+listener → no dead control); wizard wraps every `/api/config/set` in try/catch and
+surfaces failures via `Toast` while preserving input; wizard tracks a
+`pendingRestart` set from `RESTART_KEYS` and lists it on the summary; chip→wizard
+wiring is a `window` `CustomEvent('aimee:open-setup-wizard')`; `readiness.test.ts`
+grounds `READINESS_KEYS ⊆ settingsHelp` keys. **One deviation:** the proposed
+"tutorial body is a substring of settingsHelp/page text" provenance test is
+infeasible for freshly-authored copy — replaced with "every `NAV_ITEMS` route has
+a non-empty title+body and any `seeAlso` references a real route."
+
+Net slice set: **Slice 1 (tutorials)** and **Slice 2 (onboarding = readiness +
+chip + wizard, atomic)** → both PR into `feat/setup-wizard` → `feat/setup-wizard`
+→ `testing`.
+
+## Slices
+
+### Slice 1 — Per-tab tutorials (lowest risk, ships first)
+
+**Files**
+- `frontend/src/help/tutorials.ts` — `TAB_TUTORIALS: Record<route, {title; body: string[]; seeAlso?}>` for all 11 routes in `NAV_ITEMS`. Copy is 3–5 lines/tab, grounded in each page's real behaviour (see proposal §2.2).
+- `frontend/src/help/tutorialState.ts` — `hasSeen(route)`, `markSeen(route)`, `resetAll()` over `localStorage` key `aimee_tutorial_seen` (JSON string[]). Guarded against malformed/absent storage.
+- `frontend/src/components/TabTutorial.tsx` — given the active route: first visit auto-opens a dismissible overlay; after dismissal a "?" button re-opens it. No content for a route → renders nothing (graceful).
+- `frontend/src/App.tsx` — mount `<TabTutorial route={location.pathname} />` once inside `<main>`; no per-page edits.
+- `frontend/src/pages/Settings.tsx` — add a "Replay tab tutorials" button calling `resetAll()` (small, localized addition).
+- `frontend/src/help/tutorials.test.ts` — asserts every `NAV_ITEMS` route has a tutorial entry with non-empty title+body; `tutorialState` seen/reset round-trips (jsdom localStorage).
+
+**Acceptance**
+- `npm run check` clean; `npm test` shows **no new failures** (still only the pre-existing Dashboard one).
+- Every route in `NAV_ITEMS` has a tutorial (asserted by test). "Replay" clears seen-state.
+
+### Slice 2 — Setup onboarding (readiness + chip + wizard, ATOMIC)
+
+Chip and wizard land together so no non-functional control is ever merged.
+
+**Files**
+- `frontend/src/setup/readiness.ts` — `type StepId = 'provider'|'embedding'|'db2'|'kb_api'|'project'`; `READINESS_KEYS` constant (the inspected config keys); `computeReadiness(cfg: Record<string,unknown>, hasProject: boolean): {ready; steps: Record<StepId,{ok; detail; optional?}>}`. Pure. Rules grounded in `settingsHelp.ts` semantics (blank `embedding_command` **and** blank `embedding_endpoint` → hash fallback → not ok; `kb_api` optional).
+- `frontend/src/setup/readiness.test.ts` — table-driven cases (all-unset → provider/embedding/project red; fully-set → ready) + **grounding test**: every key in `READINESS_KEYS` exists in `FIELD_HELP` (settingsHelp.ts).
+- `frontend/src/setup/wizardSteps.ts` — ordered step defs (keys/step, optional flag, `settingsHelp` copy reused, cheap client-side "test" e.g. embedding-dim match); `isRestartKey(key)` over `RESTART_KEYS`.
+- `frontend/src/components/SetupChip.tsx` — fetches `/api/config` once, computes readiness with `hasProject` from the session/project bundle, renders "Setup — N left" (hidden when ready); click → `window.dispatchEvent(new CustomEvent('aimee:open-setup-wizard'))`.
+- `frontend/src/components/SetupWizard.tsx` — modal; one screen/step; reads/writes `/api/config` + `/api/config/set`. **Every write in try/catch**: 4xx/5xx/network → `smoothgui` `Toast` + stay on step with input preserved. Tracks `pendingRestart: Set<string>` (adds a saved key that `isRestartKey`); final summary shows "Restart required for: […]" when non-empty; "project" step links to `/projects`; dismissal in `localStorage` (`aimee_setup_dismissed`). Opened by the event; closable anytime (non-blocking).
+- `frontend/src/App.tsx` — mount `<SetupChip />` in header + `<SetupWizard />` at root; `useEffect` listener for `aimee:open-setup-wizard`.
+- `frontend/src/pages/Settings.tsx` — "Re-run setup" button (clears dismissal + dispatches open event).
+- `frontend/src/setup/wizardSteps.test.ts` — every `StepId` has a step def; ordering = documented dependency order; `isRestartKey` matches `RESTART_KEYS`. Component test (mocked `fetch`): (a) success marks step saved; (b) 4xx/5xx → `Toast` + step stays unsaved; (c) `RESTART_KEYS` change populates the summary.
+
+**Acceptance**
+- `npm run check` clean; readiness + wizard tests pass; no new test failures.
+- Chip shows correct count / hidden when green; wizard writes via `/api/config/set`, Toasts on error, lists restart-pending keys; dismissable + re-openable.
+
+## Per-slice workflow
+
+For each slice: implement → `npm run check` + `npm test` (assert no new failures)
+→ `aimee delegate roundtable` review → apply blocking fixes → re-roundtable until
+approved → open PR into `feat/setup-wizard` → merge.
+
+## Non-goals / Future
+
+- Server-side `GET /api/setup/state` (replace client inference; enables true
+  per-user readiness incl. live DB2/provider pings).
+- Per-user **server** persistence of seen/dismissed state (replace localStorage).
+- Wizard "Test" buttons that hit real provider/embedder endpoints (MVP does only
+  cheap client-side checks like dim-match).
+- No change to how config, git, or turns execute; no new writable config keys.
+
+## Risks
+
+- **smoothgui API drift** — we reuse `Panel`/`Badge`/`Toast` already imported in
+  the app; no new smoothgui surface.
+- **Config key shape** — readiness rules depend on exact key names
+  (`provider`, `embedding_command`, `embedding_endpoint`, `db2_url`,
+  `kb_api_http_port`); pinned against `settingsHelp.ts`. A rename there breaks a
+  readiness rule → caught by the readiness unit test if we encode expected keys.
+- **Pre-existing Dashboard test failure** — must remain the *only* failure; CI
+  parity checked each slice.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import Graph from './pages/Graph';
 import Editor from './pages/Editor';
 import { SessionProvider, useSessions } from './SessionContext';
 import SettingsPanel from './components/SettingsPanel';
+import TabTutorial from './components/TabTutorial';
 
 // A render error in any page used to throw past the root and unmount the whole
 // app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
@@ -239,8 +240,10 @@ export default function App() {
               </NavLink>
             ))}
           </nav>
-          {/* Content: flex:1 + minHeight:0 so pages using height:100% resolve. */}
-          <main style={{ flex: 1, minWidth: 0, minHeight: 0, overflow: 'auto', background: '#fff' }}>
+          {/* Content: flex:1 + minHeight:0 so pages using height:100% resolve.
+           * position:relative anchors the per-tab tutorial overlay/"?" button. */}
+          <main style={{ position: 'relative', flex: 1, minWidth: 0, minHeight: 0, overflow: 'auto', background: '#fff' }}>
+            <TabTutorial route={location.pathname} />
             <ErrorBoundary key={location.pathname}>
               <Routes>
                 <Route path="/chat" element={<Chat />} />

--- a/frontend/src/components/TabTutorial.tsx
+++ b/frontend/src/components/TabTutorial.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { tutorialFor } from '../help/tutorials';
+import { hasSeen, markSeen } from '../help/tutorialState';
+
+/* Per-tab tutorial affordance. Mounted once in App inside <main>, keyed on the
+ * active route. On the first visit to a tab that has a tutorial it auto-opens a
+ * dismissible card; after dismissal it collapses to a small "?" button in the
+ * top-right that re-opens it. A route with no tutorial renders nothing.
+ *
+ * It is deliberately NON-MODAL: there is no full-area backdrop, so the rest of
+ * the page stays fully interactive while the card is open (the card is a corner
+ * panel, not a blocking overlay). All persistence + content lookups live in the
+ * tested help/ modules; this component is just presentation. */
+
+export default function TabTutorial({ route }: { route: string }) {
+  const navigate = useNavigate();
+  const tut = tutorialFor(route);
+  const [open, setOpen] = useState(false);
+
+  // On each route change, auto-open only if this tab has a tutorial the operator
+  // hasn't dismissed yet.
+  useEffect(() => {
+    if (tut && !hasSeen(route)) setOpen(true);
+    else setOpen(false);
+  }, [route, tut]);
+
+  // Escape closes the card (counts as seen) when it is open.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') { markSeen(route); setOpen(false); }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, route]);
+
+  if (!tut) return null;
+
+  function dismiss() {
+    markSeen(route);
+    setOpen(false);
+  }
+
+  // Collapsed state: just the "?" re-opener in the corner.
+  if (!open) {
+    return (
+      <button
+        aria-label="Show tab help"
+        title="What is this tab?"
+        onClick={() => setOpen(true)}
+        style={{
+          position: 'absolute', top: 10, right: 12, zIndex: 20,
+          width: 26, height: 26, borderRadius: '50%', cursor: 'pointer',
+          border: '1px solid #ccd', background: '#fff', color: '#68a',
+          fontSize: 14, fontWeight: 700, lineHeight: 1,
+        }}
+      >?</button>
+    );
+  }
+
+  // Open state: a non-modal card anchored top-right. No backdrop — the page
+  // underneath stays clickable, so the tutorial never blocks work.
+  return (
+    <div
+      role="dialog"
+      aria-label={`${tut.title} tab help`}
+      style={{
+        position: 'absolute', top: 10, right: 12, zIndex: 25,
+        maxWidth: 380, width: 'min(380px, calc(100% - 24px))',
+        background: '#fff', borderRadius: 10, border: '1px solid #dde',
+        boxShadow: '0 8px 30px rgba(0,0,0,0.18)', padding: '16px 18px',
+        fontFamily: 'system-ui', color: '#334',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+        <span style={{ fontSize: 15, fontWeight: 700, color: '#223' }}>{tut.title}</span>
+        <button
+          aria-label="Close tab help"
+          title="Close"
+          onClick={dismiss}
+          style={{ background: 'none', border: 'none', color: '#9aa', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: 0 }}
+        >×</button>
+      </div>
+      {tut.body.map((line, i) => (
+        <p key={i} style={{ fontSize: 13, lineHeight: 1.5, margin: '0 0 7px' }}>{line}</p>
+      ))}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 12 }}>
+        {tut.seeAlso ? (
+          <button
+            onClick={() => { dismiss(); navigate(tut.seeAlso!); }}
+            style={{ background: 'none', border: 'none', color: '#68a', cursor: 'pointer', fontSize: 12.5, padding: 0 }}
+          >
+            See also: {tutorialFor(tut.seeAlso)?.title ?? tut.seeAlso} →
+          </button>
+        ) : <span />}
+        <button
+          onClick={dismiss}
+          style={{
+            padding: '5px 14px', borderRadius: 6, border: '1px solid #ccd',
+            background: '#f4f6fb', color: '#446', cursor: 'pointer', fontSize: 12.5, fontWeight: 600,
+          }}
+        >Got it</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/help/tutorialState.ts
+++ b/frontend/src/help/tutorialState.ts
@@ -1,0 +1,67 @@
+/* "Seen" state for per-tab tutorials. The auto-open-on-first-visit behaviour needs
+ * to remember which tabs the operator has already dismissed. For the MVP this is
+ * per-browser localStorage (the same pattern App/LogoutButton use for chat tabs).
+ *
+ * The parse/merge logic is split from the storage side-effects so it can be unit
+ * tested under vitest's `node` environment, where `localStorage` does not exist.
+ * The storage wrappers guard `typeof localStorage` and swallow quota/security
+ * errors, so a private-mode or storage-disabled browser degrades to "always show"
+ * rather than throwing. */
+
+export const SEEN_KEY = 'aimee_tutorial_seen';
+
+/** Parse a stored blob into a clean list of route strings. Tolerates null,
+ * malformed JSON, and non-array/non-string junk — always returns a string[]. */
+export function parseSeen(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const v = JSON.parse(raw);
+    if (!Array.isArray(v)) return [];
+    return v.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
+}
+
+/** Return a new list with `route` present (idempotent, order-stable). */
+export function withSeen(list: string[], route: string): string[] {
+  return list.includes(route) ? list : [...list, route];
+}
+
+// ── localStorage-backed wrappers (side-effecting; guarded for node/SSR) ──────
+
+function readRaw(): string | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage.getItem(SEEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeList(list: string[]): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(SEEN_KEY, JSON.stringify(list));
+  } catch {
+    /* storage disabled/full — degrade to always-show */
+  }
+}
+
+export function hasSeen(route: string): boolean {
+  return parseSeen(readRaw()).includes(route);
+}
+
+export function markSeen(route: string): void {
+  writeList(withSeen(parseSeen(readRaw()), route));
+}
+
+/** Forget all seen tabs — the "Replay tab tutorials" action. */
+export function resetAll(): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(SEEN_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/help/tutorials.test.ts
+++ b/frontend/src/help/tutorials.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { TAB_TUTORIALS, tutorialFor } from './tutorials';
+import { parseSeen, withSeen, SEEN_KEY } from './tutorialState';
+
+/* The routes App exposes in NAV_ITEMS. Kept in sync by hand with App.tsx; the
+ * "every nav route has a tutorial" test below is what guards a drift (a new tab
+ * added to App without a tutorial entry fails here). */
+const NAV_ROUTES = [
+  '/chat', '/dashboard', '/logs', '/edit-workflows', '/workflow-actions',
+  '/agents', '/personas', '/projects', '/graph', '/editor', '/settings',
+];
+
+describe('TAB_TUTORIALS content contract', () => {
+  it('has a tutorial for every NAV_ITEMS route', () => {
+    for (const route of NAV_ROUTES) {
+      expect(TAB_TUTORIALS, `missing tutorial for ${route}`).toHaveProperty(route);
+    }
+  });
+
+  it('every tutorial has a non-empty title and 1–5 body lines', () => {
+    for (const [route, t] of Object.entries(TAB_TUTORIALS)) {
+      expect(t.title.trim().length, `${route} title`).toBeGreaterThan(0);
+      expect(t.body.length, `${route} body count`).toBeGreaterThan(0);
+      expect(t.body.length, `${route} body count`).toBeLessThanOrEqual(5);
+      for (const line of t.body) expect(line.trim().length, `${route} body line`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every seeAlso points at a real tutorial route', () => {
+    for (const [route, t] of Object.entries(TAB_TUTORIALS)) {
+      if (t.seeAlso) {
+        expect(TAB_TUTORIALS, `${route} seeAlso -> ${t.seeAlso}`).toHaveProperty(t.seeAlso);
+      }
+    }
+  });
+
+  it('tutorialFor returns undefined for an unknown route', () => {
+    expect(tutorialFor('/nope')).toBeUndefined();
+    expect(tutorialFor('/chat')).toBe(TAB_TUTORIALS['/chat']);
+  });
+});
+
+describe('tutorialState seen-list logic (pure)', () => {
+  it('parseSeen tolerates null, malformed, and non-string junk', () => {
+    expect(parseSeen(null)).toEqual([]);
+    expect(parseSeen('not json')).toEqual([]);
+    expect(parseSeen('{"a":1}')).toEqual([]); // object, not array
+    expect(parseSeen('[1,"/chat",true,"/logs"]')).toEqual(['/chat', '/logs']);
+  });
+
+  it('withSeen adds idempotently and preserves order', () => {
+    let list: string[] = [];
+    list = withSeen(list, '/chat');
+    list = withSeen(list, '/logs');
+    list = withSeen(list, '/chat'); // dup
+    expect(list).toEqual(['/chat', '/logs']);
+  });
+
+  it('a seen round-trip through parse/serialize is stable', () => {
+    const list = withSeen(withSeen([], '/chat'), '/settings');
+    const roundTripped = parseSeen(JSON.stringify(list));
+    expect(roundTripped).toEqual(list);
+    expect(SEEN_KEY).toBe('aimee_tutorial_seen');
+  });
+});

--- a/frontend/src/help/tutorials.ts
+++ b/frontend/src/help/tutorials.ts
@@ -1,0 +1,125 @@
+/* Per-tab tutorial content. One entry per route in App's NAV_ITEMS, keyed by the
+ * exact route path. `TabTutorial` shows the entry for the active route on first
+ * visit and behind a "?" re-opener after. Copy is short (a title + 3–5 lines) and
+ * grounded in what each page actually does; `seeAlso` points at the sibling tab a
+ * new operator most often confuses this one with. A route with no entry renders
+ * nothing (the component degrades gracefully), so adding a nav tab without a
+ * tutorial is not an error — it just shows no help until copy is added. */
+
+export type Tutorial = {
+  /** Heading shown at the top of the overlay. */
+  title: string;
+  /** Body lines, rendered as short paragraphs. Keep to 3–5. */
+  body: string[];
+  /** Optional "where this connects" pointer — a route in NAV_ITEMS. */
+  seeAlso?: string;
+};
+
+// Keyed by route path (must match App's NAV_ITEMS routes). The test in
+// tutorials.test.ts asserts every NAV_ITEMS route has an entry here.
+export const TAB_TUTORIALS: Record<string, Tutorial> = {
+  '/chat': {
+    title: 'Chat',
+    body: [
+      'This is where a turn runs — your conversation with aimee for the active session.',
+      'Attach files, use slash-commands and channels, and turn a reply into a proposal.',
+      'The session’s bound project is what every tool here acts on.',
+    ],
+    seeAlso: '/projects',
+  },
+  '/dashboard': {
+    title: 'Dashboard',
+    body: [
+      'Live health of the instance: Readiness, LSP health, per-agent success and tokens,',
+      'latency by role, provider mix, cache efficiency, guardrail actions, and traces.',
+      'Start here when something feels wrong. Cards can be reordered.',
+    ],
+    seeAlso: '/logs',
+  },
+  '/logs': {
+    title: 'Logs',
+    body: [
+      'The audit trail: every recorded action, newest first.',
+      'Click a row to expand the full-field detail modal.',
+      'Answers “what did aimee do, when, and under whose identity”.',
+    ],
+    seeAlso: '/dashboard',
+  },
+  '/edit-workflows': {
+    title: 'Edit Workflows',
+    body: [
+      'Define multi-step workflows — the design surface.',
+      'Each step sets a task, a persona, a delegate, and a role.',
+      'This is where the steps come from; you approve their runs next door.',
+    ],
+    seeAlso: '/workflow-actions',
+  },
+  '/workflow-actions': {
+    title: 'Workflow Actions',
+    body: [
+      'The runtime queue: workflow items waiting on you to approve or reject.',
+      'This is the human-in-the-loop gate.',
+      'Edit Workflows is where these steps were defined.',
+    ],
+    seeAlso: '/edit-workflows',
+  },
+  '/agents': {
+    title: 'Agents',
+    body: [
+      'Your delegates and their run history and stats.',
+      'Edit a delegate’s persona and the roles it may use.',
+      'Roles are the routing key matched between personas and agents.',
+    ],
+    seeAlso: '/personas',
+  },
+  '/personas': {
+    title: 'Personas',
+    body: [
+      'The shared ROLE vocabulary plus the PERSONA definitions.',
+      'Edit who aimee can be (identity + allowed roles) and what each role means.',
+      'Agents binds these personas and roles to actual work.',
+    ],
+    seeAlso: '/agents',
+  },
+  '/projects': {
+    title: 'Projects',
+    body: [
+      'Connect the git repositories aimee works on.',
+      'Store per-host credentials (sealed vault) and run read + remote git ops.',
+      'Credentials never reach the browser — they stay server-side.',
+    ],
+    seeAlso: '/editor',
+  },
+  '/graph': {
+    title: 'Graph',
+    body: [
+      'A read-only explorer of the code-projection graph for the session’s project.',
+      'Rank hubs, expand callers/callees/neighbours with provenance, spot “surprising links”.',
+      'For understanding the codebase’s shape — off the agent’s hot path.',
+    ],
+    seeAlso: '/editor',
+  },
+  '/editor': {
+    title: 'Editor',
+    body: [
+      'In-app VS Code, bound to the session’s isolated worktree.',
+      'It’s the same tree the agent edits, so you see and hand-edit exactly what it sees.',
+      'The editor’s port and git credentials stay server-side.',
+    ],
+    seeAlso: '/projects',
+  },
+  '/settings': {
+    title: 'Settings',
+    body: [
+      'Every typed config option with plain-English help.',
+      'Booleans are toggles, numbers are fields, strings are text; restart-sensitive keys are badged.',
+      'This is the full control plane the setup wizard walks you through a slice of.',
+    ],
+    seeAlso: '/dashboard',
+  },
+};
+
+/** Lookup helper — returns undefined for a route with no tutorial. */
+export function tutorialFor(route: string): Tutorial | undefined {
+  return TAB_TUTORIALS[route];
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Panel, Badge } from "@rakuensoftware/smoothgui";
 import { FIELD_HELP, SECTION_HELP, RESTART_KEYS } from "./settingsHelp";
+import { resetAll as resetTutorials } from "../help/tutorialState";
 
 /* Settings page: every typed Aimee config option (the config_fields allowlist,
  * e.g. typed_facts_enabled, kb_pdf_*, memory_*, autonomous). Values come from
@@ -146,6 +147,16 @@ export default function Settings() {
         />
         <button onClick={refresh} style={btn}>
           Reload
+        </button>
+        <button
+          onClick={() => {
+            resetTutorials();
+            setStatus({ kind: "ok", msg: "Tab tutorials will show again on your next visit to each tab." });
+          }}
+          style={btn}
+          title="Show the per-tab tutorial overlays again"
+        >
+          Replay tab tutorials
         </button>
         {status && (
           <span


### PR DESCRIPTION
Slice 1 of the setup-wizard + tab-tutorials feature (see docs/proposals/pending/setup-wizard-and-tab-tutorials.plan.md).

## What
- Dismissible, **non-modal** per-tab tutorial card (corner panel, no backdrop — page stays interactive). Auto-opens on first visit to a tab, collapses to a '?' re-opener; Escape / 'Got it' / '×' dismiss (mark seen).
- `help/tutorials.ts`: one short, grounded tutorial per NAV_ITEMS route, with a 'see also' pointer to the sibling tab.
- `help/tutorialState.ts`: localStorage seen-state with pure, node-env-safe parse/merge cores.
- Mounted once in `App` (no per-page edits). Settings gains a 'Replay tab tutorials' button.
- `tutorials.test.ts`: every route has a tutorial; seen-list logic round-trips.

## Verification
- `npm run check` (tsc): clean.
- `npm test`: +7 tests pass; the only failure is the pre-existing Dashboard guardrail-audit test (out of scope).
- Roundtable: APPROVED (after fixing an initial blocking-overlay finding — overlay is now non-modal).