### PR TITLE
ci(release): fix Auto release startup_failure (nested rerank-artifacts permissions)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -79,8 +79,14 @@ jobs:
   images:
     needs: version
     uses: ./.github/workflows/publish-images.yml
+    # contents: write (not read) because publish-images.yml nests the
+    # publish-rerank-artifacts.yml job, which creates/uploads the
+    # rerank-artifacts release. A nested reusable workflow can't request more
+    # than the caller grants, so a read-only ceiling here fails the whole run
+    # at startup ("nested job 'rerank-artifacts' is requesting 'contents:
+    # write', but is only allowed 'contents: read'").
     permissions:
-      contents: read
+      contents: write
       packages: write
     with:
       version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
## Problem

After #1274 merged to `main`, the **Auto release** workflow failed with `startup_failure` before any job scheduled ([run 29200516606](https://github.com/RakuenSoftware/aimee/actions/runs/29200516606)):

> The nested job 'rerank-artifacts' is requesting 'contents: write', but is only allowed 'contents: read'.

## Cause

`auto-release.yml`'s `images` job calls `publish-images.yml` with a permission ceiling of `contents: read`. But `publish-images.yml` nests `publish-rerank-artifacts.yml` (the `rerank-artifacts` job), which needs `contents: write` to create/upload the `rerank-artifacts-v1` release. A nested reusable workflow cannot exceed the caller's grant, so the read-only ceiling failed the entire release run at startup.

This only surfaced via `auto-release` (workflow_call): on a standalone `v*` tag push, `publish-images.yml` runs at top level with the repo's default token permissions, so the nested `contents: write` was within bounds.

## Fix

Raise the `images` job's ceiling in `auto-release.yml` from `contents: read` to `contents: write` (one line + explanatory comment). `packages: write` is unchanged; the nested job's write request is now within the caller's grant.

Routing through `testing` per the repo's promotion flow; promote `testing`→`main` to land it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzwU1Nkkm8M8D2vo54gWq1)_