### PR TITLE
fix(roundtable): compose panels from the configured default preset's seat models

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -11,6 +11,14 @@ Thin-client + credential hardening, the client owns the working tree; agent
 credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).
 
+- **Roundtable panels use the configured default preset's models**: a review
+  persona that no agent advertises (e.g. `qa`/`reviewer`) no longer degrades the
+  gate. The live panel now falls back to the active `roundtable.default` preset,
+  dispatching each persona on the **model bound to its seat** (e.g.
+  `qa → mistral-medium-3-5`, `security → mimo-v2.5-pro`). So a `gate.roundtable`
+  composes from the operator's configured roundtable instead of failing closed to
+  `panel_degraded` when a bare persona has no assigned agent.
+
 - **Roundtable ↔ planner now refine together**: when a `gate.roundtable` requests
   changes, the panel's blockers are captured and persisted for the work item, and
   the next `author.proposal`/`author.plan` pass folds them into its prompt — so the

--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -20,9 +20,11 @@
 #include "agent.h"
 #include "agent_config.h"
 #include "agent_exec.h"
+#include "config.h"
 #include "delegate_role.h"
 #include "persona.h"
 #include "provider_catalog.h"
+#include "roundtable_preset.h"
 #include "log.h"
 #include "util.h"
 
@@ -97,6 +99,38 @@ static char *dispatch_review(const char *workdir, const char *persona, const cha
             chosen = ag;
             chosen_role = r;
             best_tier = ag->cost_tier;
+         }
+      }
+   }
+   /* No agent advertises this review persona (roles + persona-support). Fall back
+    * to the configured DEFAULT ROUNDTABLE preset (roundtable.default): each seat
+    * binds a persona to a concrete model, so dispatch the persona on that model's
+    * agent. This lets the panel compose from the operator's configured roundtable
+    * instead of failing closed to DEGRADED when the bare persona has no agent. */
+   if (!chosen)
+   {
+      config_t cfg;
+      roundtable_preset_t pr;
+      if (config_load(&cfg) == 0 && cfg.roundtable_default[0] &&
+          roundtable_preset_load(cfg.roundtable_default, &pr) == 0)
+      {
+         for (int si = 0; si < pr.seat_count && !chosen; si++)
+         {
+            if (strcmp(pr.seats[si].persona, persona) != 0 || !pr.seats[si].model[0])
+               continue;
+            for (int ai = 0; ai < acfg.agent_count; ai++)
+            {
+               agent_t *ag = &acfg.agents[ai];
+               if (ag->enabled && strcmp(ag->name, pr.seats[si].model) == 0 &&
+                   agent_is_available_for_routing(ag) &&
+                   provider_catalog_get_health(ag->name) != CATALOG_HEALTH_DOWN)
+               {
+                  chosen = ag;
+                  chosen_role =
+                      delegate_role_canonicalize(pinfo.roles_count > 0 ? pinfo.roles[0] : "review");
+                  break;
+               }
+            }
          }
       }
    }


### PR DESCRIPTION
## What

Makes `gate.roundtable` **compose its panel from the configured `roundtable.default` preset**: when a review persona has no agent that advertises it, the panelist is dispatched on the **model bound to that persona's seat** in the preset — instead of the gate failing closed to `panel_degraded`.

## Why

`dispatch_review` (live panel) resolves a persona → agent by matching the persona's roles **and** `agent_supports_persona`. On .254 no agent advertises the bare `qa`/`reviewer` (etc.) review personas, so:

```
WARN wfe-panel: no agent for required persona 'qa' -> degrade
```

→ the required lens gets no verdict → `wfe_gate_decide` **degrades** → the run parks `panel_degraded` at the roundtable, **before reviewing anything**. Every autonomous build stalls there (`wi_712049`, `wi_2c954134` observed).

The operator's configured **`default` roundtable preset** already solves this by binding each persona to a concrete model:

| persona | model |
|---|---|
| reviewer-constructive | GLM-5.2 |
| architect | MiniMax-M3 |
| qa | mistral-medium-3-5 |
| security | mimo-v2.5-pro |
| reviewer | codex |

## Change

In `dispatch_review` (`wfe_live_panel.c`), when the role/persona-support search finds no agent, fall back to the active `roundtable.default` preset: find the seat whose `persona` matches and dispatch on that seat's `model`'s agent (enabled, available, not DOWN). So the panel composes from the operator's configured roundtable.

Server-side only; the per-persona dispatch is **integration-exercised** (per this file's own contract — it needs reachable review agents, so it isn't in the unit suite). Full server build + link verified locally.

## Why this matters now

This **unblocks** the plan↔roundtable feedback loop (#1238): that fix is deployed and correct, but its convergence can't be *observed* until the panel stops degrading. With the panel composing, the roundtable actually reviews, returns verdicts, and the feedback loop can drive refinement.

## Validation

Deploy to .254 + re-fire a proposal; confirm `plan_gate` composes a panel (no `panel_degraded`) and the run proceeds through the roundtable. (Validation-pending until deployed.)