### PR TITLE
feat(persona): session-start persona prose (uniform per persona) + configurable default persona

### DIFF
--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -244,8 +244,7 @@ static char *build_session_context(const char *client_cwd)
    /* Principles and Aimee lookup hints lead the session context for primacy
     * bias, driven by the active persona. */
    ctx_appendf(buf, cap, &pos, "%s",
-                           persona.principles_text ? persona.principles_text
-                                                   : prompt_principles_text(mode));
+               persona.principles_text ? persona.principles_text : prompt_principles_text(mode));
 
    /* Inject the active persona's own prose at the start of every primary session
     * — uniformly, for every persona. Engineer is not special here: it is simply
@@ -265,20 +264,19 @@ static char *build_session_context(const char *client_cwd)
 
    if (persona.brief_text)
       ctx_appendf(buf, cap, &pos,
-                              "# Aimee Context\n%s"
-                              "- Use `aimee session brief` to inspect the full startup brief.\n\n",
-                              persona.brief_text);
+                  "# Aimee Context\n%s"
+                  "- Use `aimee session brief` to inspect the full startup brief.\n\n",
+                  persona.brief_text);
    else
-      ctx_appendf(
-          buf, cap, &pos,
-          "# Aimee Context\n"
-          "- Use `aimee index overview` or `aimee index find <symbol>` for indexed code "
-          "lookup when it helps.\n"
-          "- Use `aimee memory search <terms>` for prior project context before "
-          "rediscovery.\n"
-          "- Use `aimee delegate <role> \"prompt\"` for bounded delegated or parallel "
-          "work.\n"
-          "- Use `aimee session brief` to inspect the full startup brief.\n\n");
+      ctx_appendf(buf, cap, &pos,
+                  "# Aimee Context\n"
+                  "- Use `aimee index overview` or `aimee index find <symbol>` for indexed code "
+                  "lookup when it helps.\n"
+                  "- Use `aimee memory search <terms>` for prior project context before "
+                  "rediscovery.\n"
+                  "- Use `aimee delegate <role> \"prompt\"` for bounded delegated or parallel "
+                  "work.\n"
+                  "- Use `aimee session brief` to inspect the full startup brief.\n\n");
 
    /* Enforce aimee's memory system as the single memory of record: steer the
     * agent to aimee memory commands rather than a native store. `.md` memory is
@@ -374,8 +372,7 @@ static char *build_session_context(const char *client_cwd)
             ctx_appendf(buf, cap, &pos, "# Key Facts\n");
             has_facts = 1;
          }
-         ctx_appendf(buf, cap, &pos, "- %s: %.300s\n", facts[i].key,
-                                 facts[i].content);
+         ctx_appendf(buf, cap, &pos, "- %s: %.300s\n", facts[i].key, facts[i].content);
       }
       if (has_facts)
          ctx_appendf(buf, cap, &pos, "\n");
@@ -423,8 +420,8 @@ static char *build_session_context(const char *client_cwd)
             ctx_appendf(buf, cap, &pos, "Hosts (%d): ", nw->host_count);
             int show = nw->host_count < 5 ? nw->host_count : 5;
             for (int i = 0; i < show && pos < cap - 128; i++)
-               ctx_appendf(buf, cap, &pos, "%s%s (%s)", i > 0 ? ", " : "",
-                                       nw->hosts[i].name, nw->hosts[i].ip);
+               ctx_appendf(buf, cap, &pos, "%s%s (%s)", i > 0 ? ", " : "", nw->hosts[i].name,
+                           nw->hosts[i].ip);
             if (nw->host_count > show)
                ctx_appendf(buf, cap, &pos, " +%d more", nw->host_count - show);
             ctx_appendf(buf, cap, &pos, "\n");
@@ -436,8 +433,8 @@ static char *build_session_context(const char *client_cwd)
                            nw->networks[i].cidr, nw->networks[i].desc);
          }
          ctx_appendf(buf, cap, &pos,
-                                 "Run `aimee agent network` or `aimee --json agent network` "
-                                 "for full host details.\n\n");
+                     "Run `aimee agent network` or `aimee --json agent network` "
+                     "for full host details.\n\n");
       }
    }
 
@@ -484,15 +481,13 @@ static char *build_session_context(const char *client_cwd)
                {
                   if (!has_section)
                   {
-                     ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n",
-                                             project_name);
+                     ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n", project_name);
                      has_section = 1;
                   }
                   const char *text =
                       like_rows[i].content[0] ? like_rows[i].content : like_rows[i].key;
                   if (like_rows[i].kind[0])
-                     ctx_appendf(buf, cap, &pos, "- [%s] %.300s\n",
-                                             like_rows[i].kind, text);
+                     ctx_appendf(buf, cap, &pos, "- [%s] %.300s\n", like_rows[i].kind, text);
                   else
                      ctx_appendf(buf, cap, &pos, "- %.300s\n", text);
                }
@@ -507,12 +502,11 @@ static char *build_session_context(const char *client_cwd)
             {
                if (!has_section)
                {
-                  ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n",
-                                          project_name);
+                  ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n", project_name);
                   has_section = 1;
                }
-               ctx_appendf(buf, cap, &pos, "- %d files indexed, %d definitions\n",
-                                       file_count, def_count);
+               ctx_appendf(buf, cap, &pos, "- %d files indexed, %d definitions\n", file_count,
+                           def_count);
             }
 
             if (has_section)
@@ -586,8 +580,8 @@ static char *build_session_context(const char *client_cwd)
             ctx_appendf(buf, cap, &pos, "- [%s] via %s: OK (%d turns, %d tools)\n", drole, dagent,
                         rows[i].turns, rows[i].tool_calls);
          else
-            ctx_appendf(buf, cap, &pos, "- [%s] via %s: FAILED (%.80s)\n", drole,
-                                    dagent, rows[i].error[0] ? rows[i].error : "unknown");
+            ctx_appendf(buf, cap, &pos, "- [%s] via %s: FAILED (%.80s)\n", drole, dagent,
+                        rows[i].error[0] ? rows[i].error : "unknown");
       }
       if (n > 0 && pos < cap - 256)
          ctx_appendf(buf, cap, &pos, "\n");

--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -34,6 +34,30 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdarg.h>
+
+/* Bounded formatted append into buf[cap] at *pos. Advances *pos only when the
+ * whole formatted string fits; on truncation or a formatting error it restores
+ * the prior NUL terminator and leaves *pos unchanged. A no-op once the buffer is
+ * full. This keeps *pos <= cap for every caller, so a later append can never
+ * compute an out-of-bounds `buf + *pos` or an underflowed `cap - *pos`. Returns
+ * 1 if the whole string was written, 0 otherwise. */
+static int ctx_appendf(char *buf, size_t cap, size_t *pos, const char *fmt, ...)
+{
+   if (*pos >= cap)
+      return 0;
+   va_list ap;
+   va_start(ap, fmt);
+   int n = vsnprintf(buf + *pos, cap - *pos, fmt, ap);
+   va_end(ap);
+   if (n < 0 || (size_t)n >= cap - *pos)
+   {
+      buf[*pos] = '\0';
+      return 0;
+   }
+   *pos += (size_t)n;
+   return 1;
+}
 
 /* --- cmd_session_start --- */
 
@@ -150,20 +174,20 @@ static size_t session_append_scope_section(const memory_t *rows, int n_rows, cha
 
    qsort(items, (size_t)item_count, sizeof(items[0]), session_scope_item_cmp);
 
-   pos += (size_t)snprintf(buf + pos, cap - pos, "%s\n", header);
+   ctx_appendf(buf, cap, &pos, "%s\n", header);
    int emitted = 0;
    for (int i = 0; i < item_count && emitted < limit && pos < cap - 512; i++)
    {
       const char *text = items[i].content[0] ? items[i].content : items[i].key;
       if (items[i].kind[0])
-         pos += (size_t)snprintf(buf + pos, cap - pos, "- [%s] %.300s\n", items[i].kind, text);
+         ctx_appendf(buf, cap, &pos, "- [%s] %.300s\n", items[i].kind, text);
       else
-         pos += (size_t)snprintf(buf + pos, cap - pos, "- %.300s\n", text);
+         ctx_appendf(buf, cap, &pos, "- %.300s\n", text);
       emitted++;
    }
 
    if (emitted > 0)
-      pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+      ctx_appendf(buf, cap, &pos, "\n");
    return pos;
 }
 
@@ -189,7 +213,7 @@ static int session_context_verbose_enabled(void)
 
 static char *build_session_context(const char *client_cwd)
 {
-   size_t cap = 32768;
+   size_t cap = 65536;
    char *buf = malloc(cap);
    size_t pos = 0;
    char scope_cwd[MAX_PATH_LEN];
@@ -219,17 +243,34 @@ static char *build_session_context(const char *client_cwd)
 
    /* Principles and Aimee lookup hints lead the session context for primacy
     * bias, driven by the active persona. */
-   pos += (size_t)snprintf(buf + pos, cap - pos, "%s",
+   ctx_appendf(buf, cap, &pos, "%s",
                            persona.principles_text ? persona.principles_text
                                                    : prompt_principles_text(mode));
+
+   /* Inject the active persona's own prose at the start of every primary session
+    * — uniformly, for every persona. Engineer is not special here: it is simply
+    * the default persona, and its prose carries the manager/work-queue framing
+    * because it is the orchestrator persona. Whichever persona resolved above,
+    * its "You are ..." identity and role lead the context so the session adopts
+    * it. Delegates never receive this block — they compose their prompt via
+    * persona_compose_delegate_prompt, which omits the engineer manager framing.
+    * Bounded append: pos is advanced only if the block fully fits, so a
+    * truncating render can never push pos past cap and corrupt later appends. */
+   {
+      char *identity = persona_identity_prose(&persona, scope_cwd);
+      if (identity && identity[0])
+         ctx_appendf(buf, cap, &pos, "\n# Persona\n%s\n", identity);
+      free(identity);
+   }
+
    if (persona.brief_text)
-      pos += (size_t)snprintf(buf + pos, cap - pos,
+      ctx_appendf(buf, cap, &pos,
                               "# Aimee Context\n%s"
                               "- Use `aimee session brief` to inspect the full startup brief.\n\n",
                               persona.brief_text);
    else
-      pos += (size_t)snprintf(
-          buf + pos, cap - pos,
+      ctx_appendf(
+          buf, cap, &pos,
           "# Aimee Context\n"
           "- Use `aimee index overview` or `aimee index find <symbol>` for indexed code "
           "lookup when it helps.\n"
@@ -243,8 +284,8 @@ static char *build_session_context(const char *client_cwd)
     * agent to aimee memory commands rather than a native store. `.md` memory is
     * retired — a write under the memory dir is intercepted into aimee and never
     * persisted as a file. */
-   pos += (size_t)snprintf(
-       buf + pos, cap - pos,
+   ctx_appendf(
+       buf, cap, &pos,
        "# Memory (use aimee, not your own store)\n"
        "- aimee is the single memory of record. Store durable memory with "
        "`aimee memory store <key> <content>`; set who-you-are / preferences with "
@@ -253,7 +294,7 @@ static char *build_session_context(const char *client_cwd)
        "- Memory `.md` files are RETIRED: a `.md` write UNDER YOUR MEMORY DIR is intercepted "
        "into aimee and not persisted as a file. Writing `.md` files elsewhere (docs, READMEs, "
        "notes) is unaffected — only the memory dir is intercepted.\n");
-   pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+   ctx_appendf(buf, cap, &pos, "\n");
 
    {
       char cwd[MAX_PATH_LEN];
@@ -278,7 +319,7 @@ static char *build_session_context(const char *client_cwd)
       free(skill_index);
    }
 
-   pos += (size_t)snprintf(buf + pos, cap - pos, "# Rules\n\n");
+   ctx_appendf(buf, cap, &pos, "# Rules\n\n");
 
    /* Aimee rules (from feedback/learning) */
 
@@ -292,7 +333,7 @@ static char *build_session_context(const char *client_cwd)
       while (*body == '\n')
          body++;
       if (*body)
-         pos += (size_t)snprintf(buf + pos, cap - pos, "%s\n", body);
+         ctx_appendf(buf, cap, &pos, "%s\n", body);
    }
    free(rules);
 
@@ -312,7 +353,7 @@ static char *build_session_context(const char *client_cwd)
             {
                if (pos + disc.bytes_used + 2 < cap)
                {
-                  pos += (size_t)snprintf(buf + pos, cap - pos, "%s\n", disc.rendered);
+                  ctx_appendf(buf, cap, &pos, "%s\n", disc.rendered);
                }
             }
             context_discovery_free(&disc);
@@ -330,14 +371,14 @@ static char *build_session_context(const char *client_cwd)
       {
          if (!has_facts)
          {
-            pos += (size_t)snprintf(buf + pos, cap - pos, "# Key Facts\n");
+            ctx_appendf(buf, cap, &pos, "# Key Facts\n");
             has_facts = 1;
          }
-         pos += (size_t)snprintf(buf + pos, cap - pos, "- %s: %.300s\n", facts[i].key,
+         ctx_appendf(buf, cap, &pos, "- %s: %.300s\n", facts[i].key,
                                  facts[i].content);
       }
       if (has_facts)
-         pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+         ctx_appendf(buf, cap, &pos, "\n");
    }
 
    /* Open commitments + unresolved directives — phase-2-step-2 recall.
@@ -376,26 +417,25 @@ static char *build_session_context(const char *client_cwd)
       if (agent_load_config(&net_cfg) == 0 && net_cfg.network.ssh_entry[0])
       {
          agent_network_t *nw = &net_cfg.network;
-         pos += (size_t)snprintf(buf + pos, cap - pos, "# Network\nEntry: %s\n", nw->ssh_entry);
+         ctx_appendf(buf, cap, &pos, "# Network\nEntry: %s\n", nw->ssh_entry);
          if (nw->host_count > 0)
          {
-            pos += (size_t)snprintf(buf + pos, cap - pos, "Hosts (%d): ", nw->host_count);
+            ctx_appendf(buf, cap, &pos, "Hosts (%d): ", nw->host_count);
             int show = nw->host_count < 5 ? nw->host_count : 5;
             for (int i = 0; i < show && pos < cap - 128; i++)
-               pos += (size_t)snprintf(buf + pos, cap - pos, "%s%s (%s)", i > 0 ? ", " : "",
+               ctx_appendf(buf, cap, &pos, "%s%s (%s)", i > 0 ? ", " : "",
                                        nw->hosts[i].name, nw->hosts[i].ip);
             if (nw->host_count > show)
-               pos += (size_t)snprintf(buf + pos, cap - pos, " +%d more", nw->host_count - show);
-            pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+               ctx_appendf(buf, cap, &pos, " +%d more", nw->host_count - show);
+            ctx_appendf(buf, cap, &pos, "\n");
          }
          if (nw->network_count > 0)
          {
             for (int i = 0; i < nw->network_count && pos < cap - 128; i++)
-               pos +=
-                   (size_t)snprintf(buf + pos, cap - pos, "- %s: %s (%s)\n", nw->networks[i].name,
-                                    nw->networks[i].cidr, nw->networks[i].desc);
+               ctx_appendf(buf, cap, &pos, "- %s: %s (%s)\n", nw->networks[i].name,
+                           nw->networks[i].cidr, nw->networks[i].desc);
          }
-         pos += (size_t)snprintf(buf + pos, cap - pos,
+         ctx_appendf(buf, cap, &pos,
                                  "Run `aimee agent network` or `aimee --json agent network` "
                                  "for full host details.\n\n");
       }
@@ -444,17 +484,17 @@ static char *build_session_context(const char *client_cwd)
                {
                   if (!has_section)
                   {
-                     pos += (size_t)snprintf(buf + pos, cap - pos, "# Project Context (%s)\n",
+                     ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n",
                                              project_name);
                      has_section = 1;
                   }
                   const char *text =
                       like_rows[i].content[0] ? like_rows[i].content : like_rows[i].key;
                   if (like_rows[i].kind[0])
-                     pos += (size_t)snprintf(buf + pos, cap - pos, "- [%s] %.300s\n",
+                     ctx_appendf(buf, cap, &pos, "- [%s] %.300s\n",
                                              like_rows[i].kind, text);
                   else
-                     pos += (size_t)snprintf(buf + pos, cap - pos, "- %.300s\n", text);
+                     ctx_appendf(buf, cap, &pos, "- %.300s\n", text);
                }
             }
 
@@ -467,16 +507,16 @@ static char *build_session_context(const char *client_cwd)
             {
                if (!has_section)
                {
-                  pos += (size_t)snprintf(buf + pos, cap - pos, "# Project Context (%s)\n",
+                  ctx_appendf(buf, cap, &pos, "# Project Context (%s)\n",
                                           project_name);
                   has_section = 1;
                }
-               pos += (size_t)snprintf(buf + pos, cap - pos, "- %d files indexed, %d definitions\n",
+               ctx_appendf(buf, cap, &pos, "- %d files indexed, %d definitions\n",
                                        file_count, def_count);
             }
 
             if (has_section)
-               pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+               ctx_appendf(buf, cap, &pos, "\n");
          }
       }
    }
@@ -526,7 +566,7 @@ static char *build_session_context(const char *client_cwd)
          {
             char delblock[1024];
             persona_delegation_block(&persona, delblock, sizeof(delblock));
-            pos += (size_t)snprintf(buf + pos, cap - pos, "%s", delblock);
+            ctx_appendf(buf, cap, &pos, "%s", delblock);
          }
       }
    }
@@ -537,21 +577,20 @@ static char *build_session_context(const char *client_cwd)
       db1_agent_log_display_t rows[5];
       int n = db1_agent_log_list_recent(rows, 5);
       if (n > 0 && pos < cap - 256)
-         pos += (size_t)snprintf(buf + pos, cap - pos, "# Recent Delegations\n");
+         ctx_appendf(buf, cap, &pos, "# Recent Delegations\n");
       for (int i = 0; i < n && pos < cap - 256; i++)
       {
          const char *drole = rows[i].role[0] ? rows[i].role : "?";
          const char *dagent = rows[i].agent_name[0] ? rows[i].agent_name : "?";
          if (rows[i].success)
-            pos +=
-                (size_t)snprintf(buf + pos, cap - pos, "- [%s] via %s: OK (%d turns, %d tools)\n",
-                                 drole, dagent, rows[i].turns, rows[i].tool_calls);
+            ctx_appendf(buf, cap, &pos, "- [%s] via %s: OK (%d turns, %d tools)\n", drole, dagent,
+                        rows[i].turns, rows[i].tool_calls);
          else
-            pos += (size_t)snprintf(buf + pos, cap - pos, "- [%s] via %s: FAILED (%.80s)\n", drole,
+            ctx_appendf(buf, cap, &pos, "- [%s] via %s: FAILED (%.80s)\n", drole,
                                     dagent, rows[i].error[0] ? rows[i].error : "unknown");
       }
       if (n > 0 && pos < cap - 256)
-         pos += (size_t)snprintf(buf + pos, cap - pos, "\n");
+         ctx_appendf(buf, cap, &pos, "\n");
    }
 
    /* Workspace project descriptions and style guides */

--- a/src/headers/persona.h
+++ b/src/headers/persona.h
@@ -82,6 +82,15 @@ extern "C"
    char *persona_compose_delegate_prompt(const char *name, const char *cwd,
                                          const char *base_prompt);
 
+   /* Render a persona's own prose (the "You are ..." body, role, workflow, and
+    * any work queue), with the first %s replaced by `cwd`, for injection at the
+    * start of a primary session — uniformly for every persona. Heap-owned
+    * (caller frees) or NULL if the persona has none. Built-ins use their
+    * canonical code prose (prompts.c); custom personas use their file
+    * `## Persona` body. Never used for delegate prompts (see
+    * persona_compose_delegate_prompt). */
+   char *persona_identity_prose(const persona_t *p, const char *cwd);
+
    /* Resolve persona `name`. Lookup: project file -> user file -> built-in.
     * Unknown name with no file falls back to the engineer built-in and still
     * returns 0 (callers always get a usable persona). Fills *out; heap fields

--- a/src/persona.c
+++ b/src/persona.c
@@ -460,6 +460,25 @@ static char *persona_apply_cwd(const char *text, const char *cwd)
    return out;
 }
 
+char *persona_identity_prose(const persona_t *p, const char *cwd)
+{
+   if (!p)
+      return NULL;
+   /* Return the persona's COMPLETE identity prose. Built-ins keep their full
+    * block in code (prompts.c) — a built-in's file `## Persona` may be only a
+    * thin one-liner, with the rest of the framing in sibling sections that
+    * load_file does not extract — so a built-in uses its enum prose; a custom
+    * persona uses its file `## Persona` body. */
+   if (p->builtin)
+   {
+      const char *prose = prompt_persona_text(aimee_mode_from_string(p->name));
+      return (prose && prose[0]) ? persona_apply_cwd(prose, cwd) : NULL;
+   }
+   if (p->persona_text && p->persona_text[0])
+      return persona_apply_cwd(p->persona_text, cwd);
+   return NULL;
+}
+
 char *persona_compose_delegate_prompt(const char *name, const char *cwd, const char *base_prompt)
 {
    const char *base = base_prompt ? base_prompt : "";

--- a/src/tests/test_persona.c
+++ b/src/tests/test_persona.c
@@ -93,6 +93,40 @@ int main(void)
       free(contrarian);
    }
 
+   /* --- primary-session persona prose is uniform per persona (engineer is not
+    * special): each persona's own prose, cwd-substituted; and the engineer
+    * manager framing never leaks into a delegate prompt. --- */
+   {
+      /* Engineer (the default persona) carries the manager/work-queue framing. */
+      persona_t eng;
+      assert(persona_load(NULL, "engineer", &eng) == 0);
+      char *eid = persona_identity_prose(&eng, "/tmp/session-cwd");
+      assert(eid);
+      assert(strstr(eid, "You are the MANAGER") != NULL); /* manager role */
+      assert(strstr(eid, "## Work Queue") != NULL);       /* work queue */
+      assert(strstr(eid, "/tmp/session-cwd") != NULL);    /* %s -> cwd */
+      assert(strstr(eid, "%s") == NULL);
+      free(eid);
+      persona_free(&eng);
+
+      /* Another built-in gets its OWN prose the same way — no engineer framing
+       * bleeds in, confirming there is no engineer special-case. */
+      persona_t arch;
+      assert(persona_load(NULL, "architect", &arch) == 0);
+      char *aid = persona_identity_prose(&arch, "/tmp/session-cwd");
+      assert(aid && aid[0]);
+      assert(strstr(aid, "You are the MANAGER") == NULL);
+      assert(strstr(aid, "## Work Queue") == NULL);
+      free(aid);
+      persona_free(&arch);
+
+      /* Primary-only: an engineer delegate prompt must never contain it. */
+      char *deleg = persona_compose_delegate_prompt("engineer", "/tmp/x", NULL);
+      assert(deleg);
+      assert(strstr(deleg, "You are the MANAGER") == NULL);
+      free(deleg);
+   }
+
    /* --- unknown name falls back to engineer --- */
    {
       persona_t p;

--- a/webchat/settings.go
+++ b/webchat/settings.go
@@ -34,6 +34,50 @@ var settingsAllow = []settingField{
 	{Key: "kb_fusion_mode", Label: "Retrieval fusion mode", Type: "enum",
 		Options: []string{"rrf", "static_alpha", "dynamic_alpha"},
 		Help:    "How lexical + dense KB search results are blended. dynamic_alpha adapts the weight per query (boost exact-token queries); rrf is the safe default."},
+	// Options are filled at request time from the installed personas (see the
+	// GET handler); the static list stays empty so it never drifts from the
+	// engine's persona registry.
+	{Key: "default_persona", Label: "Default persona", Type: "enum",
+		Help: "Persona a new session starts in when none is explicitly set (defaults to engineer)."},
+}
+
+// personaNames lists the persona names the Default-persona selector offers, from
+// aimee-server's /v1/personas (built-ins + any custom personas). The bool is
+// true only when the live list was actually retrieved; on failure it returns
+// (["engineer"], false) so the selector still renders while callers can tell the
+// list is authoritative or a fallback (update-time validation relies on this).
+func (s *server) personaNames(ctx context.Context) ([]string, bool) {
+	st, data, err := s.v1Request(ctx, http.MethodGet, "/v1/personas", nil)
+	if err != nil || st != http.StatusOK {
+		return []string{"engineer"}, false
+	}
+	var d struct {
+		Personas []struct {
+			Name string `json:"name"`
+		} `json:"personas"`
+	}
+	if json.Unmarshal(data, &d) != nil {
+		return []string{"engineer"}, false
+	}
+	names := make([]string, 0, len(d.Personas))
+	for _, p := range d.Personas {
+		if p.Name != "" {
+			names = append(names, p.Name)
+		}
+	}
+	if len(names) == 0 {
+		return []string{"engineer"}, false
+	}
+	return names, true
+}
+
+func containsString(xs []string, v string) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+	return false
 }
 
 func settingAllowed(key string) bool {
@@ -73,6 +117,16 @@ func (s *server) handleSettings(w http.ResponseWriter, r *http.Request) {
 					val = d.Value
 				}
 			}
+			if f.Key == "default_persona" {
+				f.Options, _ = s.personaNames(ctx)
+				// Always keep the currently-saved value selectable, even if the
+				// persona list is a fallback or has since dropped it — otherwise
+				// the dropdown would render an invalid selection or silently
+				// overwrite it on the next save.
+				if cur, ok := val.(string); ok && cur != "" && !containsString(f.Options, cur) {
+					f.Options = append([]string{cur}, f.Options...)
+				}
+			}
 			out = append(out, outField{settingField: f, Value: val})
 		}
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"fields": out})
@@ -89,6 +143,18 @@ func (s *server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		if !settingAllowed(req.Key) {
 			writeJSONError(w, http.StatusForbidden, "setting not allowed")
 			return
+		}
+		// default_persona is a dynamic enum: reject an unknown persona when the
+		// live list is authoritative (so a direct API caller can't bypass the
+		// dropdown). When the persona service is unavailable we allow the write
+		// and rely on the engine resolving an unknown name to the engineer
+		// fallback, rather than blocking a legitimate change on a transient outage.
+		if req.Key == "default_persona" {
+			name, _ := req.Value.(string)
+			if names, ok := s.personaNames(ctx); ok && !containsString(names, name) {
+				writeJSONError(w, http.StatusBadRequest, "unknown persona")
+				return
+			}
 		}
 		body, _ := json.Marshal(map[string]interface{}{"key": req.Key, "value": req.Value})
 		st, data, err := s.v1Request(ctx, http.MethodPost, "/v1/config/set", body)


### PR DESCRIPTION
## What

Two operator-facing changes plus a safety hardening, all reviewed via `aimee` roundtable (3 rounds → **SIGN-OFF**).

### 1. Inject the active persona's prose at session start (uniform for every persona)
`build_session_context()` now emits a `# Persona` block containing the **resolved active persona's own prose**, for **every** persona. Engineer is not special — it is simply the default persona; its manager/work-queue framing rides along because it is the orchestrator persona.
- New `persona_identity_prose()` renders a persona's full prose (built-ins from the `prompts.c` enum, custom personas from their file `## Persona`), with `%s` → cwd.
- The framing reaches the **primary only** — delegates still compose via `persona_compose_delegate_prompt()`, which omits it (covered by a new test).

### 2. Configurable default persona in the webchat Settings UI
`default_persona` is added to the Settings allowlist as an enum whose options come from the live `/v1/personas` list (built-ins + custom). Reads/writes go through the existing `config.show`/`config.set`; no frontend change (the panel renders any enum as a `<select>`).
- GET keeps the currently-saved value selectable even if the live/fallback list omits it.
- POST rejects an unknown persona **only when the live list is authoritative**; otherwise it allows the write and relies on the engine's engineer fallback.

### 3. Buffer-safety hardening of `build_session_context()`
Shared `ctx_appendf()` bounded-append helper replaces the unchecked `pos += snprintf(buf+pos, cap-pos, ...)` pattern throughout (and in `session_append_scope_section()`): it keeps `pos <= cap` and never leaves a truncated append in the buffer. Buffer raised to 64 KiB.

## Testing
- `unit-test-persona` (extended: engineer prose has manager+cwd; architect prose has neither; engineer *delegate* has no manager text) — pass.
- `unit-test-session-start-util`, `unit-test-prompts`, `unit-test-config` — pass.
- Full server build (`-Werror`) + `webchat` `go build`/`go vet` — clean.

## Validation-pending
`build_session_context()` runs server-side and the server is deployed remotely, so the rendered session-start context was **not** exercised end-to-end locally — verified by reading + compile + unit tests. Runtime confirmation is pending deployment.