### PR TITLE
fix(kb): store vectors at the embedder's runtime dim; reclaim & bound curator drain

### DIFF
--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1460,7 +1460,10 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
                   "{\"error\":\"failed to open knowledge service store\"}");
          return 503;
       }
-      if (pgvec_kb_service_ensure_kb_collection(384) != 0)
+      int kb_embed_dim = db2_embedding_dim();
+      if (kb_embed_dim <= 0 || kb_embed_dim > EMBED_MAX_DIM)
+         kb_embed_dim = 1024;
+      if (pgvec_kb_service_ensure_kb_collection(kb_embed_dim) != 0)
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"vector store unavailable\"}");
          return 503;
@@ -1799,7 +1802,10 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          config_load(&embed_cfg);
          snprintf(embed_cmd, sizeof(embed_cmd), "%s", config_embedding_command(&embed_cfg, NULL));
       }
-      if (pgvec_kb_service_ensure_kb_collection(384) != 0)
+      int kb_embed_dim = db2_embedding_dim();
+      if (kb_embed_dim <= 0 || kb_embed_dim > EMBED_MAX_DIM)
+         kb_embed_dim = 1024;
+      if (pgvec_kb_service_ensure_kb_collection(kb_embed_dim) != 0)
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"vector store unavailable\"}");
          return 503;

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -19,11 +19,22 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #define CCU_ERRBUF     256
 #define CCU_OUTBUF     (256 * 1024)
 #define CCU_BODY_LINES 100
+
+/* Hard wall-clock cap for the extraction sidecar (which runs the model —
+ * "seconds to minutes" on a CPU model). An unbounded popen/pclose wedges the
+ * drain thread forever when the sidecar hangs. */
+#define CCU_SIDECAR_TIMEOUT_S 300
+/* A job left in 'running' longer than this lease was orphaned (worker crash/
+ * restart or a wedged call) — comfortably above the sidecar cap above. */
+#define CCU_STALE_LEASE       "-15 minutes"
+/* Reclaim runs at most this often (throttled; the drain calls the entry per job). */
+#define CCU_RECLAIM_EVERY_S   60
 
 typedef struct
 {
@@ -123,6 +134,48 @@ static void ccu_mark_retry_or_fail(int64_t job_id, int attempts, int max_attempt
    snprintf(errbuf, sizeof(errbuf), "%s", error_msg ? error_msg : "unknown error");
    aimee_pg_bind_text(st, "?2", errbuf);
    aimee_pg_bind_int64(st, "?3", job_id);
+   (void)aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+}
+
+/* Reclaim code-unit jobs orphaned in 'running'. The claim only ever selects
+ * status='pending', so a job whose worker crashed/restarted or whose sidecar
+ * wedged stays 'running' forever — lost work, and (until the fix above) a
+ * permanently shrunk drain. Reset rows older than the lease back to 'pending'
+ * so they retry, or to 'failed' once attempts are exhausted so a poison job
+ * cannot loop. attempts is preserved (it was incremented at claim time).
+ * Throttled to at most once per CCU_RECLAIM_EVERY_S since the drain calls the
+ * entry point once per job. */
+static void ccu_reclaim_stale_running(int max_attempts)
+{
+   static time_t last_run = 0;
+   time_t now = time(NULL);
+   if (last_run != 0 && now - last_run < CCU_RECLAIM_EVERY_S)
+      return;
+   last_run = now;
+
+   if (max_attempts < 1)
+      max_attempts = 1;
+
+   void *conn = db2_conn();
+   if (!conn)
+      return;
+   char err[CCU_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn,
+       "UPDATE kb_code_unit_jobs"
+       " SET status = CASE WHEN attempts >= ?1 THEN 'failed' ELSE 'pending' END,"
+       "     claimed_by = '', claimed_at = '',"
+       "     last_error = CASE WHEN attempts >= ?1"
+       "                       THEN 'stale running lease reclaimed after max attempts'"
+       "                       ELSE last_error END,"
+       "     updated_at = pg_now_text()"
+       " WHERE status = 'running' AND claimed_at <> '' AND claimed_at < pg_now_text(?2)",
+       err, sizeof(err));
+   if (!st)
+      return;
+   aimee_pg_bind_int(st, "?1", max_attempts);
+   aimee_pg_bind_text(st, "?2", CCU_STALE_LEASE);
    (void)aimee_pg_step(st, err, sizeof(err));
    aimee_pg_finalize(st);
 }
@@ -316,7 +369,16 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
    close(fd);
 
    char full_cmd[1024];
-   snprintf(full_cmd, sizeof(full_cmd), "%s < %s", cmd, tmppath);
+   /* Bound the sidecar with coreutils `timeout` (present on the kb image):
+    * SIGTERM at the ceiling, SIGKILL 10s later if it ignores TERM. Without this
+    * a hung sidecar wedges the drain thread forever via pclose(); on timeout
+    * pclose() returns non-zero and the caller retries/fails the job instead.
+    * Run the configured command under `sh -c` INSIDE timeout so it keeps the
+    * shell semantics popen() gave it (env-var prefixes like `FOO=bar python …`,
+    * builtins, operators) — passing it as timeout's own argv would break those
+    * and let compound commands escape the bound. `cmd` is trusted config. */
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c \"%s\" < %s",
+            CCU_SIDECAR_TIMEOUT_S, cmd, tmppath);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)
@@ -511,6 +573,10 @@ int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts)
 {
    ccu_job_t job;
    memset(&job, 0, sizeof(job));
+
+   /* Recover jobs orphaned in 'running' before claiming fresh work, so a crash/
+    * restart or a previously-wedged sidecar cannot permanently strand them. */
+   ccu_reclaim_stale_running(opts ? opts->max_attempts : 1);
 
    if (!ccu_claim_job(&job))
       return 0; /* queue empty */

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -32,9 +32,9 @@
 #define CCU_SIDECAR_TIMEOUT_S 300
 /* A job left in 'running' longer than this lease was orphaned (worker crash/
  * restart or a wedged call) — comfortably above the sidecar cap above. */
-#define CCU_STALE_LEASE       "-15 minutes"
+#define CCU_STALE_LEASE "-15 minutes"
 /* Reclaim runs at most this often (throttled; the drain calls the entry per job). */
-#define CCU_RECLAIM_EVERY_S   60
+#define CCU_RECLAIM_EVERY_S 60
 
 typedef struct
 {
@@ -377,8 +377,8 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
     * shell semantics popen() gave it (env-var prefixes like `FOO=bar python …`,
     * builtins, operators) — passing it as timeout's own argv would break those
     * and let compound commands escape the bound. `cmd` is trusted config. */
-   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c \"%s\" < %s",
-            CCU_SIDECAR_TIMEOUT_S, cmd, tmppath);
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c \"%s\" < %s", CCU_SIDECAR_TIMEOUT_S,
+            cmd, tmppath);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)

--- a/src/kb/kb_curator_link_artifacts.c
+++ b/src/kb/kb_curator_link_artifacts.c
@@ -35,8 +35,12 @@
  * semantic passes share this set so an entity is linked at most once). */
 #define LINK_MAX_LINKED 128
 
-/* Dimension of the curator entity embedding space (matches resolve_entities). */
-#define CURATOR_LINK_ENTITY_DIM 384
+/* Buffer for the curator entity embedding, sized to the max embedder output so
+ * the concept embedding keeps the embedder's native dimension (matches
+ * resolve_entities, which uses EMBED_MAX_DIM). A hardcoded 384 truncated the
+ * concept vector and made it undimensionable against the runtime-dim entity
+ * vectors it NN-searches, breaking semantic entity linking. */
+#define CURATOR_LINK_ENTITY_DIM EMBED_MAX_DIM
 
 /* Top-K nearest entity vectors fetched per concept for semantic linking. */
 #define CURATOR_LINK_SEMANTIC_TOPK 5
@@ -134,8 +138,11 @@ static int link_concept_semantic(const char *code_id, const char *concept, const
    /* Entities with no context were embedded from their bare name, so embedding
     * the concept string directly keeps both sides in the same space. */
    float vec[CURATOR_LINK_ENTITY_DIM];
+   /* Keep the embedder's native dimension (matches resolve_entities: accept
+    * whatever the model emits, then NN-search the runtime-dim entity vectors
+    * with that same dim). */
    int dim = memory_embed_text(concept, embed_cmd, vec, CURATOR_LINK_ENTITY_DIM);
-   if (dim != CURATOR_LINK_ENTITY_DIM)
+   if (dim <= 0)
       return 0;
 
    int64_t ids[CURATOR_LINK_SEMANTIC_TOPK];

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -214,7 +214,14 @@ static int kb_handle_memory_repair(int fd, cJSON *req)
 
    if (!db2_is_initialized())
       return kb_send_error(fd, "failed to open knowledge service store");
-   if (pgvec_kb_service_ensure_memory_collection(384) != 0)
+   /* Size the memory retrieval index at the deployment's embedding dimension —
+    * the same runtime dim the halfvec memory_embeddings column was created at
+    * (db2_set_embedding_dim at startup: 2560 GPU / 1024 CPU / external cap 4000).
+    * A hardcoded 384 never matched the halfvec column, so the index was wrong. */
+   int mem_embed_dim = db2_embedding_dim();
+   if (mem_embed_dim <= 0 || mem_embed_dim > EMBED_MAX_DIM)
+      mem_embed_dim = 1024;
+   if (pgvec_kb_service_ensure_memory_collection(mem_embed_dim) != 0)
    {
       return kb_send_error(fd, "failed to initialize the memory retrieval index");
    }

--- a/src/memory_core_crud.c
+++ b/src/memory_core_crud.c
@@ -15,6 +15,7 @@
 #include "db1_optional.h"
 #include "db2/entity_edges.h"
 #include "db2/kb_runtime_state.h"
+#include "db2/lifecycle.h" /* db2_embedding_dim — runtime embedding dimension */
 #include "db2/memory_health.h"
 #include "db2/memory_payload.h"
 #include "db2/feature_rows.h"
@@ -598,7 +599,14 @@ int memory_rebuild_vector_index_for_version(const char *version, int *failed_out
    struct timespec t_start;
    clock_gettime(CLOCK_MONOTONIC, &t_start);
 
-   if (pgvec_memory_vector_collection_recreate(384) != 0)
+   /* Recreate the memory vector collection at the deployment's embedding
+    * dimension (the runtime dim the halfvec memory_embeddings column uses:
+    * 2560 GPU / 1024 CPU / external cap 4000), not a hardcoded 384 that would
+    * never match the column and leave every upsert failing. */
+   int mem_embed_dim = db2_embedding_dim();
+   if (mem_embed_dim <= 0 || mem_embed_dim > EMBED_MAX_DIM)
+      mem_embed_dim = 1024;
+   if (pgvec_memory_vector_collection_recreate(mem_embed_dim) != 0)
    {
       db2_kb_runtime_state_vector_rebuild_lock_release();
       return -1;

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -759,7 +759,10 @@ int db2_is_initialized(void)
 
 int pgvec_kb_service_ensure_kb_collection(int dim)
 {
-   assert(dim == 384);
+   /* The route now sizes the collection at the deployment's runtime embedding
+    * dim (db2_embedding_dim(), i.e. g_test_embedding_dim here), not a hardcoded
+    * 384, so it matches the halfvec(__EMBED_DIM__) column. */
+   assert(dim == g_test_embedding_dim);
    return g_pgvec_ensure_rc;
 }
 


### PR DESCRIPTION
## Why

Two production-invalidating bugs on the aimee-kb curator, surfaced by the .254 deployment running the 7900 XTX at full tilt for days without converging.

### 1. Embedding dimension truncated to a hardcoded 384
Several KB vector paths hardcoded **384** dims while the deployment's embedder emits its own dimension (**2560** GPU / **~1024** CPU / external, cap `EMBED_MAX_DIM=4000`). Vectors were truncated or never matched the `halfvec(__EMBED_DIM__)` columns, degrading recall and breaking upserts. Production spammed:
```
WARN memory: embedding truncated: model emitted 2560 dims > EMBED_MAX_DIM 384; recall degraded
```

- `kb_service.c` / `kb_http.c` (×2) / `memory_core_crud.c`: size the memory & kb vector collections at `db2_embedding_dim()` (bounded `1..EMBED_MAX_DIM`, fallback 1024), matching the existing `kb_service_code_embed.c` pattern.
- `kb_curator_link_artifacts.c`: embed entity concepts into an `EMBED_MAX_DIM` buffer and accept the model's **native** dim (`dim <= 0` guard), matching `resolve_entities`. The old 384 buffer truncated the concept vector so it couldn't NN-match the runtime-dim entity vectors — semantic entity-linking was broken.

### 2. Curator drain leaked worker slots
Jobs claimed into `status='running'` were never reclaimed when a worker crashed/restarted or the extraction sidecar wedged (the claim only ever selects `pending`). They were stranded forever and effective concurrency shrank — observed throughput fell ~3× (Jul 8: 21,970/day → Jul 9: 6,788/day) as slots leaked; 8 jobs sat `running` for 1.5–3.8 days.

- `kb_curator_extract_code.c`: throttled stale-`running` reclaim — requeue to `pending`, or `failed` once `attempts` are exhausted; `attempts` preserved.
- Bound the extraction sidecar with `timeout -k 10 300 sh -c "<cmd>"` (GNU `timeout` verified present on the kb image) so a hung sidecar cannot wedge the drain thread; on timeout the existing retry/fail path handles the job. `sh -c` preserves the shell semantics `popen` gave the configured command.

## Review
Roundtable-reviewed (correctness + security). Both reviewers passed the SQL/attempts logic, dim changes, guard change, reclaim throttle, and injection safety; the one finding (the `timeout` wrapper initially broke shell semantics) is fixed via the `sh -c` form above.

## Verification
- Compile-clean (`cmake --build build --target aimee`).
- Follows in-tree patterns verbatim.
- **Validation-pending end-to-end**: the "stores 2560 / no truncation" and reclaim behaviors get exercised on the .254 redeploy + re-embed (needs the live KB + embedder + Postgres loop).

## Follow-up (not in this PR)
`evidence_vectors` is a separate, deliberate `vector(384)` space; moving it to the runtime dim needs a schema migration + a product call.