### PR TITLE
refactor(webchat): adopt smoothgui Button across WorkflowActions, EditWorkflows, Projects, Agents

### DIFF
--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
-import { Panel, Badge, Spinner, Modal, InlineStatus, EmptyState, KeyValue } from "@rakuensoftware/smoothgui";
+import { Panel, Badge, Spinner, Modal, InlineStatus, EmptyState, KeyValue, Button } from "@rakuensoftware/smoothgui";
 import PrimaryChooser from "../setup/PrimaryChooser";
 
 /* ---- API types ---- */
@@ -164,19 +164,20 @@ export default function Agents() {
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12 }}>
         <strong style={{ fontSize: 18 }}>Agents</strong>
         <Badge label={`${agents.length}`} variant="neutral" />
-        <button onClick={refresh} style={btn} title="Reload the delegate list and run stats.">
+        <Button onClick={refresh} size="md" title="Reload the delegate list and run stats.">
           Refresh
-        </button>
-        <button onClick={probeAll} style={btn} disabled={!agents.length} title="Test live reachability of every configured delegate.">
+        </Button>
+        <Button onClick={probeAll} size="md" disabled={!agents.length} title="Test live reachability of every configured delegate.">
           Probe all
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="primary"
+          size="md"
           onClick={() => setShowAdd((v) => !v)}
-          style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
           title="Show or hide the form for adding a new delegate."
         >
           {showAdd ? "Close" : "+ Add delegate"}
-        </button>
+        </Button>
         <Spinner loading={loading} text="loading…" />
         <InlineStatus status={status} />
       </div>
@@ -314,14 +315,15 @@ function AgentCard({
               {probe.msg.slice(0, 80)}
             </div>
           )}
-          <button
+          <Button
+            size="sm"
             onClick={onProbe}
-            style={{ ...btnSmall, marginTop: 6 }}
+            style={{ marginTop: 6 }}
             disabled={pstate === "probing"}
             title="Test whether this delegate is reachable right now."
           >
             {pstate === "probing" ? "probing…" : "Probe"}
-          </button>
+          </Button>
         </div>
 
         {/* right: run stats */}
@@ -351,13 +353,14 @@ function AgentCard({
       </div>
 
       <div style={{ marginTop: 8, borderTop: "1px solid #eee", paddingTop: 8 }}>
-        <button
+        <Button
+          variant="primary"
+          size="sm"
           onClick={onEdit}
-          style={{ ...btnSmall, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
           title="Open the editor to change this delegate's config and role/persona bindings."
         >
           Edit
-        </button>
+        </Button>
       </div>
     </Panel>
   );
@@ -554,25 +557,28 @@ function AgentEditModal({
       {err && <div style={{ fontSize: 12, color: "#c00", marginTop: 8 }}>{err}</div>}
 
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 14 }}>
-        <button
+        <Button
+          variant="primary"
+          size="md"
           onClick={() => void save()}
           disabled={busy}
-          style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
           title="Save all changes to this delegate."
         >
           {busy ? "Saving…" : "Save"}
-        </button>
-        <button onClick={onClose} disabled={busy} style={btn} title="Discard changes and close the editor.">
+        </Button>
+        <Button onClick={onClose} disabled={busy} size="md" title="Discard changes and close the editor.">
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="danger"
+          size="md"
           onClick={() => void remove()}
           disabled={busy}
-          style={{ ...btn, marginLeft: "auto", background: "#fff5f5", color: "#c00", borderColor: "#e6b3b3" }}
+          style={{ marginLeft: "auto" }}
           title="Remove this delegate, editing agents.json."
         >
           Remove delegate
-        </button>
+        </Button>
       </div>
     </Modal>
   );

--- a/frontend/src/pages/EditWorkflows.tsx
+++ b/frontend/src/pages/EditWorkflows.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { Panel, Badge, Spinner, InlineStatus, KeyValue } from "@rakuensoftware/smoothgui";
+import { Panel, Badge, Spinner, InlineStatus, KeyValue, Button } from "@rakuensoftware/smoothgui";
 import ProjectPicker from "../components/ProjectPicker";
 import type { ProjectSelection } from "../components/ProjectPicker";
 import { useSessions } from "../SessionContext";
@@ -672,9 +672,9 @@ export default function EditWorkflows() {
         }}
       >
         <Panel title="Workflows" count={defs.length}>
-          <button onClick={newDef} style={btn} title="Create a new workflow definition and open it in the editor.">
+          <Button onClick={newDef} size="md" title="Create a new workflow definition and open it in the editor.">
             + New
-          </button>
+          </Button>
           <div style={{ marginTop: 6 }}>
             {defs.map((d) => (
               <div
@@ -696,9 +696,9 @@ export default function EditWorkflows() {
           </div>
         </Panel>
         <Panel title="Blocks" count={blocks.length}>
-          <button onClick={newBlock} style={btn} title="Create a new custom delegate block.">
+          <Button onClick={newBlock} size="md" title="Create a new custom delegate block.">
             + New
-          </button>
+          </Button>
           <div style={{ marginTop: 6 }}>
             {blocks.map((b) => (
               <div
@@ -710,16 +710,17 @@ export default function EditWorkflows() {
                 <span>{b.name}</span>
                 <span style={{ display: "flex", gap: 4, alignItems: "center" }}>
                   {b.custom && b.executor === "delegate" && (
-                    <button
+                    <Button
+                      size="sm"
                       onClick={(e) => {
                         e.stopPropagation();
                         editExistingBlock(b);
                       }}
-                      style={{ ...btnSmall, padding: "0 6px" }}
+                      style={{ padding: "0 6px" }}
                       title="edit this custom block"
                     >
                       ✎
-                    </button>
+                    </Button>
                   )}
                   <Badge
                     label={b.custom ? "custom" : b.produces}
@@ -785,16 +786,17 @@ export default function EditWorkflows() {
                 />
               </label>
               <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-                <button onClick={saveBlock} style={btn} title="Save this custom block definition.">
+                <Button onClick={saveBlock} size="md" title="Save this custom block definition.">
                   Save
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="danger"
+                  size="md"
                   onClick={deleteBlock}
-                  style={{ ...btn, color: "#b00" }}
                   title={editBlock.isNew ? "Discard this new block." : "Delete this custom block."}
                 >
                   {editBlock.isNew ? "Cancel" : "Delete"}
-                </button>
+                </Button>
                 {blockStatus && <span style={{ fontSize: 12, color: "#b00" }}>{blockStatus}</span>}
               </div>
             </div>
@@ -819,17 +821,18 @@ export default function EditWorkflows() {
           {version && (
             <Badge label={`v ${version.slice(0, 8)}`} variant="neutral" />
           )}
-          <button onClick={validate} disabled={!graph} style={btn} title="Check the current workflow for errors without saving.">
+          <Button onClick={validate} disabled={!graph} size="md" title="Check the current workflow for errors without saving.">
             Validate
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
             onClick={save}
             disabled={!graph}
-            style={{ ...btn, background: "#2563eb", color: "#fff" }}
             title="Save the workflow definition (fails if the on-disk version changed)."
           >
             Save
-          </button>
+          </Button>
           <InlineStatus status={status} />
           <Spinner loading={loading} text="loading…" />
         </div>
@@ -1272,17 +1275,17 @@ function NodeInspector({
             style={{ ...inp, flex: 1, minWidth: 0 }}
           />
           {(isMulti || parts.length > 1) && (
-            <button onClick={() => delPart(i)} style={btnSmall} title="remove">
+            <Button onClick={() => delPart(i)} size="sm" title="remove">
               ×
-            </button>
+            </Button>
           )}
         </div>
       ))}
       {isMulti && (
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <button onClick={addPart} style={btnSmall} title="Add another persona/delegate to the review panel.">
+          <Button onClick={addPart} size="sm" title="Add another persona/delegate to the review panel.">
             + participant
-          </button>
+          </Button>
           <label style={{ ...lbl, margin: 0 }} title="How many panelists must pass; blank means all.">
             quorum&nbsp;
             <input
@@ -1407,14 +1410,14 @@ function NodeInspector({
                   </option>
                 ))}
             </select>
-            <button
+            <Button
+              size="sm"
               onClick={() => onOpenWorkflow(childWorkflowName(node))}
               disabled={!childWorkflowName(node)}
-              style={btnSmall}
               title="open the child workflow in this editor"
             >
               open ↗
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -1423,14 +1426,14 @@ function NodeInspector({
       <KeyValue label="block" value={node.block + (node.custom ? " (custom)" : "")} mono />
       <KeyValue label="produces" value={node.produces} mono />
       <div style={{ margin: "6px 0" }}>
-        <button
+        <Button
+          size="md"
           onClick={setStart}
           disabled={graph.start === node.id}
-          style={btn}
           title="Make this node the workflow's start node."
         >
           {graph.start === node.id ? "start node ✓" : "set as start"}
-        </button>
+        </Button>
       </div>
 
       <label style={lbl} title="Named outputs from other nodes fed into this step.">Inputs</label>
@@ -1455,14 +1458,14 @@ function NodeInspector({
               </option>
             ))}
           </select>
-          <button onClick={() => delBinding(i)} style={btnSmall} title="Remove this input binding.">
+          <Button onClick={() => delBinding(i)} size="sm" title="Remove this input binding.">
             ×
-          </button>
+          </Button>
         </div>
       ))}
-      <button onClick={addBinding} style={btnSmall} title="Add an input binding from another node's output.">
+      <Button onClick={addBinding} size="sm" title="Add an input binding from another node's output.">
         + input
-      </button>
+      </Button>
 
       {(["next", "on_pass", "on_fail"] as const).map((edge) => (
         <div key={edge} style={{ marginTop: 6 }}>
@@ -1484,7 +1487,8 @@ function NodeInspector({
       ))}
 
       <div style={{ marginTop: 10 }}>
-        <button
+        <Button
+          size="sm"
           onClick={() => {
             const nv = !showAdv;
             setShowAdv(nv);
@@ -1493,11 +1497,10 @@ function NodeInspector({
               setParamsErr("");
             }
           }}
-          style={btnSmall}
           title="Show/hide the raw params JSON editor."
         >
           {showAdv ? "▾ Advanced (raw params)" : "▸ Advanced (raw params)"}
-        </button>
+        </Button>
       </div>
       {showAdv && (
         <>
@@ -1522,31 +1525,20 @@ function NodeInspector({
         </>
       )}
 
-      <button
+      <Button
+        variant="danger"
+        size="md"
         onClick={onDelete}
-        style={{ ...btn, marginTop: 10, color: "#c00", borderColor: "#e0a0a0" }}
+        style={{ marginTop: 10 }}
         title="Remove this node from the workflow."
       >
         Delete node
-      </button>
+      </Button>
     </div>
   );
 }
 
 /* ---- inline styles ---- */
-const btn: React.CSSProperties = {
-  fontSize: 13,
-  padding: "4px 10px",
-  border: "1px solid #ccc",
-  borderRadius: 4,
-  background: "#fff",
-  cursor: "pointer",
-};
-const btnSmall: React.CSSProperties = {
-  ...btn,
-  padding: "2px 6px",
-  fontSize: 12,
-};
 const row: React.CSSProperties = {
   display: "flex",
   justifyContent: "space-between",

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Panel } from '@rakuensoftware/smoothgui';
+import { Panel, Button } from '@rakuensoftware/smoothgui';
 import ConnectHosts from '../setup/ConnectHosts';
 import { useSessions } from '../SessionContext';
 import { groupProjectsByOrg, parseOwnerOnly, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type OwnerRef, type ProjectDetail, type ProjectDeleteResponse } from '../setup/ownerUrl';
@@ -40,10 +40,6 @@ async function api(path: string, init?: RequestInit): Promise<Response> {
   });
 }
 
-const btn: React.CSSProperties = {
-  padding: '3px 10px', borderRadius: '4px', border: '1px solid #ccc', background: '#fff',
-  color: '#444', cursor: 'pointer', fontSize: '12px',
-};
 const input: React.CSSProperties = {
   padding: '6px 8px', borderRadius: '4px', border: '1px solid #ccc', fontSize: '13px',
 };
@@ -277,11 +273,11 @@ export default function Projects() {
               onKeyDown={e => { if (e.key === 'Enter' && url.trim() && !busy) connect(); }} />
             <input style={{ ...input, flex: 1, minWidth: '120px' }} placeholder="name (optional)"
               value={name} onChange={e => setName(e.target.value)} />
-            <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
+            <Button variant="primary" size="sm"
               disabled={busy || !url.trim()} onClick={connect}
               title="Clone the repository, or if you entered an owner/org URL, list its repositories to bulk-clone.">
               {parseOwnerOnly(url) ? 'List repositories' : 'Clone'}
-            </button>
+            </Button>
           </div>
           <input style={{ ...input, width: '100%' }} type="password" autoComplete="off"
             placeholder="access token — only for a private repo/org (GitHub/Gitea/GitLab…); saved server-side per host"
@@ -295,13 +291,13 @@ export default function Projects() {
                   {orgRef.host}/{orgRef.owner}: {orgRepos.length} repositor{orgRepos.length === 1 ? 'y' : 'ies'}
                   {orgProvider ? ` · ${orgProvider}` : ''}
                 </div>
-                <button style={{ ...btn, border: 'none', color: '#3a6ea5', padding: 0 }}
+                <Button variant="ghost" size="sm" style={{ color: '#3a6ea5', padding: 0 }}
                   title="Select every repository that is not already cloned."
                   onClick={() => setOrgSelected(Object.fromEntries(orgRepos.map(r =>
-                    [r.name, !repoAlreadyCloned(r, orgRef.owner, projects, details)])))}>all</button>
-                <button style={{ ...btn, border: 'none', color: '#3a6ea5', padding: 0 }}
+                    [r.name, !repoAlreadyCloned(r, orgRef.owner, projects, details)])))}>all</Button>
+                <Button variant="ghost" size="sm" style={{ color: '#3a6ea5', padding: 0 }}
                   title="Deselect all repositories."
-                  onClick={() => setOrgSelected({})}>none</button>
+                  onClick={() => setOrgSelected({})}>none</Button>
               </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '2px', maxHeight: '220px', overflow: 'auto',
                             border: '1px solid #ddd', borderRadius: '6px', padding: '8px' }}>
@@ -319,12 +315,12 @@ export default function Projects() {
                 })}
               </div>
               <div>
-                <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
+                <Button variant="primary" size="sm"
                   disabled={busy || orgRepos.filter(r => orgSelected[r.name]).length === 0}
                   title="Clone the checked repositories as new projects."
                   onClick={cloneOrgSelected}>
                   Clone selected ({orgRepos.filter(r => orgSelected[r.name]).length})
-                </button>
+                </Button>
               </div>
             </div>
           )}
@@ -353,9 +349,9 @@ export default function Projects() {
       <Panel title="Git accounts" count={hosts.length}>
         <div style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
-            <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
+            <Button variant="primary" size="sm"
               title="Connect a git account (OAuth, access token, or SSH key) via the setup wizard."
-              onClick={() => setConnectOpen(true)}>+ Connect git account</button>
+              onClick={() => setConnectOpen(true)}>+ Connect git account</Button>
             <span style={{ color: '#888', fontSize: '12px' }}>
               OAuth sign-in, an access token, or an SSH key — stored server-side, never shown again.
             </span>
@@ -366,9 +362,9 @@ export default function Projects() {
                 <div key={h} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                   <span style={{ fontSize: '13px', fontFamily: 'monospace', flex: 1 }}>{h}</span>
                   <span style={{ fontSize: '11px', color: '#2a7' }}>● token set</span>
-                  <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy}
+                  <Button variant="danger" size="sm" disabled={busy}
                     title="Delete the stored access token for this git host."
-                    onClick={() => removeCred(h)}>remove</button>
+                    onClick={() => removeCred(h)}>remove</Button>
                 </div>
               ))}
             </div>
@@ -390,16 +386,16 @@ export default function Projects() {
                   <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
                     {g.refs.map(p => (
                       <span key={p} style={{ display: 'inline-flex' }}>
-                        <button onClick={() => { setSelected(p); setOutput(''); setErr(''); }}
+                        <Button onClick={() => { setSelected(p); setOutput(''); setErr(''); }}
+                          variant={p === selected ? 'primary' : 'default'} size="sm"
                           title="Select this project to run git operations on it."
-                          style={{ ...btn, background: p === selected ? '#234' : '#fff', color: p === selected ? '#8cf' : '#444',
-                                   borderColor: p === selected ? '#456' : '#ccc', borderRadius: '4px 0 0 4px' }}>
+                          style={{ borderRadius: '4px 0 0 4px' }}>
                           {p}
-                        </button>
-                        <button title={`Delete ${p}`} disabled={busy} onClick={() => openDelete(p)}
-                          style={{ ...btn, borderColor: '#d99', color: '#c33', borderRadius: '0 4px 4px 0', borderLeft: 'none' }}>
+                        </Button>
+                        <Button variant="danger" size="sm" title={`Delete ${p}`} disabled={busy} onClick={() => openDelete(p)}
+                          style={{ borderRadius: '0 4px 4px 0', borderLeft: 'none' }}>
                           ×
-                        </button>
+                        </Button>
                       </span>
                     ))}
                   </div>
@@ -420,23 +416,23 @@ export default function Projects() {
                 <input style={{ ...input, flex: 1, minWidth: '180px', fontFamily: 'monospace' }} placeholder={delRef}
                   value={delTyped} onChange={e => setDelTyped(e.target.value)} />
                 {!delKbDown && (
-                  <button style={{ ...btn, background: '#c33', color: '#fff', borderColor: '#a22' }}
+                  <Button variant="danger" size="sm"
                     disabled={busy || delTyped !== delRef} onClick={() => deleteProject(false)}
-                    title="Permanently delete the clone and all indexed knowledge for this project.">Delete</button>
+                    title="Permanently delete the clone and all indexed knowledge for this project.">Delete</Button>
                 )}
-                <button style={btn} disabled={busy} onClick={closeDelete}>Cancel</button>
+                <Button size="sm" disabled={busy} onClick={closeDelete}>Cancel</Button>
               </div>
               {delKbDown && (
                 <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                  <button style={btn} disabled={busy || delTyped !== delRef}
+                  <Button size="sm" disabled={busy || delTyped !== delRef}
                     title="Retry the delete now that the knowledge service may be back."
-                    onClick={() => deleteProject(false)}>Retry</button>
-                  <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy || delTyped !== delRef}
+                    onClick={() => deleteProject(false)}>Retry</Button>
+                  <Button variant="danger" size="sm" disabled={busy || delTyped !== delRef}
                     onClick={() => { if (delForceArmed) deleteProject(true); else setDelForceArmed(true); }}>
                     {delForceArmed
                       ? 'Click again to confirm force delete'
                       : 'Force delete (leaves knowledge orphaned until the knowledge service returns)'}
-                  </button>
+                  </Button>
                 </div>
               )}
             </div>
@@ -446,31 +442,31 @@ export default function Projects() {
             <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' }}>
                 {READ_OPS.map(op => (
-                  <button key={op} style={btn} disabled={busy} title={OP_HELP[op]} onClick={() => runOp(op)}>{op}</button>
+                  <Button key={op} size="sm" disabled={busy} title={OP_HELP[op]} onClick={() => runOp(op)}>{op}</Button>
                 ))}
                 {REMOTE_OPS.map(op => (
-                  <button key={op} style={{ ...btn, borderColor: '#a96' }} disabled={busy} title={OP_HELP[op]} onClick={() => runOp(op)}>{op}</button>
+                  <Button key={op} size="sm" style={{ borderColor: '#a96' }} disabled={busy} title={OP_HELP[op]} onClick={() => runOp(op)}>{op}</Button>
                 ))}
               </div>
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' }}>
                 <input style={{ ...input, flex: 1, minWidth: '180px' }} placeholder="commit message"
                   value={commitMsg} onChange={e => setCommitMsg(e.target.value)} />
-                <button style={btn} disabled={busy || !commitMsg.trim()}
+                <Button size="sm" disabled={busy || !commitMsg.trim()}
                   title="Commit staged changes with the entered message."
-                  onClick={() => { runOp('commit', { message: commitMsg }); setCommitMsg(''); }}>commit</button>
+                  onClick={() => { runOp('commit', { message: commitMsg }); setCommitMsg(''); }}>commit</Button>
                 <input style={{ ...input, width: '140px' }} placeholder="branch"
                   value={branch} onChange={e => setBranch(e.target.value)} />
-                <button style={btn} disabled={busy || !branch.trim()}
+                <Button size="sm" disabled={busy || !branch.trim()}
                   title="Switch to (or create) the named branch."
-                  onClick={() => runOp('checkout', { branch })}>checkout</button>
+                  onClick={() => runOp('checkout', { branch })}>checkout</Button>
               </div>
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' }}>
                 <input style={{ ...input, flex: 1, minWidth: '180px' }}
                   placeholder="PR title (optional — empty fills from commits)"
                   value={prTitle} onChange={e => setPrTitle(e.target.value)} />
-                <button style={{ ...btn, borderColor: '#7a7' }} disabled={busy}
+                <Button size="sm" style={{ borderColor: '#7a7' }} disabled={busy}
                   title="Open a GitHub pull request for the pushed branch"
-                  onClick={async () => { if (await runOp('pr', { message: prTitle })) setPrTitle(''); }}>open PR</button>
+                  onClick={async () => { if (await runOp('pr', { message: prTitle })) setPrTitle(''); }}>open PR</Button>
               </div>
             </div>
           )}

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Panel, Badge, Spinner, InlineStatus, EmptyState } from "@rakuensoftware/smoothgui";
+import { Panel, Badge, Spinner, InlineStatus, EmptyState, Button } from "@rakuensoftware/smoothgui";
 import type { BadgeVariant } from "@rakuensoftware/smoothgui";
 import { renderMd } from "./chat/markdown";
 
@@ -413,24 +413,23 @@ export default function WorkflowActions() {
         <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
           <strong style={{ fontSize: 16 }}>Workflows</strong>
           <Badge label={`${items.length}`} variant="neutral" />
-          <button onClick={refreshList} style={btn} title="Reload the proposal list.">
+          <Button onClick={refreshList} size="md" title="Reload the proposal list.">
             Refresh
-          </button>
+          </Button>
         </div>
-        <button
+        <Button
+          variant="primary"
+          size="md"
           onClick={startNew}
           title="Start composing a new proposal to submit."
           style={{
-            ...btn,
             width: "100%",
-            background: composing ? "#eef4ff" : "#2563eb",
-            color: composing ? "#2563eb" : "#fff",
-            borderColor: "#2563eb",
             marginBottom: 8,
+            ...(composing ? { background: "#eef4ff", color: "#2563eb" } : {}),
           }}
         >
           + New proposal
-        </button>
+        </Button>
         <label
           style={{ fontSize: 12, color: "#666", display: "flex", alignItems: "center", gap: 6 }}
           title="Show every run across all users, not just your own."
@@ -511,49 +510,53 @@ export default function WorkflowActions() {
                 (below) rather than resume. */}
             <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap", margin: "4px 0 10px" }}>
               {canResume && (
-                <button onClick={() => void doLifecycle("resume")} disabled={acting} style={btn} title="Resume this paused run.">
+                <Button onClick={() => void doLifecycle("resume")} disabled={acting} size="md" title="Resume this paused run.">
                   ▶ Start
-                </button>
+                </Button>
               )}
               {canPause && (
-                <button onClick={() => void doLifecycle("pause")} disabled={acting} style={btn} title="Pause this active run.">
+                <Button onClick={() => void doLifecycle("pause")} disabled={acting} size="md" title="Pause this active run.">
                   ⏸ Pause
-                </button>
+                </Button>
               )}
               {canStop && (
-                <button
+                <Button
+                  variant="danger"
+                  size="md"
                   onClick={() => void doLifecycle("stop")}
                   disabled={acting}
-                  style={{ ...btn, background: "#fbeaea", color: "#a33", borderColor: "#e0a0a0" }}
                   title="Abandon this run; it cannot be resumed."
                 >
                   ⏹ Stop
-                </button>
+                </Button>
               )}
-              <button
+              <Button
+                variant="danger"
+                size="md"
                 onClick={() => void doLifecycle("delete")}
                 disabled={acting}
-                style={{ ...btn, background: "#fff5f5", color: "#c00", borderColor: "#e6b3b3", marginLeft: "auto" }}
+                style={{ marginLeft: "auto" }}
                 title="Permanently delete this run, its history, and proposal file."
               >
                 🗑 Delete
-              </button>
+              </Button>
               {actMsg && <span style={{ fontSize: 12, color: "#c00", flexBasis: "100%" }}>{actMsg}</span>}
             </div>
 
             {canDecide && (
               <Panel title={`Human gate · ${detail.stage}`}>
                 <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                  <button onClick={() => void decideGate("approve")} style={btn} title="Approve this gate and resume the run.">
+                  <Button onClick={() => void decideGate("approve")} size="md" title="Approve this gate and resume the run.">
                     Approve
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="md"
                     onClick={() => void decideGate("reject")}
-                    style={{ ...btn, background: "#fbeaea", color: "#a33", borderColor: "#e0a0a0" }}
                     title="Reject at this gate."
                   >
                     Reject
-                  </button>
+                  </Button>
                   {gateMsg && <span style={{ fontSize: 12, color: "#667" }}>{gateMsg}</span>}
                 </div>
               </Panel>
@@ -759,19 +762,20 @@ function Composer({
         >
           <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
             <strong style={{ fontSize: 13 }}>Delegate draft — preview</strong>
-            <button
+            <Button
+              variant="primary"
+              size="md"
               onClick={() => {
                 update({ body: preview });
                 setPreview(null);
               }}
-              style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
               title="Replace the proposal body with this generated draft."
             >
               Use this draft
-            </button>
-            <button onClick={() => setPreview(null)} style={btn} title="Discard this draft preview and keep your current body.">
+            </Button>
+            <Button onClick={() => setPreview(null)} size="md" title="Discard this draft preview and keep your current body.">
               Discard
-            </button>
+            </Button>
             <span style={{ fontSize: 11, color: "#888" }}>Replaces the body above.</span>
           </div>
           <div
@@ -782,30 +786,31 @@ function Composer({
       )}
 
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 10 }}>
-        <button
+        <Button
+          variant="primary"
+          size="md"
           onClick={onSubmit}
           disabled={busy}
-          style={{ ...btn, background: "#2563eb", color: "#fff", borderColor: "#2563eb" }}
           title="Submit the proposal and start the selected workflow."
         >
           {submitting ? "Submitting…" : `Submit → run "${draft.workflow || "build"}"`}
-        </button>
-        <button
+        </Button>
+        <Button
+          size="md"
           onClick={() => void generate()}
           disabled={busy}
-          style={btn}
           title="Generate a proposal draft from your title and notes (shown as a preview to accept)."
         >
           {drafting ? "Drafting…" : "✨ Draft with a delegate"}
-        </button>
-        <button
+        </Button>
+        <Button
+          size="md"
           onClick={() => (browsing ? setBrowsing(false) : openBrowser())}
           disabled={busy}
-          style={btn}
           title="Browse the project checkout and load a .md file as the proposal."
         >
           {browsing ? "Close browser" : "📂 Load from project"}
-        </button>
+        </Button>
         {submitMsg && <span style={{ fontSize: 12, color: "#c00" }}>{submitMsg}</span>}
         {draftErr && <span style={{ fontSize: 12, color: "#c00" }}>{draftErr}</span>}
       </div>
@@ -980,14 +985,6 @@ function Field({ k, v }: { k: string; v: string }) {
   );
 }
 
-const btn: React.CSSProperties = {
-  fontSize: 13,
-  padding: "4px 10px",
-  border: "1px solid #ccc",
-  borderRadius: 4,
-  background: "#fff",
-  cursor: "pointer",
-};
 const inp: React.CSSProperties = {
   fontSize: 13,
   padding: "5px 7px",


### PR DESCRIPTION
Third slice of the Button sweep (follows #1465, #1467). Migrates 52 raw `<button>` elements + per-page `const btn`/`btnSmall` onto shared smoothgui `Button` across 4 of the largest webchat pages.

## Variant mapping (follows original color, verified against source)
- gray `btn` → **default**
- blue/accent fill (`#2563eb`, Projects `#234`/`#8cf`) → **primary**
- red (`#b00`) delete/remove/reject → **danger**
- borderless text-links (Projects all/none) → **ghost**
Sizes preserve source (Projects fs12 → sm; others fs13 → md). Stateful/toggle colors and per-instance residuals (marginLeft, borderRadius, active-bg) kept via `style`.

## Left as raw `<button>` (custom controls, no clean variant)
- Projects modal close `×` (icon-only, transparent)
- Agents modal close `×` and the ChipSelect toggle chip (custom green/maroon active fills)

## Verification
- `npm run check` (tsc -b): clean
- `npm run build`: passes
- No runtime/visual harness; palette shifts inferred from tokens.