### PR TITLE
feat(delegate): make the canonical IR the default response parser

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -276,7 +276,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 152 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 153 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -476,7 +476,7 @@ The binaries read 152 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CONCURRENCY`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CONCURRENCY`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_RESPONSE_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -255,7 +255,7 @@ else ifeq ($(UNAME_S),Darwin)
         posix/agent_shell_claude.c posix/agent_shell_claude_pty.c posix/agent_shell_codex.c  \
         $(UI_PLATFORM_SRCS)
     PLATFORM_AGENT_SRCS = \
-        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
+        posix/agent_runtime.c posix/agent_ir_parse.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
 else
     PLATFORM_BASIC_SRCS = \
         posix/platform_ipc.c posix/platform_path.c posix/platform_process.c \
@@ -271,7 +271,7 @@ else
         posix/agent_shell_claude.c posix/agent_shell_claude_pty.c posix/agent_shell_codex.c  \
         $(UI_PLATFORM_SRCS)
     PLATFORM_AGENT_SRCS = \
-        posix/agent_runtime.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
+        posix/agent_runtime.c posix/agent_ir_parse.c posix/agent_max_turns.c posix/agent_runtime_messages.c posix/agent_runtime_support.c posix/agent_runtime_tmux.c posix/agent_bridge.c posix/agent_tools.c posix/workspace_provider.c posix/agent_source_authority.c posix/agent_tools_dispatch.c posix/td_search_render.c posix/sandbox.c
 endif
 
 PLATFORM_SRCS       = $(PLATFORM_BASIC_SRCS) $(PLATFORM_EXTRA_SRCS) $(PLATFORM_AGENT_SRCS)

--- a/src/headers/agent_protocol.h
+++ b/src/headers/agent_protocol.h
@@ -78,6 +78,12 @@ int agent_request_max_tokens(const agent_t *agent, int requested);
 void agent_parse_response_openai(struct cJSON *root, parsed_response_t *out);
 void agent_parse_response_responses(const char *body, parsed_response_t *out);
 void agent_parse_response_anthropic(struct cJSON *root, parsed_response_t *out);
+
+/* Parse a provider JSON response through the canonical IR and bridge it into a
+ * parsed_response_t (the default response path; see aimee_ir_response_path_enabled).
+ * `anthropic` selects the anthropic vs openai backend parser. Returns 0 on success,
+ * -1 if the IR could not parse (caller falls back to the legacy translators). */
+int agent_ir_parse_json_response(struct cJSON *root, int anthropic, parsed_response_t *out);
 /* Parse a Gemini generateContent response. Tracks cachedContentTokenCount as cache_read_tokens. */
 void agent_free_parsed_response(parsed_response_t *p);
 

--- a/src/headers/aimee_ir_serve.h
+++ b/src/headers/aimee_ir_serve.h
@@ -30,6 +30,12 @@ char *aimee_ir_build_provider_body(const struct cJSON *req, const char *driver_n
 /* 1 if the IR live-path flag is enabled (config-only: AIMEE_IR_PATH env). */
 int aimee_ir_path_enabled(void);
 
+/* 1 when the IR backend parsers are the primary parser for a delegate turn's
+ * provider RESPONSE (default ON; env AIMEE_IR_RESPONSE_PATH=0 forces legacy). Only
+ * the anthropic + openai JSON wires use it; the responses/SSE wire and any IR parse
+ * failure fall back to the legacy agent_parse_response_* translators. */
+int aimee_ir_response_path_enabled(void);
+
 /* 1 if the IR-delta streaming relay is enabled (config-only: AIMEE_IR_STREAM_RELAY
  * env; DEFAULT-OFF, gated separately from AIMEE_IR_PATH). When on, the incremental
  * OpenAI-chat -> Anthropic SSE relay uses the neutral IR-delta model instead of the

--- a/src/posix/agent_ir_parse.c
+++ b/src/posix/agent_ir_parse.c
@@ -1,0 +1,103 @@
+/* agent_ir_parse.c: parse a provider JSON response through the canonical IR and
+ * bridge it into the legacy parsed_response_t the delegate turn loop consumes.
+ * Split out of agent_runtime.c so it can be unit-tested without the whole runtime. */
+#include "aimee.h"
+
+#include "agent_protocol.h"
+#include "aimee_backend.h"
+#include "aimee_ir.h"
+#include "tool_call_args.h"
+#include "cJSON.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Parse a provider JSON response through the canonical IR and bridge it into the
+ * legacy parsed_response_t the turn loop consumes. Content and tool calls come from
+ * the IR backend parser -- the proven path (shadow-validated 191/191 on live .254
+ * traffic across the anthropic + openai wires, 0 mismatches). assistant_message --
+ * the conversation-replay turn, which the response shadow does NOT cover -- is taken
+ * from `root` exactly as the legacy parser does, so multi-turn history stays
+ * byte-identical. Returns 0 on success; -1 if the IR could not parse (the caller
+ * then falls back to the legacy translator). */
+int agent_ir_parse_json_response(cJSON *root, int anthropic, parsed_response_t *out)
+{
+   memset(out, 0, sizeof(*out));
+   aimee_response_t ir;
+   memset(&ir, 0, sizeof(ir));
+   char err[128] = "";
+   int rc = anthropic ? anthropic_backend_parse(root, &ir, err, sizeof err)
+                      : openai_backend_parse(root, &ir, err, sizeof err);
+   if (rc != 0)
+   {
+      aimee_response_free(&ir);
+      return -1;
+   }
+
+   if (ir.model)
+      snprintf(out->model, sizeof(out->model), "%s", ir.model);
+   if (ir.raw_stop_reason)
+      snprintf(out->stop_reason, sizeof(out->stop_reason), "%s", ir.raw_stop_reason);
+   out->prompt_tokens = (int)ir.usage_in;
+   out->completion_tokens = (int)ir.usage_out;
+   out->cache_write_tokens = (int)ir.usage_cache_write;
+   out->cache_read_tokens = (int)ir.usage_cache_read;
+
+   /* content: concatenated TEXT blocks (THINKING is excluded by the IR accessor). */
+   size_t need = 1;
+   for (int i = 0; i < ir.n_content; i++)
+      if (ir.content[i].type == AIMEE_BLK_TEXT && ir.content[i].text)
+         need += strlen(ir.content[i].text);
+   if (need > 1)
+   {
+      out->content = malloc(need);
+      if (out->content)
+         aimee_ir_response_text(&ir, out->content, need);
+   }
+
+   /* tool calls: id / name / arguments (arguments as a JSON string, like legacy). */
+   for (int i = 0; i < ir.n_content && out->call_count < AGENT_MAX_TOOL_CALLS; i++)
+   {
+      const aimee_block_t *b = &ir.content[i];
+      if (b->type != AIMEE_BLK_TOOL_USE)
+         continue;
+      out->is_tool_call = 1;
+      parsed_tool_call_t *c = &out->calls[out->call_count++];
+      if (b->tool_id)
+         snprintf(c->id, sizeof(c->id), "%s", b->tool_id);
+      if (b->tool_name)
+         snprintf(c->name, sizeof(c->name), "%s", b->tool_name);
+      char *args = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
+      c->arguments = args ? args : strdup("{}");
+   }
+
+   /* assistant_message for multi-turn replay -- taken from the raw response the same
+    * way the legacy parser does (content array for anthropic; the choice message,
+    * normalized, for openai), since the shadow validated content/tools but not this. */
+   if (anthropic)
+   {
+      if (out->is_tool_call)
+      {
+         cJSON *content = cJSON_GetObjectItemCaseSensitive(root, "content");
+         if (content)
+            out->assistant_message = cJSON_Duplicate(content, 1);
+      }
+   }
+   else
+   {
+      cJSON *choices = cJSON_GetObjectItemCaseSensitive(root, "choices");
+      cJSON *choice0 = choices ? cJSON_GetArrayItem(choices, 0) : NULL;
+      cJSON *msg = choice0 ? cJSON_GetObjectItemCaseSensitive(choice0, "message") : NULL;
+      if (msg)
+      {
+         out->assistant_message = cJSON_Duplicate(msg, 1);
+         for (int i = 0; i < out->call_count; i++)
+            tool_call_normalize_assistant_arguments(out->assistant_message, i,
+                                                    out->calls[i].arguments);
+         tool_call_sanitize_assistant_arguments(out->assistant_message);
+      }
+   }
+
+   aimee_response_free(&ir);
+   return 0;
+}

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -6,6 +6,10 @@
 #include "aimee.h"
 #include "agent.h"
 #include "aimee_ir_shadow.h"
+#include "aimee_backend.h"  /* anthropic_backend_parse / openai_backend_parse */
+#include "aimee_ir.h"       /* aimee_response_t + block accessors */
+#include "aimee_ir_serve.h" /* aimee_ir_response_path_enabled */
+#include "tool_call_args.h" /* assistant_message arg normalize/sanitize */
 #include "agent_exec.h"
 #include "agent_protocol.h"
 #include "agent_runtime_messages.h"
@@ -1106,20 +1110,40 @@ native_provider_http:
          cJSON *root = cJSON_Parse(response_body);
          if (root)
          {
-            if (anthropic)
-               agent_parse_response_anthropic(root, &parsed);
-            else
-               agent_parse_response_openai(root, &parsed);
-            /* Shadow (response side): parse the SAME response JSON through the IR
-             * backend parser and record whether it agrees with the legacy result.
-             * Off unless AIMEE_IR_SHADOW is set; never changes the turn -- the
-             * legacy `parsed` is what runs. This is the response-side twin of the
-             * request-body shadow, and the evidence that must show parity before
-             * the response translators can be retired. Only anthropic/openai are
-             * comparable here; the responses/SSE wire above is not JSON. */
+            aimee_wire_t rwire = anthropic ? AIMEE_WIRE_ANTHROPIC : AIMEE_WIRE_OPENAI_CHAT;
+            /* IR is now the primary response parser for the JSON wires (default ON;
+             * AIMEE_IR_RESPONSE_PATH=0 forces legacy). The legacy translators remain
+             * the automatic fallback if the IR cannot parse. */
+            int ir_primary = aimee_ir_response_path_enabled() &&
+                             agent_ir_parse_json_response(root, anthropic, &parsed) == 0;
+            if (!ir_primary)
+            {
+               if (anthropic)
+                  agent_parse_response_anthropic(root, &parsed);
+               else
+                  agent_parse_response_openai(root, &parsed);
+            }
+            /* Shadow (response side): keep comparing LEGACY vs IR even now that IR is
+             * primary -- run the legacy parse into a throwaway and compare, so the
+             * parity signal stays meaningful (not IR-vs-IR). Off unless
+             * AIMEE_IR_SHADOW is set; never changes the turn. When IR is NOT primary,
+             * `parsed` already holds the legacy result and is compared directly. */
             if (aimee_ir_shadow_enabled())
-               aimee_ir_shadow_compare_response(
-                   &parsed, root, anthropic ? AIMEE_WIRE_ANTHROPIC : AIMEE_WIRE_OPENAI_CHAT);
+            {
+               if (ir_primary)
+               {
+                  parsed_response_t legacy_p;
+                  memset(&legacy_p, 0, sizeof(legacy_p));
+                  if (anthropic)
+                     agent_parse_response_anthropic(root, &legacy_p);
+                  else
+                     agent_parse_response_openai(root, &legacy_p);
+                  aimee_ir_shadow_compare_response(&legacy_p, root, rwire);
+                  agent_free_parsed_response(&legacy_p);
+               }
+               else
+                  aimee_ir_shadow_compare_response(&parsed, root, rwire);
+            }
             cJSON_Delete(root);
          }
          else

--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -22,6 +22,21 @@ int aimee_ir_path_enabled(void)
    return 1;
 }
 
+int aimee_ir_response_path_enabled(void)
+{
+   /* DEFAULT-ON: the IR backend parsers are now the primary way a delegate turn's
+    * provider RESPONSE is parsed (proven live on .254 -- 191/191 response-parity
+    * matches across the anthropic + openai wires, 0 mismatches, after the legacy
+    * text-on-tool_use bug was fixed). An explicit setting wins; the legacy
+    * agent_parse_response_* translators remain as the automatic fallback on any IR
+    * parse failure, and still serve the responses/SSE (codex) wire, which the
+    * response shadow does not cover. Set AIMEE_IR_RESPONSE_PATH=0 to force legacy. */
+   const char *v = getenv("AIMEE_IR_RESPONSE_PATH");
+   if (v && v[0])
+      return v[0] != '0';
+   return 1;
+}
+
 int aimee_ir_stream_relay_enabled(void)
 {
    /* DEFAULT-OFF, gated SEPARATELY from AIMEE_IR_PATH (roundtable Q6: gate

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -149,6 +149,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-aimee-ir \
                $(TESTPREFIX)/unit-test-ir-legacy-parity \
                $(TESTPREFIX)/unit-test-aimee-ir-rescue \
+               $(TESTPREFIX)/unit-test-agent-ir-parse \
                $(TESTPREFIX)/unit-test-ir-shadow-response \
                $(TESTPREFIX)/unit-test-shadow-mirror \
                $(TESTPREFIX)/unit-test-aimee-ir-metrics \
@@ -4230,4 +4231,14 @@ $(TESTPREFIX)/unit-test-ir-shadow-response: $(OBJDIR)/tests/test_ir_shadow_respo
 $(TESTPREFIX)/unit-test-shadow-mirror: $(OBJDIR)/tests/test_shadow_mirror.o \
                                        $(OBJDIR)/server/shadow_mirror.o \
                                        $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-agent-ir-parse: $(OBJDIR)/tests/test_agent_ir_parse.o \
+                                        $(OBJDIR)/posix/agent_ir_parse.o \
+                                        $(OBJDIR)/server/aimee_backend_anthropic.o \
+                                        $(OBJDIR)/server/aimee_backend_openai.o \
+                                        $(OBJDIR)/server/aimee_ir.o \
+                                        $(OBJDIR)/server/aimee_ir_metrics.o \
+                                        $(OBJDIR)/server/tool_call_args.o \
+                                        $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/support/ir_shadow_stubs.c
+++ b/src/tests/support/ir_shadow_stubs.c
@@ -20,3 +20,45 @@ __attribute__((weak)) void aimee_ir_shadow_compare_response(const struct parsed_
    (void)resp_json;
    (void)wire;
 }
+
+/* --- IR response-path symbols wired into agent_runtime.c ------------------
+ * Weak so the minimal-link agent tests that don't exercise the IR response path
+ * resolve without the whole backend/IR chain. aimee_ir_response_path_enabled() ->
+ * 0 keeps those tests on the legacy parser, so the parse stubs below are never
+ * CALLED -- they exist only to satisfy the link. Real objects win when linked. */
+#include "aimee_backend.h"
+#include "aimee_ir.h"
+
+__attribute__((weak)) int aimee_ir_response_path_enabled(void)
+{
+   return 0;
+}
+__attribute__((weak)) int anthropic_backend_parse(const struct cJSON *resp, aimee_response_t *out,
+                                                  char *err, size_t errn)
+{
+   (void)resp;
+   (void)out;
+   (void)err;
+   (void)errn;
+   return -1;
+}
+__attribute__((weak)) int openai_backend_parse(const struct cJSON *resp, aimee_response_t *out,
+                                               char *err, size_t errn)
+{
+   (void)resp;
+   (void)out;
+   (void)err;
+   (void)errn;
+   return -1;
+}
+__attribute__((weak)) size_t aimee_ir_response_text(const aimee_response_t *r, char *buf, size_t n)
+{
+   (void)r;
+   if (buf && n)
+      buf[0] = '\0';
+   return 0;
+}
+__attribute__((weak)) void aimee_response_free(aimee_response_t *r)
+{
+   (void)r;
+}

--- a/src/tests/test_agent_ir_parse.c
+++ b/src/tests/test_agent_ir_parse.c
@@ -1,0 +1,114 @@
+/* test_agent_ir_parse.c -- agent_ir_parse_json_response: the IR-backed response
+ * parser that is now the default for delegate turns. The shadow validated content +
+ * tool-call parity on live traffic; this pins the bridge's own output shape --
+ * especially assistant_message (the multi-turn replay), which the shadow does not
+ * cover -- so a regression in the conversation-history contract is caught here. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aimee.h"
+
+#include "agent_protocol.h"
+#include "cJSON.h"
+
+/* Local copy of agent_free_parsed_response (agent_bridge.c) so the test stays
+ * self-contained rather than linking the whole legacy bridge. Same semantics. */
+void agent_free_parsed_response(parsed_response_t *p)
+{
+   if (!p)
+      return;
+   for (int i = 0; i < p->call_count; i++)
+      free(p->calls[i].arguments);
+   free(p->content);
+   if (p->assistant_message)
+      cJSON_Delete(p->assistant_message);
+   memset(p, 0, sizeof(*p));
+}
+
+int main(void)
+{
+   printf("agent-ir-parse:\n");
+
+   /* 1. Anthropic: text AND a tool_use in one turn. Both survive; assistant_message
+    * is the raw content array (what the anthropic multi-turn append re-wraps). */
+   {
+      const char *resp =
+          "{\"model\":\"m\",\"stop_reason\":\"tool_use\",\"content\":["
+          "{\"type\":\"text\",\"text\":\"Let me check.\"},"
+          "{\"type\":\"tool_use\",\"id\":\"t1\",\"name\":\"bash\",\"input\":{\"cmd\":\"ls\"}}],"
+          "\"usage\":{\"input_tokens\":11,\"output_tokens\":7}}";
+      cJSON *root = cJSON_Parse(resp);
+      assert(root);
+      parsed_response_t p;
+      int rc = agent_ir_parse_json_response(root, 1 /*anthropic*/, &p);
+      assert(rc == 0);
+      assert(p.is_tool_call == 1);
+      assert(p.call_count == 1 && strcmp(p.calls[0].name, "bash") == 0);
+      assert(strcmp(p.calls[0].id, "t1") == 0);
+      assert(p.content && strcmp(p.content, "Let me check.") == 0); /* text preserved */
+      assert(p.prompt_tokens == 11 && p.completion_tokens == 7);
+      assert(strcmp(p.stop_reason, "tool_use") == 0);
+      /* assistant_message == the content array (2 blocks), for anthropic replay */
+      assert(p.assistant_message && cJSON_IsArray(p.assistant_message));
+      assert(cJSON_GetArraySize(p.assistant_message) == 2);
+      /* the tool arguments round-trip to the input object */
+      cJSON *a = cJSON_Parse(p.calls[0].arguments);
+      assert(a && strcmp(cJSON_GetObjectItem(a, "cmd")->valuestring, "ls") == 0);
+      cJSON_Delete(a);
+      agent_free_parsed_response(&p);
+      cJSON_Delete(root);
+      printf("  PASS: anthropic text+tool_use bridged (text kept, assistant_message = content)\n");
+   }
+
+   /* 2. OpenAI: a tool_calls response. assistant_message is the choice message
+    * object (with tool_calls), which the openai multi-turn append reads. */
+   {
+      const char *resp =
+          "{\"model\":\"m\",\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":null,"
+          "\"tool_calls\":[{\"id\":\"c1\",\"type\":\"function\",\"function\":{\"name\":\"grep\","
+          "\"arguments\":\"{\\\"q\\\":\\\"x\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}],"
+          "\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3}}";
+      cJSON *root = cJSON_Parse(resp);
+      assert(root);
+      parsed_response_t p;
+      int rc = agent_ir_parse_json_response(root, 0 /*openai*/, &p);
+      assert(rc == 0);
+      assert(p.is_tool_call == 1 && p.call_count == 1);
+      assert(strcmp(p.calls[0].name, "grep") == 0);
+      /* assistant_message is the message object carrying tool_calls (for replay) */
+      assert(p.assistant_message && cJSON_IsObject(p.assistant_message));
+      assert(cJSON_GetObjectItem(p.assistant_message, "tool_calls") != NULL);
+      agent_free_parsed_response(&p);
+      cJSON_Delete(root);
+      printf("  PASS: openai tool_calls bridged (assistant_message = choice message)\n");
+   }
+
+   /* 3. Plain anthropic text (no tool call): content set, not a tool call, and no
+    * assistant_message (anthropic only replays it on a tool turn). */
+   {
+      const char *resp = "{\"model\":\"m\",\"stop_reason\":\"end_turn\",\"content\":["
+                         "{\"type\":\"text\",\"text\":\"done\"}]}";
+      cJSON *root = cJSON_Parse(resp);
+      parsed_response_t p;
+      assert(agent_ir_parse_json_response(root, 1, &p) == 0);
+      assert(p.is_tool_call == 0 && p.content && strcmp(p.content, "done") == 0);
+      assert(p.assistant_message == NULL);
+      agent_free_parsed_response(&p);
+      cJSON_Delete(root);
+      printf("  PASS: plain text response bridged\n");
+   }
+
+   /* 4. Unparseable -> -1 so the caller can fall back to the legacy translator. */
+   {
+      cJSON *root = cJSON_CreateArray(); /* not an object; backend parse fails */
+      parsed_response_t p;
+      assert(agent_ir_parse_json_response(root, 1, &p) == -1);
+      cJSON_Delete(root);
+      printf("  PASS: unparseable response returns -1 (legacy fallback)\n");
+   }
+
+   printf("agent-ir-parse: ok\n");
+   return 0;
+}


### PR DESCRIPTION
The first step of retiring the legacy translators: **make the canonical IR the default parser for a delegate turn's provider response.** Until now the IR response path was validated but had zero production callers — this flips it on by default.

## What it does

`agent_ir_parse_json_response` (new, `posix/agent_ir_parse.c`) parses a provider JSON response through `anthropic_backend_parse` / `openai_backend_parse` into the IR, then bridges it into the `parsed_response_t` the turn loop consumes:

- **Content and tool calls** come from the IR — the path the response shadow validated at **191/191 matches on live .254 traffic** (anthropic + openai wires, 0 mismatches).
- **`assistant_message`** (the multi-turn replay turn, which the shadow does *not* cover) is taken from the raw response exactly as the legacy parser does — the content array for anthropic, the choice message (normalized) for openai — so conversation history stays byte-identical.

## Gating and safety

Gated by `aimee_ir_response_path_enabled()`, **default ON**, `AIMEE_IR_RESPONSE_PATH=0` forces legacy.

- Only the **anthropic + openai JSON wires** use the IR. The **responses/SSE (codex) wire stays on legacy** — the response shadow doesn't cover it.
- On any IR parse failure, the caller **falls back to the legacy translator**, so a shape the IR can't handle degrades to today's behavior rather than erroring.
- The **XML rescue block is unchanged** (still `delegate_rescue_parse_tool_calls`); moving XML parsing under the IR is the next step.
- The **response shadow keeps comparing legacy vs IR** even now that IR is primary (it runs the legacy parse into a throwaway and compares), so the parity signal stays meaningful for a live rollout window.

## Tests

`agent_ir_parse_json_response` is pinned directly: anthropic text+tool_use (text kept, `assistant_message` = content array), openai tool_calls (`assistant_message` = choice message with tool_calls), plain text, and unparseable → −1 fallback. Falsified by dropping the text bridge (suite aborts; passes on restore). `make all` + 486 tests + lint clean; config reference regenerated.

## Rollout note

This is the riskiest change of the migration (the primary delegate execution path), which is why it ships **default-on but reversible**, keeps legacy as the automatic fallback, and leaves the shadow running to confirm parity in production. The recommended validation is: merge → deploy → confirm `ir_resp_mismatch` stays at 0 on live traffic with the IR now primary.
