### PR TITLE
feat(wfe): parallel autonomy scheduler — bounded worker pool per sweep

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -272,7 +272,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 153 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 154 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -475,7 +475,7 @@ The binaries read 153 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CONCURRENCY`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/db1/cognify_jobs.c
+++ b/src/db1/cognify_jobs.c
@@ -79,7 +79,7 @@ int db1_cognify_job_claim_next(db1_cognify_job_t *out)
       return -1;
    memset(out, 0, sizeof(*out));
 
-   if (sqlite3_exec(db, "BEGIN IMMEDIATE", NULL, NULL, NULL) != SQLITE_OK)
+   if (db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
       return -1;
    if (sqlite3_prepare_v2(db, sel_sql, -1, &sel, NULL) != SQLITE_OK)
       goto fail;
@@ -87,7 +87,7 @@ int db1_cognify_job_claim_next(db1_cognify_job_t *out)
    if (sqlite3_step(sel) != SQLITE_ROW)
    {
       sqlite3_finalize(sel);
-      sqlite3_exec(db, "COMMIT", NULL, NULL, NULL);
+      db1_txn_end(db, "COMMIT");
       return 0;
    }
 
@@ -114,7 +114,7 @@ int db1_cognify_job_claim_next(db1_cognify_job_t *out)
       goto fail;
    sqlite3_finalize(upd);
 
-   if (sqlite3_exec(db, "COMMIT", NULL, NULL, NULL) != SQLITE_OK)
+   if (db1_txn_end(db, "COMMIT") != 0)
       return -1;
    snprintf(out->status, sizeof(out->status), "%s", "running");
    return 1;
@@ -124,7 +124,7 @@ fail:
       sqlite3_finalize(sel);
    if (upd)
       sqlite3_finalize(upd);
-   sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+   db1_txn_end(db, "ROLLBACK");
    return -1;
 }
 

--- a/src/db1/coord_jobs.c
+++ b/src/db1/coord_jobs.c
@@ -125,7 +125,7 @@ int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_ta
    sqlite3 *db = db1_conn();
    if (!db)
       return -1;
-   if (sqlite3_exec(db, "BEGIN IMMEDIATE", NULL, NULL, NULL) != SQLITE_OK)
+   if (db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
       return -1;
 
    sqlite3_stmt *stmt = NULL;
@@ -133,7 +133,7 @@ int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_ta
                                     " WHERE job_id = ? AND status IN ('claimed', 'running')";
    if (sqlite3_prepare_v2(db, running_sql, -1, &stmt, NULL) != SQLITE_OK)
    {
-      (void)sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      (void)db1_txn_end(db, "ROLLBACK");
       return -1;
    }
    sqlite3_bind_int(stmt, 1, job_id);
@@ -149,7 +149,7 @@ int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_ta
                                     " ORDER BY id ASC";
    if (sqlite3_prepare_v2(db, pending_sql, -1, &stmt, NULL) != SQLITE_OK)
    {
-      (void)sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      (void)db1_txn_end(db, "ROLLBACK");
       return -1;
    }
    sqlite3_bind_int(stmt, 1, job_id);
@@ -183,7 +183,7 @@ int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_ta
 
    if (found_id < 0)
    {
-      (void)sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      (void)db1_txn_end(db, "ROLLBACK");
       return -1;
    }
 
@@ -192,7 +192,7 @@ int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_ta
                                   " WHERE id = ? AND status = 'pending'";
    if (sqlite3_prepare_v2(db, claim_sql, -1, &stmt, NULL) != SQLITE_OK)
    {
-      (void)sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      (void)db1_txn_end(db, "ROLLBACK");
       return -1;
    }
    sqlite3_bind_text(stmt, 1, delegate_name, -1, SQLITE_TRANSIENT);
@@ -200,7 +200,7 @@ int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_ta
    if (sqlite3_step(stmt) != SQLITE_DONE || sqlite3_changes(db) == 0)
    {
       sqlite3_finalize(stmt);
-      (void)sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      (void)db1_txn_end(db, "ROLLBACK");
       return -1;
    }
    sqlite3_finalize(stmt);
@@ -215,9 +215,9 @@ int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_ta
       sqlite3_finalize(stmt);
    }
 
-   if (sqlite3_exec(db, "COMMIT", NULL, NULL, NULL) != SQLITE_OK)
+   if (db1_txn_end(db, "COMMIT") != 0)
    {
-      (void)sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      /* gate already released; a failed COMMIT auto-rolls-back in sqlite */
       return -1;
    }
 

--- a/src/db1/db1_init.c
+++ b/src/db1/db1_init.c
@@ -115,3 +115,27 @@ sqlite3 *db1_conn(void)
     * error at the domain-function layer. */
    return g_conn;
 }
+
+/* See db1_internal.h. One process-wide gate: explicit transactions on the
+ * shared connection are mutually exclusive across threads. */
+static pthread_mutex_t g_txn_gate = PTHREAD_MUTEX_INITIALIZER;
+
+int db1_txn_begin(sqlite3 *db, const char *begin_sql)
+{
+   if (!db)
+      return -1;
+   pthread_mutex_lock(&g_txn_gate);
+   if (sqlite3_exec(db, begin_sql, NULL, NULL, NULL) != SQLITE_OK)
+   {
+      pthread_mutex_unlock(&g_txn_gate);
+      return -1;
+   }
+   return 0;
+}
+
+int db1_txn_end(sqlite3 *db, const char *end_sql)
+{
+   int ok = db && sqlite3_exec(db, end_sql, NULL, NULL, NULL) == SQLITE_OK;
+   pthread_mutex_unlock(&g_txn_gate);
+   return ok ? 0 : -1;
+}

--- a/src/db1/db1_internal.h
+++ b/src/db1/db1_internal.h
@@ -23,6 +23,17 @@ extern "C"
     * .c files call this at the top of every public function. */
    sqlite3 *db1_conn(void);
 
+   /* Cross-thread transaction gate for the SHARED connection. sqlite allows one
+    * open transaction per connection; two threads issuing BEGIN IMMEDIATE on the
+    * same handle collide ("cannot start a transaction within a transaction") and
+    * a COMMIT from the wrong thread would commit the other's half-done writes.
+    * Every explicit-transaction site must open via db1_txn_begin (locks the gate,
+    * then execs the BEGIN; unlocks on exec failure) and close via db1_txn_end
+    * (execs COMMIT/ROLLBACK, then unlocks). Single-statement writes need no gate
+    * (FULLMUTEX serializes them). Both return 0 on success, -1 on exec failure. */
+   int db1_txn_begin(sqlite3 *db, const char *begin_sql);
+   int db1_txn_end(sqlite3 *db, const char *end_sql);
+
    /* Copy a TEXT column into a fixed-size buffer with NULL-safety — the
     * `snprintf(dst, cap, "%s", sqlite3_column_text(...) ?: "")` shape that
     * ~19 db1 row-mapper .c files each open-coded as a private static. */

--- a/src/db1/local_operator.c
+++ b/src/db1/local_operator.c
@@ -9,17 +9,17 @@
 
 static int begin_tx(sqlite3 *db)
 {
-   return sqlite3_exec(db, "BEGIN IMMEDIATE TRANSACTION", NULL, NULL, NULL) == SQLITE_OK ? 0 : -1;
+   return db1_txn_begin(db, "BEGIN IMMEDIATE TRANSACTION");
 }
 
 static void rollback_tx(sqlite3 *db)
 {
-   sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+   db1_txn_end(db, "ROLLBACK");
 }
 
 static int commit_tx(sqlite3 *db)
 {
-   return sqlite3_exec(db, "COMMIT", NULL, NULL, NULL) == SQLITE_OK ? 0 : -1;
+   return db1_txn_end(db, "COMMIT");
 }
 
 static int clear_active(sqlite3 *db)

--- a/src/db1/model_catalog.c
+++ b/src/db1/model_catalog.c
@@ -104,18 +104,14 @@ int db1_model_catalog_replace(const char *provider, char **models, int n)
    if (!db)
       return -1;
 
-   char *err = NULL;
-   if (sqlite3_exec(db, "BEGIN IMMEDIATE", NULL, NULL, &err) != SQLITE_OK)
-   {
-      sqlite3_free(err);
+   if (db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
       return -1;
-   }
 
    sqlite3_stmt *del = NULL;
    static const char *delete_sql = "DELETE FROM model_catalog WHERE provider = ?";
    if (sqlite3_prepare_v2(db, delete_sql, -1, &del, NULL) != SQLITE_OK)
    {
-      sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      db1_txn_end(db, "ROLLBACK");
       return -1;
    }
    sqlite3_bind_text(del, 1, provider, -1, SQLITE_TRANSIENT);
@@ -123,7 +119,7 @@ int db1_model_catalog_replace(const char *provider, char **models, int n)
    sqlite3_finalize(del);
    if (!ok)
    {
-      sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      db1_txn_end(db, "ROLLBACK");
       return -1;
    }
 
@@ -135,7 +131,7 @@ int db1_model_catalog_replace(const char *provider, char **models, int n)
        " VALUES (?, ?, 0, 0, 0, 0, datetime('now'), '{}')";
    if (sqlite3_prepare_v2(db, insert_sql, -1, &ins, NULL) != SQLITE_OK)
    {
-      sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      db1_txn_end(db, "ROLLBACK");
       return -1;
    }
    for (int i = 0; i < n; i++)
@@ -147,7 +143,7 @@ int db1_model_catalog_replace(const char *provider, char **models, int n)
       if (sqlite3_step(ins) != SQLITE_DONE)
       {
          sqlite3_finalize(ins);
-         sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+         db1_txn_end(db, "ROLLBACK");
          return -1;
       }
       sqlite3_reset(ins);
@@ -155,10 +151,9 @@ int db1_model_catalog_replace(const char *provider, char **models, int n)
    }
    sqlite3_finalize(ins);
 
-   if (sqlite3_exec(db, "COMMIT", NULL, NULL, &err) != SQLITE_OK)
+   if (db1_txn_end(db, "COMMIT") != 0)
    {
-      sqlite3_free(err);
-      sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      /* gate already released; a failed COMMIT auto-rolls-back in sqlite */
       return -1;
    }
    return 0;

--- a/src/db1/session_state.c
+++ b/src/db1/session_state.c
@@ -174,12 +174,8 @@ int db1_session_state_save(const char *sid, const session_state_t *in)
    if (!db)
       return -1;
 
-   char *err = NULL;
-   if (sqlite3_exec(db, "BEGIN IMMEDIATE", NULL, NULL, &err) != SQLITE_OK)
-   {
-      sqlite3_free(err);
+   if (db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
       return -1;
-   }
 
    /* Upsert scalar row. */
    sqlite3_stmt *stmt = NULL;
@@ -387,15 +383,12 @@ int db1_session_state_save(const char *sid, const session_state_t *in)
       sqlite3_finalize(stmt);
    }
 
-   if (sqlite3_exec(db, "COMMIT", NULL, NULL, &err) != SQLITE_OK)
-   {
-      sqlite3_free(err);
-      goto rollback;
-   }
+   if (db1_txn_end(db, "COMMIT") != 0)
+      return -1; /* gate already released; a failed COMMIT auto-rolls-back */
    return 0;
 
 rollback:
-   sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+   db1_txn_end(db, "ROLLBACK");
    return -1;
 }
 

--- a/src/db1/wfe_binding.c
+++ b/src/db1/wfe_binding.c
@@ -20,7 +20,7 @@ int db1_wfe_bind(const char *session_id, const char *work_item_id, const char *e
 
    /* IMMEDIATE so the single-writer check + upsert are one atomic write txn
     * (two concurrent binds on the same work-item can't both pass the check). */
-   if (sqlite3_exec(db, "BEGIN IMMEDIATE", NULL, NULL, NULL) != SQLITE_OK)
+   if (db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
       return -1;
 
    int rc = 0;
@@ -48,7 +48,7 @@ int db1_wfe_bind(const char *session_id, const char *work_item_id, const char *e
    }
    if (rc != 0)
    {
-      sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
+      db1_txn_end(db, "ROLLBACK");
       return rc;
    }
 
@@ -71,7 +71,7 @@ int db1_wfe_bind(const char *session_id, const char *work_item_id, const char *e
          rc = -1;
       sqlite3_finalize(stmt);
    }
-   sqlite3_exec(db, rc == 0 ? "COMMIT" : "ROLLBACK", NULL, NULL, NULL);
+   db1_txn_end(db, rc == 0 ? "COMMIT" : "ROLLBACK");
    return rc;
 }
 

--- a/src/db1/wfe_store.c
+++ b/src/db1/wfe_store.c
@@ -763,22 +763,18 @@ int db1_stage_attempt_get(const char *wi, const char *stage)
    return v;
 }
 
-static int txn_exec(const char *cmd)
-{
-   sqlite3 *db = db1_conn();
-   if (!db)
-      return -1;
-   return sqlite3_exec(db, cmd, NULL, NULL, NULL) == SQLITE_OK ? 0 : -1;
-}
+/* All three route through the db1 transaction gate (db1_internal.h): begin
+ * holds the cross-thread mutex until the matching commit/rollback, so parallel
+ * engine advances can't interleave transactions on the shared connection. */
 int db1_lifecycle_txn_begin(void)
 {
-   return txn_exec("BEGIN IMMEDIATE");
+   return db1_txn_begin(db1_conn(), "BEGIN IMMEDIATE");
 }
 int db1_lifecycle_txn_commit(void)
 {
-   return txn_exec("COMMIT");
+   return db1_txn_end(db1_conn(), "COMMIT");
 }
 int db1_lifecycle_txn_rollback(void)
 {
-   return txn_exec("ROLLBACK");
+   return db1_txn_end(db1_conn(), "ROLLBACK");
 }

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -3,8 +3,9 @@
  * Drives active autonomous work items forward via wfe_autonomy_run on a
  * background thread, so a submitted proposal runs to completion (or to a human
  * gate) regardless of who is connected. Wakes on notify (submit / gate satisfied)
- * and on a periodic backstop sweep. Bounded concurrency = 1 (sequential) for now;
- * the roundtable's Q1 home (coord-dispatcher) pattern is mirrored here. */
+ * and on a periodic backstop sweep. Each sweep drives eligible items via a
+ * bounded worker pool (AIMEE_AUTONOMY_CONCURRENCY, default 8) in LRU order;
+ * DB transaction safety across workers is the db1 txn gate. */
 #include "wfe_scheduler.h"
 
 #include "log.h"
@@ -34,16 +35,66 @@ static int g_notified;
  * the deliberate exception — autonomy re-runs the panel a bounded number of times
  * (one attempt per sweep) so a momentary provider blip self-heals rather than
  * dead-ending the run. Terminal/interactive items are skipped. */
+/* Concurrency of the autonomy pass. Delegate work dominates a stage's
+ * wall-clock, and stages are independent per work item (a fresh fan-out is a
+ * dozen sibling slices), so driving one item at a time serializes hours of
+ * delegate runs behind each other. DB safety under parallel advances comes
+ * from the db1 transaction gate (db1_internal.h) — the engine's short
+ * post-executor transactions are mutually exclusive; delegate execution
+ * itself holds no transaction (see wfe_engine_advance). */
+static long wfe_sched_concurrency(void)
+{
+   const char *v = getenv("AIMEE_AUTONOMY_CONCURRENCY");
+   if (v && v[0])
+   {
+      char *end = NULL;
+      long k = strtol(v, &end, 10);
+      if (end && *end == '\0' && k >= 1 && k <= 64)
+         return k;
+   }
+   return 8;
+}
+
+/* Work-stealing cursor shared by the pass workers. */
+typedef struct
+{
+   db1_work_item_t *items;
+   int n;
+   int next; /* next unclaimed index; guarded by lock */
+   pthread_mutex_t lock;
+} sched_pass_t;
+
+static void *wfe_sched_worker(void *arg)
+{
+   sched_pass_t *p = arg;
+   for (;;)
+   {
+      pthread_mutex_lock(&p->lock);
+      int i = (p->next < p->n) ? p->next++ : -1;
+      pthread_mutex_unlock(&p->lock);
+      if (i < 0)
+         return NULL;
+      char err[256] = "";
+      if (wfe_autonomy_run(p->items[i].work_item_id, err, sizeof err) != 0)
+         aimee_log(LOG_WARN, "wfe-sched", "autonomy run %s: %s", p->items[i].work_item_id,
+                   err[0] ? err : "error");
+   }
+}
+
 void wfe_scheduler_run_once(void)
 {
-   /* LRU order (least-recently-updated first): the pass below is sequential
-    * and each item may hold the thread up to its wall-clock cap, so a fixed
-    * newest-first order lets the busiest items eat every sweep and starve the
-    * rest (observed live: 2 of 13 slices monopolized 3.5h of sweeps). */
+   /* LRU order (least-recently-updated first): a fixed newest-first order lets
+    * the busiest items eat every sweep and starve the rest (observed live: 2 of
+    * 13 slices monopolized 3.5h of sweeps). With the parallel pass below the
+    * order decides who gets a worker FIRST when items outnumber workers. */
    db1_work_item_t *items = NULL;
    int n = db1_work_item_list_lru(&items);
    if (n <= 0 || !items)
       return;
+   /* Eligible autonomy targets are collected during the (cheap, sequential)
+    * cleanup walk, then driven by a bounded worker pool. */
+   db1_work_item_t *run = malloc((size_t)n * sizeof *run);
+   int run_n = 0;
    for (int i = 0; i < n; i++)
    {
       const char *st = items[i].state;
@@ -67,11 +118,26 @@ void wfe_scheduler_run_once(void)
          continue; /* any other non-terminal state: leave it (don't reap its worktree) */
       if (strcmp(items[i].mode, "autonomous") != 0)
          continue; /* interactive items are human-driven in the webchat */
-      char err[256] = "";
-      if (wfe_autonomy_run(items[i].work_item_id, err, sizeof err) != 0)
-         aimee_log(LOG_WARN, "wfe-sched", "autonomy run %s: %s", items[i].work_item_id,
-                   err[0] ? err : "error");
+      if (run)
+         run[run_n++] = items[i];
    }
+   if (run && run_n > 0)
+   {
+      sched_pass_t pass = {run, run_n, 0, PTHREAD_MUTEX_INITIALIZER};
+      long want = wfe_sched_concurrency();
+      int k = (int)((want < run_n) ? want : run_n);
+      pthread_t tids[64];
+      int spawned = 0;
+      for (int i = 0; i < k; i++)
+         if (pthread_create(&tids[spawned], NULL, wfe_sched_worker, &pass) == 0)
+            spawned++;
+      if (spawned == 0)
+         wfe_sched_worker(&pass); /* thread creation failed: degrade to inline */
+      for (int i = 0; i < spawned; i++)
+         pthread_join(tids[i], NULL);
+      pthread_mutex_destroy(&pass.lock);
+   }
+   free(run);
    free(items);
 
    /* Age-based orphan GC: reap wfe-worktrees dirs no live work item owns (a deleted


### PR DESCRIPTION
The autonomy pass was sequential ("bounded concurrency = 1 for now"): one thread walked the item list, each item holding it up to its wall-clock cap — a 13-slice fan-out advanced one slice at a time, serializing hours of independent delegate work.

**1) db1 transaction gate.** sqlite allows one open transaction per connection and every subsystem shares the db1 handle, so parallel advances would collide ("cannot start a transaction within a transaction") or worse, commit each other's half-done writes. A process-wide mutex now guards explicit transactions: `db1_txn_begin` locks then BEGINs, `db1_txn_end` COMMITs/ROLLBACKs then unlocks. All seven `BEGIN IMMEDIATE` sites route through it (engine lifecycle txns, capped submit, binding, coord/cognify jobs, model catalog, session state, local operator). With #1326 the engine's transactions no longer span executors, so the gate is held for milliseconds.

**2) Worker-pool sweep.** `run_once` collects eligible items during the cheap cleanup walk, then drives them with up to `AIMEE_AUTONOMY_CONCURRENCY` workers (default 8, env-overridable 1..64) pulling from a shared cursor in LRU order (#1329) — so when items outnumber workers, the longest-waiting go first. Thread-creation failure degrades to the old inline sequential pass.

Tests: `unit-test-wfe-scheduler` (now exercising the pool path), `unit-test-wfe-engine`, `unit-test-wfe-autonomy`, `unit-test-cognify-jobs`, `unit-test-coord-jobs`, `unit-test-wfe-binding` all pass locally.