### PR TITLE
fix(cli): don't abandon a long /v1 run on one transient poll failure

### DIFF
--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -1016,23 +1016,38 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
 
    int waited = 0;
    const int step_ms = 500;
+   /* A long remote run (delegate ensembles, kb.build, index.scan, …) polls for many
+    * minutes. A single transient poll failure — a TLS/connection blip while the run
+    * is still progressing server-side — must NOT abandon it; that surfaced as the
+    * misleading "could not reach the /v1 endpoint" on long roundtables. Tolerate a
+    * bounded run of CONSECUTIVE poll failures (reset on any success) before giving
+    * up, so a momentary blip is ridden out instead of failing the whole run. */
+   int consec_fail = 0;
+   const int max_consec_fail = 20;
    for (;;)
    {
       cJSON *snap = cli_v1_send(remote, bearer, "GET", runpath, NULL, 15000, &status);
       if (!snap)
-         return NULL;
-      cJSON *st = cJSON_GetObjectItemCaseSensitive(snap, "status");
-      if (cJSON_IsString(st) &&
-          (strcmp(st->valuestring, "completed") == 0 || strcmp(st->valuestring, "failed") == 0 ||
-           strcmp(st->valuestring, "cancelled") == 0))
       {
-         cJSON *result = cJSON_DetachItemFromObjectCaseSensitive(snap, "result");
-         cJSON_Delete(snap);
-         /* Completed runs carry the raw dispatch result; a failed/empty run yields
-          * an empty object so the caller still gets a well-formed response. */
-         return result ? result : cJSON_CreateObject();
+         if (++consec_fail > max_consec_fail)
+            return NULL;
       }
-      cJSON_Delete(snap);
+      else
+      {
+         consec_fail = 0;
+         cJSON *st = cJSON_GetObjectItemCaseSensitive(snap, "status");
+         if (cJSON_IsString(st) &&
+             (strcmp(st->valuestring, "completed") == 0 || strcmp(st->valuestring, "failed") == 0 ||
+              strcmp(st->valuestring, "cancelled") == 0))
+         {
+            cJSON *result = cJSON_DetachItemFromObjectCaseSensitive(snap, "result");
+            cJSON_Delete(snap);
+            /* Completed runs carry the raw dispatch result; a failed/empty run yields
+             * an empty object so the caller still gets a well-formed response. */
+            return result ? result : cJSON_CreateObject();
+         }
+         cJSON_Delete(snap);
+      }
       if (timeout_ms > 0 && waited >= timeout_ms)
          return NULL;
       cli_v1_sleep_ms(step_ms);


### PR DESCRIPTION
## Symptom
`aimee delegate roundtable` intermittently failed with *"could not reach the aimee-server /v1 endpoint"* against a remote aimee-server — even though the run was executing fine server-side (jobs visible in `aimee jobs`), and `aimee remote status` reported the endpoint reachable.

## Root cause
`cli_v1_run_and_poll` polls `GET /v1/runs/{id}` every 500ms until the async run reaches a terminal status. It **returned NULL on the first failed poll GET**. A single transient TLS/connection blip therefore aborted the entire run. The roundtable's poll budget is correct (900s, `cli_v1_routes.c:251`) and short runs rarely blip — but a ~15-min roundtable does ~1800 polls, so under remote-server load one blip kills it, surfacing as the misleading "could not reach" hint.

## Fix
Ride out a bounded run of **consecutive** poll failures (reset on any success) before giving up. The per-run `timeout_ms` budget and terminal-status handling are unchanged; this only changes the transient-failure path. Also benefits the other async /v1 runs (aggregate, kb.build, index.scan, eval.run, …).

## Verified
Rebuilt CLI compiles clean (`-Werror`); roundtable runs to completion via it (`[roundtable: 2 round(s), converged]`, rc=0). clang-format + aimee-home-check clean.

## Follow-up (separate)
The roundtable's provider panel is narrow (2 providers) because `.254`'s `ensemble.reference_models` is unset — a server-config tuning, not this bug.