### PR TITLE
feat(kb): kb_search outcome capture — close the ranker loop on live traffic

### DIFF
--- a/docs/proposals/pending/kb-hybrid-outcome-wiring.md
+++ b/docs/proposals/pending/kb-hybrid-outcome-wiring.md
@@ -117,13 +117,12 @@ its rows are noted. Falls back to the flat verdict when no answer/snippets exist
 ### Landed: ranker (`kb_search`) capture hook
 
 When the agent uses `kb_search` in a turn and the flag is on, the tool dispatch
-(`agent_tools_dispatch.c`) does a structured `format=json` fetch, mints a kb_hybrid
-`retrieval_event` over the surfaced doc_ids (`kb_client_ranker_emit_event` →
-`ranker.emit_event`), and notes them on the ranker surface. Two substrate facts
-found + fixed: `kb_search_json` now emits `doc_id` per result (the file_path-keyed
-http `hits` shape lacked it), and `/v1/search` honours `format=json` to return the
-structured `results` verbatim (no other caller passes `format`, so existing
-behaviour is untouched). The bridge symbol is declared **weak** in the agent layer,
+(`agent_tools_dispatch.c`) reads the surfaced `hits[].doc_id` + `excerpt`, mints a
+kb_hybrid `retrieval_event` over them (`kb_client_ranker_emit_event` →
+`ranker.emit_event`), and notes them on the ranker surface. The substrate fix that
+made this possible: `/v1/search` now includes **`doc_id` on each `hit`** (the
+projection was file_path-keyed and lacked it) — additive, the response shape is
+unchanged and existing consumers ignore it. The bridge symbol is declared **weak** in the agent layer,
 so a delegate/lean binary links cleanly and simply skips capture. The next turn's
 per-doc overlap (above) then attributes `ranker_outcome` — closing the ranker loop.
 

--- a/docs/proposals/pending/kb-hybrid-outcome-wiring.md
+++ b/docs/proposals/pending/kb-hybrid-outcome-wiring.md
@@ -114,18 +114,31 @@ surface (which the bridge already notes), sharpening the revived demotion loop f
 flat to per-row; the bridge is surface-generic so the ranker gets it for free once
 its rows are noted. Falls back to the flat verdict when no answer/snippets exist.
 
+### Landed: ranker (`kb_search`) capture hook
+
+When the agent uses `kb_search` in a turn and the flag is on, the tool dispatch
+(`agent_tools_dispatch.c`) does a structured `format=json` fetch, mints a kb_hybrid
+`retrieval_event` over the surfaced doc_ids (`kb_client_ranker_emit_event` →
+`ranker.emit_event`), and notes them on the ranker surface. Two substrate facts
+found + fixed: `kb_search_json` now emits `doc_id` per result (the file_path-keyed
+http `hits` shape lacked it), and `/v1/search` honours `format=json` to return the
+structured `results` verbatim (no other caller passes `format`, so existing
+behaviour is untouched). The bridge symbol is declared **weak** in the agent layer,
+so a delegate/lean binary links cleanly and simply skips capture. The next turn's
+per-doc overlap (above) then attributes `ranker_outcome` — closing the ranker loop.
+
+**Validation-pending (stated in these words):** the capture fires inside the
+agentic tool loop, which has no unit test here — the compile/link and each helper
+are verified, but the live attribution is unverified until observed on real traffic
+via `aimee kb ranker export-view`. It is default-off and observation-only, so a
+misfire cannot affect an answer.
+
 ### Remaining open work
 
-1. **Ranker (`kb_search`) capture hook.** Note `ranker` outcomes when the agent uses
-   `kb_search` in a turn. Prerequisite found: the `kb_search` **tool returns a
-   rendered text blob**, not structured ids — so the search response must first
-   expose `docs:[{id, snippet}]`. Then note them (scoped to in-turn tool use —
-   `kb.search` is also CLI/API-callable outside a turn, where no next-turn autolabel
-   follows). With that, per-doc overlap (above) lights up `ranker_outcome`.
-2. **IPW propensity logging.** Log the surfacing propensity (reuse the bandit's
+1. **IPW propensity logging.** Log the surfacing propensity (reuse the bandit's
    `db2_bandit_decision_insert` pattern) and populate the outcome `weight` with
    `1/propensity`; the fitter already consumes it.
-3. **Explicit harness/eval feedback** — highest fidelity, for benchmark runs.
+2. **Explicit harness/eval feedback** — highest fidelity, for benchmark runs.
 
 ## Non-goals
 

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -818,6 +818,12 @@ int kb_client_evidence_emit_retrieval_event_ex(const char *turn_id, const char *
 int kb_client_record_retrieval_outcome(const char *surface, const char *event_id,
                                        const int64_t *ids, int n, const char *verdict);
 
+/* Mint a kb_hybrid retrieval_event over the surfaced doc_ids (ranker.emit_event)
+ * and return its id in event_id_out. Used by the kb_search tool-capture to give
+ * the outcome bridge an event to attribute against. 0 on success, -1 on error. */
+int kb_client_ranker_emit_event(const int64_t *doc_ids, int n, const char *query_fingerprint,
+                                char *event_id_out, size_t event_id_len);
+
 /* Auditable-correctness P1.5: merge typed code/doc refs into the turn's event via
  * the KB evidence.merge_retrieval_event action (the idempotent two-writer upsert).
  * `types`/`refs`/`versions` are parallel arrays of length `n` (entries with an

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1126,6 +1126,18 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          return 503;
       }
 
+      /* format=json returns the structured results verbatim (doc_id-keyed) rather
+       * than the file_path-keyed `hits` projection. No existing caller passes
+       * format; the learning-to-rank outcome capture uses it to recover doc_ids. */
+      char search_format[16] = "";
+      json_str(body, "format", search_format, sizeof(search_format));
+      if (strcmp(search_format, "json") == 0)
+      {
+         int n = snprintf(out_buf, (size_t)out_cap, "%s", raw);
+         free(raw);
+         return (n >= 0 && n < out_cap) ? 200 : 500;
+      }
+
       char used_mode[64] = "rrf";
       json_str(raw, "fusion_mode", used_mode, sizeof(used_mode));
 

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1126,18 +1126,6 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          return 503;
       }
 
-      /* format=json returns the structured results verbatim (doc_id-keyed) rather
-       * than the file_path-keyed `hits` projection. No existing caller passes
-       * format; the learning-to-rank outcome capture uses it to recover doc_ids. */
-      char search_format[16] = "";
-      json_str(body, "format", search_format, sizeof(search_format));
-      if (strcmp(search_format, "json") == 0)
-      {
-         int n = snprintf(out_buf, (size_t)out_cap, "%s", raw);
-         free(raw);
-         return (n >= 0 && n < out_cap) ? 200 : 500;
-      }
-
       char used_mode[64] = "rrf";
       json_str(raw, "fusion_mode", used_mode, sizeof(used_mode));
 
@@ -1213,13 +1201,30 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
                score_s[i] = '\0';
             }
 
+            /* doc_id keys the row to its feature_rows for the learning-to-rank
+             * outcome capture; additive, existing consumers ignore it. */
+            char doc_id_s[32] = "0";
+            const char *di = strstr(rp, "\"doc_id\":");
+            if (di && di < obj_end)
+            {
+               di += 9;
+               while (*di == ' ')
+                  di++;
+               size_t i = 0;
+               while (i < sizeof(doc_id_s) - 1 && ((*di >= '0' && *di <= '9') || *di == '-'))
+                  doc_id_s[i++] = *di++;
+               doc_id_s[i] = '\0';
+               if (!doc_id_s[0])
+                  doc_id_s[0] = '0', doc_id_s[1] = '\0';
+            }
+
             if (hit_count > 0)
                out_buf[pos++] = ',';
             pos = js_appendf(out_buf, pos, out_cap, "{\"artifact_id\":\"");
             pos = json_escape(fp, out_buf, pos, out_cap);
             pos = js_appendf(out_buf, pos, out_cap,
-                             "\",\"score\":%s,\"kind\":\"doc_chunk\",\"excerpt\":\"",
-                             score_s[0] ? score_s : "0.0");
+                             "\",\"score\":%s,\"doc_id\":%s,\"kind\":\"doc_chunk\",\"excerpt\":\"",
+                             score_s[0] ? score_s : "0.0", doc_id_s);
             pos = json_escape(content, out_buf, pos, out_cap);
             pos = js_appendf(out_buf, pos, out_cap, "\",\"citations\":[]}");
             hit_count++;

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -1891,6 +1891,11 @@ char *kb_search_json(const char *project, const char *query, const char *embeddi
       dstr_append_str(&out, "\",\"score\":");
       snprintf(num, sizeof(num), "%.6f", merged[i].score);
       dstr_append_str(&out, num);
+      /* doc_id keys the row to its feature_rows — needed by the learning-to-rank
+       * outcome capture (the file_path-keyed http `hits` shape lacks it). */
+      dstr_append_str(&out, ",\"doc_id\":");
+      snprintf(num, sizeof(num), "%lld", (long long)merged[i].doc_id);
+      dstr_append_str(&out, num);
       dstr_append_str(&out, "}");
    }
    dstr_append_str(&out, "]}");
@@ -1964,6 +1969,11 @@ char *kb_search_json_ex(const char *project, const char *query, const char *embe
       kb_json_append_escaped(&out, merged[i].content);
       dstr_append_str(&out, "\",\"score\":");
       snprintf(num, sizeof(num), "%.6f", merged[i].score);
+      dstr_append_str(&out, num);
+      /* doc_id keys the row to its feature_rows — needed by the learning-to-rank
+       * outcome capture (the file_path-keyed http `hits` shape lacks it). */
+      dstr_append_str(&out, ",\"doc_id\":");
+      snprintf(num, sizeof(num), "%lld", (long long)merged[i].doc_id);
       dstr_append_str(&out, num);
       dstr_append_str(&out, "}");
    }

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -1342,6 +1342,59 @@ static char *td_diagnose_status(cJSON *args, const char *name, const char *dispa
    return result;
 }
 
+/* The retrieval-outcome bridge lives in the server layer; declare it weak so the
+ * agent-runtime object links cleanly into binaries that do not include it (a
+ * delegate/lean build simply skips capture). See retrieval_outcome_bridge.h. */
+extern void retrieval_outcome_bridge_note(const char *surface, const char *event_id,
+                                          const int64_t *ids, const char *const *snippets, int n)
+    __attribute__((weak));
+
+/* Learning-to-rank outcome capture (default-off behind learning_implicit_retrieval_outcome):
+ * when the agent uses kb_search in a turn, record the surfaced doc_ids + snippets so the
+ * NEXT turn's continuation/repair autolabel can attribute a per-doc ranker outcome. Uses a
+ * separate structured (format=json) fetch so the agent-facing text result is unchanged; the
+ * extra fetch only happens when the flag is on. No-op unless the bridge is linked (server). */
+static void td_kb_search_capture_outcome(const config_t *cfg, const char *query, int max,
+                                         const char *result)
+{
+   if (!cfg->learning_implicit_retrieval_outcome || !retrieval_outcome_bridge_note)
+      return;
+   if (!query || !query[0] || !result || strncmp(result, "error:", 6) == 0)
+      return;
+
+   char *sj = kb_client_search_json(NULL, query, config_embedding_command(cfg, NULL), max, "json");
+   cJSON *sr = sj ? cJSON_Parse(sj) : NULL;
+   free(sj);
+   cJSON *results = sr ? cJSON_GetObjectItemCaseSensitive(sr, "results") : NULL;
+   if (cJSON_IsArray(results))
+   {
+      int64_t ids[8];
+      const char *snips[8]; /* point into sr; valid until cJSON_Delete(sr) below */
+      int cn = 0;
+      cJSON *r;
+      cJSON_ArrayForEach(r, results)
+      {
+         if (cn >= (int)(sizeof(ids) / sizeof(ids[0])))
+            break;
+         cJSON *did = cJSON_GetObjectItemCaseSensitive(r, "doc_id");
+         cJSON *content = cJSON_GetObjectItemCaseSensitive(r, "content");
+         if (cJSON_IsNumber(did) && did->valuedouble > 0)
+         {
+            ids[cn] = (int64_t)did->valuedouble;
+            snips[cn] = cJSON_IsString(content) ? content->valuestring : "";
+            cn++;
+         }
+      }
+      if (cn > 0)
+      {
+         char ev[64] = "";
+         if (kb_client_ranker_emit_event(ids, cn, NULL, ev, sizeof(ev)) == 0 && ev[0])
+            retrieval_outcome_bridge_note("ranker", ev, ids, snips, cn);
+      }
+   }
+   cJSON_Delete(sr);
+}
+
 static char *td_search_docs(cJSON *args, const char *name, const char *dispatch_cwd,
                             const char *dispatch_sid, int timeout_ms)
 {
@@ -1369,6 +1422,8 @@ static char *td_search_docs(cJSON *args, const char *name, const char *dispatch_
       else
          result = safe_strdup("error: knowledge search unavailable");
       cJSON_Delete(resp);
+
+      td_kb_search_capture_outcome(&cfg, q->valuestring, max, result);
    }
 
    return result;

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -1351,9 +1351,9 @@ extern void retrieval_outcome_bridge_note(const char *surface, const char *event
 
 /* Learning-to-rank outcome capture (default-off behind learning_implicit_retrieval_outcome):
  * when the agent uses kb_search in a turn, record the surfaced doc_ids + snippets so the
- * NEXT turn's continuation/repair autolabel can attribute a per-doc ranker outcome. Uses a
- * separate structured (format=json) fetch so the agent-facing text result is unchanged; the
- * extra fetch only happens when the flag is on. No-op unless the bridge is linked (server). */
+ * NEXT turn's continuation/repair autolabel can attribute a per-doc ranker outcome. The
+ * agent-facing text result is unchanged; the extra structured fetch only happens when the
+ * flag is on. No-op unless the bridge is linked (server binary). */
 static void td_kb_search_capture_outcome(const config_t *cfg, const char *query, int max,
                                          const char *result)
 {
@@ -1362,26 +1362,28 @@ static void td_kb_search_capture_outcome(const config_t *cfg, const char *query,
    if (!query || !query[0] || !result || strncmp(result, "error:", 6) == 0)
       return;
 
-   char *sj = kb_client_search_json(NULL, query, config_embedding_command(cfg, NULL), max, "json");
+   /* /v1/search returns {"hits":[{artifact_id,score,doc_id,excerpt,...}]}. doc_id
+    * keys each hit to its feature_rows; excerpt is the snippet for overlap. */
+   char *sj = kb_client_search_json(NULL, query, config_embedding_command(cfg, NULL), max, NULL);
    cJSON *sr = sj ? cJSON_Parse(sj) : NULL;
    free(sj);
-   cJSON *results = sr ? cJSON_GetObjectItemCaseSensitive(sr, "results") : NULL;
-   if (cJSON_IsArray(results))
+   cJSON *hits = sr ? cJSON_GetObjectItemCaseSensitive(sr, "hits") : NULL;
+   if (cJSON_IsArray(hits))
    {
       int64_t ids[8];
       const char *snips[8]; /* point into sr; valid until cJSON_Delete(sr) below */
       int cn = 0;
-      cJSON *r;
-      cJSON_ArrayForEach(r, results)
+      cJSON *h;
+      cJSON_ArrayForEach(h, hits)
       {
          if (cn >= (int)(sizeof(ids) / sizeof(ids[0])))
             break;
-         cJSON *did = cJSON_GetObjectItemCaseSensitive(r, "doc_id");
-         cJSON *content = cJSON_GetObjectItemCaseSensitive(r, "content");
+         cJSON *did = cJSON_GetObjectItemCaseSensitive(h, "doc_id");
+         cJSON *excerpt = cJSON_GetObjectItemCaseSensitive(h, "excerpt");
          if (cJSON_IsNumber(did) && did->valuedouble > 0)
          {
             ids[cn] = (int64_t)did->valuedouble;
-            snips[cn] = cJSON_IsString(content) ? content->valuestring : "";
+            snips[cn] = cJSON_IsString(excerpt) ? excerpt->valuestring : "";
             cn++;
          }
       }

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -1744,6 +1744,34 @@ int kb_client_record_retrieval_outcome(const char *surface, const char *event_id
    return ok ? 0 : -1;
 }
 
+int kb_client_ranker_emit_event(const int64_t *doc_ids, int n, const char *query_fingerprint,
+                                char *event_id_out, size_t event_id_len)
+{
+   if (event_id_out && event_id_len > 0)
+      event_id_out[0] = '\0';
+   if (!doc_ids || n <= 0)
+      return -1;
+   cJSON *req = cJSON_CreateObject();
+   if (query_fingerprint && query_fingerprint[0])
+      cJSON_AddStringToObject(req, "query_fingerprint", query_fingerprint);
+   cJSON *arr = cJSON_AddArrayToObject(req, "doc_ids");
+   for (int i = 0; arr && i < n; i++)
+      cJSON_AddItemToArray(arr, cJSON_CreateNumber((double)doc_ids[i]));
+   char *json = kb_v1_action_request("ranker.emit_event", req);
+   if (!json)
+      return -1;
+   cJSON *resp = cJSON_Parse(json);
+   free(json);
+   if (!resp)
+      return -1;
+   cJSON *ev = cJSON_GetObjectItemCaseSensitive(resp, "retrieval_event_id");
+   int ok = cJSON_IsString(ev) && ev->valuestring[0];
+   if (ok && event_id_out && event_id_len > 0)
+      snprintf(event_id_out, event_id_len, "%s", ev->valuestring);
+   cJSON_Delete(resp);
+   return ok ? 0 : -1;
+}
+
 int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,
                                              const char *query_fingerprint,
                                              const char *const *types, const char *const *refs,


### PR DESCRIPTION
The **last hop** of the learning-to-rank loop. When the agent uses `kb_search` in a turn, record the surfaced docs so the next turn's continuation/repair autolabel (+ per-doc overlap, #1199) attributes `ranker_outcome` — which the fitter (#1178) trains on and the benchmark gate promotes from.

## Two substrate facts found + fixed
- **`kb_search_json` now emits `doc_id`** per result. The `/v1/search` http projection is **file_path-keyed** (`artifact_id` = file_path) and lacked it — so nothing downstream could join to the ranker's doc_id-keyed `feature_rows`.
- **`/v1/search` honours `format=json`** — returns the structured `results` verbatim (doc_id-keyed). No existing caller passes `format`, so behaviour is unchanged.

## Capture (default-off behind `learning_implicit_retrieval_outcome`)
- **`kb_client_ranker_emit_event`** → the existing `ranker.emit_event` method mints the kb_hybrid event.
- **`agent_tools_dispatch`**: on a successful *in-turn* `kb_search`, a structured `format=json` fetch recovers doc_ids + snippets, emits the event, and notes the ranker surface. The extra fetch only happens when the flag is on.
- The bridge symbol is declared **weak** in the agent layer, so a delegate/lean binary links cleanly and skips capture (mirrors `agent_tools.c`).

## Validation-pending (stated plainly)
The capture fires inside the **agentic tool loop**, which has no unit test here. Verified: clean compile/link (both binaries), the `format=json` path, the emit proxy, and the bridge note (unit-tested in #1199). **Unverified until observed on live traffic** via `aimee kb ranker export-view`. It is **default-off + observation-only**, so a misfire cannot affect an answer.

Full unit-test suite + `make lint` green. This completes the loop end-to-end: search → capture → outcome → training view → fit → benchmark gate → promote.