### PR TITLE
fix(wfe): stop workflow worktrees from leaking /tmp inodes (test cleanup + runtime orphan GC + cap)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -253,7 +253,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 146 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 147 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -451,7 +451,7 @@ The binaries read 146 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -9,7 +9,7 @@
 
 #include "log.h"
 #include "wfe_autonomy.h"
-#include "wfe_blocks.h" /* wfe_worktree_cleanup — orphan-sweep of terminal worktrees */
+#include "wfe_blocks.h" /* wfe_worktree_cleanup (terminal) + wfe_worktree_orphan_gc (age-based) */
 #include "wfe_store.h"
 
 #include <pthread.h>
@@ -65,6 +65,25 @@ void wfe_scheduler_run_once(void)
                    err[0] ? err : "error");
    }
    free(items);
+
+   /* Age-based orphan GC: reap wfe-worktrees dirs no live work item owns (a deleted
+    * row, or a crashed run that never reached terminal) once past a grace window,
+    * so a full git worktree can't be stranded — and its inodes leaked — forever.
+    * Complements the per-item terminal cleanup above, which only fires on a clean
+    * state transition. AIMEE_WFE_WORKTREE_GC_GRACE_SECS overrides the default. */
+   long grace = 3600;
+   const char *gv = getenv("AIMEE_WFE_WORKTREE_GC_GRACE_SECS");
+   if (gv && gv[0])
+   {
+      char *end = NULL;
+      long g = strtol(gv, &end, 10);
+      if (end && *end == '\0' && g >= 0)
+         grace = g;
+   }
+   const char *rl = getenv("AIMEE_WORKFLOW_REPO");
+   int reaped = wfe_worktree_orphan_gc((rl && rl[0]) ? rl : ".", grace);
+   if (reaped > 0)
+      aimee_log(LOG_INFO, "wfe-sched", "orphan-GC reaped %d stale worktree(s)", reaped);
 }
 
 static void *wfe_scheduler_loop(void *arg)

--- a/src/tests/test_wfe_advance_exec.c
+++ b/src/tests/test_wfe_advance_exec.c
@@ -4,6 +4,7 @@
  * resolves the binding, applies the CAS/replay decision, advances exactly one
  * engine step on OK, refuses stale/unbound, is idempotent on replay, and audits
  * every decision to the lifecycle log. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,7 +40,7 @@ static const char *WF = "name: t\n"
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_adv_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_approval.c
+++ b/src/tests/test_wfe_approval.c
@@ -1,4 +1,5 @@
 /* test_wfe_approval.c -- W4: HMAC approval signer + gate.human executor. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,7 +40,7 @@ static char g_home[64];
 static void setup_home(void)
 {
    strcpy(g_home, "/tmp/wfe_appr_XXXXXX");
-   char *dir = mkdtemp(g_home);
+   char *dir = wfe_test_mkdtemp(g_home);
    assert(dir);
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -1,4 +1,5 @@
 /* test_wfe_autonomy.c -- W6: the autonomy driver + human-only gate-override. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -90,7 +91,7 @@ int main(void)
 {
    printf("wfe-autonomy: ");
    char d[] = "/tmp/wfe_auto_XXXXXX";
-   char *dir = mkdtemp(d);
+   char *dir = wfe_test_mkdtemp(d);
    assert(dir);
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -2,6 +2,7 @@
  * (real DB1 + router + engine, stub executors). Asserts: only enforced-routed
  * turns bind, dial-off is inert, binding is idempotent per session, and a bind
  * lifecycle event is recorded. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,7 +65,7 @@ static const char *WF_MC = "name: mc\n"
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_bind_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_block_resolve.c
+++ b/src/tests/test_wfe_block_resolve.c
@@ -2,6 +2,7 @@
  * dispatch-time externalization guard, against a real in-memory DB1 + engine
  * (stub executors). Covers the pure decision table, the DB resolve, and the
  * composed guard (default-off, deny/warn/allow, delivered lifts, audit). */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -83,7 +84,7 @@ static void write_wf(const char *dir, const char *name, const char *body)
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_res_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_blocks.c
+++ b/src/tests/test_wfe_blocks.c
@@ -1,5 +1,6 @@
 /* test_wfe_blocks.c -- W3: the real git freeze helper + default executor
  * registration. The delegate/forge executors are integration-gated. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,7 +30,7 @@ int main(void)
 
    /* --- wfe_git_freeze against a real temp git repo --- */
    char dir[] = "/tmp/wfe_repo_XXXXXX";
-   if (!mkdtemp(dir))
+   if (!wfe_test_mkdtemp(dir))
    {
       printf("(skip git freeze: mkdtemp) ok\n");
       return 0;

--- a/src/tests/test_wfe_custom.c
+++ b/src/tests/test_wfe_custom.c
@@ -1,5 +1,6 @@
 /* test_wfe_custom.c -- config-extensible blocks: registry load/validate, custom
  * block type-checking, and exec_custom (command opt-in) through the engine. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -52,7 +53,7 @@ int main(void)
 {
    printf("wfe-custom: ");
    strcpy(g_home, "/tmp/wfe_cust_XXXXXX");
-   assert(mkdtemp(g_home));
+   assert(wfe_test_mkdtemp(g_home));
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", g_home);
    mkdir(wf, 0755);

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -4,6 +4,7 @@
  * Phase A of full-autonomous-development: producing blocks dispatch real work
  * through registered hooks; with no provider they fail closed; tests inject
  * mocks to assert the wiring. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -148,7 +149,7 @@ int main(void)
 {
    printf("wfe-delegate-seam: ");
    char home[] = "/tmp/wfe_ds_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wf[160];
    snprintf(wf, sizeof wf, "%s/workflows", home);
    mkdir(wf, 0755);
@@ -361,7 +362,7 @@ int main(void)
     *    idempotent; cleanup removes it. */
    {
       char repo[] = "/tmp/wfe_f2_repo_XXXXXX";
-      assert(mkdtemp(repo));
+      assert(wfe_test_mkdtemp(repo));
       char cmd[640];
       snprintf(cmd, sizeof cmd,
                "cd %s && git init -q && git -c user.email=t@t -c user.name=t "

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -395,6 +395,70 @@ int main(void)
       (void)system(cmd);
    }
 
+   /* F: orphan-worktree GC + inode cap — reap worktrees no LIVE item owns, keep
+    *    active ones, honour the grace window, and fail-closed at the cap. */
+   {
+      char repo[] = "/tmp/wfe_gc_repo_XXXXXX";
+      assert(wfe_test_mkdtemp(repo));
+      char cmd[640];
+      snprintf(cmd, sizeof cmd,
+               "cd %s && git init -q && git -c user.email=t@t -c user.name=t "
+               "commit -q --allow-empty -m base",
+               repo);
+      assert(system(cmd) == 0);
+      struct stat stt;
+      char err[256] = "";
+      /* Start from an empty worktree pool so counts are deterministic (earlier
+       * blocks left terminal-item worktrees under the shared AIMEE_HOME). */
+      snprintf(cmd, sizeof cmd, "rm -rf %s/wfe-worktrees", home);
+      (void)system(cmd);
+
+      /* (1) an active item's worktree survives a grace=0 GC (it still owns it). */
+      char live_id[80] = "";
+      assert(wfe_work_item_create("ds", "gcL", "gcpL", "autonomous", live_id, err, sizeof err) ==
+             0);
+      char wl[1024] = "";
+      assert(wfe_worktree_ensure(live_id, "", repo, "HEAD", wl, sizeof wl) == 0);
+      assert(wfe_worktree_orphan_gc(repo, 0) == 0); /* nothing reapable */
+      assert(stat(wl, &stt) == 0);                  /* kept */
+
+      /* (2) a TERMINAL item's stranded worktree is reaped. */
+      char term_id[80] = "";
+      assert(wfe_work_item_create("ds", "gcT", "gcpT", "autonomous", term_id, err, sizeof err) ==
+             0);
+      char wtm[1024] = "";
+      assert(wfe_worktree_ensure(term_id, "", repo, "HEAD", wtm, sizeof wtm) == 0);
+      assert(db1_work_item_set_terminal(term_id, "abandoned") == 0);
+      assert(wfe_worktree_orphan_gc(repo, 0) == 1);
+      assert(stat(wtm, &stt) != 0); /* reaped */
+      assert(stat(wl, &stt) == 0);  /* the active one is untouched */
+
+      /* (3) a VANISHED row reaps its worktree, but only past the grace window. */
+      char orph_id[80] = "";
+      assert(wfe_work_item_create("ds", "gcO", "gcpO", "autonomous", orph_id, err, sizeof err) ==
+             0);
+      char wo[1024] = "";
+      assert(wfe_worktree_ensure(orph_id, "", repo, "HEAD", wo, sizeof wo) == 0);
+      assert(db1_work_item_delete(orph_id) == 0);
+      assert(wfe_worktree_orphan_gc(repo, 100000) == 0); /* too fresh -> kept */
+      assert(stat(wo, &stt) == 0);
+      assert(wfe_worktree_orphan_gc(repo, 0) == 1); /* grace 0 -> reaped */
+      assert(stat(wo, &stt) != 0);
+
+      /* (4) inode cap fails closed: with MAX=1 and the active worktree holding the
+       *     one slot, a second ensure can't allocate and returns -1 (the caller
+       *     then degrades to the shared checkout). */
+      setenv("AIMEE_WFE_WORKTREE_MAX", "1", 1);
+      char cap_id[80] = "";
+      assert(wfe_work_item_create("ds", "gcC", "gcpC", "autonomous", cap_id, err, sizeof err) == 0);
+      char wc[1024] = "";
+      assert(wfe_worktree_ensure(cap_id, "", repo, "HEAD", wc, sizeof wc) == -1);
+      unsetenv("AIMEE_WFE_WORKTREE_MAX");
+
+      snprintf(cmd, sizeof cmd, "rm -rf %s", repo);
+      (void)system(cmd);
+   }
+
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_wfe_engine.c
+++ b/src/tests/test_wfe_engine.c
@@ -1,6 +1,7 @@
 /* test_wfe_engine.c -- W2: work-item state machine + engine. Exercises
  * create -> run -> accepted, the audit log, loop-back max_attempts pause, and
  * the cost-cap pause, using deterministic executors. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -72,7 +73,7 @@ static wfe_step_result_t exec_cost(wfe_ctx *c, const wfe_node_t *n)
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_foreach.c
+++ b/src/tests/test_wfe_foreach.c
@@ -8,6 +8,7 @@
  *   - all children accepted              -> advance (every slice merged)
  *   - a child rejected or abandoned      -> park pending_human (a slice will not merge)
  */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -40,7 +41,7 @@ static const char *FE = "name: fe\n"
 static void setup_home(void)
 {
    char d[] = "/tmp/wfe_fe_XXXXXX";
-   char *dir = mkdtemp(d);
+   char *dir = wfe_test_mkdtemp(d);
    assert(dir);
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_foreach_spawn.c
+++ b/src/tests/test_wfe_foreach_spawn.c
@@ -2,6 +2,7 @@
  * fans out to one child "slice" work item per packet, linked to the parent, seeded
  * with its packet, idempotent, and cap-bounded. (The child-DRIVING is the autonomy
  * driver's job, integration-gated; this pins the fan-OUT creation logic.) */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,7 +44,7 @@ int main(void)
 {
    printf("wfe-foreach-spawn: ");
    char home[] = "/tmp/wfe_spawn_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wf[160];
    snprintf(wf, sizeof wf, "%s/workflows", home);
    mkdir(wf, 0755);

--- a/src/tests/test_wfe_manager_flow.c
+++ b/src/tests/test_wfe_manager_flow.c
@@ -5,6 +5,7 @@
  * git worktree or live panel). Asserts the enforced workflow reaches delivery
  * (crosses gate.deliver -> accepted) and the lifecycle trail records each
  * manager step's advance. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -118,7 +119,7 @@ static wfe_step_result_t stub_adv(wfe_ctx *c, const wfe_node_t *n)
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_mgr_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_roundtable.c
+++ b/src/tests/test_wfe_roundtable.c
@@ -1,5 +1,6 @@
 /* test_wfe_roundtable.c -- W5: the fail-closed gate decision rule + the
  * gate.roundtable executor through the engine with a mock panel provider. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -81,7 +82,7 @@ static const char *RT = "name: rt\n"
 static void setup_home(void)
 {
    char d[] = "/tmp/wfe_rt_XXXXXX";
-   char *dir = mkdtemp(d);
+   char *dir = wfe_test_mkdtemp(d);
    assert(dir);
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_router_catalog.c
+++ b/src/tests/test_wfe_router_catalog.c
@@ -1,6 +1,7 @@
 /* test_wfe_router_catalog.c -- the router catalog I/O layer: enumerate
  * $AIMEE_HOME/workflows/<name>.yaml, read router metadata, add the built-in lanes,
  * skip symlinks (escape guard), and reject a workflow that claims `default`. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,7 +23,7 @@ int main(void)
 {
    printf("wfe-router-catalog: ");
    char tmpl[] = "/tmp/wfe_cat_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_safety.c
+++ b/src/tests/test_wfe_safety.c
@@ -1,5 +1,6 @@
 /* test_wfe_safety.c -- gate.ci / check.mergeable / idempotent merge via a mock
  * forge provider, exercised through the engine. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -135,7 +136,7 @@ int main(void)
 {
    printf("wfe-safety: ");
    char home[] = "/tmp/wfe_sft_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", home);
    mkdir(wf, 0755);

--- a/src/tests/test_wfe_scheduler.c
+++ b/src/tests/test_wfe_scheduler.c
@@ -1,6 +1,7 @@
 /* test_wfe_scheduler.c -- the autonomy scheduler drives ACTIVE AUTONOMOUS work
  * items forward and leaves interactive ones for the human (Phase B). Uses the
  * synchronous wfe_scheduler_run_once + stub executors for determinism. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,7 +27,7 @@ int main(void)
 {
    printf("wfe-scheduler: ");
    char home[] = "/tmp/wfe_sc_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wf[160];
    snprintf(wf, sizeof wf, "%s/workflows", home);
    mkdir(wf, 0755);

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -3,6 +3,7 @@
  * blocks catalog (built-ins + safety + custom), save/get canonical round-trip
  * byte-stability (incl. a cyclic graph), optimistic-lock conflicts, path-name
  * safety, validate, and work-item run-state. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -67,7 +68,7 @@ int main(void)
 {
    printf("wfe-webapi: ");
    char home[] = "/tmp/wfe_web_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wfdir[128];
    snprintf(wfdir, sizeof wfdir, "%s/workflows", home);
    mkdir(wfdir, 0755);

--- a/src/tests/wfe_test_home.h
+++ b/src/tests/wfe_test_home.h
@@ -1,0 +1,47 @@
+#ifndef WFE_TEST_HOME_H
+#define WFE_TEST_HOME_H 1
+
+/* wfe_test_home.h -- a mkdtemp() that removes its directory at process exit, so a
+ * WFE unit test never strands its /tmp AIMEE_HOME. Each test points AIMEE_HOME at
+ * a mkdtemp'd dir and the engine fills it with git worktrees (wfe-worktrees/wi_*,
+ * ~4k files each); left behind across runs they exhausted /tmp's inodes. This is a
+ * drop-in for mkdtemp() -- same signature and return -- that also schedules an
+ * `rm -rf` of every dir it created via atexit. Header-only + static so no Rules.mk
+ * or link changes are needed: each test binary is one translation unit and gets
+ * its own private list, so parallel test runs only ever remove their OWN dirs. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define WFE_TEST_HOME_MAX 16
+static char wfe_test_home_dirs__[WFE_TEST_HOME_MAX][256];
+static int wfe_test_home_n__;
+
+static void wfe_test_home_sweep__(void)
+{
+   for (int i = 0; i < wfe_test_home_n__; i++)
+   {
+      char cmd[320];
+      /* mkdtemp paths are our own short /tmp/wfe_*_XXXXXX templates (no shell
+       * metacharacters); best-effort removal, status is irrelevant at exit. */
+      if (snprintf(cmd, sizeof cmd, "rm -rf '%s'", wfe_test_home_dirs__[i]) < (int)sizeof cmd)
+         (void)system(cmd);
+   }
+}
+
+/* Drop-in mkdtemp(): creates the dir and schedules its recursive removal at exit.
+ * Returns mkdtemp's result (the mutated template on success, NULL on failure). */
+static char *wfe_test_mkdtemp(char *tmpl)
+{
+   char *p = mkdtemp(tmpl);
+   if (p && wfe_test_home_n__ < WFE_TEST_HOME_MAX)
+   {
+      if (wfe_test_home_n__ == 0)
+         atexit(wfe_test_home_sweep__);
+      snprintf(wfe_test_home_dirs__[wfe_test_home_n__++], 256, "%s", p);
+   }
+   return p;
+}
+
+#endif /* WFE_TEST_HOME_H */

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -7,6 +7,8 @@
  * suite (the engine test overrides them with mocks via the vtable). */
 #include "wfe_blocks.h"
 
+#include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -156,6 +158,44 @@ static void wt_scrub(const char *rl, const char *path, const char *branch)
    free(o);
 }
 
+/* A positive long from `name`, else `def` (rejects junk/non-positive/overflow so a
+ * malformed override can't silently disable the guardrail). */
+static long wt_env_long(const char *name, long def)
+{
+   const char *v = getenv(name);
+   if (!v || !v[0])
+      return def;
+   errno = 0;
+   char *end = NULL;
+   long n = strtol(v, &end, 10);
+   if (errno == ERANGE || !end || *end != '\0' || n <= 0)
+      return def;
+   return n;
+}
+
+/* Count the worktree directories currently under `parent` (best-effort; a
+ * missing/unreadable dir is 0). Lock files and non-dirs are ignored. */
+static int wt_dir_count(const char *parent)
+{
+   DIR *dp = opendir(parent);
+   if (!dp)
+      return 0;
+   int n = 0;
+   struct dirent *e;
+   while ((e = readdir(dp)) != NULL)
+   {
+      if (e->d_name[0] == '.')
+         continue;
+      char path[1024];
+      struct stat st;
+      if (snprintf(path, sizeof path, "%s/%s", parent, e->d_name) < (int)sizeof path &&
+          stat(path, &st) == 0 && S_ISDIR(st.st_mode))
+         n++;
+   }
+   closedir(dp);
+   return n;
+}
+
 int wfe_worktree_ensure(const char *work_item_id, const char *existing, const char *repo_local,
                         const char *base, char *out_path, size_t n)
 {
@@ -215,6 +255,19 @@ int wfe_worktree_ensure(const char *work_item_id, const char *existing, const ch
       goto unlock;
    }
 
+   /* Inode guardrail: bound how many worktrees can exist at once so a runaway (or a
+    * pile of orphaned checkouts from crashed runs) can't exhaust the filesystem's
+    * inodes. Reclaim orphans first; only if still at the cap do we fail-closed here
+    * — the caller then degrades to the shared checkout rather than adding an
+    * unbounded worktree. AIMEE_WFE_WORKTREE_MAX overrides the default. */
+   long cap = wt_env_long("AIMEE_WFE_WORKTREE_MAX", 32);
+   if (wt_dir_count(parent) >= cap)
+   {
+      wfe_worktree_orphan_gc(rl, 0);
+      if (wt_dir_count(parent) >= cap)
+         goto unlock; /* rc_final stays -1 -> shared-checkout fallback */
+   }
+
    o = NULL;
    const char *add[] = {"git", "-C", rl, "worktree", "add", "--lock", "-b", branch, path, b, NULL};
    int rc = safe_exec_capture(add, &o, 1 << 16);
@@ -256,6 +309,80 @@ int wfe_worktree_cleanup(const char *worktree, const char *repo_local)
    int rc = safe_exec_capture(rm, &o, 1 << 14);
    free(o);
    return rc == 0 ? 0 : -1;
+}
+
+/* True for an immutable-terminal work-item state (mirrors the scheduler sweep's
+ * set): such an item's worktree should already be gone, so a lingering one is
+ * reapable rather than in-use. */
+static int wt_state_terminal(const char *st)
+{
+   return st && (!strcmp(st, "accepted") || !strcmp(st, "rejected") || !strcmp(st, "abandoned"));
+}
+
+int wfe_worktree_orphan_gc(const char *repo_local, long grace_secs)
+{
+   const char *home = aimee_home();
+   if (!home || !home[0])
+      return 0;
+   char parent[768];
+   if (sn(parent, sizeof parent, "%s/wfe-worktrees", home) != 0)
+      return 0;
+   DIR *dp = opendir(parent);
+   if (!dp)
+      return 0; /* no worktrees dir yet -> nothing to reap */
+   const char *rl = (repo_local && repo_local[0]) ? repo_local : ".";
+   time_t now = time(NULL);
+   int reaped = 0;
+   struct dirent *e;
+   while ((e = readdir(dp)) != NULL)
+   {
+      if (e->d_name[0] == '.')
+         continue;
+      size_t nl = strlen(e->d_name);
+      if (nl >= 5 && strcmp(e->d_name + nl - 5, ".lock") == 0)
+         continue; /* a lock is reaped alongside its worktree, below */
+      char path[1024];
+      if (snprintf(path, sizeof path, "%s/%s", parent, e->d_name) >= (int)sizeof path)
+         continue;
+      struct stat stt;
+      if (stat(path, &stt) != 0 || !S_ISDIR(stt.st_mode))
+         continue; /* only directories are worktrees */
+
+      /* Keep a worktree that a LIVE (non-terminal) work item still owns — an
+       * active/parked item needs it, and the terminal-sweep handles terminal ones.
+       * This GC only fills the gap those miss: a vanished row, or a terminal row
+       * whose worktree was left behind. */
+      db1_work_item_t wi;
+      int have = db1_work_item_get(e->d_name, &wi);
+      if (have == 1 && !wt_state_terminal(wi.state))
+         continue;
+
+      /* Age gate: a worktree dir exists before its row/column is written, so never
+       * reap one younger than the grace window (grace_secs <= 0 = reap now). */
+      if (grace_secs > 0 && now - stt.st_mtime < grace_secs)
+         continue;
+
+      char branch[220];
+      if (sn(branch, sizeof branch, "aimee/wi/%s", e->d_name) != 0)
+         continue;
+      wt_scrub(rl, path, branch); /* force-remove worktree + rm -rf + delete branch */
+      char lockf[1100];
+      if (snprintf(lockf, sizeof lockf, "%s.lock", path) < (int)sizeof lockf)
+         unlink(lockf);
+      if (have == 1)
+         db1_work_item_set_worktree(e->d_name, ""); /* clear a stale terminal column */
+      reaped++;
+   }
+   closedir(dp);
+   if (reaped > 0)
+   {
+      /* Drop git's admin refs (.git/worktrees/<id>) for the dirs we removed. */
+      char *o = NULL;
+      const char *prune[] = {"git", "-C", rl, "worktree", "prune", NULL};
+      safe_exec_capture(prune, &o, 1 << 14);
+      free(o);
+   }
+   return reaped;
 }
 
 /* ---- forge seam (gate.ci / check.mergeable / merge) ---- */

--- a/src/workflow/wfe_blocks.h
+++ b/src/workflow/wfe_blocks.h
@@ -176,4 +176,14 @@ int wfe_worktree_ensure(const char *work_item_id, const char *existing, const ch
                         const char *base, char *out_path, size_t n);
 int wfe_worktree_cleanup(const char *worktree, const char *repo_local);
 
+/* Orphan GC: reap wfe-worktrees/<id> dirs that no LIVE (non-terminal) work item
+ * owns — a vanished row (deleted item) or a terminal row whose terminal-cleanup
+ * was missed would otherwise strand a full git worktree (~thousands of inodes)
+ * forever. Only dirs older than `grace_secs` are reaped (grace_secs <= 0 reaps
+ * immediately), so an in-flight worktree mid-creation is never raced. Force-removes
+ * the worktree + its branch + lock, prunes git's admin refs, and clears any stale
+ * DB worktree column. Returns the number reaped. Belt-and-suspenders to the
+ * terminal-cleanup path (wfe_autonomy_cleanup_worktree / scheduler sweep). */
+int wfe_worktree_orphan_gc(const char *repo_local, long grace_secs);
+
 #endif /* DEC_WFE_BLOCKS_H */


### PR DESCRIPTION
## Problem

`/tmp` on the dev/CI host had **920k inodes (89%) consumed by 331 `/tmp/wfe_*` dirs** — enough to fail builds with ENOSPC despite free space. Root cause: the WFE workflow engine gives each work item a **git worktree** (`wfe-worktrees/<id>`, ~4k files each), and two things let them pile up unbounded.

## Two fixes

### 1. Test hygiene (the actual /tmp leak) — `test(wfe): auto-remove each test's /tmp AIMEE_HOME at exit`
Every `test_wfe_*.c` `mkdtemp`'d an AIMEE_HOME, let the engine fill it with worktrees, and returned **without removing it** — so each suite run stranded ~18–20 dirs. Added a header-only drop-in for `mkdtemp()` (`wfe_test_mkdtemp`) that `rm -rf`'s each dir it created via `atexit`. Header-only + static → no Rules.mk/link changes, and each test binary only removes its own dirs (parallel-safe). Swapped the 18 call sites across 17 tests.

### 2. Runtime self-healing — `feat(wfe): age-based orphan-worktree GC + an inode cap on creation`
The runtime already tears a worktree down when its item reaches a terminal state — but a **crashed run** (never terminal) or a **deleted item row** strands the worktree with nothing to reap it, and nothing bounds the pool size.

- **`wfe_worktree_orphan_gc(repo, grace)`** — reap `wfe-worktrees/<id>` dirs no *live* (non-terminal) item owns, once older than a grace window (never races a mid-creation worktree). Force-removes worktree + branch + lock, prunes git admin refs, clears stale DB column. Scheduler runs it each sweep (`AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, default 3600).
- **Inode cap in `wfe_worktree_ensure`** — before creating, if the pool is at `AIMEE_WFE_WORKTREE_MAX` (default 32), reclaim orphans first; if still full, fail-closed (caller degrades to the shared checkout) so the pool can't grow without bound.

## Verification

- Full **34-target WFE suite passes**, and a full run now leaves **zero `/tmp/wfe_*` dirs** (was ~18–20/run).
- New GC/cap test (`delegate_seam` block F): active worktree survives GC; terminal + vanished-row worktrees reaped; grace window protects a fresh orphan; cap returns `-1` when full.
- `wfe_blocks.o` + `wfe_scheduler.o` compile clean under `-Werror`; all changed files clang-format-clean.
- Cleared the 331 stranded dirs on the host: **/tmp inodes 89% → 1%**.

## Answer to "why not clean up per-step?"
Steps within a work item **share one worktree** (the `code` step's files are what `review`/`gate`/`merge` act on), so per-step cleanup would destroy in-progress work. Cleanup is correctly bound to the work item completing; this PR makes that bulletproof against the paths where completion never happens cleanly.