### PR TITLE
feat(guard): honour Codex worktrees (.codex/worktrees/)

### DIFF
--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -565,18 +565,20 @@ static void attn_lexical_normalize(const char *path, char *out, size_t out_n)
 }
 
 /* Returns 1 iff `norm` (an already lexically-normalized path) is inside a
- * managed session worktree. Matches the two canonical managed locations:
+ * managed session worktree. Matches the canonical managed locations:
  *   "/.aimee/worktrees/"  — aimee's own launcher + delegate worktrees
  *   "/.claude/worktrees/" — Claude Code's native worktrees (EnterWorktree)
- * Both are isolated worktrees on a branch off the default branch — the exact
- * isolation this guard requires — so a Claude Code session working in its own
- * worktree is honoured, not blocked. Deliberately the full "/worktrees/" path,
+ *   "/.codex/worktrees/"  — Codex's native worktrees
+ * All are isolated worktrees on a branch off the default branch — the exact
+ * isolation this guard requires — so a Claude Code / Codex session working in its
+ * own worktree is honoured, not blocked. Deliberately the full "/worktrees/" path,
  * NOT the looser "/.aimee-" / "/.claude" prefixes, which would false-match
  * unrelated dirs like "/home/u/.aimee-notes/..." or "~/.claude/". */
 static int attn_path_in_managed_worktree(const char *norm)
 {
    return norm && (strstr(norm, "/.aimee/worktrees/") != NULL ||
-                   strstr(norm, "/.claude/worktrees/") != NULL);
+                   strstr(norm, "/.claude/worktrees/") != NULL ||
+                   strstr(norm, "/.codex/worktrees/") != NULL);
 }
 
 /* Pure decision for the session-isolation guard (testable in isolation).

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -203,6 +203,14 @@ static void test_session_isolation_decision(void)
    /* The loose "/.claude" prefix (e.g. ~/.claude/) is NOT a managed worktree. */
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "/home/u/.claude/x.c", primary_cwd) == 1);
 
+   /* Codex's native worktrees (/.codex/worktrees/) are honoured the same way. */
+   const char *cx_wt = "/home/u/repo/.codex/worktrees/feat/src/x.c";
+   const char *cx_wt_cwd = "/home/u/repo/.codex/worktrees/feat";
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, cx_wt, primary_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, cx_wt_cwd) == 0);
+   /* The loose "/.codex" prefix is NOT a managed worktree. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "/home/u/.codex/x.c", primary_cwd) == 1);
+
    /* The loose "/.aimee-" prefix is NOT treated as a managed worktree (only the
     * canonical "/.aimee/worktrees/" counts) — avoids false-matching e.g. a
     * user's "/.aimee-notes" dir. */


### PR DESCRIPTION
## What
Extends the session-isolation guard to honour **Codex's native worktrees** (`/.codex/worktrees/`), completing #1144 which added Claude Code's `/.claude/worktrees/` alongside aimee's own `/.aimee/worktrees/`.

Codex uses the same model — an isolated checkout on a branch off the default branch — which is exactly the isolation this guard requires, so a Codex agent in `.codex/worktrees/<name>` should be honoured, not have every mutation blocked.

One-line change in `attn_path_in_managed_worktree` + a parallel unit test (`test_attention_guard`): honoured as target path or cwd; the loose `~/.codex/` prefix is still correctly *not* a managed worktree. Local test passes.

## Context / follow-up
This is the guard-acceptance half. Full lifecycle **management** of `.claude`/`.codex` worktrees — `workspace.c` still hardcodes `/.aimee/worktrees/` for worktree creation, the `registry.tsv`, GC, and session adoption — is a larger, design-heavy follow-up (so aimee would *manage* and branch-associate these the same as its own, and adopt the worktree a session is already in instead of spawning a redundant `.aimee` one). Flagged, not done here.