### PR TITLE
fix(shadow): fold streamed codex text into the responses object

### DIFF
--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -770,11 +770,45 @@ void agent_parse_response_responses(const char *body, parsed_response_t *out)
       cJSON_Delete(collected_output);
 }
 
+/* 1 if `resp`'s output array already carries a non-empty output_text part. */
+static int responses_object_has_output_text(cJSON *resp)
+{
+   cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");
+   if (!cJSON_IsArray(output))
+      return 0;
+   cJSON *item = NULL;
+   cJSON_ArrayForEach(item, output)
+   {
+      cJSON *type = cJSON_GetObjectItemCaseSensitive(item, "type");
+      if (!type || !cJSON_IsString(type) || strcmp(type->valuestring, "message") != 0)
+         continue;
+      cJSON *content = cJSON_GetObjectItemCaseSensitive(item, "content");
+      cJSON *part = NULL;
+      if (cJSON_IsArray(content))
+         cJSON_ArrayForEach(part, content)
+         {
+            cJSON *pt = cJSON_GetObjectItemCaseSensitive(part, "type");
+            cJSON *tx = cJSON_GetObjectItemCaseSensitive(part, "text");
+            if (pt && cJSON_IsString(pt) && strcmp(pt->valuestring, "output_text") == 0 && tx &&
+                cJSON_IsString(tx) && tx->valuestring[0])
+               return 1;
+         }
+   }
+   return 0;
+}
+
 /* Extract the Responses (codex) "response object" -- the one carrying the `output`
  * item array -- from an SSE body, so the IR responses_backend_parse (and the response
  * shadow) can consume the same shape the JSON wires do. Prefers the response.completed
  * event's payload; falls back to parsing the whole body as a single JSON object
- * (non-streaming). Returns a new cJSON the caller owns, or NULL. */
+ * (non-streaming).
+ *
+ * Codex streams the answer text as output_text deltas and its completed event's
+ * message body is often EMPTY, so responses_backend_parse would see no text (while the
+ * legacy parser recovered it from the deltas). Fold the SSE-aggregated text -- the
+ * same text legacy uses, captured in the scratch parse below -- back into the object's
+ * output when the completed message lacks it, so the object is self-contained. Returns
+ * a new cJSON the caller owns, or NULL. */
 cJSON *agent_responses_sse_response_object(const char *body)
 {
    if (!body)
@@ -786,14 +820,34 @@ cJSON *agent_responses_sse_response_object(const char *body)
    cJSON *completed = NULL;
    responses_parse_sse_events(body, &scratch, collected, &delta_text, &done_text, &part_text,
                               &completed);
-   free(delta_text);
-   free(done_text);
-   free(part_text);
-   agent_free_parsed_response(&scratch);
+   /* Fold the streamed text into scratch.content the same way the legacy parser does
+    * (output_item.done text, else content_part.done, else the output_text deltas --
+    * longest wins). These helpers consume the passed-in strings. */
+   responses_take_longer_content(&scratch, &part_text);
+   responses_take_longer_content(&scratch, &done_text);
+   responses_take_longer_content(&scratch, &delta_text);
    cJSON_Delete(collected);
-   if (completed)
-      return completed; /* the response object (has `output` + `usage`) */
-   return cJSON_Parse(body);
+
+   cJSON *resp = completed ? completed : cJSON_Parse(body);
+   if (resp && scratch.content && scratch.content[0] && !responses_object_has_output_text(resp))
+   {
+      cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");
+      if (!cJSON_IsArray(output))
+         output = cJSON_AddArrayToObject(resp, "output");
+      if (cJSON_IsArray(output))
+      {
+         cJSON *msg = cJSON_CreateObject();
+         cJSON_AddStringToObject(msg, "type", "message");
+         cJSON *content = cJSON_AddArrayToObject(msg, "content");
+         cJSON *part = cJSON_CreateObject();
+         cJSON_AddStringToObject(part, "type", "output_text");
+         cJSON_AddStringToObject(part, "text", scratch.content);
+         cJSON_AddItemToArray(content, part);
+         cJSON_AddItemToArray(output, msg);
+      }
+   }
+   agent_free_parsed_response(&scratch);
+   return resp;
 }
 
 void agent_parse_response_anthropic(cJSON *root, parsed_response_t *out)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -30,6 +30,8 @@ void test_tools_enabled_capability_default(void);
  * 2000-line hard limit); called from main() below. */
 void test_responses_parser_keeps_all_output_text_parts(void);
 void test_responses_parser_accumulates_output_text_deltas(void);
+void test_responses_object_folds_in_delta_text(void);
+void test_responses_object_keeps_existing_text(void);
 void test_responses_parser_uses_output_text_done(void);
 void test_responses_parser_separates_message_items(void);
 
@@ -2594,6 +2596,8 @@ int main(void)
    test_codex_oauth_auth_resolution();
    test_responses_parser_keeps_all_output_text_parts();
    test_responses_parser_accumulates_output_text_deltas();
+   test_responses_object_folds_in_delta_text();
+   test_responses_object_keeps_existing_text();
    test_responses_parser_uses_output_text_done();
    test_responses_parser_separates_message_items();
    test_agent_is_exec_role();

--- a/src/tests/test_agent_responses.c
+++ b/src/tests/test_agent_responses.c
@@ -9,6 +9,7 @@
 #include "aimee.h"
 #include "agent.h"
 #include "agent_protocol.h"
+#include "cJSON.h"
 
 void test_responses_parser_keeps_all_output_text_parts(void)
 {
@@ -49,6 +50,84 @@ void test_responses_parser_accumulates_output_text_deltas(void)
    assert(parsed.prompt_tokens == 5);
    assert(parsed.completion_tokens == 6);
    agent_free_parsed_response(&parsed);
+}
+
+/* Walk a Responses object's output[] for the first non-empty message output_text.
+ * Returns a borrowed pointer into `resp`, or NULL. */
+static const char *first_output_text(struct cJSON *resp)
+{
+   struct cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");
+   struct cJSON *item = NULL;
+   cJSON_ArrayForEach(item, output)
+   {
+      struct cJSON *type = cJSON_GetObjectItemCaseSensitive(item, "type");
+      if (!type || !cJSON_IsString(type) || strcmp(type->valuestring, "message") != 0)
+         continue;
+      struct cJSON *content = cJSON_GetObjectItemCaseSensitive(item, "content");
+      struct cJSON *part = NULL;
+      cJSON_ArrayForEach(part, content)
+      {
+         struct cJSON *pt = cJSON_GetObjectItemCaseSensitive(part, "type");
+         struct cJSON *tx = cJSON_GetObjectItemCaseSensitive(part, "text");
+         if (pt && cJSON_IsString(pt) && strcmp(pt->valuestring, "output_text") == 0 && tx &&
+             cJSON_IsString(tx) && tx->valuestring[0])
+            return tx->valuestring;
+      }
+   }
+   return NULL;
+}
+
+/* Codex streams the answer as output_text deltas and its response.completed event
+ * carries "output":[] (empty). The response OBJECT the IR/shadow consume must still
+ * carry the text, so agent_responses_sse_response_object folds the SSE-aggregated
+ * text back into output[] -- otherwise responses_backend_parse sees zero text while
+ * the legacy parser recovered it (the live wire=3 shadow mismatch). */
+void test_responses_object_folds_in_delta_text(void)
+{
+   const char *body =
+       "event: response.output_text.delta\r\n"
+       "data: {\"delta\":\"deployed to \"}\r\n\r\n"
+       "event: response.output_text.delta\r\n"
+       "data: {\"delta\":\"192.168.1.254\"}\r\n\r\n"
+       "event: response.completed\r\n"
+       "data: {\"response\":{\"output\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":6}}}"
+       "\r\n\r\n";
+
+   struct cJSON *resp = agent_responses_sse_response_object(body);
+   assert(resp != NULL);
+   const char *txt = first_output_text(resp);
+   assert(txt != NULL);
+   assert(strcmp(txt, "deployed to 192.168.1.254") == 0);
+   cJSON_Delete(resp);
+}
+
+/* Guard against double-injection: when the completed object ALREADY carries the
+ * message text (non-codex responses that repeat it in output[]), the extractor must
+ * leave a single output_text -- not append a duplicate. */
+void test_responses_object_keeps_existing_text(void)
+{
+   const char *body = "event: response.output_text.delta\r\n"
+                      "data: {\"delta\":\"hello there\"}\r\n\r\n"
+                      "event: response.completed\r\n"
+                      "data: {\"response\":{\"output\":[{\"type\":\"message\",\"content\":["
+                      "{\"type\":\"output_text\",\"text\":\"hello there\"}]}],"
+                      "\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\r\n\r\n";
+
+   struct cJSON *resp = agent_responses_sse_response_object(body);
+   assert(resp != NULL);
+   struct cJSON *output = cJSON_GetObjectItemCaseSensitive(resp, "output");
+   int message_items = 0;
+   struct cJSON *item = NULL;
+   cJSON_ArrayForEach(item, output)
+   {
+      struct cJSON *type = cJSON_GetObjectItemCaseSensitive(item, "type");
+      if (type && cJSON_IsString(type) && strcmp(type->valuestring, "message") == 0)
+         message_items++;
+   }
+   assert(message_items == 1); /* not duplicated */
+   const char *txt = first_output_text(resp);
+   assert(txt != NULL && strcmp(txt, "hello there") == 0);
+   cJSON_Delete(resp);
 }
 
 void test_responses_parser_uses_output_text_done(void)


### PR DESCRIPTION
## What

The responses/SSE (codex) shadow reported `wire=3` mismatches on live .254 traffic: legacy recovered the reply text, the IR saw `text=0`.

Codex streams the answer as `output_text` deltas and its `response.completed` event carries `"output":[]` (empty). `responses_backend_parse` is a static-object parser, so it found no text, while the legacy parser aggregated it from the deltas — a real parity gap on the only wire that was previously invisible to the shadow.

## Fix

`agent_responses_sse_response_object` now folds the SSE-aggregated text (the same `output_item.done` / `content_part.done` / delta selection the legacy parser uses, longest wins) back into the response object's `output[]` when the completed message lacks it. Guarded against double-injection when the object already carries the text, so non-codex responses are untouched.

This makes the extracted object self-contained, so the IR and legacy agree on the responses wire — the last wire blocking deletion of the legacy translators.

## Tests

- `test_responses_object_folds_in_delta_text` — a delta-only stream with empty `output` folds the text in.
- `test_responses_object_keeps_existing_text` — a completed object already carrying `output_text` is left with a single message (no duplicate).

Both bite under falsification (poison the fold → assertion aborts).