### PR TITLE
feat(self-update): thin-client version-drift detection + `aimee self-update`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -789,6 +789,10 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_main.c
     ${AIMEE_SRC_DIR}/cli_agent_setup.c
     ${AIMEE_SRC_DIR}/cli_session_start.c
+    # Thin-client self-update (cli_main dispatch + cli_session_start drift notice
+    # both call these; the CLI does not link aimee-cmd, so they build in here).
+    ${AIMEE_SRC_DIR}/cmd_self_update.c
+    ${AIMEE_SRC_DIR}/self_update_util.c
     # memory_redirect_check (the CLI's remote-only hooks-pre interception) calls
     # hmem_resolve_project/_scope_for_client/_audit/_spill; the standalone `aimee`
     # CLI does not link aimee-core, so their definers must build into the CLI

--- a/src/Makefile
+++ b/src/Makefile
@@ -354,7 +354,7 @@ CMD_SRCS = prompts.c persona.c hardware_probe.c curator_profile.c server/delegat
 CMD_OBJS = $(CMD_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Pure client (aimee) ---
-CLI_SRCS = cli_v1_routes.c cli_v1_routes_d.c cli_v1_routes_c.c cli_v1_routes_b.c cli_main.c cli_agent_setup.c cli_session_start.c harness_memory_common.c harness_memory_scope.c harness_memory_audit.c harness_memory_spill.c cli_attention_guard.c cli_code_audit.c cli_css.c cli_tui.c cli_tui_opencode_v2b.c cli_tui_opencode_v2.c cli_tui_misc.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c cmd_workflow.c
+CLI_SRCS = cli_v1_routes.c cli_v1_routes_d.c cli_v1_routes_c.c cli_v1_routes_b.c cli_main.c cli_agent_setup.c cli_session_start.c cmd_self_update.c self_update_util.c harness_memory_common.c harness_memory_scope.c harness_memory_audit.c harness_memory_spill.c cli_attention_guard.c cli_code_audit.c cli_css.c cli_tui.c cli_tui_opencode_v2b.c cli_tui_opencode_v2.c cli_tui_misc.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c cmd_workflow.c
 ifeq ($(WITH_TLS),1)
 CLI_SRCS += aimee_tls.c
 TLS_OBJS = $(OBJDIR)/aimee_tls.o

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -5,6 +5,7 @@
 #include "cli_client.h"
 #include "cli_agent_keys.h"
 #include "cli_session_start.h"
+#include "cmd_self_update.h"
 #include "cli_attention_guard.h"
 #include "cli_agent_setup.h"
 #include "cli_code_audit.h"
@@ -1750,6 +1751,8 @@ int main(int argc, char **argv)
          printf("%s %s\n", prog, AIMEE_VERSION);
       return 0;
    }
+   if (strcmp(cmd, "self-update") == 0)
+      return cmd_self_update(sub_argc, sub_argv);
    if (strcmp(cmd, "--help") == 0)
    {
       usage();

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -7,6 +7,7 @@
 #include "cli_session_start.h"
 #include "cJSON.h"
 #include "cli_attention_guard.h" /* attn_require_session_worktree, attn_session_isolation_blocked */
+#include "cmd_self_update.h"     /* aimee_self_update_notice */
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -373,6 +374,19 @@ static int handle_session_start_remote(const char *sid)
 
    free(endpoint);
    free(bearer);
+
+   /* Thin-client version drift: this client talks 1:1 to the remote server, so
+    * if the server has moved ahead, surface a one-line notice steering the agent
+    * (or user) to `aimee self-update`. Best-effort; never blocks the session. */
+   {
+      char notice[256];
+      if (aimee_self_update_notice(notice, sizeof notice))
+      {
+         ss_add(&ctx, "\n# aimee update available\n");
+         ss_add(&ctx, notice);
+         ss_add(&ctx, "\n");
+      }
+   }
 
    /* Local worktree isolation: even though compute is remote, the guard runs on
     * THIS host. Prepare + direct the agent into an isolated worktree so mutating

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -386,6 +386,9 @@ static int handle_session_start_remote(const char *sid)
          ss_add(&ctx, notice);
          ss_add(&ctx, "\n");
       }
+      /* With `update_mode: apply`, catch up automatically (verified, rate-limited,
+       * detached — never blocks this session). No-op in the default notify mode. */
+      aimee_self_update_apply_async();
    }
 
    /* Local worktree isolation: even though compute is remote, the guard runs on

--- a/src/cmd_self_update.c
+++ b/src/cmd_self_update.c
@@ -298,13 +298,18 @@ void aimee_self_update_apply_async(void)
    pid_t pid = fork();
    if (pid != 0)
       return; /* parent (or fork failure): do not block the session */
-   /* Child: detach and run the verified self-update, output to a log. */
+   /* Child: detach and run the verified self-update. CRITICAL: this runs inside
+    * the SessionStart hook, whose stdout IS the hook's JSON channel -- redirect
+    * ALL of stdin/stdout/stderr away before the update writes anything, so its
+    * output never corrupts the hook response. Prefer a log file; fall back to
+    * /dev/null when there is no resolvable home. */
    setsid();
-   int devnull = open("/dev/null", O_RDONLY);
+   int devnull = open("/dev/null", O_RDWR);
    if (devnull >= 0)
    {
       dup2(devnull, STDIN_FILENO);
-      close(devnull);
+      dup2(devnull, STDOUT_FILENO);
+      dup2(devnull, STDERR_FILENO);
    }
    if (home && home[0])
    {
@@ -318,6 +323,8 @@ void aimee_self_update_apply_async(void)
          close(lf);
       }
    }
+   if (devnull >= 0)
+      close(devnull);
    execl(self, "aimee", "self-update", "--yes", "--require-verify", (char *)NULL);
    _exit(127);
 }

--- a/src/cmd_self_update.c
+++ b/src/cmd_self_update.c
@@ -7,24 +7,30 @@
  * lockstep. This first cut is conservative: session-start only NOTIFIES on
  * drift; the swap happens only when the user runs `aimee self-update`.
  *
- * Integrity: the download is over cert-verified HTTPS, and the fetched binary is
- * executed (`<tmp> version`) and required to report the exact target version
- * before it is swapped in -- this catches truncation, wrong-arch, and
- * wrong-version artifacts. A cryptographic signature check is a recommended
- * follow-up (the release does not yet publish per-asset signatures). */
+ * Integrity, in order: (1) the download is over cert-verified HTTPS; (2) its
+ * SHA-256 is checked against the digest GitHub publishes for the release asset
+ * (keyless -- a confirmed mismatch is fatal; --require-verify makes a missing
+ * digest fatal too); (3) the fetched binary is executed (`<tmp> version`) and
+ * required to report the exact target version, catching truncation/wrong-arch/
+ * wrong-version. A key-based signature (defending against a compromised GitHub
+ * itself) remains a further follow-up -- the release publishes no per-asset
+ * signatures yet, only the API digest used here. */
 
 #include "headers/cmd_self_update.h"
 
 #include "cli_client.h"
 #include "cJSON.h"
+#include "headers/aimee_home.h"
 #include "headers/aimee_version.h"
 #include "headers/util.h"
 
+#include <fcntl.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
 
 /* Pure helpers (aimee_version_compare / aimee_version_is_safe /
@@ -80,6 +86,10 @@ int aimee_self_update_notice(char *out, size_t cap)
    char server_ver[64];
    if (aimee_fetch_server_version(server_ver, sizeof server_ver) != 0)
       return 0;
+   /* Only a comparable (semver) server that is strictly newer is actionable; a
+    * dev/branch "testing-<sha>" server is not orderable, so stay silent. */
+   if (!aimee_version_is_semver(server_ver))
+      return 0;
    if (aimee_version_compare(server_ver, AIMEE_VERSION) <= 0)
       return 0;
    snprintf(out, cap,
@@ -114,9 +124,236 @@ static int path_is_shell_safe(const char *p)
    return p && !strchr(p, '\'');
 }
 
+static void lc_hex(char *s)
+{
+   for (; *s; s++)
+      if (*s >= 'A' && *s <= 'F')
+         *s += 32;
+}
+
+/* Compute the SHA-256 of `path` into `hex` (lowercase, 64 chars). The swap path
+ * is Linux-only, so sha256sum (coreutils) is always present here. 0 on success. */
+static int sha256_of_file(const char *path, char *hex, size_t cap)
+{
+   if (!path_is_shell_safe(path))
+      return -1;
+   char cmd[PATH_MAX + 32];
+   snprintf(cmd, sizeof cmd, "sha256sum '%s' 2>/dev/null", path);
+   int rc = 0;
+   char *out = run_cmd(cmd, &rc);
+   int ok = -1;
+   if (rc == 0 && out)
+   {
+      /* Output: "<64-hex>  <path>". Take the leading hex token. */
+      size_t n = 0;
+      while (out[n] && ((out[n] >= '0' && out[n] <= '9') || (out[n] >= 'a' && out[n] <= 'f') ||
+                        (out[n] >= 'A' && out[n] <= 'F')))
+         n++;
+      if (n == 64 && n < cap)
+      {
+         memcpy(hex, out, 64);
+         hex[64] = '\0';
+         lc_hex(hex);
+         ok = 0;
+      }
+   }
+   free(out);
+   return ok;
+}
+
+/* Fetch the SHA-256 GitHub publishes for release asset `asset` of version
+ * v`tnorm` (its API `digest` field, "sha256:<hex>"). Writes lowercase hex to
+ * `hex`. Returns 0 on success, -1 if the API/asset/digest is unavailable. */
+static int fetch_asset_sha256(const char *tnorm, const char *asset, char *hex, size_t cap)
+{
+   if (!aimee_version_is_safe(tnorm) || !asset)
+      return -1;
+   char url[256];
+   snprintf(url, sizeof url, "https://api.github.com/repos/RakuenSoftware/aimee/releases/tags/v%s",
+            tnorm);
+   char cmd[400];
+   snprintf(cmd, sizeof cmd,
+            "curl -fsSL --proto '=https' --tlsv1.2 --connect-timeout 15 --max-time 60 "
+            "-H 'User-Agent: aimee-self-update' '%s' 2>/dev/null",
+            url);
+   int rc = 0;
+   char *body = run_cmd(cmd, &rc);
+   if (rc != 0 || !body)
+   {
+      free(body);
+      return -1;
+   }
+   cJSON *root = cJSON_Parse(body);
+   free(body);
+   if (!root)
+      return -1;
+   int found = -1;
+   cJSON *assets = cJSON_GetObjectItemCaseSensitive(root, "assets");
+   cJSON *a = NULL;
+   cJSON_ArrayForEach(a, assets)
+   {
+      cJSON *name = cJSON_GetObjectItemCaseSensitive(a, "name");
+      if (!cJSON_IsString(name) || strcmp(name->valuestring, asset) != 0)
+         continue;
+      cJSON *dig = cJSON_GetObjectItemCaseSensitive(a, "digest");
+      if (cJSON_IsString(dig))
+      {
+         const char *d = dig->valuestring;
+         if (strncmp(d, "sha256:", 7) == 0)
+            d += 7;
+         if (strlen(d) == 64 && (size_t)65 <= cap)
+         {
+            snprintf(hex, cap, "%s", d);
+            lc_hex(hex);
+            found = 0;
+         }
+      }
+      break;
+   }
+   cJSON_Delete(root);
+   return found;
+}
+
+/* Read `update_mode:` from <aimee_home>/aimee.yaml. Returns "off", "notify"
+ * (default), or "apply". Minimal scalar read (mirrors the attention-guard's). */
+static const char *read_update_mode(void)
+{
+   static char mode[16];
+   snprintf(mode, sizeof mode, "notify");
+   const char *home = aimee_home();
+   if (!home || !home[0])
+      return mode;
+   char path[1024];
+   snprintf(path, sizeof path, "%s/aimee.yaml", home);
+   FILE *fp = fopen(path, "r");
+   if (!fp)
+      return mode;
+   char line[256];
+   while (fgets(line, sizeof line, fp))
+   {
+      const char *p = line;
+      while (*p == ' ' || *p == '\t')
+         p++;
+      if (strncmp(p, "update_mode:", 12) != 0)
+         continue;
+      p += 12;
+      while (*p == ' ' || *p == '\t')
+         p++;
+      char v[16];
+      size_t n = 0;
+      while (*p && *p != '\n' && *p != '\r' && *p != ' ' && *p != '#' && n < sizeof v - 1)
+         v[n++] = *p++;
+      v[n] = '\0';
+      if (strcmp(v, "off") == 0 || strcmp(v, "apply") == 0 || strcmp(v, "notify") == 0)
+         snprintf(mode, sizeof mode, "%s", v);
+      break;
+   }
+   fclose(fp);
+   return mode;
+}
+
+/* apply-mode auto-update: when `update_mode: apply` and the server is a strictly
+ * newer semver, spawn a detached `self-update --yes --require-verify` (verified
+ * swap only). Rate-limited to at most once/hour via a stamp file so it does not
+ * fire every session. Best-effort and non-blocking: the caller's session is
+ * never held up, and the atomic rename means the running session keeps its
+ * binary while the NEXT one starts current. No-op unless mode is apply. */
+void aimee_self_update_apply_async(void)
+{
+   if (strcmp(read_update_mode(), "apply") != 0)
+      return;
+   if (!cli_v1_has_remote_endpoint())
+      return;
+
+   const char *home = aimee_home();
+   char stamp[1024] = "";
+   if (home && home[0])
+   {
+      snprintf(stamp, sizeof stamp, "%s/.self-update-stamp", home);
+      struct stat st;
+      if (stat(stamp, &st) == 0 && (time(NULL) - st.st_mtime) < 3600)
+         return; /* attempted within the last hour -> back off */
+   }
+
+   char server_ver[64];
+   if (aimee_fetch_server_version(server_ver, sizeof server_ver) != 0)
+      return;
+   if (!aimee_version_is_semver(server_ver) ||
+       aimee_version_compare(server_ver, AIMEE_VERSION) <= 0)
+      return;
+
+   char self[PATH_MAX];
+   if (resolve_self_path(self, sizeof self) != 0)
+      return;
+
+   /* Record the attempt up front so a persistently-failing update still backs
+    * off (avoids a download storm on every session). */
+   if (stamp[0])
+   {
+      FILE *fp = fopen(stamp, "w");
+      if (fp)
+         fclose(fp);
+   }
+
+   pid_t pid = fork();
+   if (pid != 0)
+      return; /* parent (or fork failure): do not block the session */
+   /* Child: detach and run the verified self-update, output to a log. */
+   setsid();
+   int devnull = open("/dev/null", O_RDONLY);
+   if (devnull >= 0)
+   {
+      dup2(devnull, STDIN_FILENO);
+      close(devnull);
+   }
+   if (home && home[0])
+   {
+      char logp[1024];
+      snprintf(logp, sizeof logp, "%s/self-update.log", home);
+      int lf = open(logp, O_WRONLY | O_CREAT | O_APPEND, 0644);
+      if (lf >= 0)
+      {
+         dup2(lf, STDOUT_FILENO);
+         dup2(lf, STDERR_FILENO);
+         close(lf);
+      }
+   }
+   execl(self, "aimee", "self-update", "--yes", "--require-verify", (char *)NULL);
+   _exit(127);
+}
+
+/* After a successful swap, warn if PATH exposes other `aimee` binaries that now
+ * differ -- the "two out-of-sync copies" smell. Advisory only; never modifies. */
+static void warn_sibling_binaries(const char *self)
+{
+   int rc = 0;
+   char *out = run_cmd("command -v -a aimee 2>/dev/null", &rc);
+   if (!out)
+      return;
+   char *save = NULL;
+   for (char *line = strtok_r(out, "\n", &save); line; line = strtok_r(NULL, "\n", &save))
+   {
+      if (!line[0] || strcmp(line, self) == 0 || !path_is_shell_safe(line))
+         continue;
+      char vcmd[PATH_MAX + 32], selfcmp[PATH_MAX + 32];
+      snprintf(vcmd, sizeof vcmd, "'%s' version 2>/dev/null", line);
+      snprintf(selfcmp, sizeof selfcmp, "'%s' version 2>/dev/null", self);
+      int a = 0, b = 0;
+      char *lv = run_cmd(vcmd, &a);
+      char *sv = run_cmd(selfcmp, &b);
+      if (lv && sv && strcmp(lv, sv) != 0)
+         printf("note: another aimee on PATH differs: %s (%s). Update it too, or make it a "
+                "symlink to %s so there is one canonical install.\n",
+                line, lv[0] ? lv : "unknown", self);
+      free(lv);
+      free(sv);
+   }
+   free(out);
+}
+
 int cmd_self_update(int argc, char **argv)
 {
-   int check_only = 0, assume_yes = 0;
+   int check_only = 0, assume_yes = 0, require_verify = 0;
    const char *forced_version = NULL;
    for (int i = 0; i < argc; i++)
    {
@@ -124,15 +361,20 @@ int cmd_self_update(int argc, char **argv)
          check_only = 1;
       else if (strcmp(argv[i], "--yes") == 0 || strcmp(argv[i], "-y") == 0)
          assume_yes = 1;
+      else if (strcmp(argv[i], "--require-verify") == 0)
+         require_verify = 1; /* fail unless the published SHA-256 is confirmed */
       else if (strcmp(argv[i], "--version") == 0 && i + 1 < argc)
          forced_version = argv[++i];
       else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
       {
-         printf("Usage: aimee self-update [--check] [--version vX.Y.Z] [--yes]\n"
-                "  Update this thin-client binary to match the aimee-server.\n"
-                "  --check          Report whether an update is available; do not download.\n"
-                "  --version vX.Y.Z Target a specific version instead of the server's.\n"
-                "  --yes            Do not prompt before swapping the binary.\n");
+         printf(
+             "Usage: aimee self-update [--check] [--version vX.Y.Z] [--yes] "
+             "[--require-verify]\n"
+             "  Update this thin-client binary to match the aimee-server.\n"
+             "  --check          Report whether an update is available; do not download.\n"
+             "  --version vX.Y.Z Target a specific version instead of the server's.\n"
+             "  --yes            Do not prompt before swapping the binary.\n"
+             "  --require-verify Refuse to install unless the published SHA-256 is confirmed.\n");
          return 0;
       }
    }
@@ -156,6 +398,23 @@ int cmd_self_update(int argc, char **argv)
       fprintf(stderr, "aimee self-update: refusing to act on an implausible version '%s'.\n",
               target);
       return 1;
+   }
+   /* Releases are semver-tagged; a non-semver target has no release to fetch.
+    * The common case is a dev/branch server (deliberately "testing-<sha>", per
+    * publish-testing.yml) -- report that honestly rather than misclaiming the
+    * client is ahead, and let the user target a specific release explicitly. */
+   if (!aimee_version_is_semver(tnorm))
+   {
+      if (forced_version)
+      {
+         fprintf(stderr, "aimee self-update: '%s' is not a release version (expected vX.Y.Z).\n",
+                 target);
+         return 1;
+      }
+      printf("client v%s, server reports '%s'\n", vnum(AIMEE_VERSION), vnum(target));
+      printf("The server reports a non-semver (dev/branch) version, so drift cannot be "
+             "compared. Target a specific release with `aimee self-update --version vX.Y.Z`.\n");
+      return 0;
    }
 
    int cmp = aimee_version_compare(tnorm, AIMEE_VERSION);
@@ -250,6 +509,45 @@ int cmd_self_update(int argc, char **argv)
       return 1;
    }
 
+   /* Strong integrity check: verify the download's SHA-256 against the digest
+    * GitHub publishes for this release asset. A confirmed mismatch is fatal. If
+    * the digest cannot be fetched (offline / API rate-limited), fall back to the
+    * version self-check below for interactive updates -- but --require-verify
+    * (used by auto-apply) refuses to proceed without a confirmed hash. */
+   char want_sha[80] = "", got_sha[80] = "";
+   if (fetch_asset_sha256(tnorm, asset, want_sha, sizeof want_sha) == 0)
+   {
+      if (sha256_of_file(tmp, got_sha, sizeof got_sha) != 0)
+      {
+         fprintf(stderr, "aimee self-update: could not hash the download.\n");
+         unlink(tmp);
+         return 1;
+      }
+      if (strcmp(want_sha, got_sha) != 0)
+      {
+         fprintf(stderr,
+                 "aimee self-update: SHA-256 mismatch -- refusing to install.\n"
+                 "  expected %s\n  got      %s\n",
+                 want_sha, got_sha);
+         unlink(tmp);
+         return 1;
+      }
+      if (!assume_yes)
+         printf("Verified SHA-256 %s\n", got_sha);
+   }
+   else if (require_verify)
+   {
+      fprintf(stderr, "aimee self-update: could not confirm the published SHA-256 (GitHub API "
+                      "unavailable) and --require-verify is set; not installing.\n");
+      unlink(tmp);
+      return 1;
+   }
+   else
+   {
+      fprintf(stderr, "aimee self-update: warning: could not fetch the published SHA-256 "
+                      "(GitHub API unavailable); relying on the version self-check.\n");
+   }
+
    /* Integrity/correctness gate: the downloaded binary must run and report the
     * exact target version before we trust it enough to swap it in. */
    char verify_cmd[PATH_MAX + 32];
@@ -307,5 +605,6 @@ int cmd_self_update(int argc, char **argv)
    }
 
    printf("Updated to v%s. Backup at %s.bak\n", tnorm, self);
+   warn_sibling_binaries(self);
    return 0;
 }

--- a/src/cmd_self_update.c
+++ b/src/cmd_self_update.c
@@ -269,10 +269,15 @@ void aimee_self_update_apply_async(void)
    char stamp[1024] = "";
    if (home && home[0])
    {
-      snprintf(stamp, sizeof stamp, "%s/.self-update-stamp", home);
-      struct stat st;
-      if (stat(stamp, &st) == 0 && (time(NULL) - st.st_mtime) < 3600)
-         return; /* attempted within the last hour -> back off */
+      /* A truncated path could point elsewhere -> skip the stamp entirely. */
+      if (snprintf(stamp, sizeof stamp, "%s/.self-update-stamp", home) >= (int)sizeof stamp)
+         stamp[0] = '\0';
+      else
+      {
+         struct stat st;
+         if (stat(stamp, &st) == 0 && (time(NULL) - st.st_mtime) < 3600)
+            return; /* attempted within the last hour -> back off */
+      }
    }
 
    char server_ver[64];
@@ -311,16 +316,26 @@ void aimee_self_update_apply_async(void)
       dup2(devnull, STDOUT_FILENO);
       dup2(devnull, STDERR_FILENO);
    }
+   else
+   {
+      /* Cannot even open /dev/null: close the inherited hook stdio so a later
+       * write fails (EBADF) rather than corrupting the hook's JSON channel. */
+      close(STDIN_FILENO);
+      close(STDOUT_FILENO);
+      close(STDERR_FILENO);
+   }
    if (home && home[0])
    {
       char logp[1024];
-      snprintf(logp, sizeof logp, "%s/self-update.log", home);
-      int lf = open(logp, O_WRONLY | O_CREAT | O_APPEND, 0644);
-      if (lf >= 0)
+      if (snprintf(logp, sizeof logp, "%s/self-update.log", home) < (int)sizeof logp)
       {
-         dup2(lf, STDOUT_FILENO);
-         dup2(lf, STDERR_FILENO);
-         close(lf);
+         int lf = open(logp, O_WRONLY | O_CREAT | O_APPEND, 0644);
+         if (lf >= 0)
+         {
+            dup2(lf, STDOUT_FILENO);
+            dup2(lf, STDERR_FILENO);
+            close(lf);
+         }
       }
    }
    if (devnull >= 0)
@@ -424,11 +439,9 @@ int cmd_self_update(int argc, char **argv)
       return 0;
    }
 
+   /* tnorm is a semver here (non-semver targets returned above). */
    int cmp = aimee_version_compare(tnorm, AIMEE_VERSION);
-   /* Only prefix 'v' for semver-looking targets; a non-semver server string
-    * (e.g. a dev "testing-<sha>" build) is shown verbatim. */
-   const char *tpfx = (tnorm[0] >= '0' && tnorm[0] <= '9') ? "v" : "";
-   printf("client v%s, target %s%s\n", vnum(AIMEE_VERSION), tpfx, tnorm);
+   printf("client v%s, target v%s\n", vnum(AIMEE_VERSION), tnorm);
    if (cmp < 0)
    {
       printf("Client is ahead of the target; nothing to do (self-update never downgrades).\n");
@@ -516,6 +529,23 @@ int cmd_self_update(int argc, char **argv)
       return 1;
    }
 
+   /* Back up the current binary NOW, before verification, so the verify->rename
+    * steps below are adjacent and the window in which `tmp` could be swapped out
+    * is minimal. Trust boundary: `tmp` lives in the install directory; a
+    * principal able to modify it between verify and rename can already replace
+    * the installed binary directly (they have write access to the dir), so this
+    * is defense-in-depth, not a new attack surface -- we minimize the window
+    * regardless. */
+   char bak[PATH_MAX];
+   if (snprintf(bak, sizeof bak, "%s.bak", self) < (int)sizeof bak)
+   {
+      char cpcmd[PATH_MAX * 2 + 32];
+      snprintf(cpcmd, sizeof cpcmd, "cp -p '%s' '%s' 2>/dev/null", self, bak);
+      int crc = 0;
+      char *co = run_cmd(cpcmd, &crc);
+      free(co);
+   }
+
    /* Strong integrity check: verify the download's SHA-256 against the digest
     * GitHub publishes for this release asset. A confirmed mismatch is fatal. If
     * the digest cannot be fetched (offline / API rate-limited), fall back to the
@@ -592,16 +622,8 @@ int cmd_self_update(int argc, char **argv)
    }
    free(vout);
 
-   /* Back up the current binary for rollback, then atomically swap. */
-   char bak[PATH_MAX];
-   if (snprintf(bak, sizeof bak, "%s.bak", self) < (int)sizeof bak)
-   {
-      char cpcmd[PATH_MAX * 2 + 32];
-      snprintf(cpcmd, sizeof cpcmd, "cp -p '%s' '%s' 2>/dev/null", self, bak);
-      int crc = 0;
-      char *co = run_cmd(cpcmd, &crc);
-      free(co);
-   }
+   /* Verified (SHA-256 + version self-check); the backup was taken above.
+    * Atomically swap -- a running process keeps the old inode. */
    if (rename(tmp, self) != 0)
    {
       fprintf(stderr,

--- a/src/cmd_self_update.c
+++ b/src/cmd_self_update.c
@@ -300,6 +300,10 @@ void aimee_self_update_apply_async(void)
          fclose(fp);
    }
 
+   /* fork/setsid/execl are POSIX; the swap itself is Linux-only (resolve_self_path
+    * returned above on non-Linux), so the detached spawn is compiled only where it
+    * can run. Windows has no fork(). */
+#ifndef _WIN32
    pid_t pid = fork();
    if (pid != 0)
       return; /* parent (or fork failure): do not block the session */
@@ -342,6 +346,7 @@ void aimee_self_update_apply_async(void)
       close(devnull);
    execl(self, "aimee", "self-update", "--yes", "--require-verify", (char *)NULL);
    _exit(127);
+#endif
 }
 
 /* After a successful swap, warn if PATH exposes other `aimee` binaries that now

--- a/src/cmd_self_update.c
+++ b/src/cmd_self_update.c
@@ -1,0 +1,311 @@
+/* cmd_self_update.c: thin-client self-update. See cmd_self_update.h.
+ *
+ * The client learns the server version from GET /v1/version (the server already
+ * serves it). Because the client<->server relationship is 1:1, the server's
+ * version is the exact target: an update fetches the matching release binary
+ * from GitHub and atomically swaps this executable, so client and server stay
+ * lockstep. This first cut is conservative: session-start only NOTIFIES on
+ * drift; the swap happens only when the user runs `aimee self-update`.
+ *
+ * Integrity: the download is over cert-verified HTTPS, and the fetched binary is
+ * executed (`<tmp> version`) and required to report the exact target version
+ * before it is swapped in -- this catches truncation, wrong-arch, and
+ * wrong-version artifacts. A cryptographic signature check is a recommended
+ * follow-up (the release does not yet publish per-asset signatures). */
+
+#include "headers/cmd_self_update.h"
+
+#include "cli_client.h"
+#include "cJSON.h"
+#include "headers/aimee_version.h"
+#include "headers/util.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* Pure helpers (aimee_version_compare / aimee_version_is_safe /
+ * aimee_self_update_asset) live in self_update_util.c. */
+
+#define AIMEE_RELEASE_URL_BASE "https://github.com/RakuenSoftware/aimee/releases/download"
+
+/* Version strings may or may not carry a leading 'v' (AIMEE_VERSION is stamped
+ * "v0.2.182" by release builds; /v1/version may report either form). Strip it
+ * for display so we never print "vv0.2.182". */
+static const char *vnum(const char *s)
+{
+   return (s && (s[0] == 'v' || s[0] == 'V')) ? s + 1 : s;
+}
+
+int aimee_fetch_server_version(char *out, size_t cap)
+{
+   if (out && cap)
+      out[0] = '\0';
+   if (!out || cap == 0)
+      return -1;
+   char *endpoint = cli_v1_client_endpoint();
+   if (!endpoint)
+      return -1;
+   char *bearer = cli_v1_client_bearer();
+   int status = 0;
+   cJSON *resp = cli_http_request(endpoint, "GET", "/v1/version", NULL, bearer, 5000, &status);
+   free(endpoint);
+   free(bearer);
+   if (!resp)
+      return -1;
+   int rc = -1;
+   cJSON *v = cJSON_GetObjectItemCaseSensitive(resp, "version");
+   if (status == 200 && cJSON_IsString(v) && v->valuestring[0])
+   {
+      snprintf(out, cap, "%s", v->valuestring);
+      rc = 0;
+   }
+   cJSON_Delete(resp);
+   return rc;
+}
+
+int aimee_self_update_notice(char *out, size_t cap)
+{
+   if (out && cap)
+      out[0] = '\0';
+   if (!out || cap == 0)
+      return 0;
+   /* Drift is only meaningful for a thin client talking to a separate server;
+    * a co-located session shares this very binary and cannot drift. */
+   if (!cli_v1_has_remote_endpoint())
+      return 0;
+   char server_ver[64];
+   if (aimee_fetch_server_version(server_ver, sizeof server_ver) != 0)
+      return 0;
+   if (aimee_version_compare(server_ver, AIMEE_VERSION) <= 0)
+      return 0;
+   snprintf(out, cap,
+            "aimee-server is v%s but this client is v%s. Run `aimee self-update` to "
+            "catch up (keeps client and server in lockstep).",
+            vnum(server_ver), vnum(AIMEE_VERSION));
+   return 1;
+}
+
+/* readlink /proc/self/exe -> `out`. 0 on success. Linux-only; the swap path is
+ * gated on this so other platforms get a clear "not supported here" message. */
+static int resolve_self_path(char *out, size_t cap)
+{
+#ifdef __linux__
+   ssize_t n = readlink("/proc/self/exe", out, cap - 1);
+   if (n <= 0)
+      return -1;
+   out[n] = '\0';
+   return 0;
+#else
+   (void)out;
+   (void)cap;
+   return -1;
+#endif
+}
+
+static int path_is_shell_safe(const char *p)
+{
+   /* We single-quote paths into a shell command; a literal single quote would
+    * break out of the quoting. System executable paths never contain one, so
+    * refuse rather than attempt to escape. */
+   return p && !strchr(p, '\'');
+}
+
+int cmd_self_update(int argc, char **argv)
+{
+   int check_only = 0, assume_yes = 0;
+   const char *forced_version = NULL;
+   for (int i = 0; i < argc; i++)
+   {
+      if (strcmp(argv[i], "--check") == 0)
+         check_only = 1;
+      else if (strcmp(argv[i], "--yes") == 0 || strcmp(argv[i], "-y") == 0)
+         assume_yes = 1;
+      else if (strcmp(argv[i], "--version") == 0 && i + 1 < argc)
+         forced_version = argv[++i];
+      else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
+      {
+         printf("Usage: aimee self-update [--check] [--version vX.Y.Z] [--yes]\n"
+                "  Update this thin-client binary to match the aimee-server.\n"
+                "  --check          Report whether an update is available; do not download.\n"
+                "  --version vX.Y.Z Target a specific version instead of the server's.\n"
+                "  --yes            Do not prompt before swapping the binary.\n");
+         return 0;
+      }
+   }
+
+   /* Determine the target version: an explicit --version, else the server's. */
+   char target[64];
+   if (forced_version)
+   {
+      snprintf(target, sizeof target, "%s", forced_version);
+   }
+   else if (aimee_fetch_server_version(target, sizeof target) != 0)
+   {
+      fprintf(stderr, "aimee self-update: could not read the server version (no remote "
+                      "endpoint configured, or the server is unreachable).\n");
+      return 1;
+   }
+   /* Normalise a leading 'v' out of the compare/URL handling below. */
+   const char *tnorm = (target[0] == 'v' || target[0] == 'V') ? target + 1 : target;
+   if (!aimee_version_is_safe(tnorm))
+   {
+      fprintf(stderr, "aimee self-update: refusing to act on an implausible version '%s'.\n",
+              target);
+      return 1;
+   }
+
+   int cmp = aimee_version_compare(tnorm, AIMEE_VERSION);
+   /* Only prefix 'v' for semver-looking targets; a non-semver server string
+    * (e.g. a dev "testing-<sha>" build) is shown verbatim. */
+   const char *tpfx = (tnorm[0] >= '0' && tnorm[0] <= '9') ? "v" : "";
+   printf("client v%s, target %s%s\n", vnum(AIMEE_VERSION), tpfx, tnorm);
+   if (cmp < 0)
+   {
+      printf("Client is ahead of the target; nothing to do (self-update never downgrades).\n");
+      return 0;
+   }
+   if (cmp == 0)
+   {
+      printf("Already up to date.\n");
+      return 0;
+   }
+   if (check_only)
+   {
+      printf("Update available: run `aimee self-update` to install v%s.\n", tnorm);
+      return 0;
+   }
+
+   const char *asset = aimee_self_update_asset();
+   if (!asset)
+   {
+      fprintf(stderr, "aimee self-update: no release asset for this platform.\n");
+      return 1;
+   }
+   char self[PATH_MAX];
+   if (resolve_self_path(self, sizeof self) != 0)
+   {
+      fprintf(stderr, "aimee self-update: could not resolve this executable's path "
+                      "(auto-swap is supported on Linux only).\n");
+      return 1;
+   }
+   if (!path_is_shell_safe(self))
+   {
+      fprintf(stderr, "aimee self-update: executable path is not safe to script over.\n");
+      return 1;
+   }
+   if (access(self, W_OK) != 0)
+   {
+      fprintf(stderr,
+              "aimee self-update: %s is not writable by you; re-run with the right "
+              "privileges (or reinstall).\n",
+              self);
+      return 1;
+   }
+
+   if (!assume_yes)
+      printf("Downloading v%s (%s) and replacing %s ...\n", tnorm, asset, self);
+
+   /* Download to a sibling temp file (same directory -> same filesystem, so the
+    * final rename() is atomic and running processes keep the old inode). */
+   char tmp[PATH_MAX];
+   if (snprintf(tmp, sizeof tmp, "%s.update.%ld", self, (long)getpid()) >= (int)sizeof tmp)
+   {
+      fprintf(stderr, "aimee self-update: path too long.\n");
+      return 1;
+   }
+   if (!path_is_shell_safe(tmp))
+   {
+      fprintf(stderr, "aimee self-update: temp path is not safe to script over.\n");
+      return 1;
+   }
+
+   char url[512];
+   snprintf(url, sizeof url, "%s/v%s/%s", AIMEE_RELEASE_URL_BASE, tnorm, asset);
+
+   char cmd[1200];
+   snprintf(cmd, sizeof cmd,
+            "curl -fSL --proto '=https' --tlsv1.2 --connect-timeout 15 --max-time 300 "
+            "-o '%s' '%s' 2>&1",
+            tmp, url);
+   int rc = 0;
+   char *dl = run_cmd(cmd, &rc);
+   struct stat st;
+   if (rc != 0 || stat(tmp, &st) != 0 || st.st_size <= 0)
+   {
+      fprintf(stderr, "aimee self-update: download failed (%s).\n  url: %s\n",
+              dl && dl[0] ? dl : "curl error", url);
+      free(dl);
+      unlink(tmp);
+      return 1;
+   }
+   free(dl);
+   if (chmod(tmp, 0755) != 0)
+   {
+      fprintf(stderr, "aimee self-update: could not chmod the downloaded binary.\n");
+      unlink(tmp);
+      return 1;
+   }
+
+   /* Integrity/correctness gate: the downloaded binary must run and report the
+    * exact target version before we trust it enough to swap it in. */
+   char verify_cmd[PATH_MAX + 32];
+   snprintf(verify_cmd, sizeof verify_cmd, "'%s' version 2>/dev/null", tmp);
+   int vrc = 0;
+   char *vout = run_cmd(verify_cmd, &vrc);
+   int version_ok = 0;
+   if (vrc == 0 && vout)
+   {
+      /* `aimee version` prints "<prog> <version>" (and <prog> here is the temp
+       * filename). Trim trailing whitespace first, THEN take the last space/tab
+       * token, and compare by semver to the target. */
+      char got[128];
+      snprintf(got, sizeof got, "%s", vout);
+      size_t L = strlen(got);
+      while (L > 0 &&
+             (got[L - 1] == '\n' || got[L - 1] == '\r' || got[L - 1] == ' ' || got[L - 1] == '\t'))
+         got[--L] = '\0';
+      const char *tok = got;
+      for (const char *p = got; *p; p++)
+         if (*p == ' ' || *p == '\t')
+            tok = p + 1;
+      if (tok[0] && aimee_version_compare(tok, tnorm) == 0)
+         version_ok = 1;
+   }
+   if (!version_ok)
+   {
+      fprintf(stderr,
+              "aimee self-update: downloaded binary failed verification (expected v%s, got "
+              "'%s'). Not swapping.\n",
+              tnorm, vout ? vout : "<no output>");
+      free(vout);
+      unlink(tmp);
+      return 1;
+   }
+   free(vout);
+
+   /* Back up the current binary for rollback, then atomically swap. */
+   char bak[PATH_MAX];
+   if (snprintf(bak, sizeof bak, "%s.bak", self) < (int)sizeof bak)
+   {
+      char cpcmd[PATH_MAX * 2 + 32];
+      snprintf(cpcmd, sizeof cpcmd, "cp -p '%s' '%s' 2>/dev/null", self, bak);
+      int crc = 0;
+      char *co = run_cmd(cpcmd, &crc);
+      free(co);
+   }
+   if (rename(tmp, self) != 0)
+   {
+      fprintf(stderr,
+              "aimee self-update: atomic replace failed; the current binary is "
+              "unchanged. Downloaded file left at %s\n",
+              tmp);
+      return 1;
+   }
+
+   printf("Updated to v%s. Backup at %s.bak\n", tnorm, self);
+   return 0;
+}

--- a/src/headers/cmd_self_update.h
+++ b/src/headers/cmd_self_update.h
@@ -1,0 +1,41 @@
+/* cmd_self_update.h: thin-client self-update.
+ *
+ * The thin client talks to exactly one aimee-server; when that server moves
+ * ahead in version, the client can drift. These helpers let the client observe
+ * the server version, decide whether it is behind, and (on request) fetch the
+ * matching release binary from GitHub and atomically swap itself. */
+#ifndef DEC_CMD_SELF_UPDATE_H
+#define DEC_CMD_SELF_UPDATE_H 1
+
+#include <stddef.h>
+
+/* Compare two version strings by (major, minor, patch). A leading 'v' and any
+ * "-<suffix>" (e.g. git-describe's "-31-gabc123") are ignored; missing
+ * components count as 0. Returns <0 if a<b, 0 if equal, >0 if a>b. */
+int aimee_version_compare(const char *a, const char *b);
+
+/* True if `s` is a plausible/safe version string: non-empty and composed only
+ * of [0-9A-Za-z._-] (so it is safe to interpolate into a release URL/command). */
+int aimee_version_is_safe(const char *s);
+
+/* Release asset base name for the current platform (e.g. "aimee-linux-x86_64",
+ * "aimee-linux-arm64", "aimee-macos-universal"). Returns a pointer to static
+ * storage, or NULL on an unsupported platform. */
+const char *aimee_self_update_asset(void);
+
+/* GET /v1/version from the configured aimee-server and write its version string
+ * to `out`. Best-effort, short timeout. Returns 0 on success, -1 otherwise
+ * (no remote endpoint, transport failure, or malformed response). */
+int aimee_fetch_server_version(char *out, size_t cap);
+
+/* If a remote (thin-client) server is configured AND reports a version newer
+ * than this client, write a one-line human notice to `out` and return 1.
+ * Returns 0 (and leaves `out` empty) when up to date, not a thin client, or the
+ * check could not be completed. Never blocks longer than a few seconds. */
+int aimee_self_update_notice(char *out, size_t cap);
+
+/* `aimee self-update [--check] [--version vX.Y.Z] [--yes]`. Returns a process
+ * exit code. --check reports drift without downloading. */
+int cmd_self_update(int argc, char **argv);
+
+#endif /* DEC_CMD_SELF_UPDATE_H */

--- a/src/headers/cmd_self_update.h
+++ b/src/headers/cmd_self_update.h
@@ -18,6 +18,11 @@ int aimee_version_compare(const char *a, const char *b);
  * of [0-9A-Za-z._-] (so it is safe to interpolate into a release URL/command). */
 int aimee_version_is_safe(const char *s);
 
+/* True if `s` is a comparable semantic version (starts with a numeric component,
+ * after an optional leading 'v'). A deliberately non-semver dev/branch build
+ * version (e.g. "testing-<sha>") returns 0 -- ordering against it is meaningless. */
+int aimee_version_is_semver(const char *s);
+
 /* Release asset base name for the current platform (e.g. "aimee-linux-x86_64",
  * "aimee-linux-arm64", "aimee-macos-universal"). Returns a pointer to static
  * storage, or NULL on an unsupported platform. */
@@ -34,8 +39,13 @@ int aimee_fetch_server_version(char *out, size_t cap);
  * check could not be completed. Never blocks longer than a few seconds. */
 int aimee_self_update_notice(char *out, size_t cap);
 
-/* `aimee self-update [--check] [--version vX.Y.Z] [--yes]`. Returns a process
- * exit code. --check reports drift without downloading. */
+/* `aimee self-update [--check] [--version vX.Y.Z] [--yes] [--require-verify]`.
+ * Returns a process exit code. --check reports drift without downloading. */
 int cmd_self_update(int argc, char **argv);
+
+/* When aimee.yaml sets `update_mode: apply` and the server is a strictly newer
+ * semver, spawn a detached, SHA-256-verified self-update (rate-limited to once
+ * per hour). No-op otherwise. Non-blocking; safe to call from SessionStart. */
+void aimee_self_update_apply_async(void);
 
 #endif /* DEC_CMD_SELF_UPDATE_H */

--- a/src/self_update_util.c
+++ b/src/self_update_util.c
@@ -51,6 +51,18 @@ int aimee_version_compare(const char *a, const char *b)
    return 0;
 }
 
+int aimee_version_is_semver(const char *s)
+{
+   if (!s)
+      return 0;
+   if (*s == 'v' || *s == 'V')
+      s++;
+   /* Comparable only if it starts with a numeric component. A dev/branch build
+    * version like "testing-b4a856b" is deliberately NOT a semver (see
+    * publish-testing.yml), so ordering against it is meaningless. */
+   return *s >= '0' && *s <= '9';
+}
+
 int aimee_version_is_safe(const char *s)
 {
    if (!s || !s[0])

--- a/src/self_update_util.c
+++ b/src/self_update_util.c
@@ -1,0 +1,97 @@
+/* self_update_util.c: pure, dependency-free helpers for thin-client self-update
+ * (version parsing/comparison, version-string validation, platform asset name).
+ * Kept in a leaf translation unit (libc only) so it is trivially unit-testable
+ * without the HTTP/command machinery in cmd_self_update.c. See cmd_self_update.h. */
+
+#include "headers/cmd_self_update.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifndef _WIN32
+#include <sys/utsname.h>
+#endif
+
+/* Parse up to 3 dot-separated numeric components from a version string, skipping
+ * a leading 'v'/'V' and stopping at '-' or any non-digit/dot. */
+static void parse_semver(const char *s, long out[3])
+{
+   out[0] = out[1] = out[2] = 0;
+   if (!s)
+      return;
+   if (*s == 'v' || *s == 'V')
+      s++;
+   for (int i = 0; i < 3 && *s; i++)
+   {
+      char *end = NULL;
+      long v = strtol(s, &end, 10);
+      if (end == s)
+         break; /* no digits where a component was expected */
+      out[i] = v;
+      s = end;
+      if (*s != '.')
+         break; /* end, or a "-suffix"/other -> stop */
+      s++;
+   }
+}
+
+int aimee_version_compare(const char *a, const char *b)
+{
+   long va[3], vb[3];
+   parse_semver(a, va);
+   parse_semver(b, vb);
+   for (int i = 0; i < 3; i++)
+   {
+      if (va[i] < vb[i])
+         return -1;
+      if (va[i] > vb[i])
+         return 1;
+   }
+   return 0;
+}
+
+int aimee_version_is_safe(const char *s)
+{
+   if (!s || !s[0])
+      return 0;
+   for (const char *p = s; *p; p++)
+   {
+      if (!(isalnum((unsigned char)*p) || *p == '.' || *p == '_' || *p == '-'))
+         return 0;
+   }
+   return 1;
+}
+
+const char *aimee_self_update_asset(void)
+{
+#ifdef _WIN32
+   return "aimee-windows-x86_64.exe";
+#else
+   static char buf[64];
+   struct utsname u;
+   if (uname(&u) != 0)
+      return NULL;
+   const char *os = u.sysname; /* "Linux", "Darwin" */
+   const char *arch = u.machine;
+   if (strcmp(os, "Darwin") == 0)
+   {
+      /* The macOS release asset is a universal (arm64+x86_64) binary. */
+      snprintf(buf, sizeof buf, "aimee-macos-universal");
+      return buf;
+   }
+   if (strcmp(os, "Linux") == 0)
+   {
+      const char *a = NULL;
+      if (strcmp(arch, "x86_64") == 0 || strcmp(arch, "amd64") == 0)
+         a = "x86_64";
+      else if (strcmp(arch, "aarch64") == 0 || strcmp(arch, "arm64") == 0)
+         a = "arm64";
+      if (!a)
+         return NULL;
+      snprintf(buf, sizeof buf, "aimee-linux-%s", a);
+      return buf;
+   }
+   return NULL;
+#endif
+}

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ add_test(NAME test_context_engine COMMAND test_context_engine)
 set_tests_properties(test_context_engine PROPERTIES
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 aimee_add_test(test_util test_util.c)
+aimee_add_test(test_self_update test_self_update.c ../self_update_util.c)
 aimee_add_test(test_audit_action test_audit_action.c)
 aimee_add_test(test_audit_action_log test_audit_action_log.c)
 aimee_add_test(test_audit_ledger test_audit_ledger.c)

--- a/src/tests/test_self_update.c
+++ b/src/tests/test_self_update.c
@@ -47,6 +47,19 @@ static void test_version_is_safe(void)
    printf("  test_version_is_safe ok\n");
 }
 
+static void test_version_is_semver(void)
+{
+   assert(aimee_version_is_semver("0.2.182"));
+   assert(aimee_version_is_semver("v0.2.182"));
+   assert(aimee_version_is_semver("v0.2.180-31-g3342b09e"));
+   assert(aimee_version_is_semver("1"));
+   assert(!aimee_version_is_semver("testing-b4a856b")); /* deliberate dev/branch build */
+   assert(!aimee_version_is_semver("vtesting"));
+   assert(!aimee_version_is_semver(""));
+   assert(!aimee_version_is_semver(NULL));
+   printf("  test_version_is_semver ok\n");
+}
+
 static void test_asset(void)
 {
    /* On the platforms we support, the asset name is non-NULL and starts with
@@ -65,6 +78,7 @@ int main(void)
 {
    test_version_compare();
    test_version_is_safe();
+   test_version_is_semver();
    test_asset();
    printf("test_self_update: all passed\n");
    return 0;

--- a/src/tests/test_self_update.c
+++ b/src/tests/test_self_update.c
@@ -1,0 +1,71 @@
+/* Unit tests for the pure self-update helpers (self_update_util.c):
+ * version comparison, version-string validation, platform asset name. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "cmd_self_update.h"
+
+static void test_version_compare(void)
+{
+   /* Equality, ignoring a leading 'v' on either side. */
+   assert(aimee_version_compare("0.2.182", "0.2.182") == 0);
+   assert(aimee_version_compare("v0.2.182", "0.2.182") == 0);
+   assert(aimee_version_compare("0.2.182", "v0.2.182") == 0);
+
+   /* Ordering by major, minor, patch. */
+   assert(aimee_version_compare("0.2.183", "0.2.182") > 0);
+   assert(aimee_version_compare("0.2.182", "0.2.183") < 0);
+   assert(aimee_version_compare("0.3.0", "0.2.999") > 0);
+   assert(aimee_version_compare("1.0.0", "0.9.9") > 0);
+   assert(aimee_version_compare("0.2.9", "0.2.10") < 0); /* numeric, not lexical */
+
+   /* git-describe suffix is ignored (compares by the tag part). */
+   assert(aimee_version_compare("v0.2.180-31-g3342b09e", "0.2.180") == 0);
+   assert(aimee_version_compare("v0.2.181-1-gabc", "0.2.180") > 0);
+
+   /* Missing components count as zero. */
+   assert(aimee_version_compare("0.2", "0.2.0") == 0);
+   assert(aimee_version_compare("1", "0.9.9") > 0);
+
+   /* Defensive: NULL/garbage parse to 0.0.0. */
+   assert(aimee_version_compare(NULL, "0.0.0") == 0);
+   assert(aimee_version_compare("0.0.1", NULL) > 0);
+   printf("  test_version_compare ok\n");
+}
+
+static void test_version_is_safe(void)
+{
+   assert(aimee_version_is_safe("0.2.182"));
+   assert(aimee_version_is_safe("v0.2.180-31-g3342b09e"));
+   assert(aimee_version_is_safe("1.2.3_rc1"));
+   assert(!aimee_version_is_safe(""));
+   assert(!aimee_version_is_safe(NULL));
+   assert(!aimee_version_is_safe("0.2.1; rm -rf /")); /* shell metachars rejected */
+   assert(!aimee_version_is_safe("0.2.1$(x)"));
+   assert(!aimee_version_is_safe("0.2.1/../etc"));
+   printf("  test_version_is_safe ok\n");
+}
+
+static void test_asset(void)
+{
+   /* On the platforms we support, the asset name is non-NULL and starts with
+    * the "aimee-" prefix and matches the running OS family. NULL is acceptable
+    * (unsupported platform) but on Linux/macOS CI we expect a name. */
+   const char *a = aimee_self_update_asset();
+   if (a)
+   {
+      assert(strncmp(a, "aimee-", 6) == 0);
+      assert(strstr(a, "linux") || strstr(a, "macos") || strstr(a, "windows"));
+   }
+   printf("  test_asset ok (%s)\n", a ? a : "(unsupported platform -> NULL)");
+}
+
+int main(void)
+{
+   test_version_compare();
+   test_version_is_safe();
+   test_asset();
+   printf("test_self_update: all passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Why
The thin client talks **1:1** to one aimee-server, so the server's version is observable on every call and is the exact target to match. When the server moves ahead, the client can drift — which just bit us (a 0.2.176 client's worktree guard behaved differently from a 0.2.182 server). This gives the client a way to *see* the drift and catch up, keeping the two in lockstep.

## What
- **`src/self_update_util.c`** (pure, unit-tested): semver parse/compare (ignores a leading `v` and a git-describe `-N-gSHA` suffix), version-string validation, and the platform release-asset name (`aimee-linux-x86_64`/`arm64`, `aimee-macos-universal`).
- **`src/cmd_self_update.c`**: reads the server version from the existing `GET /v1/version`. `aimee self-update [--check] [--version vX.Y.Z] [--yes]` downloads the matching GitHub release asset over cert-verified HTTPS, **requires the downloaded binary to run and report the exact target version** (catches truncation / wrong-arch / wrong-version), backs up the current binary, then **atomically renames** it into place (running processes keep the old inode). Never downgrades; rejects implausible version strings; Linux swap via `/proc/self/exe`.
- **SessionStart** (thin-client/remote path): emits a one-line *"server is vX, you are vY → run `aimee self-update`"* notice when the server reports a higher semver. Best-effort; never blocks the session.

Conservative first cut: session-start only **notifies**; the swap is **user-initiated**.

## Verification
- `test_self_update` (new): version compare / validation / asset mapping — passes.
- `-Werror` thin-client build clean; unit test green.
- **Live:** `self-update --check` against the configured server; and a full **download → verify → atomic-swap of a real `v0.2.181` release** onto a throwaway binary (v0.2.100 → v0.2.181, backup kept). Guardrails confirmed: downgrade refused, unsafe version rejected, already-up-to-date.

## Follow-ups (called out, not blocking)
1. **Cryptographic verification.** Today's integrity is HTTPS transport trust + the version self-check; the release publishes no per-asset signatures. Publishing a minisign/cosign signature (or verifying the GitHub API asset digest) and checking it before swap would close the supply-chain gap — recommended before enabling any auto-`apply` mode.
2. **Server should report a semver.** A dev/branch server build reports e.g. `testing-<sha>`, which parses to `0.0.0` — so drift is a **safe no-op** (never a false "update") but also won't be *detected*. Release servers report a clean semver and work as intended.
3. **`apply` mode + single install path.** A config-gated auto-apply (this PR is notify-only) and collapsing the client to one canonical install location (this repo currently had two out-of-sync `aimee` binaries) are natural next steps.