### PR TITLE
fix(delegate): make the background-delegate ephemeral workspace writable (git init)

### DIFF
--- a/src/server/delegate_ephemeral_ws.c
+++ b/src/server/delegate_ephemeral_ws.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 /* A deleg_id is server-generated (e.g. "deleg-105-1783801198975185376-10"), but
@@ -101,12 +102,37 @@ int delegate_ephemeral_ws_create(const char *deleg_id, char *out, size_t out_cap
    if (nfd >= 0)
    {
       static const char note[] =
-          "This is a server-side ephemeral workspace for a background aimee delegate.\n"
+          "This is a server-side ephemeral git workspace for a background aimee delegate.\n"
           "The dispatching client disconnected, so the client's repository is NOT present\n"
-          "here -- file/shell tools run against this empty directory. A background code\n"
-          "delegate that must edit the client tree needs the repo provisioned server-side.\n";
+          "here -- file/shell tools run against this initially-empty checkout. A background\n"
+          "code delegate that must edit the client tree needs the repo provisioned here.\n";
       (void)!write(nfd, note, sizeof(note) - 1);
       close(nfd);
+   }
+
+   /* Make the workspace a git checkout: aimee's write-guard permits file writes
+    * only in a git checkout / worktree (cwd_is_git_checkout), so a plain dir would
+    * block every edit. `git init` in the leaf via fchdir on the already-opened
+    * no-follow fd (no path re-resolution -> no TOCTOU). Best-effort: if git is
+    * missing the workspace still exists, only writes stay guarded. */
+   pid_t pid = fork();
+   if (pid == 0)
+   {
+      if (fchdir(leaf) != 0)
+         _exit(127);
+      int devnull = open("/dev/null", O_WRONLY | O_CLOEXEC);
+      if (devnull >= 0)
+      {
+         dup2(devnull, STDOUT_FILENO);
+         dup2(devnull, STDERR_FILENO);
+      }
+      execlp("git", "git", "init", "-q", (char *)NULL);
+      _exit(127);
+   }
+   if (pid > 0)
+   {
+      int status = 0;
+      waitpid(pid, &status, 0);
    }
 
    close(leaf);

--- a/src/server/delegate_ephemeral_ws.c
+++ b/src/server/delegate_ephemeral_ws.c
@@ -116,7 +116,9 @@ int delegate_ephemeral_ws_create(const char *deleg_id, char *out, size_t out_cap
     * only in a git checkout / worktree (cwd_is_git_checkout), so a plain dir would
     * block every edit. `git init` in the leaf via fchdir on the already-opened
     * no-follow fd (no path re-resolution -> no TOCTOU). Best-effort: if git is
-    * missing the workspace still exists, only writes stay guarded. */
+    * missing the workspace still exists, only writes stay guarded.
+    * fd hygiene: anchor/leaf/note (and the child's devnull) are all O_CLOEXEC, so
+    * only the intended dirfd survives into the exec'd git. */
    pid_t pid = fork();
    if (pid < 0)
    {

--- a/src/server/delegate_ephemeral_ws.c
+++ b/src/server/delegate_ephemeral_ws.c
@@ -11,10 +11,12 @@
 #include "delegate_ephemeral_ws.h"
 
 #include "aimee_home.h"
+#include "log.h"
 #include "platform_path.h"
 
 #include <ctype.h>
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
@@ -116,7 +118,17 @@ int delegate_ephemeral_ws_create(const char *deleg_id, char *out, size_t out_cap
     * no-follow fd (no path re-resolution -> no TOCTOU). Best-effort: if git is
     * missing the workspace still exists, only writes stay guarded. */
    pid_t pid = fork();
-   if (pid == 0)
+   if (pid < 0)
+   {
+      /* Could not fork: the workspace stays a plain dir, so the write-guard will
+       * block writes here. Surface it so operators can diagnose read-only-delegate
+       * symptoms rather than it failing silently. */
+      aimee_log(LOG_WARN, "delegate",
+                "ephemeral workspace %s: fork for 'git init' failed (%s); file writes here will "
+                "be blocked by the write-guard",
+                deleg_id, strerror(errno));
+   }
+   else if (pid == 0)
    {
       if (fchdir(leaf) != 0)
          _exit(127);
@@ -129,10 +141,14 @@ int delegate_ephemeral_ws_create(const char *deleg_id, char *out, size_t out_cap
       execlp("git", "git", "init", "-q", (char *)NULL);
       _exit(127);
    }
-   if (pid > 0)
+   else
    {
       int status = 0;
-      waitpid(pid, &status, 0);
+      if (waitpid(pid, &status, 0) == pid && (!WIFEXITED(status) || WEXITSTATUS(status) != 0))
+         aimee_log(LOG_WARN, "delegate",
+                   "ephemeral workspace %s: 'git init' did not succeed (wait status %d); file "
+                   "writes here will be blocked by the write-guard (is git installed?)",
+                   deleg_id, status);
    }
 
    close(leaf);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1333,8 +1333,14 @@ void delegate_worker(void *arg)
    delegate_run_ctx_restore(&run_ctx);
    if (detached_bound) /* unbind last: keep the binding live for any teardown that consults it */
       workspace_turn_unbind_active();
-   if (ephemeral_ws[0]) /* remove the server-side ephemeral workspace we created above */
+   if (ephemeral_ws[0])
+   {
+      /* Clear the thread-local cwd BEFORE removing the workspace so any post-run
+       * teardown exec (transcript capture, etc.) does not try to `cd` into a
+       * directory we just deleted (a harmless-but-noisy "cd: can't cd" error). */
+      run_cmd_set_cwd(NULL);
       delegate_ephemeral_ws_remove(ephemeral_ws);
+   }
    (void)db1_delegation_spawn_complete(deleg_id);
 
    /* Post-run named-file drift check: verify named existing paths appear in response. */

--- a/src/tests/test_delegate_ephemeral_ws.c
+++ b/src/tests/test_delegate_ephemeral_ws.c
@@ -53,6 +53,11 @@ int main(void)
    char note[1100];
    snprintf(note, sizeof(note), "%s/AIMEE_WORKSPACE_NOTE.txt", out);
    assert(path_exists(note));
+   /* The workspace is git-init'd so aimee's write-guard (cwd_is_git_checkout)
+    * permits file writes in it — a plain dir would block every edit. */
+   char gitdir[1100];
+   snprintf(gitdir, sizeof(gitdir), "%s/.git", out);
+   assert(path_exists(gitdir));
    printf("  creates_dir_and_note: ok\n");
 
    /* 3. remove() cleans up the workspace it created. */

--- a/src/tests/test_delegate_ephemeral_ws.c
+++ b/src/tests/test_delegate_ephemeral_ws.c
@@ -54,10 +54,15 @@ int main(void)
    snprintf(note, sizeof(note), "%s/AIMEE_WORKSPACE_NOTE.txt", out);
    assert(path_exists(note));
    /* The workspace is git-init'd so aimee's write-guard (cwd_is_git_checkout)
-    * permits file writes in it — a plain dir would block every edit. */
-   char gitdir[1100];
-   snprintf(gitdir, sizeof(gitdir), "%s/.git", out);
-   assert(path_exists(gitdir));
+    * permits file writes in it — a plain dir would block every edit. git init is
+    * best-effort, so only assert .git when git is actually available (git-less CI
+    * runners still exercise the rest of the suite). */
+   if (system("git --version >/dev/null 2>&1") == 0)
+   {
+      char gitdir[1100];
+      snprintf(gitdir, sizeof(gitdir), "%s/.git", out);
+      assert(path_exists(gitdir));
+   }
    printf("  creates_dir_and_note: ok\n");
 
    /* 3. remove() cleans up the workspace it created. */


### PR DESCRIPTION
## Problem
A background delegate's server-side ephemeral workspace (from the earlier detached-workspace fix) was a **plain directory**, so aimee's write-guard (writes require `cwd_is_git_checkout` / a worktree / a detached workspace) **blocked every file write** there: "write blocked because this session is not running in a worktree." The delegate could read but not write — any edit/clone was refused. (Before the detached-workspace fix the detached cwd itself satisfied `cwd_is_detached_workspace`, so writes were "allowed" — they just hit the dead reverse channel and returned `-1`. That fix traded it for exec-works-but-writes-blocked.)

## Fix
- `delegate_ephemeral_ws_create` now **`git init`s** the workspace (via `fchdir` on the already-opened `O_NOFOLLOW` leaf fd — no path re-resolution, TOCTOU-safe), so `cwd_is_git_checkout()` is true and the write-guard permits writes. `fork()<0` and non-zero `git init` exit are logged (`LOG_WARN`); best-effort (git-less → workspace still exists, only writes stay guarded).
- `server_compute` clears the thread-local `run_cmd` cwd **before** removing the ephemeral dir, killing the benign `cd: can't cd to .../delegate-ws/<id>` teardown noise.
- Test asserts `.git` exists (gated on `git --version` so git-less CI still runs).

NOTE: the workspace is an initially-empty checkout — it still does not contain the client repo. A background *code* delegate that must edit a specific repo needs that repo provisioned into the workspace (follow-up); this change unblocks writes.

## Review
Roundtable: **APPROVE (unanimous 4/4)**. An earlier round raised fork-in-multithreaded-server / `waitpid`·`SIGCHLD` / fd-inheritance concerns; addressed with code evidence (child does only async-signal-safe calls; `run_cmd` uses the identical `fork+execve+waitpid` pattern in the same server; no global `SIGCHLD` handler; fds are `O_CLOEXEC`). Verified on the deployed hang-fixed roundtable.
