### PR TITLE
fix(bridge): keep assistant text when a turn also makes a tool call

### DIFF
--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -796,7 +796,6 @@ void agent_parse_response_anthropic(cJSON *root, parsed_response_t *out)
    cJSON *stop = cJSON_GetObjectItem(root, "stop_reason");
    if (stop && cJSON_IsString(stop) && stop->valuestring)
       snprintf(out->stop_reason, sizeof(out->stop_reason), "%s", stop->valuestring);
-   int has_tool_use = (stop && cJSON_IsString(stop) && strcmp(stop->valuestring, "tool_use") == 0);
 
    cJSON *content = cJSON_GetObjectItem(root, "content");
    if (!content || !cJSON_IsArray(content))
@@ -832,11 +831,16 @@ void agent_parse_response_anthropic(cJSON *root, parsed_response_t *out)
             call->arguments = strdup("{}");
          out->call_count++;
       }
-      else if (strcmp(type->valuestring, "text") == 0 && !has_tool_use)
+      else if (strcmp(type->valuestring, "text") == 0)
       {
+         /* Preserve text even when the turn also makes a tool call: an Anthropic
+          * assistant response can carry both prose and a tool_use, and gating this
+          * on !has_tool_use DROPPED that text -- a real bug the canonical IR does
+          * not have (the shadow caught it as an ir_resp mismatch on live traffic).
+          * append_text concatenates multiple text blocks, matching the IR. */
          cJSON *text = cJSON_GetObjectItem(block, "text");
          if (text && cJSON_IsString(text))
-            out->content = strdup(text->valuestring);
+            append_text(&out->content, text->valuestring);
       }
    }
 

--- a/src/server/aimee_ir_shadow.c
+++ b/src/server/aimee_ir_shadow.c
@@ -158,8 +158,21 @@ void aimee_ir_shadow_compare_response(const struct parsed_response *legacy, cons
       return;
    }
 
-   char ir_text[8192];
-   aimee_ir_response_text(&ir, ir_text, sizeof(ir_text));
+   /* Size the buffer to the full concatenated TEXT rather than a fixed 8 KB: a
+    * fixed buffer truncated the IR text on long responses and every response longer
+    * than the buffer was a FALSE mismatch (legacy content full-length vs IR text cut
+    * at the cap). Sum the TEXT blocks and allocate exactly. */
+   size_t ir_text_cap = 1;
+   for (int i = 0; i < ir.n_content; i++)
+      if (ir.content[i].type == AIMEE_BLK_TEXT && ir.content[i].text)
+         ir_text_cap += strlen(ir.content[i].text);
+   char *ir_text = malloc(ir_text_cap);
+   if (!ir_text)
+   {
+      aimee_response_free(&ir);
+      return;
+   }
+   aimee_ir_response_text(&ir, ir_text, ir_text_cap);
    int ir_has_tool = aimee_ir_response_has_tool_use(&ir);
 
    int same = (legacy->is_tool_call ? 1 : 0) == (ir_has_tool ? 1 : 0) &&
@@ -183,6 +196,7 @@ void aimee_ir_shadow_compare_response(const struct parsed_response *legacy, cons
                  strlen(ir_text));
       }
    }
+   free(ir_text);
    aimee_response_free(&ir);
 }
 

--- a/src/tests/test_agent_http.c
+++ b/src/tests/test_agent_http.c
@@ -476,6 +476,30 @@ static void test_parse_response_captures_provider_model(void)
    printf("parse_response_captures_provider_model OK\n");
 }
 
+/* Regression: an Anthropic response can carry BOTH text and a tool_use in the same
+ * turn (prose, then a tool call). The legacy parser used to drop the text whenever
+ * stop_reason was tool_use -- a real bug the canonical IR did not have, which the
+ * shadow flagged as ir_resp mismatches on live traffic. The text must survive
+ * alongside the tool call. */
+static void test_parse_response_keeps_text_with_tool_use(void)
+{
+   const char *ant =
+       "{\"model\":\"m\",\"stop_reason\":\"tool_use\",\"content\":["
+       "{\"type\":\"text\",\"text\":\"Let me check that.\"},"
+       "{\"type\":\"tool_use\",\"id\":\"t1\",\"name\":\"grep\",\"input\":{\"q\":\"x\"}}]}";
+   cJSON *root = cJSON_Parse(ant);
+   assert(root != NULL);
+   parsed_response_t p;
+   memset(&p, 0, sizeof(p));
+   agent_parse_response_anthropic(root, &p);
+   assert(p.is_tool_call == 1);
+   assert(p.call_count == 1 && strcmp(p.calls[0].name, "grep") == 0);
+   assert(p.content && strcmp(p.content, "Let me check that.") == 0); /* text NOT dropped */
+   agent_free_parsed_response(&p);
+   cJSON_Delete(root);
+   printf("parse_response_keeps_text_with_tool_use OK\n");
+}
+
 static void test_delegate_rescue_parses_mistral_bracket(void)
 {
    parsed_response_t parsed;
@@ -956,6 +980,7 @@ int main(void)
    test_agent_config_recommended_sampling_roundtrip();
    test_parse_response_openai_sanitizes_invalid_tool_arguments();
    test_parse_response_captures_provider_model();
+   test_parse_response_keeps_text_with_tool_use();
    test_delegate_rescue_parses_mistral_bracket();
    test_delegate_rescue_parses_fenced_json();
    test_delegate_rescue_detects_invoke_markup();

--- a/src/tests/test_ir_shadow_response.c
+++ b/src/tests/test_ir_shadow_response.c
@@ -89,6 +89,27 @@ int main(void)
       printf("  PASS: divergent text counts a mismatch\n");
    }
 
+   /* 2b. A response longer than the old fixed 8 KB text buffer must still MATCH:
+    * the buffer used to truncate the IR text and every long response was a false
+    * mismatch (legacy full-length vs IR text cut at the cap). */
+   {
+      aimee_ir_metrics_reset();
+      size_t big = 20000;
+      char *longtext = malloc(big + 1);
+      memset(longtext, 'a', big);
+      longtext[big] = '\0';
+      parsed_response_t lg;
+      memset(&lg, 0, sizeof(lg));
+      lg.content = strdup(longtext);
+      cJSON *r = text_resp(longtext);
+      aimee_ir_shadow_compare_response(&lg, r, AIMEE_WIRE_ANTHROPIC);
+      assert(match() == 1 && mism() == 0);
+      cJSON_Delete(r);
+      free(lg.content);
+      free(longtext);
+      printf("  PASS: a >8KB response text is a match (no truncation false-positive)\n");
+   }
+
    /* 3. Whitespace-only difference is NOT a divergence. */
    {
       aimee_ir_metrics_reset();


### PR DESCRIPTION
## What breadth found

Running the response-side shadow against **broad, real .254 traffic** (Anthropic-wire delegates — mimo, MiniMax — not just the narrow OpenAI-wire subscriber test) surfaced a **~24% `ir_resp` mismatch rate**. Reading the diffs, *none of it was the IR being wrong.* It was two other things:

### 1. A real legacy bug (the IR was already correct)

`agent_parse_response_anthropic` dropped the assistant's **text** whenever `stop_reason` was `tool_use` (`type=="text" && !has_tool_use`). But an Anthropic turn can carry **both** prose and a `tool_use` in one response — legacy threw the prose away; the canonical IR kept it. So the shadow was flagging the IR being *more* correct than legacy.

```
legacy{tool=1 text=0}  ir{tool=1 text=284}   ← legacy dropped 284 chars of assistant text
```

Fixed: extract text regardless of `tool_use`, and **append** (not overwrite) so multiple text blocks concatenate, matching the IR. Downstream is unaffected — the delegate loop gates on `is_tool_call`, not on `content` being NULL, so preserving the text doesn't disturb tool dispatch.

### 2. A bug in the shadow comparator itself

`compare_response` concatenated the IR text into a fixed **8 KB** buffer, so any response longer than that was truncated on the IR side and counted as a **false mismatch** against legacy's full-length content.

```
legacy text=12213  ir text=8191   ← truncated by the comparator's buffer, not a real diff
```

Fixed: size the buffer to the actual concatenated text length.

## Why this matters for the migration

Together these were the *entire* `ir_resp_mismatch` signal on the broad run. Neither is the IR diverging from a correct legacy — one is legacy being wrong (IR fixes it), the other is my test harness. This **strengthens** the case for the IR: on real cross-wire traffic it's either identical to legacy or strictly more correct, with zero cases of the IR being worse.

## Tests

- The parser keeps text alongside a `tool_use` — falsified by re-injecting the original `!has_tool_use` guard (aborts), passes on restore.
- The comparator matches a >8 KB response — falsified by re-truncating the buffer (aborts), passes on restore.
- `make all` + 486 unit tests + lint clean.
