### PR TITLE
feat(roundtable): configurable default persona (GUI-settable, default engineer)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (156)
+## CLI-settable keys (157)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -51,6 +51,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `db2_url` | string | DB2 connection URL (aimee's vector / knowledge-base store). |
 | `dedup_enabled` | bool | Deduplicate near-identical responses. |
 | `dedup_window_seconds` | int | Window (seconds) for response dedup. |
+| `default_persona` | string | Persona a fresh primary session starts as, and the persona draft roundtable panelists author with when none is set (default 'engineer'). |
 | `delegate_graph_context_enabled` | bool | Prepend a structural code-graph context block (callers/dependencies of files a delegate task references) to the delegate prompt (advisory, fail-open, default off). |
 | `dogfood_autolabel_continuation` | bool | Auto-label continuation turns for dogfood capture. |
 | `dogfood_autolabel_repair` | bool | Auto-label repair turns for dogfood capture. |

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -47,7 +47,7 @@ function category(key: string): string {
     [/^memory/, "Memory"],
     [/^(ingress|gateway|tool_output|code_span|context|fold|compact)/, "Gateway & context"],
     [/^(audit|governance|decision|guardrail)/, "Audit & governance"],
-    [/^(provider|openai|anthropic|model|delegate|agent|roundtable)/, "Providers & delegates"],
+    [/^(provider|openai|anthropic|model|delegate|agent|roundtable|default_persona|persona)/, "Providers & delegates"],
     [/^(autonomous|cross_verify|ecomode|max_iterations|reasoning|verify|autopilot|trigger)/, "Agent behavior"],
     [/^(learning|intelligence|calibrat|bandit)/, "Learning & intelligence"],
     [/^(kb_curator|curator|synth|embed|rerank|extract|index)/, "Knowledge curation"],

--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -62,6 +62,8 @@ export const FIELD_HELP: Record<string, string> = {
     "How aimee handles a risky tool call: 'approve' asks you first (default), 'prompt' warns but proceeds, 'deny' refuses it outright.",
   db2_url: "Postgres connection URL for the shared knowledge store (DB2). Changing it needs a server restart.",
   provider: "Which primary agent aimee drives — e.g. claude, codex, or an openai-compatible endpoint.",
+  default_persona:
+    "The persona a fresh primary session starts as, and the persona draft roundtable panelists author with when none is set. Defaults to 'engineer' (e.g. qa, security, reviewer, architect, or a custom persona).",
   claude_model:
     "Model to force when the primary is Claude, passed as --model on launch. Blank uses the CLI's own default.",
   openai_endpoint: "Base URL for an OpenAI-compatible primary, e.g. https://api.openai.com/v1.",

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -260,6 +260,7 @@ CFG_KEY_DESC = {
     "openai_key_cmd": "Command that prints the OpenAI API key.",
     "openai_model": "OpenAI model name.",
     "provider": "Default model provider.",
+    "default_persona": "Persona a fresh primary session starts as, and the persona draft roundtable panelists author with when none is set (default 'engineer').",
     "reasoning_cap_enabled": "Cap the model's reasoning effort.",
     "typed_facts_enabled": "Enable the typed-fact knowledge layer (master gate; default off).",
     "audit_worm_enabled": "Dual-write governed-action audit rows into the append-only, "

--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -197,6 +197,21 @@ static char *build_session_context(const char *client_cwd)
    aimee_mode_t mode = config_current_mode();
    char persona_name[PERSONA_NAME_MAX];
    config_current_persona(persona_name, sizeof(persona_name));
+   /* When nothing more specific selected a persona — no AIMEE_MODE override and no
+    * durable /novel-style mode file, so the resolver fell through to the built-in
+    * `engineer` default — honor the operator-configured default persona so a fresh
+    * primary session starts as it (config.default_persona itself defaults to
+    * engineer, so this is a no-op until the operator changes it). */
+   if (strcmp(persona_name, "engineer") == 0)
+   {
+      config_t persona_cfg;
+      if (config_load(&persona_cfg) == 0 && persona_cfg.default_persona[0] &&
+          strcmp(persona_cfg.default_persona, "engineer") != 0)
+      {
+         snprintf(persona_name, sizeof(persona_name), "%s", persona_cfg.default_persona);
+         mode = aimee_mode_from_string(persona_name);
+      }
+   }
    persona_t persona;
    persona_load(NULL, persona_name, &persona);
 

--- a/src/config.c
+++ b/src/config.c
@@ -310,6 +310,7 @@ static const config_schema_entry_t config_schema[] = {
     {"toolsets", SCHEMA_OBJECT, 0},
     {"script", SCHEMA_OBJECT, 0},
     {"provider", SCHEMA_STRING, 0},
+    {"default_persona", SCHEMA_STRING, 0},
     {"use_builtin_cli", SCHEMA_BOOL, 0},
     {"claude_model", SCHEMA_STRING, 0},
     {"codex_model", SCHEMA_STRING, 0},
@@ -809,6 +810,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->db2_vector_corpus_diskann_threshold = 1000000;
    cfg->ensemble_min_successful = 2;
    cfg->ensemble_max_cost_usd = 0.0; /* 0 = no cost cap (unlimited) by default */
+   snprintf(cfg->default_persona, sizeof(cfg->default_persona), "engineer");
    cfg->roundtable_max_rounds = 1;
    cfg->roundtable_converge_threshold = 10;
    /* Saner default: 6 min (was 10). Long enough for a multi-round reasoning-model
@@ -1035,6 +1037,10 @@ int config_load_file(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "provider");
    if (cJSON_IsString(item) && item->valuestring[0])
       snprintf(cfg->provider, sizeof(cfg->provider), "%s", item->valuestring);
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "default_persona");
+   if (cJSON_IsString(item) && item->valuestring[0])
+      snprintf(cfg->default_persona, sizeof(cfg->default_persona), "%s", item->valuestring);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "openai_endpoint");
    if (cJSON_IsString(item) && item->valuestring[0])

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -19,6 +19,8 @@ const config_field_t config_fields[] = {
     {"db2_url", offsetof(config_t, db2_url), sizeof(((config_t *)0)->db2_url), 0, CFG_STRING,
      RELOAD_RESTART}, /* the postgres pool is opened at startup */
     {"provider", offsetof(config_t, provider), sizeof(((config_t *)0)->provider), 0, CFG_STRING},
+    {"default_persona", offsetof(config_t, default_persona),
+     sizeof(((config_t *)0)->default_persona), 0, CFG_STRING},
     {"claude_model", offsetof(config_t, claude_model), sizeof(((config_t *)0)->claude_model), 0,
      CFG_STRING},
     {"openai_endpoint", offsetof(config_t, openai_endpoint),

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -318,6 +318,8 @@ int config_save(const config_t *cfg)
       cJSON_AddNumberToObject(root, "db2_pool_size", cfg->db2_pool_size);
    cJSON_AddStringToObject(root, "guardrail_mode", cfg->guardrail_mode);
    cJSON_AddStringToObject(root, "provider", cfg->provider);
+   if (cfg->default_persona[0] && strcmp(cfg->default_persona, "engineer") != 0)
+      cJSON_AddStringToObject(root, "default_persona", cfg->default_persona);
 
    if (cfg->autonomous)
       cJSON_AddTrueToObject(root, "autonomous");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -268,6 +268,10 @@ typedef struct config
    int workspace_count;
    char guardrail_mode[16];
    char provider[16];
+   /* Durable default persona: the persona a fresh primary session starts as, and
+    * the persona draft roundtable panelists author with when none is set. Width =
+    * PERSONA_NAME_MAX (persona.h). Defaults to "engineer"; settable in the GUI. */
+   char default_persona[64];
 
    /* Claude primary CLI model override (enforced via --model flag on launch) */
    char claude_model[128]; /* e.g. "claude-opus-4-6" — empty means use CLI default */

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -182,10 +182,10 @@ void ensemble_filter_panel_authorization(config_t *cfg, const agent_config_t *ac
  * auto-seeded-but-unkeyed model never burns a seat and degrades the round. */
 void ensemble_filter_panel_availability(config_t *cfg, const agent_config_t *acfg);
 
-/* Persona name for review panelist `model_index`: a configured
- * ensemble.reference_personas[model_index] if set, else a round-robin over the
- * engine's diverse default lineup keyed on the stable model index. Returns NULL
- * for non-review modes (draft/aggregate keep their NULL-persona behavior).
+/* Persona name for panelist `model_index`: a configured
+ * ensemble.reference_personas[model_index] if set (any mode), else a mode default
+ * — DRAFT uses the built-in `engineer` persona for every panelist, REVIEW
+ * round-robins the diverse default lineup keyed on the stable model index.
  * Borrowed pointer (string literal or config field) — do not free. Exposed for
  * tests. */
 const char *panel_persona_name(const config_t *cfg, roundtable_mode_t mode, int model_index);

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1065,10 +1065,11 @@ static const char *const PANEL_DEFAULT_PERSONAS[] = {"security", "architect", "q
 
 /* Persona name for panelist `model_index`. An explicit per-slot override
  * (ensemble.reference_personas[model_index]) binds first in ANY mode. Otherwise
- * the default depends on mode: DRAFT authors every panelist as the built-in
- * `engineer` persona (the default autonomous-engineer prompt), while REVIEW
- * round-robins the diverse critique lineup keyed on the stable model index. The
- * returned pointer is a borrowed string literal or config field; do not free it. */
+ * the default depends on mode: DRAFT authors every panelist as the configured
+ * default persona (config.default_persona, itself defaulting to `engineer`),
+ * while REVIEW round-robins the diverse critique lineup keyed on the stable model
+ * index. The returned pointer is a borrowed string literal or config field; do
+ * not free it. */
 const char *panel_persona_name(const config_t *cfg, roundtable_mode_t mode, int model_index)
 {
    if (!cfg || model_index < 0)
@@ -1077,7 +1078,7 @@ const char *panel_persona_name(const config_t *cfg, roundtable_mode_t mode, int 
        cfg->ensemble_reference_personas[model_index][0])
       return cfg->ensemble_reference_personas[model_index];
    if (mode != ROUNDTABLE_REVIEW)
-      return "engineer";
+      return cfg->default_persona[0] ? cfg->default_persona : "engineer";
    return PANEL_DEFAULT_PERSONAS[model_index % PANEL_DEFAULT_PERSONA_COUNT];
 }
 

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1063,25 +1063,30 @@ static const char *const PANEL_DEFAULT_PERSONAS[] = {"security", "architect", "q
 #define PANEL_DEFAULT_PERSONA_COUNT                                                                \
    ((int)(sizeof(PANEL_DEFAULT_PERSONAS) / sizeof(PANEL_DEFAULT_PERSONAS[0])))
 
-/* Persona name for review panelist `model_index`. Returns NULL for non-review
- * modes (draft/aggregate keep their prior NULL-persona behavior) and when no
- * persona applies. The returned pointer is a borrowed string literal or config
- * field; do not free it. */
+/* Persona name for panelist `model_index`. An explicit per-slot override
+ * (ensemble.reference_personas[model_index]) binds first in ANY mode. Otherwise
+ * the default depends on mode: DRAFT authors every panelist as the built-in
+ * `engineer` persona (the default autonomous-engineer prompt), while REVIEW
+ * round-robins the diverse critique lineup keyed on the stable model index. The
+ * returned pointer is a borrowed string literal or config field; do not free it. */
 const char *panel_persona_name(const config_t *cfg, roundtable_mode_t mode, int model_index)
 {
-   if (mode != ROUNDTABLE_REVIEW || !cfg || model_index < 0)
+   if (!cfg || model_index < 0)
       return NULL;
    if (model_index < cfg->ensemble_reference_persona_count &&
        cfg->ensemble_reference_personas[model_index][0])
       return cfg->ensemble_reference_personas[model_index];
+   if (mode != ROUNDTABLE_REVIEW)
+      return "engineer";
    return PANEL_DEFAULT_PERSONAS[model_index % PANEL_DEFAULT_PERSONA_COUNT];
 }
 
-/* Compose the system prompt for review panelist `model_index`. Returns a heap
- * string the caller must free, or NULL (no persona, or compose failed — both
- * fall back to today's NULL-system-prompt behavior, never dropping a panelist).
- * persona_compose_delegate_prompt resolves project->user->built-in and itself
- * falls back to a usable persona, so an unknown custom name is non-fatal. */
+/* Compose the system prompt for panelist `model_index` (draft: engineer; review:
+ * the diverse lineup — see panel_persona_name). Returns a heap string the caller
+ * must free, or NULL (no persona name, or compose failed — both fall back to a
+ * NULL-system-prompt run, never dropping a panelist). persona_compose_delegate_prompt
+ * resolves project->user->built-in and itself falls back to a usable persona, so
+ * an unknown custom name is non-fatal. */
 static char *panel_persona_prompt(const config_t *cfg, roundtable_mode_t mode, int model_index)
 {
    const char *name = panel_persona_name(cfg, mode, model_index);
@@ -1111,8 +1116,8 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
       prompts[i] = build_round_prompt(task, artifact, peer_notes, mode, round, brief, context);
       if (!prompts[i])
          goto fail;
-      /* Per-participant persona (review mode only) is the system prompt; the
-       * round prompt still drives the output shape. */
+      /* Per-participant persona is the system prompt (draft: engineer; review:
+       * the diverse lineup); the round prompt still drives the output shape. */
       personas[i] = panel_persona_prompt(cfg, mode, i);
       tasks[i].role = mode == ROUNDTABLE_REVIEW ? "review" : "draft";
       tasks[i].agent = cfg->ensemble_reference_models[i];

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -116,6 +116,7 @@ int main(void)
       memset(&cfg, 0, sizeof(cfg));
       config_load(&cfg);
       snprintf(cfg.provider, sizeof(cfg.provider), "gemini");
+      snprintf(cfg.default_persona, sizeof(cfg.default_persona), "architect");
       snprintf(cfg.claude_model, sizeof(cfg.claude_model), "claude-sonnet-4-6");
       snprintf(cfg.codex_model, sizeof(cfg.codex_model), "gpt-5.4");
       snprintf(cfg.model_reasoning_effort, sizeof(cfg.model_reasoning_effort), "high");
@@ -361,6 +362,7 @@ int main(void)
       memset(&cfg2, 0, sizeof(cfg2));
       config_load(&cfg2);
       assert(strcmp(cfg2.provider, "gemini") == 0);
+      assert(strcmp(cfg2.default_persona, "architect") == 0);
       assert(strcmp(cfg2.claude_model, "claude-sonnet-4-6") == 0);
       assert(strcmp(cfg2.codex_model, "gpt-5.4") == 0);
       assert(strcmp(cfg2.model_reasoning_effort, "high") == 0);

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -1069,9 +1069,16 @@ static void test_panel_persona_name_assignment(void)
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_REVIEW, 4), "reviewer-constructive") == 0);
    /* wraps after the lineup is exhausted */
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_REVIEW, 5), "security") == 0);
-   /* DRAFT authors every panelist as the default `engineer` persona. */
+   /* DRAFT authors every panelist as the configured default persona; an unset
+    * default_persona falls back to the built-in `engineer`. */
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 0), "engineer") == 0);
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 4), "engineer") == 0);
+   snprintf(cfg.default_persona, sizeof(cfg.default_persona), "architect");
+   assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 0), "architect") == 0);
+   assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 4), "architect") == 0);
+   /* the configured default persona does not disturb the REVIEW lineup */
+   assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_REVIEW, 0), "security") == 0);
+   cfg.default_persona[0] = '\0';
    /* a configured persona pins to its model slot; an empty entry within the
     * configured range still falls back to the mode default */
    cfg.ensemble_reference_persona_count = 2;

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -1069,16 +1069,22 @@ static void test_panel_persona_name_assignment(void)
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_REVIEW, 4), "reviewer-constructive") == 0);
    /* wraps after the lineup is exhausted */
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_REVIEW, 5), "security") == 0);
-   /* draft/aggregate keep their prior NULL-persona behavior */
-   assert(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 0) == NULL);
+   /* DRAFT authors every panelist as the default `engineer` persona. */
+   assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 0), "engineer") == 0);
+   assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 4), "engineer") == 0);
    /* a configured persona pins to its model slot; an empty entry within the
-    * configured range still falls back to the default lineup */
+    * configured range still falls back to the mode default */
    cfg.ensemble_reference_persona_count = 2;
    snprintf(cfg.ensemble_reference_personas[1], 64, "security");
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_REVIEW, 1), "security") == 0); /* override */
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_REVIEW, 0), "security") ==
           0); /* empty->dflt */
    assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_REVIEW, 3), "reviewer") ==
+          0); /* beyond->dflt */
+   /* the per-slot override also binds in DRAFT; empty/beyond slots fall to engineer */
+   assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 1), "security") == 0); /* override */
+   assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 0), "engineer") == 0); /* empty->dflt */
+   assert(strcmp(panel_persona_name(&cfg, ROUNDTABLE_DRAFT, 3), "engineer") ==
           0); /* beyond->dflt */
    printf("  test_panel_persona_name_assignment: ok\n");
 }


### PR DESCRIPTION
## What

A durable **default persona** — settable in the GUI, defaulting to `engineer` on install — that governs every place a persona isn't explicitly chosen.

### Default persona (new config)
- New `config.default_persona` (`config_t` + `config_fields` allowlist + load/save + schema), default **`engineer`**; round-trips.
- Because it's a `config_fields` entry, it **auto-renders as a control on the Settings page** (GET `/api/config` → POST `/api/config/set`) — no bespoke frontend wiring. Added GUI help text and routed it to the "Providers & delegates" section.

### Where the default persona applies
- **Draft roundtable panelists** author as `config.default_persona` when no per-slot `ensemble.reference_personas[i]` override is set. Previously draft panelists ran with **no persona** at all; the review lineup (`security / architect / qa / reviewer / reviewer-constructive`) is unchanged.
- **Primary session start** uses `config.default_persona` when nothing more specific selected a persona (no `AIMEE_MODE` / `/novel`-style mode-file override). A no-op until an operator changes it, since the default is `engineer`.

### Persona wiring recap
`panel_persona_name` resolves: explicit per-slot override (any mode) → else DRAFT = `default_persona`, REVIEW = diverse lineup. Composed into each panelist's **system prompt** in both parallel and sequential round runners.

## Testing
- `cd src && make lint` (clang-format-19 + `docs-gen-check`) — ok
- `make -j all server` — clean under `-Werror`
- `unit-test-delegate-ensemble`, `unit-test-config` — pass
- frontend `tsc -b` + `vitest` — pass
