### PR TITLE
coord: make the delegate handoff contract opt-in, off for ad-hoc WFE jobs

### DIFF
--- a/src/headers/server_compute_impl.h
+++ b/src/headers/server_compute_impl.h
@@ -97,7 +97,7 @@ int tool_execute_dispatch(server_ctx_t *ctx, compute_ctx_t *cctx);
 /* Dispatch a coord task as a background delegate worker. Returns 0 on success, -1 on failure. */
 int server_compute_dispatch_coord_task(server_ctx_t *ctx, int task_id, const char *role,
                                        const char *prompt, const char *files_json, const char *cwd,
-                                       const char *persona);
+                                       const char *persona, int require_handoff);
 /* Delegate worker thread entry point — non-static so skill_jobs.c can reference it. */
 void delegate_worker(void *arg);
 

--- a/src/server/server_coord_dispatcher.c
+++ b/src/server/server_coord_dispatcher.c
@@ -22,7 +22,7 @@
  * worker. Lives here (its only caller) rather than in server_compute.c. */
 int server_compute_dispatch_coord_task(server_ctx_t *ctx, int task_id, const char *role,
                                        const char *prompt, const char *files_json, const char *cwd,
-                                       const char *persona)
+                                       const char *persona, int require_handoff)
 {
    if (!ctx || task_id <= 0 || !prompt || !prompt[0])
       return -1;
@@ -35,7 +35,13 @@ int server_compute_dispatch_coord_task(server_ctx_t *ctx, int task_id, const cha
     * the coord task now — the orchestrator that enqueued it (coord planner or the
     * workflow engine) named it. Default to engineer for legacy rows. */
    cJSON_AddStringToObject(req, "persona", (persona && persona[0]) ? persona : "engineer");
-   cJSON_AddTrueToObject(req, "handoff_json");
+   /* The structured delegate_result_v1 handoff is the patch-COORDINATOR's contract
+    * (plan-based jobs aggregate structured results). WFE's ad-hoc jobs don't use
+    * it — the delegate produces free-form output (a plan, a review verdict, code)
+    * that WFE reads raw from the task result — so requiring a handoff would fail
+    * every WFE task with "invalid delegate handoff". The caller decides. */
+   if (require_handoff)
+      cJSON_AddTrueToObject(req, "handoff_json");
    if (files_json && files_json[0])
       cJSON_AddStringToObject(req, "files", files_json);
    if (cwd && cwd[0])
@@ -125,8 +131,12 @@ static int dispatcher_sweep(void)
             continue;
          }
 
-         if (server_compute_dispatch_coord_task(g_ctx, task_id, role, prompt, files, cwd,
-                                                persona) != 0)
+         /* Plan-based coord jobs use the structured handoff contract; an ad-hoc
+          * WFE job (WFE_COORD_PLAN_ID) does not — its delegate returns free-form
+          * output that the workflow engine reads raw. */
+         int require_handoff = (job.plan_id != WFE_COORD_PLAN_ID);
+         if (server_compute_dispatch_coord_task(g_ctx, task_id, role, prompt, files, cwd, persona,
+                                                require_handoff) != 0)
          {
             /* Pool full — release the claim and retry next sweep. */
             db1_coord_job_release_task(task_id);


### PR DESCRIPTION
Follow-up to #1390/#1394. With WFE now dispatching through the coord queue, its tasks hit the coord dispatch's **hardcoded `handoff_json=true`** — which forces every delegate to emit a structured `delegate_result_v1` handoff. That is the patch-**coordinator**'s contract (plan-based jobs aggregate structured results), but WFE's ad-hoc jobs don't use it: a WFE delegate produces **free-form output** (a plan, a review verdict, code) that WFE reads raw from the task result.

Seen live: the coord job dispatched cleanly (**0 429s**, correct `persona=architect`) but the task **failed on `invalid delegate handoff: missing schema_version delegate_result_v1`**.

## Fix

`server_compute_dispatch_coord_task` takes `require_handoff`; the dispatcher derives it from the job's `plan_id` (plan-based → true, `WFE_COORD_PLAN_ID` ad-hoc → false). With it off, no handoff contract is appended to the prompt and no handoff validation runs, so the delegate's raw `response` flows to the task result (`compute_update_coord_task` writes `resp["response"]`). The worktree apply is git-diff based and independent of the handoff, so **code tasks still apply**.

Server + full unit suite build clean. This is the next fix surfaced by the live WFE run after #1394 — the core path (enqueue → dispatch → shared delegate execution, concurrency-limited) is confirmed working; this lets the tasks actually succeed.