### PR TITLE
fix(config): hot-reload on out-of-band config file changes, not just SIGHUP

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1887,3 +1887,45 @@ int config_reload(void)
    pthread_mutex_unlock(&g_snap_wlock);
    return 1; /* a new snapshot was published */
 }
+
+/* Live-config-reload P4: reload on an OUT-OF-BAND write to the config file — a CLI local
+ * `config set` one-shot, a manual edit, or the server's own autonomous config_save (wfe/
+ * trigger path) — without a restart or a SIGHUP. The server reads config from the push
+ * snapshot (config_load -> config_snapshot_get), which previously only refreshed via
+ * config_reload on SIGHUP or the in-server config.set route; a plain file write therefore
+ * did not take effect. Call this from the server's 1s main-loop tick.
+ *
+ * Tracks the file's (mtime,size,inode) across calls (same cheap identity config_load_file
+ * caches on; mtime alone is spoofable on the tiered appliance FS). The FIRST call reloads
+ * unconditionally to reconcile the snapshot with the on-disk file (covers an edit landed in
+ * the <1s window between snapshot-init and the first tick); config_reload's token no-op
+ * guard makes that a cheap no-op when nothing changed. Reusing config_reload gives us its
+ * validate-or-keep semantics for free, so a bad edit never replaces a good running config,
+ * and the server rewriting its own equivalent config is a no-op (no reload churn).
+ *
+ * Returns config_reload()'s result (1 published / 0 no-op / -1 kept) when a change was
+ * observed, else 0. */
+int config_reload_if_changed(void)
+{
+   static struct timespec last_mt;
+   static off_t last_size;
+   static ino_t last_ino;
+   static int seeded = 0;
+
+   const char *path = config_default_path();
+   struct stat st;
+   if (stat(path, &st) != 0)
+      return 0; /* transiently absent (e.g. an atomic rename in flight) — retry next tick */
+
+   struct timespec mt = AIMEE_STAT_MTIM(st);
+   int changed =
+       !seeded || !timespec_eq(&mt, &last_mt) || st.st_size != last_size || st.st_ino != last_ino;
+   if (!changed)
+      return 0;
+
+   last_mt = mt;
+   last_size = st.st_size;
+   last_ino = st.st_ino;
+   seeded = 1;
+   return config_reload();
+}

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -2061,6 +2061,12 @@ void config_snapshot_init(const config_t *cfg);
 int config_snapshot_get(config_t *out);
 int config_reload(void);
 
+/* config_reload_if_changed — reload iff the config file changed on disk since the last call
+ * (out-of-band write: CLI local config.set, manual edit, or autonomous config_save). Poll it
+ * from the server's main-loop tick so a file change takes effect without a restart or SIGHUP.
+ * First call reconciles unconditionally. Returns config_reload()'s 1/0/-1 on a change, else 0. */
+int config_reload_if_changed(void);
+
 /* Re-applier registry (live-config-reload P3): a hook invoked after config_reload publishes a
  * new snapshot, receiving the OLD and NEW config so it can push bound state (env bridge, log
  * level, TLS, …) live when the section it owns changed. Register once at startup. Re-appliers

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2360,6 +2360,14 @@ int server_run(server_ctx_t *ctx)
           * is picked up on SIGHUP without dropping the listener (live-config-reload). */
          (void)server_tls_reload();
       }
+      /* Live-config-reload P4: also pick up an OUT-OF-BAND file change (a CLI local
+       * `config set`, a manual edit, or the autonomous config_save) — not just SIGHUP — so
+       * the "operator toggle applies without a restart" contract holds however the file was
+       * written. No-op tick when the file is unchanged. */
+      int cfg_rc = config_reload_if_changed();
+      if (cfg_rc != 0)
+         aimee_log(cfg_rc < 0 ? LOG_WARN : LOG_INFO, "config", "config file change: %s",
+                   cfg_rc > 0 ? "reloaded" : "rejected (kept running config)");
    }
    return 0;
 }

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -132,6 +132,22 @@ int main(void)
       assert(atomic_load_explicit(&g_reapply_calls, memory_order_relaxed) == mid);
    }
 
+   /* --- P4 config_reload_if_changed: an OUT-OF-BAND file write (as a CLI local config.set,
+    * a manual edit, or the autonomous config_save produces) is picked up on the main-loop
+    * tick WITHOUT an explicit config_reload()/SIGHUP; an unchanged file is a no-op. --- */
+   {
+      (void)config_reload_if_changed();        /* first call seeds the baseline + reconciles */
+      assert(config_reload_if_changed() == 0); /* no on-disk change since -> no-op */
+      write_marker(0, 3333);                   /* out-of-band write */
+      assert(config_reload_if_changed() == 1); /* detected the change + published */
+      {
+         config_t got;
+         assert(config_snapshot_get(&got) == 0);
+         assert(got.coord_closet_budget_bytes == 3333); /* the new value is live now */
+      }
+      assert(config_reload_if_changed() == 0); /* stable again -> no-op */
+   }
+
    /* --- autonomy-live: config_autonomy_lookup (operator env override > live snapshot,
     * non-config var -> fall back) --- */
    {


### PR DESCRIPTION
## Problem
The server reads config from the push-driven snapshot (`config_load` → `config_snapshot_get`), which only refreshes when `config_reload()` runs — and that fires on exactly two triggers: **SIGHUP** (`server.c`) and the **in-server `config.set` route** (`server_config.c`). So a config file write that doesn't go through the server never reaches the running process:

- a CLI **local** `aimee config set` one-shot (no remote configured — e.g. run inside the server container),
- a **manual edit** of `aimee.yaml`,
- the server's **own autonomous `config_save`** (wfe/trigger regeneration).

This contradicts the documented "operator toggle applies without a restart" contract. Observed live: `aimee config set reduce.gateway_mutate true` persisted to disk (`config get` returned `true`) but the running server kept serving its stale startup snapshot, so the gateway economizer never engaged. SIGHUP is the only escape hatch and it's unreliable for a PID-1 server under the LXC2Docker runtime (a HUP produced no reload).

## Fix
`config_reload_if_changed()` — polled from the **existing 1s main-loop tick**. It stats the config file (mtime+size+inode, the same cheap identity `config_load_file` already caches on) and calls `config_reload()` when it changes, so an out-of-band write takes effect within ~1s however the file was written and regardless of SIGHUP.

- Reuses `config_reload`'s **validate-or-keep** + content-hash **no-op guard**: a bad edit never replaces a good running config, and the server re-reading its own `config_save` is a no-op (no reload churn/loop).
- First call reconciles unconditionally to close the snapshot-init→first-tick window.
- Additive; SIGHUP and the `config.set` route are unchanged.

## Test
`test_config_snapshot` extended: seed → unchanged no-op → out-of-band change published → stable no-op. Full `make unit-tests` green; `make build-integrity` green; clang-format-19 clean.
