### PR TITLE
refactor(ir): the responses/codex wire is IR-primary (stage 2)

### DIFF
--- a/src/headers/agent_protocol.h
+++ b/src/headers/agent_protocol.h
@@ -94,6 +94,16 @@ void agent_parse_response_anthropic(struct cJSON *root, parsed_response_t *out);
 int agent_ir_parse_json_response(struct cJSON *root, int anthropic, int rescue_mode, int *n_rescued,
                                  parsed_response_t *out);
 
+/* Parse a Responses/SSE (codex) reply through the canonical IR and bridge it into a
+ * parsed_response_t. Extracts the response object from the SSE `body` (via
+ * agent_responses_sse_response_object), parses it with responses_backend_parse, and
+ * owns the XML rescue (rescue_mode: <0 skips; 0 dialect calls; 1 also bare JSON;
+ * *n_rescued receives the count). assistant_message for multi-turn replay is the
+ * response's output-item array (function_call items carry call_id). Returns 0 on
+ * success, -1 if the IR could not parse. */
+int agent_ir_parse_responses(const char *body, int rescue_mode, int *n_rescued,
+                             parsed_response_t *out);
+
 /* Build an OpenAI assistant message ({role, content:null, tool_calls}) from parsed
  * calls -- used to make a replayable turn after an XML tool-call rescue. */
 struct cJSON *agent_build_openai_assistant_message_from_calls(parsed_response_t *parsed);

--- a/src/posix/agent_ir_parse.c
+++ b/src/posix/agent_ir_parse.c
@@ -80,6 +80,8 @@ cJSON *agent_build_openai_assistant_message_from_calls(parsed_response_t *parsed
  * legacy did) and openai rebuilds it from the recovered calls.
  *
  * Returns 0 on success; -1 if the IR could not parse (caller falls back to legacy). */
+static void ir_bridge_common(const aimee_response_t *ir, parsed_response_t *out);
+
 int agent_ir_parse_json_response(cJSON *root, int anthropic, int rescue_mode, int *n_rescued,
                                  parsed_response_t *out)
 {
@@ -107,42 +109,8 @@ int agent_ir_parse_json_response(cJSON *root, int anthropic, int rescue_mode, in
    if (n_rescued)
       *n_rescued = rescued;
 
-   if (ir.model)
-      snprintf(out->model, sizeof(out->model), "%s", ir.model);
-   if (ir.raw_stop_reason)
-      snprintf(out->stop_reason, sizeof(out->stop_reason), "%s", ir.raw_stop_reason);
-   out->prompt_tokens = (int)ir.usage_in;
-   out->completion_tokens = (int)ir.usage_out;
-   out->cache_write_tokens = (int)ir.usage_cache_write;
-   out->cache_read_tokens = (int)ir.usage_cache_read;
-
-   /* content: concatenated TEXT blocks (THINKING is excluded by the IR accessor). */
-   size_t need = 1;
-   for (int i = 0; i < ir.n_content; i++)
-      if (ir.content[i].type == AIMEE_BLK_TEXT && ir.content[i].text)
-         need += strlen(ir.content[i].text);
-   if (need > 1)
-   {
-      out->content = malloc(need);
-      if (out->content)
-         aimee_ir_response_text(&ir, out->content, need);
-   }
-
-   /* tool calls: id / name / arguments (arguments as a JSON string, like legacy). */
-   for (int i = 0; i < ir.n_content && out->call_count < AGENT_MAX_TOOL_CALLS; i++)
-   {
-      const aimee_block_t *b = &ir.content[i];
-      if (b->type != AIMEE_BLK_TOOL_USE)
-         continue;
-      out->is_tool_call = 1;
-      parsed_tool_call_t *c = &out->calls[out->call_count++];
-      if (b->tool_id)
-         snprintf(c->id, sizeof(c->id), "%s", b->tool_id);
-      if (b->tool_name)
-         snprintf(c->name, sizeof(c->name), "%s", b->tool_name);
-      char *args = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
-      c->arguments = args ? args : strdup("{}");
-   }
+   /* model, stop reason, usage, TEXT content, and TOOL_USE calls (shared bridge). */
+   ir_bridge_common(&ir, out);
 
    /* assistant_message for multi-turn replay. When a rescue fired the raw response
     * carried the calls as prose, so it cannot be replayed: anthropic drops it (as
@@ -179,5 +147,94 @@ int agent_ir_parse_json_response(cJSON *root, int anthropic, int rescue_mode, in
    }
 
    aimee_response_free(&ir);
+   return 0;
+}
+
+/* Shared bridge from a parsed IR response into parsed_response_t: model, stop reason,
+ * usage, concatenated TEXT content, and TOOL_USE calls. assistant_message is left to
+ * the caller (it is wire-specific). */
+static void ir_bridge_common(const aimee_response_t *ir, parsed_response_t *out)
+{
+   if (ir->model)
+      snprintf(out->model, sizeof(out->model), "%s", ir->model);
+   if (ir->raw_stop_reason)
+      snprintf(out->stop_reason, sizeof(out->stop_reason), "%s", ir->raw_stop_reason);
+   out->prompt_tokens = (int)ir->usage_in;
+   out->completion_tokens = (int)ir->usage_out;
+   out->cache_write_tokens = (int)ir->usage_cache_write;
+   out->cache_read_tokens = (int)ir->usage_cache_read;
+
+   size_t need = 1;
+   for (int i = 0; i < ir->n_content; i++)
+      if (ir->content[i].type == AIMEE_BLK_TEXT && ir->content[i].text)
+         need += strlen(ir->content[i].text);
+   if (need > 1)
+   {
+      out->content = malloc(need);
+      if (out->content)
+         aimee_ir_response_text(ir, out->content, need);
+   }
+
+   for (int i = 0; i < ir->n_content && out->call_count < AGENT_MAX_TOOL_CALLS; i++)
+   {
+      const aimee_block_t *b = &ir->content[i];
+      if (b->type != AIMEE_BLK_TOOL_USE)
+         continue;
+      out->is_tool_call = 1;
+      parsed_tool_call_t *c = &out->calls[out->call_count++];
+      if (b->tool_id)
+         snprintf(c->id, sizeof(c->id), "%s", b->tool_id);
+      if (b->tool_name)
+         snprintf(c->name, sizeof(c->name), "%s", b->tool_name);
+      char *args = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
+      c->arguments = args ? args : strdup("{}");
+   }
+}
+
+int agent_ir_parse_responses(const char *body, int rescue_mode, int *n_rescued,
+                             parsed_response_t *out)
+{
+   memset(out, 0, sizeof(*out));
+   if (n_rescued)
+      *n_rescued = 0;
+
+   /* The responses wire is SSE, not a single JSON object: extract the response object
+    * (output items + usage) the same way the shadow does, then parse it via the IR. */
+   cJSON *robj = agent_responses_sse_response_object(body);
+   if (!robj)
+      return -1;
+
+   aimee_response_t ir;
+   memset(&ir, 0, sizeof(ir));
+   char err[128] = "";
+   if (responses_backend_parse(robj, &ir, err, sizeof err) != 0)
+   {
+      aimee_response_free(&ir);
+      cJSON_Delete(robj);
+      return -1;
+   }
+
+   int rescued = 0;
+   if (rescue_mode >= 0)
+      rescued = aimee_ir_rescue_tool_calls(&ir, rescue_mode);
+   if (n_rescued)
+      *n_rescued = rescued;
+
+   ir_bridge_common(&ir, out);
+
+   /* assistant_message for multi-turn replay is the output-item array itself: the
+    * turn loop appends the function_call items (matched by call_id) to the next
+    * request's `input`. Matches the legacy parser's collected_output. When a rescue
+    * fired, the calls came from prose (not native output items), so it cannot replay
+    * -- leave it NULL, as the anthropic rescue path does. */
+   if (out->is_tool_call && rescued == 0)
+   {
+      cJSON *output = cJSON_GetObjectItemCaseSensitive(robj, "output");
+      if (output && cJSON_IsArray(output))
+         out->assistant_message = cJSON_Duplicate(output, 1);
+   }
+
+   aimee_response_free(&ir);
+   cJSON_Delete(robj);
    return 0;
 }

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -1072,21 +1072,14 @@ native_provider_http:
       int n_rescued = 0;
       if (chatgpt)
       {
-         agent_parse_response_responses(response_body, &parsed);
-         /* Shadow: extend parity to the responses/SSE (codex) wire -- the one wire the
-          * response shadow did not cover. Extract the response object from the stream
-          * and compare the IR's parse of it against the legacy SSE parse. The codex
-          * parser is UNCHANGED (still legacy); this only measures. Off unless
-          * AIMEE_IR_SHADOW is set; never touches the turn. */
-         if (aimee_ir_shadow_enabled())
-         {
-            cJSON *robj = agent_responses_sse_response_object(response_body);
-            if (robj)
-            {
-               aimee_ir_shadow_compare_response(&parsed, robj, AIMEE_WIRE_RESPONSES);
-               cJSON_Delete(robj);
-            }
-         }
+         /* IR is the SOLE parser for the responses/SSE (codex) wire -- the legacy SSE
+          * parser is gone (shadow-proven at parity on live .254 traffic). It owns the
+          * XML rescue (via rescue_mode); ir_primary / n_rescued carry the outcome to
+          * the rescue-policy step below. A parse failure yields an empty response. */
+         ir_primary =
+             agent_ir_parse_responses(response_body, rescue_mode, &n_rescued, &parsed) == 0;
+         if (!ir_primary)
+            memset(&parsed, 0, sizeof(parsed));
       }
       else
       {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -894,6 +894,10 @@ $(TESTPREFIX)/unit-test-tasks: $(OBJDIR)/tests/test_tasks.o $(OBJDIR)/tasks.o $(
 
 $(TESTPREFIX)/unit-test-agent: $(OBJDIR)/tests/test_agent.o $(OBJDIR)/tests/test_agent_caps.o \
                       $(OBJDIR)/tests/test_agent_responses.o \
+                      $(OBJDIR)/posix/agent_ir_parse.o $(OBJDIR)/server/aimee_backend_responses.o \
+                      $(OBJDIR)/server/aimee_backend_anthropic.o $(OBJDIR)/server/aimee_backend_openai.o \
+                      $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/server/aimee_ir_rescue.o \
+                      $(OBJDIR)/server/aimee_ir_metrics.o \
                       $(OBJDIR)/tests/test_agent_delegate_root.o $(OBJDIR)/server/agent_cli_shell.o \
                       $(OBJDIR)/audit_action.o $(OBJDIR)/audit_worm.o $(OBJDIR)/audit_worm_chain.o $(OBJDIR)/workflow/wfe_canonical.o \
                       $(OBJDIR)/server/tool_call_args.o \

--- a/src/tests/support/ir_shadow_stubs.c
+++ b/src/tests/support/ir_shadow_stubs.c
@@ -47,6 +47,21 @@ __attribute__((weak)) int openai_backend_parse(const struct cJSON *resp, aimee_r
    (void)errn;
    return -1;
 }
+__attribute__((weak)) int responses_backend_parse(const struct cJSON *resp, aimee_response_t *out,
+                                                  char *err, size_t errn)
+{
+   (void)resp;
+   (void)out;
+   (void)err;
+   (void)errn;
+   return -1;
+}
+__attribute__((weak)) int aimee_ir_rescue_tool_calls(aimee_response_t *r, int allow_json)
+{
+   (void)r;
+   (void)allow_json;
+   return 0;
+}
 __attribute__((weak)) size_t aimee_ir_response_text(const aimee_response_t *r, char *buf, size_t n)
 {
    (void)r;

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -36,6 +36,8 @@ void test_responses_parser_keeps_all_output_text_parts(void);
 void test_responses_parser_accumulates_output_text_deltas(void);
 void test_responses_object_folds_in_delta_text(void);
 void test_responses_object_keeps_existing_text(void);
+void test_ir_parse_responses_tool_call(void);
+void test_ir_parse_responses_text_only(void);
 void test_responses_parser_uses_output_text_done(void);
 void test_responses_parser_separates_message_items(void);
 
@@ -2876,6 +2878,8 @@ int main(void)
    test_responses_parser_accumulates_output_text_deltas();
    test_responses_object_folds_in_delta_text();
    test_responses_object_keeps_existing_text();
+   test_ir_parse_responses_tool_call();
+   test_ir_parse_responses_text_only();
    test_responses_parser_uses_output_text_done();
    test_responses_parser_separates_message_items();
    test_agent_is_exec_role();

--- a/src/tests/test_agent_responses.c
+++ b/src/tests/test_agent_responses.c
@@ -130,6 +130,57 @@ void test_responses_object_keeps_existing_text(void)
    cJSON_Delete(resp);
 }
 
+/* agent_ir_parse_responses: the IR-backed parser for the responses/SSE (codex) wire.
+ * A native function_call becomes a tool call, and assistant_message is the output-item
+ * array (function_call items carry call_id) that the turn loop replays into the next
+ * request's `input`. */
+void test_ir_parse_responses_tool_call(void)
+{
+   const char *body =
+       "event: response.output_item.done\r\n"
+       "data: {\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"bash\","
+       "\"arguments\":\"{\\\"cmd\\\":\\\"ls\\\"}\"}}\r\n\r\n"
+       "event: response.completed\r\n"
+       "data: {\"response\":{\"output\":[{\"type\":\"function_call\",\"call_id\":\"call_1\","
+       "\"name\":\"bash\",\"arguments\":\"{\\\"cmd\\\":\\\"ls\\\"}\"}],"
+       "\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}}\r\n\r\n";
+
+   parsed_response_t p;
+   int rc = agent_ir_parse_responses(body, -1, NULL, &p);
+   assert(rc == 0);
+   assert(p.is_tool_call == 1);
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].name, "bash") == 0);
+   assert(strcmp(p.calls[0].id, "call_1") == 0);
+   /* assistant_message is the output array; the turn loop matches function_call items
+    * by call_id, so the id must be present and equal. */
+   assert(p.assistant_message != NULL && cJSON_IsArray(p.assistant_message));
+   cJSON *item = cJSON_GetArrayItem(p.assistant_message, 0);
+   cJSON *cid = cJSON_GetObjectItemCaseSensitive(item, "call_id");
+   assert(cid && cJSON_IsString(cid) && strcmp(cid->valuestring, "call_1") == 0);
+   agent_free_parsed_response(&p);
+}
+
+/* Text-only codex reply: no tool call, no assistant_message, usage bridged. */
+void test_ir_parse_responses_text_only(void)
+{
+   const char *body =
+       "event: response.output_text.delta\r\n"
+       "data: {\"delta\":\"hello world\"}\r\n\r\n"
+       "event: response.completed\r\n"
+       "data: {\"response\":{\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}"
+       "\r\n\r\n";
+
+   parsed_response_t p;
+   int rc = agent_ir_parse_responses(body, -1, NULL, &p);
+   assert(rc == 0);
+   assert(p.is_tool_call == 0);
+   assert(p.content && strcmp(p.content, "hello world") == 0);
+   assert(p.assistant_message == NULL);
+   assert(p.prompt_tokens == 1 && p.completion_tokens == 2);
+   agent_free_parsed_response(&p);
+}
+
 void test_responses_parser_uses_output_text_done(void)
 {
    const char *body =


### PR DESCRIPTION
## Stage 2 of the legacy-parser removal — **stacked on #1398**

Makes the delegate runtime's **responses/SSE (codex) wire** IR-primary, matching the anthropic + openai wires. After this, `posix/agent_runtime.c` no longer calls any legacy `agent_parse_response_*` — the whole delegate runtime is IR-only across all three wires.

### New: `agent_ir_parse_responses`
Extracts the response object from the SSE stream (`agent_responses_sse_response_object`, which folds in streamed `output_text` — the #1397 fix), parses via `responses_backend_parse`, owns the XML rescue, and bridges to `parsed_response_t`. `assistant_message` is the output-item array itself — the shape the turn loop replays into the next request's `input` (matches the legacy `collected_output`), verified against the consumer at `agent_runtime.c:1353`.

### Shared bridge
Extracts `ir_bridge_common` (model / stop / usage / TEXT / TOOL_USE) so the json and responses parsers don't duplicate the bridge. The json path is byte-identical (guarded by the existing `unit-test-agent-ir-parse` tests).

### Shadow
Removes the responses shadow-comparison from the runtime — with the wire IR-primary there's no legacy parse to compare against. Parity was already proven live on .254 (`ir_resp` 14/14, 0 mismatch on codex).

### Tests
Two new `agent_ir_parse_responses` tests (native function_call → tool call + output-array `assistant_message`; text-only → no replay). Both falsification-proven. `unit-test-agent` now links the real IR objects; minimal-link binaries get weak `responses_backend_parse` / rescue stubs.

Full `make all` + `make unit-tests` green.

⚠️ **Merge #1398 first.** Needs live multi-turn tool-using codex validation on .254 before the parsers are deleted (stage 6).