### PR TITLE
fix(wfe): an unnamed step delegate resolves via the $random selector

### DIFF
--- a/src/headers/wfe_live_delegate.h
+++ b/src/headers/wfe_live_delegate.h
@@ -13,11 +13,12 @@ void wfe_autonomy_register(void);
 
 #include "agent_config.h"
 
-/* Resolve a workflow step's delegate name to a concrete agent. "" -> "" (route
- * by role); a specific name -> itself; the sentinel "$random" -> a uniformly
- * random ENABLED agent from `acfg`. Returns 0 on success (out filled, possibly
- * ""), -1 if "$random" but no enabled agent exists (fail fast — never leak the
- * sentinel). */
+/* Resolve a workflow step's delegate name to a concrete agent. A specific name
+ * -> itself; "" (no per-step delegate) and the sentinel "$random" both -> a
+ * uniformly random ENABLED agent from `acfg` — an unnamed delegate means "any
+ * agent", not "the same first-in-roster agent every dispatch". Returns 0 on
+ * success (out filled), -1 if no enabled agent exists (fail fast — never leak
+ * the sentinel). */
 int wfe_resolve_delegate(const char *name, agent_config_t *acfg, char *out, size_t outn);
 
 /* Seed the $random selector for deterministic tests. */

--- a/src/server/wfe_delegate_resolve.c
+++ b/src/server/wfe_delegate_resolve.c
@@ -44,7 +44,7 @@ int wfe_resolve_delegate(const char *name, agent_config_t *acfg, char *out, size
    if (out && outn)
       out[0] = '\0';
    if (!name || !name[0])
-      return 0; /* no per-step delegate -> route by role */
+      name = "$random"; /* no per-step delegate -> random over the enabled roster */
    if (strcmp(name, "$random") != 0)
    {
       if (out)

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -95,13 +95,15 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
       return -1;
    }
 
-   /* Resolve the step's delegate ("$random" -> a random roster agent; "" -> route
-    * by role). Fail fast rather than leak the sentinel downstream. */
+   /* Resolve the step's delegate: a specific name -> itself; "" and "$random"
+    * -> a uniformly random ENABLED roster agent (an unnamed delegate means "any
+    * agent", so successive dispatches assort across the roster instead of
+    * pinning to one). Fail fast rather than leak the sentinel downstream. */
    char agent_name[MAX_AGENT_NAME] = "";
    if (wfe_resolve_delegate(delegate, &acfg, agent_name, sizeof agent_name) != 0)
    {
       if (err && errlen)
-         snprintf(err, errlen, "wfe live delegate: no enabled agent for '$random'");
+         snprintf(err, errlen, "wfe live delegate: no enabled agent in the roster");
       return -1;
    }
 
@@ -113,77 +115,28 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
     * agent can serve. */
    const char *persona = (role && role[0]) ? role : "engineer";
    char *sys_prompt = persona_compose_delegate_prompt(persona, workdir, "");
-   persona_t pinfo;
-   memset(&pinfo, 0, sizeof pinfo);
-   persona_load(NULL, persona, &pinfo);
 
    /* Run WITH TOOLS, pinned to the work-item worktree, so file edits land there.
-    * A specific agent runs by name; otherwise route by persona. */
+    * The resolve above always yields a concrete agent name, so dispatch is
+    * uniformly by name; an unroutable pick fails here and the block's retry
+    * loop re-rolls a different agent. */
    run_cmd_set_cwd(workdir);
    agent_result_t res;
    memset(&res, 0, sizeof(res));
    int rc;
-   if (agent_name[0])
+   agent_t *ag = agent_find(&acfg, agent_name);
+   if (!ag)
    {
-      agent_t *ag = agent_find(&acfg, agent_name);
-      if (!ag)
-      {
-         run_cmd_set_cwd(NULL);
-         free(sys_prompt);
-         persona_free(&pinfo);
-         if (err && errlen)
-            snprintf(err, errlen, "wfe live delegate: unknown delegate '%s'", agent_name);
-         return -1;
-      }
-      rc = agent_execute_with_tools(ag, &acfg.network, sys_prompt ? sys_prompt : "", prompt,
-                                    AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
+      run_cmd_set_cwd(NULL);
+      free(sys_prompt);
+      if (err && errlen)
+         snprintf(err, errlen, "wfe live delegate: unknown delegate '%s'", agent_name);
+      return -1;
    }
-   else
-   {
-      /* Route by the persona's allowed roles (ordered by preference): for the
-       * first role that ANY healthy, persona-eligible agent serves, pick the
-       * lowest-cost-tier such agent. Scanning every agent per role (not just
-       * agent_route's single best) means a persona-ineligible best-tier agent
-       * can't shadow an eligible one that serves the same role. */
-      agent_t *chosen = NULL;
-      const char *chosen_role = NULL;
-      int best_tier = 0;
-      for (int ri = 0; ri < pinfo.roles_count && !chosen; ri++)
-      {
-         const char *r = delegate_role_canonicalize(pinfo.roles[ri]);
-         for (int ai = 0; ai < acfg.agent_count; ai++)
-         {
-            agent_t *ag = &acfg.agents[ai];
-            if (!ag->enabled || !agent_has_role(ag, r) || !agent_supports_persona(ag, persona) ||
-                !agent_is_available_for_routing(ag))
-               continue;
-            if (provider_catalog_get_health(ag->name) == CATALOG_HEALTH_DOWN)
-               continue;
-            if (!chosen || ag->cost_tier < best_tier)
-            {
-               chosen = ag;
-               chosen_role = r;
-               best_tier = ag->cost_tier;
-            }
-         }
-      }
-      if (!chosen)
-      {
-         run_cmd_set_cwd(NULL);
-         free(sys_prompt);
-         persona_free(&pinfo);
-         if (err && errlen)
-            snprintf(err, errlen, "wfe live delegate: no enabled agent eligible for persona '%s'",
-                     persona);
-         return -1;
-      }
-      rc = agent_execute_with_tools_for_role(chosen, &acfg.network, chosen_role,
-                                             sys_prompt ? sys_prompt : "", prompt,
-                                             AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
-   }
+   rc = agent_execute_with_tools(ag, &acfg.network, sys_prompt ? sys_prompt : "", prompt,
+                                 AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
    run_cmd_set_cwd(NULL);
    free(sys_prompt);
-   persona_free(&pinfo);
 
    if (rc != 0)
    {

--- a/src/tests/test_wfe_random_delegate.c
+++ b/src/tests/test_wfe_random_delegate.c
@@ -14,8 +14,7 @@ int main(void)
    printf("wfe-random-delegate: ");
    char out[64];
 
-   /* Empty / specific names pass through. */
-   assert(wfe_resolve_delegate("", NULL, out, sizeof out) == 0 && out[0] == '\0');
+   /* Specific names pass through. */
    assert(wfe_resolve_delegate("mistral", NULL, out, sizeof out) == 0 &&
           strcmp(out, "mistral") == 0);
 
@@ -47,10 +46,28 @@ int main(void)
    }
    assert(saw_alpha && saw_gamma); /* both enabled agents reachable */
 
-   /* Empty roster -> fail fast (never leak "$random"). */
+   /* An UNNAMED delegate ("") routes through the same random selector — it
+    * means "any enabled agent", never a fixed roster-order pick. */
+   int e_alpha = 0, e_gamma = 0;
+   for (unsigned s = 1; s <= 20; s++)
+   {
+      wfe_resolve_delegate_seed(s);
+      assert(wfe_resolve_delegate("", &acfg, out, sizeof out) == 0);
+      assert(strcmp(out, "beta") != 0); /* disabled excluded */
+      assert(strcmp(out, "alpha") == 0 || strcmp(out, "gamma") == 0);
+      if (!strcmp(out, "alpha"))
+         e_alpha = 1;
+      if (!strcmp(out, "gamma"))
+         e_gamma = 1;
+   }
+   assert(e_alpha && e_gamma);
+
+   /* Empty roster -> fail fast (never leak "$random"), named or unnamed. */
    agent_config_t empty;
    memset(&empty, 0, sizeof empty);
    assert(wfe_resolve_delegate("$random", &empty, out, sizeof out) == -1);
+   assert(out[0] == '\0');
+   assert(wfe_resolve_delegate("", &empty, out, sizeof out) == -1);
    assert(out[0] == '\0');
 
    printf("ok\n");

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -892,8 +892,9 @@ static int run_fanout_units(const char *wd, const wfe_node_t *node, double *cost
       int ok = 0;
       for (long attempt = 0; attempt <= retry_max && !ok; attempt++)
       {
-         /* retry-DIFFERENT-delegate: the first attempt uses the pinned delegate;
-          * retries use $random so a fresh perspective takes over (Q2). */
+         /* retry-DIFFERENT-delegate: the first attempt uses the pinned delegate
+          * (an unnamed one resolves to a random roster agent); retries force
+          * $random so a fresh perspective takes over (Q2). */
          const char *deleg = (attempt == 0) ? node_delegate(node) : "$random";
          char uc[64] = "";
          if (wfe_delegate_dispatch(wd, "engineer", deleg, prompt, NULL, uc, cost) < 0)


### PR DESCRIPTION
A workflow step with no `delegate` param fell into persona-role routing, which picks the lowest-cost-tier eligible agent with first-scanned-wins ties. On a flat (all-one-tier) roster that pinned **every** dispatch to whichever agent came first in agents.json — observed live on the .254 appliance: 1200+ consecutive implement dispatches all landed on the same MiniMax-M3 seat. An unnamed delegate means *any agent*, so successive dispatches should assort across the roster.

Fix: route the empty name through the existing, unit-tested `$random` selector in `wfe_resolve_delegate` (uniform over ENABLED agents, seedable for tests) instead of adding a parallel picker. The resolve now always yields a concrete agent name, so the per-persona role-scan branch in `wfe_live_delegate_run` is dead and removed for the producing path (net −28 lines); the judge provider keeps its own lens routing untouched. An unroutable random pick fails the dispatch and the implement block's retry loop re-rolls a different agent (retries already forced `$random`).

Tests: `test_wfe_random_delegate.c` extended — `""` assorts over enabled agents (never the disabled one), and an empty roster fails fast for both `""` and `$random`. `unit-test-wfe-random-delegate` and `unit-test-wfe-delegate-seam` pass locally.