### PR TITLE
feat(ir): wire response-side shadow live (Slice 2)

### DIFF
--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -525,6 +525,15 @@ static int messages_buffered(const char *body, char *resp, int cap)
           * *parsed on failure), matching the driver hooks. */
          agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, &parsed);
 
+      /* Slice 2 (canonical-IR): shadow-compare the legacy parse against the IR
+       * response parse -> RESP_MATCH / RESP_MISMATCH on GET /v1/dashboard/metrics.
+       * No-op unless AIMEE_IR_SHADOW; never affects the served reply. Provider wire
+       * is anthropic when the primary is anthropic, else OpenAI chat (codex is SSE,
+       * so provider_resp is NULL here and the compare self-skips). */
+      aimee_ir_shadow_compare_response(&parsed, provider_resp,
+                                       driver_is_anthropic(driver) ? AIMEE_WIRE_ANTHROPIC
+                                                                   : AIMEE_WIRE_OPENAI_CHAT);
+
       /* P2c (response-side tool policing, buffered). Drops any `tool_use` block
        * the model emitted despite the request-side strip, before the audit row
        * reads parsed.stop_reason (so the audit log matches the wire) and before
@@ -992,6 +1001,12 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                else
                   /* No driver: default to the openai wire via the IR. */
                   agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, &parsed);
+               /* Slice 2 (canonical-IR): shadow-compare legacy vs IR response parse
+                * (RESP_MATCH / RESP_MISMATCH). No-op unless AIMEE_IR_SHADOW. */
+               aimee_ir_shadow_compare_response(&parsed, provider_resp,
+                                                driver_is_anthropic(driver)
+                                                    ? AIMEE_WIRE_ANTHROPIC
+                                                    : AIMEE_WIRE_OPENAI_CHAT);
                gateway_policy_police_parsed_response(&parsed);
                emit_message_as_sse(&parsed, msg_id, model, emit, ctx);
                /* Cost accounting (mirror the buffered path). */

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -158,6 +158,16 @@ static int driver_is_anthropic(const delegate_driver_t *driver)
    return driver && driver->name && strcmp(driver->name, "anthropic") == 0;
 }
 
+/* Provider wire for the response-side IR shadow: compare_response re-parses the
+ * provider reply through this backend, so it must match the wire the legacy path
+ * parsed. driver_is_anthropic() is NULL-safe, so a NULL/absent driver yields
+ * OpenAI-chat -- exactly the no-driver legacy branch, which parses with
+ * agent_ir_parse_json_response with the openai wire (0). */
+static aimee_wire_t shadow_provider_wire(const delegate_driver_t *driver)
+{
+   return driver_is_anthropic(driver) ? AIMEE_WIRE_ANTHROPIC : AIMEE_WIRE_OPENAI_CHAT;
+}
+
 static int driver_consumes_system_prompt(const delegate_driver_t *driver, const agent_t *ag)
 {
    driver_caps_t caps;
@@ -530,9 +540,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
        * No-op unless AIMEE_IR_SHADOW; never affects the served reply. Provider wire
        * is anthropic when the primary is anthropic, else OpenAI chat (codex is SSE,
        * so provider_resp is NULL here and the compare self-skips). */
-      aimee_ir_shadow_compare_response(&parsed, provider_resp,
-                                       driver_is_anthropic(driver) ? AIMEE_WIRE_ANTHROPIC
-                                                                   : AIMEE_WIRE_OPENAI_CHAT);
+      aimee_ir_shadow_compare_response(&parsed, provider_resp, shadow_provider_wire(driver));
 
       /* P2c (response-side tool policing, buffered). Drops any `tool_use` block
        * the model emitted despite the request-side strip, before the audit row
@@ -1004,9 +1012,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                /* Slice 2 (canonical-IR): shadow-compare legacy vs IR response parse
                 * (RESP_MATCH / RESP_MISMATCH). No-op unless AIMEE_IR_SHADOW. */
                aimee_ir_shadow_compare_response(&parsed, provider_resp,
-                                                driver_is_anthropic(driver)
-                                                    ? AIMEE_WIRE_ANTHROPIC
-                                                    : AIMEE_WIRE_OPENAI_CHAT);
+                                                shadow_provider_wire(driver));
                gateway_policy_police_parsed_response(&parsed);
                emit_message_as_sse(&parsed, msg_id, model, emit, ctx);
                /* Cost accounting (mirror the buffered path). */

--- a/src/tests/support/ir_ingress_stubs.c
+++ b/src/tests/support/ir_ingress_stubs.c
@@ -92,6 +92,18 @@ __attribute__((weak)) void aimee_ir_shadow_observe_request(const void *req, int 
    (void)frontend;
 }
 
+/* Slice 2-wire: the response-side shadow. anthropic_http.o now calls this on the
+ * live buffered paths; the minimal shape/p2c test links do not pull the real
+ * aimee_ir_shadow.o (+ backend parsers), so a weak inert stub resolves the link.
+ * Real aimee_ir_shadow.o wins when linked. */
+__attribute__((weak)) void aimee_ir_shadow_compare_response(const void *legacy,
+                                                            const void *resp_json, int wire)
+{
+   (void)legacy;
+   (void)resp_json;
+   (void)wire;
+}
+
 __attribute__((weak)) int aimee_ir_path_enabled(void)
 {
    return 0;


### PR DESCRIPTION
Implements **Slice 2** of `docs/proposals/pending/ir-sole-path-and-pluggable-stages.md`.

`aimee_ir_shadow_compare_response` had **zero live callers**, so the response-parse parity counters (`ir_resp_match` / `ir_resp_mismatch`) were never populated on real traffic — the metric that gates retiring the response translators (Slice 3+) was blind.

This calls it at the two live buffered response sites where both the legacy `parsed_response_t` and the provider JSON object are in hand (`anthropic_http.c` buffered `/v1/messages` and streaming buffered-replay). Provider wire = anthropic for an anthropic primary, else OpenAI chat; codex is SSE (no JSON object at these sites) so the compare self-skips.

- Self-gating on `AIMEE_IR_SHADOW`; **no effect on the served reply**.
- Counters already surface under `ir` on `GET /v1/dashboard/metrics` (`server_state.c:1454`).
- Edited TU compiles clean under `-Werror`; `compare_response` logic is already covered by `test_ir_shadow_response.c`.

Verification plan: CI build/tests, then confirm `ir_resp_match` increments and `ir_resp_mismatch == 0` on live .254 traffic with `AIMEE_IR_SHADOW` set.