### PR TITLE
feat(deploy): wizard provisions a pre-baked CPU aimee-llm

### DIFF
--- a/deploy/container/aimee-managed.compose.yaml
+++ b/deploy/container/aimee-managed.compose.yaml
@@ -6,12 +6,18 @@
 # operator directly; the server picks the services with COMPOSE_PROFILES, which
 # `aimee config deploy-env` derives from the wizard's page-2 config:
 #
-#   local kb, LLM external/off  -> COMPOSE_PROFILES=kb       -> postgres + aimee-kb
-#   local kb, a role local      -> COMPOSE_PROFILES=kb,llm   -> + aimee-llm
-#   remote kb                   -> COMPOSE_PROFILES=          -> nothing (server connects out)
+#   local kb, LLM external/off  -> COMPOSE_PROFILES=kb         -> postgres + aimee-kb
+#   local kb, a local GPU tier  -> COMPOSE_PROFILES=kb,llm     -> + aimee-llm (downloads)
+#   local kb, a local CPU tier  -> COMPOSE_PROFILES=kb,llm-cpu -> + aimee-llm-cpu (pre-baked)
+#   remote kb                   -> COMPOSE_PROFILES=            -> nothing (server connects out)
+#
+# The GPU (aimee-llm) and CPU (aimee-llm-cpu) LLM services are mutually exclusive —
+# config_emit_deploy_env picks exactly one profile — and BOTH answer to the network
+# host `aimee-llm` (the CPU service carries that alias), so aimee-server and aimee-kb
+# reach whichever is deployed at the same http://aimee-llm:8742.
 #
 # Every service joins the EXTERNAL `aimee` network that aimee-server is also on, so
-# the server reaches them by name (aimee-kb:8741, aimee-llm:8080, postgres:5432).
+# the server reaches them by name (aimee-kb:8741, aimee-llm:8742, postgres:5432).
 # That network is created by compose.server-managed.yaml.
 
 networks:
@@ -52,7 +58,7 @@ services:
       # embed + rerank + synth via the unified aimee-llm container (the kb runs no
       # model). When no role is local (llm profile off) the operator points this at
       # an external endpoint; the kb fail-opens on embedding if it is unreachable.
-      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8080}
+      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8742}
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
     command: ["--http-port=8741"]
     depends_on:
@@ -66,27 +72,56 @@ services:
     volumes:
       - aimee-managed-kb-home:/var/lib/aimee
 
+  # GPU / download variant: model-less image, pulls its tier on first boot and
+  # persists it in the /models volume. Selected by COMPOSE_PROFILES=...,llm when a
+  # local role runs a GPU tier (small|mid|large).
   aimee-llm:
     profiles: ["llm"]
     restart: unless-stopped
     image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     networks: [aimee]
     environment:
-      AIMEE_LLM_PORT: "8080"
-      # CPU by default; GPU = AIMEE_LLM_TIER=small|mid|large + AIMEE_LLM_NGL=99 +
-      # /dev/dri (deploy/compose/aimee.gpu.yaml). Models download on first boot.
+      AIMEE_LLM_PORT: "8742"
+      # GPU = AIMEE_LLM_TIER=small|mid|large + AIMEE_LLM_NGL=99 + /dev/dri
+      # (deploy/compose/aimee.gpu.yaml). Models download on first boot.
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
-      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-small}
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
     volumes:
       - aimee-managed-llm-models:/models
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
       interval: 10s
       timeout: 5s
       retries: 5
       # Cold first boot downloads the tier's GGUFs before /health is OK.
       start_period: 1200s
+
+  # CPU / pre-baked variant: the cpu-tier GGUFs are baked into aimee-llm-cpu, so it
+  # serves offline with no first-boot download and NO /models volume (an empty bind
+  # would overlay/hide the baked models). Selected by COMPOSE_PROFILES=...,llm-cpu
+  # when the local stack has no GPU tier. Aliased to `aimee-llm` so aimee-server and
+  # aimee-kb reach it at the same http://aimee-llm:8742 the GPU variant uses. With
+  # aimee-server + aimee-kb this is the split-stack replacement for aimee-combined.
+  aimee-llm-cpu:
+    profiles: ["llm-cpu"]
+    restart: unless-stopped
+    image: ${AIMEE_LLM_CPU_IMAGE:-ghcr.io/rakuensoftware/aimee-llm-cpu:latest}
+    networks:
+      aimee:
+        aliases: [aimee-llm]
+    environment:
+      AIMEE_LLM_PORT: "8742"
+      AIMEE_LLM_NGL: "0"
+      # Must match the tier baked into the image; the supervisor finds the baked
+      # GGUFs + .ready markers and serves immediately, downloading nothing.
+      AIMEE_LLM_TIER: "cpu"
+      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   aimee-managed-postgres:

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -103,6 +103,15 @@ static const char *deploy_role_mode(const char *backend)
    return "";
 }
 
+/* A GPU-class model tier — one served by the model-less aimee-llm image, which
+ * downloads the tier on first boot. The absence of any GPU tier (cpu, or an unset
+ * tier that resolves to cpu) selects the pre-baked aimee-llm-cpu image instead. */
+static int deploy_tier_is_gpu(const char *tier)
+{
+   return tier && (strcmp(tier, "small") == 0 || strcmp(tier, "mid") == 0 ||
+                   strcmp(tier, "large") == 0);
+}
+
 void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
 {
    if (!buf || n == 0)
@@ -123,12 +132,24 @@ void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
    const int any_local =
        strcmp(eb, "local") == 0 || strcmp(rb, "local") == 0 || strcmp(sb, "local") == 0;
 
+   /* The locally-served LLM image depends on the tier. Any GPU tier (small/mid/
+    * large) on a local role selects the model-less aimee-llm image (profile "llm"),
+    * which downloads that tier on first boot and persists it in the /models volume.
+    * A pure-CPU stack (no GPU tier) selects the pre-baked aimee-llm-cpu image
+    * (profile "llm-cpu"), which ships the cpu GGUFs in the image and mounts no
+    * volume — the offline appliance LLM that, with aimee-kb, retires aimee-combined.
+    * The two profiles are mutually exclusive; both answer to the host "aimee-llm". */
+   const int gpu_local = (strcmp(eb, "local") == 0 && deploy_tier_is_gpu(cfg->llm_embed_tier)) ||
+                         (strcmp(rb, "local") == 0 && deploy_tier_is_gpu(cfg->llm_rerank_tier)) ||
+                         (strcmp(sb, "local") == 0 && deploy_tier_is_gpu(cfg->llm_synth_tier));
+
    /* COMPOSE_PROFILES: a remote kb deploys nothing; a local kb runs the "kb"
-    * service, plus "llm" whenever any role is served locally on this host. */
+    * service, plus the LLM profile whenever any role is served locally here. */
    char profiles[64] = "";
    if (!remote_kb)
    {
-      snprintf(profiles, sizeof(profiles), "kb%s", any_local ? ",llm" : "");
+      snprintf(profiles, sizeof(profiles), "kb%s",
+               any_local ? (gpu_local ? ",llm" : ",llm-cpu") : "");
    }
    EMITF("COMPOSE_PROFILES=%s\n", profiles);
 

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -108,8 +108,8 @@ static const char *deploy_role_mode(const char *backend)
  * tier that resolves to cpu) selects the pre-baked aimee-llm-cpu image instead. */
 static int deploy_tier_is_gpu(const char *tier)
 {
-   return tier && (strcmp(tier, "small") == 0 || strcmp(tier, "mid") == 0 ||
-                   strcmp(tier, "large") == 0);
+   return tier &&
+          (strcmp(tier, "small") == 0 || strcmp(tier, "mid") == 0 || strcmp(tier, "large") == 0);
 }
 
 void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -2212,6 +2212,26 @@ int main(void)
       assert(strstr(env, "AIMEE_LLM_URL=http://aimee-llm:8742\n") != NULL);
       assert(strstr(env, "AIMEE_EMBEDDING_DIM") == NULL); /* local embed => unpinned/derived */
 
+      /* Local kb; all roles local at the CPU tier => the pre-baked llm-cpu profile
+       * (aimee-llm-cpu image), NOT the download "llm" profile. Same aimee-llm URL. */
+      memset(&cfg, 0, sizeof(cfg));
+      snprintf(cfg.kb_mode, sizeof(cfg.kb_mode), "local");
+      snprintf(cfg.llm_embed_backend, sizeof(cfg.llm_embed_backend), "local");
+      snprintf(cfg.llm_embed_tier, sizeof(cfg.llm_embed_tier), "cpu");
+      snprintf(cfg.llm_synth_backend, sizeof(cfg.llm_synth_backend), "local");
+      snprintf(cfg.llm_synth_tier, sizeof(cfg.llm_synth_tier), "cpu");
+      config_emit_deploy_env(&cfg, env, sizeof(env));
+      assert(strstr(env, "COMPOSE_PROFILES=kb,llm-cpu\n") != NULL);
+      assert(strstr(env, "COMPOSE_PROFILES=kb,llm\n") == NULL); /* not the GPU profile */
+      assert(strstr(env, "AIMEE_LLM_URL=http://aimee-llm:8742\n") != NULL);
+
+      /* A local role with an unset tier resolves to cpu, so it also takes llm-cpu. */
+      memset(&cfg, 0, sizeof(cfg));
+      snprintf(cfg.kb_mode, sizeof(cfg.kb_mode), "local");
+      snprintf(cfg.llm_synth_backend, sizeof(cfg.llm_synth_backend), "local");
+      config_emit_deploy_env(&cfg, env, sizeof(env));
+      assert(strstr(env, "COMPOSE_PROFILES=kb,llm-cpu\n") != NULL);
+
       /* Remote kb: connect out, deploy nothing (no profiles, no llm env). */
       memset(&cfg, 0, sizeof(cfg));
       snprintf(cfg.kb_mode, sizeof(cfg.kb_mode), "remote");


### PR DESCRIPTION
Third step of retiring aimee-combined: the aimee-server setup wizard can now stand up a full **pure-CPU** local stack (server + kb + pre-baked CPU llm) with no first-boot model download.

## What this fixes

The wizard already provisions aimee-kb + aimee-llm on demand — page-2 config feeds `config_emit_deploy_env`, which emits `COMPOSE_PROFILES`, and `deploy_apply.c` runs `aimee-managed.compose.yaml up -d` over the mounted docker socket. Two gaps blocked a CPU stack from replacing aimee-combined:

1. **Port mismatch (bug).** The managed `aimee-llm` service ran on `:8080`, but `config_emit_deploy_env` (and every split-stack plugin/compose) points aimee-server + aimee-kb at `aimee-llm:8742`. A wizard-provisioned local LLM was therefore unreachable by the server. Aligned the managed compose to the canonical **8742**.

2. **CPU download.** The only local-LLM service used the model-less `aimee-llm` image, which downloads ~6GB on first boot. Added the pre-baked **`aimee-llm-cpu`** service (profile `llm-cpu`), using `ghcr.io/rakuensoftware/aimee-llm-cpu:latest` (#1381). It mounts **no `/models` volume** — an empty bind would overlay and hide the baked GGUFs, forcing a download — and carries the network alias `aimee-llm`, so it answers at the same `aimee-llm:8742` the GPU variant uses.

`config_emit_deploy_env` now selects the profile by tier: `llm-cpu` for a pure-CPU stack, `llm` only when a local role runs a GPU tier (small/mid/large). The two services are mutually exclusive.

## Validation

- `test_config` extended: CPU-tier and unset-tier stacks emit `COMPOSE_PROFILES=kb,llm-cpu` (not the GPU `kb,llm`); GPU tier still emits `kb,llm`. Passes.
- Real docker compose v2 on CT .253 (docker 26.1.5): `kb,llm-cpu` renders `aimee-kb + aimee-llm-cpu + postgres` with the `aimee-llm` alias, port 8742, and **no `/models` volume**; `kb,llm` renders the GPU download variant.

## Not in this PR

Deleting `aimee-combined` itself (Dockerfile.combined, its CI legs, entrypoint) comes last, after .254 is migrated onto the split plugin stack.