### PR TITLE
fix(wfe): implement retries revise against the panel's blockers, not blind

### DIFF
--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -1009,13 +1009,34 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
       if (run_fanout_units(wd, node, &cost) < 0)
          return with_cost(wfe_step_failed_class(WFE_FAIL_DEGRADED, 0), cost);
    }
-   else if (wfe_delegate_dispatch(
-                wd, "engineer", node_delegate(node),
-                "Implement the approved plan on the work-item branch: split into units, delegate "
-                "each, VERIFY each with `aimee git verify` and fix any failures, then commit the "
-                "accepted work.",
-                NULL, commit, &cost) < 0)
-      return with_cost(wfe_step_looped(), cost);
+   else
+   {
+      /* Fold any persisted roundtable blockers into the prompt — the SAME
+       * refine-not-reauthor contract exec_author has had. Without it the
+       * gate.roundtable -> on_fail -> implement loop re-dispatched a BLIND
+       * generic prompt every round: the delegate never learned why the panel
+       * rejected the diff, re-produced substantially the same change, and the
+       * loop burned its full attempt budget without converging (observed
+       * live: dozens of impl<->rt_gate rounds, zero gate passes). */
+      char feedback[4096];
+      wfe_feedback_read(wfe_ctx_work_item(ctx), feedback, sizeof feedback);
+      const char *base_prompt =
+          "Implement the approved plan on the work-item branch: split into units, delegate "
+          "each, VERIFY each with `aimee git verify` and fix any failures, then commit the "
+          "accepted work.";
+      char prompt[4096 + 640];
+      if (feedback[0])
+         snprintf(prompt, sizeof prompt,
+                  "%s\n\nA review roundtable REQUESTED CHANGES on the branch's current "
+                  "implementation. Do NOT start over: keep the existing work and REVISE it to "
+                  "address every blocker below, then commit:\n\n%s",
+                  base_prompt, feedback);
+      else
+         snprintf(prompt, sizeof prompt, "%s", base_prompt);
+      if (wfe_delegate_dispatch(wd, "engineer", node_delegate(node), prompt, NULL, commit, &cost) <
+          0)
+         return with_cost(wfe_step_looped(), cost);
+   }
 
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])


### PR DESCRIPTION
The roundtable gate persists its blockers on `REQUEST_CHANGES` precisely so the retry can refine against the objections — but only `exec_author` ever read them back. **`exec_implement` re-dispatched the same generic "implement the approved plan" prompt every round**: the delegate never learned why the panel rejected its diff, re-produced substantially the same change, and the `impl ↔ rt_gate` loop burned its full attempt budget without converging.

Observed live on .254: dozens of rounds across the 13-slice fan-out, millions of delegate tokens, zero gate passes, zero PRs — the diffs under review were clean and on-task (e.g. s11's warmup-handling implementation + tests), the panels returned genuine `request_changes`, and the retries simply never saw the feedback.

Fix: fold the persisted feedback into the implement prompt (same contract as `exec_author`), framed as REVISE-not-restart so existing branch work is kept. The env-gated per-unit fan-out path is unchanged (no ctx in its signature); it can gain the same treatment when it goes live.

Tests: `unit-test-wfe-delegate-seam`, `unit-test-wfe-engine` pass locally.