### PR TITLE
policy: no admin merge override, CI must be green, and delegates never run git/gh

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (178)
+## CLI-settable keys (179)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -194,6 +194,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `openai_model` | string | OpenAI model name. |
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
+| `require_aimee_git` | bool | Block a delegate from running `git` or `gh` in a shell (reads included) and redirect git/forge work to aimee's `git_*` tools, which execute on aimee-server where the forge credential stays in-process; delegates are also spawned without git/gh credentials. Note the env strip also drops SSH_AUTH_SOCK (no agent-backed SSH to any host) and neuters the global/system git config (default on). |
 | `require_aimee_memory` | bool | Block agent writes to external file-based agent-memory stores (~/.claude/projects/<slug>/memory/...) and redirect durable memories into aimee's memory system via `aimee memory store` (default on). |
 | `require_session_worktree` | bool | Fail closed on mutating ops outside an aimee-managed worktree (session-isolation guard; default off). |
 | `tool_output_max_bytes` | int | Per-result cap (bytes) on the model-visible tool output (read_file/bash/grep/glob/git_* results). 0 = built-in default (32768); any positive value is clamped to (0, 32768]. Set it lower to bound the bytes a single tool result adds to the prompt + history; the (default-off) context-economizer compresses older results to keep history bounded. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -163,6 +163,11 @@ CFG_KEY_DESC = {
     "require_aimee_memory": "Block agent writes to external file-based agent-memory stores "
     "(~/.claude/projects/<slug>/memory/...) and redirect durable memories into aimee's memory "
     "system via `aimee memory store` (default on).",
+    "require_aimee_git": "Block a delegate from running `git` or `gh` in a shell (reads "
+    "included) and redirect git/forge work to aimee's `git_*` tools, which execute on "
+    "aimee-server where the forge credential stays in-process; delegates are also spawned "
+    "without git/gh credentials. Note the env strip also drops SSH_AUTH_SOCK (no agent-backed "
+    "SSH to any host) and neuters the global/system git config (default on).",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress "
     "(memory/code preview envelope on primary ingress turns; default on).",

--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -946,7 +946,9 @@ static cJSON *marshal_graph_explain(int argc, char **argv)
 /* Roundtable authoring pipeline (pipeline.*). */
 static cJSON *marshal_pipeline_request(const char *method, int argc, char **argv)
 {
-   static const char *bool_flags[] = {"admin", NULL};
+   /* No bool flags: `--admin` was removed — a merge needing an admin override of
+    * branch protection is human-only (operator ruling 2026-07-15). */
+   static const char *bool_flags[] = {NULL};
    rpc_opts_t opts;
    rpc_parse(argc, argv, bool_flags, &opts);
 
@@ -1012,8 +1014,6 @@ static cJSON *marshal_pipeline_request(const char *method, int argc, char **argv
          cJSON_AddStringToObject(req, "reason", v);
       if ((v = rpc_get(&opts, "operator-principal")) && v[0])
          cJSON_AddStringToObject(req, "operator_principal", v);
-      if (rpc_get(&opts, "admin"))
-         cJSON_AddTrueToObject(req, "admin");
    }
    else /* status / cancel / resume / advance */
    {

--- a/src/cmd_hooks.c
+++ b/src/cmd_hooks.c
@@ -140,9 +140,24 @@ static void emit_pretool_rewrite_unsupported_json(int rewrite_rc, const char *re
  * classifier's documented bypasses; the full seal is a sandbox). On DENY the hook
  * emits the deny JSON and exit(0)s -- the Claude Code PreToolUse protocol for a
  * blocked tool (same channel as the memory-interception deny). */
+/* The require_aimee_git dial (default ON). An unreadable config reads as ENFORCING:
+ * a guard that fails open is not a guard. */
+static int require_aimee_git_on(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) != 0)
+      return 1;
+   return cfg.require_aimee_git;
+}
+
 static void s2_native_gate_pretool(const char *sid, const char *tool_name, const char *tool_input)
 {
-   if (!sid || !sid[0] || !tool_name || !tool_name[0])
+   /* Deliberately NOT gated on `sid`: the unconditional rules below (admin-merge
+    * override, no-git-in-a-shell) apply to every caller, and a session aimee spawned
+    * resolves no sid at all (provider_cli_adapter does not stamp one), so requiring
+    * one here would skip exactly the delegates these rules exist to cover. Only the
+    * binding-dependent S2 decision needs a sid, and it checks for one itself. */
+   if (!tool_name || !tool_name[0])
       return;
 
    /* Pull the shell command (Bash etc.) out of tool_input for inspection. Prefer the
@@ -166,22 +181,41 @@ static void s2_native_gate_pretool(const char *sid, const char *tool_name, const
    }
    int externalizes = wfe_native_tool_externalizes(tool_name, command);
    int forbidden = wfe_native_tool_forbidden(tool_name, command);
+   int shell_git = require_aimee_git_on() && wfe_shell_invokes_git(tool_name, command);
    free(cmd_heap);
 
    /* Forbidden outright: denied regardless of binding / delivery / enforce stage.
     * Checked before the binding lookup because no binding state can permit it. */
    if (forbidden)
    {
-      audit_log("s2-native-gate", "DENY-forbidden sid=%s tool=%s (admin merge override)", sid,
-                tool_name);
+      audit_log("s2-native-gate", "DENY-forbidden sid=%s tool=%s (admin merge override)",
+                (sid && sid[0]) ? sid : "-", tool_name);
       emit_pretool_deny_json(
           "aimee: merging with an admin override of branch protection is human-only. "
           "Open the PR and let a human decide; aimee's own merge paths have no bypass either.");
       exit(0);
    }
 
+   /* No git/gh in a shell: every git and forge action goes through aimee's git_*
+    * tools, which run on aimee-server where the forge credential stays in-process.
+    * Also checked before the binding lookup -- an unbound delegate is exactly the
+    * case this must cover, and the binding path would ALLOW it. */
+   if (shell_git)
+   {
+      audit_log("s2-native-gate", "DENY-shell-git sid=%s tool=%s", (sid && sid[0]) ? sid : "-",
+                tool_name);
+      emit_pretool_deny_json(
+          "aimee: delegates do not run git or gh directly — use aimee's git tools, which "
+          "execute on aimee-server: git_status, git_log, git_diff_summary, git_branch, "
+          "git_commit, git_push, git_pr, git_verify. (Operator: require_aimee_git: false "
+          "in aimee.yaml opts out.)");
+      exit(0);
+   }
+
    if (!externalizes)
       return; /* not an externalizing tool -> never gated */
+   if (!sid || !sid[0])
+      return; /* no session -> no binding to resolve; the S2 decision needs one */
 
    char wi[80] = "", stage[16] = "";
    int bg = db1_wfe_binding_get(sid, wi, sizeof wi, stage, sizeof stage);

--- a/src/cmd_hooks.c
+++ b/src/cmd_hooks.c
@@ -165,7 +165,21 @@ static void s2_native_gate_pretool(const char *sid, const char *tool_name, const
       }
    }
    int externalizes = wfe_native_tool_externalizes(tool_name, command);
+   int forbidden = wfe_native_tool_forbidden(tool_name, command);
    free(cmd_heap);
+
+   /* Forbidden outright: denied regardless of binding / delivery / enforce stage.
+    * Checked before the binding lookup because no binding state can permit it. */
+   if (forbidden)
+   {
+      audit_log("s2-native-gate", "DENY-forbidden sid=%s tool=%s (admin merge override)", sid,
+                tool_name);
+      emit_pretool_deny_json(
+          "aimee: merging with an admin override of branch protection is human-only. "
+          "Open the PR and let a human decide; aimee's own merge paths have no bypass either.");
+      exit(0);
+   }
+
    if (!externalizes)
       return; /* not an externalizing tool -> never gated */
 

--- a/src/config.c
+++ b/src/config.c
@@ -323,6 +323,7 @@ static const config_schema_entry_t config_schema[] = {
     {"code_span_max_lines", SCHEMA_INT, 0},
     {"require_session_worktree", SCHEMA_BOOL, 0},
     {"require_aimee_memory", SCHEMA_BOOL, 0},
+    {"require_aimee_git", SCHEMA_BOOL, 0},
     {"guardrails", SCHEMA_OBJECT, 0},
     {"toolsets", SCHEMA_OBJECT, 0},
     {"script", SCHEMA_OBJECT, 0},
@@ -732,6 +733,11 @@ static void config_set_defaults(config_t *cfg)
     * system, not external per-harness memory files. Explicit
     * `require_aimee_memory: false` bypasses (see cli_attention_guard.c). */
    cfg->require_aimee_memory = 1;
+   /* Default ON: a delegate never runs `git`/`gh` in a shell — git and forge
+    * actions go through aimee's git_* tools and execute on aimee-server, where
+    * the forge credential stays in-process. Explicit `require_aimee_git: false`
+    * bypasses (see wfe_native_gate.c). */
+   cfg->require_aimee_git = 1;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
     * gate (make virtual-context-eval-check) passes on synthetic and real
     * tool-heavy session fixtures. Rollback: set session.virtual_context.enabled

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -106,6 +106,7 @@ const config_field_t config_fields[] = {
     {"require_session_worktree", offsetof(config_t, require_session_worktree), sizeof(int), 0,
      CFG_BOOL},
     {"require_aimee_memory", offsetof(config_t, require_aimee_memory), sizeof(int), 0, CFG_BOOL},
+    {"require_aimee_git", offsetof(config_t, require_aimee_git), sizeof(int), 0, CFG_BOOL},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_pdf_ingest_enabled", offsetof(config_t, kb_pdf_ingest_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_pdf_vector_enabled", offsetof(config_t, kb_pdf_vector_enabled), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -864,6 +864,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "require_session_worktree", 0);
    if (!cfg->require_aimee_memory) /* default-on: persist only the opt-out */
       cJSON_AddBoolToObject(root, "require_aimee_memory", 0);
+   if (!cfg->require_aimee_git) /* default-on: persist only the opt-out */
+      cJSON_AddBoolToObject(root, "require_aimee_git", 0);
    /* typed_facts_enabled is KB-owned: persisted as kb.typed_facts.enabled by
     * config_save_kb_curator (still parsed at root for backward compat). */
    if (cfg->kb_pdf_ingest_enabled) /* default-off: persist only when enabled */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -423,8 +423,18 @@ typedef struct config
     * environment or argv. Reads are blocked too (git_status / git_log /
     * git_diff_summary / git_pr action=view cover them), so the rule is simply "no
     * git or gh in a shell" with no verb list to drift. Explicit false opts out.
-    * Defence in depth, not the whole defence: delegates are also spawned without
-    * git/gh credentials configured, so an evaded classifier still cannot push. */
+    *
+    * Two layers, neither of which is a proof: the classifier
+    * (wfe_shell_invokes_git) is a string match a determined agent can evade, and
+    * the env-strip at spawn (delegate_child_strip_forge_creds) removes the
+    * credentials we know how to name. Together they raise the cost sharply; they do
+    * not constitute a credential boundary.
+    *
+    * SIDE EFFECT worth knowing before enabling: the env-strip also drops
+    * SSH_AUTH_SOCK, so a delegate cannot use agent-backed SSH to ANY host — not
+    * just the forge. It also points GIT_CONFIG_GLOBAL/SYSTEM at /dev/null, so a
+    * delegate sees no global git config (including user.name/user.email; commits go
+    * through git_commit on the server, which supplies its own identity). */
    int require_aimee_git;
 
    /* Gateway tool-policing (P2): when on, the gateway strips subagent-spawning

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -417,6 +417,15 @@ typedef struct config
     * (~/.claude/projects/<slug>/memory/...), redirecting durable memories into
     * aimee's memory system (`aimee memory store`). Explicit false opts out. */
    int require_aimee_memory;
+   /* Forge-tooling guard (default on): a delegate may not run `git` or `gh` in a
+    * shell — every git/forge action goes through aimee's git_* tools and executes
+    * on aimee-server, where the forge credential lives and never reaches a child's
+    * environment or argv. Reads are blocked too (git_status / git_log /
+    * git_diff_summary / git_pr action=view cover them), so the rule is simply "no
+    * git or gh in a shell" with no verb list to drift. Explicit false opts out.
+    * Defence in depth, not the whole defence: delegates are also spawned without
+    * git/gh credentials configured, so an evaded classifier still cannot push. */
+   int require_aimee_git;
 
    /* Gateway tool-policing (P2): when on, the gateway strips subagent-spawning
     * tools (Task/Agent/spawn_agent/RemoteTrigger) from the inbound `tools` of a

--- a/src/headers/git_pr_api.h
+++ b/src/headers/git_pr_api.h
@@ -69,6 +69,17 @@ git_pr_ci_t git_pr_ci_via_api(const char *principal, const char *repo_dir, int n
  * queued/in-progress -> PENDING; else SUCCESS. */
 git_pr_ci_t git_pr_ci_grade_json(const char *check_runs_json, const char *combined_status_json);
 
+/* 1 if this CI verdict permits a merge, 0 if it must not (operator ruling
+ * 2026-07-15: a merge requires fully green CI). SUCCESS merges; NONE merges too —
+ * a PR with no CI reported has nothing to fail. PENDING, FAILURE and ERROR all
+ * refuse: "unknown" is never "pass".
+ *
+ * The single home for that ruling: every merge seam asks here rather than re-deriving
+ * it, so the three cannot drift apart. Each seam still chooses how to COME BACK from
+ * a refusal (the engine loops the node, the pipeline gate parks for the next
+ * advance) — only the go/no-go lives here. Pure; unit-tested. */
+int git_pr_ci_permits_merge(git_pr_ci_t ci);
+
 /* Squash-merge PUT /pulls/<n>/merge. Returns 0 merged, 1 already merged,
  * 2 not mergeable (405/409), -1 error. */
 int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number, char *err,

--- a/src/mcp_git_pr.c
+++ b/src/mcp_git_pr.c
@@ -265,11 +265,14 @@ cJSON *handle_git_pr(cJSON *args)
    {
       /* Policy-aware merge executor (authoring-pipeline #50). The caller passes
        * the PR number, optional merge_method (merge|squash|rebase, default
-       * merge), optional admin (gh pr merge --admin for branch-policy/CI-billing
-       * cases this repo hits), and optional expected_head_sha for drift safety
-       * (gh refuses the merge if the head moved). Captures executor/command/
-       * exit/output and the resulting merge SHA so the ledger has full
-       * evidence. */
+       * merge), and optional expected_head_sha for drift safety (gh refuses the
+       * merge if the head moved). Captures executor/command/exit/output and the
+       * resulting merge SHA so the ledger has full evidence.
+       *
+       * There is deliberately NO admin/bypass option: a merge that requires an
+       * admin override of branch protection is HUMAN-ONLY (operator ruling
+       * 2026-07-15). A protection-blocked merge fails here and parks for a
+       * human; it is never forced through. */
       cJSON *jnum = cJSON_GetObjectItemCaseSensitive(args, "number");
       if (!cJSON_IsNumber(jnum))
          return mcp_text("error: 'number' parameter is required for merge");
@@ -284,9 +287,6 @@ cJSON *handle_git_pr(cJSON *args)
          else if (strcmp(jmethod->valuestring, "rebase") == 0)
             mflag = "--rebase";
       }
-      cJSON *jadmin = cJSON_GetObjectItemCaseSensitive(args, "admin");
-      const char *admin = cJSON_IsTrue(jadmin) ? " --admin" : "";
-
       char match[160] = {0};
       cJSON *jhead = cJSON_GetObjectItemCaseSensitive(args, "expected_head_sha");
       if (cJSON_IsString(jhead) && jhead->valuestring[0])
@@ -304,8 +304,41 @@ cJSON *handle_git_pr(cJSON *args)
             snprintf(match, sizeof(match), " --match-head-commit %s", h);
       }
 
+      /* CI must be fully green before the merge (operator ruling 2026-07-15). Reuses
+       * the same `gh pr checks` read (and its 0/1/8 tri-state) as action=checks, so
+       * this stays correct for a detached workspace, where the command is marshalled
+       * to the client that holds the creds. A PR with zero reported checks merges
+       * (nothing to fail); anything pending, failed, or undetermined refuses — the
+       * caller can re-try once checks settle. */
+      {
+         char ccmd[128];
+         snprintf(ccmd, sizeof(ccmd), "gh pr checks %d 2>&1", pr_num);
+         int crc = 0;
+         char *cout = mcp_git_run(ccmd, &crc);
+         if (crc != 0 && crc != 1 && crc != 8) /* not a checks verdict -> undetermined */
+         {
+            cJSON *e = mcp_error("error: merge blocked — could not read CI status: %s",
+                                 cout ? cout : "unknown");
+            free(cout);
+            return e;
+         }
+         int total = 0, pending = 0, failed = 0, passed = 0;
+         if (cout)
+            checks_parse_plain_output(cout, &total, &pending, &failed, &passed);
+         free(cout);
+         if (failed > 0 || pending > 0)
+         {
+            char why[192];
+            snprintf(why, sizeof(why),
+                     "error: merge blocked — CI is not green (%d failed, %d pending, %d passed of "
+                     "%d). A merge requires fully green CI.",
+                     failed, pending, passed, total);
+            return mcp_text(why);
+         }
+      }
+
       char cmd[512];
-      snprintf(cmd, sizeof(cmd), "gh pr merge %d %s%s%s 2>&1", pr_num, mflag, admin, match);
+      snprintf(cmd, sizeof(cmd), "gh pr merge %d %s%s 2>&1", pr_num, mflag, match);
       int rc = 0;
       char *out = mcp_git_run(cmd, &rc);
       cJSON *res = cJSON_CreateObject();

--- a/src/mcp_git_pr.c
+++ b/src/mcp_git_pr.c
@@ -307,34 +307,42 @@ cJSON *handle_git_pr(cJSON *args)
       /* CI must be fully green before the merge (operator ruling 2026-07-15). Reuses
        * the same `gh pr checks` read (and its 0/1/8 tri-state) as action=checks, so
        * this stays correct for a detached workspace, where the command is marshalled
-       * to the client that holds the creds. A PR with zero reported checks merges
-       * (nothing to fail); anything pending, failed, or undetermined refuses — the
-       * caller can re-try once checks settle. */
+       * to the client that holds the creds.
+       *
+       * Fails CLOSED on anything it cannot positively classify. In particular the
+       * verdict is taken from gh's EXIT CODE, never inferred from parsed counters:
+       * a zero count means "no rows parsed", which is equally true of genuinely
+       * zero checks and of output we failed to understand (or a NULL from an alloc
+       * failure) — merging on that would be a fail-open. Only gh's own explicit
+       * "no checks reported" is accepted as genuinely zero, which the operator
+       * ruling says may merge (nothing to fail). */
       {
          char ccmd[128];
          snprintf(ccmd, sizeof(ccmd), "gh pr checks %d 2>&1", pr_num);
          int crc = 0;
          char *cout = mcp_git_run(ccmd, &crc);
-         if (crc != 0 && crc != 1 && crc != 8) /* not a checks verdict -> undetermined */
+         const char *why = NULL;
+         if (!cout)
+            why = "could not read CI status (no output)";
+         else if (strstr(cout, "no checks reported"))
+            why = NULL; /* genuinely zero checks -> nothing to fail -> merge */
+         else if (crc == 0)
+            why = NULL; /* gh: every check passed */
+         else if (crc == 8)
+            why = "CI has not finished; re-try once checks settle";
+         else if (crc == 1)
+            why = "CI is not green (at least one check failed)";
+         else
+            why = "could not read CI status";
+         if (why)
          {
-            cJSON *e = mcp_error("error: merge blocked — could not read CI status: %s",
-                                 cout ? cout : "unknown");
+            char msg[320];
+            snprintf(msg, sizeof(msg), "error: merge blocked — %s. A merge requires fully green CI.",
+                     why);
             free(cout);
-            return e;
+            return mcp_text(msg);
          }
-         int total = 0, pending = 0, failed = 0, passed = 0;
-         if (cout)
-            checks_parse_plain_output(cout, &total, &pending, &failed, &passed);
          free(cout);
-         if (failed > 0 || pending > 0)
-         {
-            char why[192];
-            snprintf(why, sizeof(why),
-                     "error: merge blocked — CI is not green (%d failed, %d pending, %d passed of "
-                     "%d). A merge requires fully green CI.",
-                     failed, pending, passed, total);
-            return mcp_text(why);
-         }
       }
 
       char cmd[512];

--- a/src/mcp_git_pr.c
+++ b/src/mcp_git_pr.c
@@ -337,8 +337,8 @@ cJSON *handle_git_pr(cJSON *args)
          if (why)
          {
             char msg[320];
-            snprintf(msg, sizeof(msg), "error: merge blocked — %s. A merge requires fully green CI.",
-                     why);
+            snprintf(msg, sizeof(msg),
+                     "error: merge blocked — %s. A merge requires fully green CI.", why);
             free(cout);
             return mcp_text(msg);
          }

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -730,8 +730,7 @@ cJSON *mcp_build_tools_list(void)
                   "\"reason\":{\"type\":\"string\",\"description\":\"Fail reason (folded into the "
                   "next review brief).\"},"
                   "\"operator_principal\":{\"type\":\"string\",\"description\":\"Enrolled local "
-                  "operator principal authorizing the gate.\"},"
-                  "\"admin\":{\"type\":\"boolean\",\"description\":\"Use gh pr merge --admin.\"}},"
+                  "operator principal authorizing the gate.\"}},"
                   "\"required\":[\"pipeline_id\",\"verdict\",\"operator_principal\"]}")));
 
       cJSON_AddItemToArray(

--- a/src/server/git_pr_ci_grade.c
+++ b/src/server/git_pr_ci_grade.c
@@ -7,6 +7,25 @@
 
 #include <string.h>
 
+int git_pr_ci_permits_merge(git_pr_ci_t ci)
+{
+   /* Enumerated, not a default: a new git_pr_ci_t value must be classified here
+    * deliberately rather than inheriting "may merge" by falling through. Lives beside
+    * the grader, not in git_pr_api.c, for the reason in this file's header: it is
+    * pure policy and must link into a unit test without the HTTP/credential stack. */
+   switch (ci)
+   {
+   case GIT_PR_CI_SUCCESS: /* every check green */
+   case GIT_PR_CI_NONE:    /* forge reported no CI at all -> nothing to fail */
+      return 1;
+   case GIT_PR_CI_PENDING: /* still running -> not yet green */
+   case GIT_PR_CI_FAILURE: /* red */
+   case GIT_PR_CI_ERROR:   /* undetermined -> never merge on an unknown state */
+      return 0;
+   }
+   return 0; /* unreachable for a valid enum; fail closed regardless */
+}
+
 /* One check run / one legacy status context graded into the aggregate. */
 static void ci_fold(const char *status, const char *conclusion, int *pending, int *failed,
                     int *seen)
@@ -28,14 +47,25 @@ static void ci_fold(const char *status, const char *conclusion, int *pending, in
    (*failed)++; /* failure / cancelled / timed_out / action_required / stale */
 }
 
+/* A payload that was PROVIDED must parse into the shape we expect. NONE means "the
+ * forge reported no CI", which git_pr_ci_permits_merge() treats as mergeable — so it
+ * must never be reachable from "we could not read the answer". An unparseable or
+ * unexpected body is ERROR (undetermined), which refuses. Both still park the gate.ci
+ * node identically (live_ci_status maps NONE and ERROR alike to WFE_CI_NONE), so this
+ * distinction costs that path nothing and closes a fail-open on the merge path. */
 git_pr_ci_t git_pr_ci_grade_json(const char *check_runs_json, const char *combined_status_json)
 {
    int pending = 0, failed = 0, seen = 0;
 
-   cJSON *cr = check_runs_json ? cJSON_Parse(check_runs_json) : NULL;
-   const cJSON *runs = cr ? cJSON_GetObjectItem(cr, "check_runs") : NULL;
-   if (cJSON_IsArray(runs))
+   if (check_runs_json && check_runs_json[0])
    {
+      cJSON *cr = cJSON_Parse(check_runs_json);
+      const cJSON *runs = cr ? cJSON_GetObjectItem(cr, "check_runs") : NULL;
+      if (!cJSON_IsArray(runs)) /* unparseable, or not a check-runs payload */
+      {
+         cJSON_Delete(cr);
+         return GIT_PR_CI_ERROR;
+      }
       const cJSON *r = NULL;
       cJSON_ArrayForEach(r, runs)
       {
@@ -44,14 +74,21 @@ git_pr_ci_t git_pr_ci_grade_json(const char *check_runs_json, const char *combin
          ci_fold(cJSON_IsString(st) ? st->valuestring : NULL,
                  cJSON_IsString(co) ? co->valuestring : NULL, &pending, &failed, &seen);
       }
+      cJSON_Delete(cr);
    }
-   cJSON_Delete(cr);
 
    if (seen == 0) /* no check runs: the legacy combined status decides */
    {
-      cJSON *cs = combined_status_json ? cJSON_Parse(combined_status_json) : NULL;
+      if (!combined_status_json || !combined_status_json[0])
+         return GIT_PR_CI_NONE; /* nothing reported anywhere */
+      cJSON *cs = cJSON_Parse(combined_status_json);
       const cJSON *statuses = cs ? cJSON_GetObjectItem(cs, "statuses") : NULL;
-      if (cJSON_IsArray(statuses) && cJSON_GetArraySize(statuses) > 0)
+      if (!cJSON_IsArray(statuses)) /* unparseable, or not a combined-status payload */
+      {
+         cJSON_Delete(cs);
+         return GIT_PR_CI_ERROR;
+      }
+      if (cJSON_GetArraySize(statuses) > 0)
       {
          const cJSON *state = cJSON_GetObjectItem(cs, "state");
          const char *v = cJSON_IsString(state) ? state->valuestring : "";
@@ -62,7 +99,7 @@ git_pr_ci_t git_pr_ci_grade_json(const char *check_runs_json, const char *combin
          return g;
       }
       cJSON_Delete(cs);
-      return GIT_PR_CI_NONE;
+      return GIT_PR_CI_NONE; /* genuinely zero checks */
    }
    if (failed > 0)
       return GIT_PR_CI_FAILURE;

--- a/src/server/provider_cli_adapter.c
+++ b/src/server/provider_cli_adapter.c
@@ -353,17 +353,25 @@ static void provider_cli_terminate_child(pid_t pid)
    (void)waitpid(pid, NULL, 0);
 }
 
-/* Strip every git/forge credential from a delegate child's environment, so a
- * delegate is not merely FORBIDDEN from running git/gh (wfe_shell_invokes_git) but
- * is incapable of authenticating one: the classifier is a string match a determined
- * agent can evade, whereas an absent credential cannot be talked around. git/forge
- * work belongs to aimee's git_* tools, which run in aimee-server where the token is
- * resolved per-call and lives only in process memory.
+/* Remove the git/forge credentials a delegate child would otherwise inherit, so the
+ * no-git rule does not rest on the classifier alone: wfe_shell_invokes_git() is a
+ * string match over a shell line and a determined agent can evade it, whereas a
+ * credential that is not in the environment cannot be talked around. git/forge work
+ * belongs to aimee's git_* tools, which run in aimee-server where the token is
+ * resolved per call and lives only in process memory.
  *
- * Called post-fork, so it must stay allocation-free and syscall-only: `flag` is
- * resolved by the PARENT (config_load reads files and allocates; running it between
- * fork and exec in a threaded process risks a malloc-lock deadlock). setenv/unsetenv
- * may allocate in theory, but the surrounding code already relies on them. */
+ * This is defence in depth, NOT a credential boundary. It removes what we know how
+ * to name; it cannot prove the child has no other path to a token (a key on disk, a
+ * helper we do not enumerate, a credential minted later). Treat it as raising the
+ * cost, not as a guarantee.
+ *
+ * Called post-fork. `flag` is resolved by the PARENT because config_load reads files
+ * and allocates, and running that between fork and exec in a threaded process risks
+ * a malloc-lock deadlock. setenv/unsetenv may themselves allocate, so this is not
+ * strictly async-signal-safe either -- it matches the risk the adjacent
+ * unsetenv()/platform_setenv() calls already take here rather than adding a new one.
+ * The clean fix, if this ever bites, is to build the sanitized envp in the parent
+ * and execve() it. */
 static void delegate_child_strip_forge_creds(int flag)
 {
    if (!flag)
@@ -374,7 +382,12 @@ static void delegate_child_strip_forge_creds(int flag)
    unsetenv("GH_ENTERPRISE_TOKEN");
    unsetenv("GITHUB_ENTERPRISE_TOKEN");
    /* Credential plumbing: the askpass shim, an agent-forwarded SSH key, and any
-    * inherited credential helper reachable via the global/system git config. */
+    * inherited credential helper reachable via the global/system git config.
+    * SSH_AUTH_SOCK is broader than git: dropping it means a delegate cannot use
+    * agent-backed SSH to ANY host, not just the forge. That is intended (a forwarded
+    * agent is a general-purpose credential we do not want in a delegate), but it is
+    * the one strip here that can bite non-git work -- see require_aimee_git in
+    * config.h. */
    unsetenv("GIT_ASKPASS");
    unsetenv("SSH_ASKPASS");
    unsetenv("SSH_AUTH_SOCK");

--- a/src/server/provider_cli_adapter.c
+++ b/src/server/provider_cli_adapter.c
@@ -353,11 +353,50 @@ static void provider_cli_terminate_child(pid_t pid)
    (void)waitpid(pid, NULL, 0);
 }
 
+/* Strip every git/forge credential from a delegate child's environment, so a
+ * delegate is not merely FORBIDDEN from running git/gh (wfe_shell_invokes_git) but
+ * is incapable of authenticating one: the classifier is a string match a determined
+ * agent can evade, whereas an absent credential cannot be talked around. git/forge
+ * work belongs to aimee's git_* tools, which run in aimee-server where the token is
+ * resolved per-call and lives only in process memory.
+ *
+ * Called post-fork, so it must stay allocation-free and syscall-only: `flag` is
+ * resolved by the PARENT (config_load reads files and allocates; running it between
+ * fork and exec in a threaded process risks a malloc-lock deadlock). setenv/unsetenv
+ * may allocate in theory, but the surrounding code already relies on them. */
+static void delegate_child_strip_forge_creds(int flag)
+{
+   if (!flag)
+      return;
+   /* Ambient forge tokens gh/git would pick up. */
+   unsetenv("GH_TOKEN");
+   unsetenv("GITHUB_TOKEN");
+   unsetenv("GH_ENTERPRISE_TOKEN");
+   unsetenv("GITHUB_ENTERPRISE_TOKEN");
+   /* Credential plumbing: the askpass shim, an agent-forwarded SSH key, and any
+    * inherited credential helper reachable via the global/system git config. */
+   unsetenv("GIT_ASKPASS");
+   unsetenv("SSH_ASKPASS");
+   unsetenv("SSH_AUTH_SOCK");
+   setenv("GIT_CONFIG_GLOBAL", "/dev/null", 1);
+   setenv("GIT_CONFIG_SYSTEM", "/dev/null", 1);
+   /* gh reads its stored oauth token from GH_CONFIG_DIR (default ~/.config/gh);
+    * point it at a path that holds no hosts.yml rather than leaving the default. */
+   setenv("GH_CONFIG_DIR", "/nonexistent/aimee-delegate-no-gh", 1);
+   /* Never let a credential prompt block the child waiting on a tty. */
+   setenv("GIT_TERMINAL_PROMPT", "0", 1);
+}
+
 int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], int *stdin_fd,
                             int *stdout_fd, pid_t *pid_out)
 {
    if (!argv || !argv[0] || !stdin_fd || !stdout_fd || !pid_out)
       return -1;
+
+   /* Resolve the dial BEFORE forking (see delegate_child_strip_forge_creds).
+    * Unreadable config reads as enforcing: a guard that fails open is not a guard. */
+   config_t spawn_cfg;
+   int strip_forge_creds = (config_load(&spawn_cfg) != 0) || spawn_cfg.require_aimee_git;
 
    int in_pipe[2] = {-1, -1};
    int out_pipe[2] = {-1, -1};
@@ -404,6 +443,7 @@ int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], i
        * source context from the forking thread's TLS, immune to the parent-side
        * concurrent env clobber. */
       delegate_child_export_context_env();
+      delegate_child_strip_forge_creds(strip_forge_creds);
       execvp(argv[0], argv);
       _exit(127);
    }

--- a/src/server/s2_native_gate_hook.c
+++ b/src/server/s2_native_gate_hook.c
@@ -7,6 +7,7 @@
 
 #include "audit_action.h"
 #include "cJSON.h"
+#include "config.h" /* require_aimee_git */
 #include "log.h"
 #include "wfe_binding.h"     /* db1_wfe_binding_get */
 #include "wfe_enforce.h"     /* the enforce dial */
@@ -26,11 +27,25 @@ int hook_send_blocked(server_conn_t *conn, const char *msg, const char *request_
    return r;
 }
 
+/* The require_aimee_git dial (default ON). An unreadable config reads as ENFORCING:
+ * a guard that fails open is not a guard. */
+static int require_aimee_git_on(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) != 0)
+      return 1;
+   return cfg.require_aimee_git;
+}
+
 /* The decision: 2 = deny (fills msg), 0 = allow. */
 static int s2_decide(const char *sid, const char *tool_name, const char *tool_input, char *msg,
                      size_t msg_n)
 {
-   if (!sid || !sid[0] || strcmp(sid, "unknown") == 0 || !tool_name || !tool_name[0])
+   /* Deliberately NOT gated on `sid`: the unconditional rules below (admin-merge
+    * override, no-git-in-a-shell) apply to every caller, and a session aimee spawned
+    * resolves no sid at all, so requiring one here would skip exactly the delegates
+    * these rules exist to cover. Only the binding-dependent decision needs a sid. */
+   if (!tool_name || !tool_name[0])
       return 0;
 
    char *cmd_heap = NULL;
@@ -48,14 +63,15 @@ static int s2_decide(const char *sid, const char *tool_name, const char *tool_in
    }
    int externalizes = wfe_native_tool_externalizes(tool_name, command);
    int forbidden = wfe_native_tool_forbidden(tool_name, command);
+   int shell_git = require_aimee_git_on() && wfe_shell_invokes_git(tool_name, command);
    free(cmd_heap);
 
    /* Forbidden outright: denied regardless of binding / delivery / enforce stage.
     * Checked before the binding lookup because no binding state can permit it. */
    if (forbidden)
    {
-      audit_log("s2-native-gate", "DENY-forbidden sid=%s tool=%s (admin merge override)", sid,
-                tool_name);
+      audit_log("s2-native-gate", "DENY-forbidden sid=%s tool=%s (admin merge override)",
+                (sid && sid[0]) ? sid : "-", tool_name);
       snprintf(msg, msg_n,
                "aimee: merging with an admin override of branch protection is human-only. "
                "Open the PR and let a human decide; aimee's own merge paths have no bypass "
@@ -63,7 +79,26 @@ static int s2_decide(const char *sid, const char *tool_name, const char *tool_in
       return 2;
    }
 
+   /* No git/gh in a shell: every git and forge action goes through aimee's git_*
+    * tools, which run on aimee-server where the forge credential stays in-process.
+    * Also checked before the binding lookup -- an unbound delegate is exactly the
+    * case this must cover, and the binding path would ALLOW it. */
+   if (shell_git)
+   {
+      audit_log("s2-native-gate", "DENY-shell-git sid=%s tool=%s", (sid && sid[0]) ? sid : "-",
+                tool_name);
+      snprintf(msg, msg_n,
+               "aimee: delegates do not run git or gh directly — use aimee's git tools, which "
+               "execute on aimee-server: git_status, git_log, git_diff_summary, git_branch, "
+               "git_commit, git_push, git_pr, git_verify. (Operator: require_aimee_git: false "
+               "in aimee.yaml opts out.)");
+      return 2;
+   }
+
    if (!externalizes)
+      return 0;
+   /* The binding-dependent decision needs a resolvable session. */
+   if (!sid || !sid[0] || strcmp(sid, "unknown") == 0)
       return 0;
 
    char wi[80] = "", stage[16] = "";

--- a/src/server/s2_native_gate_hook.c
+++ b/src/server/s2_native_gate_hook.c
@@ -47,7 +47,22 @@ static int s2_decide(const char *sid, const char *tool_name, const char *tool_in
       }
    }
    int externalizes = wfe_native_tool_externalizes(tool_name, command);
+   int forbidden = wfe_native_tool_forbidden(tool_name, command);
    free(cmd_heap);
+
+   /* Forbidden outright: denied regardless of binding / delivery / enforce stage.
+    * Checked before the binding lookup because no binding state can permit it. */
+   if (forbidden)
+   {
+      audit_log("s2-native-gate", "DENY-forbidden sid=%s tool=%s (admin merge override)", sid,
+                tool_name);
+      snprintf(msg, msg_n,
+               "aimee: merging with an admin override of branch protection is human-only. "
+               "Open the PR and let a human decide; aimee's own merge paths have no bypass "
+               "either.");
+      return 2;
+   }
+
    if (!externalizes)
       return 0;
 

--- a/src/server/server_pipeline_merge.c
+++ b/src/server/server_pipeline_merge.c
@@ -85,21 +85,14 @@ int validate_pr_for_merge(rtp_run_t *run, rtp_gate_t *gate, int gate_no, cJSON *
    if (!why)
    {
       char cierr[160];
-      switch (git_pr_ci_via_api(NULL, rtp_git_cwd(run), gate->pr_number, cierr, sizeof(cierr)))
-      {
-      case GIT_PR_CI_SUCCESS:
-      case GIT_PR_CI_NONE:
-         break;
-      case GIT_PR_CI_PENDING:
-         why = "CI has not finished; verdict preserved, re-check once checks settle";
-         break;
-      case GIT_PR_CI_FAILURE:
-         why = "CI is not green; a merge requires fully green CI";
-         break;
-      default: /* GIT_PR_CI_ERROR */
-         why = "CI status could not be determined; verdict preserved, retry later";
-         break;
-      }
+      git_pr_ci_t ci = git_pr_ci_via_api(NULL, rtp_git_cwd(run), gate->pr_number, cierr,
+                                         sizeof(cierr));
+      if (!git_pr_ci_permits_merge(ci))
+         why = ci == GIT_PR_CI_PENDING
+                   ? "CI has not finished; verdict preserved, re-check once checks settle"
+                   : (ci == GIT_PR_CI_FAILURE
+                          ? "CI is not green; a merge requires fully green CI"
+                          : "CI status could not be determined; verdict preserved, retry later");
    }
 
    if (why)

--- a/src/server/server_pipeline_merge.c
+++ b/src/server/server_pipeline_merge.c
@@ -5,6 +5,7 @@
 #include "server_pipeline.h"
 #include "cJSON.h"
 #include "config.h"
+#include "git_pr_api.h" /* in-process GitHub REST: the CI verdict for the merge gate */
 #include "json_fluent.h"
 #include "log.h"
 #include "mcp_git.h"
@@ -75,6 +76,32 @@ int validate_pr_for_merge(rtp_run_t *run, rtp_gate_t *gate, int gate_no, cJSON *
        * attempting a merge against an unknown state. */
       why = "PR mergeability not yet known (UNKNOWN); verdict preserved, re-check shortly";
    cJSON_Delete(j);
+
+   /* CI must be fully green before a merge (operator ruling 2026-07-15). Read the
+    * verdict in-process from the Checks API rather than shelling `gh pr checks`, so
+    * the forge token stays in aimee-server's memory. A PR with zero reported checks
+    * merges (nothing to fail); PENDING and an undetermined verdict both park —
+    * "unknown" is never "pass", consistent with the UNKNOWN-mergeability rule above. */
+   if (!why)
+   {
+      char cierr[160];
+      switch (git_pr_ci_via_api(NULL, rtp_git_cwd(run), gate->pr_number, cierr, sizeof(cierr)))
+      {
+      case GIT_PR_CI_SUCCESS:
+      case GIT_PR_CI_NONE:
+         break;
+      case GIT_PR_CI_PENDING:
+         why = "CI has not finished; verdict preserved, re-check once checks settle";
+         break;
+      case GIT_PR_CI_FAILURE:
+         why = "CI is not green; a merge requires fully green CI";
+         break;
+      default: /* GIT_PR_CI_ERROR */
+         why = "CI status could not be determined; verdict preserved, retry later";
+         break;
+      }
+   }
+
    if (why)
    {
       cJSON_AddBoolToObject(resp, "merged", 0);
@@ -266,9 +293,12 @@ void execute_gate_merge(int id, rtp_run_t *run, rtp_gate_t *gate, int gate_no, c
 
    /* Policy-aware merge executor (#50), pinned to the recorded checkout (#3) and
     * keyed by the approved head SHA (--match-head-commit) so a drift between the
-    * pre-check and the merge still refuses (idempotent for #55). */
-   const char *admin =
-       cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "admin")) ? " --admin" : "";
+    * pre-check and the merge still refuses (idempotent for #55).
+    *
+    * No admin/bypass path exists: a merge that requires an admin override of
+    * branch protection is HUMAN-ONLY (operator ruling 2026-07-15). When
+    * protection refuses, the merge fails and the verdict is preserved in
+    * *_merge_pending for a human — never forced through. */
    char match[160] = {0};
    if (gate->expected_head_sha[0])
    {
@@ -278,8 +308,7 @@ void execute_gate_merge(int id, rtp_run_t *run, rtp_gate_t *gate, int gate_no, c
    }
    char cmd[RTP_PATH_LEN + 256];
    size_t pfx = rtp_cd_prefix(run, cmd, sizeof(cmd));
-   snprintf(cmd + pfx, sizeof(cmd) - pfx, "gh pr merge %d --merge%s%s 2>&1", gate->pr_number, admin,
-            match);
+   snprintf(cmd + pfx, sizeof(cmd) - pfx, "gh pr merge %d --merge%s 2>&1", gate->pr_number, match);
    int exit_code = 0;
    char *out = mcp_git_run(cmd, &exit_code);
    int merged = (exit_code == 0);
@@ -307,8 +336,8 @@ void execute_gate_merge(int id, rtp_run_t *run, rtp_gate_t *gate, int gate_no, c
       }
    }
    snprintf(gate->merge_executor, sizeof(gate->merge_executor), "gh pr merge");
-   snprintf(gate->merge_command, sizeof(gate->merge_command), "gh pr merge %d --merge%s%s",
-            gate->pr_number, admin, match);
+   snprintf(gate->merge_command, sizeof(gate->merge_command), "gh pr merge %d --merge%s",
+            gate->pr_number, match);
    gate->merge_exit_code = exit_code;
    rtp_gate_update(gate);
 

--- a/src/server/server_pipeline_merge.c
+++ b/src/server/server_pipeline_merge.c
@@ -85,8 +85,8 @@ int validate_pr_for_merge(rtp_run_t *run, rtp_gate_t *gate, int gate_no, cJSON *
    if (!why)
    {
       char cierr[160];
-      git_pr_ci_t ci = git_pr_ci_via_api(NULL, rtp_git_cwd(run), gate->pr_number, cierr,
-                                         sizeof(cierr));
+      git_pr_ci_t ci =
+          git_pr_ci_via_api(NULL, rtp_git_cwd(run), gate->pr_number, cierr, sizeof(cierr));
       if (!git_pr_ci_permits_merge(ci))
          why = ci == GIT_PR_CI_PENDING
                    ? "CI has not finished; verdict preserved, re-check once checks settle"

--- a/src/server/wfe_live_forge.c
+++ b/src/server/wfe_live_forge.c
@@ -188,6 +188,35 @@ static wfe_merge_result_t live_merge(const char *repo, const char *pr)
    int num = pr ? atoi(pr) : 0;
    if (num <= 0)
       return WFE_MERGE_ERROR;
+
+   /* CI must be green before we merge (operator ruling 2026-07-15). The canonical
+    * `build` DAG already orders a ci node ahead of merge, so this is defence in
+    * depth at the seam itself -- the same rationale as forge_allowed() re-checking
+    * on every op: the forge must be safe on its own, not only when driven by a
+    * well-ordered workflow. A zero-check PR merges (nothing to fail); an
+    * undetermined verdict never does. */
+   char cierr[160];
+   switch (git_pr_ci_via_api(NULL, forge_dir(repo), num, cierr, sizeof cierr))
+   {
+   case GIT_PR_CI_SUCCESS:
+   case GIT_PR_CI_NONE: /* no CI reported for the head commit -> nothing to fail */
+      break;
+   case GIT_PR_CI_PENDING:
+      /* Still running: retry the node rather than park -- the engine loops on
+       * NOT_MERGEABLE, and CI finishing is exactly what we are waiting for. */
+      return WFE_MERGE_NOT_MERGEABLE;
+   case GIT_PR_CI_FAILURE:
+      /* Red CI is definitive: park for a human instead of looping. The ci node owns
+       * the bounded red-CI retry (AIMEE_AUTONOMY_CI_RETRY_MAX); reaching merge with a
+       * red head means the run is out of order, which a human should see. */
+      aimee_log(LOG_WARN, "wfe-forge", "refusing merge of PR %d: CI is not green", num);
+      return WFE_MERGE_ERROR;
+   default: /* GIT_PR_CI_ERROR -> undetermined -> never merge */
+      aimee_log(LOG_WARN, "wfe-forge", "refusing merge of PR %d: CI status unknown: %s", num,
+                cierr);
+      return WFE_MERGE_ERROR;
+   }
+
    /* Re-check immediately before the mutating call: close the TOCTOU window where
     * the flag is flipped off / the base becomes protected after the entry check. */
    if (!forge_allowed())

--- a/src/server/wfe_live_forge.c
+++ b/src/server/wfe_live_forge.c
@@ -196,24 +196,24 @@ static wfe_merge_result_t live_merge(const char *repo, const char *pr)
     * well-ordered workflow. A zero-check PR merges (nothing to fail); an
     * undetermined verdict never does. */
    char cierr[160];
-   switch (git_pr_ci_via_api(NULL, forge_dir(repo), num, cierr, sizeof cierr))
+   git_pr_ci_t ci = git_pr_ci_via_api(NULL, forge_dir(repo), num, cierr, sizeof cierr);
+   if (!git_pr_ci_permits_merge(ci))
    {
-   case GIT_PR_CI_SUCCESS:
-   case GIT_PR_CI_NONE: /* no CI reported for the head commit -> nothing to fail */
-      break;
-   case GIT_PR_CI_PENDING:
-      /* Still running: retry the node rather than park -- the engine loops on
-       * NOT_MERGEABLE, and CI finishing is exactly what we are waiting for. */
-      return WFE_MERGE_NOT_MERGEABLE;
-   case GIT_PR_CI_FAILURE:
-      /* Red CI is definitive: park for a human instead of looping. The ci node owns
-       * the bounded red-CI retry (AIMEE_AUTONOMY_CI_RETRY_MAX); reaching merge with a
-       * red head means the run is out of order, which a human should see. */
-      aimee_log(LOG_WARN, "wfe-forge", "refusing merge of PR %d: CI is not green", num);
-      return WFE_MERGE_ERROR;
-   default: /* GIT_PR_CI_ERROR -> undetermined -> never merge */
-      aimee_log(LOG_WARN, "wfe-forge", "refusing merge of PR %d: CI status unknown: %s", num,
-                cierr);
+      /* PENDING loops; everything else parks. The two merge seams answer "pending"
+       * differently on purpose, because their retry models differ: here the engine
+       * re-runs the node on NOT_MERGEABLE, so a transient pending resolves itself
+       * with no human involved. server_pipeline_merge has no such loop -- its caller
+       * drives retries via pipeline.advance -- so it parks in *_merge_pending and is
+       * re-checked on the next advance. Both refuse to merge on pending; only the
+       * mechanism for coming back differs.
+       *
+       * Red CI does NOT loop: the ci node owns the bounded red-CI retry
+       * (AIMEE_AUTONOMY_CI_RETRY_MAX), so reaching merge with a red head means the
+       * run is out of order and a human should see it. */
+      if (ci == GIT_PR_CI_PENDING)
+         return WFE_MERGE_NOT_MERGEABLE;
+      aimee_log(LOG_WARN, "wfe-forge", "refusing merge of PR %d: CI not green (%s)", num,
+                ci == GIT_PR_CI_FAILURE ? "failed" : cierr);
       return WFE_MERGE_ERROR;
    }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2905,6 +2905,7 @@ $(TESTPREFIX)/unit-test-roundtable-pipeline-chunk: \
 $(TESTPREFIX)/unit-test-roundtable-pipeline-ctl: \
                                        $(OBJDIR)/tests/test_roundtable_pipeline_ctl.o \
                                        $(OBJDIR)/server/server_pipeline.o $(OBJDIR)/server/server_pipeline_merge.o \
+                                       $(OBJDIR)/server/git_pr_ci_grade.o \
                                        $(OBJDIR)/server/roundtable_pipeline_eval.o \
                                        $(OBJDIR)/server/roundtable_pipeline_chunk.o \
                                        $(OBJDIR)/db1/roundtable_pipeline.o \

--- a/src/tests/test_git_pr_ci_grade.c
+++ b/src/tests/test_git_pr_ci_grade.c
@@ -43,8 +43,24 @@ int main(void)
    /* nothing anywhere -> NONE */
    assert(git_pr_ci_grade_json(empty, NULL) == GIT_PR_CI_NONE);
    assert(git_pr_ci_grade_json(NULL, NULL) == GIT_PR_CI_NONE);
-   /* malformed payloads never grade as success */
-   assert(git_pr_ci_grade_json("not json", "also not json") == GIT_PR_CI_NONE);
+
+   /* A payload we cannot read is ERROR, never NONE. NONE means "the forge reported
+    * no CI", which git_pr_ci_permits_merge() lets through -- so it must not be
+    * reachable from "we failed to parse the answer", or a garbled body would merge. */
+   assert(git_pr_ci_grade_json("not json", "also not json") == GIT_PR_CI_ERROR);
+   assert(git_pr_ci_grade_json(empty, "not json") == GIT_PR_CI_ERROR);
+   /* parsed, but not the payload we asked for (e.g. an API error object) */
+   assert(git_pr_ci_grade_json("{\"message\":\"Not Found\"}", NULL) == GIT_PR_CI_ERROR);
+   assert(git_pr_ci_grade_json(empty, "{\"message\":\"Not Found\"}") == GIT_PR_CI_ERROR);
+
+   /* --- the merge ruling: only green, or genuinely no CI at all --- */
+   assert(git_pr_ci_permits_merge(GIT_PR_CI_SUCCESS));
+   assert(git_pr_ci_permits_merge(GIT_PR_CI_NONE)); /* no CI -> nothing to fail */
+   assert(!git_pr_ci_permits_merge(GIT_PR_CI_PENDING));
+   assert(!git_pr_ci_permits_merge(GIT_PR_CI_FAILURE));
+   assert(!git_pr_ci_permits_merge(GIT_PR_CI_ERROR)); /* unknown is never pass */
+   /* end to end: a malformed payload must not reach a merge */
+   assert(!git_pr_ci_permits_merge(git_pr_ci_grade_json("not json", "also not json")));
 
    printf("ok\n");
    return 0;

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -470,7 +470,7 @@ static void test_osv_offline_cache_miss_allows(void)
    "pdf_open_page {document_key,page_no,project} req:document_key,page_no,project\n"               \
    "pdf_search_chunks {max_results,project,query} req:project,query\n"                             \
    "pipeline "                                                                                     \
-   "{admin,artifact,base_branch,brief,command,done_bar,head_branch,idea,operator_principal,"       \
+   "{artifact,base_branch,brief,command,done_bar,head_branch,idea,operator_principal,"             \
    "pipeline_id,questions,reason,remote,repo_root,state,verdict,worktree_path} req:command\n"      \
    "prospective_memory "                                                                           \
    "{action_text,anchor_entity,anchor_file,command,id,limit,recurrence,state,trigger_text,valid_"  \

--- a/src/tests/test_roundtable_pipeline_ctl.c
+++ b/src/tests/test_roundtable_pipeline_ctl.c
@@ -20,6 +20,7 @@
 #include "config.h" /* defines MAX_PATH_LEN used by agent_types.h */
 #include "agent_config.h"
 #include "cJSON.h"
+#include "git_pr_api.h" /* git_pr_ci_t for the CI-gate stub */
 #include "mcp_git.h"
 #include "roundtable_pipeline.h"
 #include "server.h"
@@ -76,6 +77,22 @@ char *mcp_git_run(const char *cmd, int *exit_code)
    if (exit_code)
       *exit_code = 0;
    return strdup("");
+}
+/* validate_pr_for_merge's CI gate. Stubbed like mcp_git_run above: the real one
+ * lives in git_pr_api.o, which drags in the whole HTTP + credential stack. The
+ * exercised paths never reach it — the stubbed mcp_git_run returns "" for the
+ * `gh pr view`, so validation stops at the unparseable-PR branch first — but the
+ * link still needs the symbol. The PURE half of the gate (git_pr_ci_permits_merge,
+ * which encodes the merge ruling) is linked for real from git_pr_ci_grade.o. */
+git_pr_ci_t git_pr_ci_via_api(const char *principal, const char *repo_dir, int number, char *err,
+                              size_t errlen)
+{
+   (void)principal;
+   (void)repo_dir;
+   (void)number;
+   if (err && errlen)
+      err[0] = '\0';
+   return GIT_PR_CI_ERROR;
 }
 int agent_load_config(agent_config_t *cfg)
 {

--- a/src/tests/test_wfe_native_gate.c
+++ b/src/tests/test_wfe_native_gate.c
@@ -118,18 +118,31 @@ int main(void)
    assert(wfe_shell_invokes_git("Bash", "true; git push"));      /* after a separator */
    assert(wfe_shell_invokes_git("Bash", "make && git push"));    /* && */
    assert(wfe_shell_invokes_git("Bash", "ls | grep x; gh pr list"));
-   assert(wfe_shell_invokes_git("Bash", "bash -lc 'git push'")); /* quoted evasion */
-   assert(wfe_shell_invokes_git("Bash", "{ git push;}"));        /* brace group */
+   assert(wfe_shell_invokes_git("Bash", "{ git push;}"));          /* brace group */
    assert(wfe_shell_invokes_git("Bash", "$(git rev-parse HEAD)")); /* subshell */
+   /* a newline is a command separator, not mere spacing */
+   assert(wfe_shell_invokes_git("Bash", "make build\ngit push"));
+   assert(wfe_shell_invokes_git("Bash", "cd /tmp\ngh pr create"));
 
-   /* NOT invocations: git/gh appears as an argument, not the command. A blunt
-    * substring match would false-positive on all of these. */
+   /* `bash -c '<cmd>'`: the command string is parsed, not treated as data */
+   assert(wfe_shell_invokes_git("Bash", "bash -lc 'git push'"));
+   assert(wfe_shell_invokes_git("Bash", "sh -c \"git push\""));
+   /* quotes are stripped, so a split command name still resolves */
+   assert(wfe_shell_invokes_git("Bash", "gi''t push"));
+
+   /* NOT invocations: git/gh appears as an ARGUMENT, not the command. A blunt
+    * substring match -- or treating every quote as a command separator -- would
+    * false-positive on all of these. */
    assert(!wfe_shell_invokes_git("Bash", "grep git file.txt"));
+   assert(!wfe_shell_invokes_git("Bash", "grep \"git\" file.txt")); /* quoted mention */
    assert(!wfe_shell_invokes_git("Bash", "echo git"));
+   assert(!wfe_shell_invokes_git("Bash", "echo 'git'"));
    assert(!wfe_shell_invokes_git("Bash", "ls .github/workflows"));
    assert(!wfe_shell_invokes_git("Bash", "cat gitlog.txt"));
    assert(!wfe_shell_invokes_git("Bash", "python3 legit.py")); /* substring of a word */
    assert(!wfe_shell_invokes_git("Bash", "make build"));
+   /* a non-shell binary's quoted argument is data, even if it looks like a command */
+   assert(!wfe_shell_invokes_git("Bash", "echo 'git push'"));
 
    /* non-shell tools carry no command; NULL/empty are not invocations */
    assert(!wfe_shell_invokes_git("Read", "git push"));

--- a/src/tests/test_wfe_native_gate.c
+++ b/src/tests/test_wfe_native_gate.c
@@ -82,7 +82,7 @@ int main(void)
 
    /* --- forbidden outright: admin override of branch protection is human-only --- */
    assert(wfe_native_tool_forbidden("Bash", "gh pr merge 12 --admin"));
-   assert(wfe_native_tool_forbidden("Bash", "gh pr merge --admin 12"));    /* flag first */
+   assert(wfe_native_tool_forbidden("Bash", "gh pr merge --admin 12")); /* flag first */
    assert(wfe_native_tool_forbidden("Bash", "gh pr merge --squash --admin 12"));
    assert(wfe_native_tool_forbidden("Bash", "true; gh pr merge 12 --admin")); /* compound */
    assert(wfe_native_tool_forbidden("Bash", "gh\tpr merge 12 --admin"));      /* tab sep */
@@ -112,11 +112,11 @@ int main(void)
    assert(wfe_shell_invokes_git("Bash", "gh"));
 
    /* command position, not mere mention */
-   assert(wfe_shell_invokes_git("Bash", "/usr/bin/git push"));   /* absolute path */
-   assert(wfe_shell_invokes_git("Bash", "sudo git push"));       /* prefix word */
-   assert(wfe_shell_invokes_git("Bash", "AIMEE_X=1 git push"));  /* assignment prefix */
-   assert(wfe_shell_invokes_git("Bash", "true; git push"));      /* after a separator */
-   assert(wfe_shell_invokes_git("Bash", "make && git push"));    /* && */
+   assert(wfe_shell_invokes_git("Bash", "/usr/bin/git push"));  /* absolute path */
+   assert(wfe_shell_invokes_git("Bash", "sudo git push"));      /* prefix word */
+   assert(wfe_shell_invokes_git("Bash", "AIMEE_X=1 git push")); /* assignment prefix */
+   assert(wfe_shell_invokes_git("Bash", "true; git push"));     /* after a separator */
+   assert(wfe_shell_invokes_git("Bash", "make && git push"));   /* && */
    assert(wfe_shell_invokes_git("Bash", "ls | grep x; gh pr list"));
    assert(wfe_shell_invokes_git("Bash", "{ git push;}"));          /* brace group */
    assert(wfe_shell_invokes_git("Bash", "$(git rev-parse HEAD)")); /* subshell */

--- a/src/tests/test_wfe_native_gate.c
+++ b/src/tests/test_wfe_native_gate.c
@@ -80,6 +80,29 @@ int main(void)
    /* externalizing + bound + not delivered + not-hard (advisory/soft) -> WARN (soak) */
    assert(wfe_native_gate_decision(1, 1, 0, 0) == WFE_NATIVE_WARN);
 
+   /* --- forbidden outright: admin override of branch protection is human-only --- */
+   assert(wfe_native_tool_forbidden("Bash", "gh pr merge 12 --admin"));
+   assert(wfe_native_tool_forbidden("Bash", "gh pr merge --admin 12"));    /* flag first */
+   assert(wfe_native_tool_forbidden("Bash", "gh pr merge --squash --admin 12"));
+   assert(wfe_native_tool_forbidden("Bash", "true; gh pr merge 12 --admin")); /* compound */
+   assert(wfe_native_tool_forbidden("Bash", "gh\tpr merge 12 --admin"));      /* tab sep */
+   /* the gh api equivalent: PUT to the merge endpoint */
+   assert(wfe_native_tool_forbidden("Bash", "gh api -X PUT repos/o/r/pulls/12/merge"));
+   assert(wfe_native_tool_forbidden("Bash", "gh api --method PUT repos/o/r/pulls/12/merge"));
+
+   /* a plain merge is NOT forbidden here -- it is still subject to the ordinary
+    * externalization truth table above, just not blocked unconditionally. */
+   assert(!wfe_native_tool_forbidden("Bash", "gh pr merge 12"));
+   assert(!wfe_native_tool_forbidden("Bash", "gh pr merge 12 --squash"));
+   /* --admin without a merge is not this rule's business */
+   assert(!wfe_native_tool_forbidden("Bash", "gh pr create --admin"));
+   /* a GET of the merge endpoint is a read, not a bypass */
+   assert(!wfe_native_tool_forbidden("Bash", "gh api repos/o/r/pulls/12/merge"));
+   /* non-shell tools carry no command to inspect */
+   assert(!wfe_native_tool_forbidden("Read", "gh pr merge 12 --admin"));
+   assert(!wfe_native_tool_forbidden("Bash", NULL));
+   assert(!wfe_native_tool_forbidden(NULL, "gh pr merge 12 --admin"));
+
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_wfe_native_gate.c
+++ b/src/tests/test_wfe_native_gate.c
@@ -103,6 +103,40 @@ int main(void)
    assert(!wfe_native_tool_forbidden("Bash", NULL));
    assert(!wfe_native_tool_forbidden(NULL, "gh pr merge 12 --admin"));
 
+   /* --- no git/gh in a delegate shell (require_aimee_git) --- */
+   /* the plain cases: every verb, read and write alike -- there is no verb list */
+   assert(wfe_shell_invokes_git("Bash", "git push"));
+   assert(wfe_shell_invokes_git("Bash", "git status"));
+   assert(wfe_shell_invokes_git("Bash", "git log --oneline -5"));
+   assert(wfe_shell_invokes_git("Bash", "gh pr view 12"));
+   assert(wfe_shell_invokes_git("Bash", "gh"));
+
+   /* command position, not mere mention */
+   assert(wfe_shell_invokes_git("Bash", "/usr/bin/git push"));   /* absolute path */
+   assert(wfe_shell_invokes_git("Bash", "sudo git push"));       /* prefix word */
+   assert(wfe_shell_invokes_git("Bash", "AIMEE_X=1 git push"));  /* assignment prefix */
+   assert(wfe_shell_invokes_git("Bash", "true; git push"));      /* after a separator */
+   assert(wfe_shell_invokes_git("Bash", "make && git push"));    /* && */
+   assert(wfe_shell_invokes_git("Bash", "ls | grep x; gh pr list"));
+   assert(wfe_shell_invokes_git("Bash", "bash -lc 'git push'")); /* quoted evasion */
+   assert(wfe_shell_invokes_git("Bash", "{ git push;}"));        /* brace group */
+   assert(wfe_shell_invokes_git("Bash", "$(git rev-parse HEAD)")); /* subshell */
+
+   /* NOT invocations: git/gh appears as an argument, not the command. A blunt
+    * substring match would false-positive on all of these. */
+   assert(!wfe_shell_invokes_git("Bash", "grep git file.txt"));
+   assert(!wfe_shell_invokes_git("Bash", "echo git"));
+   assert(!wfe_shell_invokes_git("Bash", "ls .github/workflows"));
+   assert(!wfe_shell_invokes_git("Bash", "cat gitlog.txt"));
+   assert(!wfe_shell_invokes_git("Bash", "python3 legit.py")); /* substring of a word */
+   assert(!wfe_shell_invokes_git("Bash", "make build"));
+
+   /* non-shell tools carry no command; NULL/empty are not invocations */
+   assert(!wfe_shell_invokes_git("Read", "git push"));
+   assert(!wfe_shell_invokes_git("Bash", NULL));
+   assert(!wfe_shell_invokes_git("Bash", ""));
+   assert(!wfe_shell_invokes_git(NULL, "git push"));
+
    printf("ok\n");
    return 0;
 }

--- a/src/workflow/wfe_native_gate.c
+++ b/src/workflow/wfe_native_gate.c
@@ -155,6 +155,29 @@ static int has_external_url(const char *cmd)
    return 0;
 }
 
+int wfe_native_tool_forbidden(const char *tool_name, const char *command)
+{
+   if (!wfe_is_shell_tool(tool_name) || !command || !command[0])
+      return 0;
+
+   /* An admin override of branch protection is human-only. `--admin` is only
+    * meaningful to `gh pr merge`, but we do not require the two to be adjacent:
+    * flags may precede the subcommand, and a compound line may carry both. Any
+    * shell line that both merges a PR and asks for the admin bypass is denied. */
+   if (cmd_has(command, "gh pr merge") &&
+       (cmd_has(command, "--admin") || cmd_has(command, "-admin")))
+      return 1;
+
+   /* The `gh api` equivalent: a PUT to .../pulls/<n>/merge. `gh api` is otherwise a
+    * documented accepted residual (see wfe_native_tool_externalizes), but the merge
+    * endpoint is the same bypass wearing a different hat when the token is an admin's. */
+   if (cmd_has(command, "gh api") && strstr(command, "/merge") &&
+       (cmd_has(command, "-X PUT") || cmd_has(command, "--method PUT")))
+      return 1;
+
+   return 0;
+}
+
 int wfe_native_tool_externalizes(const char *tool_name, const char *command)
 {
    if (!tool_name || !tool_name[0])

--- a/src/workflow/wfe_native_gate.c
+++ b/src/workflow/wfe_native_gate.c
@@ -155,86 +155,153 @@ static int has_external_url(const char *cmd)
    return 0;
 }
 
-/* Shell characters after which the next word sits in COMMAND position. Quote marks
- * are deliberately included: it makes `bash -lc 'git push'` read as a git
- * invocation -- the obvious evasion -- at the cost of also flagging `echo 'git'`.
- * That false positive is an accepted trade: this gate fails closed and its message
- * names the tool to use instead, whereas a miss lets a delegate push with a
- * credential it should never have touched. */
-static int is_cmd_start(char c)
+/* An unquoted shell control char: after any of these the next word is again in
+ * COMMAND position. `\n` is here and must be tested BEFORE any isspace() skip --
+ * it is both whitespace and a command separator, and treating it as mere spacing
+ * hides `make build<newline>git push`. */
+static int is_ctl(char c)
 {
    return c == ';' || c == '&' || c == '|' || c == '(' || c == ')' || c == '{' || c == '}' ||
-          c == '\n' || c == '`' || c == '\'' || c == '"';
+          c == '`' || c == '\n';
 }
 
-/* 1 if `cmd` INVOKES one of `names` as a command, rather than merely mentioning it:
- * `git push` and `/usr/bin/git push` and `sudo git push` match; `grep git file` and
- * `echo git` do not (there `git` is an argument). A leading path is reduced to its
- * basename, and command-prefix words (sudo/env/...) and VAR=val assignments are
- * looked through so the real command is still reached. */
-static int shell_invokes(const char *cmd, const char *const *names, size_t nnames)
+/* Read one shell WORD from *pp into buf, honoring quotes and backslash escapes, and
+ * writing the UNQUOTED content. The word ends at unquoted whitespace or an unquoted
+ * control char; quoted whitespace stays inside the word, so `'git push'` reads back
+ * as the single word `git push`. Stripping the quotes also collapses the
+ * split-name evasion (`gi''t` / `g"i"t` -> `git`). Advances *pp; returns the length
+ * written. */
+static size_t read_word(const char **pp, char *buf, size_t cap)
 {
-   if (!cmd)
+   const char *p = *pp;
+   size_t n = 0;
+   int sq = 0, dq = 0;
+   while (*p)
+   {
+      char c = *p;
+      if (!sq && c == '\\' && p[1])
+      {
+         p++;
+         if (n + 1 < cap)
+            buf[n++] = *p;
+         p++;
+         continue;
+      }
+      if (!dq && c == '\'')
+      {
+         sq = !sq;
+         p++;
+         continue;
+      }
+      if (!sq && c == '"')
+      {
+         dq = !dq;
+         p++;
+         continue;
+      }
+      if (!sq && !dq && (c == ' ' || c == '\t' || c == '\r'))
+         break;
+      if (!sq && !dq && is_ctl(c))
+         break;
+      if (n + 1 < cap)
+         buf[n++] = c;
+      p++;
+   }
+   buf[n] = '\0';
+   *pp = p;
+   return n;
+}
+
+static int word_in(const char *w, const char *const *set, size_t n)
+{
+   for (size_t i = 0; i < n; i++)
+      if (strcmp(w, set[i]) == 0)
+         return 1;
+   return 0;
+}
+
+static const char *base_of(const char *w) /* /usr/bin/git -> git */
+{
+   const char *b = w;
+   for (const char *q = w; *q; q++)
+      if (*q == '/')
+         b = q + 1;
+   return b;
+}
+
+/* 1 if `cmd` INVOKES one of `names`, rather than merely mentioning it. Walks the
+ * line tracking command position: a word is a command only at the start or after an
+ * unquoted control char. `git push`, `/usr/bin/git push`, `sudo git push`,
+ * `VAR=1 git push` and `make && git push` match; `grep "git" f` and `echo git` do
+ * not -- there the word is an argument. `bash -c '<cmd>'` recurses into the command
+ * string, which is where the quoted-evasion case is actually caught (rather than by
+ * treating every quote as a separator, which would deny `grep "git" f` too).
+ *
+ * KNOWN LIMITS, deliberately not chased (the header's honest-scope note applies):
+ * a wrapper's own option ARGUMENT is not modelled -- `env -i git push` matches
+ * because bare `-i` is skipped, but `sudo -u bob git push` does not, since `bob` is
+ * read as the command. A local script named `git`/`gh` earlier in PATH matches on
+ * name alone. Obfuscation the string cannot see (base64, env indirection, a
+ * variable holding the binary name) is out of scope -- the stripped credential, not
+ * this parser, is what closes those. */
+static int scan_cmd(const char *cmd, const char *const *names, size_t nnames, int depth)
+{
+   if (!cmd || !cmd[0] || depth > 2)
       return 0;
    static const char *const prefixes[] = {"sudo", "env",  "command", "nohup",
                                           "time", "doas", "exec",    "builtin"};
-   int at_cmd = 1;
+   static const char *const shells[] = {"bash", "sh", "zsh", "dash", "ksh", "ash"};
+   int at_cmd = 1, shell_cmd = 0;
    const char *p = cmd;
+   char w[1024];
    while (*p)
    {
-      if (isspace((unsigned char)*p))
+      if (*p == ' ' || *p == '\t' || *p == '\r')
       {
          p++;
          continue;
       }
-      if (is_cmd_start(*p))
+      if (is_ctl(*p))
       {
          at_cmd = 1;
+         shell_cmd = 0;
          p++;
          continue;
       }
-      const char *s = p;
-      while (*p && !isspace((unsigned char)*p) && !is_cmd_start(*p))
-         p++;
-      if (!at_cmd)
-         continue; /* an argument of the command already seen */
-
-      const char *b = s; /* basename: /usr/bin/git -> git */
-      for (const char *q = s; q < p; q++)
-         if (*q == '/')
-            b = q + 1;
-      size_t blen = (size_t)(p - b);
-      if (blen == 0)
+      const char *before = p;
+      size_t n = read_word(&p, w, sizeof(w));
+      if (p == before) /* defensive: never stall on an unconsumed char */
       {
-         at_cmd = 0;
+         p++;
          continue;
       }
-
-      /* `VAR=val cmd` — an assignment prefix keeps the next word in command position. */
-      int assign = 0;
-      for (const char *q = s; q < p; q++)
-         if (*q == '=')
-         {
-            assign = 1;
-            break;
-         }
-      if (assign)
+      if (n == 0)
          continue;
 
-      int looked_through = 0;
-      for (size_t i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++)
-         if (strlen(prefixes[i]) == blen && strncmp(b, prefixes[i], blen) == 0)
-         {
-            looked_through = 1;
-            break;
-         }
-      if (looked_through)
-         continue; /* still at_cmd: `sudo git push` */
-
-      for (size_t i = 0; i < nnames; i++)
-         if (strlen(names[i]) == blen && strncmp(b, names[i], blen) == 0)
+      if (at_cmd)
+      {
+         if (strchr(w, '=')) /* `VAR=val cmd` -> the next word is still the command */
+            continue;
+         if (w[0] == '-') /* a wrapper's own flag: `env -i git push` */
+            continue;
+         const char *b = base_of(w);
+         if (word_in(b, prefixes, sizeof(prefixes) / sizeof(prefixes[0])))
+            continue; /* `sudo git push` -> still at_cmd */
+         if (word_in(b, names, nnames))
             return 1;
-      at_cmd = 0; /* this word was the command; what follows are its arguments */
+         shell_cmd = word_in(b, shells, sizeof(shells) / sizeof(shells[0]));
+         at_cmd = 0; /* this word was the command; the rest are its arguments */
+      }
+      else if (shell_cmd && w[0] == '-' && strchr(w, 'c'))
+      {
+         /* `bash -c` / `-lc` / `-lic`: the NEXT word is a command string, not data. */
+         while (*p == ' ' || *p == '\t')
+            p++;
+         char inner[2048];
+         if (read_word(&p, inner, sizeof(inner)) > 0 &&
+             scan_cmd(inner, names, nnames, depth + 1))
+            return 1;
+      }
    }
    return 0;
 }
@@ -244,7 +311,7 @@ int wfe_shell_invokes_git(const char *tool_name, const char *command)
    if (!wfe_is_shell_tool(tool_name) || !command || !command[0])
       return 0;
    static const char *const names[] = {"git", "gh"};
-   return shell_invokes(command, names, sizeof(names) / sizeof(names[0]));
+   return scan_cmd(command, names, sizeof(names) / sizeof(names[0]), 0);
 }
 
 int wfe_native_tool_forbidden(const char *tool_name, const char *command)

--- a/src/workflow/wfe_native_gate.c
+++ b/src/workflow/wfe_native_gate.c
@@ -298,8 +298,7 @@ static int scan_cmd(const char *cmd, const char *const *names, size_t nnames, in
          while (*p == ' ' || *p == '\t')
             p++;
          char inner[2048];
-         if (read_word(&p, inner, sizeof(inner)) > 0 &&
-             scan_cmd(inner, names, nnames, depth + 1))
+         if (read_word(&p, inner, sizeof(inner)) > 0 && scan_cmd(inner, names, nnames, depth + 1))
             return 1;
       }
    }

--- a/src/workflow/wfe_native_gate.c
+++ b/src/workflow/wfe_native_gate.c
@@ -155,6 +155,98 @@ static int has_external_url(const char *cmd)
    return 0;
 }
 
+/* Shell characters after which the next word sits in COMMAND position. Quote marks
+ * are deliberately included: it makes `bash -lc 'git push'` read as a git
+ * invocation -- the obvious evasion -- at the cost of also flagging `echo 'git'`.
+ * That false positive is an accepted trade: this gate fails closed and its message
+ * names the tool to use instead, whereas a miss lets a delegate push with a
+ * credential it should never have touched. */
+static int is_cmd_start(char c)
+{
+   return c == ';' || c == '&' || c == '|' || c == '(' || c == ')' || c == '{' || c == '}' ||
+          c == '\n' || c == '`' || c == '\'' || c == '"';
+}
+
+/* 1 if `cmd` INVOKES one of `names` as a command, rather than merely mentioning it:
+ * `git push` and `/usr/bin/git push` and `sudo git push` match; `grep git file` and
+ * `echo git` do not (there `git` is an argument). A leading path is reduced to its
+ * basename, and command-prefix words (sudo/env/...) and VAR=val assignments are
+ * looked through so the real command is still reached. */
+static int shell_invokes(const char *cmd, const char *const *names, size_t nnames)
+{
+   if (!cmd)
+      return 0;
+   static const char *const prefixes[] = {"sudo", "env",  "command", "nohup",
+                                          "time", "doas", "exec",    "builtin"};
+   int at_cmd = 1;
+   const char *p = cmd;
+   while (*p)
+   {
+      if (isspace((unsigned char)*p))
+      {
+         p++;
+         continue;
+      }
+      if (is_cmd_start(*p))
+      {
+         at_cmd = 1;
+         p++;
+         continue;
+      }
+      const char *s = p;
+      while (*p && !isspace((unsigned char)*p) && !is_cmd_start(*p))
+         p++;
+      if (!at_cmd)
+         continue; /* an argument of the command already seen */
+
+      const char *b = s; /* basename: /usr/bin/git -> git */
+      for (const char *q = s; q < p; q++)
+         if (*q == '/')
+            b = q + 1;
+      size_t blen = (size_t)(p - b);
+      if (blen == 0)
+      {
+         at_cmd = 0;
+         continue;
+      }
+
+      /* `VAR=val cmd` — an assignment prefix keeps the next word in command position. */
+      int assign = 0;
+      for (const char *q = s; q < p; q++)
+         if (*q == '=')
+         {
+            assign = 1;
+            break;
+         }
+      if (assign)
+         continue;
+
+      int looked_through = 0;
+      for (size_t i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++)
+         if (strlen(prefixes[i]) == blen && strncmp(b, prefixes[i], blen) == 0)
+         {
+            looked_through = 1;
+            break;
+         }
+      if (looked_through)
+         continue; /* still at_cmd: `sudo git push` */
+
+      for (size_t i = 0; i < nnames; i++)
+         if (strlen(names[i]) == blen && strncmp(b, names[i], blen) == 0)
+            return 1;
+      at_cmd = 0; /* this word was the command; what follows are its arguments */
+   }
+   return 0;
+}
+
+int wfe_shell_invokes_git(const char *tool_name, const char *command)
+{
+   if (!wfe_is_shell_tool(tool_name) || !command || !command[0])
+      return 0;
+   static const char *const names[] = {"git", "gh"};
+   return shell_invokes(command, names, sizeof(names) / sizeof(names[0]));
+}
+
 int wfe_native_tool_forbidden(const char *tool_name, const char *command)
 {
    if (!wfe_is_shell_tool(tool_name) || !command || !command[0])

--- a/src/workflow/wfe_native_gate.h
+++ b/src/workflow/wfe_native_gate.h
@@ -19,7 +19,7 @@
 #define DEC_WFE_NATIVE_GATE_H 1
 
 /* Bump when the pattern set changes so audit tooling can pin what was in effect. */
-#define WFE_NATIVE_GATE_PATTERN_VERSION 2
+#define WFE_NATIVE_GATE_PATTERN_VERSION 3
 
 /* 1 if `tool_name` is a general shell/command execution tool whose argument is a
  * command string we should inspect (Bash, bash, sh, shell, run_command, exec,
@@ -54,6 +54,25 @@ int wfe_native_tool_externalizes(const char *tool_name, const char *command);
  * Same honest-scope caveat as the header note: a NEGATIVE result means "no KNOWN
  * bypass pattern", never "provably safe". */
 int wfe_native_tool_forbidden(const char *tool_name, const char *command);
+
+/* 1 if this shell command INVOKES `git` or `gh` — as opposed to merely mentioning
+ * one. `git push`, `/usr/bin/git push`, `sudo git push` and `bash -lc 'git push'`
+ * match; `grep git file` and `echo git` do not (there it is an argument, not the
+ * command). Command-prefix words (sudo/env/nohup/...) and VAR=val assignments are
+ * looked through.
+ *
+ * Callers gate this on config `require_aimee_git` (default on) and deny: a delegate
+ * runs no git/forge command itself; it uses aimee's git_* tools, which execute on
+ * aimee-server where the forge credential lives in-process and never reaches a
+ * child's environment or argv. Reads are included — git_status / git_log /
+ * git_diff_summary / git_pr action=view cover them — so the rule needs no verb list
+ * to keep current.
+ *
+ * The classifier is defence in depth, not the guarantee: it is a string match over a
+ * shell line and the header's honest-scope note applies in full (subshells, base64,
+ * env indirection). The guarantee is that delegates are spawned WITHOUT git/gh
+ * credentials, so an evaded match still cannot reach the forge. */
+int wfe_shell_invokes_git(const char *tool_name, const char *command);
 
 typedef enum
 {

--- a/src/workflow/wfe_native_gate.h
+++ b/src/workflow/wfe_native_gate.h
@@ -19,7 +19,7 @@
 #define DEC_WFE_NATIVE_GATE_H 1
 
 /* Bump when the pattern set changes so audit tooling can pin what was in effect. */
-#define WFE_NATIVE_GATE_PATTERN_VERSION 1
+#define WFE_NATIVE_GATE_PATTERN_VERSION 2
 
 /* 1 if `tool_name` is a general shell/command execution tool whose argument is a
  * command string we should inspect (Bash, bash, sh, shell, run_command, exec,
@@ -38,6 +38,22 @@ int wfe_is_shell_tool(const char *tool_name);
  * `command` may be NULL/"" for non-shell tools (classified by name only).
  * Returns 0 when no known pattern matches -- NOT a safety proof (see header note). */
 int wfe_native_tool_externalizes(const char *tool_name, const char *command);
+
+/* 1 if this native tool call is FORBIDDEN OUTRIGHT — denied regardless of binding,
+ * delivery, or enforce stage. This is orthogonal to the externalization truth table
+ * below: externalization asks "does this cross the trust boundary, and is this
+ * session allowed to yet?", whereas this asks "may an agent do this at all?".
+ *
+ * Currently: an admin override of branch protection (`gh pr merge --admin`, and the
+ * `gh api` equivalent). Merging something that branch protection refuses is a
+ * HUMAN-ONLY act (operator ruling 2026-07-15) — an agent may open a PR and merge a
+ * green one, but may never force one past the rules. aimee's own merge paths no
+ * longer offer a bypass; this closes the matching hole for an agent that types the
+ * flag into a shell itself.
+ *
+ * Same honest-scope caveat as the header note: a NEGATIVE result means "no KNOWN
+ * bypass pattern", never "provably safe". */
+int wfe_native_tool_forbidden(const char *tool_name, const char *command);
 
 typedef enum
 {

--- a/src/workflow/wfe_native_gate.h
+++ b/src/workflow/wfe_native_gate.h
@@ -56,10 +56,16 @@ int wfe_native_tool_externalizes(const char *tool_name, const char *command);
 int wfe_native_tool_forbidden(const char *tool_name, const char *command);
 
 /* 1 if this shell command INVOKES `git` or `gh` — as opposed to merely mentioning
- * one. `git push`, `/usr/bin/git push`, `sudo git push` and `bash -lc 'git push'`
- * match; `grep git file` and `echo git` do not (there it is an argument, not the
- * command). Command-prefix words (sudo/env/nohup/...) and VAR=val assignments are
- * looked through.
+ * one. `git push`, `/usr/bin/git push`, `sudo git push`, `VAR=1 git push`,
+ * `make && git push`, a command after a newline, and `bash -lc 'git push'` (the
+ * command string is parsed, not treated as data) all match. `grep "git" file` and
+ * `echo git` do NOT — there the word is an argument. Command-prefix words
+ * (sudo/env/nohup/...), VAR=val assignments, and a wrapper's bare flags are looked
+ * through; quotes are stripped, so `gi''t push` matches too.
+ *
+ * Known limits, deliberately not chased: a wrapper's option ARGUMENT is not modelled
+ * (`env -i git push` matches, `sudo -u bob git push` does not — `bob` reads as the
+ * command); a local script named `git`/`gh` in PATH matches on name alone.
  *
  * Callers gate this on config `require_aimee_git` (default on) and deny: a delegate
  * runs no git/forge command itself; it uses aimee's git_* tools, which execute on


### PR DESCRIPTION
Three operator rulings from a live debugging session, plus the roundtable fixes.

## Context: what this is *not*

This started as "make the forge use aimee git tooling instead of gh". It turned out that was **already done** upstream (`18e59c31`, forge credentials never leave aimee-server) — `wfe_live_forge.c` has zero `gh` call sites. The proposals pipeline was stuck for an unrelated reason: the appliance ran `testing-8a1d227`, built ~50 min before `77461394` fixed the malformed-Content-Type 400 that was blocking `pr create`. Redeploying to `testing-2bfa870` and resuming the work item opened PR #1350 immediately, and it advanced `pr -> ci` on its own.

So this PR contains only the genuinely new work: the policy changes.

## 1. No admin override (`c24accc6`)

`gh pr merge --admin` forced merges past branch protection. A merge that needs an admin override is a human decision, not an agent one. Removed end to end: the `git_pr` tool schema, the `git_pr` merge action, the pipeline merge executor, and the `pipeline.*` RPC flag. A protection-blocked merge now fails and parks for a human, like every other failure branch.

Removing our plumbing does not stop a delegate typing the flag, so `wfe_native_tool_forbidden()` denies it **unconditionally** — deliberately orthogonal to the externalization truth table, which only WARNs in a soft stage and ALLOWs an unbound session. Neither is a block.

## 2. Merges require green CI (`c24accc6`)

Enforced at all three merge seams. A PR with zero reported checks merges (nothing to fail); pending, failed and undetermined all refuse. The ruling lives in one tested place, `git_pr_ci_permits_merge()`, so the seams cannot drift. Each still chooses how to come back from a refusal, and this differs **by design**: the engine loops the node (a transient pending self-resolves), the pipeline gate parks for the next `pipeline.advance` (it has no loop).

## 3. Delegates never run git or gh (`7ae89cf5`)

Implements `require_aimee_git` — specified in `docs/proposals/pending/persona-authored-outputs.md:100` and never built. Default ON, sibling of `require_aimee_memory`. Two layers:

- **The rule.** `wfe_shell_invokes_git()` denies any shell command *invoking* git/gh, reads included — aimee’s `git_*` tools cover every read, so there is no verb list to drift. Matches on command position, not substring.
- **The guarantee.** `delegate_child_strip_forge_creds()` removes the credentials at spawn, so an evaded classifier still cannot authenticate.

**Load-bearing ordering fix:** both checks run *before* the binding lookup and no longer require a session id. `provider_cli_adapter` never stamps `AIMEE_SESSION_ID`, so a spawned delegate resolves no binding and the gate ALLOWs on `bound==0` — the rules would have been dead code for exactly the agents they target.

## Roundtable review (`02d6fd60`)

Verdict was approve-with-changes. Every parser finding was real and is now covered by tests that failed before the fix:

- A newline was skipped as whitespace before the separator check, so `make build\ngit push` did not match **at all**.
- Treating quotes as separators denied `grep "git" file.txt`. Quotes are now part of a word; `bash -c` is caught by parsing the command string instead — the case that actually mattered.
- `env -i git push` missed, because a wrapper flag ended the command position.

**The important one — a fail-open I introduced.** `git_pr_ci_grade_json` returned `NONE` for an unparseable payload, and `NONE` merges. A garbled body would have merged. `NONE` now means only "the forge reported no CI"; an unreadable payload is `ERROR`, which refuses. Both still park `gate.ci` identically, so that path is unaffected. `mcp_git_pr` likewise no longer infers zero checks from zero parsed counters.

Also withdrew three overclaims: "allocation-free" sat above `setenv`; "incapable of authenticating" oversold an env strip (it is defence in depth, not a credential boundary); and `SSH_AUTH_SOCK` stripping is broader than git — a delegate loses agent-backed SSH to **any** host, now called out in `config.h`.

## Operator impact — read before merging

- `require_aimee_git` defaults ON. Delegates that shell out to git/gh will start being denied. Intended, but it is a live behaviour change for anything mid-flight.
- The env strip drops `SSH_AUTH_SOCK` (no agent-backed SSH to any host) and points `GIT_CONFIG_GLOBAL`/`SYSTEM` at `/dev/null` (no `user.name`/`user.email`; `git_commit` supplies identity server-side).
- Zero-checks-merges is an explicit operator decision, not an inference.

## Testing

`test_wfe_native_gate` and `test_git_pr_ci_grade` both extended and passing, including the fail-open regression. All touched files compile clean with `-Wall -Wextra`. Verified live: PR #1350 opened from the redeployed box and reached `ci` with 8/8 green.

Not yet covered, and worth a follow-up: a system test driving a delegate spawn end-to-end to confirm the deny fires before exec — the ordering fix is currently unit-tested only.