### PR TITLE
coord: allow ad-hoc (plan-less) jobs via WFE_COORD_PLAN_ID sentinel

### DIFF
--- a/src/db1/coord_jobs.c
+++ b/src/db1/coord_jobs.c
@@ -64,7 +64,13 @@ static void fill_task(db1_coord_task_t *out, sqlite3_stmt *stmt)
 
 int db1_coord_job_create(int plan_id, int max_concurrent)
 {
-   if (plan_id <= 0)
+   /* A real plan_id (>0) ties the job to an execution plan. WFE_COORD_PLAN_ID is
+    * the one sanctioned exception: an AD-HOC coord job the workflow engine
+    * enqueues to orchestrate a single delegate with no plan-IR decomposition
+    * (the task flow claim->dispatch->complete runs on job_id alone; plan_id is
+    * only metadata). Everything else — 0, other negatives — stays invalid, so an
+    * accidental 0 from a plan-based caller is still caught. */
+   if (plan_id <= 0 && plan_id != WFE_COORD_PLAN_ID)
       return -1;
    if (max_concurrent <= 0)
       max_concurrent = DB1_COORD_DEFAULT_PAR;

--- a/src/db1/coord_jobs.h
+++ b/src/db1/coord_jobs.h
@@ -25,6 +25,12 @@ extern "C"
 #define DB1_COORD_MAX_TASKS    64
 #define DB1_COORD_DEFAULT_PAR  3
 
+/* Sentinel plan_id for an AD-HOC coord job — one the workflow engine enqueues to
+ * orchestrate a single delegate with no execution-plan decomposition behind it.
+ * db1_coord_job_create accepts this in place of a real (>0) plan_id; every other
+ * non-positive value stays rejected, so an accidental 0 is still an error. */
+#define WFE_COORD_PLAN_ID (-1)
+
    typedef struct
    {
       int id;

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -110,7 +110,7 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
    }
 
    const char *persona = (role && role[0]) ? role : "engineer";
-   int job_id = db1_coord_job_create(0, 1);
+   int job_id = db1_coord_job_create(WFE_COORD_PLAN_ID, 1);
    if (job_id <= 0)
    {
       if (err && errlen)
@@ -246,7 +246,7 @@ static int wfe_live_judge_run(const char *workdir, const char *lens, char *out_v
     * write role, so the shared path's write-capable gate blocks any file edit at
     * the tool layer — the read-only property is enforced by the delegate system,
     * not by a WFE-side hard-reset. WFE just reads the verdict. */
-   int job_id = db1_coord_job_create(0, 1);
+   int job_id = db1_coord_job_create(WFE_COORD_PLAN_ID, 1);
    if (job_id <= 0)
    {
       snprintf(out_verdict, n, "{\"refuted\":true,\"reason\":\"could not create coord job\"}");

--- a/src/tests/test_coord_jobs.c
+++ b/src/tests/test_coord_jobs.c
@@ -105,6 +105,33 @@ static void test_job_create(void)
    printf("  PASS: test_job_create\n");
 }
 
+/* --- Test: ad-hoc job (WFE_COORD_PLAN_ID) vs. accidental plan_id 0 --- */
+
+static void test_adhoc_job_create(void)
+{
+   sqlite3 *db = setup();
+
+   /* The workflow engine enqueues plan-less delegate jobs with the sentinel. */
+   int adhoc = db1_coord_job_create(WFE_COORD_PLAN_ID, 1);
+   assert(adhoc > 0);
+   db1_coord_job_t job;
+   assert(db1_coord_job_get(adhoc, &job) == 0);
+   assert(job.plan_id == WFE_COORD_PLAN_ID);
+
+   /* An ad-hoc job still drives real tasks + dispatch on job_id alone. */
+   int tid = db1_coord_job_add_task(adhoc, 0, "[]", "code", "do it", "/wt", "architect");
+   assert(tid > 0);
+
+   /* But an accidental plan_id 0 (or other non-positive) is still rejected — the
+    * sentinel is the ONLY exception, so plan-based callers can't slip a bad id
+    * through unnoticed. */
+   assert(db1_coord_job_create(0, 1) < 0);
+   assert(db1_coord_job_create(-2, 1) < 0);
+
+   teardown(db);
+   printf("  PASS: test_adhoc_job_create\n");
+}
+
 /* --- Test: add tasks and list them --- */
 
 static void test_add_and_list_tasks(void)
@@ -458,8 +485,11 @@ static void test_invalid_ops(void)
 {
    sqlite3 *db = setup();
 
-   /* Invalid IDs */
-   assert(db1_coord_job_create(-1, 3) == -1);
+   /* Invalid IDs. plan_id 0 and other negatives are rejected; -1 is the
+    * WFE_COORD_PLAN_ID sentinel (a valid ad-hoc job) and is covered by
+    * test_adhoc_job_create, not here. */
+   assert(db1_coord_job_create(0, 3) == -1);
+   assert(db1_coord_job_create(-5, 3) == -1);
    assert(db1_coord_job_add_task(-1, 0, "[]", "", "", "", "engineer") == -1);
 
    db1_coord_task_t t;
@@ -554,6 +584,7 @@ int main(void)
 {
    printf("test_coord_jobs:\n");
    test_job_create();
+   test_adhoc_job_create();
    test_add_and_list_tasks();
    test_claim_no_conflict();
    test_file_conflict();


### PR DESCRIPTION
Follow-up to #1390 (WFE orchestrates delegates via the coord queue). That refactor enqueues one delegate task per workflow step with **no execution plan** behind it — `db1_coord_job_create(0, 1)`. But that function rejects `plan_id <= 0`, so **every WFE delegate dispatch failed instantly** and the block fast-looped to its cap with no coord job created. Caught the moment it ran live: plan/impl looping dozens of times in under a second, `coord_jobs` empty.

## Fix

Add `WFE_COORD_PLAN_ID` (`-1`) — a distinguished sentinel meaning *ad-hoc coord job, no plan-IR decomposition*. `db1_coord_job_create` accepts it in place of a real (`>0`) plan_id; **`0` and every other negative stay rejected**, so a plan-based caller that accidentally passes `0` is still caught.

Chosen over relaxing the guard to `<= 0`, which would have silently accepted that mistake for every caller. Nothing downstream needs `plan_id > 0` — the dispatcher drains by task status + `job_id` (`db1_coord_job_list_active_ids`), and `plan_id` is only metadata.

## Test

`test_adhoc_job_create`: an ad-hoc job creates + accepts tasks and dispatches on `job_id` alone, while `plan_id` `0` / other negatives are still rejected. `test_invalid_ops` updated (it asserted `-1` invalid; `-1` is now the sentinel). Full coord suite + server build clean.

_This is the fix that makes #1390 actually dispatch — validated by the live run that surfaced the fast-loop._