### PR TITLE
feat(ir): response-side shadow — parse every delegate reply both ways

### DIFF
--- a/src/headers/aimee_ir_metrics.h
+++ b/src/headers/aimee_ir_metrics.h
@@ -33,6 +33,14 @@ typedef enum
    /* Shadow: IR and legacy produced byte-identical provider bodies. */
    AIMEE_IR_M_BODY_MATCH,
    AIMEE_IR_M_RESCUE_RECOVERIES,
+   /* Shadow (response side): the IR backend parser and the legacy translator
+    * disagreed about the SAME provider response -- different text, or a different
+    * set of tool calls. This is the response-side twin of BODY_MISMATCH and the
+    * gate for retiring the response translators: the request-side shadow proves the
+    * IR sends the same bytes, this proves it reads the reply the same way. */
+   AIMEE_IR_M_RESP_MISMATCH,
+   /* Shadow (response side): IR and legacy parsed the response identically. */
+   AIMEE_IR_M_RESP_MATCH,
    AIMEE_IR_M__COUNT
 } aimee_ir_metric_t;
 

--- a/src/headers/aimee_ir_shadow.h
+++ b/src/headers/aimee_ir_shadow.h
@@ -32,6 +32,24 @@ void aimee_ir_shadow_observe_request(const struct cJSON *req, aimee_wire_t front
 void aimee_ir_shadow_compare_bodies(const char *ir_body, const char *legacy_body,
                                     aimee_wire_t frontend);
 
+/* Shadow-compare how the two paths PARSED the same provider response: the legacy
+ * translator's parsed_response_t (`legacy`, the production result) vs what the IR
+ * backend parser makes of the same response JSON (`resp_json`). Parses via the IR
+ * for the given wire, then checks they agree on the answer text and on the set of
+ * tool calls (count + names + argument JSON). Counts ir_resp_match /
+ * ir_resp_mismatch and logs a capped, truncated note.
+ *
+ * This is the response-side twin of compare_bodies: the request shadow proves the
+ * IR sends the provider the same bytes; this proves it reads the reply the same
+ * way. Both are required before the response translators can be retired.
+ *
+ * No-op unless AIMEE_IR_SHADOW is set (the extra parse is real work) or if either
+ * argument is NULL. Never affects the turn -- the legacy result is what runs.
+ * `legacy` is a `parsed_response_t`; forward-declared to keep this header light. */
+struct parsed_response;
+void aimee_ir_shadow_compare_response(const struct parsed_response *legacy,
+                                      const struct cJSON *resp_json, aimee_wire_t wire);
+
 /* 1 when shadow mode is on, so callers can skip building the comparison body. */
 int aimee_ir_shadow_enabled(void);
 

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -5,6 +5,7 @@
 /* posix/agent.c: POSIX implementation of agent_execute_with_tools. */
 #include "aimee.h"
 #include "agent.h"
+#include "aimee_ir_shadow.h"
 #include "agent_exec.h"
 #include "agent_protocol.h"
 #include "agent_runtime_messages.h"
@@ -1096,6 +1097,16 @@ native_provider_http:
                agent_parse_response_anthropic(root, &parsed);
             else
                agent_parse_response_openai(root, &parsed);
+            /* Shadow (response side): parse the SAME response JSON through the IR
+             * backend parser and record whether it agrees with the legacy result.
+             * Off unless AIMEE_IR_SHADOW is set; never changes the turn -- the
+             * legacy `parsed` is what runs. This is the response-side twin of the
+             * request-body shadow, and the evidence that must show parity before
+             * the response translators can be retired. Only anthropic/openai are
+             * comparable here; the responses/SSE wire above is not JSON. */
+            if (aimee_ir_shadow_enabled())
+               aimee_ir_shadow_compare_response(
+                   &parsed, root, anthropic ? AIMEE_WIRE_ANTHROPIC : AIMEE_WIRE_OPENAI_CHAT);
             cJSON_Delete(root);
          }
          else

--- a/src/server/aimee_ir_metrics.c
+++ b/src/server/aimee_ir_metrics.c
@@ -68,6 +68,10 @@ const char *aimee_ir_metric_name(aimee_ir_metric_t m)
       return "ir_body_match";
    case AIMEE_IR_M_RESCUE_RECOVERIES:
       return "ir_rescue_recoveries";
+   case AIMEE_IR_M_RESP_MISMATCH:
+      return "ir_resp_mismatch";
+   case AIMEE_IR_M_RESP_MATCH:
+      return "ir_resp_match";
    case AIMEE_IR_M__COUNT:
    default:
       return "unknown";

--- a/src/server/aimee_ir_shadow.c
+++ b/src/server/aimee_ir_shadow.c
@@ -1,6 +1,9 @@
 /* aimee_ir_shadow.c -- see aimee_ir_shadow.h. */
+#include "aimee.h" /* MAX_PATH_LEN et al: agent_types.h depends on it */
+
 #include "aimee_ir_shadow.h"
 
+#include "agent_protocol.h" /* parsed_response_t (response comparison) */
 #include "aimee_backend.h"
 #include "aimee_frontend.h"
 #include "aimee_ir_metrics.h"
@@ -52,6 +55,123 @@ void aimee_ir_shadow_compare_bodies(const char *ir_body, const char *legacy_body
               (int)frontend, ir_body ? strlen(ir_body) : 0, legacy_body ? strlen(legacy_body) : 0,
               ir_body ? ir_body : "(null)", legacy_body ? legacy_body : "(null)");
    }
+}
+
+/* Whitespace-insensitive text equality: the two parsers may differ only in leading
+ * or trailing trim, which is not a semantic divergence. Both NULL/empty == equal. */
+static int text_equal_trimmed(const char *a, const char *b)
+{
+   if (!a)
+      a = "";
+   if (!b)
+      b = "";
+   while (*a == ' ' || *a == '\n' || *a == '\t' || *a == '\r')
+      a++;
+   while (*b == ' ' || *b == '\n' || *b == '\t' || *b == '\r')
+      b++;
+   size_t la = strlen(a), lb = strlen(b);
+   while (la > 0 &&
+          (a[la - 1] == ' ' || a[la - 1] == '\n' || a[la - 1] == '\t' || a[la - 1] == '\r'))
+      la--;
+   while (lb > 0 &&
+          (b[lb - 1] == ' ' || b[lb - 1] == '\n' || b[lb - 1] == '\t' || b[lb - 1] == '\r'))
+      lb--;
+   return la == lb && memcmp(a, b, la) == 0;
+}
+
+/* Do the IR's TOOL_USE blocks match the legacy calls[] one-for-one: same count,
+ * same names in order, same argument JSON (semantic, via cJSON_Compare)? */
+static int tool_calls_equal(const parsed_response_t *legacy, const aimee_response_t *ir)
+{
+   int ir_n = 0;
+   for (int i = 0; i < ir->n_content; i++)
+      if (ir->content[i].type == AIMEE_BLK_TOOL_USE)
+         ir_n++;
+   if (ir_n != legacy->call_count)
+      return 0;
+
+   int k = 0;
+   for (int i = 0; i < ir->n_content; i++)
+   {
+      const aimee_block_t *b = &ir->content[i];
+      if (b->type != AIMEE_BLK_TOOL_USE)
+         continue;
+      const char *ir_name = b->tool_name ? b->tool_name : "";
+      const char *lg_name = legacy->calls[k].name;
+      if (strcmp(ir_name, lg_name) != 0)
+         return 0;
+      /* Arguments: compare the parsed JSON, not the string form, so key order and
+       * spacing don't read as a divergence. Legacy stores args as a JSON string. */
+      cJSON *lg_args = legacy->calls[k].arguments ? cJSON_Parse(legacy->calls[k].arguments) : NULL;
+      /* Both sides argument-less counts as equal; otherwise a missing side diverges.
+       * cJSON_Compare(x, NULL) is false, so handle the both-NULL case explicitly. */
+      int args_ok = (!b->tool_input && !lg_args) ? 1 : cJSON_Compare(b->tool_input, lg_args, 1);
+      cJSON_Delete(lg_args);
+      if (!args_ok)
+         return 0;
+      k++;
+   }
+   return 1;
+}
+
+void aimee_ir_shadow_compare_response(const struct parsed_response *legacy, const cJSON *resp_json,
+                                      aimee_wire_t wire)
+{
+   if (!shadow_enabled() || !legacy || !resp_json)
+      return;
+
+   aimee_response_t ir;
+   memset(&ir, 0, sizeof(ir));
+   char err[128] = {0};
+   int rc;
+   if (wire == AIMEE_WIRE_ANTHROPIC)
+      rc = anthropic_backend_parse(resp_json, &ir, err, sizeof(err));
+   else if (wire == AIMEE_WIRE_OPENAI_CHAT)
+      rc = openai_backend_parse(resp_json, &ir, err, sizeof(err));
+   else
+      return; /* responses/SSE wire not comparable here -- caller skips it */
+
+   /* A parse failure is itself a divergence: legacy produced a result, the IR could
+    * not. That is exactly the case that must reach zero before we trust the IR. */
+   if (rc != 0)
+   {
+      aimee_ir_metric_inc(AIMEE_IR_M_RESP_MISMATCH, wire);
+      if (g_logged < SHADOW_LOG_CAP)
+      {
+         g_logged++;
+         fprintf(stderr, "aimee_ir_shadow: response parse FAILED in IR (wire=%d): %s\n", (int)wire,
+                 err[0] ? err : "(no detail)");
+      }
+      aimee_response_free(&ir);
+      return;
+   }
+
+   char ir_text[8192];
+   aimee_ir_response_text(&ir, ir_text, sizeof(ir_text));
+   int ir_has_tool = aimee_ir_response_has_tool_use(&ir);
+
+   int same = (legacy->is_tool_call ? 1 : 0) == (ir_has_tool ? 1 : 0) &&
+              tool_calls_equal(legacy, &ir) && text_equal_trimmed(legacy->content, ir_text);
+
+   if (same)
+      aimee_ir_metric_inc(AIMEE_IR_M_RESP_MATCH, wire);
+   else
+   {
+      aimee_ir_metric_inc(AIMEE_IR_M_RESP_MISMATCH, wire);
+      if (g_logged < SHADOW_LOG_CAP)
+      {
+         g_logged++;
+         /* Shape only, no content: which axis diverged and the counts, never the
+          * text or arguments (same roundtable ruling as compare_bodies). */
+         fprintf(stderr,
+                 "aimee_ir_shadow: response mismatch (wire=%d) "
+                 "legacy{tool=%d calls=%d text=%zu} ir{tool=%d calls=%d text=%zu}\n",
+                 (int)wire, legacy->is_tool_call ? 1 : 0, legacy->call_count,
+                 legacy->content ? strlen(legacy->content) : 0, ir_has_tool ? 1 : 0, ir.n_content,
+                 strlen(ir_text));
+      }
+   }
+   aimee_response_free(&ir);
 }
 
 void aimee_ir_shadow_observe_request(const cJSON *req, aimee_wire_t frontend)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -23,7 +23,7 @@ TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/main
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/agent_config.o $(OBJDIR)/tests/support/vault_service_stub.o $(OBJDIR)/tests/support/oauth_tokens_stub.o $(OBJDIR)/server/agent_adapter.o $(OBJDIR)/cmd_describe.o \
                              $(OBJDIR)/posix/cmd_describe.o \
-                             $(OBJDIR)/server/agent_runtime.o $(OBJDIR)/server/agent_logging.o $(OBJDIR)/server/request_context.o $(OBJDIR)/server/skill_review.o $(OBJDIR)/skill_curator.o $(OBJDIR)/server/agent_context_budget.o $(OBJDIR)/prompts.o $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_mistral.o $(OBJDIR)/server/cli_acp.o $(OBJDIR)/conversation_context.o $(OBJDIR)/server/provider_catalog.o $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o $(OBJDIR)/server/agent_request_shaping.o $(OBJDIR)/server/agent_policy.o $(OBJDIR)/server/model_sampling.o \
+                             $(OBJDIR)/server/agent_runtime.o $(OBJDIR)/tests/support/ir_shadow_stubs.o $(OBJDIR)/server/agent_logging.o $(OBJDIR)/server/request_context.o $(OBJDIR)/server/skill_review.o $(OBJDIR)/skill_curator.o $(OBJDIR)/server/agent_context_budget.o $(OBJDIR)/prompts.o $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_mistral.o $(OBJDIR)/server/cli_acp.o $(OBJDIR)/conversation_context.o $(OBJDIR)/server/provider_catalog.o $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o $(OBJDIR)/server/agent_request_shaping.o $(OBJDIR)/server/agent_policy.o $(OBJDIR)/server/model_sampling.o \
                              $(OBJDIR)/server/agent_tasks.o $(OBJDIR)/server/agent_eval.o $(OBJDIR)/server/agent_eval_memory_support.o $(OBJDIR)/server/agent_eval_baseline.o \
                              $(OBJDIR)/server/agent_coord.o $(OBJDIR)/server/agent_tools.o $(OBJDIR)/server/script_runner.o $(OBJDIR)/server/script_rpc.o $(OBJDIR)/toolset.o $(OBJDIR)/server/tool_args_coerce.o $(OBJDIR)/server/tool_schema_sanitizer.o \
                              $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_index_parse.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/tests/server/kb_client_tool_registry.o $(OBJDIR)/server/kb_client_prospective.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cli_client.o $(OBJDIR)/cli_v1_routes.o $(OBJDIR)/cli_v1_routes_b.o $(OBJDIR)/cli_v1_routes_c.o $(OBJDIR)/cli_v1_routes_d.o \
@@ -149,6 +149,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-aimee-ir \
                $(TESTPREFIX)/unit-test-ir-legacy-parity \
                $(TESTPREFIX)/unit-test-aimee-ir-rescue \
+               $(TESTPREFIX)/unit-test-ir-shadow-response \
                $(TESTPREFIX)/unit-test-aimee-ir-metrics \
                $(TESTPREFIX)/unit-test-aimee-frontend \
                $(TESTPREFIX)/unit-test-aimee-backend \
@@ -4189,4 +4190,17 @@ $(TESTPREFIX)/unit-test-aimee-ir-rescue: $(OBJDIR)/tests/test_aimee_ir_rescue.o 
                                          $(OBJDIR)/server/aimee_ir_metrics.o \
                                          $(OBJDIR)/server/delegate_xml_fallback.o \
                                          $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-ir-shadow-response: $(OBJDIR)/tests/test_ir_shadow_response.o \
+                                            $(OBJDIR)/server/aimee_ir_shadow.o \
+                                            $(OBJDIR)/server/aimee_backend_anthropic.o \
+                                            $(OBJDIR)/server/aimee_backend_openai.o \
+                                            $(OBJDIR)/server/aimee_backend_responses.o \
+                                            $(OBJDIR)/server/aimee_frontend_anthropic.o \
+                                            $(OBJDIR)/server/aimee_frontend_openai.o \
+                                            $(OBJDIR)/server/aimee_frontend_responses.o \
+                                            $(OBJDIR)/server/aimee_ir.o \
+                                            $(OBJDIR)/server/aimee_ir_metrics.o \
+                                            $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/support/ir_shadow_stubs.c
+++ b/src/tests/support/ir_shadow_stubs.c
@@ -1,0 +1,22 @@
+/* ir_shadow_stubs.c -- WEAK no-op stubs for the response-side shadow hook wired
+ * into agent_runtime.c. Tests that link agent_runtime.o to exercise the delegate
+ * turn loop do not test the IR shadow, so they don't need the real
+ * aimee_ir_shadow.o (which pulls in the whole backend/frontend/IR chain). These
+ * stubs are WEAK: the real object's strong definitions win in the full binary and
+ * in the shadow's own tests. With the stub, shadow is simply disabled (enabled ->
+ * 0), so compare_response is never called by the runtime anyway. */
+#include "aimee_ir_shadow.h"
+
+__attribute__((weak)) int aimee_ir_shadow_enabled(void)
+{
+   return 0;
+}
+
+__attribute__((weak)) void aimee_ir_shadow_compare_response(const struct parsed_response *legacy,
+                                                            const struct cJSON *resp_json,
+                                                            aimee_wire_t wire)
+{
+   (void)legacy;
+   (void)resp_json;
+   (void)wire;
+}

--- a/src/tests/test_ir_shadow_response.c
+++ b/src/tests/test_ir_shadow_response.c
@@ -1,0 +1,218 @@
+/* test_ir_shadow_response.c -- the response-side shadow comparator.
+ *
+ * aimee_ir_shadow_compare_response parses a provider response through the IR backend
+ * parser and records whether it agrees with the legacy translator's
+ * parsed_response_t. This is the evidence that must show parity before the response
+ * translators can be retired, so the test's job is to prove the comparator actually
+ * DISTINGUISHES agreement from each kind of divergence -- not just that it counts a
+ * match when handed two identical things. Every mismatch axis is exercised, and each
+ * assertion is one the comparator would fail if it stopped checking that axis. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aimee.h" /* MAX_PATH_LEN et al: agent_types.h depends on it */
+
+#include "aimee_ir_metrics.h"
+#include "aimee_ir_shadow.h"
+#include "agent_protocol.h"
+#include "cJSON.h"
+
+static cJSON *text_resp(const char *text)
+{
+   cJSON *r = cJSON_CreateObject();
+   cJSON_AddStringToObject(r, "stop_reason", "end_turn");
+   cJSON *content = cJSON_AddArrayToObject(r, "content");
+   cJSON *blk = cJSON_CreateObject();
+   cJSON_AddStringToObject(blk, "type", "text");
+   cJSON_AddStringToObject(blk, "text", text);
+   cJSON_AddItemToArray(content, blk);
+   return r;
+}
+
+static cJSON *tool_resp(const char *name, cJSON *input)
+{
+   cJSON *r = cJSON_CreateObject();
+   cJSON_AddStringToObject(r, "stop_reason", "tool_use");
+   cJSON *content = cJSON_AddArrayToObject(r, "content");
+   cJSON *blk = cJSON_CreateObject();
+   cJSON_AddStringToObject(blk, "type", "tool_use");
+   cJSON_AddStringToObject(blk, "id", "t1");
+   cJSON_AddStringToObject(blk, "name", name);
+   cJSON_AddItemToObject(blk, "input", input);
+   cJSON_AddItemToArray(content, blk);
+   return r;
+}
+
+static long mism(void)
+{
+   return aimee_ir_metric_total(AIMEE_IR_M_RESP_MISMATCH);
+}
+static long match(void)
+{
+   return aimee_ir_metric_total(AIMEE_IR_M_RESP_MATCH);
+}
+
+int main(void)
+{
+   /* The comparator is a no-op unless shadow mode is on -- turn it on. */
+   setenv("AIMEE_IR_SHADOW", "1", 1);
+   printf("ir-shadow-response:\n");
+
+   /* 1. Identical text -> match. */
+   {
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.content = strdup("hello world");
+      cJSON *r = text_resp("hello world");
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(match() == 1 && mism() == 0);
+      cJSON_Delete(r);
+      free(lg.content);
+      printf("  PASS: identical text counts a match\n");
+   }
+
+   /* 2. Different text -> mismatch. If the comparator ignored text, this would be a
+    * false match and parity would look proven when it is not. */
+   {
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.content = strdup("hello world");
+      cJSON *r = text_resp("something else entirely");
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(mism() == 1 && match() == 0);
+      cJSON_Delete(r);
+      free(lg.content);
+      printf("  PASS: divergent text counts a mismatch\n");
+   }
+
+   /* 3. Whitespace-only difference is NOT a divergence. */
+   {
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.content = strdup("  hello world\n");
+      cJSON *r = text_resp("hello world");
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(match() == 1 && mism() == 0);
+      cJSON_Delete(r);
+      free(lg.content);
+      printf("  PASS: trim-only text difference is a match\n");
+   }
+
+   /* 4. Same tool call (name + args) -> match. */
+   {
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.is_tool_call = 1;
+      lg.call_count = 1;
+      strncpy(lg.calls[0].name, "bash", sizeof(lg.calls[0].name) - 1);
+      lg.calls[0].arguments = strdup("{\"cmd\":\"ls\"}");
+      cJSON *input = cJSON_CreateObject();
+      cJSON_AddStringToObject(input, "cmd", "ls");
+      cJSON *r = tool_resp("bash", input);
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(match() == 1 && mism() == 0);
+      cJSON_Delete(r);
+      free(lg.calls[0].arguments);
+      printf("  PASS: identical tool call (name+args) counts a match\n");
+   }
+
+   /* 5. Same shape but different tool NAME -> mismatch. */
+   {
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.is_tool_call = 1;
+      lg.call_count = 1;
+      strncpy(lg.calls[0].name, "grep", sizeof(lg.calls[0].name) - 1);
+      lg.calls[0].arguments = strdup("{\"cmd\":\"ls\"}");
+      cJSON *input = cJSON_CreateObject();
+      cJSON_AddStringToObject(input, "cmd", "ls");
+      cJSON *r = tool_resp("bash", input);
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(mism() == 1 && match() == 0);
+      cJSON_Delete(r);
+      free(lg.calls[0].arguments);
+      printf("  PASS: differing tool name counts a mismatch\n");
+   }
+
+   /* 6. Same name, different ARGS -> mismatch (semantic, not string). */
+   {
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.is_tool_call = 1;
+      lg.call_count = 1;
+      strncpy(lg.calls[0].name, "bash", sizeof(lg.calls[0].name) - 1);
+      lg.calls[0].arguments = strdup("{\"cmd\":\"rm -rf /\"}");
+      cJSON *input = cJSON_CreateObject();
+      cJSON_AddStringToObject(input, "cmd", "ls");
+      cJSON *r = tool_resp("bash", input);
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(mism() == 1 && match() == 0);
+      cJSON_Delete(r);
+      free(lg.calls[0].arguments);
+      printf("  PASS: differing tool arguments counts a mismatch\n");
+   }
+
+   /* 7. Key ORDER in args must NOT read as a divergence (semantic compare). */
+   {
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.is_tool_call = 1;
+      lg.call_count = 1;
+      strncpy(lg.calls[0].name, "bash", sizeof(lg.calls[0].name) - 1);
+      lg.calls[0].arguments = strdup("{\"a\":1,\"b\":2}");
+      cJSON *input = cJSON_CreateObject();
+      cJSON_AddNumberToObject(input, "b", 2);
+      cJSON_AddNumberToObject(input, "a", 1);
+      cJSON *r = tool_resp("bash", input);
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(match() == 1 && mism() == 0);
+      cJSON_Delete(r);
+      free(lg.calls[0].arguments);
+      printf("  PASS: argument key order is not a divergence\n");
+   }
+
+   /* 8. text-vs-tool disagreement -> mismatch: legacy says tool, IR sees text. */
+   {
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.is_tool_call = 1;
+      lg.call_count = 1;
+      strncpy(lg.calls[0].name, "bash", sizeof(lg.calls[0].name) - 1);
+      lg.calls[0].arguments = strdup("{}");
+      cJSON *r = text_resp("no tool here");
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(mism() == 1 && match() == 0);
+      cJSON_Delete(r);
+      free(lg.calls[0].arguments);
+      printf("  PASS: tool-vs-text disagreement counts a mismatch\n");
+   }
+
+   /* 9. Disabled by default: with the flag off, the comparator records nothing. */
+   {
+      unsetenv("AIMEE_IR_SHADOW");
+      aimee_ir_metrics_reset();
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.content = strdup("hello");
+      cJSON *r = text_resp("hello");
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(match() == 0 && mism() == 0);
+      cJSON_Delete(r);
+      free(lg.content);
+      setenv("AIMEE_IR_SHADOW", "1", 1);
+      printf("  PASS: off unless AIMEE_IR_SHADOW is set\n");
+   }
+
+   printf("ir-shadow-response: ok\n");
+   return 0;
+}


### PR DESCRIPTION
First step of the delegate IR rewire, done as validation-before-flip — the same discipline the request side got, and what the roundtable ruling requires (*do NOT delete the translators until parity is proven on real traffic*).

## The gap this closes

The request-side shadow proves the IR sends the provider the same **bytes** legacy would. It says nothing about the other half: whether the IR reads the provider's **reply** the same way. Until this PR the IR response parsers (`anthropic`/`openai`/`responses_backend_parse`) had **zero production callers** — that half was entirely unmeasured, and it's the half that decides whether a turn dispatches the right tool.

## What it does

In the one place every delegate reply is parsed (`posix/agent_runtime.c`), after the legacy translator parses the response, parse the **same** response JSON through the IR backend parser and record whether they agree on:
- the answer text (whitespace-normalized), and
- the set of tool calls — count, names, and argument JSON compared **semantically** (`cJSON_Compare`), so key order and spacing don't read as drift.

The legacy result is still what runs — **the shadow never touches the turn**. Off unless `AIMEE_IR_SHADOW` is set. Only the anthropic/openai wires are compared; the responses/SSE wire isn't JSON at this point and is skipped **explicitly**, not silently.

## The evidence it produces

`ir_resp_match` / `ir_resp_mismatch` join the existing `ir_*` counters on the dashboard, so response parity becomes a number you watch on real traffic — the response-side gate for retiring the translators, alongside the request-side `ir_body_*` gate. An IR parse failure counts as a mismatch, because "legacy produced a result, the IR could not" is exactly the case that must reach zero.

## Why this and not a straight parser swap

`agent_runtime.c` is the primary delegate execution path — gateway policing, respond-tool stripping, assistant-message construction, and XML rescue all hang off the legacy `parsed_response_t`. Flipping the parser before there's any evidence the IR reads replies identically would be an unvalidated leap on the riskiest path in the system. This makes the IR parsers live (their first production callers) and generates the parity data, at zero risk to delegation. The flip comes after the numbers say it's safe.

## Testing

Comparator tested against nine cases — identical text, divergent text, trim-only difference, identical tool call, wrong name, wrong args, reordered arg keys, tool-vs-text disagreement, disabled-by-default. Each comparison **axis** is falsified by neutering it: text, tool-set, name, and args each abort the suite when defeated and pass on restore. Full suite 2× clean, `make all` + lint clean.

Tests linking `agent_runtime.o` that don't exercise the shadow get a weak stub (`tests/support/ir_shadow_stubs.c`), the same pattern as `ir_ingress_stubs.c`, so they don't drag in the whole backend/frontend/IR chain.