### PR TITLE
fix(llm): cap synth host prompt-cache (OOM) + per-tier context defaults

### DIFF
--- a/deploy/container/aimee-managed.compose.yaml
+++ b/deploy/container/aimee-managed.compose.yaml
@@ -6,12 +6,18 @@
 # operator directly; the server picks the services with COMPOSE_PROFILES, which
 # `aimee config deploy-env` derives from the wizard's page-2 config:
 #
-#   local kb, LLM external/off  -> COMPOSE_PROFILES=kb       -> postgres + aimee-kb
-#   local kb, a role local      -> COMPOSE_PROFILES=kb,llm   -> + aimee-llm
-#   remote kb                   -> COMPOSE_PROFILES=          -> nothing (server connects out)
+#   local kb, LLM external/off  -> COMPOSE_PROFILES=kb         -> postgres + aimee-kb
+#   local kb, a local GPU tier  -> COMPOSE_PROFILES=kb,llm     -> + aimee-llm (downloads)
+#   local kb, a local CPU tier  -> COMPOSE_PROFILES=kb,llm-cpu -> + aimee-llm-cpu (pre-baked)
+#   remote kb                   -> COMPOSE_PROFILES=            -> nothing (server connects out)
+#
+# The GPU (aimee-llm) and CPU (aimee-llm-cpu) LLM services are mutually exclusive —
+# config_emit_deploy_env picks exactly one profile — and BOTH answer to the network
+# host `aimee-llm` (the CPU service carries that alias), so aimee-server and aimee-kb
+# reach whichever is deployed at the same http://aimee-llm:8742.
 #
 # Every service joins the EXTERNAL `aimee` network that aimee-server is also on, so
-# the server reaches them by name (aimee-kb:8741, aimee-llm:8080, postgres:5432).
+# the server reaches them by name (aimee-kb:8741, aimee-llm:8742, postgres:5432).
 # That network is created by compose.server-managed.yaml.
 
 networks:
@@ -52,7 +58,7 @@ services:
       # embed + rerank + synth via the unified aimee-llm container (the kb runs no
       # model). When no role is local (llm profile off) the operator points this at
       # an external endpoint; the kb fail-opens on embedding if it is unreachable.
-      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8080}
+      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8742}
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
     command: ["--http-port=8741"]
     depends_on:
@@ -66,27 +72,56 @@ services:
     volumes:
       - aimee-managed-kb-home:/var/lib/aimee
 
+  # GPU / download variant: model-less image, pulls its tier on first boot and
+  # persists it in the /models volume. Selected by COMPOSE_PROFILES=...,llm when a
+  # local role runs a GPU tier (small|mid|large).
   aimee-llm:
     profiles: ["llm"]
     restart: unless-stopped
     image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:latest}
     networks: [aimee]
     environment:
-      AIMEE_LLM_PORT: "8080"
-      # CPU by default; GPU = AIMEE_LLM_TIER=small|mid|large + AIMEE_LLM_NGL=99 +
-      # /dev/dri (deploy/compose/aimee.gpu.yaml). Models download on first boot.
+      AIMEE_LLM_PORT: "8742"
+      # GPU = AIMEE_LLM_TIER=small|mid|large + AIMEE_LLM_NGL=99 + /dev/dri
+      # (deploy/compose/aimee.gpu.yaml). Models download on first boot.
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
-      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-cpu}
+      AIMEE_LLM_TIER: ${AIMEE_LLM_TIER:-small}
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
     volumes:
       - aimee-managed-llm-models:/models
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
       interval: 10s
       timeout: 5s
       retries: 5
       # Cold first boot downloads the tier's GGUFs before /health is OK.
       start_period: 1200s
+
+  # CPU / pre-baked variant: the cpu-tier GGUFs are baked into aimee-llm-cpu, so it
+  # serves offline with no first-boot download and NO /models volume (an empty bind
+  # would overlay/hide the baked models). Selected by COMPOSE_PROFILES=...,llm-cpu
+  # when the local stack has no GPU tier. Aliased to `aimee-llm` so aimee-server and
+  # aimee-kb reach it at the same http://aimee-llm:8742 the GPU variant uses. With
+  # aimee-server + aimee-kb this is the split-stack replacement for aimee-combined.
+  aimee-llm-cpu:
+    profiles: ["llm-cpu"]
+    restart: unless-stopped
+    image: ${AIMEE_LLM_CPU_IMAGE:-ghcr.io/rakuensoftware/aimee-llm-cpu:latest}
+    networks:
+      aimee:
+        aliases: [aimee-llm]
+    environment:
+      AIMEE_LLM_PORT: "8742"
+      AIMEE_LLM_NGL: "0"
+      # Must match the tier baked into the image; the supervisor finds the baked
+      # GGUFs + .ready markers and serves immediately, downloading nothing.
+      AIMEE_LLM_TIER: "cpu"
+      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   aimee-managed-postgres:

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -34,11 +34,12 @@ MODELS_DIR="${AIMEE_LLM_MODELS_DIR:-/models}"
 RERANK_ASSET_BASE="${AIMEE_LLM_RERANK_ASSET_BASE:-https://github.com/RakuenSoftware/aimee/releases/download/rerank-artifacts-v1}"
 # Synth context window. The synth GGUF (gemma) trains to 256K, but a hardcoded
 # --ctx-size 8192 wasted that: large code symbols / doc chunks overran 8K and the
-# server returned HTTP 400, failing extraction entirely. Default to a 16GB-VRAM-
-# safe 32K (4x the old cap, covers real source files); raise it on bigger cards
-# via AIMEE_LLM_SYNTH_CTX (e.g. 131072 for 128K). KV cache scales with context, so
-# size it to the card. Embed/rerank inputs are small — they keep the 8K default.
-SYNTH_CTX="${AIMEE_LLM_SYNTH_CTX:-32768}"
+# server returned HTTP 400, failing extraction entirely. The synth context defaults
+# PER TIER (synth_coords sets TIER_CTX; SYNTH_CTX is resolved from it once the tier
+# is known): cpu/small 32K, mid 256K (2 slots ×128K), large 1024K (4 slots ×256K).
+# KV cache scales with context and lives in VRAM under -ngl, so each tier's total is
+# sized to its target card. AIMEE_LLM_SYNTH_CTX overrides per deploy (e.g. a 24GB
+# card runs mid at 280000 = 4×70K). Embed/rerank inputs are small — they keep 8K.
 
 # ---- per-role tier -> model coordinates -------------------------------------
 # Each role's tier is chosen independently via AIMEE_LLM_<ROLE>_TIER, falling back
@@ -74,26 +75,26 @@ synth_coords() {
     cpu)
       SYNTH_REPO="ggml-org/gemma-4-E4B-it-GGUF"; SYNTH_FILE="gemma-4-E4B-it-Q4_K_M.gguf"
       SYNTH_REVISION="main"; SYNTH_SHA256=""
-      TIER_FA="off"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"; SYNTH_NGL=0
+      TIER_FA="off"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"; TIER_CTX="32768"; SYNTH_NGL=0
       ;;
     small)
       SYNTH_REPO="unsloth/gemma-4-12B-it-qat-GGUF"; SYNTH_FILE="gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"
       SYNTH_REVISION="9586f3257bc62bd179767241c7ec0f66bc2a314a"
       SYNTH_SHA256="cc9ff072e0a8203429ed854e6662c17a6c2bc1e5dca5b475dd4736caaacbc165"
-      TIER_FA="on"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"; SYNTH_NGL="$NGL"
+      TIER_FA="on"; TIER_MOE="0"; TIER_N_CPU_MOE="0"; TIER_SLOTS="1"; TIER_CTX="32768"; SYNTH_NGL="$NGL"
       ;;
     mid)
       SYNTH_REPO="unsloth/gemma-4-26B-A4B-it-qat-GGUF"; SYNTH_FILE="gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf"
       SYNTH_REVISION="02749a7b272109255a4c559a80894d3d9777574c"
       SYNTH_SHA256="dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e"
-      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="2"; SYNTH_NGL="$NGL"
+      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="2"; TIER_CTX="256000"; SYNTH_NGL="$NGL"
       ;;
     large)
-      # Byte-identical to mid EXCEPT SLOTS=4 (24GB→32GB card headroom).
+      # Byte-identical to mid EXCEPT SLOTS=4 + a 1024K ctx (24GB→32GB card headroom).
       SYNTH_REPO="unsloth/gemma-4-26B-A4B-it-qat-GGUF"; SYNTH_FILE="gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf"
       SYNTH_REVISION="02749a7b272109255a4c559a80894d3d9777574c"
       SYNTH_SHA256="dcf179a91153e3a7ece792e48ef872180d9d6ef9b7677f0a0bd3e83cfe624d5e"
-      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="4"; SYNTH_NGL="$NGL"
+      TIER_FA="on"; TIER_MOE="1"; TIER_N_CPU_MOE="0"; TIER_SLOTS="4"; TIER_CTX="1024000"; SYNTH_NGL="$NGL"
       ;;
     *) echo "aimee-llm: invalid AIMEE_LLM_SYNTH_TIER='$SYNTH_TIER' (cpu, small, mid, large)" >&2; exit 1 ;;
   esac
@@ -102,6 +103,10 @@ synth_coords() {
 embed_coords
 rerank_coords
 synth_coords
+
+# Synth context: an explicit AIMEE_LLM_SYNTH_CTX wins; otherwise the tier default
+# (TIER_CTX) set in synth_coords. Resolved here so the tier is already known.
+SYNTH_CTX="${AIMEE_LLM_SYNTH_CTX:-$TIER_CTX}"
 
 # ---- per-role backend mode (local | external | off) -------------------------
 # Each LLM role is independently local (a baked llama-server), external (the
@@ -137,6 +142,13 @@ MOE="${AIMEE_LLM_SYNTH_MOE:-$TIER_MOE}"
 MOE_LAYERS="${AIMEE_LLM_SYNTH_MOE_LAYERS:-40}"
 N_CPU_MOE="${AIMEE_LLM_SYNTH_N_CPU_MOE:-$TIER_N_CPU_MOE}"
 SLOTS="${AIMEE_LLM_SYNTH_SLOTS:-$TIER_SLOTS}"
+# Host-RAM prompt-cache cap (MiB). llama-server's default is 8192 (8 GiB) of
+# ANONYMOUS host RAM for its server-side prompt/checkpoint cache — independent of
+# the KV cache, which lives in VRAM under -ngl. On a modest appliance (e.g. a 16 GB
+# box also hosting postgres + kb + server) that 8 GiB default triggers a host OOM
+# that kills a postgres backend. Cap it low by default; operators with RAM to spare
+# can raise AIMEE_LLM_SYNTH_CACHE_RAM. The embedder already runs --cache-ram 0.
+SYNTH_CACHE_RAM="${AIMEE_LLM_SYNTH_CACHE_RAM:-2048}"
 
 # Gateway-facing model identity (all current tiers share the qwen3 embedder id +
 # last-token pooling — the gateway reads these for /health + the drift guard).
@@ -283,7 +295,8 @@ case "${AIMEE_LLM_STUB:-}" in
     # synth MODEL + its runtime profile come from the synth tier above; explicit
     # AIMEE_LLM_SYNTH_* envs still override per deploy.
     if [ "$SYNTH_MODE" = "local" ] && [ -f "$SYNTH_D/synth.gguf" ]; then
-      synth_args=(-ngl "$SYNTH_NGL" -m "$SYNTH_D/synth.gguf" --ctx-size "$SYNTH_CTX" --jinja --parallel "$SLOTS")
+      synth_args=(-ngl "$SYNTH_NGL" -m "$SYNTH_D/synth.gguf" --ctx-size "$SYNTH_CTX" --jinja \
+        --parallel "$SLOTS" --cache-ram "$SYNTH_CACHE_RAM")
       # Flash-attention + quantized KV (K8V4 by default). NOTE: quantized V-cache
       # REQUIRES fa (llama.cpp refuses otherwise), so a healthy start proves fa on.
       if [ "$FA" = "on" ]; then

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -103,6 +103,15 @@ static const char *deploy_role_mode(const char *backend)
    return "";
 }
 
+/* A GPU-class model tier — one served by the model-less aimee-llm image, which
+ * downloads the tier on first boot. The absence of any GPU tier (cpu, or an unset
+ * tier that resolves to cpu) selects the pre-baked aimee-llm-cpu image instead. */
+static int deploy_tier_is_gpu(const char *tier)
+{
+   return tier && (strcmp(tier, "small") == 0 || strcmp(tier, "mid") == 0 ||
+                   strcmp(tier, "large") == 0);
+}
+
 void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
 {
    if (!buf || n == 0)
@@ -123,12 +132,24 @@ void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)
    const int any_local =
        strcmp(eb, "local") == 0 || strcmp(rb, "local") == 0 || strcmp(sb, "local") == 0;
 
+   /* The locally-served LLM image depends on the tier. Any GPU tier (small/mid/
+    * large) on a local role selects the model-less aimee-llm image (profile "llm"),
+    * which downloads that tier on first boot and persists it in the /models volume.
+    * A pure-CPU stack (no GPU tier) selects the pre-baked aimee-llm-cpu image
+    * (profile "llm-cpu"), which ships the cpu GGUFs in the image and mounts no
+    * volume — the offline appliance LLM that, with aimee-kb, retires aimee-combined.
+    * The two profiles are mutually exclusive; both answer to the host "aimee-llm". */
+   const int gpu_local = (strcmp(eb, "local") == 0 && deploy_tier_is_gpu(cfg->llm_embed_tier)) ||
+                         (strcmp(rb, "local") == 0 && deploy_tier_is_gpu(cfg->llm_rerank_tier)) ||
+                         (strcmp(sb, "local") == 0 && deploy_tier_is_gpu(cfg->llm_synth_tier));
+
    /* COMPOSE_PROFILES: a remote kb deploys nothing; a local kb runs the "kb"
-    * service, plus "llm" whenever any role is served locally on this host. */
+    * service, plus the LLM profile whenever any role is served locally here. */
    char profiles[64] = "";
    if (!remote_kb)
    {
-      snprintf(profiles, sizeof(profiles), "kb%s", any_local ? ",llm" : "");
+      snprintf(profiles, sizeof(profiles), "kb%s",
+               any_local ? (gpu_local ? ",llm" : ",llm-cpu") : "");
    }
    EMITF("COMPOSE_PROFILES=%s\n", profiles);
 

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -108,8 +108,8 @@ static const char *deploy_role_mode(const char *backend)
  * tier that resolves to cpu) selects the pre-baked aimee-llm-cpu image instead. */
 static int deploy_tier_is_gpu(const char *tier)
 {
-   return tier && (strcmp(tier, "small") == 0 || strcmp(tier, "mid") == 0 ||
-                   strcmp(tier, "large") == 0);
+   return tier &&
+          (strcmp(tier, "small") == 0 || strcmp(tier, "mid") == 0 || strcmp(tier, "large") == 0);
 }
 
 void config_emit_deploy_env(const config_t *cfg, char *buf, size_t n)

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -2212,6 +2212,26 @@ int main(void)
       assert(strstr(env, "AIMEE_LLM_URL=http://aimee-llm:8742\n") != NULL);
       assert(strstr(env, "AIMEE_EMBEDDING_DIM") == NULL); /* local embed => unpinned/derived */
 
+      /* Local kb; all roles local at the CPU tier => the pre-baked llm-cpu profile
+       * (aimee-llm-cpu image), NOT the download "llm" profile. Same aimee-llm URL. */
+      memset(&cfg, 0, sizeof(cfg));
+      snprintf(cfg.kb_mode, sizeof(cfg.kb_mode), "local");
+      snprintf(cfg.llm_embed_backend, sizeof(cfg.llm_embed_backend), "local");
+      snprintf(cfg.llm_embed_tier, sizeof(cfg.llm_embed_tier), "cpu");
+      snprintf(cfg.llm_synth_backend, sizeof(cfg.llm_synth_backend), "local");
+      snprintf(cfg.llm_synth_tier, sizeof(cfg.llm_synth_tier), "cpu");
+      config_emit_deploy_env(&cfg, env, sizeof(env));
+      assert(strstr(env, "COMPOSE_PROFILES=kb,llm-cpu\n") != NULL);
+      assert(strstr(env, "COMPOSE_PROFILES=kb,llm\n") == NULL); /* not the GPU profile */
+      assert(strstr(env, "AIMEE_LLM_URL=http://aimee-llm:8742\n") != NULL);
+
+      /* A local role with an unset tier resolves to cpu, so it also takes llm-cpu. */
+      memset(&cfg, 0, sizeof(cfg));
+      snprintf(cfg.kb_mode, sizeof(cfg.kb_mode), "local");
+      snprintf(cfg.llm_synth_backend, sizeof(cfg.llm_synth_backend), "local");
+      config_emit_deploy_env(&cfg, env, sizeof(env));
+      assert(strstr(env, "COMPOSE_PROFILES=kb,llm-cpu\n") != NULL);
+
       /* Remote kb: connect out, deploy nothing (no profiles, no llm env). */
       memset(&cfg, 0, sizeof(cfg));
       snprintf(cfg.kb_mode, sizeof(cfg.kb_mode), "remote");


### PR DESCRIPTION
Root-caused and fixed a recurring host OOM on aimee-llm appliances that was taking down the KB.

## The bug

The synth `llama-server` launches with **no `--cache-ram`**, so it takes llama.cpp's **8 GiB default host-RAM prompt cache**. That is *anonymous host memory*, independent of the KV cache (which correctly lives in VRAM under `-ngl 99`). On a 16 GB appliance also running postgres + kb + server, that 8 GiB allocation triggers a host-wide OOM.

Observed live on .254 (24 GB GPU, 15 GB RAM): `llama-server` `anon-rss ~11 GB`, **`global_oom` roughly daily**, each kill taking a postgres backend with it (`terminating connection because of crash of another server process ... possibly corrupted shared memory`), leaving a 19h-wedged kb DB pool connection and a KB reporting `db2_ok:false / pgvec_ok:false`. The embedder already ran `--cache-ram 0`; only the synth path was uncapped.

## The fix

- **Cap the synth host prompt cache**: `--cache-ram "$SYNTH_CACHE_RAM"`, default **2048 MiB**, override via `AIMEE_LLM_SYNTH_CACHE_RAM`.
- **Per-tier synth context defaults** instead of one global 32K: cpu/small 32K, **mid 256K (2×128K)**, **large 1024K (4×256K)**, resolved from the tier once known. `AIMEE_LLM_SYNTH_CTX` still overrides per deploy (a 24 GB card runs mid at `280000` = 4×70K). `SLOTS` already defaulted per tier.

## Validation (live on .254)

After hot-patching the supervisor and restarting the LLM container:

| | before | after |
|---|---|---|
| synth `--cache-ram` | (8192 default) | **2048** |
| synth RSS | 8.75 GB | **62 MB** |
| host free / available | ~2 GB, swap exhausted | **~7 GB free / 11 GB avail** |
| GPU VRAM | 22.7/24.6 GB | 22.7/24.6 GB (unchanged — model+KV still on GPU) |
| kb health | `db2_ok:false, pgvec_ok:false` | **`db2_ok:true, pgvec_ok:true, 8248 vectors, 3448 chunks`** |

Tier→context resolution unit-checked: mid=2×128K, large=4×256K, and the `AIMEE_LLM_SYNTH_CTX=280000 SLOTS=4` override = 4×70K.