### PR TITLE
fix(agent): primary never self-delegates; claude-CLI delegate opt-in enforced routing-wide

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -38,6 +38,21 @@ int agent_any_delegate_available(void);
  * gains no link dependency on provider_catalog. */
 void agent_set_route_health_filter(int (*fn)(const char *agent_name));
 
+/* Optional route-time delegate-POLICY filter, same mechanism as the health
+ * filter (returns nonzero to EXCLUDE the agent; NULL disables). The server
+ * registers a live-config predicate enforcing two invariants everywhere
+ * routing happens, not just on one dispatch path:
+ *   1) the PRIMARY passthrough — the agent named after config.provider — is
+ *      never a delegation target (the primary must not delegate back to
+ *      itself; roundtables already enforce this for panel seats);
+ *   2) a claude-CLI agent is a delegate only behind the explicit ToS-sensitive
+ *      operator opt-in (claude_cli_delegate_enabled).
+ * The structural half of (2) — a claude-CLI agent that is not server-hosted
+ * can never execute as a delegate — is enforced unconditionally in
+ * agent_is_available_for_routing, so even filter-less builds (CLI/tests) never
+ * route to a client-only claude. */
+void agent_set_route_policy_filter(int (*fn)(const agent_t *agent));
+
 int agent_has_role(const agent_t *agent, const char *role);
 int agent_supports_persona(const agent_t *agent, const char *persona);
 int agent_is_exec_role(const agent_t *agent, const char *role);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1284,6 +1284,14 @@ void agent_set_route_health_filter(int (*fn)(const char *agent_name))
    g_route_health_filter = fn;
 }
 
+/* Optional route-time delegate-policy filter; see agent_set_route_policy_filter. */
+static int (*g_route_policy_filter)(const agent_t *agent) = NULL;
+
+void agent_set_route_policy_filter(int (*fn)(const agent_t *agent))
+{
+   g_route_policy_filter = fn;
+}
+
 int agent_is_available_for_routing(const agent_t *agent)
 {
    if (!agent)
@@ -1294,6 +1302,16 @@ int agent_is_available_for_routing(const agent_t *agent)
     * healthy peer; routing returns NULL (clean "no agent" error) only when
     * every candidate is filtered out. */
    if (g_route_health_filter && agent->name[0] && g_route_health_filter(agent->name))
+      return 0;
+   /* A claude-CLI agent can only ever execute as a delegate SERVER-SIDE (a
+    * client-only claude has no server session to drive — dispatch would just
+    * fail). Structural, so it is enforced even with no policy filter
+    * registered; the config-dependent rules (the claude_cli_delegate_enabled
+    * ToS opt-in, primary self-delegation) live in the registered policy
+    * filter, which sees the live config. */
+   if (agent_is_claude_cli(agent) && !agent->is_server_hosted)
+      return 0;
+   if (g_route_policy_filter && g_route_policy_filter(agent))
       return 0;
    if (strcmp(agent->backend, AGENT_BACKEND_TMUX_CLI) == 0)
    {

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1835,6 +1835,33 @@ static int server_agent_route_is_down(const char *agent_name)
    return provider_catalog_get_health(agent_name) == CATALOG_HEALTH_DOWN;
 }
 
+/* Route-time delegate-policy predicate (returns nonzero to EXCLUDE):
+ * 1) the primary passthrough — the agent named after config.provider — is
+ *    never a delegation target: the primary must not delegate back to itself
+ *    (observed in the wild as a streak of failed 'code' delegations to the
+ *    operator's own OAuth claude entry). Matched by NAME only, deliberately:
+ *    other agents that merely share the provider tag (e.g. gateway-routed
+ *    anthropic models) are legitimate delegates.
+ * 2) a claude-CLI agent (tmux/provider-cli claude — the interactive-login
+ *    ToS-sensitive class) is a delegate ONLY behind the explicit operator
+ *    opt-in claude_cli_delegate_enabled — previously enforced on one dispatch
+ *    path and on panel seats, now at every routing decision.
+ * A config_load failure fails closed for the gated class (a claude-CLI agent
+ * is excluded, everything else routes) rather than voiding the opt-in. */
+static int server_agent_route_policy_excluded(const agent_t *ag)
+{
+   if (!ag)
+      return 1;
+   config_t cfg;
+   if (config_load(&cfg) != 0)
+      return agent_is_claude_cli(ag);
+   if (cfg.provider[0] && ag->name[0] && strcasecmp(ag->name, cfg.provider) == 0)
+      return 1;
+   if (agent_is_claude_cli(ag) && !cfg.claude_cli_delegate_enabled)
+      return 1;
+   return 0;
+}
+
 /* Production agent-name resolver for the vault bootstrap: validate against
  * agents.json and return the canonical agent name. agent_load_config is cached,
  * so the per-secret calls are cheap. */
@@ -2016,6 +2043,10 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * delegates. Routing falls back to a healthy peer; only when every candidate
     * for a role is DOWN does routing return a clean "no agent available". */
    agent_set_route_health_filter(server_agent_route_is_down);
+   /* Delegate-policy invariants at every routing decision: the primary never
+    * delegates to itself, and a claude-CLI agent is only a delegate behind the
+    * explicit claude_cli_delegate_enabled opt-in. */
+   agent_set_route_policy_filter(server_agent_route_policy_excluded);
    LOG_INFO("server",
             "initialized (v%s, protocol %d, background=%d session=%d threads); /v1 HTTP "
             "surface owns the listeners",

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -173,6 +173,59 @@ static void test_agent_find(void)
    assert(agent_find(&cfg, "missing") == NULL);
 }
 
+/* Route-time delegate-policy filter (the server registers a live-config
+ * predicate; here a test double): an excluded agent is never routed, even when
+ * it is the preferred default agent — the primary must not delegate to itself. */
+static int test_policy_exclude_primary(const agent_t *ag)
+{
+   return strcmp(ag->name, "primary") == 0;
+}
+
+static void test_agent_route_policy_filter(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 2;
+   strcpy(cfg.default_agent, "primary");
+   strcpy(cfg.agents[0].name, "primary");
+   strcpy(cfg.agents[0].roles[0], "summarize");
+   cfg.agents[0].role_count = 1;
+   cfg.agents[0].cost_tier = 0;
+   cfg.agents[0].enabled = 1;
+   strcpy(cfg.agents[1].name, "peer");
+   strcpy(cfg.agents[1].roles[0], "summarize");
+   cfg.agents[1].role_count = 1;
+   cfg.agents[1].cost_tier = 1;
+   cfg.agents[1].enabled = 1;
+
+   /* Baseline: the default agent is preferred. */
+   assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
+
+   /* With the policy filter registered, the excluded agent is unroutable
+    * EVERYWHERE — including as the preferred default — and routing falls back
+    * to the peer. */
+   agent_set_route_policy_filter(test_policy_exclude_primary);
+   assert(agent_is_available_for_routing(&cfg.agents[0]) == 0);
+   assert(agent_route(&cfg, "summarize") == &cfg.agents[1]);
+   agent_set_route_policy_filter(NULL);
+   assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
+}
+
+/* Structural rule (no filter needed): a claude-CLI agent that is not
+ * server-hosted has no server session to drive — it can never be a delegate,
+ * so routing refuses it before any PATH/credential probing. */
+static void test_agent_route_client_only_claude_excluded(void)
+{
+   agent_t a;
+   memset(&a, 0, sizeof(a));
+   strcpy(a.name, "claude");
+   strcpy(a.cli_kind, "claude");
+   strcpy(a.backend, AGENT_BACKEND_TMUX_CLI);
+   a.enabled = 1;
+   a.is_server_hosted = 0;
+   assert(agent_is_available_for_routing(&a) == 0);
+}
+
 static void test_agent_route(void)
 {
    agent_config_t cfg;
@@ -592,7 +645,11 @@ static void test_agent_config_provider_cli_roundtrip(void)
    assert(strcmp(loaded.agents[5].cli_kind, "claude-code") == 0);
    assert(strcmp(loaded.agents[5].cli_cmd, "/bin/echo") == 0);
    assert(loaded.agents[5].session_reuse == 1);
-   assert(agent_is_available_for_routing(&loaded.agents[5]) == 1);
+   /* A claude-CLI agent that is NOT server-hosted (no `is_server_hosted` in its
+    * record) is structurally excluded from delegate routing: a client-only
+    * claude has no server session to drive, so dispatch could only fail. This
+    * short-circuits before any tmux/PATH probing, so it holds everywhere. */
+   assert(agent_is_available_for_routing(&loaded.agents[5]) == 0);
 
    assert(agent_save_config(&loaded) == 0);
 
@@ -631,7 +688,8 @@ static void test_agent_config_provider_cli_roundtrip(void)
    assert(strcmp(reloaded.agents[5].cli_kind, "claude-code") == 0);
    assert(strcmp(reloaded.agents[5].cli_cmd, "/bin/echo") == 0);
    assert(reloaded.agents[5].session_reuse == 1);
-   assert(agent_is_available_for_routing(&reloaded.agents[5]) == 1);
+   /* Still excluded after the save/reload roundtrip (see the load-side assert). */
+   assert(agent_is_available_for_routing(&reloaded.agents[5]) == 0);
 
    if (old_path)
    {
@@ -2326,6 +2384,8 @@ int main(void)
    test_agent_supports_persona();
    test_agent_find();
    test_agent_route();
+   test_agent_route_policy_filter();
+   test_agent_route_client_only_claude_excluded();
    test_agent_route_with_caps_honors_tools_enabled();
    test_agent_route_with_caps_honors_context_override();
    test_current_code_only_role_tool_policy();


### PR DESCRIPTION
## What

User-observed: repeated failed `code` delegations to the operator's own server-hosted OAuth claude entry, on a box where `claude_cli_delegate_enabled` is unset. Root causes:

1. The claude-CLI delegate authorization gate (`claude_cli_delegate_enabled` + `is_server_hosted`) was enforced on only one dispatch path and on roundtable seats — the general routing layer never consulted it.
2. `agent_route` prefers the default agent, so the primary's own entry was the first pick for every role it advertises — the primary delegating back to itself.

## Fix

Both invariants now live where every routing decision funnels (`agent_is_available_for_routing`):

- **Structural**: a claude-CLI agent that is not server-hosted is never routable as a delegate (a client-only claude has no server session to drive; dispatch could only fail).
- **Policy filter** (registered by the server alongside the route-health filter, so `agent_config.o` gains no new link dependency): the primary passthrough (agent named after `config.provider`) is never a delegation target, and claude-CLI agents route as delegates only behind the explicit ToS-sensitive `claude_cli_delegate_enabled` opt-in. Name-match only, deliberately — other agents sharing a provider tag (gateway-routed models) remain legitimate delegates.

## Tests

- New: policy filter excludes the preferred default agent from routing (and restores on unregister); client-only claude structurally excluded.
- Updated: the provider-cli roundtrip now asserts the exclusion for a non-server-hosted claude-code tmux agent (was asserting routability).
- `unit-test-agent`, `unit-test-delegate-ensemble`, `unit-test-roundtable-seat-resolve` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)