### PR TITLE
refactor(llm): one model-less aimee-llm image, tier fetched at runtime

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -6,9 +6,7 @@
 #   aimee-kb         (Dockerfile)             ghcr.io/<owner>/aimee-kb
 #   aimee-server-kb  (Dockerfile.combined)    ghcr.io/<owner>/aimee-server-kb
 #   aimee-embedder   (Dockerfile.embedder)    ghcr.io/<owner>/aimee-embedder (+ -4b)
-#   aimee-kb-cpu        (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-kb-cpu
-#   aimee-kb-gpu-small  (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-kb-gpu-small
-#   aimee-kb-gpu-mid    (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-kb-gpu-mid
+#   aimee-llm        (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-llm (model-less; amd64)
 #   aimee-css-render (deploy/css-render/Dockerfile) ghcr.io/<owner>/aimee-css-render
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
@@ -81,25 +79,13 @@ jobs:
           # baked in. Pair with embedding_dim: 2560 (see docs). Default (above) is
           # the 0.6b embedder + 400m reranker.
           - { name: aimee-embedder-4b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1" }
-          # The unified aimee-kb container (one Vulkan llama.cpp + the gateway serving
-          # embed+rerank+synth, models baked in). FOUR tiers differ only by the SYNTH
-          # model + its runtime profile (embed/rerank identical within a class):
-          #   aimee-kb-cpu       defaults: 0.6B emb + ettin-68m + gemma-4-E4B (CPU)
-          #   aimee-kb-gpu-small 4B/400m + Gemma-4-12B qat-UD-Q4_K_XL (dense, FA+K8V4; 16GB)
-          #   aimee-kb-gpu-mid   4B/400m + Gemma-4-26B-A4B qat-UD-Q4_K_XL (MoE, 4B active,
-          #                      FA+K8V4; ~14GB fits 24GB fully-resident → N_CPU_MOE=0;
-          #                      GGUF pinned by HF rev+sha256; SLOTS=2 → deploy 2×128K)
-          #   aimee-kb-gpu-large IDENTICAL to gpu-mid (same 26B-A4B GGUF/profile) but
-          #                      SLOTS=4 for 32GB cards → deploy 4×256K (each agent the
-          #                      full native 262144 window; Gemma's windowed KV keeps
-          #                      even 4×256K under ~28.5GiB, validated vs the 24GB mid card)
-          # gpu-small/mid/large share the 2560-dim embedder so a KB is portable across the
-          # synth swap. amd64 GPU host runs the x64 Vulkan binary; NGL set at deploy.
-          - { name: aimee-kb-cpu, dockerfile: Dockerfile.aimee-llm }
-          - { name: aimee-kb-gpu-small, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF\nSYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=9586f3257bc62bd179767241c7ec0f66bc2a314a\nSYNTH_SHA256=cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165\nSYNTH_FA=on" }
-          - { name: aimee-kb-gpu-mid, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF\nSYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c\nSYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=0\nSYNTH_SLOTS=2" }
-          # gpu-large: same GGUF as gpu-mid, only SYNTH_SLOTS=4 (24GB→32GB card headroom).
-          - { name: aimee-kb-gpu-large, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF\nSYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c\nSYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e\nSYNTH_FA=on\nSYNTH_MOE=1\nSYNTH_N_CPU_MOE=0\nSYNTH_SLOTS=4" }
+          # The unified aimee-llm container (one Vulkan llama.cpp + the gateway serving
+          # embed+rerank+synth). MODEL-LESS: one image for every tier — the tier
+          # (cpu/small/mid/large) is chosen at RUNTIME via AIMEE_LLM_TIER and the models
+          # are downloaded on first boot, so there are no baked GGUFs and no build-args.
+          # amd64 only: the llama.cpp Vulkan release binary is x64-only (skipped on arm64
+          # below). NGL is set at deploy.
+          - { name: aimee-llm, dockerfile: Dockerfile.aimee-llm }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -123,21 +109,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The aimee-llm images bake multi-GB GGUFs (the GPU tier ~11 GB: Qwen3-4B +
-      # gemma-12B) through a torch conversion stage that downloads them AND a runtime
-      # stage that re-COPYs them — a transient footprint of ~40 GB. That overran even
-      # a cleaned ~38 GB free on / (the GPU leg failed with "No space left on device").
-      # So for the llm legs: (1) reclaim ALL the preinstalled toolchains we don't use,
-      # and (2) point docker's storage at the runner's larger /mnt disk (~65 GB free)
-      # BEFORE the buildx builder is created, so buildkit writes its layers there. Both
-      # are scoped to the llm legs — the C images build fine without paying this cost.
-      - name: Free disk space (aimee-llm + combined legs)
-        # The combined (aimee-server-kb) image now bundles the aimee-llm CPU
-        # runtime + ~5.5 GB of baked GGUFs (COPYd from aimee-llm-cpu), so it needs
-        # the same disk headroom as the llm legs.
-        if: startsWith(matrix.image.name, 'aimee-kb-') || matrix.image.name == 'aimee-server-kb'
+      # The combined (aimee-server-kb) image bundles the aimee-llm runtime + webchat
+      # + code-server, a large transient build footprint. It no longer bakes GGUFs
+      # (the model-less aimee-llm downloads them at runtime), but reclaiming the
+      # preinstalled toolchains keeps its build comfortably within a stock runner.
+      # The model-less aimee-llm image is small and needs none of this.
+      - name: Free disk space (combined leg)
+        if: matrix.image.name == 'aimee-server-kb'
         run: |
-          echo "before:"; df -h / /mnt
+          echo "before:"; df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
             /opt/hostedtoolcache /usr/local/.ghcup /usr/local/share/boost \
             /usr/share/swift /usr/local/share/powershell /usr/local/lib/node_modules \
@@ -145,25 +125,15 @@ jobs:
           sudo apt-get clean || true
           echo "after:"; df -h /
 
-      - name: Move docker storage to /mnt (aimee-llm + combined legs)
-        if: startsWith(matrix.image.name, 'aimee-kb-') || matrix.image.name == 'aimee-server-kb'
-        run: |
-          sudo systemctl stop docker docker.socket || true
-          sudo mkdir -p /mnt/docker
-          printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
-          sudo systemctl start docker || sudo systemctl start docker.socket docker || true
-          docker info -f 'docker root: {{ .DockerRootDir }}' || true
-          df -h / /mnt
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push by digest
         id: build
-        # aimee-kb-gpu-mid/large (Gemma-4-26B-A4B, ~14GB) are amd64-only: arm64 would bake a
-        # non-runnable x64 Vulkan binary and double the build/disk cost. Skip them on arm64
-        # -> the merge job emits a single-arch amd64 manifest (it tolerates count>=1).
-        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
+        # aimee-llm is amd64-only: the llama.cpp Vulkan release binary is x64-only, so an
+        # arm64 image would ship a non-runnable binary. Skip it on arm64 -> the merge job
+        # emits a single-arch amd64 manifest (it tolerates count>=1).
+        if: ${{ !(matrix.image.name == 'aimee-llm' && matrix.platform.arch == 'arm64') }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context || '.' }}
@@ -177,23 +147,21 @@ jobs:
           # would blow the 10 GB GHA cache budget and evict the (small, high-reuse)
           # C-image caches, defeating the purpose. The embedder's real win is the
           # runtime model fetch (embedder-runtime-fetch-autodim proposal), not the
-          # layer cache. Same exclusion for the aimee-kb-* tiers: they BAKE multi-GB
-          # GGUFs (Qwen3-Embedding + gemma) into the image, so caching those layers
-          # would likewise blow the 10 GB GHA budget and evict the C-image caches.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-kb-gpu-large' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-kb-cpu' && matrix.image.name != 'aimee-kb-gpu-small' && matrix.image.name != 'aimee-kb-gpu-mid' && matrix.image.name != 'aimee-kb-gpu-large' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          # layer cache. aimee-llm is now model-less (no baked GGUFs) so it is small
+          # and cached like the C images.
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
-          # Bundled aimee-llm in the combined image is AMD64-ONLY: the llama.cpp
-          # runtime baked into aimee-kb-cpu is the x64 Vulkan binary, so the arm64
-          # combined leg builds lean (WITH_LLM=0) and points at an external llm.
-          # CAVEAT (ordering): the amd64 combined leg COPYs from aimee-llm-cpu:latest (the existing image; the
-          # — i.e. the PREVIOUS release's llm image, since this run's llm tags aren't
-          # manifest-merged until after the build matrix. The gateway/model contract
-          # is stable across releases, but for a release that materially changes the
-          # llm image, combined->aimee-kb-cpu migration is a follow-up once it publishes). Re-run the leg or promote first (or re-run this leg).
-          # Digest-pinned ordering (combined `needs` the llm digest) is the follow-up.
+          # Bundled aimee-llm in the combined image is AMD64-ONLY: the llama.cpp Vulkan
+          # runtime is the x64 binary, so the arm64 combined leg builds lean (WITH_LLM=0)
+          # and points at an external llm. CAVEAT (ordering): the amd64 combined leg
+          # COPYs the runtime from aimee-llm:latest — i.e. the PREVIOUS release's llm
+          # image, since this run's llm tags aren't manifest-merged until after the build
+          # matrix. The gateway contract is stable across releases (and the image is now
+          # model-less, so there are no baked GGUFs to drift); digest-pinned ordering
+          # (combined `needs` the llm digest) is the follow-up.
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_WEBCHAT=1
@@ -201,18 +169,18 @@ jobs:
             ${{ matrix.image.reranker_arg }}
             ${{ matrix.image.extra_args }}
             ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'amd64') && 'WITH_LLM=1' || '' }}
-            ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'amd64') && format('AIMEE_LLM_CPU_IMAGE=ghcr.io/{0}/aimee-llm-cpu:latest', env.OWNER) || '' }}
+            ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'amd64') && format('AIMEE_LLM_CPU_IMAGE=ghcr.io/{0}/aimee-llm:latest', env.OWNER) || '' }}
             ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'arm64') && 'WITH_LLM=0' || '' }}
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
+        if: ${{ !(matrix.image.name == 'aimee-llm' && matrix.platform.arch == 'arm64') }}
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.image.name }}-${{ matrix.platform.arch }}"
 
       - name: Upload digest
-        if: ${{ !((matrix.image.name == 'aimee-kb-gpu-mid' || matrix.image.name == 'aimee-kb-gpu-large') && matrix.platform.arch == 'arm64') }}
+        if: ${{ !(matrix.image.name == 'aimee-llm' && matrix.platform.arch == 'arm64') }}
         uses: actions/upload-artifact@v4
         with:
           name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}
@@ -227,7 +195,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-kb-cpu, aimee-kb-gpu-small, aimee-kb-gpu-mid, aimee-kb-gpu-large, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-llm, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/.github/workflows/publish-llm-testing.yml
+++ b/.github/workflows/publish-llm-testing.yml
@@ -1,19 +1,16 @@
-# Build the unified aimee-kb container on `testing` and publish it under the
+# Build the unified aimee-llm container on `testing` and publish it under the
 # DELIBERATELY non-semver `:testing` tag (+ `:testing-<sha>`), mirroring how
 # publish-testing.yml ships aimee-server-kb. This lets .254 (the GPU deploy
-# target) pull a tested-but-unreleased aimee-kb image WITHOUT promoting to main;
+# target) pull a tested-but-unreleased aimee-llm image WITHOUT promoting to main;
 # versioned + `:latest` publishing stays owned by main (auto-release.yml ->
 # publish-images.yml).
 #
-# Kept SEPARATE from publish-testing.yml on purpose: aimee-kb bakes multi-GB
-# GGUFs (no layer cache — see publish-images.yml) and rebuilding it on every
-# server-code push would be wasteful. So it triggers ONLY on the aimee-kb
-# sources (the Dockerfile + the gateway/supervisor scripts).
-#
-# Tiers built every push: aimee-kb-cpu + aimee-kb-gpu-small (Gemma). The big MoE
-# tiers aimee-kb-gpu-mid and aimee-kb-gpu-large (both Gemma-4-26B-A4B, ~14GB; they
-# differ ONLY in baked SYNTH_SLOTS, 2 vs 4) are dispatch-only. amd64 only (the .254
-# deploy target); the release pipeline owns multi-arch.
+# ONE model-less image now (aimee-llm): the tier (cpu/small/mid/large) is chosen
+# at RUNTIME via AIMEE_LLM_TIER and the models are downloaded on first boot, so
+# there are no baked GGUFs and no per-tier build matrix — a single small image
+# serves every tier. The pre-converted ettin rerank artifacts it fetches are
+# published separately by publish-rerank-artifacts.yml. amd64 only (the llama.cpp
+# Vulkan release binary is x64-only; the release pipeline owns any multi-arch).
 name: Publish testing aimee-llm
 
 on:
@@ -26,15 +23,6 @@ on:
       - "scripts/aimee-llm-supervisor.sh"
       - ".github/workflows/publish-llm-testing.yml"
   workflow_dispatch:
-    inputs:
-      build_kb_gpu_mid:
-        description: "Also build the aimee-kb-gpu-mid (Gemma-4-26B-A4B synth, ~14GB, SLOTS=2)"
-        type: boolean
-        default: false
-      build_kb_gpu_large:
-        description: "Also build the aimee-kb-gpu-large (same 26B-A4B synth, ~14GB, SLOTS=4, 32GB card)"
-        type: boolean
-        default: false
 
 concurrency:
   group: publish-llm-testing-${{ github.ref }}
@@ -47,16 +35,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # cpu tier = Dockerfile defaults (0.6B emb + ettin-68m + gemma-4-E4B).
-        # gpu-small overrides to the 4B/400m + Gemma-4-12B qat-UD synth (FA+K8V4).
-        # gpu-mid (Gemma-4-26B-A4B synth, ~14GB) is the dispatch-only job below — an
-        # uncached build every push is near-zero-signal (model + llama.cpp rarely change).
-        tier:
-          - { name: aimee-kb-cpu, dockerfile: Dockerfile.aimee-llm, extra_args: "" }
-          - { name: aimee-kb-gpu-small, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF\nSYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf\nSYNTH_REVISION=9586f3257bc62bd179767241c7ec0f66bc2a314a\nSYNTH_SHA256=cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165\nSYNTH_FA=on" }
     steps:
       - uses: actions/checkout@v4
 
@@ -76,87 +54,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # The GPU tier bakes ~11 GB of GGUFs (Qwen3-4B + gemma-12B) plus a torch
-      # conversion stage, overrunning the ~14 GB free on a stock runner. Reclaim
-      # the preinstalled toolchains we don't use before building.
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
-          sudo docker image prune --all --force || true
-          df -h /
-
-      - name: Build and push ${{ matrix.tier.name }}:testing
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.tier.dockerfile }}
-          platforms: linux/amd64
-          push: true
-          provenance: false
-          # No layer cache: the baked multi-GB model layers would blow the GHA
-          # cache budget (same rationale as publish-images.yml). Dockerfile.aimee-llm
-          # takes no AIMEE_VERSION/WITH_WEBCHAT arg — only the tier model overrides.
-          build-args: |
-            ${{ matrix.tier.extra_args }}
-          tags: |
-            ghcr.io/${{ env.OWNER }}/${{ matrix.tier.name }}:testing
-            ghcr.io/${{ env.OWNER }}/${{ matrix.tier.name }}:testing-${{ env.SHA7 }}
-
-  # aimee-kb-gpu-mid (Gemma-4-26B-A4B synth, ~14GB MoE): NOT built on every push —
-  # the model + llama.cpp rarely change, so an uncached download+build per push is
-  # near-zero-signal (option (d), 2026-07-01 follow-up roundtable). Runs ONLY on a
-  # manual workflow_dispatch with build_kb_gpu_mid=true. Keeps the docker data-root on
-  # /mnt — the image's transient build footprint overruns / — plus a df pre-flight
-  # that fails fast rather than dying mid-build with 'no space left'.
-  build-kb-gpu-mid:
-    if: github.event_name == 'workflow_dispatch' && inputs.build_kb_gpu_mid
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Normalize owner + short sha
-        run: |
-          echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-          echo "SHA7=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Reclaim toolchains AND relocate docker's data-root to the larger /mnt disk
-      # BEFORE buildx is created, so buildkit writes the ~14GB model layers there
-      # (mirrors publish-images.yml's aimee-kb-leg fix, commit f26cf76).
-      - name: Free disk + move docker storage to /mnt
-        run: |
-          echo "before:"; df -h / /mnt
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
-          sudo docker image prune --all --force || true
-          sudo systemctl stop docker docker.socket || true
-          sudo mkdir -p /mnt/docker
-          printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
-          sudo systemctl start docker || true
-          echo "after:"; df -h / /mnt
-
-      # Fail fast if /mnt can't hold the image's transient footprint instead of dying
-      # mid-build with ENOSPC after the model download. (Threshold left at 80GB for
-      # ample headroom; the ~14GB Gemma synth needs less than the prior 22GB Qwen.)
-      - name: Pre-flight disk check
-        run: |
-          avail=$(df --output=avail -BG /mnt | tail -1 | tr -dc '0-9')
-          echo "/mnt available: ${avail}GB"
-          if [ "${avail:-0}" -lt 80 ]; then
-            echo "::error::/mnt has only ${avail}GB free; need >=80GB for the kb-gpu-mid build"; exit 1
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push aimee-kb-gpu-mid:testing
+      # The image is model-less (no baked GGUFs), so it fits a stock runner and can
+      # use the gha layer cache — no disk gymnastics needed.
+      - name: Build and push aimee-llm:testing
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -164,91 +64,8 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: false
-          build-args: |
-            EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF
-            EMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf
-            RERANK_REPO=cross-encoder/ettin-reranker-400m-v1
-            SYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF
-            SYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
-            SYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c
-            SYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e
-            SYNTH_FA=on
-            SYNTH_MOE=1
-            SYNTH_N_CPU_MOE=0
-            SYNTH_SLOTS=2
+          cache-from: type=gha,scope=aimee-llm-amd64
+          cache-to: type=gha,mode=max,scope=aimee-llm-amd64
           tags: |
-            ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing
-            ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-mid:testing-${{ env.SHA7 }}
-
-  # aimee-kb-gpu-large (Gemma-4-26B-A4B synth, ~14GB MoE): byte-identical to gpu-mid
-  # except baked SYNTH_SLOTS=4 (24GB→32GB card headroom; deploy at 4×256K). Same
-  # dispatch-only + /mnt-relocation + df pre-flight rationale as build-kb-gpu-mid.
-  build-kb-gpu-large:
-    if: github.event_name == 'workflow_dispatch' && inputs.build_kb_gpu_large
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Normalize owner + short sha
-        run: |
-          echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
-          echo "SHA7=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
-
-      - name: Log in to ghcr.io
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Reclaim toolchains AND relocate docker's data-root to the larger /mnt disk
-      # BEFORE buildx is created, so buildkit writes the ~14GB model layers there
-      # (mirrors publish-images.yml's aimee-kb-leg fix, commit f26cf76).
-      - name: Free disk + move docker storage to /mnt
-        run: |
-          echo "before:"; df -h / /mnt
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
-          sudo docker image prune --all --force || true
-          sudo systemctl stop docker docker.socket || true
-          sudo mkdir -p /mnt/docker
-          printf '{ "data-root": "/mnt/docker" }\n' | sudo tee /etc/docker/daemon.json
-          sudo systemctl start docker || true
-          echo "after:"; df -h / /mnt
-
-      # Fail fast if /mnt can't hold the image's transient footprint instead of dying
-      # mid-build with ENOSPC after the model download.
-      - name: Pre-flight disk check
-        run: |
-          avail=$(df --output=avail -BG /mnt | tail -1 | tr -dc '0-9')
-          echo "/mnt available: ${avail}GB"
-          if [ "${avail:-0}" -lt 80 ]; then
-            echo "::error::/mnt has only ${avail}GB free; need >=80GB for the kb-gpu-large build"; exit 1
-          fi
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push aimee-kb-gpu-large:testing
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.aimee-llm
-          platforms: linux/amd64
-          push: true
-          provenance: false
-          build-args: |
-            EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF
-            EMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf
-            RERANK_REPO=cross-encoder/ettin-reranker-400m-v1
-            SYNTH_REPO=unsloth/gemma-4-26B-A4B-it-qat-GGUF
-            SYNTH_FILE=gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
-            SYNTH_REVISION=02749a7b272109255a4c559a80894d3d9777574c
-            SYNTH_SHA256=dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e
-            SYNTH_FA=on
-            SYNTH_MOE=1
-            SYNTH_N_CPU_MOE=0
-            SYNTH_SLOTS=4
-          tags: |
-            ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-large:testing
-            ghcr.io/${{ env.OWNER }}/aimee-kb-gpu-large:testing-${{ env.SHA7 }}
+            ghcr.io/${{ env.OWNER }}/aimee-llm:testing
+            ghcr.io/${{ env.OWNER }}/aimee-llm:testing-${{ env.SHA7 }}

--- a/.github/workflows/publish-rerank-artifacts.yml
+++ b/.github/workflows/publish-rerank-artifacts.yml
@@ -1,0 +1,83 @@
+# Convert the ettin rerankers ONCE and publish them as GitHub release assets, so
+# the model-less aimee-llm image can `wget` the pre-converted encoder GGUF + Dense
+# head at runtime (the ST score head doesn't survive GGUF conversion, so the
+# gateway applies it — see scripts/aimee_llm_rerank_head.py). This is the ONLY
+# piece of the aimee-llm model set that isn't a plain HF GGUF pull; embed + synth
+# come straight from Hugging Face at container start.
+#
+# Dispatch-only + rarely run: the ettin models + the llama.cpp converter change
+# almost never, and the outputs are content-addressed by the SHA256SUMS the
+# supervisor verifies. Re-run only when bumping the reranker or the converter.
+#
+# Assets uploaded to the `rerank-artifacts-v1` release (names the supervisor
+# depends on — scripts/aimee-llm-supervisor.sh, RERANK_ASSET_BASE):
+#   rerank-ettin-68m.gguf   rerank-ettin-68m.head.npz
+#   rerank-ettin-400m.gguf  rerank-ettin-400m.head.npz
+#   SHA256SUMS
+name: Publish rerank artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to publish the converted rerank artifacts to"
+        type: string
+        default: rerank-artifacts-v1
+
+concurrency:
+  group: publish-rerank-artifacts-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  convert:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag || 'rerank-artifacts-v1' }}
+      HF_HUB_DISABLE_TELEMETRY: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Torch (CPU wheel) + the conversion deps. This mirrors the old Dockerfile
+      # `modelprep` stage exactly — it is the same conversion, just hoisted to CI so
+      # the runtime image needs neither torch nor the converter.
+      - name: Install conversion deps
+        run: |
+          python -m pip install --quiet torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install --quiet transformers safetensors numpy gguf sentencepiece protobuf huggingface_hub
+
+      # convert_hf_to_gguf.py + gguf-py from a recent llama.cpp (ModernBert supported).
+      - name: Clone llama.cpp (converter)
+        run: git clone --depth 1 https://github.com/ggml-org/llama.cpp /tmp/llama
+
+      # Convert BOTH ettin tiers: encoder -> GGUF (f16) + Dense head -> head.npz.
+      # 68m backs the cpu tier; 400m backs small/mid/large.
+      - name: Convert ettin rerankers
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          python scripts/convert_ettin_rerank.py 68m  cross-encoder/ettin-reranker-68m-v1  out /tmp/llama
+          python scripts/convert_ettin_rerank.py 400m cross-encoder/ettin-reranker-400m-v1 out /tmp/llama
+          ( cd out && sha256sum rerank-ettin-*.gguf rerank-ettin-*.head.npz > SHA256SUMS )
+          echo "== artifacts =="; ls -l out; cat out/SHA256SUMS
+
+      # Create the release if it doesn't exist, then upload (clobber to allow re-runs).
+      - name: Publish to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 \
+            || gh release create "$RELEASE_TAG" \
+                 --title "aimee-llm rerank artifacts" \
+                 --notes "Pre-converted ettin reranker encoder GGUFs + Dense heads fetched by aimee-llm at runtime."
+          gh release upload "$RELEASE_TAG" \
+            out/rerank-ettin-68m.gguf out/rerank-ettin-68m.head.npz \
+            out/rerank-ettin-400m.gguf out/rerank-ettin-400m.head.npz \
+            out/SHA256SUMS --clobber

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -66,11 +66,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # The combined (aimee-server-kb) image now bundles the aimee-llm CPU runtime
-      # + baked GGUFs (~5.5 GB), COPYd from the prebuilt aimee-llm-cpu:testing
-      # image — so reclaim the preinstalled toolchains we don't use to make room
-      # for the pull + the larger output image. Scoped to the combined leg (the
-      # split server/kb images stay lean and build fine without this).
+      # The combined (aimee-server-kb) image bundles the aimee-llm runtime, COPYd from
+      # the prebuilt model-less aimee-llm:testing image (no baked GGUFs — the bundled
+      # supervisor downloads the cpu tier at runtime) — reclaim the preinstalled
+      # toolchains we don't use to keep the webchat/code-server build within the
+      # runner. Scoped to the combined leg (the split server/kb images stay lean).
       - name: Free disk space (aimee-server-kb leg)
         if: matrix.image.name == 'aimee-server-kb'
         run: |
@@ -99,15 +99,15 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-amd64
           # WITH_WEBCHAT bundles the browser UI (default for server/combined; the
           # aimee-kb image ignores it). WITH_LLM=1 + AIMEE_LLM_CPU_IMAGE make the
-          # combined image bundle the aimee-llm CPU runtime by COPYing from the
-          # prebuilt aimee-llm-cpu:testing (published by publish-llm-testing.yml,
-          # which must have run first). The split server/kb Dockerfiles don't
-          # declare these args (a harmless "not consumed" warning).
+          # combined image bundle the aimee-llm runtime by COPYing from the prebuilt
+          # model-less aimee-llm:testing (published by publish-llm-testing.yml, which
+          # must have run first). The split server/kb Dockerfiles don't declare these
+          # args (a harmless "not consumed" warning).
           build-args: |
             AIMEE_VERSION=testing-${{ env.SHA7 }}
             WITH_WEBCHAT=1
             WITH_LLM=1
-            AIMEE_LLM_CPU_IMAGE=ghcr.io/${{ env.OWNER }}/aimee-llm-cpu:testing
+            AIMEE_LLM_CPU_IMAGE=ghcr.io/${{ env.OWNER }}/aimee-llm:testing
           tags: |
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing-${{ env.SHA7 }}

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -43,7 +43,11 @@ ENV LD_LIBRARY_PATH=/opt/llama/lib:/opt/llama PATH=/opt/llama:/opt/llama/bin:$PA
 
 COPY scripts/aimee_llm_gateway.py scripts/aimee_llm_rerank_head.py /opt/aimee/
 COPY scripts/aimee-llm-supervisor.sh /opt/aimee/supervisor.sh
-RUN chmod +x /opt/aimee/supervisor.sh
+# Create /models as a REAL directory (not just a VOLUME mountpoint): a bare
+# `VOLUME /models` on an otherwise-empty path leaves no directory layer, so a
+# downstream `COPY --from=aimee-llm /models/` (the combined image bundles this
+# runtime) fails with "/models: not found". The explicit mkdir gives it a layer.
+RUN chmod +x /opt/aimee/supervisor.sh && mkdir -p /models
 
 # Persistent model cache: the supervisor downloads the tier's GGUFs here on first
 # boot. Mount a volume so restarts (and tier switches) don't re-pull multi-GB models.

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -1,96 +1,27 @@
 # The unified aimee-llm container: one llama.cpp (Vulkan) runtime + the aimee-llm
-# gateway, serving embeddings, reranking, and synthesis from BAKED-IN GGUFs.
-# Replaces the torch embedder + the standalone llama.cpp `llm` container.
+# gateway, serving embeddings, reranking, and synthesis. Replaces the torch
+# embedder + the standalone llama.cpp `llm` container.
 #
-# Two published images (operator-directed: models baked in, not runtime-fetched —
-# turnkey, reproducible, no HF dependency at run time):
-#   aimee-kb-cpu       (defaults): Qwen3-Embedding-0.6B + ettin-68m + gemma-4-E4B
-#   aimee-kb-gpu-small/mid/large (build args): 4B + ettin-400m + gemma-4-12B (small,
-#     16GB) OR gemma-4-26B-A4B (mid=24GB SLOTS=2 / large=32GB SLOTS=4 — same GGUF)
+# MODEL-LESS by design: the image ships with NO GGUFs baked in. At container
+# start the supervisor resolves AIMEE_LLM_TIER and DOWNLOADS + configures that
+# tier's models into the /models volume (download-once, sha256-verified):
+#   (unset)/cpu  Qwen3-Embedding-0.6B + ettin-68m  + gemma-4-E4B      (dense, CPU)
+#   small        Qwen3-Embedding-4B   + ettin-400m + gemma-4-12B      (dense, GPU)
+#   mid          Qwen3-Embedding-4B   + ettin-400m + gemma-4-26B-A4B  (MoE, SLOTS=2)
+#   large        SAME 26B-A4B as mid but SLOTS=4 (32GB card)
+# One published image for every tier; the tier table lives in the supervisor.
+# Embed+synth are plain GGUF pulls from HF; the ettin reranker is a pre-converted
+# encoder GGUF + Dense head fetched from a GitHub release (the ST score head
+# doesn't survive GGUF conversion — see benchmarks/results/unified-llm/
+# P2-serving-validation.md — so the gateway applies it; the conversion runs once
+# in .github/workflows/publish-rerank-artifacts.yml, not at build or run time).
+#
 # The llama.cpp binary is the VENDOR-AGNOSTIC Vulkan build (one binary for AMD/
-# Nvidia/Intel); GPU is selected at runtime by AIMEE_LLM_NGL (CPU image defaults 0).
-#
-# The reranker is ettin served as ENCODER + a gateway-side Dense head (the ST score
-# head doesn't survive GGUF conversion — see benchmarks/results/unified-llm/
-# P2-serving-validation.md): convert the ettin encoder to GGUF and keep the head
-# safetensors; the gateway applies the head.
+# Nvidia/Intel); GPU is selected at runtime by AIMEE_LLM_NGL (defaults 0 = CPU).
 
 ARG LLAMA_TAG=b9775
-ARG EMBED_REPO=Qwen/Qwen3-Embedding-0.6B-GGUF
-ARG EMBED_FILE=Qwen3-Embedding-0.6B-f16.gguf
-ARG EMBED_POOLING=last
-ARG RERANK_REPO=cross-encoder/ettin-reranker-68m-v1
-ARG SYNTH_REPO=ggml-org/gemma-4-E4B-it-GGUF
-ARG SYNTH_FILE=gemma-4-E4B-it-Q4_K_M.gguf
-# Supply-chain pins for the synth GGUF (optional; set per tier in CI). When
-# SYNTH_SHA256 is set the build verifies the download and FAILS on mismatch — a
-# compromised/MITM'd HF upload can't ship. SYNTH_REVISION pins the HF commit.
-ARG SYNTH_REVISION=main
-ARG SYNTH_SHA256=
-# Per-tier synth runtime profile (baked -> ENV; the supervisor reads these). Defaults
-# = the CPU/gemma tier (dense, no FA/MoE). The gpu-mid (gemma-4-26B-A4B MoE) tier overrides.
-ARG SYNTH_FA=off
-ARG SYNTH_KV_K=q8_0
-ARG SYNTH_KV_V=q4_0
-ARG SYNTH_MOE=0
-ARG SYNTH_MOE_LAYERS=40
-ARG SYNTH_N_CPU_MOE=0
-ARG SYNTH_SLOTS=1
 
-# ---- stage 1: prepare the baked models (convert ettin encoder + fetch GGUFs) ----
-FROM python:3.12-slim AS modelprep
-ARG LLAMA_TAG
-ARG EMBED_REPO
-ARG EMBED_FILE
-ARG RERANK_REPO
-ARG SYNTH_REPO
-ARG SYNTH_FILE
-ARG SYNTH_REVISION
-ARG SYNTH_SHA256
-ENV PIP_NO_CACHE_DIR=1 HF_HUB_DISABLE_TELEMETRY=1
-RUN apt-get update && apt-get install -y --no-install-recommends git wget ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-RUN pip install --quiet torch --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --quiet transformers safetensors numpy gguf sentencepiece protobuf huggingface_hub
-# convert script + gguf-py from a recent llama.cpp (ModernBert supported)
-RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /llama
-WORKDIR /out
-# Ettin reranker: download the sentence-transformers repo, convert the ENCODER to
-# GGUF, and keep the Dense head (2_Dense/3_LayerNorm/4_Dense) for the gateway.
-RUN python - <<'PY'
-import os
-from huggingface_hub import snapshot_download
-p = snapshot_download(os.environ["RERANK_REPO"], local_dir="/tmp/ettin")
-print("ettin ->", p)
-PY
-RUN cd /llama && PYTHONPATH=/llama/gguf-py python convert_hf_to_gguf.py /tmp/ettin \
-        --outfile /out/rerank-encoder.gguf --outtype f16 \
-    && mkdir -p /out/rerank-head
-# Bake the Dense head as a numpy .npz so the slim runtime needs only numpy (no
-# safetensors). Keys match EttinRerankHead.from_npz (W2/W4/b4/gamma/beta).
-RUN python - <<'PY'
-import numpy as np
-from safetensors.numpy import load_file
-e = "/tmp/ettin"
-W2 = load_file(f"{e}/2_Dense/model.safetensors")["linear.weight"]
-d4 = load_file(f"{e}/4_Dense/model.safetensors")
-ln = load_file(f"{e}/3_LayerNorm/model.safetensors")
-np.savez("/out/rerank-head/head.npz", W2=W2, W4=d4["linear.weight"], b4=d4["linear.bias"],
-         gamma=ln["norm.weight"], beta=ln["norm.bias"])
-print("head.npz written")
-PY
-# Embedder + synth GGUFs. Synth is pinned by revision (default main) with retries so
-# a transient blip on the large mid-tier pull doesn't kill the build, then sha256-
-# verified when SYNTH_SHA256 is set (build fails on a compromised/MITM'd upload).
-RUN wget -q -O /out/embed.gguf  "https://huggingface.co/${EMBED_REPO}/resolve/main/${EMBED_FILE}" \
-    && wget -q -c --tries=5 --timeout=30 --waitretry=10 -O /out/synth.gguf \
-        "https://huggingface.co/${SYNTH_REPO}/resolve/${SYNTH_REVISION}/${SYNTH_FILE}" \
-    && if [ -n "${SYNTH_SHA256}" ]; then \
-         echo "${SYNTH_SHA256}  /out/synth.gguf" | sha256sum -c - \
-         && echo "${SYNTH_SHA256}  synth.gguf" > /out/synth.sha256 ; \
-       fi
-
-# ---- stage 2: runtime — Vulkan llama.cpp + the gateway ----
+# ---- runtime — Vulkan llama.cpp + the gateway (no models, no torch) ----------
 # Base is Debian TRIXIE (Mesa 25.x): its RADV exposes VK_KHR_cooperative_matrix on
 # RDNA3 (gfx1100), so the prebuilt llama.cpp Vulkan binary uses the 7900 XTX WMMA
 # matrix cores. Bookworm's Mesa 22.3.6 predates RADV coopmat (added in Mesa 24.1) →
@@ -99,7 +30,6 @@ RUN wget -q -O /out/embed.gguf  "https://huggingface.co/${EMBED_REPO}/resolve/ma
 # NOTE: trixie's 64-bit time_t transition renames libcurl4 -> libcurl4t64.
 FROM debian:trixie-slim AS runtime
 ARG LLAMA_TAG
-ARG EMBED_POOLING
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl wget libgomp1 libcurl4t64 libvulkan1 mesa-vulkan-drivers \
         python3 python3-numpy \
@@ -114,41 +44,23 @@ ENV LD_LIBRARY_PATH=/opt/llama/lib:/opt/llama PATH=/opt/llama:/opt/llama/bin:$PA
 COPY scripts/aimee_llm_gateway.py scripts/aimee_llm_rerank_head.py /opt/aimee/
 COPY scripts/aimee-llm-supervisor.sh /opt/aimee/supervisor.sh
 RUN chmod +x /opt/aimee/supervisor.sh
-COPY --from=modelprep /out /models
 
-# Per-tier synth runtime profile baked from build-args (the supervisor reads these).
-ARG SYNTH_FA
-ARG SYNTH_KV_K
-ARG SYNTH_KV_V
-ARG SYNTH_MOE
-ARG SYNTH_MOE_LAYERS
-ARG SYNTH_N_CPU_MOE
-ARG SYNTH_SLOTS
-ARG SYNTH_REPO
-ARG SYNTH_FILE
-ARG SYNTH_SHA256
-LABEL org.aimee.kb.synth.model="${SYNTH_REPO}/${SYNTH_FILE}" \
-      org.aimee.kb.synth.sha256="${SYNTH_SHA256}"
-ENV AIMEE_LLM_SYNTH_FA=${SYNTH_FA} \
-    AIMEE_LLM_SYNTH_KV_K=${SYNTH_KV_K} \
-    AIMEE_LLM_SYNTH_KV_V=${SYNTH_KV_V} \
-    AIMEE_LLM_SYNTH_MOE=${SYNTH_MOE} \
-    AIMEE_LLM_SYNTH_MOE_LAYERS=${SYNTH_MOE_LAYERS} \
-    AIMEE_LLM_SYNTH_N_CPU_MOE=${SYNTH_N_CPU_MOE} \
-    AIMEE_LLM_SYNTH_SLOTS=${SYNTH_SLOTS}
+# Persistent model cache: the supervisor downloads the tier's GGUFs here on first
+# boot. Mount a volume so restarts (and tier switches) don't re-pull multi-GB models.
+VOLUME /models
 
-# Gateway + per-role serving config (the supervisor reads these).
+# Gateway + per-role serving wiring (the supervisor reads these; per-tier model
+# identity — embedder id, pooling, rerank head dir — is exported by the supervisor).
 ENV AIMEE_LLM_PORT=8080 \
     AIMEE_LLM_EMBED_URL=http://127.0.0.1:8081 \
     AIMEE_LLM_RERANK_URL=http://127.0.0.1:8082 \
     AIMEE_LLM_SYNTH_URL=http://127.0.0.1:8083 \
-    AIMEE_LLM_RERANK_HEAD=/models/rerank-head \
-    AIMEE_LLM_EMBED_MODEL=qwen3-embedding \
-    AIMEE_LLM_EMBED_POOLING=${EMBED_POOLING} \
     AIMEE_LLM_NGL=0 \
     PYTHONPATH=/opt/aimee
 WORKDIR /opt/aimee
 EXPOSE 8080
-HEALTHCHECK --interval=30s --timeout=5s --start-period=300s --retries=3 \
+# start-period is long: the first boot downloads the tier's models (multi-GB on the
+# GPU tiers) before /health is OK. The /models volume makes later boots fast.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=1200s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8080/health >/dev/null || exit 1
 ENTRYPOINT ["/opt/aimee/supervisor.sh"]

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -20,16 +20,17 @@ ARG WITH_WEBCHAT=1
 # default — the editor is a first-class feature; build with --build-arg
 # WITH_VSCODE=0 to omit it (saves ~100 MB).
 ARG WITH_VSCODE=1
-# WITH_LLM bundles the aimee-llm CPU runtime + baked GGUFs (the unified
-# llama.cpp/Vulkan gateway: embed + rerank + Tier-A synth) INTO this image, so
-# the combined container is self-contained — no external embedder/llm service.
-# ON by default; build with --build-arg WITH_LLM=0 for the lean server+kb image
-# that points at an external AIMEE_LLM_URL (saves ~5.5 GB of baked models). The
-# runtime is COPYd from the prebuilt aimee-llm-cpu image (AIMEE_LLM_CPU_IMAGE),
-# so this build does NOT re-download or re-convert models; that image must exist
-# (CI: aimee-llm-cpu:testing / release: :latest, published by publish-llm-*.yml).
+# WITH_LLM bundles the aimee-llm runtime (the unified llama.cpp/Vulkan gateway:
+# embed + rerank + Tier-A synth) INTO this image, so the combined container is
+# self-contained — no external embedder/llm service. The bundled LLM is the SAME
+# model-less aimee-llm image as everything else: its runtime (/opt/llama,
+# /opt/aimee) is COPYd here, and the supervisor DOWNLOADS the cpu-tier models to
+# /models on first boot (nothing is baked). ON by default; build --build-arg
+# WITH_LLM=0 for the lean server+kb image that points at an external AIMEE_LLM_URL.
+# AIMEE_LLM_CPU_IMAGE must exist (CI: aimee-llm:testing / release: :latest,
+# published by publish-llm-*.yml).
 ARG WITH_LLM=1
-ARG AIMEE_LLM_CPU_IMAGE=ghcr.io/rakuensoftware/aimee-llm-cpu:latest
+ARG AIMEE_LLM_CPU_IMAGE=ghcr.io/rakuensoftware/aimee-llm:latest
 FROM debian:bookworm-slim AS build
 
 # Union of the aimee-server and aimee-kb build deps: server links libsqlite3
@@ -113,11 +114,11 @@ FROM debian:bookworm-slim AS code-server-stage-0
 RUN mkdir -p /opt/codeserver/usr
 FROM code-server-stage-${WITH_VSCODE} AS code-server-stage
 
-# Optional bundled aimee-llm (CPU). "1" pulls the prebuilt aimee-llm-cpu image
-# (llama.cpp/Vulkan runtime at /opt/llama, the gateway + supervisor under
-# /opt/aimee, and the baked GGUFs under /models) — BuildKit only materializes the
-# stage the final selector references, so WITH_LLM=0 never pulls this multi-GB
-# image. "0" is an empty stage so the COPYs below are no-ops.
+# Optional bundled aimee-llm. "1" pulls the model-less aimee-llm image (the
+# llama.cpp/Vulkan runtime at /opt/llama and the gateway + supervisor under
+# /opt/aimee; /models is empty — the supervisor fetches the cpu tier on first
+# boot) — BuildKit only materializes the stage the final selector references, so
+# WITH_LLM=0 never pulls it. "0" is an empty stage so the COPYs below are no-ops.
 FROM ${AIMEE_LLM_CPU_IMAGE} AS llm-stage-1
 FROM debian:bookworm-slim AS llm-stage-0
 RUN mkdir -p /opt/llama /opt/aimee /models
@@ -149,11 +150,11 @@ RUN apt-get update \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
 
-# Bundled aimee-llm (CPU) runtime deps — only when WITH_LLM=1, so the lean image
-# isn't burdened with the Vulkan driver stack. The llama.cpp release binary is the
+# Bundled aimee-llm runtime deps — only when WITH_LLM=1, so the lean image isn't
+# burdened with the Vulkan driver stack. The llama.cpp release binary is the
 # vendor-agnostic Vulkan build (needs libvulkan1 + an ICD even at NGL=0 on CPU);
 # the gateway is python3 (already present) + numpy for the rerank head; the
-# supervisor is a bash script.
+# supervisor is a bash script that fetches the tier's GGUFs with wget on first boot.
 ARG WITH_LLM=1
 RUN if [ "$WITH_LLM" = "1" ]; then \
         apt-get update \
@@ -163,6 +164,7 @@ RUN if [ "$WITH_LLM" = "1" ]; then \
             libvulkan1 \
             mesa-vulkan-drivers \
             python3-numpy \
+            wget \
         && rm -rf /var/lib/apt/lists/*; \
     fi
 
@@ -217,17 +219,16 @@ ENV AIMEE_LLM_PORT=8742
 ENV AIMEE_BUNDLED_LLM=auto
 # Bundled aimee-llm gateway wiring — mirrors Dockerfile.aimee-llm's runtime ENV
 # (the COPY only brings the files, not that image's ENV). Without these the
-# gateway 503s on /rerank (no AIMEE_LLM_RERANK_HEAD) and /v1/chat/completions (no
-# AIMEE_LLM_SYNTH_URL); embeds would default-resolve but rerank/synth would fail.
-# The per-role llama-servers the supervisor starts are loopback 8081/8082/8083;
-# the gateway itself binds loopback only (same container/netns as the kb/server).
-# Harmless when WITH_LLM=0 (no gateway runs).
-ENV AIMEE_LLM_EMBED_URL=http://127.0.0.1:8081 \
+# gateway 503s on /v1/chat/completions (no AIMEE_LLM_SYNTH_URL). The supervisor
+# resolves AIMEE_LLM_TIER (cpu here), downloads that tier's models to /models on
+# first boot, and EXPORTS the per-tier AIMEE_LLM_RERANK_HEAD (/models/cpu/...) +
+# embed identity, so those aren't baked here. The per-role llama-servers the
+# supervisor starts are loopback 8081/8082/8083; the gateway itself binds loopback
+# only (same container/netns as the kb/server). Harmless when WITH_LLM=0.
+ENV AIMEE_LLM_TIER=cpu \
+    AIMEE_LLM_EMBED_URL=http://127.0.0.1:8081 \
     AIMEE_LLM_RERANK_URL=http://127.0.0.1:8082 \
     AIMEE_LLM_SYNTH_URL=http://127.0.0.1:8083 \
-    AIMEE_LLM_RERANK_HEAD=/models/rerank-head \
-    AIMEE_LLM_EMBED_MODEL=qwen3-embedding \
-    AIMEE_LLM_EMBED_POOLING=last \
     AIMEE_LLM_NGL=0 \
     AIMEE_LLM_BIND=127.0.0.1
 # Mirror tier (workspace-resource-plane §3): durable bare mirrors + worktrees on
@@ -255,15 +256,18 @@ VOLUME /var/lib/aimee-workspaces
 COPY --from=build /src/aimee-server /usr/local/bin/aimee-server
 COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
 
-# Bundled aimee-llm (CPU): the llama.cpp/Vulkan runtime, the unified gateway +
-# rerank head + supervisor, and the baked GGUFs. From the empty llm-stage-0 when
-# WITH_LLM=0 these are no-op copies of empty dirs (the entrypoint then finds no
+# Bundled aimee-llm: the llama.cpp/Vulkan runtime and the unified gateway +
+# supervisor. /models is empty (model-less image) — the supervisor downloads the
+# cpu tier there on first boot. From the empty llm-stage-0 when WITH_LLM=0 these
+# are no-op copies of empty dirs (the entrypoint then finds no
 # /opt/aimee/supervisor.sh and starts no gateway). The gateway files land in
 # /opt/aimee/ so the supervisor's hardcoded paths (PYTHONPATH=/opt/aimee,
 # /opt/aimee/aimee_llm_gateway.py) resolve unchanged.
 COPY --from=llm-stage /opt/llama/ /opt/llama/
 COPY --from=llm-stage /opt/aimee/ /opt/aimee/
 COPY --from=llm-stage /models/ /models/
+# Persist the bundled LLM's downloaded model cache (empty when WITH_LLM=0).
+VOLUME /models
 
 # kb sidecar clients (LLM/embedder access code the kb invokes via popen).
 COPY scripts/embed-remote.py scripts/rerank-remote.py scripts/llm-chat.py \
@@ -323,12 +327,13 @@ EXPOSE 8740 8743 8741 8443
 # 401 — which still proves the listener is up. Treat 200/401 as healthy; only a
 # connection failure ("000") is unhealthy. Mirrors Dockerfile.server.
 # start-period is generous: with the bundled aimee-llm (WITH_LLM=1) the entrypoint
-# waits for the gateway's cold multi-GB model load before starting the server, so
-# the server /v1 listener can take minutes to appear. A long start-period prevents
-# the orchestrator marking the container unhealthy during that load (a success
-# during the period still flips it healthy immediately, so the fast WITH_LLM=0
-# path is unaffected). Override AIMEE_LLM_WAIT_SECONDS to bound the entrypoint wait.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=660s --retries=5 \
+# waits for the gateway, which on FIRST boot DOWNLOADS the cpu tier's GGUFs before
+# it is healthy, so the server /v1 listener can take minutes to appear. A long
+# start-period prevents the orchestrator marking the container unhealthy during
+# that fetch (a success during the period still flips it healthy immediately, so
+# the fast WITH_LLM=0 path is unaffected). Later boots reuse the /models volume.
+# Override AIMEE_LLM_WAIT_SECONDS to bound the entrypoint wait.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=1200s --retries=5 \
     CMD curl -s -o /dev/null -w '%{http_code}' \
         http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$'
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1418,11 +1418,11 @@ the server. Four compose files ship, built from three images: `aimee-server`
 `aimee-server+kb` (`Dockerfile.combined`). Every stack also brings up a
 `pgvector/pgvector:pg16` Postgres, and the kb auto-applies its DB2 schema
 (`pg_trgm` and `vector` extensions plus tables) on first boot. The combined image
-bundles a CPU inference gateway (embeddings, reranking, and synthesis) from the
-`aimee-kb` image family, so embedding and reranking work with nothing external.
-The CPU tier serves Qwen3-Embedding-0.6B at 1024 dims; the GPU tiers
-(`aimee-kb-gpu-small` 16 GB, `aimee-kb-gpu-mid` 24 GB, `aimee-kb-gpu-large` 32 GB)
-serve Qwen3-Embedding-4B at 2560 dims.
+bundles the `aimee-llm` inference gateway (embeddings, reranking, and synthesis),
+which downloads its cpu-tier models on first boot, so embedding and reranking work
+with nothing external. The tier is chosen by `AIMEE_LLM_TIER`: `cpu` serves
+Qwen3-Embedding-0.6B at 1024 dims; the GPU tiers (`small` 16 GB, `mid` 24 GB,
+`large` 32 GB) serve Qwen3-Embedding-4B at 2560 dims.
 To run a standalone embedder or curator LLM instead of the bundled gateway, use
 the `external-llm` compose profile. Backends and tiers:
 [KB_LLM_BACKENDS.md](docs/KB_LLM_BACKENDS.md) and

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -111,6 +111,9 @@ services:
       # AIMEE_BUNDLED_LLM=off and uncomment the external-llm wiring below.
       AIMEE_LLM_URL: ${AIMEE_LLM_URL:-}
       AIMEE_BUNDLED_LLM: ${AIMEE_BUNDLED_LLM:-auto}
+      # Bundled LLM tier — cpu by default; the supervisor downloads it to /models
+      # on first boot. Raise to small/mid/large only with a GPU (AIMEE_LLM_NGL=99).
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
       # Override only for a GPU/external tier (the bundled CPU tier is 1024).
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       LLM_MODEL: ${LLM_MODEL:-gemma-3n-e4b}
@@ -161,10 +164,15 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 20s
+      # Long: the bundled aimee-llm downloads the cpu tier's GGUFs on first boot
+      # before the entrypoint brings up the server /v1 listener. Later boots reuse
+      # the aimee-combined-llm-models volume and come up fast.
+      start_period: 1200s
     volumes:
       - aimee-combined-home:/var/lib/aimee
       - aimee-combined-workspaces:/var/lib/aimee-workspaces
+      # Persist the bundled LLM's downloaded per-tier model cache.
+      - aimee-combined-llm-models:/models
 
   # External curator LLM — OFF by default (the bundled aimee-llm gateway already
   # serves synthesis at /v1). This standalone llama.cpp is only for the lean
@@ -197,3 +205,4 @@ volumes:
   aimee-combined-postgres:
   aimee-embedder-models:
   aimee-llm-models:
+  aimee-combined-llm-models:

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -89,6 +89,11 @@ services:
       # dependency (@rakuensoftware/smoothgui) is vendored under frontend/vendor/,
       # so the build needs NO credentials. Build --build-arg WITH_WEBCHAT=0 to
       # ship the server+kb services only.
+      args:
+        # The bundled LLM runtime is COPYd from this model-less aimee-llm image.
+        # Default to the published :latest (as in prod); a local build (e2e) can
+        # inject a freshly-built image so it doesn't depend on a published tag.
+        AIMEE_LLM_CPU_IMAGE: ${AIMEE_LLM_CPU_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     # Published combined image (built + pushed to ghcr on every merge to main).
     # `docker compose pull` fetches it so the standard deploy creates containers
     # from the merge-built image without a local build; `up --build` still
@@ -114,6 +119,10 @@ services:
       # Bundled LLM tier — cpu by default; the supervisor downloads it to /models
       # on first boot. Raise to small/mid/large only with a GPU (AIMEE_LLM_NGL=99).
       AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
+      # CI/dev: AIMEE_LLM_STUB=1 makes the bundled supervisor serve deterministic
+      # embed/rerank/synth with NO model download (off in prod, empty default).
+      AIMEE_LLM_STUB: ${AIMEE_LLM_STUB:-}
+      AIMEE_LLM_STUB_DIM: ${AIMEE_LLM_STUB_DIM:-}
       # Override only for a GPU/external tier (the bundled CPU tier is 1024).
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       LLM_MODEL: ${LLM_MODEL:-gemma-3n-e4b}

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -199,28 +199,35 @@ services:
 
   # Unified llama.cpp+Vulkan container — the kb's single LLM backend (embed +
   # rerank + synth on :8080). DEFAULT (the unified-llm cutover; the legacy
-  # embedder/llm services moved behind profiles). CPU tier by default; GPU =
-  # AIMEE_LLM_IMAGE=...-gpu + AIMEE_LLM_NGL=99 + /dev/dri (deploy/compose/aimee.gpu.yaml).
-  # Internal only — kb reaches it at aimee-llm:8080; auth-off (kb sends no bearer).
+  # embedder/llm services moved behind profiles). One model-less image; the tier is
+  # chosen at runtime via AIMEE_LLM_TIER (unset ≡ cpu) and models download to the
+  # /models volume on first boot. GPU = AIMEE_LLM_TIER=small|mid|large +
+  # AIMEE_LLM_NGL=99 + /dev/dri (deploy/compose/aimee.gpu.yaml). Internal only — kb
+  # reaches it at aimee-llm:8080; auth-off (kb sends no bearer).
   # CI/dev: AIMEE_LLM_DOCKERFILE=Dockerfile.aimee-llm-stub + AIMEE_LLM_STUB=1.
   aimee-llm:
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-kb-cpu:latest}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     build:
       context: .
       dockerfile: ${AIMEE_LLM_DOCKERFILE:-Dockerfile.aimee-llm}
     environment:
       AIMEE_LLM_PORT: "8080"
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
       AIMEE_LLM_STUB: ${AIMEE_LLM_STUB:-}
       AIMEE_LLM_STUB_DIM: ${AIMEE_LLM_STUB_DIM:-}
+    volumes:
+      # Persist the downloaded per-tier GGUFs so restarts don't re-fetch.
+      - aimee-llm-models:/models
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 300s
+      # Cold first boot downloads the tier's models; STUB mode skips it.
+      start_period: 1200s
 
 volumes:
   aimee-kb-home:

--- a/compose.yaml
+++ b/compose.yaml
@@ -156,35 +156,41 @@ services:
       # Long: the cold first boot downloads the multi-GB GGUF before /health is OK.
       start_period: 1200s
 
-  # Unified llama.cpp+Vulkan container: one image serving embed + rerank + synth
-  # from baked-in GGUFs behind the gateway (the /embed,/embed_batch,/rerank,
-  # /v1/chat/completions contract). The kb's single LLM backend (DEFAULT now —
-  # the unified-llm cutover; the legacy embedder/llm services moved behind
-  # profiles). CPU tier by default; GPU = AIMEE_LLM_IMAGE=...-gpu + AIMEE_LLM_NGL=99
-  # + a /dev/dri device (see deploy/compose/aimee.gpu.yaml). Internal only — the
-  # kb reaches it at aimee-llm:8080. Auth-off (the kb sends no bearer).
+  # Unified llama.cpp+Vulkan container: one model-less image serving embed + rerank
+  # + synth behind the gateway (the /embed,/embed_batch,/rerank,/v1/chat/completions
+  # contract). The kb's single LLM backend (DEFAULT now — the unified-llm cutover;
+  # the legacy embedder/llm services moved behind profiles). The tier is chosen at
+  # runtime via AIMEE_LLM_TIER (unset ≡ cpu) and the models download to the /models
+  # volume on first boot; GPU = AIMEE_LLM_TIER=small|mid|large + AIMEE_LLM_NGL=99 +
+  # a /dev/dri device (see deploy/compose/aimee.gpu.yaml). Internal only — the kb
+  # reaches it at aimee-llm:8080. Auth-off (the kb sends no bearer).
   # CI/dev: AIMEE_LLM_DOCKERFILE=Dockerfile.aimee-llm-stub + AIMEE_LLM_STUB=1
   # builds a tiny python-only stub (no llama.cpp / GGUFs) — see e2e-matrix.sh.
   aimee-llm:
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-kb-cpu:latest}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     build:
       context: .
       dockerfile: ${AIMEE_LLM_DOCKERFILE:-Dockerfile.aimee-llm}
     environment:
       AIMEE_LLM_PORT: "8080"
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
       # CI/dev stub (off in prod): deterministic embed/rerank/synth, no models.
       AIMEE_LLM_STUB: ${AIMEE_LLM_STUB:-}
       AIMEE_LLM_STUB_DIM: ${AIMEE_LLM_STUB_DIM:-}
+    volumes:
+      # Persist the downloaded per-tier GGUFs so restarts don't re-fetch.
+      - aimee-llm-models:/models
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
       interval: 10s
       timeout: 5s
       retries: 5
-      # Baked GGUFs load into RAM/VRAM (no download); generous for the GPU tier.
-      start_period: 300s
+      # Cold first boot downloads the tier's models; the /models volume makes later
+      # boots fast. STUB mode skips the download and flips healthy quickly.
+      start_period: 1200s
 
 volumes:
   aimee-kb-home:

--- a/deploy/compose/aimee.gpu.yaml
+++ b/deploy/compose/aimee.gpu.yaml
@@ -9,9 +9,13 @@
 # re-embed (the kb_meta drift guard refuses a stale mismatch).
 services:
   aimee-llm:
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-kb-gpu-small:latest}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     environment:
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-99}
+      # GPU tier: pick the synth by AIMEE_LLM_TIER (small=12B / mid=26B-A4B SLOTS=2 /
+      # large=26B-A4B SLOTS=4). small is the 16GB-safe default; the models download
+      # to /models on first boot. small/mid/large share the 2560-dim embedder.
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-small}
       # gemma-4-12b trains to 256K; the supervisor's default cap is a 16GB-safe 32K.
       # 128K is safe on the .254 card (RADV GFX1100 / 7900 XTX, 24560 MiB confirmed):
       # ~6.6GB Q4_K_M model + ~1.5GB embed/rerank + KV cache. gemma-4 uses
@@ -19,10 +23,10 @@ services:
       # 128K KV is dominated by the few global layers (~2-3GB), not all-layers-x-128K —
       # well under 24GB. 256K would still fit with KV-cache quantization if ever needed.
       #
-      # Tier picks (override AIMEE_LLM_IMAGE + AIMEE_LLM_SYNTH_CTX per card):
-      #   gpu-small (16GB): ...-gpu-small,  CTX 131072  (1 × 128K)
-      #   gpu-mid   (24GB): ...-gpu-mid,    CTX 262144   (2 × 128K, SLOTS=2)
-      #   gpu-large (32GB): ...-gpu-large,  CTX 1048576  (4 × 256K, SLOTS=4) — each of
+      # Tier picks (set AIMEE_LLM_TIER + AIMEE_LLM_SYNTH_CTX per card):
+      #   small (16GB): TIER=small, CTX 131072   (1 × 128K)
+      #   mid   (24GB): TIER=mid,   CTX 262144   (2 × 128K, SLOTS=2)
+      #   large (32GB): TIER=large, CTX 1048576  (4 × 256K, SLOTS=4) — each of
       #     4 agents gets the full native 256K window; ~28.5GiB used, ~3.5GB headroom.
       AIMEE_LLM_SYNTH_CTX: ${AIMEE_LLM_SYNTH_CTX:-131072}
     devices:

--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -28,22 +28,29 @@ services:
       retries: 5
 
   # Unified llama.cpp/Vulkan container: embed (/embed,/embed_batch), rerank
-  # (/rerank) and synth (/v1/chat/completions). CPU tier here; the kb sends no
-  # bearer, so it runs auth-off (AIMEE_LLM_AUTH_TOKEN empty) on the internal net.
+  # (/rerank) and synth (/v1/chat/completions). One model-less image; the tier is
+  # chosen at runtime via AIMEE_LLM_TIER (unset ≡ cpu here) and the models are
+  # downloaded to the /models volume on first boot. The kb sends no bearer, so it
+  # runs auth-off (AIMEE_LLM_AUTH_TOKEN empty) on the internal net.
   aimee-llm:
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-kb-cpu:latest}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     environment:
       AIMEE_LLM_PORT: "8742"
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
+      # cpu tier by default (unset ≡ cpu); the GPU override sets small/mid/large.
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+    volumes:
+      # Persist the downloaded per-tier GGUFs so restarts don't re-fetch.
+      - aimee-llm-models:/models
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
       interval: 30s
       timeout: 5s
       retries: 5
-      # Cold boot loads the baked GGUFs into RAM before /health is OK.
-      start_period: 600s
+      # Cold first boot downloads the tier's models before /health is OK.
+      start_period: 1200s
 
   aimee-kb:
     restart: unless-stopped
@@ -116,3 +123,4 @@ volumes:
   aimee-kb-home:
   aimee-server-home:
   aimee-server-workspaces:
+  aimee-llm-models:

--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -57,6 +57,15 @@ fi
 chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspaces}" 2>/dev/null || true
 [ -f "$AIMEE_HOME/aimee.yaml" ] && chown aimee:aimee "$AIMEE_HOME/aimee.yaml" 2>/dev/null || true
 [ -f "$AIMEE_HOME/agents.json" ] && chown aimee:aimee "$AIMEE_HOME/agents.json" 2>/dev/null || true
+# The bundled aimee-llm supervisor runs as "aimee" and DOWNLOADS the tier's GGUFs
+# to /models on first boot — make the (possibly root-owned, freshly-mounted) cache
+# writable by uid 1000. Recurse ONLY when the root isn't already aimee-owned (a
+# fresh/root volume or a migration): once aimee owns /models the supervisor creates
+# its per-tier files as aimee, so later restarts skip the multi-GB `chown -R` walk.
+# Harmless when WITH_LLM=0 (/models is an empty dir).
+if [ -d /models ] && [ "$(stat -c %u /models 2>/dev/null || echo 0)" != "1000" ]; then
+    chown -R aimee:aimee /models 2>/dev/null || true
+fi
 
 kb_pid=""
 server_pid=""

--- a/deploy/smoothnas/aimee-llm.compose.yaml
+++ b/deploy/smoothnas/aimee-llm.compose.yaml
@@ -1,25 +1,36 @@
 # aimee-llm — SmoothNAS compose-native plugin (split topology): the unified
 # Vulkan llama.cpp backend (embed + rerank + synth), standalone. GPU tier via
 # /dev/dri (LXC2Docker adds the cgroup allow). No cross-plugin deps — the kb
-# plugin points AIMEE_LLM_URL at this host's published :8742. Baked GGUFs, so no
-# tiered volume. Migrated from aimee-llm.plugin.yaml (gpu-amd profile).
+# plugin points AIMEE_LLM_URL at this host's published :8742. One model-less
+# image; the tier is chosen at runtime via AIMEE_LLM_TIER (mid on the .254 24GB
+# card) and the models download to the aimee-llm-models volume on first boot.
+# Migrated from aimee-llm.plugin.yaml (gpu-amd profile).
 name: aimee-llm
 services:
   aimee-llm:
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:gpu}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     environment:
       AIMEE_LLM_PORT: "8742"
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-99}
+      # Synth tier: small (12B) / mid (26B-A4B SLOTS=2) / large (26B-A4B SLOTS=4).
+      # mid fits the .254 24GB card fully GPU-resident. Models download on first boot.
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-mid}
       AIMEE_LLM_SYNTH_CTX: ${AIMEE_LLM_SYNTH_CTX:-131072}
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
     devices:
       - "/dev/dri:/dev/dri"
     ports:
       - "8742:8742"
+    volumes:
+      # Persist the downloaded per-tier GGUFs so restarts don't re-fetch (multi-GB).
+      - aimee-llm-models:/models
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
       interval: 30s
       timeout: 5s
       retries: 5
-      start_period: 600s
+      # Cold first boot downloads the tier's models before /health is OK.
+      start_period: 1200s
+volumes:
+  aimee-llm-models:

--- a/deploy/smoothnas/aimee-llm.plugin.yaml
+++ b/deploy/smoothnas/aimee-llm.plugin.yaml
@@ -2,15 +2,17 @@ apiVersion: smoothnas.io/v1
 kind: Plugin
 metadata:
   name: aimee-llm
-  version: 0.2.57
+  version: 0.2.58
   description: >-
     aimee-llm — the unified Vulkan llama.cpp container: one GPU-offloaded
     runtime + the aimee-llm gateway, serving embeddings (/embed, /embed_batch),
-    reranking (/rerank), and synthesis (/v1/chat/completions) from baked-in
-    GGUFs. Replaces the torch aimee-embedder + the standalone llama.cpp `llm`
-    container. The aimee-kb plugin points AIMEE_EMBEDDER_URL at this service.
-    GPU tier (.254): Qwen3-Embedding-4B (2560-dim) + ettin-reranker-400m +
-    gemma-4-26B-A4B, offloaded to the AMD 7900 XTX via Vulkan/RADV (AIMEE_LLM_NGL=99).
+    reranking (/rerank), and synthesis (/v1/chat/completions). One model-less
+    image; the tier is chosen at runtime via AIMEE_LLM_TIER and the models are
+    downloaded to the models volume on first boot. Replaces the torch
+    aimee-embedder + the standalone llama.cpp `llm` container. The aimee-kb plugin
+    points AIMEE_EMBEDDER_URL at this service. GPU tier (.254): AIMEE_LLM_TIER=mid
+    → Qwen3-Embedding-4B (2560-dim) + ettin-reranker-400m + gemma-4-26B-A4B,
+    offloaded to the AMD 7900 XTX via Vulkan/RADV (AIMEE_LLM_NGL=99).
   vendor: RakuenSoftware
   homepage: https://github.com/RakuenSoftware/aimee
 profiles:
@@ -31,25 +33,30 @@ services:
       # publish-images.yml). On `testing`, pin to :testing instead to validate a
       # tested-but-unreleased build (publish-llm-testing.yml).
       #
-      # SYNTH TIER = which image you reference (embed+rerank identical on the GPU
-      # tiers, so switching is an image swap, no KB re-embed):
-      #   aimee-kb-gpu-small  Gemma-4-12B synth (dense; fits 16GB+)
-      #   aimee-kb-gpu-mid    Gemma-4-26B-A4B synth (MoE, 4B active; ~14GB fits a 24GB
-      #                       card fully GPU-resident, baked AIMEE_LLM_SYNTH_N_CPU_MOE=0)
-      #   aimee-kb-gpu-large  SAME 26B-A4B GGUF as gpu-mid but baked SYNTH_SLOTS=4 for a
-      #                       32GB card — deploy AIMEE_LLM_SYNTH_CTX=1048576 (4 × 256K)
-      # aimee-kb-cpu is the CPU tier (1024-dim; NGL=0). See docs/AIMEE_KB_SYNTH_TIERS.md.
-      # This .254 plugin stays on gpu-mid (its card is 24GB); gpu-large is for 32GB hosts.
-      image: ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest
+      # SYNTH TIER = AIMEE_LLM_TIER (embed+rerank identical on the GPU tiers, so
+      # switching is an env change, no KB re-embed — but a different tier downloads
+      # to its own /models subdir on first boot):
+      #   small  Gemma-4-12B synth (dense; fits 16GB+)
+      #   mid    Gemma-4-26B-A4B synth (MoE, 4B active; ~14GB fits a 24GB card fully
+      #          GPU-resident, N_CPU_MOE=0; SLOTS=2)
+      #   large  SAME 26B-A4B GGUF as mid but SLOTS=4 for a 32GB card — deploy
+      #          AIMEE_LLM_SYNTH_CTX=1048576 (4 × 256K)
+      # cpu is the CPU tier (1024-dim; NGL=0). See docs/AIMEE_KB_SYNTH_TIERS.md.
+      # This .254 plugin stays on the mid tier (its card is 24GB); large is for 32GB.
+      image: ghcr.io/rakuensoftware/aimee-llm:latest
     container:
       restartPolicy: unless-stopped
     env:
       # Offload all layers to the GPU (the 7900 XTX has the VRAM for the 4B embed +
-      # the ~14GB gemma-4-26B-A4B synth, fully resident). The CPU image defaults NGL to 0.
+      # the ~14GB gemma-4-26B-A4B synth, fully resident). The cpu tier defaults NGL to 0.
       AIMEE_LLM_NGL: "99"
-      # gpu-mid bakes SYNTH_SLOTS=2, so ctx-size is split 2 × 128K. Gemma's sliding-window
-      # KV is cheap; 262144 (256K total) fits alongside the resident synth on 24GB. Lower
-      # this (or raise the baked N_CPU_MOE) only if the container logs a VRAM alloc failure.
+      # Synth tier for this 24GB card. mid = gemma-4-26B-A4B MoE, SLOTS=2, fully
+      # GPU-resident. Models download to /models on first boot (persisted below).
+      AIMEE_LLM_TIER: "mid"
+      # The mid tier serves SYNTH_SLOTS=2, so ctx-size is split 2 × 128K. Gemma's
+      # sliding-window KV is cheap; 262144 (256K total) fits alongside the resident
+      # synth on 24GB. Lower this (or raise AIMEE_LLM_SYNTH_N_CPU_MOE) only if the
+      # container logs a VRAM alloc failure.
       AIMEE_LLM_SYNTH_CTX: "262144"
       # Gateway port. 8742 (aimee's 874x range: server 8740, kb 8741) — NOT 8080,
       # which Wolf's WolfLeash UI host-publishes. A hostExpose port is published on
@@ -77,6 +84,15 @@ services:
       # from the secret store (vault / Docker secret / .gitignore'd per-host .env)
       # — NEVER a checked-in plaintext value. Document its rotation (runbook §3).
       # AIMEE_LLM_AUTH_TOKEN: "<set-at-deploy-time-not-in-git>"
+    volumes:
+      # Persist the per-tier model cache: the supervisor downloads the tier's GGUFs
+      # here on first boot (~14GB for the mid tier), so a restart doesn't re-fetch.
+      # SSD slot for fast model load into VRAM. NOTE (tierd bind gotcha): the bind
+      # source must be pre-created on the host before install, or the mount fails.
+      - name: models
+        mode: tier-bound
+        slot: SSD
+        bind: /models
     ports:
       # The embed/rerank/synth gateway. hostExpose so the aimee-kb plugin can reach
       # it across the runtime bridge gateway at http://10.100.0.1:8742 — set the

--- a/deploy/smoothnas/aimee.compose.yaml
+++ b/deploy/smoothnas/aimee.compose.yaml
@@ -45,20 +45,24 @@ services:
 
   aimee-llm:
     restart: unless-stopped
-    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:gpu}
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     environment:
       AIMEE_LLM_PORT: "8742"
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-99}
+      # Synth tier chosen at runtime (small/mid/large); mid fits the 24GB card.
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-mid}
       AIMEE_LLM_SYNTH_CTX: ${AIMEE_LLM_SYNTH_CTX:-131072}
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
     devices:
       - "/dev/dri:/dev/dri" # AMD render path; LXC2Docker adds the cgroup allow
+    volumes:
+      - aimee-llm-models:/models # persist the downloaded per-tier GGUFs
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
       interval: 30s
       timeout: 5s
       retries: 5
-      start_period: 600s # cold boot loads the baked GGUFs into RAM first
+      start_period: 1200s # cold first boot downloads the tier's models
 
   aimee-kb:
     restart: unless-stopped
@@ -122,4 +126,6 @@ volumes:
   aimee-server-home:
     x-smoothnas: { tier: aimee-data }
   aimee-server-workspaces:
+    x-smoothnas: { tier: aimee-data }
+  aimee-llm-models:
     x-smoothnas: { tier: aimee-data }

--- a/docs/AIMEE_KB_SYNTH_TIERS.md
+++ b/docs/AIMEE_KB_SYNTH_TIERS.md
@@ -1,32 +1,37 @@
-# aimee-kb image synth tiers
+# aimee-llm synth tiers
 
-The `aimee-kb-*` image is the unified Vulkan llama.cpp stack: one runtime serving
+The `aimee-llm` image is the unified Vulkan llama.cpp stack: one runtime serving
 **embeddings** (`/embed`), **reranking** (`/rerank`), and **synthesis**
-(`/v1/chat/completions`) from baked-in GGUFs. Four published tiers differ only in the
-**synth model** (and its runtime profile); embed + rerank are identical within a
-CPU/GPU class, so a KB stays byte-portable when you swap the GPU synth tier.
+(`/v1/chat/completions`). It is a single **model-less** image — the **tier** is
+chosen at runtime via `AIMEE_LLM_TIER` and the models are **downloaded on first
+boot** into the `/models` volume. The four tiers differ only in the **synth
+model** (and its runtime profile); embed + rerank are identical within a CPU/GPU
+class, so a KB stays byte-portable when you switch the GPU synth tier.
 
-| Image | Embed / Rerank | Synth | Runtime (target card) | Pull size |
+| `AIMEE_LLM_TIER` | Embed / Rerank | Synth | Runtime (target card) | Model download |
 |---|---|---|---|---|
-| `aimee-kb-cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) | ~6.5 GB |
-| `aimee-kb-gpu-small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB | ~11.4 GB |
-| `aimee-kb-gpu-mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB | ~17.8 GB |
-| `aimee-kb-gpu-large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `gpu-mid`, 4 slots — 32 GB | ~17.8 GB |
+| `cpu` | Qwen3-Emb-0.6B / ettin-68m (1024-dim) | gemma-4-E4B (**Tier A only**) | CPU (`NGL=0`) | ~6.5 GB |
+| `small` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 12B** `qat-UD-Q4_K_XL` | GPU, dense, FA+K8V4 — 16 GB | ~11.4 GB |
+| `mid` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | GPU, MoE (4B active), FA+K8V4, fully resident, 2 slots — 24 GB | ~17.8 GB |
+| `large` | Qwen3-Emb-4B / ettin-400m (2560-dim) | **Gemma 4 26B-A4B** `qat-UD-Q4_K_XL` | Same GGUF as `mid`, 4 slots — 32 GB | ~17.8 GB |
 
-`gpu-large` is byte-identical to `gpu-mid` (same synth GGUF/revision/SHA + MoE/FA profile);
-it only bakes `SYNTH_SLOTS=4` instead of `2`, so a 32 GB card runs **4 concurrent agents**
+`large` is identical to `mid` (same synth GGUF/revision/SHA + MoE/FA profile); it
+only serves `SYNTH_SLOTS=4` instead of `2`, so a 32 GB card runs **4 concurrent agents**
 each with the model's full native **256 K** window (deploy `AIMEE_LLM_SYNTH_CTX=1048576`).
 Gemma-4 uses interleaved sliding-window attention (only 5 of 30 layers are full-attention),
-so even 4×256 K KV stays ~28.5 GiB — validated against the 24 GB `gpu-mid` card (2×128 K =
-22.4/24 GiB). `gpu-small`, `gpu-mid`, and `gpu-large` share the **same embedder + reranker**
+so even 4×256 K KV stays ~28.5 GiB — validated against the 24 GB `mid` card (2×128 K =
+22.4/24 GiB). `small`, `mid`, and `large` share the **same embedder + reranker**
 (2560-dim), so a KB embedded on one is byte-compatible with the others — switching the synth
-tier is a plugin **image swap**, no re-embed.
+tier is an `AIMEE_LLM_TIER` change, no re-embed.
 
-**Image size** (amd64, compressed pull from ghcr): `cpu` ~6.5 GB, `gpu-small` ~11.4 GB,
-`gpu-mid` / `gpu-large` **~17.8 GB**. The mid/large image bakes ~19.3 GB of GGUFs
-(embed 4.28 GB + rerank 0.79 GB + synth 14.25 GB) → ~20 GB uncompressed on disk. `gpu-large`
-carries the *same* layers as `gpu-mid` (only the `SYNTH_SLOTS=4` env differs), so it is the
-same size — allow ~20 GB free disk on the host per GPU image, plus transient build headroom.
+**Model download** (the first-boot fetch into the `/models` volume, per tier): `cpu`
+~6.5 GB, `small` ~11.4 GB, `mid` / `large` **~17.8 GB** (embed 4.28 GB + rerank 0.79 GB +
+synth 14.25 GB). The **image itself is small** (no baked GGUFs) — allow ~20 GB free on the
+`/models` volume per GPU tier for the downloaded models. `mid` and `large` download the same
+models (only `SYNTH_SLOTS` differs); each tier caches under its own `/models/<tier>` subdir,
+so switching tiers keeps both. Embed + synth pull straight from Hugging Face; the ettin
+reranker is a pre-converted encoder GGUF + Dense head fetched from a GitHub release
+(published by `.github/workflows/publish-rerank-artifacts.yml`).
 
 ## Tier-A vs Tier-B synthesis
 
@@ -36,29 +41,32 @@ The curator synthesizes in two tiers:
 - **Tier B**, the reasoning passes: judge, resolve entities, reconcile contradictions,
   synthesize, promote.
 
-`aimee-kb-cpu` runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider (a weak model would poison the graph), so a CPU-only deployment gets retrieval + Tier-A
-synthesis and nothing more. **Tier B needs a GPU tier (`gpu-small` / `gpu-mid` / `gpu-large`)
+The `cpu` tier runs **Tier A only**. Its gemma-4-E4B synth is not wired as a Tier-B provider (a weak model would poison the graph), so a CPU-only deployment gets retrieval + Tier-A
+synthesis and nothing more. **Tier B needs a GPU tier (`small` / `mid` / `large`)
 or an external LLM.** With no Tier-B provider the reasoning passes are skipped, not errored. Full
 config surface: [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
 
 ## Package names
 
-Two image families share the `aimee-kb` prefix. Keep them straight:
+Keep the two `aimee-*` inference-adjacent images straight:
 
-- **`aimee-kb`** (no suffix): the KB service (DB2 + curator). Runs no model; it calls one
+- **`aimee-kb`**: the KB service (DB2 + curator). Runs no model; it calls one
   over HTTP. See [KB_LLM_BACKENDS.md](KB_LLM_BACKENDS.md).
-- **`aimee-kb-{cpu,gpu-small,gpu-mid,gpu-large}`**: the inference tiers in this doc (embed +
-  rerank + synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS `aimee-llm` plugin.
+- **`aimee-llm`**: the single model-less inference image in this doc (embed +
+  rerank + synth), built from `Dockerfile.aimee-llm`, deployed as the SmoothNAS
+  `aimee-llm` plugin. The tier is `AIMEE_LLM_TIER`, not the image name.
 
-Retired names: `aimee-llm-cpu`/`aimee-llm-gpu` were the old tier names (now
-`aimee-kb-cpu`/`aimee-kb-gpu-small`); `aimee-embedder`/`aimee-embedder-4b` were the
-standalone torch embedder, now baked into the tiers.
+Retired names: `aimee-kb-{cpu,gpu-small,gpu-mid,gpu-large}` (and before them
+`aimee-llm-cpu`/`aimee-llm-gpu`) were the old **baked per-tier** images — replaced
+by the one model-less `aimee-llm` image + `AIMEE_LLM_TIER`. `aimee-embedder`/
+`aimee-embedder-4b` were the standalone torch embedder, now served by `aimee-llm`.
 
-## Deploy: one plugin image swap
+## Deploy: one env knob
 
-The synth tier is chosen by which image the SmoothNAS `aimee-llm` plugin references,
-e.g. `ghcr.io/rakuensoftware/aimee-kb-gpu-mid:latest` for Gemma 4 26B-A4B. No separate synth
-container, no `SYNTH_LOCAL` juggling: the tier *is* the synth.
+The synth tier is chosen by `AIMEE_LLM_TIER` on the SmoothNAS `aimee-llm` plugin
+(or any compose topology), e.g. `AIMEE_LLM_TIER=mid` for Gemma 4 26B-A4B. No separate synth
+container, no `SYNTH_LOCAL` juggling, no image swap: the tier *is* the synth, and its models
+download on first boot.
 
 ### Two consumers of the gateway synth (`/v1/chat/completions`)
 
@@ -67,12 +75,12 @@ independent callers, one automatic, one an explicit operator step:
 
 1. **KB curator synthesis (automatic).** The `aimee-kb` plugin points `LLM_ENDPOINT` /
    `LLM_MODEL` at the gateway, so the curator's `tier_a`/`tier_b` use the synth tier the
-   moment the image is deployed. Swapping tiers needs no KB change.
+   moment the container is deployed. Switching tiers needs no KB change.
 
 2. **aimee-server delegate, an explicit runtime registration (NOT automatic).** To make
    the local synth usable as an `aimee` delegate (roundtable / fallback), register it once
    against the server (endpoint is model-neutral, so the registration survives synth-tier
-   swaps):
+   switches):
 
    ```sh
    aimee agent local local-synth http://<runtime-gw>:8742/v1 \
@@ -83,18 +91,20 @@ independent callers, one automatic, one an explicit operator step:
    This lives in the server's `agents.json` (runtime/per-deployment state, not baked into
    the image). On `.254` this is registered as `local-synth` and sits in `fallback_chain`.
 
-## Synth runtime knobs (baked per tier; overridable via plugin env)
+## Synth runtime knobs (tier defaults; overridable via plugin env)
+
+Each tier sets these from the tier table in the supervisor; an explicit env still wins.
 
 | Env | Default (per tier) | Meaning |
 |---|---|---|
-| `AIMEE_LLM_SYNTH_CTX` | 32768 baked; gpu-mid deploys `262144` (2 × 128 K), gpu-large `1048576` (4 × 256 K) | synth context window (total across slots) |
-| `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on gpu-mid, 4 on gpu-large) | `--parallel` concurrent slots |
+| `AIMEE_LLM_SYNTH_CTX` | 32768; `mid` deploys `262144` (2 × 128 K), `large` `1048576` (4 × 256 K) | synth context window (total across slots) |
+| `AIMEE_LLM_SYNTH_SLOTS` | 1 (2 on `mid`, 4 on `large`) | `--parallel` concurrent slots |
 | `AIMEE_LLM_SYNTH_FA` | `off` cpu / `on` gpu | flash-attention (required for quantized V-cache) |
 | `AIMEE_LLM_SYNTH_KV_K` / `_KV_V` | `q8_0` / `q4_0` (K8V4) | KV cache quant on the gpu tiers |
-| `AIMEE_LLM_SYNTH_MOE` | `1` on gpu-mid | enable the `--n-cpu-moe` expert-offload knob |
-| `AIMEE_LLM_SYNTH_N_CPU_MOE` | `0` on gpu-mid | MoE layers whose experts live in system RAM (0 = fully GPU-resident) |
+| `AIMEE_LLM_SYNTH_MOE` | `1` on `mid`/`large` | enable the `--n-cpu-moe` expert-offload knob |
+| `AIMEE_LLM_SYNTH_N_CPU_MOE` | `0` on `mid`/`large` | MoE layers whose experts live in system RAM (0 = fully GPU-resident) |
 
-### Tuning `N_CPU_MOE` on gpu-mid (Gemma 4 26B-A4B, ~14 GB synth)
+### Tuning `N_CPU_MOE` on the `mid` tier (Gemma 4 26B-A4B, ~14 GB synth)
 
 The mid tier is **Gemma 4 26B-A4B**, a MoE with only **4B active parameters/token** at
 `qat-UD-Q4_K_XL` (~14 GB). Unlike a 22 GB synth, it **co-fits embed+rerank (~7 GB) on a
@@ -124,7 +134,7 @@ The GPU tiers are based on `debian:trixie-slim` (Mesa 25) on purpose: its RADV e
 cores. On an older Mesa without coopmat (bookworm's 22.3.6) llama.cpp falls back to scalar
 shaders. The synth goes compute-bound, the memory bus sits idle, and generation crawls.
 
-Measured on the 7900 XTX, gpu-mid resident: **~1265 tok/s prompt, ~62–95 tok/s generation**
+Measured on the 7900 XTX, `mid` tier resident: **~1265 tok/s prompt, ~62–95 tok/s generation**
 with coopmat; ~33–76 / ~30 without it. If a GPU tier is slow, check the base image is
 trixie (Mesa ≥ 24.1) and that `mem_busy` climbs under load. A pegged GPU with an idle
 memory bus means the matrix cores aren't in play.

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -6,25 +6,32 @@ How to point `aimee-kb` at the model backend that does its **embedding**,
 ## Principle: the kb runs no model
 
 `aimee-kb` is a thin DB2 / curator service. It **never** runs an LLM or embedder
-in-process. It *calls* one over HTTP. Inference lives in a separate **`aimee-kb-*`
-tier image** (`aimee-kb-cpu` / `aimee-kb-gpu-small` / `aimee-kb-gpu-mid` / `aimee-kb-gpu-large`,
-the unified Vulkan llama.cpp stack, deployed as the SmoothNAS `aimee-llm` plugin) or any external
-OpenAI-compatible endpoint. You only ever give the kb a **URL**. The tiers themselves are
-documented in [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
+in-process. It *calls* one over HTTP. Inference lives in a separate **`aimee-llm`
+container** (the unified Vulkan llama.cpp stack, deployed as the SmoothNAS
+`aimee-llm` plugin) or any external OpenAI-compatible endpoint. `aimee-llm` is a
+single **model-less** image: the **tier** (`cpu` / `small` / `mid` / `large`) is
+chosen at runtime via `AIMEE_LLM_TIER` and the models are downloaded on first
+boot. You only ever give the kb a **URL**. The tiers themselves are documented in
+[AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 
 ## Tiers: what each backend provides
 
-| Backend | Embedding / reranking | Synthesis | Embedding dim | Pull size |
+All served by the one `aimee-llm` image; `AIMEE_LLM_TIER` picks which models it
+downloads on first boot. "Model download" is the first-boot fetch into the
+`/models` volume (the image itself is small and model-less).
+
+| `AIMEE_LLM_TIER` | Embedding / reranking | Synthesis | Embedding dim | Model download |
 | --- | --- | --- | --- | --- |
-| **`aimee-kb-cpu`** (default) | Qwen3-Emb-0.6B + ettin-68m | **Tier-A** only (gemma-4-E4B, CPU) | **1024** | ~6.5 GB |
-| **`aimee-kb-gpu-small`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 12B) | **2560** (set explicitly) | ~11.4 GB |
-| **`aimee-kb-gpu-mid`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 26B-A4B, 24 GB card, 2 slots) | **2560** (set explicitly) | ~17.8 GB |
-| **`aimee-kb-gpu-large`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (same 26B-A4B, 32 GB card, 4 slots × 256 K) | **2560** (set explicitly) | ~17.8 GB |
+| **`cpu`** (default) | Qwen3-Emb-0.6B + ettin-68m | **Tier-A** only (gemma-4-E4B, CPU) | **1024** | ~6.5 GB |
+| **`small`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 12B) | **2560** (set explicitly) | ~11.4 GB |
+| **`mid`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (Gemma 4 26B-A4B, 24 GB card, 2 slots) | **2560** (set explicitly) | ~17.8 GB |
+| **`large`** | Qwen3-Emb-4B + ettin-400m | **Tier-A + Tier-B** (same 26B-A4B, 32 GB card, 4 slots × 256 K) | **2560** (set explicitly) | ~17.8 GB |
 | **External LLM** | per the endpoint | per the endpoint | per the endpoint | — |
 
-`gpu-small`, `gpu-mid`, and `gpu-large` share the 2560-dim embedder, so a KB moves between them
-with no re-embed. `gpu-large` is byte-identical to `gpu-mid` bar `SYNTH_SLOTS=4` (4 concurrent
-agents for a 32 GB card). Pick by synth need + card size, not by the KB.
+`small`, `mid`, and `large` share the 2560-dim embedder, so a KB moves between them
+with no re-embed. `large` is identical to `mid` bar `SYNTH_SLOTS=4` (4 concurrent
+agents for a 32 GB card). Pick by synth need + card size, not by the KB — switching
+is a `AIMEE_LLM_TIER` change (the new tier downloads to its own `/models` subdir).
 
 *Tier-A* = mechanical extract/index passes. *Tier-B* = reasoning passes (judge,
 resolve-entities, contradictions, **synthesize**, promote). A small CPU model is
@@ -34,10 +41,11 @@ when you point the kb at a capable container via `AIMEE_LLM_URL`.
 
 ## Zero-config default
 
-If **no** LLM is configured, the kb deployment brings up a **CPU `aimee-kb-cpu`
-container beside it** and points itself at it: embedding, reranking, and Tier-A
-synthesis work with nothing to set. The operator only opts *up*:
-configure a GPU container or an external LLM and the CPU sibling is not started.
+If **no** LLM is configured, the kb deployment brings up a **cpu-tier `aimee-llm`
+container beside it** (`AIMEE_LLM_TIER=cpu`) and points itself at it: embedding,
+reranking, and Tier-A synthesis work with nothing to set. The operator only opts
+*up*: set `AIMEE_LLM_TIER=small|mid|large` (with a GPU) or point at an external LLM
+and the CPU sibling is not started.
 
 > The default CPU sibling is owned by the **deploy unit** (the smoothnas plugin /
 > compose), not the kb process. The kb never touches a container runtime.
@@ -97,8 +105,9 @@ AIMEE_EMBEDDER_URL=https://embed.internal  # pin embedding elsewhere
 AIMEE_EMBEDDING_DIM=<that model's dim>
 ```
 
-**Default (nothing set):** the deploy brings up the CPU `aimee-kb-cpu` sibling;
-retrieval + Tier-A synthesis work at 1024-dim with no configuration.
+**Default (nothing set):** the deploy brings up the cpu-tier `aimee-llm` sibling
+(`AIMEE_LLM_TIER=cpu`); retrieval + Tier-A synthesis work at 1024-dim with no
+configuration.
 
 ## Notes for plugin / compose operators
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -33,14 +33,16 @@ credentials live in the server's **sealed vault**; see
   transcripts and build progress dropped), with the full output spilled for lossless
   recovery. Fail-open and byte-identical when off. Toggle it in the web Settings page. See
   [features/tool-output-condensation.md](features/tool-output-condensation.md).
-- **Self-hosted GPU inference tiers**: the `aimee-kb` inference image ships four tiers you
-  swap with one plugin image. `aimee-kb-cpu` runs retrieval on any host (~6.5 GB image),
-  `aimee-kb-gpu-small` bakes a Gemma 4 12B synth (~11.4 GB, 16 GB card), `aimee-kb-gpu-mid`
-  bakes a Gemma 4 26B-A4B synth that fits a 24 GB card fully resident (~17.8 GB, 2 slots),
-  and `aimee-kb-gpu-large` reuses that same synth on a 32 GB card with 4 concurrent agents at
-  the full 256 K window (same ~17.8 GB image, only `SYNTH_SLOTS=4`). The GPU tiers build on a
-  Mesa 25 base so RADV uses the RDNA3 matrix cores. The local synth also registers as a free
-  delegate. See [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
+- **Self-hosted GPU inference tiers**: the `aimee-llm` inference image is a single
+  **model-less** image whose **tier** is chosen at runtime via `AIMEE_LLM_TIER` — the models
+  download on first boot into a `/models` volume, so there is nothing baked and no per-tier
+  image to pull. `cpu` runs retrieval on any host (~6.5 GB download), `small` a Gemma 4 12B
+  synth (~11.4 GB, 16 GB card), `mid` a Gemma 4 26B-A4B synth that fits a 24 GB card fully
+  resident (~17.8 GB, 2 slots), and `large` reuses that synth on a 32 GB card with 4
+  concurrent agents at the full 256 K window (only `SYNTH_SLOTS=4`). The GPU tiers build on a
+  Mesa 25 base so RADV uses the RDNA3 matrix cores. The bundled all-in-one image
+  (`aimee-server-kb`) uses the same image and downloads the cpu tier on first boot. The local
+  synth also registers as a free delegate. See [AIMEE_KB_SYNTH_TIERS.md](AIMEE_KB_SYNTH_TIERS.md).
 - **Cross-repo code graph**: the symbol and call graph resolves dependency edges across the
   repositories in your workspace, so blast radius and caller lookups cross repo boundaries.
   Ask in three directions: what a project depends on, what depends on it, or both. See

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -23,10 +23,10 @@ scalar score, so its size is a quality choice, not a dimension constraint.)
 
 Two embedding widths ship:
 
-| Tier | Embedder (`embedding_dim`) | Reranker |
+| `AIMEE_LLM_TIER` | Embedder (`embedding_dim`) | Reranker |
 |------|----------------------------|----------|
-| `aimee-kb-cpu` | Qwen3-Embedding-0.6B (`1024`) | ettin-68m |
-| `aimee-kb-gpu-small` / `-gpu-mid` / `-gpu-large` | Qwen3-Embedding-4B (`2560`) | ettin-400m |
+| `cpu` | Qwen3-Embedding-0.6B (`1024`) | ettin-68m |
+| `small` / `mid` / `large` | Qwen3-Embedding-4B (`2560`) | ettin-400m |
 
 The 4B/2560 tier has better recall on large or meaning-heavy corpora; the 0.6B/1024 tier is
 the low-footprint default. The retrieval pipeline (hybrid search, reranking, fusion) is
@@ -34,14 +34,15 @@ identical either way. Only the model sizes differ.
 
 ### Switching tiers
 
-Switch by deploying a different `aimee-kb-*` tier (the `aimee-llm` plugin image) and setting
-the width to match:
+Switch by setting `AIMEE_LLM_TIER` on the `aimee-llm` container (one model-less image; the
+new tier downloads on first boot) and setting the width to match:
 
 ```bash
+AIMEE_LLM_TIER=small       # cpu | small | mid | large
 AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
 ```
 
-All GPU tiers are 2560-dim, so moving between `gpu-small`, `gpu-mid`, and `gpu-large` needs no re-embed.
+All GPU tiers are 2560-dim, so moving between `small`, `mid`, and `large` needs no re-embed.
 Moving between 1024 and 2560 is a model-identity **and** width change: on an **empty** DB
 just set the dim; on a **populated** one it's a drop-and-rebuild re-embed (the `halfvec`
 columns are sized to `embedding_dim`), which the `kb_meta` drift guard enforces. See
@@ -200,9 +201,10 @@ unchanged, since the dimension has not moved.
 ## Reranking
 
 An optional cross-encoder reranker refines the top-k of a recall before it is
-returned. It is baked into the same tier image and sized to match the embedder: the GPU tiers
-(`aimee-kb-gpu-small` / `-gpu-mid` / `-gpu-large`) bake `cross-encoder/ettin-reranker-400m-v1`; the CPU
-tier bakes ettin-68m. Build-time override: `--build-arg RERANK_REPO=<hf id>`.
+returned. It is served by the same `aimee-llm` container and sized to match the embedder: the
+GPU tiers (`small` / `mid` / `large`) use `cross-encoder/ettin-reranker-400m-v1`; the `cpu`
+tier uses ettin-68m. Each is a pre-converted encoder GGUF + Dense head the container downloads
+on first boot per `AIMEE_LLM_TIER` (published by `publish-rerank-artifacts.yml`).
 
 It is configured independently of the embedder dimension:
 

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -9,19 +9,20 @@ the images build, serve `/embed`+`/rerank`(ettin encoder + gateway
 head)+`/v1/chat/completions`, and offload to the AMD 7900 XTX via Vulkan (`-ngl 99`).
 
 > **Naming update (post-cutover):** the images built here were renamed
-> `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small`, and two more GPU
-> tiers were added — `aimee-kb-gpu-mid` (Gemma 4 26B-A4B, 24 GB card) and `aimee-kb-gpu-large`
-> (same synth, 32 GB card, `SYNTH_SLOTS=4`); `aimee-llm` is now only the plugin name. The
-> steps below keep the original names as a record, for the current tiers, image sizes, and
-> build-args see [../AIMEE_KB_SYNTH_TIERS.md](../AIMEE_KB_SYNTH_TIERS.md).
+> `aimee-llm-cpu`/`aimee-llm-gpu` → `aimee-kb-cpu`/`aimee-kb-gpu-small` (+ `gpu-mid`/`gpu-large`),
+> and have since been **collapsed back into one model-less `aimee-llm` image**: the tier is
+> chosen at runtime via `AIMEE_LLM_TIER` (`cpu`/`small`/`mid`/`large`) and the models download
+> on first boot — there are no baked per-tier images anymore. The steps below keep the original
+> names as a record; for the current image, tiers, and env knobs see
+> [../AIMEE_KB_SYNTH_TIERS.md](../AIMEE_KB_SYNTH_TIERS.md).
 
 ## 0. What changes
 
 - **From:** torch `aimee-embedder` (pplx-embed + ettin via sentence-transformers) + the
   stock `llm` llama.cpp container (gemma synth).
-- **To:** one `aimee-llm` image (CPU or GPU tier): Vulkan llama.cpp serving embed
-  (Qwen3-Embedding) + rerank (ettin encoder + the gateway Dense head) + synth (gemma),
-  models baked in.
+- **To:** one model-less `aimee-llm` image: Vulkan llama.cpp serving embed
+  (Qwen3-Embedding) + rerank (ettin encoder + the gateway Dense head) + synth (gemma). The
+  tier (`AIMEE_LLM_TIER`) selects the models, which download on first boot into `/models`.
 - **Corpus re-embed required:** `pplx-embed` → `Qwen3-Embedding` is a **`model_id` change**
   (and 0.6B→1024 / 4B→2560 a possible **dim** change), so the `kb_meta` drift guard (P1,
   now activated, `db2_set_embedder_model_id`) will **refuse** to serve the new embedder
@@ -38,30 +39,26 @@ release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollb
 
 ## 2. Build + publish the images
 
-CI builds + publishes both tiers as part of the normal release cycle:
-- **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds
-  `aimee-kb-cpu` + `aimee-kb-gpu-small` + `aimee-kb-gpu-mid` + `aimee-kb-gpu-large` on every
-  release and tags them `:<version>` + `:latest`. They are in both the `build` and the `merge`
-  matrices; the merge step applies the tags, so a build that pushes only by digest leaves
-  `tags:null`. (`gpu-mid` and `gpu-large` are amd64-only.)
-- **testing:** `.github/workflows/publish-llm-testing.yml` builds `cpu` + `gpu-small` on
-  `testing` pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts,
-  tagged `:testing` (+ `:testing-<sha>`, amd64). `gpu-mid` and `gpu-large` are dispatch-only
-  (`build_kb_gpu_mid=true` / `build_kb_gpu_large=true`): tested-but-unreleased images for `.254`.
+CI builds + publishes the **one** model-less `aimee-llm` image as part of the normal cycle
+(no per-tier images — the tier is a runtime env, not a build):
+- **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds `aimee-llm`
+  on every release and tags it `:<version>` + `:latest`. It is in both the `build` and `merge`
+  matrices; the merge step applies the tags. amd64-only (the llama.cpp Vulkan binary is x64).
+- **testing:** `.github/workflows/publish-llm-testing.yml` builds `aimee-llm` on `testing`
+  pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts, tagged `:testing`
+  (+ `:testing-<sha>`, amd64).
+- **rerank artifacts (prerequisite):** `.github/workflows/publish-rerank-artifacts.yml` is a
+  dispatch job that converts the ettin rerankers once and uploads them to the
+  `rerank-artifacts-v1` GitHub release. **Run it before any container starts** — the supervisor
+  fetches the rerank encoder + head from that release on first boot.
 
-To build out-of-band (e.g. on a PVE CT with docker):
+To build out-of-band (e.g. on a PVE CT with docker) — one model-less image, no model build-args:
 
 ```
-docker build -f Dockerfile.aimee-llm -t aimee-kb-cpu .
-docker build -f Dockerfile.aimee-llm -t aimee-kb-gpu-small \
-  --build-arg EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF \
-  --build-arg EMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf \
-  --build-arg RERANK_REPO=cross-encoder/ettin-reranker-400m-v1 \
-  --build-arg SYNTH_REPO=unsloth/gemma-4-12B-it-qat-GGUF \
-  --build-arg SYNTH_FILE=gemma-4-12B-it-qat-UD-Q4_K_XL.gguf \
-  --build-arg SYNTH_FA=on .
+docker build -f Dockerfile.aimee-llm -t aimee-llm .
+# then at run time pick the tier:  docker run -e AIMEE_LLM_TIER=small ... aimee-llm
 ```
-(gpu-mid swaps the synth args to Gemma 4 26B-A4B; see the tiers doc for the exact pins.)
+(The tier selects the models the supervisor downloads on first boot; see the tiers doc.)
 
 ## 3. Deploy to `.254` (tierd / LXC, GPU)
 

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -1,21 +1,101 @@
 #!/bin/bash
-# aimee-llm container supervisor: launch the per-role llama.cpp servers (embed,
-# rerank-encoder, synth) from the baked GGUFs, then the gateway. Each role is its
-# own llama-server process so a crash is isolated to that role; if any exits the
+# aimee-llm container supervisor: resolve the TIER, download its models on first
+# boot (the image ships model-less), then launch the per-role llama.cpp servers
+# (embed, rerank-encoder, synth) and the gateway. Each role is its own
+# llama-server process so a crash is isolated to that role; if any exits the
 # supervisor tears the container down (the orchestrator restarts it). A full
 # s6-overlay (per-role restart) is the follow-up; this is the MVP supervisor.
+#
+# TIER SELECTION (runtime, not baked): AIMEE_LLM_TIER picks WHICH models to fetch
+# and how to serve the synth. NGL (GPU offload) is a SEPARATE per-deploy knob.
+#   (unset)/cpu  0.6B emb + ettin-68m  + gemma-4-E4B      (dense, CPU)
+#   small        4B emb   + ettin-400m + gemma-4-12B      (dense, GPU, FA+K8V4)
+#   mid          4B emb   + ettin-400m + gemma-4-26B-A4B  (MoE, GPU, FA+K8V4; SLOTS=2)
+#   large        SAME 26B-A4B as mid but SLOTS=4 (32GB card → deploy 4×256K)
+# The tier table below is the SINGLE source of truth (was Dockerfile ARGs + the
+# CI build matrix). Embed+synth are plain GGUF pulls from HF; the ettin reranker
+# is a pre-converted encoder GGUF + Dense head (head.npz) fetched from a GitHub
+# release (published by .github/workflows/publish-rerank-artifacts.yml) — the ST
+# score head doesn't survive GGUF conversion, so the gateway applies it.
 set -u
 LLAMA=/opt/llama/llama-server
 NGL="${AIMEE_LLM_NGL:-0}"
-POOL="${AIMEE_LLM_EMBED_POOLING:-last}"
-# Synth context window. The synth GGUF (gemma-4-12b) trains to 256K, but a
-# hardcoded --ctx-size 8192 wasted that: large code symbols / doc chunks overran
-# 8K and the server returned HTTP 400, failing extraction entirely. Default to a
-# 16GB-VRAM-safe 32K (4x the old cap, covers real source files); raise it on
-# bigger cards via AIMEE_LLM_SYNTH_CTX (e.g. 131072 for 128K). KV cache scales
-# with context, so size it to the card. Embed/rerank inputs are small — they keep
-# the 8K default.
+MODELS_DIR="${AIMEE_LLM_MODELS_DIR:-/models}"
+# Base URL for the pre-converted ettin rerank artifacts (override for a mirror).
+RERANK_ASSET_BASE="${AIMEE_LLM_RERANK_ASSET_BASE:-https://github.com/RakuenSoftware/aimee/releases/download/rerank-artifacts-v1}"
+# Synth context window. The synth GGUF (gemma) trains to 256K, but a hardcoded
+# --ctx-size 8192 wasted that: large code symbols / doc chunks overran 8K and the
+# server returned HTTP 400, failing extraction entirely. Default to a 16GB-VRAM-
+# safe 32K (4x the old cap, covers real source files); raise it on bigger cards
+# via AIMEE_LLM_SYNTH_CTX (e.g. 131072 for 128K). KV cache scales with context, so
+# size it to the card. Embed/rerank inputs are small — they keep the 8K default.
 SYNTH_CTX="${AIMEE_LLM_SYNTH_CTX:-32768}"
+
+# ---- tier table (single source of truth) ------------------------------------
+# Resolve AIMEE_LLM_TIER into the per-role model coordinates + the synth runtime
+# profile. Empty tier ≡ cpu. Unknown tier fails fast.
+TIER="${AIMEE_LLM_TIER:-cpu}"
+tier_config() {
+  case "$TIER" in
+    cpu)
+      EMBED_REPO="Qwen/Qwen3-Embedding-0.6B-GGUF"; EMBED_FILE="Qwen3-Embedding-0.6B-f16.gguf"
+      RERANK_SIZE="68m"
+      SYNTH_REPO="ggml-org/gemma-4-E4B-it-GGUF"; SYNTH_FILE="gemma-4-E4B-it-Q4_K_M.gguf"
+      SYNTH_REVISION="main"; SYNTH_SHA256=""
+      TIER_FA="off"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"
+      ;;
+    small)
+      EMBED_REPO="Qwen/Qwen3-Embedding-4B-GGUF"; EMBED_FILE="Qwen3-Embedding-4B-Q8_0.gguf"
+      RERANK_SIZE="400m"
+      SYNTH_REPO="unsloth/gemma-4-12B-it-qat-GGUF"; SYNTH_FILE="gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"
+      SYNTH_REVISION="9586f3257bc62bd179767241c7ec0f66bc2a314a"
+      SYNTH_SHA256="cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165"
+      TIER_FA="on"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"
+      ;;
+    mid)
+      EMBED_REPO="Qwen/Qwen3-Embedding-4B-GGUF"; EMBED_FILE="Qwen3-Embedding-4B-Q8_0.gguf"
+      RERANK_SIZE="400m"
+      SYNTH_REPO="unsloth/gemma-4-26B-A4B-it-qat-GGUF"; SYNTH_FILE="gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf"
+      SYNTH_REVISION="02749a7b272109255a4c559a80894d3d9777574c"
+      SYNTH_SHA256="dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e"
+      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="2"
+      ;;
+    large)
+      # Byte-identical to mid EXCEPT SLOTS=4 (24GB→32GB card headroom).
+      EMBED_REPO="Qwen/Qwen3-Embedding-4B-GGUF"; EMBED_FILE="Qwen3-Embedding-4B-Q8_0.gguf"
+      RERANK_SIZE="400m"
+      SYNTH_REPO="unsloth/gemma-4-26B-A4B-it-qat-GGUF"; SYNTH_FILE="gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf"
+      SYNTH_REVISION="02749a7b272109255a4c559a80894d3d9777574c"
+      SYNTH_SHA256="dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e"
+      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="4"
+      ;;
+    *)
+      echo "aimee-llm: invalid AIMEE_LLM_TIER='$TIER' (valid: cpu, small, mid, large; empty ≡ cpu)" >&2
+      exit 1
+      ;;
+  esac
+}
+tier_config
+
+# Per-tier model cache (persist /models to a volume so restarts don't re-fetch).
+D="$MODELS_DIR/$TIER"
+
+# Deploy-time overrides win over the tier default (operators set CTX/SLOTS per card).
+FA="${AIMEE_LLM_SYNTH_FA:-$TIER_FA}"
+KV_K="${AIMEE_LLM_SYNTH_KV_K:-q8_0}"
+KV_V="${AIMEE_LLM_SYNTH_KV_V:-q4_0}"
+MOE="${AIMEE_LLM_SYNTH_MOE:-$TIER_MOE}"
+MOE_LAYERS="${AIMEE_LLM_SYNTH_MOE_LAYERS:-40}"
+N_CPU_MOE="${AIMEE_LLM_SYNTH_N_CPU_MOE:-$TIER_N_CPU_MOE}"
+SLOTS="${AIMEE_LLM_SYNTH_SLOTS:-$TIER_SLOTS}"
+
+# Gateway-facing model identity (all current tiers share the qwen3 embedder id +
+# last-token pooling — the gateway reads these for /health + the drift guard).
+export AIMEE_LLM_EMBED_MODEL="${AIMEE_LLM_EMBED_MODEL:-qwen3-embedding}"
+export AIMEE_LLM_EMBED_POOLING="${AIMEE_LLM_EMBED_POOLING:-last}"
+export AIMEE_LLM_RERANK_HEAD="$D/rerank-head"
+POOL="$AIMEE_LLM_EMBED_POOLING"
+
 pids=()
 
 start() { # name port extra-args...
@@ -25,40 +105,79 @@ start() { # name port extra-args...
   pids+=("$!")
 }
 
-# STUB mode (CI/dev): no GGUFs, no llama-servers — the gateway serves
+# fetch URL DEST — download with retries; return non-zero on failure (the caller
+# leaves .ready absent so the next start retries a partial pull).
+fetch() {
+  local url="$1" dest="$2"
+  wget -q -c --tries=5 --timeout=30 --waitretry=10 -O "$dest" "$url" \
+    || { echo "aimee-llm: download FAILED: $url" >&2; return 1; }
+}
+
+# download_models — populate $D for the resolved tier ONCE (guarded by $D/.ready).
+# Embed+synth pull straight from HF; the rerank encoder+head come from the GH
+# release, and everything sha256-verified where a checksum is known.
+download_models() {
+  if [ -f "$D/.ready" ]; then
+    echo "aimee-llm: tier '$TIER' models present in $D (skip download)" >&2
+    return 0
+  fi
+  echo "aimee-llm: fetching tier '$TIER' models into $D" >&2
+  mkdir -p "$D/rerank-head" || return 1
+
+  # Embedder GGUF (repo default branch).
+  fetch "https://huggingface.co/${EMBED_REPO}/resolve/main/${EMBED_FILE}" "$D/embed.gguf" || return 1
+
+  # Synth GGUF, pinned to the tier's HF revision; sha256-verified when known so a
+  # compromised/MITM'd upload can't ship.
+  fetch "https://huggingface.co/${SYNTH_REPO}/resolve/${SYNTH_REVISION}/${SYNTH_FILE}" "$D/synth.gguf" || return 1
+  if [ -n "$SYNTH_SHA256" ]; then
+    echo "${SYNTH_SHA256}  $D/synth.gguf" | sha256sum -c - >&2 || {
+      echo "aimee-llm: synth.gguf sha256 MISMATCH — refusing to serve" >&2; return 1; }
+  fi
+
+  # Pre-converted ettin rerank artifacts (encoder GGUF + Dense head npz) from the
+  # GH release, verified against its SHA256SUMS.
+  local rr="rerank-ettin-${RERANK_SIZE}"
+  fetch "${RERANK_ASSET_BASE}/${rr}.gguf"     "$D/rerank-encoder.gguf"   || return 1
+  fetch "${RERANK_ASSET_BASE}/${rr}.head.npz" "$D/rerank-head/head.npz"  || return 1
+  if fetch "${RERANK_ASSET_BASE}/SHA256SUMS" "$D/SHA256SUMS"; then
+    ( cd "$D" \
+      && grep -E "  ${rr}\.gguf\$" SHA256SUMS | sed "s#${rr}\.gguf#rerank-encoder.gguf#" | sha256sum -c - \
+      && grep -E "  ${rr}\.head\.npz\$" SHA256SUMS | sed "s#${rr}\.head\.npz#rerank-head/head.npz#" | sha256sum -c - ) >&2 || {
+      echo "aimee-llm: rerank artifact sha256 MISMATCH — refusing to serve" >&2; return 1; }
+  else
+    echo "aimee-llm: WARNING — no SHA256SUMS for rerank artifacts (unverified)" >&2
+  fi
+
+  touch "$D/.ready"
+  echo "aimee-llm: tier '$TIER' models ready in $D" >&2
+}
+
+# STUB mode (CI/dev): no GGUFs, no downloads, no llama-servers — the gateway serves
 # deterministic embed/rerank/synth. Lets e2e exercise the kb->gateway contract
-# cheaply (and the image can be built without baking models).
+# cheaply (and the image runs without any model fetch).
 case "${AIMEE_LLM_STUB:-}" in
   ""|0|false)
+    download_models || { echo "aimee-llm: model provisioning failed; shutting down" >&2; exit 1; }
     # Embedder: one vector per input, no prompt-cache fragmentation (P2 flags).
-    start embed 8081 -m /models/embed.gguf --embeddings --pooling "$POOL" \
+    start embed 8081 -m "$D/embed.gguf" --embeddings --pooling "$POOL" \
       --ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots
     # Reranker ENCODER: CLS pooling + flash-attn; the gateway applies the Dense head.
-    start rerank 8082 -m /models/rerank-encoder.gguf --embeddings --pooling cls -fa on
+    start rerank 8082 -m "$D/rerank-encoder.gguf" --embeddings --pooling cls -fa on
     # Synth: OpenAI-compatible /v1/chat/completions (grammar/JSON via --jinja). The
-    # synth MODEL + its runtime profile is baked per TIER (build-args -> ENV):
-    #   aimee-kb-cpu       gemma-4-E4B     (dense, CPU)
-    #   aimee-kb-gpu-small gemma-4-12B     (dense, GPU, FA+K8V4)
-    #   aimee-kb-gpu-mid   gemma-4-26B-A4B (MoE, GPU, FA+K8V4, fully resident on 24GB;
-    #                      SYNTH_SLOTS=2 -> deploy 2x128K)
-    #   aimee-kb-gpu-large gemma-4-26B-A4B (SAME GGUF/profile as mid, SYNTH_SLOTS=4 for
-    #                      32GB cards -> deploy 4x256K; Gemma windowed KV keeps ~28.5GiB)
-    # The gemma tiers leave FA/MoE unset -> identical to prior behaviour. AIMEE_LLM_
-    # SYNTH_LOCAL=0 still lets an operator disable the local synth and forward via
-    # AIMEE_LLM_SYNTH_URL instead.
-    if [ "${AIMEE_LLM_SYNTH_LOCAL:-1}" != "0" ] && [ -f /models/synth.gguf ]; then
-      synth_args=(-m /models/synth.gguf --ctx-size "$SYNTH_CTX" --jinja \
-                  --parallel "${AIMEE_LLM_SYNTH_SLOTS:-1}")
+    # synth MODEL + its runtime profile come from the TIER table above; explicit
+    # AIMEE_LLM_SYNTH_* envs still override per deploy. AIMEE_LLM_SYNTH_LOCAL=0 lets
+    # an operator disable the local synth and forward via AIMEE_LLM_SYNTH_URL instead.
+    if [ "${AIMEE_LLM_SYNTH_LOCAL:-1}" != "0" ] && [ -f "$D/synth.gguf" ]; then
+      synth_args=(-m "$D/synth.gguf" --ctx-size "$SYNTH_CTX" --jinja --parallel "$SLOTS")
       # Flash-attention + quantized KV (K8V4 by default). NOTE: quantized V-cache
       # REQUIRES fa (llama.cpp refuses otherwise), so a healthy start proves fa on.
-      if [ "${AIMEE_LLM_SYNTH_FA:-off}" = "on" ]; then
-        synth_args+=(-fa on \
-          --cache-type-k "${AIMEE_LLM_SYNTH_KV_K:-q8_0}" \
-          --cache-type-v "${AIMEE_LLM_SYNTH_KV_V:-q4_0}")
+      if [ "$FA" = "on" ]; then
+        synth_args+=(-fa on --cache-type-k "$KV_K" --cache-type-v "$KV_V")
       fi
-      # MoE static expert-offload to system RAM (mid tier). Clamp to [0, layers].
-      if [ "${AIMEE_LLM_SYNTH_MOE:-0}" = "1" ]; then
-        ncm="${AIMEE_LLM_SYNTH_N_CPU_MOE:-0}"; mlayers="${AIMEE_LLM_SYNTH_MOE_LAYERS:-40}"
+      # MoE static expert-offload to system RAM (mid/large tiers). Clamp to [0, layers].
+      if [ "$MOE" = "1" ]; then
+        ncm="$N_CPU_MOE"; mlayers="$MOE_LAYERS"
         case "$ncm" in ''|*[!0-9]*) ncm=0;; esac
         [ "$ncm" -gt "$mlayers" ] && ncm=$mlayers
         synth_args+=(--n-cpu-moe "$ncm")
@@ -68,7 +187,7 @@ case "${AIMEE_LLM_STUB:-}" in
     fi
     ;;
   *)
-    echo "aimee-llm: STUB mode — skipping llama-servers; gateway serves deterministic responses" >&2
+    echo "aimee-llm: STUB mode — skipping model fetch + llama-servers; gateway serves deterministic responses" >&2
     ;;
 esac
 

--- a/scripts/convert_ettin_rerank.py
+++ b/scripts/convert_ettin_rerank.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Convert an ettin cross-encoder reranker to the runtime form aimee-llm serves:
+the ENCODER as a GGUF (via llama.cpp's convert_hf_to_gguf.py) plus the Dense score
+head as a numpy .npz (keys W2/W4/b4/gamma/beta, matching EttinRerankHead.from_npz).
+
+CI-only helper (see .github/workflows/publish-rerank-artifacts.yml). The ST score
+head doesn't survive GGUF conversion, so the gateway applies it from the .npz at
+runtime. Hoisted here so neither the build nor the runtime image needs torch.
+
+Usage: convert_ettin_rerank.py <size> <hf_repo> <out_dir> <llama_cpp_dir>
+"""
+import os
+import subprocess
+import sys
+
+import numpy as np
+from huggingface_hub import snapshot_download
+from safetensors.numpy import load_file
+
+
+def main() -> int:
+    if len(sys.argv) != 5:
+        print(__doc__, file=sys.stderr)
+        return 2
+    size, repo, out_dir, llama = sys.argv[1:5]
+    dest = f"/tmp/ettin-{size}"
+    print(f"snapshot {repo} -> {snapshot_download(repo, local_dir=dest)}")
+
+    gguf = os.path.join(out_dir, f"rerank-ettin-{size}.gguf")
+    env = dict(os.environ, PYTHONPATH=os.path.join(llama, "gguf-py"))
+    subprocess.run(
+        [sys.executable, os.path.join(llama, "convert_hf_to_gguf.py"),
+         dest, "--outfile", gguf, "--outtype", "f16"],
+        check=True, env=env,
+    )
+
+    W2 = load_file(f"{dest}/2_Dense/model.safetensors")["linear.weight"]
+    d4 = load_file(f"{dest}/4_Dense/model.safetensors")
+    ln = load_file(f"{dest}/3_LayerNorm/model.safetensors")
+    npz = os.path.join(out_dir, f"rerank-ettin-{size}.head.npz")
+    np.savez(npz, W2=W2, W4=d4["linear.weight"], b4=d4["linear.bias"],
+             gamma=ln["norm.weight"], beta=ln["norm.bias"])
+    print(f"wrote {gguf} + {npz}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -37,6 +37,7 @@ set -uo pipefail
 
 cd "$(dirname "$0")/.."
 SCRIPTS="$(pwd)/scripts"
+ROOT="$(pwd)"
 
 ONLY="T1,T2,T3,T4,T5,T6,PC"
 KB_URL=""
@@ -147,6 +148,21 @@ run_docker_topology() {
 run_docker_topology T1 "Docker kb-only"            aimee-kb-docker-smoke.sh                compose.yaml                     "aimee-kb=${KB_PORT}:8741"
 run_docker_topology T2 "Docker server+kb split"    aimee-server-docker-smoke.sh            compose.server.yaml              "aimee-server=${SERVER_PORT}:8743" "aimee-kb=${KB_PORT}:8741"
 run_docker_topology T3 "Docker server standalone"  aimee-server-standalone-docker-smoke.sh compose.server-standalone.yaml   "aimee-server=${SERVER_PORT}:8743"
+
+# T4 combined COPYs the aimee-llm runtime (/opt/llama + /opt/aimee + /models) from
+# AIMEE_LLM_CPU_IMAGE. In prod that is the published aimee-llm image (built by the
+# publish-* workflows first); in CI there is no freshly-published tag, so build the
+# model-less image locally (llama binary + gateway, no GGUFs — fast) and inject it.
+# The bundled LLM then runs in STUB mode (AIMEE_LLM_STUB=1, exported above), so it
+# serves deterministic responses with no model download.
+if selected T4 && have_docker; then
+  bold "==> Building local aimee-llm image for the T4 combined bundled LLM"
+  if docker build -f "$ROOT/Dockerfile.aimee-llm" -t aimee-llm-local:e2e "$ROOT"; then
+    export AIMEE_LLM_CPU_IMAGE="aimee-llm-local:e2e"
+  else
+    bold "==> WARNING: local aimee-llm build failed; T4 will use the default AIMEE_LLM_CPU_IMAGE"
+  fi
+fi
 run_docker_topology T4 "Docker combined server+kb" aimee-combined-docker-smoke.sh          compose.combined.yaml            "aimee-server-kb=${SERVER_PORT}:8743,${KB_PORT}:8741"
 
 # --- Local topologies (Linux only) ----------------------------------------

--- a/src/README.md
+++ b/src/README.md
@@ -936,11 +936,12 @@ Containers are the recommended deployment (developers then install only the
 topology. They build from three images: **`aimee-server`** (`Dockerfile.server`),
 **`aimee-kb`** (`Dockerfile`), and **`aimee-server+kb`** (`Dockerfile.combined`).
 Every stack also brings up a `pgvector/pgvector:pg16` Postgres (DB2), and the kb
-auto-applies its DB2 schema on first boot. The combined image bundles a CPU
-inference gateway (embeddings, reranking, and synthesis) from the `aimee-kb` image
-family, so embedding and reranking work with nothing external. The CPU tier serves
-Qwen3-Embedding-0.6B at 1024 dims; the GPU tiers (`aimee-kb-gpu-small`,
-`aimee-kb-gpu-mid`) serve Qwen3-Embedding-4B at 2560 dims and add a GPU synth. To
+auto-applies its DB2 schema on first boot. The combined image bundles the
+`aimee-llm` inference gateway (embeddings, reranking, and synthesis), which
+downloads its cpu-tier models on first boot, so embedding and reranking work with
+nothing external. The tier is chosen by `AIMEE_LLM_TIER`: `cpu` serves
+Qwen3-Embedding-0.6B at 1024 dims; the GPU tiers (`small`, `mid`, `large`) serve
+Qwen3-Embedding-4B at 2560 dims and add a GPU synth. To
 run a standalone embedder or curator LLM instead of the bundled gateway, use the
 `external-llm` compose profile. Backends and tiers:
 [KB_LLM_BACKENDS.md](../docs/KB_LLM_BACKENDS.md) and


### PR DESCRIPTION
## Summary
Converts the `aimee-llm` container from **four build-time-baked tier images**
(`aimee-kb-cpu` / `gpu-small` / `gpu-mid` / `gpu-large`) to **one model-less image**
(`ghcr.io/rakuensoftware/aimee-llm`) that downloads + configures its models at
container start, selected by `AIMEE_LLM_TIER` (empty≡`cpu`, `cpu`, `small`, `mid`,
`large`; unknown fails fast).

## What changed
- **Supervisor** (`scripts/aimee-llm-supervisor.sh`): tier table (single source of
  truth — was Dockerfile ARGs + the CI matrix) + download-once into `/models/<tier>`
  (`.ready` guard, sha256-verified); synth runtime profile from the tier with
  per-deploy env overrides. STUB mode preserved.
- **`Dockerfile.aimee-llm`**: removed the torch `modelprep` baking stage + all model
  build-args; `VOLUME /models`; healthcheck `start-period 1200s`.
- **Reranker** (`scripts/convert_ettin_rerank.py` + `.github/workflows/publish-rerank-artifacts.yml`):
  a one-time dispatch job converts ettin 68m/400m → encoder GGUF + Dense head
  `head.npz` and publishes them + `SHA256SUMS` to the `rerank-artifacts-v1` release;
  the supervisor fetches them per tier.
- **Combined** (`Dockerfile.combined`, `deploy/container/combined-entrypoint.sh`,
  `compose.combined.yaml`): the all-in-one `aimee-server-kb` bundles the **same**
  model-less image and downloads the `cpu` tier on first boot (added `wget`, `chown
  /models` for uid 1000 recursing only when ownership is wrong, `VOLUME /models`,
  `AIMEE_LLM_TIER=cpu`, longer start-periods).
- **CI** (`publish-llm-testing.yml`, `publish-images.yml`, `publish-testing.yml`):
  collapse the tier matrix to one `aimee-llm` image; layer cache re-enabled; combined
  COPYs from `aimee-llm` instead of `aimee-llm-cpu`.
- **Deploy** (7 compose/plugin files): single image + `AIMEE_LLM_TIER` + persistent
  `/models` volume (cpu default; gpu→small; smoothnas→mid).
- **Docs** updated to the runtime-fetch model.

## Review
Roundtable review (reviewer + architect perspectives) found no material bugs; the
download/serve logic, sha256 verification, tier mapping, combined-image wiring, and CI
collapse all verified correct. One perf nit (recursive `chown` on every restart) fixed.

## ⚠️ Operational prerequisite
Run **`publish-rerank-artifacts.yml` once** before any container starts — the
supervisor fetches the rerank encoder + head from the `rerank-artifacts-v1` release on
first boot, so every tier crash-loops until that release exists.

## Validation
`bash -n`, `py_compile`, and `yaml.safe_load` pass on all changed files.
**Validation-pending** (no GPU host / Docker daemon in the dev env): the real image
build, first-boot download+serve, and the rerank-artifacts release upload.

## Follow-up hardening (non-blocking)
- Pin the embed GGUF revision + sha256 per tier (currently pulled from HF `main`,
  unverified — parity with the prior baked build, not a regression).
- Pin the rerank sha in the supervisor rather than trusting the same-release `SHA256SUMS`.