### PR TITLE
feat(trigger): mode field on trigger rules (autonomous by default)

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -11,6 +11,16 @@ Thin-client + credential hardening, the client owns the working tree; agent
 credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).
 
+- **Trigger `mode` (autonomous by default)**: `trigger_rules` now take a `mode`
+  field selecting how a triggered run executes — `autonomous` (the default: the
+  autonomy scheduler drives it hands-off, right for "merging a proposal *is* the
+  approval") or `interactive` (file it and park for a human to drive in the
+  webchat). The `proposals` source now files its runs `autonomous` by default, so
+  a merged proposal builds out end-to-end without further sign-off. In-flight
+  human gates remain a property of the *workflow* you name (`gate.human` /
+  `with_user`), independent of the trigger's `mode`. See
+  [WORKFLOWS.md § Triggers](WORKFLOWS.md#triggers).
+
 - **Dashboard overhaul + Logs tab**: the web UI **Dashboard** is now a customizable
   grid of **server-incurred** metric panels: delegations, per-role metrics, token/cost,
   guardrail actions, agents, active sessions, readiness, plus opt-in panels (success by

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -237,6 +237,88 @@ the API):
 - Server `/v1/workflow/*` ([server_workflow_api.c](../src/server/server_workflow_api.c))
   exposes the def read/author surface and the work-item read surface.
 
+## Triggers
+
+A **trigger** is the *first step* that starts a workflow run — the thing that
+decides *when* a run begins and *which* workflow it begins. A trigger is
+deliberately generic: the event that fires it can be autonomous (a new proposal
+appears in a repo, a schedule elapses, a webhook arrives) or a person (clicking
+**Run** on the Workflow Actions tab is itself a trigger). The intent is a small
+set of generic trigger sources that you wire to whatever workflow you want —
+the trigger starts the run; what happens next is entirely the workflow's design.
+
+Triggers are configured as a `trigger_rules` list in `aimee.yaml`. Each rule
+names a **source** (what fires it), how the filed run should execute (**mode**),
+and the **pipeline** (which workflow, in which repo):
+
+```yaml
+trigger:
+  max_concurrent: 1          # cap on concurrently-executing triggered runs
+
+trigger_rules:
+  - source: proposals              # scan a git repo for new proposals
+    event: docs/proposals/pending  # repo-relative dir to watch (this is the default)
+    schedule: main                 # git ref/branch to read (default: auto-detected origin HEAD)
+    mode: autonomous               # autonomous (default) | interactive
+    pipeline:
+      template: build              # the workflow to start for each new proposal
+      workspace: /srv/repos/myproject   # absolute path of the git repo to scan
+```
+
+### Rule fields
+
+| Field | Meaning |
+| --- | --- |
+| `source` | What fires the rule: `proposals`, `cron`, or a webhook source. |
+| `event` | Source-specific match. For `proposals`, the repo-relative directory to scan (default `docs/proposals/pending`). |
+| `schedule` | For `cron`, the cron expression. For `proposals`, the git ref/branch to read (default: auto-detected `origin` HEAD, then `HEAD`). |
+| `mode` | Execution mode stamped on the filed work item — see below. `autonomous` (default) or `interactive`. |
+| `pipeline.template` | The workflow to start (any saved workflow name, e.g. `build`). |
+| `pipeline.workspace` | Absolute path of the git repo the run operates in (and, for `proposals`, the repo to scan). |
+| `pipeline.max_spend_usd` | Optional per-run spend cap. |
+
+### `mode`: autonomous vs. interactive
+
+`mode` selects **how the run executes once the trigger files it**, independent
+of the workflow it names:
+
+- **`autonomous`** (the default) — the autonomy scheduler drives the run
+  hands-off, start to finish. Use this when the trigger event *is* the approval:
+  merging a proposal into the watched branch, for example, is itself the decision
+  to build it, so no further human sign-off is wanted.
+- **`interactive`** — the run is filed and then **parks for a human** to drive in
+  the webchat (Workflow Actions tab). Use this when someone should review before
+  anything runs.
+
+This is distinct from **gating inside the workflow**. A `gate.human` step (or an
+`author.proposal` node marked `with_user`) parks *that step* for a person
+regardless of `mode` — it is a property of the workflow you build, not of the
+trigger. So you can compose either shape: an `autonomous` trigger into a
+workflow that still pauses at a human gate partway through, or an `interactive`
+trigger into a fully hands-off workflow. Pick the trigger `mode` for the
+*start* decision; put in-flight gates in the *workflow*.
+
+### The `proposals` source
+
+The `proposals` source turns "a proposal was committed" into a workflow run. On
+each scan (roughly once a minute) it lists the proposal directory at the
+configured git ref, and for every proposal it has not seen before it:
+
+1. materializes the proposal's content under `$AIMEE_HOME/triggers/proposals/`,
+2. files exactly one work item on `pipeline.template`, in `pipeline.workspace`,
+   with the configured `mode` (default `autonomous`),
+3. de-duplicates by proposal, so re-scanning the same tree never files twice.
+
+Merging a new proposal onto the watched branch is therefore all it takes to
+kick off a build — and with `mode: autonomous`, that build runs to its PR
+without further intervention (subject to `trigger.max_concurrent` and any
+`max_spend_usd` cap). Point the rule at a different `template` to run any other
+workflow you have authored.
+
+> The filed run still enters through the same capped, audited intake as every
+> other run (see [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)); the trigger
+> supplies the proposal text, so the *propose → … → PR* framing below still holds.
+
 ## Current limitations
 
 These are real today and worth knowing before you lean on workflows:

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -241,7 +241,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`skills`** — _Skill subsystem (capability, curator, dispatch, eval, manage, review; nested objects)._ Keys: `capability`, `curator`, `dispatch`, `eval`, `manage`, `review`
 - **`transport`** — _Transport tweaks (cache-aware rewrite)._ Keys: `cache_aware_rewrite`
 - **`trigger`** — _Trigger listener (auth, concurrency)._ Keys: `auth_token`, `max_concurrent`
-- **`trigger_rules`** — _Trigger rule definitions (array of objects)._ Keys: `event`, `pipeline`, `schedule`, `source`
+- **`trigger_rules`** — _Trigger rule definitions (array of objects)._ Keys: `event`, `mode`, `pipeline`, `schedule`, `source`
 - **`workspaces`** — _Workspace definitions (array of objects)._ Keys: `head`, `path`, `provider`, `remote`
 - **`worktree_gc`** — `enabled`, `max_age_days`
 

--- a/src/config_trigger.c
+++ b/src/config_trigger.c
@@ -9,6 +9,7 @@
  * trigger_rules:
  *   - source: "github-webhook"   # valid sources include github-webhook, cron, proposals
  *     event: "push"
+ *     mode: "autonomous"         # "autonomous" (default) | "interactive"
  *     pipeline:
  *       template: "ci"
  *       workspace: "/ws/myproject"
@@ -18,6 +19,13 @@
  * repo to scan, pipeline.template is the workflow name, event is the
  * repo-relative proposal dir (default docs/proposals/pending), and schedule is
  * the git ref/branch (default auto-detect).
+ *
+ * mode selects how the filed work item runs, independent of the workflow it
+ * names: "autonomous" (the default) lets the autonomy scheduler drive the run
+ * hands-off — appropriate when the trigger event *is* the approval (e.g. a
+ * merged proposal); "interactive" files the item and parks it for a human to
+ * drive in the webchat. Gating BEYOND this (e.g. a gate.human step) is a
+ * property of the workflow the rule names, not of the trigger.
  */
 
 #include "aimee.h"
@@ -261,6 +269,18 @@ int config_parse_trigger(config_t *cfg, const cJSON *root)
       if (schedule && cJSON_IsString(schedule) && schedule->valuestring[0])
          snprintf(r->schedule, sizeof(r->schedule), "%s", schedule->valuestring);
 
+      const cJSON *mode = cJSON_GetObjectItemCaseSensitive(rule, "mode");
+      if (mode && cJSON_IsString(mode) && mode->valuestring[0])
+      {
+         if (strcmp(mode->valuestring, "autonomous") != 0 &&
+             strcmp(mode->valuestring, "interactive") != 0)
+            issues += config_issue(
+                "trigger_rules[].mode expected \"autonomous\" or \"interactive\", got \"%s\"",
+                mode->valuestring);
+         else
+            snprintf(r->mode, sizeof(r->mode), "%s", mode->valuestring);
+      }
+
       const cJSON *pipeline = cJSON_GetObjectItemCaseSensitive(rule, "pipeline");
       if (pipeline && cJSON_IsObject(pipeline))
       {
@@ -305,7 +325,7 @@ void config_save_trigger(const config_t *cfg, cJSON *root)
       }
    }
 
-   /* trigger_rules[] — {source,event,schedule,pipeline:{template,workspace,max_spend_usd}} */
+   /* trigger_rules[] — {source,event,schedule,mode,pipeline:{template,workspace,max_spend_usd}} */
    if (cfg->trigger_rule_count > 0)
    {
       cJSON *rules = cJSON_AddArrayToObject(root, "trigger_rules");
@@ -321,6 +341,8 @@ void config_save_trigger(const config_t *cfg, cJSON *root)
             cJSON_AddStringToObject(o, "event", r->event);
          if (r->schedule[0])
             cJSON_AddStringToObject(o, "schedule", r->schedule);
+         if (r->mode[0])
+            cJSON_AddStringToObject(o, "mode", r->mode);
          if (r->pipeline_template[0] || r->workspace[0] || r->max_spend_usd != 0.0)
          {
             cJSON *p = cJSON_AddObjectToObject(o, "pipeline");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -194,6 +194,7 @@ typedef struct
 #define TRIGGER_RULE_MAX_SCHEDULE 64
 #define TRIGGER_RULE_MAX_TEMPLATE 128
 #define TRIGGER_RULE_MAX_WS       256
+#define TRIGGER_RULE_MAX_MODE     32
 #define TRIGGER_RULES_MAX         32
 
 typedef struct
@@ -203,6 +204,10 @@ typedef struct
    char schedule[TRIGGER_RULE_MAX_SCHEDULE]; /* cron expression (source=cron only) */
    char pipeline_template[TRIGGER_RULE_MAX_TEMPLATE];
    char workspace[TRIGGER_RULE_MAX_WS];
+   char mode[TRIGGER_RULE_MAX_MODE]; /* work-item mode the rule files: "autonomous"
+                                      * (default — the run advances hands-off) or
+                                      * "interactive" (parks for a human to drive in
+                                      * the webchat). Empty => "autonomous". */
    double max_spend_usd;
 } trigger_rule_t;
 

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -242,10 +242,12 @@ static int schedule_matches(const char *expr, const struct tm *tm)
 /* Proposals trigger source                                             */
 /* ------------------------------------------------------------------ */
 
-/* source="proposals" overloads trigger_rule_t without adding fields:
+/* source="proposals" overloads trigger_rule_t's shared fields:
  * workspace = absolute repo path (required), pipeline_template = workflow name
  * (required), event = repo-relative proposal dir (default docs/proposals/pending),
- * schedule = git ref/branch (default auto-detected origin HEAD, then HEAD). */
+ * schedule = git ref/branch (default auto-detected origin HEAD, then HEAD), and
+ * mode = the filed work item's execution mode ("autonomous" default, or
+ * "interactive" to park it for a human in the webchat). */
 typedef struct
 {
    char sha[41];
@@ -540,8 +542,12 @@ static void scan_proposals(const trigger_rule_t *rule)
       free(blob);
 
       char id[80] = "", err[256] = "";
-      rc = wfe_work_item_create(rule->pipeline_template, rule->workspace, proposal_path,
-                                "proposals", id, err, sizeof(err));
+      /* mode drives whether the autonomy scheduler advances the run hands-off
+       * ("autonomous", the default when the rule omits it) or the item parks for
+       * a human to drive in the webchat ("interactive"). */
+      const char *mode = rule->mode[0] ? rule->mode : "autonomous";
+      rc = wfe_work_item_create(rule->pipeline_template, rule->workspace, proposal_path, mode, id,
+                                err, sizeof(err));
       if (rc == 0 && id[0])
          aimee_log(LOG_INFO, "trigger.sched", "filed proposal workflow=%s repo=%s sha=%s id=%s",
                    rule->pipeline_template, rule->workspace, entries[i].sha, id);

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -314,6 +314,7 @@ int main(void)
       snprintf(cfg.trigger_rules[0].event, sizeof(cfg.trigger_rules[0].event), "push:main");
       snprintf(cfg.trigger_rules[0].pipeline_template,
                sizeof(cfg.trigger_rules[0].pipeline_template), "review");
+      snprintf(cfg.trigger_rules[0].mode, sizeof(cfg.trigger_rules[0].mode), "interactive");
       cfg.trigger_rules[0].max_spend_usd = 2.5;
       cfg.cron_job_count = 1;
       snprintf(cfg.cron_jobs[0].id, sizeof(cfg.cron_jobs[0].id), "nightly");
@@ -508,6 +509,7 @@ int main(void)
       assert(strcmp(cfg2.trigger_rules[0].source, "github-webhook") == 0);
       assert(strcmp(cfg2.trigger_rules[0].event, "push:main") == 0);
       assert(strcmp(cfg2.trigger_rules[0].pipeline_template, "review") == 0);
+      assert(strcmp(cfg2.trigger_rules[0].mode, "interactive") == 0);
       assert(cfg2.trigger_rules[0].max_spend_usd > 2.4 &&
              cfg2.trigger_rules[0].max_spend_usd < 2.6);
       assert(cfg2.cron_job_count == 1);

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -743,10 +743,12 @@ static void test_scan_proposals_end_to_end(void)
    assert(strcmp(g_lstree_ref, "origin/testing") == 0);
    size_t pl = strlen(g_lstree_pathspec);
    assert(pl > 0 && g_lstree_pathspec[pl - 1] == '/');
-   /* Correct launch args: workflow=pipeline_template, repo=workspace, mode=proposals. */
+   /* Correct launch args: workflow=pipeline_template, repo=workspace, and — with
+    * the rule's mode left empty — the default execution mode "autonomous" (so the
+    * autonomy scheduler drives the run hands-off). */
    assert(strcmp(g_created[0].wf, "build") == 0);
    assert(strcmp(g_created[0].repo, "/repo/aimee") == 0);
-   assert(strcmp(g_created[0].mode, "proposals") == 0);
+   assert(strcmp(g_created[0].mode, "autonomous") == 0);
    /* proposal_path is <home>/triggers/proposals/<blob-sha>.md and holds the blob. */
    char exp0[700], exp1[700];
    snprintf(exp0, sizeof exp0, "%s/triggers/proposals/%s.md", g_home, g_blobs[0].sha);
@@ -773,6 +775,37 @@ static void test_scan_proposals_end_to_end(void)
    assert(strcmp(g_created[2].wf, "build") == 0);
 
    printf("  PASS: test_scan_proposals_end_to_end\n");
+}
+
+/* An explicit mode on the rule is passed through verbatim to the filed work item
+ * (here "interactive" -> the run parks for a human instead of advancing hands-off). */
+static void test_scan_proposals_honors_explicit_mode(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-mode-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# Proposal A\n");
+   g_nblobs = 1;
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+   snprintf(rule.event, sizeof rule.event, "docs/proposals/pending");
+   snprintf(rule.mode, sizeof rule.mode, "interactive");
+
+   scan_proposals(&rule);
+
+   assert(g_ncreated == 1);
+   assert(strcmp(g_created[0].mode, "interactive") == 0);
+
+   printf("  PASS: test_scan_proposals_honors_explicit_mode\n");
 }
 
 static void test_scan_proposals_requires_workspace_and_workflow(void)
@@ -918,6 +951,7 @@ int main(void)
    test_parse_ls_tree_empty_and_garbage();
    test_parse_ls_tree_buffer_cap();
    test_scan_proposals_end_to_end();
+   test_scan_proposals_honors_explicit_mode();
    test_scan_proposals_requires_workspace_and_workflow();
    test_scan_proposals_custom_event_and_schedule();
    test_scan_proposals_rejects_unsafe_ref_and_path();


### PR DESCRIPTION
## What

Adds a generic **`mode`** field to `trigger_rules`, selecting how a triggered run executes — independent of the workflow it names:

- **`autonomous`** (default) — the autonomy scheduler drives the run hands-off, start to finish. Right for "merging a proposal *is* the approval."
- **`interactive`** — the run is filed and parks for a human to drive in the webchat.

## Why

The `proposals` trigger source previously stamped a non-canonical `mode="proposals"` on the work items it filed. The autonomy scheduler only drives `mode="autonomous"` items (`wfe_scheduler.c`), so triggered runs were **filed but never advanced** — they sat idle until a human drove them in the GUI. Discovered while trying the proposals trigger end-to-end on the .254 deployment: a merged proposal filed a `build` work item that parked at `draft` with `$0` cost and no delegate ever spawned.

Triggers are meant to be generic *first steps* that start a workflow; whether a run is hands-off or human-gated should be a deliberate choice, not an accident of a hardcoded mode string. `mode` makes that choice explicit and defaults it to autonomous.

In-flight human gates remain a property of the **workflow** you name (`gate.human` / an `author.proposal` node's `with_user`), independent of the trigger's `mode`. So you can compose either shape — an autonomous trigger into a workflow that still pauses at a human gate, or an interactive trigger into a fully hands-off workflow.

## Changes

- **config** (`config.h`, `config_trigger.c`): parse + validate (`autonomous` | `interactive`) + serialize `trigger_rules[].mode`; round-trips through `config_save`.
- **scheduler** (`trigger_scheduler.c`): file work items with `rule->mode`, defaulting to `autonomous` when omitted.
- **tests** (`test_trigger.c`, `test_config.c`): `scan_proposals` default (`autonomous`) + explicit `interactive` passthrough; config save/reload round-trip of `mode`.
- **docs**: new **Triggers** section in `WORKFLOWS.md` (concept, rule fields, `mode` semantics, the `proposals` source), a `WHATS_NEW` entry, and the regenerated `configuration.md` reference.

## Verification

- `unit-test-trigger` — green (incl. new `test_scan_proposals_honors_explicit_mode` and the updated default→`autonomous` assertion).
- `unit-test-config` — green (incl. `mode` round-trip).
- `config_trigger.c` compiles clean under `-Werror`.
- Docs regenerated via `make -C src docs-gen` (only the intended `trigger_rules` key delta).