### PR TITLE
bench(swebench): wire the agentic supervised SWE-bench live paths (#987)

### DIFF
--- a/benchmarks/coding/AGENTIC_SWEBENCH_WIRING_STATUS.md
+++ b/benchmarks/coding/AGENTIC_SWEBENCH_WIRING_STATUS.md
@@ -57,6 +57,26 @@ tool-row assertion). Fully unit-tested.
 4. **The claim gate is human-gated by design** (S6 criterion 6: an independent reviewer who did not
    author the harness) — it can never be auto-satisfied autonomously.
 
+## Multi-provider roundtable review (6 providers, 0 failed) — fixes applied
+
+A full-panel `aimee delegate aggregate` review of the wiring plan (codex, GLM-5.2, MiniMax-M3,
+mistral, mimo-v2.5-pro, gpu-mid) flagged two real honesty issues, both **fixed**:
+
+- **Hallucination gap (biggest risk).** A response-text ```diff the agent *wrote* but never
+  *applied* must not be graded. **Fix:** in co-located mode the graded patch is the actual
+  filesystem diff (`git diff base_commit`) only; a response-text diff is tagged
+  `patch_source="response_text"` and `AgenticResult.authoritative` is False (never graded). If the
+  workspace is clean the record grades nothing (`patch_source="none"`). Proven by
+  `TestHallucinationGapGuard` (the claimed "lie" diff is excluded; the real FS edit is graded).
+- **Attribution fragility.** Prefer EXACT `delegation_id` matching (captured from
+  `delegation_spawns`) over the job-id `LIKE '%-<job_id>'` heuristic; the LIKE remains a fallback
+  when capture is unavailable. Records now carry `patch_source` for reporter exclusion.
+
+Panel items that are **validation-pending** (need the real ledger to confirm): arm-A token
+granularity (does the transport emit a `token_audit` row per internal sub-turn under one
+`delegation_id`? — the exact-delegation sum captures however many rows exist, but the per-sub-turn
+emission itself is unconfirmed); and that $0-priced worker dispatches still emit realized rows.
+
 ## Why the proposal is NOT moved to `done`
 
 Acceptance criteria #5 and #6 are deployment-tier: the official graded suite on CT 101 across

--- a/benchmarks/coding/AGENTIC_SWEBENCH_WIRING_STATUS.md
+++ b/benchmarks/coding/AGENTIC_SWEBENCH_WIRING_STATUS.md
@@ -1,0 +1,65 @@
+# Agentic supervised SWE-bench (#987) — live-wiring status
+
+Status of wiring the 7 live `NotImplementedError` stubs in the agentic supervised SWE-bench
+harness. Honest split of **implemented / locally-verified / validation-pending**. Written
+2026-07-08 (autonomous session, JBailes). The proposal is
+`docs/proposals/pending/agentic-supervised-swebench.md`.
+
+## Summary
+
+The pure S0–S6 cores were already merged + unit-tested. This work wired every live stub onto the
+**`aimee delegate` transport + job-id attribution** model (the deployment-verified correction from
+`swebench_live_attribution.py`, not the theoretical `/v1/runs` EMPTY-polarity model). All
+reproducibility-critical logic is pure and unit-tested; the live glue is thin, composes the tested
+cores, and takes injected seams so it is exercised in CI with a fake fleet.
+
+**Bench tests: 593 pass** (`python3 -m unittest discover -s benchmarks/tests`), +~35 new. The S0–S6
+runbook fast-check (161 tests) is green.
+
+## What was wired (previously `NotImplementedError`)
+
+| stub | module | status |
+|---|---|---|
+| `run_agentic_loop` | `swebench_agentic_harness.py` (S1) | wired: provision → dispatch `code --tools --worktree` → extract patch (workspace diff, else returned diff) |
+| `run_arm_a` | `swebench_arm_runner.py` (S2) | wired: composes the loop + job-id token headline; two wall-clocks |
+| `run_arm_c_supervised` | `swebench_supervision.py` (S3) | wired: Option A — N concurrent workers + tools-OFF supervisor + deterministic best-of-N + gated escalation |
+| `run_suite` | `swebench_suite.py` (S5) | wired: run-plan → arms → official grade (lease + retry) → K-aggregate → report; injected seams |
+| `run_live_matrix` | `swebench_live_attribution.py` (S0-live) | wired: dispatch primary+worker probe → verify L1–L4 over the real schema |
+| `_invoke_v1_runs`, `_invoke_agent_shell` | `swebench_transport_verify.py` (S0) | intentionally left raising, message updated to redirect to the sanctioned delegate transport (the `/v1/runs` EMPTY-polarity model is superseded) |
+
+New module: `swebench_live_transport.py` — the single live transport (argv build with the
+tools⇒worktree invariant, dispatch/poll with an injectable runner, job-id token split, supervisor
+tool-row assertion). Fully unit-tested.
+
+## Verified from this box
+
+- **Fleet transport works** via the .254 gateway: dispatch → `job_id` → poll → terminal `result`
+  (real `GLM-5.2` jobs 25/26). `aimee insights` confirms the token ledger is real and reachable in
+  aggregate (my glm-5.2 calls appear).
+- **All pure logic + the dispatch/poll loop** are unit-tested with a fake fleet (593 green).
+- **Multi-provider consultation** (`aimee delegate aggregate`) engages all 6 providers
+  (mimo-v2.5-pro, GLM-5.2, gpu-mid, MiniMax-M3, mistral, codex; 0 failed).
+
+## Validation-pending (needs hardware not reachable from this box) — **hypothesis, unverified**
+
+1. **End-to-end graded run + claim gate (acceptance #5/#6).** Requires the official SWE-bench
+   grader on **CT 101** (real docker + py3.11). Verified 2026-07-08 that the `.253` host docker is
+   the **LXC2Docker shim** (mangles images) with py3.13 and ~14G root — unsuitable; confirms the
+   documented CT-101-only rule. Grading was **not executed**; `official_grade_fn` parses the report
+   `resolved_ids` but that parse is validated against the documented schema, not a live report.
+2. **Real-ledger token attribution.** The ledger lives on the fleet host
+   (`/mnt/media/.plugins/aimee-server/server/home/aimee.db` on .254); this box reaches the fleet via
+   the gateway but has no SSH/DB access. The job-id split logic is unit-tested; the numbers against
+   the real ledger are pending.
+3. **Workspace co-location.** Arm-A/C workers must edit a repo checked out at `base_commit`
+   co-located with where the delegate executes (server-side on the fleet). The provisioning +
+   extraction functions are tested; the co-located server-side execution is the operator step.
+4. **The claim gate is human-gated by design** (S6 criterion 6: an independent reviewer who did not
+   author the harness) — it can never be auto-satisfied autonomously.
+
+## Why the proposal is NOT moved to `done`
+
+Acceptance criteria #5 and #6 are deployment-tier: the official graded suite on CT 101 across
+Benchmark 1 (K=10) **and** Benchmark 2, plus an **independent** claim-gate reviewer. Those require
+the co-located fleet + CT-101 real docker + a human reviewer and cannot be completed from this
+client box. The code is wired and CI-green; the graded run + gate remain the operator's step.

--- a/benchmarks/coding/SUPERVISED_SWEBENCH.md
+++ b/benchmarks/coding/SUPERVISED_SWEBENCH.md
@@ -122,8 +122,10 @@ live parts (server transport, per-worker container, official grading) as marked 
 
 | module | slice | role |
 |---|---|---|
-| `swebench_transport_verify.py` | S0 | 5 token-attribution assertions (primary = `delegation_id` EMPTY; no cross-bill; cache split; primary tools billed) — the blocking transport gate |
-| `swebench_agentic_harness.py` | S1 | per-worker workspace provision at `base_commit`, per-worker OS-resource allocator, canonical secret-redacted patch (`git add -A` → `diff --cached`), loop bounds |
+| `swebench_transport_verify.py` | S0 | 5 FAKE-mode token-attribution assertions (theoretical EMPTY-polarity model — **superseded live** by the delegate transport; kept as the CI gate) |
+| `swebench_live_attribution.py` | S0-live | the **corrected** deployment model + `run_live_matrix` (L1–L4 over the real `delegation_spawns`/`token_audit`, job-id partitioned) |
+| `swebench_live_transport.py` | S0–S5 | the live `aimee delegate` transport: argv build (tools ⇒ worktree), dispatch/poll (injectable runner), job-id token split, supervisor-tool-row assertion |
+| `swebench_agentic_harness.py` | S1 | per-worker workspace provision at `base_commit`, per-worker OS-resource allocator, canonical secret-redacted patch (`git add -A` → `diff --cached`), loop bounds, **`run_agentic_loop`** (live) |
 | `swebench_arm_runner.py` | S2 | arm A runner + shared measurement core: **uncached** primary-token headline, two wall-clocks (total vs work) |
 | `swebench_supervision.py` | S3 | arm C honesty core: hard-capped leak-guarded digests, **deterministic** best-of-N, gated escalation, context fold, tool allowlist |
 | `supervised_report_panels.py` | S4 | BCa CI, Pareto, selection-skill (oracle vs actual), escalation exclusion, context drift, two-wall-clock, arm-parity |
@@ -153,6 +155,8 @@ withheld, the summary still reports the honest number, e.g.
 ```bash
 python3 -m unittest \
   benchmarks.tests.test_swebench_transport_verify \
+  benchmarks.tests.test_swebench_live_transport \
+  benchmarks.tests.test_swebench_live_attribution \
   benchmarks.tests.test_swebench_agentic_harness \
   benchmarks.tests.test_swebench_arm_runner \
   benchmarks.tests.test_swebench_supervision \
@@ -161,10 +165,60 @@ python3 -m unittest \
   benchmarks.tests.test_swebench_claim_gate
 ```
 
-## Live run (needs the .254 fleet + CT 101 real docker)
+## Live transport (the corrected, deployment-verified model)
 
-The live transport, per-worker container, and official grading are marked
-`NotImplementedError` stubs that print the exact wiring step. Wire them against the `.254`
-fleet (`run_agentic_loop`, `run_arm_a`, `run_arm_c_supervised`, `run_suite`) and grade on CT 101
-per the recipe above; feed the records through `supervised_report` + `supervised_report_panels`,
-then `swebench_claim_gate`.
+The live paths are **wired** on the `aimee delegate` transport (`swebench_live_transport.py`),
+which supersedes the theoretical `/v1/runs` + EMPTY-delegation-polarity model. This is not a
+choice — a live 2026-07-05 run (`swebench_live_attribution.py`) established that the real fleet
+emits almost no EMPTY-delegation rows, so the harness runs **both** the primary and the workers as
+`aimee delegate` jobs and distinguishes them by **which delegation_id (job_id) it dispatched**:
+
+- **Dispatch:** `aimee delegate <role> --via <agent> --tools --worktree <branch> --json --durable`.
+  A tools-enabled dispatch **must** carry `--worktree` (FINDING 4: the parent-worktree write-guard
+  silently blocks a plain `--tools` delegate). `build_delegate_argv` enforces this.
+- **Attribution:** a dispatch's `delegation_id` ends in `-<job_id>` (the CLI job_id), so primary
+  tokens = `SUM(token_audit WHERE model=<primary> AND usage_kind='realized' AND delegation_id LIKE
+  '%-<job_id>')`, headline = `prompt − cache_read` (uncached). Reuses PR #986 job-id scoping.
+- **Arm A** = one `code --tools --worktree` primary dispatch (its own multi-turn loop runs
+  internally); tokens read by its job_id.
+- **Arm C** (Option A, roundtable 2026-07-08) = N concurrent `code --tools --worktree` **worker**
+  dispatches (priced $0) + **one tools-OFF** `review` **supervisor** dispatch over capped,
+  leak-guarded digests. "No raw code" is **structural** (the supervisor has no tool loop). The
+  submitted patch is chosen by the **pure, deterministic** `select_best_of_n` (reproducible); the
+  supervisor's tokens are the arm-C headline. Runtime gate: `supervisor_tool_call_rows` must be 0.
+- **Patch:** preferred from the co-located workspace (`git diff <base_commit>`, byte-stable), else
+  the delegate's returned ```diff (both secret-redacted).
+
+## Live run (needs the fleet + CT 101 real docker)
+
+```python
+from benchmarks.coding import swebench_suite as Q
+# Prep instances first (swebench_supervised_prep.py) into <regions_dir>/<instance-set>/.
+out = Q.run_suite(only=["b1_reddit10"], token_db="$AIMEE_HOME/aimee.db",
+                  regions_dir="benchmarks/results/swebench_supervised/regions",
+                  workers=["GLM-5.2","MiniMax-M3","mistral-medium-3-5","mimo-v2.5-pro","gpu-mid"],
+                  primary_agent="codex", primary_model="gpt-5.5",
+                  base_repos={"django/django": "/path/to/django/clone", ...})
+# out["records_by_run"] -> supervised_report + supervised_report_panels -> swebench_claim_gate.
+```
+
+**S0 live gate** (run on the ledger host, or a host with a readable copy of the aimee.db):
+
+```python
+from benchmarks.coding.swebench_live_attribution import run_live_matrix
+r = run_live_matrix(db_path="$AIMEE_HOME/aimee.db", primary_agent="codex", worker="GLM-5.2")
+assert r["passed"]   # L1-L4 over the real delegation_spawns/token_audit schema
+```
+
+### Deployment prerequisites (validation-pending until run on real hardware)
+
+1. **Grading host.** The official grader (`swebench.harness.run_evaluation`) needs **real docker +
+   python3.11**. The `.253/.254` host docker is the **LXC2Docker shim** (mangles stock images) and
+   host python is too new → grade on **CT 101** (real docker, py3.11) only. `official_grade_fn`
+   derives resolved ids from the harness report (`resolved_ids`).
+2. **Workspace co-location.** Arm-A/C workers edit a repo checked out at `base_commit`; that
+   workspace must be co-located with where the delegate executes (server-side on the fleet). Pass
+   `base_repos` mapping each repo → its base clone; `provision_workspace` builds the per-worker
+   worktree.
+3. **Ledger access.** Token attribution reads `token_db` on the fleet host; the client-only box
+   sees the fleet via the gateway but not the ledger file.

--- a/benchmarks/coding/swebench_agentic_harness.py
+++ b/benchmarks/coding/swebench_agentic_harness.py
@@ -302,14 +302,126 @@ def workspace_fingerprint(repo: str, base_commit: str, patch: str) -> str:
     return h.hexdigest()[:16]
 
 
-# ------------------------------------------------------------ LIVE stubs -------
-# The following need a live server / .254 workspace / container / grader and are NOT exercised in
-# CI. They fail honestly with the exact wiring to do, mirroring S0's stub discipline.
+# ------------------------------------------------------------ agentic loop -----
+# S1 live wiring (roundtable 2026-07-05 + arm-C transport ruling 2026-07-08). A tools-using
+# delegate runs its OWN explore/edit/test loop server-side under ONE dispatch; the loop bound is
+# handed to the delegate as --max-turns/--timeout. The diff is taken from the provisioned
+# workspace (`git diff base_commit`, byte-stable) when the workspace is co-located with the
+# delegate, else from the delegate's returned unified diff (the proven PR #986 text path). Both
+# paths run scan_and_redact_secrets. Attribution is by the dispatch's job_id (delegation_id ends
+# in `-<job_id>`), captured here so the caller can read tokens without touching the filesystem.
+_DIFF_LINE = re.compile(r"^(diff --git |index |--- |\+\+\+ |@@ |[ +\-\\]|rename |similarity |"
+                        r"new file |deleted file |old mode |new mode |Binary )")
+
+
+def extract_diff_from_text(text: str) -> str:
+    """Pull a unified diff out of a delegate's response and STOP at the first non-diff line so
+    trailing prose is never submitted as a patch. Mirrors bench_swebench_supervised._extract_diff
+    (the merged single-shot extractor) so the agentic arm and the single-shot arm agree."""
+    if not text:
+        return ""
+    m = re.search(r"```diff\s*\n(.*?)```", text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+    lines = text.splitlines()
+    start = next((i for i, ln in enumerate(lines)
+                  if ln.startswith("diff --git ") or ln.startswith("--- ")), None)
+    if start is None:
+        return ""
+    out = []
+    for ln in lines[start:]:
+        if ln == "" or _DIFF_LINE.match(ln):
+            out.append(ln)
+        else:
+            break
+    return "\n".join(out).strip()
+
+
+def agentic_prompt(instance: dict, *, arm: str) -> str:
+    """The bounded problem statement handed to a tools-using delegate. It gets the issue text and
+    (when the prep extracted one) the focal file/region as a hint, and is told to edit the repo
+    in its workspace and END by emitting the full unified diff (```diff fenced) so the harness can
+    extract a patch even when it cannot read the delegate's server-side worktree."""
+    repo = instance.get("repo", "the repository")
+    problem = instance.get("problem") or instance.get("problem_statement", "")
+    focal = instance.get("file", "")
+    region = instance.get("region", "")
+    hint = f"\n\nThe fix likely touches `{focal}`.\n```python\n{region}\n```" if region else ""
+    return (f"You are fixing a bug in {repo}. Explore the checked-out repository in your "
+            f"workspace, make the minimal edit that resolves the issue, and (if you can) run the "
+            f"relevant tests.\n\n## Issue\n{problem}{hint}\n\nWhen done, output the COMPLETE fix as "
+            f"a single unified git diff in a ```diff fenced block (a/ and b/ prefixes, correct "
+            f"context lines). Do not commit; leave the working tree dirty.")
+
+
+@dataclass
+class AgenticResult:
+    """One worker/primary agentic run: the emitted patch + attribution handles + loop telemetry."""
+    patch: str
+    redactions: int
+    job_id: int | None
+    delegation_id: str | None
+    agent: str
+    status: str
+    api_calls: int
+    error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "done" and not self.error and bool(self.patch.strip())
+
+
+def worktree_branch(instance_id: str, arm: str, worker_idx: int) -> str:
+    """Deterministic per-(instance,arm,worker) worktree branch (F2 isolation naming)."""
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "-", f"{instance_id}-{arm}-{worker_idx}")
+    return f"aimee/wi/swebench-{safe}"
+
+
 def run_agentic_loop(instance: dict, env: WorkerEnv, budget: LoopBudget, *, arm: str,
-                     worker: str | None = None) -> str:
-    raise NotImplementedError(
-        "live agentic loop not wired. arm C: dispatch a tools-enabled `code`/`execute` delegate "
-        "against a server-side .254 workspace (Q3 option a), poll to a bounded terminal, extract "
-        "`git -C <ws> diff <base_commit>`. arm A: drive the same loop via the S0 /v1/runs "
-        "transport. In-loop tests default OFF (Q1 c); isolation via per-worker container or the "
-        "venv+EnvAllocator fallback (Q2).")
+                     worker: str | None = None, base_repo: str | None = None,
+                     token_db: str = "", session_id: str = "", worker_idx: int = 0,
+                     aimee_bin: str = "aimee", role: str = "code",
+                     dispatch=None) -> AgenticResult:
+    """Live per-instance agentic loop, shared by arm A (primary drives) and arm C (worker drives).
+
+    Provisions an isolated workspace at base_commit (when `base_repo` is given and co-located with
+    the delegate), dispatches ONE tools-enabled `code` delegate on a per-worker worktree branch
+    (FINDING 4: tools need --worktree), polls to a bounded terminal, and extracts a canonical,
+    secret-redacted patch — preferring the workspace diff, falling back to the delegate's returned
+    diff text. `dispatch` is injected (default: the live transport) so CI drives a fake fleet.
+
+    Returns an AgenticResult; a fleet/patch failure is recorded on it, never raised."""
+    from benchmarks.coding import swebench_live_transport as _T
+    if dispatch is None:
+        dispatch = _T.dispatch_and_wait
+    instance_id = instance["instance_id"]
+    base_commit = instance.get("base_commit", "")
+    branch = worktree_branch(instance_id, arm, worker_idx)
+
+    if base_repo:
+        try:
+            provision_workspace(base_repo, base_commit, env.workspace)
+        except ProvisionError as e:
+            return AgenticResult("", 0, None, None, worker or "", "error", 0, error=str(e))
+
+    outcome = dispatch(
+        role, agentic_prompt(instance, arm=arm), aimee_bin=aimee_bin, via=worker,
+        persona="engineer", tools=True, worktree=branch, max_turns=budget.max_turns,
+        timeout_ms=int(budget.max_wall_s * 1000), token_db=token_db, session_id=session_id)
+
+    # Prefer the byte-stable workspace diff when the delegate edited a co-located checkout; else
+    # fall back to the delegate's returned diff text (the proven PR #986 path).
+    patch, redactions = "", 0
+    ws = Path(env.workspace)
+    if base_repo and (ws / ".git").exists():
+        try:
+            patch, redactions = extract_patch(env.workspace, base_commit)
+        except (PatchError, ProvisionError, subprocess.CalledProcessError):
+            patch = ""
+    if not patch.strip():
+        patch, redactions = scan_and_redact_secrets(extract_diff_from_text(outcome.result))
+
+    status = outcome.status if outcome.job_id is not None else "error"
+    return AgenticResult(patch=patch, redactions=redactions, job_id=outcome.job_id,
+                         delegation_id=outcome.delegation_id, agent=outcome.agent_name or (worker or ""),
+                         status=status, api_calls=outcome.api_calls, error=outcome.error)

--- a/benchmarks/coding/swebench_agentic_harness.py
+++ b/benchmarks/coding/swebench_agentic_harness.py
@@ -365,6 +365,16 @@ class AgenticResult:
     status: str
     api_calls: int
     error: str = ""
+    patch_source: str = "none"      # "workspace" | "response_text" | "none"
+    returned_diff: str = ""          # the diff text the delegate CLAIMED (diagnostic only)
+
+    @property
+    def authoritative(self) -> bool:
+        """A patch is graded-authoritative ONLY when it came from the co-located workspace's actual
+        filesystem state (`git diff`). A response-text diff is a CLAIM the agent may not have applied
+        — grading it would decouple 'resolved' from the filesystem (the roundtable's hallucination-
+        gap risk), so it is never authoritative."""
+        return self.patch_source == "workspace" and bool(self.patch.strip())
 
     @property
     def ok(self) -> bool:
@@ -409,19 +419,27 @@ def run_agentic_loop(instance: dict, env: WorkerEnv, budget: LoopBudget, *, arm:
         persona="engineer", tools=True, worktree=branch, max_turns=budget.max_turns,
         timeout_ms=int(budget.max_wall_s * 1000), token_db=token_db, session_id=session_id)
 
-    # Prefer the byte-stable workspace diff when the delegate edited a co-located checkout; else
-    # fall back to the delegate's returned diff text (the proven PR #986 path).
-    patch, redactions = "", 0
+    returned_diff = extract_diff_from_text(outcome.result)   # what the delegate CLAIMED (diagnostic)
+    patch, redactions, source = "", 0, "none"
     ws = Path(env.workspace)
-    if base_repo and (ws / ".git").exists():
-        try:
-            patch, redactions = extract_patch(env.workspace, base_commit)
-        except (PatchError, ProvisionError, subprocess.CalledProcessError):
-            patch = ""
-    if not patch.strip():
-        patch, redactions = scan_and_redact_secrets(extract_diff_from_text(outcome.result))
+    if base_repo:
+        # Co-located mode: the ACTUAL filesystem diff is the ONLY graded source (anti hallucination-
+        # gap — a response-text diff the agent never applied must never be graded). If git diff
+        # yields nothing, the extraction failed; we do NOT fall back to the claimed text.
+        if (ws / ".git").exists():
+            try:
+                patch, redactions = extract_patch(env.workspace, base_commit)
+                source = "workspace" if patch.strip() else "none"
+            except (PatchError, ProvisionError, subprocess.CalledProcessError):
+                patch, source = "", "none"
+    else:
+        # Degraded/dev mode (no co-located workspace): the returned text is all there is. Flag it
+        # NON-AUTHORITATIVE so the reporter can exclude it from the graded headline.
+        patch, redactions = scan_and_redact_secrets(returned_diff)
+        source = "response_text" if patch.strip() else "none"
 
     status = outcome.status if outcome.job_id is not None else "error"
     return AgenticResult(patch=patch, redactions=redactions, job_id=outcome.job_id,
                          delegation_id=outcome.delegation_id, agent=outcome.agent_name or (worker or ""),
-                         status=status, api_calls=outcome.api_calls, error=outcome.error)
+                         status=status, api_calls=outcome.api_calls, error=outcome.error,
+                         patch_source=source, returned_diff=returned_diff)

--- a/benchmarks/coding/swebench_arm_runner.py
+++ b/benchmarks/coding/swebench_arm_runner.py
@@ -146,12 +146,17 @@ def _fake_arm_a_record(instance, primary_model):
 
 
 # ------------------------------------------------------------ token assembly ---
-def primary_tokens_by_jobs(token_db: str, primary_model: str, job_ids: list) -> PrimaryTokens:
-    """PrimaryTokens for a LIVE agentic run: sum the primary's realized turns over its dispatch
-    job_ids (delegation_id ends in `-<job_id>`). This is the deployment attribution (NON-EMPTY
-    delegation_id, job-id partitioned) — `primary_token_totals` above stays for the EMPTY-polarity
-    FAKE/theoretical path (swebench_live_attribution FINDING 1)."""
-    uncached, cached, output, turns = T.read_realized_by_jobs(token_db, primary_model, job_ids)
+def primary_tokens_by_jobs(token_db: str, primary_model: str, job_ids: list,
+                           delegation_ids: list | None = None) -> PrimaryTokens:
+    """PrimaryTokens for a LIVE agentic run. PREFERS exact delegation_id matching (when the dispatch
+    captured a delegation_id from delegation_spawns); falls back to the job-id `LIKE '%-<job_id>'`
+    scoping (PR #986) when capture was unavailable. This is the deployment attribution (NON-EMPTY
+    delegation_id) — `primary_token_totals` stays for the EMPTY-polarity FAKE/theoretical path."""
+    dids = [d for d in (delegation_ids or []) if d]
+    if dids:
+        uncached, cached, output, turns = T.read_realized_by_delegations(token_db, dids)
+    else:
+        uncached, cached, output, turns = T.read_realized_by_jobs(token_db, primary_model, job_ids)
     return PrimaryTokens(input_uncached=uncached, input_cached=cached, output=output, turns=turns)
 
 
@@ -173,7 +178,8 @@ def run_arm_a(instance: dict, primary_model: str, *, token_db: str, base_repo: s
                              base_repo=base_repo, token_db=token_db, aimee_bin=aimee_bin,
                              dispatch=dispatch)
     t1 = now()
-    tok = primary_tokens_by_jobs(token_db, primary_model, [res.job_id])
+    tok = primary_tokens_by_jobs(token_db, primary_model, [res.job_id],
+                                 delegation_ids=[res.delegation_id])
     wall = WallClock(t0=t0, first_work=t0, t1=t1)  # single dispatch: queue folded into work
     rec = build_arm_record(
         instance_id, "A", primary_model, tokens=tok, worker_in=0, worker_out=0, wall=wall,
@@ -183,6 +189,7 @@ def run_arm_a(instance: dict, primary_model: str, *, token_db: str, base_repo: s
     # The secret-redacted patch text is needed by the official grader (build_predictions); the
     # record already carries only the fingerprint for the ledger, so attach the patch explicitly.
     rec["patch"] = res.patch
+    rec["patch_source"] = res.patch_source   # "workspace" (graded) | "response_text" (non-authoritative)
     rec["job_id"] = res.job_id
     rec["agent"] = res.agent
     return rec

--- a/benchmarks/coding/swebench_arm_runner.py
+++ b/benchmarks/coding/swebench_arm_runner.py
@@ -24,6 +24,7 @@ is NOT extractable today. `thinking_tokens` is reported as None until the ledger
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -31,6 +32,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from benchmarks.coding import swebench_transport_verify as V
 from benchmarks.coding import swebench_agentic_harness as H
+from benchmarks.coding import swebench_live_transport as T
 
 _FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
 
@@ -143,15 +145,44 @@ def _fake_arm_a_record(instance, primary_model):
                             repo=instance.get("repo", "x/y"), redactions=red)
 
 
+# ------------------------------------------------------------ token assembly ---
+def primary_tokens_by_jobs(token_db: str, primary_model: str, job_ids: list) -> PrimaryTokens:
+    """PrimaryTokens for a LIVE agentic run: sum the primary's realized turns over its dispatch
+    job_ids (delegation_id ends in `-<job_id>`). This is the deployment attribution (NON-EMPTY
+    delegation_id, job-id partitioned) — `primary_token_totals` above stays for the EMPTY-polarity
+    FAKE/theoretical path (swebench_live_attribution FINDING 1)."""
+    uncached, cached, output, turns = T.read_realized_by_jobs(token_db, primary_model, job_ids)
+    return PrimaryTokens(input_uncached=uncached, input_cached=cached, output=output, turns=turns)
+
+
 # ------------------------------------------------------------ live entry -------
 def run_arm_a(instance: dict, primary_model: str, *, token_db: str, base_repo: str,
-              allocator: "H.EnvAllocator", budget: "H.LoopBudget") -> dict:
-    """Live arm-A run for one instance. Provisions a workspace, drives the primary agentic loop
-    via the S0-verified /v1/runs transport, extracts the patch, and reads the primary's tokens
-    from token_audit scoped to the run's session_id. Marked live (needs a server)."""
+              allocator: "H.EnvAllocator", budget: "H.LoopBudget", primary_agent: str | None = None,
+              aimee_bin: str = "aimee", dispatch=None, now=time.perf_counter) -> dict:
+    """Live arm-A run for one instance. Provisions a workspace, drives the primary agentic loop as
+    a tools-enabled `code` delegate (routed via `primary_agent`, e.g. codex=gpt-5.5), extracts the
+    patch, and reads the primary's tokens from token_audit scoped to the dispatch's job_id. The
+    `dispatch` seam is injected so this is drivable with a fake fleet; `resolved` is left None here
+    and set later by the official grader (S5). Requires a live server on the real path."""
     if _FAKE:
         return _fake_arm_a_record(instance, primary_model)
-    raise NotImplementedError(
-        "live arm-A run not wired: provision via H.provision_workspace, drive H.run_agentic_loop "
-        "(arm='A', /v1/runs transport), extract via H.extract_patch, then read tokens with "
-        "V.collect_rows(token_db, session_id) + primary_token_totals(). Requires a live server.")
+    instance_id = instance["instance_id"]
+    env = allocator.allocate(instance_id, "A", 0)
+    t0 = now()
+    res = H.run_agentic_loop(instance, env, budget, arm="A", worker=primary_agent,
+                             base_repo=base_repo, token_db=token_db, aimee_bin=aimee_bin,
+                             dispatch=dispatch)
+    t1 = now()
+    tok = primary_tokens_by_jobs(token_db, primary_model, [res.job_id])
+    wall = WallClock(t0=t0, first_work=t0, t1=t1)  # single dispatch: queue folded into work
+    rec = build_arm_record(
+        instance_id, "A", primary_model, tokens=tok, worker_in=0, worker_out=0, wall=wall,
+        resolved=None, patch=res.patch, base_commit=instance.get("base_commit", ""),
+        repo=instance.get("repo", ""), n_workers=1, redactions=res.redactions,
+        invalid=not res.ok)
+    # The secret-redacted patch text is needed by the official grader (build_predictions); the
+    # record already carries only the fingerprint for the ledger, so attach the patch explicitly.
+    rec["patch"] = res.patch
+    rec["job_id"] = res.job_id
+    rec["agent"] = res.agent
+    return rec

--- a/benchmarks/coding/swebench_live_attribution.py
+++ b/benchmarks/coding/swebench_live_attribution.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
+from pathlib import Path
 
 
 # ------------------------------------------------------------ schema names -----
@@ -130,12 +131,67 @@ def verify_live_attribution(con: sqlite3.Connection, primary_did: str,
     return out
 
 
+def split_by_jobs(con: sqlite3.Connection, primary_job_id, worker_job_ids: list) -> dict:
+    """The corrected primary-vs-worker split keyed by CLI job_id (delegation_id ends in `-<job>`),
+    the attribution PR #986 verified and the agentic arms reuse. Realized rows only (FINDING 3)."""
+    def _tot(job_ids):
+        jids = [j for j in job_ids if j is not None]
+        if not jids:
+            return TokenTotals(0, 0, 0, 0)
+        likes = " OR ".join([f"{AUDIT}.delegation_id LIKE ?"] * len(jids))
+        q = (f"SELECT COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(cache_read_tokens),0), "
+             f"COALESCE(SUM(completion_tokens),0), COUNT(*) FROM {AUDIT} "
+             f"WHERE usage_kind='realized' AND ({likes})")
+        prompt, cache_read, completion, rows = con.execute(q, [f"%-{j}" for j in jids]).fetchone()
+        return TokenTotals(max(0, prompt - cache_read), cache_read, completion, rows)
+    p, w = _tot([primary_job_id]), _tot(worker_job_ids)
+    return {"primary_job_id": primary_job_id, "primary_input_uncached": p.input_uncached,
+            "primary_input_cached": p.input_cached, "primary_output": p.output,
+            "primary_headline": p.total_headline, "primary_rows": p.rows,
+            "worker_job_ids": list(worker_job_ids), "worker_input": w.input_uncached + w.input_cached,
+            "worker_output": w.output, "worker_rows": w.rows}
+
+
 # ------------------------------------------------------------ live runner ------
-def run_live_matrix(*, ssh_host: str, db_path: str):
-    raise NotImplementedError(
-        "live matrix runner not wired for autonomous exec: it SSHes to `ssh_host`, copies/queries "
-        f"{db_path} (aimee.db) against delegation_spawns + token_audit, and for a dispatched "
-        "primary+workers run computes primary_worker_split()/verify_live_attribution(). On .254 "
-        "the DB is at /mnt/media/.plugins/aimee-server/server/home/aimee.db and readable over ssh "
-        "(BatchMode key auth). Also note FINDING 4: workers need `delegate ... --worktree` for "
-        "tools to run (the write guard blocks a plain --tools dispatch).")
+def run_live_matrix(*, db_path: str, primary_agent: str = "codex", worker: str = "GLM-5.2",
+                    aimee_bin: str = "aimee", dispatch=None) -> dict:
+    """S0-live gate (corrected model). Dispatch a real PRIMARY agentic probe and a WORKER probe via
+    the delegate transport, then verify attribution over the REAL schema (`db_path` = aimee.db,
+    readable where this runs — the fleet host, or a copy). Returns the assertion matrix + the split.
+
+    Run it on the host that owns the ledger (`$AIMEE_HOME/aimee.db`, or a scp'd copy of
+    /mnt/media/.plugins/aimee-server/server/home/aimee.db on .254). FINDING 4: the worker probe
+    dispatches with `--worktree` so its tools actually run. `dispatch` is injected for CI."""
+    from benchmarks.coding import swebench_live_transport as T
+    if dispatch is None:
+        dispatch = T.dispatch_and_wait
+    probe = ("Read the repository, make a one-line no-op edit to a scratch file, and emit the diff "
+             "in a ```diff block. Use tools.")
+    # Primary probe: a tools-enabled agentic dispatch routed via the primary agent.
+    p = dispatch("code", probe, aimee_bin=aimee_bin, via=primary_agent, tools=True,
+                 worktree="aimee/wi/s0-primary")
+    # Worker probe: same, routed via a cheap worker (FINDING 4: --worktree required).
+    w = dispatch("code", probe, aimee_bin=aimee_bin, via=worker, tools=True,
+                 worktree="aimee/wi/s0-worker")
+    result = {"primary_job_id": p.job_id, "worker_job_id": w.job_id,
+              "primary_status": p.status, "worker_status": w.status,
+              "primary_delegation_id": p.delegation_id, "worker_delegation_id": w.delegation_id}
+    if not db_path or not Path(db_path).exists():
+        result["passed"] = False
+        result["error"] = f"db not readable at {db_path!r} (run on the ledger host)"
+        return result
+    con = sqlite3.connect(db_path)
+    split = split_by_jobs(con, p.job_id, [w.job_id])
+    l1 = split["primary_rows"] >= 1 and split["primary_output"] >= 0
+    l2 = p.delegation_id != w.delegation_id
+    l3 = p.job_id != w.job_id
+    checks = {
+        "L1_primary_measured": (l1, f"{split['primary_rows']} realized primary rows"),
+        "L2_worker_disjoint": (l2, "primary and worker delegation_ids differ"),
+        "L3_no_cross_bill": (l3, "primary and worker job_ids differ (no shared attribution)"),
+        "L4_realized_only": (True, "SQL filters usage_kind='realized'"),
+    }
+    result.update({k: {"ok": ok, "detail": d} for k, (ok, d) in checks.items()})
+    result["split"] = split
+    result["passed"] = all(v[0] for v in checks.values())
+    return result

--- a/benchmarks/coding/swebench_live_transport.py
+++ b/benchmarks/coding/swebench_live_transport.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Live delegate transport for the agentic supervised SWE-bench benchmark (#987).
+
+The single place the live arm-A / arm-C / S0 paths talk to the fleet. It supersedes the
+theoretical `/v1/runs` + EMPTY-delegation-polarity model of `swebench_transport_verify.py`
+with the DEPLOYMENT-VERIFIED model established in `swebench_live_attribution.py` (live .254
+run, 2026-07-05):
+
+  * the "primary" and the workers are BOTH dispatched as `aimee delegate` jobs — a top-level
+    tmux-Claude primary does not reliably emit EMPTY-delegation rows (FINDING 1), so we
+    distinguish primary from worker by WHICH delegation_id the harness dispatched, read from
+    `delegation_spawns` (FINDING 2);
+  * agentic `--tools` needs `--worktree` or the parent-worktree write-guard blocks every tool
+    (FINDING 4) — so a tools-enabled dispatch here ALWAYS carries a worktree branch;
+  * only `usage_kind='realized'` rows are spend (FINDING 3).
+
+Design (roundtable-ratified 2026-07-08, arm-C transport):
+  - argv construction and status parsing are PURE and unit-tested;
+  - dispatch/poll take an INJECTED `runner` (argv -> CompletedRun) so the whole loop is
+    exercised in CI with a fake fleet, and the live path just passes a subprocess runner;
+  - delegation_id is captured with a BEFORE-dispatch watermark over `delegation_spawns`
+    (max id for the session), then the newest row after dispatch (H7: bound by session_id +
+    watermark so a concurrent sibling dispatch can't be misattributed).
+
+The DB read (token attribution) lives on the fleet host (`--token-db`); it is an operator-
+supplied path (`$AIMEE_HOME/aimee.db`, or `/mnt/media/.plugins/aimee-server/server/home/aimee.db`
+on .254). This module never assumes it is local.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from benchmarks.coding import swebench_live_attribution as LA
+
+_FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
+
+# Terminal job_status values from agent_jobs (verified live): success vs failure.
+_TERMINAL_OK = frozenset({"done"})
+_TERMINAL_FAIL = frozenset({"failed", "error", "cancelled"})
+
+
+def is_terminal(status: str) -> bool:
+    return status in _TERMINAL_OK or status in _TERMINAL_FAIL
+
+
+def is_ok(status: str) -> bool:
+    return status in _TERMINAL_OK
+
+
+# ------------------------------------------------------------ argv construction -
+def build_delegate_argv(role: str, prompt: str, *, aimee_bin: str = "aimee", via: str | None = None,
+                        persona: str = "engineer", tools: bool = False, worktree: str | None = None,
+                        model: str | None = None, max_turns: int | None = None,
+                        timeout_ms: int | None = None, durable: bool = True,
+                        extra: list[str] | None = None) -> list[str]:
+    """Build the `aimee delegate <role> ...` argv (PURE). Enforces FINDING 4: a tools-enabled
+    dispatch MUST carry a worktree branch, else the write-guard silently blocks every tool."""
+    if tools and not worktree:
+        raise ValueError("tools-enabled dispatch requires a worktree branch (FINDING 4: the "
+                         "parent-worktree write guard blocks a plain --tools delegate)")
+    argv = [aimee_bin, "delegate", role, prompt, "--persona", persona, "--json"]
+    if via:
+        argv += ["--via", via]
+    if tools:
+        argv.append("--tools")
+    if worktree:
+        argv += ["--worktree", worktree]
+    if model:
+        argv += ["--model", model]
+    if max_turns is not None:
+        argv += ["--max-turns", str(max_turns)]
+    if timeout_ms is not None:
+        argv += ["--timeout", str(timeout_ms)]
+    if durable:
+        argv.append("--durable")
+    if extra:
+        argv += list(extra)
+    return argv
+
+
+def build_status_argv(job_id, *, aimee_bin: str = "aimee") -> list[str]:
+    return [aimee_bin, "delegate", "status", str(job_id), "--json"]
+
+
+# ------------------------------------------------------------ status parsing ----
+@dataclass
+class DelegateStatus:
+    job_id: int | None
+    status: str            # pending | running | done | failed | error | cancelled
+    result: str            # the delegate's final text (empty until terminal)
+    agent_name: str
+    api_calls: int
+    raw: dict = field(default_factory=dict)
+
+    @property
+    def terminal(self) -> bool:
+        return is_terminal(self.status)
+
+    @property
+    def ok(self) -> bool:
+        return is_ok(self.status)
+
+
+def parse_status(stdout: str) -> DelegateStatus:
+    """Parse `aimee delegate status --json` output (PURE). Tolerates a trailing/leading log line
+    by scanning for the first JSON object."""
+    obj = _first_json_object(stdout)
+    return DelegateStatus(
+        job_id=obj.get("job_id"),
+        status=str(obj.get("job_status") or obj.get("status") or "unknown"),
+        result=str(obj.get("result") or ""),
+        agent_name=str(obj.get("agent_name") or ""),
+        api_calls=int(obj.get("api_call_count") or 0),
+        raw=obj,
+    )
+
+
+def parse_dispatch(stdout: str) -> int | None:
+    """Parse the `{"job_id":N,"job_status":"pending"}` a dispatch prints (PURE)."""
+    obj = _first_json_object(stdout)
+    jid = obj.get("job_id")
+    return int(jid) if jid is not None else None
+
+
+def _first_json_object(text: str) -> dict:
+    """Return the first well-formed top-level JSON object in `text`, or {}."""
+    if not text:
+        return {}
+    # Fast path: the whole thing is JSON.
+    t = text.strip()
+    try:
+        v = json.loads(t)
+        return v if isinstance(v, dict) else {}
+    except Exception:
+        pass
+    # Scan for a balanced {...} span.
+    depth = 0
+    start = -1
+    for i, ch in enumerate(text):
+        if ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0 and start >= 0:
+                try:
+                    v = json.loads(text[start:i + 1])
+                    if isinstance(v, dict):
+                        return v
+                except Exception:
+                    start = -1
+    return {}
+
+
+# ------------------------------------------------------------ runner protocol ---
+@dataclass
+class CompletedRun:
+    rc: int
+    stdout: str
+    stderr: str = ""
+
+
+def subprocess_runner(argv: list[str], *, timeout_s: float = 900.0) -> CompletedRun:
+    """The live runner: run argv, capture output. Never raises on non-zero rc (a delegate error
+    is data, not a crash — S0 discipline)."""
+    try:
+        p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
+        return CompletedRun(p.returncode, p.stdout, p.stderr)
+    except subprocess.TimeoutExpired as e:
+        return CompletedRun(124, e.stdout or "", f"timeout after {timeout_s}s")
+    except Exception as e:  # pragma: no cover - defensive
+        return CompletedRun(1, "", f"{type(e).__name__}: {e}")
+
+
+# ------------------------------------------------------------ dispatch + poll ----
+@dataclass
+class DispatchOutcome:
+    job_id: int | None
+    status: str
+    result: str
+    agent_name: str
+    delegation_id: str | None
+    api_calls: int
+    polls: int
+    error: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return is_ok(self.status) and not self.error
+
+
+def _spawn_watermark(token_db: str, session_id: str) -> int:
+    """Max delegation_spawns.id for a session BEFORE dispatch (0 if unreadable). The newest row
+    with id > watermark after dispatch is this dispatch's delegation_id (H7 race guard)."""
+    if not token_db or not session_id or not Path(token_db).exists():
+        return 0
+    try:
+        con = sqlite3.connect(token_db)
+        r = con.execute(f"SELECT COALESCE(MAX(id),0) FROM {LA.SPAWNS} WHERE session_id=?",
+                        (session_id,)).fetchone()
+        return int(r[0]) if r else 0
+    except Exception:
+        return 0
+
+
+def _capture_delegation(token_db: str, session_id: str, watermark: int) -> str | None:
+    if not token_db or not session_id or not Path(token_db).exists():
+        return None
+    try:
+        con = sqlite3.connect(token_db)
+        return LA.capture_dispatch_delegation(con, session_id, watermark)
+    except Exception:
+        return None
+
+
+def dispatch_and_wait(role: str, prompt: str, *, runner=subprocess_runner,
+                      poll_interval_s: float = 6.0, max_polls: int = 300,
+                      token_db: str = "", session_id: str = "", sleep=time.sleep,
+                      **argv_kwargs) -> DispatchOutcome:
+    """Dispatch one delegate and poll to a terminal state. Captures the dispatch's delegation_id
+    from `delegation_spawns` (if `token_db`/`session_id` are given) using a before/after watermark.
+
+    `runner` is injected so CI drives a fake fleet; the live path uses `subprocess_runner`. All
+    fleet/DB errors are folded into the outcome (never raised) so a benchmark cell degrades to a
+    recorded failure rather than crashing the suite."""
+    aimee_bin = argv_kwargs.get("aimee_bin", "aimee")
+    watermark = _spawn_watermark(token_db, session_id)
+    argv = build_delegate_argv(role, prompt, **argv_kwargs)
+    disp = runner(argv)
+    job_id = parse_dispatch(disp.stdout)
+    if job_id is None:
+        return DispatchOutcome(None, "error", "", "", None, 0, 0,
+                               error=f"dispatch produced no job_id (rc={disp.rc}): "
+                                     f"{(disp.stderr or disp.stdout)[:200]}")
+    delegation_id = _capture_delegation(token_db, session_id, watermark)
+    st = DelegateStatus(job_id, "pending", "", "", 0)
+    for polls in range(1, max_polls + 1):
+        s = runner(build_status_argv(job_id, aimee_bin=aimee_bin))
+        st = parse_status(s.stdout)
+        if st.terminal:
+            # delegation_id may only materialize once the job registers its spawn row.
+            if delegation_id is None:
+                delegation_id = _capture_delegation(token_db, session_id, watermark)
+            return DispatchOutcome(job_id, st.status, st.result, st.agent_name, delegation_id,
+                                   st.api_calls, polls)
+        sleep(poll_interval_s)
+    return DispatchOutcome(job_id, st.status or "timeout", st.result, st.agent_name, delegation_id,
+                           st.api_calls, max_polls, error="poll budget exhausted")
+
+
+# ------------------------------------------------------------ token attribution -
+def read_split(token_db: str, primary_did: str | None, worker_dids: list[str]) -> dict | None:
+    """Primary-vs-worker token split for a completed run (delegation_id partitioned, realized
+    only). Returns None if the DB is unreadable or the primary delegation was never captured."""
+    if not token_db or not primary_did or not Path(token_db).exists():
+        return None
+    try:
+        con = sqlite3.connect(token_db)
+        return LA.primary_worker_split(con, primary_did, [w for w in worker_dids if w])
+    except Exception:
+        return None
+
+
+def read_realized_by_jobs(token_db: str, model: str, job_ids: list) -> tuple[int, int, int, int]:
+    """(input_uncached, input_cached, output, rows) for one agent's realized turns over the given
+    dispatch job_ids. Reuses PR #986's job-id scoping: a delegate turn's delegation_id ends in
+    `-<job_id>` (the CLI job_id), so `delegation_id LIKE '%-<job_id>'` selects exactly this run's
+    turns for `model` — no time window, no cross-run/cross-agent contamination. UNCACHED input
+    (prompt - cache_read) is the headline denominator (B2a: multi-turn re-reads must not skew A/C).
+
+    This is the LIVE-deployment attribution (delegation_id NON-EMPTY, partitioned by job_id),
+    superseding the EMPTY-polarity model for real runs (swebench_live_attribution FINDING 1)."""
+    jids = [j for j in (job_ids or []) if j is not None]
+    if not token_db or not model or not jids or not Path(token_db).exists():
+        return (0, 0, 0, 0)
+    try:
+        con = sqlite3.connect(token_db)
+        likes = " OR ".join(["delegation_id LIKE ?"] * len(jids))
+        params = [model] + [f"%-{j}" for j in jids]
+        r = con.execute(
+            f"SELECT COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(cache_read_tokens),0), "
+            f"COALESCE(SUM(completion_tokens),0), COUNT(*) FROM {LA.AUDIT} "
+            f"WHERE model=? AND usage_kind='realized' AND ({likes})", params).fetchone()
+        prompt, cache_read, completion, rows = r
+        return (max(0, prompt - cache_read), cache_read, completion, rows)
+    except Exception:
+        return (0, 0, 0, 0)
+
+
+def read_worker_tokens_by_jobs(token_db: str, job_ids: list) -> tuple[int, int]:
+    """(input, output) summed over the workers' dispatch job_ids, MODEL-AGNOSTIC (arm-C workers
+    span many models). Priced $0 downstream — reported only for the honesty panel."""
+    jids = [j for j in (job_ids or []) if j is not None]
+    if not token_db or not jids or not Path(token_db).exists():
+        return (0, 0)
+    try:
+        con = sqlite3.connect(token_db)
+        likes = " OR ".join(["delegation_id LIKE ?"] * len(jids))
+        params = [f"%-{j}" for j in jids]
+        r = con.execute(
+            f"SELECT COALESCE(SUM(prompt_tokens),0), COALESCE(SUM(completion_tokens),0) "
+            f"FROM {LA.AUDIT} WHERE usage_kind='realized' AND ({likes})", params).fetchone()
+        return (int(r[0]), int(r[1]))
+    except Exception:
+        return (0, 0)
+
+
+def supervisor_tool_call_rows(token_db: str, delegation_id: str) -> int:
+    """H1/H2 runtime assertion support: count token_audit rows for a delegation that name a tool.
+    For the arm-C supervisor (dispatched with NO --tools) this MUST be 0 — any non-zero value
+    means the 'no raw code' structural guarantee was violated. Returns -1 if unreadable."""
+    if not token_db or not delegation_id or not Path(token_db).exists():
+        return -1
+    try:
+        con = sqlite3.connect(token_db)
+        r = con.execute(
+            f"SELECT COUNT(*) FROM {LA.AUDIT} WHERE delegation_id=? AND usage_kind='realized' "
+            f"AND tool_name IS NOT NULL AND tool_name<>''", (delegation_id,)).fetchone()
+        return int(r[0]) if r else 0
+    except Exception:
+        return -1
+
+
+def argv_str(argv: list[str]) -> str:
+    """A copy-pasteable shell rendering of a dispatch argv (for runbook/logging)."""
+    return " ".join(shlex.quote(a) for a in argv)

--- a/benchmarks/coding/swebench_live_transport.py
+++ b/benchmarks/coding/swebench_live_transport.py
@@ -297,6 +297,22 @@ def read_realized_by_jobs(token_db: str, model: str, job_ids: list) -> tuple[int
         return (0, 0, 0, 0)
 
 
+def read_realized_by_delegations(token_db: str, delegation_ids: list) -> tuple[int, int, int, int]:
+    """(input_uncached, input_cached, output, rows) over EXACT delegation_ids — the precise
+    attribution when the dispatch's delegation_id was captured from delegation_spawns. Preferred
+    over the job-id `LIKE '%-<job_id>'` heuristic (which relies on the trailing segment being the
+    job_id and can over-match a malformed id); the LIKE stays as a fallback when capture failed."""
+    dids = [d for d in (delegation_ids or []) if d]
+    if not token_db or not dids or not Path(token_db).exists():
+        return (0, 0, 0, 0)
+    try:
+        con = sqlite3.connect(token_db)
+        t = LA.realized_totals(con, dids)
+        return (t.input_uncached, t.input_cached, t.output, t.rows)
+    except Exception:
+        return (0, 0, 0, 0)
+
+
 def read_worker_tokens_by_jobs(token_db: str, job_ids: list) -> tuple[int, int]:
     """(input, output) summed over the workers' dispatch job_ids, MODEL-AGNOSTIC (arm-C workers
     span many models). Priced $0 downstream — reported only for the honesty panel."""

--- a/benchmarks/coding/swebench_suite.py
+++ b/benchmarks/coding/swebench_suite.py
@@ -23,9 +23,15 @@ Grade only on the official harness; never let in-loop signal decide `resolved` (
 """
 from __future__ import annotations
 
+import glob
 import hashlib
+import json
+import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+
+_FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
 
 
 # ------------------------------------------------------------ benchmark specs --
@@ -180,11 +186,159 @@ def build_predictions(records: list[dict[str, Any]], run_id: str) -> list[dict[s
     return list(seen.values())
 
 
-# ------------------------------------------------------------ live stub --------
-def run_suite(only: list[str] = None, *, token_db: str, aimee_bin: str):
-    raise NotImplementedError(
-        "live suite execution not wired: for each RunCell from generate_run_plan(), dispatch arm "
-        "A (run_arm_a) or arm C (run_arm_c_supervised) on the .254 fleet, hold CT101Lease.GRADER "
-        "while grading each run_id's build_predictions() with the official swebench Docker harness "
-        "on CT 101 under GraderRetry, aggregate_k across repeats, then feed the records to "
-        "supervised_report + supervised_report_panels. Requires the live server + CT 101.")
+# ------------------------------------------------------------ instance loading -
+def load_instances(instances_spec: str, regions_dir: str) -> list[dict]:
+    """Resolve a benchmark's instance-set label to the prepared region records on disk. The prep
+    (`swebench_supervised_prep.py`) writes one JSON per instance under regions_dir; `reddit10`,
+    `lite:N`, and `all` are prepared into subdirs by the prep, so we read the matching subdir (or
+    the flat dir). Returns [] when nothing is prepared (the caller logs and skips the cell)."""
+    label = instances_spec.replace(":", "_")
+    for cand in (Path(regions_dir) / label, Path(regions_dir)):
+        files = sorted(glob.glob(str(cand / "*.json")))
+        if files:
+            return [json.load(open(f)) for f in files]
+    return []
+
+
+# ------------------------------------------------------------ grading ----------
+def resolved_ids_from_report(report: dict) -> set:
+    """Extract the resolved instance_ids from an official SWE-bench evaluation report (PURE).
+
+    The harness writes a top-level report with a `resolved_ids` list; older/summary shapes instead
+    map each instance_id to a dict carrying a `resolved` bool. Handle both so a schema variant can't
+    silently zero out the resolution number (the `_grade_with_harness` first-tuple element is always
+    an empty set today — this is where `resolved` actually comes from)."""
+    if not isinstance(report, dict):
+        return set()
+    if isinstance(report.get("resolved_ids"), list):
+        return set(report["resolved_ids"])
+    out = set()
+    for k, v in report.items():
+        if isinstance(v, dict) and v.get("resolved") is True:
+            out.add(k)
+    return out
+
+
+def official_grade_fn(predictions: list[dict], run_id: str, *, lease: "CT101Lease" = None) -> set:
+    """Grade predictions with the OFFICIAL SWE-bench Docker harness (the SOLE resolution source).
+    Holds the CT101 grader lease for the duration so in-loop docker can never pollute a grade.
+    Returns the set of resolved instance_ids. Delegates to the merged single-shot grader wiring
+    (`bench_swebench._grade_with_harness`) so both benchmarks grade identically, then derives the
+    resolved set from the report (that wiring returns the report but an empty id-set)."""
+    if not predictions:
+        return set()
+    from benchmarks.coding.bench_swebench import _write_predictions, _grade_with_harness
+    lease = lease or CT101Lease()
+    while not lease.request_grader():
+        raise LeaseError("CT101 grader lease unavailable (iteration pool holds it)")
+    try:
+        out = Path(f"/tmp/swebench_preds_{run_id}.jsonl")
+        _write_predictions(out, predictions)
+        resolved, report = _grade_with_harness(out, run_id)
+        return set(resolved) or resolved_ids_from_report(report)
+    finally:
+        lease.release(CT101Lease.GRADER)
+
+
+# ------------------------------------------------------------ suite driver -----
+def run_suite(only: list[str] = None, *, token_db: str = "", aimee_bin: str = "aimee",
+              regions_dir: str = "benchmarks/results/swebench_supervised/regions",
+              workers: list[str] = None, primary_agent: str = "codex", primary_model: str = "gpt-5.5",
+              base_repos: dict = None, allocator_factory=None, budget=None,
+              arm_a_runner=None, arm_c_runner=None, grade_fn=None, instances_loader=None,
+              on_log=None) -> dict:
+    """Execute the six-benchmark suite (or a subset via `only`) and grade every patch with the
+    official harness. Every external effect is an INJECTED seam so the orchestration is unit-tested
+    with a fake fleet+grader; the live defaults compose run_arm_a / run_arm_c_supervised + the
+    official CT-101 grader. Returns {cells, records_by_run, aggregate, report}.
+
+    Per (benchmark,instance-set): load instances, run each RunCell's arm over all instances, grade
+    the run_id's predictions once (GraderRetry on ERROR only), set `resolved`, then majority-vote
+    aggregate across the K repeats with flip detection. Records feed supervised_report downstream."""
+    from benchmarks.coding import supervised_report
+    from benchmarks.coding import swebench_arm_runner as R
+    from benchmarks.coding import swebench_supervision as S
+    from benchmarks.coding import swebench_agentic_harness as H
+
+    log = on_log or (lambda m: None)
+    arm_a_runner = arm_a_runner or R.run_arm_a
+    arm_c_runner = arm_c_runner or S.run_arm_c_supervised
+    grade_fn = grade_fn or official_grade_fn
+    instances_loader = instances_loader or (lambda spec: load_instances(spec, regions_dir))
+    allocator_factory = allocator_factory or (lambda: H.EnvAllocator(str(Path(regions_dir).parent / "ws")))
+    budget = budget or H.LoopBudget()
+    workers = workers or ["GLM-5.2", "MiniMax-M3", "mistral-medium-3-5", "mimo-v2.5-pro", "gpu-mid"]
+    base_repos = base_repos or {}
+
+    plan = generate_run_plan(only=only)
+    lease = CT101Lease()
+    inst_cache: dict[str, list] = {}
+    records_by_run: dict[str, list] = {}
+    cells_meta = []
+
+    for cell in plan:
+        insts = inst_cache.setdefault(cell.instances, instances_loader(cell.instances))
+        if not insts:
+            log(f"SKIP {cell.run_id}: no instances prepared for '{cell.instances}' in {regions_dir}")
+            cells_meta.append({"run_id": cell.run_id, "benchmark": cell.benchmark, "arm": cell.arm,
+                               "skipped": "no_instances"})
+            continue
+        alloc = allocator_factory()
+        records = []
+        for inst in insts:
+            base_repo = base_repos.get(inst.get("repo"))
+            if cell.arm == "A":
+                rec = arm_a_runner(inst, cell.primary, token_db=token_db, base_repo=base_repo,
+                                   allocator=alloc, budget=budget, primary_agent=primary_agent,
+                                   aimee_bin=aimee_bin)
+            else:
+                rec = arm_c_runner(inst, workers=workers, n=cell.n, allocator=alloc, budget=budget,
+                                   token_db=token_db, base_repo=base_repo, primary_agent=primary_agent,
+                                   primary_model=cell.primary, aimee_bin=aimee_bin)
+            rec["run_id"] = cell.run_id
+            records.append(rec)
+
+        preds = build_predictions([{**r, "patch": r.get("patch", "")} for r in records], cell.run_id)
+        # Attach the patch text needed for grading onto the prediction (records only carry a
+        # fingerprint), so callers pass patches explicitly via the arm result if they need grading.
+        retry = GraderRetry()
+        try:
+            resolved = retry.run(lambda: ("ok", grade_fn(preds, cell.run_id, lease=lease)))
+        except Exception as e:  # grader unavailable -> resolved unknown, reported honestly
+            log(f"GRADER unavailable for {cell.run_id}: {e}")
+            resolved = None
+        for r in records:
+            if resolved is not None:
+                r["resolved"] = r["instance_id"] in resolved
+        records_by_run[cell.run_id] = records
+        cells_meta.append({"run_id": cell.run_id, "benchmark": cell.benchmark, "arm": cell.arm,
+                           "n": cell.n, "primary": cell.primary, "repeat": cell.repeat,
+                           "instances": len(insts), "grader_attempts": retry.attempts,
+                           "graded": resolved is not None})
+
+    # Majority-vote aggregate across K repeats per (benchmark, arm, primary, N, instance).
+    aggregate = _aggregate_repeats(plan, records_by_run)
+    all_records = [r for recs in records_by_run.values() for r in recs]
+    report = supervised_report.build_report(all_records) if all_records else {}
+    return {"cells": cells_meta, "records_by_run": records_by_run, "aggregate": aggregate,
+            "report": report}
+
+
+def _aggregate_repeats(plan: list, records_by_run: dict) -> dict:
+    """Group the K repeats of each logical cell and majority-vote each instance's resolution, with
+    a flip flag when resolution is unstable across repeats (grader flake vs run noise, S5)."""
+    groups: dict[tuple, dict[str, list]] = {}
+    for cell in plan:
+        recs = records_by_run.get(cell.run_id)
+        if not recs:
+            continue
+        key = (cell.benchmark, cell.arm, cell.primary, cell.n, int(cell.reducers), cell.worker_pool)
+        by_inst = groups.setdefault(key, {})
+        for r in recs:
+            if r.get("resolved") is not None:
+                by_inst.setdefault(r["instance_id"], []).append(bool(r["resolved"]))
+    out = {}
+    for key, by_inst in groups.items():
+        name = ":".join(str(k) for k in key)
+        out[name] = {iid: aggregate_k(vals) for iid, vals in by_inst.items()}
+    return out

--- a/benchmarks/coding/swebench_supervision.py
+++ b/benchmarks/coding/swebench_supervision.py
@@ -431,9 +431,10 @@ def run_arm_c_supervised(instance: dict, *, workers: list[str], n: int, allocato
     first_work = t0  # workers dispatched immediately; queue folded into work for a single round
 
     # Candidates + leak-guarded digests (the ONLY thing the supervisor sees).
-    candidates, digests, worker_jobs, redactions = [], [], [], 0
+    candidates, digests, worker_jobs, redactions, sources = [], [], [], 0, {}
     for w, res in worker_results:
         redactions += res.redactions
+        sources[w] = res.patch_source
         if res.job_id is not None:
             worker_jobs.append(res.job_id)
         if res.patch.strip():
@@ -454,8 +455,14 @@ def run_arm_c_supervised(instance: dict, *, workers: list[str], n: int, allocato
     # H1 runtime assertion: the tools-OFF supervisor must have ZERO tool rows (structural no-code).
     sup_tool_rows = T.supervisor_tool_call_rows(token_db, sup.delegation_id) if sup.delegation_id else -1
 
-    tok = R.primary_tokens_by_jobs(token_db, primary_model, [sup.job_id])
-    worker_in, worker_out = T.read_worker_tokens_by_jobs(token_db, worker_jobs)
+    tok = R.primary_tokens_by_jobs(token_db, primary_model, [sup.job_id],
+                                   delegation_ids=[sup.delegation_id])
+    worker_dids = [res.delegation_id for _, res in worker_results if res.delegation_id]
+    if worker_dids:
+        wi, wc, wo, _ = T.read_realized_by_delegations(token_db, worker_dids)
+        worker_in, worker_out = wi + wc, wo
+    else:
+        worker_in, worker_out = T.read_worker_tokens_by_jobs(token_db, worker_jobs)
     esc = EscalationState()
     # Gated escalation (R3): only when NO worker produced a candidate. A separate, bounded,
     # attributed read-enabled dispatch; its output is re-digested before it could reach the frame.
@@ -472,6 +479,7 @@ def run_arm_c_supervised(instance: dict, *, workers: list[str], n: int, allocato
             if epatch.strip():
                 best = Candidate(worker_id=f"{primary_agent}@escalate", diff=epatch,
                                  verify=VerifyEnum.NOT_RUN, turns=e.api_calls)
+                sources[f"{primary_agent}@escalate"] = "response_text"
 
     wall = R.WallClock(t0=t0, first_work=first_work, t1=t1)
     escalation_dominated = is_escalation_dominated(esc.escalation_tokens, tok.input_uncached)
@@ -483,6 +491,7 @@ def run_arm_c_supervised(instance: dict, *, workers: list[str], n: int, allocato
         invalid=(best is None) or escalation_dominated)
     rec.update({
         "patch": best.diff if best else "",   # secret-redacted patch for the official grader
+        "patch_source": sources.get(best.worker_id, "none") if best else "none",
         "n_candidates": len(candidates),
         "selected_worker": best.worker_id if best else None,
         "supervisor_job_id": sup.job_id,

--- a/benchmarks/coding/swebench_supervision.py
+++ b/benchmarks/coding/swebench_supervision.py
@@ -28,9 +28,16 @@ Ratified rulings baked in:
 """
 from __future__ import annotations
 
+import json
+import os
+import random
 import re
+import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
+
+_FAKE = os.environ.get("AIMEE_BENCH_FAKE_AGENT") == "1"
 
 # ------------------------------------------------------------ enums ------------
 class VerifyEnum(str, Enum):
@@ -336,11 +343,171 @@ def tool_allowed(tool: str, *, escalated: bool = False) -> bool:
     return False
 
 
-# ------------------------------------------------------------ live stub --------
-def run_arm_c_supervised(instance: dict, *, workers: list[str], n: int, redirect: bool = False):
-    raise NotImplementedError(
-        "live arm-C supervision loop not wired: dispatch N tools-enabled workers on isolated "
-        "workspaces (S1), build capped leak-guarded digests each turn (build_digest), keep the "
-        "supervisor context bounded (ContextWindow), select deterministically (select_best_of_n), "
-        "escalate only on the gated triggers, and read primary tokens via the S0 polarity + S2 "
-        "arm-runner accounting. The optional LLM-supervisor selection is a separate ablation.")
+# ------------------------------------------------------------ supervisor turn --
+# Option A (roundtable 2026-07-08): the supervisor is dispatched as a delegate with TOOLS OFF, so
+# "no raw code" is a STRUCTURAL guarantee (no tool loop) rather than an allowlist. Its input is the
+# capped, leak-guarded digest frame; its tokens ARE the arm-C primary headline. The actual submitted
+# patch is chosen by the PURE, deterministic select_best_of_n() (reproducible) — the LLM turn's
+# stated preference is parsed and logged but never overrides the deterministic selection.
+def supervisor_prompt(instance: dict, frame: str, candidate_ids: list[str]) -> str:
+    problem = instance.get("problem") or instance.get("problem_statement", "")
+    ids = ", ".join(candidate_ids) or "(none)"
+    return ("You are supervising a team of engineers fixing a bug. You may read ONLY the capped "
+            "progress digests below (worker id, state, verify result, and a short candidate diff) "
+            "— you have NO access to the source. Decide which candidate best resolves the issue.\n\n"
+            f"## Issue\n{problem}\n\n## Worker digests\n{frame}\n\n"
+            f"Candidate worker ids: {ids}\n\nRespond with ONLY a JSON object: "
+            '{"action":"select","worker_id":"<id>","rationale":"<=15 words"} '
+            '(or {"action":"escalate","rationale":"..."} if no candidate is viable).')
+
+
+def parse_supervisor_decision(text: str) -> dict:
+    """Parse the supervisor's JSON decision (PURE). Falls back to {'action':'select','worker_id':None}
+    on malformed output (H3) so a parse failure degrades to the deterministic selector, never a crash."""
+    if text:
+        m = re.search(r"\{.*\}", text, re.DOTALL)
+        if m:
+            try:
+                d = json.loads(m.group(0))
+                if isinstance(d, dict) and d.get("action") in ("select", "escalate", "redirect"):
+                    return {"action": d["action"], "worker_id": d.get("worker_id"),
+                            "rationale": str(d.get("rationale", ""))[:120]}
+            except Exception:
+                pass
+    return {"action": "select", "worker_id": None, "rationale": "parse_error"}
+
+
+def _pick_workers(pool: list[str], n: int, seed: str) -> list[str]:
+    """N DISTINCT workers for one instance, seeded for reproducibility (matches PR #986 M6)."""
+    rng = random.Random(seed)
+    p = list(pool)
+    rng.shuffle(p)
+    return p[:min(n, len(p))]
+
+
+def _worker_turn(res, worker_id: str) -> WorkerTurn:
+    """Build a WorkerTurn from an agentic result. verify=NOT_RUN: in-loop tests default OFF (Q1);
+    the OFFICIAL grader is the sole resolution source (run later), so the digest never claims a
+    verify it did not run."""
+    state = WorkerState.DONE if (res.status == "done" and res.patch.strip()) else WorkerState.FAILED
+    added = sum(1 for ln in res.patch.splitlines() if ln.startswith("+") and not ln.startswith("+++"))
+    deleted = sum(1 for ln in res.patch.splitlines() if ln.startswith("-") and not ln.startswith("---"))
+    return WorkerTurn(worker_id=worker_id, turn_index=0, state=state, action_label=f"agentic loop ({res.api_calls} calls)",
+                      unified_diff=res.patch, verify=VerifyEnum.NOT_RUN, added=added, deleted=deleted)
+
+
+# ------------------------------------------------------------ live arm C -------
+def run_arm_c_supervised(instance: dict, *, workers: list[str], n: int, allocator, budget,
+                         token_db: str = "", base_repo: str | None = None, primary_agent: str = "codex",
+                         primary_model: str = "gpt-5.5", seed: int = 1729, redirect: bool = False,
+                         aimee_bin: str = "aimee", dispatch=None, max_concurrency: int = 8) -> dict:
+    """Live arm-C supervision run for one instance (Option A). Dispatches N tools-enabled worker
+    agentic loops CONCURRENTLY (each in its own worktree — the fleet-parallelism that answers
+    Reddit's serial-worker wall-clock), builds capped leak-guarded digests, runs ONE tools-OFF
+    supervisor turn over the digest frame (its tokens = the primary headline), and selects the
+    submitted patch DETERMINISTICALLY with select_best_of_n. Worker tokens are read separately and
+    priced $0. `dispatch` is injected so CI drives a fake fleet; `resolved` is set later by S5."""
+    from benchmarks.coding import swebench_agentic_harness as H
+    from benchmarks.coding import swebench_arm_runner as R
+    from benchmarks.coding import swebench_live_transport as T
+    if _FAKE:
+        return _fake_arm_c_record(instance, primary_model, n)
+    if dispatch is None:
+        dispatch = T.dispatch_and_wait
+
+    instance_id = instance["instance_id"]
+    picks = _pick_workers(workers, n, f"{seed}:{instance_id}")
+    t0 = time.perf_counter()
+
+    def _run_worker(idx_worker):
+        idx, w = idx_worker
+        env = allocator.allocate(instance_id, "C", idx)
+        return w, H.run_agentic_loop(instance, env, budget, arm="C", worker=w, base_repo=base_repo,
+                                     token_db=token_db, worker_idx=idx, aimee_bin=aimee_bin,
+                                     dispatch=dispatch)
+
+    with ThreadPoolExecutor(max_workers=min(max_concurrency, max(1, len(picks)))) as ex:
+        worker_results = list(ex.map(_run_worker, list(enumerate(picks))))
+    first_work = t0  # workers dispatched immediately; queue folded into work for a single round
+
+    # Candidates + leak-guarded digests (the ONLY thing the supervisor sees).
+    candidates, digests, worker_jobs, redactions = [], [], [], 0
+    for w, res in worker_results:
+        redactions += res.redactions
+        if res.job_id is not None:
+            worker_jobs.append(res.job_id)
+        if res.patch.strip():
+            candidates.append(Candidate(worker_id=w, diff=res.patch, verify=VerifyEnum.NOT_RUN,
+                                        turns=res.api_calls))
+        digests.append(build_digest(_worker_turn(res, w)))
+    frame, _frame_rejected = serialize_supervisor_frame(digests)
+
+    # Deterministic submitted patch (reproducible authority).
+    best = select_best_of_n(candidates)
+
+    # Supervisor turn: tools OFF, digests-only -> the primary headline spend.
+    sup = dispatch("review", supervisor_prompt(instance, frame, [c.worker_id for c in candidates]),
+                   via=primary_agent, tools=False, token_db=token_db, aimee_bin=aimee_bin)
+    decision = parse_supervisor_decision(sup.result)
+    t1 = time.perf_counter()
+
+    # H1 runtime assertion: the tools-OFF supervisor must have ZERO tool rows (structural no-code).
+    sup_tool_rows = T.supervisor_tool_call_rows(token_db, sup.delegation_id) if sup.delegation_id else -1
+
+    tok = R.primary_tokens_by_jobs(token_db, primary_model, [sup.job_id])
+    worker_in, worker_out = T.read_worker_tokens_by_jobs(token_db, worker_jobs)
+    esc = EscalationState()
+    # Gated escalation (R3): only when NO worker produced a candidate. A separate, bounded,
+    # attributed read-enabled dispatch; its output is re-digested before it could reach the frame.
+    if not candidates and base_repo:
+        trig = esc.should_escalate(all_failed=True, made_progress=False)
+        if trig != EscalationTrigger.NONE and esc.escalations < 3:
+            branch = H.worktree_branch(instance_id, "C-esc", 0)
+            e = dispatch("code", H.agentic_prompt(instance, arm="C"), via=primary_agent, tools=True,
+                         worktree=branch, token_db=token_db, aimee_bin=aimee_bin,
+                         max_turns=budget.max_turns, timeout_ms=int(budget.max_wall_s * 1000))
+            e_in, _ = T.read_worker_tokens_by_jobs(token_db, [e.job_id])
+            esc.record_escalation(e_in)
+            epatch = H.scan_and_redact_secrets(H.extract_diff_from_text(e.result))[0]
+            if epatch.strip():
+                best = Candidate(worker_id=f"{primary_agent}@escalate", diff=epatch,
+                                 verify=VerifyEnum.NOT_RUN, turns=e.api_calls)
+
+    wall = R.WallClock(t0=t0, first_work=first_work, t1=t1)
+    escalation_dominated = is_escalation_dominated(esc.escalation_tokens, tok.input_uncached)
+    rec = R.build_arm_record(
+        instance_id, "C", primary_model, tokens=tok, worker_in=worker_in, worker_out=worker_out,
+        wall=wall, resolved=None, patch=best.diff if best else "",
+        base_commit=instance.get("base_commit", ""), repo=instance.get("repo", ""),
+        n_workers=len(picks), redactions=redactions, escalations=esc.escalations,
+        invalid=(best is None) or escalation_dominated)
+    rec.update({
+        "patch": best.diff if best else "",   # secret-redacted patch for the official grader
+        "n_candidates": len(candidates),
+        "selected_worker": best.worker_id if best else None,
+        "supervisor_job_id": sup.job_id,
+        "supervisor_decision": decision["action"],
+        "supervisor_tool_rows": sup_tool_rows,   # MUST be 0 (or -1 if db unreadable) — H1 gate
+        "escalation_tokens": esc.escalation_tokens,
+        "escalation_dominated": escalation_dominated,
+        "candidate_health_ok": len(candidates) >= -(-n // 2),  # >= ceil(n/2)
+    })
+    return rec
+
+
+def _fake_arm_c_record(instance: dict, primary_model: str, n: int) -> dict:
+    from benchmarks.coding import swebench_arm_runner as R
+    from benchmarks.coding import swebench_transport_verify as V
+    iid = instance["instance_id"]
+    rows = V._fake_rows("pass", primary_model, "glm-5.2")
+    tok = R.primary_token_totals(rows, primary_model)
+    wall = R.WallClock(t0=0.0, first_work=0.4, t1=8.0)
+    rec = R.build_arm_record(iid, "C", primary_model, tokens=tok, worker_in=1200, worker_out=5000,
+                             wall=wall, resolved=True, patch="diff --git a/x b/x\n+ok\n",
+                             base_commit=instance.get("base_commit", "0" * 40),
+                             repo=instance.get("repo", "x/y"), n_workers=n)
+    rec.update({"patch": "diff --git a/x b/x\n+ok\n", "n_candidates": n,
+                "selected_worker": "glm-5.2", "supervisor_job_id": 1, "supervisor_decision": "select",
+                "supervisor_tool_rows": 0, "escalation_tokens": 0, "escalation_dominated": False,
+                "candidate_health_ok": True})
+    return rec

--- a/benchmarks/coding/swebench_transport_verify.py
+++ b/benchmarks/coding/swebench_transport_verify.py
@@ -175,14 +175,20 @@ _PROBE_TASK = ("Read PROBE.txt, delegate a summary of it to a worker, then write
 
 def _invoke_v1_runs(ctx: ProbeCtx) -> str:
     raise NotImplementedError(
-        "live /v1/runs probe not wired: POST an agentic run to /v1/runs on the server, poll "
-        "to completion, return its session_id. Task: " + _PROBE_TASK)
+        "the /v1/runs + EMPTY-delegation-polarity transport is SUPERSEDED on the live deployment "
+        "(swebench_live_attribution.py FINDING 1: the real fleet emits almost no EMPTY-delegation "
+        "rows). Use the sanctioned DELEGATE transport instead: swebench_live_attribution."
+        "run_live_matrix(db_path=..., primary_agent='codex', worker='GLM-5.2'), which dispatches a "
+        "real primary+worker agentic probe via swebench_live_transport and verifies attribution by "
+        "delegation_id/job_id (L1-L4). The P1-P5 assertions here remain the FAKE-mode CI gate. "
+        "Task: " + _PROBE_TASK)
 
 
 def _invoke_agent_shell(ctx: ProbeCtx) -> str:
     raise NotImplementedError(
-        "live agent_shell probe not wired: submit the probe task via the server-side "
-        "agent_shell execution mode and return its session_id. Task: " + _PROBE_TASK)
+        "superseded (see _invoke_v1_runs): the live S0 gate is the delegate-transport probe in "
+        "swebench_live_attribution.run_live_matrix, not a server-side agent_shell run. "
+        "Task: " + _PROBE_TASK)
 
 
 DEFAULT_PROBES = [

--- a/benchmarks/tests/test_swebench_agentic_harness.py
+++ b/benchmarks/tests/test_swebench_agentic_harness.py
@@ -188,11 +188,61 @@ class TestFingerprint(unittest.TestCase):
                             H.workspace_fingerprint("r", "c", "y"))
 
 
-class TestLiveStubHonesty(unittest.TestCase):
-    def test_run_agentic_loop_is_marked_stub(self):
-        with self.assertRaises(NotImplementedError):
-            H.run_agentic_loop({}, H.EnvAllocator("/r").allocate("i", "A", 0),
-                               H.LoopBudget(), arm="A")
+class TestAgenticPromptAndDiff(unittest.TestCase):
+    def test_prompt_includes_issue_and_diff_instruction(self):
+        p = H.agentic_prompt({"repo": "django/django", "problem": "TZ bug",
+                              "file": "django/utils/tz.py", "region": "def now(): pass"}, arm="C")
+        self.assertIn("TZ bug", p)
+        self.assertIn("django/utils/tz.py", p)
+        self.assertIn("```diff", p)
+
+    def test_extract_diff_from_fenced_block(self):
+        txt = "prose\n```diff\ndiff --git a/x b/x\n+ok\n```\ntrailing"
+        self.assertEqual(H.extract_diff_from_text(txt), "diff --git a/x b/x\n+ok")
+
+    def test_extract_diff_stops_at_prose(self):
+        txt = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n+ok\nNow some prose."
+        out = H.extract_diff_from_text(txt)
+        self.assertIn("+ok", out)
+        self.assertNotIn("prose", out)
+
+    def test_worktree_branch_is_deterministic_and_safe(self):
+        b = H.worktree_branch("django__django-12908", "C", 2)
+        self.assertEqual(b, H.worktree_branch("django__django-12908", "C", 2))
+        self.assertTrue(b.startswith("aimee/wi/swebench-"))
+        self.assertNotIn(" ", b)
+
+
+class TestRunAgenticLoopLive(unittest.TestCase):
+    def test_loop_extracts_patch_from_returned_diff(self):
+        from benchmarks.coding import swebench_live_transport as LT
+
+        def fake_dispatch(role, prompt, **kw):
+            self.assertEqual(role, "code")
+            self.assertTrue(kw["tools"] and kw["worktree"])   # FINDING 4
+            return LT.DispatchOutcome(job_id=9, status="done",
+                                      result="```diff\ndiff --git a/f b/f\n+patch\n```",
+                                      agent_name="GLM-5.2", delegation_id="deleg-1-2-9",
+                                      api_calls=3, polls=1)
+
+        env = H.EnvAllocator("/tmp/wsx").allocate("i", "C", 0)
+        res = H.run_agentic_loop({"instance_id": "i", "repo": "x/y", "base_commit": "0" * 40,
+                                  "problem": "b"}, env, H.LoopBudget(), arm="C", worker="GLM-5.2",
+                                 base_repo="", dispatch=fake_dispatch)
+        self.assertTrue(res.ok)
+        self.assertIn("+patch", res.patch)
+        self.assertEqual(res.job_id, 9)
+        self.assertEqual(res.delegation_id, "deleg-1-2-9")
+
+    def test_failed_dispatch_is_recorded_not_raised(self):
+        from benchmarks.coding import swebench_live_transport as LT
+        fake = lambda role, prompt, **kw: LT.DispatchOutcome(None, "error", "", "", None, 0, 0,
+                                                             error="no job_id")
+        env = H.EnvAllocator("/tmp/wsx").allocate("i", "A", 0)
+        res = H.run_agentic_loop({"instance_id": "i", "base_commit": "0" * 40}, env,
+                                 H.LoopBudget(), arm="A", dispatch=fake)
+        self.assertFalse(res.ok)
+        self.assertEqual(res.status, "error")
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_swebench_agentic_harness.py
+++ b/benchmarks/tests/test_swebench_agentic_harness.py
@@ -9,6 +9,7 @@ Run: python3 -m unittest benchmarks.tests.test_swebench_agentic_harness
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -243,6 +244,72 @@ class TestRunAgenticLoopLive(unittest.TestCase):
                                  H.LoopBudget(), arm="A", dispatch=fake)
         self.assertFalse(res.ok)
         self.assertEqual(res.status, "error")
+
+    def test_response_text_patch_is_non_authoritative(self):
+        # Dev mode (no co-located workspace): a returned diff is usable but NOT graded-authoritative
+        # (it is only a claim — the roundtable hallucination-gap guard).
+        from benchmarks.coding import swebench_live_transport as LT
+        fake = lambda role, prompt, **kw: LT.DispatchOutcome(9, "done",
+            "```diff\ndiff --git a/f b/f\n+claimed\n```", "GLM-5.2", "d-9", 1, 1)
+        env = H.EnvAllocator("/tmp/wsx").allocate("i", "C", 0)
+        res = H.run_agentic_loop({"instance_id": "i", "base_commit": "0" * 40, "problem": "b"},
+                                 env, H.LoopBudget(), arm="C", worker="GLM-5.2", base_repo="",
+                                 dispatch=fake)
+        self.assertEqual(res.patch_source, "response_text")
+        self.assertFalse(res.authoritative)          # never graded from a mere claim
+        self.assertTrue(res.ok)                       # still a produced patch (dev/telemetry)
+
+
+class TestHallucinationGapGuard(unittest.TestCase):
+    """Co-located mode: the graded patch is the ACTUAL filesystem diff (git diff), never the diff
+    the delegate merely CLAIMED in its response text."""
+
+    def _base_repo(self):
+        import subprocess, tempfile
+        d = tempfile.mkdtemp()
+        run = lambda *a: subprocess.run(["git", "-C", d, *a], check=True, capture_output=True,
+                                        text=True, env={"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL":
+                                        "t@t", "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL":
+                                        "t@t", "PATH": os.environ.get("PATH", "")})
+        subprocess.run(["git", "init", "-q", d], check=True, capture_output=True)
+        Path(d, "f.py").write_text("x = 1\n")
+        run("add", "-A"); run("-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "base")
+        commit = run("rev-parse", "HEAD").stdout.strip()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        return d, commit
+
+    def test_colocated_uses_workspace_diff_not_claim(self):
+        from benchmarks.coding import swebench_live_transport as LT
+        base, commit = self._base_repo()
+        env = H.EnvAllocator(__import__("tempfile").mkdtemp()).allocate("i", "A", 0)
+
+        def fake_dispatch(role, prompt, **kw):
+            # The agent ACTUALLY edits the workspace...
+            Path(env.workspace, "f.py").write_text("x = 2  # real edit\n")
+            # ...but its response text CLAIMS a different, unrelated diff.
+            return LT.DispatchOutcome(5, "done", "```diff\ndiff --git a/OTHER b/OTHER\n+lie\n```",
+                                      "codex", "d-5", 2, 1)
+
+        res = H.run_agentic_loop({"instance_id": "i", "repo": "x/y", "base_commit": commit},
+                                 env, H.LoopBudget(), arm="A", base_repo=base, dispatch=fake_dispatch)
+        self.assertEqual(res.patch_source, "workspace")
+        self.assertTrue(res.authoritative)
+        self.assertIn("real edit", res.patch)        # the FS edit, graded
+        self.assertNotIn("lie", res.patch)           # the claimed diff is NOT graded
+        self.assertIn("OTHER", res.returned_diff)    # claim retained only as diagnostic
+
+    def test_colocated_clean_workspace_is_not_graded_from_claim(self):
+        from benchmarks.coding import swebench_live_transport as LT
+        base, commit = self._base_repo()
+        env = H.EnvAllocator(__import__("tempfile").mkdtemp()).allocate("i", "A", 0)
+        # The agent edits NOTHING but claims a fix -> must NOT be graded (patch_source none).
+        fake = lambda role, prompt, **kw: LT.DispatchOutcome(6, "done",
+            "```diff\ndiff --git a/f.py b/f.py\n+claimed fix\n```", "codex", "d-6", 1, 1)
+        res = H.run_agentic_loop({"instance_id": "i", "repo": "x/y", "base_commit": commit},
+                                 env, H.LoopBudget(), arm="A", base_repo=base, dispatch=fake)
+        self.assertEqual(res.patch_source, "none")
+        self.assertFalse(res.authoritative)
+        self.assertEqual(res.patch, "")
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_swebench_arm_runner.py
+++ b/benchmarks/tests/test_swebench_arm_runner.py
@@ -114,12 +114,43 @@ class TestFakeMode(unittest.TestCase):
         self.assertIn("patch_fingerprint", rec)
 
 
-class TestLiveStubHonesty(unittest.TestCase):
-    def test_run_arm_a_live_is_marked_stub(self):
-        inst = {"instance_id": "i", "repo": "x/y", "base_commit": "0" * 40}
-        with self.assertRaises(NotImplementedError):
-            R.run_arm_a(inst, PRIMARY, token_db="/x", base_repo="/y",
-                        allocator=None, budget=None)
+class TestRunArmALive(unittest.TestCase):
+    """run_arm_a drives the real path with an INJECTED fake fleet (no server): assert it produces
+    a schema-valid record from the delegate's returned diff, with wall-clock captured."""
+
+    def setUp(self):
+        # Force the LIVE path regardless of a global AIMEE_BENCH_FAKE_AGENT (this test injects a
+        # fake fleet, so it must not short-circuit to the synthesized fake record).
+        self._orig = R._FAKE
+        R._FAKE = False
+        self.addCleanup(lambda: setattr(R, "_FAKE", self._orig))
+
+    def test_run_arm_a_with_fake_dispatch(self):
+        from benchmarks.coding import swebench_agentic_harness as H
+        from benchmarks.coding import swebench_live_transport as LT
+
+        def fake_dispatch(role, prompt, **kw):
+            self.assertEqual(role, "code")
+            self.assertTrue(kw.get("tools"))
+            self.assertTrue(kw.get("worktree"))  # FINDING 4: tools require a worktree
+            return LT.DispatchOutcome(job_id=7, status="done",
+                                      result="```diff\ndiff --git a/x b/x\n+fix\n```",
+                                      agent_name="codex", delegation_id="deleg-1-2-7",
+                                      api_calls=5, polls=2)
+
+        inst = {"instance_id": "django__django-1", "repo": "django/django",
+                "base_commit": "0" * 40, "problem": "boom"}
+        clk = iter([100.0, 142.0])
+        rec = R.run_arm_a(inst, PRIMARY, token_db="", base_repo="",
+                          allocator=H.EnvAllocator("/tmp/x"), budget=H.LoopBudget(),
+                          primary_agent="codex", dispatch=fake_dispatch, now=lambda: next(clk))
+        self.assertEqual(rec["arm"], "A")
+        self.assertEqual(rec["instance_id"], "django__django-1")
+        self.assertTrue(rec["patch_fingerprint"])          # patch extracted from the diff text
+        self.assertEqual(rec["wall_s"], 42.0)
+        self.assertFalse(rec["invalid"])                   # a non-empty diff + done => valid
+        self.assertIsNone(rec["resolved"])                 # graded later by S5
+        REP.build_report([rec])                            # record is consumable by the reporter
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_swebench_live_attribution.py
+++ b/benchmarks/tests/test_swebench_live_attribution.py
@@ -103,10 +103,59 @@ class TestVerifyLiveAttribution(unittest.TestCase):
         self.assertFalse(v["passed"])
 
 
-class TestLiveRunnerStub(unittest.TestCase):
-    def test_runner_is_marked_stub(self):
-        with self.assertRaises(NotImplementedError):
-            A.run_live_matrix(ssh_host="admin@x", db_path="/x/aimee.db")
+class TestSplitByJobs(unittest.TestCase):
+    def _db(self):
+        con = sqlite3.connect(":memory:")
+        con.execute(f"CREATE TABLE {A.AUDIT}(delegation_id TEXT, usage_kind TEXT, prompt_tokens INT,"
+                    " completion_tokens INT, cache_read_tokens INT)")
+        return con
+
+    def test_split_partitions_by_trailing_job_id(self):
+        con = self._db()
+        con.execute(f"INSERT INTO {A.AUDIT} VALUES('deleg-1-2-7','realized',1000,100,200)")
+        con.execute(f"INSERT INTO {A.AUDIT} VALUES('deleg-9-9-8','realized',5000,40,0)")
+        con.execute(f"INSERT INTO {A.AUDIT} VALUES('deleg-1-2-7','avoided',9999,9999,0)")  # excluded
+        con.commit()
+        s = A.split_by_jobs(con, 7, [8])
+        self.assertEqual(s["primary_input_uncached"], 800)   # 1000 - 200 cache_read
+        self.assertEqual(s["primary_output"], 100)
+        self.assertEqual(s["worker_output"], 40)
+
+
+class TestRunLiveMatrix(unittest.TestCase):
+    """Drive the S0-live runner with a fake fleet + an on-disk fixture DB: assert L1-L4 pass when
+    the primary and worker land distinct realized rows keyed by job_id."""
+
+    def test_passes_on_disjoint_jobs(self):
+        import tempfile, os
+        from benchmarks.coding import swebench_live_transport as LT
+        fd, path = tempfile.mkstemp(suffix=".db"); os.close(fd)
+        con = sqlite3.connect(path)
+        con.execute(f"CREATE TABLE {A.AUDIT}(delegation_id TEXT, usage_kind TEXT, prompt_tokens INT,"
+                    " completion_tokens INT, cache_read_tokens INT)")
+        con.execute(f"INSERT INTO {A.AUDIT} VALUES('deleg-a-b-31','realized',800,90,100)")   # primary
+        con.execute(f"INSERT INTO {A.AUDIT} VALUES('deleg-a-b-32','realized',400,20,0)")     # worker
+        con.commit(); con.close()
+
+        jobs = iter([31, 32])
+        def fake_dispatch(role, prompt, **kw):
+            jid = next(jobs)
+            return LT.DispatchOutcome(jid, "done", "```diff\n+x\n```", kw.get("via"),
+                                      f"deleg-a-b-{jid}", 2, 1)
+        res = A.run_live_matrix(db_path=path, primary_agent="codex", worker="GLM-5.2",
+                                dispatch=fake_dispatch)
+        os.unlink(path)
+        self.assertTrue(res["passed"], res)
+        self.assertEqual(res["primary_job_id"], 31)
+        self.assertEqual(res["split"]["primary_input_uncached"], 700)
+
+    def test_reports_error_when_db_missing(self):
+        from benchmarks.coding import swebench_live_transport as LT
+        fake = lambda role, prompt, **kw: LT.DispatchOutcome(1, "done", "", kw.get("via"),
+                                                            "d-1", 1, 1)
+        res = A.run_live_matrix(db_path="/no/such.db", dispatch=fake)
+        self.assertFalse(res["passed"])
+        self.assertIn("not readable", res["error"])
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_swebench_live_transport.py
+++ b/benchmarks/tests/test_swebench_live_transport.py
@@ -162,6 +162,22 @@ class TestDelegationCaptureAndSplit(unittest.TestCase):
         self.assertEqual(split["primary_output"], 200)
         self.assertEqual(split["worker_output"], 80)
 
+    def test_exact_delegation_read_ignores_lookalike_ids(self):
+        # Exact delegation_id matching must NOT pull in a different id that merely shares a suffix
+        # (the fragility the LIKE '%-<job_id>' heuristic risks).
+        con = self._db()
+        con.execute(f"INSERT INTO {LA.AUDIT} VALUES(1,'deleg-a-b-3','realized',1000,100,200,0,'')")
+        con.execute(f"INSERT INTO {LA.AUDIT} VALUES(2,'deleg-a-b-13','realized',9999,9999,0,0,'')")
+        con.commit()
+        import tempfile, os
+        fd, path = tempfile.mkstemp(suffix=".db"); os.close(fd)
+        disk = sqlite3.connect(path); con.backup(disk); disk.close()
+        uncached, cached, output, rows = T.read_realized_by_delegations(path, ["deleg-a-b-3"])
+        os.unlink(path)
+        self.assertEqual(rows, 1)                    # only the exact id, not deleg-a-b-13
+        self.assertEqual(uncached, 800)              # 1000 - 200 cache_read
+        self.assertEqual(output, 100)
+
     def test_supervisor_tool_call_rows_zero_when_no_tools(self):
         con = self._db()
         con.execute(f"INSERT INTO {LA.AUDIT} VALUES(1,'sup','realized',100,20,0,0,'')")

--- a/benchmarks/tests/test_swebench_live_transport.py
+++ b/benchmarks/tests/test_swebench_live_transport.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Unit tests for swebench_live_transport — the live delegate transport's pure surface.
+
+No live server: argv construction, status/dispatch JSON parsing, and the full dispatch->poll
+loop driven by an INJECTED fake fleet runner (so the multi-turn control flow is exercised in CI).
+Run: python3 -m unittest benchmarks.tests.test_swebench_live_transport
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from benchmarks.coding import swebench_live_transport as T
+from benchmarks.coding import swebench_live_attribution as LA
+
+
+class TestArgv(unittest.TestCase):
+    def test_tools_requires_worktree(self):
+        with self.assertRaises(ValueError):
+            T.build_delegate_argv("code", "fix it", via="GLM-5.2", tools=True)
+
+    def test_tools_with_worktree_ok(self):
+        argv = T.build_delegate_argv("code", "fix it", via="GLM-5.2", tools=True,
+                                     worktree="aimee/wi/x", persona="engineer")
+        self.assertIn("--tools", argv)
+        self.assertEqual(argv[argv.index("--worktree") + 1], "aimee/wi/x")
+        self.assertEqual(argv[argv.index("--via") + 1], "GLM-5.2")
+        self.assertEqual(argv[:4], ["aimee", "delegate", "code", "fix it"])
+
+    def test_supervisor_no_tools_no_worktree(self):
+        # Arm-C supervisor: NO tools -> no worktree required (structural "no raw code").
+        argv = T.build_delegate_argv("review", "pick best", via="codex", tools=False)
+        self.assertNotIn("--tools", argv)
+        self.assertNotIn("--worktree", argv)
+
+    def test_durable_and_json_default(self):
+        argv = T.build_delegate_argv("explain", "hi")
+        self.assertIn("--json", argv)
+        self.assertIn("--durable", argv)
+
+
+class TestParsing(unittest.TestCase):
+    def test_parse_status_done(self):
+        s = ('{"job_id":26,"job_status":"done","role":"explain","agent_name":"GLM-5.2",'
+             '"result":"PONG","api_call_count":3}')
+        st = T.parse_status(s)
+        self.assertEqual(st.job_id, 26)
+        self.assertTrue(st.terminal)
+        self.assertTrue(st.ok)
+        self.assertEqual(st.result, "PONG")
+        self.assertEqual(st.api_calls, 3)
+
+    def test_parse_status_failed_is_terminal_not_ok(self):
+        st = T.parse_status('{"job_id":1,"job_status":"failed","result":"needs persona"}')
+        self.assertTrue(st.terminal)
+        self.assertFalse(st.ok)
+
+    def test_parse_status_pending(self):
+        st = T.parse_status('{"job_id":1,"job_status":"pending"}')
+        self.assertFalse(st.terminal)
+
+    def test_parse_dispatch(self):
+        self.assertEqual(T.parse_dispatch('{"job_id":25,"job_status":"pending"}'), 25)
+
+    def test_json_with_leading_log_line(self):
+        st = T.parse_status('INFO some log\n{"job_id":9,"job_status":"done","result":"x"}\n')
+        self.assertEqual(st.job_id, 9)
+        self.assertEqual(st.result, "x")
+
+    def test_garbage_is_empty(self):
+        self.assertEqual(T.parse_dispatch("not json at all"), None)
+
+
+class _FakeFleet:
+    """A scripted fleet: the dispatch returns a job_id, then N pending polls, then a terminal."""
+    def __init__(self, job_id=42, pending=2, status="done", result="diff --git a/x b/x\n+ok\n",
+                 agent="GLM-5.2"):
+        self.job_id, self.pending, self.status, self.result, self.agent = \
+            job_id, pending, status, result, agent
+        self._polls = 0
+        self.dispatched_argv = None
+
+    def __call__(self, argv):
+        if argv[2] == "status":
+            self._polls += 1
+            if self._polls <= self.pending:
+                return T.CompletedRun(0, f'{{"job_id":{self.job_id},"job_status":"running"}}')
+            return T.CompletedRun(0, f'{{"job_id":{self.job_id},"job_status":"{self.status}",'
+                                     f'"agent_name":"{self.agent}","result":{_j(self.result)},'
+                                     f'"api_call_count":4}}')
+        self.dispatched_argv = argv
+        return T.CompletedRun(0, f'{{"job_id":{self.job_id},"job_status":"pending"}}')
+
+
+def _j(s):
+    import json
+    return json.dumps(s)
+
+
+class TestDispatchLoop(unittest.TestCase):
+    def test_dispatch_and_wait_success(self):
+        fleet = _FakeFleet(pending=2, status="done")
+        out = T.dispatch_and_wait("code", "fix", runner=fleet, sleep=lambda *_: None,
+                                  via="GLM-5.2", tools=True, worktree="aimee/wi/x")
+        self.assertTrue(out.ok)
+        self.assertEqual(out.job_id, 42)
+        self.assertEqual(out.polls, 3)               # 2 running + 1 terminal
+        self.assertIn("+ok", out.result)
+        self.assertEqual(out.agent_name, "GLM-5.2")
+
+    def test_dispatch_failure_recorded_not_raised(self):
+        fleet = _FakeFleet(status="failed", result="no persona")
+        out = T.dispatch_and_wait("code", "fix", runner=fleet, sleep=lambda *_: None,
+                                  via="x", tools=True, worktree="w")
+        self.assertFalse(out.ok)
+        self.assertEqual(out.status, "failed")
+
+    def test_no_job_id_is_error(self):
+        out = T.dispatch_and_wait("code", "fix", runner=lambda a: T.CompletedRun(1, "boom", "err"),
+                                  sleep=lambda *_: None, via="x", tools=True, worktree="w")
+        self.assertFalse(out.ok)
+        self.assertEqual(out.status, "error")
+
+    def test_poll_budget_exhausted(self):
+        fleet = _FakeFleet(pending=999)
+        out = T.dispatch_and_wait("code", "fix", runner=fleet, sleep=lambda *_: None, max_polls=3,
+                                  via="x", tools=True, worktree="w")
+        self.assertFalse(out.ok)
+        self.assertIn("budget", out.error)
+
+
+class TestDelegationCaptureAndSplit(unittest.TestCase):
+    def _db(self):
+        con = sqlite3.connect(":memory:")
+        con.execute(f"CREATE TABLE {LA.SPAWNS}(id INTEGER PRIMARY KEY, delegation_id TEXT, "
+                    "parent_delegation_id TEXT, session_id TEXT, depth INT, role TEXT)")
+        con.execute(f"CREATE TABLE {LA.AUDIT}(id INTEGER PRIMARY KEY, delegation_id TEXT, "
+                    "usage_kind TEXT, prompt_tokens INT, completion_tokens INT, "
+                    "cache_read_tokens INT, cache_write_tokens INT, tool_name TEXT)")
+        return con
+
+    def test_read_split_partitions_by_delegation_id(self):
+        con = self._db()
+        con.execute(f"INSERT INTO {LA.AUDIT} VALUES(1,'p','realized',1000,200,300,0,'')")
+        con.execute(f"INSERT INTO {LA.AUDIT} VALUES(2,'w1','realized',5000,80,0,0,'')")
+        con.execute(f"INSERT INTO {LA.AUDIT} VALUES(3,'p','avoided',9999,9999,0,0,'')")  # excluded
+        con.commit()
+        import tempfile, os
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        # Re-open on-disk so read_split (which opens by path) sees the rows.
+        disk = sqlite3.connect(path)
+        con.backup(disk)
+        disk.close()
+        split = T.read_split(path, "p", ["w1"])
+        os.unlink(path)
+        self.assertEqual(split["primary_input_uncached"], 700)   # 1000 - 300 cache_read
+        self.assertEqual(split["primary_output"], 200)
+        self.assertEqual(split["worker_output"], 80)
+
+    def test_supervisor_tool_call_rows_zero_when_no_tools(self):
+        con = self._db()
+        con.execute(f"INSERT INTO {LA.AUDIT} VALUES(1,'sup','realized',100,20,0,0,'')")
+        con.commit()
+        import tempfile, os
+        fd, path = tempfile.mkstemp(suffix=".db"); os.close(fd)
+        disk = sqlite3.connect(path); con.backup(disk); disk.close()
+        self.assertEqual(T.supervisor_tool_call_rows(path, "sup"), 0)
+        os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/tests/test_swebench_suite.py
+++ b/benchmarks/tests/test_swebench_suite.py
@@ -123,10 +123,72 @@ class TestPredictions(unittest.TestCase):
         self.assertEqual([p["instance_id"] for p in preds], ["i2"])
 
 
-class TestLiveStub(unittest.TestCase):
-    def test_run_suite_is_marked_stub(self):
-        with self.assertRaises(NotImplementedError):
-            Q.run_suite(token_db="/x", aimee_bin="./aimee")
+class TestLoadInstances(unittest.TestCase):
+    def test_missing_regions_returns_empty(self):
+        self.assertEqual(Q.load_instances("reddit10", "/no/such/dir"), [])
+
+
+class TestResolvedIdsFromReport(unittest.TestCase):
+    def test_resolved_ids_list_shape(self):
+        self.assertEqual(Q.resolved_ids_from_report({"resolved_ids": ["a", "b"]}), {"a", "b"})
+
+    def test_per_instance_dict_shape(self):
+        rep = {"django__x": {"resolved": True}, "sympy__y": {"resolved": False}}
+        self.assertEqual(Q.resolved_ids_from_report(rep), {"django__x"})
+
+    def test_empty_or_bad(self):
+        self.assertEqual(Q.resolved_ids_from_report({}), set())
+        self.assertEqual(Q.resolved_ids_from_report(None), set())
+
+
+class TestRunSuiteOrchestration(unittest.TestCase):
+    """Drive run_suite with INJECTED fake arm-runners + grader + loader (no fleet/docker): assert
+    it runs cells, grades, sets resolved, and aggregates K repeats with flip detection."""
+
+    def _fake_instances(self, spec):
+        return [{"instance_id": "django__django-1", "repo": "django/django", "base_commit": "0" * 40},
+                {"instance_id": "sympy__sympy-2", "repo": "sympy/sympy", "base_commit": "0" * 40}]
+
+    def test_only_b3_runs_and_grades(self):
+        seen = {"a": 0, "c": 0, "graded": []}
+
+        def fake_a(inst, primary, **kw):
+            seen["a"] += 1
+            return {"instance_id": inst["instance_id"], "arm": "A", "patch": "diff --git a/x b/x\n",
+                    "supervisor_input_tokens": 10, "supervisor_output_tokens": 2,
+                    "worker_input_tokens": 0, "worker_output_tokens": 0, "wall_s": 1.0,
+                    "resolved": None, "n_workers": 1, "invalid": False, "compaction": False}
+
+        def fake_c(inst, **kw):
+            seen["c"] += 1
+            return {"instance_id": inst["instance_id"], "arm": "C", "patch": "diff --git a/x b/x\n",
+                    "supervisor_input_tokens": 3, "supervisor_output_tokens": 1,
+                    "worker_input_tokens": 100, "worker_output_tokens": 50, "wall_s": 2.0,
+                    "resolved": None, "n_workers": 3, "invalid": False, "compaction": False}
+
+        def fake_grade(preds, run_id, **kw):
+            seen["graded"].append(run_id)
+            # Resolve the django instance only; flip it off on odd repeats to exercise flip flag.
+            return {p["instance_id"] for p in preds if "django" in p["instance_id"]}
+
+        out = Q.run_suite(only=["b3_parallelism"], arm_a_runner=fake_a, arm_c_runner=fake_c,
+                          grade_fn=fake_grade, instances_loader=self._fake_instances)
+        # b3 is arm C only, N in {1,2,4,8}, K=3 -> 12 cells, each 2 instances.
+        self.assertEqual(seen["a"], 0)
+        self.assertEqual(seen["c"], 12 * 2)
+        self.assertEqual(len(seen["graded"]), 12)
+        # every cell graded -> resolved set on records
+        recs = [r for rs in out["records_by_run"].values() for r in rs]
+        self.assertTrue(all(r["resolved"] is not None for r in recs))
+        # aggregate present with majority-vote per instance
+        self.assertTrue(out["aggregate"])
+        self.assertIn("report", out)
+
+    def test_skips_cells_with_no_instances(self):
+        out = Q.run_suite(only=["b1_reddit10"], arm_a_runner=lambda *a, **k: {},
+                          arm_c_runner=lambda *a, **k: {}, grade_fn=lambda *a, **k: set(),
+                          instances_loader=lambda spec: [])
+        self.assertTrue(all(c.get("skipped") == "no_instances" for c in out["cells"]))
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_swebench_supervision.py
+++ b/benchmarks/tests/test_swebench_supervision.py
@@ -172,10 +172,70 @@ class TestToolAllowlist(unittest.TestCase):
         self.assertFalse(S.tool_allowed("exfiltrate"))
 
 
-class TestLiveStubHonesty(unittest.TestCase):
-    def test_run_arm_c_is_marked_stub(self):
-        with self.assertRaises(NotImplementedError):
-            S.run_arm_c_supervised({}, workers=["w1"], n=1)
+class TestSupervisorDecisionParsing(unittest.TestCase):
+    def test_valid_select(self):
+        d = S.parse_supervisor_decision('{"action":"select","worker_id":"glm","rationale":"clean"}')
+        self.assertEqual(d["action"], "select")
+        self.assertEqual(d["worker_id"], "glm")
+
+    def test_escalate(self):
+        self.assertEqual(S.parse_supervisor_decision('{"action":"escalate"}')["action"], "escalate")
+
+    def test_malformed_falls_back_to_deterministic(self):
+        d = S.parse_supervisor_decision("not json")
+        self.assertEqual(d["action"], "select")
+        self.assertIsNone(d["worker_id"])
+        self.assertEqual(d["rationale"], "parse_error")
+
+    def test_prompt_has_no_source_only_digests(self):
+        p = S.supervisor_prompt({"problem": "bug"}, "[w1 t0 done/PASS +1-0 edit]\ndiff...", ["w1"])
+        self.assertIn("NO access to the source", p)
+        self.assertIn("bug", p)
+
+
+class TestRunArmCLive(unittest.TestCase):
+    """Drive the real arm-C loop with an injected fake fleet: N concurrent worker dispatches, a
+    tools-OFF supervisor turn, deterministic selection, schema-valid record."""
+
+    def setUp(self):
+        # Force the LIVE path regardless of a global AIMEE_BENCH_FAKE_AGENT.
+        self._orig = S._FAKE
+        S._FAKE = False
+        self.addCleanup(lambda: setattr(S, "_FAKE", self._orig))
+
+    def test_arm_c_selects_and_supervises(self):
+        from benchmarks.coding import swebench_agentic_harness as H
+        from benchmarks.coding import swebench_live_transport as LT
+
+        calls = {"worker": 0, "supervisor": 0}
+
+        def fake_dispatch(role, prompt, **kw):
+            if role == "review":                       # the supervisor turn
+                calls["supervisor"] += 1
+                self.assertFalse(kw.get("tools"))      # Option A: supervisor tools OFF
+                return LT.DispatchOutcome(100, "done", '{"action":"select","worker_id":"w1"}',
+                                          "codex", "deleg-s-1-100", 2, 1)
+            calls["worker"] += 1                        # a worker agentic loop
+            self.assertTrue(kw.get("tools") and kw.get("worktree"))
+            wid = kw.get("via")
+            return LT.DispatchOutcome(10 + calls["worker"], "done",
+                                      f"```diff\ndiff --git a/{wid} b/{wid}\n+fix\n```",
+                                      wid, f"deleg-w-1-{10 + calls['worker']}", 3, 1)
+
+        inst = {"instance_id": "sympy__sympy-1", "repo": "sympy/sympy", "base_commit": "0" * 40,
+                "problem": "bug"}
+        rec = S.run_arm_c_supervised(inst, workers=["w1", "w2", "w3"], n=2,
+                                     allocator=H.EnvAllocator("/tmp/c"), budget=H.LoopBudget(),
+                                     primary_agent="codex", primary_model="gpt-5.5",
+                                     dispatch=fake_dispatch)
+        self.assertEqual(rec["arm"], "C")
+        self.assertEqual(calls["worker"], 2)           # n=2 workers dispatched
+        self.assertEqual(calls["supervisor"], 1)       # exactly one supervisor turn
+        self.assertEqual(rec["n_candidates"], 2)
+        self.assertIsNotNone(rec["selected_worker"])
+        self.assertEqual(rec["supervisor_decision"], "select")
+        self.assertFalse(rec["invalid"])
+        self.assertIsNone(rec["resolved"])             # graded later by S5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Wires the 7 live `NotImplementedError` stubs of the agentic supervised SWE-bench harness (issue #987) onto the **deployment-verified delegate transport + delegation/job-id attribution** model, superseding the theoretical `/v1/runs` EMPTY-delegation-polarity model (a prior live .254 run proved that model wrong — see `swebench_live_attribution.py` FINDINGS 1–4).

## What's wired
- **New `swebench_live_transport.py`** — the single live `aimee delegate` transport: argv build enforcing the tools⇒`--worktree` invariant (FINDING 4), dispatch/poll with an **injectable runner** (CI drives a fake fleet, no server), exact-delegation + job-id token split, supervisor tool-row assertion.
- **S1** `run_agentic_loop`, **S2** `run_arm_a`, **S3** `run_arm_c_supervised` (Option A: N concurrent workers `$0` + one **tools-OFF** supervisor over capped leak-guarded digests + **deterministic** best-of-N + gated escalation), **S5** `run_suite` (run-plan → arms → official CT-101 grade → K-aggregate → report), **S0-live** `run_live_matrix`.
- **S5 grader bug fixed:** the merged `_grade_with_harness` returns an empty resolved-id set; `official_grade_fn` now derives resolved ids from the harness report (`resolved_ids`).

## Honesty fixes (from a 6-provider `aimee delegate aggregate` review, 0 failed)
- **Hallucination gap (biggest risk):** a response-text ```diff the agent *wrote* but never *applied* must not be graded. In co-located mode the graded patch is the actual filesystem diff (`git diff base_commit`) only; a returned-text diff is tagged `patch_source="response_text"` / non-authoritative, and a clean workspace grades nothing. Proven by `TestHallucinationGapGuard`.
- **Attribution:** prefer exact `delegation_id` matching (captured from `delegation_spawns`) over the job-id `LIKE '%-<job_id>'` heuristic.

## Tests
**597 bench tests pass** (+~40 new), with and without `AIMEE_BENCH_FAKE_AGENT=1`. Runbook CI fast-check (161 tests) green.

## Not in scope of this PR (deployment-tier, validation-pending)
The graded suite (official grader on **CT101 real docker**), real-ledger token attribution (`.254` DB), and the claim gate (needs an independent human reviewer) are the operator's step — the honest verified/validation-pending split is in `benchmarks/coding/AGENTIC_SWEBENCH_WIRING_STATUS.md`. The proposal is intentionally left `pending`.