### PR TITLE
fix(toolset): scope the per-turn toolset override per thread, not the process

### DIFF
--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -64,6 +64,16 @@ void agent_tools_sanitize_for_agent(struct cJSON *tools, const agent_t *agent);
 
 char *dispatch_tool_call_ctx(const char *name, const char *arguments_json, int timeout_ms);
 void agent_tools_set_dispatch_role(const char *role);
+
+/* The toolset THIS THREAD's turn resolves against, overriding the role. Thread-local
+ * because delegate turns run on pooled worker threads and overlap: the process-wide
+ * AIMEE_ACTIVE_TOOLSET env var this replaces was set per turn with a save/restore
+ * bracket, which looked scoped while a concurrent delegate's setenv changed what
+ * this one resolved — a reviewer could resolve a coder's toolset. The env var is
+ * still honoured (it is how the single-process CLI passes --toolset); this takes
+ * precedence. Set NULL/"" to clear. */
+void agent_tools_set_active_toolset(const char *toolset);
+const char *agent_tools_active_toolset(void);
 const char *agent_tools_dispatch_role(void);
 
 /* Git-write seam (git_commit / git_push / git_branch / git_pr).

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -57,6 +57,34 @@ _Thread_local static char g_parent_write_root[MAX_PATH_LEN] = {0};
  * delegation from the delegate's write policy; reset on guard clear. */
 _Thread_local static int g_write_capable = 1;
 
+/* The toolset THIS THREAD's turn resolves against, overriding the role.
+ *
+ * Thread-local for the same reason g_write_capable above is: delegate turns run on
+ * POOLED worker threads and overlap by design (session_threads defaults above 1,
+ * and review panels fan out through agent_run_parallel). This was the process-wide
+ * AIMEE_ACTIVE_TOOLSET env var, set per turn with a save/restore bracket that made
+ * it LOOK scoped. Measured: with 4 concurrent turns, 3 of 4 resolved the LAST
+ * writer's toolset — a reviewer could hold a coder's tools, which is the boundary
+ * agent_tools_tool_allowed_for_role exists to enforce.
+ *
+ * Lives here, beside its reader, rather than in the dispatch TU: the state and the
+ * code that resolves against it belong together. The env var is still honoured (it
+ * is how the single-process CLI passes --toolset); this takes precedence. */
+_Thread_local static char g_active_toolset[128];
+
+void agent_tools_set_active_toolset(const char *toolset)
+{
+   if (toolset && toolset[0])
+      snprintf(g_active_toolset, sizeof(g_active_toolset), "%s", toolset);
+   else
+      g_active_toolset[0] = '\0';
+}
+
+const char *agent_tools_active_toolset(void)
+{
+   return g_active_toolset[0] ? g_active_toolset : NULL;
+}
+
 static int agent_tools_path_under_root(const char *path, const char *root)
 {
    if (!path || !path[0] || !root || !root[0])
@@ -398,7 +426,12 @@ int agent_tools_tool_allowed_for_role(const char *role, const char *tool_name)
    if (!tool_name || !tool_name[0])
       return 0;
 
-   const char *toolset_name = getenv("AIMEE_ACTIVE_TOOLSET");
+   /* This thread's turn first: the env var is process-wide, so on a pooled worker a
+    * concurrent delegate's value would otherwise decide what THIS one may call. The
+    * env var stays as the single-process CLI's --toolset channel. */
+   const char *toolset_name = agent_tools_active_toolset();
+   if (!toolset_name || !toolset_name[0])
+      toolset_name = getenv("AIMEE_ACTIVE_TOOLSET");
    if (!toolset_name || !toolset_name[0])
       toolset_name = toolset_for_delegate_role(role);
    if (toolset_name && toolset_name[0])

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1281,11 +1281,13 @@ void delegate_worker(void *arg)
    }
 
    int rc;
-   const char *saved_toolset_env = getenv("AIMEE_ACTIVE_TOOLSET");
-   char saved_toolset_buf[128] = "";
-   if (saved_toolset_env && saved_toolset_env[0])
-      snprintf(saved_toolset_buf, sizeof(saved_toolset_buf), "%s", saved_toolset_env);
-   platform_setenv("AIMEE_ACTIVE_TOOLSET", toolset_override ? toolset_override : "");
+   /* Thread-local, not the process env: delegate turns run on POOLED worker threads
+    * and overlap by design (session_threads defaults above 1; panels fan out through
+    * agent_run_parallel). The old save/restore around a process-wide setenv looked
+    * scoped but was not — a concurrent delegate's value decided what this one could
+    * call, so a reviewer could resolve a coder's toolset. That is the boundary
+    * agent_tools_filter_for_role exists to enforce. */
+   agent_tools_set_active_toolset(toolset_override);
    /* Bind detached workspace: delegate reads the client's live files (no-op if shared). */
    int detached_bound = cwd[0] ? workspace_turn_bind_active(cwd) : 0;
    /* A background/durable delegate has no live client connection to serve a
@@ -1497,7 +1499,9 @@ void delegate_worker(void *arg)
                   handoff_validation.error[0] ? handoff_validation.error : "validation failed");
       }
    }
-   platform_setenv("AIMEE_ACTIVE_TOOLSET", saved_toolset_buf);
+   /* Clear unconditionally: this thread is going back to the pool, and a leftover
+    * override would silently re-scope the NEXT delegate's tools. */
+   agent_tools_set_active_toolset(NULL);
    /* Reset the read-only gate unconditionally so the next user of this pooled
     * worker thread is not left in a prior delegate's (possibly read-only) state. */
    agent_tools_write_capable_set(1);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.
 TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-spill $(TESTPREFIX)/unit-test-harness-memory-audit $(TESTPREFIX)/unit-test-roundtable-brief $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-skill-review $(TESTPREFIX)/unit-test-curator-queue $(TESTPREFIX)/unit-test-curator-pipeline-sched $(TESTPREFIX)/unit-test-curator-custom-stages $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
-               $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-workspace-provider-container $(TESTPREFIX)/unit-test-mcp-native-surface $(TESTPREFIX)/unit-test-mcp-native-dispatch $(TESTPREFIX)/unit-test-extractors \
+               $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-toolset-thread-scope $(TESTPREFIX)/unit-test-workspace-provider-container $(TESTPREFIX)/unit-test-mcp-native-surface $(TESTPREFIX)/unit-test-mcp-native-dispatch $(TESTPREFIX)/unit-test-extractors \
                $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-roundtable-preset $(TESTPREFIX)/unit-test-roundtable-seat-resolve $(TESTPREFIX)/unit-test-audit-worm $(TESTPREFIX)/unit-test-kb-audit-worm $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-snapshot $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
@@ -2908,6 +2908,13 @@ $(TESTPREFIX)/unit-test-workspace-provider-container: \
                                        $(OBJDIR)/server/workspace_provider_container.o \
                                        $(OBJDIR)/posix/workspace_provider.o \
                                        $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-toolset-thread-scope: \
+                                       $(OBJDIR)/tests/test_toolset_thread_scope.o \
+                                       $(OBJDIR)/server/agent_tools.o \
+                                       $(OBJDIR)/toolset.o \
+                                       $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-toolset: \

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -333,6 +333,17 @@ void agent_tools_write_capable_set(int capable)
 {
    (void)capable;
 }
+/* Per-turn toolset override. Stubbed alongside the write guard because this test
+ * links server_compute without the agent-tools TU; the real one is thread-local
+ * (see agent_tools.c) precisely because delegate turns overlap on pooled threads. */
+void agent_tools_set_active_toolset(const char *toolset)
+{
+   (void)toolset;
+}
+const char *agent_tools_active_toolset(void)
+{
+   return NULL;
+}
 int agent_tools_readonly_delegate_blocks(void)
 {
    return 0;

--- a/src/tests/test_toolset_thread_scope.c
+++ b/src/tests/test_toolset_thread_scope.c
@@ -1,0 +1,109 @@
+/* test_toolset_thread_scope.c: the active toolset must be scoped to ONE turn.
+ *
+ * Delegate turns run on POOLED worker threads and overlap by design
+ * (session_threads defaults above 1, and review panels fan out through
+ * agent_run_parallel). The toolset override used to be the process-wide
+ * AIMEE_ACTIVE_TOOLSET env var, set per turn with a save/restore bracket — which
+ * made it LOOK scoped. It was not: a concurrent delegate's setenv decided what
+ * another delegate resolved.
+ *
+ * That is not a cosmetic race. agent_tools_filter_for_role is the thing that stops
+ * a reviewer holding a coder's tools, and it resolves through this value. Get it
+ * wrong under concurrency and the boundary silently is not one.
+ *
+ * These tests fail against the env-var implementation and pass against the
+ * thread-local, which is the whole point of writing them. */
+#include "aimee.h"
+#include "agent_tools.h"
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Each worker sets its OWN toolset, waits for the others to set theirs, and only
+ * then reads back. The barrier is what makes the race deterministic instead of
+ * lucky: with a process-global, the last writer wins and the others see it. */
+static pthread_barrier_t g_barrier;
+
+typedef struct
+{
+   const char *mine;
+   int ok;
+} worker_ctx_t;
+
+static void *worker(void *arg)
+{
+   worker_ctx_t *c = arg;
+   agent_tools_set_active_toolset(c->mine);
+   pthread_barrier_wait(&g_barrier); /* every thread has now written */
+   const char *seen = agent_tools_active_toolset();
+   c->ok = (seen && strcmp(seen, c->mine) == 0);
+   pthread_barrier_wait(&g_barrier); /* hold the value while others read */
+   agent_tools_set_active_toolset(NULL);
+   return NULL;
+}
+
+/* Concurrent turns must each see their own toolset. */
+static void test_active_toolset_is_per_thread(void)
+{
+   enum
+   {
+      N = 4
+   };
+   const char *names[N] = {"review_indexed", "code", "full_stack", "readonly"};
+   pthread_t th[N];
+   worker_ctx_t ctx[N];
+   assert(pthread_barrier_init(&g_barrier, NULL, N) == 0);
+   for (int i = 0; i < N; i++)
+   {
+      ctx[i].mine = names[i];
+      ctx[i].ok = 0;
+      assert(pthread_create(&th[i], NULL, worker, &ctx[i]) == 0);
+   }
+   for (int i = 0; i < N; i++)
+      pthread_join(th[i], NULL);
+   pthread_barrier_destroy(&g_barrier);
+
+   for (int i = 0; i < N; i++)
+      assert(ctx[i].ok); /* each thread saw ITS OWN, not the last writer's */
+   printf("  PASS: active_toolset_is_per_thread\n");
+}
+
+/* A worker thread's override must not leak into the thread that spawned it, nor
+ * survive into the next turn on a pooled thread. */
+static void *setter(void *arg)
+{
+   (void)arg;
+   agent_tools_set_active_toolset("code");
+   return NULL;
+}
+
+static void test_override_does_not_leak_across_threads(void)
+{
+   agent_tools_set_active_toolset("review_indexed");
+   pthread_t t;
+   assert(pthread_create(&t, NULL, setter, NULL) == 0);
+   pthread_join(t, NULL);
+   /* The worker set "code"; this thread must still be its own. With the process env
+    * this assertion fails — which is exactly the delegate-to-delegate leak. */
+   const char *seen = agent_tools_active_toolset();
+   assert(seen && strcmp(seen, "review_indexed") == 0);
+
+   /* Cleared means cleared: a leftover override would silently re-scope the next
+    * delegate to land on this pooled thread. */
+   agent_tools_set_active_toolset(NULL);
+   assert(agent_tools_active_toolset() == NULL);
+   agent_tools_set_active_toolset("");
+   assert(agent_tools_active_toolset() == NULL); /* "" is not a toolset */
+   printf("  PASS: override_does_not_leak_across_threads\n");
+}
+
+int main(void)
+{
+   printf("test_toolset_thread_scope:\n");
+   test_active_toolset_is_per_thread();
+   test_override_does_not_leak_across_threads();
+   printf("All toolset_thread_scope tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
## The bug

`AIMEE_ACTIVE_TOOLSET` overrides a delegate's role at tool resolution — `agent_tools_tool_allowed_for_role` reads it **first**, before falling back to the role. `server_compute` set it per delegate turn with a **process-global `setenv`** and a save/restore bracket.

The bracket makes it *look* scoped. It isn't: delegate turns run on **pooled worker threads** and overlap by design — `session_threads` defaults above 1, and review panels fan out through `agent_run_parallel`. So one delegate's `setenv` decides what a **concurrent** delegate resolves.

## Measured, not argued

A standalone probe — four threads, each setting its own toolset under a barrier, then reading back:

```
process-global env:  3 of 4 threads resolved the LAST writer's toolset
thread-local:        0 of 4
```

A reviewer resolving a **coder's** toolset gains write tools — the exact boundary `agent_tools_tool_allowed_for_role` exists to enforce. Panels run in parallel, so concurrent delegates are the normal case.

## The fix

Follows the pattern this codebase already uses next door: `g_dispatch_role`, the read-only-delegate gate, and the parent-write guard are all `_Thread_local` for this same reason. The override becomes a thread-local (`agent_tools_set_active_toolset` / `agent_tools_active_toolset`), set and cleared per turn. The env var is still honoured as the single-process CLI's `--toolset` channel, at lower precedence.

Lives in `agent_tools.c` beside its reader, not in the dispatch TU — the state and the code that resolves against it belong together.

## Testing

Two threads each set a different toolset under a barrier and assert each sees its own; a worker's override must not leak into its spawner or survive into the next turn on a pooled thread. **Planting the old process-global implementation aborts the suite** (built clean, verified it compiled — an earlier plant had silently failed to build and run a stale binary; this one is confirmed).

## Why now

The [slice-7 delegate-sandbox roundtable](https://github.com/RakuenSoftware/aimee) ruled that the reviewer filesystem policy must **not** be built on `AIMEE_ACTIVE_TOOLSET` until this race is fixed. This unblocks that.