### PR TITLE
refactor(webchat): adopt smoothgui TypingIndicator + DiffViewer in chat

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
-import { Spinner, Tabs, tokens } from '@rakuensoftware/smoothgui';
+import { Spinner, Tabs, TypingIndicator, tokens } from '@rakuensoftware/smoothgui';
 import { BootstrapBanner, DiffBlock, Message, RewindMarker, ThinkingBlock, ToolBlock, TurnSummaryCard } from './chat/ChatPrimitives';
 import { renderWithMentions } from './chat/markdown';
 import ProjectPicker from '../components/ProjectPicker';
@@ -830,32 +830,6 @@ function PluginsPanel({ open, plugins, loading, error, onToggle, onRefresh, onPl
   );
 }
 
-/* ---- Working indicator ---- */
-
-function WorkingIndicator() {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '8px 14px', color: tokens.primary, fontSize: '13px', alignSelf: 'flex-start' }}>
-      <div style={{ display: 'inline-flex', gap: '4px' }}>
-        {[0, 0.2, 0.4].map((delay, i) => (
-          <span
-            key={i}
-            style={{
-              width: 6, height: 6, borderRadius: '50%', background: tokens.primary,
-              animation: `pulse 1.4s ${delay}s infinite ease-in-out`,
-            }}
-          />
-        ))}
-      </div>
-      Working
-      <style>{`
-        @keyframes pulse {
-          0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
-          40% { opacity: 1; transform: scale(1); }
-        }
-      `}</style>
-    </div>
-  );
-}
 
 function WorkflowStatusCard({
   channel,
@@ -3079,7 +3053,7 @@ export default function Chat() {
           </button>
         )}
         <Transcript messages={windowedMsgs} working={working} activeSid={tabs[activeIdx]?.aimeeSid ?? ''} />
-        {working && <WorkingIndicator />}
+        {working && <div style={{ alignSelf: 'flex-start' }}><TypingIndicator /></div>}
         {remoteTurnActive && !working && (
           <div style={{
             alignSelf: 'flex-start', maxWidth: '85%', padding: '6px 10px',

--- a/frontend/src/pages/chat/ChatPrimitives.tsx
+++ b/frontend/src/pages/chat/ChatPrimitives.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo, useState } from 'react';
-import { tokens } from '@rakuensoftware/smoothgui';
+import { tokens, DiffViewer } from '@rakuensoftware/smoothgui';
 import { escHtml, renderMd } from './markdown';
 
 interface BootstrapStack {
@@ -106,19 +106,10 @@ export const TurnSummaryCard = memo(function TurnSummaryCard({ text }: { text: s
 });
 
 export const DiffBlock = memo(function DiffBlock({ path, diff }: { path?: string; diff: string }) {
-  const lines = diff.split('\n');
   return (
     <details style={{ margin: '4px 0', padding: '8px 10px', background: '#0d1117', borderLeft: '3px solid #444', borderRadius: '4px', fontSize: '12px', alignSelf: 'flex-start', maxWidth: '90%' }}>
       <summary style={{ cursor: 'pointer', color: '#8bf', fontSize: '12px', fontFamily: 'monospace' }}>{path ? `diff: ${path}` : 'diff'}</summary>
-      <pre style={{ margin: '6px 0 0', fontSize: '11px', fontFamily: 'monospace', lineHeight: 1.4, overflow: 'auto', maxHeight: '300px' }}>
-        {lines.map((line, i) => {
-          let color = '#ccc';
-          if (line.startsWith('+') && !line.startsWith('+++')) color = '#4ec94e';
-          else if (line.startsWith('-') && !line.startsWith('---')) color = '#f87171';
-          else if (line.startsWith('@@')) color = '#60a5fa';
-          return <span key={i} style={{ color, display: 'block' }}>{line}</span>;
-        })}
-      </pre>
+      <DiffViewer diff={diff} />
     </details>
   );
 });


### PR DESCRIPTION
Slice 6. The chat's local `WorkingIndicator` and `DiffBlock` were the original sources of the shared `TypingIndicator`/`DiffViewer` (smoothgui#22), so these are faithful round-trips:
- `WorkingIndicator` (3 pulsing dots + inline `@keyframes`) → `<TypingIndicator/>` (wrapped to preserve `alignSelf:flex-start`). Removes per-mount `<style>` injection.
- `DiffBlock`'s hand-rolled +/-/@@ colorizer → `<DiffViewer/>` inside its existing `<details>`; same palette, `+++`/`---` headers still excluded, lines still rendered as escaped text.

Net −35 lines. Roundtable: no issues. Verified: tsc + build (spa+console) + 93/93 vitest.