### PR TITLE
Promote testing → main: arm64 combined runtime fix (trixie base)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,9 +530,16 @@ jobs:
   # docs/proposals/pending/aimee-e2e-deploy-matrix.md. GitHub's ubuntu runners
   # ship Docker + compose, so no port offset is needed (8740/8741 are free).
   e2e-docker:
+    # One runner per topology so the deploy matrix runs in PARALLEL instead of
+    # serially on one runner (T1+T2+T3 back-to-back was the long pole of CI).
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        topology: [T1, T2, T3]
+    name: e2e-docker (${{ matrix.topology }})
     steps:
       - uses: actions/checkout@v4
       - name: Runner diagnostics
@@ -540,16 +547,39 @@ jobs:
           docker version --format '{{.Server.Version}}'
           docker compose version
           df -h / | tail -1
-      - name: Run Docker deploy matrix (T1-T3)
+      - name: Run Docker deploy topology ${{ matrix.topology }}
         # The aimee-server image builds webchat's SPA from its vendored
         # @rakuensoftware/smoothgui dependency — no npm token needed.
-        run: scripts/e2e-matrix.sh --only T1,T2,T3
+        run: scripts/e2e-matrix.sh --only ${{ matrix.topology }}
       - name: Stack logs on failure
         if: failure()
         run: |
           for f in compose.yaml compose.server.yaml compose.server-standalone.yaml; do
             echo "::group::$f"; docker compose -f "$f" logs --tail=80 2>/dev/null || true; echo "::endgroup::"
           done
+
+  e2e-adoption:
+    # Thin-client ADOPTION (TOFU enrollment) as its own parallel E2E flow: a
+    # fresh `aimee` client against a native aimee-server holding the default
+    # bootstrap bearer must pin the cert, auto-rotate to a strong bearer, and
+    # persist it on both sides; the consumed bootstrap must be dead afterwards.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          # Same apt hygiene as the build jobs: drop flaky third-party repos,
+          # retry update with backoff.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+          i=0; until sudo apt-get update -q; do i=$((i+1)); [ "$i" -ge 5 ] && break; echo "apt-get update retry $i (transient repo failure)"; sleep $((i*4)); done
+          sudo apt-get install -y -q gcc make \
+            libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev \
+            libpq-dev
+      - name: Thin-client adoption E2E
+        run: scripts/aimee-thinclient-adoption-e2e.sh
+      - name: Server log on failure
+        if: failure()
+        run: tail -60 /tmp/*/server.log 2>/dev/null || true
 
   # §2 tree-sitter extraction front-end (opt-in). The default build compiles
   # code_treesitter.c to a stub, so the other jobs never exercise the grammar

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -104,15 +104,19 @@ COPY scripts/aimee-llm-supervisor.sh /tmp/supervisor.sh
 RUN chmod +x /tmp/supervisor.sh \
     && AIMEE_LLM_DOWNLOAD_ONLY=1 AIMEE_LLM_TIER=cpu AIMEE_LLM_MODELS_DIR=/models /tmp/supervisor.sh
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
+# trixie (not bookworm): upstream's ubuntu-vulkan-arm64 llama.cpp tarball is built
+# against Ubuntu 24.04 (GLIBC_2.38 / GLIBCXX_3.4.32); bookworm's glibc 2.36 cannot
+# load it (the x64 tarball targets an older toolchain, which masked this on amd64).
+# Same base as Dockerfile.aimee-llm.
 # Union of the runtime closures: libsqlite3 (server DB1), libpq (kb DB2),
 # libssl/libzstd/zlib (both), python3 (kb sidecars + llm gateway), curl (health +
 # entrypoint probes); tmux + nodejs + npm for OAuth CLI agents; libgomp1 + libvulkan1
-# + mesa-vulkan-drivers + libcurl4 + python3-numpy for the bundled llama.cpp runtime.
+# + mesa-vulkan-drivers + libcurl4t64 + python3-numpy for the bundled llama.cpp runtime.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl git libcurl4 libgomp1 libpam-modules libpam0g libpq5 \
-        libsqlite3-0 libssl3 libvulkan1 libzstd1 mesa-vulkan-drivers nodejs npm \
+        ca-certificates curl git libcurl4t64 libgomp1 libpam-modules libpam0g libpq5 \
+        libsqlite3-0 libssl3t64 libvulkan1 libzstd1 mesa-vulkan-drivers nodejs npm \
         openssh-client python3 python3-numpy tmux zlib1g \
     && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/smoothnas/aimee-server.plugin.yaml
+++ b/deploy/smoothnas/aimee-server.plugin.yaml
@@ -63,9 +63,10 @@ services:
         hostExpose: true
     config:
       # The server's self-signed /v1 TLS cert covers the container hostname +
-      # localhost/loopback only. Behind NAT/DNAT (a tierd plugin reached at the
-      # host's LAN IP/hostname), set the reachable address(es) here so the cert
-      # includes them and thin clients verify (pin) it WITHOUT AIMEE_TLS_INSECURE.
+      # localhost/loopback only. Thin clients that TOFU-pin (`aimee remote set`)
+      # verify by exact-leaf match and do NOT need the dialed address in the
+      # cert's SANs. Set the reachable address(es) here only for clients that
+      # verify by name instead of pinning (e.g. generic HTTPS tooling).
       # Comma-separated; bare IPs/hosts are auto-typed (e.g. "192.168.1.254" or
       # "192.168.1.254,nas.lan"). No effect when an operator cert is supplied.
       - key: AIMEE_TLS_EXTRA_SAN

--- a/scripts/aimee-thinclient-adoption-e2e.sh
+++ b/scripts/aimee-thinclient-adoption-e2e.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# aimee-thinclient-adoption-e2e.sh — E2E for thin-client ADOPTION (TOFU
+# enrollment): a NEW thin client is pointed at an aimee-server that still holds
+# the default one-time bootstrap bearer, and `aimee remote set` must
+#
+#   1. pin the server's self-signed TLS cert (remote-ca.pem) and verify,
+#   2. automatically rotate the bootstrap to a fresh strong bearer
+#      (POST /v1/api/rotate_bearer),
+#   3. persist the NEW token to the client's remote.conf (never the bootstrap),
+#      while the server persists the same token in its aimee.yaml,
+#   4. leave the bootstrap dead: raw requests with it get 401, and a SECOND
+#      fresh client presenting the bootstrap is refused enrollment.
+#
+# This drives the real `aimee` client binary against a real local aimee-server
+# over the TLS /v1 listener — the exact flow a fresh appliance install runs on
+# first connect (no docker, Linux only).
+#
+# Env:
+#   TLS_PORT      server /v1 TLS port      (default 28743)
+#   HTTP_PORT     server plaintext port    (default 28740, loopback-only)
+#   WAIT_SECONDS  health wait budget       (default 60)
+#   AIMEE_BIN / AIMEE_SERVER_BIN
+#                 prebuilt binaries to drive instead of building from src/
+#                 (e.g. run this script inside the server container image)
+#
+# Exit code: 0 = all checks passed.
+
+set -uo pipefail
+
+TLS_PORT="${TLS_PORT:-28743}"
+HTTP_PORT="${HTTP_PORT:-28740}"
+WAIT_SECONDS="${WAIT_SECONDS:-60}"
+BOOTSTRAP="aimee-local-dev"
+
+cd "$(dirname "$0")/.."
+REPO="$(pwd)"
+AIMEE_BIN="${AIMEE_BIN:-$REPO/aimee}"
+AIMEE_SERVER_BIN="${AIMEE_SERVER_BIN:-$REPO/aimee-server}"
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+
+PASS=0
+FAIL=0
+ok()   { green "  PASS  $1"; PASS=$((PASS + 1)); }
+bad()  { red   "  FAIL  $1"; [[ $# -gt 1 ]] && printf '        %s\n' "$2"; FAIL=$((FAIL + 1)); }
+
+# --- build (skipped when both binaries already exist / are supplied) --------
+if [[ -x "$AIMEE_BIN" && -x "$AIMEE_SERVER_BIN" ]]; then
+  bold "==> Using binaries: $AIMEE_BIN / $AIMEE_SERVER_BIN"
+else
+  bold "==> Building aimee (thin client) + aimee-server"
+  make -C src ../aimee ../aimee-server >/dev/null
+fi
+
+# --- server: scratch home, TLS listener, bootstrap bearer ------------------
+SERVER_HOME="$(mktemp -d)"
+CLIENT_HOME="$(mktemp -d)"
+CLIENT2_HOME="$(mktemp -d)"
+
+# Baked container default (bootstrap bearer, tls_port) remapped to test ports.
+sed "s/8740/${HTTP_PORT}/; s/8743/${TLS_PORT}/" \
+    deploy/container/aimee-server.yaml > "$SERVER_HOME/aimee.yaml"
+
+server_pid=""
+cleanup() {
+  [[ -n "$server_pid" ]] && kill "$server_pid" 2>/dev/null || true
+  rm -rf "$SERVER_HOME" "$CLIENT_HOME" "$CLIENT2_HOME"
+}
+trap cleanup EXIT
+
+ulimit -S -s 65536 || true # server worker threads need a 64 MB stack
+
+bold "==> Starting aimee-server (TLS :${TLS_PORT}, bootstrap bearer)"
+AIMEE_HOME="$SERVER_HOME" AIMEE_DB1_URL="sqlite://${SERVER_HOME}/aimee.db" \
+  AIMEE_SERVER_HTTP_BIND=1 "$AIMEE_SERVER_BIN" >"$SERVER_HOME/server.log" 2>&1 &
+server_pid=$!
+
+deadline=$((SECONDS + WAIT_SECONDS))
+until curl -sk --max-time 3 "https://127.0.0.1:${TLS_PORT}/v1/health" >/dev/null 2>&1; do
+  if (( SECONDS >= deadline )) || ! kill -0 "$server_pid" 2>/dev/null; then
+    red "server did not serve TLS /v1 within ${WAIT_SECONDS}s"
+    tail -20 "$SERVER_HOME/server.log" || true
+    exit 1
+  fi
+  sleep 1
+done
+green "    TLS /v1 listener is up"
+
+URL="https://127.0.0.1:${TLS_PORT}"
+
+# --- adoption: fresh client, default bearer --------------------------------
+bold "==> Adoption: fresh thin client runs 'aimee remote set ${URL} <bootstrap>'"
+set_json="$(AIMEE_HOME="$CLIENT_HOME" "$AIMEE_BIN" --json remote set "$URL" "$BOOTSTRAP" 2>"$CLIENT_HOME/set.err")" || true
+echo "    remote set -> ${set_json:-<no output>}"
+
+[[ "$set_json" == *'"pinned":true'* || "$set_json" == *'"verified":true'* ]] \
+  && ok "TLS trust established (pinned/verified)" \
+  || bad "TLS trust established" "$set_json $(cat "$CLIENT_HOME/set.err")"
+[[ -s "$CLIENT_HOME/remote-ca.pem" ]] \
+  && ok "server cert pinned to remote-ca.pem" \
+  || bad "server cert pinned to remote-ca.pem"
+[[ "$set_json" == *'"enrolled":true'* ]] \
+  && ok "bootstrap auto-enrolled on first connect" \
+  || bad "bootstrap auto-enrolled on first connect" "$set_json"
+
+# The client must now hold a NEW strong token — never the bootstrap.
+client_token="$(sed -n 2p "$CLIENT_HOME/remote.conf")"
+if [[ "$client_token" != "$BOOTSTRAP" && "$client_token" =~ ^[0-9a-f]{64}$ ]]; then
+  ok "remote.conf updated to a generated 256-bit bearer"
+else
+  bad "remote.conf updated to a generated 256-bit bearer" "token: '${client_token:-<empty>}'"
+fi
+
+# The server must have persisted the SAME token (survives a restart).
+grep -q "bearer_token.*${client_token}" "$SERVER_HOME/aimee.yaml" \
+  && ok "server persisted the same bearer in its aimee.yaml" \
+  || bad "server persisted the same bearer in its aimee.yaml"
+
+# The adopted client transacts real work with the new token.
+AIMEE_HOME="$CLIENT_HOME" "$AIMEE_BIN" remote status >/dev/null 2>&1 \
+  && ok "adopted client reaches /v1 with the new bearer" \
+  || bad "adopted client reaches /v1 with the new bearer"
+
+# --- the bootstrap is dead -------------------------------------------------
+bold "==> The consumed bootstrap no longer authorizes anything"
+st="$(curl -sk --max-time 10 -o /dev/null -w '%{http_code}' \
+      -H "Authorization: Bearer ${BOOTSTRAP}" "${URL}/v1/health")"
+[[ "$st" == 401 ]] \
+  && ok "raw request with the bootstrap -> 401" \
+  || bad "raw request with the bootstrap -> 401" "got HTTP $st"
+
+st="$(curl -sk --max-time 10 -o /dev/null -w '%{http_code}' \
+      -H "Authorization: Bearer ${client_token}" "${URL}/v1/health")"
+[[ "$st" == 200 ]] \
+  && ok "raw request with the rotated bearer -> 200" \
+  || bad "raw request with the rotated bearer -> 200" "got HTTP $st"
+
+# --- a second fresh client cannot re-adopt with the bootstrap ---------------
+bold "==> A second fresh client presenting the bootstrap is refused enrollment"
+set2_json="$(AIMEE_HOME="$CLIENT2_HOME" "$AIMEE_BIN" --json remote set "$URL" "$BOOTSTRAP" 2>"$CLIENT2_HOME/set.err")" || true
+[[ "$set2_json" == *'"enrolled":false'* ]] \
+  && ok "second client not enrolled (one-shot TOFU)" \
+  || bad "second client not enrolled (one-shot TOFU)" "$set2_json"
+second_token="$(sed -n 2p "$CLIENT2_HOME/remote.conf" 2>/dev/null)"
+[[ "$second_token" == "$BOOTSTRAP" ]] \
+  && ok "second client's remote.conf still holds the (useless) bootstrap" \
+  || bad "second client's remote.conf still holds the (useless) bootstrap" "token: '${second_token:-<empty>}'"
+
+echo
+bold "==> Summary: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" == 0 ]] || exit 1
+green "thin-client adoption (TOFU enrollment) works end to end."

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -14,6 +14,7 @@
 #   T5  Local full stack               (scratch server + local kb)    [Linux only]
 #   T6  Local server + Docker kb hybrid (scratch server -> :8741)     [Linux only]
 #   PC  Thin-client smoke              (against the T2 server URL)
+#   AD  Thin-client adoption           (TOFU bootstrap-bearer enrollment) [Linux only]
 #
 # Usage:
 #   scripts/e2e-matrix.sh                      # everything runnable on this host
@@ -38,7 +39,7 @@ cd "$(dirname "$0")/.."
 SCRIPTS="$(pwd)/scripts"
 ROOT="$(pwd)"
 
-ONLY="T1,T2,T3,T5,T6,PC"
+ONLY="T1,T2,T3,T5,T6,PC,AD"
 KB_URL=""
 DOWN="--down"
 PORT_OFFSET=0
@@ -165,6 +166,15 @@ if selected T6; then
     if MODE=hybrid KB_URL="$KB_URL" "$SCRIPTS/aimee-local-stack-e2e.sh"; then record T6 PASS "hybrid"; else record T6 FAIL "hybrid"; fi
   else
     bold "== T6: SKIP — local install is Linux-only"; record T6 SKIP "non-Linux host"
+  fi
+fi
+
+if selected AD; then
+  if is_linux; then
+    bold "== AD (Thin-client adoption / TOFU enrollment) =="
+    if "$SCRIPTS/aimee-thinclient-adoption-e2e.sh"; then record AD PASS "thin-client adoption"; else record AD FAIL "thin-client adoption"; fi
+  else
+    bold "== AD: SKIP — local build is Linux-only"; record AD SKIP "non-Linux host"
   fi
 fi
 

--- a/src/aimee_tls.c
+++ b/src/aimee_tls.c
@@ -83,7 +83,7 @@ static void aimee_tls_present_client_cert(SSL_CTX *ctx)
 /* Resolve <aimee_home>/remote-ca.pem — the pinned server certificate written by
  * `aimee remote set/trust`. Returns 1 (and fills |out|) when the file exists,
  * else 0. Trusting this file lets a self-signed/private server verify fully
- * (chain + hostname/SAN) without disabling verification (AIMEE_TLS_INSECURE). */
+ * without disabling verification (AIMEE_TLS_INSECURE). */
 static int pinned_ca_path(char *out, size_t n)
 {
    const char *home = aimee_home();
@@ -94,6 +94,37 @@ static int pinned_ca_path(char *out, size_t n)
    return (stat(out, &st) == 0 && S_ISREG(st.st_mode)) ? 1 : 0;
 }
 
+/* Load the pinned certificate itself (first PEM cert in remote-ca.pem), or NULL. */
+static X509 *pinned_cert_load(const char *path)
+{
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return NULL;
+   X509 *cert = PEM_read_X509(f, NULL, NULL, NULL);
+   fclose(f);
+   return cert;
+}
+
+/* Pinned-mode verify: the identity is an EXACT leaf match against the TOFU-
+ * pinned certificate (SSH known_hosts semantics). Hostname/SAN is deliberately
+ * NOT consulted: a containerized/NAT'd server cannot know its reachable
+ * host address at cert-mint time, so its self-signed cert routinely lacks the
+ * SAN the client dials — while the byte-exact pin is already a STRONGER
+ * identity than any name match (a MITM cannot present the pinned cert without
+ * its private key; any other cert, even one validly chaining to a public CA,
+ * fails the compare). Chain/time preverify results are likewise subordinate to
+ * the pin at the leaf, exactly like an SSH host key. */
+static int pin_leaf_verify_cb(int preverify_ok, X509_STORE_CTX *xctx)
+{
+   (void)preverify_ok;
+   if (X509_STORE_CTX_get_error_depth(xctx) > 0)
+      return 1; /* only the leaf decides in pinned mode */
+   SSL *ssl = X509_STORE_CTX_get_ex_data(xctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+   X509 *pin = ssl ? (X509 *)SSL_get_app_data(ssl) : NULL;
+   X509 *leaf = X509_STORE_CTX_get_current_cert(xctx);
+   return (pin && leaf && X509_cmp(pin, leaf) == 0) ? 1 : 0;
+}
+
 aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 {
    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
@@ -102,27 +133,34 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
 
    int insecure = tls_insecure();
+   X509 *pinned = NULL;
    if (!insecure)
    {
       char pin[600];
       if (pinned_ca_path(pin, sizeof(pin)))
       {
          /* Strict pin: a recorded cert means a self-signed/private server, so
-          * trust ONLY that cert and NOT the system store — a mis-issued or
+          * trust ONLY that exact cert and NOT the system store — a mis-issued or
           * compromised public-CA cert for the same host is then still rejected.
           * A pin that won't load fails the connection CLOSED rather than silently
-          * widening trust back to the system store. */
-         if (SSL_CTX_load_verify_locations(ctx, pin, NULL) != 1)
+          * widening trust back to the system store. Identity is decided by
+          * pin_leaf_verify_cb (exact leaf match); hostname/SAN is not consulted
+          * in pinned mode — see the callback's rationale. */
+         pinned = pinned_cert_load(pin);
+         if (!pinned || SSL_CTX_load_verify_locations(ctx, pin, NULL) != 1)
          {
+            if (pinned)
+               X509_free(pinned);
             SSL_CTX_free(ctx);
             return NULL;
          }
+         SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, pin_leaf_verify_cb);
       }
       else
       {
          SSL_CTX_set_default_verify_paths(ctx); /* publicly-trusted servers */
+         SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
       }
-      SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
    }
 
    aimee_tls_present_client_cert(ctx);
@@ -130,24 +168,29 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    SSL *ssl = SSL_new(ctx);
    if (!ssl)
    {
+      if (pinned)
+         X509_free(pinned);
       SSL_CTX_free(ctx);
       return NULL;
    }
    SSL_set_fd(ssl, fd);
+   if (pinned)
+      SSL_set_app_data(ssl, pinned); /* consumed by pin_leaf_verify_cb */
    if (host && *host)
    {
       SSL_set_tlsext_host_name(ssl, host); /* SNI */
-      if (!insecure)
+      if (!insecure && !pinned)
       {
          X509_VERIFY_PARAM *param = SSL_get0_param(ssl);
          X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
          /* An IP-literal host (e.g. a private server reached by address) must be
           * matched against the cert's IP-address SANs: set1_host only matches DNS
           * names/CN, so an IP would otherwise fail the name check even with a
-          * valid/pinned cert. set1_ip_asc returns 1 only for a real IP literal;
+          * valid cert. set1_ip_asc returns 1 only for a real IP literal;
           * fall back to DNS-name matching for actual hostnames. If neither arms
           * the name check, fail CLOSED — verifying the chain but not the identity
-          * would accept any otherwise-valid cert. */
+          * would accept any otherwise-valid cert. (Pinned mode skips this: the
+          * exact-leaf pin IS the identity.) */
          if (X509_VERIFY_PARAM_set1_ip_asc(param, host) != 1 &&
              X509_VERIFY_PARAM_set1_host(param, host, 0) != 1)
          {
@@ -158,7 +201,13 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
       }
    }
 
-   if (SSL_connect(ssl) != 1)
+   int connected = (SSL_connect(ssl) == 1);
+   if (pinned)
+   {
+      SSL_set_app_data(ssl, NULL); /* the handshake (and its verify) is done */
+      X509_free(pinned);
+   }
+   if (!connected)
    {
       SSL_free(ssl);
       SSL_CTX_free(ctx);

--- a/src/aimee_tls_schannel.c
+++ b/src/aimee_tls_schannel.c
@@ -218,12 +218,13 @@ static int pinned_leaf_matches(PCCERT_CONTEXT cert)
  * against the pinned self-signed cert at <aimee_home>/remote-ca.pem. Returns 0 on
  * success, -1 on any failure.
  *
- * Two accept paths, hostname/SAN enforced in BOTH (matching the OpenSSL backend):
- *   1. System trust: the chain builds to a trusted root AND the name matches.
- *   2. Pinned: the system chain is untrusted (unknown CA / self-signed), so we
- *      ignore ONLY that error in a second name-checking policy run AND require the
- *      leaf to byte-match remote-ca.pem (strict leaf pin). A different cert fails
- *      the DER compare; a wrong hostname fails the still-enforced name check. */
+ * Two accept paths (matching the OpenSSL backend):
+ *   1. Pinned: the leaf byte-matches remote-ca.pem (strict leaf pin). This alone
+ *      IS the identity (SSH known_hosts semantics) — hostname/SAN is deliberately
+ *      not consulted, because a containerized/NAT'd server cannot know its
+ *      reachable address at cert-mint time, and a MITM cannot present the pinned
+ *      cert without its private key.
+ *   2. System trust: the chain builds to a trusted root AND the name matches. */
 static int verify_server_cert(aimee_tls_t *t)
 {
    /* Fail closed if there is no hostname to verify against: a NULL pwszServerName
@@ -235,6 +236,13 @@ static int verify_server_cert(aimee_tls_t *t)
    PCCERT_CONTEXT cert = NULL;
    if (QueryContextAttributes(&t->ctx, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &cert) != SEC_E_OK || !cert)
       return -1;
+
+   /* Path 1: exact-leaf pin decides the identity on its own. */
+   if (pinned_leaf_matches(cert))
+   {
+      CertFreeCertificateContext(cert);
+      return 0;
+   }
 
    int ok = -1;
    PCCERT_CHAIN_CONTEXT chain = NULL;
@@ -258,10 +266,7 @@ static int verify_server_cert(aimee_tls_t *t)
       }
 
       if (ssl_policy_check(chain, whost, 0) == 0)
-         ok = 0; /* path 1: trusted system root + name match */
-      else if (pinned_leaf_matches(cert) &&
-               ssl_policy_check(chain, whost, SECURITY_FLAG_IGNORE_UNKNOWN_CA) == 0)
-         ok = 0; /* path 2: strict leaf pin + name match (untrusted root ignored) */
+         ok = 0; /* path 2: trusted system root + name match */
 
       CertFreeCertificateChain(chain);
    }

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -344,49 +344,40 @@ static SecCertificateRef securetransport_load_pinned_cert(const char *path)
    return cert;
 }
 
-/* During a BreakOnServerAuth handshake, manually evaluate the peer's trust so
- * that BOTH the system anchors AND the pinned cert are accepted, with the
- * SSL/hostname policy bound to |host|. Returns 1 if trusted, 0 otherwise.
- *
- * IP-literal hosts: SecPolicyCreateSSL is given the host string verbatim; when
- * that string is an IP literal, the SSL trust policy matches it against the
- * cert's iPAddress SANs (aimee is commonly reached by IP with an IP-SAN cert),
- * and against dNSName SANs/CN for real DNS names. (Could not be exercised here
- * without running on macOS — see the report's caveats.) */
+/* During a BreakOnServerAuth handshake, decide the pinned-mode trust: the
+ * identity is an EXACT leaf match against the TOFU-pinned certificate (SSH
+ * known_hosts semantics), matching the OpenSSL and Windows backends. The
+ * hostname/SAN policy is deliberately NOT consulted: a containerized/NAT'd
+ * server cannot know its reachable address at cert-mint time, so its
+ * self-signed cert routinely lacks the SAN the client dials — while the
+ * byte-exact pin is a stronger identity than any name match (a MITM cannot
+ * present the pinned cert without its private key; any other cert, even a
+ * validly-issued one, fails the DER compare). Returns 1 if trusted, 0 not.
+ * (|host| is retained in the signature for symmetry/logging call sites.) */
 static int securetransport_eval_pinned_trust(SSLContextRef ctx, const char *host,
                                              SecCertificateRef pinned)
 {
+   (void)host;
    SecTrustRef trust = NULL;
    if (SSLCopyPeerTrust(ctx, &trust) != noErr || !trust)
       return 0;
 
    int ok = 0;
-   CFStringRef cf_host = CFStringCreateWithCString(NULL, host, kCFStringEncodingUTF8);
-   SecPolicyRef policy = cf_host ? SecPolicyCreateSSL(true, cf_host) : NULL;
-   if (policy && SecTrustSetPolicies(trust, policy) == errSecSuccess)
+   SecCertificateRef leaf =
+       (SecTrustGetCertificateCount(trust) > 0) ? SecTrustGetCertificateAtIndex(trust, 0) : NULL;
+   if (leaf && pinned)
    {
-      const void *anchors[] = {pinned};
-      CFArrayRef anchor_arr = CFArrayCreate(NULL, anchors, 1, &kCFTypeArrayCallBacks);
-      /* Strict pin: SecTrustSetAnchorCertificatesOnly(true) trusts ONLY the pinned
-       * cert (not the system anchors) for this evaluation — matching the OpenSSL
-       * (load-pin-only) and Windows (leaf-DER) backends. A recorded pin means a
-       * self-signed/private server, so a mis-issued public-CA cert for the same
-       * host is still rejected. The hostname/SAN policy above remains enforced. */
-      if (anchor_arr && SecTrustSetAnchorCertificates(trust, anchor_arr) == errSecSuccess &&
-          SecTrustSetAnchorCertificatesOnly(trust, true) == errSecSuccess)
-      {
-         CFErrorRef err = NULL;
-         ok = SecTrustEvaluateWithError(trust, &err) ? 1 : 0;
-         if (err)
-            CFRelease(err);
-      }
-      if (anchor_arr)
-         CFRelease(anchor_arr);
+      CFDataRef leaf_der = SecCertificateCopyData(leaf);
+      CFDataRef pin_der = SecCertificateCopyData(pinned);
+      if (leaf_der && pin_der && CFDataGetLength(leaf_der) == CFDataGetLength(pin_der) &&
+          memcmp(CFDataGetBytePtr(leaf_der), CFDataGetBytePtr(pin_der),
+                 (size_t)CFDataGetLength(leaf_der)) == 0)
+         ok = 1;
+      if (leaf_der)
+         CFRelease(leaf_der);
+      if (pin_der)
+         CFRelease(pin_der);
    }
-   if (policy)
-      CFRelease(policy);
-   if (cf_host)
-      CFRelease(cf_host);
    CFRelease(trust);
    return ok;
 }

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -194,9 +194,13 @@ static int remote_enroll(const char *url, char *out, size_t out_sz, int json_out
    {
       if (st == 401 && !json_output)
          fprintf(stderr,
-                 "  enroll: the server rejected the bootstrap token (already enrolled by another "
-                 "client?).\n         Copy the strong bearer from the enrolled client into "
-                 "remote.conf, or re-seed the server.\n");
+                 "  enroll: the server rejected the bootstrap token — it was already consumed by "
+                 "the first\n         enrolled client (one-shot TOFU). The strong bearer is "
+                 "persisted on the server in\n         <AIMEE_HOME>/aimee.yaml under "
+                 "aimee.api.bearer_token — copy it into this client with\n         `aimee remote "
+                 "set <url> <token>`; or rotate a fresh one from an already-enrolled\n         "
+                 "client (`aimee remote enroll`); or re-seed the server's bearer_token to the\n"
+                 "         bootstrap value to re-open one-shot enrollment.\n");
       free(body);
       return -1;
    }

--- a/src/headers/wfe_live_delegate.h
+++ b/src/headers/wfe_live_delegate.h
@@ -13,11 +13,12 @@ void wfe_autonomy_register(void);
 
 #include "agent_config.h"
 
-/* Resolve a workflow step's delegate name to a concrete agent. "" -> "" (route
- * by role); a specific name -> itself; the sentinel "$random" -> a uniformly
- * random ENABLED agent from `acfg`. Returns 0 on success (out filled, possibly
- * ""), -1 if "$random" but no enabled agent exists (fail fast — never leak the
- * sentinel). */
+/* Resolve a workflow step's delegate name to a concrete agent. A specific name
+ * -> itself; "" (no per-step delegate) and the sentinel "$random" both -> a
+ * uniformly random ENABLED agent from `acfg` — an unnamed delegate means "any
+ * agent", not "the same first-in-roster agent every dispatch". Returns 0 on
+ * success (out filled), -1 if no enabled agent exists (fail fast — never leak
+ * the sentinel). */
 int wfe_resolve_delegate(const char *name, agent_config_t *acfg, char *out, size_t outn);
 
 /* Seed the $random selector for deterministic tests. */

--- a/src/server/wfe_delegate_resolve.c
+++ b/src/server/wfe_delegate_resolve.c
@@ -44,7 +44,7 @@ int wfe_resolve_delegate(const char *name, agent_config_t *acfg, char *out, size
    if (out && outn)
       out[0] = '\0';
    if (!name || !name[0])
-      return 0; /* no per-step delegate -> route by role */
+      name = "$random"; /* no per-step delegate -> random over the enabled roster */
    if (strcmp(name, "$random") != 0)
    {
       if (out)

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -95,13 +95,15 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
       return -1;
    }
 
-   /* Resolve the step's delegate ("$random" -> a random roster agent; "" -> route
-    * by role). Fail fast rather than leak the sentinel downstream. */
+   /* Resolve the step's delegate: a specific name -> itself; "" and "$random"
+    * -> a uniformly random ENABLED roster agent (an unnamed delegate means "any
+    * agent", so successive dispatches assort across the roster instead of
+    * pinning to one). Fail fast rather than leak the sentinel downstream. */
    char agent_name[MAX_AGENT_NAME] = "";
    if (wfe_resolve_delegate(delegate, &acfg, agent_name, sizeof agent_name) != 0)
    {
       if (err && errlen)
-         snprintf(err, errlen, "wfe live delegate: no enabled agent for '$random'");
+         snprintf(err, errlen, "wfe live delegate: no enabled agent in the roster");
       return -1;
    }
 
@@ -113,77 +115,28 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
     * agent can serve. */
    const char *persona = (role && role[0]) ? role : "engineer";
    char *sys_prompt = persona_compose_delegate_prompt(persona, workdir, "");
-   persona_t pinfo;
-   memset(&pinfo, 0, sizeof pinfo);
-   persona_load(NULL, persona, &pinfo);
 
    /* Run WITH TOOLS, pinned to the work-item worktree, so file edits land there.
-    * A specific agent runs by name; otherwise route by persona. */
+    * The resolve above always yields a concrete agent name, so dispatch is
+    * uniformly by name; an unroutable pick fails here and the block's retry
+    * loop re-rolls a different agent. */
    run_cmd_set_cwd(workdir);
    agent_result_t res;
    memset(&res, 0, sizeof(res));
    int rc;
-   if (agent_name[0])
+   agent_t *ag = agent_find(&acfg, agent_name);
+   if (!ag)
    {
-      agent_t *ag = agent_find(&acfg, agent_name);
-      if (!ag)
-      {
-         run_cmd_set_cwd(NULL);
-         free(sys_prompt);
-         persona_free(&pinfo);
-         if (err && errlen)
-            snprintf(err, errlen, "wfe live delegate: unknown delegate '%s'", agent_name);
-         return -1;
-      }
-      rc = agent_execute_with_tools(ag, &acfg.network, sys_prompt ? sys_prompt : "", prompt,
-                                    AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
+      run_cmd_set_cwd(NULL);
+      free(sys_prompt);
+      if (err && errlen)
+         snprintf(err, errlen, "wfe live delegate: unknown delegate '%s'", agent_name);
+      return -1;
    }
-   else
-   {
-      /* Route by the persona's allowed roles (ordered by preference): for the
-       * first role that ANY healthy, persona-eligible agent serves, pick the
-       * lowest-cost-tier such agent. Scanning every agent per role (not just
-       * agent_route's single best) means a persona-ineligible best-tier agent
-       * can't shadow an eligible one that serves the same role. */
-      agent_t *chosen = NULL;
-      const char *chosen_role = NULL;
-      int best_tier = 0;
-      for (int ri = 0; ri < pinfo.roles_count && !chosen; ri++)
-      {
-         const char *r = delegate_role_canonicalize(pinfo.roles[ri]);
-         for (int ai = 0; ai < acfg.agent_count; ai++)
-         {
-            agent_t *ag = &acfg.agents[ai];
-            if (!ag->enabled || !agent_has_role(ag, r) || !agent_supports_persona(ag, persona) ||
-                !agent_is_available_for_routing(ag))
-               continue;
-            if (provider_catalog_get_health(ag->name) == CATALOG_HEALTH_DOWN)
-               continue;
-            if (!chosen || ag->cost_tier < best_tier)
-            {
-               chosen = ag;
-               chosen_role = r;
-               best_tier = ag->cost_tier;
-            }
-         }
-      }
-      if (!chosen)
-      {
-         run_cmd_set_cwd(NULL);
-         free(sys_prompt);
-         persona_free(&pinfo);
-         if (err && errlen)
-            snprintf(err, errlen, "wfe live delegate: no enabled agent eligible for persona '%s'",
-                     persona);
-         return -1;
-      }
-      rc = agent_execute_with_tools_for_role(chosen, &acfg.network, chosen_role,
-                                             sys_prompt ? sys_prompt : "", prompt,
-                                             AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
-   }
+   rc = agent_execute_with_tools(ag, &acfg.network, sys_prompt ? sys_prompt : "", prompt,
+                                 AGENT_DEFAULT_MAX_TOKENS, 0.3, &res);
    run_cmd_set_cwd(NULL);
    free(sys_prompt);
-   persona_free(&pinfo);
 
    if (rc != 0)
    {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -298,6 +298,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-bootstrap \
                $(TESTPREFIX)/unit-test-pki \
                $(TESTPREFIX)/unit-test-aimee-tls-clientcert \
+               $(TESTPREFIX)/unit-test-aimee-tls-pin \
                $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-vault-capability \
                $(TESTPREFIX)/unit-test-agent-key-import \
@@ -3142,6 +3143,11 @@ $(TESTPREFIX)/unit-test-vault-server-key: $(OBJDIR)/tests/test_vault_server_key.
 
 $(TESTPREFIX)/unit-test-aimee-tls-clientcert: $(OBJDIR)/tests/test_aimee_tls_clientcert.o \
                               $(OBJDIR)/aimee_tls.o $(OBJDIR)/aimee_home.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-aimee-tls-pin: $(OBJDIR)/tests/test_aimee_tls_pin.o \
+                              $(OBJDIR)/aimee_tls.o $(OBJDIR)/kb/pki.o \
+                              $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-vault-capability: $(OBJDIR)/tests/test_vault_capability.o \

--- a/src/tests/test_aimee_tls_pin.c
+++ b/src/tests/test_aimee_tls_pin.c
@@ -1,0 +1,157 @@
+/* test_aimee_tls_pin.c — TOFU pin-is-identity for the thin client's TLS.
+ *
+ * A pinned server certificate (<aimee_home>/remote-ca.pem, written by
+ * `aimee remote set/trust`) must be accepted on an EXACT leaf match alone —
+ * SSH known_hosts semantics — with the hostname/SAN check waived: a
+ * containerized/NAT'd aimee-server cannot know its reachable LAN address at
+ * cert-mint time, so its self-signed cert routinely lacks the SAN the client
+ * dials (the 192.168.1.254 appliance failure). Any OTHER cert must still be
+ * rejected, pinned or not. Real handshakes over a socketpair, mirroring
+ * test_kb_tls.c. */
+#include "aimee_tls.h"
+#include "kb_pki.h"
+
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+
+#include <assert.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static char g_home[256];
+
+static void write_pin(const char *cert_pem)
+{
+   char p[320];
+   snprintf(p, sizeof(p), "%s/remote-ca.pem", g_home);
+   FILE *f = fopen(p, "w");
+   assert(f);
+   fputs(cert_pem, f);
+   fclose(f);
+}
+
+static void remove_pin(void)
+{
+   char p[320];
+   snprintf(p, sizeof(p), "%s/remote-ca.pem", g_home);
+   unlink(p);
+}
+
+/* Plain server-auth TLS server context from PEM strings (no client-cert
+ * requirement — the thin client presents none here). */
+static SSL_CTX *server_ctx_from_pem(const char *cert_pem, const char *key_pem)
+{
+   SSL_CTX *ctx = SSL_CTX_new(TLS_server_method());
+   assert(ctx);
+   BIO *cb = BIO_new_mem_buf(cert_pem, -1);
+   X509 *crt = PEM_read_bio_X509(cb, NULL, NULL, NULL);
+   BIO_free(cb);
+   BIO *kb = BIO_new_mem_buf(key_pem, -1);
+   EVP_PKEY *key = PEM_read_bio_PrivateKey(kb, NULL, NULL, NULL);
+   BIO_free(kb);
+   assert(crt && key);
+   assert(SSL_CTX_use_certificate(ctx, crt) == 1);
+   assert(SSL_CTX_use_PrivateKey(ctx, key) == 1);
+   X509_free(crt);
+   EVP_PKEY_free(key);
+   return ctx;
+}
+
+static void *server_thread(void *a)
+{
+   SSL *ssl = (SSL *)a;
+   /* A rejected client aborts mid-handshake; SSL_accept failing is fine. */
+   if (SSL_accept(ssl) == 1)
+      SSL_shutdown(ssl);
+   return NULL;
+}
+
+/* Full handshake: aimee_tls_connect() as the client against an in-process
+ * server. Returns 1 when the client accepted the server's identity. */
+static int client_accepts(SSL_CTX *server_ctx, const char *host)
+{
+   int sv[2];
+   assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+   SSL *s = SSL_new(server_ctx);
+   assert(s);
+   SSL_set_fd(s, sv[0]);
+   pthread_t th;
+   assert(pthread_create(&th, NULL, server_thread, s) == 0);
+
+   aimee_tls_t *t = aimee_tls_connect(sv[1], host);
+   int ok = (t != NULL);
+   aimee_tls_free(t);
+   /* Close the client fd BEFORE joining: a client that aborted the handshake
+    * leaves the server blocked in SSL_accept until it sees EOF. */
+   close(sv[1]);
+   pthread_join(th, NULL);
+   SSL_free(s);
+   close(sv[0]);
+   return ok;
+}
+
+int main(void)
+{
+   setvbuf(stdout, NULL, _IONBF, 0);
+   signal(SIGPIPE, SIG_IGN); /* an aborted handshake writes into a closed pipe */
+   printf("aimee_tls_pin:\n");
+
+   /* Isolated home so remote-ca.pem is under test control; strict verification
+    * (the insecure escape hatch must not mask a verify failure). */
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-tlspin-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   setenv("AIMEE_HOME", g_home, 1);
+   unsetenv("AIMEE_TLS_INSECURE");
+
+   /* A self-signed-CA server cert for "kb.local" — its SANs cover kb.local and
+    * loopback, NOT the address the client dials below (the NAT/appliance case). */
+   kb_pki_ca_t ca;
+   assert(kb_pki_ca_generate(&ca) == 0);
+   char scert[KB_PKI_CERT_PEM_MAX], skey[KB_PKI_KEY_PEM_MAX];
+   assert(kb_pki_issue_server_cert(&ca, "kb.local", 3600, scert, sizeof(scert), skey,
+                                   sizeof(skey)) == 0);
+   SSL_CTX *server = server_ctx_from_pem(scert, skey);
+
+   /* 1. Pin == leaf, dialed by an address ABSENT from the cert's SANs: the pin
+    *    is the identity, so the handshake must succeed (the regression). */
+   write_pin(scert);
+   assert(client_accepts(server, "203.0.113.9") == 1);
+   printf("  pin_match_san_mismatch_accepted: ok\n");
+
+   /* 2. Pin == leaf, matching hostname: still accepted (sanity). */
+   assert(client_accepts(server, "kb.local") == 1);
+   printf("  pin_match_name_match_accepted: ok\n");
+
+   /* 3. Pin holds a DIFFERENT cert: the server must be rejected even though its
+    *    name matches — only the pinned leaf is acceptable in pinned mode. */
+   {
+      kb_pki_ca_t other;
+      assert(kb_pki_ca_generate(&other) == 0);
+      char ocert[KB_PKI_CERT_PEM_MAX], okey[KB_PKI_KEY_PEM_MAX];
+      assert(kb_pki_issue_server_cert(&other, "kb.local", 3600, ocert, sizeof(ocert), okey,
+                                      sizeof(okey)) == 0);
+      write_pin(ocert);
+      assert(client_accepts(server, "kb.local") == 0);
+      printf("  pin_mismatch_rejected: ok\n");
+   }
+
+   /* 4. No pin: a self-signed server fails system-store verification. */
+   remove_pin();
+   assert(client_accepts(server, "kb.local") == 0);
+   printf("  unpinned_selfsigned_rejected: ok\n");
+
+   /* 5. Unparseable pin fails CLOSED (no silent fallback to the system store). */
+   write_pin("not a certificate\n");
+   assert(client_accepts(server, "kb.local") == 0);
+   printf("  corrupt_pin_fails_closed: ok\n");
+
+   SSL_CTX_free(server);
+   printf("aimee_tls_pin: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_wfe_random_delegate.c
+++ b/src/tests/test_wfe_random_delegate.c
@@ -14,8 +14,7 @@ int main(void)
    printf("wfe-random-delegate: ");
    char out[64];
 
-   /* Empty / specific names pass through. */
-   assert(wfe_resolve_delegate("", NULL, out, sizeof out) == 0 && out[0] == '\0');
+   /* Specific names pass through. */
    assert(wfe_resolve_delegate("mistral", NULL, out, sizeof out) == 0 &&
           strcmp(out, "mistral") == 0);
 
@@ -47,10 +46,28 @@ int main(void)
    }
    assert(saw_alpha && saw_gamma); /* both enabled agents reachable */
 
-   /* Empty roster -> fail fast (never leak "$random"). */
+   /* An UNNAMED delegate ("") routes through the same random selector — it
+    * means "any enabled agent", never a fixed roster-order pick. */
+   int e_alpha = 0, e_gamma = 0;
+   for (unsigned s = 1; s <= 20; s++)
+   {
+      wfe_resolve_delegate_seed(s);
+      assert(wfe_resolve_delegate("", &acfg, out, sizeof out) == 0);
+      assert(strcmp(out, "beta") != 0); /* disabled excluded */
+      assert(strcmp(out, "alpha") == 0 || strcmp(out, "gamma") == 0);
+      if (!strcmp(out, "alpha"))
+         e_alpha = 1;
+      if (!strcmp(out, "gamma"))
+         e_gamma = 1;
+   }
+   assert(e_alpha && e_gamma);
+
+   /* Empty roster -> fail fast (never leak "$random"), named or unnamed. */
    agent_config_t empty;
    memset(&empty, 0, sizeof empty);
    assert(wfe_resolve_delegate("$random", &empty, out, sizeof out) == -1);
+   assert(out[0] == '\0');
+   assert(wfe_resolve_delegate("", &empty, out, sizeof out) == -1);
    assert(out[0] == '\0');
 
    printf("ok\n");

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -892,8 +892,9 @@ static int run_fanout_units(const char *wd, const wfe_node_t *node, double *cost
       int ok = 0;
       for (long attempt = 0; attempt <= retry_max && !ok; attempt++)
       {
-         /* retry-DIFFERENT-delegate: the first attempt uses the pinned delegate;
-          * retries use $random so a fresh perspective takes over (Q2). */
+         /* retry-DIFFERENT-delegate: the first attempt uses the pinned delegate
+          * (an unnamed one resolves to a random roster agent); retries force
+          * $random so a fresh perspective takes over (Q2). */
          const char *deleg = (attempt == 0) ? node_delegate(node) : "$random";
          char uc[64] = "";
          if (wfe_delegate_dispatch(wd, "engineer", deleg, prompt, NULL, uc, cost) < 0)

--- a/src/workflow/wfe_engine.c
+++ b/src/workflow/wfe_engine.c
@@ -274,13 +274,17 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
 
    /* --- atomic critical section: cost reservation + step + state update.
     * Fail closed: if we cannot open the transaction we must NOT mutate the
-    * work item outside it (a half-applied step would corrupt the ledger). --- */
-   if (db1_lifecycle_txn_begin() != 0)
-   {
-      snprintf(err, errlen, "could not begin advance transaction");
-      wfe_def_free(def);
-      return -1;
-   }
+    * work item outside it (a half-applied step would corrupt the ledger).
+    *
+    * SCOPE: the transaction covers ONLY the post-executor state writes — it
+    * must NEVER span the executor itself. A live executor runs delegates for
+    * MINUTES; holding BEGIN IMMEDIATE on the shared db1 connection for that
+    * long makes every concurrent write on the connection (operator
+    * pause/resume, other items' events, trigger state) silently JOIN the open
+    * transaction: invisible to other readers until this step commits, and
+    * DISCARDED WHOLESALE if it rolls back (observed live: operator resumes
+    * that returned 200 yet never persisted, and a WAL frozen for the length
+    * of an implement stage). --- */
 
    /* Every state-mutating DB write below is checked; on ANY failure we roll the
     * whole step back (goto txn_fail) so the work item is never left advanced but
@@ -293,9 +297,16 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
          goto txn_fail;                                                                            \
    } while (0)
 
-   /* cost pre-flight (estimate is 0 for stubs; executors report actuals). */
+   /* cost pre-flight (estimate is 0 for stubs; executors report actuals).
+    * Its pause+event pair rides a short transaction of its own. */
    if (wi.work_item_max_cost_usd > 0 && wi.cum_cost_usd >= wi.work_item_max_cost_usd)
    {
+      if (db1_lifecycle_txn_begin() != 0)
+      {
+         snprintf(err, errlen, "could not begin advance transaction");
+         wfe_def_free(def);
+         return -1;
+      }
       WFE_CKW(db1_work_item_set_pause(work_item_id, "budget_exceeded", node->id));
       db1_lifecycle_event_add(work_item_id, node->id, "pause", "engine", "budget_exceeded", "", 0);
       db1_lifecycle_txn_commit();
@@ -306,11 +317,24 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
       return 0;
    }
 
+   /* The executor runs OUTSIDE any transaction (see scope note above). Its own
+    * incidental db1 writes (attempt counters, loop audit events) auto-commit
+    * individually, which is strictly better than riding a step txn that a later
+    * write failure would erase. */
    wfe_ctx ctx = {work_item_id, def, node, &wi};
    wfe_step_result_t r = fn(&ctx, node);
    out->last_status = r.status;
    out->failure_class = r.failure_class;
    out->failure_has_new_input = r.failure_has_new_input;
+
+   /* --- atomic critical section: cost + step outcome + state update. Held only
+    * for these writes (milliseconds), never across the executor above. --- */
+   if (db1_lifecycle_txn_begin() != 0)
+   {
+      snprintf(err, errlen, "could not begin advance transaction");
+      wfe_def_free(def);
+      return -1;
+   }
    if (r.cost_usd > 0)
       WFE_CKW(db1_work_item_add_cost(work_item_id, r.cost_usd));
    /* post-executor budget re-check: a single step's cost can push over the cap,


### PR DESCRIPTION
Promotes 10 commits. Headline: the arm64 fix for the combined appliance.

## aimee-combined arm64 runtime fix (PR #1323)
v0.2.191's arm64 aimee-combined cannot start its bundled llama.cpp: upstream's ubuntu-vulkan-arm64 tarball needs GLIBC_2.38/GLIBCXX_3.4.32 but the final image was bookworm (glibc 2.36). Final stage moves to debian:trixie-slim (matching Dockerfile.aimee-llm) with the t64 package renames.

Verified end-to-end on real hardware (qemu-user arm64 smoke on the Proxmox host, image sha-26fa341): container healthy, all three llama-servers up, gateway dim=1024, real embed vectors and sane rerank scores, models pre-baked (no first-boot download).

## Also included
- TLS: TOFU pin is the identity — exact leaf match accepted without SAN (#1321)
- e2e: thin-client adoption flow + parallel CI e2e matrix, ~29min → ~14min wall-clock (#1324)
- wfe: unnamed step delegates resolve via the $random selector (#1322); advance transaction never held across the executor (#1326)