### PR TITLE
feat(ir): cross-protocol canonical Anthropic egress (byte-identity for prompt caching)

### DIFF
--- a/src/headers/aimee_ir.h
+++ b/src/headers/aimee_ir.h
@@ -60,6 +60,10 @@ typedef struct
    aimee_block_type_t type;
    /* TEXT / THINKING */
    char *text;
+   /* THINKING: the provider's opaque signature over the reasoning block. Anthropic
+    * REQUIRES it echoed back verbatim on a resubmitted assistant thinking turn, so it
+    * must be modeled (not lost to the raw sidecar) for the canonical egress. Owned. */
+   char *thinking_signature;
    /* TOOL_USE: id = the call id (stable, links to the matching TOOL_RESULT);
     * name = opaque tool name; input = opaque argument JSON (borrowed sidecar view,
     * preserved verbatim). TOOL_RESULT: id = the tool_use id it answers;

--- a/src/headers/aimee_ir.h
+++ b/src/headers/aimee_ir.h
@@ -112,9 +112,27 @@ typedef struct
    int has_max_tokens;
    double temperature;
    int has_temperature;
+   /* Sampling params clients send at the top level. Modeled (not raw-carried) so the
+    * canonical egress can re-emit them deterministically once the raw sidecar is
+    * retired -- and so they survive cross-protocol translation. top_p/top_k are valid
+    * on both Anthropic and OpenAI; a source that omits one leaves has_* == 0. */
+   double top_p;
+   int has_top_p;
+   int top_k;
+   int has_top_k;
    int stream;
    char **stop_sequences;
    int n_stop;
+   /* Opaque top-level request metadata (e.g. Anthropic `metadata.user_id`), preserved
+    * verbatim through the IR so the canonical egress is byte-faithful without the raw
+    * sidecar. Owned. NULL when the client sent none. */
+   struct cJSON *metadata;
+   /* Anthropic `service_tier` ("auto"/"standard_only"/...); NULL if unset. Owned. */
+   char *service_tier;
+   /* Anthropic extended-thinking CONFIG object ({type:"enabled",budget_tokens:N}) -- a
+    * top-level request field, distinct from THINKING content blocks in messages.
+    * Opaque, preserved verbatim. Owned. NULL when the client sent none. */
+   struct cJSON *thinking;
    aimee_wire_t frontend; /* the client wire this was parsed from */
    /* Set to 1 by any IR transform that changes the typed fields (a module editing
     * messages/system/tools). While 0, the request is byte-identical to `raw`, so a

--- a/src/server/aimee_backend_anthropic.c
+++ b/src/server/aimee_backend_anthropic.c
@@ -22,6 +22,43 @@ static void add_cache_control(cJSON *el, const char *cc)
    cJSON_AddStringToObject(o, "type", cc[0] ? cc : "ephemeral");
 }
 
+/* Uniform aimee cache policy (cross-protocol canonical egress): cache_control on the
+ * Anthropic egress is decided by aimee at egress, NOT inherited from the client, so
+ * the bytes are identical regardless of source protocol (Anthropic prompt-caches on
+ * exact bytes; an openai-sourced request carries no markers of its own). The policy
+ * marks the stable-prefix breakpoints -- the end of the system block and the end of
+ * the tools block -- with an ephemeral cache_control. Deterministic: the same IR
+ * content yields the same markers whether parsed from anthropic, openai, or responses
+ * wire. (Message/turn-level breakpoints are a later economization refinement.) */
+/* Remove cache_control from every element of an array. The policy is the SOLE source
+ * of markers, so any client marker that leaked in (e.g. via a raw-replayed UNKNOWN
+ * block) must be stripped first, or the egress bytes would depend on the source. */
+static void strip_cache_control(cJSON *arr)
+{
+   if (!cJSON_IsArray(arr))
+      return;
+   int n = cJSON_GetArraySize(arr);
+   for (int i = 0; i < n; i++)
+   {
+      cJSON *el = cJSON_GetArrayItem(arr, i);
+      if (el && cJSON_IsObject(el))
+         cJSON_DeleteItemFromObjectCaseSensitive(el, "cache_control");
+   }
+}
+
+static void mark_cache_prefix(cJSON *arr)
+{
+   strip_cache_control(arr);
+   if (!cJSON_IsArray(arr))
+      return;
+   int n = cJSON_GetArraySize(arr);
+   if (n <= 0)
+      return;
+   cJSON *last = cJSON_GetArrayItem(arr, n - 1);
+   if (last && cJSON_IsObject(last))
+      add_cache_control(last, "ephemeral");
+}
+
 /* one IR block -> its Anthropic wire JSON (owned). NULL if not renderable. */
 static cJSON *block_to_anthropic(const aimee_block_t *b)
 {
@@ -77,7 +114,9 @@ static cJSON *block_to_anthropic(const aimee_block_t *b)
       cJSON_Delete(el);
       return b->raw ? cJSON_Duplicate(b->raw, 1) : NULL;
    }
-   add_cache_control(el, b->cache_control);
+   /* NOTE: the client's per-block cache_control is intentionally NOT copied here --
+    * the uniform aimee cache policy (mark_cache_prefix) decides markers at egress so
+    * the bytes are source-protocol-independent. */
    return el;
 }
 
@@ -126,14 +165,19 @@ cJSON *anthropic_backend_build(const aimee_request_t *ir)
    if (ir->stream)
       cJSON_AddBoolToObject(out, "stream", 1);
    if (ir->n_system > 0)
-      cJSON_AddItemToObject(out, "system", blocks_to_anthropic(ir->system, ir->n_system));
+   {
+      cJSON *sys = blocks_to_anthropic(ir->system, ir->n_system);
+      cJSON_AddItemToObject(out, "system", sys);
+      mark_cache_prefix(sys); /* uniform policy: cache the stable system prefix */
+   }
    cJSON *msgs = cJSON_AddArrayToObject(out, "messages");
    for (int i = 0; i < ir->n_messages; i++)
    {
       cJSON *m = cJSON_CreateObject();
       cJSON_AddStringToObject(m, "role", ir->messages[i].role ? ir->messages[i].role : "user");
-      cJSON_AddItemToObject(m, "content",
-                            blocks_to_anthropic(ir->messages[i].blocks, ir->messages[i].n_blocks));
+      cJSON *content = blocks_to_anthropic(ir->messages[i].blocks, ir->messages[i].n_blocks);
+      strip_cache_control(content); /* uniform policy: no client markers on messages */
+      cJSON_AddItemToObject(m, "content", content);
       cJSON_AddItemToArray(msgs, m);
    }
    if (ir->n_tools > 0)
@@ -148,9 +192,10 @@ cJSON *anthropic_backend_build(const aimee_request_t *ir)
          cJSON_AddItemToObject(t, "input_schema",
                                ir->tools[i].schema ? cJSON_Duplicate(ir->tools[i].schema, 1)
                                                    : cJSON_CreateObject());
-         add_cache_control(t, ir->tools[i].cache_control);
+         /* client tool cache_control intentionally not copied -- see mark_cache_prefix */
          cJSON_AddItemToArray(tools, t);
       }
+      mark_cache_prefix(tools); /* uniform policy: cache the stable tools block */
    }
    if (ir->tool_choice)
       cJSON_AddItemToObject(out, "tool_choice", cJSON_Duplicate(ir->tool_choice, 1));

--- a/src/server/aimee_backend_anthropic.c
+++ b/src/server/aimee_backend_anthropic.c
@@ -59,6 +59,36 @@ static void mark_cache_prefix(cJSON *arr)
       add_cache_control(last, "ephemeral");
 }
 
+/* Canonicalize a tool_result's content so an anthropic-sourced tool_result (verbatim
+ * block array) and an openai-sourced one (string) with the same text serialize
+ * IDENTICALLY. An empty or single-text-block array collapses to the plain string form
+ * (matching the NULL default and the OpenAI string). Multi-block / non-text / object
+ * content is preserved verbatim -- canonicalizing image/document blocks *inside* a
+ * tool_result is out of scope (the IR stores tool_result content opaquely). */
+static cJSON *tool_result_content(const cJSON *tr)
+{
+   if (!tr)
+      return cJSON_CreateString("");
+   if (cJSON_IsArray(tr))
+   {
+      int n = cJSON_GetArraySize(tr);
+      if (n == 0)
+         return cJSON_CreateString(""); /* empty content == the NULL default, not [] */
+      if (n == 1)
+      {
+         cJSON *only = cJSON_GetArrayItem((cJSON *)tr, 0);
+         const cJSON *t = only ? cJSON_GetObjectItemCaseSensitive(only, "type") : NULL;
+         if (t && cJSON_IsString(t) && t->valuestring && strcmp(t->valuestring, "text") == 0)
+         {
+            const cJSON *txt = cJSON_GetObjectItemCaseSensitive(only, "text");
+            return cJSON_CreateString(
+                (txt && cJSON_IsString(txt) && txt->valuestring) ? txt->valuestring : "");
+         }
+      }
+   }
+   return cJSON_Duplicate((cJSON *)tr, 1);
+}
+
 /* one IR block -> its Anthropic wire JSON (owned). NULL if not renderable. */
 static cJSON *block_to_anthropic(const aimee_block_t *b)
 {
@@ -85,9 +115,7 @@ static cJSON *block_to_anthropic(const aimee_block_t *b)
       cJSON_AddStringToObject(el, "tool_use_id", b->tool_id ? b->tool_id : "");
       if (b->tool_is_error)
          cJSON_AddBoolToObject(el, "is_error", 1);
-      cJSON_AddItemToObject(el, "content",
-                            b->tool_result ? cJSON_Duplicate(b->tool_result, 1)
-                                           : cJSON_CreateString(""));
+      cJSON_AddItemToObject(el, "content", tool_result_content(b->tool_result));
       break;
    case AIMEE_BLK_IMAGE:
    case AIMEE_BLK_DOCUMENT:

--- a/src/server/aimee_backend_anthropic.c
+++ b/src/server/aimee_backend_anthropic.c
@@ -113,6 +113,16 @@ cJSON *anthropic_backend_build(const aimee_request_t *ir)
       cJSON_AddNumberToObject(out, "max_tokens", ir->max_tokens);
    if (ir->has_temperature)
       cJSON_AddNumberToObject(out, "temperature", ir->temperature);
+   if (ir->has_top_p)
+      cJSON_AddNumberToObject(out, "top_p", ir->top_p);
+   if (ir->has_top_k)
+      cJSON_AddNumberToObject(out, "top_k", ir->top_k);
+   if (ir->metadata)
+      cJSON_AddItemToObject(out, "metadata", cJSON_Duplicate(ir->metadata, 1));
+   if (ir->service_tier)
+      cJSON_AddStringToObject(out, "service_tier", ir->service_tier);
+   if (ir->thinking)
+      cJSON_AddItemToObject(out, "thinking", cJSON_Duplicate(ir->thinking, 1));
    if (ir->stream)
       cJSON_AddBoolToObject(out, "stream", 1);
    if (ir->n_system > 0)

--- a/src/server/aimee_backend_anthropic.c
+++ b/src/server/aimee_backend_anthropic.c
@@ -136,15 +136,14 @@ cJSON *anthropic_backend_build(const aimee_request_t *ir)
 {
    if (!ir)
       return NULL;
-   /* Same-protocol byte-faithful egress: an Anthropic request that no IR transform
-    * touched is byte-identical to its raw sidecar, so ship those exact bytes. This
-    * preserves Claude Code's prompt-cache prefix (which the typed re-serialization
-    * below would perturb via key-order/formatting) and is the whole point of routing
-    * the native path through the IR instead of a verbatim passthrough that skips it.
-    * A transform that mutates the typed fields sets ir->mutated, forcing the rebuild. */
-   if (ir->frontend == AIMEE_WIRE_ANTHROPIC && !ir->mutated && ir->raw)
-      return cJSON_Duplicate(ir->raw, 1);
-
+   /* The raw-sidecar fast-path was RETIRED here (cross-protocol canonical egress): the
+    * Anthropic egress is now a pure, deterministic function of the typed IR for EVERY
+    * source. Shipping the client's raw bytes only for an Anthropic source made
+    * openai->IR->anthropic and anthropic->IR->anthropic diverge (client key-order +
+    * client cache markers), but Anthropic prompt-caches on exact bytes, so the same
+    * logical content must serialize identically regardless of source. All top-level
+    * fields the sidecar preserved are now modeled (slice 1) and cache_control is
+    * applied uniformly (slice 2), so nothing is lost by rebuilding. */
    cJSON *out = cJSON_CreateObject();
    if (ir->model)
       cJSON_AddStringToObject(out, "model", ir->model);

--- a/src/server/aimee_backend_anthropic.c
+++ b/src/server/aimee_backend_anthropic.c
@@ -102,6 +102,8 @@ static cJSON *block_to_anthropic(const aimee_block_t *b)
    case AIMEE_BLK_THINKING:
       cJSON_AddStringToObject(el, "type", "thinking");
       cJSON_AddStringToObject(el, "thinking", b->text ? b->text : "");
+      if (b->thinking_signature)
+         cJSON_AddStringToObject(el, "signature", b->thinking_signature);
       break;
    case AIMEE_BLK_TOOL_USE:
       cJSON_AddStringToObject(el, "type", "tool_use");

--- a/src/server/aimee_backend_openai.c
+++ b/src/server/aimee_backend_openai.c
@@ -51,6 +51,12 @@ cJSON *openai_backend_build(const aimee_request_t *ir)
       cJSON_AddNumberToObject(out, "max_tokens", ir->max_tokens);
    if (ir->has_temperature)
       cJSON_AddNumberToObject(out, "temperature", ir->temperature);
+   if (ir->has_top_p)
+      cJSON_AddNumberToObject(out, "top_p", ir->top_p);
+   if (ir->has_top_k) /* OpenAI-compatible local providers (ollama/llama.cpp) accept top_k */
+      cJSON_AddNumberToObject(out, "top_k", ir->top_k);
+   if (ir->metadata)
+      cJSON_AddItemToObject(out, "metadata", cJSON_Duplicate(ir->metadata, 1));
    if (ir->stream)
       cJSON_AddBoolToObject(out, "stream", 1);
 

--- a/src/server/aimee_frontend_anthropic.c
+++ b/src/server/aimee_frontend_anthropic.c
@@ -51,6 +51,7 @@ static void parse_block(const cJSON *el, aimee_block_t *b)
    {
       b->type = AIMEE_BLK_THINKING;
       b->text = dupstr(ostr(el, "thinking"));
+      b->thinking_signature = dupstr(ostr(el, "signature"));
    }
    else if (strcmp(type, "tool_use") == 0)
    {

--- a/src/server/aimee_frontend_anthropic.c
+++ b/src/server/aimee_frontend_anthropic.c
@@ -150,6 +150,27 @@ int anthropic_frontend_parse(const cJSON *req, aimee_request_t *out, char *err, 
       out->temperature = temp->valuedouble;
       out->has_temperature = 1;
    }
+   const cJSON *top_p = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "top_p");
+   if (top_p && cJSON_IsNumber(top_p))
+   {
+      out->top_p = top_p->valuedouble;
+      out->has_top_p = 1;
+   }
+   const cJSON *top_k = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "top_k");
+   if (top_k && cJSON_IsNumber(top_k))
+   {
+      out->top_k = top_k->valueint;
+      out->has_top_k = 1;
+   }
+   const cJSON *meta = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "metadata");
+   if (meta && !cJSON_IsNull(meta))
+      out->metadata = cJSON_Duplicate(meta, 1);
+   const cJSON *stier = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "service_tier");
+   if (stier && cJSON_IsString(stier) && stier->valuestring)
+      out->service_tier = strdup(stier->valuestring);
+   const cJSON *think = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "thinking");
+   if (think && !cJSON_IsNull(think))
+      out->thinking = cJSON_Duplicate(think, 1);
    const cJSON *stream = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "stream");
    out->stream = (stream && cJSON_IsTrue(stream)) ? 1 : 0;
 

--- a/src/server/aimee_frontend_openai.c
+++ b/src/server/aimee_frontend_openai.c
@@ -103,6 +103,21 @@ int openai_frontend_parse(const cJSON *req, aimee_request_t *out, char *err, siz
       out->temperature = temp->valuedouble;
       out->has_temperature = 1;
    }
+   const cJSON *top_p = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "top_p");
+   if (top_p && cJSON_IsNumber(top_p))
+   {
+      out->top_p = top_p->valuedouble;
+      out->has_top_p = 1;
+   }
+   const cJSON *top_k = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "top_k");
+   if (top_k && cJSON_IsNumber(top_k))
+   {
+      out->top_k = top_k->valueint;
+      out->has_top_k = 1;
+   }
+   const cJSON *meta = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "metadata");
+   if (meta && !cJSON_IsNull(meta))
+      out->metadata = cJSON_Duplicate(meta, 1);
    const cJSON *stream = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "stream");
    out->stream = (stream && cJSON_IsTrue(stream)) ? 1 : 0;
 

--- a/src/server/aimee_frontend_openai.c
+++ b/src/server/aimee_frontend_openai.c
@@ -66,7 +66,38 @@ static int append_openai_content(const cJSON *content, aimee_block_t **blocks, i
       {
          b->type = AIMEE_BLK_IMAGE;
          const cJSON *iu = cJSON_GetObjectItemCaseSensitive((cJSON *)el, "image_url");
-         b->media_ref = dupstr(iu ? ostr(iu, "url") : NULL);
+         const char *url = iu ? ostr(iu, "url") : NULL;
+/* Canonicalize an inline base64 data: URL into the structured media_type + base64
+ * data form the Anthropic egress emits, so an OpenAI-sourced inline image serializes
+ * identically to an Anthropic-sourced one. The RFC-2397 shape is
+ * "data:<media_type>;base64,<data>": the FIRST comma delimits the header from the
+ * data, and the header must end with ";base64". Anything else (plain http(s) URL, a
+ * non-base64 data URL, or a ";base64," that appears only inside the payload after the
+ * comma) is kept as a url reference verbatim -- Anthropic has no data:-url image form,
+ * so there is no cross-protocol counterpart to canonicalize toward. */
+#define DATA_URL_PREFIX_LEN 5 /* strlen("data:") */
+#define B64_SUFFIX          ";base64"
+#define B64_SUFFIX_LEN      7 /* strlen(";base64") */
+         const char *comma = url ? strchr(url, ',') : NULL;
+         int decomposed = 0;
+         if (url && strncmp(url, "data:", DATA_URL_PREFIX_LEN) == 0 && comma)
+         {
+            const char *hdr = url + DATA_URL_PREFIX_LEN;
+            size_t hdr_len = (size_t)(comma - hdr);
+            if (hdr_len > B64_SUFFIX_LEN &&
+                strncmp(comma - B64_SUFFIX_LEN, B64_SUFFIX, B64_SUFFIX_LEN) == 0)
+            {
+               size_t mt_len = hdr_len - B64_SUFFIX_LEN; /* media_type before ";base64" */
+               b->media_type = strndup(hdr, mt_len);
+               b->media_ref = strdup(comma + 1);
+               decomposed = 1;
+            }
+         }
+         if (!decomposed)
+            b->media_ref = dupstr(url);
+#undef DATA_URL_PREFIX_LEN
+#undef B64_SUFFIX
+#undef B64_SUFFIX_LEN
       }
       else /* text (default) */
       {

--- a/src/server/aimee_frontend_responses.c
+++ b/src/server/aimee_frontend_responses.c
@@ -69,6 +69,15 @@ int responses_frontend_parse(const cJSON *req, aimee_request_t *out, char *err, 
       out->max_tokens = mot->valueint;
       out->has_max_tokens = 1;
    }
+   const cJSON *top_p = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "top_p");
+   if (top_p && cJSON_IsNumber(top_p))
+   {
+      out->top_p = top_p->valuedouble;
+      out->has_top_p = 1;
+   }
+   const cJSON *meta = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "metadata");
+   if (meta && !cJSON_IsNull(meta))
+      out->metadata = cJSON_Duplicate(meta, 1);
    const cJSON *stream = cJSON_GetObjectItemCaseSensitive((cJSON *)req, "stream");
    out->stream = (stream && cJSON_IsTrue(stream)) ? 1 : 0;
 

--- a/src/server/aimee_ir.c
+++ b/src/server/aimee_ir.c
@@ -71,6 +71,9 @@ void aimee_request_free(aimee_request_t *r)
       free(r->tools);
    }
    cJSON_Delete(r->tool_choice);
+   cJSON_Delete(r->metadata);
+   free_str(r->service_tier);
+   cJSON_Delete(r->thinking);
    if (r->stop_sequences)
    {
       for (int i = 0; i < r->n_stop; i++)
@@ -237,6 +240,16 @@ int aimee_ir_request_equal(const aimee_request_t *a, const aimee_request_t *b)
       return 0;
    if (a->has_temperature != b->has_temperature ||
        (a->has_temperature && a->temperature != b->temperature))
+      return 0;
+   if (a->has_top_p != b->has_top_p || (a->has_top_p && a->top_p != b->top_p))
+      return 0;
+   if (a->has_top_k != b->has_top_k || (a->has_top_k && a->top_k != b->top_k))
+      return 0;
+   if (!json_eq(a->metadata, b->metadata))
+      return 0;
+   if (!str_eq(a->service_tier, b->service_tier))
+      return 0;
+   if (!json_eq(a->thinking, b->thinking))
       return 0;
    if (a->stream != b->stream || a->n_stop != b->n_stop)
       return 0;

--- a/src/server/aimee_ir.c
+++ b/src/server/aimee_ir.c
@@ -17,6 +17,7 @@ void aimee_block_free_contents(aimee_block_t *b)
    if (!b)
       return;
    free_str(b->text);
+   free_str(b->thinking_signature);
    free_str(b->tool_id);
    free_str(b->tool_name);
    cJSON_Delete(b->tool_input);
@@ -177,8 +178,9 @@ static int block_eq(const aimee_block_t *a, const aimee_block_t *b)
    switch (a->type)
    {
    case AIMEE_BLK_TEXT:
-   case AIMEE_BLK_THINKING:
       return str_eq(a->text, b->text);
+   case AIMEE_BLK_THINKING:
+      return str_eq(a->text, b->text) && str_eq(a->thinking_signature, b->thinking_signature);
    case AIMEE_BLK_TOOL_USE:
       return str_eq(a->tool_id, b->tool_id) && str_eq(a->tool_name, b->tool_name) &&
              json_eq(a->tool_input, b->tool_input);

--- a/src/server/aimee_ir_shadow.c
+++ b/src/server/aimee_ir_shadow.c
@@ -227,43 +227,50 @@ void aimee_ir_shadow_observe_request(const cJSON *req, aimee_wire_t frontend)
    }
    aimee_ir_metric_inc(AIMEE_IR_M_IR_PATH, frontend);
 
-   /* Rebuild same-protocol and check BYTE-exact parity -- the caching gate. The
-    * verbatim passthrough forwards serialize(req) (cJSON re-emits the parsed request
-    * in its original key order), so serialize(anthropic_backend_build(parse(req)))
-    * == serialize(req) means the IR egress is a byte-faithful drop-in and the
-    * passthrough can be retired. On a mismatch, semantic_equal (cJSON_Compare,
-    * key-order-insensitive) separates harmless key-order/formatting drift from real
-    * field loss. Per the roundtable no-raw-bytes rule, only lengths + the semantic
-    * flag are logged, never request content. */
-   cJSON *rebuilt = anthropic_backend_build(&ir);
-   if (!rebuilt)
+   /* The byte-parity gate was retired with the raw sidecar (the canonical egress now
+    * INTENTIONALLY re-renders every request, so byte-parity vs the client's raw bytes
+    * is meaningless). But the residual risk it implicitly covered -- a top-level field
+    * the IR does not model being silently DROPPED from the canonical egress -- remains.
+    * So the shadow is re-purposed to FIELD-COVERAGE detection: every top-level key the
+    * client sent must be one the IR models. A request using only modeled keys scores
+    * REBUILD_MATCH; one carrying an unmodeled top-level key scores REBUILD_MISMATCH and
+    * logs the key NAME (never its value -- no request content in logs), flagging a
+    * modeling gap to close. Cheap: a key-name scan, no rebuild. */
+   static const char *const MODELED[] = {
+       "model",        "max_tokens",  "messages", "system",         "tools",
+       "tool_choice",  "temperature", "top_p",    "top_k",          "metadata",
+       "service_tier", "thinking",    "stream",   "stop_sequences", NULL};
+   const char *unmodeled = NULL;
+   for (const cJSON *k = req->child; k; k = k->next)
    {
-      aimee_ir_metric_inc(AIMEE_IR_M_BACKEND_BUILD_FAIL, frontend);
+      if (!k->string)
+         continue;
+      int modeled = 0;
+      for (const char *const *m = MODELED; *m; m++)
+         if (strcmp(k->string, *m) == 0)
+         {
+            modeled = 1;
+            break;
+         }
+      if (!modeled)
+      {
+         unmodeled = k->string;
+         break;
+      }
+   }
+   if (!unmodeled)
+   {
+      aimee_ir_metric_inc(AIMEE_IR_M_REBUILD_MATCH, frontend);
    }
    else
    {
-      char *req_s = cJSON_PrintUnformatted(req);
-      char *reb_s = cJSON_PrintUnformatted(rebuilt);
-      if (req_s && reb_s && strcmp(req_s, reb_s) == 0)
+      aimee_ir_metric_inc(AIMEE_IR_M_REBUILD_MISMATCH, frontend);
+      if (g_logged < SHADOW_LOG_CAP)
       {
-         aimee_ir_metric_inc(AIMEE_IR_M_REBUILD_MATCH, frontend);
+         g_logged++;
+         fprintf(stderr, "[ir-shadow] anthropic canonical egress drops unmodeled top-level '%s'\n",
+                 unmodeled);
       }
-      else
-      {
-         aimee_ir_metric_inc(AIMEE_IR_M_REBUILD_MISMATCH, frontend);
-         if (g_logged < SHADOW_LOG_CAP)
-         {
-            g_logged++;
-            fprintf(
-                stderr,
-                "[ir-shadow] anthropic byte MISMATCH (req_len=%zu reb_len=%zu semantic_equal=%d)\n",
-                req_s ? strlen(req_s) : (size_t)0, reb_s ? strlen(reb_s) : (size_t)0,
-                cJSON_Compare(req, rebuilt, 1));
-         }
-      }
-      free(req_s);
-      free(reb_s);
-      cJSON_Delete(rebuilt);
    }
    aimee_request_free(&ir);
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -152,6 +152,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-aimee-ir \
                $(TESTPREFIX)/unit-test-ir-legacy-parity \
                $(TESTPREFIX)/unit-test-agent-request-build \
+               $(TESTPREFIX)/unit-test-ir-crossproto-egress \
                $(TESTPREFIX)/unit-test-aimee-ir-rescue \
                $(TESTPREFIX)/unit-test-agent-ir-parse \
                $(TESTPREFIX)/unit-test-responses-parity \
@@ -4307,6 +4308,15 @@ $(TESTPREFIX)/unit-test-agent-request-build: $(OBJDIR)/tests/test_agent_request_
                                        $(OBJDIR)/server/agent_request_shaping.o \
                                        $(OBJDIR)/server/provider_catalog.o \
                                        $(TEST_CORE_OBJS) $(OBJDIR)/platform_random.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-ir-crossproto-egress: $(OBJDIR)/tests/test_ir_crossproto_egress.o \
+                                       $(OBJDIR)/server/aimee_backend_anthropic.o \
+                                       $(OBJDIR)/server/aimee_frontend_anthropic.o \
+                                       $(OBJDIR)/server/aimee_frontend_openai.o \
+                                       $(OBJDIR)/server/aimee_ir.o \
+                                       $(OBJDIR)/server/aimee_ir_metrics.o \
+                                       $(OBJDIR)/text.o $(OBJDIR)/util.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-ir-legacy-parity: $(OBJDIR)/tests/test_ir_legacy_parity.o \

--- a/src/tests/test_agent_request_build.c
+++ b/src/tests/test_agent_request_build.c
@@ -63,10 +63,13 @@ int main(void)
    printf("agent_request_build golden:\n");
 
    /* Anthropic Messages wire: system + user as typed text blocks, max_tokens, then
-    * temperature (from model_sampling). This is the HARD byte-identity surface. */
+    * temperature (from model_sampling). This is the HARD byte-identity surface. The
+    * system block carries the uniform aimee cache_control policy (mark_cache_prefix):
+    * the canonical Anthropic egress caches the stable system prefix on every source. */
    golden("anthropic", "claude-3-5-sonnet",
           "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":100,"
-          "\"system\":[{\"type\":\"text\",\"text\":\"You are helpful.\"}],"
+          "\"system\":[{\"type\":\"text\",\"text\":\"You are helpful.\","
+          "\"cache_control\":{\"type\":\"ephemeral\"}}],"
           "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\","
           "\"text\":\"deploy the release\"}]}],\"temperature\":0.7}");
 

--- a/src/tests/test_aimee_backend.c
+++ b/src/tests/test_aimee_backend.c
@@ -46,26 +46,30 @@ int main(void)
    printf("aimee-backend: ");
    char err[128];
 
-   /* --- (1) same-protocol round-trip is IR-stable --- */
+   /* --- (1) the canonical Anthropic egress is DETERMINISTIC and round-trip STABLE.
+    *         The raw sidecar was retired: egress is now a pure function of the typed IR
+    *         plus the uniform cache policy, so parse->build is NOT the identity (it adds
+    *         the policy's cache markers), but it IS idempotent -- building twice is
+    *         byte-identical, and re-parsing the egress then rebuilding reproduces it. --- */
    aimee_request_t air;
    parse_anthropic(ANTHROPIC, &air);
    cJSON *built = anthropic_backend_build(&air);
    assert(built);
+   char *b1 = cJSON_PrintUnformatted(built);
+   cJSON *built2 = anthropic_backend_build(&air); /* determinism: a second build matches */
+   char *b2 = cJSON_PrintUnformatted(built2);
+   assert(b1 && b2 && strcmp(b1, b2) == 0);
    aimee_request_t air2;
    assert(anthropic_frontend_parse(built, &air2, err, sizeof err) == 0);
-   assert(aimee_ir_request_equal(&air, &air2)); /* parse->build->parse stable */
-   /* ...and BYTE-exact: an unmutated same-protocol build ships the raw sidecar, so
-    * the wire bytes are identical to the client's (prompt cache preserved). */
-   {
-      cJSON *orig = cJSON_Parse(ANTHROPIC);
-      char *os = cJSON_PrintUnformatted(orig);
-      char *bs = cJSON_PrintUnformatted(built);
-      assert(os && bs && strcmp(os, bs) == 0);
-      free(os);
-      free(bs);
-      cJSON_Delete(orig);
-   }
+   cJSON *rebuilt = anthropic_backend_build(&air2); /* idempotent round-trip */
+   char *b3 = cJSON_PrintUnformatted(rebuilt);
+   assert(b3 && strcmp(b1, b3) == 0);
+   free(b1);
+   free(b2);
+   free(b3);
    cJSON_Delete(built);
+   cJSON_Delete(built2);
+   cJSON_Delete(rebuilt);
 
    /* --- (1b) ir->mutated forces the typed rebuild; MODELED top-level fields
     *          (top_p, top_k, metadata) survive it -- required so the canonical egress

--- a/src/tests/test_aimee_backend.c
+++ b/src/tests/test_aimee_backend.c
@@ -98,26 +98,37 @@ int main(void)
       aimee_request_free(&uir);
    }
 
-   /* --- (2) CROSS-protocol build: OpenAI-parsed IR -> Anthropic request -> same IR
-    *         an Anthropic client would produce. --- */
+   /* --- (2) CROSS-protocol BYTE-IDENTITY: the Anthropic egress of the SAME logical
+    *         content is byte-identical whether sourced from OpenAI-wire or
+    *         Anthropic-wire (Anthropic prompt-caches on exact bytes). The served model
+    *         is overridden to the target agent's in the real flow, so align it here;
+    *         force air through the typed rebuild (mutated) instead of the raw sidecar. --- */
    cJSON *oj = cJSON_Parse(OPENAI);
    aimee_request_t oir;
    assert(openai_frontend_parse(oj, &oir, err, sizeof err) == 0);
    cJSON_Delete(oj);
-   cJSON *xbuilt = anthropic_backend_build(&oir); /* IR (from OpenAI) -> Anthropic wire */
-   assert(xbuilt);
-   aimee_request_t xir;
-   assert(anthropic_frontend_parse(xbuilt, &xir, err, sizeof err) == 0);
-   assert(aimee_ir_request_equal(&air, &xir)); /* OpenAI client -> Anthropic backend == native */
+   free(oir.model);
+   oir.model = strdup("claude-3-5-sonnet");
+   free(air.model);
+   air.model = strdup("claude-3-5-sonnet");
+   air.mutated = 1;
+   cJSON *xbuilt = anthropic_backend_build(&oir); /* openai -> IR -> anthropic egress */
+   cJSON *abuilt = anthropic_backend_build(&air); /* anthropic -> IR -> anthropic egress */
+   assert(xbuilt && abuilt);
+   char *xs = cJSON_PrintUnformatted(xbuilt);
+   char *as = cJSON_PrintUnformatted(abuilt);
+   assert(xs && as && strcmp(xs, as) == 0); /* cross-protocol egress is BYTE-IDENTICAL */
    /* the built Anthropic request has system as a top-level field, not a message */
    assert(cJSON_GetObjectItem(xbuilt, "system") != NULL);
    assert(cJSON_GetArraySize(cJSON_GetObjectItem(xbuilt, "messages")) == 1);
+   free(xs);
+   free(as);
    cJSON_Delete(xbuilt);
+   cJSON_Delete(abuilt);
 
    aimee_request_free(&air);
    aimee_request_free(&air2);
    aimee_request_free(&oir);
-   aimee_request_free(&xir);
 
    /* --- (3) response parse: Anthropic response -> IR --- */
    const char *RESP =

--- a/src/tests/test_aimee_backend.c
+++ b/src/tests/test_aimee_backend.c
@@ -67,20 +67,32 @@ int main(void)
    }
    cJSON_Delete(built);
 
-   /* --- (1b) ir->mutated forces the typed rebuild; an unmodeled field (top_p) is
-    *          preserved by the raw passthrough but dropped by the rebuild. --- */
+   /* --- (1b) ir->mutated forces the typed rebuild; MODELED top-level fields
+    *          (top_p, top_k, metadata) survive it -- required so the canonical egress
+    *          is byte-faithful once the raw sidecar is retired. --- */
    {
       cJSON *uj = cJSON_Parse("{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,\"messages\":[{"
                               "\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}"
-                              "],\"top_p\":0.9}");
+                              "],\"top_p\":0.9,\"top_k\":40,\"metadata\":{\"user_id\":\"u1\"},"
+                              "\"service_tier\":\"standard_only\","
+                              "\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024}}");
       aimee_request_t uir;
       assert(anthropic_frontend_parse(uj, &uir, err, sizeof err) == 0);
       cJSON_Delete(uj);
       cJSON *clean = anthropic_backend_build(&uir); /* mutated=0 -> raw passthrough */
       assert(clean && cJSON_GetObjectItem(clean, "top_p") != NULL); /* preserved */
       uir.mutated = 1;
-      cJSON *rebuilt = anthropic_backend_build(&uir);                   /* typed rebuild */
-      assert(rebuilt && cJSON_GetObjectItem(rebuilt, "top_p") == NULL); /* dropped (unmodeled) */
+      cJSON *rebuilt = anthropic_backend_build(&uir); /* typed rebuild */
+      cJSON *tp = cJSON_GetObjectItem(rebuilt, "top_p");
+      cJSON *tk = cJSON_GetObjectItem(rebuilt, "top_k");
+      cJSON *md = cJSON_GetObjectItem(rebuilt, "metadata");
+      cJSON *st = cJSON_GetObjectItem(rebuilt, "service_tier");
+      cJSON *th = cJSON_GetObjectItem(rebuilt, "thinking");
+      assert(tp && tp->valuedouble == 0.9); /* modeled -> survives the rebuild */
+      assert(tk && tk->valueint == 40);     /* modeled */
+      assert(md && cJSON_IsObject(md));     /* modeled (opaque, preserved) */
+      assert(st && cJSON_IsString(st) && strcmp(st->valuestring, "standard_only") == 0);
+      assert(th && cJSON_IsObject(th)); /* thinking config (opaque, preserved) */
       cJSON_Delete(clean);
       cJSON_Delete(rebuilt);
       aimee_request_free(&uir);

--- a/src/tests/test_aimee_ir_shadow.c
+++ b/src/tests/test_aimee_ir_shadow.c
@@ -31,33 +31,42 @@ int main(void)
    aimee_ir_shadow_observe_request(req, AIMEE_WIRE_ANTHROPIC);
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 0);
 
-   /* enabled -> byte-faithful request scores a MATCH, no mismatch */
+   /* enabled -> the observer parses (IR_PATH) and runs FIELD-COVERAGE detection: a
+    * request using only IR-modeled top-level keys scores REBUILD_MATCH; one carrying an
+    * unmodeled top-level key scores REBUILD_MISMATCH (the canonical egress would drop
+    * it). The byte-parity gate was retired with the sidecar; this replaces it with the
+    * detection that actually matters post-retirement -- silent field drop. */
    setenv("AIMEE_IR_SHADOW", "1", 1);
    aimee_ir_shadow_observe_request(req, AIMEE_WIRE_ANTHROPIC);
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 1);
    assert(aimee_ir_metric_total(AIMEE_IR_M_PARSE_FAIL) == 0);
-   assert(aimee_ir_metric_total(AIMEE_IR_M_BACKEND_BUILD_FAIL) == 0);
-   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MATCH) == 1);    /* byte-exact */
-   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 0); /* clean */
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MATCH) == 1);    /* all keys modeled */
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 0); /* no field dropped */
 
-   /* a non-Anthropic frontend is skipped in this slice */
+   /* a non-Anthropic frontend is skipped in this observer */
    aimee_ir_shadow_observe_request(req, AIMEE_WIRE_OPENAI_CHAT);
    assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 1); /* unchanged */
 
-   /* a request carrying a field the IR does not model (top_p): the byte-faithful
-    * same-protocol egress ships the raw sidecar verbatim, so top_p is PRESERVED and
-    * the round-trip still MATCHes. This is the passthrough FIXING the silent field
-    * loss the typed rebuild used to cause -- a clean Anthropic request is now
-    * byte-identical regardless of which fields the typed IR models. */
-   cJSON *unmodeled = cJSON_Parse(
+   /* modeled fields (incl. top_p, now modeled) still score MATCH */
+   cJSON *modeled = cJSON_Parse(
        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
        "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}],"
        "\"top_p\":0.9}");
+   assert(modeled);
+   aimee_ir_shadow_observe_request(modeled, AIMEE_WIRE_ANTHROPIC);
+   assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 2);
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MATCH) == 2);
+   cJSON_Delete(modeled);
+
+   /* an UNMODELED top-level field (a future Anthropic key the IR does not model) is
+    * flagged: the canonical egress would silently drop it. */
+   cJSON *unmodeled = cJSON_Parse(
+       "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
+       "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}],"
+       "\"future_knob\":true}");
    assert(unmodeled);
    aimee_ir_shadow_observe_request(unmodeled, AIMEE_WIRE_ANTHROPIC);
-   assert(aimee_ir_metric_total(AIMEE_IR_M_IR_PATH) == 2);          /* parsed + observed */
-   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MATCH) == 2);    /* both byte-identical */
-   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 0); /* passthrough preserves all */
+   assert(aimee_ir_metric_total(AIMEE_IR_M_REBUILD_MISMATCH) == 1); /* field-drop detected */
    cJSON_Delete(unmodeled);
 
    /* NULL request is safe */

--- a/src/tests/test_ir_crossproto_egress.c
+++ b/src/tests/test_ir_crossproto_egress.c
@@ -67,6 +67,77 @@ int main(void)
         "\"messages\":[{\"role\":\"system\",\"content\":\"You are helpful.\"},"
         "{\"role\":\"user\",\"content\":\"hi\"}]}");
 
+   /* Tool-bearing multi-turn: system + user + assistant tool_use + user tool_result,
+    * plus a tool definition. Exercises tool_input, tool_result shape, and tool schema
+    * canonicalization across the frontends. */
+   same(
+       "tools",
+       "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":100,"
+       "\"system\":[{\"type\":\"text\",\"text\":\"sys\"}],"
+       "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"read foo\"}]},"
+       "{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"t1\",\"name\":"
+       "\"Read\","
+       "\"input\":{\"path\":\"foo\"}}]},"
+       "{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"t1\","
+       "\"content\":\"file body\"}]}],"
+       "\"tools\":[{\"name\":\"Read\",\"description\":\"Read a file\",\"input_schema\":"
+       "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\"}}}}]}",
+       "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":100,"
+       "\"messages\":[{\"role\":\"system\",\"content\":\"sys\"},"
+       "{\"role\":\"user\",\"content\":\"read foo\"},"
+       "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"t1\","
+       "\"type\":\"function\",\"function\":{\"name\":\"Read\",\"arguments\":\"{\\\"path\\\":"
+       "\\\"foo\\\"}\"}}]},"
+       "{\"role\":\"tool\",\"tool_call_id\":\"t1\",\"content\":\"file body\"}],"
+       "\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"Read\",\"description\":\"Read a "
+       "file\",\"parameters\":{\"type\":\"object\",\"properties\":{\"path\":{\"type\":"
+       "\"string\"}}}}}]}");
+
+   /* Inline base64 image: Anthropic sends a structured base64 source; OpenAI sends a
+    * data: URL. The openai frontend must decompose the data: URL to match. */
+   same("image-b64",
+        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
+        "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"image\",\"source\":"
+        "{\"type\":\"base64\",\"media_type\":\"image/png\",\"data\":\"AAAA\"}}]}]}",
+        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
+        "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"image_url\",\"image_url\":"
+        "{\"url\":\"data:image/png;base64,AAAA\"}}]}]}");
+
+   /* tool_result as an Anthropic block-array vs an OpenAI string: the egress collapses
+    * a single text block to the string form so both match. */
+   same("tool-result-array",
+        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
+        "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\","
+        "\"tool_use_id\":\"t1\",\"content\":[{\"type\":\"text\",\"text\":\"body\"}]}]}]}",
+        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
+        "\"messages\":[{\"role\":\"tool\",\"tool_call_id\":\"t1\",\"content\":\"body\"}]}");
+
+   /* Mixed multi-part user content: text + inline base64 image in one message. */
+   same("mixed-content",
+        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
+        "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"see this\"},"
+        "{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/png\","
+        "\"data\":\"AAAA\"}}]}]}",
+        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":8,"
+        "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"see this\"},"
+        "{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,AAAA\"}}]}]}");
+
+   /* Regression: a data: URL where ";base64," appears only AFTER the first comma (i.e.
+    * inside the payload, not as the RFC-2397 header marker) must NOT be decomposed --
+    * it is kept as a verbatim url reference, not misparsed into a base64 source. */
+   {
+      char *e = egress("{\"model\":\"m\",\"max_tokens\":8,\"messages\":[{\"role\":\"user\","
+                       "\"content\":[{\"type\":\"image_url\",\"image_url\":"
+                       "{\"url\":\"data:image/png,payload;base64,tail\"}}]}]}",
+                       1);
+      assert(e);
+      assert(strstr(e, "\"type\":\"url\"") != NULL);                   /* kept as url ref */
+      assert(strstr(e, "data:image/png,payload;base64,tail") != NULL); /* verbatim */
+      assert(strstr(e, "\"type\":\"base64\"") == NULL);                /* NOT decomposed */
+      printf("  data-url-earlier-comma-passthrough OK\n");
+      free(e);
+   }
+
    printf("all cross-protocol egress byte-identity checks passed\n");
    return 0;
 }

--- a/src/tests/test_ir_crossproto_egress.c
+++ b/src/tests/test_ir_crossproto_egress.c
@@ -138,6 +138,34 @@ int main(void)
       free(e);
    }
 
+   /* Thinking block signature: Anthropic requires the opaque signature echoed back
+    * verbatim on a resubmitted assistant thinking turn. With the raw sidecar retired,
+    * the canonical rebuild must preserve it (it is modeled, not carried via raw). */
+   {
+      char *e = egress("{\"model\":\"m\",\"max_tokens\":8,\"messages\":[{\"role\":\"assistant\","
+                       "\"content\":[{\"type\":\"thinking\",\"thinking\":\"reasoning\","
+                       "\"signature\":\"sig123\"}]}]}",
+                       0);
+      assert(e);
+      assert(strstr(e, "\"signature\":\"sig123\"") != NULL); /* preserved through rebuild */
+      printf("  thinking-signature-preserved OK\n");
+      free(e);
+   }
+
+   /* redacted_thinking blocks (opaque base64 data) have no typed IR arm, so they are
+    * preserved verbatim via the UNKNOWN/raw replay path -- confirm the canonical
+    * rebuild does not drop them (required to resubmit an extended-thinking turn). */
+   {
+      char *e = egress("{\"model\":\"m\",\"max_tokens\":8,\"messages\":[{\"role\":\"assistant\","
+                       "\"content\":[{\"type\":\"redacted_thinking\",\"data\":\"Er0Bopaque\"}]}]}",
+                       0);
+      assert(e);
+      assert(strstr(e, "\"redacted_thinking\"") != NULL);
+      assert(strstr(e, "Er0Bopaque") != NULL); /* opaque data preserved verbatim */
+      printf("  redacted-thinking-preserved OK\n");
+      free(e);
+   }
+
    printf("all cross-protocol egress byte-identity checks passed\n");
    return 0;
 }

--- a/src/tests/test_ir_crossproto_egress.c
+++ b/src/tests/test_ir_crossproto_egress.c
@@ -1,0 +1,72 @@
+/* test_ir_crossproto_egress.c -- the IR-funnel HARD requirement: outbound requests
+ * to the Anthropic Messages API must be BYTE-IDENTICAL for the same logical
+ * conversation regardless of the client's source protocol, because Anthropic
+ * prompt-caches on exact bytes. So anthropic->IR->anthropic and openai->IR->anthropic
+ * must serialize identically. This is achieved by making the Anthropic egress a pure,
+ * deterministic function of the typed IR (no raw sidecar) with a uniform aimee
+ * cache_control policy applied at egress (client markers normalized away). */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "aimee_ir.h"
+#include "aimee_frontend.h"
+#include "aimee_backend.h"
+#include "cJSON.h"
+
+/* Build the Anthropic egress bytes for a request expressed in `wire`. */
+static char *egress(const char *body, int frontend /* 0=anthropic,1=openai */)
+{
+   cJSON *req = cJSON_Parse(body);
+   assert(req);
+   aimee_request_t ir;
+   char err[128];
+   int rc = (frontend == 0) ? anthropic_frontend_parse(req, &ir, err, sizeof err)
+                            : openai_frontend_parse(req, &ir, err, sizeof err);
+   assert(rc == 0);
+   cJSON *out = anthropic_backend_build(&ir);
+   assert(out);
+   char *s = cJSON_PrintUnformatted(out);
+   cJSON_Delete(out);
+   aimee_request_free(&ir);
+   cJSON_Delete(req);
+   return s;
+}
+
+static void same(const char *label, const char *anth_wire, const char *oai_wire)
+{
+   char *a = egress(anth_wire, 0);
+   char *o = egress(oai_wire, 1);
+   if (!a || !o || strcmp(a, o) != 0)
+   {
+      printf("  CROSS-PROTO DRIFT [%s]\n    anthropic-src: %s\n    openai-src   : %s\n", label,
+             a ? a : "(null)", o ? o : "(null)");
+      free(a);
+      free(o);
+      exit(1);
+   }
+   printf("  %s: byte-identical OK\n", label);
+   free(a);
+   free(o);
+}
+
+int main(void)
+{
+   printf("cross-protocol anthropic egress byte-identity:\n");
+
+   /* Text-only turn: same served model, system, and user content in each wire.
+    * The anthropic client sends its own cache_control; the openai client sends none.
+    * A uniform egress cache policy must normalize both to identical bytes. */
+   same("text",
+        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":100,"
+        "\"system\":[{\"type\":\"text\",\"text\":\"You are helpful.\","
+        "\"cache_control\":{\"type\":\"ephemeral\"}}],"
+        "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}]}",
+        "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":100,"
+        "\"messages\":[{\"role\":\"system\",\"content\":\"You are helpful.\"},"
+        "{\"role\":\"user\",\"content\":\"hi\"}]}");
+
+   printf("all cross-protocol egress byte-identity checks passed\n");
+   return 0;
+}


### PR DESCRIPTION
Makes outbound requests to the Anthropic Messages API **byte-identical for the same logical conversation regardless of source protocol** — `openai→IR→anthropic` ≡ `anthropic→IR→anthropic` — because Anthropic prompt-caches on exact bytes. Before this, the anthropic path shipped the client's raw sidecar (its key order + its cache markers) while an openai path used the renderer's order with no markers, so cross-protocol traffic (Codex→Anthropic) diverged byte-wise and got zero Anthropic caching.

## Design (user-approved)
The Anthropic egress is now a pure, deterministic function of the typed IR for every source, with `cache_control` decided **uniformly by aimee at egress** (client markers normalized away). The #1496 raw sidecar is **retired** — so every field it preserved is now modeled in the IR.

## Slices (each roundtable-approved)
1. **Model top-level fields** — `top_p`/`top_k`/`metadata`/`service_tier`/`thinking`; all frontends parse, backends emit.
2. **Uniform cache policy** — strip client `cache_control`, mark the stable-prefix breakpoints (system, tools) ephemeral, deterministically.
3. **Retire the raw sidecar** — canonical rebuild for every source; re-purpose the request shadow into a silent-field-drop (unmodeled top-level key) detector.
4. **Canonicalize content shapes** — openai `data:` URL inline images → structured base64 (RFC-2397, comma-anchored); `tool_result` single-text-block array → string.
5. **Model the thinking-block signature** — required on resubmitted extended-thinking turns; `redacted_thinking` preserved via the raw/UNKNOWN path.

Plus an integration fix: updated #1506's `agent_request_build` anthropic golden, since the uniform cache policy now marks agent_execute's originated Anthropic requests too (they gain caching).

## Verification
New `unit-test-ir-crossproto-egress`: same conversation via both wires → anthropic egress → `strcmp` byte-identical, across text / tools / base64-image / array-tool_result / mixed-content, plus regression/preservation pins (data-url comma anchoring, thinking-signature, redacted-thinking). Full `make unit-tests` + `make build-integrity` green.

## Trade-offs (accepted)
- One-time provider prompt-cache re-warm for anthropic-native clients (egress re-renders canonically); turn-over-turn stability preserved by determinism.
- The uniform policy overrides Claude Code's own `cache_control` (required for cross-source identity; where cache-breakpoint economization lives).
- Unmodeled future Anthropic top-level fields are dropped by the rebuild; the re-purposed shadow logs them (key name only).
