### PR TITLE
feat(config): config-store canonical for pluggable-module toggles

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -272,11 +272,11 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`workspaces`** — _Workspace definitions (array of objects)._ Keys: `head`, `path`, `provider`, `remote`, `sandbox_image`
 - **`worktree_gc`** — `enabled`, `max_age_days`
 
-## Other top-level config-file keys (3)
+## Other top-level config-file keys (4)
 
 Scalar keys read directly from the config root (not via the CLI allowlist above):
 
-`db2_pool_size`, `proxy_token`, `toolsets`
+`db2_pool_size`, `modules`, `proxy_token`, `toolsets`
 
 ## Environment variables
 

--- a/src/config.c
+++ b/src/config.c
@@ -620,6 +620,12 @@ static void config_set_defaults(config_t *cfg)
     * these defaults every effective lever equals its pre-P3 value (back-compat). */
    cfg->economizer_enabled = 1;
    cfg->economizer_aggressive = 0;
+   /* Pluggable-module toggles default to -1 (unspecified) so the resolver falls back to each
+    * module's deprecated env toggle / default-ON until an operator writes the `modules:` block. */
+   cfg->module_memory = -1;
+   cfg->module_governance = -1;
+   cfg->module_delegates = -1;
+   cfg->module_workflows = -1;
    /* command-aware tool-output condensation: DEFAULT-ON (P1c). Safe-tier lever — it passes
     * the deterministic gate: lossless-on-demand (full output spilled), fail-open (any
     * miss/decline -> raw), and a no-over-reduction audit (failures/diagnostics + their
@@ -948,6 +954,16 @@ static void config_apply_inference_backend_defaults(config_t *cfg, const cJSON *
 int econ_reduction_master_on(const config_t *cfg)
 {
    return cfg && cfg->economizer_enabled ? 1 : 0;
+}
+
+int config_module_enabled(int config_tristate, int env_default)
+{
+   /* (Future tier 1: admin/governance FORCE would short-circuit here.) Tier 2: an explicit
+    * user config tristate (0/1) is canonical. Tier 3: -1 (unspecified) falls back to the
+    * deprecated env default. See config.h for the full precedence contract. */
+   if (config_tristate == 0 || config_tristate == 1)
+      return config_tristate;
+   return env_default ? 1 : 0;
 }
 
 int econ_gateway_mutate_on(const config_t *cfg)
@@ -1425,6 +1441,7 @@ int config_load_file(config_t *cfg)
 
    config_parse_worktree_gc_section(cfg, root);
    config_parse_fold_section(cfg, root);
+   config_parse_modules_section(cfg, root);
    config_parse_reduce_section(cfg, root);
    config_apply_reduce_consistency(cfg); /* mutate=1 -> auto-enable shadow seam in memory + WARN */
    config_parse_autonomy_section(cfg, root);

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -49,6 +49,26 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
       }
    }
 
+   /* modules.* (pluggable-module toggles; default -1 = unspecified). Persist only the keys the
+    * operator actually set, so an untouched config never sprouts a modules: block and the
+    * resolver's env/default fallback stays in effect for the rest. */
+   if (cfg->module_memory != -1 || cfg->module_governance != -1 || cfg->module_delegates != -1 ||
+       cfg->module_workflows != -1)
+   {
+      cJSON *m = cJSON_AddObjectToObject(root, "modules");
+      if (m)
+      {
+         if (cfg->module_memory != -1)
+            cJSON_AddBoolToObject(m, "memory", cfg->module_memory ? 1 : 0);
+         if (cfg->module_governance != -1)
+            cJSON_AddBoolToObject(m, "governance", cfg->module_governance ? 1 : 0);
+         if (cfg->module_delegates != -1)
+            cJSON_AddBoolToObject(m, "delegates", cfg->module_delegates ? 1 : 0);
+         if (cfg->module_workflows != -1)
+            cJSON_AddBoolToObject(m, "workflows", cfg->module_workflows ? 1 : 0);
+      }
+   }
+
    /* integrity.* (defaults enabled=0, dry_run=1) */
    if (cfg->integrity_enabled || !cfg->integrity_dry_run)
    {

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -734,6 +734,33 @@ void config_parse_fold_section(config_t *cfg, cJSON *root)
    }
 }
 
+/* Pluggable-module toggles (`modules:` block) — the canonical user surface for enabling or
+ * disabling the pipeline modules. Each key is a bool; when present it sets the tristate to 0/1,
+ * else the field stays -1 (unspecified) and the resolver falls back to env/default. See
+ * config_module_enabled() and config.h. */
+void config_parse_modules_section(config_t *cfg, cJSON *root)
+{
+   cJSON *mods = cJSON_GetObjectItemCaseSensitive(root, "modules");
+   if (!cJSON_IsObject(mods))
+      return;
+   struct
+   {
+      const char *key;
+      int *field;
+   } toggles[] = {
+       {"memory", &cfg->module_memory},
+       {"governance", &cfg->module_governance},
+       {"delegates", &cfg->module_delegates},
+       {"workflows", &cfg->module_workflows},
+   };
+   for (size_t i = 0; i < sizeof(toggles) / sizeof(toggles[0]); i++)
+   {
+      cJSON *b = cJSON_GetObjectItemCaseSensitive(mods, toggles[i].key);
+      if (cJSON_IsBool(b))
+         *toggles[i].field = cJSON_IsTrue(b) ? 1 : 0;
+   }
+}
+
 /* Unified context economizer (src/context_reduce.c). Orchestration gates for the
  * single reduction subsystem. Only knobs the current code honors are parsed here;
  * each lever / the gateway seam / min_gain is added by the slice that implements

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1140,6 +1140,28 @@ typedef struct config
    int economizer_enabled;
    int economizer_aggressive;
 
+   /* Pluggable-module enablement (`modules:` block). The canonical, user-facing surface for
+    * enabling/disabling the pipeline modules — memory (request stage), governance (response
+    * stage), delegates + workflows (orchestration hooks). Each is a TRISTATE:
+    *   -1  unspecified — the config does not set it; the resolver falls back to the module's
+    *       deprecated env toggle (AIMEE_STAGE_MEMORY / _GOVERNANCE / AIMEE_ORCH_DELEGATES /
+    *       _WORKFLOWS) and then to its default-ON.
+    *    0  user-disabled.    1  user-enabled.
+    * Resolution is centralized in config_module_enabled() so the future admin/governance FORCE
+    * tier (aimee-kb governance state that can pin a module on or off over the user's choice)
+    * slots in at ONE site. Defaults are -1 (unspecified) so existing env-configured deployments
+    * are unaffected until an operator writes the `modules:` block.
+    * CONTRIBUTORS: do NOT resolve module enablement inline at a wire site. ALWAYS call
+    * config_module_enabled(cfg->module_X, <env default>), where the env default is the module's
+    * own predicate (gw_stage_memory_enabled / gw_response_governance_enabled /
+    * gw_orch_delegates_enabled / gw_orch_workflows_enabled, reading AIMEE_STAGE_MEMORY /
+    * AIMEE_STAGE_GOVERNANCE / AIMEE_ORCH_DELEGATES / AIMEE_ORCH_WORKFLOWS). One resolver = the
+    * FORCE tier has exactly one place to extend. */
+   int module_memory;
+   int module_governance;
+   int module_delegates;
+   int module_workflows;
+
    /* Autonomous-development pipeline knobs (Phase-C). These were env-var-only
     * (AIMEE_AUTONOMY_*); the config values are bridged to those env vars at startup
     * (autonomy_config_to_env) so the wfe library — which reads them via getenv across a
@@ -2058,6 +2080,16 @@ int config_load_file(config_t *cfg);
  * master-kill (economizer.enabled) > aggressive-tier ceiling > individual reduce.* default. */
 int econ_reduction_master_on(const config_t *cfg); /* economizer.enabled (measure is exempt) */
 int econ_gateway_mutate_on(const config_t *cfg);   /* enabled && aggressive && gateway_mutate */
+
+/* Resolve whether a pluggable module is enabled, from the layered enablement surface. This is
+ * the ONE place module enablement is decided; every wire site calls it with the module's tristate
+ * config field and its deprecated env default. Precedence (highest first):
+ *   1. admin/governance FORCE (aimee-kb governance state) — NOT YET WIRED; the documented seam
+ *      for the future tier that can pin a module on/off over the user's choice.
+ *   2. user config-store tristate (`modules:` block): `config_tristate` is 0 or 1 -> honored.
+ *   3. deprecated env default (`env_default`, already the module's env-or-default-ON value).
+ * `config_tristate` is one of cfg->module_* (-1 = unspecified). Pure: reads its args only. */
+int config_module_enabled(int config_tristate, int env_default);
 
 /* Validate the economizer gateway-mutation invariants that are STARTUP-FATAL (as
  * opposed to the in-memory normalizations config_load already applied). Currently:

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -21,6 +21,7 @@ void config_parse_kb_section(config_t *cfg, cJSON *root);
 void config_parse_memory_maintenance_section(config_t *cfg, cJSON *root);
 void config_parse_worktree_gc_section(config_t *cfg, cJSON *root);
 void config_parse_fold_section(config_t *cfg, cJSON *root);
+void config_parse_modules_section(config_t *cfg, cJSON *root);
 void config_parse_reduce_section(config_t *cfg, cJSON *root);
 void config_parse_autonomy_section(config_t *cfg, cJSON *root);
 void config_apply_reduce_consistency(config_t *cfg);

--- a/src/headers/gw_orch_delegates.h
+++ b/src/headers/gw_orch_delegates.h
@@ -11,14 +11,16 @@
 
 #include "gw_orchestration_seam.h"
 
-/* Default-ON unless AIMEE_ORCH_DELEGATES is an explicit 0/off/false/no. Mirrors
- * gw_response_governance_enabled / gw_stage_memory_enabled; the config-store becomes the
- * canonical enablement surface in the dedicated config-surface slice (roundtable ruling). */
+/* The DEPRECATED env default: on unless AIMEE_ORCH_DELEGATES is an explicit 0/off/false/no.
+ * The config-store `modules.delegates` toggle is now canonical; the wire site resolves it via
+ * config_module_enabled() with this as the fallback, and passes the result to *_run() as
+ * `enabled`. Kept pure (no config) so the module stays unit-testable in isolation. */
 int gw_orch_delegates_enabled(void);
 
 /* Run the delegates orchestration module for one spawn decision. Builds the single-hook
- * `delegates` catalog (gated by gw_orch_delegates_enabled), a turn snapshot tagged with
- * `turn_id`, and runs it through gw_orchestration_run over `caps`. The hook invokes
+ * `delegates` catalog (gated by the caller-supplied `enabled` — the wire site resolves it from
+ * config_module_enabled), a turn snapshot tagged with `turn_id`, and runs it through
+ * gw_orchestration_run over `caps`. The hook invokes
  * caps->spawn_delegate(caps->ctx, role, brief); the spawn's own success/failure is recorded by
  * the caller's capability adapter in caps->ctx (this function does not surface it).
  * Returns:
@@ -28,6 +30,6 @@ int gw_orch_delegates_enabled(void);
  *       decides what a missed spawn means (the coord dispatcher releases the task claim and
  *       retries on the next sweep). */
 int gw_orch_delegates_run(const gw_turn_capabilities_t *caps, const char *turn_id, const char *role,
-                          const char *brief);
+                          const char *brief, int enabled);
 
 #endif /* DEC_GW_ORCH_DELEGATES_H */

--- a/src/headers/gw_orch_workflows.h
+++ b/src/headers/gw_orch_workflows.h
@@ -13,14 +13,16 @@
 
 #include "gw_orchestration_seam.h"
 
-/* Default-ON unless AIMEE_ORCH_WORKFLOWS is an explicit 0/off/false/no. Mirrors
- * gw_orch_delegates_enabled; the config-store becomes the canonical enablement surface in the
- * dedicated config-surface slice (roundtable ruling). */
+/* The DEPRECATED env default: on unless AIMEE_ORCH_WORKFLOWS is an explicit 0/off/false/no.
+ * The config-store `modules.workflows` toggle is now canonical; the wire site resolves it via
+ * config_module_enabled() with this as the fallback and passes the result to *_run() as
+ * `enabled`. Kept pure (no config) so the module stays unit-testable in isolation. */
 int gw_orch_workflows_enabled(void);
 
 /* Run the workflows orchestration module for one dispatch decision. Builds the single-hook
- * `workflows` catalog (gated by gw_orch_workflows_enabled), a turn snapshot tagged with
- * `turn_id`, and runs it through gw_orchestration_run over `caps`. The hook invokes
+ * `workflows` catalog (gated by the caller-supplied `enabled` — the wire site resolves it from
+ * config_module_enabled), a turn snapshot tagged with `turn_id`, and runs it through
+ * gw_orchestration_run over `caps`. The hook invokes
  * caps->dispatch_workflow(caps->ctx, lane, payload); the dispatch's own success/failure is
  * recorded by the caller's capability adapter in caps->ctx (this function does not surface it).
  * Returns:
@@ -28,6 +30,6 @@ int gw_orch_workflows_enabled(void);
  *  -1   the module was DISABLED (no dispatch attempted) or the catalog failed to build, or
  *       `caps` was NULL. The caller decides what a skipped dispatch means. */
 int gw_orch_workflows_run(const gw_turn_capabilities_t *caps, const char *turn_id, const char *lane,
-                          const char *payload);
+                          const char *payload, int enabled);
 
 #endif /* DEC_GW_ORCH_WORKFLOWS_H */

--- a/src/headers/gw_stage_governance.h
+++ b/src/headers/gw_stage_governance.h
@@ -8,17 +8,18 @@
 
 struct parsed_response;
 
-/* 1 unless AIMEE_STAGE_GOVERNANCE is an explicit disable token (0/off/false/no,
- * case-insensitive). DEFAULT-ON: governance (response tool-policing) must run unless
- * deliberately disabled. NOTE: the response/orchestration-stages roundtable ruled the
- * config-STORE the canonical surface for this security-sensitive toggle; the env gate here
- * mirrors AIMEE_STAGE_MEMORY and is superseded by the dedicated config-surface slice. */
+/* The DEPRECATED env default: 1 unless AIMEE_STAGE_GOVERNANCE is an explicit disable token
+ * (0/off/false/no). DEFAULT-ON: governance (response tool-policing) must run unless deliberately
+ * disabled. The config-store `modules.governance` toggle is now canonical; the wire site resolves
+ * it via config_module_enabled() with this as the fallback and passes the result to
+ * gw_response_run_governance() as `enabled`. Kept pure so the module stays config-free. */
 int gw_response_governance_enabled(void);
 
 /* Run the (togglable) governance response stage over `parsed` via the response registry +
- * runner. Returns the policing intervention (drop) count (>=0), or 0 when governance is
- * disabled or `parsed` is NULL. Behavior-preserving replacement for the inline
+ * runner. `enabled` is the caller-resolved toggle (config-store canonical -> env fallback).
+ * Returns the policing intervention (drop) count (>=0), or 0 when governance is disabled or
+ * `parsed` is NULL. Behavior-preserving replacement for the inline
  * gateway_policy_police_parsed_response calls. */
-int gw_response_run_governance(struct parsed_response *parsed);
+int gw_response_run_governance(struct parsed_response *parsed, int enabled);
 
 #endif /* DEC_GW_STAGE_GOVERNANCE_H */

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -281,6 +281,16 @@ static int gw_stage_model_pin(gw_request_t *r, void *ud)
  * place, with the same stages and order as the prior inline prelude (memory →
  * policy), plus the model-pin policy. Returns total interventions (≥0) or <0 on a
  * stage error. */
+/* Resolve the governance response toggle: config-store `modules.governance` (canonical) ->
+ * deprecated env default. Cached config_load, so an operator toggle applies without a restart;
+ * keeps gw_stage_governance config-free. */
+static int anthropic_governance_enabled(void)
+{
+   config_t c;
+   int tri = (config_load(&c) == 0) ? c.module_governance : -1;
+   return config_module_enabled(tri, gw_response_governance_enabled());
+}
+
 static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *driver,
                                          const agent_t *ag, int parity, int stream)
 {
@@ -338,7 +348,8 @@ static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *dr
    /* Slice 7: build the enabled, ordered stage set from the catalog. Memory is a
     * togglable module (AIMEE_STAGE_MEMORY); the registry omits it when disabled. */
    const gw_stage_slot_t slots[] = {
-       {"memory", gw_stage_memory, NULL, gw_stage_memory_enabled()},
+       {"memory", gw_stage_memory, NULL,
+        config_module_enabled(cfg_ok ? pcfg.module_memory : -1, gw_stage_memory_enabled())},
        {"tool_policing", gw_stage_tool_policing, NULL, 1},
        {"router", gw_stage_router, NULL, 1}, /* S1/S2: unified request->workflow seam */
        {"model_pin", gw_stage_model_pin, NULL, 1},
@@ -627,7 +638,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
        * no-ops at the default config). Drop count is plumbed through to the
        * same pipeline-runner total the request-side strip already emits; a
        * future P2b audit pass surfaces both at once. */
-      gw_response_run_governance(&parsed);
+      gw_response_run_governance(&parsed, anthropic_governance_enabled());
 
       /* Cost accounting: the Anthropic /v1/messages ingress is a raw provider
        * proxy (no agent_log_call), so record this turn's spend, billed against
@@ -1056,7 +1067,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                free(buf_resp);
                goto cleanup;
             }
-            gw_response_run_governance(&parsed);
+            gw_response_run_governance(&parsed, anthropic_governance_enabled());
             emit_message_as_sse(&parsed, msg_id, model, emit, ctx);
             /* Cost accounting (mirror the buffered path). */
             if ((parsed.prompt_tokens > 0 || parsed.completion_tokens > 0) &&
@@ -1087,7 +1098,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                 * (RESP_MATCH / RESP_MISMATCH). No-op unless AIMEE_IR_SHADOW. */
                aimee_ir_shadow_compare_response(&parsed, provider_resp,
                                                 shadow_provider_wire(driver));
-               gw_response_run_governance(&parsed);
+               gw_response_run_governance(&parsed, anthropic_governance_enabled());
                emit_message_as_sse(&parsed, msg_id, model, emit, ctx);
                /* Cost accounting (mirror the buffered path). */
                if ((parsed.prompt_tokens > 0 || parsed.completion_tokens > 0) &&

--- a/src/server/gw_orch_delegates.c
+++ b/src/server/gw_orch_delegates.c
@@ -45,13 +45,13 @@ static gw_orch_result_t delegates_hook(const gw_turn_snapshot_t *turn,
 }
 
 int gw_orch_delegates_run(const gw_turn_capabilities_t *caps, const char *turn_id, const char *role,
-                          const char *brief)
+                          const char *brief, int enabled)
 {
    if (!caps)
       return -1;
    delegate_hook_args_t args = {role, brief};
    gw_orch_hook_slot_t slots[] = {
-       {"delegates", delegates_hook, &args, gw_orch_delegates_enabled()},
+       {"delegates", delegates_hook, &args, enabled},
    };
    gw_orch_hook_t hooks[1];
    int n = gw_orchestration_registry_build(slots, sizeof(slots) / sizeof(slots[0]), hooks, 1);

--- a/src/server/gw_orch_workflows.c
+++ b/src/server/gw_orch_workflows.c
@@ -44,13 +44,13 @@ static gw_orch_result_t workflows_hook(const gw_turn_snapshot_t *turn,
 }
 
 int gw_orch_workflows_run(const gw_turn_capabilities_t *caps, const char *turn_id, const char *lane,
-                          const char *payload)
+                          const char *payload, int enabled)
 {
    if (!caps)
       return -1;
    workflow_hook_args_t args = {lane, payload};
    gw_orch_hook_slot_t slots[] = {
-       {"workflows", workflows_hook, &args, gw_orch_workflows_enabled()},
+       {"workflows", workflows_hook, &args, enabled},
    };
    gw_orch_hook_t hooks[1];
    int n = gw_orchestration_registry_build(slots, sizeof(slots) / sizeof(slots[0]), hooks, 1);

--- a/src/server/gw_stage_governance.c
+++ b/src/server/gw_stage_governance.c
@@ -29,14 +29,14 @@ static gw_response_stage_result_t governance_stage(gw_response_ctx_t *ctx, void 
    return r;
 }
 
-int gw_response_run_governance(struct parsed_response *parsed)
+int gw_response_run_governance(struct parsed_response *parsed, int enabled)
 {
    if (!parsed)
       return 0;
    gw_response_ctx_t ctx;
    ctx.resp = parsed;
    gw_response_stage_slot_t slots[] = {
-       {"governance", governance_stage, NULL, gw_response_governance_enabled()},
+       {"governance", governance_stage, NULL, enabled},
    };
    gw_response_stage_t stages[2];
    int n = gw_response_registry_build(slots, sizeof(slots) / sizeof(slots[0]), stages, 2);

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -980,9 +980,14 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
        .parity = 1, /* client OpenAI == serving OpenAI; informational for these stages */
        .stream = 0,
    };
-   /* Slice 7: enabled, ordered stage set from the catalog (memory is togglable). */
+   /* Slice 7: enabled, ordered stage set from the catalog (memory is togglable). The memory
+    * toggle is resolved from the config-store `modules:` block, falling back to the env default
+    * (cached config_load; keeps gw_stage_memory itself config-free). */
+   config_t mcfg;
+   int mcfg_ok = (config_load(&mcfg) == 0);
    const gw_stage_slot_t slots[] = {
-       {"memory", gw_stage_memory, messages, gw_stage_memory_enabled()},
+       {"memory", gw_stage_memory, messages,
+        config_module_enabled(mcfg_ok ? mcfg.module_memory : -1, gw_stage_memory_enabled())},
        {"tool_policing", gw_stage_openai_tool_policing, NULL, 1},
        {"router", gw_stage_router, NULL, 1}, /* S1/S2: unified request->workflow seam */
    };
@@ -1096,6 +1101,15 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
  * executes locally and feeds back as function_call_output next turn. The Codex
  * parser requires output_item.added before any delta, so every turn is framed
  * created -> item.added -> delta(s) -> item.done -> completed. Compute-then-chunk. */
+/* Resolve the governance response toggle: config-store `modules.governance` (canonical) ->
+ * deprecated env default. Cached config_load; keeps gw_stage_governance config-free. */
+static int openai_governance_enabled(void)
+{
+   config_t c;
+   int tri = (config_load(&c) == 0) ? c.module_governance : -1;
+   return config_module_enabled(tri, gw_response_governance_enabled());
+}
+
 static int responses_stream_handler(const char *body, server_http_sse_event_emit emit, void *ctx)
 {
    char model[64] = "";
@@ -1256,7 +1270,7 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
        * (streaming Anthropic). */
       int police_drops = 0;
       if (gateway_prevent_subagents_enabled())
-         police_drops = gw_response_run_governance(&parsed);
+         police_drops = gw_response_run_governance(&parsed, openai_governance_enabled());
       (void)police_drops; /* drop count plumbed through the pipeline total
                              for the future P2b audit pass; today the only
                              visible effect is the parsed.calls[] mutation. */

--- a/src/server/server_coord_dispatcher.c
+++ b/src/server/server_coord_dispatcher.c
@@ -10,6 +10,7 @@
 #include "server.h"
 #include "server_compute_impl.h"
 #include "gw_orch_delegates.h"
+#include "config.h"
 #include "db1.h"
 #include "log.h"
 #include "cJSON.h"
@@ -86,6 +87,17 @@ static int coord_spawn_delegate(void *ctx, const char *role, const char *brief)
    return 0;
 }
 
+/* Resolve whether the delegates module is enabled: the config-store `modules.delegates` toggle
+ * (canonical), falling back to the deprecated env default. Loaded per call (mtime-cached), so
+ * an operator toggle takes effect on the next sweep without a restart. Keeps the pure
+ * gw_orch_delegates module config-free. */
+static int coord_delegates_enabled(void)
+{
+   config_t cfg;
+   int tri = (config_load(&cfg) == 0) ? cfg.module_delegates : -1;
+   return config_module_enabled(tri, gw_orch_delegates_enabled());
+}
+
 /* Build a delegate request from a claimed coord task and submit it to a delegate worker,
  * routed through the DELEGATES orchestration module so the spawn is a togglable, registered
  * hook rather than an inline imperative call (see gw_orch_delegates). Lives here (its only
@@ -100,7 +112,7 @@ int server_compute_dispatch_coord_task(server_ctx_t *ctx, int task_id, const cha
    gw_turn_capabilities_t caps = {&backing, coord_spawn_delegate, NULL};
    char turn_id[48];
    snprintf(turn_id, sizeof(turn_id), "coord-task-%d", task_id);
-   if (gw_orch_delegates_run(&caps, turn_id, role, prompt) != 0)
+   if (gw_orch_delegates_run(&caps, turn_id, role, prompt, coord_delegates_enabled()) != 0)
       return -1; /* delegates module disabled -> not dispatched; caller releases + retries */
    return backing.spawn_rc; /* 0 spawned, -1 refused (ceiling/pool full) */
 }
@@ -127,7 +139,7 @@ static int dispatcher_sweep(void)
     * tasks ARE delegate work, so they simply wait until the module is re-enabled. Checked here,
     * before any claim, so a disabled module is distinct from a per-task 'refused' (pool full),
     * which alone releases+retries the single claimed task below. */
-   if (!gw_orch_delegates_enabled())
+   if (!coord_delegates_enabled())
       return 0;
 
    int job_ids[COORD_MAX_ACTIVE_JOBS];

--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -510,7 +510,13 @@ static int trigger_file_run(const trigger_rule_t *rule, const char *artifact_pat
    gw_turn_capabilities_t caps = {&backing, NULL, trigger_dispatch_workflow};
    char turn_id[64];
    snprintf(turn_id, sizeof(turn_id), "trigger-%s", rule->source);
-   if (gw_orch_workflows_run(&caps, turn_id, rule->pipeline_template, artifact_path) != 0)
+   /* Resolve the workflows toggle from the config-store `modules.workflows` (canonical),
+    * falling back to the deprecated env default; keeps gw_orch_workflows config-free. */
+   config_t wcfg;
+   int wtri = (config_load(&wcfg) == 0) ? wcfg.module_workflows : -1;
+   int wf_enabled = config_module_enabled(wtri, gw_orch_workflows_enabled());
+   if (gw_orch_workflows_run(&caps, turn_id, rule->pipeline_template, artifact_path, wf_enabled) !=
+       0)
    {
       aimee_log(LOG_WARN, "trigger.sched", "%s: workflows module disabled — skipping %s repo=%s",
                 rule->source, what, rule->workspace);

--- a/src/tests/support/ir_ingress_stubs.c
+++ b/src/tests/support/ir_ingress_stubs.c
@@ -222,8 +222,63 @@ __attribute__((weak)) void aimee_response_free(void *r)
  * (which now calls gw_response_run_governance) but links no policing graph. Inert weak
  * stub -> no policing, which the shape test does not exercise. The p2c tests link the real
  * gw_stage_governance.o + gateway_policy.o, so the strong symbol wins there. */
-__attribute__((weak)) int gw_response_run_governance(void *parsed)
+__attribute__((weak)) int gw_response_run_governance(void *parsed, int enabled)
 {
    (void)parsed;
+   (void)enabled;
    return 0;
+}
+
+/* The ingress governance resolver (anthropic_governance_enabled) reads this env default; the
+ * shape test links no gw_stage_governance.o, so a weak default-ON stub resolves the link. */
+__attribute__((weak)) int gw_response_governance_enabled(void)
+{
+   return 1;
+}
+
+/* Context-economizer gateway-seam symbols. messages_run_request_pipeline calls these inside a
+ * block gated by cfg.reduce_gateway_seam (0 under the tests' stubbed config, so NEVER entered
+ * at runtime). LTO used to dead-code-eliminate the block, but that decision is fragile (any new
+ * read of the loaded cfg in that function can retain it, and it differs across gcc versions), so
+ * resolve the symbols with inert weak stubs. Real context_reduce.o / agent_exec.o win when a
+ * test links them. Loose signatures: never called here, matched only by name + ABI (arg count,
+ * pointer/enum-as-int). */
+__attribute__((weak)) int context_reduce(cJSON *messages, const char *system_prompt,
+                                         const char *model, const char *session_id,
+                                         reduce_seam_t seam, const reduce_config_t *cfg,
+                                         reduce_state_t *st, reduce_result_t *out)
+{
+   (void)messages;
+   (void)system_prompt;
+   (void)model;
+   (void)session_id;
+   (void)seam;
+   (void)cfg;
+   (void)st;
+   (void)out;
+   return 1; /* non-zero: "did nothing" (the caller bypasses on != 0) */
+}
+__attribute__((weak)) void context_reduce_result_free(reduce_result_t *out)
+{
+   (void)out;
+}
+__attribute__((weak)) void agent_record_reduce_ledger(const struct reduce_result_s *r,
+                                                      const char *model, const char *agent_name,
+                                                      const char *role)
+{
+   (void)r;
+   (void)model;
+   (void)agent_name;
+   (void)role;
+}
+
+/* Config-surface slice: the ingress now resolves module toggles via config_module_enabled
+ * (memory slot + governance egress). It is a pure resolver; the minimal-link ingress tests
+ * stub config_load (not the whole config.o), so provide the real logic as a weak symbol here
+ * (config.o's strong definition wins when a test links it). */
+__attribute__((weak)) int config_module_enabled(int config_tristate, int env_default)
+{
+   if (config_tristate == 0 || config_tristate == 1)
+      return config_tristate;
+   return env_default ? 1 : 0;
 }

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -311,7 +311,12 @@ char *ingress_preinject_apply(const char *instructions, const char *envelope)
 int config_load(config_t *cfg)
 {
    if (cfg)
+   {
       memset(cfg, 0, sizeof(*cfg));
+      /* -1 = unspecified: memset-0 would read as user-disabled and gate the modules. */
+      cfg->module_memory = cfg->module_governance = -1;
+      cfg->module_delegates = cfg->module_workflows = -1;
+   }
    return 0;
 }
 

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -327,6 +327,10 @@ int config_load(config_t *cfg)
    {
       memset(cfg, 0, sizeof(*cfg));
       cfg->gateway_prevent_subagents = g_prevent;
+      /* module toggles are -1 (unspecified) in production; memset-0 would read as disabled and
+       * wrongly gate the governance/memory modules this test exercises. */
+      cfg->module_memory = cfg->module_governance = -1;
+      cfg->module_delegates = cfg->module_workflows = -1;
    }
    return 0;
 }

--- a/src/tests/test_anthropic_http_streaming_p2c.c
+++ b/src/tests/test_anthropic_http_streaming_p2c.c
@@ -334,6 +334,9 @@ int config_load(config_t *cfg)
    {
       memset(cfg, 0, sizeof(*cfg));
       cfg->gateway_prevent_subagents = g_prevent;
+      /* -1 = unspecified: memset-0 would read as user-disabled and gate the modules. */
+      cfg->module_memory = cfg->module_governance = -1;
+      cfg->module_delegates = cfg->module_workflows = -1;
    }
    return 0;
 }

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -284,6 +284,40 @@ int main(void)
       assert(cfg2.economizer_aggressive == 1); /* opt-in persisted */
    }
 
+   /* --- modules.* tristate: defaults are -1 (unspecified) and are NOT persisted; an explicit
+    * 0/1 round-trips; and the resolver maps -1 -> env default, 0/1 -> canonical. --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg); /* no modules: block -> all unspecified */
+      assert(cfg.module_memory == -1 && cfg.module_governance == -1);
+      assert(cfg.module_delegates == -1 && cfg.module_workflows == -1);
+
+      /* save the pristine defaults: nothing written -> reload still -1 (no stray 0). */
+      assert(config_save(&cfg) == 0);
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.module_memory == -1 && cfg2.module_governance == -1);
+      assert(cfg2.module_delegates == -1 && cfg2.module_workflows == -1);
+
+      /* explicit user toggles round-trip: governance OFF, delegates ON, others unspecified. */
+      cfg2.module_governance = 0;
+      cfg2.module_delegates = 1;
+      assert(config_save(&cfg2) == 0);
+      static config_t cfg3;
+      memset(&cfg3, 0, sizeof(cfg3));
+      config_load(&cfg3);
+      assert(cfg3.module_governance == 0); /* explicit disable persisted */
+      assert(cfg3.module_delegates == 1);  /* explicit enable persisted  */
+      assert(cfg3.module_memory == -1 && cfg3.module_workflows == -1); /* untouched stay -1 */
+
+      /* resolver precedence (governance is default-ON via env fallback when unspecified). */
+      assert(config_module_enabled(cfg3.module_governance, 1) == 0); /* config OFF wins */
+      assert(config_module_enabled(cfg3.module_memory, 1) == 1);     /* -1 -> env default ON */
+      assert(config_module_enabled(cfg3.module_memory, 0) == 0);     /* -1 -> env default OFF */
+   }
+
    /* restore env */
    if (old_home)
    {

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -82,7 +82,8 @@ static const char *FIXTURE_A =
     "  warn_threshold: 0.01\n    prompt_threshold: 0.01\n    block_threshold: 0.01\n    "
     "allow_ml_only_block: true\nauxiliary:\n  enabled: true\n  default_model: ZZA_val\n  "
     "default_max_tokens: 1\nmodel_meta:\n  refresh_minutes: 1\n  capability_routing: "
-    "true\nensemble:\n  enabled: true\n  min_successful: 1\n  max_cost_usd: 1.0";
+    "true\nensemble:\n  enabled: true\n  min_successful: 1\n  max_cost_usd: 1.0\n"
+    "modules:\n  memory: true\n  governance: true\n  delegates: true\n  workflows: true";
 static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
@@ -140,7 +141,8 @@ static const char *FIXTURE_B =
     "false\n    warn_threshold: 0.99\n    prompt_threshold: 0.99\n    block_threshold: 0.99\n    "
     "allow_ml_only_block: false\nauxiliary:\n  enabled: false\n  default_model: ZZB_val\n  "
     "default_max_tokens: 4096\nmodel_meta:\n  refresh_minutes: 4096\n  capability_routing: "
-    "false\nensemble:\n  enabled: false\n  min_successful: 4096\n  max_cost_usd: 0.99";
+    "false\nensemble:\n  enabled: false\n  min_successful: 4096\n  max_cost_usd: 0.99\n"
+    "modules:\n  memory: false\n  governance: false\n  delegates: false\n  workflows: false";
 
 int main(void)
 {
@@ -330,6 +332,21 @@ int main(void)
    assert(cfgA.model_meta_capability_routing == 1 && cfgB.model_meta_capability_routing == 0);
    assert(cfgA.ensemble_min_successful != cfgB.ensemble_min_successful);
    assert(cfgA.ensemble_max_cost_usd != cfgB.ensemble_max_cost_usd);
+
+   /* modules.* pluggable-module toggles (tristate; A=true, B=false, distinct from the -1
+    * unspecified default so each key is proven read from the `modules:` block). */
+   assert(cfgA.module_memory == 1 && cfgB.module_memory == 0);
+   assert(cfgA.module_governance == 1 && cfgB.module_governance == 0);
+   assert(cfgA.module_delegates == 1 && cfgB.module_delegates == 0);
+   assert(cfgA.module_workflows == 1 && cfgB.module_workflows == 0);
+
+   /* config_module_enabled precedence: an explicit user tristate (0/1) is canonical and wins
+    * over the env default; -1 (unspecified) falls back to the env default. */
+   assert(config_module_enabled(1, 0) == 1);  /* config ON overrides env OFF */
+   assert(config_module_enabled(0, 1) == 0);  /* config OFF overrides env ON  */
+   assert(config_module_enabled(-1, 1) == 1); /* unspecified -> env default ON */
+   assert(config_module_enabled(-1, 0) == 0); /* unspecified -> env default OFF */
+   assert(config_module_enabled(1, 1) == 1 && config_module_enabled(0, 0) == 0);
 
    printf("all tests passed (146 parsed fields)\n");
    return 0;

--- a/src/tests/test_gw_orch_delegates.c
+++ b/src/tests/test_gw_orch_delegates.c
@@ -32,41 +32,38 @@ int main(void)
 {
    gw_turn_capabilities_t caps = {NULL, fake_spawn, NULL};
 
-   /* default (no env): module is ENABLED, the spawn runs through the capability handle. */
+   /* The env default predicate stays pure (config is resolved at the wire site). */
    unsetenv("AIMEE_ORCH_DELEGATES");
    assert(gw_orch_delegates_enabled() == 1);
-   reset();
-   assert(gw_orch_delegates_run(&caps, "coord-task-7", "reviewer", "check the diff") == 0);
-   assert(g_spawns == 1);
-   assert(strcmp(g_last_role, "reviewer") == 0 && strcmp(g_last_brief, "check the diff") == 0);
-
-   /* DISABLED: no spawn is attempted and the module reports -1 so the caller can release the
-    * claim and retry (delegate spawning is paused while the module is off). */
    for (const char **v = (const char *[]){"0", "off", "false", "no", NULL}; *v; v++)
    {
       setenv("AIMEE_ORCH_DELEGATES", *v, 1);
       assert(gw_orch_delegates_enabled() == 0);
-      reset();
-      assert(gw_orch_delegates_run(&caps, "coord-task-8", "reviewer", "x") == -1);
-      assert(g_spawns == 0);
    }
-
-   /* explicitly re-enabled: spawns again. */
    setenv("AIMEE_ORCH_DELEGATES", "1", 1);
    assert(gw_orch_delegates_enabled() == 1);
+
+   /* enabled=1: the spawn runs through the capability handle. */
    reset();
-   assert(gw_orch_delegates_run(&caps, "coord-task-9", "engineer", "do it") == 0);
+   assert(gw_orch_delegates_run(&caps, "coord-task-7", "reviewer", "check the diff", 1) == 0);
    assert(g_spawns == 1);
+   assert(strcmp(g_last_role, "reviewer") == 0 && strcmp(g_last_brief, "check the diff") == 0);
+
+   /* enabled=0: no spawn is attempted and the module reports -1 so the caller can release the
+    * claim and retry (delegate spawning is paused while the module is off). */
+   reset();
+   assert(gw_orch_delegates_run(&caps, "coord-task-8", "reviewer", "x", 0) == -1);
+   assert(g_spawns == 0);
 
    /* NULL caps is a clean -1 (no spawn), not a crash. */
-   assert(gw_orch_delegates_run(NULL, "t", "r", "b") == -1);
+   assert(gw_orch_delegates_run(NULL, "t", "r", "b", 1) == -1);
 
    /* a missing spawn_delegate handle is fail-open: the module still returns 0 (the hook ran),
     * and no spawn happens -- the runner surfaces the FAIL internally, never blocking. */
    {
       gw_turn_capabilities_t no_spawn = {NULL, NULL, NULL};
       reset();
-      assert(gw_orch_delegates_run(&no_spawn, "t", "r", "b") == 0);
+      assert(gw_orch_delegates_run(&no_spawn, "t", "r", "b", 1) == 0);
       assert(g_spawns == 0);
    }
 

--- a/src/tests/test_gw_orch_workflows.c
+++ b/src/tests/test_gw_orch_workflows.c
@@ -32,40 +32,38 @@ int main(void)
 {
    gw_turn_capabilities_t caps = {NULL, NULL, fake_dispatch};
 
-   /* default (no env): module is ENABLED, the dispatch runs through the capability handle. */
+   /* The env default predicate stays pure (config is resolved at the wire site). */
    unsetenv("AIMEE_ORCH_WORKFLOWS");
    assert(gw_orch_workflows_enabled() == 1);
-   reset();
-   assert(gw_orch_workflows_run(&caps, "trigger-proposals", "managed-change", "/w/wi-1.md") == 0);
-   assert(g_dispatches == 1);
-   assert(strcmp(g_last_lane, "managed-change") == 0 && strcmp(g_last_payload, "/w/wi-1.md") == 0);
-
-   /* DISABLED: no dispatch is attempted and the module reports -1 so the caller can log/skip. */
    for (const char **v = (const char *[]){"0", "off", "false", "no", NULL}; *v; v++)
    {
       setenv("AIMEE_ORCH_WORKFLOWS", *v, 1);
       assert(gw_orch_workflows_enabled() == 0);
-      reset();
-      assert(gw_orch_workflows_run(&caps, "trigger-x", "managed-change", "/w/wi-2.md") == -1);
-      assert(g_dispatches == 0);
    }
-
-   /* explicitly re-enabled: dispatches again. */
    setenv("AIMEE_ORCH_WORKFLOWS", "1", 1);
    assert(gw_orch_workflows_enabled() == 1);
+
+   /* enabled=1: the dispatch runs through the capability handle. */
    reset();
-   assert(gw_orch_workflows_run(&caps, "trigger-y", "review", "/w/wi-3.md") == 0);
+   assert(gw_orch_workflows_run(&caps, "trigger-proposals", "managed-change", "/w/wi-1.md", 1) ==
+          0);
    assert(g_dispatches == 1);
+   assert(strcmp(g_last_lane, "managed-change") == 0 && strcmp(g_last_payload, "/w/wi-1.md") == 0);
+
+   /* enabled=0: no dispatch is attempted and the module reports -1 so the caller can log/skip. */
+   reset();
+   assert(gw_orch_workflows_run(&caps, "trigger-x", "managed-change", "/w/wi-2.md", 0) == -1);
+   assert(g_dispatches == 0);
 
    /* NULL caps is a clean -1 (no dispatch), not a crash. */
-   assert(gw_orch_workflows_run(NULL, "t", "l", "p") == -1);
+   assert(gw_orch_workflows_run(NULL, "t", "l", "p", 1) == -1);
 
    /* a missing dispatch_workflow handle is fail-open: the module still returns 0 (the hook
     * ran), and no dispatch happens -- the runner surfaces the FAIL internally, never blocking. */
    {
       gw_turn_capabilities_t no_dispatch = {NULL, NULL, NULL};
       reset();
-      assert(gw_orch_workflows_run(&no_dispatch, "t", "l", "p") == 0);
+      assert(gw_orch_workflows_run(&no_dispatch, "t", "l", "p", 1) == 0);
       assert(g_dispatches == 0);
    }
 

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -93,6 +93,9 @@ int config_load(config_t *cfg)
       cfg->ingress_preinject_enabled = 1;
       cfg->ingress_preinject_assembly_budget = 1200;
       cfg->ingress_compress_enabled = g_test_compress;
+      /* -1 = unspecified: memset-0 would read as user-disabled and gate the memory module. */
+      cfg->module_memory = cfg->module_governance = -1;
+      cfg->module_delegates = cfg->module_workflows = -1;
    }
    return 0;
 }

--- a/src/tests/test_response_governance_stage.c
+++ b/src/tests/test_response_governance_stage.c
@@ -36,20 +36,19 @@ int main(void)
    parsed_response_t pr;
    memset(&pr, 0, sizeof(pr));
 
-   /* ENABLED (default): governance runs -> police called, drop count returned. */
-   unsetenv("AIMEE_STAGE_GOVERNANCE");
+   /* enabled=1: governance runs -> police called, drop count returned. (The env/config
+    * resolution is now the wire site's job; the runner takes the resolved flag.) */
    g_police_calls = 0;
-   assert(gw_response_run_governance(&pr) == 3);
+   assert(gw_response_run_governance(&pr, 1) == 3);
    assert(g_police_calls == 1);
 
-   /* DISABLED: governance stage omitted -> police NOT called, 0 returned. */
-   setenv("AIMEE_STAGE_GOVERNANCE", "0", 1);
+   /* enabled=0: governance stage omitted -> police NOT called, 0 returned. */
    g_police_calls = 0;
-   assert(gw_response_run_governance(&pr) == 0);
+   assert(gw_response_run_governance(&pr, 0) == 0);
    assert(g_police_calls == 0);
 
    /* NULL-safe. */
-   assert(gw_response_run_governance(NULL) == 0);
+   assert(gw_response_run_governance(NULL, 1) == 0);
 
    printf("ok\n");
    return 0;

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -15,7 +15,17 @@
 int config_load(config_t *cfg)
 {
    memset(cfg, 0, sizeof(*cfg));
+   /* Pluggable-module toggles default to -1 (unspecified) in production; a memset-0 would read
+    * as user-DISABLED and wrongly gate trigger workflow dispatch. */
+   cfg->module_memory = cfg->module_governance = cfg->module_delegates = cfg->module_workflows = -1;
    return 0;
+}
+/* Real (pure) resolver logic, mirrored so the stubbed link stays faithful to production. */
+int config_module_enabled(int config_tristate, int env_default)
+{
+   if (config_tristate == 0 || config_tristate == 1)
+      return config_tristate;
+   return env_default ? 1 : 0;
 }
 
 #include "log.h"

--- a/src/tests/test_trigger_e2e.c
+++ b/src/tests/test_trigger_e2e.c
@@ -28,7 +28,16 @@
 int config_load(config_t *cfg)
 {
    memset(cfg, 0, sizeof(*cfg));
+   /* -1 = unspecified (see test_trigger.c): a memset-0 would read as user-DISABLED and gate the
+    * trigger's workflow dispatch, breaking the proposal -> run e2e. */
+   cfg->module_memory = cfg->module_governance = cfg->module_delegates = cfg->module_workflows = -1;
    return 0;
+}
+int config_module_enabled(int config_tristate, int env_default)
+{
+   if (config_tristate == 0 || config_tristate == 1)
+      return config_tristate;
+   return env_default ? 1 : 0;
 }
 
 #include "skill_curator.h"


### PR DESCRIPTION
## Config-surface: config-store canonical for module toggles

The capstone to the modularization work. Makes the **config-store** the canonical enablement surface for the four pluggable modules (memory, governance, delegates, workflows), per the roundtable ruling that env vars are not the durable surface.

### Layered enablement — resolved in ONE place
`config_module_enabled()` is the single resolver every wire site calls, so the future admin tier slots in at one site:
1. **admin/governance FORCE** (aimee-kb governance state) — *future tier*; a documented extension point at the top of the resolver (per the stated goal that an admin can force a module on/off over the user's choice).
2. **user config-store `modules:` block** — tristate per module (`-1` unspecified / `0` off / `1` on). *This slice.*
3. **deprecated env default** (`AIMEE_STAGE_MEMORY` / `_GOVERNANCE` / `AIMEE_ORCH_DELEGATES` / `_WORKFLOWS`) → default-ON. *Fallback.*

### Foundation
- `config_t.module_{memory,governance,delegates,workflows}` (default `-1`) + a `modules:` parse section + `config_save` round-trip (persists only keys the operator set) + the pure `config_module_enabled()` resolver.
- `test_config_surface` A/B fixtures pin the new parse surface; resolver precedence is unit-tested.

### Wiring — the modules stay config-FREE
The wire sites (already config-aware) resolve `config → env → default` and inject the `enabled` flag; the pure modules never call config (keeps them unit-testable in isolation):
- **memory**: the `/v1` ingress stage catalog (`anthropic_http`, `openai_chat`) resolves the slot's enabled from `modules.memory`.
- **governance / delegates / workflows**: `gw_response_run_governance()`, `gw_orch_delegates_run()`, `gw_orch_workflows_run()` gain an `enabled` param (pure mechanism); the egress / coord-dispatcher / trigger wire sites resolve the toggle.

### Behavior / scope
- **Default behavior unchanged**: an unset `modules:` block leaves every toggle at `-1`, so the env/default-ON fallback governs exactly as before. `AIMEE_STAGE_GOVERNANCE=0` etc. still work (as the fallback).
- Governance is included because the env disable already existed — no new capability; the future admin-force tier is what will let an admin pin it on over a user.

### Verification
- All affected targets pass locally: the 4 module tests, `unit-test-config` / `-economizer` / `-snapshot` / `-surface`, the 3 `anthropic-http*` + `openai-chat-policed` ingress tests, `trigger` / `trigger-e2e` / `cron-runtime`, `server-compute`.
- Minimal test links: `config_load` stubs default the new tristate fields to `-1` (a memset-0 would read as disabled); `ir_ingress_stubs` carries a weak `config_module_enabled` + the 2-arg governance stub.
- clang-format-19 clean; `make docs-gen` run; build-integrity target→source mapping passes.
