### PR TITLE
Per-agent Primary Agent Only flag; unify tmux CLI output via IR

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -439,11 +439,14 @@ sequenceDiagram
   the same host as the CLI), the tmux session runs locally exactly as before.
 - **Claude via the CLI is primary-only by default.** Claude run via the `claude`
   CLI/tmux login (not an API key) is allowed as the interactive primary but is
-  gated out of delegate routing unless `claude_cli_delegate_enabled` is set,
-  automating a personal Claude subscription as a delegate risks Anthropic account
-  action. The routing above applies to the primary chat turn always, and to a
-  Claude-CLI delegate only when that flag is enabled; this gate is
-  Claude-CLI-specific (other CLI/API agents are unaffected). See
+  gated out of delegate routing whenever its per-agent **Primary Agent Only**
+  flag (`primary_only` in `agents.json`) is set — the Web GUI pre-checks it when
+  you add a claude-oauth subscription, because automating a personal Claude
+  subscription as a delegate risks Anthropic account action. The routing above
+  applies to the primary chat turn always, and to a Claude-CLI delegate only when
+  you uncheck Primary Agent Only for it. The flag is a per-agent choice available
+  to any agent, and replaced the former global `claude_cli_delegate_enabled`
+  opt-in. See
   [DELEGATES.md](DELEGATES.md#claude-via-the-cli-is-primary-only-by-default) and
   [SECURITY.md](SECURITY.md).
 

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -374,8 +374,8 @@ trail (not the host AI's own sub-agent tools, which are blocked).
 > participate. `aimee delegate review --via M` is a *single, exploratory* review
 > that runs tools-on so the reviewer can read the surrounding code, the right
 > tool for "review the auth module", the wrong tool for a panel gate. The panel
-> skips agents that cannot run as a server-side HTTP delegate (e.g. claude-CLI
-> unless `claude_cli_delegate_enabled`) and falls back to another panelist if the
+> skips agents that cannot run as a server-side HTTP delegate and any agent
+> flagged **Primary Agent Only** (`primary_only`), and falls back to another panelist if the
 > aggregator model fails, so one flaky model does not collapse the synthesis.
 
 The panel is configured under `ensemble` in `aimee.yaml`:
@@ -482,13 +482,18 @@ Practical notes:
 #### Claude via the CLI is primary-only by default
 
 Claude run via the `claude` CLI / tmux login, authenticated by the **interactive
-Claude subscription login, not an API key**, is **primary-only by default**. It
-can be your interactive primary (via the web chat or `acp-serve`), but it is **not** eligible as a
-delegate (neither auto-routed nor `aimee delegate … --via claude`). Attempting to
-use it as a delegate fails with a message pointing you here.
+Claude subscription login, not an API key**, is **primary-only by default**. When
+you add a claude-oauth subscription in the Web GUI, the **Primary Agent Only**
+checkbox is pre-checked, which sets the per-agent `primary_only` flag in
+`agents.json`. A primary-only agent can be your interactive primary (via the web
+chat or `acp-serve`), but it is **not** eligible as a delegate (neither
+auto-routed nor `aimee delegate … --via claude`). Attempting to use it as a
+delegate fails with a message pointing you here.
 
-This gate is **Claude-CLI-specific**. It does not affect any other agent: API-key
-/ HTTP agents (`minimax`, `openai`, `anthropic` with a key, `gemini-cli`,
+**Primary Agent Only** is a per-agent choice available to any agent (it replaced
+the former global `claude_cli_delegate_enabled` opt-in); it is simply pre-checked
+for a claude-oauth subscription and left off for every other agent, so API-key /
+HTTP agents (`minimax`, `openai`, `anthropic` with a key, `gemini-cli`,
 `mistral`, …) and other CLI agents (e.g. the Codex CLI) delegate normally.
 
 > ⚠️ **Anthropic account-risk warning.** Using a personal **Claude subscription**
@@ -499,16 +504,12 @@ This gate is **Claude-CLI-specific**. It does not affect any other agent: API-ke
 > automated or delegated Claude workloads, use an **Anthropic API key** (billed
 > per token) instead, add an `anthropic` agent with `--key`.
 
-To opt in anyway, at your own risk:
-
-```bash
-aimee config set claude_cli_delegate_enabled true
-```
-
-This prints the warning once, at the time you enable it. With the flag on,
-Claude-via-CLI may be routed to / selected as a delegate (and, on a thin client,
-runs on the client exactly like the primary path above). Set it back to `false`
-to restore the primary-only default. The default is `false`.
+To allow a claude-oauth agent to act as a delegate anyway, at your own risk,
+**uncheck Primary Agent Only** for it in the Agents tab (or run
+`aimee agent set claude --primary-only off`). With that flag off, Claude-via-CLI
+may be routed to / selected as a delegate (and, on a thin client, runs on the
+client exactly like the primary path above). Re-check it to restore the
+primary-only default.
 
 ### Config format
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -277,7 +277,8 @@ client runs them locally, with `claude` authenticating via the client's own logi
   that network, use TLS / a trusted network for the server endpoint.
 - Claude run via the `claude` CLI login (not an API key) is **primary-only by
   default**, see [DELEGATES.md](DELEGATES.md#claude-via-the-cli-is-primary-only-by-default)
-  for the account-risk rationale and the `claude_cli_delegate_enabled` opt-in.
+  for the account-risk rationale and the per-agent **Primary Agent Only**
+  (`primary_only`) flag that governs it.
 
 ## Explicit Non-Goals
 

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (184)
+## CLI-settable keys (183)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -32,7 +32,6 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `cache_aware_rewrite_enabled` | bool | Rewrite prompts to align with the provider's prompt cache. |
 | `cache_min_chars` | int | Minimum prompt size (chars) before cache-shaping applies. |
 | `cache_shaping_enabled` | bool | Enable prompt cache-shaping. |
-| `claude_cli_delegate_enabled` | bool | Allow delegating to the local Claude CLI agent. |
 | `claude_model` | string | Default Claude model (empty = CLI default). |
 | `client_integrations_enabled` | bool | Auto-register aimee (MCP server, hooks, slash commands) into detected AI-tool user configs — Claude Code (~/.claude), Gemini, Copilot, Codex. Default-ON; set false, or export AIMEE_NO_CLIENT_INTEGRATIONS, to keep aimee out of every tool's global config and wire a single project by hand. |
 | `code_hybrid_rrf_k` | float | Reciprocal Rank Fusion rank constant k for /v1/code/hybrid (default 60). |
@@ -682,7 +681,7 @@ Beyond the config store, aimee reads a few standalone JSON/policy files (paths u
 | `tunnels` | Tunnel definitions. |
 | `user` | Remote user (ssh backend). |
 
-> **Undocumented agent fields** (add to `AGENT_FIELD_DESC`): `exp`, `is_server_hosted`, `refresh_token`
+> **Undocumented agent fields** (add to `AGENT_FIELD_DESC`): `exp`, `is_server_hosted`, `primary_only`, `refresh_token`
 
 ### Toolsets — `AIMEE_TOOLSETS_CONFIG` (or the config `toolsets` map)
 

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -14,6 +14,7 @@ interface AgentCfg {
   cost_tier?: number;
   enabled: boolean;
   tools_enabled?: boolean;
+  primary_only?: boolean;
   max_turns?: number;
   max_parallel?: number;
   context_window?: number;
@@ -398,6 +399,7 @@ function AgentEditModal({
   const [contextWindow, setContextWindow] = useState(String(agent.context_window ?? 0));
   const [tools, setTools] = useState(!!agent.tools_enabled);
   const [enabled, setEnabled] = useState(!!agent.enabled);
+  const [primaryOnly, setPrimaryOnly] = useState(!!agent.primary_only);
   const [roles, setRoles] = useState<string[]>(agent.roles || []);
   const [personas, setPersonas] = useState<string[]>(agent.personas || []);
   const [apiKey, setApiKey] = useState("");
@@ -431,6 +433,7 @@ function AgentEditModal({
       "--context-window", contextWindow || "0",
       "--tools", tools ? "on" : "off",
       "--enabled", enabled ? "true" : "false",
+      "--primary-only", primaryOnly ? "on" : "off",
       "--roles", roles.join(","),
       "--personas", personas.join(","),
     ];
@@ -578,6 +581,13 @@ function AgentEditModal({
             >
               <input type="checkbox" checked={tools} onChange={(e) => setTools(e.target.checked)} disabled={busy} />
               tools enabled
+            </label>
+            <label
+              style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: "#444" }}
+              title="When on, this agent can only be the primary — it is never routed as a delegate. Recommended for a Claude subscription (ToS)."
+            >
+              <input type="checkbox" checked={primaryOnly} onChange={(e) => setPrimaryOnly(e.target.checked)} disabled={busy} />
+              primary agent only
             </label>
           </div>
 

--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -110,8 +110,6 @@ export const FIELD_HELP: Record<string, string> = {
   llm_synth_model: "Model name the synthesizer serves.",
 
   ecomode: "Always route to the cheapest capable agent instead of the default one. Off by default.",
-  claude_cli_delegate_enabled:
-    "Allow the subscription-logged-in Claude CLI to be used as a delegate, not just the primary. Off by default — driving a personal Claude subscription as an automated delegate may breach Anthropic's terms.",
   delegate_graph_context_enabled:
     "Prepend the callers and dependencies of the files a delegate task mentions to its prompt. Advisory, off by default.",
 

--- a/frontend/src/setup/PrimaryChooser.tsx
+++ b/frontend/src/setup/PrimaryChooser.tsx
@@ -152,6 +152,11 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
   // Delegate mode only: the roster name + delegation roles for the new agent.
   const [name, setName] = useState('');
   const [roles, setRoles] = useState('summarize,format,draft');
+  // "Primary Agent Only": when checked the agent can ONLY be the primary, never a
+  // delegate. Pre-checked for a Claude subscription (driving a personal Claude
+  // plan as an automated delegate may breach Anthropic's terms); off for every
+  // other agent. Persisted per-agent (agents.json `primary_only`).
+  const [primaryOnly, setPrimaryOnly] = useState(false);
 
   // Subscription OAuth flow.
   const [oauth, setOauth] = useState<OauthState | null>(null);
@@ -171,12 +176,15 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
     setName(delegate ? `${spec.provider}-delegate` : '');
     setError('');
     setOauth(null);
+    setPrimaryOnly(false); // API-key agents are delegate-eligible by default
   };
   const chooseSub = (spec: SubSpec) => {
     setSelected(spec.kind);
     setError('');
     setOauth(null);
     setCodeBack('');
+    // A Claude subscription defaults to primary-only (ToS); Codex does not.
+    setPrimaryOnly(spec.vendor === 'claude');
   };
   const reset = () => {
     setSelected(null); setError(''); setOauth(null); setCodeBack('');
@@ -207,6 +215,7 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
       } else {
         args.push('--default');
       }
+      args.push('--primary-only', primaryOnly ? 'on' : 'off');
       await postJSON('/api/agents/add', { args });
       await onConfigured(apiSpec.provider);
     } catch (e) {
@@ -221,12 +230,14 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
       const r = await postJSON<{ state?: string; agent?: string; error?: string }>(
         '/api/agents/oauth/poll', { vendor, session });
       if (r.state === 'authenticated') {
-        // Primary mode: promote the freshly-registered vendor agent to the
-        // global primary. A delegate stays an ordinary roster entry.
-        if (!delegate) {
-          const agent = r.agent || vendor;
-          await postJSON('/api/agents/set', { args: [agent, '--default'] });
-        }
+        // Apply the operator's "Primary Agent Only" choice to the freshly
+        // OAuth-registered agent (the server registers a claude subscription
+        // primary-only by default; this honours an unchecked box so it can serve
+        // as a delegate). Primary mode also promotes it to the global primary.
+        const agent = r.agent || vendor;
+        const setArgs = [agent, '--primary-only', primaryOnly ? 'on' : 'off'];
+        if (!delegate) setArgs.push('--default');
+        await postJSON('/api/agents/set', { args: setArgs });
         return 'authenticated';
       }
       if (r.state === 'failed') { setError(r.error || 'Login failed or timed out.'); return 'failed'; }
@@ -235,7 +246,7 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
       setError(e instanceof Error ? e.message : 'Poll failed.');
       return 'failed';
     }
-  }, [delegate]);
+  }, [delegate, primaryOnly]);
 
   const runPoll = useCallback(async (vendor: string, session: string, provider: string) => {
     setPolling(true);
@@ -345,6 +356,7 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
           <div style={{ fontSize: 11.5, color: '#778' }}>
             The key is sealed into aimee-server’s vault — it is never stored in the browser or in agents.json.
           </div>
+          <PrimaryOnlyToggle checked={primaryOnly} disabled={busy} onChange={setPrimaryOnly} />
           <div>
             <button style={primaryBtn} disabled={busy} onClick={submitApi}>
               {busy ? 'Saving…' : delegate ? 'Add delegate' : 'Save & set as primary'}
@@ -362,6 +374,7 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
                 aimee installs the {subSpec.vendor} CLI on the server and starts a login. You’ll get a
                 link to authorize in your browser. This can take up to a minute on first run.
               </p>
+              <PrimaryOnlyToggle checked={primaryOnly} disabled={busy} onChange={setPrimaryOnly} />
               <div>
                 <button style={primaryBtn} disabled={busy} onClick={startSub}>
                   {busy ? 'Starting…' : `Sign in with ${subSpec.label}`}
@@ -426,6 +439,26 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
     <label style={{ display: 'block' }}>
       <div style={{ fontSize: 12.5, fontWeight: 600, marginBottom: 3 }}>{label}</div>
       {children}
+    </label>
+  );
+}
+
+// "Primary Agent Only" checkbox shown in every add flow. Checked = this agent can
+// only be the primary and is never routed as a delegate; unchecked = it may serve
+// as a delegate. Pre-checked for a Claude subscription (see PrimaryChooser).
+function PrimaryOnlyToggle(
+  { checked, disabled, onChange }:
+  { checked: boolean; disabled?: boolean; onChange: (v: boolean) => void },
+) {
+  return (
+    <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, fontSize: 12.5, color: '#556', cursor: disabled ? 'default' : 'pointer' }}>
+      <input type="checkbox" checked={checked} disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)} style={{ marginTop: 2 }} />
+      <span>
+        <strong style={{ color: '#334' }}>Primary Agent Only</strong> — use only as the primary,
+        never as a delegate. Recommended for a Claude subscription: driving a personal Claude plan as
+        an automated delegate may breach Anthropic’s terms.
+      </span>
     </label>
   );
 }

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -104,7 +104,6 @@ CFG_KEY_DESC = {
     "cache_aware_rewrite_enabled": "Rewrite prompts to align with the provider's prompt cache.",
     "cache_min_chars": "Minimum prompt size (chars) before cache-shaping applies.",
     "cache_shaping_enabled": "Enable prompt cache-shaping.",
-    "claude_cli_delegate_enabled": "Allow delegating to the local Claude CLI agent.",
     "delegate_graph_context_enabled": "Prepend a structural code-graph context block (callers/dependencies of files a delegate task references) to the delegate prompt (advisory, fail-open, default off).",
     "memory_md_retire": "Retire the agent file-memory surface into aimee (default on): a Write under ~/.claude/projects/<slug>/memory/<name>.md is intercepted into aimee's db1 and the .md is never materialized; session-start skips .md hydration. Set false for the legacy re-materialized .md mirrors.",
     "claude_model": "Default Claude model (empty = CLI default).",

--- a/src/config.c
+++ b/src/config.c
@@ -414,7 +414,6 @@ static const config_schema_entry_t config_schema[] = {
     {"aimee", SCHEMA_OBJECT, 0},
     {"trigger", SCHEMA_OBJECT, 0},
     {"trigger_rules", SCHEMA_ARRAY, 0},
-    {"claude_cli_delegate_enabled", SCHEMA_BOOL, 0},
     {NULL, 0, 0},
 };
 
@@ -1142,10 +1141,6 @@ int config_load_file(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "verify_enabled");
    if (cJSON_IsBool(item))
       cfg->verify_enabled = cJSON_IsTrue(item);
-
-   item = cJSON_GetObjectItemCaseSensitive(root, "claude_cli_delegate_enabled");
-   if (cJSON_IsBool(item))
-      cfg->claude_cli_delegate_enabled = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "delegate_graph_context_enabled");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -310,8 +310,6 @@ const config_field_t config_fields[] = {
     {"kb_mining_enabled", offsetof(config_t, kb_mining_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_mining_min_poll_s", offsetof(config_t, kb_mining_min_poll_s), sizeof(int), 0, CFG_INT},
     {"verify_enabled", offsetof(config_t, verify_enabled), sizeof(int), 1, CFG_BOOL},
-    {"claude_cli_delegate_enabled", offsetof(config_t, claude_cli_delegate_enabled), sizeof(int), 1,
-     CFG_BOOL},
     {"delegate_graph_context_enabled", offsetof(config_t, delegate_graph_context_enabled),
      sizeof(int), 0, CFG_BOOL},
     {"roundtable.replay_verify_enabled", offsetof(config_t, roundtable_replay_verify_enabled),

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -833,8 +833,6 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "verify_enabled", 1);
    if (cfg->verify_cross_project)
       cJSON_AddBoolToObject(root, "verify_cross_project", 1);
-   if (cfg->claude_cli_delegate_enabled)
-      cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
    if (cfg->delegate_graph_context_enabled)
       cJSON_AddBoolToObject(root, "delegate_graph_context_enabled", 1);
    if (cfg->ingress_preinject_enabled)

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -49,8 +49,9 @@ void agent_set_route_health_filter(int (*fn)(const char *agent_name));
  *   1) the PRIMARY passthrough — the agent named after config.provider — is
  *      never a delegation target (the primary must not delegate back to
  *      itself; roundtables already enforce this for panel seats);
- *   2) a claude-CLI agent is a delegate only behind the explicit ToS-sensitive
- *      operator opt-in (claude_cli_delegate_enabled).
+ *   2) an agent flagged "Primary Agent Only" (agents.json `primary_only`) is
+ *      never a delegation target — the per-agent choice that replaced the global
+ *      claude_cli_delegate_enabled opt-in.
  * The structural half of (2) — a claude-CLI agent that is not server-hosted
  * can never execute as a delegate — is enforced unconditionally in
  * agent_is_available_for_routing, so even filter-less builds (CLI/tests) never
@@ -138,10 +139,11 @@ void agent_request_creds_restore(const agent_request_creds_t *creds);
 
 /* True if `agent` is the Claude CLI (`claude` / `claude-code`) run via tmux or
  * the provider-CLI binary — authenticated by the interactive `claude` login, not
- * an API key. Used to keep Claude-via-CLI primary-only by default (gated as a
- * delegate behind config.claude_cli_delegate_enabled). All other agents,
- * including other CLI agents (Codex CLI, gemini-cli) and API-key/HTTP agents,
- * return 0. */
+ * an API key. Still used for the structural server-hosted delegate rule and by
+ * the OAuth setup path; the primary-only DEFAULT for claude is now expressed as
+ * the per-agent `primary_only` flag set at add time (see agent_t.primary_only).
+ * All other agents, including other CLI agents (Codex CLI, gemini-cli) and
+ * API-key/HTTP agents, return 0. */
 int agent_is_claude_cli(const agent_t *agent);
 
 /* Generalized role dispatch. delegate_pick_for_role returns the index of a

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -274,6 +274,14 @@ typedef struct
     * — distinct from a client-only claude. The roundtable panel seats a
     * server-hosted, authenticated claude; a client-only one stays excluded. */
    int is_server_hosted;
+   /* 1 = this agent may ONLY serve as the primary; it is never a delegation
+    * target. 0 = delegate-eligible (subject to the structural rules in
+    * agent_is_available_for_routing). Replaces the former global
+    * config.claude_cli_delegate_enabled opt-in with a per-agent choice made at
+    * add time: the Web GUI pre-checks "Primary Agent Only" for a claude-oauth
+    * subscription (driving a personal Claude plan as an automated delegate may
+    * breach Anthropic's terms) and leaves it off for every other agent. */
+   int primary_only;
 } agent_t;
 
 typedef struct

--- a/src/headers/aimee_ir.h
+++ b/src/headers/aimee_ir.h
@@ -185,6 +185,15 @@ void aimee_request_free(aimee_request_t *r);
 void aimee_response_free(aimee_response_t *r);
 void aimee_block_free_contents(aimee_block_t *b);
 
+/* Build a canonical assistant response carrying a single TEXT block. This is the
+ * bridge for producers that yield only flat text (the tmux/CLI TUI handler, whose
+ * screen-scrape recovers one text answer) into the unified message IR: the result
+ * is an ordinary aimee_response_t that every IR consumer treats identically to a
+ * provider-parsed one. `model` may be NULL/empty. stop_reason is END_TURN. Fills
+ * caller-provided `out` (stack-ok); free with aimee_response_free. Returns 0 on
+ * success, -1 on allocation failure (out is left freed/zeroed). */
+int aimee_ir_response_from_text(aimee_response_t *out, const char *text, const char *model);
+
 /* ---- accessors used by the core stages / KB ----
  * Concatenate the text of the LAST user-role message's TEXT blocks into `buf`
  * (truncating to n). This is the ONE shape-agnostic query extractor that replaces

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -905,13 +905,6 @@ typedef struct config
     * gating + enforce:true auto-generated config for the current project. */
    int verify_enabled;
 
-   /* Allow Claude run via the `claude` CLI / tmux login (authenticated by the
-    * interactive Claude subscription login, NOT an API key) to be used as a
-    * DELEGATE. Default 0: Claude-via-CLI is primary-only, because driving a
-    * personal Claude subscription as an automated delegate may violate
-    * Anthropic's terms and risk account action. Set to 1 to opt in (see
-    * DELEGATES.md). Does not affect API-key/HTTP agents or other CLI agents. */
-   int claude_cli_delegate_enabled;
    /* §7 code-graph actuation: prepend a structural-context block (callers /
     * dependencies of the file paths a delegate task references) to the delegate's
     * system prompt. Advisory, fail-open, default off (opt-in). */

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -161,14 +161,13 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
 void delegate_roundtable_result_free(roundtable_result_t *r);
 
 /* Seed cfg->ensemble_reference_models from the enabled agents when no panel is
- * configured (no-op if ensemble_reference_count > 0). Skips agents that cannot
- * run as a server-side HTTP delegate (claude-CLI unless
- * claude_cli_delegate_enabled). Defaults the aggregator to the first seated
- * model. */
+ * configured (no-op if ensemble_reference_count > 0). Skips agents flagged
+ * primary-only and claude-CLI agents that cannot run server-side. Defaults the
+ * aggregator to the first seated model. */
 void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acfg);
 
-/* 1 if `ag` may sit on a panel: enabled + named, and a claude-CLI only when
- * authorized (claude_cli_delegate_enabled) AND server-hosted (is_server_hosted). */
+/* 1 if `ag` may sit on a panel: enabled + named, NOT primary-only (agents.json
+ * `primary_only`), and a claude-CLI only when server-hosted (is_server_hosted). */
 int ensemble_panelist_eligible(const config_t *cfg, const agent_t *ag);
 
 /* Replace each "$random" seat in ensemble.reference_models with a concretely

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -2,6 +2,7 @@
 
 #include "aimee.h"
 #include "agent.h"
+#include "aimee_ir.h"
 #include "cli_session.h"
 #include "log.h"
 #include <ctype.h>
@@ -288,7 +289,36 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       return -1;
    }
 
-   out->response = clean;
+   /* Unified message: fold the CLI's screen-scraped answer into the canonical
+    * message IR (one assistant TEXT block), then project it back onto the
+    * agent_result. The tmux/CLI TUI is now just another producer of an
+    * aimee_response_t — the same representation an HTTP-provider parse yields —
+    * so downstream treats this turn as a single unified message instead of a
+    * bespoke plain-text blob, and the tmux path gains a real stop_reason
+    * (end_turn) that the raw-string path never set. */
+   size_t tlen = strlen(clean);
+   aimee_response_t ir;
+   int ir_ok = (aimee_ir_response_from_text(&ir, clean, agent->model) == 0);
+   free(clean);
+   if (!ir_ok)
+   {
+      snprintf(out->error, sizeof(out->error), "out of memory");
+      return -1;
+   }
+   char *resp = malloc(tlen + 1);
+   if (resp)
+      aimee_ir_response_text(&ir, resp, tlen + 1);
+   snprintf(out->stop_reason, sizeof(out->stop_reason), "%s",
+            ir.raw_stop_reason ? ir.raw_stop_reason : aimee_stop_reason_name(ir.stop_reason));
+   aimee_response_free(&ir);
+   if (!resp || !resp[0])
+   {
+      free(resp);
+      snprintf(out->error, sizeof(out->error), "empty response from tmux session");
+      return -1;
+   }
+
+   out->response = resp;
    out->success = 1;
    out->turns = 1;
    return 0;

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -638,6 +638,7 @@ static int chat_agent_select_provider(agent_config_t *acfg, const char *provider
    if (!acfg || !provider || !provider[0])
       return 0;
 
+   /* Prefer an ENABLED agent, by name then by provider. */
    int by_name = -1;
    for (int i = 0; i < acfg->agent_count; i++)
       if (acfg->agents[i].enabled && strcmp(acfg->agents[i].name, provider) == 0)
@@ -658,6 +659,33 @@ static int chat_agent_select_provider(agent_config_t *acfg, const char *provider
    }
 
    int match = by_name >= 0 ? by_name : by_provider;
+
+   /* Auto-use the configured primary even if the operator left it DISABLED. This
+    * selector drives the PRIMARY chat path (`provider` is the configured primary
+    * — cfg.provider or a session-pinned primary), so a disabled agent that IS the
+    * configured primary must still serve the turn. Otherwise a disabled `claude`
+    * both suppressed the built-in fallback (agent_find sees it regardless of
+    * `enabled`) AND failed the enabled-only match above, surfacing the misleading
+    * "provider '…' is not configured as an aimee agent" error for an agent that
+    * is plainly present. Delegate routing is unaffected — it runs through
+    * agent_route_*, which still honours `enabled`. */
+   if (match < 0)
+   {
+      for (int i = 0; i < acfg->agent_count; i++)
+         if (strcmp(acfg->agents[i].name, provider) == 0)
+         {
+            by_name = i;
+            break;
+         }
+      if (by_name < 0)
+         for (int i = 0; i < acfg->agent_count; i++)
+            if (strcmp(acfg->agents[i].provider, provider) == 0)
+            {
+               by_provider = i;
+               break;
+            }
+      match = by_name >= 0 ? by_name : by_provider;
+   }
    if (match < 0)
       return -1;
 
@@ -665,6 +693,9 @@ static int chat_agent_select_provider(agent_config_t *acfg, const char *provider
       acfg->agents[i].enabled = acfg->agents[i].enabled &&
                                 (by_name >= 0 ? strcmp(acfg->agents[i].name, provider) == 0
                                               : strcmp(acfg->agents[i].provider, provider) == 0);
+   /* Force the chosen primary enabled for this turn even if it was disabled on
+    * disk — the operator is actively chatting with it as the primary. */
+   acfg->agents[match].enabled = 1;
 
    snprintf(acfg->default_agent, sizeof(acfg->default_agent), "%s", acfg->agents[match].name);
    acfg->fallback_count = 0;

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -868,6 +868,9 @@ int agent_load_config(agent_config_t *cfg)
          v = cJSON_GetObjectItem(a, "is_server_hosted");
          if (v && cJSON_IsBool(v))
             ag->is_server_hosted = cJSON_IsTrue(v);
+         v = cJSON_GetObjectItem(a, "primary_only");
+         if (v && cJSON_IsBool(v))
+            ag->primary_only = cJSON_IsTrue(v);
 
          agent_normalize_legacy_claude_cli(ag);
          agent_normalize_builtin_cost_tier(ag);
@@ -1137,6 +1140,8 @@ int agent_save_config(const agent_config_t *cfg)
          JSON_ADD_STR(a, "cli_kind", ag->cli_kind);
       if (ag->is_server_hosted)
          cJSON_AddBoolToObject(a, "is_server_hosted", 1);
+      if (ag->primary_only)
+         cJSON_AddBoolToObject(a, "primary_only", 1);
 
       /* Middleware config: only write if any non-zero field is set */
       {
@@ -1462,9 +1467,8 @@ int agent_is_available_for_routing(const agent_t *agent)
    /* A claude-CLI agent can only ever execute as a delegate SERVER-SIDE (a
     * client-only claude has no server session to drive — dispatch would just
     * fail). Structural, so it is enforced even with no policy filter
-    * registered; the config-dependent rules (the claude_cli_delegate_enabled
-    * ToS opt-in, primary self-delegation) live in the registered policy
-    * filter, which sees the live config. */
+    * registered; the per-agent rules (the `primary_only` opt-out, primary
+    * self-delegation) live in the registered policy filter. */
    if (agent_is_claude_cli(agent) && !agent->is_server_hosted)
       return 0;
    if (g_route_policy_filter && g_route_policy_filter(agent))

--- a/src/server/aimee_ir.c
+++ b/src/server/aimee_ir.c
@@ -302,6 +302,36 @@ static size_t ir_concat_blocks(const aimee_block_t *blocks, int n_blocks, aimee_
    return used;
 }
 
+int aimee_ir_response_from_text(aimee_response_t *out, const char *text, const char *model)
+{
+   if (!out)
+      return -1;
+   memset(out, 0, sizeof *out);
+   aimee_block_t *blk = calloc(1, sizeof *blk);
+   out->role = strdup("assistant");
+   out->raw_stop_reason = strdup("end_turn");
+   if (!blk || !out->role || !out->raw_stop_reason)
+   {
+      free(blk);
+      aimee_response_free(out);
+      return -1;
+   }
+   blk->type = AIMEE_BLK_TEXT;
+   blk->text = strdup(text ? text : "");
+   if (!blk->text)
+   {
+      free(blk);
+      aimee_response_free(out);
+      return -1;
+   }
+   out->content = blk; /* owned single-element array; freed by aimee_response_free */
+   out->n_content = 1;
+   out->stop_reason = AIMEE_STOP_END_TURN;
+   if (model && model[0])
+      out->model = strdup(model); /* best-effort; NULL is fine */
+   return 0;
+}
+
 size_t aimee_ir_response_text(const aimee_response_t *r, char *buf, size_t n)
 {
    if (buf && n)

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1244,14 +1244,16 @@ static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const
    return 0;
 }
 
-/* Is `ag` allowed to sit on a roundtable/ensemble panel? Enabled + named, and —
- * for claude-CLI — AUTHORIZED as a delegate (claude_cli_delegate_enabled, the
- * explicit, ToS-sensitive operator opt-in) AND able to run server-side
- * (is_server_hosted, via `aimee agent add claude-oauth`). A client-only claude
- * has no server endpoint and would just burn a slot on a "failed to build request
- * URL" participant; server-hosting is capability, NOT authorization, so both are
- * required. So an unauthorized or disabled claude is never seated, even after a
- * server-side OAuth setup. Other enabled agents are eligible.
+/* Is `ag` allowed to sit on a roundtable/ensemble panel? Enabled + named, NOT
+ * flagged primary-only (agents.json `primary_only` — the per-agent delegate
+ * opt-out that replaced the global claude_cli_delegate_enabled; a claude-oauth
+ * subscription is pre-flagged primary-only for the ToS reason), and — for
+ * claude-CLI — able to run server-side (is_server_hosted, via `aimee agent add
+ * claude-oauth`). A client-only claude has no server endpoint and would just
+ * burn a slot on a "failed to build request URL" participant; server-hosting is
+ * capability, primary_only is authorization, so both must pass. So a
+ * primary-only or disabled claude is never seated, even after a server-side
+ * OAuth setup. Other enabled agents are eligible.
  *
  * The PRIMARY agent is also never seated: a roundtable exists for an INDEPENDENT
  * second opinion, so the model the operator runs as primary (config.provider)
@@ -1266,7 +1268,9 @@ int ensemble_panelist_eligible(const config_t *cfg, const agent_t *ag)
    if (cfg->provider[0] && (strcasecmp(ag->name, cfg->provider) == 0 ||
                             (ag->provider[0] && strcasecmp(ag->provider, cfg->provider) == 0)))
       return 0; /* the primary must never sit on its own panel */
-   if (agent_is_claude_cli(ag) && (!cfg->claude_cli_delegate_enabled || !ag->is_server_hosted))
+   if (ag->primary_only)
+      return 0;
+   if (agent_is_claude_cli(ag) && !ag->is_server_hosted)
       return 0;
    return 1;
 }

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1920,12 +1920,15 @@ static int server_agent_route_is_down(const char *agent_name)
  *    operator's own OAuth claude entry). Matched by NAME only, deliberately:
  *    other agents that merely share the provider tag (e.g. gateway-routed
  *    anthropic models) are legitimate delegates.
- * 2) a claude-CLI agent (tmux/provider-cli claude — the interactive-login
- *    ToS-sensitive class) is a delegate ONLY behind the explicit operator
- *    opt-in claude_cli_delegate_enabled — previously enforced on one dispatch
- *    path and on panel seats, now at every routing decision.
- * A config_load failure fails closed for the gated class (a claude-CLI agent
- * is excluded, everything else routes) rather than voiding the opt-in. */
+ * 2) a per-agent "Primary Agent Only" choice (agents.json `primary_only`)
+ *    excludes the agent from ALL delegation. This replaces the former global
+ *    claude_cli_delegate_enabled opt-in with a per-agent flag set at add time:
+ *    a claude-oauth subscription is pre-flagged primary-only (driving a personal
+ *    Claude plan as an automated delegate may breach Anthropic's terms), every
+ *    other agent defaults off.
+ * Rule 2 is config-independent (it reads the agent record), so a config_load
+ * failure only means rule 1's primary name is unknown — the per-agent gate
+ * still holds. */
 static int server_agent_route_policy_excluded(const agent_t *ag)
 {
    if (!ag)
@@ -1938,11 +1941,10 @@ static int server_agent_route_policy_excluded(const agent_t *ag)
    if (agent_routing_primary_turn())
       return 0;
    config_t cfg;
-   if (config_load(&cfg) != 0)
-      return agent_is_claude_cli(ag);
-   if (cfg.provider[0] && ag->name[0] && strcasecmp(ag->name, cfg.provider) == 0)
+   if (config_load(&cfg) == 0 && cfg.provider[0] && ag->name[0] &&
+       strcasecmp(ag->name, cfg.provider) == 0)
       return 1;
-   if (agent_is_claude_cli(ag) && !cfg.claude_cli_delegate_enabled)
+   if (ag->primary_only)
       return 1;
    return 0;
 }
@@ -2271,8 +2273,8 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
     * for a role is DOWN does routing return a clean "no agent available". */
    agent_set_route_health_filter(server_agent_route_is_down);
    /* Delegate-policy invariants at every routing decision: the primary never
-    * delegates to itself, and a claude-CLI agent is only a delegate behind the
-    * explicit claude_cli_delegate_enabled opt-in. */
+    * delegates to itself, and an agent flagged "Primary Agent Only"
+    * (agents.json `primary_only`) is never a delegation target. */
    agent_set_route_policy_filter(server_agent_route_policy_excluded);
    LOG_INFO("server",
             "initialized (v%s, protocol %d, background=%d session=%d threads); /v1 HTTP "

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -411,6 +411,7 @@ static cJSON *server_agent_to_json(const agent_t *ag)
    cJSON_AddNumberToObject(obj, "cost_tier", ag->cost_tier);
    cJSON_AddBoolToObject(obj, "enabled", ag->enabled);
    cJSON_AddBoolToObject(obj, "tools_enabled", ag->tools_enabled);
+   cJSON_AddBoolToObject(obj, "primary_only", ag->primary_only);
    cJSON_AddNumberToObject(obj, "max_turns", ag->max_turns);
    cJSON_AddNumberToObject(obj, "max_parallel", ag->max_parallel);
    if (ag->middleware.context_window > 0)
@@ -726,6 +727,20 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    ag->timeout_ms = opt_get_int(&opts, "timeout-ms", opt_get_int(&opts, "timeout", ag->timeout_ms));
    ag->middleware.context_window =
        opt_get_int(&opts, "ctx", opt_get_int(&opts, "context-window", 0));
+
+   /* Primary-only: a flagged agent is never a delegation target (replaces the
+    * former global claude_cli_delegate_enabled opt-in with a per-agent choice).
+    * An explicit --primary-only on|off wins; absent, a claude-CLI (tmux) agent
+    * defaults ON — driving a personal Claude plan as an automated delegate may
+    * breach Anthropic's terms — and every other agent defaults OFF. */
+   {
+      const char *po = opt_get(&opts, "primary-only");
+      if (po && po[0])
+         ag->primary_only =
+             (strcmp(po, "off") != 0 && strcmp(po, "false") != 0 && strcmp(po, "0") != 0);
+      else
+         ag->primary_only = agent_is_claude_cli(ag) ? 1 : 0;
+   }
 
    if (opt_has(&opts, "default") || cfg.agent_count == 1 || !cfg.default_agent[0])
       snprintf(cfg.default_agent, sizeof(cfg.default_agent), "%s", ag->name);
@@ -1069,6 +1084,8 @@ int handle_agent_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    }
    if ((v = opt_get(&opts, "enabled")) != NULL)
       ag->enabled = (strcmp(v, "true") == 0 || strcmp(v, "1") == 0 || strcmp(v, "on") == 0);
+   if ((v = opt_get(&opts, "primary-only")) != NULL)
+      ag->primary_only = (strcmp(v, "true") == 0 || strcmp(v, "1") == 0 || strcmp(v, "on") == 0);
    if ((v = opt_get(&opts, "roles")) != NULL)
       server_agent_set_roles_csv(
           ag,
@@ -1231,6 +1248,11 @@ static void sagent_configure_tmux_cli_agent(agent_t *ag, const char *name, const
    ag->max_turns = -1;
    ag->max_parallel = AGENT_DEFAULT_MAX_PARALLEL;
    ag->session_reuse = 1;
+   /* A freshly OAuth'd claude subscription defaults to primary-only: driving a
+    * personal Claude plan as an automated delegate may breach Anthropic's terms.
+    * The Web GUI pre-checks "Primary Agent Only" to match, and can override this
+    * with a follow-up agent.set --primary-only off. */
+   ag->primary_only = 1;
 
    /* Advertise the CLI's real context window so capability routing (min_context
     * floors, e.g. the review role) keeps this agent in the fleet. A tmux-CLI

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -774,7 +774,7 @@ void delegate_worker(void *arg)
     * driver marshals its commands over the reverse channel) against the client's
     * tree, doing its own edits — so it bypasses the server-side worktree
     * isolation / write-guard machinery below (which assumes a local fs), exactly
-    * as the primary chat path does. Gated by claude_cli_delegate_enabled. */
+    * as the primary chat path does. Gated by the agent's `primary_only` flag. */
    if (via_name && via_name[0])
    {
       agent_t *cag = agent_find(&acfg, via_name);
@@ -784,15 +784,13 @@ void delegate_worker(void *arg)
          const workspace_provider_t *wsp = workspace_provider_active();
          if (detached_bound && wsp && wsp->kind == WS_PROVIDER_DETACHED && wsp->exec_shell)
          {
-            config_t gate_cfg;
-            config_load(&gate_cfg);
-            if (!gate_cfg.claude_cli_delegate_enabled)
+            if (cag->primary_only)
             {
                workspace_turn_unbind_active();
                char m[320];
                snprintf(m, sizeof(m),
-                        "agent '%s' is Claude via the `claude` CLI and is primary-only by default; "
-                        "set claude_cli_delegate_enabled=true to allow it as a delegate "
+                        "agent '%s' is marked Primary Agent Only and cannot run as a delegate; "
+                        "uncheck 'Primary Agent Only' for it in the Agents tab to allow delegation "
                         "(see DELEGATES.md for the Anthropic account-risk warning)",
                         cag->name);
                delegation_compute_error(cctx, m);
@@ -898,17 +896,16 @@ void delegate_worker(void *arg)
       compute_ctx_free(cctx);
       return;
    }
-   /* Claude run via the `claude` CLI/tmux login (not an API key) is primary-only
-    * by default: driving a personal Claude subscription as an automated delegate
-    * may breach Anthropic's terms. Opt in with `claude_cli_delegate_enabled`.
-    * (Concise here — the risk warning is shown once at setup when the flag is
-    * enabled, and in DELEGATES.md.) */
-   if (agent_is_claude_cli(target_agent) && !route_cfg.claude_cli_delegate_enabled)
+   /* An agent flagged "Primary Agent Only" (agents.json `primary_only`) is never
+    * a delegation target. A claude-oauth subscription is pre-flagged this way at
+    * add time: driving a personal Claude plan as an automated delegate may breach
+    * Anthropic's terms. (Concise here — the risk warning is in DELEGATES.md.) */
+   if (target_agent->primary_only)
    {
       char errmsg[320];
       snprintf(errmsg, sizeof(errmsg),
-               "agent '%s' is Claude via the `claude` CLI and is primary-only by default; "
-               "set claude_cli_delegate_enabled=true to allow it as a delegate "
+               "agent '%s' is marked Primary Agent Only and cannot run as a delegate; "
+               "uncheck 'Primary Agent Only' for it in the Agents tab to allow delegation "
                "(see DELEGATES.md for the Anthropic account-risk warning)",
                target_agent->name);
       delegation_compute_error(cctx, errmsg);

--- a/src/server/server_config.c
+++ b/src/server/server_config.c
@@ -110,16 +110,5 @@ int handle_config_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
     * effect now or needs a restart, instead of leaving them to guess. */
    cJSON_AddStringToObject(resp, "reload", config_field_reload_verdict(f));
    cJSON_AddBoolToObject(resp, "applied_live", f->reload_class != RELOAD_RESTART);
-   /* One-time setup warning: enabling delegate use of Claude-via-CLI carries an
-    * Anthropic account-action risk. Surfaced here (not on every delegate call)
-    * and in DELEGATES.md. */
-   if (strcmp(key, "claude_cli_delegate_enabled") == 0 && cfg.claude_cli_delegate_enabled)
-      cJSON_AddStringToObject(
-          resp, "notice",
-          "WARNING: Claude run via the `claude` CLI / tmux login (not an API key) can now be used "
-          "as a delegate. Driving a personal Anthropic Claude subscription through "
-          "automated/headless delegation may violate Anthropic's terms of service and risk "
-          "suspension or termination of your account. Use an Anthropic API key (billed per token) "
-          "for automated/delegated workloads. See DELEGATES.md.");
    return server_send_ok(conn, resp);
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -47,6 +47,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                              $(OBJDIR)/tests/support/git_cred_inject_stub.o \
                              $(OBJDIR)/gateway_delegate.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o \
+                             $(OBJDIR)/server/aimee_ir.o \
                              $(PLATFORM_AGENT_OBJS)
 
 TEST_MCP_CLIENT_OBJS = $(OBJDIR)/server/mcp_client.o \

--- a/src/tests/test_agent_list_handler.c
+++ b/src/tests/test_agent_list_handler.c
@@ -124,12 +124,41 @@ static void test_populated_config_lists_agents(void)
    printf("  PASS: a populated config lists its agents\n");
 }
 
+/* primary_only survives parse -> agent_load_config -> server_agent_to_json (the
+ * /v1/agent/list surface the Web GUI reads to render the checkbox). An agent that
+ * omits the field defaults to false. */
+static void test_primary_only_round_trips(void)
+{
+   set_home_empty();
+   write_agents("{\"agents\":["
+                "{\"name\":\"claude\",\"provider\":\"claude\",\"backend\":\"tmux-cli\","
+                "\"cli_kind\":\"claude\",\"primary_only\":true,\"roles\":[\"code\"]},"
+                "{\"name\":\"minimax\",\"provider\":\"anthropic\",\"model\":\"m\",\"roles\":[\"all\"]}"
+                "]}\n");
+   reset_capture();
+
+   assert(handle_agent_list(NULL, NULL, NULL) == 0);
+   assert(g_last_error[0] == '\0' && g_last_response != NULL);
+   cJSON *agents = cJSON_GetObjectItemCaseSensitive(g_last_response, "agents");
+   assert(cJSON_IsArray(agents) && cJSON_GetArraySize(agents) == 2);
+
+   cJSON *a0 = cJSON_GetArrayItem(agents, 0); /* claude */
+   cJSON *po0 = cJSON_GetObjectItemCaseSensitive(a0, "primary_only");
+   assert(cJSON_IsBool(po0) && cJSON_IsTrue(po0));
+
+   cJSON *a1 = cJSON_GetArrayItem(agents, 1); /* minimax: field omitted -> false */
+   cJSON *po1 = cJSON_GetObjectItemCaseSensitive(a1, "primary_only");
+   assert(cJSON_IsBool(po1) && !cJSON_IsTrue(po1));
+   printf("  PASS: primary_only round-trips through the list handler\n");
+}
+
 int main(void)
 {
    printf("agent_list_handler:\n");
    test_load_failure_is_an_error_not_empty();
    test_empty_config_is_ok_with_empty_array();
    test_populated_config_lists_agents();
+   test_primary_only_round_trips();
    printf("all agent_list_handler tests passed\n");
    return 0;
 }

--- a/src/tests/test_aimee_ir.c
+++ b/src/tests/test_aimee_ir.c
@@ -238,6 +238,34 @@ int main(void)
    }
    printf("response-accessors ok; ");
 
+   /* aimee_ir_response_from_text: the bridge the tmux/CLI TUI handler uses to
+    * fold flat scraped text into the unified message IR. */
+   {
+      aimee_response_t r;
+      assert(aimee_ir_response_from_text(&r, "line one\nline two", "claude") == 0);
+      assert(r.role && strcmp(r.role, "assistant") == 0);
+      assert(r.n_content == 1 && r.content[0].type == AIMEE_BLK_TEXT);
+      assert(r.stop_reason == AIMEE_STOP_END_TURN);
+      assert(r.raw_stop_reason && strcmp(r.raw_stop_reason, "end_turn") == 0);
+      assert(r.model && strcmp(r.model, "claude") == 0);
+      char buf[64];
+      /* Round-trips through the standard accessor -> a multi-line answer survives
+       * verbatim, so the handler's projection is lossless. */
+      assert(aimee_ir_response_text(&r, buf, sizeof buf) == (size_t)strlen("line one\nline two"));
+      assert(strcmp(buf, "line one\nline two") == 0);
+      assert(aimee_ir_response_has_tool_use(&r) == 0);
+      aimee_response_free(&r);
+
+      /* NULL/empty text is tolerated (empty TEXT block), model may be NULL. */
+      assert(aimee_ir_response_from_text(&r, NULL, NULL) == 0);
+      assert(r.n_content == 1 && r.content[0].text && r.content[0].text[0] == '\0');
+      assert(r.model == NULL);
+      aimee_response_free(&r);
+
+      assert(aimee_ir_response_from_text(NULL, "x", "y") == -1);
+   }
+   printf("response-from-text ok; ");
+
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -909,28 +909,33 @@ static void test_default_panel_excludes_claude_cli(void)
    assert(strcmp(cfg.ensemble_reference_models[1], "codex") == 0);
    assert(strcmp(cfg.ensemble_aggregator, "mistral") == 0);
 
-   /* claude needs BOTH authorization (claude_cli_delegate_enabled) AND
-    * server-hosting to be seated; neither alone is enough. */
+   /* claude needs BOTH authorization (NOT primary_only) AND server-hosting to be
+    * seated; neither alone is enough. Authorization is now the per-agent
+    * `primary_only` flag (0 = delegate-eligible), which replaced the global
+    * claude_cli_delegate_enabled opt-in. */
 
-   /* (a) authorized but client-only (not server-hosted) -> still excluded */
+   /* (a) authorized (primary_only=0) but client-only (not server-hosted) -> still
+    * excluded */
+   acfg.agents[1].primary_only = 0;
    config_t cfg2;
    memset(&cfg2, 0, sizeof(cfg2));
-   cfg2.claude_cli_delegate_enabled = 1;
    ensemble_default_panel_from_agents(&cfg2, &acfg);
    assert(cfg2.ensemble_reference_count == 2);
 
-   /* (b) server-hosted but NOT authorized -> still excluded (the key invariant:
-    * a server-side OAuth setup is not authorization to act as a panelist) */
+   /* (b) server-hosted but NOT authorized (primary_only=1) -> still excluded (the
+    * key invariant: a server-side OAuth setup is not authorization to act as a
+    * panelist) */
    acfg.agents[1].is_server_hosted = 1;
+   acfg.agents[1].primary_only = 1;
    config_t cfg3;
    memset(&cfg3, 0, sizeof(cfg3));
    ensemble_default_panel_from_agents(&cfg3, &acfg);
    assert(cfg3.ensemble_reference_count == 2);
 
-   /* (c) authorized AND server-hosted -> seated */
+   /* (c) authorized (primary_only=0) AND server-hosted -> seated */
+   acfg.agents[1].primary_only = 0;
    config_t cfg4;
    memset(&cfg4, 0, sizeof(cfg4));
-   cfg4.claude_cli_delegate_enabled = 1;
    ensemble_default_panel_from_agents(&cfg4, &acfg);
    assert(cfg4.ensemble_reference_count == 3);
 
@@ -938,11 +943,11 @@ static void test_default_panel_excludes_claude_cli(void)
    acfg.agents[1].enabled = 0;
    config_t cfg5;
    memset(&cfg5, 0, sizeof(cfg5));
-   cfg5.claude_cli_delegate_enabled = 1;
    ensemble_default_panel_from_agents(&cfg5, &acfg);
    assert(cfg5.ensemble_reference_count == 2);
    acfg.agents[1].enabled = 1;
    acfg.agents[1].is_server_hosted = 0;
+   acfg.agents[1].primary_only = 0;
 
    /* a configured panel is left untouched (no-op) */
    config_t cfg6;
@@ -979,11 +984,12 @@ static void test_panel_filter_drops_unauthorized_claude(void)
    assert(strcmp(cfg.ensemble_reference_models[1], "adhoc-model") == 0);
    assert(strcmp(cfg.ensemble_aggregator, "mistral") == 0); /* repointed off the dropped claude */
 
-   /* Authorized + server-hosted claude survives the explicit-list filter. */
+   /* Authorized (primary_only=0) + server-hosted claude survives the
+    * explicit-list filter. */
    acfg.agents[1].is_server_hosted = 1;
+   acfg.agents[1].primary_only = 0;
    config_t cfg2;
    memset(&cfg2, 0, sizeof(cfg2));
-   cfg2.claude_cli_delegate_enabled = 1;
    cfg2.ensemble_reference_count = 2;
    snprintf(cfg2.ensemble_reference_models[0], 128, "mistral");
    snprintf(cfg2.ensemble_reference_models[1], 128, "claude");
@@ -1015,7 +1021,8 @@ static void test_panel_excludes_primary(void)
 
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
-   cfg.claude_cli_delegate_enabled = 1; /* claude would otherwise be authorized */
+   /* claude is authorized by default (primary_only=0); the point of this test is
+    * that the PRIMARY exclusion still applies regardless. */
    snprintf(cfg.provider, sizeof(cfg.provider), "claude"); /* PRIMARY = claude */
 
    /* per-agent predicate */
@@ -1038,7 +1045,6 @@ static void test_panel_excludes_primary(void)
    /* seeding from enabled agents also never seats the primary */
    config_t seed_cfg;
    memset(&seed_cfg, 0, sizeof(seed_cfg));
-   seed_cfg.claude_cli_delegate_enabled = 1;
    snprintf(seed_cfg.provider, sizeof(seed_cfg.provider), "claude");
    ensemble_default_panel_from_agents(&seed_cfg, &acfg);
    assert(seed_cfg.ensemble_reference_count == 1); /* only codex */


### PR DESCRIPTION
## Summary
Replaces the global `claude_cli_delegate_enabled` opt-in with a per-agent **Primary Agent Only** flag, fixes the disabled-primary routing trap, and folds the tmux/CLI handler's output into the canonical message IR.

### A) Per-agent Primary Agent Only (replaces the global option)
- New `agent_t.primary_only`: parsed/saved in `agents.json`, emitted on `/v1/agent/list`, settable via `agent add`/`set --primary-only on|off`. A claude-oauth subscription defaults it ON (driving a personal Claude plan as an automated delegate may breach Anthropic's terms).
- All delegate gates now key off `primary_only` (route-policy filter, ensemble panel seat, both delegate dispatch checks) — generalized to any agent, not just claude-CLI.
- Removed the global `claude_cli_delegate_enabled` config field end-to-end (schema, parse, save, settings API, field table, generated config reference, help) and updated ARCHITECTURE/SECURITY/DELEGATES.
- Web GUI: Primary Agent Only checkbox in the wizard + Agents add flows (pre-checked for a Claude subscription, off otherwise) and the per-agent Edit modal; removed the old settings toggle.

### Routing fix
A disabled agent that *is* the configured primary is now auto-used for the primary chat path (delegate routing still honors `enabled`). This fixes the misleading "provider 'claude' is not configured as an aimee agent" error observed when the primary agent was left disabled — a disabled same-named agent both suppressed the built-in fallback and failed the enabled-only selector.

### B) Unified message for the tmux/CLI handler
New `aimee_ir_response_from_text()` builds a canonical assistant `aimee_response_t` (single TEXT block, `end_turn`). `agent_execute_cli_session` now projects its scraped answer through the IR, so the CLI path is just another producer of the unified message and gains a real `stop_reason`.

## Testing
- Full `aimee-server` builds and runs locally; 10 relevant unit tests pass.
- New: `primary_only` round-trip through the list handler; `aimee_ir_response_from_text`; delegate-ensemble panel eligibility rewritten to the `primary_only` semantics.
- Regenerated `docs/gen/configuration.md`.
- Original failure reproduced + root-caused live on the .254 appliance (the primary `claude` agent was `enabled:false`).