### PR TITLE
P3c: read_symbol (anchored symbol span from the index)

### DIFF
--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -45,6 +45,10 @@ char *tool_test(const char *path, const char *check);
 char *tool_request_input(const char *question);
 char *tool_code_search(const char *query, const char *project, int max_results);
 char *tool_find_symbol(const char *identifier);
+/* Fetch a single symbol's definition span (via the code index), anchored, so the
+ * caller can edit it by reference without reading the whole file. Ambiguous names
+ * return the candidate sites for disambiguation. `sid` scopes the read snapshot. */
+char *tool_read_symbol(const char *identifier, const char *sid);
 char *tool_create_note(const char *title, const char *content, const char *tags);
 char *tool_list_notes(const char *tag, int limit);
 char *tool_search_notes(const char *query);

--- a/src/posix/agent_source_authority.c
+++ b/src/posix/agent_source_authority.c
@@ -1,6 +1,7 @@
 #include "aimee.h"
 #include "agent_tools.h"
 #include "agent_source_authority.h"
+#include "dstr.h"
 #include "kb_client.h"
 #include "platform_process.h"
 #include "util.h"
@@ -411,4 +412,81 @@ char *tool_find_symbol(const char *identifier)
    }
 
    return safe_strdup(buf);
+}
+
+/* True if hit i duplicates an earlier hit (same file + start line + kind). Kind
+ * is part of the key so two distinct definitions that happen to share a file:line
+ * (e.g. a macro and a function) are surfaced as separate candidates, not merged. */
+static int rs_is_dup(const term_hit_t *hits, int i)
+{
+   for (int j = 0; j < i; j++)
+      if (hits[i].line == hits[j].line && strcmp(hits[i].file_path, hits[j].file_path) == 0 &&
+          strcmp(hits[i].kind, hits[j].kind) == 0)
+         return 1;
+   return 0;
+}
+
+char *tool_read_symbol(const char *identifier, const char *sid)
+{
+   if (!identifier || !identifier[0])
+      return safe_strdup("error: missing identifier");
+
+   term_hit_t hits[20];
+   int count = kb_client_index_find(identifier, hits, 20);
+   if (count <= 0)
+   {
+      char e[256];
+      snprintf(e, sizeof(e),
+               "error: no indexed symbol found for '%s' (try find_symbol, grep, or read_file)",
+               identifier);
+      return safe_strdup(e);
+   }
+
+   int distinct = 0;
+   for (int i = 0; i < count; i++)
+      if (!rs_is_dup(hits, i))
+         distinct++;
+
+   /* Ambiguous: never guess — list the candidate definition sites and let the
+    * caller pick (a more qualified name, or read the chosen span directly). */
+   if (distinct > 1)
+   {
+      dstr_t d;
+      dstr_init(&d);
+      dstr_appendf(&d,
+                   "'%s' resolves to %d definitions — disambiguate (use a more qualified name, or "
+                   "read_file the chosen span):\n",
+                   identifier, distinct);
+      for (int i = 0; i < count; i++)
+      {
+         if (rs_is_dup(hits, i))
+            continue;
+         if (hits[i].line_end >= hits[i].line)
+            dstr_appendf(&d, "  %s:%d-%d  [%s]\n", hits[i].file_path, hits[i].line,
+                         hits[i].line_end, hits[i].kind[0] ? hits[i].kind : "symbol");
+         else
+            dstr_appendf(&d, "  %s:%d  [%.31s]\n", hits[i].file_path, hits[i].line,
+                         hits[i].kind[0] ? hits[i].kind : "symbol");
+      }
+      return d.data ? d.data : safe_strdup("error: out of memory");
+   }
+
+   /* Unique definition: fetch just its span, anchored, so the caller can edit it
+    * by reference without reading the whole file. Reuses the anchored read path
+    * (whole-file snapshot + windowed anchored output). */
+   const term_hit_t *h = &hits[0];
+   if (!h->file_path[0])
+      return safe_strdup("error: symbol has no file path in the index");
+   int start = h->line >= 1 ? h->line : 1;
+   int span = (h->line_end >= h->line) ? (h->line_end - h->line + 1) : 1;
+   char *body = tool_read_file_ex(h->file_path, start - 1, span, 1 /*anchored*/, sid);
+
+   dstr_t d;
+   dstr_init(&d);
+   dstr_appendf(&d, "symbol %s  [%.31s]  %s:%d%s\n", identifier, h->kind[0] ? h->kind : "symbol",
+                h->file_path, start,
+                (h->line_end >= h->line) ? "" : " (span end unknown; showing the definition line)");
+   dstr_append_str(&d, body ? body : "");
+   free(body);
+   return d.data ? d.data : safe_strdup("error: out of memory");
 }

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -861,6 +861,15 @@ static char *td_find_symbol(cJSON *args, const char *name, const char *dispatch_
    return result;
 }
 
+static char *td_read_symbol(cJSON *args, const char *name, const char *dispatch_cwd,
+                            const char *dispatch_sid, int timeout_ms)
+{
+   cJSON *id = cJSON_GetObjectItem(args, "identifier");
+   if (!id || !cJSON_IsString(id))
+      return safe_strdup("error: missing 'identifier' parameter");
+   return tool_read_symbol(id->valuestring, dispatch_sid);
+}
+
 static char *td_search_memory(cJSON *args, const char *name, const char *dispatch_cwd,
                               const char *dispatch_sid, int timeout_ms)
 {
@@ -1677,6 +1686,8 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
       result = td_code_search(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "find_symbol") == 0)
       result = td_find_symbol(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
+   else if (strcmp(name, "read_symbol") == 0)
+      result = td_read_symbol(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "search_memory") == 0)
       result = td_search_memory(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "web_search") == 0)

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -895,6 +895,20 @@ static cJSON *tp_find_symbol(void)
    return params;
 }
 
+static cJSON *tp_read_symbol(void)
+{
+   cJSON *params = tp_obj();
+   cJSON *props = cJSON_CreateObject();
+   tp_prop(props, "identifier", "string",
+           "Symbol name whose definition span to fetch (function/type/macro). Ambiguous names "
+           "return the candidate sites to disambiguate.");
+   cJSON_AddItemToObject(params, "properties", props);
+   cJSON *req = cJSON_CreateArray();
+   cJSON_AddItemToArray(req, cJSON_CreateString("identifier"));
+   cJSON_AddItemToObject(params, "required", req);
+   return params;
+}
+
 static cJSON *tp_search_memory(void)
 {
    cJSON *params = tp_obj();
@@ -1019,6 +1033,11 @@ static const builtin_tool_def_t g_builtin_tools[] = {
      "indexed codebase. Returns file:line matches. Prefer this over grep for finding where "
      "something is defined or which header to include.",
      tp_find_symbol, TSURF_ALL},
+    {"read_symbol",
+     "Fetch just one symbol's definition span (function/type/macro) from the code index, with "
+     "N:hash edit anchors and a snapshot id — so you can read and then edit_file the symbol by "
+     "anchor without reading the whole file. Ambiguous names return the candidate sites.",
+     tp_read_symbol, TSURF_ALL},
     {"search_memory",
      "Search aimee's knowledge base for stored facts, prior decisions, and project context. "
      "Use before starting any task to check for relevant prior work or constraints.",

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -44,6 +44,7 @@ char *tool_edit_file_anchored(const char *path, const char *snapshot_id, const c
                               int dry_run, const char *sid);
 char *tool_grep_ex(const char *path, const char *pattern, int max_results, int anchored,
                    const char *sid);
+char *tool_read_symbol(const char *identifier, const char *sid);
 char *tool_list_files(const char *path, const char *pattern);
 char *tool_grep(const char *path, const char *pattern, int max_results);
 char *dispatch_tool_call(const char *name, const char *arguments_json, int timeout_ms);
@@ -1359,6 +1360,22 @@ static void test_tool_grep_anchored(void)
    unlink(tmppath);
 }
 
+static void test_tool_read_symbol(void)
+{
+   /* Missing identifier is an explicit error. */
+   char *e = tool_read_symbol("", "rsX");
+   assert(e && strstr(e, "error: missing identifier") != NULL);
+   free(e);
+
+   /* An identifier the index cannot resolve returns the explicit no-symbol error
+    * (the unit-test environment has no such symbol indexed). The anchored happy
+    * path is validated against a live index. */
+   char *n = tool_read_symbol("zzz_definitely_not_a_symbol_9f8e7d", "rsX");
+   assert(n != NULL);
+   assert(strstr(n, "no indexed symbol found") != NULL);
+   free(n);
+}
+
 static void test_parent_write_guard_blocks_parent_writes(void)
 {
    char root[512];
@@ -2585,6 +2602,7 @@ int main(void)
    test_tool_edit_file();
    test_tool_edit_file_anchored();
    test_tool_grep_anchored();
+   test_tool_read_symbol();
    test_parent_write_guard_blocks_parent_writes();
    test_session_isolation_guard();
    test_parent_write_guard_readonly_pipeline();


### PR DESCRIPTION
Phase 3c — read_symbol fetches one symbol's definition span via the code index and returns it anchored (N:hash + snapshot), so the symbol can be edited by reference without reading the whole file. Ambiguous names list candidate sites (file:line-line_end [kind]); no-match/missing-id error out. Thin wrapper over the merged, tested anchored-read path (tool_read_file_ex). Roundtable SHIP WITH CHANGES (dedup-by-kind, span in candidates, tightened test, bounded kind print; memory/underflow blockers verified false). make lint + full unit-tests green. Refs: proposal P3.