### PR TITLE
feat(trigger): watch-dir canonical source + triggers-as-blocks proposal

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -305,7 +305,7 @@ trigger:
   max_concurrent: 1          # cap on concurrently-executing triggered runs
 
 trigger_rules:
-  - source: proposals              # scan a git repo for new proposals
+  - source: watch-dir              # scan a repo dir for new files (alias: proposals)
     event: docs/proposals/pending  # repo-relative dir to watch (this is the default)
     schedule: main                 # git ref/branch to read (default: auto-detected origin HEAD)
     mode: autonomous               # autonomous (default) | interactive
@@ -318,12 +318,12 @@ trigger_rules:
 
 | Field | Meaning |
 | --- | --- |
-| `source` | What fires the rule: `proposals`, `cron`, or a webhook source. |
-| `event` | Source-specific match. For `proposals`, the repo-relative directory to scan (default `docs/proposals/pending`). |
-| `schedule` | For `cron`, the cron expression. For `proposals`, the git ref/branch to read (default: auto-detected `origin` HEAD, then `HEAD`). |
+| `source` | What fires the rule: `watch-dir` (alias `proposals`), `cron`, or a webhook source. |
+| `event` | Source-specific match. For `watch-dir`/`proposals`, the repo-relative directory to scan (default `docs/proposals/pending`). |
+| `schedule` | For `cron`, the cron expression. For `watch-dir`/`proposals`, the git ref/branch to read (default: auto-detected `origin` HEAD, then `HEAD`). |
 | `mode` | Execution mode stamped on the filed work item — see below. `autonomous` (default) or `interactive`. |
 | `pipeline.template` | The workflow to start (any saved workflow name, e.g. `build`). |
-| `pipeline.workspace` | Absolute path of the git repo the run operates in (and, for `proposals`, the repo to scan). |
+| `pipeline.workspace` | Absolute path of the git repo the run operates in (and, for `watch-dir`/`proposals`, the repo to scan). |
 | `pipeline.max_spend_usd` | Optional per-run spend cap. |
 
 ### `mode`: autonomous vs. interactive
@@ -347,9 +347,11 @@ workflow that still pauses at a human gate partway through, or an `interactive`
 trigger into a fully hands-off workflow. Pick the trigger `mode` for the
 *start* decision; put in-flight gates in the *workflow*.
 
-### The `proposals` source
+### The `watch-dir` source (alias: `proposals`)
 
-The `proposals` source turns "a proposal was committed" into a workflow run. On
+The `watch-dir` source turns "a file was committed into a watched directory"
+into a workflow run — `proposals` is the original alias for the same scanner,
+whose default directory (`docs/proposals/pending`) is just one configuration. On
 each scan (roughly once a minute) it lists the proposal directory at the
 configured git ref, and for every proposal it has not seen before it:
 

--- a/docs/proposals/pending/trigger-blocks.md
+++ b/docs/proposals/pending/trigger-blocks.md
@@ -1,0 +1,68 @@
+# Triggers as workflow blocks — graph-native run starts
+
+## Why
+
+Triggers today live *outside* the workflow system: a `trigger_rules` list in
+`aimee.yaml` names a source (`watch-dir`/`proposals`, `cron`) and points it at a
+saved workflow. That works — the proposals pipeline files and completes runs
+hands-off — but it splits one design across two authoring surfaces. The
+workflow graph declares everything about a run *except* what starts it; the
+thing that starts it is a config stanza the composer never sees, validated by
+different code, with its own field vocabulary (`event`, `schedule`,
+`pipeline.workspace`) that overloads meanings per source.
+
+The trigger-source registry (`{name, due, fire}` in
+`src/server/trigger_scheduler.c`) already made sources pluggable. This proposal
+finishes the thought: a trigger becomes a **block** — the entry node of the
+workflow that wants it — so "what starts this workflow" is composed, validated,
+versioned, and displayed exactly like every other step.
+
+## What
+
+1. **A `trigger.*` block kind** in the catalog (`wfe_def.c`), starting with one
+   concrete block:
+   - `trigger.watch-dir` — params `{dir, ref, suffix}` (defaults
+     `docs/proposals/pending`, auto-detected origin HEAD, `.md`). Produces a
+     `proposal` artifact: the materialized content of each new file seen in the
+     watched directory, exactly what the `watch-dir` source materializes today.
+   - The block-kind namespace leaves room for `trigger.cron` and
+     `trigger.webhook` rows later; each is a thin adapter over the same
+     scheduler plumbing.
+2. **Validator rules**: a `trigger.*` block may appear only as the `start`
+   node, at most one per workflow, with no inbound edges and no `in` bindings.
+   Its `next` edge feeds the produced artifact into the graph (e.g.
+   `trigger.watch-dir → author.proposal` replaces the pre-supplied-proposal
+   special case with an explicit data edge).
+3. **Arming**: a saved workflow whose start node is a trigger block is an
+   *armed* workflow. The trigger scheduler's tick enumerates armed workflows
+   (same registry, same per-rule rate limit, same global
+   `trigger.max_concurrent`, same per-run USD ceiling policy) and instantiates
+   one work item per event through the existing `trigger_file_run` back half —
+   the run starts at the node *after* the trigger block, with the trigger's
+   artifact bound.
+4. **Workspace binding**: the armed workflow carries its repo binding
+   (`params.workspace` on the trigger block, or the project the workflow was
+   saved under in the webchat). Executors already honor the work item's own
+   repo (`wfe_repo_local`), so this closes the loop: one YAML file states
+   *watch this dir, in this repo, and run this graph*.
+5. **Compatibility**: `trigger_rules` keeps working unchanged — it is the
+   "arm someone else's workflow without editing it" form, and its sources and
+   the trigger blocks share one implementation. The webchat composer gains the
+   trigger blocks in the rail like any other block.
+
+## Acceptance
+
+- `aimee workflow validate` accepts a workflow whose start is
+  `trigger.watch-dir` and rejects a trigger block anywhere else in the graph
+  (non-start, inbound edge, `in` binding, or a second trigger).
+- Saving such a workflow arms it: committing a matching file into the watched
+  dir files exactly one run bound to the configured repo, with the standard
+  cost cap, visible in the Workflow Actions tab; re-scans never double-file.
+- Disabling/deleting the workflow disarms it (no orphaned watchers).
+- An equivalent `trigger_rules` stanza and an armed workflow produce
+  byte-identical work items (same intake, cap, audit events) for the same
+  event.
+- The `build` composition gains a sibling `build-triggered.yaml` example whose
+  entry is `trigger.watch-dir`, and `docs/WORKFLOWS.md` documents the block
+  form as the primary authoring path with `trigger_rules` as the external
+  alternative.

--- a/src/config_trigger.c
+++ b/src/config_trigger.c
@@ -7,7 +7,8 @@
  *   max_concurrent: 2
  *
  * trigger_rules:
- *   - source: "github-webhook"   # valid sources include github-webhook, cron, proposals
+ *   - source: "github-webhook"   # valid sources include github-webhook, cron,
+ *                                # watch-dir (alias: proposals)
  *     event: "push"
  *     mode: "autonomous"         # "autonomous" (default) | "interactive"
  *     pipeline:

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -999,6 +999,11 @@ static void cron_fire(const trigger_rule_t *rule, int max_concurrent)
 }
 
 static const trigger_source_t g_trigger_sources[] = {
+    /* watch-dir is the canonical generic source: watch a repo-relative
+     * directory at a git ref and file one run per new file. `proposals` is the
+     * original alias for the same scanner — its default dir
+     * (docs/proposals/pending) is just one configuration of watch-dir. */
+    {"watch-dir", proposals_due, proposals_fire},
     {"proposals", proposals_due, proposals_fire},
     {"cron", cron_due, cron_fire},
 };

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -1095,6 +1095,9 @@ static void test_trigger_source_registry(void)
    assert(trigger_source_find("cron") != NULL);
    assert(trigger_source_find("github-webhook") == NULL);
    assert(trigger_source_find("") == NULL);
+   /* watch-dir is the canonical name for the same scanner proposals aliases. */
+   assert(trigger_source_find("watch-dir") != NULL);
+   assert(trigger_source_find("watch-dir")->fire == trigger_source_find("proposals")->fire);
 
    trigger_rule_t rule;
    memset(&rule, 0, sizeof rule);


### PR DESCRIPTION
## What

Follow-through on the generalization direction:

- **`watch-dir` is now the canonical generic source** — one registry row aliasing the same scanner as `proposals` (which remains valid for existing configs). The docs present dir-watching as the general mechanism with `docs/proposals/pending` as one configuration.
- **`docs/proposals/pending/trigger-blocks.md`**: the design for making triggers part of the block catalog — a `trigger.watch-dir` entry node arms the workflow that carries it (validator rules, arming/disarming semantics, workspace binding via the work item's repo, byte-identical intake with `trigger_rules`). Since it lands in `pending/`, the .254 appliance's own trigger will pick it up and drain it into `build` — the system building its own next step.

## Tests

`unit-test-trigger` extended: `watch-dir` resolves and shares the scanner with `proposals`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)