### PR TITLE
feat(wfe): hard-gate autonomous merges to feature branches only

### DIFF
--- a/config/workflows/slice.yaml
+++ b/config/workflows/slice.yaml
@@ -52,6 +52,13 @@ nodes:
     block: pr.open
     in:
       src: freeze.out
+    params:
+      # A slice sub-PR merges INTO the parent's durable feature branch
+      # (aimee/feat/<parent>), NEVER the integration branch. Without this the base
+      # falls through to the autonomous default (testing) and the slice would
+      # merge straight into the integration branch — the merge seam now hard-gates
+      # that, so this keeps the slice mergeable at all.
+      base: feature
     next: ci
     # forge push/open can fail transiently; retry rather than dead-end.
     on_fail: pr

--- a/src/headers/git_pr_api.h
+++ b/src/headers/git_pr_api.h
@@ -43,6 +43,7 @@ typedef struct
    int merged;        /* merged flag */
    int mergeable;     /* 1 mergeable, 0 conflicting, -1 unknown (GitHub still computing) */
    char head_sha[72]; /* head commit (for CI lookups) */
+   char base[128];    /* base.ref: the branch this PR merges INTO (empty if unknown) */
 } git_pr_info_t;
 
 int git_pr_info_via_api(const char *principal, const char *repo_dir, int number, git_pr_info_t *out,

--- a/src/server/git_pr_api.c
+++ b/src/server/git_pr_api.c
@@ -398,6 +398,8 @@ int git_pr_info_via_api(const char *principal, const char *repo_dir, int number,
    const cJSON *mergeable = cJSON_GetObjectItem(j, "mergeable");
    const cJSON *headj = cJSON_GetObjectItem(j, "head");
    const cJSON *sha = headj ? cJSON_GetObjectItem(headj, "sha") : NULL;
+   const cJSON *basej = cJSON_GetObjectItem(j, "base");
+   const cJSON *baseref = basej ? cJSON_GetObjectItem(basej, "ref") : NULL;
    out->open =
        cJSON_IsString(state) && state->valuestring && strcmp(state->valuestring, "open") == 0;
    out->merged = cJSON_IsTrue(merged) ? 1 : 0;
@@ -405,6 +407,8 @@ int git_pr_info_via_api(const char *principal, const char *repo_dir, int number,
       out->mergeable = cJSON_IsTrue(mergeable) ? 1 : 0; /* null stays -1 (computing) */
    if (cJSON_IsString(sha) && sha->valuestring)
       snprintf(out->head_sha, sizeof(out->head_sha), "%s", sha->valuestring);
+   if (cJSON_IsString(baseref) && baseref->valuestring)
+      snprintf(out->base, sizeof(out->base), "%s", baseref->valuestring);
    cJSON_Delete(j);
    return 0;
 }

--- a/src/server/wfe_live_forge.c
+++ b/src/server/wfe_live_forge.c
@@ -182,12 +182,34 @@ static int live_is_merged(const char *repo, const char *pr)
 
 static wfe_merge_result_t live_merge(const char *repo, const char *pr)
 {
-   (void)repo;
    if (!forge_allowed())
       return WFE_MERGE_ERROR; /* disabled / protected target -> fail closed */
    int num = pr ? atoi(pr) : 0;
    if (num <= 0)
       return WFE_MERGE_ERROR;
+
+   /* HARD merge-target gate: refuse to merge unless the PR's base is a feature
+    * branch. Read the PR's ACTUAL base from the forge (not a config default) and
+    * fail closed on an unknown/non-feature base — an autonomous run must never
+    * merge into an integration/protected branch. */
+   {
+      char berr[160];
+      git_pr_info_t bi;
+      if (git_pr_info_via_api(NULL, forge_dir(repo), num, &bi, berr, sizeof berr) != 0)
+      {
+         aimee_log(LOG_WARN, "wfe-forge", "refusing merge of PR %d: cannot read base (%s)", num,
+                   berr);
+         return WFE_MERGE_ERROR;
+      }
+      if (!wfe_base_is_feature(bi.base))
+      {
+         aimee_log(LOG_WARN, "wfe-forge",
+                   "refusing merge of PR %d: base '%s' is not a feature branch — autonomous "
+                   "merges land only in aimee/feat/*; merging elsewhere is a human action",
+                   num, bi.base[0] ? bi.base : "(unknown)");
+         return WFE_MERGE_ERROR; /* parks for a human */
+      }
+   }
 
    /* CI must be green before we merge (operator ruling 2026-07-15). The canonical
     * `build` DAG already orders a ci node ahead of merge, so this is defence in

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -546,6 +546,19 @@ int main(void)
       (void)system(cmd);
    }
 
+   /* F: wfe_base_is_feature — the merge-seam hard gate's predicate. ONLY an
+    *    aimee-managed feature branch is an autonomous merge target; every
+    *    integration/protected/other base (and an empty/unknown base) is refused,
+    *    so a misconfigured pr.open base cannot merge work into a non-feature branch. */
+   assert(wfe_base_is_feature("aimee/feat/wi_x") == 1);
+   assert(wfe_base_is_feature("aimee/feat/") == 1); /* prefix match is sufficient */
+   assert(wfe_base_is_feature("testing") == 0);
+   assert(wfe_base_is_feature("main") == 0);
+   assert(wfe_base_is_feature("aimee/wi/x.s0") == 0); /* aimee-namespaced but not feat/ */
+   assert(wfe_base_is_feature("xaimee/feat/y") == 0); /* prefix must anchor at start */
+   assert(wfe_base_is_feature("") == 0);
+   assert(wfe_base_is_feature(NULL) == 0);
+
    printf("ok\n");
    return 0;
 }

--- a/src/workflow/wfe_iface.c
+++ b/src/workflow/wfe_iface.c
@@ -56,6 +56,11 @@ int wfe_autonomous_target_ok(void)
    return !wfe_base_is_protected(wfe_autonomous_base());
 }
 
+int wfe_base_is_feature(const char *base)
+{
+   return base && strncmp(base, "aimee/feat/", 11) == 0;
+}
+
 /* Server-side authoritative cost estimate (WP-5): a delegate turn's USD cost as
  * wall-clock seconds * a configured rate. Provider-agnostic (never trusts a
  * provider-reported figure) so the per-run USD budget cap actually bites. Rate is

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -186,6 +186,11 @@ const char *wfe_repo_local(const char *wi_repo);
 const char *wfe_autonomous_base(void);
 int wfe_base_is_protected(const char *branch); /* 1 if main/master/release* (refused) */
 int wfe_autonomous_target_ok(void);            /* 1 if the configured base is mergeable */
+/* 1 iff `base` is an aimee-managed feature branch (an "aimee/feat/" prefix) — the
+ * ONLY base an autonomous merge may land a PR into. The merge seam refuses every
+ * other base (integration/protected branches) so a misconfigured pr.open base
+ * cannot merge work into a non-feature branch. */
+int wfe_base_is_feature(const char *base);
 
 /* Authoritative server-side USD cost for a delegate turn of `elapsed_secs`
  * wall-clock (rate AIMEE_AUTONOMY_USD_PER_SEC, default 0.0005). Provider-agnostic,


### PR DESCRIPTION
## Hard gate: autonomous merges land only in feature branches

An autonomous aimee run must **never** merge a PR into a non-feature branch. This closes that gap at the merge seam and fixes the root cause that let a single-slice run merge straight into the integration branch.

### Changes
- **Merge seam (`wfe_live_forge.c` `live_merge`)** — before merging, read the PR's *actual* base from the forge and refuse unless it is an aimee-managed feature branch (`aimee/feat/` prefix). An unknown/unreadable base fails closed. Merging anywhere else is a human action, so the run parks instead of merging. The gate runs on every call (TOCTOU-safe) and sits before any side-effecting forge call.
- **Predicate (`wfe_base_is_feature`)** — lives in `wfe_iface.c` (beside `wfe_base_is_protected`) so it is unit-testable without the heavy forge dependencies. Anchored prefix match; NULL/empty → refused.
- **Slice sub-PRs (`slice.yaml` `pr.open`)** — pin `base: feature` so a slice targets the parent's durable feature branch (`aimee/feat/<parent>`) instead of falling through to the autonomous default (`testing`). Without this, a slice merged straight into the integration branch, leaving the parent feature-branch aggregate empty and the final feature→trunk PR a 422 (empty diff).
- **`git_pr_info_t.base`** — new field parsed from `base.ref` so the seam can read a PR's target branch (`out` is memset, so a missing base is `""` → fail-closed).

### Tests
`test_wfe_delegate_seam.c` gains an eight-case table for `wfe_base_is_feature` (accepts `aimee/feat/<name>` and the bare prefix; rejects `testing`, `main`, `aimee/wi/x.s0`, an unanchored `xaimee/feat/y`, empty, and NULL). Builds clean and passes.

### Review
Passed the roundtable (security, architect, qa, reviewer) — 4/4 approve, no blocking findings.
