### PR TITLE
fix: E2E-stack fixes — SPA fetch loop, gateway /health dim, fenced verdicts, chat primary routing, guard memory carve-out, config schema

### DIFF
--- a/frontend/src/components/ProjectPicker.tsx
+++ b/frontend/src/components/ProjectPicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Picker } from '@rakuensoftware/smoothgui';
 
 /* ProjectPicker — a compact "select or clone a project" control embedded in each
@@ -38,9 +38,16 @@ export default function ProjectPicker({ storageKey, onChange }: {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
 
+  // onChange goes through a ref so its identity never feeds the load/effect
+  // chain: parents pass inline closures that patch their own state, and a
+  // load() → onChange → parent re-render → new closure → new load() cycle
+  // re-fires the mount effect forever (an unthrottled /api/git/projects loop).
+  const onChangeRef = useRef(onChange);
+  useEffect(() => { onChangeRef.current = onChange; }, [onChange]);
+
   const emit = useCallback((project: string, rootPath: string) => {
-    onChange(project && rootPath ? { project, root: rootPath } : null);
-  }, [onChange]);
+    onChangeRef.current(project && rootPath ? { project, root: rootPath } : null);
+  }, []);
 
   const load = useCallback(async () => {
     try {
@@ -48,16 +55,16 @@ export default function ProjectPicker({ storageKey, onChange }: {
       const d = await r.json();
       if (!r.ok) { setErr(d.error || 'failed to list projects'); return; }
       const ps: string[] = d.projects || [];
+      const rootPath = d.root || '';
       setProjects(ps);
-      setRoot(d.root || '');
+      setRoot(rootPath);
       // keep the persisted selection if still present, else clear
-      setSelected(prev => {
-        const next = prev && ps.includes(prev) ? prev : '';
-        emit(next, d.root || '');
-        return next;
-      });
+      const prev = localStorage.getItem(storageKey) || '';
+      const next = prev && ps.includes(prev) ? prev : '';
+      setSelected(next);
+      emit(next, rootPath);
     } catch { setErr('aimee-server unavailable'); }
-  }, [emit]);
+  }, [emit, storageKey]);
 
   useEffect(() => { load(); }, [load]);
 

--- a/scripts/aimee_llm_gateway.py
+++ b/scripts/aimee_llm_gateway.py
@@ -256,6 +256,25 @@ def health_state(child_oks):
     return "ok" if all(configured.values()) else "down"
 
 
+# The kb's readiness probe (embed-remote.py --dim) reads payload["dim"] from
+# /health and treats a missing/absent dim as "embedder not ready" forever — so
+# the real (non-stub) path must report it too, not just the stub. The embedder
+# child doesn't expose its dim as metadata, so learn it once from an actual
+# embedding and cache it; until the child can embed, /health simply omits dim
+# (status won't be "ok" yet either).
+_embed_dim = None
+
+
+def embed_dim():
+    global _embed_dim
+    if _embed_dim is None:
+        try:
+            _embed_dim = len(do_embed("dim probe"))
+        except Exception:  # noqa: BLE001 - child not ready; retry on a later probe
+            return None
+    return _embed_dim
+
+
 # ---- handlers (call llama.cpp; the rerank head is the validated P2 path) ----
 
 _head = None
@@ -477,7 +496,17 @@ def build_server():
                     self._send(200, {"status": "ok", "model": "aimee-llm-stub", "dim": STUB_DIM})
                     return
                 st = health_state(child_health())
-                self._send(200 if st == "ok" else 503, {"status": st, "model": EMBED_MODEL})
+                payload = {"status": st, "model": EMBED_MODEL}
+                if st == "ok":
+                    dim = embed_dim()
+                    if dim:
+                        payload["dim"] = dim
+                    else:
+                        # embedder reachable but not serving embeddings yet: the kb
+                        # gates on dim, so don't report ok without one.
+                        st = "loading"
+                        payload["status"] = st
+                self._send(200 if st == "ok" else 503, payload)
             elif path in ("/health/embed", "/health/rerank", "/health/synth"):
                 role = path.rsplit("/", 1)[1]
                 st = role_states()[role]

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -589,6 +589,18 @@ static int attn_path_in_managed_worktree(const char *norm)
                    strstr(norm, "/.codex/worktrees/") != NULL);
 }
 
+/* Returns 1 iff `norm` is harness-owned session state rather than repo content:
+ * Claude Code's per-project state dir ("~/.claude/projects/<slug>/..." — auto-
+ * memory, transcripts, tool-result spills). The harness writes there as part of
+ * normal operation from ANY cwd; blocking it doesn't protect the checkout, it
+ * just breaks the harness (observed: memory writes refused mid-session). The
+ * loose "/.claude/" prefix stays blocked — only the projects state dir is
+ * carved out. */
+static int attn_path_is_harness_state(const char *norm)
+{
+   return norm && strstr(norm, "/.claude/projects/") != NULL;
+}
+
 /* Pure decision for the session-isolation guard (testable in isolation).
  * Returns 1 to BLOCK: a mutating op (SOFT/HARD) whose effective target is NOT
  * inside an aimee-managed worktree. Read / raw-scan ops are never blocked here.
@@ -611,7 +623,9 @@ int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const ch
 
    char norm[2048];
    attn_lexical_normalize(joined, norm, sizeof(norm));
-   return attn_path_in_managed_worktree(norm) ? 0 : 1;
+   if (attn_path_in_managed_worktree(norm) || attn_path_is_harness_state(norm))
+      return 0;
+   return 1;
 }
 
 int handle_attention_guard(void)

--- a/src/config.c
+++ b/src/config.c
@@ -401,6 +401,9 @@ static const config_schema_entry_t config_schema[] = {
     {"ensemble", SCHEMA_OBJECT, 0},
     {"roundtable", SCHEMA_OBJECT, 0},
     {"cron_jobs", SCHEMA_ARRAY, 0},
+    {"trigger", SCHEMA_OBJECT, 0},
+    {"trigger_rules", SCHEMA_ARRAY, 0},
+    {"claude_cli_delegate_enabled", SCHEMA_BOOL, 0},
     {NULL, 0, 0},
 };
 

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -53,6 +53,17 @@ void agent_set_route_health_filter(int (*fn)(const char *agent_name));
  * route to a client-only claude. */
 void agent_set_route_policy_filter(int (*fn)(const agent_t *agent));
 
+/* Primary-turn marker for the delegate-policy filter. The PRIMARY chat turn
+ * routes the provider-named agent through the same machinery as delegation
+ * (agent_run_with_tools -> agent_route), where policy rule (1) above would
+ * exclude it and rule (2) would demand the delegate opt-in — but a primary
+ * turn is not delegation: driving claude via its CLI as the PRIMARY is the
+ * documented default. The chat worker brackets the turn with set(1)/set(0) on
+ * its own thread (thread-local, so concurrent delegate routing on other
+ * threads stays policed); the server's policy predicate consults it. */
+void agent_routing_set_primary_turn(int on);
+int agent_routing_primary_turn(void);
+
 int agent_has_role(const agent_t *agent, const char *role);
 int agent_supports_persona(const agent_t *agent, const char *persona);
 int agent_is_exec_role(const agent_t *agent, const char *role);

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -831,8 +831,14 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
+   /* This is the PRIMARY turn: the provider-named agent must be routable for
+    * its own chat even though the delegate-policy filter excludes it as a
+    * delegation target (see agent_routing_set_primary_turn). Thread-local, so
+    * any delegation the turn spawns (other worker threads) stays policed. */
+   agent_routing_set_primary_turn(1);
    int rc = agent_run_with_tools(&acfg, "code", system_prompt ? system_prompt : "", message,
                                  AGENT_DEFAULT_MAX_TOKENS, &result);
+   agent_routing_set_primary_turn(0);
 
    cli_session_set_error_grace_ms(prev_error_grace);
    cli_session_set_cancel_check(prev_cancel_cb, prev_cancel_ud);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1292,6 +1292,21 @@ void agent_set_route_policy_filter(int (*fn)(const agent_t *agent))
    g_route_policy_filter = fn;
 }
 
+/* See agent_config.h: marks the current thread's turn as PRIMARY (not
+ * delegation) so the policy filter doesn't exclude the provider-named agent
+ * from its own chat turn. */
+static _Thread_local int g_routing_primary_turn;
+
+void agent_routing_set_primary_turn(int on)
+{
+   g_routing_primary_turn = on ? 1 : 0;
+}
+
+int agent_routing_primary_turn(void)
+{
+   return g_routing_primary_turn;
+}
+
 int agent_is_available_for_routing(const agent_t *agent)
 {
    if (!agent)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1852,6 +1852,13 @@ static int server_agent_route_policy_excluded(const agent_t *ag)
 {
    if (!ag)
       return 1;
+   /* A PRIMARY chat turn routes the provider-named agent through the same
+    * machinery as delegation; both rules below are delegation policy, so they
+    * must not exclude the primary from its own turn (they otherwise break
+    * every server-side chat whose provider is a configured agent — the
+    * webchat's default). The marker is thread-local to the chat worker. */
+   if (agent_routing_primary_turn())
+      return 0;
    config_t cfg;
    if (config_load(&cfg) != 0)
       return agent_is_claude_cli(ag);

--- a/src/server/wfe_panel_verdict.c
+++ b/src/server/wfe_panel_verdict.c
@@ -23,15 +23,30 @@ void wfe_panel_verdict_from_review(const char *persona, const char *artifact_has
       return;
 
    /* Extract ONLY the last non-empty line (the delegate emits one JSON line at the
-    * end). A whole-response scan could false-approve on quoted JSON in the reasoning. */
+    * end). A whole-response scan could false-approve on quoted JSON in the reasoning.
+    * Providers routinely wrap that final JSON in a markdown code fence, leaving
+    * "```" as the literal last line — skip trailing fence-only lines (``` or
+    * ```json) so a fenced verdict isn't misread as MALFORMED, but never skip past
+    * anything else. */
    const char *r = review_text;
    size_t len = strlen(r);
-   while (len > 0 &&
-          (r[len - 1] == '\n' || r[len - 1] == '\r' || r[len - 1] == ' ' || r[len - 1] == '\t'))
-      len--;
-   size_t start = len;
-   while (start > 0 && r[start - 1] != '\n')
-      start--;
+   size_t start;
+   for (;;)
+   {
+      while (len > 0 &&
+             (r[len - 1] == '\n' || r[len - 1] == '\r' || r[len - 1] == ' ' || r[len - 1] == '\t'))
+         len--;
+      start = len;
+      while (start > 0 && r[start - 1] != '\n')
+         start--;
+      size_t l = len - start;
+      if (l >= 3 && l <= 16 && strncmp(r + start, "```", 3) == 0)
+      {
+         len = start; /* fence-only line: consider the line above instead */
+         continue;
+      }
+      break;
+   }
 
    /* Capture the reviewer's critique — everything before the final JSON verdict
     * line — so a request_changes can be threaded back to the re-authoring

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1681,7 +1681,7 @@ $(TESTPREFIX)/unit-test-wfe-roundtable: $(OBJDIR)/tests/test_wfe_roundtable.o \
                                         $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                         $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
                                         $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o $(OBJDIR)/aimee_home.o \
-                                        $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
+                                        $(OBJDIR)/util.o $(OBJDIR)/posix/util.o $(OBJDIR)/tests/support/log_stub.o \
                                         $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1729,6 +1729,7 @@ $(TESTPREFIX)/unit-test-wfe-sliced-build: $(OBJDIR)/tests/test_wfe_sliced_build.
 # Workflow engine W6: autonomy driver + gate-override.
 $(TESTPREFIX)/unit-test-wfe-autonomy: $(OBJDIR)/tests/test_wfe_autonomy.o \
                                       $(OBJDIR)/workflow/wfe_autonomy.o $(OBJDIR)/workflow/wfe_approval.o \
+                                      $(OBJDIR)/tests/support/log_stub.o \
                                       $(OBJDIR)/workflow/wfe_roundtable.o $(OBJDIR)/workflow/wfe_verdict.o \
                                       $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/db1/db1_init.o \
                                       $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/wfe_store.o \

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -211,6 +211,38 @@ static void test_agent_route_policy_filter(void)
    assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
 }
 
+/* The server's live predicate consults agent_routing_primary_turn() so the
+ * PRIMARY chat turn can route the provider-named agent even though it is
+ * excluded as a delegation target (mirrored here by a marker-aware double). */
+static int test_policy_exclude_primary_unless_primary_turn(const agent_t *ag)
+{
+   if (agent_routing_primary_turn())
+      return 0;
+   return strcmp(ag->name, "primary") == 0;
+}
+
+static void test_agent_route_primary_turn_marker(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 1;
+   strcpy(cfg.default_agent, "primary");
+   strcpy(cfg.agents[0].name, "primary");
+   strcpy(cfg.agents[0].roles[0], "code");
+   cfg.agents[0].role_count = 1;
+   cfg.agents[0].enabled = 1;
+
+   agent_set_route_policy_filter(test_policy_exclude_primary_unless_primary_turn);
+   /* Delegation context: the primary is unroutable and routing fails. */
+   assert(agent_route(&cfg, "code") == NULL);
+   /* Primary chat turn: the same agent routes for its own turn. */
+   agent_routing_set_primary_turn(1);
+   assert(agent_route(&cfg, "code") == &cfg.agents[0]);
+   agent_routing_set_primary_turn(0);
+   assert(agent_route(&cfg, "code") == NULL);
+   agent_set_route_policy_filter(NULL);
+}
+
 /* Structural rule (no filter needed): a claude-CLI agent that is not
  * server-hosted has no server session to drive — it can never be a delegate,
  * so routing refuses it before any PATH/credential probing. */
@@ -2385,6 +2417,7 @@ int main(void)
    test_agent_find();
    test_agent_route();
    test_agent_route_policy_filter();
+   test_agent_route_primary_turn_marker();
    test_agent_route_client_only_claude_excluded();
    test_agent_route_with_caps_honors_tools_enabled();
    test_agent_route_with_caps_honors_context_override();

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -202,6 +202,12 @@ static void test_session_isolation_decision(void)
    assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, cc_wt_cwd) == 0);
    /* The loose "/.claude" prefix (e.g. ~/.claude/) is NOT a managed worktree. */
    assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "/home/u/.claude/x.c", primary_cwd) == 1);
+   /* ...but the harness's own per-project state dir (auto-memory etc.) is
+    * session state, not repo content — writable from any cwd. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "/home/u/.claude/projects/p/memory/m.md",
+                                         primary_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, "/home/u/.claude/projects/p/MEMORY.md",
+                                         wt_cwd) == 0);
 
    /* Codex's native worktrees (/.codex/worktrees/) are honoured the same way. */
    const char *cx_wt = "/home/u/repo/.codex/worktrees/feat/src/x.c";

--- a/src/tests/test_wfe_panel_verdict.c
+++ b/src/tests/test_wfe_panel_verdict.c
@@ -60,6 +60,16 @@ int main(void)
    /* trailing whitespace/newlines after the JSON line are tolerated */
    assert(map("{\"verdict\":\"approve\"}\n\n  \n").kind == WFE_V_APPROVE);
 
+   /* a markdown-fenced verdict (the common provider habit) is still parsed:
+    * trailing fence-only lines are skipped, not treated as the verdict line */
+   assert(map("blockers noted.\n```json\n{\"verdict\":\"request_changes\"}\n```\n").kind ==
+          WFE_V_REQUEST_CHANGES);
+   assert(map("```\n{\"verdict\":\"approve\"}\n```").kind == WFE_V_APPROVE);
+   /* a fence-only response stays MALFORMED (nothing above the fences) */
+   assert(map("```\n```").kind == WFE_V_MALFORMED);
+   /* prose after the fenced verdict still wins as the last line (no rescan) */
+   assert(map("```\n{\"verdict\":\"approve\"}\n```\nnot json").kind == WFE_V_MALFORMED);
+
    /* a null artifact hash still yields a (fail-closed) verdict with an empty hash */
    {
       wfe_verdict_t v;

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "cJSON.h"
+#include "log.h"  /* degraded-gate WARN carries wfe_gate_decide's reason */
 #include "util.h" /* safe_exec_capture — compute the change-under-review diff */
 #include "wfe_store.h"
 #include "wfe_def.h"
@@ -203,6 +204,12 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
    }
    case WFE_GATE_DEGRADED:
    default:
+      /* The reason (which required persona was missing/untrustworthy) is
+       * otherwise discarded, leaving nothing in the log to distinguish a
+       * seat-resolution failure from a malformed verdict when triaging a
+       * parked run. */
+      aimee_log(LOG_WARN, "wfe-gate", "%s: panel degraded at gate: %s", node->id,
+                reason[0] ? reason : "(no reason)");
       return wfe_step_pending(WFE_PAUSE_PANEL_DEGRADED);
    }
 }


### PR DESCRIPTION
## Summary
Six independent defects found while standing up the full stack (server + kb + llm + webchat + proposals trigger) end-to-end on a live appliance:

1. **frontend/ProjectPicker**: `load` depended on `emit` → `onChange`, and every parent passes an inline closure that patches parent state — each fetch re-rendered the parent, recreated the closure, and re-fired `useEffect([load])`: an unthrottled `GET /api/git/projects` loop (~200 req/s per open tab observed; 700k+ requests / 64 MB server.log). Fixed by routing `onChange` through a ref; the fetch runs once per mount.
2. **scripts/aimee_llm_gateway.py**: the real (non-stub) `/health` omitted `dim`, but the kb's readiness probe (`embed-remote.py --dim`) requires it — a fresh aimee-kb against a live aimee-llm never came up. The gateway now learns the dim from one embedding, caches it, and holds `/health` at `loading` until then.
3. **wfe panel verdicts**: reviewers routinely close with a markdown code fence, leaving a literal ``` as the reply's last line — the parser read the fence as the verdict line, failed the verdict MALFORMED, and required-lens coverage parked the run `panel_degraded` (observed: 6 consecutive gate attempts on a live autonomous build run). Trailing fence-only lines are now skipped; the fail-closed rule is unchanged. The gate's degrade `reason` (previously discarded) is now logged.
4. **server chat routing regression (from #1292)**: the routing-wide delegate-policy filter excludes the agent named after `config.provider` from *every* routing decision — but the server-side chat turn (webchat `/v1/chat/stream`) routes the PRIMARY through the same machinery, so every chat on a box whose provider matches a configured agent failed instantly with `no agent available for role 'code'` (delegation itself worked — verified live: `aimee delegate code/explain` → PONG; chat → instant error). The chat worker now marks its turn PRIMARY via a thread-local that the policy predicate consults; delegation spawned by the turn runs on other threads and stays policed.
5. **attention-guard**: the session-isolation guard blocked mutating ops to Claude Code's own per-project state dir (`~/.claude/projects/<slug>/` — auto-memory, MEMORY.md), breaking the harness memory feature whenever `require_session_worktree` is on (hit live mid-session). Carved out `/.claude/projects/` only; the loose `~/.claude/` prefix stays blocked.
6. **config schema**: `trigger`, `trigger_rules`, `claude_cli_delegate_enabled` are parsed but missing from `config_schema[]` — every load warned 'unknown key' (and `--config-strict` would reject them).

## Testing
- frontend: tsc clean, vitest 81/81, singlefile build ok; hot-deployed to the appliance — loop gone after fresh login.
- gateway: stub-mode smoke; hot-deployed to the .254 aimee-llm — kb came up healthy (dim 2560) and thin-client memory store/search round-trips E2E.
- verdict parser: test_wfe_panel_verdict extended (fenced/fence-only/prose-after-fence); standalone build green.
- primary-turn marker: test_agent extended with a marker-aware policy double (route fails in delegation context, routes on the primary turn).
- attention-guard: test_attention_guard extended (state-dir allowed, ~/.claude still blocked); standalone build green.