### PR TITLE
fix: the git tool schemas described tools that do not exist

### DIFF
--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -558,6 +558,20 @@ static void tp_prop(cJSON *props, const char *name, const char *type, const char
    cJSON_AddItemToObject(props, name, p);
 }
 
+/* An array-of-strings property. Separate from tp_prop because a bare
+ * {"type":"array"} is incomplete JSON Schema — `items` is what tells a provider
+ * what the array holds, and strict ones reject the schema without it. */
+static void tp_prop_str_array(cJSON *props, const char *name, const char *desc)
+{
+   cJSON *p = cJSON_CreateObject();
+   cJSON_AddStringToObject(p, "type", "array");
+   cJSON_AddStringToObject(p, "description", desc);
+   cJSON *items = cJSON_CreateObject();
+   cJSON_AddStringToObject(items, "type", "string");
+   cJSON_AddItemToObject(p, "items", items);
+   cJSON_AddItemToObject(props, name, p);
+}
+
 static cJSON *tp_bash(void)
 {
    cJSON *params = tp_obj();
@@ -735,9 +749,12 @@ static cJSON *tp_git_commit(void)
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
    tp_prop(props, "message", "string", "Commit message");
-   tp_prop(props, "path", "string",
-           "Path to the git repository (defaults to the session worktree)");
-   tp_prop(props, "add_all", "boolean", "Stage all modified/untracked files first (default false)");
+   /* `files` is how anything gets STAGED — including a file you just created.
+    * There is deliberately no add-everything flag: sensitive paths are screened
+    * per file. Omit it and only already-staged changes are committed. */
+   tp_prop_str_array(props, "files",
+                     "Paths to stage before committing (git add -- <files>). REQUIRED for a new "
+                     "or unstaged file; without it only already-staged changes are committed.");
    cJSON_AddItemToObject(params, "properties", props);
    cJSON *req = cJSON_CreateArray();
    cJSON_AddItemToArray(req, cJSON_CreateString("message"));
@@ -749,9 +766,10 @@ static cJSON *tp_git_push(void)
 {
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
-   tp_prop(props, "path", "string",
-           "Path to the git repository (defaults to the session worktree)");
-   tp_prop(props, "set_upstream", "boolean", "Push with -u to set upstream (default false)");
+   /* No path/upstream args: the handler pushes the current branch of the session
+    * worktree and sets upstream itself. */
+   tp_prop(props, "force", "boolean", "Force-push with lease (default false)");
+   tp_prop(props, "mirror", "boolean", "Push to the configured mirror remote (default false)");
    cJSON_AddItemToObject(params, "properties", props);
    cJSON_AddItemToObject(params, "required", cJSON_CreateArray());
    return params;
@@ -761,10 +779,11 @@ static cJSON *tp_git_branch(void)
 {
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
-   tp_prop(props, "action", "string", "list | create | claim | current");
-   tp_prop(props, "name", "string", "Branch name (for create/claim)");
-   tp_prop(props, "path", "string",
-           "Path to the git repository (defaults to the session worktree)");
+   tp_prop(props, "action", "string", "list | create | switch | claim | delete | orphan");
+   tp_prop(props, "name", "string", "Branch name (for create/switch/claim/delete)");
+   tp_prop(props, "base", "string", "Base ref for create (defaults to the current HEAD)");
+   tp_prop(props, "remote", "boolean", "Include remote branches when listing");
+   tp_prop(props, "force", "boolean", "Force the operation (e.g. delete an unmerged branch)");
    cJSON_AddItemToObject(params, "properties", props);
    cJSON *req = cJSON_CreateArray();
    cJSON_AddItemToArray(req, cJSON_CreateString("action"));
@@ -777,11 +796,15 @@ static cJSON *tp_git_pr(void)
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
    tp_prop(props, "action", "string",
-           "create | view | list | edit | checks | merge_status | merge");
+           "create | view | list | edit | checks | watch | merge_status | merge");
    tp_prop(props, "number", "integer", "PR number (for view/edit/checks/merge_status/merge)");
    tp_prop(props, "title", "string", "PR title (for create/edit)");
    tp_prop(props, "body", "string", "PR body (for create/edit)");
    tp_prop(props, "base", "string", "Base branch (for create/edit)");
+   tp_prop(props, "merge_method", "string", "merge | squash | rebase (for merge; default merge)");
+   tp_prop(props, "expected_head_sha", "string",
+           "For merge: refuse if the PR head has moved from this SHA (drift safety)");
+   tp_prop(props, "wait", "boolean", "For checks: poll until the checks settle");
    cJSON_AddItemToObject(params, "properties", props);
    cJSON *req = cJSON_CreateArray();
    cJSON_AddItemToArray(req, cJSON_CreateString("action"));


### PR DESCRIPTION
Found by a delegate on .254 that was asked to commit a new file. It reported:

> The `add_all: true` on `git_commit` appears to map to `git commit -a` which only stages modified tracked files, not untracked ones.

It was reasoning carefully about **a parameter I invented**.

## What was wrong

`handle_git_commit` takes **`files`** — an array staged via `git add -- <files>`. There is no `add_all`. So the agent passed what the schema promised, the handler ignored it, and git replied *"nothing added to commit but untracked files present"* — which reads like the agent being incompetent rather than the schema lying to it.

I wrote these schemas from imagination: I looked for an MCP-side schema, did not find one, and guessed instead of reading the handlers.

| tool | I declared | handler takes |
|---|---|---|
| `git_commit` | `message`, `path`, `add_all` | `message`, **`files`** |
| `git_push` | `path`, `set_upstream` | **`force`**, **`mirror`** |
| `git_branch` | list/create/claim/current | + **switch/delete/orphan**, `base`/`remote`/`force` |
| `git_pr` | action/number/title/body/base | + **`merge_method`**, **`expected_head_sha`**, `wait`, `watch` |

All four now mirror `mcp_git_write.c` / `mcp_git_branch.c` / `mcp_git_pr.c`.

`files` gets a proper `items` spec via a new `tp_prop_str_array` — a bare `{"type":"array"}` is incomplete JSON Schema, and the strict providers `tool_schema_sanitizer` exists for would reject it. No native tool had used `array` before, so there was no precedent to copy.

## Why this one matters

`require_aimee_git` now **forbids the shell route**. A delegate that cannot make `git_commit` work has nothing left — the rule points at a tool, and the tool’s manual was fiction. A schema that lies is worse than no schema: the agent cannot tell it is being misled.

Every step of this chain has now been found the same way — by running it on hardware, not by reading it.