### PR TITLE
fix(test): sandbox AIMEE_HOME in test_agent — stop deleting the live agents.json

### DIFF
--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -2420,8 +2420,19 @@ int main(void)
    snprintf(tmp_home, sizeof(tmp_home), "%s/aimee-test-agent-home-XXXXXX", platform_tmpdir());
    assert(platform_mkdtemp(tmp_home) != NULL);
    assert(platform_setenv("HOME", tmp_home) == 0);
+   /* AIMEE_HOME OVERRIDES HOME in aimee_home(), so sandboxing HOME alone is a
+    * no-op anywhere AIMEE_HOME is set - which is every deployed server (the
+    * appliance runs with AIMEE_HOME=/var/lib/aimee). Tests below write to and
+    * unlink() agent_config_path(); without this line they destroy the
+    * operator's real agents.json. Set it before any config or agent call. */
+   assert(platform_setenv("AIMEE_HOME", tmp_home) == 0);
    assert(platform_setenv("AIMEE_NO_CACHE", "1") == 0);
    assert(config_output_dir()[0] != '\0');
+
+   /* Guard the sandbox itself: if agent_config_path() ever resolves outside the
+    * temp home, this suite is about to eat real operator config. Fail loudly
+    * here rather than silently deleting it. */
+   assert(strncmp(agent_config_path(), tmp_home, strlen(tmp_home)) == 0);
    session_id_set_override("unit-test-agent");
    test_tool_surface_single_source();
    test_agent_name_valid();


### PR DESCRIPTION
Running the unit suite on any box where `AIMEE_HOME` is set **destroys the operator’s `agents.json`**. On the appliance (`AIMEE_HOME=/var/lib/aimee`) every `make unit-tests` run wipes the live agent config — observed repeatedly as agents present one hour and gone the next while the server stayed up, with no restart.

## Root cause

`test_agent.c`’s `main` sandboxes `HOME` before the suite writes to and `unlink()`s `agent_config_path()`. But that path resolves `config_default_dir()` → `aimee_home()`, and `aimee_home()` checks `AIMEE_HOME` **first**:

```c
/* 1. Explicit override wins. Operators or tests set AIMEE_HOME */
const char *override = getenv("AIMEE_HOME");
if (override && override[0]) { ... return override; }
```

So sandboxing `HOME` alone is a **no-op wherever `AIMEE_HOME` is set** — i.e. every deployed server. `agent_config_path()` then resolves to the live `/var/lib/aimee/agents.json`, which `test_tools_enabled_capability_default()` overwrites with three dummy mistral agents and then `unlink()`s.

`test_agent_apikey.c` already does this correctly (`mkdtemp` + `setenv("AIMEE_HOME", ...)`). Only `test_agent`’s `main` set `HOME` alone.

## Fix

Set `AIMEE_HOME` to the same temp dir, and assert `agent_config_path()` actually resolves inside it — so a future regression fails the suite loudly instead of silently eating real config.

## Verification

A/B with a real `agents.json` at `$AIMEE_HOME`:

| | outcome |
|---|---|
| before this change | `agents.json` **DESTROYED** |
| after this change | `agents.json` **survives intact** |

Full unit suite passes; `unit-test-agent` passes.