### PR TITLE
feat(sandbox): bind aimee-server UDS into delegate containers (slice 6 companion)

### DIFF
--- a/src/server/delegate_backend_docker.c
+++ b/src/server/delegate_backend_docker.c
@@ -22,6 +22,13 @@
 #include "util.h"
 
 #include "aimee.h" /* MAX_PATH_LEN */
+#include "aimee_home.h" /* aimee_home() — resolves the server's UDS path */
+
+/* Fixed in-container path for the bind-mounted aimee-server UDS. The delegate's
+ * only outward channel: `--network none` cuts every IP route, and AIMEE_API_ENDPOINT
+ * points the baked-in `aimee` CLI at this socket, so `aimee git_commit`,
+ * `aimee web_search`, `aimee memory ...` reach the server (and nothing else). */
+#define DELEGATE_SOCK_PATH "/run/aimee/aimee-http.sock"
 
 #include <ctype.h>
 #include <errno.h>
@@ -512,22 +519,44 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
       if (st->mount_host_tree)
          snprintf(userflag, sizeof(userflag), "%u:%u", (unsigned)getuid(), (unsigned)getgid());
 
+      /* The aimee-server UDS is the delegate's only outward channel (see the
+       * DELEGATE_SOCK_PATH note). Resolve + bind it; if the server has no socket
+       * yet (should not happen for a running server) we still create the container
+       * so file/exec isolation holds — the delegate just cannot call `aimee`. */
+      char host_sock[MAX_PATH_LEN + 32] = "";
+      char sock_bind[MAX_PATH_LEN + 96] = "";
+      const char *aimee_h = aimee_home();
+      if (aimee_h && aimee_h[0])
+         snprintf(host_sock, sizeof(host_sock), "%s/aimee-http.sock", aimee_h);
+      struct stat sock_st;
+      const int have_sock = host_sock[0] && stat(host_sock, &sock_st) == 0;
+      if (have_sock)
+         snprintf(sock_bind, sizeof(sock_bind), "%s:%s", host_sock, DELEGATE_SOCK_PATH);
+
       /* Sized from the mount array itself: a hand-counted bound silently overflows
-       * the day a fourth mount is added. */
-      const char *create_argv[18 + 2 * (sizeof(st->mounts) / sizeof(st->mounts[0]))];
+       * the day a fourth mount is added. Fixed slots cover docker/create/--name/
+       * --network/--user/-w/image/sleep + the aimee-socket -v and -e. */
+      const char *create_argv[24 + 2 * (sizeof(st->mounts) / sizeof(st->mounts[0]))];
       int n = 0;
       create_argv[n++] = "docker";
       create_argv[n++] = "create";
       create_argv[n++] = "--name";
       create_argv[n++] = st->container_name;
-      /* Sandbox slice 6: no IP network at all. The delegate has no egress — web
-       * tools (web_search) run SERVER-side, and every file/exec op is marshalled in
-       * over `docker exec`, so nothing legitimate needs the container's network.
-       * `--network none` removes lateral movement and data-exfil paths in one flag.
-       * INVARIANT: never add a docker-socket bind (/var/run/docker.sock) below — it
-       * would hand the delegate root-equivalent control of the host daemon. */
+      /* No IP network: the container's only reachable peer is aimee-server, over the
+       * bound UDS below. Removes lateral movement and data-exfil in one flag.
+       * INVARIANT: never bind the docker socket (/var/run/docker.sock) — that would
+       * hand the delegate root-equivalent control of the host daemon. */
       create_argv[n++] = "--network";
       create_argv[n++] = "none";
+      if (have_sock)
+      {
+         /* The one permitted channel out: aimee-server's UDS, with the in-container
+          * `aimee` CLI pointed at it. Auth is filesystem-permission on the socket. */
+         create_argv[n++] = "-v";
+         create_argv[n++] = sock_bind;
+         create_argv[n++] = "-e";
+         create_argv[n++] = "AIMEE_API_ENDPOINT=unix:" DELEGATE_SOCK_PATH;
+      }
       if (userflag[0])
       {
          create_argv[n++] = "--user";

--- a/src/server/delegate_backend_docker.c
+++ b/src/server/delegate_backend_docker.c
@@ -21,7 +21,7 @@
 #include "delegate_backend_docker.h"
 #include "util.h"
 
-#include "aimee.h" /* MAX_PATH_LEN */
+#include "aimee.h"      /* MAX_PATH_LEN */
 #include "aimee_home.h" /* aimee_home() — resolves the server's UDS path */
 
 /* Fixed in-container path for the bind-mounted aimee-server UDS. The delegate's

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3581,6 +3581,7 @@ $(TESTPREFIX)/unit-test-delegate-backend-ssh: $(OBJDIR)/tests/test_delegate_back
 $(TESTPREFIX)/unit-test-delegate-backend-docker: $(OBJDIR)/tests/test_delegate_backend_docker.o \
                      $(OBJDIR)/server/delegate_backend.o \
                      $(OBJDIR)/server/delegate_backend_docker.o $(OBJDIR)/log.o \
+                     $(OBJDIR)/aimee_home.o \
                      $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_delegate_backend_docker.c
+++ b/src/tests/test_delegate_backend_docker.c
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "aimee_home.h"
 #include "delegate_backend_docker.h"
 
 /* Forward decls — definitions live further down with the rest of the
@@ -252,6 +253,19 @@ static void test_acquire_creates_and_starts_container(void)
    const char *fixture = write_fake_docker_fixture();
    setenv("AIMEE_DOCKER_BIN", fixture, 1);
 
+   /* Slice 6: the backend binds aimee-server's UDS only when it exists on disk.
+    * Point aimee_home at a temp dir and plant a socket file there so the create
+    * argv includes the socket channel. (stat() only checks existence — a plain
+    * file stands in for the UDS.) */
+   char tmphome[] = "/tmp/aimee-deleg-sock-XXXXXX";
+   char sockpath[512] = "";
+   assert(mkdtemp(tmphome) != NULL);
+   setenv("AIMEE_HOME", tmphome, 1);
+   snprintf(sockpath, sizeof(sockpath), "%s/aimee-http.sock", tmphome);
+   FILE *sf = fopen(sockpath, "w");
+   assert(sf != NULL);
+   fclose(sf);
+
    delegate_backend_config_t cfg = {0};
    cfg.image = "ubuntu:22.04";
    void *state = NULL;
@@ -265,6 +279,13 @@ static void test_acquire_creates_and_starts_container(void)
     * socket is NEVER bind-mounted in (that would be host-root for the delegate). */
    assert(create_argv_has("--network") && create_argv_has("none"));
    assert(!create_argv_has("docker.sock"));
+   /* The delegate's ONE outward channel: aimee-server's UDS is bound in and the
+    * in-container `aimee` CLI is pointed at it (so `aimee git_commit` etc. work). */
+   assert(create_argv_has("aimee-http.sock"));
+   assert(create_argv_has("AIMEE_API_ENDPOINT=unix:/run/aimee/aimee-http.sock"));
+   unlink(sockpath);
+   unsetenv("AIMEE_HOME");
+   rmdir(tmphome);
 
    /* release(hibernate=0) → docker rm -f → flag removed. */
    b->release(b, state, 0);


### PR DESCRIPTION
Completes slice 6. `--network none` (#1392) cut every IP route from a delegate container — but that also severed the delegate's path to **aimee-server**, which is how a sandboxed delegate does anything outward: `aimee git_commit`, `aimee web_search`, `aimee memory …` run *in-container* and reach the server (which holds the forge creds and does the web fetch) over the `aimee-http.sock` UDS. Without the socket, a `--network none` delegate can't use `aimee` commands at all.

## Change
The delegate `docker create` now binds the server's UDS (`aimee_home()/aimee-http.sock`) into the container at a fixed **`/run/aimee/aimee-http.sock`** and sets **`AIMEE_API_ENDPOINT=unix:/run/aimee/aimee-http.sock`** so the baked-in `aimee` CLI (#1352) finds it. Combined with `--network none`, aimee-server becomes the delegate's **one and only** outward channel. The docker socket is still never mounted. Auth on the UDS is filesystem-permission (the container runs as the server uid for host-tree mounts).

## Validation
- **Unit**: the test points `aimee_home` at a temp dir, plants a socket, and hard-asserts the create argv carries the `aimee-http.sock` bind **and** `AIMEE_API_ENDPOINT` (added `aimee_home.o` to the test link set). Full `make unit-tests` suite green.
- **Real docker** (CT on .253, docker 26.1.5), a `--network none` container created exactly as the backend does, with the UDS bound:
  - in-container `AIMEE_API_ENDPOINT` = `unix:/run/aimee/aimee-http.sock`
  - the container **reaches the bound UDS** → the host socket server replies `AIMEE-SERVER-REACHED`
  - IP egress still **blocked** (`NO_EGRESS`), `NetworkMode=none`

So the delegate can reach aimee-server (and only aimee-server) for its git/web/memory commands, with no other network path.