### PR TITLE
feat(webchat): surface autonomous runs in the Workflows tab + rename the tab

### DIFF
--- a/frontend/src/help/tutorials.ts
+++ b/frontend/src/help/tutorials.ts
@@ -55,7 +55,7 @@ export const TAB_TUTORIALS: Record<string, Tutorial> = {
     seeAlso: '/workflow-actions',
   },
   '/workflow-actions': {
-    title: 'Workflow Actions',
+    title: 'Workflows',
     body: [
       'The runtime queue: workflow items waiting on you to approve or reject.',
       'This is the human-in-the-loop gate.',

--- a/frontend/src/nav.ts
+++ b/frontend/src/nav.ts
@@ -12,7 +12,7 @@ export const NAV_ITEMS: Tab[] = [
   { label: 'Dashboard', icon: '📊', route: '/dashboard' },
   { label: 'Logs', icon: '📜', route: '/logs' },
   { label: 'Edit Workflows', icon: '🔀', route: '/edit-workflows' },
-  { label: 'Workflow Actions', icon: '📝', route: '/workflow-actions' },
+  { label: 'Workflows', icon: '📝', route: '/workflow-actions' },
   { label: 'Agents', icon: '🤝', route: '/agents' },
   { label: 'Personas', icon: '🎭', route: '/personas' },
   { label: 'Roles', icon: '🎬', route: '/roles' },

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -411,7 +411,7 @@ export default function WorkflowActions() {
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
-          <strong style={{ fontSize: 16 }}>Workflow Actions</strong>
+          <strong style={{ fontSize: 16 }}>Workflows</strong>
           <Badge label={`${items.length}`} variant="neutral" />
           <button onClick={refreshList} style={btn}>
             Refresh

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -610,11 +610,22 @@ static const char *path_basename(const char *p)
    return slash ? slash + 1 : (p ? p : "");
 }
 
-/* Ownership: true iff the item's submitter equals the calling principal (string
- * compare; both must be non-empty). A NULL/empty submitter (CLI/legacy/system
- * rows) is owned by nobody, so owner-only reads refuse it — fail-closed. */
+/* Ownership / operator-visibility for the Workflow Actions surface. True iff:
+ *   - the run is AUTONOMOUS (system/triggered: the proposals trigger, cron, or a
+ *     dev-submit pipeline). These are not private human proposals, so they are
+ *     visible to — and operable (pause/resume/stop) by — any authenticated
+ *     dashboard operator, so the tab shows the autonomous pipeline regardless of
+ *     which webuser convened it; OR
+ *   - the item's submitter equals the calling principal — an INTERACTIVE human
+ *     proposal stays owner-scoped (closes the list IDOR; one user never sees
+ *     another's drafts).
+ * A NULL/empty submitter on a non-autonomous row is owned by nobody -> fail
+ * closed. The human-gate decision (approve/reject) is separately CAP_WORKFLOW_
+ * ADMIN-gated, so widening visibility here does not widen gate authority. */
 static int wf_owns(const db1_work_item_t *wi)
 {
+   if (strcmp(wi->mode, "autonomous") == 0)
+      return 1;
    const char *principal = server_http_identity_principal();
    return wi->submitter[0] && principal && principal[0] && strcmp(principal, wi->submitter) == 0;
 }

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -277,14 +277,16 @@ int main(void)
    assert(wf_api_events("no-such-item", 0, 200, buf, CAP) == 404);
    assert(wf_api_proposal("no-such-item", buf, CAP) == 404);
 
-   /* --- ownership: a work item submitted by another principal is not readable ---
-    * The test runs with an un-attested (empty) principal, so an item whose submitter
-    * is set is owned by nobody-in-this-context: the per-item reads must 403 (the
-    * IDOR closure). The owner-allowed path + pagination + proposal read-back are
-    * exercised live (a request carrying the matching webuser principal). */
+   /* --- ownership: an INTERACTIVE work item submitted by another principal is not
+    * readable --- The test runs with an un-attested (empty) principal, so an
+    * interactive item whose submitter is set is owned by nobody-in-this-context:
+    * the per-item reads must 403 (the IDOR closure). (Autonomous runs are the
+    * deliberate exception — see the operator-visibility block below.) The
+    * owner-allowed path + pagination + proposal read-back are exercised live (a
+    * request carrying the matching webuser principal). */
    {
       assert(db1_work_item_create("wi_owned", "", "wi_owned.md", "build", "v1", "draft",
-                                  "autonomous") == 0);
+                                  "interactive") == 0);
       assert(db1_work_item_set_submitter("wi_owned", "webuser:someone-else") == 0);
       (void)db1_lifecycle_event_add("wi_owned", "draft", "create", "user", "", "", 0.0);
 
@@ -310,6 +312,36 @@ int main(void)
       assert(strcmp(cJSON_GetObjectItemCaseSensitive(it, "proposal_name")->valuestring,
                     "wi_owned.md") == 0);
       assert(cJSON_HasObjectItem(it, "cum_cost_usd") && cJSON_HasObjectItem(it, "pr_ref"));
+      cJSON_Delete(o);
+   }
+
+   /* --- autonomous / triggered runs are OPERATOR-VISIBLE regardless of submitter ---
+    * A system-initiated run (mode "autonomous": the proposals trigger, cron, or a
+    * dev-submit pipeline) is not a private human proposal, so a dashboard operator
+    * — here the un-attested (non-submitting) principal — can read it AND it appears
+    * in the DEFAULT owner-scoped list. This is what surfaces the autonomous pipeline
+    * in the Workflows tab. Interactive proposals stay owner-scoped (block above). */
+   {
+      assert(db1_work_item_create("wi_auto", "", "wi_auto.md", "build", "v1", "draft",
+                                  "autonomous") == 0);
+      assert(db1_work_item_set_submitter("wi_auto", "webuser:someone-else") == 0);
+      (void)db1_lifecycle_event_add("wi_auto", "draft", "create", "engine", "", "", 0.0);
+
+      /* principal is empty (non-owner), yet the autonomous run is readable... */
+      assert(wf_api_item("wi_auto", buf, CAP) == 200);
+      assert(wf_api_events("wi_auto", 0, 200, buf, CAP) == 200);
+      /* ...and it shows in the default owner-scoped list (the Workflows tab). */
+      assert(wf_api_items(buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      cJSON *items = cJSON_GetObjectItemCaseSensitive(o, "items");
+      int found = 0;
+      for (int i = 0; i < cJSON_GetArraySize(items); i++)
+      {
+         cJSON *it = cJSON_GetArrayItem(items, i);
+         if (strcmp(cJSON_GetObjectItemCaseSensitive(it, "id")->valuestring, "wi_auto") == 0)
+            found = 1;
+      }
+      assert(found);
       cJSON_Delete(o);
    }
 


### PR DESCRIPTION
## Two operator-visibility changes for the Workflow Actions surface

**1. Triggered/autonomous runs now show in the tab.** The tab is owner-scoped (`submitter == principal`) to close the list IDOR, but system-initiated runs (proposals trigger, cron, dev-submit) are submitted under the trigger's principal (e.g. `webuser:aimee`), so a human logged in as a different user only saw them under "Show all (operator)". `wf_owns` now returns true for any **autonomous-mode** run → visible to (and pausable/stoppable by) any authenticated dashboard operator, while **interactive** human proposals stay owner-scoped. The human-gate decision (approve/reject) is separately `CAP_WORKFLOW_ADMIN`-gated, so visibility ≠ gate authority.

**2. Tab renamed** "Workflow Actions" → **"Workflows"** (nav label, page heading, tutorial title). Route/component names unchanged.

## Verification
- `test_wfe_webapi`: the IDOR-closure case switched to an **interactive** item (still 403 + absent from the owner list for a non-owner); a new block asserts an **autonomous** run by another principal IS readable and appears in the default owner-scoped list. Passes under `-Werror`.
- Frontend: label-string-only changes.

Follows the roundtable-resilience fixes (#1268 autonomy retry, #1270 agent reuse) that get the autonomous pipeline running — this makes it observable in the GUI.
