### PR TITLE
feat(ir): openai-wire response parse via the IR (Slice 3, dark behind flag)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -278,7 +278,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 155 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 156 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -481,7 +481,7 @@ The binaries read 155 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CONCURRENCY`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CONCURRENCY`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_RESP_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_OCR_URL`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/src/headers/aimee_ir_serve.h
+++ b/src/headers/aimee_ir_serve.h
@@ -8,6 +8,8 @@
 
 #include <stddef.h>
 
+#include "aimee_ir.h" /* aimee_response_t */
+
 struct cJSON;
 
 /* Build the provider request body from `req` (an Anthropic Messages request) via
@@ -54,5 +56,15 @@ int aimee_ir_responses_to_chat(const char *body, char *model, size_t model_n,
 struct cJSON *aimee_ir_build_from_chat(const char *agent_model, const struct cJSON *messages,
                                        const struct cJSON *tools, const char *system,
                                        const char *driver_name);
+
+
+/* Slice 3 gate (AIMEE_IR_RESP_PATH env, DEFAULT-OFF): route the OPENAI-WIRE buffered
+ * response parse through the IR. Per-wire; anthropic + responses stay on legacy. */
+int aimee_ir_resp_path_enabled(void);
+
+struct parsed_response;
+/* TRANSITIONAL: IR response -> legacy parsed_response_t (see .c). Remove once emit +
+ * police are IR-native. */
+void aimee_ir_response_to_parsed(const aimee_response_t *r, struct parsed_response *out);
 
 #endif /* DEC_AIMEE_IR_SERVE_H */

--- a/src/headers/aimee_ir_serve.h
+++ b/src/headers/aimee_ir_serve.h
@@ -57,7 +57,6 @@ struct cJSON *aimee_ir_build_from_chat(const char *agent_model, const struct cJS
                                        const struct cJSON *tools, const char *system,
                                        const char *driver_name);
 
-
 /* Slice 3 gate (AIMEE_IR_RESP_PATH env, DEFAULT-OFF): route the OPENAI-WIRE buffered
  * response parse through the IR. Per-wire; anthropic + responses stay on legacy. */
 int aimee_ir_resp_path_enabled(void);

--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -4,7 +4,7 @@
 #include "aimee_backend.h"
 #include "aimee_frontend.h"
 #include "aimee_ir_metrics.h"
-#include "aimee.h" /* size macros for agent_types.h */
+#include "aimee.h"          /* size macros for agent_types.h */
 #include "agent_protocol.h" /* parsed_response_t (Slice 3 transitional adapter) */
 #include "aimee_ir.h"
 #include "cJSON.h"
@@ -234,7 +234,6 @@ cJSON *aimee_ir_build_from_chat(const char *agent_model, const cJSON *messages, 
       aimee_ir_metric_inc(AIMEE_IR_M_IR_PATH, AIMEE_WIRE_OPENAI_CHAT);
    return prov;
 }
-
 
 /* aimee_ir_resp_path_enabled -- Slice 3 gate (config-only: AIMEE_IR_RESP_PATH env,
  * DEFAULT-OFF). When on, the OPENAI-WIRE buffered response parse on the /v1/messages

--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -4,6 +4,9 @@
 #include "aimee_backend.h"
 #include "aimee_frontend.h"
 #include "aimee_ir_metrics.h"
+#include "aimee.h" /* size macros for agent_types.h */
+#include "agent_protocol.h" /* parsed_response_t (Slice 3 transitional adapter) */
+#include "aimee_ir.h"
 #include "cJSON.h"
 
 #include <stdio.h>
@@ -230,4 +233,79 @@ cJSON *aimee_ir_build_from_chat(const char *agent_model, const cJSON *messages, 
    else
       aimee_ir_metric_inc(AIMEE_IR_M_IR_PATH, AIMEE_WIRE_OPENAI_CHAT);
    return prov;
+}
+
+
+/* aimee_ir_resp_path_enabled -- Slice 3 gate (config-only: AIMEE_IR_RESP_PATH env,
+ * DEFAULT-OFF). When on, the OPENAI-WIRE buffered response parse on the /v1/messages
+ * ingress runs provider-JSON -> openai_backend_parse -> IR -> aimee_ir_response_to_parsed,
+ * replacing driver->parse_response. Per-wire by ruling: anthropic + responses stay on
+ * legacy until their response-shadow parity is proven live. Ships dark; flip after the
+ * on-box emit diff confirms byte-identity. */
+int aimee_ir_resp_path_enabled(void)
+{
+   const char *v = getenv("AIMEE_IR_RESP_PATH");
+   return v && (strcmp(v, "1") == 0 || strcmp(v, "on") == 0 || strcmp(v, "true") == 0);
+}
+
+/* TRANSITIONAL (Slice 3, canonical-IR) -- bridge the IR response back to the legacy
+ * parsed_response_t so the existing Anthropic emit + gateway policing keep working
+ * while the response PARSE moves onto the IR. REMOVE once the emit + police paths are
+ * IR-native (proposal: full IR render + IR-coupled police). DO NOT add new callers.
+ * Fills every parsed_response_t field the ingress emit/police consume (audited): content,
+ * calls[]/call_count, is_tool_call, prompt/completion/cache tokens, stop_reason, model.
+ * `out` is zeroed here; caller frees via the usual agent_free_parsed_response. */
+void aimee_ir_response_to_parsed(const aimee_response_t *r, parsed_response_t *out)
+{
+   if (!out)
+      return;
+   memset(out, 0, sizeof(*out));
+   if (!r)
+      return;
+
+   out->prompt_tokens = (int)r->usage_in;
+   out->completion_tokens = (int)r->usage_out;
+   out->cache_read_tokens = (int)r->usage_cache_read;
+   out->cache_write_tokens = (int)r->usage_cache_write;
+   if (r->model)
+      snprintf(out->model, sizeof(out->model), "%s", r->model);
+   if (r->raw_stop_reason)
+      snprintf(out->stop_reason, sizeof(out->stop_reason), "%s", r->raw_stop_reason);
+
+   /* content = concatenation of all TEXT blocks (parsed_response_t convention: a
+    * single flat string; NULL when there is no text, e.g. a pure tool call). */
+   size_t cap = 1;
+   for (int i = 0; i < r->n_content; i++)
+      if (r->content[i].type == AIMEE_BLK_TEXT && r->content[i].text)
+         cap += strlen(r->content[i].text);
+   if (cap > 1)
+   {
+      out->content = malloc(cap);
+      if (out->content)
+      {
+         out->content[0] = '\0';
+         for (int i = 0; i < r->n_content; i++)
+            if (r->content[i].type == AIMEE_BLK_TEXT && r->content[i].text)
+               strncat(out->content, r->content[i].text, cap - strlen(out->content) - 1);
+      }
+   }
+
+   /* tool calls: id (opaque) / name / arguments (serialized tool_input JSON). */
+   int nc = 0;
+   for (int i = 0; i < r->n_content && nc < AGENT_MAX_TOOL_CALLS; i++)
+   {
+      const aimee_block_t *b = &r->content[i];
+      if (b->type != AIMEE_BLK_TOOL_USE)
+         continue;
+      parsed_tool_call_t *c = &out->calls[nc++];
+      if (b->tool_id)
+         snprintf(c->id, sizeof(c->id), "%s", b->tool_id);
+      if (b->tool_name)
+         snprintf(c->name, sizeof(c->name), "%s", b->tool_name);
+      c->arguments = b->tool_input ? cJSON_PrintUnformatted(b->tool_input) : NULL;
+      if (!c->arguments)
+         c->arguments = strdup("{}");
+   }
+   out->call_count = nc;
+   out->is_tool_call = (nc > 0);
 }

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -183,6 +183,34 @@ static aimee_wire_t shadow_provider_wire(const delegate_driver_t *driver)
    return driver_is_anthropic(driver) ? AIMEE_WIRE_ANTHROPIC : AIMEE_WIRE_OPENAI_CHAT;
 }
 
+/* Slice 3: parse the provider JSON response into `parsed`. When AIMEE_IR_RESP_PATH is
+ * on and the primary is OPENAI-WIRE, route through the canonical IR
+ * (openai_backend_parse -> IR -> transitional adapter); legacy driver->parse_response
+ * on flag-off, anthropic wire, or any IR-parse failure. `raw` is the original response
+ * text handed to the legacy parser. */
+static void ir_or_legacy_parse_response(cJSON *provider_resp, const char *raw,
+                                        const delegate_driver_t *driver, parsed_response_t *parsed)
+{
+   if (aimee_ir_resp_path_enabled() && !driver_is_anthropic(driver))
+   {
+      aimee_response_t ir_resp;
+      char ir_err[128];
+      memset(&ir_resp, 0, sizeof(ir_resp));
+      if (openai_backend_parse(provider_resp, &ir_resp, ir_err, sizeof(ir_err)) == 0)
+      {
+         aimee_ir_response_to_parsed(&ir_resp, parsed);
+         aimee_response_free(&ir_resp);
+         return;
+      }
+      aimee_response_free(&ir_resp);
+   }
+   if (driver && driver->parse_response)
+      driver->parse_response(provider_resp, raw, parsed);
+   else
+      /* No driver: default to the openai wire via the IR (zeroed *parsed on failure). */
+      agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, parsed);
+}
+
 static int driver_consumes_system_prompt(const delegate_driver_t *driver, const agent_t *ag)
 {
    driver_caps_t caps;
@@ -556,33 +584,8 @@ static int messages_buffered(const char *body, char *resp, int cap)
    memset(&parsed, 0, sizeof(parsed));
    if (provider_resp)
    {
-      /* Slice 3 (canonical-IR): OPENAI-WIRE response parse via the IR when
-       * AIMEE_IR_RESP_PATH is on (default-off, ships dark). provider-JSON ->
-       * openai_backend_parse -> IR -> transitional adapter -> parsed_response_t, so
-       * the existing emit + policing are unchanged. Anthropic stays on legacy
-       * (per-wire ruling); legacy fallback on any IR-parse failure. */
-      int used_ir_resp = 0;
-      if (aimee_ir_resp_path_enabled() && !driver_is_anthropic(driver))
-      {
-         aimee_response_t ir_resp;
-         char ir_err[128];
-         memset(&ir_resp, 0, sizeof(ir_resp));
-         if (openai_backend_parse(provider_resp, &ir_resp, ir_err, sizeof(ir_err)) == 0)
-         {
-            aimee_ir_response_to_parsed(&ir_resp, &parsed);
-            used_ir_resp = 1;
-         }
-         aimee_response_free(&ir_resp);
-      }
-      if (!used_ir_resp)
-      {
-         if (driver && driver->parse_response)
-            driver->parse_response(provider_resp, response, &parsed);
-         else
-            /* No driver: default to the openai wire, parsed through the IR (zeroed
-             * *parsed on failure), matching the driver hooks. */
-            agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, &parsed);
-      }
+      /* Slice 3: OPENAI-WIRE response parse via the IR (default-off flag). */
+      ir_or_legacy_parse_response(provider_resp, response, driver, &parsed);
 
       /* Slice 2 (canonical-IR): shadow-compare the legacy parse against the IR
        * response parse -> RESP_MATCH / RESP_MISMATCH on GET /v1/dashboard/metrics.
@@ -1053,29 +1056,8 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
             cJSON *provider_resp = cJSON_Parse(buf_resp);
             if (provider_resp)
             {
-               /* Slice 3: OPENAI-WIRE response parse via the IR (default-off flag);
-                * legacy fallback on failure. Anthropic stays on legacy. */
-               int used_ir_resp = 0;
-               if (aimee_ir_resp_path_enabled() && !driver_is_anthropic(driver))
-               {
-                  aimee_response_t ir_resp;
-                  char ir_err[128];
-                  memset(&ir_resp, 0, sizeof(ir_resp));
-                  if (openai_backend_parse(provider_resp, &ir_resp, ir_err, sizeof(ir_err)) == 0)
-                  {
-                     aimee_ir_response_to_parsed(&ir_resp, &parsed);
-                     used_ir_resp = 1;
-                  }
-                  aimee_response_free(&ir_resp);
-               }
-               if (!used_ir_resp)
-               {
-                  if (driver && driver->parse_response)
-                     driver->parse_response(provider_resp, buf_resp, &parsed);
-                  else
-                     /* No driver: default to the openai wire via the IR. */
-                     agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, &parsed);
-               }
+               /* Slice 3: OPENAI-WIRE response parse via the IR (default-off flag). */
+               ir_or_legacy_parse_response(provider_resp, buf_resp, driver, &parsed);
                /* Slice 2 (canonical-IR): shadow-compare legacy vs IR response parse
                 * (RESP_MATCH / RESP_MISMATCH). No-op unless AIMEE_IR_SHADOW. */
                aimee_ir_shadow_compare_response(&parsed, provider_resp,

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -32,6 +32,7 @@
 #include "aimee_ir_shadow.h" /* Slice 3: IR shadow-mode observer */
 #include "aimee_ir_metrics.h"
 #include "aimee_ir_serve.h"  /* Slice 5: IR live request-build */
+#include "aimee_backend.h"   /* Slice 3: openai_backend_parse (IR response path) */
 #include "aimee_ir_stream.h" /* Slice 5-wire: IR-delta incremental relay */
 #include "ingress_preinject.h"
 #include "json_fluent.h"
@@ -555,12 +556,33 @@ static int messages_buffered(const char *body, char *resp, int cap)
    memset(&parsed, 0, sizeof(parsed));
    if (provider_resp)
    {
-      if (driver && driver->parse_response)
-         driver->parse_response(provider_resp, response, &parsed);
-      else
-         /* No driver: default to the openai wire, parsed through the IR (zeroed
-          * *parsed on failure), matching the driver hooks. */
-         agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, &parsed);
+      /* Slice 3 (canonical-IR): OPENAI-WIRE response parse via the IR when
+       * AIMEE_IR_RESP_PATH is on (default-off, ships dark). provider-JSON ->
+       * openai_backend_parse -> IR -> transitional adapter -> parsed_response_t, so
+       * the existing emit + policing are unchanged. Anthropic stays on legacy
+       * (per-wire ruling); legacy fallback on any IR-parse failure. */
+      int used_ir_resp = 0;
+      if (aimee_ir_resp_path_enabled() && !driver_is_anthropic(driver))
+      {
+         aimee_response_t ir_resp;
+         char ir_err[128];
+         memset(&ir_resp, 0, sizeof(ir_resp));
+         if (openai_backend_parse(provider_resp, &ir_resp, ir_err, sizeof(ir_err)) == 0)
+         {
+            aimee_ir_response_to_parsed(&ir_resp, &parsed);
+            used_ir_resp = 1;
+         }
+         aimee_response_free(&ir_resp);
+      }
+      if (!used_ir_resp)
+      {
+         if (driver && driver->parse_response)
+            driver->parse_response(provider_resp, response, &parsed);
+         else
+            /* No driver: default to the openai wire, parsed through the IR (zeroed
+             * *parsed on failure), matching the driver hooks. */
+            agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, &parsed);
+      }
 
       /* Slice 2 (canonical-IR): shadow-compare the legacy parse against the IR
        * response parse -> RESP_MATCH / RESP_MISMATCH on GET /v1/dashboard/metrics.
@@ -1031,11 +1053,29 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
             cJSON *provider_resp = cJSON_Parse(buf_resp);
             if (provider_resp)
             {
-               if (driver && driver->parse_response)
-                  driver->parse_response(provider_resp, buf_resp, &parsed);
-               else
-                  /* No driver: default to the openai wire via the IR. */
-                  agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, &parsed);
+               /* Slice 3: OPENAI-WIRE response parse via the IR (default-off flag);
+                * legacy fallback on failure. Anthropic stays on legacy. */
+               int used_ir_resp = 0;
+               if (aimee_ir_resp_path_enabled() && !driver_is_anthropic(driver))
+               {
+                  aimee_response_t ir_resp;
+                  char ir_err[128];
+                  memset(&ir_resp, 0, sizeof(ir_resp));
+                  if (openai_backend_parse(provider_resp, &ir_resp, ir_err, sizeof(ir_err)) == 0)
+                  {
+                     aimee_ir_response_to_parsed(&ir_resp, &parsed);
+                     used_ir_resp = 1;
+                  }
+                  aimee_response_free(&ir_resp);
+               }
+               if (!used_ir_resp)
+               {
+                  if (driver && driver->parse_response)
+                     driver->parse_response(provider_resp, buf_resp, &parsed);
+                  else
+                     /* No driver: default to the openai wire via the IR. */
+                     agent_ir_parse_json_response(provider_resp, 0 /*openai*/, -1, NULL, &parsed);
+               }
                /* Slice 2 (canonical-IR): shadow-compare legacy vs IR response parse
                 * (RESP_MATCH / RESP_MISMATCH). No-op unless AIMEE_IR_SHADOW. */
                aimee_ir_shadow_compare_response(&parsed, provider_resp,

--- a/src/tests/support/ir_ingress_stubs.c
+++ b/src/tests/support/ir_ingress_stubs.c
@@ -204,7 +204,8 @@ __attribute__((weak)) void aimee_ir_response_to_parsed(const void *r, void *out)
    (void)r;
    (void)out;
 }
-__attribute__((weak)) int openai_backend_parse(const void *resp, void *out, char *err, unsigned long errn)
+__attribute__((weak)) int openai_backend_parse(const void *resp, void *out, char *err,
+                                               unsigned long errn)
 {
    (void)resp;
    (void)out;

--- a/src/tests/support/ir_ingress_stubs.c
+++ b/src/tests/support/ir_ingress_stubs.c
@@ -190,3 +190,29 @@ __attribute__((weak)) void *aimee_ir_build_from_chat(const char *agent_model, co
    (void)driver_name;
    return NULL;
 }
+
+/* Slice 3: the OPENAI-WIRE IR response path. The anthropic_http shape/p2c tests
+ * #include anthropic_http.c and link minimally; these inert weak stubs resolve the
+ * link. aimee_ir_resp_path_enabled()->0 keeps the legacy parse on the test path, so
+ * the other three are never actually called. Real objects win when linked. */
+__attribute__((weak)) int aimee_ir_resp_path_enabled(void)
+{
+   return 0;
+}
+__attribute__((weak)) void aimee_ir_response_to_parsed(const void *r, void *out)
+{
+   (void)r;
+   (void)out;
+}
+__attribute__((weak)) int openai_backend_parse(const void *resp, void *out, char *err, unsigned long errn)
+{
+   (void)resp;
+   (void)out;
+   (void)err;
+   (void)errn;
+   return -1;
+}
+__attribute__((weak)) void aimee_response_free(void *r)
+{
+   (void)r;
+}

--- a/src/tests/test_aimee_ir_serve.c
+++ b/src/tests/test_aimee_ir_serve.c
@@ -6,6 +6,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "aimee.h"
+#include "agent_protocol.h"
+#include "aimee_ir.h"
 #include "aimee_ir_serve.h"
 #include "cJSON.h"
 
@@ -116,6 +119,58 @@ int main(void)
    cJSON_Delete(fc);
    cJSON_Delete(cm);
    cJSON_Delete(ct);
+
+   /* Slice 3: aimee_ir_response_to_parsed adapter (IR response -> parsed_response_t).
+    * Exhaustive per the roundtable ruling: text, tool calls, tokens, cache tokens,
+    * stop_reason, model, and the NULL guard. */
+   {
+      aimee_block_t b1 = {0};
+      b1.type = AIMEE_BLK_TEXT;
+      b1.text = (char *)"hello world";
+      aimee_response_t r1 = {0};
+      r1.model = (char *)"minimax-m3";
+      r1.raw_stop_reason = (char *)"stop";
+      r1.content = &b1;
+      r1.n_content = 1;
+      r1.usage_in = 12;
+      r1.usage_out = 5;
+      r1.usage_cache_read = 3;
+      r1.usage_cache_write = 7;
+      parsed_response_t p1;
+      aimee_ir_response_to_parsed(&r1, &p1);
+      assert(p1.content && strcmp(p1.content, "hello world") == 0);
+      assert(p1.is_tool_call == 0 && p1.call_count == 0);
+      assert(p1.prompt_tokens == 12 && p1.completion_tokens == 5);
+      assert(p1.cache_read_tokens == 3 && p1.cache_write_tokens == 7);
+      assert(strcmp(p1.model, "minimax-m3") == 0);
+      assert(strcmp(p1.stop_reason, "stop") == 0);
+      free(p1.content);
+
+      cJSON *ti = cJSON_CreateObject();
+      cJSON_AddStringToObject(ti, "city", "Paris");
+      aimee_block_t b2 = {0};
+      b2.type = AIMEE_BLK_TOOL_USE;
+      b2.tool_id = (char *)"call_abc";
+      b2.tool_name = (char *)"get_weather";
+      b2.tool_input = ti;
+      aimee_response_t r2 = {0};
+      r2.raw_stop_reason = (char *)"tool_use";
+      r2.content = &b2;
+      r2.n_content = 1;
+      parsed_response_t p2;
+      aimee_ir_response_to_parsed(&r2, &p2);
+      assert(p2.is_tool_call == 1 && p2.call_count == 1);
+      assert(strcmp(p2.calls[0].id, "call_abc") == 0);
+      assert(strcmp(p2.calls[0].name, "get_weather") == 0);
+      assert(p2.calls[0].arguments && strstr(p2.calls[0].arguments, "Paris"));
+      assert(p2.content == NULL); /* pure tool call -> no text */
+      free(p2.calls[0].arguments);
+      cJSON_Delete(ti);
+
+      parsed_response_t p3;
+      aimee_ir_response_to_parsed(NULL, &p3);
+      assert(p3.call_count == 0 && p3.content == NULL && p3.is_tool_call == 0);
+   }
 
    printf("ok\n");
    return 0;


### PR DESCRIPTION
Implements **Slice 3** of `docs/proposals/pending/ir-sole-path-and-pluggable-stages.md`, scoped per the roundtable's ruling (per-wire, evidence-honest, ships dark).

## What
Routes the **openai-wire** buffered response parse on the `/v1/messages` ingress through the canonical IR: `provider-JSON → openai_backend_parse → aimee_response_t → aimee_ir_response_to_parsed (new transitional adapter) → parsed_response_t`, feeding the **existing** emit + policing unchanged. Both live buffered sites wired.

## Roundtable-directed scope
- **Per-wire:** only the openai wire (parity proven live, 8/8 `ir_resp_match`, 0 mismatch on .254) routes through the IR. Anthropic + responses stay on `driver->parse_response`; the codex `raw_responses` branch is **not** deleted.
- **Ships dark** behind `AIMEE_IR_RESP_PATH` (default-off) with legacy fallback on any IR-parse failure → merge is a no-op until the flag is flipped after an on-box emit-diff confirms byte-identity.
- Adapter marked **transitional** (removed once emit + police are IR-native).

## Tests
Adapter unit-tested exhaustively (text, tool calls, prompt/completion/cache tokens, stop_reason, model, NULL guard) — passes locally. Weak stubs added for the minimal `anthropic_http` test links (same pattern as Slice 2).