### PR TITLE
fix(process): don't let a fast-failing child SIGPIPE-kill the caller

### DIFF
--- a/src/posix/platform_process.c
+++ b/src/posix/platform_process.c
@@ -257,6 +257,20 @@ int platform_exec_pipe(const char *cmd, const char *input, size_t input_len, cha
    close(stdin_pipe[0]);
    close(stdout_pipe[1]);
 
+   /* A child that exits before draining its stdin (e.g. a rerank command that
+    * fails fast with a non-zero status) closes the read end, so our write() to it
+    * raises SIGPIPE. With the default disposition that terminates THIS process --
+    * turning a handled subprocess failure into a hard crash of the caller (seen as
+    * a flaky SIGPIPE kill of unit-test-memory under load, and a latent server
+    * crash in production). Ignore SIGPIPE across the write so the failed write
+    * surfaces as EPIPE and the loop breaks cleanly; restore the prior disposition
+    * after. Save/restore matches workspace_provider.c. */
+   struct sigaction old_pipe, ignore_pipe;
+   memset(&ignore_pipe, 0, sizeof(ignore_pipe));
+   ignore_pipe.sa_handler = SIG_IGN;
+   sigemptyset(&ignore_pipe.sa_mask);
+   int restore_pipe = sigaction(SIGPIPE, &ignore_pipe, &old_pipe) == 0;
+
    if (input && input_len > 0)
    {
       size_t off = 0;
@@ -269,6 +283,9 @@ int platform_exec_pipe(const char *cmd, const char *input, size_t input_len, cha
       }
    }
    close(stdin_pipe[1]);
+
+   if (restore_pipe)
+      sigaction(SIGPIPE, &old_pipe, NULL);
 
    size_t cap = 4096;
    size_t len = 0;

--- a/src/tests/test_platform_process.c
+++ b/src/tests/test_platform_process.c
@@ -62,6 +62,45 @@ static void test_exec_capture_cancellable(void)
    free(out);
 }
 
+/* Regression: a child that exits before draining its stdin must not crash the
+ * caller. platform_exec_pipe write()s `input` to the child's stdin; if the child
+ * has already closed the read end, that write raises SIGPIPE, which by default
+ * terminates THIS process. That turned a handled subprocess failure (a rerank
+ * command exiting non-zero) into a hard SIGPIPE kill of the caller -- flaky under
+ * load in unit-test-memory, and a latent server crash wherever exec_pipe feeds a
+ * command that can fail fast. The fix ignores SIGPIPE across the write.
+ *
+ * Made deterministic by two things: `true` exits immediately without reading, and
+ * the input is far larger than any pipe buffer (64 KiB pipe on Linux), so the
+ * write is guaranteed to reach the closed pipe rather than fitting entirely in the
+ * kernel buffer before the child is gone. Before the fix this test dies with
+ * signal 13; after it, exec_pipe returns the child's status and we survive to
+ * assert. */
+static void test_exec_pipe_child_exits_without_reading(void)
+{
+   size_t big = 1024 * 1024; /* 1 MiB >> pipe capacity */
+   char *input = malloc(big);
+   assert(input);
+   memset(input, 'x', big);
+
+   char *out = NULL;
+   size_t len = 0;
+   /* `true` ignores and closes stdin, then exits 0. The point is not the status
+    * but that we are still alive to read it. */
+   int rc = platform_exec_pipe("true", input, big, &out, &len);
+   assert(rc == 0); /* reached at all == SIGPIPE did not kill us */
+   free(out);
+
+   /* And a fast NON-zero exit (the real rerank-fails case) is likewise survivable
+    * and reported, not swallowed. */
+   out = NULL;
+   len = 0;
+   rc = platform_exec_pipe("exit 2", input, big, &out, &len);
+   assert(rc == 2);
+   free(out);
+   free(input);
+}
+
 int main(void)
 {
    test_exec_capture_basic();
@@ -69,6 +108,7 @@ int main(void)
    test_exec_capture_timeout();
    test_exec_capture_no_timeout_fast_cmd();
    test_exec_capture_cancellable();
+   test_exec_pipe_child_exits_without_reading();
    printf("platform_process: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## The flaky test, and the real bug behind it

`unit-test-memory` intermittently died with **exit 141 (SIGPIPE)** under the parallel runner, while passing every time when run alone. That difference is the whole story: it is a race, not a logic error.

`platform_exec_pipe()` writes the caller's input to a child's stdin. When the child exits before draining it — the normal case for a rerank/cross-encoder command that **fails fast with a non-zero status** — it closes the read end, and the parent's next `write()` raises `SIGPIPE`. With the default disposition that terminates the *parent*. So a subprocess failure the caller was fully prepared to handle (`memory_core_search_b.c` logs `cross-encoder command failed` and degrades to plain ordering) instead becomes a hard crash of the caller. Under `-P` the child loses the race to exit before the parent finishes writing, and the parent dies mid-write.

This is **not just a test bug**. Every `exec_pipe` caller whose command can fail fast carries the same latent crash — guardrails, oauth token refresh, memory embed/improve. In production a rerank binary that exits non-zero would take down the server process.

## The fix

Ignore `SIGPIPE` across the write and restore the prior disposition after (save/restore via `sigaction`, matching the existing pattern in `workspace_provider.c`). The broken pipe then surfaces as `EPIPE` and the existing `if (n <= 0) break;` handles it cleanly.

## Evidence

- Reproduced **6/36** failures under concurrent load; **0/48** after the fix.
- Falsified: poisoning the guard back to `SIG_DFL` brings the crash back (**3/24**); restoring removes it. Causation, not correlation.
- Regression test is **deterministic**, not load-dependent: a child that exits without reading (`true`, then `exit 2`), fed 1 MiB — far past the pipe buffer — so the write is guaranteed to reach the closed pipe. It dies with signal 13 before the fix and returns the child's status after.
- Full suite run 3× clean; `make all` + lint clean.

Windows is unaffected: `write()` to a broken pipe there returns an error rather than raising a signal, and the loop already breaks on it.