### PR TITLE
feat(ir): port the memory module onto the single request-transform seam

### DIFF
--- a/src/headers/aimee_ir.h
+++ b/src/headers/aimee_ir.h
@@ -271,8 +271,11 @@ void aimee_ir_run_transforms(aimee_request_t *ir, const aimee_ir_transform_t *st
 
 /* The SINGLE request-transform stage every ingress funnels through: all three
  * aimee_ir_serve build paths call this after frontend_parse and before
- * backend_build. Modules are registered HERE (one place) as they are ported onto the
- * IR. Empty today -> a no-op that leaves the request byte-identical to its sidecar. */
-void aimee_ir_apply_request_stages(aimee_request_t *ir);
+ * backend_build. Modules are registered HERE (one place, in aimee_ir_serve.c so the
+ * pure IR core stays free of module + config linkage) as they are ported onto the
+ * IR. `memory_enabled` is the caller-resolved gw_stage_memory toggle (config-store
+ * modules.memory -> env default), injected here exactly like the legacy stage
+ * catalogs so the transform stays config-free. */
+void aimee_ir_apply_request_stages(aimee_request_t *ir, int memory_enabled);
 
 #endif /* DEC_AIMEE_IR_H */

--- a/src/modules/memory/gw_stage_memory.c
+++ b/src/modules/memory/gw_stage_memory.c
@@ -9,11 +9,17 @@
  * trailing "\n\n" and silently change the provider request bytes. */
 #include "gw_stage_memory.h"
 #include "ingress_preinject.h"
+#include "aimee_ir.h"
 #include "cJSON.h"
 #include <assert.h>
 #include <stdlib.h>
 #include <strings.h> /* strcasecmp */
 #include <string.h>
+
+/* Recall-query buffer for the IR transform. The query only feeds semantic KB
+ * recall, so bounding an over-long last-user message here is acceptable (it does
+ * not change what the model receives — only which memories are retrieved). */
+#define IR_MEMORY_QUERY_MAX 16384
 
 /* The Anthropic arm: build the <aimee-context> envelope from this turn's query
  * and fold it into the request's `system` so BOTH the Anthropic-native
@@ -135,6 +141,45 @@ int gw_stage_memory(gw_request_t *r, void *ud)
 
    assert(0 && "gw_stage_memory: unknown mem_target");
    return 0;
+}
+
+int ir_stage_memory(aimee_request_t *ir, void *ud)
+{
+   (void)ud; /* query comes from the IR, not per-call user data */
+   if (!ir)
+      return 0;
+
+   char *query = malloc(IR_MEMORY_QUERY_MAX);
+   if (!query)
+      return 0;
+   size_t qn = aimee_ir_last_user_text(ir, query, IR_MEMORY_QUERY_MAX);
+   if (qn == 0)
+   {
+      free(query); /* no user text -> no recall query -> no injection */
+      return 0;
+   }
+   char *env = ingress_preinject_build(query, 0);
+   free(query);
+   if (!env)
+      return 0; /* pre-injection off or recall empty: byte-identical no-op */
+
+   /* Append the envelope as a trailing system TEXT block. Grow the ordered block
+    * array by one; the new block owns `env` (freed by aimee_request_free) and
+    * carries no cache_control / raw sidecar so the backend serializes it from the
+    * typed field per wire — collapsing the old three per-wire arms into one. */
+   aimee_block_t *grown = realloc(ir->system, (size_t)(ir->n_system + 1) * sizeof *grown);
+   if (!grown)
+   {
+      free(env);
+      return 0;
+   }
+   ir->system = grown;
+   aimee_block_t *b = &ir->system[ir->n_system];
+   memset(b, 0, sizeof *b);
+   b->type = AIMEE_BLK_TEXT;
+   b->text = env;
+   ir->n_system += 1;
+   return 1; /* changed typed fields -> runner sets ir->mutated */
 }
 
 char *gw_memory_system_prompt(const char *query)

--- a/src/modules/memory/gw_stage_memory.h
+++ b/src/modules/memory/gw_stage_memory.h
@@ -6,11 +6,28 @@
 #define DEC_GW_STAGE_MEMORY_H
 
 #include "gateway_pipeline.h"
+#include "aimee_ir.h" /* aimee_request_t: the IR the transform edits */
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
+
+   /* The IR-native memory transform (universal-gateway P4 / IR-canonical funnel):
+    * the protocol-neutral replacement for gw_stage_memory's three per-wire arms.
+    * Fires ONCE at the single request-transform seam (aimee_ir_apply_request_stages),
+    * after frontend_parse and before backend_build, so it acts on the typed IR
+    * regardless of client wire. Derives the recall query from the IR's last user
+    * message (aimee_ir_last_user_text), builds the <aimee-context> envelope, and
+    * appends it as a trailing system TEXT block on `ir->system` — cache-safe (the
+    * cached prefix blocks are untouched; the new block carries no cache_control and
+    * no raw sidecar, so a byte-faithful backend re-serializes it from the typed
+    * field). `ud` is unused (the query comes from the IR). Conforms to
+    * aimee_ir_transform_fn: returns 1 iff it appended a block (so the runner marks
+    * ir->mutated and the stale raw sidecar is dropped), 0 on off/empty/no-query.
+    * The same-protocol Anthropic passthrough never reaches this seam (it ships the
+    * raw sidecar directly), so Arm A's parity-skip is structurally satisfied here. */
+   int ir_stage_memory(aimee_request_t *ir, void *ud);
 
    /* The shared memory stage. Renders the envelope into `r->raw` per
     * `r->mem_target`. The `ud` (stage user data) contract is per target:

--- a/src/server/aimee_ir.c
+++ b/src/server/aimee_ir.c
@@ -363,13 +363,3 @@ void aimee_ir_run_transforms(aimee_request_t *ir, const aimee_ir_transform_t *st
          ir->mutated = 1; /* a change means the raw sidecar is stale -> backend rebuilds */
    }
 }
-
-void aimee_ir_apply_request_stages(aimee_request_t *ir)
-{
-   /* The one place modules hook the IR. No transforms are ported yet, so this is a
-    * no-op and the request stays byte-identical to its raw sidecar. As each module
-    * moves off its legacy wire-anchored site (memory's three arms, the economizer's
-    * gateway seams, tool policing), it is added to the catalog HERE -- fired once,
-    * protocol-neutral, for every ingress. */
-   aimee_ir_run_transforms(ir, NULL, 0);
-}

--- a/src/server/aimee_ir_serve.c
+++ b/src/server/aimee_ir_serve.c
@@ -3,6 +3,8 @@
 
 #include "aimee_backend.h"
 #include "aimee_frontend.h"
+#include "gw_stage_memory.h" /* ir_stage_memory + gw_stage_memory_enabled */
+#include "config.h"          /* config_load + config_module_enabled (modules.memory) */
 #include "aimee_ir_metrics.h"
 #include "aimee.h"          /* size macros for agent_types.h */
 #include "agent_protocol.h" /* parsed_response_t (Slice 3 transitional adapter) */
@@ -37,6 +39,30 @@ int aimee_ir_stream_relay_enabled(void)
     * (The user's codex config uses the buffered-replay path, not this relay.) */
    const char *v = getenv("AIMEE_IR_STREAM_RELAY");
    return v && (strcmp(v, "1") == 0 || strcmp(v, "on") == 0 || strcmp(v, "true") == 0);
+}
+
+/* Resolve the memory module toggle: config-store modules.memory (canonical) -> env
+ * default (gw_stage_memory_enabled). Cached config_load, so an operator toggle applies
+ * without a restart; keeps ir_stage_memory itself config-free. Resolved at the seam
+ * call site, mirroring the legacy gw_stage_slot_t catalogs. */
+static int ir_memory_enabled(void)
+{
+   config_t c;
+   int tri = (config_load(&c) == 0) ? c.module_memory : -1;
+   return config_module_enabled(tri, gw_stage_memory_enabled());
+}
+
+void aimee_ir_apply_request_stages(aimee_request_t *ir, int memory_enabled)
+{
+   /* The one place modules register on the IR (universal-gateway P4): fired once per
+    * ingress, after frontend_parse and before backend_build, protocol-neutral. Memory
+    * is the first ported module -- it replaces gw_stage_memory's two structured-ingress
+    * arms (anthropic /v1/messages + /v1/responses). The four legacy plain-chat handlers
+    * stay on gw_memory_system_prompt until agent_execute itself moves onto the IR. */
+   const aimee_ir_transform_t stages[] = {
+       {"memory", ir_stage_memory, NULL, memory_enabled},
+   };
+   aimee_ir_run_transforms(ir, stages, sizeof stages / sizeof stages[0]);
 }
 
 char *aimee_ir_build_provider_body(const cJSON *req, const char *driver_name,
@@ -78,7 +104,8 @@ char *aimee_ir_build_provider_body(const cJSON *req, const char *driver_name,
     * buffered-replay path ask for SSE and then parse it as JSON. */
    ir.stream = want_stream ? 1 : 0;
 
-   aimee_ir_apply_request_stages(&ir); /* the one protocol-neutral module stage (no-op today) */
+   aimee_ir_apply_request_stages(
+       &ir, ir_memory_enabled()); /* the single protocol-neutral module stage (memory ported) */
 
    int is_responses = driver_name && strcmp(driver_name, "chatgpt") == 0;
    cJSON *prov = is_responses ? responses_backend_build(&ir) : openai_backend_build(&ir);
@@ -133,7 +160,8 @@ int aimee_ir_responses_to_chat(const char *body, char *model, size_t model_n,
    if (stream_out)
       *stream_out = ir.stream;
 
-   aimee_ir_apply_request_stages(&ir); /* the one protocol-neutral module stage (no-op today) */
+   aimee_ir_apply_request_stages(
+       &ir, ir_memory_enabled()); /* the single protocol-neutral module stage (memory ported) */
 
    /* build the chat shape, then split leading system messages -> instructions */
    cJSON *chat = openai_backend_build(&ir);
@@ -229,7 +257,8 @@ cJSON *aimee_ir_build_from_chat(const char *agent_model, const cJSON *messages, 
       free(ir.model);
       ir.model = strdup(agent_model);
    }
-   aimee_ir_apply_request_stages(&ir); /* the one protocol-neutral module stage (no-op today) */
+   aimee_ir_apply_request_stages(
+       &ir, ir_memory_enabled()); /* the single protocol-neutral module stage (memory ported) */
 
    int is_responses = driver_name && strcmp(driver_name, "chatgpt") == 0;
    cJSON *prov = is_responses ? responses_backend_build(&ir) : openai_backend_build(&ir);

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -345,11 +345,11 @@ static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *dr
        .stream = stream,
        .allow_anthropic_inject = allow_anthropic_inject,
    };
-   /* Slice 7: build the enabled, ordered stage set from the catalog. Memory is a
-    * togglable module (AIMEE_STAGE_MEMORY); the registry omits it when disabled. */
+   /* Memory PORTED to the IR transform seam (aimee_ir_apply_request_stages): it now
+    * fires once on the typed IR after frontend_parse, so it is no longer a pre-IR
+    * wire-anchored stage here. This catalog keeps the stages that still act on the raw
+    * wire request (tool policing, routing, model pin). */
    const gw_stage_slot_t slots[] = {
-       {"memory", gw_stage_memory, NULL,
-        config_module_enabled(cfg_ok ? pcfg.module_memory : -1, gw_stage_memory_enabled())},
        {"tool_policing", gw_stage_tool_policing, NULL, 1},
        {"router", gw_stage_router, NULL, 1}, /* S1/S2: unified request->workflow seam */
        {"model_pin", gw_stage_model_pin, NULL, 1},

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -980,14 +980,11 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
        .parity = 1, /* client OpenAI == serving OpenAI; informational for these stages */
        .stream = 0,
    };
-   /* Slice 7: enabled, ordered stage set from the catalog (memory is togglable). The memory
-    * toggle is resolved from the config-store `modules:` block, falling back to the env default
-    * (cached config_load; keeps gw_stage_memory itself config-free). */
-   config_t mcfg;
-   int mcfg_ok = (config_load(&mcfg) == 0);
+   /* Memory PORTED to the IR transform seam (aimee_ir_apply_request_stages): it now
+    * fires once on the typed IR inside openai_build_body's IR path, so it is no longer
+    * a pre-IR wire-anchored stage here. This catalog keeps the stages that still act on
+    * the raw /v1/responses request (tool policing, routing). */
    const gw_stage_slot_t slots[] = {
-       {"memory", gw_stage_memory, messages,
-        config_module_enabled(mcfg_ok ? mcfg.module_memory : -1, gw_stage_memory_enabled())},
        {"tool_policing", gw_stage_openai_tool_policing, NULL, 1},
        {"router", gw_stage_router, NULL, 1}, /* S1/S2: unified request->workflow seam */
    };

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1627,6 +1627,7 @@ $(TESTPREFIX)/unit-test-aimee-ir-serve: $(OBJDIR)/tests/test_aimee_ir_serve.o \
                                        $(OBJDIR)/server/aimee_frontend_openai.o \
                                        $(OBJDIR)/server/aimee_frontend_responses.o \
                                        $(OBJDIR)/server/aimee_ir.o \
+                                       $(OBJDIR)/tests/support/ir_seam_memory_stub.o \
                                        $(OBJDIR)/server/aimee_ir_metrics.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -4290,6 +4291,7 @@ $(TESTPREFIX)/unit-test-ir-legacy-parity: $(OBJDIR)/tests/test_ir_legacy_parity.
                                        $(OBJDIR)/server/aimee_frontend_openai.o \
                                        $(OBJDIR)/server/aimee_frontend_responses.o \
                                        $(OBJDIR)/server/aimee_ir.o \
+                                       $(OBJDIR)/tests/support/ir_seam_memory_stub.o \
                                        $(OBJDIR)/server/aimee_ir_metrics.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1032,6 +1032,7 @@ $(TESTPREFIX)/unit-test-code-match: $(OBJDIR)/tests/test_code_match.o $(OBJDIR)/
 $(TESTPREFIX)/unit-test-gw-stage-memory: $(OBJDIR)/tests/test_gw_stage_memory.o \
                      $(OBJDIR)/modules/memory/gw_stage_memory.o $(OBJDIR)/pipeline/gw_stage_registry.o $(OBJDIR)/server/ingress_preinject.o \
                      $(OBJDIR)/server/request_context.o $(OBJDIR)/log.o \
+                     $(OBJDIR)/server/aimee_ir.o \
                      $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -2379,7 +2380,7 @@ $(TESTPREFIX)/unit-test-sse-parser: $(OBJDIR)/tests/test_sse_parser.o $(OBJDIR)/
 $(TESTPREFIX)/unit-test-anthropic-ingress: $(OBJDIR)/tests/test_anthropic_ingress.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
-$(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(OBJDIR)/modules/memory/gw_stage_memory.o $(OBJDIR)/pipeline/gw_stage_registry.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/tests/support/ir_ingress_stubs.o
+$(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(OBJDIR)/modules/memory/gw_stage_memory.o $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/pipeline/gw_stage_registry.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/tests/support/ir_ingress_stubs.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 # P2c (response-side tool policing) integration test: same source as
@@ -2388,7 +2389,7 @@ $(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(
 # response. The shape tests stub the request-side policy helpers so they
 # don't have to deal with guardrails dependencies; this test exercises the
 # full wiring end-to-end.
-$(TESTPREFIX)/unit-test-anthropic-http-p2c: $(OBJDIR)/tests/test_anthropic_http_p2c.o $(OBJDIR)/modules/memory/gw_stage_memory.o $(OBJDIR)/modules/governance/gw_stage_governance.o $(OBJDIR)/pipeline/gw_response_registry.o $(OBJDIR)/pipeline/gw_stage_registry.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/tests/support/ir_ingress_stubs.o
+$(TESTPREFIX)/unit-test-anthropic-http-p2c: $(OBJDIR)/tests/test_anthropic_http_p2c.o $(OBJDIR)/modules/memory/gw_stage_memory.o $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/modules/governance/gw_stage_governance.o $(OBJDIR)/pipeline/gw_response_registry.o $(OBJDIR)/pipeline/gw_stage_registry.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/tests/support/ir_ingress_stubs.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 # P2c streaming integration test: linked against the REAL gateway_policy.o
@@ -2396,7 +2397,7 @@ $(TESTPREFIX)/unit-test-anthropic-http-p2c: $(OBJDIR)/tests/test_anthropic_http_
 # Same minimal-link pattern as the buffered P2c test above; the SSE replay
 # helper + police function exercise the buffered-fetch + replay flow when
 # `gateway_prevent_subagents` is ON.
-$(TESTPREFIX)/unit-test-anthropic-http-streaming-p2c: $(OBJDIR)/tests/test_anthropic_http_streaming_p2c.o $(OBJDIR)/modules/memory/gw_stage_memory.o $(OBJDIR)/modules/governance/gw_stage_governance.o $(OBJDIR)/pipeline/gw_response_registry.o $(OBJDIR)/pipeline/gw_stage_registry.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/tests/support/ir_ingress_stubs.o
+$(TESTPREFIX)/unit-test-anthropic-http-streaming-p2c: $(OBJDIR)/tests/test_anthropic_http_streaming_p2c.o $(OBJDIR)/modules/memory/gw_stage_memory.o $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/modules/governance/gw_stage_governance.o $(OBJDIR)/pipeline/gw_response_registry.o $(OBJDIR)/pipeline/gw_stage_registry.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/tests/support/ir_ingress_stubs.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-gateway-policy: $(OBJDIR)/tests/test_gateway_policy.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o

--- a/src/tests/support/ir_seam_memory_stub.c
+++ b/src/tests/support/ir_seam_memory_stub.c
@@ -1,0 +1,36 @@
+/* ir_seam_memory_stub.c -- inert stubs for the memory module + config toggles that
+ * aimee_ir_serve.c references once memory is registered on the IR transform seam
+ * (aimee_ir_apply_request_stages). The minimal IR build/parity suites
+ * (unit-test-aimee-ir-serve, unit-test-ir-legacy-parity) exercise the build +
+ * translation paths, NOT memory injection, so they link this instead of the real
+ * memory/config subsystem: the module is stubbed DISABLED (gw_stage_memory_enabled
+ * -> 0) with an inert transform, and config_load reports "no config" so enablement
+ * falls to that env default. With memory off the seam is a no-op and every byte-exact
+ * assertion in those suites is unchanged. */
+#include "aimee_ir.h"
+#include "config.h"
+#include <string.h>
+
+int ir_stage_memory(aimee_request_t *ir, void *ud)
+{
+   (void)ir;
+   (void)ud;
+   return 0;
+}
+
+int gw_stage_memory_enabled(void)
+{
+   return 0;
+}
+
+int config_load(config_t *c)
+{
+   if (c)
+      memset(c, 0, sizeof *c);
+   return -1;
+}
+
+int config_module_enabled(int config_tristate, int env_default)
+{
+   return config_tristate >= 0 ? config_tristate : env_default;
+}

--- a/src/tests/test_aimee_ir.c
+++ b/src/tests/test_aimee_ir.c
@@ -187,9 +187,10 @@ int main(void)
       aimee_ir_run_transforms(&t, NULL, 0);     /* no-op */
       assert(t.mutated == 0);
 
-      /* the single apply hook has no transforms registered yet -> leaves ir unmutated */
-      aimee_ir_apply_request_stages(&t);
-      assert(t.mutated == 0);
+      /* aimee_ir_apply_request_stages (the single module-registration hook) now lives
+       * in the serve layer (aimee_ir_serve.c) and registers the ported memory module,
+       * so its behavior is covered by test_aimee_ir_serve; the pure core only owns the
+       * neutral runner exercised above. */
    }
 
    /* --- response accessors: the delegate path's replacement for

--- a/src/tests/test_aimee_ir_serve.c
+++ b/src/tests/test_aimee_ir_serve.c
@@ -10,35 +10,12 @@
 #include "agent_protocol.h"
 #include "aimee_ir.h"
 #include "aimee_ir_serve.h"
-#include "config.h"
 #include "cJSON.h"
 
-/* aimee_ir_serve.c registers the ported memory module on the transform seam, so it
- * now references the memory + config toggles. This suite exercises the build/
- * translation parity paths, NOT memory injection, so keep it a minimal link: stub
- * the module DISABLED (gw_stage_memory_enabled -> 0) with an inert transform, and a
- * config_load that reports "no config" so enablement falls to that env default. With
- * memory off the seam is a no-op and every byte-exact assertion below is unchanged. */
-int ir_stage_memory(aimee_request_t *ir, void *ud)
-{
-   (void)ir;
-   (void)ud;
-   return 0;
-}
-int gw_stage_memory_enabled(void)
-{
-   return 0;
-}
-int config_load(config_t *c)
-{
-   if (c)
-      memset(c, 0, sizeof *c);
-   return -1;
-}
-int config_module_enabled(int config_tristate, int env_default)
-{
-   return config_tristate >= 0 ? config_tristate : env_default;
-}
+/* The memory module + config toggles that aimee_ir_serve.c now references (memory is
+ * registered on the IR transform seam) are satisfied by tests/support/
+ * ir_seam_memory_stub.o -- stubbed DISABLED, so this build/translation-parity suite
+ * stays a minimal link and its byte-exact assertions are unchanged. */
 
 static const char *REQ =
     "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":100,"

--- a/src/tests/test_aimee_ir_serve.c
+++ b/src/tests/test_aimee_ir_serve.c
@@ -10,7 +10,35 @@
 #include "agent_protocol.h"
 #include "aimee_ir.h"
 #include "aimee_ir_serve.h"
+#include "config.h"
 #include "cJSON.h"
+
+/* aimee_ir_serve.c registers the ported memory module on the transform seam, so it
+ * now references the memory + config toggles. This suite exercises the build/
+ * translation parity paths, NOT memory injection, so keep it a minimal link: stub
+ * the module DISABLED (gw_stage_memory_enabled -> 0) with an inert transform, and a
+ * config_load that reports "no config" so enablement falls to that env default. With
+ * memory off the seam is a no-op and every byte-exact assertion below is unchanged. */
+int ir_stage_memory(aimee_request_t *ir, void *ud)
+{
+   (void)ir;
+   (void)ud;
+   return 0;
+}
+int gw_stage_memory_enabled(void)
+{
+   return 0;
+}
+int config_load(config_t *c)
+{
+   if (c)
+      memset(c, 0, sizeof *c);
+   return -1;
+}
+int config_module_enabled(int config_tristate, int env_default)
+{
+   return config_tristate >= 0 ? config_tristate : env_default;
+}
 
 static const char *REQ =
     "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":100,"

--- a/src/tests/test_gw_stage_memory.c
+++ b/src/tests/test_gw_stage_memory.c
@@ -336,6 +336,53 @@ static void test_instructions_placement_appends(void)
    printf("instructions_placement_appends OK\n");
 }
 
+/* Build a minimal IR carrying a single last-user text block (heap-owned so
+ * aimee_request_free reclaims everything). */
+static void mk_user_ir(aimee_request_t *ir, const char *user_text)
+{
+   memset(ir, 0, sizeof *ir);
+   ir->messages = calloc(1, sizeof *ir->messages);
+   ir->n_messages = 1;
+   ir->messages[0].role = strdup("user");
+   ir->messages[0].blocks = calloc(1, sizeof *ir->messages[0].blocks);
+   ir->messages[0].n_blocks = 1;
+   ir->messages[0].blocks[0].type = AIMEE_BLK_TEXT;
+   ir->messages[0].blocks[0].text = strdup(user_text);
+}
+
+/* IR seam (P4 port): ir_stage_memory appends the envelope as a trailing system TEXT
+ * block, derives the query from the last user message, and reports the mutation. The
+ * appended env is byte-identical to the legacy ingress_preinject_build(query, 0). */
+static void test_ir_stage_appends_system_block(void)
+{
+   aimee_request_t ir;
+   mk_user_ir(&ir, "deploy matrix");
+   int rc = ir_stage_memory(&ir, NULL);
+   assert(rc == 1);          /* changed typed fields -> runner marks ir->mutated */
+   assert(ir.n_system == 1); /* exactly one trailing block appended */
+   assert(ir.system[0].type == AIMEE_BLK_TEXT);
+   assert(ir.system[0].cache_control == NULL); /* trailing block stays uncached */
+   char *direct = ingress_preinject_build("deploy matrix", 0);
+   assert(direct && ir.system[0].text && strcmp(ir.system[0].text, direct) == 0);
+   free(direct);
+   aimee_request_free(&ir);
+   printf("ir_stage_appends_system_block OK\n");
+}
+
+/* IR seam: empty recall -> ingress_preinject_build NULL -> no block, no mutation. */
+static void test_ir_stage_no_recall_noop(void)
+{
+   g_no_recall = 1;
+   aimee_request_t ir;
+   mk_user_ir(&ir, "deploy matrix");
+   int rc = ir_stage_memory(&ir, NULL);
+   assert(rc == 0);
+   assert(ir.n_system == 0 && ir.system == NULL);
+   aimee_request_free(&ir);
+   g_no_recall = 0;
+   printf("ir_stage_no_recall_noop OK\n");
+}
+
 int main(void)
 {
    printf("test_gw_stage_memory:\n");
@@ -346,6 +393,8 @@ int main(void)
    test_anthropic_parity_gate();
    test_anthropic_parity_opt_in_inject();
    test_disabled_noop();
+   test_ir_stage_appends_system_block();
+   test_ir_stage_no_recall_noop();
    printf("all gw_stage_memory tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Step 5 of the IR-canonical-funnel program (ingress → IR → egress, one IR, delete legacy). #1499 landed the empty request-transform seam; this registers the first real module on it.

## What
`gw_stage_memory` fired **pre-IR, per wire**, at each ingress (its three per-target arms). This ports the two **structured-ingress** arms to one protocol-neutral transform on the typed IR:

- **`ir_stage_memory`** (`modules/memory`): derives the recall query from the IR's last user message (`aimee_ir_last_user_text`), builds the `<aimee-context>` envelope, and appends it as a **trailing uncached system TEXT block** on `ir->system`. Returns 1 so the runner marks `ir->mutated` — the raw sidecar is stale, so the backend re-serializes per wire, collapsing the old per-wire byte divergence into a single block append.
- **Registration** moves from the pure core (`aimee_ir.c`) to the serve layer (`aimee_ir_serve.c`) so `aimee_ir.o` stays free of module + config linkage. The memory toggle (config-store `modules.memory` → env default) is resolved at the seam call site and injected as `enabled`, keeping the transform config-free — mirroring the legacy `gw_stage_slot_t` catalogs.
- The **memory slot is removed** from both structured catalogs (`anthropic_http.c` `/v1/messages`, `openai_chat.c` `/v1/responses`).

## Parity / prompt cache
The same-protocol Anthropic passthrough never reaches this seam (`aimee_ir_build_provider_body` always *translates*; the byte-faithful passthrough ships the raw sidecar directly), so Arm A's parity-skip is **structurally satisfied** — no parity plumbing at the seam, and #1495/#1496 byte-exact egress is preserved.

## Scope — why only 2 of 6 sites
The four legacy plain-chat handlers (`/v1/chat/completions`, `/v1/completions`, and their streaming variants) keep `gw_memory_system_prompt`. Audit: they route `gw_memory_system_prompt → agent_dispatch_one → agent_execute → build_request_*` (`agent_runtime.c`, **zero `aimee_ir` refs**) = pure legacy that never reaches the seam. Deleting their injection now would drop memory with no IR replacement. They move once `agent_execute` itself is ported onto the IR (the next funnel prerequisite).

## Fallback
Per the "delete all legacy, no fallback" direction, memory fires only on the IR path; the transitional legacy build-failure fallback is not given a memory re-inject (it is destined for deletion).

## Tests
- `test_gw_stage_memory`: `ir_stage_memory` appends the envelope **byte-identically** to the legacy `ingress_preinject_build(query,0)`, and no-ops on empty recall.
- Moved seam covered via the serve layer; `aimee_ir.o` (cJSON-only footprint) added to the four minimal test link lines that link `gw_stage_memory.o`.
- Green: full `make server`, `make build-integrity`, and the ir / memory / anthropic (`-p2c`, `-streaming-p2c`) / openai-chat-policed unit tests.

## Review asks
- The serve-layer relocation of `aimee_ir_apply_request_stages` (+ injected `memory_enabled`) vs. registering in the core.
- The `IR_MEMORY_QUERY_MAX` (16 KiB) recall-query bound — acceptable since it only feeds semantic recall, not model input.
