### PR TITLE
fix(ir): byte-exact same-protocol parity metric (caching gate) + delete dead routing enum

### DIFF
--- a/src/headers/aimee_ir.h
+++ b/src/headers/aimee_ir.h
@@ -229,22 +229,6 @@ size_t aimee_ir_response_reasoning(const aimee_response_t *r, char *buf, size_t 
 const char *aimee_stop_reason_name(aimee_stop_reason_t s);
 aimee_stop_reason_t aimee_stop_reason_parse(const char *canonical_name);
 
-/* The path a request takes (ruling Q2). */
-typedef enum
-{
-   AIMEE_ROUTE_PASSTHROUGH = 0, /* same-protocol, no mutation: forward raw bytes verbatim
-                                   (prompt-cache preserved) */
-   AIMEE_ROUTE_IR               /* cross-protocol OR a stage will mutate: parse -> IR -> build */
-} aimee_route_t;
-
-/* Decide the request path UP-FRONT (avoids the TOCTOU where a mutating stage has
- * already broken byte-parity). PASSTHROUGH only when frontend==backend protocol,
- * both known, AND no stage will mutate the request; otherwise the IR path (a
- * mutation already invalidates the cached suffix, so the IR round-trip costs
- * nothing extra). */
-aimee_route_t aimee_ir_route_decide(aimee_wire_t frontend, aimee_wire_t backend,
-                                    int stage_will_mutate);
-
 /* 1 if two requests are SEMANTICALLY equal: same system blocks, messages (role +
  * ordered content blocks incl. tool ids/names/args/results + cache_control),
  * tools, tool_choice, and sampling params. IGNORES provenance that legitimately

--- a/src/headers/aimee_ir_metrics.h
+++ b/src/headers/aimee_ir_metrics.h
@@ -15,7 +15,15 @@ typedef enum
    AIMEE_IR_M_RENDER_FAIL,        /* frontend.render(IR) failed */
    AIMEE_IR_M_BACKEND_BUILD_FAIL, /* backend.build(IR) failed */
    AIMEE_IR_M_BACKEND_PARSE_FAIL, /* backend.parse(provider resp) failed */
-   AIMEE_IR_M_REBUILD_MISMATCH,   /* same-protocol round-trip != original bytes (BUG) */
+   /* Same-protocol round-trip serialize(backend_build(parse(req))) vs serialize(req),
+    * BYTE-exact. This is the CACHING gate: Claude Code's prompt cache keys on exact
+    * bytes, so the verbatim Anthropic passthrough cannot be retired until MISMATCH
+    * reads 0 over real traffic. Distinct from BODY_MATCH (semantic / key-order
+    * insensitive). MATCH is the denominator so a parity RATE is computable; a mismatch
+    * that is still semantically equal is harmless key-order/formatting drift, one that
+    * is semantically UNEQUAL is real field loss (logged with a semantic_equal flag). */
+   AIMEE_IR_M_REBUILD_MATCH,
+   AIMEE_IR_M_REBUILD_MISMATCH,
    AIMEE_IR_M_STAGE_MUTATION,     /* a core stage mutated the request (forces IR path) */
    AIMEE_IR_M_CACHE_CONTROL_LOST, /* a cache_control marker was dropped in round-trip (BUG) */
    AIMEE_IR_M_PASSTHROUGH,        /* same-protocol raw-passthrough fast-path taken */

--- a/src/server/aimee_ir.c
+++ b/src/server/aimee_ir.c
@@ -125,18 +125,6 @@ size_t aimee_ir_last_user_text(const aimee_request_t *r, char *buf, size_t n)
    return used;
 }
 
-aimee_route_t aimee_ir_route_decide(aimee_wire_t frontend, aimee_wire_t backend,
-                                    int stage_will_mutate)
-{
-   if (frontend == AIMEE_WIRE_UNKNOWN || backend == AIMEE_WIRE_UNKNOWN)
-      return AIMEE_ROUTE_IR; /* unknown protocol: don't risk a raw passthrough */
-   if (frontend != backend)
-      return AIMEE_ROUTE_IR; /* cross-protocol always needs the IR pivot */
-   if (stage_will_mutate)
-      return AIMEE_ROUTE_IR; /* mutation already breaks byte-parity -> IR is free */
-   return AIMEE_ROUTE_PASSTHROUGH;
-}
-
 const char *aimee_stop_reason_name(aimee_stop_reason_t s)
 {
    switch (s)

--- a/src/server/aimee_ir_metrics.c
+++ b/src/server/aimee_ir_metrics.c
@@ -50,6 +50,8 @@ const char *aimee_ir_metric_name(aimee_ir_metric_t m)
       return "ir_backend_build_failures";
    case AIMEE_IR_M_BACKEND_PARSE_FAIL:
       return "ir_backend_parse_failures";
+   case AIMEE_IR_M_REBUILD_MATCH:
+      return "ir_rebuild_match_bytes";
    case AIMEE_IR_M_REBUILD_MISMATCH:
       return "ir_rebuild_mismatch_bytes";
    case AIMEE_IR_M_STAGE_MUTATION:

--- a/src/server/aimee_ir_shadow.c
+++ b/src/server/aimee_ir_shadow.c
@@ -227,7 +227,14 @@ void aimee_ir_shadow_observe_request(const cJSON *req, aimee_wire_t frontend)
    }
    aimee_ir_metric_inc(AIMEE_IR_M_IR_PATH, frontend);
 
-   /* rebuild same-protocol and check the round-trip is IR-stable */
+   /* Rebuild same-protocol and check BYTE-exact parity -- the caching gate. The
+    * verbatim passthrough forwards serialize(req) (cJSON re-emits the parsed request
+    * in its original key order), so serialize(anthropic_backend_build(parse(req)))
+    * == serialize(req) means the IR egress is a byte-faithful drop-in and the
+    * passthrough can be retired. On a mismatch, semantic_equal (cJSON_Compare,
+    * key-order-insensitive) separates harmless key-order/formatting drift from real
+    * field loss. Per the roundtable no-raw-bytes rule, only lengths + the semantic
+    * flag are logged, never request content. */
    cJSON *rebuilt = anthropic_backend_build(&ir);
    if (!rebuilt)
    {
@@ -235,25 +242,27 @@ void aimee_ir_shadow_observe_request(const cJSON *req, aimee_wire_t frontend)
    }
    else
    {
-      aimee_request_t ir2;
-      if (anthropic_frontend_parse(rebuilt, &ir2, err, sizeof err) == 0)
+      char *req_s = cJSON_PrintUnformatted(req);
+      char *reb_s = cJSON_PrintUnformatted(rebuilt);
+      if (req_s && reb_s && strcmp(req_s, reb_s) == 0)
       {
-         if (!aimee_ir_request_equal(&ir, &ir2))
-         {
-            aimee_ir_metric_inc(AIMEE_IR_M_REBUILD_MISMATCH, frontend);
-            if (g_logged < SHADOW_LOG_CAP)
-            {
-               fprintf(stderr, "[ir-shadow] anthropic round-trip MISMATCH (n_msgs=%d n_tools=%d)\n",
-                       ir.n_messages, ir.n_tools);
-               g_logged++;
-            }
-         }
-         aimee_request_free(&ir2);
+         aimee_ir_metric_inc(AIMEE_IR_M_REBUILD_MATCH, frontend);
       }
       else
       {
-         aimee_ir_metric_inc(AIMEE_IR_M_PARSE_FAIL, frontend);
+         aimee_ir_metric_inc(AIMEE_IR_M_REBUILD_MISMATCH, frontend);
+         if (g_logged < SHADOW_LOG_CAP)
+         {
+            g_logged++;
+            fprintf(
+                stderr,
+                "[ir-shadow] anthropic byte MISMATCH (req_len=%zu reb_len=%zu semantic_equal=%d)\n",
+                req_s ? strlen(req_s) : (size_t)0, reb_s ? strlen(reb_s) : (size_t)0,
+                cJSON_Compare(req, rebuilt, 1));
+         }
       }
+      free(req_s);
+      free(reb_s);
       cJSON_Delete(rebuilt);
    }
    aimee_request_free(&ir);

--- a/src/tests/test_aimee_ir.c
+++ b/src/tests/test_aimee_ir.c
@@ -150,16 +150,6 @@ int main(void)
    aimee_request_free(&a);
    aimee_request_free(&b);
 
-   /* --- route decision (Q2) --- */
-   /* same protocol, no mutation -> raw passthrough (byte-parity) */
-   assert(aimee_ir_route_decide(AIMEE_WIRE_ANTHROPIC, AIMEE_WIRE_ANTHROPIC, 0) ==
-          AIMEE_ROUTE_PASSTHROUGH);
-   /* same protocol but a stage will mutate -> IR path */
-   assert(aimee_ir_route_decide(AIMEE_WIRE_ANTHROPIC, AIMEE_WIRE_ANTHROPIC, 1) == AIMEE_ROUTE_IR);
-   /* cross-protocol -> IR path regardless */
-   assert(aimee_ir_route_decide(AIMEE_WIRE_ANTHROPIC, AIMEE_WIRE_RESPONSES, 0) == AIMEE_ROUTE_IR);
-   /* unknown protocol -> IR path (safe) */
-   assert(aimee_ir_route_decide(AIMEE_WIRE_UNKNOWN, AIMEE_WIRE_ANTHROPIC, 0) == AIMEE_ROUTE_IR);
    /* --- response accessors: the delegate path's replacement for
     *     parsed_response_t.content / .is_tool_call ---
     *

--- a/src/tests/test_aimee_ir_metrics.c
+++ b/src/tests/test_aimee_ir_metrics.c
@@ -31,6 +31,7 @@ int main(void)
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 1);
 
    /* names are stable + distinct */
+   assert(strcmp(aimee_ir_metric_name(AIMEE_IR_M_REBUILD_MATCH), "ir_rebuild_match_bytes") == 0);
    assert(strcmp(aimee_ir_metric_name(AIMEE_IR_M_REBUILD_MISMATCH), "ir_rebuild_mismatch_bytes") ==
           0);
    assert(strcmp(aimee_ir_metric_name(AIMEE_IR_M_PASSTHROUGH), "ir_passthrough") == 0);

--- a/src/tests/test_aimee_ir_shadow.c
+++ b/src/tests/test_aimee_ir_shadow.c
@@ -1,6 +1,8 @@
-/* test_aimee_ir_shadow.c -- Slice 3: the shadow observer is a gated no-op when
- * AIMEE_IR_SHADOW is unset, and records a clean round-trip (no mismatch) on a
- * well-formed Anthropic request when enabled. */
+/* test_aimee_ir_shadow.c -- the request-side shadow observer: a gated no-op when
+ * AIMEE_IR_SHADOW is unset, and a BYTE-exact same-protocol parity check when
+ * enabled. A request the Anthropic backend reproduces byte-for-byte counts as
+ * REBUILD_MATCH; one it cannot (an unmodeled field it drops) counts as
+ * REBUILD_MISMATCH. This is the caching gate for retiring the verbatim passthrough. */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,6 +16,9 @@ int main(void)
    printf("ir-shadow: ");
    aimee_ir_metrics_reset();
 
+   /* A request already in the Anthropic backend's canonical key order, so
+    * serialize(backend_build(parse(req))) == serialize(req): a byte-faithful
+    * round-trip. */
    cJSON *req = cJSON_Parse(
        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
        "\"system\":[{\"type\":\"text\",\"text\":\"sys\"}],"
@@ -26,17 +31,33 @@ int main(void)
    aimee_ir_shadow_observe_request(req, AIMEE_WIRE_ANTHROPIC);
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 0);
 
-   /* enabled -> observes; a well-formed request round-trips cleanly */
+   /* enabled -> byte-faithful request scores a MATCH, no mismatch */
    setenv("AIMEE_IR_SHADOW", "1", 1);
    aimee_ir_shadow_observe_request(req, AIMEE_WIRE_ANTHROPIC);
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 1);
    assert(aimee_ir_metric_total(AIMEE_IR_M_PARSE_FAIL) == 0);
-   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 0); /* clean */
    assert(aimee_ir_metric_total(AIMEE_IR_M_BACKEND_BUILD_FAIL) == 0);
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MATCH) == 1);    /* byte-exact */
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 0); /* clean */
 
    /* a non-Anthropic frontend is skipped in this slice */
    aimee_ir_shadow_observe_request(req, AIMEE_WIRE_OPENAI_CHAT);
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 1); /* unchanged */
+
+   /* a request carrying a field the IR does not model (top_p) parses fine but the
+    * backend drops it on rebuild -> the bytes differ -> REBUILD_MISMATCH. This is the
+    * exact class (silent field loss) the byte gate must catch before we can retire
+    * the passthrough. */
+   cJSON *lossy = cJSON_Parse(
+       "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
+       "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}],"
+       "\"top_p\":0.9}");
+   assert(lossy);
+   aimee_ir_shadow_observe_request(lossy, AIMEE_WIRE_ANTHROPIC);
+   assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 2);          /* parsed + observed */
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 1); /* dropped top_p */
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MATCH) == 1);    /* still just the first */
+   cJSON_Delete(lossy);
 
    /* NULL request is safe */
    aimee_ir_shadow_observe_request(NULL, AIMEE_WIRE_ANTHROPIC);


### PR DESCRIPTION
First concrete step of the IR-canonical-funnel program (all LLM traffic ingress → IR → egress, one IR, delete legacy). The lead domino is routing the Anthropic-native path through the IR and deleting its verbatim `cJSON_Duplicate` passthrough — but that's only safe once the IR egress reproduces the client's **exact bytes** (Claude Code's prompt cache keys on them). We had no live measurement of that.

## The defect
`AIMEE_IR_M_REBUILD_MISMATCH` is named `ir_rebuild_mismatch_bytes` and documented as "round-trip != original **bytes**", but `aimee_ir_shadow_observe_request` implemented it as **IR-semantic** equality (`aimee_ir_request_equal` on parse vs parse-of-rebuild). Key-order/formatting drift — and dropped-then-defaulted fields — passed the check. The name lied, and there was no MATCH counter, so no parity **rate** was computable.

## Fix
`observe_request` now compares `serialize(anthropic_backend_build(parse(req)))` to `serialize(req)` **byte-for-byte**, incrementing `REBUILD_MATCH` / `REBUILD_MISMATCH`. On a mismatch it logs only lengths + a `semantic_equal` flag (`cJSON_Compare`) — never request content (no-raw-bytes rule) — so harmless key-order drift (`semantic_equal=1`) is distinguishable from real field loss (`semantic_equal=0`). Added `REBUILD_MATCH` as the denominator. `observe_request` is already wired live (`anthropic_http.c:491`, `:902`), so with `AIMEE_IR_SHADOW=1` the dashboard now surfaces the true byte-parity rate on real Claude Code traffic — the evidence gate for the passthrough flip.

Tests prove both arms: a canonical-order request → `REBUILD_MATCH`; a request with an unmodeled field (`top_p`) the backend drops → `REBUILD_MISMATCH` (observed 125→113 bytes, `semantic_equal=0`).

## Dead-code deletion (religious)
`aimee_ir_route_decide` / `aimee_route_t` / `AIMEE_ROUTE_*` had **zero references** anywhere (grep-verified). Beyond dead, `AIMEE_ROUTE_PASSTHROUGH` ("forward raw bytes verbatim, skip IR") encodes the *abandoned* skip-IR design that contradicts the everything-through-IR target. Deleted.

## Verification
Server links; `unit-test-aimee-ir-shadow` + `unit-test-aimee-ir-metrics` pass (strengthened to assert both parity arms); `make build-integrity` green; clang-format-19 clean.

Next: make `anthropic_backend_build` emit from raw sidecars for untouched blocks to drive live mismatches → 0, then flip the Anthropic path onto IR and delete `build_anthropic_provider_body`.