### PR TITLE
fix(sandbox): grant aimee the docker-socket group + accurate ARMED posture

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -120,6 +120,29 @@ webchat_start
 # or fails the server start, and runs as the same 'aimee' user that owns the
 # install prefix ($AIMEE_HOME/.npm-global). The lazy install on first setup still
 # covers it if this hasn't finished yet.
+# Delegate sandbox: when the host Docker socket is bind-mounted in (so aimee-server
+# can spawn per-delegate containers), grant the unprivileged 'aimee' user the
+# socket's group. runuser re-initialises supplementary groups from /etc/group via
+# initgroups(), so a container `--group-add <gid>` is dropped for the server child
+# unless 'aimee' is actually a member in /etc/group. Without this the docker backend
+# is INERT and delegates silently run on the HOST (see the delegate-sandbox posture
+# log). Root here; the runuser calls below then pick the group up.
+for _dsock in /var/run/docker.sock /run/docker.sock; do
+    [ -S "$_dsock" ] || continue
+    _dgid=$(stat -c %g "$_dsock" 2>/dev/null) || continue
+    { [ -n "$_dgid" ] && [ "$_dgid" != 0 ]; } || continue
+    _dgrp=$(getent group "$_dgid" | cut -d: -f1)
+    if [ -z "$_dgrp" ]; then
+        _dgrp=dockerhost
+        groupadd -g "$_dgid" "$_dgrp" 2>/dev/null || true
+    fi
+    if ! id -nG aimee 2>/dev/null | tr ' ' '\n' | grep -qx "$_dgrp"; then
+        usermod -aG "$_dgrp" aimee 2>/dev/null || true
+    fi
+    log "delegate sandbox: granted 'aimee' the docker socket group ($_dgrp/$_dgid)"
+    break
+done
+
 log "pre-warming server-hosted OAuth CLIs (background)"
 runuser -u aimee -- aimee-server --prewarm-cli-oauth >/dev/null 2>&1 &
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2011,11 +2011,11 @@ static void delegate_sandbox_log_posture(void)
       if (nl)
          *nl = '\0';
    }
-   aimee_log(LOG_WARN, "delegate-sandbox",
-             "ARMED: delegate file/exec will bind to a per-delegate container (docker server %s). "
-             "NOTE this is not yet the full seal: the container still has a network and this does "
-             "not take it away, so the shell-git gate and the credential strip remain the live "
-             "boundary",
+   aimee_log(LOG_INFO, "delegate-sandbox",
+             "ARMED: delegate file/exec binds to a per-delegate container (docker server %s), "
+             "created with --network none — no IP egress; its only outward channel is the "
+             "bind-mounted aimee-server UDS (aimee_home/aimee-http.sock). The shell-git gate and "
+             "credential strip remain complementary boundaries within that container.",
              (ver && ver[0]) ? ver : "?");
    free(ver);
 }


### PR DESCRIPTION
Two upstream fixes surfaced while running the delegate-sandbox E2E on a real containerized aimee-server (a .253 CT with its own docker), per "address any container constraints with a push to upstream."

## 1. Entrypoint drops the docker-socket group → sandbox silently INERT
`server-entrypoint.sh` starts the server with `runuser -u aimee`, which re-initialises supplementary groups from `/etc/group` (`initgroups()`). So `docker run --group-add <docker-gid>` is **dropped for the server child** unless `aimee` is a real member in `/etc/group`. Result: the server can't reach the docker daemon, `docker version` fails, and the posture goes **INERT** — `delegate_sandbox=true` but *delegates silently run on the HOST* ("appearing sandboxed"). A nasty footgun.

Fix: the entrypoint now detects a bind-mounted docker socket, ensures a group with its GID exists, and adds `aimee` to it **before** the `runuser` switch, so `initgroups()` picks it up.

**Validated on real docker** (.253 CT, docker 26.1.5): with only `-v /var/run/docker.sock:/var/run/docker.sock` and **no** `--group-add`, the posture flipped from:
```
INERT: ... `docker version` failed (rc=1) ... every delegate will run on the HOST while appearing sandboxed
```
to:
```
delegate sandbox: granted aimee the docker socket group (dockerhost/105)
ARMED: delegate file/exec binds to a per-delegate container (docker server 26.1.5+dfsg1) ...
```

## 2. Stale ARMED posture message
The ARMED log predated slice 6 and claimed "the container still has a network and this does not take it away." Slice 6 (#1392) creates the delegate container with `--network none` and binds only the aimee-server UDS (#1395). Updated the message to describe that, and dropped `WARN`→`INFO` since ARMED is now the sealed state.

## Note on deployment
This means a containerized aimee-server that should spawn sandboxed delegates needs the host docker socket bind-mounted (and, because the socket is `root:<docker-gid>`, this fix grants the group). It also needs **path-identity mounts** for `AIMEE_HOME`/workspaces (`-v /var/lib/aimee:/var/lib/aimee`) so the paths it hands to `docker create` resolve on the host — worth documenting in the deploy guide as a follow-up.