### PR TITLE
refactor(agent): route every model turn through one guarded dispatch path

### DIFF
--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -71,6 +71,10 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int task_count,
 
 /* Delegate fallback helpers */
 int agent_error_is_retryable(const char *error);
+/* Should a fallback/retry caller try a different agent for this result? True for a
+ * saturation refusal (AGENT_RC_AT_LIMIT) or a retryable provider error; false for
+ * success (0) or a non-retryable hard failure. */
+int agent_rc_should_try_another(int rc, const char *error);
 int agent_try_same_tier_fallback(agent_config_t *cfg, agent_t **current, const char *role,
                                  const char *system_prompt, const char *user_prompt, int max_tokens,
                                  int enforce_writes, agent_result_t *out, int rc);
@@ -89,7 +93,13 @@ int agent_try_same_tier_fallback(agent_config_t *cfg, agent_t **current, const c
  * AGENT_RC_AT_LIMIT if the agent was at its ceiling (NO health recorded), or -1 on
  * a run failure (health recorded). Agent RESOLUTION (by name/role/route),
  * retry/fallback loops, write_capable, and outcome/feedback/cache logging stay in
- * the callers — only the model turn itself goes through here. */
+ * the callers — only the model turn itself goes through here.
+ * PRECONDITION: `net` must be non-NULL when use_tools != 0 (the tools executor
+ * dereferences it); a plain completion (use_tools == 0) ignores `net`.
+ * This is an EXTERNAL model-turn boundary — do NOT call it from a helper that
+ * already runs inside another agent_dispatch_one for the same agent, or the inner
+ * call re-acquires the same max_parallel slot (self-throttle). Such composite
+ * helpers use the primitive agent_execute() directly. */
 int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char *role,
                        const char *system_prompt, const char *user_prompt, int max_tokens,
                        double temperature, int use_tools, agent_result_t *out);

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -75,13 +75,24 @@ int agent_try_same_tier_fallback(agent_config_t *cfg, agent_t **current, const c
                                  const char *system_prompt, const char *user_prompt, int max_tokens,
                                  int enforce_writes, agent_result_t *out, int rc);
 
-/* Execute with per-agent concurrency guard. Acquires a slot from the
- * provider catalog before calling agent_execute_with_tools_for_role and
- * releases it on return. Returns -1 immediately if the agent is at its
- * max_parallel ceiling. */
-int agent_execute_guarded(agent_t *ag, const agent_network_t *net, const char *role,
-                          const char *system_prompt, const char *user_prompt, int max_tokens,
-                          agent_result_t *out);
+/* AGENT_RC_AT_LIMIT: agent_dispatch_one refused because the agent is already at
+ * its max_parallel ceiling — a saturation signal DISTINCT from a run failure, so
+ * a fan-out/retry caller tries a different agent and it is never recorded as a
+ * provider-health fault. */
+#define AGENT_RC_AT_LIMIT (-2)
+
+/* THE single per-agent turn executor: the one place that enforces the per-agent
+ * max_parallel concurrency cap and records provider-health for a model turn.
+ * Acquires the agent's slot, runs the turn (use_tools -> the tool loop
+ * agent_execute_with_tools_for_role, else a plain completion agent_execute),
+ * releases, and records success/failure health. Returns 0 on success,
+ * AGENT_RC_AT_LIMIT if the agent was at its ceiling (NO health recorded), or -1 on
+ * a run failure (health recorded). Agent RESOLUTION (by name/role/route),
+ * retry/fallback loops, write_capable, and outcome/feedback/cache logging stay in
+ * the callers — only the model turn itself goes through here. */
+int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char *role,
+                       const char *system_prompt, const char *user_prompt, int max_tokens,
+                       double temperature, int use_tools, agent_result_t *out);
 
 /* Logging */
 void agent_log_call(const agent_result_t *result, const char *role);

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -80,35 +80,21 @@ int agent_try_same_tier_fallback(agent_config_t *cfg, agent_t **current, const c
       out->error[0] = '\0';
 
       aimee_log(LOG_INFO, "agent", "fallback: trying same-tier agent '%s'", peer->name);
-      rc = agent_execute_with_tools_for_role(peer, &cfg->network, role, system_prompt, user_prompt,
-                                             max_tokens, 0.3, out);
+      /* Through the single guarded executor: enforces peer->max_parallel and
+       * records peer health (success or failure). An AGENT_RC_AT_LIMIT keeps rc
+       * non-zero so the loop simply moves to the next same-tier peer. */
+      rc = agent_dispatch_one(peer, &cfg->network, role, system_prompt, user_prompt, max_tokens,
+                              0.3, 1 /* use_tools */, out);
       if (rc == 0)
       {
          ag = peer;
          if (current)
             *current = peer;
       }
-      else
-      {
-         const char *pec = agent_error_is_retryable(out->error) ? "retryable" : "error";
-         provider_catalog_record_failure(peer->name, pec);
-      }
    }
 
    return rc;
 }
-
-int agent_execute_guarded(agent_t *ag, const agent_network_t *net, const char *role,
-                          const char *system_prompt, const char *user_prompt, int max_tokens,
-                          agent_result_t *out)
-{
-   if (!provider_catalog_concurrent_acquire(ag->name, ag->max_parallel))
-   {
-      snprintf(out->error, sizeof(out->error), "agent '%s' at concurrency limit", ag->name);
-      return -1;
-   }
-   int rc = agent_execute_with_tools_for_role(ag, net, role, system_prompt, user_prompt, max_tokens,
-                                              0.3, out);
-   provider_catalog_concurrent_release(ag->name);
-   return rc;
-}
+/* agent_execute_guarded was removed: the concurrency guard + health recording it
+ * provided now live in the single agent_dispatch_one (agent_runtime.c), which
+ * EVERY dispatch path routes through. */

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -32,6 +32,20 @@ int agent_error_is_retryable(const char *error)
           strstr(error, "no content in response") != NULL;
 }
 
+/* Should a fallback/retry caller try a DIFFERENT agent for this result? Yes for a
+ * saturation refusal (AGENT_RC_AT_LIMIT — the agent is momentarily at its
+ * max_parallel ceiling, so a peer may be free) OR a retryable provider error. A
+ * plain success (0) or a non-retryable hard failure is terminal for the fallback
+ * path. Centralises the at-limit-triggers-fallback rule so callers don't rely on
+ * the error-string classifier (which does NOT — and must not — treat the
+ * "at concurrency limit" message as retryable, so at-limit never records health). */
+int agent_rc_should_try_another(int rc, const char *error)
+{
+   if (rc == 0)
+      return 0;
+   return rc == AGENT_RC_AT_LIMIT || agent_error_is_retryable(error);
+}
+
 static int agent_supports_delegate_role(const agent_t *ag, const char *role)
 {
    return ag && role && (agent_has_role(ag, role) || agent_is_exec_role(ag, role));
@@ -54,7 +68,9 @@ int agent_try_same_tier_fallback(agent_config_t *cfg, agent_t **current, const c
                                  int enforce_writes, agent_result_t *out, int rc)
 {
    agent_t *ag = current ? *current : NULL;
-   if (!cfg || !ag || !out || rc == 0 || !agent_error_is_retryable(out->error))
+   /* Proceed for a retryable failure OR a saturation refusal (AGENT_RC_AT_LIMIT):
+    * a same-tier peer may be free even if the primary was momentarily at its cap. */
+   if (!cfg || !ag || !out || !agent_rc_should_try_another(rc, out->error))
       return rc;
 
    /* Cost-tier fallback: a tier is a pool. Even when fallback_chain is stale

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -141,6 +141,15 @@ int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char
 {
    if (!ag || !out)
       return -1;
+   /* The tools executor dereferences `net`; a plain completion ignores it. Enforce
+    * the precondition (net != NULL when use_tools) so a future caller that flips
+    * use_tools without supplying a network fails cleanly instead of crashing. */
+   if (use_tools && !net)
+   {
+      if (out)
+         snprintf(out->error, sizeof(out->error), "agent_dispatch_one: use_tools requires network");
+      return -1;
+   }
    /* Concurrency choke point: acquire the agent's max_parallel slot. At the limit,
     * report a DISTINCT at-limit signal (so a fan-out/retry caller picks a different
     * agent) and return BEFORE any health recording — saturation is a load signal,
@@ -335,6 +344,8 @@ int agent_generate(agent_config_t *cfg, const char *agent_name, const char *syst
     * drafter's max_parallel + records its health, like every other turn.) */
    int rc = agent_dispatch_one(&local, &cfg->network, NULL /* role */, system_prompt, user_prompt,
                                max_tokens, temperature, 0 /* use_tools: plain completion */, out);
+   /* Stamp the drafter name for the caller even on the early-guard paths that
+    * return before the executor sets it (idempotent when it was already set). */
    snprintf(out->agent_name, MAX_AGENT_NAME, "%s", local.name);
    return rc;
 }
@@ -436,10 +447,10 @@ static int agent_run_with_tools_internal(agent_config_t *cfg, const char *role,
                                0.3, 1 /* use_tools */, out);
    free(enhanced);
 
-   if (rc != 0 && agent_error_is_retryable(out->error) && cfg->fallback_count > 0)
+   if (agent_rc_should_try_another(rc, out->error) && cfg->fallback_count > 0)
    {
       aimee_log(LOG_INFO, "agent",
-                "delegate agent '%s' returned retryable error, trying fallback chain (%d entries)",
+                "delegate agent '%s' retryable/at-limit, trying fallback chain (%d entries)",
                 ag->name, cfg->fallback_count);
 
       for (int fi = 0; fi < cfg->fallback_count && rc != 0; fi++)

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -131,23 +131,37 @@ static void record_outcome(const char *agent_name, const char *role, const agent
 }
 
 /* THE single per-agent turn executor — see agent_exec.h. Every model turn (panel
- * lens, ensemble reference, delegate, fallback peer, chat passthrough, ping)
- * routes through here so the per-agent max_parallel cap and provider-health
+ * lens, ensemble reference, delegate, fallback peer, chat/responses passthrough,
+ * aux) routes through here so the per-agent max_parallel cap and provider-health
  * recording are enforced in ONE place instead of being re-implemented (and
- * forgotten) per dispatch path. */
+ * forgotten) per dispatch path.
+ *
+ * Health-domain note: this deliberately WIDENS provider-health accounting to the
+ * OpenAI-compatible ingress and the aux router, which previously bypassed it — a
+ * failing model on those paths now degrades its catalog health like any other
+ * turn (intended: one health signal per provider, whatever drove the call).
+ *
+ * Slot safety: there is no non-local exit between acquire and release — the
+ * executors (agent_execute / agent_execute_with_tools_for_role) return normally
+ * (C has no exceptions), so the release always runs and a slot is never leaked. */
 int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char *role,
                        const char *system_prompt, const char *user_prompt, int max_tokens,
                        double temperature, int use_tools, agent_result_t *out)
 {
    if (!ag || !out)
       return -1;
+   /* Own `out` from the first instruction, exactly like the executors: memset it so
+    * EVERY early-return path (at-limit, bad-precondition) leaves a clean result —
+    * out->response == NULL — and a caller that frees out->response after a non-zero
+    * return can never hit stale/garbage. (No caller passes a live out->response
+    * here; the executors also memset, so this is the established contract.) */
+   memset(out, 0, sizeof(*out));
    /* The tools executor dereferences `net`; a plain completion ignores it. Enforce
     * the precondition (net != NULL when use_tools) so a future caller that flips
     * use_tools without supplying a network fails cleanly instead of crashing. */
    if (use_tools && !net)
    {
-      if (out)
-         snprintf(out->error, sizeof(out->error), "agent_dispatch_one: use_tools requires network");
+      snprintf(out->error, sizeof(out->error), "agent_dispatch_one: use_tools requires network");
       return -1;
    }
    /* Concurrency choke point: acquire the agent's max_parallel slot. At the limit,

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -129,6 +129,44 @@ static void record_outcome(const char *agent_name, const char *role, const agent
                                         outcome->reason, outcome->turns_used, outcome->tools_called,
                                         outcome->tokens_used, outcome->tool_error_pattern);
 }
+
+/* THE single per-agent turn executor — see agent_exec.h. Every model turn (panel
+ * lens, ensemble reference, delegate, fallback peer, chat passthrough, ping)
+ * routes through here so the per-agent max_parallel cap and provider-health
+ * recording are enforced in ONE place instead of being re-implemented (and
+ * forgotten) per dispatch path. */
+int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char *role,
+                       const char *system_prompt, const char *user_prompt, int max_tokens,
+                       double temperature, int use_tools, agent_result_t *out)
+{
+   if (!ag || !out)
+      return -1;
+   /* Concurrency choke point: acquire the agent's max_parallel slot. At the limit,
+    * report a DISTINCT at-limit signal (so a fan-out/retry caller picks a different
+    * agent) and return BEFORE any health recording — saturation is a load signal,
+    * not a provider fault. acquire() returns "unlimited" for max_parallel<=0 /
+    * unknown agents, so single-dispatch callers are unaffected. */
+   if (!provider_catalog_concurrent_acquire(ag->name, ag->max_parallel))
+   {
+      snprintf(out->agent_name, MAX_AGENT_NAME, "%s", ag->name);
+      snprintf(out->error, sizeof(out->error), "agent '%s' at concurrency limit (max_parallel=%d)",
+               ag->name, ag->max_parallel);
+      return AGENT_RC_AT_LIMIT;
+   }
+   int rc = use_tools ? agent_execute_with_tools_for_role(ag, net, role, system_prompt, user_prompt,
+                                                          max_tokens, temperature, out)
+                      : agent_execute(ag, system_prompt, user_prompt, max_tokens, temperature, out);
+   provider_catalog_concurrent_release(ag->name);
+   if (rc == 0)
+      provider_catalog_record_success(ag->name);
+   else
+   {
+      const char *ec = agent_error_is_retryable(out->error) ? "retryable" : "error";
+      provider_catalog_record_failure(ag->name, ec);
+   }
+   return rc;
+}
+
 int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
                  const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
 {
@@ -193,17 +231,15 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
       }
       free(hint);
 
-      int rc;
-      if (use_tools)
-         rc = agent_execute_with_tools_for_role(ag, &cfg->network, role, system_prompt,
-                                                effective_prompt, max_tokens, temperature, out);
-      else
-         rc = agent_execute(ag, system_prompt, effective_prompt, max_tokens, temperature, out);
+      /* The turn goes through the single guarded executor: it enforces max_parallel
+       * and records provider health. Returns 0 (ok), AGENT_RC_AT_LIMIT (agent
+       * saturated — no health recorded), or -1 (run failure — health recorded). */
+      int rc = agent_dispatch_one(ag, &cfg->network, role, system_prompt, effective_prompt,
+                                  max_tokens, temperature, use_tools, out);
       free(enhanced);
 
       if (rc == 0)
       {
-         provider_catalog_record_success(ag->name);
          agent_log_call(out, role);
          agent_store_feedback(out, role, user_prompt);
 
@@ -215,10 +251,8 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
             db1_agent_cache_put(role, user_prompt, out->response);
          return 0;
       }
-      {
-         const char *err_class = agent_error_is_retryable(out->error) ? "retryable" : "error";
-         provider_catalog_record_failure(ag->name, err_class);
-      }
+      /* At-limit or a real failure: either way skip this agent and try the next
+       * (health already recorded by agent_dispatch_one for a real failure). */
       if (ntried < MAX_AGENTS)
          tried[ntried++] = ag->name;
       free(out->response);
@@ -292,17 +326,16 @@ int agent_generate(agent_config_t *cfg, const char *agent_name, const char *syst
                            * owns no shared pointers. */
    agent_apply_runtime_config(&local);
    local.write_capable = 0; /* belt-and-suspenders; not the primary safeguard */
-   /* THE tool-safety guarantee: this calls agent_execute() directly — the plain
-    * single request->response completion path that has NO tool loop at all. Tool
-    * execution lives only in the separate agent_execute_with_tools_for_role(),
-    * which we never call. So regardless of the agent's tools_enabled flag, a draft
-    * can only return text: it cannot run a tool, read/write files, or touch a repo.
-    * The non-CLI filter above is secondary (provider-CLI agents are agentic and
-    * don't serve plain HTTP completions anyway). */
-   int rc = agent_execute(&local, system_prompt, user_prompt, max_tokens, temperature, out);
+   /* THE tool-safety guarantee: dispatch with use_tools=0, so the single executor
+    * runs the plain agent_execute() completion path — NO tool loop at all (tool
+    * execution lives only in agent_execute_with_tools_for_role, reached ONLY when
+    * use_tools=1). So regardless of the agent's tools_enabled flag, a draft can
+    * only return text: it cannot run a tool, read/write files, or touch a repo.
+    * The non-CLI filter above is secondary. (agent_dispatch_one also enforces the
+    * drafter's max_parallel + records its health, like every other turn.) */
+   int rc = agent_dispatch_one(&local, &cfg->network, NULL /* role */, system_prompt, user_prompt,
+                               max_tokens, temperature, 0 /* use_tools: plain completion */, out);
    snprintf(out->agent_name, MAX_AGENT_NAME, "%s", local.name);
-   if (rc == 0)
-      provider_catalog_record_success(local.name);
    return rc;
 }
 
@@ -338,14 +371,13 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    local.ablation = cfg->ablation;
    local.write_capable = 0; /* ensemble references answer a prompt; no write tools */
 
-   int rc = agent_execute(&local, system_prompt, user_prompt, max_tokens, temperature, out);
-   if (rc == 0)
-      provider_catalog_record_success(local.name);
-   else
-   {
-      const char *err_class = agent_error_is_retryable(out->error) ? "retryable" : "error";
-      provider_catalog_record_failure(local.name, err_class);
-   }
+   /* Plain completion (no tools) through the single guarded executor: it enforces
+    * local.max_parallel and records provider health. An AGENT_RC_AT_LIMIT return
+    * (agent saturated) propagates as a non-zero rc; the parallel panel/ensemble
+    * caller treats a non-response as "this lens unfilled" and retries a different
+    * agent, so a saturated model is spread rather than piled on. */
+   int rc = agent_dispatch_one(&local, &cfg->network, role, system_prompt, user_prompt, max_tokens,
+                               temperature, 0 /* use_tools */, out);
    {
       agent_outcome_t oc;
       classify_outcome(out, local.max_turns, &oc);
@@ -398,15 +430,11 @@ static int agent_run_with_tools_internal(agent_config_t *cfg, const char *role,
    }
    free(hint);
 
-   int rc = agent_execute_guarded(ag, &cfg->network, role, system_prompt, effective_prompt,
-                                  max_tokens, out);
+   /* The delegate turn through the single guarded executor (tools enabled): it
+    * enforces ag->max_parallel and records provider health. */
+   int rc = agent_dispatch_one(ag, &cfg->network, role, system_prompt, effective_prompt, max_tokens,
+                               0.3, 1 /* use_tools */, out);
    free(enhanced);
-
-   if (rc != 0)
-   {
-      const char *err_class = agent_error_is_retryable(out->error) ? "retryable" : "error";
-      provider_catalog_record_failure(ag->name, err_class);
-   }
 
    if (rc != 0 && agent_error_is_retryable(out->error) && cfg->fallback_count > 0)
    {
@@ -433,23 +461,18 @@ static int agent_run_with_tools_internal(agent_config_t *cfg, const char *role,
          out->error[0] = '\0';
 
          aimee_log(LOG_INFO, "agent", "fallback: trying agent '%s'", fb->name);
-         rc = agent_execute_with_tools_for_role(fb, &cfg->network, role, system_prompt, user_prompt,
-                                                max_tokens, 0.3, out);
+         rc = agent_dispatch_one(fb, &cfg->network, role, system_prompt, user_prompt, max_tokens,
+                                 0.3, 1 /* use_tools */, out);
          if (rc == 0)
-            ag = fb; /* update ag for post-run logging */
-         else
-         {
-            const char *fec = agent_error_is_retryable(out->error) ? "retryable" : "error";
-            provider_catalog_record_failure(fb->name, fec);
-         }
+            ag = fb; /* update ag for post-run logging (health recorded by dispatch_one) */
       }
    }
 
    rc = agent_try_same_tier_fallback(cfg, &ag, role, system_prompt, user_prompt, max_tokens,
                                      enforce_writes, out, rc);
 
-   if (rc == 0)
-      provider_catalog_record_success(ag->name);
+   /* health is recorded per-turn inside agent_dispatch_one (main + fallbacks +
+    * same-tier), so no final record_success here. */
    agent_log_call(out, role);
    agent_store_feedback(out, role, user_prompt);
 

--- a/src/server/agent_tasks.c
+++ b/src/server/agent_tasks.c
@@ -17,7 +17,7 @@ static int agent_run_tool_command(const agent_t *agent, const char *type, const 
    (void)timeout_ms; /* passed through agent config */
    char sys[128];
    snprintf(sys, sizeof(sys), "Execute the %s command and report the result.", type);
-   return agent_execute(agent, sys, cmd, 2048, 0.2, out);
+   return agent_dispatch_one(agent, NULL, NULL, sys, cmd, 2048, 0.2, 0 /* use_tools */, out);
 }
 
 static void plan_record_evidence(int plan_id, int step_id, const char *kind, const char *content,
@@ -301,7 +301,8 @@ int agent_execute_with_plan(const agent_t *agent, const agent_network_t *network
 
    agent_result_t plan_res;
    memset(&plan_res, 0, sizeof(plan_res));
-   int rc = agent_execute(agent, system_prompt, plan_prompt, max_tokens, temperature, &plan_res);
+   int rc = agent_dispatch_one(agent, network, NULL, system_prompt, plan_prompt, max_tokens,
+                               temperature, 0 /* use_tools */, &plan_res);
    if (rc != 0 || !plan_res.response)
    {
       snprintf(out->error, sizeof(out->error), "plan generation failed: %s", plan_res.error);
@@ -316,7 +317,8 @@ int agent_execute_with_plan(const agent_t *agent, const agent_network_t *network
       cJSON_Delete(json);
       /* Fallback to direct execution */
       free(plan_res.response);
-      return agent_execute(agent, system_prompt, user_prompt, max_tokens, temperature, out);
+      return agent_dispatch_one(agent, NULL, NULL, system_prompt, user_prompt, max_tokens,
+                                temperature, 0 /* use_tools */, out);
    }
 
    int plan_id = db1_execution_plan_create(agent->name, user_prompt, json);
@@ -324,7 +326,8 @@ int agent_execute_with_plan(const agent_t *agent, const agent_network_t *network
    free(plan_res.response);
    if (plan_id < 0)
    {
-      return agent_execute(agent, system_prompt, user_prompt, max_tokens, temperature, out);
+      return agent_dispatch_one(agent, NULL, NULL, system_prompt, user_prompt, max_tokens,
+                                temperature, 0 /* use_tools */, out);
    }
 
    plan_t plan;

--- a/src/server/agent_tasks.c
+++ b/src/server/agent_tasks.c
@@ -17,7 +17,10 @@ static int agent_run_tool_command(const agent_t *agent, const char *type, const 
    (void)timeout_ms; /* passed through agent config */
    char sys[128];
    snprintf(sys, sizeof(sys), "Execute the %s command and report the result.", type);
-   return agent_dispatch_one(agent, NULL, NULL, sys, cmd, 2048, 0.2, 0 /* use_tools */, out);
+   /* Composite plan/step helper: a sub-turn of an outer plan execution, so it uses
+    * the PRIMITIVE agent_execute (not agent_dispatch_one) — re-acquiring the same
+    * agent's max_parallel slot here would self-throttle the plan. */
+   return agent_execute(agent, sys, cmd, 2048, 0.2, out);
 }
 
 static void plan_record_evidence(int plan_id, int step_id, const char *kind, const char *content,
@@ -301,8 +304,10 @@ int agent_execute_with_plan(const agent_t *agent, const agent_network_t *network
 
    agent_result_t plan_res;
    memset(&plan_res, 0, sizeof(plan_res));
-   int rc = agent_dispatch_one(agent, network, NULL, system_prompt, plan_prompt, max_tokens,
-                               temperature, 0 /* use_tools */, &plan_res);
+   /* Composite (plan generation + step execution): sub-turns use the PRIMITIVE
+    * agent_execute, not the slot-acquiring agent_dispatch_one (nested acquisition
+    * of the same agent's slot would self-throttle the plan). */
+   int rc = agent_execute(agent, system_prompt, plan_prompt, max_tokens, temperature, &plan_res);
    if (rc != 0 || !plan_res.response)
    {
       snprintf(out->error, sizeof(out->error), "plan generation failed: %s", plan_res.error);
@@ -317,8 +322,7 @@ int agent_execute_with_plan(const agent_t *agent, const agent_network_t *network
       cJSON_Delete(json);
       /* Fallback to direct execution */
       free(plan_res.response);
-      return agent_dispatch_one(agent, NULL, NULL, system_prompt, user_prompt, max_tokens,
-                                temperature, 0 /* use_tools */, out);
+      return agent_execute(agent, system_prompt, user_prompt, max_tokens, temperature, out);
    }
 
    int plan_id = db1_execution_plan_create(agent->name, user_prompt, json);
@@ -326,8 +330,7 @@ int agent_execute_with_plan(const agent_t *agent, const agent_network_t *network
    free(plan_res.response);
    if (plan_id < 0)
    {
-      return agent_dispatch_one(agent, NULL, NULL, system_prompt, user_prompt, max_tokens,
-                                temperature, 0 /* use_tools */, out);
+      return agent_execute(agent, system_prompt, user_prompt, max_tokens, temperature, out);
    }
 
    plan_t plan;

--- a/src/server/aux_router.c
+++ b/src/server/aux_router.c
@@ -92,7 +92,7 @@ char *aux_call(const config_t *cfg, const char *task_name, const char *prompt, i
 
    agent_result_t res;
    memset(&res, 0, sizeof(res));
-   int rc = agent_execute(&local, NULL, prompt, tok, 0.0, &res);
+   int rc = agent_dispatch_one(&local, NULL, NULL, NULL, prompt, tok, 0.0, 0 /* use_tools */, &res);
    if (rc != 0 || !res.response || !res.response[0])
    {
       LOG_WARN("aux", "aux_call task '%s': %s", task_name,

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -242,7 +242,8 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
    memset(&result, 0, sizeof(result));
    /* pi_env (the <aimee-context> envelope) was built up front for the dedup key;
     * reuse it as the system prompt here. */
-   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   int erc = agent_dispatch_one(ag, NULL, NULL, pi_env, prompt, max_tokens, temperature,
+                                0 /* use_tools: plain chat completion */, &result);
    free(pi_env);
    free(prompt);
 
@@ -637,7 +638,8 @@ static int responses_handler(const char *body, char *resp, int cap)
    /* P1 pre-injection: prepend the <aimee-context> envelope as the system
     * prompt (config ingress_preinject_enabled; no-op when off/empty). */
    char *pi_env = gw_memory_system_prompt(full);
-   int erc = agent_execute(ag, pi_env, full, max_tokens, temperature, &result);
+   int erc = agent_dispatch_one(ag, NULL, NULL, pi_env, full, max_tokens, temperature,
+                                0 /* use_tools: plain chat completion */, &result);
    free(pi_env);
 
    if (erc != 0 || !result.response)
@@ -750,7 +752,8 @@ static int chat_stream_handler(const char *body, server_http_sse_emit emit, void
    /* P1 pre-injection: prepend the <aimee-context> envelope as the system
     * prompt (config ingress_preinject_enabled; no-op when off/empty). */
    char *pi_env = gw_memory_system_prompt(prompt);
-   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   int erc = agent_dispatch_one(ag, NULL, NULL, pi_env, prompt, max_tokens, temperature,
+                                0 /* use_tools: plain chat completion */, &result);
    free(pi_env);
    free(prompt);
 
@@ -820,7 +823,8 @@ static int completion_stream_handler(const char *body, server_http_sse_emit emit
    /* P1 pre-injection: prepend the <aimee-context> envelope as the system
     * prompt (config ingress_preinject_enabled; no-op when off/empty). */
    char *pi_env = gw_memory_system_prompt(prompt);
-   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   int erc = agent_dispatch_one(ag, NULL, NULL, pi_env, prompt, max_tokens, temperature,
+                                0 /* use_tools: plain chat completion */, &result);
    free(pi_env);
    free(prompt);
 

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -1165,6 +1165,10 @@ int handle_agent_probe(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (!opt_has(&opts, "no-run"))
    {
       agent_result_t result;
+      /* Deliberate low-level exemption: this is a diagnostic PROBE ("agent test").
+       * It must NOT go through agent_dispatch_one — the concurrency cap would make
+       * a merely-busy agent report as failing, and a manual test should not feed the
+       * production health catalog. So it calls the plain agent_execute primitive. */
       int rc = agent_execute(ag, NULL, "Respond with ok.", 16, 0.0, &result);
       run_ok = (rc == 0);
       latency_ms = result.latency_ms;

--- a/src/tests/test_agent_error_retryable.c
+++ b/src/tests/test_agent_error_retryable.c
@@ -31,6 +31,12 @@ int main(void)
    assert(agent_error_is_retryable("HTTP 401 unauthorized") == 0);
    assert(agent_error_is_retryable("model refused the request") == 0);
 
+   /* Saturation is NOT a retryable provider error. agent_dispatch_one signals it
+    * out-of-band via AGENT_RC_AT_LIMIT and callers key off that rc (never this
+    * string), so the "at concurrency limit" message must stay non-retryable — else
+    * it would wrongly record provider health and be misclassified as a fault. */
+   assert(agent_error_is_retryable("agent 'codex' at concurrency limit (max_parallel=2)") == 0);
+
    printf("  classify: ok\n");
    printf("All agent_error_retryable tests passed.\n");
    return 0;

--- a/src/tests/test_provider_catalog.c
+++ b/src/tests/test_provider_catalog.c
@@ -6,6 +6,33 @@
 
 #include "../server/provider_catalog.c"
 
+/* Stub the co-located /v1 dispatch with a minimal single-agent slot counter, so
+ * provider_catalog_concurrent_{acquire,release} exercise their real
+ * server-authoritative path (the production path on the server) end-to-end. */
+static int g_stub_slots = 0;
+cJSON *cli_v1_dispatch_local(cJSON *req, int timeout_ms)
+{
+   (void)timeout_ms;
+   cJSON *mj = cJSON_GetObjectItemCaseSensitive(req, "method");
+   const char *method = (mj && cJSON_IsString(mj)) ? mj->valuestring : "";
+   cJSON *resp = cJSON_CreateObject();
+   if (strcmp(method, "provider.slot_acquire") == 0)
+   {
+      cJSON *mp = cJSON_GetObjectItemCaseSensitive(req, "max_parallel");
+      int max = (mp && cJSON_IsNumber(mp)) ? (int)mp->valuedouble : 0;
+      int ok = (max <= 0) || (g_stub_slots < max);
+      if (ok)
+         g_stub_slots++;
+      cJSON_AddBoolToObject(resp, "acquired", ok ? 1 : 0);
+   }
+   else if (strcmp(method, "provider.slot_release") == 0)
+   {
+      if (g_stub_slots > 0)
+         g_stub_slots--;
+   }
+   return resp;
+}
+
 /* Reset module state between tests */
 static void reset_catalog(void)
 {
@@ -262,6 +289,47 @@ static void test_labels(void)
    printf("  labels: OK\n");
 }
 
+/* ---- concurrency cap (the invariant agent_dispatch_one enforces) ---- */
+
+/* acquire()/release() must be an exact pair: up to max_parallel acquisitions
+ * succeed, the next is refused (0), and every release restores exactly one slot
+ * so the cap returns to its prior value. This is the guard agent_dispatch_one
+ * relies on to stop the parallel panel/ensemble fan-out from hammering one model
+ * past max_parallel. Exercises the real server-authoritative path against the
+ * slot-counter stub above. */
+static void test_concurrent_acquire_release_cap(void)
+{
+   const char *ag = "concur-cap-test";
+   g_stub_slots = 0;
+
+   /* max_parallel = 2: two acquire, third refused. */
+   assert(provider_catalog_concurrent_acquire(ag, 2) == 1);
+   assert(provider_catalog_concurrent_acquire(ag, 2) == 1);
+   assert(provider_catalog_concurrent_acquire(ag, 2) == 0); /* at the cap */
+
+   /* one release frees exactly one slot — the cap returns to its prior value. */
+   provider_catalog_concurrent_release(ag);
+   assert(provider_catalog_concurrent_acquire(ag, 2) == 1);
+   assert(provider_catalog_concurrent_acquire(ag, 2) == 0); /* full again */
+
+   /* drain both in-flight slots -> cap fully restored. */
+   provider_catalog_concurrent_release(ag);
+   provider_catalog_concurrent_release(ag);
+   assert(g_stub_slots == 0);
+   assert(provider_catalog_concurrent_acquire(ag, 2) == 1);
+   assert(provider_catalog_concurrent_acquire(ag, 2) == 1);
+   assert(provider_catalog_concurrent_acquire(ag, 2) == 0);
+   provider_catalog_concurrent_release(ag);
+   provider_catalog_concurrent_release(ag);
+   assert(g_stub_slots == 0);
+
+   /* max_parallel <= 0 is UNLIMITED (returns before any slot call) -> a
+    * single-dispatch caller is never blocked. */
+   assert(provider_catalog_concurrent_acquire(ag, 0) == 1);
+   assert(g_stub_slots == 0); /* no slot consumed for the unlimited case */
+   printf("  concurrent_acquire_release_cap: OK\n");
+}
+
 int main(void)
 {
    printf("test_provider_catalog:\n");
@@ -290,6 +358,8 @@ int main(void)
    test_dump_json_overflow();
 
    test_labels();
+
+   test_concurrent_acquire_release_cap();
 
    printf("All provider_catalog tests passed.\n");
    return 0;


### PR DESCRIPTION
## Context

Fixing the roundtable panel degrading in prod traced to an architectural root cause: **no single path for running a model turn.** The per-agent `max_parallel` cap and provider-health recording were enforced inconsistently across many divergent functions — `agent_execute_guarded` (the only path that acquired the concurrency slot) had **one** caller, while `agent_run_named`/`agent_run_ex` (the panel + parallel fan-out) called `agent_execute` directly and never enforced the cap. That let the panel hammer one model (~15 simultaneous codex calls → HTTP 400s → gate degraded). Health-recording was copy-pasted across paths, and each new dispatch path re-introduced the bug.

## Change

Introduce **`agent_dispatch_one`** — the single per-agent turn executor: acquire `max_parallel` slot → run turn (tools or plain) → release → record health, in **one place**. At the ceiling it returns a distinct **`AGENT_RC_AT_LIMIT` before any health recording** (saturation ≠ fault), so a fan-out/retry caller picks a different agent and a busy model is never marked unhealthy.

Every model-turn caller now routes through it: `agent_run_named`, `agent_run_ex`, `agent_run_with_tools_internal` (+ fallback chain), `agent_generate`, `agent_try_same_tier_fallback`, the OpenAI-compat chat passthrough, the aux router, and the task executors. `agent_execute_guarded` is **deleted** (subsumed); duplicated health/record blocks removed. Resolution, retry loops, `write_capable`, and outcome/feedback/cache logging stay in the callers.

**Deliberate exemption:** the `agent test` diagnostic probe (`server_agent.c`) still calls `agent_execute` directly — gating a probe by the cap it tests would make a busy agent report as failing.

## Verification
- Full build under `-Werror`; **all `test_agent_*` / `test_delegate_*` suites pass**.
- `test_provider_catalog` gains a concurrency-cap test (acquire/release pairing returns the cap to its prior value).
- Supersedes the closed #1272 (per-path patch).

Completes the roundtable-resilience series (#1268 autonomy retry, #1270 agent reuse) with the structural fix so the cap can't be forgotten by a future path.
