### PR TITLE
fix(wfe): human-gate operability — approval key at startup, gate-response UAF, coherent roundtable levers

### DIFF
--- a/config/workflows/build-triggered.yaml
+++ b/config/workflows/build-triggered.yaml
@@ -63,6 +63,11 @@ nodes:
           - contrarian
       quorum: 4
       max_rounds: 6
+      # The gate's own loop budget (panel convenes -> request_changes -> the plan
+      # is re-authored -> gate again). The engine's default cap parked runs after
+      # a handful of rounds; honest refinement loops need more headroom before
+      # escalating to a human.
+      max_iters: 24
       focus: does this implementation plan fully satisfy the proposal/request?
     on_pass: split
     on_fail: plan

--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -74,6 +74,11 @@ nodes:
           - contrarian
       quorum: 4
       max_rounds: 6
+      # The gate's own loop budget (panel convenes -> request_changes -> the plan
+      # is re-authored -> gate again). The engine's default cap parked runs after
+      # a handful of rounds; honest refinement loops need more headroom before
+      # escalating to a human.
+      max_iters: 24
       focus: does this implementation plan fully satisfy the proposal/request?
     on_pass: split
     on_fail: plan

--- a/src/db1/wfe_store.c
+++ b/src/db1/wfe_store.c
@@ -714,6 +714,24 @@ int db1_stage_attempt_inc(const char *wi, const char *stage)
    return db1_stage_attempt_get(wi, stage);
 }
 
+/* Reset a stage's loop-attempt budget (operator resume of an escalated
+ * roundtable park re-arms the refinement loop). 0 on success. */
+int db1_stage_attempt_reset(const char *wi, const char *stage)
+{
+   sqlite3 *db = db1_conn();
+   if (!db || !wi || !stage)
+      return -1;
+   static const char *sql = "DELETE FROM lifecycle_stage_attempt WHERE work_item_id=? AND stage=?";
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(st, 1, wi, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(st, 2, stage, -1, SQLITE_TRANSIENT);
+   int rc = sqlite3_step(st);
+   sqlite3_finalize(st);
+   return rc == SQLITE_DONE ? 0 : -1;
+}
+
 int db1_stage_attempt_get(const char *wi, const char *stage)
 {
    sqlite3 *db = db1_conn();

--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -155,7 +155,8 @@ int db1_lifecycle_event_add(const char *work_item_id, const char *stage, const c
 int db1_lifecycle_event_list(const char *work_item_id, db1_lifecycle_event_t **out);
 
 /* Per-stage attempt counter (for loop-back max_attempts). */
-int db1_stage_attempt_inc(const char *work_item_id, const char *stage); /* new count */
+int db1_stage_attempt_inc(const char *work_item_id, const char *stage);   /* new count */
+int db1_stage_attempt_reset(const char *work_item_id, const char *stage); /* re-arm the loop */
 int db1_stage_attempt_get(const char *work_item_id, const char *stage);
 
 /* Coarse transaction control for an atomic advance critical section (the engine

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -299,7 +299,13 @@ static int rh_workflow_gate(const route_req_t *rq, char *resp, int cap)
    cJSON *body = rq->body ? cJSON_Parse(rq->body) : NULL;
    cJSON *jdec = body ? cJSON_GetObjectItemCaseSensitive(body, "decision") : NULL;
    cJSON *jgate = body ? cJSON_GetObjectItemCaseSensitive(body, "gate") : NULL;
-   const char *decision = (jdec && cJSON_IsString(jdec)) ? jdec->valuestring : "";
+   /* Copy the decision OUT of `body` now: the cJSON doc is deleted before the
+    * final response is formatted, so a pointer into it must not outlive it
+    * (this was a use-after-free that echoed garbage in the success response). */
+   char decision_buf[16] = "";
+   if (jdec && cJSON_IsString(jdec) && jdec->valuestring)
+      snprintf(decision_buf, sizeof decision_buf, "%s", jdec->valuestring);
+   const char *decision = decision_buf;
    const char *actor = server_http_identity_principal();
    if (!actor || !actor[0])
       actor = "operator";

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -330,6 +330,31 @@ static int rh_workflow_gate(const route_req_t *rq, char *resp, int cap)
       snprintf(resp, cap, "{\"error\":\"decision must be 'approve' or 'reject'\"}");
       return 400;
    }
+   /* Approving a ROUNDTABLE gate is refused, mirroring wfe_gate_override's rail
+    * (a human must not force-pass a panel): previously this endpoint recorded a
+    * phantom approval + cleared the pause, and the engine simply re-ran the
+    * gate — misleading the operator into thinking approve crossed it. The
+    * levers for an escalated roundtable are: let the panel re-converge (the
+    * pause clears on resume of the loop budget), raise the node's max_iters,
+    * or reject. */
+   if (strcmp(decision, "approve") == 0)
+   {
+      char ferr[256];
+      wfe_def_t *gdef = wfe_load_workflow(wi.workflow_name, ferr, sizeof ferr);
+      const wfe_node_t *gnode = gdef ? wfe_def_node(gdef, wi.current_stage) : NULL;
+      int is_rt = gnode && gnode->block == WFE_BLK_GATE_ROUNDTABLE;
+      if (gdef)
+         wfe_def_free(gdef);
+      if (is_rt)
+      {
+         cJSON_Delete(body);
+         snprintf(resp, cap,
+                  "{\"error\":\"'%s' is a roundtable gate — a human cannot force-pass a panel. "
+                  "Resume re-runs the panel; reject terminates.\"}",
+                  wi.current_stage);
+         return 409;
+      }
+   }
 
    const char *result_kind = decision; /* audit kind; a reject may become reject_retry */
    char detail[256] = "";

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -22,7 +22,8 @@
 #include "cJSON.h"
 #include "server_http_identity.h" /* server_http_identity_principal — ownership scoping */
 #include "wfe_def.h"
-#include "yaml.h" /* yaml_emit — write blocks.yaml */
+#include "wfe_engine.h" /* wfe_load_workflow — roundtable-park resume check */
+#include "yaml.h"       /* yaml_emit — write blocks.yaml */
 #include "wfe_iface.h"
 #include "wfe_store.h"
 
@@ -863,9 +864,25 @@ int wf_api_item_resume(const char *id, int is_operator, char *resp, int cap)
    if (!wi.pause_reason[0])
       return err(resp, cap, 409, "run is not paused");
    /* A run parked at a human gate must be decided via Approve/Reject so the
-    * signed approval is recorded — never silently un-paused here. */
+    * signed approval is recorded — never silently un-paused here. The one
+    * exception: a ROUNDTABLE gate escalated at its loop cap. A human cannot
+    * force-pass a panel (approve refuses it), so resume is the operator lever
+    * that re-arms the refinement loop: clear the pause and the sweep re-runs
+    * the panel with the (possibly re-authored/raised) budget. */
    if (strcmp(wi.pause_reason, "pending_human") == 0)
-      return err(resp, cap, 409, "run is at a human gate — use Approve or Reject");
+   {
+      char ferr[256];
+      wfe_def_t *rdef = wfe_load_workflow(wi.workflow_name, ferr, sizeof ferr);
+      const wfe_node_t *rnode = rdef ? wfe_def_node(rdef, wi.current_stage) : NULL;
+      int is_rt = rnode && rnode->block == WFE_BLK_GATE_ROUNDTABLE;
+      if (rdef)
+         wfe_def_free(rdef);
+      if (!is_rt)
+         return err(resp, cap, 409, "run is at a human gate — use Approve or Reject");
+      /* roundtable escalation: fall through to the un-pause below. Re-arm the
+       * loop budget so the gate doesn't instantly re-park at the same cap. */
+      db1_stage_attempt_reset(id, wi.current_stage);
+   }
    if (db1_work_item_clear_pause(id) != 0)
       return err(resp, cap, 500, "could not resume run");
    db1_lifecycle_event_add(id, wi.current_stage, "resume", wf_actor(), "resumed by operator", "",

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -20,6 +20,7 @@
 
 #include "wfe_live_delegate.h"
 
+#include "aimee_home.h"
 #include "agent_config.h"
 #include "agent_exec.h"
 #include "agent_types.h"
@@ -457,5 +458,15 @@ void wfe_autonomy_register(void)
     * foreach node after its plan is authored + roundtabled); without it the foreach
     * node fails closed (parks). */
    wfe_live_foreach_register();
+   /* The human-gate approval trust root (HMAC key) must exist before the first
+    * operator decision: without it every approve fails "could not record
+    * approval" and a parked run can never be driven past a human gate (the
+    * ensure was previously only called from tests). Best-effort: a failure
+    * logs and the first approve still fails closed. */
+   if (wfe_approval_ensure_key() != 0)
+      aimee_log(LOG_WARN, "wfe",
+                "could not provision the approval key; human-gate approvals "
+                "will fail until %s/.approval-key exists",
+                aimee_home());
    aimee_log(LOG_INFO, "wfe", "autonomous development registered (default-on)");
 }


### PR DESCRIPTION
## Summary
Defects found driving a live parked run past its gates (operator control surface):

1. **No deployment could ever approve a human gate.** `wfe_approval_ensure_key()` was only called from tests — the HMAC trust root (`$AIMEE_HOME/.approval-key`) never existed, so the first `POST /v1/workflow/items/{id}/gate` approve failed `could not record approval`, forever. Provisioned at wfe registration now (WARN + still fail-closed if it can't be created).
2. **Use-after-free in the gate endpoint**: the success response and the audit `kind` were formatted from `decision`, a pointer into the request's cJSON doc deleted earlier on that path. Observed live: garbage bytes echoed in the response AND **persisted into the lifecycle_event row** (broke UTF-8 decoding of the audit trail). The decision is copied out before any delete.
3. **Coherent operator levers at an escalated roundtable.** `/gate approve` on a roundtable is now refused (409), mirroring `wfe_gate_override`'s a-human-must-not-force-pass-a-panel rail — previously it recorded a phantom approval and cleared the pause, and the engine just re-ran the gate. In exchange, **`resume` now works for a roundtable park**: it clears the pause and re-arms the stage's loop budget (`db1_stage_attempt_reset`) so the refinement loop continues rather than instantly re-parking at the same cap. True human gates still refuse resume.
4. **Templates**: `plan_gate` carries an explicit `max_iters: 24` in build/build-triggered — the default cap counted every historical attempt (including rounds burned by the now-fixed fenced-verdict parsing) and escalated too early.

## Testing
- Live on .254: key provisioning verified (approve succeeded once the key existed); the UAF garbage reproduced on the same call (response + audit row); the resume-lever flow (budget reset + pause clear) validated manually against the running work item.
- clang-format 19; syntax-checked TUs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)