### PR TITLE
fix(agent-config): never let a save destroy a populated agents.json

### DIFF
--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -16,6 +16,8 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <time.h>
+#include "log.h"
+#include <fcntl.h>
 #include <unistd.h>
 
 int agent_name_valid(const char *name)
@@ -1004,6 +1006,45 @@ int agent_load_config(agent_config_t *cfg)
    return 0;
 }
 
+/* Count the agents in the on-disk agents.json WITHOUT the cache — the cache can be
+ * stale or empty, and this guards against destroying the real file. Returns the
+ * count, or -1 if the file is absent or unparseable (i.e. "nothing to protect"). */
+static int agent_config_existing_agent_count(void)
+{
+   FILE *f = fopen(agent_config_path(), "r");
+   if (!f)
+      return -1;
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return -1;
+   }
+   long sz = ftell(f);
+   if (sz <= 0 || sz > 8 * 1024 * 1024)
+   {
+      fclose(f);
+      return -1;
+   }
+   rewind(f);
+   char *buf = malloc((size_t)sz + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return -1;
+   }
+   size_t rd = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   buf[rd] = '\0';
+   cJSON *root = cJSON_Parse(buf);
+   free(buf);
+   if (!root)
+      return -1;
+   cJSON *arr = cJSON_GetObjectItemCaseSensitive(root, "agents");
+   int n = cJSON_IsArray(arr) ? cJSON_GetArraySize(arr) : -1;
+   cJSON_Delete(root);
+   return n;
+}
+
 int agent_save_config(const agent_config_t *cfg)
 {
    cJSON *root = cJSON_CreateObject();
@@ -1200,21 +1241,68 @@ int agent_save_config(const agent_config_t *cfg)
    if (!json)
       return -1;
 
+   /* Never overwrite a populated agents.json with an empty registry. A zero-agent
+    * save is legitimate ONLY on a fresh install (no existing file, or an existing
+    * file that already has none) — never as a silent wipe of configured agents.
+    * This is the agents.json-deletion guard: whatever the trigger (a load that
+    * came back empty, a caller with a zeroed cfg), the destruction stops here, and
+    * it stops LOUDLY so the next occurrence is diagnosable rather than invisible. */
+   if (cfg->agent_count == 0)
+   {
+      int existing = agent_config_existing_agent_count();
+      if (existing > 0)
+      {
+         aimee_log(LOG_ERROR, "agent-config",
+                   "REFUSING to overwrite %d configured agent(s) in %s with an empty registry. "
+                   "An empty save is only valid on a fresh install; this is the deletion guard. "
+                   "If a wipe is truly intended, remove the file first.",
+                   existing, agent_config_path());
+         free(json);
+         return -1;
+      }
+   }
+
    /* Ensure directory exists */
    char dir[MAX_PATH_LEN];
    snprintf(dir, sizeof(dir), "%s", config_default_dir());
    platform_mkdir_p(dir, 0700);
 
-   FILE *f = fopen(agent_config_path(), "w");
-   if (!f)
+   /* Write atomically: a temp file, fsync, then rename over the target. rename(2)
+    * is atomic on a POSIX filesystem, so an interrupted or failed write can NEVER
+    * leave a truncated or empty agents.json — the previous file survives untouched.
+    * The old fopen(path, "w") truncated the real file to zero the instant it
+    * opened, before a single byte was written; any hiccup then destroyed it, which
+    * on a tiered/networked home is exactly how it went missing. */
+   char tmp[MAX_PATH_LEN];
+   if ((size_t)snprintf(tmp, sizeof(tmp), "%s.tmp.%d", agent_config_path(), (int)getpid()) >=
+       sizeof(tmp))
    {
       free(json);
       return -1;
    }
-   fputs(json, f);
-   fputc('\n', f);
-   fclose(f);
-   /* Restrict permissions (contains API keys and auth tokens) */
+   int fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+   if (fd < 0)
+   {
+      free(json);
+      return -1;
+   }
+   size_t jlen = strlen(json);
+   int ok = (write(fd, json, jlen) == (ssize_t)jlen) && (write(fd, "\n", 1) == 1);
+   /* fsync before rename: a rename can otherwise be durable while the data it
+    * points at is not, leaving an empty file after a crash — the very failure this
+    * guards against. */
+   if (ok && fsync(fd) != 0)
+      ok = 0;
+   if (close(fd) != 0)
+      ok = 0;
+   if (!ok || rename(tmp, agent_config_path()) != 0)
+   {
+      unlink(tmp); /* leave the existing agents.json intact */
+      aimee_log(LOG_ERROR, "agent-config", "atomic write of %s failed; existing file left intact",
+                agent_config_path());
+      free(json);
+      return -1;
+   }
    chmod(agent_config_path(), 0600);
    {
       struct stat st;

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -2482,6 +2482,66 @@ static void test_agent_config_cache_detects_same_mtime_rewrite(void)
    printf("  PASS: test_agent_config_cache_detects_same_mtime_rewrite\n");
 }
 
+/* The agents.json deletion guard: agent_save_config must never destroy a populated
+ * file, and its write must be atomic. This pins the two ways the file used to go
+ * missing on the live server — an empty registry overwriting it, and a truncating
+ * fopen("w") that a failed/interrupted write left at zero bytes. */
+static void test_agent_config_deletion_guard(void)
+{
+   char home[MAX_PATH_LEN];
+   snprintf(home, sizeof(home), "%s/aimee-guard-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(home) != NULL);
+   setenv("HOME", home, 1);
+   unsetenv("AIMEE_HOME");
+   assert(platform_mkdir_p(config_default_dir(), 0700) == 0 ||
+          access(config_default_dir(), F_OK) == 0);
+
+   /* Seed a populated registry (2 agents). */
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 2;
+   snprintf(cfg.agents[0].name, sizeof(cfg.agents[0].name), "alpha");
+   snprintf(cfg.agents[0].provider, sizeof(cfg.agents[0].provider), "openai");
+   snprintf(cfg.agents[1].name, sizeof(cfg.agents[1].name), "beta");
+   snprintf(cfg.agents[1].provider, sizeof(cfg.agents[1].provider), "openai");
+   assert(agent_save_config(&cfg) == 0);
+
+   agent_config_t chk;
+   assert(agent_load_config(&chk) == 0 && chk.agent_count == 2);
+
+   /* (1) An EMPTY registry must be REFUSED over the populated file, and the file
+    * must survive untouched. This is the guard proper. */
+   {
+      agent_config_t empty;
+      memset(&empty, 0, sizeof(empty));
+      assert(agent_save_config(&empty) != 0);
+      agent_config_t after;
+      assert(agent_load_config(&after) == 0);
+      assert(after.agent_count == 2); /* NOT wiped */
+   }
+
+   /* (2) A zero-agent save IS allowed with no existing file (fresh install). */
+   {
+      unlink(agent_config_path());
+      agent_config_t empty;
+      memset(&empty, 0, sizeof(empty));
+      assert(agent_save_config(&empty) == 0);
+   }
+
+   /* (3) Atomic write leaves no <path>.tmp.* behind on success. */
+   {
+      assert(agent_save_config(&cfg) == 0);
+      char cmd[MAX_PATH_LEN + 64];
+      snprintf(cmd, sizeof(cmd), "ls %s.tmp.* >/dev/null 2>&1", agent_config_path());
+      assert(system(cmd) != 0);
+   }
+
+   char rm[MAX_PATH_LEN + 16];
+   snprintf(rm, sizeof(rm), "rm -rf %s", home);
+   (void)system(rm);
+   printf("  PASS: agent_config_deletion_guard\n");
+}
+
 int main(void)
 {
    char tmp_home[512];
@@ -2523,6 +2583,7 @@ int main(void)
    test_tools_enabled_capability_default();
    test_agent_config_cache_detects_same_mtime_rewrite();
    test_agent_adapter_registry();
+   test_agent_config_deletion_guard();
    test_local_synth_not_masked_by_tmux_codex();
    test_provider_cli_shell_exec_uses_argv_not_shell();
    test_provider_cli_shell_timeout_covers_prompt_write();


### PR DESCRIPTION
## The bug

The live server loses `agents.json` — `aimee agent list` comes back empty for a file that should be there. Two weaknesses in `agent_save_config`, either of which destroys it. The **trigger is not yet known** (I can't observe .254 directly), so this guards against both *and* makes the next occurrence diagnosable instead of silent.

## 1. Non-atomic write

```c
FILE *f = fopen(agent_config_path(), "w");   /* truncates to 0 bytes on open */
```

`fopen(…, "w")` zeroes the file the instant it opens, before writing a byte. Any interruption between that and `fclose` — a kill, a full disk, a hiccup on a tiered/networked home — leaves `agents.json` empty or partial, which fails to parse and reads as "no agents."

**Fix:** write to a temp file, `fsync`, then `rename(2)` over the target. An interrupted or failed write leaves the **previous** file untouched, because rename is atomic on POSIX.

## 2. No empty guard

Nothing stopped a zero-agent registry overwriting a populated one. A zero-agent save is legitimate **only on a fresh install** (confirmed with the operator); as a wipe it never is.

`agent_save_config` now refuses to write an empty registry over an existing populated file, and refuses **loudly** (`LOG_ERROR` naming the count it protected). So whatever the trigger — a load that came back empty, a caller with a zeroed cfg — the next occurrence leaves a **log line instead of a missing file**. The existing count is read raw from disk, bypassing the cache (which can itself be stale).

## Behaviour change

Removing the **last** agent now fails rather than emptying the registry (the operator's rule: populated → empty is only a fresh install). The error tells you to remove the file first if a wipe is genuinely intended.

## Honest about the tests

- The empty-guard is unit-tested and **plant-verified** — removing the guard aborts the suite (rebuilt + binary-existence-checked, not a stale run).
- **Atomicity is not unit-testable** without simulating a crash mid-write. Test (3) asserts only that a successful save leaves no temp file behind (the rename path ran). The atomic write stands on the standard tmp+fsync+rename construction.

## What this does *not* fix

If the real trigger is a container-recreate wiping the mounted home (.254's `AIMEE_HOME` is mounted from a tiered store), that's a deployment/persistence problem this code can't fix. But the guard would still turn the resulting empty-save into a **refusal** rather than a silent loss — and the log line would point at the mechanism.