### PR TITLE
fix(ingress): primary-agent fallback must skip disabled agents

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -20,6 +20,10 @@ agent_t *agent_route_at_tier(agent_config_t *cfg, const char *role, int tier);
 agent_t *agent_route_with_caps(agent_config_t *cfg, const char *role, const config_t *sys_cfg,
                                unsigned required_caps, int min_context);
 agent_t *agent_find(agent_config_t *cfg, const char *name);
+/* Select the default "primary" agent for ingress paths that don't name a model:
+ * an explicitly configured default when it is enabled, else the first enabled
+ * agent, else NULL. Never returns a disabled agent. */
+agent_t *agent_default_primary(agent_config_t *cfg);
 int agent_is_available_for_routing(const agent_t *agent);
 
 /* True if at least one configured agent is enabled AND routable as a delegate

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1509,6 +1509,25 @@ agent_t *agent_find(agent_config_t *cfg, const char *name)
    return NULL;
 }
 
+agent_t *agent_default_primary(agent_config_t *cfg)
+{
+   /* An explicitly configured default wins — but only when it is actually
+    * usable. Routing to a disabled default (or, historically, a disabled
+    * agents[0]) makes every ingress request that doesn't name a model fast-fail
+    * as "failed to reach the primary provider" even though enabled agents
+    * exist, so the fallback deliberately skips disabled seats. */
+   if (cfg->default_agent[0])
+   {
+      agent_t *ag = agent_find(cfg, cfg->default_agent);
+      if (ag && ag->enabled)
+         return ag;
+   }
+   for (int i = 0; i < cfg->agent_count; i++)
+      if (cfg->agents[i].enabled)
+         return &cfg->agents[i];
+   return NULL;
+}
+
 /* Pick randomly from an array of candidates using monotonic-clock nanoseconds.
  * Thread-safe: no shared mutable state. */
 static agent_t *agent_pick_random(agent_t **candidates, int count)

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -41,20 +41,16 @@
 #include <string.h>
 #include <time.h>
 
-/* Resolve aimee's primary agent (the configured default, else the first
- * agent). Claude Code's requested model is intentionally ignored — switching
- * models is `aimee primary`. acfg is caller-owned and must outlive the returned
- * pointer (it indexes into acfg). Returns NULL when none configured. */
+/* Resolve aimee's primary agent (the configured default, else the first enabled
+ * agent — see agent_default_primary). Claude Code's requested model is
+ * intentionally ignored — switching models is `aimee primary`. acfg is
+ * caller-owned and must outlive the returned pointer (it indexes into acfg).
+ * Returns NULL when no usable agent exists → caller reports 503. */
 static agent_t *resolve_primary(agent_config_t *acfg)
 {
-   agent_t *ag = NULL;
    if (agent_load_config(acfg) != 0)
       return NULL;
-   if (acfg->default_agent[0])
-      ag = agent_find(acfg, acfg->default_agent);
-   if (!ag && acfg->agent_count > 0)
-      ag = &acfg->agents[0];
-   return ag;
+   return agent_default_primary(acfg);
 }
 
 /* Mint a "msg_<epoch>" id for the response/stream. */

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -190,9 +190,7 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
       }
    }
    if (!ag)
-      ag = agent_find(&acfg, acfg.default_agent);
-   if (!ag && acfg.agent_count > 0)
-      ag = &acfg.agents[0];
+      ag = agent_default_primary(&acfg);
    if (!ag)
    {
       free(pi_env);
@@ -603,9 +601,7 @@ static int responses_handler(const char *body, char *resp, int cap)
       }
    }
    if (!ag)
-      ag = agent_find(&acfg, acfg.default_agent);
-   if (!ag && acfg.agent_count > 0)
-      ag = &acfg.agents[0];
+      ag = agent_default_primary(&acfg);
    if (!ag)
    {
       free(prompt);
@@ -711,10 +707,7 @@ static agent_t *stream_pick_agent(agent_config_t *acfg, const char *model)
     * silently streaming a different model than the client asked for. */
    if (model[0] && strcmp(model, "aimee") != 0)
       return agent_find(acfg, model);
-   agent_t *ag = agent_find(acfg, acfg->default_agent);
-   if (!ag && acfg->agent_count > 0)
-      ag = &acfg->agents[0];
-   return ag;
+   return agent_default_primary(acfg);
 }
 
 static int chat_stream_handler(const char *body, server_http_sse_emit emit, void *ctx)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -29,6 +29,7 @@
 void test_agent_route_with_caps_honors_tools_enabled(void);
 void test_agent_route_with_caps_honors_context_override(void);
 void test_tools_enabled_capability_default(void);
+void test_agent_default_primary_skips_disabled(void);
 
 /* Defined in test_agent_responses.c (split out to keep this file under the
  * 2000-line hard limit); called from main() below. */
@@ -2982,6 +2983,7 @@ int main(void)
    test_request_creds_snapshot_carries_vault_principal();
    test_agent_config_provider_cli_roundtrip();
    test_tools_enabled_capability_default();
+   test_agent_default_primary_skips_disabled();
    test_agent_config_cache_detects_same_mtime_rewrite();
    test_agent_adapter_registry();
    test_agent_config_deletion_guard();

--- a/src/tests/test_agent_caps.c
+++ b/src/tests/test_agent_caps.c
@@ -125,3 +125,40 @@ void test_tools_enabled_capability_default(void)
    unlink(agent_config_path());
    printf("  PASS: test_tools_enabled_capability_default\n");
 }
+
+/* agent_default_primary must never hand back a disabled seat: a disabled
+ * agents[0] (e.g. an unconfigured "claude") otherwise becomes the fallback
+ * primary and every ingress request that doesn't name a model fast-fails as
+ * "failed to reach the primary provider". */
+void test_agent_default_primary_skips_disabled(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 3;
+   strcpy(cfg.agents[0].name, "claude"); /* disabled fallback footgun */
+   cfg.agents[0].enabled = 0;
+   strcpy(cfg.agents[1].name, "minimax");
+   cfg.agents[1].enabled = 1;
+   strcpy(cfg.agents[2].name, "codex");
+   cfg.agents[2].enabled = 1;
+
+   /* No default set → first ENABLED agent, not the disabled agents[0]. */
+   cfg.default_agent[0] = '\0';
+   assert(agent_default_primary(&cfg) == &cfg.agents[1]);
+
+   /* An enabled explicit default wins. */
+   strcpy(cfg.default_agent, "codex");
+   assert(agent_default_primary(&cfg) == &cfg.agents[2]);
+
+   /* A disabled explicit default is ignored → first enabled agent. */
+   strcpy(cfg.default_agent, "claude");
+   assert(agent_default_primary(&cfg) == &cfg.agents[1]);
+
+   /* Nothing enabled → NULL (caller reports a clear 503, not a phantom route). */
+   cfg.agents[1].enabled = 0;
+   cfg.agents[2].enabled = 0;
+   cfg.default_agent[0] = '\0';
+   assert(agent_default_primary(&cfg) == NULL);
+
+   printf("  PASS: test_agent_default_primary_skips_disabled\n");
+}

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -54,6 +54,11 @@ agent_t *agent_find(agent_config_t *cfg, const char *name)
    return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
 }
 
+agent_t *agent_default_primary(agent_config_t *cfg)
+{
+   return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
+}
+
 void delegate_drivers_init(void)
 {
 }

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -73,6 +73,11 @@ agent_t *agent_find(agent_config_t *cfg, const char *name)
    return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
 }
 
+agent_t *agent_default_primary(agent_config_t *cfg)
+{
+   return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
+}
+
 void delegate_drivers_init(void)
 {
 }

--- a/src/tests/test_anthropic_http_streaming_p2c.c
+++ b/src/tests/test_anthropic_http_streaming_p2c.c
@@ -76,6 +76,11 @@ agent_t *agent_find(agent_config_t *cfg, const char *name)
    return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
 }
 
+agent_t *agent_default_primary(agent_config_t *cfg)
+{
+   return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
+}
+
 void delegate_drivers_init(void)
 {
 }


### PR DESCRIPTION
## Problem

On `.254` (and any box without an explicit `default_agent`), every `/v1/messages` request fast-failed with `502 "failed to reach the primary provider"` in ~0.2s — before any upstream call — even though enabled agents (codex, MiniMax) were configured and healthy.

**Root cause:** the ingress paths resolve the "primary" agent as `agent_find(default_agent) else agents[0]`, with **no `enabled` check**. `agents.json` had `default_agent` unset and `agents[0]` = a disabled `claude` seat (`enabled:false`, empty model/endpoint). So the primary resolved to that dead seat and fast-failed. `/v1/messages` also ignores the request `model` field by design (model switching is `aimee primary`), so no client could route around it.

The same naive `agents[0]` fallback existed in **three** `openai_chat.c` sites (the OpenAI-compat ingress default path).

## Fix

Extract the shared selection into `agent_default_primary()`:
- an explicitly configured `default_agent` **when it is enabled**, else
- the first **enabled** agent, else
- `NULL` — which callers already surface as a clear `503 "no primary/agent configured"`, more honest than routing into a disabled seat.

All four call sites now route through it (`anthropic_http.c` `resolve_primary` + three `openai_chat.c` sites), removing the triplicated pattern.

## Test

`test_agent_default_primary_skips_disabled` (in `test_agent_caps.c`, run from `unit-test-agent`): a disabled `agents[0]` is skipped in favour of the first enabled agent; an enabled explicit default wins; a disabled explicit default falls through to first-enabled; an all-disabled config returns `NULL`. Passes locally (`agent: all tests passed`).

## Note

This does not change the deliberate design that `/v1/messages` ignores the request `model` field — it only fixes the *fallback* so an unconfigured `default_agent` lands on a working enabled agent instead of a dead one. Operators should still set `default_agent`/`aimee primary` to choose intentionally.