### PR TITLE
feat(kb): correct contradictory memory facts on commit (§4)

### DIFF
--- a/src/db2/entity_edges.c
+++ b/src/db2/entity_edges.c
@@ -4,6 +4,7 @@
 #include "entity_edges.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
+#include "../headers/rel_types.h" /* correction_behavior + rel_type_is_functional (§4) */
 
 #include <stddef.h>
 #include <stdio.h>
@@ -230,6 +231,53 @@ int db2_entity_edge_upsert_semantic(const char *source, const char *relation, co
    gmtime_r(&now_t, &now_tm);
    char asserted_at[32];
    strftime(asserted_at, sizeof(asserted_at), "%Y-%m-%d %H:%M:%S", &now_tm);
+   /* §4 correction/supersede for contradictory objects. For a FUNCTIONAL
+    * (single-valued) relation, a new object contradicts any prior object for the
+    * same subject+relation; apply the relation's correction_behavior. The exact
+    * triple was already handled (bumped) above, so any prior row here asserts a
+    * DIFFERENT object. Multi-valued relations accumulate (no correction). */
+   if (rel_type_is_functional(relation))
+   {
+      const rel_type_def_t *rdef = rel_types_seed_lookup(relation);
+      correction_behavior_t corr = rdef ? rdef->correction_behavior : CORR_SUPERSEDE;
+      if (corr == CORR_IMMUTABLE)
+      {
+         static const char *chk =
+             "SELECT 1 FROM entity_edges WHERE source=?1 AND relation=?2 AND target<>?3"
+             " AND edge_class='semantic' AND superseded_at='' AND suppressed=0 LIMIT 1";
+         aimee_pg_stmt_t *cs = aimee_pg_prepare(conn, chk, err, sizeof(err));
+         if (cs)
+         {
+            aimee_pg_bind_text(cs, "?1", source);
+            aimee_pg_bind_text(cs, "?2", relation);
+            aimee_pg_bind_text(cs, "?3", target);
+            int have_prior = (aimee_pg_step(cs, err, sizeof(err)) == AIMEE_PG_ROW);
+            aimee_pg_finalize(cs);
+            if (have_prior)
+               return 0; /* immutable fact is fixed: drop the contradicting new object */
+         }
+      }
+      else
+      {
+         const char *upd =
+             (corr == CORR_HARD_DELETE)
+                 ? "UPDATE entity_edges SET suppressed=1, superseded_at=?4 WHERE source=?1"
+                   " AND relation=?2 AND target<>?3 AND edge_class='semantic'"
+                   " AND superseded_at='' AND suppressed=0"
+                 : "UPDATE entity_edges SET superseded_at=?4 WHERE source=?1 AND relation=?2"
+                   " AND target<>?3 AND edge_class='semantic' AND superseded_at='' AND suppressed=0";
+         aimee_pg_stmt_t *us = aimee_pg_prepare(conn, upd, err, sizeof(err));
+         if (us)
+         {
+            aimee_pg_bind_text(us, "?1", source);
+            aimee_pg_bind_text(us, "?2", relation);
+            aimee_pg_bind_text(us, "?3", target);
+            aimee_pg_bind_text(us, "?4", asserted_at);
+            (void)aimee_pg_step(us, err, sizeof(err));
+            aimee_pg_finalize(us);
+         }
+      }
+   }
 
    static const char *ins =
        "INSERT INTO entity_edges (source, relation, target, weight,"

--- a/src/db2/entity_edges.c
+++ b/src/db2/entity_edges.c
@@ -265,7 +265,8 @@ int db2_entity_edge_upsert_semantic(const char *source, const char *relation, co
                    " AND relation=?2 AND target<>?3 AND edge_class='semantic'"
                    " AND superseded_at='' AND suppressed=0"
                  : "UPDATE entity_edges SET superseded_at=?4 WHERE source=?1 AND relation=?2"
-                   " AND target<>?3 AND edge_class='semantic' AND superseded_at='' AND suppressed=0";
+                   " AND target<>?3 AND edge_class='semantic' AND superseded_at='' AND "
+                   "suppressed=0";
          aimee_pg_stmt_t *us = aimee_pg_prepare(conn, upd, err, sizeof(err));
          if (us)
          {

--- a/src/headers/rel_types.h
+++ b/src/headers/rel_types.h
@@ -92,6 +92,13 @@ extern "C"
     * `def`? NODE_OTHER in the def's list is the ANY wildcard. */
    int rel_type_kind_allowed(const rel_type_def_t *def, int is_head, memory_node_kind_t kind);
 
+   /* Is `rel_type` single-valued (functional)? A functional relation's new object
+    * contradicts any prior object for the same subject, so the commit path applies
+    * the relation's correction_behavior (supersede/hard-delete/reject-if-immutable).
+    * Multi-valued relations (knows, member_of, parent_of, also_known_as, ...)
+    * accumulate objects and are not corrected. */
+   int rel_type_is_functional(const char *rel_type);
+
    /* Validate the SEED_ONTOLOGY for internal consistency (R1-D1): every head/tail
     * kind is a known entity kind; a symmetric type's inverse is itself and its
     * head/tail kind sets match; a non-symmetric type's declared inverse exists in

--- a/src/rel_types.c
+++ b/src/rel_types.c
@@ -322,7 +322,7 @@ int rel_type_is_functional(const char *rel_type)
    if (!rel_type)
       return 0;
    static const char *const functional[] = {
-       "lives_in", "born_in",  "age",      "located_in", "has_hostname",
+       "lives_in", "born_in",   "age",      "located_in",    "has_hostname",
        "spouse",   "works_for", "has_role", "device_has_ip",
    };
    for (size_t i = 0; i < sizeof(functional) / sizeof(functional[0]); i++)

--- a/src/rel_types.c
+++ b/src/rel_types.c
@@ -313,6 +313,24 @@ static int is_known_kind(memory_node_kind_t k)
    return 0;
 }
 
+/* Single-valued (functional) relations: a new object supersedes/replaces the prior
+ * for the same subject (via correction_behavior). Kept explicit in one place so the
+ * set is reviewed together; multi-valued relations (knows, member_of, parent_of,
+ * child_of, also_known_as, ...) accumulate and are absent here. */
+int rel_type_is_functional(const char *rel_type)
+{
+   if (!rel_type)
+      return 0;
+   static const char *const functional[] = {
+       "lives_in", "born_in",  "age",      "located_in", "has_hostname",
+       "spouse",   "works_for", "has_role", "device_has_ip",
+   };
+   for (size_t i = 0; i < sizeof(functional) / sizeof(functional[0]); i++)
+      if (strcmp(rel_type, functional[i]) == 0)
+         return 1;
+   return 0;
+}
+
 int rel_type_kind_allowed(const rel_type_def_t *def, int is_head, memory_node_kind_t kind)
 {
    if (!def)

--- a/src/tests/test_fact_lifecycle.c
+++ b/src/tests/test_fact_lifecycle.c
@@ -185,13 +185,31 @@ int main(void)
 
    /* §4 retract — target (old-value) scoping: only the matching edge is retracted,
     * sibling values of the same (subject, relation) are untouched. */
-   assert(db2_fact_commit("gus", NODE_PERSON, "works_for", "acme", NODE_ORG, FACT_AUTHORITY_USER,
+   assert(db2_fact_commit("gus", NODE_PERSON, "member_of", "acme", NODE_ORG, FACT_AUTHORITY_USER,
                           1) == FACT_GATE_ACCEPT);
-   assert(db2_fact_commit("gus", NODE_PERSON, "works_for", "globex", NODE_ORG, FACT_AUTHORITY_USER,
+   assert(db2_fact_commit("gus", NODE_PERSON, "member_of", "globex", NODE_ORG, FACT_AUTHORITY_USER,
                           1) == FACT_GATE_ACCEPT);
    assert(db2_fact_current_count("gus") == 2);
-   assert(db2_fact_retract("gus", "works_for", "acme", FACT_AUTHORITY_USER) == 1);
+   assert(db2_fact_retract("gus", "member_of", "acme", FACT_AUTHORITY_USER) == 1);
    assert(db2_fact_current_count("gus") == 1); /* globex remains */
+
+   /* Commit correction: a FUNCTIONAL relation supersedes the prior object. hank
+    * works_for acme, then globex -> globex current, acme archived (superseded). */
+   assert(db2_fact_commit("hank", NODE_PERSON, "works_for", "acme", NODE_ORG, FACT_AUTHORITY_USER,
+                          1) == FACT_GATE_ACCEPT);
+   assert(db2_fact_current_count("hank") == 1);
+   assert(db2_fact_commit("hank", NODE_PERSON, "works_for", "globex", NODE_ORG, FACT_AUTHORITY_USER,
+                          1) == FACT_GATE_ACCEPT);
+   assert(db2_fact_current_count("hank") == 1); /* globex supersedes acme */
+
+   /* Commit correction: an IMMUTABLE relation rejects a contradicting object. iris
+    * born_in kyoto is fixed; a later born_in osaka is dropped. */
+   assert(db2_fact_commit("iris", NODE_PERSON, "born_in", "kyoto", NODE_PLACE, FACT_AUTHORITY_USER,
+                          1) == FACT_GATE_ACCEPT);
+   assert(db2_fact_current_count("iris") == 1);
+   (void)db2_fact_commit("iris", NODE_PERSON, "born_in", "osaka", NODE_PLACE, FACT_AUTHORITY_USER,
+                         1);
+   assert(db2_fact_current_count("iris") == 1); /* still kyoto, immutable */
 
    /* bad args / no-op. */
    assert(db2_fact_retract(NULL, "works_for", NULL, FACT_AUTHORITY_MODEL) == -1);

--- a/src/tests/test_rel_types.c
+++ b/src/tests/test_rel_types.c
@@ -68,6 +68,23 @@ static void test_kind_allowed(void)
    printf("  PASS: test_kind_allowed\n");
 }
 
+static void test_functional_classification(void)
+{
+   /* Single-valued: a new object supersedes the prior (commit-time §4 correction). */
+   assert(rel_type_is_functional("lives_in") == 1);
+   assert(rel_type_is_functional("works_for") == 1);
+   assert(rel_type_is_functional("born_in") == 1);
+   assert(rel_type_is_functional("has_role") == 1);
+   assert(rel_type_is_functional("device_has_ip") == 1);
+   /* Multi-valued: objects accumulate, no correction. */
+   assert(rel_type_is_functional("knows") == 0);
+   assert(rel_type_is_functional("member_of") == 0);
+   assert(rel_type_is_functional("also_known_as") == 0);
+   assert(rel_type_is_functional("parent_of") == 0);
+   assert(rel_type_is_functional(NULL) == 0);
+   printf("  PASS: test_functional_classification\n");
+}
+
 static void test_enum_text(void)
 {
    assert(correction_behavior_from_text("immutable") == CORR_IMMUTABLE);
@@ -96,6 +113,7 @@ int main(void)
    test_normalize();
    test_seed_lookup_case_insensitive();
    test_kind_allowed();
+   test_functional_classification();
    test_enum_text();
    test_governance_rel_types();
    printf("rel_types: all tests passed\n");


### PR DESCRIPTION
Implements memory-fact contradiction handling — the "§4 correction/supersede for contradictory objects" that was a comment placeholder in `entity_edges.c`.

## Problem (proven live on .254)
A new memory fact never superseded a contradicting old one — "Elena lives_in Osaka" then "Elena lives_in Berlin" left **both active**. The supersede logic existed only in the separate `typed_facts` table, which the memory drain doesn't use.

## Fix
In `db2_entity_edge_upsert_semantic`, for a **functional (single-valued)** relation a new object contradicts any prior object for the same subject+relation, so apply the relation's `correction_behavior`:
- **SUPERSEDE** → archive the prior (`superseded_at`)
- **HARD_DELETE** → tombstone the prior (`suppressed`)
- **IMMUTABLE** → reject the change (e.g. `born_in`)

**Multi-valued** relations (`knows`, `member_of`, `parent_of`, `child_of`, `also_known_as`, …) accumulate as before — no correction.

New `rel_type_is_functional()` holds the single-valued set: **lives_in, born_in, age, located_in, has_hostname, spouse, works_for, has_role, device_has_ip** (the "broader" set). `correction_behavior` alone can't drive this — it's also set on multi-valued relations, so naive supersede would archive coexisting facts ("knows Alice" wiped by "knows Bob").

## Verification
Builds + links; `test_rel_types` covers the functional classification. **End-to-end (Osaka→Berlin supersedes, born_in immutable) pending :testing deploy** — will confirm on .254 before considering done.