### PR TITLE
refactor(webchat): adopt smoothgui DataTable across Dashboard

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Badge, Button, Panel, EmptyState, StatusDot } from '@rakuensoftware/smoothgui';
-import type { BadgeVariant } from '@rakuensoftware/smoothgui';
+import { Badge, Button, Panel, EmptyState, StatusDot, DataTable } from '@rakuensoftware/smoothgui';
+import type { BadgeVariant, Column } from '@rakuensoftware/smoothgui';
 
 /* ---- API types ---- */
 
@@ -266,133 +266,89 @@ export function toDashData(raw: RawDashboard | null | undefined): DashData {
   };
 }
 
-/* ---- Shared table styles ---- */
-
-const tableStyle: React.CSSProperties = {
-  width: '100%', borderCollapse: 'collapse', fontSize: '12px',
-};
-
-const thStyle: React.CSSProperties = {
-  textAlign: 'left', padding: '6px 10px', borderBottom: '1px solid #eee',
-  color: '#888', fontSize: '11px', textTransform: 'uppercase',
-  letterSpacing: '0.3px', position: 'sticky', top: 0, background: '#fafafa',
-};
-
-const tdStyle: React.CSSProperties = {
-  padding: '5px 10px', borderBottom: '1px solid #f5f5f5',
-};
-
-const numTd: React.CSSProperties = { ...tdStyle, textAlign: 'right', fontVariantNumeric: 'tabular-nums' };
-
-
 /* ---- Panels ---- */
+
+const DELEGATION_COLUMNS: Column<Delegation>[] = [
+  { key: 'agent', label: 'Agent', render: r => e(r.agent) },
+  { key: 'role', label: 'Role', render: r => e(r.role) },
+  {
+    key: 'status', label: 'Status',
+    render: r => <Badge label={r.success ? 'OK' : 'ERR'} variant={r.success ? 'success' : 'error'} />,
+  },
+  { key: 'turns', label: 'Turns', align: 'right', render: r => r.turns },
+  { key: 'tools', label: 'Tools', align: 'right', render: r => r.tool_calls },
+  { key: 'latency', label: 'Latency', align: 'right', render: r => <span title={`${r.latency_ms}ms`}>{fmtDuration(r.latency_ms)}</span> },
+];
 
 function DelegationsPanel({ data }: { data: Delegation[] }) {
   return (
     <Panel title="Delegations" count={data.length}>
-      <table style={tableStyle}>
-        <thead>
-          <tr>
-            {['Agent', 'Role', 'Status', 'Turns', 'Tools', 'Latency'].map(h => (
-              <th key={h} style={thStyle}>{h}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((r, i) => (
-            <tr key={i}>
-              <td style={tdStyle}>{e(r.agent)}</td>
-              <td style={tdStyle}>{e(r.role)}</td>
-              <td style={tdStyle}>
-                <Badge label={r.success ? 'OK' : 'ERR'} variant={r.success ? 'success' : 'error'} />
-              </td>
-              <td style={numTd}>{r.turns}</td>
-              <td style={numTd}>{r.tool_calls}</td>
-              <td style={numTd} title={`${r.latency_ms}ms`}>{fmtDuration(r.latency_ms)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DataTable columns={DELEGATION_COLUMNS} rows={data} rowKey={(_r, i) => i} />
     </Panel>
   );
 }
+
+const METRIC_COLUMNS: Column<Metric>[] = [
+  { key: 'role', label: 'Role', render: r => e(r.role) },
+  { key: 'total', label: 'Total', align: 'right', render: r => r.total },
+  { key: 'ok', label: 'OK', align: 'right', render: r => r.successes },
+  { key: 'avglat', label: 'Avg Lat', align: 'right', render: r => <span title={`${r.avg_latency_ms}ms`}>{fmtDuration(r.avg_latency_ms)}</span> },
+  { key: 'tokens', label: 'Tokens', align: 'right', render: r => <span title={`${r.tokens} tokens`}>{fmtCompact(r.tokens)}</span> },
+];
 
 function MetricsPanel({ data }: { data: Metric[] }) {
   return (
     <Panel title="Metrics">
-      <table style={tableStyle}>
-        <thead>
-          <tr>
-            {['Role', 'Total', 'OK', 'Avg Lat', 'Tokens'].map(h => (
-              <th key={h} style={thStyle}>{h}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((r, i) => (
-            <tr key={i}>
-              <td style={tdStyle}>{e(r.role)}</td>
-              <td style={numTd}>{r.total}</td>
-              <td style={numTd}>{r.successes}</td>
-              <td style={numTd} title={`${r.avg_latency_ms}ms`}>{fmtDuration(r.avg_latency_ms)}</td>
-              <td style={numTd} title={`${r.tokens} tokens`}>{fmtCompact(r.tokens)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DataTable columns={METRIC_COLUMNS} rows={data} rowKey={(_r, i) => i} />
     </Panel>
   );
 }
+
+const PLAN_COLUMNS: Column<Plan>[] = [
+  { key: 'id', label: 'ID', align: 'right', render: r => r.id },
+  { key: 'agent', label: 'Agent', render: r => e(r.agent) },
+  { key: 'status', label: 'Status', render: r => <Badge label={r.status} variant={planVariant(r.status)} /> },
+  { key: 'steps', label: 'Steps', align: 'right', render: r => `${r.done_steps}/${r.total_steps}` },
+  { key: 'task', label: 'Task', render: r => e(r.task.substring(0, 60)) },
+];
 
 function PlansPanel({ data }: { data: Plan[] }) {
   return (
     <Panel title="Execution Plans">
-      <table style={tableStyle}>
-        <thead>
-          <tr>
-            {['ID', 'Agent', 'Status', 'Steps', 'Task'].map(h => (
-              <th key={h} style={thStyle}>{h}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((r, i) => (
-            <tr key={i}>
-              <td style={numTd}>{r.id}</td>
-              <td style={tdStyle}>{e(r.agent)}</td>
-              <td style={tdStyle}><Badge label={r.status} variant={planVariant(r.status)} /></td>
-              <td style={numTd}>{r.done_steps}/{r.total_steps}</td>
-              <td style={tdStyle}>{e(r.task.substring(0, 60))}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DataTable columns={PLAN_COLUMNS} rows={data} rowKey={(_r, i) => i} />
     </Panel>
   );
 }
 
+const TRACE_COLUMNS: Column<Trace>[] = [
+  { key: 'turn', label: 'Turn', align: 'right', render: r => r.turn },
+  { key: 'tool', label: 'Tool', render: r => e(r.tool_name ?? '--') },
+  { key: 'dir', label: 'Dir', render: r => e(r.direction) },
+];
+
 function TracesPanel({ data }: { data: Trace[] }) {
   return (
     <Panel title="Traces">
-      <table style={tableStyle}>
-        <thead>
-          <tr>
-            {['Turn', 'Tool', 'Dir'].map(h => <th key={h} style={thStyle}>{h}</th>)}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((r, i) => (
-            <tr key={i}>
-              <td style={numTd}>{r.turn}</td>
-              <td style={tdStyle}>{e(r.tool_name ?? '--')}</td>
-              <td style={tdStyle}>{e(r.direction)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DataTable columns={TRACE_COLUMNS} rows={data} rowKey={(_r, i) => i} />
     </Panel>
   );
 }
+
+const MEMORY_COLUMNS: Column<MemoryStat>[] = [
+  {
+    key: 'tier', label: 'Tier',
+    render: r => (
+      <>
+        {e(r.tier)}
+        {r.functional_name ? (
+          <span style={{ color: '#aaa', marginLeft: '6px' }}>{e(r.functional_name)}</span>
+        ) : null}
+      </>
+    ),
+  },
+  { key: 'kind', label: 'Kind', render: r => e(r.kind) },
+  { key: 'count', label: 'Count', align: 'right', render: r => r.count },
+];
 
 function MemoryPanel({ data }: { data: MemoryStat[] }) {
   return (
@@ -402,33 +358,15 @@ function MemoryPanel({ data }: { data: MemoryStat[] }) {
           No memories recorded
         </div>
       ) : (
-        <table style={tableStyle}>
-          <thead>
-            <tr>
-              {['Tier', 'Kind', 'Count'].map(h => <th key={h} style={thStyle}>{h}</th>)}
-            </tr>
-          </thead>
-          <tbody>
-            {data.map((r, i) => (
-              <tr key={i}>
-                <td style={tdStyle}>
-                  {e(r.tier)}
-                  {r.functional_name ? (
-                    <span style={{ color: '#aaa', marginLeft: '6px' }}>{e(r.functional_name)}</span>
-                  ) : null}
-                </td>
-                <td style={tdStyle}>{e(r.kind)}</td>
-                <td style={numTd}>{r.count}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable columns={MEMORY_COLUMNS} rows={data} rowKey={(_r, i) => i} />
       )}
     </Panel>
   );
 }
 
 /* Cost / Token spend — realized spend rolled up per role, plus a headline total. */
+type CostRow = [string, { tokens: number; cost: number; calls: number }];
+
 function CostPanel({ data }: { data: TokenAudit[] }) {
   const totalCost = data.reduce((n, r) => n + (r.estimated_cost_usd || 0), 0);
   const totalTokens = data.reduce(
@@ -444,6 +382,12 @@ function CostPanel({ data }: { data: TokenAudit[] }) {
     byRole.set(key, cur);
   }
   const rows = [...byRole.entries()].sort((a, b) => b[1].tokens - a[1].tokens);
+  const columns: Column<CostRow>[] = [
+    { key: 'role', label: 'Role', render: ([role]) => e(role) },
+    { key: 'calls', label: 'Calls', align: 'right', render: ([, v]) => v.calls },
+    { key: 'tokens', label: 'Tokens', align: 'right', render: ([, v]) => fmtCompact(v.tokens) },
+    { key: 'cost', label: 'Cost', align: 'right', render: ([, v]) => fmtUsd(v.cost) },
+  ];
   return (
     <Panel title="Cost / Tokens" count={rows.length}>
       {data.length === 0 ? (
@@ -461,21 +405,7 @@ function CostPanel({ data }: { data: TokenAudit[] }) {
             </div>
           </div>
           <div style={{ flex: 1, overflow: 'auto' }}>
-            <table style={tableStyle}>
-              <thead>
-                <tr>{['Role', 'Calls', 'Tokens', 'Cost'].map(h => <th key={h} style={thStyle}>{h}</th>)}</tr>
-              </thead>
-              <tbody>
-                {rows.map(([role, v]) => (
-                  <tr key={role}>
-                    <td style={tdStyle}>{e(role)}</td>
-                    <td style={numTd}>{v.calls}</td>
-                    <td style={numTd}>{fmtCompact(v.tokens)}</td>
-                    <td style={numTd}>{fmtUsd(v.cost)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+            <DataTable columns={columns} rows={rows} rowKey={([role]) => role} />
           </div>
         </div>
       )}
@@ -484,28 +414,29 @@ function CostPanel({ data }: { data: TokenAudit[] }) {
 }
 
 /* Active Sessions — live chat/agent sessions (title, working dir, last activity). */
+const SESSION_COLUMNS: Column<Session>[] = [
+  { key: 'title', label: 'Title', render: s => e(s.title || '(untitled)') },
+  {
+    key: 'cwd', label: 'Working dir', width: 140,
+    render: s => (
+      <span style={{ display: 'block', color: '#999', maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={s.cwd}>
+        {e(shortenPath(s.cwd))}
+      </span>
+    ),
+  },
+  {
+    key: 'last_active', label: 'Last active',
+    render: s => <span style={{ whiteSpace: 'nowrap', color: '#999' }}>{e((s.last_active || '').replace('T', ' ').slice(0, 16))}</span>,
+  },
+];
+
 function SessionsPanel({ data }: { data: Session[] }) {
   return (
     <Panel title="Active Sessions" count={data.length}>
       {data.length === 0 ? (
         <EmptyState message="No active sessions" inline />
       ) : (
-        <table style={tableStyle}>
-          <thead>
-            <tr>{['Title', 'Working dir', 'Last active'].map(h => <th key={h} style={thStyle}>{h}</th>)}</tr>
-          </thead>
-          <tbody>
-            {data.map((s, i) => (
-              <tr key={s.id ?? i}>
-                <td style={tdStyle}>{e(s.title || '(untitled)')}</td>
-                <td style={{ ...tdStyle, color: '#999', maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={s.cwd}>
-                  {e(shortenPath(s.cwd))}
-                </td>
-                <td style={{ ...tdStyle, whiteSpace: 'nowrap', color: '#999' }}>{e((s.last_active || '').replace('T', ' ').slice(0, 16))}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable columns={SESSION_COLUMNS} rows={data} rowKey={(s, i) => s.id ?? i} />
       )}
     </Panel>
   );
@@ -563,6 +494,28 @@ function agentEnabledDot(enabled: boolean | undefined): string {
   return enabled ? '#22c55e' : '#9ca3af';
 }
 
+const AGENT_COLUMNS: Column<Agent>[] = [
+  {
+    key: 'enabled', label: '',
+    render: a => (
+      <span title={a.enabled ? 'enabled' : 'disabled'}>
+        <StatusDot color={agentEnabledDot(a.enabled)} />
+      </span>
+    ),
+  },
+  { key: 'name', label: 'Name', render: a => e(a.name) },
+  { key: 'provider', label: 'Provider', render: a => e(a.provider) || '—' },
+  { key: 'model', label: 'Model', render: a => e(a.model) || '—' },
+  {
+    key: 'roles', label: 'Roles',
+    render: a => (
+      <span title={(a.roles ?? []).join(', ')}>
+        {a.roles && a.roles.length > 0 ? e(a.roles.join(', ')) : '—'}
+      </span>
+    ),
+  },
+];
+
 function AgentsPanel({ data }: { data: Agent[] }) {
   return (
     <Panel title="Agents" count={data.length}>
@@ -571,30 +524,7 @@ function AgentsPanel({ data }: { data: Agent[] }) {
           No agents configured
         </div>
       ) : (
-        <table style={tableStyle}>
-          <thead>
-            <tr>
-              {['', 'Name', 'Provider', 'Model', 'Roles'].map(h => (
-                <th key={h} style={thStyle}>{h}</th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {data.map((a, i) => (
-              <tr key={i}>
-                <td style={tdStyle} title={a.enabled ? 'enabled' : 'disabled'}>
-                  <StatusDot color={agentEnabledDot(a.enabled)} />
-                </td>
-                <td style={tdStyle}>{e(a.name)}</td>
-                <td style={tdStyle}>{e(a.provider) || '—'}</td>
-                <td style={tdStyle}>{e(a.model) || '—'}</td>
-                <td style={tdStyle} title={(a.roles ?? []).join(', ')}>
-                  {a.roles && a.roles.length > 0 ? e(a.roles.join(', ')) : '—'}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable columns={AGENT_COLUMNS} rows={data} rowKey={(_a, i) => i} />
       )}
     </Panel>
   );
@@ -757,22 +687,16 @@ function LatencyByRolePanel({ data }: { data: Delegation[] }) {
     const s = [...lats].sort((a, b) => a - b);
     return { role, p50: percentile(s, 50), p95: percentile(s, 95), max: s[s.length - 1], n: s.length };
   }).sort((a, b) => b.p95 - a.p95);
+  const columns: Column<typeof rows[number]>[] = [
+    { key: 'role', label: 'Role', render: r => e(r.role) },
+    { key: 'p50', label: 'p50', align: 'right', render: r => fmtDuration(r.p50) },
+    { key: 'p95', label: 'p95', align: 'right', render: r => fmtDuration(r.p95) },
+    { key: 'max', label: 'max', align: 'right', render: r => fmtDuration(r.max) },
+  ];
   return (
     <Panel title="Latency by Role" count={rows.length}>
       {rows.length === 0 ? <EmptyState message="No delegations" inline /> : (
-        <table style={tableStyle}>
-          <thead><tr>{['Role', 'p50', 'p95', 'max'].map(h => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
-          <tbody>
-            {rows.map(r => (
-              <tr key={r.role}>
-                <td style={tdStyle}>{e(r.role)}</td>
-                <td style={numTd}>{fmtDuration(r.p50)}</td>
-                <td style={numTd}>{fmtDuration(r.p95)}</td>
-                <td style={numTd}>{fmtDuration(r.max)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable columns={columns} rows={rows} rowKey={r => r.role} />
       )}
     </Panel>
   );
@@ -843,24 +767,19 @@ function CachePanel({ data }: { data: TokenAudit[] }) {
 }
 
 /* Failures — recent unsuccessful delegations. */
+const FAILURE_COLUMNS: Column<Delegation>[] = [
+  { key: 'agent', label: 'Agent', render: d => e(d.agent) },
+  { key: 'role', label: 'Role', render: d => e(d.role) },
+  { key: 'turns', label: 'Turns', align: 'right', render: d => d.turns },
+  { key: 'latency', label: 'Latency', align: 'right', render: d => fmtDuration(d.latency_ms) },
+];
+
 function FailuresPanel({ data }: { data: Delegation[] }) {
   const fails = data.filter(d => !d.success);
   return (
     <Panel title="Failures" count={fails.length}>
       {fails.length === 0 ? <EmptyState message="No failed delegations 🎉" inline /> : (
-        <table style={tableStyle}>
-          <thead><tr>{['Agent', 'Role', 'Turns', 'Latency'].map(h => <th key={h} style={thStyle}>{h}</th>)}</tr></thead>
-          <tbody>
-            {fails.slice(0, 20).map((d, i) => (
-              <tr key={i}>
-                <td style={tdStyle}>{e(d.agent)}</td>
-                <td style={tdStyle}>{e(d.role)}</td>
-                <td style={numTd}>{d.turns}</td>
-                <td style={numTd}>{fmtDuration(d.latency_ms)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable columns={FAILURE_COLUMNS} rows={fails.slice(0, 20)} rowKey={(_d, i) => i} />
       )}
     </Panel>
   );


### PR DESCRIPTION
Second DataTable adoption (follows Logs #1476). Migrates the **10 columnar data tables** in Dashboard.tsx to shared `DataTable` (0.8.0), removing the local `tableStyle`/`thStyle`/`tdStyle`/`numTd` constants (−81 net lines).

## Faithfulness
- Each table → `Column<Row>[]` with `render` reproducing every cell exactly: StatusDot health dots (identical `color=` exprs), Badges, colored/monospace cells, right-aligned tabular numbers (`align:'right'` → DataTable auto-applies `tabular-nums`), per-cell `title` tooltips wrapped on spans (DataTable has no per-cell title), Sessions working-dir ellipsis clamp moved onto a `display:block` span at width 140.
- `rowKey` reuses each table's original key (index or id). Per-panel empty-state conditionals preserved verbatim. No table had a row onClick → `onRowClick` omitted.
- DataTable 0.8.0 row-hover applies only to clickable (onRowClick) tables — none here — so these non-clickable tables get no hover, matching the originals.

## Left as raw `<table>`
The 3 non-columnar key-value tables — `LspPanel`, `OnboardPanel`, `CachePanel` (header-less `<tbody>` layouts).

## Verification
`npm run check`: clean · `npm run build`: passes