### PR TITLE
wfe panel: request_changes must cite verifiable evidence (file:line replayed against the worktree)

### DIFF
--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -88,10 +88,23 @@ static char *build_prompt(const char *persona, const wfe_review_packet_t *pkt)
    const char *focus =
        (pkt->focus && pkt->focus[0]) ? pkt->focus : "correctness, quality, and completeness";
    const char *proposal = (pkt->proposal && pkt->proposal[0]) ? pkt->proposal : "(none provided)";
-   const char *diff = (pkt->diff && pkt->diff[0])
-                          ? pkt->diff
-                          : "(no code diff — review the plan/proposal artifact against the ask)";
-   size_t cap = 2048 + strlen(focus) + strlen(proposal) + strlen(diff);
+   int have_diff = pkt->diff && pkt->diff[0];
+   const char *diff =
+       have_diff ? pkt->diff : "(no code diff — review the plan/proposal artifact against the ask)";
+   /* Code reviews must GROUND every blocker: a request_changes carries citations
+    * (file:line + the exact quoted text) that the gate replays against the
+    * worktree; an unreproducible objection is re-graded to a non-blocking
+    * comment. Plan/proposal reviews have no lines to cite, so the requirement
+    * (and the replay) only applies when a diff is under review. */
+   const char *cite =
+       have_diff
+           ? " A request_changes MUST also carry \"blockers\":[{\"file\":\"<repo-relative "
+             "path>\",\"line\":<n>,\"quote\":\"<exact text on that line>\",\"summary\":\"<why it "
+             "blocks>\"}] (at most 8) citing real evidence for EVERY blocker; each citation is "
+             "verified against the worktree, an unverifiable blocker is discarded, and a "
+             "request_changes with no verifiable citation counts only as a comment."
+           : "";
+   size_t cap = 2560 + strlen(focus) + strlen(proposal) + strlen(diff);
    char *buf = malloc(cap);
    if (!buf)
       return NULL;
@@ -105,8 +118,8 @@ static char *build_prompt(const char *persona, const wfe_review_packet_t *pkt)
             "End your reply with EXACTLY one JSON line and nothing after it: "
             "{\"verdict\":\"approve\"} if it satisfies the ask with no high-severity blocker, "
             "{\"verdict\":\"request_changes\",\"high_sev_blockers\":<N>} if there is a real "
-            "blocker, or {\"verdict\":\"comment\"} if you only have non-blocking remarks.",
-            persona, focus, proposal, diff);
+            "blocker, or {\"verdict\":\"comment\"} if you only have non-blocking remarks.%s",
+            persona, focus, proposal, diff, cite);
    return buf;
 }
 
@@ -355,6 +368,24 @@ static int live_panel(const wfe_review_packet_t *pkt, const char *const *require
             wfe_panel_verdict_from_review(required[i], pkt->artifact_hash, results[t].response,
                                           &out[filled]);
             snprintf(out[filled].model, sizeof out[filled].model, "%s", taskagent[t]);
+            /* Ground the verdict: replay blocker citations against the worktree.
+             * Only meaningful for a code review — a plan/proposal gate (no diff)
+             * has no lines to cite, so its request_changes stands unverified. */
+            if (out[filled].kind == WFE_V_REQUEST_CHANGES && pkt->diff && pkt->diff[0])
+            {
+               int cited = out[filled].blocker_count;
+               int ver = wfe_panel_blockers_verify(&out[filled], pkt->workdir);
+               if (out[filled].kind == WFE_V_COMMENT)
+                  aimee_log(LOG_WARN, "wfe-panel",
+                            "lens '%s' request_changes from agent '%s' re-graded to comment: "
+                            "%d blocker citation(s), none reproduced in the worktree",
+                            required[i], taskagent[t], cited);
+               else if (ver < cited)
+                  aimee_log(LOG_INFO, "wfe-panel",
+                            "lens '%s': %d/%d blocker citation(s) reproduced (unverified ones "
+                            "discarded)",
+                            required[i], ver, cited);
+            }
             /* Attribute the verdict so a degraded gate is triageable: without
              * this there is no record of WHICH agent served a lens or what it
              * returned. On MALFORMED include the reply's tail — that is the

--- a/src/server/wfe_panel_verdict.c
+++ b/src/server/wfe_panel_verdict.c
@@ -1,10 +1,46 @@
-/* wfe_panel_verdict.c -- map a panel reviewer's reply to a roundtable verdict. */
+/* wfe_panel_verdict.c -- map a panel reviewer's reply to a roundtable verdict,
+ * and replay-verify a request_changes verdict's blocker citations against the
+ * worktree under review. */
 #include "wfe_panel_verdict.h"
 
 #include "cJSON.h"
 
 #include <stdio.h>
 #include <string.h>
+
+/* Copy the blockers array (if any) off the verdict JSON line. Entries without a
+ * non-empty file and a positive line are interpretive (nothing to replay) and
+ * are not stored; at most WFE_VERDICT_MAX_BLOCKERS are kept. */
+static void parse_blockers(const cJSON *doc, wfe_verdict_t *out)
+{
+   const cJSON *bl = cJSON_GetObjectItemCaseSensitive(doc, "blockers");
+   if (!bl || !cJSON_IsArray(bl))
+      return;
+   const cJSON *b = NULL;
+   cJSON_ArrayForEach(b, bl)
+   {
+      if (out->blocker_count >= WFE_VERDICT_MAX_BLOCKERS)
+         break;
+      if (!cJSON_IsObject(b))
+         continue;
+      const cJSON *f = cJSON_GetObjectItemCaseSensitive(b, "file");
+      const cJSON *ln = cJSON_GetObjectItemCaseSensitive(b, "line");
+      if (!f || !cJSON_IsString(f) || !f->valuestring || !f->valuestring[0])
+         continue;
+      if (!ln || !cJSON_IsNumber(ln) || ln->valueint < 1)
+         continue;
+      wfe_blocker_t *o = &out->blockers[out->blocker_count];
+      snprintf(o->file, sizeof o->file, "%s", f->valuestring);
+      o->line = ln->valueint;
+      const cJSON *q = cJSON_GetObjectItemCaseSensitive(b, "quote");
+      if (q && cJSON_IsString(q) && q->valuestring)
+         snprintf(o->quote, sizeof o->quote, "%s", q->valuestring);
+      const cJSON *s = cJSON_GetObjectItemCaseSensitive(b, "summary");
+      if (s && cJSON_IsString(s) && s->valuestring)
+         snprintf(o->summary, sizeof o->summary, "%s", s->valuestring);
+      out->blocker_count++;
+   }
+}
 
 void wfe_panel_verdict_from_review(const char *persona, const char *artifact_hash,
                                    const char *review_text, wfe_verdict_t *out)
@@ -93,5 +129,112 @@ void wfe_panel_verdict_from_review(const char *persona, const char *artifact_has
    const cJSON *hs = cJSON_GetObjectItemCaseSensitive(doc, "high_sev_blockers");
    if (hs && cJSON_IsNumber(hs) && hs->valueint > 0)
       out->high_sev_blockers = hs->valueint;
+   parse_blockers(doc, out);
    cJSON_Delete(doc);
+}
+
+/* Repo-relative only: no absolute paths and no ".." path component (a citation
+ * must point INSIDE the worktree under review). */
+static int citation_path_safe(const char *rel)
+{
+   if (!rel || !rel[0] || rel[0] == '/')
+      return 0;
+   for (const char *p = rel; *p; p++)
+   {
+      if (p[0] != '.' || p[1] != '.')
+         continue;
+      int at_start = (p == rel) || (p[-1] == '/');
+      int at_end = (p[2] == '\0') || (p[2] == '/');
+      if (at_start && at_end)
+         return 0;
+   }
+   return 1;
+}
+
+/* Does the blocker's citation reproduce in workdir/file? The file must exist
+ * and the cited line must exist in it; when a quote is given, its text must
+ * additionally appear within +/-2 lines of the cited line (the tolerance
+ * forgives an off-by-a-couple citation — reviewers count from a diff). A
+ * fabricated file, out-of-range line, or unmatched quote does not reproduce. */
+static int citation_reproduces(const char *workdir, const wfe_blocker_t *b)
+{
+   char quote[sizeof b->quote];
+   snprintf(quote, sizeof quote, "%s", b->quote);
+   char *q = quote;
+   while (*q == ' ' || *q == '\t')
+      q++;
+   for (char *p = q; *p; p++)
+      if (*p == '\n' || *p == '\r')
+      {
+         *p = '\0'; /* compare the first cited line only */
+         break;
+      }
+   size_t ql = strlen(q);
+   while (ql > 0 && (q[ql - 1] == ' ' || q[ql - 1] == '\t'))
+      q[--ql] = '\0';
+   if (!citation_path_safe(b->file))
+      return 0;
+
+   char path[512];
+   if (snprintf(path, sizeof path, "%s/%s", workdir, b->file) >= (int)sizeof path)
+      return 0;
+   FILE *fp = fopen(path, "r");
+   if (!fp)
+      return 0;
+   char linebuf[4096];
+   int lineno = 0, hit = 0;
+   while (fgets(linebuf, sizeof linebuf, fp))
+   {
+      lineno++;
+      if (ql == 0)
+      {
+         if (lineno >= b->line)
+         {
+            hit = 1; /* quote-less citation: the cited line exists */
+            break;
+         }
+         continue;
+      }
+      if (lineno > b->line + 2)
+         break;
+      if (lineno >= b->line - 2 && strstr(linebuf, q))
+      {
+         hit = 1;
+         break;
+      }
+   }
+   fclose(fp);
+   return hit;
+}
+
+int wfe_panel_blockers_verify(wfe_verdict_t *v, const char *workdir)
+{
+   if (!v || v->kind != WFE_V_REQUEST_CHANGES)
+      return 0;
+   if (!workdir || !workdir[0])
+      return v->blocker_count; /* nothing to replay against -> keep, unverified
+                                * (mirror INDEX_UNAVAILABLE: never penalize) */
+   int verified = 0;
+   for (int i = 0; i < v->blocker_count; i++)
+   {
+      v->blockers[i].verified = citation_reproduces(workdir, &v->blockers[i]);
+      verified += v->blockers[i].verified;
+   }
+   if (verified > 0)
+   {
+      /* re-ground the blocking weight to what actually reproduced */
+      v->high_sev_blockers = verified;
+      return verified;
+   }
+   /* No citation reproduced (or none was given): an interpretive objection can
+    * never block — re-grade to a non-blocking comment, exactly as the compute
+    * roundtable caps NO_EVIDENCE items and rejects CONTRADICTED ones. */
+   v->kind = WFE_V_COMMENT;
+   v->high_sev_blockers = 0;
+   size_t used = strlen(v->feedback);
+   snprintf(v->feedback + used, sizeof v->feedback - used,
+            "%s[panel-verify] request_changes re-graded to comment: no blocker citation "
+            "(file:line + exact quote) reproduced in the worktree",
+            used ? "\n" : "");
+   return 0;
 }

--- a/src/server/wfe_panel_verdict.h
+++ b/src/server/wfe_panel_verdict.h
@@ -17,4 +17,16 @@
 void wfe_panel_verdict_from_review(const char *persona, const char *artifact_hash,
                                    const char *review_text, wfe_verdict_t *out);
 
+/* Replay a REQUEST_CHANGES verdict's blocker citations against the worktree
+ * under review: each blocker must cite a repo-relative file:line that exists,
+ * and when it quotes text, that text must reproduce within +/-2 lines of the
+ * cited line. Sets each blocker's `verified` flag and
+ * re-grounds high_sev_blockers to the verified count. When NO citation
+ * reproduces the verdict is re-graded to WFE_V_COMMENT (an interpretive
+ * objection never blocks — the wfe twin of roundtable_grade_item's
+ * NO_EVIDENCE-caps / CONTRADICTED-rejects rule) and a note is appended to
+ * `feedback`. Verdicts of any other kind, and a NULL/empty workdir (nothing to
+ * replay against), are left untouched. Returns the verified-blocker count. */
+int wfe_panel_blockers_verify(wfe_verdict_t *v, const char *workdir);
+
 #endif /* DEC_WFE_PANEL_VERDICT_H */

--- a/src/tests/test_wfe_panel_verdict.c
+++ b/src/tests/test_wfe_panel_verdict.c
@@ -5,7 +5,10 @@
  * MALFORMED (never a default approve). */
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "server/wfe_panel_verdict.h"
 
@@ -14,6 +17,17 @@ static wfe_verdict_t map(const char *review)
    wfe_verdict_t v;
    wfe_panel_verdict_from_review("security", "HASH123", review, &v);
    return v;
+}
+
+/* A request_changes verdict citing one blocker at file:line with `quote`. */
+static wfe_verdict_t map_blocker(const char *file, int line, const char *quote)
+{
+   char review[512];
+   snprintf(review, sizeof review,
+            "found a bug.\n{\"verdict\":\"request_changes\",\"high_sev_blockers\":3,"
+            "\"blockers\":[{\"file\":\"%s\",\"line\":%d,\"quote\":\"%s\",\"summary\":\"bad\"}]}",
+            file, line, quote);
+   return map(review);
 }
 
 int main(void)
@@ -75,6 +89,113 @@ int main(void)
       wfe_verdict_t v;
       wfe_panel_verdict_from_review("qa", NULL, "{\"verdict\":\"approve\"}", &v);
       assert(v.kind == WFE_V_APPROVE && v.reviewed_content_hash[0] == '\0');
+   }
+
+   /* ---- blocker citations: parse ---- */
+   {
+      wfe_verdict_t v = map_blocker("src/a.c", 12, "free(p);");
+      assert(v.kind == WFE_V_REQUEST_CHANGES && v.blocker_count == 1);
+      assert(strcmp(v.blockers[0].file, "src/a.c") == 0 && v.blockers[0].line == 12);
+      assert(strcmp(v.blockers[0].quote, "free(p);") == 0);
+      assert(strcmp(v.blockers[0].summary, "bad") == 0 && v.blockers[0].verified == 0);
+   }
+   /* entries without a file or a positive line are interpretive -> not stored */
+   {
+      wfe_verdict_t v = map("x\n{\"verdict\":\"request_changes\",\"blockers\":["
+                            "{\"line\":3,\"quote\":\"q\"},{\"file\":\"a.c\",\"line\":0},"
+                            "{\"file\":\"a.c\",\"line\":7}]}");
+      assert(v.blocker_count == 1 && v.blockers[0].line == 7);
+   }
+   /* no blockers key -> zero */
+   assert(map("{\"verdict\":\"request_changes\"}").blocker_count == 0);
+
+   /* ---- blocker citations: replay against a worktree fixture ---- */
+   {
+      char dir[] = "/tmp/wfe-panel-verdict-XXXXXX";
+      assert(mkdtemp(dir) != NULL);
+      char sub[300], path[300];
+      snprintf(sub, sizeof sub, "%s/src", dir);
+      assert(mkdir(sub, 0755) == 0);
+      snprintf(path, sizeof path, "%s/src/a.c", dir);
+      FILE *fp = fopen(path, "w");
+      assert(fp);
+      fputs("int main(void)\n{\n   char *p = malloc(4);\n   free(p);\n   return 0;\n}\n", fp);
+      fclose(fp);
+
+      /* exact file:line + quote reproduces -> blocker stands, weight re-grounded */
+      {
+         wfe_verdict_t v = map_blocker("src/a.c", 4, "free(p);");
+         assert(wfe_panel_blockers_verify(&v, dir) == 1);
+         assert(v.kind == WFE_V_REQUEST_CHANGES && v.blockers[0].verified == 1);
+         assert(v.high_sev_blockers == 1); /* claimed 3, one reproduced */
+      }
+      /* off-by-two line still reproduces (diff-counting tolerance) */
+      {
+         wfe_verdict_t v = map_blocker("src/a.c", 6, "free(p);");
+         assert(wfe_panel_blockers_verify(&v, dir) == 1);
+      }
+      /* quote-less citation: cited line exists -> reproduces at the weak level */
+      {
+         wfe_verdict_t v = map_blocker("src/a.c", 4, "");
+         assert(wfe_panel_blockers_verify(&v, dir) == 1);
+      }
+      /* quote-less citation past EOF -> re-graded to comment */
+      {
+         wfe_verdict_t v = map_blocker("src/a.c", 40, "");
+         assert(wfe_panel_blockers_verify(&v, dir) == 0);
+         assert(v.kind == WFE_V_COMMENT && v.high_sev_blockers == 0);
+         assert(strstr(v.feedback, "[panel-verify]"));
+      }
+      /* fabricated quote -> re-graded to comment */
+      {
+         wfe_verdict_t v = map_blocker("src/a.c", 4, "unlock(&mu);");
+         assert(wfe_panel_blockers_verify(&v, dir) == 0 && v.kind == WFE_V_COMMENT);
+      }
+      /* fabricated file -> re-graded to comment */
+      {
+         wfe_verdict_t v = map_blocker("src/nope.c", 4, "free(p);");
+         assert(wfe_panel_blockers_verify(&v, dir) == 0 && v.kind == WFE_V_COMMENT);
+      }
+      /* traversal / absolute citations never reproduce */
+      {
+         wfe_verdict_t v = map_blocker("../a.c", 1, "int");
+         assert(wfe_panel_blockers_verify(&v, dir) == 0 && v.kind == WFE_V_COMMENT);
+         v = map_blocker("/etc/hostname", 1, "");
+         assert(v.blocker_count == 1); /* parsed, but... */
+         assert(wfe_panel_blockers_verify(&v, dir) == 0 && v.kind == WFE_V_COMMENT);
+      }
+      /* uncited request_changes (no blockers at all) can no longer block */
+      {
+         wfe_verdict_t v = map("bad vibes.\n{\"verdict\":\"request_changes\","
+                               "\"high_sev_blockers\":2}");
+         assert(wfe_panel_blockers_verify(&v, dir) == 0);
+         assert(v.kind == WFE_V_COMMENT && v.high_sev_blockers == 0);
+      }
+      /* one real + one fabricated citation: stands, unverified one discarded */
+      {
+         wfe_verdict_t v =
+             map("x\n{\"verdict\":\"request_changes\",\"high_sev_blockers\":2,\"blockers\":["
+                 "{\"file\":\"src/a.c\",\"line\":4,\"quote\":\"free(p);\"},"
+                 "{\"file\":\"src/ghost.c\",\"line\":9,\"quote\":\"boom\"}]}");
+         assert(wfe_panel_blockers_verify(&v, dir) == 1);
+         assert(v.kind == WFE_V_REQUEST_CHANGES && v.high_sev_blockers == 1);
+         assert(v.blockers[0].verified == 1 && v.blockers[1].verified == 0);
+      }
+      /* NULL/empty workdir: nothing to replay against -> verdict untouched */
+      {
+         wfe_verdict_t v = map_blocker("src/ghost.c", 9, "boom");
+         assert(wfe_panel_blockers_verify(&v, NULL) == 1);
+         assert(v.kind == WFE_V_REQUEST_CHANGES && v.high_sev_blockers == 3);
+      }
+      /* non-request_changes verdicts are never re-graded */
+      {
+         wfe_verdict_t v = map("{\"verdict\":\"approve\"}");
+         assert(wfe_panel_blockers_verify(&v, dir) == 0 && v.kind == WFE_V_APPROVE);
+      }
+
+      remove(path);
+      rmdir(sub);
+      rmdir(dir);
    }
 
    printf("ok\n");

--- a/src/workflow/wfe_verdict.h
+++ b/src/workflow/wfe_verdict.h
@@ -21,6 +21,25 @@ typedef enum
    WFE_V_MALFORMED /* unparseable/empty -> fail-closed to REQUEST_CHANGES */
 } wfe_verdict_kind_t;
 
+/* A request_changes verdict carries its blocking findings as CITATIONS: a
+ * repo-relative file, a 1-based line, and the exact text the reviewer claims at
+ * that line. The panel provider replays each citation against the worktree under
+ * review (wfe_panel_blockers_verify): a citation that does not reproduce is
+ * discarded, and a request_changes with NO reproducible citation is re-graded to
+ * a non-blocking comment — the same rule the compute roundtable enforces via
+ * evidence_replay (interpretation never blocks; contradicted claims are
+ * rejected). */
+#define WFE_VERDICT_MAX_BLOCKERS 8
+
+typedef struct
+{
+   char file[160];    /* repo-relative path the blocker cites */
+   int line;          /* 1-based line the blocker cites */
+   char quote[128];   /* exact text claimed at file:line ("" = uncited) */
+   char summary[128]; /* why this blocks */
+   int verified;      /* citation reproduced in the worktree (set by verify) */
+} wfe_blocker_t;
+
 typedef struct
 {
    char persona[32];
@@ -31,6 +50,8 @@ typedef struct
    int high_sev_blockers;                   /* count of unresolved high-severity blockers */
    char feedback[WFE_VERDICT_FEEDBACK_MAX]; /* the panelist's critique text (reasoning before
                                              * the JSON verdict line); may be empty */
+   wfe_blocker_t blockers[WFE_VERDICT_MAX_BLOCKERS]; /* cited blocking findings */
+   int blocker_count;
 } wfe_verdict_t;
 
 typedef enum


### PR DESCRIPTION
## Problem
A hallucinated reviewer objection can block a work item round after round: the wfe `rt_gate` live panel takes a bare `{"verdict":"request_changes"}` line at face value. The codebase already has the rule that fixes this — the compute roundtable's replayable-verification pass (`roundtable_verify.c`: interpretive items can never block, contradicted claims are rejected) — but the wfe panel path never went through it.

## Change
- The panel prompt for a **code review** now requires a `request_changes` verdict line to carry `"blockers":[{"file","line","quote","summary"}]` — real evidence for every blocker.
- `wfe_panel_blockers_verify()` replays each citation against the worktree under review: the cited file must exist and the cited line must exist in it; when text is quoted, it must reproduce within ±2 lines of the cited line (diff-counting tolerance). Citations are repo-relative only — absolute paths and `..` components never verify.
- Unverifiable blockers are discarded and `high_sev_blockers` is re-grounded to the verified count. A `request_changes` with **no** reproducible citation is re-graded to a non-blocking `comment`; the re-grade is appended to the feedback threaded back to the implementer and WARN-logged for triage.
- **Unchanged semantics preserved:** plan/proposal gates (no diff) are exempt — nothing to cite lines in, their `request_changes` stands. MALFORMED replies still fail closed. Verdicts other than `request_changes` are never touched, and an empty workdir keeps the verdict unverified rather than penalized (the INDEX_UNAVAILABLE analog).

## Tests
`unit-test-wfe-panel-verdict` extended: blocker parsing (missing file/line entries skipped), exact and ±2-line quote reproduction, quote-less file:line existence check, fabricated file/line/quote → re-graded to comment, traversal/absolute rejection, uncited request_changes can no longer block, partial verification re-grounds the blocker count, NULL workdir and non-request_changes verdicts untouched. `unit-test-wfe-roundtable` and `unit-test-wfe-autonomy` still green.