### PR TITLE
refactor(aimee-llm): decouple roles + per-role tiers (fetch/serve only what's needed)

### DIFF
--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -7,16 +7,20 @@ on:
   pull_request:
     paths:
       - 'scripts/aimee_llm_*.py'
+      - 'scripts/aimee-llm-supervisor.sh'
       - 'scripts/tests/test_rerank_head.py'
       - 'scripts/tests/test_gateway.py'
       - 'scripts/tests/test_gateway_security.py'
+      - 'scripts/tests/test_supervisor_roles.py'
       - '.github/workflows/gateway-tests.yml'
   push:
     branches: [testing, main]
     paths:
       - 'scripts/aimee_llm_*.py'
+      - 'scripts/aimee-llm-supervisor.sh'
       - 'scripts/tests/test_rerank_head.py'
       - 'scripts/tests/test_gateway.py'
+      - 'scripts/tests/test_supervisor_roles.py'
 
 jobs:
   gateway-unit:
@@ -33,3 +37,5 @@ jobs:
           python -m unittest discover -s scripts/tests -p 'test_rerank_head.py' -v
           python -m unittest discover -s scripts/tests -p 'test_gateway.py' -v
           python -m unittest discover -s scripts/tests -p 'test_gateway_security.py' -v
+      - name: Supervisor role-decouple test (stdlib only)
+        run: python -m unittest discover -s scripts/tests -p 'test_supervisor_roles.py' -v

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -55,6 +55,12 @@ VOLUME /models
 
 # Gateway + per-role serving wiring (the supervisor reads these; per-tier model
 # identity — embedder id, pooling, rerank head dir — is exported by the supervisor).
+# Per-role backend is chosen at runtime (NOT baked, so they stay unset by default
+# and the supervisor can honor the legacy AIMEE_LLM_SYNTH_LOCAL=0 knob):
+#   AIMEE_LLM_EMBED_MODE  / AIMEE_LLM_RERANK_MODE / AIMEE_LLM_SYNTH_MODE = local|external|off
+# `local` (default) bakes+serves the tier's model; `external` forwards to the
+# operator-set AIMEE_LLM_<ROLE>_URL; `off` gates the role. A non-local role is
+# neither downloaded nor launched — only what is served locally is fetched.
 ENV AIMEE_LLM_PORT=8080 \
     AIMEE_LLM_EMBED_URL=http://127.0.0.1:8081 \
     AIMEE_LLM_RERANK_URL=http://127.0.0.1:8082 \

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -18,7 +18,9 @@
 # release (published by .github/workflows/publish-rerank-artifacts.yml) — the ST
 # score head doesn't survive GGUF conversion, so the gateway applies it.
 set -u
-LLAMA=/opt/llama/llama-server
+# The llama.cpp server binary. Overridable so the role-decouple test can shim it
+# (and so a custom install can point elsewhere); defaults to the image path.
+LLAMA="${AIMEE_LLM_LLAMA_BIN:-/opt/llama/llama-server}"
 NGL="${AIMEE_LLM_NGL:-0}"
 MODELS_DIR="${AIMEE_LLM_MODELS_DIR:-/models}"
 # Base URL for the pre-converted ettin rerank artifacts (override for a mirror).
@@ -77,6 +79,32 @@ tier_config() {
 }
 tier_config
 
+# ---- per-role backend mode (local | external | off) -------------------------
+# Each LLM role is independently local (a baked llama-server), external (the
+# gateway forwards to an operator-provided OpenAI-compatible upstream), or off
+# (the role is gated). Default is `local` for every role => byte-for-byte the
+# prior all-local behavior. A role that is NOT local is neither downloaded nor
+# launched: the plugin fetches and serves ONLY the roles it hosts. When every
+# role is external/off the supervisor pulls nothing and starts no llama-server —
+# the gateway is a pure forwarder (the deploy layer normally skips deploying the
+# plugin at all in that case).
+EMBED_MODE="${AIMEE_LLM_EMBED_MODE:-local}"
+RERANK_MODE="${AIMEE_LLM_RERANK_MODE:-local}"
+SYNTH_MODE="${AIMEE_LLM_SYNTH_MODE:-local}"
+# Back-compat: the older AIMEE_LLM_SYNTH_LOCAL=0 knob means "external synth".
+if [ "${AIMEE_LLM_SYNTH_LOCAL:-1}" = "0" ] && [ -z "${AIMEE_LLM_SYNTH_MODE:-}" ]; then
+  SYNTH_MODE="external"
+fi
+validate_mode() { # env-name value
+  case "$2" in
+    local|external|off) ;;
+    *) echo "aimee-llm: invalid $1='$2' (valid: local, external, off)" >&2; exit 1;;
+  esac
+}
+validate_mode AIMEE_LLM_EMBED_MODE "$EMBED_MODE"
+validate_mode AIMEE_LLM_RERANK_MODE "$RERANK_MODE"
+validate_mode AIMEE_LLM_SYNTH_MODE "$SYNTH_MODE"
+
 # Per-tier model cache (persist /models to a volume so restarts don't re-fetch).
 D="$MODELS_DIR/$TIER"
 
@@ -93,7 +121,7 @@ SLOTS="${AIMEE_LLM_SYNTH_SLOTS:-$TIER_SLOTS}"
 # last-token pooling — the gateway reads these for /health + the drift guard).
 export AIMEE_LLM_EMBED_MODEL="${AIMEE_LLM_EMBED_MODEL:-qwen3-embedding}"
 export AIMEE_LLM_EMBED_POOLING="${AIMEE_LLM_EMBED_POOLING:-last}"
-export AIMEE_LLM_RERANK_HEAD="$D/rerank-head"
+# AIMEE_LLM_RERANK_HEAD is set per-mode in resolve_upstreams (local rerank only).
 POOL="$AIMEE_LLM_EMBED_POOLING"
 
 pids=()
@@ -113,44 +141,87 @@ fetch() {
     || { echo "aimee-llm: download FAILED: $url" >&2; return 1; }
 }
 
-# download_models — populate $D for the resolved tier ONCE (guarded by $D/.ready).
-# Embed+synth pull straight from HF; the rerank encoder+head come from the GH
-# release, and everything sha256-verified where a checksum is known.
+# download_models — populate $D with ONLY the roles served locally, each guarded
+# by its own $D/.<role>.ready marker so switching one role to external/off never
+# re-pulls the others. Embed+synth pull straight from HF; the rerank encoder+head
+# come from the GH release, everything sha256-verified where a checksum is known.
 download_models() {
-  if [ -f "$D/.ready" ]; then
-    echo "aimee-llm: tier '$TIER' models present in $D (skip download)" >&2
-    return 0
-  fi
-  echo "aimee-llm: fetching tier '$TIER' models into $D" >&2
   mkdir -p "$D/rerank-head" || return 1
 
-  # Embedder GGUF (repo default branch).
-  fetch "https://huggingface.co/${EMBED_REPO}/resolve/main/${EMBED_FILE}" "$D/embed.gguf" || return 1
+  # Migrate the legacy single all-roles marker: a volume provisioned before the
+  # per-role split has $D/.ready (all three fetched). Honor it so an upgrade does
+  # not needlessly re-download multi-GB GGUFs.
+  if [ -f "$D/.ready" ]; then
+    touch "$D/.embed.ready" "$D/.synth.ready" "$D/.rerank.ready"
+  fi
+
+  # Embedder GGUF (repo default branch) — local embed only.
+  if [ "$EMBED_MODE" = "local" ] && [ ! -f "$D/.embed.ready" ]; then
+    echo "aimee-llm: fetching tier '$TIER' embed model into $D" >&2
+    fetch "https://huggingface.co/${EMBED_REPO}/resolve/main/${EMBED_FILE}" "$D/embed.gguf" || return 1
+    touch "$D/.embed.ready"
+  fi
 
   # Synth GGUF, pinned to the tier's HF revision; sha256-verified when known so a
-  # compromised/MITM'd upload can't ship.
-  fetch "https://huggingface.co/${SYNTH_REPO}/resolve/${SYNTH_REVISION}/${SYNTH_FILE}" "$D/synth.gguf" || return 1
-  if [ -n "$SYNTH_SHA256" ]; then
-    echo "${SYNTH_SHA256}  $D/synth.gguf" | sha256sum -c - >&2 || {
-      echo "aimee-llm: synth.gguf sha256 MISMATCH — refusing to serve" >&2; return 1; }
+  # compromised/MITM'd upload can't ship — local synth only.
+  if [ "$SYNTH_MODE" = "local" ] && [ ! -f "$D/.synth.ready" ]; then
+    echo "aimee-llm: fetching tier '$TIER' synth model into $D" >&2
+    fetch "https://huggingface.co/${SYNTH_REPO}/resolve/${SYNTH_REVISION}/${SYNTH_FILE}" "$D/synth.gguf" || return 1
+    if [ -n "$SYNTH_SHA256" ]; then
+      echo "${SYNTH_SHA256}  $D/synth.gguf" | sha256sum -c - >&2 || {
+        echo "aimee-llm: synth.gguf sha256 MISMATCH — refusing to serve" >&2; return 1; }
+    fi
+    touch "$D/.synth.ready"
   fi
 
   # Pre-converted ettin rerank artifacts (encoder GGUF + Dense head npz) from the
-  # GH release, verified against its SHA256SUMS.
-  local rr="rerank-ettin-${RERANK_SIZE}"
-  fetch "${RERANK_ASSET_BASE}/${rr}.gguf"     "$D/rerank-encoder.gguf"   || return 1
-  fetch "${RERANK_ASSET_BASE}/${rr}.head.npz" "$D/rerank-head/head.npz"  || return 1
-  if fetch "${RERANK_ASSET_BASE}/SHA256SUMS" "$D/SHA256SUMS"; then
-    ( cd "$D" \
-      && grep -E "  ${rr}\.gguf\$" SHA256SUMS | sed "s#${rr}\.gguf#rerank-encoder.gguf#" | sha256sum -c - \
-      && grep -E "  ${rr}\.head\.npz\$" SHA256SUMS | sed "s#${rr}\.head\.npz#rerank-head/head.npz#" | sha256sum -c - ) >&2 || {
-      echo "aimee-llm: rerank artifact sha256 MISMATCH — refusing to serve" >&2; return 1; }
-  else
-    echo "aimee-llm: WARNING — no SHA256SUMS for rerank artifacts (unverified)" >&2
+  # GH release, verified against its SHA256SUMS — local rerank only.
+  if [ "$RERANK_MODE" = "local" ] && [ ! -f "$D/.rerank.ready" ]; then
+    echo "aimee-llm: fetching tier '$TIER' rerank artifacts into $D" >&2
+    local rr="rerank-ettin-${RERANK_SIZE}"
+    fetch "${RERANK_ASSET_BASE}/${rr}.gguf"     "$D/rerank-encoder.gguf"   || return 1
+    fetch "${RERANK_ASSET_BASE}/${rr}.head.npz" "$D/rerank-head/head.npz"  || return 1
+    if fetch "${RERANK_ASSET_BASE}/SHA256SUMS" "$D/SHA256SUMS"; then
+      ( cd "$D" \
+        && grep -E "  ${rr}\.gguf\$" SHA256SUMS | sed "s#${rr}\.gguf#rerank-encoder.gguf#" | sha256sum -c - \
+        && grep -E "  ${rr}\.head\.npz\$" SHA256SUMS | sed "s#${rr}\.head\.npz#rerank-head/head.npz#" | sha256sum -c - ) >&2 || {
+        echo "aimee-llm: rerank artifact sha256 MISMATCH — refusing to serve" >&2; return 1; }
+    else
+      echo "aimee-llm: WARNING — no SHA256SUMS for rerank artifacts (unverified)" >&2
+    fi
+    touch "$D/.rerank.ready"
   fi
 
-  touch "$D/.ready"
-  echo "aimee-llm: tier '$TIER' models ready in $D" >&2
+  echo "aimee-llm: model provisioning done (embed=$EMBED_MODE rerank=$RERANK_MODE synth=$SYNTH_MODE)" >&2
+}
+
+# resolve_upstreams — point the gateway's per-role upstream at the right place for
+# each mode: local => the baked llama-server; external => the operator's upstream
+# (must be set to a non-local base); off => empty so the gateway gates the role.
+# The rerank Dense head is applied locally by the gateway, so only a LOCAL rerank
+# encoder carries a head dir; external/off rerank clears it (gated).
+resolve_upstreams() {
+  resolve_one EMBED  "$EMBED_MODE"  "http://127.0.0.1:8081"
+  resolve_one RERANK "$RERANK_MODE" "http://127.0.0.1:8082"
+  resolve_one SYNTH  "$SYNTH_MODE"  "http://127.0.0.1:8083"
+  if [ "$RERANK_MODE" = "local" ]; then
+    export AIMEE_LLM_RERANK_HEAD="$D/rerank-head"
+  else
+    export AIMEE_LLM_RERANK_HEAD=""
+  fi
+}
+resolve_one() { # ROLE MODE localurl
+  local role="$1" mode="$2" localurl="$3" var="AIMEE_LLM_${1}_URL" cur
+  eval "cur=\${$var:-}"
+  case "$mode" in
+    local) export "$var=$localurl" ;;
+    external)
+      if [ -z "$cur" ] || [ "$cur" = "$localurl" ]; then
+        echo "aimee-llm: ${role} mode=external requires $var set to the external upstream base" >&2
+        exit 1
+      fi ;;
+    off) export "$var=" ;;
+  esac
 }
 
 # STUB mode (CI/dev): no GGUFs, no downloads, no llama-servers — the gateway serves
@@ -160,15 +231,18 @@ case "${AIMEE_LLM_STUB:-}" in
   ""|0|false)
     download_models || { echo "aimee-llm: model provisioning failed; shutting down" >&2; exit 1; }
     # Embedder: one vector per input, no prompt-cache fragmentation (P2 flags).
-    start embed 8081 -m "$D/embed.gguf" --embeddings --pooling "$POOL" \
-      --ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots
+    if [ "$EMBED_MODE" = "local" ]; then
+      start embed 8081 -m "$D/embed.gguf" --embeddings --pooling "$POOL" \
+        --ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots
+    fi
     # Reranker ENCODER: CLS pooling + flash-attn; the gateway applies the Dense head.
-    start rerank 8082 -m "$D/rerank-encoder.gguf" --embeddings --pooling cls -fa on
+    if [ "$RERANK_MODE" = "local" ]; then
+      start rerank 8082 -m "$D/rerank-encoder.gguf" --embeddings --pooling cls -fa on
+    fi
     # Synth: OpenAI-compatible /v1/chat/completions (grammar/JSON via --jinja). The
     # synth MODEL + its runtime profile come from the TIER table above; explicit
-    # AIMEE_LLM_SYNTH_* envs still override per deploy. AIMEE_LLM_SYNTH_LOCAL=0 lets
-    # an operator disable the local synth and forward via AIMEE_LLM_SYNTH_URL instead.
-    if [ "${AIMEE_LLM_SYNTH_LOCAL:-1}" != "0" ] && [ -f "$D/synth.gguf" ]; then
+    # AIMEE_LLM_SYNTH_* envs still override per deploy.
+    if [ "$SYNTH_MODE" = "local" ] && [ -f "$D/synth.gguf" ]; then
       synth_args=(-m "$D/synth.gguf" --ctx-size "$SYNTH_CTX" --jinja --parallel "$SLOTS")
       # Flash-attention + quantized KV (K8V4 by default). NOTE: quantized V-cache
       # REQUIRES fa (llama.cpp refuses otherwise), so a healthy start proves fa on.
@@ -190,6 +264,10 @@ case "${AIMEE_LLM_STUB:-}" in
     echo "aimee-llm: STUB mode — skipping model fetch + llama-servers; gateway serves deterministic responses" >&2
     ;;
 esac
+
+# Point the gateway at each role's resolved upstream (local server / external base
+# / gated) now that the local servers, if any, are launching.
+resolve_upstreams
 
 # Gateway (foreground-ish; backgrounded so we can reap any child exit).
 echo "aimee-llm: starting gateway on :${AIMEE_LLM_PORT:-8080}" >&2

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
-# aimee-llm container supervisor: resolve the TIER, download its models on first
-# boot (the image ships model-less), then launch the per-role llama.cpp servers
-# (embed, rerank-encoder, synth) and the gateway. Each role is its own
-# llama-server process so a crash is isolated to that role; if any exits the
-# supervisor tears the container down (the orchestrator restarts it). A full
-# s6-overlay (per-role restart) is the follow-up; this is the MVP supervisor.
+# aimee-llm container supervisor: resolve each role's tier + backend mode, download
+# only what it serves locally on first boot (the image ships model-less), then
+# launch the per-role llama.cpp servers (embed, rerank-encoder, synth) and the
+# gateway. Each role is its own llama-server process so a crash is isolated to that
+# role; if any exits the supervisor tears the container down (the orchestrator
+# restarts it). A full s6-overlay (per-role restart) is the follow-up.
 #
-# TIER SELECTION (runtime, not baked): AIMEE_LLM_TIER picks WHICH models to fetch
-# and how to serve the synth. NGL (GPU offload) is a SEPARATE per-deploy knob.
-#   (unset)/cpu  0.6B emb + ettin-68m  + gemma-4-E4B      (dense, CPU)
-#   small        4B emb   + ettin-400m + gemma-4-12B      (dense, GPU, FA+K8V4)
-#   mid          4B emb   + ettin-400m + gemma-4-26B-A4B  (MoE, GPU, FA+K8V4; SLOTS=2)
-#   large        SAME 26B-A4B as mid but SLOTS=4 (32GB card → deploy 4×256K)
-# The tier table below is the SINGLE source of truth (was Dockerfile ARGs + the
+# ROLE BACKEND (runtime, not baked): each role is independently
+#   AIMEE_LLM_<ROLE>_MODE = local | external | off   (default local)
+# and, when local, sized by
+#   AIMEE_LLM_<ROLE>_TIER = cpu | small | mid | large (falls back to AIMEE_LLM_TIER,
+#                                                      then cpu)
+# so ONE instance can serve, e.g., a cpu embedder beside a gpu-large synth. NGL is
+# forced 0 for a cpu-tier role and uses the deploy's AIMEE_LLM_NGL for a gpu one.
+# Per-role tier -> model coordinates (embed/rerank collapse small/mid/large -> gpu;
+# synth honors the full ladder):
+#   cpu    0.6B emb + ettin-68m  + gemma-4-E4B      (dense, CPU)
+#   small  4B emb   + ettin-400m + gemma-4-12B      (dense, GPU, FA+K8V4)
+#   mid    4B emb   + ettin-400m + gemma-4-26B-A4B  (MoE, GPU, FA+K8V4; SLOTS=2)
+#   large  SAME 26B-A4B as mid but SLOTS=4 (32GB card → deploy 4×256K)
+# The resolvers below are the SINGLE source of truth (was Dockerfile ARGs + the
 # CI build matrix). Embed+synth are plain GGUF pulls from HF; the ettin reranker
 # is a pre-converted encoder GGUF + Dense head (head.npz) fetched from a GitHub
 # release (published by .github/workflows/publish-rerank-artifacts.yml) — the ST
@@ -33,51 +40,68 @@ RERANK_ASSET_BASE="${AIMEE_LLM_RERANK_ASSET_BASE:-https://github.com/RakuenSoftw
 # size it to the card. Embed/rerank inputs are small — they keep the 8K default.
 SYNTH_CTX="${AIMEE_LLM_SYNTH_CTX:-32768}"
 
-# ---- tier table (single source of truth) ------------------------------------
-# Resolve AIMEE_LLM_TIER into the per-role model coordinates + the synth runtime
-# profile. Empty tier ≡ cpu. Unknown tier fails fast.
-TIER="${AIMEE_LLM_TIER:-cpu}"
-tier_config() {
-  case "$TIER" in
+# ---- per-role tier -> model coordinates -------------------------------------
+# Each role's tier is chosen independently via AIMEE_LLM_<ROLE>_TIER, falling back
+# to the instance-wide AIMEE_LLM_TIER, then cpu. ONE aimee-llm instance serves all
+# of its local roles, each at its OWN tier — e.g. a cpu embedder beside a gpu-large
+# synth on the same box. Embed/rerank have only cpu-vs-gpu variants (small/mid/large
+# all resolve to the gpu model); synth honors the full size ladder. GPU offload is
+# forced off for a cpu-tier role and uses $NGL for a gpu-tier one. Each role caches
+# its GGUFs under $MODELS_DIR/<its-tier>, so roles sharing a tier share a dir (and a
+# legacy all-in-one $MODELS_DIR/<tier> volume keeps working). Unknown tier fails fast.
+EMBED_TIER="${AIMEE_LLM_EMBED_TIER:-${AIMEE_LLM_TIER:-cpu}}"
+RERANK_TIER="${AIMEE_LLM_RERANK_TIER:-${AIMEE_LLM_TIER:-cpu}}"
+SYNTH_TIER="${AIMEE_LLM_SYNTH_TIER:-${AIMEE_LLM_TIER:-cpu}}"
+
+embed_coords() {
+  case "$EMBED_TIER" in
+    cpu)             EMBED_REPO="Qwen/Qwen3-Embedding-0.6B-GGUF"; EMBED_FILE="Qwen3-Embedding-0.6B-f16.gguf"; EMBED_NGL=0 ;;
+    small|mid|large) EMBED_REPO="Qwen/Qwen3-Embedding-4B-GGUF";   EMBED_FILE="Qwen3-Embedding-4B-Q8_0.gguf";  EMBED_NGL="$NGL" ;;
+    *) echo "aimee-llm: invalid AIMEE_LLM_EMBED_TIER='$EMBED_TIER' (cpu, small, mid, large)" >&2; exit 1 ;;
+  esac
+  EMBED_D="$MODELS_DIR/$EMBED_TIER"
+}
+rerank_coords() {
+  case "$RERANK_TIER" in
+    cpu)             RERANK_SIZE="68m";  RERANK_NGL=0 ;;
+    small|mid|large) RERANK_SIZE="400m"; RERANK_NGL="$NGL" ;;
+    *) echo "aimee-llm: invalid AIMEE_LLM_RERANK_TIER='$RERANK_TIER' (cpu, small, mid, large)" >&2; exit 1 ;;
+  esac
+  RERANK_D="$MODELS_DIR/$RERANK_TIER"
+}
+synth_coords() {
+  case "$SYNTH_TIER" in
     cpu)
-      EMBED_REPO="Qwen/Qwen3-Embedding-0.6B-GGUF"; EMBED_FILE="Qwen3-Embedding-0.6B-f16.gguf"
-      RERANK_SIZE="68m"
       SYNTH_REPO="ggml-org/gemma-4-E4B-it-GGUF"; SYNTH_FILE="gemma-4-E4B-it-Q4_K_M.gguf"
       SYNTH_REVISION="main"; SYNTH_SHA256=""
-      TIER_FA="off"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"
+      TIER_FA="off"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"; SYNTH_NGL=0
       ;;
     small)
-      EMBED_REPO="Qwen/Qwen3-Embedding-4B-GGUF"; EMBED_FILE="Qwen3-Embedding-4B-Q8_0.gguf"
-      RERANK_SIZE="400m"
       SYNTH_REPO="unsloth/gemma-4-12B-it-qat-GGUF"; SYNTH_FILE="gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"
       SYNTH_REVISION="9586f3257bc62bd179767241c7ec0f66bc2a314a"
       SYNTH_SHA256="cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165"
-      TIER_FA="on"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"
+      TIER_FA="on"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"; SYNTH_NGL="$NGL"
       ;;
     mid)
-      EMBED_REPO="Qwen/Qwen3-Embedding-4B-GGUF"; EMBED_FILE="Qwen3-Embedding-4B-Q8_0.gguf"
-      RERANK_SIZE="400m"
       SYNTH_REPO="unsloth/gemma-4-26B-A4B-it-qat-GGUF"; SYNTH_FILE="gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf"
       SYNTH_REVISION="02749a7b272109255a4c559a80894d3d9777574c"
       SYNTH_SHA256="dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e"
-      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="2"
+      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="2"; SYNTH_NGL="$NGL"
       ;;
     large)
       # Byte-identical to mid EXCEPT SLOTS=4 (24GB→32GB card headroom).
-      EMBED_REPO="Qwen/Qwen3-Embedding-4B-GGUF"; EMBED_FILE="Qwen3-Embedding-4B-Q8_0.gguf"
-      RERANK_SIZE="400m"
       SYNTH_REPO="unsloth/gemma-4-26B-A4B-it-qat-GGUF"; SYNTH_FILE="gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf"
       SYNTH_REVISION="02749a7b272109255a4c559a80894d3d9777574c"
       SYNTH_SHA256="dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e"
-      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="4"
+      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="4"; SYNTH_NGL="$NGL"
       ;;
-    *)
-      echo "aimee-llm: invalid AIMEE_LLM_TIER='$TIER' (valid: cpu, small, mid, large; empty ≡ cpu)" >&2
-      exit 1
-      ;;
+    *) echo "aimee-llm: invalid AIMEE_LLM_SYNTH_TIER='$SYNTH_TIER' (cpu, small, mid, large)" >&2; exit 1 ;;
   esac
+  SYNTH_D="$MODELS_DIR/$SYNTH_TIER"
 }
-tier_config
+embed_coords
+rerank_coords
+synth_coords
 
 # ---- per-role backend mode (local | external | off) -------------------------
 # Each LLM role is independently local (a baked llama-server), external (the
@@ -105,10 +129,7 @@ validate_mode AIMEE_LLM_EMBED_MODE "$EMBED_MODE"
 validate_mode AIMEE_LLM_RERANK_MODE "$RERANK_MODE"
 validate_mode AIMEE_LLM_SYNTH_MODE "$SYNTH_MODE"
 
-# Per-tier model cache (persist /models to a volume so restarts don't re-fetch).
-D="$MODELS_DIR/$TIER"
-
-# Deploy-time overrides win over the tier default (operators set CTX/SLOTS per card).
+# Deploy-time overrides win over the synth tier default (operators set CTX/SLOTS per card).
 FA="${AIMEE_LLM_SYNTH_FA:-$TIER_FA}"
 KV_K="${AIMEE_LLM_SYNTH_KV_K:-q8_0}"
 KV_V="${AIMEE_LLM_SYNTH_KV_V:-q4_0}"
@@ -126,10 +147,10 @@ POOL="$AIMEE_LLM_EMBED_POOLING"
 
 pids=()
 
-start() { # name port extra-args...
+start() { # name port extra-args...   (caller passes -ngl per role: cpu=0, gpu=$NGL)
   local name="$1" port="$2"; shift 2
-  echo "aimee-llm: starting $name on :$port (ngl=$NGL)" >&2
-  "$LLAMA" --host 127.0.0.1 --port "$port" -ngl "$NGL" "$@" >&2 &
+  echo "aimee-llm: starting $name on :$port" >&2
+  "$LLAMA" --host 127.0.0.1 --port "$port" "$@" >&2 &
   pids+=("$!")
 }
 
@@ -141,58 +162,60 @@ fetch() {
     || { echo "aimee-llm: download FAILED: $url" >&2; return 1; }
 }
 
-# download_models — populate $D with ONLY the roles served locally, each guarded
-# by its own $D/.<role>.ready marker so switching one role to external/off never
-# re-pulls the others. Embed+synth pull straight from HF; the rerank encoder+head
-# come from the GH release, everything sha256-verified where a checksum is known.
+# download_models — fetch ONLY the roles served locally, each into its own tier's
+# cache dir ($MODELS_DIR/<role-tier>) and guarded by its own .<role>.ready marker,
+# so switching one role's tier/mode never re-pulls the others. Embed+synth pull
+# straight from HF; the rerank encoder+head come from the GH release, everything
+# sha256-verified where a checksum is known.
 download_models() {
-  mkdir -p "$D/rerank-head" || return 1
-
   # Migrate the legacy single all-roles marker: a volume provisioned before the
-  # per-role split has $D/.ready (all three fetched). Honor it so an upgrade does
-  # not needlessly re-download multi-GB GGUFs.
-  if [ -f "$D/.ready" ]; then
-    touch "$D/.embed.ready" "$D/.synth.ready" "$D/.rerank.ready"
-  fi
+  # per-role split has <dir>/.ready (all three fetched together at that tier).
+  # Honor it per role so an upgrade does not needlessly re-download multi-GB GGUFs.
+  [ -f "$EMBED_D/.ready" ]  && touch "$EMBED_D/.embed.ready"
+  [ -f "$SYNTH_D/.ready" ]  && touch "$SYNTH_D/.synth.ready"
+  [ -f "$RERANK_D/.ready" ] && touch "$RERANK_D/.rerank.ready"
 
   # Embedder GGUF (repo default branch) — local embed only.
-  if [ "$EMBED_MODE" = "local" ] && [ ! -f "$D/.embed.ready" ]; then
-    echo "aimee-llm: fetching tier '$TIER' embed model into $D" >&2
-    fetch "https://huggingface.co/${EMBED_REPO}/resolve/main/${EMBED_FILE}" "$D/embed.gguf" || return 1
-    touch "$D/.embed.ready"
+  if [ "$EMBED_MODE" = "local" ] && [ ! -f "$EMBED_D/.embed.ready" ]; then
+    echo "aimee-llm: fetching embed tier '$EMBED_TIER' into $EMBED_D" >&2
+    mkdir -p "$EMBED_D" || return 1
+    fetch "https://huggingface.co/${EMBED_REPO}/resolve/main/${EMBED_FILE}" "$EMBED_D/embed.gguf" || return 1
+    touch "$EMBED_D/.embed.ready"
   fi
 
   # Synth GGUF, pinned to the tier's HF revision; sha256-verified when known so a
   # compromised/MITM'd upload can't ship — local synth only.
-  if [ "$SYNTH_MODE" = "local" ] && [ ! -f "$D/.synth.ready" ]; then
-    echo "aimee-llm: fetching tier '$TIER' synth model into $D" >&2
-    fetch "https://huggingface.co/${SYNTH_REPO}/resolve/${SYNTH_REVISION}/${SYNTH_FILE}" "$D/synth.gguf" || return 1
+  if [ "$SYNTH_MODE" = "local" ] && [ ! -f "$SYNTH_D/.synth.ready" ]; then
+    echo "aimee-llm: fetching synth tier '$SYNTH_TIER' into $SYNTH_D" >&2
+    mkdir -p "$SYNTH_D" || return 1
+    fetch "https://huggingface.co/${SYNTH_REPO}/resolve/${SYNTH_REVISION}/${SYNTH_FILE}" "$SYNTH_D/synth.gguf" || return 1
     if [ -n "$SYNTH_SHA256" ]; then
-      echo "${SYNTH_SHA256}  $D/synth.gguf" | sha256sum -c - >&2 || {
+      echo "${SYNTH_SHA256}  $SYNTH_D/synth.gguf" | sha256sum -c - >&2 || {
         echo "aimee-llm: synth.gguf sha256 MISMATCH — refusing to serve" >&2; return 1; }
     fi
-    touch "$D/.synth.ready"
+    touch "$SYNTH_D/.synth.ready"
   fi
 
   # Pre-converted ettin rerank artifacts (encoder GGUF + Dense head npz) from the
   # GH release, verified against its SHA256SUMS — local rerank only.
-  if [ "$RERANK_MODE" = "local" ] && [ ! -f "$D/.rerank.ready" ]; then
-    echo "aimee-llm: fetching tier '$TIER' rerank artifacts into $D" >&2
+  if [ "$RERANK_MODE" = "local" ] && [ ! -f "$RERANK_D/.rerank.ready" ]; then
+    echo "aimee-llm: fetching rerank tier '$RERANK_TIER' into $RERANK_D" >&2
+    mkdir -p "$RERANK_D/rerank-head" || return 1
     local rr="rerank-ettin-${RERANK_SIZE}"
-    fetch "${RERANK_ASSET_BASE}/${rr}.gguf"     "$D/rerank-encoder.gguf"   || return 1
-    fetch "${RERANK_ASSET_BASE}/${rr}.head.npz" "$D/rerank-head/head.npz"  || return 1
-    if fetch "${RERANK_ASSET_BASE}/SHA256SUMS" "$D/SHA256SUMS"; then
-      ( cd "$D" \
+    fetch "${RERANK_ASSET_BASE}/${rr}.gguf"     "$RERANK_D/rerank-encoder.gguf"   || return 1
+    fetch "${RERANK_ASSET_BASE}/${rr}.head.npz" "$RERANK_D/rerank-head/head.npz"  || return 1
+    if fetch "${RERANK_ASSET_BASE}/SHA256SUMS" "$RERANK_D/SHA256SUMS"; then
+      ( cd "$RERANK_D" \
         && grep -E "  ${rr}\.gguf\$" SHA256SUMS | sed "s#${rr}\.gguf#rerank-encoder.gguf#" | sha256sum -c - \
         && grep -E "  ${rr}\.head\.npz\$" SHA256SUMS | sed "s#${rr}\.head\.npz#rerank-head/head.npz#" | sha256sum -c - ) >&2 || {
         echo "aimee-llm: rerank artifact sha256 MISMATCH — refusing to serve" >&2; return 1; }
     else
       echo "aimee-llm: WARNING — no SHA256SUMS for rerank artifacts (unverified)" >&2
     fi
-    touch "$D/.rerank.ready"
+    touch "$RERANK_D/.rerank.ready"
   fi
 
-  echo "aimee-llm: model provisioning done (embed=$EMBED_MODE rerank=$RERANK_MODE synth=$SYNTH_MODE)" >&2
+  echo "aimee-llm: model provisioning done (embed=$EMBED_MODE/$EMBED_TIER rerank=$RERANK_MODE/$RERANK_TIER synth=$SYNTH_MODE/$SYNTH_TIER)" >&2
 }
 
 # resolve_upstreams — point the gateway's per-role upstream at the right place for
@@ -205,7 +228,7 @@ resolve_upstreams() {
   resolve_one RERANK "$RERANK_MODE" "http://127.0.0.1:8082"
   resolve_one SYNTH  "$SYNTH_MODE"  "http://127.0.0.1:8083"
   if [ "$RERANK_MODE" = "local" ]; then
-    export AIMEE_LLM_RERANK_HEAD="$D/rerank-head"
+    export AIMEE_LLM_RERANK_HEAD="$RERANK_D/rerank-head"
   else
     export AIMEE_LLM_RERANK_HEAD=""
   fi
@@ -232,18 +255,18 @@ case "${AIMEE_LLM_STUB:-}" in
     download_models || { echo "aimee-llm: model provisioning failed; shutting down" >&2; exit 1; }
     # Embedder: one vector per input, no prompt-cache fragmentation (P2 flags).
     if [ "$EMBED_MODE" = "local" ]; then
-      start embed 8081 -m "$D/embed.gguf" --embeddings --pooling "$POOL" \
+      start embed 8081 -ngl "$EMBED_NGL" -m "$EMBED_D/embed.gguf" --embeddings --pooling "$POOL" \
         --ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots
     fi
     # Reranker ENCODER: CLS pooling + flash-attn; the gateway applies the Dense head.
     if [ "$RERANK_MODE" = "local" ]; then
-      start rerank 8082 -m "$D/rerank-encoder.gguf" --embeddings --pooling cls -fa on
+      start rerank 8082 -ngl "$RERANK_NGL" -m "$RERANK_D/rerank-encoder.gguf" --embeddings --pooling cls -fa on
     fi
     # Synth: OpenAI-compatible /v1/chat/completions (grammar/JSON via --jinja). The
-    # synth MODEL + its runtime profile come from the TIER table above; explicit
+    # synth MODEL + its runtime profile come from the synth tier above; explicit
     # AIMEE_LLM_SYNTH_* envs still override per deploy.
-    if [ "$SYNTH_MODE" = "local" ] && [ -f "$D/synth.gguf" ]; then
-      synth_args=(-m "$D/synth.gguf" --ctx-size "$SYNTH_CTX" --jinja --parallel "$SLOTS")
+    if [ "$SYNTH_MODE" = "local" ] && [ -f "$SYNTH_D/synth.gguf" ]; then
+      synth_args=(-ngl "$SYNTH_NGL" -m "$SYNTH_D/synth.gguf" --ctx-size "$SYNTH_CTX" --jinja --parallel "$SLOTS")
       # Flash-attention + quantized KV (K8V4 by default). NOTE: quantized V-cache
       # REQUIRES fa (llama.cpp refuses otherwise), so a healthy start proves fa on.
       if [ "$FA" = "on" ]; then

--- a/scripts/tests/test_supervisor_roles.py
+++ b/scripts/tests/test_supervisor_roles.py
@@ -1,0 +1,169 @@
+"""Role-decouple coverage for scripts/aimee-llm-supervisor.sh.
+
+Runs the REAL supervisor with PATH shims for the external commands it drives —
+`wget` (records fetch URLs, creates the dest), the llama binary (records the
+--port it was started on), `python3` (the gateway: dumps its env then exits so
+the supervisor's `wait -n` returns), and `sha256sum` (no-op). Each mode combo
+then asserts which models were downloaded, which llama-servers were launched,
+and which per-role upstream the gateway was pointed at.
+
+The invariant under test: a role that is not `local` is neither downloaded nor
+launched, and when every role is external/off the plugin fetches nothing and
+starts no llama-server (pure forwarder).
+"""
+import os
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+SUP = pathlib.Path(__file__).resolve().parents[1] / "aimee-llm-supervisor.sh"
+
+
+def _write(path, body):
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _make_shims(tmp):
+    bindir = tmp / "bin"
+    logdir = tmp / "log"
+    bindir.mkdir()
+    logdir.mkdir()
+    # wget: find `-O <dest>` and the trailing URL; touch the dest, log the URL.
+    _write(bindir / "wget", textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        dest=""; url=""
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            -O) dest="$2"; shift 2;;
+            -*) shift;;
+            *) url="$1"; shift;;
+          esac
+        done
+        [ -n "$dest" ] && : > "$dest"
+        echo "$url" >> "{logdir}/wget.log"
+        exit 0
+        """))
+    # llama-server: record the --port; stay alive so the gateway's exit (below) is
+    # what trips the supervisor's `wait -n`, after it has dumped its env.
+    _write(bindir / "llama", textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        port=""
+        while [ $# -gt 0 ]; do case "$1" in --port) port="$2"; shift 2;; *) shift;; esac; done
+        echo "$port" >> "{logdir}/llama.log"
+        # Detach from the captured stdout/stderr pipe before blocking, so the test's
+        # subprocess sees EOF the moment the supervisor exits (not when sleep ends).
+        exec sleep 30 >/dev/null 2>&1
+        """))
+    # gateway: dump the resolved env (per-role URLs) then exit so `wait -n` returns.
+    _write(bindir / "python3", textwrap.dedent(f"""\
+        #!/usr/bin/env bash
+        env > "{logdir}/gateway_env.log"
+        exit 0
+        """))
+    _write(bindir / "sha256sum", "#!/usr/bin/env bash\ncat >/dev/null 2>&1 || true\nexit 0\n")
+    return bindir, logdir
+
+
+class SupervisorRoleTest(unittest.TestCase):
+    def run_supervisor(self, modes=None, tier="cpu", extra_env=None):
+        tmp = pathlib.Path(tempfile.mkdtemp(prefix="sup-roles-"))
+        bindir, logdir = _make_shims(tmp)
+        env = dict(os.environ)
+        env["PATH"] = f"{bindir}:{env['PATH']}"
+        env["AIMEE_LLM_LLAMA_BIN"] = str(bindir / "llama")
+        env["AIMEE_LLM_MODELS_DIR"] = str(tmp / "models")
+        env["AIMEE_LLM_TIER"] = tier
+        env["AIMEE_LLM_NGL"] = "0"
+        env.pop("AIMEE_LLM_STUB", None)
+        for k in ("AIMEE_LLM_EMBED_MODE", "AIMEE_LLM_RERANK_MODE", "AIMEE_LLM_SYNTH_MODE",
+                  "AIMEE_LLM_SYNTH_LOCAL", "AIMEE_LLM_EMBED_URL", "AIMEE_LLM_RERANK_URL",
+                  "AIMEE_LLM_SYNTH_URL"):
+            env.pop(k, None)
+        for k, v in (modes or {}).items():
+            env[k] = v
+        if extra_env:
+            env.update(extra_env)
+        proc = subprocess.run(["bash", str(SUP)], env=env, capture_output=True,
+                              text=True, timeout=30)
+
+        def read_lines(name):
+            p = logdir / name
+            return p.read_text().split() if p.exists() else []
+
+        gw = {}
+        ge = logdir / "gateway_env.log"
+        if ge.exists():
+            for line in ge.read_text().splitlines():
+                if "=" in line:
+                    key, val = line.split("=", 1)
+                    gw[key] = val
+        return proc, read_lines("wget.log"), read_lines("llama.log"), gw
+
+    def test_all_local_downloads_and_launches_all(self):
+        proc, urls, ports, gw = self.run_supervisor()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertTrue(any("Embedding" in u for u in urls), f"embed not fetched: {urls}")
+        self.assertTrue(any("gemma" in u.lower() for u in urls), f"synth not fetched: {urls}")
+        self.assertTrue(any("rerank-ettin" in u for u in urls), f"rerank not fetched: {urls}")
+        self.assertEqual(set(ports), {"8081", "8082", "8083"}, ports)
+        self.assertEqual(gw.get("AIMEE_LLM_EMBED_URL"), "http://127.0.0.1:8081")
+        self.assertEqual(gw.get("AIMEE_LLM_RERANK_URL"), "http://127.0.0.1:8082")
+        self.assertEqual(gw.get("AIMEE_LLM_SYNTH_URL"), "http://127.0.0.1:8083")
+        self.assertTrue(gw.get("AIMEE_LLM_RERANK_HEAD", "").endswith("cpu/rerank-head"),
+                        gw.get("AIMEE_LLM_RERANK_HEAD"))
+
+    def test_external_embed_skips_embed_download_and_server(self):
+        proc, urls, ports, gw = self.run_supervisor(
+            modes={"AIMEE_LLM_EMBED_MODE": "external",
+                   "AIMEE_LLM_EMBED_URL": "http://ext-embed:9000"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertFalse(any("Embedding" in u for u in urls), f"embed should not download: {urls}")
+        self.assertTrue(any("gemma" in u.lower() for u in urls), urls)     # synth still local
+        self.assertTrue(any("rerank-ettin" in u for u in urls), urls)      # rerank still local
+        self.assertNotIn("8081", ports, ports)
+        self.assertEqual(set(ports), {"8082", "8083"}, ports)
+        self.assertEqual(gw.get("AIMEE_LLM_EMBED_URL"), "http://ext-embed:9000")
+
+    def test_synth_off_gates_the_role(self):
+        proc, urls, ports, gw = self.run_supervisor(
+            modes={"AIMEE_LLM_SYNTH_MODE": "off"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertFalse(any("gemma" in u.lower() for u in urls), f"synth should not download: {urls}")
+        self.assertNotIn("8083", ports, ports)
+        self.assertEqual(gw.get("AIMEE_LLM_SYNTH_URL", "SENTINEL"), "")  # empty => gated
+
+    def test_all_external_downloads_nothing_and_starts_no_server(self):
+        proc, urls, ports, gw = self.run_supervisor(modes={
+            "AIMEE_LLM_EMBED_MODE": "external", "AIMEE_LLM_EMBED_URL": "http://e:1",
+            "AIMEE_LLM_RERANK_MODE": "external", "AIMEE_LLM_RERANK_URL": "http://r:2",
+            "AIMEE_LLM_SYNTH_MODE": "external", "AIMEE_LLM_SYNTH_URL": "http://s:3",
+        })
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(urls, [], f"nothing should download: {urls}")
+        self.assertEqual(ports, [], f"no llama-server should start: {ports}")
+
+    def test_external_without_url_fails_fast(self):
+        proc, _urls, _ports, _gw = self.run_supervisor(
+            modes={"AIMEE_LLM_EMBED_MODE": "external"})  # no AIMEE_LLM_EMBED_URL
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("mode=external requires", proc.stderr)
+
+    def test_legacy_synth_local_zero_is_external(self):
+        proc, urls, ports, gw = self.run_supervisor(
+            modes={"AIMEE_LLM_SYNTH_LOCAL": "0", "AIMEE_LLM_SYNTH_URL": "http://legacy-synth:8"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertFalse(any("gemma" in u.lower() for u in urls), urls)
+        self.assertNotIn("8083", ports, ports)
+        self.assertEqual(gw.get("AIMEE_LLM_SYNTH_URL"), "http://legacy-synth:8")
+
+    def test_invalid_mode_rejected(self):
+        proc, _u, _p, _g = self.run_supervisor(modes={"AIMEE_LLM_EMBED_MODE": "bogus"})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("invalid AIMEE_LLM_EMBED_MODE", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_supervisor_roles.py
+++ b/scripts/tests/test_supervisor_roles.py
@@ -1,18 +1,22 @@
-"""Role-decouple coverage for scripts/aimee-llm-supervisor.sh.
+"""Role- and tier-decouple coverage for scripts/aimee-llm-supervisor.sh.
 
 Runs the REAL supervisor with PATH shims for the external commands it drives —
-`wget` (records fetch URLs, creates the dest), the llama binary (records the
---port it was started on), `python3` (the gateway: dumps its env then exits so
-the supervisor's `wait -n` returns), and `sha256sum` (no-op). Each mode combo
-then asserts which models were downloaded, which llama-servers were launched,
-and which per-role upstream the gateway was pointed at.
+`wget` (records fetch URLs, creates the dest), the llama binary (records its full
+argv, one line per launch), `python3` (the gateway: dumps its env then exits so
+the supervisor's `wait -n` returns), and `sha256sum` (no-op). Each combo then
+asserts which models were downloaded, which llama-servers were launched (and with
+which per-role tier model / --ngl / --parallel), and which per-role upstream the
+gateway was pointed at.
 
-The invariant under test: a role that is not `local` is neither downloaded nor
-launched, and when every role is external/off the plugin fetches nothing and
-starts no llama-server (pure forwarder).
+Invariants under test:
+  - a role that is not `local` is neither downloaded nor launched;
+  - all-external/off downloads nothing and starts no llama-server;
+  - each local role is sized by its OWN tier (one instance can mix e.g. a cpu
+    embedder and a gpu-large synth), with GPU offload forced off on a cpu tier.
 """
 import os
 import pathlib
+import re
 import subprocess
 import tempfile
 import textwrap
@@ -31,7 +35,6 @@ def _make_shims(tmp):
     logdir = tmp / "log"
     bindir.mkdir()
     logdir.mkdir()
-    # wget: find `-O <dest>` and the trailing URL; touch the dest, log the URL.
     _write(bindir / "wget", textwrap.dedent(f"""\
         #!/usr/bin/env bash
         dest=""; url=""
@@ -46,18 +49,13 @@ def _make_shims(tmp):
         echo "$url" >> "{logdir}/wget.log"
         exit 0
         """))
-    # llama-server: record the --port; stay alive so the gateway's exit (below) is
-    # what trips the supervisor's `wait -n`, after it has dumped its env.
+    # llama-server: record the full argv (one line), then detach from the captured
+    # pipe and block, so the supervisor's exit — not `sleep` — ends the test call.
     _write(bindir / "llama", textwrap.dedent(f"""\
         #!/usr/bin/env bash
-        port=""
-        while [ $# -gt 0 ]; do case "$1" in --port) port="$2"; shift 2;; *) shift;; esac; done
-        echo "$port" >> "{logdir}/llama.log"
-        # Detach from the captured stdout/stderr pipe before blocking, so the test's
-        # subprocess sees EOF the moment the supervisor exits (not when sleep ends).
+        echo "$*" >> "{logdir}/llama.log"
         exec sleep 30 >/dev/null 2>&1
         """))
-    # gateway: dump the resolved env (per-role URLs) then exit so `wait -n` returns.
     _write(bindir / "python3", textwrap.dedent(f"""\
         #!/usr/bin/env bash
         env > "{logdir}/gateway_env.log"
@@ -67,20 +65,30 @@ def _make_shims(tmp):
     return bindir, logdir
 
 
+def _port(argv):
+    m = re.search(r"--port (\d+)", argv)
+    return m.group(1) if m else None
+
+
+def _ngl(argv):
+    m = re.search(r"-ngl (\S+)", argv)
+    return m.group(1) if m else None
+
+
 class SupervisorRoleTest(unittest.TestCase):
-    def run_supervisor(self, modes=None, tier="cpu", extra_env=None):
+    def run_supervisor(self, modes=None, extra_env=None):
         tmp = pathlib.Path(tempfile.mkdtemp(prefix="sup-roles-"))
         bindir, logdir = _make_shims(tmp)
         env = dict(os.environ)
         env["PATH"] = f"{bindir}:{env['PATH']}"
         env["AIMEE_LLM_LLAMA_BIN"] = str(bindir / "llama")
         env["AIMEE_LLM_MODELS_DIR"] = str(tmp / "models")
-        env["AIMEE_LLM_TIER"] = tier
         env["AIMEE_LLM_NGL"] = "0"
         env.pop("AIMEE_LLM_STUB", None)
-        for k in ("AIMEE_LLM_EMBED_MODE", "AIMEE_LLM_RERANK_MODE", "AIMEE_LLM_SYNTH_MODE",
-                  "AIMEE_LLM_SYNTH_LOCAL", "AIMEE_LLM_EMBED_URL", "AIMEE_LLM_RERANK_URL",
-                  "AIMEE_LLM_SYNTH_URL"):
+        for k in ("AIMEE_LLM_TIER", "AIMEE_LLM_EMBED_MODE", "AIMEE_LLM_RERANK_MODE",
+                  "AIMEE_LLM_SYNTH_MODE", "AIMEE_LLM_SYNTH_LOCAL", "AIMEE_LLM_EMBED_URL",
+                  "AIMEE_LLM_RERANK_URL", "AIMEE_LLM_SYNTH_URL", "AIMEE_LLM_EMBED_TIER",
+                  "AIMEE_LLM_RERANK_TIER", "AIMEE_LLM_SYNTH_TIER"):
             env.pop(k, None)
         for k, v in (modes or {}).items():
             env[k] = v
@@ -89,9 +97,9 @@ class SupervisorRoleTest(unittest.TestCase):
         proc = subprocess.run(["bash", str(SUP)], env=env, capture_output=True,
                               text=True, timeout=30)
 
-        def read_lines(name):
+        def lines(name):
             p = logdir / name
-            return p.read_text().split() if p.exists() else []
+            return p.read_text().splitlines() if p.exists() else []
 
         gw = {}
         ge = logdir / "gateway_env.log"
@@ -100,69 +108,102 @@ class SupervisorRoleTest(unittest.TestCase):
                 if "=" in line:
                     key, val = line.split("=", 1)
                     gw[key] = val
-        return proc, read_lines("wget.log"), read_lines("llama.log"), gw
+        return proc, lines("wget.log"), lines("llama.log"), gw
 
+    def _launched(self, llama):
+        return {_port(a): a for a in llama}
+
+    # ---- role mode (local | external | off) --------------------------------
     def test_all_local_downloads_and_launches_all(self):
-        proc, urls, ports, gw = self.run_supervisor()
+        proc, urls, llama, gw = self.run_supervisor()
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertTrue(any("Embedding" in u for u in urls), f"embed not fetched: {urls}")
-        self.assertTrue(any("gemma" in u.lower() for u in urls), f"synth not fetched: {urls}")
-        self.assertTrue(any("rerank-ettin" in u for u in urls), f"rerank not fetched: {urls}")
-        self.assertEqual(set(ports), {"8081", "8082", "8083"}, ports)
+        self.assertTrue(any("Embedding-0.6B" in u for u in urls), urls)   # cpu embed
+        self.assertTrue(any("gemma-4-E4B" in u for u in urls), urls)      # cpu synth
+        self.assertTrue(any("rerank-ettin-68m" in u for u in urls), urls) # cpu rerank
+        self.assertEqual(set(self._launched(llama)), {"8081", "8082", "8083"})
         self.assertEqual(gw.get("AIMEE_LLM_EMBED_URL"), "http://127.0.0.1:8081")
-        self.assertEqual(gw.get("AIMEE_LLM_RERANK_URL"), "http://127.0.0.1:8082")
         self.assertEqual(gw.get("AIMEE_LLM_SYNTH_URL"), "http://127.0.0.1:8083")
-        self.assertTrue(gw.get("AIMEE_LLM_RERANK_HEAD", "").endswith("cpu/rerank-head"),
-                        gw.get("AIMEE_LLM_RERANK_HEAD"))
+        self.assertTrue(gw.get("AIMEE_LLM_RERANK_HEAD", "").endswith("cpu/rerank-head"))
 
     def test_external_embed_skips_embed_download_and_server(self):
-        proc, urls, ports, gw = self.run_supervisor(
+        proc, urls, llama, gw = self.run_supervisor(
             modes={"AIMEE_LLM_EMBED_MODE": "external",
                    "AIMEE_LLM_EMBED_URL": "http://ext-embed:9000"})
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertFalse(any("Embedding" in u for u in urls), f"embed should not download: {urls}")
-        self.assertTrue(any("gemma" in u.lower() for u in urls), urls)     # synth still local
-        self.assertTrue(any("rerank-ettin" in u for u in urls), urls)      # rerank still local
-        self.assertNotIn("8081", ports, ports)
-        self.assertEqual(set(ports), {"8082", "8083"}, ports)
+        self.assertFalse(any("Embedding" in u for u in urls), urls)
+        self.assertTrue(any("gemma" in u.lower() for u in urls), urls)
+        self.assertEqual(set(self._launched(llama)), {"8082", "8083"})
         self.assertEqual(gw.get("AIMEE_LLM_EMBED_URL"), "http://ext-embed:9000")
 
     def test_synth_off_gates_the_role(self):
-        proc, urls, ports, gw = self.run_supervisor(
-            modes={"AIMEE_LLM_SYNTH_MODE": "off"})
+        proc, urls, llama, gw = self.run_supervisor(modes={"AIMEE_LLM_SYNTH_MODE": "off"})
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertFalse(any("gemma" in u.lower() for u in urls), f"synth should not download: {urls}")
-        self.assertNotIn("8083", ports, ports)
-        self.assertEqual(gw.get("AIMEE_LLM_SYNTH_URL", "SENTINEL"), "")  # empty => gated
+        self.assertFalse(any("gemma" in u.lower() for u in urls), urls)
+        self.assertNotIn("8083", self._launched(llama))
+        self.assertEqual(gw.get("AIMEE_LLM_SYNTH_URL", "X"), "")
 
     def test_all_external_downloads_nothing_and_starts_no_server(self):
-        proc, urls, ports, gw = self.run_supervisor(modes={
+        proc, urls, llama, _gw = self.run_supervisor(modes={
             "AIMEE_LLM_EMBED_MODE": "external", "AIMEE_LLM_EMBED_URL": "http://e:1",
             "AIMEE_LLM_RERANK_MODE": "external", "AIMEE_LLM_RERANK_URL": "http://r:2",
             "AIMEE_LLM_SYNTH_MODE": "external", "AIMEE_LLM_SYNTH_URL": "http://s:3",
         })
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertEqual(urls, [], f"nothing should download: {urls}")
-        self.assertEqual(ports, [], f"no llama-server should start: {ports}")
+        self.assertEqual(urls, [], urls)
+        self.assertEqual(llama, [], llama)
 
     def test_external_without_url_fails_fast(self):
-        proc, _urls, _ports, _gw = self.run_supervisor(
-            modes={"AIMEE_LLM_EMBED_MODE": "external"})  # no AIMEE_LLM_EMBED_URL
+        proc, *_ = self.run_supervisor(modes={"AIMEE_LLM_EMBED_MODE": "external"})
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("mode=external requires", proc.stderr)
 
     def test_legacy_synth_local_zero_is_external(self):
-        proc, urls, ports, gw = self.run_supervisor(
-            modes={"AIMEE_LLM_SYNTH_LOCAL": "0", "AIMEE_LLM_SYNTH_URL": "http://legacy-synth:8"})
+        proc, urls, llama, gw = self.run_supervisor(
+            modes={"AIMEE_LLM_SYNTH_LOCAL": "0", "AIMEE_LLM_SYNTH_URL": "http://legacy:8"})
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertFalse(any("gemma" in u.lower() for u in urls), urls)
-        self.assertNotIn("8083", ports, ports)
-        self.assertEqual(gw.get("AIMEE_LLM_SYNTH_URL"), "http://legacy-synth:8")
+        self.assertNotIn("8083", self._launched(llama))
+        self.assertEqual(gw.get("AIMEE_LLM_SYNTH_URL"), "http://legacy:8")
 
     def test_invalid_mode_rejected(self):
-        proc, _u, _p, _g = self.run_supervisor(modes={"AIMEE_LLM_EMBED_MODE": "bogus"})
+        proc, *_ = self.run_supervisor(modes={"AIMEE_LLM_EMBED_MODE": "bogus"})
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("invalid AIMEE_LLM_EMBED_MODE", proc.stderr)
+
+    # ---- per-role tier -----------------------------------------------------
+    def test_global_tier_applies_to_all_roles(self):
+        proc, urls, llama, _gw = self.run_supervisor(
+            modes={"AIMEE_LLM_TIER": "mid", "AIMEE_LLM_NGL": "99"})
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertTrue(any("Embedding-4B" in u for u in urls), urls)     # gpu embed
+        self.assertTrue(any("gemma-4-26B" in u for u in urls), urls)      # mid synth
+        self.assertTrue(any("rerank-ettin-400m" in u for u in urls), urls)
+        launched = self._launched(llama)
+        self.assertEqual(_ngl(launched["8081"]), "99")                    # gpu embed offloads
+        self.assertIn("--parallel 2", launched["8083"])                   # mid => SLOTS=2
+
+    def test_mixed_per_role_tiers_in_one_instance(self):
+        # cpu embedder beside a gpu-large synth on the same instance.
+        proc, urls, llama, gw = self.run_supervisor(modes={
+            "AIMEE_LLM_EMBED_TIER": "cpu",
+            "AIMEE_LLM_RERANK_TIER": "cpu",
+            "AIMEE_LLM_SYNTH_TIER": "large",
+            "AIMEE_LLM_NGL": "99",
+        })
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertTrue(any("Embedding-0.6B" in u for u in urls), urls)   # cpu embed model
+        self.assertTrue(any("gemma-4-26B" in u for u in urls), urls)      # large synth model
+        self.assertTrue(any("rerank-ettin-68m" in u for u in urls), urls)
+        launched = self._launched(llama)
+        self.assertEqual(_ngl(launched["8081"]), "0")                     # cpu embed: no offload
+        self.assertEqual(_ngl(launched["8083"]), "99")                    # gpu synth: offload
+        self.assertIn("--parallel 4", launched["8083"])                   # large => SLOTS=4
+        self.assertTrue(gw.get("AIMEE_LLM_RERANK_HEAD", "").endswith("cpu/rerank-head"))
+
+    def test_invalid_tier_rejected(self):
+        proc, *_ = self.run_supervisor(modes={"AIMEE_LLM_SYNTH_TIER": "bogus"})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("invalid AIMEE_LLM_SYNTH_TIER", proc.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Phase 0** of the page-2 (LLM backend) setup-wizard work. Page 2 lets an operator put each LLM role (embedder / synthesizer / reranker) on a different backend — external, or a local tier — and (per the confirmed model) **one `aimee-llm` instance hosts all the local roles**, each at its own tier. Today the plugin bundles all three: one `AIMEE_LLM_TIER` fetches embed+rerank+synth and launches all three llama-servers unconditionally.

### Role decouple (mode)
- `AIMEE_LLM_{EMBED,RERANK,SYNTH}_MODE = local | external | off` (default `local` => prior all-local behavior; legacy `AIMEE_LLM_SYNTH_LOCAL=0` => synth `external`).
- `download_models` fetches a role's model only when it is `local`; per-role `.ready` markers (legacy `.ready` migrated) so switching one role never re-pulls the others.
- Launch each llama-server only when its role is `local`. `resolve_upstreams` points the gateway's `AIMEE_LLM_<ROLE>_URL` at the local server / operator upstream (validated non-local) / empty (gated). Rerank head dir set only for a local encoder.
- All-external/off: nothing downloads, no server starts (pure forwarder; the deploy layer skips deploying the plugin entirely then).

### Per-role tier (size)
- `AIMEE_LLM_{EMBED,RERANK,SYNTH}_TIER = cpu | small | mid | large`, each falling back to `AIMEE_LLM_TIER` then `cpu` (single-tier deploys unchanged).
- One instance can mix tiers — e.g. a **cpu embedder beside a gpu-large synth**. embed/rerank collapse small/mid/large -> the gpu model; synth honors the full ladder (E4B / 12B / 26B-A4B×2 / 26B-A4B×4).
- Per-role GPU offload: `-ngl` forced `0` on a cpu-tier role, uses the deploy's `AIMEE_LLM_NGL` on a gpu one. Each role caches under `$MODELS_DIR/<its-tier>` (roles sharing a tier share a dir; legacy volume still works).
- `AIMEE_LLM_LLAMA_BIN` makes the llama binary path overridable (test shim / custom installs).

### Tests
`scripts/tests/test_supervisor_roles.py` drives the **real** supervisor with `wget`/`llama`/`python3`/`sha256sum` shims — 10 cases covering per-mode download+launch+upstreams AND per-role tier (incl. a mixed cpu-embed + gpu-large-synth instance asserting per-role model, `--ngl 0` vs `99`, synth `SLOTS=4`), plus mode/tier validation. 0.11s, stdlib-only, wired into `gateway-tests.yml`. Gateway `.py` untouched; its 40 tests still pass.

### Deploy model
A single `aimee-llm` instance hosts **all** locally-served roles together (external/off roles just aren't fetched/launched on it) — one instance for all local roles, NOT one per role. Removing the auto-deploy + wiring the wizard config is Phase 2.

### Not covered
No live container build/boot here (validation-pending): the real `docker build` + first-boot per-role fetch is exercised by the image-publish + e2e-docker CI paths.
