### PR TITLE
delegates: give every delegate aimee, then require it

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -32,7 +32,13 @@ RUN apt-get update \
 WORKDIR /src
 COPY . .
 ARG AIMEE_VERSION=""
-RUN make -C src ../aimee-server ${AIMEE_VERSION:+GIT_VERSION=v$AIMEE_VERSION}
+# The CLI ships alongside the server. It is what gives a spawned provider-CLI
+# delegate (the `claude` binary) any access to aimee at all: `aimee mcp serve` is
+# the stdio MCP proxy that forwards tool calls to this server over /v1, and
+# `aimee hooks pre` is the PreToolUse guard. Without the binary in the image a
+# delegate has no aimee tools and no guard can run — it gets a bare shell and its
+# own credentials, which is the opposite of the intent.
+RUN make -C src ../aimee-server ../aimee ${AIMEE_VERSION:+GIT_VERSION=v$AIMEE_VERSION}
 
 # --- webchat frontend: build the React SPA into a single index.html ---
 # vite-plugin-singlefile inlines all JS/CSS, so the runtime image ships one file.
@@ -205,6 +211,9 @@ RUN useradd --uid 1000 --user-group --home-dir /var/lib/aimee --create-home --sh
 # when no named volume is mounted; operators can bind/name it for backups.
 VOLUME /var/lib/aimee-workspaces
 COPY --from=build /src/aimee-server /usr/local/bin/aimee-server
+# See the build stage: delegates reach aimee THROUGH this binary (`aimee mcp serve`
+# as their MCP server, `aimee hooks pre` as their PreToolUse guard).
+COPY --from=build /src/aimee /usr/local/bin/aimee
 
 # Co-located webchat browser UI: the Go service, the single-file React SPA, the
 # PAM stack for browser login, and the bootstrap/launch helpers. webchat shares

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -42,6 +42,20 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
                     const char *system_prompt, const char *user_prompt, int max_tokens,
                     double temperature, agent_result_t *out);
 
+/* agent_run_named, but WITH tools. Exists for review panelists: they must route by
+ * NAME (each lens is bound to a seat model) yet still reach aimee, and the two
+ * existing tools-enabled runners select by role only.
+ *
+ * Panelists were tool-less, which is why a diff-only reviewer could not answer
+ * "does anything call this?" or "is this file product?" — questions that decide
+ * whether a change is real. With tools, the role's toolset applies: `review` maps
+ * to `review_indexed` (code_search / find_symbol / search_memory / search_docs),
+ * i.e. the diff plus aimee's own code + memory tooling, and no filesystem or write
+ * tools. write_capable is pinned 0 regardless of the agent's config. */
+int agent_run_named_with_tools(agent_config_t *cfg, const char *name, const char *role,
+                               const char *system_prompt, const char *user_prompt, int max_tokens,
+                               double temperature, agent_result_t *out);
+
 /* One-shot, TOOL-FREE text generation for UI drafting: selects a single non-CLI
  * (HTTP-provider) agent (prefer `agent_name`, else default, else first enabled
  * non-CLI) and runs the plain-completion agent_execute() — no tools, no worktree,

--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -66,6 +66,26 @@ char *dispatch_tool_call_ctx(const char *name, const char *arguments_json, int t
 void agent_tools_set_dispatch_role(const char *role);
 const char *agent_tools_dispatch_role(void);
 
+/* Git-write seam (git_commit / git_push / git_branch / git_pr).
+ *
+ * Those tools are implemented in the SERVER tier (the MCP git dispatch, which owns
+ * the worktree refusal, branch-ownership and verify rails), but the agent tool
+ * surface lives in the agent tier and is linked by binaries and tests that carry no
+ * server objects. Calling across that boundary directly would break their links and
+ * invert the tier order, so the server REGISTERS its dispatcher here at startup and
+ * the agent tier calls through the pointer — the same shape as wfe_set_forge_provider
+ * and workspace_provider_active.
+ *
+ * Unregistered (thin client, unit tests) the git-write tools are neither ADVERTISED
+ * nor dispatchable: an agent is never offered a tool that cannot work. Returns MCP
+ * content blocks (caller owns), or NULL for an unknown tool. */
+typedef struct cJSON *(*agent_git_write_fn)(const char *tool, struct cJSON *args, const char *sid);
+void agent_tools_set_git_write_provider(agent_git_write_fn fn);
+agent_git_write_fn agent_tools_git_write_provider(void);
+
+/* 1 if `name` is one of the git-write tools that ride the seam above. */
+int agent_tools_is_git_write(const char *name);
+
 /* Tool-call lifecycle hook. A streaming chat worker or a /v1/runs worker
  * installs a thread-local callback (NULL by default — every other caller is
  * unaffected) before running a turn; dispatch_tool_call_ctx fires it as each

--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -86,6 +86,19 @@ agent_git_write_fn agent_tools_git_write_provider(void);
 /* 1 if `name` is one of the git-write tools that ride the seam above. */
 int agent_tools_is_git_write(const char *name);
 
+/* Shell-git gate seam: 1 if this shell command must be refused because git belongs
+ * to aimee (require_aimee_git). Registered by the server for the same reason as the
+ * git-write provider — the decision needs the config dial, the forge credential and
+ * the command classifier, which live in tiers the agent surface cannot link.
+ *
+ * The server only registers it when refusing is HONEST: the dial is on, aimee-server
+ * actually holds a forge credential, and the git_* tools are available to point at.
+ * Unregistered, there is no gate — a rule with no working alternative is breakage,
+ * not policy, so the absence of the alternative disables the rule by construction. */
+typedef int (*agent_shell_git_gate_fn)(const char *command);
+void agent_tools_set_shell_git_gate(agent_shell_git_gate_fn fn);
+agent_shell_git_gate_fn agent_tools_shell_git_gate(void);
+
 /* Tool-call lifecycle hook. A streaming chat worker or a /v1/runs worker
  * installs a thread-local callback (NULL by default — every other caller is
  * unaffected) before running a turn; dispatch_tool_call_ctx fires it as each

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -301,6 +301,14 @@ typedef struct
     * distinct agents instead of N copies of the one default agent. When NULL,
     * routing is unchanged (role-based default route). */
    const char *agent;
+   /* Run this task WITH tools (default 0 = the historical plain completion, so no
+    * existing fan-out changes). Set by the review panel: a panelist holding only a
+    * diff cannot check whether the change is reachable, or whether a new file is
+    * product — the facts that decide if a change is real live outside the diff.
+    * With tools the task's role picks the toolset (`review` -> the index-only
+    * `review_indexed`: code_search / find_symbol / search_memory / search_docs);
+    * write tools stay off regardless. */
+   int use_tools;
 } agent_task_t;
 
 typedef struct

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -63,9 +63,11 @@ typedef struct
    const char *brief;
    int brief_truncated;
    /* Optional pre-assembled read-only context (aimee memory recall + code-graph
-    * snippets) injected into every panelist prompt. Panelists run with no tools,
-    * so this is the only way they see aimee memory and the code graph. The caller
-    * owns the string for the duration of the run; NULL = no context injected. */
+    * snippets) injected into every panelist prompt — a useful SEED, no longer the
+    * only window: REVIEW-mode panelists now run with aimee's index-only toolset
+    * (`review_indexed`) and can look things up themselves. Drafting panelists are
+    * still tool-less, so for them this remains the only view of memory and the code
+    * graph. The caller owns the string for the duration of the run; NULL = none. */
    const char *context;
    const char **questions;
    int question_count;

--- a/src/headers/git_cred_inject.h
+++ b/src/headers/git_cred_inject.h
@@ -73,6 +73,18 @@ int git_cred_inject_resolve_token(const char *principal, const char *remote_url,
                                   const char *repo_dir, const char *preferred_token, char *out,
                                   size_t cap);
 
+/* 1 if aimee-server can itself authenticate to the forge for `repo_dir` (NULL =
+ * "any forge identity at all"), under the same precedence as the resolvers above.
+ * Resolves and immediately wipes; never returns the token.
+ *
+ * This is the predicate the require_aimee_git restriction hangs off (operator
+ * ruling 2026-07-15). That rule says "do not shell out to git/gh — use aimee's
+ * git_* tools, which run on aimee-server". If aimee-server holds no credential,
+ * aimee's tools cannot do git either, so blocking the shell would remove the only
+ * working route rather than redirect it, and strip credentials a delegate needs
+ * with nothing to offer in their place. No aimee route -> no restriction. */
+int git_cred_forge_configured(const char *repo_dir);
+
 /* Free an envp from git_cred_inject_build_env (zeroes the GH_TOKEN entry first). */
 void git_cred_inject_free_env(char **envp);
 

--- a/src/headers/mcp_git.h
+++ b/src/headers/mcp_git.h
@@ -24,6 +24,22 @@ cJSON *handle_git_reset(cJSON *args);
 cJSON *handle_git_restore(cJSON *args);
 cJSON *handle_git_issue(cJSON *args);
 
+/* Run a git tool by NAME through the full git dispatch path: mirror-cwd remap,
+ * detached-workspace binding, mcp_chdir_git_root (which REFUSES rather than let a
+ * mutating op run against the main repo), the mutating-op context-mismatch guard,
+ * and the handler itself — then unwinds all of it. Returns MCP content blocks
+ * (caller owns), or NULL for an unknown tool.
+ *
+ * Exists so the NATIVE agent surface executes git through the SAME path as an
+ * external MCP client rather than a second implementation that could drift: the
+ * write handlers own the safety rails (branch ownership, the verify gate,
+ * AI-attribution stripping), and those must not depend on which surface called in.
+ *
+ * git_verify is deliberately NOT reachable here — it needs the server ctx/conn the
+ * MCP path supplies, and the native agent has its own `verify` tool. `sid`, when
+ * non-empty, sets the session-id override for the call. */
+cJSON *mcp_git_run_tool(const char *tool, cJSON *args, const char *sid);
+
 /* Track whether the current MCP git operation is running in a worktree. */
 void mcp_git_set_worktree(int val);
 int mcp_git_get_worktree(void);

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -7,7 +7,6 @@
 #include "aimee_home.h"
 #include "delegate_ephemeral_ws.h"
 #include "log.h"
-#include "mcp_git.h" /* mcp_git_run_tool: git writes go through the MCP dispatch */
 #include "tool_condense.h"
 #include "tool_args_coerce.h"
 #include "workspace_provider.h"
@@ -1568,6 +1567,39 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
          cJSON_Delete(args);
          return current_code_role_policy_error(
              active_role, "mutating or broad aimee context commands are disabled for this role");
+      }
+   }
+
+   /* --- No git/gh in a delegate's shell (require_aimee_git) --- */
+   /* The native agent IS the wfe `implement` delegate, so this is the path that
+    * decides whether the rule means anything at all. The DECISION lives server-side
+    * behind a seam (see agent_tools.h): it needs the config dial, the forge
+    * credential and the command classifier, none of which the agent tier may link.
+    * Unregistered — thin client, unit tests — there is no gate and nothing changes. */
+   {
+      const char *shell_cmd = NULL;
+      if (strcmp(name, "bash") == 0)
+      {
+         cJSON *c = cJSON_GetObjectItem(args, "command");
+         if (cJSON_IsString(c))
+            shell_cmd = c->valuestring;
+      }
+      else if (strcmp(name, "execute_script") == 0)
+      {
+         cJSON *b = cJSON_GetObjectItem(args, "body");
+         if (cJSON_IsString(b))
+            shell_cmd = b->valuestring;
+      }
+      agent_shell_git_gate_fn gate = agent_tools_shell_git_gate();
+      if (shell_cmd && gate && gate(shell_cmd))
+      {
+         cJSON_Delete(args);
+         return safe_strdup(
+             "error: run git through aimee, not a shell — use git_status, git_log, "
+             "git_diff, git_branch, git_commit, git_push or git_pr. They execute on "
+             "aimee-server, which holds the forge credential; this shell has none, so a "
+             "raw git/gh command cannot authenticate anyway. (Operator: "
+             "require_aimee_git: false in aimee.yaml opts out.)");
       }
    }
 

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -7,6 +7,7 @@
 #include "aimee_home.h"
 #include "delegate_ephemeral_ws.h"
 #include "log.h"
+#include "mcp_git.h" /* mcp_git_run_tool: git writes go through the MCP dispatch */
 #include "tool_condense.h"
 #include "tool_args_coerce.h"
 #include "workspace_provider.h"
@@ -725,6 +726,57 @@ static char *td_git_status(cJSON *args, const char *name, const char *dispatch_c
    else
       result = tool_git_status(p->valuestring);
 
+   return result;
+}
+
+/* The git WRITE tools (commit / push / branch / pr). Rather than reimplement them
+ * for this surface, hand off through the git-write seam to the server's MCP git
+ * dispatch — the same path an external MCP client goes through — so the worktree
+ * refusal, mutating-context guard, branch-ownership check and attribution strip
+ * cannot drift between the two surfaces. The seam (rather than a direct call) keeps
+ * the agent tier from linking the server tier; see agent_tools.h.
+ *
+ * `cwd` is injected from the dispatcher's cwd when the caller did not name a path,
+ * because mcp_chdir_git_root resolves the repo from that arg; without it the
+ * handler would resolve against the daemon's cwd — the bug #1318 fixed on the
+ * verify gate. The handler returns MCP content blocks; the native surface wants a
+ * plain string, so flatten the text blocks. */
+static char *td_git_write(cJSON *args, const char *name, const char *dispatch_cwd,
+                          const char *dispatch_sid, int timeout_ms)
+{
+   (void)timeout_ms;
+   agent_git_write_fn fn = agent_tools_git_write_provider();
+   if (!fn) /* not advertised without a provider, so this is a caller inventing a name */
+      return safe_strdup("error: git tools are not available on this surface");
+
+   cJSON *call = cJSON_Duplicate(args, 1);
+   if (!call)
+      return safe_strdup("error: out of memory");
+   cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(call, "cwd");
+   if (!jcwd && dispatch_cwd && dispatch_cwd[0])
+      cJSON_AddStringToObject(call, "cwd", dispatch_cwd);
+
+   cJSON *content = fn(name, call, dispatch_sid);
+   cJSON_Delete(call);
+   if (!content)
+      return safe_strdup("error: git tool unavailable on this surface");
+
+   dstr_t out;
+   dstr_init(&out);
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, content)
+   {
+      cJSON *text = cJSON_GetObjectItemCaseSensitive(item, "text");
+      if (cJSON_IsString(text) && text->valuestring)
+      {
+         if (out.len)
+            dstr_append_char(&out, '\n');
+         dstr_append_str(&out, text->valuestring);
+      }
+   }
+   cJSON_Delete(content);
+   char *result = safe_strdup(out.len && out.data ? out.data : "(no output)");
+   dstr_free(&out);
    return result;
 }
 
@@ -1607,6 +1659,9 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
       result = td_git_diff(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "git_status") == 0)
       result = td_git_status(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
+   else if (strcmp(name, "git_commit") == 0 || strcmp(name, "git_push") == 0 ||
+            strcmp(name, "git_branch") == 0 || strcmp(name, "git_pr") == 0)
+      result = td_git_write(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "env_get") == 0)
       result = td_env_get(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else if (strcmp(name, "test") == 0)

--- a/src/server/agent_parallel.c
+++ b/src/server/agent_parallel.c
@@ -50,8 +50,13 @@ static void *parallel_worker(void *arg)
    /* Per-task temperature, defaulting to the historical 0.3 when unset (0). */
    double temp = ctx->task->temperature > 0.0 ? ctx->task->temperature : 0.3;
    if (ctx->task->agent && ctx->task->agent[0])
-      agent_run_named(ctx->cfg, ctx->task->agent, ctx->task->role, ctx->task->system_prompt,
-                      ctx->task->user_prompt, ctx->task->max_tokens, temp, ctx->result);
+      (ctx->task->use_tools ? agent_run_named_with_tools : agent_run_named)(
+          ctx->cfg, ctx->task->agent, ctx->task->role, ctx->task->system_prompt,
+          ctx->task->user_prompt, ctx->task->max_tokens, temp, ctx->result);
+   else if (ctx->task->use_tools)
+      agent_run_with_tools_write_enforce(ctx->cfg, ctx->task->role, ctx->task->system_prompt,
+                                         ctx->task->user_prompt, ctx->task->max_tokens, 1,
+                                         ctx->result);
    else
       agent_run_ex(ctx->cfg, ctx->task->role, ctx->task->system_prompt, ctx->task->user_prompt,
                    ctx->task->max_tokens, temp, ctx->result);
@@ -215,8 +220,13 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int task_count,
       double temp = tasks[0].temperature > 0.0 ? tasks[0].temperature : 0.3;
       int rc;
       if (tasks[0].agent && tasks[0].agent[0])
-         rc = agent_run_named(cfg, tasks[0].agent, tasks[0].role, tasks[0].system_prompt,
-                              tasks[0].user_prompt, tasks[0].max_tokens, temp, &out[0]);
+         rc = (tasks[0].use_tools ? agent_run_named_with_tools : agent_run_named)(
+             cfg, tasks[0].agent, tasks[0].role, tasks[0].system_prompt, tasks[0].user_prompt,
+             tasks[0].max_tokens, temp, &out[0]);
+      else if (tasks[0].use_tools)
+         rc = agent_run_with_tools_write_enforce(cfg, tasks[0].role, tasks[0].system_prompt,
+                                                 tasks[0].user_prompt, tasks[0].max_tokens, 1,
+                                                 &out[0]);
       else
          rc = agent_run_ex(cfg, tasks[0].role, tasks[0].system_prompt, tasks[0].user_prompt,
                            tasks[0].max_tokens, temp, &out[0]);

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -411,6 +411,40 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    return rc;
 }
 
+int agent_run_named_with_tools(agent_config_t *cfg, const char *name, const char *role,
+                               const char *system_prompt, const char *user_prompt, int max_tokens,
+                               double temperature, agent_result_t *out)
+{
+   memset(out, 0, sizeof(*out));
+
+   agent_t *src = agent_find(cfg, name);
+   if (!src || !src->enabled)
+   {
+      snprintf(out->agent_name, MAX_AGENT_NAME, "%s", name ? name : "");
+      snprintf(out->error, sizeof(out->error), "named participant '%s' not found or disabled",
+               name ? name : "(null)");
+      return -1;
+   }
+
+   agent_t local = *src; /* clone before mutating — see agent_run_named */
+   agent_apply_runtime_config(&local);
+   local.ablation = cfg->ablation;
+   /* write_capable stays 0: this exists for REVIEWERS, and a reviewer that can edit
+    * the code it is judging is not a reviewer — the tree that passed the gate would
+    * no longer be the tree that was judged. The role's toolset (review -> the
+    * index-only `review_indexed`) is what actually decides which tools appear. */
+   local.write_capable = 0;
+
+   int rc = agent_dispatch_one(&local, &cfg->network, role, system_prompt, user_prompt, max_tokens,
+                               temperature, 1 /* use_tools */, out);
+   {
+      agent_outcome_t oc;
+      classify_outcome(out, local.max_turns, &oc);
+      record_outcome(out->agent_name, role ? role : "ensemble", &oc);
+   }
+   return rc;
+}
+
 static int agent_run_with_tools_internal(agent_config_t *cfg, const char *role,
                                          const char *system_prompt, const char *user_prompt,
                                          int max_tokens, int enforce_writes, agent_result_t *out)

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -721,6 +721,74 @@ static cJSON *tp_git_diff(void)
    return params;
 }
 
+/* The git WRITE tools. These exist so a delegate has an aimee route to commit /
+ * push / open a PR at all: before this, the native builtin set carried read-only
+ * git (log/diff/status), so the ONLY way for a delegate to land work was shelling
+ * out to `git` — which is exactly what require_aimee_git forbids. A rule with no
+ * permitted alternative is just breakage, so the tools land first.
+ *
+ * They dispatch through mcp_git_run_tool, i.e. the same path an external MCP
+ * client takes, so the safety rails (worktree refusal, branch ownership, the
+ * verify gate, AI-attribution stripping) hold identically on both surfaces. */
+static cJSON *tp_git_commit(void)
+{
+   cJSON *params = tp_obj();
+   cJSON *props = cJSON_CreateObject();
+   tp_prop(props, "message", "string", "Commit message");
+   tp_prop(props, "path", "string",
+           "Path to the git repository (defaults to the session worktree)");
+   tp_prop(props, "add_all", "boolean", "Stage all modified/untracked files first (default false)");
+   cJSON_AddItemToObject(params, "properties", props);
+   cJSON *req = cJSON_CreateArray();
+   cJSON_AddItemToArray(req, cJSON_CreateString("message"));
+   cJSON_AddItemToObject(params, "required", req);
+   return params;
+}
+
+static cJSON *tp_git_push(void)
+{
+   cJSON *params = tp_obj();
+   cJSON *props = cJSON_CreateObject();
+   tp_prop(props, "path", "string",
+           "Path to the git repository (defaults to the session worktree)");
+   tp_prop(props, "set_upstream", "boolean", "Push with -u to set upstream (default false)");
+   cJSON_AddItemToObject(params, "properties", props);
+   cJSON_AddItemToObject(params, "required", cJSON_CreateArray());
+   return params;
+}
+
+static cJSON *tp_git_branch(void)
+{
+   cJSON *params = tp_obj();
+   cJSON *props = cJSON_CreateObject();
+   tp_prop(props, "action", "string", "list | create | claim | current");
+   tp_prop(props, "name", "string", "Branch name (for create/claim)");
+   tp_prop(props, "path", "string",
+           "Path to the git repository (defaults to the session worktree)");
+   cJSON_AddItemToObject(params, "properties", props);
+   cJSON *req = cJSON_CreateArray();
+   cJSON_AddItemToArray(req, cJSON_CreateString("action"));
+   cJSON_AddItemToObject(params, "required", req);
+   return params;
+}
+
+static cJSON *tp_git_pr(void)
+{
+   cJSON *params = tp_obj();
+   cJSON *props = cJSON_CreateObject();
+   tp_prop(props, "action", "string",
+           "create | view | list | edit | checks | merge_status | merge");
+   tp_prop(props, "number", "integer", "PR number (for view/edit/checks/merge_status/merge)");
+   tp_prop(props, "title", "string", "PR title (for create/edit)");
+   tp_prop(props, "body", "string", "PR body (for create/edit)");
+   tp_prop(props, "base", "string", "Base branch (for create/edit)");
+   cJSON_AddItemToObject(params, "properties", props);
+   cJSON *req = cJSON_CreateArray();
+   cJSON_AddItemToArray(req, cJSON_CreateString("action"));
+   cJSON_AddItemToObject(params, "required", req);
+   return params;
+}
+
 static cJSON *tp_git_status(void)
 {
    cJSON *params = tp_obj();
@@ -946,6 +1014,25 @@ static const builtin_tool_def_t g_builtin_tools[] = {
      TSURF_ALL},
     {"git_status", "Show git status (porcelain format) for a repository.", tp_git_status,
      TSURF_ALL},
+    /* Git writes go through these, never through `bash`: they run on aimee-server,
+     * where the forge credential is resolved per call and stays in process memory
+     * instead of reaching a child's environment. They also carry the rails a raw
+     * `git` command has no idea about — branch ownership, the verify gate, and
+     * attribution stripping. Appended after the read-only git tools so the
+     * pre-existing surface order (which the tools/list golden pins) is untouched. */
+    {"git_commit",
+     "Commit staged (or, with add_all, all) changes in the session worktree. Use this instead "
+     "of running `git commit` in a shell.",
+     tp_git_commit, TSURF_ALL},
+    {"git_push",
+     "Push the current branch to the forge. Authenticates on aimee-server; you do not need "
+     "(and will not have) git credentials. Use this instead of running `git push`.",
+     tp_git_push, TSURF_ALL},
+    {"git_branch", "List, create, claim, or show the current git branch.", tp_git_branch,
+     TSURF_ALL},
+    {"git_pr",
+     "Create, view, list, edit, or check a pull request. Use this instead of running `gh`.",
+     tp_git_pr, TSURF_ALL},
     {"env_get", "Get the value of an environment variable.", tp_env_get, TSURF_ALL},
     {"test",
      "Check file/dir existence, type, and permissions. "
@@ -1007,6 +1094,28 @@ static const builtin_tool_def_t g_builtin_tools[] = {
  * using that surface's JSON shape:
  *   TSURF_CHAT: {"type":"function","function":{name,description,parameters}}
  *   TSURF_RESP: {"type":"function",name,description,parameters}            */
+/* The git-write seam. Registered by the server at startup; NULL everywhere else
+ * (thin client, unit tests), where the git-write tools are simply not offered. */
+static agent_git_write_fn g_git_write_fn = NULL;
+
+void agent_tools_set_git_write_provider(agent_git_write_fn fn)
+{
+   g_git_write_fn = fn;
+}
+
+agent_git_write_fn agent_tools_git_write_provider(void)
+{
+   return g_git_write_fn;
+}
+
+int agent_tools_is_git_write(const char *name)
+{
+   if (!name)
+      return 0;
+   return strcmp(name, "git_commit") == 0 || strcmp(name, "git_push") == 0 ||
+          strcmp(name, "git_branch") == 0 || strcmp(name, "git_pr") == 0;
+}
+
 static void emit_builtin_tools(cJSON *tools, unsigned surface)
 {
    size_t n = sizeof(g_builtin_tools) / sizeof(g_builtin_tools[0]);
@@ -1014,6 +1123,12 @@ static void emit_builtin_tools(cJSON *tools, unsigned surface)
    {
       const builtin_tool_def_t *d = &g_builtin_tools[i];
       if (!(d->surfaces & surface))
+         continue;
+      /* Never advertise a tool that cannot run: without the server's git dispatcher
+       * the git-write tools have no implementation behind them. Offering them anyway
+       * would teach an agent to call a tool that always errors — and, worse, would
+       * let require_aimee_git point at tools that do not exist. */
+      if (agent_tools_is_git_write(d->name) && !g_git_write_fn)
          continue;
       cJSON *tool = cJSON_CreateObject();
       cJSON_AddStringToObject(tool, "type", "function");

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -1116,6 +1116,18 @@ int agent_tools_is_git_write(const char *name)
           strcmp(name, "git_branch") == 0 || strcmp(name, "git_pr") == 0;
 }
 
+static agent_shell_git_gate_fn g_shell_git_gate = NULL;
+
+void agent_tools_set_shell_git_gate(agent_shell_git_gate_fn fn)
+{
+   g_shell_git_gate = fn;
+}
+
+agent_shell_git_gate_fn agent_tools_shell_git_gate(void)
+{
+   return g_shell_git_gate;
+}
+
 static void emit_builtin_tools(cJSON *tools, unsigned surface)
 {
    size_t n = sizeof(g_builtin_tools) / sizeof(g_builtin_tools[0]);

--- a/src/server/cli_claude.c
+++ b/src/server/cli_claude.c
@@ -42,6 +42,19 @@ static int claude_build_argv(const provider_cli_cfg_t *cfg, char **tokens, int c
    CLAUDE_ADD_ARG("stream-json");
    CLAUDE_ADD_ARG("--verbose");
    CLAUDE_ADD_ARG("--include-partial-messages");
+   /* Hand the delegate aimee. `aimee mcp serve` is the stdio MCP proxy that
+    * forwards tool calls to this server over /v1, so a spawned CLI delegate reaches
+    * the same tools a native agent does — git_commit / git_push / git_pr, memory,
+    * the code index — instead of the nothing it had before. Without this a delegate
+    * has no aimee tools at all, and its only route to git is a raw shell with
+    * whatever credentials it inherits: exactly backwards.
+    *
+    * The binary ships in the server image (Dockerfile.server) and resolves its
+    * endpoint + bearer from AIMEE_API_ENDPOINT and AIMEE_HOME's aimee.yaml, both of
+    * which the spawn exports (provider_cli_adapter). */
+   CLAUDE_ADD_ARG("--mcp-config");
+   CLAUDE_ADD_ARG(
+       "{\"mcpServers\":{\"aimee\":{\"command\":\"aimee\",\"args\":[\"mcp\",\"serve\"]}}}");
    CLAUDE_ADD_ARG("--allowedTools");
    CLAUDE_ADD_ARG("Bash(*)");
    CLAUDE_ADD_ARG("Edit");
@@ -52,6 +65,7 @@ static int claude_build_argv(const provider_cli_cfg_t *cfg, char **tokens, int c
    CLAUDE_ADD_ARG("WebFetch");
    CLAUDE_ADD_ARG("WebSearch");
    CLAUDE_ADD_ARG("NotebookEdit");
+   CLAUDE_ADD_ARG("mcp__aimee"); /* the aimee MCP server's tools */
    CLAUDE_ADD_ARG("--disallowedTools");
    /* Enforce delegate-only: block Claude Code's CLIENT-SIDE subagent tools so the
     * primary must use aimee delegates. `Task` is Claude Code's real sub-agent

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1142,6 +1142,17 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
        * the diverse lineup); the round prompt still drives the output shape. */
       personas[i] = panel_persona_prompt(cfg, mode, i);
       tasks[i].role = mode == ROUNDTABLE_REVIEW ? "review" : "draft";
+      /* Reviewers get aimee. A panelist holding only a diff cannot answer the
+       * questions that decide whether a change is REAL — does anything call this?
+       * is this new file product or run bookkeeping? — because those facts live
+       * outside the diff. Blind reviews pass blind: one slice cleared 12 rounds
+       * still carrying its own scope artifact, and a guard was approved that no
+       * deployed path could ever execute. The `review` role resolves to the
+       * index-only `review_indexed` toolset (code_search / find_symbol /
+       * search_memory / search_docs), so panelists navigate the repo through
+       * aimee's own index rather than a worktree a remote seat cannot reach, and
+       * still get no write tools. Drafting stays tool-less. */
+      tasks[i].use_tools = (mode == ROUNDTABLE_REVIEW);
       tasks[i].agent = cfg->ensemble_reference_models[i];
       tasks[i].system_prompt = personas[i];
       tasks[i].user_prompt = prompts[i];

--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -198,6 +198,16 @@ int git_cred_inject_resolve_token(const char *principal, const char *remote_url,
    return resolve_token(principal, remote_url, repo_dir, preferred_token, out, cap);
 }
 
+int git_cred_forge_configured(const char *repo_dir)
+{
+   char token[GIT_CRED_TOKEN_MAX] = {0};
+   int have = (resolve_token(NULL, NULL, repo_dir, NULL, token, sizeof(token)) == 1 && token[0]);
+   volatile char *p = (volatile char *)token; /* never let the token outlive the check */
+   for (size_t i = 0; i < sizeof(token); i++)
+      p[i] = 0;
+   return have;
+}
+
 void git_cred_inject_free_env(char **envp)
 {
    if (!envp)

--- a/src/server/provider_cli_adapter.c
+++ b/src/server/provider_cli_adapter.c
@@ -3,6 +3,7 @@
 
 #include "aimee.h"
 #include "cJSON.h"
+#include "aimee_home.h"      /* aimee_home() — the delegate's /v1 socket path */
 #include "git_cred_inject.h" /* git_cred_forge_configured — no aimee route, no strip */
 #include "util.h"
 
@@ -401,6 +402,20 @@ static void delegate_child_strip_forge_creds(int flag)
    setenv("GIT_TERMINAL_PROMPT", "0", 1);
 }
 
+/* Point the delegate's `aimee` CLI at THIS server, so its MCP proxy
+ * (`aimee mcp serve`, wired in cli_claude.c) has somewhere to forward to. The /v1
+ * Unix socket is the right transport here: it is always served, needs no TCP port
+ * (server_api_http_port defaults to 0/disabled) and no network bearer.
+ *
+ * Never overwrites: an operator who set AIMEE_API_ENDPOINT explicitly means it.
+ * Pre-resolved by the parent — see delegate_child_strip_forge_creds on why the
+ * child does no allocation. */
+static void delegate_child_export_aimee_endpoint(const char *endpoint)
+{
+   if (endpoint && endpoint[0])
+      setenv("AIMEE_API_ENDPOINT", endpoint, 0);
+}
+
 int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], int *stdin_fd,
                             int *stdout_fd, pid_t *pid_out)
 {
@@ -419,6 +434,15 @@ int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], i
    config_t spawn_cfg;
    int strip_forge_creds = ((config_load(&spawn_cfg) != 0) || spawn_cfg.require_aimee_git) &&
                            git_cred_forge_configured(NULL);
+
+   /* Resolve the delegate's aimee endpoint before forking (aimee_home may read/
+    * allocate). See delegate_child_export_aimee_endpoint. */
+   char aimee_endpoint[MAX_PATH_LEN + 32] = "";
+   {
+      const char *home = aimee_home();
+      if (home && home[0])
+         snprintf(aimee_endpoint, sizeof(aimee_endpoint), "unix:%s/aimee-http.sock", home);
+   }
 
    int in_pipe[2] = {-1, -1};
    int out_pipe[2] = {-1, -1};
@@ -465,6 +489,7 @@ int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], i
        * source context from the forking thread's TLS, immune to the parent-side
        * concurrent env clobber. */
       delegate_child_export_context_env();
+      delegate_child_export_aimee_endpoint(aimee_endpoint);
       delegate_child_strip_forge_creds(strip_forge_creds);
       execvp(argv[0], argv);
       _exit(127);

--- a/src/server/provider_cli_adapter.c
+++ b/src/server/provider_cli_adapter.c
@@ -3,6 +3,7 @@
 
 #include "aimee.h"
 #include "cJSON.h"
+#include "git_cred_inject.h" /* git_cred_forge_configured — no aimee route, no strip */
 #include "util.h"
 
 #include <errno.h>
@@ -407,9 +408,17 @@ int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], i
       return -1;
 
    /* Resolve the dial BEFORE forking (see delegate_child_strip_forge_creds).
-    * Unreadable config reads as enforcing: a guard that fails open is not a guard. */
+    * Unreadable config reads as enforcing: a guard that fails open is not a guard.
+    *
+    * ...but ONLY strip when aimee-server actually holds a forge credential
+    * (operator ruling 2026-07-15). The point of taking the delegate's credentials
+    * away is to push its git through aimee, which runs on the server. If the server
+    * has no credential, aimee's git cannot work either, so stripping would remove
+    * the delegate's only route and leave it nothing — breakage dressed as policy.
+    * No aimee route, no restriction. */
    config_t spawn_cfg;
-   int strip_forge_creds = (config_load(&spawn_cfg) != 0) || spawn_cfg.require_aimee_git;
+   int strip_forge_creds = ((config_load(&spawn_cfg) != 0) || spawn_cfg.require_aimee_git) &&
+                           git_cred_forge_configured(NULL);
 
    int in_pipe[2] = {-1, -1};
    int out_pipe[2] = {-1, -1};

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -13,8 +13,10 @@
 #include "primary_cli_ingestor.h"
 #include "server.h"
 
-#include "agent_tools.h" /* agent_tools_set_git_write_provider */
-#include "mcp_git.h"     /* mcp_git_run_tool — the native surface's git-write impl */
+#include "agent_tools.h"     /* agent_tools_set_git_write_provider / _set_shell_git_gate */
+#include "git_cred_inject.h" /* git_cred_forge_configured — no aimee route, no restriction */
+#include "mcp_git.h"         /* mcp_git_run_tool — the native surface's git-write impl */
+#include "wfe_native_gate.h" /* wfe_shell_invokes_git — the shell-git classifier */
 #include "turn_registry.h"
 #include "server_http.h"
 #include "server_tls.h" /* server_http_api_status_report */
@@ -1889,6 +1891,28 @@ static int server_bootstrap_resolve_agent(const char *name, char *canon, size_t 
    return 1;
 }
 
+/* The shell-git gate (agent_tools.h): 1 = refuse this shell command, git belongs to
+ * aimee. Lives here because the decision needs three things from three tiers that
+ * the agent tool surface must not link — the config dial, the command classifier,
+ * and the forge credential.
+ *
+ * Both extra conditions exist to keep the rule from becoming breakage:
+ *  - a forge credential must EXIST, or aimee's own git cannot work either and this
+ *    would take away the delegate's only route rather than redirect it;
+ *  - the caller only reaches here when the git_* tools are registered (server.c
+ *    wires this gate immediately after the provider), so we never forbid the shell
+ *    while the alternative is absent.
+ * An unreadable config reads as ON: a guard that fails open is not a guard. */
+static int server_shell_git_blocked(const char *command)
+{
+   if (!command || !command[0] || !wfe_shell_invokes_git("bash", command))
+      return 0;
+   config_t cfg;
+   if (config_load(&cfg) == 0 && !cfg.require_aimee_git)
+      return 0;
+   return git_cred_forge_configured(NULL);
+}
+
 int server_init(server_ctx_t *ctx, const char *socket_path)
 {
    memset(ctx, 0, sizeof(*ctx));
@@ -2079,6 +2103,12 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * rails), so a thin client or a unit test is never offered a tool that would
     * fail on it. */
    agent_tools_set_git_write_provider(mcp_git_run_tool);
+   /* ...and only THEN forbid the shell route. Registered after the provider, and
+    * only when refusing is honest: the tools we redirect to are now available, and
+    * server_shell_git_blocked additionally requires a forge credential to exist.
+    * A rule whose alternative is missing is breakage, so the alternative is wired
+    * first and the rule hangs off it. */
+   agent_tools_set_shell_git_gate(server_shell_git_blocked);
    /* Boot-time enforcement-posture signal for the primary-CLI-ingestor: makes an
     * "enabled but silently inert" misconfig (flag on, dial off) visible at startup. */
    primary_cli_ingestor_log_posture();

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -12,6 +12,9 @@
 #include "memory_redirect.h"       /* memory_redirect_classify / _bash_targets / _rematerialize */
 #include "primary_cli_ingestor.h"
 #include "server.h"
+
+#include "agent_tools.h" /* agent_tools_set_git_write_provider */
+#include "mcp_git.h"     /* mcp_git_run_tool — the native surface's git-write impl */
 #include "turn_registry.h"
 #include "server_http.h"
 #include "server_tls.h" /* server_http_api_status_report */
@@ -2068,6 +2071,14 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * end-to-end server-side. Registration runs nothing on its own — a run begins
     * only when intake creates a work item and the autonomy driver advances it. */
    wfe_autonomy_register();
+   /* Hand the native agent surface aimee's git-write tools. Without this the
+    * builtin set is read-only git, so a delegate's ONLY way to land work is to
+    * shell out to `git` — the thing we then tell it not to do. The tools are
+    * neither advertised nor dispatchable until this runs, which is deliberate:
+    * only aimee-server can honour them (it owns the credential and the MCP git
+    * rails), so a thin client or a unit test is never offered a tool that would
+    * fail on it. */
+   agent_tools_set_git_write_provider(mcp_git_run_tool);
    /* Boot-time enforcement-posture signal for the primary-CLI-ingestor: makes an
     * "enabled but silently inert" misconfig (flag on, dial off) visible at startup. */
    primary_cli_ingestor_log_posture();

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -1521,6 +1521,29 @@ static cJSON *dispatch_git_tool(server_ctx_t *ctx, server_conn_t *conn, const ch
    return content;
 }
 
+/* See mcp_git.h. The native agent surface's door into the git tools: one dispatch
+ * path, so a delegate committing through git_commit gets byte-for-byte the same
+ * chdir/worktree refusal, mutating-context guard, branch-ownership check and
+ * attribution strip an external MCP client gets. ctx/conn are NULL-safe here
+ * because every use of them sits behind the git_verify branch, which this refuses. */
+cJSON *mcp_git_run_tool(const char *tool, cJSON *args, const char *sid)
+{
+   if (!tool || !tool[0])
+      return NULL;
+   if (strcmp(tool, "git_verify") == 0)
+      return NULL; /* needs the server ctx/conn; native agents use their own `verify` */
+   int known = 0;
+   for (size_t i = 0; i < sizeof(git_tool_table) / sizeof(git_tool_table[0]); i++)
+      if (strcmp(tool, git_tool_table[i].name) == 0)
+      {
+         known = 1;
+         break;
+      }
+   if (!known)
+      return NULL;
+   return dispatch_git_tool(NULL, NULL, tool, args, sid);
+}
+
 /* ── Discovery meta-tools (P2) ────────────────────────────────────────────────
  * find_tools / describe_tool introspect the FULL served catalog (unfiltered by
  * the presentation profile) so a lean tools/list loses no reach: the model can

--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -16,9 +16,13 @@
  * review agent is eligible right now the panel QUEUES for a seat up to
  * AIMEE_PANEL_SEAT_WAIT_SECS before the gate degrades.
  *
- * NOTE: panelists are tool-less (the engine embeds the change in the prompt),
- * so the panel no longer touches the worktree at all; only the verification
- * pass reads it. Dispatch requires reachable review agents, so this provider is
+ * NOTE: the engine embeds the change in the prompt, and panelists additionally
+ * carry aimee's INDEX-ONLY review toolset (`review_indexed`: code_search /
+ * find_symbol / search_memory / search_docs) so they can check what the diff
+ * cannot show — callers, writers, whether a named alternative exists. Still no
+ * filesystem or write tools: the panel does not touch the worktree (a remote seat
+ * may not reach it, and a reviewer must not edit what it judges); only the
+ * verification pass reads it. Dispatch requires reachable review agents, so this provider is
  * exercised by integration (a live deployment); the risk-bearing pieces — the
  * verdict mapping and the worktree replay backend — are unit-tested in
  * test_wfe_panel_roundtable / test_wfe_replay_worktree. */
@@ -69,9 +73,11 @@ static long wfe_panel_seat_wait_secs(void)
 
 #define WFE_PANEL_SEAT_POLL_SECS 15
 
-/* The engine review task: what was asked plus the change under review. The
- * panelists are tool-less — the diff IS the material — and the engine's own
- * REVIEW round instruction supplies the structured-items output contract
+/* The engine review task: what was asked, the change under review, and the standing
+ * questions the diff alone cannot answer. Panelists carry aimee's index-only
+ * toolset, so the diff is the SUBJECT rather than the whole of the material — they
+ * look up callers, writers and alternatives themselves. The engine's own REVIEW
+ * round instruction supplies the structured-items output contract
  * (severity/category/location/summary/recommendation + replayable evidence). */
 static char *build_review_task(const wfe_review_packet_t *pkt)
 {
@@ -89,6 +95,19 @@ static char *build_review_task(const wfe_review_packet_t *pkt)
             "Review the CHANGE UNDER REVIEW below AGAINST what was asked.\n\n"
             "FOCUS: %s\n\nORIGINAL PROPOSAL/REQUEST:\n%.4000s\n\n"
             "CHANGE UNDER REVIEW (diff vs the base repo):\n%s\n\n"
+            "You have aimee's tools (code_search, find_symbol, search_memory, search_docs). "
+            "The diff shows what CHANGED; it does not show whether the change is REAL. Look "
+            "the rest up — do not infer it from the diff:\n"
+            "1. REACHABLE: for new behaviour, especially a guard/gate/check, find its callers. "
+            "Name the path from a real entrypoint to this code in the artifact that actually "
+            "ships. Code with no caller, or whose only caller needs a binary or config the "
+            "deployment lacks, is inert — that is a blocking defect no matter how correct the "
+            "code reads.\n"
+            "2. PRODUCT: every added file must be something we ship. Search for what writes it. "
+            "Run bookkeeping, scope/intent records and scratch files are not deliverables.\n"
+            "3. ALTERNATIVE EXISTS: if the change forbids or removes a way of doing something, "
+            "confirm the replacement it points people to actually exists and works on the "
+            "surface it targets. A rule with no working alternative is breakage.\n\n"
             "For every item, location is \"file:line\" from the change wherever possible, and a "
             "blocking severity REQUIRES reproducible factual evidence about this code.",
             focus, proposal, diff);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -44,6 +44,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/minimax_profile.o \
                              $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                              $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
+                             $(OBJDIR)/tests/support/git_cred_inject_stub.o \
                              $(OBJDIR)/gateway_delegate.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o \
                              $(PLATFORM_AGENT_OBJS)
 
@@ -903,6 +904,7 @@ $(TESTPREFIX)/unit-test-script-runner: $(OBJDIR)/tests/test_script_runner.o \
 
 $(TESTPREFIX)/unit-test-provider-cli-adapter: $(OBJDIR)/tests/test_provider_cli_adapter.o \
                       $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
+                      $(OBJDIR)/tests/support/git_cred_inject_stub.o \
                       $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o \
                       $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o \
                       $(OBJDIR)/server/cli_acp.o $(OBJDIR)/posix/workspace_provider.o \
@@ -911,6 +913,7 @@ $(TESTPREFIX)/unit-test-provider-cli-adapter: $(OBJDIR)/tests/test_provider_cli_
 
 $(TESTPREFIX)/unit-test-cli-acp: $(OBJDIR)/tests/test_cli_acp.o \
                       $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
+                      $(OBJDIR)/tests/support/git_cred_inject_stub.o \
                       $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o \
                       $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o \
                       $(OBJDIR)/server/cli_acp.o $(OBJDIR)/posix/workspace_provider.o \

--- a/src/tests/support/git_cred_inject_stub.c
+++ b/src/tests/support/git_cred_inject_stub.c
@@ -35,3 +35,14 @@ void git_cred_inject_free_env(char **envp)
 {
    (void)envp;
 }
+
+/* "aimee-server holds no forge credential", consistent with the NULL env above.
+ * For provider_cli_adapter's spawn that means the delegate credential strip does
+ * NOT apply — no aimee git route, no restriction — which is the honest answer for a
+ * test binary that has no vault, and keeps these tests exercising the spawn rather
+ * than a credential policy they never configured. */
+int git_cred_forge_configured(const char *repo_dir)
+{
+   (void)repo_dir;
+   return 0;
+}

--- a/src/tests/test_agent_parallel.c
+++ b/src/tests/test_agent_parallel.c
@@ -55,6 +55,40 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    snprintf(out->agent_name, sizeof(out->agent_name), "%s", name ? name : "");
    return 0;
 }
+/* The tools-enabled runners a task with use_tools routes to. They tag the response
+ * so a test can assert WHICH runner ran: a review panelist reaching aimee (rather
+ * than a plain completion) is the whole point of the flag. */
+int agent_run_named_with_tools(agent_config_t *cfg, const char *name, const char *role,
+                               const char *system_prompt, const char *user_prompt, int max_tokens,
+                               double temperature, agent_result_t *out)
+{
+   (void)cfg;
+   (void)role;
+   (void)system_prompt;
+   (void)user_prompt;
+   (void)max_tokens;
+   (void)temperature;
+   memset(out, 0, sizeof(*out));
+   out->response = strdup("ok+tools");
+   out->success = 1;
+   snprintf(out->agent_name, sizeof(out->agent_name), "%s", name ? name : "");
+   return 0;
+}
+int agent_run_with_tools_write_enforce(agent_config_t *cfg, const char *role,
+                                       const char *system_prompt, const char *user_prompt,
+                                       int max_tokens, int enforce_writes, agent_result_t *out)
+{
+   (void)cfg;
+   (void)role;
+   (void)system_prompt;
+   (void)user_prompt;
+   (void)max_tokens;
+   (void)enforce_writes;
+   memset(out, 0, sizeof(*out));
+   out->response = strdup("ok+tools");
+   out->success = 1;
+   return 0;
+}
 int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
                  const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
 {
@@ -131,11 +165,76 @@ static void test_no_deadline_runs_all(void)
    printf("  test_no_deadline_runs_all: ok\n");
 }
 
+/* use_tools picks the tools-enabled runner — the difference between a review
+ * panelist that can look up whether a change is reachable and one that can only
+ * squint at the diff. Both routes (by name, and by role) must honour it, and a task
+ * that does not ask for tools must still get the historical plain completion. */
+static void test_use_tools_routes_to_tools_runner(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+
+   /* single-task fast path, routed BY NAME */
+   agent_task_t named = {0};
+   named.role = "review";
+   named.user_prompt = "review this";
+   named.agent = "seat-1";
+   named.use_tools = 1;
+   agent_result_t out1;
+   memset(&out1, 0, sizeof(out1));
+   assert(agent_run_parallel(&cfg, &named, 1, &out1, 0) == 1);
+   assert(strcmp(out1.response, "ok+tools") == 0);
+   free(out1.response);
+
+   /* single-task fast path, routed BY ROLE (no agent name) */
+   agent_task_t byrole = {0};
+   byrole.role = "review";
+   byrole.user_prompt = "review this";
+   byrole.use_tools = 1;
+   agent_result_t out2;
+   memset(&out2, 0, sizeof(out2));
+   assert(agent_run_parallel(&cfg, &byrole, 1, &out2, 0) == 1);
+   assert(strcmp(out2.response, "ok+tools") == 0);
+   free(out2.response);
+
+   /* the default is unchanged: no use_tools -> the plain completion */
+   agent_task_t plain = {0};
+   plain.role = "draft";
+   plain.user_prompt = "draft this";
+   plain.agent = "seat-1";
+   agent_result_t out3;
+   memset(&out3, 0, sizeof(out3));
+   assert(agent_run_parallel(&cfg, &plain, 1, &out3, 0) == 1);
+   assert(strcmp(out3.response, "ok") == 0);
+   free(out3.response);
+
+   /* and through the threaded fan-out, not just the fast path */
+   agent_task_t many[2] = {0};
+   many[0].role = "review";
+   many[0].user_prompt = "a";
+   many[0].agent = "seat-1";
+   many[0].use_tools = 1;
+   many[1].role = "review";
+   many[1].user_prompt = "b";
+   many[1].agent = "seat-2";
+   many[1].use_tools = 1;
+   agent_result_t outn[2];
+   memset(outn, 0, sizeof(outn));
+   assert(agent_run_parallel(&cfg, many, 2, outn, 0) == 2);
+   for (int i = 0; i < 2; i++)
+   {
+      assert(strcmp(outn[i].response, "ok+tools") == 0);
+      free(outn[i].response);
+   }
+   printf("  test_use_tools_routes_to_tools_runner: ok\n");
+}
+
 int main(void)
 {
    printf("agent_parallel tests\n");
    test_deadline_abandons_hung_worker();
    test_no_deadline_runs_all();
+   test_use_tools_routes_to_tools_runner();
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Delegates were built around aimee but were never handed aimee. This gives it to all three kinds, and only then enforces the rule that says to use it.

## The hole

PR #1351 shipped `require_aimee_git` — "do not shell out to git/gh, use aimee's `git_*` tools". Two problems, found while trying to validate it on the appliance:

**It could not fire.** `Dockerfile.server:35` built only `aimee-server`. The classifier lives in `cmd_hooks` (needs the `aimee` CLI — **rc=127** in the container) and in the S2 hook (needs an external client to POST a PreToolUse). The wfe `implement` delegate is the NATIVE agent and reaches neither. Correct code, structurally inert.

**Had it fired, it would have broken everything.** The tools it points at did not exist for delegates:

| Delegate | git tools it had |
|---|---|
| Native agent (`implement` default) | `git_log`/`git_diff`/`git_status` — **read-only** |
| Provider-CLI (`claude`) | **none** — `Bash(*)`, no `--mcp-config`, no MCP server |

`git_commit`/`git_push`/`git_pr` existed only in `server_mcp.c`'s table — the surface for **external** MCP clients. A delegate's only route to land work was `bash git`. Forbidding it first would have left `implement` unable to commit at all.

## The fix, in order

**1. Native agents get aimee's git-write tools.** Reuses the ONE dispatch (`mcp_git_run_tool` exports `dispatch_git_tool`), so a native `git_commit` gets the same worktree refusal, branch-ownership, verify gate and attribution strip an external client gets — not a second write path that drifts.

**2. CLI delegates get the aimee MCP server.** The image now ships the CLI, and `cli_claude` registers `aimee mcp serve` (the existing stdio→/v1 proxy). The spawn exports `AIMEE_API_ENDPOINT=unix:<AIMEE_HOME>/aimee-http.sock` — always served, no TCP port (`server_api_http_port` defaults to 0), no network bearer.

Shipping the CLI also un-bricks `aimee hooks pre`. One omission had caused both failures.

**3. Only then, the gate.** Enforced in `agent_tools_dispatch` — where the `implement` delegate actually runs — behind three conditions, each preventing the rule from becoming breakage:
- the operator dial is on (unreadable config reads as ON; a guard that fails open is not a guard);
- **aimee-server actually holds a forge credential** — otherwise aimee's git cannot work either and this removes the delegate's only route rather than redirecting it (operator ruling);
- the `git_*` tools are **registered** — the gate is wired immediately after the provider, so the alternative always exists before the rule applies.

## Reviews were blind, and that is why 12 rounds missed it

A slice cleared **12 rounds** of roundtable still carrying its own scope artifact. The roundtable reviewed #1351 and never asked whether the guard could execute. Same cause, and it was not the lenses or the wording — the code says it outright:

> `wfe_live_panel.c:73` — "The panelists are tool-less — the diff IS the material"
> `delegate_ensemble.h:65` — "Panelists run with no tools, so this [pre-assembled context] is the only way they see aimee memory and the code graph"

A reviewer holding only a diff **cannot** answer "does anything call this?" or "is this file product?". 48 blind reviews are still blind.

Panelists now run with tools. The plumbing already pointed here: tasks already carry `role="review"`, and `toolset.c` already maps that to `review_indexed` — *"the reviewer works from the caller-provided diff plus aimee's branch-indexed capabilities"*. Designed for exactly this, never applied, because the fan-out ran the no-tools runner.

So a panelist gets the diff plus `code_search`/`find_symbol`/`search_memory`/`search_docs`. No filesystem, no writes — a reviewer that can edit what it judges is not a reviewer. The brief now asks the questions the diff cannot answer (reachable? product? does the named alternative exist?). Both real misses were answerable this way.

Fixes both surfaces: `gate.roundtable` and `aimee delegate roundtable` share the fan-out.

## Tier discipline

The agent tool surface is linked by binaries and tests carrying no server objects, so the decisions live server-side behind **seams** (the shape `wfe_set_forge_provider` already uses) and the server registers them at startup. `agent_tools_dispatch` gains **zero** new link deps. Unregistered — thin client, unit tests — the tools are neither advertised nor dispatchable and there is no gate: an agent is never offered a tool that cannot work.

Every seam is wired `declare → define → REGISTER → consume`. The missing REGISTER is exactly what made #1351 inert.

## Operator impact

- **Image gains the `aimee` CLI** (~2MB). Required: without it delegates have no MCP server and no hook.
- CLI delegates now spawn with an MCP server attached.
- Review panelists now make tool calls — reviews cost more and take longer. `s2` ran 12 rounds × ~4 seats, so this is a real multiplier on the dominant cost. Bounded by the existing `max_spend_usd`/`max_iters`; worth watching on first live run.
- `require_aimee_git` now actually bites on the native path — intended, and the reason the tools land first.

## Testing

`test_agent_parallel` asserts `use_tools` routes to the tools runner by name, by role, and through the threaded fan-out, and that the default is unchanged. `test_wfe_native_gate` and `test_git_pr_ci_grade` still green. All touched files clang-format clean.

**Not yet validated on the box** — a native delegate committing via `git_commit`, and `bash git commit` being refused. That validation gap is exactly what produced #1351's inert guard, so it is the next step, not an afterthought.