### PR TITLE
feat(gui): built-in curator pipeline presets (full / docs-only / code-only)

### DIFF
--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -22,6 +22,7 @@ type Stage = {
   order: number;
   config_key: string | null;
 };
+type Preset = { name: string; description: string; enabled: string[] };
 
 const csrf = () => ({ "X-CSRF-Token": window._csrf || "" });
 
@@ -45,6 +46,7 @@ const DEFAULT_DESC = "Active whenever an embedder is configured (no individual t
 
 export default function Pipeline() {
   const [stages, setStages] = useState<Stage[]>([]);
+  const [presets, setPresets] = useState<Preset[]>([]);
   const [cfg, setCfg] = useState<Record<string, Val>>({});
   const [loaded, setLoaded] = useState(false);
   const [busy, setBusy] = useState<string>("");
@@ -54,14 +56,15 @@ export default function Pipeline() {
     Promise.all([
       fetch("/api/curator/stages", { method: "POST", headers: { "Content-Type": "application/json", ...csrf() }, body: "{}" })
         .then((r) => r.json())
-        .then((d: { stages?: Stage[] }) => d.stages || [])
-        .catch(() => [] as Stage[]),
+        .then((d: { stages?: Stage[]; presets?: Preset[] }) => ({ stages: d.stages || [], presets: d.presets || [] }))
+        .catch(() => ({ stages: [] as Stage[], presets: [] as Preset[] })),
       fetch("/api/config", { headers: csrf() })
         .then((r) => r.json())
         .then((d: { config?: Record<string, Val> }) => d.config || {})
         .catch(() => ({} as Record<string, Val>)),
-    ]).then(([s, c]) => {
-      setStages([...s].sort((a, b) => a.order - b.order));
+    ]).then(([sp, c]) => {
+      setStages([...sp.stages].sort((a, b) => a.order - b.order));
+      setPresets(sp.presets);
       setCfg(c);
       setLoaded(true);
     });
@@ -79,6 +82,30 @@ export default function Pipeline() {
       setStatus({ kind: "err", msg: error || `save failed (${st})` });
     }
   }, []);
+
+  // Apply a preset: enable its listed config keys, disable every other toggleable
+  // stage. One config.set per stage, in parallel; embedder-gated stages (no
+  // config_key) are untouched.
+  const applyPreset = useCallback(async (p: Preset) => {
+    setBusy(`preset:${p.name}`);
+    const on = new Set(p.enabled);
+    const targets = stages.filter((s) => s.config_key);
+    const results = await Promise.all(
+      targets.map((s) => postJSON("/api/config/set", { key: s.config_key, value: on.has(s.config_key as string) })),
+    );
+    setBusy("");
+    setCfg((prev) => {
+      const next = { ...prev };
+      for (const s of targets) next[s.config_key as string] = on.has(s.config_key as string);
+      return next;
+    });
+    const failed = results.filter((r) => r.error || r.status < 200 || r.status >= 300).length;
+    setStatus(
+      failed
+        ? { kind: "err", msg: `preset "${p.name}" applied with ${failed} error(s)` }
+        : { kind: "ok", msg: `preset "${p.name}" applied` },
+    );
+  }, [stages]);
 
   const isOn = (k: string) => cfg[k] === true || cfg[k] === 1;
 
@@ -131,6 +158,26 @@ export default function Pipeline() {
         take effect on the KB's next config load. Stages run in two resource lanes concurrently, and this
         view is generated live from the backend stage registry.
       </p>
+      {presets.length > 0 && (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", marginBottom: 18 }}>
+          <span style={{ fontSize: 13, fontWeight: 600, color: "#555" }}>Presets:</span>
+          {presets.map((p) => (
+            <button
+              key={p.name}
+              disabled={busy === `preset:${p.name}`}
+              onClick={() => applyPreset(p)}
+              title={p.description}
+              style={{
+                padding: "5px 12px", fontSize: 13, borderRadius: 14, cursor: "pointer",
+                border: "1px solid #cbd5e1", background: busy === `preset:${p.name}` ? "#eef" : "#f8fafc",
+              }}
+            >
+              {p.name}
+            </button>
+          ))}
+          <span style={{ fontSize: 12, color: "#999" }}>apply a profile, then fine-tune below</span>
+        </div>
+      )}
       {(["llm", "index"] as Lane[]).map((lane) => {
         const meta = LANE_META[lane];
         const laneStages = stages.filter((s) => s.lane === lane);

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -386,6 +386,58 @@ cJSON *kb_curator_stages_json(void)
    return arr;
 }
 
+/* Built-in curator presets (v1): named enabled-sets of stage config keys. The GUI
+ * applies a preset by enabling the listed keys and disabling the rest. Backend-
+ * defined so they stay in step with the stage set (single source of truth); the
+ * user-defined/saved presets the product owner wants are a planned follow-up that
+ * will extend this list from stored config rather than replace it. Returns a fresh
+ * cJSON array [{name,description,enabled:[config_key,...]}]; caller owns it. */
+cJSON *kb_curator_presets_json(void)
+{
+   static const struct
+   {
+      const char *name;
+      const char *desc;
+      const char *keys; /* comma-separated config keys enabled by this preset */
+   } PRESETS[] = {
+       {"full", "Every curated stage — docs, code, contradictions, and graph.",
+        "kb_curator_extract_docs_enabled,kb_curator_extract_code_enabled,"
+        "kb_curator_resolve_entities_enabled,kb_curator_index_narrative_enabled,"
+        "kb_curator_index_claims_enabled,kb_curator_detect_contradictions_enabled,"
+        "kb_curator_index_code_unit_enabled,kb_curator_link_artifacts_enabled,"
+        "kb_curator_synthesize_enabled,kb_curator_promote_entity_enabled,"
+        "kb_evidence_embed_enabled,kb_curator_projection_graph_enabled,"
+        "kb_curator_cross_repo_graph_enabled"},
+       {"docs-only",
+        "Document knowledge: extract, resolve, index, detect contradictions, synthesize.",
+        "kb_curator_extract_docs_enabled,kb_curator_resolve_entities_enabled,"
+        "kb_curator_index_narrative_enabled,kb_curator_index_claims_enabled,"
+        "kb_curator_detect_contradictions_enabled,kb_curator_synthesize_enabled,"
+        "kb_curator_promote_entity_enabled,kb_evidence_embed_enabled"},
+       {"code-only",
+        "Code knowledge: extract code units, index, link, projection + cross-repo graph.",
+        "kb_curator_extract_code_enabled,kb_curator_index_code_unit_enabled,"
+        "kb_curator_link_artifacts_enabled,kb_curator_projection_graph_enabled,"
+        "kb_curator_cross_repo_graph_enabled"},
+   };
+   cJSON *arr = cJSON_CreateArray();
+   for (size_t i = 0; i < sizeof(PRESETS) / sizeof(PRESETS[0]); i++)
+   {
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddStringToObject(o, "name", PRESETS[i].name);
+      cJSON_AddStringToObject(o, "description", PRESETS[i].desc);
+      cJSON *keys = cJSON_CreateArray();
+      char buf[1024];
+      snprintf(buf, sizeof(buf), "%s", PRESETS[i].keys);
+      char *save = NULL;
+      for (char *tok = strtok_r(buf, ",", &save); tok; tok = strtok_r(NULL, ",", &save))
+         cJSON_AddItemToArray(keys, cJSON_CreateString(tok));
+      cJSON_AddItemToObject(o, "enabled", keys);
+      cJSON_AddItemToArray(arr, o);
+   }
+   return arr;
+}
+
 static void *drain_thread_main(void *arg)
 {
    kb_curator_drain_ctx_t *ctx = (kb_curator_drain_ctx_t *)arg;

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -916,6 +916,7 @@ static int kb_handle_curator_stages(int fd, cJSON *req)
    (void)req;
    cJSON *resp = jo_ok();
    cJSON_AddItemToObject(resp, "stages", kb_curator_stages_json());
+   cJSON_AddItemToObject(resp, "presets", kb_curator_presets_json());
    int rc = kb_send_response(fd, resp);
    cJSON_Delete(resp);
    return rc;

--- a/src/kb_curator_drain.h
+++ b/src/kb_curator_drain.h
@@ -27,4 +27,8 @@ void kb_curator_drain_shutdown(kb_curator_drain_ctx_t *ctx);
 struct cJSON;
 struct cJSON *kb_curator_stages_json(void);
 
+/* Built-in curator presets (named enabled-sets of stage config keys) for the
+ * Pipeline GUI. Returns a fresh cJSON array the caller owns (cJSON_Delete). */
+struct cJSON *kb_curator_presets_json(void);
+
 #endif /* DEC_KB_CURATOR_DRAIN_H */


### PR DESCRIPTION
## What
Adds named **stage-set presets** to the Pipeline page — apply a curation profile in one click, then fine-tune individual stages.

## How
- **KB** — `kb_curator_presets_json()` returns `[{name,description,enabled:[config_key]}]`; served on the existing `curator.stages` endpoint (now `{stages, presets}`) so no new route/spec. Backend-defined = single source of truth, and the natural extension point for the **user-defined/saved presets** planned next.
- **Frontend** — a presets bar; applying a preset enables its config keys and disables the rest (parallel `config.set`), leaving embedder-gated stages untouched.

## v1 built-ins
- **full** — every curated stage
- **docs-only** — document knowledge (extract/resolve/index/contradictions/synthesize)
- **code-only** — code knowledge (extract code/index/link/projection + cross-repo graph)

## Verified
`aimee-kb` compiles + links clean; `tsc -b` clean; `make lint` clean (incl. clang-format + server-api-conformance — reuses the existing endpoint). Part of the user-configurable-pipeline work; reorder + user-defined presets/stages follow (design in progress via the multi-provider roundtable).