### PR TITLE
fix(wfe): roundtable panel reuses agents when lenses outnumber eligible agents

### DIFF
--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -259,15 +259,28 @@ static int live_panel(const wfe_review_packet_t *pkt, const char *const *require
              * DOWNGRADE: reuse an already-seated agent (drop the exclusion) — the
              * same model reviews this lens under its own persona prompt. The gate
              * then degrades only when NO review agent is eligible at all. */
+            int reused = 0;
             rt_seat_resolve_t rc =
                 rt_resolve_seat_model(&acfg, RT_SEAT_RANDOM, "review", used, nused, &idx);
             if (rc == RT_SEAT_RANDOM_EXHAUSTED)
+            {
                rc = rt_resolve_seat_model(&acfg, RT_SEAT_RANDOM, "review", NULL, 0, &idx);
-            if (rc != RT_SEAT_OK)
+               reused = 1;
+            }
+            /* rt_resolve_seat_model only sets a valid idx on RT_SEAT_OK; bound-check
+             * defensively anyway before indexing acfg.agents. */
+            if (rc != RT_SEAT_OK || idx < 0 || idx >= acfg.agent_count)
                continue; /* no eligible review agent at all -> unfilled (gate degrades) */
             agent = acfg.agents[idx].name;
-            if (nused < MAX_AGENTS)
-               used[nused++] = agent;
+            if (reused)
+               /* surface the degraded-diversity composition so operators can see the
+                * panel ran with fewer distinct agents than lenses. */
+               aimee_log(LOG_INFO, "wfe-panel",
+                         "reusing agent '%s' for lens '%s' (fewer eligible review agents "
+                         "than lenses)",
+                         agent, required[i]);
+            else if (nused < MAX_AGENTS)
+               used[nused++] = agent; /* only DISTINCT picks join the diversity set */
          }
          tasks[nt].role = "review";
          tasks[nt].agent = agent;

--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -252,9 +252,19 @@ static int live_panel(const wfe_review_packet_t *pkt, const char *const *require
          else
          {
             int idx = -1;
-            if (rt_resolve_seat_model(&acfg, RT_SEAT_RANDOM, "review", used, nused, &idx) !=
-                RT_SEAT_OK)
-               continue; /* $random exhausted -> leave unfilled (gate degrades) */
+            /* Prefer a UNIQUE agent per lens (the `used` exclusion gives panel
+             * diversity). But when there are fewer eligible review agents than
+             * lenses, insisting on distinctness would leave the surplus lenses
+             * unfilled and needlessly DEGRADE the whole gate. So on exhaustion,
+             * DOWNGRADE: reuse an already-seated agent (drop the exclusion) — the
+             * same model reviews this lens under its own persona prompt. The gate
+             * then degrades only when NO review agent is eligible at all. */
+            rt_seat_resolve_t rc =
+                rt_resolve_seat_model(&acfg, RT_SEAT_RANDOM, "review", used, nused, &idx);
+            if (rc == RT_SEAT_RANDOM_EXHAUSTED)
+               rc = rt_resolve_seat_model(&acfg, RT_SEAT_RANDOM, "review", NULL, 0, &idx);
+            if (rc != RT_SEAT_OK)
+               continue; /* no eligible review agent at all -> unfilled (gate degrades) */
             agent = acfg.agents[idx].name;
             if (nused < MAX_AGENTS)
                used[nused++] = agent;

--- a/src/tests/test_roundtable_seat_resolve.c
+++ b/src/tests/test_roundtable_seat_resolve.c
@@ -79,6 +79,17 @@ int main(void)
    assert(rt_resolve_seat_model(&cfg, "$random", "review", used3, 3, &idx) ==
           RT_SEAT_RANDOM_EXHAUSTED);
 
+   /* Downgrade contract (wfe_live_panel): when the DISTINCT pool is exhausted (more
+    * lenses than eligible agents), a retry WITHOUT the exclusion still resolves —
+    * i.e. an already-seated agent is REUSED rather than leaving the lens unfilled.
+    * This is what lets a panel compose by reusing agents instead of degrading the
+    * gate; it degrades only when NO eligible agent exists at all. */
+   assert(rt_resolve_seat_model(&cfg, "$random", "review", used3, 3, &idx) ==
+          RT_SEAT_RANDOM_EXHAUSTED); /* distinct: none */
+   assert(rt_resolve_seat_model(&cfg, "$random", "review", NULL, 0, &idx) ==
+          RT_SEAT_OK);           /* reuse */
+   assert(idx >= 0 && idx <= 2); /* reuse still respects role eligibility (A/B/C, not D/E) */
+
    /* Empty/unset model behaves as "$random", not a pinned failure. */
    assert(rt_resolve_seat_model(&cfg, "", "review", NULL, 0, &idx) == RT_SEAT_OK);
 


### PR DESCRIPTION
## Problem

The live roundtable panel resolved **one distinct agent per required lens**: each `$random` seat excluded every already-seated agent (`used`), so once the distinct pool was spent, `rt_resolve_seat_model` returned `RANDOM_EXHAUSTED` and the surplus lenses were left **unfilled** — degrading the whole gate (`panel_degraded`).

So a roundtable with **more required lenses than eligible review agents** (e.g. 5 lenses but only 2–3 available agents — common once a provider goes DOWN) **always** parked `panel_degraded`, regardless of how healthy the available agents were. This was a primary cause of the overnight proposal-ingestion workflow stalling at `plan_gate`.

## Fix

The panel still **prefers a unique agent per lens** (the `used` exclusion → diversity), but now **downgrades to reusing an already-seated agent** when the distinct pool is exhausted — the same model reviews the surplus lens under its own persona prompt. The gate degrades only when **no** review agent is eligible at all, not merely when agents < lenses. Pinned seats are unchanged (exact, no substitution).

## Verification

- `test_roundtable_seat_resolve` pins the two-step contract the fix relies on: distinct-exhausted → a `NULL`-exclusion retry still resolves (reuse), still respecting role eligibility.
- Compiles clean under `-Werror`; full CI.
- Will be validated live on .254 (does `plan_gate` now compose with the available agent set?).

Complements the just-merged autonomy fix (#1268): that stops a transient degrade from dead-ending a run; this stops the *most common* degrade from happening at all.
