### PR TITLE
feat(gui): curator stage registry endpoint — single source of truth (Phase 4 Option B)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -2432,6 +2432,11 @@ paths:
       summary: Curator invalidated claims
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Invalidated, content: { application/json: { schema: { type: object } } } } }
+  /curator/stages:
+    post:
+      summary: Curator pipeline stage registry (name/label/lane/order/config_key) for the GUI
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: Stage registry, content: { application/json: { schema: { type: object } } } } }
   /graph/explain:
     post:
       summary: Explain a graph relationship

--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -1,48 +1,34 @@
 import { useCallback, useEffect, useState } from "react";
+import { FIELD_HELP } from "./settingsHelp";
 
-/* Pipeline page: the curator pipeline as an ordered, resource-lane-grouped view of
- * the stage registry (mirrors CURATOR_STAGES in src/kb/kb_curator_drain.c). Each
- * stage's enable flag comes from GET /api/config and toggles via POST
- * /api/config/set (persisted to aimee.yaml; the KB picks it up on next load).
+/* Pipeline page: the curator pipeline as an ordered, resource-lane-grouped view.
  *
- * NB: STAGES below mirrors the C registry (name/lane/order). Keep in sync when
- * stages are added/reordered there — the enable state is live from config, but the
- * lane/order/labels are presentational metadata. */
+ * Option B (single source of truth): the stage list, order, lanes, and the
+ * config key that toggles each stage come LIVE from the backend registry via
+ * POST /api/curator/stages (curator.stages -> CURATOR_STAGES + the projection
+ * sweeps in src/kb/kb_curator_drain.c). There is no hand-kept frontend mirror to
+ * drift. Enable state comes from GET /api/config and toggles via POST
+ * /api/config/set (persisted to aimee.yaml; the KB picks it up on next load). A
+ * stage with a null config_key is embedder-gated (active whenever an embedder is
+ * configured) and shown read-only. Descriptions come from the shared FIELD_HELP. */
 
 type Val = boolean | number | string;
-type Lane = "LLM" | "INDEX";
-type Stage = { key: string; label: string; lane: Lane; desc: string; gated?: "embedder" };
+type Lane = "llm" | "index";
+type Stage = {
+  name: string;
+  label: string;
+  lane: Lane;
+  budget: number;
+  order: number;
+  config_key: string | null;
+};
 
-// Registry order. LLM = GPU-bound (one/pass); INDEX = CPU-bound (drains each pass).
-const STAGES: Stage[] = [
-  { key: "kb_curator_extract_docs_enabled", label: "Extract docs", lane: "LLM", desc: "LLM-extract a document chunk into claims / entities / doc_summary." },
-  { key: "kb_curator_extract_code_enabled", label: "Extract code", lane: "LLM", desc: "Extract a code symbol into a code_unit artifact." },
-  { key: "kb_curator_resolve_entities_enabled", label: "Resolve entities", lane: "LLM", desc: "Resolve entity mentions against the canonical entity graph." },
-  { key: "kb_curator_synthesize_enabled", label: "Synthesize", lane: "LLM", desc: "Synthesize a topic summary from committed artifacts." },
-  { key: "kb_curator_promote_entity_enabled", label: "Promote entity", lane: "LLM", desc: "Promote a recurrent entity to the canonical registry." },
-  { key: "kb_curator_index_narrative_enabled", label: "Index narrative", lane: "INDEX", desc: "Embed doc_summary / narrative text." },
-  { key: "kb_curator_index_claims_enabled", label: "Index claims", lane: "INDEX", desc: "Embed each claim's subject/attribute/value into the claim-vector store." },
-  { key: "kb_curator_detect_contradictions_enabled", label: "Detect contradictions", lane: "INDEX", desc: "Self-join claim vectors: same subject+attribute, different value → contradicts link." },
-  { key: "kb_curator_index_code_unit_enabled", label: "Index code_unit", lane: "INDEX", desc: "Embed code_unit artifacts." },
-  { key: "kb_curator_link_artifacts_enabled", label: "Link artifacts", lane: "INDEX", desc: "Link related artifacts (implements / relates-to)." },
-  { key: "kb_curator_projection_graph_enabled", label: "Projection graph", lane: "INDEX", desc: "Publish a fresh typed-edge generation per changed project." },
-  { key: "kb_curator_cross_repo_graph_enabled", label: "Cross-repo graph", lane: "INDEX", desc: "Rebuild cross-repo identities / routes / distinctiveness model." },
-  { key: "kb_evidence_embed_enabled", label: "Embed evidence", lane: "INDEX", desc: "Fill evidence_vectors for the neighbourhood builder." },
-];
-// Embedder-gated stages (no config toggle — active whenever an embedder is configured).
-const GATED: Stage[] = [
-  { key: "embed_code", label: "Embed code", lane: "INDEX", desc: "Embed changed files into the code-vector layer.", gated: "embedder" },
-  { key: "ingest_docs", label: "Ingest docs", lane: "INDEX", desc: "Chunk + embed prose/doc files into kb_documents.", gated: "embedder" },
-];
+const csrf = () => ({ "X-CSRF-Token": window._csrf || "" });
 
-async function getJSON<T>(url: string): Promise<T> {
-  const r = await fetch(url, { headers: { "X-CSRF-Token": window._csrf || "" } });
-  return (await r.json()) as T;
-}
 async function postJSON(url: string, body: unknown): Promise<{ status: number; error?: string }> {
   const r = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json", "X-CSRF-Token": window._csrf || "" },
+    headers: { "Content-Type": "application/json", ...csrf() },
     body: JSON.stringify(body),
   });
   let d: { error?: string } = {};
@@ -51,20 +37,34 @@ async function postJSON(url: string, body: unknown): Promise<{ status: number; e
 }
 
 const LANE_META: Record<Lane, { title: string; hint: string; color: string }> = {
-  LLM: { title: "LLM lane · GPU", hint: "One unit per pass — extraction/reasoning on the GPU model.", color: "#8cf" },
-  INDEX: { title: "Index lane · CPU", hint: "Drains its queue each pass — embedding + SQL, concurrent with the GPU lane.", color: "#7d7" },
+  llm: { title: "LLM lane · GPU", hint: "One unit per pass — extraction/reasoning on the GPU model.", color: "#8cf" },
+  index: { title: "Index lane · CPU", hint: "Drains its queue each pass — embedding + SQL, concurrent with the GPU lane.", color: "#7d7" },
 };
 
+const DEFAULT_DESC = "Active whenever an embedder is configured (no individual toggle).";
+
 export default function Pipeline() {
+  const [stages, setStages] = useState<Stage[]>([]);
   const [cfg, setCfg] = useState<Record<string, Val>>({});
   const [loaded, setLoaded] = useState(false);
   const [busy, setBusy] = useState<string>("");
   const [status, setStatus] = useState<{ kind: "ok" | "err"; msg: string } | null>(null);
 
   const refresh = useCallback(() => {
-    getJSON<{ config?: Record<string, Val> }>("/api/config")
-      .then((d) => { setCfg(d.config || {}); setLoaded(true); })
-      .catch(() => setLoaded(true));
+    Promise.all([
+      fetch("/api/curator/stages", { method: "POST", headers: { "Content-Type": "application/json", ...csrf() }, body: "{}" })
+        .then((r) => r.json())
+        .then((d: { stages?: Stage[] }) => d.stages || [])
+        .catch(() => [] as Stage[]),
+      fetch("/api/config", { headers: csrf() })
+        .then((r) => r.json())
+        .then((d: { config?: Record<string, Val> }) => d.config || {})
+        .catch(() => ({} as Record<string, Val>)),
+    ]).then(([s, c]) => {
+      setStages([...s].sort((a, b) => a.order - b.order));
+      setCfg(c);
+      setLoaded(true);
+    });
   }, []);
   useEffect(() => { refresh(); }, [refresh]);
 
@@ -80,28 +80,30 @@ export default function Pipeline() {
     }
   }, []);
 
-  const enabled = (k: string) => cfg[k] === true || cfg[k] === 1;
+  const isOn = (k: string) => cfg[k] === true || cfg[k] === 1;
 
   const row = (s: Stage, i: number) => {
-    const on = s.gated ? true : enabled(s.key);
+    const gated = !s.config_key;
+    const on = gated ? true : isOn(s.config_key as string);
+    const desc = (s.config_key && FIELD_HELP[s.config_key]) || DEFAULT_DESC;
     return (
-      <div key={s.key} style={{
+      <div key={s.name} style={{
         display: "flex", alignItems: "center", gap: 12, padding: "8px 12px",
-        borderBottom: "1px solid #eee", opacity: s.gated ? 0.75 : 1,
+        borderBottom: "1px solid #eee", opacity: gated ? 0.75 : 1,
       }}>
         <span style={{ width: 22, color: "#aaa", fontSize: 12, fontFamily: "ui-monospace, monospace" }}>{i + 1}</span>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontWeight: 600, fontSize: 14 }}>{s.label}
-            {s.gated && <span style={{ marginLeft: 8, fontSize: 11, color: "#999" }}>(embedder-gated)</span>}
+            {gated && <span style={{ marginLeft: 8, fontSize: 11, color: "#999" }}>(embedder-gated)</span>}
           </div>
-          <div style={{ fontSize: 12, color: "#777" }}>{s.desc}</div>
+          <div style={{ fontSize: 12, color: "#777" }}>{desc}</div>
         </div>
-        {s.gated ? (
+        {gated ? (
           <span style={{ fontSize: 12, color: "#7d7", whiteSpace: "nowrap" }}>● active</span>
         ) : (
           <button
-            disabled={busy === s.key}
-            onClick={() => toggle(s.key, !on)}
+            disabled={busy === s.config_key}
+            onClick={() => toggle(s.config_key as string, !on)}
             title={on ? "Disable stage" : "Enable stage"}
             style={{
               width: 52, height: 26, borderRadius: 13, border: "1px solid #ccc", cursor: "pointer",
@@ -120,28 +122,32 @@ export default function Pipeline() {
 
   if (!loaded) return <div style={{ padding: 24, color: "#888" }}>Loading pipeline…</div>;
 
-  const all = [...STAGES, ...GATED];
   return (
     <div style={{ padding: "18px 24px", maxWidth: 860, margin: "0 auto", fontFamily: "system-ui" }}>
       <h2 style={{ margin: "0 0 4px" }}>Curator pipeline</h2>
       <p style={{ color: "#777", fontSize: 13, margin: "0 0 18px" }}>
         Ingested content flows through these stages into curated knowledge (claims, entities,
         contradictions, graph). Toggle a stage to include/exclude it; changes persist to aimee.yaml and
-        take effect on the KB's next config load. Stages run in two resource lanes concurrently.
+        take effect on the KB's next config load. Stages run in two resource lanes concurrently, and this
+        view is generated live from the backend stage registry.
       </p>
-      {(["LLM", "INDEX"] as Lane[]).map((lane) => {
+      {(["llm", "index"] as Lane[]).map((lane) => {
         const meta = LANE_META[lane];
-        const stages = all.filter((s) => s.lane === lane);
+        const laneStages = stages.filter((s) => s.lane === lane);
+        if (!laneStages.length) return null;
         return (
           <div key={lane} style={{ marginBottom: 22, border: "1px solid #e2e2e2", borderRadius: 8, overflow: "hidden" }}>
             <div style={{ padding: "8px 12px", background: "#fafafa", borderBottom: "1px solid #e2e2e2" }}>
               <span style={{ fontWeight: 700, color: meta.color }}>{meta.title}</span>
               <span style={{ marginLeft: 10, fontSize: 12, color: "#999" }}>{meta.hint}</span>
             </div>
-            {stages.map((s, i) => row(s, i))}
+            {laneStages.map((s, i) => row(s, i))}
           </div>
         );
       })}
+      {!stages.length && (
+        <div style={{ color: "#888" }}>No stages reported (aimee-server unreachable, or the KB has no curator registry).</div>
+      )}
       {status && (
         <div style={{ fontSize: 13, color: status.kind === "ok" ? "#2a2" : "#c33", marginTop: 8 }}>{status.msg}</div>
       )}

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -621,6 +621,7 @@ static const struct
     {"curator.contradictions", "POST", "/v1/curator/contradictions"},
     {"curator.implements", "POST", "/v1/curator/implements"},
     {"curator.invalidated", "POST", "/v1/curator/invalidated"},
+    {"curator.stages", "POST", "/v1/curator/stages"},
     {"dashboard.all", "GET", "/v1/dashboard/all"},
     {"dashboard.audit", "GET", "/v1/dashboard/audit"},
     {"dashboard.delegations", "GET", "/v1/dashboard/delegations"},

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -38,6 +38,7 @@
 #include "aimee.h"
 #include "config.h"
 #include "kb_background.h"
+#include "cJSON.h"
 #include "log.h"
 
 #include <pthread.h>
@@ -324,6 +325,66 @@ static const kb_curator_stage_desc_t CURATOR_STAGES[] = {
     {"embed_evidence", "embed evidence", en_evidence_embed, stage_embed_evidence, 1,
      KB_CURATOR_LANE_INDEX},
 };
+
+/* Option B (single source of truth): expose the stage registry as data so the
+ * Pipeline GUI renders from the running backend instead of a hand-kept mirror.
+ * Returns a fresh cJSON array [{name,label,lane,budget,order,config_key}]; the
+ * caller owns it. `config_key` is the aimee.yaml flag the GUI toggles via
+ * config.set: embed_code/ingest_docs are gated on the embedder command (no
+ * individual flag) so they report null (read-only); embed_evidence uses
+ * kb_evidence_embed_enabled; every other stage uses kb_curator_<name>_enabled
+ * (the en_* predicate convention above). */
+cJSON *kb_curator_stages_json(void)
+{
+   cJSON *arr = cJSON_CreateArray();
+   size_t n = sizeof(CURATOR_STAGES) / sizeof(CURATOR_STAGES[0]);
+   for (size_t i = 0; i < n; i++)
+   {
+      const kb_curator_stage_desc_t *st = &CURATOR_STAGES[i];
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddStringToObject(o, "name", st->name);
+      cJSON_AddStringToObject(o, "label", st->label);
+      cJSON_AddStringToObject(o, "lane", st->lane == KB_CURATOR_LANE_LLM ? "llm" : "index");
+      cJSON_AddNumberToObject(o, "budget", st->budget);
+      cJSON_AddNumberToObject(o, "order", (double)i);
+      if (strcmp(st->name, "embed_code") == 0 || strcmp(st->name, "ingest_docs") == 0)
+         cJSON_AddNullToObject(o, "config_key");
+      else if (strcmp(st->name, "embed_evidence") == 0)
+         cJSON_AddStringToObject(o, "config_key", "kb_evidence_embed_enabled");
+      else
+      {
+         char key[96];
+         snprintf(key, sizeof(key), "kb_curator_%s_enabled", st->name);
+         cJSON_AddStringToObject(o, "config_key", key);
+      }
+      cJSON_AddItemToArray(arr, o);
+   }
+   /* The projection-graph + cross-repo refresh run on the INDEX lane via
+    * kb_curator_projection_sweep (batch sweeps, not per-item CURATOR_STAGES
+    * entries) -- but they ARE user-togglable pipeline steps, so surface them for
+    * the GUI too, after the registry stages. */
+   {
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddStringToObject(o, "name", "projection_graph");
+      cJSON_AddStringToObject(o, "label", "projection graph");
+      cJSON_AddStringToObject(o, "lane", "index");
+      cJSON_AddNumberToObject(o, "budget", 1);
+      cJSON_AddNumberToObject(o, "order", (double)n);
+      cJSON_AddStringToObject(o, "config_key", "kb_curator_projection_graph_enabled");
+      cJSON_AddItemToArray(arr, o);
+   }
+   {
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddStringToObject(o, "name", "cross_repo_graph");
+      cJSON_AddStringToObject(o, "label", "cross-repo graph");
+      cJSON_AddStringToObject(o, "lane", "index");
+      cJSON_AddNumberToObject(o, "budget", 1);
+      cJSON_AddNumberToObject(o, "order", (double)(n + 1));
+      cJSON_AddStringToObject(o, "config_key", "kb_curator_cross_repo_graph_enabled");
+      cJSON_AddItemToArray(arr, o);
+   }
+   return arr;
+}
 
 static void *drain_thread_main(void *arg)
 {

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -16,6 +16,7 @@
 #include "memory.h"
 #include "lifecycle.h"
 #include "kb_vectors.h"
+#include "kb_curator_drain.h" /* kb_curator_stages_json — Option B registry endpoint */
 #include <errno.h>
 #include <pthread.h>
 #include <stdint.h>
@@ -908,6 +909,18 @@ static int kb_handle_learning_mutate(int fd, cJSON *req, const char *verb)
    return srv_rc;
 }
 
+/* curator.stages: the curator stage registry as data for the Pipeline GUI to
+ * render dynamically (Option B — single source of truth, no hand-kept mirror). */
+static int kb_handle_curator_stages(int fd, cJSON *req)
+{
+   (void)req;
+   cJSON *resp = jo_ok();
+   cJSON_AddItemToObject(resp, "stages", kb_curator_stages_json());
+   int rc = kb_send_response(fd, resp);
+   cJSON_Delete(resp);
+   return rc;
+}
+
 /* Method -> handler dispatch for the uniform `int (int fd, cJSON *req)` kb RPCs.
  * The handful that do not fit that shape stay inline in kb_handle_request
  * (server.info / server.health, which read ctx; the learning.* mutate verbs,
@@ -926,6 +939,7 @@ static const struct
    kb_rpc_fn fn;
 } kb_rpc_table[] = {
     {"kb.file.get", kb_handle_file_get},
+    {"curator.stages", kb_handle_curator_stages},
     {"kb.maintenance.run", kb_handle_maintenance_run},
     {"kb.export", kb_handle_kb_export},
     {"kb.import", kb_handle_kb_import},

--- a/src/kb_curator_drain.h
+++ b/src/kb_curator_drain.h
@@ -20,4 +20,11 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx);
 /* Stop the drain thread and wait for it to exit. */
 void kb_curator_drain_shutdown(kb_curator_drain_ctx_t *ctx);
 
+/* Option B (single source of truth): the curator stage registry as JSON, for
+ * the Pipeline GUI to render dynamically. Returns a fresh cJSON array
+ * [{name,label,lane,budget,order,config_key}]; the caller owns it
+ * (cJSON_Delete). Defined in kb_curator_drain.c beside CURATOR_STAGES. */
+struct cJSON;
+struct cJSON *kb_curator_stages_json(void);
+
 #endif /* DEC_KB_CURATOR_DRAIN_H */

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -1986,6 +1986,7 @@ static const http_route_t g_v1_routes[] = {
      rh_dispatch_op},
     {"POST", "/v1/curator/implements", NULL, RM_EXACT, "curator.implements", 0, rh_dispatch_op},
     {"POST", "/v1/curator/invalidated", NULL, RM_EXACT, "curator.invalidated", 0, rh_dispatch_op},
+    {"POST", "/v1/curator/stages", NULL, RM_EXACT, "curator.stages", 0, rh_dispatch_op},
     {"POST", "/v1/graph/explain", NULL, RM_EXACT, "graph.explain", 0, rh_dispatch_op},
     {"POST", "/v1/code/audit", NULL, RM_EXACT, "code.audit", 0, rh_dispatch_op},
     {"POST", "/v1/audit/trace", NULL, RM_EXACT, "evidence.trace_retrieval_event", 0,


### PR DESCRIPTION
## What
Replaces the Pipeline page's hand-kept frontend mirror of the C stage registry with a **live backend endpoint**, so `CURATOR_STAGES` is the single source of truth for the pipeline view (the roundtable's "future evolution" from Option A → Option B).

## How
- **KB** — `kb_curator_stages_json()` (beside `CURATOR_STAGES` in `kb_curator_drain.c`) serialises the registry **+ the projection / cross-repo INDEX-lane sweeps** to `[{name,label,lane,budget,order,config_key}]`. Served via a new `curator.stages` RPC in `kb_service.c`. `config_key` is the `aimee.yaml` flag the GUI toggles; embedder-gated stages (`embed_code`/`ingest_docs`) report `null` → read-only.
- **Server** — `POST /v1/curator/stages` proxies to the KB (`rh_dispatch_op`).
- **Frontend** — `Pipeline.tsx` fetches `/api/curator/stages` and renders dynamically; the hardcoded `STAGES`/`GATED` arrays are gone. Descriptions come from the shared `FIELD_HELP` (by `config_key`); enable state still from `/api/config`.

## Why
Eliminates the frontend-vs-C drift the Option A "keep in sync" comment guarded against — no mirror left to drift.

## Verified
`aimee-kb` + `aimee-server` compile + link clean; `tsc -b` clean; `curator-story-check` + `docs-gen-check` pass. (Live GUI render will be exercised at release-time deploy.)