### PR TITLE
feat(gui): user-defined saved curator presets (Phase C)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (155)
+## CLI-settable keys (156)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -104,6 +104,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `kb_curator_resolve_entities_enabled` | bool | — |
 | `kb_curator_stage_order` | string | — |
 | `kb_curator_synthesize_enabled` | bool | — |
+| `kb_curator_user_presets` | string | — |
 | `kb_evidence_embed_enabled` | bool | — |
 | `kb_evidence_emit_enabled` | bool | Emit evidence records from KB ingest. |
 | `kb_fusion_mode` | string | KB retrieval fusion mode: rrf (default), static_alpha, or dynamic_alpha. |
@@ -182,7 +183,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 | `wfe_live_forge_enabled` | bool | — |
 
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_docs_enabled`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_evidence_embed_enabled`, `wfe_live_forge_enabled`
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_docs_enabled`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_curator_user_presets`, `kb_evidence_embed_enabled`, `wfe_live_forge_enabled`
 
 ## Config-file sections (53)
 

--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -28,7 +28,7 @@ type Stage = {
   config_key: string | null;
   requires: string[];
 };
-type Preset = { name: string; description: string; enabled: string[] };
+type Preset = { name: string; description: string; enabled: string[]; builtin?: boolean };
 
 const csrf = () => ({ "X-CSRF-Token": window._csrf || "" });
 
@@ -129,6 +129,50 @@ export default function Pipeline() {
         : { kind: "ok", msg: `preset "${p.name}" applied` },
     );
   }, [stages]);
+
+  // User presets are stored as a JSON array in the kb_curator_user_presets config
+  // string; the GUI reads/edits it and persists via config.set (no bespoke op).
+  const readUserPresets = useCallback((): Preset[] => {
+    const raw = cfg.kb_curator_user_presets;
+    if (typeof raw !== "string" || !raw) return [];
+    try {
+      const arr = JSON.parse(raw);
+      return Array.isArray(arr) ? (arr as Preset[]) : [];
+    } catch {
+      return [];
+    }
+  }, [cfg]);
+
+  const writeUserPresets = useCallback(async (list: Preset[], okMsg: string) => {
+    setBusy("user-presets");
+    const { status: st, error } = await postJSON("/api/config/set", {
+      key: "kb_curator_user_presets",
+      value: JSON.stringify(list),
+    });
+    setBusy("");
+    if (st >= 200 && st < 300 && !error) {
+      setStatus({ kind: "ok", msg: okMsg });
+      refresh();
+    } else {
+      setStatus({ kind: "err", msg: error || `save failed (${st})` });
+    }
+  }, [refresh]);
+
+  const saveCurrentAsPreset = useCallback(async () => {
+    const name = window.prompt("Save the current stage toggles as a preset named:")?.trim();
+    if (!name) return;
+    const enabled = stages
+      .filter((s) => s.config_key && (cfg[s.config_key] === true || cfg[s.config_key] === 1))
+      .map((s) => s.config_key as string);
+    const list = readUserPresets().filter((p) => p.name !== name);
+    list.push({ name, description: "User preset", enabled, builtin: false });
+    await writeUserPresets(list, `preset "${name}" saved`);
+  }, [stages, cfg, readUserPresets, writeUserPresets]);
+
+  const deletePreset = useCallback(async (name: string) => {
+    const list = readUserPresets().filter((p) => p.name !== name);
+    await writeUserPresets(list, `preset "${name}" deleted`);
+  }, [readUserPresets, writeUserPresets]);
 
   const persistOrder = useCallback(async (arr: Stage[]) => {
     const order = arr.map((s) => s.name).join(",");
@@ -243,26 +287,50 @@ export default function Pipeline() {
         (dependencies are enforced). Changes persist to aimee.yaml and take effect on the KB's next
         config load. This view is generated live from the backend stage registry.
       </p>
-      {presets.length > 0 && (
-        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", marginBottom: 18 }}>
-          <span style={{ fontSize: 13, fontWeight: 600, color: "#555" }}>Presets:</span>
-          {presets.map((p) => (
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", marginBottom: 18 }}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: "#555" }}>Presets:</span>
+        {presets.map((p) => (
+          <span key={p.name} style={{ display: "inline-flex", alignItems: "center" }}>
             <button
-              key={p.name}
               disabled={busy === `preset:${p.name}`}
               onClick={() => applyPreset(p)}
               title={p.description}
               style={{
-                padding: "5px 12px", fontSize: 13, borderRadius: 14, cursor: "pointer",
-                border: "1px solid #cbd5e1", background: busy === `preset:${p.name}` ? "#eef" : "#f8fafc",
+                padding: "5px 12px", fontSize: 13, cursor: "pointer", border: "1px solid #cbd5e1",
+                borderRadius: p.builtin === false ? "14px 0 0 14px" : 14,
+                background: busy === `preset:${p.name}` ? "#eef" : "#f8fafc",
               }}
             >
               {p.name}
             </button>
-          ))}
-          <span style={{ fontSize: 12, color: "#999" }}>apply a profile, then fine-tune below</span>
-        </div>
-      )}
+            {p.builtin === false && (
+              <button
+                disabled={busy === "user-presets"}
+                onClick={() => deletePreset(p.name)}
+                title={`Delete preset "${p.name}"`}
+                style={{
+                  padding: "5px 8px", fontSize: 13, borderRadius: "0 14px 14px 0", cursor: "pointer",
+                  border: "1px solid #cbd5e1", borderLeft: "none", background: "#f8fafc", color: "#b00",
+                }}
+              >
+                ×
+              </button>
+            )}
+          </span>
+        ))}
+        <button
+          disabled={busy === "user-presets"}
+          onClick={saveCurrentAsPreset}
+          title="Save the current stage toggles as a named preset"
+          style={{
+            padding: "5px 12px", fontSize: 13, borderRadius: 14, cursor: "pointer",
+            border: "1px dashed #cbd5e1", background: "#fff", color: "#555",
+          }}
+        >
+          ＋ Save current
+        </button>
+        <span style={{ fontSize: 12, color: "#999" }}>apply a profile, save your own, then fine-tune below</span>
+      </div>
       {(["llm", "index"] as Lane[]).map((lane) => {
         const meta = LANE_META[lane];
         const laneStages = stages.filter((s) => s.lane === lane);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -323,6 +323,8 @@ const config_field_t config_fields[] = {
      sizeof(int), 0, CFG_BOOL},
     {"kb_curator_stage_order", offsetof(config_t, kb_curator_stage_order),
      sizeof(((config_t *)0)->kb_curator_stage_order), 0, CFG_STRING},
+    {"kb_curator_user_presets", offsetof(config_t, kb_curator_user_presets),
+     sizeof(((config_t *)0)->kb_curator_user_presets), 0, CFG_STRING},
     {"kb_curator_extract_code_enabled", offsetof(config_t, kb_curator_extract_code_enabled),
      sizeof(int), 0, CFG_BOOL},
     {"kb_curator_resolve_entities_enabled", offsetof(config_t, kb_curator_resolve_entities_enabled),

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -48,6 +48,7 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_promote_min_sources = 3;
    cfg->kb_curator_extract_command[0] = '\0';
    cfg->kb_curator_stage_order[0] = '\0';
+   cfg->kb_curator_user_presets[0] = '\0';
    cfg->kb_curator_judge_command[0] = '\0';
    cfg->kb_curator_synthesize_command[0] = '\0';
    cfg->kb_curator_synthesize_k = 8;
@@ -359,6 +360,11 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
    if (stage_order && cJSON_IsString(stage_order) && stage_order->valuestring)
       snprintf(cfg->kb_curator_stage_order, sizeof(cfg->kb_curator_stage_order), "%s",
                stage_order->valuestring);
+
+   const cJSON *user_presets = cJSON_GetObjectItemCaseSensitive(curator, "user_presets");
+   if (user_presets && cJSON_IsString(user_presets) && user_presets->valuestring)
+      snprintf(cfg->kb_curator_user_presets, sizeof(cfg->kb_curator_user_presets), "%s",
+               user_presets->valuestring);
 
    const cJSON *judge_command = cJSON_GetObjectItemCaseSensitive(curator, "judge_command");
    if (judge_command && cJSON_IsString(judge_command) && judge_command->valuestring)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1574,6 +1574,11 @@ typedef struct config
     * invalid order falls back to registry order with a WARN. Opt-in: unset changes
     * nothing. See docs/proposals/pending/user-configurable-curator-pipeline.md. */
    char kb_curator_stage_order[512];
+   /* User-defined curator presets as a JSON array string:
+    * [{"name":"...","enabled":["kb_curator_..._enabled",...]}]. Merged with the
+    * built-in presets on the curator.stages endpoint; the GUI saves/deletes named
+    * profiles here via config.set (flat string, no bespoke op). Empty = none. */
+   char kb_curator_user_presets[4096];
    int kb_curator_extract_max_tokens;
    int kb_curator_max_attempts;
    /* Curator LLM provider (curator-llm-backend §2), operator-owned and kb-level

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -475,7 +475,50 @@ cJSON *kb_curator_presets_json(void)
       for (char *tok = strtok_r(buf, ",", &save); tok; tok = strtok_r(NULL, ",", &save))
          cJSON_AddItemToArray(keys, cJSON_CreateString(tok));
       cJSON_AddItemToObject(o, "enabled", keys);
+      cJSON_AddBoolToObject(o, "builtin", 1);
       cJSON_AddItemToArray(arr, o);
+   }
+   /* Append user-defined presets from kb.curator.user_presets (a JSON array string
+    * the GUI edits via config.set). Marked builtin:false so the GUI shows them as
+    * deletable. Malformed entries are skipped; capped so a bad config can't blow up
+    * the response. */
+   config_t cfg;
+   config_load(&cfg);
+   if (cfg.kb_curator_user_presets[0])
+   {
+      cJSON *ups = cJSON_Parse(cfg.kb_curator_user_presets);
+      if (ups && cJSON_IsArray(ups))
+      {
+         int count = 0;
+         cJSON *up = NULL;
+         cJSON_ArrayForEach(up, ups)
+         {
+            if (count >= 64)
+               break;
+            if (!cJSON_IsObject(up))
+               continue;
+            cJSON *nm = cJSON_GetObjectItemCaseSensitive(up, "name");
+            cJSON *en = cJSON_GetObjectItemCaseSensitive(up, "enabled");
+            if (!cJSON_IsString(nm) || !nm->valuestring || !cJSON_IsArray(en))
+               continue;
+            cJSON *o = cJSON_CreateObject();
+            cJSON_AddStringToObject(o, "name", nm->valuestring);
+            cJSON *dsc = cJSON_GetObjectItemCaseSensitive(up, "description");
+            cJSON_AddStringToObject(o, "description",
+                                    (cJSON_IsString(dsc) && dsc->valuestring) ? dsc->valuestring
+                                                                              : "User preset");
+            cJSON *keys = cJSON_CreateArray();
+            cJSON *k = NULL;
+            cJSON_ArrayForEach(k, en) if (cJSON_IsString(k) && k->valuestring)
+                cJSON_AddItemToArray(keys, cJSON_CreateString(k->valuestring));
+            cJSON_AddItemToObject(o, "enabled", keys);
+            cJSON_AddBoolToObject(o, "builtin", 0);
+            cJSON_AddItemToArray(arr, o);
+            count++;
+         }
+      }
+      if (ups)
+         cJSON_Delete(ups);
    }
    return arr;
 }


### PR DESCRIPTION
Phase C of the user-configurable pipeline — the 'ultimately user-defined presets' ask, on top of the built-ins (#1173).

## What
Save the current stage toggles as a **named preset**; delete your own. Built-ins stay read-only.

## How
- **config:** `kb_curator_user_presets` — a JSON array string (`[{name,enabled:[config_key],...}]`) in config_t + `kb.curator` parse + `config_fields` allowlist. The GUI edits it with a flat `config.set` (no bespoke op).
- **KB:** `kb_curator_presets_json` marks built-ins `builtin:true` and appends parsed user presets (`builtin:false`), skipping malformed entries, capped at 64. Served on the existing `curator.stages` endpoint.
- **Frontend:** '＋ Save current' (prompts a name, captures enabled config keys) + a delete (×) on user presets; apply reuses the existing path.

## Verified / pending
`aimee-kb` compiles + links clean; `tsc -b` clean; `make lint` clean (docs-gen, clang-format, conformance — reuses the endpoint). Runtime validation-pending until release deploy. Design in the proposal; roundtable was unavailable this session (flagged).

Remaining: Phase D (user-added **composed** stages) is left **designed, not built** — it's architectural and precisely what the roundtable should vet.