### PR TITLE
feat(gui): tooltips across relevant UI controls

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -228,6 +228,7 @@ export default function App() {
               <NavLink
                 key={it.route}
                 to={it.route}
+                title={it.hint}
                 style={({ isActive }) => ({
                   display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 6,
                   fontSize: 14, textDecoration: 'none',

--- a/frontend/src/nav.ts
+++ b/frontend/src/nav.ts
@@ -5,21 +5,23 @@
  * than silently shipping with no help. Kept in its own module (not App.tsx) so that
  * test can import it without pulling in the whole app/router tree. */
 
-export type Tab = { label: string; icon: string; route: string };
+/* `hint` is a one-line tooltip (rendered as the NavLink `title` in App.tsx) — a
+ * quick "what is this tab" on hover, distinct from the fuller TabTutorial card. */
+export type Tab = { label: string; icon: string; route: string; hint: string };
 
 export const NAV_ITEMS: Tab[] = [
-  { label: 'Chat', icon: '💬', route: '/chat' },
-  { label: 'Dashboard', icon: '📊', route: '/dashboard' },
-  { label: 'Logs', icon: '📜', route: '/logs' },
-  { label: 'Edit Workflows', icon: '🔀', route: '/edit-workflows' },
-  { label: 'Workflows', icon: '📝', route: '/workflow-actions' },
-  { label: 'Agents', icon: '🤝', route: '/agents' },
-  { label: 'Personas', icon: '🎭', route: '/personas' },
-  { label: 'Roles', icon: '🎬', route: '/roles' },
-  { label: 'Roundtable', icon: '⚖️', route: '/roundtable' },
-  { label: 'Projects', icon: '📁', route: '/projects' },
-  { label: 'Graph', icon: '🕸️', route: '/graph' },
-  { label: 'Pipeline', icon: '🧩', route: '/pipeline' },
-  { label: 'Editor', icon: '🖥️', route: '/editor' },
-  { label: 'Settings', icon: '⚙️', route: '/settings' },
+  { label: 'Chat', icon: '💬', route: '/chat', hint: 'Talk to Aimee for the active session — attach files, run slash-commands, turn a reply into a proposal.' },
+  { label: 'Dashboard', icon: '📊', route: '/dashboard', hint: 'Live instance health: readiness, LSP, per-agent success and tokens, latency, provider mix, traces.' },
+  { label: 'Logs', icon: '📜', route: '/logs', hint: 'The audit trail — every recorded action, newest first. Click a row for full detail.' },
+  { label: 'Edit Workflows', icon: '🔀', route: '/edit-workflows', hint: 'Design multi-step workflows — each step sets a task, persona, delegate, and role.' },
+  { label: 'Workflows', icon: '📝', route: '/workflow-actions', hint: 'The runtime queue — workflow items waiting on you to approve or reject.' },
+  { label: 'Agents', icon: '🤝', route: '/agents', hint: 'Your delegates, their run history and stats — bind each to a persona and allowed roles.' },
+  { label: 'Personas', icon: '🎭', route: '/personas', hint: 'Edit who Aimee can be — each persona is an identity plus the roles it may use.' },
+  { label: 'Roles', icon: '🎬', route: '/roles', hint: 'The shared role vocabulary — each role’s prompt template and per-role turn cap.' },
+  { label: 'Roundtable', icon: '⚖️', route: '/roundtable', hint: 'Configure the multi-model review panels — seats, aggregator, and loop knobs.' },
+  { label: 'Projects', icon: '📁', route: '/projects', hint: 'Connect the git repositories Aimee works on and store sealed per-host credentials.' },
+  { label: 'Graph', icon: '🕸️', route: '/graph', hint: 'Read-only explorer of the code-projection graph for the session’s project.' },
+  { label: 'Pipeline', icon: '🧩', route: '/pipeline', hint: 'The curator pipeline — toggle each stage’s enable flag by resource lane.' },
+  { label: 'Editor', icon: '🖥️', route: '/editor', hint: 'In-app VS Code bound to the session’s isolated worktree — the same tree the agent edits.' },
+  { label: 'Settings', icon: '⚙️', route: '/settings', hint: 'Every typed config option with plain-English help; restart-sensitive keys are badged.' },
 ];

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -163,15 +163,16 @@ export default function Agents() {
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
         <strong style={{ fontSize: 18 }}>Agents</strong>
         <Badge label={`${agents.length}`} variant="neutral" />
-        <button onClick={refresh} style={btn}>
+        <button onClick={refresh} style={btn} title="Reload the delegate list and run stats.">
           Refresh
         </button>
-        <button onClick={probeAll} style={btn} disabled={!agents.length}>
+        <button onClick={probeAll} style={btn} disabled={!agents.length} title="Test live reachability of every configured delegate.">
           Probe all
         </button>
         <button
           onClick={() => setShowAdd((v) => !v)}
           style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+          title="Show or hide the form for adding a new delegate."
         >
           {showAdd ? "Close" : "+ Add delegate"}
         </button>
@@ -325,6 +326,7 @@ function AgentCard({
             onClick={onProbe}
             style={{ ...btnSmall, marginTop: 6 }}
             disabled={pstate === "probing"}
+            title="Test whether this delegate is reachable right now."
           >
             {pstate === "probing" ? "probing…" : "Probe"}
           </button>
@@ -360,6 +362,7 @@ function AgentCard({
         <button
           onClick={onEdit}
           style={{ ...btnSmall, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+          title="Open the editor to change this delegate's config and role/persona bindings."
         >
           Edit
         </button>
@@ -506,14 +509,14 @@ function AgentEditModal({
         >
           <strong style={{ fontSize: 15 }}>Edit delegate</strong>
           <span style={{ fontSize: 13, color: "#667", fontFamily: "monospace" }}>{agent.name}</span>
-          <button onClick={onClose} style={{ ...btn, marginLeft: "auto" }}>
+          <button onClick={onClose} style={{ ...btn, marginLeft: "auto" }} title="Close the editor without saving.">
             Close
           </button>
         </div>
 
         <div style={{ padding: 16 }}>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10 }}>
-            <L label="provider">
+            <L label="provider" title="The backend provider used to run this delegate.">
               <select value={provider} onChange={(e) => setProvider(e.target.value)} style={inp} disabled={busy}>
                 {(PROVIDERS.includes(provider) ? PROVIDERS : [provider, ...PROVIDERS]).map((p) => (
                   <option key={p} value={p}>
@@ -522,10 +525,13 @@ function AgentEditModal({
                 ))}
               </select>
             </L>
-            <L label="model">
+            <L label="model" title="The model identifier this delegate calls.">
               <input value={model} onChange={(e) => setModel(e.target.value)} style={inp} disabled={busy} />
             </L>
-            <L label={cliProvider ? "endpoint (optional for CLI)" : "endpoint"}>
+            <L
+              label={cliProvider ? "endpoint (optional for CLI)" : "endpoint"}
+              title="API base URL for this delegate; optional for CLI providers."
+            >
               <input
                 value={endpoint}
                 onChange={(e) => setEndpoint(e.target.value)}
@@ -534,19 +540,19 @@ function AgentEditModal({
                 disabled={busy}
               />
             </L>
-            <L label="cost tier">
+            <L label="cost tier" title="Relative cost tier used when routing picks a delegate.">
               <input type="number" value={costTier} onChange={(e) => setCostTier(e.target.value)} style={inp} min={0} disabled={busy} />
             </L>
-            <L label="max turns (-1 = default)">
+            <L label="max turns (-1 = default)" title="Cap on turns per run for this delegate; -1 uses the default.">
               <input type="number" value={maxTurns} onChange={(e) => setMaxTurns(e.target.value)} style={inp} disabled={busy} />
             </L>
-            <L label="max parallel">
+            <L label="max parallel" title="Maximum number of concurrent runs of this delegate.">
               <input type="number" value={maxParallel} onChange={(e) => setMaxParallel(e.target.value)} style={inp} min={0} disabled={busy} />
             </L>
-            <L label="context window (tok, 0 = auto)">
+            <L label="context window (tok, 0 = auto)" title="Context window in tokens; 0 auto-detects.">
               <input type="number" value={contextWindow} onChange={(e) => setContextWindow(e.target.value)} style={inp} min={0} disabled={busy} />
             </L>
-            <L label="API key (blank = keep current)">
+            <L label="API key (blank = keep current)" title="Set an API key or $ENV_VAR reference; leave blank to keep the current key.">
               <input
                 type="password"
                 value={apiKey}
@@ -559,23 +565,36 @@ function AgentEditModal({
           </div>
 
           <div style={{ display: "flex", gap: 20, marginTop: 10 }}>
-            <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}>
+            <label
+              style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}
+              title="Whether this delegate is available for routing."
+            >
               <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} disabled={busy} />
               enabled
             </label>
-            <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}>
+            <label
+              style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}
+              title="Whether this delegate is allowed to use tools."
+            >
               <input type="checkbox" checked={tools} onChange={(e) => setTools(e.target.checked)} disabled={busy} />
               tools enabled
             </label>
           </div>
 
-          <ChipSelect label="roles" selected={roles} options={knownRoles} onChange={setRoles} />
+          <ChipSelect
+            label="roles"
+            selected={roles}
+            options={knownRoles}
+            onChange={setRoles}
+            hint="Toggle whether this delegate serves this role."
+          />
           <ChipSelect
             label="personas"
             selected={personas}
             options={knownPersonas}
             onChange={setPersonas}
             emptyHint="(none set = all)"
+            hint="Toggle whether this delegate is bound to this persona (none set = all)."
           />
 
           {err && <div style={{ fontSize: 12, color: "#c00", marginTop: 8 }}>{err}</div>}
@@ -585,16 +604,18 @@ function AgentEditModal({
               onClick={() => void save()}
               disabled={busy}
               style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+              title="Save all changes to this delegate."
             >
               {busy ? "Saving…" : "Save"}
             </button>
-            <button onClick={onClose} disabled={busy} style={btn}>
+            <button onClick={onClose} disabled={busy} style={btn} title="Discard changes and close the editor.">
               Cancel
             </button>
             <button
               onClick={() => void remove()}
               disabled={busy}
               style={{ ...btn, marginLeft: "auto", background: "#fff5f5", color: "#c00", borderColor: "#e6b3b3" }}
+              title="Remove this delegate, editing agents.json."
             >
               Remove delegate
             </button>
@@ -635,12 +656,14 @@ function ChipSelect({
   options,
   onChange,
   emptyHint,
+  hint,
 }: {
   label: string;
   selected: string[];
   options: string[];
   onChange: (v: string[]) => void;
   emptyHint?: string;
+  hint?: string;
 }) {
   const all = useMemo(() => {
     const s = new Set<string>(["all", ...options, ...selected]);
@@ -663,6 +686,7 @@ function ChipSelect({
             <button
               key={r}
               onClick={() => toggle(r)}
+              title={hint}
               style={{
                 ...btnSmall,
                 padding: "1px 7px",
@@ -727,9 +751,9 @@ function Field({ k, v, mono }: { k: string; v: string; mono?: boolean }) {
   );
 }
 
-function L({ label, children }: { label: string; children: React.ReactNode }) {
+function L({ label, title, children }: { label: string; title?: string; children: React.ReactNode }) {
   return (
-    <label style={{ display: "block", fontSize: 12 }}>
+    <label style={{ display: "block", fontSize: 12 }} title={title}>
       <span style={{ color: "#888", display: "block", marginBottom: 2 }}>{label}</span>
       {children}
     </label>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -3156,7 +3156,10 @@ export default function Chat() {
         {/* The project is set in ONE place — the session ProjectPicker at the top
             of the chat (bound to the active session). No per-prompt project
             selector here. */}
-        <span style={{ fontSize: '11px', color: tokens.textFaint, fontFamily: 'system-ui' }}>
+        <span
+          style={{ fontSize: '11px', color: tokens.textFaint, fontFamily: 'system-ui' }}
+          title="How much context Aimee assembles for this turn: Minimal is fastest and cheapest, Extended packs in the most background."
+        >
           Prompt:
         </span>
         <Tabs
@@ -3178,6 +3181,7 @@ export default function Chat() {
             <select
               value={activeSkill}
               onChange={e => changeSkill(e.target.value)}
+              title="Load a packaged skill for this session — its instructions steer how Aimee handles the turn. None runs the default behaviour."
               style={{
                 fontSize: '11px', fontFamily: 'system-ui',
                 background: activeSkill ? tokens.primary : tokens.surface,

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1005,7 +1005,8 @@ function CustomizePopover({ layout, setLayout, onClose }: {
           const p = PANELS.find(x => x.id === id)!;
           const on = enabled.has(id);
           return (
-            <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '3px 6px', borderRadius: 4 }}>
+            <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '3px 6px', borderRadius: 4 }}
+              title="Show or hide this panel on the dashboard.">
               <input type="checkbox" checked={on} onChange={() => toggle(id)} />
               <span style={{ flex: 1, fontSize: 13, color: on ? '#333' : '#999' }}>{p.title}</span>
               {on && (
@@ -1018,7 +1019,7 @@ function CustomizePopover({ layout, setLayout, onClose }: {
           );
         })}
         <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 6px 2px' }}>
-          <button onClick={() => setLayout(defaultLayout())} style={ctrlBtn}>Reset</button>
+          <button onClick={() => setLayout(defaultLayout())} style={ctrlBtn} title="Restore the default set and order of panels.">Reset</button>
           <button onClick={onClose} style={ctrlBtn}>Done</button>
         </div>
       </div>
@@ -1068,8 +1069,8 @@ export default function Dashboard() {
         display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0,
       }}>
         <span style={{ fontSize: 14, fontWeight: 600, color: '#555' }}>Dashboard</span>
-        <button onClick={load} style={ctrlBtn}>Refresh</button>
-        <button onClick={() => setCustomizing(v => !v)} style={{ ...ctrlBtn, marginLeft: 'auto' }}>⚙ Customize</button>
+        <button onClick={load} style={ctrlBtn} title="Reload all dashboard data from the server.">Refresh</button>
+        <button onClick={() => setCustomizing(v => !v)} style={{ ...ctrlBtn, marginLeft: 'auto' }} title="Choose which panels are shown and reorder them.">⚙ Customize</button>
         {loading && <span style={{ fontSize: 12, color: '#aaa' }}>Loading…</span>}
       </div>
 

--- a/frontend/src/pages/EditWorkflows.tsx
+++ b/frontend/src/pages/EditWorkflows.tsx
@@ -672,7 +672,7 @@ export default function EditWorkflows() {
         }}
       >
         <Panel title="Workflows" count={defs.length}>
-          <button onClick={newDef} style={btn}>
+          <button onClick={newDef} style={btn} title="Create a new workflow definition and open it in the editor.">
             + New
           </button>
           <div style={{ marginTop: 6 }}>
@@ -680,6 +680,7 @@ export default function EditWorkflows() {
               <div
                 key={d.name}
                 onClick={() => openDef(d.name)}
+                title="Open this workflow definition for editing."
                 style={{
                   ...row,
                   fontWeight: graph?.name === d.name ? 600 : 400,
@@ -695,7 +696,7 @@ export default function EditWorkflows() {
           </div>
         </Panel>
         <Panel title="Blocks" count={blocks.length}>
-          <button onClick={newBlock} style={btn}>
+          <button onClick={newBlock} style={btn} title="Create a new custom delegate block.">
             + New
           </button>
           <div style={{ marginTop: 6 }}>
@@ -732,7 +733,7 @@ export default function EditWorkflows() {
         {editBlock && (
           <Panel title={editBlock.isNew ? "New custom block" : `Edit block: ${editBlock.name}`}>
             <div style={{ display: "grid", gap: 6 }}>
-              <label style={lbl}>
+              <label style={lbl} title="Identifier for this custom block (letters, digits, - _ .); fixed once created.">
                 name
                 <input
                   style={{ ...inp, width: "100%" }}
@@ -741,7 +742,7 @@ export default function EditWorkflows() {
                   onChange={(e) => setEditBlock({ ...editBlock, name: e.target.value })}
                 />
               </label>
-              <label style={lbl}>
+              <label style={lbl} title="Artifact type this block takes as input.">
                 consumes
                 <select
                   style={{ ...inp, width: "100%" }}
@@ -755,7 +756,7 @@ export default function EditWorkflows() {
                   ))}
                 </select>
               </label>
-              <label style={lbl}>
+              <label style={lbl} title="Artifact type this block emits (branch, or none).">
                 produces
                 <select
                   style={{ ...inp, width: "100%" }}
@@ -766,7 +767,7 @@ export default function EditWorkflows() {
                   <option value="none">none</option>
                 </select>
               </label>
-              <label style={lbl}>
+              <label style={lbl} title="Persona the delegate runs as when this block executes.">
                 persona
                 <input
                   style={{ ...inp, width: "100%" }}
@@ -775,7 +776,7 @@ export default function EditWorkflows() {
                   onChange={(e) => setEditBlock({ ...editBlock, persona: e.target.value })}
                 />
               </label>
-              <label style={lbl}>
+              <label style={lbl} title="Instructions given to the delegate each time this block runs.">
                 prompt
                 <textarea
                   style={{ ...inp, width: "100%", minHeight: 80, fontFamily: "ui-monospace, monospace" }}
@@ -784,10 +785,14 @@ export default function EditWorkflows() {
                 />
               </label>
               <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-                <button onClick={saveBlock} style={btn}>
+                <button onClick={saveBlock} style={btn} title="Save this custom block definition.">
                   Save
                 </button>
-                <button onClick={deleteBlock} style={{ ...btn, color: "#b00" }}>
+                <button
+                  onClick={deleteBlock}
+                  style={{ ...btn, color: "#b00" }}
+                  title={editBlock.isNew ? "Discard this new block." : "Delete this custom block."}
+                >
                   {editBlock.isNew ? "Cancel" : "Delete"}
                 </button>
                 {blockStatus && <span style={{ fontSize: 12, color: "#b00" }}>{blockStatus}</span>}
@@ -814,13 +819,14 @@ export default function EditWorkflows() {
           {version && (
             <Badge label={`v ${version.slice(0, 8)}`} variant="neutral" />
           )}
-          <button onClick={validate} disabled={!graph} style={btn}>
+          <button onClick={validate} disabled={!graph} style={btn} title="Check the current workflow for errors without saving.">
             Validate
           </button>
           <button
             onClick={save}
             disabled={!graph}
             style={{ ...btn, background: "#2563eb", color: "#fff" }}
+            title="Save the workflow definition (fails if the on-disk version changed)."
           >
             Save
           </button>
@@ -1282,6 +1288,7 @@ function NodeInspector({
             list="wf-persona-opts"
             value={p.persona}
             placeholder="persona"
+            title="Persona this step's agent runs as."
             onChange={(e) => setPart(i, "persona", e.target.value)}
             style={{ ...inp, flex: 1, minWidth: 0 }}
           />
@@ -1289,6 +1296,7 @@ function NodeInspector({
             list="wf-delegate-opts"
             value={p.delegate}
             placeholder="delegate"
+            title="Delegate that carries out this step ($random picks one at run time)."
             onChange={(e) => setPart(i, "delegate", e.target.value)}
             style={{ ...inp, flex: 1, minWidth: 0 }}
           />
@@ -1301,10 +1309,10 @@ function NodeInspector({
       ))}
       {isMulti && (
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <button onClick={addPart} style={btnSmall}>
+          <button onClick={addPart} style={btnSmall} title="Add another persona/delegate to the review panel.">
             + participant
           </button>
-          <label style={{ ...lbl, margin: 0 }}>
+          <label style={{ ...lbl, margin: 0 }} title="How many panelists must pass; blank means all.">
             quorum&nbsp;
             <input
               type="number"
@@ -1405,6 +1413,7 @@ function NodeInspector({
           <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
             <select
               value={childWorkflowName(node)}
+              title="Workflow each fan-out packet runs."
               onChange={(e) => {
                 const v = e.target.value;
                 mutate((g) => ({
@@ -1447,21 +1456,24 @@ function NodeInspector({
           onClick={setStart}
           disabled={graph.start === node.id}
           style={btn}
+          title="Make this node the workflow's start node."
         >
           {graph.start === node.id ? "start node ✓" : "set as start"}
         </button>
       </div>
 
-      <label style={lbl}>Inputs</label>
+      <label style={lbl} title="Named outputs from other nodes fed into this step.">Inputs</label>
       {node.in.map((b, i) => (
         <div key={i} style={{ display: "flex", gap: 4, marginBottom: 4 }}>
           <input
             value={b.input}
+            title="Name this step refers to the input by."
             onChange={(e) => setBinding(i, "input", e.target.value)}
             style={{ ...inp, width: 60 }}
           />
           <select
             value={b.producer}
+            title="Which upstream node supplies this input."
             onChange={(e) => setBinding(i, "producer", e.target.value)}
             style={inp}
           >
@@ -1472,12 +1484,12 @@ function NodeInspector({
               </option>
             ))}
           </select>
-          <button onClick={() => delBinding(i)} style={btnSmall}>
+          <button onClick={() => delBinding(i)} style={btnSmall} title="Remove this input binding.">
             ×
           </button>
         </div>
       ))}
-      <button onClick={addBinding} style={btnSmall}>
+      <button onClick={addBinding} style={btnSmall} title="Add an input binding from another node's output.">
         + input
       </button>
 
@@ -1486,6 +1498,7 @@ function NodeInspector({
           <label style={lbl}>{edge}</label>
           <select
             value={node[edge] || ""}
+            title="Node to go to on this transition."
             onChange={(e) => setEdge(edge, e.target.value)}
             style={{ ...inp, width: "100%" }}
           >
@@ -1510,6 +1523,7 @@ function NodeInspector({
             }
           }}
           style={btnSmall}
+          title="Show/hide the raw params JSON editor."
         >
           {showAdv ? "▾ Advanced (raw params)" : "▸ Advanced (raw params)"}
         </button>
@@ -1540,6 +1554,7 @@ function NodeInspector({
       <button
         onClick={onDelete}
         style={{ ...btn, marginTop: 10, color: "#c00", borderColor: "#e0a0a0" }}
+        title="Remove this node from the workflow."
       >
         Delete node
       </button>

--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -79,7 +79,7 @@ export default function Graph() {
         <strong>Code graph — {project}</strong>
         {edgeCount != null && <Badge label={`${edgeCount} edges`} variant="neutral" />}
         {loading && <span style={{ color: '#888', fontSize: 12 }}>loading…</span>}
-        <button onClick={loadHubs} style={{ marginLeft: 'auto', ...btn }}>↻ refresh</button>
+        <button onClick={loadHubs} style={{ marginLeft: 'auto', ...btn }} title="Reload the ranked hub list for this project's code graph.">↻ refresh</button>
       </div>
       {err && <div style={{ color: '#b00', fontSize: 13 }}>{err}</div>}
 
@@ -115,8 +115,8 @@ export default function Graph() {
 
       <Panel title="Surprising links" count={links.length}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-          <button onClick={loadSurprising} style={btn}>find</button>
-          <label style={{ fontSize: 12, color: '#555' }}>
+          <button onClick={loadSurprising} style={btn} title="Find file pairs that are semantically close yet structurally far apart.">find</button>
+          <label style={{ fontSize: 12, color: '#555' }} title="Run an LLM to confirm or reject each surprising link (slower).">
             <input type="checkbox" checked={judge} onChange={e => setJudge(e.target.checked)} /> LLM confirm
           </label>
           <span style={{ fontSize: 11, color: '#999' }}>semantically close yet structurally far</span>

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -136,13 +136,13 @@ export default function Logs() {
             placeholder="filter tool…"
             style={{ ...selectStyle, width: 120 }}
           />
-          <select value={verdict} onChange={e => setVerdict(e.target.value)} style={selectStyle}>
+          <select value={verdict} onChange={e => setVerdict(e.target.value)} style={selectStyle} title="Filter rows to a single guardrail verdict.">
             {['all', 'allow', 'block', 'rewrite', 'approval_required'].map(v => <option key={v} value={v}>{v}</option>)}
           </select>
-          <select value={actor} onChange={e => setActor(e.target.value)} style={selectStyle}>
+          <select value={actor} onChange={e => setActor(e.target.value)} style={selectStyle} title="Filter rows by actor (primary agent or delegate).">
             {['all', 'primary', 'delegate'].map(a => <option key={a} value={a}>{a}</option>)}
           </select>
-          <button onClick={load} style={{ ...selectStyle, cursor: 'pointer' }}>Refresh</button>
+          <button onClick={load} style={{ ...selectStyle, cursor: 'pointer' }} title="Reload the newest page of audit rows.">Refresh</button>
           {loading && <span style={{ fontSize: 12, color: '#aaa' }}>Loading…</span>}
         </div>
       </div>

--- a/frontend/src/pages/Personas.tsx
+++ b/frontend/src/pages/Personas.tsx
@@ -185,14 +185,18 @@ export default function Personas() {
                 {p.builtin ? " ·" : ""}
               </button>
             ))}
-            <button onClick={newPersona} style={{ ...btn, borderStyle: "dashed" }}>
+            <button
+              onClick={newPersona}
+              style={{ ...btn, borderStyle: "dashed" }}
+              title="Create a new persona from scratch"
+            >
               + New
             </button>
           </div>
 
           {form && (
             <div style={{ display: "grid", gap: 8 }}>
-              <div>
+              <div title="The persona’s identifier (alphanumeric, - or _). Built-in personas can’t be renamed.">
                 <label style={lbl}>name</label>
                 <input
                   style={{ ...ta, fontFamily: "system-ui" }}
@@ -201,7 +205,7 @@ export default function Personas() {
                   onChange={(e) => upd({ name: e.target.value })}
                 />
               </div>
-              <div>
+              <div title="Short summary shown when picking this persona in Chat and the roundtable.">
                 <label style={lbl}>description</label>
                 <input
                   style={{ ...ta, fontFamily: "system-ui" }}
@@ -209,7 +213,7 @@ export default function Personas() {
                   onChange={(e) => upd({ description: e.target.value })}
                 />
               </div>
-              <div>
+              <div title="Which roles (routing keys) this persona may delegate to. “all” matches any role. Roles are edited on the Roles tab.">
                 <label style={lbl}>roles (routing key — click to toggle; edit roles on the Roles tab)</label>
                 <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
                   {roleOptions.map((r) => {
@@ -232,7 +236,7 @@ export default function Personas() {
                   })}
                 </div>
               </div>
-              <div>
+              <div title="How much delegates may do on this persona’s behalf: full = read + write tools, readonly = read-only tools, none = no delegates.">
                 <label style={lbl}>delegate policy</label>
                 <select
                   style={{ ...ta, fontFamily: "system-ui" }}
@@ -244,23 +248,27 @@ export default function Personas() {
                   <option value="none">none</option>
                 </select>
               </div>
-              <div>
+              <div title="The system prompt that defines this identity — injected at the top of the persona’s context.">
                 <label style={lbl}>persona (system prompt)</label>
                 <textarea rows={5} style={ta} value={form.persona || ""} onChange={(e) => upd({ persona: e.target.value })} />
               </div>
-              <div>
+              <div title="Engineering principles appended to the persona’s guidance for every turn.">
                 <label style={lbl}>principles</label>
                 <textarea rows={4} style={ta} value={form.principles || ""} onChange={(e) => upd({ principles: e.target.value })} />
               </div>
-              <div>
+              <div title="Short session hints added when a session starts under this persona.">
                 <label style={lbl}>brief (session hints)</label>
                 <textarea rows={3} style={ta} value={form.brief || ""} onChange={(e) => upd({ brief: e.target.value })} />
               </div>
               <div style={{ display: "flex", gap: 8 }}>
-                <button onClick={savePersona} style={btn}>
+                <button onClick={savePersona} style={btn} title="Write this persona to config.">
                   Save persona
                 </button>
-                <button onClick={deletePersona} style={{ ...btn, color: "#b00" }}>
+                <button
+                  onClick={deletePersona}
+                  style={{ ...btn, color: "#b00" }}
+                  title="Delete this persona. Built-ins reset to their default instead of disappearing."
+                >
                   Delete
                 </button>
                 {form.builtin && <Badge label="built-in" variant="neutral" />}

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -12,6 +12,16 @@ import { groupProjectsByOrg, parseOwnerOnly, repoAlreadyCloned, type CloneKbAnno
 
 const READ_OPS = ['status', 'log', 'diff', 'branch'] as const;
 const REMOTE_OPS = ['fetch', 'pull', 'push'] as const;
+// Hover help for each git op button.
+const OP_HELP: Record<string, string> = {
+  status: 'Show the working-tree status of this project.',
+  log: 'Show recent commit history.',
+  diff: 'Show uncommitted changes.',
+  branch: 'List branches.',
+  fetch: 'Fetch updates from the remote.',
+  pull: 'Pull and merge remote changes.',
+  push: 'Push local commits to the remote.',
+};
 
 async function api(path: string, init?: RequestInit): Promise<Response> {
   return fetch(path, {
@@ -337,7 +347,8 @@ export default function Projects() {
             <input style={{ ...input, flex: 1, minWidth: '120px' }} placeholder="name (optional)"
               value={name} onChange={e => setName(e.target.value)} />
             <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
-              disabled={busy || !url.trim()} onClick={connect}>
+              disabled={busy || !url.trim()} onClick={connect}
+              title="Clone the repository, or if you entered an owner/org URL, list its repositories to bulk-clone.">
               {parseOwnerOnly(url) ? 'List repositories' : 'Clone'}
             </button>
           </div>
@@ -354,9 +365,11 @@ export default function Projects() {
                   {orgProvider ? ` · ${orgProvider}` : ''}
                 </div>
                 <button style={{ ...btn, border: 'none', color: '#3a6ea5', padding: 0 }}
+                  title="Select every repository that is not already cloned."
                   onClick={() => setOrgSelected(Object.fromEntries(orgRepos.map(r =>
                     [r.name, !repoAlreadyCloned(r, orgRef.owner, projects, details)])))}>all</button>
                 <button style={{ ...btn, border: 'none', color: '#3a6ea5', padding: 0 }}
+                  title="Deselect all repositories."
                   onClick={() => setOrgSelected({})}>none</button>
               </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', maxHeight: '220px', overflow: 'auto',
@@ -377,6 +390,7 @@ export default function Projects() {
               <div>
                 <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
                   disabled={busy || orgRepos.filter(r => orgSelected[r.name]).length === 0}
+                  title="Clone the checked repositories as new projects."
                   onClick={cloneOrgSelected}>
                   Clone selected ({orgRepos.filter(r => orgSelected[r.name]).length})
                 </button>
@@ -412,7 +426,8 @@ export default function Projects() {
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
             <button style={{ ...btn, background: ghConfigured ? '#24292e' : '#888', color: '#fff', borderColor: '#24292e' }}
-              disabled={busy || !!ghCode || !ghConfigured} onClick={startGithub}>Sign in with GitHub</button>
+              disabled={busy || !!ghCode || !ghConfigured} onClick={startGithub}
+              title="Authorize aimee via GitHub device flow and store the token server-side.">Sign in with GitHub</button>
             {ghCode && (
               <span style={{ fontSize: '13px', color: '#444' }}>
                 Go to <a href={ghUri} target="_blank" rel="noreferrer">{ghUri}</a> and enter code{' '}
@@ -432,7 +447,8 @@ export default function Projects() {
               <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
                 <input style={{ ...input, flex: 1, minWidth: '200px' }} placeholder="GitHub OAuth App Client ID (e.g. Iv1.xxxxxxxx)"
                   value={ghClientId} onChange={e => setGhClientId(e.target.value)} />
-                <button style={btn} disabled={busy || !ghClientId.trim()} onClick={saveGhConfig}>Save</button>
+                <button style={btn} disabled={busy || !ghClientId.trim()} onClick={saveGhConfig}
+                  title="Save the GitHub OAuth App Client ID that enables device-flow sign-in.">Save</button>
               </div>
             </div>
           </details>
@@ -443,6 +459,7 @@ export default function Projects() {
                   <span style={{ fontSize: '13px', fontFamily: 'monospace', flex: 1 }}>{h}</span>
                   <span style={{ fontSize: '11px', color: '#2a7' }}>● token set</span>
                   <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy}
+                    title="Delete the stored access token for this git host."
                     onClick={() => removeCred(h)}>remove</button>
                 </div>
               ))}
@@ -454,7 +471,8 @@ export default function Projects() {
             <input style={{ ...input, flex: 2, minWidth: '200px' }} type="password" autoComplete="off"
               placeholder="access token" value={credToken} onChange={e => setCredToken(e.target.value)} />
             <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
-              disabled={busy || !credHost.trim() || !credToken.trim()} onClick={addCred}>Save</button>
+              disabled={busy || !credHost.trim() || !credToken.trim()} onClick={addCred}
+              title="Store this access token server-side for the given host.">Save</button>
           </div>
           <details style={{ marginTop: '10px', fontSize: '12px', color: '#aaa' }}>
             <summary style={{ cursor: 'pointer' }}>SSH private key (for git over SSH)</summary>
@@ -468,8 +486,10 @@ export default function Projects() {
                 value={credSSHKey} onChange={e => setCredSSHKey(e.target.value)} />
               <div style={{ display: 'flex', gap: '8px', marginTop: '6px', flexWrap: 'wrap' }}>
                 <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
-                  disabled={busy || !credSSHKey.trim()} onClick={addSSHKey}>Save SSH key</button>
+                  disabled={busy || !credSSHKey.trim()} onClick={addSSHKey}
+                  title="Seal this private key in the server vault for git-over-SSH.">Save SSH key</button>
                 <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy}
+                  title="Remove the stored SSH private key from the server vault."
                   onClick={removeSSHKey}>Clear SSH key</button>
               </div>
             </div>
@@ -492,6 +512,7 @@ export default function Projects() {
                     {g.refs.map(p => (
                       <span key={p} style={{ display: 'inline-flex' }}>
                         <button onClick={() => { setSelected(p); setOutput(''); setErr(''); }}
+                          title="Select this project to run git operations on it."
                           style={{ ...btn, background: p === selected ? '#234' : '#fff', color: p === selected ? '#8cf' : '#444',
                                    borderColor: p === selected ? '#456' : '#ccc', borderRadius: '4px 0 0 4px' }}>
                           {p}
@@ -521,13 +542,15 @@ export default function Projects() {
                   value={delTyped} onChange={e => setDelTyped(e.target.value)} />
                 {!delKbDown && (
                   <button style={{ ...btn, background: '#c33', color: '#fff', borderColor: '#a22' }}
-                    disabled={busy || delTyped !== delRef} onClick={() => deleteProject(false)}>Delete</button>
+                    disabled={busy || delTyped !== delRef} onClick={() => deleteProject(false)}
+                    title="Permanently delete the clone and all indexed knowledge for this project.">Delete</button>
                 )}
                 <button style={btn} disabled={busy} onClick={closeDelete}>Cancel</button>
               </div>
               {delKbDown && (
                 <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
                   <button style={btn} disabled={busy || delTyped !== delRef}
+                    title="Retry the delete now that the knowledge service may be back."
                     onClick={() => deleteProject(false)}>Retry</button>
                   <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy || delTyped !== delRef}
                     onClick={() => { if (delForceArmed) deleteProject(true); else setDelForceArmed(true); }}>
@@ -544,20 +567,22 @@ export default function Projects() {
             <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' }}>
                 {READ_OPS.map(op => (
-                  <button key={op} style={btn} disabled={busy} onClick={() => runOp(op)}>{op}</button>
+                  <button key={op} style={btn} disabled={busy} title={OP_HELP[op]} onClick={() => runOp(op)}>{op}</button>
                 ))}
                 {REMOTE_OPS.map(op => (
-                  <button key={op} style={{ ...btn, borderColor: '#a96' }} disabled={busy} onClick={() => runOp(op)}>{op}</button>
+                  <button key={op} style={{ ...btn, borderColor: '#a96' }} disabled={busy} title={OP_HELP[op]} onClick={() => runOp(op)}>{op}</button>
                 ))}
               </div>
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' }}>
                 <input style={{ ...input, flex: 1, minWidth: '180px' }} placeholder="commit message"
                   value={commitMsg} onChange={e => setCommitMsg(e.target.value)} />
                 <button style={btn} disabled={busy || !commitMsg.trim()}
+                  title="Commit staged changes with the entered message."
                   onClick={() => { runOp('commit', { message: commitMsg }); setCommitMsg(''); }}>commit</button>
                 <input style={{ ...input, width: '140px' }} placeholder="branch"
                   value={branch} onChange={e => setBranch(e.target.value)} />
                 <button style={btn} disabled={busy || !branch.trim()}
+                  title="Switch to (or create) the named branch."
                   onClick={() => runOp('checkout', { branch })}>checkout</button>
               </div>
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' }}>

--- a/frontend/src/pages/Roles.tsx
+++ b/frontend/src/pages/Roles.tsx
@@ -153,11 +153,12 @@ export default function Roles() {
                 key={r}
                 onClick={() => openRole(r)}
                 style={{ ...btn, background: roleSel === r ? "#e8eef9" : "#fff" }}
+                title="Open this role to edit its prompt template and turn cap."
               >
                 {r}
               </button>
             ))}
-            <button onClick={newRole} style={{ ...btn, borderStyle: "dashed" }}>
+            <button onClick={newRole} style={{ ...btn, borderStyle: "dashed" }} title="Create a new role, prompting for its name.">
               + New
             </button>
           </div>
@@ -182,10 +183,10 @@ export default function Roles() {
                 }}
               />
               <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-                <button onClick={saveRole} style={btn}>
+                <button onClick={saveRole} style={btn} title="Save this role's template and turn cap.">
                   Save role
                 </button>
-                <button onClick={deleteRole} style={{ ...btn, color: "#b00" }}>
+                <button onClick={deleteRole} style={{ ...btn, color: "#b00" }} title="Delete this role; built-in roles reset to their default.">
                   Delete
                 </button>
               </div>

--- a/frontend/src/pages/Roundtable.tsx
+++ b/frontend/src/pages/Roundtable.tsx
@@ -283,14 +283,14 @@ export default function Roundtable() {
                 {p.active ? " ★" : ""}
               </button>
             ))}
-            <button onClick={newPreset} style={{ ...btn, borderStyle: "dashed" }}>
+            <button onClick={newPreset} style={{ ...btn, borderStyle: "dashed" }} title="Create a new roundtable preset, prompting for its name.">
               + New
             </button>
           </div>
 
           {form && (
             <div>
-              <label style={lbl}>Description</label>
+              <label style={lbl} title="A short note describing what this panel is for.">Description</label>
               <input
                 style={input}
                 value={form.description}
@@ -315,6 +315,7 @@ export default function Roundtable() {
                     list={modelList}
                     style={{ ...input, flex: 1, ...(isRandom ? { color: "#0a58ca", fontStyle: "italic" } : {}) }}
                     placeholder="model / agent (e.g. codex)"
+                    title="Model or agent for this seat; type a value or pick a configured agent."
                     value={isRandom ? "Random — any review-capable" : seat.model}
                     readOnly={isRandom}
                     onChange={(e) => setSeat(i, { model: e.target.value })}
@@ -330,6 +331,7 @@ export default function Roundtable() {
                     list={personaList}
                     style={{ ...input, flex: 1 }}
                     placeholder="persona (blank = engine default)"
+                    title="Persona this seat reviews as; blank uses the engine default."
                     value={seat.persona}
                     onChange={(e) => setSeat(i, { persona: e.target.value })}
                   />
@@ -343,13 +345,13 @@ export default function Roundtable() {
                 </div>
                 );
               })}
-              <button onClick={addSeat} style={{ ...btn, borderStyle: "dashed", marginBottom: 8 }}>
+              <button onClick={addSeat} style={{ ...btn, borderStyle: "dashed", marginBottom: 8 }} title="Add another model/persona seat to the panel.">
                 + Add seat
               </button>
 
               {/* Aggregator + guards. */}
               <div style={{ display: "flex", flexWrap: "wrap", gap: 16, marginTop: 10 }}>
-                <div style={{ flex: "1 1 240px" }}>
+                <div style={{ flex: "1 1 240px" }} title="Model that synthesizes the panel's outputs; blank uses the engine default.">
                   <label style={lbl}>Aggregator (synthesis model)</label>
                   <input
                     list={modelList}
@@ -359,11 +361,11 @@ export default function Roundtable() {
                     placeholder="blank = engine default"
                   />
                 </div>
-                <div>
+                <div title="Minimum number of seats that must succeed for the round to count.">
                   <label style={lbl}>Min successful</label>
                   {numField(form.min_successful, (n) => patch({ min_successful: n }), 1)}
                 </div>
-                <div>
+                <div title="Per-round cost ceiling in USD; 0 means no limit.">
                   <label style={lbl}>Max cost (USD, 0 = none)</label>
                   {numField(form.max_cost_usd, (n) => patch({ max_cost_usd: n }))}
                 </div>
@@ -371,19 +373,19 @@ export default function Roundtable() {
 
               {/* Loop knobs. */}
               <div style={{ display: "flex", flexWrap: "wrap", gap: 16, marginTop: 10 }}>
-                <div>
+                <div title="Maximum number of review/revise rounds.">
                   <label style={lbl}>Max rounds</label>
                   {numField(form.max_rounds, (n) => patch({ max_rounds: n }))}
                 </div>
-                <div>
+                <div title="Agreement level required to stop looping early.">
                   <label style={lbl}>Converge threshold</label>
                   {numField(form.converge_threshold, (n) => patch({ converge_threshold: n }))}
                 </div>
-                <div>
+                <div title="Overall time budget for the roundtable in milliseconds.">
                   <label style={lbl}>Deadline (ms)</label>
                   {numField(form.deadline_ms, (n) => patch({ deadline_ms: n }))}
                 </div>
-                <div>
+                <div title="Whether seats run in parallel or one after another.">
                   <label style={lbl}>Turns</label>
                   <select
                     style={{ ...input, width: 140 }}
@@ -400,6 +402,7 @@ export default function Roundtable() {
               <button
                 onClick={() => setShowAdvanced((v) => !v)}
                 style={{ ...btn, marginTop: 12, background: "#f5f5f5" }}
+                title="Show or hide the authoring-pipeline settings."
               >
                 {showAdvanced ? "▾" : "▸"} Advanced — authoring pipeline
               </button>
@@ -410,7 +413,7 @@ export default function Roundtable() {
                     backstops). Leave at defaults unless you run authoring pipelines.
                   </p>
                   <div style={{ display: "flex", flexWrap: "wrap", gap: 16 }}>
-                    <div style={{ flex: "1 1 220px" }}>
+                    <div style={{ flex: "1 1 220px" }} title="Condition that marks an authoring pass complete.">
                       <label style={lbl}>Done bar</label>
                       <select
                         style={input}
@@ -424,35 +427,35 @@ export default function Roundtable() {
                         </option>
                       </select>
                     </div>
-                    <div>
+                    <div title="Maximum authoring passes; 0 means unlimited.">
                       <label style={lbl}>Max passes (0 = ∞)</label>
                       {numField(form.pipeline.max_passes, (n) => patchPipeline({ max_passes: n }))}
                     </div>
-                    <div>
+                    <div title="Maximum revise attempts within a single pass.">
                       <label style={lbl}>Attempts / pass</label>
                       {numField(form.pipeline.max_attempts_per_pass, (n) =>
                         patchPipeline({ max_attempts_per_pass: n }), 1)}
                     </div>
-                    <div>
+                    <div title="Cost ceiling for one authoring phase in USD.">
                       <label style={lbl}>Per-phase cost (USD)</label>
                       {numField(form.pipeline.max_cost_usd, (n) => patchPipeline({ max_cost_usd: n }))}
                     </div>
-                    <div>
+                    <div title="Cost ceiling for the whole authoring run in USD.">
                       <label style={lbl}>Total cost (USD)</label>
                       {numField(form.pipeline.max_total_cost_usd, (n) =>
                         patchPipeline({ max_total_cost_usd: n }))}
                     </div>
-                    <div>
+                    <div title="How long a review gate stays valid, in hours; 0 means none.">
                       <label style={lbl}>Gate TTL (h, 0 = none)</label>
                       {numField(form.pipeline.gate_ttl_h, (n) => patchPipeline({ gate_ttl_h: n }))}
                     </div>
-                    <div>
+                    <div title="Assumed token count when a document's context size is unknown.">
                       <label style={lbl}>Unknown ctx tokens</label>
                       {numField(form.pipeline.unknown_context_tokens, (n) =>
                         patchPipeline({ unknown_context_tokens: n }))}
                     </div>
                   </div>
-                  <label style={{ ...lbl, marginTop: 8 }}>
+                  <label style={{ ...lbl, marginTop: 8 }} title="When a gate is parked, free its active slot for other work.">
                     <input
                       type="checkbox"
                       checked={form.pipeline.parked_releases_slot}
@@ -464,13 +467,13 @@ export default function Roundtable() {
               )}
 
               <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
-                <button onClick={save} style={btn}>
+                <button onClick={save} style={btn} title="Save this preset's settings.">
                   Save preset
                 </button>
-                <button onClick={makeActive} style={{ ...btn, background: "#e8f7e8", fontWeight: 600 }}>
+                <button onClick={makeActive} style={{ ...btn, background: "#e8f7e8", fontWeight: 600 }} title="Save this preset and make it the active default roundtable.">
                   Save &amp; set as default
                 </button>
-                <button onClick={del} style={{ ...btn, color: "#b00" }}>
+                <button onClick={del} style={{ ...btn, color: "#b00" }} title="Delete this roundtable preset.">
                   Delete
                 </button>
               </div>

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -413,12 +413,13 @@ export default function WorkflowActions() {
         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
           <strong style={{ fontSize: 16 }}>Workflows</strong>
           <Badge label={`${items.length}`} variant="neutral" />
-          <button onClick={refreshList} style={btn}>
+          <button onClick={refreshList} style={btn} title="Reload the proposal list.">
             Refresh
           </button>
         </div>
         <button
           onClick={startNew}
+          title="Start composing a new proposal to submit."
           style={{
             ...btn,
             width: "100%",
@@ -430,7 +431,10 @@ export default function WorkflowActions() {
         >
           + New proposal
         </button>
-        <label style={{ fontSize: 12, color: "#666", display: "flex", alignItems: "center", gap: 6 }}>
+        <label
+          style={{ fontSize: 12, color: "#666", display: "flex", alignItems: "center", gap: 6 }}
+          title="Show every run across all users, not just your own."
+        >
           <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
           Show all (operator)
         </label>
@@ -449,6 +453,7 @@ export default function WorkflowActions() {
               <div
                 key={it.id}
                 onClick={() => openProposal(it.id)}
+                title="Open this run to see its status and history."
                 style={{
                   padding: "8px 8px",
                   borderRadius: 6,
@@ -506,12 +511,12 @@ export default function WorkflowActions() {
                 (below) rather than resume. */}
             <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", margin: "4px 0 10px" }}>
               {canResume && (
-                <button onClick={() => void doLifecycle("resume")} disabled={acting} style={btn}>
+                <button onClick={() => void doLifecycle("resume")} disabled={acting} style={btn} title="Resume this paused run.">
                   ▶ Start
                 </button>
               )}
               {canPause && (
-                <button onClick={() => void doLifecycle("pause")} disabled={acting} style={btn}>
+                <button onClick={() => void doLifecycle("pause")} disabled={acting} style={btn} title="Pause this active run.">
                   ⏸ Pause
                 </button>
               )}
@@ -520,6 +525,7 @@ export default function WorkflowActions() {
                   onClick={() => void doLifecycle("stop")}
                   disabled={acting}
                   style={{ ...btn, background: "#fbeaea", color: "#a33", borderColor: "#e0a0a0" }}
+                  title="Abandon this run; it cannot be resumed."
                 >
                   ⏹ Stop
                 </button>
@@ -528,6 +534,7 @@ export default function WorkflowActions() {
                 onClick={() => void doLifecycle("delete")}
                 disabled={acting}
                 style={{ ...btn, background: "#fff5f5", color: "#c00", borderColor: "#e6b3b3", marginLeft: "auto" }}
+                title="Permanently delete this run, its history, and proposal file."
               >
                 🗑 Delete
               </button>
@@ -537,12 +544,13 @@ export default function WorkflowActions() {
             {canDecide && (
               <Panel title={`Human gate · ${detail.stage}`}>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                  <button onClick={() => void decideGate("approve")} style={btn}>
+                  <button onClick={() => void decideGate("approve")} style={btn} title="Approve this gate and resume the run.">
                     Approve
                   </button>
                   <button
                     onClick={() => void decideGate("reject")}
                     style={{ ...btn, background: "#fbeaea", color: "#a33", borderColor: "#e0a0a0" }}
+                    title="Reject at this gate."
                   >
                     Reject
                   </button>
@@ -710,6 +718,7 @@ function Composer({
             onChange={(e) => update({ workflow: e.target.value })}
             style={inp}
             disabled={busy}
+            title="Workflow to run this proposal through end-to-end."
           >
             {workflows.map((w) => (
               <option key={w} value={w}>
@@ -756,10 +765,11 @@ function Composer({
                 setPreview(null);
               }}
               style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+              title="Replace the proposal body with this generated draft."
             >
               Use this draft
             </button>
-            <button onClick={() => setPreview(null)} style={btn}>
+            <button onClick={() => setPreview(null)} style={btn} title="Discard this draft preview and keep your current body.">
               Discard
             </button>
             <span style={{ fontSize: 11, color: "#888" }}>Replaces the body above.</span>
@@ -776,13 +786,24 @@ function Composer({
           onClick={onSubmit}
           disabled={busy}
           style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
+          title="Submit the proposal and start the selected workflow."
         >
           {submitting ? "Submitting…" : `Submit → run "${draft.workflow || "build"}"`}
         </button>
-        <button onClick={() => void generate()} disabled={busy} style={btn}>
+        <button
+          onClick={() => void generate()}
+          disabled={busy}
+          style={btn}
+          title="Generate a proposal draft from your title and notes (shown as a preview to accept)."
+        >
           {drafting ? "Drafting…" : "✨ Draft with a delegate"}
         </button>
-        <button onClick={() => (browsing ? setBrowsing(false) : openBrowser())} disabled={busy} style={btn}>
+        <button
+          onClick={() => (browsing ? setBrowsing(false) : openBrowser())}
+          disabled={busy}
+          style={btn}
+          title="Browse the project checkout and load a .md file as the proposal."
+        >
           {browsing ? "Close browser" : "📂 Load from project"}
         </button>
         {submitMsg && <span style={{ fontSize: 12, color: "#c00" }}>{submitMsg}</span>}


### PR DESCRIPTION
## What

Adds hover tooltips (native `title=`) to interactive controls across the web GUI, so hovering any button, select, input, or toggle explains what it does. Requested with particular interest in **personas**.

## Coverage

| Area | Added |
| --- | --- |
| Left nav | One-line `hint` per tab (new field on the nav registry, rendered as the `NavLink` title) |
| Personas | Help on every persona form field (name, description, roles, delegate policy, system prompt, principles, brief) and action buttons |
| Chat | Prompt-tier and Skill selectors (Persona already had one) |
| Roles | Role list + Save/Delete |
| Agents | Toolbar, card Probe/Edit, full delegate editor (via a `title` prop on the `L` label helper), role/persona chips (via a `hint` prop on `ChipSelect`) |
| Roundtable | New/Description, seats, aggregator + guards, loop knobs, authoring-pipeline fields |
| Edit Workflows | Workflow/block lists, block editor, Validate/Save toolbar, node inspector (persona/delegate, quorum, bindings, edges, advanced, delete) |
| Workflows | Refresh/New, lifecycle (Start/Pause/Stop/Delete), human gate (Approve/Reject), composer actions |
| Projects | Git ops (status/log/diff/branch/fetch/pull/push), account management, project select, delete flow |
| Graph, Logs, Dashboard | Refresh/filters/customize controls |

Pipeline and Editor already had full coverage — unchanged.

## Convention

Follows the existing codebase: native `title=` attributes (there is no tooltip component). For helper-rendered fields the `title` is attached to the label/wrapping element or threaded through a small optional prop. Text inputs that already carry descriptive `placeholder`s were generally left as-is.

## Verification

- `tsc --noEmit` clean
- `vitest run` — 93/93 pass (incl. the nav/tutorial coverage test that imports the changed nav registry)
- `vite build` succeeds