### PR TITLE
feat(webchat-gui): org-grouped projects, typed-confirm delete, clone outcome notices (slice 3)

### DIFF
--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -299,9 +299,12 @@ export default function Projects() {
         setDelKbDown(true); setDelForceArmed(false);
         setErr(d.error || 'knowledge service unavailable — retry, or force delete');
       } else {
+        // A non-kb error must disarm any pending force confirmation — the
+        // armed state only ever applies to the 503 kb-down flow it came from.
+        setDelKbDown(false); setDelForceArmed(false);
         setErr(d.error || `delete failed (${r.status})`);
       }
-    } catch { setErr('aimee-server unavailable'); } finally { setBusy(false); }
+    } catch { setDelForceArmed(false); setErr('aimee-server unavailable'); } finally { setBusy(false); }
   }
 
   async function runOp(op: string, extra?: Record<string, unknown>): Promise<boolean> {

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Panel } from '@rakuensoftware/smoothgui';
 import { useSessions } from '../SessionContext';
-import { parseOwnerOnly, repoAlreadyCloned, type GitProjectsResponse, type OwnerRef, type ProjectDetail } from '../setup/ownerUrl';
+import { groupProjectsByOrg, parseOwnerOnly, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type OwnerRef, type ProjectDetail, type ProjectDeleteResponse } from '../setup/ownerUrl';
 
 /* Git projects (webchat-git WP-F2). Lists the user's cloned repos, connects a
  * new one, and runs per-project git ops — all via /api/git/* (the server forwards
@@ -59,7 +59,17 @@ export default function Projects() {
   const [orgRepos, setOrgRepos] = useState<{ name: string; clone_url: string; private?: boolean }[]>([]);
   const [orgSelected, setOrgSelected] = useState<Record<string, boolean>>({});
   const [orgProvider, setOrgProvider] = useState('');
-  const [orgResults, setOrgResults] = useState<{ name: string; ok: boolean; error?: string | null }[]>([]);
+  const [orgResults, setOrgResults] = useState<({ name: string; ok: boolean; error?: string | null } & CloneKbAnnotations)[]>([]);
+  // Post-clone notices (org placement, kb indexing) for the single-repo form.
+  const [cloneNotes, setCloneNotes] = useState<string[]>([]);
+  // Delete flow: the ref pending confirmation, the typed-ref gate, and whether
+  // the last attempt aborted on an unavailable knowledge service (503 → offer
+  // retry / explicit force, which itself needs a second click to confirm).
+  const [delRef, setDelRef] = useState('');
+  const [delTyped, setDelTyped] = useState('');
+  const [delKbDown, setDelKbDown] = useState(false);
+  const [delForceArmed, setDelForceArmed] = useState(false);
+  const [notice, setNotice] = useState('');
 
   const loadGhConfig = useCallback(async () => {
     try {
@@ -190,7 +200,7 @@ export default function Projects() {
     // An owner/org URL (no repo segment) enumerates instead of cloning.
     const owner = parseOwnerOnly(url);
     if (owner) { await listOrgRepos(owner); return; }
-    setBusy(true); setErr(''); setOutput('');
+    setBusy(true); setErr(''); setOutput(''); setCloneNotes([]);
     try {
       const r = await api('/api/git/clone', {
         method: 'POST',
@@ -198,13 +208,20 @@ export default function Projects() {
       });
       const d = await r.json();
       if (!r.ok) { setErr(d.error || 'clone failed'); }
-      else { setUrl(''); setName(''); setToken(''); await loadProjects(); await loadHosts(); setSelected(d.name || ''); }
+      else {
+        setUrl(''); setName(''); setToken('');
+        const notes: string[] = [];
+        if (d.org_note) notes.push(d.org_note);
+        if (d.kb_indexed === false) notes.push(`not indexed in the knowledge base — ${d.kb_reason || 'knowledge service unavailable'}`);
+        setCloneNotes(notes);
+        await loadProjects(); await loadHosts(); setSelected(d.name || '');
+      }
     } finally { setBusy(false); }
   }
 
   // Enumerate an owner/org's repositories (wizard parity: /api/git/org-repos).
   async function listOrgRepos(owner: OwnerRef) {
-    setBusy(true); setErr(''); setOutput(''); setOrgResults([]);
+    setBusy(true); setErr(''); setOutput(''); setOrgResults([]); setCloneNotes([]);
     try {
       // Save the token first (private/self-hosted org) so enumeration is authed.
       if (token.trim()) {
@@ -246,6 +263,44 @@ export default function Projects() {
       setOrgResults(d.results || []);
       setUrl('');
       await loadProjects();
+    } catch { setErr('aimee-server unavailable'); } finally { setBusy(false); }
+  }
+
+  function openDelete(ref: string) {
+    setDelRef(ref); setDelTyped(''); setDelKbDown(false); setDelForceArmed(false); setErr(''); setNotice('');
+  }
+
+  function closeDelete() {
+    setDelRef(''); setDelTyped(''); setDelKbDown(false); setDelForceArmed(false);
+  }
+
+  async function deleteProject(force: boolean) {
+    if (!delRef || delTyped !== delRef) return;
+    setBusy(true); setErr(''); setNotice('');
+    try {
+      const r = await api('/api/git/projects/delete', {
+        method: 'POST',
+        body: JSON.stringify(force ? { ref: delRef, force: true } : { ref: delRef }),
+      });
+      const d: ProjectDeleteResponse = await r.json().catch(() => ({}));
+      if (r.ok) {
+        const kb = d.kb_status === 'retained'
+          ? 'knowledge retained — other users still hold this repo'
+          : d.kb_status === 'forced'
+            ? 'forced — knowledge orphaned until the knowledge service returns'
+            : 'knowledge purged';
+        setNotice(`Deleted ${delRef} — ${kb}.`);
+        closeDelete();
+        await loadProjects();
+      } else if (r.status === 503) {
+        // kb-first ordering aborted the delete: the clone is intact. Offer a
+        // retry, or an explicit force (second click) that leaves the knowledge
+        // orphaned until the service returns.
+        setDelKbDown(true); setDelForceArmed(false);
+        setErr(d.error || 'knowledge service unavailable — retry, or force delete');
+      } else {
+        setErr(d.error || `delete failed (${r.status})`);
+      }
     } catch { setErr('aimee-server unavailable'); } finally { setBusy(false); }
   }
 
@@ -296,7 +351,8 @@ export default function Projects() {
                   {orgProvider ? ` · ${orgProvider}` : ''}
                 </div>
                 <button style={{ ...btn, border: 'none', color: '#3a6ea5', padding: 0 }}
-                  onClick={() => setOrgSelected(Object.fromEntries(orgRepos.map(r => [r.name, true])))}>all</button>
+                  onClick={() => setOrgSelected(Object.fromEntries(orgRepos.map(r =>
+                    [r.name, !repoAlreadyCloned(r, orgRef.owner, projects, details)])))}>all</button>
                 <button style={{ ...btn, border: 'none', color: '#3a6ea5', padding: 0 }}
                   onClick={() => setOrgSelected({})}>none</button>
               </div>
@@ -305,12 +361,12 @@ export default function Projects() {
                 {orgRepos.map(repo => {
                   const already = repoAlreadyCloned(repo, orgRef.owner, projects, details);
                   return (
-                    <label key={repo.name} style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', cursor: 'pointer' }}>
-                      <input type="checkbox" checked={!!orgSelected[repo.name]}
+                    <label key={repo.name} style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', cursor: already ? 'default' : 'pointer' }}>
+                      <input type="checkbox" disabled={already} checked={!already && !!orgSelected[repo.name]}
                         onChange={e => setOrgSelected(p => ({ ...p, [repo.name]: e.target.checked }))} />
-                      <span style={{ fontFamily: 'monospace', flex: 1 }}>{repo.name}</span>
+                      <span style={{ fontFamily: 'monospace', flex: 1, color: already ? '#999' : undefined }}>{repo.name}</span>
                       {repo.private && <span style={{ fontSize: '10.5px', color: '#8a5a00' }}>private</span>}
-                      {already && <span style={{ fontSize: '11px', color: '#2a7' }}>● cloned</span>}
+                      {already && <span style={{ fontSize: '11px', color: '#2a7' }}>cloned</span>}
                     </label>
                   );
                 })}
@@ -330,9 +386,17 @@ export default function Projects() {
                 <div key={res.name} style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '12.5px' }}>
                   <span aria-hidden>{res.ok ? '✅' : '⛔'}</span>
                   <span style={{ fontFamily: 'monospace', flex: 1 }}>{res.name}</span>
+                  {res.ok && res.org_note && <span style={{ fontSize: '11px', color: '#8a5a00' }}>{res.org_note}</span>}
+                  {res.ok && res.kb_indexed === false &&
+                    <span style={{ fontSize: '11px', color: '#8a5a00' }}>not indexed — {res.kb_reason || 'knowledge service unavailable'}</span>}
                   {!res.ok && <span style={{ color: '#c62828' }}>{res.error || 'failed'}</span>}
                 </div>
               ))}
+            </div>
+          )}
+          {cloneNotes.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '3px' }}>
+              {cloneNotes.map(n => <div key={n} style={{ fontSize: '12px', color: '#8a5a00' }}>{n}</div>)}
             </div>
           )}
         </div>
@@ -415,14 +479,61 @@ export default function Projects() {
           {projects.length === 0 ? (
             <div style={{ color: '#888', fontSize: '13px' }}>No projects yet — connect a repository above.</div>
           ) : (
-            <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-              {projects.map(p => (
-                <button key={p} onClick={() => { setSelected(p); setOutput(''); setErr(''); }}
-                  style={{ ...btn, background: p === selected ? '#234' : '#fff', color: p === selected ? '#8cf' : '#444',
-                           borderColor: p === selected ? '#456' : '#ccc' }}>
-                  {p}
-                </button>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              {groupProjectsByOrg(projects, details).map(g => (
+                <div key={g.org || '(ungrouped)'} style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                  <div style={{ fontSize: '11px', fontWeight: 700, color: '#888', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+                    {g.org || 'ungrouped'}
+                  </div>
+                  <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                    {g.refs.map(p => (
+                      <span key={p} style={{ display: 'inline-flex' }}>
+                        <button onClick={() => { setSelected(p); setOutput(''); setErr(''); }}
+                          style={{ ...btn, background: p === selected ? '#234' : '#fff', color: p === selected ? '#8cf' : '#444',
+                                   borderColor: p === selected ? '#456' : '#ccc', borderRadius: '4px 0 0 4px' }}>
+                          {p}
+                        </button>
+                        <button title={`Delete ${p}`} disabled={busy} onClick={() => openDelete(p)}
+                          style={{ ...btn, borderColor: '#d99', color: '#c33', borderRadius: '0 4px 4px 0', borderLeft: 'none' }}>
+                          ×
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                </div>
               ))}
+            </div>
+          )}
+
+          {delRef && (
+            <div style={{ border: '1px solid #d99', borderRadius: '6px', padding: '10px', background: '#fff7f7',
+                          display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              <div style={{ fontSize: '13px', fontWeight: 600, color: '#c33' }}>Delete {delRef}?</div>
+              <div style={{ fontSize: '12px', color: '#844' }}>
+                This removes the clone and all indexed knowledge. Type{' '}
+                <code style={{ background: '#fee', padding: '1px 5px', borderRadius: '4px' }}>{delRef}</code> to confirm.
+              </div>
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+                <input style={{ ...input, flex: 1, minWidth: '180px', fontFamily: 'monospace' }} placeholder={delRef}
+                  value={delTyped} onChange={e => setDelTyped(e.target.value)} />
+                {!delKbDown && (
+                  <button style={{ ...btn, background: '#c33', color: '#fff', borderColor: '#a22' }}
+                    disabled={busy || delTyped !== delRef} onClick={() => deleteProject(false)}>Delete</button>
+                )}
+                <button style={btn} disabled={busy} onClick={closeDelete}>Cancel</button>
+              </div>
+              {delKbDown && (
+                <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+                  <button style={btn} disabled={busy || delTyped !== delRef}
+                    onClick={() => deleteProject(false)}>Retry</button>
+                  <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy || delTyped !== delRef}
+                    onClick={() => { if (delForceArmed) deleteProject(true); else setDelForceArmed(true); }}>
+                    {delForceArmed
+                      ? 'Click again to confirm force delete'
+                      : 'Force delete (leaves knowledge orphaned until the knowledge service returns)'}
+                  </button>
+                </div>
+              )}
             </div>
           )}
 
@@ -458,6 +569,7 @@ export default function Projects() {
           )}
 
           {err && <div style={{ color: '#c62828', fontSize: '12px' }}>{err}</div>}
+          {notice && <div style={{ color: '#2a7', fontSize: '12px' }}>{notice}</div>}
           {output && (
             <pre style={{ fontSize: '12px', background: '#0d1117', color: '#c9d1d9', padding: '10px',
                           borderRadius: '6px', overflow: 'auto', maxHeight: '320px', whiteSpace: 'pre-wrap' }}>

--- a/frontend/src/setup/ConnectWorkspace.tsx
+++ b/frontend/src/setup/ConnectWorkspace.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { parseOwner, repoAlreadyCloned, type GitProjectsResponse, type ProjectDetail } from './ownerUrl';
+import { parseOwner, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type ProjectDetail } from './ownerUrl';
 
 /* Wizard — Workspaces & projects. A workspace is your collection of projects: the
  * repos under an owner/org (e.g. github.com/RakuenSoftware). Point at that owner,
@@ -40,7 +40,7 @@ interface Repo {
   private?: boolean;
 }
 
-interface CloneResult {
+interface CloneResult extends CloneKbAnnotations {
   name: string;
   ok: boolean;
   project?: string | null;
@@ -157,7 +157,7 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
   const ownerName = parseOwner(ownerInput)?.owner || '';
   const toggleAll = (on: boolean) => {
     const sel: Record<string, boolean> = {};
-    for (const r of repos) sel[r.name] = on;
+    for (const r of repos) sel[r.name] = on && !repoAlreadyCloned(r, ownerName, projects, details);
     setSelected(sel);
   };
 
@@ -196,12 +196,12 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
             {repos.map((repo) => {
               const already = repoAlreadyCloned(repo, ownerName, projects, details);
               return (
-                <label key={repo.name} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer' }}>
-                  <input type="checkbox" checked={!!selected[repo.name]}
+                <label key={repo.name} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: already ? 'default' : 'pointer' }}>
+                  <input type="checkbox" disabled={already} checked={!already && !!selected[repo.name]}
                     onChange={(e) => setSelected((p) => ({ ...p, [repo.name]: e.target.checked }))} />
-                  <span style={{ fontFamily: 'monospace', flex: 1 }}>{repo.name}</span>
+                  <span style={{ fontFamily: 'monospace', flex: 1, color: already ? '#99a' : undefined }}>{repo.name}</span>
                   {repo.private && <span style={{ fontSize: 10.5, color: '#8a5a00', background: '#fff6e6', border: '1px solid #f0d8a8', borderRadius: 4, padding: '0 5px' }}>private</span>}
-                  {already && <span style={{ fontSize: 11, color: '#2a7' }}>● cloned</span>}
+                  {already && <span style={{ fontSize: 11, color: '#2a7' }}>cloned</span>}
                 </label>
               );
             })}
@@ -221,6 +221,9 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
             <div key={res.name} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12.5 }}>
               <span aria-hidden>{res.ok ? '✅' : '⛔'}</span>
               <span style={{ fontFamily: 'monospace', flex: 1 }}>{res.name}</span>
+              {res.ok && res.org_note && <span style={{ fontSize: 11, color: '#8a5a00' }}>{res.org_note}</span>}
+              {res.ok && res.kb_indexed === false &&
+                <span style={{ fontSize: 11, color: '#8a5a00' }}>not indexed — {res.kb_reason || 'knowledge service unavailable'}</span>}
               {!res.ok && <span style={{ color: '#c62828' }}>{res.error || 'failed'}</span>}
             </div>
           ))}

--- a/frontend/src/setup/ownerUrl.test.ts
+++ b/frontend/src/setup/ownerUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canonicalRemote, parseOwner, parseOwnerOnly, repoAlreadyCloned, type ProjectDetail } from './ownerUrl';
+import { canonicalRemote, groupProjectsByOrg, parseOwner, parseOwnerOnly, repoAlreadyCloned, type ProjectDetail } from './ownerUrl';
 
 describe('parseOwner', () => {
   it('parses the plain owner form', () => {
@@ -95,5 +95,41 @@ describe('repoAlreadyCloned', () => {
   it('uses the plain projects list when the server sends no details', () => {
     expect(repoAlreadyCloned(repo, 'RakuenSoftware', ['RakuenSoftware/aimee'], [])).toBe(true);
     expect(repoAlreadyCloned(repo, 'RakuenSoftware', ['other'], [])).toBe(false);
+  });
+});
+
+describe('groupProjectsByOrg', () => {
+  const details: ProjectDetail[] = [
+    { ref: 'zeta/one', org: 'zeta', name: 'one' },
+    { ref: 'acme/foo', org: 'acme', name: 'foo' },
+    { ref: 'legacy', org: '', name: 'legacy' },
+    { ref: 'acme/bar', org: 'acme', name: 'bar' },
+  ];
+
+  it('groups refs under their orgs, orgs alphabetical, ungrouped last', () => {
+    expect(groupProjectsByOrg(['zeta/one', 'acme/foo', 'legacy', 'acme/bar'], details)).toEqual([
+      { org: 'acme', refs: ['acme/foo', 'acme/bar'] },
+      { org: 'zeta', refs: ['zeta/one'] },
+      { org: '', refs: ['legacy'] },
+    ]);
+  });
+
+  it('derives the org from the ref when the server sends no details', () => {
+    expect(groupProjectsByOrg(['acme/foo', 'legacy'], [])).toEqual([
+      { org: 'acme', refs: ['acme/foo'] },
+      { org: '', refs: ['legacy'] },
+    ]);
+  });
+
+  it('round-trips: every ref appears exactly once and joins back to the input', () => {
+    const projects = ['zeta/one', 'acme/foo', 'legacy', 'acme/bar'];
+    const flat = groupProjectsByOrg(projects, details).flatMap(g => g.refs);
+    expect(flat.slice().sort()).toEqual(projects.slice().sort());
+    expect(flat).toHaveLength(projects.length);
+  });
+
+  it('handles all-ungrouped and empty inputs', () => {
+    expect(groupProjectsByOrg(['a', 'b'], [])).toEqual([{ org: '', refs: ['a', 'b'] }]);
+    expect(groupProjectsByOrg([], [])).toEqual([]);
   });
 });

--- a/frontend/src/setup/ownerUrl.ts
+++ b/frontend/src/setup/ownerUrl.ts
@@ -56,6 +56,55 @@ export interface GitProjectsResponse {
   error?: string;
 }
 
+/* Knowledge-indexing annotations a clone response (or a clone-org per-repo
+ * result row) may carry: `kb_indexed:false` means the clone succeeded but the
+ * code scan did not run — `kb_reason` says why. A single clone may also carry
+ * `org_note` (multi-segment owner cloned flat; pass an explicit org). */
+export interface CloneKbAnnotations {
+  org_note?: string;
+  kb_indexed?: boolean;
+  kb_reason?: string;
+}
+
+/** POST /api/git/projects/delete response. 200 carries `kb_status`
+ * ("purged" | "retained" | "forced") + `purge_id`; 503 (kb unavailable —
+ * retry or force) and 400/404 carry `error`. `kb` is the per-store detail. */
+export interface ProjectDeleteResponse {
+  ok?: boolean;
+  ref?: string;
+  kb_status?: 'purged' | 'retained' | 'forced';
+  purge_id?: string;
+  kb?: Record<string, unknown>;
+  error?: string;
+}
+
+/** One org heading on the Projects page: the org name ('' = ungrouped legacy
+ * flat clones) and its project refs in server order. */
+export interface OrgGroup {
+  org: string;
+  refs: string[];
+}
+
+/** Group project refs under their orgs for display. The org comes from the
+ * details row when the server sent one, else from the ref itself ("org/name" →
+ * "org", flat → ''). Named orgs sort alphabetically; the ungrouped bucket
+ * (legacy flat clones) comes last. Refs keep server order within a group. */
+export function groupProjectsByOrg(projects: string[], details: ProjectDetail[]): OrgGroup[] {
+  const byRef = new Map(details.map(d => [d.ref, d]));
+  const groups = new Map<string, string[]>();
+  for (const ref of projects) {
+    const d = byRef.get(ref);
+    const slash = ref.indexOf('/');
+    const org = d ? d.org : slash > 0 ? ref.slice(0, slash) : '';
+    const bucket = groups.get(org);
+    if (bucket) bucket.push(ref);
+    else groups.set(org, [ref]);
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => (a === '' ? 1 : b === '' ? -1 : a.localeCompare(b)))
+    .map(([org, refs]) => ({ org, refs }));
+}
+
 // Hosts whose repo paths are case-insensitive (mirrors the server's
 // util_url_host_is_case_insensitive).
 const CI_HOSTS = ['github.com', 'gitlab.com', 'bitbucket.org'];


### PR DESCRIPTION
Slice 3 (final) of the webchat project-lifecycle feature (proposal: `docs/proposals/pending/webchat-project-lifecycle.md`). Frontend-only.

- Projects page groups projects under org headings (flat/legacy under 'ungrouped', last); pure `groupProjectsByOrg` helper with vitest coverage.
- Per-project Delete with typed-ref confirm ('removes the clone and all indexed knowledge') → `POST /api/git/projects/delete`; `kb_status` mapped to purged/retained/forced notices; 503 offers Retry plus a double-confirmed Force delete (re-POSTs `force:true`).
- Clone outcome surfacing everywhere clones start: `org_note` (multi-segment owner guidance) and `kb_indexed:false` + `kb_reason` notices, on the single form and per-row on bulk results (Projects + ConnectWorkspace).
- Org-repos picker disables already-cloned remotes (canonical-remote comparison) with a 'cloned' label; select-all skips them.

`tsc -b` clean; vitest 93 tests pass (4 new).