### PR TITLE
feat(logging): register ACP and MCP sessions in server_sessions

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -253,7 +253,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 147 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 148 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -451,7 +451,7 @@ The binaries read 147 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -21,7 +21,7 @@
 #include "delegate_plan.h"
 #include "cli_tui.h"
 #include "platform.h"
-#include "platform_path.h"
+#include "platform_path.h" /* platform_getppid */
 #include "platform_process.h"
 #include "cJSON.h"
 #include "memory_redirect.h"
@@ -1542,7 +1542,22 @@ static char *acp_dispatch_prompt(const char *content, const char *session_id)
    const char *sock = cli_ensure_server_for_method("chat.send_stream");
    if (!sock)
       return NULL;
-   return cli_chat_stream(sock, session_id, content, acp_stream_delta, acp_stream_tool,
+   /* Single-session ACP clients never call session/new and omit sessionId, so
+    * session_id arrives empty and the turn would carry no aimee_session_id -- the
+    * server could not log it in server_sessions. Derive a stable per-editor id for
+    * LOGGING (keyed on the parent pid, mirroring the MCP serve proxy's
+    * session-ppid-*) so every turn from one editor process is recorded under one
+    * recoverable id. The outbound session/update notifications keep echoing the
+    * client's original sessionId (empty when none was sent), so the ACP wire
+    * contract is unchanged -- only the server-side logging id is synthesized. */
+   char fallback[32];
+   const char *log_sid = session_id;
+   if (!log_sid || !log_sid[0])
+   {
+      snprintf(fallback, sizeof(fallback), "acp-ppid-%d", platform_getppid());
+      log_sid = fallback;
+   }
+   return cli_chat_stream(sock, log_sid, content, acp_stream_delta, acp_stream_tool,
                           (void *)session_id);
 }
 
@@ -1862,9 +1877,16 @@ int main(int argc, char **argv)
    if (strcmp(cmd, "mcp-serve") == 0)
       return cli_mcp_serve();
 
-   /* ACP stdio server: lets ACP editors (Zed, Aider) use aimee as a backend. */
+   /* ACP stdio server: lets ACP editors (Zed, Aider) use aimee as a backend.
+    * Tag every chat turn this loop dispatches as "acp" so the session is logged
+    * under its real surface (builtin_chat_send_ex forwards AIMEE_CLIENT_TYPE into
+    * the chat request; the server records it on the server_sessions row). */
    if (strcmp(cmd, "acp-serve") == 0)
+   {
+      /* platform_setenv: portable (POSIX setenv / Windows SetEnvironmentVariable). */
+      platform_setenv("AIMEE_CLIENT_TYPE", "acp");
       return acp_server_run(acp_dispatch_prompt);
+   }
 
    /* Explicit server lifecycle. The CLI no longer auto-spawns on demand
     * (#1660); systemd / launchd / SCM owns the lifecycle on each platform,

--- a/src/cli_tui.c
+++ b/src/cli_tui.c
@@ -372,6 +372,15 @@ builtin_chat_send_ex(const char *sock, const char *provider_session_id,
       if (attach_env && attach_env[0])
          cJSON_AddStringToObject(req, "attach_id", attach_env);
    }
+   /* Client type of the host driving this turn (e.g. "acp" for an editor over the
+    * ACP serve loop). The server records it on the server_sessions row via
+    * chat_session_register, so a turn is logged under its real surface instead of
+    * the generic "chat" default. Absent → server defaults to "chat", as before. */
+   {
+      const char *ct_env = getenv("AIMEE_CLIENT_TYPE");
+      if (ct_env && ct_env[0])
+         cJSON_AddStringToObject(req, "client_type", ct_env);
+   }
    if (aimee_session_id && aimee_session_id[0])
       cJSON_AddStringToObject(req, "aimee_session_id", aimee_session_id);
    if (provider_session_id && provider_session_id[0])

--- a/src/headers/server_mcp_internal.h
+++ b/src/headers/server_mcp_internal.h
@@ -2,6 +2,14 @@
 #define SERVER_MCP_INTERNAL_H
 #include "server.h"
 /* Cross-TU decls split from server_mcp.c. */
+
+/* Idempotently register an MCP session in the server_sessions registry (tagged
+ * client_type "mcp"), so an MCP serve session -- which is pure tool calls and
+ * never drives a chat turn -- is locatable after a crash/restart. Best-effort:
+ * a NULL/empty/unsafe sid or a DB failure is a silent no-op. Called from the
+ * mcp.call seam (tools/list is a bodyless GET that carries no session id). */
+void mcp_session_register(server_conn_t *conn, const char *sid);
+
 /* promoted cross-TU (former .inc statics) */
 cJSON *text_content(const char *text);
 cJSON *tool_ast_grep_search(cJSON *args);

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -10,6 +10,7 @@
 #include "index.h"
 #include "code_span.h"
 #include "db1.h"
+#include "util.h" /* is_safe_id */
 #include "kb_client.h"
 #include "dashboard.h"
 #include "work_queue.h"
@@ -1610,6 +1611,26 @@ static cJSON *mcp_tool_describe_tool(cJSON *args)
    return json_result_content(found);
 }
 
+/* Idempotently register an MCP session in the server_sessions registry, tagged
+ * client_type "mcp", so a session is locatable after a crash/restart -- matching
+ * every other session entry seam (handle_hooks_session_start,
+ * handle_session_create, chat_session_register). MCP sessions are pure tool calls
+ * and never drive a chat turn, so the MCP request handlers are the only seam that
+ * can log them; without this an MCP serve session left no findable record.
+ * Best-effort: a NULL/empty/unsafe sid or a DB failure is a silent no-op and must
+ * never fail the request. */
+void mcp_session_register(server_conn_t *conn, const char *sid)
+{
+   if (!conn || !sid || !sid[0] || !is_safe_id(sid))
+      return;
+   db1_server_session_t existing;
+   if (db1_server_session_get(sid, &existing) == 0)
+      return; /* already registered */
+   char principal[32];
+   snprintf(principal, sizeof(principal), "uid:%d", (int)conn->peer_uid);
+   (void)db1_server_session_create(sid, "mcp", principal);
+}
+
 int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    cJSON *jtool = cJSON_GetObjectItemCaseSensitive(req, "tool");
@@ -1617,6 +1638,9 @@ int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    cJSON *jsid = cJSON_GetObjectItemCaseSensitive(req, "session_id");
    cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(req, "cwd");
    const char *sid = (jsid && cJSON_IsString(jsid)) ? jsid->valuestring : NULL;
+
+   /* Log this MCP session in server_sessions before dispatching the tool. */
+   mcp_session_register(conn, sid);
 
    if (!cJSON_IsString(jtool))
       return server_send_error(conn, "missing 'tool' parameter", NULL);

--- a/src/server/server_mcp_tools.c
+++ b/src/server/server_mcp_tools.c
@@ -190,6 +190,11 @@ int handle_mcp_tools_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
    (void)req;
+   /* NOTE: a session that ONLY lists tools (never calls one) is not logged here:
+    * mcp.tools_list is served over a bodyless GET /v1/mcp/tools_list, so no
+    * session_id reaches this handler. Sessions that call any tool are logged at
+    * the mcp.call seam (mcp_session_register). Closing this residual gap would
+    * require threading the session id through the GET route (query/header). */
 
    cJSON *resp = cJSON_CreateObject();
    if (!resp)


### PR DESCRIPTION
## Problem
MCP tool-call sessions and ACP editor sessions never wrote a row to the `server_sessions` registry, so they couldn't be found after a crash/restart — unlike Claude Code sessions (SessionStart hook) and explicit `session.create` callers.

## Change
- **MCP:** `handle_mcp_call` idempotently registers its session tagged `client_type="mcp"` via a shared `mcp_session_register` helper. Best-effort — a DB failure never fails the tool call.
- **ACP:** `acp-serve` tags the chat turns it dispatches as `"acp"` — `builtin_chat_send_ex` forwards `AIMEE_CLIENT_TYPE` into the chat request `client_type` field (which the server already records via `chat_session_register`), and `acp_dispatch_prompt` synthesizes a stable `acp-ppid-<ppid>` logging id when the client omits `sessionId`, leaving the ACP wire contract unchanged.

## Verified
- Built `aimee-server` + `aimee-kb` + client clean (`-Werror`).
- Live end-to-end against an isolated server: an `mcp.call` with a session_id creates a row tagged `mcp`; ACP with a sessionId creates one tagged `acp`; ACP without a sessionId creates `acp-ppid-<ppid>` tagged `acp`.
- Regression: `unit-test-server-dispatch`, `unit-test-acp-server`, `unit-test-cli-acp` pass.

## Known limitation
A session that only lists tools and never calls one is still not logged: `mcp.tools_list` is a bodyless `GET` that carries no session id. Documented in `handle_mcp_tools_list`.