### PR TITLE
feat(llm): aimee-llm-cpu — pre-baked CPU LLM image (step 1 of retiring aimee-combined)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -96,6 +96,11 @@ jobs:
           # Multi-arch: upstream llama.cpp ships x64 + arm64 Vulkan tarballs, mapped
           # from TARGETARCH in the Dockerfile. NGL is set at deploy.
           - { name: aimee-llm, dockerfile: Dockerfile.aimee-llm }
+          # The PRE-BAKED cpu variant: same Dockerfile, AIMEE_LLM_BAKE_TIER=cpu runs
+          # the supervisor at BUILD time so the cpu-tier GGUFs (embed+rerank+synth)
+          # ship in the image — serves offline with no first-boot download. This is
+          # the pure-CPU appliance LLM that replaces aimee-combined's bundled models.
+          - { name: aimee-llm-cpu, dockerfile: Dockerfile.aimee-llm, extra_args: "AIMEE_LLM_BAKE_TIER=cpu" }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -123,7 +128,7 @@ jobs:
       # code-server + the llama.cpp runtime — a large transient build footprint.
       # Reclaim the preinstalled toolchains to keep it within a stock runner.
       - name: Free disk space (combined leg)
-        if: matrix.image.name == 'aimee-combined'
+        if: matrix.image.name == 'aimee-combined' || matrix.image.name == 'aimee-llm-cpu'
         run: |
           echo "before:"; df -h /
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
@@ -154,8 +159,8 @@ jobs:
           # not the layer cache; the combined image pre-bakes its cpu-tier GGUFs.
           # aimee-llm is model-less (no baked GGUFs) so it is small and cached like
           # the C images.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-combined' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-combined' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-combined' && matrix.image.name != 'aimee-llm-cpu' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-combined' && matrix.image.name != 'aimee-llm-cpu' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
@@ -189,7 +194,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-combined, aimee-embedder, aimee-embedder-4b, aimee-llm, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-combined, aimee-embedder, aimee-embedder-4b, aimee-llm, aimee-llm-cpu, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -23,6 +23,37 @@
 
 ARG LLAMA_TAG=b9775
 
+# One Dockerfile, two published images — a reduction in responsibility over the
+# old aimee-combined, which baked the cpu models inside the all-in-one appliance.
+#   AIMEE_LLM_BAKE_TIER=""    -> model-less: downloads its tier at first boot (GPU)
+#   AIMEE_LLM_BAKE_TIER=cpu   -> the cpu tier's GGUFs baked in: serves offline, no
+#                               multi-GB first-boot pull (the pure-CPU appliance LLM)
+# The bake runs the SAME supervisor as the runtime download, so the tier table has
+# exactly one home. Empty is the default, so the plain aimee-llm image is byte-for-
+# byte the behaviour it has today.
+ARG AIMEE_LLM_BAKE_TIER=
+
+# ---- optional model bake (build time) ----------------------------------------
+# Runs the supervisor's own download logic (AIMEE_LLM_DOWNLOAD_ONLY=1) so a tier's
+# GGUFs + their .ready markers are baked in. When AIMEE_LLM_BAKE_TIER is empty this
+# stage produces an EMPTY /models, and the runtime COPY below is a no-op — the
+# image stays model-less. No llama.cpp here: download-only needs only wget.
+FROM debian:bookworm-slim AS models-bake
+ARG AIMEE_LLM_BAKE_TIER
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget \
+    && rm -rf /var/lib/apt/lists/*
+COPY scripts/aimee-llm-supervisor.sh /tmp/supervisor.sh
+# mkdir FIRST so /models exists as a real directory even with no bake — otherwise
+# `COPY --from=models-bake /models/` fails with "/models: not found" on an empty path.
+RUN chmod +x /tmp/supervisor.sh && mkdir -p /models \
+    && if [ -n "${AIMEE_LLM_BAKE_TIER}" ]; then \
+         echo "baking aimee-llm tier '${AIMEE_LLM_BAKE_TIER}' at build time"; \
+         AIMEE_LLM_DOWNLOAD_ONLY=1 AIMEE_LLM_TIER="${AIMEE_LLM_BAKE_TIER}" \
+           AIMEE_LLM_MODELS_DIR=/models /tmp/supervisor.sh; \
+       else \
+         echo "no AIMEE_LLM_BAKE_TIER — model-less image; models download at first boot"; \
+       fi
+
 # ---- runtime — Vulkan llama.cpp + the gateway (no models, no torch) ----------
 # Base is Debian TRIXIE (Mesa 25.x): its RADV exposes VK_KHR_cooperative_matrix on
 # RDNA3 (gfx1100), so the prebuilt llama.cpp Vulkan binary uses the 7900 XTX WMMA
@@ -58,6 +89,11 @@ COPY scripts/aimee-llm-supervisor.sh /opt/aimee/supervisor.sh
 # downstream `COPY --from=aimee-llm /models/` fails with "/models: not found".
 # The explicit mkdir gives it a layer.
 RUN chmod +x /opt/aimee/supervisor.sh && mkdir -p /models
+# Seed /models from the bake stage: empty for the plain (download) image, the
+# cpu-tier GGUFs + .ready markers for aimee-llm-cpu. A named volume mounted here is
+# populated from this image content on first start, so the pre-baked image serves
+# offline while the plain image still downloads into the volume as before.
+COPY --from=models-bake /models/ /models/
 
 # Persistent model cache: the supervisor downloads the tier's GGUFs here on first
 # boot. Mount a volume so restarts (and tier switches) don't re-pull multi-GB models.


### PR DESCRIPTION
First step of the workstream to collapse to **one server, one KB, two LLM images, and delete `aimee-combined`** (task #19). This adds the **pre-baked CPU** image that replaces the LLM role combined bundles.

## A faithful extraction, not a new image

`aimee-combined` already bakes the CPU GGUFs by running the aimee-llm supervisor at build time (`AIMEE_LLM_DOWNLOAD_ONLY=1 AIMEE_LLM_TIER=cpu`). `Dockerfile.aimee-llm` now takes an `AIMEE_LLM_BAKE_TIER` build-arg doing exactly that in an optional stage:

| build-arg | result |
|---|---|
| `AIMEE_LLM_BAKE_TIER=""` (default) | model-less; downloads its tier at first boot — **today's behaviour, byte-for-byte** |
| `AIMEE_LLM_BAKE_TIER=cpu` | the CPU tier's GGUFs + `.ready` markers baked in |

**One Dockerfile, two published images.** The supervisor stays the single source of truth for the tier table — no second copy of the model coordinates.

## Validated end-to-end on real docker (nesting CT on .253, docker 26.1.5)

- **Default build**: fast, `/models` empty — identical to the current image, no regression.
- **`--build-arg AIMEE_LLM_BAKE_TIER=cpu`**: the supervisor ran at build time and baked `embed.gguf` (1.2G) + `synth.gguf` (5.3G) + `rerank-encoder.gguf` + head, each with its `.ready` marker (`model provisioning done embed=local/cpu rerank=local/cpu synth=local/cpu`).
- **Offline proof**: `docker run --network none` with download-only reported provisioning done **instantly** — no fetch, no network error — because the `.ready` markers make the supervisor skip. So the pre-baked image serves with **no first-boot download**, exactly as `aimee-combined` did.

## CI

`publish-images.yml` gains an `aimee-llm-cpu` leg (build + merge matrices), with the same free-disk step and gha-cache exclusion `aimee-combined` uses — its baked multi-GB layer would otherwise blow the 10 GB cache budget. The plain `aimee-llm` leg is unchanged. The image itself builds on release, not on this PR, so the **.253 build above is the image proof**; PR CI confirms the YAML is valid and nothing else regressed.

## Not in this PR (task #19, in order)

The wizard provisioning KB + CPU-LLM on demand; tier-binding the split deployment's postgres/home volumes so state survives a container recreate (the live .254 pgvector loss); then **deleting `aimee-combined`** — last, after its replacements exist and .254 is migrated.

_Follow-up: the testing lane (`publish-llm-testing.yml`) builds only the model-less image; a `aimee-llm-cpu:testing` leg can be added when the split deployment needs it._