### PR TITLE
Release: proposals trigger E2E, trigger generalization, delegate-policy routing, technical-writer persona, forge default-on

### DIFF
--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -144,6 +144,8 @@ nodes:
           - architect
           - qa
           - reviewer
+        eligible:
+          - technical-writer # the documentation domain expert joins when seatable
       quorum: 3
       max_rounds: 6
       focus: is the documentation complete, accurate, and clear for this feature?

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -285,6 +285,17 @@ appears in a repo, a schedule elapses, a webhook arrives) or a person (clicking
 set of generic trigger sources that you wire to whatever workflow you want —
 the trigger starts the run; what happens next is entirely the workflow's design.
 
+Sources are a registry in
+[src/server/trigger_scheduler.c](../src/server/trigger_scheduler.c): each entry
+is `{name, due, fire}` — `due` decides whether this tick should fire (a repo
+scanner polls every pass; cron matches its schedule), `fire` matches events and
+materializes artifacts, and files each run through the shared
+`trigger_file_run` back half (work item on the rule's pipeline + workspace +
+mode, per-run USD ceiling from `max_spend_usd` or the intake-wide default,
+audit log line). The tick loop owns the rest — per-rule rate limiting and the
+global `trigger.max_concurrent` — so adding a source is one table row plus its
+`fire`.
+
 Triggers are configured as a `trigger_rules` list in `aimee.yaml`. Each rule
 names a **source** (what fires it), how the filed run should execute (**mode**),
 and the **pipeline** (which workflow, in which repo):

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -257,9 +257,11 @@ The engine advances it one step at a time
   recorded against the step's content hash, so an approval is bound to the exact
   artifact it approved.
 
-A step resolves the working repository from `$AIMEE_WORKFLOW_REPO` (or the
-process cwd), see [Limitations](#current-limitations) for the
-run-in-a-specific-project gap.
+A step resolves the working repository from the work item's own `repo` when it
+names a local directory (a trigger rule's `pipeline.workspace` binds the run to
+that repository), falling back to `$AIMEE_WORKFLOW_REPO`, then the process cwd.
+See [Limitations](#current-limitations) for the forge-side residue of the old
+process-global behavior.
 
 ## Inspecting runs
 
@@ -343,13 +345,23 @@ configured git ref, and for every proposal it has not seen before it:
 1. materializes the proposal's content under `$AIMEE_HOME/triggers/proposals/`,
 2. files exactly one work item on `pipeline.template`, in `pipeline.workspace`,
    with the configured `mode` (default `autonomous`),
-3. de-duplicates by proposal, so re-scanning the same tree never files twice.
+3. de-duplicates by proposal, so re-scanning the same tree never files twice,
+4. stamps the run's USD ceiling — the rule's `max_spend_usd` if set, else the
+   same default every autonomous intake gets ($5.00; `AIMEE_AUTONOMY_MAX_USD`
+   overrides, `0` disables) — and wakes the autonomy scheduler so the run
+   starts immediately rather than on its next backstop sweep.
+
+`trigger.max_concurrent` is enforced at filing time: when that many
+trigger-filed runs are still active, further proposals are deferred (not
+dropped — the dedup key is the materialized proposal, so they file on a later
+scan once a slot frees). The work item's `repo` is the rule's
+`pipeline.workspace`, and every per-step block resolves its working directory
+from it, so the run executes in the watched repository.
 
 Merging a new proposal onto the watched branch is therefore all it takes to
 kick off a build — and with `mode: autonomous`, that build runs to its PR
-without further intervention (subject to `trigger.max_concurrent` and any
-`max_spend_usd` cap). Point the rule at a different `template` to run any other
-workflow you have authored.
+without further intervention. Point the rule at a different `template` to run
+any other workflow you have authored.
 
 > The filed run still enters through the same capped, audited intake as every
 > other run (see [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)); the trigger
@@ -368,10 +380,13 @@ These are real today and worth knowing before you lean on workflows:
    agents — but all of them require a `proposal_md`: there is still no way to
    start a workflow whose entry node isn't `author.proposal` without supplying
    proposal text. (There is still no Run button on the **Edit Workflows** page.)
-2. **Run-in-a-specific-project isn't wired.** A work-item has a `repo` field, but
-   the per-step blocks resolve their working directory from
-   `$AIMEE_WORKFLOW_REPO`/cwd rather than the work-item's `repo`, so binding a run
-   to a UI-selected project is incomplete.
+2. **Forge operations are process-global.** Per-step blocks now resolve their
+   working directory from the work-item's `repo` (when it names a local
+   directory; `$AIMEE_WORKFLOW_REPO`/cwd otherwise), so a triggered run executes
+   in its configured workspace. But the forge half (`git push`, `gh pr …` via
+   the vaulted runner) still runs in the server's own checkout, so PR-opening
+   workflows against a workspace that is not the server's primary repo are not
+   yet fully wired.
 3. **Composer ergonomics.** New steps are added disconnected; you wire order in
    the inspector. The **Edit Workflows** page has no live run/progress view — you
    start and watch runs on the separate **Workflow Actions** tab.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -305,7 +305,7 @@ trigger:
   max_concurrent: 1          # cap on concurrently-executing triggered runs
 
 trigger_rules:
-  - source: proposals              # scan a git repo for new proposals
+  - source: watch-dir              # scan a repo dir for new files (alias: proposals)
     event: docs/proposals/pending  # repo-relative dir to watch (this is the default)
     schedule: main                 # git ref/branch to read (default: auto-detected origin HEAD)
     mode: autonomous               # autonomous (default) | interactive
@@ -318,12 +318,12 @@ trigger_rules:
 
 | Field | Meaning |
 | --- | --- |
-| `source` | What fires the rule: `proposals`, `cron`, or a webhook source. |
-| `event` | Source-specific match. For `proposals`, the repo-relative directory to scan (default `docs/proposals/pending`). |
-| `schedule` | For `cron`, the cron expression. For `proposals`, the git ref/branch to read (default: auto-detected `origin` HEAD, then `HEAD`). |
+| `source` | What fires the rule: `watch-dir` (alias `proposals`), `cron`, or a webhook source. |
+| `event` | Source-specific match. For `watch-dir`/`proposals`, the repo-relative directory to scan (default `docs/proposals/pending`). |
+| `schedule` | For `cron`, the cron expression. For `watch-dir`/`proposals`, the git ref/branch to read (default: auto-detected `origin` HEAD, then `HEAD`). |
 | `mode` | Execution mode stamped on the filed work item — see below. `autonomous` (default) or `interactive`. |
 | `pipeline.template` | The workflow to start (any saved workflow name, e.g. `build`). |
-| `pipeline.workspace` | Absolute path of the git repo the run operates in (and, for `proposals`, the repo to scan). |
+| `pipeline.workspace` | Absolute path of the git repo the run operates in (and, for `watch-dir`/`proposals`, the repo to scan). |
 | `pipeline.max_spend_usd` | Optional per-run spend cap. |
 
 ### `mode`: autonomous vs. interactive
@@ -347,9 +347,11 @@ workflow that still pauses at a human gate partway through, or an `interactive`
 trigger into a fully hands-off workflow. Pick the trigger `mode` for the
 *start* decision; put in-flight gates in the *workflow*.
 
-### The `proposals` source
+### The `watch-dir` source (alias: `proposals`)
 
-The `proposals` source turns "a proposal was committed" into a workflow run. On
+The `watch-dir` source turns "a file was committed into a watched directory"
+into a workflow run — `proposals` is the original alias for the same scanner,
+whose default directory (`docs/proposals/pending`) is just one configuration. On
 each scan (roughly once a minute) it lists the proposal directory at the
 configured git ref, and for every proposal it has not seen before it:
 

--- a/docs/WORKFLOW_ACTIONS.md
+++ b/docs/WORKFLOW_ACTIONS.md
@@ -252,9 +252,11 @@ The page is read/UI only; the behavior it drives is governed by existing config:
   agent config (see [`DELEGATES.md`](DELEGATES.md)); with only CLI delegates, the draft
   endpoint returns an error and the button surfaces it.
 - **Autonomous execution** is governed by the wfe engine
-  ([`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). Notably the **live forge
-  is default-off** (`wfe_live_forge_enabled`): with it off, a run advances and parks at
-  gates without pushing a real PR, which is the safe default for exercising the page.
+  ([`AUTONOMOUS_DEVELOPMENT.md`](AUTONOMOUS_DEVELOPMENT.md)). The **live forge is
+  default-on** (`wfe_live_forge_enabled`); set it to `false` to exercise the page
+  without real pushes — a run then advances and parks at gates instead of opening a
+  PR. Even on, the merge-target rail bounds every op (PRs open-only against the
+  trunk; merges only to the unprotected autonomous base).
 - **Submit** is bounded by the intake's existing caps (a 1 MB proposal body cap and the
   intake-auth per-principal rate/concurrency limits); the user-supplied `repo` is
   handled by the same `/v1/dev/submit` intake that the CLI uses; its validation and

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -3,7 +3,7 @@
 A **persona** is the primary agent's identity, its system-prompt voice, craft
 principles, session-brief hints, the delegate roles it advertises, and its
 **delegate policy**. Personas are server-owned and user-extensible: aimee ships
-eight built-ins and seeds them as editable files, and you can add your own.
+nine built-ins and seeds them as editable files, and you can add your own.
 
 ## Built-in personas
 
@@ -17,14 +17,20 @@ eight built-ins and seeds them as editable files, and you can add your own.
 | `reviewer` | Senior **contrarian** code reviewer (thorough, comprehensive) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 | `reviewer-constructive` | Senior **constructive** code reviewer (assess as written) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 | `architect` | Software-architecture reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
+| `technical-writer` | Senior technical writer / documentation reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 
-The five reviewer personas (`qa`, `security`, `reviewer`,
-`reviewer-constructive`, `architect`) reframe the agent as a read-only senior
+The six reviewer personas (`qa`, `security`, `reviewer`,
+`reviewer-constructive`, `architect`, `technical-writer`) reframe the agent as a read-only senior
 reviewer: it investigates and surfaces findings with evidence, never editing the
 code. They share a common **Review Principles** block and each carry their own
 review methodology. `reviewer` and `reviewer-constructive` are a deliberate pair
 ,  the former is adversarial (tries to refute), the latter assesses the work as
-written, so a roundtable panel can blend both stances.
+written, so a roundtable panel can blend both stances. `technical-writer`
+judges the documentation of a change — accuracy against the code, completeness,
+clarity, runnable examples — and is an eligible seat on the default `build`
+workflow's documentation gate. It writes and reviews to a human standard:
+brevity first, and machine-sounding prose (AI clichés, filler, padded
+sentences) is itself a finding.
 
 ## Where personas live
 
@@ -33,7 +39,7 @@ Single markdown files, resolved project → user → built-in:
 - Project: `<project>/.aimee/personas/<name>.md`
 - User: `~/.config/aimee/personas/<name>.md`
 - Built-in fallback
-  (engineer/novel/songwriter/qa/security/reviewer/reviewer-constructive/architect)
+  (engineer/novel/songwriter/qa/security/reviewer/reviewer-constructive/architect/technical-writer)
 
 `aimee init` seeds the built-ins as editable files under
 `~/.config/aimee/personas/` (idempotent, it never overwrites an existing file),

--- a/docs/proposals/pending/trigger-blocks.md
+++ b/docs/proposals/pending/trigger-blocks.md
@@ -1,0 +1,68 @@
+# Triggers as workflow blocks — graph-native run starts
+
+## Why
+
+Triggers today live *outside* the workflow system: a `trigger_rules` list in
+`aimee.yaml` names a source (`watch-dir`/`proposals`, `cron`) and points it at a
+saved workflow. That works — the proposals pipeline files and completes runs
+hands-off — but it splits one design across two authoring surfaces. The
+workflow graph declares everything about a run *except* what starts it; the
+thing that starts it is a config stanza the composer never sees, validated by
+different code, with its own field vocabulary (`event`, `schedule`,
+`pipeline.workspace`) that overloads meanings per source.
+
+The trigger-source registry (`{name, due, fire}` in
+`src/server/trigger_scheduler.c`) already made sources pluggable. This proposal
+finishes the thought: a trigger becomes a **block** — the entry node of the
+workflow that wants it — so "what starts this workflow" is composed, validated,
+versioned, and displayed exactly like every other step.
+
+## What
+
+1. **A `trigger.*` block kind** in the catalog (`wfe_def.c`), starting with one
+   concrete block:
+   - `trigger.watch-dir` — params `{dir, ref, suffix}` (defaults
+     `docs/proposals/pending`, auto-detected origin HEAD, `.md`). Produces a
+     `proposal` artifact: the materialized content of each new file seen in the
+     watched directory, exactly what the `watch-dir` source materializes today.
+   - The block-kind namespace leaves room for `trigger.cron` and
+     `trigger.webhook` rows later; each is a thin adapter over the same
+     scheduler plumbing.
+2. **Validator rules**: a `trigger.*` block may appear only as the `start`
+   node, at most one per workflow, with no inbound edges and no `in` bindings.
+   Its `next` edge feeds the produced artifact into the graph (e.g.
+   `trigger.watch-dir → author.proposal` replaces the pre-supplied-proposal
+   special case with an explicit data edge).
+3. **Arming**: a saved workflow whose start node is a trigger block is an
+   *armed* workflow. The trigger scheduler's tick enumerates armed workflows
+   (same registry, same per-rule rate limit, same global
+   `trigger.max_concurrent`, same per-run USD ceiling policy) and instantiates
+   one work item per event through the existing `trigger_file_run` back half —
+   the run starts at the node *after* the trigger block, with the trigger's
+   artifact bound.
+4. **Workspace binding**: the armed workflow carries its repo binding
+   (`params.workspace` on the trigger block, or the project the workflow was
+   saved under in the webchat). Executors already honor the work item's own
+   repo (`wfe_repo_local`), so this closes the loop: one YAML file states
+   *watch this dir, in this repo, and run this graph*.
+5. **Compatibility**: `trigger_rules` keeps working unchanged — it is the
+   "arm someone else's workflow without editing it" form, and its sources and
+   the trigger blocks share one implementation. The webchat composer gains the
+   trigger blocks in the rail like any other block.
+
+## Acceptance
+
+- `aimee workflow validate` accepts a workflow whose start is
+  `trigger.watch-dir` and rejects a trigger block anywhere else in the graph
+  (non-start, inbound edge, `in` binding, or a second trigger).
+- Saving such a workflow arms it: committing a matching file into the watched
+  dir files exactly one run bound to the configured repo, with the standard
+  cost cap, visible in the Workflow Actions tab; re-scans never double-file.
+- Disabling/deleting the workflow disarms it (no orphaned watchers).
+- An equivalent `trigger_rules` stanza and an armed workflow produce
+  byte-identical work items (same intake, cap, audit events) for the same
+  event.
+- The `build` composition gains a sibling `build-triggered.yaml` example whose
+  entry is `trigger.watch-dir`, and `docs/WORKFLOWS.md` documents the block
+  form as the primary authoring path with `trigger_rules` as the external
+  alternative.

--- a/src/config.c
+++ b/src/config.c
@@ -808,9 +808,13 @@ static void config_set_defaults(config_t *cfg)
    cfg->css_style_graph_enabled = 1; /* default-on: the indexer builds the CSS style
                                         graph so the read-only css signals/report work
                                         out of the box (set false to opt out) */
-   cfg->wfe_live_forge_enabled = 0;  /* default-OFF (security): the autonomous live
-                                        forge stays unregistered until an operator
-                                        explicitly enables it (F4) */
+   cfg->wfe_live_forge_enabled = 1;  /* default-ON (operator ruling 2026-07-13,
+                                        restoring the plan's default): the live forge
+                                        registers at standup; set false to opt out.
+                                        The merge-target rail still bounds every op --
+                                        PRs open-only against the resolved trunk,
+                                        merges only to the unprotected autonomous
+                                        base -- and each op re-checks flag + rail. */
    cfg->audit_action_enabled = 1;    /* default-ON: the trajectory_export reader (S3)
                                         shipped, so the passive per-action audit row
                                         is on by default; set false to opt out */

--- a/src/config_mode.c
+++ b/src/config_mode.c
@@ -27,6 +27,8 @@ static aimee_mode_t mode_parse(const char *s)
       return AIMEE_MODE_ARCHITECT;
    if (s && strcasecmp(s, "reviewer-constructive") == 0)
       return AIMEE_MODE_REVIEWER_CONSTRUCTIVE;
+   if (s && strcasecmp(s, "technical-writer") == 0)
+      return AIMEE_MODE_TECH_WRITER;
    return AIMEE_MODE_ENGINEER;
 }
 

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -887,8 +887,8 @@ int config_save(const config_t *cfg)
       cJSON_AddStringToObject(root, "ocr_command", cfg->ocr_command);
    if (!cfg->css_style_graph_enabled) /* default-on: persist only the opt-out */
       cJSON_AddBoolToObject(root, "css_style_graph_enabled", 0);
-   if (cfg->wfe_live_forge_enabled) /* default-off: persist only the opt-in (enable) */
-      cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 1);
+   if (!cfg->wfe_live_forge_enabled) /* default-on: persist only the opt-out (disable) */
+      cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 0);
    if (!cfg->audit_action_enabled) /* default-on: persist only the opt-out (disable) */
       cJSON_AddBoolToObject(root, "audit_action_enabled", 0);
    if (cfg->audit_worm_enabled) /* default-off: persist only the opt-in (enable) */

--- a/src/config_trigger.c
+++ b/src/config_trigger.c
@@ -7,7 +7,8 @@
  *   max_concurrent: 2
  *
  * trigger_rules:
- *   - source: "github-webhook"   # valid sources include github-webhook, cron, proposals
+ *   - source: "github-webhook"   # valid sources include github-webhook, cron,
+ *                                # watch-dir (alias: proposals)
  *     event: "push"
  *     mode: "autonomous"         # "autonomous" (default) | "interactive"
  *     pipeline:

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -38,6 +38,21 @@ int agent_any_delegate_available(void);
  * gains no link dependency on provider_catalog. */
 void agent_set_route_health_filter(int (*fn)(const char *agent_name));
 
+/* Optional route-time delegate-POLICY filter, same mechanism as the health
+ * filter (returns nonzero to EXCLUDE the agent; NULL disables). The server
+ * registers a live-config predicate enforcing two invariants everywhere
+ * routing happens, not just on one dispatch path:
+ *   1) the PRIMARY passthrough — the agent named after config.provider — is
+ *      never a delegation target (the primary must not delegate back to
+ *      itself; roundtables already enforce this for panel seats);
+ *   2) a claude-CLI agent is a delegate only behind the explicit ToS-sensitive
+ *      operator opt-in (claude_cli_delegate_enabled).
+ * The structural half of (2) — a claude-CLI agent that is not server-hosted
+ * can never execute as a delegate — is enforced unconditionally in
+ * agent_is_available_for_routing, so even filter-less builds (CLI/tests) never
+ * route to a client-only claude. */
+void agent_set_route_policy_filter(int (*fn)(const agent_t *agent));
+
 int agent_has_role(const agent_t *agent, const char *role);
 int agent_supports_persona(const agent_t *agent, const char *persona);
 int agent_is_exec_role(const agent_t *agent, const char *role);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -316,12 +316,13 @@ typedef struct config
     * assistant's style-graph write path during indexing (WP-C). When off, the
     * indexer keeps only the legacy lexical CSS class-name scan. */
    int css_style_graph_enabled;
-   /* wfe_live_forge_enabled: gate (default 0, OFF) for the autonomous live forge
+   /* wfe_live_forge_enabled: gate (default 1, ON — operator ruling 2026-07-13,
+    * restoring the plan's default) for the autonomous live forge
     * (full-autonomous-development F4). When OFF the wfe forge provider is not
     * registered and every forge op fails closed, so an autonomous run can never
-    * open or merge a real PR. Turning it ON is a deliberate operator deployment
-    * action (branch protection + scoped creds + break-glass) — never a code default,
-    * per the security-roundtable deviation. */
+    * open or merge a real PR. Even ON, every op re-checks this flag AND the
+    * merge-target rail: PRs open-only against the resolved trunk, merges only
+    * to the unprotected autonomous base. Set false to opt out. */
    int wfe_live_forge_enabled;
    /* audit_action_enabled: emit a per-tool-call governed-action row (kind=
     * tool_action) to audit.log from pre_tool_check. Default-ON (the

--- a/src/headers/prompts.h
+++ b/src/headers/prompts.h
@@ -43,6 +43,7 @@ typedef enum
    AIMEE_MODE_REVIEWER = 5,              /* senior, thorough, contrarian code reviewer */
    AIMEE_MODE_ARCHITECT = 6,             /* software-architecture reviewer */
    AIMEE_MODE_REVIEWER_CONSTRUCTIVE = 7, /* constructive reviewer: assess as written */
+   AIMEE_MODE_TECH_WRITER = 8,           /* technical writer / documentation reviewer */
 } aimee_mode_t;
 
 /* Parse a mode name ("engineer", "novel", "songwriter", "qa", "security",

--- a/src/headers/wfe_live_forge.h
+++ b/src/headers/wfe_live_forge.h
@@ -1,7 +1,7 @@
 /* wfe_live_forge.h: register the live forge provider (F4).
  *
- * Installs a wfe_forge_t that does real git push + `gh` PR/CI/merge — but ONLY when
- * the operator has set wfe_live_forge_enabled=true (default OFF). Otherwise the
+ * Installs a wfe_forge_t that does real git push + `gh` PR/CI/merge — unless the
+ * operator has set wfe_live_forge_enabled=false (default ON). When disabled the
  * engine keeps its fail-closed stub. Called from wfe_autonomy_register. */
 #ifndef DEC_WFE_LIVE_FORGE_H
 #define DEC_WFE_LIVE_FORGE_H 1

--- a/src/persona.c
+++ b/src/persona.c
@@ -87,6 +87,16 @@ static const char *REVIEWER_CONSTRUCTIVE_BRIEF =
     "- You produce the review yourself; use READ-ONLY delegates only — `aimee delegate review "
     "\"...\"` (or diagnose, validate, research) to investigate in parallel.\n";
 
+static const char *TECH_WRITER_BRIEF =
+    "- Use `aimee index find <name>` / `aimee memory search <terms>` to locate the change under "
+    "review and the documentation around it.\n"
+    "- Trace each documented claim to the code and each new behaviour back to the docs; walk the "
+    "instructions as the least-context reader and note where they break.\n"
+    "- Write like a person and prefer brevity; treat AI-isms and padded, machine-sounding prose "
+    "in the docs as findings.\n"
+    "- You produce the review yourself; use READ-ONLY delegates only — `aimee delegate review "
+    "\"...\"` (or diagnose, validate, research) to investigate in parallel.\n";
+
 /* Built-ins. Roles are the delegate roles the persona may use, consistent with
  * its delegate policy (engineer: full set; novel: read-only checks only;
  * songwriter: none). */
@@ -107,6 +117,8 @@ static const builtin_persona_t g_builtins[] = {
     {"reviewer-constructive", AIMEE_MODE_REVIEWER_CONSTRUCTIVE,
      "Senior constructive code reviewer (assess as written)", "review,diagnose,validate,research",
      "", "", "readonly"},
+    {"technical-writer", AIMEE_MODE_TECH_WRITER, "Senior technical writer / documentation reviewer",
+     "review,diagnose,validate,research", "", "", "readonly"},
     {NULL, 0, NULL, NULL, NULL, NULL, NULL},
 };
 
@@ -175,6 +187,8 @@ static const char *builtin_brief(const builtin_persona_t *b)
       return ARCHITECT_BRIEF;
    if (b->mode == AIMEE_MODE_REVIEWER_CONSTRUCTIVE)
       return REVIEWER_CONSTRUCTIVE_BRIEF;
+   if (b->mode == AIMEE_MODE_TECH_WRITER)
+      return TECH_WRITER_BRIEF;
    return "";
 }
 

--- a/src/prompts.c
+++ b/src/prompts.c
@@ -432,6 +432,58 @@ static const char *PROMPT_REVIEWER_CONSTRUCTIVE_TEXT =
     "Write delegates are refused. Always use aimee delegates over the Agent tool\n"
     "(the Agent tool is disabled in aimee).\n";
 
+static const char *PROMPT_TECH_WRITER_TEXT =
+    "You are a senior technical writer reviewing the documentation of a change\n"
+    "in %s. Your role is to judge whether a reader who was not in the room can\n"
+    "understand, use, and operate what shipped: docs, READMEs, changelogs, API\n"
+    "references, and the prose around the code. You report findings; you do not\n"
+    "edit the code.\n"
+    "\n"
+    "## Workflow\n"
+    "1. UNDERSTAND: Establish what the change does and who has to read about\n"
+    "   it — end users, operators, or the next engineer.\n"
+    "2. TRACE: Follow each documented claim to the code and each behaviour in\n"
+    "   the code back to the docs; note what exists in only one of the two.\n"
+    "3. WALK THROUGH: Read as the least-context reader — follow the\n"
+    "   instructions literally and note where they break, skip a step, or\n"
+    "   assume unstated knowledge.\n"
+    "4. ASSESS STRUCTURE: Judge organisation, naming, headings, and examples —\n"
+    "   can a reader find the answer, and is every example runnable as shown?\n"
+    "5. REPORT: List concrete gaps and inaccuracies — missing docs, stale\n"
+    "   claims, broken examples, unclear prose — each with its location and a\n"
+    "   suggested fix, ranked by reader impact.\n"
+    "\n"
+    "## Focus\n"
+    "- Accuracy: the docs describe what the code actually does, not what it\n"
+    "  used to do or was meant to do.\n"
+    "- Completeness: new behaviour, flags, endpoints, and failure modes are\n"
+    "  documented where their readers will look.\n"
+    "- Clarity: plain sentences, defined terms, no unexplained jargon; examples\n"
+    "  that run as written.\n"
+    "- Consistency: terminology, tone, and structure match the surrounding\n"
+    "  documentation.\n"
+    "\n"
+    "## Voice\n"
+    "Hold your own writing and the docs under review to the same standard:\n"
+    "- Sound human. Plain, direct sentences; vary their rhythm; no padding.\n"
+    "- Prefer brevity. Say it once, cut filler, and stop when the point is\n"
+    "  made — a shorter accurate sentence beats a longer complete one.\n"
+    "- No AI-isms. Ban the stock phrases and tics of machine prose: 'delve',\n"
+    "  'leverage', 'seamless', 'robust', 'crucial', 'comprehensive',\n"
+    "  'streamline', 'elevate', 'unlock', 'It's important to note',\n"
+    "  'In today's fast-paced world', reflexive rule-of-three lists, and\n"
+    "  every-noun-gets-an-adjective inflation.\n"
+    "- Flag prose in the docs that reads machine-written, padded, or generic\n"
+    "  as a finding, the same as an inaccuracy.\n"
+    "\n"
+    "## Delegation\n"
+    "You produce the review yourself. Use READ-ONLY delegates only, to\n"
+    "investigate in parallel:\n"
+    "  aimee delegate <role> --persona <name> \"prompt\"   (roles: review, diagnose,\n"
+    "  validate, research; a persona is required, e.g. security, qa, architect)\n"
+    "Write delegates are refused. Always use aimee delegates over the Agent tool\n"
+    "(the Agent tool is disabled in aimee).\n";
+
 static const char *PROMPT_ARCHITECT_TEXT =
     "You are a senior software architect reviewing a change in %s.\n"
     "Your role is to judge how this change fits the system: its structure,\n"
@@ -580,6 +632,8 @@ aimee_mode_t aimee_mode_from_string(const char *name)
       return AIMEE_MODE_ARCHITECT;
    if (name && strcasecmp(name, "reviewer-constructive") == 0)
       return AIMEE_MODE_REVIEWER_CONSTRUCTIVE;
+   if (name && strcasecmp(name, "technical-writer") == 0)
+      return AIMEE_MODE_TECH_WRITER;
    return AIMEE_MODE_ENGINEER;
 }
 
@@ -601,6 +655,8 @@ const char *aimee_mode_to_string(aimee_mode_t mode)
       return "architect";
    case AIMEE_MODE_REVIEWER_CONSTRUCTIVE:
       return "reviewer-constructive";
+   case AIMEE_MODE_TECH_WRITER:
+      return "technical-writer";
    default:
       return "engineer";
    }
@@ -619,6 +675,7 @@ const char *prompt_principles_text(aimee_mode_t mode)
    case AIMEE_MODE_REVIEWER:
    case AIMEE_MODE_ARCHITECT:
    case AIMEE_MODE_REVIEWER_CONSTRUCTIVE:
+   case AIMEE_MODE_TECH_WRITER:
       return PROMPT_REVIEW_PRINCIPLES_TEXT;
    default:
       return PROMPT_CODE_PRINCIPLES_TEXT;
@@ -643,6 +700,8 @@ const char *prompt_persona_text(aimee_mode_t mode)
       return PROMPT_ARCHITECT_TEXT;
    case AIMEE_MODE_REVIEWER_CONSTRUCTIVE:
       return PROMPT_REVIEWER_CONSTRUCTIVE_TEXT;
+   case AIMEE_MODE_TECH_WRITER:
+      return PROMPT_TECH_WRITER_TEXT;
    default:
       return PROMPT_STANDARD_TEXT;
    }

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1284,6 +1284,14 @@ void agent_set_route_health_filter(int (*fn)(const char *agent_name))
    g_route_health_filter = fn;
 }
 
+/* Optional route-time delegate-policy filter; see agent_set_route_policy_filter. */
+static int (*g_route_policy_filter)(const agent_t *agent) = NULL;
+
+void agent_set_route_policy_filter(int (*fn)(const agent_t *agent))
+{
+   g_route_policy_filter = fn;
+}
+
 int agent_is_available_for_routing(const agent_t *agent)
 {
    if (!agent)
@@ -1294,6 +1302,16 @@ int agent_is_available_for_routing(const agent_t *agent)
     * healthy peer; routing returns NULL (clean "no agent" error) only when
     * every candidate is filtered out. */
    if (g_route_health_filter && agent->name[0] && g_route_health_filter(agent->name))
+      return 0;
+   /* A claude-CLI agent can only ever execute as a delegate SERVER-SIDE (a
+    * client-only claude has no server session to drive — dispatch would just
+    * fail). Structural, so it is enforced even with no policy filter
+    * registered; the config-dependent rules (the claude_cli_delegate_enabled
+    * ToS opt-in, primary self-delegation) live in the registered policy
+    * filter, which sees the live config. */
+   if (agent_is_claude_cli(agent) && !agent->is_server_hosted)
+      return 0;
+   if (g_route_policy_filter && g_route_policy_filter(agent))
       return 0;
    if (strcmp(agent->backend, AGENT_BACKEND_TMUX_CLI) == 0)
    {

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -383,20 +383,27 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
     * them and the pane exits instantly ("failed to send prompt to tmux
     * session"). A non-login shell inherits the tmux server's env (= aimee-
     * server's, which carries the image PATH), so the CLI resolves. */
+   /* shell_escape() only escapes embedded single quotes; the caller supplies the
+    * surrounding '...'. Leaving them off worked only while cli_cmd was a single
+    * word ("claude"): a multi-word command (the AIMEE_SESSION_ID=<sid> stamp, or
+    * --model/--dangerously-skip-permissions flags) gets word-split by the outer
+    * shell, tmux re-joins the pieces, and the pane's `sh -c` ends up executing
+    * just the leading env assignment — exiting 0 instantly and taking the tmux
+    * server down with it ("failed to send prompt to tmux session"). */
    char create_cmd[1024];
    char *esc_cli = shell_escape(cli_cmd && cli_cmd[0] ? cli_cmd : "claude");
    if (work_dir && work_dir[0])
    {
       char *esc_dir = shell_escape(work_dir);
       snprintf(create_cmd, sizeof(create_cmd),
-               "tmux new-session -d -s '%s' -x 220 -y 50 -c %s /bin/sh -c %s 2>/dev/null",
+               "tmux new-session -d -s '%s' -x 220 -y 50 -c '%s' /bin/sh -c '%s' 2>/dev/null",
                session_name, esc_dir, esc_cli);
       free(esc_dir);
    }
    else
    {
       snprintf(create_cmd, sizeof(create_cmd),
-               "tmux new-session -d -s '%s' -x 220 -y 50 /bin/sh -c %s 2>/dev/null", session_name,
+               "tmux new-session -d -s '%s' -x 220 -y 50 /bin/sh -c '%s' 2>/dev/null", session_name,
                esc_cli);
    }
    free(esc_cli);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1835,6 +1835,33 @@ static int server_agent_route_is_down(const char *agent_name)
    return provider_catalog_get_health(agent_name) == CATALOG_HEALTH_DOWN;
 }
 
+/* Route-time delegate-policy predicate (returns nonzero to EXCLUDE):
+ * 1) the primary passthrough — the agent named after config.provider — is
+ *    never a delegation target: the primary must not delegate back to itself
+ *    (observed in the wild as a streak of failed 'code' delegations to the
+ *    operator's own OAuth claude entry). Matched by NAME only, deliberately:
+ *    other agents that merely share the provider tag (e.g. gateway-routed
+ *    anthropic models) are legitimate delegates.
+ * 2) a claude-CLI agent (tmux/provider-cli claude — the interactive-login
+ *    ToS-sensitive class) is a delegate ONLY behind the explicit operator
+ *    opt-in claude_cli_delegate_enabled — previously enforced on one dispatch
+ *    path and on panel seats, now at every routing decision.
+ * A config_load failure fails closed for the gated class (a claude-CLI agent
+ * is excluded, everything else routes) rather than voiding the opt-in. */
+static int server_agent_route_policy_excluded(const agent_t *ag)
+{
+   if (!ag)
+      return 1;
+   config_t cfg;
+   if (config_load(&cfg) != 0)
+      return agent_is_claude_cli(ag);
+   if (cfg.provider[0] && ag->name[0] && strcasecmp(ag->name, cfg.provider) == 0)
+      return 1;
+   if (agent_is_claude_cli(ag) && !cfg.claude_cli_delegate_enabled)
+      return 1;
+   return 0;
+}
+
 /* Production agent-name resolver for the vault bootstrap: validate against
  * agents.json and return the canonical agent name. agent_load_config is cached,
  * so the per-secret calls are cheap. */
@@ -2016,6 +2043,10 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * delegates. Routing falls back to a healthy peer; only when every candidate
     * for a role is DOWN does routing return a clean "no agent available". */
    agent_set_route_health_filter(server_agent_route_is_down);
+   /* Delegate-policy invariants at every routing decision: the primary never
+    * delegates to itself, and a claude-CLI agent is only a delegate behind the
+    * explicit claude_cli_delegate_enabled opt-in. */
+   agent_set_route_policy_filter(server_agent_route_policy_excluded);
    LOG_INFO("server",
             "initialized (v%s, protocol %d, background=%d session=%d threads); /v1 HTTP "
             "surface owns the listeners",

--- a/src/server/server_dev_submit.c
+++ b/src/server/server_dev_submit.c
@@ -7,11 +7,11 @@
 #include "cJSON.h"
 #include "aimee_home.h"    /* aimee_home */
 #include "router_advise.h" /* router_autonomous_pick / router_autonomous_audit */
+#include "wfe_autonomy.h"  /* wfe_autonomy_default_max_cost_usd — shared intake cap policy */
 #include "wfe_engine.h"    /* wfe_work_item_resolve */
 #include "wfe_scheduler.h" /* wfe_scheduler_notify */
 #include "wfe_store.h"     /* db1_work_item_submit_capped / _set_terminal / _set_cost_cap */
 #include <errno.h>
-#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -168,18 +168,11 @@ int dev_submit_run(const char *proposal_md, const char *workflow_opt, const char
       router_autonomous_audit(id, workflow, autoroute_src, autoroute_raw, autoroute_clamped,
                               autoroute_tag);
    /* WP-5: a per-run USD budget ceiling so a runaway autonomous run parks
-    * (budget_exceeded) instead of burning unbounded delegate cost. Default $5.00;
-    * AIMEE_AUTONOMY_MAX_USD overrides (set it to 0 to disable the cap). */
+    * (budget_exceeded) instead of burning unbounded delegate cost. The default
+    * policy ($5.00, AIMEE_AUTONOMY_MAX_USD override, 0 disables) is shared with
+    * every other autonomous intake (wfe_autonomy_default_max_cost_usd). */
    {
-      double cap_usd = 5.0;
-      const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
-      if (v && v[0])
-      {
-         char *e = NULL;
-         double d = strtod(v, &e);
-         if (e && *e == '\0' && isfinite(d) && d >= 0) /* reject inf/NaN: would void the cap */
-            cap_usd = d;
-      }
+      double cap_usd = wfe_autonomy_default_max_cost_usd();
       if (cap_usd > 0)
          db1_work_item_set_cost_cap(id, cap_usd);
    }

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -21,11 +21,13 @@
 #include "trigger_scheduler.h"
 #include "util.h"
 #include "wfe_engine.h"
+#include "wfe_scheduler.h" /* wfe_scheduler_notify — drive a filed run now, not on the 30s sweep */
 
 #include <pthread.h>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -440,7 +442,55 @@ static int trigger_write_atomic(const char *path, const char *bytes)
    return 0;
 }
 
-static void scan_proposals(const trigger_rule_t *rule)
+/* The per-run USD ceiling for a trigger-filed run: the rule's explicit
+ * pipeline.max_spend_usd when set (> 0), else the same default every autonomous
+ * intake applies ($5.00, AIMEE_AUTONOMY_MAX_USD override, 0 disables) — a
+ * trigger-filed run must never be the one intake path with NO runaway cost cap.
+ * Mirrors dev_submit_run (server_dev_submit.c). Returns 0 for "no cap". */
+static double trigger_cost_cap(const trigger_rule_t *rule)
+{
+   if (rule->max_spend_usd > 0 && isfinite(rule->max_spend_usd))
+      return rule->max_spend_usd;
+   double cap_usd = 5.0;
+   const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
+   if (v && v[0])
+   {
+      char *e = NULL;
+      double d = strtod(v, &e);
+      if (e && *e == '\0' && isfinite(d) && d >= 0) /* reject inf/NaN: would void the cap */
+         cap_usd = d;
+   }
+   return cap_usd;
+}
+
+/* Count ACTIVE work items that were filed by the proposals trigger (their
+ * proposal artifact lives under <home>/triggers/proposals/), across all rules —
+ * trigger.max_concurrent is a GLOBAL cap on concurrently-executing triggered
+ * runs. Returns the count, or -1 on a DB read failure (caller fails closed:
+ * files nothing this pass rather than overshooting the cap). */
+static int trigger_active_filed_runs(const char *home)
+{
+   char prefix[1100];
+   if (snprintf(prefix, sizeof(prefix), "%s/triggers/proposals/", home) >= (int)sizeof(prefix))
+      return -1;
+   db1_work_item_t *items = NULL;
+   int n = db1_work_item_list(&items);
+   if (n < 0 || !items)
+   {
+      free(items);
+      return n < 0 ? -1 : 0;
+   }
+   int active = 0;
+   size_t plen = strlen(prefix);
+   for (int i = 0; i < n; i++)
+      if (strcmp(items[i].state, "active") == 0 &&
+          strncmp(items[i].proposal_path, prefix, plen) == 0)
+         active++;
+   free(items);
+   return active;
+}
+
+static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
 {
    if (!rule || !rule->workspace[0] || !rule->pipeline_template[0])
       return;
@@ -510,8 +560,41 @@ static void scan_proposals(const trigger_rule_t *rule)
       return;
    }
 
+   /* trigger.max_concurrent: admission cap on concurrently-executing triggered
+    * runs. Filing is deferred, not lost — the per-proposal dedup key is the
+    * materialized artifact path, so an un-filed proposal is re-seen and filed on
+    * a later pass once a slot frees up. A cap <= 0 means uncapped. */
+   int budget = -1; /* uncapped */
+   if (max_concurrent > 0)
+   {
+      int active = trigger_active_filed_runs(home);
+      if (active < 0)
+      {
+         aimee_log(LOG_WARN, "trigger.sched",
+                   "proposals: could not count active triggered runs; deferring this pass");
+         return; /* fail closed: never overshoot the cap on a DB read fault */
+      }
+      budget = max_concurrent - active;
+      if (budget <= 0)
+      {
+         aimee_log(LOG_INFO, "trigger.sched",
+                   "proposals: %d active triggered run(s) >= max_concurrent=%d; deferring",
+                   active, max_concurrent);
+         return;
+      }
+   }
+
+   int filed = 0;
    for (int i = 0; i < n; i++)
    {
+      if (budget == 0)
+      {
+         aimee_log(LOG_INFO, "trigger.sched",
+                   "proposals: max_concurrent=%d reached; remaining proposals deferred to a "
+                   "later pass",
+                   max_concurrent);
+         break;
+      }
       char proposal_path[1200];
       if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md", home,
                    entries[i].sha) >= (int)sizeof(proposal_path))
@@ -549,12 +632,28 @@ static void scan_proposals(const trigger_rule_t *rule)
       rc = wfe_work_item_create(rule->pipeline_template, rule->workspace, proposal_path, mode, id,
                                 err, sizeof(err));
       if (rc == 0 && id[0])
+      {
+         /* Per-run USD ceiling (rule's max_spend_usd, else the intake default) so
+          * a triggered run parks budget_exceeded instead of burning unbounded
+          * delegate cost. Best-effort, mirroring dev_submit_run. */
+         double cap = trigger_cost_cap(rule);
+         if (cap > 0)
+            db1_work_item_set_cost_cap(id, cap);
+         filed++;
+         if (budget > 0)
+            budget--;
          aimee_log(LOG_INFO, "trigger.sched", "filed proposal workflow=%s repo=%s sha=%s id=%s",
                    rule->pipeline_template, rule->workspace, entries[i].sha, id);
+      }
       else
          aimee_log(LOG_WARN, "trigger.sched", "proposal create skipped/failed repo=%s sha=%s: %s",
                    rule->workspace, entries[i].sha, err[0] ? err : "already exists");
    }
+
+   /* Wake the autonomy driver so a just-filed run advances now rather than on
+    * its 30s backstop sweep (parity with the /v1/dev/submit intake). */
+   if (filed > 0)
+      wfe_scheduler_notify();
 }
 
 /* ------------------------------------------------------------------ */
@@ -872,7 +971,7 @@ static void sched_tick(void)
          if (now - g_last_fired[i] < 55)
             continue;
          g_last_fired[i] = now;
-         scan_proposals(rule);
+         scan_proposals(rule, cfg.trigger_max_concurrent);
          continue;
       }
 

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -20,6 +20,7 @@
 #include "skill_curator.h"
 #include "trigger_scheduler.h"
 #include "util.h"
+#include "wfe_autonomy.h" /* wfe_autonomy_default_max_cost_usd — the shared intake cap policy */
 #include "wfe_engine.h"
 #include "wfe_scheduler.h" /* wfe_scheduler_notify — drive a filed run now, not on the 30s sweep */
 
@@ -443,24 +444,47 @@ static int trigger_write_atomic(const char *path, const char *bytes)
 }
 
 /* The per-run USD ceiling for a trigger-filed run: the rule's explicit
- * pipeline.max_spend_usd when set (> 0), else the same default every autonomous
- * intake applies ($5.00, AIMEE_AUTONOMY_MAX_USD override, 0 disables) — a
- * trigger-filed run must never be the one intake path with NO runaway cost cap.
- * Mirrors dev_submit_run (server_dev_submit.c). Returns 0 for "no cap". */
+ * pipeline.max_spend_usd when set (> 0), else the intake-wide default policy
+ * (wfe_autonomy_default_max_cost_usd, shared with /v1/dev/submit) — a
+ * trigger-filed run must never be the one intake path with NO runaway cost
+ * cap. Returns 0 for "no cap". */
 static double trigger_cost_cap(const trigger_rule_t *rule)
 {
    if (rule->max_spend_usd > 0 && isfinite(rule->max_spend_usd))
       return rule->max_spend_usd;
-   double cap_usd = 5.0;
-   const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
-   if (v && v[0])
+   return wfe_autonomy_default_max_cost_usd();
+}
+
+/* File one run for a materialized trigger artifact — the shared back half of
+ * every artifact-producing trigger source: create the work item on the rule's
+ * pipeline (in the rule's workspace, with the rule's mode), stamp the per-run
+ * USD ceiling, and log the outcome. `what` labels the artifact in logs (e.g.
+ * "sha=<blob>"). De-duplication is the SOURCE's job — each source knows its
+ * own identity key; this helper is pure filing. Returns 0 filed (out_id set),
+ * -1 refused/failed. */
+static int trigger_file_run(const trigger_rule_t *rule, const char *artifact_path, const char *what,
+                            char out_id[80])
+{
+   char err[256] = "";
+   out_id[0] = '\0';
+   /* mode drives whether the autonomy scheduler advances the run hands-off
+    * ("autonomous", the default when the rule omits it) or the item parks for
+    * a human to drive in the webchat ("interactive"). */
+   const char *mode = rule->mode[0] ? rule->mode : "autonomous";
+   if (wfe_work_item_create(rule->pipeline_template, rule->workspace, artifact_path, mode, out_id,
+                            err, sizeof(err)) != 0 ||
+       !out_id[0])
    {
-      char *e = NULL;
-      double d = strtod(v, &e);
-      if (e && *e == '\0' && isfinite(d) && d >= 0) /* reject inf/NaN: would void the cap */
-         cap_usd = d;
+      aimee_log(LOG_WARN, "trigger.sched", "%s: create skipped/failed repo=%s %s: %s", rule->source,
+                rule->workspace, what, err[0] ? err : "already exists");
+      return -1;
    }
-   return cap_usd;
+   double cap = trigger_cost_cap(rule);
+   if (cap > 0)
+      db1_work_item_set_cost_cap(out_id, cap);
+   aimee_log(LOG_INFO, "trigger.sched", "filed run workflow=%s repo=%s %s id=%s",
+             rule->pipeline_template, rule->workspace, what, out_id);
+   return 0;
 }
 
 /* Count ACTIVE work items that were filed by the proposals trigger (their
@@ -624,30 +648,14 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
       }
       free(blob);
 
-      char id[80] = "", err[256] = "";
-      /* mode drives whether the autonomy scheduler advances the run hands-off
-       * ("autonomous", the default when the rule omits it) or the item parks for
-       * a human to drive in the webchat ("interactive"). */
-      const char *mode = rule->mode[0] ? rule->mode : "autonomous";
-      rc = wfe_work_item_create(rule->pipeline_template, rule->workspace, proposal_path, mode, id,
-                                err, sizeof(err));
-      if (rc == 0 && id[0])
+      char what[64], id[80];
+      snprintf(what, sizeof(what), "sha=%s", entries[i].sha);
+      if (trigger_file_run(rule, proposal_path, what, id) == 0)
       {
-         /* Per-run USD ceiling (rule's max_spend_usd, else the intake default) so
-          * a triggered run parks budget_exceeded instead of burning unbounded
-          * delegate cost. Best-effort, mirroring dev_submit_run. */
-         double cap = trigger_cost_cap(rule);
-         if (cap > 0)
-            db1_work_item_set_cost_cap(id, cap);
          filed++;
          if (budget > 0)
             budget--;
-         aimee_log(LOG_INFO, "trigger.sched", "filed proposal workflow=%s repo=%s sha=%s id=%s",
-                   rule->pipeline_template, rule->workspace, entries[i].sha, id);
       }
-      else
-         aimee_log(LOG_WARN, "trigger.sched", "proposal create skipped/failed repo=%s sha=%s: %s",
-                   rule->workspace, entries[i].sha, err[0] ? err : "already exists");
    }
 
    /* Wake the autonomy driver so a just-filed run advances now rather than on
@@ -950,6 +958,60 @@ static int config_has_cron_job(const config_t *cfg, const char *id)
 }
 
 /* ------------------------------------------------------------------ */
+/* Trigger-source registry                                             */
+/* ------------------------------------------------------------------ */
+
+/* A trigger source turns "something happened" into filed runs. The tick loop
+ * owns the shared plumbing — one probe per rule per ~minute window, the global
+ * trigger.max_concurrent handed to fire() — and each source owns its own event
+ * matching, artifact materialization, and de-duplication. Adding a source is
+ * one table row: `due` says whether this tick should fire (a scanner that
+ * polls on every pass returns 1 unconditionally; cron matches its schedule),
+ * `fire` does the work and files runs through trigger_file_run. */
+typedef struct
+{
+   const char *name;
+   int (*due)(const trigger_rule_t *rule, const struct tm *tm);
+   void (*fire)(const trigger_rule_t *rule, int max_concurrent);
+} trigger_source_t;
+
+static int proposals_due(const trigger_rule_t *rule, const struct tm *tm)
+{
+   (void)rule;
+   (void)tm;
+   return 1; /* poll the repo every pass; per-proposal dedup makes re-scans idempotent */
+}
+
+static void proposals_fire(const trigger_rule_t *rule, int max_concurrent)
+{
+   scan_proposals(rule, max_concurrent);
+}
+
+static int cron_due(const trigger_rule_t *rule, const struct tm *tm)
+{
+   return rule->schedule[0] && schedule_matches(rule->schedule, tm) == 1;
+}
+
+static void cron_fire(const trigger_rule_t *rule, int max_concurrent)
+{
+   (void)max_concurrent; /* cron files a legacy pipeline, not a wfe work item */
+   trigger_scheduler_fire_rule(rule);
+}
+
+static const trigger_source_t g_trigger_sources[] = {
+    {"proposals", proposals_due, proposals_fire},
+    {"cron", cron_due, cron_fire},
+};
+
+static const trigger_source_t *trigger_source_find(const char *name)
+{
+   for (size_t i = 0; i < sizeof(g_trigger_sources) / sizeof(g_trigger_sources[0]); i++)
+      if (strcmp(g_trigger_sources[i].name, name) == 0)
+         return &g_trigger_sources[i];
+   return NULL;
+}
+
+/* ------------------------------------------------------------------ */
 /* Scheduler tick                                                      */
 /* ------------------------------------------------------------------ */
 
@@ -965,31 +1027,17 @@ static void sched_tick(void)
    for (int i = 0; i < cfg.trigger_rule_count && i < TRIGGER_RULES_MAX; i++)
    {
       const trigger_rule_t *rule = &cfg.trigger_rules[i];
-
-      if (strcmp(rule->source, "proposals") == 0)
-      {
-         if (now - g_last_fired[i] < 55)
-            continue;
-         g_last_fired[i] = now;
-         scan_proposals(rule, cfg.trigger_max_concurrent);
+      const trigger_source_t *src = trigger_source_find(rule->source);
+      if (!src)
+         continue; /* unknown source (e.g. a webhook handled on its own ingress) */
+      if (!src->due(rule, &tm))
          continue;
-      }
-
-      if (strcmp(rule->source, "cron") != 0)
-         continue;
-      if (!rule->schedule[0])
-         continue;
-
-      int match = schedule_matches(rule->schedule, &tm);
-      if (match != 1)
-         continue;
-
-      /* Deduplicate: skip if we fired within the last 55 seconds */
+      /* Shared per-rule rate limit: one fire per ~minute window, so the 30s
+       * tick never double-fires a minute-granular source. */
       if (now - g_last_fired[i] < 55)
          continue;
-
       g_last_fired[i] = now;
-      trigger_scheduler_fire_rule(rule);
+      src->fire(rule, cfg.trigger_max_concurrent);
    }
 
    for (int i = 0; i < cfg.cron_job_count && i < CRON_JOBS_MAX; i++)

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -999,6 +999,11 @@ static void cron_fire(const trigger_rule_t *rule, int max_concurrent)
 }
 
 static const trigger_source_t g_trigger_sources[] = {
+    /* watch-dir is the canonical generic source: watch a repo-relative
+     * directory at a git ref and file one run per new file. `proposals` is the
+     * original alias for the same scanner — its default dir
+     * (docs/proposals/pending) is just one configuration of watch-dir. */
+    {"watch-dir", proposals_due, proposals_fire},
     {"proposals", proposals_due, proposals_fire},
     {"cron", cron_due, cron_fire},
 };

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -578,8 +578,8 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
       if (budget <= 0)
       {
          aimee_log(LOG_INFO, "trigger.sched",
-                   "proposals: %d active triggered run(s) >= max_concurrent=%d; deferring",
-                   active, max_concurrent);
+                   "proposals: %d active triggered run(s) >= max_concurrent=%d; deferring", active,
+                   max_concurrent);
          return;
       }
    }

--- a/src/server/wfe_live_forge.c
+++ b/src/server/wfe_live_forge.c
@@ -5,17 +5,17 @@
  * (mcp_git_run, which injects the forge token via git_cred_inject) and the autonomous
  * merge-target rail (wfe_autonomous_base / _target_ok).
  *
- * SECURITY: registered ONLY when the operator has set wfe_live_forge_enabled=true
- * (default OFF — see config.h). Even once registered, EVERY op re-checks the flag
- * AND the merge-target rail via forge_allowed() and fails closed if either is off —
- * including immediately before each mutating git/gh call, so a config flip or a
- * base misconfig mid-op can't slip a push/PR/merge through (TOCTOU-safe). An
+ * SECURITY: registered unless the operator has set wfe_live_forge_enabled=false
+ * (default ON — operator ruling 2026-07-13, restoring the plan's default; see
+ * config.h). Registered or not, EVERY op re-checks the flag AND the merge-target
+ * rail via forge_allowed() and fails closed if either is off — including
+ * immediately before each mutating git/gh call, so a config flip or a base
+ * misconfig mid-op can't slip a push/PR/merge through (TOCTOU-safe). An
  * autonomous run can never MERGE into a protected branch; it may OPEN a
  * human-reviewed PR against the repo's own default branch (trunk) -- open-only, never
  * auto-merged (the default "build" workflow's terminal). Any OTHER protected base
- * stays refused. Turning the flag on is a deliberate operator deployment action gated
- * on branch protection + scoped creds (the security-roundtable deviation from §7's
- * default-on). */
+ * stays refused. Real pushes additionally require forge creds (the vaulted git
+ * runner); without them ops fail cleanly and the run parks. */
 #include "aimee.h"
 
 #include "wfe_live_forge.h"

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -10,6 +10,7 @@
 #include "log.h"
 #include "wfe_autonomy.h"
 #include "wfe_blocks.h" /* wfe_worktree_cleanup (terminal) + wfe_worktree_orphan_gc (age-based) */
+#include "wfe_iface.h"  /* wfe_repo_local — resolve each item's own repo for cleanup */
 #include "wfe_store.h"
 
 #include <pthread.h>
@@ -53,8 +54,7 @@ void wfe_scheduler_run_once(void)
       {
          if (items[i].worktree[0])
          {
-            const char *rl = getenv("AIMEE_WORKFLOW_REPO");
-            if (wfe_worktree_cleanup(items[i].worktree, (rl && rl[0]) ? rl : ".") == 0)
+            if (wfe_worktree_cleanup(items[i].worktree, wfe_repo_local(items[i].repo)) == 0)
                db1_work_item_set_worktree(items[i].work_item_id, "");
          }
          continue;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -423,6 +423,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-roadmap-auto \
                $(TESTPREFIX)/unit-test-kb-mdl \
                $(TESTPREFIX)/unit-test-trigger \
+               $(TESTPREFIX)/unit-test-trigger-e2e \
                $(TESTPREFIX)/unit-test-kb-mining \
                $(TESTPREFIX)/unit-test-corpus-structural \
                $(TESTPREFIX)/unit-test-corpus-jobs \
@@ -2222,6 +2223,27 @@ $(TESTPREFIX)/unit-test-delegate-plan: $(OBJDIR)/tests/test_delegate_plan.o \
 $(TESTPREFIX)/unit-test-delegate-role: $(OBJDIR)/tests/test_delegate_role.o \
                              $(OBJDIR)/server/delegate_role.o $(OBJDIR)/role_templates.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
+
+# Trigger end-to-end: the REAL scan_proposals (textually included, real git
+# subprocesses + real DB1) files a work item from a committed pending proposal
+# and the real autonomy scheduler drives it to terminal (stub executors only).
+$(TESTPREFIX)/unit-test-trigger-e2e: $(OBJDIR)/tests/test_trigger_e2e.o \
+                                    $(OBJDIR)/server/wfe_scheduler.o $(OBJDIR)/workflow/wfe_autonomy.o \
+                                    $(OBJDIR)/tests/support/log_stub.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/tests/support/config_autonomy_stub.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/workflow/wfe_roundtable.o $(OBJDIR)/workflow/wfe_approval.o \
+                                    $(OBJDIR)/workflow/wfe_verdict.o $(OBJDIR)/workflow/wfe_deliver.o \
+                                    $(OBJDIR)/workflow/wfe_manager_artifacts.o \
+                                    $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
+                                    $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+$(OBJDIR)/tests/test_trigger_e2e.o: tests/test_trigger_e2e.c server/trigger_scheduler.c
+	@mkdir -p $(dir $@)
+	$(CC) -c $(TEST_C_FLAGS) -I. -o $@ $<
 
 $(TESTPREFIX)/unit-test-trigger: $(OBJDIR)/tests/test_trigger.o $(OBJDIR)/cJSON.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -173,6 +173,59 @@ static void test_agent_find(void)
    assert(agent_find(&cfg, "missing") == NULL);
 }
 
+/* Route-time delegate-policy filter (the server registers a live-config
+ * predicate; here a test double): an excluded agent is never routed, even when
+ * it is the preferred default agent — the primary must not delegate to itself. */
+static int test_policy_exclude_primary(const agent_t *ag)
+{
+   return strcmp(ag->name, "primary") == 0;
+}
+
+static void test_agent_route_policy_filter(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 2;
+   strcpy(cfg.default_agent, "primary");
+   strcpy(cfg.agents[0].name, "primary");
+   strcpy(cfg.agents[0].roles[0], "summarize");
+   cfg.agents[0].role_count = 1;
+   cfg.agents[0].cost_tier = 0;
+   cfg.agents[0].enabled = 1;
+   strcpy(cfg.agents[1].name, "peer");
+   strcpy(cfg.agents[1].roles[0], "summarize");
+   cfg.agents[1].role_count = 1;
+   cfg.agents[1].cost_tier = 1;
+   cfg.agents[1].enabled = 1;
+
+   /* Baseline: the default agent is preferred. */
+   assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
+
+   /* With the policy filter registered, the excluded agent is unroutable
+    * EVERYWHERE — including as the preferred default — and routing falls back
+    * to the peer. */
+   agent_set_route_policy_filter(test_policy_exclude_primary);
+   assert(agent_is_available_for_routing(&cfg.agents[0]) == 0);
+   assert(agent_route(&cfg, "summarize") == &cfg.agents[1]);
+   agent_set_route_policy_filter(NULL);
+   assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
+}
+
+/* Structural rule (no filter needed): a claude-CLI agent that is not
+ * server-hosted has no server session to drive — it can never be a delegate,
+ * so routing refuses it before any PATH/credential probing. */
+static void test_agent_route_client_only_claude_excluded(void)
+{
+   agent_t a;
+   memset(&a, 0, sizeof(a));
+   strcpy(a.name, "claude");
+   strcpy(a.cli_kind, "claude");
+   strcpy(a.backend, AGENT_BACKEND_TMUX_CLI);
+   a.enabled = 1;
+   a.is_server_hosted = 0;
+   assert(agent_is_available_for_routing(&a) == 0);
+}
+
 static void test_agent_route(void)
 {
    agent_config_t cfg;
@@ -592,7 +645,11 @@ static void test_agent_config_provider_cli_roundtrip(void)
    assert(strcmp(loaded.agents[5].cli_kind, "claude-code") == 0);
    assert(strcmp(loaded.agents[5].cli_cmd, "/bin/echo") == 0);
    assert(loaded.agents[5].session_reuse == 1);
-   assert(agent_is_available_for_routing(&loaded.agents[5]) == 1);
+   /* A claude-CLI agent that is NOT server-hosted (no `is_server_hosted` in its
+    * record) is structurally excluded from delegate routing: a client-only
+    * claude has no server session to drive, so dispatch could only fail. This
+    * short-circuits before any tmux/PATH probing, so it holds everywhere. */
+   assert(agent_is_available_for_routing(&loaded.agents[5]) == 0);
 
    assert(agent_save_config(&loaded) == 0);
 
@@ -631,7 +688,8 @@ static void test_agent_config_provider_cli_roundtrip(void)
    assert(strcmp(reloaded.agents[5].cli_kind, "claude-code") == 0);
    assert(strcmp(reloaded.agents[5].cli_cmd, "/bin/echo") == 0);
    assert(reloaded.agents[5].session_reuse == 1);
-   assert(agent_is_available_for_routing(&reloaded.agents[5]) == 1);
+   /* Still excluded after the save/reload roundtrip (see the load-side assert). */
+   assert(agent_is_available_for_routing(&reloaded.agents[5]) == 0);
 
    if (old_path)
    {
@@ -2326,6 +2384,8 @@ int main(void)
    test_agent_supports_persona();
    test_agent_find();
    test_agent_route();
+   test_agent_route_policy_filter();
+   test_agent_route_client_only_claude_excluded();
    test_agent_route_with_caps_honors_tools_enabled();
    test_agent_route_with_caps_honors_context_override();
    test_current_code_only_role_tool_policy();

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -31,6 +31,11 @@ static long long test_mono_ms(void)
    return (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
+/* Path the fake tmux appends every `new-session` argv element to (one per
+ * line, bracketed), so the create test can assert the pane command reached
+ * tmux as a single intact argument rather than word-split fragments. */
+static char g_createlog[300];
+
 /* Path the fake tmux appends every `send-keys` invocation to, so a test can
  * assert which interrupt key (if any) the cancel path sent. */
 static char g_sendlog[320];
@@ -42,6 +47,7 @@ static void install_fake_tmux(void)
    char counter[300];
    snprintf(counter, sizeof(counter), "%s/counter", g_fake_dir);
    snprintf(g_sendlog, sizeof(g_sendlog), "%s/sendlog", g_fake_dir);
+   snprintf(g_createlog, sizeof(g_createlog), "%s/createlog", g_fake_dir);
    char script[320];
    snprintf(script, sizeof(script), "%s/tmux", g_fake_dir);
    FILE *f = fopen(script, "w");
@@ -76,10 +82,11 @@ static void install_fake_tmux(void)
            "'\"$c\"' end';\n"
            "    else echo 'STATIC OUTPUT'; fi; exit 0 ;;\n"
            "  send-keys) shift; echo \"$*\" >> '%s'; exit 0 ;;\n"
+           "  new-session) shift; for a in \"$@\"; do echo \"ARG:[$a]\" >> '%s'; done; exit 0 ;;\n"
            "  *) exit 0 ;;\n"
            "esac\n",
            counter, counter, counter, counter, counter, counter, counter, counter, counter,
-           g_sendlog);
+           g_sendlog, g_createlog);
    fclose(f);
    assert(chmod(script, 0700) == 0);
 
@@ -107,6 +114,40 @@ static int sendlog_has(const char *needle)
    buf[n] = '\0';
    fclose(f);
    return strstr(buf, needle) != NULL;
+}
+
+/* True if the fake tmux new-session argv log contains `needle`. */
+static int createlog_has(const char *needle)
+{
+   FILE *f = fopen(g_createlog, "r");
+   if (!f)
+      return 0;
+   char buf[4096];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   return strstr(buf, needle) != NULL;
+}
+
+/* cli_session_create must hand tmux the pane command (and workdir) as ONE
+ * argument each. cli_cmd is multi-word in production (the AIMEE_SESSION_ID
+ * stamp, --model, --dangerously-skip-permissions): unquoted interpolation gets
+ * word-split by the outer shell, tmux re-joins the fragments, and the pane's
+ * `sh -c` executes only the leading env assignment — exiting 0 instantly and
+ * surfacing as "failed to send prompt to tmux session". */
+static void test_create_multiword_cli_cmd_single_arg(void)
+{
+   unlink(g_createlog);
+   cli_session_t s;
+   int rc = cli_session_create(&s, "aimee-quoting-test",
+                               "AIMEE_SESSION_ID=web-1 claude --dangerously-skip-permissions",
+                               "/tmp/aimee quoting wd", 0);
+   assert(rc == 0);
+   assert(createlog_has("ARG:[AIMEE_SESSION_ID=web-1 claude --dangerously-skip-permissions]"));
+   assert(createlog_has("ARG:[/tmp/aimee quoting wd]"));
+   /* No fragment may arrive as its own argument (the word-split regression). */
+   assert(!createlog_has("ARG:[AIMEE_SESSION_ID=web-1]"));
+   s.active = 0; /* fake tmux: no real session to tear down */
 }
 static void sendlog_reset(void)
 {
@@ -933,6 +974,10 @@ int main(void)
    printf("OK\n");
 
    install_fake_tmux();
+
+   printf("test_create_multiword_cli_cmd_single_arg... ");
+   test_create_multiword_cli_cmd_single_arg();
+   printf("OK\n");
 
    printf("test_recv_timeout_on_changing_pane... ");
    test_recv_timeout_on_changing_pane();

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -59,9 +59,10 @@ int main(void)
       assert(fabs(cfg.code_hybrid_weight_graph - 1.0) < 1e-9);
       assert(fabs(cfg.code_hybrid_rrf_k - 60.0) < 1e-9);
       assert(cfg.guardrails_blast_radius_advisory_enabled == 0);
-      /* SECURITY: the autonomous live forge (F4) must default OFF — an operator
-       * has to explicitly enable it before any autonomous run can open/merge a PR. */
-      assert(cfg.wfe_live_forge_enabled == 0);
+      /* The autonomous live forge (F4) defaults ON (operator ruling 2026-07-13);
+       * the merge-target rail still bounds every op, and wfe_live_forge_enabled:
+       * false opts out. */
+      assert(cfg.wfe_live_forge_enabled == 1);
       assert(cfg.db1_path[0] != '\0');
       assert(cfg.guardrails_semantic_advisory_only == 1);
       assert(cfg.skills_review_nudge_interval == 10);

--- a/src/tests/test_persona.c
+++ b/src/tests/test_persona.c
@@ -63,9 +63,9 @@ int main(void)
       persona_free(&p);
 
       /* --- reviewer built-ins: read-only, review-oriented roles, no gate --- */
-      const char *reviewers[] = {"qa", "security", "reviewer", "architect",
-                                 "reviewer-constructive"};
-      for (int i = 0; i < 5; i++)
+      const char *reviewers[] = {
+          "qa", "security", "reviewer", "architect", "reviewer-constructive", "technical-writer"};
+      for (int i = 0; i < 6; i++)
       {
          assert(persona_load(NULL, reviewers[i], &p) == 0);
          assert(p.builtin == 1);
@@ -262,8 +262,8 @@ int main(void)
       char dir[PATH_MAX];
       snprintf(dir, sizeof(dir), "%s/defaults", home);
       int w = persona_install_defaults(dir);
-      assert(w == 8); /* engineer, novel, songwriter, qa, security, reviewer, architect,
-                         reviewer-constructive */
+      assert(w == 9); /* engineer, novel, songwriter, qa, security, reviewer, architect,
+                         reviewer-constructive, technical-writer */
       char path[PATH_MAX];
       snprintf(path, sizeof(path), "%s/novel.md", dir);
       FILE *f = fopen(path, "r");

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -272,6 +272,16 @@ void wfe_scheduler_notify(void)
    g_notify_count++;
 }
 
+/* Stub of the shared intake cap policy (the real env-driven policy lives in
+ * wfe_autonomy.c and is exercised by unit-test-trigger-e2e, which links it);
+ * test-settable so the plumbing — rule cap wins, else this default, 0 = no
+ * cap — is asserted deterministically. */
+static double g_default_cap = 5.0;
+double wfe_autonomy_default_max_cost_usd(void)
+{
+   return g_default_cap;
+}
+
 /* Pull in static cron_matches / field_matches via direct .c include. */
 #include "../server/trigger_scheduler.c"
 
@@ -1012,7 +1022,8 @@ static void test_scan_proposals_applies_cost_cap(void)
    assert(g_ncreated == 1);
    assert(g_created[0].cost_cap == 1.25);
 
-   /* No rule cap -> the $5 intake default. */
+   /* No rule cap -> the shared intake default (stubbed here; the real
+    * env-driven policy is asserted by unit-test-trigger-e2e). */
    snprintf(g_lstree_out, sizeof g_lstree_out,
             "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n");
    rule.max_spend_usd = 0.0;
@@ -1020,12 +1031,12 @@ static void test_scan_proposals_applies_cost_cap(void)
    assert(g_ncreated == 2);
    assert(g_created[1].cost_cap == 5.0);
 
-   /* AIMEE_AUTONOMY_MAX_USD=0 disables the default cap. */
+   /* A default of 0 means "no cap": nothing is stamped. */
    snprintf(g_lstree_out, sizeof g_lstree_out,
             "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
-   setenv("AIMEE_AUTONOMY_MAX_USD", "0", 1);
+   g_default_cap = 0.0;
    scan_proposals(&rule, 0);
-   unsetenv("AIMEE_AUTONOMY_MAX_USD");
+   g_default_cap = 5.0;
    assert(g_ncreated == 3);
    assert(g_created[2].cost_cap == 0.0);
 
@@ -1073,6 +1084,31 @@ static void test_scan_proposals_enforces_max_concurrent(void)
    assert(g_ncreated == 3);
 
    printf("  PASS: test_scan_proposals_enforces_max_concurrent\n");
+}
+
+/* The trigger-source registry: rules dispatch by source name; a scanner source
+ * is due on every pass, cron only on a schedule match, and an unknown source
+ * is skipped (no registry row -> no fire). */
+static void test_trigger_source_registry(void)
+{
+   assert(trigger_source_find("proposals") != NULL);
+   assert(trigger_source_find("cron") != NULL);
+   assert(trigger_source_find("github-webhook") == NULL);
+   assert(trigger_source_find("") == NULL);
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   struct tm at3 = make_tm(0, 3, 1, 4, 2);
+   struct tm at4 = make_tm(0, 4, 1, 4, 2);
+
+   assert(proposals_due(&rule, &at3) == 1); /* scanners poll every pass */
+
+   assert(cron_due(&rule, &at3) == 0); /* no schedule -> never due */
+   snprintf(rule.schedule, sizeof rule.schedule, "0 3 * * *");
+   assert(cron_due(&rule, &at3) == 1);
+   assert(cron_due(&rule, &at4) == 0);
+
+   printf("  PASS: test_trigger_source_registry\n");
 }
 
 /* ------------------------------------------------------------------ */
@@ -1125,6 +1161,7 @@ int main(void)
    test_scan_proposals_notifies_scheduler();
    test_scan_proposals_applies_cost_cap();
    test_scan_proposals_enforces_max_concurrent();
+   test_trigger_source_registry();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -1095,6 +1095,9 @@ static void test_trigger_source_registry(void)
    assert(trigger_source_find("cron") != NULL);
    assert(trigger_source_find("github-webhook") == NULL);
    assert(trigger_source_find("") == NULL);
+   /* watch-dir is the canonical name for the same scanner proposals aliases. */
+   assert(trigger_source_find("watch-dir") != NULL);
+   assert(trigger_source_find("watch-dir")->fire == trigger_source_find("proposals")->fire);
 
    trigger_rule_t rule;
    memset(&rule, 0, sizeof rule);

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -26,6 +26,7 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
    (void)fmt;
 }
 
+#include "db1/wfe_store.h" /* db1_work_item_t for the list/cost-cap stubs */
 #include "db1_trigger.h"
 int db1_trigger_insert(const char *id, const char *source, const char *event, const char *task,
                        const char *workspace, const char *metadata)
@@ -113,14 +114,18 @@ static struct
    char repo[512];
    char path[600];
    char mode[32];
+   char state[24];  /* stub work-item state, "active" on create; tests may complete it */
+   double cost_cap; /* recorded by the db1_work_item_set_cost_cap stub; 0 = none */
 } g_created[32];
 static int g_ncreated;
+static int g_notify_count; /* wfe_scheduler_notify() invocations */
 
 static void trig_stub_reset(void)
 {
    g_symref_out[0] = g_lstree_out[0] = g_lstree_ref[0] = g_lstree_pathspec[0] = '\0';
    g_nblobs = 0;
    g_ncreated = 0;
+   g_notify_count = 0;
 }
 
 const char *aimee_home(void)
@@ -221,6 +226,8 @@ int wfe_work_item_create(const char *workflow_name, const char *repo, const char
       snprintf(g_created[g_ncreated].path, sizeof g_created[0].path, "%s",
                proposal_path ? proposal_path : "");
       snprintf(g_created[g_ncreated].mode, sizeof g_created[0].mode, "%s", mode ? mode : "");
+      snprintf(g_created[g_ncreated].state, sizeof g_created[0].state, "active");
+      g_created[g_ncreated].cost_cap = 0.0;
       g_ncreated++;
    }
    if (out_id)
@@ -228,6 +235,41 @@ int wfe_work_item_create(const char *workflow_name, const char *repo, const char
    if (err && errlen > 0)
       err[0] = '\0';
    return 0;
+}
+
+/* Cost-cap stub: record the cap against the just-created item ("wi_<n>"). */
+int db1_work_item_set_cost_cap(const char *work_item_id, double cap)
+{
+   int idx = work_item_id ? atoi(work_item_id + 3) - 1 : -1;
+   if (idx >= 0 && idx < g_ncreated)
+      g_created[idx].cost_cap = cap;
+   return 0;
+}
+
+/* Work-item list stub: every created item, with its (test-controlled) state. */
+int db1_work_item_list(db1_work_item_t **out)
+{
+   if (!out)
+      return -1;
+   *out = NULL;
+   if (g_ncreated == 0)
+      return 0;
+   db1_work_item_t *items = calloc((size_t)g_ncreated, sizeof(*items));
+   if (!items)
+      return -1;
+   for (int i = 0; i < g_ncreated; i++)
+   {
+      snprintf(items[i].work_item_id, sizeof items[i].work_item_id, "wi_%d", i + 1);
+      snprintf(items[i].proposal_path, sizeof items[i].proposal_path, "%s", g_created[i].path);
+      snprintf(items[i].state, sizeof items[i].state, "%s", g_created[i].state);
+   }
+   *out = items;
+   return g_ncreated;
+}
+
+void wfe_scheduler_notify(void)
+{
+   g_notify_count++;
 }
 
 /* Pull in static cron_matches / field_matches via direct .c include. */
@@ -734,7 +776,7 @@ static void test_scan_proposals_end_to_end(void)
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
    snprintf(rule.event, sizeof rule.event, "docs/proposals/pending");
 
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
 
    /* Two .md proposals -> two work items; .gitkeep filtered out. */
    assert(g_ncreated == 2);
@@ -759,7 +801,7 @@ static void test_scan_proposals_end_to_end(void)
    assert(file_equals(exp1, "# Proposal B\n"));
 
    /* Re-scan with the same tree -> dedup pre-check skips both -> no new work items. */
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 2);
 
    /* A genuinely new proposal (new blob) -> exactly one new work item. */
@@ -770,7 +812,7 @@ static void test_scan_proposals_end_to_end(void)
             "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
             "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
             "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 3);
    assert(strcmp(g_created[2].wf, "build") == 0);
 
@@ -800,7 +842,7 @@ static void test_scan_proposals_honors_explicit_mode(void)
    snprintf(rule.event, sizeof rule.event, "docs/proposals/pending");
    snprintf(rule.mode, sizeof rule.mode, "interactive");
 
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
 
    assert(g_ncreated == 1);
    assert(strcmp(g_created[0].mode, "interactive") == 0);
@@ -826,14 +868,14 @@ static void test_scan_proposals_requires_workspace_and_workflow(void)
 
    /* Missing workspace -> no-op. */
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
 
    /* Missing workflow (pipeline_template) -> no-op. */
    memset(&rule, 0, sizeof rule);
    snprintf(rule.source, sizeof rule.source, "proposals");
    snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
 
    printf("  PASS: test_scan_proposals_requires_workspace_and_workflow\n");
@@ -859,7 +901,7 @@ static void test_scan_proposals_custom_event_and_schedule(void)
    snprintf(rule.event, sizeof rule.event, "rfcs");       /* custom scan dir */
    snprintf(rule.schedule, sizeof rule.schedule, "main"); /* custom branch */
 
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 1);
    assert(strcmp(g_lstree_ref, "main") == 0);          /* schedule used as ref */
    assert(strncmp(g_lstree_pathspec, "rfcs", 4) == 0); /* custom event dir */
@@ -885,7 +927,7 @@ static void test_scan_proposals_rejects_unsafe_ref_and_path(void)
    snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
    snprintf(rule.schedule, sizeof rule.schedule, "--all");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
    assert(g_lstree_ref[0] == '\0'); /* ls-tree never invoked */
 
@@ -896,16 +938,141 @@ static void test_scan_proposals_rejects_unsafe_ref_and_path(void)
    snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
    snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
    snprintf(rule.event, sizeof rule.event, "../../etc");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
    assert(g_lstree_ref[0] == '\0');
 
    /* An absolute scan dir is rejected. */
    snprintf(rule.event, sizeof rule.event, "/etc");
-   scan_proposals(&rule);
+   scan_proposals(&rule, 0);
    assert(g_ncreated == 0);
 
    printf("  PASS: test_scan_proposals_rejects_unsafe_ref_and_path\n");
+}
+
+/* Filing wakes the autonomy driver once (parity with /v1/dev/submit); a pass
+ * that files nothing must not wake it. */
+static void test_scan_proposals_notifies_scheduler(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-notify-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# Proposal A\n");
+   g_nblobs = 1;
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+
+   scan_proposals(&rule, 0);
+   assert(g_ncreated == 1);
+   assert(g_notify_count == 1);
+
+   /* Re-scan: dedup files nothing -> no spurious wake. */
+   scan_proposals(&rule, 0);
+   assert(g_ncreated == 1);
+   assert(g_notify_count == 1);
+   printf("  PASS: test_scan_proposals_notifies_scheduler\n");
+}
+
+/* pipeline.max_spend_usd is applied to the filed run; a rule without one gets
+ * the intake default ($5, AIMEE_AUTONOMY_MAX_USD override, 0 disables). */
+static void test_scan_proposals_applies_cost_cap(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-cap-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# A\n");
+   snprintf(g_blobs[1].sha, sizeof g_blobs[1].sha, "fedcba9876543210fedcba9876543210fedcba98");
+   snprintf(g_blobs[1].content, sizeof g_blobs[1].content, "# B\n");
+   snprintf(g_blobs[2].sha, sizeof g_blobs[2].sha, "2222222222222222222222222222222222222222");
+   snprintf(g_blobs[2].content, sizeof g_blobs[2].content, "# C\n");
+   g_nblobs = 3;
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+
+   /* Explicit rule cap wins. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n");
+   rule.max_spend_usd = 1.25;
+   unsetenv("AIMEE_AUTONOMY_MAX_USD");
+   scan_proposals(&rule, 0);
+   assert(g_ncreated == 1);
+   assert(g_created[0].cost_cap == 1.25);
+
+   /* No rule cap -> the $5 intake default. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n");
+   rule.max_spend_usd = 0.0;
+   scan_proposals(&rule, 0);
+   assert(g_ncreated == 2);
+   assert(g_created[1].cost_cap == 5.0);
+
+   /* AIMEE_AUTONOMY_MAX_USD=0 disables the default cap. */
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
+   setenv("AIMEE_AUTONOMY_MAX_USD", "0", 1);
+   scan_proposals(&rule, 0);
+   unsetenv("AIMEE_AUTONOMY_MAX_USD");
+   assert(g_ncreated == 3);
+   assert(g_created[2].cost_cap == 0.0);
+
+   printf("  PASS: test_scan_proposals_applies_cost_cap\n");
+}
+
+/* trigger.max_concurrent caps concurrently-ACTIVE triggered runs; deferred
+ * proposals file on a later pass once a slot frees (dedup keys on the artifact
+ * path, so nothing is lost). */
+static void test_scan_proposals_enforces_max_concurrent(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-conc-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# A\n");
+   snprintf(g_blobs[1].sha, sizeof g_blobs[1].sha, "fedcba9876543210fedcba9876543210fedcba98");
+   snprintf(g_blobs[1].content, sizeof g_blobs[1].content, "# B\n");
+   snprintf(g_blobs[2].sha, sizeof g_blobs[2].sha, "2222222222222222222222222222222222222222");
+   snprintf(g_blobs[2].content, sizeof g_blobs[2].content, "# C\n");
+   g_nblobs = 3;
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\tdocs/proposals/pending/a.md\n"
+            "100644 blob fedcba9876543210fedcba9876543210fedcba98\tdocs/proposals/pending/b.md\n"
+            "100644 blob 2222222222222222222222222222222222222222\tdocs/proposals/pending/c.md\n");
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+
+   /* Three pending, cap 2 -> exactly two filed this pass. */
+   scan_proposals(&rule, 2);
+   assert(g_ncreated == 2);
+
+   /* Both still active -> the next pass files nothing. */
+   scan_proposals(&rule, 2);
+   assert(g_ncreated == 2);
+
+   /* One run completes -> a slot frees -> the deferred proposal files. */
+   snprintf(g_created[0].state, sizeof g_created[0].state, "accepted");
+   scan_proposals(&rule, 2);
+   assert(g_ncreated == 3);
+
+   printf("  PASS: test_scan_proposals_enforces_max_concurrent\n");
 }
 
 /* ------------------------------------------------------------------ */
@@ -955,6 +1122,9 @@ int main(void)
    test_scan_proposals_requires_workspace_and_workflow();
    test_scan_proposals_custom_event_and_schedule();
    test_scan_proposals_rejects_unsafe_ref_and_path();
+   test_scan_proposals_notifies_scheduler();
+   test_scan_proposals_applies_cost_cap();
+   test_scan_proposals_enforces_max_concurrent();
    printf("All tests passed.\n");
    return 0;
 }

--- a/src/tests/test_trigger_e2e.c
+++ b/src/tests/test_trigger_e2e.c
@@ -171,9 +171,9 @@ int main(void)
    assert(n == 1);
    assert(strcmp(items[0].state, "active") == 0);
    assert(strcmp(items[0].mode, "autonomous") == 0);
-   assert(strcmp(items[0].repo, repo) == 0);            /* bound to the watched repo */
-   assert(strcmp(items[0].workflow_name, "e2e") == 0);  /* on the rule's workflow */
-   assert(items[0].work_item_max_cost_usd == 5.0);      /* default USD ceiling stamped */
+   assert(strcmp(items[0].repo, repo) == 0);           /* bound to the watched repo */
+   assert(strcmp(items[0].workflow_name, "e2e") == 0); /* on the rule's workflow */
+   assert(items[0].work_item_max_cost_usd == 5.0);     /* default USD ceiling stamped */
    /* The proposal was materialized under $AIMEE_HOME/triggers/proposals/. */
    char want_prefix[600];
    snprintf(want_prefix, sizeof want_prefix, "%s/triggers/proposals/", home);

--- a/src/tests/test_trigger_e2e.c
+++ b/src/tests/test_trigger_e2e.c
@@ -1,0 +1,241 @@
+/* test_trigger_e2e.c — end-to-end: a proposal committed under
+ * docs/proposals/pending/ in a REAL git repo is picked up by the proposals
+ * trigger (real git subprocesses, real materialization, real DB1 work-item
+ * store, real cost-cap stamping), filed as an autonomous work item bound to
+ * that repo, and driven to a TERMINAL state by the real autonomy scheduler +
+ * engine. Only the block executors are stubbed (the vtable seam every engine
+ * test uses) — everything between "a proposal appears in pending/" and
+ * "the workflow completed" is the production code path. */
+#include "wfe_test_home.h"
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "cJSON.h"
+#include "config.h"
+#include "db1.h"
+#include "log.h"
+#include "wfe_engine.h"
+#include "wfe_scheduler.h"
+#include "wfe_store.h"
+
+/* ---- stubs for trigger_scheduler.c symbols outside the proposals path ---- */
+
+int config_load(config_t *cfg)
+{
+   memset(cfg, 0, sizeof(*cfg));
+   return 0;
+}
+
+#include "skill_curator.h"
+int skill_curator_maybe(void)
+{
+   return 0;
+}
+
+#include "db1_trigger.h"
+int db1_trigger_insert(const char *id, const char *source, const char *event, const char *task,
+                       const char *workspace, const char *metadata)
+{
+   (void)id;
+   (void)source;
+   (void)event;
+   (void)task;
+   (void)workspace;
+   (void)metadata;
+   return 0;
+}
+int db1_trigger_status_set(const char *id, const char *status, const char *pipeline_id,
+                           const char *error)
+{
+   (void)id;
+   (void)status;
+   (void)pipeline_id;
+   (void)error;
+   return 0;
+}
+
+#include "pipelines.h"
+int db1_pipeline_create(const char *task, const char *request_classification,
+                        const char *plan_depth, int *out_id)
+{
+   (void)task;
+   (void)request_classification;
+   (void)plan_depth;
+   if (out_id)
+      *out_id = 1;
+   return 0;
+}
+int db1_pipeline_cancel(int pipeline_id)
+{
+   (void)pipeline_id;
+   return 0;
+}
+
+int platform_random_bytes(void *buf, size_t len)
+{
+   memset(buf, 0x42, len);
+   return 0;
+}
+
+#include "db1/db1_cron_jobs.h"
+int db1_cron_jobs_load(cron_job_t *out, int max, int enabled_only)
+{
+   (void)out;
+   (void)max;
+   (void)enabled_only;
+   return 0;
+}
+
+int cron_run_config_job(const cron_job_t *job, cJSON **out_resp)
+{
+   (void)job;
+   (void)out_resp;
+   return 0;
+}
+
+/* Pull in the REAL scan_proposals (static) with the real git capture path. */
+#include "../server/trigger_scheduler.c"
+
+/* ---- helpers ---- */
+
+static int sh(const char *fmt, ...)
+{
+   char cmd[2048];
+   va_list ap;
+   va_start(ap, fmt);
+   vsnprintf(cmd, sizeof cmd, fmt, ap);
+   va_end(ap);
+   return system(cmd);
+}
+
+/* A two-step workflow: normalize the proposal, then author the plan. Terminal
+ * after `plan` advances (no next edge). */
+static const char *WF = "name: e2e\n"
+                        "start: draft\n"
+                        "nodes:\n"
+                        "  - id: draft\n"
+                        "    block: author.proposal\n"
+                        "    next: plan\n"
+                        "    on_fail: draft\n"
+                        "  - id: plan\n"
+                        "    block: author.plan\n"
+                        "    in:\n"
+                        "      proposal: draft.out\n";
+
+int main(void)
+{
+   printf("trigger-e2e: ");
+
+   /* AIMEE_HOME with the workflow definition. */
+   char home[] = "/tmp/wfe_te_home_XXXXXX";
+   assert(wfe_test_mkdtemp(home));
+   char path[512];
+   snprintf(path, sizeof path, "%s/workflows", home);
+   mkdir(path, 0755);
+   snprintf(path, sizeof path, "%s/workflows/e2e.yaml", home);
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(WF, f);
+   fclose(f);
+   setenv("AIMEE_HOME", home, 1);
+   unsetenv("AIMEE_AUTONOMY_MAX_USD"); /* assert the default $5 cap below */
+   assert(db1_init(":memory:") == 0);
+
+   /* A real git repo with a pending proposal committed on its default branch. */
+   char repo[] = "/tmp/wfe_te_repo_XXXXXX";
+   assert(wfe_test_mkdtemp(repo));
+   assert(sh("cd %s && git init -q && git config user.email t@t && git config user.name t && "
+             "git config commit.gpgsign false && mkdir -p docs/proposals/pending && "
+             "printf '# Add /healthz\\n\\nReturn {status:ok}.\\n' > "
+             "docs/proposals/pending/add-healthz.md && "
+             "git add -A && git commit -qm 'proposal: add /healthz'",
+             repo) == 0);
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "%s", repo);
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "e2e");
+   /* event/schedule/mode empty: default dir, auto-detected ref, autonomous. */
+
+   /* --- the trigger picks the proposal up --- */
+   scan_proposals(&rule, 2);
+
+   db1_work_item_t *items = NULL;
+   int n = db1_work_item_list(&items);
+   assert(n == 1);
+   assert(strcmp(items[0].state, "active") == 0);
+   assert(strcmp(items[0].mode, "autonomous") == 0);
+   assert(strcmp(items[0].repo, repo) == 0);            /* bound to the watched repo */
+   assert(strcmp(items[0].workflow_name, "e2e") == 0);  /* on the rule's workflow */
+   assert(items[0].work_item_max_cost_usd == 5.0);      /* default USD ceiling stamped */
+   /* The proposal was materialized under $AIMEE_HOME/triggers/proposals/. */
+   char want_prefix[600];
+   snprintf(want_prefix, sizeof want_prefix, "%s/triggers/proposals/", home);
+   assert(strncmp(items[0].proposal_path, want_prefix, strlen(want_prefix)) == 0);
+   f = fopen(items[0].proposal_path, "rb");
+   assert(f);
+   char body[256] = {0};
+   size_t rd = fread(body, 1, sizeof body - 1, f);
+   fclose(f);
+   assert(rd > 0 && strstr(body, "# Add /healthz") == body);
+   char id[80];
+   snprintf(id, sizeof id, "%s", items[0].work_item_id);
+   free(items);
+
+   /* --- the autonomy scheduler completes the workflow --- */
+   wfe_reset_block_executors();
+   wfe_register_stub_executors();
+   wfe_scheduler_run_once();
+
+   db1_work_item_t done;
+   assert(db1_work_item_get(id, &done) == 1);
+   assert(strcmp(done.state, "accepted") == 0); /* ran draft -> plan -> terminal */
+
+   /* The audit log shows the full run: create, draft->plan advance, terminal. */
+   db1_lifecycle_event_t *evs = NULL;
+   int nev = db1_lifecycle_event_list(id, &evs);
+   assert(nev >= 3);
+   int advances = 0, terminals = 0;
+   for (int i = 0; i < nev; i++)
+   {
+      if (strcmp(evs[i].kind, "advance") == 0)
+         advances++;
+      if (strcmp(evs[i].kind, "terminal") == 0)
+         terminals++;
+   }
+   free(evs);
+   assert(advances >= 1 && terminals == 1);
+
+   /* --- a re-scan of the same tree files nothing (dedup), including for the
+    *     now-completed proposal: done work is never re-run --- */
+   scan_proposals(&rule, 2);
+   items = NULL;
+   assert(db1_work_item_list(&items) == 1);
+   free(items);
+
+   /* --- a NEW proposal on the branch files a second run --- */
+   assert(sh("cd %s && printf '# Second\\n' > docs/proposals/pending/second.md && "
+             "git add -A && git commit -qm 'proposal: second'",
+             repo) == 0);
+   scan_proposals(&rule, 2);
+   items = NULL;
+   n = db1_work_item_list(&items);
+   assert(n == 2);
+   free(items);
+   wfe_scheduler_run_once();
+   items = NULL;
+   n = db1_work_item_list(&items);
+   assert(n == 2);
+   for (int i = 0; i < n; i++)
+      assert(strcmp(items[i].state, "accepted") == 0);
+   free(items);
+
+   printf("ok (proposal -> trigger -> autonomous run -> accepted, x2)\n");
+   return 0;
+}

--- a/src/tests/test_wfe_blocks.c
+++ b/src/tests/test_wfe_blocks.c
@@ -48,6 +48,20 @@ int main(void)
    assert(wfe_lookup_block_executor(WFE_BLK_PR_OPEN));
    assert(wfe_lookup_block_executor(WFE_BLK_MERGE));
 
+   /* --- wfe_repo_local: the work item's repo wins when it names a local dir --- */
+   {
+      unsetenv("AIMEE_WORKFLOW_REPO");
+      assert(strcmp(wfe_repo_local("/tmp"), "/tmp") == 0);        /* local dir -> itself */
+      assert(strcmp(wfe_repo_local("/no/such/dir-x"), ".") == 0); /* absent -> env/cwd */
+      assert(strcmp(wfe_repo_local("org/repo"), ".") == 0);       /* identifier -> env/cwd */
+      assert(strcmp(wfe_repo_local(""), ".") == 0);
+      assert(strcmp(wfe_repo_local(NULL), ".") == 0);
+      setenv("AIMEE_WORKFLOW_REPO", "/srv/shared", 1);
+      assert(strcmp(wfe_repo_local("/tmp"), "/tmp") == 0); /* per-item repo still wins */
+      assert(strcmp(wfe_repo_local("org/repo"), "/srv/shared") == 0);
+      unsetenv("AIMEE_WORKFLOW_REPO");
+   }
+
    /* --- wfe_git_freeze against a real temp git repo --- */
    char dir[] = "/tmp/wfe_repo_XXXXXX";
    if (!wfe_test_mkdtemp(dir))

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -24,8 +24,7 @@ static void wfe_autonomy_cleanup_worktree(const char *work_item_id)
    db1_work_item_t wi;
    if (db1_work_item_get(work_item_id, &wi) != 1 || !wi.worktree[0])
       return;
-   const char *rl = getenv("AIMEE_WORKFLOW_REPO");
-   if (wfe_worktree_cleanup(wi.worktree, (rl && rl[0]) ? rl : ".") == 0)
+   if (wfe_worktree_cleanup(wi.worktree, wfe_repo_local(wi.repo)) == 0)
       db1_work_item_set_worktree(work_item_id, "");
 }
 

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -3,6 +3,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <math.h> /* isfinite — validate the AIMEE_AUTONOMY_MAX_USD override */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -152,6 +153,22 @@ static int wfe_autonomy_park_stuck(const char *work_item_id, const char *why)
    db1_lifecycle_event_add(work_item_id, wi.current_stage, "pause", "engine",
                            (why && why[0]) ? why : "unrecoverable advance failure", "", 0);
    return 0;
+}
+
+double wfe_autonomy_default_max_cost_usd(void)
+{
+   /* WP-5: the shared per-run USD budget ceiling (see wfe_autonomy.h). Reject
+    * inf/NaN — either would void the cap rather than tune it. */
+   double cap_usd = 5.0;
+   const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
+   if (v && v[0])
+   {
+      char *e = NULL;
+      double d = strtod(v, &e);
+      if (e && *e == '\0' && isfinite(d) && d >= 0)
+         cap_usd = d;
+   }
+   return cap_usd;
 }
 
 int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)

--- a/src/workflow/wfe_autonomy.h
+++ b/src/workflow/wfe_autonomy.h
@@ -25,6 +25,14 @@
  * clean stop (terminal or parked), -1 on error. */
 int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen);
 
+/* The default per-run USD ceiling every autonomous intake applies when the
+ * caller supplies no explicit cap: $5.00, AIMEE_AUTONOMY_MAX_USD overrides
+ * (0 disables the cap; a malformed/inf/NaN override falls back to the
+ * default). One policy for every filing path — /v1/dev/submit, the MCP tool,
+ * and each trigger source — so no intake is ever the one without a runaway
+ * cost cap. Returns the cap in USD; 0 means "no cap". */
+double wfe_autonomy_default_max_cost_usd(void);
+
 /* Human-only escape from a stuck gate: records a signed override (counts as a
  * human approval), increments override_count, and clears the pause so the next
  * run advances. On the (WFE_MAX_OVERRIDES+1)th override the work item is forced

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -41,11 +41,12 @@ static const char *repo_dir(void)
  * into `buf`; never empty. */
 static void resolve_workdir(wfe_ctx *ctx, char *buf, size_t n)
 {
-   if (wfe_worktree_ensure(wfe_ctx_work_item(ctx), wfe_ctx_worktree(ctx), repo_dir(),
+   const char *repo = wfe_repo_local(wfe_ctx_repo(ctx));
+   if (wfe_worktree_ensure(wfe_ctx_work_item(ctx), wfe_ctx_worktree(ctx), repo,
                            wfe_autonomous_base(), buf, n) != 0)
-      snprintf(buf, n, "%s", repo_dir()); /* fall back to the shared checkout */
-   if (!buf[0])                           /* guarantee a non-empty workdir for every caller */
-      snprintf(buf, n, "%s", repo_dir());
+      snprintf(buf, n, "%s", repo); /* fall back to the shared checkout */
+   if (!buf[0])                     /* guarantee a non-empty workdir for every caller */
+      snprintf(buf, n, "%s", repo);
 }
 
 static int git_capture(const char *const argv[], char **out)

--- a/src/workflow/wfe_iface.c
+++ b/src/workflow/wfe_iface.c
@@ -5,7 +5,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h> /* strcasecmp / strncasecmp */
+#include <strings.h>  /* strcasecmp / strncasecmp */
+#include <sys/stat.h> /* stat — wfe_repo_local dir check */
+
+/* ---- per-work-item repo resolution (see wfe_iface.h) ---- */
+
+const char *wfe_repo_local(const char *wi_repo)
+{
+   /* The work item's own repo binds the run to its repository (a trigger rule's
+    * pipeline.workspace, or an explicit dev-submit repo) — honor it whenever it
+    * names a local directory. Anything else (an identifier/URL, or "") falls back
+    * to the process-wide $AIMEE_WORKFLOW_REPO, then cwd, preserving
+    * single-repo deployments unchanged. */
+   if (wi_repo && wi_repo[0] == '/')
+   {
+      struct stat st;
+      if (stat(wi_repo, &st) == 0 && S_ISDIR(st.st_mode))
+         return wi_repo;
+   }
+   const char *d = getenv("AIMEE_WORKFLOW_REPO");
+   return (d && d[0]) ? d : ".";
+}
 
 /* ---- autonomous merge-target rail (WP-5 safety; see wfe_iface.h) ---- */
 

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -155,6 +155,15 @@ typedef enum
 } wfe_failure_disposition_t;
 wfe_failure_disposition_t wfe_failure_disposition(wfe_failure_class_t cls, int has_new_input);
 
+/* Resolve the local working repo for a work item from its stored `repo` column:
+ * the repo itself when it names a local directory (a trigger rule's
+ * pipeline.workspace binds the run to that repository), else the process-wide
+ * $AIMEE_WORKFLOW_REPO, else cwd. Every per-work-item repo consumer (block
+ * executors, roundtable workdir, worktree cleanup) resolves through this so a
+ * run filed against a specific workspace executes there, not wherever the
+ * server process happens to sit. */
+const char *wfe_repo_local(const char *wi_repo);
+
 /* ---- Autonomous merge-target rail (WP-5 safety) ----
  * The single source of truth for the branch an autonomous run may target for a
  * PR/merge. Autonomous merges only ever go to this branch (default "testing");

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -125,12 +125,12 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
    /* The directory the panel reviews the change in: the per-work-item worktree, or —
     * when worktree isolation is unavailable and a run fell back to the shared checkout
     * (wfe_worktree_ensure failed) — that shared repo dir. Mirrors the producing blocks'
-    * resolve_workdir fallback (AIMEE_WORKFLOW_REPO, else "."), so the panel can always
-    * convene rather than fail closed to panel_unreachable when the worktree is empty. */
+    * resolve_workdir fallback (the work item's own repo, else AIMEE_WORKFLOW_REPO, else
+    * "."), so the panel convenes in the run's repository rather than fail closed to
+    * panel_unreachable when the worktree is empty. */
    const char *worktree = wfe_ctx_worktree(ctx);
-   const char *workdir = (worktree && worktree[0]) ? worktree : getenv("AIMEE_WORKFLOW_REPO");
-   if (!workdir || !workdir[0])
-      workdir = ".";
+   const char *workdir =
+       (worktree && worktree[0]) ? worktree : wfe_repo_local(wfe_ctx_repo(ctx));
 
    /* Push the change under review to the panel: the branch diff vs the autonomous
     * base ("what changed from the default repo"). Computed once here so panelists

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -129,8 +129,7 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
     * "."), so the panel convenes in the run's repository rather than fail closed to
     * panel_unreachable when the worktree is empty. */
    const char *worktree = wfe_ctx_worktree(ctx);
-   const char *workdir =
-       (worktree && worktree[0]) ? worktree : wfe_repo_local(wfe_ctx_repo(ctx));
+   const char *workdir = (worktree && worktree[0]) ? worktree : wfe_repo_local(wfe_ctx_repo(ctx));
 
    /* Push the change under review to the panel: the branch diff vs the autonomous
     * base ("what changed from the default repo"). Computed once here so panelists

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -455,10 +455,10 @@ func (s *server) handleGitClone(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "url required")
 		return
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), cloneTimeout)
 	defer cancel()
 	body, _ := json.Marshal(map[string]string{"url": req.URL, "name": req.Name, "token": req.Token})
-	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone", body)
+	st, data, err := s.v1RequestWebuserT(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone", body, cloneTimeout)
 	s.gitRelay(w, st, data, err)
 }
 
@@ -563,6 +563,6 @@ func (s *server) handleGitCloneOrg(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), cloneOrgTimeout)
 	defer cancel()
 	body, _ := json.Marshal(req)
-	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone-org", body)
+	st, data, err := s.v1RequestWebuserT(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone-org", body, cloneOrgTimeout)
 	s.gitCloneOrgRelay(w, st, data, err)
 }

--- a/webchat/socket.go
+++ b/webchat/socket.go
@@ -17,8 +17,9 @@ import (
 
 const socketCallTimeout = 10 * time.Second
 
-// cloneOrgTimeout bounds a bulk org clone (up to 100 repos, each a full git
-// clone) — far longer than a normal socket call.
+// cloneTimeout bounds a single full git clone; cloneOrgTimeout bounds a bulk
+// org clone (up to 100 repos) — both far longer than a normal socket call.
+const cloneTimeout = 2 * time.Minute
 const cloneOrgTimeout = 5 * time.Minute
 const chatReconnectTimeout = 30 * time.Second
 const chatReconnectStep = 250 * time.Millisecond


### PR DESCRIPTION
## What

Promotes `testing` to `main`. Since the last sync (#1288), this carries:

- **#1290** — proposals trigger finished end-to-end: scheduler wake on filing, per-run spend cap, `trigger.max_concurrent` admission, per-work-item repo resolution (`wfe_repo_local`); plus a hermetic E2E test of the real pipeline (real git, real DB1, real scheduler → terminal `accepted`).
- **#1291** — tmux pane command quoting fix for the server-hosted claude CLI delegate.
- **#1292** — delegate-policy invariants at every routing decision: the primary passthrough never receives delegations; claude-CLI agents route as delegates only behind `claude_cli_delegate_enabled` + `is_server_hosted`.
- **#1293** — trigger generalization: `{name, due, fire}` source registry, shared `trigger_file_run` filing back half, one intake cost-cap policy (`wfe_autonomy_default_max_cost_usd`).
- **#1294** — `watch-dir` as the canonical generic source (`proposals` stays as its alias) + the triggers-as-blocks proposal in `docs/proposals/pending/`.
- **#1295** — `technical-writer` default persona (read-only documentation reviewer; human voice, brevity-first, AI-isms flagged as findings), eligible seat on `build`'s doc gate.
- **#1296** — `wfe_live_forge_enabled` defaults ON (operator ruling); `false` is the persisted opt-out. Merge-target rails unchanged and re-checked per op.

Verified live on the reference appliance: aimee autonomously drains its own `docs/proposals/pending/` into `build` runs (one at a time, capped), with the live forge now enabled.