### PR TITLE
guard: require aimee memory for agent-authored memories

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (176)
+## CLI-settable keys (177)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -193,6 +193,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `openai_model` | string | OpenAI model name. |
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
+| `require_aimee_memory` | bool | Block agent writes to external file-based agent-memory stores (~/.claude/projects/<slug>/memory/...) and redirect durable memories into aimee's memory system via `aimee memory store` (default on). |
 | `require_session_worktree` | bool | Fail closed on mutating ops outside an aimee-managed worktree (session-isolation guard; default off). |
 | `tool_output_max_bytes` | int | Per-result cap (bytes) on the model-visible tool output (read_file/bash/grep/glob/git_* results). 0 = built-in default (32768); any positive value is clamped to (0, 32768]. Set it lower to bound the bytes a single tool result adds to the prompt + history; the (default-off) context-economizer compresses older results to keep history bounded. |
 | `tsr_command` | string | TSR sidecar endpoint/command for structured-PDF table recognition (resolves like embedding_command; AIMEE_TSR_URL env fallback). |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -160,6 +160,9 @@ CFG_KEY_DESC = {
     "history bounded.",
     "require_session_worktree": "Fail closed on mutating ops outside an aimee-managed worktree "
     "(session-isolation guard; default off).",
+    "require_aimee_memory": "Block agent writes to external file-based agent-memory stores "
+    "(~/.claude/projects/<slug>/memory/...) and redirect durable memories into aimee's memory "
+    "system via `aimee memory store` (default on).",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress "
     "(memory/code preview envelope on primary ingress turns; default on).",

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -408,13 +408,13 @@ static int attn_config_ingress_max_raw_scans(void)
    return value;
 }
 
-/* Parse a boolean `require_session_worktree:` line from an aimee.yaml buffer.
- * Accepts true/1/yes/on (case-insensitive) as true; anything else (incl. a
- * missing key) is false. Mirrors attn_parse_ingress_max_raw_scans' lean,
+/* Parse a boolean `<key>:` line from an aimee.yaml buffer. Accepts
+ * true/1/yes/on (case-insensitive) as true; anything else (incl. a missing
+ * key) leaves *out untouched. Mirrors attn_parse_ingress_max_raw_scans' lean,
  * link-free YAML-line scan so the guard need not pull in the full config. */
-static int attn_parse_require_session_worktree(const char *buf, int *out)
+static int attn_parse_bool_key(const char *buf, const char *key, int *out)
 {
-   if (!buf || !out)
+   if (!buf || !key || !out)
       return 0;
 
    const char *line = buf;
@@ -430,8 +430,8 @@ static int attn_parse_require_session_worktree(const char *buf, int *out)
          if (*p == '"' || *p == '\'')
             quote = *p++;
 
-         size_t key_len = strlen("require_session_worktree");
-         if (strncmp(p, "require_session_worktree", key_len) == 0)
+         size_t key_len = strlen(key);
+         if (strncmp(p, key, key_len) == 0)
          {
             p += key_len;
             if (quote)
@@ -484,7 +484,30 @@ static int attn_config_require_session_worktree(void)
       return 1; /* no config file -> default ON */
 
    int value = 1; /* default ON; only an explicit key overrides */
-   (void)attn_parse_require_session_worktree(buf, &value);
+   (void)attn_parse_bool_key(buf, "require_session_worktree", &value);
+   free(buf);
+   return value;
+}
+
+static int attn_config_require_aimee_memory(void)
+{
+   /* Default ON: durable memories authored by an agent belong in aimee's memory
+    * system (`aimee memory store`), where they are indexed, recalled, and
+    * audited — not in per-harness markdown files aimee never sees. Only an
+    * explicit `require_aimee_memory: false` opts out. */
+   const char *home = aimee_home();
+   if (!home || !home[0])
+      return 1; /* no resolvable home -> fail closed to enforcement */
+
+   char path[1024];
+   snprintf(path, sizeof(path), "%s/aimee.yaml", home);
+
+   char *buf = NULL;
+   if (!attn_read_file(path, &buf))
+      return 1; /* no config file -> default ON */
+
+   int value = 1; /* default ON; only an explicit key overrides */
+   (void)attn_parse_bool_key(buf, "require_aimee_memory", &value);
    free(buf);
    return value;
 }
@@ -590,15 +613,132 @@ static int attn_path_in_managed_worktree(const char *norm)
 }
 
 /* Returns 1 iff `norm` is harness-owned session state rather than repo content:
- * Claude Code's per-project state dir ("~/.claude/projects/<slug>/..." — auto-
- * memory, transcripts, tool-result spills). The harness writes there as part of
- * normal operation from ANY cwd; blocking it doesn't protect the checkout, it
- * just breaks the harness (observed: memory writes refused mid-session). The
- * loose "/.claude/" prefix stays blocked — only the projects state dir is
- * carved out. */
+ * Claude Code's per-project state dir ("~/.claude/projects/<slug>/..." —
+ * transcripts, tool-result spills). The harness writes there as part of normal
+ * operation from ANY cwd; blocking it doesn't protect the checkout, it just
+ * breaks the harness. The loose "/.claude/" prefix stays blocked — only the
+ * projects state dir is carved out. NOTE: the file-based agent-memory subtree
+ * of this dir is NOT writable through this carve-out — the external-memory
+ * guard (attn_external_memory_blocked, checked first) redirects memory writes
+ * into aimee's memory system. */
 static int attn_path_is_harness_state(const char *norm)
 {
    return norm && strstr(norm, "/.claude/projects/") != NULL;
+}
+
+/* Returns 1 iff `norm` points into an external file-based agent-memory store:
+ * Claude Code's per-project auto-memory dir
+ * ("~/.claude/projects/<slug>/memory/..." incl. its MEMORY.md index). Matches
+ * the "/memory" component itself and anything under it. */
+static int attn_path_is_external_agent_memory(const char *norm)
+{
+   const char *m = norm ? strstr(norm, "/.claude/projects/") : NULL;
+   if (!m)
+      return 0;
+   const char *mem = strstr(m + 18, "/memory"); /* 18 = strlen("/.claude/projects/") */
+   if (!mem)
+      return 0;
+   return mem[7] == '\0' || mem[7] == '/';
+}
+
+/* True when `cmd` contains an output redirect that actually lands somewhere
+ * ('>' / '>>'), ignoring pure-discard ("> /dev/null") and fd-dup ("2>&1")
+ * forms so a read like `cat f 2>/dev/null` is not misread as a write. */
+static int cmd_has_real_redirect(const char *cmd)
+{
+   for (const char *p = cmd ? strchr(cmd, '>') : NULL; p; p = strchr(p + 1, '>'))
+   {
+      const char *q = p + 1;
+      if (*q == '>')
+         q++;
+      if (*q == '&')
+      {
+         q++;
+         if (isdigit((unsigned char)*q))
+            continue; /* fd dup, e.g. 2>&1 */
+      }
+      while (*q == ' ' || *q == '\t')
+         q++;
+      if (strncmp(q, "/dev/null", 9) == 0)
+         continue;
+      return 1;
+   }
+   return 0;
+}
+
+/* True when `tok` appears in `cmd` at a word START (preceded by whitespace,
+ * start-of-string, or a shell separator) — the right side is unconstrained so
+ * "python" matches "python3" and "node" matches "nodejs". Over-matching is the
+ * fail-closed direction here. */
+static int cmd_has_word_prefix(const char *cmd, const char *tok)
+{
+   size_t n = strlen(tok);
+   for (const char *p = cmd; (p = strstr(p, tok)) != NULL; p += n)
+   {
+      char l = (p == cmd) ? ' ' : p[-1];
+      if (l == ' ' || l == '\t' || l == '\n' || l == ';' || l == '|' || l == '&' || l == '(' ||
+          l == '`' || l == '$')
+         return 1;
+   }
+   return 0;
+}
+
+/* True if `cmd` plausibly writes files: a real output redirect, an in-place
+ * editor, a file-moving tool, or an interpreter (which can write anything).
+ * Conservative substring matching, same spirit as bash_is_hard(): a false
+ * positive blocks with a clear redirect message; a false negative would let a
+ * memory write slip through. */
+static int bash_cmd_can_write(const char *cmd)
+{
+   if (!cmd || !cmd[0])
+      return 0;
+   if (cmd_has_real_redirect(cmd))
+      return 1;
+   static const char *toks[] = {
+       "tee",  "sed -i", "sed --in-place", "perl -i", "awk -i",  "cp",    "mv",
+       "rm",   "touch",  "truncate",       "shred",   "install", "rsync", "dd",
+       "ln",   "chmod",  "chown",          "mkdir",   "python",  "perl",  "ruby",
+       "node", "php",    "xargs",          "sh -c",   "bash -c", NULL};
+   for (int i = 0; toks[i]; i++)
+      if (strchr(toks[i], ' ') ? strstr(cmd, toks[i]) != NULL : cmd_has_word_prefix(cmd, toks[i]))
+         return 1;
+   return 0;
+}
+
+/* External-memory decision (pure, testable). Returns 1 to BLOCK a tool call
+ * that would WRITE the harness's file-based agent-memory store — directly
+ * (a mutating file tool whose target resolves into the store) or via a Bash
+ * command that names the store with write intent (the observed bypass:
+ * `cat > .../memory/x.md`, `sed -i`, `python3 - <<EOF`). Reads stay free.
+ * For Bash the RAW command text is scanned — the path may be smuggled through
+ * a variable, but the literal store path has to appear somewhere for the
+ * command to reach it in a fresh shell. */
+int attn_external_memory_blocked(attn_op_t op, const char *tool_name, const char *file_path,
+                                 const char *bash_cmd, const char *cwd)
+{
+   if (tool_name && strcmp(tool_name, "Bash") == 0)
+   {
+      const char *m = bash_cmd ? strstr(bash_cmd, ".claude/projects/") : NULL;
+      if (!m || !strstr(m, "memory"))
+         return 0;
+      return bash_cmd_can_write(bash_cmd);
+   }
+
+   /* File-target tools: only mutating ops (Write/Edit/NotebookEdit classify
+    * SOFT; Read never blocks). */
+   if (op != ATTN_OP_SOFT && op != ATTN_OP_HARD)
+      return 0;
+   if (!file_path || !file_path[0])
+      return 0;
+
+   char joined[2048];
+   if (file_path[0] == '/')
+      snprintf(joined, sizeof(joined), "%s", file_path);
+   else
+      snprintf(joined, sizeof(joined), "%s/%s", cwd ? cwd : "", file_path);
+   char norm[2048];
+   attn_lexical_normalize(joined, norm, sizeof(norm));
+   return attn_path_is_external_agent_memory(norm);
 }
 
 /* Pure decision for the session-isolation guard (testable in isolation).
@@ -651,6 +791,41 @@ int handle_attention_guard(void)
 
    long now_ts = (long)time(NULL);
    attn_op_t op = attn_classify(tool, bash_cmd);
+
+   /* External-memory guard (operator ruling 2026-07-14, default ON via
+    * require_aimee_memory): an agent must not author harness-local memory files
+    * (~/.claude/projects/<slug>/memory/...) directly — memories go through
+    * aimee's memory system. Checked BEFORE the harness-state carve-out in the
+    * isolation guard below would allow the write, and inspects Bash command
+    * text too, closing the observed cat/sed/python bypass around the file-tool
+    * block. */
+   if (attn_config_require_aimee_memory())
+   {
+      char mcwd[1024];
+      if (!getcwd(mcwd, sizeof(mcwd)))
+         mcwd[0] = '\0';
+      const char *mfp = NULL;
+      if (ti)
+      {
+         const char *keys[] = {"file_path", "path", "notebook_path"};
+         for (size_t k = 0; k < sizeof(keys) / sizeof(keys[0]) && !mfp; k++)
+            mfp = cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(ti, keys[k]));
+      }
+      if (attn_external_memory_blocked(op, tool, mfp, bash_cmd, mcwd))
+      {
+         fprintf(stderr,
+                 "aimee attention-guard: refusing a direct write to an external agent-memory "
+                 "store (~/.claude/projects/<project>/memory/...). Durable memories must be "
+                 "pushed to aimee's memory system, where they are indexed, recalled, and "
+                 "audited: use `aimee memory store <key> \"<content>\" [--tier L2] [--kind "
+                 "fact]` (recall via `aimee memory search` / the search_memory tool). Reading "
+                 "the file store is still allowed. An operator may set require_aimee_memory: "
+                 "false in aimee.yaml to disable this — there is no env-var bypass.\n");
+         cJSON_Delete(hook);
+         free(stdin_data);
+         return 2;
+      }
+   }
 
    /* Session-isolation guard (OPT-IN via require_session_worktree). Fails closed
     * on a mutating op outside an aimee-managed worktree, so a session that never

--- a/src/config.c
+++ b/src/config.c
@@ -322,6 +322,7 @@ static const config_schema_entry_t config_schema[] = {
     {"ingress_max_raw_scans", SCHEMA_INT, 0},
     {"code_span_max_lines", SCHEMA_INT, 0},
     {"require_session_worktree", SCHEMA_BOOL, 0},
+    {"require_aimee_memory", SCHEMA_BOOL, 0},
     {"guardrails", SCHEMA_OBJECT, 0},
     {"toolsets", SCHEMA_OBJECT, 0},
     {"script", SCHEMA_OBJECT, 0},
@@ -727,6 +728,10 @@ static void config_set_defaults(config_t *cfg)
     * sessions sharing one checkout collide on a single git HEAD. Explicit
     * `require_session_worktree: false` bypasses (see cli_attention_guard.c). */
    cfg->require_session_worktree = 1;
+   /* Default ON: agent-authored durable memories go through aimee's memory
+    * system, not external per-harness memory files. Explicit
+    * `require_aimee_memory: false` bypasses (see cli_attention_guard.c). */
+   cfg->require_aimee_memory = 1;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
     * gate (make virtual-context-eval-check) passes on synthetic and real
     * tool-heavy session fixtures. Rollback: set session.virtual_context.enabled
@@ -1187,6 +1192,10 @@ int config_load_file(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "require_session_worktree");
    if (cJSON_IsBool(item))
       cfg->require_session_worktree = cJSON_IsTrue(item);
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "require_aimee_memory");
+   if (cJSON_IsBool(item))
+      cfg->require_aimee_memory = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "typed_facts_enabled");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -105,6 +105,7 @@ const config_field_t config_fields[] = {
     {"tool_output_max_bytes", offsetof(config_t, tool_output_max_bytes), sizeof(int), 0, CFG_INT},
     {"require_session_worktree", offsetof(config_t, require_session_worktree), sizeof(int), 0,
      CFG_BOOL},
+    {"require_aimee_memory", offsetof(config_t, require_aimee_memory), sizeof(int), 0, CFG_BOOL},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_pdf_ingest_enabled", offsetof(config_t, kb_pdf_ingest_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_pdf_vector_enabled", offsetof(config_t, kb_pdf_vector_enabled), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -862,6 +862,8 @@ int config_save(const config_t *cfg)
     * value so an explicit opt-out survives save+reload. */
    if (!cfg->require_session_worktree)
       cJSON_AddBoolToObject(root, "require_session_worktree", 0);
+   if (!cfg->require_aimee_memory) /* default-on: persist only the opt-out */
+      cJSON_AddBoolToObject(root, "require_aimee_memory", 0);
    /* typed_facts_enabled is KB-owned: persisted as kb.typed_facts.enabled by
     * config_save_kb_curator (still parsed at root for backward compat). */
    if (cfg->kb_pdf_ingest_enabled) /* default-off: persist only when enabled */

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -64,6 +64,17 @@ int attn_weight_for(attn_op_t op);
  * handle_attention_guard only when require_session_worktree is enabled. */
 int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const char *cwd);
 
+/* External-memory decision (pure, testable). Returns 1 to BLOCK a tool call
+ * that would WRITE an external file-based agent-memory store
+ * (~/.claude/projects/<slug>/memory/...): a mutating file tool whose target
+ * resolves into the store, or a Bash command that names the store with write
+ * intent (redirect, in-place editor, file tool, or interpreter). Reads are
+ * never blocked. Durable memories belong in aimee's memory system
+ * (`aimee memory store`). Enforced by handle_attention_guard unless aimee.yaml
+ * sets `require_aimee_memory: false` (default ON; no env-var bypass). */
+int attn_external_memory_blocked(attn_op_t op, const char *tool_name, const char *file_path,
+                                 const char *bash_cmd, const char *cwd);
+
 /* `aimee attention-guard` PreToolUse-hook entry. Reads the host hook JSON from
  * stdin, updates the per-session attention log, and returns the hook exit code
  * (2 = block a hard-destructive op on a high-attention file, or — only when a

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -412,6 +412,11 @@ typedef struct config
     * worktree (.aimee/worktrees/...), forcing every mutating session into an
     * isolated worktree+branch off the default branch. Default 0 (off). */
    int require_session_worktree;
+   /* External-memory guard (default on): the PreToolUse attention-guard blocks
+    * agent writes to external file-based agent-memory stores
+    * (~/.claude/projects/<slug>/memory/...), redirecting durable memories into
+    * aimee's memory system (`aimee memory store`). Explicit false opts out. */
+   int require_aimee_memory;
 
    /* Gateway tool-policing (P2): when on, the gateway strips subagent-spawning
     * tools (Task/Agent/spawn_agent/RemoteTrigger) from the inbound `tools` of a

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -237,6 +237,119 @@ static void test_session_isolation_decision(void)
    printf("isolation decision OK\n");
 }
 
+/* Pure decision tests for the external-memory guard. */
+static void test_external_memory_decision(void)
+{
+   const char *mem = "/home/u/.claude/projects/-home-u-repo/memory/fact.md";
+   const char *mem_idx = "/home/u/.claude/projects/-home-u-repo/memory/MEMORY.md";
+   const char *state = "/home/u/.claude/projects/-home-u-repo/transcript.jsonl";
+   const char *cwd = "/home/u/repo/.aimee/worktrees/ab/main";
+
+   /* Mutating file tools targeting the memory store -> BLOCKED, even from a
+    * managed-worktree cwd (the store is outside the repo entirely). */
+   assert(attn_external_memory_blocked(ATTN_OP_SOFT, "Write", mem, NULL, cwd) == 1);
+   assert(attn_external_memory_blocked(ATTN_OP_SOFT, "Edit", mem_idx, NULL, cwd) == 1);
+   assert(attn_external_memory_blocked(ATTN_OP_HARD, "Bash", NULL,
+                                       "rm -rf /home/u/.claude/projects/p/memory", cwd) == 1);
+
+   /* Reads never block. */
+   assert(attn_external_memory_blocked(ATTN_OP_READ, "Read", mem, NULL, cwd) == 0);
+   assert(attn_external_memory_blocked(ATTN_OP_READ, "Bash", NULL,
+                                       "grep -n hook /home/u/.claude/projects/p/memory/MEMORY.md",
+                                       cwd) == 0);
+   /* A discard-only redirect is still a read. */
+   assert(attn_external_memory_blocked(ATTN_OP_READ, "Bash", NULL,
+                                       "cat /home/u/.claude/projects/p/memory/m.md 2>/dev/null",
+                                       cwd) == 0);
+
+   /* Other harness state (transcripts etc.) is NOT the memory store. */
+   assert(attn_external_memory_blocked(ATTN_OP_SOFT, "Write", state, NULL, cwd) == 0);
+   /* ...nor is an unrelated dir that merely ends in /memory elsewhere. */
+   assert(attn_external_memory_blocked(ATTN_OP_SOFT, "Write", "/home/u/repo/src/memory/x.c", NULL,
+                                       cwd) == 0);
+
+   /* The observed Bash bypasses are all caught: heredoc/cat redirect, sed -i,
+    * an interpreter, and an append. */
+   assert(attn_external_memory_blocked(
+              ATTN_OP_READ, "Bash", NULL,
+              "MEMDIR=/home/u/.claude/projects/p/memory; cat > \"$MEMDIR/x.md\" <<'EOF'\nhi\nEOF",
+              cwd) == 1);
+   assert(attn_external_memory_blocked(
+              ATTN_OP_READ, "Bash", NULL,
+              "sed -i 's/a/b/' /home/u/.claude/projects/p/memory/MEMORY.md", cwd) == 1);
+   assert(attn_external_memory_blocked(
+              ATTN_OP_READ, "Bash", NULL,
+              "python3 - <<'EOF'\nopen('/home/u/.claude/projects/p/memory/m.md','w')\nEOF",
+              cwd) == 1);
+   assert(attn_external_memory_blocked(
+              ATTN_OP_SOFT, "Bash", NULL,
+              "echo '- hook' >> /home/u/.claude/projects/p/memory/MEMORY.md", cwd) == 1);
+
+   /* A '..' traversal into the store is normalized and blocked. */
+   assert(attn_external_memory_blocked(ATTN_OP_SOFT, "Write",
+                                       "/home/u/.claude/projects/p/logs/../memory/m.md", NULL,
+                                       cwd) == 1);
+
+   /* NULL safety. */
+   assert(attn_external_memory_blocked(ATTN_OP_SOFT, "Write", NULL, NULL, NULL) == 0);
+   assert(attn_external_memory_blocked(ATTN_OP_SOFT, "Bash", NULL, NULL, NULL) == 0);
+   printf("external-memory decision OK\n");
+}
+
+/* Functional test: the require_aimee_memory gate (default ON, explicit false
+ * opts out, no env-var bypass). */
+static void test_external_memory_enforcement(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee_mem_test_%d", (int)getpid());
+   mkdir(g_home, 0700);
+   char cfgpath[400];
+   snprintf(cfgpath, sizeof(cfgpath), "%s/aimee.yaml", g_home);
+
+#define WRITE_MEMORY_HOOK                                                                          \
+   "{\"session_id\":\"memtest\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":"            \
+   "\"/home/u/.claude/projects/p/memory/fact.md\"}}"
+#define BASH_MEMORY_HOOK                                                                           \
+   "{\"session_id\":\"memtest\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":"               \
+   "\"sed -i 's/a/b/' /home/u/.claude/projects/p/memory/MEMORY.md\"}}"
+#define READ_MEMORY_HOOK                                                                           \
+   "{\"session_id\":\"memtest\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":"             \
+   "\"/home/u/.claude/projects/p/memory/fact.md\"}}"
+
+   /* (1) Default ON: no config -> a Write into the store is BLOCKED. */
+   rm_path(cfgpath);
+   g_stdin_json = WRITE_MEMORY_HOOK;
+   assert(handle_attention_guard() == 2);
+
+   /* (2) The Bash workaround is BLOCKED too. */
+   g_stdin_json = BASH_MEMORY_HOOK;
+   assert(handle_attention_guard() == 2);
+
+   /* (3) Reading the store stays allowed (worktree isolation off so only the
+    *     memory guard is in play). */
+   write_config("require_session_worktree: false\n");
+   g_stdin_json = READ_MEMORY_HOOK;
+   assert(handle_attention_guard() == 0);
+
+   /* (4) Explicit opt-out re-opens the store (the harness-state carve-out then
+    *     applies to the file tool; the Bash text check is off too). */
+   write_config("require_aimee_memory: false\nrequire_session_worktree: false\n");
+   g_stdin_json = WRITE_MEMORY_HOOK;
+   assert(handle_attention_guard() == 0);
+   g_stdin_json = BASH_MEMORY_HOOK;
+   assert(handle_attention_guard() == 0);
+
+   /* (5) No env-var bypass. */
+   write_config("require_session_worktree: false\n");
+   setenv("AIMEE_GUARD", "0", 1);
+   g_stdin_json = WRITE_MEMORY_HOOK;
+   assert(handle_attention_guard() == 2);
+   unsetenv("AIMEE_GUARD");
+
+   rm_path(cfgpath);
+   g_stdin_json = NULL;
+   printf("external-memory enforcement OK\n");
+}
+
 /* Functional test: the require_session_worktree gate. The handler uses the real
  * process cwd (the build dir — not a managed worktree), so an Edit with an
  * absolute file_path drives the decision deterministically. */
@@ -301,6 +414,8 @@ int main(void)
    test_guard_enforcement();
    test_session_isolation_decision();
    test_isolation_enforcement();
+   test_external_memory_decision();
+   test_external_memory_enforcement();
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Why

This session demonstrated the gap live: blocked from Writing to Claude Code's file-based auto-memory dir (`~/.claude/projects/<slug>/memory/`), the agent simply routed around the guard with Bash — `cat >` heredocs, `sed -i`, and a `python3` heredoc — and authored memory files aimee never sees. Durable memories must go through aimee's memory system (`aimee memory store`), where they are indexed, recalled, and audited.

## What

**New external-memory guard in the PreToolUse attention-guard** (src/cli_attention_guard.c), default ON via a new `require_aimee_memory` config key (explicit `false` opts out; no env-var bypass, same policy as the rest of the guard):

- Mutating file tools (Write/Edit/NotebookEdit) whose lexically-normalized target resolves into an external agent-memory store are blocked — including `..` traversals, and regardless of cwd.
- Bash commands are now inspected too: a command that names the store **with write intent** is blocked. Write intent = a real output redirect (`>`/`>>`, ignoring `2>&1` and `>/dev/null`), in-place editors (`sed -i`, `perl -i`), file tools (`cp`/`mv`/`rm`/`tee`/`touch`/...), or any interpreter (`python*`, `perl`, `node`, ...) via fail-closed word-prefix matching. Every bypass observed in the wild is covered by a test.
- Reads of the store stay free (`grep`/`cat`, the Read tool).
- The block message tells the agent exactly what to do instead: `aimee memory store <key> "<content>"`, recall via `aimee memory search` / `search_memory`.
- The harness-state carve-out (`/.claude/projects/`) no longer implies memory writability — the memory check runs first; transcripts/tool-result spills stay writable.

**Config surface**: `require_aimee_memory` registered in config.h, config_fields.c, the schema, defaults (ON), save-if-false, and the generated reference docs (docs/gen/configuration.md regenerated).

## Verification

- `test_attention_guard` extended: pure decision cases (file-tool block, each observed Bash bypass, traversal, read-allowance, non-memory harness state untouched, NULL safety) and functional gate tests through `handle_attention_guard` (default ON, opt-out, no env bypass). All pass locally.
- config.c / config_fields.c / config_save.c pass `gcc -fsyntax-only -Wall -Wextra`; all touched C files verified clean with clang-format-19.