### PR TITLE
feat(kb): pairwise ranker-fit objective + IPW weight plumbing

### DIFF
--- a/docs/proposals/pending/kb-hybrid-outcome-wiring.md
+++ b/docs/proposals/pending/kb-hybrid-outcome-wiring.md
@@ -84,20 +84,38 @@ non-correction follow-up** — i.e. "the user kept talking and didn't immediatel
 correct me," a loose proxy for "the rows were useful." So the label skews heavily
 positive (the exact position/outcome bias the LTR proposal's Risks section names).
 It is a legitimate *first* source — it turns a dead loop into a live trickle of
-real weak labels — but the pointwise fitter inherits the bias, and the benchmark
-gate remains the backstop. Higher-fidelity sources are the real goal.
+real weak labels — but the fitter must not over-trust it, and the benchmark gate
+remains the backstop. Higher-fidelity sources are the real goal.
 
-### Remaining open work
+### Fitter side, landed: pairwise objective + IPW weight
 
-1. **Ranker (`kb_search`) capture hook.** Note `ranker` outcomes when the agent
-   uses `kb_search` in a turn. Subtlety to handle first: `kb.search` is also
-   callable from the CLI/API *outside* a conversational turn, where no next-turn
-   autolabel follows — the note must be scoped to in-turn tool use to avoid
-   mis-attribution, and `kb_search`'s response must expose `doc_id`.
-2. **Answer-attribution** — a turn citing a surfaced doc → a stronger `accepted`
-   signal than the continuation heuristic (uses the `artifact_citations` /
-   `lessons_cite_tracker` machinery).
-3. **Explicit harness/eval feedback** — highest fidelity, for benchmark runs.
+The fitter (`scripts/rank-fit.py`) now supports a **pairwise (RankNet) objective**
+(`intelligence.ranking.fit.objective = pairwise`) alongside pointwise. This matters
+directly for the weak-label problem: pairwise optimises *within-query ordering*, so
+a feature that is **constant across a query's candidates earns ~0 weight** — which
+is exactly why a turn-level, all-`accepted` label carries no learnable signal, and
+why the *per-document contrast* below is the thing that unlocks it. The
+per-candidate `weight` field now flows through to the fitter, so an **IPW /
+propensity or confidence weight** on an outcome is honoured unchanged.
+
+### Remaining open work — the real fidelity lever
+
+1. **Per-document answer↔doc overlap attribution.** The turn verdict is applied to
+   *all* surfaced rows identically, giving a ranker no within-query contrast (and
+   the existing "citation" machinery is circular — `memory_collect_answer_citation_ids`
+   returns the top-ranked match's cluster, computed at *retrieval* time, so it just
+   reinforces the current order). The non-circular fix: at attribution time, the
+   prior turn's assistant answer is already in the message history — score each
+   surfaced doc's snippet against it and emit **per-doc** `accepted` (used) vs
+   `contradicted` (surfaced-but-unused). This is what turns a flat verdict into the
+   contrastive labels the pairwise objective needs.
+2. **Ranker (`kb_search`) capture hook.** Note `ranker` outcomes when the agent uses
+   `kb_search` in a turn (scoped to in-turn tool use — `kb.search` is also CLI/API
+   callable outside a turn; `kb_search`'s response must expose `doc_id`).
+3. **IPW propensity logging.** Log the surfacing propensity (reuse the bandit's
+   `db2_bandit_decision_insert` pattern) and populate the outcome `weight` with
+   `1/propensity`; the fitter already consumes it.
+4. **Explicit harness/eval feedback** — highest fidelity, for benchmark runs.
 
 ## Non-goals
 

--- a/scripts/rank-fit.py
+++ b/scripts/rank-fit.py
@@ -143,6 +143,46 @@ def _fit_pure(X, y):
     return w, loss, it
 
 
+def _fit_pairwise(groups):
+    """RankNet-style pairwise logistic on within-query (positive > negative)
+    pairs. Optimises ORDERING rather than absolute labels, so:
+      * features that are constant within a query get ~0 weight (they can't
+        discriminate) — which is exactly why turn-level all-`accepted` labels
+        carry no pointwise signal but the per-doc contrast here does;
+      * it is robust to the heavily positive-skewed live label distribution.
+    Each pair's weight is the product of the two rows' weights, so an IPW /
+    propensity weight on the outcomes flows straight through. Returns
+    (w, n_pairs, usable_groups), or None when no query has both classes.
+    `groups`: dict group -> list of (feature_vec, label01, weight)."""
+    pairs = []  # (x_pos, x_neg, weight)
+    usable = 0
+    for items in groups.values():
+        pos = [it for it in items if it[1] == 1]
+        neg = [it for it in items if it[1] == 0]
+        if pos and neg:
+            usable += 1
+        for p in pos:
+            for ng in neg:
+                pairs.append((p[0], ng[0], p[2] * ng[2]))
+    if not pairs:
+        return None
+
+    d = len(FEATURES)
+    w = [0.0] * d
+    npair = len(pairs)
+    for _ in range(MAX_ITERS):
+        grad = [L2 * w[j] for j in range(d)]
+        for xp, xn, wt in pairs:
+            diff = sum(w[j] * (xp[j] - xn[j]) for j in range(d))
+            # dL/d(diff) for log(1+exp(-diff)) is -sigmoid(-diff); stable form.
+            s = 1.0 / (1.0 + math.exp(diff)) if diff > -30.0 else 1.0
+            for j in range(d):
+                grad[j] += (-s * (xp[j] - xn[j]) * wt) / npair
+        for j in range(d):
+            w[j] -= LR * grad[j]
+    return w, npair, usable
+
+
 def fit(req):
     fsv = req.get("feature_set_version", "")
     if fsv != SUPPORTED_FEATURE_SET_VERSION:
@@ -150,10 +190,7 @@ def fit(req):
                        supported=SUPPORTED_FEATURE_SET_VERSION)
 
     objective = req.get("objective", "pointwise")
-    if objective != "pointwise":
-        # Pairwise/LambdaMART is a later objective behind the same field; this
-        # sidecar only fits pointwise today. Refuse rather than silently
-        # fitting the wrong objective.
+    if objective not in ("pointwise", "pairwise"):
         return _refuse("unsupported_objective", objective=objective)
 
     rows = req.get("rows", [])
@@ -161,30 +198,57 @@ def fit(req):
         return _refuse("bad_request", detail="rows must be a list")
 
     min_groups = int(req.get("min_groups", 8))
-    groups = set()
-    X = []
-    y = []
+
+    # Parse once into groups of (feature_vec, label, weight). `weight` carries an
+    # optional IPW/propensity or confidence weight (default 1.0).
+    groups = {}
     n_positive = 0
     for r in rows:
-        feats = r.get("features") or {}
+        g = str(r.get("group", ""))
         label = 1 if float(r.get("label", 0) or 0) > 0.5 else 0
-        groups.add(str(r.get("group", "")))
-        X.append(_feature_vector(feats))
-        y.append(label)
+        weight = float(r.get("weight", 1.0) or 1.0)
+        if weight <= 0.0:
+            weight = 1.0
+        groups.setdefault(g, []).append((_feature_vector(r.get("features") or {}), label, weight))
         n_positive += label
 
     n_groups = len(groups)
-    n_rows = len(X)
+    n_rows = sum(len(v) for v in groups.values())
 
     if n_groups < min_groups:
         return _refuse("below_floor", n_groups=n_groups, min_groups=min_groups,
                        n_rows=n_rows)
 
-    # Degenerate label distribution — a single class carries no ranking signal.
+    if objective == "pairwise":
+        res = _fit_pairwise(groups)
+        if res is None:
+            # No query has both a used and an unused candidate — no ordering to learn.
+            return _refuse("insufficient_pairs", n_groups=n_groups, n_rows=n_rows,
+                           n_positive=n_positive)
+        w, n_pairs, usable = res
+        weights = {FEATURES[j]: round(float(w[j]), 6) for j in range(len(FEATURES))}
+        return {
+            "status": "ok",
+            "weights": weights,
+            "fit_metrics": {
+                "objective": "pairwise",
+                "feature_set_version": fsv,
+                "n_groups": n_groups,
+                "n_rows": n_rows,
+                "n_positive": n_positive,
+                "n_pairs": n_pairs,
+                "usable_groups": usable,
+            },
+        }
+
+    # ---- pointwise ----
+    # Degenerate label distribution — a single class carries no pointwise signal.
     if n_positive == 0 or n_positive == n_rows:
         return _refuse("degenerate", n_positive=n_positive, n_rows=n_rows,
                        n_groups=n_groups)
 
+    X = [x for items in groups.values() for (x, _, _) in items]
+    y = [lab for items in groups.values() for (_, lab, _) in items]
     try:
         w, loss, iters = _fit_numpy(X, y)
     except Exception:

--- a/src/config_learning.c
+++ b/src/config_learning.c
@@ -292,6 +292,7 @@ void config_apply_ranking_settings(config_t *cfg, cJSON *root)
    cfg->kb_ranker_fit_min_groups = 0;
    cfg->kb_ranker_fit_benchmark[0] = '\0';
    cfg->kb_ranker_fit_bench_k = 0;
+   cfg->kb_ranker_fit_objective[0] = '\0';
 
    cJSON *intel = cJSON_GetObjectItemCaseSensitive(root, "intelligence");
    if (!cJSON_IsObject(intel))
@@ -357,6 +358,11 @@ void config_apply_ranking_settings(config_t *cfg, cJSON *root)
       item = cJSON_GetObjectItemCaseSensitive(fit, "bench_k");
       if (cJSON_IsNumber(item))
          cfg->kb_ranker_fit_bench_k = (int)item->valuedouble;
+
+      item = cJSON_GetObjectItemCaseSensitive(fit, "objective");
+      if (cJSON_IsString(item) && item->valuestring)
+         snprintf(cfg->kb_ranker_fit_objective, sizeof(cfg->kb_ranker_fit_objective), "%s",
+                  item->valuestring);
    }
 }
 

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1400,12 +1400,16 @@ typedef struct config
     *                          (0 → default 8) — the thin-log overfit guardrail.
     * kb_ranker_fit_benchmark: path to the recall-track fixture used as the
     *                          promotion gate (empty → benchmarks/rank/kb_hybrid/queries.json).
-    * kb_ranker_fit_bench_k:   NDCG cutoff for the gate (0 → default 5). */
+    * kb_ranker_fit_bench_k:   NDCG cutoff for the gate (0 → default 5).
+    * kb_ranker_fit_objective: "pointwise" (default) or "pairwise" — the fitter
+    *                          objective. Pairwise learns within-query ordering
+    *                          and is robust to positive-skewed labels. */
    int kb_ranker_fit_enabled;
    char kb_ranker_fit_command[512];
    int kb_ranker_fit_min_groups;
    char kb_ranker_fit_benchmark[512];
    int kb_ranker_fit_bench_k;
+   char kb_ranker_fit_objective[16];
 
    /* Graph reasoning (Datalog sidecar).
     * reasoning_datalog_command: path to Datalog evaluator; empty = disabled.

--- a/src/kb/kb_ranker_fit.c
+++ b/src/kb/kb_ranker_fit.c
@@ -591,10 +591,15 @@ int kb_ranker_fit_run(const config_t *cfg, char *id_out, int id_out_len, char **
    if (!cfg->kb_ranker_fit_command[0])
       return finish_refused(report, "no_fitter_command", report_out, rows);
 
-   /* Build the sidecar request: {feature_set_version, objective, min_groups, rows}. */
+   /* Build the sidecar request: {feature_set_version, objective, min_groups, rows}.
+    * Objective is operator-selectable (pointwise default | pairwise). The rows
+    * already carry per-candidate `weight`, so an IPW/confidence weight flows to
+    * the sidecar unchanged. */
+   const char *objective =
+       cfg->kb_ranker_fit_objective[0] ? cfg->kb_ranker_fit_objective : "pointwise";
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "feature_set_version", KB_FEATURE_SET_VERSION);
-   cJSON_AddStringToObject(req, "objective", "pointwise");
+   cJSON_AddStringToObject(req, "objective", objective);
    cJSON_AddNumberToObject(req, "min_groups", min_groups);
    /* Hand the rows to the sidecar (detach from `rows` so we can free it). */
    cJSON *req_rows = cJSON_Duplicate(rows, 1);

--- a/src/tests/test_ranker_fit.c
+++ b/src/tests/test_ranker_fit.c
@@ -425,6 +425,68 @@ static void test_sidecar_recovers_order(void)
    printf("  sidecar_recovers_order: ok\n");
 }
 
+/* ---- 9. the real sidecar fits the pairwise objective (within-query ordering) ---- */
+static void test_sidecar_pairwise(void)
+{
+   const char *cands[] = {"scripts/rank-fit.py", "../scripts/rank-fit.py",
+                          "../../scripts/rank-fit.py"};
+   const char *script = NULL;
+   for (size_t i = 0; i < sizeof(cands) / sizeof(cands[0]); i++)
+      if (access(cands[i], R_OK) == 0)
+      {
+         script = cands[i];
+         break;
+      }
+   if (!script || system("command -v python3 >/dev/null 2>&1") != 0)
+   {
+      printf("  sidecar_pairwise: skipped (python3/rank-fit.py unavailable)\n");
+      return;
+   }
+
+   /* Each query has a used (label 1) and an unused (label 0) candidate that
+    * differ only in dense/lex — so pairwise must recover positive dense/lex
+    * weight and ~0 on the constant recency feature. */
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "python3 %s > /tmp/rf_pairout.json", script);
+   FILE *p = popen(cmd, "w");
+   assert(p);
+   fputs("{\"feature_set_version\":\"v1\",\"objective\":\"pairwise\",\"min_groups\":4,\"rows\":[",
+         p);
+   for (int g = 0; g < 6; g++)
+   {
+      if (g)
+         fputs(",", p);
+      fprintf(p,
+              "{\"group\":\"q%d\",\"label\":1,\"weight\":1.0,\"features\":{\"dense.cos\":0.9,"
+              "\"lex.cos\":0.8,\"temp.recency\":0.5}},"
+              "{\"group\":\"q%d\",\"label\":0,\"weight\":1.0,\"features\":{\"dense.cos\":0.3,"
+              "\"lex.cos\":0.2,\"temp.recency\":0.5}}",
+              g, g);
+   }
+   fputs("]}", p);
+   assert(pclose(p) == 0);
+
+   FILE *rf = fopen("/tmp/rf_pairout.json", "rb");
+   assert(rf);
+   char buf[4096];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, rf);
+   buf[n] = '\0';
+   fclose(rf);
+   cJSON *o = cJSON_Parse(buf);
+   assert(o);
+   assert(strcmp(sstr(o, "status"), "ok") == 0);
+   cJSON *m = cJSON_GetObjectItemCaseSensitive(o, "fit_metrics");
+   assert(strcmp(sstr(m, "objective"), "pairwise") == 0);
+   assert(snum(m, "n_pairs") > 0.0);
+   cJSON *w = cJSON_GetObjectItemCaseSensitive(o, "weights");
+   assert(snum(w, "dense.cos") > 0.0);
+   assert(snum(w, "lex.cos") > 0.0);
+   /* Constant-within-query feature earns ~0 weight — the pairwise property. */
+   assert(snum(w, "temp.recency") < 0.5 && snum(w, "temp.recency") > -0.5);
+   cJSON_Delete(o);
+   printf("  sidecar_pairwise: ok\n");
+}
+
 int main(void)
 {
    printf("test_ranker_fit:\n");
@@ -437,6 +499,7 @@ int main(void)
    test_gate_hold_on_no_lift();
    test_sidecar_refusal();
    test_sidecar_recovers_order();
+   test_sidecar_pairwise();
    printf("test_ranker_fit: all passed\n");
    return 0;
 }


### PR DESCRIPTION
Makes the learning-to-rank fitter **stronger** — the objective the LTR proposal deferred to "phase 4", now with IPW-ready weighting.

## Why
The live outcome label (continuation/repair) is **turn-level and heavily positive-skewed**, so a pointwise fit over it learns little. Pairwise fixes the structural half: it optimises **within-query ordering**, so a feature that is *constant across a query's candidates earns ~0 weight*. That is exactly why per-document contrast is what unlocks a learnable signal — and why pairwise is the objective that can use it once the labels have contrast.

## What
- **`scripts/rank-fit.py`**: RankNet-style **pairwise** objective (positive>negative pairs within each group), selected by `objective="pairwise"`. Refuses `insufficient_pairs` when no query has both classes. Each pair's weight is the product of the two rows' weights, so an **IPW / propensity / confidence weight** on an outcome flows through unchanged. Pointwise preserved.
- **`kb_ranker_fit.c`**: objective is operator-selectable (`intelligence.ranking.fit.objective`, default `pointwise`); training-view rows already carry per-candidate `weight`, so it reaches the sidecar untouched.
- **config**: `kb_ranker_fit_objective`.

## Tests
`test_ranker_fit.c` gains `sidecar_pairwise` — the real `rank-fit.py` recovers the planted within-query ordering (`dense`/`lex` weights positive), **zeros the constant feature** (the pairwise property), and reports `n_pairs`. Full unit-test suite + `make lint` green.

## Honesty note that reshaped the roadmap
While scoping per-doc attribution I verified the existing "citation" machinery (`memory_collect_answer_citation_ids`) is **circular** — it returns the top-ranked match's cluster computed at *retrieval* time, not answer usage, so it would just reinforce the current order. The proposal now re-leads the remaining work with **per-document answer↔doc overlap attribution** (non-circular; the prior answer is already in the message history at the bridge call site) as the contrastive-label source this objective needs, followed by the `kb_search` capture hook, IPW propensity logging, and harness ground truth.