### PR TITLE
ci(llm): auto-ensure rerank artifacts before publishing the image

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -64,9 +64,17 @@ jobs:
           fi
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
+  # Ensure the rerank artifacts release exists BEFORE any image is published, so a
+  # container pulling :latest never crash-loops on a missing rerank fetch. Cheap +
+  # idempotent: only converts when the release is missing an asset (see the workflow).
+  rerank-artifacts:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-rerank-artifacts.yml
+
   # Build each image for each arch on a native runner; push by digest only.
   build:
-    needs: prep
+    needs: [prep, rerank-artifacts]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-llm-testing.yml
+++ b/.github/workflows/publish-llm-testing.yml
@@ -33,7 +33,16 @@ permissions:
   packages: write
 
 jobs:
+  # Ensure the rerank artifacts release exists BEFORE the image is published, so a
+  # container pulling :testing never crash-loops on a missing rerank fetch. Cheap +
+  # idempotent: only converts when the release is missing an asset (see the workflow).
+  rerank-artifacts:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-rerank-artifacts.yml
+
   build:
+    needs: rerank-artifacts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-rerank-artifacts.yml
+++ b/.github/workflows/publish-rerank-artifacts.yml
@@ -1,32 +1,41 @@
-# Convert the ettin rerankers ONCE and publish them as GitHub release assets, so
-# the model-less aimee-llm image can `wget` the pre-converted encoder GGUF + Dense
-# head at runtime (the ST score head doesn't survive GGUF conversion, so the
-# gateway applies it — see scripts/aimee_llm_rerank_head.py). This is the ONLY
-# piece of the aimee-llm model set that isn't a plain HF GGUF pull; embed + synth
-# come straight from Hugging Face at container start.
+# Convert the ettin rerankers and publish them as GitHub release assets, so the
+# model-less aimee-llm image can `wget` the pre-converted encoder GGUF + Dense head
+# at runtime (the ST score head doesn't survive GGUF conversion, so the gateway
+# applies it — see scripts/aimee_llm_rerank_head.py). This is the ONLY piece of the
+# aimee-llm model set that isn't a plain HF GGUF pull; embed + synth come straight
+# from Hugging Face at container start.
 #
-# Dispatch-only + rarely run: the ettin models + the llama.cpp converter change
-# almost never, and the outputs are content-addressed by the SHA256SUMS the
-# supervisor verifies. Re-run only when bumping the reranker or the converter.
+# AUTOMATED, not a manual prerequisite: the image-publish workflows
+# (publish-llm-testing.yml, publish-images.yml) CALL this as a prerequisite job, so
+# a container image is never published without the rerank release existing. It is
+# IDEMPOTENT — the expensive conversion runs only when the `rerank-artifacts-v1`
+# release is missing an asset (or a dispatch sets force=true); otherwise it detects
+# the complete release and skips in seconds. Bumping the reranker/converter is thus
+# picked up automatically (delete the release, or dispatch with force=true, to
+# re-convert), and every normal CI run just confirms the assets are present.
 #
-# Assets uploaded to the `rerank-artifacts-v1` release (names the supervisor
-# depends on — scripts/aimee-llm-supervisor.sh, RERANK_ASSET_BASE):
+# Assets on the `rerank-artifacts-v1` release (names the supervisor depends on —
+# scripts/aimee-llm-supervisor.sh, RERANK_ASSET_BASE):
 #   rerank-ettin-68m.gguf   rerank-ettin-68m.head.npz
 #   rerank-ettin-400m.gguf  rerank-ettin-400m.head.npz
 #   SHA256SUMS
 name: Publish rerank artifacts
 
 on:
+  # Called by the image-publish workflows as a prerequisite (see their `needs`).
+  workflow_call: {}
   workflow_dispatch:
     inputs:
-      release_tag:
-        description: "Release tag to publish the converted rerank artifacts to"
-        type: string
-        default: rerank-artifacts-v1
+      force:
+        description: "Re-convert and re-upload even if the release already has the assets"
+        type: boolean
+        default: false
 
 concurrency:
-  group: publish-rerank-artifacts-${{ github.ref }}
-  cancel-in-progress: true
+  # Static group (not per-ref) + no cancel: concurrent callers serialize on the
+  # single shared release instead of racing two uploads or cancelling each other.
+  group: publish-rerank-artifacts
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -35,12 +44,35 @@ jobs:
   convert:
     runs-on: ubuntu-latest
     env:
-      RELEASE_TAG: ${{ inputs.release_tag || 'rerank-artifacts-v1' }}
+      RELEASE_TAG: rerank-artifacts-v1
       HF_HUB_DISABLE_TELEMETRY: "1"
     steps:
       - uses: actions/checkout@v4
 
+      # Skip the expensive conversion when the release already has every asset
+      # (idempotent). force=true (dispatch only) always re-converts.
+      - name: Check whether the release already has all assets
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          need="rerank-ettin-68m.gguf rerank-ettin-68m.head.npz rerank-ettin-400m.gguf rerank-ettin-400m.head.npz SHA256SUMS"
+          skip=false
+          if [ "${{ github.event.inputs.force }}" != "true" ] \
+             && gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' > have.txt 2>/dev/null; then
+            skip=true
+            for a in $need; do grep -qxF "$a" have.txt || skip=false; done
+          fi
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+          if [ "$skip" = true ]; then
+            echo "release $RELEASE_TAG already has all assets — skipping conversion"
+          else
+            echo "release incomplete or force set — conversion needed"
+          fi
+
       - uses: actions/setup-python@v5
+        if: steps.check.outputs.skip != 'true'
         with:
           python-version: "3.12"
 
@@ -48,17 +80,20 @@ jobs:
       # `modelprep` stage exactly — it is the same conversion, just hoisted to CI so
       # the runtime image needs neither torch nor the converter.
       - name: Install conversion deps
+        if: steps.check.outputs.skip != 'true'
         run: |
           python -m pip install --quiet torch --index-url https://download.pytorch.org/whl/cpu
           python -m pip install --quiet transformers safetensors numpy gguf sentencepiece protobuf huggingface_hub
 
       # convert_hf_to_gguf.py + gguf-py from a recent llama.cpp (ModernBert supported).
       - name: Clone llama.cpp (converter)
+        if: steps.check.outputs.skip != 'true'
         run: git clone --depth 1 https://github.com/ggml-org/llama.cpp /tmp/llama
 
       # Convert BOTH ettin tiers: encoder -> GGUF (f16) + Dense head -> head.npz.
       # 68m backs the cpu tier; 400m backs small/mid/large.
       - name: Convert ettin rerankers
+        if: steps.check.outputs.skip != 'true'
         run: |
           set -euo pipefail
           mkdir -p out
@@ -69,6 +104,7 @@ jobs:
 
       # Create the release if it doesn't exist, then upload (clobber to allow re-runs).
       - name: Publish to the release
+        if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -47,10 +47,13 @@ CI builds + publishes the **one** model-less `aimee-llm` image as part of the no
 - **testing:** `.github/workflows/publish-llm-testing.yml` builds `aimee-llm` on `testing`
   pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts, tagged `:testing`
   (+ `:testing-<sha>`, amd64).
-- **rerank artifacts (prerequisite):** `.github/workflows/publish-rerank-artifacts.yml` is a
-  dispatch job that converts the ettin rerankers once and uploads them to the
-  `rerank-artifacts-v1` GitHub release. **Run it before any container starts** — the supervisor
-  fetches the rerank encoder + head from that release on first boot.
+- **rerank artifacts (automatic):** `.github/workflows/publish-rerank-artifacts.yml` converts
+  the ettin rerankers and uploads them to the `rerank-artifacts-v1` GitHub release, which the
+  supervisor fetches on first boot. Both publish workflows above CALL it as a prerequisite
+  (`needs`), so a container image is never published without the release existing — no manual
+  step. It is idempotent: the expensive conversion runs only when an asset is missing (first
+  run, or after you delete the release / dispatch it with `force=true` to bump the reranker);
+  every other run just confirms the assets are present and skips.
 
 To build out-of-band (e.g. on a PVE CT with docker) — one model-less image, no model build-args:
 


### PR DESCRIPTION
## Summary
Follow-up to #1232. The `rerank-artifacts-v1` release was a **manual dispatch prerequisite**
— a footgun, since an `aimee-llm` container crash-loops on its first-boot rerank fetch until
someone remembers to run the workflow. This makes it **purely automated**.

## Changes
- **`publish-rerank-artifacts.yml`**: adds a `workflow_call` trigger and is now **idempotent** —
  a cheap first step checks whether the release already has all five assets and skips the
  torch conversion when it does (a `workflow_dispatch` with `force=true` re-converts). Static
  concurrency group (no cancel) so concurrent callers serialize on the one shared release
  instead of racing two uploads.
- **`publish-llm-testing.yml`** and **`publish-images.yml`**: call it as a prerequisite job
  (`needs: rerank-artifacts`), so an `aimee-llm` image is **never published without the
  release existing**. First run converts + publishes once (~minutes); every later run just
  confirms the assets are present and skips (~seconds).
- **Docs**: the cutover runbook now describes the release as automatic, not a manual step.

## Result
No human ever runs a workflow by hand. Bumping the reranker = delete the release (or dispatch
with `force=true`); the next image publish re-converts automatically.