### PR TITLE
webchat: allow dots in work-item ids so slice human-gates are reachable

### DIFF
--- a/webchat/workflow.go
+++ b/webchat/workflow.go
@@ -151,9 +151,13 @@ func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 	if i := strings.IndexByte(rest, '/'); i >= 0 {
 		id, suffix = rest[:i], rest[i:]
 	}
-	// <id> must be one safe segment (no separators/traversal/percent-encoding that
-	// could smuggle a '/' past this guard); the server's matcher is authoritative.
-	if id == "" || strings.ContainsAny(id, "/.%") {
+	// <id> must be one safe segment: no '/' or '%' (could smuggle a separator past
+	// this guard) and no ".." traversal sequence. A single '.' IS allowed — child
+	// slice work-item ids are "<parent>.s<N>" (e.g. wi_abc123.s0), so rejecting all
+	// dots made every slice's detail/gate/events unreachable (400 "bad path"),
+	// which blocked approving a slice parked at a human gate. The server's matcher
+	// is authoritative for what resolves.
+	if id == "" || strings.ContainsAny(id, "/%") || strings.Contains(id, "..") {
 		http.Error(w, `{"error":"bad path"}`, http.StatusBadRequest)
 		return
 	}

--- a/webchat/workflow_test.go
+++ b/webchat/workflow_test.go
@@ -68,6 +68,75 @@ func TestWorkflowItemsLifecycleRouting(t *testing.T) {
 	}
 }
 
+// Child-slice work-item ids are "<parent>.s<N>" — they contain a dot. The proxy
+// must route them through (detail GET, /gate, /events, /proposal), not reject the
+// dot as traversal. Regression: a "/.%" guard rejected every slice id as "bad
+// path", so a slice parked at a human gate could not be opened or approved.
+func TestWorkflowItemsSliceIDRouting(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  string
+		apiPath string
+		wantV1  string
+	}{
+		{"detail", http.MethodGet, "/api/workflow/items/wi123.s0", "/v1/workflow/items/wi123.s0"},
+		{"gate", http.MethodPost, "/api/workflow/items/wi123.s0/gate", "/v1/workflow/items/wi123.s0/gate"},
+		{"events", http.MethodGet, "/api/workflow/items/wi123.s0/events", "/v1/workflow/items/wi123.s0/events"},
+		{"proposal", http.MethodGet, "/api/workflow/items/wi123.s0/proposal", "/v1/workflow/items/wi123.s0/proposal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			mux := http.NewServeMux()
+			mux.HandleFunc(tc.wantV1, func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"status":"ok"}`))
+			})
+			cfg := startFakeV1(t, mux)
+			if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"),
+				[]byte("sekret-token\n"), 0600); err != nil {
+				t.Fatalf("write server.token: %v", err)
+			}
+			s := &server{cfg: cfg}
+			var body []byte
+			if tc.method == http.MethodPost {
+				body = []byte(`{"decision":"approve"}`)
+			}
+			req := withUser(httptest.NewRequest(tc.method, tc.apiPath, strings.NewReader(string(body))), "alice")
+			rr := httptest.NewRecorder()
+			s.handleWorkflowItems(rr, req)
+			if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"status":"ok"`) {
+				t.Fatalf("%s: code=%d body=%q (slice id rejected as bad path?)", tc.name, rr.Code, rr.Body.String())
+			}
+			if gotPath != tc.wantV1 {
+				t.Fatalf("%s: proxied to %s, want %s", tc.name, gotPath, tc.wantV1)
+			}
+		})
+	}
+}
+
+// A ".." traversal sequence (or a '/'/'%' separator/encoding) must still be
+// refused even though a single '.' is now allowed for slice ids.
+func TestWorkflowItemsRejectsTraversal(t *testing.T) {
+	for _, apiPath := range []string{
+		"/api/workflow/items/wi123..evil",
+		"/api/workflow/items/..",
+		"/api/workflow/items/wi123..",
+		"/api/workflow/items/..wi.s0",   // leading traversal mixed with legit dots
+		"/api/workflow/items/wi%25s0",   // %25 -> '%' in the id: percent still rejected
+		"/api/workflow/items/a%2Fb",     // %2F -> '/': a smuggled separator is refused
+	} {
+		s := &server{cfg: startFakeV1(t, http.NewServeMux())}
+		req := withUser(httptest.NewRequest(http.MethodGet, apiPath, nil), "alice")
+		rr := httptest.NewRecorder()
+		s.handleWorkflowItems(rr, req)
+		if rr.Code != http.StatusBadRequest || !strings.Contains(rr.Body.String(), "bad path") {
+			t.Fatalf("%s: code=%d body=%q, want 400 bad path", apiPath, rr.Code, rr.Body.String())
+		}
+	}
+}
+
 // Any (method, suffix) pair the item proxy doesn't map must be refused as
 // "bad path" rather than silently forwarded — including a wrong method on an
 // otherwise-known lifecycle suffix and a mutating method on the bare id path.


### PR DESCRIPTION
## Problem

In the webchat **Workflow Actions** page, clicking a child slice of an autonomous run showed an empty panel with **no Approve/Reject button** — a slice parked at a human gate could not be opened or approved at all.

## Root cause

`webchat/workflow.go` proxies `/api/workflow/items/<id>[/gate|/events|/proposal]` to the `/v1` server. Its path-safety guard was:

```go
if id == "" || strings.ContainsAny(id, "/.%") { … 400 "bad path" }
```

Child-slice work-item ids are `"<parent>.s<N>"` (e.g. `wi_abc123.s0`), so the `.` tripped the guard and **every** slice request (detail, `/gate`, `/events`, `/proposal`) returned `400 "bad path"`. The frontend's detail fetch failed → `setDetail(null)` → the empty placeholder rendered. The parent (no dot) opened fine; the slices you actually approve did not.

## Fix

Reject only the real dangers — a `/` or `%` separator/encoding and a `..` traversal sequence — and allow a single `.`:

```go
if id == "" || strings.ContainsAny(id, "/%") || strings.Contains(id, "..") { … }
```

A lone `.` cannot smuggle a path separator, and the `/v1` route matcher stays authoritative for what actually resolves.

## Tests

- `TestWorkflowItemsSliceIDRouting` — a slice id (`wi123.s0`) routes through for detail / `/gate` / `/events` / `/proposal`, asserting the exact proxied `/v1` path.
- `TestWorkflowItemsRejectsTraversal` — `..` shapes (incl. leading-`..` mixed with legit dots), a percent (`%25`), and a smuggled slash (`%2F`) are still refused.

## Review

Reviewed by the roundtable — verdict **Approve / "land it"**: narrowly scoped, no traversal or separator-smuggling regression from allowing a lone dot, regression well-pinned by tests. The three extra negative cases it suggested are included.