### PR TITLE
feat(roundtable): chair evidence-gate — members must back findings with checkable evidence

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -681,6 +681,7 @@ static void config_set_defaults(config_t *cfg)
     * is memset-0 above, so this explicit assignment is what makes the contract
     * hold (the config_fields[] row carries is_bool, not a default value). */
    cfg->roundtable_replay_verify_enabled = 1;
+   cfg->roundtable_require_evidence = 1; /* evidence gate on: no-evidence findings dropped */
    /* Default-on to preserve behavior: profile-card refresh ran ungated in the
     * maintenance REPLAY pass before the enable-gate was wired. Maintenance is
     * itself default-off, so this is a no-op until maintenance is enabled. */

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -314,6 +314,8 @@ const config_field_t config_fields[] = {
      sizeof(int), 0, CFG_BOOL},
     {"roundtable.replay_verify_enabled", offsetof(config_t, roundtable_replay_verify_enabled),
      sizeof(int), 1, CFG_BOOL},
+    {"roundtable.require_evidence", offsetof(config_t, roundtable_require_evidence), sizeof(int), 1,
+     CFG_BOOL},
     {"verify_cross_project", offsetof(config_t, verify_cross_project), sizeof(int), 1, CFG_BOOL},
     {"roundtable.max_rounds", offsetof(config_t, roundtable_max_rounds), sizeof(int), 0, CFG_INT},
     {"roundtable.converge_threshold", offsetof(config_t, roundtable_converge_threshold),

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -918,6 +918,15 @@ typedef struct config
     * appendix — byte-identical to pre-Part-A. */
    int roundtable_replay_verify_enabled;
 
+   /* roundtable_require_evidence (default 1, ON): the evidence gate. A review finding
+    * with NO structured evidence (kind=none) is an unfalsifiable opinion the chair
+    * cannot check against the code, so it is REJECTED rather than kept-but-capped —
+    * members may only raise findings they back with checkable evidence (refs/symbol/
+    * search). Only meaningful when roundtable_replay_verify_enabled is on (the chair
+    * runs). Set 0 to restore the legacy behavior (interpretive items capped, not
+    * dropped). */
+   int roundtable_require_evidence;
+
    /* Verify scope. When 0 (default), `aimee git verify` and the push/PR verify
     * gate apply only to the session's current project (the repo the session is
     * rooted in). Cross-project repositories are neither auto-configured (no

--- a/src/headers/roundtable_verify.h
+++ b/src/headers/roundtable_verify.h
@@ -37,11 +37,14 @@ extern "C"
                                          char *out_sev, size_t out_cap);
 
    /* Replay + grade every item in out->items, compacting kept items and filling
-    * out->rejected[] / the counts. Uses the real code index. */
-   void roundtable_verify_items(roundtable_result_t *out);
+    * out->rejected[] / the counts. Uses the real code index. `require_evidence` is the
+    * evidence gate: when non-zero, an item whose replay yields no structured evidence
+    * (an unfalsifiable opinion) is REJECTED, not kept-and-capped. */
+   void roundtable_verify_items(roundtable_result_t *out, int require_evidence);
 
    /* As above but against an explicit replay backend (for tests, no DB). */
-   void roundtable_verify_items_with(roundtable_result_t *out, const replay_backend_t *be);
+   void roundtable_verify_items_with(roundtable_result_t *out, const replay_backend_t *be,
+                                     int require_evidence);
 
    /* Markdown appendix listing rejected items + the verified/degraded/capped
     * counts. Returns a malloc'd string (caller frees), or NULL if nothing to add. */

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -636,7 +636,7 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,
                                 roundtable_mode_t mode, int round, const char *brief,
-                                const char *context)
+                                const char *context, int require_evidence)
 {
    const char *role_hint = mode == ROUNDTABLE_REVIEW ? "review and critique" : "draft and revise";
    const char *mode_task =
@@ -652,12 +652,12 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
              "\"recommendation\":\"...\","
              "\"evidence\":{\"kind\":\"refs|symbol|search|none\",\"target\":\"symbol or search "
              "term\",\"project\":\"\",\"count\":0,\"factual\":true}}],\"overall\":\"...\"}. "
-             "evidence lets the engine VERIFY a factual structural claim against the code index "
-             "(you do NOT run it — just name it): kind=refs target=<fn> count=<claimed call "
-             "sites>; kind=symbol target=<symbol> (does it exist); kind=search target=<term>. Set "
-             "factual=true ONLY for a checkable code fact; for a judgment/opinion use kind=none "
-             "and factual=false (it will be capped below blocking). A blocking severity REQUIRES "
-             "reproducible factual evidence. "
+             "evidence lets the CHAIR VERIFY your claim against the code index (you do NOT run "
+             "it — just name what the chair should check): kind=refs target=<fn> count=<claimed "
+             "call sites>; kind=symbol target=<symbol> (does it exist); kind=search target=<term>. "
+             "Ground every finding with checkable evidence — name the refs/symbol/search the chair "
+             "can check, even for an interpretive concern. Set factual=true ONLY for a checkable "
+             "code fact; blocking REQUIRES reproducible factual evidence. "
              "Output raw JSON only — no markdown, no ``` code fences, no prose. "
              "Do not invent stable keys; the engine computes identity keys."
            : "Return the next complete draft. Incorporate useful peer input and do not describe "
@@ -670,6 +670,16 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
     * the bottom "return only JSON" instruction is tens of KB down the context and
     * long-context models drift to prose — which then parses to zero items. Leading
     * with the contract keeps it salient. */
+   /* The evidence VERDICT is conditional on the gate, so the prompt never promises a
+    * behavior the engine won't deliver: gate ON -> no-evidence findings are dropped
+    * (omit rather than fabricate); gate OFF -> legacy (kept but capped below blocking). */
+   const char *ev_verdict =
+       mode != ROUNDTABLE_REVIEW ? ""
+       : require_evidence
+           ? "\nEVIDENCE GATE: a finding with kind=none (no checkable evidence) is an "
+             "unfalsifiable opinion the chair will DISCARD — omit a genuinely non-verifiable "
+             "concern rather than fabricate evidence; it is dropped by design, not penalized."
+           : "\nA finding with kind=none is kept but capped below blocking (never blocking).";
    const char *head_note =
        mode == ROUNDTABLE_REVIEW
            ? "OUTPUT CONTRACT: reply with ONE raw JSON object "
@@ -712,7 +722,7 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
 
    size_t needed = strlen(task ? task : "") + strlen(artifact) + strlen(peer_notes) +
                    strlen(brief_block) + strlen(context_block) + strlen(mode_task) +
-                   strlen(role_hint) + strlen(head_note) + 512;
+                   strlen(ev_verdict) + strlen(role_hint) + strlen(head_note) + 512;
    char *prompt = malloc(needed);
    if (!prompt)
    {
@@ -724,9 +734,9 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
        prompt, needed,
        "You are one participant in an agent roundtable. Your role is to %s.\n\n%s"
        "TASK:\n%s\n\n%sCURRENT SHARED ARTIFACT:\n%s\n\nPEER NOTES FROM PREVIOUS TURN:\n%s\n\n%s"
-       "ROUND %d INSTRUCTION:\n%s\n",
+       "ROUND %d INSTRUCTION:\n%s%s\n",
        role_hint, head_note, task ? task : "", context_block, artifact[0] ? artifact : "(none yet)",
-       peer_notes[0] ? peer_notes : "(none yet)", brief_block, round, mode_task);
+       peer_notes[0] ? peer_notes : "(none yet)", brief_block, round, mode_task, ev_verdict);
 
    free(owned_brief_block);
    free(owned_context_block);
@@ -1135,7 +1145,8 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
    memset(personas, 0, sizeof(personas));
    for (int i = 0; i < ref_count; i++)
    {
-      prompts[i] = build_round_prompt(task, artifact, peer_notes, mode, round, brief, context);
+      prompts[i] = build_round_prompt(task, artifact, peer_notes, mode, round, brief, context,
+                                      cfg->roundtable_require_evidence);
       if (!prompts[i])
          goto fail;
       /* Per-participant persona is the system prompt (draft: engineer; review:
@@ -1218,7 +1229,8 @@ static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const
    for (int oi = 0; oi < ref_count; oi++)
    {
       int i = order[oi];
-      char *prompt = build_round_prompt(task, artifact, *peer_notes, mode, round, brief, context);
+      char *prompt = build_round_prompt(task, artifact, *peer_notes, mode, round, brief, context,
+                                        cfg->roundtable_require_evidence);
       if (!prompt)
          return -1;
       /* Persona binds to the stable model index `i`, not the shuffled slot. */
@@ -1863,7 +1875,7 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
           * artifact reflects only kept items; the rejected appendix is appended
           * after. Gated; off => identical to prior behavior. */
          if (cfg->roundtable_replay_verify_enabled)
-            roundtable_verify_items(out);
+            roundtable_verify_items(out, cfg->roundtable_require_evidence);
          best_artifact = assemble_review_artifact(out);
          if (cfg->roundtable_replay_verify_enabled)
             roundtable_artifact_append_rejected(&best_artifact, out);

--- a/src/server/roundtable_verify.c
+++ b/src/server/roundtable_verify.c
@@ -91,7 +91,8 @@ static int idkey_seen(const roundtable_result_t *out, int upto, const char *idke
    return -1;
 }
 
-void roundtable_verify_items_with(roundtable_result_t *out, const replay_backend_t *be)
+void roundtable_verify_items_with(roundtable_result_t *out, const replay_backend_t *be,
+                                  int require_evidence)
 {
    if (!out)
       return;
@@ -115,6 +116,12 @@ void roundtable_verify_items_with(roundtable_result_t *out, const replay_backend
       char sev[16];
       verify_action_t act =
           roundtable_grade_item(st, it.evidence.factual, it.severity, sev, sizeof(sev));
+
+      /* Evidence gate: a finding the chair cannot check against the code (no structured
+       * evidence) is an unfalsifiable opinion — reject it rather than keep it capped, so
+       * the primary never has to triage a claim no one can verify or refute. */
+      if (require_evidence && st == REPLAY_NO_EVIDENCE)
+         act = VERIFY_REJECT;
 
       if (act == VERIFY_REJECT)
       {
@@ -156,12 +163,12 @@ void roundtable_verify_items_with(roundtable_result_t *out, const replay_backend
    out->item_count = keep;
 }
 
-void roundtable_verify_items(roundtable_result_t *out)
+void roundtable_verify_items(roundtable_result_t *out, int require_evidence)
 {
    /* Use the process-registered backend (the server installs a kb_client-backed
     * one at startup). NULL backend => every item degrades (kept, unverified). The
     * verifier references no index/db2/kb symbol directly, so it links everywhere. */
-   roundtable_verify_items_with(out, evidence_replay_active_backend());
+   roundtable_verify_items_with(out, evidence_replay_active_backend(), require_evidence);
 }
 
 char *roundtable_render_rejected(const roundtable_result_t *out)

--- a/src/server/wfe_live_panel.c
+++ b/src/server/wfe_live_panel.c
@@ -339,7 +339,8 @@ static int live_panel(const wfe_review_packet_t *pkt, const char *const *require
        * reviewed: interpretation caps below blocking, contradicted claims are
        * rejected — the same rule as the compute roundtable, re-grounded. */
       wfe_replay_worktree_set_root(pkt->workdir);
-      roundtable_verify_items_with(&rt, wfe_replay_worktree_backend());
+      roundtable_verify_items_with(&rt, wfe_replay_worktree_backend(),
+                                   cfg.roundtable_require_evidence);
       wfe_replay_worktree_set_root(NULL);
       aimee_log(LOG_INFO, "wfe-panel",
                 "panel items: %d kept (verified=%d capped=%d degraded=%d), %d rejected",

--- a/src/tests/test_roundtable_verify.c
+++ b/src/tests/test_roundtable_verify.c
@@ -83,7 +83,7 @@ static void test_verify_items(void)
    set_item(&r->items[2], "blocking", "opinion", EV_NONE, NULL, 0);
    r->item_count = 3;
 
-   roundtable_verify_items_with(r, &be);
+   roundtable_verify_items_with(r, &be, 0);
 
    assert(r->item_count == 2); /* the contradicted item is removed */
    assert(r->rejected_count == 1);
@@ -119,7 +119,7 @@ static void test_dedup_by_idkey(void)
    snprintf(r->items[1].sources, sizeof(r->items[1].sources), "mistral");
    r->item_count = 2;
 
-   roundtable_verify_items_with(r, &be);
+   roundtable_verify_items_with(r, &be, 0);
    assert(r->item_count == 1); /* deduped */
    assert(r->verified_count == 1);
    assert(r->rejected_count == 0);
@@ -138,7 +138,7 @@ static void test_degrade_when_index_unavailable(void)
    set_item(&r->items[1], "blocking", "claim b", EV_REFS, "absent", 1);
    r->item_count = 2;
 
-   roundtable_verify_items_with(r, &be);
+   roundtable_verify_items_with(r, &be, 0);
    g_fpc = 1;                      /* restore for other tests */
    assert(r->item_count == 2);     /* both kept */
    assert(r->rejected_count == 0); /* nothing rejected when we cannot verify */
@@ -155,7 +155,7 @@ static void test_render_rejected(void)
    set_item(&r->items[0], "blocking", "bogus", EV_REFS, "absent", 1);
    set_item(&r->items[1], "blocking", "good", EV_REFS, "present", 1);
    r->item_count = 2;
-   roundtable_verify_items_with(r, &be);
+   roundtable_verify_items_with(r, &be, 0);
 
    char *md = roundtable_render_rejected(r);
    assert(md);
@@ -188,6 +188,50 @@ static void test_render_nothing(void)
    free(r);
 }
 
+/* The evidence gate: with require_evidence=1 a no-structured-evidence finding is
+ * REJECTED (not kept-and-capped), so an unfalsifiable opinion never reaches synthesis. */
+static void test_evidence_gate(void)
+{
+   replay_backend_t be = fake();
+
+   /* gate OFF: the EV_NONE opinion is capped and kept (legacy behavior). */
+   roundtable_result_t *r = calloc(1, sizeof(*r));
+   assert(r);
+   set_item(&r->items[0], "blocking", "real refs claim", EV_REFS, "present", 1);
+   set_item(&r->items[1], "suggestion", "opinion", EV_NONE, NULL, 0);
+   r->item_count = 2;
+   roundtable_verify_items_with(r, &be, 0);
+   assert(r->item_count == 2 && r->rejected_count == 0 && r->capped_count == 1);
+   free(r);
+
+   /* gate ON: the same EV_NONE opinion is rejected; the evidence-backed item survives. */
+   r = calloc(1, sizeof(*r));
+   assert(r);
+   set_item(&r->items[0], "blocking", "real refs claim", EV_REFS, "present", 1);
+   set_item(&r->items[1], "suggestion", "opinion", EV_NONE, NULL, 0);
+   r->item_count = 2;
+   roundtable_verify_items_with(r, &be, 1);
+   assert(r->item_count == 1);     /* only the evidence-backed finding remains */
+   assert(r->rejected_count == 1); /* the opinion was rejected by the gate */
+   assert(r->capped_count == 0);
+   assert(strcmp(r->items[0].summary, "real refs claim") == 0);
+   assert(strcmp(r->rejected[0].summary, "opinion") == 0);
+   free(r);
+
+   /* gate ON must NOT reject an evidence-BEARING item merely because the index is
+    * unavailable (that is DEGRADE, not NO_EVIDENCE) — the gate only drops kind=none. */
+   r = calloc(1, sizeof(*r));
+   assert(r);
+   g_fpc = 0; /* index unavailable -> replay yields INDEX_UNAVAILABLE -> DEGRADE */
+   set_item(&r->items[0], "blocking", "refs claim, index down", EV_REFS, "present", 1);
+   r->item_count = 1;
+   roundtable_verify_items_with(r, &be, 1);
+   g_fpc = 1; /* restore */
+   assert(r->item_count == 1 && r->rejected_count == 0 && r->degraded_count == 1);
+   assert(strcmp(r->items[0].severity, "blocking") == 0); /* degrade does not penalize */
+   free(r);
+}
+
 int main(void)
 {
    test_rubric();
@@ -196,6 +240,7 @@ int main(void)
    test_degrade_when_index_unavailable();
    test_render_rejected();
    test_render_nothing();
+   test_evidence_gate();
    printf("roundtable_verify: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Directive

Refuting participant findings should be the roundtable's job, not the primary agent's — and only *with evidence*. The engine already has a deterministic evidence-refuter (`roundtable_verify.c` — "the panel proposes, the code decides"), which on a recent PR correctly rejected 8 of 9 findings. This PR turns it into a **gate**.

## Change

New config **`roundtable_require_evidence`** (default **on**). When on, the chair **rejects** a finding with no structured evidence (`kind=none`) instead of keeping-and-capping it — a member may only raise a finding it backs with checkable evidence (`refs`/`symbol`/`search`) the chair can verify or refute against the code index. The primary then receives only evidence-backed, non-refuted findings.

- Threaded `require_evidence` through `roundtable_verify_items[_with]`; the **pure grade rubric `roundtable_grade_item` is unchanged** (only `NO_EVIDENCE` items are dropped — `CONTRADICTED`→reject, `MATCH`→keep, `INDEX_UNAVAILABLE`→degrade, reproduced-but-not-factual→cap all behave exactly as before).
- The member prompt's evidence **verdict is conditional on the flag** (gate on → "no-evidence findings are DISCARDED; omit a genuinely non-verifiable concern rather than fabricate evidence"; gate off → legacy "kept but capped"), so the prompt never promises behavior the engine won't deliver.
- Wired at the single-round compute roundtable and the wfe live panel (both had `cfg`).

## Scope

This is **PR-A (the deterministic gate)**. The LLM reasoning-chair — for a *technically-true-but-over-flagged* finding the code index can't refute (which needs judgment, "just like the primary did by hand") — is **PR-B**.

## Tests

`test_evidence_gate`: gate-off (legacy cap kept) vs gate-on (no-evidence rejected), plus the key regression — a gate-on evidence-BEARING item whose index is merely *unavailable* **degrades (kept), not rejected**. All roundtable tests pass; server links.

## Review

Roundtable-reviewed before opening (per the standing directive). It raised one blocking item — the prompt hardening was unconditional, so `require_evidence=0` didn't restore legacy wording — now fixed by making the verdict conditional. Its escape-hatch suggestion (omit rather than fabricate) and its regression-test nit are both folded in.