### PR TITLE
refactor(delegate): generalized "viable delegate for role X, retry until works"

### DIFF
--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -7,6 +7,17 @@ current version and prints it once after an upgrade.
 
 ## Unreleased (testing)
 
+- **Generalized delegate dispatch (viable delegate for a role, retry until one works)**:
+  `agent_run_ex` no longer walks a configured `fallback_chain` — it routes to the
+  preferred agent for the role, then retries other **viable** agents (enabled,
+  routable, serving the role; a DOWN agent is skipped) at random until one
+  succeeds. The roundtable panel is now just N `review` delegate requests: it
+  dispatches by the `review` role (the persona rides in the prompt as the lens),
+  excludes agents already seated for a **diverse** panel, and retries a flaky
+  agent onto a different one instead of degrading the gate. Non-review agents
+  (e.g. `gpu-mid`, which lacks the `review` role) are never seated. A specific
+  agent is used only when explicitly pinned.
+
 Thin-client + credential hardening, the client owns the working tree; agent
 credentials live in the server's **sealed vault**; see
 [THIN_CLIENT.md](THIN_CLIENT.md).

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -114,4 +114,14 @@ void agent_request_creds_restore(const agent_request_creds_t *creds);
  * return 0. */
 int agent_is_claude_cli(const agent_t *agent);
 
+/* Generalized role dispatch. delegate_pick_for_role returns the index of a
+ * viable agent (enabled, routable, serves `role`) not named in `exclude`,
+ * uniformly at random among the eligible set — or -1 if none remain. Callers
+ * loop pick->run->exclude-on-failure->repick until one works. A roundtable of N
+ * `review` delegates excludes those already used to get diverse reviewers. */
+int delegate_pick_for_role(agent_config_t *cfg, const char *role, const char *const exclude[],
+                           int nexclude);
+/* Seed the picker's RNG for deterministic tests (otherwise /dev/urandom). */
+void delegate_role_pick_seed(unsigned seed);
+
 #endif /* DEC_AGENT_CONFIG_H */

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -11,6 +11,7 @@
 #include "cJSON.h"
 #include "json_fluent.h"
 #include <ctype.h>
+#include <stdlib.h>
 #include <stdatomic.h>
 #include <sys/stat.h>
 #include <time.h>
@@ -1360,6 +1361,62 @@ int agent_is_claude_cli(const agent_t *agent)
    return strcmp(agent->backend, AGENT_BACKEND_TMUX_CLI) == 0 ||
           strcmp(agent->backend, AGENT_BACKEND_PROVIDER_CLI) == 0 ||
           strcmp(agent->backend, AGENT_BACKEND_CLI_STDIO) == 0;
+}
+
+/* --- generalized role dispatch: a viable delegate for a role ---
+ * Return the index of an enabled, routable agent that serves `role` and is not
+ * named in `exclude`, chosen uniformly at random among the eligible set (so
+ * repeated requests for the same role vary — a roundtable of N `review`
+ * delegates, excluding those already used, gets diverse reviewers). Returns -1
+ * when none remain. Callers loop: pick -> run -> on failure add the agent to
+ * `exclude` -> pick again, until one works. Eligibility + retry-until-viable is
+ * the whole mechanism; a specific agent is used only when a caller pins one. */
+static unsigned g_role_rand_seed;
+static int g_role_rand_seeded;
+void delegate_role_pick_seed(unsigned seed)
+{
+   g_role_rand_seed = seed;
+   g_role_rand_seeded = 1;
+}
+static unsigned delegate_role_rand(void)
+{
+   if (g_role_rand_seeded)
+      return (unsigned)rand_r(&g_role_rand_seed);
+   unsigned v = 0;
+   FILE *f = fopen("/dev/urandom", "rb");
+   if (f)
+   {
+      if (fread(&v, 1, sizeof v, f) != sizeof v)
+         v = 0;
+      fclose(f);
+   }
+   if (!v)
+      v = (unsigned)time(NULL);
+   return v;
+}
+int delegate_pick_for_role(agent_config_t *cfg, const char *role, const char *const exclude[],
+                           int nexclude)
+{
+   if (!cfg || !role || !role[0])
+      return -1;
+   int elig[MAX_AGENTS];
+   int n = 0;
+   for (int i = 0; i < cfg->agent_count && i < MAX_AGENTS; i++)
+   {
+      agent_t *ag = &cfg->agents[i];
+      if (!ag->enabled || !agent_supports_role(ag, role) || !agent_is_available_for_routing(ag))
+         continue;
+      int skip = 0;
+      for (int e = 0; e < nexclude && !skip; e++)
+         if (exclude[e] && strcmp(exclude[e], ag->name) == 0)
+            skip = 1;
+      if (skip)
+         continue;
+      elig[n++] = i;
+   }
+   if (n == 0)
+      return -1;
+   return elig[delegate_role_rand() % (unsigned)n];
 }
 
 agent_t *agent_route(agent_config_t *cfg, const char *role)

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -147,58 +147,29 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
       }
    }
 
-   for (int pass = 0; pass < 2; pass++)
+   /* Route to the best agent for the role (cost-tier), then retry other viable
+    * agents at random until one succeeds. This replaces the configured
+    * fallback_chain: eligibility + retry-until-viable is the whole mechanism. A
+    * DOWN agent is never tried (agent_is_available_for_routing filters it). */
+   const char *tried[MAX_AGENTS];
+   int ntried = 0;
+   for (int attempt = 0; attempt <= MAX_AGENTS; attempt++)
    {
-      for (int i = 0; i < cfg->fallback_count; i++)
+      agent_t *ag;
+      if (attempt == 0)
+         ag = agent_route(cfg, role); /* preferred (cost-tier) pick first */
+      else
       {
-         agent_t *ag = agent_find(cfg, cfg->fallback_chain[i]);
-         if (!ag || !ag->enabled || !agent_has_role(ag, role))
-            continue;
-         if (pass == 0 && provider_catalog_get_health(ag->name) == CATALOG_HEALTH_DOWN)
-         {
-            aimee_log(LOG_DEBUG, "agent", "skipping DOWN agent '%s' in fallback (pass 0)",
-                      ag->name);
-            continue;
-         }
-
-         int use_tools =
-             agent_uses_provider_cli(ag) || (ag->tools_enabled && agent_is_exec_role(ag, role));
-         agent_apply_runtime_config(ag);
-         ag->ablation = cfg->ablation;
-         ag->write_capable = use_tools && delegate_role_is_write(role) ? 1 : 0;
-         int rc;
-         if (use_tools)
-            rc = agent_execute_with_tools_for_role(ag, &cfg->network, role, system_prompt,
-                                                   user_prompt, max_tokens, temperature, out);
-         else
-            rc = agent_execute(ag, system_prompt, user_prompt, max_tokens, temperature, out);
-
-         if (rc == 0)
-         {
-            provider_catalog_record_success(ag->name);
-            agent_log_call(out, role);
-            agent_store_feedback(out, role, user_prompt);
-
-            agent_outcome_t oc;
-            classify_outcome(out, ag->max_turns, &oc);
-            record_outcome(out->agent_name, role, &oc);
-
-            if (cache_enabled && out->response)
-               db1_agent_cache_put(role, user_prompt, out->response);
-            return 0;
-         }
-         {
-            const char *err_class = agent_error_is_retryable(out->error) ? "retryable" : "error";
-            provider_catalog_record_failure(ag->name, err_class);
-         }
-         free(out->response);
-         out->response = NULL;
+         int idx = delegate_pick_for_role(cfg, role, tried, ntried);
+         ag = idx >= 0 ? &cfg->agents[idx] : NULL;
       }
-   }
+      if (!ag)
+      {
+         if (attempt == 0)
+            continue; /* no primary route -> fall through to the random picker */
+         break;       /* no viable agent remains */
+      }
 
-   agent_t *ag = agent_route(cfg, role);
-   if (ag)
-   {
       int use_tools =
           agent_uses_provider_cli(ag) || (ag->tools_enabled && agent_is_exec_role(ag, role));
       agent_apply_runtime_config(ag);
@@ -228,7 +199,6 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
                                                 effective_prompt, max_tokens, temperature, out);
       else
          rc = agent_execute(ag, system_prompt, effective_prompt, max_tokens, temperature, out);
-
       free(enhanced);
 
       if (rc == 0)
@@ -249,6 +219,10 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
          const char *err_class = agent_error_is_retryable(out->error) ? "retryable" : "error";
          provider_catalog_record_failure(ag->name, err_class);
       }
+      if (ntried < MAX_AGENTS)
+         tried[ntried++] = ag->name;
+      free(out->response);
+      out->response = NULL;
    }
 
    agent_store_feedback(out, role, user_prompt);

--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -50,16 +50,17 @@ static void panel_git(const char *workdir, const char *const extra[], int extra_
  * Returns the agent's response (malloc'd, caller frees), or NULL if no eligible agent
  * could run. Any edit the reviewer makes is discarded (hard reset) — read-only is
  * enforced, not merely requested. */
-static char *dispatch_review(const char *workdir, const char *persona, const char *prompt)
+static char *dispatch_review(const char *workdir, const char *persona, const char *prompt,
+                             const char *const used[], int nused, char *out_agent,
+                             size_t out_agent_n)
 {
+   if (out_agent && out_agent_n)
+      out_agent[0] = '\0';
    agent_config_t acfg;
    memset(&acfg, 0, sizeof acfg);
    if (agent_load_config(&acfg) != 0)
       return NULL;
    char *sys_prompt = persona_compose_delegate_prompt(persona, workdir, "");
-   persona_t pinfo;
-   memset(&pinfo, 0, sizeof pinfo);
-   persona_load(NULL, persona, &pinfo);
 
    char pre_head[64] = "";
    {
@@ -76,38 +77,44 @@ static char *dispatch_review(const char *workdir, const char *persona, const cha
    }
 
    run_cmd_set_cwd(workdir);
+
+   /* Ask for a viable `review` delegate. The persona rides in the system prompt as
+    * the review lens; agent selection is purely by the `review` role, so non-review
+    * agents (e.g. gpu-mid, which lacks the role) are never picked. Exclude agents
+    * already seated on this panel (diversity) and any that fail this round, and
+    * retry until one lands — a flaky agent no longer degrades the whole gate. */
+   const char *tried[MAX_AGENTS];
+   int ntried = 0;
+   for (int i = 0; i < nused && ntried < MAX_AGENTS; i++)
+      tried[ntried++] = used[i];
+
    agent_result_t res;
    memset(&res, 0, sizeof res);
    agent_t *chosen = NULL;
-   const char *chosen_role = NULL;
-   int best_tier = 0;
-   for (int ri = 0; ri < pinfo.roles_count && !chosen; ri++)
-   {
-      const char *r = delegate_role_canonicalize(pinfo.roles[ri]);
-      for (int ai = 0; ai < acfg.agent_count; ai++)
-      {
-         agent_t *ag = &acfg.agents[ai];
-         if (!ag->enabled || !agent_has_role(ag, r) || !agent_supports_persona(ag, persona) ||
-             !agent_is_available_for_routing(ag))
-            continue;
-         if (provider_catalog_get_health(ag->name) == CATALOG_HEALTH_DOWN)
-            continue;
-         if (!chosen || ag->cost_tier < best_tier)
-         {
-            chosen = ag;
-            chosen_role = r;
-            best_tier = ag->cost_tier;
-         }
-      }
-   }
    int rc = -1;
-   if (chosen)
-      rc = agent_execute_with_tools_for_role(chosen, &acfg.network, chosen_role,
+   while (ntried < MAX_AGENTS)
+   {
+      int idx = delegate_pick_for_role(&acfg, "review", tried, ntried);
+      if (idx < 0)
+         break;
+      chosen = &acfg.agents[idx];
+      memset(&res, 0, sizeof res);
+      rc = agent_execute_with_tools_for_role(chosen, &acfg.network, "review",
                                              sys_prompt ? sys_prompt : "", prompt,
                                              AGENT_DEFAULT_MAX_TOKENS, 0.2, &res);
+      if (rc == 0 && res.response && res.response[0])
+         break;
+      provider_catalog_record_failure(chosen->name,
+                                      agent_error_is_retryable(res.error) ? "retryable" : "error");
+      free(res.response);
+      memset(&res, 0, sizeof res);
+      tried[ntried++] = chosen->name;
+      chosen = NULL;
+      rc = -1;
+   }
+
    run_cmd_set_cwd(NULL);
    free(sys_prompt);
-   persona_free(&pinfo);
 
    /* Enforce read-only: hard-reset to the pre-review HEAD + clean untracked. */
    if (pre_head[0])
@@ -119,8 +126,13 @@ static char *dispatch_review(const char *workdir, const char *persona, const cha
    }
 
    char *out = NULL;
-   if (rc == 0 && res.response && res.response[0])
+   if (rc == 0 && chosen && res.response && res.response[0])
+   {
       out = strdup(res.response);
+      provider_catalog_record_success(chosen->name);
+      if (out_agent && out_agent_n)
+         snprintf(out_agent, out_agent_n, "%s", chosen->name);
+   }
    free(res.response);
    return out;
 }
@@ -165,24 +177,38 @@ static int live_panel(const wfe_review_packet_t *pkt, const char *const *require
    if (!pkt || !pkt->workdir || !pkt->workdir[0])
       return -1; /* no worktree to review in -> panel can't compose -> park */
 
+   /* Distinct agent per seated lens: each review delegate excludes the agents
+    * already used on this panel, so the roundtable is a genuinely diverse panel. */
+   char used_buf[MAX_AGENTS][MAX_AGENT_NAME];
+   const char *used[MAX_AGENTS];
+   int nused = 0;
+
    int filled = 0;
    for (int i = 0; i < nreq && filled < max; i++)
    {
       char *prompt = build_prompt(required[i], pkt);
       if (!prompt)
          continue; /* OOM building the prompt -> leave this lens unfilled (gate degrades) */
-      char *resp = dispatch_review(pkt->workdir, required[i], prompt);
+      char agent_name[MAX_AGENT_NAME] = "";
+      char *resp = dispatch_review(pkt->workdir, required[i], prompt, used, nused, agent_name,
+                                   sizeof agent_name);
       free(prompt);
       if (!resp)
       {
-         /* This required persona couldn't be dispatched: leave it WITHOUT a verdict so
-          * the gate DEGRADES (a missing required lens must never be papered over). */
-         aimee_log(LOG_WARN, "wfe-panel", "no agent for required persona '%s' -> degrade",
+         /* No viable review agent remains for this lens: leave it WITHOUT a verdict
+          * so the gate DEGRADES (a missing required lens must never be papered over). */
+         aimee_log(LOG_WARN, "wfe-panel", "no viable review agent for lens '%s' -> degrade",
                    required[i]);
          continue;
       }
       wfe_panel_verdict_from_review(required[i], pkt->artifact_hash, resp, &out[filled]);
       free(resp);
+      if (agent_name[0] && nused < MAX_AGENTS)
+      {
+         snprintf(used_buf[nused], sizeof used_buf[0], "%s", agent_name);
+         used[nused] = used_buf[nused];
+         nused++;
+      }
       filled++;
    }
    /* filled==0 (nothing composed) -> the gate sees no required verdicts -> DEGRADED. */


### PR DESCRIPTION
**Draft** — this rewrites the central delegate path (`agent_run_ex`), so it wants live integration validation before merge (see Validation).

## What

One dispatch mechanism everywhere: **ask for a delegate that supports a role → get a viable one.** Eligibility + retry-until-viable *is* the mechanism; a specific agent is used only when explicitly pinned. No configured `fallback_chain`.

## Change

- **`agent_config`** — `delegate_pick_for_role(cfg, role, exclude[], nexclude)`: a uniformly-random enabled, routable agent that serves `role` and isn't in `exclude` (or `-1`). Seedable RNG for tests.
- **`agent_runtime`** — `agent_run_ex` drops the two-pass `fallback_chain` loop. It routes to the preferred (cost-tier) agent first, then **retries other viable agents** via the picker until one succeeds; a DOWN agent is never tried. Every site already calling `agent_run_ex(role)` (implement, sweep, cron, eval, …) inherits this for free.
- **`wfe_live_panel`** (roundtable) — `dispatch_review` stops hand-picking by persona/role. It asks for a **`review`** delegate (the persona rides in the system prompt as the review lens), **excludes agents already seated** for a diverse panel, and **retries a flaky agent** onto another instead of leaving the lens empty → the gate no longer degrades on one transient miss. Non-review agents (no `review` role, e.g. `gpu-mid`) are never seated.

## Deliberate call

Selection becomes eligibility + random + retry rather than the configured `fallback_chain`. `agent_route`'s cost-tier preference is kept as the *first* pick, so single delegate requests still favour the cheap agent; the randomness/exclusion gives the roundtable its diversity.

## Validation

- Server **builds + links**; delegate/routing regression (`cmd-delegate`, `agent-runtime-messages`, `wfe-random-delegate`) **passes**.
- `agent_run_ex` is the central delegate path and `dispatch_review` is integration-exercised (not unit-tested, per that file's contract). **Broad correctness is validation-pending on a live deployment** — I won't mark this done on unit tests alone.

## Follow-ups (not in this PR)

- `$random` seat resolution in `delegate_ensemble` (the ensemble/authoring roundtable path).
- Removing the now-unused `fallback_chain` config/GUI/CLI surface.