### PR TITLE
fix(kb/curator): reclaim orphaned job leases; unblock extract_doc throughput; make sidecar failures diagnosable

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (179)
+## CLI-settable keys (180)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -100,6 +100,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `kb_curator_extract_code_enabled` | bool | — |
 | `kb_curator_extract_code_workers` | int | — |
 | `kb_curator_extract_docs_enabled` | bool | — |
+| `kb_curator_extract_docs_workers` | int | — |
 | `kb_curator_index_claims_enabled` | bool | — |
 | `kb_curator_index_code_unit_enabled` | bool | — |
 | `kb_curator_index_narrative_enabled` | bool | — |
@@ -206,7 +207,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 | `wfe_live_forge_enabled` | bool | — |
 
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_client_bearer_token`, `kb_client_url`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_custom_stages`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_code_workers`, `kb_curator_extract_docs_enabled`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_curator_user_presets`, `kb_evidence_embed_enabled`, `kb_mode`, `llm_embed_backend`, `llm_embed_gpu`, `llm_embed_host`, `llm_embed_tier`, `llm_rerank_backend`, `llm_rerank_endpoint`, `llm_rerank_gpu`, `llm_rerank_host`, `llm_rerank_tier`, `llm_synth_backend`, `llm_synth_endpoint`, `llm_synth_gpu`, `llm_synth_host`, `llm_synth_model`, `llm_synth_tier`, `wfe_live_forge_enabled`
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_client_bearer_token`, `kb_client_url`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_custom_stages`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_code_workers`, `kb_curator_extract_docs_enabled`, `kb_curator_extract_docs_workers`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_curator_user_presets`, `kb_evidence_embed_enabled`, `kb_mode`, `llm_embed_backend`, `llm_embed_gpu`, `llm_embed_host`, `llm_embed_tier`, `llm_rerank_backend`, `llm_rerank_endpoint`, `llm_rerank_gpu`, `llm_rerank_host`, `llm_rerank_tier`, `llm_synth_backend`, `llm_synth_endpoint`, `llm_synth_gpu`, `llm_synth_host`, `llm_synth_model`, `llm_synth_tier`, `wfe_live_forge_enabled`
 
 ## Config-file sections (53)
 

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -367,6 +367,8 @@ const config_field_t config_fields[] = {
      * nested kb.curator.* YAML the KB reads on its next load. */
     {"kb_curator_extract_docs_enabled", offsetof(config_t, kb_curator_extract_docs_enabled),
      sizeof(int), 0, CFG_BOOL},
+    {"kb_curator_extract_docs_workers", offsetof(config_t, kb_curator_extract_docs_workers),
+     sizeof(int), 0, CFG_INT},
     {"kb_curator_stage_order", offsetof(config_t, kb_curator_stage_order),
      sizeof(((config_t *)0)->kb_curator_stage_order), 0, CFG_STRING},
     {"kb_curator_user_presets", offsetof(config_t, kb_curator_user_presets),

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -37,6 +37,7 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_typed_facts_promote_threshold = 3;
    cfg->kb_curator_extract_code_enabled = 1;
    cfg->kb_curator_extract_code_workers = 1;
+   cfg->kb_curator_extract_docs_workers = 1;
    cfg->kb_curator_resolve_entities_enabled = 1;
    cfg->kb_curator_index_narrative_enabled = 1;
    cfg->kb_curator_index_claims_enabled = 1;
@@ -167,6 +168,11 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
       const cJSON *enabled = cJSON_GetObjectItemCaseSensitive(extract_docs, "enabled");
       if (enabled && cJSON_IsBool(enabled))
          cfg->kb_curator_extract_docs_enabled = cJSON_IsTrue(enabled) ? 1 : 0;
+      /* workers: dedicated extract_doc drain threads (see config.h). Clamped
+       * to [1,8]; non-numeric / out-of-range values keep the default. */
+      const cJSON *workers = cJSON_GetObjectItemCaseSensitive(extract_docs, "workers");
+      if (workers && cJSON_IsNumber(workers) && workers->valueint >= 1 && workers->valueint <= 8)
+         cfg->kb_curator_extract_docs_workers = workers->valueint;
    }
 
    const cJSON *extract_code = cJSON_GetObjectItemCaseSensitive(curator, "extract_code");

--- a/src/db2/kb_service_backend.c
+++ b/src/db2/kb_service_backend.c
@@ -304,11 +304,19 @@ static int db2_kb_service_async_queue_claim_next(int64_t *job_id, int64_t *docum
    /* Single-claim correctness comes from the follow-up UPDATE's WHERE
     * id=?2 AND status='pending' guard plus the changes!=1 check below: if
     * two workers race on the same row, only one UPDATE will see status =
-    * 'pending' and report changes==1; the loser ROLLBACKs and retries. */
+    * 'pending' and report changes==1; the loser ROLLBACKs and retries.
+    *
+    * The kind filter is load-bearing, not a nicety: kb_async_jobs is shared with
+    * the curator stages (extract_doc, memory_facts), which own their own claim
+    * lifecycle. Without it this claim takes the lowest-id pending row of ANY
+    * kind, and the dispatch below marks everything it does not recognize
+    * 'failed' — so one call to the drain endpoint would silently destroy the
+    * curator's queued work. Keep this list in sync with that dispatch. */
    aimee_pg_stmt_t *sel = aimee_pg_prepare(conn,
                                            "SELECT id, document_id, kind"
                                            " FROM kb_async_jobs"
                                            " WHERE status = 'pending'"
+                                           "   AND kind IN ('embed_raw', 'embed_pdf')"
                                            " ORDER BY id ASC LIMIT 1",
                                            err, sizeof(err));
    if (!sel)

--- a/src/db2/kb_service_backend.c
+++ b/src/db2/kb_service_backend.c
@@ -24,6 +24,18 @@
 
 #define KBS_ERRBUF 256
 
+/* The job kinds this drain handles — the single source of truth for BOTH the
+ * claim's IN-list and the dispatch in db2_kb_service_async_queue_drain. They
+ * must agree, and the failure mode when they drift is silent and destructive:
+ * kb_async_jobs is shared with the curator stages (extract_doc, memory_facts),
+ * which own their own claim lifecycle, and the dispatch marks every kind it
+ * does not recognize 'failed'. An unfiltered claim therefore takes the
+ * lowest-id pending row of ANY kind, so a single call to the drain endpoint
+ * would destroy the curator's queued work. Adding a kind here without adding a
+ * dispatch branch fails those jobs; adding a dispatch branch without adding it
+ * here leaves them unclaimed forever. */
+#define KBS_ASYNC_DRAIN_KINDS_SQL "('embed_raw', 'embed_pdf')"
+
 static const char *DB2_KB_DIRECTIVE_SELECT_COLS =
     "id, question, topic, anchor_entity, anchor_file, cause, priority, state,"
     " memory_a_id, memory_b_id, resolution_memory_id, evidence, source_session,"
@@ -304,21 +316,14 @@ static int db2_kb_service_async_queue_claim_next(int64_t *job_id, int64_t *docum
    /* Single-claim correctness comes from the follow-up UPDATE's WHERE
     * id=?2 AND status='pending' guard plus the changes!=1 check below: if
     * two workers race on the same row, only one UPDATE will see status =
-    * 'pending' and report changes==1; the loser ROLLBACKs and retries.
-    *
-    * The kind filter is load-bearing, not a nicety: kb_async_jobs is shared with
-    * the curator stages (extract_doc, memory_facts), which own their own claim
-    * lifecycle. Without it this claim takes the lowest-id pending row of ANY
-    * kind, and the dispatch below marks everything it does not recognize
-    * 'failed' — so one call to the drain endpoint would silently destroy the
-    * curator's queued work. Keep this list in sync with that dispatch. */
-   aimee_pg_stmt_t *sel = aimee_pg_prepare(conn,
-                                           "SELECT id, document_id, kind"
-                                           " FROM kb_async_jobs"
-                                           " WHERE status = 'pending'"
-                                           "   AND kind IN ('embed_raw', 'embed_pdf')"
-                                           " ORDER BY id ASC LIMIT 1",
-                                           err, sizeof(err));
+    * 'pending' and report changes==1; the loser ROLLBACKs and retries. */
+   aimee_pg_stmt_t *sel =
+       aimee_pg_prepare(conn,
+                        "SELECT id, document_id, kind"
+                        " FROM kb_async_jobs"
+                        " WHERE status = 'pending'"
+                        "   AND kind IN " KBS_ASYNC_DRAIN_KINDS_SQL " ORDER BY id ASC LIMIT 1",
+                        err, sizeof(err));
    if (!sel)
    {
       (void)aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
@@ -632,7 +637,14 @@ int db2_kb_service_async_queue_drain(const char *embedding_cmd, int timeout_secs
          rc = db2_kb_service_async_process_embed_pdf(document_id, effective_cmd, errbuf,
                                                      sizeof(errbuf));
       else
-         snprintf(errbuf, sizeof(errbuf), "unknown job kind: %s", kind);
+         /* Unreachable unless KBS_ASYNC_DRAIN_KINDS_SQL and this chain have
+          * drifted apart — the claim cannot hand us a kind not in that list. If
+          * it ever happens the job is about to be marked 'failed', so say so
+          * loudly rather than discarding another stage's work in silence. */
+         snprintf(errbuf, sizeof(errbuf),
+                  "unknown job kind: %s (claimed but not dispatchable — "
+                  "KBS_ASYNC_DRAIN_KINDS_SQL is out of sync with the dispatch)",
+                  kind);
 
       if (rc == 0)
          (void)db2_kb_service_async_queue_mark_job(job_id, "done", "");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1646,6 +1646,14 @@ typedef struct config
     * for a --parallel 4 llama-server), since each job is one LLM sidecar
     * call. Clamped to [1,8]. */
    int kb_curator_extract_code_workers;
+   /* Dedicated extract_doc worker threads (kb_curator_extract_docs_workers),
+    * exactly as above but for the doc stage. Default 1.
+    *
+    * Without this, extract_doc has only the shared LLM lane, which spends most
+    * of each pass on the other LLM stages — so docs drain at a small fraction
+    * of the rate a configured extract_code pool achieves even though both are
+    * one sidecar call per job. Clamped to [1,8]. */
+   int kb_curator_extract_docs_workers;
    /* resolve_entities pass: 0 = off (default), 1 = commit proposed `entity`
     * mentions into curator_entity_vectors on the curator drain. */
    int kb_curator_resolve_entities_enabled;

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -949,6 +949,46 @@ static void *kb_curator_code_worker_main(void *arg)
    return NULL;
 }
 
+/* Dedicated extract_doc worker: the exact analogue of the extract_code worker
+ * above, and minimal for the same reason — no sweeps, no other stages, so N
+ * workers map 1:1 onto the synth backend's parallel slots.
+ *
+ * The doc stage needs this as much as the code stage does. Both are one LLM
+ * sidecar call per job, but the shared LLM lane spends most of each pass on the
+ * OTHER LLM stages (a code unit, resolve_entities, synthesize, promote_entity),
+ * so extract_doc gets a thin slice of one thread. On the .254 appliance, with
+ * extract_code.workers=4 and no doc pool, that measured as ~30 docs/hr against
+ * ~1,750 code units/hr — a backlog that drains in days rather than hours. */
+static void *kb_curator_doc_worker_main(void *arg)
+{
+   kb_curator_drain_ctx_t *ctx = (kb_curator_drain_ctx_t *)arg;
+   while (!ctx->stop)
+   {
+      config_t cfg;
+      config_load(&cfg);
+      if (!cfg.kb_curator_extract_docs_enabled)
+      {
+         sleep(DRAIN_POLL_SECS);
+         continue;
+      }
+      kb_curator_extract_opts_t opts;
+      memset(&opts, 0, sizeof(opts));
+      snprintf(opts.extract_command, sizeof(opts.extract_command), "%s",
+               cfg.kb_curator_extract_command);
+      opts.max_tokens =
+          cfg.kb_curator_extract_max_tokens > 0 ? cfg.kb_curator_extract_max_tokens : 2048;
+      opts.max_attempts = cfg.kb_curator_max_attempts > 0 ? cfg.kb_curator_max_attempts : 3;
+
+      int r = kb_curator_extract_one(&opts);
+      db2_lease_release_idle();
+      if (r == 1)
+         continue; /* did work — claim the next job immediately */
+      /* empty queue (0) or error (<0): back off the poll interval */
+      sleep(DRAIN_POLL_SECS);
+   }
+   return NULL;
+}
+
 static void *kb_curator_index_lane_main(void *arg)
 {
    kb_curator_drain_ctx_t *ctx = (kb_curator_drain_ctx_t *)arg;
@@ -1057,6 +1097,28 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx)
       aimee_log(LOG_INFO, "kb.curator.drain", "%d extract_code worker thread(s) started",
                 ctx->code_active);
    }
+
+   /* Dedicated extract_doc workers — same contract as the code workers above:
+    * kb_curator_extract_docs_workers - 1 extra threads, since the main LLM lane
+    * still contributes one doc per pass. Claims are transactional (UPDATE ...
+    * SELECT ... LIMIT 1 FOR UPDATE SKIP LOCKED), so workers never double-claim. */
+   ctx->doc_active = 0;
+   if (cfg.kb_curator_extract_docs_enabled && cfg.kb_curator_extract_docs_workers > 1)
+   {
+      int extra = cfg.kb_curator_extract_docs_workers - 1;
+      if (extra > KB_CURATOR_MAX_DOC_WORKERS)
+         extra = KB_CURATOR_MAX_DOC_WORKERS;
+      for (int i = 0; i < extra; i++)
+      {
+         if (pthread_create(&ctx->doc_threads[ctx->doc_active], NULL, kb_curator_doc_worker_main,
+                            ctx) == 0)
+            ctx->doc_active++;
+         else
+            break;
+      }
+      aimee_log(LOG_INFO, "kb.curator.drain", "%d extract_doc worker thread(s) started",
+                ctx->doc_active);
+   }
    if (pthread_create(&ctx->index_thread, NULL, kb_curator_index_lane_main, ctx) == 0)
    {
       ctx->index_active = 1;
@@ -1070,7 +1132,8 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx)
 
 void kb_curator_drain_shutdown(kb_curator_drain_ctx_t *ctx)
 {
-   if (!ctx || (!ctx->active && !ctx->index_active && ctx->code_active <= 0))
+   if (!ctx ||
+       (!ctx->active && !ctx->index_active && ctx->code_active <= 0 && ctx->doc_active <= 0))
       return;
    ctx->stop = 1;
    if (ctx->active)
@@ -1086,5 +1149,8 @@ void kb_curator_drain_shutdown(kb_curator_drain_ctx_t *ctx)
    for (int i = 0; i < ctx->code_active; i++)
       pthread_join(ctx->code_threads[i], NULL);
    ctx->code_active = 0;
+   for (int i = 0; i < ctx->doc_active; i++)
+      pthread_join(ctx->doc_threads[i], NULL);
+   ctx->doc_active = 0;
    aimee_log(LOG_DEBUG, "kb.curator.drain", "drain threads stopped");
 }

--- a/src/kb/kb_curator_extract.c
+++ b/src/kb/kb_curator_extract.c
@@ -18,6 +18,7 @@
 #include "db2/feature_rows.h"
 #include "kb_mdl.h"
 
+#include <pthread.h> /* reclaim throttle is shared across the doc workers */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -236,28 +237,48 @@ static void ce_mark_retry_or_fail(int64_t job_id, int attempts, int max_attempts
  * Scoped to kind='extract_doc': kb_async_jobs is shared with other kinds that
  * own their own claim/lease lifecycle, and reclaiming those from here would
  * yank jobs out from under their stage. Throttled — the drain calls the entry
- * point once per job. */
+ * point once per job.
+ *
+ * The throttle is mutex-guarded because kb_curator_extract_one runs on the main
+ * LLM lane AND on every kb_curator_extract_docs_workers thread, so the state is
+ * genuinely shared. The lock is held across the UPDATE, which is free in
+ * practice: it is taken once per CE_RECLAIM_EVERY_S, and workers that lose the
+ * race just observe the throttle and return. */
 static void ce_reclaim_stale_running(int max_attempts)
 {
+   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
    static time_t last_run = 0;
-   time_t now = time(NULL);
-   if (last_run != 0 && now - last_run < CE_RECLAIM_EVERY_S)
-      return;
-   last_run = now;
 
    if (max_attempts < 1)
       max_attempts = 1;
 
+   pthread_mutex_lock(&lock);
+   time_t now = time(NULL);
+   if (last_run != 0 && now - last_run < CE_RECLAIM_EVERY_S)
+   {
+      pthread_mutex_unlock(&lock);
+      return;
+   }
+
    void *conn = db2_conn();
    if (!conn)
+   {
+      /* Deliberately do NOT arm the throttle here, nor on the failures below: a
+       * reclaim that never ran must not suppress the next attempt for a minute.
+       * Only a completed UPDATE counts as "ran recently". */
+      pthread_mutex_unlock(&lock);
       return;
+   }
    char err[CE_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(
        conn,
        "UPDATE kb_async_jobs"
        " SET status = CASE WHEN attempts >= ?1 THEN 'failed' ELSE 'pending' END,"
        "     claimed_by = '', claimed_at = '',"
-       "     last_error = CASE WHEN attempts >= ?1"
+       /* Only fill last_error when the worker left none: an existing message is
+        * the diagnostic from the attempt that died, and 'reclaimed after max
+        * attempts' only says we gave up — overwriting would destroy the reason. */
+       "     last_error = CASE WHEN attempts >= ?1 AND last_error = ''"
        "                       THEN 'stale running lease reclaimed after max attempts'"
        "                       ELSE last_error END,"
        "     updated_at = pg_now_text()"
@@ -265,11 +286,19 @@ static void ce_reclaim_stale_running(int max_attempts)
        "   AND claimed_at <> '' AND claimed_at < pg_now_text(?2)",
        err, sizeof(err));
    if (!st)
+   {
+      aimee_log(LOG_WARN, "kb.curator.extract", "stale-lease reclaim could not prepare: %s", err);
+      pthread_mutex_unlock(&lock);
       return;
+   }
    aimee_pg_bind_int(st, "?1", max_attempts);
    aimee_pg_bind_text(st, "?2", CE_STALE_LEASE);
-   (void)aimee_pg_step(st, err, sizeof(err));
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_DONE)
+      last_run = now; /* only a completed UPDATE arms the throttle */
+   else
+      aimee_log(LOG_WARN, "kb.curator.extract", "stale-lease reclaim failed: %s", err);
    aimee_pg_finalize(st);
+   pthread_mutex_unlock(&lock);
 }
 
 /* Pick the curator-extract sidecar command from a candidate list. Shared by the

--- a/src/kb/kb_curator_extract.c
+++ b/src/kb/kb_curator_extract.c
@@ -28,6 +28,13 @@
 #define CE_DOCBUF 65536
 #define CE_OUTBUF (256 * 1024)
 
+/* A job left in 'running' longer than this lease was orphaned (worker crash/
+ * restart or a wedged sidecar). Mirrors the code-unit stage's lease; both sit
+ * comfortably above that stage's sidecar wall-clock cap. */
+#define CE_STALE_LEASE "-15 minutes"
+/* Reclaim runs at most this often (throttled; the drain calls the entry per job). */
+#define CE_RECLAIM_EVERY_S 60
+
 /* System prompt for the extract stage (Tier-A) when routed through a configured
  * provider (§2b). The legacy python sidecar carried its own prompt; the in-process
  * provider needs one here. The request JSON's `role`/`prompt_version` select the
@@ -217,6 +224,54 @@ static void ce_mark_retry_or_fail(int64_t job_id, int attempts, int max_attempts
    aimee_pg_finalize(st);
 }
 
+/* Reclaim extract_doc jobs orphaned in 'running'. ce_claim_job only ever selects
+ * status='pending', so a job whose worker crashed/restarted or whose sidecar
+ * wedged stays 'running' forever: the document is never extracted, and the row
+ * pins a db2 pool member well past its 300s ceiling ("missed lease_end?"). The
+ * code-unit stage has had this guard since it shipped; kb_async_jobs never got
+ * one, which stranded a job for 15h in production. Reset rows older than the
+ * lease to 'pending' so they retry, or to 'failed' once attempts are exhausted
+ * so a poison job cannot loop. attempts is preserved (incremented at claim).
+ *
+ * Scoped to kind='extract_doc': kb_async_jobs is shared with other kinds that
+ * own their own claim/lease lifecycle, and reclaiming those from here would
+ * yank jobs out from under their stage. Throttled — the drain calls the entry
+ * point once per job. */
+static void ce_reclaim_stale_running(int max_attempts)
+{
+   static time_t last_run = 0;
+   time_t now = time(NULL);
+   if (last_run != 0 && now - last_run < CE_RECLAIM_EVERY_S)
+      return;
+   last_run = now;
+
+   if (max_attempts < 1)
+      max_attempts = 1;
+
+   void *conn = db2_conn();
+   if (!conn)
+      return;
+   char err[CE_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn,
+       "UPDATE kb_async_jobs"
+       " SET status = CASE WHEN attempts >= ?1 THEN 'failed' ELSE 'pending' END,"
+       "     claimed_by = '', claimed_at = '',"
+       "     last_error = CASE WHEN attempts >= ?1"
+       "                       THEN 'stale running lease reclaimed after max attempts'"
+       "                       ELSE last_error END,"
+       "     updated_at = pg_now_text()"
+       " WHERE kind = 'extract_doc' AND status = 'running'"
+       "   AND claimed_at <> '' AND claimed_at < pg_now_text(?2)",
+       err, sizeof(err));
+   if (!st)
+      return;
+   aimee_pg_bind_int(st, "?1", max_attempts);
+   aimee_pg_bind_text(st, "?2", CE_STALE_LEASE);
+   (void)aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+}
+
 /* Pick the curator-extract sidecar command from a candidate list. Shared by the
  * doc and code extract stages and exposed for testing. The script is invoked as
  * `python3 <path>`, so it only needs to be READABLE — the previous code checked
@@ -365,6 +420,10 @@ int kb_curator_extract_one(const kb_curator_extract_opts_t *opts)
 {
    ce_job_t job;
    memset(&job, 0, sizeof(job));
+
+   /* Recover jobs orphaned in 'running' before claiming fresh work, so a crash/
+    * restart or a previously-wedged sidecar cannot permanently strand them. */
+   ce_reclaim_stale_running(opts ? opts->max_attempts : 1);
 
    if (!ce_claim_job(&job))
       return 0; /* queue empty */

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -418,27 +418,31 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
     * builtins, operators) — passing it as timeout's own argv would break those
     * and let compound commands escape the bound.
     *
-    * The script is shell-QUOTED and the redirection stays inside the command's
-    * own parse context, passing the path as $1 — see kb_curator_sidecar_run for
-    * the full reasoning. Raw interpolation would let an embedded quote/$/backtick
-    * re-parse the command, and redirecting the wrapper's stdin instead of the
-    * command's would hand the file to the wrong end of a pipeline. */
-   char script[640];
-   int sn = snprintf(script, sizeof(script), "%s < \"$1\"", cmd);
-   char qscript[2688]; /* worst case: every byte of the script is a quote */
-   char qtmp[1040];
+    * The script is shell-QUOTED, the redirection stays inside the command's own
+    * parse context, and the path is embedded as a quoted LITERAL — see
+    * kb_curator_sidecar_run for the full reasoning. */
+   char qtmp[1040]; /* worst case: every byte of a 256-char path is a quote */
+   if (kb_curator_shell_quote(tmppath, qtmp, sizeof(qtmp)) != 0)
+   {
+      unlink(tmppath);
+      snprintf(errbuf, errlen, "sidecar temp path too long to quote safely");
+      return NULL;
+   }
+
+   char script[1600];
+   int sn = snprintf(script, sizeof(script), "%s < %s", cmd, qtmp);
+   char qscript[6464]; /* worst case: every byte of the script is a quote */
    if (sn < 0 || (size_t)sn >= sizeof(script) ||
-       kb_curator_shell_quote(script, qscript, sizeof(qscript)) != 0 ||
-       kb_curator_shell_quote(tmppath, qtmp, sizeof(qtmp)) != 0)
+       kb_curator_shell_quote(script, qscript, sizeof(qscript)) != 0)
    {
       unlink(tmppath);
       snprintf(errbuf, errlen, "sidecar command too long to quote safely");
       return NULL;
    }
 
-   char full_cmd[3840];
-   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s sh %s", CCU_SIDECAR_TIMEOUT_S,
-            qscript, qtmp);
+   char full_cmd[6528];
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s", CCU_SIDECAR_TIMEOUT_S,
+            qscript);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -18,6 +18,7 @@
 #include "db2/db_postgres.h"
 
 #include <errno.h>
+#include <pthread.h> /* reclaim throttle is shared across the code workers */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -147,39 +148,68 @@ static void ccu_mark_retry_or_fail(int64_t job_id, int attempts, int max_attempt
  * so they retry, or to 'failed' once attempts are exhausted so a poison job
  * cannot loop. attempts is preserved (it was incremented at claim time).
  * Throttled to at most once per CCU_RECLAIM_EVERY_S since the drain calls the
- * entry point once per job. */
+ * entry point once per job.
+ *
+ * The throttle is mutex-guarded because kb_curator_extract_code_unit_one runs on
+ * the main LLM lane AND on every kb_curator_extract_code_workers thread, so the
+ * state is genuinely shared (this box runs 4). The lock is held across the
+ * UPDATE, which is free in practice: it is taken once per CCU_RECLAIM_EVERY_S,
+ * and workers that lose the race just observe the throttle and return. */
 static void ccu_reclaim_stale_running(int max_attempts)
 {
+   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
    static time_t last_run = 0;
-   time_t now = time(NULL);
-   if (last_run != 0 && now - last_run < CCU_RECLAIM_EVERY_S)
-      return;
-   last_run = now;
 
    if (max_attempts < 1)
       max_attempts = 1;
 
+   pthread_mutex_lock(&lock);
+   time_t now = time(NULL);
+   if (last_run != 0 && now - last_run < CCU_RECLAIM_EVERY_S)
+   {
+      pthread_mutex_unlock(&lock);
+      return;
+   }
+
    void *conn = db2_conn();
    if (!conn)
+   {
+      /* Deliberately do NOT arm the throttle here, nor on the failures below: a
+       * reclaim that never ran must not suppress the next attempt for a minute.
+       * Only a completed UPDATE counts as "ran recently". */
+      pthread_mutex_unlock(&lock);
       return;
+   }
    char err[CCU_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(
        conn,
        "UPDATE kb_code_unit_jobs"
        " SET status = CASE WHEN attempts >= ?1 THEN 'failed' ELSE 'pending' END,"
        "     claimed_by = '', claimed_at = '',"
-       "     last_error = CASE WHEN attempts >= ?1"
+       /* Only fill last_error when the worker left none: an existing message is
+        * the diagnostic from the attempt that died, and 'reclaimed after max
+        * attempts' only says we gave up — overwriting would destroy the reason. */
+       "     last_error = CASE WHEN attempts >= ?1 AND last_error = ''"
        "                       THEN 'stale running lease reclaimed after max attempts'"
        "                       ELSE last_error END,"
        "     updated_at = pg_now_text()"
        " WHERE status = 'running' AND claimed_at <> '' AND claimed_at < pg_now_text(?2)",
        err, sizeof(err));
    if (!st)
+   {
+      aimee_log(LOG_WARN, "kb.curator.extract_code", "stale-lease reclaim could not prepare: %s",
+                err);
+      pthread_mutex_unlock(&lock);
       return;
+   }
    aimee_pg_bind_int(st, "?1", max_attempts);
    aimee_pg_bind_text(st, "?2", CCU_STALE_LEASE);
-   (void)aimee_pg_step(st, err, sizeof(err));
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_DONE)
+      last_run = now; /* only a completed UPDATE arms the throttle */
+   else
+      aimee_log(LOG_WARN, "kb.curator.extract_code", "stale-lease reclaim failed: %s", err);
    aimee_pg_finalize(st);
+   pthread_mutex_unlock(&lock);
 }
 
 /* ── Body extraction ─────────────────────────────────────────────────────── */
@@ -379,7 +409,6 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
    }
    close(fd);
 
-   char full_cmd[1024];
    /* Bound the sidecar with coreutils `timeout` (present on the kb image):
     * SIGTERM at the ceiling, SIGKILL 10s later if it ignores TERM. Without this
     * a hung sidecar wedges the drain thread forever via pclose(); on timeout
@@ -387,9 +416,24 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
     * Run the configured command under `sh -c` INSIDE timeout so it keeps the
     * shell semantics popen() gave it (env-var prefixes like `FOO=bar python …`,
     * builtins, operators) — passing it as timeout's own argv would break those
-    * and let compound commands escape the bound. `cmd` is trusted config. */
-   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c \"%s\" < %s", CCU_SIDECAR_TIMEOUT_S,
-            cmd, tmppath);
+    * and let compound commands escape the bound.
+    *
+    * cmd and tmppath are shell-QUOTED: the timeout wrapper hands this line to a
+    * second shell, so interpolating them raw would let an embedded quote, $ or
+    * backtick re-parse the command (and expand $VARs twice). */
+   char qcmd[2176]; /* worst case: every byte of a 512-char command is a quote */
+   char qtmp[1040];
+   if (kb_curator_shell_quote(cmd, qcmd, sizeof(qcmd)) != 0 ||
+       kb_curator_shell_quote(tmppath, qtmp, sizeof(qtmp)) != 0)
+   {
+      unlink(tmppath);
+      snprintf(errbuf, errlen, "sidecar command too long to quote safely");
+      return NULL;
+   }
+
+   char full_cmd[3328];
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s < %s", CCU_SIDECAR_TIMEOUT_S,
+            qcmd, qtmp);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -418,12 +418,17 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
     * builtins, operators) — passing it as timeout's own argv would break those
     * and let compound commands escape the bound.
     *
-    * cmd and tmppath are shell-QUOTED: the timeout wrapper hands this line to a
-    * second shell, so interpolating them raw would let an embedded quote, $ or
-    * backtick re-parse the command (and expand $VARs twice). */
-   char qcmd[2176]; /* worst case: every byte of a 512-char command is a quote */
+    * The script is shell-QUOTED and the redirection stays inside the command's
+    * own parse context, passing the path as $1 — see kb_curator_sidecar_run for
+    * the full reasoning. Raw interpolation would let an embedded quote/$/backtick
+    * re-parse the command, and redirecting the wrapper's stdin instead of the
+    * command's would hand the file to the wrong end of a pipeline. */
+   char script[640];
+   int sn = snprintf(script, sizeof(script), "%s < \"$1\"", cmd);
+   char qscript[2688]; /* worst case: every byte of the script is a quote */
    char qtmp[1040];
-   if (kb_curator_shell_quote(cmd, qcmd, sizeof(qcmd)) != 0 ||
+   if (sn < 0 || (size_t)sn >= sizeof(script) ||
+       kb_curator_shell_quote(script, qscript, sizeof(qscript)) != 0 ||
        kb_curator_shell_quote(tmppath, qtmp, sizeof(qtmp)) != 0)
    {
       unlink(tmppath);
@@ -431,9 +436,9 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
       return NULL;
    }
 
-   char full_cmd[3328];
-   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s < %s", CCU_SIDECAR_TIMEOUT_S,
-            qcmd, qtmp);
+   char full_cmd[3840];
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s sh %s", CCU_SIDECAR_TIMEOUT_S,
+            qscript, qtmp);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -9,6 +9,7 @@
 
 #include "kb_curator_extract.h"
 #include "kb_curator_grounding.h"
+#include "kb_curator_sidecar.h" /* kb_curator_describe_wait_status */
 #include "aimee.h"
 #include "cJSON.h"
 #include "log.h"
@@ -16,6 +17,7 @@
 #include "db2/db2_internal.h"
 #include "db2/db_postgres.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -349,12 +351,21 @@ static char *ccu_read_body(const char *file_path, int line, char *errbuf, size_t
 static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *errbuf,
                                 size_t errlen)
 {
+   /* Honour TMPDIR like the rest of the tree (see code_collect.c): a hardcoded
+    * /tmp gives an operator no way to move the spool off a full or slow
+    * filesystem. */
+   const char *tmpdir = getenv("TMPDIR");
+   if (!tmpdir || !tmpdir[0])
+      tmpdir = "/tmp";
    char tmppath[256];
-   snprintf(tmppath, sizeof(tmppath), "/tmp/aimee_ccu_XXXXXX");
+   snprintf(tmppath, sizeof(tmppath), "%s/aimee_ccu_XXXXXX", tmpdir);
    int fd = mkstemp(tmppath);
    if (fd < 0)
    {
-      snprintf(errbuf, errlen, "mkstemp failed");
+      /* Carry errno: ENOSPC (full spool), EMFILE (fd exhaustion) and EACCES are
+       * different incidents with different fixes, and last_error is the only
+       * forensic record a failed job leaves behind. */
+      snprintf(errbuf, errlen, "mkstemp failed for %s: %s", tmppath, strerror(errno));
       return NULL;
    }
 
@@ -411,7 +422,7 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
 
    if (rc != 0)
    {
-      snprintf(errbuf, errlen, "sidecar exited %d", rc);
+      kb_curator_describe_wait_status(rc, CCU_SIDECAR_TIMEOUT_S, errbuf, errlen);
       free(out);
       return NULL;
    }

--- a/src/kb/kb_curator_sidecar.c
+++ b/src/kb/kb_curator_sidecar.c
@@ -95,7 +95,14 @@ void kb_curator_describe_wait_status(int status, int timeout_s, char *errbuf, si
    {
       int code = WEXITSTATUS(status);
       if (timeout_s > 0 && code == 124)
-         snprintf(errbuf, errlen, "sidecar timed out after %ds", timeout_s);
+         /* 124 is timeout(1)'s deadline signal, but it also propagates a wrapped
+          * command's own exit code — so a sidecar that exits 124 itself is
+          * indistinguishable from here. Same honesty as the 128+n case below:
+          * name the likely cause without asserting it as fact. */
+         snprintf(errbuf, errlen,
+                  "sidecar exited 124 (timeout after %ds, or the command itself "
+                  "exited 124)",
+                  timeout_s);
       else if (code > 128)
          /* A shell reports a signal-killed child as 128+n, so 137 is very likely
           * an OOM kill — but a process can also exit(137) of its own accord, and
@@ -159,13 +166,27 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
     * python …`, builtins, operators) — passing it as timeout's own argv would
     * break those and let compound commands escape the bound.
     *
-    * Both cmd and tmppath are shell-QUOTED rather than interpolated raw: the
-    * timeout wrapper means a second shell parses this line, and a command
-    * containing a quote, $ or backtick would otherwise be re-interpreted —
-    * silently changing the meaning of commands that worked under a bare popen. */
-   char qcmd[2176]; /* worst case: every byte of a 512-char command is a quote */
+    * The invariant is that adding the timeout wrapper changes NOTHING about how
+    * the command is interpreted, which takes two things:
+    *
+    *  - QUOTE the script. A second shell parses this line, so a command
+    *    containing a quote, $ or backtick would otherwise be re-parsed (and
+    *    $VARs expanded twice) — commands that worked under the bare popen.
+    *
+    *  - Keep the redirection INSIDE the command's own parse context. The old
+    *    form was `sh -c "<cmd> < tmp"`, where `< tmp` is parsed alongside cmd:
+    *    for `a | b` it binds to b, the last pipeline command. Redirecting the
+    *    wrapper's stdin instead would hand the file to `a` — a silent change in
+    *    meaning. So append the redirection to the script and pass the path as a
+    *    positional ($1) rather than interpolating it: `sh -c '<cmd> < "$1"' sh
+    *    <tmppath>`. $1 is inside single quotes, so only the INNER shell expands
+    *    it, and the path never re-parses. */
+   char script[640];
+   int sn = snprintf(script, sizeof(script), "%s < \"$1\"", cmd);
+   char qscript[2688]; /* worst case: every byte of the script is a quote */
    char qtmp[1040];
-   if (kb_curator_shell_quote(cmd, qcmd, sizeof(qcmd)) != 0 ||
+   if (sn < 0 || (size_t)sn >= sizeof(script) ||
+       kb_curator_shell_quote(script, qscript, sizeof(qscript)) != 0 ||
        kb_curator_shell_quote(tmppath, qtmp, sizeof(qtmp)) != 0)
    {
       unlink(tmppath);
@@ -174,9 +195,9 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
       return NULL;
    }
 
-   char full_cmd[3328];
-   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s < %s", CS_SIDECAR_TIMEOUT_S,
-            qcmd, qtmp);
+   char full_cmd[3840];
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s sh %s", CS_SIDECAR_TIMEOUT_S,
+            qscript, qtmp);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)

--- a/src/kb/kb_curator_sidecar.c
+++ b/src/kb/kb_curator_sidecar.c
@@ -15,6 +15,19 @@
 
 #define CS_DEFAULT_OUTBUF 8192
 
+/* Hard wall-clock cap for the sidecar, mirroring the code-unit stage's bound.
+ *
+ * This is load-bearing for the stale-lease reclaims (kb_curator_extract.c,
+ * kb_memory_facts.c), not just hygiene. An unbounded popen/pclose wedges its
+ * drain thread forever — and a reclaim that re-arms a job whose original worker
+ * is STILL running would hand the same job to a second worker: duplicate
+ * artifacts, and the wedged thread later clobbering the status of a job it no
+ * longer owns. A lease is only safe if the work under it is bounded well below
+ * the lease. 300s sits comfortably under the 15-minute lease (and far above the
+ * 13-22s a real doc extraction takes), so a job that outlives this cap is
+ * genuinely wedged and its slot is free by the time the reclaim fires. */
+#define CS_SIDECAR_TIMEOUT_S 300
+
 /* Render a pclose(3) return value into an operator-legible reason.
  *
  * pclose returns a wait(2)-encoded status, NOT an exit code: reporting it raw
@@ -47,10 +60,13 @@ void kb_curator_describe_wait_status(int status, int timeout_s, char *errbuf, si
       if (timeout_s > 0 && code == 124)
          snprintf(errbuf, errlen, "sidecar timed out after %ds", timeout_s);
       else if (code > 128)
-         /* A shell reports a signal-killed child as 128+n; distinguishing which
-          * signal is what tells OOM (9) apart from a clean TERM (15). */
-         snprintf(errbuf, errlen, "sidecar killed by signal %d (%s)", code - 128,
-                  strsignal(code - 128));
+         /* A shell reports a signal-killed child as 128+n, so 137 is very likely
+          * an OOM kill — but a process can also exit(137) of its own accord, and
+          * the two are indistinguishable from here. Report the exit code as the
+          * fact and the signal as the reading, rather than asserting a kill that
+          * may not have happened and sending an operator hunting a phantom OOM. */
+         snprintf(errbuf, errlen, "sidecar exited %d (128+%d: likely killed by signal %d, %s)",
+                  code, code - 128, code - 128, strsignal(code - 128));
       else
          snprintf(errbuf, errlen, "sidecar exited %d", code);
       return;
@@ -99,8 +115,16 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
    }
    close(fd);
 
+   /* Bound the sidecar with coreutils `timeout` (present on the kb image):
+    * SIGTERM at the ceiling, SIGKILL 10s later if it ignores TERM. Run the
+    * configured command under `sh -c` INSIDE timeout so it keeps the shell
+    * semantics popen() gave it (env-var prefixes like `FOO=bar python …`,
+    * builtins, operators) — passing it as timeout's own argv would break those
+    * and let compound commands escape the bound. `cmd` is trusted config.
+    * Mirrors ccu_invoke_sidecar in kb_curator_extract_code.c. */
    char full_cmd[1024];
-   snprintf(full_cmd, sizeof(full_cmd), "%s < %s", cmd, tmppath);
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c \"%s\" < %s", CS_SIDECAR_TIMEOUT_S,
+            cmd, tmppath);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)
@@ -135,9 +159,7 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
 
    if (rc != 0)
    {
-      /* This caller does not wrap the command in timeout(1), so 124 carries no
-       * special meaning here. */
-      kb_curator_describe_wait_status(rc, 0, errbuf, errlen);
+      kb_curator_describe_wait_status(rc, CS_SIDECAR_TIMEOUT_S, errbuf, errlen);
       free(out);
       return NULL;
    }

--- a/src/kb/kb_curator_sidecar.c
+++ b/src/kb/kb_curator_sidecar.c
@@ -28,6 +28,43 @@
  * genuinely wedged and its slot is free by the time the reclaim fires. */
 #define CS_SIDECAR_TIMEOUT_S 300
 
+/* Quote `in` as a single sh word. See the header for why this is required.
+ *
+ * The POSIX-portable form: wrap in single quotes, and render each embedded
+ * single quote as '\'' (close, escaped quote, reopen). Nothing inside single
+ * quotes is special to the shell, so this is total — no per-metacharacter
+ * escaping to get subtly wrong. */
+int kb_curator_shell_quote(const char *in, char *out, size_t outlen)
+{
+   if (!in || !out || outlen < 3)
+      return -1;
+
+   size_t o = 0;
+   out[o++] = '\'';
+   for (const char *p = in; *p; p++)
+   {
+      if (*p == '\'')
+      {
+         /* '\'' — 4 bytes, plus the closing quote and NUL still to come. */
+         if (o + 4 + 2 > outlen)
+            return -1;
+         out[o++] = '\'';
+         out[o++] = '\\';
+         out[o++] = '\'';
+         out[o++] = '\'';
+      }
+      else
+      {
+         if (o + 1 + 2 > outlen)
+            return -1;
+         out[o++] = *p;
+      }
+   }
+   out[o++] = '\'';
+   out[o] = '\0';
+   return 0;
+}
+
 /* Render a pclose(3) return value into an operator-legible reason.
  *
  * pclose returns a wait(2)-encoded status, NOT an exit code: reporting it raw
@@ -115,16 +152,31 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
    }
    close(fd);
 
-   /* Bound the sidecar with coreutils `timeout` (present on the kb image):
-    * SIGTERM at the ceiling, SIGKILL 10s later if it ignores TERM. Run the
-    * configured command under `sh -c` INSIDE timeout so it keeps the shell
-    * semantics popen() gave it (env-var prefixes like `FOO=bar python …`,
-    * builtins, operators) — passing it as timeout's own argv would break those
-    * and let compound commands escape the bound. `cmd` is trusted config.
-    * Mirrors ccu_invoke_sidecar in kb_curator_extract_code.c. */
-   char full_cmd[1024];
-   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c \"%s\" < %s", CS_SIDECAR_TIMEOUT_S,
-            cmd, tmppath);
+   /* Bound the sidecar with coreutils `timeout` (present on every image — they
+    * are all debian-slim): SIGTERM at the ceiling, SIGKILL 10s later if it
+    * ignores TERM. Run the configured command under `sh -c` INSIDE timeout so it
+    * keeps the shell semantics popen() gave it (env-var prefixes like `FOO=bar
+    * python …`, builtins, operators) — passing it as timeout's own argv would
+    * break those and let compound commands escape the bound.
+    *
+    * Both cmd and tmppath are shell-QUOTED rather than interpolated raw: the
+    * timeout wrapper means a second shell parses this line, and a command
+    * containing a quote, $ or backtick would otherwise be re-interpreted —
+    * silently changing the meaning of commands that worked under a bare popen. */
+   char qcmd[2176]; /* worst case: every byte of a 512-char command is a quote */
+   char qtmp[1040];
+   if (kb_curator_shell_quote(cmd, qcmd, sizeof(qcmd)) != 0 ||
+       kb_curator_shell_quote(tmppath, qtmp, sizeof(qtmp)) != 0)
+   {
+      unlink(tmppath);
+      if (errbuf)
+         snprintf(errbuf, errlen, "sidecar command too long to quote safely");
+      return NULL;
+   }
+
+   char full_cmd[3328];
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s < %s", CS_SIDECAR_TIMEOUT_S,
+            qcmd, qtmp);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)

--- a/src/kb/kb_curator_sidecar.c
+++ b/src/kb/kb_curator_sidecar.c
@@ -177,17 +177,27 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
     *    form was `sh -c "<cmd> < tmp"`, where `< tmp` is parsed alongside cmd:
     *    for `a | b` it binds to b, the last pipeline command. Redirecting the
     *    wrapper's stdin instead would hand the file to `a` — a silent change in
-    *    meaning. So append the redirection to the script and pass the path as a
-    *    positional ($1) rather than interpolating it: `sh -c '<cmd> < "$1"' sh
-    *    <tmppath>`. $1 is inside single quotes, so only the INNER shell expands
-    *    it, and the path never re-parses. */
-   char script[640];
-   int sn = snprintf(script, sizeof(script), "%s < \"$1\"", cmd);
-   char qscript[2688]; /* worst case: every byte of the script is a quote */
-   char qtmp[1040];
+    *    meaning. So the script keeps the same `<cmd> < <path>` shape the bare
+    *    popen produced, with the path shell-quoted as a LITERAL.
+    *
+    * The path is embedded literally rather than passed as a positional ($1):
+    * with `sh -c '<cmd> < "$1"' sh <path>`, a configured command containing
+    * `set --` would rebind $1 before the redirection expanded and read a
+    * different file. A literal cannot be reassigned. */
+   char qtmp[1040]; /* worst case: every byte of a 256-char path is a quote */
+   if (kb_curator_shell_quote(tmppath, qtmp, sizeof(qtmp)) != 0)
+   {
+      unlink(tmppath);
+      if (errbuf)
+         snprintf(errbuf, errlen, "sidecar temp path too long to quote safely");
+      return NULL;
+   }
+
+   char script[1600];
+   int sn = snprintf(script, sizeof(script), "%s < %s", cmd, qtmp);
+   char qscript[6464]; /* worst case: every byte of the script is a quote */
    if (sn < 0 || (size_t)sn >= sizeof(script) ||
-       kb_curator_shell_quote(script, qscript, sizeof(qscript)) != 0 ||
-       kb_curator_shell_quote(tmppath, qtmp, sizeof(qtmp)) != 0)
+       kb_curator_shell_quote(script, qscript, sizeof(qscript)) != 0)
    {
       unlink(tmppath);
       if (errbuf)
@@ -195,9 +205,8 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
       return NULL;
    }
 
-   char full_cmd[3840];
-   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s sh %s", CS_SIDECAR_TIMEOUT_S,
-            qscript, qtmp);
+   char full_cmd[6528];
+   snprintf(full_cmd, sizeof(full_cmd), "timeout -k 10 %d sh -c %s", CS_SIDECAR_TIMEOUT_S, qscript);
 
    FILE *fp = popen(full_cmd, "r");
    if (!fp)

--- a/src/kb/kb_curator_sidecar.c
+++ b/src/kb/kb_curator_sidecar.c
@@ -6,12 +6,57 @@
 
 #include "kb_curator_sidecar.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #define CS_DEFAULT_OUTBUF 8192
+
+/* Render a pclose(3) return value into an operator-legible reason.
+ *
+ * pclose returns a wait(2)-encoded status, NOT an exit code: reporting it raw
+ * printed "sidecar exited 256" for a plain `exit(1)` (1 << 8), which reads like
+ * an exotic failure and sends you looking for a signal that never happened.
+ *
+ * timeout_s > 0 means the caller wrapped the command in coreutils timeout(1),
+ * which reports the wall-clock cap as exit 124 — only then can 124 be read as a
+ * timeout rather than the command's own exit code. Callers that do not wrap
+ * pass 0. */
+void kb_curator_describe_wait_status(int status, int timeout_s, char *errbuf, size_t errlen)
+{
+   if (!errbuf || errlen == 0)
+      return;
+
+   if (status == -1)
+   {
+      snprintf(errbuf, errlen, "pclose failed: %s", strerror(errno));
+      return;
+   }
+   if (WIFSIGNALED(status))
+   {
+      int sig = WTERMSIG(status);
+      snprintf(errbuf, errlen, "sidecar killed by signal %d (%s)", sig, strsignal(sig));
+      return;
+   }
+   if (WIFEXITED(status))
+   {
+      int code = WEXITSTATUS(status);
+      if (timeout_s > 0 && code == 124)
+         snprintf(errbuf, errlen, "sidecar timed out after %ds", timeout_s);
+      else if (code > 128)
+         /* A shell reports a signal-killed child as 128+n; distinguishing which
+          * signal is what tells OOM (9) apart from a clean TERM (15). */
+         snprintf(errbuf, errlen, "sidecar killed by signal %d (%s)", code - 128,
+                  strsignal(code - 128));
+      else
+         snprintf(errbuf, errlen, "sidecar exited %d", code);
+      return;
+   }
+   snprintf(errbuf, errlen, "sidecar ended abnormally (wait status %d)", status);
+}
 
 char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_cap, char *errbuf,
                              size_t errlen)
@@ -26,14 +71,20 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
    }
    size_t cap = out_cap > 0 ? (size_t)out_cap : CS_DEFAULT_OUTBUF;
 
-   /* Write the request JSON to a temp file, then pipe it into the command. */
+   /* Write the request JSON to a temp file, then pipe it into the command.
+    * Honour TMPDIR (as code_collect.c does) so the spool can be moved off a full
+    * or slow filesystem, and carry errno on failure — ENOSPC, EMFILE and EACCES
+    * are different incidents, and this string is the only forensic record. */
+   const char *tmpdir = getenv("TMPDIR");
+   if (!tmpdir || !tmpdir[0])
+      tmpdir = "/tmp";
    char tmppath[256];
-   snprintf(tmppath, sizeof(tmppath), "/tmp/aimee_curator_sidecar_XXXXXX");
+   snprintf(tmppath, sizeof(tmppath), "%s/aimee_curator_sidecar_XXXXXX", tmpdir);
    int fd = mkstemp(tmppath);
    if (fd < 0)
    {
       if (errbuf)
-         snprintf(errbuf, errlen, "mkstemp failed");
+         snprintf(errbuf, errlen, "mkstemp failed for %s: %s", tmppath, strerror(errno));
       return NULL;
    }
 
@@ -84,8 +135,9 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
 
    if (rc != 0)
    {
-      if (errbuf)
-         snprintf(errbuf, errlen, "sidecar exited %d", rc);
+      /* This caller does not wrap the command in timeout(1), so 124 carries no
+       * special meaning here. */
+      kb_curator_describe_wait_status(rc, 0, errbuf, errlen);
       free(out);
       return NULL;
    }

--- a/src/kb/kb_curator_sidecar.h
+++ b/src/kb/kb_curator_sidecar.h
@@ -17,6 +17,18 @@
 char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_cap, char *errbuf,
                              size_t errlen);
 
+/* Quote `in` as a single sh word (POSIX single-quote form), so it can be
+ * interpolated into a shell command line without the shell re-parsing its
+ * contents. Exposed for testing.
+ *
+ * Needed because bounding a sidecar with timeout(1) means handing the configured
+ * command to a SECOND shell: interpolating it raw into `sh -c "<cmd>"` would let
+ * an embedded quote, $, backtick or backslash change the command's meaning —
+ * commands that worked under a bare popen. Returns 0 on success, -1 if the
+ * quoted form does not fit (caller must treat that as a hard error, never as a
+ * reason to fall back to the raw string). */
+int kb_curator_shell_quote(const char *in, char *out, size_t outlen);
+
 /* Render a pclose(3) wait status into an operator-legible reason. Shared with
  * callers that run their own popen (the code-unit stage wraps its command in
  * timeout(1)); exposed for testing.

--- a/src/kb/kb_curator_sidecar.h
+++ b/src/kb/kb_curator_sidecar.h
@@ -17,4 +17,15 @@
 char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_cap, char *errbuf,
                              size_t errlen);
 
+/* Render a pclose(3) wait status into an operator-legible reason. Shared with
+ * callers that run their own popen (the code-unit stage wraps its command in
+ * timeout(1)); exposed for testing.
+ *
+ * pclose returns a wait(2)-encoded status, not an exit code — reporting it raw
+ * logged "sidecar exited 256" for a plain exit(1). Distinguishes a non-zero
+ * exit, a signal kill (OOM), and a timeout. Pass timeout_s > 0 only if the
+ * command was wrapped in coreutils timeout(1) (whose cap shows as exit 124);
+ * callers that do not wrap pass 0. */
+void kb_curator_describe_wait_status(int status, int timeout_s, char *errbuf, size_t errlen);
+
 #endif /* KB_CURATOR_SIDECAR_H */

--- a/src/kb/kb_memory_facts.c
+++ b/src/kb/kb_memory_facts.c
@@ -170,25 +170,27 @@ static void mf_mark_retry_or_fail(int64_t job_id, int attempts, const char *erro
  * attempts is preserved (incremented at claim time).
  *
  * Scoped to kind='memory_facts' so it cannot disturb the other stages sharing
- * kb_async_jobs. Throttled — the drain calls this once per batch. */
+ * kb_async_jobs. Throttled — the drain calls this once per batch. Unlike the
+ * extract_doc reclaim, the throttle needs no lock: kb_memory_facts_drain has a
+ * single caller on the drain thread (no worker pool), so this is single-entry. */
 static void mf_reclaim_stale_running(void)
 {
    static time_t last_run = 0;
    time_t now = time(NULL);
    if (last_run != 0 && now - last_run < MF_RECLAIM_EVERY_S)
       return;
-   last_run = now;
 
    void *conn = db2_conn();
    if (!conn)
-      return;
+      return; /* never ran: leave the throttle unarmed so the next call retries */
    char err[MF_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(
        conn,
        "UPDATE kb_async_jobs"
        " SET status = CASE WHEN attempts >= ?1 THEN 'failed' ELSE 'pending' END,"
        "     claimed_by = '', claimed_at = '',"
-       "     last_error = CASE WHEN attempts >= ?1"
+       /* Preserve an existing diagnostic; see the extract_doc reclaim. */
+       "     last_error = CASE WHEN attempts >= ?1 AND last_error = ''"
        "                       THEN 'stale running lease reclaimed after max attempts'"
        "                       ELSE last_error END,"
        "     updated_at = pg_now_text()"
@@ -196,10 +198,16 @@ static void mf_reclaim_stale_running(void)
        "   AND claimed_at <> '' AND claimed_at < pg_now_text(?2)",
        err, sizeof(err));
    if (!st)
+   {
+      aimee_log(LOG_WARN, "kb.memory.facts", "stale-lease reclaim could not prepare: %s", err);
       return;
+   }
    aimee_pg_bind_int(st, "?1", MF_MAX_ATTEMPTS);
    aimee_pg_bind_text(st, "?2", MF_STALE_LEASE);
-   (void)aimee_pg_step(st, err, sizeof(err));
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_DONE)
+      last_run = now; /* only a completed UPDATE arms the throttle */
+   else
+      aimee_log(LOG_WARN, "kb.memory.facts", "stale-lease reclaim failed: %s", err);
    aimee_pg_finalize(st);
 }
 

--- a/src/kb/kb_memory_facts.c
+++ b/src/kb/kb_memory_facts.c
@@ -23,10 +23,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h> /* strcasecmp */
+#include <time.h>    /* time() — reclaim throttle */
 
 #define MF_ERRBUF       256
 #define MF_LLM_OUT_CAP  8192
 #define MF_MAX_ATTEMPTS 3
+/* A job left in 'running' longer than this lease was orphaned (worker crash/
+ * restart or a wedged LLM call). Mirrors the curator stages' lease. */
+#define MF_STALE_LEASE "-15 minutes"
+/* Reclaim runs at most this often (throttled; the drain calls it per batch). */
+#define MF_RECLAIM_EVERY_S 60
 /* Auto-injected into every turn (ingress_preinject), so precision matters more
  * than recall: only commit facts the model is confident are durable. */
 #define MF_CONF_FLOOR 0.6
@@ -151,6 +157,48 @@ static void mf_mark_retry_or_fail(int64_t job_id, int attempts, const char *erro
    aimee_pg_bind_text(st, "?1", new_status);
    aimee_pg_bind_text(st, "?2", error_msg ? error_msg : "");
    aimee_pg_bind_int64(st, "?3", job_id);
+   (void)aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+}
+
+/* Reclaim memory_facts jobs orphaned in 'running'. Identical in shape and
+ * rationale to the extract_doc reclaim in kb_curator_extract.c: mf_claim_job
+ * only ever selects status='pending', so a job whose worker crashed or whose
+ * LLM call wedged stays 'running' forever — never retried, and pinning a db2
+ * pool member past its ceiling. Reset rows older than the lease to 'pending',
+ * or to 'failed' once attempts are exhausted so a poison job cannot loop.
+ * attempts is preserved (incremented at claim time).
+ *
+ * Scoped to kind='memory_facts' so it cannot disturb the other stages sharing
+ * kb_async_jobs. Throttled — the drain calls this once per batch. */
+static void mf_reclaim_stale_running(void)
+{
+   static time_t last_run = 0;
+   time_t now = time(NULL);
+   if (last_run != 0 && now - last_run < MF_RECLAIM_EVERY_S)
+      return;
+   last_run = now;
+
+   void *conn = db2_conn();
+   if (!conn)
+      return;
+   char err[MF_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn,
+       "UPDATE kb_async_jobs"
+       " SET status = CASE WHEN attempts >= ?1 THEN 'failed' ELSE 'pending' END,"
+       "     claimed_by = '', claimed_at = '',"
+       "     last_error = CASE WHEN attempts >= ?1"
+       "                       THEN 'stale running lease reclaimed after max attempts'"
+       "                       ELSE last_error END,"
+       "     updated_at = pg_now_text()"
+       " WHERE kind = 'memory_facts' AND status = 'running'"
+       "   AND claimed_at <> '' AND claimed_at < pg_now_text(?2)",
+       err, sizeof(err));
+   if (!st)
+      return;
+   aimee_pg_bind_int(st, "?1", MF_MAX_ATTEMPTS);
+   aimee_pg_bind_text(st, "?2", MF_STALE_LEASE);
    (void)aimee_pg_step(st, err, sizeof(err));
    aimee_pg_finalize(st);
 }
@@ -295,6 +343,10 @@ int kb_memory_facts_drain(const config_t *cfg, int batch)
       return 0;
    if (!db2_conn())
       return 0;
+
+   /* Recover jobs orphaned in 'running' before claiming fresh work, so a crash/
+    * restart or a previously-wedged LLM call cannot permanently strand them. */
+   mf_reclaim_stale_running();
 
    int processed = 0;
    for (int i = 0; i < batch; i++)

--- a/src/kb_curator_drain.h
+++ b/src/kb_curator_drain.h
@@ -4,6 +4,7 @@
 #include <pthread.h>
 
 #define KB_CURATOR_MAX_CODE_WORKERS 8
+#define KB_CURATOR_MAX_DOC_WORKERS  8
 
 typedef struct
 {
@@ -15,6 +16,9 @@ typedef struct
     * many sidecar extractions in parallel. */
    pthread_t code_threads[KB_CURATOR_MAX_CODE_WORKERS];
    int code_active; /* number of spawned extract_code workers */
+   /* Dedicated extract_doc workers — same shape, same rationale. */
+   pthread_t doc_threads[KB_CURATOR_MAX_DOC_WORKERS];
+   int doc_active; /* number of spawned extract_doc workers */
    int active;
    int index_active;
    volatile int stop;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -751,11 +751,26 @@ $(TESTPREFIX)/unit-test-curator-queue: \
                                        $(OBJDIR)/tests/test_curator_queue.o \
                                        $(OBJDIR)/kb/kb_curator_queue.o \
                                        $(OBJDIR)/kb/kb_curator_extract.o \
+                                       $(OBJDIR)/kb/kb_memory_facts.o \
                                        $(OBJDIR)/kb/kb_curator_llm.o \
                                        $(OBJDIR)/kb/kb_curator_sidecar.o \
                                        $(OBJDIR)/kb_curator_provider.o \
                                        $(OBJDIR)/provider_client.o \
                                        $(OBJDIR)/tests/support/mock_agent_http.o \
+                                       $(OBJDIR)/db2/typed_facts.o \
+                                       $(OBJDIR)/db2/rel_types_store.o \
+                                       $(OBJDIR)/db2/fact_recall.o \
+                                       $(OBJDIR)/db2/fact_ingest.o \
+                                       $(OBJDIR)/db2/fact_lifecycle.o \
+                                       $(OBJDIR)/db2/entity_edges.o \
+                                       $(OBJDIR)/db2/entity_registry.o \
+                                       $(OBJDIR)/db2/ontology_evolution.o \
+                                       $(OBJDIR)/db2/memory_query.o \
+                                       $(OBJDIR)/db2/memory_row_mapper_pg.o \
+                                       $(OBJDIR)/memory_extract_patterns.o \
+                                       $(OBJDIR)/memory_fact_gate.o \
+                                       $(OBJDIR)/memory_pii_gate.o \
+                                       $(OBJDIR)/rel_types.o \
                                        $(OBJDIR)/index.o \
                                        $(OBJDIR)/db2/code_index.o \
                                        $(OBJDIR)/db2/kb_payload.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -750,6 +750,12 @@ $(TESTPREFIX)/unit-test-curator-custom-stages: $(OBJDIR)/tests/test_curator_cust
 $(TESTPREFIX)/unit-test-curator-queue: \
                                        $(OBJDIR)/tests/test_curator_queue.o \
                                        $(OBJDIR)/kb/kb_curator_queue.o \
+                                       $(OBJDIR)/kb/kb_curator_extract.o \
+                                       $(OBJDIR)/kb/kb_curator_llm.o \
+                                       $(OBJDIR)/kb/kb_curator_sidecar.o \
+                                       $(OBJDIR)/kb_curator_provider.o \
+                                       $(OBJDIR)/provider_client.o \
+                                       $(OBJDIR)/tests/support/mock_agent_http.o \
                                        $(OBJDIR)/index.o \
                                        $(OBJDIR)/db2/code_index.o \
                                        $(OBJDIR)/db2/kb_payload.o \
@@ -2626,6 +2632,7 @@ $(TESTPREFIX)/unit-test-curator-code-unit: \
                                        $(OBJDIR)/kb/kb_curator_queue.o \
                                        $(OBJDIR)/kb/kb_curator_extract_code.o \
                                        $(OBJDIR)/kb/kb_curator_extract.o \
+                                       $(OBJDIR)/kb/kb_curator_sidecar.o \
                                        $(OBJDIR)/kb/kb_curator_grounding.o \
                                        $(OBJDIR)/db2/artifacts.o $(OBJDIR)/db2/kb_audit_worm.o $(OBJDIR)/audit_worm_chain.o $(OBJDIR)/workflow/wfe_canonical.o \
                                        $(OBJDIR)/db2/feature_rows.o \

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -18,6 +18,7 @@
 #include "config.h"
 #include "kb_curator_extract.h"
 #include "kb/kb_curator_grounding.h"
+#include "kb/kb_curator_sidecar.h"
 
 /* The deep-curator code-extract gate is now ON by compiled default, but the
  * gate-off tests below need it OFF. Point AIMEE_HOME at an isolated temp config
@@ -352,6 +353,55 @@ static void test_extract_reads_body_from_db2_when_file_absent(void)
  * candidate even when it is not executable — invoked as `python3 <path>`, the
  * old access(X_OK) check wrongly rejected the shipped 0644 script and stalled
  * every extract job — and (c) fall back to the cwd-relative path when none match. */
+/* kb_curator_describe_wait_status: pclose(3) hands back a wait(2)-encoded status,
+ * not an exit code. Reporting it raw wrote "sidecar exited 256" into
+ * kb_code_unit_jobs.last_error for a sidecar that merely exit(1)'d — an opaque
+ * number that reads like an exotic fault and hides the real failure mode. These
+ * assert each status class decodes to something an operator can act on. */
+static void test_describe_wait_status(void)
+{
+   char out[256];
+
+   /* (a) The regression: exit(1) is 1<<8 == 256 in wait encoding. */
+   kb_curator_describe_wait_status(1 << 8, 300, out, sizeof(out));
+   assert(strcmp(out, "sidecar exited 1") == 0);
+
+   /* (b) Success-shaped status still renders an exit line if a caller asks. */
+   kb_curator_describe_wait_status(0, 300, out, sizeof(out));
+   assert(strcmp(out, "sidecar exited 0") == 0);
+
+   /* (c) timeout(1) reports its wall-clock cap as exit 124 — named only when the
+    *     caller says it wrapped the command, and echoing the cap it was given. */
+   kb_curator_describe_wait_status(124 << 8, 300, out, sizeof(out));
+   assert(strcmp(out, "sidecar timed out after 300s") == 0);
+
+   /* (d) Same status WITHOUT a timeout wrapper is just the command's exit code;
+    *     claiming a timeout there would be a lie (kb_curator_sidecar.c does not
+    *     wrap, and passes 0). */
+   kb_curator_describe_wait_status(124 << 8, 0, out, sizeof(out));
+   assert(strcmp(out, "sidecar exited 124") == 0);
+
+   /* (e) A real signal death — SIGKILL is the OOM-killer signature we care about
+    *     on a box where the model shares RAM with the drain. */
+   kb_curator_describe_wait_status(9 /* WIFSIGNALED: low 7 bits = signo */, 300, out, sizeof(out));
+   assert(strncmp(out, "sidecar killed by signal 9", 26) == 0);
+
+   /* (f) A shell reports a signal-killed child as 128+n; decode rather than
+    *     printing a bare 137. */
+   kb_curator_describe_wait_status((128 + 9) << 8, 300, out, sizeof(out));
+   assert(strncmp(out, "sidecar killed by signal 9", 26) == 0);
+
+   /* (g) pclose itself failing is distinct from any child status. */
+   kb_curator_describe_wait_status(-1, 300, out, sizeof(out));
+   assert(strncmp(out, "pclose failed:", 14) == 0);
+
+   /* (h) Null/zero-length buffers must not be written through. */
+   kb_curator_describe_wait_status(1 << 8, 300, NULL, 0);
+   kb_curator_describe_wait_status(1 << 8, 300, out, 0);
+
+   printf("  PASS: test_describe_wait_status\n");
+}
+
 static void test_pick_sidecar_command_resolution(void)
 {
    char out[768];
@@ -405,6 +455,7 @@ int main(void)
    test_extract_accepts_pure_function();
    test_extract_reads_body_from_db2_when_file_absent();
    test_pick_sidecar_command_resolution();
+   test_describe_wait_status();
 
    printf("ok\n");
    return 0;

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -456,9 +456,12 @@ static void test_describe_wait_status(void)
    assert(strcmp(out, "sidecar exited 0") == 0);
 
    /* (c) timeout(1) reports its wall-clock cap as exit 124 — named only when the
-    *     caller says it wrapped the command, and echoing the cap it was given. */
+    *     caller says it wrapped the command, and echoing the cap it was given.
+    *     Hedged, because timeout also PROPAGATES a command's own exit 124: the
+    *     two are indistinguishable, so the message must not assert either. */
    kb_curator_describe_wait_status(124 << 8, 300, out, sizeof(out));
-   assert(strcmp(out, "sidecar timed out after 300s") == 0);
+   assert(strcmp(out,
+                 "sidecar exited 124 (timeout after 300s, or the command itself exited 124)") == 0);
 
    /* (d) Same status WITHOUT a timeout wrapper is just the command's exit code;
     *     claiming a timeout there would be a lie (kb_curator_sidecar.c does not
@@ -558,6 +561,23 @@ static void test_sidecar_quoting_end_to_end(void)
    assert(out2 != NULL);
    assert(strcmp(out2, "a b") == 0);
    free(out2);
+
+   /* The redirection must stay in the COMMAND's parse context, not the wrapper's.
+    * A pipeline is where the two diverge: under the bare popen the line is
+    * `printf ABC | wc -c < tmp`, so `< tmp` binds to wc (the LAST command) and
+    * wc counts the 2-byte request. Redirecting the timeout wrapper's stdin
+    * instead would feed tmp to printf and leave wc counting printf's 3 bytes —
+    * a silent change of meaning. Asserting 2 pins the bare-popen semantics.
+    *
+    *   bare popen:                  2
+    *   wrapper stdin redirect:      3   <- the bug
+    *   redirect inside, path as $1: 2   <- preserved
+    */
+   char *out3 = kb_curator_sidecar_run("printf ABC | wc -c", "{}", 256, err, sizeof(err));
+   assert(out3 != NULL);
+   long counted = strtol(out3, NULL, 10);
+   assert(counted == 2);
+   free(out3);
 
    printf("  PASS: test_sidecar_quoting_end_to_end\n");
 }

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -381,15 +381,18 @@ static void test_describe_wait_status(void)
    kb_curator_describe_wait_status(124 << 8, 0, out, sizeof(out));
    assert(strcmp(out, "sidecar exited 124") == 0);
 
-   /* (e) A real signal death — SIGKILL is the OOM-killer signature we care about
-    *     on a box where the model shares RAM with the drain. */
+   /* (e) A real signal death — the kernel says so via WIFSIGNALED, so the
+    *     message may state it as fact. SIGKILL is the OOM-killer signature we
+    *     care about on a box where the model shares RAM with the drain. */
    kb_curator_describe_wait_status(9 /* WIFSIGNALED: low 7 bits = signo */, 300, out, sizeof(out));
-   assert(strncmp(out, "sidecar killed by signal 9", 26) == 0);
+   assert(strcmp(out, "sidecar killed by signal 9 (Killed)") == 0);
 
-   /* (f) A shell reports a signal-killed child as 128+n; decode rather than
-    *     printing a bare 137. */
+   /* (f) 128+n is the SHELL's convention for a signal-killed child — but a
+    *     process can also exit(137) itself, and the two are indistinguishable
+    *     here. So report the exit code as fact and the signal as a reading:
+    *     asserting a kill outright would fake an OOM that never happened. */
    kb_curator_describe_wait_status((128 + 9) << 8, 300, out, sizeof(out));
-   assert(strncmp(out, "sidecar killed by signal 9", 26) == 0);
+   assert(strcmp(out, "sidecar exited 137 (128+9: likely killed by signal 9, Killed)") == 0);
 
    /* (g) pclose itself failing is distinct from any child status. */
    kb_curator_describe_wait_status(-1, 300, out, sizeof(out));

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -76,6 +76,91 @@ static void test_queue_null_args(void)
 
 /* ── DB-backed tests ────────────────────────────────────────────────────── */
 
+/* Read one column of a kb_code_unit_jobs row into buf. Returns 0 on success. */
+static int ccu_test_job_field(sqlite3 *db, long long id, const char *col, char *buf, size_t buflen)
+{
+   char sql[256];
+   snprintf(sql, sizeof(sql), "SELECT %s FROM kb_code_unit_jobs WHERE id=%lld", col, id);
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   int rc = -1;
+   if (sqlite3_step(st) == SQLITE_ROW)
+   {
+      const unsigned char *t = sqlite3_column_text(st, 0);
+      snprintf(buf, buflen, "%s", t ? (const char *)t : "");
+      rc = 0;
+   }
+   sqlite3_finalize(st);
+   return rc;
+}
+
+/* ccu_reclaim_stale_running: the code-unit analogue of the extract_doc reclaim.
+ * ccu_claim_job only ever selects status='pending', so a job orphaned in
+ * 'running' (worker crash/restart, wedged sidecar) is never retried and pins a
+ * db2 pool member past its ceiling.
+ *
+ * MUST run before any other test that calls kb_curator_extract_code_unit_one:
+ * the reclaim throttles on a process-wide static, and a successful reclaim in an
+ * earlier test would arm it and make this one silently skip. max_attempts=1 puts
+ * every reclaimed row on the terminal branch so the follow-on claim stays quiet
+ * and these assertions are about the reclaim alone. */
+static void test_reclaim_stale_running_code_unit(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   assert(db != NULL);
+
+   /* (a) orphan: stale claim, attempts exhausted -> 'failed', and its existing
+    *     diagnostic is PRESERVED rather than overwritten with the reclaim's own
+    *     message — that error is why the attempt died. */
+   assert(sqlite3_exec(db,
+                       "INSERT INTO kb_code_unit_jobs (id,project,file_path,symbol,status,attempts,"
+                       "last_error,claimed_by,claimed_at) VALUES (9101,'p','a.c','fn_a','running',"
+                       "1,'mkstemp failed for /tmp/x: No space left on device','kb.curator.drain',"
+                       "datetime('now','-60 minutes'))",
+                       NULL, NULL, NULL) == SQLITE_OK);
+
+   /* (b) orphan with no diagnostic -> reclaim explains why it is terminal. */
+   assert(sqlite3_exec(db,
+                       "INSERT INTO kb_code_unit_jobs (id,project,file_path,symbol,status,attempts,"
+                       "last_error,claimed_by,claimed_at) VALUES (9102,'p','b.c','fn_b','running',"
+                       "1,'','kb.curator.drain',datetime('now','-60 minutes'))",
+                       NULL, NULL, NULL) == SQLITE_OK);
+
+   /* (c) claimed just now: in-flight, NOT orphaned — reclaiming would yank live
+    *     work out from under a running sidecar. */
+   assert(sqlite3_exec(db,
+                       "INSERT INTO kb_code_unit_jobs (id,project,file_path,symbol,status,attempts,"
+                       "last_error,claimed_by,claimed_at) VALUES (9103,'p','c.c','fn_c','running',"
+                       "1,'','kb.curator.drain',datetime('now'))",
+                       NULL, NULL, NULL) == SQLITE_OK);
+
+   kb_curator_extract_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.max_attempts = 1;
+   opts.max_tokens = 256;
+   (void)kb_curator_extract_code_unit_one(&opts);
+
+   char buf[256];
+   assert(ccu_test_job_field(db, 9101, "status", buf, sizeof(buf)) == 0);
+   assert(strcmp(buf, "failed") == 0);
+   assert(ccu_test_job_field(db, 9101, "last_error", buf, sizeof(buf)) == 0);
+   assert(strstr(buf, "No space left on device") != NULL); /* diagnostic survived */
+
+   assert(ccu_test_job_field(db, 9102, "status", buf, sizeof(buf)) == 0);
+   assert(strcmp(buf, "failed") == 0);
+   assert(ccu_test_job_field(db, 9102, "last_error", buf, sizeof(buf)) == 0);
+   assert(strcmp(buf, "stale running lease reclaimed after max attempts") == 0);
+
+   assert(ccu_test_job_field(db, 9103, "status", buf, sizeof(buf)) == 0);
+   assert(strcmp(buf, "running") == 0); /* in-flight untouched */
+
+   db2_test_shim_close();
+   printf("  PASS: test_reclaim_stale_running_code_unit (orphans reclaimed; diagnostic preserved; "
+          "in-flight untouched)\n");
+}
+
 static void test_extract_code_unit_one_empty_queue(void)
 {
    db2_test_shim_open();
@@ -405,6 +490,78 @@ static void test_describe_wait_status(void)
    printf("  PASS: test_describe_wait_status\n");
 }
 
+/* kb_curator_shell_quote: bounding the sidecar with timeout(1) means a SECOND
+ * shell parses the command line, so the configured command must be quoted rather
+ * than interpolated raw. Without this, adding the timeout wrapper would silently
+ * re-interpret commands that worked fine under a bare popen — an embedded quote
+ * ends the string early, and $VAR expands twice. */
+static void test_shell_quote(void)
+{
+   char out[2176];
+
+   /* (a) an ordinary command is wrapped, contents untouched. */
+   assert(kb_curator_shell_quote("python3 /opt/aimee/scripts/curator-extract.py", out,
+                                 sizeof(out)) == 0);
+   assert(strcmp(out, "'python3 /opt/aimee/scripts/curator-extract.py'") == 0);
+
+   /* (b) the regression: shell metacharacters must survive as LITERALS. Inside
+    *     single quotes nothing is special, so $VAR cannot expand and the double
+    *     quote cannot terminate anything. */
+   assert(kb_curator_shell_quote("python3 -c \"print($HOME)\"", out, sizeof(out)) == 0);
+   assert(strcmp(out, "'python3 -c \"print($HOME)\"'") == 0);
+
+   /* (c) an embedded single quote is the one case single-quoting can't nest:
+    *     close, escape, reopen. */
+   assert(kb_curator_shell_quote("echo 'hi'", out, sizeof(out)) == 0);
+   assert(strcmp(out, "'echo '\\''hi'\\'''") == 0);
+
+   /* (d) backslashes and backticks are literal too. */
+   assert(kb_curator_shell_quote("a\\b`id`", out, sizeof(out)) == 0);
+   assert(strcmp(out, "'a\\b`id`'") == 0);
+
+   /* (e) empty string still yields a valid empty shell word. */
+   assert(kb_curator_shell_quote("", out, sizeof(out)) == 0);
+   assert(strcmp(out, "''") == 0);
+
+   /* (f) overflow is a hard error, never a truncated (and thus mis-quoted)
+    *     string the caller might still run. */
+   char tiny[8];
+   assert(kb_curator_shell_quote("aaaaaaaaaaaaaaaa", tiny, sizeof(tiny)) == -1);
+   assert(kb_curator_shell_quote("abc", NULL, 16) == -1);
+   assert(kb_curator_shell_quote(NULL, out, sizeof(out)) == -1);
+
+   printf("  PASS: test_shell_quote\n");
+}
+
+/* The quoting must survive a REAL shell round-trip, not just a string compare.
+ *
+ * The invariant is NOT "nothing expands" — the command still runs under `sh -c`,
+ * so the INNER shell applies normal semantics, exactly as the bare popen did.
+ * The invariant is that wrapping in timeout(1) changes NOTHING about how the
+ * command is interpreted. This command is chosen so the two disagree:
+ *
+ *   bare popen (correct):        lit::"q"
+ *   new, quoted wrapper:         lit::"q"   <- identical, semantics preserved
+ *   old, raw interpolation:      lit::q     <- outer shell ate the \" escapes
+ */
+static void test_sidecar_quoting_end_to_end(void)
+{
+   char err[256] = "";
+   char *out = kb_curator_sidecar_run("printf '%s' \"lit:$NOT_A_REAL_VAR:\\\"q\\\"\"", "{}", 256,
+                                      err, sizeof(err));
+   assert(out != NULL);
+   assert(strcmp(out, "lit::\"q\"") == 0);
+   free(out);
+
+   /* A single-quoted argument is the case the '\'' escaping exists for. */
+   char *out2 = kb_curator_sidecar_run("printf '%s' 'a b'", "{}", 256, err, sizeof(err));
+   assert(out2 != NULL);
+   assert(strcmp(out2, "a b") == 0);
+   free(out2);
+
+   printf("  PASS: test_sidecar_quoting_end_to_end\n");
+}
+
 static void test_pick_sidecar_command_resolution(void)
 {
    char out[768];
@@ -443,6 +600,10 @@ int main(void)
    printf("curator_code_unit:\n");
 
    test_force_curator_gate_off();
+   /* MUST precede any other kb_curator_extract_code_unit_one caller: the
+    * reclaim's throttle is a process-wide static that a successful earlier
+    * reclaim would arm, silently skipping this one. */
+   test_reclaim_stale_running_code_unit();
    test_queue_code_unit_gate_off();
    test_queue_code_units_for_project_gate_off();
    test_queue_null_args();
@@ -459,6 +620,8 @@ int main(void)
    test_extract_reads_body_from_db2_when_file_absent();
    test_pick_sidecar_command_resolution();
    test_describe_wait_status();
+   test_shell_quote();
+   test_sidecar_quoting_end_to_end();
 
    printf("ok\n");
    return 0;

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -579,6 +579,16 @@ static void test_sidecar_quoting_end_to_end(void)
    assert(counted == 2);
    free(out3);
 
+   /* The request path is embedded as a quoted literal, not passed as $1. With a
+    * positional, a command containing `set --` rebinds $1 before the redirection
+    * expands and the sidecar silently reads a DIFFERENT file — measured at 5
+    * bytes (/etc/hostname) instead of the 2-byte request. A literal cannot be
+    * reassigned, so this still reads the request. */
+   char *out4 = kb_curator_sidecar_run("set -- /etc/hostname; wc -c", "{}", 256, err, sizeof(err));
+   assert(out4 != NULL);
+   assert(strtol(out4, NULL, 10) == 2);
+   free(out4);
+
    printf("  PASS: test_sidecar_quoting_end_to_end\n");
 }
 

--- a/src/tests/test_curator_queue.c
+++ b/src/tests/test_curator_queue.c
@@ -14,6 +14,7 @@
 #include "platform_test_util.h"
 #include "db2_test_shim.h"
 #include "../kb_curator_queue.h"
+#include "../kb_curator_extract.h"
 
 static sqlite3 *open_db(void)
 {
@@ -40,6 +41,74 @@ static int jobs(sqlite3 *db)
    int n = sqlite3_column_int(st, 0);
    sqlite3_finalize(st);
    return n;
+}
+
+static const char *job_status(sqlite3 *db, int64_t id)
+{
+   static char buf[64];
+   sqlite3_stmt *st;
+   assert(sqlite3_prepare_v2(db, "SELECT status FROM kb_async_jobs WHERE id=?1", -1, &st, NULL) ==
+          SQLITE_OK);
+   sqlite3_bind_int64(st, 1, id);
+   assert(sqlite3_step(st) == SQLITE_ROW);
+   snprintf(buf, sizeof(buf), "%s", (const char *)sqlite3_column_text(st, 0));
+   sqlite3_finalize(st);
+   return buf;
+}
+
+/* The exact production regression: kb_curator_extract_one only ever CLAIMS
+ * status='pending', so an extract_doc job orphaned in 'running' (worker crash,
+ * restart, wedged sidecar) stayed there forever — one sat for 15h on the .254
+ * appliance, never retried, pinning a db2 pool member past its 300s ceiling.
+ * The code-unit stage had a lease reclaim from the start; kb_async_jobs had none.
+ *
+ * The reclaim self-throttles (it runs at most once a minute, since the drain
+ * calls the entry point once per job), so this exercises ONE call and seeds every
+ * case around it. max_attempts=1 makes every reclaimed row terminal, which keeps
+ * the follow-on claim from re-running these jobs and muddying the assertions. */
+static void test_reclaim_stale_running_extract_doc(sqlite3 *db)
+{
+   /* Backing docs: kb_async_jobs.document_id is a FK onto kb_documents. The ids
+    * sit deliberately far above the docs seeded earlier in this process, because
+    * kb_async_jobs is UNIQUE(kind, document_id) and those already hold
+    * extract_doc rows. */
+   seed(db, "INSERT INTO kb_documents (id,project,file_path,file_hash,chunk_index,content,doc_kind)"
+            " VALUES (9001,'p','r1.md','rh1',0,'t','')");
+   seed(db, "INSERT INTO kb_documents (id,project,file_path,file_hash,chunk_index,content,doc_kind)"
+            " VALUES (9002,'p','r2.md','rh2',0,'t','')");
+   seed(db, "INSERT INTO kb_documents (id,project,file_path,file_hash,chunk_index,content,doc_kind)"
+            " VALUES (9003,'p','r3.md','rh3',0,'t','')");
+
+   /* (a) stale extract_doc job, attempts exhausted -> reclaimed to 'failed'. */
+   seed(db, "INSERT INTO kb_async_jobs (id,kind,document_id,project,status,attempts,claimed_by,"
+            "claimed_at,created_at,updated_at) VALUES (9001,'extract_doc',9001,'p','running',1,"
+            "'kb.curator.drain',datetime('now','-60 minutes'),datetime('now','-60 minutes'),"
+            "datetime('now','-60 minutes'))");
+
+   /* (b) a job claimed just now is in-flight, NOT orphaned — must be left alone,
+    *     or the reclaim would yank live work out from under a running sidecar. */
+   seed(db, "INSERT INTO kb_async_jobs (id,kind,document_id,project,status,attempts,claimed_by,"
+            "claimed_at,created_at,updated_at) VALUES (9002,'extract_doc',9002,'p','running',1,"
+            "'kb.curator.drain',datetime('now'),datetime('now'),datetime('now'))");
+
+   /* (c) another kind, equally stale: kb_async_jobs is shared, and memory_facts
+    *     owns its own claim lifecycle. Reclaiming it from the doc stage would be
+    *     cross-stage theft. */
+   seed(db, "INSERT INTO kb_async_jobs (id,kind,document_id,project,status,attempts,claimed_by,"
+            "claimed_at,created_at,updated_at) VALUES (9003,'memory_facts',9003,'p','running',1,"
+            "'kb.curator.drain',datetime('now','-60 minutes'),datetime('now','-60 minutes'),"
+            "datetime('now','-60 minutes'))");
+
+   kb_curator_extract_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.max_attempts = 1;
+   snprintf(opts.extract_command, sizeof(opts.extract_command), "%s", "true");
+   (void)kb_curator_extract_one(&opts);
+
+   assert(strcmp(job_status(db, 9001), "failed") == 0);  /* orphan reclaimed */
+   assert(strcmp(job_status(db, 9002), "running") == 0); /* in-flight untouched */
+   assert(strcmp(job_status(db, 9003), "running") == 0); /* other kind untouched */
+   printf("  PASS: reclaim_stale_running (orphan reclaimed; in-flight + other kinds untouched)\n");
 }
 
 int main(void)
@@ -79,6 +148,8 @@ int main(void)
    kb_curator_queue_docs_all_projects(1);
    assert(jobs(db) == 3); /* +proj/x.md */
    printf("  PASS: queue_docs_all_projects (drain backfill queues indexed docs; disabled=no-op)\n");
+
+   test_reclaim_stale_running_extract_doc(db);
 
    printf("test_curator_queue: all tests passed\n");
    return 0;

--- a/src/tests/test_curator_queue.c
+++ b/src/tests/test_curator_queue.c
@@ -15,6 +15,8 @@
 #include "db2_test_shim.h"
 #include "../kb_curator_queue.h"
 #include "../kb_curator_extract.h"
+#include "../kb/kb_memory_facts.h"
+#include "config.h"
 
 static sqlite3 *open_db(void)
 {
@@ -93,10 +95,13 @@ static void test_reclaim_stale_running_extract_doc(sqlite3 *db)
 
    /* (c) another kind, equally stale: kb_async_jobs is shared, and memory_facts
     *     owns its own claim lifecycle. Reclaiming it from the doc stage would be
-    *     cross-stage theft. */
+    *     cross-stage theft. attempts is at MF_MAX_ATTEMPTS so that when its own
+    *     drain reclaims it below, it lands on the terminal 'failed' branch and
+    *     no follow-on claim can process it — keeping that assertion about the
+    *     reclaim alone. */
    seed(db, "INSERT INTO kb_async_jobs (id,kind,document_id,project,status,attempts,claimed_by,"
-            "claimed_at,created_at,updated_at) VALUES (9003,'memory_facts',9003,'p','running',1,"
-            "'kb.curator.drain',datetime('now','-60 minutes'),datetime('now','-60 minutes'),"
+            "claimed_at,created_at,updated_at) VALUES (9003,'memory_facts',9003,'p','running',3,"
+            "'kb.memory.facts',datetime('now','-60 minutes'),datetime('now','-60 minutes'),"
             "datetime('now','-60 minutes'))");
 
    kb_curator_extract_opts_t opts;
@@ -109,6 +114,25 @@ static void test_reclaim_stale_running_extract_doc(sqlite3 *db)
    assert(strcmp(job_status(db, 9002), "running") == 0); /* in-flight untouched */
    assert(strcmp(job_status(db, 9003), "running") == 0); /* other kind untouched */
    printf("  PASS: reclaim_stale_running (orphan reclaimed; in-flight + other kinds untouched)\n");
+}
+
+/* memory_facts shares kb_async_jobs and had the same missing-reclaim gap: its
+ * claim also only selects 'pending', so a wedged LLM call stranded the job
+ * forever. Job 9003 above is the stale memory_facts row the extract_doc reclaim
+ * correctly refused to touch — here its OWN drain must reclaim it, which also
+ * pins the kind scoping from the other side. */
+static void test_reclaim_stale_running_memory_facts(sqlite3 *db)
+{
+   assert(strcmp(job_status(db, 9003), "running") == 0); /* still stale from above */
+
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.typed_facts_enabled = 1;
+   (void)kb_memory_facts_drain(&cfg, 8);
+
+   assert(strcmp(job_status(db, 9003), "failed") == 0);  /* orphan reclaimed */
+   assert(strcmp(job_status(db, 9002), "running") == 0); /* extract_doc untouched */
+   printf("  PASS: reclaim_stale_running_memory_facts (orphan reclaimed; other kinds untouched)\n");
 }
 
 int main(void)
@@ -150,6 +174,7 @@ int main(void)
    printf("  PASS: queue_docs_all_projects (drain backfill queues indexed docs; disabled=no-op)\n");
 
    test_reclaim_stale_running_extract_doc(db);
+   test_reclaim_stale_running_memory_facts(db);
 
    printf("test_curator_queue: all tests passed\n");
    return 0;


### PR DESCRIPTION
Found while investigating why ingestion looked stuck on the `.254` appliance. The pipeline turned out to be **healthy but leaking work**: both queues drain cleanly in id order, code-unit extraction runs at ~1,700 jobs/hr. The real problems were a wedged lease and a set of failures nobody could diagnose.

## What this fixes

**1. `extract_doc` jobs orphaned in `running` were never recovered.** `ce_claim_job` only ever selects `status='pending'`, so a job whose worker crashed or whose sidecar wedged stays `running` forever — never extracted, and pinning a db2 pool member long past its 300s ceiling. On `.254`, job 3401 sat wedged for 15h:

```
3401 | running | attempts=1 | kb.curator.drain | claimed_at 2026-07-14 19:19:32
aimee: db2.pool: member 0 leased 54483876ms (> 300000ms ceiling) — missed lease_end?
```

54483876ms is 15.13h — the same incident, not two. The code-unit stage has had `ccu_reclaim_stale_running` since it shipped; `kb_async_jobs` never got one. This mirrors it, scoped to `kind='extract_doc'` so the other stages sharing that table keep their own claim lifecycle.

**2. `pclose(3)` returns a wait(2)-encoded status, not an exit code.** Reporting it raw wrote `sidecar exited 256` for a sidecar that merely `exit(1)`'d (`1 << 8`). That opaque number reads like an exotic fault and sends you hunting a signal that never happened. Now decoded into exit / signal / timeout — on a box where llama-server holds 53% of RAM, an OOM kill and a clean non-zero exit are different incidents. Factored into `kb_curator_sidecar.c`, which both popen callers already sit under.

**3. `mkstemp` failures discarded `errno`.** 5,114 code-unit jobs on `.254` died on a bare `mkstemp failed` — which cannot distinguish `ENOSPC` (root fs is 96% full) from `EMFILE` from `EACCES`. **This does not fix those failures; it makes the next one diagnosable.** Also honours `TMPDIR`, as `code_collect.c` already does, so the spool can be moved off a full filesystem.

**4. The generic async drain claimed jobs of ANY kind.** `db2_kb_service_async_queue_claim_next` had no `kind` filter, while its dispatch marks anything it doesn't recognize `failed`. One call to that endpoint would have silently destroyed all 5,682 pending `extract_doc` jobs. Latent (it isn't on the drain thread's path) but a live footgun.

## Testing

- `reclaim_stale_running` — asserts an orphan is reclaimed, while an in-flight job and another `kind` are left untouched. **Verified failing without the fix** (neutered the reclaim call; the 9001 assertion fires), so it's a real guard rather than a vacuous one.
- `describe_wait_status` — pins each status class, including the exact `256`-means-`exit 1` regression, and that 124 is only read as a timeout when the caller actually wrapped in `timeout(1)`.
- Ran `unit-test-curator-queue`, `unit-test-curator-code-unit`, `unit-test-kb-curator-llm`, `unit-test-curator-version`, `unit-test-curator-custom-stages`, `unit-test-db2-pool` — all pass. `make line-check`, `make module-boundary-check`, and clang-format-19 clean.

## Deliberately NOT changed

- **`ccu_mark_retry_or_fail(job_id, opts->max_attempts, opts->max_attempts, ...)`** at the body-read failure looks like an argument bug, but `kb_curator_extract.c:380` uses the same idiom with a log line that says "marking failed" — it's a deliberate fail-fast for non-retryable conditions. Left alone.
- **Re-queuing the 5,229 already-failed code-unit jobs.** They're at `attempts=3` and the backfill's `ON CONFLICT DO NOTHING` will never reset them, so they need an explicit requeue. Doing that now would just re-fail them until the `mkstemp` root cause is known — which is what fix 3 unblocks. Worth a follow-up once we have a real errno.

## Known gaps (follow-ups, not in scope here)

- `memory_facts` shares `kb_async_jobs` and has the same missing-reclaim gap. No wedge observed, so not fixed blind.
- `extract_doc` throughput is ~1 doc/90s single-threaded, with 5,682 pending — roughly 6 days to drain. That's a capacity question, not a bug.
- Root fs on `.254` is at 96%. Operational, but plausibly related to fix 3.