### PR TITLE
feat(workflow): thread roundtable feedback into re-authoring (refinement convergence)

### DIFF
--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -45,10 +45,16 @@ nodes:
       base: trunk
     next: plan
   # The primary authors the implementation/action plan from the proposal.
+  # max_iters gives the plan<->plan_gate refinement loop enough re-author rounds
+  # to converge: each rejection persists the panel's blockers, which the next
+  # author.plan pass folds into its prompt (see wfe_blocks exec_author). The
+  # roundtable's own debate is separately bounded by plan_gate.max_rounds.
   - id: plan
     block: author.plan
     in:
       proposal: draft.out
+    params:
+      max_iters: 60
     next: plan_gate
     on_fail: plan
   # Roundtable approves the plan AGAINST the proposal (focus lens). Standard

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -11,6 +11,15 @@ Thin-client + credential hardening, the client owns the working tree; agent
 credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).
 
+- **Roundtable ↔ planner now refine together**: when a `gate.roundtable` requests
+  changes, the panel's blockers are captured and persisted for the work item, and
+  the next `author.proposal`/`author.plan` pass folds them into its prompt — so the
+  re-author addresses the actual objections instead of re-authoring blind. Before
+  this, the panel's critique was discarded (only the pass/fail enum survived), so
+  the plan↔gate loop couldn't converge and churned until the per-node `max_iters`
+  backstop parked the run. The build workflow's `plan` step also gets a larger
+  `max_iters` so a genuinely converging refinement loop isn't cut off early.
+
 - **`author.proposal` accepts a pre-supplied proposal**: an autonomous run whose
   proposal is already complete (the proposals trigger materializes a finished,
   merged proposal — the merge is the approval) no longer loops the `draft` step to

--- a/src/server/wfe_panel_verdict.c
+++ b/src/server/wfe_panel_verdict.c
@@ -32,6 +32,28 @@ void wfe_panel_verdict_from_review(const char *persona, const char *artifact_has
    size_t start = len;
    while (start > 0 && r[start - 1] != '\n')
       start--;
+
+   /* Capture the reviewer's critique — everything before the final JSON verdict
+    * line — so a request_changes can be threaded back to the re-authoring
+    * delegate. Keep the TAIL when it overflows the buffer: reviewers tend to
+    * conclude with their concrete blockers just above the verdict line. Done for
+    * every kind (incl. MALFORMED, which the gate coerces to request_changes). */
+   size_t body = start;
+   while (body > 0 &&
+          (r[body - 1] == '\n' || r[body - 1] == '\r' || r[body - 1] == ' ' || r[body - 1] == '\t'))
+      body--;
+   if (body > 0)
+   {
+      size_t keep = body, off = 0;
+      if (keep >= sizeof out->feedback)
+      {
+         keep = sizeof out->feedback - 1;
+         off = body - keep;
+      }
+      memcpy(out->feedback, r + off, keep);
+      out->feedback[keep] = '\0';
+   }
+
    size_t llen = len - start;
    char line[1024];
    if (llen == 0 || llen >= sizeof line)

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -23,15 +23,16 @@ static int g_deleg_calls;
 static int g_deleg_rc; /* 0 success, -1 failure */
 static char g_deleg_last_role[32];
 static char g_deleg_last_delegate[32];
+static char g_deleg_last_prompt[8192];
 static int mock_deleg_run(const char *workdir, const char *role, const char *delegate,
                           const char *prompt, const char *artifact_path, char out_commit_sha[64],
                           char *err, size_t n)
 {
    (void)workdir;
-   (void)prompt;
    (void)artifact_path;
    (void)err;
    (void)n;
+   snprintf(g_deleg_last_prompt, sizeof g_deleg_last_prompt, "%s", prompt ? prompt : "");
    g_deleg_calls++;
    snprintf(g_deleg_last_role, sizeof g_deleg_last_role, "%s", role ? role : "");
    snprintf(g_deleg_last_delegate, sizeof g_deleg_last_delegate, "%s", delegate ? delegate : "");
@@ -307,6 +308,28 @@ int main(void)
       assert(wfe_work_item_create("ds", "r", pp, "interactive", id, err, sizeof err) == 0);
       (void)wfe_engine_run(id, err, sizeof err); /* author loops -> parks at max_iters */
       assert(g_open_calls == 0);                 /* never advanced past the author node */
+   }
+
+   /* C4: roundtable feedback is folded into the re-authoring prompt. A gate that
+    *     requested changes persists blockers for the work item; the next author
+    *     pass must carry them so it refines against the panel's objections rather
+    *     than re-authoring blind. */
+   {
+      char pp[300];
+      snprintf(pp, sizeof pp, "%s/fb-proposal.md", home);
+      FILE *pf = fopen(pp, "wb");
+      assert(pf);
+      fputs("# proposal\n", pf);
+      fclose(pf);
+      g_deleg_rc = 0; /* author advances normally */
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("ds", "r", pp, "autonomous", id, err, sizeof err) == 0);
+      /* the roundtable persisted these blockers on a prior request_changes */
+      assert(wfe_feedback_write(id, "## qa\nNo tests specified. Add acceptance criteria.") == 0);
+      g_deleg_last_prompt[0] = '\0';
+      assert(wfe_engine_run(id, err, sizeof err) == 0);
+      assert(strstr(g_deleg_last_prompt, "No tests specified") != NULL); /* blockers threaded */
+      wfe_feedback_clear(id);
    }
 
    /* D: implement verify gate (WP-1b) — a unit advances ONLY on a top-level

--- a/src/tests/test_wfe_panel_verdict.c
+++ b/src/tests/test_wfe_panel_verdict.c
@@ -28,14 +28,18 @@ int main(void)
       assert(strcmp(v.reviewed_content_hash, "HASH123") == 0); /* gate integrity check */
       assert(v.schema_version == WFE_VERDICT_SCHEMA);
       assert(v.high_sev_blockers == 0);
+      assert(strcmp(v.feedback, "looks good overall.") == 0); /* critique captured */
    }
-   /* request_changes with blocker count */
+   /* request_changes with blocker count + captured critique (threaded to re-author) */
    {
       wfe_verdict_t v =
           map("found a bug.\n{\"verdict\":\"request_changes\",\"high_sev_blockers\":2}");
       assert(v.kind == WFE_V_REQUEST_CHANGES);
       assert(v.high_sev_blockers == 2);
+      assert(strcmp(v.feedback, "found a bug.") == 0);
    }
+   /* no reasoning (verdict line only) -> feedback empty */
+   assert(map("{\"verdict\":\"request_changes\"}").feedback[0] == '\0');
    /* comment */
    assert(map("{\"verdict\":\"comment\"}").kind == WFE_V_COMMENT);
 

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -608,13 +608,14 @@ static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
    if (feedback[0])
       snprintf(prompt, sizeof prompt,
                "%s\n\nA prior review roundtable REQUESTED CHANGES on your last revision. You MUST "
-               "address every blocker below and commit the improved artifact:\n\n%s", base_prompt,
-               feedback);
+               "address every blocker below and commit the improved artifact:\n\n%s",
+               base_prompt, feedback);
    else
       snprintf(prompt, sizeof prompt, "%s", base_prompt);
    char commit[64] = "";
    double cost = 0.0;
-   int drc = wfe_delegate_dispatch(wd, "architect", node_delegate(node), prompt, path, commit, &cost);
+   int drc =
+       wfe_delegate_dispatch(wd, "architect", node_delegate(node), prompt, path, commit, &cost);
    /* Hash the artifact file as the produced content, and note whether it holds
     * any content at all. */
    char hash[65] = "";

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -593,15 +593,28 @@ static wfe_step_result_t with_cost(wfe_step_result_t r, double cost)
 static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
 {
    const char *path = wfe_ctx_proposal_path(ctx);
-   /* Dispatch a delegate to author/edit `path` (no-op if no provider installed). */
+   /* Dispatch a delegate to author/edit `path` (no-op if no provider installed).
+    * If a prior review roundtable left blockers for this work item (persisted via
+    * on_fail), fold them into the prompt so this pass REFINES against the panel's
+    * objections rather than re-authoring blind — the plan<->roundtable loop can
+    * then converge instead of churning to max_iters. */
    char wd[1024];
    resolve_workdir(ctx, wd, sizeof wd);
+   char feedback[4096];
+   wfe_feedback_read(wfe_ctx_work_item(ctx), feedback, sizeof feedback);
+   const char *base_prompt = "Author or revise the workflow artifact at the given path per the "
+                             "work item, then commit it.";
+   char prompt[4096 + 512];
+   if (feedback[0])
+      snprintf(prompt, sizeof prompt,
+               "%s\n\nA prior review roundtable REQUESTED CHANGES on your last revision. You MUST "
+               "address every blocker below and commit the improved artifact:\n\n%s", base_prompt,
+               feedback);
+   else
+      snprintf(prompt, sizeof prompt, "%s", base_prompt);
    char commit[64] = "";
    double cost = 0.0;
-   int drc = wfe_delegate_dispatch(wd, "architect", node_delegate(node),
-                                   "Author or revise the workflow artifact at the given path "
-                                   "per the work item, then commit it.",
-                                   path, commit, &cost);
+   int drc = wfe_delegate_dispatch(wd, "architect", node_delegate(node), prompt, path, commit, &cost);
    /* Hash the artifact file as the produced content, and note whether it holds
     * any content at all. */
    char hash[65] = "";

--- a/src/workflow/wfe_def.c
+++ b/src/workflow/wfe_def.c
@@ -5,7 +5,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#ifdef _WIN32
+#include <direct.h>
+#define WFE_MKDIR(p) _mkdir(p)
+#else
 #include <sys/stat.h>
+#define WFE_MKDIR(p) mkdir((p), 0700)
+#endif
 
 #include "yaml.h"
 
@@ -416,7 +422,7 @@ int wfe_feedback_write(const char *work_item_id, const char *text)
    const char *home = getenv("AIMEE_HOME");
    char dir[1024];
    snprintf(dir, sizeof dir, "%s/wfe-feedback", (home && home[0]) ? home : ".");
-   mkdir(dir, 0700);
+   WFE_MKDIR(dir);
    char path[1200];
    wfe_feedback_path(work_item_id, path, sizeof path);
    FILE *f = fopen(path, "wb");

--- a/src/workflow/wfe_def.c
+++ b/src/workflow/wfe_def.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <sys/stat.h>
 
 #include "yaml.h"
 
@@ -394,6 +395,63 @@ int wfe_node_max_iters(const wfe_node_t *n)
    if (cJSON_IsNumber(m) && m->valueint > 0)
       return m->valueint;
    return WFE_DEFAULT_MAX_ITERS;
+}
+
+/* ---- roundtable -> re-author feedback channel ----
+ * A gate.roundtable persists the panel's blockers here on request_changes; the
+ * re-authoring delegate (author.proposal / author.plan) reads them so it refines
+ * against the actual objections instead of re-authoring blind. Keyed by work item
+ * under $AIMEE_HOME/wfe-feedback/<id>.md (outside any git tree, so it is never
+ * committed). Best-effort: a missing/failed file is simply "no feedback". */
+static void wfe_feedback_path(const char *wid, char *buf, size_t n)
+{
+   const char *home = getenv("AIMEE_HOME");
+   snprintf(buf, n, "%s/wfe-feedback/%s.md", (home && home[0]) ? home : ".", wid ? wid : "");
+}
+
+int wfe_feedback_write(const char *work_item_id, const char *text)
+{
+   if (!work_item_id || !work_item_id[0])
+      return -1;
+   const char *home = getenv("AIMEE_HOME");
+   char dir[1024];
+   snprintf(dir, sizeof dir, "%s/wfe-feedback", (home && home[0]) ? home : ".");
+   mkdir(dir, 0700);
+   char path[1200];
+   wfe_feedback_path(work_item_id, path, sizeof path);
+   FILE *f = fopen(path, "wb");
+   if (!f)
+      return -1;
+   if (text && text[0])
+      fwrite(text, 1, strlen(text), f);
+   fclose(f);
+   return 0;
+}
+
+int wfe_feedback_read(const char *work_item_id, char *buf, size_t cap)
+{
+   if (buf && cap)
+      buf[0] = '\0';
+   if (!work_item_id || !work_item_id[0] || !buf || cap == 0)
+      return 0;
+   char path[1200];
+   wfe_feedback_path(work_item_id, path, sizeof path);
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return 0;
+   size_t rd = fread(buf, 1, cap - 1, f);
+   buf[rd] = '\0';
+   fclose(f);
+   return (int)rd;
+}
+
+void wfe_feedback_clear(const char *work_item_id)
+{
+   if (!work_item_id || !work_item_id[0])
+      return;
+   char path[1200];
+   wfe_feedback_path(work_item_id, path, sizeof path);
+   remove(path);
 }
 
 wfe_on_max_t wfe_node_on_max(const wfe_node_t *n)

--- a/src/workflow/wfe_def.h
+++ b/src/workflow/wfe_def.h
@@ -177,7 +177,7 @@ int wfe_sha256_raw(const void *data, size_t len, unsigned char out[32]);
  * them on request_changes; the re-authoring author node reads them so it refines
  * against the objections). Stored at $AIMEE_HOME/wfe-feedback/<id>.md, outside any
  * git tree. All best-effort. */
-int wfe_feedback_write(const char *work_item_id, const char *text); /* 0 on success */
+int wfe_feedback_write(const char *work_item_id, const char *text);     /* 0 on success */
 int wfe_feedback_read(const char *work_item_id, char *buf, size_t cap); /* bytes read (0=none) */
 void wfe_feedback_clear(const char *work_item_id);
 

--- a/src/workflow/wfe_def.h
+++ b/src/workflow/wfe_def.h
@@ -172,4 +172,13 @@ int wfe_sha256_hex(const void *data, size_t len, char out_hex[65]);
 /* sha256 raw 32-byte digest (used for HMAC in the approval signer). */
 int wfe_sha256_raw(const void *data, size_t len, unsigned char out[32]);
 
+/* ---- roundtable -> re-author feedback channel ----
+ * Persist the review panel's blockers for a work item (a gate.roundtable writes
+ * them on request_changes; the re-authoring author node reads them so it refines
+ * against the objections). Stored at $AIMEE_HOME/wfe-feedback/<id>.md, outside any
+ * git tree. All best-effort. */
+int wfe_feedback_write(const char *work_item_id, const char *text); /* 0 on success */
+int wfe_feedback_read(const char *work_item_id, char *buf, size_t cap); /* bytes read (0=none) */
+void wfe_feedback_clear(const char *work_item_id);
+
 #endif /* DEC_WFE_DEF_H */

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -164,12 +164,33 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
    {
    case WFE_GATE_APPROVE:
    {
+      /* Passed: drop any stale review feedback so it can't bleed into a later
+       * author step for this work item. */
+      wfe_feedback_clear(wi);
       char handle[80];
       snprintf(handle, sizeof handle, "%s.out", node->id);
       return wfe_step_advanced(handle, artifact_hash, 0.0);
    }
    case WFE_GATE_CHANGES:
+   {
+      /* Persist the panel's blockers so the re-authoring delegate (via on_fail)
+       * refines against the actual objections instead of re-authoring blind. */
+      const cJSON *fj = node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "focus") : NULL;
+      const char *focus = (fj && cJSON_IsString(fj)) ? fj->valuestring : "";
+      char agg[4096];
+      int off = snprintf(agg, sizeof agg,
+                         "The review roundtable requested changes%s%s. Revise to resolve the "
+                         "reviewers' blockers below, then commit:\n",
+                         focus[0] ? " — focus: " : "", focus);
+      for (int i = 0; i < nv && off > 0 && (size_t)off < sizeof agg; i++)
+         if ((verdicts[i].kind == WFE_V_REQUEST_CHANGES || verdicts[i].kind == WFE_V_MALFORMED) &&
+             verdicts[i].feedback[0])
+            off += snprintf(agg + off, sizeof agg - (size_t)off, "\n## %s\n%s\n",
+                            verdicts[i].persona[0] ? verdicts[i].persona : "reviewer",
+                            verdicts[i].feedback);
+      wfe_feedback_write(wi, agg);
       return wfe_step_looped();
+   }
    case WFE_GATE_DEGRADED:
    default:
       return wfe_step_pending(WFE_PAUSE_PANEL_DEGRADED);

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -175,7 +175,8 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
    {
       /* Persist the panel's blockers so the re-authoring delegate (via on_fail)
        * refines against the actual objections instead of re-authoring blind. */
-      const cJSON *fj = node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "focus") : NULL;
+      const cJSON *fj =
+          node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "focus") : NULL;
       const char *focus = (fj && cJSON_IsString(fj)) ? fj->valuestring : "";
       char agg[4096];
       int off = snprintf(agg, sizeof agg,

--- a/src/workflow/wfe_verdict.h
+++ b/src/workflow/wfe_verdict.h
@@ -8,6 +8,11 @@
 
 #define WFE_VERDICT_SCHEMA 1
 
+/* Max length of a panelist's captured critique (the reasoning that precedes the
+ * final JSON verdict line). Threaded back to the re-authoring delegate on a
+ * request_changes so the planner refines against the actual objections. */
+#define WFE_VERDICT_FEEDBACK_MAX 1024
+
 typedef enum
 {
    WFE_V_APPROVE = 0,
@@ -23,7 +28,9 @@ typedef struct
    int schema_version;
    char reviewed_content_hash[72];
    wfe_verdict_kind_t kind;
-   int high_sev_blockers; /* count of unresolved high-severity blockers */
+   int high_sev_blockers;                   /* count of unresolved high-severity blockers */
+   char feedback[WFE_VERDICT_FEEDBACK_MAX]; /* the panelist's critique text (reasoning before
+                                             * the JSON verdict line); may be empty */
 } wfe_verdict_t;
 
 typedef enum


### PR DESCRIPTION
## What

Makes the roundtable and the planner **refine together**: when a `gate.roundtable` requests changes, its blockers are captured, persisted, and folded into the next `author.proposal`/`author.plan` prompt — so the re-author addresses the objections instead of re-authoring blind.

## Why

The `plan ↔ plan_gate` loop structurally couldn't converge:

- Each panelist writes a real critique, but `wfe_verdict_t` kept **only** the verdict enum + a blocker *count* (`kind` + `high_sev_blockers`), and `live_panel` **freed** the reviewer's full response — the critique was discarded.
- On `request_changes`, `on_fail: plan` re-ran a planner whose only input was `proposal: draft.out`, with a generic *"author or revise"* prompt. **No feedback reached it.**

So the planner re-planned blind → near-identical plan → rejected again → looped until the plan node's `max_iters` backstop parked the run. Observed live on .254: a triggered proposal cleared `draft → feature → plan`, then looped `plan` 20× → `max_iters` (surfaced as `pending_human`).

## Change

- **`wfe_verdict_t`** gains a `feedback` field; **`wfe_panel_verdict_from_review`** captures the reviewer's critique (the reasoning above the final JSON verdict line, tail-truncated).
- **`exec_roundtable`** (`WFE_GATE_CHANGES`): aggregates the `request_changes` blockers and persists them per work item via new **`wfe_feedback_{write,read,clear}`** helpers (`$AIMEE_HOME/wfe-feedback/<id>.md`, outside any git tree). On approve, clears them so they can't bleed into a later stage.
- **`exec_author`**: reads any persisted blockers and folds them into the delegate prompt (*"a prior review roundtable REQUESTED CHANGES … address every blocker below"*).
- **`build.yaml`**: the `plan` node gets a larger `max_iters` so a genuinely converging refinement loop isn't guillotined by the runaway backstop (which stays as a cost/​loop guard).

## Verification

- `unit-test-wfe-panel-verdict` — critique captured for approve/request_changes; empty when only the verdict line is present.
- `unit-test-wfe-delegate-seam` — new **C4**: persisted feedback for a work item is present in the re-authoring delegate's prompt.
- Regressions green: `wfe-roundtable`, `wfe-autonomy`, `wfe-engine`, `wfe-sliced-build`, `config`.

## Follow-up (not in this PR)

Wiring the workflow's roundtable panels to the **configured default roundtable preset** (`roundtable.default`) is a separable, linkage-sensitive change (engine → config/preset) and lands next.