### PR TITLE
feat(config): delegate_sandbox_package_access mode key (plumbing)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (182)
+## CLI-settable keys (183)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -55,6 +55,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `default_persona` | string | Persona a fresh primary session starts as, and the persona draft roundtable panelists author with when none is set (default 'engineer'). |
 | `delegate_graph_context_enabled` | bool | Prepend a structural code-graph context block (callers/dependencies of files a delegate task references) to the delegate prompt (advisory, fail-open, default off). |
 | `delegate_sandbox` | bool | Run a delegate's shell and file ops INSIDE its own container (via the `docker` delegate backend) instead of in-process in aimee-server. Off (the default) a delegate's `bash`/read/write/list run with aimee-server's filesystem and environment. This is not yet a full sandbox on its own: the container still has a network, so `require_aimee_git` and the credential strip remain the live boundary. The delegate image must carry whatever the work needs (a toolchain, or `verify` fails). The server logs OFF/INERT/ARMED at boot, probing `docker version` — check it, because an unreachable daemon means every delegate runs on the host (default off). |
+| `delegate_sandbox_package_access` | string | Runtime package-access policy for a `--network none` delegate sandbox. aimee always performs and logs the fetch (the delegate holds no outside socket); this selects how much: `proxy` (default) proxies package-manager fetches to any host — egress-via-aimee, for out-of-the-box functionality; `off` no runtime proxy (build-time installs + learned pre-bake only); `gated` host-allowlisted registries, off-allowlist requires human approval; `governance` allowlist from a governance provider, off-allowlist refused. Only meaningful when `delegate_sandbox` is on. |
 | `dogfood_autolabel_continuation` | bool | Auto-label continuation turns for dogfood capture. |
 | `dogfood_autolabel_repair` | bool | Auto-label repair turns for dogfood capture. |
 | `dogfood_autolabel_repeat_question` | bool | Auto-label repeated-question turns. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -177,6 +177,13 @@ CFG_KEY_DESC = {
     "delegate image must carry whatever the work needs (a toolchain, or `verify` fails). The "
     "server logs OFF/INERT/ARMED at boot, probing `docker version` — check it, because an "
     "unreachable daemon means every delegate runs on the host (default off).",
+    "delegate_sandbox_package_access": "Runtime package-access policy for a `--network none` "
+    "delegate sandbox. aimee always performs and logs the fetch (the delegate holds no outside "
+    "socket); this selects how much: `proxy` (default) proxies package-manager fetches to any "
+    "host — egress-via-aimee, for out-of-the-box functionality; `off` no runtime proxy "
+    "(build-time installs + learned pre-bake only); `gated` host-allowlisted registries, "
+    "off-allowlist requires human approval; `governance` allowlist from a governance provider, "
+    "off-allowlist refused. Only meaningful when `delegate_sandbox` is on.",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress "
     "(memory/code preview envelope on primary ingress turns; default on).",

--- a/src/config.c
+++ b/src/config.c
@@ -329,6 +329,7 @@ static const config_schema_entry_t config_schema[] = {
     {"require_aimee_git", SCHEMA_BOOL, 0},
     {"delegate_sandbox", SCHEMA_BOOL, 0},
     {"delegate_sandbox_image", SCHEMA_STRING, 0},
+    {"delegate_sandbox_package_access", SCHEMA_STRING, 0}, /* valid: proxy|off|gated|governance */
     {"guardrails", SCHEMA_OBJECT, 0},
     {"toolsets", SCHEMA_OBJECT, 0},
     {"script", SCHEMA_OBJECT, 0},
@@ -553,6 +554,12 @@ void config_kb_curator_defaults(config_t *cfg);
 /* Defined in config_skills.c. */
 int config_parse_skills(config_t *cfg, const cJSON *root);
 void config_computer_use_defaults(config_t *cfg);
+
+int config_sandbox_package_access_valid(const char *s)
+{
+   return s && (strcmp(s, "proxy") == 0 || strcmp(s, "off") == 0 || strcmp(s, "gated") == 0 ||
+                strcmp(s, "governance") == 0);
+}
 int config_parse_computer_use(config_t *cfg, const cJSON *root);
 
 static void config_set_defaults(config_t *cfg)
@@ -562,6 +569,8 @@ static void config_set_defaults(config_t *cfg)
    /* Defaults */
    snprintf(cfg->db1_path, sizeof(cfg->db1_path), "%s", config_default_db1_path());
    snprintf(cfg->guardrail_mode, sizeof(cfg->guardrail_mode), "%s", MODE_APPROVE);
+   snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access),
+            "proxy");
    snprintf(cfg->provider, sizeof(cfg->provider), "claude");
    cfg->compact_enabled = 1; /* default on; set before no-config early returns */
    cfg->coord_closet_enabled =
@@ -1240,6 +1249,15 @@ int config_load_file(config_t *cfg)
    if (cJSON_IsString(item) && item->valuestring[0])
       snprintf(cfg->delegate_sandbox_image, sizeof(cfg->delegate_sandbox_image), "%s",
                item->valuestring);
+   item = cJSON_GetObjectItemCaseSensitive(root, "delegate_sandbox_package_access");
+   if (cJSON_IsString(item) && config_sandbox_package_access_valid(item->valuestring))
+      snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access),
+               "%s", item->valuestring);
+   else if (cJSON_IsString(item)) /* present but not a valid mode (incl. "") — warn, keep default */
+      fprintf(stderr,
+              "aimee: config warning: delegate_sandbox_package_access: unknown value \"%s\" — "
+              "keeping default \"proxy\" (valid: proxy, off, gated, governance)\n",
+              item->valuestring);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "typed_facts_enabled");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -108,6 +108,8 @@ const config_field_t config_fields[] = {
     {"require_aimee_memory", offsetof(config_t, require_aimee_memory), sizeof(int), 0, CFG_BOOL},
     {"require_aimee_git", offsetof(config_t, require_aimee_git), sizeof(int), 0, CFG_BOOL},
     {"delegate_sandbox", offsetof(config_t, delegate_sandbox), sizeof(int), 0, CFG_BOOL},
+    {"delegate_sandbox_package_access", offsetof(config_t, delegate_sandbox_package_access),
+     sizeof(((config_t *)0)->delegate_sandbox_package_access), 0, CFG_STRING},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_pdf_ingest_enabled", offsetof(config_t, kb_pdf_ingest_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_pdf_vector_enabled", offsetof(config_t, kb_pdf_vector_enabled), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -872,6 +872,11 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "delegate_sandbox", 1);
    if (cfg->delegate_sandbox_image[0])
       cJSON_AddStringToObject(root, "delegate_sandbox_image", cfg->delegate_sandbox_image);
+   /* Persist only when non-default ("proxy"); absence means the default. */
+   if (cfg->delegate_sandbox_package_access[0] &&
+       strcmp(cfg->delegate_sandbox_package_access, "proxy") != 0)
+      cJSON_AddStringToObject(root, "delegate_sandbox_package_access",
+                              cfg->delegate_sandbox_package_access);
    /* typed_facts_enabled is KB-owned: persisted as kb.typed_facts.enabled by
     * config_save_kb_curator (still parsed at root for backward compat). */
    if (cfg->kb_pdf_ingest_enabled) /* default-off: persist only when enabled */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -470,6 +470,16 @@ typedef struct config
     * reference (used as-is); the build-from-spec form lives in .aimee/project.yaml. */
    char delegate_sandbox_image[256];
 
+   /* Runtime package-access policy for a `--network none` delegate sandbox. aimee
+    * always performs the fetch (the delegate never holds an outside socket) and logs
+    * it; this selects HOW MUCH aimee will fetch on the delegate's behalf:
+    *   "proxy"      (default) proxy package-manager fetches to any host
+    *   "off"        no runtime proxy; build-time installs + learned pre-bake only
+    *   "gated"      host-allowlisted registries; off-allowlist -> human approval
+    *   "governance" allowlist from a governance provider; off-allowlist refused
+    * See docs/proposals/pending/delegate-sandbox-image-customization.md. */
+   char delegate_sandbox_package_access[32];
+
    /* Gateway tool-policing (P2): when on, the gateway strips subagent-spawning
     * tools (Task/Agent/spawn_agent/RemoteTrigger) from the inbound `tools` of a
     * proxied /v1/messages or /v1/chat/completions request, so the served model is
@@ -2044,6 +2054,9 @@ const char *config_output_dir(void);
 
 /* Effective guardrail mode (defaults to "approve"). */
 const char *config_guardrail_mode(const config_t *cfg);
+
+/* 1 if `s` is a valid delegate_sandbox_package_access mode (proxy/off/gated/governance). */
+int config_sandbox_package_access_valid(const char *s);
 
 /* Resolve the embedding command actually used to embed text. Precedence:
  * a per-call `requested` command (e.g. from a request payload), then the

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1928,6 +1928,57 @@ int main(void)
       unlink(cpath);
    }
 
+   /* --- delegate_sandbox_package_access: default proxy, round-trip, validation --- */
+   {
+      assert(config_sandbox_package_access_valid("proxy"));
+      assert(config_sandbox_package_access_valid("off"));
+      assert(config_sandbox_package_access_valid("gated"));
+      assert(config_sandbox_package_access_valid("governance"));
+      assert(!config_sandbox_package_access_valid("bogus"));
+      assert(!config_sandbox_package_access_valid(NULL));
+
+      char cpath[512];
+      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+      unlink(cpath);
+      platform_setenv("AIMEE_NO_CACHE", "1");
+
+      static config_t def;
+      memset(&def, 0, sizeof(def));
+      assert(config_load(&def) == 0);
+      assert(strcmp(def.delegate_sandbox_package_access, "proxy") == 0); /* default */
+
+      /* Round-trip a non-default value. */
+      snprintf(def.delegate_sandbox_package_access, sizeof(def.delegate_sandbox_package_access),
+               "gated");
+      assert(config_save(&def) == 0);
+      static config_t got;
+      memset(&got, 0, sizeof(got));
+      assert(config_load(&got) == 0);
+      assert(strcmp(got.delegate_sandbox_package_access, "gated") == 0);
+
+      /* An unknown value in the file is ignored — the default stands. (The stderr
+       * warning itself is not captured here; only the default-preserving behavior.) */
+      FILE *f = fopen(cpath, "w");
+      assert(f);
+      fputs("delegate_sandbox_package_access: nonsense\n", f);
+      fclose(f);
+      static config_t bad;
+      memset(&bad, 0, sizeof(bad));
+      assert(config_load(&bad) == 0);
+      assert(strcmp(bad.delegate_sandbox_package_access, "proxy") == 0);
+
+      /* An explicitly empty value is also invalid -> keep the default. */
+      f = fopen(cpath, "w");
+      assert(f);
+      fputs("delegate_sandbox_package_access: \"\"\n", f);
+      fclose(f);
+      static config_t empty;
+      memset(&empty, 0, sizeof(empty));
+      assert(config_load(&empty) == 0);
+      assert(strcmp(empty.delegate_sandbox_package_access, "proxy") == 0);
+      unlink(cpath);
+   }
+
    if (old_home)
    {
       platform_setenv("HOME", old_home);


### PR DESCRIPTION
PR1 of the delegate-sandbox package-access work. Adds the config key `delegate_sandbox_package_access` — an enum: `proxy` (default) / `off` / `gated` / `governance` (see the design proposal, merged in #1420). **Plumbing only, no runtime behavior** — the proxy/gating that consumes this key is a follow-up PR.

## What's here
- Struct field + default (`proxy`), YAML parse with validation, save (persist only when non-default), schema entry, and the `config_fields` registry so `aimee config set delegate_sandbox_package_access <mode>` works.
- Regenerated `docs/gen/configuration.md` with a full description of the modes/default/security semantics.
- Unit test: default is `proxy`; round-trips a non-default value; an unknown or empty value warns and keeps the default.

## Semantics
`proxy` is the shipping default — at runtime aimee will proxy a `--network none` delegate's package-manager fetches to any host (egress performed and **logged** by aimee; the delegate holds no outside socket), chosen for out-of-the-box functionality. `off`/`gated`/`governance` are the config paths to a tighter boundary. The key is only meaningful when `delegate_sandbox` is on.

## Review
Reviewed by the aimee **roundtable** (MiniMax-M3, mimo-v2.5-pro, kimi-k2.7-code, synth): initial **REQUEST-CHANGES** → resolved (config-table description; empty-value warning; buffer `16→32`; schema allowed-values hint; test coverage; two findings confirmed as false positives) → final **APPROVE**.