### PR TITLE
fix(delegate): report the real reason a --via agent is unroutable

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -26,6 +26,27 @@ agent_t *agent_find(agent_config_t *cfg, const char *name);
 agent_t *agent_default_primary(agent_config_t *cfg);
 int agent_is_available_for_routing(const agent_t *agent);
 
+/* Why an agent is not a routable delegate. Mirrors the decision order of
+ * agent_is_available_for_routing so callers can surface the ACTUAL reason
+ * instead of a single catch-all "unavailable" string. */
+typedef enum
+{
+   AGENT_ROUTE_OK = 0,             /* routable */
+   AGENT_ROUTE_NULL,               /* NULL agent */
+   AGENT_ROUTE_HEALTH_DOWN,        /* health catalog marked the provider DOWN (breaker open) */
+   AGENT_ROUTE_CLIENT_ONLY_CLAUDE, /* claude CLI agent that is not server-hosted */
+   AGENT_ROUTE_POLICY_EXCLUDED,    /* registered delegate-policy filter excluded it */
+   AGENT_ROUTE_MISSING_COMMAND,    /* a required CLI (tmux / provider-cli) is not on PATH */
+   AGENT_ROUTE_NO_CREDENTIALS,     /* an HTTP agent with no resolvable credentials */
+} agent_route_block_t;
+
+/* Same decision as agent_is_available_for_routing, but reports WHY. On a block
+ * that names something specific (the missing command, or a Primary-Agent-Only
+ * flag) a short phrase is written to `detail` (pass NULL/0 to skip). Returns
+ * AGENT_ROUTE_OK when the agent is routable. */
+agent_route_block_t agent_routing_block_reason(const agent_t *agent, char *detail,
+                                               size_t detail_sz);
+
 /* True if at least one configured agent is enabled AND routable as a delegate
  * right now (loads agents.json). Gates sub-agent interception — only redirect to
  * delegates when usable delegates exist. */

--- a/src/headers/aimee_errors.h
+++ b/src/headers/aimee_errors.h
@@ -35,6 +35,11 @@ enum aimee_error_code
    /* The provider's per-agent concurrency slots are exhausted (max_parallel).
     * Transient/aimee-side back-pressure, not an upstream error. 503. */
    AIMEE_ERR_CONCURRENCY_LIMIT = 1011,
+   /* The named agent exists but is not a valid DELEGATION target: it is flagged
+    * "Primary Agent Only", it is the configured primary passthrough, or it is a
+    * client-only claude CLI that cannot run server-side. A policy/structural
+    * decision, distinct from a health breaker (1010) -- nothing is "down". 400. */
+   AIMEE_ERR_DELEGATE_INELIGIBLE = 1012,
 };
 
 /* Short, stable, greppable slug for a code -- used in log lines. */
@@ -52,6 +57,8 @@ static inline const char *aimee_err_slug(int code)
       return "breaker_open";
    case AIMEE_ERR_CONCURRENCY_LIMIT:
       return "concurrency_limit";
+   case AIMEE_ERR_DELEGATE_INELIGIBLE:
+      return "delegate_ineligible";
    default:
       return "unknown";
    }

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1477,43 +1477,74 @@ int agent_routing_primary_turn(void)
    return g_routing_primary_turn;
 }
 
-int agent_is_available_for_routing(const agent_t *agent)
+agent_route_block_t agent_routing_block_reason(const agent_t *agent, char *detail, size_t detail_sz)
 {
+   if (detail && detail_sz)
+      detail[0] = '\0';
    if (!agent)
-      return 0;
+      return AGENT_ROUTE_NULL;
    /* A provider the health catalog has marked unavailable (e.g. DOWN after a
     * failure streak) must not receive new routed work, or delegates wedge on
     * a dead endpoint. Treat it like a disabled agent so callers fall back to a
     * healthy peer; routing returns NULL (clean "no agent" error) only when
     * every candidate is filtered out. */
    if (g_route_health_filter && agent->name[0] && g_route_health_filter(agent->name))
-      return 0;
+      return AGENT_ROUTE_HEALTH_DOWN;
    /* A claude-CLI agent can only ever execute as a delegate SERVER-SIDE (a
     * client-only claude has no server session to drive — dispatch would just
     * fail). Structural, so it is enforced even with no policy filter
     * registered; the per-agent rules (the `primary_only` opt-out, primary
     * self-delegation) live in the registered policy filter. */
    if (agent_is_claude_cli(agent) && !agent->is_server_hosted)
-      return 0;
+      return AGENT_ROUTE_CLIENT_ONLY_CLAUDE;
    if (g_route_policy_filter && g_route_policy_filter(agent))
-      return 0;
+   {
+      /* The filter is opaque here, but the agent record names the common case:
+       * a Primary-Agent-Only opt-out. Anything else is a generic policy block. */
+      if (detail && detail_sz && agent->primary_only)
+         snprintf(detail, detail_sz, "it is flagged \"Primary Agent Only\"");
+      return AGENT_ROUTE_POLICY_EXCLUDED;
+   }
    if (strcmp(agent->backend, AGENT_BACKEND_TMUX_CLI) == 0)
    {
       const char *cmd =
           agent->cli_cmd[0] ? agent->cli_cmd : (agent->cli_kind[0] ? agent->cli_kind : "claude");
-      return agent_command_on_path("tmux") && agent_command_on_path(cmd);
+      if (!agent_command_on_path("tmux"))
+      {
+         if (detail && detail_sz)
+            snprintf(detail, detail_sz, "tmux");
+         return AGENT_ROUTE_MISSING_COMMAND;
+      }
+      if (!agent_command_on_path(cmd))
+      {
+         if (detail && detail_sz)
+            snprintf(detail, detail_sz, "%s", cmd);
+         return AGENT_ROUTE_MISSING_COMMAND;
+      }
+      return AGENT_ROUTE_OK;
    }
 
    if (strcmp(agent->backend, AGENT_BACKEND_PROVIDER_CLI) != 0 &&
        strcmp(agent->backend, AGENT_BACKEND_CLI_STDIO) != 0)
-      return agent_has_resolvable_credentials(agent);
+      return agent_has_resolvable_credentials(agent) ? AGENT_ROUTE_OK : AGENT_ROUTE_NO_CREDENTIALS;
 
    const provider_cli_adapter_t *adapter = provider_cli_adapter_get(agent->cli_kind);
    if (adapter && adapter->native_provider && adapter->native_provider[0])
-      return 1;
+      return AGENT_ROUTE_OK;
 
    const char *cmd = agent->cli_cmd[0] ? agent->cli_cmd : agent->cli_kind;
-   return agent_command_on_path(cmd);
+   if (!agent_command_on_path(cmd))
+   {
+      if (detail && detail_sz)
+         snprintf(detail, detail_sz, "%s", cmd);
+      return AGENT_ROUTE_MISSING_COMMAND;
+   }
+   return AGENT_ROUTE_OK;
+}
+
+int agent_is_available_for_routing(const agent_t *agent)
+{
+   return agent_routing_block_reason(agent, NULL, 0) == AGENT_ROUTE_OK;
 }
 
 int agent_any_delegate_available(void)

--- a/src/server/delegate_routing.c
+++ b/src/server/delegate_routing.c
@@ -304,17 +304,54 @@ int delegate_apply_route_overrides(agent_config_t *cfg, const char *role, const 
                    NULL);
          return -1;
       }
-      if (!agent_is_available_for_routing(selected))
+      char rdetail[128];
+      agent_route_block_t rblock = agent_routing_block_reason(selected, rdetail, sizeof(rdetail));
+      if (rblock != AGENT_ROUTE_OK)
       {
-         /* Aimee's circuit breaker declining to route (or a missing CLI): an
-          * aimee-internal condition, tagged with the aimee error SLUG so it's
-          * identifiable, not mistaken for a provider outage. Slug (not the numeric
-          * code) to stay clear of substring-based error classifiers. */
-         char emsg[256];
-         snprintf(emsg, sizeof(emsg),
-                  "agent '%s' is currently unavailable (health down after repeated "
-                  "failures, or its provider-cli command is missing) [aimee_err=%s]",
-                  via_name, aimee_err_slug(AIMEE_ERR_BREAKER_OPEN));
+         /* Report the ACTUAL reason routing declined, tagged with the matching
+          * aimee error SLUG. Collapsing every cause into "health down / breaker
+          * open" sent operators chasing a provider outage when the real block was
+          * a delegate-policy decision (Primary Agent Only) or a missing CLI. Slug
+          * (not the numeric code) to stay clear of substring-based classifiers. */
+         const char *reason;
+         int code;
+         switch (rblock)
+         {
+         case AGENT_ROUTE_HEALTH_DOWN:
+            reason = "its provider health is marked DOWN (circuit breaker open after repeated "
+                     "failures)";
+            code = AIMEE_ERR_BREAKER_OPEN;
+            break;
+         case AGENT_ROUTE_CLIENT_ONLY_CLAUDE:
+            reason = "it is a client-only claude CLI agent; only a server-hosted claude can run "
+                     "as a delegate";
+            code = AIMEE_ERR_DELEGATE_INELIGIBLE;
+            break;
+         case AGENT_ROUTE_POLICY_EXCLUDED:
+            reason = rdetail[0] ? rdetail
+                                : "it is excluded by delegate policy (e.g. it is the configured "
+                                  "primary provider, which never delegates to itself)";
+            code = AIMEE_ERR_DELEGATE_INELIGIBLE;
+            break;
+         case AGENT_ROUTE_NO_CREDENTIALS:
+            reason = "its credentials could not be resolved";
+            code = AIMEE_ERR_ROUTE_UNRESOLVED;
+            break;
+         case AGENT_ROUTE_MISSING_COMMAND:
+         default:
+            reason = NULL; /* built below with the missing-command detail */
+            code = AIMEE_ERR_ROUTE_UNRESOLVED;
+            break;
+         }
+         char emsg[320];
+         if (rblock == AGENT_ROUTE_MISSING_COMMAND)
+            snprintf(emsg, sizeof(emsg),
+                     "agent '%s' cannot be routed: required command '%s' is not on PATH "
+                     "[aimee_err=%s]",
+                     via_name, rdetail[0] ? rdetail : "(unknown)", aimee_err_slug(code));
+         else
+            snprintf(emsg, sizeof(emsg), "agent '%s' cannot be routed: %s [aimee_err=%s]", via_name,
+                     reason, aimee_err_slug(code));
          route_err(errbuf, errbuf_sz, "%s", emsg, NULL);
          return -1;
       }

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -270,6 +270,58 @@ static void test_agent_route_client_only_claude_excluded(void)
    assert(agent_is_available_for_routing(&a) == 0);
 }
 
+/* agent_routing_block_reason reports WHY an agent is not routable so the delegate
+ * error path can name the real cause instead of a catch-all "unavailable". */
+static void test_agent_routing_block_reason(void)
+{
+   char detail[128];
+
+   /* Client-only claude: structural block, no filter needed. */
+   agent_t claude;
+   memset(&claude, 0, sizeof(claude));
+   strcpy(claude.name, "claude");
+   strcpy(claude.cli_kind, "claude");
+   strcpy(claude.backend, AGENT_BACKEND_TMUX_CLI);
+   claude.enabled = 1;
+   claude.is_server_hosted = 0;
+   assert(agent_routing_block_reason(&claude, detail, sizeof(detail)) ==
+          AGENT_ROUTE_CLIENT_ONLY_CLAUDE);
+
+   /* Policy exclusion of a Primary-Agent-Only agent: reason + a naming detail. */
+   agent_t primary;
+   memset(&primary, 0, sizeof(primary));
+   strcpy(primary.name, "primary");
+   strcpy(primary.backend, AGENT_BACKEND_PROVIDER_CLI);
+   strcpy(primary.cli_cmd, "sh"); /* on PATH, so only the policy filter can block */
+   primary.enabled = 1;
+   primary.primary_only = 1;
+   agent_set_route_policy_filter(test_policy_exclude_primary);
+   assert(agent_routing_block_reason(&primary, detail, sizeof(detail)) ==
+          AGENT_ROUTE_POLICY_EXCLUDED);
+   assert(strstr(detail, "Primary Agent Only") != NULL);
+   agent_set_route_policy_filter(NULL);
+
+   /* Missing provider-cli command: reason names the absent binary. */
+   agent_t missing;
+   memset(&missing, 0, sizeof(missing));
+   strcpy(missing.name, "gone");
+   strcpy(missing.backend, AGENT_BACKEND_PROVIDER_CLI);
+   strcpy(missing.cli_cmd, "definitely-not-a-real-binary-xyz");
+   missing.enabled = 1;
+   assert(agent_routing_block_reason(&missing, detail, sizeof(detail)) ==
+          AGENT_ROUTE_MISSING_COMMAND);
+   assert(strstr(detail, "definitely-not-a-real-binary-xyz") != NULL);
+
+   /* A provider-cli agent whose command IS on PATH is routable. */
+   agent_t ok;
+   memset(&ok, 0, sizeof(ok));
+   strcpy(ok.name, "ok");
+   strcpy(ok.backend, AGENT_BACKEND_PROVIDER_CLI);
+   strcpy(ok.cli_cmd, "sh");
+   ok.enabled = 1;
+   assert(agent_routing_block_reason(&ok, detail, sizeof(detail)) == AGENT_ROUTE_OK);
+}
+
 static void test_agent_route(void)
 {
    agent_config_t cfg;
@@ -3092,6 +3144,7 @@ int main(void)
    test_agent_route_policy_filter();
    test_agent_route_primary_turn_marker();
    test_agent_route_client_only_claude_excluded();
+   test_agent_routing_block_reason();
    test_agent_route_with_caps_honors_tools_enabled();
    test_agent_route_with_caps_honors_context_override();
    test_current_code_only_role_tool_policy();

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -73,6 +73,14 @@ int agent_is_available_for_routing(const agent_t *agent)
 {
    return agent && agent->enabled;
 }
+agent_route_block_t agent_routing_block_reason(const agent_t *agent, char *detail, size_t detail_sz)
+{
+   if (detail && detail_sz)
+      detail[0] = '\0';
+   if (!agent)
+      return AGENT_ROUTE_NULL;
+   return agent->enabled ? AGENT_ROUTE_OK : AGENT_ROUTE_POLICY_EXCLUDED;
+}
 
 agent_t *agent_find(agent_config_t *cfg, const char *name)
 {

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -288,6 +288,16 @@ int agent_is_available_for_routing(const agent_t *agent)
       return 0;
    return 1;
 }
+agent_route_block_t agent_routing_block_reason(const agent_t *agent, char *detail, size_t detail_sz)
+{
+   if (detail && detail_sz)
+      detail[0] = '\0';
+   if (!agent || !agent->enabled)
+      return AGENT_ROUTE_POLICY_EXCLUDED;
+   if (strcmp(agent->auth_type, "bearer") == 0 && agent->credential_count == 0)
+      return AGENT_ROUTE_NO_CREDENTIALS;
+   return AGENT_ROUTE_OK;
+}
 /* Stubs for the seat resolver pulled in via ensemble_resolve_random_seats. These
  * test seats are all specific model names (never "$random"), so rt_seat_is_random
  * returns 0 and the resolver passes them through unchanged; delegate_pick_for_role

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -447,6 +447,13 @@ int agent_is_available_for_routing(const agent_t *agent)
    (void)agent;
    return 1;
 }
+agent_route_block_t agent_routing_block_reason(const agent_t *agent, char *detail, size_t detail_sz)
+{
+   (void)agent;
+   if (detail && detail_sz)
+      detail[0] = '\0';
+   return AGENT_ROUTE_OK;
+}
 agent_t *agent_route_at_tier(agent_config_t *cfg, const char *role, int tier)
 {
    (void)role;


### PR DESCRIPTION
## Problem
`aimee delegate --via <agent>` reported every routing refusal as:
> agent '…' is currently unavailable (health down after repeated failures, or its provider-cli command is missing) [aimee_err=breaker_open]

None of those causes may be true. A Primary-Agent-Only policy exclusion, a client-only claude, or a missing CLI all surfaced as a **provider health breaker**, which sent operators chasing a nonexistent provider outage (it cost real debugging time in the claude-as-delegate work).

## Fix
- Add `agent_routing_block_reason()` — mirrors the decision order of `agent_is_available_for_routing` and returns the specific reason (`HEALTH_DOWN`, `CLIENT_ONLY_CLAUDE`, `POLICY_EXCLUDED`, `MISSING_COMMAND`, `NO_CREDENTIALS`) plus a short detail (the absent binary, or the Primary-Agent-Only flag).
- `agent_is_available_for_routing` is now a thin wrapper over it — no behavior change for existing callers.
- The `--via` error names the real cause and tags it with the matching aimee slug. New `AIMEE_ERR_DELEGATE_INELIGIBLE (1012)` for policy/structural blocks, kept distinct from the health breaker `1010`.
- Unit test `test_agent_routing_block_reason` covers client-only claude, policy exclusion (with detail), missing command (with detail), and the routable case.

Changed TUs syntax-check clean and are clang-format-19 clean.