### PR TITLE
feat(wfe): source.archive block — retire the triggering proposal to done/ on the run branch

### DIFF
--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -149,8 +149,17 @@ nodes:
       quorum: 3
       max_rounds: 6
       focus: is the documentation complete, accurate, and clear for this feature?
-    on_pass: final_pr
+    on_pass: archive
     on_fail: document
+  # Retire the triggering proposal on the run branch: move it from the watch dir
+  # (docs/proposals/pending) to docs/proposals/done, committed on the feature
+  # branch so the final PR retires the trigger input atomically with the work.
+  # A run without a trigger artifact (interactive intake) advances as a no-op.
+  - id: archive
+    block: source.archive
+    in:
+      branch: document.out
+    next: final_pr
   # Open the final PR: feature branch -> the repo's DEFAULT branch. Terminal: the
   # workflow ends here. pr.open only OPENS the PR (base:trunk, never merged); a human
   # reviews and merges it on the forge.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -564,6 +564,7 @@ nodes:
 | `author.plan` | `plan` | `proposal` |
 | `implement` | `branch` | `plan` |
 | `document` | `branch` | `branch` |
+| `source.archive` | `branch` | `branch` |
 | `freeze` | `frozen_diff` | `branch` |
 | `gate.roundtable` | `verdict` | `proposal`, `plan`, `frozen_diff` |
 | `gate.human` | `approval` | `proposal`, `plan`, `branch`, `frozen_diff`, `pr` |

--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -314,8 +314,7 @@ static int live_panel(const wfe_review_packet_t *pkt, const char *const *require
                static const char *const kind_names[] = {"approve", "request_changes", "comment",
                                                         "malformed"};
                wfe_verdict_kind_t k = out[filled].kind;
-               const char *kn =
-                   (k >= 0 && k <= WFE_V_MALFORMED) ? kind_names[k] : "?";
+               const char *kn = (k >= 0 && k <= WFE_V_MALFORMED) ? kind_names[k] : "?";
                if (k == WFE_V_MALFORMED)
                {
                   const char *r = results[t].response;

--- a/src/tests/test_wfe_blocks.c
+++ b/src/tests/test_wfe_blocks.c
@@ -133,6 +133,41 @@ int main(void)
    assert(wfe_tdd_tests_survive("", red) == 1);
    assert(wfe_tdd_tests_survive(dir, "0000000000000000000000000000000000000000") == 1);
 
+   /* --- source.archive: content-addressed retire of the triggering file --- */
+   {
+      assert(wfe_lookup_block_executor(WFE_BLK_SOURCE_ARCHIVE));
+      snprintf(cmd, sizeof cmd,
+               "cd %s && mkdir -p docs/proposals/pending && printf 'proposal body\\n' > "
+               "docs/proposals/pending/idea.md && git add -A && git commit -q -m proposal",
+               dir);
+      assert(sh(cmd) == 0);
+      /* the trigger keys the run on the file's BLOB sha */
+      char sha[64] = "";
+      {
+         char c2[1200];
+         snprintf(c2, sizeof c2, "git -C %s rev-parse HEAD:docs/proposals/pending/idea.md", dir);
+         FILE *p = popen(c2, "r");
+         assert(p && fgets(sha, sizeof sha, p));
+         pclose(p);
+         sha[40] = '\0';
+      }
+      /* moved + committed */
+      assert(wfe_source_archive_move(dir, sha, "docs/proposals/pending", "docs/proposals/done") ==
+             1);
+      snprintf(
+          cmd, sizeof cmd,
+          "test ! -e %s/docs/proposals/pending/idea.md && test -f "
+          "%s/docs/proposals/done/idea.md && git -C %s status --porcelain | wc -l | grep -qx 0",
+          dir, dir, dir);
+      assert(sh(cmd) == 0);
+      /* idempotent: the blob is gone from pending/ -> nothing to do */
+      assert(wfe_source_archive_move(dir, sha, "docs/proposals/pending", "docs/proposals/done") ==
+             0);
+      /* unknown sha -> nothing to do (never an error) */
+      assert(wfe_source_archive_move(dir, "0000000000000000000000000000000000000000",
+                                     "docs/proposals/pending", "docs/proposals/done") == 0);
+   }
+
    snprintf(cmd, sizeof cmd, "rm -rf %s", dir);
    sh(cmd);
    printf("ok\n");

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -28,7 +28,7 @@
 #include "wfe_engine.h"
 #include "wfe_iface.h"
 #include "wfe_manager_artifacts.h" /* typed intent/packet/verdict schema validators */
-#include "wfe_store.h" /* db1_work_item_set_worktree — persist the per-item worktree */
+#include "wfe_store.h"             /* db1_work_item_set_worktree — persist the per-item worktree */
 
 /* Resolve the local working repo for a work item: $AIMEE_WORKFLOW_REPO or cwd. */
 static const char *repo_dir(void)

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -7,6 +7,7 @@
  * suite (the engine test overrides them with mocks via the vtable). */
 #include "wfe_blocks.h"
 
+#include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -27,7 +28,7 @@
 #include "wfe_engine.h"
 #include "wfe_iface.h"
 #include "wfe_manager_artifacts.h" /* typed intent/packet/verdict schema validators */
-#include "wfe_store.h"             /* db1_work_item_set_worktree — persist the per-item worktree */
+#include "wfe_store.h" /* db1_work_item_set_worktree — persist the per-item worktree */
 
 /* Resolve the local working repo for a work item: $AIMEE_WORKFLOW_REPO or cwd. */
 static const char *repo_dir(void)
@@ -1058,6 +1059,146 @@ static wfe_step_result_t exec_document(wfe_ctx *ctx, const wfe_node_t *node)
    return wfe_step_advanced(handle, head, cost);
 }
 
+/* mkdir -p for a repo-relative dir under `wd` (single-purpose: the archive
+ * destination). Best-effort; the git mv below surfaces any real failure. */
+static void archive_mkdir_parents(const char *wd, const char *rel)
+{
+   char buf[1200];
+   int n = snprintf(buf, sizeof buf, "%s/%s", wd, rel);
+   if (n <= 0 || n >= (int)sizeof buf)
+      return;
+   for (char *p = buf + strlen(wd) + 1; *p; p++)
+      if (*p == '/')
+      {
+         *p = '\0';
+         mkdir(buf, 0755);
+         *p = '/';
+      }
+   mkdir(buf, 0755);
+}
+
+/* The git half of source.archive (unit-testable against a real repo): find the
+ * file under `from`/ whose HEAD blob is `sha`, `git mv` it into `to`/ and
+ * commit. Returns 1 moved+committed, 0 nothing to do (no matching blob), -1 on
+ * a git failure. */
+int wfe_source_archive_move(const char *wd, const char *sha, const char *from, const char *to)
+{
+   char spec[600];
+   if (snprintf(spec, sizeof spec, "%s/", from) >= (int)sizeof spec)
+      return -1;
+   const char *ls[] = {"git", "-C", (char *)wd, "ls-tree", "HEAD", "--", spec, NULL};
+   char *out = NULL;
+   if (safe_exec_capture(ls, &out, 1 << 20) != 0 || !out)
+   {
+      free(out);
+      return -1;
+   }
+   /* lines: <mode> SP blob SP <sha> TAB <path> */
+   char path[512] = "";
+   for (char *line = out; line && *line;)
+   {
+      char *nl = strchr(line, '\n');
+      if (nl)
+         *nl = '\0';
+      char *tab = strchr(line, '\t');
+      const char *shapos = strstr(line, sha);
+      if (tab && shapos && shapos < tab)
+      {
+         snprintf(path, sizeof path, "%s", tab + 1);
+         break;
+      }
+      line = nl ? nl + 1 : NULL;
+   }
+   free(out);
+   if (!path[0])
+      return 0;
+
+   const char *pbn = strrchr(path, '/');
+   pbn = pbn ? pbn + 1 : path;
+   char dest[1024];
+   if (snprintf(dest, sizeof dest, "%s/%s", to, pbn) >= (int)sizeof dest)
+      return -1;
+   archive_mkdir_parents(wd, to);
+   const char *mv[] = {"git", "-C", (char *)wd, "mv", "-f", path, dest, NULL};
+   char *o = NULL;
+   if (safe_exec_capture(mv, &o, 1 << 16) != 0)
+   {
+      free(o);
+      return -1;
+   }
+   free(o);
+   o = NULL;
+   char msg[700];
+   snprintf(msg, sizeof msg, "chore: archive completed proposal %s -> %s", pbn, to);
+   const char *ci[] = {"git", "-C", (char *)wd, "commit", "-m", msg, NULL};
+   if (safe_exec_capture(ci, &o, 1 << 16) != 0)
+   {
+      free(o);
+      return -1;
+   }
+   free(o);
+   return 1;
+}
+
+/* source.archive: retire the run's triggering source file (trigger-first
+ * lifecycle). The trigger materialized the watched file as
+ * <home>/triggers/<source>/<blob-sha>.md and filed the run keyed on that path;
+ * this block finds the file in params.from (default docs/proposals/pending)
+ * whose HEAD blob matches that sha, `git mv`s it into params.to (default
+ * docs/proposals/done), and commits on the run branch — so the final PR retires
+ * the trigger input atomically with the work. Runs without a content-addressed
+ * trigger artifact (interactive/dev-submit intake), or whose source file was
+ * already moved/edited, advance as a no-op: the block never blocks a run that
+ * has nothing to retire. */
+static wfe_step_result_t exec_source_archive(wfe_ctx *ctx, const wfe_node_t *node)
+{
+   char wd[1024];
+   resolve_workdir(ctx, wd, sizeof wd);
+   char handle[80];
+   snprintf(handle, sizeof handle, "%s.out", node->id);
+
+   char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
+   if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
+      return wfe_step_failed_class(WFE_FAIL_CORRUPTION, 0); /* worktree/git unavailable */
+
+   const char *wi = wfe_ctx_work_item(ctx);
+   db1_work_item_t row;
+   if (!wi || !wi[0] || db1_work_item_get(wi, &row) != 1 || !row.proposal_path[0])
+      return wfe_step_advanced(handle, head, 0.0);
+   const char *bn = strrchr(row.proposal_path, '/');
+   bn = bn ? bn + 1 : row.proposal_path;
+   char sha[41];
+   if (strlen(bn) != 43 || strcmp(bn + 40, ".md") != 0)
+      return wfe_step_advanced(handle, head, 0.0);
+   for (int i = 0; i < 40; i++)
+      if (!isxdigit((unsigned char)bn[i]))
+         return wfe_step_advanced(handle, head, 0.0);
+   memcpy(sha, bn, 40);
+   sha[40] = '\0';
+
+   /* params.from/.to are repo-relative; an absolute or traversing dir could point
+    * git outside the worktree -> fail closed (a misconfigured node, not a retry). */
+   const cJSON *jf = node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "from") : NULL;
+   const cJSON *jt = node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "to") : NULL;
+   const char *from = (jf && cJSON_IsString(jf) && jf->valuestring && jf->valuestring[0])
+                          ? jf->valuestring
+                          : "docs/proposals/pending";
+   const char *to = (jt && cJSON_IsString(jt) && jt->valuestring && jt->valuestring[0])
+                        ? jt->valuestring
+                        : "docs/proposals/done";
+   if (from[0] == '/' || to[0] == '/' || strstr(from, "..") || strstr(to, ".."))
+      return wfe_step_failed();
+
+   int rc = wfe_source_archive_move(wd, sha, from, to);
+   if (rc < 0)
+      return wfe_step_looped();
+   if (rc == 0)
+      return wfe_step_advanced(handle, head, 0.0); /* nothing (left) to retire */
+   if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
+      return wfe_step_failed_class(WFE_FAIL_CORRUPTION, 0);
+   return wfe_step_advanced(handle, head, 0.0);
+}
+
 /* freeze: capture the cumulative diff at a stable freeze commit. */
 static wfe_step_result_t exec_freeze(wfe_ctx *ctx, const wfe_node_t *node)
 {
@@ -1809,6 +1950,7 @@ void wfe_register_default_executors(void)
    wfe_register_block_executor(WFE_BLK_AUTHOR_PLAN, exec_author);
    wfe_register_block_executor(WFE_BLK_IMPLEMENT, exec_implement);
    wfe_register_block_executor(WFE_BLK_DOCUMENT, exec_document);
+   wfe_register_block_executor(WFE_BLK_SOURCE_ARCHIVE, exec_source_archive);
    wfe_register_block_executor(WFE_BLK_FREEZE, exec_freeze);
    wfe_register_block_executor(WFE_BLK_PR_OPEN, exec_pr_open);
    wfe_register_block_executor(WFE_BLK_MERGE, exec_merge);

--- a/src/workflow/wfe_blocks.h
+++ b/src/workflow/wfe_blocks.h
@@ -14,6 +14,11 @@ void wfe_register_default_executors(void);
  * merge-base of HEAD against `base_branch` (e.g. "origin/testing" or "main").
  * Fills the short SHAs and the sha256 hex of the cumulative diff. Returns 0 on
  * success. Standalone (no engine ctx) so it is directly unit-testable. */
+/* source.archive git half (unit-testable): move the file under from/ whose HEAD
+ * blob is `sha` into to/ and commit. 1 = moved+committed, 0 = nothing to do,
+ * -1 = git failure. */
+int wfe_source_archive_move(const char *wd, const char *sha, const char *from, const char *to);
+
 int wfe_git_freeze(const char *repo_dir, const char *base_branch, char out_base_sha[64],
                    char out_head_sha[64], char out_diff_hash[65], char *err, size_t errlen);
 

--- a/src/workflow/wfe_def.c
+++ b/src/workflow/wfe_def.c
@@ -37,6 +37,9 @@ static const struct
      * branch, produces the documented branch) -> composes between implement and
      * freeze, or anywhere a branch is in hand. */
     {WFE_BLK_DOCUMENT, "document", WFE_ART_BRANCH, 1, {WFE_ART_BRANCH, WFE_ART_NONE}},
+    /* retire the run's triggering source file onto the run branch (trigger-first
+     * lifecycle; see wfe_iface.h); branch -> branch so it composes anywhere. */
+    {WFE_BLK_SOURCE_ARCHIVE, "source.archive", WFE_ART_BRANCH, 1, {WFE_ART_BRANCH, WFE_ART_NONE}},
     {WFE_BLK_FREEZE, "freeze", WFE_ART_FROZEN_DIFF, 1, {WFE_ART_BRANCH, WFE_ART_NONE}},
     {WFE_BLK_GATE_ROUNDTABLE,
      "gate.roundtable",

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -60,6 +60,12 @@ typedef enum
     * workflow run and parks the parent until every child is terminal. */
    WFE_BLK_BRANCH_OPEN,      /* open/return a durable feature branch -> branch */
    WFE_BLK_FOREACH_WORKFLOW, /* per-packet child workflow fan-out -> branch */
+   /* Retire the run's triggering source file (trigger-first lifecycle): move the
+    * watched file that filed this run (content-addressed by the materialized
+    * artifact's blob-sha name) from its watch dir to a done dir, committed on the
+    * run branch so the final PR retires the trigger input atomically with the
+    * work. No-op advance for runs without a content-addressed trigger artifact. */
+   WFE_BLK_SOURCE_ARCHIVE, /* branch -> branch */
    WFE_BLK__COUNT
 } wfe_block_type_t;
 


### PR DESCRIPTION
## Summary
Closes the trigger-first lifecycle loop for the proposals pipeline: a completed run now **moves its triggering proposal from `docs/proposals/pending/` to `docs/proposals/done/`** as part of the work itself.

- New block `source.archive` (branch → branch, composes anywhere a branch is in hand): finds the file under `params.from` (default `docs/proposals/pending`) whose HEAD blob matches the run's materialized trigger artifact sha (`<home>/triggers/<source>/<blob-sha>.md` — the same content-address the trigger dedups on), `git mv`s it into `params.to` (default `docs/proposals/done`), and commits on the run branch. The final PR therefore retires the trigger input atomically with the work; merging it removes the proposal from pending so the watch never re-fires.
- Generic by construction: `from`/`to` are params, so any watch-dir rule (not just proposals) gets the same retire-on-completion semantics.
- Fail-open where it must be: runs without a content-addressed trigger artifact (interactive intake, /v1/dev/submit) and already-moved/edited files advance as a no-op — the block never wedges a run that has nothing to retire. Absolute/traversing `from`/`to` fail closed.
- `build` template: new `archive` node between `doc_gate` and `final_pr`.

## Testing
- `wfe_source_archive_move` unit-tested against a real git repo in test_wfe_blocks (moved+committed with clean tree, idempotent second call, unknown-sha no-op), executor-registration assert included.
- All five shipped workflow templates re-validated through the real parser+validator (`wfe_def_load_file` + `wfe_def_validate`), including the modified `build`.
- clang-formatted; `gcc -fsyntax-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)