### PR TITLE
Merge testing to main

### DIFF
--- a/deploy/container/webchat-lib.sh
+++ b/deploy/container/webchat-lib.sh
@@ -38,16 +38,37 @@ webchat_provision_user() {
     _pu_user="$1"
     _pu_pass="$2"
     [ -n "$_pu_user" ] && [ -n "$_pu_pass" ] || return 0
-    getent group "$WEBCHAT_GROUP" >/dev/null 2>&1 || groupadd --system "$WEBCHAT_GROUP"
+    # PAM authenticates against a real OS user, and useradd's default NAME_REGEX
+    # (and the webchat user manager) only accept lowercase letters, digits, '-'
+    # and '_'. Reject anything else LOUDLY here rather than let useradd fail
+    # silently and leave login broken with a confusing "invalid credentials".
+    case "$_pu_user" in
+        *[!a-z0-9_-]* | [!a-z_]*)
+            webchat_log "ERROR: login user '$_pu_user' is not a valid username (use lowercase letters, digits, '-', '_'; must not start with a digit/hyphen). Skipping — browser login for it will fail."
+            return 0
+            ;;
+    esac
+    getent group "$WEBCHAT_GROUP" >/dev/null 2>&1 || groupadd --system "$WEBCHAT_GROUP" || true
     if id "$_pu_user" >/dev/null 2>&1; then
-        # Existing user (e.g. the service account): just ensure group membership.
+        # Existing user (e.g. the aimee service account): just ensure group membership.
         usermod --append --groups "$WEBCHAT_GROUP" "$_pu_user" 2>/dev/null || true
     else
         webchat_log "creating login user '$_pu_user'"
-        useradd --create-home --shell /usr/sbin/nologin --groups "$WEBCHAT_GROUP" "$_pu_user"
+        # Guard useradd so a failure is reported, not swallowed by the entrypoint's
+        # `set -e` (which would crash the container before webchat even starts).
+        if ! useradd --create-home --shell /usr/sbin/nologin --groups "$WEBCHAT_GROUP" "$_pu_user"; then
+            webchat_log "ERROR: useradd failed for '$_pu_user' — browser login for it will fail"
+            return 0
+        fi
     fi
-    printf '%s:%s\n' "$_pu_user" "$_pu_pass" | chpasswd
-    webchat_log "login user '$_pu_user' ready (group $WEBCHAT_GROUP)"
+    # Set the password from AIMEE_WEBCHAT_PASSWORD. chpasswd splits on the FIRST
+    # ':', so a password may contain ':'. Report a failure instead of leaving the
+    # account with no usable password.
+    if printf '%s:%s\n' "$_pu_user" "$_pu_pass" | chpasswd; then
+        webchat_log "login user '$_pu_user' ready (group $WEBCHAT_GROUP)"
+    else
+        webchat_log "ERROR: could not set password for '$_pu_user' (chpasswd failed) — browser login for it will fail"
+    fi
 }
 
 # Additional persistent logins from AIMEE_WEBCHAT_USERS: a list of "user:password"

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,7 +39,11 @@ Starts `aimee-server` only (webchat built in). `/v1` is on `:8743` (native TLS, 
 
 ### 1.2 Run the setup wizard
 
-Open **https://localhost:8443** (accept the self-signed cert) and log in as `aimee` / `aimee-local-dev`. The wizard covers:
+Open **https://localhost:8443** (accept the self-signed cert) and log in as `aimee` / `aimee-local-dev`.
+
+The browser login is a real PAM account the container creates on startup from **`AIMEE_WEBCHAT_USER`** / **`AIMEE_WEBCHAT_PASSWORD`** (defaults `aimee` / `aimee-local-dev`) — set them in the compose file for anything past local dev. The username must be a valid Linux name: **lowercase letters, digits, `-`, `_`, and not starting with a digit** (so `admin` or `web-user`, not `Admin` or `bob.smith`). For more than one login, set `AIMEE_WEBCHAT_USERS` to a comma-separated `user:password` list. If a login is rejected, check the container logs for `[webchat]` lines — they report exactly which account was created or why it couldn't be.
+
+The wizard covers:
 
 - **Primary provider** — which agent aimee drives.
 - **Knowledge base** — a local one (default), or an existing remote `aimee-kb`.
@@ -48,8 +52,6 @@ Open **https://localhost:8443** (accept the self-signed cert) and log in as `aim
 - **Connection & workspaces** — sign in to your git hosts and clone repos.
 
 The final **Deploy** launches `aimee-kb` + `aimee-llm` + Postgres and shows their status. The first run pulls images and the CPU model weights (a few minutes); later boots are fast — state lives in named volumes.
-
-> Change `AIMEE_WEBCHAT_USER` / `AIMEE_WEBCHAT_PASSWORD` for anything past local dev.
 
 ### 1.3 Verify it's healthy
 


### PR DESCRIPTION
Promote `testing` to `main`.

Contains the webchat login fix (#1279): the browser login is a PAM account the container creates on startup from `AIMEE_WEBCHAT_USER` / `AIMEE_WEBCHAT_PASSWORD`. `webchat_provision_user` now validates the username (lowercase letters/digits/`-`/`_`, no leading digit), and guards `useradd` + `chpasswd` so a failure is logged (`[webchat] ERROR …`) instead of silently leaving login broken or crash-looping the container under `set -e`. QUICKSTART documents the login env vars + username constraint.