### PR TITLE
fix(server): run server-hosted CLI (claude) sessions in a server-valid cwd

### DIFF
--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -72,6 +72,15 @@ void cli_session_set_kind(cli_session_t *s, const char *cli_kind);
  * before cli_session_send so the turn's reply is diffed from a clean boundary. */
 void cli_session_mark_baseline(cli_session_t *s);
 
+/* Resolve the directory a SERVER-HOSTED CLI session should run in. Writes the
+ * chosen dir into `out` (turn_cwd when it exists on this host, else the server
+ * process cwd) and returns 1 iff it FELL BACK — i.e. a non-empty turn_cwd was
+ * absent here and had to be replaced. On fallback the caller must retarget
+ * run_cmd_set_cwd() to `out`, else run_cmd's `cd '<turn_cwd>' &&` prefix fails
+ * every session shell-out ("failed to create tmux session"). Returns 0 when
+ * turn_cwd is usable or empty (nothing to retarget). */
+int cli_session_resolve_cwd(const char *turn_cwd, char *out, size_t n);
+
 /* --- Lifecycle --- */
 /* Creates (or attaches to existing) tmux session, starts CLI.
  * session_name must be unique (e.g. "aimee-<agent>-<taskid>").

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -12,10 +12,15 @@
 #include <unistd.h>
 
 /* run_cmd cwd control (util.c): the active turn binds the thread-local working
- * directory to the (client) workspace root. On a detached thin-client turn the
- * tmux session runs on the client, so the session must be created in the
- * client's cwd, not the server's process cwd. */
+ * directory to the (client) workspace root, and run_cmd prefixes each shell-out
+ * with `cd '<that dir>' &&`. For a SERVER-HOSTED CLI agent (e.g. the fleet's
+ * claude) the tmux session runs on the server, where a detached thin-client's
+ * bound cwd does not exist — so the cd fails and tmux never launches. The public
+ * wrapper below resolves a server-valid cwd (cli_session_resolve_cwd) and
+ * retargets this thread-local for the session's lifetime, restoring it on the
+ * single exit. Co-located turns (bound cwd present here) are unaffected. */
 extern const char *run_cmd_get_cwd(void);
+extern void run_cmd_set_cwd(const char *cwd);
 
 /* delegation_active_id is provided by server_compute.c at link time (a
  * thread-local: the id of the delegate running on THIS thread, or NULL for a
@@ -25,9 +30,9 @@ extern const char *run_cmd_get_cwd(void);
  * across concurrent delegate threads. */
 const char *delegation_active_id(void);
 
-int agent_execute_cli_session(const agent_t *agent, const agent_network_t *network,
-                              const char *system_prompt, const char *user_prompt, int max_tokens,
-                              double temperature, agent_result_t *out)
+static int cli_session_execute_inner(const agent_t *agent, const agent_network_t *network,
+                                     const char *system_prompt, const char *user_prompt,
+                                     int max_tokens, double temperature, agent_result_t *out)
 {
    (void)network;
    (void)max_tokens;
@@ -322,4 +327,35 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    out->success = 1;
    out->turns = 1;
    return 0;
+}
+
+/* Public entry. A server-hosted CLI agent runs its tmux session on THIS host,
+ * but the turn-bound cwd can be a detached client's workspace path that exists
+ * only on the client; run_cmd would then prefix every session shell-out with a
+ * `cd '<client-path>' &&` that fails, so tmux never launches ("failed to create
+ * tmux session for <agent>"). Resolve a server-valid cwd and retarget run_cmd's
+ * thread-local cwd for the whole session, restoring it on this single exit — so
+ * the inner runner keeps its many per-failure returns without any cwd bookkeeping. */
+int agent_execute_cli_session(const agent_t *agent, const agent_network_t *network,
+                              const char *system_prompt, const char *user_prompt, int max_tokens,
+                              double temperature, agent_result_t *out)
+{
+   char server_cwd[MAX_PATH_LEN];
+   int fell_back = cli_session_resolve_cwd(run_cmd_get_cwd(), server_cwd, sizeof(server_cwd));
+
+   char saved_cwd[MAX_PATH_LEN] = {0};
+   if (fell_back)
+   {
+      const char *cur = run_cmd_get_cwd();
+      if (cur)
+         snprintf(saved_cwd, sizeof(saved_cwd), "%s", cur);
+      run_cmd_set_cwd(server_cwd[0] ? server_cwd : NULL);
+   }
+
+   int rc = cli_session_execute_inner(agent, network, system_prompt, user_prompt, max_tokens,
+                                      temperature, out);
+
+   if (fell_back)
+      run_cmd_set_cwd(saved_cwd[0] ? saved_cwd : NULL);
+   return rc;
 }

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -355,6 +355,27 @@ void cli_session_prepare_claude(const char *work_dir, int autonomous)
    pthread_mutex_unlock(&g_prep_mu);
 }
 
+int cli_session_resolve_cwd(const char *turn_cwd, char *out, size_t n)
+{
+   if (!out || n == 0)
+      return 0;
+   /* The turn-bound cwd is usable only if it exists on THIS host. It won't on a
+    * detached thin-client turn whose bound cwd is the client's workspace path,
+    * where a server-hosted CLI session actually runs — using it would make every
+    * `cd '<path>' &&` shell-out fail. Fall back to the server process cwd and
+    * report the fallback so the caller can retarget run_cmd's thread-local cwd. */
+   if (turn_cwd && turn_cwd[0] && access(turn_cwd, F_OK) == 0)
+   {
+      snprintf(out, n, "%s", turn_cwd);
+      return 0;
+   }
+   if (getcwd(out, n) == NULL)
+      out[0] = '\0';
+   /* Fell back only if there WAS a bound cwd that we had to discard; an empty
+    * bound cwd is the ordinary co-located case (run_cmd has no cd prefix). */
+   return (turn_cwd && turn_cwd[0]) ? 1 : 0;
+}
+
 int cli_session_create(cli_session_t *s, const char *session_name, const char *cli_cmd,
                        const char *work_dir, int reuse)
 {

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -377,6 +377,43 @@ static void test_make_name_null_role(void)
    free(name);
 }
 
+/* --- cli_session_resolve_cwd tests --- */
+
+/* A bound cwd that exists on this host is used verbatim; no fallback. */
+static void test_resolve_cwd_existing_used(void)
+{
+   char out[256];
+   int fb = cli_session_resolve_cwd("/tmp", out, sizeof(out));
+   assert(fb == 0);
+   assert(strcmp(out, "/tmp") == 0);
+}
+
+/* A non-empty bound cwd that is ABSENT on this host (the detached thin-client
+ * case that used to make every tmux shell-out `cd` fail) falls back to the
+ * server process cwd and reports the fallback so the caller retargets run_cmd. */
+static void test_resolve_cwd_missing_falls_back(void)
+{
+   char out[4096], here[4096];
+   assert(getcwd(here, sizeof(here)) != NULL);
+   int fb = cli_session_resolve_cwd("/no/such/dir/aimee-does-not-exist-xyz", out, sizeof(out));
+   assert(fb == 1);
+   assert(strcmp(out, here) == 0);
+}
+
+/* An empty / NULL bound cwd is the ordinary co-located case: use the server cwd
+ * but report NO fallback (run_cmd has no `cd` prefix to retarget). */
+static void test_resolve_cwd_empty_no_fallback(void)
+{
+   char out[4096], here[4096];
+   assert(getcwd(here, sizeof(here)) != NULL);
+   int fb = cli_session_resolve_cwd(NULL, out, sizeof(out));
+   assert(fb == 0);
+   assert(strcmp(out, here) == 0);
+   fb = cli_session_resolve_cwd("", out, sizeof(out));
+   assert(fb == 0);
+   assert(strcmp(out, here) == 0);
+}
+
 /* --- cli_session_strip_ansi tests --- */
 
 static void test_strip_ansi_plain_text(void)
@@ -841,6 +878,18 @@ static void test_prepare_claude_nonautonomous_skips_bypass_seed(void)
 
 int main(void)
 {
+   printf("test_resolve_cwd_existing_used... ");
+   test_resolve_cwd_existing_used();
+   printf("OK\n");
+
+   printf("test_resolve_cwd_missing_falls_back... ");
+   test_resolve_cwd_missing_falls_back();
+   printf("OK\n");
+
+   printf("test_resolve_cwd_empty_no_fallback... ");
+   test_resolve_cwd_empty_no_fallback();
+   printf("OK\n");
+
    printf("test_prepare_claude_seeds_gates... ");
    test_prepare_claude_seeds_gates();
    printf("OK\n");


### PR DESCRIPTION
## Problem

Server-hosted `claude` delegates fail with **\`failed to create tmux session for claude\`** on detached thin-client turns. Reproduced live on the fleet; the server log shows the smoking gun:

```
sh: 1: cd: can't cd to /home/virant/dev/aimee/.claude/worktrees/bench-cost-savings
```

`claude` runs its vendor CLI in a **server-side tmux session**, but the turn binds `run_cmd`'s thread-local cwd to the **client's** workspace path. `run_cmd` prefixes every shell-out with `cd '<that dir>' &&`; on a detached turn that path doesn't exist on the server, the `cd` fails, and `tmux new-session` never runs → `cli_session_create` returns -1. `codex` is unaffected (HTTP `responses` wire, no tmux). tmux itself is present and healthy (verified `tmux 3.3a`, `new-session` succeeds as the server user).

## Fix

- Add `cli_session_resolve_cwd(turn_cwd, out, n)`: returns the bound cwd when it exists on **this** host, else the server process cwd, reporting whether it fell back.
- `agent_execute_cli_session` now resolves a server-valid cwd and, **only on fallback**, retargets `run_cmd`'s thread-local cwd for the session's lifetime, restoring it on a single exit. Co-located turns (bound cwd present here) are byte-for-byte unaffected.
- To keep the cwd scoping to one save/restore across the runner's many per-failure returns, the body is split into `cli_session_execute_inner` (unchanged) behind a thin wrapper.

## Tests

Adds `test_resolve_cwd_existing_used`, `test_resolve_cwd_missing_falls_back`, `test_resolve_cwd_empty_no_fallback` to `test_cli_session`. `make server` links clean; full `unit-test-cli-session` green.

## Deploy note

Fixes the code path; the running fleet needs the rebuilt server image to pick it up.