### PR TITLE
fix: say whether the review panel actually looked

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1165,6 +1165,30 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
    /* Account each participant's run onto the originating session, like a delegate. */
    for (int i = 0; i < ref_count; i++)
       ensemble_fold_cost(acfg, &results[i], cfg->ensemble_reference_models[i]);
+
+   /* Did the reviewers actually LOOK? A review panel was tool-less for its whole
+    * life, and giving it tools is worth nothing if the panelists never call one —
+    * a diff-only reviewer that hedges ("audit every caller before deleting")
+    * reads exactly like one that checked and found nothing. Without this line the
+    * two are indistinguishable from outside, which is how the tool-less panel
+    * passed 12 rounds on a slice carrying its own scope artifact.
+    *
+    * Zero across a whole round is the signal: the tools are offered but unused,
+    * so the panel is still judging the diff alone. */
+   if (mode == ROUNDTABLE_REVIEW)
+   {
+      int total_calls = 0, used = 0;
+      for (int i = 0; i < ref_count; i++)
+      {
+         total_calls += results[i].tool_calls;
+         if (results[i].tool_calls > 0)
+            used++;
+      }
+      aimee_log(total_calls > 0 ? LOG_INFO : LOG_WARN, "roundtable.progress",
+                "round %d: %d/%d panelists used aimee tools (%d call%s total)%s", round, used,
+                ref_count, total_calls, total_calls == 1 ? "" : "s",
+                total_calls > 0 ? "" : " — reviewing the diff ALONE (tools offered, none called)");
+   }
    for (int i = 0; i < ref_count; i++)
    {
       free(prompts[i]);


### PR DESCRIPTION
Follow-up to #1352, which gave review panelists aimee's index tools. Whether a panelist ever **calls** one is invisible — and that gap matters more than it sounds.

## Live evidence

I gave a review panel a diff deleting `toolset_for_delegate_role()` — a function with **12 callers outside the diff**, one `code_search` away. I asked explicitly for a caller `file:line` as evidence. It returned:

> Deleting `toolset_for_delegate_role()` breaks callers that still reference this symbol; the deletion is unsafe **absent a full audit of call sites, which the artifact does not document**. Before deleting, **audit every caller**...

It asked someone *else* to audit. It cited `src/toolset.c:466` — the deleted function itself — as its evidence. It never found one of the twelve.

The verdict was right. The method was hedging. **From the outside those are identical** — which is exactly how a tool-less panel passed 12 rounds on a slice carrying its own scope artifact.

## The change

Per round, log how many panelists called a tool and how many calls total. Zero across a round is `WARN` and says so plainly:

```
roundtable.progress: round 1: 0/4 panelists used aimee tools (0 calls total)
                     — reviewing the diff ALONE (tools offered, none called)
```

## What this does and does not do

It does **not** fix the behaviour. It makes the behaviour **visible**, which is the prerequisite for knowing whether the prompt, the toolset, or the model choice needs the work — I currently cannot tell which, and I would rather measure than guess.

Every guard shipped today was inert until something said so out loud. This is that line for the panel.