### PR TITLE
feat(economizer): promote to a first-class modules.* toggle

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -626,6 +626,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->module_governance = -1;
    cfg->module_delegates = -1;
    cfg->module_workflows = -1;
+   cfg->module_economizer = -1;
    /* command-aware tool-output condensation: DEFAULT-ON (P1c). Safe-tier lever — it passes
     * the deterministic gate: lossless-on-demand (full output spilled), fail-open (any
     * miss/decline -> raw), and a no-over-reduction audit (failures/diagnostics + their
@@ -953,7 +954,12 @@ static void config_apply_inference_backend_defaults(config_t *cfg, const cJSON *
 
 int econ_reduction_master_on(const config_t *cfg)
 {
-   return cfg && cfg->economizer_enabled ? 1 : 0;
+   /* The economizer's master gate is a pluggable-module toggle like the other four: the
+    * modules.economizer tristate is canonical when set (0/1); -1 (unspecified) falls back to
+    * the legacy economizer.enabled bool, which plays the "deprecated default" role env plays
+    * for memory/governance/delegates/workflows. Every economizer sub-predicate routes through
+    * here, so modules.economizer:false is one authoritative kill. */
+   return cfg ? config_module_enabled(cfg->module_economizer, cfg->economizer_enabled) : 0;
 }
 
 int config_module_enabled(int config_tristate, int env_default)
@@ -970,7 +976,7 @@ int econ_gateway_mutate_on(const config_t *cfg)
 {
    /* the live-primary mutator needs the master ON, the aggressive tier opted IN, AND the
     * lever itself set — the aggressive flag alone never activates a live-traffic mutator. */
-   return cfg && cfg->economizer_enabled && cfg->economizer_aggressive && cfg->reduce_gateway_mutate
+   return econ_reduction_master_on(cfg) && cfg->economizer_aggressive && cfg->reduce_gateway_mutate
               ? 1
               : 0;
 }

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -53,7 +53,7 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
     * operator actually set, so an untouched config never sprouts a modules: block and the
     * resolver's env/default fallback stays in effect for the rest. */
    if (cfg->module_memory != -1 || cfg->module_governance != -1 || cfg->module_delegates != -1 ||
-       cfg->module_workflows != -1)
+       cfg->module_workflows != -1 || cfg->module_economizer != -1)
    {
       cJSON *m = cJSON_AddObjectToObject(root, "modules");
       if (m)
@@ -66,6 +66,8 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
             cJSON_AddBoolToObject(m, "delegates", cfg->module_delegates ? 1 : 0);
          if (cfg->module_workflows != -1)
             cJSON_AddBoolToObject(m, "workflows", cfg->module_workflows ? 1 : 0);
+         if (cfg->module_economizer != -1)
+            cJSON_AddBoolToObject(m, "economizer", cfg->module_economizer ? 1 : 0);
       }
    }
 

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -748,10 +748,9 @@ void config_parse_modules_section(config_t *cfg, cJSON *root)
       const char *key;
       int *field;
    } toggles[] = {
-       {"memory", &cfg->module_memory},
-       {"governance", &cfg->module_governance},
-       {"delegates", &cfg->module_delegates},
-       {"workflows", &cfg->module_workflows},
+       {"memory", &cfg->module_memory},         {"governance", &cfg->module_governance},
+       {"delegates", &cfg->module_delegates},   {"workflows", &cfg->module_workflows},
+       {"economizer", &cfg->module_economizer},
    };
    for (size_t i = 0; i < sizeof(toggles) / sizeof(toggles[0]); i++)
    {

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1161,6 +1161,10 @@ typedef struct config
    int module_governance;
    int module_delegates;
    int module_workflows;
+   /* economizer's env-default analog is the legacy economizer.enabled bool (not an AIMEE_*
+    * env), so its resolver call is config_module_enabled(module_economizer, economizer_enabled)
+    * inside econ_reduction_master_on(). */
+   int module_economizer;
 
    /* Autonomous-development pipeline knobs (Phase-C). These were env-var-only
     * (AIMEE_AUTONOMY_*); the config values are bridged to those env vars at startup

--- a/src/modules/economizer/tool_condense.c
+++ b/src/modules/economizer/tool_condense.c
@@ -51,8 +51,9 @@ void tool_condense_stats_reset(void)
 
 int tool_condense_enabled(const config_t *cfg)
 {
-   /* safe-tier lever, gated by the P3 master switch: economizer.enabled off = one kill. */
-   return cfg && cfg->economizer_enabled && cfg->reduce_command_filter ? 1 : 0;
+   /* safe-tier lever, gated by the P3 master switch: master off = one kill. Resolve the master
+    * through econ_reduction_master_on so the modules.economizer toggle is honored here too. */
+   return econ_reduction_master_on(cfg) && cfg->reduce_command_filter ? 1 : 0;
 }
 
 /* ---- command recognition (Slice 2) ---- */

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -201,7 +201,7 @@ static int run_server(const char *socket_path, log_level_t log_level)
 
    /* P3: surface suppressed intent — an explicit lever the two-tier switches override, so an
     * operator is never silently ignored (per the two-tier design's startup-WARN ruling). */
-   if (!cfg.economizer_enabled &&
+   if (!econ_reduction_master_on(&cfg) &&
        (cfg.reduce_history_fold || cfg.reduce_compress || cfg.reduce_command_filter))
       aimee_log(LOG_WARN, "economizer",
                 "economizer.enabled=false MASTER-KILL: all reduction is off (measure still "

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2215,7 +2215,8 @@ $(TESTPREFIX)/unit-test-edit-anchored: $(OBJDIR)/tests/test_edit_anchored.o \
                       $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
-$(TESTPREFIX)/unit-test-tool-condense: $(OBJDIR)/tests/test_tool_condense.o $(OBJDIR)/modules/economizer/tool_condense.o
+$(TESTPREFIX)/unit-test-tool-condense: $(OBJDIR)/tests/test_tool_condense.o $(OBJDIR)/modules/economizer/tool_condense.o \
+                      $(OBJDIR)/config.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-workspace-provider: $(OBJDIR)/tests/test_workspace_provider.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2216,7 +2216,7 @@ $(TESTPREFIX)/unit-test-edit-anchored: $(OBJDIR)/tests/test_edit_anchored.o \
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-tool-condense: $(OBJDIR)/tests/test_tool_condense.o $(OBJDIR)/modules/economizer/tool_condense.o \
-                      $(OBJDIR)/config.o $(OBJDIR)/cJSON.o
+                      $(OBJDIR)/config.o $(OBJDIR)/cJSON.o $(OBJDIR)/platform_random.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-workspace-provider: $(OBJDIR)/tests/test_workspace_provider.o \

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -16,7 +16,7 @@
  * tool_condense_enabled without pulling the CORE object into this test's link set. */
 static int cf_effective(const config_t *c)
 {
-   return c->economizer_enabled && c->reduce_command_filter;
+   return econ_reduction_master_on(c) && c->reduce_command_filter;
 }
 
 /* P3 two-tier resolution: master-kill, aggressive ceiling, and BACK-COMPAT (default
@@ -25,6 +25,7 @@ static void test_two_tier_resolution(void)
 {
    config_t c;
    memset(&c, 0, sizeof c);
+   c.module_economizer = -1; /* config_load default: unspecified -> legacy economizer.enabled */
 
    /* back-compat: defaults (enabled=1, aggressive=0) => effective == raw individual */
    c.economizer_enabled = 1;
@@ -292,6 +293,7 @@ int main(void)
       config_load(&cfg); /* no modules: block -> all unspecified */
       assert(cfg.module_memory == -1 && cfg.module_governance == -1);
       assert(cfg.module_delegates == -1 && cfg.module_workflows == -1);
+      assert(cfg.module_economizer == -1);
 
       /* save the pristine defaults: nothing written -> reload still -1 (no stray 0). */
       assert(config_save(&cfg) == 0);
@@ -300,22 +302,41 @@ int main(void)
       config_load(&cfg2);
       assert(cfg2.module_memory == -1 && cfg2.module_governance == -1);
       assert(cfg2.module_delegates == -1 && cfg2.module_workflows == -1);
+      assert(cfg2.module_economizer == -1);
 
-      /* explicit user toggles round-trip: governance OFF, delegates ON, others unspecified. */
+      /* explicit user toggles round-trip: governance OFF, delegates ON, economizer OFF. */
       cfg2.module_governance = 0;
       cfg2.module_delegates = 1;
+      cfg2.module_economizer = 0;
       assert(config_save(&cfg2) == 0);
       static config_t cfg3;
       memset(&cfg3, 0, sizeof(cfg3));
       config_load(&cfg3);
       assert(cfg3.module_governance == 0); /* explicit disable persisted */
       assert(cfg3.module_delegates == 1);  /* explicit enable persisted  */
+      assert(cfg3.module_economizer == 0); /* explicit disable persisted */
       assert(cfg3.module_memory == -1 && cfg3.module_workflows == -1); /* untouched stay -1 */
 
       /* resolver precedence (governance is default-ON via env fallback when unspecified). */
       assert(config_module_enabled(cfg3.module_governance, 1) == 0); /* config OFF wins */
       assert(config_module_enabled(cfg3.module_memory, 1) == 1);     /* -1 -> env default ON */
       assert(config_module_enabled(cfg3.module_memory, 0) == 0);     /* -1 -> env default OFF */
+
+      /* economizer master gate honors modules.economizer AUTHORITATIVELY over the legacy
+       * economizer.enabled bool (economizer's "env default" analog). */
+      config_t ec;
+      memset(&ec, 0, sizeof(ec));
+      ec.economizer_enabled = 1; /* legacy master ON... */
+      ec.module_economizer = 0;  /* ...but modules.economizer:false wins */
+      assert(econ_reduction_master_on(&ec) == 0);
+      ec.economizer_enabled = 0; /* legacy master OFF... */
+      ec.module_economizer = 1;  /* ...but modules.economizer:true wins */
+      assert(econ_reduction_master_on(&ec) == 1);
+      ec.module_economizer = -1; /* unspecified -> fall back to legacy economizer.enabled */
+      ec.economizer_enabled = 1;
+      assert(econ_reduction_master_on(&ec) == 1);
+      ec.economizer_enabled = 0;
+      assert(econ_reduction_master_on(&ec) == 0);
    }
 
    /* restore env */

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -83,7 +83,8 @@ static const char *FIXTURE_A =
     "allow_ml_only_block: true\nauxiliary:\n  enabled: true\n  default_model: ZZA_val\n  "
     "default_max_tokens: 1\nmodel_meta:\n  refresh_minutes: 1\n  capability_routing: "
     "true\nensemble:\n  enabled: true\n  min_successful: 1\n  max_cost_usd: 1.0\n"
-    "modules:\n  memory: true\n  governance: true\n  delegates: true\n  workflows: true";
+    "modules:\n  memory: true\n  governance: true\n  delegates: true\n  workflows: true\n  "
+    "economizer: true";
 static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
@@ -142,7 +143,8 @@ static const char *FIXTURE_B =
     "allow_ml_only_block: false\nauxiliary:\n  enabled: false\n  default_model: ZZB_val\n  "
     "default_max_tokens: 4096\nmodel_meta:\n  refresh_minutes: 4096\n  capability_routing: "
     "false\nensemble:\n  enabled: false\n  min_successful: 4096\n  max_cost_usd: 0.99\n"
-    "modules:\n  memory: false\n  governance: false\n  delegates: false\n  workflows: false";
+    "modules:\n  memory: false\n  governance: false\n  delegates: false\n  workflows: false\n  "
+    "economizer: false";
 
 int main(void)
 {
@@ -339,6 +341,7 @@ int main(void)
    assert(cfgA.module_governance == 1 && cfgB.module_governance == 0);
    assert(cfgA.module_delegates == 1 && cfgB.module_delegates == 0);
    assert(cfgA.module_workflows == 1 && cfgB.module_workflows == 0);
+   assert(cfgA.module_economizer == 1 && cfgB.module_economizer == 0);
 
    /* config_module_enabled precedence: an explicit user tristate (0/1) is canonical and wins
     * over the env default; -1 (unspecified) falls back to the env default. */

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -25,6 +25,8 @@ int main(void)
    {
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
+      cfg.module_economizer =
+          -1; /* config_load default: unspecified -> legacy economizer.enabled */
       assert(tool_condense_enabled(&cfg) == 0);
       cfg.reduce_command_filter = 1;
       assert(tool_condense_enabled(&cfg) == 0); /* P3 master (economizer.enabled) still off */
@@ -255,6 +257,8 @@ int main(void)
    {
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
+      cfg.module_economizer =
+          -1; /* config_load default: unspecified -> legacy economizer.enabled */
 
       /* a big passing pytest run (exit 0) */
       char big[8192];
@@ -347,6 +351,8 @@ int main(void)
    {
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
+      cfg.module_economizer =
+          -1; /* config_load default: unspecified -> legacy economizer.enabled */
       cfg.reduce_command_filter = 1;
       cfg.economizer_enabled = 1; /* P3 master gate */
       char big[8192];
@@ -374,6 +380,8 @@ int main(void)
       tool_condense_stats_reset();
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
+      cfg.module_economizer =
+          -1; /* config_load default: unspecified -> legacy economizer.enabled */
       cfg.reduce_command_filter = 1;
       cfg.economizer_enabled = 1; /* P3 master gate */
       char big[8192];


### PR DESCRIPTION
## What

The economizer was consolidated into `src/modules/economizer/` (#1485/#1488) but was still the **odd module out**: its master gate was the legacy plain-bool `economizer.enabled` (its own `economizer:` block, read ad-hoc), not the tristate `modules.*` surface the other four modules share via `config_module_enabled()` — the single resolver that is also the documented hook for the future admin/governance FORCE tier.

This gives it a real peer toggle: **`modules.economizer`**.

## How

- `module_economizer` tristate field (`-1` = unspecified default) on `config_t`; parsed in the `modules:` block; persisted by `config_save`.
- `econ_reduction_master_on()` resolves via `config_module_enabled(module_economizer, economizer_enabled)` — the tristate is canonical when set (`0/1`); `-1` falls back to the legacy `economizer.enabled` bool, which now plays the "deprecated default" role env plays for the other four. **Read-time** resolution (not a load-time normalize) keeps the `economizer.enabled` save round-trip intact.
- The sub-predicates that read `economizer_enabled` directly (`tool_condense_enabled`, `econ_gateway_mutate_on`, the `server_main` startup WARN) now route through the master, so `modules.economizer:false` is **one authoritative kill**, not a leaky toggle. Byte-identical today since `master == economizer_enabled`.

Production always builds config via `config_load` (which sets `-1`), so the fallback is correct; only hand-built test configs needed the `-1` default set explicitly.

## Tests

- `config-surface`: `modules.economizer` parse (true/false fixtures).
- `config-economizer`: tristate default/round-trip + **authority over the legacy bool** (`modules.economizer` wins over `economizer.enabled` both directions; `-1` falls back).
- `tool-condense`: master-gate propagation. `unit-test-tool-condense` gains `config.o`/`cJSON.o` in its link set (it now calls `econ_reduction_master_on`).

Local: server links; `unit-test-config-economizer`, `unit-test-config-surface`, `unit-test-tool-condense` all pass; changed files clang-format-19 clean.