### PR TITLE
feat(webchat): first-run setup wizard + per-tab tutorials

### DIFF
--- a/docs/proposals/pending/proposal-setup-wizard-and-tab-tutorials.md
+++ b/docs/proposals/pending/proposal-setup-wizard-and-tab-tutorials.md
@@ -1,0 +1,244 @@
+# Proposal: aimee-server web GUI — first-run setup wizard + per-tab tutorials
+
+- **State:** proposed (pending — not started)
+- **Charter role(s):** none (product/UX surface; consumes existing config + readiness contracts, adds no intelligence pass)
+- **Surfaces:** `frontend/` (the aimee-server web GUI), `/api/config`, `/api/config/set`, `/api/git/*`, Dashboard readiness
+
+## Thesis
+
+A fresh aimee-server install drops the operator straight onto `/chat` with no
+guidance. Everything needed to make the instance *actually work* — pick a
+primary provider, wire an embedding backend, point at DB2, connect a git
+project — is reachable but never surfaced. It lives in the Settings tab as a
+flat, searchable list of ~80 config keys (`frontend/src/pages/Settings.tsx`,
+`settingsHelp.ts`), with no notion of "what do I set **first**, and in what
+order, to get from zero to a working turn." The Dashboard already computes a
+**Readiness** signal and **LSP Health** — but only *after* you've found the
+Dashboard tab and only as a display, not a fix-it flow.
+
+Two gaps, one theme (nobody tells the operator what to do):
+
+1. **No guided setup.** There is no wizard that detects what's unconfigured and
+   walks the operator through the minimum viable environment. The knowledge to
+   do it exists (every field has a plain-English line in `settingsHelp.ts`; the
+   restart-sensitive keys are enumerated in `RESTART_KEYS`) — it's just never
+   assembled into a path.
+2. **No per-tab orientation.** The eleven tools in the left nav
+   (`NAV_ITEMS` in `frontend/src/App.tsx`) are discoverable by clicking, but
+   each lands you in a working surface with no "what is this / how do I use it"
+   affordance. A new operator learns Workflow Actions vs Edit Workflows vs
+   Agents by trial and error.
+
+## Goal
+
+Two additions to the existing GUI, sharing one content store:
+
+- **A) A first-run setup wizard** that runs on an under-configured instance,
+  detects readiness, and walks the operator through the minimum path to a
+  working turn — writing every change through the *existing* `/api/config/set`
+  allowlist (no new mutation surface, no new secrets path).
+- **B) A per-tab tutorial layer** — a dismissible "how this tab works" overlay
+  on each of the eleven tabs, reusable as a "?" affordance after first run.
+
+Both are **additive and non-blocking**: an operator who knows the product can
+skip the wizard and never see a tutorial again. Nothing changes about how
+config, git, or turns actually execute.
+
+## §0 What already exists (do not rebuild)
+
+- **Settings tab** — `frontend/src/pages/Settings.tsx` reads `GET /api/config`
+  (`config.show`), writes `POST /api/config/set`, infers the control from the
+  value's JSON type, and groups keys into sections via `category()`.
+- **Plain-English help** — `frontend/src/pages/settingsHelp.ts`: `FIELD_HELP`
+  (one line per key, states the default), `SECTION_HELP` (one line per section),
+  and `RESTART_KEYS` (`db2_url`, `kb_api_http_port`, `kb_api_bearer_token` — the
+  only keys that need a restart rather than applying next turn). **The wizard's
+  copy comes from here; it is not rewritten.**
+- **Readiness + LSP Health** — the Dashboard (`frontend/src/pages/Dashboard.tsx`)
+  already renders "Readiness" and "LSP Health" cards. The wizard should consume
+  the *same* server signal, not invent a second definition of "ready."
+- **Git project connect** — `frontend/src/pages/Projects.tsx` already does clone,
+  per-host credential storage (sealed vault), and GitHub device-flow OAuth
+  (`/api/git/oauth/github/*`). The wizard's "connect a project" step **launches
+  this existing flow**, it does not reimplement it.
+- **Sessions** — a session bundles a chat + its project (`SessionContext.tsx`);
+  every tool operates on the active session's project.
+- **No wizard, no onboarding, no per-tab help.** Confirmed: `grep -rilE
+  'wizard|onboard|first.?run|getting.?started'` over `frontend/src` returns only
+  Dashboard/settings incidental matches. This is greenfield UX over an existing
+  config plane.
+
+## §1 The setup wizard
+
+### §1.1 Trigger
+
+On load, `App` already gates on `/api/chat/session`. Add a lightweight
+`GET /api/setup/state` that returns a **readiness summary** (reusing the
+Dashboard readiness computation server-side, not a new heuristic):
+
+```jsonc
+{
+  "ready": false,
+  "steps": {
+    "provider":  { "ok": true,  "detail": "claude" },
+    "embedding": { "ok": false, "detail": "built-in hash fallback (test-only)" },
+    "db2":       { "ok": true,  "detail": "connected" },
+    "kb_api":    { "ok": false, "detail": "disabled (port 0)" },
+    "project":   { "ok": false, "detail": "no project connected" }
+  },
+  "dismissed": false
+}
+```
+
+The wizard auto-opens when `ready === false && dismissed === false`. It is a
+modal *over* the app, never a separate route — the operator can close it and the
+app is fully usable. A persistent **"Setup — N steps left"** chip in the header
+re-opens it. Dismissal is per-user server state so it survives a new browser.
+
+### §1.2 Steps (minimum viable environment)
+
+Each step is one screen: the `settingsHelp.ts` line as the explanation, the live
+value, an input, and a **"Test"** button that validates before advancing. Order
+is the real dependency order for a working turn:
+
+1. **Primary provider** — `provider`, then the provider-specific keys it reveals
+   (`claude_model`; or `openai_endpoint` / `openai_model` / `openai_key_cmd`).
+   Test = a trivial provider ping. *Green already when Claude CLI is logged in.*
+2. **Embedding backend** — `embedding_command` **or** `embedding_endpoint`, plus
+   `embedding_model` / `embedding_dim`. The wizard must **loudly** flag the
+   built-in 384-dim hash as test-only (that copy already exists in
+   `FIELD_HELP.embedding_command`) — this is the #1 silent-degradation trap.
+   Test = embed a fixed string, assert the returned vector width equals
+   `embedding_dim`.
+3. **Shared store (DB2)** — `db2_url`. Flagged `RESTART` (in `RESTART_KEYS`).
+   Test = connection check. Wizard shows the "applies after restart" banner and
+   offers a restart-needed reminder rather than pretending it took effect.
+4. **Knowledge-base API (optional)** — `kb_api_http_port` + `kb_api_bearer_token`
+   (both `RESTART`). Presented as **optional/skippable** with a one-line "what
+   you lose if you skip" (no REST access to the KB).
+5. **Connect a project** — hands off to the existing `Projects` connect flow
+   (clone or GitHub OAuth). On return, the wizard confirms the session now has a
+   project bound.
+
+A final **summary screen** re-renders `/api/setup/state` so the operator sees
+green across the board (or exactly what remains + why), plus any pending-restart
+callout. "Finish" sets `dismissed`.
+
+### §1.3 Constraints (what the wizard is *not* allowed to do)
+
+- **No new write path.** Every set goes through `POST /api/config/set` — the same
+  allowlist Settings uses. The wizard cannot set a key Settings can't.
+- **No new secret handling.** `openai_key_cmd` stays a *command that prints the
+  key* (keeps the key out of config); git credentials stay in the sealed vault
+  via the existing `/api/git/*` path. The wizard never accepts a raw API key into
+  a config value.
+- **Honest about restarts.** Keys in `RESTART_KEYS` are labelled and the wizard
+  never reports them as live until a restart happens.
+
+## §2 Per-tab tutorials
+
+### §2.1 Mechanism
+
+A small `<TabTutorial tabId=… />` affordance rendered by each page (or once in
+`App` keyed on route). First visit to a tab auto-shows a **dismissible overlay**;
+after dismissal it collapses to a **"?"** button in the tab's top-right that
+re-opens it. Per-tab "seen" state lives in the same per-user store as wizard
+dismissal, so it's stable across browsers and a "Replay all tutorials" toggle in
+Settings resets it. Content is data (§3), not hard-coded JSX, so it's editable
+without a component change.
+
+### §2.2 Content — one tutorial per real tab
+
+Grounded in what each page actually does today (`frontend/src/pages/*`,
+`NAV_ITEMS` in `App.tsx`):
+
+- **💬 Chat** — the session's conversation with aimee; attach files, use
+  slash-commands, channels, and turn a reply into a proposal. "This is where a
+  turn runs; the active session's project is what it acts on."
+- **📊 Dashboard** — live health: Readiness, LSP Health, per-agent success/tokens,
+  latency by role, provider mix, cache efficiency, guardrail actions, traces.
+  "Start here when something feels wrong." (Cards are reorderable.)
+- **📜 Logs** — the audit trail; every row expands to a full-field detail modal.
+  "What did aimee do, when, and under whose identity."
+- **🔀 Edit Workflows** — *define* multi-step workflows (per-step task, persona,
+  delegate, role). The design surface.
+- **📝 Workflow Actions** — the *runtime* queue: pending items to **approve /
+  reject**. "This is the human-in-the-loop gate; Edit Workflows is where the
+  steps came from." (Explicitly disambiguates the two adjacent tabs — the #1
+  confusion.)
+- **🤝 Agents** — delegates and their run history/stats; edit a delegate's
+  persona + role. "Roles are the routing key matched between personas and agents."
+- **🎭 Personas** — the shared ROLE vocabulary + PERSONA definitions (identity +
+  allowed roles). "Edit *who* aimee can be and *what* each role means; Agents
+  binds them to work."
+- **📁 Projects** — connect a git repo, store per-host credentials (sealed vault),
+  run read + remote git ops. "Connect the code aimee works on; creds never reach
+  the browser."
+- **🕸️ Graph** — read-only code-projection explorer: rank hubs, expand
+  callers/callees/neighbours with provenance, spot "surprising links." "Understand
+  the codebase's shape; off the agent's hot path."
+- **🖥️ Editor** — in-app VS Code bound to the session's isolated worktree — the
+  same tree the agent edits. "See and hand-edit exactly what the agent sees."
+- **⚙️ Settings** — every typed config key with plain-English help; boolean→toggle,
+  number→field, string→text; restart-sensitive keys badged. "The full control
+  plane the wizard walked you through a slice of."
+
+Each tutorial is **3–5 lines max** + one "where this connects" pointer to a
+sibling tab. Long-form docs stay in `docs/`; the overlay links out, it doesn't
+duplicate.
+
+## §3 Where the content lives
+
+One content module, `frontend/src/help/tutorials.ts`, keyed by `tabId` and by
+wizard `stepId`:
+
+```ts
+export const TAB_TUTORIALS: Record<string, { title: string; body: string[]; seeAlso?: string }> = { … }
+export const WIZARD_STEPS: Array<{ id: string; keys: string[]; test?: TestSpec; optional?: boolean }> = { … }
+```
+
+- Wizard step **copy** reuses `FIELD_HELP` / `SECTION_HELP` verbatim — single
+  source of truth, so a config-help edit updates both surfaces (the existing
+  sync rule between `settingsHelp.ts` and `config.h` comments extends to cover
+  it).
+- Tab copy is authored fresh (the pages have no help strings today) but kept to
+  the length above and reviewed against the page's own header comment so it can't
+  drift silently.
+
+## §4 Rollout
+
+Ships in independent slices; each is useful alone:
+
+1. `GET /api/setup/state` + the header **Readiness chip** (no wizard yet) — makes
+   readiness visible without the Dashboard.
+2. Per-tab tutorial overlays (§2) — pure frontend, no new endpoint, lowest risk.
+3. The wizard modal (§1) over the existing `/api/config/set` — the largest slice.
+4. "Replay tutorials" / "Re-run setup" controls in Settings.
+
+## Non-goals
+
+- **Not a new config surface.** Zero new writable keys; the wizard is a *view*
+  over `/api/config/set`. If Settings can't set it, the wizard can't either.
+- **Not provisioning.** The wizard configures an aimee-server that is already
+  running; it does not install sidecars (OCR/TSR/rerank), stand up Postgres, or
+  deploy containers. Where a key needs a sidecar, it says so and links the doc.
+- **Not a replacement for Settings.** Settings stays the exhaustive plane; the
+  wizard is the curated first-mile through it.
+- **Not blocking.** A configured instance never forces the wizard; a returning
+  operator never re-sees a dismissed tutorial.
+
+## Acceptance criteria (validation-pending — this is a proposal)
+
+- On an instance with the built-in hash embedder and no project,
+  `GET /api/setup/state` returns `ready:false` with `embedding` and `project` red;
+  the wizard auto-opens.
+- Completing every step (test buttons green) flips `/api/setup/state` to
+  `ready:true`; a `RESTART_KEYS` change is reported as pending-restart, never as
+  live.
+- Every wizard write is observable as a `POST /api/config/set` — no other mutation
+  endpoint is introduced.
+- Each of the eleven `NAV_ITEMS` tabs shows its tutorial on first visit and a "?"
+  re-opener after; "Replay tutorials" resets the seen-state for all eleven.
+
+> These criteria are the exit test for implementation, not claims about current
+> behaviour — nothing here is built yet.

--- a/docs/proposals/pending/setup-wizard-and-tab-tutorials.plan.md
+++ b/docs/proposals/pending/setup-wizard-and-tab-tutorials.plan.md
@@ -1,0 +1,112 @@
+# Implementation plan: setup wizard + per-tab tutorials
+
+Companion to [`proposal-setup-wizard-and-tab-tutorials.md`](./proposal-setup-wizard-and-tab-tutorials.md).
+This plan is the concrete, sliced build-out. Each slice is independently
+shippable, **frontend-only**, and verifiable with `npm run check` + `npm test`
+(no C-server or Go-webchat rebuild required for the MVP).
+
+## Guiding decisions (design-for-implementability)
+
+1. **No new backend for the MVP.** The proposal floated a server-side
+   `GET /api/setup/state`. We defer it. Readiness is computed **client-side**
+   from the values already returned by `GET /api/config` (`config.show`), and
+   every wizard write goes through the **existing** `POST /api/config/set`
+   allowlist. This keeps the whole feature inside `frontend/` and testable
+   without a running server. A server-side readiness endpoint is a documented
+   follow-up (§Future), not a blocker.
+2. **Single mount point, not 11 edits.** Tutorials and the setup chip mount once
+   in `App.tsx`, keyed on `location.pathname` / global shell — we do **not** edit
+   each of the eleven page components. Content lives in data modules.
+3. **Persistence: `localStorage` for the MVP.** "Tutorial seen" and "wizard
+   dismissed" live in `localStorage` (per-browser). The proposal's per-user
+   server store is a follow-up; localStorage keeps slices frontend-only and is
+   the established pattern in this app (`aimee_chat_tabs`, `aimee_active_chat_tab`,
+   `aimee_proposal_draft` in `App.tsx`/`LogoutButton`). Trade-off noted for the
+   roundtable.
+4. **Pure, unit-testable core.** Readiness logic is a pure function over a config
+   object, tested with vitest — no network, no DOM. Same for the tutorial
+   content registry (shape-validated by a test).
+
+## Baseline (stock, before any change)
+
+- `npm run check` (`tsc -b`): **clean**.
+- `npm test` (vitest): **14 pass, 1 pre-existing failure** —
+  `Dashboard.test.ts` "populates the guardrail audit". This failure exists on
+  stock `testing` and is **out of scope**; no slice may touch Dashboard audit
+  logic, and our done-bar is "no *new* test failures", not "0 failures".
+
+## Roundtable outcome (converged, 2 rounds)
+
+Adopted: merge Slices 2+3 into one atomic PR (chip never lands without its wizard
+listener → no dead control); wizard wraps every `/api/config/set` in try/catch and
+surfaces failures via `Toast` while preserving input; wizard tracks a
+`pendingRestart` set from `RESTART_KEYS` and lists it on the summary; chip→wizard
+wiring is a `window` `CustomEvent('aimee:open-setup-wizard')`; `readiness.test.ts`
+grounds `READINESS_KEYS ⊆ settingsHelp` keys. **One deviation:** the proposed
+"tutorial body is a substring of settingsHelp/page text" provenance test is
+infeasible for freshly-authored copy — replaced with "every `NAV_ITEMS` route has
+a non-empty title+body and any `seeAlso` references a real route."
+
+Net slice set: **Slice 1 (tutorials)** and **Slice 2 (onboarding = readiness +
+chip + wizard, atomic)** → both PR into `feat/setup-wizard` → `feat/setup-wizard`
+→ `testing`.
+
+## Slices
+
+### Slice 1 — Per-tab tutorials (lowest risk, ships first)
+
+**Files**
+- `frontend/src/help/tutorials.ts` — `TAB_TUTORIALS: Record<route, {title; body: string[]; seeAlso?}>` for all 11 routes in `NAV_ITEMS`. Copy is 3–5 lines/tab, grounded in each page's real behaviour (see proposal §2.2).
+- `frontend/src/help/tutorialState.ts` — `hasSeen(route)`, `markSeen(route)`, `resetAll()` over `localStorage` key `aimee_tutorial_seen` (JSON string[]). Guarded against malformed/absent storage.
+- `frontend/src/components/TabTutorial.tsx` — given the active route: first visit auto-opens a dismissible overlay; after dismissal a "?" button re-opens it. No content for a route → renders nothing (graceful).
+- `frontend/src/App.tsx` — mount `<TabTutorial route={location.pathname} />` once inside `<main>`; no per-page edits.
+- `frontend/src/pages/Settings.tsx` — add a "Replay tab tutorials" button calling `resetAll()` (small, localized addition).
+- `frontend/src/help/tutorials.test.ts` — asserts every `NAV_ITEMS` route has a tutorial entry with non-empty title+body; `tutorialState` seen/reset round-trips (jsdom localStorage).
+
+**Acceptance**
+- `npm run check` clean; `npm test` shows **no new failures** (still only the pre-existing Dashboard one).
+- Every route in `NAV_ITEMS` has a tutorial (asserted by test). "Replay" clears seen-state.
+
+### Slice 2 — Setup onboarding (readiness + chip + wizard, ATOMIC)
+
+Chip and wizard land together so no non-functional control is ever merged.
+
+**Files**
+- `frontend/src/setup/readiness.ts` — `type StepId = 'provider'|'embedding'|'db2'|'kb_api'|'project'`; `READINESS_KEYS` constant (the inspected config keys); `computeReadiness(cfg: Record<string,unknown>, hasProject: boolean): {ready; steps: Record<StepId,{ok; detail; optional?}>}`. Pure. Rules grounded in `settingsHelp.ts` semantics (blank `embedding_command` **and** blank `embedding_endpoint` → hash fallback → not ok; `kb_api` optional).
+- `frontend/src/setup/readiness.test.ts` — table-driven cases (all-unset → provider/embedding/project red; fully-set → ready) + **grounding test**: every key in `READINESS_KEYS` exists in `FIELD_HELP` (settingsHelp.ts).
+- `frontend/src/setup/wizardSteps.ts` — ordered step defs (keys/step, optional flag, `settingsHelp` copy reused, cheap client-side "test" e.g. embedding-dim match); `isRestartKey(key)` over `RESTART_KEYS`.
+- `frontend/src/components/SetupChip.tsx` — fetches `/api/config` once, computes readiness with `hasProject` from the session/project bundle, renders "Setup — N left" (hidden when ready); click → `window.dispatchEvent(new CustomEvent('aimee:open-setup-wizard'))`.
+- `frontend/src/components/SetupWizard.tsx` — modal; one screen/step; reads/writes `/api/config` + `/api/config/set`. **Every write in try/catch**: 4xx/5xx/network → `smoothgui` `Toast` + stay on step with input preserved. Tracks `pendingRestart: Set<string>` (adds a saved key that `isRestartKey`); final summary shows "Restart required for: […]" when non-empty; "project" step links to `/projects`; dismissal in `localStorage` (`aimee_setup_dismissed`). Opened by the event; closable anytime (non-blocking).
+- `frontend/src/App.tsx` — mount `<SetupChip />` in header + `<SetupWizard />` at root; `useEffect` listener for `aimee:open-setup-wizard`.
+- `frontend/src/pages/Settings.tsx` — "Re-run setup" button (clears dismissal + dispatches open event).
+- `frontend/src/setup/wizardSteps.test.ts` — every `StepId` has a step def; ordering = documented dependency order; `isRestartKey` matches `RESTART_KEYS`. Component test (mocked `fetch`): (a) success marks step saved; (b) 4xx/5xx → `Toast` + step stays unsaved; (c) `RESTART_KEYS` change populates the summary.
+
+**Acceptance**
+- `npm run check` clean; readiness + wizard tests pass; no new test failures.
+- Chip shows correct count / hidden when green; wizard writes via `/api/config/set`, Toasts on error, lists restart-pending keys; dismissable + re-openable.
+
+## Per-slice workflow
+
+For each slice: implement → `npm run check` + `npm test` (assert no new failures)
+→ `aimee delegate roundtable` review → apply blocking fixes → re-roundtable until
+approved → open PR into `feat/setup-wizard` → merge.
+
+## Non-goals / Future
+
+- Server-side `GET /api/setup/state` (replace client inference; enables true
+  per-user readiness incl. live DB2/provider pings).
+- Per-user **server** persistence of seen/dismissed state (replace localStorage).
+- Wizard "Test" buttons that hit real provider/embedder endpoints (MVP does only
+  cheap client-side checks like dim-match).
+- No change to how config, git, or turns execute; no new writable config keys.
+
+## Risks
+
+- **smoothgui API drift** — we reuse `Panel`/`Badge`/`Toast` already imported in
+  the app; no new smoothgui surface.
+- **Config key shape** — readiness rules depend on exact key names
+  (`provider`, `embedding_command`, `embedding_endpoint`, `db2_url`,
+  `kb_api_http_port`); pinned against `settingsHelp.ts`. A rename there breaks a
+  readiness rule → caught by the readiness unit test if we encode expected keys.
+- **Pre-existing Dashboard test failure** — must remain the *only* failure; CI
+  parity checked each slice.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import Graph from './pages/Graph';
 import Editor from './pages/Editor';
 import { SessionProvider, useSessions } from './SessionContext';
 import SettingsPanel from './components/SettingsPanel';
+import TabTutorial from './components/TabTutorial';
 
 // A render error in any page used to throw past the root and unmount the whole
 // app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
@@ -239,8 +240,10 @@ export default function App() {
               </NavLink>
             ))}
           </nav>
-          {/* Content: flex:1 + minHeight:0 so pages using height:100% resolve. */}
-          <main style={{ flex: 1, minWidth: 0, minHeight: 0, overflow: 'auto', background: '#fff' }}>
+          {/* Content: flex:1 + minHeight:0 so pages using height:100% resolve.
+           * position:relative anchors the per-tab tutorial overlay/"?" button. */}
+          <main style={{ position: 'relative', flex: 1, minWidth: 0, minHeight: 0, overflow: 'auto', background: '#fff' }}>
+            <TabTutorial route={location.pathname} />
             <ErrorBoundary key={location.pathname}>
               <Routes>
                 <Route path="/chat" element={<Chat />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import SettingsPanel from './components/SettingsPanel';
 import TabTutorial from './components/TabTutorial';
 import SetupChip from './components/SetupChip';
 import SetupWizard from './components/SetupWizard';
+import SilentBoundary from './components/SilentBoundary';
 import { OPEN_WIZARD_EVENT } from './setup/setupState';
 
 // A render error in any page used to throw past the root and unmount the whole
@@ -224,7 +225,7 @@ export default function App() {
         >
           <span style={{ color: '#8cf', fontWeight: 700, fontSize: 18 }}>aimee</span>
           <SessionTabBar />
-          <SetupChip />
+          <SilentBoundary><SetupChip /></SilentBoundary>
           <SettingsPanel />
           <LogoutButton />
         </header>
@@ -255,7 +256,7 @@ export default function App() {
           {/* Content: flex:1 + minHeight:0 so pages using height:100% resolve.
            * position:relative anchors the per-tab tutorial overlay/"?" button. */}
           <main style={{ position: 'relative', flex: 1, minWidth: 0, minHeight: 0, overflow: 'auto', background: '#fff' }}>
-            <TabTutorial route={location.pathname} />
+            <SilentBoundary><TabTutorial route={location.pathname} /></SilentBoundary>
             <ErrorBoundary key={location.pathname}>
               <Routes>
                 <Route path="/chat" element={<Chat />} />
@@ -277,7 +278,7 @@ export default function App() {
           </main>
         </div>
       </div>
-      <SetupWizard open={wizardOpen} onClose={() => setWizardOpen(false)} />
+      <SilentBoundary><SetupWizard open={wizardOpen} onClose={() => setWizardOpen(false)} /></SilentBoundary>
       <Toast />
     </SessionProvider>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,9 @@ import Editor from './pages/Editor';
 import { SessionProvider, useSessions } from './SessionContext';
 import SettingsPanel from './components/SettingsPanel';
 import TabTutorial from './components/TabTutorial';
+import SetupChip from './components/SetupChip';
+import SetupWizard from './components/SetupWizard';
+import { OPEN_WIZARD_EVENT } from './setup/setupState';
 
 // A render error in any page used to throw past the root and unmount the whole
 // app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
@@ -173,7 +176,15 @@ function LogoutButton() {
 
 export default function App() {
   const [ready, setReady] = useState(false);
+  const [wizardOpen, setWizardOpen] = useState(false);
   const location = useLocation();
+
+  // The setup chip / "Re-run setup" dispatch this event to open the wizard.
+  useEffect(() => {
+    const openWizard = () => setWizardOpen(true);
+    window.addEventListener(OPEN_WIZARD_EVENT, openWizard);
+    return () => window.removeEventListener(OPEN_WIZARD_EVENT, openWizard);
+  }, []);
 
   useEffect(() => {
     fetch('/api/chat/session')
@@ -213,6 +224,7 @@ export default function App() {
         >
           <span style={{ color: '#8cf', fontWeight: 700, fontSize: 18 }}>aimee</span>
           <SessionTabBar />
+          <SetupChip />
           <SettingsPanel />
           <LogoutButton />
         </header>
@@ -265,6 +277,7 @@ export default function App() {
           </main>
         </div>
       </div>
+      <SetupWizard open={wizardOpen} onClose={() => setWizardOpen(false)} />
       <Toast />
     </SessionProvider>
   );

--- a/frontend/src/components/SetupChip.tsx
+++ b/frontend/src/components/SetupChip.tsx
@@ -39,6 +39,9 @@ export default function SetupChip() {
 
   // Auto-open the wizard once per page load when unconfigured and not dismissed.
   const autoOpened = useRef(false);
+  // Reset the once-per-session auto-open guard when the active session changes,
+  // so a freshly-selected unconfigured session can auto-open the wizard too.
+  useEffect(() => { autoOpened.current = false; }, [active?.id]);
   useEffect(() => {
     if (readiness && !readiness.ready && !isDismissed() && !autoOpened.current) {
       autoOpened.current = true;

--- a/frontend/src/components/SetupChip.tsx
+++ b/frontend/src/components/SetupChip.tsx
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSessions } from '../SessionContext';
+import { loadConfig, type ConfigMap } from '../setup/configApi';
+import { computeReadiness, stepsRemaining } from '../setup/readiness';
+import { requestOpenWizard, isDismissed, SETUP_UPDATED_EVENT } from '../setup/setupState';
+
+/* Header chip: "Setup — N left". Reads GET /api/config once (and again whenever
+ * the wizard reports a change or the window regains focus), computes readiness
+ * against the active session's project, and shows how many required steps remain.
+ * Hidden entirely once ready. Clicking it opens the wizard. On first load, if the
+ * instance is not ready and the wizard hasn't been dismissed, it auto-opens the
+ * wizard once. All heavy lifting is in the tested setup/ modules. */
+
+export default function SetupChip() {
+  const { active } = useSessions();
+  const hasProject = !!active?.projectName;
+  const [cfg, setCfg] = useState<ConfigMap | null>(null);
+
+  const load = useCallback(() => {
+    loadConfig().then(setCfg);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  useEffect(() => {
+    const onUpdate = () => load();
+    window.addEventListener(SETUP_UPDATED_EVENT, onUpdate);
+    window.addEventListener('focus', onUpdate);
+    return () => {
+      window.removeEventListener(SETUP_UPDATED_EVENT, onUpdate);
+      window.removeEventListener('focus', onUpdate);
+    };
+  }, [load]);
+
+  const readiness = useMemo(
+    () => (cfg ? computeReadiness(cfg, hasProject) : null),
+    [cfg, hasProject],
+  );
+
+  // Auto-open the wizard once per page load when unconfigured and not dismissed.
+  const autoOpened = useRef(false);
+  useEffect(() => {
+    if (readiness && !readiness.ready && !isDismissed() && !autoOpened.current) {
+      autoOpened.current = true;
+      requestOpenWizard();
+    }
+  }, [readiness]);
+
+  if (!readiness || readiness.ready) return null;
+
+  const n = stepsRemaining(readiness);
+  return (
+    <button
+      onClick={requestOpenWizard}
+      title="Finish setting up this instance"
+      style={{
+        display: 'flex', alignItems: 'center', gap: 6, padding: '3px 10px',
+        borderRadius: 12, cursor: 'pointer', fontSize: 12.5, whiteSpace: 'nowrap',
+        background: '#3a2a12', color: '#f4b860', border: '1px solid #6a4a1a',
+      }}
+    >
+      <span aria-hidden>⚙️</span> Setup — {n} left
+    </button>
+  );
+}

--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useToast } from '@rakuensoftware/smoothgui';
+import { useSessions } from '../SessionContext';
+import { loadConfig, saveConfigValue, type ConfigMap } from '../setup/configApi';
+import { WIZARD_STEPS, isRestartKey, helpFor } from '../setup/wizardSteps';
+import { computeReadiness } from '../setup/readiness';
+import { setDismissed, notifySetupUpdated } from '../setup/setupState';
+
+/* First-run setup wizard. A modal over the app that walks the operator through
+ * the minimum path to a working turn — provider → embedding → shared store →
+ * optional KB API → connect a project — writing every value through the existing
+ * POST /api/config/set allowlist (no new backend). It is non-blocking: closable
+ * at any time via ×, Esc, the backdrop, or "Later".
+ *
+ * Design notes:
+ * - All config I/O + step data live in the tested setup/ modules; this file is
+ *   presentation + local step state.
+ * - Every save is guarded: a 4xx/5xx/network failure surfaces a Toast and keeps
+ *   the operator on the step with their input intact.
+ * - Keys carrying RESTART_KEYS are tracked into `pendingRestart` and listed on the
+ *   summary, since they only take effect after a server restart. */
+
+function humanize(key: string): string {
+  const s = key.replace(/_/g, ' ').trim();
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// Coerce a text input back to the field's type before saving: numeric fields
+// (existing number value, or *_dim / *_port keys) go as numbers, everything else
+// as a string. Keeps the server's typed allowlist happy.
+function coerce(key: string, raw: string, original: unknown): unknown {
+  if (typeof original === 'number' || /(_dim|_port)$/.test(key)) {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : raw;
+  }
+  return raw;
+}
+
+export default function SetupWizard({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const navigate = useNavigate();
+  const toast = useToast();
+  const { active } = useSessions();
+  const hasProject = !!active?.projectName;
+
+  const [cfg, setCfg] = useState<ConfigMap>({});
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [idx, setIdx] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [pendingRestart, setPendingRestart] = useState<string[]>([]);
+  const [showSummary, setShowSummary] = useState(false);
+
+  // (Re)load config each time the wizard opens; reset step + transient state.
+  useEffect(() => {
+    if (!open) return;
+    setIdx(0);
+    setShowSummary(false);
+    setPendingRestart([]);
+    loadConfig().then((c) => {
+      setCfg(c);
+      const d: Record<string, string> = {};
+      for (const step of WIZARD_STEPS) {
+        for (const k of step.keys) {
+          const v = c[k];
+          d[k] = v == null ? '' : String(v);
+        }
+      }
+      setDraft(d);
+    });
+  }, [open]);
+
+  const close = useCallback(() => { onClose(); }, [onClose]);
+
+  // Esc closes the wizard (non-blocking).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, close]);
+
+  const step = WIZARD_STEPS[idx];
+
+  const readiness = useMemo(() => computeReadiness(cfg, hasProject), [cfg, hasProject]);
+
+  if (!open) return null;
+
+  function advance() {
+    if (idx < WIZARD_STEPS.length - 1) setIdx(idx + 1);
+    else setShowSummary(true);
+  }
+
+  // Save every edited key in the current step. Any failure aborts advance and
+  // Toasts; successes update the live cfg + restart tracking.
+  async function saveStep() {
+    setSaving(true);
+    const savedCfg: ConfigMap = { ...cfg };
+    const restart = new Set(pendingRestart);
+    try {
+      for (const key of step.keys) {
+        const raw = draft[key] ?? '';
+        // Skip keys the operator left exactly as they already were.
+        const originalStr = cfg[key] == null ? '' : String(cfg[key]);
+        if (raw === originalStr) continue;
+        const value = coerce(key, raw, cfg[key]);
+        const res = await saveConfigValue(key, value);
+        if (!res.ok) {
+          toast.error(`Couldn’t save ${humanize(key)}: ${res.error ?? 'unknown error'}`);
+          setSaving(false);
+          setCfg(savedCfg); // keep whatever succeeded so far
+          setPendingRestart(Array.from(restart));
+          return; // stay on the step, input preserved
+        }
+        savedCfg[key] = res.value ?? value;
+        if (isRestartKey(key)) restart.add(key);
+      }
+      setCfg(savedCfg);
+      setPendingRestart(Array.from(restart));
+      notifySetupUpdated();
+      setSaving(false);
+      toast.success(`${step.title} saved`);
+      advance();
+    } catch (e) {
+      setSaving(false);
+      toast.error(e instanceof Error ? e.message : 'Save failed');
+    }
+  }
+
+  const backdrop: React.CSSProperties = {
+    position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(10,10,18,0.55)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 16,
+  };
+  const card: React.CSSProperties = {
+    width: 'min(560px, 100%)', maxHeight: '86vh', overflow: 'auto', background: '#fff',
+    borderRadius: 12, border: '1px solid #dde', boxShadow: '0 12px 40px rgba(0,0,0,0.3)',
+    padding: '20px 22px', fontFamily: 'system-ui', color: '#233',
+  };
+  const primaryBtn: React.CSSProperties = {
+    padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
+    color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
+  };
+  const ghostBtn: React.CSSProperties = {
+    padding: '7px 14px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',
+    color: '#446', cursor: 'pointer', fontSize: 13,
+  };
+  const input: React.CSSProperties = {
+    width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
+    border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
+  };
+
+  const stepNum = idx + 1;
+  const total = WIZARD_STEPS.length;
+
+  return (
+    <div style={backdrop} onClick={close}>
+      <div style={card} role="dialog" aria-label="Setup wizard" onClick={(e) => e.stopPropagation()}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
+          <strong style={{ fontSize: 17 }}>Set up this instance</strong>
+          <button aria-label="Close setup" title="Close" onClick={close}
+            style={{ background: 'none', border: 'none', color: '#9aa', cursor: 'pointer', fontSize: 20, lineHeight: 1 }}>×</button>
+        </div>
+
+        {showSummary ? (
+          <div>
+            <p style={{ fontSize: 13, color: '#556', margin: '4px 0 12px' }}>
+              {readiness.ready ? 'Everything required is configured. 🎉' : 'Here’s what’s left:'}
+            </p>
+            <div style={{ display: 'grid', gap: 6, marginBottom: 14 }}>
+              {(Object.entries(readiness.steps)).map(([id, s]) => (
+                <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13 }}>
+                  <span aria-hidden>{s.ok ? '✅' : s.optional ? '⚪' : '⛔'}</span>
+                  <span style={{ fontWeight: 600, textTransform: 'capitalize', minWidth: 92 }}>{id.replace('_', ' ')}</span>
+                  <span style={{ color: '#667' }}>{s.detail}{s.optional && !s.ok ? ' (optional)' : ''}</span>
+                </div>
+              ))}
+            </div>
+            {pendingRestart.length > 0 && (
+              <div style={{ fontSize: 12.5, color: '#8a5a00', background: '#fff6e6', border: '1px solid #f0d8a8', borderRadius: 6, padding: '8px 10px', marginBottom: 14 }}>
+                ⏳ Restart required for: {pendingRestart.map(humanize).join(', ')} — these take effect after the server restarts.
+              </div>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <button style={ghostBtn} onClick={() => { setShowSummary(false); setIdx(0); }}>Back</button>
+              <button style={primaryBtn} onClick={() => { setDismissed(true); notifySetupUpdated(); close(); }}>Finish</button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div style={{ fontSize: 12, color: '#8899aa', marginBottom: 4 }}>Step {stepNum} of {total}</div>
+            <div style={{ fontSize: 15, fontWeight: 700, marginBottom: 10 }}>
+              {step.title}{step.optional ? <span style={{ color: '#9aa', fontWeight: 400, fontSize: 12 }}> · optional</span> : null}
+            </div>
+
+            {step.keys.length > 0 ? (
+              <div style={{ display: 'grid', gap: 12, marginBottom: 16 }}>
+                {step.keys.map((key) => (
+                  <label key={key} style={{ display: 'block' }}>
+                    <div style={{ fontSize: 12.5, fontWeight: 600, marginBottom: 3 }}>
+                      {humanize(key)}
+                      {isRestartKey(key) ? <span style={{ color: '#8a5a00', fontWeight: 400 }}> · needs restart</span> : null}
+                    </div>
+                    {helpFor(key) && <div style={{ fontSize: 11.5, color: '#778', marginBottom: 4, lineHeight: 1.4 }}>{helpFor(key)}</div>}
+                    <input
+                      style={input}
+                      value={draft[key] ?? ''}
+                      onChange={(e) => setDraft((p) => ({ ...p, [key]: e.target.value }))}
+                      placeholder={key}
+                    />
+                  </label>
+                ))}
+              </div>
+            ) : (
+              // Hand-off step (project): no config keys, link out to the page.
+              <div style={{ marginBottom: 16 }}>
+                <p style={{ fontSize: 13, color: '#556', lineHeight: 1.5 }}>
+                  Connect a git repository on the Projects tab so the tools have something to act on.
+                  {step.skipNote ? ` ${step.skipNote}` : ''}
+                </p>
+                <button style={{ ...primaryBtn, marginTop: 4 }} onClick={() => { navigate(step.route ?? '/projects'); close(); }}>
+                  Go to Projects →
+                </button>
+                {hasProject && <div style={{ fontSize: 12.5, color: '#2c8f56', marginTop: 8 }}>✅ A project is already connected to this session.</div>}
+              </div>
+            )}
+
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button style={ghostBtn} disabled={idx === 0} onClick={() => setIdx(Math.max(0, idx - 1))}>Back</button>
+                <button style={ghostBtn} onClick={close}>Later</button>
+              </div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                {step.optional && <button style={ghostBtn} onClick={advance}>Skip</button>}
+                {step.keys.length > 0 ? (
+                  <button style={primaryBtn} disabled={saving} onClick={saveStep}>{saving ? 'Saving…' : 'Save & continue'}</button>
+                ) : (
+                  <button style={primaryBtn} onClick={advance}>{idx === total - 1 ? 'Review' : 'Next'}</button>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SilentBoundary.tsx
+++ b/frontend/src/components/SilentBoundary.tsx
@@ -1,0 +1,24 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+/* A fail-safe error boundary for ancillary chrome (the setup chip, the tutorial
+ * card, the setup wizard). Those mount OUTSIDE the page ErrorBoundary in App, so
+ * without this a render error in one of them would throw past the root and unmount
+ * the whole shell — the exact failure the page ErrorBoundary exists to prevent.
+ * Unlike that boundary, this one renders NOTHING on error (these are optional
+ * overlays; silently dropping one is far better than taking down the app) and logs
+ * for diagnosis. */
+export default class SilentBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('SilentBoundary caught an error in optional UI', error, info);
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}

--- a/frontend/src/components/TabTutorial.tsx
+++ b/frontend/src/components/TabTutorial.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { tutorialFor } from '../help/tutorials';
+import { hasSeen, markSeen } from '../help/tutorialState';
+
+/* Per-tab tutorial affordance. Mounted once in App inside <main>, keyed on the
+ * active route. On the first visit to a tab that has a tutorial it auto-opens a
+ * dismissible card; after dismissal it collapses to a small "?" button in the
+ * top-right that re-opens it. A route with no tutorial renders nothing.
+ *
+ * It is deliberately NON-MODAL: there is no full-area backdrop, so the rest of
+ * the page stays fully interactive while the card is open (the card is a corner
+ * panel, not a blocking overlay). All persistence + content lookups live in the
+ * tested help/ modules; this component is just presentation. */
+
+export default function TabTutorial({ route }: { route: string }) {
+  const navigate = useNavigate();
+  const tut = tutorialFor(route);
+  const [open, setOpen] = useState(false);
+
+  // On each route change, auto-open only if this tab has a tutorial the operator
+  // hasn't dismissed yet.
+  useEffect(() => {
+    if (tut && !hasSeen(route)) setOpen(true);
+    else setOpen(false);
+  }, [route, tut]);
+
+  // Escape closes the card (counts as seen) when it is open.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') { markSeen(route); setOpen(false); }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, route]);
+
+  if (!tut) return null;
+
+  function dismiss() {
+    markSeen(route);
+    setOpen(false);
+  }
+
+  // Collapsed state: just the "?" re-opener in the corner.
+  if (!open) {
+    return (
+      <button
+        aria-label="Show tab help"
+        title="What is this tab?"
+        onClick={() => setOpen(true)}
+        style={{
+          position: 'absolute', top: 10, right: 12, zIndex: 20,
+          width: 26, height: 26, borderRadius: '50%', cursor: 'pointer',
+          border: '1px solid #ccd', background: '#fff', color: '#68a',
+          fontSize: 14, fontWeight: 700, lineHeight: 1,
+        }}
+      >?</button>
+    );
+  }
+
+  // Open state: a non-modal card anchored top-right. No backdrop — the page
+  // underneath stays clickable, so the tutorial never blocks work.
+  return (
+    <div
+      role="dialog"
+      aria-label={`${tut.title} tab help`}
+      style={{
+        position: 'absolute', top: 10, right: 12, zIndex: 25,
+        maxWidth: 380, width: 'min(380px, calc(100% - 24px))',
+        background: '#fff', borderRadius: 10, border: '1px solid #dde',
+        boxShadow: '0 8px 30px rgba(0,0,0,0.18)', padding: '16px 18px',
+        fontFamily: 'system-ui', color: '#334',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+        <span style={{ fontSize: 15, fontWeight: 700, color: '#223' }}>{tut.title}</span>
+        <button
+          aria-label="Close tab help"
+          title="Close"
+          onClick={dismiss}
+          style={{ background: 'none', border: 'none', color: '#9aa', cursor: 'pointer', fontSize: 18, lineHeight: 1, padding: 0 }}
+        >×</button>
+      </div>
+      {tut.body.map((line, i) => (
+        <p key={i} style={{ fontSize: 13, lineHeight: 1.5, margin: '0 0 7px' }}>{line}</p>
+      ))}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 12 }}>
+        {tut.seeAlso ? (
+          <button
+            onClick={() => { dismiss(); navigate(tut.seeAlso!); }}
+            style={{ background: 'none', border: 'none', color: '#68a', cursor: 'pointer', fontSize: 12.5, padding: 0 }}
+          >
+            See also: {tutorialFor(tut.seeAlso)?.title ?? tut.seeAlso} →
+          </button>
+        ) : <span />}
+        <button
+          onClick={dismiss}
+          style={{
+            padding: '5px 14px', borderRadius: 6, border: '1px solid #ccd',
+            background: '#f4f6fb', color: '#446', cursor: 'pointer', fontSize: 12.5, fontWeight: 600,
+          }}
+        >Got it</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/help/tutorialState.ts
+++ b/frontend/src/help/tutorialState.ts
@@ -1,0 +1,67 @@
+/* "Seen" state for per-tab tutorials. The auto-open-on-first-visit behaviour needs
+ * to remember which tabs the operator has already dismissed. For the MVP this is
+ * per-browser localStorage (the same pattern App/LogoutButton use for chat tabs).
+ *
+ * The parse/merge logic is split from the storage side-effects so it can be unit
+ * tested under vitest's `node` environment, where `localStorage` does not exist.
+ * The storage wrappers guard `typeof localStorage` and swallow quota/security
+ * errors, so a private-mode or storage-disabled browser degrades to "always show"
+ * rather than throwing. */
+
+export const SEEN_KEY = 'aimee_tutorial_seen';
+
+/** Parse a stored blob into a clean list of route strings. Tolerates null,
+ * malformed JSON, and non-array/non-string junk — always returns a string[]. */
+export function parseSeen(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const v = JSON.parse(raw);
+    if (!Array.isArray(v)) return [];
+    return v.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
+}
+
+/** Return a new list with `route` present (idempotent, order-stable). */
+export function withSeen(list: string[], route: string): string[] {
+  return list.includes(route) ? list : [...list, route];
+}
+
+// ── localStorage-backed wrappers (side-effecting; guarded for node/SSR) ──────
+
+function readRaw(): string | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage.getItem(SEEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeList(list: string[]): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(SEEN_KEY, JSON.stringify(list));
+  } catch {
+    /* storage disabled/full — degrade to always-show */
+  }
+}
+
+export function hasSeen(route: string): boolean {
+  return parseSeen(readRaw()).includes(route);
+}
+
+export function markSeen(route: string): void {
+  writeList(withSeen(parseSeen(readRaw()), route));
+}
+
+/** Forget all seen tabs — the "Replay tab tutorials" action. */
+export function resetAll(): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(SEEN_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/help/tutorials.test.ts
+++ b/frontend/src/help/tutorials.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { TAB_TUTORIALS, tutorialFor } from './tutorials';
+import { parseSeen, withSeen, SEEN_KEY } from './tutorialState';
+
+/* The routes App exposes in NAV_ITEMS. Kept in sync by hand with App.tsx; the
+ * "every nav route has a tutorial" test below is what guards a drift (a new tab
+ * added to App without a tutorial entry fails here). */
+const NAV_ROUTES = [
+  '/chat', '/dashboard', '/logs', '/edit-workflows', '/workflow-actions',
+  '/agents', '/personas', '/projects', '/graph', '/editor', '/settings',
+];
+
+describe('TAB_TUTORIALS content contract', () => {
+  it('has a tutorial for every NAV_ITEMS route', () => {
+    for (const route of NAV_ROUTES) {
+      expect(TAB_TUTORIALS, `missing tutorial for ${route}`).toHaveProperty(route);
+    }
+  });
+
+  it('every tutorial has a non-empty title and 1–5 body lines', () => {
+    for (const [route, t] of Object.entries(TAB_TUTORIALS)) {
+      expect(t.title.trim().length, `${route} title`).toBeGreaterThan(0);
+      expect(t.body.length, `${route} body count`).toBeGreaterThan(0);
+      expect(t.body.length, `${route} body count`).toBeLessThanOrEqual(5);
+      for (const line of t.body) expect(line.trim().length, `${route} body line`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every seeAlso points at a real tutorial route', () => {
+    for (const [route, t] of Object.entries(TAB_TUTORIALS)) {
+      if (t.seeAlso) {
+        expect(TAB_TUTORIALS, `${route} seeAlso -> ${t.seeAlso}`).toHaveProperty(t.seeAlso);
+      }
+    }
+  });
+
+  it('tutorialFor returns undefined for an unknown route', () => {
+    expect(tutorialFor('/nope')).toBeUndefined();
+    expect(tutorialFor('/chat')).toBe(TAB_TUTORIALS['/chat']);
+  });
+});
+
+describe('tutorialState seen-list logic (pure)', () => {
+  it('parseSeen tolerates null, malformed, and non-string junk', () => {
+    expect(parseSeen(null)).toEqual([]);
+    expect(parseSeen('not json')).toEqual([]);
+    expect(parseSeen('{"a":1}')).toEqual([]); // object, not array
+    expect(parseSeen('[1,"/chat",true,"/logs"]')).toEqual(['/chat', '/logs']);
+  });
+
+  it('withSeen adds idempotently and preserves order', () => {
+    let list: string[] = [];
+    list = withSeen(list, '/chat');
+    list = withSeen(list, '/logs');
+    list = withSeen(list, '/chat'); // dup
+    expect(list).toEqual(['/chat', '/logs']);
+  });
+
+  it('a seen round-trip through parse/serialize is stable', () => {
+    const list = withSeen(withSeen([], '/chat'), '/settings');
+    const roundTripped = parseSeen(JSON.stringify(list));
+    expect(roundTripped).toEqual(list);
+    expect(SEEN_KEY).toBe('aimee_tutorial_seen');
+  });
+});

--- a/frontend/src/help/tutorials.ts
+++ b/frontend/src/help/tutorials.ts
@@ -1,0 +1,125 @@
+/* Per-tab tutorial content. One entry per route in App's NAV_ITEMS, keyed by the
+ * exact route path. `TabTutorial` shows the entry for the active route on first
+ * visit and behind a "?" re-opener after. Copy is short (a title + 3–5 lines) and
+ * grounded in what each page actually does; `seeAlso` points at the sibling tab a
+ * new operator most often confuses this one with. A route with no entry renders
+ * nothing (the component degrades gracefully), so adding a nav tab without a
+ * tutorial is not an error — it just shows no help until copy is added. */
+
+export type Tutorial = {
+  /** Heading shown at the top of the overlay. */
+  title: string;
+  /** Body lines, rendered as short paragraphs. Keep to 3–5. */
+  body: string[];
+  /** Optional "where this connects" pointer — a route in NAV_ITEMS. */
+  seeAlso?: string;
+};
+
+// Keyed by route path (must match App's NAV_ITEMS routes). The test in
+// tutorials.test.ts asserts every NAV_ITEMS route has an entry here.
+export const TAB_TUTORIALS: Record<string, Tutorial> = {
+  '/chat': {
+    title: 'Chat',
+    body: [
+      'This is where a turn runs — your conversation with aimee for the active session.',
+      'Attach files, use slash-commands and channels, and turn a reply into a proposal.',
+      'The session’s bound project is what every tool here acts on.',
+    ],
+    seeAlso: '/projects',
+  },
+  '/dashboard': {
+    title: 'Dashboard',
+    body: [
+      'Live health of the instance: Readiness, LSP health, per-agent success and tokens,',
+      'latency by role, provider mix, cache efficiency, guardrail actions, and traces.',
+      'Start here when something feels wrong. Cards can be reordered.',
+    ],
+    seeAlso: '/logs',
+  },
+  '/logs': {
+    title: 'Logs',
+    body: [
+      'The audit trail: every recorded action, newest first.',
+      'Click a row to expand the full-field detail modal.',
+      'Answers “what did aimee do, when, and under whose identity”.',
+    ],
+    seeAlso: '/dashboard',
+  },
+  '/edit-workflows': {
+    title: 'Edit Workflows',
+    body: [
+      'Define multi-step workflows — the design surface.',
+      'Each step sets a task, a persona, a delegate, and a role.',
+      'This is where the steps come from; you approve their runs next door.',
+    ],
+    seeAlso: '/workflow-actions',
+  },
+  '/workflow-actions': {
+    title: 'Workflow Actions',
+    body: [
+      'The runtime queue: workflow items waiting on you to approve or reject.',
+      'This is the human-in-the-loop gate.',
+      'Edit Workflows is where these steps were defined.',
+    ],
+    seeAlso: '/edit-workflows',
+  },
+  '/agents': {
+    title: 'Agents',
+    body: [
+      'Your delegates and their run history and stats.',
+      'Edit a delegate’s persona and the roles it may use.',
+      'Roles are the routing key matched between personas and agents.',
+    ],
+    seeAlso: '/personas',
+  },
+  '/personas': {
+    title: 'Personas',
+    body: [
+      'The shared ROLE vocabulary plus the PERSONA definitions.',
+      'Edit who aimee can be (identity + allowed roles) and what each role means.',
+      'Agents binds these personas and roles to actual work.',
+    ],
+    seeAlso: '/agents',
+  },
+  '/projects': {
+    title: 'Projects',
+    body: [
+      'Connect the git repositories aimee works on.',
+      'Store per-host credentials (sealed vault) and run read + remote git ops.',
+      'Credentials never reach the browser — they stay server-side.',
+    ],
+    seeAlso: '/editor',
+  },
+  '/graph': {
+    title: 'Graph',
+    body: [
+      'A read-only explorer of the code-projection graph for the session’s project.',
+      'Rank hubs, expand callers/callees/neighbours with provenance, spot “surprising links”.',
+      'For understanding the codebase’s shape — off the agent’s hot path.',
+    ],
+    seeAlso: '/editor',
+  },
+  '/editor': {
+    title: 'Editor',
+    body: [
+      'In-app VS Code, bound to the session’s isolated worktree.',
+      'It’s the same tree the agent edits, so you see and hand-edit exactly what it sees.',
+      'The editor’s port and git credentials stay server-side.',
+    ],
+    seeAlso: '/projects',
+  },
+  '/settings': {
+    title: 'Settings',
+    body: [
+      'Every typed config option with plain-English help.',
+      'Booleans are toggles, numbers are fields, strings are text; restart-sensitive keys are badged.',
+      'This is the full control plane the setup wizard walks you through a slice of.',
+    ],
+    seeAlso: '/dashboard',
+  },
+};
+
+/** Lookup helper — returns undefined for a route with no tutorial. */
+export function tutorialFor(route: string): Tutorial | undefined {
+  return TAB_TUTORIALS[route];
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Panel, Badge } from "@rakuensoftware/smoothgui";
 import { FIELD_HELP, SECTION_HELP, RESTART_KEYS } from "./settingsHelp";
+import { resetAll as resetTutorials } from "../help/tutorialState";
 
 /* Settings page: every typed Aimee config option (the config_fields allowlist,
  * e.g. typed_facts_enabled, kb_pdf_*, memory_*, autonomous). Values come from
@@ -146,6 +147,16 @@ export default function Settings() {
         />
         <button onClick={refresh} style={btn}>
           Reload
+        </button>
+        <button
+          onClick={() => {
+            resetTutorials();
+            setStatus({ kind: "ok", msg: "Tab tutorials will show again on your next visit to each tab." });
+          }}
+          style={btn}
+          title="Show the per-tab tutorial overlays again"
+        >
+          Replay tab tutorials
         </button>
         {status && (
           <span

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Panel, Badge } from "@rakuensoftware/smoothgui";
 import { FIELD_HELP, SECTION_HELP, RESTART_KEYS } from "./settingsHelp";
 import { resetAll as resetTutorials } from "../help/tutorialState";
+import { setDismissed as setSetupDismissed, requestOpenWizard } from "../setup/setupState";
 
 /* Settings page: every typed Aimee config option (the config_fields allowlist,
  * e.g. typed_facts_enabled, kb_pdf_*, memory_*, autonomous). Values come from
@@ -157,6 +158,16 @@ export default function Settings() {
           title="Show the per-tab tutorial overlays again"
         >
           Replay tab tutorials
+        </button>
+        <button
+          onClick={() => {
+            setSetupDismissed(false);
+            requestOpenWizard();
+          }}
+          style={btn}
+          title="Re-open the first-run setup wizard"
+        >
+          Re-run setup
         </button>
         {status && (
           <span

--- a/frontend/src/setup/configApi.ts
+++ b/frontend/src/setup/configApi.ts
@@ -1,0 +1,67 @@
+/* Thin, testable wrappers over the config endpoints the Settings page already
+ * uses. Extracted so the wizard's write path (and its error handling) can be unit
+ * tested with a stubbed fetch — vitest runs in node, so there is no real network
+ * or DOM. `fetchImpl` is injectable for exactly that reason. */
+
+export type ConfigMap = Record<string, unknown>;
+
+type FetchLike = typeof fetch;
+
+function csrf(): string {
+  try {
+    if (typeof window !== 'undefined') return (window as { _csrf?: string })._csrf || '';
+  } catch {
+    /* ignore */
+  }
+  return '';
+}
+
+/** Load the current config map (GET /api/config → { config }). Returns {} on any
+ * failure so callers degrade rather than throw. */
+export async function loadConfig(opts?: { fetchImpl?: FetchLike }): Promise<ConfigMap> {
+  const f = opts?.fetchImpl ?? fetch;
+  try {
+    const r = await f('/api/config', { headers: { 'X-CSRF-Token': csrf() } });
+    const d = (await r.json()) as { config?: ConfigMap };
+    return d.config ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export interface SaveResult {
+  ok: boolean;
+  error?: string;
+  /** The persisted value the server echoed back (falls back to the input). */
+  value?: unknown;
+}
+
+/** Persist one config value (POST /api/config/set { key, value }). Mirrors the
+ * Settings page's success test (2xx && !error) and never throws — a network or
+ * parse failure returns { ok: false, error }. */
+export async function saveConfigValue(
+  key: string,
+  value: unknown,
+  opts?: { fetchImpl?: FetchLike },
+): Promise<SaveResult> {
+  const f = opts?.fetchImpl ?? fetch;
+  try {
+    const r = await f('/api/config/set', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf() },
+      body: JSON.stringify({ key, value }),
+    });
+    let data: { error?: string; value?: unknown } = {};
+    try {
+      data = (await r.json()) as { error?: string; value?: unknown };
+    } catch {
+      /* empty/invalid body — fall through to status check */
+    }
+    if (r.status >= 200 && r.status < 300 && !data.error) {
+      return { ok: true, value: data.value !== undefined ? data.value : value };
+    }
+    return { ok: false, error: data.error || `save failed (${r.status})` };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'network error' };
+  }
+}

--- a/frontend/src/setup/readiness.test.ts
+++ b/frontend/src/setup/readiness.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { FIELD_HELP } from '../pages/settingsHelp';
+import { computeReadiness, stepsRemaining, READINESS_KEYS, readinessKeysAreDocumented } from './readiness';
+
+describe('readiness grounding', () => {
+  it('every READINESS_KEYS entry is a documented config field', () => {
+    for (const k of READINESS_KEYS) {
+      expect(FIELD_HELP, `${k} missing from FIELD_HELP`).toHaveProperty(k);
+    }
+    expect(readinessKeysAreDocumented()).toBe(true);
+  });
+});
+
+describe('computeReadiness', () => {
+  it('an empty config with no project → all required steps red, not ready', () => {
+    const r = computeReadiness({}, false);
+    expect(r.ready).toBe(false);
+    expect(r.steps.provider.ok).toBe(false);
+    expect(r.steps.embedding.ok).toBe(false);
+    expect(r.steps.db2.ok).toBe(false);
+    expect(r.steps.project.ok).toBe(false);
+    expect(r.steps.kb_api.ok).toBe(false);
+    expect(r.steps.kb_api.optional).toBe(true);
+    // provider, embedding, db2, project are the 4 required-incomplete steps.
+    expect(stepsRemaining(r)).toBe(4);
+  });
+
+  it('the built-in hash embedder (both keys blank) reads as not-ok, test-only', () => {
+    const r = computeReadiness({ embedding_command: '', embedding_endpoint: '   ' }, false);
+    expect(r.steps.embedding.ok).toBe(false);
+    expect(r.steps.embedding.detail).toMatch(/hash fallback/i);
+  });
+
+  it('an embedding command OR endpoint satisfies embedding', () => {
+    expect(computeReadiness({ embedding_command: 'embed.sh' }, false).steps.embedding.ok).toBe(true);
+    expect(computeReadiness({ embedding_endpoint: 'http://e' }, false).steps.embedding.ok).toBe(true);
+  });
+
+  it('kb_api is optional: unset does not block readiness', () => {
+    const cfg = { provider: 'claude', embedding_command: 'e.sh', db2_url: 'postgres://x' };
+    const r = computeReadiness(cfg, true); // kb_api unset (port 0)
+    expect(r.steps.kb_api.ok).toBe(false);
+    expect(r.ready).toBe(true);
+    expect(stepsRemaining(r)).toBe(0);
+  });
+
+  it('a fully configured instance with a project is ready', () => {
+    const cfg = { provider: 'claude', embedding_endpoint: 'http://e', db2_url: 'postgres://x', kb_api_http_port: 8741 };
+    const r = computeReadiness(cfg, true);
+    expect(r.ready).toBe(true);
+    expect(r.steps.kb_api.ok).toBe(true);
+    expect(stepsRemaining(r)).toBe(0);
+  });
+
+  it('kb_api_http_port coerces from a string and 0 stays disabled', () => {
+    expect(computeReadiness({ kb_api_http_port: '8741' }, false).steps.kb_api.ok).toBe(true);
+    expect(computeReadiness({ kb_api_http_port: '0' }, false).steps.kb_api.ok).toBe(false);
+  });
+
+  it('a connected project flips only the project step', () => {
+    const base = { provider: 'claude', embedding_command: 'e.sh', db2_url: 'x' };
+    expect(computeReadiness(base, false).ready).toBe(false);
+    expect(computeReadiness(base, true).ready).toBe(true);
+  });
+});

--- a/frontend/src/setup/readiness.ts
+++ b/frontend/src/setup/readiness.ts
@@ -1,0 +1,101 @@
+/* Setup readiness — a PURE function over the values GET /api/config returns
+ * (config.show). It classifies the minimum steps needed for a working turn so the
+ * header chip and the wizard share one definition of "ready". No network, no DOM:
+ * unit-tested under vitest's node env.
+ *
+ * MVP scope: readiness is inferred client-side from config values (and whether the
+ * active session has a project bound). A server-side GET /api/setup/state that can
+ * additionally ping DB2/the provider is a documented follow-up. */
+
+import { FIELD_HELP } from '../pages/settingsHelp';
+
+export type StepId = 'provider' | 'embedding' | 'db2' | 'kb_api' | 'project';
+
+/* The config keys readiness inspects. Exported so a test can assert each one is a
+ * real, documented config field (a key rename in settingsHelp.ts that we miss
+ * would otherwise silently break a rule). `project` has no config key — it comes
+ * from the session bundle — so it is deliberately absent here. */
+export const READINESS_KEYS = [
+  'provider',
+  'embedding_command',
+  'embedding_endpoint',
+  'db2_url',
+  'kb_api_http_port',
+] as const;
+
+export interface StepStatus {
+  ok: boolean;
+  detail: string;
+  /** Optional steps do not block overall readiness. */
+  optional?: boolean;
+}
+
+export interface Readiness {
+  ready: boolean;
+  steps: Record<StepId, StepStatus>;
+}
+
+function asStr(cfg: Record<string, unknown>, key: string): string {
+  const v = cfg[key];
+  if (typeof v === 'string') return v.trim();
+  if (v == null) return '';
+  return String(v).trim();
+}
+
+function asNum(cfg: Record<string, unknown>, key: string): number {
+  const v = cfg[key];
+  if (typeof v === 'number') return v;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Classify the setup steps. `hasProject` comes from the active session (the
+ * config has no project field). */
+export function computeReadiness(cfg: Record<string, unknown>, hasProject: boolean): Readiness {
+  const provider = asStr(cfg, 'provider');
+  const embCmd = asStr(cfg, 'embedding_command');
+  const embEndpoint = asStr(cfg, 'embedding_endpoint');
+  const db2 = asStr(cfg, 'db2_url');
+  const kbPort = asNum(cfg, 'kb_api_http_port');
+
+  const steps: Record<StepId, StepStatus> = {
+    provider: {
+      ok: provider !== '',
+      detail: provider !== '' ? `primary: ${provider}` : 'no primary provider set',
+    },
+    embedding: {
+      // A real embedder is a command or an endpoint; blank means the built-in
+      // 384-dim hash fallback, which only works in a test setup.
+      ok: embCmd !== '' || embEndpoint !== '',
+      detail: embCmd !== '' || embEndpoint !== '' ? 'embedder configured' : 'built-in hash fallback (test-only)',
+    },
+    db2: {
+      ok: db2 !== '',
+      detail: db2 !== '' ? 'shared store configured' : 'no DB2 URL set',
+    },
+    kb_api: {
+      ok: kbPort > 0,
+      detail: kbPort > 0 ? `listening on port ${kbPort}` : 'disabled (port 0)',
+      optional: true,
+    },
+    project: {
+      ok: hasProject,
+      detail: hasProject ? 'project connected' : 'no project connected',
+    },
+  };
+
+  const ready = (Object.values(steps) as StepStatus[]).every((s) => s.ok || s.optional);
+  return { ready, steps };
+}
+
+/** How many REQUIRED steps are still incomplete (optional steps excluded). Drives
+ * the "Setup — N left" chip; 0 ⇒ chip hidden. */
+export function stepsRemaining(r: Readiness): number {
+  return (Object.values(r.steps) as StepStatus[]).filter((s) => !s.ok && !s.optional).length;
+}
+
+/** Guard used by the grounding test: every READINESS_KEYS entry must be a real
+ * documented field. Kept here so the invariant lives next to the keys. */
+export function readinessKeysAreDocumented(): boolean {
+  return READINESS_KEYS.every((k) => k in FIELD_HELP);
+}

--- a/frontend/src/setup/setupState.ts
+++ b/frontend/src/setup/setupState.ts
@@ -1,0 +1,46 @@
+/* Wizard "dismissed" flag — localStorage, per-browser (MVP; a per-user server
+ * store is a follow-up). Guarded for node/SSR and storage-disabled browsers, same
+ * as tutorialState. The custom-event name that opens the wizard lives here too so
+ * the chip, Settings, and App all agree on one string. */
+
+export const DISMISSED_KEY = 'aimee_setup_dismissed';
+export const OPEN_WIZARD_EVENT = 'aimee:open-setup-wizard';
+/** Fired after the wizard changes config so the header chip re-computes. */
+export const SETUP_UPDATED_EVENT = 'aimee:setup-updated';
+
+export function isDismissed(): boolean {
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    return localStorage.getItem(DISMISSED_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function setDismissed(dismissed: boolean): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    if (dismissed) localStorage.setItem(DISMISSED_KEY, '1');
+    else localStorage.removeItem(DISMISSED_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Fire the event that opens the wizard (chip click / "Re-run setup"). */
+export function requestOpenWizard(): void {
+  try {
+    if (typeof window !== 'undefined') window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Fire the event that tells the chip to re-read config after a wizard change. */
+export function notifySetupUpdated(): void {
+  try {
+    if (typeof window !== 'undefined') window.dispatchEvent(new CustomEvent(SETUP_UPDATED_EVENT));
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/setup/wizardSteps.test.ts
+++ b/frontend/src/setup/wizardSteps.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { WIZARD_STEPS, isRestartKey, helpFor } from './wizardSteps';
+import { RESTART_KEYS, FIELD_HELP } from '../pages/settingsHelp';
+import { saveConfigValue, loadConfig } from './configApi';
+import type { StepId } from './readiness';
+
+describe('WIZARD_STEPS structure', () => {
+  it('covers every readiness StepId exactly once, in dependency order', () => {
+    const ids = WIZARD_STEPS.map((s) => s.id);
+    expect(ids).toEqual<StepId[]>(['provider', 'embedding', 'db2', 'kb_api', 'project']);
+    expect(new Set(ids).size).toBe(ids.length); // no dupes
+  });
+
+  it('kb_api is optional and project is a hand-off (route, no keys)', () => {
+    const kb = WIZARD_STEPS.find((s) => s.id === 'kb_api')!;
+    const project = WIZARD_STEPS.find((s) => s.id === 'project')!;
+    expect(kb.optional).toBe(true);
+    expect(project.keys).toEqual([]);
+    expect(project.route).toBe('/projects');
+  });
+
+  it('every keyed step references documented config keys', () => {
+    for (const step of WIZARD_STEPS) {
+      for (const k of step.keys) {
+        expect(FIELD_HELP, `${step.id}: ${k} undocumented`).toHaveProperty(k);
+      }
+    }
+  });
+});
+
+describe('isRestartKey / helpFor', () => {
+  it('isRestartKey matches exactly the RESTART_KEYS set', () => {
+    for (const k of RESTART_KEYS) expect(isRestartKey(k)).toBe(true);
+    expect(isRestartKey('provider')).toBe(false);
+    // db2_url is a known restart key and appears in the wizard.
+    expect(isRestartKey('db2_url')).toBe(true);
+  });
+
+  it('helpFor returns the settingsHelp copy, or "" for unknowns', () => {
+    expect(helpFor('provider').length).toBeGreaterThan(0);
+    expect(helpFor('totally_made_up_key')).toBe('');
+  });
+});
+
+// Stub the fetch the config API depends on — vitest runs in node, so we control
+// the whole request/response.
+function stubFetch(status: number, body: unknown): typeof fetch {
+  return (async () => ({
+    status,
+    json: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+describe('saveConfigValue (wizard write path)', () => {
+  it('a 2xx with no error is a success and echoes the server value', async () => {
+    const res = await saveConfigValue('provider', 'claude', { fetchImpl: stubFetch(200, { value: 'claude' }) });
+    expect(res.ok).toBe(true);
+    expect(res.value).toBe('claude');
+  });
+
+  it('a 4xx surfaces the server error and does not succeed', async () => {
+    const res = await saveConfigValue('db2_url', 'bad', { fetchImpl: stubFetch(400, { error: 'invalid url' }) });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('invalid url');
+  });
+
+  it('a 2xx body carrying an error field is still a failure', async () => {
+    const res = await saveConfigValue('provider', 'x', { fetchImpl: stubFetch(200, { error: 'nope' }) });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('nope');
+  });
+
+  it('a thrown fetch (network error) is caught, not propagated', async () => {
+    const throwing = (async () => { throw new Error('network down'); }) as unknown as typeof fetch;
+    const res = await saveConfigValue('provider', 'x', { fetchImpl: throwing });
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/network down/);
+  });
+});
+
+describe('loadConfig', () => {
+  it('unwraps { config } and returns {} on failure', async () => {
+    const ok = await loadConfig({ fetchImpl: stubFetch(200, { config: { provider: 'claude' } }) });
+    expect(ok).toEqual({ provider: 'claude' });
+    const throwing = (async () => { throw new Error('x'); }) as unknown as typeof fetch;
+    expect(await loadConfig({ fetchImpl: throwing })).toEqual({});
+  });
+});

--- a/frontend/src/setup/wizardSteps.ts
+++ b/frontend/src/setup/wizardSteps.ts
@@ -1,0 +1,39 @@
+/* Ordered wizard step definitions + small helpers. Pure data/logic (no DOM), so
+ * the ordering and restart-key classification are unit-tested. The step order is
+ * the real dependency order for a working turn (provider → embedding → shared
+ * store → optional KB API → project). Each step's config keys reuse the
+ * plain-English copy in settingsHelp.ts (single source of truth). */
+
+import { FIELD_HELP, RESTART_KEYS } from '../pages/settingsHelp';
+import type { StepId } from './readiness';
+
+export interface WizardStep {
+  id: StepId;
+  title: string;
+  /** Config keys this step edits, in display order. Empty for a hand-off step. */
+  keys: string[];
+  /** Optional steps are skippable and never block "ready". */
+  optional?: boolean;
+  /** For a hand-off step (e.g. project), the route to send the operator to. */
+  route?: string;
+  /** One-line "what you lose if you skip", shown for optional steps. */
+  skipNote?: string;
+}
+
+export const WIZARD_STEPS: WizardStep[] = [
+  { id: 'provider', title: 'Primary provider', keys: ['provider', 'claude_model', 'openai_endpoint', 'openai_model', 'openai_key_cmd'] },
+  { id: 'embedding', title: 'Embedding backend', keys: ['embedding_command', 'embedding_endpoint', 'embedding_model', 'embedding_dim'] },
+  { id: 'db2', title: 'Shared store (DB2)', keys: ['db2_url'] },
+  { id: 'kb_api', title: 'Knowledge-base API', keys: ['kb_api_http_port', 'kb_api_bearer_token'], optional: true, skipNote: 'Skipping leaves the KB REST API off — no external programmatic access to the knowledge base.' },
+  { id: 'project', title: 'Connect a project', keys: [], route: '/projects', skipNote: 'Without a connected project, tools have no repository to act on.' },
+];
+
+/** True when a config key only takes effect after a server restart. */
+export function isRestartKey(key: string): boolean {
+  return RESTART_KEYS.has(key);
+}
+
+/** Plain-English help for a config key (blank if undocumented). */
+export function helpFor(key: string): string {
+  return FIELD_HELP[key] ?? '';
+}


### PR DESCRIPTION
Adds a guided first-run **setup wizard** and a **per-tab tutorial** layer to the aimee-server web GUI. Frontend-only; no new backend and no new writable config keys — the wizard drives the existing `GET /api/config` + `POST /api/config/set` allowlist.

Proposal + plan: `docs/proposals/pending/proposal-setup-wizard-and-tab-tutorials.md`, `…setup-wizard-and-tab-tutorials.plan.md`.

### Slice 1 — per-tab tutorials (#1147)
Dismissible, non-modal per-tab card (auto-opens first visit, '?' re-opener); one grounded tutorial per NAV route; localStorage seen-state (pure tested cores); 'Replay tab tutorials' in Settings.

### Slice 2 — setup onboarding (#1149)
Header `Setup — N left` chip + first-run wizard over the existing config API. Guarded writes (Toast on failure, input preserved), `RESTART_KEYS` tracked into the summary, closable anytime. Pure tested cores: `computeReadiness` (grounded vs settingsHelp), wizard steps, and `saveConfigValue`/`loadConfig` (stubbed-fetch: success/4xx/body-error/network-throw). 'Re-run setup' in Settings.

### Scope / follow-ups (deliberate)
- Client-side readiness (a server `GET /api/setup/state` that can ping DB2/provider is a follow-up).
- localStorage (per-browser) persistence; per-user server store is a follow-up.

### Verification
- `npm run check` (tsc): clean. `npm run build` (vite): clean.
- `npm test`: +25 tests added, all pass. The **only** failing test is the pre-existing `Dashboard.test.ts` guardrail-audit, which fails identically on stock `testing` and is out of scope.
- Each slice roundtable-approved; final review in progress.