### PR TITLE
fix(wfe): comment verdicts are non-blocking — count them toward gate quorum

### DIFF
--- a/src/tests/test_wfe_roundtable.c
+++ b/src/tests/test_wfe_roundtable.c
@@ -124,10 +124,21 @@ int main(void)
                            mk("architect", WFE_V_APPROVE, "H", 1)};
       assert(wfe_gate_decide(c, 2, req2, 2, 2, "H", rs, sizeof rs) == WFE_GATE_CHANGES);
 
-      /* COMMENT counts as present-not-approve -> below quorum -> CHANGES */
+      /* COMMENT is non-blocking: approve + comment meets quorum 2 -> APPROVE */
       wfe_verdict_t d[] = {mk("security", WFE_V_APPROVE, "H", 0),
                            mk("architect", WFE_V_COMMENT, "H", 0)};
-      assert(wfe_gate_decide(d, 2, req2, 2, 2, "H", rs, sizeof rs) == WFE_GATE_CHANGES);
+      assert(wfe_gate_decide(d, 2, req2, 2, 2, "H", rs, sizeof rs) == WFE_GATE_APPROVE);
+
+      /* ...but comments alone never pass: at least one explicit approve. */
+      wfe_verdict_t d2[] = {mk("security", WFE_V_COMMENT, "H", 0),
+                            mk("architect", WFE_V_COMMENT, "H", 0)};
+      assert(wfe_gate_decide(d2, 2, req2, 2, 2, "H", rs, sizeof rs) == WFE_GATE_CHANGES);
+
+      /* ...and ANY request_changes loops, even with quorum-many non-blocking. */
+      wfe_verdict_t d3[] = {mk("security", WFE_V_APPROVE, "H", 0),
+                            mk("architect", WFE_V_COMMENT, "H", 0),
+                            mk("qa", WFE_V_REQUEST_CHANGES, "H", 0)};
+      assert(wfe_gate_decide(d3, 3, req2, 2, 2, "H", rs, sizeof rs) == WFE_GATE_CHANGES);
 
       /* tampered hash on a REQUIRED persona: it never validly reviewed THIS
        * artifact -> integrity failure -> DEGRADED (not a definitive CHANGES). */

--- a/src/workflow/wfe_verdict.c
+++ b/src/workflow/wfe_verdict.c
@@ -66,15 +66,35 @@ wfe_gate_decision_t wfe_gate_decide(const wfe_verdict_t *verdicts, int n,
       }
    }
 
-   int approve = 0, high_sev = 0;
+   /* Quorum counts NON-BLOCKING verdicts: approve and comment (a comment is by
+    * definition "non-blocking remarks only" — the reviewer found nothing that
+    * blocks the change). Requiring literal approve from every lens made a
+    * required-4/quorum-4 gate practically unpassable for an autonomous run
+    * (cautious reviewers emit comment, the gate loops to its attempt cap, and
+    * every run parks pending_human). Fail-closed is preserved where it
+    * matters: ANY effective request_changes loops (malformed/tampered verdicts
+    * coerce to request_changes), any high-sev blocker loops, and at least one
+    * lens must still explicitly approve — comments alone never pass a gate. */
+   int approve = 0, high_sev = 0, changes = 0, nonblocking = 0;
    for (int i = 0; i < n; i++)
    {
       /* only trust blocker counts from structurally-valid verdicts; an
        * untrustworthy verdict already fails the gate via effective_kind. */
       if (structurally_valid(&verdicts[i], artifact_hash) && verdicts[i].high_sev_blockers > 0)
          high_sev += verdicts[i].high_sev_blockers;
-      if (effective_kind(&verdicts[i], artifact_hash) == WFE_V_APPROVE)
+      switch (effective_kind(&verdicts[i], artifact_hash))
+      {
+      case WFE_V_APPROVE:
          approve++;
+         nonblocking++;
+         break;
+      case WFE_V_COMMENT:
+         nonblocking++;
+         break;
+      default:
+         changes++;
+         break;
+      }
    }
 
    if (high_sev > 0)
@@ -83,13 +103,21 @@ wfe_gate_decision_t wfe_gate_decide(const wfe_verdict_t *verdicts, int n,
          snprintf(reason, rcap, "%d unresolved high-severity blocker(s)", high_sev);
       return WFE_GATE_CHANGES;
    }
-   if (approve < quorum)
+   if (changes > 0)
    {
       if (reason)
-         snprintf(reason, rcap, "approve quorum not met (%d/%d)", approve, quorum);
+         snprintf(reason, rcap, "%d reviewer(s) requested changes", changes);
+      return WFE_GATE_CHANGES;
+   }
+   if (approve < 1 || nonblocking < quorum)
+   {
+      if (reason)
+         snprintf(reason, rcap, "approve quorum not met (approve=%d, non-blocking=%d/%d)", approve,
+                  nonblocking, quorum);
       return WFE_GATE_CHANGES;
    }
    if (reason)
-      snprintf(reason, rcap, "approved (%d>=%d, no high-sev blockers)", approve, quorum);
+      snprintf(reason, rcap, "approved (%d approve + %d comment >= %d, no blockers)", approve,
+               nonblocking - approve, quorum);
    return WFE_GATE_APPROVE;
 }


### PR DESCRIPTION
## Summary
Autonomous convergence fix found driving the proposals-trigger build run E2E on .254: the plan gate looped to its attempt cap and parked `pending_human` on every attempt because **only literal `approve` counted toward quorum**. With required=4/quorum=4, all four lenses had to say approve; cautious reviewers answer `comment` — which the panel prompt itself defines as *non-blocking remarks only* — so an honest approve/comment mix could never pass (verified live over many rounds with the new per-lens verdict logs).

New decision rule, fail-closed preserved:
- any effective `request_changes` → CHANGES (malformed/tampered verdicts still coerce there),
- any high-severity blocker → CHANGES,
- quorum counts **non-blocking** verdicts (approve + comment), **and at least one lens must explicitly approve** — comments alone never pass,
- required-lens coverage / integrity (DEGRADED) unchanged.

## Testing
- Decision-matrix tests updated + extended in test_wfe_roundtable (approve+comment passes; comments-only fails; any request_changes fails; high-sev fails; malformed/tampered still DEGRADED); the matrix verified locally against the real `wfe_gate_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)