### PR TITLE
feat(wfe): re-review panels judge the prior blockers, not the world

### DIFF
--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -91,22 +91,40 @@ static char *build_prompt(const char *persona, const wfe_review_packet_t *pkt)
    const char *diff = (pkt->diff && pkt->diff[0])
                           ? pkt->diff
                           : "(no code diff — review the plan/proposal artifact against the ask)";
-   size_t cap = 2048 + strlen(focus) + strlen(proposal) + strlen(diff);
+   const char *prior = (pkt->prior_blockers && pkt->prior_blockers[0]) ? pkt->prior_blockers : "";
+   size_t cap = 3072 + strlen(focus) + strlen(proposal) + strlen(diff) + strlen(prior);
    char *buf = malloc(cap);
    if (!buf)
       return NULL;
+   /* Re-review scoping: once a round has produced concrete blockers, later
+    * rounds judge whether THOSE were addressed. Panel seats rotate between
+    * rounds, and an unscoped fresh reviewer reliably finds novel objections —
+    * observed live as a flat 100% request_changes rate across dozens of rounds
+    * (the author kept fixing round N's list while round N+1 raised a new one).
+    * New HIGH-SEVERITY findings still block; preferences and nits do not. */
+   char rereview[4600];
+   if (prior[0])
+      snprintf(rereview, sizeof rereview,
+               "\n\nTHIS IS A RE-REVIEW. The previous round's blockers were:\n%.4000s\n\n"
+               "Verdict approve if these blockers are now adequately addressed and you find no "
+               "NEW high-severity defect. Do NOT request changes for stylistic preferences, "
+               "scope you would merely have done differently, or issues below high severity — "
+               "raise those as comment instead.",
+               prior);
+   else
+      rereview[0] = '\0';
    snprintf(buf, cap,
             "You are the %s lens on a review roundtable. Review the CHANGE UNDER REVIEW below "
             "AGAINST what was asked. Do NOT edit files, and do NOT sweep or re-read the repo to "
             "reconstruct context: trust aimee's index/graph (find_symbol, search_memory) as the "
             "authoritative source for the current codebase, and open a file only to confirm what "
             "the index cannot resolve.\n\nFOCUS: %s\n\nORIGINAL PROPOSAL/REQUEST:\n%.4000s\n\n"
-            "CHANGE UNDER REVIEW (diff vs the base repo):\n%s\n\n"
+            "CHANGE UNDER REVIEW (diff vs the base repo):\n%s%s\n\n"
             "End your reply with EXACTLY one JSON line and nothing after it: "
             "{\"verdict\":\"approve\"} if it satisfies the ask with no high-severity blocker, "
             "{\"verdict\":\"request_changes\",\"high_sev_blockers\":<N>} if there is a real "
             "blocker, or {\"verdict\":\"comment\"} if you only have non-blocking remarks.",
-            persona, focus, proposal, diff);
+            persona, focus, proposal, diff, rereview);
    return buf;
 }
 

--- a/src/workflow/wfe_roundtable.c
+++ b/src/workflow/wfe_roundtable.c
@@ -145,6 +145,12 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
       (void)safe_exec_capture(dargv, &diff, WFE_REVIEW_DIFF_MAX);
    }
 
+   /* Re-review context: blockers persisted by this work item's previous
+    * REQUEST_CHANGES round (cleared on approve). Present => the panel judges
+    * whether THEY were addressed rather than re-reviewing from scratch. */
+   char prior_blockers[4096];
+   wfe_feedback_read(wi, prior_blockers, sizeof prior_blockers);
+
    wfe_review_packet_t pkt = {
        .artifact_hash = artifact_hash,
        .proposal = proposal ? proposal : "",
@@ -153,6 +159,7 @@ static wfe_step_result_t exec_roundtable(wfe_ctx *ctx, const wfe_node_t *node)
        .workdir = workdir,
        .diff = diff ? diff : "",
        .roundtable = (rt_j && cJSON_IsString(rt_j) && rt_j->valuestring) ? rt_j->valuestring : "",
+       .prior_blockers = prior_blockers,
    };
 
    wfe_verdict_t verdicts[WFE_PANEL_MAX];

--- a/src/workflow/wfe_roundtable.h
+++ b/src/workflow/wfe_roundtable.h
@@ -23,9 +23,15 @@ typedef struct
    const char *diff;    /* the change under review vs the base repo, pushed to the panel so it
                          * reads the delta directly (trusting the index for context) instead of
                          * re-running git; "" at a plan gate (no code change yet) */
-   const char *roundtable; /* the roundtable preset this gate convenes (from the node's
-                            * params.roundtable), for its persona->model seat bindings; "" (or
-                            * NULL) means the configured default (roundtable.default) */
+   const char *roundtable;     /* the roundtable preset this gate convenes (from the node's
+                                * params.roundtable), for its persona->model seat bindings; "" (or
+                                * NULL) means the configured default (roundtable.default) */
+   const char *prior_blockers; /* the previous round's persisted blockers when this is a
+                                * RE-REVIEW after REQUEST_CHANGES; "" on a first review. A
+                                * re-review panel judges whether these were addressed (plus any
+                                * NEW high-severity finding) instead of re-litigating from
+                                * scratch — rotating fresh-eyed seats otherwise generate novel
+                                * objections every round and the gate never converges. */
 } wfe_review_packet_t;
 
 /* Panel-provider return sentinels (negative), distinct from a verdict count (>=0). */


### PR DESCRIPTION
Panel seats rotate between rounds, and an unscoped fresh reviewer reliably finds novel objections. Observed live on .254 after the feedback fix (#1337) deployed: a flat 100% `request_changes` rate — ~20 verdicts, zero approves — because the author kept fixing round N's blocker list while round N+1's new reviewers raised a different one. Even a one-line-change packet could not pass. With the gate's any-blocker-loops rule, unscoped seat rotation makes convergence statistically impossible.

Fix: carry the previous round's persisted blockers into `wfe_review_packet_t`; when present, the panel prompt declares a **RE-REVIEW** — approve if those blockers are adequately addressed and no **new high-severity** defect is found; stylistic preferences and below-high-severity issues go to `comment` (non-blocking) instead of `request_changes`. First reviews are unchanged, as is the fail-closed rule (any effective `request_changes` still loops; malformed verdicts still coerce to `request_changes`).

Tests: `unit-test-wfe-panel-verdict`, `unit-test-wfe-engine`, `unit-test-wfe-autonomy` pass locally.