### PR TITLE
fix(wfe): run the implement mechanical verify inside the delegate sandbox

### DIFF
--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -113,7 +113,10 @@ with a `security` lens before `pr.open` adds a mandatory security review.
    The commit happens at `freeze`, not per unit.
 3. **Verify, as hard as possible.** Verification runs through the engine's gates
    and delegates, never the primary's own hands, in ascending cost:
-   - mechanical, the build compiles, targeted tests/lint pass (`gate.ci`);
+   - mechanical, the build compiles, targeted tests/lint pass (`gate.ci`). The
+     `implement` block's mandatory mechanical verify runs **inside the delegate's
+     toolchain sandbox**, not the server process — see
+     [Verifying in the delegate sandbox](DELEGATE_SANDBOX_VERIFY.md);
    - review, a roundtable / `reviewer` panel checks the change against its spec
      (`gate.roundtable`);
    - adversarial, for risky changes, skeptic verifiers attempt to refute it.

--- a/docs/DELEGATE_SANDBOX_VERIFY.md
+++ b/docs/DELEGATE_SANDBOX_VERIFY.md
@@ -1,0 +1,122 @@
+# Verifying in the delegate sandbox
+
+> **Autonomous verify runs where the toolchain is.** When the workflow engine
+> gates an `implement` unit on `aimee git verify`, the verify steps now run
+> **inside the delegate's `--network none` sandbox** — the same per-project,
+> toolchain-baked image the engineer delegate builds against — instead of in the
+> `aimee-server` process. The slim server runtime image ships no `gcc`/`make`/
+> `node`, so an in-process verify there can never build a real project; running
+> verify in the sandbox is what lets an autonomous run reach a green gate.
+
+## Why this exists
+
+An autonomous `build` run decomposes a proposal into slices and, for each slice,
+runs `implement → freeze → roundtable → PR → CI → merge`. The `implement` block
+ends with a **mandatory mechanical verify** (`wfe_implement_verify_ok`): the
+change must pass `aimee git verify` before it can advance, and the gate is
+**fail-closed** — if verify cannot run, the unit does not advance, it loops.
+
+The `aimee-server` binary ships in a **slim runtime image** (the final stage of
+`Dockerfile.server` is `debian:bookworm-slim` with the compiled binaries and
+runtime libraries only — no compiler, no build tools). Running the verify steps
+in that process therefore fails for any project that has to be compiled or
+tested: the build tool isn't there. Fail-closed then turns into an **infinite
+re-implement loop** that burns the unit's wall-clock budget and parks the run,
+never reaching the review roundtable.
+
+The delegate **sandbox** is the environment that *does* carry the project
+toolchain: a `--network none` container whose image is resolved per project and
+whose build tools are baked in (see [Delegates](DELEGATES.md) and the delegate
+sandbox image spec below). Verify belongs there, next to the toolchain and the
+worktree the delegate just edited — not in the daemon.
+
+## How it works
+
+When the live verify provider runs a work item's mechanical gate
+(`wfe_live_delegate.c`):
+
+1. **Resolve the verify steps** for the worktree (`verify_load_config`) — from
+   the project's `verify.yaml`/`project.yaml`, or auto-generated from a
+   recognized build file.
+2. **Resolve the sandbox image** for the worktree
+   (`delegate_sandbox_resolve_image`) — honoring a per-project `sandbox:` spec
+   (below), falling back to the backend default.
+3. **Acquire the sandbox** through the `docker` delegate backend
+   (`--network none`, worktree bind-mounted, the package-egress proxy armed).
+4. **Run each verify step inside the sandbox** (`exec`), collecting each step's
+   exit code.
+5. **Synthesize the verdict** — `{"verdict":"passed"|"failed","steps":[…]}` — the
+   same shape the implement gate consumes.
+
+If no sandbox is available — no `docker` backend registered, no resolvable verify
+steps, or the sandbox fails to start — verify **falls back to the in-process
+gate**, so the CLI (`aimee git verify`) and non-sandboxed deployments are
+unchanged.
+
+## Specifying a custom base image
+
+The sandbox toolchain is **per project**, because a Rust repo needs `cargo`, a C
+repo needs `gcc`/`make`, and a docs repo needs nothing. Declare it in the
+project's sandbox spec (resolved most-specific-first: project, then workspace,
+then the global default). Three forms:
+
+```yaml
+# a pre-baked image, used as-is (you maintain the toolchain)
+sandbox:
+  image: ghcr.io/acme/build-tools:latest
+
+# aimee builds a derived image: your base + these apt packages
+sandbox:
+  from: ubuntu:24.04
+  packages: [build-essential, clang, make, pkg-config]
+
+# aimee builds this Dockerfile (repo-relative or absolute)
+sandbox:
+  dockerfile: .aimee/sandbox.Dockerfile
+```
+
+Point `from`/`image` at whatever base you like and aimee bakes your dependencies
+into the sandbox image; verify then runs against exactly that toolchain.
+
+## Learned dependencies
+
+You do not have to enumerate every package up front. When a verify step (or a
+delegate) runs `apt-get install <pkgs>` inside the sandbox, aimee **captures the
+package names** (`sandbox_learned_observe`) and records them against the project.
+The **next** sandbox image build pre-bakes the learned set in, so the tools are
+present immediately with no runtime install.
+
+This is the intended **B → A** progression:
+
+- **B (first runs):** the sandbox has the package-egress proxy, so a step that
+  installs a missing build dependency succeeds over aimee's egress.
+- **A (steady state):** those installs are learned and pre-baked, so subsequent
+  verify runs need no network for dependencies — they run against the baked-in
+  toolchain offline.
+
+The learned set is a best-effort JSON sidecar under `$AIMEE_HOME`
+(`sandbox-learned.json`); it only recognizes `apt`/`apt-get install`, matching
+the apt-based image builder.
+
+## Prerequisites and limits
+
+- **A resolvable verify config.** Verify runs the steps `verify_load_config`
+  resolves. A repo whose build file the auto-generator does not recognize (for
+  example, aimee's own Makefile lives at `src/Makefile`, not the repo root) needs
+  an explicit `verify.yaml`/`project.yaml` declaring its steps, or there are no
+  steps to run and verify has nothing to gate on.
+- **The `docker` delegate backend must be engaged.** The sandbox path is used
+  when the `docker` backend is registered and a sandbox can be acquired for the
+  worktree. A deployment whose delegates run on the in-process/`local` backend
+  does not build a sandbox, so verify falls back to in-process (and inherits that
+  environment's toolchain, or lack of one).
+- **The verdict is pass/fail by step exit code.** A step's non-zero exit — or a
+  transport failure acquiring/exec'ing in the sandbox — counts as a failed step;
+  any failed step fails the verdict.
+
+## See also
+
+- [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md) — the implement → verify →
+  re-delegate loop the mechanical gate lives in.
+- [Workflows](WORKFLOWS.md) — the `implement`/`slice` blocks and their gates.
+- [Delegates](DELEGATES.md) — delegate execution backends and the sandbox.

--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -26,7 +26,10 @@
 #include "agent_types.h"
 #include "cJSON.h"
 #include "coord_jobs.h"
+#include "delegate_backend.h" /* run verify steps inside the delegate sandbox */
 #include "delegate_role.h"
+#include "delegate_sandbox_image.h" /* resolve the work item's sandbox image */
+#include "sandbox_learned.h"        /* learn verify's apt installs -> pre-bake next image */
 #include "persona.h"
 #include "provider_catalog.h"
 #include "headers/git_verify.h"
@@ -171,6 +174,113 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
 
 static const wfe_delegate_provider_t WFE_LIVE_DELEGATE = {wfe_live_delegate_run};
 
+/* Mechanical-verify default step timeout — mirrors git_verify_step.c's default so
+ * a step run in the sandbox gets the same wall budget as in-process. */
+#define WFE_VERIFY_STEP_TIMEOUT_MS (30 * 60 * 1000)
+
+/* Run the resolved verify steps INSIDE the work item's delegate sandbox — the
+ * `--network none`, toolchain-baked image the engineer delegate builds against —
+ * instead of in the aimee-server process (the slim runtime container ships no
+ * gcc/make, so an in-process `aimee git verify` there can never pass and the
+ * implement block loops to its wall-cap; see docs/DELEGATE_SANDBOX_VERIFY.md).
+ *
+ * Reuses the docker delegate backend so verify inherits the SAME sandbox the
+ * delegate used: the resolved per-project image (custom `sandbox:` spec honored
+ * via delegate_sandbox_resolve_image) and the egress package proxy for first-time
+ * dependency installs — and each step is fed to sandbox_learned_observe so those
+ * apt installs are captured and pre-baked into the next image build (egress →
+ * offline over time).
+ *
+ * Returns 0 and writes a {verdict, steps:[{name,rc}]} JSON to out_verdict when the
+ * sandbox path ran; -1 when it is unavailable (no docker backend, no resolvable
+ * verify steps, or the sandbox could not start) so the caller falls back to the
+ * in-process gate — preserving CLI and non-sandboxed behavior unchanged. */
+static int wfe_verify_in_sandbox(const char *workdir, char *out_verdict, size_t n)
+{
+   if (!workdir || !workdir[0])
+      return -1;
+   verify_config_t cfg;
+   if (verify_load_config(workdir, &cfg) != 0 || cfg.count <= 0)
+      return -1; /* no steps resolvable here -> let the caller fall back */
+
+   delegate_backend_t *be = delegate_backend_lookup("docker");
+   if (!be || !be->acquire || !be->exec || !be->release)
+      return -1; /* no sandbox backend -> fall back to in-process verify */
+
+   char image[256] = "";
+   (void)delegate_sandbox_resolve_image(workdir, image, sizeof image); /* "" -> backend default */
+
+   delegate_backend_config_t bc = {0};
+   bc.image = image[0] ? image : NULL;
+   bc.workspace = workdir;
+   bc.pkg_proxy = 1;         /* egress proxy for first-time dep installs (learned pre-bake) */
+   bc.require_isolation = 1; /* --network none; refuse to run un-isolated */
+   bc.hibernate_on_exit = 1; /* keep the container + learned materials for reuse */
+
+   /* Stable per-worktree task id so the sandbox (and its learned toolchain) is
+    * reused across an implement unit's retries rather than rebuilt each round. */
+   char task_id[80];
+   const char *slash = strrchr(workdir, '/');
+   snprintf(task_id, sizeof task_id, "wfe-verify-%s", (slash && slash[1]) ? slash + 1 : workdir);
+
+   void *state = NULL;
+   if (be->acquire(be, task_id, &bc, &state) != 0)
+      return -1; /* sandbox could not start -> fall back */
+
+   cJSON *verdict = cJSON_CreateObject();
+   cJSON *steps = verdict ? cJSON_AddArrayToObject(verdict, "steps") : NULL;
+   char *obuf = malloc(1 << 18), *ebuf = malloc(1 << 15);
+   int failed = 0, ran = 0;
+   if (verdict && steps && obuf && ebuf)
+   {
+      for (int i = 0; i < cfg.count; i++)
+      {
+         const verify_step_t *s = &cfg.steps[i];
+         if (!s->run[0])
+            continue;
+         /* Capture any apt installs this step performs so they pre-bake into the
+          * next sandbox image build (B -> A: egress-installed becomes baked-in). */
+         sandbox_learned_observe(workdir, s->run);
+         delegate_exec_result_t res = {0};
+         res.stdout_buf = obuf;
+         res.stdout_cap = 1 << 18;
+         res.stderr_buf = ebuf;
+         res.stderr_cap = 1 << 15;
+         obuf[0] = ebuf[0] = '\0';
+         int trc = be->exec(be, state, s->run, WFE_VERIFY_STEP_TIMEOUT_MS, &res);
+         int step_rc = (trc != 0) ? -1 : res.exit_code; /* transport failure = step failure */
+         if (step_rc != 0)
+            failed++;
+         ran++;
+         cJSON *js = cJSON_CreateObject();
+         if (js)
+         {
+            cJSON_AddStringToObject(js, "name", s->name);
+            cJSON_AddNumberToObject(js, "rc", step_rc);
+            cJSON_AddItemToArray(steps, js);
+         }
+      }
+   }
+   be->release(be, state, 1 /* hibernate: keep the sandbox for the next retry */);
+
+   int rc = -1;
+   if (verdict && steps && ran > 0)
+   {
+      cJSON_AddStringToObject(verdict, "verdict", failed ? "failed" : "passed");
+      char *sv = cJSON_PrintUnformatted(verdict);
+      if (sv)
+      {
+         snprintf(out_verdict, n, "%s", sv);
+         free(sv);
+         rc = 0;
+      }
+   }
+   free(obuf);
+   free(ebuf);
+   cJSON_Delete(verdict);
+   return rc;
+}
+
 /* Live verify provider (WP-1b): run the mechanical verify gate synchronously on
  * `workdir` and return the structured format=json verdict. The implement block
  * gates a unit's advance on verdict:passed. Returns 0 + fills out_verdict, or -1
@@ -179,6 +289,11 @@ static int wfe_live_verify_run(const char *workdir, char *out_verdict, size_t n)
 {
    if (out_verdict && n)
       out_verdict[0] = '\0';
+   /* Prefer the sandbox: the in-process gate below runs in the toolchain-less
+    * server container and can never build a real project. Falls through to
+    * in-process only when no sandbox is available (CLI / non-sandboxed setups). */
+   if (wfe_verify_in_sandbox(workdir, out_verdict, n) == 0)
+      return 0;
    cJSON *args = cJSON_CreateObject();
    if (!args)
       return -1;


### PR DESCRIPTION
## Summary

Found while driving a WFE proposal end-to-end on the `.254` appliance: an autonomous `build` run fired from `docs/proposals/pending`, advanced through `draft → plan → roundtable (pass) → split → slices`, then **stalled in `implement`** — each slice looped ~6× and hit the wall-clock cap, never reaching the review roundtable.

### Root cause
The `implement` block gates each unit on a **mandatory mechanical verify** (`wfe_implement_verify_ok`), fail-closed. The live provider ran it **in-process** (`handle_git_verify` under a pinned CWD) — i.e. inside the `aimee-server` runtime container, which is the slim final stage of `Dockerfile.server` (`debian:bookworm-slim`, binaries + runtime libs only, **no `gcc`/`make`/`node`**). For any project that must be built, verify there can never pass → `wfe_implement_verify_ok` fails closed → `implement` loops to its wall-cap → the run parks, **never reaching the roundtable** (so no amount of roundtable tuning helps — the run doesn't get there).

The delegate **sandbox** is the environment that carries the per-project toolchain (`--network none`, image resolved per project). Verify belongs there, next to the toolchain and the worktree the delegate just edited.

### Fix
`wfe_live_verify_run` now prefers `wfe_verify_in_sandbox`:
1. resolve the verify steps (`verify_load_config`);
2. resolve the work item's sandbox image (`delegate_sandbox_resolve_image`, honoring a custom `sandbox: {image | from,packages | dockerfile}` spec);
3. acquire the **docker** delegate backend sandbox (`--network none`, worktree bind-mounted, egress package proxy);
4. run each verify step **inside** it and synthesize the `{verdict, steps}` JSON the gate consumes.

Each step is fed to `sandbox_learned_observe`, so `apt` installs during verify are **captured and pre-baked into the next sandbox image** — the B→A progression: first runs install missing build deps over aimee's egress proxy; steady state runs offline against the baked-in toolchain. Users can point the sandbox at a **custom base image** so aimee bakes their deps in.

Falls back to the in-process gate when no docker backend / no resolvable steps / the sandbox can't start, so the CLI (`aimee git verify`) and non-sandboxed deployments are unchanged.

## Docs
New `docs/DELEGATE_SANDBOX_VERIFY.md` (why verify runs in the sandbox, custom base image, learned-dependency bake), linked from `AUTONOMOUS_DEVELOPMENT.md`.

## Testing / scope
- `make server` and `make build-integrity` pass; clang-format clean.
- **Honest limits:** the sandbox path engages only when the `docker` backend is registered and a sandbox can be acquired; full E2E validation ("verify now passes in the sandbox") needs a build-capable host with the docker backend engaged — a follow-on, not closed here.
- **Separate prerequisite:** a repo whose build file the auto-generator doesn't recognize (aimee's own Makefile is at `src/Makefile`, not root) needs an explicit `verify.yaml`/`project.yaml` for verify to have steps — documented, not addressed in this PR.
