### PR TITLE
fix(agent): key the agent-config cache on file identity, not mtime alone

### DIFF
--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -454,6 +454,15 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
  * caller's buffer first and only then publishes under the lock. */
 static agent_config_t g_agent_config_cache;
 static struct timespec g_agent_config_mtime;
+/* mtime alone is not a safe cache key. It is not monotonic and not always
+ * distinct: a rewritten agents.json can land with a timestamp equal to (or
+ * older than) the cached one, and the cache then serves stale content forever.
+ * Observed live on the tiered appliance filesystem, where a freshly installed
+ * agents.json arrived with an mtime ~9h in the past and /v1/agents kept failing
+ * until the file was touched. Size and inode are free from the same stat() and
+ * make an in-place rewrite detectable. */
+static off_t g_agent_config_size;
+static ino_t g_agent_config_ino;
 static int g_agent_config_cached;
 static pthread_mutex_t g_agent_config_cache_lock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -479,6 +488,24 @@ static int agent_config_mtime_eq(const struct timespec *a, const struct timespec
    return a->tv_sec == b->tv_sec && a->tv_nsec == b->tv_nsec;
 }
 
+/* A cache hit requires the file to look identical on every cheap axis stat()
+ * gives us: same mtime, same size, same inode. mtime alone is spoofable by a
+ * same-timestamp rewrite (see g_agent_config_size). */
+static int agent_config_stat_eq(const struct stat *st)
+{
+   struct timespec mt = agent_config_stat_mtime(st);
+   return agent_config_mtime_eq(&mt, &g_agent_config_mtime) && st->st_size == g_agent_config_size &&
+          st->st_ino == g_agent_config_ino;
+}
+
+/* Record the identity of the file whose parsed contents are now cached. */
+static void agent_config_stat_remember(const struct stat *st)
+{
+   g_agent_config_mtime = agent_config_stat_mtime(st);
+   g_agent_config_size = st->st_size;
+   g_agent_config_ino = st->st_ino;
+}
+
 int agent_load_config(agent_config_t *cfg)
 {
    memset(cfg, 0, sizeof(*cfg));
@@ -491,9 +518,8 @@ int agent_load_config(agent_config_t *cfg)
       struct stat st;
       if (stat(path, &st) == 0)
       {
-         struct timespec mt = agent_config_stat_mtime(&st);
          pthread_mutex_lock(&g_agent_config_cache_lock);
-         int hit = g_agent_config_cached && agent_config_mtime_eq(&mt, &g_agent_config_mtime);
+         int hit = g_agent_config_cached && agent_config_stat_eq(&st);
          if (hit)
             memcpy(cfg, &g_agent_config_cache, sizeof(*cfg));
          pthread_mutex_unlock(&g_agent_config_cache_lock);
@@ -969,7 +995,7 @@ int agent_load_config(agent_config_t *cfg)
       {
          pthread_mutex_lock(&g_agent_config_cache_lock);
          memcpy(&g_agent_config_cache, cfg, sizeof(g_agent_config_cache));
-         g_agent_config_mtime = agent_config_stat_mtime(&st);
+         agent_config_stat_remember(&st);
          g_agent_config_cached = 1;
          pthread_mutex_unlock(&g_agent_config_cache_lock);
       }
@@ -1196,7 +1222,7 @@ int agent_save_config(const agent_config_t *cfg)
       {
          pthread_mutex_lock(&g_agent_config_cache_lock);
          memcpy(&g_agent_config_cache, cfg, sizeof(g_agent_config_cache));
-         g_agent_config_mtime = agent_config_stat_mtime(&st);
+         agent_config_stat_remember(&st);
          g_agent_config_cached = 1;
          pthread_mutex_unlock(&g_agent_config_cache_lock);
       }

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -2414,6 +2414,74 @@ static void test_session_isolation_guard(void)
    printf("session_isolation guard (Layer 2) OK\n");
 }
 
+/* A rewritten agents.json whose mtime did not advance must still be seen.
+ * mtime alone is not a safe cache key: it is neither monotonic nor guaranteed
+ * distinct across a rewrite. Observed live on the appliance's tiered
+ * filesystem, where a reinstalled agents.json landed with an mtime ~9h in the
+ * past and every /v1/agents request kept failing (502) and /v1/agent/list kept
+ * returning an empty array until the file was touched. Size+inode come free
+ * from the same stat() and make the rewrite detectable. */
+static void test_agent_config_cache_detects_same_mtime_rewrite(void)
+{
+   struct stat st;
+   const char *path = agent_config_path();
+
+   /* The suite runs with AIMEE_NO_CACHE=1, which disables the cache path
+    * entirely. This test is ABOUT that path, so turn caching back on for the
+    * duration -- otherwise it passes without exercising anything. */
+   unsetenv("AIMEE_NO_CACHE");
+
+   {
+      FILE *f = fopen(path, "w");
+      assert(f != NULL);
+      fputs("{\"agents\":[{\"name\":\"before\",\"provider\":\"anthropic\","
+            "\"model\":\"m\",\"roles\":[\"code\"]}]}\n",
+            f);
+      fclose(f);
+   }
+
+   agent_config_t first;
+   assert(agent_load_config(&first) == 0);
+   assert(first.agent_count == 1);
+   assert(agent_find(&first, "before") != NULL);
+   assert(stat(path, &st) == 0);
+   struct timespec pinned = st.st_mtim;
+
+   /* Rewrite with different content, then pin the mtime back to what the cache
+    * already saw -- the exact situation a coarse/non-monotonic filesystem
+    * produces on its own. */
+   {
+      FILE *f = fopen(path, "w");
+      assert(f != NULL);
+      fputs("{\"agents\":[{\"name\":\"after_one\",\"provider\":\"anthropic\","
+            "\"model\":\"m\",\"roles\":[\"code\"]},"
+            "{\"name\":\"after_two\",\"provider\":\"anthropic\","
+            "\"model\":\"m\",\"roles\":[\"code\"]}]}\n",
+            f);
+      fclose(f);
+   }
+   {
+      struct timespec times[2];
+      times[0] = pinned; /* atime */
+      times[1] = pinned; /* mtime: rewind to the cached value */
+      assert(utimensat(AT_FDCWD, path, times, 0) == 0);
+      assert(stat(path, &st) == 0);
+      assert(st.st_mtim.tv_sec == pinned.tv_sec && st.st_mtim.tv_nsec == pinned.tv_nsec);
+   }
+
+   /* The cache must NOT hand back the stale single-agent config. */
+   agent_config_t second;
+   assert(agent_load_config(&second) == 0);
+   assert(second.agent_count == 2);
+   assert(agent_find(&second, "after_one") != NULL);
+   assert(agent_find(&second, "after_two") != NULL);
+   assert(agent_find(&second, "before") == NULL);
+
+   unlink(path);
+   assert(platform_setenv("AIMEE_NO_CACHE", "1") == 0); /* restore suite default */
+   printf("  PASS: test_agent_config_cache_detects_same_mtime_rewrite\n");
+}
+
 int main(void)
 {
    char tmp_home[512];
@@ -2453,6 +2521,7 @@ int main(void)
    test_request_creds_snapshot_carries_vault_principal();
    test_agent_config_provider_cli_roundtrip();
    test_tools_enabled_capability_default();
+   test_agent_config_cache_detects_same_mtime_rewrite();
    test_agent_adapter_registry();
    test_local_synth_not_masked_by_tmux_codex();
    test_provider_cli_shell_exec_uses_argv_not_shell();


### PR DESCRIPTION
A present, valid `agents.json` could be invisible to the server indefinitely: `GET /v1/agents` returned **502 "agents backend unavailable"** and `GET /v1/agent/list` returned an **empty array**, while the same file parsed fine on other paths. `touch`ing the file fixed both instantly.

## Root cause

`agent_load_config()` caches the parsed config and decides freshness on **exact mtime equality and nothing else**:

```c
static int agent_config_mtime_eq(const struct timespec *a, const struct timespec *b)
{ return a->tv_sec == b->tv_sec && a->tv_nsec == b->tv_nsec; }
```

mtime is neither monotonic nor guaranteed to change across a rewrite, so a same-timestamp rewrite is invisible and the cache serves stale content forever. Seen live on the appliance’s tiered filesystem, where a freshly installed `agents.json` landed with an mtime **~9h in the past** relative to the box clock.

Worth noting the two endpoints report the same failure very differently — `handle_agent_list` turns a load failure into `{"agents":[]}`:

```c
if (agent_load_config(&cfg) != 0) memset(&cfg, 0, sizeof(cfg));   // -> {"agents":[]}
```

so an empty array is a *silent* failure. `/v1/agents` at least said so. That asymmetry made this look like two unrelated bugs.

## Fix

Widen the cache key to the identity `stat()` already returns for free: **mtime + size + inode**. An in-place rewrite changes at least one, so a hit now means the file really is the one we parsed. No new syscalls.

## Test

Deterministic reproduction: write a config, load it, rewrite with different content, rewind the mtime to the cached value with `utimensat`, assert the reload sees the new agents.

It also has to `unsetenv("AIMEE_NO_CACHE")` — the suite sets that globally, and without it the test passes while exercising nothing (I hit exactly that: the first version of this test passed against the *unfixed* code).

**Falsified:** reverting to the mtime-only key fails the new test with `second.agent_count == 2` — the stale single-agent config is served.

Full unit suite passes; server builds clean.