### PR TITLE
fix(sandbox-proxy): CONNECT tunnel wrote a truncated 200 response (HTTPS-through-proxy hung)

### DIFF
--- a/src/server/sandbox_pkg_proxy.c
+++ b/src/server/sandbox_pkg_proxy.c
@@ -284,7 +284,11 @@ int sandbox_pkg_proxy_serve(int client_fd, int is_uds, const char *head, const c
    unsigned long up_bytes = 0, down_bytes = 0;
    if (kind == SBX_REQ_CONNECT)
    {
-      if (write_all(client_fd, "HTTP/1.1 200 Connection Established\r\n\r\n", 38) == 0)
+      /* sizeof-1, not a hand-counted length: the literal is 39 bytes and a wrong
+       * count drops the final CRLF, so the client never sees the \r\n\r\n header
+       * terminator, never starts its TLS handshake, and the tunnel hangs. */
+      static const char connect_ok[] = "HTTP/1.1 200 Connection Established\r\n\r\n";
+      if (write_all(client_fd, connect_ok, sizeof(connect_ok) - 1) == 0)
          proxy_pump(client_fd, up, &up_bytes, &down_bytes);
    }
    else /* SBX_REQ_ABSOLUTE */


### PR DESCRIPTION
## The bug

The package-access proxy's CONNECT handler replied with:

```c
write_all(client_fd, "HTTP/1.1 200 Connection Established\r\n\r\n", 38)
```

That string is **39 bytes**, not 38 — the hand-counted length drops the final `\n`. The client never sees the complete `\r\n\r\n` header terminator, so it never begins its TLS handshake and the tunnel relays zero bytes before timing out.

HTTP absolute-form proxying is unaffected (it doesn't use this response line), which is why `apt-get update` worked while **every HTTPS-through-proxy client (pip, curl, npm, cargo) hung**.

## How it was found — hardware E2E

Stood up a throwaway CT with the `:testing` image and reproduced exactly what a delegate sandbox does: a `--network none` container with the `aimee-forwarder` bridge + `http_proxy` pointed at aimee's UDS proxy. Server logs isolated the defect precisely — the allowlist, SSRF guard, and upstream dial are all correct:

```
sandbox-proxy: OK   host=archive.ubuntu.com port=80  ... down=315475 kind=http     <- HTTP relays fine (apt fetched 47 MB)
sandbox-proxy: OK   host=pypi.org          port=443 ... up=0 down=0  kind=connect  <- allowed + dialed, but 0 bytes tunneled
sandbox-proxy: OK   host=deb.debian.org    port=443 ... up=0 down=0  kind=connect
sandbox-proxy: DENY host=example.com       port=443 (allowlist/port)               <- non-allowlisted correctly refused
```

Every CONNECT reached `up=0 down=0` — the tunnel moved nothing because the client was still waiting on the truncated `200` response.

## The fix

Use `sizeof(literal) - 1` so the write length can never drift from the string again.

## Verification

- `unit-test-sandbox-pkg-proxy` (pure core) still passes; server builds.
- Definitive end-to-end re-validation will run once CI republishes `:testing`: re-pull into the E2E CT and confirm the CONNECT tunnels complete (a local rebuild can't hot-swap in — the dev binary needs GLIBC_2.38 vs the image's 2.36).