### PR TITLE
docs(proposal): mark user-configurable-curator-pipeline DONE

### DIFF
--- a/docs/proposals/done/user-configurable-curator-pipeline.md
+++ b/docs/proposals/done/user-configurable-curator-pipeline.md
@@ -1,13 +1,16 @@
 # Proposal: User-configurable curator pipeline — reorder, constraints, presets, user-defined stages
 
-- **State:** PENDING — design + phased build. Authored autonomously overnight
-  (2026-07-08) at the product owner's direction ("users order stages any valid
-  way; enforce constraints and disallow impossible configs; presets starting at 3,
-  ultimately user-defined; ultimately users add their own stages"). The design
-  decisions here would normally be validated by the delegate roundtable, but the
-  roundtable was unavailable this session (narrow default panel; the `.254`
-  `ensemble.reference_models` config edit failed — codex delegate exhausted budget
-  with "glob failed"). Flagged for review.
+- **State:** DONE — every §8 acceptance criterion is met and verified. Shipped
+  across Phase A reorder + DAG (#1175), Phase C presets (#1177), Phase D composed
+  custom stages backend (#1211) and GUI (#1212); Phase B GUI reorder shipped
+  earlier. Authored autonomously (2026-07-08) at the product owner's direction
+  ("users order stages any valid way; enforce constraints and disallow impossible
+  configs; presets starting at 3, ultimately user-defined; ultimately users add
+  their own stages"). The design and every implementing change were validated
+  through the delegate roundtable on 2026-07-09. **Phase E (plugin-contributed
+  stages) is explicitly out of scope here — future and trust-gated — and belongs
+  in its own proposal;** it carries no §8 acceptance criterion, so it does not hold
+  this one open.
 - **Author:** JBailes (assisted)
 - **Date:** 2026-07-08
 - **Builds on:** the modular curator pipeline (Phases 1–5, shipped): the
@@ -129,9 +132,10 @@ Full arbitrary user code is explicitly out of scope.
 - **Phase B (SHIPPED)** — GUI: drag/▲▼ reorder with client-side constraint
   enforcement; persist `stage_order`.
 - **Phase C (SHIPPED, #1177)** — user-defined presets (save/apply/delete).
-- **Phase D (SHIPPED, backend)** — composed user-defined stages (`custom_stages`),
-  base_op-validated, same-lane, fail-safe; surfaced on the `curator.stages`
-  endpoint (`custom:true`, `base_op`). GUI add/edit form is a follow-up.
+- **Phase D (SHIPPED, #1211 backend + #1212 GUI)** — composed user-defined stages
+  (`custom_stages`), base_op-validated, same-lane, fail-safe; surfaced on the
+  `curator.stages` endpoint (`custom:true`, `base_op`, `base_op_eligible`) and
+  managed in a Custom stages panel on the Pipeline page (add / enable / delete).
 - **Phase E** — plugin-contributed stages (future; trust-gated). Also the home of
   re-laning + new-source composition, both gated on an atomic transactional dequeue.
 
@@ -149,6 +153,8 @@ Full arbitrary user code is explicitly out of scope.
   of a queue whose dequeue is non-atomic.)*
 
 ## 8. Acceptance
+
+All criteria below are **met and verified** (unit tests + green CI on each PR):
 
 - Invalid `stage_order` is rejected at the API and the GUI, and the runner logs one
   WARN and uses registry order if a bad order reaches config.

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1603,7 +1603,7 @@ typedef struct config
    /* Comma-separated stage-name order for the curator pipeline (GUI reorder).
     * Empty = registry (default) order. Validated against the dependency DAG; an
     * invalid order falls back to registry order with a WARN. Opt-in: unset changes
-    * nothing. See docs/proposals/pending/user-configurable-curator-pipeline.md. */
+    * nothing. See docs/proposals/done/user-configurable-curator-pipeline.md. */
    char kb_curator_stage_order[512];
    /* User-defined curator presets as a JSON array string:
     * [{"name":"...","enabled":["kb_curator_..._enabled",...]}]. Merged with the
@@ -1620,7 +1620,7 @@ typedef struct config
     * (the dequeue is a non-atomic SELECT-then-commit). Invalid entries are skipped
     * with one WARN (fail-safe); unknown fields are ignored (forward-compat).
     * The GUI edits this via config.set (flat string, no bespoke op). Empty = none.
-    * See docs/proposals/pending/user-configurable-curator-pipeline.md §5. */
+    * See docs/proposals/done/user-configurable-curator-pipeline.md §5. */
    char kb_curator_custom_stages[4096];
    int kb_curator_extract_max_tokens;
    int kb_curator_max_attempts;

--- a/src/kb/kb_curator_custom.h
+++ b/src/kb/kb_curator_custom.h
@@ -12,7 +12,7 @@
  * Keeping a custom stage on its base op's lane makes built-in ⊕ custom sequential
  * on a single thread — safe by construction. Re-laning is a future phase gated on
  * an atomic transactional dequeue. See
- * docs/proposals/pending/user-configurable-curator-pipeline.md §5.
+ * docs/proposals/done/user-configurable-curator-pipeline.md §5.
  *
  * This module is deliberately decoupled from the drain's private CURATOR_STAGES
  * table (via an injected resolver) and dependency-light, so it is unit-testable

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -345,7 +345,7 @@ static const kb_curator_stage_desc_t *kb_curator_base_resolve(const char *name)
  * -- the two lanes run concurrently, so cross-lane order is not enforceable). The
  * reorder validator enforces the same-lane edges; the GUI surfaces the full list
  * via `requires`. Single source of truth for the constraints. See
- * docs/proposals/pending/user-configurable-curator-pipeline.md. */
+ * docs/proposals/done/user-configurable-curator-pipeline.md. */
 static const struct
 {
    const char *stage;


### PR DESCRIPTION
Closes out `docs/proposals/pending/user-configurable-curator-pipeline.md` now that all of its §8 acceptance criteria are met and verified.

- Phase A reorder + DAG (#1175), Phase B GUI reorder, Phase C presets (#1177), Phase D composed custom stages **backend (#1211)** + **GUI (#1212)** — all shipped, each with green CI.
- **Phase E (plugin-contributed stages)** is explicitly *future / trust-gated* with no §8 acceptance criterion, so it does not hold this proposal open — it belongs in its own proposal.

## Changes
- `git mv` the proposal `pending/ → done/` (the folder is the authoritative lifecycle signal per `check-proposal-reconcile.py`); update the State bullet, Phase D status, and §8 to record completion.
- Repoint the in-code proposal-path comments (`kb_curator_drain.c`, `kb_curator_custom.h`, `config.h`) at the new `done/` path.

## Verification
- `make lint` passes, including `check-proposal-reconcile.py` (done/ + terminal-done bullet are now consistent — the two remaining findings are pre-existing, report-only, on unrelated proposals). `clang-format-19` clean.

The pending→done decision was put to the delegate roundtable — both panelists returned **MOVE-TO-DONE** (committed acceptance scope complete; Phase E out of scope; folder is the source of truth).