### PR TITLE
fix: coding roles could not actually resolve git_commit

### DIFF
--- a/src/tests/test_toolset.c
+++ b/src/tests/test_toolset.c
@@ -48,6 +48,50 @@ static void test_full_stack_resolves_union(void)
    printf("  code_roles_resolve_edit_file: ok\n");
 }
 
+/* A coding delegate must resolve the git WRITE tools, and a reviewer must not.
+ *
+ * Registering a tool is not the same as a role being able to call it:
+ * agent_tools_filter_for_role drops anything the role's toolset does not name. A
+ * live delegate reported "there is no git_commit tool in my available toolset"
+ * while the builtin registry carried it and the server had it wired — the tools
+ * were being filtered straight back out here. require_aimee_git tells delegates to
+ * use these instead of a shell, so if this resolution regresses, the rule starts
+ * pointing at tools the delegate cannot see. */
+static void test_git_write_tools_reach_coding_roles_only(void)
+{
+   toolset_registry_t reg;
+   toolset_registry_init(&reg);
+   char tools[TOOLSET_MAX_TOOLS][TOOLSET_TOOL_MAX];
+   char err[TOOLSET_ERROR_MAX] = "";
+
+   /* code (and full_stack, which the code/refactor/execute roles actually map to) */
+   const char *coding[] = {"code", "full_stack"};
+   for (size_t i = 0; i < sizeof(coding) / sizeof(coding[0]); i++)
+   {
+      int n = toolset_resolve(&reg, coding[i], tools, TOOLSET_MAX_TOOLS, err, sizeof(err));
+      assert(n > 0);
+      assert(has_tool(tools, n, "git_commit"));
+      assert(has_tool(tools, n, "git_push"));
+      assert(has_tool(tools, n, "git_branch"));
+      assert(has_tool(tools, n, "git_pr"));
+      assert(has_tool(tools, n, "git_status")); /* the read-only set still comes too */
+   }
+
+   /* A reviewer reads; it does not commit. `git` (read-only) is inherited by
+    * readonly -> review, so the write set had to be a SEPARATE toolset or every
+    * reviewer would have silently gained push. */
+   const char *readers[] = {"review", "review_indexed", "readonly"};
+   for (size_t i = 0; i < sizeof(readers) / sizeof(readers[0]); i++)
+   {
+      int n = toolset_resolve(&reg, readers[i], tools, TOOLSET_MAX_TOOLS, err, sizeof(err));
+      assert(n > 0);
+      assert(!has_tool(tools, n, "git_commit"));
+      assert(!has_tool(tools, n, "git_push"));
+      assert(!has_tool(tools, n, "git_pr"));
+   }
+   printf("  git_write_tools_reach_coding_roles_only: ok\n");
+}
+
 /* review_indexed gives a reviewer aimee's branch-indexed capabilities and NO
  * filesystem/git tools, so a caller-provided-diff review cannot fall back to
  * reading a worktree it does not have. */
@@ -213,6 +257,7 @@ int main(void)
 {
    printf("test_toolset:\n");
    test_full_stack_resolves_union();
+   test_git_write_tools_reach_coding_roles_only();
    test_review_indexed_excludes_filesystem();
    test_cycle_rejected();
    test_unknown_tool_dropped();

--- a/src/toolset.c
+++ b/src/toolset.c
@@ -69,6 +69,16 @@ static const char *const KNOWN_TOOLS[] = {
     "grep",
     "git_diff",
     "git_status",
+    /* Git writes. This list is a NAME ALLOWLIST, checked independently of the
+     * builtin tool registry — a toolset naming a tool that is not here is pruned
+     * with a warning, which is exactly how git_write silently lost all four and a
+     * live delegate reported "there is no git_commit tool in my available toolset".
+     * Adding a tool means agreeing in three places: the builtin registry, a
+     * toolset, and here. */
+    "git_commit",
+    "git_push",
+    "git_branch",
+    "git_pr",
     "env_get",
     "test",
     "request_input",

--- a/src/toolset.c
+++ b/src/toolset.c
@@ -21,6 +21,15 @@ static const builtin_toolset_t BUILTINS[] = {
      {NULL},
      {"read_file", "list_files", "grep", "code_search", "find_symbol", "search_memory", NULL}},
     {"git", {NULL}, {"git_status", "git_log", "git_diff", NULL}},
+    /* Git WRITES, deliberately split from the read-only `git` set above: `git` is
+     * inherited by `readonly` (and thence review), which must never gain the power
+     * to commit or push. Only `code` pulls this in.
+     *
+     * Without it a delegate has no way to land work but `bash git` — the very thing
+     * require_aimee_git forbids. Adding the tools to the builtin registry is not
+     * enough on its own: agent_tools_filter_for_role strips anything the role's
+     * toolset does not name, so the rule would point at tools the filter hides. */
+    {"git_write", {NULL}, {"git_commit", "git_push", "git_branch", "git_pr", NULL}},
     {"web", {NULL}, {"web_search", NULL}},
     {"readonly", {"core", "git", NULL}, {"verify", "env_get", "test", NULL}},
     {"validate", {"readonly", NULL}, {"bash", "execute_script", NULL}},
@@ -29,7 +38,7 @@ static const builtin_toolset_t BUILTINS[] = {
      {"bash", "execute_script", "read_file", "write_file", "edit_file", "list_files", "verify",
       "grep", "env_get", "test", NULL}},
     {"code",
-     {"core", "git", "web", NULL},
+     {"core", "git", "git_write", "web", NULL},
      {"bash", "execute_script", "write_file", "edit_file", "verify", "env_get", "test",
       "run_background_process", "get_background_output", "kill_background_process",
       "list_background_processes", NULL}},


### PR DESCRIPTION
Found by asking a live delegate on .254 to commit via `git_commit`. It replied:

> **There is no `git_commit` tool in my available toolset.** The git-related tools I have are: `git_log`, `git_status`, `git_diff`.

## Why

The tools are in the builtin registry (#1352) and the server wires the provider — the boot posture says `ARMED`, which requires it. But `agent_tools_filter_for_role` drops anything the **role's toolset** does not name, and the only git toolset was read-only:

```c
{"git",  {NULL}, {"git_status", "git_log", "git_diff", NULL}},
{"code", {"core", "git", "web", NULL}, {"bash", "write_file", ...}},
```

So `require_aimee_git` was redirecting delegates to tools the filter hid. Same failure as the rest of this line of work — a rule pointing at nothing — one layer further down. Registering a tool and a role being able to **call** it are different things, and only the second is what a delegate experiences.

## The fix

A `git_write` toolset (`git_commit`/`git_push`/`git_branch`/`git_pr`), included from `code` — which is what the `code`/`refactor`/`execute` roles actually reach via `full_stack`.

**Kept separate from the read-only `git` set deliberately:** `git` is inherited by `readonly`, and thence by `review`. Folding the writes in there would have silently handed every reviewer the power to commit and push the code it is judging — and #1352 just gave reviewers tools.

## Tests

Pin both directions: `code`/`full_stack` resolve all four; `review`/`review_indexed`/`readonly` resolve none.