### PR TITLE
feat(setup): deploy-topology wizard page (page 2) — kb mode + per-role LLM placement

### DIFF
--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -7,6 +7,7 @@ import { WIZARD_STEPS, isRestartKey, helpFor } from '../setup/wizardSteps';
 import { computeReadiness } from '../setup/readiness';
 import { setDismissed, notifySetupUpdated } from '../setup/setupState';
 import PrimaryChooser from '../setup/PrimaryChooser';
+import DeployTopology from '../setup/DeployTopology';
 
 /* First-run setup wizard. A modal over the app that walks the operator through
  * the minimum path to a working turn — provider → embedding → shared store →
@@ -98,6 +99,17 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
   async function handlePrimaryConfigured(provider: string) {
     const res = await saveConfigValue('provider', provider);
     setCfg((c) => ({ ...c, provider: res.ok ? res.value ?? provider : provider }));
+    notifySetupUpdated();
+    advance();
+  }
+
+  // The deploy-topology page writes its own config keys (kb_mode + per-role
+  // llm_*). It reports the restart-class keys it changed; we refresh cfg so the
+  // summary's readiness reflects the new embedder, track restart-pending, advance.
+  async function handleDeploySaved(restartKeys: string[]) {
+    const c = await loadConfig();
+    setCfg(c);
+    setPendingRestart((prev) => Array.from(new Set([...prev, ...restartKeys])));
     notifySetupUpdated();
     advance();
   }
@@ -203,7 +215,9 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
               {step.title}{step.optional ? <span style={{ color: '#9aa', fontWeight: 400, fontSize: 12 }}> · optional</span> : null}
             </div>
 
-            {step.kind === 'chooser' ? (
+            {step.kind === 'deploy' ? (
+              <DeployTopology onSaved={handleDeploySaved} />
+            ) : step.kind === 'chooser' ? (
               <PrimaryChooser onConfigured={handlePrimaryConfigured} />
             ) : step.keys.length > 0 ? (
               <div style={{ display: 'grid', gap: 12, marginBottom: 16 }}>

--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -8,7 +8,17 @@
 // set of keys carrying reload_class RELOAD_RESTART in src/config_fields.c (the
 // Postgres pool + the kb API listener bind at startup); every other exposed key
 // applies on the next turn. Keep in sync if a field's reload_class changes.
-export const RESTART_KEYS = new Set<string>(["db2_url", "kb_api_http_port", "kb_api_bearer_token"]);
+export const RESTART_KEYS = new Set<string>([
+  "db2_url", "kb_api_http_port", "kb_api_bearer_token",
+  // Deploy-topology (page-2) record: the deploy layer reads these and the
+  // topology (which containers run) only changes on a restart — RELOAD_RESTART
+  // in src/config_fields.c. (embedding_endpoint/model/dim apply on the next turn.)
+  "kb_mode", "kb_client_url", "kb_client_bearer_token",
+  "llm_embed_backend", "llm_embed_host", "llm_embed_gpu", "llm_embed_tier",
+  "llm_rerank_backend", "llm_rerank_host", "llm_rerank_gpu", "llm_rerank_tier", "llm_rerank_endpoint",
+  "llm_synth_backend", "llm_synth_host", "llm_synth_gpu", "llm_synth_tier", "llm_synth_endpoint",
+  "llm_synth_model",
+]);
 
 // One line per section (see category() in Settings.tsx).
 export const SECTION_HELP: Record<string, string> = {
@@ -76,6 +86,29 @@ export const FIELD_HELP: Record<string, string> = {
   embedding_endpoint: "HTTP endpoint for the embedder when it's a service rather than a command.",
   embedding_dim:
     "Vector width the embedder produces (e.g. 1024, 2560). Has to match what the database columns expect.",
+
+  // Deploy topology (setup wizard page 2). The deploy layer reads these; the
+  // topology only changes on a restart. Set them from the wizard's Deploy page.
+  kb_mode:
+    "Where the knowledge base runs: 'local' deploys an aimee-kb here; 'remote' connects to an existing one (see kb_client_url).",
+  kb_client_url: "URL of an existing aimee-kb to connect to when kb_mode is 'remote'. Nothing is deployed locally.",
+  kb_client_bearer_token: "Bearer token for the remote aimee-kb (kb_mode='remote'). Needs a restart.",
+  llm_embed_backend: "How the embedder is served: 'local' (on the shared aimee-llm container), 'external' (an endpoint), or 'off'.",
+  llm_embed_host: "Host that runs the local aimee-llm container serving the embedder.",
+  llm_embed_gpu: "GPU index on the host for a local embedder; blank runs it on CPU.",
+  llm_embed_tier: "Local embedder tier: cpu / small / mid / large (sizes the model to the card).",
+  llm_rerank_backend: "How the reranker is served: 'local', 'external', or 'off'.",
+  llm_rerank_host: "Host that runs the local reranker.",
+  llm_rerank_gpu: "GPU index on the host for a local reranker; blank runs it on CPU.",
+  llm_rerank_tier: "Local reranker tier: cpu / small / mid / large.",
+  llm_rerank_endpoint: "Endpoint URL for an external reranker.",
+  llm_synth_backend: "How the synthesizer is served: 'local', 'external', or 'off'.",
+  llm_synth_host: "Host that runs the local synthesizer.",
+  llm_synth_gpu: "GPU index on the host for a local synthesizer; blank runs it on CPU.",
+  llm_synth_tier: "Local synthesizer tier: cpu / small / mid / large. CPU serves the Tier-A model only.",
+  llm_synth_endpoint: "Endpoint URL for an external synthesizer.",
+  llm_synth_model: "Model name the synthesizer serves.",
+
   ecomode: "Always route to the cheapest capable agent instead of the default one. Off by default.",
   claude_cli_delegate_enabled:
     "Allow the subscription-logged-in Claude CLI to be used as a delegate, not just the primary. Off by default — driving a personal Claude subscription as an automated delegate may breach Anthropic's terms.",

--- a/frontend/src/setup/DeployTopology.tsx
+++ b/frontend/src/setup/DeployTopology.tsx
@@ -1,0 +1,333 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useToast } from '@rakuensoftware/smoothgui';
+import { loadConfig, saveConfigValue, type ConfigMap } from './configApi';
+import { isRestartKey } from './wizardSteps';
+import {
+  ROLES,
+  type Role,
+  type Placement,
+  type KbMode,
+  type HostInfo,
+  placementOptions,
+  placementOptionId,
+  configToPlacement,
+  synthIsTierAOnly,
+  buildDesiredConfig,
+} from './deployTopology';
+
+/* Wizard page 2 — Deploy topology. Places the three LLM roles and the knowledge
+ * base onto the page-2 config record (kb_mode + per-role llm_*), which
+ * `aimee config deploy-env` translates to the compose stack. Every write goes
+ * through the existing /api/config/set allowlist (no new backend). All local
+ * roles share ONE aimee-llm container on the chosen host; a remote KB deploys
+ * nothing locally, so the LLM section is hidden for it.
+ *
+ * Self-contained like PrimaryChooser: it loads config + GET /api/hosts, guards
+ * every save (Toast + stay put on failure), and reports the restart-class keys it
+ * changed so the wizard can list them on its summary. */
+
+function csrf(): string {
+  try {
+    if (typeof window !== 'undefined') return (window as { _csrf?: string })._csrf || '';
+  } catch {
+    /* ignore */
+  }
+  return '';
+}
+
+async function fetchHosts(fetchImpl?: typeof fetch): Promise<HostInfo[]> {
+  const f = fetchImpl ?? fetch;
+  try {
+    const r = await f('/api/hosts', { headers: { 'X-CSRF-Token': csrf() } });
+    const d = (await r.json()) as { hosts?: HostInfo[] };
+    return Array.isArray(d.hosts) ? d.hosts : [];
+  } catch {
+    return [];
+  }
+}
+
+export interface DeployTopologyProps {
+  /** Called after every changed key is persisted; the argument is the set of
+   * changed keys that only take effect after a server restart. */
+  onSaved: (restartKeys: string[]) => void | Promise<void>;
+  /** Injected in tests (vitest node env has no real network). */
+  fetchImpl?: typeof fetch;
+}
+
+interface RoleUi {
+  optionId: string; // from placementOptions(host): 'cpu' | 'gpu:<i>' | 'external'
+  endpoint: string; // external endpoint text
+}
+
+export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyProps) {
+  const toast = useToast();
+  const [cfg, setCfg] = useState<ConfigMap>({});
+  const [hosts, setHosts] = useState<HostInfo[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const [kbMode, setKbMode] = useState<KbMode>('local');
+  const [kbUrl, setKbUrl] = useState('');
+  const [kbBearer, setKbBearer] = useState('');
+
+  const [hostName, setHostName] = useState('');
+  const [roleUi, setRoleUi] = useState<Record<Role, RoleUi>>({
+    embed: { optionId: 'cpu', endpoint: '' },
+    rerank: { optionId: 'cpu', endpoint: '' },
+    synth: { optionId: 'cpu', endpoint: '' },
+  });
+  const [synthModel, setSynthModel] = useState('');
+  const [embedModel, setEmbedModel] = useState('');
+  const [embedDim, setEmbedDim] = useState('');
+
+  // Load config + host inventory once on mount.
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const [c, h] = await Promise.all([loadConfig({ fetchImpl }), fetchHosts(fetchImpl)]);
+      if (!alive) return;
+      setCfg(c);
+      setHosts(h);
+      setKbMode(String(c.kb_mode ?? 'local') === 'remote' ? 'remote' : 'local');
+      setKbUrl(String(c.kb_client_url ?? ''));
+      setKbBearer(String(c.kb_client_bearer_token ?? ''));
+      setSynthModel(String(c.llm_synth_model ?? ''));
+      setEmbedModel(String(c.embedding_model ?? ''));
+      setEmbedDim(c.embedding_dim == null ? '' : String(c.embedding_dim));
+
+      // Seed the host from any local role that names one, else the local host.
+      // Fall back to an AVAILABLE host if the recorded one is no longer in the
+      // inventory — otherwise `host` is undefined and every local role silently
+      // resolves to CPU, so a Save would downgrade saved GPU placements.
+      const localOrFirst = h.find((x) => x.kind === 'local')?.name || h[0]?.name || '';
+      const recorded =
+        String(c.llm_embed_host ?? '') ||
+        String(c.llm_rerank_host ?? '') ||
+        String(c.llm_synth_host ?? '');
+      const seededHost = recorded && h.some((x) => x.name === recorded) ? recorded : localOrFirst;
+      setHostName(seededHost);
+
+      const ui = {} as Record<Role, RoleUi>;
+      for (const { role } of ROLES) {
+        const p = configToPlacement(c, role);
+        ui[role] = {
+          optionId: placementOptionId(p),
+          endpoint: p.backend === 'external' ? p.endpoint : '',
+        };
+      }
+      setRoleUi(ui);
+      setLoaded(true);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [fetchImpl]);
+
+  const host = useMemo(() => hosts.find((h) => h.name === hostName), [hosts, hostName]);
+  const options = useMemo(() => placementOptions(host), [host]);
+
+  // Resolve a role's UI selection to a concrete Placement (host-aware).
+  const resolvePlacement = useCallback(
+    (role: Role): Placement => {
+      const ui = roleUi[role];
+      if (ui.optionId === 'external') return { backend: 'external', endpoint: ui.endpoint.trim() };
+      const opt = options.find((o) => o.id === ui.optionId) ?? options[0];
+      return opt.placement;
+    },
+    [roleUi, options],
+  );
+
+  const setRole = (role: Role, patch: Partial<RoleUi>) =>
+    setRoleUi((p) => ({ ...p, [role]: { ...p[role], ...patch } }));
+
+  // When the host changes, a previously chosen GPU may not exist — fall back to CPU.
+  useEffect(() => {
+    if (!loaded) return;
+    setRoleUi((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const { role } of ROLES) {
+        const id = prev[role].optionId;
+        if (id !== 'external' && !options.some((o) => o.id === id)) {
+          next[role] = { ...prev[role], optionId: 'cpu' };
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [options, loaded]);
+
+  async function save() {
+    setSaving(true);
+    setError('');
+
+    // Build the full desired {key: value} map for the current selection.
+    const desired = buildDesiredConfig({
+      kbMode,
+      kbUrl,
+      kbBearer,
+      placements: { embed: resolvePlacement('embed'), rerank: resolvePlacement('rerank'), synth: resolvePlacement('synth') },
+      embedModel,
+      embedDim,
+      synthModel,
+    });
+
+    // Persist only what changed (mirrors SetupWizard.saveStep); abort + Toast on
+    // the first failure, keeping the operator on the page with input intact.
+    const savedCfg: ConfigMap = { ...cfg };
+    const restart = new Set<string>();
+    for (const [key, value] of Object.entries(desired)) {
+      const original = cfg[key] == null ? '' : String(cfg[key]);
+      if (value === original) continue;
+      const coerced: unknown = key === 'embedding_dim' ? (value === '' ? '' : Number(value)) : value;
+      const res = await saveConfigValue(key, coerced);
+      if (!res.ok) {
+        setError(`Couldn’t save ${key}: ${res.error ?? 'unknown error'}`);
+        toast.error(`Couldn’t save ${key}: ${res.error ?? 'unknown error'}`);
+        setSaving(false);
+        setCfg(savedCfg); // keep whatever already succeeded
+        return;
+      }
+      savedCfg[key] = res.value !== undefined ? res.value : coerced;
+      if (isRestartKey(key)) restart.add(key);
+    }
+
+    setCfg(savedCfg);
+    setSaving(false);
+    toast.success('Deploy topology saved');
+    await onSaved(Array.from(restart));
+  }
+
+  if (!loaded) {
+    return <div style={{ fontSize: 13, color: '#667', padding: '8px 0' }}>Loading hosts…</div>;
+  }
+
+  const remote = kbMode === 'remote';
+
+  return (
+    <div style={{ display: 'grid', gap: 16, marginBottom: 8 }}>
+      {/* Section A — Knowledge base */}
+      <section style={{ display: 'grid', gap: 8 }}>
+        <div style={sectionTitle}>Knowledge base</div>
+        <label style={radioRow}>
+          <input type="radio" checked={!remote} onChange={() => setKbMode('local')} />
+          <span>Deploy a local knowledge base (recommended)</span>
+        </label>
+        <label style={radioRow}>
+          <input type="radio" checked={remote} onChange={() => setKbMode('remote')} />
+          <span>Connect to an existing aimee-kb</span>
+        </label>
+        {remote && (
+          <div style={{ display: 'grid', gap: 8, paddingLeft: 24 }}>
+            <div style={{ fontSize: 11.5, color: '#778' }}>
+              A remote KB deploys nothing here — aimee-server just connects to it. LLM placement below is skipped.
+            </div>
+            <Field label="aimee-kb URL">
+              <input style={input} value={kbUrl} onChange={(e) => setKbUrl(e.target.value)} placeholder="https://kb.example:8760" />
+            </Field>
+            <Field label="Bearer token">
+              <input style={input} type="password" autoComplete="off" value={kbBearer}
+                onChange={(e) => setKbBearer(e.target.value)} placeholder="token" />
+            </Field>
+          </div>
+        )}
+      </section>
+
+      {/* Section B — LLM placement (local KB only) */}
+      {!remote && (
+        <section style={{ display: 'grid', gap: 10 }}>
+          <div style={sectionTitle}>LLM placement</div>
+          <Field label="Host for the local LLM container">
+            <select style={input} value={hostName} onChange={(e) => setHostName(e.target.value)}>
+              {hosts.map((h) => (
+                <option key={h.name} value={h.name}>
+                  {h.name} ({h.kind}){h.gpus.length ? ` · ${h.gpus.length} GPU${h.gpus.length > 1 ? 's' : ''}` : ' · CPU only'}
+                </option>
+              ))}
+            </select>
+          </Field>
+          {host?.error && (
+            <div style={{ fontSize: 11.5, color: '#a33' }}>Probe error on {host.name}: {host.error} — CPU still available.</div>
+          )}
+          <div style={{ fontSize: 11.5, color: '#778', marginTop: -2 }}>
+            All GPU/CPU-placed roles run on one aimee-llm container on this host.
+          </div>
+
+          {ROLES.map(({ role, label, blurb }) => {
+            const ui = roleUi[role];
+            const p = resolvePlacement(role);
+            const tierA = synthIsTierAOnly(role, p);
+            return (
+              <div key={role} style={roleCard}>
+                <div style={{ fontSize: 13.5, fontWeight: 700 }}>{label}</div>
+                <div style={{ fontSize: 11.5, color: '#778', marginBottom: 4 }}>{blurb}</div>
+                <select style={input} value={ui.optionId} onChange={(e) => setRole(role, { optionId: e.target.value })}>
+                  {options.map((o) => (
+                    <option key={o.id} value={o.id}>{o.label}</option>
+                  ))}
+                </select>
+                {ui.optionId === 'external' && (
+                  <input style={{ ...input, marginTop: 6 }} value={ui.endpoint}
+                    onChange={(e) => setRole(role, { endpoint: e.target.value })}
+                    placeholder={role === 'embed' ? 'https://embedder.example/v1' : 'https://llm.example/v1'} />
+                )}
+                {role === 'embed' && ui.optionId === 'external' && (
+                  <div style={{ display: 'grid', gap: 6, marginTop: 6 }}>
+                    <input style={input} value={embedModel} onChange={(e) => setEmbedModel(e.target.value)} placeholder="embedding model" />
+                    <input style={input} value={embedDim} onChange={(e) => setEmbedDim(e.target.value)} placeholder="embedding dim (e.g. 1024)" inputMode="numeric" />
+                  </div>
+                )}
+                {role === 'embed' && ui.optionId !== 'external' && ui.optionId !== 'off' && (
+                  <div style={{ fontSize: 11, color: '#889', marginTop: 4 }}>Dimension auto-detected from the tier at runtime.</div>
+                )}
+                {role === 'synth' && p.backend !== 'off' && ui.optionId !== 'external' && (
+                  <input style={{ ...input, marginTop: 6 }} value={synthModel}
+                    onChange={(e) => setSynthModel(e.target.value)} placeholder="synth model" />
+                )}
+                {tierA && (
+                  <div style={{ fontSize: 11, color: '#8a5a00', marginTop: 4 }}>CPU runs the Tier-A synth model only.</div>
+                )}
+              </div>
+            );
+          })}
+        </section>
+      )}
+
+      {error && (
+        <div style={{ fontSize: 12.5, color: '#a33', background: '#fdeaea', border: '1px solid #f2c4c4', borderRadius: 6, padding: '8px 10px' }}>
+          {error}
+        </div>
+      )}
+
+      <div>
+        <button style={primaryBtn} disabled={saving} onClick={save}>
+          {saving ? 'Saving…' : 'Save & continue'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const sectionTitle: React.CSSProperties = { fontSize: 14, fontWeight: 700, color: '#233' };
+const radioRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer' };
+const roleCard: React.CSSProperties = {
+  display: 'grid', gap: 2, padding: '10px 12px', borderRadius: 9, border: '1px solid #dde', background: '#fbfcfe',
+};
+const input: React.CSSProperties = {
+  width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
+  border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
+};
+const primaryBtn: React.CSSProperties = {
+  padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
+  color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
+};
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: 'block' }}>
+      <div style={{ fontSize: 12.5, fontWeight: 600, marginBottom: 3 }}>{label}</div>
+      {children}
+    </label>
+  );
+}

--- a/frontend/src/setup/deployTopology.test.ts
+++ b/frontend/src/setup/deployTopology.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+import {
+  vramToTier,
+  roleKeys,
+  placementToConfig,
+  configToPlacement,
+  synthIsTierAOnly,
+  placementOptions,
+  placementOptionId,
+  buildDesiredConfig,
+  ALL_ROLE_KEYS,
+  ROLES,
+  type Placement,
+  type HostInfo,
+  type DeploySelection,
+} from './deployTopology';
+
+/* The page-2 keys the server's /api/config/set allowlist accepts (mirrors
+ * src/config_fields.c). Any key placementToConfig emits MUST be in here, or the
+ * wizard would POST an un-settable key. */
+const ALLOWLISTED = new Set<string>([
+  'kb_mode', 'kb_client_url', 'kb_client_bearer_token',
+  'llm_embed_backend', 'llm_embed_host', 'llm_embed_gpu', 'llm_embed_tier',
+  'llm_rerank_backend', 'llm_rerank_host', 'llm_rerank_gpu', 'llm_rerank_tier', 'llm_rerank_endpoint',
+  'llm_synth_backend', 'llm_synth_host', 'llm_synth_gpu', 'llm_synth_tier', 'llm_synth_endpoint',
+  'llm_synth_model',
+  'embedding_endpoint', 'embedding_model', 'embedding_dim',
+]);
+
+describe('vramToTier', () => {
+  it('sizes a card to the largest tier it can host', () => {
+    expect(vramToTier(16 * 1024)).toBe('small');
+    expect(vramToTier(24 * 1024)).toBe('mid'); // e.g. 7900 XTX
+    expect(vramToTier(32 * 1024)).toBe('large');
+    expect(vramToTier(8 * 1024)).toBe('small'); // tiny GPU still labels small
+  });
+});
+
+describe('roleKeys', () => {
+  it('embed reuses embedding_endpoint; rerank/synth have their own', () => {
+    expect(roleKeys('embed').endpoint).toBe('embedding_endpoint');
+    expect(roleKeys('rerank').endpoint).toBe('llm_rerank_endpoint');
+    expect(roleKeys('synth').endpoint).toBe('llm_synth_endpoint');
+    expect(roleKeys('synth').backend).toBe('llm_synth_backend');
+  });
+});
+
+describe('placementToConfig only emits allowlisted keys', () => {
+  it('every produced key is settable via /api/config/set', () => {
+    const samples: Placement[] = [
+      { backend: 'local', tier: 'mid', host: 'smoothnas', gpu: '0' },
+      { backend: 'external', endpoint: 'https://e' },
+      { backend: 'off' },
+    ];
+    for (const { role } of ROLES) {
+      for (const p of samples) {
+        for (const k of Object.keys(placementToConfig(role, p))) {
+          expect(ALLOWLISTED.has(k), `${role}: ${k} not allowlisted`).toBe(true);
+        }
+      }
+    }
+    for (const k of ALL_ROLE_KEYS) expect(ALLOWLISTED.has(k)).toBe(true);
+  });
+});
+
+describe('placementToConfig clears stale sibling fields', () => {
+  it('external clears tier/host/gpu; local clears endpoint; off clears all', () => {
+    expect(placementToConfig('rerank', { backend: 'external', endpoint: 'https://r' })).toEqual({
+      llm_rerank_backend: 'external', llm_rerank_endpoint: 'https://r',
+      llm_rerank_tier: '', llm_rerank_host: '', llm_rerank_gpu: '',
+    });
+    expect(placementToConfig('embed', { backend: 'local', tier: 'large', host: 'h', gpu: '1' })).toEqual({
+      llm_embed_backend: 'local', llm_embed_tier: 'large', llm_embed_host: 'h', llm_embed_gpu: '1',
+      embedding_endpoint: '',
+    });
+    expect(placementToConfig('synth', { backend: 'off' })).toEqual({
+      llm_synth_backend: 'off', llm_synth_tier: '', llm_synth_host: '', llm_synth_gpu: '', llm_synth_endpoint: '',
+    });
+  });
+});
+
+describe('configToPlacement round-trips placementToConfig', () => {
+  const cases: { role: Parameters<typeof roleKeys>[0]; p: Placement }[] = [
+    { role: 'embed', p: { backend: 'local', tier: 'large', host: 'box', gpu: '0' } },
+    { role: 'rerank', p: { backend: 'local', tier: 'cpu', host: 'box', gpu: '' } },
+    { role: 'synth', p: { backend: 'external', endpoint: 'https://s' } },
+    { role: 'synth', p: { backend: 'off' } },
+  ];
+  for (const { role, p } of cases) {
+    it(`${role} ${p.backend}`, () => {
+      expect(configToPlacement(placementToConfig(role, p), role)).toEqual(p);
+    });
+  }
+
+  it('an unset backend defaults to local cpu (simplest working choice)', () => {
+    expect(configToPlacement({}, 'embed')).toEqual({ backend: 'local', tier: 'cpu', host: '', gpu: '' });
+  });
+});
+
+describe('synthIsTierAOnly', () => {
+  it('is true only for the synthesizer on CPU', () => {
+    expect(synthIsTierAOnly('synth', { backend: 'local', tier: 'cpu', host: 'h', gpu: '' })).toBe(true);
+    expect(synthIsTierAOnly('synth', { backend: 'local', tier: 'mid', host: 'h', gpu: '0' })).toBe(false);
+    expect(synthIsTierAOnly('embed', { backend: 'local', tier: 'cpu', host: 'h', gpu: '' })).toBe(false);
+    expect(synthIsTierAOnly('synth', { backend: 'external', endpoint: 'x' })).toBe(false);
+  });
+});
+
+describe('placementOptions / placementOptionId', () => {
+  const host: HostInfo = {
+    name: 'smoothnas', kind: 'local',
+    gpus: [{ index: 0, name: 'AMD 7900 XTX', vendor: 'amd', vram_mb: 24 * 1024 }],
+  };
+  it('offers CPU, each GPU (tier from VRAM), External, and Off; GPU pins the host', () => {
+    const opts = placementOptions(host);
+    expect(opts.map((o) => o.id)).toEqual(['cpu', 'gpu:0', 'external', 'off']);
+    const gpu = opts.find((o) => o.id === 'gpu:0')!;
+    expect(gpu.placement).toEqual({ backend: 'local', tier: 'mid', host: 'smoothnas', gpu: '0' });
+    expect(gpu.label).toContain('mid');
+  });
+  it('placementOptionId selects the matching control (incl. off, so it round-trips)', () => {
+    expect(placementOptionId({ backend: 'local', tier: 'cpu', host: 'h', gpu: '' })).toBe('cpu');
+    expect(placementOptionId({ backend: 'local', tier: 'mid', host: 'h', gpu: '0' })).toBe('gpu:0');
+    expect(placementOptionId({ backend: 'external', endpoint: 'x' })).toBe('external');
+    expect(placementOptionId({ backend: 'off' })).toBe('off');
+    // The 'off' id resolves back to an off placement via the options list, so a
+    // stored off role is never silently re-enabled as cpu.
+    const off = placementOptions(host).find((o) => o.id === 'off')!;
+    expect(off.placement).toEqual({ backend: 'off' });
+  });
+  it('degrades to CPU + External + Off when a host has no GPUs', () => {
+    expect(placementOptions({ name: 'l', kind: 'local', gpus: [] }).map((o) => o.id)).toEqual(['cpu', 'external', 'off']);
+  });
+});
+
+/* The three example topologies the operator described — assert the exact keys
+ * that would be persisted match the shipped deploy-env contract. */
+describe('traced example topologies', () => {
+  it('large embedder + cpu reranker + external synth', () => {
+    const written = {
+      ...placementToConfig('embed', { backend: 'local', tier: 'large', host: 'box', gpu: '0' }),
+      ...placementToConfig('rerank', { backend: 'local', tier: 'cpu', host: 'box', gpu: '' }),
+      ...placementToConfig('synth', { backend: 'external', endpoint: 'https://synth' }),
+    };
+    expect(written.llm_embed_backend).toBe('local');
+    expect(written.llm_embed_tier).toBe('large');
+    expect(written.llm_rerank_backend).toBe('local');
+    expect(written.llm_rerank_tier).toBe('cpu');
+    expect(written.llm_synth_backend).toBe('external');
+    expect(written.llm_synth_endpoint).toBe('https://synth');
+  });
+
+  it('cpu embedder + mid reranker + small synth (one shared local container)', () => {
+    const written = {
+      ...placementToConfig('embed', { backend: 'local', tier: 'cpu', host: 'box', gpu: '' }),
+      ...placementToConfig('rerank', { backend: 'local', tier: 'mid', host: 'box', gpu: '0' }),
+      ...placementToConfig('synth', { backend: 'local', tier: 'small', host: 'box', gpu: '0' }),
+    };
+    expect(written.llm_embed_tier).toBe('cpu');
+    expect(written.llm_rerank_tier).toBe('mid');
+    expect(written.llm_synth_tier).toBe('small');
+    // all local → same host (single aimee-llm container)
+    expect(written.llm_embed_host).toBe('box');
+    expect(written.llm_rerank_host).toBe('box');
+    expect(written.llm_synth_host).toBe('box');
+  });
+});
+
+describe('buildDesiredConfig (the full save map)', () => {
+  const localSel = (over: Partial<DeploySelection> = {}): DeploySelection => ({
+    kbMode: 'local',
+    kbUrl: '',
+    kbBearer: '',
+    placements: {
+      embed: { backend: 'local', tier: 'large', host: 'box', gpu: '0' },
+      rerank: { backend: 'local', tier: 'cpu', host: 'box', gpu: '' },
+      synth: { backend: 'external', endpoint: 'https://synth' },
+    },
+    embedModel: '',
+    embedDim: '',
+    synthModel: 'aimee-synth',
+    ...over,
+  });
+
+  it('local KB writes kb_mode + every role placement + synth model', () => {
+    const m = buildDesiredConfig(localSel());
+    expect(m.kb_mode).toBe('local');
+    expect(m.llm_embed_backend).toBe('local');
+    expect(m.llm_embed_tier).toBe('large');
+    expect(m.llm_rerank_tier).toBe('cpu');
+    expect(m.llm_synth_backend).toBe('external');
+    expect(m.llm_synth_endpoint).toBe('https://synth');
+    expect(m.llm_synth_model).toBe('aimee-synth');
+    // no external embedder → no embedding_model/dim written
+    expect('embedding_model' in m).toBe(false);
+  });
+
+  it('external embedder writes embedding_endpoint + model + dim', () => {
+    const m = buildDesiredConfig(
+      localSel({
+        placements: {
+          embed: { backend: 'external', endpoint: 'https://emb' },
+          rerank: { backend: 'off' },
+          synth: { backend: 'off' },
+        },
+        embedModel: 'pplx-embed',
+        embedDim: '1024',
+      }),
+    );
+    expect(m.embedding_endpoint).toBe('https://emb');
+    expect(m.embedding_model).toBe('pplx-embed');
+    expect(m.embedding_dim).toBe('1024');
+  });
+
+  it('a blank embedding_dim is omitted (never POSTed as "" to the int field)', () => {
+    const m = buildDesiredConfig(
+      localSel({
+        placements: {
+          embed: { backend: 'external', endpoint: 'https://emb' },
+          rerank: { backend: 'off' },
+          synth: { backend: 'off' },
+        },
+        embedModel: 'e',
+        embedDim: '   ',
+      }),
+    );
+    expect('embedding_dim' in m).toBe(false);
+    expect(m.embedding_model).toBe('e');
+  });
+
+  it('remote KB writes ONLY kb_* and skips all LLM placement (section B hidden)', () => {
+    const m = buildDesiredConfig({
+      ...localSel(),
+      kbMode: 'remote',
+      kbUrl: 'https://kb.example:8760',
+      kbBearer: 'secret',
+    });
+    expect(m).toEqual({
+      kb_mode: 'remote',
+      kb_client_url: 'https://kb.example:8760',
+      kb_client_bearer_token: 'secret',
+    });
+    expect(Object.keys(m).some((k) => k.startsWith('llm_'))).toBe(false);
+  });
+});

--- a/frontend/src/setup/deployTopology.ts
+++ b/frontend/src/setup/deployTopology.ts
@@ -1,0 +1,209 @@
+/* Deploy-topology (wizard page 2) — pure model + config mapping. No DOM, no
+ * network: the whole key-translation contract is unit-tested (deployTopology.test.ts).
+ *
+ * The page places three LLM roles (embedder / reranker / synthesizer) and picks
+ * the knowledge-base mode. Every value it persists goes through the SAME page-2
+ * config record the backend shipped in p1–p2b (kb_mode + per-role llm_* keys),
+ * which `aimee config deploy-env` already translates to compose env. All local
+ * roles share ONE aimee-llm container; the tier tokens cpu/small/mid/large are
+ * exactly the valid AIMEE_LLM_TIER values, and backend local|external|off maps
+ * to AIMEE_LLM_<ROLE>_MODE. See deploy/compose + src/config_database.c. */
+
+export type Role = 'embed' | 'rerank' | 'synth';
+
+export const ROLES: { role: Role; label: string; blurb: string }[] = [
+  { role: 'embed', label: 'Embedder', blurb: 'Turns text into vectors for search + memory.' },
+  { role: 'rerank', label: 'Reranker', blurb: 'Re-scores retrieved candidates for relevance.' },
+  { role: 'synth', label: 'Synthesizer', blurb: 'Writes the knowledge-base curation + summaries.' },
+];
+
+/** A local LLM tier. cpu = no GPU; small/mid/large size the co-hosted model to
+ * the card. These are the literal AIMEE_LLM_TIER tokens. */
+export type Tier = 'cpu' | 'small' | 'mid' | 'large';
+export const GPU_TIERS: Tier[] = ['small', 'mid', 'large'];
+
+/** How a role is served. `local` runs on the shared aimee-llm container at a
+ * tier on a chosen host+GPU; `external` points at an existing endpoint; `off`
+ * disables the role. */
+export type Placement =
+  | { backend: 'local'; tier: Tier; host: string; gpu: string }
+  | { backend: 'external'; endpoint: string }
+  | { backend: 'off' };
+
+export type KbMode = 'local' | 'remote';
+
+/** Map a card's VRAM to the largest tier it can host. Documented sizing:
+ * small≈16 GB, mid≈24 GB, large≈32 GB (deploy/compose/aimee.gpu.yaml). A little
+ * headroom is allowed under each floor; a GPU smaller than `small` still labels
+ * `small` (best effort — the operator can drop to cpu). */
+export function vramToTier(vram_mb: number): Tier {
+  const gb = vram_mb / 1024;
+  if (gb >= 30) return 'large';
+  if (gb >= 22) return 'mid';
+  return 'small';
+}
+
+export interface RoleKeys {
+  backend: string;
+  host: string;
+  gpu: string;
+  tier: string;
+  /** External endpoint key. The embed role reuses `embedding_endpoint` (there is
+   * no `llm_embed_endpoint`); rerank/synth have their own. */
+  endpoint: string;
+}
+
+export function roleKeys(role: Role): RoleKeys {
+  return {
+    backend: `llm_${role}_backend`,
+    host: `llm_${role}_host`,
+    gpu: `llm_${role}_gpu`,
+    tier: `llm_${role}_tier`,
+    endpoint: role === 'embed' ? 'embedding_endpoint' : `llm_${role}_endpoint`,
+  };
+}
+
+/** The synthesizer on CPU can only serve the Tier-A model (the GPU tiers add
+ * Tier-B); the UI constrains the synth model + hides larger tiers accordingly.
+ * (deploy/smoothnas/aimee-kb.plugin.yaml: "CPU tier = Tier-A synth".) */
+export function synthIsTierAOnly(role: Role, p: Placement): boolean {
+  return role === 'synth' && p.backend === 'local' && p.tier === 'cpu';
+}
+
+/** Every page-2 key this page may write, per role — used by a test to assert the
+ * mapping never emits an off-allowlist key. */
+export const ALL_ROLE_KEYS: string[] = ROLES.flatMap(({ role }) => {
+  const k = roleKeys(role);
+  return [k.backend, k.host, k.gpu, k.tier, k.endpoint];
+});
+
+/** Translate a role's placement selection into the {key: value} config map to
+ * persist. Fields not relevant to the chosen backend are cleared ('') so a
+ * switch (e.g. local→external) never leaves a stale host/tier/endpoint behind. */
+export function placementToConfig(role: Role, p: Placement): Record<string, string> {
+  const k = roleKeys(role);
+  const base = { [k.backend]: '', [k.host]: '', [k.gpu]: '', [k.tier]: '', [k.endpoint]: '' };
+  if (p.backend === 'local') {
+    return { ...base, [k.backend]: 'local', [k.tier]: p.tier, [k.host]: p.host, [k.gpu]: p.gpu };
+  }
+  if (p.backend === 'external') {
+    return { ...base, [k.backend]: 'external', [k.endpoint]: p.endpoint };
+  }
+  return { ...base, [k.backend]: 'off' };
+}
+
+/** The operator's full page-2 selection, independent of the DOM. */
+export interface DeploySelection {
+  kbMode: KbMode;
+  kbUrl: string;
+  kbBearer: string;
+  placements: Record<Role, Placement>;
+  embedModel: string;
+  embedDim: string;
+  synthModel: string;
+}
+
+/** Build the complete {key: value} config map a selection would persist. A
+ * remote KB deploys nothing locally, so ONLY the kb_* keys are written (the LLM
+ * placement is skipped, mirroring `deploy-env`'s early return). Otherwise every
+ * role's placement is emitted, plus the external-embedder model/dim and the
+ * synth model. Pure — the component saves only the keys that changed vs config. */
+export function buildDesiredConfig(sel: DeploySelection): Record<string, string> {
+  const out: Record<string, string> = { kb_mode: sel.kbMode };
+  if (sel.kbMode === 'remote') {
+    out.kb_client_url = sel.kbUrl.trim();
+    out.kb_client_bearer_token = sel.kbBearer.trim();
+    return out;
+  }
+  for (const { role } of ROLES) {
+    const p = sel.placements[role];
+    Object.assign(out, placementToConfig(role, p));
+    if (role === 'embed' && p.backend === 'external') {
+      out.embedding_model = sel.embedModel.trim();
+      // embedding_dim is a CFG_INT key — only emit it when set, never a blank
+      // string (which would reach the int allowlist as '').
+      const dim = sel.embedDim.trim();
+      if (dim !== '') out.embedding_dim = dim;
+    }
+    if (role === 'synth' && p.backend !== 'off') {
+      out.llm_synth_model = sel.synthModel.trim();
+    }
+  }
+  return out;
+}
+
+function str(cfg: Record<string, unknown>, key: string): string {
+  const v = cfg[key];
+  return v == null ? '' : String(v);
+}
+
+/** Recover the current placement for a role from a loaded config map. An unset
+ * or `local` backend reads as local (default cpu tier) so a fresh instance lands
+ * on the simplest working choice. */
+export function configToPlacement(cfg: Record<string, unknown>, role: Role): Placement {
+  const k = roleKeys(role);
+  const backend = str(cfg, k.backend);
+  if (backend === 'external') return { backend: 'external', endpoint: str(cfg, k.endpoint) };
+  if (backend === 'off') return { backend: 'off' };
+  const tier = str(cfg, k.tier) as Tier;
+  return {
+    backend: 'local',
+    tier: tier === 'small' || tier === 'mid' || tier === 'large' ? tier : 'cpu',
+    host: str(cfg, k.host),
+    gpu: str(cfg, k.gpu),
+  };
+}
+
+// --- Host inventory (GET /api/hosts) -------------------------------------
+export interface HostGpu {
+  index: number;
+  name: string;
+  vendor: string;
+  vram_mb: number;
+}
+export interface HostInfo {
+  name: string;
+  kind: 'local' | 'remote';
+  ip?: string;
+  gpus: HostGpu[];
+  error?: string;
+}
+
+/** One selectable placement option for a role, given the chosen host. */
+export interface PlacementOption {
+  id: string; // 'cpu' | 'gpu:<index>' | 'external'
+  label: string;
+  placement: Placement;
+}
+
+/** Build the per-role option list for the selected host: CPU, one per GPU (tier
+ * derived from VRAM), and External. `gpu:<index>` placements carry the host name
+ * so all local roles pin to the single shared container's host. */
+export function placementOptions(host: HostInfo | undefined): PlacementOption[] {
+  const opts: PlacementOption[] = [
+    { id: 'cpu', label: 'CPU', placement: { backend: 'local', tier: 'cpu', host: host?.name ?? '', gpu: '' } },
+  ];
+  for (const g of host?.gpus ?? []) {
+    const tier = vramToTier(g.vram_mb);
+    const gb = Math.round(g.vram_mb / 1024);
+    opts.push({
+      id: `gpu:${g.index}`,
+      label: `${g.name} · ${gb} GB (${tier})`,
+      placement: { backend: 'local', tier, host: host?.name ?? '', gpu: String(g.index) },
+    });
+  }
+  opts.push({ id: 'external', label: 'External host', placement: { backend: 'external', endpoint: '' } });
+  // `off` must be a first-class option: without it a role already stored as
+  // backend='off' has no matching <select> entry, renders as the first option
+  // (cpu), and the next save silently re-enables it as local cpu.
+  opts.push({ id: 'off', label: 'Off (disabled)', placement: { backend: 'off' } });
+  return opts;
+}
+
+/** Which option id a placement currently corresponds to (for selecting the right
+ * control). A local GPU placement matches `gpu:<gpu>`; local cpu → 'cpu'. */
+export function placementOptionId(p: Placement): string {
+  if (p.backend === 'external') return 'external';
+  if (p.backend === 'off') return 'off';
+  return p.tier === 'cpu' && !p.gpu ? 'cpu' : `gpu:${p.gpu}`;
+}

--- a/frontend/src/setup/readiness.ts
+++ b/frontend/src/setup/readiness.ts
@@ -19,6 +19,7 @@ export const READINESS_KEYS = [
   'provider',
   'embedding_command',
   'embedding_endpoint',
+  'llm_embed_backend',
   'db2_url',
   'kb_api_http_port',
 ] as const;
@@ -55,6 +56,10 @@ export function computeReadiness(cfg: Record<string, unknown>, hasProject: boole
   const provider = asStr(cfg, 'provider');
   const embCmd = asStr(cfg, 'embedding_command');
   const embEndpoint = asStr(cfg, 'embedding_endpoint');
+  // The deploy-topology page places the embedder as a role (local container or
+  // external), which also configures a real embedder.
+  const embBackend = asStr(cfg, 'llm_embed_backend');
+  const embConfigured = embCmd !== '' || embEndpoint !== '' || embBackend === 'local' || embBackend === 'external';
   const db2 = asStr(cfg, 'db2_url');
   const kbPort = asNum(cfg, 'kb_api_http_port');
 
@@ -64,10 +69,10 @@ export function computeReadiness(cfg: Record<string, unknown>, hasProject: boole
       detail: provider !== '' ? `primary: ${provider}` : 'no primary provider set',
     },
     embedding: {
-      // A real embedder is a command or an endpoint; blank means the built-in
-      // 384-dim hash fallback, which only works in a test setup.
-      ok: embCmd !== '' || embEndpoint !== '',
-      detail: embCmd !== '' || embEndpoint !== '' ? 'embedder configured' : 'built-in hash fallback (test-only)',
+      // A real embedder is a command, an endpoint, or a placed embed role; blank
+      // means the built-in 384-dim hash fallback, which only works in a test setup.
+      ok: embConfigured,
+      detail: embConfigured ? 'embedder configured' : 'built-in hash fallback (test-only)',
     },
     db2: {
       ok: db2 !== '',

--- a/frontend/src/setup/wizardSteps.test.ts
+++ b/frontend/src/setup/wizardSteps.test.ts
@@ -11,6 +11,16 @@ describe('WIZARD_STEPS structure', () => {
     expect(new Set(ids).size).toBe(ids.length); // no dupes
   });
 
+  it('provider is the chooser and page 2 is the bespoke deploy-topology step', () => {
+    const provider = WIZARD_STEPS.find((s) => s.id === 'provider')!;
+    expect(provider.kind).toBe('chooser');
+    // Page 2 (the second step) is the deploy-topology page: bespoke, no generic keys.
+    const page2 = WIZARD_STEPS[1];
+    expect(page2.kind).toBe('deploy');
+    expect(page2.keys).toEqual([]);
+    expect(page2.title).toMatch(/deploy/i);
+  });
+
   it('kb_api is optional and project is a hand-off (route, no keys)', () => {
     const kb = WIZARD_STEPS.find((s) => s.id === 'kb_api')!;
     const project = WIZARD_STEPS.find((s) => s.id === 'project')!;

--- a/frontend/src/setup/wizardSteps.ts
+++ b/frontend/src/setup/wizardSteps.ts
@@ -18,14 +18,17 @@ export interface WizardStep {
   route?: string;
   /** One-line "what you lose if you skip", shown for optional steps. */
   skipNote?: string;
-  /** A step whose body is a bespoke component (the primary chooser) rather than
-   * the generic key inputs. Rendered specially by SetupWizard. */
-  kind?: 'chooser';
+  /** A step whose body is a bespoke component rather than the generic key
+   * inputs: 'chooser' = the primary chooser, 'deploy' = the deploy-topology page.
+   * Rendered specially by SetupWizard. */
+  kind?: 'chooser' | 'deploy';
 }
 
 export const WIZARD_STEPS: WizardStep[] = [
   { id: 'provider', title: 'Primary provider', keys: [], kind: 'chooser' },
-  { id: 'embedding', title: 'Embedding backend', keys: ['embedding_command', 'embedding_endpoint', 'embedding_model', 'embedding_dim'] },
+  // Deploy topology (page 2) — kb_mode + per-role LLM placement, incl. the
+  // embedder + its dimensions. Bespoke component; owns its own config writes.
+  { id: 'embedding', title: 'Deploy topology', keys: [], kind: 'deploy' },
   { id: 'db2', title: 'Shared store (DB2)', keys: ['db2_url'] },
   { id: 'kb_api', title: 'Knowledge-base API', keys: ['kb_api_http_port', 'kb_api_bearer_token'], optional: true, skipNote: 'Skipping leaves the KB REST API off — no external programmatic access to the knowledge base.' },
   { id: 'project', title: 'Connect a project', keys: [], route: '/projects', skipNote: 'Without a connected project, tools have no repository to act on.' },


### PR DESCRIPTION
## What

Page 2 of the setup wizard: **Deploy topology**. It drives the page-1..2b backend
record (kb_mode + per-role `llm_*` placement) that `aimee config deploy-env`
already translates to the compose stack — the frontend that was the whole point
of the p1–p2b effort.

Per role (embedder / reranker / synthesizer), one placement picker:
**CPU · Small/Mid/Large GPU · External · Off**. All local roles share one
`aimee-llm` container on a chosen host (host + live GPU inventory from
`/api/hosts`); CPU-synth is constrained to Tier-A; the embedder owns its
endpoint/model/dim. A **remote aimee-kb** option writes only `kb_client_*` and
deploys nothing locally.

## Files

- `setup/deployTopology.ts` — pure model + config contract (unit-tested).
- `setup/DeployTopology.tsx` — the bespoke page; guarded saves via `/api/config/set`.
- `setup/wizardSteps.ts` + `components/SetupWizard.tsx` — page 2 becomes the
  bespoke `deploy` step (folds in the old embedding step).
- `setup/readiness.ts` — a placed embedder satisfies embedding readiness.
- `pages/settingsHelp.ts` — page-2 keys documented + added to `RESTART_KEYS`.
- `setup/deployTopology.test.ts` — 22 cases.

## Verification

- `tsc -b` clean; **60/60** vitest (baseline 40).
- Three-way review (2 delegate panelists + self); 3 real bugs found + fixed:
  phantom-host GPU downgrade, blank `embedding_dim` → int key, and an `off` role
  silently re-enabling as CPU (added an explicit `Off` option so it round-trips).
- **Live end-to-end** on a full stack (postgres + `aimee-server-kb:testing`
  serving this bundle): headless-browser render of the page + a real Save
  round-tripping `llm_rerank_backend=off` through `/api/config/set` → server →
  config. `/api/hosts` returns the exact shape the page consumes.

Backend-only note: the `deploy-env` translation of this record isn't in the
combined image (no `aimee` CLI there) but is unit-tested in `test_config.c`; the
record this UI writes was confirmed correct against the live server.
