### PR TITLE
fix(delegate): run bash/execute_script inside the sandbox, not on the host

### DIFF
--- a/docs/proposals/pending/delegate-sandbox-image-customization.md
+++ b/docs/proposals/pending/delegate-sandbox-image-customization.md
@@ -1,0 +1,141 @@
+# Proposal: Per-project delegate sandbox image customization
+
+- **State:** PENDING — design agreed, implementation to follow. Builds directly on
+  the delegate sandbox (`delegate_sandbox`, `WS_PROVIDER_CONTAINER`,
+  `delegate_backend_docker.c`, `workspace_turn_bind_container`) and on the
+  server-side git routing fix (PR #1406) that removed the last reason the sandbox
+  needed a network-facing binary of its own.
+- **Author:** JBailes
+- **Date:** 2026-07-16
+
+## Thesis
+
+The delegate sandbox runs `--network none` **by intent**: a delegate has no IP
+egress, and its only outward channel is the bound `aimee-http.sock` to
+aimee-server. Anything that needs the network or a credential (git, web search,
+package installs) is performed **by aimee on the server's side**, never inside the
+container. That is the correct boundary and it is now enforced (git was the last
+tool wrongly executing in-container; PR #1406 routes it server-side).
+
+What the sandbox still needs is the **local, network-free toolchain** for the
+model's own work: a C project needs `gcc`/`make`, a Rust project `cargo`, a Python
+project `python3`, a docs project nothing at all. Today every delegate runs on a
+hardcoded `ubuntu:22.04` (`DOCKER_DEFAULT_IMAGE`) with no override wired
+(`server_compute` binds the container with `image = NULL`), so it has coreutils and
+nothing else — `verify`/`test`/build tools all fail. The toolchain is inherently
+**per-user and per-project**; it cannot be one global image.
+
+Because `--network none` removes the network at *run* time, the toolchain must be
+baked in *before* that — at build time. aimee-server runs inside docker and drives
+the host docker daemon, so `docker build` is always available: aimee can build a
+per-project image itself, with network at build time, then run the delegate against
+it with no network.
+
+## Design
+
+### Resolution chain (most specific wins), resolved at delegate-bind time from the delegate's cwd
+
+1. **In-repo `.aimee/project.yaml` → `sandbox:` block.** The toolchain travels with
+   the project; the code declares what it needs. (Primary "project" scope.)
+2. **aimee.yaml per-workspace object → `sandbox`** on that workspace root. Operator
+   override for a specific project root. (Workspace entries are already
+   `{path, provider, …}` objects — this adds one field.)
+3. **aimee.yaml global `delegate_sandbox_image` / `sandbox` default.** The per-user /
+   per-instance default.
+4. **Built-in base fallback.** A small `aimee-delegate-base` (or `ubuntu:22.04`).
+
+### Spec forms (valid at any scope)
+
+- `image: <ref>` — use a pre-baked image as-is (no build).
+- `from: <base>` + `packages: [gcc, make, …]` — aimee generates a Dockerfile
+  (`FROM <base>` + a single `apt-get install` layer) and builds it. Covers the
+  common case in one line.
+- `dockerfile: <path>` — build a project-provided Dockerfile (escape hatch).
+
+### Build + cache
+
+- The derived image is tagged by content hash: `aimee-sbx:<sha256(base + spec)>`.
+- Built **once** with network; reused across turns and delegates; rebuilt only when
+  the spec hash changes. A short in-process lock avoids two concurrent turns racing
+  the same build.
+- Old `aimee-sbx:*` tags are pruned on an LRU/age policy.
+
+### Invariant preserved
+
+Build has network; the delegate **run** stays `--network none`. The credential and
+the git/web rails remain server-side. The sandbox only ever gains **local,
+network-free tools**.
+
+### Trust
+
+An in-repo `.aimee/project.yaml` lets a repository dictate what is built into its
+own sandbox. This is acceptable: it is the co-located developer's own code, the
+build is isolated in a throwaway layer, and the resulting container has no network.
+It is nonetheless a trust surface — the same trust already extended to the repo's
+`Makefile`/build scripts. Operators who want it locked down use scope 2/3
+(aimee.yaml) and can disable in-repo specs.
+
+## Prerequisite: the model's code execution must actually run in the sandbox
+
+Audit finding (verified in `agent_tools_dispatch.c` / `posix/agent_tools.c:713`):
+`bash` and `execute_script` route to the container provider ONLY for
+`WS_PROVIDER_DETACHED`; for `WS_PROVIDER_CONTAINER` they fall through to a **local
+fork on the aimee-server host** (`tool_bash`/`tool_execute_script`). So today a
+sandboxed delegate's arbitrary shell/script runs on the host — with the host's
+filesystem and the host's network — NOT inside the `--network none` container. The
+file tools (`read_file`/`write_file` via `ws->read_all`/`write_all`) already route
+in; the code-execution tools do not. This is a sandbox escape and it is also the
+reason image customization is currently moot (the toolchain the model uses is the
+*server's*, not the container's). **Fix this first:** route `bash`,
+`execute_script`, `verify`'s command-run and the background-process tools through
+the active provider for `CONTAINER`, exactly as the file tools do. Only after this
+does the container's own toolchain matter.
+
+## Package access without network: aimee as the package proxy + cache
+
+The sandbox stays `--network none`; its only channel is the bound aimee socket. Yet
+agents legitimately need `apt`/`npm`/`pip`/`cargo` to install a toolchain. Rather
+than pre-bake everything, **route package managers through aimee**: point `apt`,
+`npm`, `pip`, etc. inside the container at aimee as their mirror/proxy (over the
+bound channel — a loopback shim forwarding to the UDS, or an aimee-served proxy
+endpoint). aimee (which has network) fetches upstream, **caches the artifacts**, and
+serves them back. The delegate installs what it needs; the network boundary is
+never crossed by the delegate itself — only by aimee, in the same way git and web
+search already work.
+
+## Learned toolchain: customization from observed usage
+
+Because every package install flows through aimee's proxy+cache, aimee **records
+what each project actually routed and cached**. That observed set *is* the project's
+toolchain. So image customization is largely **learned**, not authored:
+
+- First runs: the delegate `apt install`s what it needs; aimee proxies + caches +
+  records it against the project.
+- Later runs: aimee can **pre-bake the learned package set** into the project's
+  `aimee-sbx:<hash>` image (build with network, run `--network none`), so the tools
+  are present immediately and installs become cache hits.
+
+The declared `.aimee/project.yaml` / aimee.yaml `sandbox` spec from the section
+above is then an **optional override / seed**, not a requirement — the common path
+is that aimee figures the toolchain out from real usage.
+
+## Phasing
+
+1. **Sandbox-escape fix (prerequisite):** route `bash`/`execute_script`/`verify`
+   command-run/background-process tools into the container for `WS_PROVIDER_CONTAINER`.
+   The sandbox now actually contains code execution.
+2. **Image resolution (declared):** parse the `sandbox` block at all three scopes;
+   resolve `image:`; wire it through `workspace_turn_bind_container` (replace the
+   `NULL` at `server_compute.c:1396`). Named pre-baked images work end-to-end.
+3. **Build-from-spec:** `from`+`packages`/`dockerfile`; content-hash tag; build lock.
+4. **Package proxy + cache:** aimee serves `apt`/`npm`/`pip` fetches over the bound
+   channel and caches artifacts; container package managers are pointed at it.
+5. **Learned toolchain:** record proxied/cached package sets per project; optionally
+   pre-bake them into the project image. Declared spec becomes an override/seed.
+6. **Cache management:** prune policy + `aimee delegate sandbox build/list/gc` CLI.
+
+## Non-goals
+
+- Giving the delegate its own IP egress (git/web/package fetch stay routed through
+  aimee — the delegate never crosses the network boundary itself).
+- A general devcontainer.json implementation (could be a later adapter onto this).

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -738,6 +738,53 @@ char *tool_bash(const char *command, int timeout_ms)
       return res ? res : safe_strdup("{}");
    }
 
+   /* Sandboxed (CONTAINER) delegate: run the shell INSIDE the container via the
+    * provider's exec_shell (docker exec), NOT as a local fork on the aimee-server
+    * host. The local fork below would execute the model's arbitrary command on the
+    * host — with the host's filesystem and network — escaping the `--network none`
+    * sandbox entirely (the file tools already route into the container; bash/script
+    * were the hole). Run in the delegate's worktree: it is bind-mounted
+    * path-identically, so the same absolute path is valid inside the container. */
+   if (ws && ws->kind == WS_PROVIDER_CONTAINER && ws->exec_shell)
+   {
+      const char *cwd = run_cmd_get_cwd();
+      char *wrapped = NULL;
+      if (cwd && cwd[0])
+      {
+         dstr_t w;
+         dstr_init(&w);
+         dstr_append_str(&w, "cd '");
+         for (const char *c = cwd; *c; c++)
+         {
+            if (*c == '\'')
+               dstr_append_str(&w, "'\\''");
+            else
+               dstr_append_char(&w, *c);
+         }
+         dstr_append_str(&w, "' && ");
+         dstr_append_str(&w, command);
+         wrapped = w.data ? safe_strdup(w.data) : NULL;
+         dstr_free(&w);
+      }
+      int exit_code = -1;
+      char *out = ws->exec_shell(ws, wrapped ? wrapped : command, &exit_code);
+      free(wrapped);
+      /* exit_code == -1 with no capture means docker exec could not run the command
+       * at all (transport failure) — distinct from a real command that exits 0 with
+       * empty output, which the container provider returns as NULL out / exit 0. */
+      if (exit_code == -1 && !out)
+         return safe_strdup("{\"stdout\":\"\",\"stderr\":\"sandbox exec failed: could not run "
+                            "the command in the delegate container\",\"exit_code\":-1}");
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "stdout", out ? out : "");
+      cJSON_AddStringToObject(r, "stderr", "");
+      cJSON_AddNumberToObject(r, "exit_code", exit_code);
+      free(out);
+      char *res = cJSON_PrintUnformatted(r);
+      cJSON_Delete(r);
+      return res ? res : safe_strdup("{}");
+   }
+
    int stdout_pipe[2], stderr_pipe[2];
    if (pipe(stdout_pipe) != 0 || pipe(stderr_pipe) != 0)
       return safe_strdup("{\"stdout\":\"\",\"stderr\":\"pipe failed\",\"exit_code\":-1}");

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -511,8 +511,8 @@ static char *td_execute_script(cJSON *args, const char *name, const char *dispat
    {
       dstr_t c;
       dstr_init(&c);
-      const char *cwd = (wd && cJSON_IsString(wd) && wd->valuestring[0]) ? wd->valuestring
-                                                                         : run_cmd_get_cwd();
+      const char *cwd =
+          (wd && cJSON_IsString(wd) && wd->valuestring[0]) ? wd->valuestring : run_cmd_get_cwd();
       if (cwd && cwd[0])
       {
          dstr_append_str(&c, "cd '");

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -493,8 +493,60 @@ static char *td_execute_script(cJSON *args, const char *name, const char *dispat
    if (!lang || !cJSON_IsString(lang) || !body || !cJSON_IsString(body))
    {
       result = safe_strdup("error: missing 'language' or 'body' parameter");
+      free(env_json);
+      return result;
    }
-   else
+
+   /* Sandboxed (CONTAINER) delegate: run the script INSIDE the container via the
+    * provider's exec_shell, NOT as tool_execute_script's local fork on the
+    * aimee-server host — the host fork would run the model's arbitrary script on the
+    * host (its filesystem, its network), escaping the `--network none` sandbox that
+    * the file tools already respect. We deliberately forgo the host script-RPC stub
+    * bridge here: a sandboxed script must not reach back into the aimee-server
+    * process, and the delegate already has aimee's tools at the agent-loop layer. The
+    * body is fed over a quoted heredoc so its contents need no escaping; the
+    * container cwd is the bind-mounted (path-identical) worktree. */
+   const workspace_provider_t *ws = workspace_provider_active();
+   if (ws && ws->kind == WS_PROVIDER_CONTAINER && ws->exec_shell)
+   {
+      dstr_t c;
+      dstr_init(&c);
+      const char *cwd = (wd && cJSON_IsString(wd) && wd->valuestring[0]) ? wd->valuestring
+                                                                         : run_cmd_get_cwd();
+      if (cwd && cwd[0])
+      {
+         dstr_append_str(&c, "cd '");
+         for (const char *p = cwd; *p; p++)
+         {
+            if (*p == '\'')
+               dstr_append_str(&c, "'\\''");
+            else
+               dstr_append_char(&c, *p);
+         }
+         dstr_append_str(&c, "' && ");
+      }
+      dstr_append_str(&c, strcmp(lang->valuestring, "python") == 0
+                              ? "python3 - <<'AIMEE_SCRIPT_EOF'\n"
+                              : "bash -s <<'AIMEE_SCRIPT_EOF'\n");
+      dstr_append_str(&c, body->valuestring);
+      dstr_append_str(&c, "\nAIMEE_SCRIPT_EOF\n");
+      int exit_code = -1;
+      char *out = c.data ? ws->exec_shell(ws, c.data, &exit_code) : NULL;
+      dstr_free(&c);
+      free(env_json);
+      if (exit_code == -1 && !out)
+         return safe_strdup("{\"stdout\":\"\",\"stderr\":\"sandbox exec failed: could not run the "
+                            "script in the delegate container\",\"exit_code\":-1}");
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "stdout", out ? out : "");
+      cJSON_AddStringToObject(r, "stderr", "");
+      cJSON_AddNumberToObject(r, "exit_code", exit_code);
+      free(out);
+      char *res = cJSON_PrintUnformatted(r);
+      cJSON_Delete(r);
+      return res ? res : safe_strdup("{}");
+   }
+
    {
       int secs = (tout && cJSON_IsNumber(tout)) ? tout->valueint : 120;
       const char *dir = (wd && cJSON_IsString(wd)) ? wd->valuestring : NULL;

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -64,6 +64,8 @@ void test_parent_write_guard_allows_workspace_file_ops(void);
 void test_parent_write_guard_allows_workspace_chain(void);
 void test_parent_write_guard_allows_readonly_printf(void);
 void test_detached_dead_channel_reports_clear_error(void);
+void test_container_bash_runs_in_sandbox(void);
+void test_container_execute_script_runs_in_sandbox(void);
 void otel_init(const char *endpoint, const char *service_name, const char *session)
 {
    (void)endpoint;
@@ -2900,6 +2902,8 @@ int main(void)
    test_parent_write_guard_allows_workspace_chain();
    test_parent_write_guard_allows_readonly_printf();
    test_detached_dead_channel_reports_clear_error();
+   test_container_bash_runs_in_sandbox();
+   test_container_execute_script_runs_in_sandbox();
    test_parent_write_guard_shell_uses_delegate_cwd_in_git_parent();
    test_tool_list_files();
    test_tool_grep_excludes_heavy_dirs();

--- a/src/tests/test_agent_delegate_root.c
+++ b/src/tests/test_agent_delegate_root.c
@@ -456,3 +456,81 @@ void test_detached_dead_channel_reports_clear_error(void)
    free(result);
    printf("  PASS: test_detached_dead_channel_reports_clear_error\n");
 }
+
+/* A CONTAINER-sandboxed delegate must run its shell/script INSIDE the container via
+ * the provider's exec_shell — NOT as a local fork on the aimee-server host, which
+ * would execute the model's arbitrary command on the host (its filesystem, its
+ * network) and escape the `--network none` sandbox. The file tools already route in;
+ * bash/execute_script were the hole. The spy stands in for the container: if either
+ * tool still forked locally, the spy would never be called. */
+static int g_sbx_exec_called;
+static char *g_sbx_exec_cmd;
+static char *sandbox_capture_exec_shell(const workspace_provider_t *p, const char *cmd,
+                                        int *exit_code)
+{
+   (void)p;
+   g_sbx_exec_called = 1;
+   free(g_sbx_exec_cmd);
+   g_sbx_exec_cmd = cmd ? strdup(cmd) : NULL;
+   if (exit_code)
+      *exit_code = 0;
+   return strdup("SANDBOX-STDOUT-MARKER");
+}
+
+void test_container_bash_runs_in_sandbox(void)
+{
+   workspace_provider_t mock;
+   memset(&mock, 0, sizeof(mock));
+   mock.kind = WS_PROVIDER_CONTAINER;
+   mock.exec_shell = sandbox_capture_exec_shell;
+   workspace_provider_set_active(&mock);
+   g_sbx_exec_called = 0;
+   free(g_sbx_exec_cmd);
+   g_sbx_exec_cmd = NULL;
+
+   char *result = tool_bash("echo hi", 5000);
+   workspace_provider_clear_active();
+
+   /* Routed INTO the container (spy hit), carrying our command. */
+   assert(g_sbx_exec_called == 1);
+   assert(g_sbx_exec_cmd && strstr(g_sbx_exec_cmd, "echo hi"));
+   cJSON *j = cJSON_Parse(result);
+   assert(j);
+   cJSON *so = cJSON_GetObjectItem(j, "stdout");
+   assert(so && cJSON_IsString(so) && strstr(so->valuestring, "SANDBOX-STDOUT-MARKER"));
+   cJSON_Delete(j);
+   free(result);
+   free(g_sbx_exec_cmd);
+   g_sbx_exec_cmd = NULL;
+   printf("  PASS: test_container_bash_runs_in_sandbox\n");
+}
+
+void test_container_execute_script_runs_in_sandbox(void)
+{
+   workspace_provider_t mock;
+   memset(&mock, 0, sizeof(mock));
+   mock.kind = WS_PROVIDER_CONTAINER;
+   mock.exec_shell = sandbox_capture_exec_shell;
+   workspace_provider_set_active(&mock);
+   g_sbx_exec_called = 0;
+   free(g_sbx_exec_cmd);
+   g_sbx_exec_cmd = NULL;
+
+   char *result =
+       dispatch_tool_call("execute_script", "{\"language\":\"bash\",\"body\":\"echo hi\"}", 5000);
+   workspace_provider_clear_active();
+
+   assert(g_sbx_exec_called == 1);
+   assert(g_sbx_exec_cmd && strstr(g_sbx_exec_cmd, "echo hi"));
+   /* Fed over a quoted heredoc so the body needs no escaping. */
+   assert(strstr(g_sbx_exec_cmd, "AIMEE_SCRIPT_EOF"));
+   cJSON *j = cJSON_Parse(result);
+   assert(j);
+   cJSON *so = cJSON_GetObjectItem(j, "stdout");
+   assert(so && cJSON_IsString(so) && strstr(so->valuestring, "SANDBOX-STDOUT-MARKER"));
+   cJSON_Delete(j);
+   free(result);
+   free(g_sbx_exec_cmd);
+   g_sbx_exec_cmd = NULL;
+   printf("  PASS: test_container_execute_script_runs_in_sandbox\n");
+}


### PR DESCRIPTION
## The escape (found auditing the delegate sandbox)
For a `CONTAINER`-sandboxed delegate, `bash` and `execute_script` — the two tools that run the model's **arbitrary code** — did not route into the container. They special-cased only `WS_PROVIDER_DETACHED`; for a container they fell through to a **local fork on the aimee-server host** (`tool_bash` / `tool_execute_script`). So the model's shell/scripts executed on the host, with the host's filesystem and the **host's network**, escaping the `--network none` container the sandbox is built on. The file tools (`read_file`/`write_file` via `ws->read_all`/`write_all`) already routed into the container — `bash` and `execute_script` were the hole.

This also contradicts what a delegate-sandbox promises: a sandboxed agent could `bash: curl …` and reach the network the sandbox was supposed to remove.

## Fix
Route both tools through the provider's `exec_shell` (docker exec) when the active provider is a `CONTAINER`, running in the delegate's worktree (bind-mounted path-identically, so the same absolute path resolves inside the container). Details:
- `execute_script` feeds its body over a **quoted heredoc**, so contents need no escaping; it deliberately forgoes the host script-RPC stub bridge — a sandboxed script must not reach back into the aimee-server process, and the delegate already has aimee's tools at the agent-loop layer.
- Container transport failure (`exit_code == -1`, no capture) is distinguished from a real command that exits 0 with empty output (which the container provider returns as `NULL`).
- `SHARED` (co-located) keeps the local sandboxed fork; `DETACHED` keeps marshalling to the serving client.

## Why this first
This is the prerequisite for the per-project sandbox-image work (see `docs/proposals/pending/delegate-sandbox-image-customization.md`): only once the model's build/test actually runs *in* the container does the container's toolchain matter. That proposal also covers routing `apt`/`npm`/`pip` through aimee (network-none package proxy + cache) and a learned toolchain.

## Tests
`test_agent_delegate_root.c`: a `CONTAINER` provider whose `exec_shell` spy stands in for the container — `bash` and `execute_script` must both hit the spy (routed in), carrying the command through (heredoc-wrapped for scripts). Verified both **abort** on the old host-fork routing and **pass** with the fix.