### PR TITLE
fix(config): key load cache on file identity, not mtime alone

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -226,6 +226,8 @@ const char *config_default_db1_path(void)
  * after a write; defined below. */
 config_t g_config_cache;
 struct timespec g_config_mtime;
+off_t g_config_size;
+ino_t g_config_ino;
 char g_config_cache_path[MAX_PATH_LEN];
 int g_config_cached;
 
@@ -949,14 +951,19 @@ int config_load_file(config_t *cfg)
 
    const char *path = config_default_path();
 
-   /* Return cached config if mtime unchanged and caching enabled */
+   /* Return cached config only if the file looks identical on every cheap axis
+    * stat() gives us: same mtime, size and inode. mtime alone is spoofable by a
+    * same-timestamp (or clock-skewed) rewrite — observed on the tiered appliance
+    * filesystem, where an in-place `aimee workspace add` rewrite kept serving the
+    * stale (empty-workspaces) snapshot, which config_save then re-serialised. */
    if (!getenv("AIMEE_NO_CACHE") && g_config_cached)
    {
       struct stat st;
       if (stat(path, &st) == 0)
       {
          struct timespec mt = AIMEE_STAT_MTIM(st);
-         if (strcmp(g_config_cache_path, path) == 0 && timespec_eq(&mt, &g_config_mtime))
+         if (strcmp(g_config_cache_path, path) == 0 && timespec_eq(&mt, &g_config_mtime) &&
+             st.st_size == g_config_size && st.st_ino == g_config_ino)
          {
             memcpy(cfg, &g_config_cache, sizeof(*cfg));
             return 0;
@@ -1609,6 +1616,8 @@ int config_load_file(config_t *cfg)
       {
          memcpy(&g_config_cache, cfg, sizeof(g_config_cache));
          g_config_mtime = AIMEE_STAT_MTIM(st);
+         g_config_size = st.st_size;
+         g_config_ino = st.st_ino;
          snprintf(g_config_cache_path, sizeof(g_config_cache_path), "%s", path);
          g_config_cached = 1;
       }

--- a/src/config_internal.h
+++ b/src/config_internal.h
@@ -23,10 +23,15 @@
  * Defined in config.c alongside the parser. */
 const char *config_mcp_transport_to_string(config_mcp_transport_t transport);
 
-/* mtime-keyed load cache, shared so config_save can stamp freshly-saved
- * values and short-circuit the next config_load() call. */
+/* File-identity-keyed load cache, shared so config_save can stamp freshly-saved
+ * values and short-circuit the next config_load() call. Keyed on mtime + size +
+ * inode: mtime alone is spoofable by a same-timestamp (or clock-skewed) rewrite,
+ * which the tiered appliance filesystem produces in practice — see the agents.json
+ * fix in #1372. */
 extern config_t g_config_cache;
 extern struct timespec g_config_mtime;
+extern off_t g_config_size;
+extern ino_t g_config_ino;
 extern char g_config_cache_path[MAX_PATH_LEN];
 extern int g_config_cached;
 

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1332,6 +1332,8 @@ int config_save(const config_t *cfg)
       {
          memcpy(&g_config_cache, cfg, sizeof(g_config_cache));
          g_config_mtime = AIMEE_STAT_MTIM(st);
+         g_config_size = st.st_size;
+         g_config_ino = st.st_ino;
          snprintf(g_config_cache_path, sizeof(g_config_cache_path), "%s", path);
          g_config_cached = 1;
       }

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <fcntl.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1869,6 +1870,61 @@ int main(void)
 
       char cpath[512];
       snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+      unlink(cpath);
+   }
+
+   /* --- cache identity: a same-mtime in-place rewrite must NOT serve stale ---
+    * The load cache used to key on path+mtime alone, so an in-place rewrite that
+    * landed with an equal (or clock-skewed) mtime kept serving the pre-rewrite
+    * snapshot forever. This is exactly the shape of `aimee workspace add` on the
+    * tiered appliance filesystem: the file grows a `workspaces:` block but the
+    * stale empty-workspaces cache is served and a later config_save re-serialises
+    * it back to nothing. Size + inode in the cache key make it detectable. */
+   {
+      char cpath[512];
+      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+
+      /* First state: short body. Load with caching on to populate the cache. */
+      FILE *f = fopen(cpath, "w");
+      assert(f);
+      fprintf(f, "db2_url: db2://a\n");
+      fclose(f);
+      platform_unsetenv("AIMEE_NO_CACHE");
+
+      static config_t cfg1;
+      memset(&cfg1, 0, sizeof(cfg1));
+      assert(config_load(&cfg1) == 0);
+      assert(strcmp(cfg1.db2_url, "db2://a") == 0);
+
+      /* Capture the exact mtime the cache just recorded. */
+      struct stat st0;
+      assert(stat(cpath, &st0) == 0);
+
+      /* Rewrite in place with a longer, different body (a size change, like an
+       * appended workspaces block), then force the mtime back to the cached one
+       * so path+mtime alone would still count as a hit. */
+      f = fopen(cpath, "w");
+      assert(f);
+      fprintf(f, "db2_url: db2://a-much-longer-different-value\n");
+      fclose(f);
+      struct timespec mt0;
+#if defined(__APPLE__)
+      mt0 = st0.st_mtimespec;
+#else
+      mt0 = st0.st_mtim;
+#endif
+      struct timespec times[2];
+      times[0] = mt0; /* atime — value irrelevant */
+      times[1] = mt0; /* mtime — force the collision */
+      assert(utimensat(AT_FDCWD, cpath, times, 0) == 0);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      assert(config_load(&cfg2) == 0);
+      /* With the mtime-only cache this returned the stale "db2://a". */
+      assert(strcmp(cfg2.db2_url, "db2://a-much-longer-different-value") == 0);
+
+      platform_setenv("AIMEE_NO_CACHE", "1");
       unlink(cpath);
    }
 


### PR DESCRIPTION
## Problem
The in-process config load cache (`g_config_cache`) validated a hit on **path + mtime only**. An in-place rewrite that landed with an equal — or clock-skewed *older* — mtime kept serving the pre-rewrite snapshot indefinitely, and a subsequent `config_save` re-serialised that stale snapshot back to disk.

This is the **same failure mode fixed for `agents.json` in #1372** (c1ae2dda), just in the config path.

### Observed
On CT 106 (path-identity mounts, tiered appliance filesystem), `aimee workspace add` writes the `workspaces:` block correctly, but a later `config_save` re-serialised `workspaces: []` — silently losing the registration. It only recovered on a **clean restart** (fresh stat, empty cache), which is the tell-tale signature of a stale mtime-keyed cache.

## Fix
Add **size + inode** to the cache key (both free from the same `stat()`), mirroring the `agent_config_stat_eq` fix. An in-place rewrite changes size and/or inode even when the mtime collides, so it's now detectable. Both stamp sites (`config_load_file`, `config_save`) record the new fields.

## Test
`test_config.c` gains a regression that:
1. loads a short config with caching **on** (populates the cache),
2. rewrites it in place with a longer, different body,
3. forces the mtime back to the cached value via `utimensat` (the collision),
4. asserts the reload returns the **new** content.

Verified it **fails** on the old mtime-only key and **passes** with the fix.