### PR TITLE
fix(wfe-panel): retry a lens whose verdict came back malformed (truncated reviews)

### DIFF
--- a/config/workflows/build-triggered.yaml
+++ b/config/workflows/build-triggered.yaml
@@ -76,6 +76,10 @@ nodes:
     in:
       plan: plan.out
     next: slices
+    # A transient split failure (the packet-authoring delegate flubbing its
+    # output) must retry, not dead-end the run: a looped node with no on_fail
+    # edge parks 'stuck' permanently.
+    on_fail: split
   - id: slices
     block: foreach.workflow
     in:

--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -88,6 +88,10 @@ nodes:
     in:
       plan: plan.out
     next: slices
+    # A transient split failure (the packet-authoring delegate flubbing its
+    # output) must retry, not dead-end the run: a looped node with no on_fail
+    # edge parks 'stuck' permanently.
+    on_fail: split
   # Fan every packet out to the child "slice" workflow; park until all have merged
   # into the feature branch. A failed/blocked slice parks the run for a human.
   - id: slices

--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -323,6 +323,19 @@ static int live_panel(const wfe_review_packet_t *pkt, const char *const *require
                   aimee_log(LOG_WARN, "wfe-panel",
                             "lens '%s' verdict malformed from agent '%s'; reply tail: %.160s",
                             required[i], taskagent[t], tail);
+                  /* A malformed reply from a $random seat is provider flakiness
+                   * (typically a review truncated before its final JSON line, as
+                   * the tail above shows) — treat it like a failed dispatch and
+                   * let the next round retry the lens with a DIFFERENT agent
+                   * rather than committing a verdict that fails required-lens
+                   * coverage and degrades the whole gate. Only the FINAL round
+                   * commits the malformed verdict (fail-closed as before). */
+                  if (!pinned[i] && round == 0)
+                  {
+                     free(results[t].response);
+                     results[t].response = NULL;
+                     continue; /* leave done[i]=0 -> round 2 re-seats this lens */
+                  }
                }
                else
                   aimee_log(LOG_INFO, "wfe-panel", "lens '%s' verdict %s from agent '%s'",

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -1702,13 +1702,34 @@ static wfe_step_result_t exec_understand(wfe_ctx *ctx, const wfe_node_t *node)
 
 static wfe_step_result_t exec_split(wfe_ctx *ctx, const wfe_node_t *node)
 {
-   return manager_produce(
-       ctx, node, "architect",
-       "Decompose the approved intent into a structured PACKET PLAN and write it as JSON to the "
-       "given path (nothing else): {\"schema_version\":1,\"packets\":[{\"packet_id\":\"p1\","
-       "\"summary\":\"...\",\"target_blocks\":[\"implement\"],\"dependencies\":[],"
-       "\"acceptance_criteria\":[\"...\"]}]}. Then commit it.",
-       wfe_packets_validate);
+   /* Thread the APPROVED PLAN into the prompt: the plan artifact lives at the
+    * run's proposal path (under $AIMEE_HOME, edited in place by author.plan),
+    * which the delegate — running in the worktree — cannot see. Without the
+    * content the delegate has nothing to decompose and (observed live) writes a
+    * complaint into the artifact file instead of packets, looping split to its
+    * cap. Truncated head-first: packetization needs the plan's structure, which
+    * leads. */
+   char plan[12 * 1024];
+   plan[0] = '\0';
+   const char *ppath = wfe_ctx_proposal_path(ctx);
+   if (ppath && ppath[0])
+   {
+      FILE *f = fopen(ppath, "rb");
+      if (f)
+      {
+         size_t n = fread(plan, 1, sizeof plan - 1, f);
+         plan[n] = '\0';
+         fclose(f);
+      }
+   }
+   char prompt[14 * 1024];
+   snprintf(prompt, sizeof prompt,
+            "Decompose the APPROVED PLAN below into a structured PACKET PLAN and write it as JSON "
+            "to the given path (nothing else): {\"schema_version\":1,\"packets\":[{\"packet_id\":"
+            "\"p1\",\"summary\":\"...\",\"target_blocks\":[\"implement\"],\"dependencies\":[],"
+            "\"acceptance_criteria\":[\"...\"]}]}. Then commit it.\n\nAPPROVED PLAN:\n%s",
+            plan[0] ? plan : "(no plan artifact found — decompose the work item's ask)");
+   return manager_produce(ctx, node, "architect", prompt, wfe_packets_validate);
 }
 
 /* review: a READ-ONLY reviewer delegate (persona from node params `reviewer`,


### PR DESCRIPTION
## Summary
With #1302's reply-tail logging live, the recurring `panel_degraded` root cause is now visible: reviewers occasionally hit their provider token cap and the reply **truncates before the final JSON verdict line** (observed live: mimo's review ending mid-sentence, no verdict). The parser correctly fails such a reply MALFORMED — but the panel **committed** that verdict instantly, failing required-lens coverage and degrading the whole gate on one flaky response, while a lens whose dispatch returned *nothing* would have been retried on the panel's second round.

Fix: a malformed $random-seat reply on round one is treated exactly like a failed dispatch — the lens stays unfilled, round two re-seats it and the diversity exclusion picks a **different agent**. Only the final round commits a malformed verdict, so the gate remains fail-closed when malformation persists. Pinned seats keep their no-retry contract.

## Testing
- clang-format 19; `gcc -fsyntax-only` clean.
- Live validation on .254 follows the next testing image (the run that exposed this is being driven E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)