### PR TITLE
feat(sandbox): call the container bind from the delegate turn

### DIFF
--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1323,6 +1323,25 @@ void delegate_worker(void *arg)
                    deleg_id);
       }
    }
+   /* Delegate sandbox (default OFF): run this delegate's shell and file ops INSIDE
+    * its own container rather than in-process here.
+    *
+    * Mutually exclusive with the detached binding above, and that is not a policy
+    * choice — a DETACHED workspace's files live on the CLIENT, served over the
+    * reverse channel, so a server-side container cannot see them. Binding both
+    * would silently replace the client's tree with an unrelated empty one. So the
+    * sandbox only applies where the files are already server-side: a shared
+    * workspace, or the ephemeral fallback above (whose client has disconnected).
+    *
+    * Bound AFTER the write guards and the detached/ephemeral resolution: those
+    * decide policy and WHICH tree, identical for every provider; this only changes
+    * WHERE the already-resolved I/O runs. Off — or if no container can be acquired
+    * — it returns 0 and the turn runs in-process exactly as today; the failure
+    * paths log at ERROR rather than falling back silently.
+    *
+    * Keyed by deleg_id, so each delegation gets its own container. */
+   int container_bound = detached_bound ? 0 : workspace_turn_bind_container(deleg_id, NULL);
+
    server_delegate_heartbeat_begin(cctx->background_job_id);
    rc = delegate_run_with_credential_retry(&acfg, target_agent, role, system_prompt, run_prompt,
                                            max_tokens, force_tools, delegate_allows_writes,
@@ -1332,6 +1351,11 @@ void delegate_worker(void *arg)
    concurrency_release_owner(conc_slot, deleg_id);
    delegate_run_ctx_restore(&run_ctx);
    if (detached_bound) /* unbind last: keep the binding live for any teardown that consults it */
+      workspace_turn_unbind_active();
+   /* Same call, and never both (see the bind): it clears the active pointer AND
+    * releases the container. Unconditional on this path so a pooled worker thread
+    * cannot carry a dead container into the next delegation. */
+   if (container_bound)
       workspace_turn_unbind_active();
    if (ephemeral_ws[0])
    {
@@ -1428,6 +1452,7 @@ void delegate_worker(void *arg)
    agent_tools_write_capable_set(1);
    if (parent_write_guard_active)
       agent_tools_parent_write_guard_clear();
+
    /* Server-initiated delegates review their own worktree (target is not
     * caller-supplied), so cwd-grounding applies. Threading a request-level
     * caller-provided-target signal here is a follow-up. */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1355,7 +1355,7 @@ $(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(
                                $(OBJDIR)/aimee_home.o \
                                $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                $(OBJDIR)/platform_random.o $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o $(OBJDIR)/server/presence.o $(OBJDIR)/server/turn_registry.o $(OBJDIR)/tests/support/agent_cancel_stub.o $(OBJDIR)/delivery_target.o \
-                               $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/server/workspace_provider_detached.o \
+                               $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/server/workspace_provider_container.o $(OBJDIR)/server/delegate_backend.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/server/workspace_provider_detached.o \
                                $(OBJDIR)/server/workspace_runner_registry.o $(OBJDIR)/server/workspace_runner_queue.o \
                                $(OBJDIR)/workspace_mirror.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o \
                                $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/json_fluent.o

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2224,7 +2224,7 @@ $(TESTPREFIX)/unit-test-workspace-runner-registry: \
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-workspace-turn: $(OBJDIR)/tests/test_workspace_turn.o \
-                      $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/tests/support/git_cred_inject_stub.o \
+                      $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/server/workspace_provider_container.o $(OBJDIR)/server/delegate_backend.o $(OBJDIR)/tests/support/git_cred_inject_stub.o \
                       $(OBJDIR)/server/workspace_provider_detached.o \
                       $(OBJDIR)/server/workspace_runner_registry.o \
                       $(OBJDIR)/server/workspace_runner_queue.o \

--- a/src/tests/test_workspace_turn.c
+++ b/src/tests/test_workspace_turn.c
@@ -5,6 +5,8 @@
 #include "workspace_turn.h"
 #include "workspace_provider.h"
 #include "config.h"
+#include "delegate_backend.h"
+#include "workspace_provider_container.h"
 #include "aimee_home.h"
 #include "platform_path.h"
 #include "platform_test_util.h"
@@ -14,6 +16,57 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* ── fake docker backend for the delegate-sandbox cases ───────────────────── */
+
+static int g_acquires, g_releases, g_last_hibernate, g_acquire_fails;
+static int g_fake_state = 1;
+
+static int fake_acquire(delegate_backend_t *self, const char *task_id,
+                        const delegate_backend_config_t *cfg, void **out)
+{
+   (void)self;
+   (void)task_id;
+   (void)cfg;
+   g_acquires++;
+   if (g_acquire_fails)
+      return -1;
+   *out = &g_fake_state;
+   return 0;
+}
+
+static void fake_release(delegate_backend_t *self, void *state, int hibernate)
+{
+   (void)self;
+   (void)state;
+   g_releases++;
+   g_last_hibernate = hibernate;
+}
+
+static int fake_exec(delegate_backend_t *self, void *state, const char *command, int timeout_ms,
+                     delegate_exec_result_t *r)
+{
+   (void)self;
+   (void)state;
+   (void)command;
+   (void)timeout_ms;
+   if (r)
+      r->exit_code = 0;
+   return 0;
+}
+
+/* Registered under the name "docker" so workspace_turn_bind_container finds it:
+ * the seam looks the backend up by name, and a test must not need a real daemon. */
+static delegate_backend_t g_fake_docker = {.name = "docker",
+                                           .description = "fake docker for tests",
+                                           .acquire = fake_acquire,
+                                           .release = fake_release,
+                                           .exec = fake_exec,
+                                           .read_file = NULL,
+                                           .write_file = NULL,
+                                           .list_dir = NULL,
+                                           .get_cwd = NULL,
+                                           .set_cwd = NULL};
 
 int main(void)
 {
@@ -112,6 +165,87 @@ int main(void)
       rc = safe_exec_capture_env(argv, NULL, &out, 256);
       assert(rc == 0 && out && out[0] == '\0');
       free(out);
+   }
+
+   /* ── delegate sandbox: workspace_turn_bind_container ─────────────────────
+    *
+    * Binding this is the difference between a delegate's shell running in its own
+    * container and running IN-PROCESS inside aimee-server with the server's
+    * filesystem and environment. Each case below is a way that distinction could
+    * silently collapse back to "on the host". */
+   {
+      delegate_backend_reset_for_test();
+      assert(delegate_backend_register(&g_fake_docker) == 0);
+
+      /* Dial OFF (the default): no container, no acquire, and the active provider
+       * is untouched — the turn runs in-process exactly as it does today. */
+      {
+         config_t c;
+         memset(&c, 0, sizeof(c));
+         config_load(&c);
+         c.delegate_sandbox = 0;
+         assert(config_save(&c) == 0);
+         g_acquires = g_releases = 0;
+         assert(workspace_turn_bind_container("deleg-1", NULL) == 0);
+         assert(g_acquires == 0); /* must not even try to take a container */
+         assert(workspace_provider_active() == shared);
+      }
+
+      /* Dial ON: acquires a container and binds a CONTAINER provider — not shared.
+       * If this ever resolved to `shared` the delegate would be on the host while
+       * the operator believed it was sandboxed. */
+      {
+         config_t c;
+         memset(&c, 0, sizeof(c));
+         config_load(&c);
+         c.delegate_sandbox = 1;
+         assert(config_save(&c) == 0);
+         g_acquires = g_releases = 0;
+         assert(workspace_turn_bind_container("deleg-2", NULL) == 1);
+         assert(g_acquires == 1);
+         const workspace_provider_t *p = workspace_provider_active();
+         assert(p != shared);
+         assert(p->kind == WS_PROVIDER_CONTAINER);
+
+         /* Unbind must RELEASE the container, not just drop the pointer: a leaked
+          * container outlives its turn and pins its workspace. And the active
+          * provider must go back to shared — a pooled worker thread that kept the
+          * binding would run the NEXT delegate's tools in a dead container. */
+         workspace_turn_unbind_active();
+         assert(g_releases == 1);
+         assert(workspace_provider_active() == shared);
+      }
+
+      /* Acquire failure must NOT bind: falling through with a half-bound provider
+       * would send every op to the host. It returns 0, so the caller runs
+       * in-process (and the seam logs at ERROR). */
+      {
+         g_acquires = g_releases = 0;
+         g_acquire_fails = 1;
+         assert(workspace_turn_bind_container("deleg-3", NULL) == 0);
+         assert(g_acquires == 1);
+         assert(g_releases == 0); /* nothing to release: it never took one */
+         assert(workspace_provider_active() == shared);
+         g_acquire_fails = 0;
+      }
+
+      /* An empty task_id is refused before any container is taken. */
+      {
+         g_acquires = 0;
+         assert(workspace_turn_bind_container("", NULL) == 0);
+         assert(workspace_turn_bind_container(NULL, NULL) == 0);
+         assert(g_acquires == 0);
+      }
+
+      /* No docker backend registered at all: the dial is on but there is nothing
+       * to bind to. Must refuse rather than silently run on the host. */
+      {
+         delegate_backend_reset_for_test();
+         g_acquires = 0;
+         assert(workspace_turn_bind_container("deleg-4", NULL) == 0);
+         assert(workspace_provider_active() == shared);
+      }
+      delegate_backend_reset_for_test();
    }
 
    printf("workspace_turn: all tests passed\n");


### PR DESCRIPTION
Slice 3 of the delegate sandbox. Follows #1366 (the provider + the bind + the dial). **Still default OFF** — but this is the commit where `delegate_sandbox` starts meaning something.

## The change

`server_compute`'s delegate turn now binds its file/exec into a per-delegate container:

```c
int container_bound = detached_bound ? 0 : workspace_turn_bind_container(deleg_id, NULL);
```

## Two things about the placement that are load-bearing

**1. Mutually exclusive with the detached binding — not by preference.** A DETACHED workspace's files live on the **client**, served over the reverse channel. A server-side container cannot see them, so binding both would silently swap the client's tree for an unrelated empty one. The sandbox only applies where the files are already server-side: a shared workspace, or the ephemeral fallback whose client has disconnected.

**2. My first cut was a use-after-free, not a style nit.** I had the bind *above* `workspace_turn_bind_active`. That function's first act is `t_turn_bound = 0` — so it silently clears the container's bound flag while the active pointer still aliases `&t_turn_container.base`. Unbind would then skip `clear_active`, release the container, and leave the active provider pointing **at the released container**.

Unbind pairs with the existing detached unbind (never both set) and releases the container — a pooled worker thread with a stale binding would run the *next* delegate's tools in a dead container.

## Testing

`unit-test-workspace-turn`, with a fake backend registered as `"docker"` — no daemon needed, because the seam looks the backend up by name:

| case | asserts |
|---|---|
| dial OFF | returns 0, does **not even attempt** an acquire, provider stays `shared` |
| dial ON | acquires; bound provider is `WS_PROVIDER_CONTAINER`, **not** `shared` |
| unbind | **releases** the container, restores `shared` |
| acquire fails | does not bind, nothing to release, stays `shared` |
| empty/NULL task_id | refused before any container is taken |
| no docker backend | refuses rather than silently running on the host |

Every one of those is a way the distinction between "sandboxed" and "running on the host with aimee-server's filesystem and environment" could silently collapse.

**Plant-tested both real failure modes:** removing the release (container leak) and ignoring an acquire failure (silent fallback) each abort the suite.

## Still to come

- **The source tree.** Per the operator ruling the container gets the *entire current tree*. Today a background delegate gets an empty `git init` dir whose own `AIMEE_WORKSPACE_NOTE.txt` admits *"the client's repository is NOT present here"* — the code comment at the ephemeral fallback says the same thing and calls it a follow-up. That's the next slice, and until it lands a container's `/workspace` is no better than the empty dir.
- `--network none` + the socket mount. **Must come after** aimee's own `web_search`/`web_read` exist — removing a capability before its replacement is the exact mistake of #1351.
- Lifting `review_indexed`'s filesystem exclusion once the tree is mounted read-only.