### PR TITLE
agent-tools: default git_status/log/diff path to the session worktree

### DIFF
--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -956,10 +956,16 @@ static char *td_git_log(cJSON *args, const char *name, const char *dispatch_cwd,
    char *result = NULL;
    cJSON *p = cJSON_GetObjectItem(args, "path");
    cJSON *n = cJSON_GetObjectItem(args, "count");
-   if (!p || !cJSON_IsString(p))
-      result = safe_strdup("error: missing 'path' parameter");
+   /* Default the repo to the delegate's session worktree (dispatch_cwd) when the
+    * caller omits 'path' — a delegate does not know its own worktree path, so a
+    * required 'path' forced it to fall back to a raw `git` shell (which the
+    * require_aimee_git gate then denies). Defaulting keeps the aimee git tool
+    * always usable. */
+   const char *path = (p && cJSON_IsString(p) && p->valuestring[0]) ? p->valuestring : dispatch_cwd;
+   if (!path || !path[0])
+      result = safe_strdup("error: git tool requires a session worktree (no 'path' given)");
    else
-      result = tool_git_log(p->valuestring, (n && cJSON_IsNumber(n)) ? n->valueint : 10);
+      result = tool_git_log(path, (n && cJSON_IsNumber(n)) ? n->valueint : 10);
 
    return result;
 }
@@ -1048,10 +1054,12 @@ static char *td_git_diff(cJSON *args, const char *name, const char *dispatch_cwd
    char *result = NULL;
    cJSON *p = cJSON_GetObjectItem(args, "path");
    cJSON *r = cJSON_GetObjectItem(args, "ref");
-   if (!p || !cJSON_IsString(p))
-      result = safe_strdup("error: missing 'path' parameter");
+   /* Default 'path' to the session worktree (see td_git_log). */
+   const char *path = (p && cJSON_IsString(p) && p->valuestring[0]) ? p->valuestring : dispatch_cwd;
+   if (!path || !path[0])
+      result = safe_strdup("error: git tool requires a session worktree (no 'path' given)");
    else
-      result = tool_git_diff(p->valuestring, (r && cJSON_IsString(r)) ? r->valuestring : NULL);
+      result = tool_git_diff(path, (r && cJSON_IsString(r)) ? r->valuestring : NULL);
 
    return result;
 }
@@ -1061,10 +1069,12 @@ static char *td_git_status(cJSON *args, const char *name, const char *dispatch_c
 {
    char *result = NULL;
    cJSON *p = cJSON_GetObjectItem(args, "path");
-   if (!p || !cJSON_IsString(p))
-      result = safe_strdup("error: missing 'path' parameter");
+   /* Default 'path' to the session worktree (see td_git_log). */
+   const char *path = (p && cJSON_IsString(p) && p->valuestring[0]) ? p->valuestring : dispatch_cwd;
+   if (!path || !path[0])
+      result = safe_strdup("error: git tool requires a session worktree (no 'path' given)");
    else
-      result = tool_git_status(p->valuestring);
+      result = tool_git_status(path);
 
    return result;
 }

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -808,12 +808,11 @@ static cJSON *tp_git_log(void)
 {
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
-   tp_prop(props, "path", "string", "Path to the git repository");
+   tp_prop(props, "path", "string",
+           "Path to the git repository (optional — defaults to your session worktree)");
    tp_prop(props, "count", "integer", "Number of commits (default 10)");
    cJSON_AddItemToObject(params, "properties", props);
-   cJSON *req = cJSON_CreateArray();
-   cJSON_AddItemToArray(req, cJSON_CreateString("path"));
-   cJSON_AddItemToObject(params, "required", req);
+   cJSON_AddItemToObject(params, "required", cJSON_CreateArray());
    return params;
 }
 
@@ -840,12 +839,11 @@ static cJSON *tp_git_diff(void)
 {
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
-   tp_prop(props, "path", "string", "Path to the git repository");
+   tp_prop(props, "path", "string",
+           "Path to the git repository (optional — defaults to your session worktree)");
    tp_prop(props, "ref", "string", "Git ref to diff against (optional)");
    cJSON_AddItemToObject(params, "properties", props);
-   cJSON *req = cJSON_CreateArray();
-   cJSON_AddItemToArray(req, cJSON_CreateString("path"));
-   cJSON_AddItemToObject(params, "required", req);
+   cJSON_AddItemToObject(params, "required", cJSON_CreateArray());
    return params;
 }
 
@@ -941,11 +939,10 @@ static cJSON *tp_git_status(void)
 {
    cJSON *params = tp_obj();
    cJSON *props = cJSON_CreateObject();
-   tp_prop(props, "path", "string", "Path to the git repository");
+   tp_prop(props, "path", "string",
+           "Path to the git repository (optional — defaults to your session worktree)");
    cJSON_AddItemToObject(params, "properties", props);
-   cJSON *req = cJSON_CreateArray();
-   cJSON_AddItemToArray(req, cJSON_CreateString("path"));
-   cJSON_AddItemToObject(params, "required", req);
+   cJSON_AddItemToObject(params, "required", cJSON_CreateArray());
    return params;
 }
 

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -2061,6 +2061,48 @@ static void test_parent_write_guard_shell_uses_delegate_cwd_in_git_parent(void)
    free(result);
    platform_test_rmrf(root);
 }
+static void test_git_tools_default_to_session_worktree(void)
+{
+   /* git_status/git_log/git_diff must default 'path' to the delegate's session
+    * worktree (the run_cmd cwd) when omitted. A delegate does not know its own
+    * worktree path, so a hard "missing 'path'" error forced it to a raw `git`
+    * shell — which the require_aimee_git gate then denies, leaving it no working
+    * git route at all. Omitting 'path' must resolve to the cwd, not error. */
+   char root[512];
+   snprintf(root, sizeof(root), "%s/aimee_git_default_cwd_XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(root) != NULL);
+   char cmd[1024];
+   int rc = 0;
+   snprintf(cmd, sizeof(cmd), "git -C '%s' init -q", root);
+   char *out = run_cmd(cmd, &rc);
+   free(out);
+   if (rc != 0)
+   {
+      platform_test_rmrf(root);
+      printf("  git_tools_default_to_session_worktree: skipped (git unavailable)\n");
+      return;
+   }
+
+   run_cmd_set_cwd(root);
+   char *st = dispatch_tool_call("git_status", "{}", 5000);
+   char *lg = dispatch_tool_call("git_log", "{}", 5000);
+   char *df = dispatch_tool_call("git_diff", "{}", 5000);
+   run_cmd_set_cwd(NULL);
+
+   /* None of the three read-only git tools may error for a missing 'path' now
+    * that it defaults to the session worktree. */
+   assert(st != NULL && strstr(st, "requires a session worktree") == NULL &&
+          strstr(st, "missing 'path'") == NULL);
+   assert(lg != NULL && strstr(lg, "requires a session worktree") == NULL &&
+          strstr(lg, "missing 'path'") == NULL);
+   assert(df != NULL && strstr(df, "requires a session worktree") == NULL &&
+          strstr(df, "missing 'path'") == NULL);
+   free(st);
+   free(lg);
+   free(df);
+   platform_test_rmrf(root);
+   printf("  git_tools_default_to_session_worktree: ok\n");
+}
 static void test_tool_list_files(void)
 {
    char tmpdir[512];
@@ -3021,6 +3063,7 @@ int main(void)
    test_container_bash_runs_in_sandbox();
    test_container_execute_script_runs_in_sandbox();
    test_parent_write_guard_shell_uses_delegate_cwd_in_git_parent();
+   test_git_tools_default_to_session_worktree();
    test_tool_list_files();
    test_tool_grep_excludes_heavy_dirs();
    test_dispatch_tool_call();


### PR DESCRIPTION
## Problem

A delegate runs in an isolated worktree and **does not know its own worktree path**. The read-only git tools `git_status`/`git_log`/`git_diff` required a `path` argument and returned `"missing 'path' parameter"` when it was omitted. So the delegate fell back to a **raw `git` shell** — which `require_aimee_git` denies (the `git_*` tools *are* the sanctioned alternative). Net effect: the delegate had **no working git route**, couldn't inspect its state, produced **no-op implementations**, and looped the `impl`/verify gate indefinitely (observed live on `.254`).

## Fix

- `td_git_log`/`td_git_diff`/`td_git_status` now **default `path` to `dispatch_cwd`** (the delegate's session worktree) when omitted — matching how the git *write* tools already resolve the repo from the session.
- The tool schemas (`tp_git_*`) mark `path` **optional** and document the default, so any model/operator reading the schema knows it can be omitted.

Now `git_status`/`git_log`/`git_diff` with no args just work from the delegate's worktree — `aimee git` is always available to delegates.

The git *write* dispatchers (`git_commit`/`git_push`) already resolve the repo from the session and were unaffected.

## Tests

Adds `test_git_tools_default_to_session_worktree`: in a temp git repo with the run_cmd cwd set, `git_status`/`git_log`/`git_diff` with `{}` args must not error for a missing path.

## Review

Roundtable verdict: **"Ship the fix as-is"** — correct, narrowly scoped, safe (defaults to the most restrictive path — the session cwd), consistent with the write tools. Its non-blocking polish (clearer error string, add `git_diff` to the test) is included.