### PR TITLE
feat(wizard): four supported primaries on setup page 1

### DIFF
--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -6,6 +6,7 @@ import { loadConfig, saveConfigValue, type ConfigMap } from '../setup/configApi'
 import { WIZARD_STEPS, isRestartKey, helpFor } from '../setup/wizardSteps';
 import { computeReadiness } from '../setup/readiness';
 import { setDismissed, notifySetupUpdated } from '../setup/setupState';
+import PrimaryChooser from '../setup/PrimaryChooser';
 
 /* First-run setup wizard. A modal over the app that walks the operator through
  * the minimum path to a working turn — provider → embedding → shared store →
@@ -88,6 +89,17 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
   function advance() {
     if (idx < WIZARD_STEPS.length - 1) setIdx(idx + 1);
     else setShowSummary(true);
+  }
+
+  // The primary chooser configures the primary through the agent endpoints; once
+  // it succeeds we stamp the legacy `provider` breadcrumb (which readiness + the
+  // header chip read) and move on. A breadcrumb-save failure is non-fatal: the
+  // primary is already set server-side, so we still advance.
+  async function handlePrimaryConfigured(provider: string) {
+    const res = await saveConfigValue('provider', provider);
+    setCfg((c) => ({ ...c, provider: res.ok ? res.value ?? provider : provider }));
+    notifySetupUpdated();
+    advance();
   }
 
   // Save every edited key in the current step. Any failure aborts advance and
@@ -191,7 +203,9 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
               {step.title}{step.optional ? <span style={{ color: '#9aa', fontWeight: 400, fontSize: 12 }}> · optional</span> : null}
             </div>
 
-            {step.keys.length > 0 ? (
+            {step.kind === 'chooser' ? (
+              <PrimaryChooser onConfigured={handlePrimaryConfigured} />
+            ) : step.keys.length > 0 ? (
               <div style={{ display: 'grid', gap: 12, marginBottom: 16 }}>
                 {step.keys.map((key) => (
                   <label key={key} style={{ display: 'block' }}>

--- a/frontend/src/setup/PrimaryChooser.tsx
+++ b/frontend/src/setup/PrimaryChooser.tsx
@@ -1,0 +1,391 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/* Wizard page-1 primary chooser. Four supported primaries, two shapes:
+ *
+ *   API key      → agent.add --default (Anthropic API, OpenAI-compatible API)
+ *   Subscription → server-hosted OAuth CLI login (Claude / Codex "sign in with
+ *                  your plan"), then agent.set --default to make it primary.
+ *
+ * Every write goes through an existing endpoint — /api/agents/add,
+ * /api/agents/set, and the /api/agents/oauth/* proxies — so there is no new
+ * config surface. The chosen primary is set as the GLOBAL default agent (the one
+ * resolve_primary drives); on success we also stamp the legacy `provider` config
+ * breadcrumb so the wizard summary + header chip (which read config, not the
+ * agent roster) reflect that a primary now exists.
+ *
+ * The subscription token is minted, vaulted, and refreshed entirely server-side:
+ * only the verification URL, an optional device code, an opaque session handle,
+ * and the login state ever reach the browser. */
+
+type ApiKind = 'anthropic' | 'openai';
+type SubKind = 'claude-sub' | 'codex-sub';
+type Kind = ApiKind | SubKind;
+
+interface ApiSpec {
+  kind: ApiKind;
+  label: string;
+  blurb: string;
+  provider: string; // agent provider + `provider` config breadcrumb
+  endpoint: string;
+  model: string;
+  keyHint: string;
+}
+
+interface SubSpec {
+  kind: SubKind;
+  label: string;
+  blurb: string;
+  vendor: 'claude' | 'codex';
+  provider: string; // `provider` config breadcrumb
+}
+
+const API_SPECS: ApiSpec[] = [
+  {
+    kind: 'anthropic',
+    label: 'Anthropic API',
+    blurb: 'Claude models via an api.anthropic.com key.',
+    provider: 'anthropic',
+    endpoint: 'https://api.anthropic.com/v1',
+    model: 'claude-sonnet-4-6',
+    keyHint: 'sk-ant-…',
+  },
+  {
+    kind: 'openai',
+    label: 'OpenAI API',
+    blurb: 'GPT (or any OpenAI-compatible endpoint) via an API key.',
+    provider: 'openai',
+    endpoint: 'https://api.openai.com/v1',
+    model: 'gpt-5.5',
+    keyHint: 'sk-…',
+  },
+];
+
+const SUB_SPECS: SubSpec[] = [
+  {
+    kind: 'claude-sub',
+    label: 'Claude Subscription',
+    blurb: 'Sign in with your Claude plan — no API key, billed to your subscription.',
+    vendor: 'claude',
+    provider: 'claude',
+  },
+  {
+    kind: 'codex-sub',
+    label: 'Codex Subscription',
+    blurb: 'Sign in with your ChatGPT/Codex plan — no API key.',
+    vendor: 'codex',
+    provider: 'codex',
+  },
+];
+
+const btn = (bg: string): React.CSSProperties => ({
+  padding: '7px 16px', borderRadius: 7, border: `1px solid ${bg}`, background: bg,
+  color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
+});
+const primaryBtn = btn('#2c8f56');
+const ghostBtn: React.CSSProperties = {
+  padding: '6px 12px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',
+  color: '#446', cursor: 'pointer', fontSize: 13,
+};
+const input: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
+  border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
+};
+
+function csrf(): string {
+  try {
+    if (typeof window !== 'undefined') return (window as { _csrf?: string })._csrf || '';
+  } catch { /* ignore */ }
+  return '';
+}
+
+async function postJSON<T>(url: string, body: unknown): Promise<T> {
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf() },
+    body: JSON.stringify(body),
+  });
+  let data: unknown = {};
+  try { data = await r.json(); } catch { /* empty body */ }
+  const d = (data ?? {}) as { error?: string };
+  if (r.status < 200 || r.status >= 300 || d.error) {
+    throw new Error(d.error || `request failed (${r.status})`);
+  }
+  return d as T;
+}
+
+// OAuth flow state for a subscription primary.
+interface OauthState {
+  session: string;
+  url: string;
+  code: string;          // device code to show (codex), '' otherwise
+  needsCodeBack: boolean; // claude: operator pastes a code back
+}
+
+export interface PrimaryChooserProps {
+  /** Called after a primary is fully configured + set as the global default; the
+   * argument is the `provider` breadcrumb to stamp into config. */
+  onConfigured: (provider: string) => void | Promise<void>;
+}
+
+export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
+  const [selected, setSelected] = useState<Kind | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  // API-key form fields (seeded when a card is chosen).
+  const [endpoint, setEndpoint] = useState('');
+  const [model, setModel] = useState('');
+  const [apiKey, setApiKey] = useState('');
+
+  // Subscription OAuth flow.
+  const [oauth, setOauth] = useState<OauthState | null>(null);
+  const [codeBack, setCodeBack] = useState('');
+  const [polling, setPolling] = useState(false);
+  const alive = useRef(true);
+  useEffect(() => () => { alive.current = false; }, []);
+
+  const apiSpec = API_SPECS.find((s) => s.kind === selected);
+  const subSpec = SUB_SPECS.find((s) => s.kind === selected);
+
+  const chooseApi = (spec: ApiSpec) => {
+    setSelected(spec.kind);
+    setEndpoint(spec.endpoint);
+    setModel(spec.model);
+    setApiKey('');
+    setError('');
+    setOauth(null);
+  };
+  const chooseSub = (spec: SubSpec) => {
+    setSelected(spec.kind);
+    setError('');
+    setOauth(null);
+    setCodeBack('');
+  };
+  const reset = () => {
+    setSelected(null); setError(''); setOauth(null); setCodeBack('');
+    setBusy(false); setPolling(false);
+  };
+
+  // --- API-key primary: agent.add --default -------------------------------
+  const submitApi = async () => {
+    if (!apiSpec) return;
+    if (!endpoint.trim() || !model.trim() || !apiKey.trim()) {
+      setError('Endpoint, model, and API key are all required.');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      await postJSON('/api/agents/add', {
+        args: [
+          apiSpec.provider, endpoint.trim(), model.trim(),
+          '--provider', apiSpec.provider,
+          '--key', apiKey.trim(),
+          '--default',
+        ],
+      });
+      await onConfigured(apiSpec.provider);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not add the agent.');
+      setBusy(false);
+    }
+  };
+
+  // --- Subscription primary: OAuth login, then agent.set --default --------
+  const pollOnce = useCallback(async (vendor: string, session: string): Promise<'pending' | 'authenticated' | 'failed'> => {
+    try {
+      const r = await postJSON<{ state?: string; agent?: string; error?: string }>(
+        '/api/agents/oauth/poll', { vendor, session });
+      if (r.state === 'authenticated') {
+        // Promote the freshly-registered vendor agent to the global primary.
+        const agent = r.agent || vendor;
+        await postJSON('/api/agents/set', { args: [agent, '--default'] });
+        return 'authenticated';
+      }
+      if (r.state === 'failed') { setError(r.error || 'Login failed or timed out.'); return 'failed'; }
+      return 'pending';
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Poll failed.');
+      return 'failed';
+    }
+  }, []);
+
+  const runPoll = useCallback(async (vendor: string, session: string, provider: string) => {
+    setPolling(true);
+    for (let i = 0; i < 120 && alive.current; i++) {
+      const state = await pollOnce(vendor, session);
+      if (!alive.current) return;
+      if (state === 'authenticated') { setPolling(false); await onConfigured(provider); return; }
+      if (state === 'failed') { setPolling(false); return; }
+      await new Promise((res) => setTimeout(res, 3000));
+    }
+    if (alive.current) { setPolling(false); setError('Timed out waiting for sign-in.'); }
+  }, [pollOnce, onConfigured]);
+
+  const startSub = async () => {
+    if (!subSpec) return;
+    setBusy(true);
+    setError('');
+    try {
+      const r = await postJSON<{ url: string; code?: string; session: string; needs_code_back?: boolean }>(
+        '/api/agents/oauth/start', { vendor: subSpec.vendor });
+      const st: OauthState = {
+        session: r.session, url: r.url, code: r.code || '', needsCodeBack: !!r.needs_code_back,
+      };
+      setOauth(st);
+      setBusy(false);
+      // Codex surfaces a device code and needs no code-back — start polling
+      // immediately. Claude waits for the operator to paste a code back first.
+      if (!st.needsCodeBack) void runPoll(subSpec.vendor, st.session, subSpec.provider);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not start sign-in.');
+      setBusy(false);
+    }
+  };
+
+  const submitCodeBack = async () => {
+    if (!subSpec || !oauth) return;
+    if (!codeBack.trim()) { setError('Paste the code shown on the authorization page.'); return; }
+    setBusy(true);
+    setError('');
+    try {
+      await postJSON('/api/agents/oauth/code', {
+        vendor: subSpec.vendor, session: oauth.session, code: codeBack.trim(),
+      });
+      setBusy(false);
+      void runPoll(subSpec.vendor, oauth.session, subSpec.provider);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not submit the code.');
+      setBusy(false);
+    }
+  };
+
+  // --- render -------------------------------------------------------------
+  if (!selected) {
+    return (
+      <div style={{ display: 'grid', gap: 10, marginBottom: 14 }}>
+        <p style={{ fontSize: 13, color: '#556', margin: '0 0 2px' }}>
+          Pick the primary model aimee drives. You can change it later on the Agents tab.
+        </p>
+        {API_SPECS.map((s) => (
+          <button key={s.kind} onClick={() => chooseApi(s)} style={cardStyle}>
+            <span style={cardTitle}>{s.label}</span>
+            <span style={cardBlurb}>{s.blurb}</span>
+          </button>
+        ))}
+        {SUB_SPECS.map((s) => (
+          <button key={s.kind} onClick={() => chooseSub(s)} style={cardStyle}>
+            <span style={cardTitle}>{s.label}</span>
+            <span style={cardBlurb}>{s.blurb}</span>
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <button onClick={reset} style={{ ...ghostBtn, marginBottom: 12 }} disabled={busy || polling}>
+        ← Choose a different primary
+      </button>
+
+      {apiSpec && (
+        <div style={{ display: 'grid', gap: 12 }}>
+          <div style={{ fontSize: 15, fontWeight: 700 }}>{apiSpec.label}</div>
+          <Field label="Endpoint">
+            <input style={input} value={endpoint} onChange={(e) => setEndpoint(e.target.value)} placeholder={apiSpec.endpoint} />
+          </Field>
+          <Field label="Model">
+            <input style={input} value={model} onChange={(e) => setModel(e.target.value)} placeholder={apiSpec.model} />
+          </Field>
+          <Field label="API key">
+            <input style={input} type="password" autoComplete="off" value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)} placeholder={apiSpec.keyHint} />
+          </Field>
+          <div style={{ fontSize: 11.5, color: '#778' }}>
+            The key is sealed into aimee-server’s vault — it is never stored in the browser or in agents.json.
+          </div>
+          <div>
+            <button style={primaryBtn} disabled={busy} onClick={submitApi}>
+              {busy ? 'Saving…' : 'Save & set as primary'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {subSpec && (
+        <div style={{ display: 'grid', gap: 12 }}>
+          <div style={{ fontSize: 15, fontWeight: 700 }}>{subSpec.label}</div>
+          {!oauth ? (
+            <>
+              <p style={{ fontSize: 13, color: '#556', margin: 0, lineHeight: 1.5 }}>
+                aimee installs the {subSpec.vendor} CLI on the server and starts a login. You’ll get a
+                link to authorize in your browser. This can take up to a minute on first run.
+              </p>
+              <div>
+                <button style={primaryBtn} disabled={busy} onClick={startSub}>
+                  {busy ? 'Starting…' : `Sign in with ${subSpec.label}`}
+                </button>
+              </div>
+            </>
+          ) : (
+            <div style={{ display: 'grid', gap: 10 }}>
+              <div style={{ fontSize: 13, color: '#556' }}>
+                1. Open this link and authorize:
+                <div style={{ marginTop: 4 }}>
+                  <a href={oauth.url} target="_blank" rel="noreferrer" style={{ color: '#2c6', wordBreak: 'break-all' }}>
+                    {oauth.url}
+                  </a>
+                </div>
+              </div>
+              {oauth.code && (
+                <div style={{ fontSize: 13, color: '#556' }}>
+                  2. Enter this one-time code on that page:{' '}
+                  <code style={{ background: '#f1f4f9', padding: '2px 6px', borderRadius: 4, fontWeight: 700 }}>{oauth.code}</code>
+                </div>
+              )}
+              {oauth.needsCodeBack && !polling && (
+                <div style={{ display: 'grid', gap: 6 }}>
+                  <div style={{ fontSize: 13, color: '#556' }}>
+                    {oauth.code ? '3.' : '2.'} After authorizing, paste the code shown back here:
+                  </div>
+                  <input style={input} value={codeBack} onChange={(e) => setCodeBack(e.target.value)} placeholder="paste code" />
+                  <div>
+                    <button style={primaryBtn} disabled={busy} onClick={submitCodeBack}>
+                      {busy ? 'Submitting…' : 'Submit code'}
+                    </button>
+                  </div>
+                </div>
+              )}
+              {polling && (
+                <div style={{ fontSize: 13, color: '#2c8f56' }}>⏳ Waiting for sign-in to complete…</div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div style={{ marginTop: 12, fontSize: 12.5, color: '#a33', background: '#fdeaea', border: '1px solid #f2c4c4', borderRadius: 6, padding: '8px 10px' }}>
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const cardStyle: React.CSSProperties = {
+  display: 'flex', flexDirection: 'column', gap: 3, textAlign: 'left', padding: '11px 13px',
+  borderRadius: 9, border: '1px solid #dde', background: '#fbfcfe', cursor: 'pointer',
+};
+const cardTitle: React.CSSProperties = { fontSize: 14, fontWeight: 700, color: '#233' };
+const cardBlurb: React.CSSProperties = { fontSize: 12, color: '#667' };
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: 'block' }}>
+      <div style={{ fontSize: 12.5, fontWeight: 600, marginBottom: 3 }}>{label}</div>
+      {children}
+    </label>
+  );
+}

--- a/frontend/src/setup/wizardSteps.ts
+++ b/frontend/src/setup/wizardSteps.ts
@@ -18,10 +18,13 @@ export interface WizardStep {
   route?: string;
   /** One-line "what you lose if you skip", shown for optional steps. */
   skipNote?: string;
+  /** A step whose body is a bespoke component (the primary chooser) rather than
+   * the generic key inputs. Rendered specially by SetupWizard. */
+  kind?: 'chooser';
 }
 
 export const WIZARD_STEPS: WizardStep[] = [
-  { id: 'provider', title: 'Primary provider', keys: ['provider', 'claude_model', 'openai_endpoint', 'openai_model', 'openai_key_cmd'] },
+  { id: 'provider', title: 'Primary provider', keys: [], kind: 'chooser' },
   { id: 'embedding', title: 'Embedding backend', keys: ['embedding_command', 'embedding_endpoint', 'embedding_model', 'embedding_dim'] },
   { id: 'db2', title: 'Shared store (DB2)', keys: ['db2_url'] },
   { id: 'kb_api', title: 'Knowledge-base API', keys: ['kb_api_http_port', 'kb_api_bearer_token'], optional: true, skipNote: 'Skipping leaves the KB REST API off — no external programmatic access to the knowledge base.' },

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -1012,7 +1012,7 @@ int handle_agent_personas(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
  * record). Backs the Web GUI's per-agent Edit modal. Args are CLI-style:
  *   set <name> [--model M] [--endpoint E] [--provider P] [--cost-tier N]
  *       [--max-turns N] [--max-parallel N] [--context-window N] [--tools on|off]
- *       [--roles csv] [--personas csv] [--enabled true|false] [--key K]
+ *       [--roles csv] [--personas csv] [--enabled true|false] [--key K] [--default]
  * A flag that is absent leaves that field untouched. */
 int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
@@ -1021,9 +1021,13 @@ int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    int argc = server_agent_args(req, argv, (int)(sizeof(argv) / sizeof(argv[0])));
    if (argc < 1 || !argv[0][0])
       return server_send_error(conn, "agent.set requires name", NULL);
-   /* All --flags carry a value (no bool flags), so each is present iff opt_get
-    * returns non-NULL — that presence check is what makes the patch surgical. */
-   static const char *bool_flags[] = {NULL};
+   /* Value --flags are present iff opt_get returns non-NULL — that presence check
+    * is what makes the patch surgical. `--default` is the one BOOL flag: when
+    * given it promotes this agent to the global primary (default_agent), the same
+    * effect `agent add --default` has, but without resetting the record — the only
+    * way to make an already-registered agent (e.g. a cli-oauth subscription
+    * agent) the primary. */
+   static const char *bool_flags[] = {"default", NULL};
    opt_parsed_t opts;
    opt_parse(argc - 1, argv + 1, bool_flags, &opts);
 
@@ -1094,6 +1098,9 @@ int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
       }
    }
+
+   if (opt_has(&opts, "default"))
+      snprintf(cfg.default_agent, sizeof(cfg.default_agent), "%s", ag->name);
 
    if (agent_save_config(&cfg) != 0)
       return server_send_error(conn, "could not save agents.json", NULL);

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type workflowSessionInfo struct {
@@ -73,27 +74,31 @@ type methodRoute struct {
 // byte-for-byte, so every caller's response parsing is unchanged.
 var methodRoutes = map[string]methodRoute{
 	// Dashboard read views (GET, no args).
-	"dashboard.all":            {http.MethodGet, "/v1/dashboard/all"},
-	"dashboard.audit":          {http.MethodGet, "/v1/dashboard/audit"},
-	"dashboard.delegations":    {http.MethodGet, "/v1/dashboard/delegations"},
-	"dashboard.metrics":        {http.MethodGet, "/v1/dashboard/metrics"},
-	"dashboard.logs":           {http.MethodGet, "/v1/dashboard/logs"},
-	"dashboard.plans":          {http.MethodGet, "/v1/dashboard/plans"},
-	"dashboard.traces":         {http.MethodGet, "/v1/dashboard/traces"},
-	"dashboard.plugins":        {http.MethodGet, "/v1/dashboard/plugins"},
-	"dashboard.memory_stats":   {http.MethodGet, "/v1/dashboard/memory_stats"},
-	"dashboard.onboard":        {http.MethodGet, "/v1/dashboard/onboard"},
-	"plugin.list":              {http.MethodGet, "/v1/plugins"},
-	"plugin.enable":            {http.MethodPost, "/v1/plugins/enable"},
-	"plugin.disable":           {http.MethodPost, "/v1/plugins/disable"},
-	"agent.list":               {http.MethodGet, "/v1/agent/list"},
-	"agent.stats":              {http.MethodGet, "/v1/agent/stats"},
-	"agent.add":                {http.MethodPost, "/v1/agent/add"},
-	"agent.remove":             {http.MethodPost, "/v1/agent/remove"},
-	"agent.enable":             {http.MethodPost, "/v1/agent/enable"},
-	"agent.disable":            {http.MethodPost, "/v1/agent/disable"},
-	"agent.probe":              {http.MethodPost, "/v1/agent/probe"},
-	"agent.set":                {http.MethodPost, "/v1/agent/set"},
+	"dashboard.all":          {http.MethodGet, "/v1/dashboard/all"},
+	"dashboard.audit":        {http.MethodGet, "/v1/dashboard/audit"},
+	"dashboard.delegations":  {http.MethodGet, "/v1/dashboard/delegations"},
+	"dashboard.metrics":      {http.MethodGet, "/v1/dashboard/metrics"},
+	"dashboard.logs":         {http.MethodGet, "/v1/dashboard/logs"},
+	"dashboard.plans":        {http.MethodGet, "/v1/dashboard/plans"},
+	"dashboard.traces":       {http.MethodGet, "/v1/dashboard/traces"},
+	"dashboard.plugins":      {http.MethodGet, "/v1/dashboard/plugins"},
+	"dashboard.memory_stats": {http.MethodGet, "/v1/dashboard/memory_stats"},
+	"dashboard.onboard":      {http.MethodGet, "/v1/dashboard/onboard"},
+	"plugin.list":            {http.MethodGet, "/v1/plugins"},
+	"plugin.enable":          {http.MethodPost, "/v1/plugins/enable"},
+	"plugin.disable":         {http.MethodPost, "/v1/plugins/disable"},
+	"agent.list":             {http.MethodGet, "/v1/agent/list"},
+	"agent.stats":            {http.MethodGet, "/v1/agent/stats"},
+	"agent.add":              {http.MethodPost, "/v1/agent/add"},
+	"agent.remove":           {http.MethodPost, "/v1/agent/remove"},
+	"agent.enable":           {http.MethodPost, "/v1/agent/enable"},
+	"agent.disable":          {http.MethodPost, "/v1/agent/disable"},
+	"agent.probe":            {http.MethodPost, "/v1/agent/probe"},
+	"agent.set":              {http.MethodPost, "/v1/agent/set"},
+	// Subscription-OAuth setup (Claude / Codex "sign in with your plan").
+	"agent.cli_oauth_start":    {http.MethodPost, "/v1/agent/cli_oauth_start"},
+	"agent.cli_oauth_code":     {http.MethodPost, "/v1/agent/cli_oauth_code"},
+	"agent.cli_oauth_poll":     {http.MethodPost, "/v1/agent/cli_oauth_poll"},
 	"collab_rules.list":        {http.MethodGet, "/v1/collab_rules"},
 	"collab_rules.list_active": {http.MethodGet, "/v1/collab_rules/active"},
 	// Mutations + arg-bearing calls (POST, body carries the args; the server
@@ -213,6 +218,49 @@ func (s *server) agentOpHandler(method string) http.HandlerFunc {
 			return
 		}
 		// resp is map[string]json.RawMessage; the values marshal back verbatim.
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// cliOauthHandler proxies the browser's subscription-OAuth setup to the
+// agent.cli_oauth_{start,code,poll} RPC ops — the Claude / Codex "sign in with
+// your subscription" flow that installs + logs the vendor CLI in server-side and
+// registers it as a primary-capable agent. The browser POSTs {vendor, session?,
+// code?}; only those fields cross. The access token is minted, vaulted, and
+// refreshed entirely server-side and never returns to the browser — the response
+// carries only the verification URL, an optional device code, the opaque session
+// handle, and the login state. `start`'s first call may install the vendor CLI
+// (a cold `npm i -g` runs well past the default 10s socket timeout), so each op
+// gets a timeout sized to its work.
+func (s *server) cliOauthHandler(method string, timeout time.Duration) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Vendor  string `json:"vendor"`
+			Session string `json:"session"`
+			Code    string `json:"code"`
+		}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if body.Vendor == "" {
+			writeJSONError(w, http.StatusBadRequest, "vendor required")
+			return
+		}
+		req := map[string]any{"method": method, "vendor": body.Vendor}
+		if body.Session != "" {
+			req["session"] = body.Session
+		}
+		if body.Code != "" {
+			req["code"] = body.Code
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		resp, err := s.rpcV1Call(ctx, req)
+		if err != nil {
+			writeJSONError(w, http.StatusBadGateway, err.Error())
+			return
+		}
 		_ = json.NewEncoder(w).Encode(resp)
 	}
 }

--- a/webchat/cli_oauth_test.go
+++ b/webchat/cli_oauth_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCliOauthHandlerProxies checks the subscription-OAuth proxy forwards the
+// browser's {vendor,session,code} to the matching agent.cli_oauth_* op and relays
+// the server's response (URL + session + device code) back verbatim.
+func TestCliOauthHandlerProxies(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/agent/cli_oauth_start", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		fmt.Fprint(w, `{"status":"ok","vendor":"claude","url":"https://auth.example/x","session":"s1","needs_code_back":true}`)
+	})
+	s := &server{cfg: startFakeV1(t, mux)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/agents/oauth/start", strings.NewReader(`{"vendor":"claude"}`))
+	s.cliOauthHandler("agent.cli_oauth_start", 5*time.Second)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotBody["vendor"] != "claude" {
+		t.Fatalf("forwarded vendor=%v want claude", gotBody["vendor"])
+	}
+	if gotBody["method"] != "agent.cli_oauth_start" {
+		t.Fatalf("forwarded method=%v", gotBody["method"])
+	}
+	var out map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode relay: %v", err)
+	}
+	if out["url"] != "https://auth.example/x" || out["session"] != "s1" {
+		t.Fatalf("relay dropped fields: %v", out)
+	}
+	if out["needs_code_back"] != true {
+		t.Fatalf("relay needs_code_back=%v want true", out["needs_code_back"])
+	}
+}
+
+// TestCliOauthHandlerForwardsSessionAndCode confirms the optional session/code
+// fields are forwarded (the claude paste-code-back hop) and omitted when blank.
+func TestCliOauthHandlerForwardsSessionAndCode(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/agent/cli_oauth_code", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		fmt.Fprint(w, `{"status":"ok"}`)
+	})
+	s := &server{cfg: startFakeV1(t, mux)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/agents/oauth/code",
+		strings.NewReader(`{"vendor":"claude","session":"s1","code":"ABC-123"}`))
+	s.cliOauthHandler("agent.cli_oauth_code", 5*time.Second)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotBody["session"] != "s1" || gotBody["code"] != "ABC-123" {
+		t.Fatalf("session/code not forwarded: %v", gotBody)
+	}
+}
+
+// TestCliOauthHandlerRejectsMissingVendor: no vendor is a 400 before any upstream
+// call (the op requires a vendor and there is nothing to proxy without it).
+func TestCliOauthHandlerRejectsMissingVendor(t *testing.T) {
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/agent/cli_oauth_start", func(http.ResponseWriter, *http.Request) { called = true })
+	s := &server{cfg: startFakeV1(t, mux)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/agents/oauth/start", strings.NewReader(`{}`))
+	s.cliOauthHandler("agent.cli_oauth_start", 5*time.Second)(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d want 400", rr.Code)
+	}
+	if called {
+		t.Fatalf("upstream should not be called without a vendor")
+	}
+}

--- a/webchat/persona.go
+++ b/webchat/persona.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // aimeeHTTPSockPath returns the path to aimee-server's /v1 HTTP-over-UDS socket,
@@ -23,8 +24,18 @@ func (s *server) aimeeHTTPSockPath() string {
 // /v1, never the legacy RPC socket. Returns status, body, and a transport error.
 func (s *server) v1Request(ctx context.Context, method, path string, body []byte) (int, []byte, error) {
 	sock := s.aimeeHTTPSockPath()
+	// Bound the call at socketCallTimeout by default, but let a caller that passed
+	// a longer ctx deadline (e.g. the subscription-OAuth `start` proxy, whose first
+	// call installs the vendor CLI server-side) extend it. Never shorten below the
+	// default floor, so every existing 10s-ctx caller is unaffected.
+	timeout := socketCallTimeout
+	if dl, ok := ctx.Deadline(); ok {
+		if d := time.Until(dl); d > timeout {
+			timeout = d
+		}
+	}
 	client := &http.Client{
-		Timeout: socketCallTimeout,
+		Timeout: timeout,
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				return (&net.Dialer{}).DialContext(ctx, "unix", sock)

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -230,6 +230,11 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/agents/roles", s.requireAuth(s.agentOpHandler("agent.roles")))
 	mux.HandleFunc("POST /api/agents/personas", s.requireAuth(s.agentOpHandler("agent.personas")))
 	mux.HandleFunc("POST /api/agents/set", s.requireAuth(s.agentOpHandler("agent.set")))
+	// Subscription-OAuth setup (Claude / Codex). `start` may install the vendor
+	// CLI server-side, so it carries a much longer timeout than the poll/code hops.
+	mux.HandleFunc("POST /api/agents/oauth/start", s.requireAuth(s.cliOauthHandler("agent.cli_oauth_start", 180*time.Second)))
+	mux.HandleFunc("POST /api/agents/oauth/code", s.requireAuth(s.cliOauthHandler("agent.cli_oauth_code", 30*time.Second)))
+	mux.HandleFunc("POST /api/agents/oauth/poll", s.requireAuth(s.cliOauthHandler("agent.cli_oauth_poll", 15*time.Second)))
 	// Role registry (the shared vocabulary matched between personas and agents).
 	mux.HandleFunc("/api/roles", s.requireAuth(s.handleRoles))
 	mux.HandleFunc("/api/roles/", s.requireAuth(s.handleRoleItem))


### PR DESCRIPTION
Reconstructs the web GUI setup-wizard **page 1** so it supports all four supported primaries, each wired to its established server op.

| Primary | Path |
|---|---|
| **Anthropic API** | `agent.add --provider anthropic --key … --default` (key sealed into the server vault) |
| **OpenAI API** | `agent.add --provider openai --key … --default` |
| **Claude Subscription** | server-hosted OAuth CLI login → paste-code-back → poll → `agent.set --default` |
| **Codex Subscription** | server-hosted OAuth CLI login (device code) → poll → `agent.set --default` |

### What's new
- **frontend** — `PrimaryChooser.tsx` drives the four tiles + the OAuth login flow (authorize URL, optional device code, Claude paste-code-back, poll). On success it stamps the legacy `provider` breadcrumb so readiness + the header chip light up without reworking `readiness.ts`.
- **webchat** — `/api/agents/oauth/{start,code,poll}` proxy to the `agent.cli_oauth_*` ops. `start` carries a longer timeout because its first call installs the vendor CLI server-side; `v1Request` now honors a caller's longer ctx deadline (floored at `socketCallTimeout`, so every existing caller is unaffected).
- **server** — `agent.set` gains a `--default` flag so an already-registered subscription agent can be promoted to the global primary (`default_agent`) without a record-clobbering re-add.

### Context
This rebuilds work from an earlier session that was lost (built by a delegate in an ephemeral worktree, never committed). It targets the OAuth/agent backend already on `testing` (`server_cli_oauth.c`, `/v1/agent/cli_oauth_*`).

### Tests
- webchat: `go build` + `go vet` + full `go test` incl. new `cli_oauth_test.go` (start/code/poll + missing-vendor)
- server C: `server_agent.c` syntax-checked with project flags
- frontend: `tsc -b --force` + existing 18 setup unit tests

### Not covered
True end-to-end (live server/browser: real OAuth completion, real key add, confirming the chosen agent serves as primary) is **not** exercised here — validation-pending, to be driven against a running deployment.