### PR TITLE
refactor(trigger): generic trigger-source registry + one intake cost-cap policy

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -285,6 +285,17 @@ appears in a repo, a schedule elapses, a webhook arrives) or a person (clicking
 set of generic trigger sources that you wire to whatever workflow you want —
 the trigger starts the run; what happens next is entirely the workflow's design.
 
+Sources are a registry in
+[src/server/trigger_scheduler.c](../src/server/trigger_scheduler.c): each entry
+is `{name, due, fire}` — `due` decides whether this tick should fire (a repo
+scanner polls every pass; cron matches its schedule), `fire` matches events and
+materializes artifacts, and files each run through the shared
+`trigger_file_run` back half (work item on the rule's pipeline + workspace +
+mode, per-run USD ceiling from `max_spend_usd` or the intake-wide default,
+audit log line). The tick loop owns the rest — per-rule rate limiting and the
+global `trigger.max_concurrent` — so adding a source is one table row plus its
+`fire`.
+
 Triggers are configured as a `trigger_rules` list in `aimee.yaml`. Each rule
 names a **source** (what fires it), how the filed run should execute (**mode**),
 and the **pipeline** (which workflow, in which repo):

--- a/src/server/server_dev_submit.c
+++ b/src/server/server_dev_submit.c
@@ -7,11 +7,11 @@
 #include "cJSON.h"
 #include "aimee_home.h"    /* aimee_home */
 #include "router_advise.h" /* router_autonomous_pick / router_autonomous_audit */
+#include "wfe_autonomy.h"  /* wfe_autonomy_default_max_cost_usd — shared intake cap policy */
 #include "wfe_engine.h"    /* wfe_work_item_resolve */
 #include "wfe_scheduler.h" /* wfe_scheduler_notify */
 #include "wfe_store.h"     /* db1_work_item_submit_capped / _set_terminal / _set_cost_cap */
 #include <errno.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -168,18 +168,11 @@ int dev_submit_run(const char *proposal_md, const char *workflow_opt, const char
       router_autonomous_audit(id, workflow, autoroute_src, autoroute_raw, autoroute_clamped,
                               autoroute_tag);
    /* WP-5: a per-run USD budget ceiling so a runaway autonomous run parks
-    * (budget_exceeded) instead of burning unbounded delegate cost. Default $5.00;
-    * AIMEE_AUTONOMY_MAX_USD overrides (set it to 0 to disable the cap). */
+    * (budget_exceeded) instead of burning unbounded delegate cost. The default
+    * policy ($5.00, AIMEE_AUTONOMY_MAX_USD override, 0 disables) is shared with
+    * every other autonomous intake (wfe_autonomy_default_max_cost_usd). */
    {
-      double cap_usd = 5.0;
-      const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
-      if (v && v[0])
-      {
-         char *e = NULL;
-         double d = strtod(v, &e);
-         if (e && *e == '\0' && isfinite(d) && d >= 0) /* reject inf/NaN: would void the cap */
-            cap_usd = d;
-      }
+      double cap_usd = wfe_autonomy_default_max_cost_usd();
       if (cap_usd > 0)
          db1_work_item_set_cost_cap(id, cap_usd);
    }

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -20,6 +20,7 @@
 #include "skill_curator.h"
 #include "trigger_scheduler.h"
 #include "util.h"
+#include "wfe_autonomy.h" /* wfe_autonomy_default_max_cost_usd — the shared intake cap policy */
 #include "wfe_engine.h"
 #include "wfe_scheduler.h" /* wfe_scheduler_notify — drive a filed run now, not on the 30s sweep */
 
@@ -443,24 +444,47 @@ static int trigger_write_atomic(const char *path, const char *bytes)
 }
 
 /* The per-run USD ceiling for a trigger-filed run: the rule's explicit
- * pipeline.max_spend_usd when set (> 0), else the same default every autonomous
- * intake applies ($5.00, AIMEE_AUTONOMY_MAX_USD override, 0 disables) — a
- * trigger-filed run must never be the one intake path with NO runaway cost cap.
- * Mirrors dev_submit_run (server_dev_submit.c). Returns 0 for "no cap". */
+ * pipeline.max_spend_usd when set (> 0), else the intake-wide default policy
+ * (wfe_autonomy_default_max_cost_usd, shared with /v1/dev/submit) — a
+ * trigger-filed run must never be the one intake path with NO runaway cost
+ * cap. Returns 0 for "no cap". */
 static double trigger_cost_cap(const trigger_rule_t *rule)
 {
    if (rule->max_spend_usd > 0 && isfinite(rule->max_spend_usd))
       return rule->max_spend_usd;
-   double cap_usd = 5.0;
-   const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
-   if (v && v[0])
+   return wfe_autonomy_default_max_cost_usd();
+}
+
+/* File one run for a materialized trigger artifact — the shared back half of
+ * every artifact-producing trigger source: create the work item on the rule's
+ * pipeline (in the rule's workspace, with the rule's mode), stamp the per-run
+ * USD ceiling, and log the outcome. `what` labels the artifact in logs (e.g.
+ * "sha=<blob>"). De-duplication is the SOURCE's job — each source knows its
+ * own identity key; this helper is pure filing. Returns 0 filed (out_id set),
+ * -1 refused/failed. */
+static int trigger_file_run(const trigger_rule_t *rule, const char *artifact_path, const char *what,
+                            char out_id[80])
+{
+   char err[256] = "";
+   out_id[0] = '\0';
+   /* mode drives whether the autonomy scheduler advances the run hands-off
+    * ("autonomous", the default when the rule omits it) or the item parks for
+    * a human to drive in the webchat ("interactive"). */
+   const char *mode = rule->mode[0] ? rule->mode : "autonomous";
+   if (wfe_work_item_create(rule->pipeline_template, rule->workspace, artifact_path, mode, out_id,
+                            err, sizeof(err)) != 0 ||
+       !out_id[0])
    {
-      char *e = NULL;
-      double d = strtod(v, &e);
-      if (e && *e == '\0' && isfinite(d) && d >= 0) /* reject inf/NaN: would void the cap */
-         cap_usd = d;
+      aimee_log(LOG_WARN, "trigger.sched", "%s: create skipped/failed repo=%s %s: %s", rule->source,
+                rule->workspace, what, err[0] ? err : "already exists");
+      return -1;
    }
-   return cap_usd;
+   double cap = trigger_cost_cap(rule);
+   if (cap > 0)
+      db1_work_item_set_cost_cap(out_id, cap);
+   aimee_log(LOG_INFO, "trigger.sched", "filed run workflow=%s repo=%s %s id=%s",
+             rule->pipeline_template, rule->workspace, what, out_id);
+   return 0;
 }
 
 /* Count ACTIVE work items that were filed by the proposals trigger (their
@@ -624,30 +648,14 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
       }
       free(blob);
 
-      char id[80] = "", err[256] = "";
-      /* mode drives whether the autonomy scheduler advances the run hands-off
-       * ("autonomous", the default when the rule omits it) or the item parks for
-       * a human to drive in the webchat ("interactive"). */
-      const char *mode = rule->mode[0] ? rule->mode : "autonomous";
-      rc = wfe_work_item_create(rule->pipeline_template, rule->workspace, proposal_path, mode, id,
-                                err, sizeof(err));
-      if (rc == 0 && id[0])
+      char what[64], id[80];
+      snprintf(what, sizeof(what), "sha=%s", entries[i].sha);
+      if (trigger_file_run(rule, proposal_path, what, id) == 0)
       {
-         /* Per-run USD ceiling (rule's max_spend_usd, else the intake default) so
-          * a triggered run parks budget_exceeded instead of burning unbounded
-          * delegate cost. Best-effort, mirroring dev_submit_run. */
-         double cap = trigger_cost_cap(rule);
-         if (cap > 0)
-            db1_work_item_set_cost_cap(id, cap);
          filed++;
          if (budget > 0)
             budget--;
-         aimee_log(LOG_INFO, "trigger.sched", "filed proposal workflow=%s repo=%s sha=%s id=%s",
-                   rule->pipeline_template, rule->workspace, entries[i].sha, id);
       }
-      else
-         aimee_log(LOG_WARN, "trigger.sched", "proposal create skipped/failed repo=%s sha=%s: %s",
-                   rule->workspace, entries[i].sha, err[0] ? err : "already exists");
    }
 
    /* Wake the autonomy driver so a just-filed run advances now rather than on
@@ -950,6 +958,60 @@ static int config_has_cron_job(const config_t *cfg, const char *id)
 }
 
 /* ------------------------------------------------------------------ */
+/* Trigger-source registry                                             */
+/* ------------------------------------------------------------------ */
+
+/* A trigger source turns "something happened" into filed runs. The tick loop
+ * owns the shared plumbing — one probe per rule per ~minute window, the global
+ * trigger.max_concurrent handed to fire() — and each source owns its own event
+ * matching, artifact materialization, and de-duplication. Adding a source is
+ * one table row: `due` says whether this tick should fire (a scanner that
+ * polls on every pass returns 1 unconditionally; cron matches its schedule),
+ * `fire` does the work and files runs through trigger_file_run. */
+typedef struct
+{
+   const char *name;
+   int (*due)(const trigger_rule_t *rule, const struct tm *tm);
+   void (*fire)(const trigger_rule_t *rule, int max_concurrent);
+} trigger_source_t;
+
+static int proposals_due(const trigger_rule_t *rule, const struct tm *tm)
+{
+   (void)rule;
+   (void)tm;
+   return 1; /* poll the repo every pass; per-proposal dedup makes re-scans idempotent */
+}
+
+static void proposals_fire(const trigger_rule_t *rule, int max_concurrent)
+{
+   scan_proposals(rule, max_concurrent);
+}
+
+static int cron_due(const trigger_rule_t *rule, const struct tm *tm)
+{
+   return rule->schedule[0] && schedule_matches(rule->schedule, tm) == 1;
+}
+
+static void cron_fire(const trigger_rule_t *rule, int max_concurrent)
+{
+   (void)max_concurrent; /* cron files a legacy pipeline, not a wfe work item */
+   trigger_scheduler_fire_rule(rule);
+}
+
+static const trigger_source_t g_trigger_sources[] = {
+    {"proposals", proposals_due, proposals_fire},
+    {"cron", cron_due, cron_fire},
+};
+
+static const trigger_source_t *trigger_source_find(const char *name)
+{
+   for (size_t i = 0; i < sizeof(g_trigger_sources) / sizeof(g_trigger_sources[0]); i++)
+      if (strcmp(g_trigger_sources[i].name, name) == 0)
+         return &g_trigger_sources[i];
+   return NULL;
+}
+
+/* ------------------------------------------------------------------ */
 /* Scheduler tick                                                      */
 /* ------------------------------------------------------------------ */
 
@@ -965,31 +1027,17 @@ static void sched_tick(void)
    for (int i = 0; i < cfg.trigger_rule_count && i < TRIGGER_RULES_MAX; i++)
    {
       const trigger_rule_t *rule = &cfg.trigger_rules[i];
-
-      if (strcmp(rule->source, "proposals") == 0)
-      {
-         if (now - g_last_fired[i] < 55)
-            continue;
-         g_last_fired[i] = now;
-         scan_proposals(rule, cfg.trigger_max_concurrent);
+      const trigger_source_t *src = trigger_source_find(rule->source);
+      if (!src)
+         continue; /* unknown source (e.g. a webhook handled on its own ingress) */
+      if (!src->due(rule, &tm))
          continue;
-      }
-
-      if (strcmp(rule->source, "cron") != 0)
-         continue;
-      if (!rule->schedule[0])
-         continue;
-
-      int match = schedule_matches(rule->schedule, &tm);
-      if (match != 1)
-         continue;
-
-      /* Deduplicate: skip if we fired within the last 55 seconds */
+      /* Shared per-rule rate limit: one fire per ~minute window, so the 30s
+       * tick never double-fires a minute-granular source. */
       if (now - g_last_fired[i] < 55)
          continue;
-
       g_last_fired[i] = now;
-      trigger_scheduler_fire_rule(rule);
+      src->fire(rule, cfg.trigger_max_concurrent);
    }
 
    for (int i = 0; i < cfg.cron_job_count && i < CRON_JOBS_MAX; i++)

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -272,6 +272,16 @@ void wfe_scheduler_notify(void)
    g_notify_count++;
 }
 
+/* Stub of the shared intake cap policy (the real env-driven policy lives in
+ * wfe_autonomy.c and is exercised by unit-test-trigger-e2e, which links it);
+ * test-settable so the plumbing — rule cap wins, else this default, 0 = no
+ * cap — is asserted deterministically. */
+static double g_default_cap = 5.0;
+double wfe_autonomy_default_max_cost_usd(void)
+{
+   return g_default_cap;
+}
+
 /* Pull in static cron_matches / field_matches via direct .c include. */
 #include "../server/trigger_scheduler.c"
 
@@ -1012,7 +1022,8 @@ static void test_scan_proposals_applies_cost_cap(void)
    assert(g_ncreated == 1);
    assert(g_created[0].cost_cap == 1.25);
 
-   /* No rule cap -> the $5 intake default. */
+   /* No rule cap -> the shared intake default (stubbed here; the real
+    * env-driven policy is asserted by unit-test-trigger-e2e). */
    snprintf(g_lstree_out, sizeof g_lstree_out,
             "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n");
    rule.max_spend_usd = 0.0;
@@ -1020,12 +1031,12 @@ static void test_scan_proposals_applies_cost_cap(void)
    assert(g_ncreated == 2);
    assert(g_created[1].cost_cap == 5.0);
 
-   /* AIMEE_AUTONOMY_MAX_USD=0 disables the default cap. */
+   /* A default of 0 means "no cap": nothing is stamped. */
    snprintf(g_lstree_out, sizeof g_lstree_out,
             "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
-   setenv("AIMEE_AUTONOMY_MAX_USD", "0", 1);
+   g_default_cap = 0.0;
    scan_proposals(&rule, 0);
-   unsetenv("AIMEE_AUTONOMY_MAX_USD");
+   g_default_cap = 5.0;
    assert(g_ncreated == 3);
    assert(g_created[2].cost_cap == 0.0);
 
@@ -1073,6 +1084,31 @@ static void test_scan_proposals_enforces_max_concurrent(void)
    assert(g_ncreated == 3);
 
    printf("  PASS: test_scan_proposals_enforces_max_concurrent\n");
+}
+
+/* The trigger-source registry: rules dispatch by source name; a scanner source
+ * is due on every pass, cron only on a schedule match, and an unknown source
+ * is skipped (no registry row -> no fire). */
+static void test_trigger_source_registry(void)
+{
+   assert(trigger_source_find("proposals") != NULL);
+   assert(trigger_source_find("cron") != NULL);
+   assert(trigger_source_find("github-webhook") == NULL);
+   assert(trigger_source_find("") == NULL);
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   struct tm at3 = make_tm(0, 3, 1, 4, 2);
+   struct tm at4 = make_tm(0, 4, 1, 4, 2);
+
+   assert(proposals_due(&rule, &at3) == 1); /* scanners poll every pass */
+
+   assert(cron_due(&rule, &at3) == 0); /* no schedule -> never due */
+   snprintf(rule.schedule, sizeof rule.schedule, "0 3 * * *");
+   assert(cron_due(&rule, &at3) == 1);
+   assert(cron_due(&rule, &at4) == 0);
+
+   printf("  PASS: test_trigger_source_registry\n");
 }
 
 /* ------------------------------------------------------------------ */
@@ -1125,6 +1161,7 @@ int main(void)
    test_scan_proposals_notifies_scheduler();
    test_scan_proposals_applies_cost_cap();
    test_scan_proposals_enforces_max_concurrent();
+   test_trigger_source_registry();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -3,6 +3,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <math.h> /* isfinite — validate the AIMEE_AUTONOMY_MAX_USD override */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -152,6 +153,22 @@ static int wfe_autonomy_park_stuck(const char *work_item_id, const char *why)
    db1_lifecycle_event_add(work_item_id, wi.current_stage, "pause", "engine",
                            (why && why[0]) ? why : "unrecoverable advance failure", "", 0);
    return 0;
+}
+
+double wfe_autonomy_default_max_cost_usd(void)
+{
+   /* WP-5: the shared per-run USD budget ceiling (see wfe_autonomy.h). Reject
+    * inf/NaN — either would void the cap rather than tune it. */
+   double cap_usd = 5.0;
+   const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
+   if (v && v[0])
+   {
+      char *e = NULL;
+      double d = strtod(v, &e);
+      if (e && *e == '\0' && isfinite(d) && d >= 0)
+         cap_usd = d;
+   }
+   return cap_usd;
 }
 
 int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)

--- a/src/workflow/wfe_autonomy.h
+++ b/src/workflow/wfe_autonomy.h
@@ -25,6 +25,14 @@
  * clean stop (terminal or parked), -1 on error. */
 int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen);
 
+/* The default per-run USD ceiling every autonomous intake applies when the
+ * caller supplies no explicit cap: $5.00, AIMEE_AUTONOMY_MAX_USD overrides
+ * (0 disables the cap; a malformed/inf/NaN override falls back to the
+ * default). One policy for every filing path — /v1/dev/submit, the MCP tool,
+ * and each trigger source — so no intake is ever the one without a runaway
+ * cost cap. Returns the cap in USD; 0 means "no cap". */
+double wfe_autonomy_default_max_cost_usd(void);
+
 /* Human-only escape from a stuck gate: records a signed override (counts as a
  * human approval), increments override_count, and clears the pause so the next
  * run advances. On the (WFE_MAX_OVERRIDES+1)th override the work item is forced


### PR DESCRIPTION
## What

Follow-up to #1290, now that the proposals trigger is verified live end-to-end (the .254 appliance is autonomously filing and completing runs from its own `docs/proposals/pending/`). This genericizes the trigger machinery:

- **Trigger-source registry**: sources are `{name, due, fire}` table rows instead of hardcoded checks in the tick loop. The loop owns shared plumbing (per-rule ~minute rate limit, global `trigger.max_concurrent`); each source owns event matching, artifact materialization, and dedup. Adding a source (webhook, path-watch, sweep, …) is one row plus its `fire()`.
- **`trigger_file_run()`**: the shared filing back half for every artifact-producing source — work item on the rule's pipeline/workspace/mode, per-run USD ceiling, audit log.
- **One intake cap policy**: `wfe_autonomy_default_max_cost_usd()` ($5, `AIMEE_AUTONOMY_MAX_USD` override, 0 disables) replaces the duplicate copies in `dev_submit_run` and the trigger path.

No behavior change: proposals scans every pass, cron fires on schedule match, same 55s per-rule window.

## Tests

- `unit-test-trigger`: new registry coverage (source lookup, cron due-on-schedule, scanner due-every-pass); cost-cap plumbing tests now drive the (stubbed) shared policy.
- `unit-test-trigger-e2e` (real pipeline, real git, real DB1, real scheduler) still passes and asserts the real default cap policy end-to-end.
- `unit-test-wfe-autonomy` passes; `make line-check module-boundary-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)