### PR TITLE
feat(wfe): generic user-definable workflow loop-back cap (max_iters/on_max)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -559,7 +559,7 @@ blocks:
 
 ### Run-level controls (not in the definition)
 
-- **Per-stage loop cap** — a gate that loops back via `on_fail` is retried at most `20` times (`WFE_MAX_ATTEMPTS`) before the run parks; fixed, not configurable.
+- **Per-stage loop cap** — a node that loops back via `on_fail` is retried at most `max_iters` times (per-node param, default `20`); on the cap its `on_max` policy resolves the loop: `human` parks (default), `fail` is a terminal reject, `pass` forces the flow forward via `on_pass`/`next`.
 - **Gate-override cap** — a parked human gate may be overridden at most `2` times (`WFE_MAX_OVERRIDES`) before the run is forced terminal.
 - **Cost cap** — an optional per-work-item USD ceiling set at run creation (`work_item_max_cost_usd`); the engine parks the run when cumulative cost reaches it.
 - **Trigger / autonomy mode** — `interactive` vs `autonomous`, set when the run is created.

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -789,9 +789,9 @@ def parse_block_catalog():
 
 
 def parse_engine_consts():
-    eng = (SRC / "workflow" / "wfe_engine.c").read_text(encoding="utf-8")
+    dfn = (SRC / "workflow" / "wfe_def.h").read_text(encoding="utf-8")
     auto = (SRC / "workflow" / "wfe_autonomy.h").read_text(encoding="utf-8")
-    att = re.search(r'#define\s+WFE_MAX_ATTEMPTS\s+(\d+)', eng)
+    att = re.search(r'#define\s+WFE_DEFAULT_MAX_ITERS\s+(\d+)', dfn)
     ovr = re.search(r'#define\s+WFE_MAX_OVERRIDES\s+(\d+)', auto)
     return (att.group(1) if att else "?"), (ovr.group(1) if ovr else "?")
 
@@ -861,9 +861,10 @@ def render_workflow(catalog, consts):
         "",
         "### Run-level controls (not in the definition)",
         "",
-        f"- **Per-stage loop cap** — a gate that loops back via `on_fail` is retried "
-        f"at most `{max_att}` times (`WFE_MAX_ATTEMPTS`) before the run parks; fixed, "
-        "not configurable.",
+        f"- **Per-stage loop cap** — a node that loops back via `on_fail` is retried at "
+        f"most `max_iters` times (per-node param, default `{max_att}`); on the cap its "
+        f"`on_max` policy resolves the loop: `human` parks (default), `fail` is a "
+        f"terminal reject, `pass` forces the flow forward via `on_pass`/`next`.",
         f"- **Gate-override cap** — a parked human gate may be overridden at most "
         f"`{max_ovr}` times (`WFE_MAX_OVERRIDES`) before the run is forced terminal.",
         "- **Cost cap** — an optional per-work-item USD ceiling set at run creation "

--- a/src/cmd_workflow.c
+++ b/src/cmd_workflow.c
@@ -176,12 +176,19 @@ static const char *TEMPLATE = "name: %s\n"
                               "          - architect\n"
                               "      quorum: 2\n"
                               "      max_rounds: 6\n"
-                              "    on_pass: done\n"
+                              "      max_iters: 3\n"
+                              "      on_max: fail\n"
+                              "    on_pass: pr\n"
                               "    on_fail: draft\n"
+                              "  - id: pr\n"
+                              "    block: pr.open\n"
+                              "    in:\n"
+                              "      src: draft.out\n"
+                              "    next: done\n"
                               "  - id: done\n"
                               "    block: merge\n"
                               "    in:\n"
-                              "      pr: draft.out\n";
+                              "      pr: pr.out\n";
 
 static int cmd_new(const char *path)
 {

--- a/src/tests/test_wfe_engine.c
+++ b/src/tests/test_wfe_engine.c
@@ -45,7 +45,7 @@ static const char *MINI = "name: mini\n"
    "start: draft\nnodes:\n"                                                                        \
    "  - id: draft\n    block: author.proposal\n    next: gate\n"                                   \
    "  - id: gate\n    block: gate.roundtable\n    in:\n      src: draft.out\n    params:\n"        \
-   "      panel:\n        required:\n          - security\n          - architect\n"               \
+   "      panel:\n        required:\n          - security\n          - architect\n"                \
    "      max_iters: 2\n      on_max: " policy "\n    on_pass: pr\n    on_fail: draft\n"           \
    "  - id: pr\n    block: pr.open\n    in:\n      src: draft.out\n    next: done\n"               \
    "  - id: done\n    block: merge\n    in:\n      pr: pr.out\n"

--- a/src/tests/test_wfe_engine.c
+++ b/src/tests/test_wfe_engine.c
@@ -39,6 +39,20 @@ static const char *MINI = "name: mini\n"
                           "    in:\n"
                           "      pr: pr.out\n";
 
+/* Loop-cap variants of `mini`: the gate carries max_iters:2 + on_max, so with an
+ * always-loop gate executor the cap is hit after 2 loops and resolves per on_max. */
+#define MINI_CAP_BODY(policy)                                                                      \
+   "start: draft\nnodes:\n"                                                                        \
+   "  - id: draft\n    block: author.proposal\n    next: gate\n"                                   \
+   "  - id: gate\n    block: gate.roundtable\n    in:\n      src: draft.out\n    params:\n"        \
+   "      panel:\n        required:\n          - security\n          - architect\n"               \
+   "      max_iters: 2\n      on_max: " policy "\n    on_pass: pr\n    on_fail: draft\n"           \
+   "  - id: pr\n    block: pr.open\n    in:\n      src: draft.out\n    next: done\n"               \
+   "  - id: done\n    block: merge\n    in:\n      pr: pr.out\n"
+static const char *MINI_FAIL = "name: minifail\n" MINI_CAP_BODY("fail");
+static const char *MINI_PASS = "name: minipass\n" MINI_CAP_BODY("pass");
+static const char *MINI_HUMAN = "name: minihuman\n" MINI_CAP_BODY("human");
+
 /* always-loop executor (forces on_fail) */
 static wfe_step_result_t exec_loop(wfe_ctx *c, const wfe_node_t *n)
 {
@@ -70,6 +84,19 @@ static void setup_home(void)
    fputs(MINI, f);
    fclose(f);
    setenv("AIMEE_HOME", dir, 1);
+}
+
+/* Write an extra workflow YAML into $AIMEE_HOME/workflows (set by setup_home). */
+static void write_workflow(const char *name, const char *yaml)
+{
+   const char *home = getenv("AIMEE_HOME");
+   assert(home);
+   char path[700];
+   snprintf(path, sizeof path, "%s/workflows/%s.yaml", home, name);
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(yaml, f);
+   fclose(f);
 }
 
 int main(void)
@@ -149,6 +176,55 @@ int main(void)
       char id2[80] = "";
       assert(wfe_work_item_create("mini", "dup", "dup.md", "interactive", id2, err, sizeof err) !=
              0);
+   }
+
+   /* --- E: loop cap on_max=fail -> terminal "rejected" after max_iters loops --- */
+   {
+      write_workflow("minifail", MINI_FAIL);
+      wfe_reset_block_executors();
+      wfe_register_stub_executors();
+      wfe_register_block_executor(WFE_BLK_GATE_ROUNDTABLE, exec_loop);
+      char id[80] = "";
+      char err[256] = "";
+      assert(wfe_work_item_create("minifail", "r_fail", "pf.md", "interactive", id, err,
+                                  sizeof err) == 0);
+      assert(wfe_engine_run(id, err, sizeof err) == 0);
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "rejected") == 0); /* on_max:fail -> terminal reject */
+   }
+
+   /* --- F: loop cap on_max=pass -> forced forward via on_pass -> accepted --- */
+   {
+      write_workflow("minipass", MINI_PASS);
+      wfe_reset_block_executors();
+      wfe_register_stub_executors();
+      wfe_register_block_executor(WFE_BLK_GATE_ROUNDTABLE, exec_loop);
+      char id[80] = "";
+      char err[256] = "";
+      assert(wfe_work_item_create("minipass", "r_pass", "pp.md", "interactive", id, err,
+                                  sizeof err) == 0);
+      assert(wfe_engine_run(id, err, sizeof err) == 0);
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "accepted") == 0); /* forced-pass rode on_pass to completion */
+   }
+
+   /* --- G: loop cap on_max=human (+ explicit max_iters:2) -> pause pending_human --- */
+   {
+      write_workflow("minihuman", MINI_HUMAN);
+      wfe_reset_block_executors();
+      wfe_register_stub_executors();
+      wfe_register_block_executor(WFE_BLK_GATE_ROUNDTABLE, exec_loop);
+      char id[80] = "";
+      char err[256] = "";
+      assert(wfe_work_item_create("minihuman", "r_hum", "ph.md", "interactive", id, err,
+                                  sizeof err) == 0);
+      assert(wfe_engine_run(id, err, sizeof err) == 0);
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "active") == 0); /* paused, not terminal */
+      assert(strcmp(wi.pause_reason, "pending_human") == 0);
    }
 
    printf("ok\n");

--- a/src/tests/test_wfe_gate_reject.c
+++ b/src/tests/test_wfe_gate_reject.c
@@ -35,12 +35,56 @@ static const char *WF_DANGLING = "name: t\nstart: g\nnodes:\n"
                                  "      retry_on_reject: true\n    on_fail: gone\n    on_pass: m\n"
                                  "  - id: m\n    block: merge\n";
 
+/* ---- Generic loop cap (max_iters / on_max) fixtures ----
+ * Built from author.proposal nodes (which require no input binding) so the ONLY
+ * thing under test is the loop-cap validation, not unrelated input/gate rules.
+ * The cap params + on_fail/on_pass edges are generic across node types. */
+/* Node g carries an explicit cap + policy; the rest is a valid loop workflow. */
+static const char *WF_CAP_OK = "name: t\nstart: g\nnodes:\n"
+                               "  - id: g\n    block: author.proposal\n    params:\n"
+                               "      max_iters: 5\n      on_max: fail\n"
+                               "    on_fail: impl\n    on_pass: m\n"
+                               "  - id: impl\n    block: author.proposal\n    next: g\n"
+                               "  - id: m\n    block: author.proposal\n";
+/* on_max:pass WITH a forward edge (on_pass) -> valid. */
+static const char *WF_CAP_PASS_OK = "name: t\nstart: g\nnodes:\n"
+                                    "  - id: g\n    block: author.proposal\n    params:\n"
+                                    "      on_max: pass\n    on_fail: impl\n    on_pass: m\n"
+                                    "  - id: impl\n    block: author.proposal\n    next: g\n"
+                                    "  - id: m\n    block: author.proposal\n";
+/* max_iters <= 0 -> invalid. */
+static const char *WF_CAP_BADITERS = "name: t\nstart: g\nnodes:\n"
+                                     "  - id: g\n    block: author.proposal\n    params:\n"
+                                     "      max_iters: 0\n    on_fail: impl\n    on_pass: m\n"
+                                     "  - id: impl\n    block: author.proposal\n    next: g\n"
+                                     "  - id: m\n    block: author.proposal\n";
+/* on_max not in the enum -> invalid. */
+static const char *WF_CAP_BADONMAX = "name: t\nstart: g\nnodes:\n"
+                                     "  - id: g\n    block: author.proposal\n    params:\n"
+                                     "      on_max: bogus\n    on_fail: impl\n    on_pass: m\n"
+                                     "  - id: impl\n    block: author.proposal\n    next: g\n"
+                                     "  - id: m\n    block: author.proposal\n";
+/* on_max:pass but NO on_pass/next forward edge -> invalid (nowhere to route). */
+static const char *WF_CAP_PASS_NOEDGE = "name: t\nstart: g\nnodes:\n"
+                                        "  - id: g\n    block: author.proposal\n    params:\n"
+                                        "      on_max: pass\n    on_fail: impl\n"
+                                        "  - id: impl\n    block: author.proposal\n    next: g\n";
+
 static wfe_def_t *parse(const char *yaml)
 {
    char err[256] = "";
    wfe_def_t *d = wfe_def_parse(yaml, err, sizeof err);
    assert(d && "parse failed");
    return d;
+}
+
+/* Validate `yaml`, returning 0/-1 and copying the error message into `err`. */
+static int validate_yaml(const char *yaml, char *err, size_t errlen)
+{
+   wfe_def_t *d = parse(yaml);
+   int rc = wfe_def_validate(d, err, errlen);
+   wfe_def_free(d);
+   return rc;
 }
 
 int main(void)
@@ -84,6 +128,40 @@ int main(void)
    char tiny[3];
    assert(wfe_gate_reject_target(d, "g", tiny, sizeof tiny) == WFE_GATE_REJECT_ERR);
    wfe_def_free(d);
+
+   /* ---- Generic loop cap: accessors ---- */
+   /* (h) explicit params are read back; the default node has no params -> defaults. */
+   d = parse(WF_CAP_OK);
+   const wfe_node_t *g = wfe_def_node(d, "g");
+   const wfe_node_t *impl = wfe_def_node(d, "impl");
+   assert(g && impl);
+   assert(wfe_node_max_iters(g) == 5);
+   assert(wfe_node_on_max(g) == WFE_ON_MAX_FAIL);
+   assert(wfe_node_max_iters(impl) == WFE_DEFAULT_MAX_ITERS); /* no params -> default */
+   assert(wfe_node_on_max(impl) == WFE_ON_MAX_HUMAN);         /* no params -> default */
+   assert(wfe_node_max_iters(NULL) == WFE_DEFAULT_MAX_ITERS); /* NULL-safe */
+   assert(wfe_node_on_max(NULL) == WFE_ON_MAX_HUMAN);
+   wfe_def_free(d);
+
+   /* (i) on_max "pass" parses to WFE_ON_MAX_PASS. */
+   d = parse(WF_CAP_PASS_OK);
+   assert(wfe_node_on_max(wfe_def_node(d, "g")) == WFE_ON_MAX_PASS);
+   wfe_def_free(d);
+
+   /* ---- Generic loop cap: validator ---- */
+   char verr[256];
+   /* (j) a good cap validates. */
+   assert(validate_yaml(WF_CAP_OK, verr, sizeof verr) == 0);
+   assert(validate_yaml(WF_CAP_PASS_OK, verr, sizeof verr) == 0);
+   /* (k) max_iters <= 0 rejected. */
+   assert(validate_yaml(WF_CAP_BADITERS, verr, sizeof verr) == -1);
+   assert(strstr(verr, "max_iters") != NULL);
+   /* (l) unknown on_max rejected. */
+   assert(validate_yaml(WF_CAP_BADONMAX, verr, sizeof verr) == -1);
+   assert(strstr(verr, "on_max") != NULL);
+   /* (m) on_max:pass without a forward edge rejected. */
+   assert(validate_yaml(WF_CAP_PASS_NOEDGE, verr, sizeof verr) == -1);
+   assert(strstr(verr, "on_max:pass") != NULL);
 
    printf("ok\n");
    return 0;

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -1136,25 +1136,14 @@ static wfe_step_result_t exec_split(wfe_ctx *ctx, const wfe_node_t *node)
 /* review: a READ-ONLY reviewer delegate (persona from node params `reviewer`,
  * validator-checked disjoint from the roundtable panel + producer) emits a typed
  * verdict. pass -> ADVANCED (on_pass); changes -> LOOPED (on_fail, re-delegate).
- * The re-delegate loop is bounded by the engine-owned per-stage attempt counter:
- * on exhaustion the step FAILS (terminal), never silently loops. Tool-level
- * read-only enforcement is the S2 tool-policy slice (documented residual). */
-static int review_max_iters(const wfe_node_t *node)
-{
-   const cJSON *m =
-       node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "max_iters") : NULL;
-   return (m && cJSON_IsNumber(m) && m->valueint > 0) ? m->valueint : 3;
-}
-
+ * The re-delegate loop is bounded by the engine's GENERIC per-node loop cap
+ * (params.max_iters / on_max, keyed on the gate node): the engine owns the cap
+ * and its resolution, so this block no longer self-terminates. A review node
+ * that wants the historical "3 tries then terminal fail" sets max_iters:3 and
+ * on_max:fail. Tool-level read-only enforcement is the S2 tool-policy slice. */
 static wfe_step_result_t exec_review(wfe_ctx *ctx, const wfe_node_t *node)
 {
    const char *wi = wfe_ctx_work_item(ctx);
-   if (wi && db1_stage_attempt_get(wi, node->id) >= review_max_iters(node))
-   {
-      db1_lifecycle_event_add(wi, node->id, "failed", "engine",
-                              "review re-delegation budget exhausted", "", 0.0);
-      return wfe_step_failed();
-   }
    const cJSON *jrev =
        node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "reviewer") : NULL;
    const char *reviewer =

--- a/src/workflow/wfe_def.c
+++ b/src/workflow/wfe_def.c
@@ -384,8 +384,7 @@ int wfe_node_max_iters(const wfe_node_t *n)
 
 wfe_on_max_t wfe_node_on_max(const wfe_node_t *n)
 {
-   const cJSON *o =
-       (n && n->params) ? cJSON_GetObjectItemCaseSensitive(n->params, "on_max") : NULL;
+   const cJSON *o = (n && n->params) ? cJSON_GetObjectItemCaseSensitive(n->params, "on_max") : NULL;
    if (cJSON_IsString(o) && o->valuestring)
    {
       if (strcmp(o->valuestring, "fail") == 0)

--- a/src/workflow/wfe_def.c
+++ b/src/workflow/wfe_def.c
@@ -372,3 +372,26 @@ wfe_gate_reject_t wfe_gate_reject_target(const wfe_def_t *def, const char *gate_
    }
    return WFE_GATE_REJECT_RETRY;
 }
+
+int wfe_node_max_iters(const wfe_node_t *n)
+{
+   const cJSON *m =
+       (n && n->params) ? cJSON_GetObjectItemCaseSensitive(n->params, "max_iters") : NULL;
+   if (cJSON_IsNumber(m) && m->valueint > 0)
+      return m->valueint;
+   return WFE_DEFAULT_MAX_ITERS;
+}
+
+wfe_on_max_t wfe_node_on_max(const wfe_node_t *n)
+{
+   const cJSON *o =
+       (n && n->params) ? cJSON_GetObjectItemCaseSensitive(n->params, "on_max") : NULL;
+   if (cJSON_IsString(o) && o->valuestring)
+   {
+      if (strcmp(o->valuestring, "fail") == 0)
+         return WFE_ON_MAX_FAIL;
+      if (strcmp(o->valuestring, "pass") == 0)
+         return WFE_ON_MAX_PASS;
+   }
+   return WFE_ON_MAX_HUMAN;
+}

--- a/src/workflow/wfe_def.h
+++ b/src/workflow/wfe_def.h
@@ -138,6 +138,27 @@ typedef enum
 wfe_gate_reject_t wfe_gate_reject_target(const wfe_def_t *def, const char *gate_id,
                                          char *out_target, size_t out_n);
 
+/* ---- Generic loop cap (max_iters / on_max) ----
+ * Any node may bound how many times it is re-entered via a loop-back. The cap
+ * comes from params.max_iters (positive int; default WFE_DEFAULT_MAX_ITERS).
+ * On reaching the cap the engine resolves per params.on_max:
+ *   "human" (default) -> pause for a human
+ *   "fail"            -> terminal `rejected`
+ *   "pass"            -> proceed forward as if advanced (via on_pass/next) */
+#define WFE_DEFAULT_MAX_ITERS 20
+typedef enum
+{
+   WFE_ON_MAX_HUMAN = 0, /* default: pause for a human when the cap is hit */
+   WFE_ON_MAX_FAIL,      /* terminal `rejected` when the cap is hit */
+   WFE_ON_MAX_PASS       /* proceed forward (on_pass/next) as if the node advanced */
+} wfe_on_max_t;
+
+/* Per-node loop cap: params.max_iters if a positive int, else WFE_DEFAULT_MAX_ITERS. */
+int wfe_node_max_iters(const wfe_node_t *n);
+/* Per-node cap-resolution policy: params.on_max ("pass"/"fail"/"human"),
+ * defaulting to WFE_ON_MAX_HUMAN. */
+wfe_on_max_t wfe_node_on_max(const wfe_node_t *n);
+
 /* ---- Validate (wfe_validate.c). Returns 0 on success; nonzero + err set. ---- */
 int wfe_def_validate(const wfe_def_t *def, char *err, size_t errlen);
 

--- a/src/workflow/wfe_engine.c
+++ b/src/workflow/wfe_engine.c
@@ -8,9 +8,6 @@
 #include "aimee_home.h"
 #include "wfe_store.h"
 
-/* Loop-back safety bound (config-overridable in W6). */
-#define WFE_MAX_ATTEMPTS 20
-
 struct wfe_ctx
 {
    const char *work_item_id;
@@ -389,12 +386,42 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
       {
          if (r.status == WFE_STEP_LOOPED)
          {
-            int att = db1_stage_attempt_inc(work_item_id, next);
-            if (att >= WFE_MAX_ATTEMPTS)
+            /* Generic per-node loop cap. Keyed on the GATE node (node->id) so
+             * distinct gates looping to a shared target keep independent budgets
+             * and the review block's own read (also node->id) agrees. */
+            int att = db1_stage_attempt_inc(work_item_id, node->id);
+            if (att >= wfe_node_max_iters(node))
             {
+               wfe_on_max_t pol = wfe_node_on_max(node);
+               if (pol == WFE_ON_MAX_FAIL)
+               {
+                  WFE_CKW(db1_work_item_set_terminal(work_item_id, "rejected"));
+                  db1_lifecycle_event_add(work_item_id, node->id, "terminal", "engine",
+                                          "rejected: max_iters reached", "", r.cost_usd);
+                  out->terminal = 1;
+                  snprintf(out->state, sizeof out->state, "rejected");
+                  db1_lifecycle_txn_commit();
+                  wfe_def_free(def);
+                  return 0;
+               }
+               if (pol == WFE_ON_MAX_PASS)
+               {
+                  /* Proceed forward as if the node advanced; the validator
+                   * guarantees on_max:pass carries an on_pass/next forward edge. */
+                  const char *fwd = node->on_pass[0] ? node->on_pass : node->next;
+                  WFE_CKW(db1_work_item_set_stage(work_item_id, fwd, r.content_hash));
+                  db1_lifecycle_event_add(work_item_id, node->id, "forced_pass", "engine", fwd,
+                                          r.content_hash, r.cost_usd);
+                  out->last_status = WFE_STEP_ADVANCED;
+                  snprintf(out->next_stage, sizeof out->next_stage, "%s", fwd);
+                  db1_lifecycle_txn_commit();
+                  wfe_def_free(def);
+                  return 0;
+               }
+               /* WFE_ON_MAX_HUMAN (default): pause for a human. */
                WFE_CKW(db1_work_item_set_pause(work_item_id, "pending_human", next));
-               db1_lifecycle_event_add(work_item_id, node->id, "pause", "engine", "max_attempts",
-                                       "", r.cost_usd);
+               db1_lifecycle_event_add(work_item_id, node->id, "pause", "engine", "max_iters", "",
+                                       r.cost_usd);
                out->last_status = WFE_STEP_PENDING;
                out->pause_reason = WFE_PAUSE_PENDING_HUMAN;
                snprintf(out->next_stage, sizeof out->next_stage, "%s", next);

--- a/src/workflow/wfe_validate.c
+++ b/src/workflow/wfe_validate.c
@@ -126,6 +126,39 @@ static int check_gate_rules(const wfe_node_t *n, char *err, size_t errlen)
    return 0;
 }
 
+/* generic loop-cap params: max_iters (positive int) + on_max (pass/fail/human). */
+static int check_loop_cap(const wfe_node_t *n, char *err, size_t errlen)
+{
+   const cJSON *mi = n->params ? cJSON_GetObjectItemCaseSensitive(n->params, "max_iters") : NULL;
+   if (mi && (!cJSON_IsNumber(mi) || mi->valueint <= 0))
+   {
+      snprintf(err, errlen, "node '%s': max_iters must be a positive integer", n->id);
+      return -1;
+   }
+   const cJSON *om = n->params ? cJSON_GetObjectItemCaseSensitive(n->params, "on_max") : NULL;
+   if (om)
+   {
+      if (!cJSON_IsString(om) ||
+          (strcmp(om->valuestring, "pass") != 0 && strcmp(om->valuestring, "fail") != 0 &&
+           strcmp(om->valuestring, "human") != 0))
+      {
+         snprintf(err, errlen, "node '%s': on_max must be one of \"pass\", \"fail\", \"human\"",
+                  n->id);
+         return -1;
+      }
+      /* on_max:pass routes forward as if advanced (via on_pass, else next); require
+       * a forward edge so the forced-pass path never resolves to an empty target. */
+      if (strcmp(om->valuestring, "pass") == 0 && !n->on_pass[0] && !n->next[0])
+      {
+         snprintf(err, errlen,
+                  "node '%s': on_max:pass requires an on_pass or next edge to route forward",
+                  n->id);
+         return -1;
+      }
+   }
+   return 0;
+}
+
 /* control-edge target must exist (dangling check). */
 static int check_edge(const wfe_def_t *def, const wfe_node_t *n, const char *edge,
                       const char *label, char *err, size_t errlen)
@@ -220,6 +253,8 @@ int wfe_def_validate(const wfe_def_t *def, char *err, size_t errlen)
       if (check_inputs(def, n, err, errlen) != 0)
          return -1;
       if (check_gate_rules(n, err, errlen) != 0)
+         return -1;
+      if (check_loop_cap(n, err, errlen) != 0)
          return -1;
       if (check_edge(def, n, n->next, "next", err, errlen) != 0)
          return -1;


### PR DESCRIPTION
## Generic user-definable workflow loop-back cap

Adds a generic, per-node loop-back cap to the WFE workflow engine — the "roundtable objects → return to a previous step, retry, then auto-resolve" pattern, usable by **any** workflow (not just roundtable review).

Any node may set:
- `max_iters` (positive int, default 20) — how many loop-back re-entries before the cap fires
- `on_max` — how the cap resolves: `human` (default; pause pending_human — unchanged effective behaviour), `fail` (terminal `rejected`), or `pass` (forced forward via `on_pass`/`next`)

### Slices
1. **def + validation** — `wfe_on_max_t`, `wfe_node_max_iters()`/`wfe_node_on_max()` accessors, validator (`max_iters>0`; `on_max ∈ {pass,fail,human}`; `on_max:pass` requires a forward edge)
2. **engine resolution** — generalizes the hardcoded `WFE_MAX_ATTEMPTS`; keys the attempt counter on the **gate node** (independent budgets for gates sharing a target; fixes the review block's latent key-mismatch); resolves per `on_max`. Reconciles the review block onto the unified cap.
3. **scaffold + fix** — `aimee workflow new` demos the cap (`max_iters:3, on_max:fail`); also fixes a pre-existing invalid scaffold (missing `pr.open` node / mis-bound merge input).

### Verification
- Full unit-test suite **468/0** on this branch
- `unit-test-wfe-engine`: fail→rejected, pass→forced-forward→accepted, human→pause (+ existing regressions)
- `unit-test-wfe-gate-reject`: accessors + validator accept/reject
- `aimee workflow new` + `validate` → `valid (4 nodes)`
- Python conformance checks not run locally (CI gate)

### Design note (roundtable-reviewed, APPROVED)
`on_max:pass` reuses `WFE_STEP_ADVANCED` + a distinct `forced_pass` lifecycle event rather than a new status enum, to avoid rippling a new enum through every switch.
