### PR TITLE
fix(kb): disable reasoning pass for Tier-A curator extraction (typed-facts landed 0)

### DIFF
--- a/src/headers/provider_client.h
+++ b/src/headers/provider_client.h
@@ -46,6 +46,13 @@ extern "C"
       double temperature;   /* <0 => omit (let the provider default). */
       int max_tokens;       /* <=0 => omit. */
       int max_attempts;     /* total attempts incl. the first; <=0 => default. */
+      int disable_thinking; /* !=0 => send chat_template_kwargs.enable_thinking=false
+                             * so a reasoning model skips its chain-of-thought pass.
+                             * For mechanical, high-volume stages (Tier-A extract/
+                             * index) the reasoning pass only adds latency and can
+                             * truncate the answer; the flag makes output compact and
+                             * deterministic. Ignored by endpoints that don't support
+                             * the jinja chat-template kwarg. */
    } provider_def_t;
 
    typedef struct

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -115,5 +115,11 @@ int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
    out->api_key = api_key[0] ? api_key : NULL; /* keyless local endpoint => no bearer */
    out->wire = PROVIDER_WIRE_OPENAI_CHAT;
    out->temperature = -1.0; /* let the provider default */
+   /* Tier-A is mechanical, grammar-constrained extraction/indexing — it does not
+    * need (and is hurt by) a reasoning model's chain-of-thought: the reasoning pass
+    * adds latency at drain volume and, worse, can consume the output budget so the
+    * JSON answer comes back truncated/empty (observed: memory-fact extraction landed
+    * 0 facts). Skip thinking for Tier-A; Tier-B (judge/synthesize) keeps it. */
+   out->disable_thinking = (kb_curator_stage_tier(stage) == KB_CURATOR_TIER_A);
    return 1;
 }

--- a/src/provider_client.c
+++ b/src/provider_client.c
@@ -43,6 +43,19 @@ struct cJSON *provider_client_build_openai(const provider_def_t *def, struct cJS
    if (def->max_tokens > 0)
       cJSON_AddNumberToObject(req, "max_tokens", def->max_tokens);
 
+   /* Skip the model's reasoning pass for mechanical stages (see provider_def_t
+    * .disable_thinking). Sent as the jinja chat-template kwarg understood by
+    * llama.cpp (--jinja) / vLLM; other endpoints ignore the extra field. */
+   if (def->disable_thinking)
+   {
+      cJSON *ctk = cJSON_CreateObject();
+      if (ctk)
+      {
+         cJSON_AddBoolToObject(ctk, "enable_thinking", 0);
+         cJSON_AddItemToObject(req, "chat_template_kwargs", ctk);
+      }
+   }
+
    if (json_schema)
    {
       cJSON *schema_copy = cJSON_Duplicate(json_schema, 1);

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -63,6 +63,7 @@ static void test_tier_a_resolves(void)
    assert(strcmp(def.model, "gemma-4-e4b") == 0);
    assert(def.api_key == NULL); /* empty key => no bearer */
    assert(def.wire == PROVIDER_WIRE_OPENAI_CHAT);
+   assert(def.disable_thinking == 1); /* Tier-A skips the reasoning pass */
 
    /* Tier-B still idle (no weak fallback to the Tier-A default). */
    assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &def) == 0);
@@ -85,10 +86,12 @@ static void test_tier_b_resolves(void)
    provider_def_t a, b;
    assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_CODE, &a) == 1);
    assert(strcmp(a.model, "small") == 0 && a.api_key == NULL);
+   assert(a.disable_thinking == 1); /* Tier-A: reasoning off */
    assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &b) == 1);
    assert(strcmp(b.base_url, "https://api.big/v1") == 0);
    assert(strcmp(b.model, "big-32b") == 0);
    assert(b.api_key && strcmp(b.api_key, "sk-secret") == 0);
+   assert(b.disable_thinking == 0); /* Tier-B keeps its reasoning pass */
    printf("kb_curator_provider: tier-A and tier-B resolve independently ok\n");
 }
 

--- a/src/tests/test_provider_client.c
+++ b/src/tests/test_provider_client.c
@@ -42,6 +42,8 @@ static void test_build_basic(void)
    assert(!cJSON_GetObjectItemCaseSensitive(req, "temperature"));
    assert(!cJSON_GetObjectItemCaseSensitive(req, "max_tokens"));
    assert(!cJSON_GetObjectItemCaseSensitive(req, "response_format"));
+   /* disable_thinking defaults off => no chat_template_kwargs. */
+   assert(!cJSON_GetObjectItemCaseSensitive(req, "chat_template_kwargs"));
 
    cJSON_Delete(req);
    cJSON_Delete(msgs);
@@ -56,6 +58,7 @@ static void test_build_options_and_schema(void)
        .wire = PROVIDER_WIRE_OPENAI_CHAT,
        .temperature = 0.2,
        .max_tokens = 512,
+       .disable_thinking = 1,
    };
    cJSON *msgs = two_messages();
    cJSON *schema = cJSON_CreateObject();
@@ -67,6 +70,11 @@ static void test_build_options_and_schema(void)
    assert(cJSON_IsNumber(temp) && temp->valuedouble > 0.19 && temp->valuedouble < 0.21);
    cJSON *mt = cJSON_GetObjectItemCaseSensitive(req, "max_tokens");
    assert(cJSON_IsNumber(mt) && mt->valueint == 512);
+   /* disable_thinking => chat_template_kwargs.enable_thinking:false */
+   cJSON *ctk = cJSON_GetObjectItemCaseSensitive(req, "chat_template_kwargs");
+   assert(ctk);
+   cJSON *et = cJSON_GetObjectItemCaseSensitive(ctk, "enable_thinking");
+   assert(cJSON_IsBool(et) && !cJSON_IsTrue(et));
 
    cJSON *rf = cJSON_GetObjectItemCaseSensitive(req, "response_format");
    assert(rf);


### PR DESCRIPTION
## Problem
On the live .254 stack, memory-fact extraction ran (job → done) but committed **0 typed facts**. Root cause: the Tier-A extractor calls the gpu-mid **reasoning** model, whose chain-of-thought pass consumes the completion budget before the JSON answer — so `content` comes back empty/truncated and nothing commits.

**Verified against the live gateway** (same note, no max_tokens):
- thinking **on** → empty / truncates at 512 tokens
- `chat_template_kwargs.enable_thinking:false` → complete JSON, `finish=stop`, **~50 tokens**

## Fix
Skip the reasoning pass for **Tier-A** stages only (mechanical extract/index — `EXTRACT_DOCS`, `EXTRACT_CODE`, index/link). **Tier-B** (judge, synthesize, resolve, contradictions, promote) keeps reasoning — it needs it.

- `provider_def_t.disable_thinking` (new flag)
- `kb_curator_provider_for_stage`: `disable_thinking = (tier == TIER_A)`
- `provider_client_build_openai`: emits `chat_template_kwargs:{enable_thinking:false}` when set; endpoints without the jinja kwarg ignore the field.

Chosen over an arbitrary `max_tokens` bump: capping a reasoning model is fragile (reasoning length is unbounded); removing the reasoning tax makes Tier-A output compact and deterministic, which is what these high-volume stages want anyway.

## Tests
- `test_kb_curator_provider`: Tier-A sets the flag, Tier-B does not.
- `test_provider_client`: request carries `chat_template_kwargs.enable_thinking:false` when set, absent by default.
- KB links; both unit tests pass.

Follow-up (separate proposal): route Tier-A extraction to a small dedicated non-reasoning model.