### PR TITLE
fix: aimee-combined never boots from scratch — dim probe, supervisor shell, wget

### DIFF
--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -83,7 +83,10 @@ trap 'shutdown' TERM INT
 # embedding until the endpoint is reachable, so the server comes up promptly.
 LLM_PORT="${AIMEE_LLM_PORT:-8080}"
 log "starting bundled aimee-llm (tier=${AIMEE_LLM_TIER:-cpu} port=$LLM_PORT) as user aimee"
-runuser -u aimee -- sh /opt/aimee/supervisor.sh &
+# Exec the script itself (bash shebang): it uses bash arrays/wait -n, which
+# dash chokes on ("Syntax error: \"(\" unexpected") — under `sh` the bundled
+# llm silently never started and the kb dim probe waited forever.
+runuser -u aimee -- /opt/aimee/supervisor.sh &
 llm_pid=$!
 
 # The kb + curator reach the bundled llm on loopback. AIMEE_LLM_URL is baked to

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -158,8 +158,16 @@ start() { # name port extra-args...   (caller passes -ngl per role: cpu=0, gpu=$
 # leaves .ready absent so the next start retries a partial pull).
 fetch() {
   local url="$1" dest="$2"
-  wget -q -c --tries=5 --timeout=30 --waitretry=10 -O "$dest" "$url" \
-    || { echo "aimee-llm: download FAILED: $url" >&2; return 1; }
+  # wget when available (the standalone aimee-llm image), else curl (the combined
+  # image ships curl only — its runtime stage has no wget, and a silent hard
+  # dependency here meant every model fetch failed there).
+  if command -v wget >/dev/null 2>&1; then
+    wget -q -c --tries=5 --timeout=30 --waitretry=10 -O "$dest" "$url" \
+      || { echo "aimee-llm: download FAILED: $url" >&2; return 1; }
+  else
+    curl -fsSL --connect-timeout 30 --retry 5 --retry-delay 10 -C - -o "$dest" "$url" \
+      || { echo "aimee-llm: download FAILED: $url" >&2; return 1; }
+  fi
 }
 
 # download_models — fetch ONLY the roles served locally, each into its own tier's

--- a/src/server/embedder_probe.c
+++ b/src/server/embedder_probe.c
@@ -3,8 +3,11 @@
  * embedder without db2 learning the embed transport (db2 stays config-free). */
 #include "embedder_probe.h"
 
+#include "aimee.h" /* EMBED_MAX_DIM + memory.h prerequisites */
 #include "lifecycle.h"
 #include "log.h"
+#include "memory.h"               /* memory_embed_text — in-process HTTP probe */
+#include "memory_core_internal.h" /* memory_embed_command_is_http */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -29,6 +32,18 @@ static int probe_once(void)
 {
    if (!g_embed_cmd[0])
       return -1;
+   /* An http(s):// "command" is the in-process embed transport (the combined /
+    * unified-container deployments export AIMEE_LLM_URL and set no sidecar
+    * command) — there is nothing to exec, and popen would fork
+    * `sh -c "http://... --dim"` forever. Probe by embedding a short text and
+    * taking the vector's length: transport-exact, and independent of whether
+    * the gateway's /health reports a dim. */
+   if (memory_embed_command_is_http(g_embed_cmd))
+   {
+      static float vec[EMBED_MAX_DIM];
+      int d = memory_embed_text("dim probe", g_embed_cmd, vec, EMBED_MAX_DIM);
+      return d > 0 ? d : -1;
+   }
    char cmd[1100];
    snprintf(cmd, sizeof(cmd), "%s --dim", g_embed_cmd);
    FILE *p = popen(cmd, "r");


### PR DESCRIPTION
## Summary
Deploying `aimee-combined:latest` from scratch (fresh Proxmox CT + `compose.combined.yaml`, nothing else) surfaced three independent defects; the appliance cannot reach healthy without all three:

1. **db2 dim probe popens an http 'command'.** Combined/unified deployments configure no sidecar embed command — `config_embedding_command` resolves to `AIMEE_LLM_URL` and embedding speaks HTTP in-process. The §2b fresh-DB dim probe still ran `popen("<cmd> --dim")`, forking `sh -c "http://127.0.0.1:8080 --dim"` every 2s forever; db2 init fails after the budget and the kb dies. Now: when the effective command is `http(s)://`, probe by embedding a short text in-process and take the vector's length — transport-exact and independent of the gateway's `/health` payload (older gateways don't report `dim`; #1298 fixes that separately).
2. **The combined entrypoint runs the bash supervisor with `sh`.** dash aborts at the first array (`Syntax error: "(" unexpected`), so the bundled llm never started — no model fetch, gateway never listening. The standalone image execs the script (bash shebang); the combined entrypoint now does the same.
3. **`fetch()` hard-requires wget, which the combined runtime stage doesn't ship.** Every model download failed with a reachable URL. `fetch()` now falls back to curl with equivalent resume/retry semantics.

Each layer masked the next: fixing (1) exposed (2), fixing (2) exposed (3).

## Testing
- Live from-scratch deploy on a Proxmox CT (docker + compose, `aimee-combined:latest` + pgvector): reproduced each failure in sequence; with all three patches hot-applied the supervisor fetches the cpu-tier models and the stack proceeds to healthy.
- `bash -n` on the supervisor; `gcc -fsyntax-only` on the probe TU.