### PR TITLE
fix(session-start): inject worktree onboarding on the co-located path too

### DIFF
--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -746,7 +746,22 @@ int handle_session_start(int json_output)
    free(augmented_hook);
    free(stdin_data);
 
+   /* Prepare + surface the per-session worktree onboarding directive when this
+    * session is running against the SHARED MAIN CLONE (not a managed worktree)
+    * and isolation is enforced. This is the SAME onboarding the remote/thin path
+    * already does (handle_session_start_remote): a co-located session started
+    * outside the launcher (e.g. a raw `claude` in the repo) never went through
+    * launch.run and so was never placed on a worktree — without this its first
+    * edit is blocked by the guard. ss_append_worktree_isolation no-ops when the
+    * session is already isolated (launcher/server-forked) or isolation is off, so
+    * an already-placed session is unaffected. It is computed independently of the
+    * RPC response so the directive is emitted even when the server returns no
+    * brief/recall or the RPC failed. */
+   struct ss_sbuf wt = {0};
+   ss_append_worktree_isolation(&wt, sid);
+
    int exit_code = nonblocking ? 0 : 1;
+   const char *server_out = NULL;
    if (resp)
    {
       cJSON *ec = cJSON_GetObjectItemCaseSensitive(resp, "exit_code");
@@ -755,26 +770,41 @@ int handle_session_start(int json_output)
 
       cJSON *jout = cJSON_GetObjectItemCaseSensitive(resp, "output");
       if (cJSON_IsString(jout) && jout->valuestring[0])
-      {
-         cJSON *out = cJSON_CreateObject();
-         cJSON *hook_out = out ? cJSON_AddObjectToObject(out, "hookSpecificOutput") : NULL;
-         if (hook_out)
-         {
-            cJSON_AddStringToObject(hook_out, "hookEventName", "SessionStart");
-            cJSON_AddStringToObject(hook_out, "additionalContext", jout->valuestring);
-            char *s = cJSON_PrintUnformatted(out);
-            if (s)
-            {
-               fputs(s, stdout);
-               fputc('\n', stdout);
-               free(s);
-            }
-         }
-         else
-            fputs(jout->valuestring, stdout);
-         cJSON_Delete(out);
-      }
+         server_out = jout->valuestring;
+   }
 
+   /* additionalContext = [worktree directive] + [server brief/recall]. Emit the
+    * hookSpecificOutput block whenever either part is present. */
+   if ((wt.p && wt.p[0]) || server_out)
+   {
+      struct ss_sbuf ctx = {0};
+      if (wt.p && wt.p[0])
+         ss_add(&ctx, wt.p);
+      if (server_out)
+         ss_add(&ctx, server_out);
+
+      cJSON *out = cJSON_CreateObject();
+      cJSON *hook_out = out ? cJSON_AddObjectToObject(out, "hookSpecificOutput") : NULL;
+      if (hook_out)
+      {
+         cJSON_AddStringToObject(hook_out, "hookEventName", "SessionStart");
+         cJSON_AddStringToObject(hook_out, "additionalContext", ctx.p ? ctx.p : "");
+         char *s = cJSON_PrintUnformatted(out);
+         if (s)
+         {
+            fputs(s, stdout);
+            fputc('\n', stdout);
+            free(s);
+         }
+      }
+      else if (server_out)
+         fputs(server_out, stdout);
+      cJSON_Delete(out);
+      free(ctx.p);
+   }
+
+   if (resp)
+   {
       cJSON *msg = cJSON_GetObjectItemCaseSensitive(resp, "message");
       if (cJSON_IsString(msg) && msg->valuestring[0])
          fprintf(stderr, "aimee: %s\n", msg->valuestring);
@@ -783,8 +813,8 @@ int handle_session_start(int json_output)
       {
          cJSON *out = cJSON_CreateObject();
          cJSON_AddNumberToObject(out, "exit_code", exit_code);
-         if (cJSON_IsString(jout) && jout->valuestring[0])
-            cJSON_AddStringToObject(out, "output", jout->valuestring);
+         if (server_out)
+            cJSON_AddStringToObject(out, "output", server_out);
          char *s = cJSON_PrintUnformatted(out);
          if (s)
          {
@@ -800,5 +830,6 @@ int handle_session_start(int json_output)
    {
       fprintf(stderr, "aimee: session-start RPC failed\n");
    }
+   free(wt.p);
    return exit_code;
 }


### PR DESCRIPTION
## Problem
aimee enforces per-session git-worktree isolation (`require_session_worktree` / attention-guard, default ON, no env bypass): a session whose cwd is the shared **main clone** has its every edit/shell command blocked until it isolates.

The onboarding that self-heals this — `ss_append_worktree_isolation()`, which prepares a per-session `.aimee/worktrees/<key>/main` and steers the session to call `EnterWorktree` before its first mutating tool call — was only wired into the **remote/thin-client** path (`handle_session_start_remote`). The **co-located** local-server path (`handle_session_start`) never called it. So a co-located session started **outside the launcher** (e.g. a raw `claude` in the repo, which skips `launch.run`) was left in the main clone with no guidance, and the guard fired on its first edit.

## Change
`src/cli_session_start.c`: call `ss_append_worktree_isolation()` from the co-located `handle_session_start` and **prepend** its directive to the emitted `hookSpecificOutput.additionalContext`, emitting it even when the server returns no brief/recall or the RPC failed. No-ops for already-isolated (launcher/server-forked) sessions and when isolation is disabled — the existing self-guards in `ss_append_worktree_isolation` handle that.

The emit path is restructured so the directive is computed independently of the RPC response and merged as `additionalContext = [directive] + [server brief/recall]`.

## Verification
- Compiles + links clean (`aimee` target, Debug); clang-format clean.
- The shared `ss_append_worktree_isolation` proven end-to-end via the remote path (creates the worktree + emits the directive).
- Roundtable review: all six {resp/output/directive} case combinations correct; memory-safe (`wt.p`/`ctx.p`/`out`/`s`/`resp` all handled, no leak/double-free/UAF — `server_out` used strictly before `cJSON_Delete(resp)`); `exit_code`, `json_output`, `message`→stderr, and RPC-failed branches preserved.
- **Validation-pending:** the live co-located path could not be exercised in the dev environment (thin client → remote server; no local `aimee-server`/DB). Needs a box with a co-located server or CI.