### PR TITLE
feat(sandbox): --network none for delegate containers (slice 6)

### DIFF
--- a/src/server/delegate_backend_docker.c
+++ b/src/server/delegate_backend_docker.c
@@ -514,12 +514,20 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
 
       /* Sized from the mount array itself: a hand-counted bound silently overflows
        * the day a fourth mount is added. */
-      const char *create_argv[16 + 2 * (sizeof(st->mounts) / sizeof(st->mounts[0]))];
+      const char *create_argv[18 + 2 * (sizeof(st->mounts) / sizeof(st->mounts[0]))];
       int n = 0;
       create_argv[n++] = "docker";
       create_argv[n++] = "create";
       create_argv[n++] = "--name";
       create_argv[n++] = st->container_name;
+      /* Sandbox slice 6: no IP network at all. The delegate has no egress — web
+       * tools (web_search) run SERVER-side, and every file/exec op is marshalled in
+       * over `docker exec`, so nothing legitimate needs the container's network.
+       * `--network none` removes lateral movement and data-exfil paths in one flag.
+       * INVARIANT: never add a docker-socket bind (/var/run/docker.sock) below — it
+       * would hand the delegate root-equivalent control of the host daemon. */
+      create_argv[n++] = "--network";
+      create_argv[n++] = "none";
       if (userflag[0])
       {
          create_argv[n++] = "--user";

--- a/src/tests/test_delegate_backend_docker.c
+++ b/src/tests/test_delegate_backend_docker.c
@@ -229,6 +229,21 @@ static int fake_container_exists(const char *container_name)
    return stat(p, &s) == 0;
 }
 
+/* Did the last `docker create` argv (captured by the fixture) contain `needle`? */
+static int create_argv_has(const char *needle)
+{
+   char p[512];
+   snprintf(p, sizeof(p), "/tmp/aimee-fake-docker-state-%d/create.argv", (int)getpid());
+   FILE *f = fopen(p, "r");
+   if (!f)
+      return 0;
+   char buf[8192];
+   size_t got = fread(buf, 1, sizeof(buf) - 1, f);
+   fclose(f);
+   buf[got] = '\0';
+   return strstr(buf, needle) != NULL;
+}
+
 static void test_acquire_creates_and_starts_container(void)
 {
    delegate_backend_reset_for_test();
@@ -245,6 +260,11 @@ static void test_acquire_creates_and_starts_container(void)
    /* The fixture's "create" handler should have touched the .exists
     * flag for the canonical container name. */
    assert(fake_container_exists("aimee-delegate-task-acq-1"));
+
+   /* Sandbox slice 6: the container is created with no IP network, and the docker
+    * socket is NEVER bind-mounted in (that would be host-root for the delegate). */
+   assert(create_argv_has("--network") && create_argv_has("none"));
+   assert(!create_argv_has("docker.sock"));
 
    /* release(hibernate=0) → docker rm -f → flag removed. */
    b->release(b, state, 0);


### PR DESCRIPTION
Sandbox slice 6: cut the delegate container's network.

## What
Delegate containers ran on the default docker bridge — a lateral-movement and data-exfil surface a sandboxed delegate has no need for. The `docker create` now passes **`--network none`**: zero IP egress.

This is safe because nothing legitimate in the container needs the network:
- **web tools (`web_search`) run SERVER-side** — the delegate calls them over its existing channel; the server does the fetch.
- **file/exec ops are marshalled in over `docker exec`** — no in-container network involved.

**Invariant (asserted in the test):** the docker socket is NEVER bind-mounted into a delegate container — that would hand it root-equivalent control of the host daemon.

## Scope note — no `aimee-http.sock` bind (yet)
The sandbox spec paired `--network none` with binding `aimee-http.sock`. I left the socket bind OUT: nothing runs in-container today that calls back to the server (the CLI provider and native tools run host-side), so mounting it now would be an unused mount. `--network none` alone is a complete, no-regression isolation win; the socket bind should land when an in-container `aimee` CLI consumer actually exists.

## Validation
- **Unit**: `test_acquire_creates_and_starts_container` now reads the fixture's captured `create.argv` and asserts `--network none` is present and no `docker.sock` mount. Full `make unit-tests` suite green.
- **Real docker** (CT on .253, docker 26.1.5), replicating the backend's `docker create --network none -v ws:ws -w ws <img> sleep infinity` + `docker exec`:
  - `NetworkMode=none`
  - egress **blocked** — TCP to 1.1.1.1 and DNS both fail
  - `docker exec` still reads the bind-mounted workspace, and writes round-trip back to the host
  - no docker socket mounted

So egress is genuinely blocked while the delegate's real operational surface (exec + workspace) keeps working.