### PR TITLE
fix(memory): heap-migrate large memory_t[] search scratch to fix stack overflow

### DIFF
--- a/src/headers/memory_core_internal.h
+++ b/src/headers/memory_core_internal.h
@@ -5,11 +5,24 @@
  * build. Unstable/private. */
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <time.h>
 #include "aimee.h"
 #include "config.h"
 #include "memory.h"
 #include "cJSON.h"
+
+/* Auto-free a heap pointer on scope exit. The memory-search chain declares large
+ * memory_t[] scratch buffers (sizeof(memory_t) ~4.4KB, e.g. [128] = 566KB); with
+ * -flto inlining the deep query chain into ~1MB frames these nest and overflow the
+ * stack (worker threads especially). Moving them to the heap keeps the chain off
+ * the stack without threading free() through every early return. */
+static inline void memory_autofree_impl(void *p)
+{
+   free(*(void **)p);
+}
+#define MEMORY_AUTOFREE __attribute__((cleanup(memory_autofree_impl)))
+
 /* memory_core real-branch shared types (moved from memory_core.c #else) */
 typedef enum
 {

--- a/src/memory_core_search.c
+++ b/src/memory_core_search.c
@@ -356,8 +356,10 @@ static int memory_collect_via(memory_db2_collect_fn collect, const char *term, i
 {
    if (!term || !term[0] || !out || count >= max)
       return count;
-   memory_t scratch[64];
-   int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+   MEMORY_AUTOFREE memory_t *scratch = calloc(64, sizeof(*scratch));
+   if (!scratch)
+      return count;
+   int cap = 64;
    int got = collect(term, limit, scratch, cap);
    for (int i = 0; i < got && count < max; i++)
       count = memory_append_unique(out, count, max, &scratch[i]);
@@ -402,8 +404,10 @@ int memory_collect_chunk_matches(const char *query, int limit, memory_t *out, in
 {
    if (!query || !query[0] || !out || count >= max)
       return count;
-   memory_t scratch[64];
-   int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+   MEMORY_AUTOFREE memory_t *scratch = calloc(64, sizeof(*scratch));
+   if (!scratch)
+      return count;
+   int cap = 64;
    config_t cm_cfg;
    config_load(&cm_cfg);
    const char *embed_cmd = config_embedding_command(&cm_cfg, NULL);
@@ -429,8 +433,10 @@ int memory_collect_unit_matches(const char *query, int limit, memory_t *out, int
    }
    if (useful < 2)
       return count;
-   memory_t scratch[64];
-   int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+   MEMORY_AUTOFREE memory_t *scratch = calloc(64, sizeof(*scratch));
+   if (!scratch)
+      return count;
+   int cap = 64;
    config_t mc_cfg;
    config_load(&mc_cfg);
    const char *embed_cmd = config_embedding_command(&mc_cfg, NULL);

--- a/src/memory_core_search_b.c
+++ b/src/memory_core_search_b.c
@@ -1092,9 +1092,11 @@ int memory_find_facts_lexical_fallback(const char *query, const char *scope_type
    if (limit > max)
       limit = max;
 
-   memory_t scratch[64];
+   MEMORY_AUTOFREE memory_t *scratch = calloc(64, sizeof(*scratch));
+   if (!scratch)
+      return 0;
    int fetch_limit = limit * 4;
-   int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+   int cap = 64;
    if (fetch_limit < limit)
       fetch_limit = limit;
    if (fetch_limit > cap)
@@ -1138,9 +1140,11 @@ int memory_find_facts_visible_lexical_fallback(const char *query, const char *wo
    if (limit > max)
       limit = max;
 
-   memory_t scratch[64];
+   MEMORY_AUTOFREE memory_t *scratch = calloc(64, sizeof(*scratch));
+   if (!scratch)
+      return 0;
    int fetch_limit = limit * 4;
-   int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+   int cap = 64;
    if (fetch_limit < limit)
       fetch_limit = limit;
    if (fetch_limit > cap)
@@ -1161,8 +1165,10 @@ int memory_find_facts_visible_lexical_fallback(const char *query, const char *wo
    {
       if (!memory_is_signal_token(tokens[t]))
          continue;
-      memory_t term_matches[64];
-      int term_cap = (int)(sizeof(term_matches) / sizeof(term_matches[0]));
+      MEMORY_AUTOFREE memory_t *term_matches = calloc(64, sizeof(*term_matches));
+      if (!term_matches)
+         break;
+      int term_cap = 64;
       got = memory_find_facts_like(tokens[t], fetch_limit, term_matches, term_cap);
       if (got < 0)
          return got;
@@ -1244,8 +1250,10 @@ static int memory_collect_code_matches(const char *query, int fetch_limit, memor
 {
    if (!query || !query[0] || !out || count >= max || fetch_limit <= 0)
       return count;
-   memory_t scratch[64];
-   int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+   MEMORY_AUTOFREE memory_t *scratch = calloc(64, sizeof(*scratch));
+   if (!scratch)
+      return count;
+   int cap = 64;
    config_t code_cfg;
    config_load(&code_cfg);
    const char *embed_cmd = config_embedding_command(&code_cfg, NULL);
@@ -1684,8 +1692,10 @@ int memory_collect_variant_candidates(const char *raw_query, const char *norm_va
    }
 
    {
-      memory_t lexical_scratch[64];
-      int lexical_cap = (int)(sizeof(lexical_scratch) / sizeof(lexical_scratch[0]));
+      MEMORY_AUTOFREE memory_t *lexical_scratch = calloc(64, sizeof(*lexical_scratch));
+      if (!lexical_scratch)
+         return count;
+      int lexical_cap = 64;
       const char *lexical_embed_cmd = config_embedding_command(&qe_cfg, NULL);
       config_t lanes_cfg;
       config_load(&lanes_cfg);

--- a/src/memory_core_search_c.c
+++ b/src/memory_core_search_c.c
@@ -60,8 +60,10 @@ static int memory_collect_graph_candidates(const char *raw_query, const char *no
       if ((int)strlen(qtokens[i]) < 3)
          continue;
 
-      memory_t scratch[32];
-      int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+      MEMORY_AUTOFREE memory_t *scratch = calloc(32, sizeof(*scratch));
+      if (!scratch)
+         break;
+      int cap = 32;
       int rel_lim = fetch_limit < 8 ? fetch_limit : 8;
       int got = db2_memory_collect_relation_token_matches(qtokens[i], rel_lim, scratch, cap);
       for (int s = 0; s < got && count < max; s++)
@@ -212,8 +214,10 @@ int memory_generate_candidates(const char *query, const char *norm_query,
          int neg_count = extract_negation_tokens(query, neg_q, sizeof(neg_q));
          if (neg_count > 0 && neg_q[0])
          {
-            memory_t scratch[64];
-            int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+            MEMORY_AUTOFREE memory_t *scratch = calloc(64, sizeof(*scratch));
+            if (!scratch)
+               return count;
+            int cap = 64;
             const char *embed_cmd = config_embedding_command(&neg_cfg, NULL);
             /* Negation tokens aren't in the vector payload yet, so this falls
              * back to memory-level semantic search of the synthetic
@@ -234,9 +238,10 @@ int memory_generate_candidates(const char *query, const char *norm_query,
    }
 
    /* Fallback: LIKE search */
-   memory_t like_matches[128];
-   int like_count = memory_find_facts_like(norm_query, fetch_limit, like_matches,
-                                           (int)(sizeof(like_matches) / sizeof(like_matches[0])));
+   MEMORY_AUTOFREE memory_t *like_matches = calloc(128, sizeof(*like_matches));
+   if (!like_matches)
+      return count;
+   int like_count = memory_find_facts_like(norm_query, fetch_limit, like_matches, 128);
    if (like_count > 0)
       memory_record_query_stage_metric(plan, "like");
    for (int i = 0; i < like_count && count < max; i++)
@@ -473,8 +478,10 @@ int memory_expand_to_session_window(memory_t *out, int count, int max, int windo
       if (!out[i].source_session[0])
          continue;
 
-      memory_t scratch[32];
-      int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
+      MEMORY_AUTOFREE memory_t *scratch = calloc(32, sizeof(*scratch));
+      if (!scratch)
+         break;
+      int cap = 32;
 
       int got = db2_memory_session_neighbors_before(out[i].source_session, out[i].id, window_radius,
                                                     scratch, cap);
@@ -724,7 +731,13 @@ int memory_find_facts_scoped(const char *query, const char *scope_type, const ch
       int orig_sem_count = 0;
       memory_candidate_source_t orig_src[128];
       int orig_src_count = 0;
-      memory_t extra[MEMORY_RERANK_BUFFER];
+      MEMORY_AUTOFREE memory_t *extra = calloc(MEMORY_RERANK_BUFFER, sizeof(*extra));
+      if (!extra)
+      {
+         pgvec_memory_vector_scope_hint_clear();
+         free(candidates);
+         return -1;
+      }
       int extra_count = memory_generate_candidates(
           query, norm_query, intent, &plan, fetch_limit / 2 > 0 ? fetch_limit / 2 : 8, extra,
           MEMORY_RERANK_BUFFER, orig_sem_ids, orig_sem_scores, &orig_sem_count, orig_src,
@@ -755,7 +768,9 @@ int memory_find_facts_scoped(const char *query, const char *scope_type, const ch
       int sub_sem_count = 0;
       memory_candidate_source_t sub_src[128];
       int sub_src_count = 0;
-      memory_t sub_cands[MEMORY_RERANK_BUFFER / 2];
+      MEMORY_AUTOFREE memory_t *sub_cands = calloc(MEMORY_RERANK_BUFFER / 2, sizeof(*sub_cands));
+      if (!sub_cands)
+         break;
       int sub_count = memory_generate_candidates(
           rewrite.sub_questions[q], sub_norm,
           memory_query_intent(rewrite.sub_questions[q], sub_norm), &sub_plan,
@@ -975,7 +990,12 @@ int memory_find_facts_visible(const char *query, const char *workspace, const ch
    int semantic_hit_count = 0;
    memory_candidate_source_t source_stats[128];
    int source_stats_count = 0;
-   memory_t candidates[MEMORY_RERANK_BUFFER];
+   MEMORY_AUTOFREE memory_t *candidates = calloc(MEMORY_RERANK_BUFFER, sizeof(*candidates));
+   if (!candidates)
+   {
+      pgvec_memory_vector_scope_hint_clear();
+      return -1;
+   }
    int scope_rank[MEMORY_RERANK_BUFFER];
 
    int count = memory_generate_candidates(query, norm_query, intent, &plan, fetch_limit, candidates,


### PR DESCRIPTION
## Why
`test_memory_advanced` segfaulted deterministically on some toolchains (local Debian gcc; CI's Ubuntu stayed just under the limit → CI green). **ASan verdict: `stack-overflow` in `main`.**

Root cause: the memory-search chain declares large `memory_t` scratch arrays on the **stack** (`sizeof(memory_t)` ≈ 4.4 KB, so `like_matches[128]` = 566 KB, several `scratch[64]` = 283 KB, `candidates[96]`/`extra[96]` = 424 KB…). Under `-Os -flto` the deep query chain (`memory_ask_query → find_facts_scoped → generate_candidates → collect_variant_candidates → collect_unit_matches → …`) inlines into ~1 MB frames that **nest and overflow the 8 MB stack**. It's a real latent risk beyond the test: `aimee-kb` runs this path on **worker threads**, whose stacks can be well under 8 MB.

## Fix
Add a small `MEMORY_AUTOFREE` (`__attribute__((cleanup))`) helper and move the large `memory_t[]` scratch buffers to `calloc` so they live on the heap and free on scope exit — no `free()` threaded through every early return.

- Each `sizeof(arr)/sizeof(arr[0])` cap → the literal element count.
- On `calloc` failure, each site returns its function's existing graceful value (`count` / `0` / `-1`) or `break`s its loop.
- **15 sites**: `memory_core_search.c` (3), `memory_core_search_b.c` (5), `memory_core_search_c.c` (7). Trivial `scratch[1]` left alone; `int scope_rank[]` and small non-`memory_t` arrays left on the stack.

## Verification
- `test_memory_advanced`: **deterministic segfault → passes 5/5** locally.
- Changed files compile clean (no `sizeof(pointer)` regressions) and are `clang-format-19` clean.
- No double-free: the pre-existing manually-managed `candidates` buffer in `memory_find_facts_scoped` is untouched; the autofree `candidates` is in a different function.