### PR TITLE
feat(learning): per-document overlap attribution for retrieval outcomes

### DIFF
--- a/docs/proposals/pending/kb-hybrid-outcome-wiring.md
+++ b/docs/proposals/pending/kb-hybrid-outcome-wiring.md
@@ -98,24 +98,34 @@ why the *per-document contrast* below is the thing that unlocks it. The
 per-candidate `weight` field now flows through to the fitter, so an **IPW /
 propensity or confidence weight** on an outcome is honoured unchanged.
 
-### Remaining open work — the real fidelity lever
+### Landed: per-document answer↔doc overlap attribution
 
-1. **Per-document answer↔doc overlap attribution.** The turn verdict is applied to
-   *all* surfaced rows identically, giving a ranker no within-query contrast (and
-   the existing "citation" machinery is circular — `memory_collect_answer_citation_ids`
-   returns the top-ranked match's cluster, computed at *retrieval* time, so it just
-   reinforces the current order). The non-circular fix: at attribution time, the
-   prior turn's assistant answer is already in the message history — score each
-   surfaced doc's snippet against it and emit **per-doc** `accepted` (used) vs
-   `contradicted` (surfaced-but-unused). This is what turns a flat verdict into the
-   contrastive labels the pairwise objective needs.
-2. **Ranker (`kb_search`) capture hook.** Note `ranker` outcomes when the agent uses
-   `kb_search` in a turn (scoped to in-turn tool use — `kb.search` is also CLI/API
-   callable outside a turn; `kb_search`'s response must expose `doc_id`).
-3. **IPW propensity logging.** Log the surfacing propensity (reuse the bandit's
+The turn verdict is no longer applied to all surfaced rows identically. At
+attribution time the prior turn's assistant answer is already in the message
+history (`ingress_preinject_last_assistant_from_messages`); the bridge scores each
+surfaced row's snippet against it (`retrieval_outcome_overlap_used`) and attributes
+**per document**: on a continuation, rows the answer used → `accepted`,
+surfaced-but-unused rows → `corrected`; on a repair, only the used rows are blamed.
+That is the **within-query contrast** the pairwise objective needs — and it is
+non-circular (the old `memory_collect_answer_citation_ids` "citation" is the
+top-ranked match computed at *retrieval* time, so it just reinforces the current
+order; overlap is derived from the answer instead). Wired for the **memory**
+surface (which the bridge already notes), sharpening the revived demotion loop from
+flat to per-row; the bridge is surface-generic so the ranker gets it for free once
+its rows are noted. Falls back to the flat verdict when no answer/snippets exist.
+
+### Remaining open work
+
+1. **Ranker (`kb_search`) capture hook.** Note `ranker` outcomes when the agent uses
+   `kb_search` in a turn. Prerequisite found: the `kb_search` **tool returns a
+   rendered text blob**, not structured ids — so the search response must first
+   expose `docs:[{id, snippet}]`. Then note them (scoped to in-turn tool use —
+   `kb.search` is also CLI/API-callable outside a turn, where no next-turn autolabel
+   follows). With that, per-doc overlap (above) lights up `ranker_outcome`.
+2. **IPW propensity logging.** Log the surfacing propensity (reuse the bandit's
    `db2_bandit_decision_insert` pattern) and populate the outcome `weight` with
    `1/propensity`; the fitter already consumes it.
-4. **Explicit harness/eval feedback** — highest fidelity, for benchmark runs.
+3. **Explicit harness/eval feedback** — highest fidelity, for benchmark runs.
 
 ## Non-goals
 

--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -102,6 +102,12 @@ char *ingress_preinject_format_envelope(const char *context_block, const char *c
  * NULL when there is no usable user text. Pure (no kb). */
 char *ingress_preinject_query_from_messages(const cJSON *messages);
 
+/* Extract the PRIOR turn's answer: the text of the last assistant-role message
+ * in `messages` (the current turn's answer does not exist yet). Returns a
+ * malloc'd string (caller frees) or NULL. Pure (no kb). Used by the
+ * retrieval-outcome bridge for per-document overlap attribution. */
+char *ingress_preinject_last_assistant_from_messages(const cJSON *messages);
+
 /* Build the envelope for a turn seeded by `query`. Honors
  * `ingress_preinject_enabled` (config) and `request_disabled` (per-request
  * override): returns NULL when disabled, when query is blank, or when recall

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -435,6 +435,37 @@ char *ingress_preinject_query_from_messages(const cJSON *messages)
    return out;
 }
 
+char *ingress_preinject_last_assistant_from_messages(const cJSON *messages)
+{
+   if (!cJSON_IsArray(messages))
+      return NULL;
+
+   /* The LAST assistant-role message is the PRIOR turn's answer (the current
+    * turn's answer does not exist yet). Used by the retrieval-outcome bridge to
+    * attribute per-document overlap. */
+   const cJSON *msg = NULL;
+   const cJSON *last_assistant = NULL;
+   cJSON_ArrayForEach(msg, messages)
+   {
+      const cJSON *role = cJSON_GetObjectItemCaseSensitive(msg, "role");
+      if (cJSON_IsString(role) && strcmp(role->valuestring, "assistant") == 0)
+         last_assistant = msg;
+   }
+   if (!last_assistant)
+      return NULL;
+
+   dstr_t d;
+   dstr_init(&d);
+   append_content_text(&d, cJSON_GetObjectItemCaseSensitive(last_assistant, "content"));
+   char *out = dstr_steal(&d);
+   if (out && out[0] == '\0')
+   {
+      free(out);
+      return NULL;
+   }
+   return out;
+}
+
 char *ingress_preinject_build(const char *query, int request_disabled)
 {
    if (request_disabled || g_request_disabled)
@@ -587,10 +618,18 @@ char *ingress_preinject_build(const char *query, int request_disabled)
        * previews surfaced into this turn (mem_n <= the diagnose cap of 5), so
        * recording all of them is the complete memory evidence, not a truncation. */
       int64_t ids[5];
+      const char *snips[5];
       int n_ids = 0;
       for (int i = 0; i < mem_n && n_ids < (int)(sizeof(ids) / sizeof(ids[0])); i++)
          if (mems[i].memory.id > 0)
-            ids[n_ids++] = mems[i].memory.id;
+         {
+            /* Snippet for per-doc overlap attribution: the same preview text the
+             * turn saw (headline, else content). */
+            snips[n_ids] =
+                mems[i].memory.headline[0] ? mems[i].memory.headline : mems[i].memory.content;
+            ids[n_ids] = mems[i].memory.id;
+            n_ids++;
+         }
       if (n_ids > 0)
       {
          char ev_id[64] = "";
@@ -599,7 +638,7 @@ char *ingress_preinject_build(const char *query, int request_disabled)
          if (kb_client_evidence_emit_retrieval_event_ex(tid, "Recall", fp, ids, n_ids, ev_id,
                                                         sizeof(ev_id)) == 0 &&
              ev_id[0])
-            retrieval_outcome_bridge_note("memory", ev_id, ids, n_ids);
+            retrieval_outcome_bridge_note("memory", ev_id, ids, snips, n_ids);
       }
 
       /* Code surface (P1.5/D3): MERGE the code hits surfaced into this turn into the

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1155,11 +1155,16 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
          learning_implicit_detect_turn(turn_text);
          /* Bridge the same continuation/repair classification into a retrieval
           * OUTCOME for the prior turn's surfaced rows (default-off). Closes the
-          * demotion + learning-to-rank loops from the signal already computed. */
+          * demotion + learning-to-rank loops from the signal already computed.
+          * The prior assistant answer (from the message history) drives per-doc
+          * overlap attribution — which surfaced rows the answer actually used. */
          {
             dogfood_autolabel_kind_t rob_kind = dogfood_classify_next_turn(turn_text);
-            retrieval_outcome_bridge_on_autolabel(rob_kind == DOGFOOD_AUTOLABEL_CONTINUATION,
+            char *prior_answer = ingress_preinject_last_assistant_from_messages(messages);
+            retrieval_outcome_bridge_on_autolabel(prior_answer,
+                                                  rob_kind == DOGFOOD_AUTOLABEL_CONTINUATION,
                                                   rob_kind == DOGFOOD_AUTOLABEL_REPAIR);
+            free(prior_answer);
          }
          free(turn_text);
       }

--- a/src/server/retrieval_outcome_bridge.c
+++ b/src/server/retrieval_outcome_bridge.c
@@ -7,9 +7,15 @@
 #include "kb_client.h"
 #include "db2/demotion.h" /* DEMOTION_VERDICT_* */
 
+#include <ctype.h>
 #include <string.h>
 
-#define ROB_MAX_IDS 8
+#define ROB_MAX_IDS     8
+#define ROB_SNIPPET_CAP 256
+/* A snippet counts as "used" when at least this fraction of its distinctive
+ * content tokens appear in the answer (and at least one token matches). */
+#define ROB_OVERLAP_FRACTION 0.34
+#define ROB_MIN_TOKEN_LEN    4 /* skip short/stopword-ish tokens */
 
 /* Process-global single-turn memory, mirroring dogfood's g_last_record_id. This
  * carries the prior turn's surfaced rows across to the next turn's autolabel. On
@@ -19,44 +25,169 @@ typedef struct
 {
    char event_id[64];
    int64_t ids[ROB_MAX_IDS];
+   char snippets[ROB_MAX_IDS][ROB_SNIPPET_CAP];
+   int has_snippets;
    int n;
 } rob_pending_t;
 
 static rob_pending_t g_mem;  /* memory surface  -> retrieval_attribution */
 static rob_pending_t g_rank; /* ranker surface  -> ranker_outcome        */
 
-static void rob_fill(rob_pending_t *p, const char *event_id, const int64_t *ids, int n)
+static void rob_fill(rob_pending_t *p, const char *event_id, const int64_t *ids,
+                     const char *const *snippets, int n)
 {
    if (!event_id || !event_id[0] || n <= 0 || !ids)
    {
       p->n = 0;
+      p->has_snippets = 0;
       return;
    }
    snprintf(p->event_id, sizeof(p->event_id), "%s", event_id);
    int k = n < ROB_MAX_IDS ? n : ROB_MAX_IDS;
+   int any_snip = 0;
    for (int i = 0; i < k; i++)
+   {
       p->ids[i] = ids[i];
+      if (snippets && snippets[i] && snippets[i][0])
+      {
+         snprintf(p->snippets[i], sizeof(p->snippets[i]), "%s", snippets[i]);
+         any_snip = 1;
+      }
+      else
+      {
+         p->snippets[i][0] = '\0';
+      }
+   }
    p->n = k;
+   p->has_snippets = any_snip;
 }
 
 void retrieval_outcome_bridge_note(const char *surface, const char *event_id, const int64_t *ids,
-                                   int n)
+                                   const char *const *snippets, int n)
 {
    if (!surface)
       return;
    if (strcmp(surface, "ranker") == 0)
-      rob_fill(&g_rank, event_id, ids, n);
+      rob_fill(&g_rank, event_id, ids, snippets, n);
    else if (strcmp(surface, "memory") == 0)
-      rob_fill(&g_mem, event_id, ids, n);
+      rob_fill(&g_mem, event_id, ids, snippets, n);
 }
 
 void retrieval_outcome_bridge_reset(void)
 {
    g_mem.n = 0;
+   g_mem.has_snippets = 0;
    g_rank.n = 0;
+   g_rank.has_snippets = 0;
 }
 
-void retrieval_outcome_bridge_on_autolabel(int is_continuation, int is_repair)
+/* Lowercase a copy of s into buf (truncating), for case-insensitive matching. */
+static void rob_lower(const char *s, char *buf, size_t cap)
+{
+   size_t i = 0;
+   for (; s && s[i] && i + 1 < cap; i++)
+      buf[i] = (char)tolower((unsigned char)s[i]);
+   buf[i] = '\0';
+}
+
+int retrieval_outcome_overlap_used(const char *answer, const char *snippet)
+{
+   if (!answer || !answer[0] || !snippet || !snippet[0])
+      return 0;
+
+   char ans[8192];
+   rob_lower(answer, ans, sizeof(ans));
+
+   char snip[ROB_SNIPPET_CAP];
+   rob_lower(snippet, snip, sizeof(snip));
+
+   int total = 0, matched = 0;
+   char tok[64];
+   size_t tl = 0;
+   /* Walk snippet tokens (alnum runs); a token "matches" if it occurs in answer. */
+   for (size_t i = 0;; i++)
+   {
+      char c = snip[i];
+      int isword = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+      if (isword && tl + 1 < sizeof(tok))
+      {
+         tok[tl++] = c;
+      }
+      else
+      {
+         if (tl >= (size_t)ROB_MIN_TOKEN_LEN)
+         {
+            tok[tl] = '\0';
+            total++;
+            if (strstr(ans, tok))
+               matched++;
+         }
+         tl = 0;
+         if (!c)
+            break;
+      }
+   }
+   if (total == 0)
+      return 0;
+   return ((double)matched / (double)total) >= ROB_OVERLAP_FRACTION ? 1 : 0;
+}
+
+/* Attribute one surface's pending note. Partition the surfaced ids by verdict and
+ * write each verdict-group as one batch. Rules:
+ *   continuation (answer good):
+ *     - per-doc available: used -> accepted, unused -> corrected (didn't help the
+ *       good answer) — this is the within-query contrast.
+ *     - else: all -> accepted (flat).
+ *   repair (answer bad):
+ *     - per-doc available: used -> corrected (fed the bad answer), unused dropped.
+ *     - else: all -> corrected (flat). */
+static void rob_attribute(rob_pending_t *p, const char *surface, const char *prior_answer,
+                          int is_continuation, int is_repair)
+{
+   if (p->n <= 0)
+      return;
+   if (!is_continuation && !is_repair)
+      return; /* no turn signal */
+
+   int per_doc = (prior_answer && prior_answer[0] && p->has_snippets);
+
+   int64_t acc[ROB_MAX_IDS];
+   int n_acc = 0;
+   int64_t neg[ROB_MAX_IDS];
+   int n_neg = 0;
+
+   for (int i = 0; i < p->n; i++)
+   {
+      int used = per_doc ? retrieval_outcome_overlap_used(prior_answer, p->snippets[i]) : -1;
+      if (is_continuation)
+      {
+         if (used == -1)
+            acc[n_acc++] = p->ids[i]; /* flat: all accepted */
+         else if (used)
+            acc[n_acc++] = p->ids[i];
+         else
+            neg[n_neg++] = p->ids[i];
+      }
+      else /* repair */
+      {
+         if (used == -1)
+            neg[n_neg++] = p->ids[i]; /* flat: all corrected */
+         else if (used)
+            neg[n_neg++] = p->ids[i];
+         /* repair + unused -> no signal, dropped */
+      }
+   }
+
+   if (n_acc > 0)
+      (void)kb_client_record_retrieval_outcome(surface, p->event_id, acc, n_acc,
+                                               DEMOTION_VERDICT_ACCEPTED);
+   if (n_neg > 0)
+      (void)kb_client_record_retrieval_outcome(surface, p->event_id, neg, n_neg,
+                                               DEMOTION_VERDICT_CORRECTED);
+}
+
+void retrieval_outcome_bridge_on_autolabel(const char *prior_answer, int is_continuation,
+                                           int is_repair)
 {
    /* Nothing pending: cheap exit before touching config. */
    if (g_mem.n <= 0 && g_rank.n <= 0)
@@ -69,25 +200,8 @@ void retrieval_outcome_bridge_on_autolabel(int is_continuation, int is_repair)
       return;
    }
 
-   /* Continuation = the answer built on these rows stuck -> accepted.
-    * Repair = the user corrected it -> corrected (a negative demotion verdict).
-    * Anything else carries no usable signal; we still consume (drop) so the note
-    * cannot leak onto a later, unrelated turn. */
-   const char *verdict = NULL;
-   if (is_continuation)
-      verdict = DEMOTION_VERDICT_ACCEPTED;
-   else if (is_repair)
-      verdict = DEMOTION_VERDICT_CORRECTED;
-
-   if (verdict)
-   {
-      if (g_mem.n > 0)
-         (void)kb_client_record_retrieval_outcome("memory", g_mem.event_id, g_mem.ids, g_mem.n,
-                                                  verdict);
-      if (g_rank.n > 0)
-         (void)kb_client_record_retrieval_outcome("ranker", g_rank.event_id, g_rank.ids, g_rank.n,
-                                                  verdict);
-   }
+   rob_attribute(&g_mem, "memory", prior_answer, is_continuation, is_repair);
+   rob_attribute(&g_rank, "ranker", prior_answer, is_continuation, is_repair);
 
    retrieval_outcome_bridge_reset();
 }

--- a/src/server/retrieval_outcome_bridge.h
+++ b/src/server/retrieval_outcome_bridge.h
@@ -3,10 +3,16 @@
  *
  * Flow (mirrors the dogfood g_last_record_id single-turn lifecycle):
  *   turn N   — a retrieval surfaces rows; the emitter calls _note() with the
- *              minted retrieval_event_id + surfaced ids (per surface).
+ *              minted retrieval_event_id + surfaced ids (and, optionally, each
+ *              row's snippet, per surface).
  *   turn N+1 — the user's next message is classified continuation (the answer
  *              stuck) or repair (it was corrected); _on_autolabel() consumes the
- *              pending note and records an outcome verdict for turn N's rows.
+ *              pending note and records an outcome verdict for turn N's rows. When
+ *              the prior turn's answer text and per-row snippets are available it
+ *              attributes PER-DOCUMENT — rows whose content the answer actually
+ *              used are `accepted`, surfaced-but-unused rows are the negatives —
+ *              giving the within-query contrast a ranker needs. Without them it
+ *              falls back to the flat turn-level verdict.
  *
  * Default-off behind config learning_implicit_retrieval_outcome. Observation-only:
  * writes evidence artifacts, never changes the turn's answer.
@@ -22,16 +28,25 @@ extern "C"
 #endif
 
    /* Record the rows surfaced this turn for later attribution. surface is
-    * "memory" (-> retrieval_attribution) or "ranker" (-> ranker_outcome). Replaces
-    * any prior un-consumed note for that surface. n<=0 clears it. */
+    * "memory" (-> retrieval_attribution) or "ranker" (-> ranker_outcome).
+    * snippets (may be NULL, or individual entries NULL) carries each row's
+    * content for per-document overlap attribution. Replaces any prior un-consumed
+    * note for that surface. n<=0 clears it. */
    void retrieval_outcome_bridge_note(const char *surface, const char *event_id, const int64_t *ids,
-                                      int n);
+                                      const char *const *snippets, int n);
 
-   /* Consume the pending notes and, when the next turn is a clear continuation
-    * (accepted) or repair (corrected), write the outcome verdict. Always clears
-    * the pending state (consume-once), so an unlabelled turn drops the signal
-    * rather than mis-attributing it to a later turn. */
-   void retrieval_outcome_bridge_on_autolabel(int is_continuation, int is_repair);
+   /* Consume the pending notes for a next turn classified continuation (the answer
+    * stuck) or repair (it was corrected). prior_answer is the previous assistant
+    * turn's text (may be NULL). With prior_answer + snippets, attributes per-doc
+    * via content overlap; otherwise writes the flat turn verdict. Always clears
+    * the pending state (consume-once) so a note never leaks onto a later turn. */
+   void retrieval_outcome_bridge_on_autolabel(const char *prior_answer, int is_continuation,
+                                              int is_repair);
+
+   /* Pure overlap test: does `answer` appear to have used `snippet`? A snippet is
+    * "used" when a sufficient fraction of its distinctive content tokens occur in
+    * the answer. Exposed for unit testing. Returns 1 (used) / 0. */
+   int retrieval_outcome_overlap_used(const char *answer, const char *snippet);
 
    /* Test seam: clear pending state. */
    void retrieval_outcome_bridge_reset(void);

--- a/src/tests/test_gw_stage_memory.c
+++ b/src/tests/test_gw_stage_memory.c
@@ -115,11 +115,12 @@ int kb_client_evidence_emit_retrieval_event_ex(const char *turn_id, const char *
    return 0;
 }
 void retrieval_outcome_bridge_note(const char *surface, const char *event_id, const int64_t *ids,
-                                   int n)
+                                   const char *const *snippets, int n)
 {
    (void)surface;
    (void)event_id;
    (void)ids;
+   (void)snippets;
    (void)n;
 }
 int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -125,11 +125,12 @@ int kb_client_evidence_emit_retrieval_event_ex(const char *turn_id, const char *
    return 0;
 }
 void retrieval_outcome_bridge_note(const char *surface, const char *event_id, const int64_t *ids,
-                                   int n)
+                                   const char *const *snippets, int n)
 {
    (void)surface;
    (void)event_id;
    (void)ids;
+   (void)snippets;
    (void)n;
 }
 int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,

--- a/src/tests/test_retrieval_outcome_bridge.c
+++ b/src/tests/test_retrieval_outcome_bridge.c
@@ -35,15 +35,33 @@ static char last_verdict[32];
 static int last_n;
 static int call_count;
 
+/* Accumulate the ids written under each verdict, so per-doc partitioning can be
+ * verified across the (up to two) batched calls per surface. */
+static int64_t g_acc_ids[16];
+static int g_acc_n;
+static int64_t g_neg_ids[16];
+static int g_neg_n;
+
 int kb_client_record_retrieval_outcome(const char *surface, const char *event_id,
                                        const int64_t *ids, int n, const char *verdict)
 {
-   (void)ids;
    snprintf(last_surface, sizeof(last_surface), "%s", surface ? surface : "");
    snprintf(last_event, sizeof(last_event), "%s", event_id ? event_id : "");
    snprintf(last_verdict, sizeof(last_verdict), "%s", verdict ? verdict : "");
    last_n = n;
    call_count++;
+   int64_t *dst = (verdict && strcmp(verdict, "accepted") == 0) ? g_acc_ids : g_neg_ids;
+   int *dn = (verdict && strcmp(verdict, "accepted") == 0) ? &g_acc_n : &g_neg_n;
+   for (int i = 0; ids && i < n && *dn < 16; i++)
+      dst[(*dn)++] = ids[i];
+   return 0;
+}
+
+static int has_id(const int64_t *a, int n, int64_t v)
+{
+   for (int i = 0; i < n; i++)
+      if (a[i] == v)
+         return 1;
    return 0;
 }
 
@@ -52,16 +70,19 @@ static void reset_capture(void)
    last_surface[0] = last_event[0] = last_verdict[0] = '\0';
    last_n = 0;
    call_count = 0;
+   g_acc_n = 0;
+   g_neg_n = 0;
    retrieval_outcome_bridge_reset();
 }
 
+/* Flat (no snippet / no prior answer) — the B2 behaviour, preserved. */
 static void test_continuation_accepted(void)
 {
    reset_capture();
    g_flag = 1;
    int64_t ids[2] = {10, 11};
-   retrieval_outcome_bridge_note("memory", "ev-1", ids, 2);
-   retrieval_outcome_bridge_on_autolabel(1 /*continuation*/, 0);
+   retrieval_outcome_bridge_note("memory", "ev-1", ids, NULL, 2);
+   retrieval_outcome_bridge_on_autolabel(NULL, 1 /*continuation*/, 0);
    assert(call_count == 1);
    assert(strcmp(last_surface, "memory") == 0);
    assert(strcmp(last_event, "ev-1") == 0);
@@ -75,8 +96,8 @@ static void test_repair_corrected_ranker(void)
    reset_capture();
    g_flag = 1;
    int64_t ids[1] = {100};
-   retrieval_outcome_bridge_note("ranker", "ev-2", ids, 1);
-   retrieval_outcome_bridge_on_autolabel(0, 1 /*repair*/);
+   retrieval_outcome_bridge_note("ranker", "ev-2", ids, NULL, 1);
+   retrieval_outcome_bridge_on_autolabel(NULL, 0, 1 /*repair*/);
    assert(call_count == 1);
    assert(strcmp(last_surface, "ranker") == 0);
    assert(strcmp(last_verdict, "corrected") == 0);
@@ -88,9 +109,9 @@ static void test_both_surfaces(void)
    reset_capture();
    g_flag = 1;
    int64_t m[1] = {1}, r[1] = {2};
-   retrieval_outcome_bridge_note("memory", "ev-m", m, 1);
-   retrieval_outcome_bridge_note("ranker", "ev-r", r, 1);
-   retrieval_outcome_bridge_on_autolabel(1, 0);
+   retrieval_outcome_bridge_note("memory", "ev-m", m, NULL, 1);
+   retrieval_outcome_bridge_note("ranker", "ev-r", r, NULL, 1);
+   retrieval_outcome_bridge_on_autolabel(NULL, 1, 0);
    assert(call_count == 2); /* one per surface */
    printf("  both_surfaces: ok\n");
 }
@@ -100,8 +121,8 @@ static void test_gate_off(void)
    reset_capture();
    g_flag = 0; /* flag off */
    int64_t ids[1] = {5};
-   retrieval_outcome_bridge_note("memory", "ev-x", ids, 1);
-   retrieval_outcome_bridge_on_autolabel(1, 0);
+   retrieval_outcome_bridge_note("memory", "ev-x", ids, NULL, 1);
+   retrieval_outcome_bridge_on_autolabel(NULL, 1, 0);
    assert(call_count == 0); /* no write when disabled */
    printf("  gate_off: ok\n");
 }
@@ -111,12 +132,12 @@ static void test_consume_once(void)
    reset_capture();
    g_flag = 1;
    int64_t ids[1] = {7};
-   retrieval_outcome_bridge_note("memory", "ev-c", ids, 1);
+   retrieval_outcome_bridge_note("memory", "ev-c", ids, NULL, 1);
    /* Turn with no clear label: drops the note. */
-   retrieval_outcome_bridge_on_autolabel(0, 0);
+   retrieval_outcome_bridge_on_autolabel(NULL, 0, 0);
    assert(call_count == 0);
    /* A later labelled turn must NOT resurrect the dropped note. */
-   retrieval_outcome_bridge_on_autolabel(1, 0);
+   retrieval_outcome_bridge_on_autolabel(NULL, 1, 0);
    assert(call_count == 0);
    printf("  consume_once: ok\n");
 }
@@ -125,9 +146,61 @@ static void test_no_pending(void)
 {
    reset_capture();
    g_flag = 1;
-   retrieval_outcome_bridge_on_autolabel(1, 0);
+   retrieval_outcome_bridge_on_autolabel(NULL, 1, 0);
    assert(call_count == 0);
    printf("  no_pending: ok\n");
+}
+
+/* The pure overlap test: an answer that reuses a snippet's content words. */
+static void test_overlap_used(void)
+{
+   assert(retrieval_outcome_overlap_used(
+              "The three-database split isolates the vector store from the graph.",
+              "three-database split isolates vector store") == 1);
+   assert(retrieval_outcome_overlap_used("Completely unrelated pizza recipe instructions here.",
+                                         "kubernetes ingress controller sidecar topology") == 0);
+   assert(retrieval_outcome_overlap_used(NULL, "x") == 0);
+   assert(retrieval_outcome_overlap_used("x", NULL) == 0);
+   printf("  overlap_used: ok\n");
+}
+
+/* Per-doc: a good (continuation) answer that used doc A's content but not doc B's
+ * -> A accepted, B corrected. This is the within-query contrast a ranker needs. */
+static void test_perdoc_continuation_contrast(void)
+{
+   reset_capture();
+   g_flag = 1;
+   int64_t ids[2] = {201, 202};
+   const char *snips[2] = {"retrieval outcome bridge attribution overlap",
+                           "unrelated quarterly budget spreadsheet figures"};
+   retrieval_outcome_bridge_note("ranker", "ev-pd", ids, snips, 2);
+   retrieval_outcome_bridge_on_autolabel(
+       "I used the retrieval outcome bridge to compute overlap attribution.", 1 /*continuation*/,
+       0);
+   /* doc 201 (used) accepted; doc 202 (unused) corrected. */
+   assert(has_id(g_acc_ids, g_acc_n, 201));
+   assert(!has_id(g_acc_ids, g_acc_n, 202));
+   assert(has_id(g_neg_ids, g_neg_n, 202));
+   assert(!has_id(g_neg_ids, g_neg_n, 201));
+   printf("  perdoc_continuation_contrast: ok\n");
+}
+
+/* Per-doc under repair: only the doc the (bad) answer actually used is blamed;
+ * the unused doc carries no signal and is dropped. */
+static void test_perdoc_repair_blames_used(void)
+{
+   reset_capture();
+   g_flag = 1;
+   int64_t ids[2] = {301, 302};
+   const char *snips[2] = {"widget frobnicator calibration procedure",
+                           "entirely different photosynthesis chlorophyll notes"};
+   retrieval_outcome_bridge_note("memory", "ev-r2", ids, snips, 2);
+   retrieval_outcome_bridge_on_autolabel("Per the widget frobnicator calibration procedure, do X.",
+                                         0, 1 /*repair*/);
+   assert(has_id(g_neg_ids, g_neg_n, 301));  /* used -> blamed */
+   assert(!has_id(g_neg_ids, g_neg_n, 302)); /* unused -> dropped */
+   assert(g_acc_n == 0);                     /* nothing accepted on a repair */
+   printf("  perdoc_repair_blames_used: ok\n");
 }
 
 int main(void)
@@ -139,6 +212,9 @@ int main(void)
    test_gate_off();
    test_consume_once();
    test_no_pending();
+   test_overlap_used();
+   test_perdoc_continuation_contrast();
+   test_perdoc_repair_blames_used();
    printf("test_retrieval_outcome_bridge: all passed\n");
    return 0;
 }


### PR DESCRIPTION
Turns the flat, turn-level outcome label into a **per-document, within-query** signal — the contrast the pairwise objective (#1189) needs, and the thing the turn-level label never had.

## Why
The bridge (#1185) stamped one verdict on *all* surfaced rows, so a ranker got zero within-query contrast. And the existing citation machinery is **circular** (returns the top retrieval-time match, not answer usage). This adds a **non-circular** per-doc signal derived from the answer itself.

## What
- **`retrieval_outcome_overlap_used(answer, snippet)`** — token-overlap test: did the answer actually use this row's content? Pure, unit-tested.
- The bridge `note` now carries each row's **snippet**; `on_autolabel` takes the **prior assistant answer** (already in the message history) and attributes **per document**:
  - continuation → rows the answer used = `accepted`, surfaced-but-unused = `corrected` (within-query contrast);
  - repair → only the *used* rows are blamed, unused dropped.
  - Falls back to the flat verdict when no answer/snippets → **B2 behaviour preserved**.
- **`ingress_preinject`**: passes recalled memory previews as snippets, and grabs the prior answer via new `ingress_preinject_last_assistant_from_messages()`.

Wired for the **memory** surface now (sharpens the revived demotion loop from flat → per-row). The bridge is surface-generic, so the **ranker inherits per-doc for free once its rows are noted** — which needs the `kb_search` response to expose `docs:[{id,snippet}]` (the tool currently returns rendered text). That's the documented next step.

## Tests
`overlap_used`, `perdoc_continuation_contrast`, `perdoc_repair_blames_used` (+ the existing flat-path tests, unchanged). Full unit-test suite + `make lint` green. Default-off behind `learning_implicit_retrieval_outcome`.