### PR TITLE
revert(learning): remove conversation→DB2 user-fact mining (wrong boundary)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -292,7 +292,6 @@ static const config_schema_entry_t config_schema[] = {
     {"audit_worm_enabled", SCHEMA_BOOL, 0},
     {"css_render_command", SCHEMA_STRING, 0},
     {"typed_facts_enabled", SCHEMA_BOOL, 0},
-    {"learn_from_conversations_enabled", SCHEMA_BOOL, 0},
     {"kb_pdf_ingest_enabled", SCHEMA_BOOL, 0},
     {"kb_pdf_vector_enabled", SCHEMA_BOOL, 0},
     {"kb_pdf_tsr_enabled", SCHEMA_BOOL, 0},
@@ -637,10 +636,6 @@ static void config_set_defaults(config_t *cfg)
     * for an accelerated backend. An explicit config value always wins. HyDE mode
     * defaults on so the rewrite, once enabled, generates a hypothetical answer. */
    cfg->typed_facts_enabled = 1;
-   /* Mine the user's own conversation turns into durable facts (feeds the typed-
-    * fact extractor). Default on so aimee learns from interactions; an operator
-    * can disable it to stop writing conversation content to the memory store. */
-   cfg->learn_from_conversations_enabled = 1;
    cfg->memory_rewrite_enabled = 0;
    cfg->memory_rewrite_hyde = 1;
    /* Replayable-evidence roundtable verification (Part A): default-on. config_t
@@ -1166,10 +1161,6 @@ int config_load_file(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "typed_facts_enabled");
    if (cJSON_IsBool(item))
       cfg->typed_facts_enabled = cJSON_IsTrue(item);
-
-   item = cJSON_GetObjectItemCaseSensitive(root, "learn_from_conversations_enabled");
-   if (cJSON_IsBool(item))
-      cfg->learn_from_conversations_enabled = cJSON_IsTrue(item);
 
    /* structured-PDF gates. These have config_fields[] rows (CLI/server-settable) but
     * historically lacked a file parse, so a value set in aimee.yaml never loaded back on a

--- a/src/db2/kb_service_backend_agent.c
+++ b/src/db2/kb_service_backend_agent.c
@@ -773,18 +773,6 @@ cJSON *db2_kb_service_directive_expire_session_json(void)
    return resp;
 }
 
-/* Ingest one salient user turn as a durable memory. The insert path enqueues a
- * "memory_facts" job (when typed facts are enabled), so the typed-fact extractor
- * mines the user's own words offline into durable, gated, auto-injected facts.
- * Best-effort; keyed by content hash so repeated phrasings dedup. */
-static void kbs_conversation_user_fact_sink(const char *session_id, const char *key,
-                                            const char *user_text)
-{
-   cJSON *r = db2_kb_service_memory_insert_ex_json("L1", "conversation", key, user_text, "", 0.5,
-                                                   session_id);
-   cJSON_Delete(r);
-}
-
 cJSON *db2_kb_service_memory_scan_conversations_json(const cJSON *dirs)
 {
    cJSON *resp = cJSON_CreateObject();
@@ -806,18 +794,7 @@ cJSON *db2_kb_service_memory_scan_conversations_json(const cJSON *dirs)
       if (cJSON_IsString(d))
          snprintf(buf[n++], MAX_PATH_LEN, "%s", d->valuestring);
    }
-   /* Enable user-turn fact mining only when both gates are on; register NULL
-    * otherwise so a prior enabled run's sink never leaks into a disabled one. */
-   {
-      config_t cfg;
-      config_load(&cfg);
-      memory_scan_register_user_fact_sink(
-          (cfg.learn_from_conversations_enabled && cfg.typed_facts_enabled)
-              ? kbs_conversation_user_fact_sink
-              : NULL);
-   }
    int rc = memory_scan_conversations(buf, n);
-   memory_scan_register_user_fact_sink(NULL); /* scan done — clear the sink */
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddNumberToObject(resp, "count", rc);
    return resp;

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -423,8 +423,7 @@ typedef struct config
     * model, P1). Single-model Anthropic-compatible shims (llama.cpp/vLLM) enable
     * this so an arbitrary client model name is not forwarded and rejected upstream. */
    int gateway_pin_model;
-   int typed_facts_enabled;              /* typed-fact knowledge layer master gate (default off) */
-   int learn_from_conversations_enabled; /* mine user turns into durable facts (default on) */
+   int typed_facts_enabled; /* typed-fact knowledge layer master gate (default off) */
    /* kb.typed_facts.* — KB-owned autonomous reconciliation knobs (proposal §7.2/§8). */
    int kb_typed_facts_auto_promote_enabled; /* default on: auto-promote recurrent provisional
                                                relations */

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -544,16 +544,6 @@ int memory_find_facts_visible(const char *query, const char *workspace, const ch
 /* --- Conversation Scanning --- */
 int memory_scan_conversations(char dirs[][MAX_PATH_LEN], int dir_count);
 
-/* Sink invoked once per salient, genuinely user-authored turn found while
- * scanning conversation transcripts. `key` is a stable content hash (for
- * dedup); `user_text` is the first-person user text with tool_result echoes
- * stripped. The KB backend registers a sink that ingests it as a durable
- * memory, which feeds the typed-fact extractor so aimee learns from the user's
- * own words. Unset (NULL) → the scan just skips user-fact mining. */
-typedef void (*memory_conv_user_fact_sink_fn)(const char *session_id, const char *key,
-                                              const char *user_text);
-void memory_scan_register_user_fact_sink(memory_conv_user_fact_sink_fn fn);
-
 /* --- Window Compaction --- */
 int memory_compact_windows(int *summary_count, int *fact_count);
 

--- a/src/memory_scan.c
+++ b/src/memory_scan.c
@@ -22,7 +22,6 @@
 #include <ctype.h>
 #include <dirent.h>
 #include <math.h>
-#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -201,132 +200,6 @@ static void scan_collect_content_text(cJSON *node, char **buf, size_t *len, size
       (void)scan_append_text(buf, len, cap, text->valuestring);
 }
 
-/* --- User-turn fact mining (feeds the typed-fact extractor) --- */
-
-static const char *scan_message_role(cJSON *msg); /* defined just below */
-
-static memory_conv_user_fact_sink_fn g_user_fact_sink = NULL;
-
-void memory_scan_register_user_fact_sink(memory_conv_user_fact_sink_fn fn)
-{
-   g_user_fact_sink = fn;
-}
-
-/* Collect ONLY genuinely user-authored text from a user message's content:
- * plain strings and {type:"text"} blocks. Skips tool_result echoes and any
- * block carrying tool output (tool_use_id / output / result) so a tool result
- * the host stores under the "user" role is never mistaken for the user's words.
- * (scan_collect_content_text deliberately harvests output/result for search
- * indexing; fact mining must not, or aimee would "learn" tool output as if the
- * user said it.) */
-static void scan_collect_user_authored_text(cJSON *node, char **buf, size_t *len, size_t *cap)
-{
-   if (!node)
-      return;
-   if (cJSON_IsString(node))
-   {
-      (void)scan_append_text(buf, len, cap, node->valuestring);
-      return;
-   }
-   if (cJSON_IsArray(node))
-   {
-      cJSON *item;
-      cJSON_ArrayForEach(item, node) scan_collect_user_authored_text(item, buf, len, cap);
-      return;
-   }
-   if (!cJSON_IsObject(node))
-      return;
-
-   const char *type = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(node, "type"));
-   if (type && strcmp(type, "text") != 0)
-      return; /* tool_result, image, thinking, … — not the user's prose */
-   if (cJSON_GetObjectItemCaseSensitive(node, "tool_use_id") ||
-       cJSON_GetObjectItemCaseSensitive(node, "output") ||
-       cJSON_GetObjectItemCaseSensitive(node, "result"))
-      return; /* defensive: a tool_result block without an explicit type */
-
-   cJSON *text = cJSON_GetObjectItemCaseSensitive(node, "text");
-   if (cJSON_IsString(text))
-      (void)scan_append_text(buf, len, cap, text->valuestring);
-}
-
-/* A user turn is worth an (LLM-priced) extraction only if it plausibly carries a
- * durable fact. Conservative on cost, permissive on content: reject empties,
- * very short turns, slash-commands, and single-word acknowledgements; keep the
- * rest and let the extractor's own confidence floor discard non-facts. */
-static int scan_user_turn_is_salient(const char *text)
-{
-   if (!text)
-      return 0;
-   while (*text && isspace((unsigned char)*text))
-      text++;
-   if (text[0] == '/') /* slash-command, not natural language */
-      return 0;
-   size_t n = strlen(text);
-   while (n > 0 && isspace((unsigned char)text[n - 1]))
-      n--;
-   if (n < 12) /* too short to assert a durable fact */
-      return 0;
-
-   static const char *fillers[] = {"ok",      "okay",   "yes",    "yep",         "yeah", "no",
-                                   "nope",    "sure",   "thanks", "thank you",   "go",   "continue",
-                                   "proceed", "please", "do it",  "sounds good", NULL};
-   for (int i = 0; fillers[i]; i++)
-      if (n == strlen(fillers[i]) && strncasecmp(text, fillers[i], n) == 0)
-         return 0;
-   return 1;
-}
-
-/* If the line is a genuine user turn with salient prose, hand it to the
- * registered sink for durable-memory ingest (which feeds fact extraction).
- * Best-effort and self-contained: parsing/allocation failures just skip. */
-static void scan_maybe_mine_user_turn(const char *session_id, const char *line)
-{
-   if (!g_user_fact_sink || !line)
-      return;
-   cJSON *root = cJSON_Parse(line);
-   if (!root)
-      return;
-
-   cJSON *msg = root;
-   cJSON *content = cJSON_GetObjectItemCaseSensitive(msg, "content");
-   if (!content)
-   {
-      cJSON *nested = cJSON_GetObjectItemCaseSensitive(root, "message");
-      if (!cJSON_IsObject(nested))
-         nested = cJSON_GetObjectItemCaseSensitive(root, "item");
-      if (cJSON_IsObject(nested))
-      {
-         msg = nested;
-         content = cJSON_GetObjectItemCaseSensitive(msg, "content");
-      }
-   }
-   const char *role = scan_message_role(msg);
-   if (!content || !role || strcmp(role, "user") != 0)
-   {
-      cJSON_Delete(root);
-      return;
-   }
-
-   char *buf = NULL;
-   size_t len = 0, cap = 0;
-   scan_collect_user_authored_text(content, &buf, &len, &cap);
-   if (buf && scan_user_turn_is_salient(buf))
-   {
-      /* FNV-1a/64 content hash → stable dedup key ("conv-<hex>"): the same
-       * user phrasing maps to the same memory key, so repeats upsert instead of
-       * piling up. Self-contained to keep this shared TU dependency-light. */
-      uint64_t h = 1469598103934665603ULL;
-      for (const unsigned char *p = (const unsigned char *)buf; *p; p++)
-         h = (h ^ *p) * 1099511628211ULL;
-      char key[32];
-      snprintf(key, sizeof(key), "conv-%016llx", (unsigned long long)h);
-      g_user_fact_sink(session_id ? session_id : "", key, buf);
-   }
-   free(buf);
-   cJSON_Delete(root);
-}
-
 static const char *scan_message_role(cJSON *msg)
 {
    const char *role = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(msg, "role"));
@@ -501,13 +374,7 @@ static int scan_file(const char *session_id, const char *file_path)
          char role[16];
          char *text = NULL;
          if (scan_extract_message_text(line_buf, role, sizeof(role), &text))
-         {
-            /* Mine the user's own words for durable facts (only new lines reach
-             * here — see the max_end_line skip above). */
-            if (strcmp(role, "user") == 0)
-               scan_maybe_mine_user_turn(session_id, line_buf);
             (void)scan_add_message_part(message_parts, &message_count, role, text);
-         }
       }
 
       /* Extract file refs from any line */

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -2034,73 +2034,6 @@ static void test_memory_scan_preserves_message_boundaries(void)
    teardown();
 }
 
-/* --- user-turn fact mining sink capture --- */
-static int g_mined_count;
-static char g_mined_text[8][512];
-static void test_user_fact_sink(const char *session_id, const char *key, const char *user_text)
-{
-   (void)session_id;
-   assert(key && key[0]); /* a content-hash key is always supplied */
-   if (g_mined_count < 8 && user_text)
-      snprintf(g_mined_text[g_mined_count], sizeof(g_mined_text[0]), "%s", user_text);
-   g_mined_count++;
-}
-
-/* The scan hands ONLY salient, genuinely user-authored turns to the sink: filler
- * and slash-commands are dropped, tool_result echoes under the "user" role are
- * never mistaken for the user's words, and assistant turns are ignored. */
-static void test_memory_scan_mines_user_turns(void)
-{
-   setup();
-
-   char dir[512];
-   snprintf(dir, sizeof(dir), "%s/aimee-test-userfacts-XXXXXX", platform_tmpdir());
-   assert(platform_mkdtemp(dir) != NULL);
-
-   char path[768];
-   snprintf(path, sizeof(path), "%s/session.jsonl", dir);
-   FILE *fp = fopen(path, "w");
-   assert(fp != NULL);
-   /* [captured] first-person durable preference */
-   fputs("{\"role\":\"user\",\"content\":\"I always prefer tabs over spaces in my code.\"}\n", fp);
-   /* [dropped] single-word filler */
-   fputs("{\"role\":\"user\",\"content\":\"ok\"}\n", fp);
-   /* [dropped] slash-command */
-   fputs("{\"role\":\"user\",\"content\":\"/compact the conversation now\"}\n", fp);
-   /* [dropped] tool_result echoed under the user role — NOT the user's words */
-   fputs("{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\","
-         "\"content\":\"wrote 200 lines to /tmp/foo successfully\"}]}\n",
-         fp);
-   /* [dropped] assistant turn */
-   fputs("{\"role\":\"assistant\",\"content\":\"Noted, you prefer tabs.\"}\n", fp);
-   /* [captured] durable fact carried in a typed text block */
-   fputs("{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"My timezone is "
-         "Europe/London for scheduling.\"}]}\n",
-         fp);
-   fclose(fp);
-
-   g_mined_count = 0;
-   memset(g_mined_text, 0, sizeof(g_mined_text));
-   memory_scan_register_user_fact_sink(test_user_fact_sink);
-
-   char dirs[1][MAX_PATH_LEN];
-   snprintf(dirs[0], sizeof(dirs[0]), "%s", dir);
-   assert(memory_scan_conversations(dirs, 1) == 1);
-
-   memory_scan_register_user_fact_sink(NULL);
-
-   /* Exactly the two salient user turns were mined. */
-   assert(g_mined_count == 2);
-   assert(strcmp(g_mined_text[0], "I always prefer tabs over spaces in my code.") == 0);
-   assert(strcmp(g_mined_text[1], "My timezone is Europe/London for scheduling.") == 0);
-   /* Tool output never leaks into what aimee "learns" the user said. */
-   for (int i = 0; i < g_mined_count; i++)
-      assert(strstr(g_mined_text[i], "wrote 200 lines") == NULL);
-
-   platform_test_rmrf(dir);
-   teardown();
-}
-
 static void test_memory_promote_uses_calibration_profile(void)
 {
    write_calibration_config(3);
@@ -2520,7 +2453,6 @@ int main(void)
    test_memory_promote_delegation_patterns_uses_db1_agent_log();
    test_memory_synthesize_failure_episodes_uses_db1_agent_log();
    test_memory_scan_preserves_message_boundaries();
-   test_memory_scan_mines_user_turns();
 
    /* --- cosine_similarity: known vectors --- */
    {


### PR DESCRIPTION
Reverts #1243.

That change mined raw user conversation turns into **DB2** memories/typed-facts. Two problems, established in review:

1. **Wrong data boundary.** DB2 is the shareable KB and must hold only *non-personal, generalizable* facts/lessons. Personal information (raw user turns, preferences, identity) must stay in **DB1** (local). #1243 pushed personal content into DB2 wholesale.
2. **It never executed.** The conversation scan runs only in `aimee-kb`, which is built with `-DAIMEE_DB1_DISABLED`; `memory_scan_conversations` early-returns before the mining loop, so the sink never fired.

Removing it cleanly. The correct design — local per-user interaction learning in DB1 (aimee-server), and a fail-closed promotion gate so only non-personal facts/lessons reach DB2 — is being built separately.