### PR TITLE
Promote testing → main: proposals trigger source + remote session-start worktree fix

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -253,7 +253,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 146 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 147 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -451,7 +451,7 @@ The binaries read 146 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -489,6 +489,14 @@ static int attn_config_require_session_worktree(void)
    return value;
 }
 
+/* Public wrapper so other client TUs (e.g. the remote/thin session-start path)
+ * can ask the SAME authoritative question the guard uses to decide whether to
+ * block — default ON unless aimee.yaml sets `require_session_worktree: false`. */
+int attn_require_session_worktree(void)
+{
+   return attn_config_require_session_worktree();
+}
+
 /* Lexically resolve '.', '..' and '//' in `path` into `out` (purely textual —
  * the write target may not exist yet, so realpath() is unusable; symlinks are
  * not followed). Closes the `.aimee/worktrees/../escape` traversal bypass: a

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -6,11 +6,18 @@
 #include "cli_client.h"
 #include "cli_session_start.h"
 #include "cJSON.h"
+#include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
-#include <unistd.h>
+
+/* This is a thin-client TU compiled without -I./-Idb2, and the client binary
+ * links none of workspace.o/guardrails.o/config.o — so worktree creation here
+ * goes through git subprocesses (below), not those functions. Only the
+ * lightweight attention-guard helpers (attn_require_session_worktree /
+ * attn_session_isolation_blocked, from cli_attention_guard.h) are available. */
 
 struct ss_sbuf
 {
@@ -112,7 +119,128 @@ static cJSON *ss_retry_post(const char *endpoint, const char *bearer, const char
    return NULL;
 }
 
-static int handle_session_start_remote(void)
+/* Capture the first trimmed stdout line of `cmd` into out[cap]; 1 on non-empty. */
+static int ss_git_first_line(const char *cmd, char *out, size_t cap)
+{
+   if (cap)
+      out[0] = '\0';
+   FILE *f = popen(cmd, "r");
+   if (!f)
+      return 0;
+   char buf[4096] = {0};
+   char *got = fgets(buf, sizeof buf, f);
+   pclose(f);
+   if (!got)
+      return 0;
+   size_t n = strlen(buf);
+   while (n > 0 &&
+          (buf[n - 1] == '\n' || buf[n - 1] == '\r' || buf[n - 1] == ' ' || buf[n - 1] == '\t'))
+      buf[--n] = '\0';
+   if (!buf[0])
+      return 0;
+   snprintf(out, cap, "%s", buf);
+   return 1;
+}
+
+/* Remote/thin session-start (handle_session_start_remote) does no local worktree
+ * setup — it assumes the client tree is absent on the remote server. But the
+ * attention-guard's `require_session_worktree` isolation still runs LOCALLY and
+ * blocks every mutation outside a managed worktree, so a remote-server deployment
+ * would wedge the session: nothing prepares or points to a worktree, yet the
+ * guard demands one. Prepare the per-session sibling worktree here (via git, as
+ * the thin client links no workspace helpers) and surface a directive telling the
+ * agent to enter it before its first mutating tool call. No-op when isolation is
+ * off, the session is already inside a worktree, or there is no local git repo. */
+static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
+{
+   if (!attn_require_session_worktree())
+      return; /* isolation not enforced -> nothing to prepare or say */
+
+   char cwd[4096];
+   if (!getcwd(cwd, sizeof cwd))
+      return;
+   /* Already inside a managed (.aimee/.claude/.codex) worktree -> a mutating op
+    * would not be blocked; don't nag or create a redundant worktree. Mirrors the
+    * guard's own decision so the directive fires exactly when it would block. */
+   if (!attn_session_isolation_blocked(ATTN_OP_SOFT, NULL, cwd))
+      return;
+
+   /* Need a stable session id to name the worktree; Claude Code always sends one. */
+   if (!sid || !sid[0])
+      return;
+   char sid_safe[64];
+   size_t si = 0;
+   for (const char *p = sid; *p && si + 1 < sizeof sid_safe; p++)
+   {
+      char c = *p;
+      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+               c == '-' || c == '_' || c == '.';
+      sid_safe[si++] = ok ? c : '-';
+   }
+   sid_safe[si] = '\0';
+   if (!sid_safe[0])
+      return;
+
+   /* A single quote in a path would break the single-quoted popen/system commands;
+    * such local repo paths are pathological -> skip rather than risk misquoting. */
+   if (strchr(cwd, '\''))
+      return;
+
+   char cmd[10240];
+   char git_root[4096];
+   snprintf(cmd, sizeof cmd, "git -C '%s' rev-parse --show-toplevel 2>/dev/null", cwd);
+   if (!ss_git_first_line(cmd, git_root, sizeof git_root) || strchr(git_root, '\''))
+      return; /* not a git repo (or unquotable path) -> nothing to prepare */
+
+   /* Base the session branch on the repo's default branch (origin HEAD -> HEAD). */
+   char base_ref[256];
+   snprintf(cmd, sizeof cmd, "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null",
+            git_root);
+   if (!ss_git_first_line(cmd, base_ref, sizeof base_ref))
+   {
+      snprintf(cmd, sizeof cmd, "git -C '%s' symbolic-ref --short HEAD 2>/dev/null", git_root);
+      if (!ss_git_first_line(cmd, base_ref, sizeof base_ref))
+         snprintf(base_ref, sizeof base_ref, "HEAD");
+   }
+   if (strchr(base_ref, '\''))
+      return;
+
+   char wt[4200];
+   if (snprintf(wt, sizeof wt, "%s/.aimee/worktrees/%s/main", git_root, sid_safe) >=
+       (int)sizeof wt)
+      return;
+
+   struct stat st;
+   if (stat(wt, &st) != 0)
+   {
+      /* Prune stale registrations (best-effort), then create the worktree+branch.
+       * git worktree add makes intermediate dirs; -Wno-unused-result covers system(). */
+      snprintf(cmd, sizeof cmd, "git -C '%s' worktree prune >/dev/null 2>&1", git_root);
+      (void)system(cmd);
+      int cn = snprintf(cmd, sizeof cmd,
+                        "git -C '%s' worktree add '%s' -b 'aimee/session/%s' '%s' >/dev/null 2>&1",
+                        git_root, wt, sid_safe, base_ref);
+      if (cn < 0 || cn >= (int)sizeof cmd)
+         return; /* command truncated -> don't run a malformed git invocation */
+      (void)system(cmd);
+   }
+   if (stat(wt, &st) != 0 || !S_ISDIR(st.st_mode))
+      return; /* creation failed -> don't point the agent at a path that isn't there */
+
+   ss_add(ctx, "\n# Isolated Checkout (REQUIRED before editing)\n");
+   ss_add(ctx,
+          "This session runs against a remote aimee-server, and session-worktree isolation "
+          "(`require_session_worktree`) is ON. You are NOT in a managed worktree, so every "
+          "edit/write/mutating shell command WILL be blocked until you enter one. An isolated "
+          "worktree has been prepared for you:\n\n  ");
+   ss_add(ctx, wt);
+   ss_add(ctx,
+          "\n\nBefore your first mutating tool call, switch into it — Claude Code: call "
+          "`EnterWorktree` with that path; or `cd` into it for shell work. Do not edit the shared "
+          "checkout.\n\n");
+}
+
+static int handle_session_start_remote(const char *sid)
 {
    char *endpoint = cli_v1_client_endpoint();
    if (!endpoint)
@@ -170,6 +298,12 @@ static int handle_session_start_remote(void)
 
    free(endpoint);
    free(bearer);
+
+   /* Local worktree isolation: even though compute is remote, the guard runs on
+    * THIS host. Prepare + direct the agent into an isolated worktree so mutating
+    * tools aren't blocked. Appended last so it shows even if the remote brief
+    * fetch returned nothing (and so a wedged session always gets the way out). */
+   ss_append_worktree_isolation(&ctx, sid);
 
    if (ctx.p && ctx.p[0])
    {
@@ -494,7 +628,7 @@ int handle_session_start(int json_output)
        * local aimee-server needed (see handle_session_start_remote). */
       if (cli_v1_has_remote_endpoint())
       {
-         int rc = handle_session_start_remote();
+         int rc = handle_session_start_remote(sid);
          cJSON_Delete(hook_json);
          free(stdin_data);
          return rc;

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -7,10 +7,12 @@
 #include "cli_session_start.h"
 #include "cJSON.h"
 #include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 /* This is a thin-client TU compiled without -I./-Idb2, and the client binary
@@ -119,27 +121,83 @@ static cJSON *ss_retry_post(const char *endpoint, const char *bearer, const char
    return NULL;
 }
 
-/* Capture the first trimmed stdout line of `cmd` into out[cap]; 1 on non-empty. */
-static int ss_git_first_line(const char *cmd, char *out, size_t cap)
+/* Run `git <argv...>` with NO shell (fork/execvp), discarding stderr. Captures
+ * the first trimmed stdout line into out[cap] (out may be NULL — status only).
+ * Returns the child's exit code (0 = success), or -1 if it could not be spawned
+ * or did not exit cleanly. Shell-free by design: session ids / repo paths never
+ * reach a shell, so there is nothing to quote or inject. */
+static int ss_git(const char *const argv[], char *out, size_t cap)
 {
-   if (cap)
+   if (out && cap)
       out[0] = '\0';
-   FILE *f = popen(cmd, "r");
-   if (!f)
-      return 0;
-   char buf[4096] = {0};
-   char *got = fgets(buf, sizeof buf, f);
-   pclose(f);
-   if (!got)
-      return 0;
-   size_t n = strlen(buf);
-   while (n > 0 &&
-          (buf[n - 1] == '\n' || buf[n - 1] == '\r' || buf[n - 1] == ' ' || buf[n - 1] == '\t'))
-      buf[--n] = '\0';
-   if (!buf[0])
-      return 0;
-   snprintf(out, cap, "%s", buf);
-   return 1;
+   int pfd[2];
+   if (pipe(pfd) != 0)
+      return -1;
+   pid_t pid = fork();
+   if (pid < 0)
+   {
+      close(pfd[0]);
+      close(pfd[1]);
+      return -1;
+   }
+   if (pid == 0)
+   {
+      dup2(pfd[1], STDOUT_FILENO);
+      int devnull = open("/dev/null", O_WRONLY);
+      if (devnull >= 0)
+         dup2(devnull, STDERR_FILENO);
+      close(pfd[0]);
+      close(pfd[1]);
+      execvp("git", (char *const *)argv);
+      _exit(127);
+   }
+   close(pfd[1]);
+   char buf[4096];
+   size_t got = 0;
+   ssize_t r;
+   while (got < sizeof buf - 1 && (r = read(pfd[0], buf + got, sizeof buf - 1 - got)) > 0)
+      got += (size_t)r;
+   buf[got] = '\0';
+   close(pfd[0]);
+   int status = 0;
+   if (waitpid(pid, &status, 0) < 0 || !WIFEXITED(status))
+      return -1;
+   int code = WEXITSTATUS(status);
+   if (out && cap && code == 0)
+   {
+      size_t n = 0;
+      while (buf[n] && buf[n] != '\n' && buf[n] != '\r')
+         n++;
+      buf[n] = '\0';
+      while (n > 0 && (buf[n - 1] == ' ' || buf[n - 1] == '\t'))
+         buf[--n] = '\0';
+      snprintf(out, cap, "%s", buf);
+   }
+   return code;
+}
+
+/* Collision-free worktree key for a session: a short alnum prefix of the id for
+ * human readability plus a 64-bit FNV-1a hash of the FULL id, so two distinct ids
+ * (even ones that share a sanitized prefix) never map to the same worktree/branch.
+ * Stable for a given id -> re-runs (startup/resume/compact) reuse the same one. */
+static void ss_worktree_key(const char *sid, char *out, size_t cap)
+{
+   unsigned long long h = 1469598103934665603ULL;
+   for (const char *p = sid; *p; p++)
+   {
+      h ^= (unsigned char)*p;
+      h *= 1099511628211ULL;
+   }
+   char pre[9];
+   size_t k = 0;
+   for (const char *p = sid; *p && k < 8; p++)
+   {
+      char c = *p;
+      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))
+         pre[k++] = c;
+   }
+   pre[k] = '\0';
+   snprintf(out, cap, "%s%s%016llx", pre, k ? "-" : "", h);
 }
 
 /* Remote/thin session-start (handle_session_start_remote) does no local worktree
@@ -168,61 +226,47 @@ static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
    /* Need a stable session id to name the worktree; Claude Code always sends one. */
    if (!sid || !sid[0])
       return;
-   char sid_safe[64];
-   size_t si = 0;
-   for (const char *p = sid; *p && si + 1 < sizeof sid_safe; p++)
-   {
-      char c = *p;
-      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-               c == '-' || c == '_' || c == '.';
-      sid_safe[si++] = ok ? c : '-';
-   }
-   sid_safe[si] = '\0';
-   if (!sid_safe[0])
+   char key[80];
+   ss_worktree_key(sid, key, sizeof key);
+   if (!key[0])
       return;
 
-   /* A single quote in a path would break the single-quoted popen/system commands;
-    * such local repo paths are pathological -> skip rather than risk misquoting. */
-   if (strchr(cwd, '\''))
-      return;
-
-   char cmd[10240];
+   const char *const rp_argv[] = {"git", "-C", cwd, "rev-parse", "--show-toplevel", NULL};
    char git_root[4096];
-   snprintf(cmd, sizeof cmd, "git -C '%s' rev-parse --show-toplevel 2>/dev/null", cwd);
-   if (!ss_git_first_line(cmd, git_root, sizeof git_root) || strchr(git_root, '\''))
-      return; /* not a git repo (or unquotable path) -> nothing to prepare */
+   if (ss_git(rp_argv, git_root, sizeof git_root) != 0 || !git_root[0])
+      return; /* not a git repo -> nothing to prepare */
 
    /* Base the session branch on the repo's default branch (origin HEAD -> HEAD). */
    char base_ref[256];
-   snprintf(cmd, sizeof cmd, "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null",
-            git_root);
-   if (!ss_git_first_line(cmd, base_ref, sizeof base_ref))
+   const char *const oh_argv[] = {"git",      "-C",     git_root, "symbolic-ref",
+                                  "--short", "refs/remotes/origin/HEAD", NULL};
+   if (ss_git(oh_argv, base_ref, sizeof base_ref) != 0 || !base_ref[0])
    {
-      snprintf(cmd, sizeof cmd, "git -C '%s' symbolic-ref --short HEAD 2>/dev/null", git_root);
-      if (!ss_git_first_line(cmd, base_ref, sizeof base_ref))
+      const char *const h_argv[] = {"git", "-C", git_root, "symbolic-ref", "--short", "HEAD", NULL};
+      if (ss_git(h_argv, base_ref, sizeof base_ref) != 0 || !base_ref[0])
          snprintf(base_ref, sizeof base_ref, "HEAD");
    }
-   if (strchr(base_ref, '\''))
+   /* A base ref that begins with '-' would be parsed as a git option; reject it. */
+   if (base_ref[0] == '-')
       return;
 
    char wt[4200];
-   if (snprintf(wt, sizeof wt, "%s/.aimee/worktrees/%s/main", git_root, sid_safe) >=
-       (int)sizeof wt)
+   if (snprintf(wt, sizeof wt, "%s/.aimee/worktrees/%s/main", git_root, key) >= (int)sizeof wt)
+      return;
+   char branch[128];
+   if (snprintf(branch, sizeof branch, "aimee/session/%s", key) >= (int)sizeof branch)
       return;
 
    struct stat st;
    if (stat(wt, &st) != 0)
    {
       /* Prune stale registrations (best-effort), then create the worktree+branch.
-       * git worktree add makes intermediate dirs; -Wno-unused-result covers system(). */
-      snprintf(cmd, sizeof cmd, "git -C '%s' worktree prune >/dev/null 2>&1", git_root);
-      (void)system(cmd);
-      int cn = snprintf(cmd, sizeof cmd,
-                        "git -C '%s' worktree add '%s' -b 'aimee/session/%s' '%s' >/dev/null 2>&1",
-                        git_root, wt, sid_safe, base_ref);
-      if (cn < 0 || cn >= (int)sizeof cmd)
-         return; /* command truncated -> don't run a malformed git invocation */
-      (void)system(cmd);
+       * git creates intermediate dirs. Let git's exit status be authoritative. */
+      const char *const prune_argv[] = {"git", "-C", git_root, "worktree", "prune", NULL};
+      (void)ss_git(prune_argv, NULL, 0);
+      const char *const add_argv[] = {"git", "-C",     git_root, "worktree", "add", wt,
+                                      "-b",  branch, base_ref, NULL};
+      (void)ss_git(add_argv, NULL, 0);
    }
    if (stat(wt, &st) != 0 || !S_ISDIR(st.st_mode))
       return; /* creation failed -> don't point the agent at a path that isn't there */

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -7,13 +7,15 @@
 #include "cli_session_start.h"
 #include "cJSON.h"
 #include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
-#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <sys/wait.h>
 #include <unistd.h>
+#ifndef _WIN32
+#include <fcntl.h>
+#include <sys/wait.h>
+#endif
 
 /* This is a thin-client TU compiled without -I./-Idb2, and the client binary
  * links none of workspace.o/guardrails.o/config.o — so worktree creation here
@@ -121,6 +123,7 @@ static cJSON *ss_retry_post(const char *endpoint, const char *bearer, const char
    return NULL;
 }
 
+#ifndef _WIN32
 /* Run `git <argv...>` with NO shell (fork/execvp), discarding stderr. Captures
  * the first trimmed stdout line into out[cap] (out may be NULL — status only).
  * Returns the child's exit code (0 = success), or -1 if it could not be spawned
@@ -238,8 +241,8 @@ static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
 
    /* Base the session branch on the repo's default branch (origin HEAD -> HEAD). */
    char base_ref[256];
-   const char *const oh_argv[] = {"git",      "-C",     git_root, "symbolic-ref",
-                                  "--short", "refs/remotes/origin/HEAD", NULL};
+   const char *const oh_argv[] = {
+       "git", "-C", git_root, "symbolic-ref", "--short", "refs/remotes/origin/HEAD", NULL};
    if (ss_git(oh_argv, base_ref, sizeof base_ref) != 0 || !base_ref[0])
    {
       const char *const h_argv[] = {"git", "-C", git_root, "symbolic-ref", "--short", "HEAD", NULL};
@@ -264,25 +267,34 @@ static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
        * git creates intermediate dirs. Let git's exit status be authoritative. */
       const char *const prune_argv[] = {"git", "-C", git_root, "worktree", "prune", NULL};
       (void)ss_git(prune_argv, NULL, 0);
-      const char *const add_argv[] = {"git", "-C",     git_root, "worktree", "add", wt,
-                                      "-b",  branch, base_ref, NULL};
+      const char *const add_argv[] = {"git", "-C", git_root, "worktree", "add",
+                                      wt,    "-b", branch,   base_ref,   NULL};
       (void)ss_git(add_argv, NULL, 0);
    }
    if (stat(wt, &st) != 0 || !S_ISDIR(st.st_mode))
       return; /* creation failed -> don't point the agent at a path that isn't there */
 
    ss_add(ctx, "\n# Isolated Checkout (REQUIRED before editing)\n");
-   ss_add(ctx,
-          "This session runs against a remote aimee-server, and session-worktree isolation "
-          "(`require_session_worktree`) is ON. You are NOT in a managed worktree, so every "
-          "edit/write/mutating shell command WILL be blocked until you enter one. An isolated "
-          "worktree has been prepared for you:\n\n  ");
+   ss_add(ctx, "This session runs against a remote aimee-server, and session-worktree isolation "
+               "(`require_session_worktree`) is ON. You are NOT in a managed worktree, so every "
+               "edit/write/mutating shell command WILL be blocked until you enter one. An isolated "
+               "worktree has been prepared for you:\n\n  ");
    ss_add(ctx, wt);
    ss_add(ctx,
           "\n\nBefore your first mutating tool call, switch into it — Claude Code: call "
           "`EnterWorktree` with that path; or `cd` into it for shell work. Do not edit the shared "
           "checkout.\n\n");
 }
+#else  /* _WIN32 */
+/* Session-worktree isolation (require_session_worktree) and the .aimee/worktrees
+ * layout are a POSIX/Linux-server feature; the Windows build ships only the thin
+ * client, and preparing a worktree needs POSIX process primitives. No-op there. */
+static void ss_append_worktree_isolation(struct ss_sbuf *ctx, const char *sid)
+{
+   (void)ctx;
+   (void)sid;
+}
+#endif /* _WIN32 */
 
 static int handle_session_start_remote(const char *sid)
 {

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -7,6 +7,7 @@
 #include "cli_session_start.h"
 #include "cJSON.h"
 #include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -157,9 +158,27 @@ static int ss_git(const char *const argv[], char *out, size_t cap)
    close(pfd[1]);
    char buf[4096];
    size_t got = 0;
-   ssize_t r;
-   while (got < sizeof buf - 1 && (r = read(pfd[0], buf + got, sizeof buf - 1 - got)) > 0)
-      got += (size_t)r;
+   /* Read the first bufful; keep draining any excess into scratch so a chatty git
+    * never gets SIGPIPE (which would look like a failure). Retry on EINTR so a
+    * signal cannot truncate a capture that then reports exit 0. */
+   for (;;)
+   {
+      char scratch[4096];
+      int have_room = got < sizeof buf - 1;
+      char *dst = have_room ? buf + got : scratch;
+      size_t room = have_room ? sizeof buf - 1 - got : sizeof scratch;
+      ssize_t r = read(pfd[0], dst, room);
+      if (r < 0)
+      {
+         if (errno == EINTR)
+            continue;
+         break;
+      }
+      if (r == 0)
+         break;
+      if (have_room)
+         got += (size_t)r;
+   }
    buf[got] = '\0';
    close(pfd[0]);
    int status = 0;

--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -244,8 +244,7 @@ static char *build_session_context(const char *client_cwd)
    /* Principles and Aimee lookup hints lead the session context for primacy
     * bias, driven by the active persona. */
    ctx_appendf(buf, cap, &pos, "%s",
-                           persona.principles_text ? persona.principles_text
-                                                   : prompt_principles_text(mode));
+               persona.principles_text ? persona.principles_text : prompt_principles_text(mode));
 
    /* Inject the active persona's own prose at the start of every primary session
     * — uniformly, for every persona. Engineer is not special here: it is simply
@@ -265,20 +264,19 @@ static char *build_session_context(const char *client_cwd)
 
    if (persona.brief_text)
       ctx_appendf(buf, cap, &pos,
-                              "# Aimee Context\n%s"
-                              "- Use `aimee session brief` to inspect the full startup brief.\n\n",
-                              persona.brief_text);
+                  "# Aimee Context\n%s"
+                  "- Use `aimee session brief` to inspect the full startup brief.\n\n",
+                  persona.brief_text);
    else
-      ctx_appendf(
-          buf, cap, &pos,
-          "# Aimee Context\n"
-          "- Use `aimee index overview` or `aimee index find <symbol>` for indexed code "
-          "lookup when it helps.\n"
-          "- Use `aimee memory search <terms>` for prior project context before "
-          "rediscovery.\n"
-          "- Use `aimee delegate <role> \"prompt\"` for bounded delegated or parallel "
-          "work.\n"
-          "- Use `aimee session brief` to inspect the full startup brief.\n\n");
+      ctx_appendf(buf, cap, &pos,
+                  "# Aimee Context\n"
+                  "- Use `aimee index overview` or `aimee index find <symbol>` for indexed code "
+                  "lookup when it helps.\n"
+                  "- Use `aimee memory search <terms>` for prior project context before "
+                  "rediscovery.\n"
+                  "- Use `aimee delegate <role> \"prompt\"` for bounded delegated or parallel "
+                  "work.\n"
+                  "- Use `aimee session brief` to inspect the full startup brief.\n\n");
 
    /* Enforce aimee's memory system as the single memory of record: steer the
     * agent to aimee memory commands rather than a native store. `.md` memory is
@@ -374,8 +372,7 @@ static char *build_session_context(const char *client_cwd)
             ctx_appendf(buf, cap, &pos, "# Key Facts\n");
             has_facts = 1;
          }
-         ctx_appendf(buf, cap, &pos, "- %s: %.300s\n", facts[i].key,
-                                 facts[i].content);
+         ctx_appendf(buf, cap, &pos, "- %s: %.300s\n", facts[i].key, facts[i].content);
       }
       if (has_facts)
          ctx_appendf(buf, cap, &pos, "\n");
@@ -423,8 +420,8 @@ static char *build_session_context(const char *client_cwd)
             ctx_appendf(buf, cap, &pos, "Hosts (%d): ", nw->host_count);
             int show = nw->host_count < 5 ? nw->host_count : 5;
             for (int i = 0; i < show && pos < cap - 128; i++)
-               ctx_appendf(buf, cap, &pos, "%s%s (%s)", i > 0 ? ", " : "",
-                                       nw->hosts[i].name, nw->hosts[i].ip);
+               ctx_appendf(buf, cap, &pos, "%s%s (%s)", i > 0 ? ", " : "", nw->hosts[i].name,
+                           nw->hosts[i].ip);
             if (nw->host_count > show)
                ctx_appendf(buf, cap, &pos, " +%d more", nw->host_count - show);
             ctx_appendf(buf, cap, &pos, "\n");
@@ -436,8 +433,8 @@ static char *build_session_context(const char *client_cwd)
                            nw->networks[i].cidr, nw->networks[i].desc);
          }
          ctx_appendf(buf, cap, &pos,
-                                 "Run `aimee agent network` or `aimee --json agent network` "
-                                 "for full host details.\n\n");
+                     "Run `aimee agent network` or `aimee --json agent network` "
+                     "for full host details.\n\n");
       }
    }
 
@@ -484,15 +481,13 @@ static char *build_session_context(const char *client_cwd)
                {
                   if (!has_section)
                   {
-                     ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n",
-                                             project_name);
+                     ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n", project_name);
                      has_section = 1;
                   }
                   const char *text =
                       like_rows[i].content[0] ? like_rows[i].content : like_rows[i].key;
                   if (like_rows[i].kind[0])
-                     ctx_appendf(buf, cap, &pos, "- [%s] %.300s\n",
-                                             like_rows[i].kind, text);
+                     ctx_appendf(buf, cap, &pos, "- [%s] %.300s\n", like_rows[i].kind, text);
                   else
                      ctx_appendf(buf, cap, &pos, "- %.300s\n", text);
                }
@@ -507,12 +502,11 @@ static char *build_session_context(const char *client_cwd)
             {
                if (!has_section)
                {
-                  ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n",
-                                          project_name);
+                  ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n", project_name);
                   has_section = 1;
                }
-               ctx_appendf(buf, cap, &pos, "- %d files indexed, %d definitions\n",
-                                       file_count, def_count);
+               ctx_appendf(buf, cap, &pos, "- %d files indexed, %d definitions\n", file_count,
+                           def_count);
             }
 
             if (has_section)
@@ -586,8 +580,8 @@ static char *build_session_context(const char *client_cwd)
             ctx_appendf(buf, cap, &pos, "- [%s] via %s: OK (%d turns, %d tools)\n", drole, dagent,
                         rows[i].turns, rows[i].tool_calls);
          else
-            ctx_appendf(buf, cap, &pos, "- [%s] via %s: FAILED (%.80s)\n", drole,
-                                    dagent, rows[i].error[0] ? rows[i].error : "unknown");
+            ctx_appendf(buf, cap, &pos, "- [%s] via %s: FAILED (%.80s)\n", drole, dagent,
+                        rows[i].error[0] ? rows[i].error : "unknown");
       }
       if (n > 0 && pos < cap - 256)
          ctx_appendf(buf, cap, &pos, "\n");

--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -34,6 +34,30 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdarg.h>
+
+/* Bounded formatted append into buf[cap] at *pos. Advances *pos only when the
+ * whole formatted string fits; on truncation or a formatting error it restores
+ * the prior NUL terminator and leaves *pos unchanged. A no-op once the buffer is
+ * full. This keeps *pos <= cap for every caller, so a later append can never
+ * compute an out-of-bounds `buf + *pos` or an underflowed `cap - *pos`. Returns
+ * 1 if the whole string was written, 0 otherwise. */
+static int ctx_appendf(char *buf, size_t cap, size_t *pos, const char *fmt, ...)
+{
+   if (*pos >= cap)
+      return 0;
+   va_list ap;
+   va_start(ap, fmt);
+   int n = vsnprintf(buf + *pos, cap - *pos, fmt, ap);
+   va_end(ap);
+   if (n < 0 || (size_t)n >= cap - *pos)
+   {
+      buf[*pos] = '\0';
+      return 0;
+   }
+   *pos += (size_t)n;
+   return 1;
+}
 
 /* --- cmd_session_start --- */
 
@@ -150,20 +174,20 @@ static size_t session_append_scope_section(const memory_t *rows, int n_rows, cha
 
    qsort(items, (size_t)item_count, sizeof(items[0]), session_scope_item_cmp);
 
-   pos += (size_t)snprintf(buf + pos, cap - pos, "%s\n", header);
+   ctx_appendf(buf, cap, &pos, "%s\n", header);
    int emitted = 0;
    for (int i = 0; i < item_count && emitted < limit && pos < cap - 512; i++)
    {
       const char *text = items[i].content[0] ? items[i].content : items[i].key;
       if (items[i].kind[0])
-         pos += (size_t)snprintf(buf + pos, cap - pos, "- [%s] %.300s\n", items[i].kind, text);
+         ctx_appendf(buf, cap, &pos, "- [%s] %.300s\n", items[i].kind, text);
       else
-         pos += (size_t)snprintf(buf + pos, cap - pos, "- %.300s\n", text);
+         ctx_appendf(buf, cap, &pos, "- %.300s\n", text);
       emitted++;
    }
 
    if (emitted > 0)
-      pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+      ctx_appendf(buf, cap, &pos, "\n");
    return pos;
 }
 
@@ -189,7 +213,7 @@ static int session_context_verbose_enabled(void)
 
 static char *build_session_context(const char *client_cwd)
 {
-   size_t cap = 32768;
+   size_t cap = 65536;
    char *buf = malloc(cap);
    size_t pos = 0;
    char scope_cwd[MAX_PATH_LEN];
@@ -219,17 +243,34 @@ static char *build_session_context(const char *client_cwd)
 
    /* Principles and Aimee lookup hints lead the session context for primacy
     * bias, driven by the active persona. */
-   pos += (size_t)snprintf(buf + pos, cap - pos, "%s",
+   ctx_appendf(buf, cap, &pos, "%s",
                            persona.principles_text ? persona.principles_text
                                                    : prompt_principles_text(mode));
+
+   /* Inject the active persona's own prose at the start of every primary session
+    * — uniformly, for every persona. Engineer is not special here: it is simply
+    * the default persona, and its prose carries the manager/work-queue framing
+    * because it is the orchestrator persona. Whichever persona resolved above,
+    * its "You are ..." identity and role lead the context so the session adopts
+    * it. Delegates never receive this block — they compose their prompt via
+    * persona_compose_delegate_prompt, which omits the engineer manager framing.
+    * Bounded append: pos is advanced only if the block fully fits, so a
+    * truncating render can never push pos past cap and corrupt later appends. */
+   {
+      char *identity = persona_identity_prose(&persona, scope_cwd);
+      if (identity && identity[0])
+         ctx_appendf(buf, cap, &pos, "\n# Persona\n%s\n", identity);
+      free(identity);
+   }
+
    if (persona.brief_text)
-      pos += (size_t)snprintf(buf + pos, cap - pos,
+      ctx_appendf(buf, cap, &pos,
                               "# Aimee Context\n%s"
                               "- Use `aimee session brief` to inspect the full startup brief.\n\n",
                               persona.brief_text);
    else
-      pos += (size_t)snprintf(
-          buf + pos, cap - pos,
+      ctx_appendf(
+          buf, cap, &pos,
           "# Aimee Context\n"
           "- Use `aimee index overview` or `aimee index find <symbol>` for indexed code "
           "lookup when it helps.\n"
@@ -243,8 +284,8 @@ static char *build_session_context(const char *client_cwd)
     * agent to aimee memory commands rather than a native store. `.md` memory is
     * retired — a write under the memory dir is intercepted into aimee and never
     * persisted as a file. */
-   pos += (size_t)snprintf(
-       buf + pos, cap - pos,
+   ctx_appendf(
+       buf, cap, &pos,
        "# Memory (use aimee, not your own store)\n"
        "- aimee is the single memory of record. Store durable memory with "
        "`aimee memory store <key> <content>`; set who-you-are / preferences with "
@@ -253,7 +294,7 @@ static char *build_session_context(const char *client_cwd)
        "- Memory `.md` files are RETIRED: a `.md` write UNDER YOUR MEMORY DIR is intercepted "
        "into aimee and not persisted as a file. Writing `.md` files elsewhere (docs, READMEs, "
        "notes) is unaffected — only the memory dir is intercepted.\n");
-   pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+   ctx_appendf(buf, cap, &pos, "\n");
 
    {
       char cwd[MAX_PATH_LEN];
@@ -278,7 +319,7 @@ static char *build_session_context(const char *client_cwd)
       free(skill_index);
    }
 
-   pos += (size_t)snprintf(buf + pos, cap - pos, "# Rules\n\n");
+   ctx_appendf(buf, cap, &pos, "# Rules\n\n");
 
    /* Aimee rules (from feedback/learning) */
 
@@ -292,7 +333,7 @@ static char *build_session_context(const char *client_cwd)
       while (*body == '\n')
          body++;
       if (*body)
-         pos += (size_t)snprintf(buf + pos, cap - pos, "%s\n", body);
+         ctx_appendf(buf, cap, &pos, "%s\n", body);
    }
    free(rules);
 
@@ -312,7 +353,7 @@ static char *build_session_context(const char *client_cwd)
             {
                if (pos + disc.bytes_used + 2 < cap)
                {
-                  pos += (size_t)snprintf(buf + pos, cap - pos, "%s\n", disc.rendered);
+                  ctx_appendf(buf, cap, &pos, "%s\n", disc.rendered);
                }
             }
             context_discovery_free(&disc);
@@ -330,14 +371,14 @@ static char *build_session_context(const char *client_cwd)
       {
          if (!has_facts)
          {
-            pos += (size_t)snprintf(buf + pos, cap - pos, "# Key Facts\n");
+            ctx_appendf(buf, cap, &pos, "# Key Facts\n");
             has_facts = 1;
          }
-         pos += (size_t)snprintf(buf + pos, cap - pos, "- %s: %.300s\n", facts[i].key,
+         ctx_appendf(buf, cap, &pos, "- %s: %.300s\n", facts[i].key,
                                  facts[i].content);
       }
       if (has_facts)
-         pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+         ctx_appendf(buf, cap, &pos, "\n");
    }
 
    /* Open commitments + unresolved directives — phase-2-step-2 recall.
@@ -376,26 +417,25 @@ static char *build_session_context(const char *client_cwd)
       if (agent_load_config(&net_cfg) == 0 && net_cfg.network.ssh_entry[0])
       {
          agent_network_t *nw = &net_cfg.network;
-         pos += (size_t)snprintf(buf + pos, cap - pos, "# Network\nEntry: %s\n", nw->ssh_entry);
+         ctx_appendf(buf, cap, &pos, "# Network\nEntry: %s\n", nw->ssh_entry);
          if (nw->host_count > 0)
          {
-            pos += (size_t)snprintf(buf + pos, cap - pos, "Hosts (%d): ", nw->host_count);
+            ctx_appendf(buf, cap, &pos, "Hosts (%d): ", nw->host_count);
             int show = nw->host_count < 5 ? nw->host_count : 5;
             for (int i = 0; i < show && pos < cap - 128; i++)
-               pos += (size_t)snprintf(buf + pos, cap - pos, "%s%s (%s)", i > 0 ? ", " : "",
+               ctx_appendf(buf, cap, &pos, "%s%s (%s)", i > 0 ? ", " : "",
                                        nw->hosts[i].name, nw->hosts[i].ip);
             if (nw->host_count > show)
-               pos += (size_t)snprintf(buf + pos, cap - pos, " +%d more", nw->host_count - show);
-            pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+               ctx_appendf(buf, cap, &pos, " +%d more", nw->host_count - show);
+            ctx_appendf(buf, cap, &pos, "\n");
          }
          if (nw->network_count > 0)
          {
             for (int i = 0; i < nw->network_count && pos < cap - 128; i++)
-               pos +=
-                   (size_t)snprintf(buf + pos, cap - pos, "- %s: %s (%s)\n", nw->networks[i].name,
-                                    nw->networks[i].cidr, nw->networks[i].desc);
+               ctx_appendf(buf, cap, &pos, "- %s: %s (%s)\n", nw->networks[i].name,
+                           nw->networks[i].cidr, nw->networks[i].desc);
          }
-         pos += (size_t)snprintf(buf + pos, cap - pos,
+         ctx_appendf(buf, cap, &pos,
                                  "Run `aimee agent network` or `aimee --json agent network` "
                                  "for full host details.\n\n");
       }
@@ -444,17 +484,17 @@ static char *build_session_context(const char *client_cwd)
                {
                   if (!has_section)
                   {
-                     pos += (size_t)snprintf(buf + pos, cap - pos, "# Project Context (%s)\n",
+                     ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n",
                                              project_name);
                      has_section = 1;
                   }
                   const char *text =
                       like_rows[i].content[0] ? like_rows[i].content : like_rows[i].key;
                   if (like_rows[i].kind[0])
-                     pos += (size_t)snprintf(buf + pos, cap - pos, "- [%s] %.300s\n",
+                     ctx_appendf(buf, cap, &pos, "- [%s] %.300s\n",
                                              like_rows[i].kind, text);
                   else
-                     pos += (size_t)snprintf(buf + pos, cap - pos, "- %.300s\n", text);
+                     ctx_appendf(buf, cap, &pos, "- %.300s\n", text);
                }
             }
 
@@ -467,16 +507,16 @@ static char *build_session_context(const char *client_cwd)
             {
                if (!has_section)
                {
-                  pos += (size_t)snprintf(buf + pos, cap - pos, "# Project Context (%s)\n",
+                  ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n",
                                           project_name);
                   has_section = 1;
                }
-               pos += (size_t)snprintf(buf + pos, cap - pos, "- %d files indexed, %d definitions\n",
+               ctx_appendf(buf, cap, &pos, "- %d files indexed, %d definitions\n",
                                        file_count, def_count);
             }
 
             if (has_section)
-               pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+               ctx_appendf(buf, cap, &pos, "\n");
          }
       }
    }
@@ -526,7 +566,7 @@ static char *build_session_context(const char *client_cwd)
          {
             char delblock[1024];
             persona_delegation_block(&persona, delblock, sizeof(delblock));
-            pos += (size_t)snprintf(buf + pos, cap - pos, "%s", delblock);
+            ctx_appendf(buf, cap, &pos, "%s", delblock);
          }
       }
    }
@@ -537,21 +577,20 @@ static char *build_session_context(const char *client_cwd)
       db1_agent_log_display_t rows[5];
       int n = db1_agent_log_list_recent(rows, 5);
       if (n > 0 && pos < cap - 256)
-         pos += (size_t)snprintf(buf + pos, cap - pos, "# Recent Delegations\n");
+         ctx_appendf(buf, cap, &pos, "# Recent Delegations\n");
       for (int i = 0; i < n && pos < cap - 256; i++)
       {
          const char *drole = rows[i].role[0] ? rows[i].role : "?";
          const char *dagent = rows[i].agent_name[0] ? rows[i].agent_name : "?";
          if (rows[i].success)
-            pos +=
-                (size_t)snprintf(buf + pos, cap - pos, "- [%s] via %s: OK (%d turns, %d tools)\n",
-                                 drole, dagent, rows[i].turns, rows[i].tool_calls);
+            ctx_appendf(buf, cap, &pos, "- [%s] via %s: OK (%d turns, %d tools)\n", drole, dagent,
+                        rows[i].turns, rows[i].tool_calls);
          else
-            pos += (size_t)snprintf(buf + pos, cap - pos, "- [%s] via %s: FAILED (%.80s)\n", drole,
+            ctx_appendf(buf, cap, &pos, "- [%s] via %s: FAILED (%.80s)\n", drole,
                                     dagent, rows[i].error[0] ? rows[i].error : "unknown");
       }
       if (n > 0 && pos < cap - 256)
-         pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+         ctx_appendf(buf, cap, &pos, "\n");
    }
 
    /* Workspace project descriptions and style guides */

--- a/src/config_trigger.c
+++ b/src/config_trigger.c
@@ -7,12 +7,17 @@
  *   max_concurrent: 2
  *
  * trigger_rules:
- *   - source: "github-webhook"
+ *   - source: "github-webhook"   # valid sources include github-webhook, cron, proposals
  *     event: "push"
  *     pipeline:
  *       template: "ci"
  *       workspace: "/ws/myproject"
  *       max_spend_usd: 0.50
+ *
+ * source: "proposals" reuses existing fields: workspace is the absolute git
+ * repo to scan, pipeline.template is the workflow name, event is the
+ * repo-relative proposal dir (default docs/proposals/pending), and schedule is
+ * the git ref/branch (default auto-detect).
  */
 
 #include "aimee.h"

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -73,4 +73,10 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
  * There is no env-var bypass; disabling it is an operator config action. */
 int handle_attention_guard(void);
 
+/* Authoritative "is session-worktree isolation required?" check (default ON
+ * unless aimee.yaml sets `require_session_worktree: false`). Exposed so the
+ * remote/thin session-start path can gate its worktree-prep directive on the
+ * same answer the guard uses to block. */
+int attn_require_session_worktree(void);
+
 #endif /* DEC_CLI_ATTENTION_GUARD_H */

--- a/src/headers/persona.h
+++ b/src/headers/persona.h
@@ -82,6 +82,15 @@ extern "C"
    char *persona_compose_delegate_prompt(const char *name, const char *cwd,
                                          const char *base_prompt);
 
+   /* Render a persona's own prose (the "You are ..." body, role, workflow, and
+    * any work queue), with the first %s replaced by `cwd`, for injection at the
+    * start of a primary session — uniformly for every persona. Heap-owned
+    * (caller frees) or NULL if the persona has none. Built-ins use their
+    * canonical code prose (prompts.c); custom personas use their file
+    * `## Persona` body. Never used for delegate prompts (see
+    * persona_compose_delegate_prompt). */
+   char *persona_identity_prose(const persona_t *p, const char *cwd);
+
    /* Resolve persona `name`. Lookup: project file -> user file -> built-in.
     * Unknown name with no file falls back to the engineer built-in and still
     * returns 0 (callers always get a usable persona). Fills *out; heap fields

--- a/src/persona.c
+++ b/src/persona.c
@@ -460,6 +460,25 @@ static char *persona_apply_cwd(const char *text, const char *cwd)
    return out;
 }
 
+char *persona_identity_prose(const persona_t *p, const char *cwd)
+{
+   if (!p)
+      return NULL;
+   /* Return the persona's COMPLETE identity prose. Built-ins keep their full
+    * block in code (prompts.c) — a built-in's file `## Persona` may be only a
+    * thin one-liner, with the rest of the framing in sibling sections that
+    * load_file does not extract — so a built-in uses its enum prose; a custom
+    * persona uses its file `## Persona` body. */
+   if (p->builtin)
+   {
+      const char *prose = prompt_persona_text(aimee_mode_from_string(p->name));
+      return (prose && prose[0]) ? persona_apply_cwd(prose, cwd) : NULL;
+   }
+   if (p->persona_text && p->persona_text[0])
+      return persona_apply_cwd(p->persona_text, cwd);
+   return NULL;
+}
+
 char *persona_compose_delegate_prompt(const char *name, const char *cwd, const char *base_prompt)
 {
    const char *base = base_prompt ? base_prompt : "";

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -380,37 +380,57 @@ static void trigger_resolve_ref(const char *workspace, const char *schedule, cha
    snprintf(out, n, "%s", "HEAD");
 }
 
+/* Create <home>/triggers/proposals (mode 0700). `home` must be a non-empty
+ * absolute path the caller already validated -- there is deliberately NO /tmp
+ * fallback (a predictable world-writable path is a symlink-clobber vector).
+ * mkdir returning EEXIST is fine; any other error propagates. */
 static int trigger_mkdir_parents(const char *home)
 {
+   if (!home || !home[0])
+      return -1;
    char dir[1024];
-   if (snprintf(dir, sizeof(dir), "%s/triggers", home ? home : "/tmp") >= (int)sizeof(dir))
+   if (snprintf(dir, sizeof(dir), "%s/triggers", home) >= (int)sizeof(dir))
       return -1;
-   mkdir(dir, 0700);
-   if (snprintf(dir, sizeof(dir), "%s/triggers/proposals", home ? home : "/tmp") >=
-       (int)sizeof(dir))
+   if (mkdir(dir, 0700) != 0 && errno != EEXIST)
       return -1;
-   mkdir(dir, 0700);
+   if (snprintf(dir, sizeof(dir), "%s/triggers/proposals", home) >= (int)sizeof(dir))
+      return -1;
+   if (mkdir(dir, 0700) != 0 && errno != EEXIST)
+      return -1;
    return 0;
 }
 
+/* Atomically write `bytes` to `path`. Uses mkstemp (O_EXCL|O_CREAT, mode 0600, a
+ * fresh unique name) so a pre-planted symlink/file at a predictable temp path
+ * cannot be followed/clobbered, then rename() onto the final path. */
 static int trigger_write_atomic(const char *path, const char *bytes)
 {
-   char tmp[1200];
-   if (snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= (int)sizeof(tmp))
+   char tmp[1300];
+   if (snprintf(tmp, sizeof(tmp), "%s.XXXXXX", path) >= (int)sizeof(tmp))
       return -1;
-   FILE *f = fopen(tmp, "wb");
-   if (!f)
+   int fd = mkstemp(tmp);
+   if (fd < 0)
       return -1;
+
+   const char *p = bytes ? bytes : "";
    size_t len = bytes ? strlen(bytes) : 0;
-   int ok = fwrite(bytes ? bytes : "", 1, len, f) == len;
-   if (fclose(f) != 0)
-      ok = 0;
-   if (!ok)
+   int ok = 1;
+   while (len > 0)
    {
-      unlink(tmp);
-      return -1;
+      ssize_t w = write(fd, p, len);
+      if (w < 0)
+      {
+         if (errno == EINTR)
+            continue;
+         ok = 0;
+         break;
+      }
+      p += w;
+      len -= (size_t)w;
    }
-   if (rename(tmp, path) != 0)
+   if (close(fd) != 0)
+      ok = 0;
+   if (!ok || rename(tmp, path) != 0)
    {
       unlink(tmp);
       return -1;
@@ -475,14 +495,24 @@ static void scan_proposals(const trigger_rule_t *rule)
                 PROPOSALS_MAX_ENTRIES, rule->workspace, scandir);
 
    const char *home = aimee_home();
-   if (trigger_mkdir_parents(home) != 0)
+   if (!home || !home[0])
+   {
+      aimee_log(LOG_WARN, "trigger.sched",
+                "proposals: no resolvable AIMEE_HOME; refusing to materialize under /tmp");
       return;
+   }
+   if (trigger_mkdir_parents(home) != 0)
+   {
+      aimee_log(LOG_WARN, "trigger.sched", "proposals: could not create %s/triggers/proposals: %s",
+                home, strerror(errno));
+      return;
+   }
 
    for (int i = 0; i < n; i++)
    {
       char proposal_path[1200];
-      if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md",
-                   home ? home : "/tmp", entries[i].sha) >= (int)sizeof(proposal_path))
+      if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md", home,
+                   entries[i].sha) >= (int)sizeof(proposal_path))
          continue;
 
       char existing[80];

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -424,8 +424,24 @@ static void scan_proposals(const trigger_rule_t *rule)
       return;
 
    const char *scanpath = rule->event[0] ? rule->event : PROPOSALS_DEFAULT_DIR;
+   /* Reject an absolute or traversing scan dir: `event` is repo-relative and must
+    * not be able to point git at a tree outside the workspace. */
+   if (scanpath[0] == '/' || strstr(scanpath, ".."))
+   {
+      aimee_log(LOG_WARN, "trigger.sched", "proposals scan dir rejected (absolute/traversal): %s",
+                scanpath);
+      return;
+   }
+
    char ref[256];
    trigger_resolve_ref(rule->workspace, rule->schedule, ref, sizeof(ref));
+   /* A ref beginning with '-' would be parsed by `git ls-tree` as an option (the
+    * `--` separator only protects args after it, not the tree-ish before it). */
+   if (ref[0] == '-')
+   {
+      aimee_log(LOG_WARN, "trigger.sched", "proposals ref rejected (leading '-'): %s", ref);
+      return;
+   }
 
    /* git ls-tree on a bare directory pathspec lists only that directory's own
     * tree entry, not the blobs inside it -- the parser (blobs only) would then
@@ -452,6 +468,11 @@ static void scan_proposals(const trigger_rule_t *rule)
    trigger_ls_tree_entry_t entries[PROPOSALS_MAX_ENTRIES];
    int n = trigger_parse_ls_tree(out ? out : "", entries, PROPOSALS_MAX_ENTRIES);
    free(out);
+   if (n == PROPOSALS_MAX_ENTRIES)
+      aimee_log(LOG_WARN, "trigger.sched",
+                "proposals scan hit the %d-entry cap for repo=%s dir=%s; extra proposals not "
+                "processed this pass",
+                PROPOSALS_MAX_ENTRIES, rule->workspace, scandir);
 
    const char *home = aimee_home();
    if (trigger_mkdir_parents(home) != 0)

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -13,21 +13,31 @@
 #include "db1/db1_cron_jobs.h"
 #include "db1/db1_trigger.h"
 #include "db1/pipelines.h"
+#include "db1/wfe_store.h"
+#include "aimee_home.h"
 #include "log.h"
 #include "platform_random.h"
 #include "skill_curator.h"
 #include "trigger_scheduler.h"
+#include "util.h"
+#include "wfe_engine.h"
 
 #include <pthread.h>
 #include <ctype.h>
+#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
 #define CRON_CONTEXT_OUTPUT_LIMIT 8192
+#define PROPOSALS_DEFAULT_DIR     "docs/proposals/pending"
+#define PROPOSALS_MAX_ENTRIES     512
+#define PROPOSALS_GIT_MAX_OUT     (256 * 1024)
+#define PROPOSALS_GIT_TIMEOUT_MS  15000
 
 /* ------------------------------------------------------------------ */
 /* Cron expression parser                                              */
@@ -226,6 +236,268 @@ static int schedule_matches(const char *expr, const struct tm *tm)
    if (r != -1)
       return r;
    return cron_matches(expr, tm);
+}
+
+/* ------------------------------------------------------------------ */
+/* Proposals trigger source                                             */
+/* ------------------------------------------------------------------ */
+
+/* source="proposals" overloads trigger_rule_t without adding fields:
+ * workspace = absolute repo path (required), pipeline_template = workflow name
+ * (required), event = repo-relative proposal dir (default docs/proposals/pending),
+ * schedule = git ref/branch (default auto-detected origin HEAD, then HEAD). */
+typedef struct
+{
+   char sha[41];
+   char name[512];
+} trigger_ls_tree_entry_t;
+
+static int trigger_is_hex_sha(const char *s)
+{
+   if (!s)
+      return 0;
+   for (int i = 0; i < 40; i++)
+      if (!isxdigit((unsigned char)s[i]))
+         return 0;
+   return s[40] == '\0';
+}
+
+static int trigger_has_md_suffix(const char *s)
+{
+   size_t n = s ? strlen(s) : 0;
+   return n >= 3 && strcmp(s + n - 3, ".md") == 0;
+}
+
+static int trigger_parse_ls_tree(const char *out, trigger_ls_tree_entry_t *entries, int max)
+{
+   if (!out || !entries || max <= 0)
+      return 0;
+
+   int count = 0;
+   const char *p = out;
+   while (*p)
+   {
+      const char *line = p;
+      const char *nl = strchr(p, '\n');
+      size_t len = nl ? (size_t)(nl - line) : strlen(line);
+      p = nl ? nl + 1 : line + len;
+
+      if (len == 0)
+         continue;
+      const char *end = line + len;
+      const char *sp1 = memchr(line, ' ', len);
+      if (!sp1)
+         continue;
+      const char *sp2 = memchr(sp1 + 1, ' ', (size_t)(end - sp1 - 1));
+      if (!sp2)
+         continue;
+      const char *tab = memchr(sp2 + 1, '\t', (size_t)(end - sp2 - 1));
+      if (!tab)
+         continue;
+      if ((size_t)(sp2 - sp1 - 1) != 4 || strncmp(sp1 + 1, "blob", 4) != 0)
+         continue;
+      if ((size_t)(tab - sp2 - 1) != 40)
+         continue;
+
+      char sha[41];
+      memcpy(sha, sp2 + 1, 40);
+      sha[40] = '\0';
+      if (!trigger_is_hex_sha(sha))
+         continue;
+
+      size_t name_len = (size_t)(end - tab - 1);
+      if (name_len == 0 || name_len >= sizeof(entries[0].name))
+         continue;
+      char name[512];
+      memcpy(name, tab + 1, name_len);
+      name[name_len] = '\0';
+      if (!trigger_has_md_suffix(name))
+         continue;
+
+      if (count >= max)
+         break;
+      memcpy(entries[count].sha, sha, sizeof(entries[count].sha));
+      memcpy(entries[count].name, name, name_len + 1);
+      count++;
+   }
+   return count;
+}
+
+extern char **environ;
+
+static int trigger_git_capture(const char *const argv[], const char *cwd, char **out)
+{
+   *out = NULL;
+   return safe_exec_capture_cwd_env_timeout(argv, cwd, environ, out, PROPOSALS_GIT_MAX_OUT,
+                                            PROPOSALS_GIT_TIMEOUT_MS);
+}
+
+static void trigger_trim_line(char *s)
+{
+   if (!s)
+      return;
+   size_t n = strlen(s);
+   while (n > 0 && (s[n - 1] == '\n' || s[n - 1] == '\r' || s[n - 1] == ' ' || s[n - 1] == '\t'))
+      s[--n] = '\0';
+}
+
+static void trigger_resolve_ref(const char *workspace, const char *schedule, char *out, size_t n)
+{
+   if (schedule && schedule[0])
+   {
+      snprintf(out, n, "%s", schedule);
+      return;
+   }
+
+   const char *const origin_head[] = {"git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD",
+                                      NULL};
+   char *buf = NULL;
+   if (trigger_git_capture(origin_head, workspace, &buf) == 0 && buf && buf[0])
+   {
+      trigger_trim_line(buf);
+      if (buf[0])
+      {
+         snprintf(out, n, "%s", buf);
+         free(buf);
+         return;
+      }
+   }
+   free(buf);
+
+   const char *const head[] = {"git", "symbolic-ref", "--short", "HEAD", NULL};
+   buf = NULL;
+   if (trigger_git_capture(head, workspace, &buf) == 0 && buf && buf[0])
+   {
+      trigger_trim_line(buf);
+      if (buf[0])
+      {
+         snprintf(out, n, "%s", buf);
+         free(buf);
+         return;
+      }
+   }
+   free(buf);
+   snprintf(out, n, "%s", "HEAD");
+}
+
+static int trigger_mkdir_parents(const char *home)
+{
+   char dir[1024];
+   if (snprintf(dir, sizeof(dir), "%s/triggers", home ? home : "/tmp") >= (int)sizeof(dir))
+      return -1;
+   mkdir(dir, 0700);
+   if (snprintf(dir, sizeof(dir), "%s/triggers/proposals", home ? home : "/tmp") >=
+       (int)sizeof(dir))
+      return -1;
+   mkdir(dir, 0700);
+   return 0;
+}
+
+static int trigger_write_atomic(const char *path, const char *bytes)
+{
+   char tmp[1200];
+   if (snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= (int)sizeof(tmp))
+      return -1;
+   FILE *f = fopen(tmp, "wb");
+   if (!f)
+      return -1;
+   size_t len = bytes ? strlen(bytes) : 0;
+   int ok = fwrite(bytes ? bytes : "", 1, len, f) == len;
+   if (fclose(f) != 0)
+      ok = 0;
+   if (!ok)
+   {
+      unlink(tmp);
+      return -1;
+   }
+   if (rename(tmp, path) != 0)
+   {
+      unlink(tmp);
+      return -1;
+   }
+   return 0;
+}
+
+static void scan_proposals(const trigger_rule_t *rule)
+{
+   if (!rule || !rule->workspace[0] || !rule->pipeline_template[0])
+      return;
+
+   const char *scanpath = rule->event[0] ? rule->event : PROPOSALS_DEFAULT_DIR;
+   char ref[256];
+   trigger_resolve_ref(rule->workspace, rule->schedule, ref, sizeof(ref));
+
+   /* git ls-tree on a bare directory pathspec lists only that directory's own
+    * tree entry, not the blobs inside it -- the parser (blobs only) would then
+    * find nothing. Normalize scanpath to exactly one trailing slash so ls-tree
+    * lists the directory's immediate contents (one level). Refuse on truncation. */
+   char scandir[TRIGGER_RULE_MAX_EVENT + 2];
+   size_t sl = strlen(scanpath);
+   while (sl > 0 && scanpath[sl - 1] == '/')
+      sl--;
+   if (snprintf(scandir, sizeof(scandir), "%.*s/", (int)sl, scanpath) >= (int)sizeof(scandir))
+      return;
+
+   const char *const ls_argv[] = {"git", "ls-tree", ref, "--", scandir, NULL};
+   char *out = NULL;
+   int rc = trigger_git_capture(ls_argv, rule->workspace, &out);
+   if (rc != 0)
+   {
+      aimee_log(LOG_WARN, "trigger.sched", "proposals ls-tree failed repo=%s ref=%s rc=%d",
+                rule->workspace, ref, rc);
+      free(out);
+      return;
+   }
+
+   trigger_ls_tree_entry_t entries[PROPOSALS_MAX_ENTRIES];
+   int n = trigger_parse_ls_tree(out ? out : "", entries, PROPOSALS_MAX_ENTRIES);
+   free(out);
+
+   const char *home = aimee_home();
+   if (trigger_mkdir_parents(home) != 0)
+      return;
+
+   for (int i = 0; i < n; i++)
+   {
+      char proposal_path[1200];
+      if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md",
+                   home ? home : "/tmp", entries[i].sha) >= (int)sizeof(proposal_path))
+         continue;
+
+      char existing[80];
+      if (db1_work_item_id_by_proposal(rule->workspace, proposal_path, existing,
+                                       sizeof(existing)) == 1)
+         continue;
+
+      const char *const cat_argv[] = {"git", "cat-file", "blob", entries[i].sha, NULL};
+      char *blob = NULL;
+      rc = trigger_git_capture(cat_argv, rule->workspace, &blob);
+      if (rc != 0)
+      {
+         aimee_log(LOG_WARN, "trigger.sched", "proposals cat-file failed repo=%s sha=%s rc=%d",
+                   rule->workspace, entries[i].sha, rc);
+         free(blob);
+         continue;
+      }
+      if (trigger_write_atomic(proposal_path, blob ? blob : "") != 0)
+      {
+         aimee_log(LOG_WARN, "trigger.sched", "proposals materialize failed path=%s: %s",
+                   proposal_path, strerror(errno));
+         free(blob);
+         continue;
+      }
+      free(blob);
+
+      char id[80] = "", err[256] = "";
+      rc = wfe_work_item_create(rule->pipeline_template, rule->workspace, proposal_path,
+                                "proposals", id, err, sizeof(err));
+      if (rc == 0 && id[0])
+         aimee_log(LOG_INFO, "trigger.sched", "filed proposal workflow=%s repo=%s sha=%s id=%s",
+                   rule->pipeline_template, rule->workspace, entries[i].sha, id);
+      else
+         aimee_log(LOG_WARN, "trigger.sched", "proposal create skipped/failed repo=%s sha=%s: %s",
+                   rule->workspace, entries[i].sha, err[0] ? err : "already exists");
+   }
 }
 
 /* ------------------------------------------------------------------ */
@@ -537,6 +809,15 @@ static void sched_tick(void)
    for (int i = 0; i < cfg.trigger_rule_count && i < TRIGGER_RULES_MAX; i++)
    {
       const trigger_rule_t *rule = &cfg.trigger_rules[i];
+
+      if (strcmp(rule->source, "proposals") == 0)
+      {
+         if (now - g_last_fired[i] < 55)
+            continue;
+         g_last_fired[i] = now;
+         scan_proposals(rule);
+         continue;
+      }
 
       if (strcmp(rule->source, "cron") != 0)
          continue;

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -9,7 +9,7 @@
 
 #include "log.h"
 #include "wfe_autonomy.h"
-#include "wfe_blocks.h" /* wfe_worktree_cleanup — orphan-sweep of terminal worktrees */
+#include "wfe_blocks.h" /* wfe_worktree_cleanup (terminal) + wfe_worktree_orphan_gc (age-based) */
 #include "wfe_store.h"
 
 #include <pthread.h>
@@ -65,6 +65,25 @@ void wfe_scheduler_run_once(void)
                    err[0] ? err : "error");
    }
    free(items);
+
+   /* Age-based orphan GC: reap wfe-worktrees dirs no live work item owns (a deleted
+    * row, or a crashed run that never reached terminal) once past a grace window,
+    * so a full git worktree can't be stranded — and its inodes leaked — forever.
+    * Complements the per-item terminal cleanup above, which only fires on a clean
+    * state transition. AIMEE_WFE_WORKTREE_GC_GRACE_SECS overrides the default. */
+   long grace = 3600;
+   const char *gv = getenv("AIMEE_WFE_WORKTREE_GC_GRACE_SECS");
+   if (gv && gv[0])
+   {
+      char *end = NULL;
+      long g = strtol(gv, &end, 10);
+      if (end && *end == '\0' && g >= 0)
+         grace = g;
+   }
+   const char *rl = getenv("AIMEE_WORKFLOW_REPO");
+   int reaped = wfe_worktree_orphan_gc((rl && rl[0]) ? rl : ".", grace);
+   if (reaped > 0)
+      aimee_log(LOG_INFO, "wfe-sched", "orphan-GC reaped %d stale worktree(s)", reaped);
 }
 
 static void *wfe_scheduler_loop(void *arg)

--- a/src/tests/test_persona.c
+++ b/src/tests/test_persona.c
@@ -93,6 +93,40 @@ int main(void)
       free(contrarian);
    }
 
+   /* --- primary-session persona prose is uniform per persona (engineer is not
+    * special): each persona's own prose, cwd-substituted; and the engineer
+    * manager framing never leaks into a delegate prompt. --- */
+   {
+      /* Engineer (the default persona) carries the manager/work-queue framing. */
+      persona_t eng;
+      assert(persona_load(NULL, "engineer", &eng) == 0);
+      char *eid = persona_identity_prose(&eng, "/tmp/session-cwd");
+      assert(eid);
+      assert(strstr(eid, "You are the MANAGER") != NULL); /* manager role */
+      assert(strstr(eid, "## Work Queue") != NULL);       /* work queue */
+      assert(strstr(eid, "/tmp/session-cwd") != NULL);    /* %s -> cwd */
+      assert(strstr(eid, "%s") == NULL);
+      free(eid);
+      persona_free(&eng);
+
+      /* Another built-in gets its OWN prose the same way — no engineer framing
+       * bleeds in, confirming there is no engineer special-case. */
+      persona_t arch;
+      assert(persona_load(NULL, "architect", &arch) == 0);
+      char *aid = persona_identity_prose(&arch, "/tmp/session-cwd");
+      assert(aid && aid[0]);
+      assert(strstr(aid, "You are the MANAGER") == NULL);
+      assert(strstr(aid, "## Work Queue") == NULL);
+      free(aid);
+      persona_free(&arch);
+
+      /* Primary-only: an engineer delegate prompt must never contain it. */
+      char *deleg = persona_compose_delegate_prompt("engineer", "/tmp/x", NULL);
+      assert(deleg);
+      assert(strstr(deleg, "You are the MANAGER") == NULL);
+      free(deleg);
+   }
+
    /* --- unknown name falls back to engineer --- */
    {
       persona_t p;

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -97,8 +97,8 @@ int db1_cron_jobs_load(cron_job_t *out, int max, int enabled_only)
 /* ------------------------------------------------------------------ */
 
 static char g_home[512] = "/tmp/aimee-test";
-static char g_symref_out[256]; /* canned `git symbolic-ref` stdout ("" -> rc!=0) */
-static char g_lstree_out[8192]; /* canned `git ls-tree` stdout */
+static char g_symref_out[256];      /* canned `git symbolic-ref` stdout ("" -> rc!=0) */
+static char g_lstree_out[8192];     /* canned `git ls-tree` stdout */
 static char g_lstree_ref[256];      /* captured ref arg passed to ls-tree */
 static char g_lstree_pathspec[512]; /* captured pathspec arg passed to ls-tree */
 static struct
@@ -215,7 +215,8 @@ int wfe_work_item_create(const char *workflow_name, const char *repo, const char
 {
    if (g_ncreated < (int)(sizeof g_created / sizeof g_created[0]))
    {
-      snprintf(g_created[g_ncreated].wf, sizeof g_created[0].wf, "%s", workflow_name ? workflow_name : "");
+      snprintf(g_created[g_ncreated].wf, sizeof g_created[0].wf, "%s",
+               workflow_name ? workflow_name : "");
       snprintf(g_created[g_ncreated].repo, sizeof g_created[0].repo, "%s", repo ? repo : "");
       snprintf(g_created[g_ncreated].path, sizeof g_created[0].path, "%s",
                proposal_path ? proposal_path : "");
@@ -720,10 +721,11 @@ static void test_scan_proposals_end_to_end(void)
    snprintf(g_blobs[1].content, sizeof g_blobs[1].content, "# Proposal B\n");
    g_nblobs = 2;
    /* Includes a non-.md (.gitkeep) row to prove the filter runs in the glue too. */
-   snprintf(g_lstree_out, sizeof g_lstree_out,
-            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
-            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
-            "100644 blob 1111111111111111111111111111111111111111\tdocs/proposals/pending/.gitkeep\n");
+   snprintf(
+       g_lstree_out, sizeof g_lstree_out,
+       "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+       "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
+       "100644 blob 1111111111111111111111111111111111111111\tdocs/proposals/pending/.gitkeep\n");
 
    trigger_rule_t rule;
    memset(&rule, 0, sizeof rule);
@@ -821,15 +823,15 @@ static void test_scan_proposals_custom_event_and_schedule(void)
    snprintf(rule.source, sizeof rule.source, "proposals");
    snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "manual-review");
-   snprintf(rule.event, sizeof rule.event, "rfcs"); /* custom scan dir */
+   snprintf(rule.event, sizeof rule.event, "rfcs");       /* custom scan dir */
    snprintf(rule.schedule, sizeof rule.schedule, "main"); /* custom branch */
 
    scan_proposals(&rule);
    assert(g_ncreated == 1);
-   assert(strcmp(g_lstree_ref, "main") == 0);             /* schedule used as ref */
-   assert(strncmp(g_lstree_pathspec, "rfcs", 4) == 0);    /* custom event dir */
+   assert(strcmp(g_lstree_ref, "main") == 0);          /* schedule used as ref */
+   assert(strncmp(g_lstree_pathspec, "rfcs", 4) == 0); /* custom event dir */
    size_t pl = strlen(g_lstree_pathspec);
-   assert(g_lstree_pathspec[pl - 1] == '/');              /* still trailing-slashed */
+   assert(g_lstree_pathspec[pl - 1] == '/'); /* still trailing-slashed */
    assert(strcmp(g_created[0].wf, "manual-review") == 0);
    printf("  PASS: test_scan_proposals_custom_event_and_schedule\n");
 }

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -834,6 +834,45 @@ static void test_scan_proposals_custom_event_and_schedule(void)
    printf("  PASS: test_scan_proposals_custom_event_and_schedule\n");
 }
 
+static void test_scan_proposals_rejects_unsafe_ref_and_path(void)
+{
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
+   mkdir(g_home, 0700);
+
+   trigger_rule_t rule;
+
+   /* A ref (schedule) beginning with '-' is rejected before ls-tree runs. */
+   trig_stub_reset();
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   snprintf(rule.schedule, sizeof rule.schedule, "--all");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+   assert(g_lstree_ref[0] == '\0'); /* ls-tree never invoked */
+
+   /* A traversing scan dir is rejected. */
+   trig_stub_reset();
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   snprintf(rule.event, sizeof rule.event, "../../etc");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+   assert(g_lstree_ref[0] == '\0');
+
+   /* An absolute scan dir is rejected. */
+   snprintf(rule.event, sizeof rule.event, "/etc");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+
+   printf("  PASS: test_scan_proposals_rejects_unsafe_ref_and_path\n");
+}
+
 /* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
@@ -879,6 +918,7 @@ int main(void)
    test_scan_proposals_end_to_end();
    test_scan_proposals_requires_workspace_and_workflow();
    test_scan_proposals_custom_event_and_schedule();
+   test_scan_proposals_rejects_unsafe_ref_and_path();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <stddef.h>
 
 /* Stubs for symbols pulled in transitively by trigger_scheduler.c */
 
@@ -83,6 +84,48 @@ int db1_cron_jobs_load(cron_job_t *out, int max, int enabled_only)
    (void)out;
    (void)max;
    (void)enabled_only;
+   return 0;
+}
+
+const char *aimee_home(void)
+{
+   return "/tmp/aimee-test";
+}
+
+int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
+                                      char **out, size_t max_output, int timeout_ms)
+{
+   (void)argv;
+   (void)cwd;
+   (void)envp;
+   (void)max_output;
+   (void)timeout_ms;
+   if (out)
+      *out = NULL;
+   return 1;
+}
+
+int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, char *out_id,
+                                 size_t out_id_len)
+{
+   (void)repo;
+   (void)proposal_path;
+   if (out_id && out_id_len > 0)
+      out_id[0] = '\0';
+   return 0;
+}
+
+int wfe_work_item_create(const char *workflow_name, const char *repo, const char *proposal_path,
+                         const char *mode, char out_id[80], char *err, size_t errlen)
+{
+   (void)workflow_name;
+   (void)repo;
+   (void)proposal_path;
+   (void)mode;
+   if (out_id)
+      snprintf(out_id, 80, "wi_test");
+   if (err && errlen > 0)
+      err[0] = '\0';
    return 0;
 }
 
@@ -495,6 +538,57 @@ static void test_cron_job_prompt_reports_truncation_like_snprintf(void)
    printf("  PASS: test_cron_job_prompt_reports_truncation_like_snprintf\n");
 }
 
+static void test_parse_ls_tree_valid_multiline(void)
+{
+   const char *out =
+       "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+       "100644 blob fedcba9876543210fedcba9876543210fedcba98\tb.md\n";
+   trigger_ls_tree_entry_t entries[4];
+   int n = trigger_parse_ls_tree(out, entries, 4);
+   assert(n == 2);
+   assert(strcmp(entries[0].sha, "0123456789abcdef0123456789abcdef01234567") == 0);
+   assert(strcmp(entries[0].name, "docs/proposals/pending/a.md") == 0);
+   assert(strcmp(entries[1].sha, "fedcba9876543210fedcba9876543210fedcba98") == 0);
+   assert(strcmp(entries[1].name, "b.md") == 0);
+   printf("  PASS: test_parse_ls_tree_valid_multiline\n");
+}
+
+static void test_parse_ls_tree_filters_non_md_and_non_blob(void)
+{
+   const char *out = "100644 blob 0123456789abcdef0123456789abcdef01234567\ta.txt\n"
+                     "040000 tree fedcba9876543210fedcba9876543210fedcba98\tdir.md\n"
+                     "100644 blob 1111111111111111111111111111111111111111\tkeep.md\n";
+   trigger_ls_tree_entry_t entries[4];
+   int n = trigger_parse_ls_tree(out, entries, 4);
+   assert(n == 1);
+   assert(strcmp(entries[0].sha, "1111111111111111111111111111111111111111") == 0);
+   assert(strcmp(entries[0].name, "keep.md") == 0);
+   printf("  PASS: test_parse_ls_tree_filters_non_md_and_non_blob\n");
+}
+
+static void test_parse_ls_tree_empty_and_garbage(void)
+{
+   const char *out = "\nnot ls tree\n100644 blob short\tbad.md\n"
+                     "100644 blob zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\tbad.md\n";
+   trigger_ls_tree_entry_t entries[2];
+   assert(trigger_parse_ls_tree("", entries, 2) == 0);
+   assert(trigger_parse_ls_tree(out, entries, 2) == 0);
+   assert(trigger_parse_ls_tree(NULL, entries, 2) == 0);
+   printf("  PASS: test_parse_ls_tree_empty_and_garbage\n");
+}
+
+static void test_parse_ls_tree_buffer_cap(void)
+{
+   const char *out = "100644 blob 0123456789abcdef0123456789abcdef01234567\ta.md\n"
+                     "100644 blob fedcba9876543210fedcba9876543210fedcba98\tb.md\n";
+   trigger_ls_tree_entry_t entries[1];
+   int n = trigger_parse_ls_tree(out, entries, 1);
+   assert(n == 1);
+   assert(strcmp(entries[0].name, "a.md") == 0);
+   assert(trigger_parse_ls_tree(out, entries, 0) == 0);
+   printf("  PASS: test_parse_ls_tree_buffer_cap\n");
+}
+
 /* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
@@ -533,6 +627,10 @@ int main(void)
    test_cron_job_prompt_omits_empty_optional_blocks();
    test_cron_job_prompt_caps_prior_output_to_8k_tail();
    test_cron_job_prompt_reports_truncation_like_snprintf();
+   test_parse_ls_tree_valid_multiline();
+   test_parse_ls_tree_filters_non_md_and_non_blob();
+   test_parse_ls_tree_empty_and_garbage();
+   test_parse_ls_tree_buffer_cap();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <time.h>
 #include <stddef.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* Stubs for symbols pulled in transitively by trigger_scheduler.c */
 
@@ -87,29 +89,122 @@ int db1_cron_jobs_load(cron_job_t *out, int max, int enabled_only)
    return 0;
 }
 
-const char *aimee_home(void)
+/* ------------------------------------------------------------------ */
+/* Programmable stubs for the scan_proposals() integration test.        */
+/* The git exec is faked with canned per-subcommand output so the whole  */
+/* orchestration (ref resolve -> ls-tree -> parse -> materialize ->       */
+/* dedup -> create) runs hermetically, with no real git or DB.           */
+/* ------------------------------------------------------------------ */
+
+static char g_home[512] = "/tmp/aimee-test";
+static char g_symref_out[256]; /* canned `git symbolic-ref` stdout ("" -> rc!=0) */
+static char g_lstree_out[8192]; /* canned `git ls-tree` stdout */
+static char g_lstree_ref[256];      /* captured ref arg passed to ls-tree */
+static char g_lstree_pathspec[512]; /* captured pathspec arg passed to ls-tree */
+static struct
 {
-   return "/tmp/aimee-test";
+   char sha[41];
+   char content[256];
+} g_blobs[16];
+static int g_nblobs;
+static struct
+{
+   char wf[64];
+   char repo[512];
+   char path[600];
+   char mode[32];
+} g_created[32];
+static int g_ncreated;
+
+static void trig_stub_reset(void)
+{
+   g_symref_out[0] = g_lstree_out[0] = g_lstree_ref[0] = g_lstree_pathspec[0] = '\0';
+   g_nblobs = 0;
+   g_ncreated = 0;
 }
 
+const char *aimee_home(void)
+{
+   return g_home;
+}
+
+/* Fake git: dispatch on the subcommand token and return canned stdout. */
 int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
                                       char **out, size_t max_output, int timeout_ms)
 {
-   (void)argv;
    (void)cwd;
    (void)envp;
    (void)max_output;
    (void)timeout_ms;
    if (out)
       *out = NULL;
+   if (!argv || !argv[0])
+      return 1;
+
+   int is_lstree = 0, is_catfile = 0, is_symref = 0, dashdash = -1;
+   const char *sha = NULL, *ref = NULL;
+   for (int i = 0; argv[i]; i++)
+   {
+      if (strcmp(argv[i], "ls-tree") == 0)
+      {
+         is_lstree = 1;
+         if (argv[i + 1])
+            ref = argv[i + 1]; /* `git ls-tree <ref> -- <dir>` */
+      }
+      if (strcmp(argv[i], "cat-file") == 0)
+         is_catfile = 1;
+      if (strcmp(argv[i], "symbolic-ref") == 0)
+         is_symref = 1;
+      if (strcmp(argv[i], "--") == 0)
+         dashdash = i;
+   }
+   if (is_symref)
+   {
+      if (!g_symref_out[0])
+         return 1; /* no symbolic-ref -> non-zero, exercises the fallback chain */
+      if (out)
+         *out = strdup(g_symref_out);
+      return 0;
+   }
+   if (is_lstree)
+   {
+      if (ref)
+         snprintf(g_lstree_ref, sizeof g_lstree_ref, "%s", ref);
+      if (dashdash >= 0 && argv[dashdash + 1])
+         snprintf(g_lstree_pathspec, sizeof g_lstree_pathspec, "%s", argv[dashdash + 1]);
+      if (out)
+         *out = strdup(g_lstree_out);
+      return 0;
+   }
+   if (is_catfile)
+   {
+      for (int i = 0; argv[i]; i++)
+         sha = argv[i]; /* last token is the blob sha */
+      for (int i = 0; i < g_nblobs; i++)
+         if (sha && strcmp(g_blobs[i].sha, sha) == 0)
+         {
+            if (out)
+               *out = strdup(g_blobs[i].content);
+            return 0;
+         }
+      if (out)
+         *out = strdup("");
+      return 0;
+   }
    return 1;
 }
 
+/* Dedup pre-check: a proposal already recorded by wfe_work_item_create "exists". */
 int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, char *out_id,
                                  size_t out_id_len)
 {
-   (void)repo;
-   (void)proposal_path;
+   for (int i = 0; i < g_ncreated; i++)
+      if (strcmp(g_created[i].repo, repo) == 0 && strcmp(g_created[i].path, proposal_path) == 0)
+      {
+         if (out_id && out_id_len > 0)
+            snprintf(out_id, out_id_len, "wi_existing");
+         return 1;
+      }
    if (out_id && out_id_len > 0)
       out_id[0] = '\0';
    return 0;
@@ -118,12 +213,17 @@ int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, ch
 int wfe_work_item_create(const char *workflow_name, const char *repo, const char *proposal_path,
                          const char *mode, char out_id[80], char *err, size_t errlen)
 {
-   (void)workflow_name;
-   (void)repo;
-   (void)proposal_path;
-   (void)mode;
+   if (g_ncreated < (int)(sizeof g_created / sizeof g_created[0]))
+   {
+      snprintf(g_created[g_ncreated].wf, sizeof g_created[0].wf, "%s", workflow_name ? workflow_name : "");
+      snprintf(g_created[g_ncreated].repo, sizeof g_created[0].repo, "%s", repo ? repo : "");
+      snprintf(g_created[g_ncreated].path, sizeof g_created[0].path, "%s",
+               proposal_path ? proposal_path : "");
+      snprintf(g_created[g_ncreated].mode, sizeof g_created[0].mode, "%s", mode ? mode : "");
+      g_ncreated++;
+   }
    if (out_id)
-      snprintf(out_id, 80, "wi_test");
+      snprintf(out_id, 80, "wi_%d", g_ncreated);
    if (err && errlen > 0)
       err[0] = '\0';
    return 0;
@@ -590,6 +690,151 @@ static void test_parse_ls_tree_buffer_cap(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* scan_proposals() end-to-end orchestration (hermetic, faked git)      */
+/* ------------------------------------------------------------------ */
+
+static int file_equals(const char *path, const char *want)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return 0;
+   char buf[512] = {0};
+   size_t n = fread(buf, 1, sizeof buf - 1, f);
+   fclose(f);
+   buf[n] = '\0';
+   return strcmp(buf, want) == 0;
+}
+
+static void test_scan_proposals_end_to_end(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
+   mkdir(g_home, 0700); /* trigger_mkdir_parents() creates triggers/ + triggers/proposals/ */
+
+   /* schedule empty -> ref resolves via the symbolic-ref fallback. */
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# Proposal A\n");
+   snprintf(g_blobs[1].sha, sizeof g_blobs[1].sha, "fedcba9876543210fedcba9876543210fedcba98");
+   snprintf(g_blobs[1].content, sizeof g_blobs[1].content, "# Proposal B\n");
+   g_nblobs = 2;
+   /* Includes a non-.md (.gitkeep) row to prove the filter runs in the glue too. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
+            "100644 blob 1111111111111111111111111111111111111111\tdocs/proposals/pending/.gitkeep\n");
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   snprintf(rule.event, sizeof rule.event, "docs/proposals/pending");
+
+   scan_proposals(&rule);
+
+   /* Two .md proposals -> two work items; .gitkeep filtered out. */
+   assert(g_ncreated == 2);
+   /* ls-tree used the resolved default ref and a TRAILING-SLASH pathspec (regression
+    * guard for the "bare dir lists only the tree entry" bug). */
+   assert(strcmp(g_lstree_ref, "origin/testing") == 0);
+   size_t pl = strlen(g_lstree_pathspec);
+   assert(pl > 0 && g_lstree_pathspec[pl - 1] == '/');
+   /* Correct launch args: workflow=pipeline_template, repo=workspace, mode=proposals. */
+   assert(strcmp(g_created[0].wf, "build") == 0);
+   assert(strcmp(g_created[0].repo, "/repo/aimee") == 0);
+   assert(strcmp(g_created[0].mode, "proposals") == 0);
+   /* proposal_path is <home>/triggers/proposals/<blob-sha>.md and holds the blob. */
+   char exp0[700], exp1[700];
+   snprintf(exp0, sizeof exp0, "%s/triggers/proposals/%s.md", g_home, g_blobs[0].sha);
+   snprintf(exp1, sizeof exp1, "%s/triggers/proposals/%s.md", g_home, g_blobs[1].sha);
+   assert(strcmp(g_created[0].path, exp0) == 0);
+   assert(strcmp(g_created[1].path, exp1) == 0);
+   assert(file_equals(exp0, "# Proposal A\n"));
+   assert(file_equals(exp1, "# Proposal B\n"));
+
+   /* Re-scan with the same tree -> dedup pre-check skips both -> no new work items. */
+   scan_proposals(&rule);
+   assert(g_ncreated == 2);
+
+   /* A genuinely new proposal (new blob) -> exactly one new work item. */
+   snprintf(g_blobs[2].sha, sizeof g_blobs[2].sha, "2222222222222222222222222222222222222222");
+   snprintf(g_blobs[2].content, sizeof g_blobs[2].content, "# Proposal C\n");
+   g_nblobs = 3;
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
+            "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
+   scan_proposals(&rule);
+   assert(g_ncreated == 3);
+   assert(strcmp(g_created[2].wf, "build") == 0);
+
+   printf("  PASS: test_scan_proposals_end_to_end\n");
+}
+
+static void test_scan_proposals_requires_workspace_and_workflow(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "x\n");
+   g_nblobs = 1;
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+
+   /* Missing workspace -> no-op. */
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+
+   /* Missing workflow (pipeline_template) -> no-op. */
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   scan_proposals(&rule);
+   assert(g_ncreated == 0);
+
+   printf("  PASS: test_scan_proposals_requires_workspace_and_workflow\n");
+}
+
+static void test_scan_proposals_custom_event_and_schedule(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   /* Non-empty schedule -> used verbatim as the ref; symbolic-ref must NOT be needed. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob abababababababababababababababababababab\trfcs/x.md\n");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "abababababababababababababababababababab");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "rfc\n");
+   g_nblobs = 1;
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "manual-review");
+   snprintf(rule.event, sizeof rule.event, "rfcs"); /* custom scan dir */
+   snprintf(rule.schedule, sizeof rule.schedule, "main"); /* custom branch */
+
+   scan_proposals(&rule);
+   assert(g_ncreated == 1);
+   assert(strcmp(g_lstree_ref, "main") == 0);             /* schedule used as ref */
+   assert(strncmp(g_lstree_pathspec, "rfcs", 4) == 0);    /* custom event dir */
+   size_t pl = strlen(g_lstree_pathspec);
+   assert(g_lstree_pathspec[pl - 1] == '/');              /* still trailing-slashed */
+   assert(strcmp(g_created[0].wf, "manual-review") == 0);
+   printf("  PASS: test_scan_proposals_custom_event_and_schedule\n");
+}
+
+/* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
 
@@ -631,6 +876,9 @@ int main(void)
    test_parse_ls_tree_filters_non_md_and_non_blob();
    test_parse_ls_tree_empty_and_garbage();
    test_parse_ls_tree_buffer_cap();
+   test_scan_proposals_end_to_end();
+   test_scan_proposals_requires_workspace_and_workflow();
+   test_scan_proposals_custom_event_and_schedule();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_wfe_advance_exec.c
+++ b/src/tests/test_wfe_advance_exec.c
@@ -4,6 +4,7 @@
  * resolves the binding, applies the CAS/replay decision, advances exactly one
  * engine step on OK, refuses stale/unbound, is idempotent on replay, and audits
  * every decision to the lifecycle log. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,7 +40,7 @@ static const char *WF = "name: t\n"
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_adv_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_approval.c
+++ b/src/tests/test_wfe_approval.c
@@ -1,4 +1,5 @@
 /* test_wfe_approval.c -- W4: HMAC approval signer + gate.human executor. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,7 +40,7 @@ static char g_home[64];
 static void setup_home(void)
 {
    strcpy(g_home, "/tmp/wfe_appr_XXXXXX");
-   char *dir = mkdtemp(g_home);
+   char *dir = wfe_test_mkdtemp(g_home);
    assert(dir);
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -1,4 +1,5 @@
 /* test_wfe_autonomy.c -- W6: the autonomy driver + human-only gate-override. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -90,7 +91,7 @@ int main(void)
 {
    printf("wfe-autonomy: ");
    char d[] = "/tmp/wfe_auto_XXXXXX";
-   char *dir = mkdtemp(d);
+   char *dir = wfe_test_mkdtemp(d);
    assert(dir);
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_bind_ingress.c
+++ b/src/tests/test_wfe_bind_ingress.c
@@ -2,6 +2,7 @@
  * (real DB1 + router + engine, stub executors). Asserts: only enforced-routed
  * turns bind, dial-off is inert, binding is idempotent per session, and a bind
  * lifecycle event is recorded. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,7 +65,7 @@ static const char *WF_MC = "name: mc\n"
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_bind_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_block_resolve.c
+++ b/src/tests/test_wfe_block_resolve.c
@@ -2,6 +2,7 @@
  * dispatch-time externalization guard, against a real in-memory DB1 + engine
  * (stub executors). Covers the pure decision table, the DB resolve, and the
  * composed guard (default-off, deny/warn/allow, delivered lifts, audit). */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -83,7 +84,7 @@ static void write_wf(const char *dir, const char *name, const char *body)
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_res_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_blocks.c
+++ b/src/tests/test_wfe_blocks.c
@@ -1,5 +1,6 @@
 /* test_wfe_blocks.c -- W3: the real git freeze helper + default executor
  * registration. The delegate/forge executors are integration-gated. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,7 +30,7 @@ int main(void)
 
    /* --- wfe_git_freeze against a real temp git repo --- */
    char dir[] = "/tmp/wfe_repo_XXXXXX";
-   if (!mkdtemp(dir))
+   if (!wfe_test_mkdtemp(dir))
    {
       printf("(skip git freeze: mkdtemp) ok\n");
       return 0;

--- a/src/tests/test_wfe_custom.c
+++ b/src/tests/test_wfe_custom.c
@@ -1,5 +1,6 @@
 /* test_wfe_custom.c -- config-extensible blocks: registry load/validate, custom
  * block type-checking, and exec_custom (command opt-in) through the engine. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -52,7 +53,7 @@ int main(void)
 {
    printf("wfe-custom: ");
    strcpy(g_home, "/tmp/wfe_cust_XXXXXX");
-   assert(mkdtemp(g_home));
+   assert(wfe_test_mkdtemp(g_home));
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", g_home);
    mkdir(wf, 0755);

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -4,6 +4,7 @@
  * Phase A of full-autonomous-development: producing blocks dispatch real work
  * through registered hooks; with no provider they fail closed; tests inject
  * mocks to assert the wiring. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -148,7 +149,7 @@ int main(void)
 {
    printf("wfe-delegate-seam: ");
    char home[] = "/tmp/wfe_ds_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wf[160];
    snprintf(wf, sizeof wf, "%s/workflows", home);
    mkdir(wf, 0755);
@@ -361,7 +362,7 @@ int main(void)
     *    idempotent; cleanup removes it. */
    {
       char repo[] = "/tmp/wfe_f2_repo_XXXXXX";
-      assert(mkdtemp(repo));
+      assert(wfe_test_mkdtemp(repo));
       char cmd[640];
       snprintf(cmd, sizeof cmd,
                "cd %s && git init -q && git -c user.email=t@t -c user.name=t "

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -395,6 +395,70 @@ int main(void)
       (void)system(cmd);
    }
 
+   /* F: orphan-worktree GC + inode cap — reap worktrees no LIVE item owns, keep
+    *    active ones, honour the grace window, and fail-closed at the cap. */
+   {
+      char repo[] = "/tmp/wfe_gc_repo_XXXXXX";
+      assert(wfe_test_mkdtemp(repo));
+      char cmd[640];
+      snprintf(cmd, sizeof cmd,
+               "cd %s && git init -q && git -c user.email=t@t -c user.name=t "
+               "commit -q --allow-empty -m base",
+               repo);
+      assert(system(cmd) == 0);
+      struct stat stt;
+      char err[256] = "";
+      /* Start from an empty worktree pool so counts are deterministic (earlier
+       * blocks left terminal-item worktrees under the shared AIMEE_HOME). */
+      snprintf(cmd, sizeof cmd, "rm -rf %s/wfe-worktrees", home);
+      (void)system(cmd);
+
+      /* (1) an active item's worktree survives a grace=0 GC (it still owns it). */
+      char live_id[80] = "";
+      assert(wfe_work_item_create("ds", "gcL", "gcpL", "autonomous", live_id, err, sizeof err) ==
+             0);
+      char wl[1024] = "";
+      assert(wfe_worktree_ensure(live_id, "", repo, "HEAD", wl, sizeof wl) == 0);
+      assert(wfe_worktree_orphan_gc(repo, 0) == 0); /* nothing reapable */
+      assert(stat(wl, &stt) == 0);                  /* kept */
+
+      /* (2) a TERMINAL item's stranded worktree is reaped. */
+      char term_id[80] = "";
+      assert(wfe_work_item_create("ds", "gcT", "gcpT", "autonomous", term_id, err, sizeof err) ==
+             0);
+      char wtm[1024] = "";
+      assert(wfe_worktree_ensure(term_id, "", repo, "HEAD", wtm, sizeof wtm) == 0);
+      assert(db1_work_item_set_terminal(term_id, "abandoned") == 0);
+      assert(wfe_worktree_orphan_gc(repo, 0) == 1);
+      assert(stat(wtm, &stt) != 0); /* reaped */
+      assert(stat(wl, &stt) == 0);  /* the active one is untouched */
+
+      /* (3) a VANISHED row reaps its worktree, but only past the grace window. */
+      char orph_id[80] = "";
+      assert(wfe_work_item_create("ds", "gcO", "gcpO", "autonomous", orph_id, err, sizeof err) ==
+             0);
+      char wo[1024] = "";
+      assert(wfe_worktree_ensure(orph_id, "", repo, "HEAD", wo, sizeof wo) == 0);
+      assert(db1_work_item_delete(orph_id) == 0);
+      assert(wfe_worktree_orphan_gc(repo, 100000) == 0); /* too fresh -> kept */
+      assert(stat(wo, &stt) == 0);
+      assert(wfe_worktree_orphan_gc(repo, 0) == 1); /* grace 0 -> reaped */
+      assert(stat(wo, &stt) != 0);
+
+      /* (4) inode cap fails closed: with MAX=1 and the active worktree holding the
+       *     one slot, a second ensure can't allocate and returns -1 (the caller
+       *     then degrades to the shared checkout). */
+      setenv("AIMEE_WFE_WORKTREE_MAX", "1", 1);
+      char cap_id[80] = "";
+      assert(wfe_work_item_create("ds", "gcC", "gcpC", "autonomous", cap_id, err, sizeof err) == 0);
+      char wc[1024] = "";
+      assert(wfe_worktree_ensure(cap_id, "", repo, "HEAD", wc, sizeof wc) == -1);
+      unsetenv("AIMEE_WFE_WORKTREE_MAX");
+
+      snprintf(cmd, sizeof cmd, "rm -rf %s", repo);
+      (void)system(cmd);
+   }
+
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_wfe_engine.c
+++ b/src/tests/test_wfe_engine.c
@@ -1,6 +1,7 @@
 /* test_wfe_engine.c -- W2: work-item state machine + engine. Exercises
  * create -> run -> accepted, the audit log, loop-back max_attempts pause, and
  * the cost-cap pause, using deterministic executors. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -72,7 +73,7 @@ static wfe_step_result_t exec_cost(wfe_ctx *c, const wfe_node_t *n)
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_foreach.c
+++ b/src/tests/test_wfe_foreach.c
@@ -8,6 +8,7 @@
  *   - all children accepted              -> advance (every slice merged)
  *   - a child rejected or abandoned      -> park pending_human (a slice will not merge)
  */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -40,7 +41,7 @@ static const char *FE = "name: fe\n"
 static void setup_home(void)
 {
    char d[] = "/tmp/wfe_fe_XXXXXX";
-   char *dir = mkdtemp(d);
+   char *dir = wfe_test_mkdtemp(d);
    assert(dir);
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_foreach_spawn.c
+++ b/src/tests/test_wfe_foreach_spawn.c
@@ -2,6 +2,7 @@
  * fans out to one child "slice" work item per packet, linked to the parent, seeded
  * with its packet, idempotent, and cap-bounded. (The child-DRIVING is the autonomy
  * driver's job, integration-gated; this pins the fan-OUT creation logic.) */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,7 +44,7 @@ int main(void)
 {
    printf("wfe-foreach-spawn: ");
    char home[] = "/tmp/wfe_spawn_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wf[160];
    snprintf(wf, sizeof wf, "%s/workflows", home);
    mkdir(wf, 0755);

--- a/src/tests/test_wfe_manager_flow.c
+++ b/src/tests/test_wfe_manager_flow.c
@@ -5,6 +5,7 @@
  * git worktree or live panel). Asserts the enforced workflow reaches delivery
  * (crosses gate.deliver -> accepted) and the lifecycle trail records each
  * manager step's advance. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -118,7 +119,7 @@ static wfe_step_result_t stub_adv(wfe_ctx *c, const wfe_node_t *n)
 static void setup_home(void)
 {
    char tmpl[] = "/tmp/wfe_mgr_home_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_roundtable.c
+++ b/src/tests/test_wfe_roundtable.c
@@ -1,5 +1,6 @@
 /* test_wfe_roundtable.c -- W5: the fail-closed gate decision rule + the
  * gate.roundtable executor through the engine with a mock panel provider. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -81,7 +82,7 @@ static const char *RT = "name: rt\n"
 static void setup_home(void)
 {
    char d[] = "/tmp/wfe_rt_XXXXXX";
-   char *dir = mkdtemp(d);
+   char *dir = wfe_test_mkdtemp(d);
    assert(dir);
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_router_catalog.c
+++ b/src/tests/test_wfe_router_catalog.c
@@ -1,6 +1,7 @@
 /* test_wfe_router_catalog.c -- the router catalog I/O layer: enumerate
  * $AIMEE_HOME/workflows/<name>.yaml, read router metadata, add the built-in lanes,
  * skip symlinks (escape guard), and reject a workflow that claims `default`. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,7 +23,7 @@ int main(void)
 {
    printf("wfe-router-catalog: ");
    char tmpl[] = "/tmp/wfe_cat_XXXXXX";
-   char *dir = mkdtemp(tmpl);
+   char *dir = wfe_test_mkdtemp(tmpl);
    assert(dir);
    char wf[512];
    snprintf(wf, sizeof wf, "%s/workflows", dir);

--- a/src/tests/test_wfe_safety.c
+++ b/src/tests/test_wfe_safety.c
@@ -1,5 +1,6 @@
 /* test_wfe_safety.c -- gate.ci / check.mergeable / idempotent merge via a mock
  * forge provider, exercised through the engine. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -135,7 +136,7 @@ int main(void)
 {
    printf("wfe-safety: ");
    char home[] = "/tmp/wfe_sft_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wf[128];
    snprintf(wf, sizeof wf, "%s/workflows", home);
    mkdir(wf, 0755);

--- a/src/tests/test_wfe_scheduler.c
+++ b/src/tests/test_wfe_scheduler.c
@@ -1,6 +1,7 @@
 /* test_wfe_scheduler.c -- the autonomy scheduler drives ACTIVE AUTONOMOUS work
  * items forward and leaves interactive ones for the human (Phase B). Uses the
  * synchronous wfe_scheduler_run_once + stub executors for determinism. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,7 +27,7 @@ int main(void)
 {
    printf("wfe-scheduler: ");
    char home[] = "/tmp/wfe_sc_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wf[160];
    snprintf(wf, sizeof wf, "%s/workflows", home);
    mkdir(wf, 0755);

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -3,6 +3,7 @@
  * blocks catalog (built-ins + safety + custom), save/get canonical round-trip
  * byte-stability (incl. a cyclic graph), optimistic-lock conflicts, path-name
  * safety, validate, and work-item run-state. */
+#include "wfe_test_home.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -67,7 +68,7 @@ int main(void)
 {
    printf("wfe-webapi: ");
    char home[] = "/tmp/wfe_web_XXXXXX";
-   assert(mkdtemp(home));
+   assert(wfe_test_mkdtemp(home));
    char wfdir[128];
    snprintf(wfdir, sizeof wfdir, "%s/workflows", home);
    mkdir(wfdir, 0755);

--- a/src/tests/wfe_test_home.h
+++ b/src/tests/wfe_test_home.h
@@ -1,0 +1,47 @@
+#ifndef WFE_TEST_HOME_H
+#define WFE_TEST_HOME_H 1
+
+/* wfe_test_home.h -- a mkdtemp() that removes its directory at process exit, so a
+ * WFE unit test never strands its /tmp AIMEE_HOME. Each test points AIMEE_HOME at
+ * a mkdtemp'd dir and the engine fills it with git worktrees (wfe-worktrees/wi_*,
+ * ~4k files each); left behind across runs they exhausted /tmp's inodes. This is a
+ * drop-in for mkdtemp() -- same signature and return -- that also schedules an
+ * `rm -rf` of every dir it created via atexit. Header-only + static so no Rules.mk
+ * or link changes are needed: each test binary is one translation unit and gets
+ * its own private list, so parallel test runs only ever remove their OWN dirs. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define WFE_TEST_HOME_MAX 16
+static char wfe_test_home_dirs__[WFE_TEST_HOME_MAX][256];
+static int wfe_test_home_n__;
+
+static void wfe_test_home_sweep__(void)
+{
+   for (int i = 0; i < wfe_test_home_n__; i++)
+   {
+      char cmd[320];
+      /* mkdtemp paths are our own short /tmp/wfe_*_XXXXXX templates (no shell
+       * metacharacters); best-effort removal, status is irrelevant at exit. */
+      if (snprintf(cmd, sizeof cmd, "rm -rf '%s'", wfe_test_home_dirs__[i]) < (int)sizeof cmd)
+         (void)system(cmd);
+   }
+}
+
+/* Drop-in mkdtemp(): creates the dir and schedules its recursive removal at exit.
+ * Returns mkdtemp's result (the mutated template on success, NULL on failure). */
+static char *wfe_test_mkdtemp(char *tmpl)
+{
+   char *p = mkdtemp(tmpl);
+   if (p && wfe_test_home_n__ < WFE_TEST_HOME_MAX)
+   {
+      if (wfe_test_home_n__ == 0)
+         atexit(wfe_test_home_sweep__);
+      snprintf(wfe_test_home_dirs__[wfe_test_home_n__++], 256, "%s", p);
+   }
+   return p;
+}
+
+#endif /* WFE_TEST_HOME_H */

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -7,6 +7,8 @@
  * suite (the engine test overrides them with mocks via the vtable). */
 #include "wfe_blocks.h"
 
+#include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -156,6 +158,44 @@ static void wt_scrub(const char *rl, const char *path, const char *branch)
    free(o);
 }
 
+/* A positive long from `name`, else `def` (rejects junk/non-positive/overflow so a
+ * malformed override can't silently disable the guardrail). */
+static long wt_env_long(const char *name, long def)
+{
+   const char *v = getenv(name);
+   if (!v || !v[0])
+      return def;
+   errno = 0;
+   char *end = NULL;
+   long n = strtol(v, &end, 10);
+   if (errno == ERANGE || !end || *end != '\0' || n <= 0)
+      return def;
+   return n;
+}
+
+/* Count the worktree directories currently under `parent` (best-effort; a
+ * missing/unreadable dir is 0). Lock files and non-dirs are ignored. */
+static int wt_dir_count(const char *parent)
+{
+   DIR *dp = opendir(parent);
+   if (!dp)
+      return 0;
+   int n = 0;
+   struct dirent *e;
+   while ((e = readdir(dp)) != NULL)
+   {
+      if (e->d_name[0] == '.')
+         continue;
+      char path[1024];
+      struct stat st;
+      if (snprintf(path, sizeof path, "%s/%s", parent, e->d_name) < (int)sizeof path &&
+          stat(path, &st) == 0 && S_ISDIR(st.st_mode))
+         n++;
+   }
+   closedir(dp);
+   return n;
+}
+
 int wfe_worktree_ensure(const char *work_item_id, const char *existing, const char *repo_local,
                         const char *base, char *out_path, size_t n)
 {
@@ -215,6 +255,19 @@ int wfe_worktree_ensure(const char *work_item_id, const char *existing, const ch
       goto unlock;
    }
 
+   /* Inode guardrail: bound how many worktrees can exist at once so a runaway (or a
+    * pile of orphaned checkouts from crashed runs) can't exhaust the filesystem's
+    * inodes. Reclaim orphans first; only if still at the cap do we fail-closed here
+    * — the caller then degrades to the shared checkout rather than adding an
+    * unbounded worktree. AIMEE_WFE_WORKTREE_MAX overrides the default. */
+   long cap = wt_env_long("AIMEE_WFE_WORKTREE_MAX", 32);
+   if (wt_dir_count(parent) >= cap)
+   {
+      wfe_worktree_orphan_gc(rl, 0);
+      if (wt_dir_count(parent) >= cap)
+         goto unlock; /* rc_final stays -1 -> shared-checkout fallback */
+   }
+
    o = NULL;
    const char *add[] = {"git", "-C", rl, "worktree", "add", "--lock", "-b", branch, path, b, NULL};
    int rc = safe_exec_capture(add, &o, 1 << 16);
@@ -256,6 +309,80 @@ int wfe_worktree_cleanup(const char *worktree, const char *repo_local)
    int rc = safe_exec_capture(rm, &o, 1 << 14);
    free(o);
    return rc == 0 ? 0 : -1;
+}
+
+/* True for an immutable-terminal work-item state (mirrors the scheduler sweep's
+ * set): such an item's worktree should already be gone, so a lingering one is
+ * reapable rather than in-use. */
+static int wt_state_terminal(const char *st)
+{
+   return st && (!strcmp(st, "accepted") || !strcmp(st, "rejected") || !strcmp(st, "abandoned"));
+}
+
+int wfe_worktree_orphan_gc(const char *repo_local, long grace_secs)
+{
+   const char *home = aimee_home();
+   if (!home || !home[0])
+      return 0;
+   char parent[768];
+   if (sn(parent, sizeof parent, "%s/wfe-worktrees", home) != 0)
+      return 0;
+   DIR *dp = opendir(parent);
+   if (!dp)
+      return 0; /* no worktrees dir yet -> nothing to reap */
+   const char *rl = (repo_local && repo_local[0]) ? repo_local : ".";
+   time_t now = time(NULL);
+   int reaped = 0;
+   struct dirent *e;
+   while ((e = readdir(dp)) != NULL)
+   {
+      if (e->d_name[0] == '.')
+         continue;
+      size_t nl = strlen(e->d_name);
+      if (nl >= 5 && strcmp(e->d_name + nl - 5, ".lock") == 0)
+         continue; /* a lock is reaped alongside its worktree, below */
+      char path[1024];
+      if (snprintf(path, sizeof path, "%s/%s", parent, e->d_name) >= (int)sizeof path)
+         continue;
+      struct stat stt;
+      if (stat(path, &stt) != 0 || !S_ISDIR(stt.st_mode))
+         continue; /* only directories are worktrees */
+
+      /* Keep a worktree that a LIVE (non-terminal) work item still owns — an
+       * active/parked item needs it, and the terminal-sweep handles terminal ones.
+       * This GC only fills the gap those miss: a vanished row, or a terminal row
+       * whose worktree was left behind. */
+      db1_work_item_t wi;
+      int have = db1_work_item_get(e->d_name, &wi);
+      if (have == 1 && !wt_state_terminal(wi.state))
+         continue;
+
+      /* Age gate: a worktree dir exists before its row/column is written, so never
+       * reap one younger than the grace window (grace_secs <= 0 = reap now). */
+      if (grace_secs > 0 && now - stt.st_mtime < grace_secs)
+         continue;
+
+      char branch[220];
+      if (sn(branch, sizeof branch, "aimee/wi/%s", e->d_name) != 0)
+         continue;
+      wt_scrub(rl, path, branch); /* force-remove worktree + rm -rf + delete branch */
+      char lockf[1100];
+      if (snprintf(lockf, sizeof lockf, "%s.lock", path) < (int)sizeof lockf)
+         unlink(lockf);
+      if (have == 1)
+         db1_work_item_set_worktree(e->d_name, ""); /* clear a stale terminal column */
+      reaped++;
+   }
+   closedir(dp);
+   if (reaped > 0)
+   {
+      /* Drop git's admin refs (.git/worktrees/<id>) for the dirs we removed. */
+      char *o = NULL;
+      const char *prune[] = {"git", "-C", rl, "worktree", "prune", NULL};
+      safe_exec_capture(prune, &o, 1 << 14);
+      free(o);
+   }
+   return reaped;
 }
 
 /* ---- forge seam (gate.ci / check.mergeable / merge) ---- */

--- a/src/workflow/wfe_blocks.h
+++ b/src/workflow/wfe_blocks.h
@@ -176,4 +176,14 @@ int wfe_worktree_ensure(const char *work_item_id, const char *existing, const ch
                         const char *base, char *out_path, size_t n);
 int wfe_worktree_cleanup(const char *worktree, const char *repo_local);
 
+/* Orphan GC: reap wfe-worktrees/<id> dirs that no LIVE (non-terminal) work item
+ * owns — a vanished row (deleted item) or a terminal row whose terminal-cleanup
+ * was missed would otherwise strand a full git worktree (~thousands of inodes)
+ * forever. Only dirs older than `grace_secs` are reaped (grace_secs <= 0 reaps
+ * immediately), so an in-flight worktree mid-creation is never raced. Force-removes
+ * the worktree + its branch + lock, prunes git's admin refs, and clears any stale
+ * DB worktree column. Returns the number reaped. Belt-and-suspenders to the
+ * terminal-cleanup path (wfe_autonomy_cleanup_worktree / scheduler sweep). */
+int wfe_worktree_orphan_gc(const char *repo_local, long grace_secs);
+
 #endif /* DEC_WFE_BLOCKS_H */

--- a/webchat/settings.go
+++ b/webchat/settings.go
@@ -34,6 +34,50 @@ var settingsAllow = []settingField{
 	{Key: "kb_fusion_mode", Label: "Retrieval fusion mode", Type: "enum",
 		Options: []string{"rrf", "static_alpha", "dynamic_alpha"},
 		Help:    "How lexical + dense KB search results are blended. dynamic_alpha adapts the weight per query (boost exact-token queries); rrf is the safe default."},
+	// Options are filled at request time from the installed personas (see the
+	// GET handler); the static list stays empty so it never drifts from the
+	// engine's persona registry.
+	{Key: "default_persona", Label: "Default persona", Type: "enum",
+		Help: "Persona a new session starts in when none is explicitly set (defaults to engineer)."},
+}
+
+// personaNames lists the persona names the Default-persona selector offers, from
+// aimee-server's /v1/personas (built-ins + any custom personas). The bool is
+// true only when the live list was actually retrieved; on failure it returns
+// (["engineer"], false) so the selector still renders while callers can tell the
+// list is authoritative or a fallback (update-time validation relies on this).
+func (s *server) personaNames(ctx context.Context) ([]string, bool) {
+	st, data, err := s.v1Request(ctx, http.MethodGet, "/v1/personas", nil)
+	if err != nil || st != http.StatusOK {
+		return []string{"engineer"}, false
+	}
+	var d struct {
+		Personas []struct {
+			Name string `json:"name"`
+		} `json:"personas"`
+	}
+	if json.Unmarshal(data, &d) != nil {
+		return []string{"engineer"}, false
+	}
+	names := make([]string, 0, len(d.Personas))
+	for _, p := range d.Personas {
+		if p.Name != "" {
+			names = append(names, p.Name)
+		}
+	}
+	if len(names) == 0 {
+		return []string{"engineer"}, false
+	}
+	return names, true
+}
+
+func containsString(xs []string, v string) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }
 
 func settingAllowed(key string) bool {
@@ -73,6 +117,16 @@ func (s *server) handleSettings(w http.ResponseWriter, r *http.Request) {
 					val = d.Value
 				}
 			}
+			if f.Key == "default_persona" {
+				f.Options, _ = s.personaNames(ctx)
+				// Always keep the currently-saved value selectable, even if the
+				// persona list is a fallback or has since dropped it — otherwise
+				// the dropdown would render an invalid selection or silently
+				// overwrite it on the next save.
+				if cur, ok := val.(string); ok && cur != "" && !containsString(f.Options, cur) {
+					f.Options = append([]string{cur}, f.Options...)
+				}
+			}
 			out = append(out, outField{settingField: f, Value: val})
 		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"fields": out})
@@ -89,6 +143,18 @@ func (s *server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		if !settingAllowed(req.Key) {
 			writeJSONError(w, http.StatusForbidden, "setting not allowed")
 			return
+		}
+		// default_persona is a dynamic enum: reject an unknown persona when the
+		// live list is authoritative (so a direct API caller can't bypass the
+		// dropdown). When the persona service is unavailable we allow the write
+		// and rely on the engine resolving an unknown name to the engineer
+		// fallback, rather than blocking a legitimate change on a transient outage.
+		if req.Key == "default_persona" {
+			name, _ := req.Value.(string)
+			if names, ok := s.personaNames(ctx); ok && !containsString(names, name) {
+				writeJSONError(w, http.StatusBadRequest, "unknown persona")
+				return
+			}
 		}
 		body, _ := json.Marshal(map[string]interface{}{"key": req.Key, "value": req.Value})
 		st, data, err := s.v1Request(ctx, http.MethodPost, "/v1/config/set", body)


### PR DESCRIPTION
Promote `testing` → `main`.

## Headline change: `proposals` trigger source + remote session-start worktree fix (was #1228)
- **New `proposals` trigger source** (`src/server/trigger_scheduler.c`): scans a proposal dir as committed on a git branch and launches a WFE workflow per new proposal (dedup via blob-SHA path + `UNIQUE(repo, proposal_path)`). Materialization is fail-closed + `mkstemp`-based (symlink-safe).
- **Remote/thin session-start fix** (`src/cli_session_start.c`): on a remote-server deployment, prepares a per-session worktree (shell-free argv git; hash-keyed) and emits an "Isolated Checkout" directive so `require_session_worktree` no longer wedges the session. POSIX-guarded (Windows ships only the thin client).
- Hermetic integration tests for the scan orchestration; two roundtable review rounds (findings addressed).

## Also included (already on `testing`)
- Age-based orphan-worktree GC + inode cap on creation, and its docs regen.
- WFE test-harness `/tmp AIMEE_HOME` auto-cleanup.

## Verification
All 13 CI checks green on the head commit (`469d8890`): build, build-integrity, unit-tests, e2e-docker, windows-build, windows-cmake, macos-build, lint, treesitter, init-migrate-service-test, memory-retrieval-eval, bench-check, no-coauthor-trailers.
