### PR TITLE
fix(workflow): roundtable panel reviews the shared repo when no worktree is set

### DIFF
--- a/src/tests/test_wfe_roundtable.c
+++ b/src/tests/test_wfe_roundtable.c
@@ -31,6 +31,7 @@ static int g_mode; /* 0=approve all required, 1=request changes, 2=unreachable *
 /* last review packet the panel saw (S1: proposal + focus reach the panel) */
 static char g_seen_proposal[512];
 static char g_seen_focus[128];
+static char g_seen_workdir[512];
 static int mock_panel(const wfe_review_packet_t *pkt, const char *const *required, int nreq,
                       const char *const *eligible, int nelig, wfe_verdict_t *out, int max)
 {
@@ -38,6 +39,7 @@ static int mock_panel(const wfe_review_packet_t *pkt, const char *const *require
    (void)nelig;
    snprintf(g_seen_proposal, sizeof g_seen_proposal, "%s", pkt->proposal);
    snprintf(g_seen_focus, sizeof g_seen_focus, "%s", pkt->focus);
+   snprintf(g_seen_workdir, sizeof g_seen_workdir, "%s", pkt->workdir);
    if (g_mode == 2)
       return -1;
    int n = 0;
@@ -166,7 +168,11 @@ int main(void)
       const char *PTEXT = "PROPOSAL: add a widget with tests.";
       assert(write(fd, PTEXT, strlen(PTEXT)) == (ssize_t)strlen(PTEXT));
       close(fd);
-      g_seen_proposal[0] = g_seen_focus[0] = '\0';
+      g_seen_proposal[0] = g_seen_focus[0] = g_seen_workdir[0] = '\0';
+      /* No per-item worktree is set on this run; the panel must still get a workdir to
+       * review in — the shared repo (AIMEE_WORKFLOW_REPO) — never an empty string that
+       * would make a live panel park panel_unreachable (the .253 live-run regression). */
+      setenv("AIMEE_WORKFLOW_REPO", "/tmp", 1);
       char id[80] = "", err[256] = "";
       assert(wfe_work_item_create("rt", "r0", pp, "interactive", id, err, sizeof err) == 0);
       assert(wfe_engine_run(id, err, sizeof err) == 0);
@@ -175,6 +181,8 @@ int main(void)
       assert(strcmp(wi.state, "accepted") == 0);
       assert(strcmp(g_seen_proposal, PTEXT) == 0); /* proposal reached the panel */
       assert(strcmp(g_seen_focus, "completion and missing tests") == 0); /* focus lens too */
+      assert(strcmp(g_seen_workdir, "/tmp") == 0); /* worktree empty -> repo-dir fallback */
+      unsetenv("AIMEE_WORKFLOW_REPO");
       unlink(pp);
    }
 

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -114,13 +114,21 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
    char *proposal = read_text_capped(wfe_ctx_proposal_path(ctx), WFE_PROPOSAL_MAX);
    const cJSON *focus_j =
        node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "focus") : NULL;
+   /* The directory the panel reviews the change in: the per-work-item worktree, or —
+    * when worktree isolation is unavailable and a run fell back to the shared checkout
+    * (wfe_worktree_ensure failed) — that shared repo dir. Mirrors the producing blocks'
+    * resolve_workdir fallback (AIMEE_WORKFLOW_REPO, else "."), so the panel can always
+    * convene rather than fail closed to panel_unreachable when the worktree is empty. */
    const char *worktree = wfe_ctx_worktree(ctx);
+   const char *workdir = (worktree && worktree[0]) ? worktree : getenv("AIMEE_WORKFLOW_REPO");
+   if (!workdir || !workdir[0])
+      workdir = ".";
    wfe_review_packet_t pkt = {
        .artifact_hash = artifact_hash,
        .proposal = proposal ? proposal : "",
        .focus =
            (focus_j && cJSON_IsString(focus_j) && focus_j->valuestring) ? focus_j->valuestring : "",
-       .workdir = worktree ? worktree : "",
+       .workdir = workdir,
    };
 
    wfe_verdict_t verdicts[WFE_PANEL_MAX];


### PR DESCRIPTION
## Fix: roundtable panel bricks when a run has no per-item worktree

Found by a **live run on a real host** (part of validating #1200): the run parked at
a `gate.roundtable` node with `panel_unreachable` and **zero reviews dispatched**.

**Root cause.** `exec_roundtable` set the review packet's `workdir` to only
`wfe_ctx_worktree(ctx)`. That field is empty whenever per-item worktree isolation
falls back to the shared checkout (`wfe_worktree_ensure` failed — e.g. the base branch
didn't exist). The live panel provider fail-closes to `-1` (panel_unreachable) on an
empty workdir, so the gate could never convene → permanent park. The unit tests always
set a worktree, so they never exercised the fallback path.

**Fix.** Resolve the *effective* workdir the same way the producing blocks do
(`resolve_workdir`): the worktree if set, else the run's repo working dir
(`AIMEE_WORKFLOW_REPO`, else `.`). The panel now always has a directory to review in.

Regression-tested in `test_wfe_roundtable`: with no worktree, the panel packet gets the
repo-dir workdir (not `""`). Full `wfe` suite + `make lint` green.
