### PR TITLE
fix(wfe): reject self-referential intent records at validation

### DIFF
--- a/src/tests/test_wfe_manager_artifacts.c
+++ b/src/tests/test_wfe_manager_artifacts.c
@@ -51,6 +51,38 @@ int main(void)
    assert(wfe_intent_validate(bad_status, err, sizeof err) != 0);
    cJSON_Delete(bad_status);
 
+   /* SELF-REFERENTIAL records -> reject: schema-valid garbage observed live,
+    * where the scope delegate wrote a record about the record instead of the
+    * task. Each is one of the three real-world shapes. */
+   cJSON *self1 = P("{\"schema_version\":1,\"status\":\"confirmed\","
+                    "\"summary\":\"Create INTENT RECORD for work item wi_2f9246\","
+                    "\"acceptance_criteria\":[\"file exists\"]}");
+   assert(wfe_intent_validate(self1, err, sizeof err) != 0);
+   cJSON_Delete(self1);
+   cJSON *self2 = P("{\"schema_version\":1,\"status\":\"confirmed\","
+                    "\"summary\":\"Scope and structure work item as intent record\","
+                    "\"acceptance_criteria\":[\"record committed\"]}");
+   assert(wfe_intent_validate(self2, err, sizeof err) != 0);
+   cJSON_Delete(self2);
+   cJSON *self3 = P("{\"schema_version\":1,\"status\":\"confirmed\","
+                    "\"summary\":\"Senior architecture review of 2f9246841f04f156 for integrity\","
+                    "\"acceptance_criteria\":[\"review done\"]}");
+   assert(wfe_intent_validate(self3, err, sizeof err) != 0); /* 16-hex id blob */
+   cJSON_Delete(self3);
+   /* a meta criterion alone also rejects */
+   cJSON *self4 = P("{\"schema_version\":1,\"status\":\"confirmed\","
+                    "\"summary\":\"discard first warmup instance per run\","
+                    "\"acceptance_criteria\":[\"INTENT RECORD contains valid schema\"]}");
+   assert(wfe_intent_validate(self4, err, sizeof err) != 0);
+   cJSON_Delete(self4);
+   /* a real task summary with ordinary hex-ish words still passes */
+   cJSON *real = P("{\"schema_version\":1,\"status\":\"confirmed\","
+                   "\"summary\":\"Implement warmup handling: discard first instance per run\","
+                   "\"acceptance_criteria\":[\"first instance excluded from metrics\","
+                   "\"warmup latency reported separately\"]}");
+   assert(wfe_intent_validate(real, err, sizeof err) == 0);
+   cJSON_Delete(real);
+
    /* ---- packet plan ---- */
    cJSON *packets = P("{\"schema_version\":1,\"packets\":[{\"packet_id\":\"p1\","
                       "\"summary\":\"impl the button\",\"target_blocks\":[\"implement\"],"

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -1743,10 +1743,13 @@ static wfe_step_result_t exec_understand(wfe_ctx *ctx, const wfe_node_t *node)
    snprintf(prompt, sizeof prompt,
             "Scope the WORK ITEM below into a structured INTENT RECORD: "
             "{\"schema_version\":1,\"status\":\"unconfirmed\",\"summary\":\"<one line>\","
-            "\"rationale\":\"<why>\",\"acceptance_criteria\":[\"<testable>\"]}. Write the JSON to "
-            "the given path and commit it if you can; if file tools are unavailable to you, your "
-            "ENTIRE reply must be exactly that JSON document — no prose, no code fences, nothing "
-            "else.\n\nWORK ITEM:\n%s",
+            "\"rationale\":\"<why>\",\"acceptance_criteria\":[\"<testable>\"]}. The record must "
+            "describe the ENGINEERING TASK in the work item — what changes, where, and how it is "
+            "verified. Producing the record is NOT the task: never write a summary or criteria "
+            "about creating/confirming intent records, and never mention work-item ids. Write the "
+            "JSON to the given path and commit it if you can; if file tools are unavailable to "
+            "you, your ENTIRE reply must be exactly that JSON document — no prose, no code "
+            "fences, nothing else.\n\nWORK ITEM:\n%s",
             src[0] ? src : "(no packet artifact found — scope the work item's ask)");
    return manager_produce(ctx, node, "architect", prompt, wfe_intent_validate);
 }

--- a/src/workflow/wfe_manager_artifacts.c
+++ b/src/workflow/wfe_manager_artifacts.c
@@ -150,8 +150,9 @@ int wfe_intent_validate(const cJSON *rec, char *err, size_t errlen)
    {
       if (icontains(it->valuestring, "intent record"))
       {
-         snprintf(err, errlen, "intent: self-referential acceptance criterion — criteria must be "
-                               "testable properties of the change, not of the record");
+         snprintf(err, errlen,
+                  "intent: self-referential acceptance criterion — criteria must be "
+                  "testable properties of the change, not of the record");
          return -1;
       }
    }

--- a/src/workflow/wfe_manager_artifacts.c
+++ b/src/workflow/wfe_manager_artifacts.c
@@ -71,6 +71,46 @@ static int all_strings(const cJSON *arr, const char *what, char *err, size_t err
 
 /* ---- intent record (understand) ---- */
 
+/* case-insensitive substring (portable strcasestr) */
+static int icontains(const char *hay, const char *needle)
+{
+   size_t nl = strlen(needle);
+   for (const char *p = hay; *p; p++)
+   {
+      size_t i = 0;
+      while (i < nl && p[i] &&
+             ((p[i] >= 'A' && p[i] <= 'Z') ? p[i] + 32 : p[i]) ==
+                 ((needle[i] >= 'A' && needle[i] <= 'Z') ? needle[i] + 32 : needle[i]))
+         i++;
+      if (i == nl)
+         return 1;
+   }
+   return 0;
+}
+
+/* Reject a SELF-REFERENTIAL intent: a record whose text is about the record /
+ * work-item bookkeeping instead of the engineering task. Observed live (3 of 13
+ * slices): scope delegates pattern-match the instruction into "the task is to
+ * create an intent record" — the schema is valid, so the garbage advanced and
+ * implement dutifully committed only .wfe-scope.json, which the roundtable then
+ * rejects every round to its cap. Markers: mentions of the record itself, of
+ * "work item" (a packet describes code, not run bookkeeping), a work-item id
+ * (wi_<hex>), or any >=16-hex-digit run id blob. */
+static int intent_self_referential(const char *s)
+{
+   if (icontains(s, "intent record") || icontains(s, "work item") || strstr(s, "wi_"))
+      return 1;
+   int hexrun = 0;
+   for (const char *p = s; *p; p++)
+   {
+      int ishex = (*p >= '0' && *p <= '9') || (*p >= 'a' && *p <= 'f') || (*p >= 'A' && *p <= 'F');
+      hexrun = ishex ? hexrun + 1 : 0;
+      if (hexrun >= 16)
+         return 1;
+   }
+   return 0;
+}
+
 int wfe_intent_validate(const cJSON *rec, char *err, size_t errlen)
 {
    if (err && errlen)
@@ -95,6 +135,26 @@ int wfe_intent_validate(const cJSON *rec, char *err, size_t errlen)
    const cJSON *ac = req_arr(rec, "acceptance_criteria", 1, err, errlen);
    if (!ac || all_strings(ac, "intent.acceptance_criteria", err, errlen) != 0)
       return -1;
+   /* Content gate, not just shape: a self-referential record loops the scope
+    * attempt (fresh delegate) instead of poisoning every downstream stage. */
+   const cJSON *sm = cJSON_GetObjectItemCaseSensitive(rec, "summary");
+   if (intent_self_referential(sm->valuestring))
+   {
+      snprintf(err, errlen,
+               "intent: self-referential — summary must scope the engineering task itself, not "
+               "the intent record / work item bookkeeping");
+      return -1;
+   }
+   const cJSON *it = NULL;
+   cJSON_ArrayForEach(it, ac)
+   {
+      if (icontains(it->valuestring, "intent record"))
+      {
+         snprintf(err, errlen, "intent: self-referential acceptance criterion — criteria must be "
+                               "testable properties of the change, not of the record");
+         return -1;
+      }
+   }
    return 0;
 }
 


### PR DESCRIPTION
Three of the first live fan-out's 13 slices (s5, s11, s12 on the .254 appliance) scoped to garbage: the scope delegate pattern-matched *"scope the WORK ITEM into an INTENT RECORD"* into *"the task is to create an intent record"*, ignoring the packet content entirely. The record was schema-valid, so it advanced — implement then faithfully committed only `.wfe-scope.json`, and the roundtable (correctly) rejected the empty change every round toward its cap. Observed summaries: `Create INTENT RECORD for work item wi_2f92…`, `Scope and structure work item … as INTENT RECORD`, `Senior architecture review of 2f9246841f04… for structural integrity`.

Fix — validate **content**, not just shape:
- `wfe_intent_validate` rejects a self-referential record: summary mentioning `intent record` / `work item`, a `wi_<hex>` id, or a ≥16-hex run-id blob; or any acceptance criterion that is a property of the record rather than the change. A rejected record loops the scope attempt (fresh artifact, and after #1322 a fresh random delegate) instead of poisoning every downstream stage.
- `exec_understand` prompt hardened: the record must describe the engineering task (what changes, where, how verified); producing the record is NOT the task; never mention work-item ids.

Tests: `test_wfe_manager_artifacts.c` pins all three live garbage shapes as rejects, a meta acceptance-criterion reject, and a realistic packet-derived record as a pass. `unit-test-wfe-manager-artifacts` passes locally.

Live remediation already applied on the box (operator commit of packet-derived records into the three slice worktrees); this PR prevents recurrence.