### PR TITLE
webchat: add-delegate uses the wizard's provider chooser (one code path)

### DIFF
--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
+import PrimaryChooser from "../setup/PrimaryChooser";
 
 /* ---- API types ---- */
 
@@ -604,112 +605,19 @@ function AgentEditModal({
   );
 }
 
-/* ---- add-delegate form: builds the `aimee agent add` argv ---- */
+/* ---- add delegate: the SAME chooser + flows as the wizard's add agent ----
+ * One code path (PrimaryChooser) drives both surfaces; 'delegate' mode only
+ * collects a roster name + roles and skips the --default promotion. Fine-tuning
+ * (cost tier, disable, endpoint tweaks) lives in the edit modal afterwards. */
 
 function AddDelegate({ onDone }: { onDone: (msg: string, ok: boolean) => void }) {
-  const [name, setName] = useState("");
-  const [endpoint, setEndpoint] = useState("");
-  const [model, setModel] = useState("");
-  const [provider, setProvider] = useState("openai");
-  const [roles, setRoles] = useState("summarize,format,draft");
-  const [apiKey, setApiKey] = useState("");
-  const [costTier, setCostTier] = useState("0");
-  const [disabled, setDisabled] = useState(false);
-  const [busy, setBusy] = useState(false);
-
-  // CLI-backed providers (claude/claude-code) run a local CLI, not an HTTP
-  // endpoint, so the endpoint field is optional for them (server ignores it).
-  const cliProvider = provider === "claude" || provider === "claude-code";
-
-  const submit = async () => {
-    if (!name.trim() || !model.trim() || (!cliProvider && !endpoint.trim())) {
-      onDone("name, endpoint and model are required", false);
-      return;
-    }
-    // Mirror `aimee agent add <name> <endpoint> <model> [--flags]`. Endpoint is a
-    // required positional; pass "-" as a placeholder for CLI providers.
-    const args = [name.trim(), cliProvider ? "-" : endpoint.trim(), model.trim()];
-    if (provider) args.push("--provider", provider);
-    if (roles.trim()) args.push("--roles", roles.trim());
-    if (apiKey.trim()) args.push("--key", apiKey.trim());
-    if (costTier && costTier !== "0") args.push("--cost-tier", costTier);
-    if (disabled) args.push("--disabled");
-
-    setBusy(true);
-    try {
-      const res = await postArgs<{ error?: string; name?: string }>(
-        "/api/agents/add",
-        args,
-      );
-      if (res.error) onDone(res.error, false);
-      else onDone(`added ${res.name || name}`, true);
-    } catch {
-      onDone("add failed", false);
-    } finally {
-      setBusy(false);
-    }
-  };
-
   return (
     <Panel title="Add delegate">
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-        <L label="name">
-          <input value={name} onChange={(e) => setName(e.target.value)} style={inp} placeholder="my-delegate" />
-        </L>
-        <L label="provider">
-          <select value={provider} onChange={(e) => setProvider(e.target.value)} style={inp}>
-            {PROVIDERS.map((p) => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </select>
-        </L>
-        <L label={cliProvider ? "endpoint (optional for CLI)" : "endpoint"}>
-          <input
-            value={endpoint}
-            onChange={(e) => setEndpoint(e.target.value)}
-            style={inp}
-            placeholder="https://host:port/v1"
-            disabled={cliProvider}
-          />
-        </L>
-        <L label="model">
-          <input value={model} onChange={(e) => setModel(e.target.value)} style={inp} placeholder="gpt-5" />
-        </L>
-        <L label="roles (comma-separated)">
-          <input value={roles} onChange={(e) => setRoles(e.target.value)} style={inp} />
-        </L>
-        <L label="cost tier">
-          <input
-            type="number"
-            value={costTier}
-            onChange={(e) => setCostTier(e.target.value)}
-            style={inp}
-            min={0}
-          />
-        </L>
-        <L label="API key (optional — stored in vault)">
-          <input
-            type="password"
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-            style={inp}
-            placeholder="sk-…  or  $ENV_VAR"
-          />
-        </L>
-        <L label="start disabled">
-          <input type="checkbox" checked={disabled} onChange={(e) => setDisabled(e.target.checked)} />
-        </L>
-      </div>
-      <div style={{ marginTop: 10 }}>
-        <button
-          onClick={submit}
-          disabled={busy}
-          style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
-        >
-          {busy ? "Adding…" : "Add delegate"}
-        </button>
+      <div style={{ padding: "12px" }}>
+        <PrimaryChooser
+          mode="delegate"
+          onConfigured={(provider) => onDone(`added ${provider} delegate`, true)}
+        />
       </div>
     </Panel>
   );

--- a/frontend/src/setup/PrimaryChooser.tsx
+++ b/frontend/src/setup/PrimaryChooser.tsx
@@ -1,17 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-/* Wizard page-1 primary chooser. Four supported primaries, two shapes:
+/* Provider chooser — wizard page 1 AND the Agents tab's "add delegate" first
+ * window. Four supported providers, two shapes:
  *
- *   API key      → agent.add --default (Anthropic API, OpenAI-compatible API)
+ *   API key      → agent.add (Anthropic API, OpenAI-compatible API)
  *   Subscription → server-hosted OAuth CLI login (Claude / Codex "sign in with
- *                  your plan"), then agent.set --default to make it primary.
+ *                  your plan")
+ *
+ * Two modes select what the add means:
+ *   'primary'  (wizard default) — the agent becomes the GLOBAL default (the one
+ *              resolve_primary drives): agent.add --default, and the OAuth flow
+ *              promotes the vendor agent via agent.set --default.
+ *   'delegate' (Agents tab) — a named roster entry, NOT the default: the API
+ *              form collects a delegate name + roles, and the OAuth flow leaves
+ *              the registered vendor agent unpromoted.
  *
  * Every write goes through an existing endpoint — /api/agents/add,
  * /api/agents/set, and the /api/agents/oauth/* proxies — so there is no new
- * config surface. The chosen primary is set as the GLOBAL default agent (the one
- * resolve_primary drives); on success we also stamp the legacy `provider` config
- * breadcrumb so the wizard summary + header chip (which read config, not the
- * agent roster) reflect that a primary now exists.
+ * config surface. In primary mode, on success we also stamp the legacy
+ * `provider` config breadcrumb so the wizard summary + header chip (which read
+ * config, not the agent roster) reflect that a primary now exists.
  *
  * The subscription token is minted, vaulted, and refreshed entirely server-side:
  * only the verification URL, an optional device code, an opaque session handle,
@@ -122,12 +130,17 @@ interface OauthState {
 }
 
 export interface PrimaryChooserProps {
-  /** Called after a primary is fully configured + set as the global default; the
-   * argument is the `provider` breadcrumb to stamp into config. */
+  /** Called after the agent is fully configured (primary mode: and set as the
+   * global default); the argument is the provider string ('primary' mode stamps
+   * it into config as the legacy breadcrumb). */
   onConfigured: (provider: string) => void | Promise<void>;
+  /** 'primary' (default): the wizard's add-and-make-default. 'delegate': the
+   * Agents tab's add — a named, non-default roster entry. */
+  mode?: 'primary' | 'delegate';
 }
 
-export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
+export default function PrimaryChooser({ onConfigured, mode = 'primary' }: PrimaryChooserProps) {
+  const delegate = mode === 'delegate';
   const [selected, setSelected] = useState<Kind | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
@@ -136,6 +149,9 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
   const [endpoint, setEndpoint] = useState('');
   const [model, setModel] = useState('');
   const [apiKey, setApiKey] = useState('');
+  // Delegate mode only: the roster name + delegation roles for the new agent.
+  const [name, setName] = useState('');
+  const [roles, setRoles] = useState('summarize,format,draft');
 
   // Subscription OAuth flow.
   const [oauth, setOauth] = useState<OauthState | null>(null);
@@ -152,6 +168,7 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
     setEndpoint(spec.endpoint);
     setModel(spec.model);
     setApiKey('');
+    setName(delegate ? `${spec.provider}-delegate` : '');
     setError('');
     setOauth(null);
   };
@@ -166,24 +183,31 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
     setBusy(false); setPolling(false);
   };
 
-  // --- API-key primary: agent.add --default -------------------------------
+  // --- API-key agent: agent.add (primary mode adds --default) -------------
   const submitApi = async () => {
     if (!apiSpec) return;
     if (!endpoint.trim() || !model.trim() || !apiKey.trim()) {
       setError('Endpoint, model, and API key are all required.');
       return;
     }
+    if (delegate && !name.trim()) {
+      setError('Give the delegate a name.');
+      return;
+    }
     setBusy(true);
     setError('');
     try {
-      await postJSON('/api/agents/add', {
-        args: [
-          apiSpec.provider, endpoint.trim(), model.trim(),
-          '--provider', apiSpec.provider,
-          '--key', apiKey.trim(),
-          '--default',
-        ],
-      });
+      const args = [
+        delegate ? name.trim() : apiSpec.provider, endpoint.trim(), model.trim(),
+        '--provider', apiSpec.provider,
+        '--key', apiKey.trim(),
+      ];
+      if (delegate) {
+        if (roles.trim()) args.push('--roles', roles.trim());
+      } else {
+        args.push('--default');
+      }
+      await postJSON('/api/agents/add', { args });
       await onConfigured(apiSpec.provider);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Could not add the agent.');
@@ -191,15 +215,18 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
     }
   };
 
-  // --- Subscription primary: OAuth login, then agent.set --default --------
+  // --- Subscription agent: OAuth login (primary mode then agent.set --default)
   const pollOnce = useCallback(async (vendor: string, session: string): Promise<'pending' | 'authenticated' | 'failed'> => {
     try {
       const r = await postJSON<{ state?: string; agent?: string; error?: string }>(
         '/api/agents/oauth/poll', { vendor, session });
       if (r.state === 'authenticated') {
-        // Promote the freshly-registered vendor agent to the global primary.
-        const agent = r.agent || vendor;
-        await postJSON('/api/agents/set', { args: [agent, '--default'] });
+        // Primary mode: promote the freshly-registered vendor agent to the
+        // global primary. A delegate stays an ordinary roster entry.
+        if (!delegate) {
+          const agent = r.agent || vendor;
+          await postJSON('/api/agents/set', { args: [agent, '--default'] });
+        }
         return 'authenticated';
       }
       if (r.state === 'failed') { setError(r.error || 'Login failed or timed out.'); return 'failed'; }
@@ -208,7 +235,7 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
       setError(e instanceof Error ? e.message : 'Poll failed.');
       return 'failed';
     }
-  }, []);
+  }, [delegate]);
 
   const runPoll = useCallback(async (vendor: string, session: string, provider: string) => {
     setPolling(true);
@@ -265,7 +292,9 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
     return (
       <div style={{ display: 'grid', gap: 10, marginBottom: 14 }}>
         <p style={{ fontSize: 13, color: '#556', margin: '0 0 2px' }}>
-          Pick the primary model aimee drives. You can change it later on the Agents tab.
+          {delegate
+            ? 'Pick the provider for this delegate.'
+            : 'Pick the primary model aimee drives. You can change it later on the Agents tab.'}
         </p>
         {API_SPECS.map((s) => (
           <button key={s.kind} onClick={() => chooseApi(s)} style={cardStyle}>
@@ -286,12 +315,23 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
   return (
     <div style={{ marginBottom: 14 }}>
       <button onClick={reset} style={{ ...ghostBtn, marginBottom: 12 }} disabled={busy || polling}>
-        ← Choose a different primary
+        ← Choose a different {delegate ? 'provider' : 'primary'}
       </button>
 
       {apiSpec && (
         <div style={{ display: 'grid', gap: 12 }}>
           <div style={{ fontSize: 15, fontWeight: 700 }}>{apiSpec.label}</div>
+          {delegate && (
+            <>
+              <Field label="Delegate name">
+                <input style={input} value={name} onChange={(e) => setName(e.target.value)}
+                  placeholder={`${apiSpec.provider}-delegate`} />
+              </Field>
+              <Field label="Roles (comma-separated)">
+                <input style={input} value={roles} onChange={(e) => setRoles(e.target.value)} />
+              </Field>
+            </>
+          )}
           <Field label="Endpoint">
             <input style={input} value={endpoint} onChange={(e) => setEndpoint(e.target.value)} placeholder={apiSpec.endpoint} />
           </Field>
@@ -307,7 +347,7 @@ export default function PrimaryChooser({ onConfigured }: PrimaryChooserProps) {
           </div>
           <div>
             <button style={primaryBtn} disabled={busy} onClick={submitApi}>
-              {busy ? 'Saving…' : 'Save & set as primary'}
+              {busy ? 'Saving…' : delegate ? 'Add delegate' : 'Save & set as primary'}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

The Agents tab's **"+ Add delegate"** first window is now identical to the wizard's add-agent step — the same four cards (**Anthropic API, OpenAI API, Claude Subscription, Codex Subscription**), rendered by the **same component** (`PrimaryChooser`), with each option provisioning exactly as the wizard does. One workflow, one code path — the old flat add-delegate form is deleted (net −52 lines).

`PrimaryChooser` gains a `mode` prop:
- `'primary'` (wizard, default — behavior unchanged): API path runs `agent.add --default`; OAuth path promotes the vendor agent via `agent.set --default`.
- `'delegate'` (Agents tab): the API form additionally collects a roster **name** (prefilled `<provider>-delegate`) and **roles** (default `summarize,format,draft`), and omits `--default`; the OAuth flow registers the vendor agent without promoting it.

Fine-tuning (cost tier, start-disabled, endpoint tweaks) remains in the existing edit modal.

## Testing

- `tsc -b` clean, all 81 vitest tests pass, production `vite build` succeeds (bundle slightly smaller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)