### PR TITLE
fix(deploy): hash-track seeded workflow defaults so upgrades reach the GUI

### DIFF
--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -43,13 +43,37 @@ if [ ! -f "$AIMEE_HOME/agents.json" ] && [ -f /opt/aimee/defaults/agents.json ];
     cp /opt/aimee/defaults/agents.json "$AIMEE_HOME/agents.json"
 fi
 # Seed default dev-lifecycle workflows so autonomous development (default-on) can
-# resolve "build" out of the box. Never clobber operator-authored workflows.
+# resolve "build" out of the box. Shipped defaults are hash-tracked under
+# .seeded/<name>: a fresh install is seeded and its hash recorded; on later
+# starts an UNMODIFIED managed default (on-disk hash still equals the recorded
+# seed hash) is refreshed when the image ships a newer one. An operator-edited
+# default (hash diverged) or one of unknown provenance (no seed record and not
+# already equal to the shipped default) is never clobbered.
 if [ -d /opt/aimee/defaults/workflows ]; then
-    mkdir -p "$AIMEE_HOME/workflows"
+    mkdir -p "$AIMEE_HOME/workflows/.seeded"
     for wf in /opt/aimee/defaults/workflows/*.yaml; do
         [ -e "$wf" ] || continue
-        dst="$AIMEE_HOME/workflows/$(basename "$wf")"
-        [ -f "$dst" ] || cp "$wf" "$dst"
+        base=$(basename "$wf")
+        dst="$AIMEE_HOME/workflows/$base"
+        rec="$AIMEE_HOME/workflows/.seeded/$base"
+        if ! command -v sha256sum >/dev/null 2>&1; then
+            # No hasher available: fall back to conservative never-clobber seed.
+            [ -f "$dst" ] || cp "$wf" "$dst"
+            continue
+        fi
+        shipped=$(sha256sum "$wf" | cut -d' ' -f1)
+        if [ ! -f "$dst" ]; then
+            cp "$wf" "$dst" && printf '%s\n' "$shipped" > "$rec"
+        elif [ -f "$rec" ]; then
+            disk=$(sha256sum "$dst" | cut -d' ' -f1)
+            if [ "$disk" = "$(cat "$rec")" ] && [ "$disk" != "$shipped" ]; then
+                cp "$wf" "$dst" && printf '%s\n' "$shipped" > "$rec"
+            fi
+        elif [ "$(sha256sum "$dst" | cut -d' ' -f1)" = "$shipped" ]; then
+            # No record yet, but already identical to the shipped default: adopt
+            # it as managed so a future image can refresh it.
+            printf '%s\n' "$shipped" > "$rec"
+        fi
     done
 fi
 # Ensure aimee (uid 1000) owns its home + workspaces so it can write on an empty

--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -36,13 +36,37 @@ if [ ! -f "$AIMEE_HOME/agents.json" ] && [ -f /opt/aimee/defaults/agents.json ];
     cp /opt/aimee/defaults/agents.json "$AIMEE_HOME/agents.json"
 fi
 # Seed default dev-lifecycle workflows so autonomous development (default-on) can
-# resolve "build" out of the box. Never clobber operator-authored workflows.
+# resolve "build" out of the box. Shipped defaults are hash-tracked under
+# .seeded/<name>: a fresh install is seeded and its hash recorded; on later
+# starts an UNMODIFIED managed default (on-disk hash still equals the recorded
+# seed hash) is refreshed when the image ships a newer one. An operator-edited
+# default (hash diverged) or one of unknown provenance (no seed record and not
+# already equal to the shipped default) is never clobbered.
 if [ -d /opt/aimee/defaults/workflows ]; then
-    mkdir -p "$AIMEE_HOME/workflows"
+    mkdir -p "$AIMEE_HOME/workflows/.seeded"
     for wf in /opt/aimee/defaults/workflows/*.yaml; do
         [ -e "$wf" ] || continue
-        dst="$AIMEE_HOME/workflows/$(basename "$wf")"
-        [ -f "$dst" ] || cp "$wf" "$dst"
+        base=$(basename "$wf")
+        dst="$AIMEE_HOME/workflows/$base"
+        rec="$AIMEE_HOME/workflows/.seeded/$base"
+        if ! command -v sha256sum >/dev/null 2>&1; then
+            # No hasher available: fall back to conservative never-clobber seed.
+            [ -f "$dst" ] || cp "$wf" "$dst"
+            continue
+        fi
+        shipped=$(sha256sum "$wf" | cut -d' ' -f1)
+        if [ ! -f "$dst" ]; then
+            cp "$wf" "$dst" && printf '%s\n' "$shipped" > "$rec"
+        elif [ -f "$rec" ]; then
+            disk=$(sha256sum "$dst" | cut -d' ' -f1)
+            if [ "$disk" = "$(cat "$rec")" ] && [ "$disk" != "$shipped" ]; then
+                cp "$wf" "$dst" && printf '%s\n' "$shipped" > "$rec"
+            fi
+        elif [ "$(sha256sum "$dst" | cut -d' ' -f1)" = "$shipped" ]; then
+            # No record yet, but already identical to the shipped default: adopt
+            # it as managed so a future image can refresh it.
+            printf '%s\n' "$shipped" > "$rec"
+        fi
     done
 fi
 chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspaces}" 2>/dev/null || true


### PR DESCRIPTION
## Problem
The web GUI lists workflows from `$AIMEE_HOME/workflows/` (`wf_api_list`), and runs resolve defs from the same dir (`def_path`). The container entrypoints seed `config/workflows/*.yaml` there **only when the file is absent** (`[ -f "$dst" ] || cp`). On a persisted volume, an old `build.yaml` from an earlier image is therefore never replaced — so the sliced-lifecycle `build` workflow (#1188, #1210) never appears in the GUI; it keeps showing the stale definition.

## Fix
Hash-track shipped defaults under `$AIMEE_HOME/workflows/.seeded/<name>`:

- **Fresh install** (no dst): seed and record the shipped hash.
- **Unmodified managed default** (on-disk hash == recorded seed hash) **and** the image ships a newer one: refresh it, update the record.
- **Unrecorded but already identical** to the shipped default: adopt it (write the record) so future upgrades can manage it.
- **Operator-edited** (hash diverged) or **unknown provenance** (no record, differs from shipped): never touched.

`.seeded/` is a subdirectory; every lister filters by the `.yaml` suffix (and a `proposals/` subdir already coexists there), so it is ignored by the GUI/CLI/engine.

## Note
A **pre-existing** stale default with no record (the current running deployment) is deliberately left untouched — it needs a one-time manual reseed. That is handled operationally out of band.

## Verification
POSIX-sh simulation of the exact block across 7 scenarios (fresh, unmodified-upgrade, operator-edited, unknown/differ, unknown/equal, already-current, idempotency) — 12/12 assertions pass. Both scripts pass `sh -n`.