### PR TITLE
fix(pki): stabilize self-signed server cert identity across container recreates

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -252,7 +252,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 144 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 145 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -449,7 +449,7 @@ The binaries read 144 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/headers/pki.h
+++ b/src/headers/pki.h
@@ -51,8 +51,17 @@ extern "C"
     * is written 0600. Returns 0 if a usable cert is in place, -1 on failure. */
    int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_path);
 
-   /* Build the self-signed server cert SAN string into |out| (cap bytes): always
-    * the hostname |cn| + localhost + IPv4/IPv6 loopback, plus |extra| (the
+   /* Resolve the STABLE common name for the self-signed server cert, preferring an
+    * operator-declared identity (AIMEE_TLS_CN, else the first non-IP token of
+    * AIMEE_TLS_EXTRA_SAN) over the OS hostname — which in a container is the
+    * volatile per-container ID and rotated the cert on every recreate, breaking
+    * TOFU-pinned clients. Falls back to gethostname(), then "aimee-server". Writes
+    * a NUL-terminated CN into |out|. Truncation-safe. Exposed for tests. */
+   void pki_resolve_server_cn(char *out, size_t cap);
+
+   /* Build the self-signed server cert SAN string into |out| (cap bytes): the
+    * type-classified |cn| (IP: for an IP literal, else DNS:) + localhost + IPv4/IPv6
+    * loopback, plus |extra| (the
     * AIMEE_TLS_EXTRA_SAN value: comma/space-separated additional names, each
     * pre-typed "IP:"/"DNS:"/… or a bare host/IP auto-classified). Lets a
     * NAT/DNAT deployment present a cert that verifies for its reachable address

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -233,6 +233,88 @@ static int set_random_serial(X509 *cert, char *hex_out, size_t hex_len)
    return hex_out[0] ? 0 : -1;
 }
 
+/* Strip a leading "DNS:"/"IP:" SAN type prefix, if present, returning the bare
+ * host/IP. Other typed prefixes (email:/URI:) are left as-is — they are not
+ * hostname candidates and the caller only tests them for IP-ness. */
+static const char *san_bare(const char *tok)
+{
+   if (strncmp(tok, "DNS:", 4) == 0)
+      return tok + 4;
+   if (strncmp(tok, "IP:", 3) == 0)
+      return tok + 3;
+   return tok;
+}
+
+/* True if |tok| parses as an IPv4 or IPv6 literal. */
+static int san_is_ip(const char *tok)
+{
+   unsigned char ipbuf[16];
+   return inet_pton(AF_INET, tok, ipbuf) == 1 || inet_pton(AF_INET6, tok, ipbuf) == 1;
+}
+
+/* Resolve the STABLE common name / primary identity for the self-signed server
+ * cert. In a container gethostname() returns the per-container ID, which changes
+ * on every recreate; feeding it into the cert rotated the self-signed cert on each
+ * restart and silently broke every TOFU-pinned client. Prefer an operator-declared
+ * identity so the cert stays put across recreates. Precedence:
+ *   1. AIMEE_TLS_CN                              — explicit override (also test hook)
+ *   2. first non-IP token of AIMEE_TLS_EXTRA_SAN — the declared reachable hostname
+ *   3. first token of AIMEE_TLS_EXTRA_SAN        — all-IP list: use the IP
+ *   4. gethostname()                             — bare-metal fallback (unchanged)
+ *   5. "aimee-server"                            — last resort
+ * Writes a NUL-terminated CN into |out|. Exposed for tests. */
+void pki_resolve_server_cn(char *out, size_t cap)
+{
+   if (!out || cap == 0)
+      return;
+   out[0] = '\0';
+
+   const char *cn_env = getenv("AIMEE_TLS_CN");
+   if (cn_env && *cn_env)
+   {
+      snprintf(out, cap, "%s", cn_env);
+      return;
+   }
+
+   const char *extra = getenv("AIMEE_TLS_EXTRA_SAN");
+   if (extra && *extra)
+   {
+      char buf[512];
+      snprintf(buf, sizeof(buf), "%s", extra);
+      char *save = NULL;
+      const char *first = NULL;
+      for (char *tok = strtok_r(buf, ", ", &save); tok; tok = strtok_r(NULL, ", ", &save))
+      {
+         if (!*tok)
+            continue;
+         const char *bare = san_bare(tok);
+         if (!*bare)
+            continue;
+         if (!first)
+            first = bare; /* remember the first entry as an all-IP fallback */
+         if (!san_is_ip(bare))
+         {
+            snprintf(out, cap, "%s", bare); /* prefer a real hostname */
+            return;
+         }
+      }
+      if (first)
+      {
+         snprintf(out, cap, "%s", first);
+         return;
+      }
+   }
+
+   char host[256];
+   if (gethostname(host, sizeof(host)) == 0 && host[0])
+   {
+      host[sizeof(host) - 1] = '\0';
+      snprintf(out, cap, "%s", host);
+      return;
+   }
+   snprintf(out, cap, "aimee-server");
+}
+
 /* Generate a self-signed EC P-256 server certificate at (cert_path, key_path)
  * when neither already exists. Makes native TLS zero-config: with
  * aimee.api.tls_port set but no operator cert present, the server provisions its
@@ -244,8 +326,11 @@ void pki_build_server_san(const char *cn, const char *extra, char *out, size_t c
 {
    if (!out || cap == 0)
       return;
-   int n = snprintf(out, cap, "DNS:%s,DNS:localhost,IP:127.0.0.1,IP:0:0:0:0:0:0:0:1",
-                    (cn && *cn) ? cn : "localhost");
+   /* Classify the leading CN entry: an IP literal must be typed "IP:", not "DNS:",
+    * or verification against the address fails (and OpenSSL rejects DNS:<ip>). */
+   const char *cnv = (cn && *cn) ? cn : "localhost";
+   const char *cn_prefix = san_is_ip(cnv) ? "IP:" : "DNS:";
+   int n = snprintf(out, cap, "%s%s,DNS:localhost,IP:127.0.0.1,IP:0:0:0:0:0:0:0:1", cn_prefix, cnv);
    if (n < 0 || (size_t)n >= cap)
    {
       out[cap - 1] = '\0';
@@ -288,12 +373,14 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
    if (!cert_path || !cert_path[0] || !key_path || !key_path[0])
       return -1;
 
-   /* Desired SAN for this boot: CN (hostname) + AIMEE_TLS_EXTRA_SAN. Computed up
-    * front so it can be compared against what a previously-provisioned cert used. */
-   char cn[200];
-   if (gethostname(cn, sizeof(cn)) != 0 || !cn[0])
-      snprintf(cn, sizeof(cn), "aimee-server");
-   cn[sizeof(cn) - 1] = '\0';
+   /* Desired SAN for this boot: a STABLE CN + AIMEE_TLS_EXTRA_SAN. Computed up
+    * front so it can be compared against what a previously-provisioned cert used.
+    * The CN comes from pki_resolve_server_cn (operator identity preferred over the
+    * OS hostname) — so a container recreate, which changes gethostname() to a fresh
+    * per-container ID, no longer shifts the SAN and rotates the cert out from under
+    * pinned clients. */
+   char cn[256];
+   pki_resolve_server_cn(cn, sizeof(cn));
    char san[1024];
    pki_build_server_san(cn, getenv("AIMEE_TLS_EXTRA_SAN"), san, sizeof(san));
 

--- a/src/tests/test_pki.c
+++ b/src/tests/test_pki.c
@@ -42,6 +42,17 @@ static int verify_chains_to_ca(const char *cert_pem, const char *ca_path)
    return ok;
 }
 
+/* Read a whole file into |buf|; returns byte count (0 on any error). */
+static long slurp(const char *path, char *buf, size_t cap)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return 0;
+   size_t n = fread(buf, 1, cap, f);
+   fclose(f);
+   return (long)n;
+}
+
 int main(void)
 {
    char home[256];
@@ -108,7 +119,59 @@ int main(void)
    assert(strstr(san, ",IP:192.168.1.254") && strstr(san, ",DNS:nas.local")); /* multi */
    pki_build_server_san("h", "fd00::1", san, sizeof(san));
    assert(strstr(san, ",IP:fd00::1")); /* IPv6 -> IP: */
+   /* A leading CN that is an IP literal must be typed IP:, never DNS:<ip>. */
+   pki_build_server_san("192.168.1.254", NULL, san, sizeof(san));
+   assert(strstr(san, "IP:192.168.1.254") && !strstr(san, "DNS:192.168.1.254"));
+   pki_build_server_san("smoothnas", NULL, san, sizeof(san));
+   assert(strstr(san, "DNS:smoothnas")); /* hostname CN stays DNS: */
    printf("pki: SAN builder ok\n");
+
+   /* Stable-CN resolution: the operator identity must win over the OS hostname so a
+    * container recreate (fresh per-container gethostname()) cannot rotate the cert
+    * and break TOFU-pinned clients. */
+   char cn[256];
+   setenv("AIMEE_TLS_CN", "explicit.example", 1);
+   setenv("AIMEE_TLS_EXTRA_SAN", "192.168.1.254,smoothnas", 1);
+   pki_resolve_server_cn(cn, sizeof(cn));
+   assert(strcmp(cn, "explicit.example") == 0); /* 1. AIMEE_TLS_CN wins */
+   unsetenv("AIMEE_TLS_CN");
+   pki_resolve_server_cn(cn, sizeof(cn));
+   assert(strcmp(cn, "smoothnas") == 0); /* 2. first NON-IP token (skips the IP) */
+   setenv("AIMEE_TLS_EXTRA_SAN", "IP:192.168.1.254,DNS:nas.local", 1);
+   pki_resolve_server_cn(cn, sizeof(cn));
+   assert(strcmp(cn, "nas.local") == 0); /* pre-typed prefixes stripped */
+   setenv("AIMEE_TLS_EXTRA_SAN", "192.168.1.254, 10.0.0.5", 1);
+   pki_resolve_server_cn(cn, sizeof(cn));
+   assert(strcmp(cn, "192.168.1.254") == 0); /* 3. all-IP list -> first IP */
+   unsetenv("AIMEE_TLS_EXTRA_SAN");
+   pki_resolve_server_cn(cn, sizeof(cn));
+   assert(cn[0] != '\0'); /* 4. no operator identity -> gethostname() fallback */
+   printf("pki: stable CN resolution ok\n");
+
+   /* End-to-end: with a fixed operator identity the provisioned cert is KEPT across
+    * boots (no churn — the regression), and refreshes only when the identity itself
+    * changes. Because the resolved CN ignores gethostname() whenever AIMEE_TLS_EXTRA_SAN
+    * is set, a container recreate that changes only the OS hostname takes the keep path. */
+   char crtp[512], keyp[512];
+   snprintf(crtp, sizeof(crtp), "%s/tls/server.crt", home);
+   snprintf(keyp, sizeof(keyp), "%s/tls/server.key", home);
+   unsetenv("AIMEE_TLS_CN");
+   setenv("AIMEE_TLS_EXTRA_SAN", "192.168.1.254,smoothnas", 1);
+   assert(pki_ensure_self_signed_server_cert(crtp, keyp) == 0);
+   char c1[8192];
+   long n1 = slurp(crtp, c1, sizeof(c1));
+   assert(n1 > 0);
+   assert(pki_ensure_self_signed_server_cert(crtp, keyp) == 0); /* second boot, same identity */
+   char c2[8192];
+   long n2 = slurp(crtp, c2, sizeof(c2));
+   assert(n1 == n2 && memcmp(c1, c2, (size_t)n1) == 0);    /* kept verbatim: NOT rotated */
+   setenv("AIMEE_TLS_EXTRA_SAN", "10.0.0.9,othername", 1); /* operator changes identity */
+   assert(pki_ensure_self_signed_server_cert(crtp, keyp) == 0);
+   char c3[8192];
+   long n3 = slurp(crtp, c3, sizeof(c3));
+   assert(!(n1 == n3 && memcmp(c1, c3, (size_t)n1) == 0)); /* refreshed on a real change */
+   unsetenv("AIMEE_TLS_EXTRA_SAN");
+   printf("pki: server cert stable across boots, refreshes on identity change ok\n");
 
    snprintf(cmd, sizeof(cmd), "rm -rf %s", home);
    (void)system(cmd);


### PR DESCRIPTION
## Problem

A thin client (`aimee` v0.2.x) pinned to a remote server via TOFU (`aimee remote set`) would suddenly fail with an opaque error after the server container was restarted/recreated:

```
aimee: could not reach the aimee-server /v1 endpoint (is the server running? ...)
```

The server and bearer token were fine the whole time — `curl -k -H "Authorization: Bearer …" https://host:8743/v1/health` returned `200`. The real cause was TLS: the server presented a **brand-new self-signed cert** after every container recreate, so the client's pinned cert no longer matched.

## Root cause

`pki_ensure_self_signed_server_cert()` derives the cert **CN and SAN from `gethostname()`**. Inside a Docker container that is the **per-container ID**, which changes on every recreate. The "SAN changed → regenerate" branch then fires each boot and mints a fresh random-CN cert, silently invalidating every TOFU-pinned client. The operator-declared, stable identity (`AIMEE_TLS_EXTRA_SAN=192.168.1.254,smoothnas`) was already present but the volatile hostname polluted the cert anyway.

## Fix

Resolve a **stable CN** via new `pki_resolve_server_cn()`:

1. `AIMEE_TLS_CN` (explicit override)
2. first **non-IP** token of `AIMEE_TLS_EXTRA_SAN` (the declared reachable hostname)
3. first token of `AIMEE_TLS_EXTRA_SAN` (all-IP list → the IP)
4. `gethostname()` (bare-metal fallback — **unchanged behavior**)
5. `"aimee-server"`

When the operator declares an identity (as the Docker deployment does), the container hostname no longer enters the cert, so a recreate takes the **keep-existing** path instead of regenerating. Also type-classifies the leading SAN entry (`IP:` vs `DNS:`) so an IP CN verifies rather than being emitted as `DNS:<ip>`.

## Tests (`test_pki`)

- CN-resolution precedence (override → non-IP token → all-IP → hostname fallback), incl. stripping pre-typed `IP:`/`DNS:` prefixes.
- Leading-SAN IP-vs-DNS classification.
- **End-to-end regression:** the provisioned cert is kept **verbatim** across two boots with a fixed operator identity (no churn), and refreshes only when the identity actually changes.

## Notes / follow-ups

- Bare-metal deployments with neither env var set are unaffected.
- After deploying, `.254` will rotate its cert **once** (CN moves from the container ID to `smoothnas`), then stay stable; pinned clients re-pin once.
- The generic client-side "could not reach" message masks a TLS-trust failure; a clearer distinct error is a worthwhile separate change but out of scope here.
- The KB CA (`src/kb/pki.c`) is a separate internal-mTLS path and is not affected.