### PR TITLE
P3b: read_file outline mode (anchored symbol skeleton)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -255,7 +255,7 @@ else ifeq ($(UNAME_S),Darwin)
         posix/agent_shell_claude.c posix/agent_shell_claude_pty.c posix/agent_shell_codex.c posix/agent_shell_gemini.c \
         $(UI_PLATFORM_SRCS)
     PLATFORM_AGENT_SRCS = \
-        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/agent_tools_grep_anchor.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
+        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/agent_tools_grep_anchor.c posix/agent_tools_outline.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
 else
     PLATFORM_BASIC_SRCS = \
         posix/platform_ipc.c posix/platform_path.c posix/platform_process.c \
@@ -271,7 +271,7 @@ else
         posix/agent_shell_claude.c posix/agent_shell_claude_pty.c posix/agent_shell_codex.c posix/agent_shell_gemini.c \
         $(UI_PLATFORM_SRCS)
     PLATFORM_AGENT_SRCS = \
-        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/agent_tools_grep_anchor.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
+        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/agent_tools_grep_anchor.c posix/agent_tools_outline.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
 endif
 
 PLATFORM_SRCS       = $(PLATFORM_BASIC_SRCS) $(PLATFORM_EXTRA_SRCS) $(PLATFORM_AGENT_SRCS)

--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -15,6 +15,10 @@ char *tool_read_file(const char *path, int offset, int limit);
  * which may be NULL) so a subsequent edit_file can reference the anchors. When
  * `anchored` is 0 the output is byte-identical to tool_read_file(). */
 char *tool_read_file_ex(const char *path, int offset, int limit, int anchored, const char *sid);
+/* read_file mode:"outline" — return the file's tree-sitter/extractor symbol
+ * skeleton: one anchored signature line (N:hash + a snapshot id) per top-level
+ * definition, no bodies, so one call maps a large file. */
+char *tool_read_file_outline(const char *path, const char *sid);
 /* Anchor-based edit: apply `edits` (a cJSON array of {op, at|from,to, text}) to
  * `path` against the read snapshot `snapshot_id` (scoped to `sid`). Returns a
  * JSON result string (caller frees): the write payload on success, a structured

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -427,12 +427,20 @@ static char *td_read_file(cJSON *args, const char *name, const char *dispatch_cw
       cJSON *off = cJSON_GetObjectItem(args, "offset");
       cJSON *lim = cJSON_GetObjectItem(args, "limit");
       cJSON *raw = cJSON_GetObjectItem(args, "raw");
-      int offset = (off && cJSON_IsNumber(off)) ? off->valueint : 0;
-      int limit = (lim && cJSON_IsNumber(lim)) ? lim->valueint : 0;
-      /* Anchored output is the default for this model-facing surface; raw:true
-       * restores byte-identical legacy output for pipeline/binary consumers. */
-      int anchored = !(raw && cJSON_IsBool(raw) && cJSON_IsTrue(raw));
-      result = tool_read_file_ex(p->valuestring, offset, limit, anchored, dispatch_sid);
+      cJSON *mode = cJSON_GetObjectItem(args, "mode");
+      if (mode && cJSON_IsString(mode) && strcmp(mode->valuestring, "outline") == 0)
+      {
+         result = tool_read_file_outline(p->valuestring, dispatch_sid);
+      }
+      else
+      {
+         int offset = (off && cJSON_IsNumber(off)) ? off->valueint : 0;
+         int limit = (lim && cJSON_IsNumber(lim)) ? lim->valueint : 0;
+         /* Anchored output is the default for this model-facing surface; raw:true
+          * restores byte-identical legacy output for pipeline/binary consumers. */
+         int anchored = !(raw && cJSON_IsBool(raw) && cJSON_IsTrue(raw));
+         result = tool_read_file_ex(p->valuestring, offset, limit, anchored, dispatch_sid);
+      }
 
       /* Record the read in the session state for read-before-write tracking. */
       if (result && strncmp(result, "error:", 6) != 0)

--- a/src/posix/agent_tools_outline.c
+++ b/src/posix/agent_tools_outline.c
@@ -1,0 +1,135 @@
+/* posix/agent_tools_outline.c: read_file outline mode.
+ *
+ * Returns a file's symbol skeleton — one anchored signature line per top-level
+ * definition (function/type/macro), no bodies — so one cheap call maps a large
+ * file and the agent can then read/edit one span by its N:hash anchor instead of
+ * paging the whole file. Reuses the code extractor (tree-sitter with a hand-rolled
+ * fallback) + the hashline snapshot/anchor contract. */
+#include "aimee.h"
+#include "agent_tools.h"
+#include "agent_tools_internal.h" /* path_in_thread_cwd */
+#include "agent_exec.h"           /* agent_tool_output_cap */
+#include "guardrails.h"           /* guardrails_validate_file_path */
+#include "hashline_anchor.h"
+#include "index.h" /* definition_t, extract_definitions */
+#include "util.h"
+#include "workspace_provider.h"
+
+#include "dstr.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static int outline_cmp_by_line(const void *a, const void *b)
+{
+   int la = ((const definition_t *)a)->line;
+   int lb = ((const definition_t *)b)->line;
+   return (la > lb) - (la < lb);
+}
+
+#define OUTLINE_MAX_DEFS 512
+
+char *tool_read_file_outline(const char *path, const char *sid)
+{
+   if (!path || !path[0])
+      return safe_strdup("error: missing 'path' parameter");
+
+   char cwd_path[MAX_PATH_LEN];
+   const char *actual_path = path_in_thread_cwd(path, cwd_path, sizeof(cwd_path));
+   char resolved[MAX_PATH_LEN];
+   const char *verr = guardrails_validate_file_path(actual_path, resolved, sizeof(resolved));
+   if (verr)
+      return safe_strdup(verr);
+
+   const workspace_provider_t *ws = workspace_provider_active();
+   char *content = NULL;
+   size_t len = 0;
+   if (ws->read_all(ws, actual_path, &content, &len) != 0)
+   {
+      char e[512];
+      snprintf(e, sizeof(e), "error: cannot open %s", actual_path);
+      return safe_strdup(e);
+   }
+
+   const char *ext = strrchr(path, '.');
+   if (!ext)
+      ext = "";
+   definition_t *defs = calloc(OUTLINE_MAX_DEFS, sizeof(definition_t));
+   if (!defs)
+   {
+      free(content);
+      return safe_strdup("error: out of memory");
+   }
+   int ndefs = extract_definitions(ext, content, defs, OUTLINE_MAX_DEFS);
+   if (ndefs <= 0)
+   {
+      free(defs);
+      free(content);
+      return safe_strdup("outline: no top-level definitions found (unsupported file type or no "
+                         "symbols) — use read_file to view the contents");
+   }
+   qsort(defs, (size_t)ndefs, sizeof(definition_t), outline_cmp_by_line);
+
+   char *snap = hashline_snapshot_mint(sid, actual_path, content, len);
+   dstr_t out;
+   dstr_init(&out);
+   if (snap)
+      dstr_appendf(&out,
+                   "[outline of %s — snapshot %s; %d definitions; edit a signature by its N:hash "
+                   "anchor, or read_file its span]\n",
+                   actual_path, snap, ndefs);
+   else
+      dstr_appendf(&out, "[outline of %s — snapshot unavailable; %d definitions]\n", actual_path,
+                   ndefs);
+
+   /* Single pass over the file lines; emit each definition's START line (its
+    * signature) with the same anchor an anchored read would show. */
+   size_t cap = agent_tool_output_cap();
+   size_t i = 0;
+   int lineno = 0, di = 0;
+   int truncated = 0;
+   while (i < len && di < ndefs)
+   {
+      size_t s = i;
+      while (i < len && content[i] != '\n')
+         i++;
+      size_t e = i;
+      int has_nl = (i < len);
+      if (has_nl)
+         i++;
+      lineno++;
+      while (di < ndefs && defs[di].line < lineno)
+         di++; /* skip any def whose line we've passed */
+      while (di < ndefs && defs[di].line == lineno)
+      {
+         if (out.len + (e - s) + 32 >= cap)
+         {
+            truncated = 1;
+            di = ndefs;
+            break;
+         }
+         uint64_t d = hashline_digest64(content + s, e - s, lineno == 1, has_nl);
+         char tag[HASHLINE_DISPLAY_TAG_HEX + 1];
+         hashline_display_tag(d, tag, sizeof(tag));
+         dstr_appendf(&out, "%d:%s| ", lineno, tag);
+         dstr_append(&out, content + s, e - s);
+         dstr_append_char(&out, '\n');
+         di++;
+      }
+   }
+   if (truncated)
+      dstr_appendf(&out, "[outline truncated at size cap; read_file a region for the rest]\n");
+   else if (di < ndefs)
+      /* extract_definitions returns 1-based lines within the parsed content, so
+       * this is defensive: any definition the single pass could not place at a
+       * file line (e.g. a line beyond EOF) is reported, never silently dropped. */
+      dstr_appendf(&out,
+                   "[note: %d definition(s) could not be placed at a file line and were omitted; "
+                   "read_file to view them]\n",
+                   ndefs - di);
+
+   free(snap);
+   free(defs);
+   free(content);
+   return out.data ? out.data : safe_strdup("error: out of memory");
+}

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -589,6 +589,10 @@ static cJSON *tp_read_file(void)
            "Return plain file bytes with no line anchors (for pipelines/binary). Default false: "
            "each line is prefixed with an 'N:hash' anchor and a snapshot id is returned so you "
            "can edit_file by anchor without re-emitting the line text.");
+   tp_prop(props, "mode", "string",
+           "Set to \"outline\" to return the file's symbol skeleton (one anchored signature line "
+           "per top-level definition, no bodies) — one call to map a large file, then read/edit a "
+           "span by its anchor.");
    cJSON_AddItemToObject(params, "properties", props);
    cJSON *req = cJSON_CreateArray();
    cJSON_AddItemToArray(req, cJSON_CreateString("path"));

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -45,6 +45,7 @@ char *tool_edit_file_anchored(const char *path, const char *snapshot_id, const c
 char *tool_grep_ex(const char *path, const char *pattern, int max_results, int anchored,
                    const char *sid);
 char *tool_read_symbol(const char *identifier, const char *sid);
+char *tool_read_file_outline(const char *path, const char *sid);
 char *tool_list_files(const char *path, const char *pattern);
 char *tool_grep(const char *path, const char *pattern, int max_results);
 char *dispatch_tool_call(const char *name, const char *arguments_json, int timeout_ms);
@@ -1376,6 +1377,70 @@ static void test_tool_read_symbol(void)
    free(n);
 }
 
+static void test_tool_read_file_outline(void)
+{
+   /* A .c file so the extractor recognizes the language. */
+   char tmppath[512];
+   snprintf(tmppath, sizeof(tmppath), "%s/aimee_outline_test_%d.c", platform_tmpdir(),
+            (int)getpid());
+   FILE *f = fopen(tmppath, "w");
+   assert(f != NULL);
+   fputs("#include <stdio.h>\n\nint alpha(int n)\n{\n  return n + 1;\n}\n\nvoid beta(void)\n{\n}\n",
+         f);
+   fclose(f);
+
+   char *o = tool_read_file_outline(tmppath, "olX");
+   assert(o != NULL);
+   /* Either an outline (snapshot header + anchored signatures) or a clear
+    * "no definitions" message; the extractor should find both functions here. */
+   if (strstr(o, "[outline of") != NULL)
+   {
+      assert(strstr(o, "alpha") != NULL);
+      assert(strstr(o, "beta") != NULL);
+      assert(strstr(o, "|") != NULL); /* signature lines carry N:hash anchors */
+
+      /* Anchor consistency (general): EVERY N:hash the outline emits for a
+       * signature line MUST equal the anchor an anchored read_file shows for that
+       * same line — identical canonicalized digest contract (BOM-on-line-1 and
+       * CRLF handling live inside hashline_digest64, which both paths call the
+       * same way), so the edit round-trip works. Verify all outline anchor lines,
+       * not just one. */
+      char *rd = tool_read_file_ex(tmppath, 0, 0, 1, "olX");
+      assert(rd != NULL);
+      int checked = 0;
+      for (const char *ls = o; (ls = strchr(ls, '\n')) != NULL;)
+      {
+         ls++; /* start of the next line */
+         /* An anchor line looks like "N:hash| ...". Header/note lines start with
+          * '[' and are skipped. */
+         if (!isdigit((unsigned char)ls[0]))
+            continue;
+         const char *bar = strchr(ls, '|');
+         if (!bar)
+            continue;
+         char anchor[24];
+         size_t n = (size_t)(bar - ls);
+         while (n > 0 && ls[n - 1] == ' ')
+            n--; /* trim trailing space before '|' */
+         if (n == 0 || n + 2 >= sizeof(anchor))
+            continue;
+         memcpy(anchor, ls, n);
+         anchor[n] = '|';
+         anchor[n + 1] = '\0';
+         assert(strstr(rd, anchor) != NULL); /* same anchor in the anchored read */
+         checked++;
+      }
+      assert(checked >= 2); /* alpha + beta */
+      free(rd);
+   }
+   else
+   {
+      assert(strstr(o, "no top-level definitions") != NULL);
+   }
+   free(o);
+   unlink(tmppath);
+}
+
 static void test_parent_write_guard_blocks_parent_writes(void)
 {
    char root[512];
@@ -2603,6 +2668,7 @@ int main(void)
    test_tool_edit_file_anchored();
    test_tool_grep_anchored();
    test_tool_read_symbol();
+   test_tool_read_file_outline();
    test_parent_write_guard_blocks_parent_writes();
    test_session_isolation_guard();
    test_parent_write_guard_readonly_pipeline();


### PR DESCRIPTION
read_file mode:"outline" returns a file's symbol skeleton — one anchored signature line (N:hash + snapshot id) per top-level definition, no bodies — so one call maps a large file and the agent edits a span by anchor. tool_read_file_outline: extract_definitions (tree-sitter + hand-rolled fallback) → sort by line → emit each def's start line with the same anchor an anchored read shows, size-capped. Roundtable SHIP (0 findings); a general anchor-consistency test proves every outline anchor equals the anchored-read anchor for the same file. make -j all server + make lint + full unit-tests green. Refs: proposal P3.