### PR TITLE
promote testing → main: org bulk-clone on Projects page; wizard skips completed steps

### DIFF
--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -3,7 +3,7 @@ import { useToast } from '@rakuensoftware/smoothgui';
 import { useSessions } from '../SessionContext';
 import { loadConfig, saveConfigValue, type ConfigMap } from '../setup/configApi';
 import { visibleSteps, isRestartKey, helpFor, APPLIANCE_HIDDEN_STEPS, type WizardKbMode } from '../setup/wizardSteps';
-import { computeReadiness, type StepId } from '../setup/readiness';
+import { completedSteps, computeReadiness, type StepId } from '../setup/readiness';
 import { setDismissed, notifySetupUpdated } from '../setup/setupState';
 import PrimaryChooser from '../setup/PrimaryChooser';
 import KnowledgeBase from '../setup/KnowledgeBase';
@@ -94,22 +94,37 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
   // The all-in-one appliance bakes the KB + LLM + store, so its wizard drops the
   // infra steps. Detected from a webchat signal (AIMEE_WIZARD_APPLIANCE).
   const [appliance, setAppliance] = useState(false);
+  // Steps already completed when the wizard opened — hidden this run. Frozen at
+  // open so finishing a step mid-run doesn't reshuffle the remaining ones.
+  const [doneAtOpen, setDoneAtOpen] = useState<ReadonlySet<StepId>>(new Set());
+  // Until the open-time loads resolve we don't know which steps to hide; gate
+  // the body so the list doesn't flash-then-shrink.
+  const [booted, setBooted] = useState(false);
 
   const kbMode: WizardKbMode = String(cfg.kb_mode) === 'remote' ? 'remote' : 'local';
-  const steps = useMemo(() => visibleSteps(kbMode, appliance), [kbMode, appliance]);
+  const steps = useMemo(
+    () => visibleSteps(kbMode, appliance).filter((s) => !doneAtOpen.has(s.id)),
+    [kbMode, appliance, doneAtOpen],
+  );
   const total = steps.length;
   // Clamp the cursor: switching to a remote KB shrinks the visible list.
   const safeIdx = Math.min(idx, total - 1);
-  const step = steps[safeIdx];
+  // Undefined when every step was already complete at open — the summary shows.
+  const step = steps[safeIdx] as (typeof steps)[number] | undefined;
 
-  // (Re)load config each time the wizard opens; reset step + transient state.
+  // (Re)load config each time the wizard opens; reset step + transient state,
+  // then hide the sections that are already set up.
   useEffect(() => {
     if (!open) return;
     setIdx(0);
     setShowSummary(false);
     setPendingRestart([]);
-    loadConfig().then((c) => {
+    setBooted(false);
+    setDoneAtOpen(new Set());
+    Promise.all([loadConfig(), fetchHostCount(), fetchAppliance()]).then(([c, hosts, appl]) => {
       setCfg(c);
+      setHostsConnected(hosts);
+      setAppliance(appl);
       const d: Record<string, string> = {};
       for (const s of visibleSteps(String(c.kb_mode) === 'remote' ? 'remote' : 'local')) {
         for (const k of s.keys) {
@@ -118,9 +133,12 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
         }
       }
       setDraft(d);
+      const done = completedSteps(c, hasProject, hosts);
+      setDoneAtOpen(done);
+      setBooted(true);
     });
-    fetchHostCount().then(setHostsConnected);
-    fetchAppliance().then(setAppliance);
+    // hasProject is read once at open: the done-set is a deliberate snapshot.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const close = useCallback(() => { onClose(); }, [onClose]);
@@ -189,6 +207,7 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
   // Save every edited key in the current (generic keyed) step. Any failure aborts
   // advance and Toasts; successes update the live cfg + restart tracking.
   async function saveStep() {
+    if (!step) return; // unreachable: the save button only renders with a step
     setSaving(true);
     const savedCfg: ConfigMap = { ...cfg };
     const restart = new Set(pendingRestart);
@@ -255,7 +274,9 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
             style={{ background: 'none', border: 'none', color: '#9aa', cursor: 'pointer', fontSize: 20, lineHeight: 1 }}>×</button>
         </div>
 
-        {showSummary ? (
+        {!booted ? (
+          <div style={{ fontSize: 13, color: '#667', padding: '10px 0' }}>Loading…</div>
+        ) : showSummary || !step ? (
           <div>
             <p style={{ fontSize: 13, color: '#556', margin: '4px 0 12px' }}>
               {readiness.ready ? 'Everything required is configured. 🎉' : 'Here’s what’s left:'}
@@ -280,8 +301,10 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
                 straight from here when the server can orchestrate Docker. The
                 appliance already runs everything in-container, so skip it there. */}
             {!appliance && <DeployPanel kbMode={kbMode} />}
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <button style={ghostBtn} onClick={() => { setShowSummary(false); setIdx(0); }}>Back</button>
+            <div style={{ display: 'flex', justifyContent: total > 0 ? 'space-between' : 'flex-end' }}>
+              {total > 0 && (
+                <button style={ghostBtn} onClick={() => { setShowSummary(false); setIdx(0); }}>Back</button>
+              )}
               <button style={primaryBtn} onClick={() => { setDismissed(true); notifySetupUpdated(); close(); }}>Finish</button>
             </div>
           </div>

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
+import PrimaryChooser from "../setup/PrimaryChooser";
 
 /* ---- API types ---- */
 
@@ -604,112 +605,19 @@ function AgentEditModal({
   );
 }
 
-/* ---- add-delegate form: builds the `aimee agent add` argv ---- */
+/* ---- add delegate: the SAME chooser + flows as the wizard's add agent ----
+ * One code path (PrimaryChooser) drives both surfaces; 'delegate' mode only
+ * collects a roster name + roles and skips the --default promotion. Fine-tuning
+ * (cost tier, disable, endpoint tweaks) lives in the edit modal afterwards. */
 
 function AddDelegate({ onDone }: { onDone: (msg: string, ok: boolean) => void }) {
-  const [name, setName] = useState("");
-  const [endpoint, setEndpoint] = useState("");
-  const [model, setModel] = useState("");
-  const [provider, setProvider] = useState("openai");
-  const [roles, setRoles] = useState("summarize,format,draft");
-  const [apiKey, setApiKey] = useState("");
-  const [costTier, setCostTier] = useState("0");
-  const [disabled, setDisabled] = useState(false);
-  const [busy, setBusy] = useState(false);
-
-  // CLI-backed providers (claude/claude-code) run a local CLI, not an HTTP
-  // endpoint, so the endpoint field is optional for them (server ignores it).
-  const cliProvider = provider === "claude" || provider === "claude-code";
-
-  const submit = async () => {
-    if (!name.trim() || !model.trim() || (!cliProvider && !endpoint.trim())) {
-      onDone("name, endpoint and model are required", false);
-      return;
-    }
-    // Mirror `aimee agent add <name> <endpoint> <model> [--flags]`. Endpoint is a
-    // required positional; pass "-" as a placeholder for CLI providers.
-    const args = [name.trim(), cliProvider ? "-" : endpoint.trim(), model.trim()];
-    if (provider) args.push("--provider", provider);
-    if (roles.trim()) args.push("--roles", roles.trim());
-    if (apiKey.trim()) args.push("--key", apiKey.trim());
-    if (costTier && costTier !== "0") args.push("--cost-tier", costTier);
-    if (disabled) args.push("--disabled");
-
-    setBusy(true);
-    try {
-      const res = await postArgs<{ error?: string; name?: string }>(
-        "/api/agents/add",
-        args,
-      );
-      if (res.error) onDone(res.error, false);
-      else onDone(`added ${res.name || name}`, true);
-    } catch {
-      onDone("add failed", false);
-    } finally {
-      setBusy(false);
-    }
-  };
-
   return (
     <Panel title="Add delegate">
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-        <L label="name">
-          <input value={name} onChange={(e) => setName(e.target.value)} style={inp} placeholder="my-delegate" />
-        </L>
-        <L label="provider">
-          <select value={provider} onChange={(e) => setProvider(e.target.value)} style={inp}>
-            {PROVIDERS.map((p) => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </select>
-        </L>
-        <L label={cliProvider ? "endpoint (optional for CLI)" : "endpoint"}>
-          <input
-            value={endpoint}
-            onChange={(e) => setEndpoint(e.target.value)}
-            style={inp}
-            placeholder="https://host:port/v1"
-            disabled={cliProvider}
-          />
-        </L>
-        <L label="model">
-          <input value={model} onChange={(e) => setModel(e.target.value)} style={inp} placeholder="gpt-5" />
-        </L>
-        <L label="roles (comma-separated)">
-          <input value={roles} onChange={(e) => setRoles(e.target.value)} style={inp} />
-        </L>
-        <L label="cost tier">
-          <input
-            type="number"
-            value={costTier}
-            onChange={(e) => setCostTier(e.target.value)}
-            style={inp}
-            min={0}
-          />
-        </L>
-        <L label="API key (optional — stored in vault)">
-          <input
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            style={inp}
-            placeholder="sk-…  or  $ENV_VAR"
-          />
-        </L>
-        <L label="start disabled">
-          <input type="checkbox" checked={disabled} onChange={(e) => setDisabled(e.target.checked)} />
-        </L>
-      </div>
-      <div style={{ marginTop: 10 }}>
-        <button
-          onClick={submit}
-          disabled={busy}
-          style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
-        >
-          {busy ? "Adding…" : "Add delegate"}
-        </button>
+      <div style={{ padding: "12px" }}>
+        <PrimaryChooser
+          mode="delegate"
+          onConfigured={(provider) => onDone(`added ${provider} delegate`, true)}
+        />
       </div>
     </Panel>
   );

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Panel } from '@rakuensoftware/smoothgui';
 import { useSessions } from '../SessionContext';
+import { parseOwnerOnly, type OwnerRef } from '../setup/ownerUrl';
 
 /* Git projects (webchat-git WP-F2). Lists the user's cloned repos, connects a
  * new one, and runs per-project git ops — all via /api/git/* (the server forwards
  * to /v1/workspace/* with the user's webuser: identity; creds live only in the
- * sealed vault). */
+ * sealed vault). The connect field also accepts an owner/org URL (e.g.
+ * github.com/RakuenSoftware): it then enumerates the owner's repositories and
+ * bulk-clones the selected ones, mirroring the wizard's Workspaces step. */
 
 const READ_OPS = ['status', 'log', 'diff', 'branch'] as const;
 const REMOTE_OPS = ['fetch', 'pull', 'push'] as const;
@@ -50,6 +53,12 @@ export default function Projects() {
   const [ghUri, setGhUri] = useState('');
   const [ghConfigured, setGhConfigured] = useState(false);
   const [ghClientId, setGhClientId] = useState('');
+  // Owner/org bulk-clone (URL parsed as an owner with no repo segment).
+  const [orgRef, setOrgRef] = useState<OwnerRef | null>(null);
+  const [orgRepos, setOrgRepos] = useState<{ name: string; clone_url: string; private?: boolean }[]>([]);
+  const [orgSelected, setOrgSelected] = useState<Record<string, boolean>>({});
+  const [orgProvider, setOrgProvider] = useState('');
+  const [orgResults, setOrgResults] = useState<{ name: string; ok: boolean; error?: string | null }[]>([]);
 
   const loadGhConfig = useCallback(async () => {
     try {
@@ -176,6 +185,9 @@ export default function Projects() {
 
   async function connect() {
     if (!url.trim()) return;
+    // An owner/org URL (no repo segment) enumerates instead of cloning.
+    const owner = parseOwnerOnly(url);
+    if (owner) { await listOrgRepos(owner); return; }
     setBusy(true); setErr(''); setOutput('');
     try {
       const r = await api('/api/git/clone', {
@@ -186,6 +198,53 @@ export default function Projects() {
       if (!r.ok) { setErr(d.error || 'clone failed'); }
       else { setUrl(''); setName(''); setToken(''); await loadProjects(); await loadHosts(); setSelected(d.name || ''); }
     } finally { setBusy(false); }
+  }
+
+  // Enumerate an owner/org's repositories (wizard parity: /api/git/org-repos).
+  async function listOrgRepos(owner: OwnerRef) {
+    setBusy(true); setErr(''); setOutput(''); setOrgResults([]);
+    try {
+      // Save the token first (private/self-hosted org) so enumeration is authed.
+      if (token.trim()) {
+        await api('/api/git/credentials', {
+          method: 'POST',
+          body: JSON.stringify({ host: owner.host, token: token.trim() }),
+        }).catch(() => undefined);
+        setToken('');
+        await loadHosts();
+      }
+      const q = `host=${encodeURIComponent(owner.host)}&owner=${encodeURIComponent(owner.owner)}`;
+      const r = await api(`/api/git/org-repos?${q}`, { method: 'GET' });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) { setErr(d.error || `could not list repositories (${r.status})`); setOrgRef(null); setOrgRepos([]); return; }
+      const list: { name: string; clone_url: string; private?: boolean }[] = d.repos || [];
+      setOrgRef(owner);
+      setOrgRepos(list);
+      setOrgProvider(d.provider || '');
+      // Default: select every repo not already cloned.
+      const sel: Record<string, boolean> = {};
+      for (const repo of list) sel[repo.name] = !projects.includes(repo.name);
+      setOrgSelected(sel);
+      if (list.length === 0) setErr('No repositories found for that owner.');
+    } catch { setErr('aimee-server unavailable'); } finally { setBusy(false); }
+  }
+
+  async function cloneOrgSelected() {
+    if (!orgRef) return;
+    const chosen = orgRepos.filter(r => orgSelected[r.name]).map(r => ({ name: r.name, clone_url: r.clone_url }));
+    if (chosen.length === 0) { setErr('Select at least one repository.'); return; }
+    setBusy(true); setErr('');
+    try {
+      const r = await api('/api/git/clone-org', {
+        method: 'POST',
+        body: JSON.stringify({ host: orgRef.host, owner: orgRef.owner, repos: chosen }),
+      });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) { setErr(d.error || `clone failed (${r.status})`); return; }
+      setOrgResults(d.results || []);
+      setUrl('');
+      await loadProjects();
+    } catch { setErr('aimee-server unavailable'); } finally { setBusy(false); }
   }
 
   async function runOp(op: string, extra?: Record<string, unknown>): Promise<boolean> {
@@ -211,16 +270,69 @@ export default function Projects() {
       <Panel title="Connect a repository">
         <div style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
           <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-            <input style={{ ...input, flex: 2, minWidth: '260px' }} placeholder="git remote URL (https or ssh)"
-              value={url} onChange={e => setUrl(e.target.value)} />
+            <input style={{ ...input, flex: 2, minWidth: '260px' }}
+              placeholder="repo URL — or an owner/org (e.g. github.com/RakuenSoftware) to clone its repos"
+              value={url} onChange={e => setUrl(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter' && url.trim() && !busy) connect(); }} />
             <input style={{ ...input, flex: 1, minWidth: '120px' }} placeholder="name (optional)"
               value={name} onChange={e => setName(e.target.value)} />
             <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
-              disabled={busy || !url.trim()} onClick={connect}>Clone</button>
+              disabled={busy || !url.trim()} onClick={connect}>
+              {parseOwnerOnly(url) ? 'List repositories' : 'Clone'}
+            </button>
           </div>
           <input style={{ ...input, width: '100%' }} type="password" autoComplete="off"
-            placeholder="access token — only for a private repo (GitHub/Gitea/GitLab…); saved server-side per host"
+            placeholder="access token — only for a private repo/org (GitHub/Gitea/GitLab…); saved server-side per host"
             value={token} onChange={e => setToken(e.target.value)} />
+
+          {/* Owner/org enumeration: pick the repos, bulk-clone as projects. */}
+          {orgRef && orgRepos.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                <div style={{ fontSize: '12.5px', fontWeight: 700 }}>
+                  {orgRef.host}/{orgRef.owner}: {orgRepos.length} repositor{orgRepos.length === 1 ? 'y' : 'ies'}
+                  {orgProvider ? ` · ${orgProvider}` : ''}
+                </div>
+                <button style={{ ...btn, border: 'none', color: '#3a6ea5', padding: 0 }}
+                  onClick={() => setOrgSelected(Object.fromEntries(orgRepos.map(r => [r.name, true])))}>all</button>
+                <button style={{ ...btn, border: 'none', color: '#3a6ea5', padding: 0 }}
+                  onClick={() => setOrgSelected({})}>none</button>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', maxHeight: '220px', overflow: 'auto',
+                            border: '1px solid #ddd', borderRadius: '6px', padding: '8px' }}>
+                {orgRepos.map(repo => {
+                  const already = projects.includes(repo.name);
+                  return (
+                    <label key={repo.name} style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', cursor: 'pointer' }}>
+                      <input type="checkbox" checked={!!orgSelected[repo.name]}
+                        onChange={e => setOrgSelected(p => ({ ...p, [repo.name]: e.target.checked }))} />
+                      <span style={{ fontFamily: 'monospace', flex: 1 }}>{repo.name}</span>
+                      {repo.private && <span style={{ fontSize: '10.5px', color: '#8a5a00' }}>private</span>}
+                      {already && <span style={{ fontSize: '11px', color: '#2a7' }}>● cloned</span>}
+                    </label>
+                  );
+                })}
+              </div>
+              <div>
+                <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
+                  disabled={busy || orgRepos.filter(r => orgSelected[r.name]).length === 0}
+                  onClick={cloneOrgSelected}>
+                  Clone selected ({orgRepos.filter(r => orgSelected[r.name]).length})
+                </button>
+              </div>
+            </div>
+          )}
+          {orgResults.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+              {orgResults.map(res => (
+                <div key={res.name} style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '12.5px' }}>
+                  <span aria-hidden>{res.ok ? '✅' : '⛔'}</span>
+                  <span style={{ fontFamily: 'monospace', flex: 1 }}>{res.name}</span>
+                  {!res.ok && <span style={{ color: '#c62828' }}>{res.error || 'failed'}</span>}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </Panel>
 

--- a/frontend/src/setup/ConnectWorkspace.tsx
+++ b/frontend/src/setup/ConnectWorkspace.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { parseOwner } from './ownerUrl';
 
 /* Wizard — Workspaces & projects. A workspace is your collection of projects: the
  * repos under an owner/org (e.g. github.com/RakuenSoftware). Point at that owner,
@@ -44,21 +45,6 @@ interface CloneResult {
   ok: boolean;
   project?: string | null;
   error?: string | null;
-}
-
-/** Parse "github.com/RakuenSoftware", "https://github.com/RakuenSoftware/", or
- * "host owner" into {host, owner}. Returns null when either part is missing. */
-export function parseOwner(input: string): { host: string; owner: string } | null {
-  let s = input.trim();
-  if (!s) return null;
-  s = s.replace(/^[a-z]+:\/\//i, ''); // strip scheme
-  s = s.replace(/^git@/i, '').replace(':', '/'); // git@host:owner → host/owner
-  const parts = s.split('/').filter(Boolean);
-  if (parts.length < 2) return null;
-  const host = parts[0].toLowerCase();
-  const owner = parts[1];
-  if (!host.includes('.') || !owner) return null;
-  return { host, owner };
 }
 
 export interface ConnectWorkspaceProps {
@@ -181,7 +167,8 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
           <input style={{ ...input, flex: 2, minWidth: 240 }}
             placeholder="owner URL (e.g. github.com/RakuenSoftware)"
-            value={ownerInput} onChange={(e) => setOwnerInput(e.target.value)} />
+            value={ownerInput} onChange={(e) => setOwnerInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter' && ownerInput.trim() && !listing) listRepos(); }} />
           <button style={primaryBtn} disabled={listing || !ownerInput.trim()} onClick={listRepos}>
             {listing ? 'Listing…' : 'List repositories'}
           </button>

--- a/frontend/src/setup/PrimaryChooser.tsx
+++ b/frontend/src/setup/PrimaryChooser.tsx
@@ -1,17 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-/* Wizard page-1 primary chooser. Four supported primaries, two shapes:
+/* Provider chooser — wizard page 1 AND the Agents tab's "add delegate" first
+ * window. Four supported providers, two shapes:
  *
- *   API key      → agent.add --default (Anthropic API, OpenAI-compatible API)
+ *   API key      → agent.add (Anthropic API, OpenAI-compatible API)
  *   Subscription → server-hosted OAuth CLI login (Claude / Codex "sign in with
- *                  your plan"), then agent.set --default to make it primary.
+ *                  your plan")
+ *
+ * Two modes select what the add means:
+ *   'primary'  (wizard default) — the agent becomes the GLOBAL default (the one
+ *              resolve_primary drives): agent.add --default, and the OAuth flow
+ *              promotes the vendor agent via agent.set --default.
+ *   'delegate' (Agents tab) — a named roster entry, NOT the default: the API
+ *              form collects a delegate name + roles, and the OAuth flow leaves
+ *              the registered vendor agent unpromoted.
  *
  * Every write goes through an existing endpoint — /api/agents/add,
  * /api/agents/set, and the /api/agents/oauth/* proxies — so there is no new
- * config surface. The chosen primary is set as the GLOBAL default agent (the one
- * resolve_primary drives); on success we also stamp the legacy `provider` config
- * breadcrumb so the wizard summary + header chip (which read config, not the
- * agent roster) reflect that a primary now exists.
+ * config surface. In primary mode, on success we also stamp the legacy
+ * `provider` config breadcrumb so the wizard summary + header chip (which read
+ * config, not the agent roster) reflect that a primary now exists.
  *
  * The subscription token is minted, vaulted, and refreshed entirely server-side:
  * only the verification URL, an optional device code, an opaque session handle,
@@ -122,12 +130,17 @@ interface OauthState {
 }
 
 export interface PrimaryChooserProps {
-  /** Called after a primary is fully configured + set as the global default; the
-   * argument is the `provider` breadcrumb to stamp into config. */
+  /** Called after the agent is fully configured (primary mode: and set as the
+   * global default); the argument is the provider string ('primary' mode stamps
+   * it into config as the legacy breadcrumb). */
   onConfigured: (provider: string) => void | Promise<void>;
+  /** 'primary' (default): the wizard's add-and-make-default. 'delegate': the
+   * Agents tab's add — a named, non-default roster entry. */
+  mode?: 'primary' | 'delegate';
 }
 
-export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
+export default function PrimaryChooser({ onConfigured, mode = 'primary' }: PrimaryChooserProps) {
+  const delegate = mode === 'delegate';
   const [selected, setSelected] = useState<Kind | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
@@ -136,6 +149,9 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
   const [endpoint, setEndpoint] = useState('');
   const [model, setModel] = useState('');
   const [apiKey, setApiKey] = useState('');
+  // Delegate mode only: the roster name + delegation roles for the new agent.
+  const [name, setName] = useState('');
+  const [roles, setRoles] = useState('summarize,format,draft');
 
   // Subscription OAuth flow.
   const [oauth, setOauth] = useState<OauthState | null>(null);
@@ -152,6 +168,7 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
     setEndpoint(spec.endpoint);
     setModel(spec.model);
     setApiKey('');
+    setName(delegate ? `${spec.provider}-delegate` : '');
     setError('');
     setOauth(null);
   };
@@ -166,24 +183,31 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
     setBusy(false); setPolling(false);
   };
 
-  // --- API-key primary: agent.add --default -------------------------------
+  // --- API-key agent: agent.add (primary mode adds --default) -------------
   const submitApi = async () => {
     if (!apiSpec) return;
     if (!endpoint.trim() || !model.trim() || !apiKey.trim()) {
       setError('Endpoint, model, and API key are all required.');
       return;
     }
+    if (delegate && !name.trim()) {
+      setError('Give the delegate a name.');
+      return;
+    }
     setBusy(true);
     setError('');
     try {
-      await postJSON('/api/agents/add', {
-        args: [
-          apiSpec.provider, endpoint.trim(), model.trim(),
-          '--provider', apiSpec.provider,
-          '--key', apiKey.trim(),
-          '--default',
-        ],
-      });
+      const args = [
+        delegate ? name.trim() : apiSpec.provider, endpoint.trim(), model.trim(),
+        '--provider', apiSpec.provider,
+        '--key', apiKey.trim(),
+      ];
+      if (delegate) {
+        if (roles.trim()) args.push('--roles', roles.trim());
+      } else {
+        args.push('--default');
+      }
+      await postJSON('/api/agents/add', { args });
       await onConfigured(apiSpec.provider);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not add the agent.');
@@ -191,15 +215,18 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
     }
   };
 
-  // --- Subscription primary: OAuth login, then agent.set --default --------
+  // --- Subscription agent: OAuth login (primary mode then agent.set --default)
   const pollOnce = useCallback(async (vendor: string, session: string): Promise<'pending' | 'authenticated' | 'failed'> => {
     try {
       const r = await postJSON<{ state?: string; agent?: string; error?: string }>(
         '/api/agents/oauth/poll', { vendor, session });
       if (r.state === 'authenticated') {
-        // Promote the freshly-registered vendor agent to the global primary.
-        const agent = r.agent || vendor;
-        await postJSON('/api/agents/set', { args: [agent, '--default'] });
+        // Primary mode: promote the freshly-registered vendor agent to the
+        // global primary. A delegate stays an ordinary roster entry.
+        if (!delegate) {
+          const agent = r.agent || vendor;
+          await postJSON('/api/agents/set', { args: [agent, '--default'] });
+        }
         return 'authenticated';
       }
       if (r.state === 'failed') { setError(r.error || 'Login failed or timed out.'); return 'failed'; }
@@ -208,7 +235,7 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
       setError(e instanceof Error ? e.message : 'Poll failed.');
       return 'failed';
     }
-  }, []);
+  }, [delegate]);
 
   const runPoll = useCallback(async (vendor: string, session: string, provider: string) => {
     setPolling(true);
@@ -265,7 +292,9 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
     return (
       <div style={{ display: 'grid', gap: 10, marginBottom: 14 }}>
         <p style={{ fontSize: 13, color: '#556', margin: '0 0 2px' }}>
-          Pick the primary model aimee drives. You can change it later on the Agents tab.
+          {delegate
+            ? 'Pick the provider for this delegate.'
+            : 'Pick the primary model aimee drives. You can change it later on the Agents tab.'}
         </p>
         {API_SPECS.map((s) => (
           <button key={s.kind} onClick={() => chooseApi(s)} style={cardStyle}>
@@ -286,12 +315,23 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
   return (
     <div style={{ marginBottom: 14 }}>
       <button onClick={reset} style={{ ...ghostBtn, marginBottom: 12 }} disabled={busy || polling}>
-        ← Choose a different primary
+        ← Choose a different {delegate ? 'provider' : 'primary'}
       </button>
 
       {apiSpec && (
         <div style={{ display: 'grid', gap: 12 }}>
           <div style={{ fontSize: 15, fontWeight: 700 }}>{apiSpec.label}</div>
+          {delegate && (
+            <>
+              <Field label="Delegate name">
+                <input style={input} value={name} onChange={(e) => setName(e.target.value)}
+                  placeholder={`${apiSpec.provider}-delegate`} />
+              </Field>
+              <Field label="Roles (comma-separated)">
+                <input style={input} value={roles} onChange={(e) => setRoles(e.target.value)} />
+              </Field>
+            </>
+          )}
           <Field label="Endpoint">
             <input style={input} value={endpoint} onChange={(e) => setEndpoint(e.target.value)} placeholder={apiSpec.endpoint} />
           </Field>
@@ -307,7 +347,7 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
           </div>
           <div>
             <button style={primaryBtn} disabled={busy} onClick={submitApi}>
-              {busy ? 'Saving…' : 'Save & set as primary'}
+              {busy ? 'Saving…' : delegate ? 'Add delegate' : 'Save & set as primary'}
             </button>
           </div>
         </div>

--- a/frontend/src/setup/ownerUrl.test.ts
+++ b/frontend/src/setup/ownerUrl.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { parseOwner, parseOwnerOnly } from './ownerUrl';
+
+describe('parseOwner', () => {
+  it('parses the plain owner form', () => {
+    expect(parseOwner('github.com/RakuenSoftware')).toEqual({ host: 'github.com', owner: 'RakuenSoftware' });
+  });
+
+  it('strips scheme and trailing slash', () => {
+    expect(parseOwner('https://github.com/RakuenSoftware/')).toEqual({ host: 'github.com', owner: 'RakuenSoftware' });
+  });
+
+  it('parses the ssh form', () => {
+    expect(parseOwner('git@gitea.example.com:MyOrg')).toEqual({ host: 'gitea.example.com', owner: 'MyOrg' });
+  });
+
+  it('a full repo URL parses to its owner', () => {
+    expect(parseOwner('https://github.com/RakuenSoftware/aimee.git')).toEqual({ host: 'github.com', owner: 'RakuenSoftware' });
+  });
+
+  it('rejects hostless or ownerless input', () => {
+    expect(parseOwner('RakuenSoftware')).toBeNull();
+    expect(parseOwner('github.com')).toBeNull();
+    expect(parseOwner('localhost/owner')).toBeNull(); // host needs a dot
+    expect(parseOwner('')).toBeNull();
+  });
+});
+
+describe('parseOwnerOnly', () => {
+  it('accepts an owner reference with no repo segment', () => {
+    expect(parseOwnerOnly('github.com/RakuenSoftware')).toEqual({ host: 'github.com', owner: 'RakuenSoftware' });
+    expect(parseOwnerOnly('https://github.com/RakuenSoftware/')).toEqual({ host: 'github.com', owner: 'RakuenSoftware' });
+    expect(parseOwnerOnly('git@github.com:RakuenSoftware')).toEqual({ host: 'github.com', owner: 'RakuenSoftware' });
+  });
+
+  it('rejects a full repo URL — that is a single clone, not an enumeration', () => {
+    expect(parseOwnerOnly('github.com/RakuenSoftware/aimee')).toBeNull();
+    expect(parseOwnerOnly('https://github.com/RakuenSoftware/aimee.git')).toBeNull();
+    expect(parseOwnerOnly('git@github.com:RakuenSoftware/aimee.git')).toBeNull();
+  });
+
+  it('rejects non-owner input', () => {
+    expect(parseOwnerOnly('RakuenSoftware')).toBeNull();
+    expect(parseOwnerOnly('')).toBeNull();
+  });
+});

--- a/frontend/src/setup/ownerUrl.ts
+++ b/frontend/src/setup/ownerUrl.ts
@@ -1,0 +1,38 @@
+/* Owner/org URL parsing shared by the wizard's Workspaces step and the Projects
+ * page. Pure (no DOM/network), unit-tested. */
+
+export interface OwnerRef {
+  host: string;
+  owner: string;
+}
+
+/** Parse "github.com/RakuenSoftware", "https://github.com/RakuenSoftware/", or
+ * "git@host:owner" into {host, owner}. Ignores anything after the owner segment,
+ * so a full repo URL also parses (to its owner). Returns null when either part
+ * is missing. */
+export function parseOwner(input: string): OwnerRef | null {
+  let s = input.trim();
+  if (!s) return null;
+  s = s.replace(/^[a-z]+:\/\//i, ''); // strip scheme
+  s = s.replace(/^git@/i, '').replace(':', '/'); // git@host:owner → host/owner
+  const parts = s.split('/').filter(Boolean);
+  if (parts.length < 2) return null;
+  const host = parts[0].toLowerCase();
+  const owner = parts[1];
+  if (!host.includes('.') || !owner) return null;
+  return { host, owner };
+}
+
+/** Like parseOwner, but ONLY for an owner/org reference with no repo segment —
+ * "github.com/RakuenSoftware" matches, "github.com/RakuenSoftware/aimee" does
+ * not. Lets a single URL field distinguish "clone this repo" from "enumerate
+ * this owner's repos". */
+export function parseOwnerOnly(input: string): OwnerRef | null {
+  let s = input.trim();
+  if (!s) return null;
+  s = s.replace(/^[a-z]+:\/\//i, '');
+  s = s.replace(/^git@/i, '').replace(':', '/');
+  const parts = s.split('/').filter(Boolean);
+  if (parts.length !== 2) return null; // host + owner, nothing after
+  return parseOwner(input);
+}

--- a/frontend/src/setup/readiness.test.ts
+++ b/frontend/src/setup/readiness.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { FIELD_HELP } from '../pages/settingsHelp';
-import { computeReadiness, stepsRemaining, READINESS_KEYS, readinessKeysAreDocumented } from './readiness';
+import { completedSteps, computeReadiness, stepsRemaining, READINESS_KEYS, readinessKeysAreDocumented } from './readiness';
 
 describe('readiness grounding', () => {
   it('every READINESS_KEYS entry is a documented config field', () => {
@@ -89,5 +89,44 @@ describe('computeReadiness (connection step)', () => {
     const two = computeReadiness(cfg, true, 2);
     expect(two.steps.connection.ok).toBe(true);
     expect(two.steps.connection.detail).toMatch(/2 hosts/);
+  });
+});
+
+describe('completedSteps (affirmative completion — hides wizard sections on reopen)', () => {
+  it('a fresh install has completed NOTHING, even steps readiness marks ok-by-default', () => {
+    const done = completedSteps({}, false, 0);
+    expect(done.size).toBe(0);
+    // Contrast: readiness says knowledge_base + db2 are ok on the same input.
+    const r = computeReadiness({}, false, 0);
+    expect(r.steps.knowledge_base.ok).toBe(true);
+    expect(r.steps.db2.ok).toBe(true);
+  });
+
+  it('each step completes on its affirmative signal', () => {
+    expect(completedSteps({ provider: 'claude' }, false).has('provider')).toBe(true);
+    expect(completedSteps({ kb_mode: 'local' }, false).has('knowledge_base')).toBe(true);
+    expect(completedSteps({ llm_embed_backend: 'local' }, false).has('embedding')).toBe(true);
+    expect(completedSteps({}, false, 1).has('connection')).toBe(true);
+    expect(completedSteps({}, true).has('project')).toBe(true);
+  });
+
+  it('remote KB completes only once the URL makes the choice real', () => {
+    expect(completedSteps({ kb_mode: 'remote' }, false).has('knowledge_base')).toBe(false);
+    expect(completedSteps({ kb_mode: 'remote', kb_client_url: 'https://kb' }, false).has('knowledge_base')).toBe(true);
+  });
+
+  it('db2 completes via an explicit URL or the deploy walk (embed role placed)', () => {
+    expect(completedSteps({}, false).has('db2')).toBe(false);
+    expect(completedSteps({ db2_url: 'postgres://x' }, false).has('db2')).toBe(true);
+    expect(completedSteps({ llm_embed_backend: 'external' }, false).has('db2')).toBe(true);
+  });
+
+  it('a fully set-up instance completes every step', () => {
+    const done = completedSteps(
+      { provider: 'claude', kb_mode: 'local', llm_embed_backend: 'local', db2_url: '' },
+      true,
+      1,
+    );
+    expect(done.size).toBe(6);
   });
 });

--- a/frontend/src/setup/readiness.ts
+++ b/frontend/src/setup/readiness.ts
@@ -127,6 +127,44 @@ export function stepsRemaining(r: Readiness): number {
   return (Object.values(r.steps) as StepStatus[]).filter((s) => !s.ok && !s.optional).length;
 }
 
+/** The steps the operator has AFFIRMATIVELY completed — used by the wizard to
+ * hide already-done sections on reopen. Deliberately stricter than
+ * computeReadiness: a step that is merely satisfied-by-default (the local-KB
+ * fork never visited, the bundled Postgres never chosen) is NOT completed, so a
+ * first run still walks every step. */
+export function completedSteps(
+  cfg: Record<string, unknown>,
+  hasProject: boolean,
+  hostsConnected = 0,
+): Set<StepId> {
+  const done = new Set<StepId>();
+  if (asStr(cfg, 'provider') !== '') done.add('provider');
+
+  // The KB fork is complete once a mode was explicitly recorded ('' = never
+  // visited); remote additionally needs the URL that makes the choice real.
+  const kbMode = asStr(cfg, 'kb_mode');
+  if (kbMode === 'local' || (kbMode === 'remote' && asStr(cfg, 'kb_client_url') !== '')) {
+    done.add('knowledge_base');
+  }
+
+  const embConfigured =
+    asStr(cfg, 'embedding_command') !== '' ||
+    asStr(cfg, 'embedding_endpoint') !== '' ||
+    asStr(cfg, 'llm_embed_backend') === 'local' ||
+    asStr(cfg, 'llm_embed_backend') === 'external';
+  if (embConfigured) done.add('embedding');
+
+  // A blank db2_url is ALSO the completed "bundled Postgres" choice, but blank
+  // is equally the never-visited default. Treat the step as walked once the
+  // local-deploy walk demonstrably happened: an explicit URL, or the embed role
+  // placed in the step right before it.
+  if (asStr(cfg, 'db2_url') !== '' || embConfigured) done.add('db2');
+
+  if (hostsConnected > 0) done.add('connection');
+  if (hasProject) done.add('project');
+  return done;
+}
+
 /** Guard used by the grounding test: every READINESS_KEYS entry must be a real
  * documented field. Kept here so the invariant lives next to the keys. */
 export function readinessKeysAreDocumented(): boolean {


### PR DESCRIPTION
Promotes testing → main. Contains #1284: Projects-page owner/org bulk-clone (shared ownerUrl parsing, wizard-parity org-repos + clone-org flow) and the setup wizard skipping already-completed sections on reopen (affirmative completedSteps(), frozen at open, straight-to-summary when done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)