### PR TITLE
fix(agent): make primary_only the sole per-agent delegate gate

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -44,26 +44,29 @@ void agent_set_route_health_filter(int (*fn)(const char *agent_name));
 
 /* Optional route-time delegate-POLICY filter, same mechanism as the health
  * filter (returns nonzero to EXCLUDE the agent; NULL disables). The server
- * registers a live-config predicate enforcing two invariants everywhere
- * routing happens, not just on one dispatch path:
- *   1) the PRIMARY passthrough — the agent named after config.provider — is
- *      never a delegation target (the primary must not delegate back to
- *      itself; roundtables already enforce this for panel seats);
- *   2) an agent flagged "Primary Agent Only" (agents.json `primary_only`) is
- *      never a delegation target — the per-agent choice that replaced the global
- *      claude_cli_delegate_enabled opt-in.
- * The structural half of (2) — a claude-CLI agent that is not server-hosted
- * can never execute as a delegate — is enforced unconditionally in
+ * registers a predicate enforcing ONE invariant everywhere routing happens,
+ * not just on one dispatch path:
+ *   an agent flagged "Primary Agent Only" (agents.json `primary_only`) is
+ *   never a delegation target — the per-agent choice that replaced the global
+ *   claude_cli_delegate_enabled opt-in. There is deliberately no separate
+ *   "provider-named agent is never a delegate" name match: that rule made the
+ *   flag unreachable for a claude-oauth-as-primary box (the OAuth flow names
+ *   the agent "claude", which then equals config.provider), so `primary_only`
+ *   is now the sole per-agent gate and unchecking it opts the primary into
+ *   self-delegation. Roundtable panels keep their own primary exclusion
+ *   (delegate_ensemble.c) so a panel second opinion is never the primary.
+ * The structural rule — a claude-CLI agent that is not server-hosted can never
+ * execute as a delegate — is enforced unconditionally in
  * agent_is_available_for_routing, so even filter-less builds (CLI/tests) never
  * route to a client-only claude. */
 void agent_set_route_policy_filter(int (*fn)(const agent_t *agent));
 
 /* Primary-turn marker for the delegate-policy filter. The PRIMARY chat turn
  * routes the provider-named agent through the same machinery as delegation
- * (agent_run_with_tools -> agent_route), where policy rule (1) above would
- * exclude it and rule (2) would demand the delegate opt-in — but a primary
- * turn is not delegation: driving claude via its CLI as the PRIMARY is the
- * documented default. The chat worker brackets the turn with set(1)/set(0) on
+ * (agent_run_with_tools -> agent_route), where the `primary_only` gate above
+ * would exclude a primary-only agent — but a primary turn is not delegation:
+ * driving claude via its CLI as the PRIMARY is the documented default. The
+ * chat worker brackets the turn with set(1)/set(0) on
  * its own thread (thread-local, so concurrent delegate routing on other
  * threads stays policed); the server's policy predicate consults it. */
 void agent_routing_set_primary_turn(int on);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1914,36 +1914,32 @@ static int server_agent_route_is_down(const char *agent_name)
 }
 
 /* Route-time delegate-policy predicate (returns nonzero to EXCLUDE):
- * 1) the primary passthrough — the agent named after config.provider — is
- *    never a delegation target: the primary must not delegate back to itself
- *    (observed in the wild as a streak of failed 'code' delegations to the
- *    operator's own OAuth claude entry). Matched by NAME only, deliberately:
- *    other agents that merely share the provider tag (e.g. gateway-routed
- *    anthropic models) are legitimate delegates.
- * 2) a per-agent "Primary Agent Only" choice (agents.json `primary_only`)
- *    excludes the agent from ALL delegation. This replaces the former global
- *    claude_cli_delegate_enabled opt-in with a per-agent flag set at add time:
- *    a claude-oauth subscription is pre-flagged primary-only (driving a personal
- *    Claude plan as an automated delegate may breach Anthropic's terms), every
- *    other agent defaults off.
- * Rule 2 is config-independent (it reads the agent record), so a config_load
- * failure only means rule 1's primary name is unknown — the per-agent gate
- * still holds. */
+ * a per-agent "Primary Agent Only" choice (agents.json `primary_only`) excludes
+ * the agent from ALL delegation. This is the SOLE per-agent gate: it replaced the
+ * former global claude_cli_delegate_enabled opt-in AND the older unconditional
+ * "the provider-named agent is never a delegation target" name match. That name
+ * match made the operator's choice unreachable for the common claude-oauth-as-
+ * primary setup — the OAuth flow always names the agent "claude", so an agent
+ * named after config.provider could never be a delegate even with Primary Agent
+ * Only unchecked. Now the flag alone decides: a claude-oauth subscription is
+ * pre-flagged primary-only at add time (driving a personal Claude plan as an
+ * automated delegate may breach Anthropic's terms), and unchecking it is an
+ * explicit operator opt-in to self-delegation. Roundtable panels keep their own
+ * primary exclusion (delegate_ensemble.c) so a second opinion is never the
+ * primary itself.
+ * The gate is config-independent (it reads the agent record), so it holds even
+ * when config_load would fail. */
 static int server_agent_route_policy_excluded(const agent_t *ag)
 {
    if (!ag)
       return 1;
    /* A PRIMARY chat turn routes the provider-named agent through the same
-    * machinery as delegation; both rules below are delegation policy, so they
-    * must not exclude the primary from its own turn (they otherwise break
-    * every server-side chat whose provider is a configured agent — the
-    * webchat's default). The marker is thread-local to the chat worker. */
+    * machinery as delegation; the gate below is delegation policy, so it must
+    * not exclude the primary from its own turn (it otherwise breaks every
+    * server-side chat whose provider is a primary-only agent — the webchat's
+    * default). The marker is thread-local to the chat worker. */
    if (agent_routing_primary_turn())
       return 0;
-   config_t cfg;
-   if (config_load(&cfg) == 0 && cfg.provider[0] && ag->name[0] &&
-       strcasecmp(ag->name, cfg.provider) == 0)
-      return 1;
    if (ag->primary_only)
       return 1;
    return 0;


### PR DESCRIPTION
## Problem
The route-time delegate-policy filter (`server_agent_route_policy_excluded`) excluded any agent whose name equals `config.provider` from delegation, **independent of the per-agent `primary_only` flag**. The OAuth flow always names the claude agent `"claude"`, so on a claude-oauth-as-primary box (`provider: claude`) that agent could never be a delegate even with "Primary Agent Only" unchecked — the per-agent flag that replaced the global `claude_cli_delegate_enabled` opt-in was unreachable.

## Fix
Drop the name match; `primary_only` is now the only per-agent gate:
- The primary-turn guard (`agent_routing_primary_turn()`) still lets the provider-named agent serve its own chat turns.
- Roundtable panels keep their independent primary exclusion (`delegate_ensemble.c`), so a panel second opinion is never the primary itself.
- claude-oauth agents still default `primary_only:true` (ToS), so using one as a delegate remains an explicit operator opt-in.

## Verification
On the test appliance, a server-hosted claude agent whose name differs from the provider routed and executed a delegate turn end-to-end via the tmux CLI (returned the exact requested token); the provider-named `claude` was blocked solely by this rule. Changed files are clang-format-19 clean.