### PR TITLE
fix(ingress): codex buffered /v1/messages returned empty (parse raw SSE)

### DIFF
--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -423,24 +423,23 @@ static char *build_anthropic_provider_body(const cJSON *in, const agent_t *ag, i
  * malloc'd JSON string (caller frees) or NULL. */
 static char *anthropic_build_prov_body(cJSON *req, const delegate_driver_t *driver,
                                        const agent_t *ag, int parity, cJSON *messages, cJSON *tools,
-                                       const char *system_text)
+                                       const char *system_text, int stream)
 {
    char *prov_body = NULL;
    if (driver_is_anthropic(driver))
-      prov_body = build_anthropic_provider_body(req, ag, 0, parity);
+      prov_body = build_anthropic_provider_body(req, ag, stream, parity);
    else
    {
       if (aimee_ir_path_enabled())
          prov_body = aimee_ir_build_provider_body(
              req, driver->name, ag->model,
-             agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
-             0 /* buffered ingress: never ask the upstream to stream */);
+             agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)), stream);
       if (!prov_body)
       {
          aimee_ir_metric_inc(AIMEE_IR_M_LEGACY_FALLBACK, AIMEE_WIRE_ANTHROPIC);
          prov_body = build_provider_body(driver, ag, messages, tools, system_text,
                                          agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
-                                         jo_num(req, "temperature", 1.0), 0);
+                                         jo_num(req, "temperature", 1.0), stream);
       }
    }
    return prov_body;
@@ -528,12 +527,18 @@ static int messages_buffered(const char *body, char *resp, int cap)
       status = write_error(resp, cap, 503, "api_error", msg, AIMEE_ERR_ROUTE_UNRESOLVED);
       goto cleanup;
    }
+   /* Codex/Responses (chatgpt wire) replies with raw SSE even to a buffered fetch
+    * and requires stream=true; asking it for stream=false yields an empty body that
+    * cJSON_Parse can't read, so the buffered reply came back empty. Keyed off the
+    * resolved upstream shape (like the streaming path), not the provider label. */
+   int responses_wire = strstr(url, "/responses") != NULL;
    if (parity)
       build_anthropic_parity_headers(extra, sizeof(extra));
    else
       agent_build_extra_headers(ag, extra, sizeof(extra));
 
-   prov_body = anthropic_build_prov_body(req, driver, ag, parity, messages, tools, system_text);
+   prov_body = anthropic_build_prov_body(req, driver, ag, parity, messages, tools, system_text,
+                                         responses_wire);
    http_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &response, ag->timeout_ms,
                                  extra[0] ? extra : NULL);
 
@@ -550,7 +555,8 @@ static int messages_buffered(const char *body, char *resp, int cap)
       system_text = NULL;
       translate_request(req, driver, ag, &messages, &tools, &system_text);
       free(prov_body);
-      prov_body = anthropic_build_prov_body(req, driver, ag, parity, messages, tools, system_text);
+      prov_body = anthropic_build_prov_body(req, driver, ag, parity, messages, tools, system_text,
+                                            responses_wire);
       free(response);
       response = NULL;
       http_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &response,
@@ -580,12 +586,23 @@ static int messages_buffered(const char *body, char *resp, int cap)
       goto cleanup;
    }
 
-   provider_resp = cJSON_Parse(response);
    memset(&parsed, 0, sizeof(parsed));
-   if (provider_resp)
+   /* Codex/Responses replies with raw SSE (response.output_* / response.completed),
+    * not a JSON body — parse it directly via the driver, the same way the streaming
+    * buffered-replay path does. cJSON_Parse would fail and yield an empty reply. */
+   if (responses_wire)
    {
-      /* Slice 3: OPENAI-WIRE response parse via the IR (default-off flag). */
-      ir_or_legacy_parse_response(provider_resp, response, driver, &parsed);
+      if (driver && driver->parse_response)
+         driver->parse_response(NULL, response, &parsed);
+   }
+   else
+      provider_resp = cJSON_Parse(response);
+   if (responses_wire || provider_resp)
+   {
+      /* Slice 3: OPENAI-WIRE response parse via the IR (default-off flag). The
+       * responses-wire reply was already parsed above from raw SSE. */
+      if (!responses_wire)
+         ir_or_legacy_parse_response(provider_resp, response, driver, &parsed);
 
       /* Slice 2 (canonical-IR): shadow-compare the legacy parse against the IR
        * response parse -> RESP_MATCH / RESP_MISMATCH on GET /v1/dashboard/metrics.

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -120,9 +120,13 @@ void delegate_get_caps(const delegate_driver_t *driver, const agent_t *agent, dr
 int delegate_build_url(const delegate_driver_t *driver, const agent_t *agent, char *url,
                        size_t url_len)
 {
-   (void)driver;
    (void)agent;
-   snprintf(url, url_len, "https://example.invalid/v1/messages");
+   /* Mirror the real chatgpt driver: a codex/Responses agent resolves to a
+    * /responses URL, which drives the buffered responses-wire (raw-SSE) path. */
+   if (driver && driver->name && strcmp(driver->name, "chatgpt") == 0)
+      snprintf(url, url_len, "https://example.invalid/backend-api/codex/responses");
+   else
+      snprintf(url, url_len, "https://example.invalid/v1/messages");
    return 0;
 }
 
@@ -490,8 +494,54 @@ static void test_messages_buffered_anthropic_police_keeps_non_subagent_tool_use(
    PASS("messages_buffered_anthropic_police_keeps_non_subagent_tool_use");
 }
 
+/* parse_response stub for the codex/Responses buffered path: invoked with
+ * (NULL, raw_sse_body) — the same contract the chatgpt driver honors — and
+ * renders a text reply. Asserts it received the RAW body, not a cJSON tree. */
+static void parsed_text_pong(cJSON *root, const char *body, parsed_response_t *out)
+{
+   memset(out, 0, sizeof(*out));
+   assert(root == NULL);
+   assert(body != NULL && strstr(body, "response.completed") != NULL);
+   out->content = strdup("PONG");
+   snprintf(out->stop_reason, sizeof(out->stop_reason), "%s", "end_turn");
+}
+
+/* Codex/Responses (chatgpt wire) replies with raw SSE even to a buffered fetch, so
+ * the ingress must parse it via the driver. Regression guard: before the fix,
+ * messages_buffered cJSON_Parse'd the SSE (failed) and returned an EMPTY reply. */
+static void test_messages_buffered_responses_wire_parses_sse(void)
+{
+   const delegate_driver_t driver = {.name = "chatgpt", .parse_response = parsed_text_pong};
+   char resp[8192];
+   cJSON *sent;
+   const cJSON *content;
+   const cJSON *blk;
+   const cJSON *text;
+
+   reset_capture();
+   g_driver = &driver;
+   /* Raw SSE — invalid JSON on purpose, so the old cJSON_Parse path yields empty. */
+   g_response_body = "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n";
+
+   assert(messages_buffered("{\"model\":\"ignored\",\"max_tokens\":16,"
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                            resp, sizeof(resp)) == 200);
+
+   sent = parse(resp);
+   assert(sent != NULL);
+   content = obj(sent, "content");
+   assert(cJSON_IsArray(content) && cJSON_GetArraySize(content) >= 1);
+   blk = cJSON_GetArrayItem(content, 0);
+   text = obj(blk, "text");
+   assert(cJSON_IsString(text) && strcmp(text->valuestring, "PONG") == 0);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_buffered_responses_wire_parses_sse");
+}
+
 int main(void)
 {
+   test_messages_buffered_responses_wire_parses_sse();
    test_messages_buffered_anthropic_police_drops_subagent_tool_use();
    test_messages_buffered_anthropic_police_keeps_non_subagent_tool_use();
    printf("anthropic_http_p2c: OK\n");

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -527,6 +527,10 @@ static void test_messages_buffered_responses_wire_parses_sse(void)
                             "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
                             resp, sizeof(resp)) == 200);
 
+   /* Send-side half of the fix: the buffered Responses fetch must ask for
+    * stream=true (codex requires it), even though the ingress reads it buffered. */
+   assert(g_last_body != NULL && strstr(g_last_body, "\"stream\":true") != NULL);
+
    sent = parse(resp);
    assert(sent != NULL);
    content = obj(sent, "content");


### PR DESCRIPTION
## Problem

With codex as the `/v1` primary, **buffered** `/v1/messages` (`stream:false`) returned an empty message — `{"content":[{"type":"text","text":""}],"usage":{...0...}}` — while **streaming** worked fine.

Root cause: `messages_buffered` asks the upstream for a non-streamed reply and `cJSON_Parse`s it. But codex/Responses (the `chatgpt` wire, `.../responses`) replies with **raw SSE** (`response.output_*` / `response.completed`) even to a buffered fetch and requires `stream:true`. So `cJSON_Parse` failed, `parsed` stayed zeroed, and the reply came back empty. The **streaming** path already special-cases this (`responses_wire` → `stream:true` + `driver->parse_response(NULL, resp)` raw-SSE parse); the buffered path did not.

## Fix

In `messages_buffered`, key off the resolved upstream shape — `responses_wire = strstr(url, "/responses")`, the **same signal the streaming path uses** — and for a responses-wire agent:
- build the provider body with `stream=true` (threaded through `anthropic_build_prov_body`, incl. the gateway-mutation restore-resend), and
- parse the reply via `driver->parse_response(NULL, response, &parsed)` (raw SSE) instead of `cJSON_Parse`.

Non-responses wires are unchanged (`cJSON_Parse` JSON path). `provider_resp` stays `NULL` on the responses-wire branch (initialized `NULL`; freed in cleanup).

## Test

`test_anthropic_http_p2c` — a `chatgpt`-driver agent resolving to `/responses` with a raw-SSE upstream body now renders the parsed text (`"PONG"`) instead of an empty reply, **and** the outbound body is asserted to carry `stream:true` (send-side half). Driver-aware `build_url` stub returns `/responses` for `chatgpt`. All 3 ingress tests pass; builds clean under `WITH_TLS`.

## Not this bug
codex **streaming** already works — an earlier "streaming unparseable" symptom was a misconfigured primary (`default_agent` vs `default` key), not a codex bug.

## Review
Roundtable-reviewed (no blocking findings). Applied its send-side test suggestion; declined the substring→shared-helper / options-struct refactors as consistency with the existing streaming path (identical `strstr(url,"/responses")` signal + `stream` param) — those are cross-cutting follow-ups on that path, not this fix.