### PR TITLE
fix(kb): doc-curation pipeline never ran — drain backfills extract_doc jobs

### DIFF
--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1517,8 +1517,10 @@ typedef struct config
    int review_batch_cap;
 
    /* Deep curator extraction (kb.curator.*).
-    * kb_curator_extract_docs_enabled:  0 = off (default), 1 = queue extract_doc jobs post-ingest.
-    * kb_curator_extract_code_enabled:  0 = off (default), 1 = queue extract_code_unit jobs.
+    * kb_curator_extract_docs_enabled:  default ON (config_kb_curator_defaults). Queues extract_doc
+    *   jobs at ingest (kb_http hook) AND via the curator-drain backfill, so docs ingested
+    *   through the drain path (kb_doc_refresh) are curated too.
+    * kb_curator_extract_code_enabled:  default ON. 1 = queue extract_code_unit jobs.
     * kb_curator_extract_command[512]:  sidecar command (default: scripts/curator-extract.py).
     * kb_curator_extract_max_tokens:    max_tokens per job stdin payload (default 2048).
     * kb_curator_max_attempts:          max drain attempts per job before marking failed (default

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -278,13 +278,6 @@ static void *drain_thread_main(void *arg)
             int b = kb_doc_embed_backfill(projects[i].name, cfg.embedding_command, 200);
             if (b > 0)
                total += b;
-            /* Backfill: queue extract_doc curation for docs that entered
-             * kb_documents via this drain (kb_doc_refresh) rather than the
-             * ingest-route hook (kb_http) -- otherwise drain-ingested docs are
-             * never curated (no claims/narrative). Idempotent: dedups against
-             * existing extract_doc jobs, so it queues the backlog once then idles. */
-            if (cfg.kb_curator_extract_docs_enabled)
-               (void)kb_curator_queue_docs_for_project(projects[i].name);
          }
          if (total > 0)
             aimee_log(LOG_DEBUG, "kb.docs.ingest", "ingested %d doc chunk(s) across %d project(s)",
@@ -300,6 +293,11 @@ static void *drain_thread_main(void *arg)
                       "dim-change re-embed reconciled (doc corpus); cleared maintenance");
          }
       }
+
+      /* Backfill: queue extract_doc curation for docs that entered kb_documents
+       * via the drain (kb_doc_refresh) rather than the ingest-route hook -- else
+       * drain-ingested docs are never curated. Idempotent, self-gated. */
+      kb_curator_queue_docs_all_projects(cfg.kb_curator_extract_docs_enabled);
 
       /* Code projection-graph drain — publish a fresh typed-edge generation per
        * CHANGED project (content-addressed: an unchanged project is skipped), so

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -22,6 +22,7 @@
 #include "kb_curator_index_narrative.h"
 #include "kb_curator_index_claims.h"
 #include "kb_curator_contradictions.h"
+#include "kb_curator_queue.h"
 #include "kb_curator_index_code_unit.h"
 #include "kb_curator_link_artifacts.h"
 #include "kb_curator_synthesize.h"
@@ -277,6 +278,13 @@ static void *drain_thread_main(void *arg)
             int b = kb_doc_embed_backfill(projects[i].name, cfg.embedding_command, 200);
             if (b > 0)
                total += b;
+            /* Backfill: queue extract_doc curation for docs that entered
+             * kb_documents via this drain (kb_doc_refresh) rather than the
+             * ingest-route hook (kb_http) -- otherwise drain-ingested docs are
+             * never curated (no claims/narrative). Idempotent: dedups against
+             * existing extract_doc jobs, so it queues the backlog once then idles. */
+            if (cfg.kb_curator_extract_docs_enabled)
+               (void)kb_curator_queue_docs_for_project(projects[i].name);
          }
          if (total > 0)
             aimee_log(LOG_DEBUG, "kb.docs.ingest", "ingested %d doc chunk(s) across %d project(s)",

--- a/src/kb/kb_curator_queue.c
+++ b/src/kb/kb_curator_queue.c
@@ -11,6 +11,7 @@
 #include "kb_curator_queue.h"
 #include "aimee.h"
 #include "config.h"
+#include "index.h" /* index_list_projects, project_info_t */
 #include "log.h"
 #include "db2/kb_payload.h"
 #include "db2/db2_internal.h"
@@ -213,4 +214,14 @@ void kb_curator_queue_counts(kb_curator_queue_counts_t *out)
       }
       aimee_pg_finalize(st);
    }
+}
+
+void kb_curator_queue_docs_all_projects(int extract_docs_enabled)
+{
+   if (!extract_docs_enabled)
+      return;
+   project_info_t projects[128];
+   int np = index_list_projects(projects, (int)(sizeof(projects) / sizeof(projects[0])));
+   for (int i = 0; i < np; i++)
+      (void)kb_curator_queue_docs_for_project(projects[i].name);
 }

--- a/src/kb_curator_queue.h
+++ b/src/kb_curator_queue.h
@@ -8,6 +8,12 @@
  * Returns count of rows enqueued, -1 on fatal error. */
 int kb_curator_queue_docs_for_project(const char *project);
 
+/* Backfill sweep: enqueue extract_doc jobs for EVERY indexed project's un-jobbed
+ * docs. The curator drain calls this so docs ingested via the drain
+ * (kb_doc_refresh) -- not only the ingest route -- get curated. No-op when
+ * extract_docs_enabled is 0; per-project dedup makes it idempotent. */
+void kb_curator_queue_docs_all_projects(int extract_docs_enabled);
+
 /* Queue one extract_code_unit job when the curator code gate is enabled. */
 int kb_curator_queue_code_unit(const char *project, const char *file_path, const char *symbol,
                                int line);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -77,7 +77,7 @@ TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/rel_types.o $(OBJDIR)/memory_fact_g
 # linking both would produce duplicate-symbol errors.
 TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.o
 
-TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-spill $(TESTPREFIX)/unit-test-harness-memory-audit $(TESTPREFIX)/unit-test-harness-memory-hydrate $(TESTPREFIX)/unit-test-harness-memory-watch $(TESTPREFIX)/unit-test-roundtable-brief $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
+TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-spill $(TESTPREFIX)/unit-test-harness-memory-audit $(TESTPREFIX)/unit-test-harness-memory-hydrate $(TESTPREFIX)/unit-test-harness-memory-watch $(TESTPREFIX)/unit-test-roundtable-brief $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-curator-queue $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
@@ -727,6 +727,21 @@ $(TESTPREFIX)/unit-test-curator-invalidate: \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
 
 $(TESTPREFIX)/unit-test-curator-notify: $(OBJDIR)/tests/test_curator_notify.o $(OBJDIR)/kb/kb_curator_notify.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
+
+$(TESTPREFIX)/unit-test-curator-queue: \
+                                       $(OBJDIR)/tests/test_curator_queue.o \
+                                       $(OBJDIR)/kb/kb_curator_queue.o \
+                                       $(OBJDIR)/index.o \
+                                       $(OBJDIR)/db2/code_index.o \
+                                       $(OBJDIR)/db2/kb_payload.o \
+                                       $(OBJDIR)/db2/artifacts.o $(OBJDIR)/db2/kb_audit_worm.o $(OBJDIR)/audit_worm_chain.o $(OBJDIR)/workflow/wfe_canonical.o \
+                                       $(OBJDIR)/db2/feature_rows.o \
+                                       $(OBJDIR)/kb/kb_mdl.o \
+                                       $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
+                                       $(OBJDIR)/db2/db_schema.o \
+                                       $(OBJDIR)/cJSON.o \
+                                       $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
 
 $(TESTPREFIX)/unit-test-pgvec: $(OBJDIR)/tests/test_pgvec.o \

--- a/src/tests/test_curator_queue.c
+++ b/src/tests/test_curator_queue.c
@@ -1,0 +1,85 @@
+/* test_curator_queue.c: extract_doc job queueing — regression guard for the
+ * doc-curation pipeline. Ingested docs MUST get extract_doc jobs, and the drain
+ * MUST backfill docs that arrived via the drain (kb_doc_refresh), not only the
+ * ingest route. See kb_curator_queue.c + kb_curator_drain.c.
+ *
+ * (Asserts on the observable side effect — rows in kb_async_jobs — not the
+ * function return, whose exact value is a db2-backend detail.) */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <sqlite3.h>
+
+#include "aimee.h"
+#include "platform_test_util.h"
+#include "db2_test_shim.h"
+#include "../kb_curator_queue.h"
+
+static sqlite3 *open_db(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   assert(db != NULL);
+   return db;
+}
+static void seed(sqlite3 *db, const char *sql)
+{
+   char *e = NULL;
+   if (sqlite3_exec(db, sql, NULL, NULL, &e) != SQLITE_OK)
+   {
+      fprintf(stderr, "seed failed: %s\n  sql: %s\n", e ? e : "?", sql);
+      assert(0);
+   }
+}
+static int jobs(sqlite3 *db)
+{
+   sqlite3_stmt *st;
+   assert(sqlite3_prepare_v2(db, "SELECT count(*) FROM kb_async_jobs WHERE kind='extract_doc'", -1,
+                             &st, NULL) == SQLITE_OK);
+   assert(sqlite3_step(st) == SQLITE_ROW);
+   int n = sqlite3_column_int(st, 0);
+   sqlite3_finalize(st);
+   return n;
+}
+
+int main(void)
+{
+   /* Deterministic config: HOME with no aimee.yaml -> config_load (called inside
+    * the queue) returns built-in defaults (extract_docs default-ON). */
+   platform_setenv("HOME", "/tmp");
+   platform_unsetenv("AIMEE_HOME");
+   platform_setenv("AIMEE_NO_CACHE", "1");
+
+   printf("test_curator_queue:\n");
+   sqlite3 *db = open_db();
+
+   /* Contract: every non-pdf doc gets one extract_doc job; PDFs are excluded;
+    * re-running enqueues nothing. Guard for "docs present but zero jobs". */
+   seed(db, "INSERT INTO kb_documents (project,file_path,file_hash,chunk_index,content,doc_kind)"
+            " VALUES ('p','a.md','h1',0,'t','')");
+   seed(db, "INSERT INTO kb_documents (project,file_path,file_hash,chunk_index,content,doc_kind)"
+            " VALUES ('p','b.md','h2',0,'t','')");
+   seed(db, "INSERT INTO kb_documents (project,file_path,file_hash,chunk_index,content,doc_kind)"
+            " VALUES ('p','c.pdf','h3',0,'t','pdf')");
+   kb_curator_queue_docs_for_project("p");
+   assert(jobs(db) == 2); /* a.md + b.md; c.pdf excluded */
+   kb_curator_queue_docs_for_project("p");
+   assert(jobs(db) == 2); /* idempotent: no duplicates */
+   printf("  PASS: queue_docs_for_project (docs->jobs, pdf-excluded, idempotent)\n");
+
+   /* The exact regression: the drain backfill sweeps indexed projects and queues
+    * their docs. A drain-ingested doc (kb_documents + projects, no ingest hook)
+    * MUST be curated; the sweep is a no-op when disabled. */
+   seed(db, "INSERT INTO projects (name,root,scanned_at)"
+            " VALUES ('proj','/r','2026-01-01 00:00:00')");
+   seed(db, "INSERT INTO kb_documents (project,file_path,file_hash,chunk_index,content,doc_kind)"
+            " VALUES ('proj','x.md','h4',0,'t','')");
+   kb_curator_queue_docs_all_projects(0);
+   assert(jobs(db) == 2); /* disabled: no new jobs */
+   kb_curator_queue_docs_all_projects(1);
+   assert(jobs(db) == 3); /* +proj/x.md */
+   printf("  PASS: queue_docs_all_projects (drain backfill queues indexed docs; disabled=no-op)\n");
+
+   printf("test_curator_queue: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## The bug
The doc-curation pipeline (extract_doc → claims/narrative → index → **detect_contradictions**) never ran on the .254 stack: **17,290 documents, 0 `extract_doc` jobs**, `document_sections=0`, `curator_claim_vectors=0` — despite `extract_docs` being enabled.

**Root cause:** docs enter `kb_documents` two ways —
1. the `kb_http` ingest route, which queues `extract_doc` jobs via `kb_curator_queue_docs_for_project`, and
2. the curator **drain**'s `kb_doc_refresh` (the "in-ingest replacement for `kb build`"), which **queued nothing**.

So docs that arrive via the drain path are never curated — no claims, so the contradiction detector has nothing to work on. Enabling `extract_docs` after the fact never backfills, and there was no drain-side queue sweep (there are cold-start backfills for cross-repo metadata and doc-embeddings, but not for `extract_doc` queueing).

## Fix
After the drain's per-project doc refresh/embed, call `kb_curator_queue_docs_for_project` when `extract_docs` is enabled. Idempotent (dedups against existing `extract_doc` jobs) — queues the backlog once, then idles. Self-heals regardless of enable-timing.

Also: `extract_docs`/`extract_code` are **default-ON** (`config_kb_curator_defaults`); the config.h comment saying "0 = off (default)" was stale — corrected.

## Verification
Builds + links. **End-to-end pending :testing deploy** — will confirm on .254 that the 17k docs get queued → curated → claims appear → `detect_contradictions` links a real contradiction.