### PR TITLE
fix(agent): enforce per-agent max_parallel in the panel/parallel dispatch path

### DIFF
--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -193,12 +193,24 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
       }
       free(hint);
 
+      /* Respect the agent's max_parallel cap (same rationale as agent_run_named):
+       * a saturated agent is SKIPPED for a different one rather than piled on.
+       * Being at the limit is a saturation signal, not a provider fault, so it is
+       * added to `tried` (excluded from the next pick) WITHOUT a health failure. */
+      if (!provider_catalog_concurrent_acquire(ag->name, ag->max_parallel))
+      {
+         free(enhanced);
+         if (ntried < MAX_AGENTS)
+            tried[ntried++] = ag->name;
+         continue;
+      }
       int rc;
       if (use_tools)
          rc = agent_execute_with_tools_for_role(ag, &cfg->network, role, system_prompt,
                                                 effective_prompt, max_tokens, temperature, out);
       else
          rc = agent_execute(ag, system_prompt, effective_prompt, max_tokens, temperature, out);
+      provider_catalog_concurrent_release(ag->name);
       free(enhanced);
 
       if (rc == 0)
@@ -338,7 +350,24 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    local.ablation = cfg->ablation;
    local.write_capable = 0; /* ensemble references answer a prompt; no write tools */
 
+   /* Enforce the agent's max_parallel cap (process-wide, keyed by name) BEFORE
+    * dispatch. The parallel panel/ensemble fan-out (parallel_worker) reaches this
+    * by-name path for every lens; without the cap a single model gets many
+    * SIMULTANEOUS reviews — tripping provider rate limits / 400s (this is exactly
+    * how a reused agent, or a busy provider like mistral with max_parallel=2, gets
+    * hammered). At the limit, report the agent unavailable so the caller (the
+    * panel's round-2 retry / the ensemble) picks a different agent instead of
+    * piling on. Return BEFORE the health-record block so "at limit" — a
+    * saturation signal, not a provider fault — never counts as a health failure. */
+   if (!provider_catalog_concurrent_acquire(local.name, local.max_parallel))
+   {
+      snprintf(out->agent_name, MAX_AGENT_NAME, "%s", local.name);
+      snprintf(out->error, sizeof(out->error), "agent '%s' at concurrency limit (max_parallel=%d)",
+               local.name, local.max_parallel);
+      return -1;
+   }
    int rc = agent_execute(&local, system_prompt, user_prompt, max_tokens, temperature, out);
+   provider_catalog_concurrent_release(local.name);
    if (rc == 0)
       provider_catalog_record_success(local.name);
    else


### PR DESCRIPTION
## Problem

The roundtable panel dispatches each review lens via `agent_run_parallel` → `parallel_worker` → `agent_run_named` / `agent_run_ex`, both of which call `agent_execute()` **directly** — bypassing the *only* place the per-agent concurrency cap is enforced (`provider_catalog_concurrent_acquire`, used solely inside `agent_execute_guarded`).

Result: a single model receives **many simultaneous** reviews with no `max_parallel` ceiling. Observed live: codex (`chatgpt/gpt-5.5`) getting ~15 calls in 2 minutes and returning HTTP 400, and rate-limit-sensitive providers like mistral (`max_parallel=2`) hammered — dragging the gate below quorum → `panel_degraded`. (This compounds with agent reuse: a reused agent can be assigned to several lenses at once.)

## Fix

Both by-name (`agent_run_named`) and by-role (`agent_run_ex`) dispatch now **acquire the agent's slot before `agent_execute` and release after**. At the limit, the agent is reported unavailable (by-name) or skipped for a different agent (by-role → added to `tried`), so the caller spreads load instead of piling on. The acquire failure returns **before** the provider-health record block — saturation is a load signal, not a provider fault, so it never counts as a health failure. `acquire()` returns "unlimited" for `max_parallel<=0` / unknown agents, so single-dispatch callers are unchanged.

## Verification
- Compiles clean under `-Werror`; `test_agent_http`, `test_agent_loop`, `test_agent_parallel` all pass (no regression).
- The concurrency primitive itself is already unit-tested; this wires it into the parallel path. Final proof is live: codex should stop being hammered and the panel should compose within provider limits.

Completes the roundtable-resilience series: #1268 (autonomy retry), #1270 (agent reuse), and this (respect concurrency caps so reuse/fan-out doesn't overload a provider).
