### PR TITLE
fix(kb/curator): don't split UTF-8 when truncating; surface the reasons behind failures

### DIFF
--- a/src/headers/util.h
+++ b/src/headers/util.h
@@ -152,6 +152,17 @@ char *normalize_key(const char *key, char *buf, size_t buf_len);
 /* Trigram Jaccard similarity between two strings. Returns 0.0-1.0. */
 double trigram_similarity(const char *a, const char *b);
 
+/* Drop a trailing PARTIAL UTF-8 character, in place.
+ *
+ * Copying text into a fixed buffer (snprintf/memcpy) cuts at a byte offset, which
+ * splits any multi-byte character straddling the limit and leaves a byte sequence
+ * that is not valid UTF-8. That matters the moment the value reaches something
+ * that validates encoding: postgres rejects the whole INSERT with "invalid byte
+ * sequence for encoding UTF8", so a single em-dash at the cut point can fail an
+ * entire row. Call this after any byte-wise truncation of text that may be
+ * non-ASCII. A string that ends on a complete character is left untouched. */
+void text_trim_partial_utf8(char *s);
+
 /* Basic Porter-like stemming. Result written to buf. Returns buf. */
 char *stem_word(const char *word, char *buf, size_t buf_len);
 

--- a/src/kb/kb_curator_extract.c
+++ b/src/kb/kb_curator_extract.c
@@ -174,9 +174,17 @@ static int ce_fetch_document(ce_job_t *job)
       const char *fp = aimee_pg_column_text(st, 0);
       const char *hp = aimee_pg_column_text(st, 1);
       const char *ct = aimee_pg_column_text(st, 2);
+      /* These cuts are byte-wise, so a doc chunk longer than the buffer has its
+       * final multi-byte character split. The partial bytes flow into the request
+       * JSON and then the artifact payload, where postgres rejects the INSERT
+       * with "invalid byte sequence for encoding UTF8" — the job dies for one
+       * stray em-dash at the cut point. Trim back to a character boundary. */
       snprintf(job->file_path, sizeof(job->file_path), "%s", fp ? fp : "");
+      text_trim_partial_utf8(job->file_path);
       snprintf(job->heading_path, sizeof(job->heading_path), "%s", hp ? hp : "");
+      text_trim_partial_utf8(job->heading_path);
       snprintf(job->content, sizeof(job->content), "%s", ct ? ct : "");
+      text_trim_partial_utf8(job->content);
       found = 1;
    }
    aimee_pg_finalize(st);

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -476,6 +476,9 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
    if (rc != 0)
    {
       kb_curator_describe_wait_status(rc, CCU_SIDECAR_TIMEOUT_S, errbuf, errlen);
+      /* Before discarding the output: the sidecar may have explained itself in
+       * it. Keep the reason, not just the exit code. */
+      kb_curator_append_sidecar_error(out, errbuf, errlen);
       free(out);
       return NULL;
    }
@@ -598,6 +601,15 @@ static int ccu_write_artifacts(const ccu_job_t *job, cJSON *artifacts_arr)
 
       if (wrc != 0)
       {
+         /* db2_artifact_write swallows the backend's message, so the only record
+          * of WHY was postgres' own log — which is how ~5,300 jobs died as a bare
+          * "artifact write failed" while the server had been saying "invalid byte
+          * sequence for encoding UTF8" all along. Name the artifact so the next
+          * one is findable without cross-referencing container logs by timestamp. */
+         aimee_log(LOG_WARN, "kb.curator.extract_code",
+                   "artifact write rejected for symbol '%s' (job %lld, kind=%s); see the db2 log "
+                   "for the backend reason",
+                   job->symbol, (long long)job->job_id, kind_j->valuestring);
          aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
          return -1;
       }
@@ -681,7 +693,13 @@ int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts)
    cJSON_AddNumberToObject(inp, "line", job.line);
    cJSON_AddStringToObject(inp, "body", body);
    /* Stash a bounded signature (first non-blank line) + body excerpt for the
-    * code_unit artifact payload before the body buffer is released. */
+    * code_unit artifact payload before the body buffer is released.
+    *
+    * Both cuts are byte-wise, so both can split a multi-byte character — source
+    * comments in this tree are full of em-dashes. The partial bytes end up in the
+    * artifact payload's JSON, and postgres then rejects the entire INSERT with
+    * "invalid byte sequence for encoding UTF8", failing the job. Trim back to a
+    * character boundary. */
    {
       const char *p = body;
       while (*p == '\n' || *p == '\r' || *p == ' ' || *p == '\t')
@@ -691,7 +709,9 @@ int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts)
          siglen++;
       memcpy(job.signature, p, siglen);
       job.signature[siglen] = '\0';
+      text_trim_partial_utf8(job.signature);
       snprintf(job.body_excerpt, sizeof(job.body_excerpt), "%s", body);
+      text_trim_partial_utf8(job.body_excerpt);
    }
    free(body);
    cJSON *conf = cJSON_AddObjectToObject(req, "config");

--- a/src/kb/kb_curator_sidecar.c
+++ b/src/kb/kb_curator_sidecar.c
@@ -5,6 +5,7 @@
 #endif
 
 #include "kb_curator_sidecar.h"
+#include "cJSON.h" /* the sidecar's own error payload is JSON */
 
 #include <errno.h>
 #include <stdio.h>
@@ -116,6 +117,33 @@ void kb_curator_describe_wait_status(int status, int timeout_s, char *errbuf, si
       return;
    }
    snprintf(errbuf, errlen, "sidecar ended abnormally (wait status %d)", status);
+}
+
+/* Append the sidecar's own error to errbuf. See the header for why.
+ *
+ * Parses rather than string-matches: the payload is JSON the sidecar wrote, and
+ * cJSON is already linked everywhere this file is. Anything that is not a
+ * well-formed {"status":"error","error":<string>} is left alone — a non-zero exit
+ * with garbage on stdout should keep the wait-status description, not inherit a
+ * misleading fragment of it. */
+void kb_curator_append_sidecar_error(const char *out, char *errbuf, size_t errlen)
+{
+   if (!out || !out[0] || !errbuf || errlen == 0)
+      return;
+
+   cJSON *root = cJSON_Parse(out);
+   if (!root)
+      return;
+   const cJSON *status = cJSON_GetObjectItemCaseSensitive(root, "status");
+   const cJSON *why = cJSON_GetObjectItemCaseSensitive(root, "error");
+   if (cJSON_IsString(status) && strcmp(status->valuestring, "error") == 0 && cJSON_IsString(why) &&
+       why->valuestring[0])
+   {
+      size_t used = strlen(errbuf);
+      if (used + 2 < errlen)
+         snprintf(errbuf + used, errlen - used, ": %s", why->valuestring);
+   }
+   cJSON_Delete(root);
 }
 
 char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_cap, char *errbuf,
@@ -242,6 +270,9 @@ char *kb_curator_sidecar_run(const char *cmd, const char *json_input, int out_ca
    if (rc != 0)
    {
       kb_curator_describe_wait_status(rc, CS_SIDECAR_TIMEOUT_S, errbuf, errlen);
+      /* Before discarding the output: the sidecar may have explained itself in
+       * it. Keep the reason, not just the exit code. */
+      kb_curator_append_sidecar_error(out, errbuf, errlen);
       free(out);
       return NULL;
    }

--- a/src/kb/kb_curator_sidecar.h
+++ b/src/kb/kb_curator_sidecar.h
@@ -40,4 +40,15 @@ int kb_curator_shell_quote(const char *in, char *out, size_t outlen);
  * callers that do not wrap pass 0. */
 void kb_curator_describe_wait_status(int status, int timeout_s, char *errbuf, size_t errlen);
 
+/* Append the sidecar's OWN error to errbuf, if it wrote one before exiting.
+ *
+ * curator-extract.py's emit_error() prints {"status":"error","error":<why>} to
+ * stdout and exits 1 — so the reason ("LLM returned non-JSON: …", "unknown
+ * role", the provider's error) is sitting in the captured output at the exact
+ * moment the caller is about to throw it away and report a bare "sidecar exited
+ * 1". Call this after kb_curator_describe_wait_status to keep the reason. A
+ * no-op when the output is absent or is not a structured error. Exposed for
+ * testing. */
+void kb_curator_append_sidecar_error(const char *out, char *errbuf, size_t errlen);
+
 #endif /* KB_CURATOR_SIDECAR_H */

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -592,6 +592,51 @@ static void test_sidecar_quoting_end_to_end(void)
    printf("  PASS: test_sidecar_quoting_end_to_end\n");
 }
 
+/* kb_curator_append_sidecar_error: curator-extract.py's emit_error() prints
+ * {"status":"error","error":<why>} to stdout and exits 1. That output was being
+ * freed unread, so a job that failed for a knowable reason recorded only
+ * "sidecar exited 1". */
+static void test_append_sidecar_error(void)
+{
+   char err[256];
+
+   /* (a) the real shape: the sidecar's reason is appended to the exit code. */
+   snprintf(err, sizeof(err), "%s", "sidecar exited 1");
+   kb_curator_append_sidecar_error(
+       "{\"version\":1,\"status\":\"error\",\"error\":\"LLM returned non-JSON: boom\"}", err,
+       sizeof(err));
+   assert(strcmp(err, "sidecar exited 1: LLM returned non-JSON: boom") == 0);
+
+   /* (b) a SUCCESSFUL payload is not an error — must not be appended. */
+   snprintf(err, sizeof(err), "%s", "sidecar exited 1");
+   kb_curator_append_sidecar_error("{\"status\":\"ok\",\"artifacts\":[]}", err, sizeof(err));
+   assert(strcmp(err, "sidecar exited 1") == 0);
+
+   /* (c) non-JSON / empty / NULL output leaves the wait-status description
+    *     intact rather than inheriting a misleading fragment. */
+   snprintf(err, sizeof(err), "%s", "sidecar exited 1");
+   kb_curator_append_sidecar_error("Traceback (most recent call last):", err, sizeof(err));
+   assert(strcmp(err, "sidecar exited 1") == 0);
+   kb_curator_append_sidecar_error("", err, sizeof(err));
+   assert(strcmp(err, "sidecar exited 1") == 0);
+   kb_curator_append_sidecar_error(NULL, err, sizeof(err));
+   assert(strcmp(err, "sidecar exited 1") == 0);
+
+   /* (d) an error field that is not a string is ignored, not printed as junk. */
+   snprintf(err, sizeof(err), "%s", "sidecar exited 1");
+   kb_curator_append_sidecar_error("{\"status\":\"error\",\"error\":42}", err, sizeof(err));
+   assert(strcmp(err, "sidecar exited 1") == 0);
+
+   /* (e) a full errbuf must not overflow. */
+   char tiny[20];
+   snprintf(tiny, sizeof(tiny), "%s", "sidecar exited 1");
+   kb_curator_append_sidecar_error("{\"status\":\"error\",\"error\":\"a very long reason here\"}",
+                                   tiny, sizeof(tiny));
+   assert(strlen(tiny) < sizeof(tiny));
+
+   printf("  PASS: test_append_sidecar_error\n");
+}
+
 static void test_pick_sidecar_command_resolution(void)
 {
    char out[768];
@@ -652,6 +697,7 @@ int main(void)
    test_describe_wait_status();
    test_shell_quote();
    test_sidecar_quoting_end_to_end();
+   test_append_sidecar_error();
 
    printf("ok\n");
    return 0;

--- a/src/tests/test_util.c
+++ b/src/tests/test_util.c
@@ -6,6 +6,57 @@
 #include <string.h>
 #include "aimee.h"
 
+/* text_trim_partial_utf8: undo a byte-wise truncation that split a character.
+ *
+ * The production failure this guards: a code body was copied into a 1536-byte
+ * buffer, the cut landed inside an em-dash (e2 80 94), and the leftover 0xe2 went
+ * into the artifact JSON — postgres rejected the whole INSERT with "invalid byte
+ * sequence for encoding UTF8: 0xe2 0x22 0x7d" (the partial byte, then the closing
+ * quote and brace). ~5,300 jobs died that way, reported only as "artifact write
+ * failed". */
+static void test_trim_partial_utf8(void)
+{
+   char buf[32];
+
+   /* (a) the exact production shape: text ending in a chopped em-dash. */
+   snprintf(buf, sizeof(buf), "%s", "here \xe2\x80\x94");
+   buf[6] = '\0'; /* cut mid-character: keeps "here " + 0xe2 */
+   assert((unsigned char)buf[5] == 0xe2);
+   text_trim_partial_utf8(buf);
+   assert(strcmp(buf, "here ") == 0); /* partial char dropped */
+
+   /* (b) a COMPLETE multi-byte character must survive untouched. */
+   snprintf(buf, sizeof(buf), "%s", "here \xe2\x80\x94");
+   text_trim_partial_utf8(buf);
+   assert(strcmp(buf, "here \xe2\x80\x94") == 0);
+
+   /* (c) 2-byte lead (0xc2, e.g. non-breaking space) cut short. */
+   snprintf(buf, sizeof(buf), "%s", "x\xc2");
+   text_trim_partial_utf8(buf);
+   assert(strcmp(buf, "x") == 0);
+
+   /* (d) 4-byte lead (emoji) with only 3 bytes present. */
+   snprintf(buf, sizeof(buf), "%s", "hi\xf0\x9f\x98");
+   text_trim_partial_utf8(buf);
+   assert(strcmp(buf, "hi") == 0);
+
+   /* (e) complete 4-byte emoji survives. */
+   snprintf(buf, sizeof(buf), "%s", "hi\xf0\x9f\x98\x80");
+   text_trim_partial_utf8(buf);
+   assert(strcmp(buf, "hi\xf0\x9f\x98\x80") == 0);
+
+   /* (f) plain ASCII and empty input are no-ops; NULL must not crash. */
+   snprintf(buf, sizeof(buf), "%s", "plain ascii");
+   text_trim_partial_utf8(buf);
+   assert(strcmp(buf, "plain ascii") == 0);
+   buf[0] = '\0';
+   text_trim_partial_utf8(buf);
+   assert(buf[0] == '\0');
+   text_trim_partial_utf8(NULL);
+
+   printf("  PASS: test_trim_partial_utf8\n");
+}
+
 static void test_normalize_key(void)
 {
    char buf[256];
@@ -280,6 +331,7 @@ int main(void)
    test_trigram_similarity();
    test_stem_word();
    test_is_likely_path();
+   test_trim_partial_utf8();
    test_shlex_split();
    test_split_camel_case();
    test_is_contradiction();

--- a/src/text.c
+++ b/src/text.c
@@ -67,6 +67,41 @@ static int trigram_in_set(const char *tri, trigram_t *set, int count)
    return 0;
 }
 
+/* Drop a trailing partial UTF-8 character. See util.h for why this matters.
+ *
+ * Walk back from the end over continuation bytes (10xxxxxx) to the character's
+ * lead byte, then compare the bytes actually present against the length the lead
+ * byte declares. Short => the character was cut by a byte-wise truncation, so
+ * terminate at the lead byte and drop it. A well-formed tail is left alone. */
+void text_trim_partial_utf8(char *s)
+{
+   if (!s || !s[0])
+      return;
+
+   size_t len = strlen(s);
+   /* A UTF-8 character is at most 4 bytes, so the lead byte of the final
+    * character is within 4 bytes of the end; anything further back is already a
+    * complete character. */
+   for (size_t back = 1; back <= 4 && back <= len; back++)
+   {
+      size_t i = len - back;
+      unsigned char c = (unsigned char)s[i];
+      if ((c & 0xC0) == 0x80)
+         continue; /* continuation byte — keep walking back to the lead */
+
+      size_t need = (c & 0x80) == 0x00   ? 1  /* 0xxxxxxx: ASCII */
+                    : (c & 0xE0) == 0xC0 ? 2  /* 110xxxxx */
+                    : (c & 0xF0) == 0xE0 ? 3  /* 1110xxxx */
+                    : (c & 0xF8) == 0xF0 ? 4  /* 11110xxx */
+                                         : 0; /* 10xxxxxx handled above; else invalid */
+      if (need == 0 || back < need)
+         s[i] = '\0'; /* invalid lead, or too few bytes present: drop the char */
+      return;         /* the last character is complete — nothing to do */
+   }
+   /* Four continuation bytes with no lead: not UTF-8 at all. Leave it; this
+    * function's contract is to undo truncation, not to sanitise arbitrary bytes. */
+}
+
 double trigram_similarity(const char *a, const char *b)
 {
    if (!a || !b || !a[0] || !b[0])


### PR DESCRIPTION
Follow-up to #1355. After requeuing the 5,449 dead jobs, 6 failed again — investigating them found a real, reproducible bug that accounts for nearly all of the historical `artifact write failed`.

## The bug: byte-wise truncation splits multi-byte UTF-8

`ccu` stashes `signature` (256B, `memcpy`) and `body_excerpt` (1536B, `snprintf`) for the artifact payload; the doc stage does the same for `content` (64KB), `heading_path`, `file_path`. All cut at a **byte** offset, so a character straddling the limit is left half-written. The partial bytes reach the artifact JSON, and postgres rejects the entire INSERT — which the kb container had been logging all along:

```
ERROR: invalid byte sequence for encoding "UTF8": 0xe2 0x22 0x7d
ERROR: invalid byte sequence for encoding "UTF8": 0xc2 0x22
```

`0xe2` is the first byte of an em-dash (`e2 80 94`); `0x22 0x7d` is the closing quote and brace cJSON wrote after it. **This tree's comments are full of em-dashes**, which is why it hit so many files.

Reproduced exactly on a failing symbol (`is_skip_dir`, `src/workspace.c:22`):

```
before trim: last byte=e2 len=1535   -> invalid (chopped em-dash)
after  trim: last byte=20 len=1534   -> valid UTF-8
```

`text_trim_partial_utf8()` (in `util.h`/`text.c` — generic, and `text.o` is already linked by ~25 binaries) walks back over continuation bytes to the lead byte and drops the character **only** if fewer bytes are present than the lead declares. A complete tail is untouched.

**Impact:** ~5,300 jobs' worth of `artifact write failed` — 5 of the 6 current failures, 12 of the 14 failed `extract_doc` jobs, and most of the pre-existing 38.

## The reasons were being thrown away — twice more

This is the same disease #1355 was about, in two more places:

- **The sidecar's own error was freed unread.** `curator-extract.py`'s `emit_error()` prints `{"status":"error","error":<why>}` to stdout and exits 1 — and both invoke paths free that buffer on `rc != 0`, reporting a bare `sidecar exited 1`. So `LLM returned non-JSON: …`, `unknown role`, and the provider's own error were discarded at the exact moment they were needed. Now parsed (cJSON, not string-matching) and appended; anything that isn't a well-formed structured error is left alone.
- **`ccu_write_artifacts` discarded the backend's message.** `db2_artifact_write` swallows it, so the only record of *why* was postgres' log. That is precisely how 5,300 jobs died as `artifact write failed` while the server was printing the encoding error. Now logs symbol/job/kind so the next one is findable without correlating container logs by timestamp.

## Testing

- `test_trim_partial_utf8` — pins the production shape (chopped em-dash) plus 2/3/4-byte leads, complete characters, ASCII, empty, NULL. **Verified failing without the fix.**
- `test_append_sidecar_error` — the real payload, a success payload, non-JSON, a non-string `error` field, and buffer overflow.
- Local: `unit-test-util`, `curator-code-unit`, `curator-queue`, `kb-curator-llm`, `typed-facts`, `db2`, `db`, `rules`, `memory-provider`, `code-index-ops` all pass; clang-format-19 clean; `line-check` ok.

## Note

The `mkstemp` failures that motivated #1355 have **not recurred** since that deploy (0 across ~600 jobs, against a prior ~22% rate) — the container restart cleared them, so the cause is something that accumulates over uptime. Still unknown, but it will now carry an errno when it returns.