### PR TITLE
fix(kb): make typed-facts actually commit (seed at startup + endpoint-kind inference)

### DIFF
--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -19,6 +19,7 @@
 #include "memory.h"
 #include "memory_graph_fusion.h"
 #include "db2/memory_vectors.h"
+#include "db2/rel_types_store.h" /* db2_rel_types_ensure_seed (typed-fact ontology) */
 #include <signal.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -619,6 +620,16 @@ int main(int argc, char **argv)
          attempt++;
       }
    }
+
+   /* Seed the relation-type ontology into the shared rel_types table now that DB2
+    * is up. The fact-commit path resolves each seed relation's id from this table
+    * (db2_fact_commit -> db2_rel_types_resolve); without the seed every seed-relation
+    * commit DEFERs and no typed fact ever lands. ensure_seed is idempotent
+    * (ON CONFLICT DO NOTHING) and cheap, so running it on each start is safe.
+    * Non-fatal: a failure is logged but does not block the KB. */
+   if (db2_rel_types_ensure_seed() != 0)
+      fprintf(stderr, "aimee-kb: warning: rel_types ontology seed failed; typed-fact "
+                      "commits will DEFER until the seed lands on a later start\n");
 
    /* Diagnostic mode: run the fusion off-vs-on recall probe and exit without
     * starting the service. */

--- a/src/kb/kb_memory_facts.c
+++ b/src/kb/kb_memory_facts.c
@@ -215,8 +215,25 @@ static int mf_commit_facts(const char *llm_json)
       if (!subject[0] || !relation[0] || !object[0] || conf < MF_CONF_FLOOR)
          continue;
 
-      fact_gate_verdict_t v = db2_fact_commit(subject, mf_subject_kind(subject), relation, object,
-                                              NODE_OTHER, FACT_AUTHORITY_MODEL, 1);
+      /* The extractor supplies no node kinds, so guess: subject via
+       * mf_subject_kind, object OTHER (unknown). But the kind gate REJECTS a
+       * seed relation whose endpoint kind mismatches its ontology def (e.g.
+       * works_for wants tail=ORG) — a wrong guess silently drops every such
+       * fact. For a known seed relation, take the endpoint kinds the relation
+       * itself implies (its def's canonical kinds) whenever the guess is not
+       * already allowed; novel relations keep the guess (not kind-checked). */
+      memory_node_kind_t subj_kind = mf_subject_kind(subject);
+      memory_node_kind_t obj_kind = NODE_OTHER;
+      const rel_type_def_t *sdef = rel_types_seed_lookup(relation);
+      if (sdef)
+      {
+         if (!rel_type_kind_allowed(sdef, 1, subj_kind) && sdef->head_kind_count > 0)
+            subj_kind = sdef->head_kinds[0];
+         if (!rel_type_kind_allowed(sdef, 0, obj_kind) && sdef->tail_kind_count > 0)
+            obj_kind = sdef->tail_kinds[0];
+      }
+      fact_gate_verdict_t v =
+          db2_fact_commit(subject, subj_kind, relation, object, obj_kind, FACT_AUTHORITY_MODEL, 1);
       if (v == FACT_GATE_ACCEPT || v == FACT_GATE_NOVEL)
          committed++;
    }


### PR DESCRIPTION
Typed-fact extraction has never landed a durable fact in production. Following the #1148 extraction fix, end-to-end validation on the live .254 stack surfaced **two more compounding blockers**, both fixed here.

## Blocker A — seed ontology never loaded at runtime
`db2_rel_types_ensure_seed()` was only ever called from unit tests, so on a live deploy `rel_types` has no seed → `db2_rel_types_resolve()` fails for every seed relation → `db2_fact_commit` returns `DEFER`. **Fix:** call it once after `db2_init` at KB startup (idempotent `ON CONFLICT DO NOTHING`), `kb_main.c`.

## Blocker B — object node-kind hardcoded (the decisive one)
`mf_commit_facts` passed `NODE_OTHER` as every fact's object kind, but seed relations require a typed tail (`works_for`→ORG, `lives_in`→PLACE), so `memory_fact_gate_check` rejected them on kind before committing. **Fix:** for a known seed relation, take the endpoint kinds the relation itself implies (`rel_types_seed_lookup` → def canonical kinds) when the guess isn't already allowed; novel relations keep the guess (the gate doesn't kind-check them). Lowest-blast-radius option — the gate and other callers are untouched.

## Evidence (live .254)
A direct gpu-mid call with the exact drain prompt + `enable_thinking:false` returns perfect facts (`works_for`/`lives_in`, conf 1.0, 52 tok), yet the drain committed 0 with the ontology even manually seeded — pinning blocker B. With A+B, seed-relation facts should resolve and commit.

## Verification
Builds + links; no regression in fact-ingest / curator / provider unit tests. **End-to-end (store→commit→recall) verification pending** a `:testing` build + KB redeploy — will confirm on the .254 stack before this is considered done.

Together with #1148 this is the full fix for "typed-facts never lands." Object-kind approach (B) chosen over widening the gate or changing the extractor contract, per the lowest-blast-radius principle.