### PR TITLE
feat(kb): kb_hybrid outcome wiring — close the LTR loop for live data (option B, B1)

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -50,8 +50,15 @@ realized in code and enforced in review; their standalone proposal documents are
 
 ## Pending
 
-The genuinely open work — nine proposals, none yet implemented.
+The genuinely open work — ten proposals (all but one not yet implemented).
 
+- [kb_hybrid outcome wiring](proposals/pending/kb-hybrid-outcome-wiring.md)
+  — closes the learning-to-rank loop on live data. B1 (the loop-closing plumbing:
+  a dedicated `ranker_outcome` kind, `ranker.emit_event` / `ranker.record_outcome`
+  KB-service endpoints mirroring the memory evidence pattern, and the fitter's
+  training view reading it) is implemented with zero `kb.c` hot-path change; B2 (a
+  production outcome source for code-search) is the remaining open work. Follow-up
+  to the done LTR fitter. **Calibrate / Evaluate-Optimize / Gate-Promote.**
 - [Agentic supervised SWE-bench](proposals/pending/agentic-supervised-swebench.md)
   — a true tool-using, iterating agentic SWE-bench harness so the "beats Reddit's
   −75.5% supervisor-token reduction at no wall-clock penalty" claim is

--- a/docs/proposals/pending/kb-hybrid-outcome-wiring.md
+++ b/docs/proposals/pending/kb-hybrid-outcome-wiring.md
@@ -1,0 +1,93 @@
+# Proposal: kb_hybrid outcome wiring — close the learning-to-rank loop on live data
+
+- **State:** in progress — B1 (the loop-closing plumbing) is implemented and
+  integrated; B2 (a production outcome source for code-search) is the remaining
+  open work. This is the follow-up prerequisite named by the done proposal
+  [learning-to-rank weight fitting](../done/learning-to-rank-weight-fitting.md),
+  whose fitter ships bench-only until this lands.
+- **Author:** JBailes
+- **Date:** 2026-07-09
+- **Charter roles:** Calibrate (feed the fitter real observed outcomes, not just
+  fixtures), Evaluate-Optimize (the fitter's benchmark gate still decides
+  promotion), Gate-Promote (unchanged — a fitted model only lands on lift).
+
+## Thesis
+
+The learning-to-rank fitter (option A) infers, fits, benchmark-gates, and refits —
+but its §1 training-view join is empty on the shipped substrate, so it can only
+ever fit fixtures. The gap: the ranker's features are written on
+`feature_rows.subject_kind='kb_document'` (the kb_hybrid code-search surface,
+`src/kb/kb.c`), while the only outcome labels that exist are attributed to
+`memory` row ids on the memory-recall surface. Disjoint id spaces; no shared
+grouping key. The fitter cannot learn from live traffic until the kb_hybrid
+surface itself reports which surfaced documents were useful.
+
+## What was found (the design pivot)
+
+The memory surface does **not** capture outcomes inline in its recall hot path.
+A dedicated, caller-driven pair of endpoints does it: `evidence.emit_retrieval_event`
+mints a `retrieval_event` over the surfaced ids, and `memory.record_retrieval_outcome`
+records per-id verdicts as artifacts. That means the kb_hybrid loop can be closed
+the same way — **endpoint-driven, with zero `src/kb/kb.c` retrieval hot-path
+change** — rather than the schema-migration + hot-path rewrite the original
+option-B framing assumed. This is strictly safer and reversible.
+
+## B1 — the loop-closing plumbing (implemented)
+
+- A dedicated `ranker_outcome` artifact kind for kb_hybrid outcomes
+  (`kb_ranker_outcome_write` in `src/kb/kb_ranker_fit.c`), keyed by kb_document
+  doc_id and tied to a `retrieval_event_id`. It is deliberately **not**
+  `retrieval_attribution`: keeping a separate kind means the memory demotion
+  scorer (which reads `retrieval_attribution`) is untouched, and a memory row id
+  that happens to equal a doc_id can never collide into the ranker's training view.
+- `kb_ranker_emit_event` mints a kb_hybrid `retrieval_event` capturing the
+  surfaced doc_ids (audit + the grouping key that ties a query's outcomes together).
+- Two caller-facing KB-service methods mirroring the memory evidence pair:
+  `ranker.emit_event` and `ranker.record_outcome`
+  (`src/kb/kb_service_agent.c`, dispatched from `src/kb/kb_service.c`).
+- The fitter's training view (`kb_ranker_training_view`) now reads `ranker_outcome`
+  instead of `retrieval_attribution` — which both enables this loop and removes the
+  latent id-collision described above. Nothing else about the fitter changes: the
+  same benchmark gate and refusal rails apply.
+
+The result: once outcomes are reported for candidates that have feature rows, the
+existing fitter fits, benchmark-gates, and (on lift) promotes — on live data.
+Verified end-to-end by `test_closed_loop_capture` in `src/tests/test_ranker_fit.c`
+(emit event → record outcomes → training view groups by event and joins feature
+rows → non-empty, correctly-labelled batch).
+
+## B2 — a production outcome source (open work)
+
+B1 makes the loop *closeable and testable*; it does not invent a signal. The
+remaining question is genuinely separate: **what reports which code-search
+documents were useful?** The memory surface has an established reporter (the agent
+attributes recalled memories). Code-search has no equivalent yet. Candidate
+sources, in rough order of fidelity:
+
+1. Answer-attribution: when a turn cites/uses a surfaced doc in its answer, emit an
+   `accepted` outcome for that doc against the query's event.
+2. Explicit harness feedback (benchmark / eval harness reporting relevance).
+3. Weak implicit signals (a later edit touching a surfaced file) — lowest fidelity,
+   position-biased.
+
+This is deferred, not faked: until a real source populates `ranker_outcome`, the
+fitter correctly stays bench-only and `aimee kb ranker export-view` keeps reporting
+the empty-view diagnostic.
+
+## Non-goals
+
+- No change to `src/kb/kb.c` retrieval scoring or ordering.
+- No schema migration (outcomes are artifacts, like every other evidence row).
+- No new inference behaviour — the fitter and its gate are unchanged.
+
+## Tests
+
+- `test_closed_loop_capture` — emit + record + training-view join over live-shaped data.
+- The existing fitter suite (`src/tests/test_ranker_fit.c`) now exercises the
+  `ranker_outcome` path throughout (refusals, gate commit/hold, round-trip).
+
+## Provenance
+
+Follow-up to `docs/proposals/done/learning-to-rank-weight-fitting.md` (option A).
+Mirrors the memory evidence pattern in `src/kb/kb_service_memory.c` and
+`src/kb/kb_service_agent.c`.

--- a/src/kb/kb_ranker_fit.c
+++ b/src/kb/kb_ranker_fit.c
@@ -39,6 +39,81 @@ static const char *const FEATURE_KEYS[] = {
 };
 #define N_FEATURES ((int)(sizeof(FEATURE_KEYS) / sizeof(FEATURE_KEYS[0])))
 
+/* ---- Option B: kb_hybrid outcome capture --------------------------------- */
+
+/* Mint a kb_hybrid retrieval_event for one search and record the surfaced
+ * kb_document candidates in its payload (for audit + as the grouping key that
+ * ties a query's outcomes together). Returns the event id in id_out; 0 ok / -1. */
+int kb_ranker_emit_event(const int64_t *doc_ids, int n, const char *query_fingerprint, char *id_out,
+                         int id_out_len)
+{
+   char id[64];
+   db2_artifact_gen_id(id, sizeof(id));
+
+   cJSON *p = cJSON_CreateObject();
+   if (!p)
+      return -1;
+   cJSON_AddStringToObject(p, "surface", "kb_hybrid");
+   cJSON_AddStringToObject(p, "query_fingerprint", query_fingerprint ? query_fingerprint : "");
+   cJSON *arr = cJSON_AddArrayToObject(p, "surfaced_doc_ids");
+   for (int i = 0; arr && doc_ids && i < n; i++)
+      cJSON_AddItemToArray(arr, cJSON_CreateNumber((double)doc_ids[i]));
+   char *payload = cJSON_PrintUnformatted(p);
+   cJSON_Delete(p);
+   if (!payload)
+      return -1;
+
+   int rc = db2_artifact_write(id, "retrieval_event", "proposed", "system", "", "", 1.0, payload);
+   free(payload);
+   if (rc != 0)
+      return -1;
+
+   /* Tag target_surface so kb_hybrid events are separable from memory-recall
+    * retrieval_events in audit/trace queries. */
+   void *conn = db2_conn();
+   if (conn)
+   {
+      char err[256] = "";
+      aimee_pg_stmt_t *st =
+          aimee_pg_prepare(conn, "UPDATE artifacts SET target_surface = 'kb_hybrid' WHERE id = ?1",
+                           err, sizeof(err));
+      if (st)
+      {
+         aimee_pg_bind_text(st, "?1", id);
+         aimee_pg_step(st, err, sizeof(err));
+         aimee_pg_finalize(st);
+      }
+   }
+
+   if (id_out && id_out_len > 0)
+      snprintf(id_out, (size_t)id_out_len, "%s", id);
+   return 0;
+}
+
+/* Record one outcome verdict for a surfaced kb_document candidate as a dedicated
+ * `ranker_outcome` artifact (NOT retrieval_attribution — that kind is the memory
+ * demotion surface). This is the label source the training view consumes. */
+int kb_ranker_outcome_write(const char *event_id, int64_t doc_id, const char *verdict,
+                            double weight)
+{
+   if (!event_id || !event_id[0] || !verdict || !verdict[0])
+      return -1;
+
+   char id[64];
+   db2_artifact_gen_id(id, sizeof(id));
+   char scope_id[32];
+   snprintf(scope_id, sizeof(scope_id), "%lld", (long long)doc_id);
+
+   char payload[512];
+   snprintf(payload, sizeof(payload),
+            "{\"retrieval_event_id\":\"%s\",\"surfaced_row_id\":%lld,\"verdict\":\"%s\","
+            "\"weight\":%.6f,\"subject_kind\":\"kb_document\"}",
+            event_id, (long long)doc_id, verdict, weight);
+
+   return db2_artifact_write(id, "ranker_outcome", "proposed", "kb_hybrid", scope_id, "", 1.0,
+                             payload);
+}
+
 /* ---- Phase 1: the training view ------------------------------------------ */
 
 int kb_ranker_training_view(const char *subject_kind, const char *feature_set_version,
@@ -63,17 +138,22 @@ int kb_ranker_training_view(const char *subject_kind, const char *feature_set_ve
    if (!conn)
       return -1;
 
-   /* Enumerate the retrieval_attribution outcome artifacts, then join each to its
-    * candidate's feature vector in C via db2_feature_row_read. Assembling the join
-    * in C (rather than a postgres ->>'x' JOIN) keeps it portable across the
-    * postgres runtime and the sqlite test shim — the same idiom demotion.c and
+   /* Enumerate the ranker_outcome artifacts, then join each to its candidate's
+    * feature vector in C via db2_feature_row_read. Assembling the join in C
+    * (rather than a postgres ->>'x' JOIN) keeps it portable across the postgres
+    * runtime and the sqlite test shim — the same idiom demotion.c and
     * kb_calibrate.c use for artifact payloads. The label is derived from the
     * verdict. One emitted row per (retrieval_event, candidate) that has BOTH a
-    * v1 feature vector and an outcome verdict. */
+    * v1 feature vector and an outcome verdict.
+    *
+    * ranker_outcome is a surface-dedicated kind (kb_hybrid / kb_document ids),
+    * distinct from the memory surface's retrieval_attribution — so this join
+    * never collides with a memory row id that happens to equal a doc_id, and the
+    * memory demotion scorer (which reads retrieval_attribution) is untouched. */
    char err[256] = "";
    aimee_pg_stmt_t *st =
        aimee_pg_prepare(conn,
-                        "SELECT payload FROM artifacts WHERE kind = 'retrieval_attribution'"
+                        "SELECT payload FROM artifacts WHERE kind = 'ranker_outcome'"
                         " ORDER BY created_at",
                         err, sizeof(err));
    if (!st)

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -992,6 +992,8 @@ static const struct
     {"maintenance.calibrate_promotions", kb_handle_maintenance_calibrate_promotions},
     {"maintenance.compute_demotions", kb_handle_maintenance_compute_demotions},
     {"memory.record_retrieval_outcome", kb_handle_memory_record_retrieval_outcome},
+    {"ranker.emit_event", kb_handle_ranker_emit_event},
+    {"ranker.record_outcome", kb_handle_ranker_record_outcome},
     {"maintenance.memory_learn_style", kb_handle_memory_learn_style},
     {"decision_log.insert", kb_handle_decision_log_insert},
     {"decision_log.list", kb_handle_decision_log_list},

--- a/src/kb/kb_service_agent.c
+++ b/src/kb/kb_service_agent.c
@@ -11,6 +11,7 @@
 #include "db2/kb_service_backend.h"
 #include "kb_calibrate.h"
 #include "kb_demote.h"
+#include "kb_ranker_fit.h"
 #include "kb_service_agent.h"
 #include "learning_evidence.h"
 
@@ -491,6 +492,95 @@ int kb_handle_memory_record_retrieval_outcome(int fd, cJSON *req)
          double w = cJSON_IsNumber(wj) ? wj->valuedouble : 1.0;
          if (learning_evidence_write_retrieval_attribution(ev_id, (int64_t)rid_j->valuedouble,
                                                            vj->valuestring, w) == 0)
+            written++;
+      }
+   }
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddNumberToObject(resp, "written", written);
+   int srv_rc = kb_send_response(fd, resp);
+   cJSON_Delete(resp);
+   return srv_rc;
+}
+
+/* ranker.emit_event {doc_ids:[...], query_fingerprint?} -> {retrieval_event_id}.
+ * Option B: the kb_hybrid analogue of evidence.emit_retrieval_event — mints an
+ * event over the surfaced kb_document candidates so a caller can attribute
+ * outcomes to it. Endpoint-driven (no kb.c hot-path change). */
+int kb_handle_ranker_emit_event(int fd, cJSON *req)
+{
+   cJSON *ids_j = cJSON_GetObjectItemCaseSensitive(req, "doc_ids");
+   cJSON *fp_j = cJSON_GetObjectItemCaseSensitive(req, "query_fingerprint");
+   const char *fp = cJSON_IsString(fp_j) ? fp_j->valuestring : "";
+
+   int n = cJSON_IsArray(ids_j) ? cJSON_GetArraySize(ids_j) : 0;
+   int64_t *ids = NULL;
+   int n_ids = 0;
+   if (n > 0)
+   {
+      ids = (int64_t *)calloc((size_t)n, sizeof(int64_t));
+      if (!ids)
+         return kb_send_error(fd, "out of memory");
+      for (int i = 0; i < n; i++)
+      {
+         cJSON *e = cJSON_GetArrayItem(ids_j, i);
+         if (cJSON_IsNumber(e) && e->valuedouble > 0)
+            ids[n_ids++] = (int64_t)e->valuedouble;
+      }
+   }
+
+   char ev_id[64] = "";
+   int rc = kb_ranker_emit_event(ids, n_ids, fp, ev_id, sizeof(ev_id));
+   free(ids);
+   if (rc != 0)
+      return kb_send_error(fd, "failed to write retrieval_event");
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "retrieval_event_id", ev_id);
+   int srv_rc = kb_send_response(fd, resp);
+   cJSON_Delete(resp);
+   return srv_rc;
+}
+
+/* ranker.record_outcome {retrieval_event_id, rows:[{id,verdict,weight}]}
+ * (or single {retrieval_event_id, surfaced_row_id, verdict, weight}).
+ * Writes ranker_outcome artifacts the fitter's training view consumes. */
+int kb_handle_ranker_record_outcome(int fd, cJSON *req)
+{
+   cJSON *ev_j = cJSON_GetObjectItemCaseSensitive(req, "retrieval_event_id");
+   cJSON *rows_j = cJSON_GetObjectItemCaseSensitive(req, "rows");
+   if (!cJSON_IsString(ev_j) || !ev_j->valuestring[0])
+      return kb_send_error(fd, "ranker.record_outcome: retrieval_event_id required");
+
+   const char *ev_id = ev_j->valuestring;
+   int written = 0;
+
+   if (cJSON_IsArray(rows_j))
+   {
+      cJSON *row;
+      cJSON_ArrayForEach(row, rows_j)
+      {
+         cJSON *id_j = cJSON_GetObjectItemCaseSensitive(row, "id");
+         cJSON *vj = cJSON_GetObjectItemCaseSensitive(row, "verdict");
+         cJSON *wj = cJSON_GetObjectItemCaseSensitive(row, "weight");
+         if (!cJSON_IsNumber(id_j) || !cJSON_IsString(vj))
+            continue;
+         double w = cJSON_IsNumber(wj) ? wj->valuedouble : 1.0;
+         if (kb_ranker_outcome_write(ev_id, (int64_t)id_j->valuedouble, vj->valuestring, w) == 0)
+            written++;
+      }
+   }
+   else
+   {
+      cJSON *rid_j = cJSON_GetObjectItemCaseSensitive(req, "surfaced_row_id");
+      cJSON *vj = cJSON_GetObjectItemCaseSensitive(req, "verdict");
+      cJSON *wj = cJSON_GetObjectItemCaseSensitive(req, "weight");
+      if (cJSON_IsNumber(rid_j) && cJSON_IsString(vj))
+      {
+         double w = cJSON_IsNumber(wj) ? wj->valuedouble : 1.0;
+         if (kb_ranker_outcome_write(ev_id, (int64_t)rid_j->valuedouble, vj->valuestring, w) == 0)
             written++;
       }
    }

--- a/src/kb_ranker_fit.h
+++ b/src/kb_ranker_fit.h
@@ -12,6 +12,25 @@ extern "C"
 {
 #endif
 
+   /* Option B — kb_hybrid outcome capture (the loop-closing plumbing).
+    * These let the surface that produced kb_document feature rows also report
+    * which candidates were useful, keyed to a shared retrieval_event, WITHOUT
+    * touching the kb.c retrieval hot path (endpoint-driven, mirroring the memory
+    * surface's evidence pattern). The training view then joins these outcomes to
+    * the already-written feature_rows. See
+    * docs/proposals/pending/kb-hybrid-outcome-wiring.md. */
+
+   /* Mint a kb_hybrid retrieval_event capturing the surfaced kb_document doc_ids.
+    * id_out receives the event id (>= 37 bytes; may be NULL). 0 ok / -1 error. */
+   int kb_ranker_emit_event(const int64_t *doc_ids, int n, const char *query_fingerprint,
+                            char *id_out, int id_out_len);
+
+   /* Record one outcome verdict for a surfaced doc_id, tied to event_id, as a
+    * `ranker_outcome` artifact. verdict per db2/demotion.h (accepted = positive).
+    * 0 on success, -1 on error. */
+   int kb_ranker_outcome_write(const char *event_id, int64_t doc_id, const char *verdict,
+                               double weight);
+
    /* §1 training view: join the retrieval_attribution outcome labels to the
     * feature_rows vector for each attributed candidate, grouped by
     * retrieval_event_id. Emits one row per (retrieval_event, candidate) that has

--- a/src/kb_service_agent.h
+++ b/src/kb_service_agent.h
@@ -49,6 +49,8 @@ int kb_handle_dashboard_recall(int fd, cJSON *req);
 int kb_handle_dashboard_directives(int fd, cJSON *req);
 int kb_handle_maintenance_calibrate_promotions(int fd, cJSON *req);
 int kb_handle_memory_record_retrieval_outcome(int fd, cJSON *req);
+int kb_handle_ranker_emit_event(int fd, cJSON *req);
+int kb_handle_ranker_record_outcome(int fd, cJSON *req);
 int kb_handle_maintenance_compute_demotions(int fd, cJSON *req);
 
 #endif /* DEC_KB_SERVICE_AGENT_H */

--- a/src/tests/test_ranker_fit.c
+++ b/src/tests/test_ranker_fit.c
@@ -49,15 +49,9 @@ static void close_db(void)
 
 static void insert_attr(const char *event_id, long long surfaced, const char *verdict)
 {
-   char id[64];
-   db2_artifact_gen_id(id, sizeof(id));
-   char payload[512];
-   snprintf(payload, sizeof(payload),
-            "{\"retrieval_event_id\":\"%s\",\"surfaced_row_id\":%lld,\"verdict\":\"%s\","
-            "\"weight\":1.0}",
-            event_id, surfaced, verdict);
-   int rc =
-       db2_artifact_write(id, "retrieval_attribution", "proposed", "memory", "", "", 1.0, payload);
+   /* Option B: outcomes for the ranker surface are dedicated `ranker_outcome`
+    * artifacts (kb_document ids), written via the capture primitive. */
+   int rc = kb_ranker_outcome_write(event_id, (int64_t)surfaced, verdict, 1.0);
    assert(rc == 0);
 }
 
@@ -161,6 +155,35 @@ static void test_training_view_join(void)
    cJSON_Delete(rows);
    close_db();
    printf("  training_view_join: ok\n");
+}
+
+/* ---- 2b. option B: emit-event + record-outcome closes the loop end-to-end ---- */
+static void test_closed_loop_capture(void)
+{
+   open_db();
+   int64_t docs[2] = {100, 101};
+   insert_feat(100, 0.9, 0.8, 0.9);
+   insert_feat(101, 0.2, 0.1, 0.3);
+
+   /* Mint a kb_hybrid event for the "query", then attribute per-doc outcomes to
+    * it — exactly what an outcome-reporting caller does after a search. */
+   char ev[64] = "";
+   assert(kb_ranker_emit_event(docs, 2, "fp-query", ev, sizeof(ev)) == 0);
+   assert(ev[0] != '\0');
+   assert(kb_ranker_outcome_write(ev, 100, "accepted", 1.0) == 0);
+   assert(kb_ranker_outcome_write(ev, 101, "contradicted", 1.0) == 0);
+
+   cJSON *rows = NULL;
+   int ng = 0, nr = 0, np = 0;
+   assert(kb_ranker_training_view("kb_document", "v1", &rows, &ng, &nr, &np) == 0);
+   assert(nr == 2); /* both candidates joined to their feature rows */
+   assert(np == 1); /* one accepted */
+   assert(ng == 1); /* the emitted event groups both outcomes */
+   cJSON *r0 = cJSON_GetArrayItem(rows, 0);
+   assert(strcmp(sstr(r0, "group"), ev) == 0); /* grouped by the emitted event id */
+   cJSON_Delete(rows);
+   close_db();
+   printf("  closed_loop_capture: ok\n");
 }
 
 /* ---- 3. fit disabled ---- */
@@ -407,6 +430,7 @@ int main(void)
    printf("test_ranker_fit:\n");
    test_empty_view_diagnostic();
    test_training_view_join();
+   test_closed_loop_capture();
    test_fit_disabled();
    test_fit_below_floor();
    test_gate_commit_on_lift();


### PR DESCRIPTION
Follow-up to the learning-to-rank fitter (**option A**, #1178), which shipped bench-only because its §1 training-view join is empty on the live substrate. This is **option B**, part B1.

## Design pivot (lower risk than the original framing)
The original option-B framing assumed a schema migration + retrieval hot-path rewrite. Reading the memory surface showed outcomes are captured by **caller-driven endpoints** (`evidence.emit_retrieval_event` + `memory.record_retrieval_outcome`), **not** the recall hot path. So B closes the loop the same way — with **zero `src/kb/kb.c` change**, fully reversible.

## B1 — the loop-closing plumbing (this PR)
- Dedicated **`ranker_outcome`** artifact kind for kb_hybrid outcomes (`kb_ranker_outcome_write`), keyed by kb_document doc_id + a `retrieval_event_id`. Deliberately **not** `retrieval_attribution`: the memory demotion scorer (which reads that kind) is untouched, and a memory row id that equals a doc_id can never collide into the ranker's training view.
- `kb_ranker_emit_event` mints a kb_hybrid `retrieval_event` over the surfaced docs (audit + grouping key).
- Two KB-service methods mirroring the memory evidence pair: **`ranker.emit_event`** / **`ranker.record_outcome`** (`kb_service_agent.c`, dispatched from `kb_service.c`).
- The fitter's training view now reads `ranker_outcome` — which enables this loop **and** removes a latent id-collision in A's view. The benchmark gate + refusal rails are unchanged.

Once outcomes are reported for candidates that have feature rows, the existing fitter fits, benchmark-gates, and (on lift) promotes — on live data.

## B2 — remaining open work
A production **outcome source** for code-search (e.g. answer-attribution: a turn citing a surfaced doc emits an `accepted` outcome). Documented in `docs/proposals/pending/kb-hybrid-outcome-wiring.md`. Until a real source populates `ranker_outcome`, the fitter correctly stays bench-only and `export-view` keeps reporting the empty-view diagnostic — deferred, not faked.

## Tests
`test_closed_loop_capture` (emit → record → training-view groups by event + joins feature rows) + the full existing fitter suite now exercising the `ranker_outcome` path. Full unit-test suite + `make lint` (format / proposal / conformance / dispatch-coverage) green.