### PR TITLE
fix(gateway): surface upstream HTTP errors instead of masking as 'invalid JSON response'

### DIFF
--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -1218,14 +1218,28 @@ int agent_execute(const agent_t *agent, const char *system_prompt, const char *u
       char snippet[256] = {0};
       if (response_body)
          snprintf(snippet, sizeof(snippet), "%.200s", response_body);
-      snprintf(out->error, sizeof(out->error), "HTTP %d: %s", http_status, snippet);
-      /* Try to parse error body */
+      /* Try to extract a STRUCTURED provider error ({"error":{"message":...}}).
+       * If the body is not JSON, parse_response() sets the generic "invalid JSON
+       * response" — which previously CLOBBERED the informative HTTP status here,
+       * making every upstream 4xx/5xx (rate limits, gateway errors, HTML error
+       * pages) undiagnosable in the field. Keep the HTTP status + body snippet
+       * unless a real structured message was extracted. */
+      out->error[0] = '\0';
       parse_response(response_body, agent, out);
+      if (!out->error[0] || strcmp(out->error, "invalid JSON response") == 0)
+         snprintf(out->error, sizeof(out->error), "HTTP %d (non-JSON body): %s", http_status,
+                  snippet);
       free(response_body);
       return -1;
    }
 
    parse_response(response_body, agent, out);
+   /* A 200 whose body is not JSON (e.g. an SSE stream leaking through, or a
+    * truncated reply) is also masked by the bare "invalid JSON response"; make it
+    * say so and show a snippet, so the cause is visible. */
+   if (out->error[0] && strcmp(out->error, "invalid JSON response") == 0)
+      snprintf(out->error, sizeof(out->error), "provider returned 200 with a non-JSON body: %.180s",
+               response_body ? response_body : "");
    free(response_body);
 
    agent_reject_degenerate_plain_response(out, agent->name);


### PR DESCRIPTION
## Problem
Chasing why the MiniMax-M3 delegate returns `upstream_error: invalid JSON response` on `/v1/chat/completions`, I found a real error-surfacing bug on the unary inference path.

`agent_runtime.c` `run_inference`: on a **non-200** provider reply it sets an informative `"HTTP <status>: <body snippet>"` error, then immediately calls `parse_response()`, which **overwrites** it with the generic `"invalid JSON response"` whenever the error body isn't JSON. So every upstream 4xx/5xx (rate limits, gateway errors, HTML error pages) is reported as a useless `"invalid JSON response"` — undiagnosable in the field, which is exactly what masks the MiniMax failure.

## Fix
- Non-200 path: preserve `HTTP <status> (non-JSON body): <snippet>` unless `parse_response` extracted a **structured** `{"error":{"message":...}}`.
- 200-with-non-JSON-body: report `provider returned 200 with a non-JSON body: <snippet>` instead of the bare generic string.

Pure diagnosability improvement — no change to the success path.

## Not this PR
The streaming buffered-replay stream-flag bug from the field notes is **already fixed in tree** (`anthropic_http.c`: `upstream_stream = responses_wire ? 1 : (buffered_replay ? 0 : 1)`). This is the separate unary-path error-masking defect.

## Verification
Server builds clean; `make lint` clean. (No new unit test: the change is a small, self-evident guard on an HTTP-boundary error path with no easily mockable seam here.)
