### PR TITLE
fix: the shell-git gate asked the wrong question and disabled itself

### DIFF
--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -91,11 +91,16 @@ int agent_tools_is_git_write(const char *name);
  * git-write provider — the decision needs the config dial, the forge credential and
  * the command classifier, which live in tiers the agent surface cannot link.
  *
- * The server only registers it when refusing is HONEST: the dial is on, aimee-server
- * actually holds a forge credential, and the git_* tools are available to point at.
+ * `cwd` is the directory the command would run in, and is REQUIRED for the decision
+ * to be correct rather than merely safe: "can aimee do git here?" is answered per
+ * repo (the credential ladder's per-host vault rung keys on the checkout's origin).
+ * Passing no directory collapses the question to "does the server have its own
+ * identity?", which most deployments never configure — the gate then concludes
+ * aimee has no git and never fires, on exactly the boxes where it should.
+ *
  * Unregistered, there is no gate — a rule with no working alternative is breakage,
  * not policy, so the absence of the alternative disables the rule by construction. */
-typedef int (*agent_shell_git_gate_fn)(const char *command);
+typedef int (*agent_shell_git_gate_fn)(const char *command, const char *cwd);
 void agent_tools_set_shell_git_gate(agent_shell_git_gate_fn fn);
 agent_shell_git_gate_fn agent_tools_shell_git_gate(void);
 

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -1570,39 +1570,6 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
       }
    }
 
-   /* --- No git/gh in a delegate's shell (require_aimee_git) --- */
-   /* The native agent IS the wfe `implement` delegate, so this is the path that
-    * decides whether the rule means anything at all. The DECISION lives server-side
-    * behind a seam (see agent_tools.h): it needs the config dial, the forge
-    * credential and the command classifier, none of which the agent tier may link.
-    * Unregistered — thin client, unit tests — there is no gate and nothing changes. */
-   {
-      const char *shell_cmd = NULL;
-      if (strcmp(name, "bash") == 0)
-      {
-         cJSON *c = cJSON_GetObjectItem(args, "command");
-         if (cJSON_IsString(c))
-            shell_cmd = c->valuestring;
-      }
-      else if (strcmp(name, "execute_script") == 0)
-      {
-         cJSON *b = cJSON_GetObjectItem(args, "body");
-         if (cJSON_IsString(b))
-            shell_cmd = b->valuestring;
-      }
-      agent_shell_git_gate_fn gate = agent_tools_shell_git_gate();
-      if (shell_cmd && gate && gate(shell_cmd))
-      {
-         cJSON_Delete(args);
-         return safe_strdup(
-             "error: run git through aimee, not a shell — use git_status, git_log, "
-             "git_diff, git_branch, git_commit, git_push or git_pr. They execute on "
-             "aimee-server, which holds the forge credential; this shell has none, so a "
-             "raw git/gh command cannot authenticate anyway. (Operator: "
-             "require_aimee_git: false in aimee.yaml opts out.)");
-      }
-   }
-
    /* --- Guardrail enforcement for ALL tool execution paths --- */
    /* dispatch_sid and cwd are kept in scope so read_file can update read-tracking below. */
    const char *dispatch_sid = session_id();
@@ -1618,6 +1585,45 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
          snprintf(dispatch_cwd, sizeof(dispatch_cwd), "%s", tl_cwd);
       else if (!getcwd(dispatch_cwd, sizeof(dispatch_cwd)))
          dispatch_cwd[0] = '\0';
+   }
+
+   /* --- No git/gh in a delegate's shell (require_aimee_git) --- */
+   /* The native agent IS the wfe `implement` delegate, so this is the path that
+    * decides whether the rule means anything at all. The DECISION lives server-side
+    * behind a seam (see agent_tools.h): it needs the config dial, the forge
+    * credential and the command classifier, none of which the agent tier may link.
+    * Unregistered — thin client, unit tests — there is no gate and nothing changes.
+    *
+    * Sits AFTER dispatch_cwd on purpose: the credential half of the decision asks
+    * whether aimee can do git FOR THIS REPO, and the per-host vault rung resolves
+    * that from the checkout's origin. Asked without a directory it can only see the
+    * server's own identity, which most deployments do not set — the gate then reads
+    * "aimee has no git" and silently never fires. */
+   {
+      const char *shell_cmd = NULL;
+      if (strcmp(name, "bash") == 0)
+      {
+         cJSON *c = cJSON_GetObjectItem(args, "command");
+         if (cJSON_IsString(c))
+            shell_cmd = c->valuestring;
+      }
+      else if (strcmp(name, "execute_script") == 0)
+      {
+         cJSON *b = cJSON_GetObjectItem(args, "body");
+         if (cJSON_IsString(b))
+            shell_cmd = b->valuestring;
+      }
+      agent_shell_git_gate_fn gate = agent_tools_shell_git_gate();
+      if (shell_cmd && gate && gate(shell_cmd, dispatch_cwd))
+      {
+         cJSON_Delete(args);
+         return safe_strdup(
+             "error: run git through aimee, not a shell — use git_status, git_log, "
+             "git_diff, git_branch, git_commit, git_push or git_pr. They execute on "
+             "aimee-server, which holds the forge credential; this shell has none, so a "
+             "raw git/gh command cannot authenticate anyway. (Operator: "
+             "require_aimee_git: false in aimee.yaml opts out.)");
+      }
    }
 
    {

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1903,14 +1903,21 @@ static int server_bootstrap_resolve_agent(const char *name, char *canon, size_t 
  *    wires this gate immediately after the provider), so we never forbid the shell
  *    while the alternative is absent.
  * An unreadable config reads as ON: a guard that fails open is not a guard. */
-static int server_shell_git_blocked(const char *command)
+static int server_shell_git_blocked(const char *command, const char *cwd)
 {
    if (!command || !command[0] || !wfe_shell_invokes_git("bash", command))
       return 0;
    config_t cfg;
    if (config_load(&cfg) == 0 && !cfg.require_aimee_git)
       return 0;
-   return git_cred_forge_configured(NULL);
+   /* Ask per REPO, not in the abstract. The credential ladder resolves a per-host
+    * vault token from the checkout's origin, so `cwd` is what makes "can aimee do
+    * git here?" answerable. Passing NULL leaves only the server's own identity rung
+    * (AIMEE_FORGE_TOKEN / a forge App), which most deployments never set — the gate
+    * would then read "aimee has no git" and never fire, on precisely the boxes whose
+    * forge works fine through a vaulted per-host token. Found on .254: the forge had
+    * opened a real PR minutes earlier while this check returned 0. */
+   return git_cred_forge_configured(cwd);
 }
 
 int server_init(server_ctx_t *ctx, const char *socket_path)


### PR DESCRIPTION
Found by deploying #1352 to .254 and running a real delegate. The gate never fired.

## What happened

`server_shell_git_blocked` passed `NULL` as the repo to `git_cred_forge_configured`. The credential ladder is:

```
1. caller-supplied token   (needs preferred_token)
2. per-host vault token    (needs remote_url OR repo_dir)   <- skipped
3. principal vault token   (needs principal)                <- skipped
4. server own identity     (AIMEE_FORGE_TOKEN / forge App)  <- the only rung reachable with NULL
```

With no repo, only rung 4 is testable. On .254 `AIMEE_FORGE_TOKEN` is **unset** and no forge App is configured — so the check returned 0, meaning "aimee has no git", and the gate **disabled itself by design**.

Minutes earlier that same box opened PR #1350 through a **vaulted per-host token** (rung 2). The forge worked perfectly; the gate simply could not see the credential that made it work.

Live proof:

```
bash: fatal: not a git repository ...   <- the shell git RAN; gate never fired
git_status: fatal: not a git repository <- the tool works (PR #1352)
```

## The fix

Ask per **repo**, with the directory the command would run in. That is also the *right* question: "can aimee do git for this checkout?" is what decides whether refusing the shell **redirects** the delegate or merely **strands** it. Moved below `dispatch_cwd` so the answer exists, and threaded `cwd` through the seam.

## Why this one stings

It is the same shape as the bug it was written to fix — correct-reading code that cannot execute — and it survived unit tests, clang-format, **16 green CI checks** and a roundtable. Only running it on hardware exposed it.

Which is the argument for #1353 (the sandbox): a delegate with no credential and no network cannot reach the forge whether or not a predicate is correct. Gates that must be right are weaker than environments that cannot be wrong.