### PR TITLE
feat(session): persist session chats to db1 for every primary

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -2511,6 +2511,11 @@ paths:
       summary: Create a session
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Session, content: { application/json: { schema: { type: object } } } } }
+  /sessions/record_transcript:
+    post:
+      summary: Persist a session's conversation transcript to DB1 under its host id
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: Recorded, content: { application/json: { schema: { type: object } } } } }
   /sessions/close:
     post:
       summary: Close a session

--- a/src/acp_server.c
+++ b/src/acp_server.c
@@ -9,6 +9,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+#include <unistd.h>
 
 #ifndef AIMEE_VERSION
 #define AIMEE_VERSION "dev"
@@ -87,14 +89,29 @@ int acp_server_build_initialize(const char *id_json, char *out, size_t out_n)
    return acp_initialize_for_id(id, out, out_n);
 }
 
-/* session/new: mint a fresh ACP session id. Phase 1 keeps it in-process; phase 3
- * maps it onto a persistent DB1 aimee session so editor reconnects restore
- * history. The id is unique per acp-serve process. */
+/* session/new: mint a fresh ACP session id. The chat turn that follows persists
+ * to DB1 under this id (server_sessions + primary_sessions transcript), so the id
+ * must be unique across acp-serve processes — a bare per-process counter reset to
+ * 1 on every restart, colliding with a prior (e.g. crashed) session's DB rows and
+ * making it unrecoverable. Qualify it with the pid and process start time; the
+ * editor stores the returned id and replays it on session/load to resume. */
 static int acp_session_new_for_id(cJSON *id, char *out, size_t out_n)
 {
+   /* acp_server_run drives session/new from a single stdin loop, so this static
+    * seq is never touched concurrently. Seed the id with the process start time to
+    * nanosecond resolution (not whole seconds) so two acp-serve processes that
+    * reuse a pid can't collide on the same second. */
    static unsigned long seq = 0;
+   static long long proc_seed = 0;
+   if (proc_seed == 0)
+   {
+      struct timespec ts;
+      proc_seed = (clock_gettime(CLOCK_REALTIME, &ts) == 0)
+                      ? (long long)ts.tv_sec * 1000000000LL + ts.tv_nsec
+                      : (long long)time(NULL);
+   }
    char sid[64];
-   snprintf(sid, sizeof(sid), "acp-sess-%lu", ++seq);
+   snprintf(sid, sizeof(sid), "acp-%d-%lld-%lu", (int)getpid(), proc_seed, ++seq);
    cJSON *root = cJSON_CreateObject();
    cJSON_AddStringToObject(root, "jsonrpc", "2.0");
    acp_add_id(root, id);

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -204,6 +204,112 @@ static int handle_session_start_remote(void)
  * the hook rather than the wire. Renders only the per-turn sections (session-
  * level identity/preferences/rules already land at SessionStart). Always
  * soft-fails (exit 0) so a prompt is never blocked. */
+/* Persist the host's on-disk conversation transcript (Claude Code's
+ * transcript_path — JSONL, one message object per line) to DB1 under the real
+ * session id. This is what makes a chat that flows through the anonymous
+ * /v1/messages model gateway — which stores no conversation — logged and
+ * recoverable after a crash. Best-effort: a *failure* never blocks the turn
+ * (errors are swallowed), but the work IS synchronous, so the POST timeout is
+ * kept short for the local daemon.
+ *
+ * The transcript is bounded. When it exceeds the cap we ship the TAIL, not the
+ * head: the file is chronological, so the tail holds the newest turns (the ones
+ * that matter most for recovery) and we never truncate mid-line into corrupt
+ * JSON. The first (partial) line of a tail read is dropped so only whole JSONL
+ * objects are parsed. A capped read is thus a valid recent-window snapshot, not
+ * a stale head prefix that silently omits the latest turns.
+ *
+ * The cap is kept below the server's per-method limit for this route
+ * (LIMIT_TRANSCRIPT, 3 MiB, itself under the 4 MiB SHTTP_MAX_BODY), with headroom
+ * for the JSON envelope — a larger body is rejected/truncated server-side and
+ * stores nothing. */
+#define SS_TRANSCRIPT_MAX     (2 * 1024 * 1024)
+#define SS_TRANSCRIPT_POST_MS 5000
+static void ss_record_transcript(const char *endpoint, const char *bearer, const char *session_id,
+                                 const char *transcript_path)
+{
+   if (!endpoint || !session_id || !session_id[0] || !transcript_path || !transcript_path[0])
+      return;
+   FILE *fp = fopen(transcript_path, "rb");
+   if (!fp)
+      return;
+   if (fseek(fp, 0, SEEK_END) != 0)
+   {
+      fclose(fp);
+      return;
+   }
+   long fsz = ftell(fp);
+   if (fsz <= 0)
+   {
+      fclose(fp);
+      return;
+   }
+   /* Oversize: read only the last SS_TRANSCRIPT_MAX bytes (the newest turns). */
+   int tail = ((size_t)fsz > SS_TRANSCRIPT_MAX);
+   long start = tail ? (fsz - (long)SS_TRANSCRIPT_MAX) : 0;
+   size_t want = (size_t)(fsz - start);
+   if (fseek(fp, start, SEEK_SET) != 0)
+   {
+      fclose(fp);
+      return;
+   }
+   char *buf = malloc(want + 1);
+   if (!buf)
+   {
+      fclose(fp);
+      return;
+   }
+   size_t n = fread(buf, 1, want, fp);
+   fclose(fp);
+   buf[n] = '\0';
+
+   /* JSONL: one JSON object per line (line content never contains a raw newline).
+    * On a tail read, skip the first line — it is the cut-through tail of a line
+    * the cap split, so it is not a complete JSON object. */
+   char *scan = buf;
+   if (tail)
+   {
+      char *first_nl = strchr(buf, '\n');
+      scan = first_nl ? first_nl + 1 : buf + n; /* no newline in window → nothing whole */
+   }
+   cJSON *messages = cJSON_CreateArray();
+   for (char *p = scan; messages && p && *p;)
+   {
+      char *nl = strchr(p, '\n');
+      if (nl)
+         *nl = '\0';
+      if (*p)
+      {
+         cJSON *obj = cJSON_Parse(p);
+         if (obj)
+            cJSON_AddItemToArray(messages, obj);
+      }
+      if (!nl)
+         break;
+      p = nl + 1;
+   }
+   free(buf);
+
+   if (!messages || cJSON_GetArraySize(messages) == 0)
+   {
+      cJSON_Delete(messages);
+      return;
+   }
+
+   cJSON *body = cJSON_CreateObject();
+   cJSON_AddStringToObject(body, "session_id", session_id);
+   cJSON_AddItemToObject(body, "messages", messages); /* takes ownership */
+   char *body_s = cJSON_PrintUnformatted(body);
+   cJSON_Delete(body);
+   if (!body_s)
+      return;
+   int status = 0;
+   cJSON *resp = cli_http_request(endpoint, "POST", "/v1/sessions/record_transcript", body_s,
+                                  bearer, SS_TRANSCRIPT_POST_MS, &status);
+   free(body_s);
+   cJSON_Delete(resp);
+}
+
 int handle_user_prompt_submit(void)
 {
    char *stdin_data = read_stdin();
@@ -221,6 +327,19 @@ int handle_user_prompt_submit(void)
       return 0;
    }
    char *bearer = cli_v1_client_bearer();
+
+   /* Log this session's conversation to DB1 under its real host id. The hook
+    * payload carries both the session id and transcript_path (the full chat the
+    * host keeps on disk); persist it every turn so a crashed session is
+    * recoverable. Runs before the recall round-trip; best-effort. */
+   {
+      char rec_sid[64] = "";
+      const char *tpath =
+          cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(hook_json, "transcript_path"));
+      if (client_hook_payload_session_id(hook_json, rec_sid, sizeof(rec_sid)) && rec_sid[0] &&
+          tpath)
+         ss_record_transcript(endpoint, bearer, rec_sid, tpath);
+   }
 
    cJSON *body = cJSON_CreateObject();
    cJSON_AddStringToObject(body, "task_hint", prompt);

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -715,6 +715,7 @@ static const struct
     {"session.create", "POST", "/v1/sessions/create"},
     {"session.get", "POST", "/v1/sessions/get"},
     {"session.presence", "GET", "/v1/sessions/presence"},
+    {"session.record_transcript", "POST", "/v1/sessions/record_transcript"},
     {"skill.archive", "POST", "/v1/skills/archive"},
     {"skill.autostub", "POST", "/v1/skills/autostub"},
     {"skill.create", "POST", "/v1/skills/create"},

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -48,7 +48,9 @@ typedef struct cJSON cJSON;
 #define LIMIT_DELEGATE (4 * 1024 * 1024) /* 4MB: supports 2MB prompt-file + JSON overhead */
 #define LIMIT_CHAT     (512 * 1024)      /* 512KB for chat messages */
 #define LIMIT_INGEST   (1024 * 1024)     /* 1MB: client-pushed code files (kb req cap) */
-#define LIMIT_DEFAULT  (256 * 1024)      /* 256KB default */
+#define LIMIT_TRANSCRIPT                                                                           \
+   (3 * 1024 * 1024)               /* 3MB: session transcript snapshots (< SHTTP_MAX_BODY) */
+#define LIMIT_DEFAULT (256 * 1024) /* 256KB default */
 
 /* JSON framing limits */
 #define JSON_MAX_DEPTH          32  /* maximum nesting depth */
@@ -272,6 +274,7 @@ const method_policy_t *server_policy_for_method(const char *method);
 
 /* Session handlers (server_session.c) */
 int handle_session_create(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_session_record_transcript(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_session_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_session_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_session_close(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -410,6 +410,62 @@ static int chat_model_passthrough_allowed(const char *model)
    return model && model[0] && strcmp(model, "aimee") != 0 && strncmp(model, "aimee:", 6) != 0;
 }
 
+/* Register the aimee session in DB1 (idempotent) so a chat that goes through ANY
+ * provider path — including the tmux CLI agent worker and inbound ACP/MCP serve
+ * turns — is locatable in `server_sessions` after a crash/restart. Previously
+ * only clients that explicitly called session.create had a registry row, so a
+ * session started purely by a chat turn (e.g. an editor over ACP) could not be
+ * found again. Best-effort; a missing sid is a no-op. */
+static void chat_session_register(const char *aimee_sid, const char *client_type)
+{
+   if (!aimee_sid || !aimee_sid[0])
+      return;
+   db1_server_session_t row;
+   if (db1_server_session_get(aimee_sid, &row) == 0)
+      return; /* already registered */
+   const char *principal = agent_get_request_vault_principal();
+   (void)db1_server_session_create(aimee_sid,
+                                   (client_type && client_type[0]) ? client_type : "chat",
+                                   principal ? principal : "");
+}
+
+/* Append one user/assistant turn to the durable `primary_sessions` transcript so
+ * chats served by the agent (tmux CLI) worker — which otherwise persists nothing
+ * to DB1 — are logged and survive a crash. The direct primary-session adapter
+ * already writes its own full provider-formatted transcript, so this is only
+ * needed for the agent path. Best-effort; keyed by the aimee session id so
+ * db1_primary_session_get_latest can recover it. */
+static void chat_log_turn_transcript(const char *aimee_sid, const char *agent_name,
+                                     const char *provider, const char *user_msg,
+                                     const char *assistant_reply)
+{
+   if (!aimee_sid || !aimee_sid[0] || !assistant_reply || !assistant_reply[0])
+      return;
+   char *existing = db1_primary_session_load(aimee_sid, agent_name, provider);
+   cJSON *messages = existing ? cJSON_Parse(existing) : NULL;
+   free(existing);
+   if (!messages || !cJSON_IsArray(messages))
+   {
+      cJSON_Delete(messages);
+      messages = cJSON_CreateArray();
+   }
+   if (!messages)
+      return;
+   cJSON *um = cJSON_CreateObject();
+   cJSON_AddStringToObject(um, "role", "user");
+   cJSON_AddStringToObject(um, "content", user_msg ? user_msg : "");
+   cJSON_AddItemToArray(messages, um);
+   cJSON *am = cJSON_CreateObject();
+   cJSON_AddStringToObject(am, "role", "assistant");
+   cJSON_AddStringToObject(am, "content", assistant_reply);
+   cJSON_AddItemToArray(messages, am);
+   char *json = cJSON_PrintUnformatted(messages);
+   cJSON_Delete(messages);
+   if (json)
+      (void)db1_primary_session_save(aimee_sid, agent_name, provider, json);
+   free(json);
+}
+
 static int chat_codex_effort_allowed(const char *effort)
 {
    return effort && (strcmp(effort, "low") == 0 || strcmp(effort, "medium") == 0 ||
@@ -818,6 +874,11 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
       return;
    }
 
+   /* Log this turn to the durable DB1 transcript. The agent (tmux CLI) worker is
+    * the one chat path that otherwise persists nothing, so a session started here
+    * (e.g. over inbound ACP/MCP) was previously unrecoverable after a crash. */
+   chat_log_turn_transcript(aimee_sid, selected, provider, message, result.response);
+
    /* If the reply already streamed incrementally, don't re-emit it whole. */
    if (!sctx.emitted && result.response && result.response[0])
       stream_event(cctx, "text", "content", result.response);
@@ -1133,6 +1194,14 @@ void chat_stream_worker(void *arg)
       compute_error(cctx, "missing message");
       compute_ctx_free(cctx);
       return;
+   }
+
+   /* Register the session in DB1 up front so it is locatable in `server_sessions`
+    * regardless of which provider path serves the turn below (codex / primary-
+    * session / agent). Idempotent and best-effort. */
+   {
+      cJSON *jct = cJSON_GetObjectItemCaseSensitive(req, "client_type");
+      chat_session_register(aimee_sid, cJSON_IsString(jct) ? jct->valuestring : NULL);
    }
 
    /* The S1/S2 request->workflow router now runs at the UNIFIED gateway seam

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1133,6 +1133,22 @@ static int handle_hooks_session_start(server_ctx_t *ctx, server_conn_t *conn, cJ
       return server_send_error(conn, "invalid session_id (must be alphanumeric/dash/underscore)",
                                request_id);
 
+   /* Register the session in the server_sessions registry under its real host id
+    * (session_start_emit persists session_state, but NOT this listings row). This
+    * makes every session locatable after a crash — the gap that meant a Claude
+    * Code session driven through the anonymous /v1/messages gateway left no
+    * findable record. Idempotent (SessionStart also fires on resume); best-effort. */
+   if (sid && sid[0])
+   {
+      db1_server_session_t existing;
+      if (db1_server_session_get(sid, &existing) != 0)
+      {
+         char principal[32];
+         snprintf(principal, sizeof(principal), "uid:%d", (int)conn->peer_uid);
+         (void)db1_server_session_create(sid, "claude-code", principal);
+      }
+   }
+
    cJSON *jnb = cJSON_GetObjectItemCaseSensitive(req, "nonblocking");
    if (cJSON_IsTrue(jnb))
    {
@@ -1322,6 +1338,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"session.brief_assemble", handle_session_brief_assemble},
     {"memory.user_capture", handle_memory_user_capture},
     {"session.create", handle_session_create},
+    {"session.record_transcript", handle_session_record_transcript},
     {"session.list", handle_session_list},
     {"session.get", handle_session_get},
     {"session.close", handle_session_close},
@@ -1578,8 +1595,13 @@ static size_t method_size_limit(const char *method)
       const char *prefix;
       size_t max;
    } limits[] = {
-       {"memory.", LIMIT_MEMORY},    {"tool.", LIMIT_TOOL}, {"delegate", LIMIT_DELEGATE},
-       {"mcp.call", LIMIT_DELEGATE}, {"chat.", LIMIT_CHAT}, {"index.ingest", LIMIT_INGEST},
+       {"memory.", LIMIT_MEMORY},
+       {"tool.", LIMIT_TOOL},
+       {"delegate", LIMIT_DELEGATE},
+       {"mcp.call", LIMIT_DELEGATE},
+       {"chat.", LIMIT_CHAT},
+       {"index.ingest", LIMIT_INGEST},
+       {"session.record_transcript", LIMIT_TRANSCRIPT},
        {NULL, LIMIT_DEFAULT},
    };
 

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -309,6 +309,73 @@ int handle_session_create(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, resp);
 }
 
+/* session.record_transcript: persist a session's conversation to DB1 under its
+ * real host id. The hook-driven primary (e.g. Claude Code) posts the transcript
+ * it already keeps on disk (transcript_path) here each turn, so a session driven
+ * through the anonymous /v1/messages gateway — which stores no conversation — is
+ * still logged and recoverable after a crash. `messages` is the transcript JSON
+ * (array preferred; any JSON value is stored verbatim). Idempotent upsert. */
+int handle_session_record_transcript(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   cJSON *jsid = cJSON_GetObjectItemCaseSensitive(req, "session_id");
+   const char *sid = cJSON_IsString(jsid) ? jsid->valuestring : NULL;
+   if (!sid || !sid[0])
+      return server_send_error(conn, "session_id required", NULL);
+   /* Enforce the same id invariant as handle_hooks_session_start: this route
+    * makes durable server_sessions + primary_sessions writes keyed by sid, so it
+    * must not admit ids the other session entry points would reject. */
+   if (!is_safe_id(sid))
+      return server_send_error(conn, "invalid session_id (must be alphanumeric/dash/underscore)",
+                               NULL);
+
+   cJSON *jmsgs = cJSON_GetObjectItemCaseSensitive(req, "messages");
+   if (!jmsgs)
+      return server_send_error(conn, "messages required", NULL);
+
+   /* Optional host metadata; the defaults suit the Claude Code hook, but a
+    * non-Claude host may identify itself. */
+   cJSON *jct = cJSON_GetObjectItemCaseSensitive(req, "client_type");
+   const char *client_type =
+       (cJSON_IsString(jct) && jct->valuestring[0]) ? jct->valuestring : "claude-code";
+   cJSON *jprov = cJSON_GetObjectItemCaseSensitive(req, "provider");
+   const char *provider =
+       (cJSON_IsString(jprov) && jprov->valuestring[0]) ? jprov->valuestring : "claude-code";
+
+   char caller[DB1_SS_PRINCIPAL_LEN];
+   snprintf(caller, sizeof(caller), "uid:%d", (int)conn->peer_uid);
+
+   /* Register (idempotent) so the session is locatable even if SessionStart never
+    * ran, then enforce ownership on the FINAL row before any durable write. When
+    * the row is missing we create it and always re-read: success requires a row to
+    * actually be present afterwards (not merely a create that returned ok), which
+    * also covers a create that raced a concurrent create. Whether the row
+    * pre-existed, we just created it, or it appeared via a race, it must belong to
+    * the caller — otherwise a caller could overwrite another principal's transcript
+    * under a known session id. */
+   db1_server_session_t existing;
+   if (db1_server_session_get(sid, &existing) != 0)
+   {
+      (void)db1_server_session_create(sid, client_type, caller);
+      if (db1_server_session_get(sid, &existing) != 0)
+         return server_send_error(conn, "failed to register session", NULL);
+   }
+   if (existing.principal[0] && strcmp(existing.principal, caller) != 0)
+      return server_send_error(conn, "session_id owned by another principal", NULL);
+
+   char *messages_json = cJSON_PrintUnformatted(jmsgs);
+   if (!messages_json)
+      return server_send_error(conn, "failed to serialize transcript", NULL);
+   int rc = db1_primary_session_save(sid, client_type, provider, messages_json);
+   free(messages_json);
+   if (rc != 0)
+      return server_send_error(conn, "failed to persist transcript", NULL);
+
+   cJSON *resp = jo_ok();
+   cJSON_AddStringToObject(resp, "session_id", sid);
+   return server_send_ok(conn, resp);
+}
+
 int handle_session_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -2013,6 +2013,8 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/skills/patch", NULL, RM_EXACT, "skill.patch", 0, rh_dispatch_op},
     {"POST", "/v1/skills/unpin", NULL, RM_EXACT, "skill.unpin", 0, rh_dispatch_op},
     {"POST", "/v1/sessions/create", NULL, RM_EXACT, "session.create", 0, rh_dispatch_op},
+    {"POST", "/v1/sessions/record_transcript", NULL, RM_EXACT, "session.record_transcript", 0,
+     rh_dispatch_op},
     {"POST", "/v1/sessions/close", NULL, RM_EXACT, "session.close", 0, rh_dispatch_op},
     {"POST", "/v1/sessions/get", NULL, RM_EXACT, "session.get", 0, rh_dispatch_op},
     {"POST", "/v1/sessions/brief", NULL, RM_EXACT, "session.brief", 0, rh_dispatch_op},

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -7,6 +7,7 @@
 #include "aimee.h"
 #include "../db1/db.h"
 #include "../db1/eval.h"
+#include "../db1/server_sessions.h"
 #include "agent_config.h"
 #include "agent_eval.h"
 #include "hud.h"
@@ -414,6 +415,22 @@ void session_start_emit(app_ctx_t *ctx, const char *hook_input, FILE *out)
    (void)hook_input;
    (void)out;
 }
+/* handle_hooks_session_start now registers a server_sessions row; stub the two
+ * db1 accessors it uses so this dispatch-routing test need not link the db1
+ * layer. get -> miss (so create is attempted), create -> success. */
+int db1_server_session_get(const char *id, db1_server_session_t *out)
+{
+   (void)id;
+   (void)out;
+   return -1;
+}
+int db1_server_session_create(const char *id, const char *client_type, const char *principal)
+{
+   (void)id;
+   (void)client_type;
+   (void)principal;
+   return 0;
+}
 /* session.brief_assemble invokes session_brief_emit (cmd_session_lifecycle.c),
  * also not linked here. Stub it with a marker so the op handler test can assert
  * the emitted brief flows into the response envelope. */
@@ -445,6 +462,10 @@ void session_id_clear_override(void)
 int handle_session_create(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "session.create");
+}
+int handle_session_record_transcript(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "session.record_transcript");
 }
 int handle_session_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {


### PR DESCRIPTION
## Problem
Session conversations were not saved to db1 when a primary ran through aimee's anonymous `/v1/messages` gateway (e.g. Claude Code). `session-start` recorded `session_state` under the real host id, but nothing registered a `server_sessions` listings row or stored the transcript — so a crashed session was unfindable and its chat unlogged.

## Fix
- **Locatable:** `session-start` now registers a `server_sessions` row under the real host session id (idempotent).
- **Logged:** new route `POST /v1/sessions/record_transcript` persists a transcript to `primary_sessions` under the session id. It enforces `is_safe_id`, confirms the `server_sessions` row is actually present after create (re-get), and checks caller ownership on the final row before any durable write.
- **Client:** the `user-prompt-submit` hook ships the host transcript (`session_id` + `transcript_path`) each turn. Oversize transcripts ship the newest **tail** (whole JSONL records only, no mid-line corruption), bounded under the per-method limit `LIMIT_TRANSCRIPT` (< `SHTTP_MAX_BODY`).
- **Native primaries:** `chat_stream_worker` registers + logs aimee-native primaries by `aimee_session_id`; inbound ACP session ids are made process-unique.

## Validation
- Multi-model **roundtable: APPROVE** (after two revise cycles addressing truncation, id validation, registration-failure, and ownership race).
- Live end-to-end against a throwaway server: new-session create+own, same-caller rewrite, cross-principal refusal (no write), bad-id rejection, oversize tail-read (17 MB → newest window), small path.
- Builds clean under `-Werror`; clang-format clean; v1 route-coverage + cli-route lints pass; acp/session unit tests pass.