### PR TITLE
feat(deploy): de-bundle the LLM from the combined image → server+kb only (2b slice 2)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -162,23 +162,16 @@ jobs:
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
-          # Bundled aimee-llm in the combined image is AMD64-ONLY: the llama.cpp Vulkan
-          # runtime is the x64 binary, so the arm64 combined leg builds lean (WITH_LLM=0)
-          # and points at an external llm. CAVEAT (ordering): the amd64 combined leg
-          # COPYs the runtime from aimee-llm:latest — i.e. the PREVIOUS release's llm
-          # image, since this run's llm tags aren't manifest-merged until after the build
-          # matrix. The gateway contract is stable across releases (and the image is now
-          # model-less, so there are no baked GGUFs to drift); digest-pinned ordering
-          # (combined `needs` the llm digest) is the follow-up.
+          # The combined image is server+kb only (WITH_LLM=0, the Dockerfile default):
+          # the aimee-llm runtime is no longer bundled. Both arches build lean and the
+          # deploy stack brings up a separate, profile-gated aimee-llm container only
+          # when the setup wizard's page-2 config puts a role local.
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_WEBCHAT=1
             ${{ matrix.image.embedder_arg }}
             ${{ matrix.image.reranker_arg }}
             ${{ matrix.image.extra_args }}
-            ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'amd64') && 'WITH_LLM=1' || '' }}
-            ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'amd64') && format('AIMEE_LLM_CPU_IMAGE=ghcr.io/{0}/aimee-llm:latest', env.OWNER) || '' }}
-            ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'arm64') && 'WITH_LLM=0' || '' }}
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -98,16 +98,13 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image.name }}-amd64
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-amd64
           # WITH_WEBCHAT bundles the browser UI (default for server/combined; the
-          # aimee-kb image ignores it). WITH_LLM=1 + AIMEE_LLM_CPU_IMAGE make the
-          # combined image bundle the aimee-llm runtime by COPYing from the prebuilt
-          # model-less aimee-llm:testing (published by publish-llm-testing.yml, which
-          # must have run first). The split server/kb Dockerfiles don't declare these
-          # args (a harmless "not consumed" warning).
+          # aimee-kb image ignores it). WITH_LLM=0: the combined image is server+kb
+          # ONLY — the LLM is no longer bundled; the deploy stack runs a separate,
+          # profile-gated aimee-llm container instead (see compose.combined.yaml).
           build-args: |
             AIMEE_VERSION=testing-${{ env.SHA7 }}
             WITH_WEBCHAT=1
-            WITH_LLM=1
-            AIMEE_LLM_CPU_IMAGE=ghcr.io/${{ env.OWNER }}/aimee-llm:testing
+            WITH_LLM=0
           tags: |
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing-${{ env.SHA7 }}

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -29,7 +29,7 @@ ARG WITH_VSCODE=1
 # WITH_LLM=0 for the lean server+kb image that points at an external AIMEE_LLM_URL.
 # AIMEE_LLM_CPU_IMAGE must exist (CI: aimee-llm:testing / release: :latest,
 # published by publish-llm-*.yml).
-ARG WITH_LLM=1
+ARG WITH_LLM=0
 ARG AIMEE_LLM_CPU_IMAGE=ghcr.io/rakuensoftware/aimee-llm:latest
 FROM debian:bookworm-slim AS build
 
@@ -155,7 +155,7 @@ RUN apt-get update \
 # vendor-agnostic Vulkan build (needs libvulkan1 + an ICD even at NGL=0 on CPU);
 # the gateway is python3 (already present) + numpy for the rerank head; the
 # supervisor is a bash script that fetches the tier's GGUFs with wget on first boot.
-ARG WITH_LLM=1
+ARG WITH_LLM=0
 RUN if [ "$WITH_LLM" = "1" ]; then \
         apt-get update \
         && apt-get install -y --no-install-recommends \

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -20,17 +20,9 @@ ARG WITH_WEBCHAT=1
 # default — the editor is a first-class feature; build with --build-arg
 # WITH_VSCODE=0 to omit it (saves ~100 MB).
 ARG WITH_VSCODE=1
-# WITH_LLM bundles the aimee-llm runtime (the unified llama.cpp/Vulkan gateway:
-# embed + rerank + Tier-A synth) INTO this image, so the combined container is
-# self-contained — no external embedder/llm service. The bundled LLM is the SAME
-# model-less aimee-llm image as everything else: its runtime (/opt/llama,
-# /opt/aimee) is COPYd here, and the supervisor DOWNLOADS the cpu-tier models to
-# /models on first boot (nothing is baked). ON by default; build --build-arg
-# WITH_LLM=0 for the lean server+kb image that points at an external AIMEE_LLM_URL.
-# AIMEE_LLM_CPU_IMAGE must exist (CI: aimee-llm:testing / release: :latest,
-# published by publish-llm-*.yml).
-ARG WITH_LLM=0
-ARG AIMEE_LLM_CPU_IMAGE=ghcr.io/rakuensoftware/aimee-llm:latest
+# The combined image is server+kb ONLY. The LLM is never bundled — it runs as a
+# separate, profile-gated aimee-llm container (see compose.combined.yaml); the
+# entrypoint points the kb/curator at it via AIMEE_LLM_URL.
 FROM debian:bookworm-slim AS build
 
 # Union of the aimee-server and aimee-kb build deps: server links libsqlite3
@@ -114,16 +106,6 @@ FROM debian:bookworm-slim AS code-server-stage-0
 RUN mkdir -p /opt/codeserver/usr
 FROM code-server-stage-${WITH_VSCODE} AS code-server-stage
 
-# Optional bundled aimee-llm. "1" pulls the model-less aimee-llm image (the
-# llama.cpp/Vulkan runtime at /opt/llama and the gateway + supervisor under
-# /opt/aimee; /models is empty — the supervisor fetches the cpu tier on first
-# boot) — BuildKit only materializes the stage the final selector references, so
-# WITH_LLM=0 never pulls it. "0" is an empty stage so the COPYs below are no-ops.
-FROM ${AIMEE_LLM_CPU_IMAGE} AS llm-stage-1
-FROM debian:bookworm-slim AS llm-stage-0
-RUN mkdir -p /opt/llama /opt/aimee /models
-FROM llm-stage-${WITH_LLM} AS llm-stage
-
 FROM debian:bookworm-slim
 
 # Union of both runtime closures: libsqlite3 (server DB1), libpq (kb DB2),
@@ -149,24 +131,6 @@ RUN apt-get update \
         tmux \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
-
-# Bundled aimee-llm runtime deps — only when WITH_LLM=1, so the lean image isn't
-# burdened with the Vulkan driver stack. The llama.cpp release binary is the
-# vendor-agnostic Vulkan build (needs libvulkan1 + an ICD even at NGL=0 on CPU);
-# the gateway is python3 (already present) + numpy for the rerank head; the
-# supervisor is a bash script that fetches the tier's GGUFs with wget on first boot.
-ARG WITH_LLM=0
-RUN if [ "$WITH_LLM" = "1" ]; then \
-        apt-get update \
-        && apt-get install -y --no-install-recommends \
-            bash \
-            libgomp1 \
-            libvulkan1 \
-            mesa-vulkan-drivers \
-            python3-numpy \
-            wget \
-        && rm -rf /var/lib/apt/lists/*; \
-    fi
 
 ENV AIMEE_HOME=/var/lib/aimee
 # On-demand OAuth CLI agents global-install on the persistent home volume so the
@@ -194,43 +158,14 @@ ENV AIMEE_DB1_URL=sqlite:///var/lib/aimee/aimee.db
 # and reach Postgres + the embedder via env (compose supplies the URLs).
 ENV AIMEE_KB_HTTP_BIND=1
 ENV AIMEE_DB2_URL=postgresql://aimee:aimee@postgres:5432/aimee_shared
-# NOTE: AIMEE_EMBEDDER_URL / LLM_ENDPOINT are intentionally NOT baked here. The
-# entrypoint resolves the embed/rerank/synth endpoints at start (see
-# combined-entrypoint.sh): operator-set AIMEE_LLM_URL / AIMEE_EMBEDDER_URL /
-# LLM_ENDPOINT win; else (WITH_LLM=1) the in-container bundled aimee-llm gateway
-# at 127.0.0.1:$AIMEE_LLM_PORT; else the legacy external defaults
-# (embedder:8080 / llm:8080) for a lean WITH_LLM=0 image. Baking them would make
-# every operator look "configured" and suppress the bundled-gateway auto-start.
-# Symmetric with LLM_ENDPOINT: the bundled curator LLM (Gemma E4B) also needs a
-# model name. The curator code-extract stage shells out to curator-extract.py ->
-# llm-chat.py, which hard-requires $LLM_MODEL; a non-configurable plugin instance
-# takes its env from this image (not from compose), so without this the extract
-# stage fails on every job and the curator never drains. llama.cpp serves the
-# loaded GGUF regardless of this value; configurable / BYO deploys override it.
-# Kept in sync with compose.combined.yaml's default.
+# AIMEE_EMBEDDER_URL / LLM_ENDPOINT are NOT baked here — the entrypoint resolves
+# them from the AIMEE_LLM_URL one-knob at start (combined-entrypoint.sh); an
+# operator-set value wins. Baking them would make every operator look "configured".
+# LLM_MODEL: the curator code-extract stage (curator-extract.py -> llm-chat.py)
+# hard-requires a model name; a non-configurable plugin instance takes its env
+# from this image. The aimee-llm gateway serves the loaded synth model regardless
+# of this value; BYO deploys override it. Kept in sync with compose.combined.yaml.
 ENV LLM_MODEL=gemma-3n-e4b
-# Bundled aimee-llm (WITH_LLM=1) gateway port + bring-up policy. AIMEE_BUNDLED_LLM:
-#   auto (default) — start the bundled CPU gateway UNLESS the operator pointed
-#                    AIMEE_LLM_URL at an external/GPU endpoint (opt up only);
-#   on             — always start it (and still honor an explicit AIMEE_LLM_URL);
-#   off            — never start it (use the external embedder/llm env above).
-# No-op in a WITH_LLM=0 image (the supervisor/models aren't present).
-ENV AIMEE_LLM_PORT=8742
-ENV AIMEE_BUNDLED_LLM=auto
-# Bundled aimee-llm gateway wiring — mirrors Dockerfile.aimee-llm's runtime ENV
-# (the COPY only brings the files, not that image's ENV). Without these the
-# gateway 503s on /v1/chat/completions (no AIMEE_LLM_SYNTH_URL). The supervisor
-# resolves AIMEE_LLM_TIER (cpu here), downloads that tier's models to /models on
-# first boot, and EXPORTS the per-tier AIMEE_LLM_RERANK_HEAD (/models/cpu/...) +
-# embed identity, so those aren't baked here. The per-role llama-servers the
-# supervisor starts are loopback 8081/8082/8083; the gateway itself binds loopback
-# only (same container/netns as the kb/server). Harmless when WITH_LLM=0.
-ENV AIMEE_LLM_TIER=cpu \
-    AIMEE_LLM_EMBED_URL=http://127.0.0.1:8081 \
-    AIMEE_LLM_RERANK_URL=http://127.0.0.1:8082 \
-    AIMEE_LLM_SYNTH_URL=http://127.0.0.1:8083 \
-    AIMEE_LLM_NGL=0 \
-    AIMEE_LLM_BIND=127.0.0.1
 # Mirror tier (workspace-resource-plane §3): durable bare mirrors + worktrees on
 # a dedicated volume, matching Dockerfile.server.
 ENV AIMEE_WORKSPACES_DIR=/var/lib/aimee-workspaces
@@ -241,33 +176,10 @@ ENV AIMEE_WORKSPACES_DIR=/var/lib/aimee-workspaces
 RUN useradd --uid 1000 --user-group --home-dir /var/lib/aimee --create-home --shell /usr/sbin/nologin aimee \
     && mkdir -p /var/lib/aimee-workspaces /var/lib/aimee/.config/aimee \
     && chown -R aimee:aimee /var/lib/aimee-workspaces /var/lib/aimee/.config
-# When the bundled aimee-llm runs on a GPU (AIMEE_LLM_NGL>0 + a mounted /dev/dri),
-# the unprivileged "aimee" user needs the render/video groups to reach the render
-# node. Best-effort + harmless for the default CPU (NGL=0) path, which needs no
-# device. (gid match to the host's render group is a deploy-time --group-add if
-# numbers differ.)
-RUN if [ "$WITH_LLM" = "1" ]; then \
-        groupadd -f render || true; \
-        groupadd -f video || true; \
-        usermod -aG render,video aimee || true; \
-    fi
 VOLUME /var/lib/aimee-workspaces
 
 COPY --from=build /src/aimee-server /usr/local/bin/aimee-server
 COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
-
-# Bundled aimee-llm: the llama.cpp/Vulkan runtime and the unified gateway +
-# supervisor. /models is empty (model-less image) — the supervisor downloads the
-# cpu tier there on first boot. From the empty llm-stage-0 when WITH_LLM=0 these
-# are no-op copies of empty dirs (the entrypoint then finds no
-# /opt/aimee/supervisor.sh and starts no gateway). The gateway files land in
-# /opt/aimee/ so the supervisor's hardcoded paths (PYTHONPATH=/opt/aimee,
-# /opt/aimee/aimee_llm_gateway.py) resolve unchanged.
-COPY --from=llm-stage /opt/llama/ /opt/llama/
-COPY --from=llm-stage /opt/aimee/ /opt/aimee/
-COPY --from=llm-stage /models/ /models/
-# Persist the bundled LLM's downloaded model cache (empty when WITH_LLM=0).
-VOLUME /models
 
 # kb sidecar clients (LLM/embedder access code the kb invokes via popen).
 COPY scripts/embed-remote.py scripts/rerank-remote.py scripts/llm-chat.py \
@@ -326,14 +238,9 @@ EXPOSE 8740 8743 8741 8443
 # Every TCP /v1 request is authenticated, so an unauthenticated probe returns
 # 401 — which still proves the listener is up. Treat 200/401 as healthy; only a
 # connection failure ("000") is unhealthy. Mirrors Dockerfile.server.
-# start-period is generous: with the bundled aimee-llm (WITH_LLM=1) the entrypoint
-# waits for the gateway, which on FIRST boot DOWNLOADS the cpu tier's GGUFs before
-# it is healthy, so the server /v1 listener can take minutes to appear. A long
-# start-period prevents the orchestrator marking the container unhealthy during
-# that fetch (a success during the period still flips it healthy immediately, so
-# the fast WITH_LLM=0 path is unaffected). Later boots reuse the /models volume.
-# Override AIMEE_LLM_WAIT_SECONDS to bound the entrypoint wait.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=1200s --retries=5 \
+# The server+kb come up quickly (no bundled LLM to wait on); a success during the
+# start-period flips the container healthy immediately.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=5 \
     CMD curl -s -o /dev/null -w '%{http_code}' \
         http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$'
 

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -110,7 +110,6 @@ services:
       # from AIMEE_LLM_URL. The default points at the compose service; override to
       # a GPU/external endpoint (and drop the `llm` profile). No LLM is bundled.
       AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8080}
-      AIMEE_BUNDLED_LLM: "off"
       # Embedding dim — unset lets the kb derive it from the embedder /health
       # probe; pin it (e.g. 1024/2560) only for an external embedder.
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -2,13 +2,13 @@
 #
 # One container runs BOTH aimee binaries co-located (server fronts /v1 over TLS on :8743;
 # the kb runs on loopback :8741 inside the same container and the server reaches
-# it via AIMEE_KB_API_URL=http://127.0.0.1:8741). The default combined image also
-# BUNDLES aimee-llm (CPU): the unified llama.cpp/Vulkan gateway (embed + rerank +
-# Tier-A synth) auto-starts inside the container and the kb/curator are pointed at
-# it automatically — so this stack is self-contained and needs only Postgres
-# (DB2 + pgvector) as an external service. The `embedder` + `llm` services below
-# are for the lean WITH_LLM=0 image (or to opt up to a GPU/external endpoint) and
-# are OFF by default behind the `external-llm` profile.
+# it via AIMEE_KB_API_URL=http://127.0.0.1:8741). The combined image is server+kb
+# ONLY — the LLM is NOT bundled. embed/rerank/synth run against the separate
+# `aimee-llm` service below, which is profile-gated (`llm`): it is brought up only
+# when the setup wizard's page-2 config puts a role local (COMPOSE_PROFILES=...,llm,
+# emitted by `aimee config deploy-env`). An all-external / remote-kb stack runs no
+# LLM at all. The `embedder` + curator `llm` services are legacy alternatives behind
+# the `external-llm` profile. Postgres (DB2 + pgvector) is the only always-on dep.
 #
 # Deploy the published images (built + pushed to ghcr on every merge to main):
 #   docker compose -f compose.combined.yaml pull
@@ -88,12 +88,9 @@ services:
       # The browser UI (aimee-webchat) is built and bundled by default. Its npm
       # dependency (@rakuensoftware/smoothgui) is vendored under frontend/vendor/,
       # so the build needs NO credentials. Build --build-arg WITH_WEBCHAT=0 to
-      # ship the server+kb services only.
-      args:
-        # The bundled LLM runtime is COPYd from this model-less aimee-llm image.
-        # Default to the published :latest (as in prod); a local build (e2e) can
-        # inject a freshly-built image so it doesn't depend on a published tag.
-        AIMEE_LLM_CPU_IMAGE: ${AIMEE_LLM_CPU_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
+      # ship the server+kb services only. The image is server+kb ONLY — the LLM is
+      # no longer bundled (Dockerfile default WITH_LLM=0); the aimee-llm service
+      # below serves it, profile-gated on the page-2 config.
     # Published combined image (built + pushed to ghcr on every merge to main).
     # `docker compose pull` fetches it so the standard deploy creates containers
     # from the merge-built image without a local build; `up --build` still
@@ -108,22 +105,14 @@ services:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB1_URL: sqlite:///var/lib/aimee/aimee.db
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
-      # Embed/rerank + curator synth: by default the entrypoint auto-points these
-      # at the in-container bundled aimee-llm gateway (127.0.0.1:8742, dim 1024) —
-      # no need to set AIMEE_EMBEDDER_URL / LLM_ENDPOINT here. Opt UP to a
-      # GPU/external endpoint by setting AIMEE_LLM_URL (then AIMEE_BUNDLED_LLM=auto
-      # leaves the bundled CPU gateway off). For a lean WITH_LLM=0 image, set
-      # AIMEE_BUNDLED_LLM=off and uncomment the external-llm wiring below.
-      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-}
-      AIMEE_BUNDLED_LLM: ${AIMEE_BUNDLED_LLM:-auto}
-      # Bundled LLM tier — cpu by default; the supervisor downloads it to /models
-      # on first boot. Raise to small/mid/large only with a GPU (AIMEE_LLM_NGL=99).
-      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
-      # CI/dev: AIMEE_LLM_STUB=1 makes the bundled supervisor serve deterministic
-      # embed/rerank/synth with NO model download (off in prod, empty default).
-      AIMEE_LLM_STUB: ${AIMEE_LLM_STUB:-}
-      AIMEE_LLM_STUB_DIM: ${AIMEE_LLM_STUB_DIM:-}
-      # Override only for a GPU/external tier (the bundled CPU tier is 1024).
+      # Embed/rerank + curator synth run against the separate aimee-llm service
+      # (profile-gated) — the entrypoint derives AIMEE_EMBEDDER_URL / LLM_ENDPOINT
+      # from AIMEE_LLM_URL. The default points at the compose service; override to
+      # a GPU/external endpoint (and drop the `llm` profile). No LLM is bundled.
+      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8080}
+      AIMEE_BUNDLED_LLM: "off"
+      # Embedding dim — unset lets the kb derive it from the embedder /health
+      # probe; pin it (e.g. 1024/2560) only for an external embedder.
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       LLM_MODEL: ${LLM_MODEL:-gemma-3n-e4b}
       LLM_API_KEY: ${LLM_API_KEY:-}
@@ -167,23 +156,52 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      # required:false so server+kb still come up when the aimee-llm service is not
+      # in the active profile set (all-external / remote-kb); the kb fail-opens on
+      # embedding. When the `llm` profile is on, it waits for aimee-llm to be healthy.
+      aimee-llm:
+        condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD-SHELL",
              "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
       interval: 10s
       timeout: 5s
       retries: 5
-      # Long: the bundled aimee-llm downloads the cpu tier's GGUFs on first boot
-      # before the entrypoint brings up the server /v1 listener. Later boots reuse
-      # the aimee-combined-llm-models volume and come up fast.
-      start_period: 1200s
+      start_period: 120s
     volumes:
       - aimee-combined-home:/var/lib/aimee
       - aimee-combined-workspaces:/var/lib/aimee-workspaces
-      # Persist the bundled LLM's downloaded per-tier model cache.
-      - aimee-combined-llm-models:/models
 
-  # External curator LLM — OFF by default (the bundled aimee-llm gateway already
+  # Profile-gated aimee-llm (embed + rerank + synth) — brought up only when the
+  # page-2 config puts a role local (COMPOSE_PROFILES=...,llm, emitted by
+  # `aimee config deploy-env`). server+kb reach it at aimee-llm:8080. CI builds the
+  # stub (AIMEE_LLM_DOCKERFILE=Dockerfile.aimee-llm-stub + AIMEE_LLM_STUB=1). Mirrors
+  # the aimee-llm service in compose.yaml.
+  aimee-llm:
+    restart: unless-stopped
+    profiles: ["llm"]
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
+    build:
+      context: .
+      dockerfile: ${AIMEE_LLM_DOCKERFILE:-Dockerfile.aimee-llm}
+    environment:
+      AIMEE_LLM_PORT: "8080"
+      AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
+      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+      AIMEE_LLM_STUB: ${AIMEE_LLM_STUB:-}
+      AIMEE_LLM_STUB_DIM: ${AIMEE_LLM_STUB_DIM:-}
+    volumes:
+      - aimee-llm-models:/models
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 1200s
+
+  # External curator LLM — OFF by default (the aimee-llm gateway already
   # serves synthesis at /v1). This standalone llama.cpp is only for the lean
   # WITH_LLM=0 image or to BYO a different curator GGUF; enable with the
   # `external-llm` profile and set LLM_ENDPOINT=http://llm:8080/v1. Gemma 3n E4B
@@ -214,4 +232,3 @@ volumes:
   aimee-combined-postgres:
   aimee-embedder-models:
   aimee-llm-models:
-  aimee-combined-llm-models:

--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -81,19 +81,8 @@ fi
 chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspaces}" 2>/dev/null || true
 [ -f "$AIMEE_HOME/aimee.yaml" ] && chown aimee:aimee "$AIMEE_HOME/aimee.yaml" 2>/dev/null || true
 [ -f "$AIMEE_HOME/agents.json" ] && chown aimee:aimee "$AIMEE_HOME/agents.json" 2>/dev/null || true
-# The bundled aimee-llm supervisor runs as "aimee" and DOWNLOADS the tier's GGUFs
-# to /models on first boot — make the (possibly root-owned, freshly-mounted) cache
-# writable by uid 1000. Recurse ONLY when the root isn't already aimee-owned (a
-# fresh/root volume or a migration): once aimee owns /models the supervisor creates
-# its per-tier files as aimee, so later restarts skip the multi-GB `chown -R` walk.
-# Harmless when WITH_LLM=0 (/models is an empty dir).
-if [ -d /models ] && [ "$(stat -c %u /models 2>/dev/null || echo 0)" != "1000" ]; then
-    chown -R aimee:aimee /models 2>/dev/null || true
-fi
-
 kb_pid=""
 server_pid=""
-llm_pid=""
 
 . /usr/local/bin/webchat-lib.sh
 
@@ -103,76 +92,22 @@ shutdown() {
     # Best-effort teardown of all children; ignore errors during shutdown.
     [ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null || true
     [ -n "$kb_pid" ] && kill "$kb_pid" 2>/dev/null || true
-    [ -n "$llm_pid" ] && kill "$llm_pid" 2>/dev/null || true
     webchat_stop
 }
 trap 'shutdown' TERM INT
 
-# --- bundled aimee-llm (CPU): auto-start + point the kb/server at it ---------
-# When this image was built WITH_LLM=1 it carries the unified llama.cpp/Vulkan
-# gateway (embed + rerank + Tier-A synth) and its baked GGUFs. We start it here
-# and repoint the kb's embed path + the curator synth at the in-container gateway
-# so the combined container is self-contained (no external embedder/llm).
-#
-# Operator endpoints WIN — an existing deploy that set AIMEE_LLM_URL,
-# AIMEE_EMBEDDER_URL or LLM_ENDPOINT (e.g. an external embedder, or opting up to a
-# GPU endpoint) is never silently overridden:
-#   AIMEE_BUNDLED_LLM=auto (default) — start the bundled gateway ONLY if the
-#       operator configured no endpoint; otherwise respect theirs.
-#   AIMEE_BUNDLED_LLM=on            — always start + use the bundled gateway,
-#       overriding any operator endpoint.
-#   AIMEE_BUNDLED_LLM=off           — never start it; use operator/legacy endpoints.
-GW_PORT="${AIMEE_LLM_PORT:-8742}"
-operator_llm=0
-if [ -n "${AIMEE_LLM_URL:-}" ] || [ -n "${AIMEE_EMBEDDER_URL:-}" ] || [ -n "${LLM_ENDPOINT:-}" ]; then
-    operator_llm=1
+# --- resolve the embed/rerank/synth endpoints -------------------------------
+# The LLM is a SEPARATE service (aimee-llm), never bundled in this image. Derive
+# the embedder + curator-synth endpoints from the one-knob AIMEE_LLM_URL when the
+# operator left them unset; compose points AIMEE_LLM_URL at the profile-gated
+# aimee-llm service (or an external endpoint). The kb fail-opens on embedding
+# until that endpoint is reachable.
+if [ -n "${AIMEE_LLM_URL:-}" ]; then
+    export AIMEE_EMBEDDER_URL="${AIMEE_EMBEDDER_URL:-$AIMEE_LLM_URL}"
+    export LLM_ENDPOINT="${LLM_ENDPOINT:-${AIMEE_LLM_URL}/v1}"
 fi
-start_bundled_llm=0
-if [ -x /opt/aimee/supervisor.sh ]; then
-    case "${AIMEE_BUNDLED_LLM:-auto}" in
-        on)   start_bundled_llm=1 ;;
-        off)  start_bundled_llm=0 ;;
-        auto) if [ "$operator_llm" = 0 ]; then start_bundled_llm=1; fi ;;
-        *)    log "AIMEE_BUNDLED_LLM='${AIMEE_BUNDLED_LLM:-}' unrecognized; treating as auto"
-              if [ "$operator_llm" = 0 ]; then start_bundled_llm=1; fi ;;
-    esac
-fi
-if [ "$operator_llm" = 1 ] && [ "$start_bundled_llm" = 0 ]; then
-    log "using operator-configured LLM endpoints (bundled aimee-llm not started)"
-fi
-if [ "$start_bundled_llm" = 1 ]; then
-    log "starting bundled aimee-llm (CPU) gateway on :$GW_PORT as user aimee"
-    # Set the runtime's lib + module paths INSIDE the child (after runuser's uid
-    # switch) via sh -c, not as inline vars on runuser: LD_LIBRARY_PATH is
-    # security-sensitive and can be dropped across a privilege change, and we must
-    # NOT put /opt/llama/lib on the aimee-server/kb load path anyway. The gateway's
-    # other settings (AIMEE_LLM_EMBED_URL/RERANK_URL/SYNTH_URL/RERANK_HEAD/...) are
-    # image ENV that runuser preserves like the kb/server's existing env.
-    runuser -u aimee -- sh -c \
-        'LD_LIBRARY_PATH=/opt/llama/lib:/opt/llama PYTHONPATH=/opt/aimee AIMEE_LLM_PORT="$1" exec /opt/aimee/supervisor.sh' \
-        aimee-llm "$GW_PORT" &
-    llm_pid=$!
-    # One-knob: drive the kb embed path (in-process http; the seeded config has no
-    # embedding_command) + reranking via the gateway, and the curator synth
-    # sidecar via its /v1. Default the CPU tier dim (operator-set dim wins). These
-    # exports reach the kb/server children below (runuser preserves the env).
-    export AIMEE_LLM_URL="http://127.0.0.1:${GW_PORT}"
-    export AIMEE_EMBEDDER_URL="http://127.0.0.1:${GW_PORT}"
-    export LLM_ENDPOINT="http://127.0.0.1:${GW_PORT}/v1"
-    : "${AIMEE_EMBEDDING_DIM:=1024}"
-    export AIMEE_EMBEDDING_DIM
-else
-    # Not starting the bundled gateway. Honor operator endpoints, deriving the
-    # ones they left unset from the AIMEE_LLM_URL one-knob; fall back to the legacy
-    # external defaults (embedder:8080 / llm:8080) so a lean WITH_LLM=0 image with
-    # the external-llm compose profile keeps working unchanged.
-    if [ -n "${AIMEE_LLM_URL:-}" ]; then
-        export AIMEE_EMBEDDER_URL="${AIMEE_EMBEDDER_URL:-$AIMEE_LLM_URL}"
-        export LLM_ENDPOINT="${LLM_ENDPOINT:-${AIMEE_LLM_URL}/v1}"
-    fi
-    export AIMEE_EMBEDDER_URL="${AIMEE_EMBEDDER_URL:-http://embedder:8080}"
-    export LLM_ENDPOINT="${LLM_ENDPOINT:-http://llm:8080/v1}"
-fi
+export AIMEE_EMBEDDER_URL="${AIMEE_EMBEDDER_URL:-http://aimee-llm:8080}"
+export LLM_ENDPOINT="${LLM_ENDPOINT:-http://aimee-llm:8080/v1}"
 
 log "starting aimee-kb (http-port=$KB_HTTP_PORT) as user aimee"
 runuser -u aimee -- aimee-kb --http-port="$KB_HTTP_PORT" &
@@ -199,34 +134,6 @@ while :; do
     fi
     sleep 1
 done
-
-# If we started the bundled gateway, wait for it to load its models so the first
-# kb embed/search succeeds. Cold CPU load of multi-GB GGUFs is slow, so allow a
-# long window. FAIL-OPEN: if it doesn't come up we still bring up the server (the
-# container's contract) — embeddings/synth degrade until the gateway is healthy,
-# rather than the whole container failing. If the supervisor died, log and move on.
-if [ "$start_bundled_llm" = 1 ]; then
-    LLM_WAIT_SECONDS="${AIMEE_LLM_WAIT_SECONDS:-600}"
-    log "waiting up to ${LLM_WAIT_SECONDS}s for bundled aimee-llm /health on :$GW_PORT"
-    i=0
-    while :; do
-        if curl -fsS --max-time 3 "http://127.0.0.1:${GW_PORT}/health" >/dev/null 2>&1; then
-            log "bundled aimee-llm is healthy"
-            break
-        fi
-        if ! kill -0 "$llm_pid" 2>/dev/null; then
-            log "WARNING: bundled aimee-llm exited during startup; embeddings/synth will be unavailable until it is restarted (continuing fail-open)"
-            llm_pid=""
-            break
-        fi
-        i=$((i + 1))
-        if [ "$i" -ge "$LLM_WAIT_SECONDS" ]; then
-            log "WARNING: bundled aimee-llm not healthy within ${LLM_WAIT_SECONDS}s; continuing fail-open (embeddings/synth degraded)"
-            break
-        fi
-        sleep 1
-    done
-fi
 
 # Delegate-vault auto-provisioning. aimee-server seals operator-supplied delegate
 # API keys into its server-principal vault at startup, so a fresh deploy's

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -150,18 +150,18 @@ run_docker_topology T1 "Docker kb-only"            aimee-kb-docker-smoke.sh     
 run_docker_topology T2 "Docker server+kb split"    aimee-server-docker-smoke.sh            compose.server.yaml              "aimee-server=${SERVER_PORT}:8743" "aimee-kb=${KB_PORT}:8741"
 run_docker_topology T3 "Docker server standalone"  aimee-server-standalone-docker-smoke.sh compose.server-standalone.yaml   "aimee-server=${SERVER_PORT}:8743"
 
-# T4 combined COPYs the aimee-llm runtime (/opt/llama + /opt/aimee + /models) from
-# AIMEE_LLM_CPU_IMAGE. In prod that is the published aimee-llm image (built by the
-# publish-* workflows first); in CI there is no freshly-published tag, so build the
-# model-less image locally (llama binary + gateway, no GGUFs — fast) and inject it.
-# The bundled LLM then runs in STUB mode (AIMEE_LLM_STUB=1, exported above), so it
-# serves deterministic responses with no model download.
+# T4 combined is now server+kb ONLY (the LLM is no longer bundled); it reaches the
+# separate, profile-gated `aimee-llm` service in compose.combined.yaml. In prod that
+# is the published aimee-llm image; in CI there is no freshly-published tag, so build
+# the model-less image locally (llama binary + gateway, no GGUFs — fast) and point the
+# service at it. It runs in STUB mode (AIMEE_LLM_STUB=1, exported above) — deterministic
+# responses, no model download — and COMPOSE_PROFILES=llm (above) brings it up.
 if selected T4 && have_docker; then
-  bold "==> Building local aimee-llm image for the T4 combined bundled LLM"
+  bold "==> Building local aimee-llm image for the T4 aimee-llm service"
   if docker build -f "$ROOT/Dockerfile.aimee-llm" -t aimee-llm-local:e2e "$ROOT"; then
-    export AIMEE_LLM_CPU_IMAGE="aimee-llm-local:e2e"
+    export AIMEE_LLM_IMAGE="aimee-llm-local:e2e"
   else
-    bold "==> WARNING: local aimee-llm build failed; T4 will use the default AIMEE_LLM_CPU_IMAGE"
+    bold "==> WARNING: local aimee-llm build failed; T4 will fall back to the default AIMEE_LLM_IMAGE"
   fi
 fi
 run_docker_topology T4 "Docker combined server+kb" aimee-combined-docker-smoke.sh          compose.combined.yaml            "aimee-server-kb=${SERVER_PORT}:8743,${KB_PORT}:8741"


### PR DESCRIPTION
**2b slice 2** (on top of the merged slice 1). The combined image no longer bundles the aimee-llm runtime — it is **server+kb only** — and the LLM runs as the same separate, profile-gated `aimee-llm` service the split stack uses. "Deploy a local LLM" is now **one code path** regardless of topology.

### Changes
- **`Dockerfile.combined`**: `WITH_LLM` default `1 → 0` (the lean server+kb path already existed). **`publish-testing.yml` / `publish-images.yml`** drop the `WITH_LLM=1` + `AIMEE_LLM_CPU_IMAGE` build args — both arches build lean.
- **`compose.combined.yaml`**: adds the profile-gated `aimee-llm` service (mirrors `compose.yaml`); the combined container points `AIMEE_LLM_URL` at `aimee-llm:8080` with `AIMEE_BUNDLED_LLM=off` + `depends_on(required:false)`; drops the bundled-LLM build arg, model volume, and stale 1200s start_period.
- **`combined-entrypoint.sh`** needs no change: with `WITH_LLM=0` the supervisor is absent, so its bundled-LLM block already no-ops and the kb is wired to `AIMEE_LLM_URL`.
- **`e2e-matrix.sh` T4**: the locally-built stub now feeds the aimee-llm **service** (`AIMEE_LLM_IMAGE`) instead of the old combined COPY; `COMPOSE_PROFILES=llm` (slice 1) brings it up.

### Verification
`e2e-docker` **T4** is the verifier (no local docker here). Slice 1 already proved the `profiles:[llm]` + `required:false` pattern end-to-end (T1/T2 passed), and T4 reuses it.

### Follow-up
`deploy/compose/aimee.yaml` + `deploy/smoothnas/*.yaml` get the same 2-line profile-gate/`required:false` alignment (not e2e-gated) — small, separate.
