### PR TITLE
fix(workflow): pause reason names the actual cap, not budget_exceeded

### DIFF
--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -16,7 +16,9 @@ typedef struct
    char state[24];        /* active | accepted | rejected | abandoned */
    char mode[16];         /* interactive | autonomous */
    char pause_reason[32]; /* "" | pending_human | panel_degraded | budget_exceeded |
-                             panel_unreachable */
+                             panel_unreachable | ci_pending | merge_pending |
+                             turn_cap_exceeded | wall_cap_exceeded | stuck |
+                             operator_paused */
    char paused_state[64];
    char content_hash[72];
    /* The forge ref returned by g_forge->open (PR number/url), opaque to the

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -198,8 +198,9 @@ int main(void)
    }
 
    /* A7: per-run turn cap (WP-5) — once the cumulative audit-event count reaches
-    * the cap, an autonomous run parks budget_exceeded BEFORE advancing further
-    * (so a runaway loop can't burn unbounded turns). */
+    * the cap, an autonomous run parks turn_cap_exceeded BEFORE advancing further
+    * (so a runaway loop can't burn unbounded turns). The pause reason names the
+    * ACTUAL breach (the turn cap), not the unrelated dollar cost cap. */
    {
       char id[80] = "", err[256] = "";
       assert(wfe_work_item_create("auto", "cap1", "cap1", "autonomous", id, err, sizeof err) == 0);
@@ -211,7 +212,7 @@ int main(void)
       db1_work_item_t wi;
       assert(db1_work_item_get(id, &wi) == 1);
       assert(strcmp(wi.state, "active") == 0);
-      assert(strcmp(wi.pause_reason, "budget_exceeded") == 0);
+      assert(strcmp(wi.pause_reason, "turn_cap_exceeded") == 0);
    }
 
    /* A8: server-side cost estimate (WP-5) — wall-clock seconds * rate; negative

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -45,11 +45,14 @@ static long wfe_env_long(const char *name, long def)
    return n;
 }
 
-/* Park an active, not-yet-parked autonomous work item with budget_exceeded and
- * audit the reason. Returns 0 on a clean park, 1 if it was already parked (still
+/* Park an active, not-yet-parked autonomous work item at a runaway-backstop cap
+ * and audit the reason. `reason` is the accurate pause token for the breach that
+ * fired (turn_cap_exceeded / wall_cap_exceeded — NOT the dollar cost cap, which
+ * is a separate ceiling that parks budget_exceeded); `why` is the human-readable
+ * audit detail. Returns 0 on a clean park, 1 if it was already parked (still
  * audits the breach), -1 if the row could not be read (caller hard-stops — a
  * safety rail must not silently no-op on a read failure). */
-static int wfe_autonomy_park_budget(const char *work_item_id, const char *why)
+static int wfe_autonomy_park_cap(const char *work_item_id, const char *reason, const char *why)
 {
    db1_work_item_t wi;
    if (db1_work_item_get(work_item_id, &wi) != 1)
@@ -58,10 +61,10 @@ static int wfe_autonomy_park_budget(const char *work_item_id, const char *why)
    {
       /* already parked (e.g. at a gate): record the breach for audit, don't
        * overwrite the existing pause reason. */
-      db1_lifecycle_event_add(work_item_id, wi.current_stage, "budget", "engine", why, "", 0);
+      db1_lifecycle_event_add(work_item_id, wi.current_stage, "cap", "engine", why, "", 0);
       return 1;
    }
-   db1_work_item_set_pause(work_item_id, "budget_exceeded", wi.current_stage);
+   db1_work_item_set_pause(work_item_id, reason, wi.current_stage);
    db1_lifecycle_event_add(work_item_id, wi.current_stage, "pause", "engine", why, "", 0);
    return 0;
 }
@@ -95,7 +98,9 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
     * because one advance emits several events it is a deliberately CONSERVATIVE upper
     * bound on advances — fine for a runaway backstop. max_wall bounds THIS resume's
     * wall-clock (a single hung resume); total run time is bounded transitively by the
-    * cumulative turn cap. On breach -> park budget_exceeded (never silently continue).
+    * cumulative turn cap. On breach -> park with the accurate cap reason
+    * (turn_cap_exceeded / wall_cap_exceeded); never silently continue. These are
+    * runaway backstops, NOT the dollar cost cap (which parks budget_exceeded).
     * Env-overridable; a bad override falls back to the default. */
    long max_turns = wfe_env_long("AIMEE_AUTONOMY_MAX_TURNS", 300);
    long max_wall = wfe_env_long("AIMEE_AUTONOMY_MAX_WALL_SECS", 1800);
@@ -120,23 +125,33 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
       db1_lifecycle_event_t *evs = NULL;
       int nev = db1_lifecycle_event_list(work_item_id, &evs);
       free(evs);
-      const char *breach = NULL;
+      const char *breach = NULL;    /* human-readable audit detail */
+      const char *reason = NULL;    /* accurate pause token for the breach */
       if (nev < 0)
+      {
          breach = "turn cap: audit log unreadable"; /* can't evaluate -> fail closed */
+         reason = "turn_cap_exceeded";
+      }
       else if ((long)nev >= max_turns)
+      {
          breach = "turn cap reached";
+         reason = "turn_cap_exceeded";
+      }
       else
       {
          struct timespec ts;
          clock_gettime(CLOCK_MONOTONIC, &ts);
          if ((long)(ts.tv_sec - ts0.tv_sec) >= max_wall)
+         {
             breach = "wall-clock cap reached (this resume)";
+            reason = "wall_cap_exceeded";
+         }
       }
       if (breach)
       {
-         if (wfe_autonomy_park_budget(work_item_id, breach) < 0)
+         if (wfe_autonomy_park_cap(work_item_id, reason, breach) < 0)
          {
-            snprintf(err, errlen, "autonomy: budget breach but work item unreadable to park");
+            snprintf(err, errlen, "autonomy: run cap breach but work item unreadable to park");
             return -1; /* surface; never leave a breached run un-parked + claim success */
          }
          return 0;

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -125,8 +125,8 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
       db1_lifecycle_event_t *evs = NULL;
       int nev = db1_lifecycle_event_list(work_item_id, &evs);
       free(evs);
-      const char *breach = NULL;    /* human-readable audit detail */
-      const char *reason = NULL;    /* accurate pause token for the breach */
+      const char *breach = NULL; /* human-readable audit detail */
+      const char *reason = NULL; /* accurate pause token for the breach */
       if (nev < 0)
       {
          breach = "turn cap: audit log unreadable"; /* can't evaluate -> fail closed */

--- a/src/workflow/wfe_engine.c
+++ b/src/workflow/wfe_engine.c
@@ -183,6 +183,10 @@ static const char *pause_name(wfe_pause_reason_t r)
       return "ci_pending";
    case WFE_PAUSE_MERGE_PENDING:
       return "merge_pending";
+   case WFE_PAUSE_TURN_CAP:
+      return "turn_cap_exceeded";
+   case WFE_PAUSE_WALL_CAP:
+      return "wall_cap_exceeded";
    default:
       return "";
    }
@@ -204,6 +208,10 @@ static wfe_pause_reason_t pause_from_name(const char *s)
       return WFE_PAUSE_CI_PENDING;
    if (strcmp(s, "merge_pending") == 0)
       return WFE_PAUSE_MERGE_PENDING;
+   if (strcmp(s, "turn_cap_exceeded") == 0)
+      return WFE_PAUSE_TURN_CAP;
+   if (strcmp(s, "wall_cap_exceeded") == 0)
+      return WFE_PAUSE_WALL_CAP;
    return WFE_PAUSE_NONE;
 }
 

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -79,11 +79,15 @@ typedef enum
    WFE_PAUSE_NONE = 0,
    WFE_PAUSE_PENDING_HUMAN,
    WFE_PAUSE_PANEL_DEGRADED,
-   WFE_PAUSE_BUDGET_EXCEEDED,
+   WFE_PAUSE_BUDGET_EXCEEDED, /* the dollar cost cap (WFE_STEP: real spend ceiling) */
    WFE_PAUSE_PANEL_UNREACHABLE,
    WFE_PAUSE_CI_PENDING,   /* gate.ci: CI still running / not yet conclusive */
-   WFE_PAUSE_MERGE_PENDING /* check.mergeable / merge: forge merge state could not
-                            * be determined (transient/unknown) -- re-drive later */
+   WFE_PAUSE_MERGE_PENDING, /* check.mergeable / merge: forge merge state could not
+                             * be determined (transient/unknown) -- re-drive later */
+   WFE_PAUSE_TURN_CAP,  /* autonomy runaway backstop: cumulative audit-event
+                         * (turn) cap reached -- NOT a spend issue */
+   WFE_PAUSE_WALL_CAP   /* autonomy runaway backstop: this resume exceeded its
+                         * wall-clock ceiling -- NOT a spend issue */
 } wfe_pause_reason_t;
 
 /* Failure taxonomy (Phase-C Q4): how the autonomy run loop should react to a

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -81,13 +81,13 @@ typedef enum
    WFE_PAUSE_PANEL_DEGRADED,
    WFE_PAUSE_BUDGET_EXCEEDED, /* the dollar cost cap (WFE_STEP: real spend ceiling) */
    WFE_PAUSE_PANEL_UNREACHABLE,
-   WFE_PAUSE_CI_PENDING,   /* gate.ci: CI still running / not yet conclusive */
+   WFE_PAUSE_CI_PENDING,    /* gate.ci: CI still running / not yet conclusive */
    WFE_PAUSE_MERGE_PENDING, /* check.mergeable / merge: forge merge state could not
                              * be determined (transient/unknown) -- re-drive later */
-   WFE_PAUSE_TURN_CAP,  /* autonomy runaway backstop: cumulative audit-event
-                         * (turn) cap reached -- NOT a spend issue */
-   WFE_PAUSE_WALL_CAP   /* autonomy runaway backstop: this resume exceeded its
-                         * wall-clock ceiling -- NOT a spend issue */
+   WFE_PAUSE_TURN_CAP,      /* autonomy runaway backstop: cumulative audit-event
+                             * (turn) cap reached -- NOT a spend issue */
+   WFE_PAUSE_WALL_CAP       /* autonomy runaway backstop: this resume exceeded its
+                             * wall-clock ceiling -- NOT a spend issue */
 } wfe_pause_reason_t;
 
 /* Failure taxonomy (Phase-C Q4): how the autonomy run loop should react to a


### PR DESCRIPTION
## Problem
The autonomy runaway backstop (`wfe_autonomy_run`) parked **every** breach as `budget_exceeded` — including the two that have nothing to do with spend:

- **turn cap** — cumulative audit-event ceiling (`AIMEE_AUTONOMY_MAX_TURNS`, default 300)
- **wall-clock cap** — this-resume wall ceiling (`AIMEE_AUTONOMY_MAX_WALL_SECS`, default 1800s)

A run parked at **\$0.37** — far under the real \$5.00 dollar cost cap — reported `budget_exceeded`. The error didn't say what actually happened. (Surfaced while investigating why triggered proposals parked; the "budget" label sent the diagnosis down the wrong path.)

## Fix
Each backstop now parks with its **own honest reason**:

| breach | pause reason |
|---|---|
| turn cap reached / audit log unreadable | `turn_cap_exceeded` |
| this resume exceeded its wall ceiling | `wall_cap_exceeded` |
| genuine dollar cost cap (`wfe_engine.c`) | `budget_exceeded` *(unchanged — really is spend)* |

- Added `WFE_PAUSE_TURN_CAP` / `WFE_PAUSE_WALL_CAP` to the typed `wfe_pause_reason_t` enum and wired both mappers (`pause_name` / `pause_from_name`), so the stored string round-trips to a real pause reason instead of collapsing to `WFE_PAUSE_NONE`.
- Both new reasons remain operator-resumable (only `pending_human` is gated behind Approve/Reject) and pass through the workflow API to the GUI as-is.
- Renamed `wfe_autonomy_park_budget` → `wfe_autonomy_park_cap` (it now takes the accurate reason token); the "already parked" audit event tag is `cap` rather than `budget`.
- Updated the `wfe_store.h` `pause_reason` inventory comment and the A7 turn-cap test to assert `turn_cap_exceeded`.

## Verification
- `aimee-core` (contains all three changed `.c` files) builds clean under `-Wall -Wextra -Werror`.
- `test_wfe_advance`, `test_wfe_enforce` pass.
- The A7 turn-cap assertion updated to the accurate token. (`test_wfe_autonomy.c` is not currently wired into CTest — pre-existing; the assertion is corrected regardless.)

No behavior change beyond the reported reason: the "is it parked" gate keys on a non-empty `pause_reason`, which is preserved.