### PR TITLE
feat(wfe): surface configured triggers in the Workflow Actions GUI

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -398,6 +398,15 @@ paths:
           content:
             application/json:
               schema: { type: object }
+  /workflow/triggers:
+    get:
+      summary: Configured trigger rules (aimee.yaml trigger_rules) that auto-start runs
+      responses:
+        "200":
+          description: "{max_concurrent,triggers:[{source,event,schedule,mode,template,workspace,max_spend_usd?}]}"
+          content:
+            application/json:
+              schema: { type: object }
   /workflow/defs/{name}:
     get:
       summary: One workflow definition (canonical form, version, node graph)

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -439,13 +439,20 @@ These are real today and worth knowing before you lean on workflows:
    agents — but all of them require a `proposal_md`: there is still no way to
    start a workflow whose entry node isn't `author.proposal` without supplying
    proposal text. (There is still no Run button on the **Edit Workflows** page.)
-2. **Forge operations are process-global.** Per-step blocks now resolve their
-   working directory from the work-item's `repo` (when it names a local
-   directory; `$AIMEE_WORKFLOW_REPO`/cwd otherwise), so a triggered run executes
-   in its configured workspace. But the forge half (`git push`, `gh pr …` via
-   the vaulted runner) still runs in the server's own checkout, so PR-opening
-   workflows against a workspace that is not the server's primary repo are not
-   yet fully wired.
+2. **Forge binding requires a local-path `repo`.** Every stage — the per-work-item
+   worktree, each step's working directory, *and* the forge half (`git push`,
+   the GitHub REST create/CI/merge, and the vaulted credential) — resolves its
+   directory from the work-item's `repo` via `wfe_repo_local()`. When `repo`
+   names a **local directory** (a trigger rule's absolute `pipeline.workspace`,
+   or an explicit dev-submit path) that repo wins end-to-end: the run's branch is
+   created in *that* checkout, pushed from *that* checkout, and the PR is opened
+   against the slug read from *that* checkout's `origin` — so a triggered
+   `watch-dir` run reaches a real PR in its configured workspace. The residual
+   gap is only when `repo` is **not** a local path — a bare `owner/name`
+   identifier or a clone URL — for which `wfe_repo_local()` falls back to
+   `$AIMEE_WORKFLOW_REPO`/cwd (the server's own checkout). So a dev-submit that
+   names a repo the server hasn't checked out is not yet workspace-isolated;
+   point the run at an absolute `pipeline.workspace`/`repo` path to bind it.
 3. **Composer ergonomics.** New steps are added disconnected; you wire order in
    the inspector. The **Edit Workflows** page has no live run/progress view — you
    start and watch runs on the separate **Workflow Actions** tab.

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -30,6 +30,16 @@ interface WfEvent {
   cost_usd: number;
   created_at: string;
 }
+// A configured trigger rule (aimee.yaml `trigger_rules`) that auto-starts runs.
+interface Trigger {
+  source: string;
+  event: string;
+  schedule: string;
+  mode: string;
+  template: string;
+  workspace: string;
+  max_spend_usd?: number;
+}
 
 const POLL_MS = 4000;
 const DRAFT_KEY = "aimee_proposal_draft"; // cleared on logout (App.tsx)
@@ -173,6 +183,8 @@ export default function WorkflowActions() {
   const [composing, setComposing] = useState(false);
   const [draft, setDraft] = useState<Draft>(loadDraft);
   const [defs, setDefs] = useState<string[]>([]);
+  const [triggers, setTriggers] = useState<Trigger[]>([]);
+  const [triggersOpen, setTriggersOpen] = useState(true);
   const [submitMsg, setSubmitMsg] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const afterRef = useRef(0); // events pagination cursor for the open proposal
@@ -192,6 +204,10 @@ export default function WorkflowActions() {
     getJSON<{ defs: { name: string }[] }>("/api/workflow/defs")
       .then((d) => setDefs((d.defs || []).map((x) => x.name)))
       .catch(() => setDefs([]));
+    // Configured trigger rules — what auto-starts runs (read-only view).
+    getJSON<{ triggers: Trigger[] }>("/api/workflow/triggers")
+      .then((d) => setTriggers(d.triggers || []))
+      .catch(() => setTriggers([]));
   }, [refreshList]);
 
   // Persist the in-progress draft locally (device-local; cleared on logout).
@@ -442,6 +458,11 @@ export default function WorkflowActions() {
             <InlineStatus status={status} />
           </div>
         )}
+        <TriggersPanel
+          triggers={triggers}
+          open={triggersOpen}
+          onToggle={() => setTriggersOpen((v) => !v)}
+        />
         <div style={{ marginTop: 8 }}>
           {items.length === 0 && (
             <EmptyState message="No proposals yet." inline />
@@ -584,6 +605,93 @@ export default function WorkflowActions() {
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+// The configured trigger rules that auto-start runs, rendered as a compact,
+// collapsible section above the run list. This is the GUI's answer to "what is
+// wired to fire a workflow, and which workflow does it start" — read-only; rules
+// are edited in aimee.yaml. Empty => a hint that runs start only from a manual
+// submit (the + New proposal button).
+function TriggersPanel({
+  triggers,
+  open,
+  onToggle,
+}: {
+  triggers: Trigger[];
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div style={{ marginTop: 10, borderTop: "1px solid #eee", paddingTop: 8 }}>
+      <div
+        onClick={onToggle}
+        style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", userSelect: "none" }}
+      >
+        <span style={{ fontSize: 11, color: "#999", width: 10 }}>{open ? "▾" : "▸"}</span>
+        <span style={{ fontWeight: 600, fontSize: 13 }}>⚡ Triggers</span>
+        <Badge label={`${triggers.length}`} variant="neutral" />
+        <span style={{ marginLeft: "auto", fontSize: 11, color: "#aaa" }}>auto-start</span>
+      </div>
+      {open && (
+        <div style={{ marginTop: 6 }}>
+          {triggers.length === 0 ? (
+            <div style={{ fontSize: 12, color: "#999", lineHeight: 1.4 }}>
+              No triggers configured — runs start from a manual submit (+ New proposal). Add a{" "}
+              <code>trigger_rules</code> entry in <code>aimee.yaml</code> to auto-start runs.
+            </div>
+          ) : (
+            triggers.map((t, i) => <TriggerCard key={i} t={t} />)
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// One trigger rule as a compact card: what fires it (source + event/schedule),
+// which workflow it starts, how it runs (mode), and where (workspace).
+function TriggerCard({ t }: { t: Trigger }) {
+  const isCron = t.source === "cron";
+  const isWatch = t.source === "watch-dir" || t.source === "proposals";
+  // The "fires when" phrase, per source: a watched dir, a cron schedule, else the raw event.
+  const fires = isCron
+    ? `cron ${t.schedule || "(unset)"}`
+    : isWatch
+      ? `watches ${t.event || "docs/proposals/pending"}`
+      : t.event || t.source;
+  const interactive = t.mode === "interactive";
+  return (
+    <div
+      style={{
+        border: "1px solid #f0f0f0",
+        borderRadius: 6,
+        padding: "6px 8px",
+        marginBottom: 4,
+        background: "#fafbfc",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+        <Badge label={t.source} variant="running" />
+        <span style={{ fontSize: 12, color: "#555", overflowWrap: "anywhere" }}>{fires}</span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 4, flexWrap: "wrap" }}>
+        <span style={{ fontSize: 11, color: "#999" }}>→</span>
+        <span style={{ fontSize: 12, fontWeight: 600 }}>{t.template || "(no workflow)"}</span>
+        <Badge
+          label={interactive ? "interactive" : "autonomous"}
+          variant={interactive ? "warning" : "success"}
+        />
+      </div>
+      {t.workspace && (
+        <div style={{ fontSize: 11, color: "#aaa", fontFamily: "monospace", marginTop: 3, overflowWrap: "anywhere" }}>
+          {t.workspace}
+          {typeof t.max_spend_usd === "number" && t.max_spend_usd > 0
+            ? ` · cap $${t.max_spend_usd.toFixed(2)}`
+            : ""}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -779,6 +779,11 @@ static int rh_wf_list(const route_req_t *rq, char *resp, int cap)
    (void)rq;
    return wf_api_list(resp, cap);
 }
+static int rh_wf_triggers(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   return wf_api_triggers(resp, cap);
+}
 static int rh_wf_get(const route_req_t *rq, char *resp, int cap)
 {
    return wf_api_get(rq->id, resp, cap);
@@ -1771,6 +1776,7 @@ static const http_route_t g_v1_routes[] = {
     {"DELETE", "/v1/workflow/blocks/", NULL, RM_PREFIX, NULL, CAP_SESSION_ADMIN,
      rh_wf_block_delete},
     {"GET", "/v1/workflow/defs", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_list},
+    {"GET", "/v1/workflow/triggers", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_triggers},
     {"GET", "/v1/workflow/defs/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_get},
     {"POST", "/v1/workflow/validate", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_validate},
     {"POST", "/v1/workflow/save", NULL, RM_EXACT, NULL, CAP_SESSION_ADMIN, rh_wf_save},

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -20,6 +20,7 @@
 
 #include "aimee_home.h"
 #include "cJSON.h"
+#include "config.h" /* trigger_rule_t / config_load — surface configured trigger rules */
 #include "server_http_identity.h" /* server_http_identity_principal — ownership scoping */
 #include "wfe_def.h"
 #include "wfe_engine.h" /* wfe_load_workflow — roundtable-park resume check */
@@ -209,6 +210,49 @@ int wf_api_blocks(char *resp, int cap)
          cJSON_AddItemToArray(acc, cJSON_CreateString(wfe_artifact_name(c->consumes)));
       cJSON_AddItemToArray(arr, b);
    }
+   return emit(o, resp, cap);
+}
+
+/* GET /v1/workflow/triggers -- the configured trigger rules (aimee.yaml
+ * `trigger_rules`) that auto-start workflow runs, so the GUI can show *what* is
+ * wired to fire a run and *which* workflow it starts. Read-only view of the
+ * live config; empty `triggers` means no rule is configured (runs start only
+ * from a manual submit). Each rule mirrors trigger_rule_t plus the effective
+ * defaults the scheduler applies, so the UI need not re-derive them. */
+int wf_api_triggers(char *resp, int cap)
+{
+   config_t *cfg = calloc(1, sizeof *cfg);
+   if (!cfg)
+   {
+      snprintf(resp, cap, "{\"error\":\"out of memory\"}");
+      return 500;
+   }
+   config_load(cfg);
+
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddNumberToObject(o, "max_concurrent", cfg->trigger_max_concurrent);
+   cJSON *arr = cJSON_AddArrayToObject(o, "triggers");
+   for (int i = 0; i < cfg->trigger_rule_count && i < TRIGGER_RULES_MAX; i++)
+   {
+      const trigger_rule_t *r = &cfg->trigger_rules[i];
+      /* A watch-dir/proposals rule watches a repo-relative directory (its
+       * `event`), defaulting to docs/proposals/pending when unset. */
+      int is_watch = strcmp(r->source, "watch-dir") == 0 || strcmp(r->source, "proposals") == 0;
+      cJSON *t = cJSON_CreateObject();
+      cJSON_AddStringToObject(t, "source", r->source);
+      cJSON_AddStringToObject(t, "event",
+                              r->event[0] ? r->event
+                                          : (is_watch ? "docs/proposals/pending" : ""));
+      cJSON_AddStringToObject(t, "schedule", r->schedule);
+      /* Empty mode => autonomous (the scheduler default). */
+      cJSON_AddStringToObject(t, "mode", r->mode[0] ? r->mode : "autonomous");
+      cJSON_AddStringToObject(t, "template", r->pipeline_template);
+      cJSON_AddStringToObject(t, "workspace", r->workspace);
+      if (r->max_spend_usd != 0.0)
+         cJSON_AddNumberToObject(t, "max_spend_usd", r->max_spend_usd);
+      cJSON_AddItemToArray(arr, t);
+   }
+   free(cfg);
    return emit(o, resp, cap);
 }
 

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -241,8 +241,7 @@ int wf_api_triggers(char *resp, int cap)
       cJSON *t = cJSON_CreateObject();
       cJSON_AddStringToObject(t, "source", r->source);
       cJSON_AddStringToObject(t, "event",
-                              r->event[0] ? r->event
-                                          : (is_watch ? "docs/proposals/pending" : ""));
+                              r->event[0] ? r->event : (is_watch ? "docs/proposals/pending" : ""));
       cJSON_AddStringToObject(t, "schedule", r->schedule);
       /* Empty mode => autonomous (the scheduler default). */
       cJSON_AddStringToObject(t, "mode", r->mode[0] ? r->mode : "autonomous");

--- a/src/server/server_workflow_api.h
+++ b/src/server/server_workflow_api.h
@@ -20,6 +20,11 @@ int wf_api_block_delete(const char *name, char *resp, int cap);
  * $AIMEE_HOME/workflows (name + valid + version). */
 int wf_api_list(char *resp, int cap);
 
+/* GET /v1/workflow/triggers -- the configured trigger rules (aimee.yaml
+ * `trigger_rules`) that auto-start runs. Returns {max_concurrent, triggers:[
+ * {source,event,schedule,mode,template,workspace,max_spend_usd?}]}. Read-only. */
+int wf_api_triggers(char *resp, int cap);
+
 /* GET /v1/workflow/defs/{name} -- one definition: canonical form, version, and a
  * structured node graph for rendering. 400 on an unsafe name, 404 if missing. */
 int wf_api_get(const char *name, char *resp, int cap);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1738,12 +1738,22 @@ $(TESTPREFIX)/unit-test-workflow-gate-caps: $(OBJDIR)/tests/test_workflow_gate_c
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 # Workflow visual composer (W7): /v1/workflow read+author handlers.
+# wf_api_triggers reads the live config's trigger_rules via config_load, so this
+# target links config.o + its section modules. check-linking pairs config.o with
+# platform_random.o (config draws entropy) — keep both here or build-integrity fails.
 $(TESTPREFIX)/unit-test-wfe-webapi: $(OBJDIR)/tests/test_wfe_webapi.o \
                                     $(OBJDIR)/server/server_workflow_api.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                     $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
                                     $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o \
+                                    $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o \
+                                    $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o \
+                                    $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o \
+                                    $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o $(OBJDIR)/config_mode.o \
+                                    $(OBJDIR)/config_fields.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
+                                    $(OBJDIR)/platform_random.o \
                                     $(OBJDIR)/aimee_home.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/support/workflow_api_stub.c
+++ b/src/tests/support/workflow_api_stub.c
@@ -36,6 +36,10 @@ int wf_api_list(char *resp, int cap)
 {
    return stub(resp, cap);
 }
+int wf_api_triggers(char *resp, int cap)
+{
+   return stub(resp, cap);
+}
 int wf_api_get(const char *name, char *resp, int cap)
 {
    (void)name;

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -311,7 +311,8 @@ int main(void)
                     "/srv/repos/demo") == 0);
       cJSON *c = cJSON_GetArrayItem(trigs, 1);
       assert(strcmp(cJSON_GetObjectItemCaseSensitive(c, "source")->valuestring, "cron") == 0);
-      assert(strcmp(cJSON_GetObjectItemCaseSensitive(c, "schedule")->valuestring, "0 * * * *") == 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(c, "schedule")->valuestring, "0 * * * *") ==
+             0);
       assert(strcmp(cJSON_GetObjectItemCaseSensitive(c, "mode")->valuestring, "interactive") == 0);
       cJSON_Delete(o);
       unlink(p); /* keep the rest of the suite config-free */

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -266,6 +266,57 @@ int main(void)
       cJSON_Delete(o);
    }
 
+   /* --- triggers: none configured (no aimee.yaml) → empty list + default cap --- */
+   {
+      assert(wf_api_triggers(buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      cJSON *trigs = cJSON_GetObjectItemCaseSensitive(o, "triggers");
+      assert(cJSON_IsArray(trigs) && cJSON_GetArraySize(trigs) == 0);
+      assert(cJSON_HasObjectItem(o, "max_concurrent"));
+      cJSON_Delete(o);
+   }
+
+   /* --- triggers: a configured watch-dir rule surfaces with its effective
+    * defaults (empty event → docs/proposals/pending, empty mode → autonomous). --- */
+   {
+      char p[256];
+      snprintf(p, sizeof p, "%s/aimee.yaml", home);
+      FILE *f = fopen(p, "wb");
+      assert(f);
+      fputs("trigger_rules:\n"
+            "  - source: watch-dir\n"
+            "    pipeline:\n"
+            "      template: build\n"
+            "      workspace: /srv/repos/demo\n"
+            "  - source: cron\n"
+            "    schedule: \"0 * * * *\"\n"
+            "    mode: interactive\n"
+            "    pipeline:\n"
+            "      template: nightly\n",
+            f);
+      fclose(f);
+
+      assert(wf_api_triggers(buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      cJSON *trigs = cJSON_GetObjectItemCaseSensitive(o, "triggers");
+      assert(cJSON_IsArray(trigs) && cJSON_GetArraySize(trigs) == 2);
+      cJSON *w = cJSON_GetArrayItem(trigs, 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(w, "source")->valuestring, "watch-dir") == 0);
+      /* empty event defaults to the proposals dir; empty mode defaults to autonomous */
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(w, "event")->valuestring,
+                    "docs/proposals/pending") == 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(w, "mode")->valuestring, "autonomous") == 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(w, "template")->valuestring, "build") == 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(w, "workspace")->valuestring,
+                    "/srv/repos/demo") == 0);
+      cJSON *c = cJSON_GetArrayItem(trigs, 1);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(c, "source")->valuestring, "cron") == 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(c, "schedule")->valuestring, "0 * * * *") == 0);
+      assert(strcmp(cJSON_GetObjectItemCaseSensitive(c, "mode")->valuestring, "interactive") == 0);
+      cJSON_Delete(o);
+      unlink(p); /* keep the rest of the suite config-free */
+   }
+
    /* --- run-state: empty list + unknown item 404 --- */
    {
       assert(wf_api_items(buf, CAP) == 200);

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -193,6 +193,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/workflow/blocks/", s.requireAuth(s.handleWorkflowBlockItem))
 	mux.HandleFunc("/api/workflow/defs", s.requireAuth(s.handleWorkflowDefs))
 	mux.HandleFunc("/api/workflow/defs/", s.requireAuth(s.handleWorkflowDefs))
+	mux.HandleFunc("/api/workflow/triggers", s.requireAuth(s.handleWorkflowTriggers))
 	mux.HandleFunc("/api/workflow/validate", s.requireAuth(s.handleWorkflowValidate))
 	mux.HandleFunc("/api/workflow/save", s.requireAuth(s.handleWorkflowSave))
 	mux.HandleFunc("/api/workflow/items", s.requireAuth(s.handleWorkflowItems))

--- a/webchat/workflow.go
+++ b/webchat/workflow.go
@@ -110,6 +110,11 @@ func (s *server) handleWorkflowDefs(w http.ResponseWriter, r *http.Request) {
 	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/defs/", "/api/workflow/defs/")
 }
 
+// GET /api/workflow/triggers — the configured trigger rules that auto-start runs.
+func (s *server) handleWorkflowTriggers(w http.ResponseWriter, r *http.Request) {
+	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/triggers", "")
+}
+
 // POST /api/workflow/validate — validate posted YAML without saving.
 func (s *server) handleWorkflowValidate(w http.ResponseWriter, r *http.Request) {
 	s.proxyWorkflow(w, r, http.MethodPost, "/v1/workflow/validate", "")


### PR DESCRIPTION
## Summary

Two related changes toward "a WFE proposal flows cleanly from proposal to an open PR, with triggers visible."

### 1. Surface configured triggers in the Workflow Actions GUI
`trigger_rules` (what auto-starts runs) were only inspectable by reading `aimee.yaml`. Now they're shown on the Workflow Actions tab:

- **`GET /v1/workflow/triggers`** (`wf_api_triggers`) — reads the live config and returns each rule with its *effective* defaults resolved (empty event → `docs/proposals/pending`, empty mode → `autonomous`), plus `max_concurrent`.
- **webchat proxy** `/api/workflow/triggers`.
- **A collapsible "⚡ Triggers" panel** above the run list: source, watched dir / cron schedule, `→` target workflow, autonomous/interactive badge, workspace + spend cap. Empty state points at *+ New proposal*.

### 2. Correct the stale "forge is process-global" limitation (docs)
While investigating the proposal→PR path I found `WORKFLOWS.md` limitation #2 is out of date. The forge half already resolves its directory from the work-item `repo` via `wfe_repo_local()` — same as the worktree and per-step blocks — and `git_pr_api` reads the owner/repo slug + credential from that directory's `origin`. So a triggered `watch-dir` run (work-item `repo` = the rule's absolute `pipeline.workspace`) creates/pushes its branch and opens its PR in that workspace, not the server's checkout. Restated the actual residual: binding requires a local-**path** `repo`; a bare `owner/name`/URL still falls back to `$AIMEE_WORKFLOW_REPO`/cwd.

## Testing
- New `wf_api_triggers` case in `test_wfe_webapi.c` (default resolution + a cron rule). The handler reads the live config, so `unit-test-wfe-webapi` now links `config.o` (+ `platform_random.o` per `check-linking`).
- `make server` ✓, `make build-integrity` ✓ (`all test targets with config.o also link platform_random.o`), `go test ./...` ✓ (webchat), frontend `tsc` + `vite build` ✓.
- Forge workspace-binding invariant is covered by existing `test_wfe_blocks.c` `wfe_repo_local` cases.
