### PR TITLE
wfe forge: push over the origin's HTTPS URL, not an SSH origin

### DIFF
--- a/src/headers/git_pr_api.h
+++ b/src/headers/git_pr_api.h
@@ -20,6 +20,14 @@
 int git_pr_create_via_api(const char *principal, const char *repo_dir, const char *title,
                           const char *body, char *out, size_t out_cap, char *err, size_t errlen);
 
+/* Resolve repo_dir's `origin` to its canonical HTTPS URL
+ * (https://github.com/<owner>/<repo>.git), regardless of whether origin is an
+ * https or an SSH/scp URL. Lets a git network op push over HTTPS — where the
+ * vaulted forge token authenticates via the askpass shim — instead of over an
+ * SSH origin the server has no key for. Returns 0 + out, or -1 + err. */
+int git_pr_https_origin_url(const char *repo_dir, char *out, size_t out_cap, char *err,
+                            size_t errlen);
+
 /* Like git_pr_create_via_api, but with an EXPLICIT head branch and base — the
  * head need not be checked out in repo_dir (the wfe forge opens PRs for
  * work-item branches while the shared checkout sits on the base). NULL/"" head

--- a/src/posix/agent_bridge.c
+++ b/src/posix/agent_bridge.c
@@ -447,9 +447,15 @@ static int send_request(http_conn_t *conn, const char *method, const parsed_url_
          off += n;
    }
 
-   if (content_type)
+   if (content_type && content_type[0])
    {
-      int n = snprintf(req + off, cap - (size_t)off, "%s\r\n", content_type);
+      /* Accept either a full header line ("Content-Type: application/json") or a
+       * bare media type ("application/json"): callers pass both conventions. A
+       * bare value emitted verbatim is a header line with no field name — an
+       * invalid HTTP header that some servers (e.g. api.github.com) reject with
+       * 400 before parsing the body. Prefix the field name when it is absent. */
+      const char *prefix = strchr(content_type, ':') ? "" : "Content-Type: ";
+      int n = snprintf(req + off, cap - (size_t)off, "%s%s\r\n", prefix, content_type);
       if (n > 0 && (size_t)off + (size_t)n < cap)
          off += n;
    }

--- a/src/server/git_pr_api.c
+++ b/src/server/git_pr_api.c
@@ -234,6 +234,34 @@ int git_pr_create_via_api(const char *principal, const char *repo_dir, const cha
                                    errlen);
 }
 
+int git_pr_https_origin_url(const char *repo_dir, char *out, size_t out_cap, char *err,
+                            size_t errlen)
+{
+   if (out && out_cap)
+      out[0] = '\0';
+   if (err && errlen)
+      err[0] = '\0';
+   char origin[1024];
+   if (git_cap(repo_dir, "config --get remote.origin.url", origin, sizeof(origin)) != 0)
+   {
+      snprintf(err, errlen, "no origin remote");
+      return -1;
+   }
+   char owner[128], repo[128];
+   if (parse_github_slug(origin, owner, sizeof(owner), repo, sizeof(repo)) != 0)
+   {
+      snprintf(err, errlen, "requires a github.com origin");
+      return -1;
+   }
+   if ((size_t)snprintf(out, out_cap, "https://github.com/%s/%s.git", owner, repo) >= out_cap)
+   {
+      snprintf(err, errlen, "url too long");
+      out[0] = '\0';
+      return -1;
+   }
+   return 0;
+}
+
 int git_pr_create_via_api_ex(const char *principal, const char *repo_dir, const char *head_in,
                              const char *base_in, const char *title, const char *body, char *out,
                              size_t out_cap, char *err, size_t errlen)

--- a/src/server/wfe_live_forge.c
+++ b/src/server/wfe_live_forge.c
@@ -47,12 +47,29 @@ static const char *forge_dir(const char *repo)
  * token rides a CLOEXEC memfd duplicated onto GIT_CRED_TOKEN_TARGET_FD in the
  * git child, where the askpass shim reads it — it never enters the child's
  * environment or argv (the same FD mode git_ops uses). NULL principal resolves
- * per-host vault -> server forge identity. */
+ * per-host vault -> server forge identity.
+ *
+ * The push targets the origin's canonical HTTPS URL, NOT the literal `origin`
+ * remote: a workspace whose origin is an SSH URL (git@github.com:...) would make
+ * git use SSH keys the server has no reason to hold, bypassing the token entirely
+ * (this bit s2 — "Permission denied (publickey)"). Pushing to the HTTPS URL makes
+ * git request the credential the askpass supplies. The same HTTPS URL is passed
+ * as remote_url so per-host token resolution is unambiguous. */
 static int forge_push_branch(const char *dir, const char *branch, const char *what)
 {
-   const char *argv[] = {"git", "-C", dir, "push", "-u", "origin", branch, NULL};
+   char url[512], err[200];
+   if (git_pr_https_origin_url(dir, url, sizeof url, err, sizeof err) != 0)
+   {
+      aimee_log(LOG_WARN, "wfe-forge", "%s %s: resolve https origin: %s", what, branch, err);
+      return -1;
+   }
+   /* Explicit refspec: push the local branch to the same-named remote branch,
+    * independent of any upstream tracking config in the shared checkout. */
+   char refspec[300];
+   snprintf(refspec, sizeof refspec, "%s:refs/heads/%s", branch, branch);
+   const char *argv[] = {"git", "-C", dir, "push", url, refspec, NULL};
    int token_fd = -1;
-   char **envp = git_cred_inject_build_env_for_repo(NULL, NULL, dir, NULL, environ, &token_fd);
+   char **envp = git_cred_inject_build_env_for_repo(NULL, url, dir, NULL, environ, &token_fd);
    char *out = NULL;
    int rc = safe_exec_capture_cwd_env_fd_timeout(argv, dir, envp ? envp : environ, &out, 1 << 16,
                                                  120000, token_fd,

--- a/src/windows/agent_bridge.c
+++ b/src/windows/agent_bridge.c
@@ -75,9 +75,13 @@ int agent_http_post_content_type(const char *url, const char *auth_header, const
       return -1;
    }
 
-   /* Add headers */
-   const char *ct =
+   /* Add headers. Accept a full header line or a bare media type: WinHttp needs a
+    * complete "Field: value" line, so prefix "Content-Type: " when the caller
+    * passed only the media type (mirrors the POSIX path). */
+   const char *ct_in =
        content_type && content_type[0] ? content_type : "Content-Type: application/json";
+   char ct[256];
+   snprintf(ct, sizeof ct, "%s%s", strchr(ct_in, ':') ? "" : "Content-Type: ", ct_in);
    wchar_t wct[512];
    MultiByteToWideChar(CP_UTF8, 0, ct, -1, wct, 512);
    WinHttpAddRequestHeaders(req, wct, -1, WINHTTP_ADDREQ_FLAG_ADD);


### PR DESCRIPTION
## Problem
s2's `pr` stage failed every push with `git@github.com: Permission denied (publickey)`. The workspace `origin` is an SSH URL (`git@github.com:rakuensoftware/aimee.git`), so git used SSH keys the server has no reason to hold and never consulted the vaulted forge token. The token exists (`host:github.com` in the server vault) and the in-process REST PR create already talks HTTPS — only the branch **push** was still bound to the origin remote's transport.

## Fix
`forge_push_branch` resolves the origin to its canonical HTTPS URL via new `git_pr_https_origin_url` (reusing the github-slug parser that already handles scp/SSH forms) and pushes to that URL with an explicit `<branch>:refs/heads/<branch>` refspec, passing the same URL as `remote_url` so per-host token resolution is unambiguous. The vaulted token still reaches git only through the CLOEXEC memfd askpass (FD mode) — never in the URL, argv, env, or logs. A non-github origin fails clean and the run parks.

## Validation
The credential path is confirmed present on the test box (server-vault `host:github.com` entry). This makes the forge independent of how a given workspace's `origin` is configured (SSH or HTTPS), which is the robust behavior for autonomous runs.

No unit harness links the live forge (integration-gated); `git_pr_https_origin_url` is a thin wrapper over the already-tested slug parser.