### PR TITLE
config: wfe_live_forge_enabled defaults ON

### DIFF
--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -252,9 +252,11 @@ The page is read/UI only; the behavior it drives is governed by existing config:
   agent config (see [`DELEGATES.md`](DELEGATES.md)); with only CLI delegates, the draft
   endpoint returns an error and the button surfaces it.
 - **Autonomous execution** is governed by the wfe engine
-  ([`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). Notably the **live forge
-  is default-off** (`wfe_live_forge_enabled`): with it off, a run advances and parks at
-  gates without pushing a real PR, which is the safe default for exercising the page.
+  ([`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). The **live forge is
+  default-on** (`wfe_live_forge_enabled`); set it to `false` to exercise the page
+  without real pushes — a run then advances and parks at gates instead of opening a
+  PR. Even on, the merge-target rail bounds every op (PRs open-only against the
+  trunk; merges only to the unprotected autonomous base).
 - **Submit** is bounded by the intake's existing caps (a 1 MB proposal body cap and the
   intake-auth per-principal rate/concurrency limits); the user-supplied `repo` is
   handled by the same `/v1/dev/submit` intake that the CLI uses; its validation and

--- a/src/config.c
+++ b/src/config.c
@@ -808,9 +808,13 @@ static void config_set_defaults(config_t *cfg)
    cfg->css_style_graph_enabled = 1; /* default-on: the indexer builds the CSS style
                                         graph so the read-only css signals/report work
                                         out of the box (set false to opt out) */
-   cfg->wfe_live_forge_enabled = 0;  /* default-OFF (security): the autonomous live
-                                        forge stays unregistered until an operator
-                                        explicitly enables it (F4) */
+   cfg->wfe_live_forge_enabled = 1;  /* default-ON (operator ruling 2026-07-13,
+                                        restoring the plan's default): the live forge
+                                        registers at standup; set false to opt out.
+                                        The merge-target rail still bounds every op --
+                                        PRs open-only against the resolved trunk,
+                                        merges only to the unprotected autonomous
+                                        base -- and each op re-checks flag + rail. */
    cfg->audit_action_enabled = 1;    /* default-ON: the trajectory_export reader (S3)
                                         shipped, so the passive per-action audit row
                                         is on by default; set false to opt out */

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -887,8 +887,8 @@ int config_save(const config_t *cfg)
       cJSON_AddStringToObject(root, "ocr_command", cfg->ocr_command);
    if (!cfg->css_style_graph_enabled) /* default-on: persist only the opt-out */
       cJSON_AddBoolToObject(root, "css_style_graph_enabled", 0);
-   if (cfg->wfe_live_forge_enabled) /* default-off: persist only the opt-in (enable) */
-      cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 1);
+   if (!cfg->wfe_live_forge_enabled) /* default-on: persist only the opt-out (disable) */
+      cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 0);
    if (!cfg->audit_action_enabled) /* default-on: persist only the opt-out (disable) */
       cJSON_AddBoolToObject(root, "audit_action_enabled", 0);
    if (cfg->audit_worm_enabled) /* default-off: persist only the opt-in (enable) */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -316,12 +316,13 @@ typedef struct config
     * assistant's style-graph write path during indexing (WP-C). When off, the
     * indexer keeps only the legacy lexical CSS class-name scan. */
    int css_style_graph_enabled;
-   /* wfe_live_forge_enabled: gate (default 0, OFF) for the autonomous live forge
+   /* wfe_live_forge_enabled: gate (default 1, ON — operator ruling 2026-07-13,
+    * restoring the plan's default) for the autonomous live forge
     * (full-autonomous-development F4). When OFF the wfe forge provider is not
     * registered and every forge op fails closed, so an autonomous run can never
-    * open or merge a real PR. Turning it ON is a deliberate operator deployment
-    * action (branch protection + scoped creds + break-glass) — never a code default,
-    * per the security-roundtable deviation. */
+    * open or merge a real PR. Even ON, every op re-checks this flag AND the
+    * merge-target rail: PRs open-only against the resolved trunk, merges only
+    * to the unprotected autonomous base. Set false to opt out. */
    int wfe_live_forge_enabled;
    /* audit_action_enabled: emit a per-tool-call governed-action row (kind=
     * tool_action) to audit.log from pre_tool_check. Default-ON (the

--- a/src/headers/wfe_live_forge.h
+++ b/src/headers/wfe_live_forge.h
@@ -1,7 +1,7 @@
 /* wfe_live_forge.h: register the live forge provider (F4).
  *
- * Installs a wfe_forge_t that does real git push + `gh` PR/CI/merge — but ONLY when
- * the operator has set wfe_live_forge_enabled=true (default OFF). Otherwise the
+ * Installs a wfe_forge_t that does real git push + `gh` PR/CI/merge — unless the
+ * operator has set wfe_live_forge_enabled=false (default ON). When disabled the
  * engine keeps its fail-closed stub. Called from wfe_autonomy_register. */
 #ifndef DEC_WFE_LIVE_FORGE_H
 #define DEC_WFE_LIVE_FORGE_H 1

--- a/src/server/wfe_live_forge.c
+++ b/src/server/wfe_live_forge.c
@@ -5,17 +5,17 @@
  * (mcp_git_run, which injects the forge token via git_cred_inject) and the autonomous
  * merge-target rail (wfe_autonomous_base / _target_ok).
  *
- * SECURITY: registered ONLY when the operator has set wfe_live_forge_enabled=true
- * (default OFF — see config.h). Even once registered, EVERY op re-checks the flag
- * AND the merge-target rail via forge_allowed() and fails closed if either is off —
- * including immediately before each mutating git/gh call, so a config flip or a
- * base misconfig mid-op can't slip a push/PR/merge through (TOCTOU-safe). An
+ * SECURITY: registered unless the operator has set wfe_live_forge_enabled=false
+ * (default ON — operator ruling 2026-07-13, restoring the plan's default; see
+ * config.h). Registered or not, EVERY op re-checks the flag AND the merge-target
+ * rail via forge_allowed() and fails closed if either is off — including
+ * immediately before each mutating git/gh call, so a config flip or a base
+ * misconfig mid-op can't slip a push/PR/merge through (TOCTOU-safe). An
  * autonomous run can never MERGE into a protected branch; it may OPEN a
  * human-reviewed PR against the repo's own default branch (trunk) -- open-only, never
  * auto-merged (the default "build" workflow's terminal). Any OTHER protected base
- * stays refused. Turning the flag on is a deliberate operator deployment action gated
- * on branch protection + scoped creds (the security-roundtable deviation from §7's
- * default-on). */
+ * stays refused. Real pushes additionally require forge creds (the vaulted git
+ * runner); without them ops fail cleanly and the run parks. */
 #include "aimee.h"
 
 #include "wfe_live_forge.h"

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -59,9 +59,10 @@ int main(void)
       assert(fabs(cfg.code_hybrid_weight_graph - 1.0) < 1e-9);
       assert(fabs(cfg.code_hybrid_rrf_k - 60.0) < 1e-9);
       assert(cfg.guardrails_blast_radius_advisory_enabled == 0);
-      /* SECURITY: the autonomous live forge (F4) must default OFF — an operator
-       * has to explicitly enable it before any autonomous run can open/merge a PR. */
-      assert(cfg.wfe_live_forge_enabled == 0);
+      /* The autonomous live forge (F4) defaults ON (operator ruling 2026-07-13);
+       * the merge-target rail still bounds every op, and wfe_live_forge_enabled:
+       * false opts out. */
+      assert(cfg.wfe_live_forge_enabled == 1);
       assert(cfg.db1_path[0] != '\0');
       assert(cfg.guardrails_semantic_advisory_only == 1);
       assert(cfg.skills_review_nudge_interval == 10);


### PR DESCRIPTION
## What

Flips the autonomous live forge to **default-on** (operator ruling, restoring the plan's original default): the forge provider registers at standup, and `wfe_live_forge_enabled: false` becomes the explicit opt-out — `config_save` now persists the disable instead of the enable, so an opt-out survives a config rewrite.

The safety rails are unchanged and re-checked on every op: `pr.open` only ever OPENS a PR against the repo's resolved trunk, `merge` only targets the unprotected autonomous base, any other protected ref fails closed, and each mutating git/gh call re-validates flag + rail (TOCTOU-safe). Without vaulted forge creds, ops fail cleanly and the run parks.

Comments/docs updated everywhere the old default was stated (config.h, wfe_live_forge.{c,h}, WORKFLOW_ACTIONS.md).

## Tests

`unit-test-config` default assertion flipped to ON and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)