### PR TITLE
feat(gui): help text for the 13 curator stage config flags

### DIFF
--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -30,6 +30,33 @@ export const SECTION_HELP: Record<string, string> = {
 
 // One line per config key. Plain language, states the default.
 export const FIELD_HELP: Record<string, string> = {
+  // Knowledge curation — curator pipeline stage gates (see the Pipeline tab)
+  kb_curator_extract_docs_enabled:
+    "Curator: extract structured claims and entities from ingested documents (LLM). The entry stage for document knowledge; feeds claim indexing and contradiction detection.",
+  kb_curator_extract_code_enabled:
+    "Curator: extract code units (functions/types) from indexed source for the code knowledge graph (LLM).",
+  kb_curator_resolve_entities_enabled:
+    "Curator: resolve and deduplicate extracted entities into canonical records (LLM).",
+  kb_curator_index_narrative_enabled:
+    "Curator: embed narrative summaries into the vector store (CPU/index lane).",
+  kb_curator_index_claims_enabled:
+    "Curator: embed extracted claims into curator_claim_vectors — the prerequisite for contradiction detection (CPU/index lane).",
+  kb_curator_detect_contradictions_enabled:
+    "Curator: flag contradicting claims (same subject + attribute, different value) as 'contradicts' artifact links (CPU/index lane). Requires claim indexing to be on.",
+  kb_curator_index_code_unit_enabled:
+    "Curator: embed extracted code units into the vector store (CPU/index lane).",
+  kb_curator_link_artifacts_enabled:
+    "Curator: build relationship links between related artifacts (CPU/index lane).",
+  kb_curator_synthesize_enabled:
+    "Curator: synthesize per-topic summaries from clustered knowledge (LLM).",
+  kb_curator_promote_entity_enabled:
+    "Curator: promote well-supported entities to durable canonical status (LLM).",
+  kb_curator_projection_graph_enabled:
+    "Curator: publish the code projection graph (typed edges per changed project) and refresh cross-repo metadata (CPU/index lane).",
+  kb_curator_cross_repo_graph_enabled:
+    "Curator: keep cross-repo precision metadata (identities, routes, build deps, distinctiveness) fresh; also gates cross-repo dependency resolution. Refreshed alongside the projection graph.",
+  kb_evidence_embed_enabled:
+    "Curator: embed evidence spans backing each claim, for grounding and citation (CPU/index lane).",
   // Providers & delegates
   guardrail_mode:
     "How aimee handles a risky tool call: 'approve' asks you first (default), 'prompt' warns but proceeds, 'deny' refuses it outright.",


### PR DESCRIPTION
The curator stage gates added in Phase 4 (`kb_curator_*_enabled` + `kb_evidence_embed_enabled`) had no `FIELD_HELP` entries — they rendered without descriptions in Settings and the Pipeline tab. Adds a concise one-line description per stage (what it does + its lane). Frontend-only; `tsc -b` clean; no config-docs impact (the generator reads `cli_help_data.h`, not the frontend).