### PR TITLE
e2e: thin-client adoption flow + parallel CI e2e matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,9 +530,16 @@ jobs:
   # docs/proposals/pending/aimee-e2e-deploy-matrix.md. GitHub's ubuntu runners
   # ship Docker + compose, so no port offset is needed (8740/8741 are free).
   e2e-docker:
+    # One runner per topology so the deploy matrix runs in PARALLEL instead of
+    # serially on one runner (T1+T2+T3 back-to-back was the long pole of CI).
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        topology: [T1, T2, T3]
+    name: e2e-docker (${{ matrix.topology }})
     steps:
       - uses: actions/checkout@v4
       - name: Runner diagnostics
@@ -540,16 +547,39 @@ jobs:
           docker version --format '{{.Server.Version}}'
           docker compose version
           df -h / | tail -1
-      - name: Run Docker deploy matrix (T1-T3)
+      - name: Run Docker deploy topology ${{ matrix.topology }}
         # The aimee-server image builds webchat's SPA from its vendored
         # @rakuensoftware/smoothgui dependency — no npm token needed.
-        run: scripts/e2e-matrix.sh --only T1,T2,T3
+        run: scripts/e2e-matrix.sh --only ${{ matrix.topology }}
       - name: Stack logs on failure
         if: failure()
         run: |
           for f in compose.yaml compose.server.yaml compose.server-standalone.yaml; do
             echo "::group::$f"; docker compose -f "$f" logs --tail=80 2>/dev/null || true; echo "::endgroup::"
           done
+
+  e2e-adoption:
+    # Thin-client ADOPTION (TOFU enrollment) as its own parallel E2E flow: a
+    # fresh `aimee` client against a native aimee-server holding the default
+    # bootstrap bearer must pin the cert, auto-rotate to a strong bearer, and
+    # persist it on both sides; the consumed bootstrap must be dead afterwards.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          # Same apt hygiene as the build jobs: drop flaky third-party repos,
+          # retry update with backoff.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
+          sudo apt-get install -y -q gcc make \
+            libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
+            libpq-dev
+      - name: Thin-client adoption E2E
+        run: scripts/aimee-thinclient-adoption-e2e.sh
+      - name: Server log on failure
+        if: failure()
+        run: tail -60 /tmp/*/server.log 2>/dev/null || true
 
   # §2 tree-sitter extraction front-end (opt-in). The default build compiles
   # code_treesitter.c to a stub, so the other jobs never exercise the grammar

--- a/scripts/aimee-thinclient-adoption-e2e.sh
+++ b/scripts/aimee-thinclient-adoption-e2e.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# aimee-thinclient-adoption-e2e.sh — E2E for thin-client ADOPTION (TOFU
+# enrollment): a NEW thin client is pointed at an aimee-server that still holds
+# the default one-time bootstrap bearer, and `aimee remote set` must
+#
+#   1. pin the server's self-signed TLS cert (remote-ca.pem) and verify,
+#   2. automatically rotate the bootstrap to a fresh strong bearer
+#      (POST /v1/api/rotate_bearer),
+#   3. persist the NEW token to the client's remote.conf (never the bootstrap),
+#      while the server persists the same token in its aimee.yaml,
+#   4. leave the bootstrap dead: raw requests with it get 401, and a SECOND
+#      fresh client presenting the bootstrap is refused enrollment.
+#
+# This drives the real `aimee` client binary against a real local aimee-server
+# over the TLS /v1 listener — the exact flow a fresh appliance install runs on
+# first connect (no docker, Linux only).
+#
+# Env:
+#   TLS_PORT      server /v1 TLS port      (default 28743)
+#   HTTP_PORT     server plaintext port    (default 28740, loopback-only)
+#   WAIT_SECONDS  health wait budget       (default 60)
+#   AIMEE_BIN / AIMEE_SERVER_BIN
+#                 prebuilt binaries to drive instead of building from src/
+#                 (e.g. run this script inside the server container image)
+#
+# Exit code: 0 = all checks passed.
+
+set -uo pipefail
+
+TLS_PORT="${TLS_PORT:-28743}"
+HTTP_PORT="${HTTP_PORT:-28740}"
+WAIT_SECONDS="${WAIT_SECONDS:-60}"
+BOOTSTRAP="aimee-local-dev"
+
+cd "$(dirname "$0")/.."
+REPO="$(pwd)"
+AIMEE_BIN="${AIMEE_BIN:-$REPO/aimee}"
+AIMEE_SERVER_BIN="${AIMEE_SERVER_BIN:-$REPO/aimee-server}"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+ok()   { green "  PASS  $1"; PASS=$((PASS + 1)); }
+bad()  { red   "  FAIL  $1"; [[ $# -gt 1 ]] && printf '        %s\n' "$2"; FAIL=$((FAIL + 1)); }
+
+# --- build (skipped when both binaries already exist / are supplied) --------
+if [[ -x "$AIMEE_BIN" && -x "$AIMEE_SERVER_BIN" ]]; then
+  bold "==> Using binaries: $AIMEE_BIN / $AIMEE_SERVER_BIN"
+else
+  bold "==> Building aimee (thin client) + aimee-server"
+  make -C src ../aimee ../aimee-server >/dev/null
+fi
+
+# --- server: scratch home, TLS listener, bootstrap bearer ------------------
+SERVER_HOME="$(mktemp -d)"
+CLIENT_HOME="$(mktemp -d)"
+CLIENT2_HOME="$(mktemp -d)"
+
+# Baked container default (bootstrap bearer, tls_port) remapped to test ports.
+sed "s/8740/${HTTP_PORT}/; s/8743/${TLS_PORT}/" \
+    deploy/container/aimee-server.yaml > "$SERVER_HOME/aimee.yaml"
+
+server_pid=""
+cleanup() {
+  [[ -n "$server_pid" ]] && kill "$server_pid" 2>/dev/null || true
+  rm -rf "$SERVER_HOME" "$CLIENT_HOME" "$CLIENT2_HOME"
+}
+trap cleanup EXIT
+
+ulimit -S -s 65536 || true # server worker threads need a 64 MB stack
+
+bold "==> Starting aimee-server (TLS :${TLS_PORT}, bootstrap bearer)"
+AIMEE_HOME="$SERVER_HOME" AIMEE_DB1_URL="sqlite://${SERVER_HOME}/aimee.db" \
+  AIMEE_SERVER_HTTP_BIND=1 "$AIMEE_SERVER_BIN" >"$SERVER_HOME/server.log" 2>&1 &
+server_pid=$!
+
+deadline=$((SECONDS + WAIT_SECONDS))
+until curl -sk --max-time 3 "https://127.0.0.1:${TLS_PORT}/v1/health" >/dev/null 2>&1; do
+  if (( SECONDS >= deadline )) || ! kill -0 "$server_pid" 2>/dev/null; then
+    red "server did not serve TLS /v1 within ${WAIT_SECONDS}s"
+    tail -20 "$SERVER_HOME/server.log" || true
+    exit 1
+  fi
+  sleep 1
+done
+green "    TLS /v1 listener is up"
+
+URL="https://127.0.0.1:${TLS_PORT}"
+
+# --- adoption: fresh client, default bearer --------------------------------
+bold "==> Adoption: fresh thin client runs 'aimee remote set ${URL} <bootstrap>'"
+set_json="$(AIMEE_HOME="$CLIENT_HOME" "$AIMEE_BIN" --json remote set "$URL" "$BOOTSTRAP" 2>"$CLIENT_HOME/set.err")" || true
+echo "    remote set -> ${set_json:-<no output>}"
+
+[[ "$set_json" == *'"pinned":true'* || "$set_json" == *'"verified":true'* ]] \
+  && ok "TLS trust established (pinned/verified)" \
+  || bad "TLS trust established" "$set_json $(cat "$CLIENT_HOME/set.err")"
+[[ -s "$CLIENT_HOME/remote-ca.pem" ]] \
+  && ok "server cert pinned to remote-ca.pem" \
+  || bad "server cert pinned to remote-ca.pem"
+[[ "$set_json" == *'"enrolled":true'* ]] \
+  && ok "bootstrap auto-enrolled on first connect" \
+  || bad "bootstrap auto-enrolled on first connect" "$set_json"
+
+# The client must now hold a NEW strong token — never the bootstrap.
+client_token="$(sed -n 2p "$CLIENT_HOME/remote.conf")"
+if [[ "$client_token" != "$BOOTSTRAP" && "$client_token" =~ ^[0-9a-f]{64}$ ]]; then
+  ok "remote.conf updated to a generated 256-bit bearer"
+else
+  bad "remote.conf updated to a generated 256-bit bearer" "token: '${client_token:-<empty>}'"
+fi
+
+# The server must have persisted the SAME token (survives a restart).
+grep -q "bearer_token.*${client_token}" "$SERVER_HOME/aimee.yaml" \
+  && ok "server persisted the same bearer in its aimee.yaml" \
+  || bad "server persisted the same bearer in its aimee.yaml"
+
+# The adopted client transacts real work with the new token.
+AIMEE_HOME="$CLIENT_HOME" "$AIMEE_BIN" remote status >/dev/null 2>&1 \
+  && ok "adopted client reaches /v1 with the new bearer" \
+  || bad "adopted client reaches /v1 with the new bearer"
+
+# --- the bootstrap is dead -------------------------------------------------
+bold "==> The consumed bootstrap no longer authorizes anything"
+st="$(curl -sk --max-time 10 -o /dev/null -w '%{http_code}' \
+      -H "Authorization: Bearer ${BOOTSTRAP}" "${URL}/v1/health")"
+[[ "$st" == 401 ]] \
+  && ok "raw request with the bootstrap -> 401" \
+  || bad "raw request with the bootstrap -> 401" "got HTTP $st"
+
+st="$(curl -sk --max-time 10 -o /dev/null -w '%{http_code}' \
+      -H "Authorization: Bearer ${client_token}" "${URL}/v1/health")"
+[[ "$st" == 200 ]] \
+  && ok "raw request with the rotated bearer -> 200" \
+  || bad "raw request with the rotated bearer -> 200" "got HTTP $st"
+
+# --- a second fresh client cannot re-adopt with the bootstrap ---------------
+bold "==> A second fresh client presenting the bootstrap is refused enrollment"
+set2_json="$(AIMEE_HOME="$CLIENT2_HOME" "$AIMEE_BIN" --json remote set "$URL" "$BOOTSTRAP" 2>"$CLIENT2_HOME/set.err")" || true
+[[ "$set2_json" == *'"enrolled":false'* ]] \
+  && ok "second client not enrolled (one-shot TOFU)" \
+  || bad "second client not enrolled (one-shot TOFU)" "$set2_json"
+second_token="$(sed -n 2p "$CLIENT2_HOME/remote.conf" 2>/dev/null)"
+[[ "$second_token" == "$BOOTSTRAP" ]] \
+  && ok "second client's remote.conf still holds the (useless) bootstrap" \
+  || bad "second client's remote.conf still holds the (useless) bootstrap" "token: '${second_token:-<empty>}'"
+
+echo
+bold "==> Summary: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" == 0 ]] || exit 1
+green "thin-client adoption (TOFU enrollment) works end to end."

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -14,6 +14,7 @@
 #   T5  Local full stack               (scratch server + local kb)    [Linux only]
 #   T6  Local server + Docker kb hybrid (scratch server -> :8741)     [Linux only]
 #   PC  Thin-client smoke              (against the T2 server URL)
+#   AD  Thin-client adoption           (TOFU bootstrap-bearer enrollment) [Linux only]
 #
 # Usage:
 #   scripts/e2e-matrix.sh                      # everything runnable on this host
@@ -38,7 +39,7 @@ cd "$(dirname "$0")/.."
 SCRIPTS="$(pwd)/scripts"
 ROOT="$(pwd)"
 
-ONLY="T1,T2,T3,T5,T6,PC"
+ONLY="T1,T2,T3,T5,T6,PC,AD"
 KB_URL=""
 DOWN="--down"
 PORT_OFFSET=0
@@ -165,6 +166,15 @@ if selected T6; then
     if MODE=hybrid KB_URL="$KB_URL" "$SCRIPTS/aimee-local-stack-e2e.sh"; then record T6 PASS "hybrid"; else record T6 FAIL "hybrid"; fi
   else
     bold "== T6: SKIP — local install is Linux-only"; record T6 SKIP "non-Linux host"
+  fi
+fi
+
+if selected AD; then
+  if is_linux; then
+    bold "== AD (Thin-client adoption / TOFU enrollment) =="
+    if "$SCRIPTS/aimee-thinclient-adoption-e2e.sh"; then record AD PASS "thin-client adoption"; else record AD FAIL "thin-client adoption"; fi
+  else
+    bold "== AD: SKIP — local build is Linux-only"; record AD SKIP "non-Linux host"
   fi
 fi
 


### PR DESCRIPTION
## Adoption E2E (the flow that broke on the appliance)

New `scripts/aimee-thinclient-adoption-e2e.sh` drives the **real** `aimee` client binary against a **real** native `aimee-server` over the TLS /v1 listener — the exact first-connect flow of a fresh install:

1. Server starts with the baked default bootstrap bearer (`deploy/container/aimee-server.yaml`, ports remapped) in a scratch `AIMEE_HOME`.
2. A fresh client runs `aimee remote set https://127.0.0.1:<port> <bootstrap>` and the script asserts: TLS trust established + cert pinned to `remote-ca.pem`; `enrolled:true`; **`remote.conf` now holds a generated 64-hex 256-bit bearer, not the bootstrap**; the server persisted the *same* token in its `aimee.yaml`; the adopted client transacts over /v1.
3. The consumed bootstrap is dead: raw request → 401, rotated bearer → 200, and a **second** fresh client presenting the bootstrap gets `enrolled:false` and keeps the useless bootstrap on disk.

`AIMEE_BIN`/`AIMEE_SERVER_BIN` accept prebuilt binaries (container/appliance runs); otherwise it builds from `src/`. Registered in `e2e-matrix.sh` as topology `AD` (Linux-only, default set).

## Parallel E2E in CI

The serial `e2e-docker` job ran T1→T2→T3 back-to-back on one runner (~20+ min long pole). It's now a `fail-fast: false` **matrix — one runner per topology** — plus `e2e-adoption` as a fourth parallel flow, so E2E wall-clock drops to the slowest single topology. `e2e-docker` is not a required status check on `testing` or `main`, so the check-name change (`e2e-docker (T1)` etc.) breaks no branch protection.

## Verification

- `bash -n` clean on both scripts; the adoption script's client-side assertions were cross-checked against `cli_remote.c`'s `remote set --json` output and `remote.conf` format, and the rotate-persistence assertion against the live appliance behavior.
- The new CI jobs on this very PR are the end-to-end execution of the adoption flow.