### PR TITLE
feat(sandbox): mount linked worktrees — the delegates that matter can now be sandboxed

### DIFF
--- a/src/headers/workspace_turn.h
+++ b/src/headers/workspace_turn.h
@@ -39,6 +39,14 @@ int workspace_turn_bind_active(const char *cwd);
  *
  * Unlike workspace_turn_bind_active this is not cwd-driven: a container provider
  * needs a live container handle, so the caller that owns the delegate decides. */
+/* Is `workspace` a tree aimee may hand a delegate? Canonicalizes into `out` (which
+ * is what the caller must then mount — the check and the mount must be the same
+ * path) and returns 1 if it lives inside a REGISTERED workspace root. Refusals are
+ * logged. Repository-ness is not authorization; the registered roots are the bound.
+ * Exposed so every path that can hand a workspace to the backend shares ONE bound —
+ * a second copy is a second thing to forget. */
+int workspace_turn_workspace_authorized(const char *workspace, char *out, size_t out_cap);
+
 int workspace_turn_bind_container(const char *task_id, const char *image, const char *workspace,
                                   int workspace_read_only);
 

--- a/src/server/delegate_backend_docker.c
+++ b/src/server/delegate_backend_docker.c
@@ -119,6 +119,16 @@ typedef struct
     * must not land root-owned. */
    int mount_host_tree;
    int mount_read_only; /* :ro — the tree is not this delegate's to change */
+   /* The in-container working directory, and what relative tool paths resolve
+    * against. Per-state, not the global resolve_docker_workdir(): a caller-provided
+    * tree is mounted at its OWN absolute host path (see docker_build_mounts), so
+    * /workspace is not where its files live. Anchoring resolution on a global while
+    * the mount moved is how a tool would read the wrong tree and report it as
+    * missing. */
+   char workdir[MAX_PATH_LEN];
+   /* Bind mounts for `docker create`, already in "<src>:<dst>[:ro]" form. */
+   char mounts[3][MAX_PATH_LEN * 2 + 8];
+   int mount_count;
 } docker_state_t;
 
 #define DOCKER_DEFAULT_IMAGE   "ubuntu:22.04"
@@ -210,6 +220,181 @@ static int run_docker(const char *const argv[])
    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
 }
 
+/* Read a linked worktree's `.git` pointer file: "gitdir: <absolute path>".
+ * Returns 0 and fills `out` on success. */
+static int docker_read_gitlink(const char *gitfile, char *out, size_t outsz)
+{
+   FILE *f = fopen(gitfile, "r");
+   if (!f)
+      return -1;
+   char line[MAX_PATH_LEN + 16];
+   if (!fgets(line, sizeof(line), f))
+   {
+      fclose(f);
+      return -1;
+   }
+   fclose(f);
+   const char *p = strstr(line, "gitdir:");
+   if (!p)
+      return -1;
+   p += 7;
+   while (*p == ' ' || *p == '\t')
+      p++;
+   size_t n = strlen(p);
+   while (n && (p[n - 1] == '\n' || p[n - 1] == '\r' || p[n - 1] == ' '))
+      n--;
+   if (!n || p[0] != '/' || n >= outsz)
+      return -1; /* must be absolute: a relative gitdir is not one we can mount */
+   memcpy(out, p, n);
+   out[n] = '\0';
+   return 0;
+}
+
+/* Add "<src>:<dst>[:ro]" to the state's mount list. */
+static int docker_add_mount(docker_state_t *st, const char *src, const char *dst, int ro)
+{
+   if (st->mount_count >= (int)(sizeof(st->mounts) / sizeof(st->mounts[0])))
+      return -1;
+   if ((size_t)snprintf(st->mounts[st->mount_count], sizeof(st->mounts[0]), "%s:%s%s", src, dst,
+                        ro ? ":ro" : "") >= sizeof(st->mounts[0]))
+      return -1;
+   st->mount_count++;
+   return 0;
+}
+
+/* Decide what to mount for a caller-provided tree `real` (already canonical).
+ *
+ * A LINKED WORKTREE's .git is a FILE holding `gitdir: <absolute host path>` into
+ * the main repo, so mounting the worktree alone leaves that path absent inside the
+ * container and every git command fails — after the delegate has started work,
+ * looking like a corrupt repo rather than a bad mount. Mounting the repo at its OWN
+ * absolute path makes the pointer resolve verbatim, with no rewriting.
+ *
+ * Isolation decides the modes, and they are measured, not assumed (validated on
+ * docker 26.1.5):
+ *   <repo>:ro     the whole tree is readable; a write outside the worktree fails
+ *                 with "Read-only file system"
+ *   <worktree>    this delegate's files, writable — a nested mount correctly
+ *                 overlays the read-only repo
+ *   <gitdir>      this delegate's git metadata, writable — `git status` refreshes
+ *                 its index here, so a read-only .git does not break it
+ * `git commit` inside then fails (blobs cannot be written to the :ro object store),
+ * which is intended: git_commit runs server-side and require_aimee_git forbids the
+ * shell route anyway.
+ *
+ * A PLAIN checkout needs none of that: one mount at its own absolute path.
+ * Returns 0 on success. */
+static int docker_build_mounts(docker_state_t *st, const char *real, int read_only)
+{
+   char gitmark[MAX_PATH_LEN];
+   if ((size_t)snprintf(gitmark, sizeof(gitmark), "%s/.git", real) >= sizeof(gitmark))
+   {
+      aimee_log(LOG_ERROR, "delegate-backend-docker",
+                "workspace path '%s' is too long to check for .git; refusing", real);
+      return -1;
+   }
+   struct stat gst;
+   if (lstat(gitmark, &gst) != 0)
+   {
+      aimee_log(LOG_ERROR, "delegate-backend-docker",
+                "workspace '%s' is not a git checkout (no .git); refusing to bind-mount an "
+                "arbitrary host directory into a delegate container",
+                real);
+      return -1;
+   }
+   if (S_ISLNK(gst.st_mode))
+   {
+      aimee_log(LOG_ERROR, "delegate-backend-docker",
+                "workspace '%s' has a symlinked .git; refusing to treat it as a checkout", real);
+      return -1;
+   }
+
+   if (S_ISDIR(gst.st_mode))
+   {
+      /* Plain checkout: the tree carries its own .git. Mount it at its own absolute
+       * path so paths inside the container match the host's. */
+      snprintf(st->workdir, sizeof(st->workdir), "%s", real);
+      return docker_add_mount(st, real, real, read_only);
+   }
+
+   /* Linked worktree. */
+   char gitdir[MAX_PATH_LEN];
+   if (docker_read_gitlink(gitmark, gitdir, sizeof(gitdir)) != 0)
+   {
+      aimee_log(LOG_ERROR, "delegate-backend-docker",
+                "workspace '%s': .git is a file but carries no absolute `gitdir:` pointer; "
+                "refusing rather than mounting a worktree whose git would be broken",
+                real);
+      return -1;
+   }
+   struct stat gdst;
+   if (stat(gitdir, &gdst) != 0 || !S_ISDIR(gdst.st_mode))
+   {
+      aimee_log(LOG_ERROR, "delegate-backend-docker",
+                "workspace '%s': gitdir '%s' does not exist on the host; refusing", real, gitdir);
+      return -1;
+   }
+   /* The repo root is what contains that gitdir: <repo>/.git/worktrees/<name>. */
+   const char *marker = strstr(gitdir, "/.git/");
+   if (!marker)
+   {
+      aimee_log(LOG_ERROR, "delegate-backend-docker",
+                "workspace '%s': gitdir '%s' is not under a <repo>/.git/ — cannot derive the repo "
+                "root to mount; refusing",
+                real, gitdir);
+      return -1;
+   }
+   char repo[MAX_PATH_LEN];
+   size_t rlen = (size_t)(marker - gitdir);
+   if (rlen == 0 || rlen >= sizeof(repo))
+      return -1;
+   memcpy(repo, gitdir, rlen);
+   repo[rlen] = '\0';
+
+   /* The worktree and its gitdir must live under that repo root, or the nested
+    * overlay does not apply and we would be mounting unrelated trees. */
+   size_t plen = strlen(repo);
+   if (strncmp(real, repo, plen) != 0 || (real[plen] != '/' && real[plen] != '\0'))
+   {
+      aimee_log(LOG_ERROR, "delegate-backend-docker",
+                "workspace '%s' is not inside its repo root '%s'; refusing (the nested "
+                "read-only overlay would not apply)",
+                real, repo);
+      return -1;
+   }
+
+   snprintf(st->workdir, sizeof(st->workdir), "%s", real);
+   /* Order matters: the repo first, then the writable parts nested over it. */
+   if (docker_add_mount(st, repo, repo, 1) != 0 ||
+       docker_add_mount(st, real, real, read_only) != 0 ||
+       docker_add_mount(st, gitdir, gitdir, read_only) != 0)
+      return -1;
+   aimee_log(LOG_INFO, "delegate-backend-docker",
+             "linked worktree '%s': mounting repo '%s' read-only with the worktree and its gitdir "
+             "%s over it",
+             real, repo, read_only ? "read-only" : "writable");
+   return 0;
+}
+
+/* 32-bit FNV-1a over the mount specs. The container is resumed by NAME
+ * (`docker start` first, create only on failure), so a task id reused with a
+ * DIFFERENT workspace would silently resume a container carrying the OLD mounts —
+ * the delegate would then work in the previous tree and nothing would say so. I hit
+ * exactly this while testing: containers created against one image were resumed and
+ * the new image ignored. Folding the mounts into the name makes a changed mount a
+ * different container by construction. */
+static unsigned docker_mounts_fingerprint(const docker_state_t *st)
+{
+   unsigned h = 2166136261u;
+   for (int i = 0; i < st->mount_count; i++)
+      for (const char *p = st->mounts[i]; *p; p++)
+      {
+         h ^= (unsigned char)*p;
+         h *= 16777619u;
+      }
+   return h;
+}
+
 static int docker_acquire(delegate_backend_t *self, const char *task_id,
                           const delegate_backend_config_t *cfg, void **state_out)
 {
@@ -232,13 +417,10 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
    snprintf(st->image, sizeof(st->image), "%s", image);
    if (cfg && cfg->workspace && cfg->workspace[0])
    {
-      /* Caller-provided tree: mount it AS the workspace, so the delegate gets the
-       * entire current source tree by bind-mount — it IS the tree, not a copy that
-       * can drift. Everything below is a refusal, and each one is a way a delegate
-       * could otherwise end up reasoning about a tree that is not the one it was
-       * told about. */
-
-      /* Canonicalize FIRST. stat() follows symlinks and so does the docker daemon,
+      /* Caller-provided tree: mount it so the delegate gets the entire current
+       * source tree — by bind-mount, so it IS the tree, not a copy that can drift.
+       *
+       * Canonicalize FIRST: stat() follows symlinks and so does the docker daemon,
        * so validating the path as given and mounting the same string would let a
        * symlinked component point the mount somewhere the checks never saw. */
       char real[MAX_PATH_LEN];
@@ -251,7 +433,6 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
          free(st);
          return -1;
       }
-
       struct stat wst;
       if (stat(real, &wst) != 0 || !S_ISDIR(wst.st_mode))
       {
@@ -260,64 +441,8 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
          free(st);
          return -1;
       }
-
-      /* It must be a git checkout. Not fussiness: it is what bounds the mount. The
-       * caller derives this path from a session cwd, so without this an unlucky or
-       * hostile cwd — '/', a secrets directory, the server's own checkout — becomes
-       * a read-write bind mount into a delegate's container. A repository root is a
-       * thing someone deliberately made; '/' is not. */
-      char gitmark[MAX_PATH_LEN];
-      if ((size_t)snprintf(gitmark, sizeof(gitmark), "%s/.git", real) >= sizeof(gitmark))
-      {
-         aimee_log(LOG_ERROR, "delegate-backend-docker",
-                   "workspace path '%s' is too long to check for .git; refusing", real);
-         free(st);
-         return -1;
-      }
-      /* lstat, not stat: a .git that is a SYMLINK is not a marker we should trust —
-       * it points outside the tree we just canonicalized, so the thing vouching for
-       * this directory lives somewhere the checks never looked. */
-      struct stat gst;
-      if (lstat(gitmark, &gst) != 0)
-      {
-         aimee_log(LOG_ERROR, "delegate-backend-docker",
-                   "workspace '%s' is not a git checkout (no .git); refusing to bind-mount an "
-                   "arbitrary host directory into a delegate container",
-                   real);
-         free(st);
-         return -1;
-      }
-
-      /* A LINKED worktree's .git is a FILE holding `gitdir: <absolute host path>`
-       * into the main repo. Mounting only the worktree leaves that path absent
-       * inside the container, so every git command fails — and it fails AFTER the
-       * delegate has started work, looking like a broken repo rather than a bad
-       * mount. Refuse until the mount can carry the common gitdir too (mounting the
-       * main repo at its own absolute path, so the gitlink resolves).
-       *
-       * This is the wfe delegate's case, so the sandbox does not cover it yet. Said
-       * out loud, at acquire time, rather than discovered by a delegate. */
-      if (S_ISLNK(gst.st_mode))
-      {
-         aimee_log(LOG_ERROR, "delegate-backend-docker",
-                   "workspace '%s' has a symlinked .git; refusing to treat it as a checkout", real);
-         free(st);
-         return -1;
-      }
-      if (S_ISREG(gst.st_mode))
-      {
-         aimee_log(LOG_ERROR, "delegate-backend-docker",
-                   "workspace '%s' is a linked git worktree (.git is a gitdir pointer, not a "
-                   "directory): mounting it alone would leave git broken inside the container. "
-                   "Refusing — worktree support needs the common gitdir mounted too",
-                   real);
-         free(st);
-         return -1;
-      }
-
-      /* Copy the CANONICAL path, and refuse truncation: a path that passed the
-       * checks above but does not fit would mount a different directory than the
-       * one that was validated. */
+      /* Refuse truncation: a path that passed the checks but does not fit would
+       * mount a different directory than the one that was validated. */
       if ((size_t)snprintf(st->workspace_host, sizeof(st->workspace_host), "%s", real) >=
           sizeof(st->workspace_host))
       {
@@ -328,8 +453,13 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
          free(st);
          return -1;
       }
-      st->mount_host_tree = 1;
       st->mount_read_only = (cfg->workspace_read_only != 0);
+      if (docker_build_mounts(st, real, st->mount_read_only) != 0)
+      {
+         free(st);
+         return -1;
+      }
+      st->mount_host_tree = 1;
    }
    else if (compute_workspace_host(task_id, st->workspace_host, sizeof(st->workspace_host)) != 0 ||
             docker_mkdir_p(st->workspace_host) != 0)
@@ -337,7 +467,34 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
       free(st);
       return -1;
    }
-   snprintf(st->cwd, sizeof(st->cwd), "%s", resolve_docker_workdir());
+   else
+   {
+      /* Our own scratch dir: keep the historical /workspace contract. */
+      snprintf(st->workdir, sizeof(st->workdir), "%s", resolve_docker_workdir());
+      if (docker_add_mount(st, st->workspace_host, st->workdir, 0) != 0)
+      {
+         free(st);
+         return -1;
+      }
+   }
+   snprintf(st->cwd, sizeof(st->cwd), "%s", st->workdir);
+
+   /* Fold the mounts into the container's identity. `docker start` resumes by name,
+    * so without this a task id reused with a different workspace resumes a container
+    * carrying the OLD mounts, and the delegate works in the previous tree with
+    * nothing to say so. Only for caller-provided trees: the scratch dir is derived
+    * from the task id already, and hibernate/resume there is the point. */
+   if (st->mount_host_tree)
+   {
+      char suffix[16];
+      snprintf(suffix, sizeof(suffix), "-%08x", docker_mounts_fingerprint(st));
+      size_t have = strlen(st->container_name);
+      if (have + strlen(suffix) < sizeof(st->container_name))
+         memcpy(st->container_name + have, suffix, strlen(suffix) + 1);
+      else /* truncating would collide two different mount sets onto one name */
+         snprintf(st->container_name + sizeof(st->container_name) - sizeof(suffix), sizeof(suffix),
+                  "%s", suffix);
+   }
 
    /* Try `docker start` first — if a container with this name already
     * exists (operator opted hibernate=1 last release), starting it
@@ -345,11 +502,6 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
    const char *start_argv[] = {"docker", "start", st->container_name, NULL};
    if (run_docker(start_argv) != 0)
    {
-      /* Build the volume mount string: <host>:/workspace */
-      const char *workdir = resolve_docker_workdir();
-      char mount[MAX_PATH_LEN + 32];
-      snprintf(mount, sizeof(mount), "%s:%s%s", st->workspace_host, workdir,
-               st->mount_read_only ? ":ro" : "");
       /* Run as the server's uid:gid when the mount is the caller's real tree.
        * Containers run as root by default, so every file the delegate creates in
        * the user's checkout would land root-owned — the user could not then edit
@@ -360,7 +512,9 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
       if (st->mount_host_tree)
          snprintf(userflag, sizeof(userflag), "%u:%u", (unsigned)getuid(), (unsigned)getgid());
 
-      const char *create_argv[12 + 2];
+      /* Sized from the mount array itself: a hand-counted bound silently overflows
+       * the day a fourth mount is added. */
+      const char *create_argv[16 + 2 * (sizeof(st->mounts) / sizeof(st->mounts[0]))];
       int n = 0;
       create_argv[n++] = "docker";
       create_argv[n++] = "create";
@@ -371,10 +525,13 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
          create_argv[n++] = "--user";
          create_argv[n++] = userflag;
       }
-      create_argv[n++] = "-v";
-      create_argv[n++] = mount;
+      for (int m = 0; m < st->mount_count; m++)
+      {
+         create_argv[n++] = "-v";
+         create_argv[n++] = st->mounts[m];
+      }
       create_argv[n++] = "-w";
-      create_argv[n++] = workdir;
+      create_argv[n++] = st->workdir;
       create_argv[n++] = st->image;
       create_argv[n++] = "sleep";
       create_argv[n++] = "infinity";
@@ -631,7 +788,8 @@ static int docker_resolve_in_workspace(const docker_state_t *st, const char *rel
       if (*p == '/')
          p++;
    }
-   if (snprintf(out, outsz, "%s/%s", resolve_docker_workdir(), rel) >= (int)outsz)
+   if (snprintf(out, outsz, "%s/%s", st->workdir[0] ? st->workdir : resolve_docker_workdir(),
+                rel) >= (int)outsz)
       return -1;
    return 0;
 }

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -24,6 +24,7 @@
 #include "config.h"     /* config_t / config_load for api.status, api.enable */
 #include "delegate_backend_docker.h"
 #include "workspace_provider.h" /* the shared provider: probe docker for the sandbox posture */
+#include "workspace_turn.h"     /* the ONE workspace bound, shared with the delegate turn */
 #include "delegate_backend_local.h"
 #include "delegate_backend_ssh.h"
 #include "server_delegate_monitor.h"
@@ -444,6 +445,9 @@ static int handle_delegate_backend_list(server_ctx_t *ctx, server_conn_t *conn, 
  *   task_id       (required) — workspace identifier
  *   command       (required) — bash command line for exec()
  *   image         (optional) — docker image hint
+ *   workspace     (optional) — host dir to expose AS the workspace (a checkout or
+ *                              a linked worktree); default = the backend's scratch
+ *   workspace_read_only (optional bool) — mount `workspace` :ro
  *   host          (optional) — ssh target
  *   no_hibernate  (optional bool) — release with hibernate=0 if true
  * Response fields:
@@ -471,6 +475,29 @@ static int handle_delegate_backend_exec(server_ctx_t *ctx, server_conn_t *conn, 
    cJSON *jhost = cJSON_GetObjectItemCaseSensitive(req, "host");
    if (cJSON_IsString(jhost))
       cfg.host = jhost->valuestring;
+   /* The workspace to expose to the container, and whether it is the delegate's to
+    * change. This RPC exists to smoke-test the registry end-to-end without the
+    * legacy delegate flow, and the mount is the part that most needs a real daemon
+    * to believe: a linked worktree's gitlink only resolves if the repo is mounted
+    * at its own absolute path, which no unit test can prove. */
+   cJSON *jws = cJSON_GetObjectItemCaseSensitive(req, "workspace");
+   char ws_authorized[MAX_PATH_LEN] = "";
+   if (cJSON_IsString(jws) && jws->valuestring[0])
+   {
+      /* Through the SAME bound the delegate turn uses. This RPC takes a path from a
+       * request, so without it any caller who can reach the registry could name any
+       * host directory and have it bind-mounted into a container. The seam having
+       * the check is not enough — a second entrance needs the same lock, and the
+       * helper exists precisely so there is one lock rather than two copies. */
+      if (!workspace_turn_workspace_authorized(jws->valuestring, ws_authorized,
+                                               sizeof(ws_authorized)))
+         return server_send_error(conn, "workspace not inside a registered workspace root",
+                                  jws->valuestring);
+      cfg.workspace = ws_authorized;
+   }
+   cJSON *jro = cJSON_GetObjectItemCaseSensitive(req, "workspace_read_only");
+   if (cJSON_IsBool(jro) && cJSON_IsTrue(jro))
+      cfg.workspace_read_only = 1;
    cJSON *jnh = cJSON_GetObjectItemCaseSensitive(req, "no_hibernate");
    if (cJSON_IsBool(jnh) && cJSON_IsTrue(jnh))
       cfg.hibernate_on_exit = 0;

--- a/src/server/workspace_turn.c
+++ b/src/server/workspace_turn.c
@@ -295,6 +295,61 @@ int workspace_turn_bind_active(const char *cwd)
    return 0; /* cwd not in any registered workspace */
 }
 
+/* Is `workspace` a tree aimee may hand a delegate? Canonicalizes into `out` and
+ * returns 1 if it lives inside one of the operator's REGISTERED workspace roots.
+ *
+ * Repository-ness is NOT authorization: `mkdir .git` in any directory satisfies
+ * that, so the backend's own .git check is a backstop, not the bound. The bound is
+ * the registered roots — the same list workspace_turn_bind_active resolves a turn's
+ * cwd against. A path outside them is not a workspace the operator ever offered
+ * aimee, and bind-mounting it into a delegate container would expose whatever it
+ * happens to be: a home directory, a secrets tree, `/`.
+ *
+ * Canonicalize first: the check and the mount must be the same path, and both
+ * stat() and the docker daemon follow symlinks. */
+int workspace_turn_workspace_authorized(const char *workspace, char *out, size_t out_cap)
+{
+   if (out && out_cap)
+      out[0] = '\0';
+   if (!workspace || !workspace[0] || !out || out_cap == 0)
+      return 0;
+   char real[MAX_PATH_LEN];
+   if (!realpath(workspace, real))
+   {
+      LOG_ERROR("delegate-sandbox", "workspace '%s' does not resolve (%s)", workspace,
+                strerror(errno));
+      return 0;
+   }
+   config_t cfg;
+   config_load(&cfg);
+   for (int i = 0; i < cfg.workspace_count; i++)
+   {
+      char root_real[MAX_PATH_LEN];
+      if (!realpath(cfg.workspaces[i], root_real))
+         continue;
+      /* "/" as a registered root would authorize every path on the host, which is
+       * not a workspace registration — it is the absence of one. */
+      if (strcmp(root_real, "/") == 0)
+      {
+         LOG_WARN("delegate-sandbox",
+                  "ignoring registered workspace root '/' for sandbox authorization: it would "
+                  "authorize every directory on the host");
+         continue;
+      }
+      if (cwd_in_workspace(real, root_real))
+      {
+         snprintf(out, out_cap, "%s", real);
+         return 1;
+      }
+   }
+   LOG_ERROR("delegate-sandbox",
+             "refusing to mount '%s' — it is not inside any registered workspace root (%d "
+             "registered). A directory the operator never registered is not a tree aimee may "
+             "hand a delegate",
+             real, cfg.workspace_count);
+   return 0;
+}
+
 int workspace_turn_bind_container(const char *task_id, const char *image, const char *workspace,
                                   int workspace_read_only)
 {
@@ -306,59 +361,10 @@ int workspace_turn_bind_container(const char *task_id, const char *image, const 
    if (!cfg.delegate_sandbox)
       return 0; /* default off: the delegate keeps running in-process, as today */
 
-   /* Authorize the tree before handing it to the backend as a bind mount.
-    *
-    * Repository-ness is NOT authorization: `mkdir .git` in any directory would
-    * satisfy that, so the backend's own .git check is a backstop, not the bound.
-    * The bound is the operator's REGISTERED workspace roots — the same list
-    * workspace_turn_bind_active resolves a turn's cwd against. A path outside them
-    * is not a workspace the operator ever offered aimee, and bind-mounting it
-    * read-write into a delegate container would expose whatever it happens to be:
-    * a home directory, a secrets tree, `/`, the server's own checkout.
-    *
-    * Canonicalize first — the check and the mount must be the same path, and both
-    * stat() and the docker daemon follow symlinks. */
    char ws_real[MAX_PATH_LEN] = "";
-   if (workspace && workspace[0])
-   {
-      if (!realpath(workspace, ws_real))
-      {
-         LOG_ERROR("delegate-sandbox",
-                   "delegate '%s': workspace '%s' does not resolve (%s); not binding a container",
-                   task_id, workspace, strerror(errno));
-         return 0;
-      }
-      int authorized = 0;
-      for (int i = 0; i < cfg.workspace_count; i++)
-      {
-         char root_real[MAX_PATH_LEN];
-         if (!realpath(cfg.workspaces[i], root_real))
-            continue;
-         /* "/" as a registered root would authorize every path on the host, which
-          * is not a workspace registration — it is the absence of one. */
-         if (strcmp(root_real, "/") == 0)
-         {
-            LOG_WARN("delegate-sandbox",
-                     "ignoring registered workspace root '/' for sandbox authorization: it would "
-                     "authorize every directory on the host");
-            continue;
-         }
-         if (cwd_in_workspace(ws_real, root_real))
-         {
-            authorized = 1;
-            break;
-         }
-      }
-      if (!authorized)
-      {
-         LOG_ERROR("delegate-sandbox",
-                   "delegate '%s': refusing to mount '%s' — it is not inside any registered "
-                   "workspace root (%d registered). A directory the operator never registered is "
-                   "not a tree aimee may hand a delegate; the turn stays in-process",
-                   task_id, ws_real, cfg.workspace_count);
-         return 0;
-      }
-   }
+   if (workspace && workspace[0] &&
+       !workspace_turn_workspace_authorized(workspace, ws_real, sizeof(ws_real)))
+      return 0; /* refused + logged; the turn stays in-process */
 
    delegate_backend_t *b = delegate_backend_lookup("docker");
    if (!b || !b->acquire)

--- a/src/tests/test_delegate_backend_docker.c
+++ b/src/tests/test_delegate_backend_docker.c
@@ -596,21 +596,66 @@ static void test_docker_workspace_validation_refusals(void)
    assert(b->acquire(b, "task-val-1", &cfg, &state) == -1);
    assert(state == NULL);
 
-   /* A LINKED worktree (.git is a gitdir POINTER FILE): mounting it alone leaves
-    * git broken inside the container, and broken AFTER the delegate starts work —
-    * looking like a corrupt repo rather than a bad mount. */
-   char wt[300];
-   snprintf(wt, sizeof(wt), "%s/worktree", base);
-   mkdir(wt, 0700);
-   char gitfile[400];
-   snprintf(gitfile, sizeof(gitfile), "%s/.git", wt);
-   FILE *g = fopen(gitfile, "w");
-   assert(g != NULL);
-   fputs("gitdir: /some/host/path/.git/worktrees/x\n", g);
-   fclose(g);
-   cfg.workspace = wt;
-   assert(b->acquire(b, "task-val-2", &cfg, &state) == -1);
-   assert(state == NULL);
+   /* A LINKED worktree is now MOUNTED, not refused: the repo goes in read-only at
+    * its own absolute path so the gitlink resolves verbatim, with the worktree and
+    * its gitdir nested writable over it. Validated on docker 26.1.5: git status
+    * refreshes its index in the per-worktree gitdir, git describe works, and a
+    * write outside the worktree fails with "Read-only file system". */
+   char repo[300];
+   snprintf(repo, sizeof(repo), "%s/repo", base);
+   char repogit[400];
+   snprintf(repogit, sizeof(repogit), "%s/.git", repo);
+   char wtdir[500];
+   snprintf(wtdir, sizeof(wtdir), "%s/worktrees/task01", repogit);
+   char cmd2[900];
+   snprintf(cmd2, sizeof(cmd2), "mkdir -p %s %s/.aimee/worktrees/k/task01", wtdir, repo);
+   (void)system(cmd2);
+   char wt2[400];
+   snprintf(wt2, sizeof(wt2), "%s/.aimee/worktrees/k/task01", repo);
+   char gitfile2[500];
+   snprintf(gitfile2, sizeof(gitfile2), "%s/.git", wt2);
+   FILE *g2 = fopen(gitfile2, "w");
+   assert(g2 != NULL);
+   fprintf(g2, "gitdir: %s\n", wtdir);
+   fclose(g2);
+
+   cfg.workspace = wt2;
+   cfg.workspace_read_only = 0;
+   assert(b->acquire(b, "task-wt", &cfg, &state) == 0);
+   {
+      char *l = read_fake_docker_create_argv();
+      assert(l != NULL);
+      /* the repo mounted READ-ONLY at its own path — the gitlink target */
+      char m_repo[700];
+      snprintf(m_repo, sizeof(m_repo), "%s:%s:ro", repo, repo);
+      assert(strstr(l, m_repo) != NULL);
+      /* the worktree writable, nested over it */
+      char m_wt[900];
+      snprintf(m_wt, sizeof(m_wt), "%s:%s", wt2, wt2);
+      assert(strstr(l, m_wt) != NULL);
+      /* the per-worktree gitdir writable — this is where git status writes its index */
+      char m_gd[1100];
+      snprintf(m_gd, sizeof(m_gd), "%s:%s", wtdir, wtdir);
+      assert(strstr(l, m_gd) != NULL);
+      /* and the workdir is the worktree, not /workspace */
+      assert(strstr(l, wt2) != NULL);
+      free(l);
+   }
+   b->release(b, state, 0);
+
+   /* A worktree whose .git carries no absolute gitdir cannot be mounted usefully:
+    * refuse rather than leave git broken inside the container. */
+   char wtbad[400];
+   snprintf(wtbad, sizeof(wtbad), "%s/wtbad", base);
+   mkdir(wtbad, 0700);
+   char gbad[500];
+   snprintf(gbad, sizeof(gbad), "%s/.git", wtbad);
+   FILE *fb = fopen(gbad, "w");
+   assert(fb != NULL);
+   fputs("gitdir: ../relative/path\n", fb);
+   fclose(fb);
+   cfg.workspace = wtbad;
+   assert(b->acquire(b, "task-wtbad", &cfg, &state) == -1);
 
    /* A symlink to a valid checkout must not slip past canonicalization: stat()
     * follows symlinks and so does the daemon, so the mount could land somewhere

--- a/src/tests/test_workspace_turn.c
+++ b/src/tests/test_workspace_turn.c
@@ -270,6 +270,29 @@ int main(void)
          workspace_turn_unbind_active();
       }
 
+      /* The shared bound itself: every entrance that can hand a workspace to the
+       * backend must go through this ONE check. A second copy is a second thing to
+       * forget, which is how the delegate.backend_exec RPC came to accept any host
+       * path while the seam refused them. */
+      {
+         char outp[MAX_PATH_LEN] = "";
+         mkdir("/tmp/ws-shared", 0700);
+         assert(workspace_turn_workspace_authorized("/tmp/ws-shared", outp, sizeof(outp)) == 1);
+         assert(strcmp(outp, "/tmp/ws-shared") == 0); /* canonical, and what to mount */
+
+         mkdir("/tmp/aimee-outside-roots", 0700);
+         outp[0] = 'x';
+         assert(workspace_turn_workspace_authorized("/tmp/aimee-outside-roots", outp,
+                                                    sizeof(outp)) == 0);
+         assert(outp[0] == '\0');
+         rmdir("/tmp/aimee-outside-roots");
+
+         assert(workspace_turn_workspace_authorized(NULL, outp, sizeof(outp)) == 0);
+         assert(workspace_turn_workspace_authorized("", outp, sizeof(outp)) == 0);
+         assert(workspace_turn_workspace_authorized("/tmp/does-not-exist-at-all", outp,
+                                                    sizeof(outp)) == 0);
+      }
+
       /* A registered root of "/" must NOT authorize the whole host: that is not a
        * workspace registration, it is the absence of one. */
       {


### PR DESCRIPTION
Slice 5. Follows #1366 / #1367 / #1368. **Still default OFF.**

## The gap this closes

#1368 **refused** linked worktrees, so the sandbox did not cover write-capable wfe delegates — the ones that matter. A worktree's `.git` is a *file* holding `gitdir: <absolute host path>`; mounting the worktree alone leaves that path absent inside the container, so every git command fails **after** the delegate starts work, looking like a corrupt repo rather than a bad mount.

## The fix

Mount the repo at its **own absolute path** so the pointer resolves verbatim — no rewriting — and nest the writable parts over it:

```
-v <repo>:<repo>:ro                          whole tree readable
-v <worktree>:<worktree>[:ro]                this delegate's files
-v <repo>/.git/worktrees/<name>:<same>[:ro]  this delegate's git metadata
-w <worktree>
```

**Everything writable is per-delegate; everything shared is `:ro`.** A plain checkout keeps one mount at its own absolute path.

## Measured end-to-end, not argued

This binary, the real backend via `delegate.backend_exec`, **docker 26.1.5**, a real repo with a real linked worktree:

| check | result |
|---|---|
| `git status` in the worktree | `?? isolated.txt`, **rc=0** — gitlink resolves; the index refreshes in the `:rw` gitdir, so a read-only `.git` does **not** break status |
| `git describe --tags` | **`v1.0`** — builds that shell out to git work against a `:ro` object store |
| write **outside** the worktree | `bash: /root/repo/main.c: Read-only file system` |
| write **inside** the worktree | succeeded; host confirms main tree untouched, worktree holds the file |

`git commit` inside still fails — blobs can't be written to the `:ro` object store. That's intended: `git_commit` runs server-side and `require_aimee_git` forbids the shell route.

## Roundtable — 5 verified, 15 rejected at verification

Three were real:

1. **`create_argv` was hand-sized for exactly 3 mounts.** A 4th would overflow the stack silently. Now sized from the mount array itself.
2. **`delegate.backend_exec` accepted a `workspace` with no bound**, while the delegate seam enforced registered roots. A second entrance needs the same lock — it's now **one shared helper** (`workspace_turn_workspace_authorized`). Verified on hardware: the RPC answers `workspace not inside a registered workspace root`.
3. **`docker start` resumes by name**, so a task id reused with a *different* workspace silently resumed a container carrying the **old mounts**. **I hit exactly this while testing** — containers built against one image were resumed and the new image ignored. The mounts are now folded into the container identity. Verified: one task id + two workspaces → two containers (`...-2af6d495`, `...-7a8f436c`), each `pwd`-ing into its own tree.

## Also

`st->workdir` is now **per-state**, and `docker_resolve_in_workspace` anchors on it instead of the global `resolve_docker_workdir()`. A caller tree is mounted at its own absolute path, so `/workspace` isn't where its files live — resolving against a global while the mount moved is how a tool reads the wrong tree and reports it missing.

`delegate.backend_exec` gains `workspace` / `workspace_read_only`. That RPC exists to smoke-test the registry without the legacy delegate flow, and the mount is the part that most needs a real daemon to believe: no unit test can prove a gitlink resolves.

`make unit-tests` and `make lint` pass locally end-to-end.