### PR TITLE
feat(kb): idle reflection synthesis on the shared curator LLM path + shadow gate

### DIFF
--- a/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
+++ b/docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md
@@ -1,6 +1,13 @@
 # Proposal: LLM-sidecar productionization — graduate curator extraction and idle reflection from stub to production
 
-- **State:** PENDING — design only, no code in this PR. Finalises three
+- **State:** PENDING — in implementation. The memory-typed-fact half (§6/§7/§8)
+  and the curator doc/code extraction path (§2) shipped ahead of this on
+  `testing` (see the **Reconciliation** section at the end for the per-criterion
+  map). The remaining code — moving idle reflection onto the shared curator LLM
+  path (§1/§3) and its shadow gate (§4) — lands on branch
+  `worktree-llm-curator-productionization`. Stays PENDING because criteria 4
+  (canary→default promotion), 6/7 (`.254` runtime proof) and part of 8 are
+  hardware-/human-gated (see Reconciliation). Finalises three
   scaffolded-but-stubbed intelligence steps that ride the shared
   `kb_curator_sidecar` / offline-extractor mechanism. Adds no new **durability**
   subsystem: it wires the existing curator extract/synthesize/judge stages, the
@@ -335,3 +342,65 @@ aimee-server is not in the loop for any of it.
   constraint) and *running* provisional→active promotion on by default — the gate
   and the durability contract themselves are unchanged. Free-form relations are no
   longer silently stranded as provisional; that is the whole point.
+
+## Reconciliation (as-built — 2026-07-08)
+
+The codebase moved past this proposal's "design-only, everything stubbed"
+premise. This section maps the proposal to what actually shipped, so the doc is
+honest about done vs validation-pending. **Human steering (2026-07-08): do NOT
+build a new popen sidecar; route through the existing curator LLM
+infrastructure** (`kb_curator_llm_run` → `provider_client`). §1 is therefore
+reconciled, not built literally.
+
+### Section-by-section
+- **§1 sidecar contract — SUPERSEDED.** The "one versioned JSON contract invoked
+  through `kb_curator_sidecar_run`" is realised by the shipped curator LLM path:
+  `kb_curator_llm_run(cfg, stage, system_prompt, request, json_schema,
+  fallback_command, …)` → a per-tier `provider_client` (strict
+  `response_format: json_schema`), version-keyed via `kb_curator_version.c`, with
+  the legacy `*_command` sidecar as a fail-closed fallback. That path — not a new
+  popen contract — is "the contract."
+- **§2 curator extraction — DONE** (`#1157`/`#1158`/`#1159`). extract_doc /
+  extract_code produce entities/facts/decisions/relationships; the doc↔code
+  `implements` bridge is `kb_curator_link_artifacts.c` + `POST /v1/implements`.
+- **§3 reflection synthesis — DONE, now unified.** `kb_reflection.c`
+  `run_synthesis_pass` already synthesised (N-attempt, MDL cluster selection,
+  writes `session_synthesis`, dedup/cooldown/idle). This branch moves its LLM step
+  off the standalone `kb_synthesize_command`/`platform_exec_pipe` onto the shared
+  `kb_curator_llm_run` under the new Tier-B stage
+  `KB_CURATOR_STAGE_SYNTHESIZE_REFLECTION` (the sidecar command remains the
+  fallback). MDL/dedup/cooldown/idle preserved verbatim.
+- **§4 gated rollout — SHADOW shipped; promotion deferred.** A fail-closed shadow
+  gate lands: `intelligence.synthesize.reflection_shadow`
+  (`kb_reflection_synthesis_shadow`, default 0) makes the pass score and log its
+  winner as evidence but write NO durable candidate. The
+  `reflection_synthesis_mode` bandit arm is declared in `kb_bandit_registry.c`
+  (status `static`). The shadow→canary→default *promotion policy* (thresholds,
+  the recorded bandit flip) is **deferred to a human** — it is validatable only on
+  live traffic / the `.254` stack.
+- **§6 offline + default-on — DONE** (`#1153`): `typed_facts_enabled` defaults on.
+- **§7 autonomous reconciliation — DONE** (`#1140`/`#1152`): ontology-constrained
+  extraction + auto-promote; facts commit recallable.
+- **§8 KB console — DONE** (`#1140`): the Typed Facts panel routes.
+
+### Acceptance criteria
+| # | State | Note |
+|---|-------|------|
+| 1 Contract / malformed⇒defer | **DONE** | Reconciled to the curator LLM path; malformed/failed response ⇒ defer, no durable write — proven by `tests/test_kb_reflection.c` (garbage + command-failure cases). |
+| 2 Curator extraction + `implements` | **DONE** | Shipped (`#1157`/`#1158`); `implements` via `kb_curator_link_artifacts.c`. |
+| 3 Reflection synthesis into pipeline | **DONE** | Unified onto `kb_curator_llm_run`; `session_synthesis` written; dedup/`reflected_at` preserved. |
+| 4 Gate shadow→canary→default | **PARTIAL** | Shadow shipped + fail-closed (test-proven); canary→default promotion + the recorded bandit flip **deferred to human** (live-traffic/`.254`). |
+| 5 CPU-first install | **DONE** | The provider path installs CPU-first (curator profile); the command fallback needs no cloud. |
+| 6 Offline + default-on | **DONE (code)** / **VALIDATION-PENDING** | Default-on shipped; the "time a store shows zero synchronous LLM" proof is a `.254` runtime check. |
+| 7 Reconciliation ⇒ recallable | **DONE (code)** / **VALIDATION-PENDING** | Committed in code (`#1152`); the end-to-end recall proof is on the `.254` stack. |
+| 8 KB console core | **DONE** | Routes shipped (`#1140`). |
+
+### Deferred to human (cannot be done unattended / off-hardware)
+1. §4 promotion policy — the shadow→canary→default thresholds and the recorded
+   `reflection_synthesis_mode` bandit flip (needs live traffic).
+2. `.254`-stack quality/latency validation for criteria 6/7 and reflection
+   synthesis output quality.
+3. Decommissioning the legacy `kb_synthesize_command` path once the provider path
+   is trusted.
+
+This proposal stays in `pending/` until the human-gated items above are closed.

--- a/src/config_learning.c
+++ b/src/config_learning.c
@@ -436,6 +436,7 @@ void config_apply_mdl_settings(config_t *cfg, cJSON *root)
    cfg->kb_mdl_bump_drift_alert = 0.30;
    cfg->kb_synthesize_n_attempts = 3;
    cfg->kb_synthesize_command[0] = '\0';
+   cfg->kb_reflection_synthesis_shadow = 0;
 
    if (!root)
       return;
@@ -463,6 +464,12 @@ void config_apply_mdl_settings(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(s, "synthesize_n_attempts");
    if (cJSON_IsNumber(item) && item->valuedouble > 0)
       cfg->kb_synthesize_n_attempts = (int)item->valuedouble;
+
+   /* Shadow gate for idle-reflection synthesis (proposal §4): when on, the pass
+    * scores and logs its winner but writes no durable candidate. Fail-closed. */
+   item = cJSON_GetObjectItemCaseSensitive(s, "reflection_shadow");
+   if (cJSON_IsBool(item) || cJSON_IsNumber(item))
+      cfg->kb_reflection_synthesis_shadow = item->valueint;
 }
 
 /* Inverse of the intelligence.* parsers (calibrate/demotion/bandit) so config_save

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1427,11 +1427,19 @@ typedef struct config
     * kb_mdl_bump_drift_alert: fraction of MDL disagreements after a prompt bump
     *   that triggers a review flag (default 0.30).
     * kb_synthesize_command: sidecar command for N-attempt synthesis (stdin=JSON, stdout=JSON).
-    * kb_synthesize_n_attempts: number of synthesis attempts per evidence bundle (default 3). */
+    * kb_synthesize_n_attempts: number of synthesis attempts per evidence bundle (default 3).
+    * kb_reflection_synthesis_shadow: 1 = shadow mode for idle-reflection synthesis
+    *   (kb_reflection.c) — the LLM runs and its winner is scored and logged as
+    *   evidence, but the durable `session_synthesis` proposed candidate is NOT
+    *   written (fail-closed, no promotion). 0 = normal (default): the scored
+    *   winner is written into the promotion pipeline. Promotion of the shadow
+    *   stream to normal is a bandit decision (reflection_synthesis_mode), wired
+    *   separately; this flag never flips itself. */
    int kb_mdl_tiebreak_enabled;
    double kb_mdl_bump_drift_alert;
    char kb_synthesize_command[512];
    int kb_synthesize_n_attempts;
+   int kb_reflection_synthesis_shadow;
 
    /* KB background ingest worker pool (kb.worker_count, kb.connection_workers,
     * kb.background_ingest.*). kb_worker_count: aimee-kb in-process KB ingest

--- a/src/headers/kb_curator_provider.h
+++ b/src/headers/kb_curator_provider.h
@@ -30,6 +30,11 @@ extern "C"
       KB_CURATOR_STAGE_DETECT_CONTRADICTIONS,
       KB_CURATOR_STAGE_SYNTHESIZE,
       KB_CURATOR_STAGE_PROMOTE_ENTITY,
+      /* Idle-time reflection synthesis (kb_reflection.c). A distinct Tier-B stage
+       * from SYNTHESIZE so its provider resolution, and any future calibration /
+       * bandit telemetry, stay isolated from the curator entity-synthesis stream
+       * (which writes a different artifact kind on a different surface). */
+      KB_CURATOR_STAGE_SYNTHESIZE_REFLECTION,
    } kb_curator_stage_t;
 
    typedef enum

--- a/src/kb/kb_bandit_registry.c
+++ b/src/kb/kb_bandit_registry.c
@@ -52,6 +52,17 @@ static const kb_bandit_decision_point_t REGISTRY[] = {
         .reward_fn = "guardrail_outcome_replay_v1",
         .status = "static",
     },
+    {
+        .id = "reflection_synthesis_mode",
+        .description = "Idle-reflection synthesis rollout (proposal §4): keep the "
+                       "candidate stream in shadow (scored, unpromoted) or promote it "
+                       "to active (writes into the promotion pipeline). Declared here; "
+                       "the shadow->active flip is wired separately, never a config edit.",
+        .arms = {"shadow", "active"},
+        .n_arms = 2,
+        .reward_fn = "reflection_synthesis_quality_replay_v1",
+        .status = "static",
+    },
 };
 
 int kb_bandit_registry_count(void)

--- a/src/kb/kb_reflection.c
+++ b/src/kb/kb_reflection.c
@@ -3,8 +3,10 @@
  * When now - last_session_rpc_ts > review_idle_trigger_minutes, fires a
  * reflection pass over unreflected session_summary artifacts older than
  * review_session_cooldown_hours.  Stamps reflected_at on each processed
- * artifact.  LLM candidate generation is stubbed pending charter sidecar
- * integration; the scheduler infrastructure and deduplication run fully.
+ * artifact.  LLM candidate generation runs the shared curator LLM path
+ * (kb_curator_llm_run, stage KB_CURATOR_STAGE_SYNTHESIZE_REFLECTION): a
+ * configured Tier-B provider, else the legacy kb_synthesize_command sidecar.
+ * The scheduler infrastructure, MDL selection, and deduplication run fully.
  *
  * No DB1 access from this file.
  */
@@ -20,12 +22,27 @@
 #include "cJSON.h"
 #include "config.h"
 #include "db2/artifacts.h"
-#include "db2/db2.h" /* db2_lease_release_idle */
+#include "db2/db2.h"             /* db2_lease_release_idle */
+#include "kb_curator_llm.h"      /* kb_curator_llm_run — shared curator LLM path */
+#include "kb_curator_provider.h" /* KB_CURATOR_STAGE_SYNTHESIZE_REFLECTION, provider_for_stage */
 #include "kb_features.h"
 #include "kb_mdl.h"
 #include "kb_service.h"
 #include "log.h"
 #include "platform_process.h"
+
+/* Reflection synthesis runs through the shared curator LLM path
+ * (kb_curator_llm_run): a configured Tier-B provider (provider_client, strict
+ * JSON) if present, else the legacy kb_synthesize_command sidecar as fallback.
+ * The provider path needs a system prompt (the legacy sidecar carried its own). */
+#define REFLECTION_SYNTH_OUTBUF 16384
+static const char *const REFLECTION_SYNTH_SYSTEM_PROMPT =
+    "You consolidate a batch of session-summary evidence into ONE higher-order "
+    "insight. Reply with a single JSON object and nothing else: "
+    "{\"candidate\": \"<the synthesized insight, one or two sentences>\", "
+    "\"cluster\": \"<a short topic label the insight belongs to>\", "
+    "\"confidence\": <0.0-1.0>}. Ground the insight in the evidence; do not invent "
+    "facts. If the evidence supports no durable insight, return a low confidence.";
 
 #include <pthread.h>
 #include <stdlib.h>
@@ -96,19 +113,22 @@ static int run_synthesis_pass(const config_t *cfg, const db2_artifact_proposed_t
       char *req_str = cJSON_PrintUnformatted(req);
       cJSON_Delete(req);
 
-      char *out = NULL;
-      size_t out_len = 0;
-      int rc =
-          platform_exec_pipe(cfg->kb_synthesize_command, req_str, strlen(req_str), &out, &out_len);
+      /* Route through the shared curator LLM path: a configured Tier-B provider
+       * (provider_client) if present, else the legacy kb_synthesize_command
+       * sidecar. A NULL return is a fail — skip this attempt (fail-closed: no
+       * durable write happens on a failed/empty response). */
+      char serr[256];
+      char *out = kb_curator_llm_run(
+          cfg, KB_CURATOR_STAGE_SYNTHESIZE_REFLECTION, REFLECTION_SYNTH_SYSTEM_PROMPT, req_str,
+          NULL, cfg->kb_synthesize_command, REFLECTION_SYNTH_OUTBUF, serr, sizeof(serr));
       free(req_str);
 
-      if (rc != 0 || !out || out_len == 0)
-      {
-         free(out);
+      if (!out)
          continue;
-      }
 
-      cJSON *resp = cJSON_ParseWithLength(out, out_len);
+      /* Tolerate prose/fence-wrapped output: scan to the first JSON object. */
+      const char *start = strchr(out, '{');
+      cJSON *resp = start ? cJSON_Parse(start) : NULL;
       free(out);
 
       if (!resp)
@@ -144,6 +164,7 @@ static int run_synthesis_pass(const config_t *cfg, const db2_artifact_proposed_t
    {
       aimee_log(LOG_WARN, "kb.reflection", "synthesis sidecar returned no valid candidates for %s",
                 row->id);
+      free(evidence_enriched);
       return -1;
    }
 
@@ -162,6 +183,26 @@ static int run_synthesis_pass(const config_t *cfg, const db2_artifact_proposed_t
    cJSON_AddNumberToObject(win, "mdl_total", scores[winner].total);
    char *win_str = cJSON_PrintUnformatted(win);
    cJSON_Delete(win);
+
+   /* Shadow gate (proposal §4): score and log the winner as evidence, but write
+    * NO durable candidate — fail-closed, nothing enters the promotion pipeline.
+    * Promoting the shadow stream to normal is a bandit decision
+    * (reflection_synthesis_mode), wired separately; this never flips itself. */
+   if (cfg->kb_reflection_synthesis_shadow)
+   {
+      aimee_log(LOG_INFO, "kb.reflection",
+                "shadow synthesis (scored, unpromoted): source=%s winner=%d conf=%.2f "
+                "mdl_total=%.2f candidate=%s",
+                row->id, winner, confidences[winner], scores[winner].total, win_str);
+      free(win_str);
+      for (int i = 0; i < n_valid; i++)
+      {
+         free(candidate_bufs[i]);
+         free(cluster_bufs[i]);
+      }
+      free(evidence_enriched);
+      return 0;
+   }
 
    char new_id[37];
    db2_artifact_gen_id(new_id, sizeof(new_id));
@@ -237,14 +278,19 @@ static void run_reflection_pass(const config_t *cfg)
          continue;
       }
 
-      if (cfg->kb_synthesize_command[0] != '\0' && cfg->kb_mdl_tiebreak_enabled)
+      /* Run when MDL tie-break is on AND we have somewhere to send the work: a
+       * configured Tier-B provider (provider_client) or the legacy sidecar. */
+      provider_def_t rprov;
+      int have_provider =
+          kb_curator_provider_for_stage(cfg, KB_CURATOR_STAGE_SYNTHESIZE_REFLECTION, &rprov);
+      if ((cfg->kb_synthesize_command[0] != '\0' || have_provider) && cfg->kb_mdl_tiebreak_enabled)
       {
          run_synthesis_pass(cfg, &rows[i]);
       }
       else
       {
-         aimee_log(LOG_INFO, "kb.reflection",
-                   "session %s reflected (synthesis sidecar not configured)", rows[i].id);
+         aimee_log(LOG_INFO, "kb.reflection", "session %s reflected (synthesis LLM not configured)",
+                   rows[i].id);
       }
       processed++;
    }

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -29,6 +29,7 @@ kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage)
    case KB_CURATOR_STAGE_DETECT_CONTRADICTIONS:
    case KB_CURATOR_STAGE_SYNTHESIZE:
    case KB_CURATOR_STAGE_PROMOTE_ENTITY:
+   case KB_CURATOR_STAGE_SYNTHESIZE_REFLECTION:
       return KB_CURATOR_TIER_B;
    }
    /* Fail safe: an unclassified / future stage routes to the capable tier (which

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -433,6 +433,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-curator-judge \
                $(TESTPREFIX)/unit-test-kb-surprising-judge \
                $(TESTPREFIX)/unit-test-curator-synthesize \
+               $(TESTPREFIX)/unit-test-kb-reflection \
                $(TESTPREFIX)/unit-test-curator-promote \
                $(TESTPREFIX)/unit-test-db1-write-retry \
                $(TESTPREFIX)/unit-test-db1-agent-job-heartbeat \
@@ -2656,6 +2657,26 @@ $(TESTPREFIX)/unit-test-kb-surprising-judge: \
 $(TESTPREFIX)/unit-test-curator-synthesize: \
                                        $(OBJDIR)/tests/test_curator_synthesize.o \
                                        $(OBJDIR)/kb/kb_curator_synthesize.o \
+                                       $(OBJDIR)/kb/kb_curator_sidecar.o \
+                                       $(OBJDIR)/kb/kb_curator_llm.o \
+                                       $(OBJDIR)/kb_curator_provider.o \
+                                       $(OBJDIR)/provider_client.o \
+                                       $(OBJDIR)/tests/support/mock_agent_http.o \
+                                       $(OBJDIR)/db2/artifacts.o $(OBJDIR)/db2/kb_audit_worm.o $(OBJDIR)/audit_worm_chain.o $(OBJDIR)/workflow/wfe_canonical.o \
+                                       $(OBJDIR)/db2/feature_rows.o \
+                                       $(OBJDIR)/kb/kb_mdl.o \
+                                       $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
+                                       $(OBJDIR)/db2/db_schema.o \
+                                       $(OBJDIR)/cJSON.o \
+                                       $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
+
+# idle-reflection synthesis write-gate (§3/§4): reflection routes through the
+# shared curator LLM path; the LLM is faked via the sidecar command seam
+# (printf fallback, no provider). Includes kb_reflection.c to reach the static
+# run_synthesis_pass; graph/feature/background deps are stubbed in the test.
+$(TESTPREFIX)/unit-test-kb-reflection: \
+                                       $(OBJDIR)/tests/test_kb_reflection.o \
                                        $(OBJDIR)/kb/kb_curator_sidecar.o \
                                        $(OBJDIR)/kb/kb_curator_llm.o \
                                        $(OBJDIR)/kb_curator_provider.o \

--- a/src/tests/test_kb_reflection.c
+++ b/src/tests/test_kb_reflection.c
@@ -1,0 +1,187 @@
+/* test_kb_reflection.c: idle-reflection synthesis write-gate.
+ *
+ * Covers the proposal §3/§4 changes to kb_reflection.c::run_synthesis_pass:
+ *   - the LLM step routes through the shared curator path (kb_curator_llm_run),
+ *     driven here deterministically via the sidecar command seam (a `printf`
+ *     fallback command, no provider configured) — no network, no GPU;
+ *   - fail-closed durable writes (the sharpest risk): a garbage response, a
+ *     failed command, and shadow mode must each write ZERO session_synthesis
+ *     artifacts; only a valid response in normal mode writes exactly one.
+ *
+ * run_synthesis_pass is static, so the unit is reached by including the .c
+ * directly (same pattern as the other curator unit tests). db2 writes land in
+ * the in-memory sqlite shim and are counted via SQL.
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* strptime, used by the included kb_reflection.c */
+#endif
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sqlite3.h>
+
+#include "db2_test_shim.h"
+
+/* The unit under test (pulls its own headers). */
+#include "../kb/kb_reflection.c"
+
+/* ── Stubs for deps the reflection TU references but this test does not link ── */
+
+/* Graph enrichment: report "no citations" so run_synthesis_pass takes the plain
+ * evidence path (the graph seam is exercised elsewhere). */
+int kb_reasoning_query(const config_t *cfg, const char *query, const char *bindings_json,
+                       const char *program, const char *facts_json,
+                       kb_reasoning_result_t *result_out)
+{
+   (void)cfg;
+   (void)query;
+   (void)bindings_json;
+   (void)program;
+   (void)facts_json;
+   if (result_out)
+      memset(result_out, 0, sizeof(*result_out));
+   return -1;
+}
+void kb_reasoning_result_free(kb_reasoning_result_t *r)
+{
+   (void)r;
+}
+
+/* Feature upsert is a side effect on a real write; no-op under the shim. */
+int kb_features_upsert_synthesis_mdl(const char *id, const kb_mdl_score_t *score)
+{
+   (void)id;
+   (void)score;
+   return 0;
+}
+
+/* Background status heartbeats — not under test. */
+void kb_background_set(const char *name, const char *descriptor_fmt, ...)
+{
+   (void)name;
+   (void)descriptor_fmt;
+}
+void kb_background_clear(const char *name)
+{
+   (void)name;
+}
+
+/* Referenced by the scheduler thread (never started here). */
+kb_service_ctx_t *g_kb_ctx = NULL;
+
+/* ── Helpers ── */
+
+static int count_session_synthesis(sqlite3 *db)
+{
+   sqlite3_stmt *st = NULL;
+   assert(sqlite3_prepare_v2(db, "SELECT COUNT(*) FROM artifacts WHERE kind='session_synthesis'",
+                             -1, &st, NULL) == SQLITE_OK);
+   assert(sqlite3_step(st) == SQLITE_ROW);
+   int n = sqlite3_column_int(st, 0);
+   sqlite3_finalize(st);
+   return n;
+}
+
+/* A config wired to run synthesis via the command seam (no provider ⇒ the
+ * reflection Tier-B stage falls back to kb_synthesize_command). */
+static void base_cfg(config_t *cfg, const char *cmd)
+{
+   memset(cfg, 0, sizeof(*cfg));
+   cfg->kb_mdl_tiebreak_enabled = 1;
+   cfg->kb_synthesize_n_attempts = 2;
+   cfg->kb_reflection_synthesis_shadow = 0;
+   snprintf(cfg->kb_synthesize_command, sizeof(cfg->kb_synthesize_command), "%s", cmd);
+}
+
+static void mk_row(db2_artifact_proposed_t *row)
+{
+   memset(row, 0, sizeof(*row));
+   snprintf(row->id, sizeof(row->id), "sess-1");
+   snprintf(row->kind, sizeof(row->kind), "session_summary");
+   snprintf(row->payload_json, sizeof(row->payload_json), "{\"summary\":\"did X and Y\"}");
+}
+
+#define VALID_JSON "{\"candidate\":\"insight\",\"cluster\":\"topicA\",\"confidence\":0.9}"
+
+/* Valid response, normal mode ⇒ exactly one durable candidate written. */
+static void test_valid_writes_one(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   config_t cfg;
+   base_cfg(&cfg, "printf '%s' '" VALID_JSON "'");
+   db2_artifact_proposed_t row;
+   mk_row(&row);
+
+   int rc = run_synthesis_pass(&cfg, &row);
+   assert(rc == 0);
+   assert(count_session_synthesis(db) == 1);
+   db2_test_shim_close();
+   printf("  valid response, normal mode → 1 candidate written OK\n");
+}
+
+/* Valid response, SHADOW mode ⇒ scored but NO durable write (fail-closed). */
+static void test_shadow_writes_none(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   config_t cfg;
+   base_cfg(&cfg, "printf '%s' '" VALID_JSON "'");
+   cfg.kb_reflection_synthesis_shadow = 1;
+   db2_artifact_proposed_t row;
+   mk_row(&row);
+
+   int rc = run_synthesis_pass(&cfg, &row);
+   assert(rc == 0); /* shadow is a clean no-write success */
+   assert(count_session_synthesis(db) == 0);
+   db2_test_shim_close();
+   printf("  valid response, shadow mode → 0 candidates written OK\n");
+}
+
+/* Non-JSON response ⇒ defer (no valid candidate), NO durable write. */
+static void test_garbage_writes_none(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   config_t cfg;
+   base_cfg(&cfg, "printf '%s' 'not json at all'");
+   db2_artifact_proposed_t row;
+   mk_row(&row);
+
+   int rc = run_synthesis_pass(&cfg, &row);
+   assert(rc == -1); /* no valid candidates */
+   assert(count_session_synthesis(db) == 0);
+   db2_test_shim_close();
+   printf("  garbage response → defer, 0 candidates written OK\n");
+}
+
+/* Command failure (non-zero exit ⇒ kb_curator_llm_run returns NULL) ⇒ no write. */
+static void test_command_failure_writes_none(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   config_t cfg;
+   base_cfg(&cfg, "false");
+   db2_artifact_proposed_t row;
+   mk_row(&row);
+
+   int rc = run_synthesis_pass(&cfg, &row);
+   assert(rc == -1);
+   assert(count_session_synthesis(db) == 0);
+   db2_test_shim_close();
+   printf("  command failure → 0 candidates written OK\n");
+}
+
+int main(void)
+{
+   printf("test_kb_reflection: reflection synthesis write-gate\n");
+   test_valid_writes_one();
+   test_shadow_writes_none();
+   test_garbage_writes_none();
+   test_command_failure_writes_none();
+   printf("test_kb_reflection: all passed\n");
+   return 0;
+}


### PR DESCRIPTION
Graduates idle-reflection synthesis onto the existing curator LLM infrastructure — **no new sidecar** — implementing the reflection half (§1/§3/§4) of `docs/proposals/pending/llm-sidecar-productionization-curator-and-reflection.md`. The memory-typed-fact half (§6/§7/§8) and curator doc/code extraction (§2) already shipped on `testing`; this closes the reflection gap.

## What changed
- **New Tier-B stage `KB_CURATOR_STAGE_SYNTHESIZE_REFLECTION`** — reflection resolves its own provider and keeps its calibration/telemetry isolated from the curator entity-synthesis stream.
- **`kb_reflection.c::run_synthesis_pass`** now calls `kb_curator_llm_run(..., fallback=kb_synthesize_command)` instead of `platform_exec_pipe`: a configured Tier-B provider (`provider_client`, strict JSON) if present, else the legacy sidecar command as a fail-closed fallback. Tolerant parse for prose/fence output. **MDL selection, dedup, cooldown, idle trigger, and `reflected_at` stamping preserved verbatim.**
- **Fail-closed shadow gate (§4):** `intelligence.synthesize.reflection_shadow` (`kb_reflection_synthesis_shadow`, default 0). In shadow the winner is scored + logged as evidence but **no durable `session_synthesis` candidate is written** — nothing enters the promotion pipeline. The `reflection_synthesis_mode` bandit arm is declared (`static`) for the deferred shadow→active flip; the flag never flips itself.
- Fix a pre-existing leak of `evidence_enriched` on the no-candidates path.
- Reconcile the proposal doc to as-built (per-criterion table) and fix the stale "stubbed" header comment.

## Test
`tests/test_kb_reflection.c` (`unit-test-kb-reflection`) drives the LLM via the sidecar command seam (no network/GPU) and asserts the fail-closed contract: **shadow / garbage / command-failure each write 0 durable candidates; a valid response in normal mode writes exactly 1.**

## Verification
Full build (`-Werror`), full `unit-tests` suite, `clang-format`, the proposal/curator/kb-intelligence lint gates, and an **ASan+UBSan** run over the test are all green.

## Deferred (proposal stays `pending/`)
Human/hardware-gated: §4 canary→default promotion policy + the recorded bandit flip (needs live traffic); the `.254`-stack runtime proofs for criteria 6/7; decommissioning the legacy `kb_synthesize_command`.