### PR TITLE
fix(delegate): run aimee git tooling on the server, not inside the sandbox

### DIFF
--- a/src/mcp_git_query.c
+++ b/src/mcp_git_query.c
@@ -39,9 +39,11 @@ int mcp_git_get_worktree(void)
    return s_in_worktree;
 }
 
-/* Route a git/gh shell command-line through the turn's active workspace
- * provider. `shared` is a passthrough to run_cmd (identical to today); a
- * `detached` workspace marshals the command to its filesystem authority. */
+/* Route a git/gh shell command-line to where aimee's git rails live. SHARED and
+ * CONTAINER both run server-side (run_cmd) — a container-sandboxed delegate has no
+ * git and no creds, so its git must run on the server against the path-identity
+ * bind-mounted worktree; only a `detached` workspace marshals to its client-held
+ * filesystem authority. See mcp_git_run for the rationale. */
 /* The registered workspace root containing `cwd`, copied into out[outsz].
  * Returns 0 on a match, -1 otherwise. */
 static int forge_workspace_for_cwd(const char *cwd, char *out, size_t outsz)
@@ -69,17 +71,28 @@ char *mcp_git_run(const char *cmd, int *exit_code)
 {
    const workspace_provider_t *ws = workspace_provider_active();
 
-   /* Credential injection: when the server runs git LOCALLY (shared provider) for
-    * a turn whose cwd is inside a registered workspace, run the command under an
-    * execve environment carrying GH_TOKEN + the GIT_ASKPASS shim so
-    * clone/fetch/push/PR authenticate — never on the command line or disk. The
-    * token is resolved through the one shared vault-first policy: a client-handed
+   /* aimee's git tooling is TRUSTED server code and must run where the forge
+    * credential, the network and the git rails live: on aimee-server — NOT inside a
+    * delegate's sandbox. A CONTAINER-sandboxed delegate runs `--network none` on a
+    * minimal image with no git binary and no credential, so routing git into it
+    * would (a) fail outright — `git: command not found` — and (b) be wrong: push/PR
+    * need the network the sandbox deliberately removes, and running git there would
+    * push the forge credential into the sandbox this design exists to keep it out of.
+    * The delegate's worktree is bind-mounted path-identically, so the server sees the
+    * delegate's edits at the same path. Run git on the server for SHARED and
+    * CONTAINER alike; only a DETACHED workspace (the client holds both the filesystem
+    * and its own creds) marshals git to the client and stays on the provider path. */
+   int run_on_server = (ws->kind == WS_PROVIDER_SHARED || ws->kind == WS_PROVIDER_CONTAINER);
+   const workspace_provider_t *exec_ws = run_on_server ? workspace_provider_shared() : ws;
+
+   /* Credential injection: for a server-run command whose cwd is inside a registered
+    * workspace, run under an execve environment carrying GH_TOKEN + the GIT_ASKPASS
+    * shim so clone/fetch/push/PR authenticate — never on the command line or disk.
+    * The token is resolved through the one shared vault-first policy: a client-handed
     * per-workspace broker token (§4) wins, else the per-host vault token for the
-    * checkout's `origin`, else the server's own forge identity (§6); no token →
-    * fall through to ambient creds (co-located dev's own gh/SSH). A `detached`
-    * workspace marshals git to the client, which holds its own creds, so it stays
-    * on the provider path. */
-   if (ws->kind == WS_PROVIDER_SHARED)
+    * checkout's `origin`, else the server's own forge identity (§6); no token → fall
+    * through to ambient creds (co-located dev's own gh/SSH). */
+   if (run_on_server)
    {
       const char *cwd = run_cmd_get_cwd();
       char wsid[MAX_PATH_LEN];
@@ -107,7 +120,7 @@ char *mcp_git_run(const char *cmd, int *exit_code)
          }
       }
    }
-   return ws->exec_shell(ws, cmd, exit_code);
+   return exec_ws->exec_shell(exec_ws, cmd, exit_code);
 }
 
 static void trim_trailing_newline(char *s)

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -9,6 +9,7 @@
 #include <sqlite3.h>
 #include "aimee.h"
 #include "mcp_git.h"
+#include "workspace_provider.h"
 #include "git_verify.h"
 #include "cJSON.h"
 #include "db_schema.h"
@@ -442,6 +443,59 @@ static void test_git_commit_skips_sensitive(void)
    cJSON_Delete(args);
 
    teardown_git_repo();
+}
+
+/* A CONTAINER-sandboxed delegate runs `--network none` on a minimal image with no
+ * git binary and no forge credential, so aimee's git tooling must execute on the
+ * SERVER against the path-identity bind-mounted worktree — never route into the
+ * container. Regression for the delegate-sandbox E2E where every git_* call died
+ * with "git: command not found" because mcp_git_run dispatched through the container
+ * provider's exec_shell. The spy mimics that no-git failure: if git were still
+ * routed into the container the commit would fail and the spy would be hit. */
+static int g_container_shell_spy_called;
+static char *container_shell_spy(const workspace_provider_t *p, const char *cmd, int *exit_code)
+{
+   (void)p;
+   (void)cmd;
+   g_container_shell_spy_called = 1;
+   if (exit_code)
+      *exit_code = 127; /* as if `git` were absent from the sandbox image */
+   return strdup("bash: git: command not found\n");
+}
+
+static void test_git_container_provider_runs_on_server(void)
+{
+   setup_git_repo();
+   system("git checkout -q -b test-sandbox");
+
+   FILE *fp = fopen("sbx.txt", "w");
+   fputs("sandbox\n", fp);
+   fclose(fp);
+   system("git add sbx.txt");
+
+   workspace_provider_t container;
+   memset(&container, 0, sizeof(container));
+   container.kind = WS_PROVIDER_CONTAINER;
+   container.exec_shell = container_shell_spy;
+   workspace_provider_set_active(&container);
+   g_container_shell_spy_called = 0;
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "message", "sandbox commit");
+   cJSON *resp = handle_git_commit(args);
+   workspace_provider_clear_active();
+
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   /* git ran on the server (the commit really landed), NOT through the container
+    * spy — so a no-git sandbox image no longer blocks a delegate's commit. */
+   assert(g_container_shell_spy_called == 0);
+   assert(strstr(text, "committed") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   teardown_git_repo();
+   printf("  PASS: test_git_container_provider_runs_on_server\n");
 }
 
 /* --- Test handle_git_push in non-git directory --- */
@@ -2256,6 +2310,7 @@ int main(void)
    test_git_commit_missing_message();
    test_git_commit_success();
    test_git_commit_skips_sensitive();
+   test_git_container_provider_runs_on_server();
    test_git_push_requires_branch();
    test_git_branch_missing_action();
    test_git_branch_create_and_list();


### PR DESCRIPTION
## The bug (found validating the delegate-sandbox E2E)
A sandboxed delegate could **never commit**. It would edit a file, then loop on `git status` forever and never stage or commit.

Root cause: `mcp_git_run` (which backs `git_commit`/`git_add`/`git_status`) dispatches git through the turn's **active workspace provider**. For a `CONTAINER`-sandboxed delegate that provider is the container, so git executes **inside the sandbox** — an image (default `ubuntu:22.04`) that has **no git binary**, no forge credential, and `--network none`. Every `git_*` call returned `git: command not found`. The file edit survived only because `write_file` writes to the bind-mounted worktree (no git needed).

Confirmed on hardware (CT 106): the delegate container spawned correctly (`--network none`, bound `aimee-http.sock`, ro parent + rw sibling worktree), the docker event log showed `git add`/`git status` being exec'd **inside** the container, and `ubuntu:22.04` ships no git.

## The fix
aimee's git tooling is **trusted server code** and must run where the credential, the network and the git rails live — on aimee-server, not in the delegate's sandbox. The delegate's worktree is bind-mounted **path-identically**, so the server operates on the same bytes the delegate edited.

`mcp_git_run` now runs git on the server for **SHARED and CONTAINER** alike; only a `DETACHED` workspace (client holds both the filesystem and its own creds) still marshals git to the client. Net effect:
- A sandboxed delegate's `git_commit`/`add`/`push`/`pr` work — via aimee-server, over the bound UDS model.
- The forge credential never enters the `--network none` container (the property the sandbox exists to guarantee).
- The model's own `bash`/`write_file` stay sandboxed in the container; only aimee's structured git operations run server-side.

## Test
`test_mcp_git.c::test_git_container_provider_runs_on_server`: with a `CONTAINER` provider whose `exec_shell` spy mimics the no-git failure, `handle_git_commit` must still succeed and must **not** touch the spy. Verified it **aborts** on the old SHARED-only routing and **passes** with the fix.