### PR TITLE
feat(sandbox): declare aimee's own delegate-sandbox toolchain (.aimee/project.yaml)

### DIFF
--- a/.aimee/project.yaml
+++ b/.aimee/project.yaml
@@ -1,0 +1,25 @@
+# aimee's own delegate-sandbox toolchain.
+#
+# When a server-executed delegate (an autonomous implement/verify step) runs on
+# this repo, aimee resolves its --network none sandbox image from this file
+# (docs/DELEGATE_SANDBOX.md). Declaring the toolchain per project — rather than a
+# global delegate_sandbox_image — is what keeps the sandbox language-appropriate:
+# aimee BUILDS a project-dedicated image once (FROM base + these apt packages,
+# content-tag cached) and the learned toolchain layers on anything a build/verify
+# step later apt-installs.
+#
+# These packages mirror Dockerfile.server's build stage — the exact deps needed to
+# `make -C src` the server/CLI — so the mechanical verify can actually compile the
+# change instead of failing on a missing compiler.
+sandbox:
+  from: debian:bookworm-slim
+  packages:
+    - build-essential
+    - ca-certificates
+    - libpq-dev
+    - libsqlite3-dev
+    - libssl-dev
+    - libzstd-dev
+    - pkg-config
+    - python3
+    - zlib1g-dev

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ session-state.json
 
 # Per-project aimee state (local/environment-specific, never committed)
 .aimee/
+!.aimee/project.yaml  # aimee's own committed delegate-sandbox toolchain declaration
 .aimee-rules
 
 # IDE


### PR DESCRIPTION
Adds aimee's repo-local `.aimee/project.yaml` declaring its own delegate-sandbox toolchain (debian:bookworm-slim + the Dockerfile.server build deps), so a server-executed delegate on this repo builds a project-dedicated `--network none` image that can actually `make -C src` the change. The consumer (`delegate_sandbox_image.c`, the `sandbox: {from, packages}` form) is already on testing — this is the missing declaration.

Reconstructed as a clean single-file add: the original branch had diverged badly behind the compute→admission refactor and the module reorgs, tangling it with already-merged #1513 work.