### PR TITLE
fix: "has aimee got git" is a server fact, not a cwd fact

### DIFF
--- a/src/headers/git_cred_inject.h
+++ b/src/headers/git_cred_inject.h
@@ -73,17 +73,23 @@ int git_cred_inject_resolve_token(const char *principal, const char *remote_url,
                                   const char *repo_dir, const char *preferred_token, char *out,
                                   size_t cap);
 
-/* 1 if aimee-server can itself authenticate to the forge for `repo_dir` (NULL =
- * "any forge identity at all"), under the same precedence as the resolvers above.
- * Resolves and immediately wipes; never returns the token.
+/* 1 if aimee-server has git configured AT ALL: a per-host vault entry (any host),
+ * or its own forge identity. Resolves nothing and returns no token — the per-host
+ * store is asked only for host NAMES.
  *
  * This is the predicate the require_aimee_git restriction hangs off (operator
- * ruling 2026-07-15). That rule says "do not shell out to git/gh — use aimee's
- * git_* tools, which run on aimee-server". If aimee-server holds no credential,
- * aimee's tools cannot do git either, so blocking the shell would remove the only
- * working route rather than redirect it, and strip credentials a delegate needs
- * with nothing to offer in their place. No aimee route -> no restriction. */
-int git_cred_forge_configured(const char *repo_dir);
+ * ruling 2026-07-15): "the restriction applies only if aimee-server has a
+ * configured git". That is a property of the SERVER, not of a checkout, and asking
+ * it per-repo made the rule fire or stand down depending on the ambient cwd of the
+ * calling thread — the same command allowed from one directory and refused from
+ * another (observed live on .254: DENY in a wfe worktree, allow from the daemon's
+ * cwd twelve seconds later).
+ *
+ * The rule it gates: "do not shell out to git/gh — use aimee's git_* tools, which
+ * run on aimee-server". With no credential anywhere, aimee's tools cannot do git
+ * either, so blocking the shell would remove the only route rather than redirect
+ * it. No aimee route -> no restriction. */
+int git_cred_forge_configured(void);
 
 /* Free an envp from git_cred_inject_build_env (zeroes the GH_TOKEN entry first). */
 void git_cred_inject_free_env(char **envp);

--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -3,6 +3,7 @@
 #include "git_cred_inject.h"
 #include "forge_credentials.h" /* forge_cred_askpass_shim / forge_cred_server_identity */
 #include "git_forge_vault.h"   /* git_forge_vault_token */
+#include "git_host_cred.h"     /* git_host_cred_list — "is git configured at all?" */
 #include "git_host_resolve.h"  /* git_host_resolve_token (per-host vault seam) */
 #include "git_ssh_agent.h"     /* git_ssh_agent_ensure */
 
@@ -198,10 +199,18 @@ int git_cred_inject_resolve_token(const char *principal, const char *remote_url,
    return resolve_token(principal, remote_url, repo_dir, preferred_token, out, cap);
 }
 
-int git_cred_forge_configured(const char *repo_dir)
+int git_cred_forge_configured(void)
 {
+   /* Any per-host vault entry means git is configured, whatever repo is in play.
+    * Host NAMES only — git_host_cred_list never returns tokens, so this asks the
+    * question without materialising a secret. */
+   char hosts[1][GIT_HOST_MAX];
+   if (git_host_cred_list(hosts, 1) > 0)
+      return 1;
+
+   /* Else the server's own identity (a forge App installation / AIMEE_FORGE_TOKEN). */
    char token[GIT_CRED_TOKEN_MAX] = {0};
-   int have = (resolve_token(NULL, NULL, repo_dir, NULL, token, sizeof(token)) == 1 && token[0]);
+   int have = (forge_cred_server_identity(token, sizeof(token), NULL, 0) == 1 && token[0]);
    volatile char *p = (volatile char *)token; /* never let the token outlive the check */
    for (size_t i = 0; i < sizeof(token); i++)
       p[i] = 0;

--- a/src/server/provider_cli_adapter.c
+++ b/src/server/provider_cli_adapter.c
@@ -433,7 +433,7 @@ int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], i
     * No aimee route, no restriction. */
    config_t spawn_cfg;
    int strip_forge_creds = ((config_load(&spawn_cfg) != 0) || spawn_cfg.require_aimee_git) &&
-                           git_cred_forge_configured(NULL);
+                           git_cred_forge_configured();
 
    /* Resolve the delegate's aimee endpoint before forking (aimee_home may read/
     * allocate). See delegate_child_export_aimee_endpoint. */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1913,23 +1913,21 @@ static int server_shell_git_blocked(const char *command, const char *cwd)
       aimee_log(LOG_DEBUG, "shell-git-gate", "allow: require_aimee_git is off (operator opt-out)");
       return 0;
    }
-   /* Ask per REPO, not in the abstract. The credential ladder resolves a per-host
-    * vault token from the checkout's origin, so `cwd` is what makes "can aimee do
-    * git here?" answerable. Passing NULL leaves only the server's own identity rung
-    * (AIMEE_FORGE_TOKEN / a forge App), which most deployments never set — the gate
-    * would then read "aimee has no git" and never fire, on precisely the boxes whose
-    * forge works fine through a vaulted per-host token. Found on .254: the forge had
-    * opened a real PR minutes earlier while this check returned 0. */
-   if (!git_cred_forge_configured(cwd))
+   /* "Has aimee-server got git configured?" is a property of the SERVER, not of the
+    * directory this thread happens to sit in. Asking it per-repo made the SAME
+    * command allowed from one cwd and refused from another — observed live on .254:
+    * DENY inside a wfe worktree, then allow from the daemon's cwd twelve seconds
+    * later, because the per-host rung only resolves where a checkout has an origin. */
+   if (!git_cred_forge_configured())
    {
-      /* The silently-inert case, and the one that hid the NULL-repo bug: the agent
-       * reached for git, the rule is ON, and we allowed it anyway because aimee has
-       * no credential to offer instead. That is deliberate — no aimee route, no
-       * restriction — but it must never be invisible, or a gate that has quietly
-       * stopped working looks exactly like a gate nobody is testing. */
+      /* The agent reached for git, the rule is ON, and we allowed it anyway because
+       * aimee-server has no credential to offer instead. Deliberate — no aimee route,
+       * no restriction — but never silent: a gate that has quietly stopped working
+       * looks exactly like a gate nobody is testing, which is how two guards shipped
+       * inert today. Server-level now, so it is the same answer every time. */
       aimee_log(LOG_INFO, "shell-git-gate",
-                "allow: agent ran git in '%s' but aimee-server has no forge credential for it "
-                "— nothing to redirect to (no aimee route, no restriction)",
+                "allow: agent ran git in '%s' but aimee-server has NO forge credential "
+                "configured — nothing to redirect to (no aimee route, no restriction)",
                 (cwd && cwd[0]) ? cwd : "(no cwd)");
       return 0;
    }
@@ -1939,8 +1937,8 @@ static int server_shell_git_blocked(const char *command, const char *cwd)
 
 /* Boot-time posture, mirroring primary_cli_ingestor_log_posture: make "the rule is
  * on but nothing enforces it" visible at startup instead of leaving it to be
- * discovered on a box months later. The credential half is per-repo and cannot be
- * resolved here, so it is reported per-decision above rather than claimed now. */
+ * discovered on a box months later. Every condition is now a server-level fact, so
+ * this states the real answer rather than a hopeful one. */
 static void server_shell_git_gate_log_posture(void)
 {
    config_t cfg;
@@ -1958,9 +1956,16 @@ static void server_shell_git_gate_log_posture(void)
                 "rule would forbid the shell with nothing to redirect to, so it will not fire");
       return;
    }
+   if (!git_cred_forge_configured())
+   {
+      aimee_log(LOG_WARN, "shell-git-gate",
+                "INERT: require_aimee_git is on but aimee-server has NO forge credential "
+                "configured — aimee's own git cannot work either, so the shell is not refused "
+                "(no aimee route, no restriction)");
+      return;
+   }
    aimee_log(LOG_INFO, "shell-git-gate",
-             "ARMED: git/gh in a delegate shell is refused wherever aimee-server holds a forge "
-             "credential for the checkout (per-repo; logged per decision)");
+             "ARMED: git/gh in a delegate shell is refused; delegates use the git_* tools");
 }
 
 int server_init(server_ctx_t *ctx, const char *socket_path)

--- a/src/tests/support/git_cred_inject_stub.c
+++ b/src/tests/support/git_cred_inject_stub.c
@@ -36,13 +36,12 @@ void git_cred_inject_free_env(char **envp)
    (void)envp;
 }
 
-/* "aimee-server holds no forge credential", consistent with the NULL env above.
- * For provider_cli_adapter's spawn that means the delegate credential strip does
- * NOT apply — no aimee git route, no restriction — which is the honest answer for a
- * test binary that has no vault, and keeps these tests exercising the spawn rather
- * than a credential policy they never configured. */
-int git_cred_forge_configured(const char *repo_dir)
+/* "aimee-server has no forge credential configured", consistent with the NULL env
+ * above. For provider_cli_adapter's spawn that means the delegate credential strip
+ * does NOT apply — no aimee git route, no restriction — which is the honest answer
+ * for a test binary that has no vault, and keeps these tests exercising the spawn
+ * rather than a credential policy they never configured. */
+int git_cred_forge_configured(void)
 {
-   (void)repo_dir;
    return 0;
 }


### PR DESCRIPTION
Found by running the gate on .254. Twelve seconds apart, same rule, same server, opposite answers:

```
12:30:05 AUDIT shell-git-gate: DENY  cwd=…/wfe-worktrees/…s0
                                     cmd=git status && git log --oneline -20
12:30:17 INFO  shell-git-gate: allow: agent ran git in "/var/lib/aimee" but
                                     aimee-server has no forge credential for it
```

## What went wrong

#1354 asked the credential question **per repo**. The per-host vault rung only resolves where a checkout has an origin, so from the daemon's cwd it resolves nothing, concludes "aimee has no git", and stands down. `cd <repo> && git …` from there is allowed.

That was over-correcting. The operator ruling is *"the restriction applies only if aimee-server has a configured git"* — a property of the **server**. Asking it per-repo made a server-level policy depend on which directory a thread happened to sit in.

## The fix

`git_cred_forge_configured()` takes no repo and answers the real question: **any** per-host vault entry (`git_host_cred_list` — host *names* only, no token is ever materialised), else the server's own forge identity. One answer, every call site, every cwd.

The boot posture gets sharper for free — it can now state INERT vs ARMED including the credential half, instead of hedging that it is per-repo and unknowable until a decision happens.

## What this hole was, and was not

I overstated it when I found it, so precisely:

| | delegate's bash | |
|---|---|---|
| `git status`, `ls-remote` | **works** | the repo is public; reads need no auth |
| `git push` | **fails** | no `GH_TOKEN`, no credential.helper, no `~/.git-credentials`, no `gh` auth |

So `cd <repo> && git push` was allowed by the gate and **would still have failed to authenticate**. The credential boundary was never breached — the token lives in aimee-server's vault, reachable only via `git_cred_inject`'s injected env or the in-process REST.

What leaked was **consistency**: the agent got a helpful redirect from one directory and a confusing git auth error from another. Worth fixing, but it is a UX/correctness bug, not a security one.

## Verification

All five tests linking the real `git_cred_inject.o` already link `git_host_cred.o`, so the new `git_host_cred_list` call resolves — checked before pushing, since this exact link-shape has broken CI three times today. No target links both the real object and `git_route_stub.o`.