### PR TITLE
docs(edit): anchored-editing reference + hashline gate confirmation

### DIFF
--- a/benchmarks/hashline/RESULTS.md
+++ b/benchmarks/hashline/RESULTS.md
@@ -115,3 +115,39 @@ retiring `old_string` a wider confirmation is warranted — more delegates
 (incl. the smallest local models), several runs to bound variance, and a look at
 the MiniMax whole-func dip — but the direction is now clearly positive, not the
 negative the small corpus suggested.
+
+---
+
+## CONFIRMATION — 3 delegates × 3 runs
+
+Wider run to bound variance and test the MiniMax whole-func dip. Same 19-task
+realistic corpus, max 4 turns.
+
+| model         | str pass@k | hl pass@k | str tok | hl tok | gate |
+|---------------|-----------:|----------:|--------:|-------:|:----:|
+| mimo-v2.5-pro |    70%     |    96%    |   416   |  350   | PASS |
+| MiniMax-M3    |    72%     |    86%    |   314   |   98   | PASS |
+| codex         |   100%     |   100%    |   313   |   62   | PASS |
+
+**Gate PASSES on all three delegates.** Findings that held up across 3 runs:
+- **collision is the consistent, decisive win** — str_replace pass@k 33–40% (100%
+  only for codex), hashline 100% everywhere, at ~5–15× fewer tokens.
+- **token savings are large and consistent** even where str_replace also succeeds
+  (codex: hashline 62 vs 313 tok — 5× fewer — at identical 100% pass@k).
+- **the MiniMax whole-func regression is real, not noise** (pass@k 87% → 53%
+  across 3 runs): the smaller model fumbles multi-line anchored ranges. This is
+  the one place hashline loses on success rate, and it points at a concrete
+  follow-up — whole-symbol edits likely want `edit_symbol` (which resolves the
+  span server-side) rather than a hand-built `replace_range`, and/or a few-shot
+  range example in the schema.
+- **drift** recovered well (67–93% → 93–100%) thanks to the re-anchor loop;
+  content-preserving insertions still slightly favor str_replace on cost.
+
+### P5 verdict
+The Part I ship criterion is met on the available delegates: hashline ≥
+str_replace pass@k and net token-negative on every model, strictly better on the
+open-weight delegates (mimo, MiniMax). The remaining reservation is the MiniMax
+whole-func dip; addressing whole-symbol edits via `edit_symbol` before removing
+`old_string` is the prudent sequence. Note the roster excludes the very smallest
+local models (the population the proposal predicts gains most) — `kimi-k2.7-code`
+was unavailable throughout (provider billing quota exhausted, not a code fault).

--- a/docs/anchored-editing.md
+++ b/docs/anchored-editing.md
@@ -1,0 +1,182 @@
+# Anchored (hashline) editing
+
+## Overview
+
+aimee's file editing historically relied on a `str_replace` model: the caller
+supplies an exact `old_string` and a `new_string`, and the server swaps the
+first (or every) occurrence. That design forces the model to re-emit content it
+already read—whitespace, surrounding context, and all—with no stable identifier
+for the lines it wants to change. The resulting failure modes ("old_string not
+found", "occurs N times", stale-file wrong-apply) are structural and hit cheap
+local/open-weight delegates hardest.
+
+Hashline editing replaces this with **anchored, transactional edits**. Every
+line read from a file is stamped with a deterministic composite anchor
+(`LINE:HASH`). Edits reference those anchors instead of re-emitting text. The
+server verifies freshness, owns all offset arithmetic, and applies batches
+atomically. The result is fewer tokens, stronger safety guarantees, and
+deterministic success on collision and drift scenarios where `str_replace`
+silently mis-applies.
+
+## Anchored reads
+
+`read_file` returns each line prefixed with a composite anchor:
+
+```
+LINE:HASH| <line content>
+```
+
+- **HASH** is a 2-hex display tag derived from a full FNV-1a-64 digest over the
+  line's canonical bytes (trailing CR/LF and a line-1 UTF-8 BOM excluded).
+- Each anchored read mints an immutable **snapshot** (`snapshot_id`) that
+  records every line's full digest plus the file's dominant line-ending, BOM,
+  and trailing-newline shape. Snapshots are TTL/LRU evicted. Concurrent reads
+  mint independent snapshots—no clobber.
+- `raw: true` returns un-anchored bytes (for grep pipelines, binary sniffing).
+- `mode: "outline"` returns a tree-sitter symbol skeleton (signatures +
+  anchors, no bodies)—one cheap call to map a large file.
+
+**Example anchored read output:**
+
+```
+1:a3| import os
+2:7b|
+3:c4| def main():
+4:0a|     print("hello")
+```
+
+## Anchored edits
+
+`edit_file` supports a primary anchored path: pass the `snapshot_id` from a
+prior read plus an `edits[]` batch. Each edit specifies:
+
+| Field        | Description                                                   |
+|--------------|---------------------------------------------------------------|
+| `op`         | One of `replace`, `replace_range`, `insert_after`, `delete_range` |
+| `at`         | A `LINE:HASH` anchor (for single-line ops)                    |
+| `from` / `to`| `LINE:HASH` anchors delimiting a range (for range ops)       |
+| `text`       | The replacement or insertion content                          |
+
+**Example call shape:**
+
+```json
+{
+  "path": "src/main.py",
+  "snapshot_id": "snap_abc123",
+  "edits": [
+    { "op": "replace", "at": "4:0a", "text": "    print(\"world\")" }
+  ]
+}
+```
+
+### Key properties
+
+- **Ordinal as primary key.** The line ordinal disambiguates identical lines;
+  the full digest verifies freshness. Each op is verified against the
+  snapshot's recorded digest before any write.
+- **All-or-nothing.** The batch is applied atomically—no edit renumbers
+  another; the server owns all offset arithmetic.
+- **Drift handling.** If the file changed since the snapshot was taken, the
+  call returns a structured `stale_anchor` payload with re-anchored context
+  and a fresh `snapshot_id`. The model retries without a blind re-read.
+- **Dry run.** `dry_run: true` previews the unified diff and structural blast
+  radius without writing.
+- **Byte preservation.** Unchanged lines are written back verbatim. Only edited
+  regions are normalized to the file's dominant terminator. A no-final-newline
+  file keeps that property.
+- **Display-tag stripping.** If a model echoes the `LINE:HASH| ` display prefix
+  into `text`, the server strips it—the tag is display-only.
+
+## Adjacent tools
+
+The same philosophy of stable references and server-side resolution extends to
+several related tools:
+
+| Tool                   | Purpose                                                                                      |
+|------------------------|----------------------------------------------------------------------------------------------|
+| `read_symbol`          | Fetch just a symbol's definition span, anchored.                                             |
+| `edit_symbol`          | Rewrite a whole function or type by name. The server resolves the span and swaps it; overloaded or shadowed names return candidates (never a blind resolve). |
+| `grep` (`anchored: true`) | Search hits become ready edit anchors, grouped under a per-file `snapshot=...` header.    |
+| `run_tests`            | Returns structured `{passed, exit_code, output}` with framework summary and failures kept; the full log is spillable via `tool_output_get`. |
+
+## Lean websearch
+
+The websearch tools are designed to keep page fetches server-side and return
+only query-relevant spans:
+
+- **`web_search`** registers `r1..rN` handles for its results.
+- **`web_read(ref, query, span, mode)`** fetches a page once server-side and
+  returns only query-relevant spans, cited by id and fenced as untrusted. A
+  **mandatory literal leg** guarantees exact needles (API names, error strings,
+  versions) appear in the result above a lexical term-overlap leg.
+  `span=N` or `mode: "full"` recover dropped spans.
+
+### SSRF-safe egress
+
+All fetches are http/https only. The host is resolved once, the resolved IP is
+validated against a private/reserved/link-local/metadata deny-list (IPv4 +
+IPv6), and the connection is **pinned** to that IP (no re-resolution) to defeat
+DNS rebinding. Redirects are not followed—they are returned to the caller.
+
+> **Note:** The neural-embedder "semantic" ranking leg is deferred. The shipped
+> path uses the mandatory literal leg + a lexical term-overlap leg.
+
+## Migration & compatibility
+
+The legacy `old_string` / `new_string` / `replace_all` path on `edit_file` is
+**retained as a deprecated one-release fallback**. It has not been removed.
+Agents that have not adopted anchored edits continue to work, but will not
+benefit from collision safety, drift recovery, or token savings.
+
+**Recommended migration path:**
+
+1. Switch `read_file` calls to default (anchored) mode. Use `raw: true` only
+   when you need un-anchored bytes.
+2. Replace `old_string`/`new_string` edits with `snapshot_id` + `edits[]`
+   batches referencing `LINE:HASH` anchors.
+3. For whole-function or whole-type rewrites, prefer `edit_symbol` over
+   hand-built `replace_range`—the server resolves the span, avoiding the
+   multi-line anchor fumble observed with smaller models.
+
+## Evaluation & status
+
+### Gating harnesses
+
+Two harnesses gate the transition before `old_string` is removed:
+
+1. **`unit-test-hashline-gate`** — a deterministic CI test proving
+   model-independent properties: hashline applies every fixture, stays safe
+   under collision and drift where `str_replace` silently mis-applies, and
+   reproduces zero already-read bytes.
+2. **`tools/hashline_agentic_eval.py`** — a multi-turn agentic eval over a
+   realistic mutation corpus generated from real repo files
+   (`tools/hashline_corpus_gen.py`): collision-at-scale, deep-indent,
+   whole-function rewrites, and drift. It renders the real anchored format and
+   feeds real tool errors back so retries are measured.
+
+### Live results
+
+Three delegates (mimo-v2.5-pro, MiniMax-M3, codex) × 3 runs on 19 tasks. Gate
+criterion: `pass@k ≥ str_replace` AND net token-negative.
+
+- **Gate passes on all three.** Collision is the decisive, consistent win:
+  `str_replace` 33–40% pass@k vs hashline 100%, at ~5–15× fewer tokens.
+  Token savings are large and consistent even where `str_replace` also succeeds
+  (codex: 62 vs 313 tokens at identical 100% pass@k).
+- **Caveat:** On MiniMax-M3, whole-function rewrites regressed (pass@k 87% →
+  53%)—the smaller model fumbles multi-line anchored ranges. This is why
+  `edit_symbol` (server-resolved span) is the recommended path for whole-symbol
+  edits, and why `old_string` removal (P5) waits.
+
+### Merge status
+
+Merged to the `testing` branch across:
+
+| PR   | Content                          |
+|------|----------------------------------|
+| #1396| Edit core + websearch            |
+| #1400| Deterministic gate               |
+| #1405| Format hardening + fair harness  |
+| #1410| Realistic corpus                 |
+
+`old_string` is retained pending whole-function handling via `edit_symbol`.


### PR DESCRIPTION
Documents the anchored (hashline) editing core and records the wider evaluation confirmation.

## Documentation
`docs/anchored-editing.md` — a developer-facing reference covering anchored reads (`LINE:HASH` + `snapshot_id`), the transactional `edits[]` protocol (ops, freshness verification, atomic apply, `stale_anchor` drift recovery, `dry_run`, byte preservation, display-tag stripping), the adjacent tools (`read_symbol` / `edit_symbol` / anchored `grep` / `run_tests`), `web_read` + SSRF-safe egress, a migration path, and the evaluation/status.

The page was **drafted through aimee's own technical-writer persona** (a delegate job on the .254 stack), then reviewed and corrected so the anchor examples match the real 2-hex display-tag format.

## Confirmation results (`benchmarks/hashline/RESULTS.md`)
Wider run to bound variance — 3 delegates × 3 runs on the 19-task realistic corpus, gate = `pass@k ≥ str_replace` AND net token-negative:

| model | str pass@k | hl pass@k | str tok | hl tok | gate |
|---|---:|---:|---:|---:|:--:|
| mimo-v2.5-pro | 70% | 96% | 416 | 350 | PASS |
| MiniMax-M3 | 72% | 86% | 314 | 98 | PASS |
| codex | 100% | 100% | 313 | 62 | PASS |

**Gate passes on all three.** Collision is the consistent, decisive win (str_replace 33–40% pass@k vs hashline 100%, ~5–15× fewer tokens). The **MiniMax whole-func dip is confirmed real** (87%→53%) — the one honest caveat, and the reason `edit_symbol` is the recommended path for whole-symbol edits before `old_string` is removed (P5).

Side note: `kimi-k2.7-code` was unavailable throughout — its provider returns *"reached your usage limit for this billing cycle"* (a billing/quota matter, not the streaming bug).

Docs + benchmark only (no code changes).
