### PR TITLE
refactor(webchat): adopt smoothgui InlineStatus across 8 pages

### DIFF
--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
-import { Panel, Badge, Spinner, Modal } from "@rakuensoftware/smoothgui";
+import { Panel, Badge, Spinner, Modal, InlineStatus } from "@rakuensoftware/smoothgui";
 import PrimaryChooser from "../setup/PrimaryChooser";
 
 /* ---- API types ---- */
@@ -178,16 +178,7 @@ export default function Agents() {
           {showAdd ? "Close" : "+ Add delegate"}
         </button>
         <Spinner loading={loading} text="loading…" />
-        {status && (
-          <span
-            style={{
-              fontSize: 13,
-              color: status.kind === "err" ? "#c00" : "#070",
-            }}
-          >
-            {status.msg}
-          </span>
-        )}
+        <InlineStatus status={status} />
       </div>
 
       {showAdd && (

--- a/frontend/src/pages/EditWorkflows.tsx
+++ b/frontend/src/pages/EditWorkflows.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
+import { Panel, Badge, Spinner, InlineStatus } from "@rakuensoftware/smoothgui";
 import ProjectPicker from "../components/ProjectPicker";
 import type { ProjectSelection } from "../components/ProjectPicker";
 import { useSessions } from "../SessionContext";
@@ -830,21 +830,7 @@ export default function EditWorkflows() {
           >
             Save
           </button>
-          {status && (
-            <span
-              style={{
-                color:
-                  status.kind === "err"
-                    ? "#c00"
-                    : status.kind === "ok"
-                      ? "#070"
-                      : "#666",
-                fontSize: 13,
-              }}
-            >
-              {status.msg}
-            </span>
-          )}
+          <InlineStatus status={status} />
           <Spinner loading={loading} text="loading…" />
         </div>
         <div

--- a/frontend/src/pages/Personas.tsx
+++ b/frontend/src/pages/Personas.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Panel, Badge } from "@rakuensoftware/smoothgui";
+import { Panel, Badge, InlineStatus } from "@rakuensoftware/smoothgui";
 
 /* Personas page: edit the PERSONA definitions (identity + the roles each persona
  * may use). Roles themselves — their bodies and per-role turn caps — live on the
@@ -162,9 +162,7 @@ export default function Personas() {
     <div style={{ padding: 16, fontFamily: "system-ui", height: "100%", overflow: "auto" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
         <strong style={{ fontSize: 18 }}>Personas</strong>
-        {status && (
-          <span style={{ fontSize: 13, color: status.kind === "err" ? "#b00" : "#080" }}>{status.msg}</span>
-        )}
+        <InlineStatus status={status} />
       </div>
 
       <div style={{ maxWidth: 720 }}>

--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { InlineStatus } from "@rakuensoftware/smoothgui";
 import { FIELD_HELP } from "./settingsHelp";
 
 /* Pipeline page: the curator pipeline as an ordered, resource-lane-grouped view.
@@ -512,7 +513,9 @@ export default function Pipeline() {
         <div style={{ color: "#888" }}>No stages reported (aimee-server unreachable, or the KB has no curator registry).</div>
       )}
       {status && (
-        <div style={{ fontSize: 13, color: status.kind === "ok" ? "#2a2" : "#c33", marginTop: 8 }}>{status.msg}</div>
+        <div style={{ marginTop: 8 }}>
+          <InlineStatus status={status} />
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/Roles.tsx
+++ b/frontend/src/pages/Roles.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Panel } from "@rakuensoftware/smoothgui";
+import { Panel, InlineStatus } from "@rakuensoftware/smoothgui";
 
 /* Roles page: edit the shared ROLE vocabulary — each role's name, what it does
  * (the delegate system-prompt template), and its per-role turn cap (max_turns,
@@ -135,9 +135,7 @@ export default function Roles() {
     <div style={{ padding: 16, fontFamily: "system-ui", height: "100%", overflow: "auto" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
         <strong style={{ fontSize: 18 }}>Roles</strong>
-        {status && (
-          <span style={{ fontSize: 13, color: status.kind === "err" ? "#b00" : "#080" }}>{status.msg}</span>
-        )}
+        <InlineStatus status={status} />
       </div>
 
       <div style={{ maxWidth: 720 }}>

--- a/frontend/src/pages/Roundtable.tsx
+++ b/frontend/src/pages/Roundtable.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Panel } from "@rakuensoftware/smoothgui";
+import { Panel, InlineStatus } from "@rakuensoftware/smoothgui";
 
 /* Roundtable page: configure the named multi-model review panels ("roundtables")
  * aimee convenes. A preset captures the seats (a model + a persona per seat), the
@@ -255,9 +255,7 @@ export default function Roundtable() {
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
         <strong style={{ fontSize: 18 }}>Roundtable</strong>
         {active && <span style={{ fontSize: 12, color: "#666" }}>active: <code>{active}</code></span>}
-        {status && (
-          <span style={{ fontSize: 13, color: status.kind === "err" ? "#b00" : "#080" }}>{status.msg}</span>
-        )}
+        <InlineStatus status={status} />
       </div>
 
       <div style={{ maxWidth: 760 }}>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Panel, Badge } from "@rakuensoftware/smoothgui";
+import { Panel, Badge, InlineStatus } from "@rakuensoftware/smoothgui";
 import { FIELD_HELP, SECTION_HELP, RESTART_KEYS } from "./settingsHelp";
 import { resetAll as resetTutorials } from "../help/tutorialState";
 import { setDismissed as setSetupDismissed, requestOpenWizard } from "../setup/setupState";
@@ -169,17 +169,7 @@ export default function Settings() {
         >
           Re-run setup
         </button>
-        {status && (
-          <span
-            style={{
-              fontSize: 12,
-              color: status.kind === "err" ? "#b00" : "#080",
-              maxWidth: 620,
-            }}
-          >
-            {status.msg}
-          </span>
-        )}
+        <InlineStatus status={status} />
       </div>
       <p style={{ fontSize: 12, color: "#666", margin: "0 0 12px" }}>
         Changes persist to <code>aimee.yaml</code> and take effect on the next turn, unless a row is

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
+import { Panel, Badge, Spinner, InlineStatus } from "@rakuensoftware/smoothgui";
 import type { BadgeVariant } from "@rakuensoftware/smoothgui";
 import { renderMd } from "./chat/markdown";
 
@@ -439,8 +439,8 @@ export default function WorkflowActions() {
           Show all (operator)
         </label>
         {status && (
-          <div style={{ fontSize: 12, color: status.kind === "err" ? "#c00" : "#070", marginTop: 6 }}>
-            {status.msg}
+          <div style={{ marginTop: 6 }}>
+            <InlineStatus status={status} />
           </div>
         )}
         <div style={{ marginTop: 8 }}>


### PR DESCRIPTION
## What

Third slice of the webchat smoothgui-primitive migration (after #1448, #1453). By-primitive sweep: the `{kind:'ok'|'err'}` red/green **form-status** ternary duplicated on every mutating page → the shared **`<InlineStatus>`**.

Pages: `Agents`, `EditWorkflows`, `Personas`, `Pipeline`, `Roles`, `Roundtable`, `Settings`, `WorkflowActions`. **Net −36 lines.**

## Verified against smoothgui 0.7.0 (roundtable follow-ups)

- **`info` kind supported.** `InlineStatusKind = 'ok'|'err'|'info'`; EditWorkflows' three-way maps cleanly (`info` → `textSecondary` = #666, unchanged).
- **Null-safe.** `InlineStatus` returns `null` for null/empty status, so the `{status && …}` guard is safely dropped where it only wrapped the span. Pipeline/WorkflowActions keep the guard so their `marginTop` wrapper never renders empty.
- **Settings `maxWidth:620`** was on an *inline* `<span>` — a CSS no-op — so dropping it changes nothing.

## Behaviour deltas (minor, intentional)

- Colors move to shared tokens (err `#c62828`, ok `#2e7d32`) per the agreed palette adoption.
- `InlineStatus` renders at `fontSize:12`; Settings was already 12 (unchanged), the other five pages shrink 13→12px.
- Top margins preserved via a thin wrapper where present (Pipeline, WorkflowActions).

## Follow-up

Adding a margin/`className` passthrough to `InlineStatus` would let the two wrapper divs go away — a small upstream smoothgui tweak, deferred.

## Verification

frontend tsc + build (spa + console) clean; 93/93 vitest.
