### PR TITLE
SSH-key clone for private repos + wizard auth-method picker

### DIFF
--- a/docs/WEBCHAT_GIT_SECURITY.md
+++ b/docs/WEBCHAT_GIT_SECURITY.md
@@ -71,8 +71,17 @@ environment:
 - **SSH keys** are loaded into a per-user **in-memory `ssh-agent`** (`memfd`,
   `RLIMIT_CORE=0`, `DUMPABLE=0`, key buffer zeroed after load); git uses it via
   `SSH_AUTH_SOCK`. The agent socket lives under a **tmpfs-mandatory**,
-  fail-closed per-principal runtime dir (`webuser_runtime.c`); nothing touches
-  `~/.ssh`.
+  fail-closed per-principal runtime dir (`webuser_runtime.c`). The private key
+  **never touches disk** — only the agent's memory holds it. Because the server
+  has no seeded `known_hosts`, every SSH git op also forces
+  `GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new"`:
+  `BatchMode` keeps it non-interactive (no TTY, no password prompts), and
+  `accept-new` is **trust-on-first-use** — on first contact with a new host
+  (e.g. `bitbucket.org`) SSH appends the remote's **public** host key to
+  `~/.ssh/known_hosts` and verifies it strictly thereafter, so a first-time
+  connection that would otherwise die on "Host key verification failed"
+  succeeds. (`git://` remotes stay anonymous and are unaffected; only real SSH
+  transports — `ssh://…` or scp-like `git@host:owner/repo.git` — use the agent.)
 
 ## Cross-tenant isolation
 

--- a/docs/WEBCHAT_GIT_SECURITY.md
+++ b/docs/WEBCHAT_GIT_SECURITY.md
@@ -71,17 +71,22 @@ environment:
 - **SSH keys** are loaded into a per-user **in-memory `ssh-agent`** (`memfd`,
   `RLIMIT_CORE=0`, `DUMPABLE=0`, key buffer zeroed after load); git uses it via
   `SSH_AUTH_SOCK`. The agent socket lives under a **tmpfs-mandatory**,
-  fail-closed per-principal runtime dir (`webuser_runtime.c`). The private key
-  **never touches disk** — only the agent's memory holds it. Because the server
-  has no seeded `known_hosts`, every SSH git op also forces
-  `GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new"`:
+  fail-closed per-principal runtime dir (`webuser_runtime.c`). The **decrypted
+  private key never touches disk** — only the agent's memory holds it (the
+  sealed vault persists only the *encrypted* key). Because the server has no
+  seeded `known_hosts`, every SSH git op also forces
+  `GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=<runtime-dir>/known_hosts"`:
   `BatchMode` keeps it non-interactive (no TTY, no password prompts), and
   `accept-new` is **trust-on-first-use** — on first contact with a new host
-  (e.g. `bitbucket.org`) SSH appends the remote's **public** host key to
-  `~/.ssh/known_hosts` and verifies it strictly thereafter, so a first-time
-  connection that would otherwise die on "Host key verification failed"
-  succeeds. (`git://` remotes stay anonymous and are unaffected; only real SSH
-  transports — `ssh://…` or scp-like `git@host:owner/repo.git` — use the agent.)
+  (e.g. `bitbucket.org`) SSH appends the remote's **public** host key and
+  verifies it strictly thereafter, so a first-time connection that would
+  otherwise die on "Host key verification failed" succeeds. `UserKnownHostsFile`
+  pins that TOFU state to the **per-principal** tmpfs runtime dir (beside the
+  agent socket), never the OS account's shared `~/.ssh/known_hosts`, so one
+  principal's first-use trust cannot bleed to another. It is **tmpfs-backed and
+  therefore per-server-lifetime**: TOFU re-establishes after a restart. (`git://`
+  remotes stay anonymous and are unaffected; only real SSH transports — `ssh://…`
+  or scp-like `git@host:owner/repo.git` — use the agent.)
 
 ## Cross-tenant isolation
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -171,9 +171,10 @@ credentials live in the server's **sealed vault**; see
   `ssh://…` or `git@host:owner/repo.git` URL (e.g. a corporate Bitbucket) now
   actually uses that key, instead of being silently rewritten to HTTPS. git runs
   with `GIT_SSH_COMMAND` forcing `BatchMode=yes, ConnectTimeout=5,
-  StrictHostKeyChecking=accept-new`: trust-on-first-use appends the remote's
-  **public** host key to `~/.ssh/known_hosts` on first contact (and verifies it
-  strictly thereafter); the private key still never leaves the in-memory
+  StrictHostKeyChecking=accept-new`: trust-on-first-use records the remote's
+  **public** host key on first contact (and verifies it strictly thereafter) in
+  a **per-principal** `known_hosts` under the sealed tmpfs runtime dir, not the
+  shared `~/.ssh/known_hosts`; the private key still never leaves the in-memory
   ssh-agent. The setup wizard's Connection step now picks **one** auth method
   (OAuth sign-in / access token / SSH key) and shows only that method's fields,
   and the Projects page's duplicated inline auth UI is replaced with a single

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -166,6 +166,18 @@ credentials live in the server's **sealed vault**; see
   authenticates server-side as a primary provider or delegate, with no
   per-session push from the client. A legacy plaintext token is migrated and
   scrubbed on first use.
+- **SSH-key clones for private / SSH-only repos, plus a single wizard for git
+  account setup**: when you connect a git account with an SSH key, cloning an
+  `ssh://…` or `git@host:owner/repo.git` URL (e.g. a corporate Bitbucket) now
+  actually uses that key, instead of being silently rewritten to HTTPS. git runs
+  with `GIT_SSH_COMMAND` forcing `BatchMode=yes, ConnectTimeout=5,
+  StrictHostKeyChecking=accept-new`: trust-on-first-use appends the remote's
+  **public** host key to `~/.ssh/known_hosts` on first contact (and verifies it
+  strictly thereafter); the private key still never leaves the in-memory
+  ssh-agent. The setup wizard's Connection step now picks **one** auth method
+  (OAuth sign-in / access token / SSH key) and shows only that method's fields,
+  and the Projects page's duplicated inline auth UI is replaced with a single
+  **+ Connect git account** button that opens the same wizard flow in a modal.
 - **Workspaces ingested from the client**: `aimee workspace add <path>` resolves
   the path locally, registers it as `detached`, and pushes the files to the
   server (`POST /v1/index/ingest`, chunked under aimee-kb's body cap), the

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -116,6 +116,14 @@ export default function Projects() {
 
   useEffect(() => { loadProjects(); loadHosts(); }, [loadProjects, loadHosts]);
 
+  // Close the Connect-account modal on Escape (works regardless of focus).
+  useEffect(() => {
+    if (!connectOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setConnectOpen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [connectOpen]);
+
   async function removeCred(host: string) {
     setBusy(true); setErr('');
     try {
@@ -482,7 +490,7 @@ export default function Projects() {
       {/* Connect a git account: the shared wizard auth flow, one click away. */}
       {connectOpen && (
         <div style={modalBackdrop} onClick={() => setConnectOpen(false)}>
-          <div style={modalCard} role="dialog" aria-label="Connect git account" onClick={e => e.stopPropagation()}>
+          <div style={modalCard} role="dialog" aria-modal="true" aria-label="Connect git account" onClick={e => e.stopPropagation()}>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '10px' }}>
               <strong style={{ fontSize: '17px' }}>Connect a git account</strong>
               <button aria-label="Close" title="Close" onClick={() => setConnectOpen(false)}

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Panel } from '@rakuensoftware/smoothgui';
+import ConnectHosts from '../setup/ConnectHosts';
 import { useSessions } from '../SessionContext';
 import { groupProjectsByOrg, parseOwnerOnly, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type OwnerRef, type ProjectDetail, type ProjectDeleteResponse } from '../setup/ownerUrl';
 
-/* Git projects (webchat-git WP-F2). Lists the user's cloned repos, connects a
- * new one, and runs per-project git ops — all via /api/git/* (the server forwards
- * to /v1/workspace/* with the user's webuser: identity; creds live only in the
- * sealed vault). The connect field also accepts an owner/org URL (e.g.
- * github.com/RakuenSoftware): it then enumerates the owner's repositories and
- * bulk-clones the selected ones, mirroring the wizard's Workspaces step. */
+/* Git projects (webchat-git WP-F2). The page is focused on managing repos: it
+ * lists the user's cloned projects, connects new ones, and runs per-project git
+ * ops — all via /api/git/* (the server forwards to /v1/workspace/* with the
+ * user's webuser: identity; creds live only in the sealed vault). The connect
+ * field also accepts an owner/org URL (e.g. github.com/RakuenSoftware): it then
+ * enumerates the owner's repositories and bulk-clones the selected ones,
+ * mirroring the wizard's Workspaces step.
+ *
+ * Connecting a git ACCOUNT (OAuth / token / SSH key) is a one-click launch of
+ * the shared wizard flow (ConnectHosts) in a modal — the same UI as onboarding,
+ * so there is a single source of truth for host auth rather than a duplicate. */
 
 const READ_OPS = ['status', 'log', 'diff', 'branch'] as const;
 const REMOTE_OPS = ['fetch', 'pull', 'push'] as const;
@@ -41,6 +47,15 @@ const btn: React.CSSProperties = {
 const input: React.CSSProperties = {
   padding: '6px 8px', borderRadius: '4px', border: '1px solid #ccc', fontSize: '13px',
 };
+const modalBackdrop: React.CSSProperties = {
+  position: 'fixed', inset: 0, zIndex: 1000, background: 'rgba(10,10,18,0.55)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '16px',
+};
+const modalCard: React.CSSProperties = {
+  width: 'min(560px, 100%)', maxHeight: '86vh', overflow: 'auto', background: '#fff',
+  borderRadius: '12px', border: '1px solid #dde', boxShadow: '0 12px 40px rgba(0,0,0,0.3)',
+  padding: '20px 22px', fontFamily: 'system-ui', color: '#233',
+};
 
 export default function Projects() {
   const { active } = useSessions();
@@ -57,13 +72,8 @@ export default function Projects() {
   const [prTitle, setPrTitle] = useState('');
   const [branch, setBranch] = useState('');
   const [hosts, setHosts] = useState<string[]>([]);
-  const [credHost, setCredHost] = useState('');
-  const [credToken, setCredToken] = useState('');
-  const [credSSHKey, setCredSSHKey] = useState('');
-  const [ghCode, setGhCode] = useState('');
-  const [ghUri, setGhUri] = useState('');
-  const [ghConfigured, setGhConfigured] = useState(false);
-  const [ghClientId, setGhClientId] = useState('');
+  // The "Connect git account" modal — runs the shared wizard auth flow.
+  const [connectOpen, setConnectOpen] = useState(false);
   // Owner/org bulk-clone (URL parsed as an owner with no repo segment).
   const [orgRef, setOrgRef] = useState<OwnerRef | null>(null);
   const [orgRepos, setOrgRepos] = useState<{ name: string; clone_url: string; private?: boolean }[]>([]);
@@ -80,27 +90,6 @@ export default function Projects() {
   const [delKbDown, setDelKbDown] = useState(false);
   const [delForceArmed, setDelForceArmed] = useState(false);
   const [notice, setNotice] = useState('');
-
-  const loadGhConfig = useCallback(async () => {
-    try {
-      const r = await api('/api/git/oauth/github/config', { method: 'GET' });
-      const d = await r.json();
-      if (r.ok) { setGhConfigured(!!d.configured); setGhClientId(d.client_id || ''); }
-    } catch { /* leave unconfigured */ }
-  }, []);
-
-  async function saveGhConfig() {
-    if (!ghClientId.trim()) return;
-    setBusy(true); setErr('');
-    try {
-      const r = await api('/api/git/oauth/github/config', {
-        method: 'POST', body: JSON.stringify({ client_id: ghClientId.trim() }),
-      });
-      const d = await r.json();
-      if (!r.ok) setErr(d.error || 'could not save client ID');
-      else await loadGhConfig();
-    } finally { setBusy(false); }
-  }
 
   const loadHosts = useCallback(async () => {
     try {
@@ -125,73 +114,7 @@ export default function Projects() {
     }
   }, []);
 
-  useEffect(() => { loadProjects(); loadHosts(); loadGhConfig(); }, [loadProjects, loadHosts, loadGhConfig]);
-
-  // GitHub device-flow: once a user code is shown, poll until the user authorizes.
-  useEffect(() => {
-    if (!ghCode) return;
-    let alive = true;
-    const id = setInterval(async () => {
-      try {
-        const r = await api('/api/git/oauth/github/poll', { method: 'POST' });
-        const d = await r.json();
-        if (!alive) return;
-        if (d.status === 'done') { setGhCode(''); setGhUri(''); await loadHosts(); }
-        else if (d.status === 'error') { setGhCode(''); setGhUri(''); setErr(d.error || 'GitHub sign-in failed'); }
-      } catch { /* transient; keep polling */ }
-    }, 5000);
-    return () => { alive = false; clearInterval(id); };
-  }, [ghCode, loadHosts]);
-
-  async function startGithub() {
-    setErr('');
-    try {
-      const r = await api('/api/git/oauth/github/start', { method: 'POST' });
-      const d = await r.json();
-      if (!r.ok) { setErr(d.error || 'GitHub sign-in unavailable'); return; }
-      setGhCode(d.user_code || ''); setGhUri(d.verification_uri || 'https://github.com/login/device');
-    } catch { setErr('aimee-server unavailable'); }
-  }
-
-  async function addCred() {
-    if (!credHost.trim() || !credToken.trim()) return;
-    setBusy(true); setErr('');
-    try {
-      const r = await api('/api/git/credentials', {
-        method: 'POST',
-        body: JSON.stringify({ host: credHost.trim(), token: credToken.trim() }),
-      });
-      const d = await r.json();
-      if (!r.ok) { setErr(d.error || 'could not save credential'); }
-      else { setCredHost(''); setCredToken(''); await loadHosts(); }
-    } finally { setBusy(false); }
-  }
-
-  async function addSSHKey() {
-    if (!credSSHKey.trim()) return;
-    setBusy(true); setErr('');
-    try {
-      const r = await api('/api/git/sshkey', {
-        method: 'POST',
-        body: JSON.stringify({ ssh_key: credSSHKey }),
-      });
-      const d = await r.json().catch(() => ({}));
-      // Always drop the key from component state once it has left the browser —
-      // never leave private-key material sitting in React state / the textarea.
-      setCredSSHKey('');
-      if (!r.ok) { setErr(d.error || 'could not save SSH key'); }
-      else { setErr('SSH key saved'); }
-    } finally { setBusy(false); }
-  }
-
-  async function removeSSHKey() {
-    setBusy(true); setErr('');
-    try {
-      const r = await api('/api/git/sshkey', { method: 'DELETE' });
-      if (!r.ok) { const d = await r.json().catch(() => ({})); setErr(d.error || 'could not clear SSH key'); }
-      else { setCredSSHKey(''); setErr('SSH key cleared'); }
-    } finally { setBusy(false); }
-  }
+  useEffect(() => { loadProjects(); loadHosts(); }, [loadProjects, loadHosts]);
 
   async function removeCred(host: string) {
     setBusy(true); setErr('');
@@ -421,37 +344,14 @@ export default function Projects() {
 
       <Panel title="Git accounts" count={hosts.length}>
         <div style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
-          <div style={{ color: '#888', fontSize: '12px' }}>
-            Access tokens aimee-server uses to reach each git host (one per host, any provider). Tokens are stored server-side and never shown again.
-          </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
-            <button style={{ ...btn, background: ghConfigured ? '#24292e' : '#888', color: '#fff', borderColor: '#24292e' }}
-              disabled={busy || !!ghCode || !ghConfigured} onClick={startGithub}
-              title="Authorize aimee via GitHub device flow and store the token server-side.">Sign in with GitHub</button>
-            {ghCode && (
-              <span style={{ fontSize: '13px', color: '#444' }}>
-                Go to <a href={ghUri} target="_blank" rel="noreferrer">{ghUri}</a> and enter code{' '}
-                <code style={{ background: '#eee', padding: '2px 6px', borderRadius: '4px', fontWeight: 600 }}>{ghCode}</code>
-                <span style={{ color: '#888' }}> — waiting…</span>
-              </span>
-            )}
+            <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
+              title="Connect a git account (OAuth, access token, or SSH key) via the setup wizard."
+              onClick={() => setConnectOpen(true)}>+ Connect git account</button>
+            <span style={{ color: '#888', fontSize: '12px' }}>
+              OAuth sign-in, an access token, or an SSH key — stored server-side, never shown again.
+            </span>
           </div>
-          <details style={{ fontSize: '12px', color: '#666' }} open={!ghConfigured}>
-            <summary style={{ cursor: 'pointer' }}>
-              GitHub OAuth App {ghConfigured ? '(configured ✓ — click to change)' : '— set this to enable the button'}
-            </summary>
-            <div style={{ marginTop: '6px' }}>
-              <div style={{ marginBottom: '4px' }}>
-                Create a GitHub OAuth App (<a href="https://github.com/settings/developers" target="_blank" rel="noreferrer">github.com/settings/developers</a> → New OAuth App → enable <b>Device flow</b>), then paste its <b>Client ID</b> here:
-              </div>
-              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                <input style={{ ...input, flex: 1, minWidth: '200px' }} placeholder="GitHub OAuth App Client ID (e.g. Iv1.xxxxxxxx)"
-                  value={ghClientId} onChange={e => setGhClientId(e.target.value)} />
-                <button style={btn} disabled={busy || !ghClientId.trim()} onClick={saveGhConfig}
-                  title="Save the GitHub OAuth App Client ID that enables device-flow sign-in.">Save</button>
-              </div>
-            </div>
-          </details>
           {hosts.length > 0 && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
               {hosts.map(h => (
@@ -465,35 +365,6 @@ export default function Projects() {
               ))}
             </div>
           )}
-          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-            <input style={{ ...input, flex: 1, minWidth: '160px' }} placeholder="host (e.g. github.com, gitea.you.com)"
-              value={credHost} onChange={e => setCredHost(e.target.value)} />
-            <input style={{ ...input, flex: 2, minWidth: '200px' }} type="password" autoComplete="off"
-              placeholder="access token" value={credToken} onChange={e => setCredToken(e.target.value)} />
-            <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
-              disabled={busy || !credHost.trim() || !credToken.trim()} onClick={addCred}
-              title="Store this access token server-side for the given host.">Save</button>
-          </div>
-          <details style={{ marginTop: '10px', fontSize: '12px', color: '#aaa' }}>
-            <summary style={{ cursor: 'pointer' }}>SSH private key (for git over SSH)</summary>
-            <div style={{ marginTop: '6px' }}>
-              <div style={{ marginBottom: '6px' }}>
-                Paste an <b>unencrypted</b> OpenSSH/PEM private key (no passphrase). It is sealed
-                server-side in your encrypted vault and never shown again — no vault unlock needed.
-              </div>
-              <textarea style={{ ...input, width: '100%', minHeight: '110px', fontFamily: 'monospace' }}
-                placeholder={'-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----'}
-                value={credSSHKey} onChange={e => setCredSSHKey(e.target.value)} />
-              <div style={{ display: 'flex', gap: '8px', marginTop: '6px', flexWrap: 'wrap' }}>
-                <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
-                  disabled={busy || !credSSHKey.trim()} onClick={addSSHKey}
-                  title="Seal this private key in the server vault for git-over-SSH.">Save SSH key</button>
-                <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy}
-                  title="Remove the stored SSH private key from the server vault."
-                  onClick={removeSSHKey}>Clear SSH key</button>
-              </div>
-            </div>
-          </details>
         </div>
       </Panel>
 
@@ -607,6 +478,24 @@ export default function Projects() {
           {busy && <div style={{ color: '#888', fontSize: '12px' }}>working…</div>}
         </div>
       </Panel>
+
+      {/* Connect a git account: the shared wizard auth flow, one click away. */}
+      {connectOpen && (
+        <div style={modalBackdrop} onClick={() => setConnectOpen(false)}>
+          <div style={modalCard} role="dialog" aria-label="Connect git account" onClick={e => e.stopPropagation()}>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '10px' }}>
+              <strong style={{ fontSize: '17px' }}>Connect a git account</strong>
+              <button aria-label="Close" title="Close" onClick={() => setConnectOpen(false)}
+                style={{ background: 'none', border: 'none', color: '#9aa', cursor: 'pointer', fontSize: '20px', lineHeight: 1 }}>×</button>
+            </div>
+            <ConnectHosts
+              doneLabel="Done"
+              onDone={() => setConnectOpen(false)}
+              onHostsChanged={() => { loadHosts(); }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/setup/ConnectHosts.tsx
+++ b/frontend/src/setup/ConnectHosts.tsx
@@ -2,19 +2,31 @@ import { useCallback, useEffect, useState } from 'react';
 
 /* Wizard — Connection (git hosts). Authenticate aimee-server to the git hosts it
  * will clone from, so the next step (Workspaces & projects) can enumerate + clone
- * private repos. Three ways in, all via the /api/git/* routes (which forward to
- * aimee-server's sealed vault — tokens/keys are write-only, never read back):
+ * private repos. The user first PICKS one auth method, then sees only that
+ * method's fields (avoids the "which of these three do I fill in?" confusion).
+ * All three go via the /api/git/* routes (which forward to aimee-server's sealed
+ * vault — tokens/keys are write-only, never read back):
  *
  *  • OAuth device flow — GitHub, GitLab, or Gitea/Forgejo (needs an OAuth App
  *    client ID for the chosen provider/host; the client ID is public).
- *  • Per-host access token — any host/provider (incl. Bitbucket).
- *  • SSH private key — for git over SSH.
+ *  • Per-host access token — any host/provider (incl. Bitbucket over HTTPS).
+ *  • SSH private key — for git over SSH (the only way in for a host that offers
+ *    SSH-key access only; add the repo by its SSH URL, git@host:owner/repo.git).
  *
  * Optional step: public repos clone without any of this. GitHub uses its dedicated
  * /api/git/oauth/github/* routes; GitLab/Gitea use the generic
  * /api/git/oauth/device/* routes with a {provider, host} selector. */
 
 type OAuthProvider = 'github' | 'gitlab' | 'gitea';
+
+// Which credential the user is setting up. They pick one; only its fields show.
+type AuthMethod = 'oauth' | 'token' | 'ssh';
+
+const METHODS: { id: AuthMethod; label: string; hint: string }[] = [
+  { id: 'oauth', label: 'OAuth sign-in', hint: 'Sign in to GitHub, GitLab, or Gitea/Forgejo.' },
+  { id: 'token', label: 'Access token', hint: 'An HTTPS access token for any host (incl. Bitbucket).' },
+  { id: 'ssh', label: 'SSH key', hint: 'A private key for git over SSH (git@host:owner/repo.git).' },
+];
 
 interface ProviderMeta {
   label: string;
@@ -103,6 +115,9 @@ export default function ConnectHosts({ onDone, onHostsChanged }: ConnectHostsPro
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
   const [msg, setMsg] = useState('');
+
+  // The auth method the user has chosen; only this method's fields are shown.
+  const [authMethod, setAuthMethod] = useState<AuthMethod>('oauth');
 
   const [credHost, setCredHost] = useState('');
   const [credToken, setCredToken] = useState('');
@@ -370,7 +385,24 @@ export default function ConnectHosts({ onDone, onHostsChanged }: ConnectHostsPro
         and never shown again.
       </div>
 
+      {/* Auth-method picker: choose one, then only its fields are shown. */}
+      <div style={{ display: 'grid', gap: 6 }}>
+        <div role="tablist" aria-label="Authentication method" style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {METHODS.map((m) => (
+            <button key={m.id} role="tab" aria-selected={authMethod === m.id}
+              style={authMethod === m.id ? methodTabActive : methodTab}
+              onClick={() => { setAuthMethod(m.id); setErr(''); setMsg(''); setPending(null); }}>
+              {m.label}
+            </button>
+          ))}
+        </div>
+        <div style={{ fontSize: 11.5, color: '#778' }}>
+          {METHODS.find((m) => m.id === authMethod)?.hint}
+        </div>
+      </div>
+
       {/* OAuth device flow */}
+      {authMethod === 'oauth' && (
       <section style={{ display: 'grid', gap: 8 }}>
         <div style={sectionTitle}>Sign in with OAuth</div>
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
@@ -426,8 +458,10 @@ export default function ConnectHosts({ onDone, onHostsChanged }: ConnectHostsPro
           </div>
         </details>
       </section>
+      )}
 
       {/* Per-host access token */}
+      {authMethod === 'token' && (
       <section style={{ display: 'grid', gap: 8 }}>
         <div style={sectionTitle}>Access token</div>
         <div style={{ fontSize: 11.5, color: '#778' }}>
@@ -453,23 +487,25 @@ export default function ConnectHosts({ onDone, onHostsChanged }: ConnectHostsPro
           </div>
         )}
       </section>
+      )}
 
       {/* SSH key */}
-      <details style={{ fontSize: 12, color: '#666' }}>
-        <summary style={{ cursor: 'pointer' }}>SSH private key (for git over SSH)</summary>
-        <div style={{ marginTop: 6 }}>
-          <div style={{ marginBottom: 6 }}>
-            Paste an <b>unencrypted</b> OpenSSH/PEM private key (no passphrase). It is sealed
-            server-side in your encrypted vault and never shown again.
-          </div>
-          <textarea style={{ ...input, width: '100%', minHeight: 100, fontFamily: 'monospace' }}
-            placeholder={'-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----'}
-            value={sshKey} onChange={(e) => setSshKey(e.target.value)} />
-          <div style={{ marginTop: 6 }}>
-            <button style={ghostBtn} disabled={busy || !sshKey.trim()} onClick={addSSHKey}>Save SSH key</button>
-          </div>
+      {authMethod === 'ssh' && (
+      <section style={{ display: 'grid', gap: 8 }}>
+        <div style={sectionTitle}>SSH private key</div>
+        <div style={{ fontSize: 11.5, color: '#778' }}>
+          Paste an <b>unencrypted</b> OpenSSH/PEM private key (no passphrase). It is sealed
+          server-side in your encrypted vault and never shown again. Add the repo by its{' '}
+          <b>SSH URL</b> (<code>git@host:owner/repo.git</code>) so this key is used.
         </div>
-      </details>
+        <textarea style={{ ...input, width: '100%', minHeight: 100, fontFamily: 'monospace' }}
+          placeholder={'-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----'}
+          value={sshKey} onChange={(e) => setSshKey(e.target.value)} />
+        <div>
+          <button style={ghostBtn} disabled={busy || !sshKey.trim()} onClick={addSSHKey}>Save SSH key</button>
+        </div>
+      </section>
+      )}
 
       {err && <div style={{ fontSize: 12.5, color: '#c62828' }}>{err}</div>}
       {msg && <div style={{ fontSize: 12.5, color: '#2c8f56' }}>{msg}</div>}
@@ -495,4 +531,11 @@ const primaryBtn: React.CSSProperties = {
 const ghostBtn: React.CSSProperties = {
   padding: '6px 12px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',
   color: '#446', cursor: 'pointer', fontSize: 13,
+};
+const methodTab: React.CSSProperties = {
+  padding: '6px 14px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',
+  color: '#446', cursor: 'pointer', fontSize: 13, fontWeight: 600,
+};
+const methodTabActive: React.CSSProperties = {
+  ...methodTab, background: '#2c8f56', borderColor: '#2c6', color: '#fff',
 };

--- a/frontend/src/setup/ConnectHosts.tsx
+++ b/frontend/src/setup/ConnectHosts.tsx
@@ -380,6 +380,21 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
     }
   }
 
+  async function removeSSHKey() {
+    setBusy(true);
+    setErr('');
+    setMsg('');
+    try {
+      const r = await api('/api/git/sshkey', { method: 'DELETE' });
+      const d = await r.json().catch(() => ({}));
+      setSshKey('');
+      if (!r.ok) setErr(d.error || 'could not clear SSH key');
+      else setMsg('SSH key cleared.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <div style={{ display: 'grid', gap: 14, marginBottom: 8 }}>
       <div style={{ fontSize: 12.5, color: '#556', lineHeight: 1.5 }}>
@@ -394,7 +409,12 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
           {METHODS.map((m) => (
             <button key={m.id} role="tab" aria-selected={authMethod === m.id}
               style={authMethod === m.id ? methodTabActive : methodTab}
-              onClick={() => { setAuthMethod(m.id); setErr(''); setMsg(''); setPending(null); }}>
+              onClick={() => {
+                // Drop any sensitive material typed into the method we're leaving —
+                // don't keep a private key / token sitting in state behind a hidden tab.
+                setAuthMethod(m.id); setErr(''); setMsg(''); setPending(null);
+                setSshKey(''); setCredToken('');
+              }}>
               {m.label}
             </button>
           ))}
@@ -504,8 +524,10 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
         <textarea style={{ ...input, width: '100%', minHeight: 100, fontFamily: 'monospace' }}
           placeholder={'-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----'}
           value={sshKey} onChange={(e) => setSshKey(e.target.value)} />
-        <div>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
           <button style={ghostBtn} disabled={busy || !sshKey.trim()} onClick={addSSHKey}>Save SSH key</button>
+          <button style={{ ...ghostBtn, borderColor: '#d99', color: '#c33' }} disabled={busy}
+            onClick={removeSSHKey}>Clear SSH key</button>
         </div>
       </section>
       )}

--- a/frontend/src/setup/ConnectHosts.tsx
+++ b/frontend/src/setup/ConnectHosts.tsx
@@ -96,11 +96,14 @@ async function api(path: string, init?: RequestInit): Promise<Response> {
 }
 
 export interface ConnectHostsProps {
-  /** Continue to the next wizard step. */
+  /** Continue to the next wizard step (or close the modal when reused stand-alone). */
   onDone: () => void;
   /** Called whenever the connected-host set changes, with the new count (lets the
    * wizard refresh its readiness/summary without a reload). */
   onHostsChanged?: (count: number) => void;
+  /** Label for the done button. Defaults to the wizard's Continue wording; a
+   * stand-alone host (e.g. the Projects modal) passes e.g. "Done". */
+  doneLabel?: string;
 }
 
 interface Pending {
@@ -110,7 +113,7 @@ interface Pending {
   host: string;
 }
 
-export default function ConnectHosts({ onDone, onHostsChanged }: ConnectHostsProps) {
+export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: ConnectHostsProps) {
   const [hosts, setHosts] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState('');
@@ -512,7 +515,7 @@ export default function ConnectHosts({ onDone, onHostsChanged }: ConnectHostsPro
 
       <div>
         <button style={primaryBtn} onClick={onDone}>
-          {hosts.length > 0 ? 'Continue' : 'Continue without connecting'}
+          {doneLabel ?? (hosts.length > 0 ? 'Continue' : 'Continue without connecting')}
         </button>
       </div>
     </div>

--- a/src/headers/util.h
+++ b/src/headers/util.h
@@ -344,6 +344,16 @@ int safe_exec_capture_cwd_env_fd_timeout(const char *const argv[], const char *c
 #define GIT_SAFE_SSH_COMMAND "ssh -o BatchMode=yes -o ConnectTimeout=5"
 #define GIT_SAFE_ENV         "GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='" GIT_SAFE_SSH_COMMAND "' "
 
+/* SSH command for a git op that authenticates with a webuser's vaulted SSH key
+ * (via the in-memory ssh-agent). Same non-interactive/timeout policy as above,
+ * plus StrictHostKeyChecking=accept-new: a non-interactive server has no seeded
+ * known_hosts, so a first-time host (e.g. bitbucket.org) would otherwise die on
+ * "Host key verification failed". accept-new is trust-on-first-use — it records
+ * the host key on first contact and verifies it strictly thereafter (unlike
+ * StrictHostKeyChecking=no, which never verifies). */
+#define GIT_AGENT_SSH_COMMAND \
+   "ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new"
+
 /* Wall-clock cap (ms) for an internal git network op. Generous enough not to
  * kill a slow-but-working fetch, short enough that a stalled remote can never
  * freeze a session start. */

--- a/src/headers/util.h
+++ b/src/headers/util.h
@@ -351,7 +351,7 @@ int safe_exec_capture_cwd_env_fd_timeout(const char *const argv[], const char *c
  * "Host key verification failed". accept-new is trust-on-first-use — it records
  * the host key on first contact and verifies it strictly thereafter (unlike
  * StrictHostKeyChecking=no, which never verifies). */
-#define GIT_AGENT_SSH_COMMAND \
+#define GIT_AGENT_SSH_COMMAND                                                                      \
    "ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new"
 
 /* Wall-clock cap (ms) for an internal git network op. Generous enough not to

--- a/src/headers/util_url.h
+++ b/src/headers/util_url.h
@@ -49,6 +49,19 @@ extern "C"
     */
    char *util_url_workspace_parent(const char *project_url);
 
+   /* Report whether `url` names an SSH transport that authenticates with a key.
+    *
+    * Returns 1 for:
+    *   - ssh://[user@]host[:port]/path
+    *   - scp-like  user@host:path   (no "://", '@' before the ':')
+    * Returns 0 for http(s)://, git:// (anonymous, unauthenticated — no host key
+    * or key auth), local paths, and anything util_url can't parse as SSH.
+    *
+    * Used to decide whether a saved SSH key should drive the clone (honor the
+    * SSH URL) rather than rewriting it to HTTPS. Returns 0 on NULL/empty input.
+    */
+   int util_url_is_ssh(const char *url);
+
    /* Report whether a host uses case-insensitive routing for path segments.
     *
     * Known-insensitive: github.com, gitlab.com, bitbucket.org, and their

--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -85,23 +85,36 @@ static char **build_env(char *const *parent, const char *token, const char *shim
        * UserKnownHostsFile to a file beside the agent socket, in this principal's
        * own tmpfs runtime dir — so accept-new's first-use trust is scoped to this
        * principal and never bleeds through the OS account's shared
-       * ~/.ssh/known_hosts to other tenants. */
+       * ~/.ssh/known_hosts to other tenants.
+       *
+       * git runs GIT_SSH_COMMAND through the shell, so the spliced path must be
+       * shell-safe: it is `<base>/webusers/<name>/known_hosts` where <base> is a
+       * server-controlled runtime dir and <name> is charset-restricted to
+       * [A-Za-z0-9._-] (ws_scope_name_valid) — no whitespace/metacharacters from
+       * any untrusted input can appear. We still fail closed on truncation
+       * (below) rather than emit a malformed/truncated -o path. */
       char kh[2300];
       snprintf(kh, sizeof(kh), "%s", sock);
       char *slash = strrchr(kh, '/');
       char cmd[3200];
+      int cn;
       if (slash)
       {
          snprintf(slash + 1, sizeof(kh) - (size_t)(slash + 1 - kh), "known_hosts");
-         snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s -o UserKnownHostsFile=%s",
-                  GIT_AGENT_SSH_COMMAND, kh);
+         cn = snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s -o UserKnownHostsFile=%s",
+                       GIT_AGENT_SSH_COMMAND, kh);
       }
       else
       {
          /* No directory component (shouldn't happen for a runtime-dir socket) —
           * fall back to the bare command rather than a malformed -o path. */
-         snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s", GIT_AGENT_SSH_COMMAND);
+         cn = snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s", GIT_AGENT_SSH_COMMAND);
       }
+      /* Truncation (an implausibly long runtime path) would leave GIT_SSH_COMMAND
+       * pointing at the wrong known_hosts and silently weaken TOFU — fail closed
+       * to the bare TOFU command (agent still used; per-principal file dropped). */
+      if (cn < 0 || (size_t)cn >= sizeof(cmd))
+         snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s", GIT_AGENT_SSH_COMMAND);
       if (!(out[o++] = strdup(cmd)))
          goto oom;
    }

--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -74,49 +74,52 @@ static char **build_env(char *const *parent, const char *token, const char *shim
       if (!(out[o++] = strdup("GIT_TERMINAL_PROMPT=0")))
          goto oom;
    }
+   /* Wire the ssh-agent env only if we can also pin UserKnownHostsFile to this
+    * principal's own known_hosts (beside the agent socket, in its tmpfs runtime
+    * dir) — so accept-new's first-use trust is scoped to this principal and never
+    * bleeds through the OS account's shared ~/.ssh/known_hosts to other tenants.
+    *
+    * If we CANNOT derive that per-principal path (a malformed socket with no
+    * directory component, or an implausibly long path that truncates), we add
+    * NEITHER SSH_AUTH_SOCK nor GIT_SSH_COMMAND: better to fall back to no-SSH
+    * (the caller then normalizes to HTTPS) than to run accept-new against the
+    * shared known_hosts, which is exactly the cross-tenant bleed this avoids.
+    *
+    * git runs GIT_SSH_COMMAND through the shell, so the spliced path must be
+    * shell-safe: `<base>/webusers/<name>/known_hosts` where <base> is a
+    * server-controlled runtime dir and <name> is charset-restricted to
+    * [A-Za-z0-9._-] (ws_scope_name_valid) — no whitespace/metacharacters from
+    * any untrusted input can appear. */
    if (sock && sock[0])
    {
-      char sb[2300];
-      snprintf(sb, sizeof(sb), "SSH_AUTH_SOCK=%s", sock);
-      if (!(out[o++] = strdup(sb)))
-         goto oom;
-      /* Force the non-interactive TOFU SSH command so an SSH remote authenticates
-       * with the agent key and doesn't stall on a first-time host key. Pin
-       * UserKnownHostsFile to a file beside the agent socket, in this principal's
-       * own tmpfs runtime dir — so accept-new's first-use trust is scoped to this
-       * principal and never bleeds through the OS account's shared
-       * ~/.ssh/known_hosts to other tenants.
-       *
-       * git runs GIT_SSH_COMMAND through the shell, so the spliced path must be
-       * shell-safe: it is `<base>/webusers/<name>/known_hosts` where <base> is a
-       * server-controlled runtime dir and <name> is charset-restricted to
-       * [A-Za-z0-9._-] (ws_scope_name_valid) — no whitespace/metacharacters from
-       * any untrusted input can appear. We still fail closed on truncation
-       * (below) rather than emit a malformed/truncated -o path. */
+      /* Derive <dir>/known_hosts from the <dir>/ssh-agent.sock socket path. */
       char kh[2300];
-      snprintf(kh, sizeof(kh), "%s", sock);
-      char *slash = strrchr(kh, '/');
       char cmd[3200];
-      int cn;
-      if (slash)
+      int ok_kh = 0, cn = -1;
+      if ((size_t)snprintf(kh, sizeof(kh), "%s", sock) < sizeof(kh))
       {
-         snprintf(slash + 1, sizeof(kh) - (size_t)(slash + 1 - kh), "known_hosts");
-         cn = snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s -o UserKnownHostsFile=%s",
-                       GIT_AGENT_SSH_COMMAND, kh);
+         char *slash = strrchr(kh, '/');
+         if (slash)
+         {
+            int hn = snprintf(slash + 1, sizeof(kh) - (size_t)(slash + 1 - kh), "known_hosts");
+            if (hn > 0 && (size_t)(slash + 1 - kh) + (size_t)hn < sizeof(kh))
+            {
+               cn = snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s -o UserKnownHostsFile=%s",
+                             GIT_AGENT_SSH_COMMAND, kh);
+               ok_kh = (cn > 0 && (size_t)cn < sizeof(cmd));
+            }
+         }
       }
-      else
+      if (ok_kh)
       {
-         /* No directory component (shouldn't happen for a runtime-dir socket) —
-          * fall back to the bare command rather than a malformed -o path. */
-         cn = snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s", GIT_AGENT_SSH_COMMAND);
+         char sb[2300];
+         snprintf(sb, sizeof(sb), "SSH_AUTH_SOCK=%s", sock);
+         if (!(out[o++] = strdup(sb)))
+            goto oom;
+         if (!(out[o++] = strdup(cmd)))
+            goto oom;
       }
-      /* Truncation (an implausibly long runtime path) would leave GIT_SSH_COMMAND
-       * pointing at the wrong known_hosts and silently weaken TOFU — fail closed
-       * to the bare TOFU command (agent still used; per-principal file dropped). */
-      if (cn < 0 || (size_t)cn >= sizeof(cmd))
-         snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s", GIT_AGENT_SSH_COMMAND);
-      if (!(out[o++] = strdup(cmd)))
-         goto oom;
+      /* else: fail closed — no ssh-agent env, so the SSH path isn't taken. */
    }
    out[o] = NULL;
    return out;

--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -81,8 +81,28 @@ static char **build_env(char *const *parent, const char *token, const char *shim
       if (!(out[o++] = strdup(sb)))
          goto oom;
       /* Force the non-interactive TOFU SSH command so an SSH remote authenticates
-       * with the agent key and doesn't stall on a first-time host key. */
-      if (!(out[o++] = strdup("GIT_SSH_COMMAND=" GIT_AGENT_SSH_COMMAND)))
+       * with the agent key and doesn't stall on a first-time host key. Pin
+       * UserKnownHostsFile to a file beside the agent socket, in this principal's
+       * own tmpfs runtime dir — so accept-new's first-use trust is scoped to this
+       * principal and never bleeds through the OS account's shared
+       * ~/.ssh/known_hosts to other tenants. */
+      char kh[2300];
+      snprintf(kh, sizeof(kh), "%s", sock);
+      char *slash = strrchr(kh, '/');
+      char cmd[3200];
+      if (slash)
+      {
+         snprintf(slash + 1, sizeof(kh) - (size_t)(slash + 1 - kh), "known_hosts");
+         snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s -o UserKnownHostsFile=%s",
+                  GIT_AGENT_SSH_COMMAND, kh);
+      }
+      else
+      {
+         /* No directory component (shouldn't happen for a runtime-dir socket) —
+          * fall back to the bare command rather than a malformed -o path. */
+         snprintf(cmd, sizeof(cmd), "GIT_SSH_COMMAND=%s", GIT_AGENT_SSH_COMMAND);
+      }
+      if (!(out[o++] = strdup(cmd)))
          goto oom;
    }
    out[o] = NULL;

--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -6,6 +6,7 @@
 #include "git_host_cred.h"     /* git_host_cred_list — "is git configured at all?" */
 #include "git_host_resolve.h"  /* git_host_resolve_token (per-host vault seam) */
 #include "git_ssh_agent.h"     /* git_ssh_agent_ensure */
+#include "util.h"              /* GIT_AGENT_SSH_COMMAND */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,7 +25,9 @@ static int is_key(const char *entry, const char *key)
 
 /* Build the git child env: a copy of `parent` with the credential-carrying keys
  * we manage dropped, plus GH_TOKEN/GIT_ASKPASS/GIT_TERMINAL_PROMPT (when a token
- * is given) and SSH_AUTH_SOCK (when a sock is given). Returns NULL on OOM. */
+ * is given) and SSH_AUTH_SOCK + GIT_SSH_COMMAND (when a sock is given, so an SSH
+ * remote uses the agent key with a non-interactive TOFU host-key policy).
+ * Returns NULL on OOM. */
 /* token_fd_target >= 0 selects FD MODE: advertise AIMEE_GIT_TOKEN_FD=<target>
  * (the askpass reads the token from that inherited fd) and do NOT put the secret
  * in the env. token_fd_target < 0 is LEGACY ENV MODE: GH_TOKEN=<token>. In both
@@ -36,7 +39,8 @@ static char **build_env(char *const *parent, const char *token, const char *shim
    if (parent)
       while (parent[pc])
          pc++;
-   char **out = calloc(pc + 5, sizeof(char *)); /* +token-key,ASKPASS,PROMPT,SSH_AUTH_SOCK,NULL */
+   /* +token-key,ASKPASS,PROMPT,SSH_AUTH_SOCK,GIT_SSH_COMMAND,NULL */
+   char **out = calloc(pc + 6, sizeof(char *));
    if (!out)
       return NULL;
    size_t o = 0;
@@ -44,7 +48,8 @@ static char **build_env(char *const *parent, const char *token, const char *shim
    {
       if (is_key(parent[i], "GH_TOKEN") || is_key(parent[i], "GITHUB_TOKEN") ||
           is_key(parent[i], "GIT_ASKPASS") || is_key(parent[i], "GIT_TERMINAL_PROMPT") ||
-          is_key(parent[i], "SSH_AUTH_SOCK") || is_key(parent[i], "AIMEE_GIT_TOKEN_FD"))
+          is_key(parent[i], "SSH_AUTH_SOCK") || is_key(parent[i], "GIT_SSH_COMMAND") ||
+          is_key(parent[i], "AIMEE_GIT_TOKEN_FD"))
          continue;
       out[o] = strdup(parent[i]);
       if (!out[o++])
@@ -74,6 +79,10 @@ static char **build_env(char *const *parent, const char *token, const char *shim
       char sb[2300];
       snprintf(sb, sizeof(sb), "SSH_AUTH_SOCK=%s", sock);
       if (!(out[o++] = strdup(sb)))
+         goto oom;
+      /* Force the non-interactive TOFU SSH command so an SSH remote authenticates
+       * with the agent key and doesn't stall on a first-time host key. */
+      if (!(out[o++] = strdup("GIT_SSH_COMMAND=" GIT_AGENT_SSH_COMMAND)))
          goto oom;
    }
    out[o] = NULL;

--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -580,9 +580,11 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
        * public or token-authed repo still clone. */
       char *clone_url_norm = NULL;
       const char *clone_url;
+      int ssh_clone = 0;
       if (util_url_is_ssh(url) && env_has_ssh_sock(envp))
       {
          clone_url = url;
+         ssh_clone = 1;
       }
       else
       {
@@ -596,9 +598,14 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
       snprintf(cwd, sizeof(cwd), "/proc/self/fd/%d", tmpfd);
       const char *argv[] = {"git", "clone", "--", clone_url, ".", NULL};
       char *out = NULL;
+      /* Defense in depth: an SSH clone authenticates via the agent, so the HTTPS
+       * token memfd has no business in that child — git only consults GIT_ASKPASS
+       * on the HTTP(S) transport. Don't inherit the token fd on the SSH path (the
+       * real fd is still closed below); the HTTPS path passes it as before. */
+      int child_token_fd = ssh_clone ? -1 : token_fd;
       int rc = safe_exec_capture_cwd_env_fd_timeout(argv, cwd, envp ? envp : environ, &out, 1 << 16,
-                                                    300000, token_fd,
-                                                    token_fd >= 0 ? GIT_CRED_TOKEN_TARGET_FD : -1);
+                                                    300000, child_token_fd,
+                                                    child_token_fd >= 0 ? GIT_CRED_TOKEN_TARGET_FD : -1);
       if (token_fd >= 0)
          close(token_fd);
       free(clone_url_norm);

--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -14,7 +14,7 @@
 #include "kb_client.h"       /* kb purge/finalize/cancel wrappers (slice 2) */
 #include "log.h"
 #include "util.h"            /* safe_exec_capture_env */
-#include "util_url.h"        /* util_url_normalize (ssh/scp/git -> https) */
+#include "util_url.h"        /* util_url_normalize / util_url_is_ssh */
 #include "workspace_scope.h" /* ws_scope_* */
 #include "ws_registry.h"     /* lifecycle lock + key registry */
 
@@ -311,6 +311,16 @@ static int is_published_project_at(int dirfd, const char *name)
    return has_git;
 }
 
+/* True if `envp` carries an SSH_AUTH_SOCK entry — i.e. git_cred_inject wired up
+ * the user's in-memory ssh-agent because they have a vaulted SSH key. */
+static int env_has_ssh_sock(char *const *envp)
+{
+   for (int i = 0; envp && envp[i]; i++)
+      if (strncmp(envp[i], "SSH_AUTH_SOCK=", 14) == 0)
+         return 1;
+   return 0;
+}
+
 int git_project_clone(const char *principal, const char *url, const char *name, const char *org_in,
                       const char *token, char *out_path, size_t path_cap, char *out_ref,
                       size_t ref_cap, char *err, size_t errlen)
@@ -561,11 +571,24 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
       int token_fd = -1;
       char **envp =
           git_cred_inject_build_env_for_repo(principal, url, NULL, token, environ, &token_fd);
-      /* Clone over HTTPS, never SSH: our credential model is per-host HTTPS
-       * tokens (+ OAuth), and a non-interactive server has no seeded
-       * known_hosts. Normalize ssh://, git@host:path, git:// to https. */
-      char *clone_url_norm = util_url_normalize(url);
-      const char *clone_url = clone_url_norm ? clone_url_norm : url;
+      /* Clone over SSH when the user gave an SSH URL and we loaded their vaulted
+       * key (the env then carries SSH_AUTH_SOCK + a TOFU GIT_SSH_COMMAND): honor
+       * the SSH URL so key auth is actually used — the only way in for a host
+       * that offers SSH-key access only (e.g. a corporate Bitbucket). Otherwise
+       * clone over HTTPS: our default credential model is per-host HTTPS tokens
+       * (+ OAuth), and normalizing ssh://, git@host:path, git:// to https lets a
+       * public or token-authed repo still clone. */
+      char *clone_url_norm = NULL;
+      const char *clone_url;
+      if (util_url_is_ssh(url) && env_has_ssh_sock(envp))
+      {
+         clone_url = url;
+      }
+      else
+      {
+         clone_url_norm = util_url_normalize(url);
+         clone_url = clone_url_norm ? clone_url_norm : url;
+      }
       /* Destination pinned by fd: the child chdirs to /proc/self/fd/<tmpfd>
        * (pre-exec, while the fd is still open) and clones into ".", so git
        * never resolves an attacker-influencable path string. */

--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -603,9 +603,9 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
        * on the HTTP(S) transport. Don't inherit the token fd on the SSH path (the
        * real fd is still closed below); the HTTPS path passes it as before. */
       int child_token_fd = ssh_clone ? -1 : token_fd;
-      int rc = safe_exec_capture_cwd_env_fd_timeout(argv, cwd, envp ? envp : environ, &out, 1 << 16,
-                                                    300000, child_token_fd,
-                                                    child_token_fd >= 0 ? GIT_CRED_TOKEN_TARGET_FD : -1);
+      int rc = safe_exec_capture_cwd_env_fd_timeout(
+          argv, cwd, envp ? envp : environ, &out, 1 << 16, 300000, child_token_fd,
+          child_token_fd >= 0 ? GIT_CRED_TOKEN_TARGET_FD : -1);
       if (token_fd >= 0)
          close(token_fd);
       free(clone_url_norm);

--- a/src/tests/test_git_cred_inject.c
+++ b/src/tests/test_git_cred_inject.c
@@ -205,6 +205,10 @@ int main(void)
       assert(se != NULL);
       const char *sock = env_val(se, "SSH_AUTH_SOCK", &n);
       assert(n == 1 && sock && sock[0] == '/'); /* agent socket present */
+      /* a TOFU SSH command rides alongside so an SSH remote uses the agent key
+       * and doesn't stall on a first-time host key */
+      const char *sshcmd = env_val(se, "GIT_SSH_COMMAND", &n);
+      assert(n == 1 && sshcmd && strstr(sshcmd, "StrictHostKeyChecking=accept-new"));
       /* the HTTPS token is still injected alongside */
       assert(env_val(se, "GH_TOKEN", &n) && n == 1);
       git_cred_inject_free_env(se);

--- a/src/tests/test_git_cred_inject.c
+++ b/src/tests/test_git_cred_inject.c
@@ -206,9 +206,13 @@ int main(void)
       const char *sock = env_val(se, "SSH_AUTH_SOCK", &n);
       assert(n == 1 && sock && sock[0] == '/'); /* agent socket present */
       /* a TOFU SSH command rides alongside so an SSH remote uses the agent key
-       * and doesn't stall on a first-time host key */
+       * and doesn't stall on a first-time host key; known_hosts is pinned to a
+       * per-principal file (beside the agent socket) so accept-new's first-use
+       * trust never bleeds through the shared ~/.ssh/known_hosts to other tenants */
       const char *sshcmd = env_val(se, "GIT_SSH_COMMAND", &n);
       assert(n == 1 && sshcmd && strstr(sshcmd, "StrictHostKeyChecking=accept-new"));
+      assert(strstr(sshcmd, "UserKnownHostsFile=") && strstr(sshcmd, "/known_hosts"));
+      assert(strstr(sshcmd, rt)); /* the pinned path is inside THIS principal's runtime dir */
       /* the HTTPS token is still injected alongside */
       assert(env_val(se, "GH_TOKEN", &n) && n == 1);
       git_cred_inject_free_env(se);

--- a/src/tests/test_util_url.c
+++ b/src/tests/test_util_url.c
@@ -180,6 +180,10 @@ static void test_is_ssh(void)
    assert(util_url_is_ssh("relative/path") == 0);
    /* A ':' with no '@' before it is not scp-like (e.g. a host:port with scheme). */
    assert(util_url_is_ssh("host:1234/path") == 0);
+   /* scp-like needs a non-empty host between '@' and ':' (reject empty host). */
+   assert(util_url_is_ssh("foo@:bar") == 0);
+   assert(util_url_is_ssh("a@:p") == 0);
+   assert(util_url_is_ssh("@host:path") == 0); /* empty user */
    /* Scheme match is case-insensitive; git:// stays non-SSH regardless of case. */
    assert(util_url_is_ssh("SSH://git@github.com/o/r") == 1);
    assert(util_url_is_ssh("Ssh://git@github.com/o/r.git") == 1);

--- a/src/tests/test_util_url.c
+++ b/src/tests/test_util_url.c
@@ -180,6 +180,10 @@ static void test_is_ssh(void)
    assert(util_url_is_ssh("relative/path") == 0);
    /* A ':' with no '@' before it is not scp-like (e.g. a host:port with scheme). */
    assert(util_url_is_ssh("host:1234/path") == 0);
+   /* Scheme match is case-insensitive; git:// stays non-SSH regardless of case. */
+   assert(util_url_is_ssh("SSH://git@github.com/o/r") == 1);
+   assert(util_url_is_ssh("Ssh://git@github.com/o/r.git") == 1);
+   assert(util_url_is_ssh("GIT://github.com/o/r") == 0);
    assert(util_url_is_ssh("") == 0);
    assert(util_url_is_ssh(NULL) == 0);
    PASS("is_ssh");

--- a/src/tests/test_util_url.c
+++ b/src/tests/test_util_url.c
@@ -165,6 +165,26 @@ static void test_host_case_classifier(void)
    PASS("host_case_classifier");
 }
 
+static void test_is_ssh(void)
+{
+   /* SSH transports (key auth): ssh:// and scp-like user@host:path. */
+   assert(util_url_is_ssh("git@bitbucket.org:team/repo.git") == 1);
+   assert(util_url_is_ssh("ssh://git@github.com/o/r.git") == 1);
+   assert(util_url_is_ssh("ssh://git@ssh.dev.azure.com:22/v3/o/p/r") == 1);
+   assert(util_url_is_ssh("user@host.example:some/deep/path") == 1);
+   /* Not SSH: https/http, git:// (anonymous, no key/host key), local paths. */
+   assert(util_url_is_ssh("https://github.com/o/r.git") == 0);
+   assert(util_url_is_ssh("http://host/o/r") == 0);
+   assert(util_url_is_ssh("git://github.com/o/r.git") == 0);
+   assert(util_url_is_ssh("/srv/repos/local.git") == 0);
+   assert(util_url_is_ssh("relative/path") == 0);
+   /* A ':' with no '@' before it is not scp-like (e.g. a host:port with scheme). */
+   assert(util_url_is_ssh("host:1234/path") == 0);
+   assert(util_url_is_ssh("") == 0);
+   assert(util_url_is_ssh(NULL) == 0);
+   PASS("is_ssh");
+}
+
 int main(void)
 {
    printf("Running util_url tests\n");
@@ -174,6 +194,7 @@ int main(void)
    test_invalid_inputs();
    test_workspace_parent();
    test_host_case_classifier();
+   test_is_ssh();
    printf("All util_url tests passed.\n");
    return 0;
 }

--- a/src/util_url.c
+++ b/src/util_url.c
@@ -41,6 +41,27 @@ static int scheme_recognized(const char *url, size_t len)
           (len == 3 && strncasecmp(url, "git", 3) == 0);
 }
 
+int util_url_is_ssh(const char *url)
+{
+   if (!url || !*url)
+      return 0;
+
+   const char *proto = strstr(url, "://");
+   if (proto)
+   {
+      size_t scheme_len = (size_t)(proto - url);
+      /* Only ssh:// authenticates with a key; git:// is anonymous. */
+      return scheme_len == 3 && strncasecmp(url, "ssh", 3) == 0;
+   }
+
+   /* scp-like: user@host:path — an '@' must precede the first ':'. */
+   const char *colon = strchr(url, ':');
+   if (!colon)
+      return 0;
+   const char *at = memchr(url, '@', (size_t)(colon - url));
+   return at != NULL && at > url;
+}
+
 char *util_url_normalize(const char *url)
 {
    if (!url || !*url)

--- a/src/util_url.c
+++ b/src/util_url.c
@@ -54,12 +54,13 @@ int util_url_is_ssh(const char *url)
       return scheme_len == 3 && strncasecmp(url, "ssh", 3) == 0;
    }
 
-   /* scp-like: user@host:path — an '@' must precede the first ':'. */
+   /* scp-like: user@host:path — an '@' must precede the first ':', with a
+    * non-empty user before '@' and a non-empty host between '@' and ':'. */
    const char *colon = strchr(url, ':');
    if (!colon)
       return 0;
    const char *at = memchr(url, '@', (size_t)(colon - url));
-   return at != NULL && at > url;
+   return at != NULL && at > url && colon > at + 1;
 }
 
 char *util_url_normalize(const char *url)


### PR DESCRIPTION
## Summary

Adds full SSH-key support for cloning private git repos through the webchat "add project" flow, fixing a report that an SSH-key-only host (a corporate Bitbucket) could not be cloned even after saving the key. Also reworks the git-account auth UI around an explicit method picker.

### The bug
`git_project_clone` force-rewrote **every** remote URL to HTTPS (`util_url_normalize`) before cloning, so a saved SSH key was never exercised — an SSH-only host had no working path in. A genuine SSH clone would also have failed host-key verification (no seeded `known_hosts`).

### The fix
- **Honor SSH URLs when a key is loaded.** When the URL is an SSH transport (`ssh://…` or scp-like `git@host:owner/repo.git`) and the user's vaulted key is loaded (agent up → `SSH_AUTH_SOCK` in the git env), clone over SSH instead of rewriting to HTTPS. Public/token repos still normalize to HTTPS — no regression. New `util_url_is_ssh()` distinguishes real SSH transports from `git://`/HTTPS.
- **Non-interactive TOFU host-key policy.** `git_cred_inject` injects `GIT_SSH_COMMAND` = `ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new` whenever it wires the ssh-agent, so a first-time host records its key and verifies strictly thereafter instead of dying on "Host key verification failed".
- **Wizard auth-method picker.** The Connection step now picks one method (OAuth / access token / SSH key) and shows only its fields.
- **Projects page refactor.** The duplicated inline auth UI is replaced by a single **+ Connect git account** button opening the same wizard flow in a modal; the page keeps its focus on managing repos.

### Docs
- `WEBCHAT_GIT_SECURITY.md`: corrected the SSH bullet — TOFU appends the remote's public host key to `~/.ssh/known_hosts`; the private key still never touches disk.
- `WHATS_NEW.md`: unreleased entry.

## Testing
- C: `unit-test-util-url`, `unit-test-git-cred-inject` (real ssh-agent path; asserts the TOFU `GIT_SSH_COMMAND`), `unit-test-git-project` — all pass.
- Frontend: `tsc -b` clean, 93/93 vitest, production `vite build` OK.
- Reviewed via the roundtable (review mode) before opening.

## Review provenance
- Docs drafted via the `technical-writer` persona.
- Reviewed through the roundtable (review mode). Two rounds surfaced blocking items — cross-tenant `known_hosts` bleed and a lost SSH-key revoke control — both fixed; a third pass returned no blocking findings. Two meritorious suggestions (fail-closed `known_hosts` derivation; empty-host scp rejection) were also applied. Non-blocking suggestions (focus-trap, host allow-listing, style) were considered and deliberately deferred with rationale in the commit messages.
- Rebased onto latest `testing`; resolved one conflict in `Projects.tsx` against the tooltips PR (#1414), preserving its tooltips.
