### PR TITLE
feat(roundtable): seed panelists with aimee memory + code graph; default to 1 round

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1018,7 +1018,7 @@ delegate for review. Full guide: [`docs/DELEGATES.md`](docs/DELEGATES.md).
 `ensemble.reference_models`, `ensemble.aggregator`, `ensemble.min_successful`,
 and `ensemble.max_cost_usd` (optional; unset or `0` means no cost cap, the
 default, set a positive value to cap a run). The panel and aggregator ship
-configured, so the roundtable runs with no setup. `roundtable.max_rounds` defaults to `3`,
+configured, so the roundtable runs with no setup. `roundtable.max_rounds` defaults to `1`,
 `roundtable.converge_threshold` to `10`, `roundtable.deadline_ms` to `600000`,
 and `roundtable.turns` to `parallel`. Draft mode returns a shared artifact;
 review mode returns a consolidated review, and `--apply` asks a final draft turn

--- a/src/config.c
+++ b/src/config.c
@@ -809,7 +809,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->db2_vector_corpus_diskann_threshold = 1000000;
    cfg->ensemble_min_successful = 2;
    cfg->ensemble_max_cost_usd = 0.0; /* 0 = no cost cap (unlimited) by default */
-   cfg->roundtable_max_rounds = 3;
+   cfg->roundtable_max_rounds = 1;
    cfg->roundtable_converge_threshold = 10;
    /* Saner default: 6 min (was 10). Long enough for a multi-round reasoning-model
     * ensemble, short enough that a wedged run fails fast instead of a 10-min

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -91,7 +91,7 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
    }
 
    /* roundtable.* (including the authoring-pipeline keys, roundtable.pipeline_*) */
-   if (cfg->roundtable_max_rounds != 3 || cfg->roundtable_converge_threshold != 10 ||
+   if (cfg->roundtable_max_rounds != 1 || cfg->roundtable_converge_threshold != 10 ||
        cfg->roundtable_deadline_ms != 600000 || strcmp(cfg->roundtable_turns, "parallel") != 0 ||
        strcmp(cfg->roundtable_pipeline_done_bar, "zero_blocking") != 0 ||
        cfg->roundtable_pipeline_max_passes != 0 ||

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -62,6 +62,11 @@ typedef struct
    int apply_review;
    const char *brief;
    int brief_truncated;
+   /* Optional pre-assembled read-only context (aimee memory recall + code-graph
+    * snippets) injected into every panelist prompt. Panelists run with no tools,
+    * so this is the only way they see aimee memory and the code graph. The caller
+    * owns the string for the duration of the run; NULL = no context injected. */
+   const char *context;
    const char **questions;
    int question_count;
    int (*cancel_requested)(void *ctx);

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -613,7 +613,8 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,
-                                roundtable_mode_t mode, int round, const char *brief)
+                                roundtable_mode_t mode, int round, const char *brief,
+                                const char *context)
 {
    const char *role_hint = mode == ROUNDTABLE_REVIEW ? "review and critique" : "draft and revise";
    const char *mode_task =
@@ -667,23 +668,46 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
       brief_block = owned_brief_block;
    }
 
+   /* Read-only aimee context (memory recall + code-graph snippets), assembled by
+    * the server-side caller. Panelists have no tools, so this block is the only
+    * way they see aimee memory and the code graph; it is authoritative reference,
+    * not something they can re-query. */
+   const char *context_block = "";
+   char *owned_context_block = NULL;
+   if (context && context[0])
+   {
+      owned_context_block =
+          xasprintf3("AIMEE CONTEXT (read-only reference — aimee memory + code graph):\n", context,
+                     "\nUse this context as grounding; it is authoritative reference you cannot "
+                     "re-query.\n\n");
+      if (!owned_context_block)
+      {
+         free(owned_brief_block);
+         return NULL;
+      }
+      context_block = owned_context_block;
+   }
+
    size_t needed = strlen(task ? task : "") + strlen(artifact) + strlen(peer_notes) +
-                   strlen(brief_block) + strlen(mode_task) + strlen(role_hint) + strlen(head_note) +
-                   512;
+                   strlen(brief_block) + strlen(context_block) + strlen(mode_task) +
+                   strlen(role_hint) + strlen(head_note) + 512;
    char *prompt = malloc(needed);
    if (!prompt)
    {
       free(owned_brief_block);
+      free(owned_context_block);
       return NULL;
    }
-   snprintf(prompt, needed,
-            "You are one participant in an agent roundtable. Your role is to %s.\n\n%s"
-            "TASK:\n%s\n\nCURRENT SHARED ARTIFACT:\n%s\n\nPEER NOTES FROM PREVIOUS TURN:\n%s\n\n%s"
-            "ROUND %d INSTRUCTION:\n%s\n",
-            role_hint, head_note, task ? task : "", artifact[0] ? artifact : "(none yet)",
-            peer_notes[0] ? peer_notes : "(none yet)", brief_block, round, mode_task);
+   snprintf(
+       prompt, needed,
+       "You are one participant in an agent roundtable. Your role is to %s.\n\n%s"
+       "TASK:\n%s\n\n%sCURRENT SHARED ARTIFACT:\n%s\n\nPEER NOTES FROM PREVIOUS TURN:\n%s\n\n%s"
+       "ROUND %d INSTRUCTION:\n%s\n",
+       role_hint, head_note, task ? task : "", context_block, artifact[0] ? artifact : "(none yet)",
+       peer_notes[0] ? peer_notes : "(none yet)", brief_block, round, mode_task);
 
    free(owned_brief_block);
+   free(owned_context_block);
    return prompt;
 }
 
@@ -1071,8 +1095,8 @@ static char *panel_persona_prompt(const config_t *cfg, roundtable_mode_t mode, i
 
 static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const char *task,
                               const char *artifact, const char *peer_notes, roundtable_mode_t mode,
-                              int round, const char *brief, agent_result_t *results,
-                              int deadline_ms)
+                              int round, const char *brief, const char *context,
+                              agent_result_t *results, int deadline_ms)
 {
    int ref_count = cfg->ensemble_reference_count;
    agent_task_t tasks[ENSEMBLE_MAX_REFS];
@@ -1083,7 +1107,7 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
    memset(personas, 0, sizeof(personas));
    for (int i = 0; i < ref_count; i++)
    {
-      prompts[i] = build_round_prompt(task, artifact, peer_notes, mode, round, brief);
+      prompts[i] = build_round_prompt(task, artifact, peer_notes, mode, round, brief, context);
       if (!prompts[i])
          goto fail;
       /* Per-participant persona (review mode only) is the system prompt; the
@@ -1119,7 +1143,8 @@ fail:
 
 static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const char *task,
                                 const char *artifact, char **peer_notes, roundtable_mode_t mode,
-                                int round, const char *brief, agent_result_t *results)
+                                int round, const char *brief, const char *context,
+                                agent_result_t *results)
 {
    int ref_count = cfg->ensemble_reference_count;
    int order[ENSEMBLE_MAX_REFS];
@@ -1130,7 +1155,7 @@ static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const
    for (int oi = 0; oi < ref_count; oi++)
    {
       int i = order[oi];
-      char *prompt = build_round_prompt(task, artifact, *peer_notes, mode, round, brief);
+      char *prompt = build_round_prompt(task, artifact, *peer_notes, mode, round, brief, context);
       if (!prompt)
          return -1;
       /* Persona binds to the stable model index `i`, not the shuffled slot. */
@@ -1465,12 +1490,12 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
       local.mode = ROUNDTABLE_DRAFT;
       local.turns = strcmp(cfg->roundtable_turns, "sequential") == 0 ? ROUNDTABLE_SEQUENTIAL
                                                                      : ROUNDTABLE_PARALLEL;
-      local.max_rounds = cfg->roundtable_max_rounds > 0 ? cfg->roundtable_max_rounds : 3;
+      local.max_rounds = cfg->roundtable_max_rounds > 0 ? cfg->roundtable_max_rounds : 1;
       local.converge_threshold = cfg->roundtable_converge_threshold;
       local.deadline_ms = cfg->roundtable_deadline_ms;
    }
    if (local.max_rounds <= 0)
-      local.max_rounds = 3;
+      local.max_rounds = 1;
    if (local.converge_threshold < 0)
       local.converge_threshold = 10;
    if (local.brief_truncated)
@@ -1553,9 +1578,9 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
       }
       int rc = local.turns == ROUNDTABLE_SEQUENTIAL
                    ? run_round_sequential(acfg, cfg, task, artifact, &peer_notes, local.mode, round,
-                                          local.brief, results)
+                                          local.brief, local.context, results)
                    : run_round_parallel(acfg, cfg, task, artifact, peer_notes, local.mode, round,
-                                        local.brief, results, panel_deadline_ms);
+                                        local.brief, local.context, results, panel_deadline_ms);
       if (rc != 0)
       {
          for (int i = 0; i < ref_count; i++)

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -50,6 +50,7 @@
 #include "workspace_provider.h"
 #include "workspace_turn.h"
 #include "cJSON.h"
+#include "dstr.h"
 
 /* Defined in agent_runtime_tmux.c (no shared header). Drives the standard CLI
  * agent over a tmux session, which runs on the client over the reverse channel
@@ -1845,6 +1846,88 @@ static const replay_backend_t rt_replay_kb_backend = {
     .project_count = rt_replay_project_count,
 };
 
+/* Assemble the read-only aimee context injected into every roundtable panelist
+ * prompt. Panelists run with NO tools, so — unlike a normal delegate, which
+ * reaches aimee memory and the code graph through tools mid-run — they can only
+ * see them if the context is pre-loaded. Combines aimee memory recall (graph-code
+ * fusion on, so code-graph-fused memory flows in) with the same code-index and
+ * structural-graph snippets a regular delegate is seeded with. Best-effort and
+ * fail-open: returns a heap string the caller frees, or NULL when nothing is
+ * available (recall disabled/empty and kb unreachable). */
+static char *roundtable_build_aimee_context(const char *prompt)
+{
+   if (!prompt || !prompt[0])
+      return NULL;
+   dstr_t s;
+   dstr_init(&s);
+
+   config_t cfg;
+   if (config_load(&cfg) == 0 && cfg.memory_recall_enabled)
+   {
+      int limit = cfg.memory_recall_limit_tokens_turn > 0 ? cfg.memory_recall_limit_tokens_turn : 0;
+      char *env = kb_client_memory_recall_json_ex(prompt, limit, 0 /* not session start */, "on");
+      cJSON *j = env ? cJSON_Parse(env) : NULL;
+      free(env);
+      cJSON *recall = j ? cJSON_GetObjectItemCaseSensitive(j, "recall") : NULL;
+      if (recall)
+      {
+         /* Same six recall sections the primary agent gets, in priority order. */
+         static const char *const sections[][2] = {{"identity", "Identity"},
+                                                   {"preferences", "Preferences"},
+                                                   {"active_context", "Active Context"},
+                                                   {"open_commitments", "Open Commitments"},
+                                                   {"reminders", "Reminders"},
+                                                   {"directives", "Directives"}};
+         int any = 0;
+         for (int si = 0; si < (int)(sizeof(sections) / sizeof(sections[0])); si++)
+         {
+            cJSON *arr = cJSON_GetObjectItemCaseSensitive(recall, sections[si][0]);
+            if (!cJSON_IsArray(arr) || cJSON_GetArraySize(arr) <= 0)
+               continue;
+            if (!any)
+            {
+               dstr_append_str(&s, "## Aimee memory\n");
+               any = 1;
+            }
+            dstr_appendf(&s, "### %s\n", sections[si][1]);
+            cJSON *it = NULL;
+            cJSON_ArrayForEach(it, arr)
+            {
+               const char *text = cJSON_GetStringValue(cJSON_GetObjectItem(it, "text"));
+               if (text && text[0])
+                  dstr_appendf(&s, "- %s\n", text);
+            }
+         }
+         if (any)
+            dstr_append_char(&s, '\n');
+      }
+      cJSON_Delete(j);
+   }
+
+   /* Code graph: the same code-index search + structural neighborhood a normal
+    * delegate is seeded with. delegate_inject_graph_context is itself gated by
+    * delegate_graph_context_enabled and both helpers fail open (NULL on a miss). */
+   char *code = delegate_inject_code_context(prompt);
+   if (code)
+   {
+      dstr_append_str(&s, code);
+      free(code);
+   }
+   char *graph = delegate_inject_graph_context(prompt, NULL);
+   if (graph)
+   {
+      dstr_append_str(&s, graph);
+      free(graph);
+   }
+
+   if (s.len == 0)
+   {
+      dstr_free(&s);
+      return NULL;
+   }
+   return dstr_steal(&s);
+}
+
 int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
@@ -1870,7 +1953,7 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    opts.mode = ROUNDTABLE_DRAFT;
    opts.turns = strcmp(cfg.roundtable_turns, "sequential") == 0 ? ROUNDTABLE_SEQUENTIAL
                                                                 : ROUNDTABLE_PARALLEL;
-   opts.max_rounds = cfg.roundtable_max_rounds > 0 ? cfg.roundtable_max_rounds : 3;
+   opts.max_rounds = cfg.roundtable_max_rounds > 0 ? cfg.roundtable_max_rounds : 1;
    opts.converge_threshold = cfg.roundtable_converge_threshold;
    opts.deadline_ms = cfg.roundtable_deadline_ms;
    opts.parent_session_id = compute_request_session_id(req); /* fold panel cost onto it */
@@ -1924,10 +2007,16 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    ensemble_filter_panel_availability(&cfg, &acfg);
    bind_request_session_creds(req);
 
+   /* Give the tool-less panelists read-only access to aimee memory + the code
+    * graph by pre-loading it into their prompt (best-effort; NULL = none). */
+   char *rt_context = roundtable_build_aimee_context(prompt);
+   opts.context = rt_context;
+
    roundtable_result_t result;
    int rc = delegate_roundtable_run(&acfg, &cfg, prompt, &opts, &result);
    if (rc != 0)
    {
+      free(rt_context);
       free(brief.rendered);
       return server_send_error(conn, "roundtable run failed (no enabled agents in agents.json?)",
                                NULL);
@@ -1950,6 +2039,7 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    cJSON_AddNumberToObject(resp, "cost_usd", result.cost_usd);
    add_roundtable_arrays(resp, &result);
    delegate_roundtable_result_free(&result);
+   free(rt_context);
    free(brief.rendered);
    return server_send_ok(conn, resp);
 }


### PR DESCRIPTION
## What

Two roundtable fixes reported by the user:

1. **Panelists now get aimee memory + code-graph context.** Roundtable panelists run with **no tools**, so — unlike a normal delegate, which reaches aimee memory and the code graph through tools mid-run — they previously had no way to see either, leaving reviews/drafts ungrounded. `handle_delegate_roundtable` now pre-assembles a read-only context block and injects it into every panelist prompt via a new `roundtable_opts_t.context` field:
   - **aimee memory** — `kb_client_memory_recall_json_ex(prompt, …, "on")`, the same recall the primary agent gets, flattened into the six standard sections (graph-code fusion **on**, so code-graph-fused memory flows in).
   - **code graph** — the same `delegate_inject_code_context` (code-index search) + `delegate_inject_graph_context` (structural neighborhood) snippets a regular delegate is seeded with.
   - Best-effort and **fail-open**: yields `NULL` (no block) when recall is disabled/empty and kb is unreachable.

2. **Default `roundtable.max_rounds` 3 → 1.** Changed the config default, the unset/invalid fallbacks in `delegate_roundtable_run`, the server request default, and the documented value in `MANUAL.md`. A caller can still request more via `--rounds`.

## Testing

- `cd src && make lint` (clang-format-19) — ok
- `make -j all server` — clean, no warnings (`-Werror`)
- `make build-integrity` — all checks pass
- `unit-test-delegate-ensemble`, `unit-test-config`, `unit-test-roundtable-brief` — all pass

## Notes

- Scope is the multi-round **roundtable** (`delegate_roundtable_run` / `/v1/delegate/roundtable`); the one-shot MoA ensemble path is unchanged.
- The new `context` opts field is additive and defaults to `NULL`, so existing callers are unaffected.