### PR TITLE
fix(wfe): a no-op implement dispatch loops instead of advancing to review

### DIFF
--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -170,6 +170,11 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
          }
       }
    }
+   /* Keep the reply's head for the no-op diagnostic below (res.response is
+    * freed here). */
+   char reply_head[224] = "(empty)";
+   if (res.response && res.response[0])
+      snprintf(reply_head, sizeof reply_head, "%.200s", res.response);
    free(res.response);
 
    /* Stage + commit whatever the delegate changed in the worktree. A commit with
@@ -179,6 +184,17 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
     * makes a downstream squash-merge inject a `Co-authored-by:` trailer, which the
     * standing directive forbids. No `-c user.name/user.email` override, and no
     * co-authorship trailer. */
+   char pre_head[64] = "";
+   {
+      const char *argv[] = {"git", "-C", workdir, "rev-parse", "HEAD", NULL};
+      char *o = NULL;
+      if (safe_exec_capture(argv, &o, 256) == 0 && o)
+      {
+         chomp(o);
+         snprintf(pre_head, sizeof pre_head, "%s", o);
+      }
+      free(o);
+   }
    {
       const char *add[] = {"add", "-A"};
       (void)git_run(workdir, add, 2);
@@ -193,6 +209,15 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
          chomp(o);
          if (out_commit_sha)
             snprintf(out_commit_sha, 64, "%s", o);
+         /* Diagnostic: a producing delegate that edited NOTHING is the top
+          * silent failure mode of the autonomous loop (rounds spin on an
+          * unchanged tree). Surface WHICH agent replied without editing and
+          * the head of what it said instead, so the cause (tool bridge down,
+          * refusal, advice-only reply) is triageable from the server log. */
+         if (pre_head[0] && strcmp(pre_head, o) == 0)
+            aimee_log(LOG_WARN, "wfe-delegate",
+                      "no-op run: agent '%s' made no edits in %s; reply head: %s",
+                      agent_name[0] ? agent_name : "(role-routed)", workdir, reply_head);
       }
       free(o);
    }

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -1033,9 +1033,33 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
                   base_prompt, feedback);
       else
          snprintf(prompt, sizeof prompt, "%s", base_prompt);
+      /* Snapshot HEAD so a NO-OP dispatch is detectable below. */
+      char pre_head[64] = "";
+      {
+         const char *argv[] = {"git", "-C", wd, "rev-parse", "HEAD", NULL};
+         char *o = NULL;
+         if (git_capture(argv, &o) == 0 && o)
+         {
+            chomp(o);
+            snprintf(pre_head, sizeof pre_head, "%s", o);
+         }
+         free(o);
+      }
       if (wfe_delegate_dispatch(wd, "engineer", node_delegate(node), prompt, NULL, commit, &cost) <
           0)
          return with_cost(wfe_step_looped(), cost);
+      /* A dispatch that changed NOTHING (reply-only, no tool edits, so the
+       * provider's add+commit no-opped and HEAD is unchanged) is a FAILED
+       * attempt, not an advance: freezing the identical tree re-runs verify and
+       * a full 4-seat panel on a diff the panel already rejected. Observed
+       * live: whole review rounds burned on byte-identical artifacts. Loop so
+       * the retry re-dispatches (a $random re-roll picks a different agent). */
+      if (pre_head[0] && commit[0] && strcmp(pre_head, commit) == 0)
+      {
+         db1_lifecycle_event_add(wfe_ctx_work_item(ctx), node->id, "loop", "engine",
+                                 "impl no-op: delegate made no edits", "", cost);
+         return with_cost(wfe_step_looped(), cost);
+      }
    }
 
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";


### PR DESCRIPTION
Many live implement rounds committed **nothing**: the delegate replied text-only (no tool edits anywhere — wfe worktree and shared clone both untouched), the provider's `git add -A` + commit no-opped, HEAD stayed put — and the step still advanced. Verify then passed the unchanged tree, freeze re-froze the identical artifact, and a full 4-seat roundtable burned a review on a byte-identical diff it had already rejected. Observed live on .254: several slices' worktree HEADs are hours older than their "revision" rounds (s5's HEAD is still the operator scope commit), while panels kept rejecting the same hash — a major component of today's token burn with zero PRs.

1. `exec_implement` snapshots HEAD before dispatch; an unchanged HEAD after a "successful" dispatch is a **failed attempt** — audited as `impl no-op: delegate made no edits` and looped (the retry re-rolls a different `$random` agent). Freeze/verify/panel only run on rounds that actually changed the tree.
2. `wfe_live_delegate_run` WARNs with the agent name and the head of the reply when a producing run edits nothing, so the root cause of reply-only runs (tool bridge, refusal, advice-only answer) is triageable from the server log.

Tests: `unit-test-wfe-delegate-seam`, `unit-test-wfe-engine`, `unit-test-wfe-autonomy` pass locally.