### PR TITLE
fix(config): allowlist the top-level 'aimee' block in the schema

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -401,6 +401,7 @@ static const config_schema_entry_t config_schema[] = {
     {"ensemble", SCHEMA_OBJECT, 0},
     {"roundtable", SCHEMA_OBJECT, 0},
     {"cron_jobs", SCHEMA_ARRAY, 0},
+    {"aimee", SCHEMA_OBJECT, 0},
     {"trigger", SCHEMA_OBJECT, 0},
     {"trigger_rules", SCHEMA_ARRAY, 0},
     {"claude_cli_delegate_enabled", SCHEMA_BOOL, 0},


### PR DESCRIPTION
Follow-up to #1298's schema additions: the top-level `aimee:` block (`aimee.api` — http_port/tls_port/bearer_token/remote_writes, parsed by `config_server_api.c`) was also missing from `config_schema[]`, so any deployment configuring the /v1 listener logs `config warning: unknown key "aimee"` on every load (observed on the .254 appliance after deploying `testing-fc48c54`), and `--config-strict` would reject a valid config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)