### PR TITLE
feat(ir): byte-faithful same-protocol Anthropic egress via raw sidecar

### DIFF
--- a/src/headers/aimee_ir.h
+++ b/src/headers/aimee_ir.h
@@ -116,9 +116,15 @@ typedef struct
    char **stop_sequences;
    int n_stop;
    aimee_wire_t frontend; /* the client wire this was parsed from */
+   /* Set to 1 by any IR transform that changes the typed fields (a module editing
+    * messages/system/tools). While 0, the request is byte-identical to `raw`, so a
+    * same-protocol backend may emit `raw` verbatim (byte-faithful egress -> prompt
+    * cache preserved). A transform that dirties the IR MUST set this so the backend
+    * re-serializes from the typed fields instead of shipping stale original bytes. */
+   int mutated;
    /* Whole-request sidecar: the ORIGINAL request JSON. Enables the same-protocol
-    * raw-passthrough fast-path (frontend==backend, no mutating stage) and lossless
-    * replay. Owned. */
+    * raw-passthrough fast-path (frontend==backend, unmutated) and lossless replay.
+    * Owned. */
    struct cJSON *raw;
 } aimee_request_t;
 

--- a/src/server/aimee_backend_anthropic.c
+++ b/src/server/aimee_backend_anthropic.c
@@ -97,6 +97,15 @@ cJSON *anthropic_backend_build(const aimee_request_t *ir)
 {
    if (!ir)
       return NULL;
+   /* Same-protocol byte-faithful egress: an Anthropic request that no IR transform
+    * touched is byte-identical to its raw sidecar, so ship those exact bytes. This
+    * preserves Claude Code's prompt-cache prefix (which the typed re-serialization
+    * below would perturb via key-order/formatting) and is the whole point of routing
+    * the native path through the IR instead of a verbatim passthrough that skips it.
+    * A transform that mutates the typed fields sets ir->mutated, forcing the rebuild. */
+   if (ir->frontend == AIMEE_WIRE_ANTHROPIC && !ir->mutated && ir->raw)
+      return cJSON_Duplicate(ir->raw, 1);
+
    cJSON *out = cJSON_CreateObject();
    if (ir->model)
       cJSON_AddStringToObject(out, "model", ir->model);

--- a/src/tests/test_aimee_backend.c
+++ b/src/tests/test_aimee_backend.c
@@ -54,7 +54,37 @@ int main(void)
    aimee_request_t air2;
    assert(anthropic_frontend_parse(built, &air2, err, sizeof err) == 0);
    assert(aimee_ir_request_equal(&air, &air2)); /* parse->build->parse stable */
+   /* ...and BYTE-exact: an unmutated same-protocol build ships the raw sidecar, so
+    * the wire bytes are identical to the client's (prompt cache preserved). */
+   {
+      cJSON *orig = cJSON_Parse(ANTHROPIC);
+      char *os = cJSON_PrintUnformatted(orig);
+      char *bs = cJSON_PrintUnformatted(built);
+      assert(os && bs && strcmp(os, bs) == 0);
+      free(os);
+      free(bs);
+      cJSON_Delete(orig);
+   }
    cJSON_Delete(built);
+
+   /* --- (1b) ir->mutated forces the typed rebuild; an unmodeled field (top_p) is
+    *          preserved by the raw passthrough but dropped by the rebuild. --- */
+   {
+      cJSON *uj = cJSON_Parse("{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,\"messages\":[{"
+                              "\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}"
+                              "],\"top_p\":0.9}");
+      aimee_request_t uir;
+      assert(anthropic_frontend_parse(uj, &uir, err, sizeof err) == 0);
+      cJSON_Delete(uj);
+      cJSON *clean = anthropic_backend_build(&uir); /* mutated=0 -> raw passthrough */
+      assert(clean && cJSON_GetObjectItem(clean, "top_p") != NULL); /* preserved */
+      uir.mutated = 1;
+      cJSON *rebuilt = anthropic_backend_build(&uir);                   /* typed rebuild */
+      assert(rebuilt && cJSON_GetObjectItem(rebuilt, "top_p") == NULL); /* dropped (unmodeled) */
+      cJSON_Delete(clean);
+      cJSON_Delete(rebuilt);
+      aimee_request_free(&uir);
+   }
 
    /* --- (2) CROSS-protocol build: OpenAI-parsed IR -> Anthropic request -> same IR
     *         an Anthropic client would produce. --- */

--- a/src/tests/test_aimee_ir_shadow.c
+++ b/src/tests/test_aimee_ir_shadow.c
@@ -44,20 +44,21 @@ int main(void)
    aimee_ir_shadow_observe_request(req, AIMEE_WIRE_OPENAI_CHAT);
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 1); /* unchanged */
 
-   /* a request carrying a field the IR does not model (top_p) parses fine but the
-    * backend drops it on rebuild -> the bytes differ -> REBUILD_MISMATCH. This is the
-    * exact class (silent field loss) the byte gate must catch before we can retire
-    * the passthrough. */
-   cJSON *lossy = cJSON_Parse(
+   /* a request carrying a field the IR does not model (top_p): the byte-faithful
+    * same-protocol egress ships the raw sidecar verbatim, so top_p is PRESERVED and
+    * the round-trip still MATCHes. This is the passthrough FIXING the silent field
+    * loss the typed rebuild used to cause -- a clean Anthropic request is now
+    * byte-identical regardless of which fields the typed IR models. */
+   cJSON *unmodeled = cJSON_Parse(
        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
        "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}],"
        "\"top_p\":0.9}");
-   assert(lossy);
-   aimee_ir_shadow_observe_request(lossy, AIMEE_WIRE_ANTHROPIC);
+   assert(unmodeled);
+   aimee_ir_shadow_observe_request(unmodeled, AIMEE_WIRE_ANTHROPIC);
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 2);          /* parsed + observed */
-   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 1); /* dropped top_p */
-   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MATCH) == 1);    /* still just the first */
-   cJSON_Delete(lossy);
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MATCH) == 2);    /* both byte-identical */
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 0); /* passthrough preserves all */
+   cJSON_Delete(unmodeled);
 
    /* NULL request is safe */
    aimee_ir_shadow_observe_request(NULL, AIMEE_WIRE_ANTHROPIC);


### PR DESCRIPTION
Step 2 of the IR-canonical-funnel program (all LLM traffic ingress → IR → egress, delete legacy). Enables step 3: flipping the Anthropic-native path onto the IR and deleting the verbatim `cJSON_Duplicate` passthrough.

## Why
Retiring the passthrough is only safe if the IR egress reproduces the client's **exact bytes** — Claude Code's prompt cache keys on them. `anthropic_backend_build` re-serialized entirely from the typed IR fields: it fixes its own key order and **drops any client field the IR doesn't model** (`top_p`, `metadata`, …). Faithful in meaning, not in bytes — as PR #1495's byte-parity metric now measures.

## Change
The IR already carries the fix: every level has a `raw` sidecar and the Anthropic frontend populates request/message/block `raw` with exact duplicates, precisely for lossless same-protocol replay. Use it — when the request is same-protocol Anthropic and **unmutated**, `anthropic_backend_build` returns `cJSON_Duplicate(ir->raw)`: byte-identical egress, cache preserved, and it *fixes* the silent field loss (`top_p` survives). A single `aimee_request_t.mutated` flag (default 0) keeps it correct-by-construction: a future IR transform that edits the typed fields sets it, forcing the typed rebuild.

## Safety
**Shadow-only in production** — `anthropic_backend_build` is only reached by `aimee_ir_shadow` today; the live Anthropic path still uses the legacy passthrough until step 3. So this just makes the byte-parity metric report MATCH on clean traffic (the evidence gate), with zero live-path change.

## Tests
- Backend build is **byte-identical** to the client request (raw passthrough).
- `ir->mutated=1` forces the typed rebuild (which drops the unmodeled `top_p`).
- The shadow round-trip now **MATCHes** the previously-"lossy" `top_p` request.
- Cross-protocol (OpenAI→Anthropic) unaffected (frontend ≠ Anthropic → typed build).

Server links; affected tests pass; full `make unit-tests` clean; `make build-integrity` green; clang-format-19 clean.