### PR TITLE
fix(wfe): verify gate ran in the daemon CWD; numeric agents.json 'enabled' ignored

### DIFF
--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -650,8 +650,20 @@ int agent_load_config(agent_config_t *cfg)
             ag->timeout_ms = reasoning ? AGENT_REASONING_TIMEOUT_MS : AGENT_DEFAULT_TIMEOUT_MS;
          }
 
+         /* "enabled" accepts a boolean or a 0/1 number: hand-edited rosters
+          * write `"enabled": 0`, and treating a non-bool as "enabled" silently
+          * re-armed agents the operator had switched off (observed live: a
+          * disabled agent with no valid key kept winning role routing and
+          * 401-looped every implement step). Absent key stays enabled. */
          v = cJSON_GetObjectItem(a, "enabled");
-         ag->enabled = (!v || !cJSON_IsBool(v)) ? 1 : cJSON_IsTrue(v);
+         if (!v)
+            ag->enabled = 1;
+         else if (cJSON_IsBool(v))
+            ag->enabled = cJSON_IsTrue(v);
+         else if (cJSON_IsNumber(v))
+            ag->enabled = (v->valueint != 0);
+         else
+            ag->enabled = 1;
 
          v = cJSON_GetObjectItem(a, "tools_enabled");
          if (v && cJSON_IsBool(v))

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -262,9 +262,18 @@ static int wfe_live_verify_run(const char *workdir, char *out_verdict, size_t n)
    cJSON_AddStringToObject(args, "action", "run");
    cJSON_AddBoolToObject(args, "async", 0); /* synchronous: we need the verdict now */
    cJSON_AddStringToObject(args, "format", "json");
+   /* handle_git_verify never reads a "path" arg itself — on the MCP route the
+    * dispatch layer chdirs the run_cmd thread before the handler runs, and
+    * resolve_verify_root() picks the root up from that CWD. Calling the handler
+    * directly (as we do here) skips that layer, so the verdict silently came
+    * from the DAEMON's CWD, not the work-item worktree: the steps ran against
+    * a non-repo dir and vacuously passed, verifying nothing. Pin the run_cmd
+    * thread CWD to the worktree for the duration, exactly like the delegate
+    * run above. */
    if (workdir && workdir[0])
-      cJSON_AddStringToObject(args, "path", workdir);
+      run_cmd_set_cwd(workdir);
    cJSON *resp = handle_git_verify(NULL, args, NULL);
+   run_cmd_set_cwd(NULL);
    cJSON_Delete(args);
    int rc = -1;
    if (resp)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -630,10 +630,10 @@ static void test_agent_config_provider_cli_roundtrip(void)
             "\"cost_tier\":2},"
             "{\"name\":\"gemini-cli\",\"provider\":\"gemini\","
             "\"roles\":[\"code\"],\"backend\":\"provider-cli\","
-            "\"cli_kind\":\"gemini\",\"cli_cmd\":\"gemini\"},"
+            "\"cli_kind\":\"gemini\",\"cli_cmd\":\"gemini\",\"enabled\":0},"
             "{\"name\":\"mistral-cli\",\"provider\":\"mistral\","
             "\"roles\":[\"code\"],\"backend\":\"provider-cli\","
-            "\"cli_kind\":\"mistral\",\"cli_cmd\":\"mistral\"},"
+            "\"cli_kind\":\"mistral\",\"cli_cmd\":\"mistral\",\"enabled\":1},"
             "{\"name\":\"claude-code\",\"provider\":\"claude-code\","
             "\"roles\":[\"code\"],\"backend\":\"tmux-cli\","
             "\"cli_kind\":\"claude-code\",\"cli_cmd\":\"/bin/echo\","
@@ -667,6 +667,10 @@ static void test_agent_config_provider_cli_roundtrip(void)
    assert(strcmp(loaded.agents[3].provider, "gemini") == 0);
    assert(strcmp(loaded.agents[3].cli_kind, "gemini") == 0);
    assert(strcmp(loaded.agents[3].cli_cmd, "gemini") == 0);
+   /* Numeric "enabled" (hand-edited rosters) must be honored, not treated as
+    * absent-and-therefore-enabled: 0 disables, 1 enables. */
+   assert(loaded.agents[3].enabled == 0);
+   assert(loaded.agents[4].enabled == 1);
    assert(strcmp(loaded.agents[4].name, "mistral-cli") == 0);
    assert(strcmp(loaded.agents[4].provider, "mistral") == 0);
    assert(strcmp(loaded.agents[4].cli_kind, "mistral") == 0);


### PR DESCRIPTION
Two independent faults kept autonomous implement units from being mechanically verified on the appliance (the last blocker for a 100% proposals→build E2E):

**1. The live verify provider verified the wrong directory.** `wfe_live_verify_run` passes a `path` arg to `handle_git_verify`, but the handler never reads it — path handling lives in the MCP dispatch layer (`mcp_chdir_git_root`), which a direct in-process call skips. The verdict was computed from the daemon's CWD (`/var/lib/aimee`, not a git repo): the operator's verify steps ran against a non-repo dir and vacuously passed, verifying nothing. Fix: pin the `run_cmd` thread CWD to the work-item worktree for the duration of the gate, mirroring what the delegate run in the same file already does.

**2. Operator-disabled agents stayed in role routing.** `agent_load_config` treated any non-boolean `enabled` as enabled. Hand-edited rosters write `"enabled": 0` (numeric), so a disabled mistral seat with no valid key kept winning the cost-tier tie and 401-looped every implement step to its loop cap (observed live on the .254 appliance: 13/13 slices parked `pending_human` at `impl max_iters`, one Mistral 401 per ~3s iteration). Fix: accept 0/1 numbers as well as booleans; absent still defaults enabled.

Tests: extended the `agent_load_config` roster round-trip in `test_agent.c` with numeric `enabled` 0/1 assertions (`unit-test-agent` and `unit-test-wfe-delegate-seam` pass locally).