### PR TITLE
wfe: read role for produce-via-reply stages; role-gate the named-file drift guard

### DIFF
--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -155,10 +155,13 @@ int delegate_prompt_allows_writes(const char *prompt);
  *   When wt_path is NULL, falls back to response-text matching:
  *     full-path match → ok; basename-only → soft drift (rc=1);
  *     absent from response → hard drift (rc=-1).
- *   Returns -1 on hard drift, 1 on soft drift, 0 when all paths are ok. */
+ *   Returns -1 on hard drift, 1 on soft drift, 0 when all paths are ok.
+ *   role_is_write is the authoritative write-intent gate: a read/analysis role
+ *   (0) can never hard-drift on a missing named file (it produces no files), so a
+ *   path scraped from reference content in its prompt never fails it. */
 int delegate_check_named_file_drift(const char *const *paths, int path_count, const char *prompt,
-                                    const char *response, const char *wt_path, char *errbuf,
-                                    size_t errbuf_size);
+                                    const char *response, const char *wt_path, int role_is_write,
+                                    char *errbuf, size_t errbuf_size);
 
 /* Build a compact validation evidence bundle for validate/review delegates.
  * The bundle includes HEAD ref, diff --stat, and changed files.

--- a/src/server/delegate_prompt.c
+++ b/src/server/delegate_prompt.c
@@ -644,14 +644,24 @@ static int drift_path_is_external(const char *path, const char *wt_path)
 }
 
 int delegate_check_named_file_drift(const char *const *paths, int path_count, const char *prompt,
-                                    const char *response, const char *wt_path, char *errbuf,
-                                    size_t errbuf_size)
+                                    const char *response, const char *wt_path, int role_is_write,
+                                    char *errbuf, size_t errbuf_size)
 {
    if (!paths || path_count <= 0)
       return 0;
 
    if (errbuf && errbuf_size > 0)
       errbuf[0] = '\0';
+
+   /* The delegate ROLE is the authoritative write-intent signal: only a
+    * write-capable role can be expected to CREATE a named file, so only it can
+    * hard-drift on one that is missing. A read/analysis delegate (WFE's
+    * understand/split/review, the judge) produces its artifact from its reply and
+    * modifies nothing, so a repo-relative path scraped out of reference content
+    * threaded into its prompt must never fail it. The prompt heuristic stays as a
+    * NARROWING override so an explicit "do not edit" still disables the hard-fail
+    * for a write role. */
+   int writes_allowed = role_is_write && delegate_prompt_allows_writes(prompt);
 
    int hard_drift = 0;
    int soft_drift = 0;
@@ -688,7 +698,7 @@ int delegate_check_named_file_drift(const char *const *paths, int path_count, co
             if (drift_path_is_external(path, wt_path))
                continue;
 
-            if (!delegate_prompt_allows_writes(prompt))
+            if (!writes_allowed)
                continue;
 
             const char *ibase = strrchr(path, '/');
@@ -753,7 +763,7 @@ int delegate_check_named_file_drift(const char *const *paths, int path_count, co
          }
          else
          {
-            if (!delegate_prompt_allows_writes(prompt))
+            if (!writes_allowed)
             {
                if (!soft_drift && errbuf && errbuf_size > 0)
                   snprintf(errbuf, errbuf_size,
@@ -789,7 +799,7 @@ int delegate_check_named_file_drift(const char *const *paths, int path_count, co
          }
          else
          {
-            if (!delegate_prompt_allows_writes(prompt))
+            if (!writes_allowed)
             {
                if (!soft_drift && errbuf && errbuf_size > 0)
                   snprintf(errbuf, errbuf_size,

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1192,8 +1192,9 @@ void delegate_worker(void *arg)
       char drift_err[512];
       const char *drift_root =
           delegate_worktree_path[0] ? delegate_worktree_path : (cwd[0] ? cwd : NULL);
-      int drift_rc = delegate_check_named_file_drift(path_ptrs, named_path_count, prompt, NULL,
-                                                     drift_root, drift_err, sizeof(drift_err));
+      int drift_rc =
+          delegate_check_named_file_drift(path_ptrs, named_path_count, prompt, NULL, drift_root,
+                                          is_write_role, drift_err, sizeof(drift_err));
       if (drift_rc < 0)
       {
          aimee_log(LOG_WARN, "delegate", "named-file drift guard (pre-flight): %s", drift_err);
@@ -1427,9 +1428,10 @@ void delegate_worker(void *arg)
       for (int i = 0; i < named_path_count; i++)
          path_ptrs[i] = named_paths[i];
       char drift_err[512];
-      int drift_rc = delegate_check_named_file_drift(
-          path_ptrs, named_path_count, prompt, result.response,
-          delegate_worktree_path[0] ? delegate_worktree_path : NULL, drift_err, sizeof(drift_err));
+      int drift_rc =
+          delegate_check_named_file_drift(path_ptrs, named_path_count, prompt, result.response,
+                                          delegate_worktree_path[0] ? delegate_worktree_path : NULL,
+                                          is_write_role, drift_err, sizeof(drift_err));
       if (drift_rc < 0)
       {
          aimee_log(LOG_WARN, "delegate", "named-file drift (post-run): %s", drift_err);

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -93,8 +93,8 @@ static int wfe_coord_task_wait(int job_id, int task_id, char *result_out, size_t
  * (container-ready — WFE never assumes a local process or a shared checkout).
  * WFE holds no server_ctx, spawns no delegate, and runs no git: `freeze` owns the
  * commit, so out_commit_sha is left empty here. The block's `role` arg is the
- * delegate PERSONA (architect/engineer/...); a producing delegate routes on a
- * WRITE role so the delegate system isolates + applies its changes. */
+ * delegate PERSONA (architect/engineer/...); the delegate ROLE (read vs write) is
+ * derived from whether the block named a captured artifact_path — see below. */
 static int wfe_live_delegate_run(const char *workdir, const char *role, const char *delegate,
                                  const char *prompt, const char *artifact_path,
                                  char out_commit_sha[64], char *err, size_t errlen)
@@ -110,6 +110,19 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
    }
 
    const char *persona = (role && role[0]) ? role : "engineer";
+   /* Produce-via-reply vs worktree-mutating, keyed on whether the block named a
+    * captured artifact_path:
+    *   - artifact_path set (author/understand/split/review): the delegate's OUTPUT
+    *     is its reply, which WFE persists below. A READ role ("review"): it
+    *     modifies no files, so the shared path's named-file drift guard never
+    *     hard-fails it on a repo-relative path quoted in the reference content
+    *     threaded into its prompt.
+    *   - artifact_path NULL (implement/decompose/tdd/document): the delegate
+    *     MUTATES the worktree. A WRITE role ("code") so the delegate system
+    *     isolates its checkout and applies the diff back into `workdir`.
+    * cwd = the work-item worktree; persona names the delegate identity. */
+   int produce_via_reply = (artifact_path && artifact_path[0]);
+   const char *delegate_role = produce_via_reply ? "review" : "code";
    int job_id = db1_coord_job_create(WFE_COORD_PLAN_ID, 1);
    if (job_id <= 0)
    {
@@ -117,10 +130,7 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
          snprintf(err, errlen, "wfe live delegate: could not create coord job");
       return -1;
    }
-   /* Write role ("code") so the shared path runs the delegate in an isolated
-    * worktree and applies its diff back into `workdir`. cwd = the work-item
-    * worktree; persona names the delegate identity. */
-   int task_id = db1_coord_job_add_task(job_id, 0, "[]", "code", prompt, workdir, persona);
+   int task_id = db1_coord_job_add_task(job_id, 0, "[]", delegate_role, prompt, workdir, persona);
    if (task_id <= 0)
    {
       db1_coord_job_cancel(job_id);

--- a/src/tests/test_delegate_context_shed.c
+++ b/src/tests/test_delegate_context_shed.c
@@ -205,7 +205,7 @@ static void test_preflight_nonexistent_no_create_intent(void)
    char errbuf[512] = {0};
    const char *paths[] = {"src/nonexistent.c"};
    int rc = delegate_check_named_file_drift(paths, 1, "Edit src/nonexistent.c to fix the bug.",
-                                            NULL, NULL, errbuf, sizeof(errbuf));
+                                            NULL, NULL, 1, errbuf, sizeof(errbuf));
    assert(rc == -1);
    assert(strstr(errbuf, "nonexistent.c") != NULL);
    assert(strstr(errbuf, "create intent") != NULL);
@@ -218,7 +218,7 @@ static void test_preflight_nonexistent_with_create_intent(void)
    const char *paths[] = {"src/newfile.c"};
    int rc =
        delegate_check_named_file_drift(paths, 1, "Create a new file src/newfile.c with the module.",
-                                       NULL, NULL, errbuf, sizeof(errbuf));
+                                       NULL, NULL, 1, errbuf, sizeof(errbuf));
    assert(rc == 0);
    printf("  preflight_nonexistent_with_create_intent: ok\n");
 }
@@ -229,7 +229,7 @@ static void test_preflight_readonly_missing_file_as_context(void)
    const char *paths[] = {"src/newfile.c"};
    int rc = delegate_check_named_file_drift(paths, 1,
                                             "Read-only review of src/newfile.c. Do not edit files.",
-                                            NULL, NULL, errbuf, sizeof(errbuf));
+                                            NULL, NULL, 1, errbuf, sizeof(errbuf));
    assert(rc == 0);
    printf("  preflight_readonly_missing_file_as_context: ok\n");
 }
@@ -249,7 +249,7 @@ static void test_preflight_existing_file_no_error(void)
    const char *paths[] = {full_path};
    int rc =
        delegate_check_named_file_drift(paths, 1, "Edit the config parser to handle edge cases.",
-                                       NULL, NULL, errbuf, sizeof(errbuf));
+                                       NULL, NULL, 1, errbuf, sizeof(errbuf));
    /* Existing file: pre-flight passes regardless */
    assert(rc == 0);
    cleanup_tmpdir();
@@ -267,8 +267,8 @@ static void test_preflight_relative_existing_file_with_base(void)
    char errbuf[512] = {0};
    const char *paths[] = {"isolated/context.c"};
    int rc = delegate_check_named_file_drift(
-       paths, 1, "Read isolated/context.c and summarize it without edits.", NULL, g_tmpdir, errbuf,
-       sizeof(errbuf));
+       paths, 1, "Read isolated/context.c and summarize it without edits.", NULL, g_tmpdir, 1,
+       errbuf, sizeof(errbuf));
    assert(rc == 0);
    cleanup_tmpdir();
    printf("  preflight_relative_existing_file_with_base: ok\n");
@@ -291,7 +291,7 @@ static void test_preflight_remote_scp_path_skipped(void)
 
    char errbuf[512] = {0};
    const char *paths[] = {extracted[0]};
-   int rc = delegate_check_named_file_drift(paths, 1, prompt, NULL, "/home/virant/dev/aimee",
+   int rc = delegate_check_named_file_drift(paths, 1, prompt, NULL, "/home/virant/dev/aimee", 1,
                                             errbuf, sizeof(errbuf));
    assert(rc == 0);
    assert(errbuf[0] == '\0');
@@ -304,9 +304,9 @@ static void test_preflight_absolute_outside_worktree_skipped(void)
     * file, not an in-repo create target — pre-flight must not hard-fail. */
    char errbuf[512] = {0};
    const char *paths[] = {"/mnt/media/other/thing.c"};
-   int rc = delegate_check_named_file_drift(paths, 1,
-                                            "Update /mnt/media/other/thing.c on the remote host.",
-                                            NULL, "/home/virant/dev/aimee", errbuf, sizeof(errbuf));
+   int rc = delegate_check_named_file_drift(
+       paths, 1, "Update /mnt/media/other/thing.c on the remote host.", NULL,
+       "/home/virant/dev/aimee", 1, errbuf, sizeof(errbuf));
    assert(rc == 0);
    printf("  preflight_absolute_outside_worktree_skipped: ok\n");
 }
@@ -318,11 +318,38 @@ static void test_preflight_relative_under_worktree_still_fails(void)
     * the guard for real in-repo targets. */
    char errbuf[512] = {0};
    const char *paths[] = {"src/nonexistent_xyz.c"};
-   int rc = delegate_check_named_file_drift(paths, 1, "Edit src/nonexistent_xyz.c to fix the bug.",
-                                            NULL, "/home/virant/dev/aimee", errbuf, sizeof(errbuf));
+   int rc =
+       delegate_check_named_file_drift(paths, 1, "Edit src/nonexistent_xyz.c to fix the bug.", NULL,
+                                       "/home/virant/dev/aimee", 1, errbuf, sizeof(errbuf));
    assert(rc == -1);
    assert(strstr(errbuf, "create intent") != NULL);
    printf("  preflight_relative_under_worktree_still_fails: ok\n");
+}
+
+static void test_read_role_scraped_path_no_hard_drift(void)
+{
+   /* WFE regression: a read/analysis delegate (understand/split/review) threads a
+    * reference doc into its prompt whose markdown links get scraped as named
+    * paths. It produces its artifact from its reply and creates no files, so a
+    * missing scraped path must NEVER hard-fail it — the role, not the prompt's
+    * write-y wording, is the authoritative gate. The SAME inputs under a write
+    * role still hard-fail (proving the gate is what changed). An edit-verb prompt
+    * with no create intent isolates the gate: a write role hard-drifts on the
+    * missing path, a read role does not. */
+   const char *prompt = "Edit done/full-autonomous-development.md to revise the plan.";
+   const char *paths[] = {"done/full-autonomous-development.md"};
+
+   char errbuf[512] = {0};
+   int rc_read = delegate_check_named_file_drift(paths, 1, prompt, NULL, "/home/virant/dev/aimee",
+                                                 0 /* read role */, errbuf, sizeof(errbuf));
+   assert(rc_read == 0);
+   assert(errbuf[0] == '\0');
+
+   errbuf[0] = '\0';
+   int rc_write = delegate_check_named_file_drift(paths, 1, prompt, NULL, "/home/virant/dev/aimee",
+                                                  1 /* write role */, errbuf, sizeof(errbuf));
+   assert(rc_write == -1);
+   printf("  read_role_scraped_path_no_hard_drift: ok\n");
 }
 
 /* ---- delegate_prompt_allows_writes ---- */
@@ -461,7 +488,8 @@ static void test_postrun_path_in_response(void)
 
    char errbuf[512] = {0};
    const char *paths[] = {full_path};
-   int rc = delegate_check_named_file_drift(paths, 1, NULL, response, NULL, errbuf, sizeof(errbuf));
+   int rc =
+       delegate_check_named_file_drift(paths, 1, NULL, response, NULL, 1, errbuf, sizeof(errbuf));
    assert(rc == 0);
    cleanup_tmpdir();
    printf("  postrun_path_in_response: ok\n");
@@ -482,7 +510,8 @@ static void test_postrun_path_absent_hard_drift(void)
 
    char errbuf[512] = {0};
    const char *paths[] = {full_path};
-   int rc = delegate_check_named_file_drift(paths, 1, NULL, response, NULL, errbuf, sizeof(errbuf));
+   int rc =
+       delegate_check_named_file_drift(paths, 1, NULL, response, NULL, 1, errbuf, sizeof(errbuf));
    assert(rc == -1);
    assert(strstr(errbuf, "drift") != NULL || strstr(errbuf, "not found") != NULL);
    cleanup_tmpdir();
@@ -506,7 +535,7 @@ static void test_postrun_readonly_path_absent_soft_drift(void)
    char errbuf[512] = {0};
    const char *paths[] = {full_path};
    int rc =
-       delegate_check_named_file_drift(paths, 1, prompt, response, NULL, errbuf, sizeof(errbuf));
+       delegate_check_named_file_drift(paths, 1, prompt, response, NULL, 1, errbuf, sizeof(errbuf));
    assert(rc == 1);
    assert(strstr(errbuf, "read-only context") != NULL);
    cleanup_tmpdir();
@@ -529,7 +558,8 @@ static void test_postrun_basename_only_soft_drift(void)
 
    char errbuf[512] = {0};
    const char *paths[] = {full_path};
-   int rc = delegate_check_named_file_drift(paths, 1, NULL, response, NULL, errbuf, sizeof(errbuf));
+   int rc =
+       delegate_check_named_file_drift(paths, 1, NULL, response, NULL, 1, errbuf, sizeof(errbuf));
    assert(rc == 1); /* soft drift — only basename matched */
    assert(strstr(errbuf, "ambiguous") != NULL || strstr(errbuf, "basename") != NULL);
    cleanup_tmpdir();
@@ -542,7 +572,8 @@ static void test_postrun_nonexistent_skipped(void)
    const char *response = "I completed the task without touching that file.";
    char errbuf[512] = {0};
    const char *paths[] = {"/tmp/definitely_nonexistent_file_xyz.c"};
-   int rc = delegate_check_named_file_drift(paths, 1, NULL, response, NULL, errbuf, sizeof(errbuf));
+   int rc =
+       delegate_check_named_file_drift(paths, 1, NULL, response, NULL, 1, errbuf, sizeof(errbuf));
    assert(rc == 0);
    printf("  postrun_nonexistent_skipped: ok\n");
 }
@@ -566,7 +597,7 @@ static void test_postrun_wt_readonly_missing_file_soft_drift(void)
    const char *response = "No blocking findings.";
    char errbuf[512] = {0};
    const char *paths[] = {missing_path};
-   int rc = delegate_check_named_file_drift(paths, 1, prompt, response, g_tmpdir, errbuf,
+   int rc = delegate_check_named_file_drift(paths, 1, prompt, response, g_tmpdir, 1, errbuf,
                                             sizeof(errbuf));
    assert(rc == 1);
    assert(strstr(errbuf, "read-only context") != NULL);
@@ -606,8 +637,8 @@ static void test_postrun_wt_context_file_soft_drift(void)
    const char *response = "Created src/new_module.c with the requested functionality.";
    char errbuf[512] = {0};
    const char *paths[] = {full_path};
-   int rc =
-       delegate_check_named_file_drift(paths, 1, NULL, response, g_tmpdir, errbuf, sizeof(errbuf));
+   int rc = delegate_check_named_file_drift(paths, 1, NULL, response, g_tmpdir, 1, errbuf,
+                                            sizeof(errbuf));
    /* context file not in git diff, exists on disk → soft drift, not hard */
    assert(rc == 1);
    assert(strstr(errbuf, "context") != NULL || strstr(errbuf, "not modified") != NULL);
@@ -619,8 +650,9 @@ static void test_null_inputs(void)
 {
    char errbuf[512] = {0};
    assert(delegate_extract_named_paths(NULL, NULL, 0) == 0);
-   assert(delegate_check_named_file_drift(NULL, 0, NULL, NULL, NULL, errbuf, sizeof(errbuf)) == 0);
-   assert(delegate_check_named_file_drift(NULL, 5, "prompt", "response", NULL, errbuf,
+   assert(delegate_check_named_file_drift(NULL, 0, NULL, NULL, NULL, 1, errbuf, sizeof(errbuf)) ==
+          0);
+   assert(delegate_check_named_file_drift(NULL, 5, "prompt", "response", NULL, 1, errbuf,
                                           sizeof(errbuf)) == 0);
    printf("  null_inputs: ok\n");
 }
@@ -659,6 +691,7 @@ int main(void)
    test_preflight_remote_scp_path_skipped();
    test_preflight_absolute_outside_worktree_skipped();
    test_preflight_relative_under_worktree_still_fails();
+   test_read_role_scraped_path_no_hard_drift();
    test_prompt_write_intent();
    test_validation_bundle_identifies_source_worktree();
    test_validation_bundle_keeps_large_diff_handlers();


### PR DESCRIPTION
## Problem

Routing WFE through the shared `delegate_worker` path (the coord-queue refactor) subjected WFE's prompts to the **named-file drift guard** for the first time. That guard scrapes repo-relative paths out of the delegate prompt and hard-fails a write delegate that did not create them.

WFE's analysis stages (`understand`/`split`) thread a large reference document into the prompt. Its incidental markdown links get scraped as if they were required outputs — so `split` hard-failed on `done/full-autonomous-development.md`, a path quoted in the very plan it was decomposing. Observed live: the run looped `split` to its cap and never advanced.

## Root cause

- `wfe_live_delegate_run` dispatched **every** producing block as a write-role `code` task, even the ones that only produce a captured-reply artifact and modify no files.
- `delegate_check_named_file_drift` decided "writes are allowed" from a **prompt-text heuristic** (`delegate_prompt_allows_writes`) rather than the delegate's authoritative role, so an analysis delegate whose prompt happened to contain write-y wording was held to a write delegate's file-creation contract.

## Fix

1. **`wfe_live_delegate_run` derives the delegate ROLE from `artifact_path` presence.** Produce-via-reply blocks (`author`/`understand`/`split`/`review`) name a captured `artifact_path` — their output is the delegate's reply, which WFE persists — so they get a **read** role. Only worktree-mutating blocks (`implement`/`decompose`/`tdd`/`document`, `artifact_path == NULL`) get the **write** role.

2. **`delegate_check_named_file_drift` takes `role_is_write` as the authoritative write-intent gate**, replacing the prompt heuristic as the primary signal. The prompt heuristic stays only as a *narrowing* override, so an explicit "do not edit" still disables the hard-fail for a write role. A read/analysis delegate can never hard-drift on a missing named file, so a path scraped from reference content in its prompt never fails it.

## Testing

- New regression test `read_role_scraped_path_no_hard_drift`: a read role does **not** hard-drift on a scraped missing path; the same inputs under a write role still do.
- Full `unit-test-delegate-context-shed` suite green (incl. the worktree post-run path where the live failure occurred).
- `unit-test-coord-jobs` and `unit-test-wfe-advance` green.
- Full server build clean.

Validated against the live `.254` run that was stuck at `split`: this is the remaining code blocker after the coord-queue refactor (0 × 429s, correct per-stage persona, handoff opt-out all confirmed on that run).