### PR TITLE
docs(proposals): persona-authored outputs and permission roles

### DIFF
--- a/docs/proposals/pending/persona-authored-outputs.md
+++ b/docs/proposals/pending/persona-authored-outputs.md
@@ -1,0 +1,154 @@
+# Persona-authored outputs and permission roles
+
+## Why
+
+Personas decide who *reviews*, not who *writes*. The prose a workflow run
+ships is authored by accident or not at all: `pr.open` sends the work-item
+text as the PR title and an empty body, commit messages come from whichever
+producing delegate happens to run (and on the live path the harness commit
+overwrites them with a hardcoded message), and the `document` block
+hardcodes the `engineer` persona while `technical-writer` only reviews the
+result.
+
+The seams that would fix this are load-bearing in the wrong places. A
+persona's stance is welded into its prose: every reviewer built-in says
+"You report findings; you do not edit the code" in its identity paragraph,
+so asking `technical-writer` to author anything composes a
+self-contradictory prompt. A role's capability is a hardcoded name list
+(`delegate_role_is_write()`), disconnected from what the work needs. And
+delegates are addressed by (role template, persona name) pairs, so callers
+hardwire *who* instead of *what capabilities the job requires*.
+
+One model change fixes all of this. Roles become permissions. Delegates
+advertise permissions. A persona declares the permissions it requires, and
+any delegate that covers them is a valid target. Stance is generated from
+the granted permissions instead of baked into prose. On that footing,
+routing "the technical writer writes the commit messages, the PR messages,
+and the docs" is config and workflow YAML, not prompt surgery.
+
+## What
+
+### Part A — roles are permissions
+
+1. A role is a permission set drawn from `read`, `write`, `execute`. The
+   source of truth is a built-in permission table in code, one row per
+   built-in role, replacing `delegate_role_is_write()`'s name list. An
+   on-disk role template may override its grant with `permissions:`
+   frontmatter; unknown tokens are rejected at load and a missing or empty
+   grant means read-only. Grants are resolved once per dispatch, never by
+   file I/O inside a write gate. `aimee delegate <role>` keeps working: the
+   role name resolves to (template, permission set).
+2. Capability behavior derives from the grant. Write-gating and
+   tool-enablement both follow it (a `write` or `execute` grant turns tools
+   on), so a granted permission is honored end to end. The per-role
+   economics heuristics (result cache, turn caps, early-final) stay
+   name-keyed by design; they are cost policy, not capability.
+3. Delegates are defined by roles, not personas. A delegate's granted set
+   is the union of its roles' grants. A persona's frontmatter gains
+   `requires:` — the permissions it needs (reviewer built-ins `[read]`,
+   engineer `[read, write, execute]`). A delegate is a valid target for a
+   persona iff its grants cover the persona's requirements, on both the CLI
+   and workflow dispatch paths; a workflow-named delegate that fails
+   coverage is rejected with a named error rather than silently accepted.
+   The persona `roles:` advertisement is
+   retired in favor of `requires:` plus coverage; `delegates:
+   full|readonly|none` remains as the ceiling on what a persona's own
+   delegates may be granted.
+4. Callers cannot name a persona. `--persona` on `aimee delegate` and the
+   `persona` property on the MCP `delegate` tool are deprecated: accepted
+   and ignored with a warning for one release, then removed. A delegate
+   runs as the dispatching context's persona — the workflow node's
+   `persona:` param, else the session persona, else `default_persona`, else
+   `engineer`. Context selects the persona; delegates never target one.
+5. Stance is generated, not written. The composer receives the granted
+   permission set and emits the stance block itself: without `write`,
+   "report findings, do not edit"; with `write`, authoring framing. The
+   built-in persona prose is re-authored stance-neutral — the stance
+   sentences, the read-only delegation blocks, and every literal
+   `--persona` example are removed from the prompt bodies. Seeded persona
+   files are versioned and re-seeded so stale review-framed copies do not
+   override the re-authored built-ins; the release embeds the prior seed
+   content hashes so pristine legacy files are distinguishable from
+   user-edited ones, which are preserved.
+
+### Part B — persona-authored outputs
+
+6. `pr.open` writes real PR text. The executor dispatches one
+   read-granted delegate as the node's `persona:` param (default
+   `technical-writer`) over the branch log and diffstat. The reply comes
+   back through a temporary out-of-tree artifact file; read-granted
+   dispatches never auto-commit. The executor validates the reply: first
+   line becomes the title (non-empty, single line), the rest the body. On
+   dispatch failure, garbage output, or a forge `open()` rejection, it
+   retries once with today's arguments (work-item title, empty body).
+   Opening the PR never blocks on prose, and the no-provider path is
+   unchanged.
+7. `document` honors a per-node persona, read the same way the `implement`
+   block's TDD path already reads one, and the `build` composition sets
+   `persona: technical-writer` on its document node.
+8. Commit messages are delegate-authored, styled, and actually used. The
+   live dispatch path today commits with a hardcoded message; committing
+   dispatches will instead carry the structured delegate handoff, and the
+   harness commit consumes the `commit_message` it supplies. A new config
+   key, `commit_style_persona` (default `technical-writer`, empty
+   disables), appends that persona's voice guidance as a
+   "## Commit message style" block to every dispatch that commits:
+   `implement` (plain, fanout units, TDD), and `document`. The `author.*`
+   blocks produce prose artifacts, not commits, and are excluded. When a
+   delegate self-commits mid-run with its own git tools, the style block
+   guides it but the resulting message is best-effort.
+9. Voice becomes addressable. The built-in technical-writer's voice prose
+   is factored into a built-in voice field; `## Voice` joins the sections
+   parsed from persona files and the seeded output. A persona without a
+   voice makes `commit_style_persona` a logged no-op.
+10. Persona names and grants are validated. `aimee workflow validate`
+    rejects an unknown `persona:` on producing and `pr.open` nodes —
+    today a typo silently falls back to `engineer` — and template loading
+    rejects unknown permission tokens.
+11. Docs and help follow the interface: `docs/personas.md`,
+    `docs/DELEGATES.md`, `docs/WORKFLOW_ACTIONS.md`, the CLI help text,
+    and the generated command reference all drop `--persona` and document
+    the permission model.
+
+Out of scope: a general action→persona binding table, and any permission
+beyond `read`/`write`/`execute`. Mechanics — caller enumerations, file
+lists, signatures, migration, and the test seam — are in
+[persona-authored-outputs.plan.md](persona-authored-outputs.plan.md).
+
+## Acceptance
+
+- The built-in permission table reproduces today's write set exactly; a
+  template `permissions:` override is honored; an unknown token fails the
+  template load with a named error. `aimee delegate review "…"` still runs
+  read-only.
+- A `write` grant on a role outside today's tool-enable name list still
+  yields a delegate with write tools (grant honored end to end, unit-tested
+  through the runtime's write-capability path).
+- Coverage matching: a `[read]` delegate is a valid target for a reviewer
+  persona and an invalid target for a persona requiring `write`, on both
+  dispatch paths.
+- `--persona` / `persona` are accepted with a deprecation warning and
+  ignored; no built-in prompt or delegation block emits `--persona`
+  anywhere in the composed session or delegate prompts.
+- The composed prompt for a write-granted `technical-writer` dispatch
+  contains its identity and voice and no "do not edit" text; the same
+  persona composed read-only contains the generated read-only stance. A
+  stale seeded persona file is re-seeded on version bump and no longer
+  overrides the re-authored prose.
+- A `build` run opens its PR with a delegate-authored title and non-empty
+  body, and no extra commit lands on the branch from the PR-text dispatch.
+  With the dispatch failing, returning garbage, or the forge rejecting the
+  text, the PR still opens with the work-item title and empty body —
+  observed via the block-test forge recorder, not parked.
+- The commit created by a live-path dispatch carries the delegate-supplied
+  message, not the hardcoded one; with `commit_style_persona` set (and by
+  default) the message follows the styled prompt, and the resulting
+  message — not just the prompt — is asserted in tests. Config round-trips
+  through save/load like `default_persona`.
+- Setting `commit_style_persona` to a persona with no voice logs and
+  no-ops. `## Voice` in a persona file parses into the persona.
+- `aimee workflow validate` rejects an unknown `persona:` on `pr.open`,
+  `document`, and `implement` nodes with a named error.
+- Commit messages and PR bodies produced under the default binding contain
+  no AI-attribution trailers; the existing server/CI ban stays the outer
+  guard on both paths.

--- a/docs/proposals/pending/persona-authored-outputs.plan.md
+++ b/docs/proposals/pending/persona-authored-outputs.plan.md
@@ -1,0 +1,225 @@
+# persona-authored-outputs — implementation plan
+
+Mechanics for [persona-authored-outputs.md](persona-authored-outputs.md).
+Numbers refer to that document's What items. Paths are under `src/` unless
+noted; workflow-engine files live in `src/workflow/`.
+
+## A1 — permission table and grant resolution
+
+- New `delegate_role_permissions(role)` in `server/delegate_role.c`
+  returning a bitmask (`PERM_READ|PERM_WRITE|PERM_EXECUTE`). The table is
+  keyed on **canonical** role names (aliases resolve first via
+  `delegate_role_canonicalize`, so `test`→`validate`, `research`→`execute`
+  need no rows of their own). Rows seed today's behavior:
+  `code`, `refactor`, `prose`, `line-edit`, `lyric`, `hook` → rwx (the
+  current `delegate_role_is_write()` list, `delegate_role.c:54`);
+  `validate`, `execute` → r+x (they run commands);
+  `review`, `diagnose`, plus any canonical role with no row and no
+  template → r.
+- On-disk override: `permissions: [read, write]` frontmatter in
+  `<config>/role_templates/<role>.md`, parsed next to `max_turns:`
+  (`role_template_max_turns`, `role_templates.c:468`). Unknown token →
+  template load error; absent/empty grant → the table row, else `[read]`.
+- Grants are resolved once at dispatch setup and carried with the
+  dispatch; gate sites read the carried grant — no file I/O in
+  `server_compute.c` / `agent_runtime.c` hot paths.
+- Migrate every `delegate_role_is_write()` caller, then delete it:
+  `server_compute.c:1024,1167`, `agent_runtime.c:238,439,482`,
+  `agent_fallback.c:92`, `server_http.c:207`, `agent_loop.c:249`,
+  `cmd_agent_delegate.c:1715`.
+
+## A2 — capability from grant
+
+- `agent_runtime.c:234-238`: `use_tools` gains "or the grant carries
+  write|execute" alongside the name heuristic, so
+  `write_capable = use_tools && (grant & PERM_WRITE)` cannot self-cancel.
+  Invariant check before landing: no built-in write role self-cancels
+  today (each already reaches tools by name or explicit `--tools`); if one
+  does, this step is a behavior fix, not a no-op, and is called out in the
+  commit.
+- `delegate_role_result_cache_enabled`, `delegate_default_max_turns_for_role`,
+  `delegate_final_after_turns_for_role` stay name-keyed (economics).
+- The review-evidence and diff-bundle injections
+  (`server/delegate_prompt.c:1188,1486,1840`) keep their review-family
+  gate and additionally require a read-only grant: **read-only AND
+  review-family**, never read-only alone. Keying purely off read-only
+  would drag every read dispatch — including B6's PR-text dispatch — into
+  the diff-evidence guard, whose drift check can fail the dispatch.
+
+## A3 — coverage matching
+
+- Persona frontmatter: `requires: [read, ...]` parsed in `persona.c`
+  `load_file()` (additive key, like `roles:` today); built-ins get values
+  in `g_builtins` (`persona.c:103`): reviewers `[read]`, engineer
+  `[read, write, execute]`, novel/songwriter `[read, write]`.
+- A delegate agent's granted set = union of its advertised roles' grants
+  (`roles[]`/`exec_roles[]`, `delegate_role.c:24`).
+- Workflow producing path: agent selection today does **no** persona/role
+  matching — `wfe_resolve_delegate` (`server/wfe_delegate_resolve.c:42`)
+  resolves `$random`/named only, and `wfe_live_delegate_run` dispatches
+  whatever it returns. Coverage enforcement lands at that selection point:
+  the resolver (or the agent pick immediately after it) filters candidates
+  by `granted ⊇ persona.requires`. A workflow-named delegate that fails
+  coverage is rejected with a named dispatch error, not silently accepted;
+  no eligible delegate at all fails the dispatch the same way the no-agent
+  case does today.
+- Workflow judge path: `wfe_live_judge_run`'s agent loop
+  (`server/wfe_live_delegate.c:315-321`) is the one place that walks
+  `pinfo.roles[]`/`agent_supports_persona` today. It migrates to the same
+  coverage predicate when `roles[]` retires — left as-is it would see
+  `roles_count == 0`, choose no agent, and every judge dispatch would
+  fail closed.
+- CLI path: `delegate_agent_supports_role` filtering gains the same
+  coverage predicate.
+- `persona_t.roles[]` and its frontmatter key are parsed but ignored
+  (deprecation note in docs). `check_role`/`check_marker` unchanged.
+- `delegates: full|readonly|none` ceiling enforcement point unchanged
+  (`cmd_agent_delegate.c`), now expressed as max grantable set
+  (full→rwx, readonly→r, none→∅).
+
+## A4 — persona from context, grant through the provider
+
+- `cmd_agent_delegate.c:630`: `--persona` no longer required; if present,
+  warn "deprecated, ignored". Resolution: workflow node `persona:` param
+  (threaded per B) → session persona (`config_current_persona()`) →
+  `config.default_persona` → `engineer`.
+- MCP `delegate` tool (`mcp_tools.c:606`): `persona` drops from required;
+  if supplied, ignored with a warning in the tool result.
+- `wfe_delegate_dispatch` (`workflow/wfe_blocks.c:636`) and the provider
+  contract `wfe_delegate_provider_t`'s `run()` gain **two** params: an
+  explicit persona and the resolved grant bitmask (mock providers grow
+  them too: `test_wfe_delegate_seam.c`, `test_wfe_manager_flow.c`).
+  `wfe_live_delegate_run` (`server/wfe_live_delegate.c:75`) stops reading
+  the role slot as the persona (`:116`); the role slot means a
+  permission-role again. Inside the live provider the grant is enforced,
+  not advisory: tools are gated on `write|execute`, and the auto-commit
+  block (`git add -A` + `git commit --no-verify`,
+  `server/wfe_live_delegate.c:183-185`, unconditional today) is skipped
+  entirely when the grant lacks `write` — a read dispatch must not sweep
+  pre-existing staged changes into a commit.
+
+## A5 — generated stance and prose re-authoring
+
+- `persona_compose_delegate_prompt()` (`persona.c:496`) gains the granted
+  bitmask; emits the stance block from it. Callers threaded:
+  `server/wfe_live_delegate.c:117,289`, `server/wfe_live_panel.c:184`,
+  `delegate_ensemble.c:1117`, `delegate_prompt.c:1812`,
+  `cmd_agent_delegate.c:841`, test stubs (`test_server_compute.c:488`,
+  `test_delegate_ensemble.c:44`, `test_persona.c`).
+- Re-author in `prompts.c`: remove the stance sentence from each reviewer
+  identity paragraph (`prompts.c:309,340,373,408,439,491`), the read-only
+  `## Delegation` blocks, and every literal
+  `aimee delegate <role> --persona` example (engineer :54, primary :108,
+  novel :152, songwriter :192, reviewers :331,364,398,430,482,518).
+  `persona_delegation_block()` (`persona.c:135`) regenerates without
+  `--persona`.
+- Seeded-file migration: `persona_install_defaults()` (`persona.c:611`,
+  skip-if-exists at :626) starts writing a `seed_version:` frontmatter
+  key. Because every existing install's files carry no version and the
+  re-authoring removes the old prose from the binary, the release
+  **embeds a frozen table of the v0 seed content hashes** (one per
+  built-in persona, captured from the pre-change generator before the
+  prose edit lands). On startup seeding (`server_seed_config.c:79`): file
+  with no `seed_version` whose hash matches its v0 entry → pristine
+  legacy seed, re-seed it; hash mismatch → user-edited, leave it and log;
+  `seed_version` current → skip.
+
+## B6 — pr.open text
+
+- `exec_pr_open` (`workflow/wfe_blocks.c:1343`) pre-step: dispatch persona
+  = node `persona:` param or `technical-writer`, grant `[read]`, prompt
+  carries `git log <base>..<branch>` + `git diff --stat`. Artifact path:
+  `mkstemp` under the run's scratch dir, out-of-tree. The read grant makes
+  the provider skip tools-with-write and the auto-commit (A4), so nothing
+  can land on the branch.
+- Validate: non-empty single-line title, non-empty body. Do not try to
+  predict the forge's post-quoting caps (`shq` into `etitle[512]` /
+  `ebody[1024]`, `server/wfe_live_forge.c:264-280`): call `open()` with
+  the authored text; on -1, retry once with (work-item, "") before
+  returning `wfe_step_looped()`.
+
+## B7 — document persona
+
+- `exec_document` (`workflow/wfe_blocks.c:1044`): persona =
+  `node_str(node, "persona")`, default `engineer` (pattern:
+  `wfe_blocks.c:965`). `config/workflows/build.yaml` document node gains
+  `persona: technical-writer`.
+
+## B8 — commit message capture and style
+
+- The live path frees the delegate reply and commits with a fixed message
+  (`res.response` freed at `server/wfe_live_delegate.c:173`; commit
+  `-m "aimee: autonomous delegate change"` at `:185`). There is no
+  structured handoff on this path today — the `delegate_result_v1`
+  contract exists only on the plan-packet path (`delegate_launch.c:301`,
+  `delegate_prompt.c:151`).
+- The contract itself gains the field: `delegate_result_v1` today carries
+  `schema_version, status, changed_files, tests, summary` and has **no
+  commit-message carrier**. `delegate_handoff_append_contract`
+  (`delegate_prompt.c:151`) adds `commit_message` (required for committing
+  dispatches) to the contract text, and the parser
+  (`delegate_handoff_validate_text` →  `delegate_handoff_validation_t`,
+  `headers/cmd_agent_delegate_impl.h`) retains the string — today it keeps
+  only counts and status.
+- Mechanism, discriminated by dispatch kind so artifact blocks keep raw
+  text: committing dispatches (`implement` plain, fanout units, TDD,
+  `document`) get the contract appended to their prompt; the provider
+  parses `res.response` as the contract (before the free at `:173`) and
+  extracts `commit_message`; the harness commit uses it, else the current
+  fixed message. Artifact dispatches (`author.*`, B6's PR text) keep
+  `res.response` verbatim.
+- Scope note: when a delegate self-commits mid-run via its own git tools,
+  the styled message reaches it only as prompt guidance — best-effort, not
+  asserted.
+- Style block: producing dispatch prompts (`implement` plain
+  `wfe_blocks.c:1011`, fanout units `:888` — note the fixed
+  `char prompt[1024]` there needs growth to take the block, TDD RED/GREEN
+  `:932,:969`, `document` `:1048`) append "## Commit message style" =
+  `commit_style_persona`'s voice text when non-empty.
+- Config key `commit_style_persona[64]`: `headers/config.h` (next to
+  `default_persona:279`), default + load in `config.c` (pattern of
+  `default_persona` at :842, :1076), descriptor `config_fields.c:22`
+  pattern, save `config_save.c:356` pattern.
+
+## B9 — voice field
+
+- `persona_t` gains `voice_text`; `extract_section` list (`persona.c:407`)
+  gains `## Voice`; `persona_install_defaults` writes it; built-in
+  fallback: the tech-writer voice prose moves from
+  `PROMPT_TECH_WRITER_TEXT` (`prompts.c:466`) into a
+  `prompt_persona_voice(mode)` accessor (NULL for personas without one).
+
+## B10 — validation
+
+- `wfe_def_validate` (`workflow/wfe_validate.c`): for `implement`,
+  `document`, `pr.open` nodes with a `persona:` param, resolve against
+  built-ins + persona files; unknown → named validation error. (The
+  validator gains a resolver hook so the pure-def path stays testable.)
+
+## Test map (one row per acceptance bullet)
+
+| Acceptance bullet | Test |
+|---|---|
+| table reproduces write set; override honored; unknown token rejected | `test_delegate_role.c` new cases |
+| write grant honored end to end (tool-enable × write_capable) | `test_server_compute.c` runtime case through `agent_runtime` write path |
+| coverage matching, both dispatch paths; named-delegate miss rejected | `test_delegate_ensemble.c` (CLI path) + `test_wfe_delegate_seam.c` (workflow routing) |
+| `--persona` deprecation warning; no `--persona` in composed prompts | `test_cmd_delegate.c` warning case + prompt-scan assertion in `test_persona.c` |
+| stance across grants; stale-seed re-seed vs edited-file preserved | `test_persona.c` (compose with `[read]` vs `[read,write]`; fabricated v0 file with no `seed_version` key, hash-match and hash-mismatch cases) |
+| PR text happy path; garbage/empty fallback; open() −1 retry-with-empty; no extra commit | `test_wfe_blocks.c` with new capturing delegate stub + forge recorder |
+| harness commit carries delegate message; styled prompt; config round-trip | `test_wfe_blocks.c` (handoff parse → commit message) + `test_config.c` round-trip |
+| voiceless persona no-op; `## Voice` parsed | `test_persona.c` |
+| validate rejects unknown persona on the three node kinds | `test_wfe_validate.c` (new file; existing def-validate coverage lives in `test_workflow.c`) |
+| no AI-attribution trailers on either path | existing `strip_ai_attribution` coverage + commit-path equivalent in `test_wfe_blocks.c` |
+
+## Sequencing
+
+1. A1 (permission table + gates) — mechanical; the table reproduces
+   today's sets by construction.
+2. A2 (tool-enable from grant, injection gates) — behavior-affecting;
+   guarded by the self-cancel invariant check above.
+3. A5 prose re-authoring + composer grant param, with A4's
+   dispatch-persona/grant threading through the provider contract.
+4. A3 matching + `requires:`.
+5. B8 commit capture, B9 voice, B7 document, B6 pr.open, B10 validation.
+6. Docs (personas.md, DELEGATES.md, WORKFLOW_ACTIONS.md, CLI help,
+   generated command reference).


### PR DESCRIPTION
## What

Adds `docs/proposals/pending/persona-authored-outputs.md` and its implementation plan. The proposal covers three operator requirements:

1. **Persona-authored outputs** — commit messages, PR title/body, and documentation are routed to a bound persona (default `technical-writer`): `pr.open` gains a delegate-authored title/body with a fail-open fallback, `document` gains a per-node `persona:` param, and a new `commit_style_persona` config key styles commit messages, which the harness commit now actually consumes via a `commit_message` field added to the delegate handoff.
2. **Roles are permissions** — a role becomes a permission set (`read`/`write`/`execute`) backed by a built-in table with role-template frontmatter overrides, replacing the hardcoded `delegate_role_is_write()` name list; write-gating and tool-enablement derive from the grant.
3. **Delegates by coverage, not persona targeting** — delegates advertise permissions, personas declare `requires:`, and a delegate is a valid target iff its grants cover the persona's requirements; `--persona` is deprecated (context selects the persona), and reviewer/author stance is generated from the granted permissions instead of baked into persona prose, with a hash-based re-seed migration for stale seeded persona files.

Follow-up in #1330 adds the git-tooling enforcement shift (`require_aimee_git` and the persona-authored commit gate).

## Review

The proposal went through a five-seat roundtable (architect, qa, reviewer, reviewer-constructive, technical-writer) over five rounds. Highlights of what the rounds caught and the doc now reflects: the missing text-return channel for PR prose (artifact capture), the unconditional live-path auto-commit needing an explicit grant gate, the `delegate_result_v1` contract lacking a commit-message carrier, the seed migration needing embedded prior-seed hashes, the judge-path `roles[]` fail-closed hazard, and the diff-bundle injection staying review-family-gated. Final round: all five seats approve, no blocking or major findings outstanding.

No code changes in this PR — proposal documents only.
