### PR TITLE
refactor(webchat): adopt smoothgui AutoGrowTextarea for the chat composer

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback, memo } from 'react';
-import { Button, Drawer, Spinner, Tabs, TypingIndicator, tokens } from '@rakuensoftware/smoothgui';
+import { AutoGrowTextarea, Button, Drawer, Spinner, Tabs, TypingIndicator, tokens } from '@rakuensoftware/smoothgui';
 import { BootstrapBanner, DiffBlock, Message, RewindMarker, ThinkingBlock, ToolBlock, TurnSummaryCard } from './chat/ChatPrimitives';
 import { renderWithMentions } from './chat/markdown';
 import ProjectPicker from '../components/ProjectPicker';
@@ -2343,9 +2343,7 @@ export default function Chat() {
     if (!text) return;
 
     setInputText('');
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-    }
+    // AutoGrowTextarea reflows its own height when inputText clears.
 
     // Steering: if a turn is already in flight for the active tab — a local send
     // (client stream open) or a server/foreign turn (events stream) — sending
@@ -2826,12 +2824,6 @@ export default function Chat() {
     }
   }
 
-  function handleInput(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    setInputText(e.target.value);
-    e.target.style.height = 'auto';
-    e.target.style.height = Math.min(e.target.scrollHeight, 200) + 'px';
-  }
-
   return (
     <div style={{
       display: 'flex', flexDirection: 'column', height: '100%',
@@ -3085,21 +3077,16 @@ export default function Chat() {
         padding: '12px 16px', background: tokens.surfaceAlt, borderTop: `1px solid ${tokens.border}`,
         display: 'flex', gap: '8px', flexShrink: 0,
       }}>
-        <textarea
+        <AutoGrowTextarea
           ref={textareaRef}
           value={inputText}
-          onChange={handleInput}
+          onChange={setInputText}
           onKeyDown={handleKeyDown}
+          maxHeight={200}
           placeholder={(working || remoteTurnActive)
             ? 'Steer the running turn — Enter interrupts and continues'
             : 'Type a message… (Shift+Enter for newline)'}
-          rows={1}
-          style={{
-            flex: 1, padding: '10px', backgroundColor: tokens.surface, color: tokens.text,
-            border: `1px solid ${tokens.borderMedium}`, borderRadius: '6px', fontSize: '14px',
-            resize: 'none', fontFamily: 'system-ui', minHeight: '44px', maxHeight: '200px',
-            outline: 'none',
-          }}
+          style={{ flex: 1, minHeight: '44px' }}
           onFocus={e => (e.target.style.borderColor = tokens.primary)}
           onBlur={e => (e.target.style.borderColor = tokens.borderMedium)}
           autoFocus


### PR DESCRIPTION
Final primitive adoption. Replaces the hand-rolled auto-grow composer `<textarea>` with smoothgui `AutoGrowTextarea` (0.8.1, vendored in #1480).

## Faithfulness
- The component owns grow-to-`maxHeight(200)`, so `handleInput`'s height math and the post-send manual height reset are removed; `onChange` just sets `inputText`.
- `handleKeyDown` passed via `onKeyDown` — AutoGrowTextarea forwards it and respects `defaultPrevented`, so **Enter-to-send / Shift+Enter is unchanged**.
- **Post-turn refocus preserved:** the composer keeps `textareaRef` via AutoGrowTextarea's **forwarded ref** (the 0.8.1 enhancement); `textareaRef.current.focus()` still works.
- Residual style is just `flex:1` + `minHeight:44` — AutoGrowTextarea already supplies identical padding/border/radius/font/background. `onFocus`/`onBlur` border-color, `autoFocus`, placeholder preserved.

## Not converted
The ChannelView @mention `<textarea>` — it has no auto-grow and drives `selectionRange` for autocomplete.

## Verification
`npm run check`: clean · `npm run build`: passes