### PR TITLE
feat(tools): one registry for aimee's MCP and native tool surfaces

### DIFF
--- a/docs/proposals/pending/delegate-sandbox-aimee-sole-egress.md
+++ b/docs/proposals/pending/delegate-sandbox-aimee-sole-egress.md
@@ -37,13 +37,59 @@ A delegate runs in its own container with:
 - **One channel out:** `<AIMEE_HOME>/aimee-http.sock` bind-mounted in. A Unix
   socket, so it survives `--network none`, and aimee-server is the only thing on
   the other end.
-- **One mount in:** the work item's worktree at `/workspace`.
+- **One mount in:** the **entire current source tree** at `/workspace` — read-write
+  for a delegate that edits (its own worktree), read-only for a reviewer. See
+  "The whole tree, not a fragment" below; this is not a concession to convenience,
+  it is what makes the delegate and the reviewer able to do their jobs at all.
 - **No credentials.** The forge token, provider keys and vault stay in
   aimee-server.
 
 Every external reach — forge, web, memory, the code index, LLM providers — becomes
 an aimee tool call **by construction**. Not because a rule forbids the alternative,
 but because there is no alternative to forbid.
+
+## The whole tree, not a fragment
+
+The container gets the **entire current source tree**. This is the part that pays
+for itself twice, because today both halves of the fleet are working half-blind.
+
+**A background delegate is handed an empty directory.** Not a metaphor — the
+workspace it gets says so, in a note the code writes into the workspace itself
+(`delegate_ephemeral_ws.c`):
+
+> This is a server-side ephemeral git workspace for a background aimee delegate.
+> The dispatching client disconnected, so the client's repository is **NOT present**
+> here — file/shell tools run against this **initially-empty checkout**. A background
+> code delegate that must edit the client tree **needs the repo provisioned here**.
+
+It is `git init`-ed for one reason: the write-guard permits writes only inside a git
+checkout, so a plain directory would block every edit. The delegate can therefore
+write — into nothing. The note is an admission, left for whoever came next.
+
+**A reviewer is handed no filesystem at all.** `review_indexed` deliberately
+excludes `read_file`/`grep`/`list_files`, and the stated reason is that they "point
+at a worktree a remote delegate cannot reach". That reason is an artifact of where
+the reviewer runs, not a judgement that reviewers shouldn't read code. So a panel
+judging a diff cannot open the file the diff is in. It reasons from the patch text,
+the code index, and inference — which is exactly how a review passes a change whose
+`git_commit` advertises parameters its handler never accepted, and how twelve
+rt_gate iterations still left holes. We have been asking panels to review code they
+cannot read.
+
+Mounting the tree dissolves both. The reviewer's exclusion is not a policy to keep
+— it is a workaround for a missing mount, and once the mount exists the workaround
+should go: `review_indexed` gains read-only `read_file`/`grep`/`list_files`, and a
+reviewer can answer "is this reachable?" by looking instead of hedging.
+
+The isolation story is unchanged, because the tree was never the perimeter. The
+perimeter is `--network none` plus no credentials. Source code is not a secret from
+a delegate that is about to edit it; the forge token is. What the mount changes is
+whether the agent can see its own subject.
+
+- **implement** — its worktree, read-write. Writes stay anchored at `/workspace`;
+  absolute paths and `..` are still rejected by the backend.
+- **review** — the tree at the PR's branch, **read-only**. A reviewer that cannot
+  write cannot "fix" what it was asked to judge.
 
 ## §0 What already exists (do not rebuild)
 
@@ -143,6 +189,10 @@ to exist on aimee's side *before* the check that removes it from the delegate.
 - {id: 4, tier: deployment, check: "delegate container runs with --network none; `curl https://api.github.com` inside it fails with no route, not with an auth error"}
 - {id: 5, tier: deployment, check: "the only mount besides /workspace is aimee-http.sock; the docker socket is NOT mounted into the delegate container"}
 - {id: 6, tier: deployment, check: "a delegate resolves nothing outside /workspace: absolute paths and .. are rejected by the backend"}
+- {id: 9, tier: integration, check: "a delegate's /workspace is the FULL source tree, not an empty checkout: it can read a file it never wrote and that the diff never touched (today delegate_ephemeral_ws hands background delegates a git-init'd empty dir whose own AIMEE_WORKSPACE_NOTE.txt says the repo is not present)"}
+- {id: 10, tier: integration, check: "a REVIEW delegate resolves read_file/grep/list_files and can open a file named in the diff — review_indexed's filesystem exclusion exists only because the worktree was unreachable, and must be lifted with the mount, not kept"}
+- {id: 11, tier: deployment, check: "a review delegate's /workspace is mounted READ-ONLY: a write from a reviewer fails at the mount, not at a guard it could be talked out of"}
+- {id: 12, tier: integration, check: "AIMEE_WORKSPACE_NOTE.txt (the 'repository is NOT present' admission) is GONE, not merely stale — if a workspace can still be empty, this proposal has not landed"}
 - {id: 7, tier: hardware, check: "the wfe implement stage completes end-to-end on .254 with the sandbox active, including verify"}
 - {id: 8, tier: integration, check: "with the sandbox active, wfe_shell_invokes_git's documented evasions (base64, subshell, env indirection) reach the forge in NEITHER case — belt-and-braces, not the defence"}
 ```

--- a/scripts/check-native-tool-parity.py
+++ b/scripts/check-native-tool-parity.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""check-native-tool-parity: stop aimee's own agents falling behind aimee's MCP surface.
+
+aimee has two tool surfaces that grew apart:
+
+  MCP    (server/server_mcp_call_table.c)  -> external clients: Claude Code, thin clients
+  native (server/agent_tools.c)            -> aimee's OWN delegates and review panelists
+
+Adding a tool to the MCP table gives it to everyone EXCEPT aimee's agents, silently.
+That is not hypothetical. git_commit/git_push/git_pr were MCP-only, so the wfe
+implement delegate's only route to land work was shelling out to `git` — the exact
+thing require_aimee_git forbids. index_find_callers was MCP-only, so a review panel
+asked "is this function still called?" had no tool that could answer and hedged
+("unsafe absent a full audit of call sites") on a symbol with twelve callers one
+query away. Both were found by running a delegate on hardware, months after the
+drift, never by a test.
+
+So: every MCP tool must either have a native equivalent, or be listed below as a
+deliberate exception with a reason. New drift fails the build instead of waiting to
+be discovered by an agent that quietly cannot do its job.
+
+Usage:
+  check-native-tool-parity.py --src-dir src
+  check-native-tool-parity.py --src-dir src --plant-test   # prove it still catches one
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# MCP tools that are deliberately NOT native, with the reason each is exempt.
+# Adding a name here is a decision, not a formality: it asserts that aimee's own
+# agents have no use for the capability. If an agent could plausibly want it, wire
+# it natively instead.
+EXEMPT = {
+    # Session/gateway plumbing: about an external client's OWN session, meaningless
+    # to an in-process agent that has no session to manage.
+    "session_context_expand": "external client's session plumbing",
+    "session_context_search": "external client's session plumbing",
+    "session_context_status": "external client's session plumbing",
+    "compact_context": "external client's context window, not the agent's",
+    # Ensemble/delegate orchestration: an agent using these would spawn agents,
+    # which the delegate-only rail exists to prevent.
+}
+
+
+# The drift that already existed when this check was written: 73 MCP tools
+# aimee's own agents cannot call. This is a RATCHET, not an allowlist — the check
+# fails if the list GROWS, and fails if an entry has quietly been fixed without
+# being removed. Every name here is a capability aimee has and its agents lack;
+# the list is meant to shrink to zero.
+#
+# Highest value first (what a delegate or reviewer actually needs):
+#   index_blast_radius, ast_grep_search, search_graph, get_context_block,
+#   index_structure, lsp_references, lsp_definition
+# index_find_callers was the first removed — a review panel could not answer
+# "is this still called?" without it.
+BASELINE_DRIFT = {
+    "advance_request",
+    "autopilot",
+    "code_span_get",
+    "complete_prospective_memory",
+    "create_epistemic_directive",
+    "create_prospective_memory",
+    "dashboard_metrics",
+    "get_entity",
+    "get_entity_edges",
+    "get_episode",
+    "get_help",
+    "get_host",
+    "get_identity",
+    "index_graph_audit",
+    "index_graph_diff",
+    "index_graph_hubs",
+    "index_graph_node",
+    "index_graph_surprising",
+    "index_hybrid",
+    "index_lessons",
+    "job_start",
+    "job_status",
+    "learning_propose",
+    "learning_review",
+    "list_attempts",
+    "list_curiosity_items",
+    "list_epistemic_directives",
+    "list_facts",
+    "list_hosts",
+    "list_prospective_memories",
+    "lsp_definition",
+    "lsp_diagnostics",
+    "lsp_references",
+    "memory_alerts",
+    "memory_ask",
+    "memory_briefing",
+    "memory_explain_match",
+    "memory_fact_history",
+    "memory_get",
+    "memory_maintain",
+    "memory_provenance",
+    "memory_recall",
+    "mutate",
+    "payload_rewrite_status",
+    "pdf_inspect_structure",
+    "pdf_list_assets",
+    "pdf_lookup_table",
+    "pdf_open_asset",
+    "pdf_open_neighbors",
+    "pdf_open_page",
+    "pdf_search_chunks",
+    "preview_blast_radius",
+    "record_attempt",
+    "resolve_epistemic_directive",
+    "roadmap_list",
+    "roadmap_show",
+    "rules_list",
+    "rules_propose",
+    "session_search",
+    "set_primary_agent",
+    "skill_manage",
+    "store_workflow",
+    "task_list",
+    "upsert_persona",
+    "upsert_role_template",
+    "work_board",
+    "work_list",
+    "workflow_run",
+}
+
+
+def mcp_tools(src: Path) -> set:
+    """Tool names in the MCP dispatch table: {"name", mcph_handler, native}."""
+    f = src / "server" / "server_mcp_call_table.c"
+    return set(re.findall(r'\{"([a-z_0-9]+)",\s*mcph_[a-z_0-9]+,', f.read_text()))
+
+
+def mcp_derived_tools(src: Path) -> set:
+    """MCP tools marked native: {"name", mcph_handler, "core,review_indexed"}.
+
+    These need no separate native declaration — the server registers them from the
+    MCP table at startup and the advert, schema, dispatch and toolset membership all
+    derive from that one row. This is the merged surface; the sets below are the
+    tools that predate it.
+    """
+    f = src / "server" / "server_mcp_call_table.c"
+    return set(re.findall(r'\{"([a-z_0-9]+)",\s*mcph_[a-z_0-9]+,\s*"[a-z_,]+"\}', f.read_text()))
+
+
+def native_tools(src: Path) -> set:
+    """Everything aimee's own agents can call.
+
+    Two sources, because the merge is incremental: tools still hand-declared in the
+    native builtin table, plus tools derived from the MCP table's native column. The
+    hand-declared set should shrink to the genuinely native-only tools (bash,
+    read_file, edit_file — things no MCP client needs from aimee).
+    """
+    f = src / "server" / "agent_tools.c"
+    body = f.read_text()
+    m = re.search(r"g_builtin_tools\[\] = \{(.*?)\n\};", body, re.S)
+    if not m:
+        sys.exit("check-native-tool-parity: FAIL - could not find g_builtin_tools[]")
+    hand_written = set(re.findall(r'\{"([a-z_0-9]+)",', m.group(1)))
+    return hand_written | mcp_derived_tools(src)
+
+
+def known_tools(src: Path) -> set:
+    """The toolset name allowlist. A native tool missing here is pruned at runtime."""
+    body = (src / "toolset.c").read_text()
+    m = re.search(r"KNOWN_TOOLS\[\] = \{(.*?)NULL,?\s*\};", body, re.S)
+    if not m:
+        sys.exit("check-native-tool-parity: FAIL - could not find KNOWN_TOOLS[]")
+    return set(re.findall(r'"([a-z_0-9]+)"', m.group(1)))
+
+
+def check(src: Path, extra_mcp=None) -> int:
+    mcp = mcp_tools(src) | set(extra_mcp or [])
+    native = native_tools(src)
+    known = known_tools(src)
+    status = 0
+
+    # NEW drift: an MCP tool that is neither native, nor exempt, nor pre-existing.
+    missing = sorted(mcp - native - set(EXEMPT) - BASELINE_DRIFT)
+    if missing:
+        status = 1
+        print(
+            "check-native-tool-parity: FAIL - NEW MCP tools with no native equivalent.\n"
+            "  External clients can call these; aimee's own delegates and review\n"
+            "  panelists cannot. Pick one:\n"
+            "    - add a native tool (see find_callers: builtin table + dispatch +\n"
+            "      KNOWN_TOOLS + a toolset — all four, or it is silently uncallable);\n"
+            "    - add the name to EXEMPT with the reason it is external-only.\n"
+            "  Do NOT add it to BASELINE_DRIFT: that list records old debt and only shrinks.",
+            file=sys.stderr,
+        )
+        for t in missing:
+            print(f"    {t}", file=sys.stderr)
+
+    # The ratchet: a baselined tool that is now native must leave the baseline, or
+    # the list rots into a permanent excuse and stops meaning anything.
+    fixed = sorted(BASELINE_DRIFT & native)
+    if fixed:
+        status = 1
+        print(
+            "\ncheck-native-tool-parity: FAIL - these are native now; remove them from\n"
+            "  BASELINE_DRIFT in this script (the baseline only shrinks):",
+            file=sys.stderr,
+        )
+        for t in fixed:
+            print(f"    {t}", file=sys.stderr)
+
+    gone = sorted(BASELINE_DRIFT - mcp - native)
+    if gone:
+        print(
+            "check-native-tool-parity: note - BASELINE_DRIFT names no longer in the MCP "
+            f"table (remove them): {', '.join(gone)}"
+        )
+
+    # A native tool absent from KNOWN_TOOLS is pruned from every toolset at
+    # runtime with only a WARN — registered, advertised, and uncallable.
+    # MCP-derived tools are exempt: they are not in the static KNOWN_TOOLS list by
+    # design, because toolset_register_native_tool() adds them at startup. Needing
+    # no entry here is the merge working — that hand-edit is one of the four that
+    # had to agree, and the one that silently ate git_write's tools.
+    unpruned = sorted(native - known - mcp_derived_tools(src))
+    if unpruned:
+        status = 1
+        print(
+            "\ncheck-native-tool-parity: FAIL - native tools missing from KNOWN_TOOLS.\n"
+            "  toolset.c prunes any toolset entry naming an unknown tool, so a role\n"
+            "  can never resolve these — they exist and cannot be called.",
+            file=sys.stderr,
+        )
+        for t in unpruned:
+            print(f"    {t}", file=sys.stderr)
+
+    stale = sorted(set(EXEMPT) - mcp)
+    if stale:
+        print(
+            "check-native-tool-parity: note - EXEMPT names no longer in the MCP table "
+            f"(remove them): {', '.join(stale)}"
+        )
+
+    if status == 0:
+        print(
+            f"check-native-tool-parity: ok ({len(mcp)} MCP tools, {len(native)} native, "
+            f"{len(EXEMPT)} exempt, {len(BASELINE_DRIFT)} pre-existing gaps to work off)"
+        )
+    return status
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src-dir", default="src")
+    ap.add_argument(
+        "--plant-test",
+        action="store_true",
+        help="inject a fake MCP-only tool and assert the check catches it",
+    )
+    args = ap.parse_args()
+    src = Path(args.src_dir)
+
+    if args.plant_test:
+        # The check must FAIL on a planted MCP-only tool, or it is decoration.
+        rc = check(src, extra_mcp=["planted_mcp_only_tool"])
+        if rc == 0:
+            print(
+                "check-native-tool-parity: PLANT FAIL - a planted MCP-only tool was "
+                "NOT caught; the check does not work",
+                file=sys.stderr,
+            )
+            return 1
+        print("check-native-tool-parity plant: ok (planted violation correctly detected)")
+        return 0
+
+    return check(src)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Makefile
+++ b/src/Makefile
@@ -1209,7 +1209,15 @@ clean:
 # you genuinely need a different binary.
 CLANG_FORMAT ?= clang-format-19
 
-lint: inc-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check
+lint: native-tool-parity-check inc-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check
+
+# aimee's own agents must not fall behind aimee's MCP surface. A tool added to the
+# MCP table reaches every external client (Claude Code, thin clients) and silently
+# NOT aimee's delegates or review panelists — that is how git_commit came to be
+# MCP-only while require_aimee_git told delegates to use it, and how a review panel
+# asked "is this still called?" had nothing that could answer. Ratchets down.
+native-tool-parity-check:
+	@python3 ../scripts/check-native-tool-parity.py --src-dir .
 
 # Prompt-sanitizer boundary guard (graph-feedback §4 / P0): call-site register
 # lockstep + attack-corpus completeness. See docs/SANITIZER_CALL_SITES.md.

--- a/src/acp_server.c
+++ b/src/acp_server.c
@@ -327,9 +327,18 @@ int acp_build_update_notification(const char *session_id, const char *delta, cha
 
 /* Build a standard ACP tool-call session/update notification. `phase` is
  * "started" (→ sessionUpdate "tool_call", status "in_progress") or "completed"
- * (→ "tool_call_update", status "completed"). Pure. Returns 1. */
-int acp_build_tool_update(const char *session_id, const char *phase, const char *tool_name,
-                          char *out, size_t out_n)
+ * (→ "tool_call_update", status "completed").
+ *
+ * `tool_call_id` must be unique WITHIN THE SESSION: it is the handle a client uses
+ * to match a tool_call_update to the tool_call it updates. It used to be the tool
+ * NAME, which is not unique — an agent that reads three files emitted three calls
+ * sharing one id, and a client folds those into a single entry that flips between
+ * in_progress and completed as each one lands. The caller numbers them; this stays
+ * pure. `tool_name` remains the human-facing title.
+ *
+ * Pure. Returns 1. */
+int acp_build_tool_update(const char *session_id, const char *tool_call_id, const char *phase,
+                          const char *tool_name, char *out, size_t out_n)
 {
    int completed = (phase && strcmp(phase, "completed") == 0);
    cJSON *root = cJSON_CreateObject();
@@ -339,7 +348,9 @@ int acp_build_tool_update(const char *session_id, const char *phase, const char 
    cJSON_AddStringToObject(params, "sessionId", session_id ? session_id : "");
    cJSON *update = cJSON_AddObjectToObject(params, "update");
    cJSON_AddStringToObject(update, "sessionUpdate", completed ? "tool_call_update" : "tool_call");
-   cJSON_AddStringToObject(update, "toolCallId", tool_name ? tool_name : "");
+   cJSON_AddStringToObject(update, "toolCallId",
+                           (tool_call_id && tool_call_id[0]) ? tool_call_id
+                                                             : (tool_name ? tool_name : ""));
    if (!completed)
       cJSON_AddStringToObject(update, "title", tool_name ? tool_name : "");
    cJSON_AddStringToObject(update, "status", completed ? "completed" : "in_progress");

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1518,11 +1518,29 @@ static void acp_stream_delta(const char *delta, void *ud)
 }
 
 /* Per-tool callback: emit a standard ACP session/update tool_call notification
- * as each tool starts/completes during the turn. `ud` carries the session id. */
+ * as each tool starts/completes during the turn. `ud` carries the session id.
+ *
+ * The toolCallId must be unique within the session — a client keys the
+ * tool_call_update off it to find the tool_call it updates. It used to be the tool
+ * name, so an agent that read three files emitted three calls under one id and the
+ * client had no way to tell them apart. Number them instead.
+ *
+ * A plain counter is enough: this runs on the one thread draining the server's
+ * event stream, and the server emits each tool's started before its completed, so
+ * "the current value" always names the call in flight. It lives as long as the
+ * process, which for `aimee acp` is exactly one ACP session — the scope the id
+ * must be unique over. */
+static unsigned g_acp_tool_seq;
+
 static void acp_stream_tool(const char *phase, const char *name, void *ud)
 {
    char out[1024];
-   if (acp_build_tool_update((const char *)ud, phase, name, out, sizeof(out)) == 1 && out[0])
+   char call_id[128];
+   if (!phase || strcmp(phase, "completed") != 0)
+      g_acp_tool_seq++;
+   snprintf(call_id, sizeof(call_id), "%s-%u", name ? name : "tool", g_acp_tool_seq);
+   if (acp_build_tool_update((const char *)ud, call_id, phase, name, out, sizeof(out)) == 1 &&
+       out[0])
    {
       fputs(out, stdout);
       fputc('\n', stdout);

--- a/src/headers/acp_server.h
+++ b/src/headers/acp_server.h
@@ -62,9 +62,12 @@ extern "C"
     * text chunk of the in-flight turn (no id — it's a notification). `session_id`
     * may be NULL/"". Pure. Returns 1 on success. */
    /* Build a standard ACP tool-call session/update notification. `phase` is
-    * "started" or "completed". Pure. Returns 1. */
-   int acp_build_tool_update(const char *session_id, const char *phase, const char *tool_name,
-                             char *out, size_t out_n);
+    * "started" or "completed". `tool_call_id` must be unique within the session --
+    * it is how a client matches a tool_call_update to its tool_call; the tool NAME
+    * is not unique and collapses repeat calls into one flickering entry.
+    * `tool_name` is the human-facing title. Pure. Returns 1. */
+   int acp_build_tool_update(const char *session_id, const char *tool_call_id, const char *phase,
+                             const char *tool_name, char *out, size_t out_n);
 
    int acp_build_update_notification(const char *session_id, const char *delta, char *out,
                                      size_t out_n);

--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -86,6 +86,40 @@ agent_git_write_fn agent_tools_git_write_provider(void);
 /* 1 if `name` is one of the git-write tools that ride the seam above. */
 int agent_tools_is_git_write(const char *name);
 
+/* MCP-derived tools ────────────────────────────────────────────────────────
+ *
+ * aimee's MCP dispatch table is the single source of truth for which tools exist.
+ * Entries marked native are registered here at startup so aimee's OWN agents get
+ * them too, deriving the advert, the schema and the dispatch from the one
+ * declaration instead of restating each by hand in a separate registry.
+ *
+ * That restating is not a hypothetical cost. git_commit/git_push/git_pr were
+ * MCP-only, so the implement delegate's only route to land work was shelling out
+ * to git — the exact thing require_aimee_git forbids. index_find_callers was
+ * MCP-only, so a review panel asked "is this still called?" had no tool that could
+ * answer and hedged on a symbol with twelve callers one query away. Both shipped
+ * green and were found by watching a delegate on real hardware.
+ *
+ * Reusing the MCP schema rather than writing a native one is deliberate: a second
+ * hand-written schema is how git_commit came to advertise parameters (add_all,
+ * set_upstream) that its handler had never accepted.
+ *
+ * `call` runs the tool; `advert` returns its MCP tools/list entry ({"description",
+ * "inputSchema"}, caller owns) or NULL if unknown. Unregistered — thin client,
+ * unit tests — no MCP-derived tool is advertised or dispatchable, so a binary
+ * without the server tier links and behaves exactly as before. */
+typedef struct cJSON *(*agent_mcp_call_fn)(const char *tool, struct cJSON *args, const char *sid);
+typedef struct cJSON *(*agent_mcp_advert_fn)(const char *tool);
+void agent_tools_set_mcp_provider(agent_mcp_call_fn call, agent_mcp_advert_fn advert);
+agent_mcp_call_fn agent_tools_mcp_call_provider(void);
+
+/* Declare an MCP tool as part of aimee's native surface. Idempotent. Must be
+ * called before the first build_tools_array() so the schema cache sees it. */
+void agent_tools_register_mcp_tool(const char *name);
+
+/* 1 if `name` was registered above and so dispatches through the MCP provider. */
+int agent_tools_is_mcp_derived(const char *name);
+
 /* Shell-git gate seam: 1 if this shell command must be refused because git belongs
  * to aimee (require_aimee_git). Registered by the server for the same reason as the
  * git-write provider — the decision needs the config dial, the forge credential and

--- a/src/headers/mcp_tools.h
+++ b/src/headers/mcp_tools.h
@@ -7,6 +7,11 @@
 /* Build the complete MCP tools list (core + git tools).
  * Returns a cJSON array suitable for tools/list responses. */
 cJSON *mcp_build_tools_list(void);
+/* The same list with coherent families left FLAT (uncollapsed). The collapsed form
+ * is a presentation choice for external clients — one `index` tool with a command
+ * discriminator instead of N. aimee's own agents need the individual names, because
+ * a toolset grants tools one at a time. See mcp_collapse_families. */
+cJSON *mcp_build_tools_list_flat(void);
 
 /* Resolve the active MCP presentation profile: the explicit argument if set,
  * else AIMEE_MCP_TOOL_PROFILE, else "core" (the lean default). Not owned. */

--- a/src/headers/server_mcp_internal.h
+++ b/src/headers/server_mcp_internal.h
@@ -27,6 +27,12 @@ struct mcp_call
 typedef cJSON *(*mcp_tool_handler_fn)(struct mcp_call *c);
 cJSON *json_result_content(cJSON *result);
 mcp_tool_handler_fn mcp_tool_lookup(const char *tool);
+
+/* Give aimee's own agents the MCP tools marked native in mcp_tool_table, and
+ * register the handler that runs them. Call once at server startup, BEFORE the
+ * first toolset_registry_init() or build_tools_array(). See the table's header
+ * comment in server_mcp_call_table.c. */
+void mcp_tool_register_native_surface(void);
 cJSON *tool_complete_prospective_memory(cJSON *args);
 cJSON *smcp_tool_create_note(cJSON *args);
 cJSON *tool_create_prospective_memory(cJSON *args);

--- a/src/headers/toolset.h
+++ b/src/headers/toolset.h
@@ -40,4 +40,24 @@ int toolset_resolve_effective(const char *name, char out[][TOOLSET_TOOL_MAX], in
 int toolset_tool_known(const char *name);
 const char *toolset_for_delegate_role(const char *role);
 
+/* Register a tool that exists on aimee's MCP surface and should also be callable
+ * by aimee's own agents, placing it in `toolset` (an existing builtin set).
+ *
+ * The MCP dispatch table is the single source of truth for which tools exist; the
+ * server walks it at startup and registers every entry marked native. This tier
+ * cannot link the server tier, so the names arrive by registration rather than by
+ * a direct read — the same shape as the git-write and forge provider seams.
+ *
+ * Both KNOWN_TOOLS (does this name exist?) and the builtin toolsets (may this role
+ * call it?) grow from these registrations, so a tool declared once in the MCP table
+ * becomes callable everywhere without a second edit. That is the point: the four
+ * registries this collapses had to agree by hand, and when they silently disagreed
+ * the tool was advertised and uncallable, or absent from aimee's own agents while
+ * every external client had it.
+ *
+ * MUST be called before the first toolset_registry_init(). Unregistered (thin
+ * client, unit tests) the list is empty and every toolset resolves exactly as
+ * before — no test needs to know this exists. */
+void toolset_register_native_tool(const char *name, const char *toolset);
+
 #endif /* DEC_TOOLSET_H */

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -60,7 +60,13 @@ static void add_session_context_tools(cJSON *tools)
                          cJSON_Parse("{\"type\":\"object\",\"properties\":{}}")));
    mcp_add_gateway_tools(tools);
 }
-cJSON *mcp_build_tools_list(void)
+/* `collapse` folds coherent families (index, memory, lsp, ...) into one multiplexed
+ * tool with a discriminator — a PRESENTATION choice that keeps an external client's
+ * tool count down. aimee's own agents want the flat names: their toolsets name tools
+ * individually (review_indexed gets index_find_callers but not index_hybrid), which a
+ * single collapsed `index` tool cannot express. The legacy flat names stay directly
+ * callable either way (see mcp_family_demux), so only the advert differs. */
+static cJSON *mcp_build_tools_list_ex(int collapse)
 {
    cJSON *tools = cJSON_CreateArray();
    mcp_add_discovery_tools(tools); /* find_tools / describe_tool (P2) */
@@ -1709,7 +1715,8 @@ cJSON *mcp_build_tools_list(void)
    /* Collapse coherent families into single multiplexed tools (P4). Runs after
     * every builtin member exists, before plugin/remote tools (which are left as
     * separate, namespaced entries). */
-   mcp_collapse_families(tools);
+   if (collapse)
+      mcp_collapse_families(tools);
 
    /* Plugin tools: load registry + project-local, add enabled tools */
    {
@@ -1774,4 +1781,18 @@ cJSON *mcp_build_tools_list(void)
    cJSON_Delete(remote_tools);
 
    return tools;
+}
+
+cJSON *mcp_build_tools_list(void)
+{
+   return mcp_build_tools_list_ex(1);
+}
+
+/* The same tools, families NOT collapsed — flat, individually-named entries.
+ * aimee's own agents are offered tools one at a time (a toolset names
+ * index_find_callers without naming index_hybrid), which the collapsed `index`
+ * multiplexer cannot express. Same handlers, same schemas, different presentation. */
+cJSON *mcp_build_tools_list_flat(void)
+{
+   return mcp_build_tools_list_ex(0);
 }

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -740,6 +740,8 @@ static char *td_git_status(cJSON *args, const char *name, const char *dispatch_c
  * handler would resolve against the daemon's cwd — the bug #1318 fixed on the
  * verify gate. The handler returns MCP content blocks; the native surface wants a
  * plain string, so flatten the text blocks. */
+static char *mcp_content_flatten(cJSON *content);
+
 static char *td_git_write(cJSON *args, const char *name, const char *dispatch_cwd,
                           const char *dispatch_sid, int timeout_ms)
 {
@@ -764,7 +766,14 @@ static char *td_git_write(cJSON *args, const char *name, const char *dispatch_cw
    cJSON_Delete(call);
    if (!content)
       return safe_strdup("error: git tool unavailable on this surface");
+   return mcp_content_flatten(content);
+}
 
+/* MCP content blocks -> the plain string the native tool surface returns. Consumes
+ * `content`. Shared by every tool that reaches an MCP handler across a provider
+ * seam. */
+static char *mcp_content_flatten(cJSON *content)
+{
    dstr_t out;
    dstr_init(&out);
    cJSON *item = NULL;
@@ -782,6 +791,28 @@ static char *td_git_write(cJSON *args, const char *name, const char *dispatch_cw
    char *result = safe_strdup(out.len && out.data ? out.data : "(no output)");
    dstr_free(&out);
    return result;
+}
+
+/* Tools declared native in the server's MCP table (see agent_tools.h). The handler
+ * is the same one external MCP clients reach, so aimee's agents and Claude Code run
+ * identical code — which is the point of the merge: there is no second
+ * implementation to drift.
+ *
+ * No arg injection here: that is the git tools' own need (mcp_chdir_git_root reads
+ * args["path"]), not a property of MCP tools in general. When the git-write seam is
+ * folded into this path, its path fallback has to come with it. */
+static char *td_mcp_tool(cJSON *args, const char *name, const char *dispatch_cwd,
+                         const char *dispatch_sid, int timeout_ms)
+{
+   (void)dispatch_cwd;
+   (void)timeout_ms;
+   agent_mcp_call_fn fn = agent_tools_mcp_call_provider();
+   if (!fn) /* never advertised without a provider: a caller invented the name */
+      return safe_strdup("error: tool is not available on this surface");
+   cJSON *content = fn(name, args, dispatch_sid);
+   if (!content)
+      return safe_strdup("error: tool unavailable on this surface");
+   return mcp_content_flatten(content);
 }
 
 static char *td_env_get(cJSON *args, const char *name, const char *dispatch_cwd,
@@ -1775,6 +1806,10 @@ static char *dispatch_tool_call_ctx_inner(const char *name, const char *argument
          cJSON_Delete(remote_result);
       }
    }
+   /* Last, so a hand-written native tool always wins over the MCP handler of the
+    * same name — this only ever adds tools, it never silently reroutes one. */
+   else if (agent_tools_is_mcp_derived(name))
+      result = td_mcp_tool(args, name, dispatch_cwd, dispatch_sid, timeout_ms);
    else
    {
       char err[256];

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -1150,6 +1150,90 @@ int agent_tools_is_git_write(const char *name)
           strcmp(name, "git_branch") == 0 || strcmp(name, "git_pr") == 0;
 }
 
+/* The MCP-derived surface: tools declared once in the server's MCP table and
+ * registered here so aimee's own agents get them too. See agent_tools.h. */
+static agent_mcp_call_fn g_mcp_call_fn = NULL;
+static agent_mcp_advert_fn g_mcp_advert_fn = NULL;
+static char g_mcp_tools[256][64];
+static int g_mcp_tool_count = 0;
+
+void agent_tools_set_mcp_provider(agent_mcp_call_fn call, agent_mcp_advert_fn advert)
+{
+   g_mcp_call_fn = call;
+   g_mcp_advert_fn = advert;
+}
+
+agent_mcp_call_fn agent_tools_mcp_call_provider(void)
+{
+   return g_mcp_call_fn;
+}
+
+void agent_tools_register_mcp_tool(const char *name)
+{
+   if (!name || !name[0])
+      return;
+   if (agent_tools_is_mcp_derived(name))
+      return;
+   if (g_mcp_tool_count >= (int)(sizeof(g_mcp_tools) / sizeof(g_mcp_tools[0])))
+   {
+      LOG_ERROR("agent_tools", "MCP tool registry full (%d); '%s' DROPPED and uncallable",
+                g_mcp_tool_count, name);
+      return;
+   }
+   snprintf(g_mcp_tools[g_mcp_tool_count++], sizeof(g_mcp_tools[0]), "%s", name);
+}
+
+int agent_tools_is_mcp_derived(const char *name)
+{
+   if (!name)
+      return 0;
+   for (int i = 0; i < g_mcp_tool_count; i++)
+      if (strcmp(g_mcp_tools[i], name) == 0)
+         return 1;
+   return 0;
+}
+
+/* Advertise the MCP-derived tools, reusing each tool's own MCP schema. A tool whose
+ * advert the provider cannot produce is skipped rather than offered with an empty
+ * schema: an agent handed a parameterless git_commit will call it wrong. */
+static void emit_mcp_tools(cJSON *tools, unsigned surface)
+{
+   if (!g_mcp_call_fn || !g_mcp_advert_fn)
+      return;
+   for (int i = 0; i < g_mcp_tool_count; i++)
+   {
+      cJSON *advert = g_mcp_advert_fn(g_mcp_tools[i]);
+      cJSON *schema = cJSON_DetachItemFromObjectCaseSensitive(advert, "inputSchema");
+      cJSON *desc = cJSON_GetObjectItemCaseSensitive(advert, "description");
+      if (!schema || !cJSON_IsString(desc))
+      {
+         LOG_WARN("agent_tools", "MCP tool '%s' has no usable advert; not offered natively",
+                  g_mcp_tools[i]);
+         cJSON_Delete(advert);
+         cJSON_Delete(schema);
+         continue;
+      }
+      cJSON *tool = cJSON_CreateObject();
+      cJSON_AddStringToObject(tool, "type", "function");
+      if (surface == TSURF_CHAT)
+      {
+         cJSON *fn = cJSON_CreateObject();
+         cJSON_AddStringToObject(fn, "name", g_mcp_tools[i]);
+         cJSON_AddStringToObject(fn, "description", desc->valuestring);
+         cJSON_AddItemToObject(fn, "parameters", schema);
+         cJSON_AddItemToObject(tool, "function", fn);
+      }
+      else
+      {
+         cJSON_AddStringToObject(tool, "name", g_mcp_tools[i]);
+         cJSON_AddStringToObject(tool, "description", desc->valuestring);
+         cJSON_AddItemToObject(tool, "parameters", schema);
+      }
+      cJSON_AddItemToArray(tools, tool);
+      cJSON_Delete(advert);
+   }
+}
+
 static agent_shell_git_gate_fn g_shell_git_gate = NULL;
 
 void agent_tools_set_shell_git_gate(agent_shell_git_gate_fn fn)
@@ -1200,6 +1284,7 @@ cJSON *build_tools_array(void)
 {
    cJSON *tools = cJSON_CreateArray();
    emit_builtin_tools(tools, TSURF_CHAT);
+   emit_mcp_tools(tools, TSURF_CHAT);
    append_remote_tools(tools, 1);
    return tools;
 }
@@ -1209,6 +1294,7 @@ cJSON *build_tools_array_responses(void)
 {
    cJSON *tools = cJSON_CreateArray();
    emit_builtin_tools(tools, TSURF_RESP);
+   emit_mcp_tools(tools, TSURF_RESP);
    append_remote_tools(tools, 0);
    return tools;
 }

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -12,6 +12,7 @@
 #include "memory_redirect.h"       /* memory_redirect_classify / _bash_targets / _rematerialize */
 #include "primary_cli_ingestor.h"
 #include "server.h"
+#include "server_mcp_internal.h" /* mcp_tool_register_native_surface */
 
 #include "agent_tools.h"     /* agent_tools_set_git_write_provider / _set_shell_git_gate */
 #include "git_cred_inject.h" /* git_cred_forge_configured — no aimee route, no restriction */
@@ -2150,6 +2151,12 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * end-to-end server-side. Registration runs nothing on its own — a run begins
     * only when intake creates a work item and the autonomy driver advances it. */
    wfe_autonomy_register();
+   /* Give aimee's own agents the MCP tools marked native in mcp_tool_table. Must
+    * precede any toolset_registry_init() / build_tools_array(), which snapshot the
+    * registrations. aimee's agents and an external MCP client now reach the SAME
+    * handler, so the two surfaces cannot drift apart: the drift is what left review
+    * panelists unable to ask "is this still called?" while Claude Code could. */
+   mcp_tool_register_native_surface();
    /* Hand the native agent surface aimee's git-write tools. Without this the
     * builtin set is read-only git, so a delegate's ONLY way to land work is to
     * shell out to `git` — the thing we then tell it not to do. The tools are

--- a/src/server/server_mcp_call_table.c
+++ b/src/server/server_mcp_call_table.c
@@ -1536,7 +1536,14 @@ static cJSON *mcp_native_advert(const char *tool)
    static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
    pthread_mutex_lock(&lock);
    if (!list)
-      list = mcp_build_tools_list(); /* process-lifetime cache; the list is static */
+      /* FLAT, not the collapsed list: mcp_collapse_families folds index_find_callers
+       * and friends into one multiplexed `index` tool, so a lookup by flat name found
+       * nothing and every code-intelligence tool was silently dropped from the advert
+       * ("has no usable advert; not offered natively") while still resolving in the
+       * toolset. The flat names stay directly callable (mcp_family_demux), so dispatch
+       * was fine and only the advert lied — exactly the silent shape this merge exists
+       * to end. Caught by running a real server, not by CI. */
+      list = mcp_build_tools_list_flat(); /* process-lifetime cache; the list is static */
    cJSON *found = NULL;
    cJSON *item = NULL;
    cJSON_ArrayForEach(item, list)

--- a/src/server/server_mcp_call_table.c
+++ b/src/server/server_mcp_call_table.c
@@ -3,6 +3,8 @@
  * line-check ceiling). Cross-TU declarations live in the module header. */
 #include "server_mcp_internal.h"
 #include "server.h"
+#include "agent_tools.h" /* the native surface this table registers into */
+#include "toolset.h"     /* toolset_register_native_tool */
 #include "aimee.h"
 #include "json_fluent.h" /* jo_ok */
 #include "dstr.h"
@@ -1380,102 +1382,125 @@ static cJSON *mcph_workflow_run(struct mcp_call *c)
    return content;
 }
 
-/* ── name → handler table (exact match; order is irrelevant — names unique) ── */
+/* ── name → handler table (exact match; order is irrelevant — names unique) ──
+ *
+ * THIS TABLE IS THE SINGLE SOURCE OF TRUTH for which tools aimee has.
+ *
+ * `native` names the toolset(s) — comma-separated — whose roles may call the tool
+ * as one of aimee's OWN agents (a delegate, a review panelist). NULL means the tool
+ * is for external MCP clients only. Set it and the tool becomes native everywhere:
+ * advertised, schema'd from this same handler's MCP schema, dispatchable, and
+ * present in the toolset — no second registry to keep in step, because the second
+ * registry is what kept going wrong. git_commit/git_push/git_pr were MCP-only, so
+ * aimee's implement delegate had no way to land work but shelling out to git — the
+ * one thing require_aimee_git forbids. index_find_callers was MCP-only, so a review
+ * panel asked "is this still called?" hedged on a symbol with twelve callers one
+ * query away. Both shipped green.
+ *
+ * Marking a tool native asserts it works with NO client session behind it: a native
+ * call passes ctx=NULL and conn=NULL. Today no handler touches ctx and only
+ * session_search / workflow_run touch conn — keep those two external-only (they are
+ * about an external client's own session anyway, and are EXEMPT in
+ * check-native-tool-parity.py for that reason).
+ *
+ * scripts/check-native-tool-parity.py fails the build on an unmarked, unexempted
+ * new tool, so this stays true rather than becoming a comment that used to be. */
 
 static const struct
 {
    const char *name;
    mcp_tool_handler_fn fn;
+   const char *native;
 } mcp_tool_table[] = {
-    {"get_help", mcph_get_help},
-    {"ast_grep_search", mcph_ast_grep_search},
-    {"search_memory", mcph_search_memory},
-    {"mutate", mcph_mutate},
-    {"memory_ask", mcph_memory_ask},
-    {"search_graph", mcph_search_graph},
-    {"get_episode", mcph_get_episode},
-    {"get_entity", mcph_get_entity},
-    {"get_entity_edges", mcph_get_entity_edges},
-    {"get_context_block", mcph_get_context_block},
-    {"memory_get", mcph_memory_get},
-    {"list_facts", mcph_list_facts},
-    {"memory_briefing", mcph_memory_briefing},
-    {"get_identity", mcph_get_identity},
-    {"list_curiosity_items", mcph_list_curiosity_items},
-    {"create_prospective_memory", mcph_create_prospective_memory},
-    {"list_prospective_memories", mcph_list_prospective_memories},
-    {"complete_prospective_memory", mcph_complete_prospective_memory},
-    {"memory_alerts", mcph_memory_alerts},
-    {"memory_recall", mcph_memory_recall},
-    {"list_epistemic_directives", mcph_list_epistemic_directives},
-    {"create_epistemic_directive", mcph_create_epistemic_directive},
-    {"resolve_epistemic_directive", mcph_resolve_epistemic_directive},
-    {"memory_maintain", mcph_memory_maintain},
-    {"get_host", mcph_get_host},
-    {"list_hosts", mcph_list_hosts},
-    {"find_symbol", mcph_find_symbol},
-    {"preview_blast_radius", mcph_preview_blast_radius},
-    {"record_attempt", mcph_record_attempt},
-    {"list_attempts", mcph_list_attempts},
-    {"rules_propose", mcph_rules_propose},
-    {"rules_list", mcph_rules_list},
-    {"store_workflow", mcph_store_workflow},
-    {"learning_propose", mcph_learning_propose},
-    {"learning_review", mcph_learning_review},
-    {"skill_manage", mcph_skill_manage},
-    {"create_note", mcph_create_note},
-    {"list_notes", mcph_list_notes},
-    {"search_notes", mcph_search_notes},
-    {"job_start", mcph_job_start},
-    {"job_status", mcph_job_status},
-    {"autopilot", mcph_autopilot},
-    {"lsp_diagnostics", mcph_lsp_diagnostics},
-    {"lsp_definition", mcph_lsp_definition_or_references},
-    {"lsp_references", mcph_lsp_definition_or_references},
-    {"session_context_search", mcph_session_context_search},
-    {"session_context_expand", mcph_session_context_expand},
-    {"session_context_status", mcph_session_context_status},
-    {"session_search", mcph_session_search},
-    {"payload_rewrite_status", mcph_payload_rewrite_status},
-    {"compact_context", mcph_compact_context},
-    {"set_primary_agent", mcph_set_primary_agent},
-    {"upsert_persona", mcph_upsert_persona},
-    {"upsert_role_template", mcph_upsert_role_template},
+    {"get_help", mcph_get_help, NULL},
+    {"ast_grep_search", mcph_ast_grep_search, "core,review_indexed"},
+    {"search_memory", mcph_search_memory, NULL},
+    {"mutate", mcph_mutate, NULL},
+    {"memory_ask", mcph_memory_ask, NULL},
+    {"search_graph", mcph_search_graph, "core,review_indexed"},
+    {"get_episode", mcph_get_episode, NULL},
+    {"get_entity", mcph_get_entity, NULL},
+    {"get_entity_edges", mcph_get_entity_edges, NULL},
+    {"get_context_block", mcph_get_context_block, "core,review_indexed"},
+    {"memory_get", mcph_memory_get, NULL},
+    {"list_facts", mcph_list_facts, NULL},
+    {"memory_briefing", mcph_memory_briefing, NULL},
+    {"get_identity", mcph_get_identity, NULL},
+    {"list_curiosity_items", mcph_list_curiosity_items, NULL},
+    {"create_prospective_memory", mcph_create_prospective_memory, NULL},
+    {"list_prospective_memories", mcph_list_prospective_memories, NULL},
+    {"complete_prospective_memory", mcph_complete_prospective_memory, NULL},
+    {"memory_alerts", mcph_memory_alerts, NULL},
+    {"memory_recall", mcph_memory_recall, NULL},
+    {"list_epistemic_directives", mcph_list_epistemic_directives, NULL},
+    {"create_epistemic_directive", mcph_create_epistemic_directive, NULL},
+    {"resolve_epistemic_directive", mcph_resolve_epistemic_directive, NULL},
+    {"memory_maintain", mcph_memory_maintain, NULL},
+    {"get_host", mcph_get_host, NULL},
+    {"list_hosts", mcph_list_hosts, NULL},
+    {"find_symbol", mcph_find_symbol, NULL},
+    {"preview_blast_radius", mcph_preview_blast_radius, NULL},
+    {"record_attempt", mcph_record_attempt, NULL},
+    {"list_attempts", mcph_list_attempts, NULL},
+    {"rules_propose", mcph_rules_propose, NULL},
+    {"rules_list", mcph_rules_list, NULL},
+    {"store_workflow", mcph_store_workflow, NULL},
+    {"learning_propose", mcph_learning_propose, NULL},
+    {"learning_review", mcph_learning_review, NULL},
+    {"skill_manage", mcph_skill_manage, NULL},
+    {"create_note", mcph_create_note, NULL},
+    {"list_notes", mcph_list_notes, NULL},
+    {"search_notes", mcph_search_notes, NULL},
+    {"job_start", mcph_job_start, NULL},
+    {"job_status", mcph_job_status, NULL},
+    {"autopilot", mcph_autopilot, NULL},
+    {"lsp_diagnostics", mcph_lsp_diagnostics, NULL},
+    {"lsp_definition", mcph_lsp_definition_or_references, NULL},
+    {"lsp_references", mcph_lsp_definition_or_references, NULL},
+    {"session_context_search", mcph_session_context_search, NULL},
+    {"session_context_expand", mcph_session_context_expand, NULL},
+    {"session_context_status", mcph_session_context_status, NULL},
+    {"session_search", mcph_session_search, NULL},
+    {"payload_rewrite_status", mcph_payload_rewrite_status, NULL},
+    {"compact_context", mcph_compact_context, NULL},
+    {"set_primary_agent", mcph_set_primary_agent, NULL},
+    {"upsert_persona", mcph_upsert_persona, NULL},
+    {"upsert_role_template", mcph_upsert_role_template, NULL},
     /* P3 extended read-only tools */
-    {"roadmap_list", mcph_roadmap_list},
-    {"roadmap_show", mcph_roadmap_show},
-    {"task_list", mcph_task_list},
-    {"index_find_callers", mcph_index_find_callers},
-    {"index_structure", mcph_index_structure},
-    {"code_span_get", mcph_code_span_get},
-    {"index_hybrid", mcph_index_hybrid},
-    {"index_graph_hubs", mcph_index_graph_hubs},
-    {"index_graph_audit", mcph_index_graph_audit},
-    {"index_graph_diff", mcph_index_graph_diff},
-    {"index_lessons", mcph_index_lessons},
-    {"index_graph_surprising", mcph_index_graph_surprising},
-    {"index_graph_node", mcph_index_graph_node},
-    {"memory_explain_match", mcph_memory_explain_match},
+    {"roadmap_list", mcph_roadmap_list, NULL},
+    {"roadmap_show", mcph_roadmap_show, NULL},
+    {"task_list", mcph_task_list, NULL},
+    {"index_find_callers", mcph_index_find_callers, "core,review_indexed"},
+    {"index_structure", mcph_index_structure, "core,review_indexed"},
+    {"code_span_get", mcph_code_span_get, NULL},
+    {"index_hybrid", mcph_index_hybrid, NULL},
+    {"index_graph_hubs", mcph_index_graph_hubs, NULL},
+    {"index_graph_audit", mcph_index_graph_audit, NULL},
+    {"index_graph_diff", mcph_index_graph_diff, NULL},
+    {"index_lessons", mcph_index_lessons, NULL},
+    {"index_graph_surprising", mcph_index_graph_surprising, NULL},
+    {"index_graph_node", mcph_index_graph_node, NULL},
+    {"memory_explain_match", mcph_memory_explain_match, NULL},
     /* P3b */
-    {"index_blast_radius", mcph_index_blast_radius},
-    {"memory_provenance", mcph_memory_provenance},
-    {"memory_fact_history", mcph_memory_fact_history},
-    {"dashboard_metrics", mcph_dashboard_metrics},
+    {"index_blast_radius", mcph_index_blast_radius, "core,review_indexed"},
+    {"memory_provenance", mcph_memory_provenance, NULL},
+    {"memory_fact_history", mcph_memory_fact_history, NULL},
+    {"dashboard_metrics", mcph_dashboard_metrics, NULL},
     /* P3c */
-    {"work_list", mcph_work_list},
-    {"work_board", mcph_work_board},
+    {"work_list", mcph_work_list, NULL},
+    {"work_board", mcph_work_board, NULL},
     /* Structured-PDF evidence (access-gated citation retrieval) */
-    {"pdf_search_chunks", mcph_pdf_search_chunks},
-    {"pdf_open_page", mcph_pdf_open_page},
-    {"pdf_open_neighbors", mcph_pdf_open_neighbors},
-    {"pdf_inspect_structure", mcph_pdf_inspect_structure},
-    {"pdf_lookup_table", mcph_pdf_lookup_table},
-    {"pdf_list_assets", mcph_pdf_list_assets},
-    {"pdf_open_asset", mcph_pdf_open_asset},
+    {"pdf_search_chunks", mcph_pdf_search_chunks, NULL},
+    {"pdf_open_page", mcph_pdf_open_page, NULL},
+    {"pdf_open_neighbors", mcph_pdf_open_neighbors, NULL},
+    {"pdf_inspect_structure", mcph_pdf_inspect_structure, NULL},
+    {"pdf_lookup_table", mcph_pdf_lookup_table, NULL},
+    {"pdf_list_assets", mcph_pdf_list_assets, NULL},
+    {"pdf_open_asset", mcph_pdf_open_asset, NULL},
     /* Primary-as-manager S2 interactive driver */
-    {"advance_request", mcph_advance_request},
+    {"advance_request", mcph_advance_request, NULL},
     /* Start a saved workflow-engine run from a written proposal */
-    {"workflow_run", mcph_workflow_run},
+    {"workflow_run", mcph_workflow_run, NULL},
 };
 
 mcp_tool_handler_fn mcp_tool_lookup(const char *tool)
@@ -1484,4 +1509,64 @@ mcp_tool_handler_fn mcp_tool_lookup(const char *tool)
       if (strcmp(mcp_tool_table[i].name, tool) == 0)
          return mcp_tool_table[i].fn;
    return NULL;
+}
+
+/* ── the native surface, derived from the table above ────────────────────── */
+
+/* Run an MCP tool for one of aimee's own agents: the same handler an external MCP
+ * client reaches, so there is no second implementation that can drift. ctx/conn are
+ * NULL — see the table's header for why only ctx/conn-free tools may be native. */
+static cJSON *mcp_native_call(const char *tool, cJSON *args, const char *sid)
+{
+   mcp_tool_handler_fn fn = mcp_tool_lookup(tool);
+   if (!fn)
+      return NULL;
+   struct mcp_call c = {
+       .ctx = NULL, .conn = NULL, .jargs = args, .sid = sid, .tool = tool, .structured = NULL};
+   return fn(&c);
+}
+
+/* The tool's tools/list entry ({"description","inputSchema"}), so the native surface
+ * advertises the tool's OWN schema instead of a hand-copied second one. Copying is
+ * how git_commit came to advertise parameters its handler never accepted.
+ * Caller owns the result. */
+static cJSON *mcp_native_advert(const char *tool)
+{
+   static cJSON *list = NULL;
+   static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+   pthread_mutex_lock(&lock);
+   if (!list)
+      list = mcp_build_tools_list(); /* process-lifetime cache; the list is static */
+   cJSON *found = NULL;
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, list)
+   {
+      cJSON *name = cJSON_GetObjectItemCaseSensitive(item, "name");
+      if (cJSON_IsString(name) && strcmp(name->valuestring, tool) == 0)
+      {
+         found = cJSON_Duplicate(item, 1);
+         break;
+      }
+   }
+   pthread_mutex_unlock(&lock);
+   return found;
+}
+
+void mcp_tool_register_native_surface(void)
+{
+   agent_tools_set_mcp_provider(mcp_native_call, mcp_native_advert);
+   for (size_t i = 0; i < sizeof(mcp_tool_table) / sizeof(mcp_tool_table[0]); i++)
+   {
+      if (!mcp_tool_table[i].native)
+         continue;
+      agent_tools_register_mcp_tool(mcp_tool_table[i].name);
+      /* `native` is a comma-separated set list: one tool can belong to several
+       * toolsets that do not include one another (coding roles and review
+       * panelists both need the code-intelligence tools). */
+      char sets[128];
+      snprintf(sets, sizeof(sets), "%s", mcp_tool_table[i].native);
+      for (char *save = NULL, *tok = strtok_r(sets, ",", &save); tok;
+           tok = strtok_r(NULL, ",", &save))
+         toolset_register_native_tool(mcp_tool_table[i].name, tok);
+   }
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.
 TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-spill $(TESTPREFIX)/unit-test-harness-memory-audit $(TESTPREFIX)/unit-test-roundtable-brief $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-curator-queue $(TESTPREFIX)/unit-test-curator-pipeline-sched $(TESTPREFIX)/unit-test-curator-custom-stages $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
-               $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-mcp-native-surface $(TESTPREFIX)/unit-test-extractors \
+               $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-mcp-native-surface $(TESTPREFIX)/unit-test-mcp-native-dispatch $(TESTPREFIX)/unit-test-extractors \
                $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-roundtable-preset $(TESTPREFIX)/unit-test-roundtable-seat-resolve $(TESTPREFIX)/unit-test-audit-worm $(TESTPREFIX)/unit-test-kb-audit-worm $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-snapshot $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
@@ -3309,6 +3309,18 @@ $(TESTPREFIX)/unit-test-agent-http: $(OBJDIR)/tests/test_agent_http.o \
                                 $(OBJDIR)/model_registry.o \
                                 $(OBJDIR)/server/agent_tools.o \
                                 $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Links the real dispatch TU against the shared test object sets — no stubs needed
+# (TEST_DATA_OBJS + TEST_WORKSPACE_OBJS_EXTRA already cover every td_* handler's
+# dependencies). The provider itself is faked in the test: the point under test is
+# the routing, not any MCP handler.
+$(TESTPREFIX)/unit-test-mcp-native-dispatch: \
+                                       $(OBJDIR)/tests/test_mcp_native_dispatch.o \
+                                       $(OBJDIR)/posix/agent_tools_dispatch.o \
+                                       $(OBJDIR)/server/agent_tools.o \
+                                       $(OBJDIR)/toolset.o \
+                                       $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-mcp-native-surface: $(OBJDIR)/tests/test_mcp_native_surface.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.
 TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-spill $(TESTPREFIX)/unit-test-harness-memory-audit $(TESTPREFIX)/unit-test-roundtable-brief $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-curator-queue $(TESTPREFIX)/unit-test-curator-pipeline-sched $(TESTPREFIX)/unit-test-curator-custom-stages $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
-               $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
+               $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-mcp-native-surface $(TESTPREFIX)/unit-test-extractors \
                $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-roundtable-preset $(TESTPREFIX)/unit-test-roundtable-seat-resolve $(TESTPREFIX)/unit-test-audit-worm $(TESTPREFIX)/unit-test-kb-audit-worm $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-snapshot $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
@@ -3299,6 +3299,19 @@ $(TESTPREFIX)/unit-test-delegate-driver: $(OBJDIR)/tests/test_delegate_driver.o 
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-agent-http: $(OBJDIR)/tests/test_agent_http.o \
+                                 $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
+                                $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o \
+                                $(OBJDIR)/server/agent_request_shaping.o \
+                                $(OBJDIR)/server/delegate_driver.o \
+                                $(OBJDIR)/server/delegate_openai.o \
+                                $(OBJDIR)/server/delegate_gemini.o \
+                                $(OBJDIR)/server/delegate_xml_fallback.o \
+                                $(OBJDIR)/model_registry.o \
+                                $(OBJDIR)/server/agent_tools.o \
+                                $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-mcp-native-surface: $(OBJDIR)/tests/test_mcp_native_surface.o \
                                  $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                 $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o \
                                 $(OBJDIR)/server/agent_request_shaping.o \

--- a/src/tests/test_acp_server.c
+++ b/src/tests/test_acp_server.c
@@ -229,23 +229,55 @@ static void test_update_notification(void)
 static void test_tool_update(void)
 {
    char out[2048];
-   /* started -> tool_call / in_progress, with title. */
-   assert(acp_build_tool_update("s1", "started", "read_file", out, sizeof(out)) == 1);
+   /* started -> tool_call / in_progress, with the tool name as the title and the
+    * caller's id as the handle. */
+   assert(acp_build_tool_update("s1", "read_file-1", "started", "read_file", out, sizeof(out)) ==
+          1);
    cJSON *o = parse(out);
    cJSON *u = cJSON_GetObjectItem(cJSON_GetObjectItem(o, "params"), "update");
    assert(strcmp(cJSON_GetObjectItem(u, "sessionUpdate")->valuestring, "tool_call") == 0);
-   assert(strcmp(cJSON_GetObjectItem(u, "toolCallId")->valuestring, "read_file") == 0);
+   assert(strcmp(cJSON_GetObjectItem(u, "toolCallId")->valuestring, "read_file-1") == 0);
    assert(strcmp(cJSON_GetObjectItem(u, "title")->valuestring, "read_file") == 0);
    assert(strcmp(cJSON_GetObjectItem(u, "status")->valuestring, "in_progress") == 0);
    cJSON_Delete(o);
-   /* completed -> tool_call_update / completed. */
-   assert(acp_build_tool_update("s1", "completed", "read_file", out, sizeof(out)) == 1);
+   /* completed -> tool_call_update / completed, carrying the SAME id so the client
+    * can find the call it updates. */
+   assert(acp_build_tool_update("s1", "read_file-1", "completed", "read_file", out, sizeof(out)) ==
+          1);
    o = parse(out);
    u = cJSON_GetObjectItem(cJSON_GetObjectItem(o, "params"), "update");
    assert(strcmp(cJSON_GetObjectItem(u, "sessionUpdate")->valuestring, "tool_call_update") == 0);
+   assert(strcmp(cJSON_GetObjectItem(u, "toolCallId")->valuestring, "read_file-1") == 0);
    assert(strcmp(cJSON_GetObjectItem(u, "status")->valuestring, "completed") == 0);
    cJSON_Delete(o);
    printf("  PASS: tool_update\n");
+}
+
+/* Two calls to the SAME tool in one session must not share a toolCallId.
+ *
+ * The id was the tool name, so an agent that read three files emitted three
+ * tool_calls under the id "read_file" — a client keys tool_call_update off the id
+ * to find the call it updates, so all three collapsed into one entry that flipped
+ * in_progress/completed as each landed. The ids are the caller's to number; this
+ * pins the contract that distinct calls get distinct handles. */
+static void test_tool_call_ids_are_unique_per_call(void)
+{
+   char a[2048], b[2048];
+   assert(acp_build_tool_update("s1", "read_file-1", "started", "read_file", a, sizeof(a)) == 1);
+   assert(acp_build_tool_update("s1", "read_file-2", "started", "read_file", b, sizeof(b)) == 1);
+   cJSON *oa = parse(a), *ob = parse(b);
+   const char *ida =
+       cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(oa, "params"), "update"),
+                           "toolCallId")
+           ->valuestring;
+   const char *idb =
+       cJSON_GetObjectItem(cJSON_GetObjectItem(cJSON_GetObjectItem(ob, "params"), "update"),
+                           "toolCallId")
+           ->valuestring;
+   assert(strcmp(ida, idb) != 0);
+   cJSON_Delete(oa);
+   cJSON_Delete(ob);
+   printf("  PASS: tool_call_ids_are_unique_per_call\n");
 }
 
 static void test_session_prompt_parse(void)
@@ -284,6 +316,7 @@ int main(void)
    test_prompt_parse();
    test_session_prompt_parse();
    test_tool_update();
+   test_tool_call_ids_are_unique_per_call();
    test_build_prompt_result();
    test_build_prompt_stop();
    test_session_load();

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -624,11 +624,66 @@ static void test_tool_profile_filter(void)
    cJSON_Delete(t);
 }
 
+static int tools_have(cJSON *tools, const char *name)
+{
+   cJSON *t = NULL;
+   cJSON_ArrayForEach(t, tools)
+   {
+      cJSON *n = cJSON_GetObjectItemCaseSensitive(t, "name");
+      if (cJSON_IsString(n) && strcmp(n->valuestring, name) == 0)
+         return 1;
+   }
+   return 0;
+}
+
+/* The flat list keeps family members; the collapsed one folds them away.
+ *
+ * mcp_collapse_families presents coherent families as ONE multiplexed tool
+ * (index{command:"find_callers"}) to keep an external client's tool count down.
+ * aimee's own agents need the individual names, because a toolset grants tools one
+ * at a time -- review_indexed gets index_find_callers but not index_hybrid, which a
+ * single `index` tool cannot express.
+ *
+ * The native advert first looked the flat names up in the COLLAPSED list, found
+ * nothing, and silently dropped every code-intelligence tool ("has no usable
+ * advert; not offered natively") -- while the toolset still resolved them. So a
+ * review panel was granted index_find_callers and never offered it. Dispatch was
+ * fine throughout (the flat names stay callable via mcp_family_demux); only the
+ * advert lied. Four green CI runs and a passing unit test with a faked provider all
+ * missed it; a real server on real hardware caught it in one line of log. */
+static void test_flat_list_keeps_family_members(void)
+{
+   cJSON *flat = mcp_build_tools_list_flat();
+   cJSON *collapsed = mcp_build_tools_list();
+
+   /* A family member: flat has the individual tool, collapsed folds it into `index`. */
+   assert(tools_have(flat, "index_find_callers"));
+   assert(!tools_have(collapsed, "index_find_callers"));
+   assert(tools_have(collapsed, "index"));
+   assert(!tools_have(flat, "index"));
+
+   /* Every tool the native surface declares must survive in the flat list, or it is
+    * registered, resolvable in a toolset, and never offered to the model. */
+   const char *native[] = {"index_find_callers", "index_blast_radius", "index_structure",
+                           "get_context_block",  "search_graph",       "ast_grep_search"};
+   for (size_t i = 0; i < sizeof(native) / sizeof(native[0]); i++)
+      assert(tools_have(flat, native[i]));
+
+   /* A non-family tool is in both: collapsing changes nothing for it. */
+   assert(tools_have(flat, "ast_grep_search") && tools_have(collapsed, "ast_grep_search"));
+
+   assert(cJSON_GetArraySize(flat) > cJSON_GetArraySize(collapsed));
+   cJSON_Delete(flat);
+   cJSON_Delete(collapsed);
+   printf("  PASS: flat_list_keeps_family_members\n");
+}
+
 int main(void)
 {
    printf("test_mcp_client_registry\n");
    test_tools_list_surface();
    test_tool_profile_filter();
+   test_flat_list_keeps_family_members();
    test_boot_and_lazy_tools();
    test_namespaced_tools_and_dispatch();
    test_failed_client_does_not_abort_boot();

--- a/src/tests/test_mcp_native_dispatch.c
+++ b/src/tests/test_mcp_native_dispatch.c
@@ -1,0 +1,128 @@
+/* test_mcp_native_dispatch.c: dispatch_tool_call routing for MCP-derived tools.
+ *
+ * The other half of the registry merge. test_mcp_native_surface pins the ADVERT
+ * (the tool reaches the model's tools array); this pins the DISPATCH (calling that
+ * name actually reaches the MCP handler and its output comes back as the plain
+ * string the native surface returns).
+ *
+ * Both halves have failed silently and differently in production:
+ *   - git_commit was MCP-only, so a delegate had no route to land work but `git`.
+ *   - index_find_callers was advertised-but-unroutable in an early cut of this
+ *     merge, and separately advertised from the COLLAPSED tools/list where its flat
+ *     name does not exist, so it was dropped from the advert while still resolving
+ *     in the toolset.
+ * Neither was caught by a test. Both were caught by running a server.
+ *
+ * The provider is faked: what is under test is the ROUTING (does the name reach the
+ * seam, is the fallthrough still "unknown tool", does the content flatten), not any
+ * MCP handler. tests/support/agent_dispatch_stubs.c satisfies the other td_*
+ * handlers' dependencies at link time — this TU pulls in every tool aimee has, and
+ * none of those paths run here. */
+#include "aimee.h" /* MAX_PATH_LEN via agent_types.h */
+#include "agent_tools.h"
+#include "cJSON.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FAKE_TOOL "index_find_callers"
+
+static int g_call_count;
+static char g_last_tool[64];
+static char g_last_args[256];
+
+static cJSON *fake_advert(const char *tool)
+{
+   if (!tool || strcmp(tool, FAKE_TOOL) != 0)
+      return NULL;
+   cJSON *t = cJSON_CreateObject();
+   cJSON_AddStringToObject(t, "name", FAKE_TOOL);
+   cJSON_AddStringToObject(t, "description", "Find the call sites of a symbol.");
+   cJSON *s = cJSON_AddObjectToObject(t, "inputSchema");
+   cJSON_AddStringToObject(s, "type", "object");
+   cJSON_AddObjectToObject(s, "properties");
+   return t;
+}
+
+/* Returns MCP content blocks, the shape every MCP handler returns. */
+static cJSON *fake_call(const char *tool, cJSON *args, const char *sid)
+{
+   (void)sid;
+   g_call_count++;
+   snprintf(g_last_tool, sizeof(g_last_tool), "%s", tool ? tool : "");
+   cJSON *sym = args ? cJSON_GetObjectItemCaseSensitive(args, "symbol") : NULL;
+   snprintf(g_last_args, sizeof(g_last_args), "%s",
+            (cJSON_IsString(sym) && sym->valuestring) ? sym->valuestring : "");
+   cJSON *content = cJSON_CreateArray();
+   cJSON *b1 = cJSON_CreateObject();
+   cJSON_AddStringToObject(b1, "type", "text");
+   cJSON_AddStringToObject(b1, "text", "toolset.c:137  in toolset_tool_known");
+   cJSON_AddItemToArray(content, b1);
+   cJSON *b2 = cJSON_CreateObject();
+   cJSON_AddStringToObject(b2, "type", "text");
+   cJSON_AddStringToObject(b2, "text", "server.c:2158  in server_init");
+   cJSON_AddItemToArray(content, b2);
+   return content;
+}
+
+/* A registered MCP tool's name reaches the provider, with its arguments, and the
+ * handler's content blocks come back flattened into the string the native surface
+ * hands the model. */
+static void test_registered_tool_dispatches_to_the_provider(void)
+{
+   g_call_count = 0;
+   agent_tools_set_mcp_provider(fake_call, fake_advert);
+   agent_tools_register_mcp_tool(FAKE_TOOL);
+
+   char *out = dispatch_tool_call(FAKE_TOOL, "{\"symbol\":\"toolset_tool_known\"}", 5000);
+   assert(out != NULL);
+   assert(g_call_count == 1);
+   assert(strcmp(g_last_tool, FAKE_TOOL) == 0);
+   /* The arguments survive the trip, not just the name. */
+   assert(strcmp(g_last_args, "toolset_tool_known") == 0);
+   /* Every text block is flattened, newline-joined — not just the first. */
+   assert(strstr(out, "toolset_tool_known") != NULL || strstr(out, "toolset.c:137") != NULL);
+   assert(strstr(out, "server.c:2158") != NULL);
+   assert(strstr(out, "\n") != NULL);
+   free(out);
+   printf("  PASS: registered_tool_dispatches_to_the_provider\n");
+}
+
+/* An unregistered name must still fall through to the unknown-tool error, not get
+ * swallowed by the MCP branch. This is the control that proves the routing is
+ * selective rather than a catch-all: on hardware it is what distinguished "the tool
+ * ran" from "the tool does not exist". */
+static void test_unregistered_name_still_reports_unknown(void)
+{
+   agent_tools_set_mcp_provider(fake_call, fake_advert);
+   char *out = dispatch_tool_call("definitely_not_a_tool", "{}", 5000);
+   assert(out != NULL);
+   assert(strstr(out, "unknown tool") != NULL);
+   free(out);
+   printf("  PASS: unregistered_name_still_reports_unknown\n");
+}
+
+/* With no provider registered (thin client, unit tests) a registered name must not
+ * pretend to work: it is never advertised, so reaching here means a caller invented
+ * the name, and the honest answer is an error rather than a crash on a NULL fn. */
+static void test_no_provider_is_an_error_not_a_crash(void)
+{
+   agent_tools_set_mcp_provider(NULL, NULL);
+   /* still "registered" from an earlier test — the provider is what is missing */
+   char *out = dispatch_tool_call(FAKE_TOOL, "{\"symbol\":\"x\"}", 5000);
+   assert(out != NULL);
+   assert(strstr(out, "error") != NULL);
+   free(out);
+   printf("  PASS: no_provider_is_an_error_not_a_crash\n");
+}
+
+int main(void)
+{
+   printf("test_mcp_native_dispatch:\n");
+   test_registered_tool_dispatches_to_the_provider();
+   test_unregistered_name_still_reports_unknown();
+   test_no_provider_is_an_error_not_a_crash();
+   printf("All mcp_native_dispatch tests passed.\n");
+   return 0;
+}

--- a/src/tests/test_mcp_native_surface.c
+++ b/src/tests/test_mcp_native_surface.c
@@ -1,0 +1,181 @@
+/* test_mcp_native_surface.c: the MCP-derived native tool surface.
+ *
+ * aimee's MCP table is the single source of truth for which tools exist; entries
+ * marked native are registered at startup so aimee's OWN agents get them too. This
+ * pins the half that only the server could exercise before: that a registered tool
+ * is ADVERTISED to the model, carrying the tool's own MCP schema.
+ *
+ * That half is exactly where this class of bug has always hidden. git_commit was
+ * MCP-only, so a delegate's only route to land work was shelling out to `git` --
+ * the thing require_aimee_git forbids. index_find_callers was MCP-only, so a review
+ * panel asked "is this still called?" hedged on a symbol with twelve callers one
+ * query away. Both read correctly and both shipped green; both were caught by
+ * running a delegate on hardware. A registry that resolves in a toolset but never
+ * reaches the model's tools array fails the same silent way.
+ *
+ * The provider is faked so this needs no server: the point under test is aimee's
+ * plumbing (advertise / schema / filter), not any one MCP handler. */
+#include "aimee.h" /* MAX_PATH_LEN, via agent_types.h */
+#include "agent_tools.h"
+#include "cJSON.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#define FAKE_TOOL "index_find_callers"
+
+static int g_advert_calls;
+
+/* Stands in for the real MCP tools/list entry: {"name","description","inputSchema"}. */
+static cJSON *fake_advert(const char *tool)
+{
+   g_advert_calls++;
+   if (!tool || strcmp(tool, FAKE_TOOL) != 0)
+      return NULL;
+   cJSON *t = cJSON_CreateObject();
+   cJSON_AddStringToObject(t, "name", FAKE_TOOL);
+   cJSON_AddStringToObject(t, "description", "Find the call sites of a symbol.");
+   cJSON *schema = cJSON_AddObjectToObject(t, "inputSchema");
+   cJSON_AddStringToObject(schema, "type", "object");
+   cJSON *props = cJSON_AddObjectToObject(schema, "properties");
+   cJSON *sym = cJSON_AddObjectToObject(props, "symbol");
+   cJSON_AddStringToObject(sym, "type", "string");
+   return t;
+}
+
+static cJSON *fake_call(const char *tool, cJSON *args, const char *sid)
+{
+   (void)args;
+   (void)sid;
+   cJSON *content = cJSON_CreateArray();
+   cJSON *block = cJSON_CreateObject();
+   cJSON_AddStringToObject(block, "type", "text");
+   cJSON_AddStringToObject(block, "text", tool);
+   cJSON_AddItemToArray(content, block);
+   return content;
+}
+
+/* Find a tool in an OpenAI Chat-format tools array: {type,function:{name,...}}. */
+static cJSON *find_chat_tool(cJSON *tools, const char *name)
+{
+   cJSON *t = NULL;
+   cJSON_ArrayForEach(t, tools)
+   {
+      cJSON *fn = cJSON_GetObjectItemCaseSensitive(t, "function");
+      cJSON *n = cJSON_GetObjectItemCaseSensitive(fn, "name");
+      if (cJSON_IsString(n) && strcmp(n->valuestring, name) == 0)
+         return fn;
+   }
+   return NULL;
+}
+
+/* Unregistered — a thin client or any binary without the server tier — must not
+ * advertise a tool that has no implementation behind it. An agent offered a tool
+ * that always errors is worse than one that was never offered it. */
+static void test_unregistered_advertises_nothing(void)
+{
+   agent_tools_set_mcp_provider(NULL, NULL);
+   assert(!agent_tools_is_mcp_derived(FAKE_TOOL));
+   cJSON *tools = build_tools_array();
+   assert(find_chat_tool(tools, FAKE_TOOL) == NULL);
+   cJSON_Delete(tools);
+   printf("  PASS: unregistered_advertises_nothing\n");
+}
+
+/* The registration reaches the model's tools array, carrying the tool's OWN schema.
+ *
+ * Reusing the MCP schema rather than hand-writing a native one is the point: a
+ * second hand-written schema is how git_commit came to advertise add_all and
+ * set_upstream, parameters its handler had never accepted. */
+static void test_registered_tool_is_advertised_with_its_mcp_schema(void)
+{
+   agent_tools_set_mcp_provider(fake_call, fake_advert);
+   agent_tools_register_mcp_tool(FAKE_TOOL);
+   assert(agent_tools_is_mcp_derived(FAKE_TOOL));
+
+   cJSON *tools = build_tools_array();
+   cJSON *fn = find_chat_tool(tools, FAKE_TOOL);
+   assert(fn != NULL);
+
+   cJSON *desc = cJSON_GetObjectItemCaseSensitive(fn, "description");
+   assert(cJSON_IsString(desc) && strstr(desc->valuestring, "call sites") != NULL);
+
+   /* The schema must arrive intact — not an empty object. A parameterless
+    * git_commit would be called wrong on the first turn. */
+   cJSON *params = cJSON_GetObjectItemCaseSensitive(fn, "parameters");
+   assert(params != NULL);
+   cJSON *props = cJSON_GetObjectItemCaseSensitive(params, "properties");
+   assert(props && cJSON_GetObjectItemCaseSensitive(props, "symbol") != NULL);
+   cJSON_Delete(tools);
+   printf("  PASS: registered_tool_is_advertised_with_its_mcp_schema\n");
+}
+
+/* Both native surfaces, not just the one that happened to be wired. The Responses
+ * API shape is flat (name/description/parameters at the top level) rather than
+ * nested under "function" — a tool present in one and missing from the other is
+ * invisible to whichever providers use that shape. */
+static void test_advertised_on_the_responses_surface_too(void)
+{
+   agent_tools_set_mcp_provider(fake_call, fake_advert);
+   agent_tools_register_mcp_tool(FAKE_TOOL);
+
+   cJSON *tools = build_tools_array_responses();
+   int found = 0;
+   cJSON *t = NULL;
+   cJSON_ArrayForEach(t, tools)
+   {
+      cJSON *n = cJSON_GetObjectItemCaseSensitive(t, "name");
+      if (cJSON_IsString(n) && strcmp(n->valuestring, FAKE_TOOL) == 0)
+      {
+         assert(cJSON_GetObjectItemCaseSensitive(t, "parameters") != NULL);
+         found = 1;
+      }
+   }
+   assert(found);
+   cJSON_Delete(tools);
+   printf("  PASS: advertised_on_the_responses_surface_too\n");
+}
+
+/* Registration is idempotent, and a tool with no usable advert is skipped rather
+ * than offered with an empty schema. */
+static void test_registration_is_idempotent_and_bad_advert_is_skipped(void)
+{
+   agent_tools_set_mcp_provider(fake_call, fake_advert);
+   agent_tools_register_mcp_tool(FAKE_TOOL);
+   agent_tools_register_mcp_tool(FAKE_TOOL);
+   agent_tools_register_mcp_tool(FAKE_TOOL);
+
+   cJSON *tools = build_tools_array();
+   int count = 0;
+   cJSON *t = NULL;
+   cJSON_ArrayForEach(t, tools)
+   {
+      cJSON *fn = cJSON_GetObjectItemCaseSensitive(t, "function");
+      cJSON *n = cJSON_GetObjectItemCaseSensitive(fn, "name");
+      if (cJSON_IsString(n) && strcmp(n->valuestring, FAKE_TOOL) == 0)
+         count++;
+   }
+   assert(count == 1); /* three registrations, advertised once */
+   cJSON_Delete(tools);
+
+   /* fake_advert returns NULL for anything else: registered, but unadvertisable. */
+   agent_tools_register_mcp_tool("tool_the_provider_does_not_know");
+   tools = build_tools_array();
+   assert(find_chat_tool(tools, "tool_the_provider_does_not_know") == NULL);
+   cJSON_Delete(tools);
+   printf("  PASS: registration_is_idempotent_and_bad_advert_is_skipped\n");
+}
+
+int main(void)
+{
+   printf("test_mcp_native_surface:\n");
+   /* Order matters: the unregistered case must run before anything registers,
+    * since the registry is process-global (the server registers once at startup). */
+   test_unregistered_advertises_nothing();
+   test_registered_tool_is_advertised_with_its_mcp_schema();
+   test_advertised_on_the_responses_surface_too();
+   test_registration_is_idempotent_and_bad_advert_is_skipped();
+   assert(g_advert_calls > 0); /* the schema really came from the provider */
+   printf("All mcp_native_surface tests passed.\n");
+   return 0;
+}

--- a/src/tests/test_toolset.c
+++ b/src/tests/test_toolset.c
@@ -92,6 +92,53 @@ static void test_git_write_tools_reach_coding_roles_only(void)
    printf("  git_write_tools_reach_coding_roles_only: ok\n");
 }
 
+/* find_callers must reach BOTH a reviewer and a coding delegate.
+ *
+ * It is the only tool that answers "is this still called?" — code_search is
+ * semantic (it matched a file not containing the symbol) and find_symbol returns
+ * definitions only. A review panel asked to judge a deletion had neither, so it
+ * hedged: "unsafe absent a full audit of call sites". The lens that asks for a
+ * call path is only honest while this resolves. */
+static void test_find_callers_reaches_reviewers_and_coders(void)
+{
+   /* The tool is declared native in the server's MCP table, which this binary does
+    * not link — so register it here exactly as mcp_tool_register_native_surface()
+    * would. That is the point of the check: the mechanism must carry a tool all the
+    * way from one declaration to a resolved role, through BOTH gates that used to
+    * need hand-editing (KNOWN_TOOLS, which silently pruned git_write's four tools,
+    * and toolset membership, which agent_tools_filter_for_role enforces). */
+   toolset_register_native_tool("index_find_callers", "core");
+   toolset_register_native_tool("index_find_callers", "review_indexed");
+
+   toolset_registry_t reg;
+   toolset_registry_init(&reg);
+   char tools[TOOLSET_MAX_TOOLS][TOOLSET_TOOL_MAX];
+   char err[TOOLSET_ERROR_MAX] = "";
+   const char *roles[] = {"review_indexed", "review",     "readonly",
+                          "code",           "full_stack", "script_rpc"};
+   for (size_t i = 0; i < sizeof(roles) / sizeof(roles[0]); i++)
+   {
+      int n = toolset_resolve(&reg, roles[i], tools, TOOLSET_MAX_TOOLS, err, sizeof(err));
+      assert(n > 0);
+      if (strcmp(roles[i], "script_rpc") == 0)
+         continue; /* the scripted RPC surface is pinned separately; not a reviewer */
+      assert(has_tool(tools, n, "index_find_callers"));
+   }
+   printf("  find_callers_reaches_reviewers_and_coders: ok\n");
+}
+
+/* A registration naming a set that does not exist must not invent it: an orphan set
+ * nothing includes would leave the tool advertised and unreachable — the silent
+ * failure this whole mechanism exists to end. It should be reported and dropped. */
+static void test_native_tool_unknown_toolset_is_not_invented(void)
+{
+   toolset_register_native_tool("index_find_callers", "no_such_toolset");
+   toolset_registry_t reg;
+   toolset_registry_init(&reg);
+   assert(toolset_registry_find(&reg, "no_such_toolset") == NULL);
+   printf("  native_tool_unknown_toolset_is_not_invented: ok\n");
+}
+
 /* review_indexed gives a reviewer aimee's branch-indexed capabilities and NO
  * filesystem/git tools, so a caller-provided-diff review cannot fall back to
  * reading a worktree it does not have. */
@@ -258,6 +305,7 @@ int main(void)
    printf("test_toolset:\n");
    test_full_stack_resolves_union();
    test_git_write_tools_reach_coding_roles_only();
+   test_find_callers_reaches_reviewers_and_coders();
    test_review_indexed_excludes_filesystem();
    test_cycle_rejected();
    test_unknown_tool_dropped();
@@ -266,6 +314,10 @@ int main(void)
    test_script_rpc_toolset();
    test_script_allowed_tools_config();
    test_script_allowed_tools_unknown_rejected();
+   /* Last: registrations are process-global (the server registers once at startup),
+    * so this test's deliberately-bad entry would otherwise re-report on every
+    * subsequent registry_init and drown the other tests' output. */
+   test_native_tool_unknown_toolset_is_not_invented();
    printf("All toolset tests passed.\n");
    return 0;
 }

--- a/src/toolset.c
+++ b/src/toolset.c
@@ -17,9 +17,19 @@ typedef struct
 } builtin_toolset_t;
 
 static const builtin_toolset_t BUILTINS[] = {
+    /* The code-intelligence tools (index_find_callers, index_blast_radius, ...) are
+     * NOT listed here: they are declared native in the server's MCP table and land in
+     * `core` and `review_indexed` by registration. One declaration, one schema, one
+     * handler shared with external MCP clients. */
     {"core",
      {NULL},
-     {"read_file", "list_files", "grep", "code_search", "find_symbol", "search_memory", NULL}},
+     {"read_file", "list_files", "grep", "code_search", "find_symbol", "search_memory",
+      /* aimee condenses long tool output and leaves a '[... ref "tc-..."]' pointer.
+       * The tool that expands it was advertised to every agent (TSURF_ALL) and named
+       * by no toolset, so agent_tools_filter_for_role stripped it from every role
+       * that has one: agents were handed a ref they had no tool to redeem. It
+       * belongs in core because the condensation applies to every tool. */
+      "tool_output_get", NULL}},
     {"git", {NULL}, {"git_status", "git_log", "git_diff", NULL}},
     /* Git WRITES, deliberately split from the read-only `git` set above: `git` is
      * inherited by `readonly` (and thence review), which must never gain the power
@@ -83,6 +93,7 @@ static const char *const KNOWN_TOOLS[] = {
     "test",
     "request_input",
     "code_search",
+    "tool_output_get",
     "web_search",
     "create_note",
     "list_notes",
@@ -121,6 +132,41 @@ static int name_valid(const char *name)
    return 1;
 }
 
+/* Tools registered from the MCP table at startup (see toolset_register_native_tool).
+ * Sized to hold every MCP tool: the intended end state is that most of them are
+ * native, so the table growing must never silently truncate. */
+typedef struct
+{
+   char name[TOOLSET_TOOL_MAX];
+   char toolset[TOOLSET_NAME_MAX];
+} registered_tool_t;
+
+static registered_tool_t g_registered[256];
+static int g_registered_count;
+
+void toolset_register_native_tool(const char *name, const char *toolset)
+{
+   if (!name || !name[0] || !toolset || !toolset[0])
+      return;
+   /* Dedup on the (tool, set) PAIR, not the name: one tool legitimately belongs to
+    * several sets — the code-intelligence tools go to coding roles and to review
+    * panelists both, and those sets do not include one another. */
+   for (int i = 0; i < g_registered_count; i++)
+      if (strcmp(g_registered[i].name, name) == 0 && strcmp(g_registered[i].toolset, toolset) == 0)
+         return; /* idempotent: re-registration is not an error */
+   if (g_registered_count >= (int)(sizeof(g_registered) / sizeof(g_registered[0])))
+   {
+      /* Loud: a dropped tool is exactly the silent-uncallable failure this
+       * registry exists to end. */
+      LOG_ERROR("toolset", "native tool registry full (%d); '%s' DROPPED and uncallable",
+                g_registered_count, name);
+      return;
+   }
+   registered_tool_t *r = &g_registered[g_registered_count++];
+   snprintf(r->name, sizeof(r->name), "%s", name);
+   snprintf(r->toolset, sizeof(r->toolset), "%s", toolset);
+}
+
 int toolset_tool_known(const char *name)
 {
    if (!name || !name[0])
@@ -129,6 +175,9 @@ int toolset_tool_known(const char *name)
       return 1;
    for (int i = 0; KNOWN_TOOLS[i]; i++)
       if (strcmp(KNOWN_TOOLS[i], name) == 0)
+         return 1;
+   for (int i = 0; i < g_registered_count; i++)
+      if (strcmp(g_registered[i].name, name) == 0)
          return 1;
    return 0;
 }
@@ -194,6 +243,21 @@ void toolset_registry_init(toolset_registry_t *registry)
          toolset_add_include(def, BUILTINS[i].include[j]);
       for (int j = 0; BUILTINS[i].tools[j]; j++)
          toolset_add_tool(def, BUILTINS[i].tools[j]);
+   }
+   /* Fold in the tools the server registered from the MCP table. A registration
+    * naming a set that does not exist is a typo in the MCP table, not a reason to
+    * invent a set: say so rather than create an orphan nothing includes. */
+   for (int i = 0; i < g_registered_count; i++)
+   {
+      if (!toolset_registry_find(registry, g_registered[i].toolset))
+      {
+         LOG_ERROR("toolset", "native tool '%s' names unknown toolset '%s'; not callable",
+                   g_registered[i].name, g_registered[i].toolset);
+         continue;
+      }
+      toolset_def_t *def = toolset_registry_upsert(registry, g_registered[i].toolset);
+      if (def)
+         toolset_add_tool(def, g_registered[i].name);
    }
 }
 


### PR DESCRIPTION
## Why

aimee had two tool tables that had to agree by hand. When they silently disagreed, the loser was always aimee's own agents:

- **`git_commit`/`git_push`/`git_pr` were MCP-only** — so the wfe implement delegate's only route to land work was shelling out to `git`, the exact thing `require_aimee_git` forbids.
- **`index_find_callers` was MCP-only** — so a review panel asked *"is this still called?"* had no tool that could answer, and hedged (*"unsafe absent a full audit of call sites"*) on a symbol with twelve callers one query away.

Both shipped green. Both were found by watching a delegate on real hardware, never by a test.

## The split had no structural reason

I assumed the tier boundary was real. It isn't:

| fact | evidence |
|---|---|
| Both surfaces run in **one process** | `src/Makefile:911` links `AGENT_OBJS` *and* `SERVER_OBJS` into `aimee-server`; `:893` links neither into the thin CLI |
| **79 of 82** MCP handlers are portable as-is | they touch only `c->jargs`/`c->sid`; **zero** need `c->ctx`; two need `c->conn` |
| The `cJSON`→`char*` adapter already exists | `td_git_write` |

So the split was history plus test-link convenience.

## What this does

`mcp_tool_table` becomes the **single source of truth**. A `native` column names the toolset(s) that get the tool as one of aimee's own agents:

```c
{"index_find_callers", mcph_index_find_callers, "core,review_indexed"},
{"get_help",           mcph_get_help,           NULL},  /* external clients only */
```

The server walks the table once at startup; the advert, the schema, the dispatch and the toolset membership all derive from that row. **Adding a tool with `native` set makes it native everywhere — you cannot forget a registry because there is only one.**

`-Wmissing-field-initializers` forces every row to state its intent.

### ACP and the CLI needed no work

Neither defines tools. ACP is a *view* of native dispatch (`sessionUpdate: tool_call`, fed by the `agent_tools_set_tool_event_cb` hook); `aimee mcp-serve` proxies to the server over `cli_v1_forward` — which is why the thin CLI links neither table. These two tables were the only ones in the codebase, so merging them is the single source of truth for **ACP, MCP and CLI** alike.

### Seams, not direct calls

8 test targets link `agent_tools.o` without the MCP table, `posix/` cannot link `server/` at all, and `KNOWN_TOOLS` is a static array in the base tier. So the server **registers** and the lower tiers hold pointers — the same shape as `wfe_set_forge_provider`. Unregistered (thin client, unit tests) nothing is advertised or dispatchable and every link is unchanged.

Reusing each tool's own MCP schema is deliberate: a second hand-written schema is how `git_commit` came to advertise `add_all`/`set_upstream`, parameters its handler never accepted.

### First tranche

The code intelligence the panel actually needed → `core` + `review_indexed`:
`index_find_callers`, `index_blast_radius`, `index_structure`, `get_context_block`, `search_graph`, `ast_grep_search`.

The hand-written `find_callers` from earlier today is **deleted** — the merge supersedes it, which is rather the point.

## Two real bugs found on the way

1. **`tool_output_get` was uncallable.** Advertised to every agent (`TSURF_ALL`) and dispatchable, but named by no toolset and missing from `KNOWN_TOOLS`, so `agent_tools_filter_for_role` stripped it from every role that has one. Agents were handed `[output condensed ... ref "tc-..."]` pointers with no tool to redeem them. Now in `core`, where it belongs — the condensation applies to every tool.
2. **6 stale `EXEMPT` entries** (`ensemble_*`, `spawn_agent`, `delegate`) name tools that aren't in the MCP table at all.

## Enforcement

`scripts/check-native-tool-parity.py`, wired into `make lint`. New drift fails the build. `BASELINE_DRIFT` records the pre-existing debt and **only shrinks** — a baselined tool that becomes native *must* leave the list, so it can't rot into a permanent excuse. **73 → 68** with this change. `--plant-test` proves the check still catches a planted violation.

## Testing

- `unit-test-toolset` drives the mechanism end to end: one registration → resolved in the roles that should have it, through both gates that used to need hand-editing (`KNOWN_TOOLS`, which silently ate `git_write`'s four tools; and toolset membership).
- New: a registration naming an unknown toolset is reported and dropped rather than inventing an orphan set nothing includes.
- `unit-test-agent-parallel`, `unit-test-mcp-client-registry` pass.
- Full `aimee-server` compiles (every object, including `server.o`); the final link fails **only** on my dev box, whose scratchpad-extracted static `libcrypto.a` wants zstd. CI does the real link.

## Not yet validated

**The runtime half is unproven.** `emit_mcp_tools` producing a valid advert and `td_mcp_tool` dispatching correctly both need the server running — and every bug in this class has been found on hardware, not in CI. Deploy + a panelist actually calling `index_find_callers` is the next step, before this is called done.

## Follow-ups

- Fold the `git_write` seam into the general provider (it needs its `path` fallback carried across — `mcp_chdir_git_root` reads `args["path"]`).
- Work `BASELINE_DRIFT` down: `lsp_references`, `lsp_definition`, `index_hybrid` are the next most valuable.
- Naming: MCP `index_find_callers` vs the deleted native `find_callers` — worth settling.
