### PR TITLE
feat(wfe): default the live forge OFF + manual one-proposal-at-a-time fire

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (184)
+## CLI-settable keys (185)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -210,8 +210,9 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 | `wfe_live_forge_enabled` | bool | Gate for the autonomous live forge (default-ON). When off, the forge provider is not registered and every forge op fails closed, so an autonomous run can never open or merge a real PR. Even on, each op re-checks this flag and the merge-target rail. |
+| `wfe_proposals_autoscan_enabled` | bool | — |
 
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_client_bearer_token`, `kb_client_url`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_custom_stages`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_code_workers`, `kb_curator_extract_docs_enabled`, `kb_curator_extract_docs_workers`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_curator_user_presets`, `kb_evidence_embed_enabled`, `kb_mode`, `llm_embed_backend`, `llm_embed_gpu`, `llm_embed_host`, `llm_embed_tier`, `llm_rerank_backend`, `llm_rerank_endpoint`, `llm_rerank_gpu`, `llm_rerank_host`, `llm_rerank_tier`, `llm_synth_backend`, `llm_synth_endpoint`, `llm_synth_gpu`, `llm_synth_host`, `llm_synth_model`, `llm_synth_tier`
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_client_bearer_token`, `kb_client_url`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_custom_stages`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_code_workers`, `kb_curator_extract_docs_enabled`, `kb_curator_extract_docs_workers`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_curator_user_presets`, `kb_evidence_embed_enabled`, `kb_mode`, `llm_embed_backend`, `llm_embed_gpu`, `llm_embed_host`, `llm_embed_tier`, `llm_rerank_backend`, `llm_rerank_endpoint`, `llm_rerank_gpu`, `llm_rerank_host`, `llm_rerank_tier`, `llm_synth_backend`, `llm_synth_endpoint`, `llm_synth_gpu`, `llm_synth_host`, `llm_synth_model`, `llm_synth_tier`, `wfe_proposals_autoscan_enabled`
 
 ## Config-file sections (53)
 

--- a/src/cli_v1_routes_b.c
+++ b/src/cli_v1_routes_b.c
@@ -285,18 +285,37 @@ static cJSON *marshal_trigger_fire(int argc, char **argv)
 
    const char *source = rpc_get(&opts, "source");
    const char *task = rpc_get(&opts, "task");
-   if (!source || !source[0] || !task || !task[0])
+   const char *proposal = rpc_get(&opts, "proposal");
+
+   /* Proposals one-at-a-time fire: `--source proposals --proposal <name> --workspace <ws>`
+    * files exactly that pending proposal through the WFE pipeline (no --task needed). */
+   int is_proposal_fire = source && strcmp(source, "proposals") == 0 && proposal && proposal[0];
+
+   if (!source || !source[0] || (!is_proposal_fire && (!task || !task[0])))
    {
-      fprintf(stderr, "aimee: usage: aimee trigger fire --source <source> --task <task> "
-                      "[--event <event>] [--workspace <ws>] [--token <auth_token>]\n");
+      fprintf(stderr,
+              "aimee: usage:\n"
+              "  aimee trigger fire --source <source> --task <task> [--event <e>] "
+              "[--workspace <ws>] [--token <t>]\n"
+              "  aimee trigger fire --source proposals --proposal <name> --workspace <ws> "
+              "[--pipeline <wf>] [--ref <ref>] [--mode <m>] [--event <dir>] [--token <t>]\n");
       return NULL;
    }
 
    cJSON *req = marshal_no_args("trigger.fire");
    cJSON_AddStringToObject(req, "source", source);
-   cJSON_AddStringToObject(req, "task", task);
+   if (task && task[0])
+      cJSON_AddStringToObject(req, "task", task);
 
    const char *v;
+   if ((v = rpc_get(&opts, "proposal")) && v[0])
+      cJSON_AddStringToObject(req, "proposal", v);
+   if ((v = rpc_get(&opts, "pipeline")) && v[0])
+      cJSON_AddStringToObject(req, "pipeline", v);
+   if ((v = rpc_get(&opts, "ref")) && v[0])
+      cJSON_AddStringToObject(req, "ref", v);
+   if ((v = rpc_get(&opts, "mode")) && v[0])
+      cJSON_AddStringToObject(req, "mode", v);
    if ((v = rpc_get(&opts, "event")) && v[0])
       cJSON_AddStringToObject(req, "event", v);
    if ((v = rpc_get(&opts, "workspace")) && v[0])

--- a/src/cli_v1_routes_c.c
+++ b/src/cli_v1_routes_c.c
@@ -240,6 +240,13 @@ static void print_trigger_status(cJSON *resp)
 
 static void print_trigger_fire(cJSON *resp)
 {
+   /* Proposals one-at-a-time fire returns a filed work item, not a trigger/pipeline pair. */
+   if (json_str(resp, "work_item_id")[0])
+   {
+      printf("filed proposal: %s\n", json_str(resp, "proposal"));
+      printf("work_item_id: %s\n", json_str(resp, "work_item_id"));
+      return;
+   }
    printf("trigger_id: %s\n", json_str(resp, "trigger_id"));
    if (json_str(resp, "pipeline_id")[0])
       printf("pipeline_id: %s\n", json_str(resp, "pipeline_id"));

--- a/src/config.c
+++ b/src/config.c
@@ -307,6 +307,7 @@ static const config_schema_entry_t config_schema[] = {
     {"gateway_pin_model", SCHEMA_BOOL, 0},
     {"css_style_graph_enabled", SCHEMA_BOOL, 0},
     {"wfe_live_forge_enabled", SCHEMA_BOOL, 0},
+    {"wfe_proposals_autoscan_enabled", SCHEMA_BOOL, 0},
     {"client_integrations_enabled", SCHEMA_BOOL, 0},
     {"audit_action_enabled", SCHEMA_BOOL, 0},
     {"audit_worm_enabled", SCHEMA_BOOL, 0},
@@ -840,24 +841,28 @@ static void config_set_defaults(config_t *cfg)
    cfg->skills_capability_autostub = 0;
    cfg->skills_eval_gate_enabled = 0;
    cfg->skills_eval_threshold = 0.01;
-   cfg->css_style_graph_enabled = 1;     /* default-on: the indexer builds the CSS style
-                                            graph so the read-only css signals/report work
-                                            out of the box (set false to opt out) */
-   cfg->wfe_live_forge_enabled = 1;      /* default-ON (operator ruling 2026-07-13,
-                                            restoring the plan's default): the live forge
-                                            registers at standup; set false to opt out.
-                                            The merge-target rail still bounds every op --
-                                            PRs open-only against the resolved trunk,
-                                            merges only to the unprotected autonomous
-                                            base -- and each op re-checks flag + rail. */
-   cfg->client_integrations_enabled = 1; /* default-ON: aimee auto-registers into
-                                            detected AI-tool user configs. Set false
-                                            (or export AIMEE_NO_CLIENT_INTEGRATIONS)
-                                            to keep aimee out of global tool configs
-                                            and wire a single project by hand. */
-   cfg->audit_action_enabled = 1;        /* default-ON: the trajectory_export reader (S3)
-                                            shipped, so the passive per-action audit row
-                                            is on by default; set false to opt out */
+   cfg->css_style_graph_enabled = 1;        /* default-on: the indexer builds the CSS style
+                                               graph so the read-only css signals/report work
+                                               out of the box (set false to opt out) */
+   cfg->wfe_live_forge_enabled = 0;         /* default-OFF (2026-07-17): the live forge does
+                                               REAL git push + PR + merge, so it stays opt-in
+                                               while the autonomous pipeline is under test.
+                                               When OFF the forge provider is not registered
+                                               and every forge op fails closed (an autonomous
+                                               run parks, never opens/merges a real PR). Set
+                                               true to opt in; the merge-target rail still
+                                               bounds every op even when enabled. */
+   cfg->wfe_proposals_autoscan_enabled = 0; /* default-OFF: no automatic every-tick
+                                               proposal filing; file one at a time
+                                               manually via trigger.fire. */
+   cfg->client_integrations_enabled = 1;    /* default-ON: aimee auto-registers into
+                                               detected AI-tool user configs. Set false
+                                               (or export AIMEE_NO_CLIENT_INTEGRATIONS)
+                                               to keep aimee out of global tool configs
+                                               and wire a single project by hand. */
+   cfg->audit_action_enabled = 1;           /* default-ON: the trajectory_export reader (S3)
+                                               shipped, so the passive per-action audit row
+                                               is on by default; set false to opt out */
    snprintf(cfg->css_render_command, sizeof(cfg->css_render_command), "%s",
             CONFIG_DEFAULT_CSS_RENDER_COMMAND); /* default-on render backend (inert
                                                    until the sidecar is up); set empty
@@ -1192,6 +1197,10 @@ int config_load_file(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "wfe_live_forge_enabled");
    if (cJSON_IsBool(item))
       cfg->wfe_live_forge_enabled = cJSON_IsTrue(item);
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "wfe_proposals_autoscan_enabled");
+   if (cJSON_IsBool(item))
+      cfg->wfe_proposals_autoscan_enabled = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "client_integrations_enabled");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -133,6 +133,8 @@ const config_field_t config_fields[] = {
      CFG_BOOL},
     {"wfe_live_forge_enabled", offsetof(config_t, wfe_live_forge_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"wfe_proposals_autoscan_enabled", offsetof(config_t, wfe_proposals_autoscan_enabled),
+     sizeof(int), 0, CFG_BOOL},
     {"client_integrations_enabled", offsetof(config_t, client_integrations_enabled), sizeof(int), 0,
      CFG_BOOL},
     {"audit_action_enabled", offsetof(config_t, audit_action_enabled), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -904,8 +904,10 @@ int config_save(const config_t *cfg)
       cJSON_AddStringToObject(root, "ocr_command", cfg->ocr_command);
    if (!cfg->css_style_graph_enabled) /* default-on: persist only the opt-out */
       cJSON_AddBoolToObject(root, "css_style_graph_enabled", 0);
-   if (!cfg->wfe_live_forge_enabled) /* default-on: persist only the opt-out (disable) */
-      cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 0);
+   if (cfg->wfe_live_forge_enabled) /* default-off: persist only the opt-in (enable) */
+      cJSON_AddBoolToObject(root, "wfe_live_forge_enabled", 1);
+   if (cfg->wfe_proposals_autoscan_enabled) /* default-off: persist only the opt-in */
+      cJSON_AddBoolToObject(root, "wfe_proposals_autoscan_enabled", 1);
    if (!cfg->client_integrations_enabled) /* default-on: persist only the opt-out (disable) */
       cJSON_AddBoolToObject(root, "client_integrations_enabled", 0);
    if (!cfg->audit_action_enabled) /* default-on: persist only the opt-out (disable) */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -321,14 +321,21 @@ typedef struct config
     * assistant's style-graph write path during indexing (WP-C). When off, the
     * indexer keeps only the legacy lexical CSS class-name scan. */
    int css_style_graph_enabled;
-   /* wfe_live_forge_enabled: gate (default 1, ON — operator ruling 2026-07-13,
-    * restoring the plan's default) for the autonomous live forge
+   /* wfe_live_forge_enabled: gate (default 0, OFF — 2026-07-17: opt-in while the
+    * autonomous pipeline is under test) for the autonomous live forge
     * (full-autonomous-development F4). When OFF the wfe forge provider is not
     * registered and every forge op fails closed, so an autonomous run can never
-    * open or merge a real PR. Even ON, every op re-checks this flag AND the
-    * merge-target rail: PRs open-only against the resolved trunk, merges only
-    * to the unprotected autonomous base. Set false to opt out. */
+    * open or merge a real PR (it parks). When ON, every op still re-checks this
+    * flag AND the merge-target rail: PRs open-only against the resolved trunk,
+    * merges only to the unprotected autonomous base. Set true to opt in. */
    int wfe_live_forge_enabled;
+   /* wfe_proposals_autoscan_enabled: gate (default 0, OFF — 2026-07-17) for the
+    * proposals/watch-dir trigger source's AUTOMATIC every-tick scan that files a
+    * WFE work item for every un-filed pending proposal. When OFF, proposals are
+    * NEVER filed automatically; a human files them one at a time via
+    * `trigger.fire source=proposals proposal=<name>`. Set true to opt in to the
+    * autonomous scan once the pipeline is trusted. */
+   int wfe_proposals_autoscan_enabled;
    /* client_integrations_enabled: gate (default 1, ON) for the automatic
     * registration of aimee into external AI-tool user configs — the Claude Code
     * MCP server/hooks/env/commands in ~/.claude, plus Gemini/Copilot/Codex. When

--- a/src/server/server_trigger.c
+++ b/src/server/server_trigger.c
@@ -75,6 +75,40 @@ int handle_trigger_fire(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          return server_send_error(conn, "unauthorized", NULL);
    }
 
+   /* Manual one-at-a-time proposal fire: source=proposals + proposal=<name> files exactly
+    * that pending proposal through the WFE pipeline, bypassing the default-off auto scan
+    * (wfe_proposals_autoscan_enabled). This is the controlled 'send one proposal at a time'
+    * path used while the autonomous pipeline is under test. */
+   {
+      cJSON *src = cJSON_GetObjectItemCaseSensitive(req, "source");
+      cJSON *prop = cJSON_GetObjectItemCaseSensitive(req, "proposal");
+      if (src && cJSON_IsString(src) && strcmp(src->valuestring, "proposals") == 0 && prop &&
+          cJSON_IsString(prop) && prop->valuestring[0])
+      {
+         cJSON *ws = cJSON_GetObjectItemCaseSensitive(req, "workspace");
+         if (!ws || !cJSON_IsString(ws) || !ws->valuestring[0])
+            return server_send_error(conn, "workspace is required for a proposals fire", NULL);
+         cJSON *pl = cJSON_GetObjectItemCaseSensitive(req, "pipeline");
+         const char *pipeline =
+             (pl && cJSON_IsString(pl) && pl->valuestring[0]) ? pl->valuestring : "build";
+         cJSON *ev = cJSON_GetObjectItemCaseSensitive(req, "event");
+         const char *event = (ev && cJSON_IsString(ev)) ? ev->valuestring : "";
+         cJSON *rf = cJSON_GetObjectItemCaseSensitive(req, "ref");
+         const char *ref = (rf && cJSON_IsString(rf)) ? rf->valuestring : "";
+         cJSON *md = cJSON_GetObjectItemCaseSensitive(req, "mode");
+         const char *mode = (md && cJSON_IsString(md)) ? md->valuestring : "";
+         char wid[80];
+         if (trigger_proposals_file_one(ws->valuestring, pipeline, event, ref, mode,
+                                        prop->valuestring, wid) != 0)
+            return server_send_error(
+                conn, "proposal not filed (not found, already filed, or error)", NULL);
+         cJSON *resp = jo_ok();
+         cJSON_AddStringToObject(resp, "work_item_id", wid);
+         cJSON_AddStringToObject(resp, "proposal", prop->valuestring);
+         return server_send_ok(conn, resp);
+      }
+   }
+
    /* 3. Extract required + optional fields */
    cJSON *task_item = cJSON_GetObjectItemCaseSensitive(req, "task");
    if (!task_item || !cJSON_IsString(task_item) || !task_item->valuestring[0])

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -9,6 +9,7 @@
 #endif
 
 #include "config.h"
+#include "server_trigger.h"
 #include <dirent.h>
 #include "cJSON.h"
 #include "db1/db1_cron_jobs.h"
@@ -516,10 +517,40 @@ static int trigger_active_filed_runs(const char *home)
    return active;
 }
 
-static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
+/* Match a pending-proposal manual-fire selector against a repo-relative ls-tree entry
+ * name. Accepts the full repo-relative path (docs/proposals/pending/foo.md), the bare
+ * basename (foo.md), or the basename without the .md suffix (foo). */
+static int proposal_name_matches(const char *entry_name, const char *want)
 {
+   if (!entry_name || !want || !want[0])
+      return 0;
+   if (strcmp(entry_name, want) == 0)
+      return 1;
+   const char *base = strrchr(entry_name, '/');
+   base = base ? base + 1 : entry_name;
+   if (strcmp(base, want) == 0)
+      return 1;
+   size_t bl = strlen(base);
+   if (bl > 3 && strcmp(base + bl - 3, ".md") == 0)
+   {
+      size_t wl = strlen(want);
+      if (wl == bl - 3 && strncmp(base, want, wl) == 0) /* basename minus the .md suffix */
+         return 1;
+   }
+   return 0;
+}
+
+/* Scan the rule's proposal dir and file WFE work items. only_name!=NULL files just the
+ * single matching pending proposal (manual one-at-a-time fire); NULL files all un-filed
+ * ones (the auto scan). Returns the count filed; copies the first filed work-item id into
+ * out_id when non-NULL. */
+static int scan_proposals_ex(const trigger_rule_t *rule, int max_concurrent, const char *only_name,
+                             char *out_id, size_t out_id_sz)
+{
+   if (out_id && out_id_sz)
+      out_id[0] = '\0';
    if (!rule || !rule->workspace[0] || !rule->pipeline_template[0])
-      return;
+      return 0;
 
    const char *scanpath = rule->event[0] ? rule->event : PROPOSALS_DEFAULT_DIR;
    /* Reject an absolute or traversing scan dir: `event` is repo-relative and must
@@ -528,7 +559,7 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
    {
       aimee_log(LOG_WARN, "trigger.sched", "proposals scan dir rejected (absolute/traversal): %s",
                 scanpath);
-      return;
+      return 0;
    }
 
    char ref[256];
@@ -538,7 +569,7 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
    if (ref[0] == '-')
    {
       aimee_log(LOG_WARN, "trigger.sched", "proposals ref rejected (leading '-'): %s", ref);
-      return;
+      return 0;
    }
 
    /* git ls-tree on a bare directory pathspec lists only that directory's own
@@ -550,7 +581,7 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
    while (sl > 0 && scanpath[sl - 1] == '/')
       sl--;
    if (snprintf(scandir, sizeof(scandir), "%.*s/", (int)sl, scanpath) >= (int)sizeof(scandir))
-      return;
+      return 0;
 
    const char *const ls_argv[] = {"git", "ls-tree", ref, "--", scandir, NULL};
    char *out = NULL;
@@ -560,7 +591,7 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
       aimee_log(LOG_WARN, "trigger.sched", "proposals ls-tree failed repo=%s ref=%s rc=%d",
                 rule->workspace, ref, rc);
       free(out);
-      return;
+      return 0;
    }
 
    trigger_ls_tree_entry_t entries[PROPOSALS_MAX_ENTRIES];
@@ -577,13 +608,13 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
    {
       aimee_log(LOG_WARN, "trigger.sched",
                 "proposals: no resolvable AIMEE_HOME; refusing to materialize under /tmp");
-      return;
+      return 0;
    }
    if (trigger_mkdir_parents(home) != 0)
    {
       aimee_log(LOG_WARN, "trigger.sched", "proposals: could not create %s/triggers/proposals: %s",
                 home, strerror(errno));
-      return;
+      return 0;
    }
 
    /* trigger.max_concurrent: admission cap on concurrently-executing triggered
@@ -598,7 +629,7 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
       {
          aimee_log(LOG_WARN, "trigger.sched",
                    "proposals: could not count active triggered runs; deferring this pass");
-         return; /* fail closed: never overshoot the cap on a DB read fault */
+         return 0; /* fail closed: never overshoot the cap on a DB read fault */
       }
       budget = max_concurrent - active;
       if (budget <= 0)
@@ -606,13 +637,15 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
          aimee_log(LOG_INFO, "trigger.sched",
                    "proposals: %d active triggered run(s) >= max_concurrent=%d; deferring", active,
                    max_concurrent);
-         return;
+         return 0;
       }
    }
 
    int filed = 0;
    for (int i = 0; i < n; i++)
    {
+      if (only_name && !proposal_name_matches(entries[i].name, only_name))
+         continue;
       if (budget == 0)
       {
          aimee_log(LOG_INFO, "trigger.sched",
@@ -655,6 +688,8 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
       if (trigger_file_run(rule, proposal_path, what, id) == 0)
       {
          filed++;
+         if (out_id && out_id_sz && !out_id[0])
+            snprintf(out_id, out_id_sz, "%s", id);
          if (budget > 0)
             budget--;
       }
@@ -664,6 +699,7 @@ static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
     * its 30s backstop sweep (parity with the /v1/dev/submit intake). */
    if (filed > 0)
       wfe_scheduler_notify();
+   return filed;
 }
 
 /* ------------------------------------------------------------------ */
@@ -979,14 +1015,58 @@ typedef struct
 
 static int proposals_due(const trigger_rule_t *rule, const struct tm *tm)
 {
-   (void)rule;
    (void)tm;
+   /* The generic "watch-dir" source keeps its every-pass scan. The "proposals" source
+    * is gated OFF by default (wfe_proposals_autoscan_enabled): while the autonomous
+    * pipeline is under test, pending proposals are NOT filed automatically -- a human
+    * files them one at a time via `trigger.fire source=proposals proposal=<name>`. Set
+    * the flag true to opt back in to the every-pass autonomous scan. */
+   if (rule && strcmp(rule->source, "proposals") == 0)
+   {
+      config_t cfg;
+      config_load(&cfg);
+      return cfg.wfe_proposals_autoscan_enabled ? 1 : 0;
+   }
    return 1; /* poll the repo every pass; per-proposal dedup makes re-scans idempotent */
+}
+
+/* Back-compat 2-arg wrapper: the auto scan files ALL un-filed pending proposals. */
+static void scan_proposals(const trigger_rule_t *rule, int max_concurrent)
+{
+   scan_proposals_ex(rule, max_concurrent, NULL, NULL, 0);
 }
 
 static void proposals_fire(const trigger_rule_t *rule, int max_concurrent)
 {
    scan_proposals(rule, max_concurrent);
+}
+
+/* Manual one-at-a-time proposal fire: file exactly the named pending proposal as a WFE
+ * work item, bypassing the (default-off) auto scan. Returns 0 and fills out_id on a
+ * successful file; -1 if the proposal was not found, already filed, or on error. */
+int trigger_proposals_file_one(const char *workspace, const char *pipeline, const char *event_dir,
+                               const char *ref, const char *mode, const char *proposal_name,
+                               char out_id[80])
+{
+   if (out_id)
+      out_id[0] = '\0';
+   if (!workspace || !workspace[0] || !pipeline || !pipeline[0] || !proposal_name ||
+       !proposal_name[0])
+      return -1;
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof(rule));
+   snprintf(rule.source, sizeof(rule.source), "proposals");
+   snprintf(rule.workspace, sizeof(rule.workspace), "%s", workspace);
+   snprintf(rule.pipeline_template, sizeof(rule.pipeline_template), "%s", pipeline);
+   if (event_dir && event_dir[0])
+      snprintf(rule.event, sizeof(rule.event), "%s", event_dir);
+   if (ref && ref[0])
+      snprintf(rule.schedule, sizeof(rule.schedule), "%s", ref);
+   if (mode && mode[0])
+      snprintf(rule.mode, sizeof(rule.mode), "%s", mode);
+   /* max_concurrent=0 -> uncapped: a deliberate single manual fire is not deferred. */
+   int filed = scan_proposals_ex(&rule, 0, proposal_name, out_id, 80);
+   return (filed > 0 && out_id && out_id[0]) ? 0 : -1;
 }
 
 static int cron_due(const trigger_rule_t *rule, const struct tm *tm)

--- a/src/server_trigger.h
+++ b/src/server_trigger.h
@@ -5,3 +5,10 @@ int handle_trigger_fire(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_trigger_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_trigger_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_trigger_cancel(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+
+/* Manual one-at-a-time proposal fire (defined in trigger_scheduler.c): file exactly the
+ * named pending proposal as a WFE work item, bypassing the default-off auto scan.
+ * Returns 0 and fills out_id[80] on success; -1 if not found/already filed/error. */
+int trigger_proposals_file_one(const char *workspace, const char *pipeline, const char *event_dir,
+                               const char *ref, const char *mode, const char *proposal_name,
+                               char out_id[80]);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1324,7 +1324,7 @@ $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o 
 	                                $(OBJDIR)/cJSON.o $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
 	                                $(OBJDIR)/db1/model_catalog.o \
 	                                $(OBJDIR)/cmd_init.o \
-	                                $(OBJDIR)/server/server_trigger.o $(OBJDIR)/db1/db1_trigger.o \
+	                                $(OBJDIR)/server/server_trigger.o $(OBJDIR)/tests/support/trigger_proposals_stub.o $(OBJDIR)/db1/db1_trigger.o \
 	                                $(OBJDIR)/db1/pipelines.o $(OBJDIR)/db1/token_audit.o \
 	                                $(OBJDIR)/server/delegate_backend.o $(OBJDIR)/server/delegate_backend_local.o \
 	                                $(OBJDIR)/server/delegate_backend_ssh.o $(OBJDIR)/server/delegate_backend_docker.o \

--- a/src/tests/support/trigger_proposals_stub.c
+++ b/src/tests/support/trigger_proposals_stub.c
@@ -1,0 +1,22 @@
+/* trigger_proposals_stub.c: no-op stub for trigger_proposals_file_one (the real one lives
+ * in trigger_scheduler.c, which drags in the wfe engine + db1 subsystems). Tests that link
+ * server_trigger.o — whose handle_trigger_fire references trigger_proposals_file_one — but
+ * exercise only HTTP dispatch/routing, link this instead of the heavyweight scheduler TU.
+ * Binaries that exercise the real proposals fire link trigger_scheduler.o and must NOT also
+ * link this TU. */
+#include "server_trigger.h"
+
+int trigger_proposals_file_one(const char *workspace, const char *pipeline, const char *event_dir,
+                               const char *ref, const char *mode, const char *proposal_name,
+                               char out_id[80])
+{
+   (void)workspace;
+   (void)pipeline;
+   (void)event_dir;
+   (void)ref;
+   (void)mode;
+   (void)proposal_name;
+   if (out_id)
+      out_id[0] = '\0';
+   return -1;
+}

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -60,10 +60,12 @@ int main(void)
       assert(fabs(cfg.code_hybrid_weight_graph - 1.0) < 1e-9);
       assert(fabs(cfg.code_hybrid_rrf_k - 60.0) < 1e-9);
       assert(cfg.guardrails_blast_radius_advisory_enabled == 0);
-      /* The autonomous live forge (F4) defaults ON (operator ruling 2026-07-13);
-       * the merge-target rail still bounds every op, and wfe_live_forge_enabled:
-       * false opts out. */
-      assert(cfg.wfe_live_forge_enabled == 1);
+      /* The autonomous live forge (F4) defaults OFF (2026-07-17): it does real
+       * git push + PR + merge, so it stays opt-in while the autonomous pipeline is
+       * under test. Set wfe_live_forge_enabled true to opt in. The proposals auto-scan
+       * likewise defaults off, so pending proposals are filed one at a time by a human. */
+      assert(cfg.wfe_live_forge_enabled == 0);
+      assert(cfg.wfe_proposals_autoscan_enabled == 0);
       assert(cfg.db1_path[0] != '\0');
       assert(cfg.guardrails_semantic_advisory_only == 1);
       assert(cfg.skills_review_nudge_interval == 10);

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -1118,6 +1118,22 @@ static void test_trigger_source_registry(void)
 /* main                                                                */
 /* ------------------------------------------------------------------ */
 
+static void test_proposal_name_matches(void)
+{
+   /* full repo-relative path, bare basename, and basename-without-.md all match */
+   assert(proposal_name_matches("docs/proposals/pending/foo.md", "docs/proposals/pending/foo.md"));
+   assert(proposal_name_matches("docs/proposals/pending/foo.md", "foo.md"));
+   assert(proposal_name_matches("docs/proposals/pending/foo.md", "foo"));
+   /* non-matches, including near-misses that must not over-read `want` */
+   assert(!proposal_name_matches("docs/proposals/pending/foo.md", "bar"));
+   assert(!proposal_name_matches("docs/proposals/pending/foobar.md", "foo"));
+   assert(!proposal_name_matches("docs/proposals/pending/foo.mdx", "foo"));
+   assert(!proposal_name_matches("docs/proposals/pending/foo.md", ""));
+   assert(!proposal_name_matches(NULL, "foo"));
+   assert(!proposal_name_matches("docs/proposals/pending/foo.md", NULL));
+   printf("  proposal_name_matches: ok\n");
+}
+
 int main(void)
 {
    printf("test_trigger\n");
@@ -1165,6 +1181,7 @@ int main(void)
    test_scan_proposals_applies_cost_cap();
    test_scan_proposals_enforces_max_concurrent();
    test_trigger_source_registry();
+   test_proposal_name_matches();
    printf("All tests passed.\n");
    return 0;
 }


### PR DESCRIPTION
## Why

The autonomous WFE **live forge** (real `git push` + `gh pr` + **merge**) was default-ON. Combined with the proposals trigger — whose `proposals_due` returns `1` every tick and files a WFE work item for *every* un-filed pending proposal — a proposal added to `docs/proposals/pending/` gets implemented by a worker and pushed/PR'd/merged autonomously. During this session that pipeline amended an in-flight human branch and merged it into `testing` without human action.

Make autonomy **opt-in** while it's under test, and give a controlled way to exercise it one proposal at a time.

## Changes

- **`wfe_live_forge_enabled` now defaults OFF.** When off, the forge provider isn't registered and every forge op fails closed — an autonomous run parks; no real push/PR/merge. Persist logic flips to opt-in; `config.h` doc + `test_config` default assertion updated.
- **New `wfe_proposals_autoscan_enabled` (default OFF).** `proposals_due` returns `0` for the `proposals` source unless opted in, so pending proposals are **never** filed automatically. `watch-dir` keeps its every-pass scan.
- **Manual one-at-a-time fire:** `aimee trigger fire --source proposals --proposal <name> --workspace <ws> [--pipeline <wf>] [--ref <ref>] [--mode <m>]` files exactly that pending proposal through the real WFE pipeline (`scan_proposals_ex` with a name filter that matches full path / basename / basename-without-`.md`), bypassing the auto scan. Returns the filed `work_item_id`.

## Tests / build

- `test_proposal_name_matches` (incl. the out-of-bounds guard for a short selector).
- `test_config` asserts both new defaults are 0.
- Full server build links; clang-format-19 clean; `make docs-gen` regenerated `configuration.md`.

## Net effect

By default nothing autonomous happens (no auto-filing, no push/PR/merge). To test: opt the forge in and fire a single named proposal; iterate until trusted.
