### PR TITLE
feat(ir): the single request transform stage (protocol-neutral module seam)

### DIFF
--- a/src/headers/aimee_ir.h
+++ b/src/headers/aimee_ir.h
@@ -244,4 +244,35 @@ aimee_stop_reason_t aimee_stop_reason_parse(const char *canonical_name);
  * identical IR -> identical KB input + identical backend build. */
 int aimee_ir_request_equal(const aimee_request_t *a, const aimee_request_t *b);
 
+/* ----- Request transform stage (the protocol-neutral module seam) -------------
+ * A transform edits the typed IR request in place BETWEEN frontend_parse and
+ * backend_build. This is where modules act ONCE, on the one IR, regardless of the
+ * client wire -- replacing the per-ingress, per-wire-format sites (gw_stage_memory's
+ * three arms, the economizer's gateway seams, tool policing, ...). Producer-specific
+ * translation stays at the edges (frontend/backend); everything here is neutral. */
+
+/* Edit `ir` in place; return nonzero IFF the typed fields (messages/system/tools/...)
+ * were CHANGED, so the caller sets ir->mutated and a same-protocol backend
+ * re-serializes instead of shipping the now-stale raw sidecar. A read-only transform
+ * (e.g. measurement) returns 0. */
+typedef int (*aimee_ir_transform_fn)(aimee_request_t *ir, void *ud);
+
+typedef struct
+{
+   const char *name; /* stable id, for ordering + trace */
+   aimee_ir_transform_fn fn;
+   void *ud;
+   int enabled; /* 0 -> the slot is skipped */
+} aimee_ir_transform_t;
+
+/* Run `stages` (length n) over `ir` in catalog order; skips disabled / empty-name /
+ * NULL-fn slots. Sets ir->mutated if any transform reports a change. NULL-safe. */
+void aimee_ir_run_transforms(aimee_request_t *ir, const aimee_ir_transform_t *stages, size_t n);
+
+/* The SINGLE request-transform stage every ingress funnels through: all three
+ * aimee_ir_serve build paths call this after frontend_parse and before
+ * backend_build. Modules are registered HERE (one place) as they are ported onto the
+ * IR. Empty today -> a no-op that leaves the request byte-identical to its sidecar. */
+void aimee_ir_apply_request_stages(aimee_request_t *ir);
+
 #endif /* DEC_AIMEE_IR_H */

--- a/src/server/aimee_ir.c
+++ b/src/server/aimee_ir.c
@@ -349,3 +349,27 @@ int aimee_ir_response_has_tool_use(const aimee_response_t *r)
          return 1;
    return 0;
 }
+
+void aimee_ir_run_transforms(aimee_request_t *ir, const aimee_ir_transform_t *stages, size_t n)
+{
+   if (!ir || !stages)
+      return;
+   for (size_t i = 0; i < n; i++)
+   {
+      const aimee_ir_transform_t *s = &stages[i];
+      if (!s->enabled || !s->fn || !s->name || !s->name[0])
+         continue;
+      if (s->fn(ir, s->ud))
+         ir->mutated = 1; /* a change means the raw sidecar is stale -> backend rebuilds */
+   }
+}
+
+void aimee_ir_apply_request_stages(aimee_request_t *ir)
+{
+   /* The one place modules hook the IR. No transforms are ported yet, so this is a
+    * no-op and the request stays byte-identical to its raw sidecar. As each module
+    * moves off its legacy wire-anchored site (memory's three arms, the economizer's
+    * gateway seams, tool policing), it is added to the catalog HERE -- fired once,
+    * protocol-neutral, for every ingress. */
+   aimee_ir_run_transforms(ir, NULL, 0);
+}

--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -78,6 +78,8 @@ char *aimee_ir_build_provider_body(const cJSON *req, const char *driver_name,
     * buffered-replay path ask for SSE and then parse it as JSON. */
    ir.stream = want_stream ? 1 : 0;
 
+   aimee_ir_apply_request_stages(&ir); /* the one protocol-neutral module stage (no-op today) */
+
    int is_responses = driver_name && strcmp(driver_name, "chatgpt") == 0;
    cJSON *prov = is_responses ? responses_backend_build(&ir) : openai_backend_build(&ir);
    aimee_request_free(&ir);
@@ -130,6 +132,8 @@ int aimee_ir_responses_to_chat(const char *body, char *model, size_t model_n,
       snprintf(model, model_n, "%s", ir.model);
    if (stream_out)
       *stream_out = ir.stream;
+
+   aimee_ir_apply_request_stages(&ir); /* the one protocol-neutral module stage (no-op today) */
 
    /* build the chat shape, then split leading system messages -> instructions */
    cJSON *chat = openai_backend_build(&ir);
@@ -225,6 +229,8 @@ cJSON *aimee_ir_build_from_chat(const char *agent_model, const cJSON *messages, 
       free(ir.model);
       ir.model = strdup(agent_model);
    }
+   aimee_ir_apply_request_stages(&ir); /* the one protocol-neutral module stage (no-op today) */
+
    int is_responses = driver_name && strcmp(driver_name, "chatgpt") == 0;
    cJSON *prov = is_responses ? responses_backend_build(&ir) : openai_backend_build(&ir);
    aimee_request_free(&ir);

--- a/src/tests/test_aimee_ir.c
+++ b/src/tests/test_aimee_ir.c
@@ -19,6 +19,21 @@ static aimee_block_t *mk_blocks(int n)
    return calloc((size_t)n, sizeof(aimee_block_t));
 }
 
+/* transform-stage test fns: t_count is read-only (returns 0, bumps a counter);
+ * t_change reports a mutation (returns 1). */
+static int t_count(aimee_request_t *ir, void *ud)
+{
+   (void)ir;
+   (*(int *)ud)++;
+   return 0;
+}
+static int t_change(aimee_request_t *ir, void *ud)
+{
+   (void)ir;
+   (void)ud;
+   return 1;
+}
+
 int main(void)
 {
    printf("aimee-ir: ");
@@ -149,6 +164,33 @@ int main(void)
    assert(aimee_ir_request_equal(&a, NULL) == 0);
    aimee_request_free(&a);
    aimee_request_free(&b);
+
+   /* --- request transform stage (the protocol-neutral module seam) --- */
+   {
+      aimee_request_t t;
+      memset(&t, 0, sizeof t);
+      int calls = 0;
+      aimee_ir_transform_t stages[] = {
+          {"reader", t_count, &calls, 1},   /* runs */
+          {"disabled", t_count, &calls, 0}, /* skipped: enabled=0 */
+          {"", t_count, &calls, 1},         /* skipped: empty name */
+          {"nofn", NULL, &calls, 1},        /* skipped: NULL fn */
+          {"mutator", t_change, NULL, 1},   /* runs, reports a change */
+      };
+      aimee_ir_run_transforms(&t, stages, sizeof(stages) / sizeof(stages[0]));
+      assert(calls == 1);     /* only "reader" ran among the counters */
+      assert(t.mutated == 1); /* mutator set it */
+
+      /* NULL-safe + empty catalog is a no-op */
+      t.mutated = 0;
+      aimee_ir_run_transforms(NULL, stages, 1); /* no crash */
+      aimee_ir_run_transforms(&t, NULL, 0);     /* no-op */
+      assert(t.mutated == 0);
+
+      /* the single apply hook has no transforms registered yet -> leaves ir unmutated */
+      aimee_ir_apply_request_stages(&t);
+      assert(t.mutated == 0);
+   }
 
    /* --- response accessors: the delegate path's replacement for
     *     parsed_response_t.content / .is_tool_call ---


### PR DESCRIPTION
Step 4 groundwork for the IR-canonical-funnel program (all LLM traffic ingress → IR → egress, one IR, delete legacy).

## Why
Every pluggable request module currently fires **pre-IR, at each ingress, on wire-format data** — which is why `gw_stage_memory` carries three per-target arms and the economizer duplicates its gateway seam per wire. The cure is **one hook on the typed IR**, between `frontend_parse` and `backend_build`, where a module acts once, protocol-neutral, for every ingress.

## The seam
- `aimee_ir_transform_fn` / `aimee_ir_transform_t` — a transform edits the typed IR in place and returns nonzero iff it **changed** the typed fields.
- `aimee_ir_run_transforms(ir, stages, n)` — runs the enabled catalog in order (skips disabled/empty-name/NULL-fn), and sets `ir->mutated` if any transform reports a change, so a same-protocol backend re-serializes instead of shipping the now-stale raw sidecar (ties into #1496's byte-faithful egress).
- `aimee_ir_apply_request_stages(ir)` — **the single stage every ingress funnels through**. All three `aimee_ir_serve` build paths call it after parse/adjust, before build.

## Safety
The catalog is **empty today → a no-op**: zero behavior change, requests stay byte-identical to their raw sidecar. Modules are registered **here, one place**, as each is ported off its legacy wire-anchored site (memory first, then the economizer as the one cache-safe IR-messages transform). Producer-specifics stay at the edges (frontend/backend); everything at this seam is neutral.

## Tests
Runner runs enabled slots in order, skips disabled/empty/NULL, sets `mutated` on a reported change, is NULL-safe; the apply hook is a no-op with nothing registered. Server links; full `make unit-tests` clean; `make build-integrity` green; clang-format-19 clean.

Next: port the first module (memory) onto this stage — collapsing its three wire arms into one IR transform — then the economizer.