### PR TITLE
refactor(webchat): adopt smoothgui Switch for the Pipeline stage toggles

### DIFF
--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { InlineStatus } from "@rakuensoftware/smoothgui";
+import { InlineStatus, Switch } from "@rakuensoftware/smoothgui";
 import { FIELD_HELP } from "./settingsHelp";
 
 /* Pipeline page: the curator pipeline as an ordered, resource-lane-grouped view.
@@ -345,20 +345,14 @@ export default function Pipeline() {
         {gated ? (
           <span style={{ fontSize: 12, color: "#7d7", whiteSpace: "nowrap" }}>● active</span>
         ) : (
-          <button
-            disabled={busy === s.config_key}
-            onClick={() => toggle(s.config_key as string, !on)}
-            title={on ? "Disable stage" : "Enable stage"}
-            style={{
-              width: 52, height: 26, borderRadius: 13, border: "1px solid #ccc", cursor: "pointer",
-              background: on ? "#7d7" : "#ddd", position: "relative", transition: "background .15s",
-            }}
-          >
-            <span style={{
-              position: "absolute", top: 2, left: on ? 28 : 2, width: 20, height: 20,
-              borderRadius: "50%", background: "#fff", transition: "left .15s",
-            }} />
-          </button>
+          <span title={on ? "Disable stage" : "Enable stage"} style={{ display: "inline-flex" }}>
+            <Switch
+              checked={on}
+              onChange={(next) => toggle(s.config_key as string, next)}
+              disabled={busy === s.config_key}
+              ariaLabel={on ? "Disable stage" : "Enable stage"}
+            />
+          </span>
         )}
       </div>
     );
@@ -477,20 +471,14 @@ export default function Pipeline() {
                       </div>
                       <div style={{ fontSize: 12, color: "#777" }}>Recomposes {s.base_op} on the {s.lane} lane.</div>
                     </div>
-                    <button
-                      disabled={busy === "custom-stages"}
-                      onClick={() => toggleCustomStage(s.name, !on)}
-                      title={on ? "Disable stage" : "Enable stage"}
-                      style={{
-                        width: 52, height: 26, borderRadius: 13, border: "1px solid #ccc", cursor: "pointer",
-                        background: on ? "#7d7" : "#ddd", position: "relative", transition: "background .15s",
-                      }}
-                    >
-                      <span style={{
-                        position: "absolute", top: 2, left: on ? 28 : 2, width: 20, height: 20,
-                        borderRadius: "50%", background: "#fff", transition: "left .15s",
-                      }} />
-                    </button>
+                    <span title={on ? "Disable stage" : "Enable stage"} style={{ display: "inline-flex" }}>
+                      <Switch
+                        checked={on}
+                        onChange={(next) => toggleCustomStage(s.name, next)}
+                        disabled={busy === "custom-stages"}
+                        ariaLabel={on ? "Disable stage" : "Enable stage"}
+                      />
+                    </span>
                     <button
                       disabled={busy === "custom-stages"}
                       onClick={() => deleteCustomStage(s.name)}


### PR DESCRIPTION
Slice 5. The two identical hand-rolled 52×26 sliding toggles in Pipeline (built-in + custom stage enable/disable) → shared `<Switch>`. `onChange` receives the new checked value; palette shifts to `tokens.success`.

**Roundtable Blocking resolved:** the original toggles had a `title` hover tooltip that `Switch` (aria-label only) dropped — each `<Switch>` is now wrapped in a `<span title=…>` restoring the tooltip. (Adding a `title` prop to `Switch` upstream is a possible future cleanup.)

Verified: tsc + build (spa+console) clean; 93/93 vitest.