### PR TITLE
feat(webchat): project delete/purge with generation-fenced kb pipeline (slice 2)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -4485,6 +4485,99 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workspace/projects/delete:
+    post:
+      summary: Delete a cloned project under the calling webchat user's workspace
+      description: >
+        Delete the project at `ref` ("<org>/<repo>" or flat "<repo>") from the
+        authenticated `webuser:` principal's workspace (webchat project
+        lifecycle, slice 2). Identity comes EXCLUSIVELY from the attested
+        `X-Aimee-Webuser` layer; a ref outside the caller's tree is a plain
+        404. Under the project lifecycle lock the last holder of the ref runs
+        the fenced knowledge purge before the filesystem removal; other
+        holders keep the shared knowledge (`kb_status` "retained"). When the
+        knowledge service is unreachable or a store fails, the delete aborts
+        with 503 and nothing is destroyed unless `force` is true, in which
+        case the filesystem proceeds and the response carries the full
+        per-store detail (`kb_status` "forced"). Every attempt — including
+        aborts — writes structured webuser_project_delete_audit_v1 lines
+        sharing the echoed `purge_id`. Capability: tool:execute.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ref]
+              properties:
+                ref:
+                  type: string
+                  description: The project ref ("<org>/<repo>" or flat "<repo>").
+                force:
+                  type: boolean
+                  description: >
+                    Proceed with the filesystem removal even when the knowledge
+                    purge fails or the service is unreachable. The response and
+                    audit carry the per-store outcome so the purge can be
+                    re-run to convergence later.
+      responses:
+        "200":
+          description: Project deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  ref: { type: string }
+                  kb_status:
+                    type: string
+                    enum: [purged, retained, forced]
+                    description: >
+                      purged — last holder, all knowledge stores cleared;
+                      retained — other holders keep the shared knowledge;
+                      forced — filesystem removed despite a kb failure.
+                  purge_id:
+                    type: string
+                    description: >
+                      The operation id shared by every audit line and the
+                      knowledge fence for this delete.
+                  kb:
+                    type: object
+                    additionalProperties: true
+                    description: >
+                      Per-store purge detail (row counts, or {"error": ...})
+                      when a purge ran; absent when retained.
+        "400":
+          description: Missing/invalid ref
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: The ref does not resolve under the caller's workspace
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "503":
+          description: >
+            Knowledge service unavailable or a store failed (without force):
+            nothing was removed; the body's `kb` member carries the detail. A
+            failed purge-cancel is reported here too ("purge committed but
+            unfinished") — re-running the delete converges.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  kb:
+                    type: object
+                    additionalProperties: true
   /workspace/git:
     post:
       summary: Run a git operation on the calling webchat user's project

--- a/api/openapi-v1.yaml
+++ b/api/openapi-v1.yaml
@@ -684,6 +684,96 @@ components:
         chunks_deleted:
           type: integer
 
+    MaintenancePurgeProjectRequest:
+      type: object
+      required: [project, generation, purge_id]
+      properties:
+        project:
+          type: string
+        generation:
+          type: string
+          description: Fence generation token (no spaces).
+        purge_id:
+          type: string
+          description: Purge operation id (no spaces).
+        takeover:
+          type: boolean
+          description: >
+            Displace a LIVE fence held by another owner. Without it a live
+            foreign fence is refused with 409.
+
+    MaintenancePurgeProjectResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        ok:
+          type: boolean
+          description: True only when every store delete succeeded.
+        project:
+          type: string
+        generation:
+          type: string
+        purge_id:
+          type: string
+        fence_replaced:
+          type: boolean
+        displaced:
+          type: object
+          description: Present when fence_replaced — the displaced owner's ids.
+          properties:
+            generation:
+              type: string
+            purge_id:
+              type: string
+        stores:
+          type: object
+          description: >
+            Per-store outcome, in fan-out order — a deleted-row count on
+            success (0 for primitives that report no count) or
+            {"error": "..."} on failure.
+          additionalProperties: true
+
+    MaintenancePurgeFenceRequest:
+      type: object
+      required: [project, generation, purge_id]
+      properties:
+        project:
+          type: string
+        generation:
+          type: string
+        purge_id:
+          type: string
+
+    MaintenancePurgeHeartbeatResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        refreshed:
+          type: boolean
+        fence:
+          type: string
+          description: >
+            Present when refreshed is false — the current fence as
+            "generation purge_id" (empty when no fence exists).
+
+    MaintenancePurgeClearResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        cleared:
+          type: boolean
+        fence:
+          type: string
+          description: >
+            Present when cleared is false — the current fence as
+            "generation purge_id" (empty when no fence exists).
+
     PipelineStatusResponse:
       type: object
       properties:
@@ -2069,6 +2159,111 @@ paths:
                 $ref: "#/components/schemas/MaintenanceClearResponse"
         "400":
           description: Missing project
+        "401":
+          description: Unauthorized
+        "500":
+          description: Clear failed
+
+  /maintenance/purge-project:
+    post:
+      operationId: postMaintenancePurgeProject
+      summary: Purge every kb store for a project under a generation fence
+      description: >
+        Writes the project-purge generation fence, then deletes the project
+        from every kb store the ingest path writes (chunks, file index,
+        vectors, code embeddings, curator code-unit vectors, canonical index,
+        code-unit jobs, pdf vectors, minhash), continuing past per-store
+        failures. The fence is NOT cleared here — call purge-finalize (or
+        purge-cancel) once the caller's own deletion completed. Idempotent.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MaintenancePurgeProjectRequest"
+      responses:
+        "200":
+          description: Purge fan-out completed (see per-store outcomes)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MaintenancePurgeProjectResponse"
+        "400":
+          description: Missing or invalid parameters
+        "401":
+          description: Unauthorized
+        "409":
+          description: A live fence is held by another owner (takeover absent)
+        "500":
+          description: Fence write failed
+
+  /maintenance/purge-heartbeat:
+    post:
+      operationId: postMaintenancePurgeHeartbeat
+      summary: Refresh the project-purge fence heartbeat
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MaintenancePurgeFenceRequest"
+      responses:
+        "200":
+          description: Heartbeat outcome (refreshed false on fence mismatch)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MaintenancePurgeHeartbeatResponse"
+        "400":
+          description: Missing or invalid parameters
+        "401":
+          description: Unauthorized
+        "500":
+          description: Heartbeat failed
+
+  /maintenance/purge-finalize:
+    post:
+      operationId: postMaintenancePurgeFinalize
+      summary: Clear the project-purge fence after deletion completed
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MaintenancePurgeFenceRequest"
+      responses:
+        "200":
+          description: Clear outcome (cleared false on fence mismatch)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MaintenancePurgeClearResponse"
+        "400":
+          description: Missing or invalid parameters
+        "401":
+          description: Unauthorized
+        "500":
+          description: Clear failed
+
+  /maintenance/purge-cancel:
+    post:
+      operationId: postMaintenancePurgeCancel
+      summary: Clear the project-purge fence on abort
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MaintenancePurgeFenceRequest"
+      responses:
+        "200":
+          description: Clear outcome (cleared false on fence mismatch)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MaintenancePurgeClearResponse"
+        "400":
+          description: Missing or invalid parameters
         "401":
           description: Unauthorized
         "500":

--- a/src/config.c
+++ b/src/config.c
@@ -782,6 +782,7 @@ static void config_set_defaults(config_t *cfg)
 #endif
    cfg->kb_bg_watch_debounce_secs = 30;
    cfg->kb_reembed_on_dim_change = 0; /* §2c: refuse-and-instruct by default */
+   cfg->kb_purge_fence_ttl_s = 900;   /* project-purge fence staleness bound */
    cfg->kb_maintenance_enabled = 0;
    cfg->kb_maintenance_interval_hours = 24;
    cfg->kb_maintenance_lambda = 0.005;

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -1533,6 +1533,11 @@ void config_parse_kb_section2(config_t *cfg, cJSON *root)
       if (cJSON_IsBool(item))
          cfg->kb_reembed_on_dim_change = cJSON_IsTrue(item) ? 1 : 0;
 
+      /* Project-purge generation-fence TTL (webchat-project-lifecycle slice 2). */
+      item = cJSON_GetObjectItemCaseSensitive(kb, "purge_fence_ttl_s");
+      if (cJSON_IsNumber(item) && item->valuedouble > 0)
+         cfg->kb_purge_fence_ttl_s = (int)item->valuedouble;
+
       cJSON *bg = cJSON_GetObjectItemCaseSensitive(kb, "background_ingest");
       if (cJSON_IsObject(bg))
       {

--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -17,6 +17,7 @@
 #include "css_graph.h" /* CSS migration assistant: style graph + component join (WP-C/D) */
 #include "db2.h"
 #include "db2_internal.h"
+#include "kb_runtime_state.h" /* db2_kb_purge_fence_active: commit-point fence check */
 
 #include "aimee.h"
 #include "db_postgres.h"
@@ -196,14 +197,18 @@ static int ci_file_modified_since(void *conn, int64_t project_id, const char *re
 
 /* ---- File body replacement (transactional) --------------------- */
 
-static void ci_replace_file_data(void *conn, int64_t file_id, const char *ext, const char *content)
+/* Returns 0 on success, -1 when the write was aborted at its commit point
+ * because a purge fence is active for `project` (webchat-project-lifecycle
+ * slice 2) — callers must stop the scan for that project. */
+static int ci_replace_file_data(void *conn, const char *project, int64_t file_id, const char *ext,
+                                const char *content)
 {
    char err[CI_ERRBUF] = "";
 
    if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
    {
       LOG_WARN(CI_LOG_TAG, "BEGIN failed: %s", err);
-      return;
+      return 0;
    }
 
    db2_exec_conn_int64(conn, "DELETE FROM file_exports WHERE file_id = ?1", file_id);
@@ -365,11 +370,23 @@ static void ci_replace_file_data(void *conn, int64_t file_id, const char *ext, c
          aimee_pg_finalize(st);
    }
 
+   /* Generation-fence check INSIDE the transaction, immediately before
+    * COMMIT: an in-flight scan that started pre-fence still cannot commit
+    * index rows for a project being purged. */
+   if (db2_kb_purge_fence_active(project))
+   {
+      LOG_WARN(CI_LOG_TAG, "purge fence active for project '%s': aborting index write",
+               project ? project : "?");
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
+   }
+
    if (aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
    {
       LOG_WARN(CI_LOG_TAG, "COMMIT failed: %s", err);
       aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
    }
+   return 0;
 }
 
 /* CSS migration assistant (WP-C/D): build the style graph for .css files and the
@@ -1106,7 +1123,15 @@ int canonical_index_scan_project(const char *name, const char *root, int force, 
       }
 
       const char *ext = ci_get_extension(full);
-      ci_replace_file_data(conn, file_id, ext, content);
+      if (ci_replace_file_data(conn, name, file_id, ext, content) != 0)
+      {
+         /* Purge fence: abort the whole scan for this project. */
+         free(content);
+         for (int j = i; j < list.count; j++)
+            free(list.paths[j]);
+         free(list.paths);
+         return -1;
+      }
       ci_css_index_file(file_id, ext, content, css_on);
 
       free(content);
@@ -1159,7 +1184,13 @@ int canonical_index_scan_files(const char *name, const char *root_label,
          continue;
 
       const char *css_ext = ci_get_extension(rel);
-      ci_replace_file_data(conn, file_id, css_ext, content);
+      if (ci_replace_file_data(conn, name, file_id, css_ext, content) != 0)
+      {
+         /* Purge fence: abort the whole scan for this project. */
+         if (inspected_out)
+            *inspected_out = inspected;
+         return -1;
+      }
       ci_css_index_file(file_id, css_ext, content, css_on);
       scanned++;
    }

--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -372,7 +372,16 @@ static int ci_replace_file_data(void *conn, const char *project, int64_t file_id
 
    /* Generation-fence check INSIDE the transaction, immediately before
     * COMMIT: an in-flight scan that started pre-fence still cannot commit
-    * index rows for a project being purged. */
+    * index rows for a project being purged. The advisory guard serializes
+    * this check+commit against the fence-publish transaction, closing the
+    * "checked no-fence, fence lands, stale commit" window. */
+   if (db2_kb_purge_txn_guard(project) != 0)
+   {
+      LOG_WARN(CI_LOG_TAG, "purge guard failed for project '%s': aborting index write",
+               project ? project : "?");
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
+   }
    if (db2_kb_purge_fence_active(project))
    {
       LOG_WARN(CI_LOG_TAG, "purge fence active for project '%s': aborting index write",

--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -605,6 +605,28 @@ int db2_code_index_purge_hidden_pollution(void)
    return total;
 }
 
+int db2_code_index_project_delete(const char *name)
+{
+   if (!name || !name[0])
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char err[CIDX_ERRBUF] = "";
+   /* Children (files -> file_exports/file_imports/terms/code_calls/
+    * file_contents) all cascade off the projects row (schema.sql FKs). */
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn, "DELETE FROM projects WHERE name = ?1", err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", name);
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   int changes = aimee_pg_stmt_changes(st);
+   aimee_pg_finalize(st);
+   return (rc == AIMEE_PG_DONE) ? changes : -1;
+}
+
 int db2_code_index_file_replace(int64_t file_id, const code_index_file_data_t *data)
 {
    if (!data)

--- a/src/db2/code_index.h
+++ b/src/db2/code_index.h
@@ -100,6 +100,14 @@ extern "C"
     * a no-op once the index is clean. */
    int db2_code_index_purge_hidden_pollution(void);
 
+   /* Delete one project's entire canonical-index tree by project NAME:
+    * the projects row plus (via ON DELETE CASCADE) files, file_exports,
+    * file_imports, terms, code_calls and file_contents. Part of the
+    * /v1/maintenance/purge-project fan-out (webchat-project-lifecycle
+    * slice 2). Returns projects rows deleted (0 when the name is unknown —
+    * idempotent), or -1 on DB / connection error. */
+   int db2_code_index_project_delete(const char *name);
+
    /* Bundle of per-file derived data passed to db2_code_index_file_replace. */
    typedef struct
    {

--- a/src/db2/css_graph.c
+++ b/src/db2/css_graph.c
@@ -4,12 +4,42 @@
 #include "db2.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
+#include "kb_runtime_state.h" /* purge fence: guard + commit-point check */
 
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 
 #define CSSG_ERRBUF 256
+
+/* Purge-fence commit gate (webchat-project-lifecycle slice 2): CSS-derived
+ * rows are written by the scan AFTER the fenced per-file canonical-index
+ * transaction, so they need their own guarded commit-point check. Resolves
+ * the owning project from file_id INSIDE the open transaction, takes the
+ * shared advisory guard, then checks the fence. Returns 1 when the commit
+ * must be aborted (fence active or guard failed — fail closed), 0 to
+ * proceed (including "file row gone": the delete cascade already owns it). */
+static int cssg_purge_fence_abort(void *conn, int64_t file_id)
+{
+   char project[256] = "";
+   char err[CSSG_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
+                                          "SELECT p.name FROM projects p"
+                                          " JOIN files f ON f.project_id = p.id"
+                                          " WHERE f.id = ?1",
+                                          err, sizeof(err));
+   if (!st)
+      return 1;
+   aimee_pg_bind_int64(st, "?1", file_id);
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      db2_copy_text(project, sizeof(project), aimee_pg_column_text(st, 0));
+   aimee_pg_finalize(st);
+   if (!project[0])
+      return 0;
+   if (db2_kb_purge_txn_guard(project) != 0)
+      return 1;
+   return db2_kb_purge_fence_active(project) ? 1 : 0;
+}
 
 int64_t db2_css_graph_resolve_file(const char *project, const char *file_path)
 {
@@ -105,6 +135,8 @@ int db2_css_graph_replace(int64_t file_id, const css_rule_t *rules, int n)
       }
    }
 
+   if (rc == 0 && cssg_purge_fence_abort(conn, file_id))
+      rc = -1;
    if (rc == 0)
       aimee_pg_exec(conn, "COMMIT", err, sizeof(err));
    else
@@ -447,6 +479,8 @@ int db2_css_component_resolve(int64_t component_file_id, const char (*tokens)[CS
       aimee_pg_finalize(si);
    }
 
+   if (rc == 0 && cssg_purge_fence_abort(conn, component_file_id))
+      rc = -1;
    if (rc == 0)
       aimee_pg_exec(conn, "COMMIT", err, sizeof(err));
    else

--- a/src/db2/kb_runtime_state.c
+++ b/src/db2/kb_runtime_state.c
@@ -174,8 +174,9 @@ static void kbrs_fence_keys(const char *project, char *key, size_t key_cap, char
 }
 
 /* 1 iff the heartbeat row for ts_key is younger than `secs`. A missing or
- * unparseable heartbeat row counts as NOT within — an expired (or partially
- * written) fence is treated as absent so it can never block writers forever. */
+ * unparseable heartbeat row counts as NOT within. (Writer-side fail-closed
+ * handling of "identity row without a heartbeat row" lives in
+ * db2_kb_purge_fence_active, not here — liveness callers want stale=0.) */
 static int kbrs_fence_ts_within(const char *ts_key, int secs)
 {
    void *conn = db2_conn();
@@ -201,16 +202,149 @@ static int kbrs_fence_ts_within(const char *ts_key, int secs)
    return within;
 }
 
+/* Project-keyed transaction-scoped advisory lock, shared by the fence-publish
+ * transaction (purge route) and every writer's commit-point check: taking it
+ * on both sides serializes "publish fence" against "check fence + commit", so
+ * a writer that read no-fence cannot commit after the fence lands. Must be
+ * called INSIDE an open transaction (the lock is xact-scoped). Under the
+ * sqlite test shim both functions are registered as no-ops — sqlite's
+ * single-writer serialization covers the same guarantee. */
+int db2_kb_purge_txn_guard(const char *project)
+{
+   if (!project || !project[0])
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char err[KBRS_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn, "SELECT pg_advisory_xact_lock(hashtext('aimee_purge:' || ?1))", err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+   return (rc == AIMEE_PG_ROW || rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+/* Write both fence rows, TS ROW FIRST, inside the (possibly already open)
+ * caller transaction. Ordering matters: a torn write can then only leave an
+ * orphan ts row (harmless — inactive without the identity row), never an
+ * identity row without a heartbeat. */
+static int kbrs_fence_write_rows(const char *project, const char *generation, const char *purge_id)
+{
+   char key[320], ts_key[320], value[256];
+   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
+   snprintf(value, sizeof(value), "%s %s", generation, purge_id);
+   if (db2_kb_runtime_state_set_now(ts_key) != 0)
+      return -1;
+   return db2_kb_runtime_state_set(key, value);
+}
+
 int db2_kb_purge_fence_write(const char *project, const char *generation, const char *purge_id)
 {
    if (!project || !project[0] || !generation || !generation[0] || !purge_id || !purge_id[0])
       return -1;
-   char key[320], ts_key[320], value[256];
-   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
-   snprintf(value, sizeof(value), "%s %s", generation, purge_id);
-   if (db2_kb_runtime_state_set(key, value) != 0)
+   void *conn = db2_conn();
+   if (!conn)
       return -1;
-   return db2_kb_runtime_state_set_now(ts_key);
+
+   char err[KBRS_ERRBUF] = "";
+   if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
+      return -1;
+   if (kbrs_fence_write_rows(project, generation, purge_id) != 0 ||
+       aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
+   }
+   return 0;
+}
+
+int db2_kb_purge_fence_acquire(const char *project, const char *generation, const char *purge_id,
+                               int takeover, char *cur_gen, size_t gen_cap, char *cur_pid,
+                               size_t pid_cap, int *replaced_out)
+{
+   if (cur_gen && gen_cap)
+      cur_gen[0] = '\0';
+   if (cur_pid && pid_cap)
+      cur_pid[0] = '\0';
+   if (replaced_out)
+      *replaced_out = 0;
+   if (!project || !project[0] || !generation || !generation[0] || !purge_id || !purge_id[0])
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char key[320], ts_key[320];
+   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
+
+   char err[KBRS_ERRBUF] = "";
+   if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
+      return -1;
+   /* Guard FIRST: serializes this publish against every writer's
+    * guard-then-check commit point. */
+   if (db2_kb_purge_txn_guard(project) != 0)
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
+   }
+
+   /* Read-decide-write on the identity row under FOR UPDATE so two
+    * concurrent purge-project calls serialize on the same decision. */
+   char have_gen[128] = "", have_pid[128] = "";
+   int have = 0;
+   {
+      aimee_pg_stmt_t *st = aimee_pg_prepare(
+          conn, "SELECT state_value FROM kb_runtime_state WHERE state_key = ?1 FOR UPDATE", err,
+          sizeof(err));
+      if (!st)
+      {
+         aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+         return -1;
+      }
+      aimee_pg_bind_text(st, "?1", key);
+      if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         char value[256] = "";
+         const char *v = aimee_pg_column_text(st, 0);
+         snprintf(value, sizeof(value), "%s", v ? v : "");
+         char *sp = strchr(value, ' ');
+         if (sp)
+            *sp = '\0';
+         snprintf(have_gen, sizeof(have_gen), "%s", value);
+         snprintf(have_pid, sizeof(have_pid), "%s", sp ? sp + 1 : "");
+         have = 1;
+      }
+      aimee_pg_finalize(st);
+   }
+   if (cur_gen && gen_cap)
+      snprintf(cur_gen, gen_cap, "%s", have_gen);
+   if (cur_pid && pid_cap)
+      snprintf(cur_pid, pid_cap, "%s", have_pid);
+
+   int same = have && strcmp(have_gen, generation) == 0 && strcmp(have_pid, purge_id) == 0;
+   /* LIVE = heartbeat younger than TTL/3 (2x the expected TTL/6 heartbeat
+    * interval). A live foreign fence is refused without takeover. */
+   if (have && !same && !takeover && kbrs_fence_ts_within(ts_key, kbrs_fence_ttl_s() / 3))
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return 0;
+   }
+   if (replaced_out)
+      *replaced_out = (have && !same);
+
+   if (kbrs_fence_write_rows(project, generation, purge_id) != 0 ||
+       aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      if (replaced_out)
+         *replaced_out = 0;
+      return -1;
+   }
+   return 1;
 }
 
 int db2_kb_purge_fence_read(const char *project, char *gen_out, size_t gen_cap, char *pid_out,
@@ -254,39 +388,84 @@ int db2_kb_purge_fence_active(const char *project)
    kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
    if (db2_kb_runtime_state_get(key, value, sizeof(value)) != 0)
       return 0;
+   /* Identity row present but no heartbeat row: FAIL CLOSED (active). The
+    * publish path writes the ts row first inside one transaction, so this
+    * state cannot arise from a torn write — only from manual surgery — and
+    * treating it as active keeps "a partially written fence is never
+    * inactive". An OLD heartbeat (row present, past TTL) is still expiry. */
+   char ts[64] = "";
+   if (db2_kb_runtime_state_get(ts_key, ts, sizeof(ts)) != 0)
+      return 1;
    return kbrs_fence_ts_within(ts_key, kbrs_fence_ttl_s());
-}
-
-/* Match rule shared by heartbeat/finalize/cancel: BOTH generation and purge_id
- * must equal the stored fence; a displaced owner mismatches and no-ops. */
-static int kbrs_fence_matches(const char *project, const char *generation, const char *purge_id)
-{
-   char gen[128] = "", pid[128] = "";
-   if (db2_kb_purge_fence_read(project, gen, sizeof(gen), pid, sizeof(pid), NULL) != 1)
-      return 0;
-   return generation && purge_id && strcmp(gen, generation) == 0 && strcmp(pid, purge_id) == 0;
 }
 
 int db2_kb_purge_fence_heartbeat(const char *project, const char *generation, const char *purge_id)
 {
-   if (!project || !project[0])
+   if (!project || !project[0] || !generation || !purge_id)
       return -1;
-   if (!kbrs_fence_matches(project, generation, purge_id))
-      return 0;
-   char key[320], ts_key[320];
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char key[320], ts_key[320], expected[256];
    kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
-   return db2_kb_runtime_state_set_now(ts_key) == 0 ? 1 : -1;
+   snprintf(expected, sizeof(expected), "%s %s", generation, purge_id);
+
+   /* Single conditional statement: the match test and the refresh are one
+    * atomic step, so a displaced owner cannot interleave between them. */
+   char err[KBRS_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn,
+                        "UPDATE kb_runtime_state SET state_value = pg_now_text()"
+                        " WHERE state_key = ?1"
+                        "   AND EXISTS (SELECT 1 FROM kb_runtime_state"
+                        "                WHERE state_key = ?2 AND state_value = ?3)",
+                        err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", ts_key);
+   aimee_pg_bind_text(st, "?2", key);
+   aimee_pg_bind_text(st, "?3", expected);
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   int changes = aimee_pg_stmt_changes(st);
+   aimee_pg_finalize(st);
+   if (rc != AIMEE_PG_DONE)
+      return -1;
+   return changes > 0 ? 1 : 0;
 }
 
 int db2_kb_purge_fence_clear(const char *project, const char *generation, const char *purge_id)
 {
-   if (!project || !project[0])
+   if (!project || !project[0] || !generation || !purge_id)
       return -1;
-   if (!kbrs_fence_matches(project, generation, purge_id))
-      return 0;
-   char key[320], ts_key[320];
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char key[320], ts_key[320], expected[256];
    kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
-   int rc = db2_kb_runtime_state_delete(key);
-   int rc_ts = db2_kb_runtime_state_delete(ts_key);
-   return (rc == 0 && rc_ts == 0) ? 1 : -1;
+   snprintf(expected, sizeof(expected), "%s %s", generation, purge_id);
+
+   /* One DELETE covering both rows, guarded by the same EXISTS match: the
+    * match test and the removal cannot be interleaved by a new owner. */
+   char err[KBRS_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn,
+                        "DELETE FROM kb_runtime_state"
+                        " WHERE state_key IN (?1, ?2)"
+                        "   AND EXISTS (SELECT 1 FROM kb_runtime_state"
+                        "                WHERE state_key = ?3 AND state_value = ?4)",
+                        err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", key);
+   aimee_pg_bind_text(st, "?2", ts_key);
+   aimee_pg_bind_text(st, "?3", key);
+   aimee_pg_bind_text(st, "?4", expected);
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   int changes = aimee_pg_stmt_changes(st);
+   aimee_pg_finalize(st);
+   if (rc != AIMEE_PG_DONE)
+      return -1;
+   return changes > 0 ? 1 : 0;
 }

--- a/src/db2/kb_runtime_state.c
+++ b/src/db2/kb_runtime_state.c
@@ -6,6 +6,7 @@
 
 #include "kb_runtime_state.h"
 
+#include "config.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
 
@@ -141,4 +142,151 @@ int db2_kb_runtime_state_vector_rebuild_lock_try_acquire(void)
 void db2_kb_runtime_state_vector_rebuild_lock_release(void)
 {
    (void)db2_kb_runtime_state_delete("vector_rebuild_lock");
+}
+
+/* ── Project-purge generation fence (webchat-project-lifecycle slice 2) ──
+ *
+ * Two kb_runtime_state rows per fenced project key:
+ *   project_purging:<key>    = "<generation> <purge_id>"  (space-separated text)
+ *   project_purging_ts:<key> = pg_now_text()              (heartbeat timestamp)
+ *
+ * The value and the heartbeat live in separate rows because state_value is
+ * TEXT and the TTL idiom (state_value::timestamp > now - interval) needs a
+ * castable timestamp — a composite value would not cast. */
+
+#define KBRS_FENCE_PREFIX    "project_purging:"
+#define KBRS_FENCE_TS_PREFIX "project_purging_ts:"
+#define KBRS_FENCE_TTL_DFLT  900
+
+static int kbrs_fence_ttl_s(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) == 0 && cfg.kb_purge_fence_ttl_s > 0)
+      return cfg.kb_purge_fence_ttl_s;
+   return KBRS_FENCE_TTL_DFLT;
+}
+
+static void kbrs_fence_keys(const char *project, char *key, size_t key_cap, char *ts_key,
+                            size_t ts_cap)
+{
+   snprintf(key, key_cap, KBRS_FENCE_PREFIX "%s", project ? project : "");
+   snprintf(ts_key, ts_cap, KBRS_FENCE_TS_PREFIX "%s", project ? project : "");
+}
+
+/* 1 iff the heartbeat row for ts_key is younger than `secs`. A missing or
+ * unparseable heartbeat row counts as NOT within — an expired (or partially
+ * written) fence is treated as absent so it can never block writers forever. */
+static int kbrs_fence_ts_within(const char *ts_key, int secs)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+   if (secs < 1)
+      secs = 1;
+
+   char sql[256];
+   snprintf(sql, sizeof(sql),
+            "SELECT 1 FROM kb_runtime_state"
+            " WHERE state_key = ?1"
+            "   AND state_value::timestamp > (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')"
+            " - interval '%d seconds'",
+            secs);
+   char err[KBRS_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   aimee_pg_bind_text(st, "?1", ts_key);
+   int within = (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW) ? 1 : 0;
+   aimee_pg_finalize(st);
+   return within;
+}
+
+int db2_kb_purge_fence_write(const char *project, const char *generation, const char *purge_id)
+{
+   if (!project || !project[0] || !generation || !generation[0] || !purge_id || !purge_id[0])
+      return -1;
+   char key[320], ts_key[320], value[256];
+   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
+   snprintf(value, sizeof(value), "%s %s", generation, purge_id);
+   if (db2_kb_runtime_state_set(key, value) != 0)
+      return -1;
+   return db2_kb_runtime_state_set_now(ts_key);
+}
+
+int db2_kb_purge_fence_read(const char *project, char *gen_out, size_t gen_cap, char *pid_out,
+                            size_t pid_cap, int *live_out)
+{
+   if (gen_out && gen_cap)
+      gen_out[0] = '\0';
+   if (pid_out && pid_cap)
+      pid_out[0] = '\0';
+   if (live_out)
+      *live_out = 0;
+   if (!project || !project[0])
+      return -1;
+
+   char key[320], ts_key[320], value[256];
+   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
+   if (db2_kb_runtime_state_get(key, value, sizeof(value)) != 0)
+      return 0;
+
+   char *sp = strchr(value, ' ');
+   if (sp)
+      *sp = '\0';
+   if (gen_out && gen_cap)
+      snprintf(gen_out, gen_cap, "%s", value);
+   if (pid_out && pid_cap)
+      snprintf(pid_out, pid_cap, "%s", sp ? sp + 1 : "");
+
+   /* Liveness bound for the takeover decision: the owning delete op heartbeats
+    * at least every TTL/6 seconds, so "younger than 2x the heartbeat interval"
+    * is TTL/3 (default 300s of a 900s TTL). */
+   if (live_out)
+      *live_out = kbrs_fence_ts_within(ts_key, kbrs_fence_ttl_s() / 3);
+   return 1;
+}
+
+int db2_kb_purge_fence_active(const char *project)
+{
+   if (!project || !project[0])
+      return 0;
+   char key[320], ts_key[320], value[256];
+   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
+   if (db2_kb_runtime_state_get(key, value, sizeof(value)) != 0)
+      return 0;
+   return kbrs_fence_ts_within(ts_key, kbrs_fence_ttl_s());
+}
+
+/* Match rule shared by heartbeat/finalize/cancel: BOTH generation and purge_id
+ * must equal the stored fence; a displaced owner mismatches and no-ops. */
+static int kbrs_fence_matches(const char *project, const char *generation, const char *purge_id)
+{
+   char gen[128] = "", pid[128] = "";
+   if (db2_kb_purge_fence_read(project, gen, sizeof(gen), pid, sizeof(pid), NULL) != 1)
+      return 0;
+   return generation && purge_id && strcmp(gen, generation) == 0 && strcmp(pid, purge_id) == 0;
+}
+
+int db2_kb_purge_fence_heartbeat(const char *project, const char *generation, const char *purge_id)
+{
+   if (!project || !project[0])
+      return -1;
+   if (!kbrs_fence_matches(project, generation, purge_id))
+      return 0;
+   char key[320], ts_key[320];
+   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
+   return db2_kb_runtime_state_set_now(ts_key) == 0 ? 1 : -1;
+}
+
+int db2_kb_purge_fence_clear(const char *project, const char *generation, const char *purge_id)
+{
+   if (!project || !project[0])
+      return -1;
+   if (!kbrs_fence_matches(project, generation, purge_id))
+      return 0;
+   char key[320], ts_key[320];
+   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
+   int rc = db2_kb_runtime_state_delete(key);
+   int rc_ts = db2_kb_runtime_state_delete(ts_key);
+   return (rc == 0 && rc_ts == 0) ? 1 : -1;
 }

--- a/src/db2/kb_runtime_state.c
+++ b/src/db2/kb_runtime_state.c
@@ -399,7 +399,43 @@ int db2_kb_purge_fence_active(const char *project)
    return kbrs_fence_ts_within(ts_key, kbrs_fence_ttl_s());
 }
 
-int db2_kb_purge_fence_heartbeat(const char *project, const char *generation, const char *purge_id)
+/* Lock the identity row FOR UPDATE inside the caller's open transaction and
+ * compare it against the expected "generation purge_id" value in C.
+ * Returns 1 exact match (row stays locked until commit/rollback), 0
+ * mismatch/absent, -1 error. */
+static int kbrs_fence_match_locked(void *conn, const char *key, const char *expected)
+{
+   char err[KBRS_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn, "SELECT state_value FROM kb_runtime_state WHERE state_key = ?1 FOR UPDATE", err,
+       sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", key);
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   int match = 0;
+   if (rc == AIMEE_PG_ROW)
+   {
+      const char *v = aimee_pg_column_text(st, 0);
+      match = (v && strcmp(v, expected) == 0) ? 1 : 0;
+   }
+   aimee_pg_finalize(st);
+   if (rc == AIMEE_PG_ERR)
+      return -1;
+   return match;
+}
+
+/* Shared serialized match-then-mutate for heartbeat (clear=0) and finalize/
+ * cancel (clear=1). A bare conditional UPDATE/DELETE with an EXISTS predicate
+ * is NOT safe here: under READ COMMITTED row re-evaluation (EvalPlanQual) the
+ * statement can block on a concurrent takeover's transaction and then mutate
+ * the rows the takeover just rewrote, while its EXISTS subplan still saw the
+ * old snapshot. So mirror db2_kb_purge_fence_acquire: one transaction that
+ * takes the project advisory lock FIRST, locks the identity row FOR UPDATE,
+ * compares in C, and only then mutates. Returns 1 mutated, 0 mismatch/absent,
+ * -1 error. */
+static int kbrs_fence_mutate_matched(const char *project, const char *generation,
+                                     const char *purge_id, int clear)
 {
    if (!project || !project[0] || !generation || !purge_id)
       return -1;
@@ -411,61 +447,46 @@ int db2_kb_purge_fence_heartbeat(const char *project, const char *generation, co
    kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
    snprintf(expected, sizeof(expected), "%s %s", generation, purge_id);
 
-   /* Single conditional statement: the match test and the refresh are one
-    * atomic step, so a displaced owner cannot interleave between them. */
    char err[KBRS_ERRBUF] = "";
-   aimee_pg_stmt_t *st =
-       aimee_pg_prepare(conn,
-                        "UPDATE kb_runtime_state SET state_value = pg_now_text()"
-                        " WHERE state_key = ?1"
-                        "   AND EXISTS (SELECT 1 FROM kb_runtime_state"
-                        "                WHERE state_key = ?2 AND state_value = ?3)",
-                        err, sizeof(err));
-   if (!st)
+   if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
       return -1;
-   aimee_pg_bind_text(st, "?1", ts_key);
-   aimee_pg_bind_text(st, "?2", key);
-   aimee_pg_bind_text(st, "?3", expected);
-   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
-   int changes = aimee_pg_stmt_changes(st);
-   aimee_pg_finalize(st);
-   if (rc != AIMEE_PG_DONE)
+   if (db2_kb_purge_txn_guard(project) != 0)
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
       return -1;
-   return changes > 0 ? 1 : 0;
+   }
+   int match = kbrs_fence_match_locked(conn, key, expected);
+   if (match != 1)
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return match; /* 0 mismatch/absent, -1 error */
+   }
+
+   int rc;
+   if (clear)
+   {
+      rc = db2_kb_runtime_state_delete(key);
+      if (rc == 0)
+         rc = db2_kb_runtime_state_delete(ts_key);
+   }
+   else
+   {
+      rc = db2_kb_runtime_state_set_now(ts_key);
+   }
+   if (rc != 0 || aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
+   {
+      aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return -1;
+   }
+   return 1;
+}
+
+int db2_kb_purge_fence_heartbeat(const char *project, const char *generation, const char *purge_id)
+{
+   return kbrs_fence_mutate_matched(project, generation, purge_id, 0);
 }
 
 int db2_kb_purge_fence_clear(const char *project, const char *generation, const char *purge_id)
 {
-   if (!project || !project[0] || !generation || !purge_id)
-      return -1;
-   void *conn = db2_conn();
-   if (!conn)
-      return -1;
-
-   char key[320], ts_key[320], expected[256];
-   kbrs_fence_keys(project, key, sizeof(key), ts_key, sizeof(ts_key));
-   snprintf(expected, sizeof(expected), "%s %s", generation, purge_id);
-
-   /* One DELETE covering both rows, guarded by the same EXISTS match: the
-    * match test and the removal cannot be interleaved by a new owner. */
-   char err[KBRS_ERRBUF] = "";
-   aimee_pg_stmt_t *st =
-       aimee_pg_prepare(conn,
-                        "DELETE FROM kb_runtime_state"
-                        " WHERE state_key IN (?1, ?2)"
-                        "   AND EXISTS (SELECT 1 FROM kb_runtime_state"
-                        "                WHERE state_key = ?3 AND state_value = ?4)",
-                        err, sizeof(err));
-   if (!st)
-      return -1;
-   aimee_pg_bind_text(st, "?1", key);
-   aimee_pg_bind_text(st, "?2", ts_key);
-   aimee_pg_bind_text(st, "?3", key);
-   aimee_pg_bind_text(st, "?4", expected);
-   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
-   int changes = aimee_pg_stmt_changes(st);
-   aimee_pg_finalize(st);
-   if (rc != AIMEE_PG_DONE)
-      return -1;
-   return changes > 0 ? 1 : 0;
+   return kbrs_fence_mutate_matched(project, generation, purge_id, 1);
 }

--- a/src/db2/kb_runtime_state.h
+++ b/src/db2/kb_runtime_state.h
@@ -82,14 +82,17 @@ extern "C"
    int db2_kb_purge_fence_active(const char *project);
 
    /* Refresh the heartbeat iff BOTH generation and purge_id match the stored
-    * fence — one conditional UPDATE, so match+refresh is atomic. 1 refreshed,
-    * 0 mismatch/absent (no-op), -1 error. */
+    * fence. Serialized like acquire: one transaction taking the project
+    * advisory lock, then FOR UPDATE on the identity row, compare in C, then
+    * refresh — a displaced owner can never touch the new owner's rows. A
+    * matching owner with a missing ts row recreates it (heartbeat repair).
+    * 1 refreshed, 0 mismatch/absent (no-op), -1 error. */
    int db2_kb_purge_fence_heartbeat(const char *project, const char *generation,
                                     const char *purge_id);
 
-   /* Clear both fence rows iff BOTH generation and purge_id match — one
-    * conditional DELETE, so match+clear is atomic. 1 cleared, 0 mismatch/
-    * absent (no-op), -1 error. */
+   /* Clear both fence rows iff BOTH generation and purge_id match. Same
+    * guard + FOR UPDATE + compare-in-C serialization as heartbeat/acquire.
+    * 1 cleared, 0 mismatch/absent (no-op), -1 error. */
    int db2_kb_purge_fence_clear(const char *project, const char *generation, const char *purge_id);
 
 #ifdef __cplusplus

--- a/src/db2/kb_runtime_state.h
+++ b/src/db2/kb_runtime_state.h
@@ -41,6 +41,34 @@ extern "C"
    /* Unconditionally drop the vector rebuild-lock row. */
    void db2_kb_runtime_state_vector_rebuild_lock_release(void);
 
+   /* ── Project-purge generation fence (webchat-project-lifecycle slice 2) ──
+    * Fence rows: `project_purging:<key>` = "<generation> <purge_id>" plus a
+    * `project_purging_ts:<key>` heartbeat written via pg_now_text(). A fence
+    * whose heartbeat is older than kb_purge_fence_ttl_s (default 900) is
+    * treated as absent by writers. */
+
+   /* Write (or overwrite) the fence for `project`. 0 on success, -1 on error. */
+   int db2_kb_purge_fence_write(const char *project, const char *generation, const char *purge_id);
+
+   /* Read the current fence. Returns 1 when a fence row exists (fills gen/pid;
+    * *live_out = 1 iff the heartbeat is younger than TTL/3 — 2x the expected
+    * heartbeat interval), 0 when absent, -1 on error. */
+   int db2_kb_purge_fence_read(const char *project, char *gen_out, size_t gen_cap, char *pid_out,
+                               size_t pid_cap, int *live_out);
+
+   /* Writer-side commit-point check: 1 iff a fence row exists AND its heartbeat
+    * is within the TTL. Expired or partially written fences count as absent. */
+   int db2_kb_purge_fence_active(const char *project);
+
+   /* Refresh the heartbeat iff BOTH generation and purge_id match the stored
+    * fence. 1 refreshed, 0 mismatch/absent (no-op), -1 error. */
+   int db2_kb_purge_fence_heartbeat(const char *project, const char *generation,
+                                    const char *purge_id);
+
+   /* Clear both fence rows iff BOTH generation and purge_id match. 1 cleared,
+    * 0 mismatch/absent (no-op), -1 error. */
+   int db2_kb_purge_fence_clear(const char *project, const char *generation, const char *purge_id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/db2/kb_runtime_state.h
+++ b/src/db2/kb_runtime_state.h
@@ -47,8 +47,26 @@ extern "C"
     * whose heartbeat is older than kb_purge_fence_ttl_s (default 900) is
     * treated as absent by writers. */
 
-   /* Write (or overwrite) the fence for `project`. 0 on success, -1 on error. */
+   /* Project-keyed transaction-scoped advisory lock shared by the fence
+    * publish transaction and every writer's commit-point check. Call INSIDE
+    * an open transaction, immediately before db2_kb_purge_fence_active().
+    * 0 on success (lock held until commit/rollback), -1 on error. */
+   int db2_kb_purge_txn_guard(const char *project);
+
+   /* Write (or overwrite) the fence for `project` — both rows in ONE
+    * transaction, ts row first (a torn write can only orphan the harmless
+    * ts row). 0 on success, -1 on error. */
    int db2_kb_purge_fence_write(const char *project, const char *generation, const char *purge_id);
+
+   /* Atomic read-decide-write for the purge route: inside one transaction,
+    * take the advisory guard, SELECT the identity row FOR UPDATE, refuse a
+    * LIVE foreign fence (heartbeat younger than TTL/3) unless takeover, else
+    * publish the new fence. Returns 1 acquired (*replaced_out set; cur_* hold
+    * the displaced ids when replaced), 0 refused (cur_* hold the live owner),
+    * -1 error. */
+   int db2_kb_purge_fence_acquire(const char *project, const char *generation, const char *purge_id,
+                                  int takeover, char *cur_gen, size_t gen_cap, char *cur_pid,
+                                  size_t pid_cap, int *replaced_out);
 
    /* Read the current fence. Returns 1 when a fence row exists (fills gen/pid;
     * *live_out = 1 iff the heartbeat is younger than TTL/3 — 2x the expected
@@ -56,17 +74,22 @@ extern "C"
    int db2_kb_purge_fence_read(const char *project, char *gen_out, size_t gen_cap, char *pid_out,
                                size_t pid_cap, int *live_out);
 
-   /* Writer-side commit-point check: 1 iff a fence row exists AND its heartbeat
-    * is within the TTL. Expired or partially written fences count as absent. */
+   /* Writer-side commit-point check: 1 iff the identity row exists AND its
+    * heartbeat is within the TTL. An identity row WITHOUT a heartbeat row is
+    * ACTIVE (fail closed — cannot arise from a torn write since the ts row is
+    * written first); a heartbeat older than the TTL is expiry (absent). Call
+    * inside the writer's transaction, after db2_kb_purge_txn_guard(). */
    int db2_kb_purge_fence_active(const char *project);
 
    /* Refresh the heartbeat iff BOTH generation and purge_id match the stored
-    * fence. 1 refreshed, 0 mismatch/absent (no-op), -1 error. */
+    * fence — one conditional UPDATE, so match+refresh is atomic. 1 refreshed,
+    * 0 mismatch/absent (no-op), -1 error. */
    int db2_kb_purge_fence_heartbeat(const char *project, const char *generation,
                                     const char *purge_id);
 
-   /* Clear both fence rows iff BOTH generation and purge_id match. 1 cleared,
-    * 0 mismatch/absent (no-op), -1 error. */
+   /* Clear both fence rows iff BOTH generation and purge_id match — one
+    * conditional DELETE, so match+clear is atomic. 1 cleared, 0 mismatch/
+    * absent (no-op), -1 error. */
    int db2_kb_purge_fence_clear(const char *project, const char *generation, const char *purge_id);
 
 #ifdef __cplusplus

--- a/src/db2/kb_service_backend.c
+++ b/src/db2/kb_service_backend.c
@@ -543,17 +543,32 @@ static int db2_kb_service_async_process_embed_pdf(int64_t document_id, const cha
       snprintf(errbuf, errbuf_size, "payload build failed");
       return -1;
    }
-   /* Generation-fence check immediately before the PDF vector write
-    * (webchat-project-lifecycle slice 2): a job claimed pre-purge must not
-    * land a vector for a project being purged. Failing the job is safe — on
-    * retry after the purge the chunk row is gone (benign skip above). */
-   if (project_buf[0] && db2_kb_purge_fence_active(project_buf))
+   /* Guarded transaction around the PDF vector write with the generation-
+    * fence check inside it (webchat-project-lifecycle slice 2): a job
+    * claimed pre-purge must not land a vector for a project being purged,
+    * and the advisory guard serializes this check+commit against the fence
+    * publish. Failing the job is safe — on retry after the purge the chunk
+    * row is gone (benign skip above). */
+   if (db2_kb_txn_begin() != 0)
    {
+      free(payload_json);
+      snprintf(errbuf, errbuf_size, "pdf vector txn begin failed");
+      return -1;
+   }
+   if (project_buf[0] &&
+       (db2_kb_purge_txn_guard(project_buf) != 0 || db2_kb_purge_fence_active(project_buf)))
+   {
+      db2_kb_txn_rollback();
       free(payload_json);
       snprintf(errbuf, errbuf_size, "purge fence active for project '%s'", project_buf);
       return -1;
    }
    int upsert_rc = pgvec_kbpdf_upsert(document_id, vec, dim, payload_json);
+   if (db2_kb_txn_commit() != 0)
+   {
+      db2_kb_txn_rollback();
+      upsert_rc = -1;
+   }
    free(payload_json);
    db2_vector_index_op_record(document_id, PGVEC_KBPDF_TABLE, 0, upsert_rc == 0,
                               upsert_rc ? "pdf upsert failed" : NULL);

--- a/src/db2/kb_service_backend.c
+++ b/src/db2/kb_service_backend.c
@@ -485,10 +485,11 @@ static int db2_kb_service_async_process_embed_pdf(int64_t document_id, const cha
    }
 
    char err[KBS_ERRBUF] = "";
-   aimee_pg_stmt_t *stmt = aimee_pg_prepare(
-       conn,
-       "SELECT heading_path, content, doc_kind, quarantine_state FROM kb_documents WHERE id = ?1",
-       err, sizeof(err));
+   aimee_pg_stmt_t *stmt =
+       aimee_pg_prepare(conn,
+                        "SELECT heading_path, content, doc_kind, quarantine_state, project"
+                        " FROM kb_documents WHERE id = ?1",
+                        err, sizeof(err));
    if (!stmt)
    {
       snprintf(errbuf, errbuf_size, "prepare failed");
@@ -506,10 +507,12 @@ static int db2_kb_service_async_process_embed_pdf(int64_t document_id, const cha
    char content_buf[3072];
    char doc_kind[32];
    char quarantine[32];
+   char project_buf[256];
    db2_copy_text(heading_buf, sizeof(heading_buf), aimee_pg_column_text(stmt, 0));
    db2_copy_text(content_buf, sizeof(content_buf), aimee_pg_column_text(stmt, 1));
    db2_copy_text(doc_kind, sizeof(doc_kind), aimee_pg_column_text(stmt, 2));
    db2_copy_text(quarantine, sizeof(quarantine), aimee_pg_column_text(stmt, 3));
+   db2_copy_text(project_buf, sizeof(project_buf), aimee_pg_column_text(stmt, 4));
    aimee_pg_finalize(stmt);
 
    /* Defense-in-depth: never write a PDF vector for a non-PDF row or for ANY quarantined
@@ -538,6 +541,16 @@ static int db2_kb_service_async_process_embed_pdf(int64_t document_id, const cha
    {
       db2_vector_index_op_record(document_id, PGVEC_KBPDF_TABLE, 0, 0, "payload build failed");
       snprintf(errbuf, errbuf_size, "payload build failed");
+      return -1;
+   }
+   /* Generation-fence check immediately before the PDF vector write
+    * (webchat-project-lifecycle slice 2): a job claimed pre-purge must not
+    * land a vector for a project being purged. Failing the job is safe — on
+    * retry after the purge the chunk row is gone (benign skip above). */
+   if (project_buf[0] && db2_kb_purge_fence_active(project_buf))
+   {
+      free(payload_json);
+      snprintf(errbuf, errbuf_size, "purge fence active for project '%s'", project_buf);
       return -1;
    }
    int upsert_rc = pgvec_kbpdf_upsert(document_id, vec, dim, payload_json);

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -1421,6 +1421,33 @@ int pgvec_curator_code_unit_upsert(int64_t point_id, const float *intent_vec,
    return (rc == AIMEE_PG_DONE) ? 0 : -1;
 }
 
+int pgvec_curator_code_unit_delete_project(const char *project)
+{
+   if (!project || !project[0])
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   /* curator_code_unit_vectors has no project column: the writer records the
+    * project as the owning artifact's scope_id (scope_kind='project',
+    * kb_curator_extract_code.c), so delete via that join. The artifacts rows
+    * themselves are NOT deleted — mirroring the ingest force-clear path, which
+    * also leaves artifacts alone. */
+   static const char *sql = "DELETE FROM curator_code_unit_vectors"
+                            " WHERE artifact_id IN"
+                            "  (SELECT id FROM artifacts"
+                            "    WHERE scope_kind = 'project' AND scope_id = :proj)";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+      return -1;
+   aimee_pg_bind_text(stmt, "proj", project);
+   aimee_pg_step_t rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf));
+   int changes = aimee_pg_stmt_changes(stmt);
+   aimee_pg_finalize(stmt);
+   return (rc == AIMEE_PG_DONE) ? changes : -1;
+}
+
 int pgvec_curator_code_unit_delete(int64_t point_id)
 {
    void *pg = db2_conn();

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -171,6 +171,13 @@ int pgvec_curator_code_unit_upsert(int64_t point_id, const float *intent_vec,
 /* Delete a single curator_code_unit_vectors row by point_id. */
 int pgvec_curator_code_unit_delete(int64_t point_id);
 
+/* Purge fan-out (webchat-project-lifecycle slice 2): delete every
+ * curator_code_unit_vectors row whose owning artifact is scoped to `project`
+ * (scope_kind='project' AND scope_id=project — the table has no project
+ * column). Returns rows deleted (>=0) or -1. Artifacts rows are left intact,
+ * mirroring the ingest force-clear behavior. */
+int pgvec_curator_code_unit_delete_project(const char *project);
+
 /* Search curator_code_unit_vectors by cosine distance.  which_vec selects the
  * named vector column to rank on: "intent", "signature" or "body" (any other
  * value, including NULL, returns -1).  def_kind is an optional equality

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1547,6 +1547,13 @@ typedef struct config
     * auto-runs — the destructive reset requires the explicit confirmed command). */
    int kb_reembed_on_dim_change;
 
+   /* webchat-project-lifecycle slice 2: TTL (seconds) after which a stale
+    * project-purge generation fence (kb_runtime_state `project_purging:<key>`)
+    * is treated as absent by kb writers. The owning delete operation heartbeats
+    * the fence between phases, so only a crash between purge and finalize
+    * leaves a fence to expire. JSON key kb.purge_fence_ttl_s (default 900). */
+   int kb_purge_fence_ttl_s;
+
    /* KB maintenance (kb.maintenance.*).
     * kb_maintenance_enabled:        0 = off (default), 1 = run background decay/prune.
     * kb_maintenance_interval_hours: hours between maintenance passes (default 24).

--- a/src/headers/git_project.h
+++ b/src/headers/git_project.h
@@ -47,6 +47,40 @@ int git_project_derive_org(const char *url, char *out, size_t cap, int *multi_se
  * joined ("group, sub"), for the org_note guidance. 0 or -1. */
 int git_project_org_candidates(const char *url, char *out, size_t cap);
 
+/* --- delete (webchat project lifecycle proposal, slice 2) ---------------- */
+
+/* Outcome of one git_project_delete operation. `kb_detail` (when non-NULL) is
+ * a malloc'd JSON string — the kb purge's per-store detail on success/force,
+ * or {"error": …} on an abort — suitable for embedding as the response's
+ * "kb" member. The caller frees it. */
+typedef struct
+{
+   char kb_status[16];  /* "purged" | "retained" | "forced" */
+   char purge_id[40];   /* random hex id shared by every audit line + the fence */
+   char generation[40]; /* monotonic fence generation (last-holder purges only) */
+   char *kb_detail;     /* malloc'd JSON or NULL; caller frees */
+} git_project_delete_result_t;
+
+/* The ref did not resolve under the caller's tree (callers 404 — plain "not
+ * found", no cross-principal existence disclosure). */
+#define GP_ERR_NOT_FOUND (-3)
+/* The kb purge failed or was unreachable and force was not set: nothing
+ * filesystem was destroyed; callers 503 with res->kb_detail. */
+#define GP_ERR_KB_UNAVAILABLE (-4)
+
+/* Delete `principal`'s project `ref` (proposal slice 2, steps 1-8). Under the
+ * first-component lifecycle lock: audit intent, resolve strictly under the
+ * caller (else GP_ERR_NOT_FOUND), decide holders via the registry
+ * (resync-then-unregister); the LAST holder runs the fenced kb purge (abort
+ * with GP_ERR_KB_UNAVAILABLE and a rolled-back decrement unless `force`),
+ * then the server-local lexical index delete, the fd-relative filesystem
+ * removal, org-dir prune, and purge-finalize. Every phase logs one
+ * webuser_project_delete_audit_v1 line sharing res->purge_id. Returns 0,
+ * GP_ERR_NOT_FOUND, GP_ERR_KB_UNAVAILABLE, or -1 (validation/internal) with a
+ * short message in err[errlen]. */
+int git_project_delete(const char *principal, const char *ref, int force,
+                       git_project_delete_result_t *res, char *err, size_t errlen);
+
 /* Read the credential-free canonical remote of `principal`'s project `ref`
  * (the .aimee/remote sidecar) into out[cap]. 0 or -1 (legacy clones without a
  * sidecar return -1; callers fall back to git config or show nothing). */

--- a/src/headers/kb.h
+++ b/src/headers/kb.h
@@ -38,7 +38,20 @@ int chunk_stream(FILE *f, text_chunk_t *chunks, int max_chunks);
 const char *kb_effective_embedding_cmd(const char *embedding_cmd);
 int accept_generated_embedding(int64_t doc_id, const float *vec, int dim);
 int sync_vector_embedding(int64_t doc_id, const float *vec, int dim);
-void delete_file_chunks(const char *project, const char *file_path);
+/* Purge-fence write discipline (webchat-project-lifecycle slice 2): every
+ * project-scoped ingest write runs inside kb_purge_fenced_txn_begin/commit —
+ * an explicit transaction taking the project advisory guard and re-checking
+ * the generation fence before the write(s). begin: 1 proceed (txn open),
+ * 0 fenced / guard failed (fail closed, nothing open), -1 error. */
+int kb_purge_fenced_txn_begin(const char *project);
+int kb_purge_fenced_txn_commit(void);
+/* Fenced single-write conveniences built on the discipline above. */
+int kb_file_index_upsert_fenced(const char *project, const char *file_path, const char *hash,
+                                const char *content);
+int kb_sync_vector_embedding_fenced(const char *project, int64_t doc_id, const float *vec, int dim);
+/* Returns 0 committed, -1 dropped (purge fence active) — stop processing the
+ * file on -1. */
+int delete_file_chunks(const char *project, const char *file_path);
 /* Read |src_path| whole and upsert it as the kb_file_index body for
  * (project, file_path) — the whole-file copy served by GET /v1/kb/file, stored
  * alongside the chunks. Oversize/unreadable files store no body (chunks still

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -87,6 +87,35 @@ char *kb_client_repair_json(const char *path, const char *project, const char *e
  * On any failure the returned JSON has {"status":"error","message":"..."}. */
 char *kb_client_clear_json(const char *project);
 
+/* webchat-project-lifecycle slice 2: project purge + generation fence.
+ * Thin wrappers over the kb /v1/maintenance/purge-* routes. Each returns the
+ * heap-allocated raw JSON response (caller frees); on transport failure the
+ * returned JSON has {"status":"error","message":"..."}. */
+
+/* POST /v1/maintenance/purge-project. Writes the generation fence and fans
+ * out per-store deletes; the response carries {"ok":bool,"stores":{...}}.
+ * `takeover` non-zero displaces a live fence held by another owner (the
+ * response then includes the displaced ids); without it a live foreign fence
+ * is an HTTP 409 (surfaced as the error JSON's "returned HTTP 409" message).
+ * Does NOT clear the fence — call purge-finalize/cancel afterwards. */
+char *kb_client_purge_project_json(const char *project, const char *generation,
+                                   const char *purge_id, int takeover);
+
+/* POST /v1/maintenance/purge-heartbeat: refresh the fence heartbeat between
+ * delete phases. Response {"refreshed":bool,...}; a mismatch is a no-op. */
+char *kb_client_purge_heartbeat_json(const char *project, const char *generation,
+                                     const char *purge_id);
+
+/* POST /v1/maintenance/purge-finalize: clear the fence after the server-side
+ * deletion completed. Response {"cleared":bool,...}; a mismatch is a no-op. */
+char *kb_client_purge_finalize_json(const char *project, const char *generation,
+                                    const char *purge_id);
+
+/* POST /v1/maintenance/purge-cancel: clear the fence on abort. Same match
+ * rule / response shape as purge-finalize. */
+char *kb_client_purge_cancel_json(const char *project, const char *generation,
+                                  const char *purge_id);
+
 /* Run a KB search via aimee-kb's public /v1/search endpoint with the given
  * project / query / embedding_command / max_results / format ("text" or
  * "json") and returns the heap-allocated JSON response envelope (caller

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -38,6 +38,9 @@
 #include "db2/vector_index_ops.h"
 #include "db2/kb_runtime_state.h"
 #include "db2/corpus_jobs.h"
+#include "db2/code_index.h"
+#include "db2/pgvec_transport.h"
+#include "db2/sketch.h"
 #include "kb.h"
 #include "kb_intel_payload.h"
 #include "log.h"
@@ -592,6 +595,72 @@ static int kb_http_owner_required(char *out, int cap, const char *what)
 {
    snprintf(out, (size_t)cap, "{\"error\":\"forbidden: %s requires the owner credential\"}", what);
    return 403;
+}
+
+/* ── webchat-project-lifecycle slice 2: purge-route helpers ─────────────── */
+
+/* Append one purge fan-out store outcome: a plain count on success (0 for the
+ * primitives that report no count), {"error":...} on failure. A failing store
+ * clears *all_ok but never stops the fan-out. */
+static void purge_store_add(cJSON *stores, const char *name, int rc, int *all_ok)
+{
+   if (rc < 0)
+   {
+      cJSON *e = cJSON_CreateObject();
+      if (e)
+         cJSON_AddStringToObject(e, "error", "delete failed");
+      cJSON_AddItemToObject(stores, name, e);
+      *all_ok = 0;
+      return;
+   }
+   cJSON_AddNumberToObject(stores, name, rc);
+}
+
+/* Serialize `resp` into out_buf and delete it. Returns `status`. */
+static int purge_respond(cJSON *resp, char *out_buf, int out_cap, int status)
+{
+   char *out = resp ? cJSON_PrintUnformatted(resp) : NULL;
+   snprintf(out_buf, (size_t)out_cap, "%s", out ? out : "{\"error\":\"out of memory\"}");
+   free(out);
+   cJSON_Delete(resp);
+   return out ? status : 500;
+}
+
+/* Parse the shared purge-route body {project, generation, purge_id}. Returns 0
+ * on success; otherwise writes a 400 body and returns -1. Generation/purge_id
+ * become the space-separated fence value, so embedded spaces are rejected. */
+static int purge_body_parse(const char *body, char *project, size_t project_cap, char *generation,
+                            size_t generation_cap, char *purge_id, size_t purge_id_cap,
+                            char *out_buf, int out_cap)
+{
+   project[0] = generation[0] = purge_id[0] = '\0';
+   if (!json_str(body, "project", project, project_cap) || !project[0])
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing project\"}");
+      return -1;
+   }
+   if (!json_str(body, "generation", generation, generation_cap) || !generation[0] ||
+       strchr(generation, ' '))
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing or invalid generation\"}");
+      return -1;
+   }
+   if (!json_str(body, "purge_id", purge_id, purge_id_cap) || !purge_id[0] || strchr(purge_id, ' '))
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing or invalid purge_id\"}");
+      return -1;
+   }
+   return 0;
+}
+
+/* Current fence rendered as its stored "generation purge_id" value (empty when
+ * no fence row exists) — echoed by heartbeat/finalize/cancel mismatch paths. */
+static void purge_fence_current(const char *project, char *out, size_t out_cap)
+{
+   char gen[128] = "", pid[128] = "";
+   out[0] = '\0';
+   if (db2_kb_purge_fence_read(project, gen, sizeof(gen), pid, sizeof(pid), NULL) == 1)
+      snprintf(out, out_cap, "%s %s", gen, pid);
 }
 /* ── Phase 5 extended routing ────────────────────────────────────────────── */
 
@@ -1886,6 +1955,175 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       pos = json_escape(project, out_buf, pos, out_cap);
       snprintf(out_buf + pos, (size_t)(out_cap - pos), "\",\"chunks_deleted\":%d}", deleted);
       return 200;
+   }
+   /* POST /v1/maintenance/purge-project {project, generation, purge_id, takeover?}
+    * (webchat-project-lifecycle slice 2). Writes the generation fence, then fans
+    * out the writer→store→delete matrix IN ORDER, continuing past per-store
+    * failures. The fence is NOT cleared here — /v1/maintenance/purge-finalize
+    * (or purge-cancel) clears it after the server-side deletion completes.
+    * Idempotent: a re-run on a purged key returns zeros. */
+   if (strcmp(path, "/v1/maintenance/purge-project") == 0)
+   {
+      if (strcmp(method, "POST") != 0)
+      {
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
+         return 405;
+      }
+      char project[256], generation[128], purge_id[128];
+      if (purge_body_parse(body, project, sizeof(project), generation, sizeof(generation), purge_id,
+                           sizeof(purge_id), out_buf, out_cap) != 0)
+         return 400;
+      int takeover = json_bool(body, "takeover", 0);
+
+      char cur_gen[128] = "", cur_pid[128] = "";
+      int live = 0;
+      int have = db2_kb_purge_fence_read(project, cur_gen, sizeof(cur_gen), cur_pid,
+                                         sizeof(cur_pid), &live);
+      if (have < 0)
+      {
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"fence read failed\"}");
+         return 500;
+      }
+      int same_owner =
+          (have == 1 && strcmp(cur_gen, generation) == 0 && strcmp(cur_pid, purge_id) == 0);
+      /* A LIVE fence (heartbeat younger than 2x the heartbeat interval, i.e.
+       * TTL/3) belonging to another owner is refused without takeover:true. */
+      if (have == 1 && live && !same_owner && !takeover)
+      {
+         cJSON *resp = cJSON_CreateObject();
+         if (resp)
+         {
+            cJSON_AddStringToObject(resp, "error", "purge fence held");
+            cJSON_AddStringToObject(resp, "generation", cur_gen);
+            cJSON_AddStringToObject(resp, "purge_id", cur_pid);
+         }
+         return purge_respond(resp, out_buf, out_cap, 409);
+      }
+      int fence_replaced = (have == 1 && !same_owner);
+      if (db2_kb_purge_fence_write(project, generation, purge_id) != 0)
+      {
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"fence write failed\"}");
+         return 500;
+      }
+
+      /* Fan-out: every kb store the ingest path writes, in matrix order. */
+      cJSON *stores = cJSON_CreateObject();
+      if (!stores)
+      {
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"out of memory\"}");
+         return 500;
+      }
+      int all_ok = 1;
+      purge_store_add(stores, "chunks", db2_kb_service_clear_project(project), &all_ok);
+      purge_store_add(stores, "file_index", db2_kb_file_index_delete_project(project), &all_ok);
+      purge_store_add(stores, "vectors", pgvec_kb_vector_delete_project(project), &all_ok);
+      purge_store_add(stores, "code_embeddings", pgvec_code_delete_project(project), &all_ok);
+      purge_store_add(stores, "curator_code_unit_vectors",
+                      pgvec_curator_code_unit_delete_project(project), &all_ok);
+      purge_store_add(stores, "canonical_index", db2_code_index_project_delete(project), &all_ok);
+      purge_store_add(stores, "code_unit_jobs", kb_curator_code_unit_jobs_delete_project(project),
+                      &all_ok);
+      purge_store_add(stores, "pdf_vectors", pgvec_kbpdf_delete_project(project), &all_ok);
+      purge_store_add(stores, "minhash", db2_sketch_minhash_signature_delete_project(project),
+                      &all_ok);
+
+      cJSON *resp = cJSON_CreateObject();
+      if (!resp)
+      {
+         cJSON_Delete(stores);
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"out of memory\"}");
+         return 500;
+      }
+      cJSON_AddStringToObject(resp, "status", "ok");
+      cJSON_AddBoolToObject(resp, "ok", all_ok);
+      cJSON_AddStringToObject(resp, "project", project);
+      cJSON_AddStringToObject(resp, "generation", generation);
+      cJSON_AddStringToObject(resp, "purge_id", purge_id);
+      cJSON_AddBoolToObject(resp, "fence_replaced", fence_replaced);
+      if (fence_replaced)
+      {
+         cJSON *displaced = cJSON_CreateObject();
+         if (displaced)
+         {
+            cJSON_AddStringToObject(displaced, "generation", cur_gen);
+            cJSON_AddStringToObject(displaced, "purge_id", cur_pid);
+         }
+         cJSON_AddItemToObject(resp, "displaced", displaced);
+      }
+      cJSON_AddItemToObject(resp, "stores", stores);
+      return purge_respond(resp, out_buf, out_cap, 200);
+   }
+   /* POST /v1/maintenance/purge-heartbeat {project, generation, purge_id}:
+    * the owning delete op refreshes the fence heartbeat between phases. A
+    * displaced owner mismatches and no-ops (refreshed:false + current fence). */
+   if (strcmp(path, "/v1/maintenance/purge-heartbeat") == 0)
+   {
+      if (strcmp(method, "POST") != 0)
+      {
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
+         return 405;
+      }
+      char project[256], generation[128], purge_id[128];
+      if (purge_body_parse(body, project, sizeof(project), generation, sizeof(generation), purge_id,
+                           sizeof(purge_id), out_buf, out_cap) != 0)
+         return 400;
+      int rc = db2_kb_purge_fence_heartbeat(project, generation, purge_id);
+      if (rc < 0)
+      {
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"fence heartbeat failed\"}");
+         return 500;
+      }
+      cJSON *resp = cJSON_CreateObject();
+      if (resp)
+      {
+         cJSON_AddStringToObject(resp, "status", "ok");
+         cJSON_AddBoolToObject(resp, "refreshed", rc == 1);
+         if (rc != 1)
+         {
+            char fence[280] = "";
+            purge_fence_current(project, fence, sizeof(fence));
+            cJSON_AddStringToObject(resp, "fence", fence);
+         }
+      }
+      return purge_respond(resp, out_buf, out_cap, 200);
+   }
+   /* POST /v1/maintenance/purge-finalize | purge-cancel {project, generation,
+    * purge_id}: clear BOTH fence rows iff generation AND purge_id match. A
+    * mismatch (displaced owner) is a logged no-op returning the current fence. */
+   if (strcmp(path, "/v1/maintenance/purge-finalize") == 0 ||
+       strcmp(path, "/v1/maintenance/purge-cancel") == 0)
+   {
+      if (strcmp(method, "POST") != 0)
+      {
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
+         return 405;
+      }
+      char project[256], generation[128], purge_id[128];
+      if (purge_body_parse(body, project, sizeof(project), generation, sizeof(generation), purge_id,
+                           sizeof(purge_id), out_buf, out_cap) != 0)
+         return 400;
+      int rc = db2_kb_purge_fence_clear(project, generation, purge_id);
+      if (rc < 0)
+      {
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"fence clear failed\"}");
+         return 500;
+      }
+      cJSON *resp = cJSON_CreateObject();
+      if (resp)
+      {
+         cJSON_AddStringToObject(resp, "status", "ok");
+         cJSON_AddBoolToObject(resp, "cleared", rc == 1);
+         if (rc != 1)
+         {
+            char fence[280] = "";
+            purge_fence_current(project, fence, sizeof(fence));
+            LOG_WARN("kb_http",
+                     "%s: fence mismatch for project '%s' (presented %s %s, current '%s') — no-op",
+                     path, project, generation, purge_id, fence);
+            cJSON_AddStringToObject(resp, "fence", fence);
+         }
+      }
+      return purge_respond(resp, out_buf, out_cap, 200);
    }
    /* GET /v1/jobs/{id} */
    if (strncmp(path, "/v1/jobs/", 9) == 0 && path[9])

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1975,20 +1975,21 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          return 400;
       int takeover = json_bool(body, "takeover", 0);
 
+      /* Atomic read-decide-write: one transaction takes the project advisory
+       * guard, inspects the identity row FOR UPDATE, refuses a LIVE foreign
+       * fence (heartbeat younger than 2x the heartbeat interval, i.e. TTL/3)
+       * without takeover:true, else publishes the new fence. */
       char cur_gen[128] = "", cur_pid[128] = "";
-      int live = 0;
-      int have = db2_kb_purge_fence_read(project, cur_gen, sizeof(cur_gen), cur_pid,
-                                         sizeof(cur_pid), &live);
-      if (have < 0)
+      int fence_replaced = 0;
+      int arc =
+          db2_kb_purge_fence_acquire(project, generation, purge_id, takeover, cur_gen,
+                                     sizeof(cur_gen), cur_pid, sizeof(cur_pid), &fence_replaced);
+      if (arc < 0)
       {
-         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"fence read failed\"}");
+         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"fence write failed\"}");
          return 500;
       }
-      int same_owner =
-          (have == 1 && strcmp(cur_gen, generation) == 0 && strcmp(cur_pid, purge_id) == 0);
-      /* A LIVE fence (heartbeat younger than 2x the heartbeat interval, i.e.
-       * TTL/3) belonging to another owner is refused without takeover:true. */
-      if (have == 1 && live && !same_owner && !takeover)
+      if (arc == 0)
       {
          cJSON *resp = cJSON_CreateObject();
          if (resp)
@@ -1998,12 +1999,6 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
             cJSON_AddStringToObject(resp, "purge_id", cur_pid);
          }
          return purge_respond(resp, out_buf, out_cap, 409);
-      }
-      int fence_replaced = (have == 1 && !same_owner);
-      if (db2_kb_purge_fence_write(project, generation, purge_id) != 0)
-      {
-         snprintf(out_buf, (size_t)out_cap, "{\"error\":\"fence write failed\"}");
-         return 500;
       }
 
       /* Fan-out: every kb store the ingest path writes, in matrix order. */

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -2001,26 +2001,61 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          return purge_respond(resp, out_buf, out_cap, 409);
       }
 
-      /* Fan-out: every kb store the ingest path writes, in matrix order. */
+      /* Fan-out: every kb store the ingest path writes, in matrix order. The
+       * OWN fence heartbeat is refreshed between stores so a slow delete (or
+       * a fan-out longer than the TTL) cannot let the fence lapse mid-purge;
+       * losing ownership (a takeover displaced us) aborts the remaining
+       * stores fail-closed. */
       cJSON *stores = cJSON_CreateObject();
       if (!stores)
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"out of memory\"}");
          return 500;
       }
-      int all_ok = 1;
-      purge_store_add(stores, "chunks", db2_kb_service_clear_project(project), &all_ok);
-      purge_store_add(stores, "file_index", db2_kb_file_index_delete_project(project), &all_ok);
-      purge_store_add(stores, "vectors", pgvec_kb_vector_delete_project(project), &all_ok);
-      purge_store_add(stores, "code_embeddings", pgvec_code_delete_project(project), &all_ok);
-      purge_store_add(stores, "curator_code_unit_vectors",
-                      pgvec_curator_code_unit_delete_project(project), &all_ok);
-      purge_store_add(stores, "canonical_index", db2_code_index_project_delete(project), &all_ok);
-      purge_store_add(stores, "code_unit_jobs", kb_curator_code_unit_jobs_delete_project(project),
-                      &all_ok);
-      purge_store_add(stores, "pdf_vectors", pgvec_kbpdf_delete_project(project), &all_ok);
-      purge_store_add(stores, "minhash", db2_sketch_minhash_signature_delete_project(project),
-                      &all_ok);
+      typedef int (*purge_store_fn)(const char *);
+      static const struct
+      {
+         const char *name;
+         purge_store_fn fn;
+      } purge_matrix[] = {
+          {"chunks", db2_kb_service_clear_project},
+          {"file_index", db2_kb_file_index_delete_project},
+          {"vectors", pgvec_kb_vector_delete_project},
+          {"code_embeddings", pgvec_code_delete_project},
+          {"curator_code_unit_vectors", pgvec_curator_code_unit_delete_project},
+          {"canonical_index", db2_code_index_project_delete},
+          {"code_unit_jobs", kb_curator_code_unit_jobs_delete_project},
+          {"pdf_vectors", pgvec_kbpdf_delete_project},
+          {"minhash", db2_sketch_minhash_signature_delete_project},
+      };
+      int all_ok = 1, fence_lost = 0;
+      for (size_t si = 0; si < sizeof(purge_matrix) / sizeof(purge_matrix[0]); si++)
+      {
+         purge_store_add(stores, purge_matrix[si].name, purge_matrix[si].fn(project), &all_ok);
+         if (si + 1 < sizeof(purge_matrix) / sizeof(purge_matrix[0]) &&
+             db2_kb_purge_fence_heartbeat(project, generation, purge_id) != 1)
+         {
+            /* Ownership lost mid-fan-out: mark the remaining stores as
+             * errored (fail closed) — the displaced owner's purge re-runs
+             * them idempotently. */
+            fence_lost = 1;
+            all_ok = 0;
+            for (size_t sj = si + 1; sj < sizeof(purge_matrix) / sizeof(purge_matrix[0]); sj++)
+            {
+               cJSON *e = cJSON_CreateObject();
+               if (e)
+               {
+                  cJSON_AddStringToObject(e, "error", "fence lost");
+                  cJSON_AddItemToObject(stores, purge_matrix[sj].name, e);
+               }
+            }
+            aimee_log(LOG_WARN, "kb.purge",
+                      "purge-project '%s': fence ownership lost after store '%s' — remaining "
+                      "stores aborted",
+                      project, purge_matrix[si].name);
+            break;
+         }
+      }
 
       cJSON *resp = cJSON_CreateObject();
       if (!resp)
@@ -2035,6 +2070,8 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       cJSON_AddStringToObject(resp, "generation", generation);
       cJSON_AddStringToObject(resp, "purge_id", purge_id);
       cJSON_AddBoolToObject(resp, "fence_replaced", fence_replaced);
+      if (fence_lost)
+         cJSON_AddBoolToObject(resp, "fence_lost", 1);
       if (fence_replaced)
       {
          cJSON *displaced = cJSON_CreateObject();

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -8,6 +8,7 @@
 #include "db2/kb_service_backend.h"
 #include "db2/memory_query.h"
 #include "db2/vector_index_ops.h"
+#include "db2/kb_runtime_state.h" /* db2_kb_purge_fence_active: ingest fence checks */
 #include "db2/sketch.h"
 #include "kb_vectors.h"
 #include "kb_curator_notify.h"
@@ -662,16 +663,25 @@ int kb_async_enabled(void)
 /* Build / Update                                                       */
 /* ------------------------------------------------------------------ */
 
-static void kb_flush_batch(int64_t *ids, float *vecs, int dim, char **payloads, int *count)
+static void kb_flush_batch(const char *project, int64_t *ids, float *vecs, int dim, char **payloads,
+                           int *count)
 {
    if (*count <= 0)
       return;
-   int rc =
-       pgvec_kb_vector_upsert_document_batch(ids, vecs, dim, (const char *const *)payloads, *count);
+   /* Generation-fence check immediately before the pgvector batch write: a
+    * batch mid-flight past its enqueue check still must not land vectors for
+    * a project being purged (webchat-project-lifecycle slice 2). */
+   int fenced = project && project[0] && db2_kb_purge_fence_active(project);
+   if (fenced)
+      LOG_WARN("kb_build", "purge fence active for project '%s': dropping %d-vector batch", project,
+               *count);
+   int rc = fenced ? -1
+                   : pgvec_kb_vector_upsert_document_batch(ids, vecs, dim,
+                                                           (const char *const *)payloads, *count);
    for (int i = 0; i < *count; i++)
    {
       int ok = (rc == 0);
-      const char *err = rc ? "batch upsert failed" : NULL;
+      const char *err = rc ? (fenced ? "purge fence active" : "batch upsert failed") : NULL;
       db2_vector_index_op_record(ids[i], pgvec_kb_vector_collection_name(), 0, ok, err);
       free(payloads[i]);
       payloads[i] = NULL;
@@ -906,7 +916,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
              * 384-d collection instead of corrupting the batch. */
             if (dim != c->kb_expected_dim)
             {
-               kb_flush_batch(c->kb_batch_ids, c->kb_batch_vecs, c->kb_expected_dim,
+               kb_flush_batch(c->project, c->kb_batch_ids, c->kb_batch_vecs, c->kb_expected_dim,
                               c->kb_batch_payloads, c->kb_batch_count);
                sync_vector_embedding(doc_id, vec, dim);
             }
@@ -925,7 +935,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
                c->kb_batch_payloads[*c->kb_batch_count] = payload_json;
                (*c->kb_batch_count)++;
                if (*c->kb_batch_count >= c->kb_batch_size)
-                  kb_flush_batch(c->kb_batch_ids, c->kb_batch_vecs, c->kb_expected_dim,
+                  kb_flush_batch(c->project, c->kb_batch_ids, c->kb_batch_vecs, c->kb_expected_dim,
                                  c->kb_batch_payloads, c->kb_batch_count);
             }
          }
@@ -948,6 +958,14 @@ static int kb_build_or_update(const char *root_path, const char *project, const 
 {
    if (!root_path || !db2_is_initialized())
       return -1;
+   /* Generation fence (webchat-project-lifecycle slice 2): refuse to start an
+    * ingest for a project whose purge is in flight. Per-batch commit-point
+    * checks in kb_flush_batch cover a fence raised mid-ingest. */
+   if (project && project[0] && db2_kb_purge_fence_active(project))
+   {
+      LOG_WARN("kb_build", "purge fence active for project '%s': refusing ingest", project);
+      return -1;
+   }
    const char *effective_cmd = kb_effective_embedding_cmd(embedding_cmd);
 
    kb_stats_t stats;
@@ -1041,7 +1059,8 @@ static int kb_build_or_update(const char *root_path, const char *project, const 
    for (int fi = 0; fi < n_files; fi++)
       kb_process_one_file(&fctx, fi);
 
-   kb_flush_batch(kb_batch_ids, kb_batch_vecs, kb_expected_dim, kb_batch_payloads, &kb_batch_count);
+   kb_flush_batch(project, kb_batch_ids, kb_batch_vecs, kb_expected_dim, kb_batch_payloads,
+                  &kb_batch_count);
    free(kb_batch_ids);
    free(kb_batch_vecs);
    free(kb_batch_payloads);

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -603,18 +603,84 @@ int accept_generated_embedding(int64_t doc_id, const float *vec, int dim)
    return 0;
 }
 
+/* ── Purge-fence write discipline (webchat-project-lifecycle slice 2) ──
+ * EVERY project-scoped ingest write runs inside an explicit transaction that
+ * takes the project advisory guard and re-checks the generation fence before
+ * the write(s): an ingest that began pre-fence cannot commit stale rows once
+ * the fence lands (the guard serializes the check+commit against the fence
+ * publish). Guard failure is fail closed. Returns 1 proceed (transaction
+ * open), 0 fenced / guard failed (nothing open), -1 transaction error. */
+int kb_purge_fenced_txn_begin(const char *project)
+{
+   if (db2_kb_txn_begin() != 0)
+      return -1;
+   if (project && project[0] &&
+       (db2_kb_purge_txn_guard(project) != 0 || db2_kb_purge_fence_active(project)))
+   {
+      db2_kb_txn_rollback();
+      LOG_WARN("kb_build", "purge fence active for project '%s': dropping ingest write", project);
+      return 0;
+   }
+   return 1;
+}
+
+/* Commit a kb_purge_fenced_txn_begin transaction. 0 on success, -1 (rolled
+ * back) on commit failure. */
+int kb_purge_fenced_txn_commit(void)
+{
+   if (db2_kb_txn_commit() != 0)
+   {
+      db2_kb_txn_rollback();
+      return -1;
+   }
+   return 0;
+}
+
+/* File-index upsert behind the fenced-transaction discipline (the file index
+ * is a purge-matrix store). Returns the upsert rc, -1 when dropped. */
+int kb_file_index_upsert_fenced(const char *project, const char *file_path, const char *hash,
+                                const char *content)
+{
+   if (kb_purge_fenced_txn_begin(project) != 1)
+      return -1;
+   int rc = db2_kb_file_index_upsert(project, file_path, hash, content);
+   if (kb_purge_fenced_txn_commit() != 0)
+      rc = -1;
+   return rc;
+}
+
+/* Single-point vector upsert (the dimension-mismatch fallback and the doc
+ * ingest worker) behind the fenced-transaction discipline. */
+int kb_sync_vector_embedding_fenced(const char *project, int64_t doc_id, const float *vec, int dim)
+{
+   if (kb_purge_fenced_txn_begin(project) != 1)
+      return -1;
+   int rc = sync_vector_embedding(doc_id, vec, dim);
+   if (kb_purge_fenced_txn_commit() != 0)
+      rc = -1;
+   return rc;
+}
+
 /* Delete all chunks for a given file path in a project.
  *
  * Caps at 1024 ids per call; a single source file producing >1024
  * chunks is far past the chunker's MAX_CHUNKS_PER_FILE (256), so the
- * cap is comfortably above any realistic value. */
-void delete_file_chunks(const char *project, const char *file_path)
+ * cap is comfortably above any realistic value.
+ *
+ * The chunk/vector/minhash removals run in one guarded, fenced transaction;
+ * returns 0 committed, -1 dropped (purge fence active / txn failure) —
+ * callers must then stop processing that file. */
+int delete_file_chunks(const char *project, const char *file_path)
 {
    /* Invalidate curator artifacts derived from this file before its chunks go
     * away; the post-ingest queue then re-extracts the (changed) source, and a
-    * best-effort push notifies a subscribed server. */
+    * best-effort push notifies a subscribed server. Runs OUTSIDE the guarded
+    * transaction: artifacts are retained by purge, and the broadcast is a
+    * network call that must not hold the advisory lock. */
    int curator_stale = db2_curator_invalidate_doc(project, file_path);
-   kb_curator_invalidation_broadcast(project, file_path, curator_stale);
+
+   if (kb_purge_fenced_txn_begin(project) != 1)
+      return -1;
    int64_t ids[1024];
    int n_ids = db2_kb_documents_list_chunk_ids_for_file(project, file_path, ids,
                                                         (int)(sizeof(ids) / sizeof(ids[0])));
@@ -625,6 +691,10 @@ void delete_file_chunks(const char *project, const char *file_path)
    }
    db2_kb_documents_delete_for_file(project, file_path);
    db2_sketch_minhash_signature_delete(project, file_path);
+   int rc = kb_purge_fenced_txn_commit();
+
+   kb_curator_invalidation_broadcast(project, file_path, curator_stale);
+   return rc;
 }
 
 /* ------------------------------------------------------------------ */
@@ -673,32 +743,16 @@ static void kb_flush_batch(const char *project, int64_t *ids, float *vecs, int d
     * the advisory guard serializes check+commit against the fence publish,
     * so a batch mid-flight past its enqueue check still cannot land vectors
     * for a project being purged. */
-   int fenced = 0;
+   int t = kb_purge_fenced_txn_begin(project);
+   int fenced = (t == 0);
    int rc = -1;
-   if (db2_kb_txn_begin() == 0)
+   if (t == 1)
    {
-      int guard_ok = 1;
-      if (project && project[0])
-      {
-         guard_ok = (db2_kb_purge_txn_guard(project) == 0);
-         fenced = guard_ok && db2_kb_purge_fence_active(project);
-      }
-      if (!guard_ok || fenced)
-         db2_kb_txn_rollback();
-      else
-      {
-         rc = pgvec_kb_vector_upsert_document_batch(ids, vecs, dim, (const char *const *)payloads,
-                                                    *count);
-         if (db2_kb_txn_commit() != 0)
-         {
-            db2_kb_txn_rollback();
-            rc = -1;
-         }
-      }
+      rc = pgvec_kb_vector_upsert_document_batch(ids, vecs, dim, (const char *const *)payloads,
+                                                 *count);
+      if (kb_purge_fenced_txn_commit() != 0)
+         rc = -1;
    }
-   if (fenced)
-      LOG_WARN("kb_build", "purge fence active for project '%s': dropping %d-vector batch", project,
-               *count);
    for (int i = 0; i < *count; i++)
    {
       int ok = (rc == 0);
@@ -710,29 +764,17 @@ static void kb_flush_batch(const char *project, int64_t *ids, float *vecs, int d
    *count = 0;
 }
 
-/* Minhash signature upsert wrapped in a guarded, fenced transaction: the
- * near-dup store is part of the purge matrix, so its autocommit write gets
- * the same commit-point serialization as the vector batch. Returns the
- * upsert's rc, or -1 when fenced / guard-failed (write dropped). */
+/* Minhash signature upsert behind the shared fenced-transaction discipline:
+ * the near-dup store is part of the purge matrix. Returns the upsert's rc,
+ * or -1 when fenced / guard-failed (write dropped). */
 static int kb_minhash_upsert_fenced(const char *project, const char *rel_path, const char *hash,
                                     const sketch_minhash_t *sig)
 {
-   if (db2_kb_txn_begin() != 0)
+   if (kb_purge_fenced_txn_begin(project) != 1)
       return -1;
-   if (project && project[0] &&
-       (db2_kb_purge_txn_guard(project) != 0 || db2_kb_purge_fence_active(project)))
-   {
-      db2_kb_txn_rollback();
-      LOG_WARN("kb_build", "purge fence active for project '%s': dropping minhash signature",
-               project);
-      return -1;
-   }
    int rc = db2_sketch_minhash_signature_upsert(project, rel_path, hash, sig);
-   if (db2_kb_txn_commit() != 0)
-   {
-      db2_kb_txn_rollback();
-      return -1;
-   }
+   if (kb_purge_fenced_txn_commit() != 0)
+      rc = -1;
    return rc;
 }
 
@@ -829,7 +871,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
       {
          if (strcmp(stored, hash) == 0)
          {
-            db2_kb_file_index_upsert(c->project, c->files[fi].rel_path, hash, NULL);
+            kb_file_index_upsert_fenced(c->project, c->files[fi].rel_path, hash, NULL);
             c->stats->files_skipped++;
             return;
          }
@@ -842,11 +884,12 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
       int dup_exists = db2_kb_documents_hash_exists(c->project, hash, dup_path, sizeof(dup_path));
       if (dup_exists == 1)
       {
-         delete_file_chunks(c->project, c->files[fi].rel_path);
+         if (delete_file_chunks(c->project, c->files[fi].rel_path) != 0)
+            return; /* purge fence: drop this file */
          db2_sketch_minhash_row_t dup_sig;
          if (dup_path[0] && db2_sketch_minhash_signature_get(c->project, dup_path, &dup_sig) == 1)
             kb_minhash_upsert_fenced(c->project, c->files[fi].rel_path, hash, &dup_sig.signature);
-         db2_kb_file_index_upsert(c->project, c->files[fi].rel_path, hash, NULL);
+         kb_file_index_upsert_fenced(c->project, c->files[fi].rel_path, hash, NULL);
          LOG_INFO("kb_build",
                   "bloom-dedupe: project=%s path=%s hash=%s matched=%s; skipping duplicate",
                   c->project ? c->project : "?", c->files[fi].rel_path, hash,
@@ -860,7 +903,8 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
    }
 
    /* Remove old chunks for this file */
-   delete_file_chunks(c->project, c->files[fi].rel_path);
+   if (delete_file_chunks(c->project, c->files[fi].rel_path) != 0)
+      return; /* purge fence: drop this file */
 
    /* Chunk the file */
    int n_chunks = chunk_file(c->files[fi].path, c->chunks, MAX_CHUNKS_PER_FILE);
@@ -911,7 +955,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
          sketch_count_min_add_hash(c->count_min, h64, 1);
          sketch_hll_add_hash(c->hll,
                              sketch_fnv1a(c->files[fi].rel_path, strlen(c->files[fi].rel_path)));
-         if (db2_kb_file_index_upsert(c->project, c->files[fi].rel_path, hash, NULL) == 0)
+         if (kb_file_index_upsert_fenced(c->project, c->files[fi].rel_path, hash, NULL) == 0)
          {
             kb_neardup_propose(c->project, c->files[fi].rel_path, near_path, near_jaccard);
             c->stats->files_skipped++;
@@ -922,19 +966,43 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
       }
    }
 
-   /* Insert chunks and link neighbours */
+   /* Insert chunks and link neighbours — ALL rows for this file in ONE
+    * guarded, fenced transaction (phase 1). Embeddings run afterwards
+    * (phase 2): the advisory guard must never be held across the slow
+    * external embedder calls. */
+   int64_t *doc_ids = malloc((size_t)n_chunks * sizeof(int64_t));
+   if (!doc_ids)
+      return;
+   if (kb_purge_fenced_txn_begin(c->project) != 1)
+   {
+      free(doc_ids); /* purge fence: drop this file */
+      return;
+   }
    int64_t prev_doc_id = 0;
    for (int ci = 0; ci < n_chunks; ci++)
    {
-      int64_t doc_id = db2_kb_documents_insert_chunk(
-          c->project, c->files[fi].rel_path, hash, ci, c->chunks[ci].heading_path,
-          c->chunks[ci].line_start, c->chunks[ci].line_end, c->chunks[ci].content,
-          c->chunks[ci].token_count);
+      doc_ids[ci] = db2_kb_documents_insert_chunk(c->project, c->files[fi].rel_path, hash, ci,
+                                                  c->chunks[ci].heading_path,
+                                                  c->chunks[ci].line_start, c->chunks[ci].line_end,
+                                                  c->chunks[ci].content, c->chunks[ci].token_count);
+      if (doc_ids[ci] < 0)
+         continue;
+      db2_kb_documents_link_neighbours(doc_ids[ci], prev_doc_id);
+      prev_doc_id = doc_ids[ci];
+      c->stats->chunks_added++;
+   }
+   if (kb_purge_fenced_txn_commit() != 0)
+   {
+      free(doc_ids);
+      return;
+   }
+
+   /* Phase 2: embed each committed chunk (sync or async). */
+   for (int ci = 0; ci < n_chunks; ci++)
+   {
+      int64_t doc_id = doc_ids[ci];
       if (doc_id < 0)
          continue;
-      db2_kb_documents_link_neighbours(doc_id, prev_doc_id);
-      prev_doc_id = doc_id;
-      c->stats->chunks_added++;
 
       /* Generate embedding synchronously or enqueue it for async draining. */
       if (c->async_enabled)
@@ -963,7 +1031,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
             {
                kb_flush_batch(c->project, c->kb_batch_ids, c->kb_batch_vecs, c->kb_expected_dim,
                               c->kb_batch_payloads, c->kb_batch_count);
-               sync_vector_embedding(doc_id, vec, dim);
+               kb_sync_vector_embedding_fenced(c->project, doc_id, vec, dim);
             }
             else
             {
@@ -986,6 +1054,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
          }
       }
    }
+   free(doc_ids);
 
    sketch_bloom_add_hash(c->bloom, h64);
    sketch_count_min_add_hash(c->count_min, h64, 1);

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -668,16 +668,37 @@ static void kb_flush_batch(const char *project, int64_t *ids, float *vecs, int d
 {
    if (*count <= 0)
       return;
-   /* Generation-fence check immediately before the pgvector batch write: a
-    * batch mid-flight past its enqueue check still must not land vectors for
-    * a project being purged (webchat-project-lifecycle slice 2). */
-   int fenced = project && project[0] && db2_kb_purge_fence_active(project);
+   /* Guarded transaction around the pgvector batch write with the
+    * generation-fence check inside it (webchat-project-lifecycle slice 2):
+    * the advisory guard serializes check+commit against the fence publish,
+    * so a batch mid-flight past its enqueue check still cannot land vectors
+    * for a project being purged. */
+   int fenced = 0;
+   int rc = -1;
+   if (db2_kb_txn_begin() == 0)
+   {
+      int guard_ok = 1;
+      if (project && project[0])
+      {
+         guard_ok = (db2_kb_purge_txn_guard(project) == 0);
+         fenced = guard_ok && db2_kb_purge_fence_active(project);
+      }
+      if (!guard_ok || fenced)
+         db2_kb_txn_rollback();
+      else
+      {
+         rc = pgvec_kb_vector_upsert_document_batch(ids, vecs, dim, (const char *const *)payloads,
+                                                    *count);
+         if (db2_kb_txn_commit() != 0)
+         {
+            db2_kb_txn_rollback();
+            rc = -1;
+         }
+      }
+   }
    if (fenced)
       LOG_WARN("kb_build", "purge fence active for project '%s': dropping %d-vector batch", project,
                *count);
-   int rc = fenced ? -1
-                   : pgvec_kb_vector_upsert_document_batch(ids, vecs, dim,
-                                                           (const char *const *)payloads, *count);
    for (int i = 0; i < *count; i++)
    {
       int ok = (rc == 0);
@@ -687,6 +708,32 @@ static void kb_flush_batch(const char *project, int64_t *ids, float *vecs, int d
       payloads[i] = NULL;
    }
    *count = 0;
+}
+
+/* Minhash signature upsert wrapped in a guarded, fenced transaction: the
+ * near-dup store is part of the purge matrix, so its autocommit write gets
+ * the same commit-point serialization as the vector batch. Returns the
+ * upsert's rc, or -1 when fenced / guard-failed (write dropped). */
+static int kb_minhash_upsert_fenced(const char *project, const char *rel_path, const char *hash,
+                                    const sketch_minhash_t *sig)
+{
+   if (db2_kb_txn_begin() != 0)
+      return -1;
+   if (project && project[0] &&
+       (db2_kb_purge_txn_guard(project) != 0 || db2_kb_purge_fence_active(project)))
+   {
+      db2_kb_txn_rollback();
+      LOG_WARN("kb_build", "purge fence active for project '%s': dropping minhash signature",
+               project);
+      return -1;
+   }
+   int rc = db2_sketch_minhash_signature_upsert(project, rel_path, hash, sig);
+   if (db2_kb_txn_commit() != 0)
+   {
+      db2_kb_txn_rollback();
+      return -1;
+   }
+   return rc;
 }
 
 static void kb_load_build_sketches(const char *project, int force_rebuild, sketch_bloom_t *bloom,
@@ -798,8 +845,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
          delete_file_chunks(c->project, c->files[fi].rel_path);
          db2_sketch_minhash_row_t dup_sig;
          if (dup_path[0] && db2_sketch_minhash_signature_get(c->project, dup_path, &dup_sig) == 1)
-            db2_sketch_minhash_signature_upsert(c->project, c->files[fi].rel_path, hash,
-                                                &dup_sig.signature);
+            kb_minhash_upsert_fenced(c->project, c->files[fi].rel_path, hash, &dup_sig.signature);
          db2_kb_file_index_upsert(c->project, c->files[fi].rel_path, hash, NULL);
          LOG_INFO("kb_build",
                   "bloom-dedupe: project=%s path=%s hash=%s matched=%s; skipping duplicate",
@@ -854,8 +900,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
    }
    if (near_jaccard >= 0.75)
    {
-      if (db2_sketch_minhash_signature_upsert(c->project, c->files[fi].rel_path, hash,
-                                              &minhash_sig) != 0)
+      if (kb_minhash_upsert_fenced(c->project, c->files[fi].rel_path, hash, &minhash_sig) != 0)
       {
          LOG_WARN("kb_build", "project=%s path=%s: minhash signature save failed",
                   c->project ? c->project : "?", c->files[fi].rel_path);
@@ -945,8 +990,7 @@ static void kb_process_one_file(kb_build_file_ctx_t *c, int fi)
    sketch_bloom_add_hash(c->bloom, h64);
    sketch_count_min_add_hash(c->count_min, h64, 1);
    sketch_hll_add_hash(c->hll, sketch_fnv1a(c->files[fi].rel_path, strlen(c->files[fi].rel_path)));
-   if (db2_sketch_minhash_signature_upsert(c->project, c->files[fi].rel_path, hash, &minhash_sig) !=
-       0)
+   if (kb_minhash_upsert_fenced(c->project, c->files[fi].rel_path, hash, &minhash_sig) != 0)
       LOG_WARN("kb_build", "project=%s path=%s: minhash signature save failed",
                c->project ? c->project : "?", c->files[fi].rel_path);
    kb_file_index_store_from_path(c->project, c->files[fi].rel_path, hash, c->files[fi].path);

--- a/src/kb/kb_curator_index_code_unit.c
+++ b/src/kb/kb_curator_index_code_unit.c
@@ -153,7 +153,10 @@ int kb_curator_index_code_unit_one(const kb_curator_extract_opts_t *opts)
       free(payload);
       return 1;
    }
-   if (project[0] && db2_kb_purge_fence_active(project))
+   /* Advisory guard immediately before the fence check: serializes this
+    * check+commit against the fence-publish transaction. Guard failure is
+    * treated like an active fence (fail closed). */
+   if (project[0] && (db2_kb_purge_txn_guard(project) != 0 || db2_kb_purge_fence_active(project)))
    {
       db2_kb_txn_rollback();
       aimee_log(LOG_WARN, "kb.curator.code_unit",

--- a/src/kb/kb_curator_index_code_unit.c
+++ b/src/kb/kb_curator_index_code_unit.c
@@ -20,6 +20,8 @@
 #include "db2/artifacts.h"
 #include "db2/db2_internal.h"
 #include "db2/db_postgres.h"
+#include "db2/kb_payload.h"       /* db2_kb_txn_* wrappers */
+#include "db2/kb_runtime_state.h" /* db2_kb_purge_fence_active */
 #include "db2/pgvec_transport.h"
 
 #include <stdint.h>
@@ -52,7 +54,7 @@ int kb_curator_index_code_unit_one(const kb_curator_extract_opts_t *opts)
    if (!conn)
       return 0;
 
-   static const char *sql = "SELECT id, payload"
+   static const char *sql = "SELECT id, payload, scope_id"
                             " FROM artifacts"
                             " WHERE kind = 'code_unit' AND state = 'proposed'"
                             " ORDER BY id LIMIT 1";
@@ -62,13 +64,16 @@ int kb_curator_index_code_unit_one(const kb_curator_extract_opts_t *opts)
       return 0;
 
    char id[64] = "";
+   char project[256] = ""; /* the extractor stores the project as scope_id */
    char *payload = NULL;
    int found = 0;
    if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
    {
       const char *c_id = aimee_pg_column_text(st, 0);
       const char *c_pl = aimee_pg_column_text(st, 1);
+      const char *c_scope = aimee_pg_column_text(st, 2);
       snprintf(id, sizeof(id), "%s", c_id ? c_id : "");
+      snprintf(project, sizeof(project), "%s", c_scope ? c_scope : "");
       payload = strdup(c_pl ? c_pl : "{}");
       found = 1;
    }
@@ -95,6 +100,14 @@ int kb_curator_index_code_unit_one(const kb_curator_extract_opts_t *opts)
    if (!intent_text[0] && !sig_text[0] && !body_text[0])
    {
       cJSON_Delete(pj);
+      /* Fence check before the state write: a project being purged must not
+       * see even a bare artifact state transition. Return 0 (stop this drain
+       * tick) so the still-proposed row cannot spin the caller. */
+      if (project[0] && db2_kb_purge_fence_active(project))
+      {
+         free(payload);
+         return 0;
+      }
       db2_artifact_set_state(id, "committed");
       free(payload);
       return 1;
@@ -109,6 +122,47 @@ int kb_curator_index_code_unit_one(const kb_curator_extract_opts_t *opts)
    int d1 = memory_embed_text(intent_text, embed_cmd, intent_vec, CURATOR_CODE_UNIT_DIM);
    int d2 = memory_embed_text(sig_text, embed_cmd, sig_vec, CURATOR_CODE_UNIT_DIM);
    int d3 = memory_embed_text(body_text, embed_cmd, body_vec, CURATOR_CODE_UNIT_DIM);
+
+   /* Job-row re-check + vector upsert + artifact commit in ONE transaction,
+    * with the purge fence checked INSIDE it: a job claimed pre-purge can never
+    * re-insert into the vector store post-purge (webchat-project-lifecycle
+    * slice 2). On fence, return 0 (this drain tick stops) so the untouched
+    * proposed row cannot spin the caller. */
+   if (db2_kb_txn_begin() != 0)
+   {
+      cJSON_Delete(pj);
+      free(payload);
+      return 0;
+   }
+   int still_proposed = 0;
+   {
+      aimee_pg_stmt_t *chk = aimee_pg_prepare(
+          conn, "SELECT 1 FROM artifacts WHERE id = ?1 AND state = 'proposed'", err, sizeof(err));
+      if (chk)
+      {
+         aimee_pg_bind_text(chk, "?1", id);
+         still_proposed = (aimee_pg_step(chk, err, sizeof(err)) == AIMEE_PG_ROW);
+         aimee_pg_finalize(chk);
+      }
+   }
+   if (!still_proposed)
+   {
+      /* Purged (or committed elsewhere) since the claim: nothing to index. */
+      db2_kb_txn_rollback();
+      cJSON_Delete(pj);
+      free(payload);
+      return 1;
+   }
+   if (project[0] && db2_kb_purge_fence_active(project))
+   {
+      db2_kb_txn_rollback();
+      aimee_log(LOG_WARN, "kb.curator.code_unit",
+                "purge fence active for project '%s': aborting code_unit %s", project, id);
+      cJSON_Delete(pj);
+      free(payload);
+      return 0;
+   }
+
    if (d1 > 0 && d1 == d2 && d2 == d3)
    {
       int64_t pid = fnv1a(id);
@@ -126,6 +180,13 @@ int kb_curator_index_code_unit_one(const kb_curator_extract_opts_t *opts)
    }
 
    db2_artifact_set_state(id, "committed");
+   if (db2_kb_txn_commit() != 0)
+   {
+      db2_kb_txn_rollback();
+      cJSON_Delete(pj);
+      free(payload);
+      return 0;
+   }
    aimee_log(LOG_INFO, "kb.curator.code_unit", "indexed code_unit %s", id);
 
    cJSON_Delete(pj);

--- a/src/kb/kb_curator_queue.c
+++ b/src/kb/kb_curator_queue.c
@@ -114,6 +114,26 @@ int kb_curator_queue_code_unit(const char *project, const char *file_path, const
    return 0;
 }
 
+int kb_curator_code_unit_jobs_delete_project(const char *project)
+{
+   if (!project || !project[0])
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char err[CQ_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn, "DELETE FROM kb_code_unit_jobs WHERE project = ?1", err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   int changes = aimee_pg_stmt_changes(st);
+   aimee_pg_finalize(st);
+   return (rc == AIMEE_PG_DONE) ? changes : -1;
+}
+
 int kb_curator_queue_code_units_for_project(const char *project, const char *root_path)
 {
    if (!project || !project[0])

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -520,7 +520,8 @@ void kb_file_index_store_from_path(const char *project, const char *file_path, c
                                    const char *src_path)
 {
    char *full = kb_read_file_all(src_path);
-   db2_kb_file_index_upsert(project, file_path, hash, full);
+   /* Fenced: the file index is a purge-matrix store (slice 2). */
+   kb_file_index_upsert_fenced(project, file_path, hash, full);
    free(full);
 }
 
@@ -546,25 +547,58 @@ int kb_ingest_doc_content(const char *project, const char *source_path, const ch
        strcmp(stored, hash) == 0)
       return 0; /* unchanged — already ingested */
 
-   delete_file_chunks(project, source_path);
+   if (delete_file_chunks(project, source_path) != 0)
+      return -1; /* purge fence: drop this document */
 
    text_chunk_t *chunks = malloc(MAX_CHUNKS_PER_FILE * sizeof(text_chunk_t));
    if (!chunks)
       return -1;
    int n_chunks = chunk_content(content, len, chunks, MAX_CHUNKS_PER_FILE);
+   if (n_chunks <= 0)
+   {
+      free(chunks);
+      return 0;
+   }
 
-   int embedded = 0;
+   /* Phase 1: all chunk rows + neighbour links in ONE guarded, fenced
+    * transaction — the advisory guard must not be held across the slow
+    * embedder round-trips below (which also drop the pool lease). */
+   int64_t *doc_ids = malloc((size_t)n_chunks * sizeof(int64_t));
+   if (!doc_ids)
+   {
+      free(chunks);
+      return -1;
+   }
+   if (kb_purge_fenced_txn_begin(project) != 1)
+   {
+      free(doc_ids);
+      free(chunks);
+      return -1; /* purge fence: drop this document */
+   }
    int64_t prev_doc_id = 0;
    for (int ci = 0; ci < n_chunks; ci++)
    {
-      int64_t doc_id = db2_kb_documents_insert_chunk(
+      doc_ids[ci] = db2_kb_documents_insert_chunk(
           project, source_path, hash, ci, chunks[ci].heading_path, chunks[ci].line_start,
           chunks[ci].line_end, chunks[ci].content, chunks[ci].token_count);
-      if (doc_id < 0)
+      if (doc_ids[ci] < 0)
          continue;
-      db2_kb_documents_link_neighbours(doc_id, prev_doc_id);
-      prev_doc_id = doc_id;
-      if (!effective_cmd[0])
+      db2_kb_documents_link_neighbours(doc_ids[ci], prev_doc_id);
+      prev_doc_id = doc_ids[ci];
+   }
+   if (kb_purge_fenced_txn_commit() != 0)
+   {
+      free(doc_ids);
+      free(chunks);
+      return -1;
+   }
+
+   /* Phase 2: embed each committed chunk. */
+   int embedded = 0;
+   for (int ci = 0; ci < n_chunks; ci++)
+   {
+      int64_t doc_id = doc_ids[ci];
+      if (doc_id < 0 || !effective_cmd[0])
          continue;
 
       char embed_text[4096];
@@ -580,13 +614,14 @@ int kb_ingest_doc_content(const char *project, const char *source_path, const ch
       if (dim > 0)
       {
          accept_generated_embedding(doc_id, vec, dim);
-         sync_vector_embedding(doc_id, vec, dim);
+         kb_sync_vector_embedding_fenced(project, doc_id, vec, dim);
          embedded++;
       }
    }
+   free(doc_ids);
    free(chunks);
    /* Store the whole file body too (served by GET /v1/kb/file), not just chunks. */
-   db2_kb_file_index_upsert(project, source_path, hash, content);
+   kb_file_index_upsert_fenced(project, source_path, hash, content);
    return embedded;
 }
 

--- a/src/kb_curator_queue.h
+++ b/src/kb_curator_queue.h
@@ -21,6 +21,11 @@ int kb_curator_queue_code_unit(const char *project, const char *file_path, const
 /* Bulk-enqueue extract_code_unit jobs for indexed terms in a project. */
 int kb_curator_queue_code_units_for_project(const char *project, const char *root_path);
 
+/* Purge fan-out (webchat-project-lifecycle slice 2): delete every queued
+ * kb_code_unit_jobs row for `project`, regardless of status. Returns rows
+ * deleted (>=0) or -1 on DB / connection error. */
+int kb_curator_code_unit_jobs_delete_project(const char *project);
+
 /* Curator queue depth, for the /v1/health curator block (§4 observability). */
 typedef struct
 {

--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -7,8 +7,10 @@
  * first-component lifecycle lock before it is published (temp dir + rename,
  * fd-pinned via openat2 — no string-path window). */
 #include "git_project.h"
+#include "cJSON.h"           /* kb purge reply parsing (delete path) */
 #include "git_cred_inject.h" /* git_cred_inject_build_env_for_repo / _free_env */
 #include "git_host_cred.h"   /* per-host token store (single-user, many hosts) */
+#include "kb_client.h"       /* kb purge/finalize/cancel wrappers (slice 2) */
 #include "log.h"
 #include "util.h"            /* safe_exec_capture_env */
 #include "util_url.h"        /* util_url_normalize (ssh/scp/git -> https) */
@@ -22,7 +24,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <time.h>
 #include <unistd.h>
+
+#include "db2/code_index.h" /* db2_code_index_project_delete (slice-2 purge fan-out) */
 
 extern char **environ;
 
@@ -615,6 +620,373 @@ out:
       (void)ws_reg_unregister(ref);
    if (tmpfd >= 0)
       close(tmpfd);
+   if (orgfd >= 0)
+      close(orgfd);
+   if (rootfd >= 0)
+      close(rootfd);
+   close(lockfd); /* releases the flock */
+   return rc_final;
+}
+
+/* ---- delete (slice 2) ---------------------------------------------------- */
+
+/* One webuser_project_delete_audit_v1 line. Every phase of one operation
+ * shares the same purge_id; `extra` (may be "") carries phase-specific
+ * key=value pairs (reason=…, kb_status=…, fence_generation=…). */
+static void delete_audit(const char *purge_id, const char *principal, const char *ref,
+                         const char *phase, const char *extra)
+{
+   aimee_log(LOG_INFO, "webuser.project.delete",
+             "webuser_project_delete_audit_v1 schema_version=1 purge_id=%s principal=%s ref=%s "
+             "phase=%s%s%s",
+             purge_id, principal, ref, phase, extra && extra[0] ? " " : "", extra ? extra : "");
+}
+
+/* Mint a random hex purge id (16 bytes of /dev/urandom -> 32 hex chars;
+ * time^pid fallback so the id is never empty). */
+static void mint_purge_id(char *out, size_t cap)
+{
+   unsigned char raw[16];
+   size_t got = 0;
+   int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+   if (fd >= 0)
+   {
+      ssize_t n = read(fd, raw, sizeof(raw));
+      if (n > 0)
+         got = (size_t)n;
+      close(fd);
+   }
+   if (got < sizeof(raw))
+   {
+      unsigned long long seed =
+          (unsigned long long)time(NULL) ^ ((unsigned long long)getpid() << 32);
+      for (size_t i = got; i < sizeof(raw); i++)
+         raw[i] = (unsigned char)(seed >> ((i % 8) * 8));
+   }
+   size_t o = 0;
+   for (size_t i = 0; i < sizeof(raw) && o + 2 < cap; i++)
+      o += (size_t)snprintf(out + o, cap - o, "%02x", raw[i]);
+   out[o] = '\0';
+}
+
+/* Parse a kb purge-wrapper reply. Returns 1 on full success ({"status":"ok",
+ * "ok":true}), 0 when the kb was REACHED but a store failed ("ok":false — the
+ * fence was written), -1 on transport failure ({"status":"error"} / no reply —
+ * the kb was never reached, so NO fence exists). Fills *detail (malloc'd JSON:
+ * the per-store map, or {"error": …}) when detail is non-NULL. */
+static int purge_reply_parse(const char *json, char **detail)
+{
+   if (detail)
+      *detail = NULL;
+   cJSON *j = json ? cJSON_Parse(json) : NULL;
+   if (!j)
+   {
+      if (detail)
+         *detail = strdup("{\"error\":\"no response from the knowledge service\"}");
+      return -1;
+   }
+   const cJSON *jstatus = cJSON_GetObjectItemCaseSensitive(j, "status");
+   const char *status = cJSON_IsString(jstatus) ? jstatus->valuestring : "";
+   if (strcmp(status, "ok") != 0)
+   {
+      const cJSON *jmsg = cJSON_GetObjectItemCaseSensitive(j, "message");
+      if (detail)
+      {
+         cJSON *d = cJSON_CreateObject();
+         cJSON_AddStringToObject(d, "error",
+                                 cJSON_IsString(jmsg) ? jmsg->valuestring : "unreachable");
+         *detail = cJSON_PrintUnformatted(d);
+         cJSON_Delete(d);
+      }
+      cJSON_Delete(j);
+      return -1;
+   }
+   const cJSON *jok = cJSON_GetObjectItemCaseSensitive(j, "ok");
+   int ok = cJSON_IsBool(jok) && cJSON_IsTrue(jok);
+   const cJSON *jstores = cJSON_GetObjectItemCaseSensitive(j, "stores");
+   if (detail && cJSON_IsObject(jstores))
+      *detail = cJSON_PrintUnformatted(jstores);
+   cJSON_Delete(j);
+   return ok ? 1 : 0;
+}
+
+/* Did a finalize/cancel wrapper reply reach the kb ({"status":"ok"})? 0/1. */
+static int purge_reply_reached(const char *json)
+{
+   cJSON *j = json ? cJSON_Parse(json) : NULL;
+   if (!j)
+      return 0;
+   const cJSON *jstatus = cJSON_GetObjectItemCaseSensitive(j, "status");
+   int ok = cJSON_IsString(jstatus) && strcmp(jstatus->valuestring, "ok") == 0;
+   cJSON_Delete(j);
+   return ok;
+}
+
+int git_project_delete(const char *principal, const char *ref, int force,
+                       git_project_delete_result_t *res, char *err, size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
+   if (!res)
+      return -1;
+   memset(res, 0, sizeof(*res));
+
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+   {
+      snprintf(err, errlen, "git projects require a webchat user");
+      return -1;
+   }
+   if (!ws_scope_openat2_available())
+   {
+      snprintf(err, errlen,
+               "the webuser project surface requires openat2 (Linux >= 5.6); it is disabled on "
+               "this kernel");
+      return -1;
+   }
+   if (!ws_reg_ready())
+   {
+      snprintf(err, errlen, "the project registry is unavailable; try again shortly");
+      return -1;
+   }
+   /* Step 1: validate the ref, mint the purge id + a monotonic generation. */
+   size_t reflen = ref ? strlen(ref) : 0;
+   if (!ws_scope_project_ref_valid(ref, reflen))
+   {
+      snprintf(err, errlen, "invalid project ref");
+      return -1;
+   }
+   mint_purge_id(res->purge_id, sizeof(res->purge_id));
+   {
+      struct timespec ts;
+      clock_gettime(CLOCK_REALTIME, &ts);
+      snprintf(res->generation, sizeof(res->generation), "%lld",
+               (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+   }
+
+   /* Step 2: audit intent FIRST — before any existence resolution — so a
+    * cross-principal or nonexistent ref still leaves a record. */
+   delete_audit(res->purge_id, principal, ref, "intent", "");
+
+   int lockfd = ws_reg_lock(ref);
+   if (lockfd < 0)
+   {
+      delete_audit(res->purge_id, principal, ref, "aborted", "reason=lock-unavailable");
+      snprintf(err, errlen, "could not acquire the project lifecycle lock");
+      return -1;
+   }
+
+   int rc_final = -1, rootfd = -1, orgfd = -1;
+   int purge_ran = 0; /* a fence was written — heartbeat + finalize apply */
+   char audit_extra[512];
+
+   /* Step 3: resolve strictly under the caller's tree; any failure is a plain
+    * not-found (no existence disclosure about other principals' trees). */
+   {
+      int pfd = ws_scope_open_project(principal, ref, 0);
+      if (pfd < 0)
+      {
+         delete_audit(res->purge_id, principal, ref, "aborted", "reason=not-found");
+         snprintf(err, errlen, "not found");
+         rc_final = GP_ERR_NOT_FOUND;
+         goto out;
+      }
+      close(pfd);
+   }
+
+   /* Step 4: holder decision (registry-based, git config authoritative).
+    * Capture the recorded remote BEFORE the decrement so an abort can roll it
+    * back with ws_reg_register. */
+   char reg_remote[1024];
+   reg_remote[0] = '\0';
+   {
+      int holders = 0;
+      if (ws_reg_resync(ref) != 0 ||
+          ws_reg_lookup(ref, reg_remote, sizeof(reg_remote), &holders) != 1)
+      {
+         delete_audit(res->purge_id, principal, ref, "aborted", "reason=registry-unavailable");
+         snprintf(err, errlen, "project registry unavailable");
+         goto out;
+      }
+   }
+   int remaining = ws_reg_unregister(ref);
+   if (remaining < 0)
+   {
+      delete_audit(res->purge_id, principal, ref, "aborted", "reason=registry-unavailable");
+      snprintf(err, errlen, "project registry unavailable");
+      goto out;
+   }
+
+   if (remaining > 0)
+   {
+      /* Other holders remain: the shared knowledge and shared lexical rows
+       * stay for them. An UNKNOWN-remote holder is conservatively a
+       * same-remote holder (stale kb rows are recoverable; a wrong purge is
+       * not) — flag the possible dangling state loudly. */
+      snprintf(res->kb_status, sizeof(res->kb_status), "retained");
+      if (strncmp(reg_remote, "unknown://", 10) == 0)
+         aimee_log(LOG_WARN, "webuser.project.delete",
+                   "ref '%s' retained for a holder with an UNKNOWN remote — kb rows may dangle; "
+                   "operator can re-run purge-project after verifying (purge_id=%s)",
+                   ref, res->purge_id);
+   }
+   else
+   {
+      /* Last holder: fenced kb purge. */
+      char *pj = kb_client_purge_project_json(ref, res->generation, res->purge_id, 0);
+      int prc = purge_reply_parse(pj, &res->kb_detail);
+      free(pj);
+      if (prc == 1)
+      {
+         snprintf(res->kb_status, sizeof(res->kb_status), "purged");
+         purge_ran = 1;
+      }
+      else if (force)
+      {
+         /* Proceed anyway; the response and audit carry the FULL per-store
+          * detail so the operator can re-run purge-project to convergence.
+          * A transport failure means no fence exists (the kb is down, so no
+          * writer is committing either) — skip heartbeat/finalize then. */
+         snprintf(res->kb_status, sizeof(res->kb_status), "forced");
+         purge_ran = (prc == 0);
+      }
+      else if (prc == -1)
+      {
+         /* Transport failure: the kb was never reached, so NO fence was
+          * written — roll the registry decrement back and abort. Nothing
+          * filesystem has been destroyed. */
+         if (ws_reg_register(ref, reg_remote) != 0)
+            aimee_log(LOG_ERROR, "webuser.project.delete",
+                      "ref '%s': could not roll back the registry decrement after a kb transport "
+                      "failure (purge_id=%s); the startup rebuild self-heals",
+                      ref, res->purge_id);
+         snprintf(audit_extra, sizeof(audit_extra), "reason=kb-unreachable kb=%.300s",
+                  res->kb_detail ? res->kb_detail : "");
+         delete_audit(res->purge_id, principal, ref, "aborted", audit_extra);
+         snprintf(err, errlen, "knowledge service unavailable");
+         rc_final = GP_ERR_KB_UNAVAILABLE;
+         goto out;
+      }
+      else
+      {
+         /* The kb was reached but a store failed: a fence exists. The
+          * decrement is reinstated ONLY if purge-cancel confirms the fence
+          * rollback; a failed cancel keeps the fence AND the decrement
+          * (terminal "purge committed but unfinished" — re-running the
+          * delete converges). */
+         char *cj = kb_client_purge_cancel_json(ref, res->generation, res->purge_id);
+         int cancelled = purge_reply_reached(cj);
+         free(cj);
+         if (cancelled)
+         {
+            if (ws_reg_register(ref, reg_remote) != 0)
+               aimee_log(LOG_ERROR, "webuser.project.delete",
+                         "ref '%s': could not roll back the registry decrement after purge-cancel "
+                         "(purge_id=%s); the startup rebuild self-heals",
+                         ref, res->purge_id);
+            snprintf(audit_extra, sizeof(audit_extra), "reason=kb-error kb=%.300s",
+                     res->kb_detail ? res->kb_detail : "");
+            delete_audit(res->purge_id, principal, ref, "aborted", audit_extra);
+            snprintf(err, errlen, "knowledge service unavailable");
+         }
+         else
+         {
+            snprintf(audit_extra, sizeof(audit_extra),
+                     "reason=purge-committed-unfinished fence_generation=%s kb=%.300s",
+                     res->generation, res->kb_detail ? res->kb_detail : "");
+            delete_audit(res->purge_id, principal, ref, "aborted", audit_extra);
+            snprintf(err, errlen,
+                     "purge committed but unfinished: the knowledge fence is set and the purge "
+                     "must be re-run to convergence");
+         }
+         rc_final = GP_ERR_KB_UNAVAILABLE;
+         goto out;
+      }
+   }
+
+   /* Step 5: server-local lexical index rows are keyed by project (shared
+    * across webusers) and follow the kb decision exactly: deleted on
+    * purged/forced, kept on retained. */
+   if (strcmp(res->kb_status, "retained") != 0)
+   {
+      if (db2_code_index_project_delete(ref) != 0)
+         aimee_log(LOG_WARN, "webuser.project.delete",
+                   "ref '%s': server-local lexical index delete failed (purge_id=%s); a re-scan "
+                   "of a future clone overwrites the rows",
+                   ref, res->purge_id);
+   }
+
+   /* Heartbeat the fence before the filesystem walk (long trees must not
+    * outlive the fence TTL). */
+   if (purge_ran)
+      free(kb_client_purge_heartbeat_json(ref, res->generation, res->purge_id));
+
+   /* Step 6: filesystem removal — an unlinkat-based walk from the pinned
+    * parent fd (rm_rf_at never follows symlinks). Step 7: prune the org dir
+    * when it emptied (best-effort, still under the first-component lock). */
+   {
+      char org[WS_REF_COMP_MAX + 1], repo[WS_REF_COMP_MAX + 1];
+      if (ws_scope_ref_split(ref, org, sizeof(org), repo, sizeof(repo)) < 0)
+      {
+         snprintf(err, errlen, "invalid project ref");
+         goto out;
+      }
+      rootfd = ws_scope_open_user_root(principal);
+      if (rootfd < 0)
+      {
+         delete_audit(res->purge_id, principal, ref, "aborted", "reason=fs-failed");
+         snprintf(err, errlen, "could not open the workspace root");
+         goto out;
+      }
+      int rm_rc;
+      if (org[0])
+      {
+         orgfd = ws_scope_openat2_dir(rootfd, org);
+         if (orgfd < 0)
+         {
+            delete_audit(res->purge_id, principal, ref, "aborted", "reason=fs-failed");
+            snprintf(err, errlen, "could not open the org directory");
+            goto out;
+         }
+         rm_rc = rm_rf_at(orgfd, repo);
+         close(orgfd);
+         orgfd = -1;
+         if (rm_rc == 0)
+            (void)unlinkat(rootfd, org, AT_REMOVEDIR); /* prune if now empty */
+      }
+      else
+         rm_rc = rm_rf_at(rootfd, repo);
+      if (rm_rc != 0)
+      {
+         /* The kb purge (when one ran) is committed and its fence stays until
+          * finalize or TTL — re-running the delete converges. */
+         delete_audit(res->purge_id, principal, ref, "aborted", "reason=fs-failed");
+         snprintf(err, errlen, "could not remove the project directory");
+         goto out;
+      }
+   }
+
+   /* Step 8: clear the fence (only when a purge ran; finalize no-ops on a
+    * generation/purge_id mismatch), then audit done. */
+   if (purge_ran)
+   {
+      char *fj = kb_client_purge_finalize_json(ref, res->generation, res->purge_id);
+      if (!purge_reply_reached(fj))
+         aimee_log(LOG_WARN, "webuser.project.delete",
+                   "ref '%s': purge-finalize did not reach the kb (purge_id=%s); the fence "
+                   "expires via its TTL",
+                   ref, res->purge_id);
+      free(fj);
+   }
+   if (strcmp(res->kb_status, "retained") == 0)
+      snprintf(audit_extra, sizeof(audit_extra), "kb_status=retained fs=removed");
+   else
+      snprintf(audit_extra, sizeof(audit_extra),
+               "kb_status=%s fs=removed fence_generation=%s kb=%.300s", res->kb_status,
+               res->generation, res->kb_detail ? res->kb_detail : "");
+   delete_audit(res->purge_id, principal, ref, "done", audit_extra);
+   rc_final = 0;
+
+out:
    if (orgfd >= 0)
       close(orgfd);
    if (rootfd >= 0)

--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -520,7 +520,10 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
    }
    int destfd_parent = org[0] ? orgfd : rootfd;
    snprintf(tmpname, sizeof(tmpname), ".tmp-%s-%d", repo, (int)getpid());
-   (void)rm_rf_at(destfd_parent, tmpname); /* stale leftover from a crash */
+   /* Stale leftover from a crashed clone only: the cleanup targets this exact
+    * ".tmp-<repo>-<pid>" name and never touches ".deleting-*" markers — those
+    * belong to the delete path's resumable tombstones. */
+   (void)rm_rf_at(destfd_parent, tmpname);
    if (mkdirat(destfd_parent, tmpname, 0700) != 0)
    {
       snprintf(err, errlen, "could not create the clone staging directory");
@@ -907,42 +910,97 @@ int git_project_delete(const char *principal, const char *ref, int force,
 
    int rc_final = -1, rootfd = -1, orgfd = -1;
    int purge_ran = 0; /* a fence was written — heartbeat + finalize apply */
+   int resumed = 0;   /* a ".deleting-<repo>" tombstone from an interrupted walk */
 
-   /* Step 3: resolve strictly under the caller's tree; any failure is a plain
-    * not-found (no existence disclosure about other principals' trees). */
+   char org[WS_REF_COMP_MAX + 1], repo[WS_REF_COMP_MAX + 1];
+   char marker[WS_REF_COMP_MAX + 32]; /* ".deleting-<repo>" rename-first tombstone */
+   if (ws_scope_ref_split(ref, org, sizeof(org), repo, sizeof(repo)) < 0)
+   {
+      snprintf(err, errlen, "invalid project ref");
+      goto out;
+   }
+   snprintf(marker, sizeof(marker), ".deleting-%s", repo);
+
+   /* Step 3: resolve strictly under the caller's tree. When the ref does not
+    * resolve, a matching ".deleting-<repo>" tombstone at the expected level
+    * marks a RESUMABLE partial delete (an earlier walk renamed the project to
+    * the tombstone, then was interrupted); only when neither exists is it a
+    * plain not-found (no existence disclosure about other principals'
+    * trees — the tombstone check runs under the caller's own root only). */
    {
       int pfd = ws_scope_open_project(principal, ref, 0);
-      if (pfd < 0)
+      if (pfd >= 0)
+         close(pfd);
+      else
       {
-         delete_audit(res->purge_id, principal, ref, "aborted", "reason=not-found");
-         snprintf(err, errlen, "not found");
-         rc_final = GP_ERR_NOT_FOUND;
-         goto out;
+         int rfd = ws_scope_open_user_root(principal);
+         if (rfd >= 0)
+         {
+            int parent = org[0] ? ws_scope_openat2_dir(rfd, org) : rfd;
+            if (parent >= 0)
+            {
+               struct stat mst;
+               if (fstatat(parent, marker, &mst, AT_SYMLINK_NOFOLLOW) == 0 && S_ISDIR(mst.st_mode))
+                  resumed = 1;
+               if (parent != rfd)
+                  close(parent);
+            }
+            close(rfd);
+         }
+         if (!resumed)
+         {
+            delete_audit(res->purge_id, principal, ref, "aborted", "reason=not-found");
+            snprintf(err, errlen, "not found");
+            rc_final = GP_ERR_NOT_FOUND;
+            goto out;
+         }
       }
-      close(pfd);
    }
 
    /* Step 4: holder decision (registry-based, git config authoritative).
     * Capture the recorded remote BEFORE the decrement so an abort can roll it
-    * back with ws_reg_register. */
+    * back with ws_reg_register. A RESUMED delete already decremented in the
+    * earlier attempt: re-derive the outcome from the current registry (the
+    * resync counts published clones only — the tombstone is invisible to it),
+    * with no second decrement and no rollback on abort. */
    char reg_remote[1024];
    reg_remote[0] = '\0';
+   int remaining;
+   if (resumed)
    {
       int holders = 0;
+      int found;
       if (ws_reg_resync(ref) != 0 ||
-          ws_reg_lookup(ref, reg_remote, sizeof(reg_remote), &holders) != 1)
+          (found = ws_reg_lookup(ref, reg_remote, sizeof(reg_remote), &holders)) < 0)
       {
          delete_audit(res->purge_id, principal, ref, "aborted", "reason=registry-unavailable");
          snprintf(err, errlen, "project registry unavailable");
          goto out;
       }
+      /* Holders remaining -> the interrupted delete was a retained one; none
+       * -> last holder: purge again under THIS run's fresh generation/purge_id
+       * (idempotent zero deletes; fence_replaced displaces any stale fence). */
+      remaining = (found == 1) ? holders : 0;
    }
-   int remaining = ws_reg_unregister(ref);
-   if (remaining < 0)
+   else
    {
-      delete_audit(res->purge_id, principal, ref, "aborted", "reason=registry-unavailable");
-      snprintf(err, errlen, "project registry unavailable");
-      goto out;
+      {
+         int holders = 0;
+         if (ws_reg_resync(ref) != 0 ||
+             ws_reg_lookup(ref, reg_remote, sizeof(reg_remote), &holders) != 1)
+         {
+            delete_audit(res->purge_id, principal, ref, "aborted", "reason=registry-unavailable");
+            snprintf(err, errlen, "project registry unavailable");
+            goto out;
+         }
+      }
+      remaining = ws_reg_unregister(ref);
+      if (remaining < 0)
+      {
+         delete_audit(res->purge_id, principal, ref, "aborted", "reason=registry-unavailable");
+         snprintf(err, errlen, "project registry unavailable");
+         goto out;
+      }
    }
 
    if (remaining > 0)
@@ -981,9 +1039,10 @@ int git_project_delete(const char *principal, const char *ref, int force,
       else if (prc == -1)
       {
          /* Transport failure: the kb was never reached, so NO fence was
-          * written — roll the registry decrement back and abort. Nothing
+          * written — roll the registry decrement back (only when THIS run
+          * decremented; a resumed run never did) and abort. Nothing
           * filesystem has been destroyed. */
-         if (ws_reg_register(ref, reg_remote) != 0)
+         if (!resumed && ws_reg_register(ref, reg_remote) != 0)
             aimee_log(LOG_ERROR, "webuser.project.delete",
                       "ref '%s': could not roll back the registry decrement after a kb transport "
                       "failure (purge_id=%s); the startup rebuild self-heals",
@@ -1006,7 +1065,7 @@ int git_project_delete(const char *principal, const char *ref, int force,
          free(cj);
          if (cancelled)
          {
-            if (ws_reg_register(ref, reg_remote) != 0)
+            if (!resumed && ws_reg_register(ref, reg_remote) != 0)
                aimee_log(LOG_ERROR, "webuser.project.delete",
                          "ref '%s': could not roll back the registry decrement after purge-cancel "
                          "(purge_id=%s); the startup rebuild self-heals",
@@ -1031,13 +1090,15 @@ int git_project_delete(const char *principal, const char *ref, int force,
 
    /* Step 5: server-local lexical index rows are keyed by project (shared
     * across webusers) and follow the kb decision exactly: deleted on
-    * purged/forced, kept on retained. A failure here ABORTS BEFORE any
-    * filesystem removal — proceeding would strand shared index rows with no
-    * retry path once the clone is gone. The clone still exists, so the
-    * holder is re-registered and the fence cancelled; re-running the delete
-    * converges (the kb deletes are idempotent, and a re-scan restores any
-    * stores this attempt already emptied). */
-   if (strcmp(res->kb_status, "retained") != 0 && db2_code_index_project_delete(ref) != 0)
+    * purged/forced, kept on retained. db2_code_index_project_delete returns
+    * the DELETED ROW COUNT (>= 0, e.g. 1 for the normal existing-project
+    * case, 0 when already gone — both success); only < 0 is a failure. A
+    * failure ABORTS BEFORE any filesystem removal — proceeding would strand
+    * shared index rows with no retry path once the clone is gone. The clone
+    * still exists, so the holder is re-registered and the fence cancelled;
+    * re-running the delete converges (the kb deletes are idempotent, and a
+    * re-scan restores any stores this attempt already emptied). */
+   if (strcmp(res->kb_status, "retained") != 0 && db2_code_index_project_delete(ref) < 0)
    {
       int cancelled;
       if (purge_ran)
@@ -1050,7 +1111,7 @@ int git_project_delete(const char *principal, const char *ref, int force,
          cancelled = 1; /* forced transport failure: no fence was ever written */
       if (cancelled)
       {
-         if (ws_reg_register(ref, reg_remote) != 0)
+         if (!resumed && ws_reg_register(ref, reg_remote) != 0)
             aimee_log(LOG_ERROR, "webuser.project.delete",
                       "ref '%s': could not roll back the registry decrement after a local-index "
                       "failure (purge_id=%s); the startup rebuild self-heals",
@@ -1096,19 +1157,18 @@ int git_project_delete(const char *principal, const char *ref, int force,
       goto out;
    }
 
-   /* Step 6: filesystem removal — an unlinkat-based walk from the pinned
-    * parent fd (rm_rf_at never follows symlinks), heartbeating via the tick
-    * hook. Step 7: prune the org dir when it emptied (best-effort, still
-    * under the first-component lock). */
+   /* Step 6: filesystem removal — rename-first tombstone, then an
+    * unlinkat-based walk from the pinned parent fd (rm_rf_at never follows
+    * symlinks), heartbeating via the tick hook. The project is atomically
+    * renamed to the dot-prefixed ".deleting-<repo>" sibling BEFORE the walk:
+    * dot names are invisible to the lister/structural rules and cannot
+    * collide with valid refs, so an interrupted walk leaves a RESUMABLE
+    * marker instead of a half-removed tree that no longer resolves. Step 7:
+    * prune the org dir when it emptied (best-effort, still under the
+    * first-component lock). */
    {
       int (*tick)(void *) = purge_ran ? gp_hb_tick : NULL;
       void *tick_ctx = purge_ran ? &hb : NULL;
-      char org[WS_REF_COMP_MAX + 1], repo[WS_REF_COMP_MAX + 1];
-      if (ws_scope_ref_split(ref, org, sizeof(org), repo, sizeof(repo)) < 0)
-      {
-         snprintf(err, errlen, "invalid project ref");
-         goto out;
-      }
       rootfd = ws_scope_open_user_root(principal);
       if (rootfd < 0)
       {
@@ -1116,7 +1176,7 @@ int git_project_delete(const char *principal, const char *ref, int force,
          snprintf(err, errlen, "could not open the workspace root");
          goto out;
       }
-      int rm_rc;
+      int parentfd = rootfd;
       if (org[0])
       {
          orgfd = ws_scope_openat2_dir(rootfd, org);
@@ -1126,14 +1186,26 @@ int git_project_delete(const char *principal, const char *ref, int force,
             snprintf(err, errlen, "could not open the org directory");
             goto out;
          }
-         rm_rc = rm_rf_at_tick(orgfd, repo, tick, tick_ctx);
+         parentfd = orgfd;
+      }
+      int rm_rc = 0;
+      if (!resumed)
+      {
+         /* Fold in any stale marker from an even older crash (renameat onto a
+          * non-empty dir would fail), then tombstone the project. */
+         (void)rm_rf_at_tick(parentfd, marker, tick, tick_ctx);
+         if (renameat(parentfd, repo, parentfd, marker) != 0)
+            rm_rc = -1;
+      }
+      if (rm_rc == 0)
+         rm_rc = rm_rf_at_tick(parentfd, marker, tick, tick_ctx);
+      if (orgfd >= 0)
+      {
          close(orgfd);
          orgfd = -1;
-         if (rm_rc == 0)
-            (void)unlinkat(rootfd, org, AT_REMOVEDIR); /* prune if now empty */
       }
-      else
-         rm_rc = rm_rf_at_tick(rootfd, repo, tick, tick_ctx);
+      if (rm_rc == 0 && org[0])
+         (void)unlinkat(rootfd, org, AT_REMOVEDIR); /* prune if now empty */
       if (rm_rc != 0)
       {
          /* The kb purge (when one ran) is committed and its fence stays until
@@ -1168,12 +1240,16 @@ int git_project_delete(const char *principal, const char *ref, int force,
                    ref, res->purge_id);
       free(fj);
    }
+   /* The 'done' record only emits here — after the marker tree is fully gone
+    * and the fence finalized. */
    if (strcmp(res->kb_status, "retained") == 0)
-      delete_audit(res->purge_id, principal, ref, "done", "kb_status=retained fs=removed");
+      delete_audit(res->purge_id, principal, ref, "done", "%skb_status=retained fs=removed",
+                   resumed ? "resumed=1 " : "");
    else
       delete_audit(res->purge_id, principal, ref, "done",
-                   "kb_status=%s fs=removed fence_generation=%s kb=%s", res->kb_status,
-                   res->generation, res->kb_detail ? res->kb_detail : "");
+                   "%skb_status=%s fs=removed fence_generation=%s kb=%s",
+                   resumed ? "resumed=1 " : "", res->kb_status, res->generation,
+                   res->kb_detail ? res->kb_detail : "");
    rc_final = 0;
 
 out:

--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -8,6 +8,7 @@
  * fd-pinned via openat2 — no string-path window). */
 #include "git_project.h"
 #include "cJSON.h"           /* kb purge reply parsing (delete path) */
+#include "config.h"          /* kb_purge_fence_ttl_s (heartbeat cadence) */
 #include "git_cred_inject.h" /* git_cred_inject_build_env_for_repo / _free_env */
 #include "git_host_cred.h"   /* per-host token store (single-user, many hosts) */
 #include "kb_client.h"       /* kb purge/finalize/cancel wrappers (slice 2) */
@@ -20,6 +21,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -230,9 +232,15 @@ int git_project_org_candidates(const char *url, char *out, size_t cap)
 
 /* Recursively remove `name` (a directory tree) under `parentfd`. Every descent
  * uses O_NOFOLLOW — directory symlinks are unlinked as entries, never
- * followed. Best-effort; returns 0 when the entry is gone. */
-static int rm_rf_at(int parentfd, const char *name)
+ * followed. Best-effort; returns 0 when the entry is gone. `tick` (optional)
+ * is a progress hook invoked per entry: a non-zero return STOPS the walk
+ * immediately (the delete path uses it to heartbeat the purge fence and to
+ * bail when fence ownership is lost — the partial tree is retried by
+ * re-running the idempotent delete). */
+static int rm_rf_at_tick(int parentfd, const char *name, int (*tick)(void *), void *tick_ctx)
 {
+   if (tick && tick(tick_ctx) != 0)
+      return -1;
    int fd = openat(parentfd, name, O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
    if (fd < 0)
       return unlinkat(parentfd, name, 0) == 0 || errno == ENOENT ? 0 : -1;
@@ -242,21 +250,40 @@ static int rm_rf_at(int parentfd, const char *name)
       close(fd);
       return -1;
    }
+   int stopped = 0;
    struct dirent *e;
    while ((e = readdir(d)) != NULL)
    {
       if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)
          continue;
+      if (tick && tick(tick_ctx) != 0)
+      {
+         stopped = 1;
+         break;
+      }
       struct stat st;
       if (fstatat(fd, e->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0)
          continue;
       if (S_ISDIR(st.st_mode))
-         rm_rf_at(fd, e->d_name);
+      {
+         if (rm_rf_at_tick(fd, e->d_name, tick, tick_ctx) != 0 && tick && tick(tick_ctx) != 0)
+         {
+            stopped = 1;
+            break;
+         }
+      }
       else
          unlinkat(fd, e->d_name, 0);
    }
    closedir(d); /* closes fd */
+   if (stopped)
+      return -1;
    return unlinkat(parentfd, name, AT_REMOVEDIR) == 0 ? 0 : -1;
+}
+
+static int rm_rf_at(int parentfd, const char *name)
+{
+   return rm_rf_at_tick(parentfd, name, NULL, NULL);
 }
 
 /* Does `name` under `dirfd` exist as a dir containing a .git entry (i.e. a
@@ -631,15 +658,38 @@ out:
 /* ---- delete (slice 2) ---------------------------------------------------- */
 
 /* One webuser_project_delete_audit_v1 line. Every phase of one operation
- * shares the same purge_id; `extra` (may be "") carries phase-specific
- * key=value pairs (reason=…, kb_status=…, fence_generation=…). */
-static void delete_audit(const char *purge_id, const char *principal, const char *ref,
-                         const char *phase, const char *extra)
+ * shares the same purge_id; `extra_fmt` (may be "") formats phase-specific
+ * key=value pairs (reason=…, kb_status=…, fence_generation=…, kb=…). The
+ * extra tail is built in a heap buffer when needed so the per-store kb detail
+ * is NEVER truncated in the audit record. */
+__attribute__((format(printf, 5, 6))) static void delete_audit(const char *purge_id,
+                                                               const char *principal,
+                                                               const char *ref, const char *phase,
+                                                               const char *extra_fmt, ...)
 {
+   char stackbuf[512];
+   char *extra = stackbuf;
+   va_list ap;
+   va_start(ap, extra_fmt);
+   int need = vsnprintf(stackbuf, sizeof(stackbuf), extra_fmt, ap);
+   va_end(ap);
+   if (need >= (int)sizeof(stackbuf))
+   {
+      char *heap = malloc((size_t)need + 1);
+      if (heap)
+      {
+         va_start(ap, extra_fmt);
+         vsnprintf(heap, (size_t)need + 1, extra_fmt, ap);
+         va_end(ap);
+         extra = heap;
+      } /* OOM: fall back to the truncated stack copy */
+   }
    aimee_log(LOG_INFO, "webuser.project.delete",
              "webuser_project_delete_audit_v1 schema_version=1 purge_id=%s principal=%s ref=%s "
              "phase=%s%s%s",
-             purge_id, principal, ref, phase, extra && extra[0] ? " " : "", extra ? extra : "");
+             purge_id, principal, ref, phase, extra[0] ? " " : "", extra);
+   if (extra != stackbuf)
+      free(extra);
 }
 
 /* Mint a random hex purge id (16 bytes of /dev/urandom -> 32 hex chars;
@@ -710,16 +760,96 @@ static int purge_reply_parse(const char *json, char **detail)
    return ok ? 1 : 0;
 }
 
-/* Did a finalize/cancel wrapper reply reach the kb ({"status":"ok"})? 0/1. */
-static int purge_reply_reached(const char *json)
+/* Was a finalize/cancel CONFIRMED? Requires {"status":"ok","cleared":true} —
+ * cleared:false is the kb's generation/purge_id-mismatch no-op (someone else
+ * owns the fence now) and an absent/malformed `cleared` is NOT confirmation.
+ * 0/1. */
+static int purge_reply_cleared(const char *json)
 {
    cJSON *j = json ? cJSON_Parse(json) : NULL;
    if (!j)
       return 0;
    const cJSON *jstatus = cJSON_GetObjectItemCaseSensitive(j, "status");
-   int ok = cJSON_IsString(jstatus) && strcmp(jstatus->valuestring, "ok") == 0;
+   const cJSON *jcleared = cJSON_GetObjectItemCaseSensitive(j, "cleared");
+   int ok = cJSON_IsString(jstatus) && strcmp(jstatus->valuestring, "ok") == 0 &&
+            cJSON_IsBool(jcleared) && cJSON_IsTrue(jcleared);
    cJSON_Delete(j);
    return ok;
+}
+
+/* The fence TTL, mirroring the kb side (JSON key kb.purge_fence_ttl_s,
+ * default 900s) so both ends agree on the staleness bound. */
+static int gp_fence_ttl_s(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) == 0 && cfg.kb_purge_fence_ttl_s > 0)
+      return cfg.kb_purge_fence_ttl_s;
+   return 900;
+}
+
+/* Heartbeat state for one delete's fence: refreshed at ~TTL/6 cadence during
+ * the filesystem walk so a tree bigger than the TTL cannot let the fence
+ * expire (and writers resume) mid-delete. */
+typedef struct
+{
+   const char *ref, *generation, *purge_id;
+   time_t last;    /* last heartbeat attempt */
+   int interval_s; /* ~TTL/6 (150s at the 900s default) */
+   int fails;      /* consecutive transport failures */
+   int lost;       /* sticky: ownership lost / kb gone — stop the walk */
+} gp_hb_ctx_t;
+
+/* Send one heartbeat now. 0 = the fence is still ours; -1 = ownership lost
+ * (refreshed:false — a takeover displaced this operation) or the transport
+ * failed repeatedly (the fence may expire under us). Sticky via hb->lost. */
+static int gp_hb_beat(gp_hb_ctx_t *hb)
+{
+   if (hb->lost)
+      return -1;
+   char *j = kb_client_purge_heartbeat_json(hb->ref, hb->generation, hb->purge_id);
+   cJSON *r = j ? cJSON_Parse(j) : NULL;
+   int reached = 0, refreshed = 1;
+   if (r)
+   {
+      const cJSON *js = cJSON_GetObjectItemCaseSensitive(r, "status");
+      reached = cJSON_IsString(js) && strcmp(js->valuestring, "ok") == 0;
+      const cJSON *jr = cJSON_GetObjectItemCaseSensitive(r, "refreshed");
+      if (cJSON_IsBool(jr))
+         refreshed = cJSON_IsTrue(jr);
+   }
+   cJSON_Delete(r);
+   free(j);
+   hb->last = time(NULL);
+   if (reached && refreshed)
+   {
+      hb->fails = 0;
+      return 0;
+   }
+   if (reached) /* refreshed:false — a takeover owns the fence now */
+   {
+      hb->lost = 1;
+      return -1;
+   }
+   if (++hb->fails >= 3) /* 3 consecutive misses at TTL/6 is still < TTL/2 */
+   {
+      hb->lost = 1;
+      return -1;
+   }
+   return 0;
+}
+
+/* rm_rf_at_tick progress hook: heartbeat when the cadence elapsed; a non-zero
+ * return stops the walk (fence lost). */
+static int gp_hb_tick(void *ctx)
+{
+   gp_hb_ctx_t *hb = ctx;
+   if (!hb)
+      return 0;
+   if (hb->lost)
+      return -1;
+   if (time(NULL) - hb->last < hb->interval_s)
+      return 0;
+   return gp_hb_beat(hb);
 }
 
 int git_project_delete(const char *principal, const char *ref, int force,
@@ -765,7 +895,7 @@ int git_project_delete(const char *principal, const char *ref, int force,
 
    /* Step 2: audit intent FIRST — before any existence resolution — so a
     * cross-principal or nonexistent ref still leaves a record. */
-   delete_audit(res->purge_id, principal, ref, "intent", "");
+   delete_audit(res->purge_id, principal, ref, "intent", "%s", "");
 
    int lockfd = ws_reg_lock(ref);
    if (lockfd < 0)
@@ -777,7 +907,6 @@ int git_project_delete(const char *principal, const char *ref, int force,
 
    int rc_final = -1, rootfd = -1, orgfd = -1;
    int purge_ran = 0; /* a fence was written — heartbeat + finalize apply */
-   char audit_extra[512];
 
    /* Step 3: resolve strictly under the caller's tree; any failure is a plain
     * not-found (no existence disclosure about other principals' trees). */
@@ -859,9 +988,8 @@ int git_project_delete(const char *principal, const char *ref, int force,
                       "ref '%s': could not roll back the registry decrement after a kb transport "
                       "failure (purge_id=%s); the startup rebuild self-heals",
                       ref, res->purge_id);
-         snprintf(audit_extra, sizeof(audit_extra), "reason=kb-unreachable kb=%.300s",
-                  res->kb_detail ? res->kb_detail : "");
-         delete_audit(res->purge_id, principal, ref, "aborted", audit_extra);
+         delete_audit(res->purge_id, principal, ref, "aborted", "reason=kb-unreachable kb=%s",
+                      res->kb_detail ? res->kb_detail : "");
          snprintf(err, errlen, "knowledge service unavailable");
          rc_final = GP_ERR_KB_UNAVAILABLE;
          goto out;
@@ -869,12 +997,12 @@ int git_project_delete(const char *principal, const char *ref, int force,
       else
       {
          /* The kb was reached but a store failed: a fence exists. The
-          * decrement is reinstated ONLY if purge-cancel confirms the fence
-          * rollback; a failed cancel keeps the fence AND the decrement
-          * (terminal "purge committed but unfinished" — re-running the
-          * delete converges). */
+          * decrement is reinstated ONLY if purge-cancel CONFIRMS the fence
+          * rollback (cleared:true — a cleared:false mismatch no-op or a
+          * failed cancel keeps the fence AND the decrement: terminal "purge
+          * committed but unfinished", re-running the delete converges). */
          char *cj = kb_client_purge_cancel_json(ref, res->generation, res->purge_id);
-         int cancelled = purge_reply_reached(cj);
+         int cancelled = purge_reply_cleared(cj);
          free(cj);
          if (cancelled)
          {
@@ -883,17 +1011,15 @@ int git_project_delete(const char *principal, const char *ref, int force,
                          "ref '%s': could not roll back the registry decrement after purge-cancel "
                          "(purge_id=%s); the startup rebuild self-heals",
                          ref, res->purge_id);
-            snprintf(audit_extra, sizeof(audit_extra), "reason=kb-error kb=%.300s",
-                     res->kb_detail ? res->kb_detail : "");
-            delete_audit(res->purge_id, principal, ref, "aborted", audit_extra);
+            delete_audit(res->purge_id, principal, ref, "aborted", "reason=kb-error kb=%s",
+                         res->kb_detail ? res->kb_detail : "");
             snprintf(err, errlen, "knowledge service unavailable");
          }
          else
          {
-            snprintf(audit_extra, sizeof(audit_extra),
-                     "reason=purge-committed-unfinished fence_generation=%s kb=%.300s",
-                     res->generation, res->kb_detail ? res->kb_detail : "");
-            delete_audit(res->purge_id, principal, ref, "aborted", audit_extra);
+            delete_audit(res->purge_id, principal, ref, "aborted",
+                         "reason=purge-committed-unfinished fence_generation=%s kb=%s",
+                         res->generation, res->kb_detail ? res->kb_detail : "");
             snprintf(err, errlen,
                      "purge committed but unfinished: the knowledge fence is set and the purge "
                      "must be re-run to convergence");
@@ -905,25 +1031,78 @@ int git_project_delete(const char *principal, const char *ref, int force,
 
    /* Step 5: server-local lexical index rows are keyed by project (shared
     * across webusers) and follow the kb decision exactly: deleted on
-    * purged/forced, kept on retained. */
-   if (strcmp(res->kb_status, "retained") != 0)
+    * purged/forced, kept on retained. A failure here ABORTS BEFORE any
+    * filesystem removal — proceeding would strand shared index rows with no
+    * retry path once the clone is gone. The clone still exists, so the
+    * holder is re-registered and the fence cancelled; re-running the delete
+    * converges (the kb deletes are idempotent, and a re-scan restores any
+    * stores this attempt already emptied). */
+   if (strcmp(res->kb_status, "retained") != 0 && db2_code_index_project_delete(ref) != 0)
    {
-      if (db2_code_index_project_delete(ref) != 0)
-         aimee_log(LOG_WARN, "webuser.project.delete",
-                   "ref '%s': server-local lexical index delete failed (purge_id=%s); a re-scan "
-                   "of a future clone overwrites the rows",
-                   ref, res->purge_id);
+      int cancelled;
+      if (purge_ran)
+      {
+         char *cj = kb_client_purge_cancel_json(ref, res->generation, res->purge_id);
+         cancelled = purge_reply_cleared(cj);
+         free(cj);
+      }
+      else
+         cancelled = 1; /* forced transport failure: no fence was ever written */
+      if (cancelled)
+      {
+         if (ws_reg_register(ref, reg_remote) != 0)
+            aimee_log(LOG_ERROR, "webuser.project.delete",
+                      "ref '%s': could not roll back the registry decrement after a local-index "
+                      "failure (purge_id=%s); the startup rebuild self-heals",
+                      ref, res->purge_id);
+         delete_audit(res->purge_id, principal, ref, "aborted", "reason=local-index-failed kb=%s",
+                      res->kb_detail ? res->kb_detail : "");
+         snprintf(err, errlen,
+                  "could not clear the server-local code index; nothing was removed — try again");
+      }
+      else
+      {
+         delete_audit(res->purge_id, principal, ref, "aborted",
+                      "reason=purge-committed-unfinished fence_generation=%s kb=%s",
+                      res->generation, res->kb_detail ? res->kb_detail : "");
+         snprintf(err, errlen,
+                  "purge committed but unfinished: the knowledge fence is set and the purge "
+                  "must be re-run to convergence");
+      }
+      rc_final = GP_ERR_KB_UNAVAILABLE;
+      goto out;
    }
 
-   /* Heartbeat the fence before the filesystem walk (long trees must not
-    * outlive the fence TTL). */
-   if (purge_ran)
-      free(kb_client_purge_heartbeat_json(ref, res->generation, res->purge_id));
+   /* Heartbeat the fence before AND periodically during the filesystem walk
+    * (a tree larger than the TTL must not let the fence expire — and writers
+    * resume — mid-delete). Losing ownership (a takeover displaced us) or the
+    * kb transport stops the walk; the partial tree is retried by re-running
+    * the idempotent delete. */
+   gp_hb_ctx_t hb;
+   memset(&hb, 0, sizeof(hb));
+   hb.ref = ref;
+   hb.generation = res->generation;
+   hb.purge_id = res->purge_id;
+   hb.interval_s = gp_fence_ttl_s() / 6;
+   if (hb.interval_s < 1)
+      hb.interval_s = 1;
+   if (purge_ran && gp_hb_beat(&hb) != 0)
+   {
+      delete_audit(res->purge_id, principal, ref, "aborted",
+                   "reason=fence-lost fence_generation=%s", res->generation);
+      snprintf(err, errlen,
+               "purge fence ownership lost before removal; re-run the delete to convergence");
+      rc_final = GP_ERR_KB_UNAVAILABLE;
+      goto out;
+   }
 
    /* Step 6: filesystem removal — an unlinkat-based walk from the pinned
-    * parent fd (rm_rf_at never follows symlinks). Step 7: prune the org dir
-    * when it emptied (best-effort, still under the first-component lock). */
+    * parent fd (rm_rf_at never follows symlinks), heartbeating via the tick
+    * hook. Step 7: prune the org dir when it emptied (best-effort, still
+    * under the first-component lock). */
    {
+      int (*tick)(void *) = purge_ran ? gp_hb_tick : NULL;
+      void *tick_ctx = purge_ran ? &hb : NULL;
       char org[WS_REF_COMP_MAX + 1], repo[WS_REF_COMP_MAX + 1];
       if (ws_scope_ref_split(ref, org, sizeof(org), repo, sizeof(repo)) < 0)
       {
@@ -947,20 +1126,32 @@ int git_project_delete(const char *principal, const char *ref, int force,
             snprintf(err, errlen, "could not open the org directory");
             goto out;
          }
-         rm_rc = rm_rf_at(orgfd, repo);
+         rm_rc = rm_rf_at_tick(orgfd, repo, tick, tick_ctx);
          close(orgfd);
          orgfd = -1;
          if (rm_rc == 0)
             (void)unlinkat(rootfd, org, AT_REMOVEDIR); /* prune if now empty */
       }
       else
-         rm_rc = rm_rf_at(rootfd, repo);
+         rm_rc = rm_rf_at_tick(rootfd, repo, tick, tick_ctx);
       if (rm_rc != 0)
       {
          /* The kb purge (when one ran) is committed and its fence stays until
-          * finalize or TTL — re-running the delete converges. */
-         delete_audit(res->purge_id, principal, ref, "aborted", "reason=fs-failed");
-         snprintf(err, errlen, "could not remove the project directory");
+          * finalize or TTL — re-running the delete converges over the partial
+          * tree in either case. */
+         if (hb.lost)
+         {
+            delete_audit(res->purge_id, principal, ref, "aborted",
+                         "reason=fence-lost fence_generation=%s", res->generation);
+            snprintf(err, errlen,
+                     "purge fence ownership lost during removal; re-run the delete to convergence");
+            rc_final = GP_ERR_KB_UNAVAILABLE;
+         }
+         else
+         {
+            delete_audit(res->purge_id, principal, ref, "aborted", "reason=fs-failed");
+            snprintf(err, errlen, "could not remove the project directory");
+         }
          goto out;
       }
    }
@@ -970,20 +1161,19 @@ int git_project_delete(const char *principal, const char *ref, int force,
    if (purge_ran)
    {
       char *fj = kb_client_purge_finalize_json(ref, res->generation, res->purge_id);
-      if (!purge_reply_reached(fj))
+      if (!purge_reply_cleared(fj))
          aimee_log(LOG_WARN, "webuser.project.delete",
-                   "ref '%s': purge-finalize did not reach the kb (purge_id=%s); the fence "
-                   "expires via its TTL",
+                   "ref '%s': purge-finalize did not confirm clearing the fence (purge_id=%s); "
+                   "it expires via its TTL",
                    ref, res->purge_id);
       free(fj);
    }
    if (strcmp(res->kb_status, "retained") == 0)
-      snprintf(audit_extra, sizeof(audit_extra), "kb_status=retained fs=removed");
+      delete_audit(res->purge_id, principal, ref, "done", "kb_status=retained fs=removed");
    else
-      snprintf(audit_extra, sizeof(audit_extra),
-               "kb_status=%s fs=removed fence_generation=%s kb=%.300s", res->kb_status,
-               res->generation, res->kb_detail ? res->kb_detail : "");
-   delete_audit(res->purge_id, principal, ref, "done", audit_extra);
+      delete_audit(res->purge_id, principal, ref, "done",
+                   "kb_status=%s fs=removed fence_generation=%s kb=%s", res->kb_status,
+                   res->generation, res->kb_detail ? res->kb_detail : "");
    rc_final = 0;
 
 out:

--- a/src/server/kb_client.c
+++ b/src/server/kb_client.c
@@ -426,6 +426,63 @@ char *kb_client_clear_json(const char *project)
    return kb_error_json("knowledge service /v1/maintenance/clear did not respond");
 }
 
+/* webchat-project-lifecycle slice 2: shared POST body/transport handling for
+ * the /v1/maintenance/purge-* fence routes. `takeover` < 0 omits the field. */
+static char *kb_client_purge_post_json(const char *endpoint, const char *project,
+                                       const char *generation, const char *purge_id, int takeover)
+{
+   if (!project || !project[0] || !generation || !generation[0] || !purge_id || !purge_id[0])
+      return kb_error_json("purge requires project, generation and purge_id");
+
+   cJSON *req = cJSON_CreateObject();
+   if (!req)
+      return kb_error_json("out of memory");
+   cJSON_AddStringToObject(req, "project", project);
+   cJSON_AddStringToObject(req, "generation", generation);
+   cJSON_AddStringToObject(req, "purge_id", purge_id);
+   if (takeover > 0)
+      cJSON_AddTrueToObject(req, "takeover");
+
+   int http_status = -1;
+   char *resp = kb_client_v1_post_json(endpoint, req, CLIENT_DEFAULT_TIMEOUT_MS, &http_status);
+   cJSON_Delete(req);
+   if (resp)
+      return resp;
+   char msg[160];
+   if (http_status >= 100)
+      snprintf(msg, sizeof(msg), "knowledge service %s returned HTTP %d", endpoint, http_status);
+   else
+      snprintf(msg, sizeof(msg), "knowledge service %s did not respond", endpoint);
+   return kb_error_json(msg);
+}
+
+char *kb_client_purge_project_json(const char *project, const char *generation,
+                                   const char *purge_id, int takeover)
+{
+   return kb_client_purge_post_json("/v1/maintenance/purge-project", project, generation, purge_id,
+                                    takeover ? 1 : 0);
+}
+
+char *kb_client_purge_heartbeat_json(const char *project, const char *generation,
+                                     const char *purge_id)
+{
+   return kb_client_purge_post_json("/v1/maintenance/purge-heartbeat", project, generation,
+                                    purge_id, -1);
+}
+
+char *kb_client_purge_finalize_json(const char *project, const char *generation,
+                                    const char *purge_id)
+{
+   return kb_client_purge_post_json("/v1/maintenance/purge-finalize", project, generation, purge_id,
+                                    -1);
+}
+
+char *kb_client_purge_cancel_json(const char *project, const char *generation, const char *purge_id)
+{
+   return kb_client_purge_post_json("/v1/maintenance/purge-cancel", project, generation, purge_id,
+                                    -1);
+}
+
 /* Synchronous build/update now run entirely inside aimee-kb (which owns DB2
  * and the filesystem) via the /v1/code/{build,update} endpoints — no
  * server-side compute or chunk push. */

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -1524,6 +1524,81 @@ static int rh_workspace_projects(const route_req_t *rq, char *resp, int cap)
    return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "response too large");
 }
 
+/* POST /v1/workspace/projects/delete {ref, force?} — delete a cloned project
+ * under the calling webchat user's scoped workspace (webchat project lifecycle
+ * proposal, slice 2). The ONLY identity source is the attested X-Aimee-Webuser
+ * principal; another webuser's ref is a plain 404. The last holder of a ref
+ * triggers the fenced kb purge (503 abort without `force`); other holders keep
+ * the shared knowledge (kb_status "retained"). Capability: tool:execute. */
+static int rh_workspace_projects_delete(const route_req_t *rq, char *resp, int cap)
+{
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
+   const char *principal = server_http_identity_principal();
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+      return err_json(resp, cap, 403, "git projects require a webchat user");
+
+   cJSON *body = (rq->body && rq->body[0]) ? cJSON_Parse(rq->body) : NULL;
+   if (!body || !cJSON_IsObject(body))
+   {
+      cJSON_Delete(body);
+      return err_json(resp, cap, 400, "invalid JSON body");
+   }
+   const cJSON *jref = cJSON_GetObjectItemCaseSensitive(body, "ref");
+   const cJSON *jforce = cJSON_GetObjectItemCaseSensitive(body, "force");
+   char ref[GIT_PROJECT_NAME_MAX];
+   ref[0] = '\0';
+   if (cJSON_IsString(jref) && jref->valuestring && strlen(jref->valuestring) < sizeof(ref))
+      snprintf(ref, sizeof(ref), "%s", jref->valuestring);
+   int force = cJSON_IsBool(jforce) && cJSON_IsTrue(jforce);
+   cJSON_Delete(body);
+   if (!ref[0])
+      return err_json(resp, cap, 400, "ref required");
+
+   git_project_delete_result_t res;
+   char err[512];
+   int rc = git_project_delete(principal, ref, force, &res, err, sizeof(err));
+   if (rc == GP_ERR_NOT_FOUND)
+   {
+      free(res.kb_detail);
+      return err_json(resp, cap, 404, "not found");
+   }
+   if (rc == GP_ERR_KB_UNAVAILABLE)
+   {
+      cJSON *out = cJSON_CreateObject();
+      cJSON_AddStringToObject(out, "error", err);
+      cJSON *kb = res.kb_detail ? cJSON_Parse(res.kb_detail) : NULL;
+      if (kb)
+         cJSON_AddItemToObject(out, "kb", kb);
+      free(res.kb_detail);
+      char *s = cJSON_PrintUnformatted(out);
+      int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
+      free(s);
+      cJSON_Delete(out);
+      return (n > 0 && n < cap) ? 503 : err_json(resp, cap, 503, "knowledge service unavailable");
+   }
+   if (rc != 0)
+   {
+      free(res.kb_detail);
+      return err_json(resp, cap, 400, err);
+   }
+
+   cJSON *out = cJSON_CreateObject();
+   cJSON_AddBoolToObject(out, "ok", 1);
+   cJSON_AddStringToObject(out, "ref", ref);
+   cJSON_AddStringToObject(out, "kb_status", res.kb_status);
+   cJSON_AddStringToObject(out, "purge_id", res.purge_id);
+   cJSON *kb = res.kb_detail ? cJSON_Parse(res.kb_detail) : NULL;
+   if (kb)
+      cJSON_AddItemToObject(out, "kb", kb);
+   free(res.kb_detail);
+   char *s = cJSON_PrintUnformatted(out);
+   int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
+   free(s);
+   cJSON_Delete(out);
+   return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "response too large");
+}
+
 /* POST /v1/chat/live {session_id, since_rev} — the browser's polling source of
  * truth for an in-flight turn. The server mirrors the tmux pane scrape into the
  * db1 webchat_live row as the answer streams; the browser tails it on a fixed
@@ -2367,6 +2442,8 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/workspace/session-dir", NULL, RM_EXACT, NULL, CAP_INDEX_READ,
      rh_workspace_session_dir},
     {"GET", "/v1/workspace/projects", NULL, RM_EXACT, NULL, CAP_INDEX_READ, rh_workspace_projects},
+    {"POST", "/v1/workspace/projects/delete", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE,
+     rh_workspace_projects_delete},
     {"GET", "/v1/workspace/org-repos", NULL, RM_EXACT, NULL, CAP_INDEX_READ,
      rh_workspace_org_repos},
     {"POST", "/v1/workspace/clone-org", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE,

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2675,6 +2675,8 @@ $(TESTPREFIX)/unit-test-curator-contradictions: \
 $(TESTPREFIX)/unit-test-curator-index-code-unit: \
                                        $(OBJDIR)/tests/test_curator_index_code_unit.o \
                                        $(OBJDIR)/kb/kb_curator_index_code_unit.o \
+                                       $(OBJDIR)/db2/kb_runtime_state.o \
+                                       $(OBJDIR)/tests/support/kb_txn_stub.o \
                                        $(OBJDIR)/db2/artifacts.o $(OBJDIR)/db2/kb_audit_worm.o $(OBJDIR)/audit_worm_chain.o $(OBJDIR)/workflow/wfe_canonical.o \
                                        $(OBJDIR)/db2/feature_rows.o \
                                        $(OBJDIR)/kb/kb_mdl.o \
@@ -2689,6 +2691,8 @@ $(TESTPREFIX)/unit-test-curator-pipeline: \
                                        $(OBJDIR)/kb/kb_curator_resolve_entities.o \
                                        $(OBJDIR)/kb_curator_provider.o \
                                        $(OBJDIR)/kb/kb_curator_index_code_unit.o \
+                                       $(OBJDIR)/db2/kb_runtime_state.o \
+                                       $(OBJDIR)/tests/support/kb_txn_stub.o \
                                        $(OBJDIR)/kb/kb_curator_link_artifacts.o \
                                        $(OBJDIR)/kb/kb_curator_serve.o \
                                        $(OBJDIR)/db2/artifacts.o $(OBJDIR)/db2/kb_audit_worm.o $(OBJDIR)/audit_worm_chain.o $(OBJDIR)/workflow/wfe_canonical.o \
@@ -3035,6 +3039,7 @@ $(TESTPREFIX)/unit-test-git-ops: $(OBJDIR)/tests/test_git_ops.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-git-project: $(OBJDIR)/tests/test_git_project.o \
+                              $(OBJDIR)/tests/support/kb_purge_stub.o \
                               $(OBJDIR)/server/git_project.o $(OBJDIR)/server/ws_registry.o $(OBJDIR)/server/git_cred_inject.o $(OBJDIR)/server/git_ssh_agent.o $(OBJDIR)/server/webuser_runtime.o \
                               $(OBJDIR)/server/git_forge_vault.o $(OBJDIR)/server/git_host_cred.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/server/workspace_scope.o \
                               $(OBJDIR)/forge_credentials.o $(OBJDIR)/util_url.o $(OBJDIR)/config.o $(OBJDIR)/aimee_home.o \
@@ -3375,7 +3380,7 @@ $(TESTPREFIX)/unit-test-turn-narration: $(OBJDIR)/tests/test_turn_narration.o \
                                          $(OBJDIR)/turn_narration.o $(OBJDIR)/cJSON.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
-$(TESTPREFIX)/unit-test-kb: $(OBJDIR)/tests/test_kb.o $(OBJDIR)/kb/kb.o $(OBJDIR)/kb/kb_ingest_workers.o $(OBJDIR)/kb/kb_bandit.o $(OBJDIR)/kb/kb_bandit_registry.o $(OBJDIR)/db2/bandit.o $(OBJDIR)/kb/kb_curator_notify.o $(OBJDIR)/kb/kb_fusion.o $(OBJDIR)/kb/kb_neardup.o $(OBJDIR)/kb/kb_conventions.o \
+$(TESTPREFIX)/unit-test-kb: $(OBJDIR)/tests/test_kb.o $(OBJDIR)/kb/kb.o $(OBJDIR)/db2/kb_runtime_state.o $(OBJDIR)/kb/kb_ingest_workers.o $(OBJDIR)/kb/kb_bandit.o $(OBJDIR)/kb/kb_bandit_registry.o $(OBJDIR)/db2/bandit.o $(OBJDIR)/kb/kb_curator_notify.o $(OBJDIR)/kb/kb_fusion.o $(OBJDIR)/kb/kb_neardup.o $(OBJDIR)/kb/kb_conventions.o \
                              $(OBJDIR)/sketch.o $(OBJDIR)/db2/sketch.o \
                              $(OBJDIR)/memory_core.o $(OBJDIR)/memory_core_crud.o $(OBJDIR)/memory_core_helpers.o $(OBJDIR)/memory_core_helpers_b.o $(OBJDIR)/memory_core_search.o $(OBJDIR)/memory_core_search_b.o $(OBJDIR)/memory_core_search_c.o $(OBJDIR)/memory_core_scope_embed.o $(OBJDIR)/memory_core_tiers.o $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/kb_payload.o $(OBJDIR)/db2/kb_service_backend.o $(OBJDIR)/db2/kb_service_backend_ingest.o $(OBJDIR)/db2/memory_lifecycle.o $(OBJDIR)/db2/memory_payload.o $(OBJDIR)/db2/memory_promotion.o $(OBJDIR)/db2/memory_query.o $(OBJDIR)/db2/memory_query_bookkeeping.o $(OBJDIR)/db2/memory_entity_graph.o $(OBJDIR)/db2/memory_score_fields.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_scenes.o $(OBJDIR)/db2/memory_briefing.o $(OBJDIR)/db2/memory_health.o $(OBJDIR)/db2/memory_row_mapper_pg.o $(OBJDIR)/db2/memory_relations.o $(OBJDIR)/db2/memory_conflicts.o $(OBJDIR)/db2/vector_index_ops.o $(OBJDIR)/db2/code_index_ops.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/db2/feedback.o $(OBJDIR)/db2/notes.o $(OBJDIR)/db2/anti_patterns.o $(OBJDIR)/db2/curiosity.o $(OBJDIR)/db2/entity_edges.o $(OBJDIR)/db2/entity_profiles.o $(OBJDIR)/db2/epistemic_directives.o $(OBJDIR)/db2/failed_queries.o $(OBJDIR)/db2/kind_lifecycle.o $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o $(OBJDIR)/tests/support/mock_agent_http.o $(OBJDIR)/tests/support/memory_embed_stub.o $(OBJDIR)/tests/support/kb_client_test_stub.o $(OBJDIR)/tests/support/kb_ws_stub.o $(OBJDIR)/posix/memory.o \
                              $(OBJDIR)/memory_logic.o $(OBJDIR)/memory_health.o $(OBJDIR)/memory_conflict.o $(OBJDIR)/memory_context.o $(OBJDIR)/memory_assemble.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -635,6 +635,7 @@ $(TESTPREFIX)/unit-test-fidelity-check: \
 $(TESTPREFIX)/unit-test-css-graph: \
                                        $(OBJDIR)/tests/test_css_graph.o \
                                        $(OBJDIR)/db2/css_graph.o \
+                                       $(OBJDIR)/db2/kb_runtime_state.o \
                                        $(OBJDIR)/css_analyze.o \
                                        $(OBJDIR)/db2/code_index.o \
                                        $(OBJDIR)/db2/cross_repo_resolver.o \
@@ -648,6 +649,7 @@ $(TESTPREFIX)/unit-test-css-insights: \
                                        $(OBJDIR)/tests/test_css_insights.o \
                                        $(OBJDIR)/db2/css_insights.o \
                                        $(OBJDIR)/db2/css_graph.o \
+                                       $(OBJDIR)/db2/kb_runtime_state.o \
                                        $(OBJDIR)/css_analyze.o \
                                        $(OBJDIR)/db2/code_index.o \
                                        $(OBJDIR)/db2/cross_repo_resolver.o \
@@ -679,6 +681,7 @@ $(TESTPREFIX)/unit-test-css-migration: \
                                        $(OBJDIR)/tests/test_css_migration.o \
                                        $(OBJDIR)/db2/css_migration.o \
                                        $(OBJDIR)/db2/css_graph.o \
+                                       $(OBJDIR)/db2/kb_runtime_state.o \
                                        $(OBJDIR)/db2/typed_facts.o \
                                        $(OBJDIR)/css_analyze.o \
                                        $(OBJDIR)/db2/code_index.o \
@@ -696,6 +699,7 @@ $(TESTPREFIX)/unit-test-css-render: \
                                        $(OBJDIR)/css_render_oracle.o \
                                        $(OBJDIR)/db2/css_migration.o \
                                        $(OBJDIR)/db2/css_graph.o \
+                                       $(OBJDIR)/db2/kb_runtime_state.o \
                                        $(OBJDIR)/db2/typed_facts.o \
                                        $(OBJDIR)/css_analyze.o \
                                        $(OBJDIR)/db2/code_index.o \

--- a/src/tests/aimee_pg_sqlite_shim.c
+++ b/src/tests/aimee_pg_sqlite_shim.c
@@ -122,6 +122,16 @@ static void pgvec_cos_dist_func(sqlite3_context *ctx, int argc, sqlite3_value **
    sqlite3_result_double(ctx, dist);
 }
 
+/* Purge-fence advisory-lock shims: pg_advisory_xact_lock / hashtext are
+ * mapped to no-ops. SQLite's single-writer serialization already provides
+ * the mutual exclusion the transaction-scoped advisory lock exists for. */
+static void shim_noop_int_func(sqlite3_context *ctx, int argc, sqlite3_value **argv)
+{
+   (void)argc;
+   (void)argv;
+   sqlite3_result_int(ctx, 0);
+}
+
 static void pgvec_register_functions(sqlite3 *db)
 {
    if (!db)
@@ -129,6 +139,10 @@ static void pgvec_register_functions(sqlite3 *db)
    sqlite3_create_function(db, "pgvec_cos_dist", 2,
                            SQLITE_UTF8 | SQLITE_DETERMINISTIC | SQLITE_INNOCUOUS, NULL,
                            pgvec_cos_dist_func, NULL, NULL);
+   sqlite3_create_function(db, "hashtext", 1, SQLITE_UTF8 | SQLITE_DETERMINISTIC | SQLITE_INNOCUOUS,
+                           NULL, shim_noop_int_func, NULL, NULL);
+   sqlite3_create_function(db, "pg_advisory_xact_lock", 1, SQLITE_UTF8 | SQLITE_INNOCUOUS, NULL,
+                           shim_noop_int_func, NULL, NULL);
    /* Fake pg_indexes so pgvec_table_ready() returns true for vector tables. */
    sqlite3_exec(
        db,

--- a/src/tests/support/git_route_stub.c
+++ b/src/tests/support/git_route_stub.c
@@ -37,6 +37,24 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
    return -1;
 }
 
+int git_project_delete(const char *principal, const char *ref, int force,
+                       git_project_delete_result_t *res, char *err, size_t errlen)
+{
+   (void)principal;
+   (void)ref;
+   (void)force;
+   if (res)
+   {
+      res->kb_status[0] = '\0';
+      res->purge_id[0] = '\0';
+      res->generation[0] = '\0';
+      res->kb_detail = NULL;
+   }
+   if (err && errlen)
+      snprintf(err, errlen, "stub");
+   return -1;
+}
+
 int git_project_derive_org(const char *url, char *out, size_t cap, int *multi_segment)
 {
    (void)url;

--- a/src/tests/support/kb_purge_stub.c
+++ b/src/tests/support/kb_purge_stub.c
@@ -1,0 +1,79 @@
+/* kb_purge_stub.c — slice-2 kb purge wrapper stubs for test binaries that link
+ * the real git_project.o but not kb_client.o (unit-test-git-project). Default
+ * behavior is a TRANSPORT failure ({"status":"error"}), which exercises the
+ * delete route's 503-abort path; setting AIMEE_TEST_KB_PURGE_MODE=ok makes the
+ * purge succeed so the purged/finalize path is testable too. Also stubs the
+ * server-local lexical index delete (db2_code_index_project_delete), which the
+ * kb agent implements in db2/. */
+#include "kb_client.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static char *dup_str(const char *s)
+{
+   size_t n = strlen(s) + 1;
+   char *p = malloc(n);
+   if (p)
+      memcpy(p, s, n);
+   return p;
+}
+
+static int stub_ok_mode(void)
+{
+   const char *m = getenv("AIMEE_TEST_KB_PURGE_MODE");
+   return m && strcmp(m, "ok") == 0;
+}
+
+char *kb_client_purge_project_json(const char *project, const char *generation,
+                                   const char *purge_id, int takeover)
+{
+   (void)project;
+   (void)generation;
+   (void)purge_id;
+   (void)takeover;
+   if (stub_ok_mode())
+      return dup_str(
+          "{\"status\":\"ok\",\"ok\":true,\"stores\":{\"stub\":0},\"fence_replaced\":false}");
+   return dup_str("{\"status\":\"error\",\"message\":\"stub\"}");
+}
+
+char *kb_client_purge_heartbeat_json(const char *project, const char *generation,
+                                     const char *purge_id)
+{
+   (void)project;
+   (void)generation;
+   (void)purge_id;
+   if (stub_ok_mode())
+      return dup_str("{\"status\":\"ok\"}");
+   return dup_str("{\"status\":\"error\",\"message\":\"stub\"}");
+}
+
+char *kb_client_purge_finalize_json(const char *project, const char *generation,
+                                    const char *purge_id)
+{
+   (void)project;
+   (void)generation;
+   (void)purge_id;
+   if (stub_ok_mode())
+      return dup_str("{\"status\":\"ok\",\"cleared\":true}");
+   return dup_str("{\"status\":\"error\",\"message\":\"stub\"}");
+}
+
+char *kb_client_purge_cancel_json(const char *project, const char *generation, const char *purge_id)
+{
+   (void)project;
+   (void)generation;
+   (void)purge_id;
+   if (stub_ok_mode())
+      return dup_str("{\"status\":\"ok\",\"cleared\":true}");
+   return dup_str("{\"status\":\"error\",\"message\":\"stub\"}");
+}
+
+/* Weak so a future db2_test_shim.c definition (kb agent) wins without a
+ * duplicate-symbol link failure. */
+__attribute__((weak)) int db2_code_index_project_delete(const char *name)
+{
+   (void)name;
+   return 0;
+}

--- a/src/tests/support/kb_purge_stub.c
+++ b/src/tests/support/kb_purge_stub.c
@@ -1,10 +1,20 @@
 /* kb_purge_stub.c — slice-2 kb purge wrapper stubs for test binaries that link
  * the real git_project.o but not kb_client.o (unit-test-git-project). Default
  * behavior is a TRANSPORT failure ({"status":"error"}), which exercises the
- * delete route's 503-abort path; setting AIMEE_TEST_KB_PURGE_MODE=ok makes the
- * purge succeed so the purged/finalize path is testable too. Also stubs the
- * server-local lexical index delete (db2_code_index_project_delete), which the
- * kb agent implements in db2/. */
+ * delete route's 503-abort path. AIMEE_TEST_KB_PURGE_MODE selects other
+ * shapes:
+ *   ok              — everything succeeds (purge ok:true, heartbeat
+ *                     refreshed:true, finalize/cancel cleared:true);
+ *   cancel-mismatch — the purge reaches the kb but a store fails (ok:false,
+ *                     fence written) and the cancel is a generation-mismatch
+ *                     no-op (cleared:false): the delete must take the
+ *                     terminal purge-committed-unfinished path and must NOT
+ *                     restore the holder count;
+ *   hb-lost         — the purge succeeds but the first heartbeat reports
+ *                     refreshed:false (a takeover displaced the operation):
+ *                     the walk must stop with the fence retained.
+ * AIMEE_TEST_CODE_INDEX_DELETE_FAIL=1 makes the (weak) local lexical-index
+ * delete fail, for the local-index-failed abort path. */
 #include "kb_client.h"
 
 #include <stdlib.h>
@@ -19,11 +29,13 @@ static char *dup_str(const char *s)
    return p;
 }
 
-static int stub_ok_mode(void)
+static const char *stub_mode(void)
 {
    const char *m = getenv("AIMEE_TEST_KB_PURGE_MODE");
-   return m && strcmp(m, "ok") == 0;
+   return m ? m : "";
 }
+
+#define STUB_TRANSPORT_ERR "{\"status\":\"error\",\"message\":\"stub\"}"
 
 char *kb_client_purge_project_json(const char *project, const char *generation,
                                    const char *purge_id, int takeover)
@@ -32,10 +44,14 @@ char *kb_client_purge_project_json(const char *project, const char *generation,
    (void)generation;
    (void)purge_id;
    (void)takeover;
-   if (stub_ok_mode())
+   const char *m = stub_mode();
+   if (strcmp(m, "ok") == 0 || strcmp(m, "hb-lost") == 0)
       return dup_str(
           "{\"status\":\"ok\",\"ok\":true,\"stores\":{\"stub\":0},\"fence_replaced\":false}");
-   return dup_str("{\"status\":\"error\",\"message\":\"stub\"}");
+   if (strcmp(m, "cancel-mismatch") == 0)
+      return dup_str("{\"status\":\"ok\",\"ok\":false,\"stores\":{\"stub\":{\"error\":\"boom\"}},"
+                     "\"fence_replaced\":false}");
+   return dup_str(STUB_TRANSPORT_ERR);
 }
 
 char *kb_client_purge_heartbeat_json(const char *project, const char *generation,
@@ -44,9 +60,12 @@ char *kb_client_purge_heartbeat_json(const char *project, const char *generation
    (void)project;
    (void)generation;
    (void)purge_id;
-   if (stub_ok_mode())
-      return dup_str("{\"status\":\"ok\"}");
-   return dup_str("{\"status\":\"error\",\"message\":\"stub\"}");
+   const char *m = stub_mode();
+   if (strcmp(m, "ok") == 0 || strcmp(m, "cancel-mismatch") == 0)
+      return dup_str("{\"status\":\"ok\",\"refreshed\":true}");
+   if (strcmp(m, "hb-lost") == 0)
+      return dup_str("{\"status\":\"ok\",\"refreshed\":false}");
+   return dup_str(STUB_TRANSPORT_ERR);
 }
 
 char *kb_client_purge_finalize_json(const char *project, const char *generation,
@@ -55,9 +74,12 @@ char *kb_client_purge_finalize_json(const char *project, const char *generation,
    (void)project;
    (void)generation;
    (void)purge_id;
-   if (stub_ok_mode())
+   const char *m = stub_mode();
+   if (strcmp(m, "ok") == 0 || strcmp(m, "hb-lost") == 0)
       return dup_str("{\"status\":\"ok\",\"cleared\":true}");
-   return dup_str("{\"status\":\"error\",\"message\":\"stub\"}");
+   if (strcmp(m, "cancel-mismatch") == 0)
+      return dup_str("{\"status\":\"ok\",\"cleared\":false}");
+   return dup_str(STUB_TRANSPORT_ERR);
 }
 
 char *kb_client_purge_cancel_json(const char *project, const char *generation, const char *purge_id)
@@ -65,9 +87,12 @@ char *kb_client_purge_cancel_json(const char *project, const char *generation, c
    (void)project;
    (void)generation;
    (void)purge_id;
-   if (stub_ok_mode())
+   const char *m = stub_mode();
+   if (strcmp(m, "ok") == 0 || strcmp(m, "hb-lost") == 0)
       return dup_str("{\"status\":\"ok\",\"cleared\":true}");
-   return dup_str("{\"status\":\"error\",\"message\":\"stub\"}");
+   if (strcmp(m, "cancel-mismatch") == 0)
+      return dup_str("{\"status\":\"ok\",\"cleared\":false}"); /* mismatch no-op */
+   return dup_str(STUB_TRANSPORT_ERR);
 }
 
 /* Weak so a future db2_test_shim.c definition (kb agent) wins without a
@@ -75,5 +100,6 @@ char *kb_client_purge_cancel_json(const char *project, const char *generation, c
 __attribute__((weak)) int db2_code_index_project_delete(const char *name)
 {
    (void)name;
-   return 0;
+   const char *fail = getenv("AIMEE_TEST_CODE_INDEX_DELETE_FAIL");
+   return (fail && strcmp(fail, "1") == 0) ? -1 : 0;
 }

--- a/src/tests/support/kb_purge_stub.c
+++ b/src/tests/support/kb_purge_stub.c
@@ -96,10 +96,12 @@ char *kb_client_purge_cancel_json(const char *project, const char *generation, c
 }
 
 /* Weak so a future db2_test_shim.c definition (kb agent) wins without a
- * duplicate-symbol link failure. */
+ * duplicate-symbol link failure. Success returns the DELETED ROW COUNT — a
+ * positive 1 here, pinning that the delete flow treats any >= 0 as success
+ * (the normal existing-project case deletes one projects row). */
 __attribute__((weak)) int db2_code_index_project_delete(const char *name)
 {
    (void)name;
    const char *fail = getenv("AIMEE_TEST_CODE_INDEX_DELETE_FAIL");
-   return (fail && strcmp(fail, "1") == 0) ? -1 : 0;
+   return (fail && strcmp(fail, "1") == 0) ? -1 : 1;
 }

--- a/src/tests/support/kb_txn_stub.c
+++ b/src/tests/support/kb_txn_stub.c
@@ -1,0 +1,34 @@
+/* kb_txn_stub.c — real (not fake) db2_kb_txn_* wrappers for test binaries that
+ * link kb objects needing transactions (e.g. kb_curator_index_code_unit.o)
+ * without pulling in db2/kb_payload.o and its dependency tree. Mirrors the
+ * kb_payload.c implementations exactly; under the sqlite shim BEGIN/COMMIT/
+ * ROLLBACK behave the same, so fenced-abort paths are exercised for real. */
+#include "db2/db_postgres.h"
+#include "db2/db2_internal.h"
+
+int db2_kb_txn_begin(void)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   char err[256] = "";
+   return aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) == 0 ? 0 : -1;
+}
+
+int db2_kb_txn_commit(void)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   char err[256] = "";
+   return aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) == 0 ? 0 : -1;
+}
+
+void db2_kb_txn_rollback(void)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return;
+   char err[256] = "";
+   (void)aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+}

--- a/src/tests/test_git_project.c
+++ b/src/tests/test_git_project.c
@@ -258,6 +258,67 @@ int main(void)
    assert(git_project_list("webuser:bob", names, 64) == 1);
    assert(strcmp(names[0], "shared") == 0);
 
+   /* cancel mismatch: the purge reaches the kb but a store fails (fence
+    * written) and the cancel is a generation-mismatch no-op (cleared:false) —
+    * terminal purge-committed-unfinished: the holder count must NOT be
+    * restored and nothing filesystem is removed. */
+   setenv("AIMEE_TEST_KB_PURGE_MODE", "cancel-mismatch", 1);
+   snprintf(check, sizeof(check), "%s/webusers/bob/shared", wsdir);
+   assert(git_project_delete("webuser:bob", "shared", 0, &dres, derr, sizeof(derr)) ==
+          GP_ERR_KB_UNAVAILABLE);
+   assert(strstr(derr, "unfinished") != NULL);
+   free(dres.kb_detail);
+   assert(stat(check, &st) == 0);                                      /* clone intact */
+   assert(ws_reg_lookup("shared", remo, sizeof(remo), &holders) == 0); /* decrement KEPT */
+   /* re-running converges: the resync step rebuilds the holder from disk and
+    * a now-successful purge completes the delete. */
+   setenv("AIMEE_TEST_KB_PURGE_MODE", "ok", 1);
+   assert(git_project_delete("webuser:bob", "shared", 0, &dres, derr, sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "purged") == 0);
+   free(dres.kb_detail);
+   assert(stat(check, &st) != 0);
+
+   /* local-index failure: aborts BEFORE any filesystem removal — the cancel
+    * confirms (cleared:true), the holder is re-registered, the clone stays. */
+   setenv("AIMEE_TEST_CODE_INDEX_DELETE_FAIL", "1", 1);
+   snprintf(check, sizeof(check), "%s/webusers/alice/srcrepo", wsdir);
+   assert(git_project_delete("webuser:alice", "srcrepo", 0, &dres, derr, sizeof(derr)) ==
+          GP_ERR_KB_UNAVAILABLE);
+   assert(strstr(derr, "code index") != NULL);
+   free(dres.kb_detail);
+   assert(stat(check, &st) == 0); /* clone intact */
+   assert(ws_reg_lookup("srcrepo", remo, sizeof(remo), &holders) == 1 &&
+          holders == 1); /* holder restored */
+   unsetenv("AIMEE_TEST_CODE_INDEX_DELETE_FAIL");
+   assert(git_project_delete("webuser:alice", "srcrepo", 0, &dres, derr, sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "purged") == 0);
+   free(dres.kb_detail);
+   assert(stat(check, &st) != 0);
+
+   /* fence ownership lost (heartbeat refreshed:false — a takeover displaced
+    * this delete): the walk stops before removing anything; the fence and the
+    * registry decrement stay (the purge committed); a re-run converges. */
+   setenv("AIMEE_TEST_KB_PURGE_MODE", "hb-lost", 1);
+   snprintf(check, sizeof(check), "%s/webusers/alice/Rakuen-Software/sanit", wsdir);
+   assert(git_project_delete("webuser:alice", "Rakuen-Software/sanit", 0, &dres, derr,
+                             sizeof(derr)) == GP_ERR_KB_UNAVAILABLE);
+   assert(strstr(derr, "fence") != NULL);
+   free(dres.kb_detail);
+   assert(stat(check, &st) == 0); /* nothing removed */
+   assert(ws_reg_lookup("Rakuen-Software/sanit", remo, sizeof(remo), &holders) == 0);
+   setenv("AIMEE_TEST_KB_PURGE_MODE", "ok", 1);
+   assert(git_project_delete("webuser:alice", "Rakuen-Software/sanit", 0, &dres, derr,
+                             sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "purged") == 0);
+   free(dres.kb_detail);
+   assert(stat(check, &st) != 0);
+   unsetenv("AIMEE_TEST_KB_PURGE_MODE");
+
+   /* final tally: alice keeps only acme/syncy; bob has nothing left. */
+   assert(git_project_list("webuser:alice", names, 64) == 1);
+   assert(strcmp(names[0], "acme/syncy") == 0);
+   assert(git_project_list("webuser:bob", names, 64) == 0);
+
    assert(run("rm -rf %s", home) == 0);
    printf("git_project: all tests passed\n");
    return 0;

--- a/src/tests/test_git_project.c
+++ b/src/tests/test_git_project.c
@@ -319,6 +319,43 @@ int main(void)
    assert(strcmp(names[0], "acme/syncy") == 0);
    assert(git_project_list("webuser:bob", names, 64) == 0);
 
+   /* --- rename-first tombstone: an interrupted walk is resumable --- */
+   setenv("AIMEE_TEST_KB_PURGE_MODE", "ok", 1);
+   /* simulate a crash right after the tombstone rename: the project sits at
+    * its ".deleting-<repo>" sibling and the crashed attempt's registry
+    * decrement persisted (resync re-derives from disk, where only the marker
+    * — invisible to it — remains). Re-running the delete must converge. */
+   char mpath[PATH_MAX];
+   snprintf(mpath, sizeof(mpath), "%s/webusers/alice/acme/.deleting-syncy", wsdir);
+   assert(run("mv %s/webusers/alice/acme/syncy %s", wsdir, mpath) == 0);
+   assert(git_project_delete("webuser:alice", "acme/syncy", 0, &dres, derr, sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "purged") == 0);
+   free(dres.kb_detail);
+   assert(stat(mpath, &st) != 0); /* marker tree fully gone */
+   snprintf(check, sizeof(check), "%s/webusers/alice/acme", wsdir);
+   assert(stat(check, &st) != 0); /* org pruned */
+   assert(ws_reg_lookup("acme/syncy", remo, sizeof(remo), &holders) == 0);
+
+   /* a flat marker with content (the ref itself no longer exists anywhere)
+    * also converges, and once converged the ref is a plain 404 again */
+   assert(run("mkdir -p %s/webusers/alice/.deleting-ghost/sub && "
+              "echo x > %s/webusers/alice/.deleting-ghost/sub/f",
+              wsdir, wsdir) == 0);
+   assert(git_project_delete("webuser:alice", "ghost", 0, &dres, derr, sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "purged") == 0);
+   free(dres.kb_detail);
+   snprintf(check, sizeof(check), "%s/webusers/alice/.deleting-ghost", wsdir);
+   assert(stat(check, &st) != 0);
+   assert(git_project_delete("webuser:alice", "ghost", 0, &dres, derr, sizeof(derr)) ==
+          GP_ERR_NOT_FOUND);
+   /* never-existing refs (flat and org) still 404 — no marker, no project */
+   assert(git_project_delete("webuser:alice", "neverwas", 0, &dres, derr, sizeof(derr)) ==
+          GP_ERR_NOT_FOUND);
+   assert(git_project_delete("webuser:alice", "no/pe", 0, &dres, derr, sizeof(derr)) ==
+          GP_ERR_NOT_FOUND);
+   unsetenv("AIMEE_TEST_KB_PURGE_MODE");
+   assert(git_project_list("webuser:alice", names, 64) == 0);
+
    assert(run("rm -rf %s", home) == 0);
    printf("git_project: all tests passed\n");
    return 0;

--- a/src/tests/test_git_project.c
+++ b/src/tests/test_git_project.c
@@ -3,6 +3,7 @@
  * the test, so it exercises the real git clone + scope resolution + name
  * derivation + refusal paths deterministically. */
 #include "git_project.h"
+#include "ws_registry.h"
 
 #include <assert.h>
 #include <limits.h>
@@ -173,6 +174,89 @@ int main(void)
    assert(git_project_list("uid:1000", names, 64) == -1);
    /* a webuser with no clones lists zero, not an error */
    assert(git_project_list("webuser:carol", names, 64) == 0);
+
+   /* --- delete (slice 2). The kb purge wrappers are the kb_purge_stub: a
+    * transport failure by default (exercising the 503-abort path), success
+    * with AIMEE_TEST_KB_PURGE_MODE=ok. --- */
+   git_project_delete_result_t dres;
+   char derr[512];
+
+   /* refusals: bad ref / non-webuser */
+   assert(git_project_delete("webuser:alice", "../x", 0, &dres, derr, sizeof(derr)) == -1);
+   assert(git_project_delete("webuser:alice", "a/b/c", 0, &dres, derr, sizeof(derr)) == -1);
+   assert(git_project_delete("uid:1000", "srcrepo", 0, &dres, derr, sizeof(derr)) == -1);
+   /* cross-principal / nonexistent: plain not-found (no existence disclosure) */
+   assert(git_project_delete("webuser:carol", "srcrepo", 0, &dres, derr, sizeof(derr)) ==
+          GP_ERR_NOT_FOUND);
+   assert(git_project_delete("webuser:bob", "srcrepo", 0, &dres, derr, sizeof(derr)) ==
+          GP_ERR_NOT_FOUND); /* alice's flat project is invisible to bob */
+
+   /* retained: alice deletes acme/orgproj while bob still holds it — the kb
+    * purge is never attempted (the stub would fail), alice's clone goes, bob's
+    * stays, the registry drops to one holder. */
+   char aorg[PATH_MAX], borg[PATH_MAX];
+   snprintf(aorg, sizeof(aorg), "%s/webusers/alice/acme/orgproj", wsdir);
+   snprintf(borg, sizeof(borg), "%s/webusers/bob/acme/orgproj", wsdir);
+   assert(git_project_delete("webuser:alice", "acme/orgproj", 0, &dres, derr, sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "retained") == 0);
+   assert(dres.purge_id[0] != '\0');
+   free(dres.kb_detail);
+   assert(stat(aorg, &st) != 0);                        /* alice's clone removed */
+   assert(stat(borg, &st) == 0 && S_ISDIR(st.st_mode)); /* bob's untouched */
+   char remo[1024];
+   int holders = 0;
+   assert(ws_reg_lookup("acme/orgproj", remo, sizeof(remo), &holders) == 1 && holders == 1);
+   /* alice's acme org dir was NOT pruned: acme/syncy still lives there */
+   snprintf(check, sizeof(check), "%s/webusers/alice/acme/syncy", wsdir);
+   assert(stat(check, &st) == 0);
+
+   /* last holder + kb unreachable, no force -> 503 abort: nothing destroyed,
+    * the registry decrement rolled back. */
+   assert(git_project_delete("webuser:bob", "acme/orgproj", 0, &dres, derr, sizeof(derr)) ==
+          GP_ERR_KB_UNAVAILABLE);
+   assert(dres.kb_detail && strstr(dres.kb_detail, "error") != NULL);
+   free(dres.kb_detail);
+   assert(stat(borg, &st) == 0); /* clone intact */
+   assert(ws_reg_lookup("acme/orgproj", remo, sizeof(remo), &holders) == 1 &&
+          holders == 1); /* count restored */
+
+   /* force: the filesystem proceeds despite the unreachable kb; the response
+    * carries the kb error detail under kb_status "forced". */
+   assert(git_project_delete("webuser:bob", "acme/orgproj", 1, &dres, derr, sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "forced") == 0);
+   assert(dres.kb_detail && strstr(dres.kb_detail, "stub") != NULL);
+   free(dres.kb_detail);
+   assert(stat(borg, &st) != 0);                                             /* clone removed */
+   assert(ws_reg_lookup("acme/orgproj", remo, sizeof(remo), &holders) == 0); /* entry gone */
+
+   /* purged: sole holder + reachable kb (stub ok mode) -> full purge path
+    * (fence write, heartbeat, finalize) and the per-store detail. */
+   setenv("AIMEE_TEST_KB_PURGE_MODE", "ok", 1);
+   snprintf(check, sizeof(check), "%s/webusers/alice/myproj", wsdir);
+   assert(stat(check, &st) == 0);
+   assert(git_project_delete("webuser:alice", "myproj", 0, &dres, derr, sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "purged") == 0);
+   assert(dres.kb_detail && strstr(dres.kb_detail, "stub") != NULL); /* per-store map */
+   assert(dres.generation[0] != '\0');
+   free(dres.kb_detail);
+   assert(stat(check, &st) != 0);
+   unsetenv("AIMEE_TEST_KB_PURGE_MODE");
+
+   /* org prune: bob's last project under acme (syncy, retained — alice still
+    * holds it) removes the clone AND the now-empty org dir. */
+   assert(git_project_delete("webuser:bob", "acme/syncy", 0, &dres, derr, sizeof(derr)) == 0);
+   assert(strcmp(dres.kb_status, "retained") == 0);
+   free(dres.kb_detail);
+   snprintf(check, sizeof(check), "%s/webusers/bob/acme", wsdir);
+   assert(stat(check, &st) != 0); /* org dir pruned */
+   snprintf(check, sizeof(check), "%s/webusers/alice/acme/syncy", wsdir);
+   assert(stat(check, &st) == 0); /* alice's holder untouched */
+
+   /* the lister agrees: alice lost acme/orgproj + myproj, bob lost both acme
+    * projects (shared remains). */
+   assert(git_project_list("webuser:alice", names, 64) == 3);
+   assert(git_project_list("webuser:bob", names, 64) == 1);
+   assert(strcmp(names[0], "shared") == 0);
 
    assert(run("rm -rf %s", home) == 0);
    printf("git_project: all tests passed\n");

--- a/src/tests/test_kb.c
+++ b/src/tests/test_kb.c
@@ -870,10 +870,11 @@ static void test_purge_fence_blocks_ingest(void)
     * arise from a torn write — the publish transaction writes ts first). */
    assert(db2_kb_runtime_state_delete("project_purging_ts:fence_proj") == 0);
    assert(db2_kb_purge_fence_active("fence_proj") == 1);
-   /* Heartbeat with matching ids but no ts row is a single-statement no-op
-    * (nothing to refresh); restore the ts row via a full re-publish. */
-   assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-1", "pid-1") == 0);
-   assert(db2_kb_purge_fence_write("fence_proj", "gen-1", "pid-1") == 0);
+   /* A displaced owner still no-ops against the identity-only fence... */
+   assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-0", "pid-0") == 0);
+   /* ...while the matching owner's heartbeat repairs the missing ts row. */
+   assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-1", "pid-1") == 1);
+   assert(db2_kb_purge_fence_active("fence_proj") == 1);
 
    /* A stale heartbeat makes the fence absent for writers (TTL expiry), while
     * the fence row itself remains readable (live=0). */

--- a/src/tests/test_kb.c
+++ b/src/tests/test_kb.c
@@ -842,6 +842,39 @@ static void test_purge_fence_blocks_ingest(void)
    assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-0", "pid-1") == 0);
    assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-1", "pid-1") == 1);
 
+   /* Atomic acquire: a LIVE foreign fence is refused without takeover (the
+    * current owner's ids are returned), displaced with takeover:true. */
+   {
+      char cg[64] = "", cp[64] = "";
+      int replaced = -1;
+      assert(db2_kb_purge_fence_acquire("fence_proj", "gen-2", "pid-2", 0, cg, sizeof(cg), cp,
+                                        sizeof(cp), &replaced) == 0);
+      assert(strcmp(cg, "gen-1") == 0);
+      assert(strcmp(cp, "pid-1") == 0);
+      assert(replaced == 0);
+      /* Same-owner re-acquire is idempotent (no refusal, not a replace). */
+      assert(db2_kb_purge_fence_acquire("fence_proj", "gen-1", "pid-1", 0, cg, sizeof(cg), cp,
+                                        sizeof(cp), &replaced) == 1);
+      assert(replaced == 0);
+      /* Takeover displaces the live owner and reports the displaced ids. */
+      assert(db2_kb_purge_fence_acquire("fence_proj", "gen-2", "pid-2", 1, cg, sizeof(cg), cp,
+                                        sizeof(cp), &replaced) == 1);
+      assert(replaced == 1);
+      assert(strcmp(cg, "gen-1") == 0);
+      assert(strcmp(cp, "pid-1") == 0);
+      /* Restore the gen-1 owner for the remaining assertions. */
+      assert(db2_kb_purge_fence_write("fence_proj", "gen-1", "pid-1") == 0);
+   }
+
+   /* Fail closed: an identity row WITHOUT a heartbeat row is ACTIVE (cannot
+    * arise from a torn write — the publish transaction writes ts first). */
+   assert(db2_kb_runtime_state_delete("project_purging_ts:fence_proj") == 0);
+   assert(db2_kb_purge_fence_active("fence_proj") == 1);
+   /* Heartbeat with matching ids but no ts row is a single-statement no-op
+    * (nothing to refresh); restore the ts row via a full re-publish. */
+   assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-1", "pid-1") == 0);
+   assert(db2_kb_purge_fence_write("fence_proj", "gen-1", "pid-1") == 0);
+
    /* A stale heartbeat makes the fence absent for writers (TTL expiry), while
     * the fence row itself remains readable (live=0). */
    assert(db2_kb_runtime_state_set("project_purging_ts:fence_proj", "2000-01-01 00:00:00") == 0);

--- a/src/tests/test_kb.c
+++ b/src/tests/test_kb.c
@@ -804,6 +804,68 @@ static void test_clear(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Tests: purge generation fence (webchat-project-lifecycle slice 2)   */
+/* ------------------------------------------------------------------ */
+
+static void test_purge_fence_blocks_ingest(void)
+{
+   char tmpdir[] = "/tmp/aimee_kb_test_fence_XXXXXX";
+   char *d = mkdtemp(tmpdir);
+   assert(d != NULL);
+   char fpath[512];
+   snprintf(fpath, sizeof(fpath), "%s/notes.md", tmpdir);
+   write_file(fpath, "# Notes\n\nFenced project notes.\n");
+
+   open_test_db();
+
+   /* No fence yet. */
+   assert(db2_kb_purge_fence_active("fence_proj") == 0);
+   assert(db2_kb_purge_fence_read("fence_proj", NULL, 0, NULL, 0, NULL) == 0);
+
+   /* Write, then read back generation/purge_id + liveness. */
+   assert(db2_kb_purge_fence_write("fence_proj", "gen-1", "pid-1") == 0);
+   assert(db2_kb_purge_fence_active("fence_proj") == 1);
+   char gen[64] = "", pid[64] = "";
+   int live = 0;
+   assert(db2_kb_purge_fence_read("fence_proj", gen, sizeof(gen), pid, sizeof(pid), &live) == 1);
+   assert(strcmp(gen, "gen-1") == 0);
+   assert(strcmp(pid, "pid-1") == 0);
+   assert(live == 1);
+
+   /* Writers refuse to start an ingest for a fenced project; another key is
+    * unaffected. */
+   kb_stats_t stats;
+   assert(kb_build(tmpdir, "fence_proj", NULL, 0, &stats) == -1);
+   assert(kb_build(tmpdir, "other_proj", NULL, 0, &stats) == 0);
+
+   /* Heartbeat: displaced ids no-op, matching ids refresh. */
+   assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-0", "pid-1") == 0);
+   assert(db2_kb_purge_fence_heartbeat("fence_proj", "gen-1", "pid-1") == 1);
+
+   /* A stale heartbeat makes the fence absent for writers (TTL expiry), while
+    * the fence row itself remains readable (live=0). */
+   assert(db2_kb_runtime_state_set("project_purging_ts:fence_proj", "2000-01-01 00:00:00") == 0);
+   assert(db2_kb_purge_fence_active("fence_proj") == 0);
+   live = 1;
+   assert(db2_kb_purge_fence_read("fence_proj", gen, sizeof(gen), pid, sizeof(pid), &live) == 1);
+   assert(live == 0);
+
+   /* Clear: displaced ids no-op, matching ids drop both rows. */
+   assert(db2_kb_purge_fence_clear("fence_proj", "gen-1", "pid-0") == 0);
+   assert(db2_kb_purge_fence_read("fence_proj", NULL, 0, NULL, 0, NULL) == 1);
+   assert(db2_kb_purge_fence_clear("fence_proj", "gen-1", "pid-1") == 1);
+   assert(db2_kb_purge_fence_read("fence_proj", NULL, 0, NULL, 0, NULL) == 0);
+
+   /* Unfenced: the ingest goes through again. */
+   assert(kb_build(tmpdir, "fence_proj", NULL, 0, &stats) == 0);
+
+   close_test_db();
+   unlink(fpath);
+   platform_test_rmrf(tmpdir);
+   printf("  PASS: purge fence blocks ingest and follows the match rules\n");
+}
+
+/* ------------------------------------------------------------------ */
 /* Tests: multiple projects are isolated                               */
 /* ------------------------------------------------------------------ */
 
@@ -950,6 +1012,9 @@ int main(void)
 
    /* Clear test */
    test_clear();
+
+   /* Purge generation fence (slice 2) */
+   test_purge_fence_blocks_ingest();
 
    /* Isolation test */
    test_project_isolation();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1187,6 +1187,109 @@ int db2_kb_file_index_delete_project(const char *project)
    return 0;
 }
 
+/* ── slice-2 purge-route stubs: fence store + fan-out delete primitives ── */
+
+static int g_fence_present = 0;
+static int g_fence_live = 0;
+static int g_fence_write_rc = 0;
+static char g_fence_gen[128] = "";
+static char g_fence_pid[128] = "";
+static char g_fence_project[256] = "";
+static int g_fence_heartbeats = 0;
+
+int db2_kb_purge_fence_write(const char *project, const char *generation, const char *purge_id)
+{
+   if (g_fence_write_rc)
+      return -1;
+   snprintf(g_fence_project, sizeof(g_fence_project), "%s", project ? project : "");
+   snprintf(g_fence_gen, sizeof(g_fence_gen), "%s", generation ? generation : "");
+   snprintf(g_fence_pid, sizeof(g_fence_pid), "%s", purge_id ? purge_id : "");
+   g_fence_present = 1;
+   g_fence_live = 1;
+   return 0;
+}
+
+int db2_kb_purge_fence_read(const char *project, char *gen_out, size_t gen_cap, char *pid_out,
+                            size_t pid_cap, int *live_out)
+{
+   (void)project;
+   if (live_out)
+      *live_out = 0;
+   if (!g_fence_present)
+      return 0;
+   if (gen_out && gen_cap)
+      snprintf(gen_out, gen_cap, "%s", g_fence_gen);
+   if (pid_out && pid_cap)
+      snprintf(pid_out, pid_cap, "%s", g_fence_pid);
+   if (live_out)
+      *live_out = g_fence_live;
+   return 1;
+}
+
+int db2_kb_purge_fence_heartbeat(const char *project, const char *generation, const char *purge_id)
+{
+   (void)project;
+   if (!g_fence_present || !generation || !purge_id || strcmp(g_fence_gen, generation) != 0 ||
+       strcmp(g_fence_pid, purge_id) != 0)
+      return 0;
+   g_fence_heartbeats++;
+   return 1;
+}
+
+int db2_kb_purge_fence_clear(const char *project, const char *generation, const char *purge_id)
+{
+   (void)project;
+   if (!g_fence_present || !generation || !purge_id || strcmp(g_fence_gen, generation) != 0 ||
+       strcmp(g_fence_pid, purge_id) != 0)
+      return 0;
+   g_fence_present = 0;
+   g_fence_gen[0] = g_fence_pid[0] = '\0';
+   return 1;
+}
+
+static int g_purge_code_embeddings_rc = 7;
+static int g_purge_curator_vectors_rc = 3;
+static int g_purge_canonical_rc = 1;
+static int g_purge_code_unit_jobs_rc = 4;
+static int g_purge_pdf_rc = 0;
+static int g_purge_minhash_rc = 0;
+
+int pgvec_code_delete_project(const char *project)
+{
+   (void)project;
+   return g_purge_code_embeddings_rc;
+}
+
+int pgvec_curator_code_unit_delete_project(const char *project)
+{
+   (void)project;
+   return g_purge_curator_vectors_rc;
+}
+
+int db2_code_index_project_delete(const char *name)
+{
+   (void)name;
+   return g_purge_canonical_rc;
+}
+
+int kb_curator_code_unit_jobs_delete_project(const char *project)
+{
+   (void)project;
+   return g_purge_code_unit_jobs_rc;
+}
+
+int pgvec_kbpdf_delete_project(const char *project)
+{
+   (void)project;
+   return g_purge_pdf_rc;
+}
+
+int db2_sketch_minhash_signature_delete_project(const char *project)
+{
+   (void)project;
+   return g_purge_minhash_rc;
+}
+
 void kb_worker_notify(kb_service_ctx_t *ctx)
 {
    (void)ctx;
@@ -3669,6 +3772,208 @@ static void test_maintenance_clear_error(void)
    g_clear_deleted = 12;
 }
 
+/* ── slice-2 purge routes: fence lifecycle + fan-out map shape ─────────── */
+
+static void purge_fence_reset(void)
+{
+   g_fence_present = 0;
+   g_fence_live = 0;
+   g_fence_write_rc = 0;
+   g_fence_gen[0] = g_fence_pid[0] = g_fence_project[0] = '\0';
+   g_fence_heartbeats = 0;
+}
+
+static void test_purge_project_writes_fence(void)
+{
+   purge_fence_reset();
+   g_clear_deleted = 12;
+   char buf[2048];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-project", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   /* Fence written for the project and NOT cleared by the purge route. */
+   assert(g_fence_present == 1);
+   assert(strcmp(g_fence_project, "proj-alpha") == 0);
+   assert(strcmp(g_fence_gen, "g1") == 0);
+   assert(strcmp(g_fence_pid, "p1") == 0);
+   assert(strstr(buf, "\"status\":\"ok\"") != NULL);
+   assert(strstr(buf, "\"ok\":true") != NULL);
+   assert(strstr(buf, "\"fence_replaced\":false") != NULL);
+   /* Per-store map, in fan-out order, counts from the stubs (0 for the
+    * no-count primitives pdf_vectors/minhash/vectors). */
+   assert(strstr(buf, "\"stores\":{") != NULL);
+   assert(strstr(buf, "\"chunks\":12") != NULL);
+   assert(strstr(buf, "\"file_index\":0") != NULL);
+   assert(strstr(buf, "\"vectors\":0") != NULL);
+   assert(strstr(buf, "\"code_embeddings\":7") != NULL);
+   assert(strstr(buf, "\"curator_code_unit_vectors\":3") != NULL);
+   assert(strstr(buf, "\"canonical_index\":1") != NULL);
+   assert(strstr(buf, "\"code_unit_jobs\":4") != NULL);
+   assert(strstr(buf, "\"pdf_vectors\":0") != NULL);
+   assert(strstr(buf, "\"minhash\":0") != NULL);
+   assert(strcmp(g_clear_project, "proj-alpha") == 0);
+}
+
+static void test_purge_project_live_fence_409(void)
+{
+   purge_fence_reset();
+   assert(db2_kb_purge_fence_write("proj-alpha", "g0", "p0") == 0);
+   g_fence_live = 1;
+   char buf[1024];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-project", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 409);
+   assert(strstr(buf, "purge fence held") != NULL);
+   assert(strstr(buf, "\"generation\":\"g0\"") != NULL);
+   assert(strstr(buf, "\"purge_id\":\"p0\"") != NULL);
+   /* Refused: the original owner's fence is untouched. */
+   assert(strcmp(g_fence_gen, "g0") == 0);
+   assert(strcmp(g_fence_pid, "p0") == 0);
+}
+
+static void test_purge_project_takeover_displaces(void)
+{
+   purge_fence_reset();
+   assert(db2_kb_purge_fence_write("proj-alpha", "g0", "p0") == 0);
+   g_fence_live = 1;
+   char buf[2048];
+   int s = kb_http_route_ex("POST", "/v1/maintenance/purge-project", NULL, NULL, NULL,
+                            "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":"
+                            "\"p1\",\"takeover\":true}",
+                            -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"fence_replaced\":true") != NULL);
+   assert(strstr(buf, "\"displaced\":{\"generation\":\"g0\",\"purge_id\":\"p0\"}") != NULL);
+   /* New owner holds the fence now. */
+   assert(strcmp(g_fence_gen, "g1") == 0);
+   assert(strcmp(g_fence_pid, "p1") == 0);
+}
+
+static void test_purge_project_stale_fence_replaced(void)
+{
+   purge_fence_reset();
+   assert(db2_kb_purge_fence_write("proj-alpha", "g0", "p0") == 0);
+   g_fence_live = 0; /* stale heartbeat: no takeover needed */
+   char buf[2048];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-project", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"fence_replaced\":true") != NULL);
+   assert(strcmp(g_fence_gen, "g1") == 0);
+}
+
+static void test_purge_project_store_error_continues(void)
+{
+   purge_fence_reset();
+   g_purge_canonical_rc = -1; /* one store fails: fan-out continues, ok:false */
+   char buf[2048];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-project", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"ok\":false") != NULL);
+   assert(strstr(buf, "\"canonical_index\":{\"error\":\"delete failed\"}") != NULL);
+   /* Stores after the failing one still ran and report counts. */
+   assert(strstr(buf, "\"code_unit_jobs\":4") != NULL);
+   assert(strstr(buf, "\"minhash\":0") != NULL);
+   g_purge_canonical_rc = 1;
+}
+
+static void test_purge_project_bad_request(void)
+{
+   purge_fence_reset();
+   char buf[512];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-project", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"purge_id\":\"p1\"}", -1, buf, sizeof(buf));
+   assert(s == 400);
+   assert(strstr(buf, "generation") != NULL);
+   /* Space-carrying tokens would corrupt the space-separated fence value. */
+   s = kb_http_route_ex("POST", "/v1/maintenance/purge-project", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g 1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 400);
+   assert(g_fence_present == 0);
+}
+
+static void test_purge_heartbeat_match_and_mismatch(void)
+{
+   purge_fence_reset();
+   assert(db2_kb_purge_fence_write("proj-alpha", "g1", "p1") == 0);
+   char buf[1024];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-heartbeat", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"refreshed\":true") != NULL);
+   assert(g_fence_heartbeats == 1);
+   /* Displaced owner: mismatch no-ops and echoes the current fence. */
+   s = kb_http_route_ex("POST", "/v1/maintenance/purge-heartbeat", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g0\",\"purge_id\":\"p0\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"refreshed\":false") != NULL);
+   assert(strstr(buf, "\"fence\":\"g1 p1\"") != NULL);
+   assert(g_fence_heartbeats == 1);
+}
+
+static void test_purge_finalize_mismatch_noop(void)
+{
+   purge_fence_reset();
+   assert(db2_kb_purge_fence_write("proj-alpha", "g1", "p1") == 0);
+   char buf[1024];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-finalize", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g0\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"cleared\":false") != NULL);
+   assert(strstr(buf, "\"fence\":\"g1 p1\"") != NULL);
+   assert(g_fence_present == 1); /* displaced owner cannot clear the fence */
+}
+
+static void test_purge_finalize_match_clears(void)
+{
+   purge_fence_reset();
+   assert(db2_kb_purge_fence_write("proj-alpha", "g1", "p1") == 0);
+   char buf[1024];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-finalize", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"cleared\":true") != NULL);
+   assert(g_fence_present == 0);
+}
+
+static void test_purge_cancel_match_clears(void)
+{
+   purge_fence_reset();
+   assert(db2_kb_purge_fence_write("proj-alpha", "g1", "p1") == 0);
+   char buf[1024];
+   int s =
+       kb_http_route_ex("POST", "/v1/maintenance/purge-cancel", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"cleared\":true") != NULL);
+   assert(g_fence_present == 0);
+   /* Idempotent: a second cancel is a mismatch/absent no-op. */
+   s = kb_http_route_ex("POST", "/v1/maintenance/purge-cancel", NULL, NULL, NULL,
+                        "{\"project\":\"proj-alpha\",\"generation\":\"g1\",\"purge_id\":\"p1\"}",
+                        -1, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"cleared\":false") != NULL);
+}
+
 static void test_job_not_found(void)
 {
    char buf[256];
@@ -4350,6 +4655,16 @@ int main(void)
    test_maintenance_reconcile_ok();
    test_maintenance_clear_ok();
    test_maintenance_clear_error();
+   test_purge_project_writes_fence();
+   test_purge_project_live_fence_409();
+   test_purge_project_takeover_displaces();
+   test_purge_project_stale_fence_replaced();
+   test_purge_project_store_error_continues();
+   test_purge_project_bad_request();
+   test_purge_heartbeat_match_and_mismatch();
+   test_purge_finalize_mismatch_noop();
+   test_purge_finalize_match_clears();
+   test_purge_cancel_match_clears();
    test_job_not_found();
    test_job_status_ok();
    test_job_status_error();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1209,6 +1209,30 @@ int db2_kb_purge_fence_write(const char *project, const char *generation, const 
    return 0;
 }
 
+/* Mirrors the real acquire's atomic read-decide-write against the in-memory
+ * fence: refuse a live foreign fence without takeover, else publish. */
+int db2_kb_purge_fence_acquire(const char *project, const char *generation, const char *purge_id,
+                               int takeover, char *cur_gen, size_t gen_cap, char *cur_pid,
+                               size_t pid_cap, int *replaced_out)
+{
+   if (cur_gen && gen_cap)
+      snprintf(cur_gen, gen_cap, "%s", g_fence_gen);
+   if (cur_pid && pid_cap)
+      snprintf(cur_pid, pid_cap, "%s", g_fence_pid);
+   if (replaced_out)
+      *replaced_out = 0;
+   if (g_fence_write_rc)
+      return -1;
+   int same = g_fence_present && strcmp(g_fence_gen, generation) == 0 &&
+              strcmp(g_fence_pid, purge_id) == 0;
+   if (g_fence_present && g_fence_live && !same && !takeover)
+      return 0;
+   if (replaced_out)
+      *replaced_out = (g_fence_present && !same);
+   (void)db2_kb_purge_fence_write(project, generation, purge_id);
+   return 1;
+}
+
 int db2_kb_purge_fence_read(const char *project, char *gen_out, size_t gen_cap, char *pid_out,
                             size_t pid_cap, int *live_out)
 {

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -1146,6 +1146,7 @@ int main(void)
           {"POST", "/v1/workspace/clone", "{}"},
           {"POST", "/v1/workspace/git", "{}"},
           {"GET", "/v1/workspace/projects", NULL},
+          {"POST", "/v1/workspace/projects/delete", "{}"},
           {"POST", "/v1/workspace/session-dir", "{}"},
           {"GET", "/v1/git/credentials", NULL},
           {"POST", "/v1/git/sshkey", "{}"},

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -490,6 +490,85 @@ func (s *server) handleGitClone(w http.ResponseWriter, r *http.Request) {
 	s.gitRelay(w, st, data, err)
 }
 
+// gitDeleteRelay passes through the project-delete outcome ({ok, ref,
+// kb_status, purge_id, kb}). Typed passthrough, never the raw upstream body;
+// `kb` is the server's per-store purge detail (already credential-free).
+func (s *server) gitDeleteRelay(w http.ResponseWriter, st int, data []byte, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "git: aimee-server unavailable")
+		return
+	}
+	if st != http.StatusOK {
+		writeJSONError(w, st, vaultSafeErrorMessage(data))
+		return
+	}
+	var up struct {
+		OK       bool            `json:"ok"`
+		Ref      string          `json:"ref"`
+		KBStatus string          `json:"kb_status"`
+		PurgeID  string          `json:"purge_id"`
+		KB       json.RawMessage `json:"kb"`
+	}
+	_ = json.Unmarshal(data, &up)
+	m := map[string]any{"ok": up.OK, "ref": up.Ref, "kb_status": up.KBStatus, "purge_id": up.PurgeID}
+	if len(up.KB) > 0 {
+		m["kb"] = up.KB
+	}
+	out, _ := json.Marshal(m)
+	w.Write(out)
+}
+
+// validProjectRef minimally validates a project ref before it is forwarded:
+// non-empty, at most 129 bytes, at most one '/', and no empty/"."/".."
+// segments. The server re-validates with the full component alphabet.
+func validProjectRef(ref string) bool {
+	if ref == "" || len(ref) > 129 || strings.Count(ref, "/") > 1 {
+		return false
+	}
+	for _, seg := range strings.Split(ref, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+// POST /api/git/projects/delete {ref, force?} — delete a cloned project (and,
+// for its last holder, its indexed knowledge). Relay contract (webchat project
+// lifecycle, slice 2): the accepted body fields are EXACTLY ref and force —
+// unknown fields are rejected so nothing can be smuggled to the server route —
+// and the principal is bound exclusively from the authenticated session (the
+// v1RequestWebuser channel), never from inbound headers or the body.
+func (s *server) handleGitProjectDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req struct {
+		Ref   string `json:"ref"`
+		Force bool   `json:"force"`
+	}
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "body accepts exactly {ref, force}")
+		return
+	}
+	if !validProjectRef(req.Ref) {
+		writeJSONError(w, http.StatusBadRequest, "invalid project ref")
+		return
+	}
+	// The purge + filesystem walk of a large clone outlives a normal socket
+	// call; give it the clone deadline.
+	ctx, cancel := context.WithTimeout(r.Context(), cloneTimeout)
+	defer cancel()
+	body, _ := json.Marshal(map[string]any{"ref": req.Ref, "force": req.Force})
+	st, data, err := s.v1RequestWebuserT(ctx, currentUser(r), http.MethodPost,
+		"/v1/workspace/projects/delete", body, cloneTimeout)
+	s.gitDeleteRelay(w, st, data, err)
+}
+
 // POST /api/git/op {project, op, message?, branch?, n?} — run a git operation.
 func (s *server) handleGitOp(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -210,6 +210,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	// Git projects (webchat-git WP-F): clone + per-project ops + listing,
 	// forwarded to /v1/workspace/* with the user's webuser: assertion.
 	mux.HandleFunc("/api/git/projects", s.requireAuth(s.handleGitProjects))
+	mux.HandleFunc("/api/git/projects/delete", s.requireAuth(s.handleGitProjectDelete))
 	mux.HandleFunc("/api/git/clone", s.requireAuth(s.handleGitClone))
 	mux.HandleFunc("/api/git/org-repos", s.requireAuth(s.handleGitOrgRepos))
 	mux.HandleFunc("/api/git/clone-org", s.requireAuth(s.handleGitCloneOrg))


### PR DESCRIPTION
Slice 2 of the webchat project-lifecycle feature (proposal: `docs/proposals/pending/webchat-project-lifecycle.md`). Targets the feature branch.

## kb side
- `POST /v1/maintenance/purge-project` — writes the generation fence, 409s a live foreign fence unless `takeover:true` (displaced ids returned), fans out the full writer→store→delete matrix in order (9 stores; three new primitives: canonical-index cascade delete, `kb_code_unit_jobs` per-project delete, `curator_code_unit_vectors` via the artifacts `scope_id` join), continues past per-store failures, per-store `{count|{error}}` map, never clears the fence itself.
- `purge-heartbeat` / `purge-finalize` / `purge-cancel` with match-both-ids no-op semantics; TTL configurable (`kb.purge_fence_ttl_s`, 900s default), expired fences read as absent.
- Fence checks at every writer's commit point: canonical scan per-file txn, ingest batch flush + `kb_build` entry, curator code-unit indexer (job re-check + vector upsert + artifact state now one transaction), async pdf embed drain.

## server side
- `POST /v1/workspace/projects/delete {ref, force?}` under the first-component lifecycle lock: audit-intent-before-resolution (`webuser_project_delete_audit_v1`, shared `purge_id` across phases), caller-tree-only resolve (404), resync-then-unregister holder decision (holders remain → kb + local index retained), last-holder fenced purge with cancel-confirmed decrement rollback, `force` with full per-store detail, heartbeat before the fs walk, fd-pinned removal, org prune, finalize.
- webchat relay `POST /api/git/projects/delete` — body exactly `{ref, force}`, unknown fields 400, session-bound principal.
- OpenAPI for all five new routes.

## Testing
- `unit-test-git-project`: delete paths — cross-principal 404, two-holder retained, no-force 503 abort (clone intact, holder count restored), force removal, purged with per-store detail, org prune — pass.
- `unit-test-kb-http-routes`: 10 fence-route tests (409/takeover/displaced, stale replace, per-store map with failing store, finalize/cancel match rules) — pass.
- `unit-test-kb`: fence blocks ingest under the sqlite shim, TTL staleness via backdated heartbeat, post-clear recovery — pass.
- Full unit sweep (~200 binaries) run by the implementation agents: 0 failures; all touched objects `-Wall -Wextra -Werror` clean.

Known accepted gap (documented in-code): artifacts rows are retained on purge (mirrors ingest force-clear); a post-finalize orphaned `proposed` artifact is a pre-existing systemic gap shared with narrative/claim artifacts.