### PR TITLE
fix(git): seal browser-set SSH keys with the server KEK — no vault unlock

### DIFF
--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -148,8 +148,7 @@ export default function Projects() {
       // Always drop the key from component state once it has left the browser —
       // never leave private-key material sitting in React state / the textarea.
       setCredSSHKey('');
-      if (r.status === 423) { setErr('unlock your vault first, then add the SSH key'); }
-      else if (!r.ok) { setErr(d.error || 'could not save SSH key'); }
+      if (!r.ok) { setErr(d.error || 'could not save SSH key'); }
       else { setErr('SSH key saved'); }
     } finally { setBusy(false); }
   }
@@ -280,8 +279,8 @@ export default function Projects() {
             <summary style={{ cursor: 'pointer' }}>SSH private key (for git over SSH)</summary>
             <div style={{ marginTop: '6px' }}>
               <div style={{ marginBottom: '6px' }}>
-                Paste an <b>unencrypted</b> OpenSSH/PEM private key (no passphrase). It is stored only in
-                your encrypted vault and never shown again. Requires your vault to be unlocked.
+                Paste an <b>unencrypted</b> OpenSSH/PEM private key (no passphrase). It is sealed
+                server-side in your encrypted vault and never shown again — no vault unlock needed.
               </div>
               <textarea style={{ ...input, width: '100%', minHeight: '110px', fontFamily: 'monospace' }}
                 placeholder={'-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----'}

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -91,6 +91,16 @@ vault_status_t vault_service_set_server(const char *agent, const char *cred, con
 vault_status_t vault_service_get_server_principal(const char *agent, const char *cred, char *out,
                                                   size_t out_len);
 
+/* Store `secret` for (agent, cred) under `principal`, wrapped ONLY with the server
+ * master KEK — NO user unlock required, yet read back autonomously via
+ * vault_service_get_server_wrap. The write-side counterpart of that read: lets the
+ * browser set a per-webuser credential the server must load without the user's
+ * session KEK (e.g. a git SSH key), keeping the secret under the owner's own
+ * principal (not the shared "server" namespace). The principal's vault file is
+ * created if absent. VAULT_OK, or VAULT_ERR_BADARG/CRYPTO/IO (fail closed). */
+vault_status_t vault_service_set_server_wrap(const char *principal, const char *agent,
+                                             const char *cred, const char *secret);
+
 /* Autonomous per-principal read via the server wrap of a dual-wrapped credential
  * (vault_service_set stores both a user-KEK and a server-KEK wrap). Resolves
  * (agent, cred) for ANY `principal` (e.g. a `webuser:` git credential) using the

--- a/src/headers/vault_store.h
+++ b/src/headers/vault_store.h
@@ -73,6 +73,15 @@ int vault_store_set_dual(const char *principal, const uint8_t kek[VAULT_KEK_LEN]
                          const uint8_t server_kek[VAULT_KEK_LEN], const char *agent,
                          const char *cred, const char *secret);
 
+/* Encrypt `secret` for (principal, agent, cred) wrapped ONLY under `server_kek`
+ * (the "wrapped_dek_server" field; NO user-KEK wrap) and upsert it into the
+ * principal's vault file. The write-side counterpart of vault_store_get_server:
+ * lets a per-`principal` credential (e.g. a webuser git SSH key) be SET with no
+ * user unlock, yet read back autonomously by the server. The vault file must
+ * already exist (the caller creates the salt). 0 on success, -1 on error. */
+int vault_store_set_server(const char *principal, const uint8_t server_kek[VAULT_KEK_LEN],
+                           const char *agent, const char *cred, const char *secret);
+
 /* Decrypt the (agent, cred) credential for `principal` using the SERVER wrap
  * ("wrapped_dek_server") under `server_kek` — NO user KEK / unlock required. This
  * is the autonomous server use-path. Returns 0 on success, VAULT_STORE_NO_ENTRY

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -1544,8 +1544,8 @@ static int rh_git_sshkey(const route_req_t *rq, char *resp, int cap)
     * storing needs NO vault unlock — parity with per-host git tokens and delegate
     * keys. It is read back the same way (git_forge_vault_sshkey ->
     * vault_service_get_server_wrap), so there is never a VAULT_ERR_LOCKED here. */
-   vault_status_t st = vault_service_set_server_wrap(principal, GIT_FORGE_VAULT_AGENT,
-                                                     GIT_FORGE_SSHKEY_CRED, key);
+   vault_status_t st =
+       vault_service_set_server_wrap(principal, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED, key);
    /* Zero our parsed copy of the secret before freeing the JSON tree. */
    if (jkey && jkey->valuestring)
    {

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -1476,13 +1476,13 @@ static int rh_git_credentials(const route_req_t *rq, char *resp, int cap)
               : err_json(resp, cap, 500, "too large");
 }
 
-/* Per-webuser SSH private key for git over SSH. Stored in the caller's OWN
- * encrypted vault under (webuser:<name>, "git", "ssh_key") — dual-wrapped so the
- * server can load it into the user's in-memory ssh-agent autonomously
- * (git_ssh_agent_ensure → git_forge_vault_sshkey), while the key never reaches
- * the browser (write-only) and never lands on disk. Storing needs the caller's
- * vault unlocked (the per-principal KEK); a locked vault returns 423 so the UI
- * can prompt an unlock. The secret is never logged. */
+/* Per-webuser SSH private key for git over SSH. Stored under the caller's OWN
+ * principal (webuser:<name>, "git", "ssh_key") but sealed with the SERVER master
+ * KEK (a server-only wrap), so the server can load it into the user's in-memory
+ * ssh-agent autonomously (git_ssh_agent_ensure → git_forge_vault_sshkey) AND
+ * storing it needs NO vault unlock — parity with per-host git tokens and delegate
+ * keys. The key never reaches the browser (write-only) and never lands on disk.
+ * The secret is never logged. */
 static int rh_git_sshkey(const route_req_t *rq, char *resp, int cap)
 {
    if (!git_surface_enabled())
@@ -1540,8 +1540,12 @@ static int rh_git_sshkey(const route_req_t *rq, char *resp, int cap)
                       "passphrase-encrypted keys are not supported; provide an unencrypted key");
    }
 
-   vault_status_t st = vault_service_set(principal, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED,
-                                         key, (long)time(NULL));
+   /* Seal the key under the SERVER master KEK (not the caller's per-user KEK) so
+    * storing needs NO vault unlock — parity with per-host git tokens and delegate
+    * keys. It is read back the same way (git_forge_vault_sshkey ->
+    * vault_service_get_server_wrap), so there is never a VAULT_ERR_LOCKED here. */
+   vault_status_t st = vault_service_set_server_wrap(principal, GIT_FORGE_VAULT_AGENT,
+                                                     GIT_FORGE_SSHKEY_CRED, key);
    /* Zero our parsed copy of the secret before freeing the JSON tree. */
    if (jkey && jkey->valuestring)
    {
@@ -1550,8 +1554,6 @@ static int rh_git_sshkey(const route_req_t *rq, char *resp, int cap)
          p[i] = 0;
    }
    cJSON_Delete(body);
-   if (st == VAULT_ERR_LOCKED)
-      return err_json(resp, cap, 423, "vault is locked — unlock it, then add the key");
    if (st != VAULT_OK)
       return err_json(resp, cap, 500, "vault store failed");
    /* A freshly stored key supersedes any agent already running with the old one. */

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -118,6 +118,31 @@ vault_status_t vault_service_set_server(const char *agent, const char *cred, con
    return st;
 }
 
+vault_status_t vault_service_set_server_wrap(const char *principal, const char *agent,
+                                             const char *cred, const char *secret)
+{
+   if (!principal || !principal[0] || !agent || !agent[0] || !cred || !cred[0] || !secret)
+      return VAULT_ERR_BADARG;
+   uint8_t server_kek[VAULT_KEK_LEN];
+   if (vault_server_kek(server_kek) != 0)
+      return VAULT_ERR_CRYPTO; /* fail-closed: no server KEK -> never store plaintext */
+
+   /* The principal's vault file must exist before set; create it (with its salt)
+    * so a webuser who has never unlocked can still have a server-wrapped cred
+    * sealed. The salt is unused for the server wrap (server KEK derives from the
+    * master key), but a later unlock uses this same salt to derive the user KEK. */
+   uint8_t salt[VAULT_SALT_LEN];
+   vault_status_t st;
+   if (vault_store_get_or_create_salt(principal, salt) != 0)
+      st = VAULT_ERR_IO;
+   else
+      st = vault_store_set_server(principal, server_kek, agent, cred, secret) == 0 ? VAULT_OK
+                                                                                   : VAULT_ERR_IO;
+   OPENSSL_cleanse(server_kek, sizeof(server_kek));
+   OPENSSL_cleanse(salt, sizeof(salt));
+   return st;
+}
+
 vault_status_t vault_service_unlock(const char *principal, attested_transport_t transport,
                                     const uint8_t *root_key, size_t root_key_len, long now_epoch)
 {

--- a/src/server/vault_store.c
+++ b/src/server/vault_store.c
@@ -333,13 +333,15 @@ static int add_b64_field(cJSON *obj, const char *name, const uint8_t *bin, size_
    return 0;
 }
 
-/* Shared set implementation. When `server_kek` is non-NULL the DEK is wrapped a
- * second time under it ("wrapped_dek_server") for dual-access (WP-C.4). */
-static int vault_store_set_impl(const char *principal, const uint8_t kek[VAULT_KEK_LEN],
+/* Shared set implementation. `kek` (user wrap) and `server_kek` (server wrap,
+ * "wrapped_dek_server", WP-C.4 dual-access) are each optional, but at least one
+ * must be present: kek-only = vault_store_set, both = _set_dual, server_kek-only
+ * = _set_server (a server-readable cred set with no user KEK / unlock). */
+static int vault_store_set_impl(const char *principal, const uint8_t *kek,
                                 const uint8_t *server_kek, const char *agent, const char *cred,
                                 const char *secret)
 {
-   if (!principal || !kek || !agent || !agent[0] || !cred || !cred[0] || !secret)
+   if (!principal || (!kek && !server_kek) || !agent || !agent[0] || !cred || !cred[0] || !secret)
       return -1;
    size_t pt_len = strlen(secret);
    if (pt_len > VAULT_SECRET_MAX)
@@ -368,7 +370,9 @@ static int vault_store_set_impl(const char *principal, const uint8_t kek[VAULT_K
    if (vault_secret_encrypt(dek, (const uint8_t *)aad, strlen(aad), (const uint8_t *)secret, pt_len,
                             nonce, ct, tag) != 0)
       goto out;
-   if (vault_dek_wrap(kek, dek, wrapped) != 0)
+   /* User wrap: optional (a server-only entry has no wrapped_dek — it is read
+    * back exclusively via the server wrap). Fail-closed on a wrap error. */
+   if (kek && vault_dek_wrap(kek, dek, wrapped) != 0)
       goto out;
    /* Dual-access: a second wrap of the same DEK under the server KEK. Fail-closed
     * — if requested but it can't be produced, store nothing (never a credential
@@ -387,7 +391,7 @@ static int vault_store_set_impl(const char *principal, const uint8_t kek[VAULT_K
          goto out;
       cJSON_AddStringToObject(obj, "agent", agent);
       cJSON_AddStringToObject(obj, "cred", cred);
-      if (add_b64_field(obj, "wrapped_dek", wrapped, sizeof(wrapped)) != 0 ||
+      if ((kek && add_b64_field(obj, "wrapped_dek", wrapped, sizeof(wrapped)) != 0) ||
           add_b64_field(obj, "nonce", nonce, sizeof(nonce)) != 0 ||
           add_b64_field(obj, "ciphertext", ct, pt_len) != 0 ||
           add_b64_field(obj, "tag", tag, sizeof(tag)) != 0 ||
@@ -427,6 +431,16 @@ int vault_store_set_dual(const char *principal, const uint8_t kek[VAULT_KEK_LEN]
    if (!server_kek)
       return -1;
    return vault_store_set_impl(principal, kek, server_kek, agent, cred, secret);
+}
+
+int vault_store_set_server(const char *principal, const uint8_t server_kek[VAULT_KEK_LEN],
+                           const char *agent, const char *cred, const char *secret)
+{
+   if (!server_kek)
+      return -1;
+   /* No user KEK: the entry carries only a server wrap, so it can be set without
+    * an unlocked user vault and read back via vault_store_get_server. */
+   return vault_store_set_impl(principal, NULL, server_kek, agent, cred, secret);
 }
 
 int vault_store_get(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,

--- a/src/tests/support/vault_service_stub.c
+++ b/src/tests/support/vault_service_stub.c
@@ -56,6 +56,18 @@ vault_status_t vault_service_set(const char *principal, const char *agent, const
    return VAULT_OK;
 }
 
+/* rh_git_sshkey now seals the key under the server KEK (no unlock); same clean
+ * success for tests linking server_http.o without the real vault. */
+vault_status_t vault_service_set_server_wrap(const char *principal, const char *agent,
+                                             const char *cred, const char *secret)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+   (void)secret;
+   return VAULT_OK;
+}
+
 vault_status_t vault_service_delete(const char *principal, const char *agent, const char *cred)
 {
    (void)principal;

--- a/src/tests/test_git_forge_vault.c
+++ b/src/tests/test_git_forge_vault.c
@@ -86,8 +86,8 @@ int main(void)
     * this change removes). GREEN: the server-sealed intake below just works. */
    assert(vault_service_set(carol, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED, ckey, T0) ==
           VAULT_ERR_LOCKED);
-   assert(vault_service_set_server_wrap(carol, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED, ckey) ==
-          VAULT_OK);
+   assert(vault_service_set_server_wrap(carol, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED,
+                                        ckey) == VAULT_OK);
    vault_kek_cache_clear();
    assert(git_forge_vault_sshkey(carol, out, sizeof(out)) == 1);
    assert(strcmp(out, ckey) == 0);

--- a/src/tests/test_git_forge_vault.c
+++ b/src/tests/test_git_forge_vault.c
@@ -76,6 +76,32 @@ int main(void)
    assert(git_forge_vault_token("", out, sizeof(out)) == 0);
    assert(out[0] == '\0');
 
+   /* SERVER-SEALED INTAKE (the /v1/git/sshkey write path): a webuser who has
+    * NEVER unlocked can seal an SSH key with the server KEK alone — no cached user
+    * KEK, no 423 — and the server reads it back autonomously. */
+   const char *carol = "webuser:carol";
+   const char *ckey = "-----BEGIN OPENSSH PRIVATE KEY-----\ncarolKEY\n-----END-----";
+   vault_kek_cache_clear(); /* prove no user KEK is cached for carol */
+   /* RED: the old per-user-KEK intake is LOCKED for a never-unlocked user (the 423
+    * this change removes). GREEN: the server-sealed intake below just works. */
+   assert(vault_service_set(carol, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED, ckey, T0) ==
+          VAULT_ERR_LOCKED);
+   assert(vault_service_set_server_wrap(carol, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED, ckey) ==
+          VAULT_OK);
+   vault_kek_cache_clear();
+   assert(git_forge_vault_sshkey(carol, out, sizeof(out)) == 1);
+   assert(strcmp(out, ckey) == 0);
+   /* The user-KEK path can't read a server-only entry carol never unlocked. */
+   assert(vault_service_get(carol, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED, out, sizeof(out),
+                            T0) != VAULT_OK);
+   /* Isolation holds: alice's own key is unaffected; carol never sees it. */
+   assert(git_forge_vault_sshkey(alice, out, sizeof(out)) == 1);
+   assert(strcmp(out, akey) == 0);
+   /* Delete round-trips with no unlock too (DELETE /v1/git/sshkey). */
+   assert(vault_service_delete(carol, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED) == VAULT_OK);
+   assert(git_forge_vault_sshkey(carol, out, sizeof(out)) == 0);
+   assert(out[0] == '\0');
+
    char clean[320];
    snprintf(clean, sizeof(clean), "rm -rf %s", home);
    assert(system(clean) == 0);


### PR DESCRIPTION
## Problem

The **Projects** webGUI page hard-required an unlocked vault for exactly one action: saving an **SSH private key** returned HTTP **423 "vault is locked"**. Everything else on the page (project list, clone, git ops, per-host access tokens, GitHub OAuth) already worked fine with a locked vault.

## Root cause

`rh_git_sshkey` wrote the key via `vault_service_set()` — the **per-user KEK** path, which needs `aimee vault unlock` first. Yet the server *reads* the key back autonomously via the **server wrap** (`vault_service_get_server_wrap`). So the write demanded an unlock the read never needed. Per-host git tokens (`git_host_cred.c`) and delegate keys already avoid this by sealing under the **server master KEK** — the SSH key was the lone holdout. Same class of bug as the delegate-key fix in #1121.

## Fix

Seal the SSH key with the server KEK at write time, keeping it under the owner's own `webuser:` principal.

- **`vault_store.{c,h}`** — new `vault_store_set_server()` writes a server-wrap-only entry (`wrapped_dek_server`, no user wrap); `vault_store_set_impl` generalized so the user KEK is optional.
- **`vault_service.{c,h}`** — new `vault_service_set_server_wrap()`, the write-side counterpart of `vault_service_get_server_wrap`; creates the principal's vault file if absent so a never-unlocked user still works.
- **`server_http_routes.c`** — `rh_git_sshkey` seals via the server wrap; dead 423-on-locked branch removed.
- **`Projects.tsx`** — reworded the SSH-key note ("no vault unlock needed"); removed the dead 423 handler.
- **`test_git_forge_vault.c`** — red→green test: a never-unlocked user's `vault_service_set` is `LOCKED`, while `set_server_wrap` seals + autonomously reads back the key, with cross-user isolation and a delete round-trip.

Existing keys are unaffected — they already carry server wraps (from dual-set or unlock-time backfill).

## Verification

- New test passes; RED assertion confirms the old path was locked.
- Regression sweep — 9 vault/git tests pass (`vault-store`, `vault-service`, `vault-master-rotate`, `git-forge-vault`, `git-ops`, `git-project`, `webchat-git-leak`, `git-ssh-agent`, `git-cred-inject`).
- `vault_store.c`, `vault_service.c`, `server_http_routes.c` compile clean under `-Werror`.
- Validation-pending: the full browser→webchat→server HTTP round-trip wasn't exercised (no running stack in the dev env); it's a straight function swap on an already-tested vault round-trip.