### PR TITLE
webchat: honour the clone deadlines in the git clone relays

### DIFF
--- a/webchat/git.go
+++ b/webchat/git.go
@@ -455,10 +455,10 @@ func (s *server) handleGitClone(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "url required")
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), cloneTimeout)
 	defer cancel()
 	body, _ := json.Marshal(map[string]string{"url": req.URL, "name": req.Name, "token": req.Token})
-	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone", body)
+	st, data, err := s.v1RequestWebuserT(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone", body, cloneTimeout)
 	s.gitRelay(w, st, data, err)
 }
 
@@ -563,6 +563,6 @@ func (s *server) handleGitCloneOrg(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), cloneOrgTimeout)
 	defer cancel()
 	body, _ := json.Marshal(req)
-	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone-org", body)
+	st, data, err := s.v1RequestWebuserT(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone-org", body, cloneOrgTimeout)
 	s.gitCloneOrgRelay(w, st, data, err)
 }

--- a/webchat/socket.go
+++ b/webchat/socket.go
@@ -17,8 +17,9 @@ import (
 
 const socketCallTimeout = 10 * time.Second
 
-// cloneOrgTimeout bounds a bulk org clone (up to 100 repos, each a full git
-// clone) — far longer than a normal socket call.
+// cloneTimeout bounds a single full git clone; cloneOrgTimeout bounds a bulk
+// org clone (up to 100 repos) — both far longer than a normal socket call.
+const cloneTimeout = 2 * time.Minute
 const cloneOrgTimeout = 5 * time.Minute
 const chatReconnectTimeout = 30 * time.Second
 const chatReconnectStep = 250 * time.Millisecond


### PR DESCRIPTION
Fixes the wizard/Projects bulk clone reporting **"git: aimee-server unavailable"** on any clone that takes longer than 10 seconds (observed live on the .254 appliance: the server completed the `/v1/workspace/clone-org` with 200 while the browser showed the error; retrying then produced mass "project already exists").

`handleGitClone`/`handleGitCloneOrg` set a clone-sized **context** deadline but relayed via `v1RequestWebuser`, whose `http.Client.Timeout` is hard-coded to `socketCallTimeout` (10s) — the shorter client timeout always won. Both relays now go through `v1RequestWebuserT` with a matching client timeout (`cloneTimeout` 2m for single clones, `cloneOrgTimeout` 5m for bulk).

Verified: `go build ./...` + `go test ./...` green on the webchat module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)