### PR TITLE
feat(economizer): gateway wire-mutation is OpenAI-only (provider gate)

### DIFF
--- a/src/modules/economizer/gateway_mutate_wire.c
+++ b/src/modules/economizer/gateway_mutate_wire.c
@@ -54,6 +54,18 @@ int gw_mutate_is_enabled(void)
    return econ_gateway_mutate_on(&cfg);
 }
 
+int gw_mutate_upstream_ok(int upstream_is_anthropic)
+{
+   /* Gateway wire-mutation is OpenAI-only by policy. An Anthropic upstream serves a
+    * byte-verbatim, prompt-cached passthrough (build_anthropic_parity_headers); mutating
+    * the wire there would bust the cached prefix AND force the request off the parity
+    * passthrough. Reducing that upstream cache-coherently is the pre-economize seam's job
+    * (delegate seam / tool_condense), not the gateway's. So the live mutator engages only
+    * when the serving upstream is NOT Anthropic. `upstream_is_anthropic` is the caller's
+    * driver_is_anthropic()/parity signal. */
+   return !upstream_is_anthropic && gw_mutate_is_enabled();
+}
+
 void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
                         const char *system_prompt, const char *session_hdr, const char *bearer,
                         const char *auth_identity, gw_mutate_ctx_t *ctx)

--- a/src/modules/economizer/gateway_mutate_wire.h
+++ b/src/modules/economizer/gateway_mutate_wire.h
@@ -40,6 +40,13 @@ extern "C"
     * OFF hot path. gw_buffered_mutate re-checks internally (defense in depth). */
    int gw_mutate_is_enabled(void);
 
+   /* Provider-gated enable: gateway wire-mutation is OpenAI-only. Returns true only when
+    * the serving upstream is NOT Anthropic AND gw_mutate_is_enabled(). An Anthropic upstream
+    * is a byte-verbatim prompt-cached passthrough, so it is reduced (if at all) at the
+    * pre-economize seam, never by mutating the live wire. `upstream_is_anthropic` is the
+    * caller's driver_is_anthropic()/parity signal. */
+   int gw_mutate_upstream_ok(int upstream_is_anthropic);
+
    /* Pre-send: under reduce_gateway_mutate, resolve the session key from the thread-
     * local request identity; if the session is not disabled, snapshot container[key],
     * run the compress-only economizer, and — when gw_should_apply passes — replace

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -512,7 +512,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
     * body is assembled from the reduced array; on a bad reduction the upstream 4xx is
     * caught below (restore-resend), the session is circuit-broken, and provenance is
     * cleared. A dark no-op when reduce_gateway_mutate is off. */
-   if (gw_mutate_is_enabled())
+   if (gw_mutate_upstream_ok(parity))
    {
       char *mut_sys = anthropic_system_to_text(req);
       gw_buffered_mutate(req, "messages", model, mut_sys, server_http_identity_session_hdr(),
@@ -952,7 +952,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
     * first byte), so on a bad reduction only SUBSEQUENT turns are circuit-broken —
     * via the SSE error-frame inspect-as-forward in relay_flush + the post-stream
     * fail-safe below. Default-OFF dark no-op. */
-   if (gw_mutate_is_enabled())
+   if (gw_mutate_upstream_ok(parity))
    {
       char *mut_sys = anthropic_system_to_text(req);
       gw_buffered_mutate(req, "messages", model, mut_sys, server_http_identity_session_hdr(),

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1011,7 +1011,11 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
    gw_mutate_ctx_init(&gwmc);
    cJSON *mbox = NULL;
    cJSON *eff_messages = messages;
-   if (gw_mutate_is_enabled())
+   /* Gateway mutation is OpenAI-only (never an Anthropic prompt-cached upstream). The
+    * /v1/responses path is OpenAI-wire, but gate defensively on the serving driver so an
+    * Anthropic-backed provider on this endpoint is still excluded. */
+   int upstream_is_anthropic = driver && driver->name && strcmp(driver->name, "anthropic") == 0;
+   if (gw_mutate_upstream_ok(upstream_is_anthropic))
    {
       mbox = cJSON_CreateObject();
       cJSON_AddItemReferenceToObject(mbox, "input", messages); /* reference: messages stays owned */

--- a/src/tests/support/ir_ingress_stubs.c
+++ b/src/tests/support/ir_ingress_stubs.c
@@ -26,6 +26,11 @@ __attribute__((weak)) int gw_mutate_is_enabled(void)
 {
    return 0;
 }
+__attribute__((weak)) int gw_mutate_upstream_ok(int upstream_is_anthropic)
+{
+   (void)upstream_is_anthropic;
+   return 0; /* mutation inert on the shape-test path; real object wins when linked */
+}
 __attribute__((weak)) void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
                                               const char *system_prompt, const char *session_hdr,
                                               const char *bearer, const char *auth_identity,

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -250,6 +250,18 @@ static void test_no_behavior_change_when_off(void)
    cJSON_Delete(c);
 }
 
+static void test_upstream_provider_gate(void)
+{
+   /* Policy: gateway wire-mutation is OpenAI-only. An Anthropic upstream is ALWAYS excluded,
+    * regardless of the enable state, so its prompt-cached verbatim passthrough is never
+    * mutated. For a non-Anthropic upstream the helper simply mirrors the base enable gate
+    * (off under this test's default config HOME). */
+   assert(gw_mutate_upstream_ok(1) == 0);                      /* Anthropic: never mutate */
+   assert(gw_mutate_upstream_ok(0) == gw_mutate_is_enabled()); /* non-Anthropic: base gate */
+   assert(gw_mutate_is_enabled() == 0);                        /* default config -> dark */
+   assert(gw_mutate_upstream_ok(0) == 0);                      /* so both are off here */
+}
+
 int main(void)
 {
    printf("gateway_mutate_wire: ");
@@ -270,6 +282,7 @@ int main(void)
    test_stream_error_classify();
    test_token_delta_sampling();
    test_no_behavior_change_when_off();
+   test_upstream_provider_gate();
    printf("ok\n");
    return 0;
 }


### PR DESCRIPTION
## What
Slice 2, gateway go-live (first cut): make the economizer's live gateway wire-mutation **OpenAI-only**. An Anthropic upstream serves a byte-verbatim, prompt-cached passthrough (`build_anthropic_parity_headers`); mutating that wire would bust the cached prefix and force the request off the parity passthrough. Claude's economization is the pre-economize seam's job (delegate seam + `tool_condense`, already live and cache-coherent) — never the gateway's.

## Changes
- `gw_mutate_upstream_ok(upstream_is_anthropic)` in the economizer module: `!upstream_is_anthropic && gw_mutate_is_enabled()`. One testable place for the policy.
- Both `anthropic_http.c` ingress sites gate on `gw_mutate_upstream_ok(parity)` (`parity == driver_is_anthropic(driver)` — the serving-upstream signal, robust to cross-protocol routing).
- `openai_chat.c` `/v1/responses` gates defensively on its serving driver.
- Weak stub for the new symbol in `ir_ingress_stubs.c` (minimal-link shape tests).
- `test_upstream_provider_gate`: an Anthropic upstream is **always** excluded regardless of enable state; a non-Anthropic upstream mirrors the base gate.

## Signal choice
Gated on `driver_is_anthropic`/`parity`, not `DRIVER_CAP_PROMPT_CACHE` — the cap flag is aspirational and set by no driver, so gating on it would misfire and mutate Anthropic.

## Not in this PR
The go-live default flip (`reduce_gateway_mutate` / `economizer.aggressive`) stays OFF. This delivers the provider gating + safety net; enabling live mutation on OpenAI traffic is an explicit operator step.

## Verification
Rebased onto current `testing` (post #1500). Server links; `unit-test-gateway-mutate-wire` (+ new test) and the three `anthropic-http` shape tests pass; `make build-integrity` green; changed `.c` files clang-format-19 clean; full `make unit-tests` green.
