### PR TITLE
feat(webchat): first-run setup wizard + readiness chip (slice 2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,9 @@ import Editor from './pages/Editor';
 import { SessionProvider, useSessions } from './SessionContext';
 import SettingsPanel from './components/SettingsPanel';
 import TabTutorial from './components/TabTutorial';
+import SetupChip from './components/SetupChip';
+import SetupWizard from './components/SetupWizard';
+import { OPEN_WIZARD_EVENT } from './setup/setupState';
 
 // A render error in any page used to throw past the root and unmount the whole
 // app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
@@ -173,7 +176,15 @@ function LogoutButton() {
 
 export default function App() {
   const [ready, setReady] = useState(false);
+  const [wizardOpen, setWizardOpen] = useState(false);
   const location = useLocation();
+
+  // The setup chip / "Re-run setup" dispatch this event to open the wizard.
+  useEffect(() => {
+    const openWizard = () => setWizardOpen(true);
+    window.addEventListener(OPEN_WIZARD_EVENT, openWizard);
+    return () => window.removeEventListener(OPEN_WIZARD_EVENT, openWizard);
+  }, []);
 
   useEffect(() => {
     fetch('/api/chat/session')
@@ -213,6 +224,7 @@ export default function App() {
         >
           <span style={{ color: '#8cf', fontWeight: 700, fontSize: 18 }}>aimee</span>
           <SessionTabBar />
+          <SetupChip />
           <SettingsPanel />
           <LogoutButton />
         </header>
@@ -265,6 +277,7 @@ export default function App() {
           </main>
         </div>
       </div>
+      <SetupWizard open={wizardOpen} onClose={() => setWizardOpen(false)} />
       <Toast />
     </SessionProvider>
   );

--- a/frontend/src/components/SetupChip.tsx
+++ b/frontend/src/components/SetupChip.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSessions } from '../SessionContext';
+import { loadConfig, type ConfigMap } from '../setup/configApi';
+import { computeReadiness, stepsRemaining } from '../setup/readiness';
+import { requestOpenWizard, isDismissed, SETUP_UPDATED_EVENT } from '../setup/setupState';
+
+/* Header chip: "Setup — N left". Reads GET /api/config once (and again whenever
+ * the wizard reports a change or the window regains focus), computes readiness
+ * against the active session's project, and shows how many required steps remain.
+ * Hidden entirely once ready. Clicking it opens the wizard. On first load, if the
+ * instance is not ready and the wizard hasn't been dismissed, it auto-opens the
+ * wizard once. All heavy lifting is in the tested setup/ modules. */
+
+export default function SetupChip() {
+  const { active } = useSessions();
+  const hasProject = !!active?.projectName;
+  const [cfg, setCfg] = useState<ConfigMap | null>(null);
+
+  const load = useCallback(() => {
+    loadConfig().then(setCfg);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  useEffect(() => {
+    const onUpdate = () => load();
+    window.addEventListener(SETUP_UPDATED_EVENT, onUpdate);
+    window.addEventListener('focus', onUpdate);
+    return () => {
+      window.removeEventListener(SETUP_UPDATED_EVENT, onUpdate);
+      window.removeEventListener('focus', onUpdate);
+    };
+  }, [load]);
+
+  const readiness = useMemo(
+    () => (cfg ? computeReadiness(cfg, hasProject) : null),
+    [cfg, hasProject],
+  );
+
+  // Auto-open the wizard once per page load when unconfigured and not dismissed.
+  const autoOpened = useRef(false);
+  useEffect(() => {
+    if (readiness && !readiness.ready && !isDismissed() && !autoOpened.current) {
+      autoOpened.current = true;
+      requestOpenWizard();
+    }
+  }, [readiness]);
+
+  if (!readiness || readiness.ready) return null;
+
+  const n = stepsRemaining(readiness);
+  return (
+    <button
+      onClick={requestOpenWizard}
+      title="Finish setting up this instance"
+      style={{
+        display: 'flex', alignItems: 'center', gap: 6, padding: '3px 10px',
+        borderRadius: 12, cursor: 'pointer', fontSize: 12.5, whiteSpace: 'nowrap',
+        background: '#3a2a12', color: '#f4b860', border: '1px solid #6a4a1a',
+      }}
+    >
+      <span aria-hidden>⚙️</span> Setup — {n} left
+    </button>
+  );
+}

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useToast } from '@rakuensoftware/smoothgui';
+import { useSessions } from '../SessionContext';
+import { loadConfig, saveConfigValue, type ConfigMap } from '../setup/configApi';
+import { WIZARD_STEPS, isRestartKey, helpFor } from '../setup/wizardSteps';
+import { computeReadiness } from '../setup/readiness';
+import { setDismissed, notifySetupUpdated } from '../setup/setupState';
+
+/* First-run setup wizard. A modal over the app that walks the operator through
+ * the minimum path to a working turn — provider → embedding → shared store →
+ * optional KB API → connect a project — writing every value through the existing
+ * POST /api/config/set allowlist (no new backend). It is non-blocking: closable
+ * at any time via ×, Esc, the backdrop, or "Later".
+ *
+ * Design notes:
+ * - All config I/O + step data live in the tested setup/ modules; this file is
+ *   presentation + local step state.
+ * - Every save is guarded: a 4xx/5xx/network failure surfaces a Toast and keeps
+ *   the operator on the step with their input intact.
+ * - Keys carrying RESTART_KEYS are tracked into `pendingRestart` and listed on the
+ *   summary, since they only take effect after a server restart. */
+
+function humanize(key: string): string {
+  const s = key.replace(/_/g, ' ').trim();
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// Coerce a text input back to the field's type before saving: numeric fields
+// (existing number value, or *_dim / *_port keys) go as numbers, everything else
+// as a string. Keeps the server's typed allowlist happy.
+function coerce(key: string, raw: string, original: unknown): unknown {
+  if (typeof original === 'number' || /(_dim|_port)$/.test(key)) {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : raw;
+  }
+  return raw;
+}
+
+export default function SetupWizard({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const { active } = useSessions();
+  const hasProject = !!active?.projectName;
+
+  const [cfg, setCfg] = useState<ConfigMap>({});
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [idx, setIdx] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [pendingRestart, setPendingRestart] = useState<string[]>([]);
+  const [showSummary, setShowSummary] = useState(false);
+
+  // (Re)load config each time the wizard opens; reset step + transient state.
+  useEffect(() => {
+    if (!open) return;
+    setIdx(0);
+    setShowSummary(false);
+    setPendingRestart([]);
+    loadConfig().then((c) => {
+      setCfg(c);
+      const d: Record<string, string> = {};
+      for (const step of WIZARD_STEPS) {
+        for (const k of step.keys) {
+          const v = c[k];
+          d[k] = v == null ? '' : String(v);
+        }
+      }
+      setDraft(d);
+    });
+  }, [open]);
+
+  const close = useCallback(() => { onClose(); }, [onClose]);
+
+  // Esc closes the wizard (non-blocking).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, close]);
+
+  const step = WIZARD_STEPS[idx];
+
+  const readiness = useMemo(() => computeReadiness(cfg, hasProject), [cfg, hasProject]);
+
+  if (!open) return null;
+
+  function advance() {
+    if (idx < WIZARD_STEPS.length - 1) setIdx(idx + 1);
+    else setShowSummary(true);
+  }
+
+  // Save every edited key in the current step. Any failure aborts advance and
+  // Toasts; successes update the live cfg + restart tracking.
+  async function saveStep() {
+    setSaving(true);
+    const savedCfg: ConfigMap = { ...cfg };
+    const restart = new Set(pendingRestart);
+    try {
+      for (const key of step.keys) {
+        const raw = draft[key] ?? '';
+        // Skip keys the operator left exactly as they already were.
+        const originalStr = cfg[key] == null ? '' : String(cfg[key]);
+        if (raw === originalStr) continue;
+        const value = coerce(key, raw, cfg[key]);
+        const res = await saveConfigValue(key, value);
+        if (!res.ok) {
+          toast.error(`Couldn’t save ${humanize(key)}: ${res.error ?? 'unknown error'}`);
+          setSaving(false);
+          setCfg(savedCfg); // keep whatever succeeded so far
+          setPendingRestart(Array.from(restart));
+          return; // stay on the step, input preserved
+        }
+        savedCfg[key] = res.value ?? value;
+        if (isRestartKey(key)) restart.add(key);
+      }
+      setCfg(savedCfg);
+      setPendingRestart(Array.from(restart));
+      notifySetupUpdated();
+      setSaving(false);
+      toast.success(`${step.title} saved`);
+      advance();
+    } catch (e) {
+      setSaving(false);
+      toast.error(e instanceof Error ? e.message : 'Save failed');
+    }
+  }
+
+  const backdrop: React.CSSProperties = {
+    position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(10,10,18,0.55)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16,
+  };
+  const card: React.CSSProperties = {
+    width: 'min(560px, 100%)', maxHeight: '86vh', overflow: 'auto', background: '#fff',
+    borderRadius: 12, border: '1px solid #dde', boxShadow: '0 12px 40px rgba(0,0,0,0.3)',
+    padding: '20px 22px', fontFamily: 'system-ui', color: '#233',
+  };
+  const primaryBtn: React.CSSProperties = {
+    padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
+    color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
+  };
+  const ghostBtn: React.CSSProperties = {
+    padding: '7px 14px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',
+    color: '#446', cursor: 'pointer', fontSize: 13,
+  };
+  const input: React.CSSProperties = {
+    width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
+    border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
+  };
+
+  const stepNum = idx + 1;
+  const total = WIZARD_STEPS.length;
+
+  return (
+    <div style={backdrop} onClick={close}>
+      <div style={card} role="dialog" aria-label="Setup wizard" onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+          <strong style={{ fontSize: 17 }}>Set up this instance</strong>
+          <button aria-label="Close setup" title="Close" onClick={close}
+            style={{ background: 'none', border: 'none', color: '#9aa', cursor: 'pointer', fontSize: 20, lineHeight: 1 }}>×</button>
+        </div>
+
+        {showSummary ? (
+          <div>
+            <p style={{ fontSize: 13, color: '#556', margin: '4px 0 12px' }}>
+              {readiness.ready ? 'Everything required is configured. 🎉' : 'Here’s what’s left:'}
+            </p>
+            <div style={{ display: 'grid', gap: 6, marginBottom: 14 }}>
+              {(Object.entries(readiness.steps)).map(([id, s]) => (
+                <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
+                  <span aria-hidden>{s.ok ? '✅' : s.optional ? '⚪' : '⛔'}</span>
+                  <span style={{ fontWeight: 600, textTransform: 'capitalize', minWidth: 92 }}>{id.replace('_', ' ')}</span>
+                  <span style={{ color: '#667' }}>{s.detail}{s.optional && !s.ok ? ' (optional)' : ''}</span>
+                </div>
+              ))}
+            </div>
+            {pendingRestart.length > 0 && (
+              <div style={{ fontSize: 12.5, color: '#8a5a00', background: '#fff6e6', border: '1px solid #f0d8a8', borderRadius: 6, padding: '8px 10px', marginBottom: 14 }}>
+                ⏳ Restart required for: {pendingRestart.map(humanize).join(', ')} — these take effect after the server restarts.
+              </div>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <button style={ghostBtn} onClick={() => { setShowSummary(false); setIdx(0); }}>Back</button>
+              <button style={primaryBtn} onClick={() => { setDismissed(true); notifySetupUpdated(); close(); }}>Finish</button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div style={{ fontSize: 12, color: '#8899aa', marginBottom: 4 }}>Step {stepNum} of {total}</div>
+            <div style={{ fontSize: 15, fontWeight: 700, marginBottom: 10 }}>
+              {step.title}{step.optional ? <span style={{ color: '#9aa', fontWeight: 400, fontSize: 12 }}> · optional</span> : null}
+            </div>
+
+            {step.keys.length > 0 ? (
+              <div style={{ display: 'grid', gap: 12, marginBottom: 16 }}>
+                {step.keys.map((key) => (
+                  <label key={key} style={{ display: 'block' }}>
+                    <div style={{ fontSize: 12.5, fontWeight: 600, marginBottom: 3 }}>
+                      {humanize(key)}
+                      {isRestartKey(key) ? <span style={{ color: '#8a5a00', fontWeight: 400 }}> · needs restart</span> : null}
+                    </div>
+                    {helpFor(key) && <div style={{ fontSize: 11.5, color: '#778', marginBottom: 4, lineHeight: 1.4 }}>{helpFor(key)}</div>}
+                    <input
+                      style={input}
+                      value={draft[key] ?? ''}
+                      onChange={(e) => setDraft((p) => ({ ...p, [key]: e.target.value }))}
+                      placeholder={key}
+                    />
+                  </label>
+                ))}
+              </div>
+            ) : (
+              // Hand-off step (project): no config keys, link out to the page.
+              <div style={{ marginBottom: 16 }}>
+                <p style={{ fontSize: 13, color: '#556', lineHeight: 1.5 }}>
+                  Connect a git repository on the Projects tab so the tools have something to act on.
+                  {step.skipNote ? ` ${step.skipNote}` : ''}
+                </p>
+                <button style={{ ...primaryBtn, marginTop: 4 }} onClick={() => { navigate(step.route ?? '/projects'); close(); }}>
+                  Go to Projects →
+                </button>
+                {hasProject && <div style={{ fontSize: 12.5, color: '#2c8f56', marginTop: 8 }}>✅ A project is already connected to this session.</div>}
+              </div>
+            )}
+
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button style={ghostBtn} disabled={idx === 0} onClick={() => setIdx(Math.max(0, idx - 1))}>Back</button>
+                <button style={ghostBtn} onClick={close}>Later</button>
+              </div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                {step.optional && <button style={ghostBtn} onClick={advance}>Skip</button>}
+                {step.keys.length > 0 ? (
+                  <button style={primaryBtn} disabled={saving} onClick={saveStep}>{saving ? 'Saving…' : 'Save & continue'}</button>
+                ) : (
+                  <button style={primaryBtn} onClick={advance}>{idx === total - 1 ? 'Review' : 'Next'}</button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Panel, Badge } from "@rakuensoftware/smoothgui";
 import { FIELD_HELP, SECTION_HELP, RESTART_KEYS } from "./settingsHelp";
 import { resetAll as resetTutorials } from "../help/tutorialState";
+import { setDismissed as setSetupDismissed, requestOpenWizard } from "../setup/setupState";
 
 /* Settings page: every typed Aimee config option (the config_fields allowlist,
  * e.g. typed_facts_enabled, kb_pdf_*, memory_*, autonomous). Values come from
@@ -157,6 +158,16 @@ export default function Settings() {
           title="Show the per-tab tutorial overlays again"
         >
           Replay tab tutorials
+        </button>
+        <button
+          onClick={() => {
+            setSetupDismissed(false);
+            requestOpenWizard();
+          }}
+          style={btn}
+          title="Re-open the first-run setup wizard"
+        >
+          Re-run setup
         </button>
         {status && (
           <span

--- a/frontend/src/setup/configApi.ts
+++ b/frontend/src/setup/configApi.ts
@@ -1,0 +1,67 @@
+/* Thin, testable wrappers over the config endpoints the Settings page already
+ * uses. Extracted so the wizard's write path (and its error handling) can be unit
+ * tested with a stubbed fetch — vitest runs in node, so there is no real network
+ * or DOM. `fetchImpl` is injectable for exactly that reason. */
+
+export type ConfigMap = Record<string, unknown>;
+
+type FetchLike = typeof fetch;
+
+function csrf(): string {
+  try {
+    if (typeof window !== 'undefined') return (window as { _csrf?: string })._csrf || '';
+  } catch {
+    /* ignore */
+  }
+  return '';
+}
+
+/** Load the current config map (GET /api/config → { config }). Returns {} on any
+ * failure so callers degrade rather than throw. */
+export async function loadConfig(opts?: { fetchImpl?: FetchLike }): Promise<ConfigMap> {
+  const f = opts?.fetchImpl ?? fetch;
+  try {
+    const r = await f('/api/config', { headers: { 'X-CSRF-Token': csrf() } });
+    const d = (await r.json()) as { config?: ConfigMap };
+    return d.config ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export interface SaveResult {
+  ok: boolean;
+  error?: string;
+  /** The persisted value the server echoed back (falls back to the input). */
+  value?: unknown;
+}
+
+/** Persist one config value (POST /api/config/set { key, value }). Mirrors the
+ * Settings page's success test (2xx && !error) and never throws — a network or
+ * parse failure returns { ok: false, error }. */
+export async function saveConfigValue(
+  key: string,
+  value: unknown,
+  opts?: { fetchImpl?: FetchLike },
+): Promise<SaveResult> {
+  const f = opts?.fetchImpl ?? fetch;
+  try {
+    const r = await f('/api/config/set', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf() },
+      body: JSON.stringify({ key, value }),
+    });
+    let data: { error?: string; value?: unknown } = {};
+    try {
+      data = (await r.json()) as { error?: string; value?: unknown };
+    } catch {
+      /* empty/invalid body — fall through to status check */
+    }
+    if (r.status >= 200 && r.status < 300 && !data.error) {
+      return { ok: true, value: data.value !== undefined ? data.value : value };
+    }
+    return { ok: false, error: data.error || `save failed (${r.status})` };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'network error' };
+  }
+}

--- a/frontend/src/setup/readiness.test.ts
+++ b/frontend/src/setup/readiness.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { FIELD_HELP } from '../pages/settingsHelp';
+import { computeReadiness, stepsRemaining, READINESS_KEYS, readinessKeysAreDocumented } from './readiness';
+
+describe('readiness grounding', () => {
+  it('every READINESS_KEYS entry is a documented config field', () => {
+    for (const k of READINESS_KEYS) {
+      expect(FIELD_HELP, `${k} missing from FIELD_HELP`).toHaveProperty(k);
+    }
+    expect(readinessKeysAreDocumented()).toBe(true);
+  });
+});
+
+describe('computeReadiness', () => {
+  it('an empty config with no project → all required steps red, not ready', () => {
+    const r = computeReadiness({}, false);
+    expect(r.ready).toBe(false);
+    expect(r.steps.provider.ok).toBe(false);
+    expect(r.steps.embedding.ok).toBe(false);
+    expect(r.steps.db2.ok).toBe(false);
+    expect(r.steps.project.ok).toBe(false);
+    expect(r.steps.kb_api.ok).toBe(false);
+    expect(r.steps.kb_api.optional).toBe(true);
+    // provider, embedding, db2, project are the 4 required-incomplete steps.
+    expect(stepsRemaining(r)).toBe(4);
+  });
+
+  it('the built-in hash embedder (both keys blank) reads as not-ok, test-only', () => {
+    const r = computeReadiness({ embedding_command: '', embedding_endpoint: '   ' }, false);
+    expect(r.steps.embedding.ok).toBe(false);
+    expect(r.steps.embedding.detail).toMatch(/hash fallback/i);
+  });
+
+  it('an embedding command OR endpoint satisfies embedding', () => {
+    expect(computeReadiness({ embedding_command: 'embed.sh' }, false).steps.embedding.ok).toBe(true);
+    expect(computeReadiness({ embedding_endpoint: 'http://e' }, false).steps.embedding.ok).toBe(true);
+  });
+
+  it('kb_api is optional: unset does not block readiness', () => {
+    const cfg = { provider: 'claude', embedding_command: 'e.sh', db2_url: 'postgres://x' };
+    const r = computeReadiness(cfg, true); // kb_api unset (port 0)
+    expect(r.steps.kb_api.ok).toBe(false);
+    expect(r.ready).toBe(true);
+    expect(stepsRemaining(r)).toBe(0);
+  });
+
+  it('a fully configured instance with a project is ready', () => {
+    const cfg = { provider: 'claude', embedding_endpoint: 'http://e', db2_url: 'postgres://x', kb_api_http_port: 8741 };
+    const r = computeReadiness(cfg, true);
+    expect(r.ready).toBe(true);
+    expect(r.steps.kb_api.ok).toBe(true);
+    expect(stepsRemaining(r)).toBe(0);
+  });
+
+  it('kb_api_http_port coerces from a string and 0 stays disabled', () => {
+    expect(computeReadiness({ kb_api_http_port: '8741' }, false).steps.kb_api.ok).toBe(true);
+    expect(computeReadiness({ kb_api_http_port: '0' }, false).steps.kb_api.ok).toBe(false);
+  });
+
+  it('a connected project flips only the project step', () => {
+    const base = { provider: 'claude', embedding_command: 'e.sh', db2_url: 'x' };
+    expect(computeReadiness(base, false).ready).toBe(false);
+    expect(computeReadiness(base, true).ready).toBe(true);
+  });
+});

--- a/frontend/src/setup/readiness.ts
+++ b/frontend/src/setup/readiness.ts
@@ -1,0 +1,101 @@
+/* Setup readiness — a PURE function over the values GET /api/config returns
+ * (config.show). It classifies the minimum steps needed for a working turn so the
+ * header chip and the wizard share one definition of "ready". No network, no DOM:
+ * unit-tested under vitest's node env.
+ *
+ * MVP scope: readiness is inferred client-side from config values (and whether the
+ * active session has a project bound). A server-side GET /api/setup/state that can
+ * additionally ping DB2/the provider is a documented follow-up. */
+
+import { FIELD_HELP } from '../pages/settingsHelp';
+
+export type StepId = 'provider' | 'embedding' | 'db2' | 'kb_api' | 'project';
+
+/* The config keys readiness inspects. Exported so a test can assert each one is a
+ * real, documented config field (a key rename in settingsHelp.ts that we miss
+ * would otherwise silently break a rule). `project` has no config key — it comes
+ * from the session bundle — so it is deliberately absent here. */
+export const READINESS_KEYS = [
+  'provider',
+  'embedding_command',
+  'embedding_endpoint',
+  'db2_url',
+  'kb_api_http_port',
+] as const;
+
+export interface StepStatus {
+  ok: boolean;
+  detail: string;
+  /** Optional steps do not block overall readiness. */
+  optional?: boolean;
+}
+
+export interface Readiness {
+  ready: boolean;
+  steps: Record<StepId, StepStatus>;
+}
+
+function asStr(cfg: Record<string, unknown>, key: string): string {
+  const v = cfg[key];
+  if (typeof v === 'string') return v.trim();
+  if (v == null) return '';
+  return String(v).trim();
+}
+
+function asNum(cfg: Record<string, unknown>, key: string): number {
+  const v = cfg[key];
+  if (typeof v === 'number') return v;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Classify the setup steps. `hasProject` comes from the active session (the
+ * config has no project field). */
+export function computeReadiness(cfg: Record<string, unknown>, hasProject: boolean): Readiness {
+  const provider = asStr(cfg, 'provider');
+  const embCmd = asStr(cfg, 'embedding_command');
+  const embEndpoint = asStr(cfg, 'embedding_endpoint');
+  const db2 = asStr(cfg, 'db2_url');
+  const kbPort = asNum(cfg, 'kb_api_http_port');
+
+  const steps: Record<StepId, StepStatus> = {
+    provider: {
+      ok: provider !== '',
+      detail: provider !== '' ? `primary: ${provider}` : 'no primary provider set',
+    },
+    embedding: {
+      // A real embedder is a command or an endpoint; blank means the built-in
+      // 384-dim hash fallback, which only works in a test setup.
+      ok: embCmd !== '' || embEndpoint !== '',
+      detail: embCmd !== '' || embEndpoint !== '' ? 'embedder configured' : 'built-in hash fallback (test-only)',
+    },
+    db2: {
+      ok: db2 !== '',
+      detail: db2 !== '' ? 'shared store configured' : 'no DB2 URL set',
+    },
+    kb_api: {
+      ok: kbPort > 0,
+      detail: kbPort > 0 ? `listening on port ${kbPort}` : 'disabled (port 0)',
+      optional: true,
+    },
+    project: {
+      ok: hasProject,
+      detail: hasProject ? 'project connected' : 'no project connected',
+    },
+  };
+
+  const ready = (Object.values(steps) as StepStatus[]).every((s) => s.ok || s.optional);
+  return { ready, steps };
+}
+
+/** How many REQUIRED steps are still incomplete (optional steps excluded). Drives
+ * the "Setup — N left" chip; 0 ⇒ chip hidden. */
+export function stepsRemaining(r: Readiness): number {
+  return (Object.values(r.steps) as StepStatus[]).filter((s) => !s.ok && !s.optional).length;
+}
+
+/** Guard used by the grounding test: every READINESS_KEYS entry must be a real
+ * documented field. Kept here so the invariant lives next to the keys. */
+export function readinessKeysAreDocumented(): boolean {
+  return READINESS_KEYS.every((k) => k in FIELD_HELP);
+}

--- a/frontend/src/setup/setupState.ts
+++ b/frontend/src/setup/setupState.ts
@@ -1,0 +1,46 @@
+/* Wizard "dismissed" flag — localStorage, per-browser (MVP; a per-user server
+ * store is a follow-up). Guarded for node/SSR and storage-disabled browsers, same
+ * as tutorialState. The custom-event name that opens the wizard lives here too so
+ * the chip, Settings, and App all agree on one string. */
+
+export const DISMISSED_KEY = 'aimee_setup_dismissed';
+export const OPEN_WIZARD_EVENT = 'aimee:open-setup-wizard';
+/** Fired after the wizard changes config so the header chip re-computes. */
+export const SETUP_UPDATED_EVENT = 'aimee:setup-updated';
+
+export function isDismissed(): boolean {
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    return localStorage.getItem(DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function setDismissed(dismissed: boolean): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    if (dismissed) localStorage.setItem(DISMISSED_KEY, '1');
+    else localStorage.removeItem(DISMISSED_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Fire the event that opens the wizard (chip click / "Re-run setup"). */
+export function requestOpenWizard(): void {
+  try {
+    if (typeof window !== 'undefined') window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Fire the event that tells the chip to re-read config after a wizard change. */
+export function notifySetupUpdated(): void {
+  try {
+    if (typeof window !== 'undefined') window.dispatchEvent(new CustomEvent(SETUP_UPDATED_EVENT));
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/setup/wizardSteps.test.ts
+++ b/frontend/src/setup/wizardSteps.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { WIZARD_STEPS, isRestartKey, helpFor } from './wizardSteps';
+import { RESTART_KEYS, FIELD_HELP } from '../pages/settingsHelp';
+import { saveConfigValue, loadConfig } from './configApi';
+import type { StepId } from './readiness';
+
+describe('WIZARD_STEPS structure', () => {
+  it('covers every readiness StepId exactly once, in dependency order', () => {
+    const ids = WIZARD_STEPS.map((s) => s.id);
+    expect(ids).toEqual<StepId[]>(['provider', 'embedding', 'db2', 'kb_api', 'project']);
+    expect(new Set(ids).size).toBe(ids.length); // no dupes
+  });
+
+  it('kb_api is optional and project is a hand-off (route, no keys)', () => {
+    const kb = WIZARD_STEPS.find((s) => s.id === 'kb_api')!;
+    const project = WIZARD_STEPS.find((s) => s.id === 'project')!;
+    expect(kb.optional).toBe(true);
+    expect(project.keys).toEqual([]);
+    expect(project.route).toBe('/projects');
+  });
+
+  it('every keyed step references documented config keys', () => {
+    for (const step of WIZARD_STEPS) {
+      for (const k of step.keys) {
+        expect(FIELD_HELP, `${step.id}: ${k} undocumented`).toHaveProperty(k);
+      }
+    }
+  });
+});
+
+describe('isRestartKey / helpFor', () => {
+  it('isRestartKey matches exactly the RESTART_KEYS set', () => {
+    for (const k of RESTART_KEYS) expect(isRestartKey(k)).toBe(true);
+    expect(isRestartKey('provider')).toBe(false);
+    // db2_url is a known restart key and appears in the wizard.
+    expect(isRestartKey('db2_url')).toBe(true);
+  });
+
+  it('helpFor returns the settingsHelp copy, or "" for unknowns', () => {
+    expect(helpFor('provider').length).toBeGreaterThan(0);
+    expect(helpFor('totally_made_up_key')).toBe('');
+  });
+});
+
+// Stub the fetch the config API depends on — vitest runs in node, so we control
+// the whole request/response.
+function stubFetch(status: number, body: unknown): typeof fetch {
+  return (async () => ({
+    status,
+    json: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+describe('saveConfigValue (wizard write path)', () => {
+  it('a 2xx with no error is a success and echoes the server value', async () => {
+    const res = await saveConfigValue('provider', 'claude', { fetchImpl: stubFetch(200, { value: 'claude' }) });
+    expect(res.ok).toBe(true);
+    expect(res.value).toBe('claude');
+  });
+
+  it('a 4xx surfaces the server error and does not succeed', async () => {
+    const res = await saveConfigValue('db2_url', 'bad', { fetchImpl: stubFetch(400, { error: 'invalid url' }) });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('invalid url');
+  });
+
+  it('a 2xx body carrying an error field is still a failure', async () => {
+    const res = await saveConfigValue('provider', 'x', { fetchImpl: stubFetch(200, { error: 'nope' }) });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('nope');
+  });
+
+  it('a thrown fetch (network error) is caught, not propagated', async () => {
+    const throwing = (async () => { throw new Error('network down'); }) as unknown as typeof fetch;
+    const res = await saveConfigValue('provider', 'x', { fetchImpl: throwing });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/network down/);
+  });
+});
+
+describe('loadConfig', () => {
+  it('unwraps { config } and returns {} on failure', async () => {
+    const ok = await loadConfig({ fetchImpl: stubFetch(200, { config: { provider: 'claude' } }) });
+    expect(ok).toEqual({ provider: 'claude' });
+    const throwing = (async () => { throw new Error('x'); }) as unknown as typeof fetch;
+    expect(await loadConfig({ fetchImpl: throwing })).toEqual({});
+  });
+});

--- a/frontend/src/setup/wizardSteps.ts
+++ b/frontend/src/setup/wizardSteps.ts
@@ -1,0 +1,39 @@
+/* Ordered wizard step definitions + small helpers. Pure data/logic (no DOM), so
+ * the ordering and restart-key classification are unit-tested. The step order is
+ * the real dependency order for a working turn (provider → embedding → shared
+ * store → optional KB API → project). Each step's config keys reuse the
+ * plain-English copy in settingsHelp.ts (single source of truth). */
+
+import { FIELD_HELP, RESTART_KEYS } from '../pages/settingsHelp';
+import type { StepId } from './readiness';
+
+export interface WizardStep {
+  id: StepId;
+  title: string;
+  /** Config keys this step edits, in display order. Empty for a hand-off step. */
+  keys: string[];
+  /** Optional steps are skippable and never block "ready". */
+  optional?: boolean;
+  /** For a hand-off step (e.g. project), the route to send the operator to. */
+  route?: string;
+  /** One-line "what you lose if you skip", shown for optional steps. */
+  skipNote?: string;
+}
+
+export const WIZARD_STEPS: WizardStep[] = [
+  { id: 'provider', title: 'Primary provider', keys: ['provider', 'claude_model', 'openai_endpoint', 'openai_model', 'openai_key_cmd'] },
+  { id: 'embedding', title: 'Embedding backend', keys: ['embedding_command', 'embedding_endpoint', 'embedding_model', 'embedding_dim'] },
+  { id: 'db2', title: 'Shared store (DB2)', keys: ['db2_url'] },
+  { id: 'kb_api', title: 'Knowledge-base API', keys: ['kb_api_http_port', 'kb_api_bearer_token'], optional: true, skipNote: 'Skipping leaves the KB REST API off — no external programmatic access to the knowledge base.' },
+  { id: 'project', title: 'Connect a project', keys: [], route: '/projects', skipNote: 'Without a connected project, tools have no repository to act on.' },
+];
+
+/** True when a config key only takes effect after a server restart. */
+export function isRestartKey(key: string): boolean {
+  return RESTART_KEYS.has(key);
+}
+
+/** Plain-English help for a config key (blank if undocumented). */
+export function helpFor(key: string): string {
+  return FIELD_HELP[key] ?? '';
+}


### PR DESCRIPTION
Slice 2 (atomic onboarding) of the setup-wizard feature — see docs/proposals/pending/setup-wizard-and-tab-tutorials.plan.md.

## What
- **Header chip** `Setup — N left`, hidden when ready; auto-opens the wizard once when unconfigured and not dismissed.
- **First-run wizard**: modal, one screen per step (provider → embedding → shared store → optional KB API → connect a project). Reads `GET /api/config`, writes the **existing** `POST /api/config/set` (no new backend).
- Every write is guarded: on 4xx/5xx/network it Toasts and keeps the operator on the step with input intact. `RESTART_KEYS` changes are tracked and listed on the summary. Closable anytime (Esc/×/backdrop/Later).
- Pure, tested cores: `computeReadiness` (grounded: READINESS_KEYS ⊆ settingsHelp), `WIZARD_STEPS`/`isRestartKey`, and `saveConfigValue`/`loadConfig` (stubbed-fetch tests: success / 4xx / body-error / network-throw).
- Settings gains **Re-run setup**.

## Verification
- `tsc` clean; `vite build` clean; `vitest` +18 tests pass. Only failure is the pre-existing Dashboard guardrail-audit test (out of scope).
- Roundtable: APPROVED (no blocking issues).