### PR TITLE
feat(roundtable): never seat the primary agent on its own panel

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -411,8 +411,8 @@ static int positional_change_0_100(const char *prev, const char *next)
 
 static int token_jaccard_change_0_100(const char *prev, const char *next)
 {
-   char (*a)[64] = calloc(512, sizeof(*a));
-   char (*b)[64] = calloc(512, sizeof(*b));
+   char(*a)[64] = calloc(512, sizeof(*a));
+   char(*b)[64] = calloc(512, sizeof(*b));
    if (!a || !b)
    {
       free(a);

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h> /* strcasecmp */
 #include <time.h>
 #include <ctype.h>
 
@@ -410,8 +411,8 @@ static int positional_change_0_100(const char *prev, const char *next)
 
 static int token_jaccard_change_0_100(const char *prev, const char *next)
 {
-   char(*a)[64] = calloc(512, sizeof(*a));
-   char(*b)[64] = calloc(512, sizeof(*b));
+   char (*a)[64] = calloc(512, sizeof(*a));
+   char (*b)[64] = calloc(512, sizeof(*b));
    if (!a || !b)
    {
       free(a);
@@ -1163,11 +1164,21 @@ static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const
  * has no server endpoint and would just burn a slot on a "failed to build request
  * URL" participant; server-hosting is capability, NOT authorization, so both are
  * required. So an unauthorized or disabled claude is never seated, even after a
- * server-side OAuth setup. Other enabled agents are eligible. */
+ * server-side OAuth setup. Other enabled agents are eligible.
+ *
+ * The PRIMARY agent is also never seated: a roundtable exists for an INDEPENDENT
+ * second opinion, so the model the operator runs as primary (config.provider)
+ * must not sit on — or aggregate — its own review panel and quietly grade its own
+ * work. Any agent that resolves to the primary provider (by agent name — the
+ * primary passthrough is named after the provider — or by its provider tag) is
+ * excluded, structurally, regardless of what ensemble.reference_models lists. */
 int ensemble_panelist_eligible(const config_t *cfg, const agent_t *ag)
 {
    if (!ag || !ag->enabled || !ag->name[0])
       return 0;
+   if (cfg->provider[0] && (strcasecmp(ag->name, cfg->provider) == 0 ||
+                            (ag->provider[0] && strcasecmp(ag->provider, cfg->provider) == 0)))
+      return 0; /* the primary must never sit on its own panel */
    if (agent_is_claude_cli(ag) && (!cfg->claude_cli_delegate_enabled || !ag->is_server_hosted))
       return 0;
    return 1;

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -975,6 +975,61 @@ static void test_panel_filter_drops_unauthorized_claude(void)
    printf("  test_panel_filter_drops_unauthorized_claude: ok\n");
 }
 
+static void test_panel_excludes_primary(void)
+{
+   /* The PRIMARY agent (config.provider) is never seated on — nor allowed to
+    * aggregate — its own review panel, even when it is an authorized,
+    * server-hosted claude that would otherwise pass the claude-CLI gate. Matched
+    * by agent name (the primary passthrough is named after the provider) or by
+    * the agent's provider tag. */
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   acfg.agent_count = 3;
+   acfg.agents[0].enabled = 1;
+   snprintf(acfg.agents[0].name, MAX_AGENT_NAME, "codex");
+   snprintf(acfg.agents[0].provider, sizeof(acfg.agents[0].provider), "openai");
+   acfg.agents[1].enabled = 1;
+   acfg.agents[1].is_server_hosted = 1; /* would otherwise be an authorized claude */
+   snprintf(acfg.agents[1].name, MAX_AGENT_NAME, "claude"); /* the primary passthrough */
+   acfg.agents[2].enabled = 1;
+   snprintf(acfg.agents[2].name, MAX_AGENT_NAME, "claude-api"); /* different name ... */
+   snprintf(acfg.agents[2].provider, sizeof(acfg.agents[2].provider),
+            "claude"); /* ... primary provider */
+
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.claude_cli_delegate_enabled = 1; /* claude would otherwise be authorized */
+   snprintf(cfg.provider, sizeof(cfg.provider), "claude"); /* PRIMARY = claude */
+
+   /* per-agent predicate */
+   assert(ensemble_panelist_eligible(&cfg, &acfg.agents[0]) == 1); /* codex/openai — seated */
+   assert(ensemble_panelist_eligible(&cfg, &acfg.agents[1]) == 0); /* claude by name — excluded */
+   assert(ensemble_panelist_eligible(&cfg, &acfg.agents[2]) ==
+          0); /* claude by provider — excluded */
+
+   /* explicit reference_models: both primary-provider seats dropped, aggregator repointed */
+   cfg.ensemble_reference_count = 3;
+   snprintf(cfg.ensemble_reference_models[0], 128, "codex");
+   snprintf(cfg.ensemble_reference_models[1], 128, "claude");
+   snprintf(cfg.ensemble_reference_models[2], 128, "claude-api");
+   snprintf(cfg.ensemble_aggregator, sizeof(cfg.ensemble_aggregator), "claude");
+   ensemble_filter_panel_authorization(&cfg, &acfg);
+   assert(cfg.ensemble_reference_count == 1);
+   assert(strcmp(cfg.ensemble_reference_models[0], "codex") == 0);
+   assert(strcmp(cfg.ensemble_aggregator, "codex") == 0); /* repointed off the primary */
+
+   /* seeding from enabled agents also never seats the primary */
+   config_t seed_cfg;
+   memset(&seed_cfg, 0, sizeof(seed_cfg));
+   seed_cfg.claude_cli_delegate_enabled = 1;
+   snprintf(seed_cfg.provider, sizeof(seed_cfg.provider), "claude");
+   ensemble_default_panel_from_agents(&seed_cfg, &acfg);
+   assert(seed_cfg.ensemble_reference_count == 1); /* only codex */
+   assert(strcmp(seed_cfg.ensemble_reference_models[0], "codex") == 0);
+
+   printf("  test_panel_excludes_primary: ok\n");
+}
+
 static void test_panel_filter_drops_unavailable(void)
 {
    /* A configured panelist that is enabled but NOT runtime-usable (a bearer HTTP
@@ -1419,6 +1474,7 @@ int main(void)
    test_roundtable_review_brief_and_items_return();
    test_default_panel_excludes_claude_cli();
    test_panel_filter_drops_unauthorized_claude();
+   test_panel_excludes_primary();
    test_panel_filter_drops_unavailable();
    test_panel_persona_name_assignment();
    test_roundtable_review_assigns_personas();


### PR DESCRIPTION
## What

A roundtable exists for an **independent** second opinion, so the model the operator runs as primary (`config.provider`) must never sit on — nor aggregate — its own review/ensemble panel and quietly grade its own work. Concretely: when the primary is `claude`, **`claude` can never be a roundtable seat**, regardless of what `ensemble.reference_models` lists.

## How

Enforced in the single eligibility predicate every panel path flows through — `ensemble_panelist_eligible()`. An agent that resolves to the primary provider (matched by **agent name** — the primary passthrough is named after the provider — or by its **provider tag**) is never eligible. That one change covers all consumers:
- default-panel **seeding** (`ensemble_default_panel_from_agents`),
- **explicit** `ensemble.reference_models` filtering (`ensemble_filter_panel_authorization`, which also **repoints the aggregator** off a now-ineligible primary),
- the sweep proposer panel.

So the exclusion is structural — it holds even if an operator explicitly lists the primary.

## Test

`test_panel_excludes_primary`: the primary is dropped by name **and** by provider tag from the per-agent predicate, the explicit list, and seeding; the aggregator is repointed to a non-primary seat — even for an otherwise-authorized, server-hosted `claude` (i.e. the primary-exclusion overrides the claude-CLI authorization gate).

## Verification
- `cd src && make -j all server` — green.
- `unit-test-delegate-ensemble` — all tests pass (incl. the new one).
- clang-format clean.

(A one-line pre-existing clang-format nit in the same file was auto-fixed.)