### PR TITLE
feat(economizer): GET /v1/economizer/stats — surface all economizer telemetry

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -2144,6 +2144,10 @@ paths:
     get:
       summary: Per-delegate run statistics
       responses: { "200": { description: Per-delegate run stats, content: { application/json: { schema: { type: object } } } } }
+  /economizer/stats:
+    get:
+      summary: Economizer telemetry (gateway mutation counters, tool-condense savings, avoided-$)
+      responses: { "200": { description: Economizer stats, content: { application/json: { schema: { type: object } } } } }
   /agent/draft:
     post:
       summary: One-shot tool-free text generation (proposal drafting) via a non-CLI delegate

--- a/docs/gen/cli-commands.md
+++ b/docs/gen/cli-commands.md
@@ -5,7 +5,7 @@
 
 `aimee` is a thin client: each command either runs a small local operation or forwards a typed request to `aimee-server`. Server-backed commands accept `--json` for machine-readable output. Run `aimee help <command>` for per-command help, or `aimee help --all` for every tier.
 
-Total commands: 58
+Total commands: 59
 
 ## Core commands
 
@@ -332,6 +332,16 @@ Subcommands:
   tag              Label one dogfood record
   review           Summarize review state and close armed reminders
   report           Build a monthly dogfood report (--month YYYY-MM, --json)
+```
+
+### `aimee economizer`
+
+Economizer telemetry.
+
+Subcommands:
+
+```
+  stats            Gateway-mutation counters, tool-condense savings, avoided-$
 ```
 
 ### `aimee ensemble`

--- a/src/cli_help_data.h
+++ b/src/cli_help_data.h
@@ -38,6 +38,8 @@
      "  list             List memories\n"
      "  get              Read a memory by id\n"
      "  read             Assemble current memory context\n"},
+    {"economizer", "Economizer telemetry", CLIENT_TIER_ADVANCED, 0,
+     "  stats            Gateway-mutation counters, tool-condense savings, avoided-$\n"},
     {"session", "Session history", CLIENT_TIER_ADVANCED, 0,
      "  list             List recent sessions\n"
      "  show             Show one session\n"

--- a/src/cli_v1_routes.c
+++ b/src/cli_v1_routes.c
@@ -150,6 +150,7 @@ static const struct
     {"memory", "show", "memory.get", NULL, NULL, 60000},
     {"memory", "read", "memory.read", NULL, NULL, 60000},
     {"memory", "stats", "memory.stats", NULL, NULL, 60000},
+    {"economizer", "stats", "economizer.stats", NULL, NULL, 60000},
     {"memory", "benchmark", "memory.benchmark", NULL, NULL, 600000},
     {"index", "scan", "index.scan", NULL, NULL, 300000},
     {"index", "overview", "index.list", NULL, "projects", 0},

--- a/src/cli_v1_routes_d.c
+++ b/src/cli_v1_routes_d.c
@@ -631,6 +631,7 @@ static const struct
     {"dogfood.report", "GET", "/v1/dogfood/report"},
     {"dogfood.review", "POST", "/v1/dogfood/review"},
     {"dogfood.tag", "POST", "/v1/dogfood/tag"},
+    {"economizer.stats", "GET", "/v1/economizer/stats"},
     {"episode.list", "GET", "/v1/episode/list"},
     {"eval.results", "GET", "/v1/eval/results"},
     {"evidence.fidelity_retrieval_event", "POST", "/v1/audit/fidelity"},

--- a/src/headers/gw_mutate_stats.h
+++ b/src/headers/gw_mutate_stats.h
@@ -8,6 +8,7 @@
 #ifndef DEC_GW_MUTATE_STATS_H
 #define DEC_GW_MUTATE_STATS_H 1
 
+#include "cJSON.h" /* gw_stat_to_json param type */
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -56,6 +57,10 @@ extern "C"
    /* Human-readable dump of every non-zero counter, one `name value` per line
     * (Prometheus-ish), for a /metrics-style endpoint or diagnostics. */
    void gw_stat_dump(FILE *out);
+
+   /* JSON view of the counters (flat counters + token_delta + reason breakdown) for the
+    * user-facing GET /v1/economizer/stats endpoint. `out` is a cJSON object to populate. */
+   void gw_stat_to_json(cJSON *out);
 
    /* Test-only: zero every counter and clear the reason registry. */
    void gw_stat_reset(void);

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -362,6 +362,7 @@ int handle_primary_clear(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_attempt_record(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_attempt_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_dashboard_metrics(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_economizer_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_dashboard_delegations(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_dashboard_traces(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_dashboard_plans(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/gw_mutate_stats.c
+++ b/src/server/gw_mutate_stats.c
@@ -2,6 +2,7 @@
  * reason registry is a small fixed table under one mutex (exceptional-event rate). */
 #include "gw_mutate_stats.h"
 
+#include "cJSON.h"
 #include <pthread.h>
 #include <stdatomic.h>
 #include <string.h>
@@ -180,6 +181,52 @@ void gw_stat_dump(FILE *out)
               (unsigned long long)g_reasons[i].count);
    }
    pthread_mutex_unlock(&g_reason_lock);
+}
+
+/* JSON view of the same counters for the user-facing GET /v1/economizer/stats endpoint.
+ * Keeps the flat-counter names (g_flat_names) and the reason registry (g_reasons)
+ * encapsulated here rather than hardcoded in the handler. Emits every flat counter
+ * (including zeros) for a stable schema; token_delta carries the sampled baseline-vs-
+ * reduced sums plus the derived pct_reduced; reasons is {group:{reason:count}} over the
+ * registered non-zero pairs. */
+void gw_stat_to_json(cJSON *out)
+{
+   if (!out)
+      return;
+
+   for (int i = 0; i < GW_STAT__COUNT; i++)
+      cJSON_AddNumberToObject(out, g_flat_names[i], (double)gw_stat_get((gw_stat_t)i));
+
+   uint64_t bs = gw_stat_token_baseline_sum();
+   uint64_t rs = gw_stat_token_reduced_sum();
+   cJSON *td = cJSON_AddObjectToObject(out, "token_delta");
+   if (td)
+   {
+      cJSON_AddNumberToObject(td, "sample_count", (double)gw_stat_token_sample_count());
+      cJSON_AddNumberToObject(td, "baseline_sum", (double)bs);
+      cJSON_AddNumberToObject(td, "reduced_sum", (double)rs);
+      /* fraction of sampled context removed; 0 before the first sample (no div-by-zero) */
+      cJSON_AddNumberToObject(td, "pct_reduced",
+                              bs > 0 ? (double)(bs - rs) * 100.0 / (double)bs : 0.0);
+      cJSON_AddNumberToObject(td, "sample_rate_1_in_n", (double)GW_STAT_TOKEN_SAMPLE_N);
+   }
+
+   cJSON *reasons = cJSON_AddObjectToObject(out, "reasons");
+   if (reasons)
+   {
+      pthread_mutex_lock(&g_reason_lock);
+      for (int i = 0; i < g_reason_n; i++)
+      {
+         if (!g_reasons[i].count)
+            continue;
+         cJSON *grp = cJSON_GetObjectItemCaseSensitive(reasons, g_reasons[i].group);
+         if (!grp)
+            grp = cJSON_AddObjectToObject(reasons, g_reasons[i].group);
+         if (grp)
+            cJSON_AddNumberToObject(grp, g_reasons[i].reason, (double)g_reasons[i].count);
+      }
+      pthread_mutex_unlock(&g_reason_lock);
+   }
 }
 
 void gw_stat_reset(void)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1523,6 +1523,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"attempt.list", handle_attempt_list},
     /* Dashboard */
     {"dashboard.metrics", handle_dashboard_metrics},
+    {"economizer.stats", handle_economizer_stats},
     {"dashboard.delegations", handle_dashboard_delegations},
     {"dashboard.traces", handle_dashboard_traces},
     {"dashboard.plans", handle_dashboard_plans},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -64,6 +64,7 @@ const method_policy_t method_registry[] = {
     {"attempt.*", CAP_SESSION_READ, "attempt log operation"},
     /* Dashboard (prefix) */
     {"dashboard.*", CAP_DASHBOARD_READ, "dashboard operation"},
+    {"economizer.*", CAP_DASHBOARD_READ, "economizer telemetry"},
     {"audit.verify", CAP_DASHBOARD_READ, "WORM audit chain verify"},
     {"audit.checkpoint", CAP_TOOL_EXECUTE, "WORM audit checkpoint"},
     {"audit.seal", CAP_TOOL_EXECUTE, "WORM audit seal snapshot"},

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -1579,6 +1579,7 @@ static const http_route_t g_v1_routes[] = {
     {"GET", "/v1/dashboard/memory_stats", NULL, RM_EXACT, "dashboard.memory_stats", 0,
      rh_dispatch_op},
     {"GET", "/v1/dashboard/metrics", NULL, RM_EXACT, "dashboard.metrics", 0, rh_dispatch_op},
+    {"GET", "/v1/economizer/stats", NULL, RM_EXACT, "economizer.stats", 0, rh_dispatch_op},
     {"GET", "/v1/dashboard/onboard", NULL, RM_EXACT, "dashboard.onboard", 0, rh_dispatch_op},
     {"GET", "/v1/dashboard/plans", NULL, RM_EXACT, "dashboard.plans", 0, rh_dispatch_op},
     {"GET", "/v1/dashboard/plugins", NULL, RM_EXACT, "dashboard.plugins", 0, rh_dispatch_op},

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -3,6 +3,9 @@
 #include "aimee.h"
 #include "aimee_ir_metrics.h"
 #include "shadow_mirror.h"
+#include "gw_mutate_stats.h" /* gw_stat_to_json — gateway-mutation economizer counters */
+#include "tool_condense.h"   /* tool_condense_stats_snapshot — tool-output condense savings */
+#include "token_audit.h"     /* db1_token_audit_spend_breakdown — avoided-$ aggregate */
 #include "server.h"
 #include "dashboard.h"
 #include "render.h"               /* decision_to_json + db2_decision_log_list */
@@ -1475,6 +1478,56 @@ int handle_dashboard_metrics(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          cJSON_AddNumberToObject(sm, "dropped", (double)shadow_mirror_dropped_count());
          cJSON_AddNumberToObject(sm, "pruned", (double)shadow_mirror_pruned_count());
       }
+   }
+
+   return send_and_free(conn, resp);
+}
+
+/* GET /v1/economizer/stats — user-facing view of ALL economizer telemetry in one place:
+ *   gateway  — live gateway-mutation counters (mutate attempted/applied, disables,
+ *              session-blocks, sampled token-reduction %, hard-bypass/disable reasons).
+ *              Process-lifetime counters; reset on restart.
+ *   tool_condense — realized tool-output condensation savings (bytes condensed vs
+ *              re-injected on page-back). Process-lifetime.
+ *   avoided  — persistent avoided-cost aggregate from the token-audit ledger (the
+ *              economizer's forecast/dedup "avoided" rows), all-time.
+ * Read-only; CAP_DASHBOARD_READ. Previously these counters had NO reachable surface. */
+int handle_economizer_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   (void)req;
+
+   cJSON *resp = jo_ok();
+
+   cJSON *gw = cJSON_AddObjectToObject(resp, "gateway");
+   if (gw)
+      gw_stat_to_json(gw);
+
+   cJSON *tc = cJSON_AddObjectToObject(resp, "tool_condense");
+   if (tc)
+   {
+      tool_condense_totals_t t;
+      tool_condense_stats_snapshot(&t);
+      cJSON_AddNumberToObject(tc, "recognized", (double)t.recognized);
+      cJSON_AddNumberToObject(tc, "applied", (double)t.applied);
+      cJSON_AddNumberToObject(tc, "applied_raw_bytes", (double)t.applied_raw);
+      cJSON_AddNumberToObject(tc, "applied_final_bytes", (double)t.applied_final);
+      cJSON_AddNumberToObject(tc, "saved_bytes", (double)t.saved_bytes);
+      cJSON_AddNumberToObject(tc, "recovered", (double)t.recovered);
+      cJSON_AddNumberToObject(tc, "recovered_bytes", (double)t.recovered_bytes);
+      cJSON_AddNumberToObject(tc, "net_saved_bytes", (double)t.net_saved_bytes);
+   }
+
+   cJSON *av = cJSON_AddObjectToObject(resp, "avoided");
+   if (av)
+   {
+      db1_token_audit_spend_t sp;
+      memset(&sp, 0, sizeof sp);
+      /* 0 = all-time (see token_audit.h). Best-effort: on a DB error the fields stay 0. */
+      (void)db1_token_audit_spend_breakdown(0, &sp);
+      cJSON_AddNumberToObject(av, "avoided_cost_usd", sp.avoided_cost_usd);
+      cJSON_AddNumberToObject(av, "realized_cost_usd", sp.realized_cost_usd);
+      cJSON_AddNumberToObject(av, "estimated_cost_usd", sp.estimated_cost_usd);
    }
 
    return send_and_free(conn, resp);

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -262,6 +262,31 @@ static void test_upstream_provider_gate(void)
    assert(gw_mutate_upstream_ok(0) == 0);                      /* so both are off here */
 }
 
+/* gw_stat_to_json: the JSON the /v1/economizer/stats endpoint serves reflects the
+ * live counters — flat counters, the sampled token_delta (+ derived pct_reduced), and
+ * the {group:{reason:count}} breakdown. */
+static void test_stat_json(void)
+{
+   gw_stat_reset();
+   gw_stat_inc(GW_STAT_MUTATE_ATTEMPTED);
+   gw_stat_inc(GW_STAT_MUTATE_APPLIED);
+   gw_stat_inc_reason("session_disabled_set", "4xx");
+   gw_stat_record_token_delta(1000, 600); /* n=0 is sampled */
+
+   cJSON *o = cJSON_CreateObject();
+   gw_stat_to_json(o);
+   assert((int)cJSON_GetNumberValue(cJSON_GetObjectItem(o, "gateway_mutate_attempted")) == 1);
+   assert((int)cJSON_GetNumberValue(cJSON_GetObjectItem(o, "gateway_mutate_applied")) == 1);
+   cJSON *td = cJSON_GetObjectItem(o, "token_delta");
+   assert(td);
+   assert((int)cJSON_GetNumberValue(cJSON_GetObjectItem(td, "baseline_sum")) == 1000);
+   assert((int)cJSON_GetNumberValue(cJSON_GetObjectItem(td, "reduced_sum")) == 600);
+   assert(cJSON_GetNumberValue(cJSON_GetObjectItem(td, "pct_reduced")) == 40.0);
+   cJSON *sds = cJSON_GetObjectItem(cJSON_GetObjectItem(o, "reasons"), "session_disabled_set");
+   assert(sds && (int)cJSON_GetNumberValue(cJSON_GetObjectItem(sds, "4xx")) == 1);
+   cJSON_Delete(o);
+}
+
 int main(void)
 {
    printf("gateway_mutate_wire: ");
@@ -283,6 +308,7 @@ int main(void)
    test_token_delta_sampling();
    test_no_behavior_change_when_off();
    test_upstream_provider_gate();
+   test_stat_json();
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -831,6 +831,10 @@ int handle_dashboard_metrics(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "dashboard.metrics");
 }
+int handle_economizer_stats(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "economizer.stats");
+}
 int handle_dashboard_delegations(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "dashboard.delegations");


### PR DESCRIPTION
## Problem
The economizer's gateway-mutation counters (`gw_mutate_stats`: mutate attempted/applied, 4xx/5xx/stream disables, session-blocks, sampled token-reduction, hard-bypass/disable reasons) were reachable from **nowhere** — `gw_stat_dump` has no caller, and there is no HTTP route, CLI command, or prom-file export. An operator running the live gateway economizer had no way to see whether it was reducing anything, by how much, or how often it disabled a session. This is also exactly the data the §6 go-live validation gates require (`gateway_token_delta_*`, mutate/disable rates).

## Change
Add a user-facing read-only endpoint, `GET /v1/economizer/stats` (cap `CAP_DASHBOARD_READ`), composing **all** economizer telemetry:

- **`gateway`** — `gw_stat_to_json()`: every flat counter (stable schema, zeros included), `token_delta` `{sample_count, baseline_sum, reduced_sum, pct_reduced, sample_rate_1_in_n}`, and a `{group:{reason:count}}` breakdown over the registered reasons. The JSON view lives in `gw_mutate_stats.c` so the counter names + reason registry stay encapsulated there.
- **`tool_condense`** — realized tool-output condensation savings from `tool_condense_stats_snapshot` (bytes condensed vs re-injected on page-back; net-of-recovery).
- **`avoided`** — persistent avoided-$ aggregate from the token-audit ledger (`db1_token_audit_spend_breakdown`, all-time).

Wired the standard four server seams (route table, op→handler map, `method_registry` cap, handler decl) plus the CLI: `aimee economizer stats` → `economizer.stats` → `GET /v1/economizer/stats`.

## Test
`test_gateway_mutate_wire` extended with `test_stat_json`: drives the counters and asserts the JSON (flat counters, `token_delta.pct_reduced == 40`, `reasons.session_disabled_set.4xx`). Full `make unit-tests` green; `make build-integrity` green (incl. the CLI-v1-route + API-conformance checks that validate the new route); clang-format-19 clean.
