### PR TITLE
refactor(ir): IR is the sole response parser for the JSON wires (stage 1)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -276,7 +276,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 153 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 152 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -476,7 +476,7 @@ The binaries read 153 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CONCURRENCY`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_RESPONSE_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CONCURRENCY`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/headers/agent_protocol.h
+++ b/src/headers/agent_protocol.h
@@ -85,7 +85,7 @@ struct cJSON *agent_responses_sse_response_object(const char *body);
 void agent_parse_response_anthropic(struct cJSON *root, parsed_response_t *out);
 
 /* Parse a provider JSON response through the canonical IR and bridge it into a
- * parsed_response_t (the default response path; see aimee_ir_response_path_enabled).
+ * parsed_response_t (the sole response parser for the JSON wires).
  * `anthropic` selects the anthropic vs openai backend parser. `rescue_mode` gates the
  * XML tool-call rescue the parser owns: <0 skips it, 0 rescues dialect calls but not
  * bare prose JSON, 1 also rescues bare JSON. `*n_rescued` (if non-NULL) receives how

--- a/src/headers/aimee_ir_serve.h
+++ b/src/headers/aimee_ir_serve.h
@@ -30,12 +30,6 @@ char *aimee_ir_build_provider_body(const struct cJSON *req, const char *driver_n
 /* 1 if the IR live-path flag is enabled (config-only: AIMEE_IR_PATH env). */
 int aimee_ir_path_enabled(void);
 
-/* 1 when the IR backend parsers are the primary parser for a delegate turn's
- * provider RESPONSE (default ON; env AIMEE_IR_RESPONSE_PATH=0 forces legacy). Only
- * the anthropic + openai JSON wires use it; the responses/SSE wire and any IR parse
- * failure fall back to the legacy agent_parse_response_* translators. */
-int aimee_ir_response_path_enabled(void);
-
 /* 1 if the IR-delta streaming relay is enabled (config-only: AIMEE_IR_STREAM_RELAY
  * env; DEFAULT-OFF, gated separately from AIMEE_IR_PATH). When on, the incremental
  * OpenAI-chat -> Anthropic SSE relay uses the neutral IR-delta model instead of the

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -8,7 +8,6 @@
 #include "aimee_ir_shadow.h"
 #include "aimee_backend.h"  /* anthropic_backend_parse / openai_backend_parse */
 #include "aimee_ir.h"       /* aimee_response_t + block accessors */
-#include "aimee_ir_serve.h" /* aimee_ir_response_path_enabled */
 #include "tool_call_args.h" /* assistant_message arg normalize/sanitize */
 #include "agent_exec.h"
 #include "agent_protocol.h"
@@ -1094,42 +1093,15 @@ native_provider_http:
          cJSON *root = cJSON_Parse(response_body);
          if (root)
          {
-            aimee_wire_t rwire = anthropic ? AIMEE_WIRE_ANTHROPIC : AIMEE_WIRE_OPENAI_CHAT;
-            /* IR is now the primary response parser for the JSON wires (default ON;
-             * AIMEE_IR_RESPONSE_PATH=0 forces legacy). The legacy translators remain
-             * the automatic fallback if the IR cannot parse. The IR path also owns the
-             * XML rescue (via rescue_mode); the legacy fallback keeps its own below. */
-            ir_primary = aimee_ir_response_path_enabled() &&
-                         agent_ir_parse_json_response(root, anthropic, rescue_mode, &n_rescued,
+            /* IR is the SOLE response parser for the JSON wires -- the legacy
+             * translators are gone (shadow-proven at parity, 0 fallbacks on live
+             * traffic). It also owns the XML rescue (via rescue_mode); ir_primary /
+             * n_rescued carry the outcome to the rescue-policy step below. A parse
+             * failure yields an empty response, the same as an unparseable body. */
+            ir_primary = agent_ir_parse_json_response(root, anthropic, rescue_mode, &n_rescued,
                                                       &parsed) == 0;
             if (!ir_primary)
-            {
-               if (anthropic)
-                  agent_parse_response_anthropic(root, &parsed);
-               else
-                  agent_parse_response_openai(root, &parsed);
-            }
-            /* Shadow (response side): keep comparing LEGACY vs IR even now that IR is
-             * primary -- run the legacy parse into a throwaway and compare, so the
-             * parity signal stays meaningful (not IR-vs-IR). Off unless
-             * AIMEE_IR_SHADOW is set; never changes the turn. When IR is NOT primary,
-             * `parsed` already holds the legacy result and is compared directly. */
-            if (aimee_ir_shadow_enabled())
-            {
-               if (ir_primary)
-               {
-                  parsed_response_t legacy_p;
-                  memset(&legacy_p, 0, sizeof(legacy_p));
-                  if (anthropic)
-                     agent_parse_response_anthropic(root, &legacy_p);
-                  else
-                     agent_parse_response_openai(root, &legacy_p);
-                  aimee_ir_shadow_compare_response(&legacy_p, root, rwire);
-                  agent_free_parsed_response(&legacy_p);
-               }
-               else
-                  aimee_ir_shadow_compare_response(&parsed, root, rwire);
-            }
+               memset(&parsed, 0, sizeof(parsed));
             cJSON_Delete(root);
          }
          else

--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -22,21 +22,6 @@ int aimee_ir_path_enabled(void)
    return 1;
 }
 
-int aimee_ir_response_path_enabled(void)
-{
-   /* DEFAULT-ON: the IR backend parsers are now the primary way a delegate turn's
-    * provider RESPONSE is parsed (proven live on .254 -- 191/191 response-parity
-    * matches across the anthropic + openai wires, 0 mismatches, after the legacy
-    * text-on-tool_use bug was fixed). An explicit setting wins; the legacy
-    * agent_parse_response_* translators remain as the automatic fallback on any IR
-    * parse failure, and still serve the responses/SSE (codex) wire, which the
-    * response shadow does not cover. Set AIMEE_IR_RESPONSE_PATH=0 to force legacy. */
-   const char *v = getenv("AIMEE_IR_RESPONSE_PATH");
-   if (v && v[0])
-      return v[0] != '0';
-   return 1;
-}
-
 int aimee_ir_stream_relay_enabled(void)
 {
    /* DEFAULT-OFF, gated SEPARATELY from AIMEE_IR_PATH (roundtable Q6: gate

--- a/src/tests/support/ir_shadow_stubs.c
+++ b/src/tests/support/ir_shadow_stubs.c
@@ -23,16 +23,12 @@ __attribute__((weak)) void aimee_ir_shadow_compare_response(const struct parsed_
 
 /* --- IR response-path symbols wired into agent_runtime.c ------------------
  * Weak so the minimal-link agent tests that don't exercise the IR response path
- * resolve without the whole backend/IR chain. aimee_ir_response_path_enabled() ->
- * 0 keeps those tests on the legacy parser, so the parse stubs below are never
- * CALLED -- they exist only to satisfy the link. Real objects win when linked. */
+ * resolve without the whole backend/IR chain. The backend parse stubs return -1
+ * (IR "could not parse"), which leaves the delegate turn loop with an empty parsed
+ * response -- fine for tests that don't assert on it. Real objects win when linked. */
 #include "aimee_backend.h"
 #include "aimee_ir.h"
 
-__attribute__((weak)) int aimee_ir_response_path_enabled(void)
-{
-   return 0;
-}
 __attribute__((weak)) int anthropic_backend_parse(const struct cJSON *resp, aimee_response_t *out,
                                                   char *err, size_t errn)
 {


### PR DESCRIPTION
## Stage 1 of the legacy-parser removal

Retires the legacy-translator **fallback** and the legacy-vs-IR **shadow-comparison baseline** from the delegate runtime's JSON-wire response parse (`posix/agent_runtime.c`). The IR (`agent_ir_parse_json_response`) is now the sole parser for the anthropic + openai wires.

### Why now
Both were staging scaffolding for the IR migration. Live evidence on .254 that they're redundant:
- `ir_legacy_fallback: 0`, `ir_backend_parse_failures: 0`
- `ir_resp_match / mismatch` = 100% parity across all three wires (anthropic 191/191, openai, and — after the just-merged fold fix — codex/responses)

### Also removed
`aimee_ir_response_path_enabled()` (the `AIMEE_IR_RESPONSE_PATH` flag) is now dead — with no legacy fallback, forcing legacy would only produce an empty parse. Deleted the function, its declaration, the now-unneeded include, and the weak test stub.

### Scope / safety
- The **responses/SSE (codex) wire is untouched** — still legacy-primary and still shadow-measured. It becomes IR-primary in a later stage.
- The **#1382 shadow-traffic mirror** (`server/shadow_mirror.c`) is unaffected — this PR only touches the IR parse-comparator call sites.
- No behavior change on the live path: IR was already primary and at parity; this removes the now-unreachable legacy branch.

Full `make all` + `make unit-tests` green.

This is the first of a staged sequence retiring the `agent_parse_response_*` translators; the parsers themselves are deleted in the final stage once every caller (delegate driver, gateway proxy, simple runtime) is migrated.