### PR TITLE
refactor(delegate): route the skill-review spawn through the orchestration seam

### DIFF
--- a/src/server/server_skill_jobs.c
+++ b/src/server/server_skill_jobs.c
@@ -4,18 +4,73 @@
 #endif
 #include "server_compute_impl.h"
 #include "skill_curator.h"
+#include "gw_orch_delegates.h"
+#include "config.h"
 #include "log.h"
 #include "cJSON.h"
 #include <stdlib.h>
 #include <stdio.h>
 
+/* Fields the spawn adapter needs beyond (role, brief), carried as the orchestration
+ * capability's opaque ctx. spawn_rc records the on-demand submit outcome so the caller can
+ * warn on a genuine submit failure (0 spawned, -1 refused/failed; -1 until the adapter runs). */
+typedef struct
+{
+   server_ctx_t *server;
+   int spawn_rc;
+} skill_review_backing_t;
+
+/* The spawn_delegate capability for the skill-review job: build the delegate request + compute
+ * ctx from (role, brief) and submit it to an on-demand delegate worker. Mirrors the coord
+ * dispatcher's adapter (server_coord_dispatcher.c). Records the outcome in the backing. */
+static int skill_review_spawn_delegate(void *ctx, const char *role, const char *brief)
+{
+   skill_review_backing_t *b = (skill_review_backing_t *)ctx;
+   if (!b)
+      return -1;
+   b->spawn_rc = -1;
+   cJSON *req = cJSON_CreateObject();
+   if (!req)
+      return -1;
+   cJSON_AddStringToObject(req, "role", role && role[0] ? role : "review");
+   cJSON_AddStringToObject(req, "prompt", brief ? brief : "");
+   cJSON_AddTrueToObject(req, "handoff_json");
+   compute_ctx_t *cctx = calloc(1, sizeof(compute_ctx_t));
+   if (!cctx)
+   {
+      cJSON_Delete(req);
+      return -1;
+   }
+   cctx->server = b->server;
+   cctx->conn_fd = -1;
+   cctx->async_slot = -1;
+   cctx->req = req;
+   /* Skill-review delegates are I/O-bound; run on-demand, not the CPU compute
+    * pool (see delegate_spawn_ondemand). */
+   if (delegate_spawn_ondemand(cctx) != 0)
+   {
+      compute_ctx_free(cctx);
+      b->spawn_rc = -1;
+      return -1;
+   }
+   b->spawn_rc = 0;
+   return 0;
+}
+
+/* Resolve whether the delegates module is enabled: the config-store `modules.delegates` toggle
+ * (canonical), falling back to the deprecated env default. Loaded per call (mtime-cached), so an
+ * operator toggle takes effect without a restart. Keeps the pure gw_orch_delegates module
+ * config-free (mirrors coord_delegates_enabled in server_coord_dispatcher.c). */
+static int skill_review_delegates_enabled(void)
+{
+   config_t cfg;
+   int tri = (config_load(&cfg) == 0) ? cfg.module_delegates : -1;
+   return config_module_enabled(tri, gw_orch_delegates_enabled());
+}
+
 void server_compute_skill_review_async(server_ctx_t *ctx, const char *session_id)
 {
    if (!ctx || !session_id || !session_id[0])
-      return;
-
-   cJSON *req = cJSON_CreateObject();
-   if (!req)
       return;
 
    char prompt[512];
@@ -28,28 +83,25 @@ void server_compute_skill_review_async(server_ctx_t *ctx, const char *session_id
             "ones. A no-op pass is acceptable.",
             session_id);
 
-   cJSON_AddStringToObject(req, "role", "review");
-   cJSON_AddStringToObject(req, "prompt", prompt);
-   cJSON_AddTrueToObject(req, "handoff_json");
-
-   compute_ctx_t *cctx = calloc(1, sizeof(compute_ctx_t));
-   if (!cctx)
+   /* Route the spawn through the DELEGATES orchestration module so it is a togglable, registered
+    * hook rather than an inline imperative call (see gw_orch_delegates), matching the coord
+    * dispatcher port. Fire-and-forget: on a disabled module we skip the review, and only warn on
+    * a genuine submit failure — the two are logged distinctly. */
+   skill_review_backing_t backing = {ctx, -1};
+   gw_turn_capabilities_t caps = {&backing, skill_review_spawn_delegate, NULL};
+   char turn_id[64];
+   snprintf(turn_id, sizeof(turn_id), "skill-review-%s", session_id);
+   if (gw_orch_delegates_run(&caps, turn_id, "review", prompt, skill_review_delegates_enabled()) !=
+       0)
    {
-      cJSON_Delete(req);
+      /* Module disabled (or catalog build failed): no spawn attempted. A disabled module is an
+       * intentional operator choice, not a failure. */
+      LOG_INFO("skill_review", "delegates module disabled — skipping review for session %s",
+               session_id);
       return;
    }
-   cctx->server = ctx;
-   cctx->conn_fd = -1;
-   cctx->async_slot = -1;
-   cctx->req = req;
-
-   /* Skill-review delegates are I/O-bound; run on-demand, not the CPU compute
-    * pool (see delegate_spawn_ondemand). */
-   if (delegate_spawn_ondemand(cctx) != 0)
-   {
-      compute_ctx_free(cctx);
+   if (backing.spawn_rc != 0)
       LOG_WARN("skill_review", "failed to submit review job for session %s", session_id);
-   }
 }
 
 void server_compute_skill_curator_async(server_ctx_t *ctx)


### PR DESCRIPTION
## What

Follow-up to the delegate orchestration-seam port (#1472). Routes the **skill-review** delegate spawn (`server_compute_skill_review_async`) through the `gw_orch_delegates` module instead of an inline `delegate_spawn_ondemand` call, so it is a togglable, registered orchestration hook — matching the merged coord dispatcher port.

## How
- New static `skill_review_spawn_delegate` adapter builds the delegate `req` (role=`review`, prompt, `handoff_json`) + `compute_ctx` and submits on-demand — the same fields/path as before, just moved behind the seam's `spawn_delegate` capability.
- New static `skill_review_delegates_enabled()` resolves the config-store `modules.delegates` tristate (canonical) with the deprecated env default as fallback, via `config_module_enabled` — identical to `coord_delegates_enabled`.
- `server_compute_skill_review_async` now builds the prompt, sets up the backing/caps, and calls `gw_orch_delegates_run(...)`.

## Behavior
- **Enabled (default): unchanged.** Same req, same on-demand submit, same WARN on a genuine submit failure.
- **Disabled:** review is skipped and logged **distinctly at INFO** (operator choice, not a failure), separate from the submit-failure WARN — applying the mislabel lesson from the workflow port.

## Scope decision (please verify)
`server_compute.c:411` (`delegate_dispatch`) is **deliberately NOT ported.** It is the execution primitive that routes an *already-decided* delegate — including client-requested `/v1` delegates — to the session pool or an on-demand thread. It sits downstream of the orchestration decision, so gating it through the module would wrongly disable client delegates too. Only genuine orchestration-decision spawn sites (coord dispatcher, skill-review) belong on the seam, mirroring the router advisory-stage grounding correction.

## Verification
- `make server`: clean build + link.
- `unit-test-gw-orch-delegates`: ok · `unit-test-skill-review`: PASS.
- The wire site is stubbed in unit tests (as the coord wire-site is); the seam mechanism is covered by `test_gw_orch_delegates`.
