### PR TITLE
fix(wfe): auto-retry transient roundtable parks instead of dead-ending autonomy

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -426,6 +426,7 @@ The binaries read 149 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 | Variable | Description |
 |----------|-------------|
+| `AIMEE_AUTONOMY_PANEL_RETRIES` | Per-(work item, stage) budget for auto-retrying a TRANSIENT roundtable park (`panel_degraded`/`panel_unreachable`) in an autonomous run, one retry per scheduler backstop sweep, before it escalates to a human. Default 6. An explicit `0` disables auto-retry (a degraded panel escalates immediately — the pre-feature behavior, useful during a known provider incident); a malformed/negative value floors to the default so a typo can't silently disable the rail. |
 | `AIMEE_DEFAULT_BRANCH` | Override the target repo's real default branch (its trunk) that a `base:trunk` `branch.open`/`pr.open` resolves to; else read from `git origin/HEAD`. Distinct from `AIMEE_AUTONOMY_BASE` (the aimee integration branch). A final feature PR opens against this branch (open-only, never auto-merged). |
 | `AIMEE_WORKFLOW_BASE` | Base branch for the engine's freeze/diff. |
 | `AIMEE_WORKFLOW_REPO` | Local repository directory the workflow engine operates on. |
@@ -469,7 +470,7 @@ The binaries read 149 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_PANEL_RETRIES`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -271,7 +271,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 148 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 149 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -469,7 +469,7 @@ The binaries read 148 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_PANEL_RETRIES`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -597,6 +597,7 @@ ENV_DESC = {
     # Workflow engine
     "AIMEE_WORKFLOW_REPO": ("Workflow engine", "Local repository directory the workflow engine operates on."),
     "AIMEE_WORKFLOW_BASE": ("Workflow engine", "Base branch for the engine's freeze/diff."),
+    "AIMEE_AUTONOMY_PANEL_RETRIES": ("Workflow engine", "Per-(work item, stage) budget for auto-retrying a TRANSIENT roundtable park (`panel_degraded`/`panel_unreachable`) in an autonomous run, one retry per scheduler backstop sweep, before it escalates to a human. Default 6. An explicit `0` disables auto-retry (a degraded panel escalates immediately — the pre-feature behavior, useful during a known provider incident); a malformed/negative value floors to the default so a typo can't silently disable the rail."),
     "AIMEE_DEFAULT_BRANCH": ("Workflow engine", "Override the target repo's real default branch (its trunk) that a `base:trunk` `branch.open`/`pr.open` resolves to; else read from `git origin/HEAD`. Distinct from `AIMEE_AUTONOMY_BASE` (the aimee integration branch). A final feature PR opens against this branch (open-only, never auto-merged)."),
     # Git verify / MCP
     "AIMEE_VERIFY_PARALLEL": ("Git verify / MCP", "Run `aimee git verify` steps in parallel."),

--- a/src/db1/wfe_store.c
+++ b/src/db1/wfe_store.c
@@ -484,6 +484,33 @@ int db1_work_item_clear_pause(const char *wi)
                             wi);
 }
 
+int db1_work_item_clear_pause_if(const char *wi, const char *expect_reason,
+                                 const char *expect_stage)
+{
+   sqlite3 *db = db1_conn();
+   if (!db || !wi)
+      return -1;
+   /* Compare-and-clear: clear the pause ONLY while the row still shows exactly the
+    * (pause_reason, current_stage) the caller observed. A single UPDATE, so two
+    * drivers of the same parked item cannot both win — the loser's WHERE no longer
+    * matches (pause already ''), guaranteeing at most one retry per park even if
+    * the single-threaded-scheduler invariant is ever relaxed. */
+   static const char *sql = "UPDATE lifecycle_work_item SET pause_reason='', paused_state='', "
+                            "updated_at=datetime('now') "
+                            "WHERE work_item_id=? AND pause_reason=? AND current_stage=?";
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(st, 1, wi, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(st, 2, expect_reason ? expect_reason : "", -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(st, 3, expect_stage ? expect_stage : "", -1, SQLITE_TRANSIENT);
+   int rc = sqlite3_step(st);
+   sqlite3_finalize(st);
+   if (rc != SQLITE_DONE)
+      return -1;
+   return sqlite3_changes(db) > 0 ? 1 : 0; /* 1 = won the clear, 0 = row no longer matched */
+}
+
 int db1_work_item_delete(const char *wi)
 {
    if (!wi || !wi[0])

--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -125,8 +125,11 @@ int db1_work_item_set_pause(const char *work_item_id, const char *reason, const 
 int db1_work_item_clear_pause(const char *work_item_id);
 /* Compare-and-clear: clear the pause only while it still equals (expect_reason,
  * expect_stage). Returns 1 if this caller cleared it, 0 if the row no longer
- * matched (another driver moved it first), -1 on error. Lets the autonomy retry
- * path claim a transient park atomically, so at most one retry runs per park. */
+ * matched (another driver moved it first), -1 on error (incl. SQLITE_BUSY — a
+ * transient lock is deliberately folded into -1: the autonomy caller treats -1
+ * and 0 identically as "did not claim; retry next sweep", so a lock just defers
+ * the attempt). Lets the autonomy retry path claim a transient park atomically,
+ * so at most one retry runs per park. */
 int db1_work_item_clear_pause_if(const char *work_item_id, const char *expect_reason,
                                  const char *expect_stage);
 int db1_work_item_add_cost(const char *work_item_id, double cost);

--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -123,6 +123,12 @@ int db1_work_item_gate_apply(const char *work_item_id, const char *expect_stage,
                              const char *terminal_state);
 int db1_work_item_set_pause(const char *work_item_id, const char *reason, const char *paused_state);
 int db1_work_item_clear_pause(const char *work_item_id);
+/* Compare-and-clear: clear the pause only while it still equals (expect_reason,
+ * expect_stage). Returns 1 if this caller cleared it, 0 if the row no longer
+ * matched (another driver moved it first), -1 on error. Lets the autonomy retry
+ * path claim a transient park atomically, so at most one retry runs per park. */
+int db1_work_item_clear_pause_if(const char *work_item_id, const char *expect_reason,
+                                 const char *expect_stage);
 int db1_work_item_add_cost(const char *work_item_id, double cost);
 int db1_work_item_set_cost_cap(const char *work_item_id, double cap);
 int db1_work_item_inc_override(const char *work_item_id); /* returns new count, -1 err */

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -27,8 +27,12 @@ static int g_running;
 static int g_notified;
 
 /* Drive every active autonomous work item one autonomy pass. wfe_autonomy_run is
- * safe to call on a human-parked item (it re-parks without re-running work), so a
- * sweep never double-executes a delegate. Terminal/interactive items are skipped. */
+ * safe to call on a human-parked item (pending_human / stuck / operator_paused):
+ * it re-parks without re-running work, so a sweep never double-executes a gated
+ * delegate. A TRANSIENT roundtable park (panel_degraded / panel_unreachable) is
+ * the deliberate exception — autonomy re-runs the panel a bounded number of times
+ * (one attempt per sweep) so a momentary provider blip self-heals rather than
+ * dead-ending the run. Terminal/interactive items are skipped. */
 void wfe_scheduler_run_once(void)
 {
    db1_work_item_t *items = NULL;

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -83,13 +83,16 @@ int wfe_worktree_cleanup(const char *worktree, const char *repo_local)
  * check passes. g_stub_panel_calls counts convenings — the retry tests assert on
  * it to prove that clearing the pause actually RE-RUNS the roundtable node. */
 static int g_stub_panel_calls;
-static int g_stub_degrade_calls;
+static int g_stub_degrade_calls; /* degrade the first N convenings; a large value (e.g. 1000) is
+                                  * the "always degrade" sentinel */
 static int g_stub_return_unreachable;
 static int stub_panel(const wfe_review_packet_t *pkt, const char *const *required, int nreq,
                       const char *const *eligible, int nelig, wfe_verdict_t *out, int max)
 {
    (void)eligible;
    (void)nelig;
+   if (!pkt)
+      return 0; /* defensive: the real seam never passes NULL, fail closed to DEGRADED */
    g_stub_panel_calls++;
    if (g_stub_panel_calls <= g_stub_degrade_calls)
       return g_stub_return_unreachable ? WFE_PANEL_UNREACHABLE : 0;
@@ -365,6 +368,9 @@ int main(void)
       assert(db1_work_item_get(id, &wi) == 1);
       assert(strcmp(wi.state, "active") == 0);
       assert(strcmp(wi.pause_reason, "panel_degraded") == 0);
+      /* the retry key is stable: every degraded re-park lands on the same node id,
+       * so the per-stage budget does not drift across retries. */
+      assert(strcmp(wi.current_stage, "gate") == 0);
       assert(g_stub_panel_calls == 3); /* 1 initial + 2 retries, then capped */
 
       db1_lifecycle_event_t *evs = NULL;
@@ -407,6 +413,43 @@ int main(void)
             retries++;
       free(evs);
       assert(retries == 1);
+
+      unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
+      wfe_set_panel_provider(NULL);
+   }
+
+   /* A13: AIMEE_AUTONOMY_PANEL_RETRIES=0 is the operator escape hatch — auto-retry
+    * is disabled and a transient park escalates to a human immediately (the
+    * pre-feature behavior), with the panel never re-convened. */
+   {
+      g_stub_panel_calls = 0;
+      g_stub_degrade_calls = 1000;
+      g_stub_return_unreachable = 0;
+      wfe_set_panel_provider(stub_panel);
+      setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "0", 1);
+
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("rta", "a13", "a13", "autonomous", id, err, sizeof err) == 0);
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* initial -> parks panel_degraded */
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "panel_degraded") == 0);
+      assert(g_stub_panel_calls == 1);
+      /* subsequent sweeps do NOT retry: no re-convene, stays parked for a human. */
+      for (int k = 0; k < 3; k++)
+         assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      assert(g_stub_panel_calls == 1);
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "panel_degraded") == 0);
+
+      db1_lifecycle_event_t *evs = NULL;
+      int n = db1_lifecycle_event_list(id, &evs);
+      int retries = 0;
+      for (int i = 0; i < n; i++)
+         if (strcmp(evs[i].kind, "panel_retry") == 0)
+            retries++;
+      free(evs);
+      assert(retries == 0); /* disabled -> no retry events at all */
 
       unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
       wfe_set_panel_provider(NULL);

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -82,9 +82,9 @@ int wfe_worktree_cleanup(const char *worktree, const char *repo_local)
  * required persona, echoing the packet's artifact_hash so the gate's hash-identity
  * check passes. g_stub_panel_calls counts convenings — the retry tests assert on
  * it to prove that clearing the pause actually RE-RUNS the roundtable node. */
+#define ALWAYS_DEGRADE 1000 /* g_stub_degrade_calls sentinel: degrade every convening */
 static int g_stub_panel_calls;
-static int g_stub_degrade_calls; /* degrade the first N convenings; a large value (e.g. 1000) is
-                                  * the "always degrade" sentinel */
+static int g_stub_degrade_calls; /* degrade the first N convenings (ALWAYS_DEGRADE = every one) */
 static int g_stub_return_unreachable;
 static int stub_panel(const wfe_review_packet_t *pkt, const char *const *required, int nreq,
                       const char *const *eligible, int nelig, wfe_verdict_t *out, int max)
@@ -354,7 +354,7 @@ int main(void)
     * (per (work item, stage)), and no further convenings happen once spent. */
    {
       g_stub_panel_calls = 0;
-      g_stub_degrade_calls = 1000; /* always degrade */
+      g_stub_degrade_calls = ALWAYS_DEGRADE; /* always degrade */
       g_stub_return_unreachable = 0;
       wfe_set_panel_provider(stub_panel);
       setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "2", 1);
@@ -390,7 +390,7 @@ int main(void)
     * transient class and is auto-retried too, not escalated immediately. */
    {
       g_stub_panel_calls = 0;
-      g_stub_degrade_calls = 1000;
+      g_stub_degrade_calls = ALWAYS_DEGRADE;
       g_stub_return_unreachable = 1; /* provider returns WFE_PANEL_UNREACHABLE */
       wfe_set_panel_provider(stub_panel);
       setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "3", 1);
@@ -423,7 +423,7 @@ int main(void)
     * pre-feature behavior), with the panel never re-convened. */
    {
       g_stub_panel_calls = 0;
-      g_stub_degrade_calls = 1000;
+      g_stub_degrade_calls = ALWAYS_DEGRADE;
       g_stub_return_unreachable = 0;
       wfe_set_panel_provider(stub_panel);
       setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "0", 1);
@@ -450,6 +450,26 @@ int main(void)
             retries++;
       free(evs);
       assert(retries == 0); /* disabled -> no retry events at all */
+
+      unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
+      wfe_set_panel_provider(NULL);
+   }
+
+   /* A14: a malformed AIMEE_AUTONOMY_PANEL_RETRIES falls back to the default cap
+    * (retry stays ENABLED — a typo must not silently disable the rail like 0
+    * does, nor crash the parser). */
+   {
+      g_stub_panel_calls = 0;
+      g_stub_degrade_calls = ALWAYS_DEGRADE;
+      g_stub_return_unreachable = 0;
+      wfe_set_panel_provider(stub_panel);
+      setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "not-a-number", 1);
+
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("rta", "a14", "a14", "autonomous", id, err, sizeof err) == 0);
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* initial park */
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* retry #1: default cap, NOT disabled */
+      assert(g_stub_panel_calls == 2); /* malformed -> default -> a retry still happens */
 
       unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
       wfe_set_panel_provider(NULL);

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -482,8 +482,51 @@ int main(void)
       assert(db1_work_item_get(id, &wi) == 1);
       assert(strcmp(wi.pause_reason, "panel_degraded") == 0);
 
+      /* negative value is also treated as malformed -> default (retry stays
+       * enabled, NOT disabled like an explicit 0): a fresh item still retries. */
+      g_stub_panel_calls = 0;
+      setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "-3", 1);
+      char idn[80] = "";
+      assert(wfe_work_item_create("rta", "a14n", "a14n", "autonomous", idn, err, sizeof err) == 0);
+      assert(wfe_autonomy_run(idn, err, sizeof err) == 0); /* initial park */
+      assert(wfe_autonomy_run(idn, err, sizeof err) == 0); /* retry #1 -> not disabled */
+      assert(g_stub_panel_calls == 2);
+
       unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
       wfe_set_panel_provider(NULL);
+   }
+
+   /* A15: a NON-transient park (pending_human) is left UNTOUCHED by the retry path.
+    * It is neither short-circuited early nor retried — it falls through to the
+    * advance loop, which re-parks it without re-running work. This pins the
+    * invariant H1 depends on: adding the transient-retry branch did not change
+    * behavior for any other park class. */
+   {
+      g_stub_panel_calls = 0;
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("auto", "a15", "a15", "autonomous", id, err, sizeof err) == 0);
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* parks pending_human */
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "pending_human") == 0);
+      char stage0[64];
+      snprintf(stage0, sizeof stage0, "%s", wi.current_stage);
+
+      /* a second sweep must NOT touch it: same reason, same stage, no panel activity. */
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "pending_human") == 0);
+      assert(strcmp(wi.current_stage, stage0) == 0);
+      assert(g_stub_panel_calls == 0);
+
+      db1_lifecycle_event_t *evs = NULL;
+      int n = db1_lifecycle_event_list(id, &evs);
+      int retries = 0;
+      for (int i = 0; i < n; i++)
+         if (strcmp(evs[i].kind, "panel_retry") == 0)
+            retries++;
+      free(evs);
+      assert(retries == 0); /* the transient-retry branch never fired for pending_human */
    }
 
    printf("ok\n");

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -89,6 +89,8 @@ static int g_stub_return_unreachable;
 static int stub_panel(const wfe_review_packet_t *pkt, const char *const *required, int nreq,
                       const char *const *eligible, int nelig, wfe_verdict_t *out, int max)
 {
+   /* The verdict set is sized from `required` (the lenses), not the eligible-agent
+    * pool, so the mock ignores eligible/nelig — matches how the gate scores. */
    (void)eligible;
    (void)nelig;
    if (!pkt)
@@ -343,7 +345,11 @@ int main(void)
       assert(wfe_autonomy_run(id, err, sizeof err) == 0);
       assert(g_stub_panel_calls == 3);
       assert(db1_work_item_get(id, &wi) == 1);
-      assert(strncmp(wi.pause_reason, "panel_", 6) != 0); /* no longer a transient park */
+      /* Recovered: not parked for ANY reason, and advanced OFF the roundtable gate
+       * (a stronger check than "not a panel_ reason" — that also passed for an
+       * unrelated runaway park like turn_cap_exceeded). */
+      assert(wi.pause_reason[0] == '\0');
+      assert(strcmp(wi.current_stage, "gate") != 0);
 
       unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
       wfe_set_panel_provider(NULL);
@@ -455,9 +461,11 @@ int main(void)
       wfe_set_panel_provider(NULL);
    }
 
-   /* A14: a malformed AIMEE_AUTONOMY_PANEL_RETRIES falls back to the default cap
-    * (retry stays ENABLED — a typo must not silently disable the rail like 0
-    * does, nor crash the parser). */
+   /* A14: a malformed AIMEE_AUTONOMY_PANEL_RETRIES falls back to the DEFAULT cap —
+    * retry stays enabled (a typo must not silently disable the rail like 0 does,
+    * nor crash the parser) AND is still bounded at the default. Driving enough
+    * sweeps pins the default EXACTLY: initial convene + default retries, no more —
+    * distinguishing it from a silent collapse to 1 or an uncapped loop. */
    {
       g_stub_panel_calls = 0;
       g_stub_degrade_calls = ALWAYS_DEGRADE;
@@ -467,9 +475,12 @@ int main(void)
 
       char id[80] = "", err[256] = "";
       assert(wfe_work_item_create("rta", "a14", "a14", "autonomous", id, err, sizeof err) == 0);
-      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* initial park */
-      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* retry #1: default cap, NOT disabled */
-      assert(g_stub_panel_calls == 2); /* malformed -> default -> a retry still happens */
+      for (int k = 0; k < WFE_AUTONOMY_PANEL_RETRY_CAP_DEFAULT + 3; k++)
+         assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      assert(g_stub_panel_calls == WFE_AUTONOMY_PANEL_RETRY_CAP_DEFAULT + 1);
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "panel_degraded") == 0);
 
       unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
       wfe_set_panel_provider(NULL);

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -75,6 +75,39 @@ int wfe_worktree_cleanup(const char *worktree, const char *repo_local)
    return 0;
 }
 
+/* A mock panel provider for the auto-retry tests. It DEGRADES its first
+ * g_stub_degrade_calls convenings (returning 0 verdicts so a required persona is
+ * unfilled -> the gate scores DEGRADED -> panel_degraded; or WFE_PANEL_UNREACHABLE
+ * when g_stub_return_unreachable is set), then APPROVES: one APPROVE verdict per
+ * required persona, echoing the packet's artifact_hash so the gate's hash-identity
+ * check passes. g_stub_panel_calls counts convenings — the retry tests assert on
+ * it to prove that clearing the pause actually RE-RUNS the roundtable node. */
+static int g_stub_panel_calls;
+static int g_stub_degrade_calls;
+static int g_stub_return_unreachable;
+static int stub_panel(const wfe_review_packet_t *pkt, const char *const *required, int nreq,
+                      const char *const *eligible, int nelig, wfe_verdict_t *out, int max)
+{
+   (void)eligible;
+   (void)nelig;
+   g_stub_panel_calls++;
+   if (g_stub_panel_calls <= g_stub_degrade_calls)
+      return g_stub_return_unreachable ? WFE_PANEL_UNREACHABLE : 0;
+   int n = 0;
+   for (int i = 0; i < nreq && n < max; i++)
+   {
+      wfe_verdict_t *v = &out[n++];
+      memset(v, 0, sizeof *v);
+      snprintf(v->persona, sizeof v->persona, "%s", required[i]);
+      v->schema_version = WFE_VERDICT_SCHEMA;
+      snprintf(v->reviewed_content_hash, sizeof v->reviewed_content_hash, "%s",
+               pkt->artifact_hash ? pkt->artifact_hash : "");
+      v->kind = WFE_V_APPROVE;
+      v->high_sev_blockers = 0;
+   }
+   return n;
+}
+
 static void write_wf(const char *dir, const char *name, const char *body)
 {
    char p[256];
@@ -277,6 +310,106 @@ int main(void)
       /* empty / NULL pr_ref is a bad arg */
       assert(db1_work_item_id_by_pr_ref("", got, sizeof got) == -1);
       assert(db1_work_item_id_by_pr_ref(NULL, got, sizeof got) == -1);
+   }
+
+   /* A10: a TRANSIENT roundtable park (panel_degraded) is AUTO-RETRIED by the
+    * autonomy driver — clearing the pause re-runs the roundtable node — and a
+    * recovered panel self-heals PAST the gate instead of dead-ending forever. */
+   {
+      g_stub_panel_calls = 0;
+      g_stub_degrade_calls = 2; /* degrade convenings 1-2, approve #3 */
+      g_stub_return_unreachable = 0;
+      wfe_set_panel_provider(stub_panel);
+      setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "5", 1);
+
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("rta", "a10", "a10", "autonomous", id, err, sizeof err) == 0);
+      db1_work_item_t wi;
+      /* run 1: initial convene -> degraded -> parks panel_degraded (no retry yet). */
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "panel_degraded") == 0);
+      assert(g_stub_panel_calls == 1);
+      /* run 2: retry #1 -> convene #2 -> still degraded -> re-parks. */
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "panel_degraded") == 0);
+      assert(g_stub_panel_calls == 2);
+      /* run 3: retry #2 -> convene #3 -> APPROVE -> advances past the gate. The
+       * convene count reaching 3 proves the pause-clear actually RE-RAN the node. */
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      assert(g_stub_panel_calls == 3);
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strncmp(wi.pause_reason, "panel_", 6) != 0); /* no longer a transient park */
+
+      unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
+      wfe_set_panel_provider(NULL);
+   }
+
+   /* A11: a persistently-degraded panel is retried only up to the cap, then stays
+    * parked to escalate to a human — exactly `cap` panel_retry events are recorded
+    * (per (work item, stage)), and no further convenings happen once spent. */
+   {
+      g_stub_panel_calls = 0;
+      g_stub_degrade_calls = 1000; /* always degrade */
+      g_stub_return_unreachable = 0;
+      wfe_set_panel_provider(stub_panel);
+      setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "2", 1);
+
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("rta", "a11", "a11", "autonomous", id, err, sizeof err) == 0);
+      for (int k = 0; k < 5; k++) /* 1 initial + 2 retries convene; the rest early-out */
+         assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "active") == 0);
+      assert(strcmp(wi.pause_reason, "panel_degraded") == 0);
+      assert(g_stub_panel_calls == 3); /* 1 initial + 2 retries, then capped */
+
+      db1_lifecycle_event_t *evs = NULL;
+      int n = db1_lifecycle_event_list(id, &evs);
+      int retries = 0;
+      for (int i = 0; i < n; i++)
+         if (strcmp(evs[i].kind, "panel_retry") == 0 && strcmp(evs[i].stage, "gate") == 0)
+            retries++;
+      free(evs);
+      assert(retries == 2); /* exactly the cap; a failed clear would NOT count here */
+
+      unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
+      wfe_set_panel_provider(NULL);
+   }
+
+   /* A12: panel_unreachable (the panel could not be reached at all) is the same
+    * transient class and is auto-retried too, not escalated immediately. */
+   {
+      g_stub_panel_calls = 0;
+      g_stub_degrade_calls = 1000;
+      g_stub_return_unreachable = 1; /* provider returns WFE_PANEL_UNREACHABLE */
+      wfe_set_panel_provider(stub_panel);
+      setenv("AIMEE_AUTONOMY_PANEL_RETRIES", "3", 1);
+
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("rta", "a12", "a12", "autonomous", id, err, sizeof err) == 0);
+      db1_work_item_t wi;
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* initial -> panel_unreachable */
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "panel_unreachable") == 0);
+      assert(g_stub_panel_calls == 1);
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0); /* retry #1 -> re-convene */
+      assert(g_stub_panel_calls == 2); /* proves re-run for the unreachable class too */
+
+      db1_lifecycle_event_t *evs = NULL;
+      int n = db1_lifecycle_event_list(id, &evs);
+      int retries = 0;
+      for (int i = 0; i < n; i++)
+         if (strcmp(evs[i].kind, "panel_retry") == 0)
+            retries++;
+      free(evs);
+      assert(retries == 1);
+
+      unsetenv("AIMEE_AUTONOMY_PANEL_RETRIES");
+      wfe_set_panel_provider(NULL);
    }
 
    printf("ok\n");

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -63,12 +63,12 @@ static long autonomy_panel_retry_cap(void)
 {
    const char *v = getenv("AIMEE_AUTONOMY_PANEL_RETRIES");
    if (!v || !v[0])
-      return 6;
+      return WFE_AUTONOMY_PANEL_RETRY_CAP_DEFAULT;
    errno = 0;
    char *end = NULL;
    long n = strtol(v, &end, 10);
    if (errno == ERANGE || !end || *end != '\0' || n < 0)
-      return 6;
+      return WFE_AUTONOMY_PANEL_RETRY_CAP_DEFAULT;
    return n; /* n >= 0; an explicit 0 disables auto-retry (escalate immediately) */
 }
 
@@ -185,7 +185,15 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
     * roundtable node, and let a recovered panel self-heal. Only once the retry
     * budget is spent does it stay parked to escalate to a human. Without this an
     * autonomous run dead-ends forever on a momentary degradation, which is
-    * exactly the opposite of what a panel "fail-closed" should mean for autonomy. */
+    * exactly the opposite of what a panel "fail-closed" should mean for autonomy.
+    *
+    * Only stuck/operator_paused are short-circuited HERE. Every other park —
+    * pending_human, budget_exceeded, ci_pending, … — falls through to the advance
+    * loop, where wfe_engine_advance sees the still-set pause_reason and returns
+    * PENDING without re-running work ("caller must resume explicitly"); those stay
+    * human-/event-gated. The explicit skip exists only to keep the backstop sweep
+    * from re-attempting an advance every cycle on the two never-self-resolving
+    * reasons. */
    {
       db1_work_item_t wi0;
       if (db1_work_item_get(work_item_id, &wi0) == 1 && wi0.pause_reason[0])
@@ -206,18 +214,24 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
             long cap = autonomy_panel_retry_cap();
             if (cap == 0 || autonomy_panel_retries_used(work_item_id, wi0.current_stage) >= cap)
                return 0; /* budget spent (or disabled): stay parked to escalate to a human */
-            /* Clear the pause FIRST, then record the retry, so the budget counts
-             * only retries that ACTUALLY happened. If the clear fails the item
-             * stays parked and no panel_retry event is written — a persistent
-             * clear failure therefore escalates via the human gate instead of
-             * silently burning the budget on retries that never ran. (This path
-             * is single-threaded: the scheduler drives work items sequentially,
-             * so there is no concurrent same-item retry to race.) */
-            if (db1_work_item_clear_pause(work_item_id) != 0)
-               return 0; /* could not clear -> leave parked, retry next sweep (no budget spent) */
+            /* Claim the retry with a compare-and-clear: clear the pause only while
+             * it still equals the (reason, stage) we just read, so the budget
+             * counts only retries that ACTUALLY happened AND at most one retry runs
+             * per park even if the single-threaded-scheduler invariant is ever
+             * relaxed (a concurrent driver's clear would find the row already
+             * moved). rc: 1 = we won, 0 = another driver moved it first, -1 = error.
+             * On anything but a win, leave it and retry next sweep — no budget
+             * spent, no uncounted retry. */
+            int claimed =
+                db1_work_item_clear_pause_if(work_item_id, wi0.pause_reason, wi0.current_stage);
+            if (claimed != 1)
+               return 0;
             /* Symmetric on the write side: if the panel_retry audit write fails the
              * retry would run UNCOUNTED and could bypass the cap, so treat it like a
-             * failed clear — re-park with the original reason and do not advance.
+             * failed clear — re-park with the original reason and do not advance. If
+             * the re-park ALSO fails the item is left unpaused with no retry event,
+             * which must not be reported as a benign no-op: surface it (return -1)
+             * so the scheduler logs it rather than silently looping.
              * (Belt-and-braces: even if the process died in the tiny window between
              * the clear and this write, the re-convened panel writes its own "pause"
              * lifecycle event, which the cumulative turn cap counts, so the runaway
@@ -225,7 +239,12 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
             if (db1_lifecycle_event_add(work_item_id, wi0.current_stage, "panel_retry", "engine",
                                         wi0.pause_reason, "", 0) != 0)
             {
-               db1_work_item_set_pause(work_item_id, wi0.pause_reason, wi0.current_stage);
+               if (db1_work_item_set_pause(work_item_id, wi0.pause_reason, wi0.current_stage) != 0)
+               {
+                  snprintf(err, errlen, "panel-retry: audit write and re-park both failed for '%s'",
+                           work_item_id);
+                  return -1;
+               }
                return 0;
             }
             /* pause cleared + retry durably recorded -> fall through to the advance

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -59,7 +59,13 @@ static int autonomy_pause_is_transient(const char *reason)
  * human instead of retrying forever. Returns the count; on a read failure it
  * returns 0 (fail toward retrying — a transient DB fault must not permanently
  * strand an otherwise-healthy run), with the cumulative turn cap as the ultimate
- * runaway backstop. */
+ * runaway backstop.
+ *
+ * Durability: the budget is derived from the audit log rather than a counter
+ * column, which is safe because lifecycle events are never pruned/compacted/
+ * rotated mid-run — the only DELETE on lifecycle_event is the terminal
+ * whole-work-item purge (db1_work_item_delete). So while a run is active its
+ * panel_retry history is complete and the derived count is authoritative. */
 static int autonomy_panel_retries_used(const char *work_item_id, const char *stage)
 {
    db1_lifecycle_event_t *evs = NULL;
@@ -183,10 +189,21 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
              * so there is no concurrent same-item retry to race.) */
             if (db1_work_item_clear_pause(work_item_id) != 0)
                return 0; /* could not clear -> leave parked, retry next sweep (no budget spent) */
-            db1_lifecycle_event_add(work_item_id, wi0.current_stage, "panel_retry", "engine",
-                                    wi0.pause_reason, "", 0);
-            /* pause cleared -> fall through to the advance loop, which re-runs the
-             * parked roundtable node for a fresh panel. */
+            /* Symmetric on the write side: if the panel_retry audit write fails the
+             * retry would run UNCOUNTED and could bypass the cap, so treat it like a
+             * failed clear — re-park with the original reason and do not advance.
+             * (Belt-and-braces: even if the process died in the tiny window between
+             * the clear and this write, the re-convened panel writes its own "pause"
+             * lifecycle event, which the cumulative turn cap counts, so the runaway
+             * backstop still holds.) */
+            if (db1_lifecycle_event_add(work_item_id, wi0.current_stage, "panel_retry", "engine",
+                                        wi0.pause_reason, "", 0) != 0)
+            {
+               db1_work_item_set_pause(work_item_id, wi0.pause_reason, wi0.current_stage);
+               return 0;
+            }
+            /* pause cleared + retry durably recorded -> fall through to the advance
+             * loop, which re-runs the parked roundtable node for a fresh panel. */
          }
       }
    }

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -64,7 +64,14 @@ static int autonomy_panel_retries_used(const char *work_item_id, const char *sta
 {
    db1_lifecycle_event_t *evs = NULL;
    int n = db1_lifecycle_event_list(work_item_id, &evs);
+   if (n <= 0)
+   {
+      free(evs); /* NULL-safe: nothing read -> 0 retries used (fail toward retry) */
+      return 0;
+   }
    int used = 0;
+   /* kind[] and stage[] are fixed-size arrays in db1_lifecycle_event_t, never
+    * NULL, so strcmp is safe without a null guard. */
    for (int i = 0; i < n; i++)
       if (strcmp(evs[i].kind, "panel_retry") == 0 && strcmp(evs[i].stage, stage) == 0)
          used++;
@@ -158,13 +165,26 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
             return 0;
          if (autonomy_pause_is_transient(wi0.pause_reason))
          {
+            /* Budget is per (work item, stage): a stage revisited after a loop
+             * inherits its earlier retry count on purpose — a stage that has
+             * already burned its budget and comes back still-degrading should
+             * escalate to a human, not silently reset. wfe_env_long floors a
+             * junk/<=0 override to the default, so cap is always >= 1 (retries
+             * cannot be accidentally disabled to 0). */
             long cap = wfe_env_long("AIMEE_AUTONOMY_PANEL_RETRIES", 6);
             if (autonomy_panel_retries_used(work_item_id, wi0.current_stage) >= cap)
-               return 0; /* budget spent: stay parked for a human resume */
+               return 0; /* budget spent: stay parked to escalate to a human */
+            /* Clear the pause FIRST, then record the retry, so the budget counts
+             * only retries that ACTUALLY happened. If the clear fails the item
+             * stays parked and no panel_retry event is written — a persistent
+             * clear failure therefore escalates via the human gate instead of
+             * silently burning the budget on retries that never ran. (This path
+             * is single-threaded: the scheduler drives work items sequentially,
+             * so there is no concurrent same-item retry to race.) */
+            if (db1_work_item_clear_pause(work_item_id) != 0)
+               return 0; /* could not clear -> leave parked, retry next sweep (no budget spent) */
             db1_lifecycle_event_add(work_item_id, wi0.current_stage, "panel_retry", "engine",
                                     wi0.pause_reason, "", 0);
-            if (db1_work_item_clear_pause(work_item_id) != 0)
-               return 0; /* could not clear the pause -> leave it, retry next sweep */
             /* pause cleared -> fall through to the advance loop, which re-runs the
              * parked roundtable node for a fresh panel. */
          }

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -215,31 +215,34 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
             if (cap == 0 || autonomy_panel_retries_used(work_item_id, wi0.current_stage) >= cap)
                return 0; /* budget spent (or disabled): stay parked to escalate to a human */
             /* Claim the retry with a compare-and-clear: clear the pause only while
-             * it still equals the (reason, stage) we just read, so the budget
-             * counts only retries that ACTUALLY happened AND at most one retry runs
-             * per park even if the single-threaded-scheduler invariant is ever
-             * relaxed (a concurrent driver's clear would find the row already
-             * moved). rc: 1 = we won, 0 = another driver moved it first, -1 = error.
-             * On anything but a win, leave it and retry next sweep — no budget
-             * spent, no uncounted retry. */
+             * it still equals the (reason, stage) we just read, so at most one
+             * retry runs per park even if the single-threaded-scheduler invariant
+             * is ever relaxed (a concurrent driver's clear would find the row
+             * already moved). rc: 1 = we won, 0 = another driver moved it first,
+             * -1 = error. On anything but a win, leave it and retry next sweep — no
+             * budget spent, no uncounted retry. NOTE the panel_retry cap bounds
+             * ATTEMPTS (parks claimed + cleared), not successful re-convenes: if the
+             * advance below dies before the panel re-runs, the attempt still counted
+             * — which is the intended, honest semantics (the turn cap is the hard
+             * backstop for a genuinely runaway loop). */
             int claimed =
                 db1_work_item_clear_pause_if(work_item_id, wi0.pause_reason, wi0.current_stage);
             if (claimed != 1)
                return 0;
             /* Symmetric on the write side: if the panel_retry audit write fails the
-             * retry would run UNCOUNTED and could bypass the cap, so treat it like a
-             * failed clear — re-park with the original reason and do not advance. If
-             * the re-park ALSO fails the item is left unpaused with no retry event,
-             * which must not be reported as a benign no-op: surface it (return -1)
-             * so the scheduler logs it rather than silently looping.
-             * (Belt-and-braces: even if the process died in the tiny window between
-             * the clear and this write, the re-convened panel writes its own "pause"
-             * lifecycle event, which the cumulative turn cap counts, so the runaway
-             * backstop still holds.) */
+             * attempt would run UNCOUNTED and could bypass the cap, so treat it like
+             * a failed clear — re-park with the ORIGINAL (reason, paused_state) and
+             * do not advance. If the re-park ALSO fails the item is left unpaused
+             * with no retry event, which must not be reported as a benign no-op:
+             * surface it (return -1) so the scheduler logs it rather than silently
+             * looping. (Belt-and-braces: even if the process died in the tiny window
+             * between the clear and this write, the re-convened panel writes its own
+             * "pause" lifecycle event, which the cumulative turn cap counts, so the
+             * runaway backstop still holds.) */
             if (db1_lifecycle_event_add(work_item_id, wi0.current_stage, "panel_retry", "engine",
                                         wi0.pause_reason, "", 0) != 0)
             {
-               if (db1_work_item_set_pause(work_item_id, wi0.pause_reason, wi0.current_stage) != 0)
+               if (db1_work_item_set_pause(work_item_id, wi0.pause_reason, wi0.paused_state) != 0)
                {
                   snprintf(err, errlen, "panel-retry: audit write and re-park both failed for '%s'",
                            work_item_id);

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -45,6 +45,33 @@ static long wfe_env_long(const char *name, long def)
    return n;
 }
 
+/* A roundtable panel that could not be composed (panel_degraded) or reached
+ * (panel_unreachable) is TRANSIENT provider flakiness, not a human decision:
+ * these two pause reasons are auto-retried by the autonomy driver. */
+static int autonomy_pause_is_transient(const char *reason)
+{
+   return strcmp(reason, "panel_degraded") == 0 || strcmp(reason, "panel_unreachable") == 0;
+}
+
+/* Count how many times this run has already auto-retried a transient roundtable
+ * park at `stage` — one "panel_retry" audit event is written per retry. Bounds
+ * the retry budget so a persistently-degraded panel eventually escalates to a
+ * human instead of retrying forever. Returns the count; on a read failure it
+ * returns 0 (fail toward retrying — a transient DB fault must not permanently
+ * strand an otherwise-healthy run), with the cumulative turn cap as the ultimate
+ * runaway backstop. */
+static int autonomy_panel_retries_used(const char *work_item_id, const char *stage)
+{
+   db1_lifecycle_event_t *evs = NULL;
+   int n = db1_lifecycle_event_list(work_item_id, &evs);
+   int used = 0;
+   for (int i = 0; i < n; i++)
+      if (strcmp(evs[i].kind, "panel_retry") == 0 && strcmp(evs[i].stage, stage) == 0)
+         used++;
+   free(evs);
+   return used;
+}
+
 /* Park an active, not-yet-parked autonomous work item at a runaway-backstop cap
  * and audit the reason. `reason` is the accurate pause token for the breach that
  * fired (turn_cap_exceeded / wall_cap_exceeded — NOT the dollar cost cap, which
@@ -111,13 +138,37 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
     * is unresolvable / has no executor); an item parked 'operator_paused' was
     * deliberately halted by an operator. Skip both so the backstop sweep doesn't
     * re-attempt an advance every cycle; a human resume clears the pause and lets
-    * the next sweep retry. */
+    * the next sweep retry.
+    *
+    * A transient roundtable park (panel_degraded / panel_unreachable), by
+    * contrast, reflects momentary provider flakiness — reviewers that were DOWN
+    * or unreachable when the panel convened — NOT a human decision. Auto-retry it
+    * a bounded number of times (one attempt per backstop sweep = natural
+    * backoff): clear the pause here so the advance loop below re-runs the
+    * roundtable node, and let a recovered panel self-heal. Only once the retry
+    * budget is spent does it stay parked to escalate to a human. Without this an
+    * autonomous run dead-ends forever on a momentary degradation, which is
+    * exactly the opposite of what a panel "fail-closed" should mean for autonomy. */
    {
       db1_work_item_t wi0;
-      if (db1_work_item_get(work_item_id, &wi0) == 1 &&
-          (strcmp(wi0.pause_reason, "stuck") == 0 ||
-           strcmp(wi0.pause_reason, "operator_paused") == 0))
-         return 0;
+      if (db1_work_item_get(work_item_id, &wi0) == 1 && wi0.pause_reason[0])
+      {
+         if (strcmp(wi0.pause_reason, "stuck") == 0 ||
+             strcmp(wi0.pause_reason, "operator_paused") == 0)
+            return 0;
+         if (autonomy_pause_is_transient(wi0.pause_reason))
+         {
+            long cap = wfe_env_long("AIMEE_AUTONOMY_PANEL_RETRIES", 6);
+            if (autonomy_panel_retries_used(work_item_id, wi0.current_stage) >= cap)
+               return 0; /* budget spent: stay parked for a human resume */
+            db1_lifecycle_event_add(work_item_id, wi0.current_stage, "panel_retry", "engine",
+                                    wi0.pause_reason, "", 0);
+            if (db1_work_item_clear_pause(work_item_id) != 0)
+               return 0; /* could not clear the pause -> leave it, retry next sweep */
+            /* pause cleared -> fall through to the advance loop, which re-runs the
+             * parked roundtable node for a fresh panel. */
+         }
+      }
    }
 
    for (int i = 0; i < 10000; i++)

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -78,8 +78,12 @@ static long autonomy_panel_retry_cap(void)
  * degraded panel eventually escalates to a human instead of retrying forever.
  * Returns the count; on a read failure it
  * returns 0 (fail toward retrying — a transient DB fault must not permanently
- * strand an otherwise-healthy run), with the cumulative turn cap as the ultimate
- * runaway backstop.
+ * strand an otherwise-healthy run). This fail-open is best-effort but bounded: a
+ * PERSISTENT audit-log read failure is caught on the very next step by the
+ * turn-cap check at the top of the advance loop, which fail-CLOSES to
+ * turn_cap_exceeded when db1_lifecycle_event_list is unreadable — so an
+ * unreadable log parks the run rather than looping. The turn cap is the hard
+ * runaway backstop; the panel-retry cap is the precise-but-best-effort bound.
  *
  * Durability: the budget is derived from the audit log rather than a counter
  * column, which is safe because lifecycle events are never pruned/compacted/

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -53,10 +53,30 @@ static int autonomy_pause_is_transient(const char *reason)
    return strcmp(reason, "panel_degraded") == 0 || strcmp(reason, "panel_unreachable") == 0;
 }
 
+/* The per-(work item, stage) transient-park retry cap. Unlike wfe_env_long (which
+ * floors junk/<=0 to the default so a safety rail can't be silently disabled by a
+ * typo), this ACCEPTS an explicit 0 as a deliberate operator escape hatch: 0 means
+ * "do not auto-retry transient panel parks — escalate to a human immediately" (the
+ * pre-feature behavior), useful to set during a known provider incident. A
+ * malformed or negative override still falls back to the default. */
+static long autonomy_panel_retry_cap(void)
+{
+   const char *v = getenv("AIMEE_AUTONOMY_PANEL_RETRIES");
+   if (!v || !v[0])
+      return 6;
+   errno = 0;
+   char *end = NULL;
+   long n = strtol(v, &end, 10);
+   if (errno == ERANGE || !end || *end != '\0' || n < 0)
+      return 6;
+   return n; /* n >= 0; an explicit 0 disables auto-retry (escalate immediately) */
+}
+
 /* Count how many times this run has already auto-retried a transient roundtable
- * park at `stage` — one "panel_retry" audit event is written per retry. Bounds
- * the retry budget so a persistently-degraded panel eventually escalates to a
- * human instead of retrying forever. Returns the count; on a read failure it
+ * park at `stage` — one "panel_retry" audit event is written per retry. The
+ * caller compares this against the cap to bound retries, so a persistently-
+ * degraded panel eventually escalates to a human instead of retrying forever.
+ * Returns the count; on a read failure it
  * returns 0 (fail toward retrying — a transient DB fault must not permanently
  * strand an otherwise-healthy run), with the cumulative turn cap as the ultimate
  * runaway backstop.
@@ -174,12 +194,14 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
             /* Budget is per (work item, stage): a stage revisited after a loop
              * inherits its earlier retry count on purpose — a stage that has
              * already burned its budget and comes back still-degrading should
-             * escalate to a human, not silently reset. wfe_env_long floors a
-             * junk/<=0 override to the default, so cap is always >= 1 (retries
-             * cannot be accidentally disabled to 0). */
-            long cap = wfe_env_long("AIMEE_AUTONOMY_PANEL_RETRIES", 6);
-            if (autonomy_panel_retries_used(work_item_id, wi0.current_stage) >= cap)
-               return 0; /* budget spent: stay parked to escalate to a human */
+             * escalate to a human, not silently reset. current_stage here is the
+             * workflow node id (a stable machine string, not user input), so the
+             * per-stage key does not drift across a degraded-park/retry cycle. The
+             * cap accepts an explicit 0 (escalate immediately) but floors a
+             * malformed/negative override to the default. */
+            long cap = autonomy_panel_retry_cap();
+            if (cap == 0 || autonomy_panel_retries_used(work_item_id, wi0.current_stage) >= cap)
+               return 0; /* budget spent (or disabled): stay parked to escalate to a human */
             /* Clear the pause FIRST, then record the retry, so the budget counts
              * only retries that ACTUALLY happened. If the clear fails the item
              * stays parked and no panel_retry event is written — a persistent

--- a/src/workflow/wfe_autonomy.h
+++ b/src/workflow/wfe_autonomy.h
@@ -14,6 +14,13 @@
 
 #define WFE_MAX_OVERRIDES 2
 
+/* Default per-(work item, stage) budget for auto-retrying a TRANSIENT roundtable
+ * park (panel_degraded / panel_unreachable). With one retry per scheduler backstop
+ * sweep this is roughly "how many sweeps a persistent degradation is tolerated
+ * before it escalates to a human." Override with AIMEE_AUTONOMY_PANEL_RETRIES
+ * (an explicit 0 disables auto-retry; a malformed/negative value floors here). */
+#define WFE_AUTONOMY_PANEL_RETRY_CAP_DEFAULT 6
+
 /* Drive a work item as far as its mode + gate policies allow. Returns 0 on a
  * clean stop (terminal or parked), -1 on error. */
 int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen);


### PR DESCRIPTION
## Problem

An autonomous work item that reached a review gate whose roundtable panel could not be **composed** (`panel_degraded` — a review lens exhausted all eligible reviewers) or **reached** (`panel_unreachable` — `nv < 0`) parked and then waited **forever for a human**.

Root cause chain:
- `wfe_autonomy_run` treated **every** `WFE_STEP_PENDING` park as an inviolable human gate and returned, waiting for a human resume.
- `wfe_engine_advance` refuses to re-run a pre-parked item (`"parked; caller must resume explicitly"`).
- So a **momentary** provider blip — a few reviewer agents transiently `DOWN`/unreachable when the panel convened — **permanently dead-ended** the run. That is the opposite of what a panel "fail-closed" should mean for an *autonomous* pipeline.

This is what parked the overnight proposal-ingestion run at `plan_gate` with `pause=panel_degraded` and left it stuck.

## Fix

`panel_degraded` / `panel_unreachable` are **transient provider flakiness**, not human decisions, so the autonomy driver now auto-retries them:

- On entry, `wfe_autonomy_run` detects a transient park and, if under `AIMEE_AUTONOMY_PANEL_RETRIES` (default **6**, counted via per-stage `panel_retry` audit events), writes a `panel_retry` event and calls `db1_work_item_clear_pause` so the advance loop **re-runs the roundtable node** for a fresh panel.
- The `wfe_scheduler` backstop sweep runs every **30s**, giving one retry per sweep = natural **backoff**.
- Once the retry budget is spent, the item **stays parked** to escalate to a human.
- `stuck` / `operator_paused` / `pending_human` parks are **unchanged** — still re-park without re-running work.

Bounded by the retry cap **and** the existing `work_item_max_cost_usd` cap (panel re-runs spawn reviewer calls); the cumulative `max_turns` (300) audit-event cap is the ultimate runaway backstop.

## Verification

- `clang-format-19` clean; `gcc -fsyntax-only` clean against the current `testing` headers (no new symbols/headers introduced).
- Full build + unit tests via CI.
- Routed through the aimee roundtable review before merge (per process).
