### PR TITLE
fix(combined): trixie runtime base — arm64 llama.cpp needs glibc 2.38

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -104,15 +104,19 @@ COPY scripts/aimee-llm-supervisor.sh /tmp/supervisor.sh
 RUN chmod +x /tmp/supervisor.sh \
     && AIMEE_LLM_DOWNLOAD_ONLY=1 AIMEE_LLM_TIER=cpu AIMEE_LLM_MODELS_DIR=/models /tmp/supervisor.sh
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
+# trixie (not bookworm): upstream's ubuntu-vulkan-arm64 llama.cpp tarball is built
+# against Ubuntu 24.04 (GLIBC_2.38 / GLIBCXX_3.4.32); bookworm's glibc 2.36 cannot
+# load it (the x64 tarball targets an older toolchain, which masked this on amd64).
+# Same base as Dockerfile.aimee-llm.
 # Union of the runtime closures: libsqlite3 (server DB1), libpq (kb DB2),
 # libssl/libzstd/zlib (both), python3 (kb sidecars + llm gateway), curl (health +
 # entrypoint probes); tmux + nodejs + npm for OAuth CLI agents; libgomp1 + libvulkan1
-# + mesa-vulkan-drivers + libcurl4 + python3-numpy for the bundled llama.cpp runtime.
+# + mesa-vulkan-drivers + libcurl4t64 + python3-numpy for the bundled llama.cpp runtime.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl git libcurl4 libgomp1 libpam-modules libpam0g libpq5 \
-        libsqlite3-0 libssl3 libvulkan1 libzstd1 mesa-vulkan-drivers nodejs npm \
+        ca-certificates curl git libcurl4t64 libgomp1 libpam-modules libpam0g libpq5 \
+        libsqlite3-0 libssl3t64 libvulkan1 libzstd1 mesa-vulkan-drivers nodejs npm \
         openssh-client python3 python3-numpy tmux zlib1g \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
First real arm64 boot of `aimee-combined:0.2.191` (qemu-user smoke test on the Proxmox host) caught a loader failure the CI build can't see:

- upstream's `ubuntu-vulkan-arm64` llama.cpp tarball is built against Ubuntu 24.04 → needs `GLIBC_2.38` / `GLIBCXX_3.4.32` / `CXXABI_1.3.15`
- the combined final image was `debian:bookworm-slim` (glibc 2.36) → every llama shared object failed to load, the supervisor exited, the llm gateway never came up
- the x64 tarball targets an older toolchain, which is why amd64 never hit this

Fix: final stage `bookworm-slim` → `trixie-slim` (glibc 2.41), the same base `Dockerfile.aimee-llm` already uses for exactly this reason, plus the trixie t64 renames (`libcurl4t64`, `libssl3t64`).

Verified under qemu on the extracted arm64 `/opt/llama`: `llama-server --version` runs on trixie+libgomp1 (`b9775, aarch64`) and reproduces the loader failure on bookworm. The model pre-bake itself worked as designed on arm64 — no first-boot download.

Validation plan post-merge: dispatch `publish-images.yml` on `testing` with no version (pushes only `sha-*` tags, leaves `:latest`/semver untouched), then boot the sha-tagged arm64 image on the pve host.