### PR TITLE
fix(roundtable): bound the aggregator/synthesis step by the roundtable deadline

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -550,9 +550,19 @@ static int build_synthesis_prompt(char *buf, size_t cap, const char *original_pr
 }
 
 static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char *synthesis_prompt,
-                          agent_result_t *out)
+                          long deadline_abs_ms, agent_result_t *out)
 {
    memset(out, 0, sizeof(*out));
+
+   /* Bound the fallback loop below. Without a deadline a flaky/empty primary
+    * aggregator followed by N panelist fallbacks — each up to the provider HTTP
+    * timeout x retries (~9 min) — can run for ~an hour, wedging the whole
+    * roundtable far past its deadline (the panel is deadline-bounded, this was
+    * not). Prefer the caller's absolute monotonic deadline; otherwise fall back to
+    * an internal cap sized like the roundtable deadline so every call site is
+    * bounded. */
+   long agg_cap_ms = cfg->roundtable_deadline_ms > 0 ? cfg->roundtable_deadline_ms : 300000;
+   long agg_deadline_ms = deadline_abs_ms > 0 ? deadline_abs_ms : (monotonic_ms() + agg_cap_ms);
 
    agent_config_t agg_cfg = *acfg;
 
@@ -602,6 +612,13 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
     * degrade when other capable panelists are available. */
    for (int i = 0; i < cfg->ensemble_reference_count; i++)
    {
+      if (monotonic_ms() >= agg_deadline_ms)
+      {
+         aimee_log(LOG_WARN, "delegate_roundtable",
+                   "aggregator: deadline reached; abandoning remaining fallback candidates so a "
+                   "flaky synthesis model cannot wedge the roundtable");
+         break;
+      }
       const char *cand = cfg->ensemble_reference_models[i];
       if (!cand[0] || (primary_name && strcmp(cand, primary_name) == 0))
          continue;
@@ -865,7 +882,7 @@ static int summarize_forward(agent_config_t *acfg, const config_t *cfg, const ch
       return -1;
    agent_result_t res;
    memset(&res, 0, sizeof(res));
-   int rc = run_aggregator(acfg, cfg, full, &res);
+   int rc = run_aggregator(acfg, cfg, full, 0, &res);
    free(full);
    if (rc != 0 || !res.response || !res.response[0])
    {
@@ -1487,7 +1504,7 @@ int delegate_ensemble_run(agent_config_t *acfg, const config_t *cfg, const char 
       free(results[i].response);
 
    agent_result_t agg_result;
-   int agg_rc = run_aggregator(acfg, cfg, synthesis_buf, &agg_result);
+   int agg_rc = run_aggregator(acfg, cfg, synthesis_buf, 0, &agg_result);
    free(synthesis_buf);
 
    if (agg_rc == 0 && agg_result.response && agg_result.response[0])
@@ -1833,7 +1850,10 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
          break;
       }
       agent_result_t agg_result;
-      int agg_rc = run_aggregator(acfg, cfg, synthesis_prompt, &agg_result);
+      /* Bound synthesis by the roundtable's own deadline so the fallback loop
+       * cannot run long past it (the panel already respects this deadline). */
+      long agg_deadline_abs = local.deadline_ms > 0 ? start_ms + local.deadline_ms : 0;
+      int agg_rc = run_aggregator(acfg, cfg, synthesis_prompt, agg_deadline_abs, &agg_result);
       free(synthesis_prompt);
       if (agg_rc != 0 || !agg_result.response || !agg_result.response[0])
       {

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -554,15 +554,17 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
 {
    memset(out, 0, sizeof(*out));
 
-   /* Bound the fallback loop below. Without a deadline a flaky/empty primary
-    * aggregator followed by N panelist fallbacks — each up to the provider HTTP
-    * timeout x retries (~9 min) — can run for ~an hour, wedging the whole
-    * roundtable far past its deadline (the panel is deadline-bounded, this was
-    * not). Prefer the caller's absolute monotonic deadline; otherwise fall back to
-    * an internal cap sized like the roundtable deadline so every call site is
-    * bounded. */
-   long agg_cap_ms = cfg->roundtable_deadline_ms > 0 ? cfg->roundtable_deadline_ms : 300000;
-   long agg_deadline_ms = deadline_abs_ms > 0 ? deadline_abs_ms : (monotonic_ms() + agg_cap_ms);
+   /* deadline_abs_ms (absolute CLOCK_MONOTONIC ms; 0 = UNBOUNDED) caps the FALLBACK
+    * FAN-OUT below. Without it a flaky/empty primary aggregator followed by N
+    * panelist fallbacks — each up to the provider HTTP timeout x retries (~9 min) —
+    * can run ~an hour and wedge the roundtable past its deadline (the panel is
+    * deadline-bounded; this path was not).
+    *
+    * This is a FAN-OUT limit, not a hard per-call bound: a call already in flight
+    * can still overrun by up to one provider timeout (delegate_run_inline exposes
+    * no per-call timeout hook). Only the roundtable round-loop passes a deadline;
+    * other callers pass 0 and keep their original unbounded behavior, so this never
+    * silently couples non-roundtable synthesis to the roundtable config. */
 
    agent_config_t agg_cfg = *acfg;
 
@@ -612,11 +614,12 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
     * degrade when other capable panelists are available. */
    for (int i = 0; i < cfg->ensemble_reference_count; i++)
    {
-      if (monotonic_ms() >= agg_deadline_ms)
+      if (deadline_abs_ms > 0 && monotonic_ms() >= deadline_abs_ms)
       {
          aimee_log(LOG_WARN, "delegate_roundtable",
-                   "aggregator: deadline reached; abandoning remaining fallback candidates so a "
-                   "flaky synthesis model cannot wedge the roundtable");
+                   "aggregator: deadline reached at fallback candidate %d/%d; abandoning the "
+                   "remaining %d (a flaky synthesis model must not wedge the roundtable)",
+                   i, cfg->ensemble_reference_count, cfg->ensemble_reference_count - i);
          break;
       }
       const char *cand = cfg->ensemble_reference_models[i];


### PR DESCRIPTION
## Root cause
`aimee delegate roundtable` hung ~1 hour. The **panel** step is deadline-bounded (a hung panelist is abandoned), but `run_aggregator` (synthesis) was **not**: when the primary aggregator returns empty/flaky (the empty-HTTP-200 class), it falls back to trying **every panelist model** as the aggregator, each up to the provider HTTP timeout × retries (~9 min). With ~5 candidates that's ~50 min, wedging the roundtable far past its 6-min deadline. Server logs matched: panels finished fast (`synthesizing`), then a ~1-hour stall.

## Fix
`run_aggregator` takes an absolute monotonic deadline; its fallback loop stops once the deadline passes (`LOG_WARN` names the candidate index/total + count abandoned). `deadline_abs_ms == 0` = **unbounded** (original behavior preserved) — only the interactive round loop passes `start_ms + local.deadline_ms`, so non-roundtable paths (`summarize_forward`, `delegate_ensemble_run`) are unchanged. Documented as a **fan-out limit**, not a hard per-call bound (`delegate_run_inline` has no per-call timeout hook).

## Review
Roundtable round 1 → REQUEST-CHANGES (config-coupling, logging, single-overrun); all addressed. Round 2 synthesis was substantively positive (no blocking issues) but the degraded roundtable cut the run before emitting a formal verdict token — this fix is what makes that reliable. Compiles clean (`-Werror`).
