### PR TITLE
docs(proposals): enforce aimee git tooling; persona-authored commit gate

### DIFF
--- a/docs/proposals/pending/persona-authored-outputs.md
+++ b/docs/proposals/pending/persona-authored-outputs.md
@@ -19,12 +19,22 @@ self-contradictory prompt. A role's capability is a hardcoded name list
 delegates are addressed by (role template, persona name) pairs, so callers
 hardwire *who* instead of *what capabilities the job requires*.
 
+And even with all of that fixed, persona-styled commit messages would stay
+best-effort as long as an agent can run raw `git commit` from a shell: the
+message only reliably passes through a persona if every commit and PR
+passes through one gate. aimee already has that gate — the guarded git
+tools (`git_commit`, `git_push`, `git_pr`) that strip AI attribution,
+block protected branches, and skip sensitive files — but nothing requires
+agents to use it.
+
 One model change fixes all of this. Roles become permissions. Delegates
 advertise permissions. A persona declares the permissions it requires, and
 any delegate that covers them is a valid target. Stance is generated from
-the granted permissions instead of baked into prose. On that footing,
-routing "the technical writer writes the commit messages, the PR messages,
-and the docs" is config and workflow YAML, not prompt surgery.
+the granted permissions instead of baked into prose. And aimee's git
+tooling becomes mandatory for agents, so the commit and PR gate is a
+choke point a persona can own. On that footing, routing "the technical
+writer writes the commit messages, the PR messages, and the docs" is
+config and workflow YAML, not prompt surgery.
 
 ## What
 
@@ -86,29 +96,46 @@ and the docs" is config and workflow YAML, not prompt surgery.
 7. `document` honors a per-node persona, read the same way the `implement`
    block's TDD path already reads one, and the `build` composition sets
    `persona: technical-writer` on its document node.
-8. Commit messages are delegate-authored, styled, and actually used. The
-   live dispatch path today commits with a hardcoded message; committing
-   dispatches will instead carry the structured delegate handoff, and the
-   harness commit consumes the `commit_message` it supplies. A new config
-   key, `commit_style_persona` (default `technical-writer`, empty
-   disables), appends that persona's voice guidance as a
-   "## Commit message style" block to every dispatch that commits:
-   `implement` (plain, fanout units, TDD), and `document`. The `author.*`
-   blocks produce prose artifacts, not commits, and are excluded. When a
-   delegate self-commits mid-run with its own git tools, the style block
-   guides it but the resulting message is best-effort.
-9. Voice becomes addressable. The built-in technical-writer's voice prose
-   is factored into a built-in voice field; `## Voice` joins the sections
-   parsed from persona files and the seeded output. A persona without a
-   voice makes `commit_style_persona` a logged no-op.
-10. Persona names and grants are validated. `aimee workflow validate`
+8. aimee's git tooling is enforced for agents, at both layers agents run
+   in. A new config key, `require_aimee_git` (default on, operator
+   opt-out only — the `require_aimee_memory` pattern), refuses raw git
+   write commands and raw `gh pr` invocations from agent shells and
+   directs them to the guarded tools: the attention-guard covers
+   hook-driven interactive sessions, and the server-side agent policy
+   covers in-process delegates, both reusing the tokenizing git-write
+   detectors the guardrails layer already has rather than a new verb
+   list. Every agent-authored commit and PR then flows through one gate.
+   aimee-server's own internal commits and forge calls are not agent
+   shells and stay as they are; and the refusal is a redirect, not a
+   sandbox — a determined bypass is out of scope, the ban on unattended
+   AI attribution remains the hard outer guard.
+9. Commit messages are persona-authored at that gate. The commit gate
+   becomes one shared implementation behind the MCP `git_commit` handler
+   and the workflow harness commit (which today hardcodes its message).
+   When `commit_style_persona` (new config key, default
+   `technical-writer`, empty disables) is set and the commit is
+   agent-originated, the gate dispatches that persona read-only over the
+   staged diff, with the caller's message as the draft, and commits with
+   the authored message. The pass is skipped when a persona-styled draft
+   already arrived (committing workflow dispatches carry one through a
+   commit-message draft channel in the delegate handoff, and their
+   prompts carry the persona's voice guidance as a
+   "## Commit message style" block) — one authoring pass per commit,
+   never two. On dispatch failure, no backend, or a message that strips
+   to empty, the draft commits as supplied; a human operator's own
+   commit message is never rewritten.
+10. Voice becomes addressable. The built-in technical-writer's voice
+    prose is factored into a built-in voice field; `## Voice` joins the
+    sections parsed from persona files and the seeded output. A persona
+    without a voice makes `commit_style_persona` a logged no-op.
+11. Persona names and grants are validated. `aimee workflow validate`
     rejects an unknown `persona:` on producing and `pr.open` nodes —
     today a typo silently falls back to `engineer` — and template loading
     rejects unknown permission tokens.
-11. Docs and help follow the interface: `docs/personas.md`,
+12. Docs and help follow the interface: `docs/personas.md`,
     `docs/DELEGATES.md`, `docs/WORKFLOW_ACTIONS.md`, the CLI help text,
     and the generated command reference all drop `--persona` and document
-    the permission model.
+    the permission model and the git-tooling requirement.
 
 Out of scope: a general action→persona binding table, and any permission
 beyond `read`/`write`/`execute`. Mechanics — caller enumerations, file
@@ -140,11 +167,24 @@ lists, signatures, migration, and the test seam — are in
   With the dispatch failing, returning garbage, or the forge rejecting the
   text, the PR still opens with the work-item title and empty body —
   observed via the block-test forge recorder, not parked.
-- The commit created by a live-path dispatch carries the delegate-supplied
-  message, not the hardcoded one; with `commit_style_persona` set (and by
-  default) the message follows the styled prompt, and the resulting
-  message — not just the prompt — is asserted in tests. Config round-trips
-  through save/load like `default_persona`.
+- With `require_aimee_git` on (the default), a raw `git commit` or `gh pr`
+  from an agent shell is refused with a message directing to the guarded
+  tools — on both the interactive-session (hook) layer and the in-process
+  delegate (agent policy) layer; with it off, the command passes. Read
+  verbs pass untouched. The guard is operator config only, with no
+  env-var bypass.
+- Every agent commit routes through the shared gate: the MCP `git_commit`
+  handler and the workflow harness commit produce the same gated behavior
+  in the caller's worktree, and the harness commit no longer carries the
+  hardcoded message.
+- With `commit_style_persona` set (and by default), an agent commit
+  without a styled draft gets the gate-authored message — asserted on the
+  resulting commit, not the prompt; a handoff-drafted commit is used as
+  supplied (no second authoring pass); on gate-dispatch failure or a
+  message that strips to empty the draft is used; a human operator's
+  message commits unchanged. With the key empty, every caller's message
+  commits unchanged. Config round-trips through save/load like
+  `default_persona`.
 - Setting `commit_style_persona` to a persona with no voice logs and
   no-ops. `## Voice` in a persona file parses into the persona.
 - `aimee workflow validate` rejects an unknown `persona:` on `pr.open`,

--- a/docs/proposals/pending/persona-authored-outputs.plan.md
+++ b/docs/proposals/pending/persona-authored-outputs.plan.md
@@ -1,8 +1,10 @@
 # persona-authored-outputs — implementation plan
 
 Mechanics for [persona-authored-outputs.md](persona-authored-outputs.md).
-Numbers refer to that document's What items. Paths are under `src/` unless
-noted; workflow-engine files live in `src/workflow/`.
+Section numbers follow that document's What items (B8 here covers its
+items 8–9, the enforced tooling and the commit gate; B9 → item 10,
+B10 → item 11). Paths are under `src/` unless noted; workflow-engine files
+live in `src/workflow/`.
 
 ## A1 — permission table and grant resolution
 
@@ -145,41 +147,109 @@ noted; workflow-engine files live in `src/workflow/`.
   `wfe_blocks.c:965`). `config/workflows/build.yaml` document node gains
   `persona: technical-writer`.
 
-## B8 — commit message capture and style
+## B8 — enforced git tooling and the shared commit gate
 
-- The live path frees the delegate reply and commits with a fixed message
-  (`res.response` freed at `server/wfe_live_delegate.c:173`; commit
-  `-m "aimee: autonomous delegate change"` at `:185`). There is no
-  structured handoff on this path today — the `delegate_result_v1`
-  contract exists only on the plan-packet path (`delegate_launch.c:301`,
-  `delegate_prompt.c:151`).
-- The contract itself gains the field: `delegate_result_v1` today carries
-  `schema_version, status, changed_files, tests, summary` and has **no
-  commit-message carrier**. `delegate_handoff_append_contract`
-  (`delegate_prompt.c:151`) adds `commit_message` (required for committing
-  dispatches) to the contract text, and the parser
-  (`delegate_handoff_validate_text` →  `delegate_handoff_validation_t`,
-  `headers/cmd_agent_delegate_impl.h`) retains the string — today it keeps
-  only counts and status.
-- Mechanism, discriminated by dispatch kind so artifact blocks keep raw
-  text: committing dispatches (`implement` plain, fanout units, TDD,
-  `document`) get the contract appended to their prompt; the provider
-  parses `res.response` as the contract (before the free at `:173`) and
-  extracts `commit_message`; the harness commit uses it, else the current
-  fixed message. Artifact dispatches (`author.*`, B6's PR text) keep
+- Enforcement config: new key `require_aimee_git` (default 1), the
+  `require_aimee_memory` pattern exactly (`config.c:325` schema, `:734`
+  default, `:1196` load). Operator opt-out in `aimee.yaml` only; no
+  env-var bypass (same stance as `require_session_worktree`). The verb
+  set is not a new list: both layers reuse the guardrails orchestrator's
+  tokenizing detectors — `bash_has_git_write`
+  (`guardrails_orchestrator.c:243,342`; quote- and `git -C`-aware),
+  `bash_has_gh_pr_create` (`:406`), and the push gate (`:329`) — extended
+  with `tag` and `stash` so every verb with a guarded MCP equivalent
+  (`server_mcp.c:1392` table) is redirected to it. Read verbs
+  (`status`, `log`, `diff`, …) pass untouched. The refusal is a redirect
+  nudge, not a sandbox (`sh -c '…'` smuggling is out of scope; the
+  AI-attribution ban stays the hard outer guard).
+- Enforcement layer 1, interactive sessions: `cli_attention_guard.c`
+  (a Claude Code PreToolUse hook; Bash text scanning precedent at `:112`,
+  `:719`) refuses matching commands with a message naming `git_commit`,
+  `git_push`, `git_pr`.
+- Enforcement layer 2, in-process delegates: the attention-guard hook
+  never sees `agent_execute_with_tools` delegates
+  (`delegate_backend_local.c:234` runs raw `/bin/bash -c`), so the same
+  refusal lands in the server-side agent policy intercept
+  (`agent_policy.c`, alongside the existing `forbidden_commands` /
+  discovery-shell intercepts), using the same orchestrator detectors.
+  Without this layer the enforcement would cover only interactive
+  sessions and the self-commit caveat would return for exactly the
+  autonomous dispatches this proposal exists to fix.
+- Out of the gate by design: aimee-server's own subprocess git (the
+  forge's push and `gh pr create`, `server/wfe_live_forge.c:289-303`;
+  `source.archive`'s chore commit on the run branch) — internal calls,
+  not agent shells. The .md scopes the one-gate claim to agent-authored
+  commits accordingly.
+- The shared commit gate: `handle_git_commit` (`mcp_git_write.c:53`) is
+  refactored so its stage→guard→commit core (AI-attribution strip,
+  main-branch block, branch ownership, sensitive-file skip) is callable
+  in-process **with an explicit workdir**: today every git call inside it
+  goes through `mcp_git_run`/`get_current_branch`, which key off the
+  process-global `run_cmd_get_cwd()` (`mcp_git_query.c:84,289`). The
+  harness caller pins `run_cmd_set_cwd(workdir)` around the core — the
+  exact pattern `wfe_live_verify_run` already uses for the same reason
+  (`server/wfe_live_delegate.c:218-227`) — so the gate commits in the
+  per-work-item worktree, not the daemon checkout (whose branch could
+  even be `main`, tripping the gate's own guard). The workflow harness
+  commit (`server/wfe_live_delegate.c:183-185`, hardcoded
+  `-m "aimee: autonomous delegate change"` today) then calls the core
+  instead of raw `git_run`.
+- Persona authorship at the gate — skip-on-draft, agent-only: the
+  authoring pass runs only when (a) `commit_style_persona` is set and the
+  persona has a voice, (b) the commit is agent-originated (MCP callers
+  and the harness; a human operator's CLI commit passes through
+  unchanged), and (c) no persona-styled draft accompanied the commit (a
+  handoff-supplied `commit_message` from a styled producing dispatch is
+  committed as supplied — never a second authoring pass; the honest
+  rationale for the style block is fallback quality, not gate cost). The
+  pass dispatches the persona read-only over `git diff --cached` plus the
+  caller's draft. Failure, no backend, empty reply, or a reply that
+  `strip_ai_attribution` reduces to empty → the draft commits as
+  supplied. Nothing staged → the gate errors before any dispatch, as
+  `git commit` does today.
+- Re-entrancy of the nested pass: the MCP-side gate dispatches through
+  the same in-process entry the workflow uses
+  (`agent_execute_with_tools`, read-only agent config), and the gate
+  saves/restores the thread-local state the inner dispatch clobbers —
+  `run_cmd` cwd and the `g_write_capable` TLS (`agent_tools.c:58`) —
+  re-pinning the workdir before the final `git commit`. Recursion is
+  bounded structurally: the authoring delegate is read-granted, so it has
+  no `git_commit` tool and cannot re-enter the gate.
+- Draft channel for harness commits, discriminated by dispatch kind so
+  artifact blocks keep raw text: committing dispatches (`implement`
+  plain, fanout units, TDD, `document`) get the `delegate_result_v1`
+  contract appended to their prompt; the contract gains a
+  `commit_message` field — `delegate_handoff_append_contract`
+  (`delegate_prompt.c:151`) adds it to the contract text (today:
+  `schema_version, status, changed_files, tests, summary`, no message
+  carrier), and the parser (`delegate_handoff_validate_text` →
+  `delegate_handoff_validation_t`, `headers/cmd_agent_delegate_impl.h`)
+  retains the string (today it keeps only counts and status; the field
+  stays optional in the validator so plan-packet handoffs keep
+  validating). The provider parses `res.response` before the free at
+  `server/wfe_live_delegate.c:183` and passes `commit_message` to the
+  gate as the draft. Artifact dispatches (`author.*`, B6's PR text) keep
   `res.response` verbatim.
-- Scope note: when a delegate self-commits mid-run via its own git tools,
-  the styled message reaches it only as prompt guidance — best-effort, not
-  asserted.
-- Style block: producing dispatch prompts (`implement` plain
-  `wfe_blocks.c:1011`, fanout units `:888` — note the fixed
-  `char prompt[1024]` there needs growth to take the block, TDD RED/GREEN
-  `:932,:969`, `document` `:1048`) append "## Commit message style" =
-  `commit_style_persona`'s voice text when non-empty.
+- Delegate self-commits route through the gate too: with
+  `require_aimee_git` on, a delegate's own commit is an MCP `git_commit`
+  call, so its message gets the same persona pass — the round-4
+  best-effort caveat disappears.
+- Style block (draft quality, keeps the gate's pass cheap): producing
+  dispatch prompts (`implement` plain `wfe_blocks.c:1011`, fanout units
+  `:888` — note the fixed `char prompt[1024]` there needs growth, TDD
+  RED/GREEN `:932,:969`, `document` `:1048`) append
+  "## Commit message style" = `commit_style_persona`'s voice text when
+  non-empty.
 - Config key `commit_style_persona[64]`: `headers/config.h` (next to
   `default_persona:279`), default + load in `config.c` (pattern of
   `default_persona` at :842, :1076), descriptor `config_fields.c:22`
   pattern, save `config_save.c:356` pattern.
+- PR side of the gate: `handle_git_pr` (`mcp_git_pr.c:160`) gets the same
+  treatment as B6's `pr.open` — an absent/empty title or body is
+  persona-authored over the branch evidence before the create, with the
+  same fail-open fallback. Note the create path today hard-rejects an
+  empty title (`'title' parameter is required`, `mcp_git_pr.c:515`); that
+  check relaxes to "author, then require".
 
 ## B9 — voice field
 
@@ -206,7 +276,9 @@ noted; workflow-engine files live in `src/workflow/`.
 | `--persona` deprecation warning; no `--persona` in composed prompts | `test_cmd_delegate.c` warning case + prompt-scan assertion in `test_persona.c` |
 | stance across grants; stale-seed re-seed vs edited-file preserved | `test_persona.c` (compose with `[read]` vs `[read,write]`; fabricated v0 file with no `seed_version` key, hash-match and hash-mismatch cases) |
 | PR text happy path; garbage/empty fallback; open() −1 retry-with-empty; no extra commit | `test_wfe_blocks.c` with new capturing delegate stub + forge recorder |
-| harness commit carries delegate message; styled prompt; config round-trip | `test_wfe_blocks.c` (handoff parse → commit message) + `test_config.c` round-trip |
+| `require_aimee_git` refuses raw git write / `gh pr` on both layers; off passes; read verbs pass | `test_attention_guard.c` (hook layer) + agent-policy intercept cases beside the orchestrator detectors' existing tests |
+| MCP `git_commit` and harness commit share the gate, in the caller's worktree; hardcoded message gone | `test_wfe_blocks.c` (harness path, workdir pinning) + MCP handler test via the shared core |
+| gate-authored vs skip-on-draft vs human pass-through; dispatch-failure / strips-to-empty → draft; empty key → pass-through; config round-trip | gate unit test with stubbed persona dispatch + `test_config.c` round-trip |
 | voiceless persona no-op; `## Voice` parsed | `test_persona.c` |
 | validate rejects unknown persona on the three node kinds | `test_wfe_validate.c` (new file; existing def-validate coverage lives in `test_workflow.c`) |
 | no AI-attribution trailers on either path | existing `strip_ai_attribution` coverage + commit-path equivalent in `test_wfe_blocks.c` |
@@ -220,6 +292,9 @@ noted; workflow-engine files live in `src/workflow/`.
 3. A5 prose re-authoring + composer grant param, with A4's
    dispatch-persona/grant threading through the provider contract.
 4. A3 matching + `requires:`.
-5. B8 commit capture, B9 voice, B7 document, B6 pr.open, B10 validation.
+5. B8 in two steps: the shared commit gate + draft channel first, then
+   `require_aimee_git` enforcement (the gate must exist before raw git is
+   refused, or agents have no commit path). B9 voice, B7 document,
+   B6 pr.open, B10 validation.
 6. Docs (personas.md, DELEGATES.md, WORKFLOW_ACTIONS.md, CLI help,
-   generated command reference).
+   generated command reference, the git-tooling requirement).


### PR DESCRIPTION
## What

Extends the persona-authored-outputs proposal (merged in #1328) with the git-tooling enforcement shift. One commit amending both proposal documents:

- **`require_aimee_git`** (default on, `require_aimee_memory` pattern, operator opt-out only) refuses raw `git` write commands and `gh pr` from agent shells at **both layers**: the attention-guard hook for interactive sessions, and the server-side agent policy intercept for in-process delegates — reusing the guardrails orchestrator's existing quote- and `git -C`-aware detectors rather than a new verb list. Server-internal git (forge shell-outs, `source.archive`) stays outside by design; the refusal is a redirect, not a sandbox.
- **A shared, workdir-safe commit gate**: the MCP `git_commit` core and the workflow harness commit unify (explicit workdir pinning per the `wfe_live_verify_run` precedent), and when `commit_style_persona` is set the gate authors the final message read-only over the staged diff. Skip-on-draft (a styled handoff draft is never re-authored), agent-only (human operator messages are never rewritten), and draft fallback on dispatch failure, no backend, or a message that strips to empty — enforcement can never block a commit on prose.
- **`git_pr`** gains the same title/body authoring as `pr.open` (the create path's hard title-reject relaxes to author-then-require).
- The round-4 'best-effort self-commit' caveat is removed: under enforcement, a delegate self-commit is a gated `git_commit` call.

## Review

Roundtable rounds 6–7 (same five seats as #1328). Round 6 caught: the attention-guard being hook-only (hence the second enforcement layer in `agent_policy.c`, verified to be on every delegate's pre-execution tool path), the shared core's process-global-cwd hazard, nested-dispatch re-entrancy (cwd + write-capable TLS save/restore), the double-dispatch cost (hence skip-on-draft), human-message rewriting, and empty-after-strip. Round 7: all seats approve; residual minors (an anchor drift, the verb-table rationale) folded in.

No code changes — proposal documents only.

Follow-up to #1328.