### PR TITLE
Promote testing to main: webchat wizard/projects work + testing-image CI fix

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -21,6 +21,11 @@ on:
       - "config/**"
       - "deploy/container/**"
       - "scripts/**"
+      # The images bundle the webchat UI (frontend/ SPA + webchat/ Go server) —
+      # see the frontend-build/webchat-build stages in Dockerfile.server and
+      # Dockerfile.combined.
+      - "frontend/**"
+      - "webchat/**"
       - "Dockerfile"
       - "Dockerfile.server"
       - "Dockerfile.combined"


### PR DESCRIPTION
Promotes the current `testing` branch to `main`:

- #1284 — webchat: org bulk-clone on the Projects page; wizard skips completed steps
- #1286 — webchat: add-delegate uses the wizard's provider chooser (one code path)
- #1287 — ci: rebuild `:testing` images on `frontend/``webchat/` changes (the paths filter previously skipped webchat-only merges, leaving the `:testing` image stale)

All of this is deployed and verified on the .254 appliance (`testing-4c48074` + the CI fix merged on top).