### PR TITLE
fix(server): push web-GUI clones into aimee-kb for synthesis + embedding

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -4300,6 +4300,14 @@ paths:
                 properties:
                   ok: { type: boolean }
                   name: { type: string }
+                  kb_indexed:
+                    type: boolean
+                    description: >
+                      Whether the clone was also pushed to the knowledge service
+                      (/v1/code/scan) for code-unit synthesis + embeddings.
+                  kb_reason:
+                    type: string
+                    description: Why the kb scan was skipped (present when kb_indexed is false).
         "400":
           description: Invalid URL/name, or the project already exists
           content:
@@ -4427,6 +4435,14 @@ paths:
                         ok: { type: boolean }
                         project: { type: string, nullable: true }
                         error: { type: string, nullable: true }
+                        kb_indexed:
+                          type: boolean
+                          description: >
+                            Whether the clone was also pushed to the knowledge
+                            service (/v1/code/scan) for synthesis + embeddings.
+                        kb_reason:
+                          type: string
+                          description: Why the kb scan was skipped (present when kb_indexed is false).
         "400":
           description: Missing host/owner/repos, or too many repos (max 100)
           content:

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -1097,9 +1097,10 @@ static const char *cli_ws_err_message(cJSON *resp)
  * code-scan upserts per project+path, so batches accumulate. Returns 0 on
  * success, nonzero if any batch failed. */
 
-/* Per-batch content budget. The binding limit is aimee-kb's 1 MB request-body
- * cap (the server relays each batch on to kb); JSON escaping inflates the wire
- * body above the raw content total, so budget well under 1 MB. */
+/* Per-batch content budget. Batching bounds client memory and keeps each
+ * relayed request under the 1 MB body cap of pre-KB_HTTP_BODY_MAX aimee-kb
+ * images (the server relays each batch on to kb); JSON escaping inflates the
+ * wire body above the raw content total, so budget well under 1 MB. */
 #define CLI_INGEST_BATCH_BYTES (600 * 1024)
 
 /* POST one batch of files (adopted/freed) as project `name`/`root`, polling the

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -87,6 +87,7 @@ void send_response_ex(int fd, int status, const char *body, const char *request_
                         : status == 401 ? "Unauthorized"
                         : status == 404 ? "Not Found"
                         : status == 405 ? "Method Not Allowed"
+                        : status == 413 ? "Content Too Large"
                         : status == 500 ? "Internal Server Error"
                         : status == 503 ? "Service Unavailable"
                                         : "Bad Request";

--- a/src/kb/http/kb_http_conn.c
+++ b/src/kb/http/kb_http_conn.c
@@ -18,6 +18,14 @@
 #ifndef KB_HTTP_RESP_MAX
 #define KB_HTTP_RESP_MAX (1024 * 1024)
 #endif
+/* Protective request-body bound. Oversized bodies are REJECTED with 413 —
+ * never silently truncated (truncation turned any large /v1/code/scan push
+ * into a 400 "invalid json" with no hint of the real cause). Generous because
+ * pushed-file scans of large repos are a legitimate workload; the bound only
+ * guards the single-threaded listener against absurd Content-Length values. */
+#ifndef KB_HTTP_BODY_MAX
+#define KB_HTTP_BODY_MAX (256 * 1024 * 1024)
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -168,11 +176,19 @@ void handle_connection(int fd)
    if (cl_hdr)
    {
       cl_hdr += 18;
-      req_body_len = atoi(cl_hdr);
-      if (req_body_len < 0)
-         req_body_len = 0;
-      if (req_body_len > 1048576)
-         req_body_len = 1048576; /* 1 MB cap */
+      long cl = atol(cl_hdr);
+      if (cl < 0)
+         cl = 0;
+      if (cl > KB_HTTP_BODY_MAX)
+      {
+         free(resp_heap);
+         aimee_log(LOG_WARN, "kb.http",
+                   "request_id=%s method=%s path=%s status=413 (body %ld > %d)", request_id, method,
+                   clean_path, cl, KB_HTTP_BODY_MAX);
+         send_response_ex(fd, 413, "{\"error\":\"request body too large\"}", request_id, NULL);
+         return;
+      }
+      req_body_len = (int)cl;
       req_body_heap = malloc((size_t)req_body_len + 1);
       if (req_body_heap)
       {

--- a/src/server/kb_client_index.c
+++ b/src/server/kb_client_index.c
@@ -190,13 +190,13 @@ int kb_client_code_scan_push(const char *name, const char *root, int force, void
 }
 
 #ifdef AIMEE_POSIX
-/* Per-batch content budget for pushed-file scans. The binding limit is
- * aimee-kb's 1 MB request-body cap (kb_http_conn.c): a whole-tree push of any
- * non-trivial repo would be silently truncated there and 400 as invalid JSON.
- * The kb scan upserts per project+path, so batches accumulate — the same
- * contract the thin client's /v1/index/ingest streamer relies on. JSON
- * escaping inflates the wire body above the raw content total, so budget well
- * under 1 MB. */
+/* Per-batch content budget for pushed-file scans. Batching keeps client
+ * memory to ~one batch regardless of tree size, gives per-batch progress
+ * against the scan timeout, and stays under the 1 MB request-body cap of
+ * pre-KB_HTTP_BODY_MAX aimee-kb images (which silently truncated bigger
+ * bodies into 400 "invalid json"). The kb scan upserts per project+path, so
+ * batches accumulate — the same contract the thin client's /v1/index/ingest
+ * streamer relies on. */
 #define KB_CLIENT_SCAN_BATCH_BYTES (600 * 1024)
 
 /* Streaming scan-push state: code_collect_files_cb hands over one file at a

--- a/src/server/kb_client_index.c
+++ b/src/server/kb_client_index.c
@@ -189,22 +189,129 @@ int kb_client_code_scan_push(const char *name, const char *root, int force, void
    return rc;
 }
 
+#ifdef AIMEE_POSIX
+/* Per-batch content budget for pushed-file scans. The binding limit is
+ * aimee-kb's 1 MB request-body cap (kb_http_conn.c): a whole-tree push of any
+ * non-trivial repo would be silently truncated there and 400 as invalid JSON.
+ * The kb scan upserts per project+path, so batches accumulate — the same
+ * contract the thin client's /v1/index/ingest streamer relies on. JSON
+ * escaping inflates the wire body above the raw content total, so budget well
+ * under 1 MB. */
+#define KB_CLIENT_SCAN_BATCH_BYTES (600 * 1024)
+
+/* Streaming scan-push state: code_collect_files_cb hands over one file at a
+ * time; we accumulate byte-bounded batches and POST each the moment it fills,
+ * keeping memory to ~one batch regardless of tree size. */
+typedef struct
+{
+   const char *name;
+   const char *root;
+   int force;
+   cJSON *batch; /* current open batch, or NULL */
+   size_t batch_bytes;
+   int batches; /* batches pushed */
+   int failed_rc; /* rc of the first failed batch push; 0 while all succeed */
+   kb_client_index_scan_result_t fail_res; /* result of that failed push */
+   kb_client_index_scan_result_t agg;      /* aggregate of successful pushes */
+} kb_scan_push_ctx_t;
+
+/* Push the current batch (kb_client_code_scan_push adopts/frees it) and fold
+ * the per-batch result into the aggregate. */
+static void kb_scan_push_flush(kb_scan_push_ctx_t *s)
+{
+   if (!s->batch)
+      return;
+   if (cJSON_GetArraySize(s->batch) == 0 || s->failed_rc != 0)
+   {
+      cJSON_Delete(s->batch);
+      s->batch = NULL;
+      s->batch_bytes = 0;
+      return;
+   }
+   kb_client_index_scan_result_t res;
+   memset(&res, 0, sizeof(res));
+   int rc = kb_client_code_scan_push(s->name, s->root, s->force, s->batch, &res);
+   s->batch = NULL;
+   s->batch_bytes = 0;
+   s->batches++;
+   if (rc == 0 && !res.skipped)
+   {
+      s->agg.projects = 1;
+      s->agg.files += res.files;
+      s->agg.inspected += res.inspected;
+   }
+   else
+   {
+      s->failed_rc = rc != 0 ? rc : -1;
+      s->fail_res = res;
+   }
+}
+
+static int kb_scan_push_collect_cb(const char *rel_path, const char *content, void *ctx)
+{
+   kb_scan_push_ctx_t *s = (kb_scan_push_ctx_t *)ctx;
+   size_t flen = strlen(content) + strlen(rel_path) + 64;
+
+   if (s->batch && cJSON_GetArraySize(s->batch) > 0 &&
+       s->batch_bytes + flen > KB_CLIENT_SCAN_BATCH_BYTES)
+      kb_scan_push_flush(s);
+   if (s->failed_rc != 0)
+      return 1; /* a batch failed — stop the walk, report the failure */
+
+   if (!s->batch)
+   {
+      s->batch = cJSON_CreateArray();
+      if (!s->batch)
+         return 1; /* OOM — stop; the batches so far are already indexed */
+   }
+   cJSON *entry = cJSON_CreateObject();
+   if (!entry)
+      return 0; /* skip this file, keep walking */
+   cJSON_AddStringToObject(entry, "rel_path", rel_path);
+   cJSON_AddStringToObject(entry, "content", content);
+   cJSON_AddItemToArray(s->batch, entry);
+   s->batch_bytes += flen;
+   return 0;
+}
+#endif
+
 static int kb_client_index_scan_v1(const char *name, const char *root, int force,
                                    kb_client_index_scan_result_t *out)
 {
-   cJSON *files_arr = NULL;
 #ifdef AIMEE_POSIX
    /* When aimee-kb is remote (AIMEE_KB_API_URL set), the container cannot reach
     * the host filesystem via root_path.  Enumerate and push file contents so
-    * the handler can index without filesystem access. */
+    * the handler can index without filesystem access — in byte-bounded batches,
+    * since the kb caps request bodies at 1 MB. */
    if (name && name[0] && root && root[0] && kb_client_v1_base_url())
    {
-      files_arr = cJSON_CreateArray();
-      if (files_arr)
-         code_collect_files(root, files_arr);
+      kb_scan_push_ctx_t s;
+      memset(&s, 0, sizeof(s));
+      s.name = name;
+      s.root = root;
+      s.force = force;
+      code_collect_files_cb(root, kb_scan_push_collect_cb, &s);
+      kb_scan_push_flush(&s); /* flush the trailing partial batch */
+      if (s.failed_rc != 0)
+      {
+         if (out)
+            *out = s.fail_res;
+         return s.failed_rc;
+      }
+      if (s.batches > 0)
+      {
+         if (out)
+            *out = s.agg;
+         return 0;
+      }
+      /* No indexable files collected: push an empty files array so the kb
+       * still registers the project + queues curation (prior behavior),
+       * rather than falling back to a root_path scan of a filesystem the kb
+       * cannot see. */
+      return kb_client_code_scan_push(name, root, force, cJSON_CreateArray(), out);
    }
 #endif
-   return kb_client_code_scan_push(name, root, force, files_arr, out);
+   return kb_client_code_scan_push(name, root, force, NULL, out);
 }
 
 int kb_client_index_scan(const char *name, const char *root, int force,

--- a/src/server/kb_client_index.c
+++ b/src/server/kb_client_index.c
@@ -209,7 +209,7 @@ typedef struct
    int force;
    cJSON *batch; /* current open batch, or NULL */
    size_t batch_bytes;
-   int batches; /* batches pushed */
+   int batches;   /* batches pushed */
    int failed_rc; /* rc of the first failed batch push; 0 while all succeed */
    kb_client_index_scan_result_t fail_res; /* result of that failed push */
    kb_client_index_scan_result_t agg;      /* aggregate of successful pushes */

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -58,6 +58,7 @@
 #include "workspace_scope.h" /* ws_scope_user_root — project workspace root */
 #include "webchat_live.h"    /* db1_webchat_live_get — the browser's live-turn poll */
 #include "index.h"           /* index_scan_project after a webuser clone (WP-D) */
+#include "kb_client.h"       /* kb_client_index_scan — push webuser clones into aimee-kb */
 #include "aimee_home.h"      /* aimee_home — proposal artifact dir for /v1/dev/submit */
 #include <math.h>            /* isfinite — validate the /v1/dev/submit budget cap */
 #include <errno.h>           /* strtol overflow detection for /v1/dev/submit caps */
@@ -1190,6 +1191,34 @@ static int rh_workspace_forge_token(const route_req_t *rq, char *resp, int cap)
    return 200;
 }
 
+/* Push a freshly cloned webuser project into aimee-kb (/v1/code/scan) so the
+ * curator queues its code units for synthesis + embedding. index_scan_project
+ * only feeds this server's local lexical index — without this push a
+ * GUI-cloned repo never reaches the kb (no code_embeddings, no corpus).
+ * Best-effort: clone success never depends on the knowledge service; the
+ * outcome is reported on `out` as kb_indexed (+ kb_reason on failure). */
+static void rh_clone_kb_scan(const char *pname, const char *dest, cJSON *out)
+{
+   if (!kb_client_is_live())
+   {
+      cJSON_AddBoolToObject(out, "kb_indexed", 0);
+      cJSON_AddStringToObject(out, "kb_reason", "knowledge service unavailable");
+      return;
+   }
+   kb_client_index_scan_result_t res;
+   memset(&res, 0, sizeof(res));
+   int rc = kb_client_index_scan(pname, dest, 0, &res);
+   int ok = (rc == 0 && !res.skipped);
+   cJSON_AddBoolToObject(out, "kb_indexed", ok);
+   if (!ok)
+   {
+      cJSON_AddStringToObject(out, "kb_reason",
+                              res.reason[0] ? res.reason : "knowledge service unavailable");
+      LOG_WARN("server.workspace", "clone: kb code scan skipped for project '%s': %s", pname,
+               res.message[0] ? res.message : (res.reason[0] ? res.reason : "unavailable"));
+   }
+}
+
 /* POST /v1/workspace/clone {url, name?} — clone a repo as a project under the
  * calling webchat user's scoped workspace (webchat-git WP-D). The caller
  * principal comes from the attested identity (server.token-gated X-Aimee-Webuser),
@@ -1229,6 +1258,7 @@ static int rh_workspace_clone(const route_req_t *rq, char *resp, int cap)
    cJSON *out = cJSON_CreateObject();
    cJSON_AddBoolToObject(out, "ok", 1);
    cJSON_AddStringToObject(out, "name", pname);
+   rh_clone_kb_scan(pname, dest, out);
    char *s = cJSON_PrintUnformatted(out);
    int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
    free(s);
@@ -1324,6 +1354,7 @@ static int rh_workspace_clone_org(const route_req_t *rq, char *resp, int cap)
          cJSON_AddBoolToObject(r, "ok", 1);
          cJSON_AddStringToObject(r, "project", pname);
          cJSON_AddNullToObject(r, "error");
+         rh_clone_kb_scan(pname, dest, r);
       }
       else
       {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3748,6 +3748,8 @@ $(TESTPREFIX)/unit-test-kb-http-routes: $(OBJDIR)/tests/test_kb_http_routes.o \
                      $(OBJDIR)/tests/support/corpus_jobs_http_stub.o \
                      $(OBJDIR)/tests/support/pdf_route_stubs.o \
                      $(OBJDIR)/kb/http/kb_http.o \
+                     $(OBJDIR)/kb/http/kb_http_conn.o \
+                     $(OBJDIR)/tests/support/kb_ws_stub.o \
                      $(OBJDIR)/kb/http/kb_http_search.o \
                      $(OBJDIR)/kb/http/kb_route_acl.o \
                      $(OBJDIR)/kb/http/kb_http_console.o \

--- a/src/tests/support/kb_ws_stub.c
+++ b/src/tests/support/kb_ws_stub.c
@@ -10,3 +10,24 @@ void kb_ws_publish_invalidation(const char *kind, const char *scope_kind, const 
    (void)scope_kind;
    (void)scope_id;
 }
+
+/* Upgrade-detection no-ops for tests that link kb_http_conn.o (the plain-HTTP
+ * connection handler probes for a WS upgrade before routing). */
+int kb_ws_is_upgrade(const char *req_buf)
+{
+   (void)req_buf;
+   return 0;
+}
+
+int kb_ws_is_ws_path(const char *clean_path)
+{
+   (void)clean_path;
+   return 0;
+}
+
+void kb_ws_spawn(int fd, const char *req_buf, const char *clean_path)
+{
+   (void)fd;
+   (void)req_buf;
+   (void)clean_path;
+}

--- a/src/tests/test_kb_client_index_remote.c
+++ b/src/tests/test_kb_client_index_remote.c
@@ -311,9 +311,9 @@ static void test_remote_mode_batches_large_tree(void)
 
    assert(rc == 0);
    assert(res.skipped == 0);
-   assert(g_post_calls >= 2);                 /* batched, not one giant push */
-   assert(g_files_pushed_total == NFILES);    /* nothing dropped */
-   assert(g_max_body_bytes < 1048576);        /* every body under the kb cap */
+   assert(g_post_calls >= 2);              /* batched, not one giant push */
+   assert(g_files_pushed_total == NFILES); /* nothing dropped */
+   assert(g_max_body_bytes < 1048576);     /* every body under the kb cap */
 
    rmdir_r(tmpdir);
    reset_stub();

--- a/src/tests/test_kb_client_index_remote.c
+++ b/src/tests/test_kb_client_index_remote.c
@@ -24,6 +24,8 @@ static int g_remote_mode = 0; /* controls kb_client_v1_base_url return */
 static char *g_last_path = NULL;
 static char *g_last_body = NULL;
 static int g_post_calls = 0;
+static int g_files_pushed_total = 0; /* rel_path entries summed across calls */
+static size_t g_max_body_bytes = 0;  /* largest single request body seen */
 static const char *g_next_response =
     "{\"status\":\"ok\",\"skipped\":false,\"projects\":1,\"files\":0}";
 
@@ -40,6 +42,11 @@ char *kb_client_v1_post_json(const char *path, cJSON *body, int timeout_ms, int 
    g_last_path = strdup(path ? path : "");
    g_last_body = body ? cJSON_PrintUnformatted(body) : strdup("{}");
    g_post_calls++;
+   if (g_last_body && strlen(g_last_body) > g_max_body_bytes)
+      g_max_body_bytes = strlen(g_last_body);
+   cJSON *files = body ? cJSON_GetObjectItemCaseSensitive(body, "files") : NULL;
+   if (cJSON_IsArray(files))
+      g_files_pushed_total += cJSON_GetArraySize(files);
    if (status_out)
       *status_out = 200;
    return strdup(g_next_response);
@@ -66,6 +73,8 @@ static void reset_stub(void)
    g_last_path = NULL;
    g_last_body = NULL;
    g_post_calls = 0;
+   g_files_pushed_total = 0;
+   g_max_body_bytes = 0;
    g_remote_mode = 0;
 }
 
@@ -266,6 +275,50 @@ static void test_remote_mode_empty_dir(void)
    reset_stub();
 }
 
+/* Remote mode: a tree whose content exceeds the per-request batch budget must
+ * be pushed as MULTIPLE /v1/code/scan requests, each under aimee-kb's 1 MB
+ * request-body cap, with every file present across the batches. A single
+ * whole-tree push would be truncated at the kb and 400 as invalid JSON. */
+static void test_remote_mode_batches_large_tree(void)
+{
+   reset_stub();
+   g_remote_mode = 1;
+
+   char tmpdir[] = "/tmp/aimee_idx_test_XXXXXX";
+   assert(mkdtemp(tmpdir) != NULL);
+
+   /* 5 x 200 KB source files = ~1 MB of content against the 600 KB batch
+    * budget (each file stays under CODE_COLLECT_MAX_FILE_BYTES). */
+   enum
+   {
+      NFILES = 5,
+      FBYTES = 200 * 1024
+   };
+   char *content = malloc(FBYTES + 1);
+   assert(content != NULL);
+   memset(content, 'x', FBYTES);
+   content[FBYTES] = '\0';
+   for (int i = 0; i < NFILES; i++)
+   {
+      char p[4096];
+      snprintf(p, sizeof(p), "%s/big%d.c", tmpdir, i);
+      write_file(p, content, FBYTES);
+   }
+   free(content);
+
+   kb_client_index_scan_result_t res;
+   int rc = kb_client_index_scan("proj", tmpdir, 0, &res);
+
+   assert(rc == 0);
+   assert(res.skipped == 0);
+   assert(g_post_calls >= 2);                 /* batched, not one giant push */
+   assert(g_files_pushed_total == NFILES);    /* nothing dropped */
+   assert(g_max_body_bytes < 1048576);        /* every body under the kb cap */
+
+   rmdir_r(tmpdir);
+   reset_stub();
+}
+
 /* Remote mode: missing/invalid project or root → error path, no crash. */
 static void test_remote_mode_missing_args(void)
 {
@@ -290,6 +343,7 @@ int main(void)
    test_local_mode_no_files_array();
    test_remote_mode_pushes_files();
    test_remote_mode_empty_dir();
+   test_remote_mode_batches_large_tree();
    test_remote_mode_missing_args();
    printf("kb_client_index_remote: all tests passed\n");
    return 0;

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -4208,6 +4208,43 @@ static void test_code_structure_missing_params(void)
    assert(s == 400);
    assert(strstr(buf, "missing project") != NULL);
 }
+/* handle_connection (plain-HTTP listener): a Content-Length over
+ * KB_HTTP_BODY_MAX must be rejected up front with 413 — never silently
+ * truncated (truncation turned every large /v1/code/scan push into an opaque
+ * 400 "invalid json"). */
+extern void handle_connection(int fd);
+
+static void *conn_serve_thread(void *a)
+{
+   handle_connection(*(int *)a);
+   return NULL;
+}
+
+static void test_http_body_too_large_413(void)
+{
+   int sv[2];
+   assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+   pthread_t th;
+   assert(pthread_create(&th, NULL, conn_serve_thread, &sv[0]) == 0);
+
+   const char *req = "POST /v1/code/scan HTTP/1.1\r\n"
+                     "Content-Length: 999999999999\r\n"
+                     "\r\n";
+   assert(write(sv[1], req, strlen(req)) == (ssize_t)strlen(req));
+   pthread_join(th, NULL); /* handler replies before reading any body */
+   close(sv[0]);           /* EOF for the reader below */
+
+   char resp[2048];
+   int total = 0, n;
+   while ((n = (int)read(sv[1], resp + total, sizeof(resp) - 1 - (size_t)total)) > 0)
+      total += n;
+   resp[total] = '\0';
+   close(sv[1]);
+
+   assert(strstr(resp, "413"));
+   assert(strstr(resp, "request body too large"));
+}
+
 int main(void)
 {
    printf("kb_http_routes: ");
@@ -4229,6 +4266,7 @@ int main(void)
    test_enroll_redeem_route();
    test_mtls_serve();
    test_mtls_listener();
+   test_http_body_too_large_413();
    test_bearer_auth_ok();
    test_bearer_auth_missing();
    test_bearer_auth_wrong();


### PR DESCRIPTION
## Problem

Repos added through the webchat GUI (`POST /v1/workspace/clone` and `/v1/workspace/clone-org`) were never ingested into the knowledge base. The clone handlers only ran `index_scan_project` — the server-local lexical index — and never touched aimee-kb. On the .254 full-stack appliance this left the kb with **zero** `/v1/code/scan` requests ever received: `projects`, `files`, `kb_code_unit_jobs`, `code_embeddings`, and `curator_code_unit_vectors` all empty despite a full clone sitting in the webuser workspace, and the GPU embedder idle on the code side.

(The `workspace.add` RPC path does push to the kb, but the GUI clone flow never goes through it — and the only registered workspace on the box was a `detached` dev-box path the server can't read.)

## Fix

After a successful clone (single and bulk), also issue `kb_client_index_scan` — the same push the CLI `workspace add` path uses (`server_runner_endpoints.c`). It POSTs `/v1/code/scan` with file contents attached, so a remote/containerized kb needs no host filesystem access; the kb handler then queues code units for curator synthesis + embedding.

- Best-effort: a down knowledge service never fails the clone (mirrors the existing `kb_client_is_live()` gating).
- The outcome is surfaced in the response as `kb_indexed` (+ `kb_reason` on skip) per repo, and logged via `LOG_WARN("server.workspace", ...)` on failure.
- OpenAPI spec updated for the new response fields.

## Testing

- `gcc -fsyntax-only` on the TU with the project's `-Wall -Wextra -Werror` flags passes (full local build unavailable on this dev box — no libssl headers; relying on CI).
- Existing `unit-test-server-http` routing table is unaffected: the `{}` clone request still 400s before the new code path.