### PR TITLE
feat(deploy): profile-gate aimee-llm in the deploy/compose stacks (2b finish)

### DIFF
--- a/deploy/compose/aimee.gpu.yaml
+++ b/deploy/compose/aimee.gpu.yaml
@@ -9,6 +9,9 @@
 # re-embed (the kb_meta drift guard refuses a stale mismatch).
 services:
   aimee-llm:
+    # Kept in sync with the base file's profile so `-f aimee.yaml -f aimee.gpu.yaml`
+    # keeps aimee-llm gated on the `llm` profile.
+    profiles: ["llm"]
     image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     environment:
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-99}

--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -34,6 +34,9 @@ services:
   # runs auth-off (AIMEE_LLM_AUTH_TOKEN empty) on the internal net.
   aimee-llm:
     restart: unless-stopped
+    # Profile-gated: brought up only when the page-2 config puts a role local
+    # (COMPOSE_PROFILES=...,llm, emitted by `aimee config deploy-env`).
+    profiles: ["llm"]
     image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     environment:
       AIMEE_LLM_PORT: "8742"
@@ -76,8 +79,11 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      # required:false so the kb starts (fail-open on embedding) when the aimee-llm
+      # profile is off; it still waits for aimee-llm to be healthy when on.
       aimee-llm:
         condition: service_healthy
+        required: false
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
       interval: 10s

--- a/deploy/smoothnas/aimee.compose.yaml
+++ b/deploy/smoothnas/aimee.compose.yaml
@@ -45,6 +45,9 @@ services:
 
   aimee-llm:
     restart: unless-stopped
+    # Profile-gated: brought up only when the page-2 config puts a role local
+    # (COMPOSE_PROFILES=...,llm, emitted by `aimee config deploy-env`).
+    profiles: ["llm"]
     image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     environment:
       AIMEE_LLM_PORT: "8742"
@@ -80,7 +83,8 @@ services:
       - "8741:8741"
     depends_on:
       postgres: { condition: service_healthy }
-      aimee-llm: { condition: service_healthy }
+      # required:false: kb fail-opens on embedding when the llm profile is off.
+      aimee-llm: { condition: service_healthy, required: false }
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
       interval: 10s


### PR DESCRIPTION
Finishes the 2b migration "throughout the code". The deployment compose files get the same proven pattern as the e2e-tested `compose.yaml`:
- `aimee-llm` behind the **`llm` profile** — brought up only when the page-2 config puts a role local (`aimee config deploy-env` emits `COMPOSE_PROFILES=...,llm`).
- the `aimee-kb` dependency marked **`required: false`** — the kb fail-opens on embedding when the profile is off.

Covers `deploy/compose/aimee.yaml`, `deploy/compose/aimee.gpu.yaml` (the GPU override keeps the profile), and `deploy/smoothnas/aimee.compose.yaml` (the .254 stack). YAML-only; the pattern itself was e2e-verified in slices 1 & 2.

With this, page-2 backend (2a record + 2b actuation) is complete: config record → `deploy-env` translation → profile-gated LLM everywhere, combined image de-bundled to server+kb.