### PR TITLE
fix(workflow): autonomous commits use the host's configured git identity

### DIFF
--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -221,14 +221,16 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
 
    /* Stage + commit whatever the delegate changed in the worktree. A commit with
     * nothing staged is a harmless no-op (rc ignored); out_commit_sha is then just
-    * the unchanged HEAD. NO co-authorship trailer (standing directive). */
+    * the unchanged HEAD. Commit with the host's CONFIGURED git identity (the same
+    * creds aimee pushes with) rather than a synthetic bot identity: a bot author
+    * makes a downstream squash-merge inject a `Co-authored-by:` trailer, which the
+    * standing directive forbids. No `-c user.name/user.email` override, and no
+    * co-authorship trailer. */
    {
       const char *add[] = {"add", "-A"};
       (void)git_run(workdir, add, 2);
-      const char *commit[] = {
-          "-c",     "user.name=aimee", "-c", "user.email=aimee@localhost",
-          "commit", "--no-verify",     "-m", "aimee: autonomous delegate change"};
-      (void)git_run(workdir, commit, 8);
+      const char *commit[] = {"commit", "--no-verify", "-m", "aimee: autonomous delegate change"};
+      (void)git_run(workdir, commit, 4);
    }
    {
       const char *argv[] = {"git", "-C", workdir, "rev-parse", "HEAD", NULL};


### PR DESCRIPTION
## Problem
Autonomous workflow commits forced a synthetic bot identity:

```c
"-c", "user.name=aimee", "-c", "user.email=aimee@localhost", "commit", ...
```

Because aimee pushes with the operator's own git credentials but authored the commits as a bot, a downstream **squash-merge** auto-generates a `Co-authored-by: aimee <…>` trailer — which the standing no-AI-authorship directive forbids. That's exactly what happened with #1210 (`Co-authored-by: aimee/wi <wi-…@aimee.local>`) and blocked a `testing → main` promotion until the trailer was scrubbed.

## Fix
Drop the `-c user.name/user.email` override so the commit uses the **host's already-configured git identity** — the same identity behind the credentials aimee pushes with. No new config, no identity lookup, no stored state: just stop overriding what git is set up to use.

```c
const char *commit[] = {"commit", "--no-verify", "-m", "aimee: autonomous delegate change"};
```

Now the commit author matches the pusher, so squash-merges don't inject a co-author trailer.

## Verification
`make server` links clean under `-Werror`; `clang-format-19` clean; `unit-test-wfe-delegate-seam` passes.