### PR TITLE
fix: git tools could not be pointed at the delegate's worktree

### DIFF
--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -751,9 +751,14 @@ static char *td_git_write(cJSON *args, const char *name, const char *dispatch_cw
    cJSON *call = cJSON_Duplicate(args, 1);
    if (!call)
       return safe_strdup("error: out of memory");
-   cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(call, "cwd");
-   if (!jcwd && dispatch_cwd && dispatch_cwd[0])
-      cJSON_AddStringToObject(call, "cwd", dispatch_cwd);
+   /* Fall back to the dispatcher's cwd when the caller named no repo. It must be
+    * `path`, not `cwd`: mcp_chdir_git_root takes args["path"] as its priority-1
+    * candidate and never reads a cwd key, so injecting cwd resolved nothing and the
+    * handler ran wherever the thread happened to be — "fatal: not a git repository"
+    * from a delegate whose worktree was three directories away. */
+   cJSON *jpath = cJSON_GetObjectItemCaseSensitive(call, "path");
+   if (!jpath && dispatch_cwd && dispatch_cwd[0])
+      cJSON_AddStringToObject(call, "path", dispatch_cwd);
 
    cJSON *content = fn(name, call, dispatch_sid);
    cJSON_Delete(call);

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -749,6 +749,9 @@ static cJSON *tp_git_commit(void)
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
    tp_prop(props, "message", "string", "Commit message");
+   tp_prop(props, "path", "string",
+           "Path to the git repository / worktree — the SAME path you pass to git_status. "
+           "Without it the repo is resolved from the session, which may not be your worktree.");
    /* `files` is how anything gets STAGED — including a file you just created.
     * There is deliberately no add-everything flag: sensitive paths are screened
     * per file. Omit it and only already-staged changes are committed. */
@@ -766,8 +769,10 @@ static cJSON *tp_git_push(void)
 {
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
-   /* No path/upstream args: the handler pushes the current branch of the session
-    * worktree and sets upstream itself. */
+   tp_prop(props, "path", "string",
+           "Path to the git repository / worktree — the SAME path you pass to git_status. "
+           "Without it the repo is resolved from the session, which may not be your worktree.");
+   /* No upstream arg: the handler pushes the current branch and sets upstream itself. */
    tp_prop(props, "force", "boolean", "Force-push with lease (default false)");
    tp_prop(props, "mirror", "boolean", "Push to the configured mirror remote (default false)");
    cJSON_AddItemToObject(params, "properties", props);
@@ -780,6 +785,9 @@ static cJSON *tp_git_branch(void)
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
    tp_prop(props, "action", "string", "list | create | switch | claim | delete | orphan");
+   tp_prop(props, "path", "string",
+           "Path to the git repository / worktree — the SAME path you pass to git_status. "
+           "Without it the repo is resolved from the session, which may not be your worktree.");
    tp_prop(props, "name", "string", "Branch name (for create/switch/claim/delete)");
    tp_prop(props, "base", "string", "Base ref for create (defaults to the current HEAD)");
    tp_prop(props, "remote", "boolean", "Include remote branches when listing");
@@ -797,6 +805,9 @@ static cJSON *tp_git_pr(void)
    cJSON *props = cJSON_CreateObject();
    tp_prop(props, "action", "string",
            "create | view | list | edit | checks | watch | merge_status | merge");
+   tp_prop(props, "path", "string",
+           "Path to the git repository / worktree — the SAME path you pass to git_status. "
+           "Without it the repo is resolved from the session, which may not be your worktree.");
    tp_prop(props, "number", "integer", "PR number (for view/edit/checks/merge_status/merge)");
    tp_prop(props, "title", "string", "PR title (for create/edit)");
    tp_prop(props, "body", "string", "PR body (for create/edit)");


### PR DESCRIPTION
A delegate on .254 diagnosed this one itself, precisely:

> `git_commit` schema does not expose a `path` parameter, so it cannot be directed at the worktree directory — it appears to execute from a CWD that is not inside any git repo, hence the discovery error.

```
error: git add failed: fatal: not a git repository
       (or any parent up to mount point /var/lib)
```

It was right on both counts.

## Two bugs

**1. No `path` in the schemas.** `git_status` has one; my four git-write tools did not. So a delegate could *read* a repo it could not *write* to — it even confirmed the repo was healthy via `git_status` (`?? VALIDATION.md`) and `git_log` (HEAD at `eea9ce4`) on the same directory.

**2. The injected key was wrong.** `td_git_write` added the dispatcher’s cwd as **`cwd`**. `mcp_chdir_git_root` takes `args["path"]` as its priority-1 candidate and never reads a `cwd` key — so the injection resolved nothing and the handler ran wherever the thread happened to be. For that delegate, three directories from its worktree.

## Fix

`path` on all four (worded to point at `git_status` — a delegate that can read the repo already has the string), and the fallback injects `path`.

## The part that matters

The delegate had **no route left**. Its own words:

> All `bash`/`execute_script` calls that would let me `cd` into the worktree and retry are blocked.

That is the gate working exactly as designed — on a delegate whose alternative was broken. Which is the precise failure this whole line of work exists to prevent, and I reintroduced it one layer down by shipping tools that could not be aimed.

**Forbidding the shell is only safe while the replacement genuinely works.** Every link in that chain has now been found by running it on hardware: the tools were unregistered (#1352), then unreachable by role (#1359), then mis-described (#1360), and now un-aimable. None of it showed up in unit tests, clang-format, or ~16 green CI checks.