### PR TITLE
ci: rebuild testing images on frontend/ and webchat/ changes

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -21,6 +21,11 @@ on:
       - "config/**"
       - "deploy/container/**"
       - "scripts/**"
+      # The images bundle the webchat UI (frontend/ SPA + webchat/ Go server) —
+      # see the frontend-build/webchat-build stages in Dockerfile.server and
+      # Dockerfile.combined.
+      - "frontend/**"
+      - "webchat/**"
       - "Dockerfile"
       - "Dockerfile.server"
       - "Dockerfile.combined"


### PR DESCRIPTION
publish-testing.yml only rebuilt the `:testing` images when `src/`, `config/`, `deploy/container/`, `scripts/`, or a Dockerfile changed — but `Dockerfile.server` and `Dockerfile.combined` also bundle the browser UI from `frontend/` (SPA) and `webchat/` (Go server). Webchat-only merges (#1284, #1286) therefore never triggered a build and `:testing` stayed stale until a manual `workflow_dispatch` (which is how it was caught while deploying to .254 today).

Adds `frontend/**` and `webchat/**` to the paths filter.