### PR TITLE
fix(agent): report agent-config load failure instead of faking an empty roster

### DIFF
--- a/src/cli_v1_routes_c.c
+++ b/src/cli_v1_routes_c.c
@@ -81,6 +81,16 @@ static void print_rules_delete(cJSON *resp)
 
 static void print_agent_list(cJSON *resp)
 {
+   /* A server-side load failure now comes back as status:error (not a fake
+    * empty roster). Surface it as an error, not as "No agents configured" —
+    * the two are different problems and only one is fixed by adding an agent. */
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   if (cJSON_IsString(status) && strcmp(status->valuestring, "error") == 0)
+   {
+      cJSON *msg = cJSON_GetObjectItemCaseSensitive(resp, "message");
+      printf("error: %s\n", cJSON_IsString(msg) ? msg->valuestring : "agent list failed");
+      return;
+   }
    cJSON *agents = cJSON_GetObjectItemCaseSensitive(resp, "agents");
    if (!cJSON_IsArray(agents) || cJSON_GetArraySize(agents) == 0)
    {

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -460,8 +460,14 @@ int handle_agent_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    (void)ctx;
    (void)req;
    agent_config_t cfg;
+   /* A load FAILURE is not an empty roster. The old code memset the config to
+    * zero and returned {"status":"ok","agents":[]}, which is indistinguishable
+    * from a config that genuinely has no agents — so a missing/unreadable/stale
+    * agents.json silently looked like "no agents configured" to every caller
+    * (it did, on the appliance). Report the failure; reserve the empty array for
+    * a config that really loaded and really has zero agents. */
    if (agent_load_config(&cfg) != 0)
-      memset(&cfg, 0, sizeof(cfg));
+      return server_send_error(conn, "failed to load agent configuration", NULL);
    cJSON *resp = jo_ok();
    cJSON *arr = cJSON_CreateArray();
    for (int i = 0; i < cfg.agent_count; i++)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -351,6 +351,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-delegate-backend-ssh \
                $(TESTPREFIX)/unit-test-delegate-backend-docker \
                $(TESTPREFIX)/unit-test-session-compact \
+               $(TESTPREFIX)/unit-test-agent-list-handler \
                $(TESTPREFIX)/unit-test-session-compact-focused \
                $(TESTPREFIX)/unit-test-compact-prune \
                $(TESTPREFIX)/unit-test-otel \
@@ -1356,6 +1357,12 @@ $(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(
                                $(OBJDIR)/server/workspace_runner_registry.o $(OBJDIR)/server/workspace_runner_queue.o \
                                $(OBJDIR)/workspace_mirror.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o \
                                $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/json_fluent.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-agent-list-handler: $(OBJDIR)/tests/test_agent_list_handler.o \
+                               $(OBJDIR)/server/server_agent.o $(OBJDIR)/server/agent_config.o \
+                               $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev_cache.o $(OBJDIR)/models_dev.o \
+                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-server-jobs-aux: $(OBJDIR)/tests/test_server_jobs_aux.o \

--- a/src/tests/test_agent_list_handler.c
+++ b/src/tests/test_agent_list_handler.c
@@ -1,0 +1,135 @@
+/* test_agent_list_handler.c: handle_agent_list must distinguish a config LOAD
+ * FAILURE from a genuinely-empty roster.
+ *
+ * Regression for the appliance incident where a missing/stale agents.json made
+ * every caller see "no agents configured": the handler memset the config to
+ * zero on load failure and returned {"status":"ok","agents":[]}, which is
+ * byte-identical to a config that really has zero agents. This test pins the
+ * two apart. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "aimee.h"
+#include "cJSON.h"
+#include "platform_path.h"
+#include "platform_test_util.h"
+
+/* --- capture layer: stub the transport so we can read what the handler sent --- */
+
+static cJSON *g_last_response = NULL;
+static char g_last_error[256];
+
+/* server_send_ok is a static inline in server.h that calls this and then frees
+ * resp itself, so this stub must NOT delete resp — it only snapshots it. Same
+ * contract the real transport and every other handler test rely on. */
+int server_send_response(void *conn, cJSON *resp)
+{
+   (void)conn;
+   if (g_last_response)
+      cJSON_Delete(g_last_response);
+   g_last_response = cJSON_Duplicate(resp, 1);
+   return 0;
+}
+
+int server_send_error(void *conn, const char *message, const char *request_id)
+{
+   (void)conn;
+   (void)request_id;
+   snprintf(g_last_error, sizeof(g_last_error), "%s", message ? message : "");
+   return 0;
+}
+
+/* The real handler under test. Declared here to avoid dragging server.h. */
+int handle_agent_list(void *ctx, void *conn, cJSON *req);
+
+/* --- helpers --- */
+
+static char g_home[256];
+
+static void set_home_empty(void)
+{
+   snprintf(g_home, sizeof(g_home), "%s/aimee-agentlist-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(g_home) != NULL);
+   assert(platform_setenv("AIMEE_HOME", g_home) == 0);
+   unsetenv("AIMEE_NO_CACHE");
+}
+
+static void write_agents(const char *json)
+{
+   char path[512];
+   snprintf(path, sizeof(path), "%s/agents.json", g_home);
+   FILE *f = fopen(path, "w");
+   assert(f);
+   fputs(json, f);
+   fclose(f);
+}
+
+static void reset_capture(void)
+{
+   if (g_last_response)
+      cJSON_Delete(g_last_response);
+   g_last_response = NULL;
+   g_last_error[0] = '\0';
+}
+
+/* --- tests --- */
+
+static void test_load_failure_is_an_error_not_empty(void)
+{
+   set_home_empty(); /* no agents.json in this home -> agent_load_config fails */
+   reset_capture();
+
+   assert(handle_agent_list(NULL, NULL, NULL) == 0);
+
+   /* Must NOT be a silent success with an empty roster. */
+   assert(g_last_response == NULL);
+   assert(g_last_error[0] != '\0');
+   printf("  PASS: a config load failure returns an error, not an empty roster\n");
+}
+
+static void test_empty_config_is_ok_with_empty_array(void)
+{
+   set_home_empty();
+   write_agents("{\"agents\":[]}\n"); /* loads fine, genuinely zero agents */
+   reset_capture();
+
+   assert(handle_agent_list(NULL, NULL, NULL) == 0);
+
+   /* This case IS a legitimate empty roster: ok + empty array, no error. */
+   assert(g_last_error[0] == '\0');
+   assert(g_last_response != NULL);
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(g_last_response, "status");
+   assert(cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0);
+   cJSON *agents = cJSON_GetObjectItemCaseSensitive(g_last_response, "agents");
+   assert(cJSON_IsArray(agents) && cJSON_GetArraySize(agents) == 0);
+   printf("  PASS: a real config with zero agents is ok with an empty array\n");
+}
+
+static void test_populated_config_lists_agents(void)
+{
+   set_home_empty();
+   write_agents("{\"agents\":[{\"name\":\"a1\",\"provider\":\"anthropic\",\"model\":\"m\","
+                "\"roles\":[\"code\"]}]}\n");
+   reset_capture();
+
+   assert(handle_agent_list(NULL, NULL, NULL) == 0);
+
+   assert(g_last_error[0] == '\0');
+   assert(g_last_response != NULL);
+   cJSON *agents = cJSON_GetObjectItemCaseSensitive(g_last_response, "agents");
+   assert(cJSON_IsArray(agents) && cJSON_GetArraySize(agents) == 1);
+   printf("  PASS: a populated config lists its agents\n");
+}
+
+int main(void)
+{
+   printf("agent_list_handler:\n");
+   test_load_failure_is_an_error_not_empty();
+   test_empty_config_is_ok_with_empty_array();
+   test_populated_config_lists_agents();
+   printf("all agent_list_handler tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
Companion to #1372. A missing/unreadable/stale `agents.json` made every caller see **"no agents configured"** — pointing at the wrong fix (add an agent) for what is actually a load failure.

## Root cause

`handle_agent_list` memset the config to zero on a load failure and returned `{"status":"ok","agents":[]}`:

```c
if (agent_load_config(&cfg) != 0) memset(&cfg, 0, sizeof(cfg));   // -> {"agents":[]}
```

That is **byte-identical** to a config that genuinely has zero agents. So a load failure and an empty roster are indistinguishable to every caller. This is exactly why the stale-cache incident (#1372) read as an empty list on `/v1/agent/list` while `/v1/agents` — which returns 502 on the same `agent_load_config() != 0` — told the truth. Two symptoms, one masking bug.

## Fix

- **Server:** report the failure (`status:error`) instead of faking success. The empty array is now reserved for a config that *loaded* and *has* zero agents — a real, distinct state.
- **CLI:** `print_agent_list` had the mirror bug — it rendered any empty/absent array as "No agents configured", including an error response. It now surfaces the error message. (This masking is what misled me while diagnosing #1371/#1372: an empty list is not proof of no agents.)

## Test

`test_agent_list_handler.c` links the **real** handler against a capture stub and drives three states via `AIMEE_HOME`:

| state | expected |
|---|---|
| no `agents.json` (load fails) | `status:error`, no roster |
| valid config, zero agents | `ok` + `[]` |
| populated config | lists agents |

The stub follows the documented `server_send_response` seam — `server_send_ok` is a `static inline` in `server.h` that frees the response itself, so the stub must **not** (that mistake caused a double-free while writing the test; fixed).

**Falsified:** restoring the `memset`+fake-ok fails the load-failure assertion (`g_last_response == NULL`).

Full unit suite passes; server builds clean.