### PR TITLE
feat(hosts): live host + GPU enumeration for the page-2 pickers

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -315,6 +315,40 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ModelsList' }
+  /hosts:
+    get:
+      summary: Enumerate hosts and their live GPU inventory
+      description: >
+        The local host plus every registered network host, each probed for its
+        GPUs (local via a device query, remote over ssh). Backs the setup
+        wizard's host + GPU pickers.
+      responses:
+        "200":
+          description: Hosts with per-host live GPU inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  hosts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name: { type: string }
+                        kind: { type: string, enum: [local, remote] }
+                        ip: { type: string }
+                        error: { type: string }
+                        gpus:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              index: { type: integer }
+                              name: { type: string }
+                              vendor: { type: string }
+                              vram_mb: { type: integer }
   /rules:
     get:
       summary: List active collaboration rules

--- a/src/Makefile
+++ b/src/Makefile
@@ -395,6 +395,7 @@ SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \
 SERVER_CMD_OBJS = $(OBJDIR)/server/cmd_session_lifecycle.o \
                   $(OBJDIR)/server/cmd_hooks_scope.o \
                   $(OBJDIR)/memory_redirect.o \
+                  $(OBJDIR)/hardware_probe.o \
                   $(OBJDIR)/server/server_session_start_stubs.o
 
 # kb_client objects — request-side glue from the daemon to the

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -652,6 +652,7 @@ static const struct
     {"hooks.post", "POST", "/v1/hooks/post"},
     {"hooks.pre", "POST", "/v1/hooks/pre"},
     {"hooks.session_start", "POST", "/v1/hooks/session_start"},
+    {"hosts.list", "GET", "/v1/hosts"},
     {"hud.status", "GET", "/v1/hud"},
     {"identity.diff", "POST", "/v1/identity/diff"},
     {"identity.show", "GET", "/v1/identity/show"},

--- a/src/hardware_probe.c
+++ b/src/hardware_probe.c
@@ -71,7 +71,8 @@ int hardware_probe_parse_amd_vram_bytes(const char *bytes_text, int *mb_out)
  * double-quotes inside, and no single-quotes, so the whole string can be wrapped
  * in single-quotes for the remote `ssh <target> '<cmd>'` without local expansion. */
 const char *const HARDWARE_GPU_PROBE_CMD =
-    "out=$(nvidia-smi --query-gpu=index,name,memory.total --format=csv,noheader,nounits 2>/dev/null); "
+    "out=$(nvidia-smi --query-gpu=index,name,memory.total --format=csv,noheader,nounits "
+    "2>/dev/null); "
     "if [ -n \"$out\" ]; then echo \"$out\" | awk 'NF{print $0\", nvidia\"}'; else "
     "i=0; for d in /sys/class/drm/card[0-9]*; do "
     "[ -e \"$d/device/vendor\" ] || continue; "
@@ -121,7 +122,8 @@ int hardware_probe_parse_gpu_csv_list(const char *csv, const char *vendor_hint,
                g->index = (int)strtol(idx, NULL, 10);
                g->vram_mb = (int)mb;
                snprintf(g->name, sizeof(g->name), "%s", name);
-               const char *v = (vendor && vendor[0]) ? vendor : (vendor_hint ? vendor_hint : "unknown");
+               const char *v =
+                   (vendor && vendor[0]) ? vendor : (vendor_hint ? vendor_hint : "unknown");
                snprintf(g->vendor, sizeof(g->vendor), "%s", v);
             }
          }

--- a/src/hardware_probe.c
+++ b/src/hardware_probe.c
@@ -65,6 +65,151 @@ int hardware_probe_parse_amd_vram_bytes(const char *bytes_text, int *mb_out)
    return *mb_out > 0 ? 0 : -1;
 }
 
+/* One shell probe, run locally (popen) and remotely (over ssh), emitting one CSV
+ * line per GPU: "<index>, <name>, <vram_mb>, <vendor>". NVIDIA via nvidia-smi
+ * (memory.total is already MiB with nounits); else AMD via /sys/class/drm. Only
+ * double-quotes inside, and no single-quotes, so the whole string can be wrapped
+ * in single-quotes for the remote `ssh <target> '<cmd>'` without local expansion. */
+const char *const HARDWARE_GPU_PROBE_CMD =
+    "out=$(nvidia-smi --query-gpu=index,name,memory.total --format=csv,noheader,nounits 2>/dev/null); "
+    "if [ -n \"$out\" ]; then echo \"$out\" | awk 'NF{print $0\", nvidia\"}'; else "
+    "i=0; for d in /sys/class/drm/card[0-9]*; do "
+    "[ -e \"$d/device/vendor\" ] || continue; "
+    "[ \"$(cat \"$d/device/vendor\" 2>/dev/null)\" = \"0x1002\" ] || continue; "
+    "n=$(cat \"$d/device/product_name\" 2>/dev/null); [ -n \"$n\" ] || n=\"AMD GPU\"; "
+    "b=$(cat \"$d/device/mem_info_vram_total\" 2>/dev/null); [ -n \"$b\" ] || b=0; "
+    "printf \"%s, %s, %s, amd\\n\" \"$i\" \"$n\" \"$((b/1048576))\"; "
+    "i=$((i+1)); done; fi";
+
+int hardware_probe_parse_gpu_csv_list(const char *csv, const char *vendor_hint,
+                                      hardware_gpu_list_t *out)
+{
+   if (!out)
+      return 0;
+   memset(out, 0, sizeof(*out));
+   if (!csv)
+      return 0;
+
+   char buf[8192];
+   snprintf(buf, sizeof(buf), "%s", csv);
+   char *saveptr = NULL;
+   char *line = strtok_r(buf, "\r\n", &saveptr);
+   while (line && out->count < HARDWARE_MAX_GPUS)
+   {
+      /* Parse "<index>, <name...>, <vram_mb>, <vendor>" from BOTH ends so a name
+       * that itself contains a comma still splits correctly: index is before the
+       * first comma, vendor after the last, vram before that, name is the middle. */
+      char *first = strchr(line, ',');
+      char *vend_c = strrchr(line, ',');
+      if (first && vend_c && vend_c > first)
+      {
+         *vend_c = '\0';
+         char *vendor = util_trim(vend_c + 1);
+         char *vram_c = strrchr(line, ',');
+         if (vram_c && vram_c > first)
+         {
+            *vram_c = '\0';
+            char *vram = util_trim(vram_c + 1);
+            *first = '\0';
+            char *idx = util_trim(line);
+            char *name = util_trim(first + 1);
+            char *e = NULL;
+            long mb = strtol(vram, &e, 10);
+            if (mb > 0 && mb <= 1024L * 1024L && name[0])
+            {
+               hardware_gpu_t *g = &out->gpus[out->count++];
+               g->index = (int)strtol(idx, NULL, 10);
+               g->vram_mb = (int)mb;
+               snprintf(g->name, sizeof(g->name), "%s", name);
+               const char *v = (vendor && vendor[0]) ? vendor : (vendor_hint ? vendor_hint : "unknown");
+               snprintf(g->vendor, sizeof(g->vendor), "%s", v);
+            }
+         }
+      }
+      line = strtok_r(NULL, "\r\n", &saveptr);
+   }
+   return out->count;
+}
+
+/* Drain a popen stream into buf (NUL-terminated), then parse the GPU CSV. */
+static int hp_read_stream_gpus(FILE *fp, hardware_gpu_list_t *out)
+{
+   char csv[8192] = {0};
+   size_t pos = 0;
+   while (pos + 1 < sizeof(csv) && fgets(csv + pos, (int)(sizeof(csv) - pos), fp))
+      pos = strlen(csv);
+   return hardware_probe_parse_gpu_csv_list(csv, NULL, out);
+}
+
+int hardware_probe_list_local(hardware_gpu_list_t *out)
+{
+   if (!out)
+      return 0;
+   memset(out, 0, sizeof(*out));
+   FILE *fp = popen(HARDWARE_GPU_PROBE_CMD, "r");
+   if (!fp)
+   {
+      snprintf(out->error, sizeof(out->error), "could not run local GPU probe");
+      return 0;
+   }
+   hp_read_stream_gpus(fp, out);
+   pclose(fp);
+   return out->count;
+}
+
+/* Reject an ssh target that isn't a plain user@host token, so it can't inject
+ * shell metacharacters into the popen'd ssh command line. */
+static int hp_ssh_target_ok(const char *t)
+{
+   if (!t || !t[0] || strlen(t) >= 256)
+      return 0;
+   for (const char *p = t; *p; p++)
+      if (!isalnum((unsigned char)*p) && !strchr("@._-:", *p))
+         return 0;
+   return 1;
+}
+
+int hardware_probe_list_remote(const char *ssh_target, int port, hardware_gpu_list_t *out)
+{
+   if (!out)
+      return 0;
+   memset(out, 0, sizeof(*out));
+   if (!hp_ssh_target_ok(ssh_target))
+   {
+      snprintf(out->error, sizeof(out->error), "invalid ssh target");
+      return 0;
+   }
+   const char *ssh_bin = getenv("AIMEE_SSH_BIN");
+   if (!ssh_bin || !ssh_bin[0])
+      ssh_bin = "ssh";
+   char port_flag[24] = "";
+   if (port > 0)
+      snprintf(port_flag, sizeof(port_flag), "-p %d ", port);
+
+   /* Single-quote the probe so the LOCAL shell passes it verbatim to ssh, which
+    * hands it to the REMOTE shell (where the $()/for expands). The probe contains
+    * no single-quote, so this wrapping is safe. */
+   char cmd[9216];
+   snprintf(cmd, sizeof(cmd),
+            "%s -o BatchMode=yes -o ConnectTimeout=8 -o StrictHostKeyChecking=accept-new %s%s '%s'",
+            ssh_bin, port_flag, ssh_target, HARDWARE_GPU_PROBE_CMD);
+   FILE *fp = popen(cmd, "r");
+   if (!fp)
+   {
+      snprintf(out->error, sizeof(out->error), "could not launch ssh to %s", ssh_target);
+      return 0;
+   }
+   hp_read_stream_gpus(fp, out);
+   int rc = pclose(fp);
+   /* A non-zero ssh exit with no GPUs means the host was unreachable / auth failed;
+    * surface it so the picker can show "unreachable" rather than "no GPU". (rc is
+    * the raw pclose status — portable across platforms without decoding it.) */
+   if (out->count == 0 && rc != 0)
+      snprintf(out->error, sizeof(out->error), "ssh probe of %s failed (unreachable or auth)",
+               ssh_target);
+   return out->count;
+}
+
 static int hp_detect_nvidia(hardware_probe_result_t *out)
 {
    FILE *fp = popen(

--- a/src/headers/hardware_probe.h
+++ b/src/headers/hardware_probe.h
@@ -16,10 +16,10 @@ typedef struct
 /* One discrete GPU on a host (an entry in an enumerated inventory). */
 typedef struct
 {
-   int index;         /* the vendor tool's device ordinal (nvidia-smi index / drm cardN) */
-   char name[128];    /* product name */
-   char vendor[32];   /* "nvidia" | "amd" */
-   int vram_mb;       /* total VRAM in MiB */
+   int index;       /* the vendor tool's device ordinal (nvidia-smi index / drm cardN) */
+   char name[128];  /* product name */
+   char vendor[32]; /* "nvidia" | "amd" */
+   int vram_mb;     /* total VRAM in MiB */
 } hardware_gpu_t;
 
 #define HARDWARE_MAX_GPUS 16

--- a/src/headers/hardware_probe.h
+++ b/src/headers/hardware_probe.h
@@ -13,7 +13,43 @@ typedef struct
    char error[256];
 } hardware_probe_result_t;
 
+/* One discrete GPU on a host (an entry in an enumerated inventory). */
+typedef struct
+{
+   int index;         /* the vendor tool's device ordinal (nvidia-smi index / drm cardN) */
+   char name[128];    /* product name */
+   char vendor[32];   /* "nvidia" | "amd" */
+   int vram_mb;       /* total VRAM in MiB */
+} hardware_gpu_t;
+
+#define HARDWARE_MAX_GPUS 16
+
+/* An enumerated GPU inventory for one host (local or remote). `error` is set (and
+ * count 0) when the probe could not run; count 0 with no error means "no GPU". */
+typedef struct
+{
+   int count;
+   hardware_gpu_t gpus[HARDWARE_MAX_GPUS];
+   char error[256];
+} hardware_gpu_list_t;
+
+/* The single shell probe run BOTH locally (popen) and remotely (over ssh) so one
+ * parser covers both. It prints one CSV line per GPU: "<index>, <name>, <vram_mb>"
+ * — NVIDIA via nvidia-smi, else AMD via /sys/class/drm. Empty output = no GPU. */
+extern const char *const HARDWARE_GPU_PROBE_CMD;
+
 void hardware_probe_result_init(hardware_probe_result_t *out);
+/* Parse the uniform "<index>, <name>, <vram_mb>" CSV (one GPU per line) into a
+ * list, ignoring blank/malformed lines. Returns the number of GPUs parsed. */
+int hardware_probe_parse_gpu_csv_list(const char *csv, const char *vendor_hint,
+                                      hardware_gpu_list_t *out);
+/* Enumerate the LOCAL host's GPUs by running HARDWARE_GPU_PROBE_CMD via popen. */
+int hardware_probe_list_local(hardware_gpu_list_t *out);
+/* Enumerate a REMOTE host's GPUs over ssh. `ssh_target` is "user@host" (or "host");
+ * `port` <= 0 uses the default. Read-only (a device query); BatchMode, no prompts.
+ * The AIMEE_SSH_BIN env override (shared with the ssh delegate backend) lets tests
+ * substitute a fixture. On ssh/transport failure, out->error is set and count 0. */
+int hardware_probe_list_remote(const char *ssh_target, int port, hardware_gpu_list_t *out);
 int hardware_probe_parse_nvidia_csv(const char *csv, hardware_probe_result_t *out);
 int hardware_probe_parse_amd_vram_bytes(const char *bytes_text, int *mb_out);
 int hardware_probe_detect(hardware_probe_result_t *out);

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -343,6 +343,7 @@ int handle_wm_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_wm_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_wm_context(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_primary_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_hosts_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_primary_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_primary_clear(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_work_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1423,6 +1423,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"wm.context", handle_wm_context},
     /* Per-session primary agent selection */
     {"primary.set", handle_primary_set},
+    {"hosts.list", handle_hosts_list},
     {"primary.get", handle_primary_get},
     {"primary.clear", handle_primary_clear},
     /* Work queue */

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -71,6 +71,7 @@ const method_policy_t method_registry[] = {
     {"audit.seal", CAP_TOOL_EXECUTE, "WORM audit seal snapshot"},
     {"audit.snapshot", CAP_TOOL_EXECUTE, "WORM audit metric snapshot"},
     {"plugin.list", CAP_DASHBOARD_READ, "plugin list"},
+    {"hosts.list", CAP_DASHBOARD_READ, "host + GPU inventory"},
     {"plugin.enable", CAP_TOOL_EXECUTE, "enable plugin"},
     {"plugin.disable", CAP_TOOL_EXECUTE, "disable plugin"},
     {"lsp.*", CAP_DASHBOARD_READ, "lsp status"},

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -1827,6 +1827,7 @@ static const http_route_t g_v1_routes[] = {
      * CAP_SESSION_READ). Mutating skill and work methods are not exposed here. */
     {"GET", "/v1/skills", NULL, RM_EXACT, "skill.list", 0, rh_dispatch_op},
     {"POST", "/v1/skills/show", NULL, RM_EXACT, "skill.show", 0, rh_dispatch_op},
+    {"GET", "/v1/hosts", NULL, RM_EXACT, "hosts.list", 0, rh_dispatch_op},
     {"GET", "/v1/work", NULL, RM_EXACT, "work.list", 0, rh_dispatch_op},
     {"GET", "/v1/work/stats", NULL, RM_EXACT, "work.stats", 0, rh_dispatch_op},
 

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -23,8 +23,8 @@
 #include "dogfood.h"
 #include "commands.h"
 #include "platform_path.h"
-#include "server_http.h"  /* session_primary_set/get/clear */
-#include "agent_config.h" /* agent_load_config / agent_find */
+#include "server_http.h"    /* session_primary_set/get/clear */
+#include "agent_config.h"   /* agent_load_config / agent_find */
 #include "hardware_probe.h" /* hardware_probe_list_local/remote — host GPU inventory */
 #include <errno.h>
 #include <unistd.h>

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -25,7 +25,9 @@
 #include "platform_path.h"
 #include "server_http.h"  /* session_primary_set/get/clear */
 #include "agent_config.h" /* agent_load_config / agent_find */
+#include "hardware_probe.h" /* hardware_probe_list_local/remote — host GPU inventory */
 #include <errno.h>
+#include <unistd.h>
 #include <pthread.h>
 #include <stdatomic.h>
 #include <sys/stat.h>
@@ -1175,6 +1177,77 @@ int handle_wm_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
 /* --- Per-session primary agent handlers (mirror the /v1/sessions/<id>/primary
  *     HTTP routes; both transports share the in-memory store). --- */
+
+/* Attach a host's enumerated GPU inventory (and any probe error) to its JSON. */
+static void hosts_add_gpus(cJSON *host, const hardware_gpu_list_t *gl)
+{
+   cJSON *garr = cJSON_CreateArray();
+   for (int i = 0; i < gl->count; i++)
+   {
+      cJSON *g = cJSON_CreateObject();
+      cJSON_AddNumberToObject(g, "index", gl->gpus[i].index);
+      jo_add_str(g, "name", gl->gpus[i].name);
+      jo_add_str(g, "vendor", gl->gpus[i].vendor);
+      cJSON_AddNumberToObject(g, "vram_mb", gl->gpus[i].vram_mb);
+      cJSON_AddItemToArray(garr, g);
+   }
+   cJSON_AddItemToObject(host, "gpus", garr);
+   if (gl->error[0])
+      jo_add_str(host, "error", gl->error);
+}
+
+/* hosts.list — enumerate the hosts the wizard can place a local LLM tier on, each
+ * with its LIVE GPU inventory: the local host (aimee-server's own box, probed via
+ * popen) plus every registered network host (probed over ssh). Read-only. Backs
+ * GET /v1/hosts -> the page-2 host + GPU pickers. */
+int handle_hosts_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   (void)req;
+   cJSON *resp = jo_ok();
+   cJSON *arr = cJSON_CreateArray();
+
+   /* Local host. */
+   {
+      cJSON *h = cJSON_CreateObject();
+      char hn[128] = "";
+      if (gethostname(hn, sizeof(hn)) != 0 || !hn[0])
+         snprintf(hn, sizeof(hn), "local");
+      jo_add_str(h, "name", hn);
+      jo_add_str(h, "kind", "local");
+      hardware_gpu_list_t gl;
+      hardware_probe_list_local(&gl);
+      hosts_add_gpus(h, &gl);
+      cJSON_AddItemToArray(arr, h);
+   }
+
+   /* Registered network hosts, probed live over ssh. */
+   agent_config_t cfg;
+   if (agent_load_config(&cfg) == 0)
+   {
+      for (int i = 0; i < cfg.network.host_count; i++)
+      {
+         const agent_net_host_t *nh = &cfg.network.hosts[i];
+         cJSON *h = cJSON_CreateObject();
+         jo_add_str(h, "name", nh->name);
+         jo_add_str(h, "kind", "remote");
+         if (nh->ip[0])
+            jo_add_str(h, "ip", nh->ip);
+         char target[128];
+         if (nh->user[0] && nh->ip[0])
+            snprintf(target, sizeof(target), "%s@%s", nh->user, nh->ip);
+         else
+            snprintf(target, sizeof(target), "%s", nh->ip[0] ? nh->ip : nh->name);
+         hardware_gpu_list_t gl;
+         hardware_probe_list_remote(target, nh->port, &gl);
+         hosts_add_gpus(h, &gl);
+         cJSON_AddItemToArray(arr, h);
+      }
+   }
+
+   cJSON_AddItemToObject(resp, "hosts", arr);
+   return send_and_free(conn, resp);
+}
 
 int handle_primary_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {

--- a/src/tests/test_hardware_probe.c
+++ b/src/tests/test_hardware_probe.c
@@ -84,10 +84,9 @@ static void test_gpu_csv_list_parse(void)
    hardware_gpu_list_t gl;
 
    /* Two NVIDIA GPUs (the uniform probe appends the vendor field). */
-   int n = hardware_probe_parse_gpu_csv_list(
-       "0, NVIDIA GeForce RTX 4090, 24564, nvidia\n"
-       "1, NVIDIA GeForce RTX 3060, 12288, nvidia\n",
-       NULL, &gl);
+   int n = hardware_probe_parse_gpu_csv_list("0, NVIDIA GeForce RTX 4090, 24564, nvidia\n"
+                                             "1, NVIDIA GeForce RTX 3060, 12288, nvidia\n",
+                                             NULL, &gl);
    assert(n == 2 && gl.count == 2);
    assert(gl.gpus[0].index == 0 && gl.gpus[0].vram_mb == 24564);
    assert(strcmp(gl.gpus[0].name, "NVIDIA GeForce RTX 4090") == 0);

--- a/src/tests/test_hardware_probe.c
+++ b/src/tests/test_hardware_probe.c
@@ -79,9 +79,42 @@ static void test_cached_no_gpu_is_terminal(void)
    db1_shutdown();
 }
 
+static void test_gpu_csv_list_parse(void)
+{
+   hardware_gpu_list_t gl;
+
+   /* Two NVIDIA GPUs (the uniform probe appends the vendor field). */
+   int n = hardware_probe_parse_gpu_csv_list(
+       "0, NVIDIA GeForce RTX 4090, 24564, nvidia\n"
+       "1, NVIDIA GeForce RTX 3060, 12288, nvidia\n",
+       NULL, &gl);
+   assert(n == 2 && gl.count == 2);
+   assert(gl.gpus[0].index == 0 && gl.gpus[0].vram_mb == 24564);
+   assert(strcmp(gl.gpus[0].name, "NVIDIA GeForce RTX 4090") == 0);
+   assert(strcmp(gl.gpus[0].vendor, "nvidia") == 0);
+   assert(gl.gpus[1].index == 1 && gl.gpus[1].vram_mb == 12288);
+
+   /* AMD, and a name that itself contains a comma must still split correctly. */
+   n = hardware_probe_parse_gpu_csv_list("0, Radeon RX 7900 XTX, Rev A, 24560, amd\n", NULL, &gl);
+   assert(n == 1);
+   assert(strcmp(gl.gpus[0].name, "Radeon RX 7900 XTX, Rev A") == 0);
+   assert(gl.gpus[0].vram_mb == 24560);
+   assert(strcmp(gl.gpus[0].vendor, "amd") == 0);
+
+   /* Blank + malformed lines are skipped; empty input => no GPUs, no crash. */
+   n = hardware_probe_parse_gpu_csv_list("\n  \ngarbage\n0, x, notanumber, nvidia\n", NULL, &gl);
+   assert(n == 0 && gl.count == 0);
+   assert(hardware_probe_parse_gpu_csv_list("", NULL, &gl) == 0);
+
+   /* vendor_hint fills in when the vendor field is present but empty. */
+   n = hardware_probe_parse_gpu_csv_list("0, Some GPU, 8192, \n", "amd", &gl);
+   assert(n == 1 && gl.gpus[0].vram_mb == 8192 && strcmp(gl.gpus[0].vendor, "amd") == 0);
+}
+
 int main(void)
 {
    test_nvidia_csv_parse();
+   test_gpu_csv_list_parse();
    test_amd_vram_parse();
    test_vram_context_tiers();
    test_model_estimate();

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -807,6 +807,10 @@ int handle_primary_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "primary.set");
 }
+int handle_hosts_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "hosts.list");
+}
 int handle_primary_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "primary.get");

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -95,6 +95,7 @@ var methodRoutes = map[string]methodRoute{
 	"agent.disable":          {http.MethodPost, "/v1/agent/disable"},
 	"agent.probe":            {http.MethodPost, "/v1/agent/probe"},
 	"agent.set":              {http.MethodPost, "/v1/agent/set"},
+	"hosts.list":             {http.MethodGet, "/v1/hosts"},
 	// Subscription-OAuth setup (Claude / Codex "sign in with your plan").
 	"agent.cli_oauth_start":    {http.MethodPost, "/v1/agent/cli_oauth_start"},
 	"agent.cli_oauth_code":     {http.MethodPost, "/v1/agent/cli_oauth_code"},

--- a/webchat/hosts.go
+++ b/webchat/hosts.go
@@ -1,0 +1,33 @@
+package main
+
+// hosts.go: the page-2 host + GPU picker data source. GET /api/hosts proxies the
+// aimee-server `hosts.list` op (GET /v1/hosts), which enumerates the local host and
+// every registered network host, each with its LIVE GPU inventory (local via a
+// popen probe, remote over ssh). Read-only; goes over the filesystem-trusted UDS
+// (no bearer), like the agent-roster proxies.
+//
+// NOTE: remote hosts are probed sequentially server-side, each bounded by ssh's
+// ConnectTimeout. Reachable hosts answer in well under the socket-call timeout;
+// several simultaneously-unreachable remote hosts could exceed it. Parallelizing
+// the server-side probe (or a longer proxy timeout) is a follow-up if that bites.
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// handleHosts proxies GET /api/hosts -> the hosts.list op (GET /v1/hosts). The
+// server's {status,hosts:[...]} envelope is returned verbatim.
+func (s *server) handleHosts(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	resp, err := s.socketCallForRequest(r, map[string]any{"method": "hosts.list"})
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "hosts: aimee-server unavailable")
+		return
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/webchat/hosts_test.go
+++ b/webchat/hosts_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleHostsProxiesV1 checks GET /api/hosts forwards to GET /v1/hosts and
+// relays the server's {status,hosts:[...]} envelope (host + live GPU inventory).
+func TestHandleHostsProxiesV1(t *testing.T) {
+	var method, path string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/hosts", func(w http.ResponseWriter, r *http.Request) {
+		method, path = r.Method, r.URL.Path
+		fmt.Fprint(w, `{"status":"ok","hosts":[`+
+			`{"name":"smoothnas","kind":"remote","ip":"192.168.1.254","gpus":[`+
+			`{"index":0,"name":"Radeon RX 7900 XTX","vendor":"amd","vram_mb":24560}]},`+
+			`{"name":"local","kind":"local","gpus":[]}]}`)
+	})
+	s := &server{cfg: startFakeV1(t, mux)}
+
+	rr := httptest.NewRecorder()
+	s.handleHosts(rr, httptest.NewRequest(http.MethodGet, "/api/hosts", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%q", rr.Code, rr.Body.String())
+	}
+	if method != http.MethodGet || path != "/v1/hosts" {
+		t.Fatalf("forwarded %s %s, want GET /v1/hosts", method, path)
+	}
+	var out struct {
+		Hosts []struct {
+			Name string `json:"name"`
+			Kind string `json:"kind"`
+			GPUs []struct {
+				Name   string `json:"name"`
+				Vendor string `json:"vendor"`
+				VRAMMB int    `json:"vram_mb"`
+			} `json:"gpus"`
+		} `json:"hosts"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode relay: %v (body=%q)", err, rr.Body.String())
+	}
+	if len(out.Hosts) != 2 {
+		t.Fatalf("hosts=%d want 2", len(out.Hosts))
+	}
+	if out.Hosts[0].Name != "smoothnas" || len(out.Hosts[0].GPUs) != 1 ||
+		out.Hosts[0].GPUs[0].VRAMMB != 24560 || out.Hosts[0].GPUs[0].Vendor != "amd" {
+		t.Fatalf("remote host/GPU not relayed: %+v", out.Hosts[0])
+	}
+}
+
+// TestHandleHostsRejectsNonGET: only GET is allowed.
+func TestHandleHostsRejectsNonGET(t *testing.T) {
+	s := &server{cfg: &config{}}
+	rr := httptest.NewRecorder()
+	s.handleHosts(rr, httptest.NewRequest(http.MethodPost, "/api/hosts", nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("code=%d want 405", rr.Code)
+	}
+}

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -221,6 +221,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 
 	// Live endpoints backed by aimee-server socket
 	mux.HandleFunc("/api/agents", s.requireAuth(s.handleAgents))
+	mux.HandleFunc("/api/hosts", s.requireAuth(s.handleHosts))
 	mux.HandleFunc("GET /api/agents/stats", s.requireAuth(s.handleAgentStats))
 	mux.HandleFunc("POST /api/agents/add", s.requireAuth(s.handleAgentAdd))
 	mux.HandleFunc("POST /api/agents/remove", s.requireAuth(s.agentOpHandler("agent.remove")))


### PR DESCRIPTION
**Phase 1** of the page-2 LLM-backend wizard: the data source for the **host + GPU pickers**. `GET /api/hosts` -> `GET /v1/hosts` (`hosts.list` op) enumerates every host the wizard can place a local LLM tier on, each with its **live GPU inventory**.

### How it works
- **hardware_probe**: one uniform shell probe (`HARDWARE_GPU_PROBE_CMD`) emitting one CSV line per GPU — `"<index>, <name>, <vram_mb>, <vendor>"` — NVIDIA via `nvidia-smi`, else AMD via `/sys/class/drm`. It runs **both** locally (`popen`) and remotely (over `ssh`), so one parser (`hardware_probe_parse_gpu_csv_list`) covers both. `hardware_probe_list_local` / `_list_remote` build a multi-GPU `hardware_gpu_list_t` (the existing probe returned only the single biggest GPU).
- **remote probe**: read-only, `BatchMode` + `ConnectTimeout` + `StrictHostKeyChecking=accept-new`, honors `AIMEE_SSH_BIN` (the ssh-backend test hook), and validates the ssh target so it can't inject shell metacharacters.
- **server**: `handle_hosts_list` returns `{hosts:[{name,kind,ip?,gpus:[{index,name,vendor,vram_mb}],error?}]}` — the local host (aimee-server's box) plus each registered `network.hosts` entry probed over ssh. Registered as `hosts.list` + `GET /v1/hosts`; `cli_v1_routes` regenerated.
- **webchat**: `GET /api/hosts` proxies over the trusted UDS (no bearer), like the agent-roster proxies.
- **link**: `hardware_probe.o` added to the server object set (was CLI/CMD-only).

### Tests
`parse_gpu_csv_list` unit test (nvidia/amd, name-with-comma, malformed, vendor-hint) in `test_hardware_probe`; `/api/hosts` proxy relay + method-guard tests in webchat. CLI + server + webchat all build locally; `cli-v1-routes` + `v1-method-coverage` checks pass.

### Known limitation
Remote hosts are probed **sequentially** server-side (noted in source). Reachable hosts answer well under the socket timeout; several simultaneously-unreachable remote hosts could exceed it — parallelizing the server-side probe is a follow-up if it bites.

### Validation-pending
The **live ssh probe against real remote GPU hosts** is not exercised here (no sshd/GPU in this env) — only the CSV parsing, op wiring, and proxy are covered by tests.

Next: Phase 2 (per-role backend config schema + remove LLM auto-deploy + embedder dim deferral), then Phase 3 (the page-2 UI consuming `/api/hosts`).
