### PR TITLE
fix(kb): doc extraction produces parseable claims (provider path needs json_schema)

### DIFF
--- a/src/kb/kb_curator_extract.c
+++ b/src/kb/kb_curator_extract.c
@@ -40,6 +40,56 @@
    "and relations grounded only in that content. Respond with a single JSON "                      \
    "object matching the request's role. Do not invent facts."
 
+/* Engineer-mode extract_doc contract: names the exact artifact kinds + payload
+ * fields (claim => subject/attribute/value, matching index_claims) so the provider
+ * path yields claims the contradiction detector can index. Paired with the envelope
+ * schema (ce_build_extract_schema) that forces fence-free {status,artifacts} JSON —
+ * without both, the reasoning model markdown-fences its output and invents an
+ * envelope, so cJSON_Parse fails ("sidecar returned non-JSON"). */
+#define CE_EXTRACT_DOC_PROMPT                                                                      \
+   "You are a knowledge-base extractor. Read the JSON request (a document chunk with a `role` "    \
+   "and `input.content`) and extract structured knowledge grounded ONLY in that content; do not "  \
+   "invent facts. Respond with a single JSON object: {\"status\":\"ok\",\"artifacts\":[...]}. "    \
+   "Each "                                                                                         \
+   "artifact is {\"kind\":<kind>,\"payload\":<obj>}. Use these kinds and exact payload fields:\n"  \
+   "- \"doc_summary\" (exactly one): {\"summary\":<one "                                           \
+   "paragraph>,\"status\":\"draft|accepted|done|"                                                  \
+   "rejected|deferred\",\"priority\":\"low|medium|high\",\"components\":[<lowercase tags>]}\n"     \
+   "- \"claim\": {\"subject\":<what the claim is about>,\"attribute\":<the property/relation "     \
+   "asserted>,\"value\":<the asserted "                                                            \
+   "value>,\"claim_kind\":\"fact|requirement|constraint|decision|"                                 \
+   "behavior\",\"text\":<full claim as one sentence>}\n"                                           \
+   "- \"entity\": {\"name\":<canonical name>,\"entity_kind\":\"component|system|concept|protocol|" \
+   "data_store|tool\",\"context\":<short phrase>}\n"                                               \
+   "Emit a claim for each distinct factual assertion and an entity for each named "                \
+   "system/component/"                                                                             \
+   "concept."
+
+/* Build the extract envelope json-schema (caller frees). provider_client wraps it
+ * as response_format:{json_schema:{schema:<this>,strict}}. */
+static cJSON *ce_build_extract_schema(void)
+{
+   const char *ok_only[] = {"ok"};
+   const char *art_req[] = {"kind", "payload"};
+   const char *top_req[] = {"status", "artifacts"};
+   cJSON *sc = cJSON_CreateObject();
+   cJSON_AddStringToObject(sc, "type", "object");
+   cJSON *props = cJSON_AddObjectToObject(sc, "properties");
+   cJSON *status = cJSON_AddObjectToObject(props, "status");
+   cJSON_AddStringToObject(status, "type", "string");
+   cJSON_AddItemToObject(status, "enum", cJSON_CreateStringArray(ok_only, 1));
+   cJSON *arts = cJSON_AddObjectToObject(props, "artifacts");
+   cJSON_AddStringToObject(arts, "type", "array");
+   cJSON *items = cJSON_AddObjectToObject(arts, "items");
+   cJSON_AddStringToObject(items, "type", "object");
+   cJSON *iprops = cJSON_AddObjectToObject(items, "properties");
+   cJSON_AddStringToObject(cJSON_AddObjectToObject(iprops, "kind"), "type", "string");
+   cJSON_AddStringToObject(cJSON_AddObjectToObject(iprops, "payload"), "type", "object");
+   cJSON_AddItemToObject(items, "required", cJSON_CreateStringArray(art_req, 2));
+   cJSON_AddItemToObject(sc, "required", cJSON_CreateStringArray(top_req, 2));
+   return sc;
+}
+
 typedef struct
 {
    int64_t job_id;
@@ -380,8 +430,12 @@ int kb_curator_extract_one(const kb_curator_extract_opts_t *opts)
              (long long)job.document_id, cmd);
 
    char sidecar_err[512] = "";
-   char *resp_str = kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, CE_SYSTEM_PROMPT,
-                                       req_str, cmd, CE_OUTBUF, sidecar_err, sizeof(sidecar_err));
+   const char *sys_prompt = novel_mode ? CE_SYSTEM_PROMPT : CE_EXTRACT_DOC_PROMPT;
+   cJSON *extract_schema = ce_build_extract_schema();
+   char *resp_str =
+       kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, sys_prompt, req_str, extract_schema,
+                          cmd, CE_OUTBUF, sidecar_err, sizeof(sidecar_err));
+   cJSON_Delete(extract_schema);
    free(req_str);
 
    if (!resp_str)

--- a/src/kb/kb_curator_judge.c
+++ b/src/kb/kb_curator_judge.c
@@ -70,7 +70,7 @@ int kb_curator_judge_same_entity(const config_t *cfg, const char *judge_cmd,
     * judge_cmd sidecar; "neither configured" surfaces as -1 (caller treats as
     * not-same / create). */
    char local_err[256];
-   char *response = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_JUDGE, CJ_SYSTEM_PROMPT, request,
+   char *response = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_JUDGE, CJ_SYSTEM_PROMPT, request, NULL,
                                        judge_cmd, 0, local_err, sizeof(local_err));
    free(request);
    if (!response)

--- a/src/kb/kb_curator_llm.c
+++ b/src/kb/kb_curator_llm.c
@@ -40,8 +40,8 @@ static cJSON *build_messages(const char *system_prompt, const char *request_json
 }
 
 char *kb_curator_llm_run(const config_t *cfg, kb_curator_stage_t stage, const char *system_prompt,
-                         const char *request_json, const char *fallback_command, int out_cap,
-                         char *errbuf, size_t errlen)
+                         const char *request_json, cJSON *json_schema, const char *fallback_command,
+                         int out_cap, char *errbuf, size_t errlen)
 {
    if (errbuf && errlen)
       errbuf[0] = '\0';
@@ -60,7 +60,7 @@ char *kb_curator_llm_run(const config_t *cfg, kb_curator_stage_t stage, const ch
       /* provider_client_complete zeroes out on entry, but zero-init here too so
        * provider_completion_free is unconditionally safe regardless of the callee. */
       provider_completion_t out = {0};
-      int rc = provider_client_complete(&def, msgs, NULL, &out, errbuf, errlen);
+      int rc = provider_client_complete(&def, msgs, json_schema, &out, errbuf, errlen);
       cJSON_Delete(msgs);
       if (rc != 0)
       {

--- a/src/kb/kb_curator_llm.h
+++ b/src/kb/kb_curator_llm.h
@@ -27,9 +27,13 @@ extern "C"
     * Returns the response body (caller frees) or NULL. out_cap bounds the sidecar
     * stdout capture ONLY; the provider path returns the full HTTP response body
     * (its length is governed by the model/max_tokens, not out_cap). */
+   /* json_schema (optional, provider path only): sent as an OpenAI response_format
+    * json_schema so the model returns strict, fence-free JSON in that shape. The
+    * sidecar fallback ignores it (it carries its own prompt contract). */
    char *kb_curator_llm_run(const config_t *cfg, kb_curator_stage_t stage,
                             const char *system_prompt, const char *request_json,
-                            const char *fallback_command, int out_cap, char *errbuf, size_t errlen);
+                            struct cJSON *json_schema, const char *fallback_command, int out_cap,
+                            char *errbuf, size_t errlen);
 
 #ifdef __cplusplus
 }

--- a/src/kb/kb_curator_synthesize.c
+++ b/src/kb/kb_curator_synthesize.c
@@ -251,7 +251,7 @@ int kb_curator_synthesize_one(const kb_curator_extract_opts_t *opts)
 
    char serr[256];
    char *response = kb_curator_llm_run(
-       &cfg, KB_CURATOR_STAGE_SYNTHESIZE, CURATOR_SYNTH_SYSTEM_PROMPT, request,
+       &cfg, KB_CURATOR_STAGE_SYNTHESIZE, CURATOR_SYNTH_SYSTEM_PROMPT, request, NULL,
        cfg.kb_curator_synthesize_command, CURATOR_SYNTH_OUTBUF, serr, sizeof(serr));
    free(request);
    if (!response)

--- a/src/kb/kb_memory_facts.c
+++ b/src/kb/kb_memory_facts.c
@@ -271,8 +271,8 @@ static int mf_process_one(const config_t *cfg, const mf_job_t *job)
    mf_build_system_prompt(sys_prompt, sizeof(sys_prompt));
 
    char err[MF_ERRBUF] = "";
-   char *resp = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, sys_prompt, request_json, "",
-                                   MF_LLM_OUT_CAP, err, sizeof(err));
+   char *resp = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, sys_prompt, request_json,
+                                   NULL, "", MF_LLM_OUT_CAP, err, sizeof(err));
    free(request_json);
    if (!resp)
    {

--- a/src/kb/kb_surprising_judge.c
+++ b/src/kb/kb_surprising_judge.c
@@ -149,7 +149,7 @@ int kb_surprising_judge(const config_t *cfg, const char *judge_cmd, const char *
    }
 
    char local_err[256];
-   char *response = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_JUDGE, SJ_SYSTEM_PROMPT, request,
+   char *response = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_JUDGE, SJ_SYSTEM_PROMPT, request, NULL,
                                        judge_cmd, 0, local_err, sizeof(local_err));
    free(request);
    if (!response)

--- a/src/tests/test_kb_curator_llm.c
+++ b/src/tests/test_kb_curator_llm.c
@@ -57,7 +57,7 @@ static void test_provider_path(void)
    char err[256];
    char *resp =
        kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, "be-a-curator", "{\"topic\":\"t\"}",
-                          "" /* no fallback */, 16384, err, sizeof(err));
+                          NULL, "" /* no fallback */, 16384, err, sizeof(err));
    assert(resp != NULL);
    assert(strcmp(resp, "{\"synthesis\":\"ok\"}") == 0);
    assert(strcmp(g_seen_url, "http://big/v1/chat/completions") == 0);
@@ -81,8 +81,8 @@ static void test_provider_error(void)
    snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
 
    char err[256] = "";
-   char *resp = kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, "sys", "{}", "", 16384, err,
-                                   sizeof(err));
+   char *resp = kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, "sys", "{}", NULL, "", 16384,
+                                   err, sizeof(err));
    assert(resp == NULL);
    assert(err[0] != '\0');
    mock_agent_http_reset();
@@ -102,8 +102,8 @@ static void test_idle_when_unconfigured(void)
    snprintf(cfg.kb_curator_provider_model, sizeof(cfg.kb_curator_provider_model), "small");
 
    char err[256] = "";
-   char *resp = kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, "sys", "{}", "", 16384, err,
-                                   sizeof(err));
+   char *resp = kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, "sys", "{}", NULL, "", 16384,
+                                   err, sizeof(err));
    assert(resp == NULL);
    assert(err[0] != '\0'); /* "no curator provider or command configured" */
    printf("kb_curator_llm: idle when tier unconfigured (no tier-A fallback) ok\n");


### PR DESCRIPTION
## Context
Follows #1157 (which fixed the doc-curation *queueing* — 17k docs now queue). With the pipeline running, **every `extract_doc` job failed** with `sidecar returned non-JSON`, so no claims → the contradiction detector stays idle.

## Root cause (reproduced against gpu-mid)
The provider path (`kb_curator_llm_run`) passed **`NULL`** as the json_schema. Probing the exact request against gpu-mid:

| variant | parseable? | output |
|---|---|---|
| no-schema (current) | ❌ | ` ```json`-fenced, `{"entities":[…]}` (wrong envelope) |
| **+ json_schema** | ✅ | clean `{"status":"ok","artifacts":[{"kind":"claim","payload":{"subject","attribute","value",…}}]}` |

The reasoning model markdown-fences its JSON and invents an envelope; `cJSON_Parse` fails. The legacy python sidecar masked this with `strip_fences` — the in-process provider path has none.

## Fix (both halves the ask called for)
1. **Provider path** — thread an optional `json_schema` through `kb_curator_llm_run` → `provider_client_complete` (was hardcoded `NULL`; 4 other callers pass `NULL`).
2. **Schema** — `extract_docs` passes an envelope schema (`status:"ok"` + `artifacts:[{kind,payload}]`) so gpu-mid returns strict, fence-free JSON.
3. **Prompt** — enrich the engineer-mode prompt to name the exact payload fields, so claims come back as `{subject,attribute,value,claim_kind,text}` (the contract `index_claims`/`detect_contradictions` need). The old vague prompt made the model emit `{subject,predicate,object}`. Novel mode keeps its prompt.

## Validation
**Empirical** — an LLM-behavior fix can't be asserted in CI. Probed against gpu-mid: `status:ok`, parseable, claims in the exact `{subject,attribute,value}` shape (e.g. `{"subject":"aimee KB","attribute":"default port","value":"8741"}`). The schema→`response_format` mechanism is covered by `test_provider_client.c`. **End-to-end proof on .254 to follow** (claims populate → a real contradiction links).