### PR TITLE
test: run the unit suite under a throwaway HOME, never the real config dir

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -470,7 +470,22 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-curator-fixtures \
                $(TESTPREFIX)/unit-test-substrate-fixtures
 unit-tests: $(BINARY) $(TEST_TARGETS)
-	@jobs="$(TEST_RUN_JOBS)"; \
+	@# Point the run's HOME at a throwaway dir so a test that does NOT isolate its
+	@# own environment defaults to $$th/.config/aimee, never the developer's real
+	@# ~/.config/aimee — the dir a running aimee-server reads agents.json, config
+	@# and the vault from. The suite and a server share it whenever AIMEE_HOME is
+	@# unset, so an unisolated test could read or overwrite live state. (No current
+	@# test was proven to do so — a full run under isolation writes nothing there —
+	@# but "none does today" is luck, not a boundary.)
+	@#
+	@# HOME only, NOT AIMEE_HOME: aimee_home() checks AIMEE_HOME before HOME, so
+	@# exporting AIMEE_HOME would OVERRIDE the many tests that set HOME themselves
+	@# to steer the config dir (e.g. test_session_brief). Exporting HOME leaves the
+	@# default safe while a test's own setenv still wins inside its process.
+	@th="$$(mktemp -d /tmp/aimee-unit-home.XXXXXX)"; \
+	export HOME="$$th"; unset AIMEE_HOME; \
+	trap 'rm -rf "$$th"' EXIT; \
+	jobs="$(TEST_RUN_JOBS)"; \
 	if [ "$$jobs" -le 1 ]; then \
 	  for t in $(TEST_TARGETS); do \
 	    log="$$(mktemp /tmp/aimee-test-run.XXXXXX)"; \


### PR DESCRIPTION
## Your question: why do `make unit-tests` and aimee-server share state?

Because both default to `~/.config/aimee` when `AIMEE_HOME` is unset. `make unit-tests` ran every test binary with the environment inherited, so a test that doesn't isolate its own env resolves config through `config_default_dir()` → `aimee_home()` → `$HOME/.config/aimee` — the same directory a running aimee-server reads `agents.json`, config and the vault from.

## What I got wrong, and the correction

I twice suggested a test had clobbered an operator's `agents.json`. **I have evidence against that, not for it:** a full suite run under an isolated HOME writes **nothing** into `$HOME/.config/aimee`. The dir-churn I mistook for test damage was `session-ppid-*` marker files from the ambient aimee agent session, written continuously regardless of the tests.

So no current test clobbers live config. But "none does today" is luck, not a boundary — one imperfectly-isolated test added later would read or overwrite an operator's live agent registry silently (`handle_agent_list` turns a load error into an empty list).

## The fix

Point the whole run's HOME at a throwaway dir, cleaned on exit. A test's own `setenv("HOME", tmp)` still wins inside its process, so nothing regresses.

**HOME only, deliberately not AIMEE_HOME:** `aimee_home()` checks `AIMEE_HOME` first, so exporting it would *override* the tests that set HOME themselves to steer the config dir — `test_session_brief` asserts `config_output_dir()` lands under its own tmp and fails if `AIMEE_HOME` points elsewhere. Exporting HOME keeps the default safe while leaving those tests correct.

## Verified

`make unit-tests` passes green under the isolation; a full run leaves no files under `$HOME/.config/aimee`; `test_session_brief` (which manipulates HOME) still passes.