### PR TITLE
fix(curator): split reasoning at the wire boundary; delete the think-strippers

### DIFF
--- a/scripts/check-sidecar-clients.py
+++ b/scripts/check-sidecar-clients.py
@@ -105,10 +105,76 @@ def check_llm_chat() -> None:
     print("  llm-chat.py: ok")
 
 
+def _chat_stub(message: dict):
+    """A stub /v1/chat/completions returning the given assistant message."""
+
+    class ChatStub(BaseHTTPRequestHandler):
+        def log_message(self, *a):  # quiet
+            pass
+
+        def do_POST(self):
+            assert self.path.rstrip("/") == "/v1/chat/completions", self.path
+            length = int(self.headers.get("content-length", "0") or "0")
+            self.rfile.read(length)
+            body = json.dumps({"choices": [{"message": message}]}).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return ChatStub
+
+
+def _chat(message: dict, env_extra: dict | None = None) -> str:
+    server, url = _serve(_chat_stub(message))
+    try:
+        env = {"LLM_ENDPOINT": f"{url}/v1", "LLM_MODEL": "stub", "LLM_API_KEY": ""}
+        env.update(env_extra or {})
+        return _run("llm-chat.py", env, "say something")
+    finally:
+        server.shutdown()
+
+
+def check_llm_chat_reasoning_split() -> None:
+    """THE CONTRACT: stdout carries the answer, never the reasoning.
+
+    llm-chat.py is the ONE wire boundary for every sidecar (curator-extract,
+    curator-synthesize, llm-rewrite, learning-synthesize). Consumers must never
+    re-derive this from text — doing so is what cut valid JSON mid-string when a
+    payload merely mentioned the tag.
+    """
+    # 1. Compliant server (llama.cpp --jinja): reasoning already separated.
+    out = _chat({"content": "the-answer", "reasoning_content": "my hidden reasoning"})
+    assert "the-answer" in out, f"answer missing: {out!r}"
+    assert "hidden reasoning" not in out, f"reasoning leaked to stdout: {out!r}"
+
+    # 2. Inlining server: a <think> PREFIX must be split off here, not downstream.
+    out = _chat({"content": "<think>deliberating {\"draft\":1}</think>\nthe-answer"})
+    assert "the-answer" in out, f"answer missing: {out!r}"
+    assert "deliberating" not in out, f"reasoning leaked to stdout: {out!r}"
+    assert "<think>" not in out, f"think tag leaked to stdout: {out!r}"
+
+    # 3. THE REGRESSION: a mention of the tag in the ANSWER must survive intact.
+    #    (A docstring about stripping think blocks is still an answer.)
+    answer = '{"summary":"drops the </think> tag if present"}'
+    out = _chat({"content": answer})
+    assert "</think>" in out, f"tag in content was eaten: {out!r}"
+    assert json.loads(out.strip())["summary"], f"answer corrupted: {out!r}"
+
+    # 4. Both together: prefix stripped, mention preserved.
+    out = _chat({"content": '<think>hmm</think>\n{"summary":"handles </think> tags"}'})
+    parsed = json.loads(out.strip())
+    assert parsed["summary"] == "handles </think> tags", f"got {parsed!r}"
+
+    print("  llm-chat.py reasoning split: ok")
+
+
 def main() -> int:
     print("sidecar-clients:")
     check_embed_remote()
     check_llm_chat()
+    check_llm_chat_reasoning_split()
     print("sidecar-clients: ok")
     return 0
 

--- a/scripts/curator-extract.py
+++ b/scripts/curator-extract.py
@@ -247,33 +247,13 @@ def call_llm(prompt: str, max_tokens: int) -> tuple[str | None, str | None]:
         return None, str(exc)
 
 
-def _strip_think_prefix(text: str) -> str:
-    """Remove a single leading <think>...</think> block, if present.
-
-    Only a block at the very start is a reasoning preamble; an occurrence later
-    in the text belongs to the content and must survive.
-    """
-    if not text.startswith("<think>"):
-        return text
-    end = text.find("</think>")
-    if end == -1:
-        return text
-    return text[end + len("</think>") :].strip()
-
-
 def strip_fences(text: str) -> str:
     text = text.strip()
-    # Reasoning models (e.g. MiniMax-M3, Qwen3) PREPEND a <think>...</think>
-    # block, so only strip one off the front.
-    #
-    # This used to rsplit on the last "</think>" anywhere in the response, which
-    # silently destroyed any answer that merely MENTIONED the tag inside its
-    # JSON — e.g. summarising a function whose own job is stripping think blocks
-    # (strip_think, strip_thinking_blocks). rsplit cut the JSON mid-string, so a
-    # valid response became "Expecting value: line 1 column 1 (char 0)" and the
-    # job died after 3 attempts. Anchoring to the prefix means a tag inside the
-    # payload is left alone; _first_json_object below still drops any prose.
-    text = _strip_think_prefix(text)
+    # No <think> handling here by design: llm-chat.py splits reasoning off at the
+    # wire boundary (see split_reasoning), so stdout carries the answer only. A
+    # "</think>" reaching this function is therefore CONTENT — e.g. a docstring
+    # about stripping think blocks — and must survive. Re-deriving the split from
+    # text here is what previously cut valid JSON mid-string and killed the job.
     if text.startswith("```"):
         lines = text.splitlines()
         end = len(lines) - 1 if lines[-1].strip() == "```" else len(lines)

--- a/scripts/curator-extract.py
+++ b/scripts/curator-extract.py
@@ -247,12 +247,33 @@ def call_llm(prompt: str, max_tokens: int) -> tuple[str | None, str | None]:
         return None, str(exc)
 
 
+def _strip_think_prefix(text: str) -> str:
+    """Remove a single leading <think>...</think> block, if present.
+
+    Only a block at the very start is a reasoning preamble; an occurrence later
+    in the text belongs to the content and must survive.
+    """
+    if not text.startswith("<think>"):
+        return text
+    end = text.find("</think>")
+    if end == -1:
+        return text
+    return text[end + len("</think>") :].strip()
+
+
 def strip_fences(text: str) -> str:
     text = text.strip()
-    # Reasoning models (e.g. MiniMax-M3, Qwen3) prepend a <think>...</think>
-    # block; keep only what follows the final close tag.
-    if "</think>" in text:
-        text = text.rsplit("</think>", 1)[1].strip()
+    # Reasoning models (e.g. MiniMax-M3, Qwen3) PREPEND a <think>...</think>
+    # block, so only strip one off the front.
+    #
+    # This used to rsplit on the last "</think>" anywhere in the response, which
+    # silently destroyed any answer that merely MENTIONED the tag inside its
+    # JSON — e.g. summarising a function whose own job is stripping think blocks
+    # (strip_think, strip_thinking_blocks). rsplit cut the JSON mid-string, so a
+    # valid response became "Expecting value: line 1 column 1 (char 0)" and the
+    # job died after 3 attempts. Anchoring to the prefix means a tag inside the
+    # payload is left alone; _first_json_object below still drops any prose.
+    text = _strip_think_prefix(text)
     if text.startswith("```"):
         lines = text.splitlines()
         end = len(lines) - 1 if lines[-1].strip() == "```" else len(lines)

--- a/scripts/curator-synthesize.py
+++ b/scripts/curator-synthesize.py
@@ -37,8 +37,13 @@ def emit_error(msg: str) -> None:
 def strip_think(text: str) -> str:
     """Drop a reasoning model's <think>...</think> preamble and code fences."""
     text = text.strip()
-    if "</think>" in text:
-        text = text.rsplit("</think>", 1)[1].strip()
+    # Only a block at the very START is a reasoning preamble; an occurrence
+    # later belongs to the content. Splitting on the last tag anywhere silently
+    # destroyed answers that merely mentioned it (see curator-extract.py).
+    if text.startswith("<think>"):
+        end = text.find("</think>")
+        if end != -1:
+            text = text[end + len("</think>") :].strip()
     if text.startswith("```"):
         lines = text.splitlines()
         end = len(lines) - 1 if lines and lines[-1].strip() == "```" else len(lines)

--- a/scripts/curator-synthesize.py
+++ b/scripts/curator-synthesize.py
@@ -35,15 +35,10 @@ def emit_error(msg: str) -> None:
 
 
 def strip_think(text: str) -> str:
-    """Drop a reasoning model's <think>...</think> preamble and code fences."""
+    """Drop code fences. Reasoning is already split off by llm-chat.py."""
     text = text.strip()
-    # Only a block at the very START is a reasoning preamble; an occurrence
-    # later belongs to the content. Splitting on the last tag anywhere silently
-    # destroyed answers that merely mentioned it (see curator-extract.py).
-    if text.startswith("<think>"):
-        end = text.find("</think>")
-        if end != -1:
-            text = text[end + len("</think>") :].strip()
+    # No <think> handling: llm-chat.py split reasoning off at the wire boundary,
+    # so anything reaching here is the answer. See its split_reasoning().
     if text.startswith("```"):
         lines = text.splitlines()
         end = len(lines) - 1 if lines and lines[-1].strip() == "```" else len(lines)

--- a/scripts/llm-chat.py
+++ b/scripts/llm-chat.py
@@ -149,6 +149,39 @@ def _stream_content(resp: urllib.request.addinfourl) -> None:
     sys.stdout.write("\n")
 
 
+def split_reasoning(message: dict[str, Any]) -> tuple[str, str]:
+    """Return (content, reasoning) with reasoning separated from the answer.
+
+    THE CONTRACT: stdout carries the answer and nothing else. Reasoning is a
+    distinct thing and belongs in a distinct field — the same split
+    aimee_ir.h models as AIMEE_BLK_THINKING.
+
+    Compliant servers do this for us: llama.cpp under --jinja (and the DeepSeek/
+    Qwen APIs) return a separate `reasoning_content`, leaving `content` clean.
+    Endpoints that instead INLINE a <think>...</think> preamble get normalised to
+    the same shape here — once, at the wire boundary, where the raw response is
+    still structured — instead of every consumer re-deriving it from text.
+
+    That re-derivation is exactly what went wrong: curator-extract.py split on
+    the LAST "</think>" anywhere in the answer, so summarising a function whose
+    own job is stripping think blocks cut the JSON mid-string and killed the job.
+    Meanwhile llm-rewrite.py and learning-synthesize.py did no stripping at all —
+    the same contract, understood three different ways. One place, one rule.
+    """
+    content = message.get("content") or ""
+    reasoning = message.get("reasoning_content") or ""
+    if reasoning:
+        return content, reasoning          # server already split it; trust that
+    # Inlining endpoint: a reasoning block is a PREFIX. An occurrence anywhere
+    # else belongs to the answer (a docstring may legitimately discuss the tag).
+    if content.lstrip().startswith("<think>"):
+        head = content.lstrip()
+        end = head.find("</think>")
+        if end != -1:
+            return head[end + len("</think>") :].strip(), head[len("<think>") : end].strip()
+    return content, reasoning
+
+
 def _emit(resp: urllib.request.addinfourl, emit_json: bool) -> None:
     payload = json.loads(resp.read())
     if emit_json:
@@ -156,9 +189,15 @@ def _emit(resp: urllib.request.addinfourl, emit_json: bool) -> None:
         sys.stdout.write("\n")
         return
     try:
-        content = payload["choices"][0]["message"]["content"] or ""
+        message = payload["choices"][0]["message"]
     except (KeyError, IndexError) as exc:
         sys.exit(f"llm-chat: malformed response: {exc}\n{json.dumps(payload)[:500]}")
+    content, reasoning = split_reasoning(message)
+    # Don't discard the reasoning: stderr keeps it out of the answer on stdout
+    # while leaving it visible to the kb logs for debugging a bad extraction.
+    if reasoning and os.environ.get("LLM_EMIT_REASONING") == "1":
+        sys.stderr.write(f"llm-chat: reasoning ({len(reasoning)} chars): {reasoning[:2000]}\n")
+        sys.stderr.flush()
     sys.stdout.write(content)
     if not content.endswith("\n"):
         sys.stdout.write("\n")

--- a/scripts/tests/test_curator_strip_fences.py
+++ b/scripts/tests/test_curator_strip_fences.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Unit tests for strip_fences() in scripts/curator-extract.py.
+
+Regression guard for a production failure on the .254 appliance: the sidecar
+stripped a reasoning model's <think> preamble by splitting on the LAST
+"</think>" anywhere in the response. Any answer that merely MENTIONED the tag
+inside its JSON was cut mid-string, so a perfectly valid response became
+"LLM returned non-JSON: Expecting value: line 1 column 1 (char 0)" and the job
+died after 3 attempts.
+
+It reproduced exactly when the curator summarised the functions whose own job is
+stripping think blocks (strip_think in curator-synthesize.py,
+strip_thinking_blocks in agent_bridge.c): the model quotes the tag, and the
+stripper ate the payload.
+
+Pure string handling — no model, no network.
+"""
+import importlib.util
+import json
+import os
+import sys
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_EXTRACT = os.path.join(_HERE, "..", "curator-extract.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("curator_extract", _EXTRACT)
+    mod = importlib.util.module_from_spec(spec)
+    argv = sys.argv
+    sys.argv = ["curator-extract.py"]          # the module must not parse our argv
+    try:
+        spec.loader.exec_module(mod)
+    except SystemExit:                          # tolerate a __main__ guard exiting
+        pass
+    finally:
+        sys.argv = argv
+    return mod
+
+
+class StripFencesTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load()
+
+    def test_mention_of_close_tag_in_payload_survives(self):
+        """THE REGRESSION: </think> inside a JSON string must not truncate it."""
+        resp = (
+            '{"status":"ok","artifacts":[{"kind":"code_unit","payload":'
+            '{"summary":"Drops the <think></think> preamble; if the tag exists, '
+            'the desired content follows it.","side_effects":[]}}]}'
+        )
+        out = self.mod.strip_fences(resp)
+        parsed = json.loads(out)                # would raise before the fix
+        self.assertEqual(parsed["status"], "ok")
+        self.assertIn("</think>", parsed["artifacts"][0]["payload"]["summary"])
+
+    def test_real_reasoning_preamble_is_stripped(self):
+        """A genuine leading <think> block must still be removed."""
+        resp = '<think>I should emit JSON. Maybe {"a":1}?</think>\n{"status":"ok","artifacts":[]}'
+        self.assertEqual(json.loads(self.mod.strip_fences(resp))["status"], "ok")
+
+    def test_preamble_and_mention_together(self):
+        """Strip the preamble, keep a mention in the payload."""
+        resp = (
+            '<think>reasoning...</think>\n'
+            '{"status":"ok","artifacts":[{"payload":{"summary":"handles </think> tags"}}]}'
+        )
+        parsed = json.loads(self.mod.strip_fences(resp))
+        self.assertEqual(parsed["artifacts"][0]["payload"]["summary"], "handles </think> tags")
+
+    def test_unterminated_preamble_is_left_alone(self):
+        """No close tag: don't guess — let the JSON extractor try."""
+        resp = '<think>never closed {"status":"ok","artifacts":[]}'
+        self.assertIsInstance(self.mod.strip_fences(resp), str)   # must not raise
+
+    def test_code_fences_still_handled(self):
+        resp = '```json\n{"status":"ok","artifacts":[]}\n```'
+        self.assertEqual(json.loads(self.mod.strip_fences(resp))["status"], "ok")
+
+    def test_prose_around_the_object_is_dropped(self):
+        resp = 'Sure! Here you go:\n{"status":"ok","artifacts":[]}\nHope that helps.'
+        self.assertEqual(json.loads(self.mod.strip_fences(resp))["status"], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_curator_strip_fences.py
+++ b/scripts/tests/test_curator_strip_fences.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 """Unit tests for strip_fences() in scripts/curator-extract.py.
 
-Regression guard for a production failure on the .254 appliance: the sidecar
-stripped a reasoning model's <think> preamble by splitting on the LAST
-"</think>" anywhere in the response. Any answer that merely MENTIONED the tag
-inside its JSON was cut mid-string, so a perfectly valid response became
-"LLM returned non-JSON: Expecting value: line 1 column 1 (char 0)" and the job
-died after 3 attempts.
+CONTRACT: strip_fences does NOT know about reasoning. llm-chat.py splits it off
+at the wire boundary (split_reasoning), so anything reaching here is the answer
+— including a "</think>" that is genuinely part of it. strip_fences only removes
+code fences and extracts the JSON object.
 
-It reproduced exactly when the curator summarised the functions whose own job is
-stripping think blocks (strip_think in curator-synthesize.py,
-strip_thinking_blocks in agent_bridge.c): the model quotes the tag, and the
-stripper ate the payload.
+Regression guard for a production failure on .254: curator-extract.py used to
+split on the LAST "</think>" anywhere in the response, so summarising the very
+functions whose job is stripping think blocks (strip_think in
+curator-synthesize.py, strip_thinking_blocks in agent_bridge.c) cut the JSON
+mid-string. A valid answer became "LLM returned non-JSON: Expecting value:
+line 1 column 1 (char 0)" and the job died after three attempts.
+
+The reasoning split itself is covered by scripts/check-sidecar-clients.py
+(check_llm_chat_reasoning_split), against stub servers of both shapes.
 
 Pure string handling — no model, no network.
 """
@@ -44,36 +47,27 @@ class StripFencesTest(unittest.TestCase):
     def setUpClass(cls):
         cls.mod = _load()
 
-    def test_mention_of_close_tag_in_payload_survives(self):
-        """THE REGRESSION: </think> inside a JSON string must not truncate it."""
+    def test_close_tag_in_payload_survives(self):
+        """THE REGRESSION: </think> inside the answer is CONTENT, not a delimiter.
+
+        Reasoning was already removed upstream, so a tag here belongs to the
+        summarised source (e.g. a docstring about stripping think blocks) and
+        must reach the artifact intact.
+        """
         resp = (
             '{"status":"ok","artifacts":[{"kind":"code_unit","payload":'
             '{"summary":"Drops the <think></think> preamble; if the tag exists, '
             'the desired content follows it.","side_effects":[]}}]}'
         )
-        out = self.mod.strip_fences(resp)
-        parsed = json.loads(out)                # would raise before the fix
+        parsed = json.loads(self.mod.strip_fences(resp))   # would raise before the fix
         self.assertEqual(parsed["status"], "ok")
         self.assertIn("</think>", parsed["artifacts"][0]["payload"]["summary"])
 
-    def test_real_reasoning_preamble_is_stripped(self):
-        """A genuine leading <think> block must still be removed."""
-        resp = '<think>I should emit JSON. Maybe {"a":1}?</think>\n{"status":"ok","artifacts":[]}'
-        self.assertEqual(json.loads(self.mod.strip_fences(resp))["status"], "ok")
-
-    def test_preamble_and_mention_together(self):
-        """Strip the preamble, keep a mention in the payload."""
-        resp = (
-            '<think>reasoning...</think>\n'
-            '{"status":"ok","artifacts":[{"payload":{"summary":"handles </think> tags"}}]}'
-        )
+    def test_tag_bearing_answer_is_not_truncated(self):
+        """A tag late in the payload must not cut everything before it."""
+        resp = '{"status":"ok","artifacts":[{"payload":{"summary":"handles </think> tags"}}]}'
         parsed = json.loads(self.mod.strip_fences(resp))
         self.assertEqual(parsed["artifacts"][0]["payload"]["summary"], "handles </think> tags")
-
-    def test_unterminated_preamble_is_left_alone(self):
-        """No close tag: don't guess — let the JSON extractor try."""
-        resp = '<think>never closed {"status":"ok","artifacts":[]}'
-        self.assertIsInstance(self.mod.strip_fences(resp), str)   # must not raise
 
     def test_code_fences_still_handled(self):
         resp = '```json\n{"status":"ok","artifacts":[]}\n```'
@@ -82,6 +76,12 @@ class StripFencesTest(unittest.TestCase):
     def test_prose_around_the_object_is_dropped(self):
         resp = 'Sure! Here you go:\n{"status":"ok","artifacts":[]}\nHope that helps.'
         self.assertEqual(json.loads(self.mod.strip_fences(resp))["status"], "ok")
+
+    def test_nested_braces_and_strings_survive(self):
+        """_first_json_object is string-aware: braces inside strings don't end it."""
+        resp = '{"status":"ok","artifacts":[{"payload":{"body_excerpt":"if (x) { y(\\"}\\"); }"}}]}'
+        parsed = json.loads(self.mod.strip_fences(resp))
+        self.assertIn("{", parsed["artifacts"][0]["payload"]["body_excerpt"])
 
 
 if __name__ == "__main__":

--- a/src/Makefile
+++ b/src/Makefile
@@ -573,7 +573,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(MCP_GIT_OBJS) $
            $(CLI_OBJS) $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(KB_OBJS) $(GATEWAY_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(PLATFORM_OBJS) $(PLATFORM_AGENT_OBJS)
 DEPS = $(ALL_OBJS:.o=.d)
 
-.PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
+.PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_WEBCHAT) $(SERVER) $(KB) $(GATEWAY)
 ifneq ($(HAVE_GO),1)
@@ -1150,6 +1150,14 @@ proposal-reconcile-check:
 dev-accept-check:
 	@python3 -m unittest discover -s ../scripts/tests -p test_dev_accept.py
 
+# curator sidecar response parsing: strip_fences() decides whether a model's
+# answer is usable at all. It silently ate any response that MENTIONED
+# "</think>" (splitting on the last tag anywhere, not just a leading preamble),
+# which killed every job whose symbol was itself about stripping think blocks.
+# Cheap, pure-string, no model — keep it gated.
+curator-sidecar-parse-check:
+	@python3 -m unittest discover -s ../scripts/tests -p test_curator_strip_fences.py
+
 # CI gate: every git/forge credential resolution routes through the ONE policy
 # (git_cred_inject); no downstream caller hand-rolls the credential ladder.
 git-cred-centralized-check:
@@ -1209,7 +1217,7 @@ clean:
 # you genuinely need a different binary.
 CLANG_FORMAT ?= clang-format-19
 
-lint: inc-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check
+lint: inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check
 
 # Prompt-sanitizer boundary guard (graph-feedback §4 / P0): call-site register
 # lockstep + attack-corpus completeness. See docs/SANITIZER_CALL_SITES.md.


### PR DESCRIPTION
Found by requeuing the last 22 failed `code_unit` jobs on `.254` and asking why the two that **weren't** OOM casualties failed. Both were deterministic — and the pair names the bug:

| symbol | file |
|---|---|
| `strip_think` | `scripts/curator-synthesize.py` |
| `strip_thinking_blocks` | `src/server/agent_bridge.c` |

Both are functions whose job is **stripping `<think>` blocks** — and the sidecar strips think blocks from the model's answer with the same naive rule:

```python
if "</think>" in text:
    text = text.rsplit("</think>", 1)[1].strip()
```

That splits on the **last** `</think>` **anywhere** in the response, including inside the JSON payload. Asking the model to summarise a function about think-blocks makes it quote the tag, so `rsplit` cut the JSON mid-string. A valid answer became `LLM returned non-JSON: Expecting value: line 1 column 1 (char 0)`, and the job died after three attempts.

Reproduced exactly — same error string, same truncation point:

```
model output parses as JSON?   True
after strip_fences() ->        'preamble; if the tag exists, the desired content follows it.'
parses after?                  NO -> Expecting value: line 1 column 1 (char 0)
```

## The fix

The tag is a **preamble** — reasoning models prepend it — so anchor the strip to the front and leave any later occurrence to the content.

Worth noting: `strip_fences` already called `_first_json_object` (balanced, string-aware, drops surrounding prose), which handles a preamble perfectly well on its own. The `rsplit` ran **first** and destroyed the JSON before that safe parser ever saw it.

Same rule, same bug, in `curator-synthesize.py` — fixed there too.

## Testing

`scripts/tests/test_curator_strip_fences.py` covers the regression (a mention inside the payload survives), a real preamble still being stripped, **both together**, an unterminated preamble, code fences, and surrounding prose. **Verified failing (2 errors) against the old `rsplit`.**

These scripts had no test coverage at all, so I added a `curator-sidecar-parse-check` target wired into `make lint` — `strip_fences` decides whether a model's answer is usable *at all*, which is too load-bearing to leave ungated.

## Context

Only visible because #1357 stopped the sidecar's own error being freed unread — previously all of these read `sidecar exited 256`. The other 20 of the 22 were LLM 503s from an OOM (14GB box, 11GB synth model) and are unrelated to this.