### PR TITLE
fix(wfe): slice fleet unblockers — impl/pr retry edges, understand fallback contract

### DIFF
--- a/config/workflows/slice.yaml
+++ b/config/workflows/slice.yaml
@@ -23,6 +23,9 @@ nodes:
     in:
       plan: scope.out
     next: freeze
+    # A transient implement failure (delegate flub, failed verify) retries; a
+    # looped node with no on_fail edge parks 'stuck' permanently.
+    on_fail: impl
   - id: freeze
     block: freeze
     in:
@@ -50,6 +53,8 @@ nodes:
     in:
       src: freeze.out
     next: ci
+    # forge push/open can fail transiently; retry rather than dead-end.
+    on_fail: pr
   # CI must be fully green before the slice may merge; red loops back to implement.
   - id: ci
     block: gate.ci

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -1721,12 +1721,34 @@ static wfe_step_result_t manager_produce(wfe_ctx *ctx, const wfe_node_t *node, c
 
 static wfe_step_result_t exec_understand(wfe_ctx *ctx, const wfe_node_t *node)
 {
-   return manager_produce(
-       ctx, node, "architect",
-       "Scope this work item into a structured INTENT RECORD and write it as JSON to the given "
-       "path (nothing else): {\"schema_version\":1,\"status\":\"unconfirmed\",\"summary\":\"<one "
-       "line>\",\"rationale\":\"<why>\",\"acceptance_criteria\":[\"<testable>\"]}. Then commit it.",
-       wfe_intent_validate);
+   /* Same read-only-persona contract as exec_split: the architect persona's
+    * delegates may have no file tools, in which case the response-persist
+    * fallback is the artifact path — the reply itself must be the JSON. Thread
+    * the packet/proposal content in so a slice child scopes ITS packet rather
+    * than guessing. */
+   char src[12 * 1024];
+   src[0] = '\0';
+   const char *ppath = wfe_ctx_proposal_path(ctx);
+   if (ppath && ppath[0])
+   {
+      FILE *f = fopen(ppath, "rb");
+      if (f)
+      {
+         size_t n = fread(src, 1, sizeof src - 1, f);
+         src[n] = '\0';
+         fclose(f);
+      }
+   }
+   char prompt[14 * 1024];
+   snprintf(prompt, sizeof prompt,
+            "Scope the WORK ITEM below into a structured INTENT RECORD: "
+            "{\"schema_version\":1,\"status\":\"unconfirmed\",\"summary\":\"<one line>\","
+            "\"rationale\":\"<why>\",\"acceptance_criteria\":[\"<testable>\"]}. Write the JSON to "
+            "the given path and commit it if you can; if file tools are unavailable to you, your "
+            "ENTIRE reply must be exactly that JSON document — no prose, no code fences, nothing "
+            "else.\n\nWORK ITEM:\n%s",
+            src[0] ? src : "(no packet artifact found — scope the work item's ask)");
+   return manager_produce(ctx, node, "architect", prompt, wfe_intent_validate);
 }
 
 static wfe_step_result_t exec_split(wfe_ctx *ctx, const wfe_node_t *node)


### PR DESCRIPTION
Driving the first live 13-slice fan-out surfaced the slice-workflow twins of bugs already fixed on the build side tonight:

- **slice.yaml**: `implement` and `pr.open` had **no `on_fail` edge** — one flaky delegate reply or forge hiccup parked the child `stuck` permanently (`node 'impl' looped with no on_fail edge`; 9 of 13 children within the first hour). Same class as the `split` fix in #1309; they self-retry now.
- **exec_understand** gets the same read-only-persona contract as `exec_split` (#1311): the architect persona's delegates have no file tools, so the response-persist fallback is the artifact path — the prompt now threads the packet content in and states the reply must be exactly the JSON document (4 of 13 children looped `scope` to the cap on narrated refusals).

Validated: templates re-validated through the real parser; clang-format 19; syntax clean. Live slice-fleet validation follows the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)