### PR TITLE
fix(agent): repair kb_search tool + fire LTR capture from one search

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -255,7 +255,7 @@ else ifeq ($(UNAME_S),Darwin)
         posix/agent_shell_claude.c posix/agent_shell_claude_pty.c posix/agent_shell_codex.c posix/agent_shell_gemini.c \
         $(UI_PLATFORM_SRCS)
     PLATFORM_AGENT_SRCS = \
-        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/sandbox.c
+        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
 else
     PLATFORM_BASIC_SRCS = \
         posix/platform_ipc.c posix/platform_path.c posix/platform_process.c \
@@ -271,7 +271,7 @@ else
         posix/agent_shell_claude.c posix/agent_shell_claude_pty.c posix/agent_shell_codex.c posix/agent_shell_gemini.c \
         $(UI_PLATFORM_SRCS)
     PLATFORM_AGENT_SRCS = \
-        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/sandbox.c
+        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
 endif
 
 PLATFORM_SRCS       = $(PLATFORM_BASIC_SRCS) $(PLATFORM_EXTRA_SRCS) $(PLATFORM_AGENT_SRCS)

--- a/src/headers/td_search_render.h
+++ b/src/headers/td_search_render.h
@@ -1,0 +1,20 @@
+/* td_search_render.h: render the /v1/search {"hits":[...]} shape into the text
+ * result the kb_search tool returns, and extract (doc_id, excerpt) pairs for the
+ * learning-to-rank outcome capture. Pure (cJSON + dstr only) so both are unit
+ * tested independently of the agent tool loop. */
+#ifndef DEC_TD_SEARCH_RENDER_H
+#define DEC_TD_SEARCH_RENDER_H 1
+
+#include "cJSON.h"
+#include <stdint.h>
+
+/* Render a /v1/search hits array into a concise text block for the tool result.
+ * Returns a malloc'd string (caller frees), or NULL on OOM. A NULL/empty/non-array
+ * `hits` yields a "no results" line rather than an error. */
+char *td_render_search_hits(const cJSON *hits, const char *query);
+
+/* Extract up to `max` (doc_id, excerpt) pairs from `hits` into ids[]/snips[].
+ * snips[] point INTO the hits cJSON (valid until it is freed). Returns the count. */
+int td_extract_hit_docs(const cJSON *hits, int64_t *ids, const char **snips, int max);
+
+#endif /* DEC_TD_SEARCH_RENDER_H */

--- a/src/headers/td_search_render.h
+++ b/src/headers/td_search_render.h
@@ -17,4 +17,14 @@ char *td_render_search_hits(const cJSON *hits, const char *query);
  * snips[] point INTO the hits cJSON (valid until it is freed). Returns the count. */
 int td_extract_hit_docs(const cJSON *hits, int64_t *ids, const char **snips, int max);
 
+/* Select the kb_search tool's text result from a parsed /v1/search response:
+ *   - a legacy {"result":"<text>"} string, if one is present (back-compat), else
+ *   - the rendered {"hits":[...]} array, else
+ *   - an "error: knowledge search unavailable" line.
+ * Returns a malloc'd string (caller frees), or NULL on OOM. This is the exact
+ * result-vs-hits selection whose earlier breakage (reading {result} off the
+ * {hits}-only endpoint) silently disabled the tool — so it is unit tested, and
+ * driven with the real handler output by the contract test. */
+char *td_search_result_from_response(const cJSON *resp, const char *query);
+
 #endif /* DEC_TD_SEARCH_RENDER_H */

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -1370,19 +1370,12 @@ static char *td_search_docs(cJSON *args, const char *name, const char *dispatch_
       cJSON *resp = envelope ? cJSON_Parse(envelope) : NULL;
       free(envelope);
 
-      /* /v1/search returns {"hits":[{artifact_id,score,doc_id,excerpt,...}]}. A
-       * refactor that moved kb_search() onto this http path left the tool
-       * unwrapping a legacy {"result":"<text>"} that the endpoint no longer sends
-       * — so it errored on every call. Honour {result} if a variant still returns
-       * it, else render the hits into the tool's text result. */
-      cJSON *legacy = resp ? cJSON_GetObjectItemCaseSensitive(resp, "result") : NULL;
+      /* Text result: legacy {result} for back-compat, else the rendered {hits},
+       * else an error line. Extracted into td_search_result_from_response so the
+       * exact result-vs-hits selection that once silently broke the tool is unit
+       * tested (see td_search_render). */
+      result = td_search_result_from_response(resp, q->valuestring);
       cJSON *hits = resp ? cJSON_GetObjectItemCaseSensitive(resp, "hits") : NULL;
-      if (cJSON_IsString(legacy) && legacy->valuestring[0])
-         result = safe_strdup(legacy->valuestring);
-      else if (cJSON_IsArray(hits))
-         result = td_render_search_hits(hits, q->valuestring);
-      else
-         result = safe_strdup("error: knowledge search unavailable");
 
       /* Learning-to-rank outcome capture (default-off): from the SAME hits — no
        * second search. Records the surfaced doc_ids + snippets so the next turn's

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -62,6 +62,7 @@ int db1_session_write_path_record(const char *session_id, const char *path);
 #include "web_search.h"
 #include "notes.h"
 #include "kb.h"
+#include "td_search_render.h"
 #include "mcp_client_registry.h"
 #include "lifecycle.h"
 #include "workspace.h"
@@ -1349,54 +1350,6 @@ extern void retrieval_outcome_bridge_note(const char *surface, const char *event
                                           const int64_t *ids, const char *const *snippets, int n)
     __attribute__((weak));
 
-/* Learning-to-rank outcome capture (default-off behind learning_implicit_retrieval_outcome):
- * when the agent uses kb_search in a turn, record the surfaced doc_ids + snippets so the
- * NEXT turn's continuation/repair autolabel can attribute a per-doc ranker outcome. The
- * agent-facing text result is unchanged; the extra structured fetch only happens when the
- * flag is on. No-op unless the bridge is linked (server binary). */
-static void td_kb_search_capture_outcome(const config_t *cfg, const char *query, int max,
-                                         const char *result)
-{
-   if (!cfg->learning_implicit_retrieval_outcome || !retrieval_outcome_bridge_note)
-      return;
-   if (!query || !query[0] || !result || strncmp(result, "error:", 6) == 0)
-      return;
-
-   /* /v1/search returns {"hits":[{artifact_id,score,doc_id,excerpt,...}]}. doc_id
-    * keys each hit to its feature_rows; excerpt is the snippet for overlap. */
-   char *sj = kb_client_search_json(NULL, query, config_embedding_command(cfg, NULL), max, NULL);
-   cJSON *sr = sj ? cJSON_Parse(sj) : NULL;
-   free(sj);
-   cJSON *hits = sr ? cJSON_GetObjectItemCaseSensitive(sr, "hits") : NULL;
-   if (cJSON_IsArray(hits))
-   {
-      int64_t ids[8];
-      const char *snips[8]; /* point into sr; valid until cJSON_Delete(sr) below */
-      int cn = 0;
-      cJSON *h;
-      cJSON_ArrayForEach(h, hits)
-      {
-         if (cn >= (int)(sizeof(ids) / sizeof(ids[0])))
-            break;
-         cJSON *did = cJSON_GetObjectItemCaseSensitive(h, "doc_id");
-         cJSON *excerpt = cJSON_GetObjectItemCaseSensitive(h, "excerpt");
-         if (cJSON_IsNumber(did) && did->valuedouble > 0)
-         {
-            ids[cn] = (int64_t)did->valuedouble;
-            snips[cn] = cJSON_IsString(excerpt) ? excerpt->valuestring : "";
-            cn++;
-         }
-      }
-      if (cn > 0)
-      {
-         char ev[64] = "";
-         if (kb_client_ranker_emit_event(ids, cn, NULL, ev, sizeof(ev)) == 0 && ev[0])
-            retrieval_outcome_bridge_note("ranker", ev, ids, snips, cn);
-      }
-   }
-   cJSON_Delete(sr);
-}
-
 static char *td_search_docs(cJSON *args, const char *name, const char *dispatch_cwd,
                             const char *dispatch_sid, int timeout_ms)
 {
@@ -1414,18 +1367,42 @@ static char *td_search_docs(cJSON *args, const char *name, const char *dispatch_
       int max = (mx && cJSON_IsNumber(mx)) ? mx->valueint : 3;
       char *envelope = kb_client_search_json(NULL, q->valuestring,
                                              config_embedding_command(&cfg, NULL), max, NULL);
-      /* The knowledge service returns {"status":"ok","result":"<text>"}; unwrap so the
-       * tool sees the same body shape kb_search() used to return. */
       cJSON *resp = envelope ? cJSON_Parse(envelope) : NULL;
       free(envelope);
-      cJSON *body = resp ? cJSON_GetObjectItemCaseSensitive(resp, "result") : NULL;
-      if (cJSON_IsString(body) && body->valuestring[0])
-         result = safe_strdup(body->valuestring);
+
+      /* /v1/search returns {"hits":[{artifact_id,score,doc_id,excerpt,...}]}. A
+       * refactor that moved kb_search() onto this http path left the tool
+       * unwrapping a legacy {"result":"<text>"} that the endpoint no longer sends
+       * — so it errored on every call. Honour {result} if a variant still returns
+       * it, else render the hits into the tool's text result. */
+      cJSON *legacy = resp ? cJSON_GetObjectItemCaseSensitive(resp, "result") : NULL;
+      cJSON *hits = resp ? cJSON_GetObjectItemCaseSensitive(resp, "hits") : NULL;
+      if (cJSON_IsString(legacy) && legacy->valuestring[0])
+         result = safe_strdup(legacy->valuestring);
+      else if (cJSON_IsArray(hits))
+         result = td_render_search_hits(hits, q->valuestring);
       else
          result = safe_strdup("error: knowledge search unavailable");
-      cJSON_Delete(resp);
 
-      td_kb_search_capture_outcome(&cfg, q->valuestring, max, result);
+      /* Learning-to-rank outcome capture (default-off): from the SAME hits — no
+       * second search. Records the surfaced doc_ids + snippets so the next turn's
+       * continuation/repair autolabel attributes a per-doc ranker outcome. The
+       * bridge symbol is weak, so a delegate/lean binary simply skips this. */
+      if (cfg.learning_implicit_retrieval_outcome && retrieval_outcome_bridge_note &&
+          cJSON_IsArray(hits))
+      {
+         int64_t ids[8];
+         const char *snips[8]; /* point into resp; copied by _note before free */
+         int cn = td_extract_hit_docs(hits, ids, snips, (int)(sizeof(ids) / sizeof(ids[0])));
+         if (cn > 0)
+         {
+            char ev[64] = "";
+            if (kb_client_ranker_emit_event(ids, cn, NULL, ev, sizeof(ev)) == 0 && ev[0])
+               retrieval_outcome_bridge_note("ranker", ev, ids, snips, cn);
+         }
+      }
+
+      cJSON_Delete(resp);
    }
 
    return result;

--- a/src/posix/td_search_render.c
+++ b/src/posix/td_search_render.c
@@ -1,0 +1,66 @@
+/* td_search_render.c: see td_search_render.h. */
+#include "td_search_render.h"
+#include "dstr.h"
+
+#include <stdio.h>
+#include <string.h>
+
+char *td_render_search_hits(const cJSON *hits, const char *query)
+{
+   dstr_t d;
+   dstr_init(&d);
+
+   int n = cJSON_IsArray(hits) ? cJSON_GetArraySize(hits) : 0;
+   if (n <= 0)
+   {
+      dstr_appendf(&d, "No knowledge-base results for \"%s\".", query ? query : "");
+      return dstr_steal(&d);
+   }
+
+   dstr_appendf(&d, "Knowledge-base results for \"%s\" (%d):\n", query ? query : "", n);
+   int i = 0;
+   const cJSON *h;
+   cJSON_ArrayForEach(h, hits)
+   {
+      i++;
+      const cJSON *aid = cJSON_GetObjectItemCaseSensitive(h, "artifact_id");
+      const cJSON *sc = cJSON_GetObjectItemCaseSensitive(h, "score");
+      const cJSON *ex = cJSON_GetObjectItemCaseSensitive(h, "excerpt");
+      dstr_appendf(&d, "%d. %s", i,
+                   (cJSON_IsString(aid) && aid->valuestring[0]) ? aid->valuestring : "(unknown)");
+      if (cJSON_IsNumber(sc))
+         dstr_appendf(&d, " (score %.3f)", sc->valuedouble);
+      dstr_append_str(&d, "\n");
+      if (cJSON_IsString(ex) && ex->valuestring[0])
+      {
+         char buf[321];
+         snprintf(buf, sizeof(buf), "%.320s", ex->valuestring);
+         dstr_append_str(&d, "   ");
+         dstr_append_str(&d, buf);
+         dstr_append_str(&d, "\n");
+      }
+   }
+   return dstr_steal(&d);
+}
+
+int td_extract_hit_docs(const cJSON *hits, int64_t *ids, const char **snips, int max)
+{
+   if (!cJSON_IsArray(hits) || !ids || !snips || max <= 0)
+      return 0;
+   int cn = 0;
+   const cJSON *h;
+   cJSON_ArrayForEach(h, hits)
+   {
+      if (cn >= max)
+         break;
+      const cJSON *did = cJSON_GetObjectItemCaseSensitive(h, "doc_id");
+      const cJSON *ex = cJSON_GetObjectItemCaseSensitive(h, "excerpt");
+      if (cJSON_IsNumber(did) && did->valuedouble > 0)
+      {
+         ids[cn] = (int64_t)did->valuedouble;
+         snips[cn] = cJSON_IsString(ex) ? ex->valuestring : "";
+         cn++;
+      }
+   }
+   return cn;
+}

--- a/src/posix/td_search_render.c
+++ b/src/posix/td_search_render.c
@@ -3,6 +3,7 @@
 #include "dstr.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 char *td_render_search_hits(const cJSON *hits, const char *query)
@@ -63,4 +64,32 @@ int td_extract_hit_docs(const cJSON *hits, int64_t *ids, const char **snips, int
       }
    }
    return cn;
+}
+
+char *td_search_result_from_response(const cJSON *resp, const char *query)
+{
+   /* /v1/search returns {"hits":[{artifact_id,score,doc_id,excerpt,...}]}. A
+    * refactor that moved kb_search() onto this http path left the tool
+    * unwrapping a legacy {"result":"<text>"} that the endpoint no longer sends —
+    * so it errored on every call. Honour {result} if some variant still returns
+    * it, else render the hits; only a response with neither is a real error. */
+   const cJSON *legacy = resp ? cJSON_GetObjectItemCaseSensitive(resp, "result") : NULL;
+   const cJSON *hits = resp ? cJSON_GetObjectItemCaseSensitive(resp, "hits") : NULL;
+   if (cJSON_IsString(legacy) && legacy->valuestring[0])
+   {
+      size_t n = strlen(legacy->valuestring) + 1;
+      char *out = malloc(n);
+      if (out)
+         memcpy(out, legacy->valuestring, n);
+      return out;
+   }
+   if (cJSON_IsArray(hits))
+      return td_render_search_hits(hits, query);
+
+   const char *err = "error: knowledge search unavailable";
+   size_t n = strlen(err) + 1;
+   char *out = malloc(n);
+   if (out)
+      memcpy(out, err, n);
+   return out;
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -411,6 +411,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-features \
                $(TESTPREFIX)/unit-test-ranker-fit \
                $(TESTPREFIX)/unit-test-retrieval-outcome-bridge \
+               $(TESTPREFIX)/unit-test-td-search-render \
                $(TESTPREFIX)/unit-test-report-enrichments \
                $(TESTPREFIX)/unit-test-reasoning \
                $(TESTPREFIX)/unit-test-bandit \
@@ -3900,6 +3901,12 @@ $(TESTPREFIX)/unit-test-ranker-fit: $(OBJDIR)/tests/test_ranker_fit.o \
 # DB/network objects are needed — just the bridge TU.
 $(TESTPREFIX)/unit-test-retrieval-outcome-bridge: $(OBJDIR)/tests/test_retrieval_outcome_bridge.o \
                      $(OBJDIR)/server/retrieval_outcome_bridge.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Pure render/extract helpers behind the kb_search tool — cJSON + dstr only.
+$(TESTPREFIX)/unit-test-td-search-render: $(OBJDIR)/tests/test_td_search_render.o \
+                     $(OBJDIR)/posix/td_search_render.o \
+                     $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-report-enrichments: $(OBJDIR)/tests/test_report_enrichments.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3714,6 +3714,7 @@ $(TESTPREFIX)/unit-test-kb-http-routes: $(OBJDIR)/tests/test_kb_http_routes.o \
                      $(OBJDIR)/kb/prompt_sanitizer.o \
                      $(OBJDIR)/kb/http/kb_http_pdf.o \
                      $(OBJDIR)/kb/http/kb_http_jobs.o \
+                     $(OBJDIR)/posix/td_search_render.o $(OBJDIR)/dstr.o \
                      $(OBJDIR)/cJSON.o \
                      $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "cJSON.h"
 #include "kb_http.h"
+#include "td_search_render.h"       /* consumer side of the /v1/search contract test */
 #include "kb/kb_surprising_judge.h" /* §4 judge stub seam (kb_surprising_verdict_t) */
 #include "db2/lifecycle.h"          /* §2c: db2_reembed_* / db2_dim_change_reset stub types */
 #include "rel_types.h"              /* REL_TYPE_NAME_MAX for the db2_ontology_* stubs below */
@@ -250,6 +251,12 @@ char *kb_service_ingest_status_json(void)
 
 /* ── Phase 5 backend stubs (satisfies extern refs in kb_http.o) ─────────── */
 
+/* When g_test_search_populated is set, the backend stub returns one populated
+ * result row so the /v1/search handler emits a real hit — used by the
+ * producer->consumer contract test. The row shape (file_path/content/score/
+ * doc_id) mirrors what the ranked backend emits and what the handler's reshaper
+ * parses. Default 0 keeps every other test on the empty-results path. */
+static int g_test_search_populated = 0;
 char *kb_search_json_ex(const char *p, const char *q, const char *e, int m, const char *f)
 {
    (void)p;
@@ -257,9 +264,13 @@ char *kb_search_json_ex(const char *p, const char *q, const char *e, int m, cons
    (void)e;
    (void)m;
    (void)f;
-   char *r = malloc(64);
+   const char *src = g_test_search_populated
+                         ? "{\"fusion_mode\":\"rrf\",\"results\":[{\"file_path\":\"docs/alpha.md\","
+                           "\"content\":\"alpha excerpt body\",\"score\":0.875,\"doc_id\":4242}]}"
+                         : "{\"fusion_mode\":\"rrf\",\"results\":[]}";
+   char *r = malloc(strlen(src) + 1);
    if (r)
-      strcpy(r, "{\"fusion_mode\":\"rrf\",\"results\":[]}");
+      strcpy(r, src);
    return r;
 }
 
@@ -3956,6 +3967,59 @@ static void test_search_ok(void)
    assert(strstr(buf, "\"fusion_mode_used\"") != NULL);
 }
 
+/* Producer->consumer contract: the /v1/search ranked handler and the kb_search
+ * agent tool must agree on the response shape. A refactor once left the tool
+ * unwrapping a top-level {"result"} field the endpoint never emits, so every
+ * kb_search call errored and the learning-to-rank capture (which reads doc_id
+ * off each hit) silently went dead. This test drives the REAL handler to emit a
+ * populated hit, then feeds that exact JSON through the REAL tool-side parse
+ * helpers (td_render_search_hits / td_extract_hit_docs). If either side renames
+ * a field or drops doc_id, or the tool reverts to reading {"result"}, it fails.
+ * That is the seam neither the handler test nor the render unit test covered. */
+static void test_search_hits_tool_contract(void)
+{
+   char buf[2048];
+   g_test_search_populated = 1;
+   int s = kb_http_route_ex("POST", "/v1/search", NULL, NULL, NULL, "{\"query\":\"foo\"}", 15, buf,
+                            sizeof(buf));
+   g_test_search_populated = 0;
+   assert(s == 200);
+
+   /* Producer side: the emitted hit carries exactly the fields the tool reads. */
+   cJSON *resp = cJSON_Parse(buf);
+   assert(resp);
+   cJSON *hits = cJSON_GetObjectItemCaseSensitive(resp, "hits");
+   assert(cJSON_IsArray(hits) && cJSON_GetArraySize(hits) == 1);
+   cJSON *h0 = cJSON_GetArrayItem(hits, 0);
+   assert(cJSON_IsString(cJSON_GetObjectItemCaseSensitive(h0, "artifact_id")));
+   assert(cJSON_IsNumber(cJSON_GetObjectItemCaseSensitive(h0, "score")));
+   assert(cJSON_IsNumber(cJSON_GetObjectItemCaseSensitive(h0, "doc_id")));
+   assert(cJSON_IsString(cJSON_GetObjectItemCaseSensitive(h0, "excerpt")));
+
+   /* Consumer side (selection + render): route the WHOLE response through the
+    * tool's real result-selection (td_search_result_from_response) — the exact
+    * function that once read the wrong field and errored. It must return
+    * non-error text naming the artifact and its excerpt. */
+   char *rendered = td_search_result_from_response(resp, "foo");
+   assert(rendered);
+   assert(strncmp(rendered, "error:", 6) != 0);
+   assert(!strstr(rendered, "No knowledge-base results"));
+   assert(strstr(rendered, "docs/alpha.md"));
+   assert(strstr(rendered, "alpha excerpt body"));
+   free(rendered);
+
+   /* Consumer side (capture): the doc_id the handler emitted is the one the LTR
+    * capture attributes, with the matching excerpt as its overlap snippet. */
+   int64_t ids[4];
+   const char *snips[4];
+   int cn = td_extract_hit_docs(hits, ids, snips, 4);
+   assert(cn == 1);
+   assert(ids[0] == 4242);
+   assert(strcmp(snips[0], "alpha excerpt body") == 0);
+
+   cJSON_Delete(resp);
+}
+
 /* §2c: while a dim-change re-embed is in flight the vector store is being
  * rebuilt at the new dim; /v1/search must refuse with 503 (maintenance) rather
  * than serve partial/empty results — and the guard runs before query parsing,
@@ -4171,6 +4235,7 @@ int main(void)
    test_curator_routes();
    test_invalidations_route();
    test_search_ok();
+   test_search_hits_tool_contract();
    test_search_503_while_reembed_in_progress();
    test_reembed_wrong_method();
    test_reembed_disabled_by_default();

--- a/src/tests/test_td_search_render.c
+++ b/src/tests/test_td_search_render.c
@@ -1,0 +1,148 @@
+/* test_td_search_render.c — the pure render/extract helpers behind the kb_search
+ * tool. These turn the /v1/search {"hits":[...]} envelope into (a) the text block
+ * the agent tool returns and (b) the (doc_id, excerpt) pairs the learning-to-rank
+ * outcome capture attributes. No DB, no network — just cJSON in, string/count out.
+ *
+ * Covers:
+ *   1. render: multiple hits -> header + numbered lines with score + excerpt.
+ *   2. render: empty / null / non-array hits -> a "no results" line (never error).
+ *   3. render: missing score / excerpt fields -> line still emitted, no crash.
+ *   4. extract: pulls doc_id + excerpt pairs, honours max, skips id<=0 / non-number.
+ *   5. extract: null args / max<=0 -> 0.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../headers/cJSON.h"
+#include "../headers/td_search_render.h"
+
+static cJSON *hit(const char *aid, double score, int64_t doc_id, const char *excerpt)
+{
+   cJSON *h = cJSON_CreateObject();
+   if (aid)
+      cJSON_AddStringToObject(h, "artifact_id", aid);
+   if (score >= 0)
+      cJSON_AddNumberToObject(h, "score", score);
+   if (doc_id != 0)
+      cJSON_AddNumberToObject(h, "doc_id", (double)doc_id);
+   if (excerpt)
+      cJSON_AddStringToObject(h, "excerpt", excerpt);
+   return h;
+}
+
+static void test_render_multiple(void)
+{
+   cJSON *hits = cJSON_CreateArray();
+   cJSON_AddItemToArray(hits, hit("docs/a.md", 0.912, 11, "alpha snippet"));
+   cJSON_AddItemToArray(hits, hit("docs/b.md", 0.501, 22, "beta snippet"));
+
+   char *s = td_render_search_hits(hits, "how do widgets work");
+   assert(s);
+   assert(strstr(s, "how do widgets work"));
+   assert(strstr(s, "(2)"));
+   assert(strstr(s, "1. docs/a.md"));
+   assert(strstr(s, "(score 0.912)"));
+   assert(strstr(s, "alpha snippet"));
+   assert(strstr(s, "2. docs/b.md"));
+   assert(strstr(s, "beta snippet"));
+   free(s);
+   cJSON_Delete(hits);
+   printf("  ok: render multiple\n");
+}
+
+static void test_render_empty(void)
+{
+   cJSON *empty = cJSON_CreateArray();
+   char *s = td_render_search_hits(empty, "nothing here");
+   assert(s);
+   assert(strstr(s, "No knowledge-base results"));
+   assert(strstr(s, "nothing here"));
+   free(s);
+   cJSON_Delete(empty);
+
+   /* null / non-array must not error — same "no results" contract. */
+   char *sn = td_render_search_hits(NULL, "q");
+   assert(sn && strstr(sn, "No knowledge-base results"));
+   free(sn);
+
+   cJSON *obj = cJSON_CreateObject();
+   char *so = td_render_search_hits(obj, "q");
+   assert(so && strstr(so, "No knowledge-base results"));
+   free(so);
+   cJSON_Delete(obj);
+   printf("  ok: render empty/null/non-array\n");
+}
+
+static void test_render_missing_fields(void)
+{
+   cJSON *hits = cJSON_CreateArray();
+   /* no score, no excerpt, no artifact_id */
+   cJSON_AddItemToArray(hits, hit(NULL, -1, 5, NULL));
+   char *s = td_render_search_hits(hits, "q");
+   assert(s);
+   assert(strstr(s, "1. (unknown)"));
+   assert(!strstr(s, "score")); /* score line omitted when absent */
+   free(s);
+   cJSON_Delete(hits);
+   printf("  ok: render missing fields\n");
+}
+
+static void test_extract(void)
+{
+   cJSON *hits = cJSON_CreateArray();
+   cJSON_AddItemToArray(hits, hit("a", 0.9, 11, "ex-a"));
+   cJSON_AddItemToArray(hits, hit("b", 0.8, 0, "no-doc")); /* doc_id 0 -> skipped */
+   cJSON_AddItemToArray(hits, hit("c", 0.7, 33, NULL));    /* null excerpt -> "" */
+   cJSON_AddItemToArray(hits, hit("d", 0.6, 44, "ex-d"));
+
+   int64_t ids[8];
+   const char *snips[8];
+   int n = td_extract_hit_docs(hits, ids, snips, 8);
+   assert(n == 3);
+   assert(ids[0] == 11 && strcmp(snips[0], "ex-a") == 0);
+   assert(ids[1] == 33 && strcmp(snips[1], "") == 0);
+   assert(ids[2] == 44 && strcmp(snips[2], "ex-d") == 0);
+
+   /* max caps the count */
+   int n2 = td_extract_hit_docs(hits, ids, snips, 2);
+   assert(n2 == 2);
+   assert(ids[0] == 11 && ids[1] == 33);
+
+   cJSON_Delete(hits);
+   printf("  ok: extract doc pairs\n");
+}
+
+static void test_extract_guards(void)
+{
+   int64_t ids[4];
+   const char *snips[4];
+   cJSON *hits = cJSON_CreateArray();
+   cJSON_AddItemToArray(hits, hit("a", 0.9, 11, "ex"));
+
+   assert(td_extract_hit_docs(NULL, ids, snips, 4) == 0);
+   assert(td_extract_hit_docs(hits, NULL, snips, 4) == 0);
+   assert(td_extract_hit_docs(hits, ids, NULL, 4) == 0);
+   assert(td_extract_hit_docs(hits, ids, snips, 0) == 0);
+
+   cJSON *obj = cJSON_CreateObject();
+   assert(td_extract_hit_docs(obj, ids, snips, 4) == 0); /* non-array */
+   cJSON_Delete(obj);
+   cJSON_Delete(hits);
+   printf("  ok: extract guards\n");
+}
+
+int main(void)
+{
+   printf("test_td_search_render:\n");
+   test_render_multiple();
+   test_render_empty();
+   test_render_missing_fields();
+   test_extract();
+   test_extract_guards();
+   printf("all td_search_render tests passed\n");
+   return 0;
+}

--- a/src/tests/test_td_search_render.c
+++ b/src/tests/test_td_search_render.c
@@ -135,6 +135,52 @@ static void test_extract_guards(void)
    printf("  ok: extract guards\n");
 }
 
+static void test_result_from_response(void)
+{
+   /* hits shape (what /v1/search actually returns) -> rendered, non-error. */
+   cJSON *r1 = cJSON_CreateObject();
+   cJSON *hits = cJSON_AddArrayToObject(r1, "hits");
+   cJSON_AddItemToArray(hits, hit("docs/a.md", 0.9, 11, "alpha"));
+   char *s1 = td_search_result_from_response(r1, "q");
+   assert(s1 && strncmp(s1, "error:", 6) != 0);
+   assert(strstr(s1, "docs/a.md") && strstr(s1, "alpha"));
+   free(s1);
+   cJSON_Delete(r1);
+
+   /* legacy {result:"..."} shape -> passed through verbatim (back-compat). */
+   cJSON *r2 = cJSON_CreateObject();
+   cJSON_AddStringToObject(r2, "result", "legacy text body");
+   char *s2 = td_search_result_from_response(r2, "q");
+   assert(s2 && strcmp(s2, "legacy text body") == 0);
+   free(s2);
+   cJSON_Delete(r2);
+
+   /* neither hits nor result -> the error line (the ONLY genuine failure). */
+   cJSON *r3 = cJSON_CreateObject();
+   cJSON_AddStringToObject(r3, "fusion_mode_used", "rrf");
+   char *s3 = td_search_result_from_response(r3, "q");
+   assert(s3 && strncmp(s3, "error:", 6) == 0);
+   free(s3);
+   cJSON_Delete(r3);
+
+   /* NULL response -> error, no crash. */
+   char *s4 = td_search_result_from_response(NULL, "q");
+   assert(s4 && strncmp(s4, "error:", 6) == 0);
+   free(s4);
+
+   /* Regression guard: an EMPTY hits array is a valid (zero-result) response,
+    * NOT an error — the tool must say "no results", never "error:". */
+   cJSON *r5 = cJSON_CreateObject();
+   cJSON_AddArrayToObject(r5, "hits");
+   char *s5 = td_search_result_from_response(r5, "nothing");
+   assert(s5 && strncmp(s5, "error:", 6) != 0);
+   assert(strstr(s5, "No knowledge-base results"));
+   free(s5);
+   cJSON_Delete(r5);
+
+   printf("  ok: result_from_response (hits/legacy/error/null/empty)\n");
+}
+
 int main(void)
 {
    printf("test_td_search_render:\n");
@@ -143,6 +189,7 @@ int main(void)
    test_render_missing_fields();
    test_extract();
    test_extract_guards();
+   test_result_from_response();
    printf("all td_search_render tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Problem

The `kb_search` agent tool unwrapped a legacy `{"result":"<text>"}` body, but a refactor moved it onto the `/v1/search` HTTP path, which only ever returns `{"hits":[...]}`. Every `kb_search` call therefore fell through to `"error: knowledge search unavailable"`.

The learning-to-rank outcome capture was guarded on that same missing `result` field (`strncmp(result,"error:",6)==0` → always true) **and** did a second, wasteful search — so it was dead code that never fired.

## Fix

`td_search_docs` now does **one** search and:
- renders the `{hits}` envelope into the tool's text result (honouring a legacy `{result}` string if some variant still returns one), and
- captures the surfaced `(doc_id, excerpt)` pairs from that **same** response for the retrieval-outcome bridge.

One search fixes three things at once: the broken tool renders real results, the double search is gone, and the default-off LTR capture actually fires.

## Notes
- Render/extract logic extracted into a pure `td_search_render` TU (cJSON + dstr only) with a new unit test (`unit-test-td-search-render`, 5 cases).
- The `retrieval_outcome_bridge_note` symbol stays weak → lean/delegate binaries link and simply skip capture.
- Capture remains gated on `learning_implicit_retrieval_outcome` (**default off**). Snippet lifetime is safe: the bridge `snprintf`-copies snippets into fixed buffers before `resp` is freed.

## Test
- `unit-test-td-search-render`, `unit-test-retrieval-outcome-bridge`, `unit-test-ranker-fit`, `unit-test-server-dispatch`, `unit-test-kb-http-routes` all pass.
- `aimee`, `aimee-server`, `aimee-kb` all link.
- clang-format-19 clean.