### PR TITLE
feat(learning): learn per-user interaction preferences into DB1 (local)

### DIFF
--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -335,6 +335,23 @@ static char *build_session_context(const char *client_cwd)
    }
    free(rules);
 
+   /* Learned per-user working profile (DB1-local): inject the interaction
+    * preferences aimee has observed about this user (verbosity, communication
+    * style, trust calibration) so the primary adapts to how they work. Personal
+    * and local — sourced from DB1, never the shared KB. Renders nothing when the
+    * switch is off or nothing has been learned yet. The observer that fills it is
+    * memory_recall_handler (per user turn). */
+   {
+      config_t wp_cfg;
+      if (config_load(&wp_cfg) == 0)
+      {
+         char *wp = prompt_apply_working_profile("", &wp_cfg);
+         if (wp && wp[0])
+            ctx_appendf(buf, cap, &pos, "%s", wp);
+         free(wp);
+      }
+   }
+
    /* Hierarchical local context: walk cwd up to project root and inject nearby
     * rule/convention files (.aimee-rules, AGENTS.md, CONTRIBUTING.md, ...). */
    {

--- a/src/config.c
+++ b/src/config.c
@@ -841,7 +841,13 @@ static void config_set_defaults(config_t *cfg)
    cfg->mcp_osv_allow_count = 0;
    config_computer_use_defaults(cfg);
    cfg->trigger_max_concurrent = 2;
-   cfg->identity_working_profile_injection_enabled = 0;
+   /* Master switch for DB1-local per-user interaction learning: observe the
+    * user's own turns into the working profile (memory_recall_handler) AND inject
+    * the learned profile into the session context (build_session_context) so the
+    * primary adapts to how they work. Default on; empty until something is
+    * learned, so it is a no-op for a fresh user. An empty field allow-list means
+    * all learned fields inject. */
+   cfg->identity_working_profile_injection_enabled = 1;
    cfg->identity_working_profile_injection_fields_count = 0;
    cfg->memory_recall_lanes_floor_summary = 4;
    cfg->memory_recall_lanes_floor_fact = 4;

--- a/src/server/server_api.c
+++ b/src/server/server_api.c
@@ -10,6 +10,7 @@
 #include "server_http.h"
 #include "kb_client.h"
 #include "config.h"
+#include "working_profile.h" /* working_profile_autoobserve_from_feedback */
 #include "agent_config.h"
 #include "agent_types.h"
 #include "cJSON.h"
@@ -183,6 +184,20 @@ static int memory_recall_handler(const char *body, char *resp, int cap)
                           : 1024;
    const cJSON *js = cJSON_GetObjectItemCaseSensitive(req, "session_start");
    int session_start = cJSON_IsTrue(js) ? 1 : 0;
+
+   /* Learn how to work with THIS user from their own turns: the UserPromptSubmit
+    * hook posts each turn's prompt here as task_hint, and this handler runs in the
+    * DB1-owning aimee-server, so it is the right seam to observe interaction
+    * preferences (e.g. "be terse", "ask first") into the DB1-local working
+    * profile. Personal and strictly local — nothing leaves for the shared KB.
+    * Only real user turns (not the session-start context fetch); best-effort, and
+    * never affects the recall response. Gated by the working-profile switch. */
+   if (!session_start)
+   {
+      config_t wp_cfg;
+      if (config_load(&wp_cfg) == 0 && wp_cfg.identity_working_profile_injection_enabled)
+         (void)working_profile_autoobserve_from_feedback(jh->valuestring);
+   }
 
    /* Graph-code fusion is always on for recall. */
    char *j = kb_client_memory_recall_json_ex(jh->valuestring, limit_tokens, session_start, "on");


### PR DESCRIPTION
The **DB1-local** half of the two-track learning design: aimee-server learns how to work with *this* user from their own turns and adapts — kept entirely local, never promoted to the shared KB. (The DB2/non-personal half, and the fail-closed promotion gate, are separate follow-ups.)

## What it does
- **Observe** — `memory_recall_handler` (`server_api.c`) is the per-turn seam the `UserPromptSubmit` hook already posts each prompt to, and it runs in the **DB1-owning aimee-server**. It now feeds the user's turn to `working_profile_autoobserve_from_feedback`, learning interaction preferences (verbosity, communication style, trust calibration) into the DB1-local working profile.
- **Inject** — `build_session_context` now renders the learned profile into the SessionStart context via `prompt_apply_working_profile` (which existed but was **never wired into prompt assembly**). The primary adapts to how the user works. Empty/disabled → renders nothing.
- **Enable** — `identity_working_profile_injection_enabled` now defaults on, as the master switch for both observe and inject. No-op for a fresh user (empty profile).

Both seams run in aimee-server where DB1 is present — no dependency on the KB, so none of the DB1-disabled-KB problem that sank the earlier conversation-scan approach.

## Verification
- **Core loop unit-tested against real DB1** (pre-existing `test_prompts`): `working_profile_autoobserve_from_feedback("please be terse…")` → committed `verbosity=terse`; `prompt_apply_working_profile` renders the `## Working Profile` block and respects the field allow-list. `unit-test-prompts` + `unit-test-config` pass with this change.
- **The two new call-sites are compile-verified and placed at the established production seams** (UserPromptSubmit→`/v1/memory/recall`→`memory_recall_handler`; SessionStart→`session_start_emit`→`build_session_context`).
- **Not driven through a live server end-to-end:** the dev sandbox reaps a persistent `aimee-server` and blocks `sleep`, so the full hook→server→DB1→session-context flow couldn't be exercised interactively. Every function it would call is independently tested, and both seams run in the DB1-present process. Recommend a smoke check in a real environment: send a turn containing "be terse", then confirm the next session's context carries the `## Working Profile` block.