### PR TITLE
fix(wfe): clear stale parent-write guard before a delegate runs (implement no-op root cause)

### DIFF
--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -22,6 +22,7 @@
 
 #include "agent_config.h"
 #include "agent_exec.h"
+#include "agent_tools.h"
 #include "agent_types.h"
 #include "cJSON.h"
 #include "delegate_role.h"
@@ -121,6 +122,22 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
     * uniformly by name; an unroutable pick fails here and the block's retry
     * loop re-rolls a different agent. */
    run_cmd_set_cwd(workdir);
+
+   /* Reset the process-global write guards before the delegate runs. These are
+    * set per-run ONLY by the primary chat path (server_compute.c, which sets
+    * them unconditionally precisely "so a pooled worker thread never inherits a
+    * prior delegate's capability"). A wfe delegate runs on a pooled worker
+    * thread and this path never touched them, so it inherited whatever a prior
+    * run left: a primary session's parent-write guard whose read-only root
+    * encloses THIS worktree (native writes rejected as "parent worktree is
+    * read-only"), or a prior read-only delegate's capability=0 (all native file
+    * writes rejected). Either way a producing delegate that edits via file tools
+    * committed an EMPTY tree — a no-op round — while bash-writers happened to
+    * slip past the same guard, so convergence silently depended on each model's
+    * tool preferences. A producing wfe delegate is write-capable and its
+    * worktree (pinned as cwd above) is the write boundary; clear the stale guard.
+    * clear() also restores write-capability. */
+   agent_tools_parent_write_guard_clear();
    agent_result_t res;
    memset(&res, 0, sizeof(res));
    int rc;

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -49,6 +49,7 @@ int agent_execute_cli_shell_driver(const agent_t *agent, const char *driver_name
 void test_cancelled_durable_job_blocks_tool_dispatch(void);
 void test_delegate_bash_cancel_kills_running_tool(void);
 void test_parent_write_guard_readonly_pipeline(void);
+void test_stale_parent_guard_blocks_other_worktree_then_clear_unblocks(void);
 void test_parent_write_guard_readonly_large_find(void);
 void test_parent_write_guard_allows_mkdir_in_delegate_worktree(void);
 void test_parent_write_guard_allows_workspace_file_ops(void);
@@ -2601,6 +2602,7 @@ int main(void)
    test_parent_write_guard_blocks_parent_writes();
    test_session_isolation_guard();
    test_parent_write_guard_readonly_pipeline();
+   test_stale_parent_guard_blocks_other_worktree_then_clear_unblocks();
    test_parent_write_guard_allows_mkdir_in_delegate_worktree();
    test_parent_write_guard_allows_workspace_file_ops();
    test_parent_write_guard_allows_workspace_chain();

--- a/src/tests/test_agent_delegate_root.c
+++ b/src/tests/test_agent_delegate_root.c
@@ -82,6 +82,61 @@ void test_parent_write_guard_readonly_pipeline(void)
    printf("  PASS: test_parent_write_guard_readonly_pipeline\n");
 }
 
+/* Regression: a wfe delegate runs on a pooled worker thread and inherits the
+ * process-global parent-write guard left by a PRIOR run (only the primary chat
+ * path sets it per-run). If that stale guard's read-only root encloses the
+ * delegate's OWN worktree while its write root points at a DIFFERENT worktree, a
+ * native write_file into the delegate's worktree is wrongly rejected as "parent
+ * read-only" — the implement delegate commits an empty tree (a no-op round).
+ * wfe_live_delegate_run now clears the guard before running; this pins the
+ * clear-unblocks-the-write behavior the fix relies on. */
+void test_stale_parent_guard_blocks_other_worktree_then_clear_unblocks(void)
+{
+   char root[512];
+   snprintf(root, sizeof(root), "%s/aimee_stale_guard_XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(root) != NULL);
+
+   /* Two sibling worktrees under a common read-only root, exactly the shape a
+    * prior primary session (pinned to worktree A) leaves behind when a wfe
+    * delegate then runs in worktree B. */
+   char wt_a[512], wt_b[512];
+   snprintf(wt_a, sizeof(wt_a), "%s/.aimee/worktrees/sessionA/main", root);
+   snprintf(wt_b, sizeof(wt_b), "%s/.aimee/worktrees/wfeB/main", root);
+   assert(platform_mkdir_p(wt_a, 0700) == 0 || access(wt_a, F_OK) == 0);
+   assert(platform_mkdir_p(wt_b, 0700) == 0 || access(wt_b, F_OK) == 0);
+
+   /* Stale guard from the prior session: read-only root = the common parent,
+    * write root = worktree A. */
+   agent_tools_parent_write_guard_set(root, wt_a);
+
+   /* The wfe delegate, running in worktree B, tries to write there. Under the
+    * stale guard this is blocked (B is under the ro root but not under A). */
+   run_cmd_set_cwd(wt_b);
+   char *blocked = tool_write_file("new_impl.txt", "codex output\n");
+   run_cmd_set_cwd(NULL);
+   assert(blocked != NULL);
+   assert(strstr(blocked, "blocked") != NULL); /* rejected as parent read-only */
+   assert(access("/dev/null", F_OK) == 0);     /* sanity: fs reachable */
+   char wrote_path[600];
+   snprintf(wrote_path, sizeof(wrote_path), "%s/new_impl.txt", wt_b);
+   assert(access(wrote_path, F_OK) != 0); /* nothing landed */
+   free(blocked);
+
+   /* The fix: clear the stale guard (also restores write capability). */
+   agent_tools_parent_write_guard_clear();
+
+   run_cmd_set_cwd(wt_b);
+   char *ok = tool_write_file("new_impl.txt", "codex output\n");
+   run_cmd_set_cwd(NULL);
+   assert(ok != NULL);
+   assert(strstr(ok, "blocked") == NULL); /* now allowed */
+   assert(access(wrote_path, F_OK) == 0); /* the write landed in worktree B */
+
+   free(ok);
+   platform_test_rmrf(root);
+   printf("  PASS: test_stale_parent_guard_blocks_other_worktree_then_clear_unblocks\n");
+}
+
 void test_parent_write_guard_readonly_large_find(void)
 {
    char root[512];


### PR DESCRIPTION
Found by driving a live `build` workflow to the `implement` stage and watching every impl round produce an **empty no-op commit** (`aimee: autonomous delegate change` with a zero diff) even though the delegate — codex — was actively spending tokens and *believed* it wrote files.

## Root cause

The parent-write guard and write-capability flag that `tool_write_file` consults are process **globals**. Only the primary chat path sets them per-run — and does so **unconditionally**, with a comment that spells out exactly why:

```c
/* Single-sourced read-only gate ... Set UNCONDITIONALLY (before the
 * cwd-dependent parent-write guard) so a pooled worker thread never inherits a
 * prior delegate's capability. */
agent_tools_write_capable_set(delegate_allows_writes);
agent_tools_parent_write_guard_set(cwd, write_root);
```

`wfe_live_delegate_run` — the WFE producing-delegate path — **never touched them**. So a delegate on a pooled worker thread inherited whatever a prior run left:

- a primary session's guard whose **read-only root enclosed this delegate's worktree** while its write root pointed at a *different* session's worktree → every native `write_file`/`edit_file` into the delegate's own worktree was rejected as *"parent worktree is read-only for delegates"*; or
- a prior read-only delegate's `write_capable=0` → all native writes refused.

Either way `git add -A && git commit` staged nothing → a no-op round. `tool_bash` writers bypass `tool_write_file`'s guard entirely, which is why the failure looked **model-dependent** (bash-preferring models slipped through; file-tool models no-op'd) rather than systemic. There's even a comment elsewhere describing this exact class: *"implement delegates that edit via file tools produced no-op rounds while bash-writers slipped through — the whole fleet's convergence depended on each model's tool preferences."*

## Fix

Clear the guard before the producing delegate runs (`clear()` also restores write-capability). The delegate's worktree, pinned as cwd immediately above, is the write boundary — there is no separate parent to protect on this path.

## Test

`test_stale_parent_guard_blocks_other_worktree_then_clear_unblocks` reproduces the exact shape: two sibling worktrees, guard pinned to A, a `tool_write_file` into B is **blocked** under the stale guard and **succeeds** after the clear (and the file actually lands in B). **Falsified** — without the stale guard set, the "blocked" assertion fails.

Full unit suite passes; server builds clean.

_Discovered while stress-testing the WFE end-to-end on the appliance; several environmental blockers cleared along the way (an over-broad git-gate for CLI delegates, structured-decomposition routing to weak free-tier agents) were config-level, but this one is a real engine bug._