### PR TITLE
fix(kb): wire the missing /v1/kb/docs/push route

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -2626,6 +2626,17 @@ paths:
       summary: Update the knowledge base (async; poll GET /runs/{id})
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Queued op run, content: { application/json: { schema: { type: object } } } } }
+  /kb/docs/push:
+    post:
+      summary: Push document contents into the knowledge base (async; poll GET /runs/{id})
+      description: >-
+        Upload document bytes from the caller's workspace into the knowledge
+        base. The workspace-owning tier reads the files and streams their
+        content to aimee-kb, so a stateless/remote aimee-kb that cannot see the
+        caller's filesystem still ingests them (unlike the path-forwarding
+        kb.build).
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: Queued op run, content: { application/json: { schema: { type: object } } } } }
   /graph/sync_code:
     post:
       summary: Sync the code graph (async; poll GET /runs/{id})

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -759,6 +759,7 @@ static const struct
     {"index.ingest", "POST", "/v1/index/ingest"},
     {"index.scan", "POST", "/v1/index/scan"},
     {"kb.build", "POST", "/v1/kb/build"},
+    {"kb.docs.push", "POST", "/v1/kb/docs/push"},
     {"kb.ingest", "POST", "/v1/kb/ingest"},
     {"kb.update", "POST", "/v1/kb/update"},
     {"memory.benchmark", "POST", "/v1/memory/benchmark"},

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -1667,6 +1667,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/kb/build", NULL, RM_EXACT, "kb.build", 0, rh_dispatch_op_async},
     {"POST", "/v1/kb/ingest", NULL, RM_EXACT, "kb.ingest", 0, rh_dispatch_op_async},
     {"POST", "/v1/kb/update", NULL, RM_EXACT, "kb.update", 0, rh_dispatch_op_async},
+    {"POST", "/v1/kb/docs/push", NULL, RM_EXACT, "kb.docs.push", 0, rh_dispatch_op_async},
     {"POST", "/v1/graph/sync_code", NULL, RM_EXACT, "graph.sync_code", 0, rh_dispatch_op_async},
     {"POST", "/v1/index/scan", NULL, RM_EXACT, "index.scan", 0, rh_dispatch_op_async},
     {"POST", "/v1/index/ingest", NULL, RM_EXACT, "index.ingest", 0, rh_dispatch_op_async},


### PR DESCRIPTION
kb.docs.push had a handler + CLI command but no `/v1` HTTP route, so the content-upload doc ingest 404'd and was unreachable. This is the correct ingest for a remote/stateless aimee-kb (aimee-server reads workspace files and uploads bytes), unlike `kb.build` which forwards a filesystem path a separate aimee-kb can't read. Adds the async route + regenerates the thin-client map (coverage gates pass). First concrete fix from the KB-ingest-architecture root-cause; the broader content-push / default-tree / delta-ordering design follows in a proposal.