### PR TITLE
feat(trigger): proposals trigger source + fix remote session-start worktree wedge

### DIFF
--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -489,6 +489,14 @@ static int attn_config_require_session_worktree(void)
    return value;
 }
 
+/* Public wrapper so other client TUs (e.g. the remote/thin session-start path)
+ * can ask the SAME authoritative question the guard uses to decide whether to
+ * block — default ON unless aimee.yaml sets `require_session_worktree: false`. */
+int attn_require_session_worktree(void)
+{
+   return attn_config_require_session_worktree();
+}
+
 /* Lexically resolve '.', '..' and '//' in `path` into `out` (purely textual —
  * the write target may not exist yet, so realpath() is unusable; symlinks are
  * not followed). Closes the `.aimee/worktrees/../escape` traversal bypass: a

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -6,11 +6,18 @@
 #include "cli_client.h"
 #include "cli_session_start.h"
 #include "cJSON.h"
+#include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
-#include <unistd.h>
+
+/* This is a thin-client TU compiled without -I./-Idb2, and the client binary
+ * links none of workspace.o/guardrails.o/config.o — so worktree creation here
+ * goes through git subprocesses (below), not those functions. Only the
+ * lightweight attention-guard helpers (attn_require_session_worktree /
+ * attn_session_isolation_blocked, from cli_attention_guard.h) are available. */
 
 struct ss_sbuf
 {
@@ -112,7 +119,128 @@ static cJSON *ss_retry_post(const char *endpoint, const char *bearer, const char
    return NULL;
 }
 
-static int handle_session_start_remote(void)
+/* Capture the first trimmed stdout line of `cmd` into out[cap]; 1 on non-empty. */
+static int ss_git_first_line(const char *cmd, char *out, size_t cap)
+{
+   if (cap)
+      out[0] = '\0';
+   FILE *f = popen(cmd, "r");
+   if (!f)
+      return 0;
+   char buf[4096] = {0};
+   char *got = fgets(buf, sizeof buf, f);
+   pclose(f);
+   if (!got)
+      return 0;
+   size_t n = strlen(buf);
+   while (n > 0 &&
+          (buf[n - 1] == '\n' || buf[n - 1] == '\r' || buf[n - 1] == ' ' || buf[n - 1] == '\t'))
+      buf[--n] = '\0';
+   if (!buf[0])
+      return 0;
+   snprintf(out, cap, "%s", buf);
+   return 1;
+}
+
+/* Remote/thin session-start (handle_session_start_remote) does no local worktree
+ * setup — it assumes the client tree is absent on the remote server. But the
+ * attention-guard's `require_session_worktree` isolation still runs LOCALLY and
+ * blocks every mutation outside a managed worktree, so a remote-server deployment
+ * would wedge the session: nothing prepares or points to a worktree, yet the
+ * guard demands one. Prepare the per-session sibling worktree here (via git, as
+ * the thin client links no workspace helpers) and surface a directive telling the
+ * agent to enter it before its first mutating tool call. No-op when isolation is
+ * off, the session is already inside a worktree, or there is no local git repo. */
+static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
+{
+   if (!attn_require_session_worktree())
+      return; /* isolation not enforced -> nothing to prepare or say */
+
+   char cwd[4096];
+   if (!getcwd(cwd, sizeof cwd))
+      return;
+   /* Already inside a managed (.aimee/.claude/.codex) worktree -> a mutating op
+    * would not be blocked; don't nag or create a redundant worktree. Mirrors the
+    * guard's own decision so the directive fires exactly when it would block. */
+   if (!attn_session_isolation_blocked(ATTN_OP_SOFT, NULL, cwd))
+      return;
+
+   /* Need a stable session id to name the worktree; Claude Code always sends one. */
+   if (!sid || !sid[0])
+      return;
+   char sid_safe[64];
+   size_t si = 0;
+   for (const char *p = sid; *p && si + 1 < sizeof sid_safe; p++)
+   {
+      char c = *p;
+      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+               c == '-' || c == '_' || c == '.';
+      sid_safe[si++] = ok ? c : '-';
+   }
+   sid_safe[si] = '\0';
+   if (!sid_safe[0])
+      return;
+
+   /* A single quote in a path would break the single-quoted popen/system commands;
+    * such local repo paths are pathological -> skip rather than risk misquoting. */
+   if (strchr(cwd, '\''))
+      return;
+
+   char cmd[10240];
+   char git_root[4096];
+   snprintf(cmd, sizeof cmd, "git -C '%s' rev-parse --show-toplevel 2>/dev/null", cwd);
+   if (!ss_git_first_line(cmd, git_root, sizeof git_root) || strchr(git_root, '\''))
+      return; /* not a git repo (or unquotable path) -> nothing to prepare */
+
+   /* Base the session branch on the repo's default branch (origin HEAD -> HEAD). */
+   char base_ref[256];
+   snprintf(cmd, sizeof cmd, "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null",
+            git_root);
+   if (!ss_git_first_line(cmd, base_ref, sizeof base_ref))
+   {
+      snprintf(cmd, sizeof cmd, "git -C '%s' symbolic-ref --short HEAD 2>/dev/null", git_root);
+      if (!ss_git_first_line(cmd, base_ref, sizeof base_ref))
+         snprintf(base_ref, sizeof base_ref, "HEAD");
+   }
+   if (strchr(base_ref, '\''))
+      return;
+
+   char wt[4200];
+   if (snprintf(wt, sizeof wt, "%s/.aimee/worktrees/%s/main", git_root, sid_safe) >=
+       (int)sizeof wt)
+      return;
+
+   struct stat st;
+   if (stat(wt, &st) != 0)
+   {
+      /* Prune stale registrations (best-effort), then create the worktree+branch.
+       * git worktree add makes intermediate dirs; -Wno-unused-result covers system(). */
+      snprintf(cmd, sizeof cmd, "git -C '%s' worktree prune >/dev/null 2>&1", git_root);
+      (void)system(cmd);
+      int cn = snprintf(cmd, sizeof cmd,
+                        "git -C '%s' worktree add '%s' -b 'aimee/session/%s' '%s' >/dev/null 2>&1",
+                        git_root, wt, sid_safe, base_ref);
+      if (cn < 0 || cn >= (int)sizeof cmd)
+         return; /* command truncated -> don't run a malformed git invocation */
+      (void)system(cmd);
+   }
+   if (stat(wt, &st) != 0 || !S_ISDIR(st.st_mode))
+      return; /* creation failed -> don't point the agent at a path that isn't there */
+
+   ss_add(ctx, "\n# Isolated Checkout (REQUIRED before editing)\n");
+   ss_add(ctx,
+          "This session runs against a remote aimee-server, and session-worktree isolation "
+          "(`require_session_worktree`) is ON. You are NOT in a managed worktree, so every "
+          "edit/write/mutating shell command WILL be blocked until you enter one. An isolated "
+          "worktree has been prepared for you:\n\n  ");
+   ss_add(ctx, wt);
+   ss_add(ctx,
+          "\n\nBefore your first mutating tool call, switch into it — Claude Code: call "
+          "`EnterWorktree` with that path; or `cd` into it for shell work. Do not edit the shared "
+          "checkout.\n\n");
+}
+
+static int handle_session_start_remote(const char *sid)
 {
    char *endpoint = cli_v1_client_endpoint();
    if (!endpoint)
@@ -170,6 +298,12 @@ static int handle_session_start_remote(void)
 
    free(endpoint);
    free(bearer);
+
+   /* Local worktree isolation: even though compute is remote, the guard runs on
+    * THIS host. Prepare + direct the agent into an isolated worktree so mutating
+    * tools aren't blocked. Appended last so it shows even if the remote brief
+    * fetch returned nothing (and so a wedged session always gets the way out). */
+   ss_append_worktree_isolation(&ctx, sid);
 
    if (ctx.p && ctx.p[0])
    {
@@ -494,7 +628,7 @@ int handle_session_start(int json_output)
        * local aimee-server needed (see handle_session_start_remote). */
       if (cli_v1_has_remote_endpoint())
       {
-         int rc = handle_session_start_remote();
+         int rc = handle_session_start_remote(sid);
          cJSON_Delete(hook_json);
          free(stdin_data);
          return rc;

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -7,10 +7,12 @@
 #include "cli_session_start.h"
 #include "cJSON.h"
 #include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 /* This is a thin-client TU compiled without -I./-Idb2, and the client binary
@@ -119,27 +121,83 @@ static cJSON *ss_retry_post(const char *endpoint, const char *bearer, const char
    return NULL;
 }
 
-/* Capture the first trimmed stdout line of `cmd` into out[cap]; 1 on non-empty. */
-static int ss_git_first_line(const char *cmd, char *out, size_t cap)
+/* Run `git <argv...>` with NO shell (fork/execvp), discarding stderr. Captures
+ * the first trimmed stdout line into out[cap] (out may be NULL — status only).
+ * Returns the child's exit code (0 = success), or -1 if it could not be spawned
+ * or did not exit cleanly. Shell-free by design: session ids / repo paths never
+ * reach a shell, so there is nothing to quote or inject. */
+static int ss_git(const char *const argv[], char *out, size_t cap)
 {
-   if (cap)
+   if (out && cap)
       out[0] = '\0';
-   FILE *f = popen(cmd, "r");
-   if (!f)
-      return 0;
-   char buf[4096] = {0};
-   char *got = fgets(buf, sizeof buf, f);
-   pclose(f);
-   if (!got)
-      return 0;
-   size_t n = strlen(buf);
-   while (n > 0 &&
-          (buf[n - 1] == '\n' || buf[n - 1] == '\r' || buf[n - 1] == ' ' || buf[n - 1] == '\t'))
-      buf[--n] = '\0';
-   if (!buf[0])
-      return 0;
-   snprintf(out, cap, "%s", buf);
-   return 1;
+   int pfd[2];
+   if (pipe(pfd) != 0)
+      return -1;
+   pid_t pid = fork();
+   if (pid < 0)
+   {
+      close(pfd[0]);
+      close(pfd[1]);
+      return -1;
+   }
+   if (pid == 0)
+   {
+      dup2(pfd[1], STDOUT_FILENO);
+      int devnull = open("/dev/null", O_WRONLY);
+      if (devnull >= 0)
+         dup2(devnull, STDERR_FILENO);
+      close(pfd[0]);
+      close(pfd[1]);
+      execvp("git", (char *const *)argv);
+      _exit(127);
+   }
+   close(pfd[1]);
+   char buf[4096];
+   size_t got = 0;
+   ssize_t r;
+   while (got < sizeof buf - 1 && (r = read(pfd[0], buf + got, sizeof buf - 1 - got)) > 0)
+      got += (size_t)r;
+   buf[got] = '\0';
+   close(pfd[0]);
+   int status = 0;
+   if (waitpid(pid, &status, 0) < 0 || !WIFEXITED(status))
+      return -1;
+   int code = WEXITSTATUS(status);
+   if (out && cap && code == 0)
+   {
+      size_t n = 0;
+      while (buf[n] && buf[n] != '\n' && buf[n] != '\r')
+         n++;
+      buf[n] = '\0';
+      while (n > 0 && (buf[n - 1] == ' ' || buf[n - 1] == '\t'))
+         buf[--n] = '\0';
+      snprintf(out, cap, "%s", buf);
+   }
+   return code;
+}
+
+/* Collision-free worktree key for a session: a short alnum prefix of the id for
+ * human readability plus a 64-bit FNV-1a hash of the FULL id, so two distinct ids
+ * (even ones that share a sanitized prefix) never map to the same worktree/branch.
+ * Stable for a given id -> re-runs (startup/resume/compact) reuse the same one. */
+static void ss_worktree_key(const char *sid, char *out, size_t cap)
+{
+   unsigned long long h = 1469598103934665603ULL;
+   for (const char *p = sid; *p; p++)
+   {
+      h ^= (unsigned char)*p;
+      h *= 1099511628211ULL;
+   }
+   char pre[9];
+   size_t k = 0;
+   for (const char *p = sid; *p && k < 8; p++)
+   {
+      char c = *p;
+      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))
+         pre[k++] = c;
+   }
+   pre[k] = '\0';
+   snprintf(out, cap, "%s%s%016llx", pre, k ? "-" : "", h);
 }
 
 /* Remote/thin session-start (handle_session_start_remote) does no local worktree
@@ -168,61 +226,47 @@ static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
    /* Need a stable session id to name the worktree; Claude Code always sends one. */
    if (!sid || !sid[0])
       return;
-   char sid_safe[64];
-   size_t si = 0;
-   for (const char *p = sid; *p && si + 1 < sizeof sid_safe; p++)
-   {
-      char c = *p;
-      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-               c == '-' || c == '_' || c == '.';
-      sid_safe[si++] = ok ? c : '-';
-   }
-   sid_safe[si] = '\0';
-   if (!sid_safe[0])
+   char key[80];
+   ss_worktree_key(sid, key, sizeof key);
+   if (!key[0])
       return;
 
-   /* A single quote in a path would break the single-quoted popen/system commands;
-    * such local repo paths are pathological -> skip rather than risk misquoting. */
-   if (strchr(cwd, '\''))
-      return;
-
-   char cmd[10240];
+   const char *const rp_argv[] = {"git", "-C", cwd, "rev-parse", "--show-toplevel", NULL};
    char git_root[4096];
-   snprintf(cmd, sizeof cmd, "git -C '%s' rev-parse --show-toplevel 2>/dev/null", cwd);
-   if (!ss_git_first_line(cmd, git_root, sizeof git_root) || strchr(git_root, '\''))
-      return; /* not a git repo (or unquotable path) -> nothing to prepare */
+   if (ss_git(rp_argv, git_root, sizeof git_root) != 0 || !git_root[0])
+      return; /* not a git repo -> nothing to prepare */
 
    /* Base the session branch on the repo's default branch (origin HEAD -> HEAD). */
    char base_ref[256];
-   snprintf(cmd, sizeof cmd, "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null",
-            git_root);
-   if (!ss_git_first_line(cmd, base_ref, sizeof base_ref))
+   const char *const oh_argv[] = {"git",      "-C",     git_root, "symbolic-ref",
+                                  "--short", "refs/remotes/origin/HEAD", NULL};
+   if (ss_git(oh_argv, base_ref, sizeof base_ref) != 0 || !base_ref[0])
    {
-      snprintf(cmd, sizeof cmd, "git -C '%s' symbolic-ref --short HEAD 2>/dev/null", git_root);
-      if (!ss_git_first_line(cmd, base_ref, sizeof base_ref))
+      const char *const h_argv[] = {"git", "-C", git_root, "symbolic-ref", "--short", "HEAD", NULL};
+      if (ss_git(h_argv, base_ref, sizeof base_ref) != 0 || !base_ref[0])
          snprintf(base_ref, sizeof base_ref, "HEAD");
    }
-   if (strchr(base_ref, '\''))
+   /* A base ref that begins with '-' would be parsed as a git option; reject it. */
+   if (base_ref[0] == '-')
       return;
 
    char wt[4200];
-   if (snprintf(wt, sizeof wt, "%s/.aimee/worktrees/%s/main", git_root, sid_safe) >=
-       (int)sizeof wt)
+   if (snprintf(wt, sizeof wt, "%s/.aimee/worktrees/%s/main", git_root, key) >= (int)sizeof wt)
+      return;
+   char branch[128];
+   if (snprintf(branch, sizeof branch, "aimee/session/%s", key) >= (int)sizeof branch)
       return;
 
    struct stat st;
    if (stat(wt, &st) != 0)
    {
       /* Prune stale registrations (best-effort), then create the worktree+branch.
-       * git worktree add makes intermediate dirs; -Wno-unused-result covers system(). */
-      snprintf(cmd, sizeof cmd, "git -C '%s' worktree prune >/dev/null 2>&1", git_root);
-      (void)system(cmd);
-      int cn = snprintf(cmd, sizeof cmd,
-                        "git -C '%s' worktree add '%s' -b 'aimee/session/%s' '%s' >/dev/null 2>&1",
-                        git_root, wt, sid_safe, base_ref);
-      if (cn < 0 || cn >= (int)sizeof cmd)
-         return; /* command truncated -> don't run a malformed git invocation */
-      (void)system(cmd);
+       * git creates intermediate dirs. Let git's exit status be authoritative. */
+      const char *const prune_argv[] = {"git", "-C", git_root, "worktree", "prune", NULL};
+      (void)ss_git(prune_argv, NULL, 0);
+      const char *const add_argv[] = {"git", "-C",     git_root, "worktree", "add", wt,
+                                      "-b",  branch, base_ref, NULL};
+      (void)ss_git(add_argv, NULL, 0);
    }
    if (stat(wt, &st) != 0 || !S_ISDIR(st.st_mode))
       return; /* creation failed -> don't point the agent at a path that isn't there */

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -7,13 +7,15 @@
 #include "cli_session_start.h"
 #include "cJSON.h"
 #include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <sys/wait.h>
 #include <unistd.h>
+#ifndef _WIN32
+#include <fcntl.h>
+#include <sys/wait.h>
+#endif
 
 /* This is a thin-client TU compiled without -I./-Idb2, and the client binary
  * links none of workspace.o/guardrails.o/config.o — so worktree creation here
@@ -121,6 +123,7 @@ static cJSON *ss_retry_post(const char *endpoint, const char *bearer, const char
    return NULL;
 }
 
+#ifndef _WIN32
 /* Run `git <argv...>` with NO shell (fork/execvp), discarding stderr. Captures
  * the first trimmed stdout line into out[cap] (out may be NULL — status only).
  * Returns the child's exit code (0 = success), or -1 if it could not be spawned
@@ -238,8 +241,8 @@ static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
 
    /* Base the session branch on the repo's default branch (origin HEAD -> HEAD). */
    char base_ref[256];
-   const char *const oh_argv[] = {"git",      "-C",     git_root, "symbolic-ref",
-                                  "--short", "refs/remotes/origin/HEAD", NULL};
+   const char *const oh_argv[] = {
+       "git", "-C", git_root, "symbolic-ref", "--short", "refs/remotes/origin/HEAD", NULL};
    if (ss_git(oh_argv, base_ref, sizeof base_ref) != 0 || !base_ref[0])
    {
       const char *const h_argv[] = {"git", "-C", git_root, "symbolic-ref", "--short", "HEAD", NULL};
@@ -264,25 +267,34 @@ static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
        * git creates intermediate dirs. Let git's exit status be authoritative. */
       const char *const prune_argv[] = {"git", "-C", git_root, "worktree", "prune", NULL};
       (void)ss_git(prune_argv, NULL, 0);
-      const char *const add_argv[] = {"git", "-C",     git_root, "worktree", "add", wt,
-                                      "-b",  branch, base_ref, NULL};
+      const char *const add_argv[] = {"git", "-C", git_root, "worktree", "add",
+                                      wt,    "-b", branch,   base_ref,   NULL};
       (void)ss_git(add_argv, NULL, 0);
    }
    if (stat(wt, &st) != 0 || !S_ISDIR(st.st_mode))
       return; /* creation failed -> don't point the agent at a path that isn't there */
 
    ss_add(ctx, "\n# Isolated Checkout (REQUIRED before editing)\n");
-   ss_add(ctx,
-          "This session runs against a remote aimee-server, and session-worktree isolation "
-          "(`require_session_worktree`) is ON. You are NOT in a managed worktree, so every "
-          "edit/write/mutating shell command WILL be blocked until you enter one. An isolated "
-          "worktree has been prepared for you:\n\n  ");
+   ss_add(ctx, "This session runs against a remote aimee-server, and session-worktree isolation "
+               "(`require_session_worktree`) is ON. You are NOT in a managed worktree, so every "
+               "edit/write/mutating shell command WILL be blocked until you enter one. An isolated "
+               "worktree has been prepared for you:\n\n  ");
    ss_add(ctx, wt);
    ss_add(ctx,
           "\n\nBefore your first mutating tool call, switch into it — Claude Code: call "
           "`EnterWorktree` with that path; or `cd` into it for shell work. Do not edit the shared "
           "checkout.\n\n");
 }
+#else  /* _WIN32 */
+/* Session-worktree isolation (require_session_worktree) and the .aimee/worktrees
+ * layout are a POSIX/Linux-server feature; the Windows build ships only the thin
+ * client, and preparing a worktree needs POSIX process primitives. No-op there. */
+static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
+{
+   (void)ctx;
+   (void)sid;
+}
+#endif /* _WIN32 */
 
 static int handle_session_start_remote(const char *sid)
 {

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -7,6 +7,7 @@
 #include "cli_session_start.h"
 #include "cJSON.h"
 #include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -157,9 +158,27 @@ static int ss_git(const char *const argv[], char *out, size_t cap)
    close(pfd[1]);
    char buf[4096];
    size_t got = 0;
-   ssize_t r;
-   while (got < sizeof buf - 1 && (r = read(pfd[0], buf + got, sizeof buf - 1 - got)) > 0)
-      got += (size_t)r;
+   /* Read the first bufful; keep draining any excess into scratch so a chatty git
+    * never gets SIGPIPE (which would look like a failure). Retry on EINTR so a
+    * signal cannot truncate a capture that then reports exit 0. */
+   for (;;)
+   {
+      char scratch[4096];
+      int have_room = got < sizeof buf - 1;
+      char *dst = have_room ? buf + got : scratch;
+      size_t room = have_room ? sizeof buf - 1 - got : sizeof scratch;
+      ssize_t r = read(pfd[0], dst, room);
+      if (r < 0)
+      {
+         if (errno == EINTR)
+            continue;
+         break;
+      }
+      if (r == 0)
+         break;
+      if (have_room)
+         got += (size_t)r;
+   }
    buf[got] = '\0';
    close(pfd[0]);
    int status = 0;

--- a/src/config_trigger.c
+++ b/src/config_trigger.c
@@ -7,12 +7,17 @@
  *   max_concurrent: 2
  *
  * trigger_rules:
- *   - source: "github-webhook"
+ *   - source: "github-webhook"   # valid sources include github-webhook, cron, proposals
  *     event: "push"
  *     pipeline:
  *       template: "ci"
  *       workspace: "/ws/myproject"
  *       max_spend_usd: 0.50
+ *
+ * source: "proposals" reuses existing fields: workspace is the absolute git
+ * repo to scan, pipeline.template is the workflow name, event is the
+ * repo-relative proposal dir (default docs/proposals/pending), and schedule is
+ * the git ref/branch (default auto-detect).
  */
 
 #include "aimee.h"

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -73,4 +73,10 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
  * There is no env-var bypass; disabling it is an operator config action. */
 int handle_attention_guard(void);
 
+/* Authoritative "is session-worktree isolation required?" check (default ON
+ * unless aimee.yaml sets `require_session_worktree: false`). Exposed so the
+ * remote/thin session-start path can gate its worktree-prep directive on the
+ * same answer the guard uses to block. */
+int attn_require_session_worktree(void);
+
 #endif /* DEC_CLI_ATTENTION_GUARD_H */

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -380,37 +380,57 @@ static void trigger_resolve_ref(const char *workspace, const char *schedule, cha
    snprintf(out, n, "%s", "HEAD");
 }
 
+/* Create <home>/triggers/proposals (mode 0700). `home` must be a non-empty
+ * absolute path the caller already validated -- there is deliberately NO /tmp
+ * fallback (a predictable world-writable path is a symlink-clobber vector).
+ * mkdir returning EEXIST is fine; any other error propagates. */
 static int trigger_mkdir_parents(const char *home)
 {
+   if (!home || !home[0])
+      return -1;
    char dir[1024];
-   if (snprintf(dir, sizeof(dir), "%s/triggers", home ? home : "/tmp") >= (int)sizeof(dir))
+   if (snprintf(dir, sizeof(dir), "%s/triggers", home) >= (int)sizeof(dir))
       return -1;
-   mkdir(dir, 0700);
-   if (snprintf(dir, sizeof(dir), "%s/triggers/proposals", home ? home : "/tmp") >=
-       (int)sizeof(dir))
+   if (mkdir(dir, 0700) != 0 && errno != EEXIST)
       return -1;
-   mkdir(dir, 0700);
+   if (snprintf(dir, sizeof(dir), "%s/triggers/proposals", home) >= (int)sizeof(dir))
+      return -1;
+   if (mkdir(dir, 0700) != 0 && errno != EEXIST)
+      return -1;
    return 0;
 }
 
+/* Atomically write `bytes` to `path`. Uses mkstemp (O_EXCL|O_CREAT, mode 0600, a
+ * fresh unique name) so a pre-planted symlink/file at a predictable temp path
+ * cannot be followed/clobbered, then rename() onto the final path. */
 static int trigger_write_atomic(const char *path, const char *bytes)
 {
-   char tmp[1200];
-   if (snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= (int)sizeof(tmp))
+   char tmp[1300];
+   if (snprintf(tmp, sizeof(tmp), "%s.XXXXXX", path) >= (int)sizeof(tmp))
       return -1;
-   FILE *f = fopen(tmp, "wb");
-   if (!f)
+   int fd = mkstemp(tmp);
+   if (fd < 0)
       return -1;
+
+   const char *p = bytes ? bytes : "";
    size_t len = bytes ? strlen(bytes) : 0;
-   int ok = fwrite(bytes ? bytes : "", 1, len, f) == len;
-   if (fclose(f) != 0)
-      ok = 0;
-   if (!ok)
+   int ok = 1;
+   while (len > 0)
    {
-      unlink(tmp);
-      return -1;
+      ssize_t w = write(fd, p, len);
+      if (w < 0)
+      {
+         if (errno == EINTR)
+            continue;
+         ok = 0;
+         break;
+      }
+      p += w;
+      len -= (size_t)w;
    }
-   if (rename(tmp, path) != 0)
+   if (close(fd) != 0)
+      ok = 0;
+   if (!ok || rename(tmp, path) != 0)
    {
       unlink(tmp);
       return -1;
@@ -475,14 +495,24 @@ static void scan_proposals(const trigger_rule_t *rule)
                 PROPOSALS_MAX_ENTRIES, rule->workspace, scandir);
 
    const char *home = aimee_home();
-   if (trigger_mkdir_parents(home) != 0)
+   if (!home || !home[0])
+   {
+      aimee_log(LOG_WARN, "trigger.sched",
+                "proposals: no resolvable AIMEE_HOME; refusing to materialize under /tmp");
       return;
+   }
+   if (trigger_mkdir_parents(home) != 0)
+   {
+      aimee_log(LOG_WARN, "trigger.sched", "proposals: could not create %s/triggers/proposals: %s",
+                home, strerror(errno));
+      return;
+   }
 
    for (int i = 0; i < n; i++)
    {
       char proposal_path[1200];
-      if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md",
-                   home ? home : "/tmp", entries[i].sha) >= (int)sizeof(proposal_path))
+      if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md", home,
+                   entries[i].sha) >= (int)sizeof(proposal_path))
          continue;
 
       char existing[80];

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -424,8 +424,24 @@ static void scan_proposals(const trigger_rule_t *rule)
       return;
 
    const char *scanpath = rule->event[0] ? rule->event : PROPOSALS_DEFAULT_DIR;
+   /* Reject an absolute or traversing scan dir: `event` is repo-relative and must
+    * not be able to point git at a tree outside the workspace. */
+   if (scanpath[0] == '/' || strstr(scanpath, ".."))
+   {
+      aimee_log(LOG_WARN, "trigger.sched", "proposals scan dir rejected (absolute/traversal): %s",
+                scanpath);
+      return;
+   }
+
    char ref[256];
    trigger_resolve_ref(rule->workspace, rule->schedule, ref, sizeof(ref));
+   /* A ref beginning with '-' would be parsed by `git ls-tree` as an option (the
+    * `--` separator only protects args after it, not the tree-ish before it). */
+   if (ref[0] == '-')
+   {
+      aimee_log(LOG_WARN, "trigger.sched", "proposals ref rejected (leading '-'): %s", ref);
+      return;
+   }
 
    /* git ls-tree on a bare directory pathspec lists only that directory's own
     * tree entry, not the blobs inside it -- the parser (blobs only) would then
@@ -452,6 +468,11 @@ static void scan_proposals(const trigger_rule_t *rule)
    trigger_ls_tree_entry_t entries[PROPOSALS_MAX_ENTRIES];
    int n = trigger_parse_ls_tree(out ? out : "", entries, PROPOSALS_MAX_ENTRIES);
    free(out);
+   if (n == PROPOSALS_MAX_ENTRIES)
+      aimee_log(LOG_WARN, "trigger.sched",
+                "proposals scan hit the %d-entry cap for repo=%s dir=%s; extra proposals not "
+                "processed this pass",
+                PROPOSALS_MAX_ENTRIES, rule->workspace, scandir);
 
    const char *home = aimee_home();
    if (trigger_mkdir_parents(home) != 0)

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -13,21 +13,31 @@
 #include "db1/db1_cron_jobs.h"
 #include "db1/db1_trigger.h"
 #include "db1/pipelines.h"
+#include "db1/wfe_store.h"
+#include "aimee_home.h"
 #include "log.h"
 #include "platform_random.h"
 #include "skill_curator.h"
 #include "trigger_scheduler.h"
+#include "util.h"
+#include "wfe_engine.h"
 
 #include <pthread.h>
 #include <ctype.h>
+#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
 #define CRON_CONTEXT_OUTPUT_LIMIT 8192
+#define PROPOSALS_DEFAULT_DIR     "docs/proposals/pending"
+#define PROPOSALS_MAX_ENTRIES     512
+#define PROPOSALS_GIT_MAX_OUT     (256 * 1024)
+#define PROPOSALS_GIT_TIMEOUT_MS  15000
 
 /* ------------------------------------------------------------------ */
 /* Cron expression parser                                              */
@@ -226,6 +236,268 @@ static int schedule_matches(const char *expr, const struct tm *tm)
    if (r != -1)
       return r;
    return cron_matches(expr, tm);
+}
+
+/* ------------------------------------------------------------------ */
+/* Proposals trigger source                                             */
+/* ------------------------------------------------------------------ */
+
+/* source="proposals" overloads trigger_rule_t without adding fields:
+ * workspace = absolute repo path (required), pipeline_template = workflow name
+ * (required), event = repo-relative proposal dir (default docs/proposals/pending),
+ * schedule = git ref/branch (default auto-detected origin HEAD, then HEAD). */
+typedef struct
+{
+   char sha[41];
+   char name[512];
+} trigger_ls_tree_entry_t;
+
+static int trigger_is_hex_sha(const char *s)
+{
+   if (!s)
+      return 0;
+   for (int i = 0; i < 40; i++)
+      if (!isxdigit((unsigned char)s[i]))
+         return 0;
+   return s[40] == '\0';
+}
+
+static int trigger_has_md_suffix(const char *s)
+{
+   size_t n = s ? strlen(s) : 0;
+   return n >= 3 && strcmp(s + n - 3, ".md") == 0;
+}
+
+static int trigger_parse_ls_tree(const char *out, trigger_ls_tree_entry_t *entries, int max)
+{
+   if (!out || !entries || max <= 0)
+      return 0;
+
+   int count = 0;
+   const char *p = out;
+   while (*p)
+   {
+      const char *line = p;
+      const char *nl = strchr(p, '\n');
+      size_t len = nl ? (size_t)(nl - line) : strlen(line);
+      p = nl ? nl + 1 : line + len;
+
+      if (len == 0)
+         continue;
+      const char *end = line + len;
+      const char *sp1 = memchr(line, ' ', len);
+      if (!sp1)
+         continue;
+      const char *sp2 = memchr(sp1 + 1, ' ', (size_t)(end - sp1 - 1));
+      if (!sp2)
+         continue;
+      const char *tab = memchr(sp2 + 1, '\t', (size_t)(end - sp2 - 1));
+      if (!tab)
+         continue;
+      if ((size_t)(sp2 - sp1 - 1) != 4 || strncmp(sp1 + 1, "blob", 4) != 0)
+         continue;
+      if ((size_t)(tab - sp2 - 1) != 40)
+         continue;
+
+      char sha[41];
+      memcpy(sha, sp2 + 1, 40);
+      sha[40] = '\0';
+      if (!trigger_is_hex_sha(sha))
+         continue;
+
+      size_t name_len = (size_t)(end - tab - 1);
+      if (name_len == 0 || name_len >= sizeof(entries[0].name))
+         continue;
+      char name[512];
+      memcpy(name, tab + 1, name_len);
+      name[name_len] = '\0';
+      if (!trigger_has_md_suffix(name))
+         continue;
+
+      if (count >= max)
+         break;
+      memcpy(entries[count].sha, sha, sizeof(entries[count].sha));
+      memcpy(entries[count].name, name, name_len + 1);
+      count++;
+   }
+   return count;
+}
+
+extern char **environ;
+
+static int trigger_git_capture(const char *const argv[], const char *cwd, char **out)
+{
+   *out = NULL;
+   return safe_exec_capture_cwd_env_timeout(argv, cwd, environ, out, PROPOSALS_GIT_MAX_OUT,
+                                            PROPOSALS_GIT_TIMEOUT_MS);
+}
+
+static void trigger_trim_line(char *s)
+{
+   if (!s)
+      return;
+   size_t n = strlen(s);
+   while (n > 0 && (s[n - 1] == '\n' || s[n - 1] == '\r' || s[n - 1] == ' ' || s[n - 1] == '\t'))
+      s[--n] = '\0';
+}
+
+static void trigger_resolve_ref(const char *workspace, const char *schedule, char *out, size_t n)
+{
+   if (schedule && schedule[0])
+   {
+      snprintf(out, n, "%s", schedule);
+      return;
+   }
+
+   const char *const origin_head[] = {"git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD",
+                                      NULL};
+   char *buf = NULL;
+   if (trigger_git_capture(origin_head, workspace, &buf) == 0 && buf && buf[0])
+   {
+      trigger_trim_line(buf);
+      if (buf[0])
+      {
+         snprintf(out, n, "%s", buf);
+         free(buf);
+         return;
+      }
+   }
+   free(buf);
+
+   const char *const head[] = {"git", "symbolic-ref", "--short", "HEAD", NULL};
+   buf = NULL;
+   if (trigger_git_capture(head, workspace, &buf) == 0 && buf && buf[0])
+   {
+      trigger_trim_line(buf);
+      if (buf[0])
+      {
+         snprintf(out, n, "%s", buf);
+         free(buf);
+         return;
+      }
+   }
+   free(buf);
+   snprintf(out, n, "%s", "HEAD");
+}
+
+static int trigger_mkdir_parents(const char *home)
+{
+   char dir[1024];
+   if (snprintf(dir, sizeof(dir), "%s/triggers", home ? home : "/tmp") >= (int)sizeof(dir))
+      return -1;
+   mkdir(dir, 0700);
+   if (snprintf(dir, sizeof(dir), "%s/triggers/proposals", home ? home : "/tmp") >=
+       (int)sizeof(dir))
+      return -1;
+   mkdir(dir, 0700);
+   return 0;
+}
+
+static int trigger_write_atomic(const char *path, const char *bytes)
+{
+   char tmp[1200];
+   if (snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= (int)sizeof(tmp))
+      return -1;
+   FILE *f = fopen(tmp, "wb");
+   if (!f)
+      return -1;
+   size_t len = bytes ? strlen(bytes) : 0;
+   int ok = fwrite(bytes ? bytes : "", 1, len, f) == len;
+   if (fclose(f) != 0)
+      ok = 0;
+   if (!ok)
+   {
+      unlink(tmp);
+      return -1;
+   }
+   if (rename(tmp, path) != 0)
+   {
+      unlink(tmp);
+      return -1;
+   }
+   return 0;
+}
+
+static void scan_proposals(const trigger_rule_t *rule)
+{
+   if (!rule || !rule->workspace[0] || !rule->pipeline_template[0])
+      return;
+
+   const char *scanpath = rule->event[0] ? rule->event : PROPOSALS_DEFAULT_DIR;
+   char ref[256];
+   trigger_resolve_ref(rule->workspace, rule->schedule, ref, sizeof(ref));
+
+   /* git ls-tree on a bare directory pathspec lists only that directory's own
+    * tree entry, not the blobs inside it -- the parser (blobs only) would then
+    * find nothing. Normalize scanpath to exactly one trailing slash so ls-tree
+    * lists the directory's immediate contents (one level). Refuse on truncation. */
+   char scandir[TRIGGER_RULE_MAX_EVENT + 2];
+   size_t sl = strlen(scanpath);
+   while (sl > 0 && scanpath[sl - 1] == '/')
+      sl--;
+   if (snprintf(scandir, sizeof(scandir), "%.*s/", (int)sl, scanpath) >= (int)sizeof(scandir))
+      return;
+
+   const char *const ls_argv[] = {"git", "ls-tree", ref, "--", scandir, NULL};
+   char *out = NULL;
+   int rc = trigger_git_capture(ls_argv, rule->workspace, &out);
+   if (rc != 0)
+   {
+      aimee_log(LOG_WARN, "trigger.sched", "proposals ls-tree failed repo=%s ref=%s rc=%d",
+                rule->workspace, ref, rc);
+      free(out);
+      return;
+   }
+
+   trigger_ls_tree_entry_t entries[PROPOSALS_MAX_ENTRIES];
+   int n = trigger_parse_ls_tree(out ? out : "", entries, PROPOSALS_MAX_ENTRIES);
+   free(out);
+
+   const char *home = aimee_home();
+   if (trigger_mkdir_parents(home) != 0)
+      return;
+
+   for (int i = 0; i < n; i++)
+   {
+      char proposal_path[1200];
+      if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md",
+                   home ? home : "/tmp", entries[i].sha) >= (int)sizeof(proposal_path))
+         continue;
+
+      char existing[80];
+      if (db1_work_item_id_by_proposal(rule->workspace, proposal_path, existing,
+                                       sizeof(existing)) == 1)
+         continue;
+
+      const char *const cat_argv[] = {"git", "cat-file", "blob", entries[i].sha, NULL};
+      char *blob = NULL;
+      rc = trigger_git_capture(cat_argv, rule->workspace, &blob);
+      if (rc != 0)
+      {
+         aimee_log(LOG_WARN, "trigger.sched", "proposals cat-file failed repo=%s sha=%s rc=%d",
+                   rule->workspace, entries[i].sha, rc);
+         free(blob);
+         continue;
+      }
+      if (trigger_write_atomic(proposal_path, blob ? blob : "") != 0)
+      {
+         aimee_log(LOG_WARN, "trigger.sched", "proposals materialize failed path=%s: %s",
+                   proposal_path, strerror(errno));
+         free(blob);
+         continue;
+      }
+      free(blob);
+
+      char id[80] = "", err[256] = "";
+      rc = wfe_work_item_create(rule->pipeline_template, rule->workspace, proposal_path,
+                                "proposals", id, err, sizeof(err));
+      if (rc == 0 && id[0])
+         aimee_log(LOG_INFO, "trigger.sched", "filed proposal workflow=%s repo=%s sha=%s id=%s",
+                   rule->pipeline_template, rule->workspace, entries[i].sha, id);
+      else
+         aimee_log(LOG_WARN, "trigger.sched", "proposal create skipped/failed repo=%s sha=%s: %s",
+                   rule->workspace, entries[i].sha, err[0] ? err : "already exists");
+   }
 }
 
 /* ------------------------------------------------------------------ */
@@ -537,6 +809,15 @@ static void sched_tick(void)
    for (int i = 0; i < cfg.trigger_rule_count && i < TRIGGER_RULES_MAX; i++)
    {
       const trigger_rule_t *rule = &cfg.trigger_rules[i];
+
+      if (strcmp(rule->source, "proposals") == 0)
+      {
+         if (now - g_last_fired[i] < 55)
+            continue;
+         g_last_fired[i] = now;
+         scan_proposals(rule);
+         continue;
+      }
 
       if (strcmp(rule->source, "cron") != 0)
          continue;

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -97,8 +97,8 @@ int db1_cron_jobs_load(cron_job_t *out, int max, int enabled_only)
 /* ------------------------------------------------------------------ */
 
 static char g_home[512] = "/tmp/aimee-test";
-static char g_symref_out[256]; /* canned `git symbolic-ref` stdout ("" -> rc!=0) */
-static char g_lstree_out[8192]; /* canned `git ls-tree` stdout */
+static char g_symref_out[256];      /* canned `git symbolic-ref` stdout ("" -> rc!=0) */
+static char g_lstree_out[8192];     /* canned `git ls-tree` stdout */
 static char g_lstree_ref[256];      /* captured ref arg passed to ls-tree */
 static char g_lstree_pathspec[512]; /* captured pathspec arg passed to ls-tree */
 static struct
@@ -215,7 +215,8 @@ int wfe_work_item_create(const char *workflow_name, const char *repo, const char
 {
    if (g_ncreated < (int)(sizeof g_created / sizeof g_created[0]))
    {
-      snprintf(g_created[g_ncreated].wf, sizeof g_created[0].wf, "%s", workflow_name ? workflow_name : "");
+      snprintf(g_created[g_ncreated].wf, sizeof g_created[0].wf, "%s",
+               workflow_name ? workflow_name : "");
       snprintf(g_created[g_ncreated].repo, sizeof g_created[0].repo, "%s", repo ? repo : "");
       snprintf(g_created[g_ncreated].path, sizeof g_created[0].path, "%s",
                proposal_path ? proposal_path : "");
@@ -720,10 +721,11 @@ static void test_scan_proposals_end_to_end(void)
    snprintf(g_blobs[1].content, sizeof g_blobs[1].content, "# Proposal B\n");
    g_nblobs = 2;
    /* Includes a non-.md (.gitkeep) row to prove the filter runs in the glue too. */
-   snprintf(g_lstree_out, sizeof g_lstree_out,
-            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
-            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
-            "100644 blob 1111111111111111111111111111111111111111\tdocs/proposals/pending/.gitkeep\n");
+   snprintf(
+       g_lstree_out, sizeof g_lstree_out,
+       "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+       "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
+       "100644 blob 1111111111111111111111111111111111111111\tdocs/proposals/pending/.gitkeep\n");
 
    trigger_rule_t rule;
    memset(&rule, 0, sizeof rule);
@@ -821,15 +823,15 @@ static void test_scan_proposals_custom_event_and_schedule(void)
    snprintf(rule.source, sizeof rule.source, "proposals");
    snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "manual-review");
-   snprintf(rule.event, sizeof rule.event, "rfcs"); /* custom scan dir */
+   snprintf(rule.event, sizeof rule.event, "rfcs");       /* custom scan dir */
    snprintf(rule.schedule, sizeof rule.schedule, "main"); /* custom branch */
 
    scan_proposals(&rule);
    assert(g_ncreated == 1);
-   assert(strcmp(g_lstree_ref, "main") == 0);             /* schedule used as ref */
-   assert(strncmp(g_lstree_pathspec, "rfcs", 4) == 0);    /* custom event dir */
+   assert(strcmp(g_lstree_ref, "main") == 0);          /* schedule used as ref */
+   assert(strncmp(g_lstree_pathspec, "rfcs", 4) == 0); /* custom event dir */
    size_t pl = strlen(g_lstree_pathspec);
-   assert(g_lstree_pathspec[pl - 1] == '/');              /* still trailing-slashed */
+   assert(g_lstree_pathspec[pl - 1] == '/'); /* still trailing-slashed */
    assert(strcmp(g_created[0].wf, "manual-review") == 0);
    printf("  PASS: test_scan_proposals_custom_event_and_schedule\n");
 }

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -834,6 +834,45 @@ static void test_scan_proposals_custom_event_and_schedule(void)
    printf("  PASS: test_scan_proposals_custom_event_and_schedule\n");
 }
 
+static void test_scan_proposals_rejects_unsafe_ref_and_path(void)
+{
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
+   mkdir(g_home, 0700);
+
+   trigger_rule_t rule;
+
+   /* A ref (schedule) beginning with '-' is rejected before ls-tree runs. */
+   trig_stub_reset();
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   snprintf(rule.schedule, sizeof rule.schedule, "--all");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+   assert(g_lstree_ref[0] == '\0'); /* ls-tree never invoked */
+
+   /* A traversing scan dir is rejected. */
+   trig_stub_reset();
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   snprintf(rule.event, sizeof rule.event, "../../etc");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+   assert(g_lstree_ref[0] == '\0');
+
+   /* An absolute scan dir is rejected. */
+   snprintf(rule.event, sizeof rule.event, "/etc");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+
+   printf("  PASS: test_scan_proposals_rejects_unsafe_ref_and_path\n");
+}
+
 /* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
@@ -879,6 +918,7 @@ int main(void)
    test_scan_proposals_end_to_end();
    test_scan_proposals_requires_workspace_and_workflow();
    test_scan_proposals_custom_event_and_schedule();
+   test_scan_proposals_rejects_unsafe_ref_and_path();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <stddef.h>
 
 /* Stubs for symbols pulled in transitively by trigger_scheduler.c */
 
@@ -83,6 +84,48 @@ int db1_cron_jobs_load(cron_job_t *out, int max, int enabled_only)
    (void)out;
    (void)max;
    (void)enabled_only;
+   return 0;
+}
+
+const char *aimee_home(void)
+{
+   return "/tmp/aimee-test";
+}
+
+int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
+                                      char **out, size_t max_output, int timeout_ms)
+{
+   (void)argv;
+   (void)cwd;
+   (void)envp;
+   (void)max_output;
+   (void)timeout_ms;
+   if (out)
+      *out = NULL;
+   return 1;
+}
+
+int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, char *out_id,
+                                 size_t out_id_len)
+{
+   (void)repo;
+   (void)proposal_path;
+   if (out_id && out_id_len > 0)
+      out_id[0] = '\0';
+   return 0;
+}
+
+int wfe_work_item_create(const char *workflow_name, const char *repo, const char *proposal_path,
+                         const char *mode, char out_id[80], char *err, size_t errlen)
+{
+   (void)workflow_name;
+   (void)repo;
+   (void)proposal_path;
+   (void)mode;
+   if (out_id)
+      snprintf(out_id, 80, "wi_test");
+   if (err && errlen > 0)
+      err[0] = '\0';
    return 0;
 }
 
@@ -495,6 +538,57 @@ static void test_cron_job_prompt_reports_truncation_like_snprintf(void)
    printf("  PASS: test_cron_job_prompt_reports_truncation_like_snprintf\n");
 }
 
+static void test_parse_ls_tree_valid_multiline(void)
+{
+   const char *out =
+       "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+       "100644 blob fedcba9876543210fedcba9876543210fedcba98\tb.md\n";
+   trigger_ls_tree_entry_t entries[4];
+   int n = trigger_parse_ls_tree(out, entries, 4);
+   assert(n == 2);
+   assert(strcmp(entries[0].sha, "0123456789abcdef0123456789abcdef01234567") == 0);
+   assert(strcmp(entries[0].name, "docs/proposals/pending/a.md") == 0);
+   assert(strcmp(entries[1].sha, "fedcba9876543210fedcba9876543210fedcba98") == 0);
+   assert(strcmp(entries[1].name, "b.md") == 0);
+   printf("  PASS: test_parse_ls_tree_valid_multiline\n");
+}
+
+static void test_parse_ls_tree_filters_non_md_and_non_blob(void)
+{
+   const char *out = "100644 blob 0123456789abcdef0123456789abcdef01234567\ta.txt\n"
+                     "040000 tree fedcba9876543210fedcba9876543210fedcba98\tdir.md\n"
+                     "100644 blob 1111111111111111111111111111111111111111\tkeep.md\n";
+   trigger_ls_tree_entry_t entries[4];
+   int n = trigger_parse_ls_tree(out, entries, 4);
+   assert(n == 1);
+   assert(strcmp(entries[0].sha, "1111111111111111111111111111111111111111") == 0);
+   assert(strcmp(entries[0].name, "keep.md") == 0);
+   printf("  PASS: test_parse_ls_tree_filters_non_md_and_non_blob\n");
+}
+
+static void test_parse_ls_tree_empty_and_garbage(void)
+{
+   const char *out = "\nnot ls tree\n100644 blob short\tbad.md\n"
+                     "100644 blob zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\tbad.md\n";
+   trigger_ls_tree_entry_t entries[2];
+   assert(trigger_parse_ls_tree("", entries, 2) == 0);
+   assert(trigger_parse_ls_tree(out, entries, 2) == 0);
+   assert(trigger_parse_ls_tree(NULL, entries, 2) == 0);
+   printf("  PASS: test_parse_ls_tree_empty_and_garbage\n");
+}
+
+static void test_parse_ls_tree_buffer_cap(void)
+{
+   const char *out = "100644 blob 0123456789abcdef0123456789abcdef01234567\ta.md\n"
+                     "100644 blob fedcba9876543210fedcba9876543210fedcba98\tb.md\n";
+   trigger_ls_tree_entry_t entries[1];
+   int n = trigger_parse_ls_tree(out, entries, 1);
+   assert(n == 1);
+   assert(strcmp(entries[0].name, "a.md") == 0);
+   assert(trigger_parse_ls_tree(out, entries, 0) == 0);
+   printf("  PASS: test_parse_ls_tree_buffer_cap\n");
+}
+
 /* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
@@ -533,6 +627,10 @@ int main(void)
    test_cron_job_prompt_omits_empty_optional_blocks();
    test_cron_job_prompt_caps_prior_output_to_8k_tail();
    test_cron_job_prompt_reports_truncation_like_snprintf();
+   test_parse_ls_tree_valid_multiline();
+   test_parse_ls_tree_filters_non_md_and_non_blob();
+   test_parse_ls_tree_empty_and_garbage();
+   test_parse_ls_tree_buffer_cap();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <time.h>
 #include <stddef.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* Stubs for symbols pulled in transitively by trigger_scheduler.c */
 
@@ -87,29 +89,122 @@ int db1_cron_jobs_load(cron_job_t *out, int max, int enabled_only)
    return 0;
 }
 
-const char *aimee_home(void)
+/* ------------------------------------------------------------------ */
+/* Programmable stubs for the scan_proposals() integration test.        */
+/* The git exec is faked with canned per-subcommand output so the whole  */
+/* orchestration (ref resolve -> ls-tree -> parse -> materialize ->       */
+/* dedup -> create) runs hermetically, with no real git or DB.           */
+/* ------------------------------------------------------------------ */
+
+static char g_home[512] = "/tmp/aimee-test";
+static char g_symref_out[256]; /* canned `git symbolic-ref` stdout ("" -> rc!=0) */
+static char g_lstree_out[8192]; /* canned `git ls-tree` stdout */
+static char g_lstree_ref[256];      /* captured ref arg passed to ls-tree */
+static char g_lstree_pathspec[512]; /* captured pathspec arg passed to ls-tree */
+static struct
 {
-   return "/tmp/aimee-test";
+   char sha[41];
+   char content[256];
+} g_blobs[16];
+static int g_nblobs;
+static struct
+{
+   char wf[64];
+   char repo[512];
+   char path[600];
+   char mode[32];
+} g_created[32];
+static int g_ncreated;
+
+static void trig_stub_reset(void)
+{
+   g_symref_out[0] = g_lstree_out[0] = g_lstree_ref[0] = g_lstree_pathspec[0] = '\0';
+   g_nblobs = 0;
+   g_ncreated = 0;
 }
 
+const char *aimee_home(void)
+{
+   return g_home;
+}
+
+/* Fake git: dispatch on the subcommand token and return canned stdout. */
 int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
                                       char **out, size_t max_output, int timeout_ms)
 {
-   (void)argv;
    (void)cwd;
    (void)envp;
    (void)max_output;
    (void)timeout_ms;
    if (out)
       *out = NULL;
+   if (!argv || !argv[0])
+      return 1;
+
+   int is_lstree = 0, is_catfile = 0, is_symref = 0, dashdash = -1;
+   const char *sha = NULL, *ref = NULL;
+   for (int i = 0; argv[i]; i++)
+   {
+      if (strcmp(argv[i], "ls-tree") == 0)
+      {
+         is_lstree = 1;
+         if (argv[i + 1])
+            ref = argv[i + 1]; /* `git ls-tree <ref> -- <dir>` */
+      }
+      if (strcmp(argv[i], "cat-file") == 0)
+         is_catfile = 1;
+      if (strcmp(argv[i], "symbolic-ref") == 0)
+         is_symref = 1;
+      if (strcmp(argv[i], "--") == 0)
+         dashdash = i;
+   }
+   if (is_symref)
+   {
+      if (!g_symref_out[0])
+         return 1; /* no symbolic-ref -> non-zero, exercises the fallback chain */
+      if (out)
+         *out = strdup(g_symref_out);
+      return 0;
+   }
+   if (is_lstree)
+   {
+      if (ref)
+         snprintf(g_lstree_ref, sizeof g_lstree_ref, "%s", ref);
+      if (dashdash >= 0 && argv[dashdash + 1])
+         snprintf(g_lstree_pathspec, sizeof g_lstree_pathspec, "%s", argv[dashdash + 1]);
+      if (out)
+         *out = strdup(g_lstree_out);
+      return 0;
+   }
+   if (is_catfile)
+   {
+      for (int i = 0; argv[i]; i++)
+         sha = argv[i]; /* last token is the blob sha */
+      for (int i = 0; i < g_nblobs; i++)
+         if (sha && strcmp(g_blobs[i].sha, sha) == 0)
+         {
+            if (out)
+               *out = strdup(g_blobs[i].content);
+            return 0;
+         }
+      if (out)
+         *out = strdup("");
+      return 0;
+   }
    return 1;
 }
 
+/* Dedup pre-check: a proposal already recorded by wfe_work_item_create "exists". */
 int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, char *out_id,
                                  size_t out_id_len)
 {
-   (void)repo;
-   (void)proposal_path;
+   for (int i = 0; i < g_ncreated; i++)
+      if (strcmp(g_created[i].repo, repo) == 0 && strcmp(g_created[i].path, proposal_path) == 0)
+      {
+         if (out_id && out_id_len > 0)
+            snprintf(out_id, out_id_len, "wi_existing");
+         return 1;
+      }
    if (out_id && out_id_len > 0)
       out_id[0] = '\0';
    return 0;
@@ -118,12 +213,17 @@ int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, ch
 int wfe_work_item_create(const char *workflow_name, const char *repo, const char *proposal_path,
                          const char *mode, char out_id[80], char *err, size_t errlen)
 {
-   (void)workflow_name;
-   (void)repo;
-   (void)proposal_path;
-   (void)mode;
+   if (g_ncreated < (int)(sizeof g_created / sizeof g_created[0]))
+   {
+      snprintf(g_created[g_ncreated].wf, sizeof g_created[0].wf, "%s", workflow_name ? workflow_name : "");
+      snprintf(g_created[g_ncreated].repo, sizeof g_created[0].repo, "%s", repo ? repo : "");
+      snprintf(g_created[g_ncreated].path, sizeof g_created[0].path, "%s",
+               proposal_path ? proposal_path : "");
+      snprintf(g_created[g_ncreated].mode, sizeof g_created[0].mode, "%s", mode ? mode : "");
+      g_ncreated++;
+   }
    if (out_id)
-      snprintf(out_id, 80, "wi_test");
+      snprintf(out_id, 80, "wi_%d", g_ncreated);
    if (err && errlen > 0)
       err[0] = '\0';
    return 0;
@@ -590,6 +690,151 @@ static void test_parse_ls_tree_buffer_cap(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* scan_proposals() end-to-end orchestration (hermetic, faked git)      */
+/* ------------------------------------------------------------------ */
+
+static int file_equals(const char *path, const char *want)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return 0;
+   char buf[512] = {0};
+   size_t n = fread(buf, 1, sizeof buf - 1, f);
+   fclose(f);
+   buf[n] = '\0';
+   return strcmp(buf, want) == 0;
+}
+
+static void test_scan_proposals_end_to_end(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
+   mkdir(g_home, 0700); /* trigger_mkdir_parents() creates triggers/ + triggers/proposals/ */
+
+   /* schedule empty -> ref resolves via the symbolic-ref fallback. */
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# Proposal A\n");
+   snprintf(g_blobs[1].sha, sizeof g_blobs[1].sha, "fedcba9876543210fedcba9876543210fedcba98");
+   snprintf(g_blobs[1].content, sizeof g_blobs[1].content, "# Proposal B\n");
+   g_nblobs = 2;
+   /* Includes a non-.md (.gitkeep) row to prove the filter runs in the glue too. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
+            "100644 blob 1111111111111111111111111111111111111111\tdocs/proposals/pending/.gitkeep\n");
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   snprintf(rule.event, sizeof rule.event, "docs/proposals/pending");
+
+   scan_proposals(&rule);
+
+   /* Two .md proposals -> two work items; .gitkeep filtered out. */
+   assert(g_ncreated == 2);
+   /* ls-tree used the resolved default ref and a TRAILING-SLASH pathspec (regression
+    * guard for the "bare dir lists only the tree entry" bug). */
+   assert(strcmp(g_lstree_ref, "origin/testing") == 0);
+   size_t pl = strlen(g_lstree_pathspec);
+   assert(pl > 0 && g_lstree_pathspec[pl - 1] == '/');
+   /* Correct launch args: workflow=pipeline_template, repo=workspace, mode=proposals. */
+   assert(strcmp(g_created[0].wf, "build") == 0);
+   assert(strcmp(g_created[0].repo, "/repo/aimee") == 0);
+   assert(strcmp(g_created[0].mode, "proposals") == 0);
+   /* proposal_path is <home>/triggers/proposals/<blob-sha>.md and holds the blob. */
+   char exp0[700], exp1[700];
+   snprintf(exp0, sizeof exp0, "%s/triggers/proposals/%s.md", g_home, g_blobs[0].sha);
+   snprintf(exp1, sizeof exp1, "%s/triggers/proposals/%s.md", g_home, g_blobs[1].sha);
+   assert(strcmp(g_created[0].path, exp0) == 0);
+   assert(strcmp(g_created[1].path, exp1) == 0);
+   assert(file_equals(exp0, "# Proposal A\n"));
+   assert(file_equals(exp1, "# Proposal B\n"));
+
+   /* Re-scan with the same tree -> dedup pre-check skips both -> no new work items. */
+   scan_proposals(&rule);
+   assert(g_ncreated == 2);
+
+   /* A genuinely new proposal (new blob) -> exactly one new work item. */
+   snprintf(g_blobs[2].sha, sizeof g_blobs[2].sha, "2222222222222222222222222222222222222222");
+   snprintf(g_blobs[2].content, sizeof g_blobs[2].content, "# Proposal C\n");
+   g_nblobs = 3;
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
+            "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
+   scan_proposals(&rule);
+   assert(g_ncreated == 3);
+   assert(strcmp(g_created[2].wf, "build") == 0);
+
+   printf("  PASS: test_scan_proposals_end_to_end\n");
+}
+
+static void test_scan_proposals_requires_workspace_and_workflow(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "x\n");
+   g_nblobs = 1;
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+
+   /* Missing workspace -> no-op. */
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+
+   /* Missing workflow (pipeline_template) -> no-op. */
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+
+   printf("  PASS: test_scan_proposals_requires_workspace_and_workflow\n");
+}
+
+static void test_scan_proposals_custom_event_and_schedule(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   /* Non-empty schedule -> used verbatim as the ref; symbolic-ref must NOT be needed. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob abababababababababababababababababababab\trfcs/x.md\n");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "abababababababababababababababababababab");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "rfc\n");
+   g_nblobs = 1;
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "manual-review");
+   snprintf(rule.event, sizeof rule.event, "rfcs"); /* custom scan dir */
+   snprintf(rule.schedule, sizeof rule.schedule, "main"); /* custom branch */
+
+   scan_proposals(&rule);
+   assert(g_ncreated == 1);
+   assert(strcmp(g_lstree_ref, "main") == 0);             /* schedule used as ref */
+   assert(strncmp(g_lstree_pathspec, "rfcs", 4) == 0);    /* custom event dir */
+   size_t pl = strlen(g_lstree_pathspec);
+   assert(g_lstree_pathspec[pl - 1] == '/');              /* still trailing-slashed */
+   assert(strcmp(g_created[0].wf, "manual-review") == 0);
+   printf("  PASS: test_scan_proposals_custom_event_and_schedule\n");
+}
+
+/* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
 
@@ -631,6 +876,9 @@ int main(void)
    test_parse_ls_tree_filters_non_md_and_non_blob();
    test_parse_ls_tree_empty_and_garbage();
    test_parse_ls_tree_buffer_cap();
+   test_scan_proposals_end_to_end();
+   test_scan_proposals_requires_workspace_and_workflow();
+   test_scan_proposals_custom_event_and_schedule();
    printf("All tests passed.\n");
    return 0;
 }


### PR DESCRIPTION
## Summary

Two changes:

### 1. New `proposals` trigger source (`src/server/trigger_scheduler.c`)
Scans a directory of proposal docs **as committed on a git branch** of a repo and launches a WFE workflow per new proposal, using the input the engine already expects (`wfe_work_item_create(..., proposal_path)`). It's the autopilot analog of `source: "cron"`, evaluated in the same 30s `sched_tick()` loop.

Schema reuses existing `trigger_rule_t` fields (no new fields):

```yaml
trigger_rules:
  - source: proposals
    workspace: /ws/aimee            # git repo to scan (required)
    event: docs/proposals/pending   # dir to scan (default if omitted)
    schedule: origin/testing        # branch/ref (default: auto origin/HEAD -> HEAD)
    pipeline:
      template: build               # workflow to launch
```

- **Dedup with no new table:** each proposal's committed blob is materialized to a deterministic `$AIMEE_HOME/triggers/proposals/<blob-sha>.md`, so `UNIQUE(repo, proposal_path)` (+ a cheap `db1_work_item_id_by_proposal` pre-check) skips already-processed proposals; an edited proposal (new SHA) is intentionally treated as new work.
- `git ls-tree` is invoked with a one-level directory listing (trailing slash) so it returns the dir's blobs, not the dir's own tree entry; the ls-tree parse is a pure, unit-tested helper filtering to `.md` blobs.

### 2. Remote/thin session-start worktree fix (`src/cli_session_start.c`)
On a remote-server (thin-client) deployment (`~/.config/aimee/remote.conf` set, no local socket), `session-start` took `handle_session_start_remote()`, which did **no** local worktree setup — while the attention-guard's `require_session_worktree` isolation still ran locally and blocked every mutation outside a managed worktree. Net: the session wedged with no worktree and no guidance to enter one.

Fix: in the thin path, when isolation is enabled and the session isn't already in a managed worktree, create the per-session worktree (`<repo>/.aimee/worktrees/<key>/main` off the default branch) and append an "Isolated Checkout (REQUIRED)" directive to the SessionStart context. The thin client links none of the workspace helpers, so git is driven via **argv-based `fork`/`execvp`** (no shell); the worktree key is a short prefix + FNV-1a hash of the full session id (collision-free).

## Verification
- Compiles clean under `-Werror` (real server TU + client binary); **28 unit tests pass**, including hermetic integration coverage of the full `scan_proposals` orchestration (ref resolution → ls-tree **with a regression guard for the trailing-slash fix** → parse → materialize → dedup → launch) and the ref/scan-dir validation guards.
- End-to-end: the corrected `git ls-tree` lists the `.md` blobs the parser accepts (0 → N); the fixed session-start creates the worktree and emits the directive in the wedged scenario, and no-ops when already isolated.

## Review
Run through the aimee roundtable; legitimate findings addressed in `fix(review): …` (shell-free git via argv, collision-free worktree key, ref/scan-dir validation, ls-tree truncation warning). False positives are documented in that commit message (blob-SHA dedup is intended; `snprintf` can't overflow; the directive is already suppressed on creation failure; `g_last_fired[]` is per-rule-index).

## Validation-pending
A fully **live** run — a running aimee-server's tick invoking real git + real `wfe_work_item_create` against DB1 to launch an actual workflow — was not exercised (this environment uses a remote server, so the server-side tick can't be driven locally). That path is covered piecewise (real git verified manually; the launch call mirrors `server_sweep.c`; the `UNIQUE(repo, proposal_path)` constraint is in the schema; the orchestration is unit-tested), but the assembled live launch remains unverified by the strict bar.
