### PR TITLE
P3a: anchored grep (hits are ready edit anchors)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -255,7 +255,7 @@ else ifeq ($(UNAME_S),Darwin)
         posix/agent_shell_claude.c posix/agent_shell_claude_pty.c posix/agent_shell_codex.c posix/agent_shell_gemini.c \
         $(UI_PLATFORM_SRCS)
     PLATFORM_AGENT_SRCS = \
-        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
+        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/agent_tools_grep_anchor.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
 else
     PLATFORM_BASIC_SRCS = \
         posix/platform_ipc.c posix/platform_path.c posix/platform_process.c \
@@ -271,7 +271,7 @@ else
         posix/agent_shell_claude.c posix/agent_shell_claude_pty.c posix/agent_shell_codex.c posix/agent_shell_gemini.c \
         $(UI_PLATFORM_SRCS)
     PLATFORM_AGENT_SRCS = \
-        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
+        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/agent_tools_grep_anchor.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
 endif
 
 PLATFORM_SRCS       = $(PLATFORM_BASIC_SRCS) $(PLATFORM_EXTRA_SRCS) $(PLATFORM_AGENT_SRCS)

--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -22,6 +22,11 @@ char *tool_read_file_ex(const char *path, int offset, int limit, int anchored, c
  * blast advisory without writing. `edits` is a `struct cJSON *`. */
 char *tool_edit_file_anchored(const char *path, const char *snapshot_id, const struct cJSON *edits,
                               int dry_run, const char *sid);
+/* Anchored grep: like tool_grep but, when `anchored`, groups hits by file with a
+ * per-file snapshot id and prefixes each hit with its `N:hash` edit anchor so a
+ * match is directly editable via edit_file. anchored=0 returns raw grep output. */
+char *tool_grep_ex(const char *path, const char *pattern, int max_results, int anchored,
+                   const char *sid);
 char *tool_write_file(const char *path, const char *content);
 /* Surgical edit: replace old_string with new_string in an existing file.
  * old_string must occur exactly once unless replace_all is non-zero (then all

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -2119,6 +2119,7 @@ char *tool_grep(const char *path, const char *pattern, int max_results)
 
    return output ? output : safe_strdup("no matches found");
 }
+
 /* --- git_diff: show working tree changes --- */
 char *tool_git_diff(const char *repo_path, const char *ref)
 {

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -748,11 +748,15 @@ static char *td_grep(cJSON *args, const char *name, const char *dispatch_cwd,
    cJSON *p = cJSON_GetObjectItem(args, "path");
    cJSON *pat = cJSON_GetObjectItem(args, "pattern");
    cJSON *mx = cJSON_GetObjectItem(args, "max_results");
+   cJSON *raw = cJSON_GetObjectItem(args, "raw");
    if (!p || !cJSON_IsString(p) || !pat || !cJSON_IsString(pat))
       result = safe_strdup("error: missing 'path' or 'pattern' parameter");
    else
-      result = tool_grep(p->valuestring, pat->valuestring,
-                         (mx && cJSON_IsNumber(mx)) ? mx->valueint : 50);
+   {
+      int anchored = !(raw && cJSON_IsBool(raw) && cJSON_IsTrue(raw));
+      result = tool_grep_ex(p->valuestring, pat->valuestring,
+                            (mx && cJSON_IsNumber(mx)) ? mx->valueint : 50, anchored, dispatch_sid);
+   }
 
    return result;
 }

--- a/src/posix/agent_tools_grep_anchor.c
+++ b/src/posix/agent_tools_grep_anchor.c
@@ -1,0 +1,227 @@
+/* posix/agent_tools_grep_anchor.c: anchored-grep post-processor.
+ *
+ * Wraps tool_grep so that, by default, hits are grouped by file with a per-file
+ * read snapshot and each matching line carries its `N:hash` edit anchor — making
+ * a grep hit directly editable via edit_file with no intervening read. Split out
+ * of posix/agent_tools.c to keep that file under the line-count limit. */
+#include "aimee.h"
+#include "agent_tools.h"
+#include "agent_tools_internal.h"
+#include "hashline_anchor.h"
+#include "util.h"
+#include "workspace_provider.h"
+
+#include "dstr.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+/* Parse one `grep -rn` output line. The output SHAPE is determined by whether the
+ * search target was a single file or a directory, so the caller passes
+ * `single_file` rather than guessing per line (removing the ambiguity between a
+ * "LINENO:CONTENT" single-file line and a directory line whose path starts with
+ * digits):
+ *   - single_file: "LINENO:CONTENT" — grep omits the filename; `*path` is set
+ *     NULL and the caller supplies the searched file path;
+ *   - directory:   "PATH:LINENO:CONTENT" — first ":<digits>:" is the LINENO
+ *     boundary (LINENO sits right after the path; CONTENT may contain its own
+ *     ":<digits>:" runs, so first-match beats last-match). A path containing a
+ *     colon can still misparse, but only degrades to a passthrough line (the read
+ *     of the misparsed path fails to resolve), never a crash.
+ * LINENO is required to be >= 1. Returns 0 on success, -1 if not a grep hit. */
+static int grep_parse_line(const char *line, size_t linelen, int single_file, const char **path,
+                           size_t *pathlen, long *lineno, const char **content)
+{
+   if (single_file)
+   {
+      size_t d = 0;
+      while (d < linelen && isdigit((unsigned char)line[d]))
+         d++;
+      if (d == 0 || d >= linelen || line[d] != ':')
+         return -1;
+      long v = strtol(line, NULL, 10);
+      if (v < 1)
+         return -1;
+      *path = NULL;
+      *pathlen = 0;
+      *lineno = v;
+      *content = line + d + 1;
+      return 0;
+   }
+   for (size_t i = 0; i < linelen; i++)
+   {
+      if (line[i] != ':' || i + 1 >= linelen || !isdigit((unsigned char)line[i + 1]))
+         continue;
+      size_t j = i + 1;
+      while (j < linelen && isdigit((unsigned char)line[j]))
+         j++;
+      if (j < linelen && line[j] == ':')
+      {
+         long v = strtol(line + i + 1, NULL, 10);
+         if (v < 1)
+            return -1;
+         *path = line;
+         *pathlen = i;
+         *lineno = v;
+         *content = line + j + 1;
+         return 0;
+      }
+   }
+   return -1;
+}
+
+#define GREP_MAX_FILES 256
+typedef struct
+{
+   char *path;                    /* NUL-terminated file path from grep */
+   char *snap;                    /* minted snapshot id (owned) */
+   hashline_snapshot_view_t view; /* owned digests (freed at end) */
+   int resolved;                  /* 1 if we successfully read+minted */
+} grep_file_t;
+
+/* Anchored grep: post-process raw `grep -rn` output so every hit is a ready edit
+ * anchor. Groups hits by file, mints one snapshot per file, and prefixes each
+ * matching line with its `N:hash` anchor. raw:true (anchored=0) returns the plain
+ * grep output. */
+char *tool_grep_ex(const char *path, const char *pattern, int max_results, int anchored,
+                   const char *sid)
+{
+   char *raw = tool_grep(path, pattern, max_results);
+   if (!anchored || !raw || strncmp(raw, "error:", 6) == 0 || strcmp(raw, "no matches found") == 0)
+      return raw;
+
+   grep_file_t files[GREP_MAX_FILES];
+   int nfiles = 0;
+   dstr_t out;
+   dstr_init(&out);
+
+   /* Grep's output shape depends on whether the target is a file or a directory.
+    * Resolve the query path once and stat it, so the parser is told the shape
+    * definitively rather than guessing per line. */
+   char qbuf[MAX_PATH_LEN];
+   const char *query_path = path_in_thread_cwd(path, qbuf, sizeof(qbuf));
+   struct stat qst;
+   int single_file = (stat(query_path, &qst) == 0 && S_ISREG(qst.st_mode));
+
+   const workspace_provider_t *ws = workspace_provider_active();
+   size_t rawlen = strlen(raw);
+   size_t i = 0;
+   const char *last_emitted_path = NULL;
+   int cap_hit = 0;
+   while (i < rawlen)
+   {
+      size_t s = i;
+      while (i < rawlen && raw[i] != '\n')
+         i++;
+      size_t e = i;
+      if (i < rawlen)
+         i++;
+      if (e == s)
+         continue;
+
+      const char *p = NULL, *content = NULL;
+      size_t plen = 0;
+      long lineno = 0;
+      if (grep_parse_line(raw + s, e - s, single_file, &p, &plen, &lineno, &content) != 0)
+      {
+         /* Non-matching line (e.g. a grep note) — pass through verbatim. */
+         dstr_append(&out, raw + s, e - s);
+         dstr_append_char(&out, '\n');
+         continue;
+      }
+      /* Single-file shape (p==NULL): the file is the resolved query path. */
+      const char *fp = p ? p : query_path;
+      size_t fplen = p ? plen : strlen(query_path);
+
+      /* Find or create the per-file cache entry (read + mint once). Entries in
+       * files[] always have a non-NULL path (we only insert on a successful
+       * strndup), so the dedup compare below never dereferences NULL. */
+      grep_file_t *gf = NULL;
+      for (int k = 0; k < nfiles; k++)
+         if (strncmp(files[k].path, fp, fplen) == 0 && files[k].path[fplen] == '\0')
+         {
+            gf = &files[k];
+            break;
+         }
+      if (!gf)
+      {
+         if (nfiles >= GREP_MAX_FILES)
+            cap_hit = 1;
+         else
+         {
+            char *pcopy = strndup(fp, fplen);
+            if (pcopy)
+            {
+               gf = &files[nfiles++];
+               memset(gf, 0, sizeof(*gf));
+               gf->path = pcopy;
+               char *fdata = NULL;
+               size_t flen = 0;
+               if (ws->read_all(ws, gf->path, &fdata, &flen) == 0)
+               {
+                  gf->snap = hashline_snapshot_mint(sid, gf->path, fdata, flen);
+                  if (gf->snap && hashline_snapshot_get(sid, gf->snap, &gf->view))
+                     gf->resolved = 1;
+               }
+               free(fdata);
+            }
+         }
+      }
+
+      size_t content_len = (size_t)((raw + e) - content);
+      const char *pathz = gf ? gf->path : NULL;
+      if (!pathz)
+      {
+         /* Cache full or path copy failed — emit a still-useful hit line. */
+         dstr_appendf(&out, "%.*s:%ld: ", (int)fplen, fp, lineno);
+         dstr_append(&out, content, content_len);
+         dstr_append_char(&out, '\n');
+         continue;
+      }
+
+      /* Emit a file header once per file (with its snapshot id). grep -rn groups
+       * all of a file's hits contiguously, so a path change is a new file. */
+      if (!last_emitted_path || strcmp(last_emitted_path, pathz) != 0)
+      {
+         if (gf->resolved && gf->snap)
+            dstr_appendf(&out, "%s  [snapshot %s]\n", pathz, gf->snap);
+         else
+            dstr_appendf(&out, "%s  [no snapshot — re-read before editing]\n", pathz);
+         last_emitted_path = pathz;
+      }
+
+      if (gf->resolved && lineno >= 1 && (size_t)lineno <= gf->view.line_count)
+      {
+         char tag[HASHLINE_DISPLAY_TAG_HEX + 1];
+         hashline_display_tag(gf->view.line_digests[lineno - 1], tag, sizeof(tag));
+         dstr_appendf(&out, "  %ld:%s| ", lineno, tag);
+      }
+      else
+      {
+         /* Unresolved file or a line past EOF: an explicit non-anchor marker so
+          * the model never mistakes it for an editable anchor. */
+         dstr_appendf(&out, "  %ld:??| ", lineno);
+      }
+      dstr_append(&out, content, content_len);
+      dstr_append_char(&out, '\n');
+   }
+
+   if (cap_hit)
+      dstr_appendf(&out,
+                   "[note: more than %d files matched; hits beyond the first %d files are "
+                   "unanchored — narrow the search or grep them individually]\n",
+                   GREP_MAX_FILES, GREP_MAX_FILES);
+
+   for (int k = 0; k < nfiles; k++)
+   {
+      free(files[k].path);
+      free(files[k].snap);
+      if (files[k].resolved)
+         hashline_snapshot_view_free(&files[k].view);
+   }
+   free(raw);
+   char *ret = out.data ? out.data : safe_strdup("no matches found");
+   return ret;
+}

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -707,6 +707,10 @@ static cJSON *tp_grep(void)
    tp_prop(props, "path", "string", "Directory or file to search in");
    tp_prop(props, "pattern", "string", "Pattern to search for (basic regex)");
    tp_prop(props, "max_results", "integer", "Max results (default 50)");
+   tp_prop(props, "raw", "boolean",
+           "Return plain grep output (file:line: text). Default false: hits are grouped by file "
+           "with a per-file snapshot id and each line carries its N:hash edit anchor, so you can "
+           "edit_file a match directly without a separate read.");
    cJSON_AddItemToObject(params, "properties", props);
    cJSON *req = cJSON_CreateArray();
    cJSON_AddItemToArray(req, cJSON_CreateString("path"));
@@ -955,8 +959,11 @@ static const builtin_tool_def_t g_builtin_tools[] = {
     {"verify", "Verify an assertion. check_type: http_status, file_contains, command_succeeds.",
      tp_verify, TSURF_ALL},
     {"git_log", "Show recent git commits for a repository.", tp_git_log, TSURF_ALL},
-    {"grep", "Search for a pattern in files. Returns matching lines with file:line.", tp_grep,
-     TSURF_ALL},
+    {"grep",
+     "Search for a pattern in files. By default returns matches grouped by file with a per-file "
+     "snapshot id and each hit prefixed by its N:hash edit anchor — pass those to edit_file to "
+     "change a match with no intervening read. Use raw:true for plain file:line output.",
+     tp_grep, TSURF_ALL},
     {"git_diff", "Show git diff for a repository. Optionally diff against a ref.", tp_git_diff,
      TSURF_ALL},
     {"git_status", "Show git status (porcelain format) for a repository.", tp_git_status,

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -42,6 +42,8 @@ char *tool_edit_file(const char *path, const char *old_string, const char *new_s
                      int replace_all);
 char *tool_edit_file_anchored(const char *path, const char *snapshot_id, const cJSON *edits,
                               int dry_run, const char *sid);
+char *tool_grep_ex(const char *path, const char *pattern, int max_results, int anchored,
+                   const char *sid);
 char *tool_list_files(const char *path, const char *pattern);
 char *tool_grep(const char *path, const char *pattern, int max_results);
 char *dispatch_tool_call(const char *name, const char *arguments_json, int timeout_ms);
@@ -1291,6 +1293,72 @@ static void test_tool_edit_file_anchored(void)
    unlink(tmppath);
 }
 
+static void test_tool_grep_anchored(void)
+{
+   char tmppath[512];
+   snprintf(tmppath, sizeof(tmppath), "%s/aimee_test_grep_XXXXXX", platform_tmpdir());
+   int fd = platform_mkstemp(tmppath, sizeof(tmppath), "aim");
+   assert(fd >= 0);
+   const char *content = "alpha\nfindme here\nbeta\nfindme again\n";
+   if (write(fd, content, strlen(content)) < 0)
+   { /* ignore */
+   }
+   close(fd);
+   const char *sid = "grepX";
+
+   /* Anchored grep: a file header carries the snapshot; each hit carries its
+    * N:hash anchor, so the match is directly editable with no intervening read. */
+   char *g = tool_grep_ex(tmppath, "findme", 50, 1, sid);
+   assert(g != NULL);
+   assert(strstr(g, "[snapshot ") != NULL);
+   assert(strstr(g, "2:") != NULL && strstr(g, "| findme here") != NULL);
+
+   /* Extract the snapshot id ("[snapshot <id>]") and the line-2 anchor
+    * ("\n  2:<tag>| ") from the grouped grep output, then edit by anchor. */
+   char snap[80], anchor2[24];
+   const char *sp = strstr(g, "[snapshot ");
+   assert(sp != NULL);
+   sp += strlen("[snapshot ");
+   size_t si = 0;
+   while (sp[si] && sp[si] != ']' && si + 1 < sizeof(snap))
+   {
+      snap[si] = sp[si];
+      si++;
+   }
+   snap[si] = '\0';
+   const char *ap = strstr(g, "\n  2:");
+   assert(ap != NULL);
+   ap += 3; /* skip "\n  " */
+   size_t ai = 0;
+   while (ap[ai] && ap[ai] != '|' && ai + 1 < sizeof(anchor2))
+   {
+      anchor2[ai] = ap[ai];
+      ai++;
+   }
+   anchor2[ai] = '\0';
+   free(g);
+   cJSON *edits = cJSON_CreateArray();
+   cJSON *op = cJSON_CreateObject();
+   cJSON_AddStringToObject(op, "op", "replace");
+   cJSON_AddStringToObject(op, "at", anchor2);
+   cJSON_AddStringToObject(op, "text", "FOUND");
+   cJSON_AddItemToArray(edits, op);
+   char *res = tool_edit_file_anchored(tmppath, snap, edits, 0, sid);
+   assert(res && strstr(res, "\"status\":\"ok\"") != NULL);
+   free(res);
+   cJSON_Delete(edits);
+   char *after = tool_read_file_ex(tmppath, 0, 0, 0, sid);
+   assert(after && strcmp(after, "alpha\nFOUND\nbeta\nfindme again\n") == 0);
+   free(after);
+
+   /* raw:true is the plain grep output — no snapshot header. */
+   char *graw = tool_grep_ex(tmppath, "findme", 50, 0, sid);
+   assert(graw && strstr(graw, "[snapshot ") == NULL);
+   free(graw);
+
+   unlink(tmppath);
+}
+
 static void test_parent_write_guard_blocks_parent_writes(void)
 {
    char root[512];
@@ -2516,6 +2584,7 @@ int main(void)
    test_tool_write_file();
    test_tool_edit_file();
    test_tool_edit_file_anchored();
+   test_tool_grep_anchored();
    test_parent_write_guard_blocks_parent_writes();
    test_session_isolation_guard();
    test_parent_write_guard_readonly_pipeline();


### PR DESCRIPTION
Phase 3a — grep hits become directly-editable anchors.

By default `grep` returns hits grouped by file with a per-file read snapshot and each matching line prefixed by its `N:hash` edit anchor, so a hit is editable via `edit_file` with no intervening read (grep→read→edit collapses to grep→edit). `raw:true` returns plain grep output.

- New `posix/agent_tools_grep_anchor.c` (`tool_grep_ex`): stats the query to pick the grep output shape (single-file `LINENO:CONTENT` vs directory `PATH:LINENO:CONTENT`), mints one snapshot per matched file, and prefixes each hit with its anchor; unresolved files / out-of-range lines get an explicit non-anchor `N:??|` marker; a `>256`-file cache overflow falls back to plain grep lines + a note. Split into its own TU for the line limit.
- `tool_grep` unchanged (`-rn`, byte-exact legacy output); dispatch adds a `raw` opt-out; schema/description advertise the anchored default.

**Review:** roundtable SHIP (final round, 0 findings) after fixing the output-shape ambiguity and verifying the memory-safety concerns were false against the code.
**Verification:** test_agent grep→edit-by-anchor + raw; make -j all server + make lint + full unit-tests green.

Refs: docs/proposals/pending/proposal-hashline-edit-and-lean-websearch.md (P3)