### PR TITLE
refactor(webchat): adopt smoothgui Button across setup/installer pages

### DIFF
--- a/frontend/src/components/SetupWizard.tsx
+++ b/frontend/src/components/SetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useToast } from '@rakuensoftware/smoothgui';
+import { Button, useToast } from '@rakuensoftware/smoothgui';
 import { useSessions } from '../SessionContext';
 import { loadConfig, saveConfigValue, type ConfigMap } from '../setup/configApi';
 import { visibleSteps, isRestartKey, helpFor, APPLIANCE_HIDDEN_STEPS, type WizardKbMode } from '../setup/wizardSteps';
@@ -250,14 +250,6 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
     borderRadius: 12, border: '1px solid #dde', boxShadow: '0 12px 40px rgba(0,0,0,0.3)',
     padding: '20px 22px', fontFamily: 'system-ui', color: '#233',
   };
-  const primaryBtn: React.CSSProperties = {
-    padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
-    color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
-  };
-  const ghostBtn: React.CSSProperties = {
-    padding: '7px 14px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',
-    color: '#446', cursor: 'pointer', fontSize: 13,
-  };
   const input: React.CSSProperties = {
     width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
     border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
@@ -303,9 +295,9 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
             {!appliance && <DeployPanel kbMode={kbMode} />}
             <div style={{ display: 'flex', justifyContent: total > 0 ? 'space-between' : 'flex-end' }}>
               {total > 0 && (
-                <button style={ghostBtn} onClick={() => { setShowSummary(false); setIdx(0); }}>Back</button>
+                <Button variant="default" onClick={() => { setShowSummary(false); setIdx(0); }}>Back</Button>
               )}
-              <button style={primaryBtn} onClick={() => { setDismissed(true); notifySetupUpdated(); close(); }}>Finish</button>
+              <Button variant="primary" onClick={() => { setDismissed(true); notifySetupUpdated(); close(); }}>Finish</Button>
             </div>
           </div>
         ) : (
@@ -349,18 +341,18 @@ export default function SetupWizard({ open, onClose }: { open: boolean; onClose:
 
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
               <div style={{ display: 'flex', gap: 8 }}>
-                <button style={ghostBtn} disabled={safeIdx === 0} onClick={() => setIdx(Math.max(0, safeIdx - 1))}>Back</button>
-                <button style={ghostBtn} onClick={close}>Later</button>
+                <Button variant="default" disabled={safeIdx === 0} onClick={() => setIdx(Math.max(0, safeIdx - 1))}>Back</Button>
+                <Button variant="default" onClick={close}>Later</Button>
               </div>
               <div style={{ display: 'flex', gap: 8 }}>
-                {step.optional && <button style={ghostBtn} onClick={advance}>Skip</button>}
+                {step.optional && <Button variant="default" onClick={advance}>Skip</Button>}
                 {step.keys.length > 0 ? (
-                  <button style={primaryBtn} disabled={saving} onClick={saveStep}>{saving ? 'Saving…' : 'Save & continue'}</button>
+                  <Button variant="primary" disabled={saving} onClick={saveStep}>{saving ? 'Saving…' : 'Save & continue'}</Button>
                 ) : step.kind === 'chooser' || step.kind === 'kb' || step.kind === 'deploy' || step.kind === 'db2' || step.kind === 'connection' || step.kind === 'workspace' ? (
                   // Bespoke steps own their own primary action (they call advance()).
                   null
                 ) : (
-                  <button style={primaryBtn} onClick={advance}>{safeIdx === total - 1 ? 'Review' : 'Next'}</button>
+                  <Button variant="primary" onClick={advance}>{safeIdx === total - 1 ? 'Review' : 'Next'}</Button>
                 )}
               </div>
             </div>

--- a/frontend/src/setup/ConnectHosts.tsx
+++ b/frontend/src/setup/ConnectHosts.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@rakuensoftware/smoothgui';
 
 /* Wizard — Connection (git hosts). Authenticate aimee-server to the git hosts it
  * will clone from, so the next step (Workspaces & projects) can enumerate + clone
@@ -440,13 +441,14 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
               placeholder={`host (e.g. ${meta.defaultHost || 'gitea.example.com'})`}
               value={oauthHost} onChange={(e) => setOauthHost(e.target.value)} />
           )}
-          <button
-            style={{ ...primaryBtn, background: configured ? '#2c8f56' : '#888', borderColor: configured ? '#2c6' : '#888' }}
+          <Button
+            variant="primary"
+            style={configured ? undefined : { background: '#888', borderColor: '#888' }}
             disabled={busy || !!pending || !configured}
             onClick={provider === 'github' && webAvailable ? startWebSignIn : startSignIn}
           >
             {provider === 'github' && webAvailable ? 'Sign in with GitHub' : 'Sign in'}
-          </button>
+          </Button>
         </div>
         {!configured && !pending && (
           <div style={{ fontSize: 11.5, color: '#a67c00' }}>
@@ -475,8 +477,8 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
                   placeholder="Client secret (optional — enables one-click)"
                   value={clientSecret} onChange={(e) => setClientSecret(e.target.value)} />
               )}
-              <button style={ghostBtn} disabled={busy || !clientId.trim() || (meta.needsHost && !effHost)}
-                onClick={saveConfig}>Save</button>
+              <Button variant="default" disabled={busy || !clientId.trim() || (meta.needsHost && !effHost)}
+                onClick={saveConfig}>Save</Button>
             </div>
           </div>
         </details>
@@ -495,7 +497,7 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
             value={credHost} onChange={(e) => setCredHost(e.target.value)} />
           <input style={{ ...input, flex: 2, minWidth: 200 }} type="password" autoComplete="off"
             placeholder="access token" value={credToken} onChange={(e) => setCredToken(e.target.value)} />
-          <button style={ghostBtn} disabled={busy || !credHost.trim() || !credToken.trim()} onClick={addCred}>Save</button>
+          <Button variant="default" disabled={busy || !credHost.trim() || !credToken.trim()} onClick={addCred}>Save</Button>
         </div>
         {hosts.length > 0 && (
           <div style={{ display: 'grid', gap: 4 }}>
@@ -503,8 +505,8 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
               <div key={h} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                 <span style={{ fontSize: 13, fontFamily: 'monospace', flex: 1 }}>{h}</span>
                 <span style={{ fontSize: 11, color: '#2a7' }}>● token set</span>
-                <button style={{ ...ghostBtn, borderColor: '#d99', color: '#c33' }} disabled={busy}
-                  onClick={() => removeCred(h)}>remove</button>
+                <Button variant="danger" disabled={busy}
+                  onClick={() => removeCred(h)}>remove</Button>
               </div>
             ))}
           </div>
@@ -525,9 +527,9 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
           placeholder={'-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----'}
           value={sshKey} onChange={(e) => setSshKey(e.target.value)} />
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          <button style={ghostBtn} disabled={busy || !sshKey.trim()} onClick={addSSHKey}>Save SSH key</button>
-          <button style={{ ...ghostBtn, borderColor: '#d99', color: '#c33' }} disabled={busy}
-            onClick={removeSSHKey}>Clear SSH key</button>
+          <Button variant="default" disabled={busy || !sshKey.trim()} onClick={addSSHKey}>Save SSH key</Button>
+          <Button variant="danger" disabled={busy}
+            onClick={removeSSHKey}>Clear SSH key</Button>
         </div>
       </section>
       )}
@@ -536,9 +538,9 @@ export default function ConnectHosts({ onDone, onHostsChanged, doneLabel }: Conn
       {msg && <div style={{ fontSize: 12.5, color: '#2c8f56' }}>{msg}</div>}
 
       <div>
-        <button style={primaryBtn} onClick={onDone}>
+        <Button variant="primary" onClick={onDone}>
           {doneLabel ?? (hosts.length > 0 ? 'Continue' : 'Continue without connecting')}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -548,14 +550,6 @@ const sectionTitle: React.CSSProperties = { fontSize: 14, fontWeight: 700, color
 const input: React.CSSProperties = {
   boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
   border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
-};
-const primaryBtn: React.CSSProperties = {
-  padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
-  color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
-};
-const ghostBtn: React.CSSProperties = {
-  padding: '6px 12px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',
-  color: '#446', cursor: 'pointer', fontSize: 13,
 };
 const methodTab: React.CSSProperties = {
   padding: '6px 14px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',

--- a/frontend/src/setup/ConnectWorkspace.tsx
+++ b/frontend/src/setup/ConnectWorkspace.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@rakuensoftware/smoothgui';
 import { parseOwner, repoAlreadyCloned, type CloneKbAnnotations, type GitProjectsResponse, type ProjectDetail } from './ownerUrl';
 
 /* Wizard — Workspaces & projects. A workspace is your collection of projects: the
@@ -174,9 +175,9 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
             placeholder="owner URL (e.g. github.com/RakuenSoftware)"
             value={ownerInput} onChange={(e) => setOwnerInput(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter' && ownerInput.trim() && !listing) listRepos(); }} />
-          <button style={primaryBtn} disabled={listing || !ownerInput.trim()} onClick={listRepos}>
+          <Button variant="primary" disabled={listing || !ownerInput.trim()} onClick={listRepos}>
             {listing ? 'Listing…' : 'List repositories'}
-          </button>
+          </Button>
         </div>
         <input style={{ ...input, width: '100%' }} type="password" autoComplete="off"
           placeholder="access token — only for a private/self-hosted org; saved server-side per host"
@@ -207,9 +208,9 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
             })}
           </div>
           <div>
-            <button style={primaryBtn} disabled={cloning || selectedCount === 0} onClick={cloneSelected}>
+            <Button variant="primary" disabled={cloning || selectedCount === 0} onClick={cloneSelected}>
               {cloning ? 'Cloning…' : `Clone selected (${selectedCount})`}
-            </button>
+            </Button>
           </div>
         </section>
       )}
@@ -239,9 +240,9 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
       {err && <div style={{ fontSize: 12.5, color: '#c62828' }}>{err}</div>}
 
       <div>
-        <button style={{ ...primaryBtn, background: '#2c8f56' }} onClick={onDone}>
+        <Button variant="primary" onClick={onDone}>
           {projects.length > 0 ? 'Done' : 'Continue'}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -250,10 +251,6 @@ export default function ConnectWorkspace({ onDone }: ConnectWorkspaceProps) {
 const input: React.CSSProperties = {
   boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
   border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
-};
-const primaryBtn: React.CSSProperties = {
-  padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
-  color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
 };
 const linkBtn: React.CSSProperties = {
   background: 'none', border: 'none', color: '#3a6ea5', cursor: 'pointer', fontSize: 12, padding: 0,

--- a/frontend/src/setup/DeployPanel.tsx
+++ b/frontend/src/setup/DeployPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@rakuensoftware/smoothgui';
 
 /* Setup-wizard summary panel — server-orchestrated deploy.
  *
@@ -174,10 +175,12 @@ export default function DeployPanel({ kbMode }: { kbMode: 'local' | 'remote' }) 
     <div style={box}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
         <div style={{ fontWeight: 700, fontSize: 13 }}>Deploy the knowledge base + LLM</div>
-        <button style={applying || status.running ? btnBusy : btn} disabled={applying || status.running}
+        <Button variant="primary"
+          style={applying || status.running ? { background: '#9aa', borderColor: '#9aa', cursor: 'default' } : undefined}
+          disabled={applying || status.running}
           onClick={deploy}>
           {status.running ? 'Deploying…' : applying ? 'Starting…' : svcs.length ? 'Re-deploy' : 'Deploy'}
-        </button>
+        </Button>
       </div>
       <div style={{ fontSize: 12, color: '#556', lineHeight: 1.5, marginBottom: svcs.length ? 8 : 0 }}>
         aimee-server brings up postgres + aimee-kb + aimee-llm for you via Docker — no extra commands.
@@ -217,8 +220,3 @@ const pre: React.CSSProperties = {
   whiteSpace: 'pre-wrap', wordBreak: 'break-word', background: '#eef1f6', borderRadius: 6,
   padding: '8px 10px', fontSize: 11.5, margin: '6px 0 0', maxHeight: 220, overflow: 'auto',
 };
-const btn: React.CSSProperties = {
-  padding: '6px 14px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
-  color: '#fff', cursor: 'pointer', fontSize: 13, fontWeight: 600,
-};
-const btnBusy: React.CSSProperties = { ...btn, background: '#9aa', borderColor: '#9aa', cursor: 'default' };

--- a/frontend/src/setup/DeployTopology.tsx
+++ b/frontend/src/setup/DeployTopology.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useToast } from '@rakuensoftware/smoothgui';
+import { Button, useToast } from '@rakuensoftware/smoothgui';
 import { loadConfig, saveConfigValue, type ConfigMap } from './configApi';
 import { isRestartKey } from './wizardSteps';
 import {
@@ -258,9 +258,9 @@ export default function DeployTopology({ onSaved, fetchImpl }: DeployTopologyPro
       )}
 
       <div>
-        <button style={primaryBtn} disabled={saving} onClick={save}>
+        <Button variant="primary" disabled={saving} onClick={save}>
           {saving ? 'Saving…' : 'Save & continue'}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -274,11 +274,6 @@ const input: React.CSSProperties = {
   width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
   border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
 };
-const primaryBtn: React.CSSProperties = {
-  padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
-  color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
-};
-
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <label style={{ display: 'block' }}>

--- a/frontend/src/setup/KnowledgeBase.tsx
+++ b/frontend/src/setup/KnowledgeBase.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useToast } from '@rakuensoftware/smoothgui';
+import { Button, useToast } from '@rakuensoftware/smoothgui';
 import { loadConfig, saveConfigValue, type ConfigMap } from './configApi';
 import { isRestartKey } from './wizardSteps';
 import { buildDesiredConfig, type KbMode } from './deployTopology';
@@ -152,9 +152,9 @@ export default function KnowledgeBase({ onSaved, fetchImpl }: KnowledgeBaseProps
       )}
 
       <div>
-        <button style={primaryBtn} disabled={saving} onClick={save}>
+        <Button variant="primary" disabled={saving} onClick={save}>
           {saving ? 'Saving…' : 'Save & continue'}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -164,10 +164,6 @@ const radioRow: React.CSSProperties = { display: 'flex', alignItems: 'center', g
 const input: React.CSSProperties = {
   width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
   border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
-};
-const primaryBtn: React.CSSProperties = {
-  padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
-  color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
 };
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {

--- a/frontend/src/setup/PrimaryChooser.tsx
+++ b/frontend/src/setup/PrimaryChooser.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@rakuensoftware/smoothgui';
 
 /* Provider chooser — wizard page 1 AND the Agents tab's "add delegate" first
  * window. Four supported providers, two shapes:
@@ -85,15 +86,6 @@ const SUB_SPECS: SubSpec[] = [
   },
 ];
 
-const btn = (bg: string): React.CSSProperties => ({
-  padding: '7px 16px', borderRadius: 7, border: `1px solid ${bg}`, background: bg,
-  color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
-});
-const primaryBtn = btn('#2c8f56');
-const ghostBtn: React.CSSProperties = {
-  padding: '6px 12px', borderRadius: 7, border: '1px solid #ccd', background: '#f4f6fb',
-  color: '#446', cursor: 'pointer', fontSize: 13,
-};
 const input: React.CSSProperties = {
   width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
   border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
@@ -325,9 +317,9 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
 
   return (
     <div style={{ marginBottom: 14 }}>
-      <button onClick={reset} style={{ ...ghostBtn, marginBottom: 12 }} disabled={busy || polling}>
+      <Button variant="default" onClick={reset} style={{ marginBottom: 12 }} disabled={busy || polling}>
         ← Choose a different {delegate ? 'provider' : 'primary'}
-      </button>
+      </Button>
 
       {apiSpec && (
         <div style={{ display: 'grid', gap: 12 }}>
@@ -358,9 +350,9 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
           </div>
           <PrimaryOnlyToggle checked={primaryOnly} disabled={busy} onChange={setPrimaryOnly} />
           <div>
-            <button style={primaryBtn} disabled={busy} onClick={submitApi}>
+            <Button variant="primary" disabled={busy} onClick={submitApi}>
               {busy ? 'Saving…' : delegate ? 'Add delegate' : 'Save & set as primary'}
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -376,9 +368,9 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
               </p>
               <PrimaryOnlyToggle checked={primaryOnly} disabled={busy} onChange={setPrimaryOnly} />
               <div>
-                <button style={primaryBtn} disabled={busy} onClick={startSub}>
+                <Button variant="primary" disabled={busy} onClick={startSub}>
                   {busy ? 'Starting…' : `Sign in with ${subSpec.label}`}
-                </button>
+                </Button>
               </div>
             </>
           ) : (
@@ -404,9 +396,9 @@ export default function PrimaryChooser({ onConfigured, mode = 'primary' }: Prima
                   </div>
                   <input style={input} value={codeBack} onChange={(e) => setCodeBack(e.target.value)} placeholder="paste code" />
                   <div>
-                    <button style={primaryBtn} disabled={busy} onClick={submitCodeBack}>
+                    <Button variant="primary" disabled={busy} onClick={submitCodeBack}>
                       {busy ? 'Submitting…' : 'Submit code'}
-                    </button>
+                    </Button>
                   </div>
                 </div>
               )}

--- a/frontend/src/setup/SharedStore.tsx
+++ b/frontend/src/setup/SharedStore.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useToast } from '@rakuensoftware/smoothgui';
+import { Button, useToast } from '@rakuensoftware/smoothgui';
 import { loadConfig, saveConfigValue, type ConfigMap } from './configApi';
 import { isRestartKey } from './wizardSteps';
 
@@ -134,9 +134,9 @@ export default function SharedStore({ onSaved, fetchImpl }: SharedStoreProps) {
       )}
 
       <div>
-        <button style={primaryBtn} disabled={saving} onClick={save}>
+        <Button variant="primary" disabled={saving} onClick={save}>
           {saving ? 'Saving…' : 'Save & continue'}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -146,8 +146,4 @@ const radioRow: React.CSSProperties = { display: 'flex', alignItems: 'center', g
 const input: React.CSSProperties = {
   width: '100%', boxSizing: 'border-box', padding: '7px 9px', borderRadius: 6,
   border: '1px solid #ccd', fontSize: 13, fontFamily: 'ui-monospace, monospace',
-};
-const primaryBtn: React.CSSProperties = {
-  padding: '7px 16px', borderRadius: 7, border: '1px solid #2c6', background: '#2c8f56',
-  color: '#fff', cursor: 'pointer', fontSize: 13.5, fontWeight: 600,
 };


### PR DESCRIPTION
Fourth slice of the Button sweep (follows #1465, #1467, #1468). Migrates the setup/installer pages' raw `<button>` and per-page `primaryBtn`/`btn`/`ghostBtn`/`btnBusy` constants onto shared smoothgui `Button`.

**Files:** ConnectHosts, ConnectWorkspace, PrimaryChooser, SharedStore, DeployTopology, DeployPanel, KnowledgeBase, components/SetupWizard.

## Variant mapping
- green `primaryBtn` (the emphasized Continue/Deploy/Finish/Save-&-continue action) → **primary** — this is the intended installer green→cyan token shift
- gray Save/Back/Skip/Later → **default**
- red remove / Clear SSH key → **danger**
- `ghostBtn` → **default** (it has a filled neutral `#f4f6fb` surface + border, not transparent; smoothgui ghost is transparent)

## Behavior preserved
- `disabled` kept verbatim; `loading` prop deliberately NOT adopted (would add aria-busy/dimming) — existing Saving…/Cloning… text stays the busy indicator.
- Busy-state buttons (sign-in, Deploy) keep a gray override for their disabled appearance (Button applies no opacity dimming on plain `disabled`).

## Left as raw `<button>` (custom controls)
- ConnectHosts method-tab segmented selector (`role=tab`)
- PrimaryChooser provider `cardStyle` cards
- SetupWizard/ConnectWorkspace `×` close glyphs and `all`/`none` bare text-links

## Verification
- `npm run check`: clean · `npm run build`: passes.