### PR TITLE
feat(ingress): aimee-internal errors carry a >=1000 code, not a bare 502

### DIFF
--- a/src/headers/aimee_errors.h
+++ b/src/headers/aimee_errors.h
@@ -1,0 +1,60 @@
+/* aimee_errors.h -- aimee-specific error codes (>=1000).
+ *
+ * HTTP status codes (<600) describe the TRANSPORT: a 502 says "the upstream gave
+ * me a bad reply", a 503 says "this service can't serve the request right now".
+ * When the fault is aimee's OWN doing -- no primary agent configured, a provider
+ * circuit breaker is open, credentials can't be resolved -- reusing an HTTP 5xx
+ * that connotes an EXTERNAL problem sends operators chasing the wrong thing (a
+ * fast-failing circuit breaker looks identical to a dead upstream under a 502).
+ *
+ * So aimee-internal failures carry a code in a range HTTP never uses (>=1000),
+ * surfaced in the JSON error body ("code") and every log line ("aimee_err="),
+ * while the WIRE status stays a standard, honest 3-digit code (503 for "this
+ * service is unavailable", 500 for an internal fault) -- never 502, which is
+ * reserved for a genuine upstream provider failure. The 4-digit code stays OUT
+ * of the status line so strict clients (the Anthropic SDK, proxies) don't choke.
+ *
+ * Ranges: 10xx = ingress / routing / provider control-plane. Grow by family. */
+#ifndef DEC_AIMEE_ERRORS_H
+#define DEC_AIMEE_ERRORS_H 1
+
+enum aimee_error_code
+{
+   /* No usable primary agent: default unset/disabled and no enabled agent. 503. */
+   AIMEE_ERR_NO_PRIMARY = 1001,
+   /* The primary agent exists but its endpoint or credentials could not be
+    * resolved (e.g. a codex-oauth seat with no available token). NOT an upstream
+    * failure -- the request never left the box. 503. */
+   AIMEE_ERR_ROUTE_UNRESOLVED = 1002,
+   /* The gateway request pipeline (memory injection / tool policing) hard-failed
+    * before any provider call. Internal fault. 500. */
+   AIMEE_ERR_REQUEST_PIPELINE = 1003,
+   /* A provider circuit breaker is open (agent health marked DOWN): aimee is
+    * declining to call a provider it believes is failing. 503. */
+   AIMEE_ERR_BREAKER_OPEN = 1010,
+   /* The provider's per-agent concurrency slots are exhausted (max_parallel).
+    * Transient/aimee-side back-pressure, not an upstream error. 503. */
+   AIMEE_ERR_CONCURRENCY_LIMIT = 1011,
+};
+
+/* Short, stable, greppable slug for a code -- used in log lines. */
+static inline const char *aimee_err_slug(int code)
+{
+   switch (code)
+   {
+   case AIMEE_ERR_NO_PRIMARY:
+      return "no_primary";
+   case AIMEE_ERR_ROUTE_UNRESOLVED:
+      return "route_unresolved";
+   case AIMEE_ERR_REQUEST_PIPELINE:
+      return "request_pipeline";
+   case AIMEE_ERR_BREAKER_OPEN:
+      return "breaker_open";
+   case AIMEE_ERR_CONCURRENCY_LIMIT:
+      return "concurrency_limit";
+   default:
+      return "unknown";
+   }
+}
+
+#endif /* DEC_AIMEE_ERRORS_H */

--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -222,6 +222,14 @@ extern "C"
     * resp[cap]. Returns bytes written, or -1. */
    int openai_format_error(char *resp, int cap, const char *type, const char *message);
 
+   /* As openai_format_error, but also stamps an aimee-specific error code
+    * (>=1000, see aimee_errors.h) into error.code and logs it when aimee_code>0,
+    * for aimee-internal faults (no primary, routing/credentials). The wire HTTP
+    * status is still chosen by the caller's return value. aimee_code==0 is
+    * identical to openai_format_error. */
+   int openai_format_error_code(char *resp, int cap, const char *type, const char *message,
+                                int aimee_code);
+
    /* P2c (response-side tool policing, OpenAI streaming): emit the tool-call
     * tail of the `response.*` SSE sequence for a parsed_response_t that carries
     * `calls[]` (the post-police shape — calls[] may be empty if every entry was

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -1,5 +1,6 @@
 #include "aimee.h"
 #include "agent_config.h" /* agent_request_cancelled — server-owned turn lifecycle */
+#include "aimee_errors.h"
 #include "db1.h"
 #include "delegate_role.h"
 #include "skill_curator.h"
@@ -172,8 +173,14 @@ int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char
    if (!provider_catalog_concurrent_acquire(ag->name, ag->max_parallel))
    {
       snprintf(out->agent_name, MAX_AGENT_NAME, "%s", ag->name);
-      snprintf(out->error, sizeof(out->error), "agent '%s' at concurrency limit (max_parallel=%d)",
-               ag->name, ag->max_parallel);
+      /* Aimee-internal back-pressure, not a provider fault: tag it with the aimee
+       * error SLUG (not the numeric code) so it's identifiable wherever out->error
+       * surfaces. The slug carries no digits, so it can't collide with
+       * agent_error_is_retryable's "502"/"503"/... substring scan the way a numeric
+       * code could; the "at concurrency limit" substring stays intact too. */
+      snprintf(out->error, sizeof(out->error),
+               "agent '%s' at concurrency limit (max_parallel=%d) [aimee_err=%s]", ag->name,
+               ag->max_parallel, aimee_err_slug(AIMEE_ERR_CONCURRENCY_LIMIT));
       return AGENT_RC_AT_LIMIT;
    }
    int rc = use_tools ? agent_execute_with_tools_for_role(ag, net, role, system_prompt, user_prompt,

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -15,6 +15,7 @@
  * executes tools itself. */
 #include "aimee.h" /* size macros for agent_types.h */
 #include "agent_config.h"
+#include "aimee_errors.h"
 #include "agent_exec.h"
 #include "context_reduce.h"
 #include "gateway_mutate_wire.h"
@@ -34,6 +35,7 @@
 #include "aimee_ir_stream.h" /* Slice 5-wire: IR-delta incremental relay */
 #include "ingress_preinject.h"
 #include "json_fluent.h"
+#include "log.h"
 #include "server_http.h"
 #include "session_compact.h"
 #include "sse_parser.h"
@@ -138,8 +140,14 @@ static int write_json(cJSON *obj, char *resp, int cap)
    return rc;
 }
 
-/* Write an Anthropic-shaped error object into resp and return `status`. */
-static int write_error(char *resp, int cap, int status, const char *type, const char *message)
+/* Write an Anthropic-shaped error object into resp and return the wire `status`.
+ * aimee_code is an aimee-specific error code (>=1000, see aimee_errors.h) when the
+ * fault is aimee's own — it rides in the body's error.code and is logged — or 0
+ * for a plain HTTP-semantic error (client 4xx, genuine upstream 5xx). The wire
+ * status stays a standard 3-digit code regardless; the 4-digit aimee code never
+ * touches the status line. */
+static int write_error(char *resp, int cap, int status, const char *type, const char *message,
+                       int aimee_code)
 {
    cJSON *o = cJSON_CreateObject();
    cJSON *e;
@@ -147,6 +155,12 @@ static int write_error(char *resp, int cap, int status, const char *type, const 
    e = cJSON_AddObjectToObject(o, "error");
    cJSON_AddStringToObject(e, "type", type);
    cJSON_AddStringToObject(e, "message", message);
+   if (aimee_code > 0)
+   {
+      cJSON_AddNumberToObject(e, "code", aimee_code);
+      LOG_WARN("ingress", "aimee_err=%d (%s) status=%d: %s", aimee_code,
+               aimee_err_slug(aimee_code), status, message ? message : "");
+   }
    char *out = cJSON_PrintUnformatted(o);
    if (out)
    {
@@ -416,7 +430,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
    gw_mutate_ctx_init(&gwmc);
 
    if (!req)
-      return write_error(resp, cap, 400, "invalid_request_error", "invalid JSON body");
+      return write_error(resp, cap, 400, "invalid_request_error", "invalid JSON body", 0);
    model = jo_cstr(req, "model");
 
    /* SHADOW (Slice 3): observe the IR round-trip on this live request. No-op unless
@@ -427,7 +441,8 @@ static int messages_buffered(const char *body, char *resp, int cap)
    if (!ag)
    {
       cJSON_Delete(req);
-      return write_error(resp, cap, 503, "api_error", "no primary agent configured");
+      return write_error(resp, cap, 503, "api_error", "no primary agent configured",
+                         AIMEE_ERR_NO_PRIMARY);
    }
 
    delegate_drivers_init();
@@ -441,7 +456,8 @@ static int messages_buffered(const char *body, char *resp, int cap)
     * stage returns <0 today; the intervention count is plumbed for P2b's audit). */
    if (messages_run_request_pipeline(req, driver, ag, parity, 0 /* buffered */) < 0)
    {
-      status = write_error(resp, cap, 500, "api_error", "gateway request pipeline failed");
+      status = write_error(resp, cap, 500, "api_error", "gateway request pipeline failed",
+                           AIMEE_ERR_REQUEST_PIPELINE);
       goto cleanup;
    }
    /* Re-read `model`: the model-pin stage may have replaced req's "model" node, so
@@ -465,7 +481,15 @@ static int messages_buffered(const char *body, char *resp, int cap)
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
    {
-      status = write_error(resp, cap, 502, "api_error", "failed to reach the primary provider");
+      /* Internal: we never reached the provider — the endpoint or credentials for
+       * the primary couldn't be resolved (e.g. a codex-oauth seat with no token).
+       * 503 (not 502) + an aimee code so this doesn't read as an upstream failure;
+       * surface the explicit auth reason (D6) when one was set. */
+      const char *why = agent_request_auth_error();
+      char msg[256];
+      snprintf(msg, sizeof(msg), "could not resolve endpoint or credentials for primary agent '%s'%s%s",
+               ag->name, (why && why[0]) ? ": " : "", (why && why[0]) ? why : "");
+      status = write_error(resp, cap, 503, "api_error", msg, AIMEE_ERR_ROUTE_UNRESOLVED);
       goto cleanup;
    }
    if (parity)
@@ -512,8 +536,10 @@ static int messages_buffered(const char *body, char *resp, int cap)
       }
       else
       {
+         /* Genuine upstream failure: the provider was reached and returned
+          * non-200. 502 with no aimee code — this really is an external problem. */
          status = write_error(resp, cap, 502, "api_error",
-                              response ? response : "primary provider call failed");
+                              response ? response : "primary provider call failed", 0);
       }
       goto cleanup;
    }

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -158,8 +158,8 @@ static int write_error(char *resp, int cap, int status, const char *type, const 
    if (aimee_code > 0)
    {
       cJSON_AddNumberToObject(e, "code", aimee_code);
-      LOG_WARN("ingress", "aimee_err=%d (%s) status=%d: %s", aimee_code,
-               aimee_err_slug(aimee_code), status, message ? message : "");
+      LOG_WARN("ingress", "aimee_err=%d (%s) status=%d: %s", aimee_code, aimee_err_slug(aimee_code),
+               status, message ? message : "");
    }
    char *out = cJSON_PrintUnformatted(o);
    if (out)
@@ -487,8 +487,9 @@ static int messages_buffered(const char *body, char *resp, int cap)
        * surface the explicit auth reason (D6) when one was set. */
       const char *why = agent_request_auth_error();
       char msg[256];
-      snprintf(msg, sizeof(msg), "could not resolve endpoint or credentials for primary agent '%s'%s%s",
-               ag->name, (why && why[0]) ? ": " : "", (why && why[0]) ? why : "");
+      snprintf(msg, sizeof(msg),
+               "could not resolve endpoint or credentials for primary agent '%s'%s%s", ag->name,
+               (why && why[0]) ? ": " : "", (why && why[0]) ? why : "");
       status = write_error(resp, cap, 503, "api_error", msg, AIMEE_ERR_ROUTE_UNRESOLVED);
       goto cleanup;
    }

--- a/src/server/delegate_routing.c
+++ b/src/server/delegate_routing.c
@@ -1,5 +1,6 @@
 /* delegate_routing.c: shared delegate route override helpers. */
 #include "cmd_agent_delegate_impl.h"
+#include "aimee_errors.h"
 #include "util.h"
 #include "model_registry.h"
 #include "provider_cli_adapter.h" /* declared context window for tmux-CLI agents */
@@ -305,10 +306,16 @@ int delegate_apply_route_overrides(agent_config_t *cfg, const char *role, const 
       }
       if (!agent_is_available_for_routing(selected))
       {
-         route_err(errbuf, errbuf_sz,
-                   "agent '%s' is currently unavailable (health down after repeated "
-                   "failures, or its provider-cli command is missing)",
-                   via_name, NULL);
+         /* Aimee's circuit breaker declining to route (or a missing CLI): an
+          * aimee-internal condition, tagged with the aimee error SLUG so it's
+          * identifiable, not mistaken for a provider outage. Slug (not the numeric
+          * code) to stay clear of substring-based error classifiers. */
+         char emsg[256];
+         snprintf(emsg, sizeof(emsg),
+                  "agent '%s' is currently unavailable (health down after repeated "
+                  "failures, or its provider-cli command is missing) [aimee_err=%s]",
+                  via_name, aimee_err_slug(AIMEE_ERR_BREAKER_OPEN));
+         route_err(errbuf, errbuf_sz, "%s", emsg, NULL);
          return -1;
       }
       if (role && role[0] && !agent_has_role(selected, role) && !agent_is_exec_role(selected, role))

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -26,6 +26,7 @@
 #include "openai_responses_store.h"   /* previous_response_id continuation store */
 #include "openai_runs_store.h"        /* GET /v1/runs/{id} record store */
 #include "aimee.h"  /* EMBED_MAX_DIM, MAX_PATH_LEN (used by agent_types.h below) */
+#include "aimee_errors.h"
 #include "config.h" /* config_t, config_load */
 #include "agent_config.h"
 #include "agent_exec.h"
@@ -171,7 +172,8 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
    {
       free(pi_env);
       free(prompt);
-      openai_format_error(resp, cap, "server_error", "no agent configuration available");
+      openai_format_error_code(resp, cap, "server_error", "no agent configuration available",
+                               AIMEE_ERR_NO_PRIMARY);
       return 503;
    }
    agent_t *ag = NULL;
@@ -197,7 +199,8 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
    {
       free(pi_env);
       free(prompt);
-      openai_format_error(resp, cap, "server_error", "no agent configured");
+      openai_format_error_code(resp, cap, "server_error", "no agent configured",
+                               AIMEE_ERR_NO_PRIMARY);
       return 503;
    }
 
@@ -587,7 +590,8 @@ static int responses_handler(const char *body, char *resp, int cap)
    if (agent_load_config(&acfg) != 0)
    {
       free(prompt);
-      openai_format_error(resp, cap, "server_error", "no agent configuration available");
+      openai_format_error_code(resp, cap, "server_error", "no agent configuration available",
+                               AIMEE_ERR_NO_PRIMARY);
       return 503;
    }
    agent_t *ag = NULL;
@@ -609,7 +613,8 @@ static int responses_handler(const char *body, char *resp, int cap)
    if (!ag)
    {
       free(prompt);
-      openai_format_error(resp, cap, "server_error", "no agent configured");
+      openai_format_error_code(resp, cap, "server_error", "no agent configured",
+                               AIMEE_ERR_NO_PRIMARY);
       return 503;
    }
 
@@ -1531,7 +1536,8 @@ static int runs_handler(const char *body, char *resp, int cap)
    if (!ag)
    {
       free(prompt);
-      openai_format_error(resp, cap, "server_error", "no agent configured");
+      openai_format_error_code(resp, cap, "server_error", "no agent configured",
+                               AIMEE_ERR_NO_PRIMARY);
       return 503;
    }
 

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -25,7 +25,7 @@
 #include "retrieval_outcome_bridge.h" /* retrieval_outcome_bridge_on_autolabel */
 #include "openai_responses_store.h"   /* previous_response_id continuation store */
 #include "openai_runs_store.h"        /* GET /v1/runs/{id} record store */
-#include "aimee.h"  /* EMBED_MAX_DIM, MAX_PATH_LEN (used by agent_types.h below) */
+#include "aimee.h" /* EMBED_MAX_DIM, MAX_PATH_LEN (used by agent_types.h below) */
 #include "aimee_errors.h"
 #include "config.h" /* config_t, config_load */
 #include "agent_config.h"

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -1359,6 +1359,12 @@ int openai_format_responses_completed_items(const char *id, const char *model, l
 
 int openai_format_error(char *resp, int cap, const char *type, const char *message)
 {
+   return openai_format_error_code(resp, cap, type, message, 0);
+}
+
+int openai_format_error_code(char *resp, int cap, const char *type, const char *message,
+                             int aimee_code)
+{
    if (!resp || cap <= 0)
       return -1;
 
@@ -1375,6 +1381,10 @@ int openai_format_error(char *resp, int cap, const char *type, const char *messa
    cJSON_AddItemToObject(root, "error", err);
    cJSON_AddStringToObject(err, "message", message ? message : "");
    cJSON_AddStringToObject(err, "type", type ? type : "");
+   /* aimee-internal faults stamp their code (>=1000) into the body; the caller
+    * logs it (this formatter stays a pure, dependency-light shape helper). */
+   if (aimee_code > 0)
+      cJSON_AddNumberToObject(err, "code", aimee_code);
 
    char *s = cJSON_PrintUnformatted(root);
    cJSON_Delete(root);

--- a/src/tests/test_agent_error_retryable.c
+++ b/src/tests/test_agent_error_retryable.c
@@ -36,6 +36,12 @@ int main(void)
     * string), so the "at concurrency limit" message must stay non-retryable — else
     * it would wrongly record provider health and be misclassified as a fault. */
    assert(agent_error_is_retryable("agent 'codex' at concurrency limit (max_parallel=2)") == 0);
+   /* The aimee-error slug tag must not flip that classification: a digit-free slug
+    * (vs a numeric code that could contain "502"/"503"/...) keeps it non-retryable. */
+   assert(
+       agent_error_is_retryable(
+           "agent 'codex' at concurrency limit (max_parallel=2) [aimee_err=concurrency_limit]") ==
+       0);
 
    printf("  classify: ok\n");
    printf("All agent_error_retryable tests passed.\n");

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -11,8 +11,18 @@
 #include "../headers/agent_exec.h"
 #include "../headers/agent_protocol.h"
 #include "../headers/delegate_driver.h"
+#include "../headers/log.h"
 #include "../headers/server_http.h"
 #include "../vendor/headers/cJSON.h"
+
+/* anthropic_http.c's write_error now logs aimee-internal error codes; this
+ * minimal link stubs the logger like the other production deps below. */
+void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
+{
+   (void)level;
+   (void)module;
+   (void)fmt;
+}
 
 #define PASS(name) printf("  PASS: %s\n", (name))
 

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -24,6 +24,13 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
    (void)fmt;
 }
 
+/* write_error's route-unresolved branch reads the per-turn auth-error channel;
+ * stub returns "no explicit reason" for this minimal link. */
+const char *agent_request_auth_error(void)
+{
+   return NULL;
+}
+
 #define PASS(name) printf("  PASS: %s\n", (name))
 
 static const delegate_driver_t *g_driver;

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -15,8 +15,18 @@
 #include "../headers/agent_exec.h"
 #include "../headers/agent_protocol.h"
 #include "../headers/delegate_driver.h"
+#include "../headers/log.h"
 #include "../headers/server_http.h"
 #include "../vendor/headers/cJSON.h"
+
+/* anthropic_http.c's write_error now logs aimee-internal error codes; this
+ * minimal link stubs the logger like the other production deps below. */
+void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
+{
+   (void)level;
+   (void)module;
+   (void)fmt;
+}
 
 #define PASS(name) printf("  PASS: %s\n", (name))
 

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -28,6 +28,13 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
    (void)fmt;
 }
 
+/* write_error's route-unresolved branch reads the per-turn auth-error channel;
+ * stub returns "no explicit reason" for this minimal link. */
+const char *agent_request_auth_error(void)
+{
+   return NULL;
+}
+
 #define PASS(name) printf("  PASS: %s\n", (name))
 
 static const delegate_driver_t *g_driver;

--- a/src/tests/test_anthropic_http_streaming_p2c.c
+++ b/src/tests/test_anthropic_http_streaming_p2c.c
@@ -34,6 +34,13 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
    (void)fmt;
 }
 
+/* write_error's route-unresolved branch reads the per-turn auth-error channel;
+ * stub returns "no explicit reason" for this minimal link. */
+const char *agent_request_auth_error(void)
+{
+   return NULL;
+}
+
 static const delegate_driver_t *g_driver;
 static char *g_last_body;
 static char *g_last_extra;

--- a/src/tests/test_anthropic_http_streaming_p2c.c
+++ b/src/tests/test_anthropic_http_streaming_p2c.c
@@ -19,10 +19,20 @@
 #include "../headers/agent_protocol.h"
 #include "../headers/anthropic_ingress.h"
 #include "../headers/delegate_driver.h"
+#include "../headers/log.h"
 #include "../headers/server_http.h"
 #include "../vendor/headers/cJSON.h"
 
 #define PASS(name) printf("  PASS: %s\n", (name))
+
+/* anthropic_http.c's write_error now logs aimee-internal error codes; this
+ * minimal link stubs the logger like the other production deps below. */
+void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
+{
+   (void)level;
+   (void)module;
+   (void)fmt;
+}
 
 static const delegate_driver_t *g_driver;
 static char *g_last_body;

--- a/src/tests/test_openai_shape.c
+++ b/src/tests/test_openai_shape.c
@@ -151,6 +151,8 @@ int main(void)
       assert(strcmp(aimee_err_slug(AIMEE_ERR_NO_PRIMARY), "no_primary") == 0);
       assert(strcmp(aimee_err_slug(AIMEE_ERR_ROUTE_UNRESOLVED), "route_unresolved") == 0);
       assert(strcmp(aimee_err_slug(AIMEE_ERR_BREAKER_OPEN), "breaker_open") == 0);
+      assert(strcmp(aimee_err_slug(AIMEE_ERR_CONCURRENCY_LIMIT), "concurrency_limit") == 0);
+      assert(strcmp(aimee_err_slug(AIMEE_ERR_REQUEST_PIPELINE), "request_pipeline") == 0);
       assert(strcmp(aimee_err_slug(4242), "unknown") == 0);
    }
 

--- a/src/tests/test_openai_shape.c
+++ b/src/tests/test_openai_shape.c
@@ -1,6 +1,7 @@
 /* test_openai_shape.c: unit tests for the OpenAI-compatible JSON shaping
  * helpers (pure — no sockets, no network, no agent execution). */
 #include "openai_shape.h"
+#include "aimee_errors.h"
 #include "cJSON.h"
 #include <assert.h>
 #include <stdio.h>
@@ -130,6 +131,27 @@ int main(void)
       assert(len > 0);
       assert(strstr(resp, "\"type\":\"invalid_request_error\""));
       assert(strstr(resp, "bad model"));
+      /* A plain HTTP-semantic error carries NO aimee code. */
+      assert(!strstr(resp, "\"code\""));
+   }
+
+   /* --- aimee-coded error envelope --- */
+   {
+      int len = openai_format_error_code(resp, sizeof(resp), "server_error", "no agent configured",
+                                         AIMEE_ERR_NO_PRIMARY);
+      assert(len > 0);
+      assert(strstr(resp, "\"type\":\"server_error\""));
+      assert(strstr(resp, "no agent configured"));
+      /* aimee-internal faults stamp error.code (>=1000) into the body. */
+      assert(strstr(resp, "\"code\":1001"));
+      /* code 0 is identical to the plain formatter — no code field. */
+      openai_format_error_code(resp, sizeof(resp), "server_error", "x", 0);
+      assert(!strstr(resp, "\"code\""));
+      /* slug table stays in sync with the enum. */
+      assert(strcmp(aimee_err_slug(AIMEE_ERR_NO_PRIMARY), "no_primary") == 0);
+      assert(strcmp(aimee_err_slug(AIMEE_ERR_ROUTE_UNRESOLVED), "route_unresolved") == 0);
+      assert(strcmp(aimee_err_slug(AIMEE_ERR_BREAKER_OPEN), "breaker_open") == 0);
+      assert(strcmp(aimee_err_slug(4242), "unknown") == 0);
    }
 
    /* --- optional sampling-field readers --- */


### PR DESCRIPTION
## Motivation

While debugging why codex was unreachable on `.254`, a `/v1/messages` request fast-failed with `502 "failed to reach the primary provider"` in ~0.6s. That 502 sent debugging toward MiniMax/codex **upstream** — but the real cause was internal: `agent_resolve_auth` couldn't resolve the codex-oauth token, so the request **never left the box**. A 502 (Bad Gateway) means the *upstream* misbehaved; using it for an aimee-internal fault is actively misleading (a circuit breaker declining to call a provider looks identical to a dead provider).

## Change

New `aimee_errors.h` defines aimee-internal error codes in a range HTTP never uses (**≥1000**). These ride in:
- the JSON error body as `error.code`, and
- the ingress log line (`aimee_err=1002 (route_unresolved) status=503 …`),

while the **wire HTTP status stays a standard 3-digit code**, chosen honestly:
- **503** — "this service can't serve the request now" (no primary, route/credentials unresolved, breaker),
- **500** — internal fault (pipeline),
- **502** — reserved strictly for a *genuine upstream provider* non-200.

The 4-digit code never touches the status line, so strict clients (the Anthropic SDK, proxies) are unaffected. The parity passthrough that relays upstream status verbatim is untouched.

### Reclassified (Anthropic `/v1/messages`)
| condition | before | after |
|---|---|---|
| endpoint/credentials unresolved | `502` | `503` + `AIMEE_ERR_ROUTE_UNRESOLVED` (1002), message now names the agent + auth reason (D6) |
| no primary agent | `503` | `503` + `AIMEE_ERR_NO_PRIMARY` (1001) |
| request pipeline failed | `500` | `500` + `AIMEE_ERR_REQUEST_PIPELINE` (1003) |
| genuine upstream non-200 | `502` | `502`, **no** aimee code (correctly external) |

### OpenAI-compat `/v1/chat/completions`
Already returned honest `503`s; `openai_format_error_code` now stamps the same body `code`. The formatter stays pure (no logging dependency, so no `log.o` ripple into shape tests).

`AIMEE_ERR_BREAKER_OPEN` / `AIMEE_ERR_CONCURRENCY_LIMIT` are defined for the delegate/runtime path (`agent_runtime.c`, `provider_catalog.c`) to adopt next — that path surfaces errors as agent-turn results, not HTTP 502s, so it's a separate follow-up.

## Test
`test_openai_shape`: coded envelope stamps `error.code:1001`, the plain formatter omits `code`, and the slug table matches the enum. Server builds clean under `-Werror`.