### PR TITLE
feat(images): multi-arch aimee-llm/combined; pre-bake cpu models in combined

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,9 +4,9 @@
 #
 #   aimee-server     (Dockerfile.server)      ghcr.io/<owner>/aimee-server
 #   aimee-kb         (Dockerfile)             ghcr.io/<owner>/aimee-kb
-#   aimee-combined   (Dockerfile.combined)    ghcr.io/<owner>/aimee-combined (all-in-one appliance; amd64)
+#   aimee-combined   (Dockerfile.combined)    ghcr.io/<owner>/aimee-combined (all-in-one appliance)
 #   aimee-embedder   (Dockerfile.embedder)    ghcr.io/<owner>/aimee-embedder (+ -4b)
-#   aimee-llm        (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-llm (model-less; amd64)
+#   aimee-llm        (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-llm (model-less)
 #   aimee-css-render (deploy/css-render/Dockerfile) ghcr.io/<owner>/aimee-css-render
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
@@ -81,8 +81,8 @@ jobs:
         image:
           - { name: aimee-server,    dockerfile: Dockerfile.server }
           - { name: aimee-kb,        dockerfile: Dockerfile }
-          # All-in-one appliance: server + kb + the bundled llama.cpp llm runtime.
-          # amd64 only (the llama.cpp binary is x64), skipped on arm64 below.
+          # All-in-one appliance: server + kb + the bundled llama.cpp llm runtime
+          # (TARGETARCH-mapped upstream tarball) + the PRE-BAKED cpu-tier models.
           - { name: aimee-combined,  dockerfile: Dockerfile.combined }
           - { name: aimee-embedder,  dockerfile: Dockerfile.embedder }
           # Higher-fidelity alternate tier: same Dockerfile, 4b embedder + 1b reranker
@@ -93,8 +93,8 @@ jobs:
           # embed+rerank+synth). MODEL-LESS: one image for every tier — the tier
           # (cpu/small/mid/large) is chosen at RUNTIME via AIMEE_LLM_TIER and the models
           # are downloaded on first boot, so there are no baked GGUFs and no build-args.
-          # amd64 only: the llama.cpp Vulkan release binary is x64-only (skipped on arm64
-          # below). NGL is set at deploy.
+          # Multi-arch: upstream llama.cpp ships x64 + arm64 Vulkan tarballs, mapped
+          # from TARGETARCH in the Dockerfile. NGL is set at deploy.
           - { name: aimee-llm, dockerfile: Dockerfile.aimee-llm }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
@@ -138,10 +138,6 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        # aimee-llm + aimee-combined are amd64-only: the llama.cpp Vulkan release
-        # binary is x64-only, so an arm64 image would ship a non-runnable binary.
-        # Skip them on arm64 -> the merge job emits a single-arch amd64 manifest.
-        if: ${{ !((matrix.image.name == 'aimee-llm' || matrix.image.name == 'aimee-combined') && matrix.platform.arch == 'arm64') }}
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context || '.' }}
@@ -151,14 +147,15 @@ jobs:
           # Reuse layers across releases. Without this every release rebuilt all
           # images on both arches from scratch — re-running the full LTO C build
           # each time. Scoped per image+arch so the matrix legs never clobber each
-          # other. EXCLUDES aimee-embedder: its torch + baked multi-GB model layers
-          # would blow the 10 GB GHA cache budget and evict the (small, high-reuse)
-          # C-image caches, defeating the purpose. The embedder's real win is the
-          # runtime model fetch (embedder-runtime-fetch-autodim proposal), not the
-          # layer cache. aimee-llm is now model-less (no baked GGUFs) so it is small
-          # and cached like the C images.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          # other. EXCLUDES aimee-embedder AND aimee-combined: their baked multi-GB
+          # model layers would blow the 10 GB GHA cache budget and evict the (small,
+          # high-reuse) C-image caches, defeating the purpose. The embedder's real
+          # win is the runtime model fetch (embedder-runtime-fetch-autodim proposal),
+          # not the layer cache; the combined image pre-bakes its cpu-tier GGUFs.
+          # aimee-llm is model-less (no baked GGUFs) so it is small and cached like
+          # the C images.
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-combined' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-combined' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
@@ -173,13 +170,11 @@ jobs:
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: ${{ !((matrix.image.name == 'aimee-llm' || matrix.image.name == 'aimee-combined') && matrix.platform.arch == 'arm64') }}
         run: |
           mkdir -p /tmp/digests
           echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ matrix.image.name }}-${{ matrix.platform.arch }}"
 
       - name: Upload digest
-        if: ${{ !((matrix.image.name == 'aimee-llm' || matrix.image.name == 'aimee-combined') && matrix.platform.arch == 'arm64') }}
         uses: actions/upload-artifact@v4
         with:
           name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}

--- a/.github/workflows/publish-llm-testing.yml
+++ b/.github/workflows/publish-llm-testing.yml
@@ -9,8 +9,9 @@
 # at RUNTIME via AIMEE_LLM_TIER and the models are downloaded on first boot, so
 # there are no baked GGUFs and no per-tier build matrix — a single small image
 # serves every tier. The pre-converted ettin rerank artifacts it fetches are
-# published separately by publish-rerank-artifacts.yml. amd64 only (the llama.cpp
-# Vulkan release binary is x64-only; the release pipeline owns any multi-arch).
+# published separately by publish-rerank-artifacts.yml. This testing build is
+# amd64 only for speed (.254 is amd64); the release pipeline (publish-images.yml)
+# publishes the multi-arch amd64+arm64 manifest.
 name: Publish testing aimee-llm
 
 on:

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -95,9 +95,12 @@ jobs:
           push: true
           provenance: false
           # Share the layer cache with the release pipeline (same scope) so testing
-          # builds are fast and never start the LTO C build from scratch.
-          cache-from: type=gha,scope=${{ matrix.image.name }}-amd64
-          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-amd64
+          # builds are fast and never start the LTO C build from scratch. EXCEPT
+          # aimee-combined: its pre-baked multi-GB cpu-tier model layer would blow
+          # the 10 GB GHA cache budget and evict the high-reuse C-image caches
+          # (matches the release pipeline's exclusion).
+          cache-from: ${{ matrix.image.name != 'aimee-combined' && format('type=gha,scope={0}-amd64', matrix.image.name) || '' }}
+          cache-to: ${{ matrix.image.name != 'aimee-combined' && format('type=gha,mode=max,scope={0}-amd64', matrix.image.name) || '' }}
           # WITH_WEBCHAT bundles the browser UI (default for aimee-server; the
           # aimee-kb image ignores it). WITH_LLM=0: no LLM is bundled — the deploy
           # stack runs a separate, profile-gated aimee-llm container instead (see

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -18,6 +18,8 @@
 #
 # The llama.cpp binary is the VENDOR-AGNOSTIC Vulkan build (one binary for AMD/
 # Nvidia/Intel); GPU is selected at runtime by AIMEE_LLM_NGL (defaults 0 = CPU).
+# MULTI-ARCH: upstream ships both ubuntu-vulkan-x64 and ubuntu-vulkan-arm64
+# tarballs, mapped from TARGETARCH below.
 
 ARG LLAMA_TAG=b9775
 
@@ -30,15 +32,23 @@ ARG LLAMA_TAG=b9775
 # NOTE: trixie's 64-bit time_t transition renames libcurl4 -> libcurl4t64.
 FROM debian:trixie-slim AS runtime
 ARG LLAMA_TAG
+ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl wget libgomp1 libcurl4t64 libvulkan1 mesa-vulkan-drivers \
         python3 python3-numpy \
     && rm -rf /var/lib/apt/lists/*
-# llama.cpp vendor-agnostic Vulkan release (one binary for AMD/Nvidia/Intel)
-RUN wget -q -O /tmp/llama.tgz \
-        "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_TAG}/llama-${LLAMA_TAG}-bin-ubuntu-vulkan-x64.tar.gz" \
-    && mkdir -p /opt/llama && tar -xzf /tmp/llama.tgz -C /opt/llama --strip-components=1 \
-    && rm /tmp/llama.tgz
+# llama.cpp vendor-agnostic Vulkan release (one binary for AMD/Nvidia/Intel).
+# Upstream names its asset arches x64/arm64; map from Docker's amd64/arm64.
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) llarch=x64 ;; \
+      arm64) llarch=arm64 ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    wget -q -O /tmp/llama.tgz \
+        "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_TAG}/llama-${LLAMA_TAG}-bin-ubuntu-vulkan-${llarch}.tar.gz"; \
+    mkdir -p /opt/llama; tar -xzf /tmp/llama.tgz -C /opt/llama --strip-components=1; \
+    rm /tmp/llama.tgz
 ENV LD_LIBRARY_PATH=/opt/llama/lib:/opt/llama PATH=/opt/llama:/opt/llama/bin:$PATH
 
 COPY scripts/aimee_llm_gateway.py scripts/aimee_llm_rerank_head.py /opt/aimee/

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -11,7 +11,10 @@
 #   docker compose -f compose.combined.yaml up -d
 #   # server /v1 on :8743 (TLS, bearer "aimee-local-dev"); kb + llm internal
 #
-# amd64 only: the bundled llama.cpp runtime is an x64 build (like aimee-llm).
+# Multi-arch (amd64 + arm64): the bundled llama.cpp runtime maps TARGETARCH to
+# upstream's x64/arm64 Vulkan tarballs (like aimee-llm). The cpu-tier models are
+# PRE-BAKED into the image (see the llm-models stage), so first boot serves
+# immediately with no multi-GB download.
 ARG WITH_WEBCHAT=1
 ARG WITH_VSCODE=1
 ARG LLAMA_TAG=b9775
@@ -70,17 +73,36 @@ FROM debian:bookworm-slim AS code-server-stage-0
 RUN mkdir -p /opt/codeserver/usr
 FROM code-server-stage-${WITH_VSCODE} AS code-server-stage
 
-# --- bundled aimee-llm runtime: the llama.cpp binary (no models) ---------------
-# Mirrors Dockerfile.aimee-llm: the vendor-agnostic Vulkan build (one x64 binary);
-# at NGL=0 (the appliance default) it runs on CPU. Models are NOT baked — the
-# supervisor downloads the cpu tier into /models on first boot.
+# --- bundled aimee-llm runtime: the llama.cpp binary ---------------------------
+# Mirrors Dockerfile.aimee-llm: the vendor-agnostic Vulkan build, TARGETARCH-mapped
+# to upstream's x64/arm64 tarball; at NGL=0 (the appliance default) it runs on CPU.
 FROM debian:bookworm-slim AS llm-runtime
 ARG LLAMA_TAG
+ARG TARGETARCH
+RUN set -eux; \
+    apt-get update; apt-get install -y --no-install-recommends ca-certificates wget; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) llarch=x64 ;; \
+      arm64) llarch=arm64 ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    wget -q -O /tmp/llama.tgz \
+        "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_TAG}/llama-${LLAMA_TAG}-bin-ubuntu-vulkan-${llarch}.tar.gz"; \
+    mkdir -p /opt/llama; tar -xzf /tmp/llama.tgz -C /opt/llama --strip-components=1; \
+    rm /tmp/llama.tgz; rm -rf /var/lib/apt/lists/*
+
+# --- pre-baked cpu-tier models --------------------------------------------------
+# Run the supervisor's own download logic (AIMEE_LLM_DOWNLOAD_ONLY=1) at BUILD
+# time so the appliance ships its cpu-tier GGUFs (embed + rerank + synth) and
+# their .ready markers baked in: first boot serves immediately instead of pulling
+# multi-GB models. The supervisor stays the single source of truth for model
+# coordinates; arch-independent content, but built per-arch like every stage.
+FROM debian:bookworm-slim AS llm-models
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget \
-    && wget -q -O /tmp/llama.tgz \
-        "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_TAG}/llama-${LLAMA_TAG}-bin-ubuntu-vulkan-x64.tar.gz" \
-    && mkdir -p /opt/llama && tar -xzf /tmp/llama.tgz -C /opt/llama --strip-components=1 \
-    && rm /tmp/llama.tgz && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
+COPY scripts/aimee-llm-supervisor.sh /tmp/supervisor.sh
+RUN chmod +x /tmp/supervisor.sh \
+    && AIMEE_LLM_DOWNLOAD_ONLY=1 AIMEE_LLM_TIER=cpu AIMEE_LLM_MODELS_DIR=/models /tmp/supervisor.sh
 
 FROM debian:bookworm-slim
 # Union of the runtime closures: libsqlite3 (server DB1), libpq (kb DB2),
@@ -148,6 +170,11 @@ COPY --from=build /src/aimee-server /usr/local/bin/aimee-server
 COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
 # Bundled llama.cpp runtime + the aimee-llm gateway/supervisor.
 COPY --from=llm-runtime /opt/llama /opt/llama
+# Pre-baked cpu-tier models (+ .ready markers, so the supervisor skips the fetch).
+# A named volume mounted at /models is seeded from this image content on first
+# use (Docker copies image data into an empty named volume), and a tier switch
+# still downloads its models into the volume as before.
+COPY --from=llm-models --chown=aimee:aimee /models/ /models/
 COPY scripts/aimee_llm_gateway.py scripts/aimee_llm_rerank_head.py /opt/aimee/
 COPY scripts/aimee-llm-supervisor.sh /opt/aimee/supervisor.sh
 RUN chmod +x /opt/aimee/supervisor.sh
@@ -183,8 +210,10 @@ WORKDIR /var/lib/aimee
 EXPOSE 8740 8743 8741 8443
 
 # Health targets the SERVER /v1 (the container contract); a 401 still proves the
-# listener is up. Long start-period: the bundled llm downloads cpu models first boot.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=1200s --retries=5 \
+# listener is up. Start-period covers seeding the baked models into a fresh
+# /models volume + loading them into RAM (cpu tier, slow disks included) — the
+# multi-GB first-boot DOWNLOAD is gone (models are pre-baked).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=600s --retries=5 \
     CMD curl -s -o /dev/null -w '%{http_code}' \
         http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$'
 

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -13,8 +13,9 @@
 # The /v1 API requires a bearer token (baked default: "aimee-local-dev"):
 #   curl -k -H "Authorization: Bearer aimee-local-dev" https://localhost:8743/v1/health
 #
-# CPU-only by design. The bundled aimee-llm downloads its cpu-tier models into the
-# models volume on first boot, so the first start takes a few minutes.
+# CPU-only by design. The image is multi-arch (amd64 + arm64) and ships its
+# cpu-tier models PRE-BAKED; first boot only seeds them into the models volume
+# (a local copy), not a multi-GB download.
 
 services:
   postgres:
@@ -68,7 +69,8 @@ services:
     volumes:
       - aimee-combined-home:/var/lib/aimee
       - aimee-combined-workspaces:/var/lib/aimee-workspaces
-      # Persist the bundled LLM's downloaded cpu-tier models across recreations.
+      # Seeded from the image's pre-baked cpu-tier models on first use; persists
+      # any other tier's downloads across recreations.
       - aimee-combined-models:/models
     healthcheck:
       test: ["CMD-SHELL",
@@ -76,8 +78,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      # Long: the bundled aimee-llm downloads its cpu models on first boot.
-      start_period: 1200s
+      # Covers seeding the baked models into a fresh volume + loading them (the
+      # first-boot model DOWNLOAD is gone — they ship in the image).
+      start_period: 600s
 
 volumes:
   aimee-combined-home:

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -43,7 +43,8 @@ CI builds + publishes the **one** model-less `aimee-llm` image as part of the no
 (no per-tier images — the tier is a runtime env, not a build):
 - **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds `aimee-llm`
   on every release and tags it `:<version>` + `:latest`. It is in both the `build` and `merge`
-  matrices; the merge step applies the tags. amd64-only (the llama.cpp Vulkan binary is x64).
+  matrices; the merge step applies the tags. Multi-arch amd64+arm64 (the llama.cpp Vulkan
+  tarball is TARGETARCH-mapped in the Dockerfile).
 - **testing:** `.github/workflows/publish-llm-testing.yml` builds `aimee-llm` on `testing`
   pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts, tagged `:testing`
   (+ `:testing-<sha>`, amd64).

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -255,6 +255,15 @@ resolve_one() { # ROLE MODE localurl
   esac
 }
 
+# DOWNLOAD-ONLY mode (build-time pre-bake): fetch the resolved tiers' models into
+# $MODELS_DIR and exit without launching anything. Dockerfile.combined uses this
+# to bake the cpu tier into the image, keeping the tier table here as the single
+# source of truth instead of duplicating model URLs in the Dockerfile.
+if [ "${AIMEE_LLM_DOWNLOAD_ONLY:-0}" = "1" ]; then
+  download_models || { echo "aimee-llm: pre-bake download failed" >&2; exit 1; }
+  exit 0
+fi
+
 # STUB mode (CI/dev): no GGUFs, no downloads, no llama-servers — the gateway serves
 # deterministic embed/rerank/synth. Lets e2e exercise the kb->gateway contract
 # cheaply (and the image runs without any model fetch).


### PR DESCRIPTION
llama.cpp upstream now ships `ubuntu-vulkan-arm64` release tarballs, so the amd64-only assumption behind aimee-llm/aimee-combined is stale (an ARM user hit the bundled x86 binary and had to patch around it).

## Multi-arch
- `Dockerfile.aimee-llm` + `Dockerfile.combined`: map `TARGETARCH` → upstream's `x64`/`arm64` Vulkan tarball names.
- `publish-images.yml`: drop the arm64 skips for aimee-llm and aimee-combined so the merge job emits true amd64+arm64 manifests.

## Pre-baked cpu-tier models in aimee-combined (~6.2 GB)
- supervisor: new `AIMEE_LLM_DOWNLOAD_ONLY=1` mode — fetch the resolved tiers' models and exit; the tier table stays the single source of truth for build-time baking.
- `Dockerfile.combined`: new `llm-models` stage runs it at build; the named `/models` volume is seeded from image content on first use; healthcheck start-period 1200s → 600s (no more first-boot download).
- `publish-images.yml` + `publish-testing.yml`: exclude aimee-combined from the gha layer cache (the baked model layer would blow the 10 GB budget, like the embedder).

First boot of the combined appliance now serves immediately instead of pulling multi-GB models.