### PR TITLE
feat(workflow): TDD option for implement steps (two-agent red→green)

### DIFF
--- a/frontend/src/pages/EditWorkflows.tsx
+++ b/frontend/src/pages/EditWorkflows.tsx
@@ -86,6 +86,16 @@ interface Participant {
 }
 
 const ROUNDTABLE_BLOCK = "gate.roundtable";
+const IMPLEMENT_BLOCK = "implement";
+
+// Read an implement node's TDD test-author participant (test_persona/test_delegate).
+function readTddTest(node: GNode): Participant {
+  const p = (node.params || {}) as Record<string, unknown>;
+  return {
+    persona: typeof p.test_persona === "string" ? p.test_persona : "",
+    delegate: typeof p.test_delegate === "string" ? p.test_delegate : "",
+  };
+}
 
 // Read the participants a node currently declares, from whichever param shape it
 // uses: a roundtable's panel (required = delegates, personas = the lenses) or a
@@ -117,9 +127,18 @@ function nodeTitle(node: GNode): string {
 }
 
 // A compact "persona@delegate, …" line for the node card, or "" when unset.
+// implement nodes in TDD mode also list the test author and a "TDD" marker.
 function participantSummary(node: GNode): string {
   const ps = readParticipants(node).filter((p) => p.persona || p.delegate);
-  if (!ps.length) return "";
+  const tddOn =
+    node.block === IMPLEMENT_BLOCK &&
+    ((node.params as Record<string, unknown> | undefined)?.tdd === true ||
+      (node.params as Record<string, unknown> | undefined)?.tdd === "true");
+  if (tddOn) {
+    const test = readTddTest(node);
+    if (test.persona || test.delegate) ps.push(test);
+  }
+  if (!ps.length) return tddOn ? "TDD" : "";
   const parts = ps
     .slice(0, 2)
     .map((p) =>
@@ -127,7 +146,9 @@ function participantSummary(node: GNode): string {
         ? `${p.persona}@${p.delegate}`
         : p.persona || p.delegate,
     );
-  return parts.join(", ") + (ps.length > 2 ? ` +${ps.length - 2}` : "");
+  const summary =
+    parts.join(", ") + (ps.length > 2 ? ` +${ps.length - 2}` : "");
+  return tddOn ? `${summary} · TDD` : summary;
 }
 
 /* ---- block-style YAML emitter (aimee's yaml.c is block-style only: no flow
@@ -979,12 +1000,20 @@ function NodeInspector({
   // A roundtable runs a panel of lenses (several persona+delegate participants);
   // every other action runs a single persona on a single delegate.
   const isMulti = node.block === ROUNDTABLE_BLOCK;
+  // implement steps can opt into TDD: a second (test-author) agent writes the
+  // failing tests before the implementer makes them pass.
+  const isImplement = node.block === IMPLEMENT_BLOCK;
 
   const [title, setTitle] = useState("");
   const [task, setTask] = useState("");
   const [parts, setParts] = useState<Participant[]>([]);
   const [quorum, setQuorum] = useState(0);
   const [focus, setFocus] = useState("");
+  const [tdd, setTdd] = useState(false);
+  const [testPart, setTestPart] = useState<Participant>({
+    persona: "",
+    delegate: "",
+  });
   const [showAdv, setShowAdv] = useState(false);
   const [paramsText, setParamsText] = useState("");
   const [paramsErr, setParamsErr] = useState("");
@@ -1003,6 +1032,8 @@ function NodeInspector({
     setParts(ps);
     setQuorum(typeof p.quorum === "number" ? p.quorum : 0);
     setFocus(typeof p.focus === "string" ? p.focus : "");
+    setTdd(p.tdd === true || p.tdd === "true");
+    setTestPart(readTddTest(node));
     setParamsText(node.params ? JSON.stringify(node.params, null, 2) : "");
     setParamsErr("");
     setShowAdv(false);
@@ -1020,17 +1051,23 @@ function NodeInspector({
     parts?: Participant[];
     quorum?: number;
     focus?: string;
+    tdd?: boolean;
+    testPart?: Participant;
   }) => {
     const t = next.title ?? title;
     const tk = next.task ?? task;
     const pr = next.parts ?? parts;
     const q = next.quorum ?? quorum;
     const fc = next.focus ?? focus;
+    const td = next.tdd ?? tdd;
+    const tp = next.testPart ?? testPart;
     if (next.title !== undefined) setTitle(next.title);
     if (next.task !== undefined) setTask(next.task);
     if (next.parts !== undefined) setParts(next.parts);
     if (next.quorum !== undefined) setQuorum(next.quorum);
     if (next.focus !== undefined) setFocus(next.focus);
+    if (next.tdd !== undefined) setTdd(next.tdd);
+    if (next.testPart !== undefined) setTestPart(next.testPart);
     mutate((g) => {
       const n = g.nodes.find((x) => x.id === node.id);
       if (!n) return g;
@@ -1074,6 +1111,22 @@ function NodeInspector({
         else delete params.persona;
         if (one?.delegate) params.delegate = one.delegate;
         else delete params.delegate;
+        // implement TDD: a second (test-author) agent + the tdd flag. The
+        // implementer reuses persona/delegate above; the test author is
+        // test_persona/test_delegate. All cleared when TDD is off or unset.
+        if (isImplement && td) {
+          params.tdd = true;
+          const tperson = tp.persona.trim();
+          const tdeleg = tp.delegate.trim();
+          if (tperson) params.test_persona = tperson;
+          else delete params.test_persona;
+          if (tdeleg) params.test_delegate = tdeleg;
+          else delete params.test_delegate;
+        } else {
+          delete params.tdd;
+          delete params.test_persona;
+          delete params.test_delegate;
+        }
       }
       n.params = Object.keys(params).length ? params : undefined;
       return g;
@@ -1170,7 +1223,11 @@ function NodeInspector({
       />
 
       <label style={{ ...lbl, marginTop: 8 }}>
-        {isMulti ? "Panel — personas & delegates" : "Persona & delegate"}
+        {isMulti
+          ? "Panel — personas & delegates"
+          : isImplement && tdd
+            ? "Implementation — persona & delegate"
+            : "Persona & delegate"}
       </label>
       {parts.map((p, i) => (
         <div key={i} style={{ display: "flex", gap: 4, marginBottom: 4 }}>
@@ -1228,6 +1285,59 @@ function NodeInspector({
             style={{ ...inp, width: "100%" }}
           />
         </>
+      )}
+      {isImplement && (
+        <div style={{ marginTop: 8 }}>
+          <label
+            style={{
+              ...lbl,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              cursor: "pointer",
+              margin: "4px 0",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={tdd}
+              onChange={(e) => commitStep({ tdd: e.target.checked })}
+            />
+            TDD — a second agent writes the failing tests, then the implementer
+            makes them pass
+          </label>
+          {tdd && (
+            <>
+              <label style={{ ...lbl, marginTop: 6 }}>
+                Test author — persona & delegate
+              </label>
+              <div style={{ display: "flex", gap: 4, marginBottom: 4 }}>
+                <input
+                  list="wf-persona-opts"
+                  value={testPart.persona}
+                  placeholder="persona"
+                  onChange={(e) =>
+                    commitStep({
+                      testPart: { ...testPart, persona: e.target.value },
+                    })
+                  }
+                  style={{ ...inp, flex: 1, minWidth: 0 }}
+                />
+                <input
+                  list="wf-delegate-opts"
+                  value={testPart.delegate}
+                  placeholder="delegate"
+                  onChange={(e) =>
+                    commitStep({
+                      testPart: { ...testPart, delegate: e.target.value },
+                    })
+                  }
+                  style={{ ...inp, flex: 1, minWidth: 0 }}
+                />
+              </div>
+            </>
+          )}
+        </div>
       )}
       <datalist id="wf-persona-opts">
         {personas.map((p) => (

--- a/src/tests/test_wfe_blocks.c
+++ b/src/tests/test_wfe_blocks.c
@@ -14,6 +14,26 @@ static int sh(const char *cmd)
    return system(cmd);
 }
 
+/* Capture `git -C dir rev-parse HEAD` into out[64]. Returns 0 on success. */
+static int git_head(const char *dir, char out[64])
+{
+   char cmd[1200];
+   snprintf(cmd, sizeof cmd, "git -C %s rev-parse HEAD 2>/dev/null", dir);
+   FILE *p = popen(cmd, "r");
+   if (!p)
+      return -1;
+   char buf[128] = "";
+   char *got = fgets(buf, sizeof buf, p);
+   pclose(p);
+   if (!got)
+      return -1;
+   size_t n = strlen(buf);
+   while (n && (buf[n - 1] == '\n' || buf[n - 1] == '\r'))
+      buf[--n] = '\0';
+   snprintf(out, 64, "%s", buf);
+   return out[0] ? 0 : -1;
+}
+
 int main(void)
 {
    printf("wfe-blocks: ");
@@ -71,6 +91,33 @@ int main(void)
    const char *bb = base2[0] ? "master" : "main";
    wfe_git_freeze(dir, bb, b3, h3, hh3, err, sizeof err);
    assert(strcmp(hh3, h_change) == 0);
+
+   /* --- TDD anti-deletion guard: red-authored tests must survive GREEN --- */
+   /* red commit: add a test file (currently on branch feat). */
+   snprintf(cmd, sizeof cmd,
+            "cd %s && printf 'test\\n' > test_x.c && git add -A && git commit -q -m red", dir);
+   assert(sh(cmd) == 0);
+   char red[64] = "";
+   assert(git_head(dir, red) == 0);
+
+   /* good GREEN: change production code, keep the test -> survives. */
+   snprintf(cmd, sizeof cmd,
+            "cd %s && printf 'a\\nb\\nc\\n' > f.txt && git add -A && git commit -q -m green_good",
+            dir);
+   assert(sh(cmd) == 0);
+   assert(wfe_tdd_tests_survive(dir, red) == 1);
+
+   /* bad GREEN: delete the red-authored test -> does not survive. */
+   snprintf(cmd, sizeof cmd, "cd %s && git rm test_x.c >/dev/null && git commit -q -m green_bad",
+            dir);
+   assert(sh(cmd) == 0);
+   assert(wfe_tdd_tests_survive(dir, red) == 0);
+
+   /* not applicable (empty args / unresolvable) -> permissive (1), the freeze +
+    * aggregate verify are the backstop. */
+   assert(wfe_tdd_tests_survive(dir, "") == 1);
+   assert(wfe_tdd_tests_survive("", red) == 1);
+   assert(wfe_tdd_tests_survive(dir, "0000000000000000000000000000000000000000") == 1);
 
    snprintf(cmd, sizeof cmd, "rm -rf %s", dir);
    sh(cmd);

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -365,6 +365,31 @@ int main(void)
       wfe_set_verify_provider(NULL);
    }
 
+   /* D1b: TDD RED gate — after the test author commits, a genuine red must NOT
+    *      already pass. It is the inverse of the verify gate when a provider is
+    *      present, and proceeds (1) with no provider (drivable). */
+   {
+      wfe_set_verify_provider(NULL);
+      assert(wfe_tdd_red_ok(".") == 1); /* no provider -> cannot enforce -> proceed */
+
+      wfe_set_verify_provider(&MOCK_VERIFY);
+      g_verify_rc = 0;
+      snprintf(g_verdict, sizeof g_verdict, "{\"schema_version\":1,\"verdict\":\"passed\"}");
+      assert(wfe_tdd_red_ok(".") == 0); /* already passes -> no failing test -> loop */
+
+      snprintf(g_verdict, sizeof g_verdict, "{\"schema_version\":1,\"verdict\":\"failed\"}");
+      assert(wfe_tdd_red_ok(".") == 1); /* tests fail -> a real red -> proceed */
+
+      g_verify_rc = -1; /* gate could not run -> red unconfirmed */
+      assert(wfe_tdd_red_ok(".") == 0);
+
+      g_verify_rc = 0;
+      snprintf(g_verdict, sizeof g_verdict, "not json");
+      assert(wfe_tdd_red_ok(".") == 0); /* unparseable -> red unconfirmed */
+
+      wfe_set_verify_provider(NULL);
+   }
+
    /* D2: adversarial gate (PC3) — reviewer + N skeptics; config-gated, majority-refute
     *     rejects, fail-closed without a provider. */
    {

--- a/src/tests/test_wfe_manager_flow.c
+++ b/src/tests/test_wfe_manager_flow.c
@@ -105,6 +105,80 @@ static int mock_delegate(const char *wd, const char *role, const char *delegate,
 }
 static const wfe_delegate_provider_t MOCK = {mock_delegate};
 
+/* ---- TDD implement (two agents): a recording mock that captures the (role,
+ * delegate) of every dispatch + whether the prompt is the RED/GREEN step, and
+ * still writes a valid intent so understand advances into implement. ---- */
+#define REC_MAX 32
+static char g_rec_role[REC_MAX][32];
+static char g_rec_deleg[REC_MAX][32];
+static int g_rec_red[REC_MAX];   /* prompt carried the RED (test-author) step */
+static int g_rec_green[REC_MAX]; /* prompt carried the GREEN (implementer) step */
+static int g_rec_n;
+static int rec_delegate(const char *wd, const char *role, const char *delegate, const char *prompt,
+                        const char *artifact_path, char out_sha[64], char *err, size_t errlen)
+{
+   (void)wd;
+   (void)err;
+   (void)errlen;
+   snprintf(out_sha, 64, "cafe0003");
+   if (g_rec_n < REC_MAX)
+   {
+      snprintf(g_rec_role[g_rec_n], 32, "%s", role ? role : "");
+      snprintf(g_rec_deleg[g_rec_n], 32, "%s", delegate ? delegate : "");
+      g_rec_red[g_rec_n] = prompt && strstr(prompt, "RED") != NULL;
+      g_rec_green[g_rec_n] = prompt && strstr(prompt, "GREEN") != NULL;
+      g_rec_n++;
+   }
+   /* let understand advance so the run reaches implement (implement then parks at
+    * the freeze against the non-git repo, AFTER its dispatches have fired). */
+   if (artifact_path && artifact_path[0] && strstr(artifact_path, "understand"))
+   {
+      FILE *f = fopen(artifact_path, "wb");
+      if (f)
+      {
+         const char *j = "{\"schema_version\":1,\"status\":\"unconfirmed\",\"summary\":\"x\","
+                         "\"acceptance_criteria\":[\"ok\"]}";
+         fwrite(j, 1, strlen(j), f);
+         fclose(f);
+      }
+   }
+   return 0;
+}
+static const wfe_delegate_provider_t REC = {rec_delegate};
+
+/* understand -> implement, implement in TDD mode: a test author (test_delegate)
+ * then the implementer (delegate). Non-enforced (terminates at implement). */
+static const char *WF_TDD = "name: tddwf\n"
+                            "start: understand\n"
+                            "nodes:\n"
+                            "  - id: understand\n"
+                            "    block: understand\n"
+                            "    next: impl\n"
+                            "  - id: impl\n"
+                            "    block: implement\n"
+                            "    in:\n"
+                            "      intent: understand.out\n"
+                            "    params:\n"
+                            "      tdd: true\n"
+                            "      persona: builder\n"
+                            "      delegate: coder\n"
+                            "      test_persona: sdet\n"
+                            "      test_delegate: tester\n";
+
+/* the same shape with TDD OFF: a single implementer dispatch, no test author. */
+static const char *WF_PLAIN = "name: plainwf\n"
+                              "start: understand\n"
+                              "nodes:\n"
+                              "  - id: understand\n"
+                              "    block: understand\n"
+                              "    next: impl\n"
+                              "  - id: impl\n"
+                              "    block: implement\n"
+                              "    in:\n"
+                              "      intent: understand.out\n"
+                              "    params:\n"
+                              "      delegate: coder\n";
+
 /* stub-advance: stand in for implement/freeze/roundtable so the test avoids git
  * and the live panel; the engine still logs an "advance" for the node (which
  * gate.deliver's re-verify relies on for the roundtable gate). */
@@ -129,6 +203,16 @@ static void setup_home(void)
    FILE *f = fopen(path, "wb");
    assert(f);
    fputs(WF, f);
+   fclose(f);
+   snprintf(path, sizeof path, "%s/tddwf.yaml", wf);
+   f = fopen(path, "wb");
+   assert(f);
+   fputs(WF_TDD, f);
+   fclose(f);
+   snprintf(path, sizeof path, "%s/plainwf.yaml", wf);
+   f = fopen(path, "wb");
+   assert(f);
+   fputs(WF_PLAIN, f);
    fclose(f);
    setenv("AIMEE_HOME", dir, 1);
    /* producing blocks act in this writable dir (the mock writes artifacts here). */
@@ -184,6 +268,61 @@ int main(void)
    }
    free(ev);
    assert(adv_understand && adv_split && adv_review && adv_deliver_terminal);
+
+   /* ---- TDD implement: two agents, tests before code ---- */
+   wfe_reset_block_executors();
+   wfe_register_default_executors(); /* REAL implement (not the stub above) */
+   wfe_set_delegate_provider(&REC);
+
+   /* TDD on: implement dispatches the test author (qa@tester) THEN the
+    * implementer (engineer@coder), RED before GREEN. The run then parks at the
+    * freeze (non-git repo), but both dispatches have already fired. */
+   g_rec_n = 0;
+   {
+      char id2[80] = "", e2[256] = "";
+      int rc2 = wfe_work_item_create("tddwf", "git@github.com:x/tdd.git", "docs/tdd.md",
+                                     "interactive", id2, e2, sizeof e2);
+      if (rc2 != 0)
+         fprintf(stderr, "\n  tddwf create failed: %s\n", e2);
+      assert(rc2 == 0);
+      (void)wfe_engine_run(id2, e2, sizeof e2);
+      /* the persona is carried in the dispatch role slot: test author = the
+       * specified `test_persona` (sdet) on `test_delegate` (tester); implementer =
+       * the node's `persona` (builder) on `delegate` (coder). */
+      int i_test = -1, i_code = -1;
+      for (int i = 0; i < g_rec_n; i++)
+      {
+         if (strcmp(g_rec_role[i], "sdet") == 0 && strcmp(g_rec_deleg[i], "tester") == 0)
+            i_test = i;
+         if (strcmp(g_rec_role[i], "builder") == 0 && strcmp(g_rec_deleg[i], "coder") == 0)
+            i_code = i;
+      }
+      assert(i_test >= 0);         /* the test author ran with its specified persona */
+      assert(i_code >= 0);         /* the implementer ran with its specified persona */
+      assert(i_test < i_code);     /* RED (tests) before GREEN (code) */
+      assert(g_rec_red[i_test]);   /* the test author got the RED prompt */
+      assert(g_rec_green[i_code]); /* the implementer got the GREEN prompt */
+   }
+
+   /* TDD off: a plain implement dispatches exactly ONE implementer (engineer) and
+    * NO separate test author (qa). */
+   g_rec_n = 0;
+   {
+      char id3[80] = "", e3[256] = "";
+      assert(wfe_work_item_create("plainwf", "git@github.com:x/plain.git", "docs/plain.md",
+                                  "interactive", id3, e3, sizeof e3) == 0);
+      (void)wfe_engine_run(id3, e3, sizeof e3);
+      int qa_calls = 0, eng_calls = 0;
+      for (int i = 0; i < g_rec_n; i++)
+      {
+         if (strcmp(g_rec_role[i], "qa") == 0)
+            qa_calls++;
+         if (strcmp(g_rec_role[i], "engineer") == 0)
+            eng_calls++;
+      }
+      assert(qa_calls == 0);  /* no TDD -> no separate test author */
+      assert(eng_calls == 1); /* the single implement dispatch */
+   }
 
    printf("ok\n");
    return 0;

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -533,6 +533,68 @@ int wfe_implement_verify_ok(const char *workdir)
    return passed ? 1 : 0;
 }
 
+/* The TDD RED gate (see wfe_blocks.h). Provider-present: a red is real iff the
+ * change does NOT pass; "passed" / can't-run / unparseable -> not a red (loop).
+ * No provider -> proceed (drivable). */
+int wfe_tdd_red_ok(const char *workdir)
+{
+   if (!g_verify || !g_verify->verify)
+      return 1; /* cannot enforce mechanically -> proceed */
+   char verdict[4096] = "";
+   if (g_verify->verify(workdir, verdict, sizeof verdict) != 0)
+      return 0; /* gate could not run -> red unconfirmed -> loop */
+   cJSON *doc = cJSON_Parse(verdict);
+   if (!doc)
+      return 0; /* unparseable -> red unconfirmed -> loop */
+   const cJSON *vd = cJSON_GetObjectItemCaseSensitive(doc, "verdict");
+   int passed = cJSON_IsString(vd) && vd->valuestring && strcmp(vd->valuestring, "passed") == 0;
+   cJSON_Delete(doc);
+   return passed ? 0 : 1; /* passed = nothing fails -> not a red -> loop */
+}
+
+/* TDD anti-deletion guard (see wfe_blocks.h). Lists the files the RED commit added/
+ * modified (NUL-delimited plumbing, so paths with spaces/specials are safe) and
+ * checks each still resolves at HEAD after GREEN. */
+int wfe_tdd_tests_survive(const char *workdir, const char *red_sha)
+{
+   if (!workdir || !workdir[0] || !red_sha || !red_sha[0])
+      return 1; /* nothing to check */
+   /* Added/Modified paths in the red commit (vs its parent; --root handles a root
+    * commit). -z => NUL-separated, unquoted — no core.quotePath ambiguity. */
+   const char *argv[] = {
+       "git",    "-C",          workdir, "diff-tree",        "-r",    "--no-commit-id",
+       "--root", "--name-only", "-z",    "--diff-filter=AM", red_sha, NULL};
+   char *o = NULL;
+   if (git_capture(argv, &o) != 0 || !o)
+   {
+      free(o);
+      return 1; /* cannot determine the red file set -> don't block (freeze backstop) */
+   }
+   int survive = 1;
+   for (char *p = o; *p;)
+   {
+      char *path = p;
+      size_t len = strlen(path); /* one NUL-terminated path */
+      p += len + 1;
+      if (!len)
+         continue;
+      char rev[1200];
+      if (snprintf(rev, sizeof rev, "HEAD:%s", path) >= (int)sizeof rev)
+         continue; /* pathological path length -> skip (don't false-positive) */
+      const char *ex[] = {"git", "-C", workdir, "cat-file", "-e", rev, NULL};
+      char *eo = NULL;
+      int rc = safe_exec_capture(ex, &eo, 1 << 12);
+      free(eo);
+      if (rc != 0)
+      {
+         survive = 0; /* a red-authored file is gone at HEAD -> GREEN deleted it */
+         break;
+      }
+   }
+   free(o);
+   return survive;
+}
+
 /* The step's assigned delegate from node params ("delegate"), or "" for none.
  * May be the sentinel "$random" — the provider resolves it to a random agent. */
 static const char *node_delegate(const wfe_node_t *node)
@@ -541,6 +603,25 @@ static const char *node_delegate(const wfe_node_t *node)
       return "";
    const cJSON *d = cJSON_GetObjectItemCaseSensitive(node->params, "delegate");
    return (d && cJSON_IsString(d) && d->valuestring) ? d->valuestring : "";
+}
+
+/* A string-typed node param by key, or "" if absent/non-string. */
+static const char *node_str(const wfe_node_t *node, const char *key)
+{
+   if (!node || !node->params)
+      return "";
+   const cJSON *v = cJSON_GetObjectItemCaseSensitive(node->params, key);
+   return (v && cJSON_IsString(v) && v->valuestring) ? v->valuestring : "";
+}
+
+/* A boolean-typed node param by key (accepts JSON true or the string "true"). */
+static int node_bool(const wfe_node_t *node, const char *key)
+{
+   if (!node || !node->params)
+      return 0;
+   const cJSON *v = cJSON_GetObjectItemCaseSensitive(node->params, key);
+   return v && (cJSON_IsTrue(v) ||
+                (cJSON_IsString(v) && v->valuestring && strcmp(v->valuestring, "true") == 0));
 }
 
 /* Dispatch one block's delegate work, if a provider is installed. `delegate` is
@@ -825,6 +906,80 @@ static int run_fanout_units(const char *wd, const wfe_node_t *node, double *cost
    return failed ? -1 : 0;
 }
 
+/* Test-Driven Development mode (implement node param `tdd: true`): drive TWO
+ * delegates in a red->green sequence on the work-item branch. The TEST agent
+ * writes the failing tests that specify the plan; the CODE agent then makes them
+ * pass without weakening them. Each agent's PERSONA and delegate are operator-
+ * specified in the composer: the test author's persona is `test_persona` (default
+ * "qa") on delegate `test_delegate`; the implementer reuses the node's own
+ * `persona` (default "engineer") on delegate `delegate`. The persona is passed in
+ * the dispatch `role` slot — the live provider treats that slot as the delegate's
+ * IDENTITY (see wfe_live_delegate.c), so this is what makes the two personas
+ * specifiable end to end. Returns 0 to proceed to the mandatory freeze + aggregate
+ * verify, -1 to loop/retry. A dispatch that reports no installed provider (0) is a
+ * no-op that still proceeds, preserving the drivable-without-a-live-delegate
+ * behavior of the single path. *cost accumulates BOTH dispatches. */
+static int run_tdd(const char *wd, const wfe_node_t *node, double *cost)
+{
+   /* 1. RED: the test author writes failing tests only — no production code. */
+   const char *test_persona = node_str(node, "test_persona");
+   if (!test_persona[0])
+      test_persona = "qa";
+   char tc[64] = "";
+   double c1 = 0.0;
+   int r1 = wfe_delegate_dispatch(
+       wd, test_persona, node_str(node, "test_delegate"),
+       "Test-Driven Development, RED step. Write FAILING tests on the work-item branch that "
+       "specify the behavior the approved plan requires. Do NOT implement the production code — "
+       "only the tests. Commit the failing tests.",
+       NULL, tc, &c1);
+   *cost += c1;
+   if (r1 < 0)
+      return -1; /* provider ran and failed -> loop/retry */
+
+   /* Enforce the RED invariant mechanically: the tests must actually FAIL now. A
+    * test author that added nothing (or passing tests) has not established a red —
+    * loop rather than let the prompt be the only guard. */
+   if (!wfe_tdd_red_ok(wd))
+      return -1;
+
+   /* Snapshot the red commit so we can prove GREEN did not delete its tests
+    * (best-effort: a non-git/degraded workdir leaves red_sha empty -> guard skipped,
+    * the freeze + aggregate verify remain the backstop). */
+   char red_sha[64] = "";
+   {
+      const char *argv[] = {"git", "-C", wd, "rev-parse", "HEAD", NULL};
+      char *o = NULL;
+      if (git_capture(argv, &o) == 0 && o)
+      {
+         chomp(o);
+         snprintf(red_sha, sizeof red_sha, "%s", o);
+      }
+      free(o);
+   }
+
+   /* 2. GREEN: the implementer makes the failing tests pass, tests unchanged. */
+   const char *code_persona = node_str(node, "persona");
+   if (!code_persona[0])
+      code_persona = "engineer";
+   char cc[64] = "";
+   double c2 = 0.0;
+   int r2 = wfe_delegate_dispatch(
+       wd, code_persona, node_delegate(node),
+       "Test-Driven Development, GREEN step. Implement the production code on the work-item branch "
+       "to make the failing tests pass WITHOUT weakening or deleting them. Run `aimee git verify`, "
+       "fix any failures, then commit the accepted work.",
+       NULL, cc, &c2);
+   *cost += c2;
+   if (r2 < 0)
+      return -1;
+
+   /* GREEN must not have deleted the red-authored tests. */
+   if (!wfe_tdd_tests_survive(wd, red_sha))
+      return -1;
+   return 0;
+}
+
 static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
 {
    char wd[1024];
@@ -834,7 +989,16 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
 
    long fanout_on = 0;
    (void)config_autonomy_lookup("AIMEE_AUTONOMY_FANOUT", &fanout_on); /* live: env > snapshot */
-   if (fanout_on)
+   if (node_bool(node, "tdd"))
+   {
+      /* Two-agent TDD (per-node opt-in): tests first, then implementation. Takes
+       * precedence over engine fan-out — the split is tests-vs-code, not per-unit.
+       * A failed dispatch loops (the engine bounds retries); the mandatory
+       * aggregate mechanical verify below still gates the merged change. */
+      if (run_tdd(wd, node, &cost) < 0)
+         return with_cost(wfe_step_looped(), cost);
+   }
+   else if (fanout_on)
    {
       /* Manager loop (PC3b): decompose -> fan out engineer per unit -> per-unit verify
        * + retry-different. A unit that never passes parks pending_human via DEGRADED

--- a/src/workflow/wfe_blocks.h
+++ b/src/workflow/wfe_blocks.h
@@ -137,6 +137,28 @@ int wfe_implement_adversarial_ok(const char *workdir);
  * unparseable, or any non-pass verdict) -> FAIL CLOSED. Exposed for the unit test. */
 int wfe_implement_verify_ok(const char *workdir);
 
+/* The TDD RED gate: after the test author commits (implement node `tdd: true`), a
+ * genuine red step must leave at least one FAILING test — the change must NOT
+ * already pass. Returns 1 to proceed to the GREEN (implementer) step, 0 to loop
+ * (re-run the test author). Cases:
+ *   - no verify provider installed -> 1 (cannot enforce mechanically; proceed, the
+ *     same drivable-without-a-provider stance as the rest of implement),
+ *   - a produced verdict that is anything OTHER than "passed" -> 1 (a real red),
+ *   - an explicit "passed" verdict (tests pass / none were added), a gate that
+ *     could not run, or an unparseable verdict -> 0 (red unconfirmed). It is the
+ *     logical inverse of wfe_implement_verify_ok in the provider-present cases.
+ * Exposed for the unit test. */
+int wfe_tdd_red_ok(const char *workdir);
+
+/* TDD anti-deletion guard: after the GREEN implementer commits, every file the RED
+ * commit `red_sha` ADDED or MODIFIED (its tests) must still exist at HEAD — GREEN
+ * makes them pass, it does not delete them. Returns 1 if all survive OR the check
+ * is not applicable (empty args, or git cannot resolve the commit — the mandatory
+ * freeze + aggregate verify remain the backstop), 0 if GREEN deleted a red-authored
+ * file. Best-effort by design so a non-git/degraded workdir stays drivable. Exposed
+ * for the unit test. */
+int wfe_tdd_tests_survive(const char *workdir, const char *red_sha);
+
 /* ---- Child-workflow fan-out seam for foreach.workflow (sliced-lifecycle build).
  * The block decomposes the split packets into one CHILD workflow run per packet
  * (the "slice" workflow: implement -> freeze -> roundtable -> sub-PR -> green CI ->


### PR DESCRIPTION
## Summary
Adds a per-node **TDD** opt-in to workflow `implement` steps. When enabled, the implement executor drives **two** delegates in a red→green sequence instead of one:

- **RED** — a test author (persona `test_persona`, default `qa`; delegate `test_delegate`) writes the failing tests that specify the plan and commits.
- **GREEN** — the implementer (persona = the node's `persona`, default `engineer`; delegate `delegate`) makes them pass without weakening them.

The persona travels in the dispatch `role` slot, which the live provider treats as the delegate's identity, so **both personas are specifiable end to end**.

## Mechanical enforcement (not prompt-only)
- `wfe_tdd_red_ok` — after RED, the change must **not already pass** (a genuine red leaves a failing test). `passed`/unrunnable/unparseable loop the test author. No verify provider → proceed (drivable), same stance as the rest of implement.
- `wfe_tdd_tests_survive` — after GREEN, every file the RED commit added/modified must still exist at HEAD (NUL-delimited `diff-tree`, injection-safe; best-effort so a non-git workdir stays drivable).
- TDD takes precedence over engine fan-out; the mandatory **freeze + aggregate mechanical verify + adversarial skeptic gate still run afterward, unchanged** — no verification bypass.

## Composer UI (`EditWorkflows.tsx`)
Clickable **TDD** checkbox on implement nodes with a *Test author — persona & delegate* row; serializes to params `tdd: true` + `test_persona`/`test_delegate`; node card shows a `· TDD` marker.

## Tests
- Engine test: `understand → implement(tdd)` dispatches the test author (`sdet@tester`, RED) **before** the implementer (`builder@coder`, GREEN); a plain implement dispatches exactly one implementer.
- Unit tests: the RED gate (mock verify provider) and the survival guard (real temp git repo — good GREEN survives, deleting GREEN fails).
- All 34 `unit-test-wfe-*` pass; frontend `tsc -b` clean.

## Review
Reviewed by a 4-persona roundtable (reviewer / security / architect / qa). Round 1 security raised one blocking finding — the red→green invariant was prompt-only — which this PR's `wfe_tdd_red_ok` + `wfe_tdd_tests_survive` gates resolve. Round 2 (security / reviewer / architect) all **APPROVE** with no blocking findings.