### PR TITLE
fix(agent): session-isolation backstop recognizes wfe worktrees as managed

### DIFF
--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -166,12 +166,23 @@ int agent_tools_session_isolation_blocks(const char *path, const char *cwd)
    if (!cfg.require_session_worktree)
       return 0;
    /* normalize_path resolves '.'/'..'/relative against cwd, closing traversal
-    * escapes. Match ONLY the canonical managed-worktree location (not the
-    * looser "/.aimee-" prefix is_aimee_worktree_path() accepts), consistent
-    * with the client-side attn_session_isolation_blocked check. */
+    * escapes. Match the canonical managed-worktree location plus the workflow
+    * engine's per-work-item worktrees (not the looser "/.aimee-" prefix
+    * is_aimee_worktree_path() accepts), consistent with the client-side
+    * attn_session_isolation_blocked check. /wfe-worktrees/ is the same fix
+    * #1314 applied to the guardrail layer: a wfe delegate's target IS an
+    * isolated worktree — without it, this backstop (default ON) refused every
+    * native write_file/edit_file into a wfe worktree, so implement delegates
+    * that edit via file tools produced no-op rounds while bash-writers slipped
+    * through — the whole fleet's convergence depended on each model's tool
+    * preferences. */
    char norm[MAX_PATH_LEN];
    normalize_path(path, cwd, norm, sizeof(norm));
-   return strstr(norm, "/.aimee/worktrees/") != NULL ? 0 : 1;
+   if (strstr(norm, "/.aimee/worktrees/") != NULL)
+      return 0;
+   if (strstr(norm, "/wfe-worktrees/") != NULL)
+      return 0;
+   return 1;
 }
 
 static int tools_array_has_name(cJSON *tools, const char *name, int openai_format)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -2396,6 +2396,16 @@ static void test_session_isolation_guard(void)
    assert(agent_tools_session_isolation_blocks("src/x.c",
                                                "/some/repo/.aimee/worktrees/ab12/main") == 0);
    assert(agent_tools_session_isolation_blocks("src/x.c", "/some/repo") == 1);
+   /* The workflow engine's per-work-item worktrees ARE managed isolation (the
+    * server-side mirror of #1314's guardrail fix): a wfe delegate's writes into
+    * its own wfe worktree must not be refused by this backstop. */
+   assert(agent_tools_session_isolation_blocks(
+              "/var/lib/aimee/wfe-worktrees/wi_ab12.s3/src/x.c", NULL) == 0);
+   assert(agent_tools_session_isolation_blocks(
+              "src/x.c", "/var/lib/aimee/wfe-worktrees/wi_ab12.s3") == 0);
+   /* Traversal OUT of a wfe worktree still blocks. */
+   assert(agent_tools_session_isolation_blocks(
+              "/var/lib/aimee/wfe-worktrees/wi_ab12.s3/../../escape.c", NULL) == 1);
    /* NULL path is a no-op (returns 0). */
    assert(agent_tools_session_isolation_blocks(NULL, NULL) == 0);
 

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -2399,10 +2399,10 @@ static void test_session_isolation_guard(void)
    /* The workflow engine's per-work-item worktrees ARE managed isolation (the
     * server-side mirror of #1314's guardrail fix): a wfe delegate's writes into
     * its own wfe worktree must not be refused by this backstop. */
-   assert(agent_tools_session_isolation_blocks(
-              "/var/lib/aimee/wfe-worktrees/wi_ab12.s3/src/x.c", NULL) == 0);
-   assert(agent_tools_session_isolation_blocks(
-              "src/x.c", "/var/lib/aimee/wfe-worktrees/wi_ab12.s3") == 0);
+   assert(agent_tools_session_isolation_blocks("/var/lib/aimee/wfe-worktrees/wi_ab12.s3/src/x.c",
+                                               NULL) == 0);
+   assert(agent_tools_session_isolation_blocks("src/x.c",
+                                               "/var/lib/aimee/wfe-worktrees/wi_ab12.s3") == 0);
    /* Traversal OUT of a wfe worktree still blocks. */
    assert(agent_tools_session_isolation_blocks(
               "/var/lib/aimee/wfe-worktrees/wi_ab12.s3/../../escape.c", NULL) == 1);


### PR DESCRIPTION
**This is the root cause of the implement no-op rounds** (diagnosed live on .254 via #1342's no-op diagnostics plus a pinned `aimee delegate --via mimo-v2.5-pro` reproduction whose transcript listed every write tool refused).

`agent_tools_session_isolation_blocks` (default **ON** since config.c:730) matched only `/.aimee/worktrees/`, so every native `write_file`/`edit_file` targeting a workflow-engine worktree (`$AIMEE_HOME/wfe-worktrees/wi_<id>`) was refused with *"target is outside an aimee-managed worktree"* — the server-side twin of the guardrail bug #1314 fixed client-side.

Live effect: implement delegates that edit via file tools could not write **at all** and returned prose ("I can't implement without calling tools" — the model was being honest; direct endpoint probes confirm e.g. mimo tool-calls natively and correctly). Delegates that write via bash side-effects slipped through, so whether a slice converged depended on each model's tool preferences rather than the work.

Fix: accept `/wfe-worktrees/` exactly as #1314 did for the guardrail layer. A traversal escaping the worktree still normalizes outside and blocks. Tests: the Layer-2 isolation suite in `test_agent.c` extended with wfe-worktree allow + traversal-escape block cases; `unit-test-agent` passes locally.