### PR TITLE
fix(pki): an existing server cert is authoritative — never recreate it

### DIFF
--- a/src/headers/pki.h
+++ b/src/headers/pki.h
@@ -47,8 +47,11 @@ extern "C"
 
    /* Provision a self-signed EC P-256 server cert at (cert_path, key_path) when
     * neither exists yet — makes native TLS zero-config when a tls_port is set but
-    * no operator cert is present. Never overwrites an existing cert/key. The key
-    * is written 0600. Returns 0 if a usable cert is in place, -1 on failure. */
+    * no operator cert is present. An EXISTING cert/key is authoritative: it is used
+    * as-is and NEVER regenerated (a rotation would break every TOFU-pinned client);
+    * to apply a changed hostname/AIMEE_TLS_EXTRA_SAN, delete the cert and restart.
+    * The key is written 0600. Returns 0 if a usable cert is in place, -1 on
+    * failure. */
    int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_path);
 
    /* Resolve the STABLE common name for the self-signed server cert, preferring an

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -373,12 +373,23 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
    if (!cert_path || !cert_path[0] || !key_path || !key_path[0])
       return -1;
 
-   /* Desired SAN for this boot: a STABLE CN + AIMEE_TLS_EXTRA_SAN. Computed up
-    * front so it can be compared against what a previously-provisioned cert used.
-    * The CN comes from pki_resolve_server_cn (operator identity preferred over the
-    * OS hostname) — so a container recreate, which changes gethostname() to a fresh
-    * per-container ID, no longer shifts the SAN and rotates the cert out from under
-    * pinned clients. */
+   /* An existing cert is AUTHORITATIVE: if a usable cert+key are already on disk,
+    * use them and never recreate. Regenerating would silently invalidate every
+    * client that pinned the previous cert (TOFU) — precisely the outage this
+    * guarantee prevents. To apply a changed hostname / AIMEE_TLS_EXTRA_SAN an
+    * operator deletes the cert and restarts (an explicit act), rather than the
+    * server rotating it out from under live clients on a whim (e.g. a container
+    * recreate that shifts gethostname()). */
+   struct stat st;
+   if (stat(cert_path, &st) == 0 && stat(key_path, &st) == 0)
+   {
+      aimee_log(LOG_DEBUG, "pki", "server TLS cert present at %s; using it (not regenerating)",
+                cert_path);
+      return 0;
+   }
+
+   /* No cert yet — provision a self-signed one. The CN prefers an operator-declared
+    * identity (pki_resolve_server_cn) over the volatile OS/container hostname. */
    char cn[256];
    pki_resolve_server_cn(cn, sizeof(cn));
    char san[1024];
@@ -386,31 +397,6 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
 
    char dir[MAX_PATH_LEN];
    snprintf(dir, sizeof(dir), "%s/tls", config_default_dir());
-   char san_path[MAX_PATH_LEN];
-   snprintf(san_path, sizeof(san_path), "%s/server.san", dir);
-
-   struct stat st;
-   if (stat(cert_path, &st) == 0 && stat(key_path, &st) == 0)
-   {
-      /* A cert already exists. Never touch an operator-mounted cert — identified
-       * by the ABSENCE of our server.san sidecar. For a cert WE provisioned
-       * (sidecar present), regenerate only when the desired SAN changed (e.g.
-       * AIMEE_TLS_EXTRA_SAN was set to add the LAN IP/hostname a thin client
-       * reaches us at) so pin+verify works without an operator manually deleting
-       * the cert. Unchanged SAN → keep it. */
-      FILE *sf = fopen(san_path, "r");
-      if (!sf)
-         return 0; /* operator / pre-sidecar cert: never overwrite */
-      char prev[1024] = "";
-      if (fgets(prev, sizeof(prev), sf))
-         prev[strcspn(prev, "\r\n")] = '\0';
-      fclose(sf);
-      if (strcmp(prev, san) == 0)
-         return 0; /* provisioned cert, SAN unchanged: keep it */
-      aimee_log(LOG_INFO, "pki", "server TLS SAN changed; regenerating self-signed cert (SAN=%s)",
-                san);
-      /* fall through: the O_TRUNC / "w" writes below overwrite the old cert+key */
-   }
 
    EVP_PKEY *key = gen_ec_key();
    if (!key)
@@ -474,15 +460,6 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
       if (ok)
       {
          rc = 0;
-         /* Record the SAN we baked in, marking this as a server-provisioned cert
-          * and enabling regeneration when AIMEE_TLS_EXTRA_SAN/hostname later change. */
-         FILE *snf = fopen(san_path, "w");
-         if (snf)
-         {
-            fputs(san, snf);
-            fputc('\n', snf);
-            fclose(snf);
-         }
          aimee_log(LOG_INFO, "pki", "generated self-signed server TLS cert (CN=%s) at %s", cn,
                    cert_path);
       }

--- a/src/tests/test_pki.c
+++ b/src/tests/test_pki.c
@@ -148,10 +148,11 @@ int main(void)
    assert(cn[0] != '\0'); /* 4. no operator identity -> gethostname() fallback */
    printf("pki: stable CN resolution ok\n");
 
-   /* End-to-end: with a fixed operator identity the provisioned cert is KEPT across
-    * boots (no churn — the regression), and refreshes only when the identity itself
-    * changes. Because the resolved CN ignores gethostname() whenever AIMEE_TLS_EXTRA_SAN
-    * is set, a container recreate that changes only the OS hostname takes the keep path. */
+   /* End-to-end: an existing cert is AUTHORITATIVE. Once provisioned it is kept
+    * verbatim across boots — and, critically, even when AIMEE_TLS_EXTRA_SAN or the
+    * hostname later changes. The server never recreates it, so a container recreate
+    * (fresh gethostname()) cannot rotate the cert out from under a TOFU-pinned
+    * client. A fresh cert is minted ONLY when none exists. */
    char crtp[512], keyp[512];
    snprintf(crtp, sizeof(crtp), "%s/tls/server.crt", home);
    snprintf(keyp, sizeof(keyp), "%s/tls/server.key", home);
@@ -164,14 +165,25 @@ int main(void)
    assert(pki_ensure_self_signed_server_cert(crtp, keyp) == 0); /* second boot, same identity */
    char c2[8192];
    long n2 = slurp(crtp, c2, sizeof(c2));
-   assert(n1 == n2 && memcmp(c1, c2, (size_t)n1) == 0);    /* kept verbatim: NOT rotated */
-   setenv("AIMEE_TLS_EXTRA_SAN", "10.0.0.9,othername", 1); /* operator changes identity */
+   assert(n1 == n2 && memcmp(c1, c2, (size_t)n1) == 0); /* kept verbatim */
+   /* An identity change — as a container recreate or an operator SAN edit would
+    * present — must NOT rotate an existing cert. This is the core guarantee. */
+   setenv("AIMEE_TLS_EXTRA_SAN", "10.0.0.9,othername", 1);
+   setenv("AIMEE_TLS_CN", "some-other-host", 1);
    assert(pki_ensure_self_signed_server_cert(crtp, keyp) == 0);
    char c3[8192];
    long n3 = slurp(crtp, c3, sizeof(c3));
-   assert(!(n1 == n3 && memcmp(c1, c3, (size_t)n1) == 0)); /* refreshed on a real change */
+   assert(n1 == n3 && memcmp(c1, c3, (size_t)n1) == 0); /* STILL kept: never recreated */
+   /* Only an absent cert triggers provisioning: delete it and a fresh one appears. */
+   assert(unlink(crtp) == 0 && unlink(keyp) == 0);
+   assert(pki_ensure_self_signed_server_cert(crtp, keyp) == 0);
+   char c4[8192];
+   long n4 = slurp(crtp, c4, sizeof(c4));
+   assert(n4 > 0 && !(n1 == n4 && memcmp(c1, c4, (size_t)n1) == 0)); /* minted when absent */
    unsetenv("AIMEE_TLS_EXTRA_SAN");
-   printf("pki: server cert stable across boots, refreshes on identity change ok\n");
+   unsetenv("AIMEE_TLS_CN");
+   printf("pki: existing server cert authoritative (kept across identity change; minted only when "
+          "absent) ok\n");
 
    snprintf(cmd, sizeof(cmd), "rm -rf %s", home);
    (void)system(cmd);


### PR DESCRIPTION
Follow-up to #1205 — the **disease-level** fix.

## The real bug

`pki_ensure_self_signed_server_cert()` had a branch that **regenerated an existing cert** whenever a freshly-computed SAN string (which embedded `gethostname()`) differed from a recorded `server.san` sidecar. In a container `gethostname()` is the per-container ID, so **every recreate rotated the cert** and silently broke every TOFU-pinned client with an opaque "could not reach /v1 endpoint".

#1205 stabilized the CN so the SAN stops changing *for deployments that set `AIMEE_TLS_EXTRA_SAN`* — but it kept the fragile regenerate-on-change path. That treated the trigger, not the disease.

## The fix

If a usable cert+key already exist on disk, **use them and return** — no SAN comparison, no sidecar, no regeneration. Provision only when the cert is **absent**. This is what the header already promised ("Never overwrites an existing cert/key") and what the behavior should always have been:

> An existing certificate is authoritative. To apply a changed hostname / `AIMEE_TLS_EXTRA_SAN`, an operator deletes the cert and restarts — an explicit act, not a silent rotation under live clients.

Independent of hostname, `AIMEE_TLS_EXTRA_SAN`, and compose entirely. Net −8 lines; removes the sidecar read+write.

## Tests

`test_pki` now asserts the existing cert is kept **verbatim across boots** *and* **across an identity change** (both `AIMEE_TLS_EXTRA_SAN` and `AIMEE_TLS_CN` changed), and that a fresh cert is minted **only when the files are absent**.