### PR TITLE
feat(kb): emit session_summary at fold + default-on reflection & calibration-shadow

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -765,7 +765,9 @@ static void config_set_defaults(config_t *cfg)
    cfg->kb_mining_enabled = 1;
    cfg->kb_mining_min_poll_s = 300;
    cfg->kb_mining_failure_learning_enabled = 0;
-   cfg->review_scheduler_enabled = 0;
+   cfg->review_scheduler_enabled = 1; /* default on: idle reflection over session_summary
+                                       * artifacts. Cheap when idle; the LLM synthesis pass only
+                                       * runs where a Tier-B provider/command is configured. */
    cfg->review_idle_trigger_minutes = 30;
    cfg->review_session_cooldown_hours = 24;
    cfg->concurrency_preempt_single_slot_only = 1;

--- a/src/config_learning.c
+++ b/src/config_learning.c
@@ -162,8 +162,10 @@ void config_apply_learning_settings(config_t *cfg, cJSON *root)
 
 void config_apply_calibration_settings(config_t *cfg, cJSON *root)
 {
-   /* Default values */
-   cfg->calibration_enabled = 0;
+   /* Default values. calibration_enabled defaults to 1 (shadow): write
+    * calibration profiles from outcomes but never enforce them — observe-only,
+    * no behaviour change. 0 = off, 2 = A/B/enforce (opt-in). */
+   cfg->calibration_enabled = 1;
    cfg->calibration_command[0] = '\0';
    cfg->calibration_buckets = 10;
    cfg->calibration_prior_alpha0 = 2.0;
@@ -514,12 +516,14 @@ void config_save_intelligence(const config_t *cfg, cJSON *root)
 {
    if (!cfg || !root)
       return;
+   /* calibration_enabled defaults to 1 (shadow); emit when it differs from the
+    * default so the off (0) and A/B (2) states survive a save round-trip. */
    int cal_any =
-       cfg->calibration_enabled || cfg->calibration_command[0] || cfg->calibration_buckets != 10 ||
-       cfg->calibration_prior_alpha0 != 2.0 || cfg->calibration_prior_beta0 != 1.0 ||
-       cfg->calibration_credible_delta != 0.10 || cfg->calibration_conformal_window != 500 ||
-       cfg->calibration_conformal_epsilon != 0.05 || cfg->calibration_tau_memory_auto != 0.70 ||
-       cfg->calibration_tau_memory_flag != 0.55 ||
+       cfg->calibration_enabled != 1 || cfg->calibration_command[0] ||
+       cfg->calibration_buckets != 10 || cfg->calibration_prior_alpha0 != 2.0 ||
+       cfg->calibration_prior_beta0 != 1.0 || cfg->calibration_credible_delta != 0.10 ||
+       cfg->calibration_conformal_window != 500 || cfg->calibration_conformal_epsilon != 0.05 ||
+       cfg->calibration_tau_memory_auto != 0.70 || cfg->calibration_tau_memory_flag != 0.55 ||
        cfg->calibration_tau_working_profile_auto != 0.80 ||
        cfg->calibration_tau_working_profile_flag != 0.65;
    /* demotion_enabled defaults to 1 (shadow); emit when it differs from the

--- a/src/db2/kb_service_backend_agent.c
+++ b/src/db2/kb_service_backend_agent.c
@@ -18,6 +18,7 @@
 #include "decision_log.h"
 #include "entity_edges.h"
 #include "learning.h"
+#include "learning_evidence.h" /* learning_evidence_write_event — session_summary emission */
 #include "learning_implicit.h"
 #include "memory.h"
 #include "feedback.h"
@@ -693,7 +694,19 @@ cJSON *db2_kb_service_memory_fold_session_json(const char *session_id)
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
       return NULL;
-   int rc = memory_fold_session(session_id ? session_id : "");
+   char summary[256] = "";
+   int rc = memory_fold_session(session_id ? session_id : "", summary, sizeof(summary));
+
+   /* Surface the folded session digest as a `session_summary` evidence artifact
+    * so the idle-reflection scheduler and the evidence-synth drain have a real
+    * candidate stream to work over — this is the producer that was otherwise
+    * missing. Cheap (one artifact write from the digest already computed, no LLM
+    * on this path), idempotent via content-hash dedup, and emitted unconditionally
+    * like other evidence capture; the LLM-heavy consumers are separately gated. */
+   if (rc >= 0 && summary[0])
+      learning_evidence_write_event("session_summary", "session", session_id ? session_id : "",
+                                    summary, "kb.fold_session", NULL, 0);
+
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddNumberToObject(resp, "count", rc < 0 ? 0 : rc);
    return resp;

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -528,8 +528,10 @@ int memory_get_provenance(int64_t memory_id, provenance_entry_t *out, int max);
 void add_provenance(int64_t memory_id, const char *session_id, const char *action,
                     const char *details);
 
-/* Session folding: compress L0 into L1 checkpoint. */
-int memory_fold_session(const char *session_id);
+/* Session folding: compress L0 into L1 checkpoint. When summary_out is non-NULL,
+ * it is filled with the session digest (the checkpoint text) so the caller can
+ * surface it as a session_summary evidence artifact; pass NULL to skip. */
+int memory_fold_session(const char *session_id, char *summary_out, size_t summary_out_len);
 
 /* --- Search --- */
 int memory_search(char **clusters, int cluster_count, int limit, search_result_t *out, int max);

--- a/src/memory_conflict.c
+++ b/src/memory_conflict.c
@@ -46,8 +46,10 @@ static time_t memory_conflict_parse_utc_timestamp(const char *s)
 
 /* --- Session Folding --- */
 
-int memory_fold_session(const char *session_id)
+int memory_fold_session(const char *session_id, char *summary_out, size_t summary_out_len)
 {
+   if (summary_out && summary_out_len > 0)
+      summary_out[0] = '\0';
    if (!session_id)
       return -1;
 
@@ -86,6 +88,13 @@ int memory_fold_session(const char *session_id)
       return 0;
 
    checkpoint[pos] = '\0';
+
+   /* Hand the session digest back to the caller so the KB layer can surface it as
+    * a `session_summary` evidence artifact (the producer the reflection scheduler
+    * was missing). Kept out of this core-memory file so it doesn't pull the
+    * learning layer into every memory-folding consumer. */
+   if (summary_out && summary_out_len > 0)
+      snprintf(summary_out, summary_out_len, "%s", checkpoint);
 
    /* INSERT as L1 episode */
    char ep_key[256];

--- a/src/tests/test_calibration.c
+++ b/src/tests/test_calibration.c
@@ -245,7 +245,7 @@ static void test_config_defaults(void)
    memset(&cfg, 0, sizeof(cfg));
    config_apply_calibration_settings(&cfg, NULL);
 
-   assert(cfg.calibration_enabled == 0);
+   assert(cfg.calibration_enabled == 1); /* default: shadow (observe-only) */
    assert(cfg.calibration_buckets == 10);
    assert(fabs(cfg.calibration_prior_alpha0 - 2.0) < 1e-9);
    assert(fabs(cfg.calibration_prior_beta0 - 1.0) < 1e-9);

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -265,8 +265,13 @@ static void test_fold_session(void)
    memory_insert(TIER_L0, KIND_SCRATCH, "task1", "content 1", 0.5, "fold-sess", &m);
    memory_insert(TIER_L0, KIND_SCRATCH, "task2", "content 2", 0.5, "fold-sess", &m);
 
-   int rc = memory_fold_session("fold-sess");
+   char fold_summary[256] = "";
+   int rc = memory_fold_session("fold-sess", fold_summary, sizeof(fold_summary));
    assert(rc == 0);
+   /* The caller-facing digest is populated so the KB layer can emit it as a
+    * session_summary evidence artifact (the reflection input producer). */
+   assert(fold_summary[0] != '\0');
+   assert(strstr(fold_summary, "content 1") != NULL);
 
    /* L0 should be gone */
    memory_t l0[10];


### PR DESCRIPTION
Unblocks the reflection→promotion candidate stream (criterion 4 of `llm-sidecar-productionization`). Diagnosis (via live `.254` inspection): the evidence pipeline had **no producer** — `learning_evidence_write_event` (which admits `session_summary`) was never called outside tests, so `0 session_summary → 0 session_synthesis → nothing for calibration/bandit to rank`. On top of that, the consumers ship default-off.

## The producer (the real blocker)
`memory_fold_session` — which runs at session-end (`prune_stale_sessions` → `maintenance.fold_session`) — already builds a session digest and folds L0→L1. It now returns that digest via an out-param, and the KB backend (`db2_kb_service_memory_fold_session_json`) emits it as a **`session_summary`** evidence artifact. This feeds **both** the idle-reflection scheduler and the evidence-synth drain. Emitted at the KB layer (not core `memory_conflict.c`) so the learning dependency stays out of every memory-folding consumer — `module-boundary-check` passes.

## Safe defaults flipped on
- `review_scheduler_enabled` **0 → 1** — idle reflection; cheap when idle, and the LLM synthesis pass only runs where a Tier-B provider/command is configured.
- `calibration_enabled` **0 → 1 (shadow)** — writes calibration profiles from outcomes but never enforces (no behaviour change). Save-guard updated to `!= 1` so `off (0)` and `A/B (2)` survive a round-trip.

## Left opt-in (behaviour-changing)
`bandit_live_decision_enabled` (acts on arms), calibration **enforce**, and the shadow→active `reflection_synthesis_mode` promotion.

## Tests
`test_fold_session` asserts the digest is returned; calibration default assertion updated. Full build (`-Werror`), full `unit-tests`, and `module-boundary`/`schema-sync`/`docs-gen`/clang-format lints all green.

## Validation
Code-level covered (digest output tested; the evidence-write path is already tested). The **live "stream fills" proof is deploy-gated** — `.254` runs an older build, so observing `session_summary → reflection → session_synthesis` end-to-end needs this deployed there.