### PR TITLE
tls: TOFU pin is the identity — accept exact leaf match without SAN

### DIFF
--- a/deploy/smoothnas/aimee-server.plugin.yaml
+++ b/deploy/smoothnas/aimee-server.plugin.yaml
@@ -63,9 +63,10 @@ services:
         hostExpose: true
     config:
       # The server's self-signed /v1 TLS cert covers the container hostname +
-      # localhost/loopback only. Behind NAT/DNAT (a tierd plugin reached at the
-      # host's LAN IP/hostname), set the reachable address(es) here so the cert
-      # includes them and thin clients verify (pin) it WITHOUT AIMEE_TLS_INSECURE.
+      # localhost/loopback only. Thin clients that TOFU-pin (`aimee remote set`)
+      # verify by exact-leaf match and do NOT need the dialed address in the
+      # cert's SANs. Set the reachable address(es) here only for clients that
+      # verify by name instead of pinning (e.g. generic HTTPS tooling).
       # Comma-separated; bare IPs/hosts are auto-typed (e.g. "192.168.1.254" or
       # "192.168.1.254,nas.lan"). No effect when an operator cert is supplied.
       - key: AIMEE_TLS_EXTRA_SAN

--- a/src/aimee_tls.c
+++ b/src/aimee_tls.c
@@ -83,7 +83,7 @@ static void aimee_tls_present_client_cert(SSL_CTX *ctx)
 /* Resolve <aimee_home>/remote-ca.pem — the pinned server certificate written by
  * `aimee remote set/trust`. Returns 1 (and fills |out|) when the file exists,
  * else 0. Trusting this file lets a self-signed/private server verify fully
- * (chain + hostname/SAN) without disabling verification (AIMEE_TLS_INSECURE). */
+ * without disabling verification (AIMEE_TLS_INSECURE). */
 static int pinned_ca_path(char *out, size_t n)
 {
    const char *home = aimee_home();
@@ -94,6 +94,37 @@ static int pinned_ca_path(char *out, size_t n)
    return (stat(out, &st) == 0 && S_ISREG(st.st_mode)) ? 1 : 0;
 }
 
+/* Load the pinned certificate itself (first PEM cert in remote-ca.pem), or NULL. */
+static X509 *pinned_cert_load(const char *path)
+{
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return NULL;
+   X509 *cert = PEM_read_X509(f, NULL, NULL, NULL);
+   fclose(f);
+   return cert;
+}
+
+/* Pinned-mode verify: the identity is an EXACT leaf match against the TOFU-
+ * pinned certificate (SSH known_hosts semantics). Hostname/SAN is deliberately
+ * NOT consulted: a containerized/NAT'd server cannot know its reachable
+ * host address at cert-mint time, so its self-signed cert routinely lacks the
+ * SAN the client dials — while the byte-exact pin is already a STRONGER
+ * identity than any name match (a MITM cannot present the pinned cert without
+ * its private key; any other cert, even one validly chaining to a public CA,
+ * fails the compare). Chain/time preverify results are likewise subordinate to
+ * the pin at the leaf, exactly like an SSH host key. */
+static int pin_leaf_verify_cb(int preverify_ok, X509_STORE_CTX *xctx)
+{
+   (void)preverify_ok;
+   if (X509_STORE_CTX_get_error_depth(xctx) > 0)
+      return 1; /* only the leaf decides in pinned mode */
+   SSL *ssl = X509_STORE_CTX_get_ex_data(xctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+   X509 *pin = ssl ? (X509 *)SSL_get_app_data(ssl) : NULL;
+   X509 *leaf = X509_STORE_CTX_get_current_cert(xctx);
+   return (pin && leaf && X509_cmp(pin, leaf) == 0) ? 1 : 0;
+}
+
 aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 {
    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
@@ -102,27 +133,34 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
 
    int insecure = tls_insecure();
+   X509 *pinned = NULL;
    if (!insecure)
    {
       char pin[600];
       if (pinned_ca_path(pin, sizeof(pin)))
       {
          /* Strict pin: a recorded cert means a self-signed/private server, so
-          * trust ONLY that cert and NOT the system store — a mis-issued or
+          * trust ONLY that exact cert and NOT the system store — a mis-issued or
           * compromised public-CA cert for the same host is then still rejected.
           * A pin that won't load fails the connection CLOSED rather than silently
-          * widening trust back to the system store. */
-         if (SSL_CTX_load_verify_locations(ctx, pin, NULL) != 1)
+          * widening trust back to the system store. Identity is decided by
+          * pin_leaf_verify_cb (exact leaf match); hostname/SAN is not consulted
+          * in pinned mode — see the callback's rationale. */
+         pinned = pinned_cert_load(pin);
+         if (!pinned || SSL_CTX_load_verify_locations(ctx, pin, NULL) != 1)
          {
+            if (pinned)
+               X509_free(pinned);
             SSL_CTX_free(ctx);
             return NULL;
          }
+         SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, pin_leaf_verify_cb);
       }
       else
       {
          SSL_CTX_set_default_verify_paths(ctx); /* publicly-trusted servers */
+         SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
       }
-      SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
    }
 
    aimee_tls_present_client_cert(ctx);
@@ -130,24 +168,29 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    SSL *ssl = SSL_new(ctx);
    if (!ssl)
    {
+      if (pinned)
+         X509_free(pinned);
       SSL_CTX_free(ctx);
       return NULL;
    }
    SSL_set_fd(ssl, fd);
+   if (pinned)
+      SSL_set_app_data(ssl, pinned); /* consumed by pin_leaf_verify_cb */
    if (host && *host)
    {
       SSL_set_tlsext_host_name(ssl, host); /* SNI */
-      if (!insecure)
+      if (!insecure && !pinned)
       {
          X509_VERIFY_PARAM *param = SSL_get0_param(ssl);
          X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
          /* An IP-literal host (e.g. a private server reached by address) must be
           * matched against the cert's IP-address SANs: set1_host only matches DNS
           * names/CN, so an IP would otherwise fail the name check even with a
-          * valid/pinned cert. set1_ip_asc returns 1 only for a real IP literal;
+          * valid cert. set1_ip_asc returns 1 only for a real IP literal;
           * fall back to DNS-name matching for actual hostnames. If neither arms
           * the name check, fail CLOSED — verifying the chain but not the identity
-          * would accept any otherwise-valid cert. */
+          * would accept any otherwise-valid cert. (Pinned mode skips this: the
+          * exact-leaf pin IS the identity.) */
          if (X509_VERIFY_PARAM_set1_ip_asc(param, host) != 1 &&
              X509_VERIFY_PARAM_set1_host(param, host, 0) != 1)
          {
@@ -158,7 +201,13 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
       }
    }
 
-   if (SSL_connect(ssl) != 1)
+   int connected = (SSL_connect(ssl) == 1);
+   if (pinned)
+   {
+      SSL_set_app_data(ssl, NULL); /* the handshake (and its verify) is done */
+      X509_free(pinned);
+   }
+   if (!connected)
    {
       SSL_free(ssl);
       SSL_CTX_free(ctx);

--- a/src/aimee_tls_schannel.c
+++ b/src/aimee_tls_schannel.c
@@ -218,12 +218,13 @@ static int pinned_leaf_matches(PCCERT_CONTEXT cert)
  * against the pinned self-signed cert at <aimee_home>/remote-ca.pem. Returns 0 on
  * success, -1 on any failure.
  *
- * Two accept paths, hostname/SAN enforced in BOTH (matching the OpenSSL backend):
- *   1. System trust: the chain builds to a trusted root AND the name matches.
- *   2. Pinned: the system chain is untrusted (unknown CA / self-signed), so we
- *      ignore ONLY that error in a second name-checking policy run AND require the
- *      leaf to byte-match remote-ca.pem (strict leaf pin). A different cert fails
- *      the DER compare; a wrong hostname fails the still-enforced name check. */
+ * Two accept paths (matching the OpenSSL backend):
+ *   1. Pinned: the leaf byte-matches remote-ca.pem (strict leaf pin). This alone
+ *      IS the identity (SSH known_hosts semantics) — hostname/SAN is deliberately
+ *      not consulted, because a containerized/NAT'd server cannot know its
+ *      reachable address at cert-mint time, and a MITM cannot present the pinned
+ *      cert without its private key.
+ *   2. System trust: the chain builds to a trusted root AND the name matches. */
 static int verify_server_cert(aimee_tls_t *t)
 {
    /* Fail closed if there is no hostname to verify against: a NULL pwszServerName
@@ -235,6 +236,13 @@ static int verify_server_cert(aimee_tls_t *t)
    PCCERT_CONTEXT cert = NULL;
    if (QueryContextAttributes(&t->ctx, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &cert) != SEC_E_OK || !cert)
       return -1;
+
+   /* Path 1: exact-leaf pin decides the identity on its own. */
+   if (pinned_leaf_matches(cert))
+   {
+      CertFreeCertificateContext(cert);
+      return 0;
+   }
 
    int ok = -1;
    PCCERT_CHAIN_CONTEXT chain = NULL;
@@ -258,10 +266,7 @@ static int verify_server_cert(aimee_tls_t *t)
       }
 
       if (ssl_policy_check(chain, whost, 0) == 0)
-         ok = 0; /* path 1: trusted system root + name match */
-      else if (pinned_leaf_matches(cert) &&
-               ssl_policy_check(chain, whost, SECURITY_FLAG_IGNORE_UNKNOWN_CA) == 0)
-         ok = 0; /* path 2: strict leaf pin + name match (untrusted root ignored) */
+         ok = 0; /* path 2: trusted system root + name match */
 
       CertFreeCertificateChain(chain);
    }

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -344,49 +344,40 @@ static SecCertificateRef securetransport_load_pinned_cert(const char *path)
    return cert;
 }
 
-/* During a BreakOnServerAuth handshake, manually evaluate the peer's trust so
- * that BOTH the system anchors AND the pinned cert are accepted, with the
- * SSL/hostname policy bound to |host|. Returns 1 if trusted, 0 otherwise.
- *
- * IP-literal hosts: SecPolicyCreateSSL is given the host string verbatim; when
- * that string is an IP literal, the SSL trust policy matches it against the
- * cert's iPAddress SANs (aimee is commonly reached by IP with an IP-SAN cert),
- * and against dNSName SANs/CN for real DNS names. (Could not be exercised here
- * without running on macOS — see the report's caveats.) */
+/* During a BreakOnServerAuth handshake, decide the pinned-mode trust: the
+ * identity is an EXACT leaf match against the TOFU-pinned certificate (SSH
+ * known_hosts semantics), matching the OpenSSL and Windows backends. The
+ * hostname/SAN policy is deliberately NOT consulted: a containerized/NAT'd
+ * server cannot know its reachable address at cert-mint time, so its
+ * self-signed cert routinely lacks the SAN the client dials — while the
+ * byte-exact pin is a stronger identity than any name match (a MITM cannot
+ * present the pinned cert without its private key; any other cert, even a
+ * validly-issued one, fails the DER compare). Returns 1 if trusted, 0 not.
+ * (|host| is retained in the signature for symmetry/logging call sites.) */
 static int securetransport_eval_pinned_trust(SSLContextRef ctx, const char *host,
                                              SecCertificateRef pinned)
 {
+   (void)host;
    SecTrustRef trust = NULL;
    if (SSLCopyPeerTrust(ctx, &trust) != noErr || !trust)
       return 0;
 
    int ok = 0;
-   CFStringRef cf_host = CFStringCreateWithCString(NULL, host, kCFStringEncodingUTF8);
-   SecPolicyRef policy = cf_host ? SecPolicyCreateSSL(true, cf_host) : NULL;
-   if (policy && SecTrustSetPolicies(trust, policy) == errSecSuccess)
+   SecCertificateRef leaf =
+       (SecTrustGetCertificateCount(trust) > 0) ? SecTrustGetCertificateAtIndex(trust, 0) : NULL;
+   if (leaf && pinned)
    {
-      const void *anchors[] = {pinned};
-      CFArrayRef anchor_arr = CFArrayCreate(NULL, anchors, 1, &kCFTypeArrayCallBacks);
-      /* Strict pin: SecTrustSetAnchorCertificatesOnly(true) trusts ONLY the pinned
-       * cert (not the system anchors) for this evaluation — matching the OpenSSL
-       * (load-pin-only) and Windows (leaf-DER) backends. A recorded pin means a
-       * self-signed/private server, so a mis-issued public-CA cert for the same
-       * host is still rejected. The hostname/SAN policy above remains enforced. */
-      if (anchor_arr && SecTrustSetAnchorCertificates(trust, anchor_arr) == errSecSuccess &&
-          SecTrustSetAnchorCertificatesOnly(trust, true) == errSecSuccess)
-      {
-         CFErrorRef err = NULL;
-         ok = SecTrustEvaluateWithError(trust, &err) ? 1 : 0;
-         if (err)
-            CFRelease(err);
-      }
-      if (anchor_arr)
-         CFRelease(anchor_arr);
+      CFDataRef leaf_der = SecCertificateCopyData(leaf);
+      CFDataRef pin_der = SecCertificateCopyData(pinned);
+      if (leaf_der && pin_der && CFDataGetLength(leaf_der) == CFDataGetLength(pin_der) &&
+          memcmp(CFDataGetBytePtr(leaf_der), CFDataGetBytePtr(pin_der),
+                 (size_t)CFDataGetLength(leaf_der)) == 0)
+         ok = 1;
+      if (leaf_der)
+         CFRelease(leaf_der);
+      if (pin_der)
+         CFRelease(pin_der);
    }
-   if (policy)
-      CFRelease(policy);
-   if (cf_host)
-      CFRelease(cf_host);
    CFRelease(trust);
    return ok;
 }

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -194,9 +194,13 @@ static int remote_enroll(const char *url, char *out, size_t out_sz, int json_out
    {
       if (st == 401 && !json_output)
          fprintf(stderr,
-                 "  enroll: the server rejected the bootstrap token (already enrolled by another "
-                 "client?).\n         Copy the strong bearer from the enrolled client into "
-                 "remote.conf, or re-seed the server.\n");
+                 "  enroll: the server rejected the bootstrap token — it was already consumed by "
+                 "the first\n         enrolled client (one-shot TOFU). The strong bearer is "
+                 "persisted on the server in\n         <AIMEE_HOME>/aimee.yaml under "
+                 "aimee.api.bearer_token — copy it into this client with\n         `aimee remote "
+                 "set <url> <token>`; or rotate a fresh one from an already-enrolled\n         "
+                 "client (`aimee remote enroll`); or re-seed the server's bearer_token to the\n"
+                 "         bootstrap value to re-open one-shot enrollment.\n");
       free(body);
       return -1;
    }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -298,6 +298,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-bootstrap \
                $(TESTPREFIX)/unit-test-pki \
                $(TESTPREFIX)/unit-test-aimee-tls-clientcert \
+               $(TESTPREFIX)/unit-test-aimee-tls-pin \
                $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-vault-capability \
                $(TESTPREFIX)/unit-test-agent-key-import \
@@ -3142,6 +3143,11 @@ $(TESTPREFIX)/unit-test-vault-server-key: $(OBJDIR)/tests/test_vault_server_key.
 
 $(TESTPREFIX)/unit-test-aimee-tls-clientcert: $(OBJDIR)/tests/test_aimee_tls_clientcert.o \
                               $(OBJDIR)/aimee_tls.o $(OBJDIR)/aimee_home.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-aimee-tls-pin: $(OBJDIR)/tests/test_aimee_tls_pin.o \
+                              $(OBJDIR)/aimee_tls.o $(OBJDIR)/kb/pki.o \
+                              $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-vault-capability: $(OBJDIR)/tests/test_vault_capability.o \

--- a/src/tests/test_aimee_tls_pin.c
+++ b/src/tests/test_aimee_tls_pin.c
@@ -1,0 +1,157 @@
+/* test_aimee_tls_pin.c — TOFU pin-is-identity for the thin client's TLS.
+ *
+ * A pinned server certificate (<aimee_home>/remote-ca.pem, written by
+ * `aimee remote set/trust`) must be accepted on an EXACT leaf match alone —
+ * SSH known_hosts semantics — with the hostname/SAN check waived: a
+ * containerized/NAT'd aimee-server cannot know its reachable LAN address at
+ * cert-mint time, so its self-signed cert routinely lacks the SAN the client
+ * dials (the 192.168.1.254 appliance failure). Any OTHER cert must still be
+ * rejected, pinned or not. Real handshakes over a socketpair, mirroring
+ * test_kb_tls.c. */
+#include "aimee_tls.h"
+#include "kb_pki.h"
+
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+
+#include <assert.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static char g_home[256];
+
+static void write_pin(const char *cert_pem)
+{
+   char p[320];
+   snprintf(p, sizeof(p), "%s/remote-ca.pem", g_home);
+   FILE *f = fopen(p, "w");
+   assert(f);
+   fputs(cert_pem, f);
+   fclose(f);
+}
+
+static void remove_pin(void)
+{
+   char p[320];
+   snprintf(p, sizeof(p), "%s/remote-ca.pem", g_home);
+   unlink(p);
+}
+
+/* Plain server-auth TLS server context from PEM strings (no client-cert
+ * requirement — the thin client presents none here). */
+static SSL_CTX *server_ctx_from_pem(const char *cert_pem, const char *key_pem)
+{
+   SSL_CTX *ctx = SSL_CTX_new(TLS_server_method());
+   assert(ctx);
+   BIO *cb = BIO_new_mem_buf(cert_pem, -1);
+   X509 *crt = PEM_read_bio_X509(cb, NULL, NULL, NULL);
+   BIO_free(cb);
+   BIO *kb = BIO_new_mem_buf(key_pem, -1);
+   EVP_PKEY *key = PEM_read_bio_PrivateKey(kb, NULL, NULL, NULL);
+   BIO_free(kb);
+   assert(crt && key);
+   assert(SSL_CTX_use_certificate(ctx, crt) == 1);
+   assert(SSL_CTX_use_PrivateKey(ctx, key) == 1);
+   X509_free(crt);
+   EVP_PKEY_free(key);
+   return ctx;
+}
+
+static void *server_thread(void *a)
+{
+   SSL *ssl = (SSL *)a;
+   /* A rejected client aborts mid-handshake; SSL_accept failing is fine. */
+   if (SSL_accept(ssl) == 1)
+      SSL_shutdown(ssl);
+   return NULL;
+}
+
+/* Full handshake: aimee_tls_connect() as the client against an in-process
+ * server. Returns 1 when the client accepted the server's identity. */
+static int client_accepts(SSL_CTX *server_ctx, const char *host)
+{
+   int sv[2];
+   assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+   SSL *s = SSL_new(server_ctx);
+   assert(s);
+   SSL_set_fd(s, sv[0]);
+   pthread_t th;
+   assert(pthread_create(&th, NULL, server_thread, s) == 0);
+
+   aimee_tls_t *t = aimee_tls_connect(sv[1], host);
+   int ok = (t != NULL);
+   aimee_tls_free(t);
+   /* Close the client fd BEFORE joining: a client that aborted the handshake
+    * leaves the server blocked in SSL_accept until it sees EOF. */
+   close(sv[1]);
+   pthread_join(th, NULL);
+   SSL_free(s);
+   close(sv[0]);
+   return ok;
+}
+
+int main(void)
+{
+   setvbuf(stdout, NULL, _IONBF, 0);
+   signal(SIGPIPE, SIG_IGN); /* an aborted handshake writes into a closed pipe */
+   printf("aimee_tls_pin:\n");
+
+   /* Isolated home so remote-ca.pem is under test control; strict verification
+    * (the insecure escape hatch must not mask a verify failure). */
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-tlspin-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   setenv("AIMEE_HOME", g_home, 1);
+   unsetenv("AIMEE_TLS_INSECURE");
+
+   /* A self-signed-CA server cert for "kb.local" — its SANs cover kb.local and
+    * loopback, NOT the address the client dials below (the NAT/appliance case). */
+   kb_pki_ca_t ca;
+   assert(kb_pki_ca_generate(&ca) == 0);
+   char scert[KB_PKI_CERT_PEM_MAX], skey[KB_PKI_KEY_PEM_MAX];
+   assert(kb_pki_issue_server_cert(&ca, "kb.local", 3600, scert, sizeof(scert), skey,
+                                   sizeof(skey)) == 0);
+   SSL_CTX *server = server_ctx_from_pem(scert, skey);
+
+   /* 1. Pin == leaf, dialed by an address ABSENT from the cert's SANs: the pin
+    *    is the identity, so the handshake must succeed (the regression). */
+   write_pin(scert);
+   assert(client_accepts(server, "203.0.113.9") == 1);
+   printf("  pin_match_san_mismatch_accepted: ok\n");
+
+   /* 2. Pin == leaf, matching hostname: still accepted (sanity). */
+   assert(client_accepts(server, "kb.local") == 1);
+   printf("  pin_match_name_match_accepted: ok\n");
+
+   /* 3. Pin holds a DIFFERENT cert: the server must be rejected even though its
+    *    name matches — only the pinned leaf is acceptable in pinned mode. */
+   {
+      kb_pki_ca_t other;
+      assert(kb_pki_ca_generate(&other) == 0);
+      char ocert[KB_PKI_CERT_PEM_MAX], okey[KB_PKI_KEY_PEM_MAX];
+      assert(kb_pki_issue_server_cert(&other, "kb.local", 3600, ocert, sizeof(ocert), okey,
+                                      sizeof(okey)) == 0);
+      write_pin(ocert);
+      assert(client_accepts(server, "kb.local") == 0);
+      printf("  pin_mismatch_rejected: ok\n");
+   }
+
+   /* 4. No pin: a self-signed server fails system-store verification. */
+   remove_pin();
+   assert(client_accepts(server, "kb.local") == 0);
+   printf("  unpinned_selfsigned_rejected: ok\n");
+
+   /* 5. Unparseable pin fails CLOSED (no silent fallback to the system store). */
+   write_pin("not a certificate\n");
+   assert(client_accepts(server, "kb.local") == 0);
+   printf("  corrupt_pin_fails_closed: ok\n");
+
+   SSL_CTX_free(server);
+   printf("aimee_tls_pin: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## What happened (the 192.168.1.254 failure)

A thin client doing `aimee remote set https://192.168.1.254:8743 <token>` pinned the appliance's self-signed cert (TOFU) — and then every request still failed TLS verification. The server mints its cert inside the container, where the only names it knows are the container hostname and loopback; the host's LAN IP can never be in the SANs unless the operator hand-sets `AIMEE_TLS_EXTRA_SAN` **and** rotates the cert. All three client TLS backends enforced hostname/SAN even in pinned mode, so first-connect against any NAT'd/containerized deployment was structurally broken — nothing automatic could have fixed it deployment-side.

## Fix: pin-is-identity (SSH known_hosts semantics)

A TOFU pin is a stronger identity than a name match: a MITM cannot present the pinned cert without its private key, and any other cert — even one validly chaining to a public CA — fails the byte compare. In pinned mode the identity is now an **exact leaf match** against `remote-ca.pem`, and the hostname/SAN check is waived:

- **OpenSSL** (src/aimee_tls.c): pinned mode installs a verify callback accepting iff `X509_cmp(leaf, pin) == 0`; hostname params are not armed. An unparseable pin still fails closed (no silent fallback to the system store).
- **Windows** (src/aimee_tls_schannel.c): exact leaf DER match accepts before the chain/name policy; the system-trust path is unchanged.
- **macOS** (src/aimee_tls_securetransport.c): the pinned-trust evaluation is an exact leaf DER compare.
- **UX** (src/cli_remote.c): the enroll-401 message now explains the one-shot TOFU, where the strong bearer is persisted server-side (`<AIMEE_HOME>/aimee.yaml` → `aimee.api.bearer_token`), and the three recovery paths.
- **Deploy docs**: `AIMEE_TLS_EXTRA_SAN` is now optional for pinning thin clients.

The unpinned path is untouched: public-CA verification still enforces chain + hostname strictly.

## Tests (the case that bit us, as real handshakes)

New `test_aimee_tls_pin` (registered in Rules.mk) drives `aimee_tls_connect()` against an in-process TLS server over a socketpair with kb_pki-issued certs:

1. Pin == leaf, dialed by an address absent from the SANs → **accepted** (the regression).
2. Pin == leaf, matching name → accepted.
3. Pin holds a different cert, matching name → **rejected**.
4. No pin, self-signed → rejected.
5. Corrupt pin file → fails closed.

All pass locally; the modified TUs are clang-format-19 clean.