### PR TITLE
fix(delegate): honor --no-tools (force_tools=0) in agent_run_ex

### DIFF
--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -27,6 +27,15 @@ int agent_execute(const agent_t *agent, const char *system_prompt, const char *u
 int agent_run(agent_config_t *cfg, const char *role, const char *system_prompt,
               const char *user_prompt, int max_tokens, agent_result_t *out);
 
+/* Per-thread override of agent_run/agent_run_ex tool-mode inference. agent_run_ex
+ * normally derives use_tools from the routed agent's config (tools_enabled +
+ * exec-role); a delegate that decided tools-OFF (CLI --no-tools -> force_tools=0)
+ * calls agent_run, so that inference would re-enable tools and ignore the
+ * decision. The delegate no-tools path sets this to 1 around its agent_run call
+ * to force use_tools=0 for the turn, then clears it. Scoped per-thread so
+ * agent_run's other ~28 callers are unaffected. */
+void agent_run_force_no_tools(int on);
+
 /* Like agent_run, but with an explicit sampling temperature. agent_run is the
  * thin wrapper that passes the historical 0.3 default, so its ~28 call sites are
  * byte-unchanged; the parallel fan-out path uses this to honour a per-task

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -197,6 +197,13 @@ int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char
    return rc;
 }
 
+/* Per-thread tool-mode override for agent_run_ex; see agent_run_force_no_tools. */
+static __thread int tl_force_no_tools = 0;
+void agent_run_force_no_tools(int on)
+{
+   tl_force_no_tools = on ? 1 : 0;
+}
+
 int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
                  const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
 {
@@ -238,8 +245,12 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
          break;       /* no viable agent remains */
       }
 
-      int use_tools =
-          agent_uses_provider_cli(ag) || (ag->tools_enabled && agent_is_exec_role(ag, role));
+      /* tl_force_no_tools: the delegate no-tools path (CLI --no-tools ->
+       * force_tools=0) sets this so a tools-capable agent on an exec role does
+       * not silently re-enable tools here and ignore the caller's decision. */
+      int use_tools = tl_force_no_tools ? 0
+                                        : (agent_uses_provider_cli(ag) ||
+                                           (ag->tools_enabled && agent_is_exec_role(ag, role)));
       agent_apply_runtime_config(ag);
       ag->ablation = cfg->ablation;
       ag->write_capable = use_tools && delegate_role_is_write(role) ? 1 : 0;

--- a/src/server/delegate_credential_retry.c
+++ b/src/server/delegate_credential_retry.c
@@ -135,7 +135,15 @@ static int run_delegate_attempt(agent_config_t *cfg, const char *role, const cha
    if (force_tools)
       return agent_run_with_tools_write_enforce(cfg, role, system_prompt, run_prompt, max_tokens,
                                                 enforce_writes, result);
-   return agent_run(cfg, role, system_prompt, run_prompt, max_tokens, result);
+   /* The delegate decided tools-OFF (e.g. CLI --no-tools -> force_tools=0). Force
+    * it for the turn: agent_run_ex would otherwise re-derive use_tools from the
+    * agent's config (tools_enabled + exec-role) and silently re-enable tools,
+    * which makes an agentic model (e.g. codex) loop on tool calls and return no
+    * text instead of the requested single-shot answer. */
+   agent_run_force_no_tools(1);
+   int rc = agent_run(cfg, role, system_prompt, run_prompt, max_tokens, result);
+   agent_run_force_no_tools(0);
+   return rc;
 }
 
 static int result_failed_for_pool(const agent_result_t *result, int rc)

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -46,6 +46,11 @@ static const char *g_agent_repair_response = NULL;
 static int g_agent_calls = 0;
 static int g_agent_run_calls = 0;
 static int g_agent_tool_run_calls = 0, g_config_tools_enabled = 1;
+/* Tracks agent_run_force_no_tools: g_force_no_tools is the live thread-local
+ * stand-in; g_agent_run_seen_no_tools latches its value at the agent_run call so
+ * a test can assert the delegate no-tools path forced tools off for the turn. */
+static int g_force_no_tools = 0;
+static int g_agent_run_seen_no_tools = 0;
 static int g_last_agent_max_turns = -999;
 static int g_last_write_enforce = -999;
 static int g_budget_acquire_calls = 0;
@@ -275,6 +280,7 @@ int agent_run(agent_config_t *cfg, const char *role, const char *system_prompt, 
       snprintf(g_last_system_prompt, sizeof(g_last_system_prompt), "%s", system_prompt);
    memset(result, 0, sizeof(*result));
    g_agent_run_calls++;
+   g_agent_run_seen_no_tools = g_force_no_tools;
    g_agent_run_seen_compute_override = g_aimee_compute_threads_override;
    g_last_agent_max_turns = cfg->agent_count > 0 ? cfg->agents[0].max_turns : -999;
    g_agent_seen_compute_override = g_aimee_compute_threads_override;
@@ -283,6 +289,11 @@ int agent_run(agent_config_t *cfg, const char *role, const char *system_prompt, 
    if (g_agent_run_rc != 0)
       snprintf(result->error, sizeof(result->error), "stubbed agent failure");
    return g_agent_run_rc;
+}
+
+void agent_run_force_no_tools(int on)
+{
+   g_force_no_tools = on ? 1 : 0;
 }
 
 int agent_run_with_tools(agent_config_t *cfg, const char *role, const char *system_prompt,
@@ -2200,6 +2211,58 @@ static void test_direct_delegate_explicit_tools_forces_tools(void)
    printf("  PASS: test_direct_delegate_explicit_tools_forces_tools\n");
 }
 
+/* Regression: an explicit tools:false (CLI --no-tools) on a tools-on-by-default
+ * exec role must run the tools-OFF branch AND force tools off for the turn, so
+ * agent_run_ex cannot silently re-enable tools from the agent config (the codex
+ * "no content in final response" bug). */
+static void test_direct_delegate_no_tools_forces_no_tools(void)
+{
+   reset_last_response();
+   g_agent_run_calls = 0;
+   g_agent_tool_run_calls = 0;
+   g_force_no_tools = 0;
+   g_agent_run_seen_no_tools = 0;
+   int fds[2];
+   assert(pipe(fds) == 0);
+   server_ctx_t *ctx = calloc(1, sizeof(*ctx));
+   server_conn_t *conn = calloc(1, sizeof(*conn));
+   assert(ctx != NULL && conn != NULL);
+   conn->fd = fds[1];
+   g_agent_response = "answer produced without tools";
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "role", "review");
+   cJSON_AddStringToObject(req, "persona", "engineer");
+   cJSON_AddStringToObject(req, "prompt", "run the direct delegate no-tools policy test prompt");
+   cJSON_AddFalseToObject(req, "tools");
+   assert(handle_delegate(ctx, conn, req) == 0);
+   assert(g_submitted_fn == delegate_worker);
+   assert(g_submitted_arg != NULL);
+   g_submitted_fn(g_submitted_arg);
+   g_submitted_arg = NULL;
+   close(fds[1]);
+   char buf[2048];
+   ssize_t n = read(fds[0], buf, sizeof(buf) - 1);
+   assert(n >= 0);
+   buf[n] = '\0';
+   close(fds[0]);
+   db1_agent_job_t job;
+   assert(delegate_current_job(&job) == 0);
+   assert(strcmp(job.status, "done") == 0);
+   db1_agent_job_free(&job);
+   /* tools:false -> the no-tools branch (agent_run, not agent_run_with_tools)... */
+   assert(g_agent_run_calls == 1);
+   assert(g_agent_tool_run_calls == 0);
+   /* ...and the fix: tools were force-disabled for the turn. */
+   assert(g_agent_run_seen_no_tools == 1);
+   /* the override is cleared again after the run. */
+   assert(g_force_no_tools == 0);
+   cJSON_Delete(req);
+   reset_last_response();
+   free(conn);
+   free(ctx);
+   printf("  PASS: test_direct_delegate_no_tools_forces_no_tools\n");
+}
+
 static void test_direct_delegate_one_turn_diagnose_suppresses_default_tools(void)
 {
    reset_last_response();
@@ -3224,6 +3287,7 @@ int main(void)
    test_direct_delegate_review_auto_tools_uses_tools();
    test_direct_delegate_reviewer_alias_auto_tools_uses_tools();
    test_direct_delegate_explicit_tools_forces_tools();
+   test_direct_delegate_no_tools_forces_no_tools();
    test_direct_delegate_one_turn_diagnose_suppresses_default_tools();
    test_readonly_code_delegate_disables_write_enforce();
    test_readonly_refactor_delegate_disables_write_enforce();


### PR DESCRIPTION
## Problem

Server-hosted **codex (gpt-5.6-sol)** delegates fail on real prompts with **\`no content in final response\`**, while MiniMax succeeds on the same task. Deep dive (raw \`/backend-api/codex/responses\` replay + \`execution_trace\` capture on the live fleet) proved the **ChatGPT backend is healthy** — the fault is aimee's request build:

- A delegate dispatched \`--no-tools\` sets \`force_tools=0\`; \`run_delegate_attempt\` correctly routes it to \`agent_run\` (not \`agent_run_with_tools\`).
- But \`agent_run\` → \`agent_run_ex\` **re-derives** \`use_tools\` from the routed agent's config: \`agent_uses_provider_cli(ag) || (ag->tools_enabled && agent_is_exec_role(ag, role))\`. codex is \`tools_enabled\` and \`draft\` is an exec role → \`use_tools=1\`.
- So the request shipped **38 tools + a tool-first "always invoke tools" system prompt**. The agentic gpt-5.6-sol answered with **tool calls** instead of the requested single-shot text; the turn ended with no final text → "no content in final response".
- Less-agentic models (MiniMax) ignore the unusable tools and just answer, which masked the bug.

## Fix

Add a per-thread \`agent_run_force_no_tools(int)\` override. The delegate no-tools path (\`run_delegate_attempt\`, \`force_tools=0\`) sets it around its \`agent_run\` call, forcing \`use_tools=0\` for that turn, then clears it. Thread-local scope leaves \`agent_run\`'s ~28 other callers (which rely on the auto-tools inference) byte-unchanged.

Precisely targeted: \`force_tools=0\` on an exec role only occurs via an explicit \`--no-tools\` (exec roles otherwise auto-set \`force_tools=1\` → \`agent_run_with_tools\`), so no other delegate flow changes.

## Verification

\`make server\` links clean under \`-Werror\`. Verified end-to-end on the fleet after deploy: \`aimee delegate draft --via codex --no-tools\` returns real diff text instead of "no content" (see PR thread).