### PR TITLE
fix(guardrails): treat /wfe-worktrees/ as an aimee-managed worktree

### DIFF
--- a/src/workspace.c
+++ b/src/workspace.c
@@ -571,7 +571,15 @@ int worktree_delegate_work_name(const char *sid, char *out, size_t cap)
 /* Check if a path is already inside an aimee worktree. */
 int is_aimee_worktree_path(const char *path)
 {
-   return path && (strstr(path, "/.aimee/worktrees/") != NULL || strstr(path, "/.aimee-") != NULL);
+   /* "/wfe-worktrees/" — the workflow engine's per-work-item worktrees
+    * ($AIMEE_HOME/wfe-worktrees/wi_<id>). A wfe delegate already runs isolated in
+    * one of these, so the session-worktree-isolation guardrail must treat its
+    * edits as already-in-a-worktree — otherwise the guard rewrites the delegate's
+    * own worktree paths into a (malformed) session sibling, scattering edits
+    * where verify can't see them (observed live: every slice's implement step
+    * failed verification because its edits landed in a mangled path). */
+   return path && (strstr(path, "/.aimee/worktrees/") != NULL || strstr(path, "/.aimee-") != NULL ||
+                   strstr(path, "/wfe-worktrees/") != NULL);
 }
 
 int worktree_managed_git_root(const char *path, char *out, size_t out_len)


### PR DESCRIPTION
The last blocker for autonomous slice implementation, found by tracing why every one of the 13 slice children failed `implement` verification.

`is_aimee_worktree_path` matched only `/.aimee/worktrees/`, so the workflow engine's per-work-item worktrees (`$AIMEE_HOME/wfe-worktrees/wi_<id>`) weren't recognized as isolated. The session-worktree-isolation guardrail therefore treated a wfe delegate's edits — already running inside their own wfe-worktree — as edits to *the real repo*, and rewrote every path into a session sibling worktree. Worse, the offset was **malformed**: `git_repo_root` of a wfe-worktree resolves to the *main* repo, so `target + gr_len` strips the wrong prefix (observed live: `.../s5/src/git_verify.c` → `.../main569f7365...s5/src/git_verify.c`). The delegate's changes landed in a path the wfe-worktree never saw, so `implement`'s mechanical verify (now live, #1313) found an empty tree and looped to the cap — on every slice child.

Fix: recognize `/wfe-worktrees/` as already-isolated (same shape as the existing `/.aimee/worktrees/` match), so the guard leaves those paths alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)