### PR TITLE
feat(kb): config-driven curator stage reorder + dependency constraints (Phase A)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (154)
+## CLI-settable keys (155)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -102,6 +102,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `kb_curator_projection_graph_enabled` | bool | — |
 | `kb_curator_promote_entity_enabled` | bool | — |
 | `kb_curator_resolve_entities_enabled` | bool | — |
+| `kb_curator_stage_order` | string | — |
 | `kb_curator_synthesize_enabled` | bool | — |
 | `kb_evidence_embed_enabled` | bool | — |
 | `kb_evidence_emit_enabled` | bool | Emit evidence records from KB ingest. |
@@ -181,7 +182,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 | `wfe_live_forge_enabled` | bool | — |
 
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_docs_enabled`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_synthesize_enabled`, `kb_evidence_embed_enabled`, `wfe_live_forge_enabled`
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_docs_enabled`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_evidence_embed_enabled`, `wfe_live_forge_enabled`
 
 ## Config-file sections (53)
 

--- a/docs/proposals/pending/user-configurable-curator-pipeline.md
+++ b/docs/proposals/pending/user-configurable-curator-pipeline.md
@@ -1,0 +1,139 @@
+# Proposal: User-configurable curator pipeline — reorder, constraints, presets, user-defined stages
+
+- **State:** PENDING — design + phased build. Authored autonomously overnight
+  (2026-07-08) at the product owner's direction ("users order stages any valid
+  way; enforce constraints and disallow impossible configs; presets starting at 3,
+  ultimately user-defined; ultimately users add their own stages"). The design
+  decisions here would normally be validated by the delegate roundtable, but the
+  roundtable was unavailable this session (narrow default panel; the `.254`
+  `ensemble.reference_models` config edit failed — codex delegate exhausted budget
+  with "glob failed"). Flagged for review.
+- **Author:** JBailes (assisted)
+- **Date:** 2026-07-08
+- **Builds on:** the modular curator pipeline (Phases 1–5, shipped): the
+  data-driven stage registry `CURATOR_STAGES` (`src/kb/kb_curator_drain.c`), the
+  two resource lanes (LLM=GPU, INDEX=CPU) with per-lane worker threads via
+  `kb_curator_pipeline_run_pass`, the `curator.stages` registry endpoint (Option B,
+  single source of truth), and built-in presets (#1173).
+
+## 1. The order model — what "order" actually means here
+
+The pipeline is **queue-decoupled and two-laned**: each stage drains its own
+queue each pass; a producer (e.g. `index_claims`) enqueues work a consumer (e.g.
+`detect_contradictions`) picks up. The two lanes run on **separate threads**
+concurrently. Consequences:
+
+- **Cross-lane order is not a thing** — the LLM and INDEX lanes run in parallel;
+  you cannot sequence an INDEX stage "before" an LLM stage. Only **intra-lane**
+  order is meaningful.
+- **Intra-lane order affects latency, not correctness** — because queues persist
+  across passes, running a consumer before its producer in one pass just defers
+  its work to the next pass; it never corrupts output. Correctness is guaranteed
+  by the queues regardless of order.
+
+So "reorder" is an **intra-lane, latency-affecting** control, and the dependency
+constraints exist to keep orders **sensible** (producer before consumer within a
+lane), not to prevent data corruption. This is why we *enforce* a DAG (disallow
+orders that invert a producer→consumer edge) rather than merely warn: it matches
+the operator's mental model and prevents pointless/confusing orders, even though
+the queue layer would tolerate them.
+
+## 2. Dependency DAG (the constraints)
+
+Producer→consumer prerequisites (a stage may not be ordered before a prerequisite
+**in the same lane**; cross-lane prerequisites are advisory and shown in the GUI
+but not order-enforced since lanes are concurrent):
+
+| stage | requires |
+|---|---|
+| resolve_entities | extract_docs |
+| index_narrative | extract_docs |
+| index_claims | extract_docs |
+| detect_contradictions | index_claims *(intra-lane — enforced)* |
+| index_code_unit | extract_code |
+| link_artifacts | extract_docs, extract_code |
+| synthesize | index_claims |
+| promote_entity | resolve_entities |
+| embed_evidence | index_claims *(intra-lane — enforced)* |
+| cross_repo_graph | projection_graph *(intra-lane — enforced)* |
+
+`extract_docs`, `extract_code`, `embed_code`, `ingest_docs`, `projection_graph`
+have no prerequisites. The enforced intra-lane edges (INDEX lane) are the ones
+that actually gate a valid order.
+
+## 3. Reorder — representation, validation, runtime
+
+- **Config:** `kb.curator.stage_order` — a comma-separated list of stage names.
+  Empty ⇒ registry order (the current default). Unknown names ignored; omitted
+  stages keep registry order after the listed ones.
+- **Validation:** `kb_curator_order_valid(order, &reason)` — every stage must
+  appear after its intra-lane prerequisites. **Disallow** invalid orders: the GUI
+  refuses the move client-side (using the `requires` from the endpoint), the
+  `config.set` path rejects an invalid `stage_order`, and the runner **fails safe**
+  (invalid config ⇒ registry order + one WARN) as defense-in-depth.
+- **Runtime:** each lane worker builds a validated, reordered view of
+  `CURATOR_STAGES` per poll and passes it to `kb_curator_pipeline_run_pass`
+  (already parameterised by a stages array). Cheap (≤15 entries).
+- **Endpoint:** `curator.stages` gains `requires: [name,...]` per stage so the GUI
+  can enforce/visualise constraints.
+
+## 4. Presets
+
+- **v1 (shipped, #1173):** built-in profiles (full / docs-only / code-only),
+  backend-defined, served on `curator.stages`; applying sets the stage flags.
+- **v2 (this proposal):** user-defined/saved presets in `kb.curator.presets`
+  (`{name: [config_key,...]}`), merged with the built-ins in the endpoint; a
+  `curator.save_preset` / `curator.delete_preset` op writes the config section
+  (config.set only does flat keys). GUI: name + save the current toggles; apply/
+  delete saved profiles.
+
+## 5. User-defined stages (the hard part)
+
+A stage today is a C struct with a **function pointer** (`run`). Arbitrary
+user-supplied code is a non-starter (correctness + security). Phased, safe path:
+
+- **v1 — composed stages:** a user stage is `{name, base_op, lane, budget}` in
+  `kb.curator.custom_stages`, where `base_op` **references an existing, vetted
+  registry op** (e.g. an operator defines a second `index_claims`-style pass over a
+  different source, or renames/relanes an existing op). The registry the workers
+  iterate becomes `built-in ⊕ custom` (custom validated against the same DAG rules
+  + lane legality). No new executable code — only recomposition of shipped ops.
+- **v2 — declarative stages:** a small, sandboxed spec (source selector →
+  transform op → sink) built from a fixed vocabulary of vetted primitives. Still
+  no arbitrary code.
+- **v3 — plugin stages:** the existing plugin/hook mechanism (`plugin_loader`,
+  `plugin_c_hook`) exposes a registration hook so a signed plugin contributes a
+  stage. This is where genuinely new stage *logic* lives, gated by the plugin
+  trust model — not user config.
+
+Full arbitrary user code is explicitly out of scope.
+
+## 6. Phase plan
+
+- **Phase A** — DAG + `requires` on the endpoint; `kb.curator.stage_order` config;
+  validation; runtime reorder (fail-safe). *(core buildable now)*
+- **Phase B** — GUI: drag/▲▼ reorder with client-side constraint enforcement;
+  persist `stage_order`.
+- **Phase C** — user-defined presets (save/apply/delete). *(builds on #1173)*
+- **Phase D** — composed user-defined stages (`custom_stages`), DAG- and
+  lane-validated.
+- **Phase E** — plugin-contributed stages (future; trust-gated).
+
+## 7. Risks
+
+- **Runner change (Phase A)** touches the core drain loop. Mitigated by: reorder is
+  latency-only (queues protect correctness), fail-safe fallback to registry order,
+  and no change to the stage set or their run functions.
+- **`config.set` rejecting invalid orders** needs a per-key validation hook — small
+  but new surface; keep the runner fail-safe regardless.
+- **Composed stages** must validate `base_op` against the vetted op set and reject
+  unknown ops (no code injection); lane legality enforced.
+
+## 8. Acceptance
+
+- Invalid `stage_order` is rejected at the API and the GUI, and the runner logs one
+  WARN and uses registry order if a bad order reaches config.
+- A valid reorder changes the per-pass stage sequence within a lane (observable in
+  the drain debug log) without changing curated output.
+- Saved user presets round-trip through config and apply correctly.
+- A composed custom stage runs its `base_op` on its lane and is DAG-validated.

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -321,6 +321,8 @@ const config_field_t config_fields[] = {
      * nested kb.curator.* YAML the KB reads on its next load. */
     {"kb_curator_extract_docs_enabled", offsetof(config_t, kb_curator_extract_docs_enabled),
      sizeof(int), 0, CFG_BOOL},
+    {"kb_curator_stage_order", offsetof(config_t, kb_curator_stage_order),
+     sizeof(((config_t *)0)->kb_curator_stage_order), 0, CFG_STRING},
     {"kb_curator_extract_code_enabled", offsetof(config_t, kb_curator_extract_code_enabled),
      sizeof(int), 0, CFG_BOOL},
     {"kb_curator_resolve_entities_enabled", offsetof(config_t, kb_curator_resolve_entities_enabled),

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -47,6 +47,7 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_promote_entity_enabled = 1;
    cfg->kb_curator_promote_min_sources = 3;
    cfg->kb_curator_extract_command[0] = '\0';
+   cfg->kb_curator_stage_order[0] = '\0';
    cfg->kb_curator_judge_command[0] = '\0';
    cfg->kb_curator_synthesize_command[0] = '\0';
    cfg->kb_curator_synthesize_k = 8;
@@ -353,6 +354,11 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
    if (extract_command && cJSON_IsString(extract_command) && extract_command->valuestring)
       snprintf(cfg->kb_curator_extract_command, sizeof(cfg->kb_curator_extract_command), "%s",
                extract_command->valuestring);
+
+   const cJSON *stage_order = cJSON_GetObjectItemCaseSensitive(curator, "stage_order");
+   if (stage_order && cJSON_IsString(stage_order) && stage_order->valuestring)
+      snprintf(cfg->kb_curator_stage_order, sizeof(cfg->kb_curator_stage_order), "%s",
+               stage_order->valuestring);
 
    const cJSON *judge_command = cJSON_GetObjectItemCaseSensitive(curator, "judge_command");
    if (judge_command && cJSON_IsString(judge_command) && judge_command->valuestring)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -423,9 +423,10 @@ typedef struct config
     * model, P1). Single-model Anthropic-compatible shims (llama.cpp/vLLM) enable
     * this so an arbitrary client model name is not forwarded and rejected upstream. */
    int gateway_pin_model;
-   int typed_facts_enabled;         /* typed-fact knowledge layer master gate (default off) */
+   int typed_facts_enabled; /* typed-fact knowledge layer master gate (default off) */
    /* kb.typed_facts.* — KB-owned autonomous reconciliation knobs (proposal §7.2/§8). */
-   int kb_typed_facts_auto_promote_enabled; /* default on: auto-promote recurrent provisional relations */
+   int kb_typed_facts_auto_promote_enabled; /* default on: auto-promote recurrent provisional
+                                               relations */
    int kb_typed_facts_promote_threshold;    /* observations before auto-promote (default 3) */
    int kb_pdf_ingest_enabled;       /* structured-pdf: route PDF uploads through the geometry
                                        extractor (kb_doc_pdf) instead of plain pdftotext (default off) */
@@ -1568,6 +1569,11 @@ typedef struct config
    int kb_curator_promote_entity_enabled;
    int kb_curator_promote_min_sources;
    char kb_curator_extract_command[512];
+   /* Comma-separated stage-name order for the curator pipeline (GUI reorder).
+    * Empty = registry (default) order. Validated against the dependency DAG; an
+    * invalid order falls back to registry order with a WARN. Opt-in: unset changes
+    * nothing. See docs/proposals/pending/user-configurable-curator-pipeline.md. */
+   char kb_curator_stage_order[512];
    int kb_curator_extract_max_tokens;
    int kb_curator_max_attempts;
    /* Curator LLM provider (curator-llm-backend §2), operator-owned and kb-level

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -326,6 +326,45 @@ static const kb_curator_stage_desc_t CURATOR_STAGES[] = {
      KB_CURATOR_LANE_INDEX},
 };
 
+/* Producer->consumer dependency DAG for the curator stages: a stage may not be
+ * ordered before a prerequisite in the SAME lane (cross-lane prereqs are advisory
+ * -- the two lanes run concurrently, so cross-lane order is not enforceable). The
+ * reorder validator enforces the same-lane edges; the GUI surfaces the full list
+ * via `requires`. Single source of truth for the constraints. See
+ * docs/proposals/pending/user-configurable-curator-pipeline.md. */
+static const struct
+{
+   const char *stage;
+   const char *reqs; /* comma-separated prerequisite stage names */
+} CURATOR_STAGE_DEPS[] = {
+    {"resolve_entities", "extract_docs"}, {"index_narrative", "extract_docs"},
+    {"index_claims", "extract_docs"},     {"detect_contradictions", "index_claims"},
+    {"index_code_unit", "extract_code"},  {"link_artifacts", "extract_docs,extract_code"},
+    {"synthesize", "index_claims"},       {"promote_entity", "resolve_entities"},
+    {"embed_evidence", "index_claims"},   {"cross_repo_graph", "projection_graph"},
+};
+
+/* Prerequisite string for a stage (comma-separated), or "" if none. */
+static const char *kb_curator_stage_reqs(const char *name)
+{
+   for (size_t i = 0; i < sizeof(CURATOR_STAGE_DEPS) / sizeof(CURATOR_STAGE_DEPS[0]); i++)
+      if (strcmp(CURATOR_STAGE_DEPS[i].stage, name) == 0)
+         return CURATOR_STAGE_DEPS[i].reqs;
+   return "";
+}
+
+/* Add a "requires":[...] array (from the DAG) to a stage JSON object. */
+static void kb_curator_add_requires(cJSON *o, const char *name)
+{
+   cJSON *reqs = cJSON_CreateArray();
+   char buf[128];
+   snprintf(buf, sizeof(buf), "%s", kb_curator_stage_reqs(name));
+   char *save = NULL;
+   for (char *t = strtok_r(buf, ",", &save); t; t = strtok_r(NULL, ",", &save))
+      cJSON_AddItemToArray(reqs, cJSON_CreateString(t));
+   cJSON_AddItemToObject(o, "requires", reqs);
+}
+
 /* Option B (single source of truth): expose the stage registry as data so the
  * Pipeline GUI renders from the running backend instead of a hand-kept mirror.
  * Returns a fresh cJSON array [{name,label,lane,budget,order,config_key}]; the
@@ -357,6 +396,7 @@ cJSON *kb_curator_stages_json(void)
          snprintf(key, sizeof(key), "kb_curator_%s_enabled", st->name);
          cJSON_AddStringToObject(o, "config_key", key);
       }
+      kb_curator_add_requires(o, st->name);
       cJSON_AddItemToArray(arr, o);
    }
    /* The projection-graph + cross-repo refresh run on the INDEX lane via
@@ -371,6 +411,7 @@ cJSON *kb_curator_stages_json(void)
       cJSON_AddNumberToObject(o, "budget", 1);
       cJSON_AddNumberToObject(o, "order", (double)n);
       cJSON_AddStringToObject(o, "config_key", "kb_curator_projection_graph_enabled");
+      kb_curator_add_requires(o, "projection_graph");
       cJSON_AddItemToArray(arr, o);
    }
    {
@@ -381,6 +422,7 @@ cJSON *kb_curator_stages_json(void)
       cJSON_AddNumberToObject(o, "budget", 1);
       cJSON_AddNumberToObject(o, "order", (double)(n + 1));
       cJSON_AddStringToObject(o, "config_key", "kb_curator_cross_repo_graph_enabled");
+      kb_curator_add_requires(o, "cross_repo_graph");
       cJSON_AddItemToArray(arr, o);
    }
    return arr;
@@ -436,6 +478,114 @@ cJSON *kb_curator_presets_json(void)
       cJSON_AddItemToArray(arr, o);
    }
    return arr;
+}
+
+/* Lane of a registry stage by name, or -1 if not a CURATOR_STAGES entry. */
+static int kb_curator_stage_lane_of(const char *name)
+{
+   for (size_t i = 0; i < sizeof(CURATOR_STAGES) / sizeof(CURATOR_STAGES[0]); i++)
+      if (strcmp(CURATOR_STAGES[i].name, name) == 0)
+         return (int)CURATOR_STAGES[i].lane;
+   return -1;
+}
+
+/* Validate a comma-separated stage order against the same-lane dependency DAG:
+ * every listed stage must appear after its same-lane prerequisites, and those
+ * prerequisites must themselves be listed (an omitted prereq would fall to the end
+ * in registry order, i.e. after its dependent). Cross-lane prereqs are advisory
+ * (the lanes run concurrently) and not checked. Unknown names are ignored. Returns
+ * 1 valid, 0 invalid (fills `err`). */
+static int kb_curator_order_valid(const char *order, char *err, size_t err_sz)
+{
+   if (err && err_sz)
+      err[0] = '\0';
+   if (!order || !order[0])
+      return 1;
+   char buf[512];
+   snprintf(buf, sizeof(buf), "%s", order);
+   const char *names[64];
+   int npos = 0;
+   char *save = NULL;
+   for (char *t = strtok_r(buf, ",", &save); t && npos < 64; t = strtok_r(NULL, ",", &save))
+   {
+      while (*t == ' ')
+         t++;
+      names[npos++] = t;
+   }
+   for (int i = 0; i < npos; i++)
+   {
+      int lane = kb_curator_stage_lane_of(names[i]);
+      if (lane < 0)
+         continue;
+      char rbuf[128];
+      snprintf(rbuf, sizeof(rbuf), "%s", kb_curator_stage_reqs(names[i]));
+      char *rsave = NULL;
+      for (char *req = strtok_r(rbuf, ",", &rsave); req; req = strtok_r(NULL, ",", &rsave))
+      {
+         if (kb_curator_stage_lane_of(req) != lane)
+            continue; /* cross-lane: advisory only */
+         int rpos = -1;
+         for (int j = 0; j < npos; j++)
+            if (strcmp(names[j], req) == 0)
+            {
+               rpos = j;
+               break;
+            }
+         if (rpos < 0 || rpos > i)
+         {
+            if (err && err_sz)
+               snprintf(err, err_sz, "stage '%s' must come after prerequisite '%s' (same lane)",
+                        names[i], req);
+            return 0;
+         }
+      }
+   }
+   return 1;
+}
+
+/* Build the stage array the lane workers iterate: kb_curator_stage_order when set
+ * AND valid (listed stages first in that order, then any unlisted in registry
+ * order), else the registry order. Fail-safe: an invalid order logs one WARN and
+ * falls back to registry order, so a bad config can never corrupt the pipeline.
+ * Fills `out` (capacity `max`); returns the count. */
+static size_t kb_curator_ordered_stages(const config_t *cfg, kb_curator_stage_desc_t *out,
+                                        size_t max)
+{
+   size_t n = sizeof(CURATOR_STAGES) / sizeof(CURATOR_STAGES[0]);
+   size_t reg = n < max ? n : max;
+   for (size_t i = 0; i < reg; i++)
+      out[i] = CURATOR_STAGES[i];
+   const char *order = cfg->kb_curator_stage_order;
+   if (!order[0])
+      return reg;
+   char err[160];
+   if (!kb_curator_order_valid(order, err, sizeof(err)))
+   {
+      aimee_log(LOG_WARN, "kb.curator.order",
+                "ignoring invalid kb_curator_stage_order (%s); using registry order", err);
+      return reg;
+   }
+   int used[32] = {0};
+   size_t k = 0;
+   char buf[512];
+   snprintf(buf, sizeof(buf), "%s", order);
+   char *save = NULL;
+   for (char *t = strtok_r(buf, ",", &save); t && k < max; t = strtok_r(NULL, ",", &save))
+   {
+      while (*t == ' ')
+         t++;
+      for (size_t i = 0; i < n; i++)
+         if (!used[i] && strcmp(CURATOR_STAGES[i].name, t) == 0)
+         {
+            out[k++] = CURATOR_STAGES[i];
+            used[i] = 1;
+            break;
+         }
+   }
+   for (size_t i = 0; i < n && k < max; i++)
+      if (!used[i])
+         out[k++] = CURATOR_STAGES[i];
+   return k;
 }
 
 static void *drain_thread_main(void *arg)
@@ -584,6 +734,12 @@ static void *drain_thread_main(void *arg)
           cfg.kb_curator_extract_max_tokens > 0 ? cfg.kb_curator_extract_max_tokens : 2048;
       opts.max_attempts = cfg.kb_curator_max_attempts > 0 ? cfg.kb_curator_max_attempts : 3;
 
+      /* Stage order for this poll: kb_curator_stage_order when set + valid, else
+       * registry order (fail-safe). Built once per poll so an invalid order WARNs
+       * at most once, not once per drained job. */
+      kb_curator_stage_desc_t ordered[16];
+      size_t nordered = kb_curator_ordered_stages(&cfg, ordered, 16);
+
       /* Drain a batch of curator jobs back-to-back. Each iteration runs ONE job
        * from the highest-priority non-empty stage (the rc chain below). Draining a
        * batch per poll — rather than one job then re-running the catch-up sweep +
@@ -600,9 +756,8 @@ static void *drain_thread_main(void *arg)
          /* This (main) worker drives the LLM lane; the CPU index lane runs on its own
           * thread (kb_curator_index_lane_main) so indexing does not wait behind each
           * multi-second extraction. */
-         int r = kb_curator_pipeline_run_pass(CURATOR_STAGES,
-                                              sizeof(CURATOR_STAGES) / sizeof(CURATOR_STAGES[0]),
-                                              KB_CURATOR_LANE_LLM, &cfg, &opts, curator_set_status);
+         int r = kb_curator_pipeline_run_pass(ordered, nordered, KB_CURATOR_LANE_LLM, &cfg, &opts,
+                                              curator_set_status);
          if (r < 0)
          {
             /* Stage error: stop the batch; the top-of-loop sleep backs off before
@@ -649,13 +804,16 @@ static void *kb_curator_index_lane_main(void *arg)
        * INDEX queue drain -- content-addressed, so cheap when nothing changed. */
       kb_curator_projection_sweep(&cfg);
 
+      /* Same stage-order resolution as the LLM lane; run_pass filters to this lane. */
+      kb_curator_stage_desc_t ordered[16];
+      size_t nordered = kb_curator_ordered_stages(&cfg, ordered, 16);
+
       int r = 0, drained = 0;
       while (!ctx->stop && drained < CURATOR_DRAIN_BATCH)
       {
          db2_lease_release_idle();
-         r = kb_curator_pipeline_run_pass(
-             CURATOR_STAGES, sizeof(CURATOR_STAGES) / sizeof(CURATOR_STAGES[0]),
-             KB_CURATOR_LANE_INDEX, &cfg, &opts, curator_index_set_status);
+         r = kb_curator_pipeline_run_pass(ordered, nordered, KB_CURATOR_LANE_INDEX, &cfg, &opts,
+                                          curator_index_set_status);
          if (r != 1)
             break; /* 0 = INDEX queues empty; <0 = a stage errored */
          drained++;


### PR DESCRIPTION
First phase of the user-configurable pipeline (design: `docs/proposals/pending/user-configurable-curator-pipeline.md`, also in this PR).

## What
Operators can reorder the curator pipeline via `kb.curator.stage_order` (comma-separated stage names); the runner honors it, **validated against a producer→consumer dependency DAG**.

## Safety
- **Opt-in:** unset ⇒ registry order (current behaviour, unchanged).
- **Fail-safe:** an invalid order (a stage before a same-lane prerequisite) → the runner logs one WARN and uses registry order. A bad config can never corrupt curation.
- Queues already guarantee cross-pass correctness; reorder is an intra-lane, same-pass **latency** control, and the DAG keeps orders sensible (cross-lane order is not enforceable — the lanes run concurrently).

## How
- **config:** `kb_curator_stage_order` (config_t + `kb.curator` parse + `config_fields` allowlist, so the GUI can set it).
- **kb_curator_drain.c:** `CURATOR_STAGE_DEPS` DAG; `kb_curator_order_valid` (same-lane enforcement); `kb_curator_ordered_stages` (fail-safe builder) driving both lane workers; `curator.stages` now emits per-stage `requires` for the GUI to enforce/visualise.
- **docs:** regenerated config reference; full design proposal.

## Verified / pending
`aimee-kb` compiles + links clean; `make lint` clean (docs-gen, clang-format, api-conformance). **Runtime behaviour is validation-pending** — exercised at release-time on .254, like the rest. **Design note:** normally roundtable-validated, but the delegate roundtable was unreachable all session (`/v1` endpoint flakiness; the .254 `ensemble.reference_models` fix failed) — the design is mine, flagged for your review.

Next: Phase B (GUI ▲▼ reorder with client-side constraint enforcement), then user-defined presets, then composed user-defined stages.