### PR TITLE
feat(delegate): build the sandbox image from a project spec (from+packages / dockerfile)

### DIFF
--- a/src/headers/delegate_sandbox_image.h
+++ b/src/headers/delegate_sandbox_image.h
@@ -18,4 +18,19 @@
  * phase. */
 int delegate_sandbox_resolve_image(const char *cwd, char *out, size_t cap);
 
+/* --- exposed for unit tests (pure helpers, no docker) --- */
+
+/* Generate the RUN-layer Dockerfile for a `from` + `packages` spec into out[cap]:
+ *   FROM <base>
+ *   RUN apt-get update && apt-get install -y --no-install-recommends <pkgs> && ...
+ * Each package name must match [A-Za-z0-9][A-Za-z0-9._+:-]* (no shell metacharacters
+ * reach the build RUN). Returns 0 on success, -1 on an invalid package, empty base,
+ * or truncation. */
+int delegate_sandbox_dockerfile_from_packages(const char *base, const char *const *pkgs, int npkgs,
+                                              char *out, size_t cap);
+
+/* Deterministic content-addressed image tag `aimee-sbx:<12-hex>` for `content`
+ * (the Dockerfile text). Same content -> same tag, so a built image is reused. */
+void delegate_sandbox_content_tag(const char *content, char *tag, size_t cap);
+
 #endif /* DEC_DELEGATE_SANDBOX_IMAGE_H */

--- a/src/server/delegate_sandbox_image.c
+++ b/src/server/delegate_sandbox_image.c
@@ -4,37 +4,286 @@
  * image at build time. That toolchain is per-project (a Rust repo needs cargo, a C
  * repo gcc/make, a docs repo nothing), so the image is resolved per delegate from,
  * most specific first: the repo's .aimee/project.yaml, a per-workspace override, or
- * the global default. This phase resolves the pre-baked `image:` form only. */
+ * the global default.
+ *
+ * A repo's .aimee/project.yaml `sandbox` block takes one of three forms:
+ *   sandbox: { image: <ref> }                     - a pre-baked image, used as-is
+ *   sandbox: { from: <base>, packages: [a, b] }   - aimee builds a derived image
+ *   sandbox: { dockerfile: <path> }               - aimee builds that Dockerfile
+ * A build runs `docker build` with network (aimee-server drives the host daemon),
+ * tags the result by content hash, and reuses it on later turns; the delegate then
+ * RUNS that image `--network none`. The per-workspace/global forms are `image:` only. */
 
 #include "delegate_sandbox_image.h"
 
 #include "aimee.h" /* MAX_PATH_LEN */
 #include "cJSON.h"
 #include "config.h"
-#include "guardrails.h" /* git_repo_root */
-#include "util.h"       /* safe_strdup */
-#include "yaml.h"       /* yaml_parse */
+#include "guardrails.h"            /* git_repo_root */
+#include "harness_memory_common.h" /* hmem_sha256_hex, HMEM_HASH_HEX_LEN */
+#include "util.h"                  /* safe_strdup, safe_exec_capture_* */
+#include "yaml.h"                  /* yaml_parse */
 
+#include <ctype.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
-/* Largest .aimee/project.yaml we will read (1 MiB); a contract file is tiny. */
-#define PROJECT_YAML_MAX (1u << 20)
+#define PROJECT_YAML_MAX        (1u << 20) /* 1 MiB; a contract file is tiny */
+#define SBX_TAG_MAX             64
+#define DOCKERFILE_MAX          8192
+#define DOCKER_BUILD_TIMEOUT_MS (10 * 60 * 1000) /* apt installs can be slow */
 
-/* Read <git-root-of-cwd>/.aimee/project.yaml and return a malloc'd copy of its
- * `sandbox.image` string, or NULL when absent/unreadable/without the field. */
-static char *project_yaml_sandbox_image(const char *cwd)
+typedef struct
 {
-   char root[MAX_PATH_LEN];
-   if (git_repo_root(cwd, root, sizeof(root)) != 0)
-      return NULL;
+   char image[256];               /* pre-baked: use as-is */
+   char from[128];                /* build: base image */
+   char dockerfile[MAX_PATH_LEN]; /* build: path to a Dockerfile (repo-relative or abs) */
+   char *packages_df;             /* build: generated Dockerfile text (from+packages); owned */
+} sandbox_spec_t;
+
+static void sandbox_spec_free(sandbox_spec_t *s)
+{
+   if (s)
+   {
+      free(s->packages_df);
+      s->packages_df = NULL;
+   }
+}
+
+static const char *resolve_docker_bin(void)
+{
+   const char *o = getenv("AIMEE_DOCKER_BIN");
+   return (o && o[0]) ? o : "docker";
+}
+
+/* --- pure helpers (also unit-tested) --- */
+
+static int package_name_valid(const char *pkg)
+{
+   if (!pkg || !pkg[0])
+      return 0;
+   if (!(isalnum((unsigned char)pkg[0])))
+      return 0;
+   for (const char *c = pkg; *c; c++)
+   {
+      if (!(isalnum((unsigned char)*c) || *c == '.' || *c == '_' || *c == '+' || *c == ':' ||
+            *c == '-'))
+         return 0;
+   }
+   return 1;
+}
+
+int delegate_sandbox_dockerfile_from_packages(const char *base, const char *const *pkgs, int npkgs,
+                                              char *out, size_t cap)
+{
+   if (!out || cap == 0)
+      return -1;
+   out[0] = '\0';
+   if (!base || !base[0])
+      return -1;
+   /* Base image ref may contain '/' and ':' (registry/repo:tag) — allow those too. */
+   for (const char *c = base; *c; c++)
+   {
+      if (!(isalnum((unsigned char)*c) || *c == '.' || *c == '_' || *c == '+' || *c == ':' ||
+            *c == '-' || *c == '/'))
+         return -1;
+   }
+
+   char pkglist[4096];
+   size_t pos = 0;
+   for (int i = 0; i < npkgs; i++)
+   {
+      if (!package_name_valid(pkgs[i]))
+         return -1;
+      int n = snprintf(pkglist + pos, sizeof(pkglist) - pos, "%s%s", pos ? " " : "", pkgs[i]);
+      if (n < 0 || (size_t)n >= sizeof(pkglist) - pos)
+         return -1;
+      pos += (size_t)n;
+   }
+
+   int n;
+   if (npkgs > 0)
+      n = snprintf(out, cap,
+                   "FROM %s\n"
+                   "RUN apt-get update && apt-get install -y --no-install-recommends %s && "
+                   "rm -rf /var/lib/apt/lists/*\n",
+                   base, pkglist);
+   else
+      n = snprintf(out, cap, "FROM %s\n", base);
+   return (n > 0 && (size_t)n < cap) ? 0 : -1;
+}
+
+void delegate_sandbox_content_tag(const char *content, char *tag, size_t cap)
+{
+   char hex[HMEM_HASH_HEX_LEN];
+   hmem_sha256_hex(content ? content : "", content ? strlen(content) : 0, hex);
+   hex[12] = '\0';
+   snprintf(tag, cap, "aimee-sbx:%s", hex);
+}
+
+/* --- docker ops (impure) --- */
+
+static int docker_image_exists(const char *tag)
+{
+   const char *argv[] = {resolve_docker_bin(), "image", "inspect", tag, NULL};
+   char *out = NULL;
+   int rc = safe_exec_capture(argv, &out, 256);
+   free(out);
+   return rc == 0;
+}
+
+/* Build `dockerfile_text` into image `tag` with an empty context. Returns 0 on
+ * success. Network is available at build time (the delegate RUN is where it is
+ * removed). Serialised by the caller's lock so two turns don't race the same tag. */
+static int docker_build(const char *tag, const char *dockerfile_text)
+{
+   char ctx[] = "/tmp/aimee-sbx-build-XXXXXX";
+   if (!mkdtemp(ctx))
+      return -1;
+   char dfpath[MAX_PATH_LEN];
+   snprintf(dfpath, sizeof(dfpath), "%s/Dockerfile", ctx);
+   FILE *fp = fopen(dfpath, "w");
+   int rc = -1;
+   if (fp)
+   {
+      if (fputs(dockerfile_text, fp) >= 0 && fclose(fp) == 0)
+      {
+         const char *argv[] = {resolve_docker_bin(), "build", "-t", tag, "-f", dfpath, ctx, NULL};
+         char *out = NULL;
+         rc = safe_exec_capture_cwd_env_timeout(argv, NULL, NULL, &out, 65536,
+                                                DOCKER_BUILD_TIMEOUT_MS);
+         free(out);
+      }
+      fp = NULL;
+   }
+   unlink(dfpath);
+   rmdir(ctx);
+   return rc;
+}
+
+static pthread_mutex_t g_build_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/* Ensure the build spec's image exists (build once, cached), writing its tag to
+ * out[cap]. Returns 0 on success, -1 on failure. */
+static int ensure_built(const char *dockerfile_text, char *out, size_t cap)
+{
+   char tag[SBX_TAG_MAX];
+   delegate_sandbox_content_tag(dockerfile_text, tag, sizeof(tag));
+
+   pthread_mutex_lock(&g_build_lock);
+   int ok = docker_image_exists(tag) || docker_build(tag, dockerfile_text) == 0;
+   pthread_mutex_unlock(&g_build_lock);
+   if (!ok)
+      return -1;
+   snprintf(out, cap, "%s", tag);
+   return 0;
+}
+
+/* --- project.yaml spec parsing --- */
+
+/* Read a repo's .aimee/project.yaml `sandbox` block into `out`. Returns 0 if a
+ * usable block was found, -1 otherwise. On a from+packages spec the generated
+ * Dockerfile is stored in out->packages_df (caller frees via sandbox_spec_free). */
+static int project_yaml_sandbox_spec(const char *cwd, char *repo_root, size_t root_cap,
+                                     sandbox_spec_t *out)
+{
+   memset(out, 0, sizeof(*out));
+   if (git_repo_root(cwd, repo_root, root_cap) != 0)
+      return -1;
 
    char path[MAX_PATH_LEN];
-   if (snprintf(path, sizeof(path), "%s/.aimee/project.yaml", root) >= (int)sizeof(path))
-      return NULL;
-
+   if (snprintf(path, sizeof(path), "%s/.aimee/project.yaml", repo_root) >= (int)sizeof(path))
+      return -1;
    FILE *fp = fopen(path, "r");
+   if (!fp)
+      return -1;
+   if (fseek(fp, 0, SEEK_END) != 0)
+   {
+      fclose(fp);
+      return -1;
+   }
+   long n = ftell(fp);
+   if (n <= 0 || n > (long)PROJECT_YAML_MAX || fseek(fp, 0, SEEK_SET) != 0)
+   {
+      fclose(fp);
+      return -1;
+   }
+   char *buf = malloc((size_t)n + 1);
+   if (!buf)
+   {
+      fclose(fp);
+      return -1;
+   }
+   size_t rd = fread(buf, 1, (size_t)n, fp);
+   fclose(fp);
+   buf[rd] = '\0';
+
+   cJSON *doc = yaml_parse(buf);
+   free(buf);
+   if (!doc)
+      return -1;
+
+   int found = -1;
+   cJSON *sb = cJSON_GetObjectItemCaseSensitive(doc, "sandbox");
+   if (cJSON_IsObject(sb))
+   {
+      cJSON *image = cJSON_GetObjectItemCaseSensitive(sb, "image");
+      cJSON *from = cJSON_GetObjectItemCaseSensitive(sb, "from");
+      cJSON *packages = cJSON_GetObjectItemCaseSensitive(sb, "packages");
+      cJSON *dockerfile = cJSON_GetObjectItemCaseSensitive(sb, "dockerfile");
+
+      if (cJSON_IsString(image) && image->valuestring[0])
+      {
+         snprintf(out->image, sizeof(out->image), "%s", image->valuestring);
+         found = 0;
+      }
+      else if (cJSON_IsString(from) && from->valuestring[0])
+      {
+         /* Collect package names into an argv for the pure Dockerfile generator. */
+         int cnt = cJSON_IsArray(packages) ? cJSON_GetArraySize(packages) : 0;
+         const char **argv = cnt > 0 ? calloc((size_t)cnt, sizeof(char *)) : NULL;
+         int argc = 0;
+         if (cnt > 0 && argv)
+         {
+            cJSON *p;
+            cJSON_ArrayForEach(p, packages)
+            {
+               if (cJSON_IsString(p) && p->valuestring[0])
+                  argv[argc++] = p->valuestring;
+            }
+         }
+         char df[DOCKERFILE_MAX];
+         if (delegate_sandbox_dockerfile_from_packages(from->valuestring, argv, argc, df,
+                                                       sizeof(df)) == 0)
+         {
+            out->packages_df = safe_strdup(df);
+            snprintf(out->from, sizeof(out->from), "%s", from->valuestring);
+            found = out->packages_df ? 0 : -1;
+         }
+         free(argv);
+      }
+      else if (cJSON_IsString(dockerfile) && dockerfile->valuestring[0])
+      {
+         snprintf(out->dockerfile, sizeof(out->dockerfile), "%s", dockerfile->valuestring);
+         found = 0;
+      }
+   }
+   cJSON_Delete(doc);
+   return found;
+}
+
+/* Read a Dockerfile (path may be repo-relative) into a malloc'd string, or NULL. */
+static char *read_dockerfile(const char *repo_root, const char *df_path)
+{
+   char full[MAX_PATH_LEN];
+   if (df_path[0] == '/')
+      snprintf(full, sizeof(full), "%s", df_path);
+   else
+      snprintf(full, sizeof(full), "%s/%s", repo_root, df_path);
+   FILE *fp = fopen(full, "r");
    if (!fp)
       return NULL;
    if (fseek(fp, 0, SEEK_END) != 0)
@@ -43,7 +292,7 @@ static char *project_yaml_sandbox_image(const char *cwd)
       return NULL;
    }
    long n = ftell(fp);
-   if (n <= 0 || n > (long)PROJECT_YAML_MAX || fseek(fp, 0, SEEK_SET) != 0)
+   if (n <= 0 || n > (long)DOCKERFILE_MAX || fseek(fp, 0, SEEK_SET) != 0)
    {
       fclose(fp);
       return NULL;
@@ -57,22 +306,7 @@ static char *project_yaml_sandbox_image(const char *cwd)
    size_t rd = fread(buf, 1, (size_t)n, fp);
    fclose(fp);
    buf[rd] = '\0';
-
-   cJSON *doc = yaml_parse(buf);
-   free(buf);
-   if (!doc)
-      return NULL;
-
-   char *image = NULL;
-   cJSON *sandbox = cJSON_GetObjectItemCaseSensitive(doc, "sandbox");
-   if (cJSON_IsObject(sandbox))
-   {
-      cJSON *img = cJSON_GetObjectItemCaseSensitive(sandbox, "image");
-      if (cJSON_IsString(img) && img->valuestring[0])
-         image = safe_strdup(img->valuestring);
-   }
-   cJSON_Delete(doc);
-   return image;
+   return buf;
 }
 
 /* True when `cwd` is `ws` itself or a path beneath it. */
@@ -90,20 +324,45 @@ int delegate_sandbox_resolve_image(const char *cwd, char *out, size_t cap)
    if (!cwd || !cwd[0])
       return -1;
 
-   /* 1. Repo contract: <git-root>/.aimee/project.yaml `sandbox.image`. */
-   char *proj = project_yaml_sandbox_image(cwd);
-   if (proj)
+   /* 1. Repo contract: <git-root>/.aimee/project.yaml `sandbox` (image | build). */
    {
-      snprintf(out, cap, "%s", proj);
-      free(proj);
-      return 0;
+      char repo_root[MAX_PATH_LEN];
+      sandbox_spec_t spec;
+      if (project_yaml_sandbox_spec(cwd, repo_root, sizeof(repo_root), &spec) == 0)
+      {
+         int rc = -1;
+         if (spec.image[0])
+         {
+            snprintf(out, cap, "%s", spec.image);
+            rc = 0;
+         }
+         else if (spec.packages_df)
+         {
+            rc = ensure_built(spec.packages_df, out, cap);
+         }
+         else if (spec.dockerfile[0])
+         {
+            char *df = read_dockerfile(repo_root, spec.dockerfile);
+            if (df)
+            {
+               rc = ensure_built(df, out, cap);
+               free(df);
+            }
+         }
+         sandbox_spec_free(&spec);
+         if (rc == 0)
+            return 0;
+         /* A declared-but-unbuildable spec falls through to the lower scopes rather
+          * than silently dropping the delegate to the default image with no signal;
+          * the build failure is surfaced by docker's own logs. */
+      }
    }
 
    config_t cfg;
    if (config_load(&cfg) != 0)
       return -1;
 
-   /* 2. Per-workspace override — the most specific (longest) matching root wins. */
+   /* 2. Per-workspace override (image ref only) — longest matching root wins. */
    int best = -1;
    size_t best_len = 0;
    for (int i = 0; i < cfg.workspace_count; i++)
@@ -126,7 +385,7 @@ int delegate_sandbox_resolve_image(const char *cwd, char *out, size_t cap)
       return 0;
    }
 
-   /* 3. Global default. */
+   /* 3. Global default (image ref only). */
    if (cfg.delegate_sandbox_image[0])
    {
       snprintf(out, cap, "%s", cfg.delegate_sandbox_image);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1058,7 +1058,8 @@ $(TESTPREFIX)/unit-test-config: $(OBJDIR)/tests/test_config.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-delegate-sandbox-image: $(OBJDIR)/tests/test_delegate_sandbox_image.o \
-                      $(OBJDIR)/server/delegate_sandbox_image.o $(OBJDIR)/guardrails_tdd.o $(TEST_CORE_OBJS)
+                      $(OBJDIR)/server/delegate_sandbox_image.o $(OBJDIR)/guardrails_tdd.o \
+                      $(OBJDIR)/harness_memory_common.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-roundtable-preset: $(OBJDIR)/tests/test_roundtable_preset.o $(OBJDIR)/roundtable_preset.o $(TEST_CORE_OBJS)
@@ -1383,7 +1384,7 @@ $(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(
                                $(OBJDIR)/aimee_home.o \
                                $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                $(OBJDIR)/platform_random.o $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o $(OBJDIR)/server/presence.o $(OBJDIR)/server/turn_registry.o $(OBJDIR)/tests/support/agent_cancel_stub.o $(OBJDIR)/delivery_target.o \
-                               $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/server/delegate_sandbox_image.o $(OBJDIR)/server/workspace_provider_container.o $(OBJDIR)/server/delegate_backend.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/server/workspace_provider_detached.o \
+                               $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/server/delegate_sandbox_image.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/server/workspace_provider_container.o $(OBJDIR)/server/delegate_backend.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/server/workspace_provider_detached.o \
                                $(OBJDIR)/server/workspace_runner_registry.o $(OBJDIR)/server/workspace_runner_queue.o \
                                $(OBJDIR)/workspace_mirror.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o \
                                $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/json_fluent.o

--- a/src/tests/test_delegate_sandbox_image.c
+++ b/src/tests/test_delegate_sandbox_image.c
@@ -96,6 +96,42 @@ int main(void)
       assert(out[0] == '\0');
    }
 
+   /* --- pure: Dockerfile generation from from+packages --- */
+   {
+      char df[4096];
+      const char *pkgs[] = {"gcc", "make", "libssl-dev"};
+      assert(delegate_sandbox_dockerfile_from_packages("ubuntu:22.04", pkgs, 3, df, sizeof(df)) ==
+             0);
+      assert(strstr(df, "FROM ubuntu:22.04\n") == df);
+      assert(strstr(df, "apt-get install -y --no-install-recommends gcc make libssl-dev") != NULL);
+
+      /* zero packages -> just FROM */
+      assert(delegate_sandbox_dockerfile_from_packages("alpine:3", NULL, 0, df, sizeof(df)) == 0);
+      assert(strcmp(df, "FROM alpine:3\n") == 0);
+
+      /* injection-y package name is rejected (no shell metacharacters reach RUN) */
+      const char *bad[] = {"gcc; rm -rf /"};
+      assert(delegate_sandbox_dockerfile_from_packages("ubuntu:22.04", bad, 1, df, sizeof(df)) ==
+             -1);
+      const char *bad2[] = {"$(whoami)"};
+      assert(delegate_sandbox_dockerfile_from_packages("ubuntu:22.04", bad2, 1, df, sizeof(df)) ==
+             -1);
+      /* empty base rejected */
+      assert(delegate_sandbox_dockerfile_from_packages("", pkgs, 1, df, sizeof(df)) == -1);
+   }
+
+   /* --- pure: content tag is deterministic + well-formed --- */
+   {
+      char t1[64], t2[64], t3[64];
+      delegate_sandbox_content_tag("FROM ubuntu:22.04\n", t1, sizeof(t1));
+      delegate_sandbox_content_tag("FROM ubuntu:22.04\n", t2, sizeof(t2));
+      delegate_sandbox_content_tag("FROM alpine:3\n", t3, sizeof(t3));
+      assert(strcmp(t1, t2) == 0); /* same content -> same tag (reuse) */
+      assert(strcmp(t1, t3) != 0); /* different content -> different tag */
+      assert(strncmp(t1, "aimee-sbx:", 10) == 0);
+      assert(strlen(t1) == 10 + 12); /* prefix + 12 hex */
+   }
+
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Phase 3 of the delegate sandbox-image arc
Builds on per-project image resolution (#1411). A repo's `.aimee/project.yaml` `sandbox` block may now, besides a pre-baked `image:`, **declare a build**:

```yaml
sandbox: { from: ubuntu:22.04, packages: [gcc, make] }   # aimee generates a Dockerfile
sandbox: { dockerfile: .aimee/sandbox.Dockerfile }        # aimee builds that file
```

aimee runs `docker build` (network is available at **build** time — aimee-server drives the host daemon), tags the result by **content hash** (`aimee-sbx:<12-hex>`), and reuses it on later turns via `docker image inspect`; the delegate then **RUNS** that image `--network none`. Builds are serialised by an in-process lock so two turns don't race the same tag. A build spec that can't be built falls through to the workspace/global image scopes rather than silently dropping to the default (the docker build logs surface the failure).

## Safety
Package names are validated against `[A-Za-z0-9][A-Za-z0-9._+:-]*`, so no shell metacharacter reaches the generated `apt-get install` RUN layer (e.g. `gcc; rm -rf /` and `$(whoami)` are rejected). The build runs in an empty context with only the generated/declared Dockerfile.

## Test
Pure helpers are exposed and unit-tested (no docker needed): `delegate_sandbox_dockerfile_from_packages` (correct FROM/RUN, injection rejection, empty-base rejection, zero-packages → bare FROM) and `delegate_sandbox_content_tag` (deterministic, `aimee-sbx:` + 12 hex, distinct content → distinct tag). Existing resolver tests (image resolution + round-trip) still pass. The docker build/inspect path is for hardware validation.

## Next
Phase 4 (network-none **package proxy + cache**) and Phase 5 (**learned toolchain**) per `docs/proposals/pending/delegate-sandbox-image-customization.md`.