### PR TITLE
fix(delegate): don't hard-fail pre-flight drift on external/remote paths

### DIFF
--- a/src/server/delegate_prompt.c
+++ b/src/server/delegate_prompt.c
@@ -618,6 +618,31 @@ static int drift_stat_named_path(const char *path, const char *base_path, struct
    return stat(full, st);
 }
 
+/* Return 1 if an absolute path does not resolve under the worktree root — i.e. a
+ * referenced EXTERNAL path (another machine's file named by an scp target such as
+ * `admin@host:/mnt/.../aimee.yaml`, or the `//host/...` residue of a URL) rather
+ * than an in-worktree create target.  A delegate creates files inside its
+ * worktree, never at an arbitrary absolute host path, so the pre-flight
+ * create-intent guard must not hard-fail on these.  Relative paths always resolve
+ * under the worktree and are never external. */
+static int drift_path_is_external(const char *path, const char *wt_path)
+{
+   if (!path || path[0] != '/')
+      return 0;
+   if (!wt_path || !wt_path[0])
+      return 1; /* absolute with no worktree root to anchor to */
+
+   size_t wlen = strlen(wt_path);
+   while (wlen > 0 && wt_path[wlen - 1] == '/')
+      wlen--;
+   if (strncmp(path, wt_path, wlen) != 0)
+      return 1; /* outside the worktree subtree */
+   /* Guard against prefix aliasing (wt=/a/b matching /a/bc): the char after the
+    * root must be a separator or end-of-string for the path to be truly under it. */
+   char after = path[wlen];
+   return (after != '\0' && after != '/');
+}
+
 int delegate_check_named_file_drift(const char *const *paths, int path_count, const char *prompt,
                                     const char *response, const char *wt_path, char *errbuf,
                                     size_t errbuf_size)
@@ -655,6 +680,14 @@ int delegate_check_named_file_drift(const char *const *paths, int path_count, co
           * rather than naming a real project file — skip it silently. */
          if (!exists && prompt)
          {
+            /* A path that can't be an in-worktree create target — an absolute
+             * host/scp/URL path outside the worktree — is a referenced external
+             * file, not an output.  Merely naming one (e.g. an ops/deploy brief
+             * that mentions admin@host:/mnt/.../aimee.yaml) must not hard-fail the
+             * delegate before it runs. */
+            if (drift_path_is_external(path, wt_path))
+               continue;
+
             if (!delegate_prompt_allows_writes(prompt))
                continue;
 

--- a/src/tests/test_delegate_context_shed.c
+++ b/src/tests/test_delegate_context_shed.c
@@ -291,8 +291,8 @@ static void test_preflight_remote_scp_path_skipped(void)
 
    char errbuf[512] = {0};
    const char *paths[] = {extracted[0]};
-   int rc = delegate_check_named_file_drift(paths, 1, prompt, NULL, "/home/virant/dev/aimee", errbuf,
-                                            sizeof(errbuf));
+   int rc = delegate_check_named_file_drift(paths, 1, prompt, NULL, "/home/virant/dev/aimee",
+                                            errbuf, sizeof(errbuf));
    assert(rc == 0);
    assert(errbuf[0] == '\0');
    printf("  preflight_remote_scp_path_skipped: ok\n");
@@ -304,9 +304,9 @@ static void test_preflight_absolute_outside_worktree_skipped(void)
     * file, not an in-repo create target — pre-flight must not hard-fail. */
    char errbuf[512] = {0};
    const char *paths[] = {"/mnt/media/other/thing.c"};
-   int rc = delegate_check_named_file_drift(
-       paths, 1, "Update /mnt/media/other/thing.c on the remote host.", NULL,
-       "/home/virant/dev/aimee", errbuf, sizeof(errbuf));
+   int rc = delegate_check_named_file_drift(paths, 1,
+                                            "Update /mnt/media/other/thing.c on the remote host.",
+                                            NULL, "/home/virant/dev/aimee", errbuf, sizeof(errbuf));
    assert(rc == 0);
    printf("  preflight_absolute_outside_worktree_skipped: ok\n");
 }

--- a/src/tests/test_delegate_context_shed.c
+++ b/src/tests/test_delegate_context_shed.c
@@ -274,6 +274,57 @@ static void test_preflight_relative_existing_file_with_base(void)
    printf("  preflight_relative_existing_file_with_base: ok\n");
 }
 
+static void test_preflight_remote_scp_path_skipped(void)
+{
+   /* An ops/deploy brief that names a remote scp target must NOT hard-fail the
+    * delegate: the tokenizer strips the `user@host:` prefix and extracts the bare
+    * absolute host path, which does not resolve under the worktree. */
+   const char *prompt =
+       "Update aimee-server on the host. The server config lives at "
+       "admin@192.168.1.254:/mnt/media/.plugins/aimee-server/server/home/aimee.yaml; "
+       "read it over SSH and confirm the bearer token.";
+
+   char extracted[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
+   int n = delegate_extract_named_paths(prompt, extracted, DELEGATE_DRIFT_MAX_PATHS);
+   assert(n == 1);
+   assert(strcmp(extracted[0], "/mnt/media/.plugins/aimee-server/server/home/aimee.yaml") == 0);
+
+   char errbuf[512] = {0};
+   const char *paths[] = {extracted[0]};
+   int rc = delegate_check_named_file_drift(paths, 1, prompt, NULL, "/home/virant/dev/aimee", errbuf,
+                                            sizeof(errbuf));
+   assert(rc == 0);
+   assert(errbuf[0] == '\0');
+   printf("  preflight_remote_scp_path_skipped: ok\n");
+}
+
+static void test_preflight_absolute_outside_worktree_skipped(void)
+{
+   /* A bare absolute path outside the worktree root is a referenced external
+    * file, not an in-repo create target — pre-flight must not hard-fail. */
+   char errbuf[512] = {0};
+   const char *paths[] = {"/mnt/media/other/thing.c"};
+   int rc = delegate_check_named_file_drift(
+       paths, 1, "Update /mnt/media/other/thing.c on the remote host.", NULL,
+       "/home/virant/dev/aimee", errbuf, sizeof(errbuf));
+   assert(rc == 0);
+   printf("  preflight_absolute_outside_worktree_skipped: ok\n");
+}
+
+static void test_preflight_relative_under_worktree_still_fails(void)
+{
+   /* Regression guard: a relative, in-worktree path that doesn't exist and has no
+    * create verb MUST still hard-fail — the external-path skip must not weaken
+    * the guard for real in-repo targets. */
+   char errbuf[512] = {0};
+   const char *paths[] = {"src/nonexistent_xyz.c"};
+   int rc = delegate_check_named_file_drift(paths, 1, "Edit src/nonexistent_xyz.c to fix the bug.",
+                                            NULL, "/home/virant/dev/aimee", errbuf, sizeof(errbuf));
+   assert(rc == -1);
+   assert(strstr(errbuf, "create intent") != NULL);
+   printf("  preflight_relative_under_worktree_still_fails: ok\n");
+}
+
 /* ---- delegate_prompt_allows_writes ---- */
 
 static void test_prompt_write_intent(void)
@@ -605,6 +656,9 @@ int main(void)
    test_preflight_readonly_missing_file_as_context();
    test_preflight_existing_file_no_error();
    test_preflight_relative_existing_file_with_base();
+   test_preflight_remote_scp_path_skipped();
+   test_preflight_absolute_outside_worktree_skipped();
+   test_preflight_relative_under_worktree_still_fails();
    test_prompt_write_intent();
    test_validation_bundle_identifies_source_worktree();
    test_validation_bundle_keeps_large_diff_handlers();


### PR DESCRIPTION
## What & why
A background delegate (role `execute`) was killed at **turn 0 — zero work done** — with:

```
named file '/mnt/media/.plugins/aimee-server/server/home/aimee.yaml' does not exist
and no create intent found in prompt; use 'create', 'new file', or 'implement' to create it
```

The brief was an **ops task** that only *mentioned* a remote scp target
(`admin@192.168.1.254:/mnt/.../aimee.yaml`) to SSH into — it never intended to create a local file.

## Root cause
The pre-flight named-file drift guard (`delegate_check_named_file_drift`, invoked for **every** role from `server_compute.c`) hard-fails a run when a named path doesn't exist locally and the prompt lacks a create verb. But `delegate_extract_named_paths` extracts absolute host paths: `drift_path_char` excludes `@`/`:`, so `admin@host:/mnt/.../aimee.yaml` tokenizes down to the bare absolute `/mnt/.../aimee.yaml` (has a `/`, and `.yaml` is a known extension) → extracted → nonexistent → hard fail.

The pre-flight "you named a nonexistent file and didn't say create" check only makes sense for files the delegate would **create inside its worktree**. An absolute path outside the worktree (an scp/host target, or the `//host/...` residue of a URL) is a referenced external file, never an in-repo output.

## Fix
- New `drift_path_is_external(path, wt_path)`: true when an absolute path doesn't resolve under the worktree root (with prefix-aliasing guard).
- Pre-flight branch skips such paths — mirroring the existing system-include / JSON-example / negated-path skips. **Relative, in-worktree paths still hard-fail exactly as before.** Post-run drift is untouched.

## Tests (`test_delegate_context_shed`)
- `preflight_remote_scp_path_skipped` — the real repro: extracts the bare abs path from the scp brief, asserts pre-flight does **not** hard-fail.
- `preflight_absolute_outside_worktree_skipped`.
- `preflight_relative_under_worktree_still_fails` — regression guard: the external-path skip must not weaken the guard for real in-repo targets.

## Verification
- Red-before-green **confirmed**: with the source fix reverted (tests kept), `preflight_remote_scp_path_skipped` fails `Assertion 'rc == 0'`; with the fix, all pass.
- `make unit-tests TEST=test_delegate_context_shed` and `TEST=test_delegate_dispatch_reliability` both green (both link `delegate_prompt.o`).