### PR TITLE
refactor(webchat): adopt smoothgui Button across 8 pages

### DIFF
--- a/frontend/src/components/ProjectPicker.tsx
+++ b/frontend/src/components/ProjectPicker.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Picker } from '@rakuensoftware/smoothgui';
+import { Button, Picker } from '@rakuensoftware/smoothgui';
 import type { GitProjectsResponse } from '../setup/ownerUrl';
 
 /* ProjectPicker — a compact "select or clone a project" control embedded in each
@@ -24,7 +24,6 @@ async function api(path: string, init?: RequestInit): Promise<Response> {
 }
 
 const input: React.CSSProperties = { padding: '5px 8px', borderRadius: 4, border: '1px solid #ccc', fontSize: 13 };
-const btn: React.CSSProperties = { padding: '5px 10px', borderRadius: 4, border: '1px solid #ccc', background: '#fff', color: '#444', cursor: 'pointer', fontSize: 13 };
 
 export default function ProjectPicker({ storageKey, onChange }: {
   storageKey: string;
@@ -101,9 +100,9 @@ export default function ProjectPicker({ storageKey, onChange }: {
         onChange={select}
         error={err}
         actions={
-          <button style={btn} onClick={() => setCloneOpen(o => !o)}>
+          <Button size="md" onClick={() => setCloneOpen(o => !o)}>
             {cloneOpen ? 'Cancel' : '+ Clone repo'}
-          </button>
+          </Button>
         }
       />
       {cloneOpen && (
@@ -112,8 +111,8 @@ export default function ProjectPicker({ storageKey, onChange }: {
             value={url} onChange={e => setUrl(e.target.value)} />
           <input style={{ ...input, flex: 1, minWidth: 160 }} type="password" autoComplete="off"
             placeholder="access token (private repos)" value={token} onChange={e => setToken(e.target.value)} />
-          <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
-            disabled={busy || !url.trim()} onClick={clone}>Clone</button>
+          <Button variant="primary" size="md"
+            disabled={busy || !url.trim()} onClick={clone}>Clone</Button>
         </div>
       )}
     </div>

--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Badge, Panel } from '@rakuensoftware/smoothgui';
+import { Badge, Button, Panel } from '@rakuensoftware/smoothgui';
 import { useSessions } from '../SessionContext';
 
 /* §8 code-graph visualization. A read-only, navigable view of the code projection
@@ -79,7 +79,7 @@ export default function Graph() {
         <strong>Code graph — {project}</strong>
         {edgeCount != null && <Badge label={`${edgeCount} edges`} variant="neutral" />}
         {loading && <span style={{ color: '#888', fontSize: 12 }}>loading…</span>}
-        <button onClick={loadHubs} style={{ marginLeft: 'auto', ...btn }} title="Reload the ranked hub list for this project's code graph.">↻ refresh</button>
+        <Button size="sm" onClick={loadHubs} style={{ marginLeft: 'auto' }} title="Reload the ranked hub list for this project's code graph.">↻ refresh</Button>
       </div>
       {err && <div style={{ color: '#b00', fontSize: 13 }}>{err}</div>}
 
@@ -115,7 +115,7 @@ export default function Graph() {
 
       <Panel title="Surprising links" count={links.length}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-          <button onClick={loadSurprising} style={btn} title="Find file pairs that are semantically close yet structurally far apart.">find</button>
+          <Button size="sm" onClick={loadSurprising} title="Find file pairs that are semantically close yet structurally far apart.">find</Button>
           <label style={{ fontSize: 12, color: '#555' }} title="Run an LLM to confirm or reject each surprising link (slower).">
             <input type="checkbox" checked={judge} onChange={e => setJudge(e.target.checked)} /> LLM confirm
           </label>
@@ -142,7 +142,6 @@ function shortNode(n: string): string {
   return i >= 0 ? n.slice(i + 1) : n;
 }
 
-const btn: React.CSSProperties = { padding: '3px 10px', borderRadius: 4, border: '1px solid #ccc', background: '#fff', color: '#444', cursor: 'pointer', fontSize: 12 };
 const row: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 6, padding: '4px 6px', borderRadius: 4, border: 'none', background: '#fff', cursor: 'pointer', fontSize: 12, textAlign: 'left', width: '100%' };
 const ellipsis: React.CSSProperties = { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 240 };
 const empty: React.CSSProperties = { color: '#999', fontSize: 12, padding: 8 };

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
-import { Badge, Modal, EmptyState } from '@rakuensoftware/smoothgui';
+import { Badge, Button, Modal, EmptyState } from '@rakuensoftware/smoothgui';
 import type { BadgeVariant } from '@rakuensoftware/smoothgui';
 
 /* All fields of an audit row, in display order, for the detail modal. */
@@ -134,7 +134,7 @@ export default function Logs() {
           <select value={actor} onChange={e => setActor(e.target.value)} style={selectStyle} title="Filter rows by actor (primary agent or delegate).">
             {['all', 'primary', 'delegate'].map(a => <option key={a} value={a}>{a}</option>)}
           </select>
-          <button onClick={load} style={{ ...selectStyle, cursor: 'pointer' }} title="Reload the newest page of audit rows.">Refresh</button>
+          <Button size="sm" onClick={load} title="Reload the newest page of audit rows.">Refresh</Button>
           {loading && <span style={{ fontSize: 12, color: '#aaa' }}>Loading…</span>}
         </div>
       </div>
@@ -179,13 +179,14 @@ export default function Logs() {
         )}
         {rows.length < total && (
           <div style={{ padding: 12, textAlign: 'center' }}>
-            <button
+            <Button
+              size="sm"
               onClick={loadMore}
               disabled={loadingMore}
-              style={{ ...selectStyle, cursor: 'pointer', padding: '6px 16px' }}
+              style={{ padding: '6px 16px' }}
             >
               {loadingMore ? 'Loading…' : `Load ${Math.min(PAGE, total - rows.length).toLocaleString()} more`}
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/frontend/src/pages/Personas.tsx
+++ b/frontend/src/pages/Personas.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Panel, Badge, InlineStatus } from "@rakuensoftware/smoothgui";
+import { Button, Panel, Badge, InlineStatus } from "@rakuensoftware/smoothgui";
 
 /* Personas page: edit the PERSONA definitions (identity + the roles each persona
  * may use). Roles themselves — their bodies and per-role turn caps — live on the
@@ -47,14 +47,6 @@ interface PersonaDef {
   builtin?: boolean;
 }
 
-const btn: React.CSSProperties = {
-  padding: "4px 10px",
-  fontSize: 13,
-  borderRadius: 6,
-  border: "1px solid #ccc",
-  background: "#fff",
-  cursor: "pointer",
-};
 const lbl: React.CSSProperties = { fontSize: 12, color: "#666", display: "block", marginBottom: 2 };
 const ta: React.CSSProperties = {
   width: "100%",
@@ -173,23 +165,25 @@ export default function Personas() {
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
             {personas.map((p) => (
-              <button
+              <Button
                 key={p.name}
+                size="md"
                 onClick={() => openPersona(p.name)}
-                style={{ ...btn, background: form?.name === p.name ? "#e8eef9" : "#fff" }}
+                style={{ background: form?.name === p.name ? "#e8eef9" : "#fff" }}
                 title={p.description || ""}
               >
                 {p.name}
                 {p.builtin ? " ·" : ""}
-              </button>
+              </Button>
             ))}
-            <button
+            <Button
+              size="md"
               onClick={newPersona}
-              style={{ ...btn, borderStyle: "dashed" }}
+              style={{ borderStyle: "dashed" }}
               title="Create a new persona from scratch"
             >
               + New
-            </button>
+            </Button>
           </div>
 
           {form && (
@@ -217,19 +211,18 @@ export default function Personas() {
                   {roleOptions.map((r) => {
                     const on = (form.roles || []).includes(r);
                     return (
-                      <button
+                      <Button
                         key={r}
+                        size="sm"
                         onClick={() => toggleRole(r)}
                         style={{
-                          ...btn,
-                          padding: "2px 8px",
                           background: on ? "#1f7a3d" : "#fff",
                           color: on ? "#fff" : r === "all" ? "#a15" : "#333",
                           fontWeight: r === "all" ? 600 : 400,
                         }}
                       >
                         {r}
-                      </button>
+                      </Button>
                     );
                   })}
                 </div>
@@ -259,16 +252,17 @@ export default function Personas() {
                 <textarea rows={3} style={ta} value={form.brief || ""} onChange={(e) => upd({ brief: e.target.value })} />
               </div>
               <div style={{ display: "flex", gap: 8 }}>
-                <button onClick={savePersona} style={btn} title="Write this persona to config.">
+                <Button size="md" onClick={savePersona} title="Write this persona to config.">
                   Save persona
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="danger"
+                  size="md"
                   onClick={deletePersona}
-                  style={{ ...btn, color: "#b00" }}
                   title="Delete this persona. Built-ins reset to their default instead of disappearing."
                 >
                   Delete
-                </button>
+                </Button>
                 {form.builtin && <Badge label="built-in" variant="neutral" />}
               </div>
             </div>

--- a/frontend/src/pages/Pipeline.tsx
+++ b/frontend/src/pages/Pipeline.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { InlineStatus, Switch } from "@rakuensoftware/smoothgui";
+import { Button, InlineStatus, Switch } from "@rakuensoftware/smoothgui";
 import { FIELD_HELP } from "./settingsHelp";
 
 /* Pipeline page: the curator pipeline as an ordered, resource-lane-grouped view.
@@ -479,17 +479,16 @@ export default function Pipeline() {
                         ariaLabel={on ? "Disable stage" : "Enable stage"}
                       />
                     </span>
-                    <button
+                    <Button
+                      variant="danger"
+                      size="md"
                       disabled={busy === "custom-stages"}
                       onClick={() => deleteCustomStage(s.name)}
                       title={`Delete custom stage "${s.name}"`}
-                      style={{
-                        padding: "5px 8px", fontSize: 13, borderRadius: 6, cursor: "pointer",
-                        border: "1px solid #cbd5e1", background: "#fff", color: "#b00",
-                      }}
+                      style={{ padding: "5px 8px" }}
                     >
                       ×
-                    </button>
+                    </Button>
                   </div>
                 );
               })

--- a/frontend/src/pages/Roles.tsx
+++ b/frontend/src/pages/Roles.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Panel, InlineStatus } from "@rakuensoftware/smoothgui";
+import { Button, Panel, InlineStatus } from "@rakuensoftware/smoothgui";
 
 /* Roles page: edit the shared ROLE vocabulary — each role's name, what it does
  * (the delegate system-prompt template), and its per-role turn cap (max_turns,
@@ -30,14 +30,6 @@ async function sendJSON<T>(
   return { status: r.status, data };
 }
 
-const btn: React.CSSProperties = {
-  padding: "4px 10px",
-  fontSize: 13,
-  borderRadius: 6,
-  border: "1px solid #ccc",
-  background: "#fff",
-  cursor: "pointer",
-};
 const lbl: React.CSSProperties = { fontSize: 12, color: "#666", display: "block", marginBottom: 2 };
 const ta: React.CSSProperties = {
   width: "100%",
@@ -147,18 +139,19 @@ export default function Roles() {
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
             {roles.map((r) => (
-              <button
+              <Button
                 key={r}
+                size="md"
                 onClick={() => openRole(r)}
-                style={{ ...btn, background: roleSel === r ? "#e8eef9" : "#fff" }}
+                style={{ background: roleSel === r ? "#e8eef9" : "#fff" }}
                 title="Open this role to edit its prompt template and turn cap."
               >
                 {r}
-              </button>
+              </Button>
             ))}
-            <button onClick={newRole} style={{ ...btn, borderStyle: "dashed" }} title="Create a new role, prompting for its name.">
+            <Button size="md" onClick={newRole} style={{ borderStyle: "dashed" }} title="Create a new role, prompting for its name.">
               + New
-            </button>
+            </Button>
           </div>
           {roleSel && (
             <div>
@@ -181,12 +174,12 @@ export default function Roles() {
                 }}
               />
               <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
-                <button onClick={saveRole} style={btn} title="Save this role's template and turn cap.">
+                <Button size="md" onClick={saveRole} title="Save this role's template and turn cap.">
                   Save role
-                </button>
-                <button onClick={deleteRole} style={{ ...btn, color: "#b00" }} title="Delete this role; built-in roles reset to their default.">
+                </Button>
+                <Button variant="danger" size="md" onClick={deleteRole} title="Delete this role; built-in roles reset to their default.">
                   Delete
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/frontend/src/pages/Roundtable.tsx
+++ b/frontend/src/pages/Roundtable.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Panel, InlineStatus } from "@rakuensoftware/smoothgui";
+import { Button, Panel, InlineStatus } from "@rakuensoftware/smoothgui";
 
 /* Roundtable page: configure the named multi-model review panels ("roundtables")
  * aimee convenes. A preset captures the seats (a model + a persona per seat), the
@@ -58,14 +58,6 @@ type Preset = {
 type PresetSummary = { name: string; description?: string; active?: boolean; synthesized?: boolean };
 type Status = { kind: "ok" | "err"; msg: string } | null;
 
-const btn: React.CSSProperties = {
-  padding: "4px 10px",
-  fontSize: 13,
-  borderRadius: 6,
-  border: "1px solid #ccc",
-  background: "#fff",
-  cursor: "pointer",
-};
 const lbl: React.CSSProperties = { fontSize: 12, color: "#666", display: "block", marginBottom: 2 };
 const input: React.CSSProperties = {
   width: "100%",
@@ -267,23 +259,23 @@ export default function Roundtable() {
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
             {presets.map((p) => (
-              <button
+              <Button
                 key={p.name}
+                size="md"
                 onClick={() => openPreset(p.name)}
                 title={p.description || ""}
                 style={{
-                  ...btn,
                   background: sel === p.name ? "#e8eef9" : "#fff",
                   fontWeight: p.active ? 700 : 400,
                 }}
               >
                 {p.name}
                 {p.active ? " ★" : ""}
-              </button>
+              </Button>
             ))}
-            <button onClick={newPreset} style={{ ...btn, borderStyle: "dashed" }} title="Create a new roundtable preset, prompting for its name.">
+            <Button size="md" onClick={newPreset} style={{ borderStyle: "dashed" }} title="Create a new roundtable preset, prompting for its name.">
               + New
-            </button>
+            </Button>
           </div>
 
           {form && (
@@ -318,13 +310,14 @@ export default function Roundtable() {
                     readOnly={isRandom}
                     onChange={(e) => setSeat(i, { model: e.target.value })}
                   />
-                  <button
+                  <Button
+                    size="md"
                     onClick={() => setSeat(i, { model: isRandom ? "" : RANDOM_MODEL })}
-                    style={{ ...btn, padding: "4px 8px", background: isRandom ? "#e8eef9" : "#fff", fontWeight: isRandom ? 700 : 400 }}
+                    style={{ padding: "4px 8px", background: isRandom ? "#e8eef9" : "#fff", fontWeight: isRandom ? 700 : 400 }}
                     title={isRandom ? "switch to a specific pinned model" : "let any review-capable agent fill this seat (retried until one is accepted)"}
                   >
                     🎲 Random
-                  </button>
+                  </Button>
                   <input
                     list={personaList}
                     style={{ ...input, flex: 1 }}
@@ -333,19 +326,21 @@ export default function Roundtable() {
                     value={seat.persona}
                     onChange={(e) => setSeat(i, { persona: e.target.value })}
                   />
-                  <button
+                  <Button
+                    variant="danger"
+                    size="md"
                     onClick={() => removeSeat(i)}
-                    style={{ ...btn, color: "#b00", padding: "4px 8px" }}
+                    style={{ padding: "4px 8px" }}
                     title="remove seat"
                   >
                     ×
-                  </button>
+                  </Button>
                 </div>
                 );
               })}
-              <button onClick={addSeat} style={{ ...btn, borderStyle: "dashed", marginBottom: 8 }} title="Add another model/persona seat to the panel.">
+              <Button size="md" onClick={addSeat} style={{ borderStyle: "dashed", marginBottom: 8 }} title="Add another model/persona seat to the panel.">
                 + Add seat
-              </button>
+              </Button>
 
               {/* Aggregator + guards. */}
               <div style={{ display: "flex", flexWrap: "wrap", gap: 16, marginTop: 10 }}>
@@ -397,13 +392,14 @@ export default function Roundtable() {
               </div>
 
               {/* Advanced: authoring-pipeline knobs. */}
-              <button
+              <Button
+                size="md"
                 onClick={() => setShowAdvanced((v) => !v)}
-                style={{ ...btn, marginTop: 12, background: "#f5f5f5" }}
+                style={{ marginTop: 12, background: "#f5f5f5" }}
                 title="Show or hide the authoring-pipeline settings."
               >
                 {showAdvanced ? "▾" : "▸"} Advanced — authoring pipeline
-              </button>
+              </Button>
               {showAdvanced && (
                 <div style={{ marginTop: 8, padding: 10, border: "1px solid #eee", borderRadius: 8 }}>
                   <p style={{ fontSize: 12, color: "#666", margin: "0 0 8px" }}>
@@ -465,15 +461,15 @@ export default function Roundtable() {
               )}
 
               <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
-                <button onClick={save} style={btn} title="Save this preset's settings.">
+                <Button size="md" onClick={save} title="Save this preset's settings.">
                   Save preset
-                </button>
-                <button onClick={makeActive} style={{ ...btn, background: "#e8f7e8", fontWeight: 600 }} title="Save this preset and make it the active default roundtable.">
+                </Button>
+                <Button variant="primary" size="md" onClick={makeActive} style={{ fontWeight: 600 }} title="Save this preset and make it the active default roundtable.">
                   Save &amp; set as default
-                </button>
-                <button onClick={del} style={{ ...btn, color: "#b00" }} title="Delete this roundtable preset.">
+                </Button>
+                <Button variant="danger" size="md" onClick={del} title="Delete this roundtable preset.">
                   Delete
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/frontend/src/pages/chat/ChatPrimitives.tsx
+++ b/frontend/src/pages/chat/ChatPrimitives.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo, useState } from 'react';
-import { tokens, DiffViewer } from '@rakuensoftware/smoothgui';
+import { Button, tokens, DiffViewer } from '@rakuensoftware/smoothgui';
 import { escHtml, renderMd } from './markdown';
 
 interface BootstrapStack {
@@ -23,12 +23,12 @@ export function BootstrapBanner({ onGenerate, onDismiss, stacks }: BannerProps) 
       <div style={{ fontWeight: 'bold', fontSize: '13px', color: '#8c8' }}>No .aimee-rules file found</div>
       <div style={{ fontSize: '12px', color: '#bbb', margin: '3px 0' }}>{stackText}</div>
       <div style={{ marginTop: '8px', display: 'flex', gap: '8px' }}>
-        <button onClick={onGenerate} style={{ padding: '5px 12px', fontSize: '12px', borderRadius: '4px', cursor: 'pointer', border: '1px solid #2d4d2d', background: '#1a3a1a', color: '#8c8' }}>
+        <Button variant="primary" size="sm" onClick={onGenerate}>
           Generate .aimee-rules
-        </button>
-        <button onClick={onDismiss} style={{ padding: '5px 12px', fontSize: '12px', borderRadius: '4px', cursor: 'pointer', border: `1px solid ${tokens.borderMedium}`, background: 'transparent', color: tokens.textSecondary }}>
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onDismiss}>
           Dismiss
-        </button>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
Second slice of the Button sweep (follows #1465, which did the Settings pilot). Migrates 27 raw `<button>` elements and the per-page `const btn`/`btnSmall`/`primaryBtn` constants onto the shared smoothgui `Button` (v0.7.0) across 8 files.

**Files:** Roles, Roundtable, Personas, Graph, Pipeline, Logs, components/ProjectPicker, chat/ChatPrimitives.

## Variant mapping (follows original visual emphasis, not label)
- neutral/gray `btn` → **default** (incl. plain Save buttons that were gray in source)
- accent/green emphasized action (e.g. Roundtable 'Save & set as default') → **primary**
- red delete/remove → **danger**
- transparent/subtle → **ghost**
Sizes preserve source (fontSize 12 → `sm`, 13 → `md`). Stateful chip/toggle background colors are kept via `style` overrides (Button spreads `style` last).

## Deliberately left as raw `<button>` (no clean single-variant map)
- Graph: Hubs/Neighbors list-row buttons (full-width borderless rows, shared `row` const also used by a div)
- Pipeline: the preset pill bar (apply/save/add pills) and the ▲▼ arrow steppers (fixed-size icon buttons)
- ChatPrimitives: the 'Rewind to here' pill (transparent accent-outlined, maps to neither primary nor ghost)

## Verification
- `npm run check` (tsc -b): clean
- `npm run build` (tsc + vite): passes
- No runtime/visual harness on this box; appearance shifts (gray→token borders, accent→primary cyan) are inferred from token values.