### PR TITLE
fix(wfe): scheduler sweeps least-recently-updated first — newest-first starved siblings

### DIFF
--- a/src/db1/wfe_store.c
+++ b/src/db1/wfe_store.c
@@ -582,14 +582,13 @@ int db1_work_item_inc_override(const char *wi)
    return -1;
 }
 
-int db1_work_item_list(db1_work_item_t **out)
+static int work_item_list_ordered(db1_work_item_t **out, const char *sql)
 {
    if (out)
       *out = NULL;
    sqlite3 *db = db1_conn();
    if (!db)
       return -1;
-   static const char *sql = "SELECT " WI_COLS " FROM lifecycle_work_item ORDER BY id DESC";
    sqlite3_stmt *st = NULL;
    if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK)
       return -1;
@@ -618,6 +617,21 @@ int db1_work_item_list(db1_work_item_t **out)
    else
       free(arr);
    return n;
+}
+
+int db1_work_item_list(db1_work_item_t **out)
+{
+   return work_item_list_ordered(out,
+                                 "SELECT " WI_COLS " FROM lifecycle_work_item ORDER BY id DESC");
+}
+
+int db1_work_item_list_lru(db1_work_item_t **out)
+{
+   /* Staleness-first (see wfe_store.h). id ASC tie-break keeps the order total
+    * and deterministic for same-second updates (a fresh fan-out stamps every
+    * child in one batch). */
+   return work_item_list_ordered(out, "SELECT " WI_COLS
+                                      " FROM lifecycle_work_item ORDER BY updated_at ASC, id ASC");
 }
 
 int db1_lifecycle_event_add(const char *wi, const char *stage, const char *kind, const char *actor,

--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -147,6 +147,15 @@ int db1_work_item_delete(const char *work_item_id);
 /* List work items (newest first). Caller frees *out. Returns count or -1. */
 int db1_work_item_list(db1_work_item_t **out);
 
+/* List work items LEAST-RECENTLY-UPDATED first — the scheduler's fairness
+ * order. A newest-first sweep starves older siblings: the sequential autonomy
+ * pass gives each item up to its wall-clock cap, so whichever items sort first
+ * eat every sweep (observed live: 2 of 13 fan-out slices monopolized 3.5h
+ * while the rest never advanced). Staleness-first makes starvation
+ * self-correcting: whoever was skipped longest goes first next sweep.
+ * Caller frees *out. Returns count or -1. */
+int db1_work_item_list_lru(db1_work_item_t **out);
+
 /* Append an audit event. */
 int db1_lifecycle_event_add(const char *work_item_id, const char *stage, const char *kind,
                             const char *actor, const char *detail, const char *content_hash,

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -36,8 +36,12 @@ static int g_notified;
  * dead-ending the run. Terminal/interactive items are skipped. */
 void wfe_scheduler_run_once(void)
 {
+   /* LRU order (least-recently-updated first): the pass below is sequential
+    * and each item may hold the thread up to its wall-clock cap, so a fixed
+    * newest-first order lets the busiest items eat every sweep and starve the
+    * rest (observed live: 2 of 13 slices monopolized 3.5h of sweeps). */
    db1_work_item_t *items = NULL;
-   int n = db1_work_item_list(&items);
+   int n = db1_work_item_list_lru(&items);
    if (n <= 0 || !items)
       return;
    for (int i = 0; i < n; i++)

--- a/src/tests/test_wfe_scheduler.c
+++ b/src/tests/test_wfe_scheduler.c
@@ -9,6 +9,8 @@
 #include <sys/stat.h>
 
 #include "db1.h"
+#include "db1_internal.h" /* db1_conn — stamp updated_at directly for the LRU test */
+#include "sqlite3.h"
 #include "wfe_engine.h"
 #include "wfe_scheduler.h"
 #include "wfe_store.h"
@@ -58,6 +60,32 @@ int main(void)
    assert(strcmp(wa.state, "active") != 0); /* autonomous item advanced past active */
    assert(strcmp(wb.state, "active") == 0); /* interactive item NOT driven by the scheduler */
 
-   printf("ok (autonomous=%s, interactive untouched)\n", wa.state);
+   /* LRU listing: the scheduler's sweep order is least-recently-updated FIRST,
+    * so a busy (recently updated) item can never permanently starve a stale
+    * sibling. Stamp distinct updated_at values and assert the order. */
+   char c[80] = "", d[80] = "";
+   assert(create("c", "autonomous", c) == 0 && c[0]);
+   assert(create("d", "autonomous", d) == 0 && d[0]);
+   {
+      char sql[256];
+      snprintf(sql, sizeof sql,
+               "UPDATE lifecycle_work_item SET updated_at='2000-01-01 00:00:01' WHERE "
+               "work_item_id='%s'",
+               d);
+      assert(sqlite3_exec(db1_conn(), sql, NULL, NULL, NULL) == SQLITE_OK);
+      snprintf(sql, sizeof sql,
+               "UPDATE lifecycle_work_item SET updated_at='2000-01-01 00:00:02' WHERE "
+               "work_item_id='%s'",
+               c);
+      assert(sqlite3_exec(db1_conn(), sql, NULL, NULL, NULL) == SQLITE_OK);
+   }
+   db1_work_item_t *lru = NULL;
+   int n = db1_work_item_list_lru(&lru);
+   assert(n >= 4);
+   assert(strcmp(lru[0].work_item_id, d) == 0); /* stalest first */
+   assert(strcmp(lru[1].work_item_id, c) == 0);
+   free(lru);
+
+   printf("ok (autonomous=%s, interactive untouched, lru order)\n", wa.state);
    return 0;
 }


### PR DESCRIPTION
The autonomy scheduler drives active items **sequentially**, each item holding the thread up to its wall-clock cap (default 30 min), in `db1_work_item_list`'s fixed newest-first (`id DESC`) order. The busiest, most-recently-created items therefore ate every sweep from the top.

Observed live on .254: of the 13-slice fan-out, s12 and s11 (highest ids → always first) monopolized **3.5 hours** of scheduler time cycling their impl↔roundtable loops, while s1–s10 never advanced once — and every server restart re-started the sweep at the same two items, resetting whatever partial progress the list tail had.

Fix: add `db1_work_item_list_lru` (`ORDER BY updated_at ASC, id ASC` — stalest first, deterministic tie-break for same-second batch stamps) and use it for the scheduler sweep. Whoever waited longest goes first, so starvation is self-correcting by construction. The UI/API listing keeps its newest-first order.

Tests: `test_wfe_scheduler.c` extended — stamps distinct `updated_at` values and asserts the LRU order; `unit-test-wfe-scheduler` passes locally.