### PR TITLE
feat(kb): dedicated extract_code worker threads (kb.curator.extract_code.workers)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (177)
+## CLI-settable keys (178)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -98,6 +98,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `kb_curator_custom_stages` | string | — |
 | `kb_curator_detect_contradictions_enabled` | bool | — |
 | `kb_curator_extract_code_enabled` | bool | — |
+| `kb_curator_extract_code_workers` | int | — |
 | `kb_curator_extract_docs_enabled` | bool | — |
 | `kb_curator_index_claims_enabled` | bool | — |
 | `kb_curator_index_code_unit_enabled` | bool | — |
@@ -204,7 +205,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 | `wfe_live_forge_enabled` | bool | — |
 
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_client_bearer_token`, `kb_client_url`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_custom_stages`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_docs_enabled`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_curator_user_presets`, `kb_evidence_embed_enabled`, `kb_mode`, `llm_embed_backend`, `llm_embed_gpu`, `llm_embed_host`, `llm_embed_tier`, `llm_rerank_backend`, `llm_rerank_endpoint`, `llm_rerank_gpu`, `llm_rerank_host`, `llm_rerank_tier`, `llm_synth_backend`, `llm_synth_endpoint`, `llm_synth_gpu`, `llm_synth_host`, `llm_synth_model`, `llm_synth_tier`, `wfe_live_forge_enabled`
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_client_bearer_token`, `kb_client_url`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_custom_stages`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_code_workers`, `kb_curator_extract_docs_enabled`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_curator_user_presets`, `kb_evidence_embed_enabled`, `kb_mode`, `llm_embed_backend`, `llm_embed_gpu`, `llm_embed_host`, `llm_embed_tier`, `llm_rerank_backend`, `llm_rerank_endpoint`, `llm_rerank_gpu`, `llm_rerank_host`, `llm_rerank_tier`, `llm_synth_backend`, `llm_synth_endpoint`, `llm_synth_gpu`, `llm_synth_host`, `llm_synth_model`, `llm_synth_tier`, `wfe_live_forge_enabled`
 
 ## Config-file sections (53)
 

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -374,6 +374,8 @@ const config_field_t config_fields[] = {
      sizeof(((config_t *)0)->kb_curator_custom_stages), 0, CFG_STRING},
     {"kb_curator_extract_code_enabled", offsetof(config_t, kb_curator_extract_code_enabled),
      sizeof(int), 0, CFG_BOOL},
+    {"kb_curator_extract_code_workers", offsetof(config_t, kb_curator_extract_code_workers),
+     sizeof(int), 0, CFG_INT},
     {"kb_curator_resolve_entities_enabled", offsetof(config_t, kb_curator_resolve_entities_enabled),
      sizeof(int), 0, CFG_BOOL},
     {"kb_curator_index_narrative_enabled", offsetof(config_t, kb_curator_index_narrative_enabled),

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -36,6 +36,7 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_typed_facts_auto_promote_enabled = 1;
    cfg->kb_typed_facts_promote_threshold = 3;
    cfg->kb_curator_extract_code_enabled = 1;
+   cfg->kb_curator_extract_code_workers = 1;
    cfg->kb_curator_resolve_entities_enabled = 1;
    cfg->kb_curator_index_narrative_enabled = 1;
    cfg->kb_curator_index_claims_enabled = 1;
@@ -177,6 +178,11 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
       const cJSON *enabled = cJSON_GetObjectItemCaseSensitive(extract_code, "enabled");
       if (enabled && cJSON_IsBool(enabled))
          cfg->kb_curator_extract_code_enabled = cJSON_IsTrue(enabled) ? 1 : 0;
+      /* workers: dedicated extract_code drain threads (see config.h). Clamped
+       * to [1,8]; non-numeric / out-of-range values keep the default. */
+      const cJSON *workers = cJSON_GetObjectItemCaseSensitive(extract_code, "workers");
+      if (workers && cJSON_IsNumber(workers) && workers->valueint >= 1 && workers->valueint <= 8)
+         cfg->kb_curator_extract_code_workers = workers->valueint;
    }
 
    const cJSON *resolve_entities = cJSON_GetObjectItemCaseSensitive(curator, "resolve_entities");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1620,6 +1620,13 @@ typedef struct config
     * events to on doc invalidation. Empty = disabled (poll the feed). */
    char kb_curator_invalidation_notify_socket[512];
    int kb_curator_extract_code_enabled;
+   /* Dedicated extract_code worker threads (kb_curator_extract_code_workers).
+    * Default 1 = the shared drain thread's one-unit-per-pass behavior. N>1
+    * spawns N-1 additional workers that drain ONLY extract_code jobs in
+    * parallel — sized to the synth backend's parallel slots (e.g. 4 workers
+    * for a --parallel 4 llama-server), since each job is one LLM sidecar
+    * call. Clamped to [1,8]. */
+   int kb_curator_extract_code_workers;
    /* resolve_entities pass: 0 = off (default), 1 = commit proposed `entity`
     * mentions into curator_entity_vectors on the curator drain. */
    int kb_curator_resolve_entities_enabled;

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -915,6 +915,40 @@ static void *drain_thread_main(void *arg)
    return NULL;
 }
 
+/* Dedicated extract_code worker: claims and processes ONE extract_code job per
+ * iteration, sleeping the poll interval when the queue is empty or the gate is
+ * off. Deliberately minimal — no sweeps, no other stages — so N workers map
+ * 1:1 onto the synth backend's parallel slots. */
+static void *kb_curator_code_worker_main(void *arg)
+{
+   kb_curator_drain_ctx_t *ctx = (kb_curator_drain_ctx_t *)arg;
+   while (!ctx->stop)
+   {
+      config_t cfg;
+      config_load(&cfg);
+      if (!cfg.kb_curator_extract_code_enabled)
+      {
+         sleep(DRAIN_POLL_SECS);
+         continue;
+      }
+      kb_curator_extract_opts_t opts;
+      memset(&opts, 0, sizeof(opts));
+      snprintf(opts.extract_command, sizeof(opts.extract_command), "%s",
+               cfg.kb_curator_extract_command);
+      opts.max_tokens =
+          cfg.kb_curator_extract_max_tokens > 0 ? cfg.kb_curator_extract_max_tokens : 2048;
+      opts.max_attempts = cfg.kb_curator_max_attempts > 0 ? cfg.kb_curator_max_attempts : 3;
+
+      int r = kb_curator_extract_code_unit_one(&opts);
+      db2_lease_release_idle();
+      if (r == 1)
+         continue; /* did work — claim the next job immediately */
+      /* empty queue (0) or error (<0): back off the poll interval */
+      sleep(DRAIN_POLL_SECS);
+   }
+   return NULL;
+}
+
 static void *kb_curator_index_lane_main(void *arg)
 {
    kb_curator_drain_ctx_t *ctx = (kb_curator_drain_ctx_t *)arg;
@@ -1000,6 +1034,29 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx)
    {
       aimee_log(LOG_WARN, "kb.curator.drain", "failed to start drain thread");
    }
+
+   /* Dedicated extract_code workers: kb_curator_extract_code_workers - 1 extra
+    * threads (the main LLM lane above still runs one extract per pass), so a
+    * synth backend serving N parallel slots actually receives N concurrent
+    * sidecar extractions. Job claims are transactional (UPDATE ... SELECT ...
+    * LIMIT 1), so concurrent workers never double-claim. */
+   ctx->code_active = 0;
+   if (cfg.kb_curator_extract_code_enabled && cfg.kb_curator_extract_code_workers > 1)
+   {
+      int extra = cfg.kb_curator_extract_code_workers - 1;
+      if (extra > KB_CURATOR_MAX_CODE_WORKERS)
+         extra = KB_CURATOR_MAX_CODE_WORKERS;
+      for (int i = 0; i < extra; i++)
+      {
+         if (pthread_create(&ctx->code_threads[ctx->code_active], NULL, kb_curator_code_worker_main,
+                            ctx) == 0)
+            ctx->code_active++;
+         else
+            break;
+      }
+      aimee_log(LOG_INFO, "kb.curator.drain", "%d extract_code worker thread(s) started",
+                ctx->code_active);
+   }
    if (pthread_create(&ctx->index_thread, NULL, kb_curator_index_lane_main, ctx) == 0)
    {
       ctx->index_active = 1;
@@ -1013,7 +1070,7 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx)
 
 void kb_curator_drain_shutdown(kb_curator_drain_ctx_t *ctx)
 {
-   if (!ctx || (!ctx->active && !ctx->index_active))
+   if (!ctx || (!ctx->active && !ctx->index_active && ctx->code_active <= 0))
       return;
    ctx->stop = 1;
    if (ctx->active)
@@ -1026,5 +1083,8 @@ void kb_curator_drain_shutdown(kb_curator_drain_ctx_t *ctx)
       pthread_join(ctx->index_thread, NULL);
       ctx->index_active = 0;
    }
+   for (int i = 0; i < ctx->code_active; i++)
+      pthread_join(ctx->code_threads[i], NULL);
+   ctx->code_active = 0;
    aimee_log(LOG_DEBUG, "kb.curator.drain", "drain threads stopped");
 }

--- a/src/kb_curator_drain.h
+++ b/src/kb_curator_drain.h
@@ -3,10 +3,18 @@
 
 #include <pthread.h>
 
+#define KB_CURATOR_MAX_CODE_WORKERS 8
+
 typedef struct
 {
    pthread_t thread;       /* LLM lane (GPU): extract/resolve/synthesize + sweeps */
    pthread_t index_thread; /* INDEX lane (CPU): embed/index + contradiction SQL */
+   /* Dedicated extract_code workers (kb_curator_extract_code_workers - 1 extra
+    * threads; the main LLM lane still contributes one unit per pass). Each
+    * drains ONLY extract_code jobs so a multi-slot synth backend runs that
+    * many sidecar extractions in parallel. */
+   pthread_t code_threads[KB_CURATOR_MAX_CODE_WORKERS];
+   int code_active; /* number of spawned extract_code workers */
    int active;
    int index_active;
    volatile int stop;


### PR DESCRIPTION
The curator drain is one thread, and `extract_code` is an LLM-lane stage budgeted one unit per pass — so a synth backend serving multiple parallel slots (`llama-server --parallel N`) still received exactly one sidecar extraction at a time. Live on .254: a 37k-unit code backlog draining at ~2 jobs/min (~13 days), while the synth GPU now runs 4×70K slots.

`kb.curator.extract_code.workers` (default **1** = today's behavior, clamped 1..8) spawns N−1 dedicated threads that claim and process ONLY `extract_code` jobs — claims are already transactional (`UPDATE … SELECT … LIMIT 1`), so concurrent workers never double-claim; the main LLM lane still contributes its one unit per pass, so N workers total. Each worker re-checks the stage gate per iteration and backs off the poll interval on empty/error.

Docs: `configuration.md` regenerated. Tests: `unit-test-config` passes locally; drain threading exercised by deployment like the rest of this module.