### PR TITLE
fix(workflow): author.proposal accepts a pre-supplied complete proposal

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -11,6 +11,14 @@ Thin-client + credential hardening, the client owns the working tree; agent
 credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).
 
+- **`author.proposal` accepts a pre-supplied proposal**: an autonomous run whose
+  proposal is already complete (the proposals trigger materializes a finished,
+  merged proposal — the merge is the approval) no longer loops the `draft` step to
+  `max_iters`. When the author delegate makes no change, `author.proposal` now
+  advances on the existing non-empty proposal instead of treating the no-op as a
+  failure. The guard is strict: with no proposal on disk yet, a failed author
+  dispatch still loops, and `author.plan`/code roles still treat a no-op as the
+  real failure it is.
 - **Trigger `mode` (autonomous by default)**: `trigger_rules` now take a `mode`
   field selecting how a triggered run executes — `autonomous` (the default: the
   autonomy scheduler drives it hands-off, right for "merging a proposal *is* the

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -270,6 +270,45 @@ int main(void)
    assert(g_deleg_calls == 1);
    assert(g_open_calls == 0); /* open is NULL -> not called, no crash */
 
+   /* C2: author.proposal accepts a pre-supplied, non-empty proposal even when the
+    *     delegate changes nothing (dispatch fails / no-op). The proposals trigger
+    *     supplies a complete, already-approved proposal (the merge IS the approval),
+    *     so a "revise" delegate correctly makes no change — this must advance, NOT
+    *     loop the draft to max_iters. */
+   wfe_set_delegate_provider(&MOCK_DELEG);
+   wfe_set_forge_provider(&MOCK_FORGE);
+   {
+      char pp[300];
+      snprintf(pp, sizeof pp, "%s/complete-proposal.md", home);
+      FILE *pf = fopen(pp, "wb");
+      assert(pf);
+      fputs("# A complete, already-approved proposal\n\nBody.\n", pf);
+      fclose(pf);
+
+      g_deleg_rc = -1; /* delegate reports success-but-no-change / failure */
+      g_deleg_calls = 0;
+      g_open_calls = 0;
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("ds", "r", pp, "interactive", id, err, sizeof err) == 0);
+      assert(wfe_engine_run(id, err, sizeof err) == 0);
+      assert(g_deleg_calls >= 1); /* the author delegate WAS dispatched */
+      assert(g_open_calls == 1);  /* author accepted the proposal and advanced to pr.open */
+   }
+
+   /* C3: the acceptance is strictly for an ALREADY-PRESENT proposal — with no
+    *     artifact on disk, a failed author dispatch still loops (and the run never
+    *     reaches pr.open). Guards against blindly advancing an empty proposal. */
+   {
+      char pp[300];
+      snprintf(pp, sizeof pp, "%s/missing-proposal.md", home); /* never created */
+      g_deleg_rc = -1;
+      g_open_calls = 0;
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("ds", "r", pp, "interactive", id, err, sizeof err) == 0);
+      (void)wfe_engine_run(id, err, sizeof err); /* author loops -> parks at max_iters */
+      assert(g_open_calls == 0);                 /* never advanced past the author node */
+   }
+
    /* D: implement verify gate (WP-1b) — a unit advances ONLY on a top-level
     *    verdict:passed; everything else (incl. NO provider) fails closed. */
    {

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -587,30 +587,32 @@ static wfe_step_result_t with_cost(wfe_step_result_t r, double cost)
 /* ---- executors ---- */
 
 /* author.proposal / author.plan: drive a delegate to produce/edit the artifact,
- * then hash the artifact file. */
+ * then hash the artifact file. A failed dispatch loops to retry — except
+ * author.proposal accepts an already-present, non-empty proposal (see below), so
+ * a pre-supplied complete proposal (the proposals-trigger case) is not looped. */
 static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
 {
    const char *path = wfe_ctx_proposal_path(ctx);
-   /* Dispatch a delegate to author/edit `path` (no-op if no provider installed;
-    * a failed run loops). Then hash the artifact file as the produced content; if
-    * it is absent (no provider ran) the gate that follows simply re-loops. */
+   /* Dispatch a delegate to author/edit `path` (no-op if no provider installed). */
    char wd[1024];
    resolve_workdir(ctx, wd, sizeof wd);
    char commit[64] = "";
    double cost = 0.0;
-   if (wfe_delegate_dispatch(wd, "architect", node_delegate(node),
-                             "Author or revise the workflow artifact at the given path "
-                             "per the work item, then commit it.",
-                             path, commit, &cost) < 0)
-      return with_cost(wfe_step_looped(), cost);
+   int drc = wfe_delegate_dispatch(wd, "architect", node_delegate(node),
+                                   "Author or revise the workflow artifact at the given path "
+                                   "per the work item, then commit it.",
+                                   path, commit, &cost);
+   /* Hash the artifact file as the produced content, and note whether it holds
+    * any content at all. */
    char hash[65] = "";
+   long sz = 0;
    if (path && path[0])
    {
       FILE *f = fopen(path, "rb");
       if (f)
       {
          fseek(f, 0, SEEK_END);
-         long sz = ftell(f);
+         sz = ftell(f);
          if (sz < 0)
             sz = 0;
          fseek(f, 0, SEEK_SET);
@@ -627,6 +629,21 @@ static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
    }
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
+   if (drc < 0)
+   {
+      /* The delegate did not advance the artifact (no provider, an error, or a
+       * no-op that changed no files). For author.proposal that is acceptable when
+       * the proposal artifact is ALREADY present and non-empty: the proposals
+       * trigger supplies a complete, already-approved proposal (the merge IS the
+       * approval), so a "revise" delegate correctly changes nothing — accept the
+       * existing proposal instead of looping to max_iters. With no artifact yet
+       * (empty/missing file) it is a genuine non-advance, so loop and retry.
+       * author.plan and every other author node have no pre-supplied artifact, so
+       * they always loop on a failed dispatch. */
+      if (node->block == WFE_BLK_AUTHOR_PROPOSAL && sz > 0 && hash[0])
+         return wfe_step_advanced(handle, hash, cost);
+      return with_cost(wfe_step_looped(), cost);
+   }
    return wfe_step_advanced(handle, hash, cost);
 }
 


### PR DESCRIPTION
## What

Makes the `build` workflow's `draft` step (`author.proposal`) **accept an already-complete proposal** instead of looping to `max_iters` when the author delegate changes nothing.

## Why (root cause)

A proposal filed by the `proposals` trigger is materialized **complete** (the merged proposal — the merge is the approval). The `draft`/`author.proposal` step dispatches an architect delegate to *revise* it, but a finished proposal needs no change, so the delegate no-ops. Then:

- `delegate_detect_noop_write` (`delegate_run_phases.c`) flags a write-role "success but no owned files changed" run as incomplete,
- `wfe_delegate_dispatch` (`wfe_blocks.c`) returns `-1`,
- `exec_author` returns `wfe_step_looped` → the engine loops `draft` to the per-node `max_iters` cap and **parks**.

**Net effect: triggered proposals never built out — they stalled at `draft`.** Verified on .254: `wi_33fadc24` looped its author delegate 20× → `max_iters` (surfaced as `pending_human`), while a `dev/submit` item on the *same* workflow advanced `draft → feature` because its author step produced a change.

## Fix

In `exec_author`, on a failed/no-op dispatch: if the node is `author.proposal` **and** the artifact file is already present and **non-empty**, advance on the existing proposal instead of looping. Strictly guarded:

- **only `author.proposal`** — `author.plan` and code roles still treat a no-op as the real failure it is (nothing produced);
- **only when the proposal file already has content** — no artifact on disk ⇒ still loop and retry.

This is the minimal change that makes "merge a finished proposal → it builds out" work, matching the intended trigger semantics. It does not touch the no-op detector (which correctly guards *implement*/code steps).

## Verification

- `unit-test-wfe-delegate-seam` — green, with two new cases:
  - **C2**: no-op dispatch (`g_deleg_rc=-1`) + a non-empty proposal on disk → `author.proposal` advances and `pr.open` fires.
  - **C3**: no artifact on disk → a failed author dispatch still loops, never advances.
  - **Red-checked**: with the fix neutered, C2 aborts (`draft` loops to `max_iters`), proving the test exercises the fix.
- Regression: `unit-test-wfe-autonomy`, `unit-test-wfe-engine`, `unit-test-wfe-sliced-build` all green.

## Relation

Completes the proposals-trigger path started in #1231 (trigger `mode`) — the trigger fires and files an autonomous item; this lets that item actually build out. Independent of #1233 (inviolable gates); both are already on `testing`.