### PR TITLE
feat(delegate-sandbox): fail-closed guard when the runtime ignores --network none

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (183)
+## CLI-settable keys (184)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -56,6 +56,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `delegate_graph_context_enabled` | bool | Prepend a structural code-graph context block (callers/dependencies of files a delegate task references) to the delegate prompt (advisory, fail-open, default off). |
 | `delegate_sandbox` | bool | Run a delegate's shell and file ops INSIDE its own container (via the `docker` delegate backend) instead of in-process in aimee-server. Off (the default) a delegate's `bash`/read/write/list run with aimee-server's filesystem and environment. This is not yet a full sandbox on its own: the container still has a network, so `require_aimee_git` and the credential strip remain the live boundary. The delegate image must carry whatever the work needs (a toolchain, or `verify` fails). The server logs OFF/INERT/ARMED at boot, probing `docker version` — check it, because an unreachable daemon means every delegate runs on the host (default off). |
 | `delegate_sandbox_package_access` | string | Runtime package-access policy for a `--network none` delegate sandbox. aimee always performs and logs the fetch (the delegate holds no outside socket); this selects how much: `proxy` (default) proxies package-manager fetches to any host — egress-via-aimee, for out-of-the-box functionality; `off` no runtime proxy (build-time installs + learned pre-bake only); `gated` host-allowlisted registries, off-allowlist requires human approval; `governance` allowlist from a governance provider, off-allowlist refused. Only meaningful when `delegate_sandbox` is on. |
+| `delegate_sandbox_require_isolation` | bool | Fail-closed guard for the `--network none` delegate sandbox (default off; only meaningful when `delegate_sandbox` is on). aimee always passes `--network none`, but some runtimes ignore it and give the sandbox real egress, defeating the package-access proxy. After the container starts aimee asks the host daemon whether a network with an IP is attached and always logs an error on a breach; when this is set, sandboxing is mandatory — aimee refuses to run the delegate at all (rather than fall back to un-isolated in-process host execution) on any failure to isolate: a breach, an unverifiable probe, docker being unavailable, or a failed acquire. |
 | `dogfood_autolabel_continuation` | bool | Auto-label continuation turns for dogfood capture. |
 | `dogfood_autolabel_repair` | bool | Auto-label repair turns for dogfood capture. |
 | `dogfood_autolabel_repeat_question` | bool | Auto-label repeated-question turns. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -185,6 +185,14 @@ CFG_KEY_DESC = {
     "(build-time installs + learned pre-bake only); `gated` host-allowlisted registries, "
     "off-allowlist requires human approval; `governance` allowlist from a governance provider, "
     "off-allowlist refused. Only meaningful when `delegate_sandbox` is on.",
+    "delegate_sandbox_require_isolation": "Fail-closed guard for the `--network none` delegate "
+    "sandbox (default off; only meaningful when `delegate_sandbox` is on). aimee always passes "
+    "`--network none`, but some runtimes ignore it and give the sandbox real egress, defeating the "
+    "package-access proxy. After the container starts aimee asks the host daemon whether a network "
+    "with an IP is attached and always logs an error on a breach; when this is set, sandboxing is "
+    "mandatory — aimee refuses to run the delegate at all (rather than fall back to un-isolated "
+    "in-process host execution) on any failure to isolate: a breach, an unverifiable probe, docker "
+    "being unavailable, or a failed acquire.",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress "
     "(memory/code preview envelope on primary ingress turns; default on).",

--- a/src/config.c
+++ b/src/config.c
@@ -331,6 +331,7 @@ static const config_schema_entry_t config_schema[] = {
     {"delegate_sandbox", SCHEMA_BOOL, 0},
     {"delegate_sandbox_image", SCHEMA_STRING, 0},
     {"delegate_sandbox_package_access", SCHEMA_STRING, 0}, /* valid: proxy|off|gated|governance */
+    {"delegate_sandbox_require_isolation", SCHEMA_BOOL, 0},
     {"guardrails", SCHEMA_OBJECT, 0},
     {"toolsets", SCHEMA_OBJECT, 0},
     {"script", SCHEMA_OBJECT, 0},
@@ -572,6 +573,8 @@ static void config_set_defaults(config_t *cfg)
    snprintf(cfg->guardrail_mode, sizeof(cfg->guardrail_mode), "%s", MODE_APPROVE);
    snprintf(cfg->delegate_sandbox_package_access, sizeof(cfg->delegate_sandbox_package_access),
             "proxy");
+   cfg->delegate_sandbox_require_isolation =
+       0; /* default OFF: breach degrades loudly, not fatally */
    snprintf(cfg->provider, sizeof(cfg->provider), "claude");
    cfg->compact_enabled = 1; /* default on; set before no-config early returns */
    cfg->coord_closet_enabled =
@@ -1259,6 +1262,10 @@ int config_load_file(config_t *cfg)
               "aimee: config warning: delegate_sandbox_package_access: unknown value \"%s\" — "
               "keeping default \"proxy\" (valid: proxy, off, gated, governance)\n",
               item->valuestring);
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "delegate_sandbox_require_isolation");
+   if (cJSON_IsBool(item))
+      cfg->delegate_sandbox_require_isolation = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "typed_facts_enabled");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -110,6 +110,8 @@ const config_field_t config_fields[] = {
     {"delegate_sandbox", offsetof(config_t, delegate_sandbox), sizeof(int), 0, CFG_BOOL},
     {"delegate_sandbox_package_access", offsetof(config_t, delegate_sandbox_package_access),
      sizeof(((config_t *)0)->delegate_sandbox_package_access), 0, CFG_STRING},
+    {"delegate_sandbox_require_isolation", offsetof(config_t, delegate_sandbox_require_isolation),
+     sizeof(int), 0, CFG_BOOL},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_pdf_ingest_enabled", offsetof(config_t, kb_pdf_ingest_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_pdf_vector_enabled", offsetof(config_t, kb_pdf_vector_enabled), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -877,6 +877,8 @@ int config_save(const config_t *cfg)
        strcmp(cfg->delegate_sandbox_package_access, "proxy") != 0)
       cJSON_AddStringToObject(root, "delegate_sandbox_package_access",
                               cfg->delegate_sandbox_package_access);
+   if (cfg->delegate_sandbox_require_isolation) /* default off: persist only the opt-in */
+      cJSON_AddBoolToObject(root, "delegate_sandbox_require_isolation", 1);
    /* typed_facts_enabled is KB-owned: persisted as kb.typed_facts.enabled by
     * config_save_kb_curator (still parsed at root for backward compat). */
    if (cfg->kb_pdf_ingest_enabled) /* default-off: persist only when enabled */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -480,6 +480,21 @@ typedef struct config
     * See docs/proposals/pending/delegate-sandbox-image-customization.md. */
    char delegate_sandbox_package_access[32];
 
+   /* delegate_sandbox_require_isolation: fail-closed guard (default 0, OFF) for the
+    * `--network none` sandbox, meaningful only when delegate_sandbox is ON. aimee always
+    * passes --network none, but some container runtimes (e.g. SmoothNAS/tierd, which
+    * attaches a "primary" veth that cannot be disconnected) ignore it and give the
+    * sandbox real egress — silently defeating the package-access proxy/allowlist. After
+    * the container starts aimee asks the host daemon whether a network with an IP is
+    * attached; on a breach it ALWAYS logs an error. When this flag is set, sandboxing is
+    * MANDATORY: rather than fall back to un-isolated in-process host execution, aimee
+    * refuses to run the delegate at all on ANY failure to achieve an isolated sandbox —
+    * a detected breach, an unverifiable probe, the docker backend being unavailable, or
+    * the container failing to acquire. Default OFF so a non-compliant runtime degrades
+    * loudly instead of breaking every delegate; set true once the runtime honours
+    * isolation. */
+   int delegate_sandbox_require_isolation;
+
    /* Gateway tool-policing (P2): when on, the gateway strips subagent-spawning
     * tools (Task/Agent/spawn_agent/RemoteTrigger) from the inbound `tools` of a
     * proxied /v1/messages or /v1/chat/completions request, so the served model is

--- a/src/headers/delegate_backend.h
+++ b/src/headers/delegate_backend.h
@@ -35,6 +35,13 @@ extern "C"
     * allocation. */
 #define DELEGATE_BACKEND_MAX 16
 
+   /* acquire() return code for a HARD isolation refusal: the sandbox could not be
+    * proven network-isolated and delegate_sandbox_require_isolation is set, so the
+    * backend tore the container down and the delegate MUST NOT run. This is distinct
+    * from a generic -1 acquire failure (which falls back to in-process execution): a
+    * hard refusal must abort the delegation, never degrade to a less-isolated path. */
+#define DELEGATE_ACQUIRE_REFUSED_ISOLATION (-2)
+
    /* Per-acquire configuration that the caller passes through. The
     * fields are advisory — backends silently ignore values they do not
     * use (e.g., `image` is meaningless to the local backend). */
@@ -66,6 +73,11 @@ extern "C"
        * in-container package forwarder + http_proxy env. The caller resolves the mode
        * (it already loads config) so the backend stays config-agnostic. */
       int pkg_proxy;
+      /* 1 when delegate_sandbox_require_isolation is set: after the sandbox starts, the
+       * docker backend probes it for network egress (a runtime may ignore --network
+       * none) and FAILS the acquire if the sandbox is not isolated. When 0 a breach is
+       * logged but the delegate still runs. Resolved by the caller (config-agnostic). */
+      int require_isolation;
    } delegate_backend_config_t;
 
    /* Result of an `exec` call. `stdout_buf` and `stderr_buf` are

--- a/src/headers/workspace_turn.h
+++ b/src/headers/workspace_turn.h
@@ -28,13 +28,19 @@ int workspace_turn_bind_active(const char *cwd);
  * it :ro — required whenever the tree is not the delegate's own, because a
  * delegate's changes must not leave its container: a shared tree must be
  * unwritable at the MOUNT, not merely guarded above it. Returns 1 if bound (pair it
- * with workspace_turn_unbind_active, which also RELEASES the container), 0
- * otherwise.
+ * with workspace_turn_unbind_active, which also RELEASES the container), 0 for the
+ * benign in-process fallback, or -1 for a HARD refusal (do not run the delegate at
+ * all — see below).
  *
  * Returns 0 — leaving the turn in-process, exactly as today — when the
  * `delegate_sandbox` config dial is off (the default), or when the docker backend
  * is unavailable, or the container cannot be acquired. Those last two are LOGGED at
  * ERROR: falling back silently would run the delegate on the host while the
+ *
+ * Returns -1 — the caller MUST abort the delegation, not fall back to in-process —
+ * when `delegate_sandbox_require_isolation` is set and the runtime did not provide a
+ * network-isolated sandbox (e.g. it ignored --network none). Running in-process on
+ * the host would be even less isolated, so a hard refusal must never degrade.
  * operator believes it is sandboxed.
  *
  * Unlike workspace_turn_bind_active this is not cwd-driven: a container provider

--- a/src/server/delegate_backend_docker.c
+++ b/src/server/delegate_backend_docker.c
@@ -229,6 +229,60 @@ static int run_docker(const char *const argv[])
    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
 }
 
+#define DOCKER_PROBE_TIMEOUT_MS 15000
+
+/* Determine whether the running sandbox `container` was actually isolated by the
+ * runtime, i.e. whether `--network none` was honoured. Asks the HOST daemon (not a
+ * binary inside the untrusted image, so distroless/scratch images are fine) for the
+ * container's attached networks and their IPs:
+ *   0  = isolated   (no attached network, or only the "none" network with no IP)
+ *   1  = has network (a non-"none" network is attached OR some network has an IP —
+ *                     the runtime gave the sandbox real egress; ANY assigned address
+ *                     counts, so a subnet-only/link-local route cannot slip past)
+ *  -1  = undetermined (the inspect probe could not run)
+ * The caller decides what an undetermined result means (fail-closed under enforce). */
+static int docker_sandbox_network_state(const char *container)
+{
+   const char *argv[] = {
+       resolve_docker_bin(),
+       "inspect",
+       "--format",
+       "{{range $k,$v := .NetworkSettings.Networks}}{{$k}}={{$v.IPAddress}};{{end}}",
+       container,
+       NULL};
+   char *out = NULL;
+   if (safe_exec_capture_cwd_env_timeout(argv, NULL, NULL, &out, 65536, DOCKER_PROBE_TIMEOUT_MS) !=
+       0)
+   {
+      free(out);
+      return -1;
+   }
+   int has_net = 0;
+   if (out)
+   {
+      char *save = NULL;
+      for (char *tok = strtok_r(out, ";\n", &save); tok; tok = strtok_r(NULL, ";\n", &save))
+      {
+         char *eq = strchr(tok, '=');
+         if (!eq)
+            continue;
+         *eq = '\0';
+         const char *name = tok, *ip = eq + 1;
+         while (*name == ' ' || *name == '\t')
+            name++;
+         while (*ip == ' ' || *ip == '\t')
+            ip++;
+         if (ip[0] || (name[0] && strcmp(name, "none") != 0))
+         {
+            has_net = 1;
+            break;
+         }
+      }
+   }
+   free(out);
+   return has_net;
+}
+
 /* Read a linked worktree's `.git` pointer file: "gitdir: <absolute path>".
  * Returns 0 and fills `out` on success. */
 static int docker_read_gitlink(const char *gitfile, char *out, size_t outsz)
@@ -685,6 +739,47 @@ static int docker_acquire(delegate_backend_t *self, const char *task_id,
       {
          free(st);
          return -1;
+      }
+   }
+
+   /* Verify the runtime honoured --network none. Some container runtimes (e.g.
+    * SmoothNAS/tierd, which attaches a primary veth that cannot be disconnected) ignore
+    * it, giving the sandbox real egress and silently defeating the package-access proxy
+    * and its allowlist. Probe now that the container is up (covers create AND resume). */
+   {
+      int net = docker_sandbox_network_state(st->container_name);
+      int enforce = cfg && cfg->require_isolation;
+      /* Under enforce, an UNDETERMINED result (-1) is also a refusal: we will not run a
+       * delegate we cannot prove is isolated. Under warn-only, only a confirmed breach
+       * (1) is worth an error; an undetermined probe is a quiet warning. */
+      if (net == 1 || (enforce && net != 0))
+      {
+         if (net == 1)
+            aimee_log(LOG_ERROR, "delegate-sandbox",
+                      "container %s has network egress despite --network none: the runtime did "
+                      "not honour network isolation, so the delegate can reach the network "
+                      "directly and BYPASS the package-access proxy/allowlist%s",
+                      st->container_name,
+                      enforce ? " — refusing to run (delegate_sandbox_require_isolation)"
+                              : " — set delegate_sandbox_require_isolation=true to refuse");
+         else /* undetermined + enforce */
+            aimee_log(LOG_ERROR, "delegate-sandbox",
+                      "container %s: could not verify network isolation and "
+                      "delegate_sandbox_require_isolation is set — refusing to run",
+                      st->container_name);
+         if (enforce)
+         {
+            const char *rm_argv[] = {"docker", "rm", "-f", st->container_name, NULL};
+            (void)run_docker(rm_argv);
+            free(st);
+            return DELEGATE_ACQUIRE_REFUSED_ISOLATION;
+         }
+      }
+      else if (net == -1) /* undetermined, warn-only: note it without failing */
+      {
+         aimee_log(LOG_WARN, "delegate-sandbox",
+                   "container %s: could not verify network isolation (probe failed)",
+                   st->container_name);
       }
    }
 

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1406,20 +1406,34 @@ void delegate_worker(void *arg)
            ? 0
            : workspace_turn_bind_container(deleg_id, sbx_image_arg, container_ws, container_ws_ro);
 
-   server_delegate_heartbeat_begin(cctx->background_job_id);
-   rc = delegate_run_with_credential_retry(&acfg, target_agent, role, system_prompt, run_prompt,
-                                           max_tokens, force_tools, delegate_allows_writes,
-                                           leased_cred_name, sizeof(leased_cred_name),
-                                           credential_state_path, &result);
-   server_delegate_heartbeat_end();
+   if (container_bound < 0)
+   {
+      /* HARD isolation refusal (delegate_sandbox_require_isolation): the runtime would
+       * not provide a network-isolated sandbox. Refuse the delegation rather than fall
+       * back to the in-process host path, which has NO isolation at all. */
+      memset(&result, 0, sizeof(result));
+      snprintf(result.error, sizeof(result.error),
+               "delegate sandbox isolation required but unavailable: the container runtime did "
+               "not honour --network none; refusing to run the delegate un-isolated");
+      rc = -1;
+   }
+   else
+   {
+      server_delegate_heartbeat_begin(cctx->background_job_id);
+      rc = delegate_run_with_credential_retry(&acfg, target_agent, role, system_prompt, run_prompt,
+                                              max_tokens, force_tools, delegate_allows_writes,
+                                              leased_cred_name, sizeof(leased_cred_name),
+                                              credential_state_path, &result);
+      server_delegate_heartbeat_end();
+   }
    concurrency_release_owner(conc_slot, deleg_id);
    delegate_run_ctx_restore(&run_ctx);
    if (detached_bound) /* unbind last: keep the binding live for any teardown that consults it */
       workspace_turn_unbind_active();
    /* Same call, and never both (see the bind): it clears the active pointer AND
-    * releases the container. Unconditional on this path so a pooled worker thread
-    * cannot carry a dead container into the next delegation. */
-   if (container_bound)
+    * releases the container. Only when a container was actually bound (>0); a hard
+    * isolation refusal (<0) already tore the container down and set no active binding. */
+   if (container_bound > 0)
       workspace_turn_unbind_active();
    if (ephemeral_ws[0])
    {

--- a/src/server/workspace_turn.c
+++ b/src/server/workspace_turn.c
@@ -361,10 +361,17 @@ int workspace_turn_bind_container(const char *task_id, const char *image, const 
    if (!cfg.delegate_sandbox)
       return 0; /* default off: the delegate keeps running in-process, as today */
 
+   /* When set, sandboxing is MANDATORY: any path below that would otherwise fall back
+    * to un-isolated in-process host execution instead returns -1 (hard refuse), so the
+    * delegate does not run rather than run un-sandboxed. Only meaningful once we are
+    * past the dial check (sandboxing was actually requested). */
+   int require_iso = cfg.delegate_sandbox_require_isolation;
+   int fallback = require_iso ? -1 : 0;
+
    char ws_real[MAX_PATH_LEN] = "";
    if (workspace && workspace[0] &&
        !workspace_turn_workspace_authorized(workspace, ws_real, sizeof(ws_real)))
-      return 0; /* refused + logged; the turn stays in-process */
+      return fallback; /* refused + logged; in-process (or hard-refuse under require_iso) */
 
    delegate_backend_t *b = delegate_backend_lookup("docker");
    if (!b || !b->acquire)
@@ -375,9 +382,11 @@ int workspace_turn_bind_container(const char *task_id, const char *image, const 
        * "enabled but inert" bug we have shipped. */
       LOG_ERROR("delegate-sandbox",
                 "delegate_sandbox is ON but the docker backend is unavailable; delegate '%s' would "
-                "run on the HOST — refusing to bind, the turn stays in-process and unsandboxed",
-                task_id);
-      return 0;
+                "run on the HOST — refusing to bind%s",
+                task_id,
+                require_iso ? " and refusing to run (delegate_sandbox_require_isolation)"
+                            : ", the turn stays in-process and unsandboxed");
+      return fallback;
    }
 
    delegate_backend_config_t bcfg = {
@@ -386,21 +395,34 @@ int workspace_turn_bind_container(const char *task_id, const char *image, const 
        .hibernate_on_exit = 0,
        .workspace = ws_real[0] ? ws_real : NULL,
        .workspace_read_only = workspace_read_only,
-       .pkg_proxy = (strcmp(cfg.delegate_sandbox_package_access, "proxy") == 0)};
+       .pkg_proxy = (strcmp(cfg.delegate_sandbox_package_access, "proxy") == 0),
+       .require_isolation = cfg.delegate_sandbox_require_isolation};
    void *state = NULL;
-   if (b->acquire(b, task_id, &bcfg, &state) != 0 || !state)
+   int arc = b->acquire(b, task_id, &bcfg, &state);
+   if (arc == DELEGATE_ACQUIRE_REFUSED_ISOLATION)
    {
+      /* HARD refuse: the sandbox could not be proven isolated and require_isolation is
+       * set. Signal the caller to abort the delegation — it must NOT fall back to the
+       * in-process host path (which is even less isolated than the container). */
       LOG_ERROR("delegate-sandbox",
-                "delegate '%s': could not acquire a container (image=%s); the turn stays "
-                "in-process and unsandboxed",
-                task_id, bcfg.image ? bcfg.image : "<default>");
-      return 0;
+                "delegate '%s': refusing to run — sandbox network isolation required "
+                "(delegate_sandbox_require_isolation) but the runtime did not provide it",
+                task_id);
+      return -1;
+   }
+   if (arc != 0 || !state)
+   {
+      LOG_ERROR("delegate-sandbox", "delegate '%s': could not acquire a container (image=%s); %s",
+                task_id, bcfg.image ? bcfg.image : "<default>",
+                require_iso ? "refusing to run (delegate_sandbox_require_isolation)"
+                            : "the turn stays in-process and unsandboxed");
+      return fallback;
    }
 
    if (ws_container_provider_init(&t_turn_container, b, state) != 0)
    {
       b->release(b, state, 0);
-      return 0;
+      return fallback;
    }
    workspace_provider_set_active(&t_turn_container.base);
    t_turn_container_backend = b;


### PR DESCRIPTION
## The gap (found during the .254 hardware E2E)

The delegate sandbox's whole security model is `docker --network none`: no route out, so aimee's package-access proxy is the only egress path. Validating the proxy live on `.254` (SmoothNAS/tierd runtime), I found the runtime **silently defeats this**:

- A `--network none` container reports `NetworkMode=none` but `docker inspect` shows an attached **`veth0` with `IPAddress 10.100.0.10, Gateway 10.100.0.1`**.
- Inside it: `eth0` present, DNS resolves, direct TCP to `1.1.1.1:443` and `:53` both succeed with no proxy.
- `docker network disconnect` is refused ("primary network cannot be disconnected").

So on that runtime a delegate has full direct egress and can bypass the proxy, allowlist, and SSRF guard. aimee's code is correct (it passes `--network none`); the runtime overrides it.

## The guard (defence-in-depth)

After the sandbox container starts, the docker backend asks the **host daemon** (`docker inspect .NetworkSettings.Networks`) whether any network with an IP is attached — a host-side check, so it needs no binary inside the untrusted image (distroless is fine), and any assigned address counts (a subnet-only or link-local/metadata route can't slip past a default-route-only check). A confirmed breach is **always logged**.

New config **`delegate_sandbox_require_isolation`** (default off) makes it **fail closed**: when set, sandboxing is mandatory and aimee refuses to run the delegate at all — rather than fall back to in-process host execution, which has *no* isolation and is strictly worse than the un-isolated container — on **any** failure to isolate: a detected breach, an unverifiable probe, the docker backend being unavailable, or a failed acquire. The refusal is threaded as a distinct `DELEGATE_ACQUIRE_REFUSED_ISOLATION` → `bind_container` returns `-1` → `server_compute` aborts the delegation (never reaches `delegate_run`). Default off so a non-compliant runtime degrades loudly instead of breaking every delegate.

The probe uses a bounded timeout, so it cannot wedge an acquire. Config resolved in `workspace_turn` and passed via `delegate_backend_config_t.require_isolation`, keeping the backend config-agnostic.

## Review

Adversarially reviewed in two rounds (the .254 roundtable's synthesis is currently down, so an equivalent independent adversarial pass was used). Round 1 caught a **critical** inversion — returning `-1` on breach collapsed into the benign in-process fallback, making enforce mode *more* dangerous; fixed with the distinct hard-refuse code + `server_compute` abort. Round 2 **APPROVED** and flagged that fail-closed should also cover backend-unavailable/acquire-failure — now done. Also hardened the probe from an in-container `/proc/net/route` read to the host-side `docker inspect` (robust to minimal images; catches any assigned IP).

## Follow-up (separate, out of this repo)

The root fix is in the tierd/SmoothNAS runtime so it honours `--network none`. Tracked separately; this PR is aimee's defence-in-depth so the security model never silently degrades regardless of runtime.