### PR TITLE
fix(workflow): human gates are inviolable — remove autonomous auto-pass

### DIFF
--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -126,8 +126,9 @@ Autonomous does not mean unsupervised. The workflow reserves **human gates**
 (proposal approval, final pass/fail). In autonomous mode the driver:
 
 - auto-advances *machine* gates (CI, mergeability, roundtable verdicts);
-- auto-satisfies **only** the human gates the submitter explicitly preauthorized;
-- **parks** at every other human gate (`pending_human`) until a person acts;
+- **parks** at **every** human gate (`pending_human`) until a person acts — a human
+  gate is **inviolable** and is never auto-satisfied (declaring one auto-satisfiable
+  via `policy: preauthorized` / `optional: true` is rejected at workflow validation);
 - **never forges a human approval**, gate-override is a signed, human-only action
   capped at a small number of uses.
 
@@ -156,8 +157,9 @@ Interactive (human-driven) work items are left alone by the scheduler.
 
 Autonomous development is default-on; the guardrails are structural, not a toggle:
 
-- **Human gates** are never auto-satisfied unless preauthorized for that run, and
-  gate-override stays human-only and capped.
+- **Human gates** are never auto-satisfied — a human gate is an inviolable stop; the
+  only way past it is a human's signed approval, and gate-override stays human-only
+  and capped.
 - **Per-run budget ceiling.** A work item carries a cost cap; on breach the run
   **parks** (`budget_exceeded`) for a human, it never silently runs away.
   (Today the cap is a work-item field; setting it *from* `/v1/dev/submit` is not

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -17,9 +17,18 @@ credentials live in the server's **sealed vault**; see
   approval") or `interactive` (file it and park for a human to drive in the
   webchat). The `proposals` source now files its runs `autonomous` by default, so
   a merged proposal builds out end-to-end without further sign-off. In-flight
-  human gates remain a property of the *workflow* you name (`gate.human` /
-  `with_user`), independent of the trigger's `mode`. See
+  human gates remain a property of the *workflow* you name (`gate.human`),
+  independent of the trigger's `mode`. See
   [WORKFLOWS.md § Triggers](WORKFLOWS.md#triggers).
+- **Human gates are inviolable**: a `gate.human` step can no longer be
+  auto-satisfied in autonomous mode. The autonomy driver's preauthorized/optional
+  auto-pass is removed — an autonomous run now **parks at every human gate** until
+  a person acts, and workflow validation **rejects** `policy: preauthorized` /
+  `optional: true` on a human gate so an overridable one can't even be authored.
+  The only way past a human gate remains a human's signed approval via
+  `POST /v1/workflow/items/<id>/gate` (operator-gated `CAP_WORKFLOW_ADMIN`,
+  attributed to the caller's attested principal, HMAC-signed and content-hash-bound).
+  See [WORKFLOWS.md](WORKFLOWS.md) and [AUTONOMOUS_DEVELOPMENT.md](AUTONOMOUS_DEVELOPMENT.md).
 
 - **Dashboard overhaul + Logs tab**: the web UI **Dashboard** is now a customizable
   grid of **server-incurred** metric panels: delegations, per-role metrics, token/cost,

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -67,7 +67,7 @@ From the catalog in [src/workflow/wfe_def.c](../src/workflow/wfe_def.c)
 | `document` | branch | branch | action | A delegate writes docs onto the branch. Composes between implement and freeze. |
 | `freeze` | frozen_diff | branch | action | Freezes the branch to an immutable diff for review. |
 | `gate.roundtable` | verdict | proposal · plan · frozen_diff | **gate** | Runs a multi-persona review **panel**; pass/fail on quorum. |
-| `gate.human` | approval | proposal · plan · branch · frozen_diff · pr | **gate** | Parks for a human decision (or auto-passes when preauthorized). |
+| `gate.human` | approval | proposal · plan · branch · frozen_diff · pr | **gate** | Parks for a human decision — **inviolable**; never auto-satisfied in autonomous mode. |
 | `pr.open` | pr | proposal · frozen_diff | action | Opens a pull request. |
 | `merge` |, (terminal) | pr | action | Merges the PR. |
 | `gate.ci` | verdict | pr | **gate** | Polls the PR's CI; **fail-closed** (no green → fail). |
@@ -213,10 +213,12 @@ The engine advances it one step at a time
   advances along `next`.
 - A **gate** evaluates and takes `on_pass` or `on_fail`.
 - A **roundtable** gate runs its persona panel as delegates and passes on quorum.
-- A **human gate** **parks** the run (`WFE_STEP_PENDING`) until an approval is
-  recorded. In `autonomous` mode the driver
-  ([wfe_autonomy.c](../src/workflow/wfe_autonomy.c)) may auto-satisfy a gate that
-  is explicitly `policy: preauthorized` or `optional: true`; otherwise it parks.
+- A **human gate** **parks** the run (`WFE_STEP_PENDING`) until a human approval is
+  recorded — and this is **inviolable**. In `autonomous` mode the driver
+  ([wfe_autonomy.c](../src/workflow/wfe_autonomy.c)) **never** auto-satisfies a
+  human gate; authoring one as auto-satisfiable (`policy: preauthorized` or
+  `optional: true`) is rejected at validation. Only a human's signed approval
+  clears it.
 - Approvals are **signed** ([wfe_approval.c](../src/workflow/wfe_approval.c)) and
   recorded against the step's content hash, so an approval is bound to the exact
   artifact it approved.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -28,7 +28,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 |-----|------|-------------|
 | `audit_action_enabled` | bool | — |
 | `audit_worm_enabled` | bool | Dual-write governed-action audit rows into the append-only, hash-chained WORM store alongside audit.log (default off). |
-| `autonomous` | bool | Run autonomously (auto-advance preauthorized gates) vs interactive. |
+| `autonomous` | bool | Run autonomously (auto-advance machine gates; human gates always park) vs interactive. |
 | `cache_aware_rewrite_enabled` | bool | Rewrite prompts to align with the provider's prompt cache. |
 | `cache_min_chars` | int | Minimum prompt size (chars) before cache-shaping applies. |
 | `cache_shaping_enabled` | bool | Enable prompt cache-shaping. |
@@ -558,7 +558,7 @@ nodes:
 ### Block parameters (`params:`)
 
 - **`gate.roundtable`** — `panel.required` (list of required reviewer personas), `panel.eligible` (list of additional eligible personas), `quorum` (int; effective quorum is `max(2, quorum)` and at least the required-panel size).
-- **`gate.human`** — `policy: preauthorized` (auto-approve in autonomous mode) and/or `optional: true` (skippable). Without these, an autonomous run parks at the gate for a human.
+- **`gate.human`** — parks the run for a human decision. **Inviolable**: never auto-satisfied in autonomous mode, and declaring it auto-satisfiable (`policy: preauthorized` / `optional: true`) is rejected at validation. Cleared only by a human's signed approval via the gate endpoint.
 - Other blocks take no params today; unknown params are ignored by the validator.
 
 ### Custom blocks — `$AIMEE_HOME/workflows/blocks.yaml`

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -100,7 +100,7 @@ CFG_TYPE = {"CFG_STRING": "string", "CFG_BOOL": "bool", "CFG_INT": "int", "CFG_F
 # surface). A key in the generated table with no entry here renders "—" and is
 # counted as undescribed so the gap is visible (see render_config).
 CFG_KEY_DESC = {
-    "autonomous": "Run autonomously (auto-advance preauthorized gates) vs interactive.",
+    "autonomous": "Run autonomously (auto-advance machine gates; human gates always park) vs interactive.",
     "cache_aware_rewrite_enabled": "Rewrite prompts to align with the provider's prompt cache.",
     "cache_min_chars": "Minimum prompt size (chars) before cache-shaping applies.",
     "cache_shaping_enabled": "Enable prompt cache-shaping.",
@@ -839,9 +839,10 @@ def render_workflow(catalog, consts):
         "personas), `panel.eligible` (list of additional eligible personas), "
         "`quorum` (int; effective quorum is `max(2, quorum)` and at least the "
         "required-panel size).",
-        "- **`gate.human`** — `policy: preauthorized` (auto-approve in autonomous "
-        "mode) and/or `optional: true` (skippable). Without these, an autonomous run "
-        "parks at the gate for a human.",
+        "- **`gate.human`** — parks the run for a human decision. **Inviolable**: never "
+        "auto-satisfied in autonomous mode, and declaring it auto-satisfiable "
+        "(`policy: preauthorized` / `optional: true`) is rejected at validation. Cleared "
+        "only by a human's signed approval via the gate endpoint.",
         "- Other blocks take no params today; unknown params are ignored by the "
         "validator.",
         "",

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -15,7 +15,7 @@
 #include "wfe_iface.h"
 #include "wfe_roundtable.h"
 
-/* human gate with policy: preauthorized */
+/* plain human gate — inviolable: autonomous mode parks at it, never auto-satisfies */
 static const char *AUTO = "name: auto\n"
                           "start: draft\n"
                           "nodes:\n"
@@ -26,8 +26,6 @@ static const char *AUTO = "name: auto\n"
                           "    block: gate.human\n"
                           "    in:\n"
                           "      src: draft.out\n"
-                          "    params:\n"
-                          "      policy: preauthorized\n"
                           "    next: pr\n"
                           "  - id: pr\n"
                           "    block: pr.open\n"
@@ -108,14 +106,15 @@ int main(void)
    wfe_register_roundtable_gate();
    wfe_set_panel_provider(NULL); /* live §0 -> degraded */
 
-   /* A1: autonomous + preauthorized human gate -> auto-advances to accepted */
+   /* A1: autonomous + human gate -> PARKS (inviolable; never auto-satisfied). */
    {
       char id[80] = "", err[256] = "";
       assert(wfe_work_item_create("auto", "a1", "a1", "autonomous", id, err, sizeof err) == 0);
       assert(wfe_autonomy_run(id, err, sizeof err) == 0);
       db1_work_item_t wi;
       assert(db1_work_item_get(id, &wi) == 1);
-      assert(strcmp(wi.state, "accepted") == 0);
+      assert(strcmp(wi.state, "active") == 0);
+      assert(strcmp(wi.pause_reason, "pending_human") == 0);
    }
 
    /* A2: interactive + same gate -> parks pending_human (no auto-approval) */

--- a/src/tests/test_workflow.c
+++ b/src/tests/test_workflow.c
@@ -168,12 +168,24 @@ int main(void)
                         "  - id: g\n    block: gate.roundtable\n    in:\n      s: a.out\n"
                         "    params:\n      panel:\n        required:\n          - security\n",
                         e, sizeof e));
-      /* gate.human optional + pr_review */
+      /* gate.human optional:true — forbidden (a human gate is inviolable) */
       assert(!validates("name: x\nstart: a\nnodes:\n"
                         "  - id: a\n    block: author.proposal\n    next: h\n"
                         "  - id: h\n    block: gate.human\n    in:\n      s: a.out\n"
-                        "    params:\n      policy: pr_review\n      optional: true\n",
+                        "    params:\n      optional: true\n",
                         e, sizeof e));
+      /* gate.human policy:preauthorized — forbidden (must not be auto-satisfiable) */
+      assert(!validates("name: x\nstart: a\nnodes:\n"
+                        "  - id: a\n    block: author.proposal\n    next: h\n"
+                        "  - id: h\n    block: gate.human\n    in:\n      s: a.out\n"
+                        "    params:\n      policy: preauthorized\n",
+                        e, sizeof e));
+      /* a plain gate.human (no auto-satisfy params) is valid */
+      assert(validates("name: x\nstart: a\nnodes:\n"
+                       "  - id: a\n    block: author.proposal\n    next: h\n"
+                       "  - id: h\n    block: gate.human\n    in:\n      s: a.out\n    next: p\n"
+                       "  - id: p\n    block: pr.open\n    in:\n      s: a.out\n",
+                       e, sizeof e));
       /* missing required input: author.plan with no input binding */
       assert(!validates("name: x\nstart: a\nnodes:\n"
                         "  - id: a\n    block: author.plan\n",

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -88,26 +88,6 @@ static int wfe_autonomy_park_stuck(const char *work_item_id, const char *why)
    return 0;
 }
 
-/* Is this paused node a human gate the driver may auto-satisfy in autonomous
- * mode? (policy preauthorized, or optional:true). */
-static int human_gate_auto_ok(const wfe_node_t *node)
-{
-   if (!node || node->block != WFE_BLK_GATE_HUMAN)
-      return 0;
-   const cJSON *policy =
-       node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "policy") : NULL;
-   const cJSON *optional =
-       node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "optional") : NULL;
-   if (policy && cJSON_IsString(policy) && strcmp(policy->valuestring, "preauthorized") == 0)
-      return 1;
-   /* accept optional written as bool/int/string (YAML emitters vary) */
-   if (optional &&
-       (cJSON_IsTrue(optional) || (cJSON_IsNumber(optional) && optional->valuedouble != 0) ||
-        (cJSON_IsString(optional) && strcasecmp(optional->valuestring, "true") == 0)))
-      return 1;
-   return 0;
-}
-
 int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
 {
    /* Per-run safety ceilings (WP-5). max_turns is a CUMULATIVE cap on the persisted
@@ -193,35 +173,13 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
       if (r.last_status != WFE_STEP_PENDING)
          continue; /* ADVANCED / LOOPED: keep going */
 
-      /* parked. Only autonomous mode + an auto-OK human gate may proceed. */
-      db1_work_item_t wi;
-      if (db1_work_item_get(work_item_id, &wi) != 1)
-         return 0;
-      if (strcmp(wi.mode, "autonomous") != 0)
-         return 0; /* interactive: park */
-
-      char ferr[256];
-      wfe_def_t *def = wfe_load_workflow(wi.workflow_name, ferr, sizeof ferr);
-      const wfe_node_t *node = def ? wfe_def_node(def, wi.current_stage) : NULL;
-      int auto_ok = human_gate_auto_ok(node);
-      if (def)
-         wfe_def_free(def);
-      if (!auto_ok)
-         return 0; /* roundtable-degraded / non-preauthorized human gate: park */
-
-      /* preauthorized human gate: record a signed approval + clear the pause so
-       * the next advance passes it. (This is a standing user authorization, not
-       * a forged approval.) */
-      if (wfe_approval_record(work_item_id, wi.current_stage, wi.content_hash,
-                              "autonomous-preauth") != 0)
-      {
-         snprintf(err, errlen, "autonomy: could not record preauth approval at '%s'",
-                  wi.current_stage);
-         return -1; /* surface the failure; do not silently park forever */
-      }
-      db1_lifecycle_event_add(work_item_id, wi.current_stage, "resume", "autonomous",
-                              "preauthorized", wi.content_hash, 0);
-      db1_work_item_clear_pause(work_item_id);
+      /* Parked at a gate. A human gate is an INVIOLABLE stop: autonomous mode
+       * never self-approves it, regardless of any node params — only a human's
+       * authenticated, signed approval (POST /v1/workflow/items/<id>/gate, which
+       * attributes the decision to the caller's attested principal and records an
+       * HMAC-signed approval bound to the content hash) can clear it. So a parked
+       * step ends this autonomy pass; the run waits for the human. */
+      return 0;
    }
    snprintf(err, errlen, "autonomy run exceeded step bound");
    return -1;

--- a/src/workflow/wfe_autonomy.h
+++ b/src/workflow/wfe_autonomy.h
@@ -1,10 +1,12 @@
 /* wfe_autonomy.h: the autonomy driver + the human-only gate-override.
  *
  * In autonomous mode the driver auto-advances machine gates (via the engine) and
- * auto-satisfies ONLY human gates whose policy is preauthorized/optional; it
- * parks at every other human gate (pending_human) and at a degraded roundtable.
- * It NEVER forges a human approval: gate-override is a signed human action that
- * autonomous runs cannot invoke. */
+ * parks at EVERY human gate (pending_human) and at a degraded roundtable. A human
+ * gate is inviolable: the driver never auto-satisfies one — not even with node
+ * params like policy:preauthorized or optional:true (those are rejected at
+ * workflow validation) — and never forges a human approval. Only a human's
+ * signed action (gate-override / the gate endpoint, attributed to an attested
+ * principal) clears a human gate; autonomous runs cannot invoke it. */
 #ifndef DEC_WFE_AUTONOMY_H
 #define DEC_WFE_AUTONOMY_H 1
 

--- a/src/workflow/wfe_validate.c
+++ b/src/workflow/wfe_validate.c
@@ -114,11 +114,23 @@ static int check_gate_rules(const wfe_node_t *n, char *err, size_t errlen)
    {
       const char *policy = param_str(n->params, "policy");
       int optional = param_bool(n->params, "optional", 0);
-      if (optional && policy && strcmp(policy, "pr_review") == 0)
+      /* A human gate is an inviolable stop: it must not be declared auto-
+       * satisfiable. policy:preauthorized and optional:true both asked the
+       * autonomy driver to clear the gate without a human — no longer permitted,
+       * so reject them at authoring time rather than silently ignoring them. */
+      if (policy && strcmp(policy, "preauthorized") == 0)
       {
          snprintf(err, errlen,
-                  "node '%s': gate.human optional:true is incompatible with "
-                  "policy pr_review",
+                  "node '%s': gate.human policy 'preauthorized' is not allowed — a "
+                  "human gate cannot be auto-satisfied in autonomous mode",
+                  n->id);
+         return -1;
+      }
+      if (optional)
+      {
+         snprintf(err, errlen,
+                  "node '%s': gate.human optional:true is not allowed — a human gate "
+                  "cannot be skipped or auto-satisfied",
                   n->id);
          return -1;
       }


### PR DESCRIPTION
## What

Makes a `gate.human` step an **inviolable** stop: it can no longer be auto-satisfied by the autonomy driver under any circumstances, and a workflow can't even declare one as auto-satisfiable.

## Why

Today, when a `gate.human` node is marked `policy: preauthorized` or `optional: true`, an autonomous run doesn't stop at it — the server records a signed `autonomous-preauth` approval (its own HMAC, no human, no human cert) and clears the pause. That means a **required human decision can be overridden** by the machine. Per the requirement that *anything human-gated must be impossible to override and require real cryptographic auth*, that path must not exist.

Discovered while wiring the proposals trigger to default to autonomous ([#1231](https://github.com/RakuenSoftware/aimee/pull/1231)): a triggered autonomous run would otherwise blow through any preauthorized gate.

## Change

- **`wfe_autonomy.c`** — delete `human_gate_auto_ok` and the preauthorized self-approval branch. A parked step now unconditionally ends the autonomy pass, so an autonomous run **parks at every human gate** until a person acts. The human-only `wfe_gate_override` path is untouched.
- **`wfe_validate.c`** — reject `policy: preauthorized` and `optional: true` on a `gate.human`, so an auto-satisfiable human gate can't be authored in the first place.

The only way past a human gate remains a **human's signed approval** via `POST /v1/workflow/items/<id>/gate`: operator-gated (`CAP_WORKFLOW_ADMIN`, outside the ordinary authenticated set), attributed to the caller's **attested principal** (mTLS client cert), and recorded as an **HMAC-signed** approval **bound to the step's content hash**.

## Blast radius

No shipped workflow uses `preauthorized`/`optional` on a `gate.human` (`build`/`hotfix`/`managed-change`/`slice` use `gate.roundtable`; `manual-review` uses `policy: pr_review`). So nothing regresses.

## Verification

- `unit-test-wfe-autonomy` — green; **A1 rewritten** to assert an autonomous run **parks** at a human gate (was: auto-advanced to accepted).
- `unit-test-workflow` — green; new negative cases reject `policy: preauthorized` and `optional: true` on `gate.human`, plus a positive case for a plain human gate.
- `unit-test-wfe-approval`, `-gate-reject`, `-native-gate`, `-sliced-build`, `-enforce`, `-safety` — all green.
- Confirmed all shipped `config/workflows/*.yaml` still validate.
- Docs regenerated via `make -C src docs-gen` (only the intended deltas).

## Relation to #1231

Composes with #1231 (trigger `mode`, default autonomous): that makes triggered runs *run*; this guarantees they still **stop** at every human gate. Independent PRs; either order is safe.