### PR TITLE
enforce: strip AI attribution from commits and PR bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     branches: [main, testing]
+    # `edited` re-runs the gate when a PR title/body is edited after open, so
+    # attribution can't be added post-hoc without failing CI.
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
 
 concurrency:
@@ -37,6 +40,19 @@ jobs:
             exit 1
           fi
           echo "no co-authorship trailers in $range — ok"
+      - name: Reject AI attribution in the PR title/body
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          hits=$(printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" \
+                 | grep -inE '^[[:space:]]*co-authored-by:|generated with \[(claude|codex)' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::The PR title/body carries AI attribution; remove it (standing directive)."
+            echo "$hits"
+            exit 1
+          fi
+          echo "no AI attribution in PR title/body — ok"
 
   lint:
     runs-on: ubuntu-latest

--- a/src/headers/util.h
+++ b/src/headers/util.h
@@ -355,6 +355,12 @@ char *safe_strdup(const char *s);
 /* Strip local-model private reasoning scaffolds from a response string. */
 char *strip_llm_private_scaffold(const char *text);
 
+/* Remove AI-attribution lines from a commit message / PR body in place: any
+ * "Co-Authored-By:" trailer and any "Generated with [Claude|Codex ...]"
+ * attribution line (same patterns as the CI ai-attribution gate). Returns the
+ * number of lines removed. */
+int strip_ai_attribution(char *text);
+
 /* Sanitize a string to only contain safe characters (alphanumeric, dash, underscore, dot).
  * Replaces all other characters with underscores in-place. */
 void sanitize_shell_token(char *s);

--- a/src/mcp_git_pr.c
+++ b/src/mcp_git_pr.c
@@ -385,6 +385,11 @@ cJSON *handle_git_pr(cJSON *args)
       if (!has_title && !has_body && !has_base)
          return mcp_text("error: edit requires at least one of title/body/base");
 
+      /* Standing directive: no AI attribution in PR bodies (in-place strip is
+       * shrink-only, so the cJSON-owned buffer is safe). */
+      if (has_body)
+         strip_ai_attribution(jbody->valuestring);
+
       char repo_slug[256];
       if (get_origin_repo_slug(repo_slug, sizeof(repo_slug)) != 0)
          return mcp_text("error: could not determine GitHub repository from origin remote");
@@ -508,6 +513,11 @@ cJSON *handle_git_pr(cJSON *args)
 
       if (!cJSON_IsString(jtitle) || !jtitle->valuestring[0])
          return mcp_text("error: 'title' parameter is required for create");
+
+      /* Standing directive: no AI attribution in PR bodies (in-place strip is
+       * shrink-only, so the cJSON-owned buffer is safe). */
+      if (cJSON_IsString(jbody))
+         strip_ai_attribution(jbody->valuestring);
 
       char *esc_title = shell_escape(jtitle->valuestring);
       char *esc_body = shell_escape(cJSON_IsString(jbody) ? jbody->valuestring : "");

--- a/src/mcp_git_write.c
+++ b/src/mcp_git_write.c
@@ -56,6 +56,14 @@ cJSON *handle_git_commit(cJSON *args)
    if (!cJSON_IsString(jmsg) || !jmsg->valuestring[0])
       return mcp_text("error: 'message' parameter is required");
 
+   /* Standing directive: no AI co-authorship trailers / "Generated with"
+    * attribution in commits. Strip in place (shrink-only, so the cJSON-owned
+    * buffer is safe) rather than reject, so agent commits stay unattended. */
+   strip_ai_attribution(jmsg->valuestring);
+   if (!jmsg->valuestring[0])
+      return mcp_text("error: commit message was only AI attribution lines; "
+                      "provide a real message (no Co-Authored-By / 'Generated with' trailers)");
+
    /* Fetch branch once — used for main-branch guard and ownership check */
    char branch[256] = "";
    get_current_branch(branch, sizeof(branch));

--- a/src/server/git_ops.c
+++ b/src/server/git_ops.c
@@ -163,6 +163,16 @@ int git_ops_run_session(const char *principal, const char *project, const char *
          snprintf(err, errlen, "commit requires a non-empty message");
          return -1;
       }
+      /* Standing directive: no AI co-authorship trailers / "Generated with"
+       * attribution in commits — strip before the message reaches git. */
+      char msg[4096];
+      snprintf(msg, sizeof(msg), "%s", text_arg);
+      strip_ai_attribution(msg);
+      if (!msg[0])
+      {
+         snprintf(err, errlen, "commit message was only AI attribution lines");
+         return -1;
+      }
       const char *add_argv[] = {"git", "add", "-A", NULL};
       char *add_out = NULL;
       int arc = run_git(principal, dir, add_argv, 0, &add_out);
@@ -172,7 +182,7 @@ int git_ops_run_session(const char *principal, const char *project, const char *
          snprintf(err, errlen, "git add failed (rc=%d)", arc);
          return -1;
       }
-      const char *argv[] = {"git", "commit", "-m", text_arg, NULL};
+      const char *argv[] = {"git", "commit", "-m", msg, NULL};
       int rc = run_git(principal, dir, argv, 0, out);
       if (rc != 0)
       {

--- a/src/server/git_pr_api.c
+++ b/src/server/git_pr_api.c
@@ -193,11 +193,18 @@ int git_pr_create_via_api(const char *principal, const char *repo_dir, const cha
       return -1;
    }
 
+   /* Standing directive: no AI co-authorship / "Generated with" attribution in
+    * PR bodies — strip a copy before it reaches GitHub. */
+   char *bclean = strdup(body ? body : "");
+   if (bclean)
+      strip_ai_attribution(bclean);
+
    cJSON *j = cJSON_CreateObject();
    cJSON_AddStringToObject(j, "title", title);
    cJSON_AddStringToObject(j, "head", head);
    cJSON_AddStringToObject(j, "base", base);
-   cJSON_AddStringToObject(j, "body", body ? body : "");
+   cJSON_AddStringToObject(j, "body", bclean ? bclean : "");
+   free(bclean);
    char *jbody = cJSON_PrintUnformatted(j);
    cJSON_Delete(j);
    if (!jbody)

--- a/src/server/wfe_live_forge.c
+++ b/src/server/wfe_live_forge.c
@@ -259,16 +259,26 @@ static int live_open(const char *repo, const char *branch, const char *base, con
       }
    }
 
+   /* Standing directive: no AI co-authorship / "Generated with" attribution in
+    * PR bodies. The body comes from the run's LLM, so strip a copy before it
+    * reaches the forge. */
+   char *bclean = strdup(body ? body : "");
+   if (!bclean)
+      return -1;
+   strip_ai_attribution(bclean);
+
    /* Escape every interpolated value; ABORT on any truncation (never run a
     * half-built shell command). */
    char ebranch[256], etitle[512], ebody[1024], ebase[128];
    if (shq(ebranch, sizeof ebranch, branch) != 0 ||
-       shq(etitle, sizeof etitle, title ? title : "") != 0 ||
-       shq(ebody, sizeof ebody, body ? body : "") != 0 || shq(ebase, sizeof ebase, base) != 0)
+       shq(etitle, sizeof etitle, title ? title : "") != 0 || shq(ebody, sizeof ebody, bclean) != 0 ||
+       shq(ebase, sizeof ebase, base) != 0)
    {
       aimee_log(LOG_WARN, "wfe-forge", "live_open: arg too long for %s", branch);
+      free(bclean);
       return -1;
    }
+   free(bclean);
 
    /* Push the work-item branch through the vaulted runner. Worktrees share the
     * branch namespace, so the push resolves the branch the run committed to. */

--- a/src/server/wfe_live_forge.c
+++ b/src/server/wfe_live_forge.c
@@ -271,8 +271,8 @@ static int live_open(const char *repo, const char *branch, const char *base, con
     * half-built shell command). */
    char ebranch[256], etitle[512], ebody[1024], ebase[128];
    if (shq(ebranch, sizeof ebranch, branch) != 0 ||
-       shq(etitle, sizeof etitle, title ? title : "") != 0 || shq(ebody, sizeof ebody, bclean) != 0 ||
-       shq(ebase, sizeof ebase, base) != 0)
+       shq(etitle, sizeof etitle, title ? title : "") != 0 ||
+       shq(ebody, sizeof ebody, bclean) != 0 || shq(ebase, sizeof ebase, base) != 0)
    {
       aimee_log(LOG_WARN, "wfe-forge", "live_open: arg too long for %s", branch);
       free(bclean);

--- a/src/tests/test_util.c
+++ b/src/tests/test_util.c
@@ -237,6 +237,43 @@ static void test_regex_match(void)
 }
 #endif
 
+static void test_strip_ai_attribution(void)
+{
+   char buf[512];
+
+   /* The standard Claude Code footer: trailer + attribution line both go. */
+   snprintf(buf, sizeof(buf),
+            "fix: handle empty input\n\nDetails here.\n\n"
+            "\xF0\x9F\xA4\x96 Generated with [Claude Code](https://claude.com/claude-code)\n\n"
+            "Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n");
+   assert(strip_ai_attribution(buf) == 2);
+   assert(strcmp(buf, "fix: handle empty input\n\nDetails here.") == 0);
+
+   /* Case-insensitive, leading whitespace, codex variant. */
+   snprintf(buf, sizeof(buf), "subject\n  CO-AUTHORED-BY: bot <b@x>\nGenerated with [Codex CLI]\n");
+   assert(strip_ai_attribution(buf) == 2);
+   assert(strcmp(buf, "subject") == 0);
+
+   /* Prose mentioning the concepts (unanchored trailer, no markdown link) stays. */
+   snprintf(buf, sizeof(buf),
+            "docs: explain co-authored-by handling\n\n"
+            "CI rejects any Co-Authored-By: trailer and text generated with Claude Code.\n");
+   assert(strip_ai_attribution(buf) == 0);
+   assert(strstr(buf, "co-authored-by handling") != NULL);
+   assert(strstr(buf, "generated with Claude") != NULL);
+
+   /* Attribution-only message strips to empty; NULL is a no-op. */
+   snprintf(buf, sizeof(buf), "Co-authored-by: X <x@y>\n");
+   assert(strip_ai_attribution(buf) == 1);
+   assert(buf[0] == '\0');
+   assert(strip_ai_attribution(NULL) == 0);
+
+   /* Interior attribution line is removed without joining its neighbours. */
+   snprintf(buf, sizeof(buf), "line one\nCo-Authored-By: A <a@b>\nline two");
+   assert(strip_ai_attribution(buf) == 1);
+   assert(strcmp(buf, "line one\nline two") == 0);
+}
+
 int main(void)
 {
    test_normalize_key();
@@ -248,6 +285,7 @@ int main(void)
    test_is_contradiction();
    test_shell_escape();
    test_shell_escape_injection_payloads();
+   test_strip_ai_attribution();
 #ifndef AIMEE_WINDOWS
    test_run_cmd();
    test_run_cmd_env();

--- a/src/util.c
+++ b/src/util.c
@@ -72,6 +72,62 @@ char *strip_llm_private_scaffold(const char *text)
    return out;
 }
 
+/* A line carries AI attribution if, after leading whitespace, it starts with a
+ * "co-authored-by:" trailer, or it contains the markdown-link attribution
+ * "generated with [claude"/"generated with [codex" anywhere. Case-insensitive.
+ * Mirrors the anchored regex in .github/workflows/ci.yml (ai-attribution gate)
+ * so Aimee never emits what CI rejects. `end` bounds the line (exclusive). */
+static int line_is_ai_attribution(const char *line, const char *end)
+{
+   const char *p = line;
+   while (p < end && (*p == ' ' || *p == '\t'))
+      p++;
+   if (end - p >= 15 && strncasecmp(p, "co-authored-by:", 15) == 0)
+      return 1;
+   for (const char *q = line; end - q >= 16 + 5; q++)
+   {
+      if (strncasecmp(q, "generated with [", 16) != 0)
+         continue;
+      const char *r = q + 16;
+      if ((end - r >= 6 && strncasecmp(r, "claude", 6) == 0) ||
+          (end - r >= 5 && strncasecmp(r, "codex", 5) == 0))
+         return 1;
+   }
+   return 0;
+}
+
+int strip_ai_attribution(char *text)
+{
+   if (!text)
+      return 0;
+   int removed = 0;
+   char *src = text, *dst = text;
+   while (*src)
+   {
+      char *eol = strchr(src, '\n');
+      char *next = eol ? eol + 1 : src + strlen(src);
+      const char *end = eol ? eol : next;
+      if (line_is_ai_attribution(src, end))
+         removed++;
+      else
+      {
+         size_t n = (size_t)(next - src);
+         memmove(dst, src, n);
+         dst += n;
+      }
+      src = next;
+   }
+   *dst = '\0';
+   if (removed)
+   {
+      size_t len = (size_t)(dst - text);
+      while (len > 0 && (text[len - 1] == '\n' || text[len - 1] == '\r' || text[len - 1] == ' ' ||
+                         text[len - 1] == '\t'))
+         text[--len] = '\0';
+   }
+   return removed;
+}
+
 void fatal(const char *fmt, ...)
 {
    va_list ap;


### PR DESCRIPTION
## Why

Commits and PR bodies were still landing with `Co-Authored-By` trailers and the "🤖 Generated with Claude Code" markdown-link footer. CI only gated new commit messages, and nothing stopped Aimee itself from authoring the attribution in the first place.

## What

**Aimee-side enforcement** — a shared `strip_ai_attribution()` (src/util.c) removes attribution lines in place, using the same patterns as the CI gate: the anchored co-authorship trailer, and the Claude/Codex markdown-link attribution line, case-insensitive. Prose that merely mentions these survives. Wired into every surface where Aimee authors commit/PR text:

- `git_commit` MCP tool (src/mcp_git_write.c) and webchat `git_ops` commit (src/server/git_ops.c) — message stripped before git; a message that was *only* attribution is rejected.
- `git_pr` MCP tool create/edit (src/mcp_git_pr.c) — PR body stripped.
- Autonomous live forge `pr.open` (src/server/wfe_live_forge.c) — body from the run's LLM stripped before push/PR.
- Webchat in-process PR API (src/server/git_pr_api.c) — body stripped before the REST call.

**CI backstop** (.github/workflows/ci.yml) — the existing `no-coauthor-trailers` job gains a step that rejects attribution in the PR title/body, and the `pull_request` trigger adds `edited` so attribution can't be added by editing the description after open.

**Tests** — `test_strip_ai_attribution` in src/tests/test_util.c: the standard Claude Code footer, case/whitespace/Codex variants, a prose false-positive guard, an attribution-only message, and interior-line removal.

## Verification

- `test_util` compiled and run locally: all tests pass.
- All five modified TUs pass `gcc -Wall -Wextra -fsyntax-only`.
- The first push of this PR failed its own gate — the commit message and body quoted the literal pattern being banned — which doubles as a live test of both the commit gate and the new body gate; both reworded.
