### PR TITLE
fix(server): quote the tmux pane command in cli_session_create

### DIFF
--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -383,20 +383,27 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
     * them and the pane exits instantly ("failed to send prompt to tmux
     * session"). A non-login shell inherits the tmux server's env (= aimee-
     * server's, which carries the image PATH), so the CLI resolves. */
+   /* shell_escape() only escapes embedded single quotes; the caller supplies the
+    * surrounding '...'. Leaving them off worked only while cli_cmd was a single
+    * word ("claude"): a multi-word command (the AIMEE_SESSION_ID=<sid> stamp, or
+    * --model/--dangerously-skip-permissions flags) gets word-split by the outer
+    * shell, tmux re-joins the pieces, and the pane's `sh -c` ends up executing
+    * just the leading env assignment — exiting 0 instantly and taking the tmux
+    * server down with it ("failed to send prompt to tmux session"). */
    char create_cmd[1024];
    char *esc_cli = shell_escape(cli_cmd && cli_cmd[0] ? cli_cmd : "claude");
    if (work_dir && work_dir[0])
    {
       char *esc_dir = shell_escape(work_dir);
       snprintf(create_cmd, sizeof(create_cmd),
-               "tmux new-session -d -s '%s' -x 220 -y 50 -c %s /bin/sh -c %s 2>/dev/null",
+               "tmux new-session -d -s '%s' -x 220 -y 50 -c '%s' /bin/sh -c '%s' 2>/dev/null",
                session_name, esc_dir, esc_cli);
       free(esc_dir);
    }
    else
    {
       snprintf(create_cmd, sizeof(create_cmd),
-               "tmux new-session -d -s '%s' -x 220 -y 50 /bin/sh -c %s 2>/dev/null", session_name,
+               "tmux new-session -d -s '%s' -x 220 -y 50 /bin/sh -c '%s' 2>/dev/null", session_name,
                esc_cli);
    }
    free(esc_cli);

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -31,6 +31,11 @@ static long long test_mono_ms(void)
    return (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
+/* Path the fake tmux appends every `new-session` argv element to (one per
+ * line, bracketed), so the create test can assert the pane command reached
+ * tmux as a single intact argument rather than word-split fragments. */
+static char g_createlog[300];
+
 /* Path the fake tmux appends every `send-keys` invocation to, so a test can
  * assert which interrupt key (if any) the cancel path sent. */
 static char g_sendlog[320];
@@ -42,6 +47,7 @@ static void install_fake_tmux(void)
    char counter[300];
    snprintf(counter, sizeof(counter), "%s/counter", g_fake_dir);
    snprintf(g_sendlog, sizeof(g_sendlog), "%s/sendlog", g_fake_dir);
+   snprintf(g_createlog, sizeof(g_createlog), "%s/createlog", g_fake_dir);
    char script[320];
    snprintf(script, sizeof(script), "%s/tmux", g_fake_dir);
    FILE *f = fopen(script, "w");
@@ -76,10 +82,11 @@ static void install_fake_tmux(void)
            "'\"$c\"' end';\n"
            "    else echo 'STATIC OUTPUT'; fi; exit 0 ;;\n"
            "  send-keys) shift; echo \"$*\" >> '%s'; exit 0 ;;\n"
+           "  new-session) shift; for a in \"$@\"; do echo \"ARG:[$a]\" >> '%s'; done; exit 0 ;;\n"
            "  *) exit 0 ;;\n"
            "esac\n",
            counter, counter, counter, counter, counter, counter, counter, counter, counter,
-           g_sendlog);
+           g_sendlog, g_createlog);
    fclose(f);
    assert(chmod(script, 0700) == 0);
 
@@ -107,6 +114,40 @@ static int sendlog_has(const char *needle)
    buf[n] = '\0';
    fclose(f);
    return strstr(buf, needle) != NULL;
+}
+
+/* True if the fake tmux new-session argv log contains `needle`. */
+static int createlog_has(const char *needle)
+{
+   FILE *f = fopen(g_createlog, "r");
+   if (!f)
+      return 0;
+   char buf[4096];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   return strstr(buf, needle) != NULL;
+}
+
+/* cli_session_create must hand tmux the pane command (and workdir) as ONE
+ * argument each. cli_cmd is multi-word in production (the AIMEE_SESSION_ID
+ * stamp, --model, --dangerously-skip-permissions): unquoted interpolation gets
+ * word-split by the outer shell, tmux re-joins the fragments, and the pane's
+ * `sh -c` executes only the leading env assignment — exiting 0 instantly and
+ * surfacing as "failed to send prompt to tmux session". */
+static void test_create_multiword_cli_cmd_single_arg(void)
+{
+   unlink(g_createlog);
+   cli_session_t s;
+   int rc = cli_session_create(&s, "aimee-quoting-test",
+                               "AIMEE_SESSION_ID=web-1 claude --dangerously-skip-permissions",
+                               "/tmp/aimee quoting wd", 0);
+   assert(rc == 0);
+   assert(createlog_has("ARG:[AIMEE_SESSION_ID=web-1 claude --dangerously-skip-permissions]"));
+   assert(createlog_has("ARG:[/tmp/aimee quoting wd]"));
+   /* No fragment may arrive as its own argument (the word-split regression). */
+   assert(!createlog_has("ARG:[AIMEE_SESSION_ID=web-1]"));
+   s.active = 0; /* fake tmux: no real session to tear down */
 }
 static void sendlog_reset(void)
 {
@@ -933,6 +974,10 @@ int main(void)
    printf("OK\n");
 
    install_fake_tmux();
+
+   printf("test_create_multiword_cli_cmd_single_arg... ");
+   test_create_multiword_cli_cmd_single_arg();
+   printf("OK\n");
 
    printf("test_recv_timeout_on_changing_pane... ");
    test_recv_timeout_on_changing_pane();


### PR DESCRIPTION
## Problem

Webchat chat turns against the tmux-CLI agent (claude) fail with:

> **Error:** server: failed to send prompt to tmux session

Debugged live on the SmoothNAS test appliance (aimee-server 0.2.188): the pane created for every chat turn died instantly with **status 0 and no output**, taking the tmux server down with it, so the subsequent `tmux load-buffer` failed and the turn errored.

## Root cause

`shell_escape()` only escapes embedded single quotes — the **caller** must supply the surrounding `'...'` — and `cli_session_create()` interpolated both the workdir and the pane command unquoted:

```
tmux new-session -d -s '%s' -x 220 -y 50 -c %s /bin/sh -c %s 2>/dev/null
```

This was harmless while the pane command was the single word `claude`. Since the S2 native-tool gate (#984) the command is stamped `AIMEE_SESSION_ID=<sid> claude ...`, making it multi-word: the outer shell word-splits it, tmux re-joins the fragments into one command string, and the pane's `sh -c` receives just `AIMEE_SESSION_ID=<sid>` (with `claude` as \$0) — a bare variable assignment that exits 0 instantly without ever launching the CLI. Captured directly from a dead pane on the appliance:

```
start=[/bin/sh -c AIMEE_SESSION_ID=1864dd2d-... claude]   pane_dead_status=0
```

`--model <m>` and `--dangerously-skip-permissions` trigger the same split.

## Fix

Quote the workdir and the pane command in both `new-session` variants (`-c '%s'` / `/bin/sh -c '%s'`).

## Testing

- New regression test `test_create_multiword_cli_cmd_single_arg`: the fake tmux logs `new-session` argv; asserts a multi-word cli_cmd and a workdir containing spaces each arrive as one intact argument, and that no word-split fragment arrives alone. Fails against the unfixed code, passes with the fix.
- Full `unit-test-cli-session` suite passes.
- Verified end-to-end on the appliance: the fixed (quoted) command form launches claude in the pane, the pasted prompt submits, and the reply streams back (`● PONG`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)