### PR TITLE
feat(persona): technical-writer default persona

### DIFF
--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -144,6 +144,8 @@ nodes:
           - architect
           - qa
           - reviewer
+        eligible:
+          - technical-writer # the documentation domain expert joins when seatable
       quorum: 3
       max_rounds: 6
       focus: is the documentation complete, accurate, and clear for this feature?

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -3,7 +3,7 @@
 A **persona** is the primary agent's identity, its system-prompt voice, craft
 principles, session-brief hints, the delegate roles it advertises, and its
 **delegate policy**. Personas are server-owned and user-extensible: aimee ships
-eight built-ins and seeds them as editable files, and you can add your own.
+nine built-ins and seeds them as editable files, and you can add your own.
 
 ## Built-in personas
 
@@ -17,14 +17,20 @@ eight built-ins and seeds them as editable files, and you can add your own.
 | `reviewer` | Senior **contrarian** code reviewer (thorough, comprehensive) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 | `reviewer-constructive` | Senior **constructive** code reviewer (assess as written) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 | `architect` | Software-architecture reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
+| `technical-writer` | Senior technical writer / documentation reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 
-The five reviewer personas (`qa`, `security`, `reviewer`,
-`reviewer-constructive`, `architect`) reframe the agent as a read-only senior
+The six reviewer personas (`qa`, `security`, `reviewer`,
+`reviewer-constructive`, `architect`, `technical-writer`) reframe the agent as a read-only senior
 reviewer: it investigates and surfaces findings with evidence, never editing the
 code. They share a common **Review Principles** block and each carry their own
 review methodology. `reviewer` and `reviewer-constructive` are a deliberate pair
 ,  the former is adversarial (tries to refute), the latter assesses the work as
-written, so a roundtable panel can blend both stances.
+written, so a roundtable panel can blend both stances. `technical-writer`
+judges the documentation of a change — accuracy against the code, completeness,
+clarity, runnable examples — and is an eligible seat on the default `build`
+workflow's documentation gate. It writes and reviews to a human standard:
+brevity first, and machine-sounding prose (AI clichés, filler, padded
+sentences) is itself a finding.
 
 ## Where personas live
 
@@ -33,7 +39,7 @@ Single markdown files, resolved project → user → built-in:
 - Project: `<project>/.aimee/personas/<name>.md`
 - User: `~/.config/aimee/personas/<name>.md`
 - Built-in fallback
-  (engineer/novel/songwriter/qa/security/reviewer/reviewer-constructive/architect)
+  (engineer/novel/songwriter/qa/security/reviewer/reviewer-constructive/architect/technical-writer)
 
 `aimee init` seeds the built-ins as editable files under
 `~/.config/aimee/personas/` (idempotent, it never overwrites an existing file),

--- a/src/config_mode.c
+++ b/src/config_mode.c
@@ -27,6 +27,8 @@ static aimee_mode_t mode_parse(const char *s)
       return AIMEE_MODE_ARCHITECT;
    if (s && strcasecmp(s, "reviewer-constructive") == 0)
       return AIMEE_MODE_REVIEWER_CONSTRUCTIVE;
+   if (s && strcasecmp(s, "technical-writer") == 0)
+      return AIMEE_MODE_TECH_WRITER;
    return AIMEE_MODE_ENGINEER;
 }
 

--- a/src/headers/prompts.h
+++ b/src/headers/prompts.h
@@ -43,6 +43,7 @@ typedef enum
    AIMEE_MODE_REVIEWER = 5,              /* senior, thorough, contrarian code reviewer */
    AIMEE_MODE_ARCHITECT = 6,             /* software-architecture reviewer */
    AIMEE_MODE_REVIEWER_CONSTRUCTIVE = 7, /* constructive reviewer: assess as written */
+   AIMEE_MODE_TECH_WRITER = 8,           /* technical writer / documentation reviewer */
 } aimee_mode_t;
 
 /* Parse a mode name ("engineer", "novel", "songwriter", "qa", "security",

--- a/src/persona.c
+++ b/src/persona.c
@@ -87,6 +87,16 @@ static const char *REVIEWER_CONSTRUCTIVE_BRIEF =
     "- You produce the review yourself; use READ-ONLY delegates only — `aimee delegate review "
     "\"...\"` (or diagnose, validate, research) to investigate in parallel.\n";
 
+static const char *TECH_WRITER_BRIEF =
+    "- Use `aimee index find <name>` / `aimee memory search <terms>` to locate the change under "
+    "review and the documentation around it.\n"
+    "- Trace each documented claim to the code and each new behaviour back to the docs; walk the "
+    "instructions as the least-context reader and note where they break.\n"
+    "- Write like a person and prefer brevity; treat AI-isms and padded, machine-sounding prose "
+    "in the docs as findings.\n"
+    "- You produce the review yourself; use READ-ONLY delegates only — `aimee delegate review "
+    "\"...\"` (or diagnose, validate, research) to investigate in parallel.\n";
+
 /* Built-ins. Roles are the delegate roles the persona may use, consistent with
  * its delegate policy (engineer: full set; novel: read-only checks only;
  * songwriter: none). */
@@ -107,6 +117,8 @@ static const builtin_persona_t g_builtins[] = {
     {"reviewer-constructive", AIMEE_MODE_REVIEWER_CONSTRUCTIVE,
      "Senior constructive code reviewer (assess as written)", "review,diagnose,validate,research",
      "", "", "readonly"},
+    {"technical-writer", AIMEE_MODE_TECH_WRITER, "Senior technical writer / documentation reviewer",
+     "review,diagnose,validate,research", "", "", "readonly"},
     {NULL, 0, NULL, NULL, NULL, NULL, NULL},
 };
 
@@ -175,6 +187,8 @@ static const char *builtin_brief(const builtin_persona_t *b)
       return ARCHITECT_BRIEF;
    if (b->mode == AIMEE_MODE_REVIEWER_CONSTRUCTIVE)
       return REVIEWER_CONSTRUCTIVE_BRIEF;
+   if (b->mode == AIMEE_MODE_TECH_WRITER)
+      return TECH_WRITER_BRIEF;
    return "";
 }
 

--- a/src/prompts.c
+++ b/src/prompts.c
@@ -432,6 +432,58 @@ static const char *PROMPT_REVIEWER_CONSTRUCTIVE_TEXT =
     "Write delegates are refused. Always use aimee delegates over the Agent tool\n"
     "(the Agent tool is disabled in aimee).\n";
 
+static const char *PROMPT_TECH_WRITER_TEXT =
+    "You are a senior technical writer reviewing the documentation of a change\n"
+    "in %s. Your role is to judge whether a reader who was not in the room can\n"
+    "understand, use, and operate what shipped: docs, READMEs, changelogs, API\n"
+    "references, and the prose around the code. You report findings; you do not\n"
+    "edit the code.\n"
+    "\n"
+    "## Workflow\n"
+    "1. UNDERSTAND: Establish what the change does and who has to read about\n"
+    "   it — end users, operators, or the next engineer.\n"
+    "2. TRACE: Follow each documented claim to the code and each behaviour in\n"
+    "   the code back to the docs; note what exists in only one of the two.\n"
+    "3. WALK THROUGH: Read as the least-context reader — follow the\n"
+    "   instructions literally and note where they break, skip a step, or\n"
+    "   assume unstated knowledge.\n"
+    "4. ASSESS STRUCTURE: Judge organisation, naming, headings, and examples —\n"
+    "   can a reader find the answer, and is every example runnable as shown?\n"
+    "5. REPORT: List concrete gaps and inaccuracies — missing docs, stale\n"
+    "   claims, broken examples, unclear prose — each with its location and a\n"
+    "   suggested fix, ranked by reader impact.\n"
+    "\n"
+    "## Focus\n"
+    "- Accuracy: the docs describe what the code actually does, not what it\n"
+    "  used to do or was meant to do.\n"
+    "- Completeness: new behaviour, flags, endpoints, and failure modes are\n"
+    "  documented where their readers will look.\n"
+    "- Clarity: plain sentences, defined terms, no unexplained jargon; examples\n"
+    "  that run as written.\n"
+    "- Consistency: terminology, tone, and structure match the surrounding\n"
+    "  documentation.\n"
+    "\n"
+    "## Voice\n"
+    "Hold your own writing and the docs under review to the same standard:\n"
+    "- Sound human. Plain, direct sentences; vary their rhythm; no padding.\n"
+    "- Prefer brevity. Say it once, cut filler, and stop when the point is\n"
+    "  made — a shorter accurate sentence beats a longer complete one.\n"
+    "- No AI-isms. Ban the stock phrases and tics of machine prose: 'delve',\n"
+    "  'leverage', 'seamless', 'robust', 'crucial', 'comprehensive',\n"
+    "  'streamline', 'elevate', 'unlock', 'It's important to note',\n"
+    "  'In today's fast-paced world', reflexive rule-of-three lists, and\n"
+    "  every-noun-gets-an-adjective inflation.\n"
+    "- Flag prose in the docs that reads machine-written, padded, or generic\n"
+    "  as a finding, the same as an inaccuracy.\n"
+    "\n"
+    "## Delegation\n"
+    "You produce the review yourself. Use READ-ONLY delegates only, to\n"
+    "investigate in parallel:\n"
+    "  aimee delegate <role> --persona <name> \"prompt\"   (roles: review, diagnose,\n"
+    "  validate, research; a persona is required, e.g. security, qa, architect)\n"
+    "Write delegates are refused. Always use aimee delegates over the Agent tool\n"
+    "(the Agent tool is disabled in aimee).\n";
+
 static const char *PROMPT_ARCHITECT_TEXT =
     "You are a senior software architect reviewing a change in %s.\n"
     "Your role is to judge how this change fits the system: its structure,\n"
@@ -580,6 +632,8 @@ aimee_mode_t aimee_mode_from_string(const char *name)
       return AIMEE_MODE_ARCHITECT;
    if (name && strcasecmp(name, "reviewer-constructive") == 0)
       return AIMEE_MODE_REVIEWER_CONSTRUCTIVE;
+   if (name && strcasecmp(name, "technical-writer") == 0)
+      return AIMEE_MODE_TECH_WRITER;
    return AIMEE_MODE_ENGINEER;
 }
 
@@ -601,6 +655,8 @@ const char *aimee_mode_to_string(aimee_mode_t mode)
       return "architect";
    case AIMEE_MODE_REVIEWER_CONSTRUCTIVE:
       return "reviewer-constructive";
+   case AIMEE_MODE_TECH_WRITER:
+      return "technical-writer";
    default:
       return "engineer";
    }
@@ -619,6 +675,7 @@ const char *prompt_principles_text(aimee_mode_t mode)
    case AIMEE_MODE_REVIEWER:
    case AIMEE_MODE_ARCHITECT:
    case AIMEE_MODE_REVIEWER_CONSTRUCTIVE:
+   case AIMEE_MODE_TECH_WRITER:
       return PROMPT_REVIEW_PRINCIPLES_TEXT;
    default:
       return PROMPT_CODE_PRINCIPLES_TEXT;
@@ -643,6 +700,8 @@ const char *prompt_persona_text(aimee_mode_t mode)
       return PROMPT_ARCHITECT_TEXT;
    case AIMEE_MODE_REVIEWER_CONSTRUCTIVE:
       return PROMPT_REVIEWER_CONSTRUCTIVE_TEXT;
+   case AIMEE_MODE_TECH_WRITER:
+      return PROMPT_TECH_WRITER_TEXT;
    default:
       return PROMPT_STANDARD_TEXT;
    }

--- a/src/tests/test_persona.c
+++ b/src/tests/test_persona.c
@@ -63,9 +63,9 @@ int main(void)
       persona_free(&p);
 
       /* --- reviewer built-ins: read-only, review-oriented roles, no gate --- */
-      const char *reviewers[] = {"qa", "security", "reviewer", "architect",
-                                 "reviewer-constructive"};
-      for (int i = 0; i < 5; i++)
+      const char *reviewers[] = {
+          "qa", "security", "reviewer", "architect", "reviewer-constructive", "technical-writer"};
+      for (int i = 0; i < 6; i++)
       {
          assert(persona_load(NULL, reviewers[i], &p) == 0);
          assert(p.builtin == 1);
@@ -262,8 +262,8 @@ int main(void)
       char dir[PATH_MAX];
       snprintf(dir, sizeof(dir), "%s/defaults", home);
       int w = persona_install_defaults(dir);
-      assert(w == 8); /* engineer, novel, songwriter, qa, security, reviewer, architect,
-                         reviewer-constructive */
+      assert(w == 9); /* engineer, novel, songwriter, qa, security, reviewer, architect,
+                         reviewer-constructive, technical-writer */
       char path[PATH_MAX];
       snprintf(path, sizeof(path), "%s/novel.md", dir);
       FILE *f = fopen(path, "r");


### PR DESCRIPTION
## What

A ninth built-in persona: **`technical-writer`** — senior technical writer / documentation reviewer. Read-only reviewer class (same delegate policy and roles as qa/security/reviewer/architect): it judges the documentation of a change — accuracy against the code, completeness, clarity, runnable examples, terminology consistency — and reports findings with locations and suggested fixes.

**Voice is part of the persona** (per operator direction): write like a person, prefer brevity, avoid AI clichés and stock machine-prose phrasing — and machine-sounding, padded prose in the docs under review is itself a finding.

Wired everywhere the built-ins live: mode enum + name mapping, persona prose + review-principles group, builtin metadata + brief, seeded file install, `config_mode` parsing, and docs. Also seated as an **eligible** panelist on the default `build` workflow's documentation gate (joins when seatable; quorum unchanged).

## Tests

`unit-test-persona` extended: technical-writer asserted through the reviewer-class loop (readonly, review/diagnose roles, brief) and the install-defaults count (now 9). `unit-test-config` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)