### PR TITLE
lint: clang-format test_agent_list_handler.c (unbreak testing)

### DIFF
--- a/src/tests/test_agent_list_handler.c
+++ b/src/tests/test_agent_list_handler.c
@@ -130,11 +130,12 @@ static void test_populated_config_lists_agents(void)
 static void test_primary_only_round_trips(void)
 {
    set_home_empty();
-   write_agents("{\"agents\":["
-                "{\"name\":\"claude\",\"provider\":\"claude\",\"backend\":\"tmux-cli\","
-                "\"cli_kind\":\"claude\",\"primary_only\":true,\"roles\":[\"code\"]},"
-                "{\"name\":\"minimax\",\"provider\":\"anthropic\",\"model\":\"m\",\"roles\":[\"all\"]}"
-                "]}\n");
+   write_agents(
+       "{\"agents\":["
+       "{\"name\":\"claude\",\"provider\":\"claude\",\"backend\":\"tmux-cli\","
+       "\"cli_kind\":\"claude\",\"primary_only\":true,\"roles\":[\"code\"]},"
+       "{\"name\":\"minimax\",\"provider\":\"anthropic\",\"model\":\"m\",\"roles\":[\"all\"]}"
+       "]}\n");
    reset_capture();
 
    assert(handle_agent_list(NULL, NULL, NULL) == 0);


### PR DESCRIPTION
PR #1440 merged `test_agent_list_handler.c` with an un-clang-formatted `write_agents(...)` string block (5 violations), so the **Check formatting** lint step fails on `testing` and every open PR inherits it via the merge base. This is a pure `clang-format-19` whitespace re-wrap — no logic change — to restore green.