### PR TITLE
trigger: finish the proposals→workflow pipeline + E2E test

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -257,9 +257,11 @@ The engine advances it one step at a time
   recorded against the step's content hash, so an approval is bound to the exact
   artifact it approved.
 
-A step resolves the working repository from `$AIMEE_WORKFLOW_REPO` (or the
-process cwd), see [Limitations](#current-limitations) for the
-run-in-a-specific-project gap.
+A step resolves the working repository from the work item's own `repo` when it
+names a local directory (a trigger rule's `pipeline.workspace` binds the run to
+that repository), falling back to `$AIMEE_WORKFLOW_REPO`, then the process cwd.
+See [Limitations](#current-limitations) for the forge-side residue of the old
+process-global behavior.
 
 ## Inspecting runs
 
@@ -343,13 +345,23 @@ configured git ref, and for every proposal it has not seen before it:
 1. materializes the proposal's content under `$AIMEE_HOME/triggers/proposals/`,
 2. files exactly one work item on `pipeline.template`, in `pipeline.workspace`,
    with the configured `mode` (default `autonomous`),
-3. de-duplicates by proposal, so re-scanning the same tree never files twice.
+3. de-duplicates by proposal, so re-scanning the same tree never files twice,
+4. stamps the run's USD ceiling — the rule's `max_spend_usd` if set, else the
+   same default every autonomous intake gets ($5.00; `AIMEE_AUTONOMY_MAX_USD`
+   overrides, `0` disables) — and wakes the autonomy scheduler so the run
+   starts immediately rather than on its next backstop sweep.
+
+`trigger.max_concurrent` is enforced at filing time: when that many
+trigger-filed runs are still active, further proposals are deferred (not
+dropped — the dedup key is the materialized proposal, so they file on a later
+scan once a slot frees). The work item's `repo` is the rule's
+`pipeline.workspace`, and every per-step block resolves its working directory
+from it, so the run executes in the watched repository.
 
 Merging a new proposal onto the watched branch is therefore all it takes to
 kick off a build — and with `mode: autonomous`, that build runs to its PR
-without further intervention (subject to `trigger.max_concurrent` and any
-`max_spend_usd` cap). Point the rule at a different `template` to run any other
-workflow you have authored.
+without further intervention. Point the rule at a different `template` to run
+any other workflow you have authored.
 
 > The filed run still enters through the same capped, audited intake as every
 > other run (see [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)); the trigger
@@ -368,10 +380,13 @@ These are real today and worth knowing before you lean on workflows:
    agents — but all of them require a `proposal_md`: there is still no way to
    start a workflow whose entry node isn't `author.proposal` without supplying
    proposal text. (There is still no Run button on the **Edit Workflows** page.)
-2. **Run-in-a-specific-project isn't wired.** A work-item has a `repo` field, but
-   the per-step blocks resolve their working directory from
-   `$AIMEE_WORKFLOW_REPO`/cwd rather than the work-item's `repo`, so binding a run
-   to a UI-selected project is incomplete.
+2. **Forge operations are process-global.** Per-step blocks now resolve their
+   working directory from the work-item's `repo` (when it names a local
+   directory; `$AIMEE_WORKFLOW_REPO`/cwd otherwise), so a triggered run executes
+   in its configured workspace. But the forge half (`git push`, `gh pr …` via
+   the vaulted runner) still runs in the server's own checkout, so PR-opening
+   workflows against a workspace that is not the server's primary repo are not
+   yet fully wired.
 3. **Composer ergonomics.** New steps are added disconnected; you wire order in
    the inspector. The **Edit Workflows** page has no live run/progress view — you
    start and watch runs on the separate **Workflow Actions** tab.

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -21,11 +21,13 @@
 #include "trigger_scheduler.h"
 #include "util.h"
 #include "wfe_engine.h"
+#include "wfe_scheduler.h" /* wfe_scheduler_notify — drive a filed run now, not on the 30s sweep */
 
 #include <pthread.h>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -440,7 +442,55 @@ static int trigger_write_atomic(const char *path, const char *bytes)
    return 0;
 }
 
-static void scan_proposals(const trigger_rule_t *rule)
+/* The per-run USD ceiling for a trigger-filed run: the rule's explicit
+ * pipeline.max_spend_usd when set (> 0), else the same default every autonomous
+ * intake applies ($5.00, AIMEE_AUTONOMY_MAX_USD override, 0 disables) — a
+ * trigger-filed run must never be the one intake path with NO runaway cost cap.
+ * Mirrors dev_submit_run (server_dev_submit.c). Returns 0 for "no cap". */
+static double trigger_cost_cap(const trigger_rule_t *rule)
+{
+   if (rule->max_spend_usd > 0 && isfinite(rule->max_spend_usd))
+      return rule->max_spend_usd;
+   double cap_usd = 5.0;
+   const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
+   if (v && v[0])
+   {
+      char *e = NULL;
+      double d = strtod(v, &e);
+      if (e && *e == '\0' && isfinite(d) && d >= 0) /* reject inf/NaN: would void the cap */
+         cap_usd = d;
+   }
+   return cap_usd;
+}
+
+/* Count ACTIVE work items that were filed by the proposals trigger (their
+ * proposal artifact lives under <home>/triggers/proposals/), across all rules —
+ * trigger.max_concurrent is a GLOBAL cap on concurrently-executing triggered
+ * runs. Returns the count, or -1 on a DB read failure (caller fails closed:
+ * files nothing this pass rather than overshooting the cap). */
+static int trigger_active_filed_runs(const char *home)
+{
+   char prefix[1100];
+   if (snprintf(prefix, sizeof(prefix), "%s/triggers/proposals/", home) >= (int)sizeof(prefix))
+      return -1;
+   db1_work_item_t *items = NULL;
+   int n = db1_work_item_list(&items);
+   if (n < 0 || !items)
+   {
+      free(items);
+      return n < 0 ? -1 : 0;
+   }
+   int active = 0;
+   size_t plen = strlen(prefix);
+   for (int i = 0; i < n; i++)
+      if (strcmp(items[i].state, "active") == 0 &&
+          strncmp(items[i].proposal_path, prefix, plen) == 0)
+         active++;
+   free(items);
+   return active;
+}
+
+static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
 {
    if (!rule || !rule->workspace[0] || !rule->pipeline_template[0])
       return;
@@ -510,8 +560,41 @@ static void scan_proposals(const trigger_rule_t *rule)
       return;
    }
 
+   /* trigger.max_concurrent: admission cap on concurrently-executing triggered
+    * runs. Filing is deferred, not lost — the per-proposal dedup key is the
+    * materialized artifact path, so an un-filed proposal is re-seen and filed on
+    * a later pass once a slot frees up. A cap <= 0 means uncapped. */
+   int budget = -1; /* uncapped */
+   if (max_concurrent > 0)
+   {
+      int active = trigger_active_filed_runs(home);
+      if (active < 0)
+      {
+         aimee_log(LOG_WARN, "trigger.sched",
+                   "proposals: could not count active triggered runs; deferring this pass");
+         return; /* fail closed: never overshoot the cap on a DB read fault */
+      }
+      budget = max_concurrent - active;
+      if (budget <= 0)
+      {
+         aimee_log(LOG_INFO, "trigger.sched",
+                   "proposals: %d active triggered run(s) >= max_concurrent=%d; deferring",
+                   active, max_concurrent);
+         return;
+      }
+   }
+
+   int filed = 0;
    for (int i = 0; i < n; i++)
    {
+      if (budget == 0)
+      {
+         aimee_log(LOG_INFO, "trigger.sched",
+                   "proposals: max_concurrent=%d reached; remaining proposals deferred to a "
+                   "later pass",
+                   max_concurrent);
+         break;
+      }
       char proposal_path[1200];
       if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md", home,
                    entries[i].sha) >= (int)sizeof(proposal_path))
@@ -549,12 +632,28 @@ static void scan_proposals(const trigger_rule_t *rule)
       rc = wfe_work_item_create(rule->pipeline_template, rule->workspace, proposal_path, mode, id,
                                 err, sizeof(err));
       if (rc == 0 && id[0])
+      {
+         /* Per-run USD ceiling (rule's max_spend_usd, else the intake default) so
+          * a triggered run parks budget_exceeded instead of burning unbounded
+          * delegate cost. Best-effort, mirroring dev_submit_run. */
+         double cap = trigger_cost_cap(rule);
+         if (cap > 0)
+            db1_work_item_set_cost_cap(id, cap);
+         filed++;
+         if (budget > 0)
+            budget--;
          aimee_log(LOG_INFO, "trigger.sched", "filed proposal workflow=%s repo=%s sha=%s id=%s",
                    rule->pipeline_template, rule->workspace, entries[i].sha, id);
+      }
       else
          aimee_log(LOG_WARN, "trigger.sched", "proposal create skipped/failed repo=%s sha=%s: %s",
                    rule->workspace, entries[i].sha, err[0] ? err : "already exists");
    }
+
+   /* Wake the autonomy driver so a just-filed run advances now rather than on
+    * its 30s backstop sweep (parity with the /v1/dev/submit intake). */
+   if (filed > 0)
+      wfe_scheduler_notify();
 }
 
 /* ------------------------------------------------------------------ */
@@ -872,7 +971,7 @@ static void sched_tick(void)
          if (now - g_last_fired[i] < 55)
             continue;
          g_last_fired[i] = now;
-         scan_proposals(rule);
+         scan_proposals(rule, cfg.trigger_max_concurrent);
          continue;
       }
 

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -578,8 +578,8 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
       if (budget <= 0)
       {
          aimee_log(LOG_INFO, "trigger.sched",
-                   "proposals: %d active triggered run(s) >= max_concurrent=%d; deferring",
-                   active, max_concurrent);
+                   "proposals: %d active triggered run(s) >= max_concurrent=%d; deferring", active,
+                   max_concurrent);
          return;
       }
    }

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -10,6 +10,7 @@
 #include "log.h"
 #include "wfe_autonomy.h"
 #include "wfe_blocks.h" /* wfe_worktree_cleanup (terminal) + wfe_worktree_orphan_gc (age-based) */
+#include "wfe_iface.h"  /* wfe_repo_local — resolve each item's own repo for cleanup */
 #include "wfe_store.h"
 
 #include <pthread.h>
@@ -53,8 +54,7 @@ void wfe_scheduler_run_once(void)
       {
          if (items[i].worktree[0])
          {
-            const char *rl = getenv("AIMEE_WORKFLOW_REPO");
-            if (wfe_worktree_cleanup(items[i].worktree, (rl && rl[0]) ? rl : ".") == 0)
+            if (wfe_worktree_cleanup(items[i].worktree, wfe_repo_local(items[i].repo)) == 0)
                db1_work_item_set_worktree(items[i].work_item_id, "");
          }
          continue;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -423,6 +423,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-roadmap-auto \
                $(TESTPREFIX)/unit-test-kb-mdl \
                $(TESTPREFIX)/unit-test-trigger \
+               $(TESTPREFIX)/unit-test-trigger-e2e \
                $(TESTPREFIX)/unit-test-kb-mining \
                $(TESTPREFIX)/unit-test-corpus-structural \
                $(TESTPREFIX)/unit-test-corpus-jobs \
@@ -2222,6 +2223,27 @@ $(TESTPREFIX)/unit-test-delegate-plan: $(OBJDIR)/tests/test_delegate_plan.o \
 $(TESTPREFIX)/unit-test-delegate-role: $(OBJDIR)/tests/test_delegate_role.o \
                              $(OBJDIR)/server/delegate_role.o $(OBJDIR)/role_templates.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
+
+# Trigger end-to-end: the REAL scan_proposals (textually included, real git
+# subprocesses + real DB1) files a work item from a committed pending proposal
+# and the real autonomy scheduler drives it to terminal (stub executors only).
+$(TESTPREFIX)/unit-test-trigger-e2e: $(OBJDIR)/tests/test_trigger_e2e.o \
+                                    $(OBJDIR)/server/wfe_scheduler.o $(OBJDIR)/workflow/wfe_autonomy.o \
+                                    $(OBJDIR)/tests/support/log_stub.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/workflow/wfe_roundtable.o $(OBJDIR)/workflow/wfe_approval.o \
+                                    $(OBJDIR)/workflow/wfe_verdict.o $(OBJDIR)/workflow/wfe_deliver.o \
+                                    $(OBJDIR)/workflow/wfe_manager_artifacts.o \
+                                    $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
+                                    $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+$(OBJDIR)/tests/test_trigger_e2e.o: tests/test_trigger_e2e.c server/trigger_scheduler.c
+	@mkdir -p $(dir $@)
+	$(CC) -c $(TEST_C_FLAGS) -I. -o $@ $<
 
 $(TESTPREFIX)/unit-test-trigger: $(OBJDIR)/tests/test_trigger.o $(OBJDIR)/cJSON.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -26,6 +26,7 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
    (void)fmt;
 }
 
+#include "db1/wfe_store.h" /* db1_work_item_t for the list/cost-cap stubs */
 #include "db1_trigger.h"
 int db1_trigger_insert(const char *id, const char *source, const char *event, const char *task,
                        const char *workspace, const char *metadata)
@@ -113,14 +114,18 @@ static struct
    char repo[512];
    char path[600];
    char mode[32];
+   char state[24];  /* stub work-item state, "active" on create; tests may complete it */
+   double cost_cap; /* recorded by the db1_work_item_set_cost_cap stub; 0 = none */
 } g_created[32];
 static int g_ncreated;
+static int g_notify_count; /* wfe_scheduler_notify() invocations */
 
 static void trig_stub_reset(void)
 {
    g_symref_out[0] = g_lstree_out[0] = g_lstree_ref[0] = g_lstree_pathspec[0] = '\0';
    g_nblobs = 0;
    g_ncreated = 0;
+   g_notify_count = 0;
 }
 
 const char *aimee_home(void)
@@ -221,6 +226,8 @@ int wfe_work_item_create(const char *workflow_name, const char *repo, const char
       snprintf(g_created[g_ncreated].path, sizeof g_created[0].path, "%s",
                proposal_path ? proposal_path : "");
       snprintf(g_created[g_ncreated].mode, sizeof g_created[0].mode, "%s", mode ? mode : "");
+      snprintf(g_created[g_ncreated].state, sizeof g_created[0].state, "active");
+      g_created[g_ncreated].cost_cap = 0.0;
       g_ncreated++;
    }
    if (out_id)
@@ -228,6 +235,41 @@ int wfe_work_item_create(const char *workflow_name, const char *repo, const char
    if (err && errlen > 0)
       err[0] = '\0';
    return 0;
+}
+
+/* Cost-cap stub: record the cap against the just-created item ("wi_<n>"). */
+int db1_work_item_set_cost_cap(const char *work_item_id, double cap)
+{
+   int idx = work_item_id ? atoi(work_item_id + 3) - 1 : -1;
+   if (idx >= 0 && idx < g_ncreated)
+      g_created[idx].cost_cap = cap;
+   return 0;
+}
+
+/* Work-item list stub: every created item, with its (test-controlled) state. */
+int db1_work_item_list(db1_work_item_t **out)
+{
+   if (!out)
+      return -1;
+   *out = NULL;
+   if (g_ncreated == 0)
+      return 0;
+   db1_work_item_t *items = calloc((size_t)g_ncreated, sizeof(*items));
+   if (!items)
+      return -1;
+   for (int i = 0; i < g_ncreated; i++)
+   {
+      snprintf(items[i].work_item_id, sizeof items[i].work_item_id, "wi_%d", i + 1);
+      snprintf(items[i].proposal_path, sizeof items[i].proposal_path, "%s", g_created[i].path);
+      snprintf(items[i].state, sizeof items[i].state, "%s", g_created[i].state);
+   }
+   *out = items;
+   return g_ncreated;
+}
+
+void wfe_scheduler_notify(void)
+{
+   g_notify_count++;
 }
 
 /* Pull in static cron_matches / field_matches via direct .c include. */
@@ -734,7 +776,7 @@ static void test_scan_proposals_end_to_end(void)
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
    snprintf(rule.event, sizeof rule.event, "docs/proposals/pending");
 
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
 
    /* Two .md proposals -> two work items; .gitkeep filtered out. */
    assert(g_ncreated == 2);
@@ -759,7 +801,7 @@ static void test_scan_proposals_end_to_end(void)
    assert(file_equals(exp1, "# Proposal B\n"));
 
    /* Re-scan with the same tree -> dedup pre-check skips both -> no new work items. */
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 2);
 
    /* A genuinely new proposal (new blob) -> exactly one new work item. */
@@ -770,7 +812,7 @@ static void test_scan_proposals_end_to_end(void)
             "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
             "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
             "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 3);
    assert(strcmp(g_created[2].wf, "build") == 0);
 
@@ -800,7 +842,7 @@ static void test_scan_proposals_honors_explicit_mode(void)
    snprintf(rule.event, sizeof rule.event, "docs/proposals/pending");
    snprintf(rule.mode, sizeof rule.mode, "interactive");
 
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
 
    assert(g_ncreated == 1);
    assert(strcmp(g_created[0].mode, "interactive") == 0);
@@ -826,14 +868,14 @@ static void test_scan_proposals_requires_workspace_and_workflow(void)
 
    /* Missing workspace -> no-op. */
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
 
    /* Missing workflow (pipeline_template) -> no-op. */
    memset(&rule, 0, sizeof rule);
    snprintf(rule.source, sizeof rule.source, "proposals");
    snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
 
    printf("  PASS: test_scan_proposals_requires_workspace_and_workflow\n");
@@ -859,7 +901,7 @@ static void test_scan_proposals_custom_event_and_schedule(void)
    snprintf(rule.event, sizeof rule.event, "rfcs");       /* custom scan dir */
    snprintf(rule.schedule, sizeof rule.schedule, "main"); /* custom branch */
 
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 1);
    assert(strcmp(g_lstree_ref, "main") == 0);          /* schedule used as ref */
    assert(strncmp(g_lstree_pathspec, "rfcs", 4) == 0); /* custom event dir */
@@ -885,7 +927,7 @@ static void test_scan_proposals_rejects_unsafe_ref_and_path(void)
    snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
    snprintf(rule.schedule, sizeof rule.schedule, "--all");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
    assert(g_lstree_ref[0] == '\0'); /* ls-tree never invoked */
 
@@ -896,16 +938,141 @@ static void test_scan_proposals_rejects_unsafe_ref_and_path(void)
    snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
    snprintf(rule.event, sizeof rule.event, "../../etc");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
    assert(g_lstree_ref[0] == '\0');
 
    /* An absolute scan dir is rejected. */
    snprintf(rule.event, sizeof rule.event, "/etc");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
 
    printf("  PASS: test_scan_proposals_rejects_unsafe_ref_and_path\n");
+}
+
+/* Filing wakes the autonomy driver once (parity with /v1/dev/submit); a pass
+ * that files nothing must not wake it. */
+static void test_scan_proposals_notifies_scheduler(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-notify-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# Proposal A\n");
+   g_nblobs = 1;
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+
+   scan_proposals(&rule, 0);
+   assert(g_ncreated == 1);
+   assert(g_notify_count == 1);
+
+   /* Re-scan: dedup files nothing -> no spurious wake. */
+   scan_proposals(&rule, 0);
+   assert(g_ncreated == 1);
+   assert(g_notify_count == 1);
+   printf("  PASS: test_scan_proposals_notifies_scheduler\n");
+}
+
+/* pipeline.max_spend_usd is applied to the filed run; a rule without one gets
+ * the intake default ($5, AIMEE_AUTONOMY_MAX_USD override, 0 disables). */
+static void test_scan_proposals_applies_cost_cap(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-cap-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# A\n");
+   snprintf(g_blobs[1].sha, sizeof g_blobs[1].sha, "fedcba9876543210fedcba9876543210fedcba98");
+   snprintf(g_blobs[1].content, sizeof g_blobs[1].content, "# B\n");
+   snprintf(g_blobs[2].sha, sizeof g_blobs[2].sha, "2222222222222222222222222222222222222222");
+   snprintf(g_blobs[2].content, sizeof g_blobs[2].content, "# C\n");
+   g_nblobs = 3;
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+
+   /* Explicit rule cap wins. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+   rule.max_spend_usd = 1.25;
+   unsetenv("AIMEE_AUTONOMY_MAX_USD");
+   scan_proposals(&rule, 0);
+   assert(g_ncreated == 1);
+   assert(g_created[0].cost_cap == 1.25);
+
+   /* No rule cap -> the $5 intake default. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n");
+   rule.max_spend_usd = 0.0;
+   scan_proposals(&rule, 0);
+   assert(g_ncreated == 2);
+   assert(g_created[1].cost_cap == 5.0);
+
+   /* AIMEE_AUTONOMY_MAX_USD=0 disables the default cap. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
+   setenv("AIMEE_AUTONOMY_MAX_USD", "0", 1);
+   scan_proposals(&rule, 0);
+   unsetenv("AIMEE_AUTONOMY_MAX_USD");
+   assert(g_ncreated == 3);
+   assert(g_created[2].cost_cap == 0.0);
+
+   printf("  PASS: test_scan_proposals_applies_cost_cap\n");
+}
+
+/* trigger.max_concurrent caps concurrently-ACTIVE triggered runs; deferred
+ * proposals file on a later pass once a slot frees (dedup keys on the artifact
+ * path, so nothing is lost). */
+static void test_scan_proposals_enforces_max_concurrent(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-conc-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# A\n");
+   snprintf(g_blobs[1].sha, sizeof g_blobs[1].sha, "fedcba9876543210fedcba9876543210fedcba98");
+   snprintf(g_blobs[1].content, sizeof g_blobs[1].content, "# B\n");
+   snprintf(g_blobs[2].sha, sizeof g_blobs[2].sha, "2222222222222222222222222222222222222222");
+   snprintf(g_blobs[2].content, sizeof g_blobs[2].content, "# C\n");
+   g_nblobs = 3;
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
+            "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+
+   /* Three pending, cap 2 -> exactly two filed this pass. */
+   scan_proposals(&rule, 2);
+   assert(g_ncreated == 2);
+
+   /* Both still active -> the next pass files nothing. */
+   scan_proposals(&rule, 2);
+   assert(g_ncreated == 2);
+
+   /* One run completes -> a slot frees -> the deferred proposal files. */
+   snprintf(g_created[0].state, sizeof g_created[0].state, "accepted");
+   scan_proposals(&rule, 2);
+   assert(g_ncreated == 3);
+
+   printf("  PASS: test_scan_proposals_enforces_max_concurrent\n");
 }
 
 /* ------------------------------------------------------------------ */
@@ -955,6 +1122,9 @@ int main(void)
    test_scan_proposals_requires_workspace_and_workflow();
    test_scan_proposals_custom_event_and_schedule();
    test_scan_proposals_rejects_unsafe_ref_and_path();
+   test_scan_proposals_notifies_scheduler();
+   test_scan_proposals_applies_cost_cap();
+   test_scan_proposals_enforces_max_concurrent();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_trigger_e2e.c
+++ b/src/tests/test_trigger_e2e.c
@@ -171,9 +171,9 @@ int main(void)
    assert(n == 1);
    assert(strcmp(items[0].state, "active") == 0);
    assert(strcmp(items[0].mode, "autonomous") == 0);
-   assert(strcmp(items[0].repo, repo) == 0);            /* bound to the watched repo */
-   assert(strcmp(items[0].workflow_name, "e2e") == 0);  /* on the rule's workflow */
-   assert(items[0].work_item_max_cost_usd == 5.0);      /* default USD ceiling stamped */
+   assert(strcmp(items[0].repo, repo) == 0);           /* bound to the watched repo */
+   assert(strcmp(items[0].workflow_name, "e2e") == 0); /* on the rule's workflow */
+   assert(items[0].work_item_max_cost_usd == 5.0);     /* default USD ceiling stamped */
    /* The proposal was materialized under $AIMEE_HOME/triggers/proposals/. */
    char want_prefix[600];
    snprintf(want_prefix, sizeof want_prefix, "%s/triggers/proposals/", home);

--- a/src/tests/test_trigger_e2e.c
+++ b/src/tests/test_trigger_e2e.c
@@ -1,0 +1,241 @@
+/* test_trigger_e2e.c — end-to-end: a proposal committed under
+ * docs/proposals/pending/ in a REAL git repo is picked up by the proposals
+ * trigger (real git subprocesses, real materialization, real DB1 work-item
+ * store, real cost-cap stamping), filed as an autonomous work item bound to
+ * that repo, and driven to a TERMINAL state by the real autonomy scheduler +
+ * engine. Only the block executors are stubbed (the vtable seam every engine
+ * test uses) — everything between "a proposal appears in pending/" and
+ * "the workflow completed" is the production code path. */
+#include "wfe_test_home.h"
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "cJSON.h"
+#include "config.h"
+#include "db1.h"
+#include "log.h"
+#include "wfe_engine.h"
+#include "wfe_scheduler.h"
+#include "wfe_store.h"
+
+/* ---- stubs for trigger_scheduler.c symbols outside the proposals path ---- */
+
+int config_load(config_t *cfg)
+{
+   memset(cfg, 0, sizeof(*cfg));
+   return 0;
+}
+
+#include "skill_curator.h"
+int skill_curator_maybe(void)
+{
+   return 0;
+}
+
+#include "db1_trigger.h"
+int db1_trigger_insert(const char *id, const char *source, const char *event, const char *task,
+                       const char *workspace, const char *metadata)
+{
+   (void)id;
+   (void)source;
+   (void)event;
+   (void)task;
+   (void)workspace;
+   (void)metadata;
+   return 0;
+}
+int db1_trigger_status_set(const char *id, const char *status, const char *pipeline_id,
+                           const char *error)
+{
+   (void)id;
+   (void)status;
+   (void)pipeline_id;
+   (void)error;
+   return 0;
+}
+
+#include "pipelines.h"
+int db1_pipeline_create(const char *task, const char *request_classification,
+                        const char *plan_depth, int *out_id)
+{
+   (void)task;
+   (void)request_classification;
+   (void)plan_depth;
+   if (out_id)
+      *out_id = 1;
+   return 0;
+}
+int db1_pipeline_cancel(int pipeline_id)
+{
+   (void)pipeline_id;
+   return 0;
+}
+
+int platform_random_bytes(void *buf, size_t len)
+{
+   memset(buf, 0x42, len);
+   return 0;
+}
+
+#include "db1/db1_cron_jobs.h"
+int db1_cron_jobs_load(cron_job_t *out, int max, int enabled_only)
+{
+   (void)out;
+   (void)max;
+   (void)enabled_only;
+   return 0;
+}
+
+int cron_run_config_job(const cron_job_t *job, cJSON **out_resp)
+{
+   (void)job;
+   (void)out_resp;
+   return 0;
+}
+
+/* Pull in the REAL scan_proposals (static) with the real git capture path. */
+#include "../server/trigger_scheduler.c"
+
+/* ---- helpers ---- */
+
+static int sh(const char *fmt, ...)
+{
+   char cmd[2048];
+   va_list ap;
+   va_start(ap, fmt);
+   vsnprintf(cmd, sizeof cmd, fmt, ap);
+   va_end(ap);
+   return system(cmd);
+}
+
+/* A two-step workflow: normalize the proposal, then author the plan. Terminal
+ * after `plan` advances (no next edge). */
+static const char *WF = "name: e2e\n"
+                        "start: draft\n"
+                        "nodes:\n"
+                        "  - id: draft\n"
+                        "    block: author.proposal\n"
+                        "    next: plan\n"
+                        "    on_fail: draft\n"
+                        "  - id: plan\n"
+                        "    block: author.plan\n"
+                        "    in:\n"
+                        "      proposal: draft.out\n";
+
+int main(void)
+{
+   printf("trigger-e2e: ");
+
+   /* AIMEE_HOME with the workflow definition. */
+   char home[] = "/tmp/wfe_te_home_XXXXXX";
+   assert(wfe_test_mkdtemp(home));
+   char path[512];
+   snprintf(path, sizeof path, "%s/workflows", home);
+   mkdir(path, 0755);
+   snprintf(path, sizeof path, "%s/workflows/e2e.yaml", home);
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(WF, f);
+   fclose(f);
+   setenv("AIMEE_HOME", home, 1);
+   unsetenv("AIMEE_AUTONOMY_MAX_USD"); /* assert the default $5 cap below */
+   assert(db1_init(":memory:") == 0);
+
+   /* A real git repo with a pending proposal committed on its default branch. */
+   char repo[] = "/tmp/wfe_te_repo_XXXXXX";
+   assert(wfe_test_mkdtemp(repo));
+   assert(sh("cd %s && git init -q && git config user.email t@t && git config user.name t && "
+             "git config commit.gpgsign false && mkdir -p docs/proposals/pending && "
+             "printf '# Add /healthz\\n\\nReturn {status:ok}.\\n' > "
+             "docs/proposals/pending/add-healthz.md && "
+             "git add -A && git commit -qm 'proposal: add /healthz'",
+             repo) == 0);
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "%s", repo);
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "e2e");
+   /* event/schedule/mode empty: default dir, auto-detected ref, autonomous. */
+
+   /* --- the trigger picks the proposal up --- */
+   scan_proposals(&rule, 2);
+
+   db1_work_item_t *items = NULL;
+   int n = db1_work_item_list(&items);
+   assert(n == 1);
+   assert(strcmp(items[0].state, "active") == 0);
+   assert(strcmp(items[0].mode, "autonomous") == 0);
+   assert(strcmp(items[0].repo, repo) == 0);            /* bound to the watched repo */
+   assert(strcmp(items[0].workflow_name, "e2e") == 0);  /* on the rule's workflow */
+   assert(items[0].work_item_max_cost_usd == 5.0);      /* default USD ceiling stamped */
+   /* The proposal was materialized under $AIMEE_HOME/triggers/proposals/. */
+   char want_prefix[600];
+   snprintf(want_prefix, sizeof want_prefix, "%s/triggers/proposals/", home);
+   assert(strncmp(items[0].proposal_path, want_prefix, strlen(want_prefix)) == 0);
+   f = fopen(items[0].proposal_path, "rb");
+   assert(f);
+   char body[256] = {0};
+   size_t rd = fread(body, 1, sizeof body - 1, f);
+   fclose(f);
+   assert(rd > 0 && strstr(body, "# Add /healthz") == body);
+   char id[80];
+   snprintf(id, sizeof id, "%s", items[0].work_item_id);
+   free(items);
+
+   /* --- the autonomy scheduler completes the workflow --- */
+   wfe_reset_block_executors();
+   wfe_register_stub_executors();
+   wfe_scheduler_run_once();
+
+   db1_work_item_t done;
+   assert(db1_work_item_get(id, &done) == 1);
+   assert(strcmp(done.state, "accepted") == 0); /* ran draft -> plan -> terminal */
+
+   /* The audit log shows the full run: create, draft->plan advance, terminal. */
+   db1_lifecycle_event_t *evs = NULL;
+   int nev = db1_lifecycle_event_list(id, &evs);
+   assert(nev >= 3);
+   int advances = 0, terminals = 0;
+   for (int i = 0; i < nev; i++)
+   {
+      if (strcmp(evs[i].kind, "advance") == 0)
+         advances++;
+      if (strcmp(evs[i].kind, "terminal") == 0)
+         terminals++;
+   }
+   free(evs);
+   assert(advances >= 1 && terminals == 1);
+
+   /* --- a re-scan of the same tree files nothing (dedup), including for the
+    *     now-completed proposal: done work is never re-run --- */
+   scan_proposals(&rule, 2);
+   items = NULL;
+   assert(db1_work_item_list(&items) == 1);
+   free(items);
+
+   /* --- a NEW proposal on the branch files a second run --- */
+   assert(sh("cd %s && printf '# Second\\n' > docs/proposals/pending/second.md && "
+             "git add -A && git commit -qm 'proposal: second'",
+             repo) == 0);
+   scan_proposals(&rule, 2);
+   items = NULL;
+   n = db1_work_item_list(&items);
+   assert(n == 2);
+   free(items);
+   wfe_scheduler_run_once();
+   items = NULL;
+   n = db1_work_item_list(&items);
+   assert(n == 2);
+   for (int i = 0; i < n; i++)
+      assert(strcmp(items[i].state, "accepted") == 0);
+   free(items);
+
+   printf("ok (proposal -> trigger -> autonomous run -> accepted, x2)\n");
+   return 0;
+}

--- a/src/tests/test_wfe_blocks.c
+++ b/src/tests/test_wfe_blocks.c
@@ -48,6 +48,20 @@ int main(void)
    assert(wfe_lookup_block_executor(WFE_BLK_PR_OPEN));
    assert(wfe_lookup_block_executor(WFE_BLK_MERGE));
 
+   /* --- wfe_repo_local: the work item's repo wins when it names a local dir --- */
+   {
+      unsetenv("AIMEE_WORKFLOW_REPO");
+      assert(strcmp(wfe_repo_local("/tmp"), "/tmp") == 0);        /* local dir -> itself */
+      assert(strcmp(wfe_repo_local("/no/such/dir-x"), ".") == 0); /* absent -> env/cwd */
+      assert(strcmp(wfe_repo_local("org/repo"), ".") == 0);       /* identifier -> env/cwd */
+      assert(strcmp(wfe_repo_local(""), ".") == 0);
+      assert(strcmp(wfe_repo_local(NULL), ".") == 0);
+      setenv("AIMEE_WORKFLOW_REPO", "/srv/shared", 1);
+      assert(strcmp(wfe_repo_local("/tmp"), "/tmp") == 0); /* per-item repo still wins */
+      assert(strcmp(wfe_repo_local("org/repo"), "/srv/shared") == 0);
+      unsetenv("AIMEE_WORKFLOW_REPO");
+   }
+
    /* --- wfe_git_freeze against a real temp git repo --- */
    char dir[] = "/tmp/wfe_repo_XXXXXX";
    if (!wfe_test_mkdtemp(dir))

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -24,8 +24,7 @@ static void wfe_autonomy_cleanup_worktree(const char *work_item_id)
    db1_work_item_t wi;
    if (db1_work_item_get(work_item_id, &wi) != 1 || !wi.worktree[0])
       return;
-   const char *rl = getenv("AIMEE_WORKFLOW_REPO");
-   if (wfe_worktree_cleanup(wi.worktree, (rl && rl[0]) ? rl : ".") == 0)
+   if (wfe_worktree_cleanup(wi.worktree, wfe_repo_local(wi.repo)) == 0)
       db1_work_item_set_worktree(work_item_id, "");
 }
 

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -41,11 +41,12 @@ static const char *repo_dir(void)
  * into `buf`; never empty. */
 static void resolve_workdir(wfe_ctx *ctx, char *buf, size_t n)
 {
-   if (wfe_worktree_ensure(wfe_ctx_work_item(ctx), wfe_ctx_worktree(ctx), repo_dir(),
+   const char *repo = wfe_repo_local(wfe_ctx_repo(ctx));
+   if (wfe_worktree_ensure(wfe_ctx_work_item(ctx), wfe_ctx_worktree(ctx), repo,
                            wfe_autonomous_base(), buf, n) != 0)
-      snprintf(buf, n, "%s", repo_dir()); /* fall back to the shared checkout */
-   if (!buf[0])                           /* guarantee a non-empty workdir for every caller */
-      snprintf(buf, n, "%s", repo_dir());
+      snprintf(buf, n, "%s", repo); /* fall back to the shared checkout */
+   if (!buf[0])                     /* guarantee a non-empty workdir for every caller */
+      snprintf(buf, n, "%s", repo);
 }
 
 static int git_capture(const char *const argv[], char **out)

--- a/src/workflow/wfe_iface.c
+++ b/src/workflow/wfe_iface.c
@@ -5,7 +5,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h> /* strcasecmp / strncasecmp */
+#include <strings.h>  /* strcasecmp / strncasecmp */
+#include <sys/stat.h> /* stat — wfe_repo_local dir check */
+
+/* ---- per-work-item repo resolution (see wfe_iface.h) ---- */
+
+const char *wfe_repo_local(const char *wi_repo)
+{
+   /* The work item's own repo binds the run to its repository (a trigger rule's
+    * pipeline.workspace, or an explicit dev-submit repo) — honor it whenever it
+    * names a local directory. Anything else (an identifier/URL, or "") falls back
+    * to the process-wide $AIMEE_WORKFLOW_REPO, then cwd, preserving
+    * single-repo deployments unchanged. */
+   if (wi_repo && wi_repo[0] == '/')
+   {
+      struct stat st;
+      if (stat(wi_repo, &st) == 0 && S_ISDIR(st.st_mode))
+         return wi_repo;
+   }
+   const char *d = getenv("AIMEE_WORKFLOW_REPO");
+   return (d && d[0]) ? d : ".";
+}
 
 /* ---- autonomous merge-target rail (WP-5 safety; see wfe_iface.h) ---- */
 

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -155,6 +155,15 @@ typedef enum
 } wfe_failure_disposition_t;
 wfe_failure_disposition_t wfe_failure_disposition(wfe_failure_class_t cls, int has_new_input);
 
+/* Resolve the local working repo for a work item from its stored `repo` column:
+ * the repo itself when it names a local directory (a trigger rule's
+ * pipeline.workspace binds the run to that repository), else the process-wide
+ * $AIMEE_WORKFLOW_REPO, else cwd. Every per-work-item repo consumer (block
+ * executors, roundtable workdir, worktree cleanup) resolves through this so a
+ * run filed against a specific workspace executes there, not wherever the
+ * server process happens to sit. */
+const char *wfe_repo_local(const char *wi_repo);
+
 /* ---- Autonomous merge-target rail (WP-5 safety) ----
  * The single source of truth for the branch an autonomous run may target for a
  * PR/merge. Autonomous merges only ever go to this branch (default "testing");

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -125,12 +125,12 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
    /* The directory the panel reviews the change in: the per-work-item worktree, or —
     * when worktree isolation is unavailable and a run fell back to the shared checkout
     * (wfe_worktree_ensure failed) — that shared repo dir. Mirrors the producing blocks'
-    * resolve_workdir fallback (AIMEE_WORKFLOW_REPO, else "."), so the panel can always
-    * convene rather than fail closed to panel_unreachable when the worktree is empty. */
+    * resolve_workdir fallback (the work item's own repo, else AIMEE_WORKFLOW_REPO, else
+    * "."), so the panel convenes in the run's repository rather than fail closed to
+    * panel_unreachable when the worktree is empty. */
    const char *worktree = wfe_ctx_worktree(ctx);
-   const char *workdir = (worktree && worktree[0]) ? worktree : getenv("AIMEE_WORKFLOW_REPO");
-   if (!workdir || !workdir[0])
-      workdir = ".";
+   const char *workdir =
+       (worktree && worktree[0]) ? worktree : wfe_repo_local(wfe_ctx_repo(ctx));
 
    /* Push the change under review to the panel: the branch diff vs the autonomous
     * base ("what changed from the default repo"). Computed once here so panelists

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -129,8 +129,7 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
     * "."), so the panel convenes in the run's repository rather than fail closed to
     * panel_unreachable when the worktree is empty. */
    const char *worktree = wfe_ctx_worktree(ctx);
-   const char *workdir =
-       (worktree && worktree[0]) ? worktree : wfe_repo_local(wfe_ctx_repo(ctx));
+   const char *workdir = (worktree && worktree[0]) ? worktree : wfe_repo_local(wfe_ctx_repo(ctx));
 
    /* Push the change under review to the panel: the branch diff vs the autonomous
     * base ("what changed from the default repo"). Computed once here so panelists


### PR DESCRIPTION
## What

Finishes the `source: proposals` trigger so a proposal in a watched repo's `docs/proposals/pending/` is picked up and driven through its workflow end-to-end, closing the four gaps between the trigger intake and the `/v1/dev/submit` intake:

- **Scheduler wake**: `scan_proposals` now calls `wfe_scheduler_notify()` after filing, so a triggered run starts immediately instead of on the 30s backstop sweep.
- **Spend cap**: `pipeline.max_spend_usd` is applied to the filed run; a rule without one gets the same $5 default (`AIMEE_AUTONOMY_MAX_USD`) as every other autonomous intake — a triggered run is no longer the one uncapped path.
- **`trigger.max_concurrent`**: enforced at filing time. Excess proposals defer (dedup keys on the materialized artifact, so nothing is lost) and file once a slot frees.
- **Per-work-item repo resolution** (docs limitation #2): block executors, the roundtable workdir, and worktree cleanup resolve the work item's own `repo` via new `wfe_repo_local()` (the stored repo when it names a local directory, else `$AIMEE_WORKFLOW_REPO`, else cwd), so a run filed against a `pipeline.workspace` executes in that repository. Forge ops (`git push`/`gh` via the vaulted runner) remain process-global; docs updated to say exactly that.

## Tests

- `unit-test-trigger`: three new cases — scheduler notify (incl. no spurious wake on a dedup-only pass), cost-cap stamping (rule cap / $5 default / env-disabled), and max_concurrent admission (defer + file-on-freed-slot).
- **New `unit-test-trigger-e2e`**: hermetic end-to-end with the REAL pipeline — a proposal committed in a real git repo → real `scan_proposals` (real git subprocesses) → real DB1 work item bound to that repo with the default cap stamped → real autonomy scheduler + engine drive it to terminal `accepted`; re-scan dedups (a completed proposal never re-runs); a second proposal files and completes. Only the block executors are stubbed.
- All 34 `unit-test-wfe-*` binaries pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)