### PR TITLE
fix(ir): match legacy's temperature default; compare provider bodies semantically

### DIFF
--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -58,6 +58,17 @@ char *aimee_ir_build_provider_body(const cJSON *req, const char *driver_name,
       ir.max_tokens = max_tokens_override;
       ir.has_max_tokens = 1;
    }
+   /* Match the legacy ingress, which defaults an absent temperature to 1.0 and
+    * always emits it (build_provider_body is fed jo_num(req, "temperature", 1.0)).
+    * Applied at BUILD time, like legacy -- not in the frontend parse, so the IR
+    * request itself stays protocol-neutral (an Anthropic-parsed and OpenAI-parsed
+    * copy of the same request remain equal). Without it the IR omits temperature
+    * when the client sends none, diverging from the legacy provider body. */
+   if (!ir.has_temperature)
+   {
+      ir.temperature = 1.0;
+      ir.has_temperature = 1;
+   }
    /* The upstream stream flag is the CALLER's decision, not the client's: a caller
     * that streams to the client may still want the upstream reply buffered so it can
     * police + replay it. Inheriting ir.stream from the request is what made the

--- a/src/server/aimee_ir_shadow.c
+++ b/src/server/aimee_ir_shadow.c
@@ -33,9 +33,21 @@ void aimee_ir_shadow_compare_bodies(const char *ir_body, const char *legacy_body
 {
    if (!shadow_enabled())
       return;
-   /* A NULL on either side is a divergence, not a skip: "the IR could not build it"
-    * is exactly the case that forces a legacy fallback in production. */
-   if (ir_body && legacy_body && strcmp(ir_body, legacy_body) == 0)
+   /* Compare the two provider bodies SEMANTICALLY (parsed JSON), not byte-for-byte.
+    * The IR and legacy legitimately serialize the same request with keys in a
+    * different order ({"model","max_tokens","messages"} vs
+    * {"model","messages","max_tokens"}); a strcmp flags that as a mismatch even
+    * though the provider sees identical requests. cJSON_Compare ignores key order
+    * but still catches a genuine divergence -- a missing/extra field or a different
+    * value (e.g. legacy injecting a temperature default the IR omitted). A NULL on
+    * either side is a divergence, not a skip: "the IR could not build it" is exactly
+    * the case that forces a legacy fallback in production. */
+   cJSON *ir_json = ir_body ? cJSON_Parse(ir_body) : NULL;
+   cJSON *legacy_json = legacy_body ? cJSON_Parse(legacy_body) : NULL;
+   int equal = ir_json && legacy_json && cJSON_Compare(ir_json, legacy_json, 1);
+   cJSON_Delete(ir_json);
+   cJSON_Delete(legacy_json);
+   if (equal)
    {
       aimee_ir_metric_inc(AIMEE_IR_M_BODY_MATCH, frontend);
       return;

--- a/src/tests/test_ir_legacy_parity.c
+++ b/src/tests/test_ir_legacy_parity.c
@@ -88,6 +88,16 @@ int main(void)
        * NULL-check but corrupt the conversation. */
       cJSON *msgs = cJSON_GetObjectItem(j, "messages");
       assert(cJSON_IsArray(msgs) && cJSON_GetArraySize(msgs) >= 1);
+      /* temperature must ALWAYS be emitted: legacy injects it at build time
+       * (defaulting an absent value to 1.0), so the IR must too or the provider
+       * bodies diverge -- the shadow caught exactly this. The client value wins when
+       * present (one corpus shape sends 0.2); the rest get the 1.0 default. So the
+       * invariant is "present and numeric", and specifically 1.0 unless the shape
+       * set its own. */
+      cJSON *temp = cJSON_GetObjectItem(j, "temperature");
+      assert(temp && cJSON_IsNumber(temp));
+      cJSON *sent = cJSON_GetObjectItem(req, "temperature");
+      assert(temp->valuedouble == (cJSON_IsNumber(sent) ? sent->valuedouble : 1.0));
 
       cJSON_Delete(j);
       free(ir);

--- a/src/tests/test_ir_shadow_response.c
+++ b/src/tests/test_ir_shadow_response.c
@@ -213,6 +213,40 @@ int main(void)
       printf("  PASS: off unless AIMEE_IR_SHADOW is set\n");
    }
 
+   /* compare_bodies is SEMANTIC (parsed JSON), not byte-exact: two provider bodies
+    * with the same fields in a different key ORDER are a MATCH -- the provider sees
+    * identical requests, and requiring byte-identical serialization would flag
+    * legitimate ordering differences between the IR and legacy builders. */
+   {
+      aimee_ir_metrics_reset();
+      const char *ir_body = "{\"model\":\"m\",\"max_tokens\":16,\"messages\":[]}";
+      const char *legacy_body = "{\"model\":\"m\",\"messages\":[],\"max_tokens\":16}";
+      aimee_ir_shadow_compare_bodies(ir_body, legacy_body, AIMEE_WIRE_ANTHROPIC);
+      assert(aimee_ir_metric_total(AIMEE_IR_M_BODY_MATCH) == 1);
+      assert(aimee_ir_metric_total(AIMEE_IR_M_BODY_MISMATCH) == 0);
+      printf("  PASS: reordered keys are a body MATCH (semantic, not byte-exact)\n");
+   }
+
+   /* But a genuine divergence -- a field one side has and the other omits (exactly
+    * the temperature-default gap the shadow caught) -- is still a MISMATCH. */
+   {
+      aimee_ir_metrics_reset();
+      const char *ir_body = "{\"model\":\"m\",\"max_tokens\":16}";
+      const char *legacy_body = "{\"model\":\"m\",\"max_tokens\":16,\"temperature\":1.0}";
+      aimee_ir_shadow_compare_bodies(ir_body, legacy_body, AIMEE_WIRE_ANTHROPIC);
+      assert(aimee_ir_metric_total(AIMEE_IR_M_BODY_MISMATCH) == 1);
+      assert(aimee_ir_metric_total(AIMEE_IR_M_BODY_MATCH) == 0);
+      printf("  PASS: a missing/extra field is still a body MISMATCH\n");
+   }
+
+   /* A NULL body (the IR could not build it) is a divergence, not a skip. */
+   {
+      aimee_ir_metrics_reset();
+      aimee_ir_shadow_compare_bodies(NULL, "{\"model\":\"m\"}", AIMEE_WIRE_ANTHROPIC);
+      assert(aimee_ir_metric_total(AIMEE_IR_M_BODY_MISMATCH) == 1);
+      printf("  PASS: a NULL body counts as a mismatch\n");
+   }
+
    printf("ir-shadow-response: ok\n");
    return 0;
 }


### PR DESCRIPTION
The response-side shadow — run against **live .254 traffic** mirrored to a subscriber on .253 — caught the IR building a different provider body than legacy on the streaming path:

```
IR     : {"model":"local","max_tokens":16,"messages":[...]}
legacy : {"model":"local","messages":[...],"max_tokens":16,"temperature":1.0}
```

This is exactly what the shadow infrastructure was built to find. Two divergences — one real, one noise:

### 1. Real: the IR omitted a temperature default legacy injects

Legacy defaults an absent `temperature` to `1.0` and always emits it (the ingress feeds `build_provider_body` a `jo_num(req,"temperature",1.0)`); the IR omitted `temperature` entirely when the client sent none. When the client sends no temperature, legacy tells the provider `1.0` and the IR tells it nothing — a real behavior difference.

Fixed in `aimee_ir_build_provider_body` — the IR analog of legacy's build site — so the default is applied at **build time, like legacy**, not in the frontend parse. Applying it in the parse broke cross-protocol IR equality (an Anthropic-parsed vs OpenAI-parsed copy of the same request would differ); at the build site the IR request stays protocol-neutral and only the emitted body carries the default.

### 2. Noise: byte-comparison flagged key reordering

The two builders serialize the same request with keys in a different order. `compare_bodies` used `strcmp`, so it called that a mismatch even though the provider sees identical requests. It now parses both bodies and compares with `cJSON_Compare` — order-insensitive, but still catching a genuinely missing/extra field or a different value (like the temperature gap above).

### Tests

- Parity corpus now asserts every built body carries `temperature` — the client's value when sent (one shape sends `0.2`), else the `1.0` default.
- Shadow test asserts reordered keys are a **MATCH**, while a missing field or a NULL body is still a **MISMATCH**.
- Both fixes **falsified**: removing the default aborts the parity suite; reverting to `strcmp` aborts the shadow suite; both pass on restore.

`make all` + 486 unit tests + lint clean.
