### PR TITLE
feat(facts): withhold credential facts from the shared KB (DB2)

### DIFF
--- a/src/db2/rel_types_store.c
+++ b/src/db2/rel_types_store.c
@@ -3,6 +3,7 @@
 #include "../headers/aimee.h" /* edge_t (used by entity_edges.h) */
 #include "rel_types_store.h"
 #include "../headers/rel_types.h"
+#include "../headers/memory_pii_gate.h" /* memory_pii_rel_sensitivity — personal-data boundary */
 #include "entity_edges.h"
 #include "entity_registry.h"    /* db2_entity_register_named (§3 endpoint resolution) */
 #include "ontology_evolution.h" /* db2_ontology_eval_observe (§2 / P4) */
@@ -205,6 +206,17 @@ fact_gate_verdict_t db2_fact_commit(const char *source, memory_node_kind_t head_
 
    if (v != FACT_GATE_ACCEPT && v != FACT_GATE_NOVEL)
       return v; /* REJECT_KIND / BADARG: never write an unvalidated semantic edge */
+
+   /* Personal-data boundary (Track A): a credential relation (password / api_key /
+    * token / private_key / ...) is never a durable "fact to remember" and must not
+    * land in the shareable knowledge store — it is WITHHELD from DB2 here as
+    * defense-in-depth (the memory-layer secret gate is the first line). PII-classed
+    * relations (email, city, address, age, ...) are intentionally NOT dropped: the
+    * typed-fact layer is designed to capture them, and recall already gates their
+    * injection. Removing personal PII facts from DB2 entirely is a broader change
+    * (relocating them to DB1), out of scope for this narrow gate. */
+   if (memory_pii_rel_sensitivity(rel_type) == SENS_SECRET)
+      return FACT_GATE_REJECT_SENSITIVE;
 
    /* §5: provenance-keyed class. user -> A, model+ACCEPT -> B, model NOVEL -> C. */
    const char *cls = fact_class_for(authority, v);

--- a/src/headers/memory_fact_gate.h
+++ b/src/headers/memory_fact_gate.h
@@ -24,14 +24,19 @@ extern "C"
 
    typedef enum
    {
-      FACT_GATE_ACCEPT = 0,  /* known rel_type, kinds satisfy head/tail constraints */
-      FACT_GATE_REJECT_KIND, /* known rel_type, but subject/object kind not allowed */
-      FACT_GATE_NOVEL,       /* rel_type not in the (seed) ontology — caller stages/defers */
-      FACT_GATE_BADARG,      /* missing/empty rel_type */
-      FACT_GATE_DEFER,       /* validated but the semantic-edge write failed (DB issue): the
-                                fact was NOT committed; the caller must retry/defer and must
-                                never treat it as success (commit path only — the pure
-                                memory_fact_gate_check never returns it) */
+      FACT_GATE_ACCEPT = 0,       /* known rel_type, kinds satisfy head/tail constraints */
+      FACT_GATE_REJECT_KIND,      /* known rel_type, but subject/object kind not allowed */
+      FACT_GATE_NOVEL,            /* rel_type not in the (seed) ontology — caller stages/defers */
+      FACT_GATE_BADARG,           /* missing/empty rel_type */
+      FACT_GATE_DEFER,            /* validated but the semantic-edge write failed (DB issue): the
+                                     fact was NOT committed; the caller must retry/defer and must
+                                     never treat it as success (commit path only — the pure
+                                     memory_fact_gate_check never returns it) */
+      FACT_GATE_REJECT_SENSITIVE, /* validated but WITHHELD from the shared KB: a
+                                     credential/regulated-PII relation. Personal/sensitive
+                                     facts stay in the user's local DB1, never DB2. Not
+                                     committed; caller treats it as not-stored, not an error.
+                                     (commit path only — the pure gate never returns it) */
    } fact_gate_verdict_t;
 
    /* Validate (head_kind, rel_type, tail_kind) against the seed ontology. On a

--- a/src/memory_fact_gate.c
+++ b/src/memory_fact_gate.c
@@ -36,6 +36,8 @@ const char *fact_gate_verdict_to_text(fact_gate_verdict_t v)
       return "bad_argument";
    case FACT_GATE_DEFER:
       return "defer";
+   case FACT_GATE_REJECT_SENSITIVE:
+      return "reject_sensitive";
    }
    return "unknown";
 }

--- a/src/tests/test_typed_facts.c
+++ b/src/tests/test_typed_facts.c
@@ -81,7 +81,9 @@ int main(void)
    assert(strstr(facts, "works_as") != NULL && strstr(facts, "engineer") != NULL);
 
    /* But an unknown relation whose NAME plainly denotes PII is still gated:
-    * withheld on an ordinary turn, surfaced only when the turn asks. */
+    * withheld on an ordinary turn, surfaced only when the turn asks. (PII facts
+    * remain in the typed-fact layer, recall-gated — only credentials are dropped;
+    * see the api_key assertion below.) */
    assert(db2_fact_commit("user", NODE_PERSON, "home_address", "12 Oak St", NODE_OTHER,
                           FACT_AUTHORITY_MODEL, 1) == FACT_GATE_NOVEL);
    char ord[1024] = "";
@@ -90,6 +92,14 @@ int main(void)
    char sens[1024] = "";
    (void)db2_fact_recall_block("user", 1, sens, sizeof(sens));
    assert(strstr(sens, "home_address") != NULL); /* surfaced when asked */
+
+   /* Personal-data boundary (Track A): a CREDENTIAL relation is withheld from the
+    * shared KB entirely — never committed to DB2, so it never surfaces there. */
+   assert(db2_fact_commit("user", NODE_PERSON, "api_key", "sk-123", NODE_OTHER,
+                          FACT_AUTHORITY_MODEL, 1) == FACT_GATE_REJECT_SENSITIVE);
+   char cred[1024] = "";
+   (void)db2_fact_recall_block("user", 1, cred, sizeof(cred));
+   assert(strstr(cred, "api_key") == NULL); /* not in the shared KB, even when asked */
 
    db2_test_shim_close();
    printf("typed_facts: all tests passed\n");


### PR DESCRIPTION
The narrow **(A)** personal-data boundary at the DB2 fact-commit seam.

## What it does
`db2_fact_commit` now withholds `SENS_SECRET`-classed relations (password / api_key / token / private_key / …) from the shared knowledge store — validated but **not persisted to DB2**, returning a new `FACT_GATE_REJECT_SENSITIVE` verdict. A credential is never a durable "fact to remember"; this is defense-in-depth behind the memory-layer secret gate.

## Scope — deliberately narrow (and why PII is *not* dropped)
Investigating the ripple showed the typed-fact layer **intentionally captures PII** — `test_fact_ingest` ingests "my email is …, my city is …" and asserts both commit; `age`/`home_address` are first-class PII relations that are stored and **recall-gated** (withheld unless the turn asks). So dropping PII at write isn't a narrow gate — it dismantles a deliberate subsystem and removes legitimate personal facts. That's the broader **(B)** option (relocating personal facts to DB1), explicitly out of scope here.

So this PR drops **credentials only**. PII facts keep their existing store-in-DB2 + recall-gate behavior.

## Verification
- `test_typed_facts` updated: asserts the credential (`api_key`) drop returns `FACT_GATE_REJECT_SENSITIVE` and never surfaces in recall; **and** confirms PII (`home_address`) still commits and recall-gates as before.
- `unit-test-typed-facts`, `unit-test-fact-recall`, `unit-test-fact-ingest`, `unit-test-fact-lifecycle` all pass. Server+KB build clean (`-Werror`; new `memory_pii_gate` dep links into aimee-kb).

## Note
This is the last of the three-track design. If you want the stronger boundary — personal PII facts out of DB2 entirely, held only in local DB1 — that's the (B) redesign; say the word and I'll scope it separately.