### PR TITLE
feat(economizer): single economizer=off|safe|aggressive tier (working model; A-C)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -620,6 +620,7 @@ static void config_set_defaults(config_t *cfg)
     * these defaults every effective lever equals its pre-P3 value (back-compat). */
    cfg->economizer_enabled = 1;
    cfg->economizer_aggressive = 0;
+   cfg->economizer_tier = ECON_TIER_SAFE; /* the single control; default lossless */
    /* Pluggable-module toggles default to -1 (unspecified) so the resolver falls back to each
     * module's deprecated env toggle / default-ON until an operator writes the `modules:` block. */
    cfg->module_memory = -1;
@@ -952,14 +953,43 @@ static void config_apply_inference_backend_defaults(config_t *cfg, const cJSON *
       cfg->memory_rewrite_enabled = accel;
 }
 
+int econ_tier(const config_t *cfg)
+{
+   if (!cfg)
+      return ECON_TIER_OFF;
+   /* modules.economizer:false is still an authoritative hard kill over the tier. */
+   if (cfg->module_economizer == 0)
+      return ECON_TIER_OFF;
+   return cfg->economizer_tier;
+}
+
+const char *econ_tier_name(int tier)
+{
+   switch (tier)
+   {
+   case ECON_TIER_OFF:
+      return "off";
+   case ECON_TIER_AGGRESSIVE:
+      return "aggressive";
+   case ECON_TIER_SAFE:
+   default:
+      return "safe";
+   }
+}
+
+int econ_tier_parse(const char *s)
+{
+   if (s && (strcasecmp(s, "off") == 0 || strcasecmp(s, "0") == 0 || strcasecmp(s, "false") == 0))
+      return ECON_TIER_OFF;
+   if (s && (strcasecmp(s, "aggressive") == 0 || strcasecmp(s, "aggro") == 0))
+      return ECON_TIER_AGGRESSIVE;
+   return ECON_TIER_SAFE; /* default / "safe" / unknown -> lossless */
+}
+
 int econ_reduction_master_on(const config_t *cfg)
 {
-   /* The economizer's master gate is a pluggable-module toggle like the other four: the
-    * modules.economizer tristate is canonical when set (0/1); -1 (unspecified) falls back to
-    * the legacy economizer.enabled bool, which plays the "deprecated default" role env plays
-    * for memory/governance/delegates/workflows. Every economizer sub-predicate routes through
-    * here, so modules.economizer:false is one authoritative kill. */
-   return cfg ? config_module_enabled(cfg->module_economizer, cfg->economizer_enabled) : 0;
+   /* Any economization at all runs unless the tier is off. */
+   return econ_tier(cfg) != ECON_TIER_OFF;
 }
 
 int config_module_enabled(int config_tristate, int env_default)
@@ -974,11 +1004,9 @@ int config_module_enabled(int config_tristate, int env_default)
 
 int econ_gateway_mutate_on(const config_t *cfg)
 {
-   /* the live-primary mutator needs the master ON, the aggressive tier opted IN, AND the
-    * lever itself set — the aggressive flag alone never activates a live-traffic mutator. */
-   return econ_reduction_master_on(cfg) && cfg->economizer_aggressive && cfg->reduce_gateway_mutate
-              ? 1
-              : 0;
+   /* The live-primary mutator is an AGGRESSIVE-tier action. (The call site additionally
+    * restricts it to OpenAI-family egress -- it never runs against Anthropic.) */
+   return econ_tier(cfg) == ECON_TIER_AGGRESSIVE ? 1 : 0;
 }
 
 static int config_snapshot_live(void);

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1139,16 +1139,9 @@ int config_save(const config_t *cfg)
                                  cfg->reduce_gateway_session_disable_ttl_ms);
    }
 
-   /* Two-tier economizer switches (P3): enabled default-ON -> persist only the opt-out;
-    * aggressive default-OFF -> persist only when opted in. */
-   if (!cfg->economizer_enabled || cfg->economizer_aggressive)
-   {
-      cJSON *econ = cJSON_AddObjectToObject(root, "economizer");
-      if (!cfg->economizer_enabled)
-         cJSON_AddBoolToObject(econ, "enabled", 0);
-      if (cfg->economizer_aggressive)
-         cJSON_AddBoolToObject(econ, "aggressive", 1);
-   }
+   /* The economizer tier -- persist as a string only when non-default (default: safe). */
+   if (cfg->economizer_tier != ECON_TIER_SAFE)
+      cJSON_AddStringToObject(root, "economizer", econ_tier_name(cfg->economizer_tier));
 
    /* Autonomous-dev knobs — persist only non-defaults (defaults: skeptics 0, fanout off,
     * unit_retry 2, unit_max 16, ci_retry_max 2). */

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -793,7 +793,7 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
       e = cJSON_GetObjectItemCaseSensitive(econ, "aggressive");
       if (cJSON_IsBool(e))
          cfg->economizer_aggressive = cJSON_IsTrue(e) ? 1 : 0;
-      cfg->economizer_tier = !cfg->economizer_enabled  ? ECON_TIER_OFF
+      cfg->economizer_tier = !cfg->economizer_enabled     ? ECON_TIER_OFF
                              : cfg->economizer_aggressive ? ECON_TIER_AGGRESSIVE
                                                           : ECON_TIER_SAFE;
    }

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -770,10 +770,22 @@ void config_parse_modules_section(config_t *cfg, cJSON *root)
  * it, so an exposed flag is never silently inert. All default-off. */
 void config_parse_reduce_section(config_t *cfg, cJSON *root)
 {
-   /* Two-tier economizer switches (P3), colocated `economizer:` block — parsed FIRST, before
-    * the reduce early-return, so a config that sets economizer.* but no reduce.* is honored. */
+   /* The economizer control — parsed FIRST (before the reduce early-return). The canonical
+    * form is a STRING: `economizer: off|safe|aggressive`. A deprecated OBJECT form
+    * ({enabled,aggressive}) is still accepted and mapped to the tier for back-compat. */
    cJSON *econ = cJSON_GetObjectItemCaseSensitive(root, "economizer");
-   if (cJSON_IsObject(econ))
+   if (cJSON_IsString(econ) && econ->valuestring)
+   {
+      const char *v = econ->valuestring;
+      /* Warn (don't fail) on an unrecognized tier so a typo like "agressive" doesn't
+       * silently resolve to safe -- fail-safe to the lossless default, but loudly. */
+      if (strcasecmp(v, "off") && strcasecmp(v, "0") && strcasecmp(v, "false") &&
+          strcasecmp(v, "safe") && strcasecmp(v, "aggressive") && strcasecmp(v, "aggro"))
+         fprintf(stderr, "aimee: config warning: unknown economizer tier \"%s\"; using \"safe\"\n",
+                 v);
+      cfg->economizer_tier = econ_tier_parse(v);
+   }
+   else if (cJSON_IsObject(econ))
    {
       cJSON *e = cJSON_GetObjectItemCaseSensitive(econ, "enabled");
       if (cJSON_IsBool(e))
@@ -781,6 +793,9 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
       e = cJSON_GetObjectItemCaseSensitive(econ, "aggressive");
       if (cJSON_IsBool(e))
          cfg->economizer_aggressive = cJSON_IsTrue(e) ? 1 : 0;
+      cfg->economizer_tier = !cfg->economizer_enabled  ? ECON_TIER_OFF
+                             : cfg->economizer_aggressive ? ECON_TIER_AGGRESSIVE
+                                                          : ECON_TIER_SAFE;
    }
 
    cJSON *reduce = cJSON_GetObjectItemCaseSensitive(root, "reduce");

--- a/src/headers/aimee_backend.h
+++ b/src/headers/aimee_backend.h
@@ -17,6 +17,11 @@ struct cJSON;
  * the caller owns (cJSON_Delete), or NULL on bad args. */
 struct cJSON *anthropic_backend_build(const aimee_request_t *ir);
 
+/* Economizer caching gate for the Anthropic egress. The server sets this from the
+ * economizer tier (off -> 0, disabling all aimee cache_control; safe/aggressive -> 1).
+ * Default 1 (caching on). Kept as a runtime flag so this pure TU needs no config. */
+void aimee_backend_anthropic_set_cache_enabled(int on);
+
 /* Parse an Anthropic Messages API response into the IR. Returns 0 (out owned by
  * caller -> aimee_response_free), -1 on error. */
 int anthropic_backend_parse(const struct cJSON *resp, aimee_response_t *out, char *err,

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -2099,8 +2099,8 @@ int config_load_file(config_t *cfg);
 /* The economizer tier — the single user control. See docs/features/economizer.md. */
 enum
 {
-   ECON_TIER_OFF = 0,   /* verbatim passthrough: no caching, no reduction */
-   ECON_TIER_SAFE = 1,  /* lossless: Anthropic caching + frozen tool condensation; OpenAI recall */
+   ECON_TIER_OFF = 0,  /* verbatim passthrough: no caching, no reduction */
+   ECON_TIER_SAFE = 1, /* lossless: Anthropic caching + frozen tool condensation; OpenAI recall */
    ECON_TIER_AGGRESSIVE = 2 /* + lossy fold/compress; OpenAI live mutation */
 };
 
@@ -2113,7 +2113,7 @@ int econ_tier_parse(const char *s);   /* string -> ECON_TIER_* (default SAFE on 
 /* Economizer resolution — compute EFFECTIVE gates from the tier without mutating config_t
  * (so config_save round-trips the raw user value). */
 int econ_reduction_master_on(const config_t *cfg); /* tier != off */
-int econ_gateway_mutate_on(const config_t *cfg);   /* tier == aggressive (OpenAI-only at call site) */
+int econ_gateway_mutate_on(const config_t *cfg); /* tier == aggressive (OpenAI-only at call site) */
 
 /* Resolve whether a pluggable module is enabled, from the layered enablement surface. This is
  * the ONE place module enablement is decided; every wire site calls it with the module's tristate

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1143,6 +1143,13 @@ typedef struct config
     *                          aggressive flag alone never activates a live-traffic mutator. */
    int economizer_enabled;
    int economizer_aggressive;
+   /* The SINGLE economizer control (supersedes economizer_enabled/aggressive + the
+    * reduce.* levers, which are being removed). One of ECON_TIER_*. Selects a
+    * provider-aware strategy: OFF = verbatim passthrough; SAFE = Anthropic prompt
+    * caching + deterministic freeze-on-first-send tool condensation, OpenAI
+    * recall-restorable reduction; AGGRESSIVE = + lossy fold/compress (OpenAI live
+    * mutation). See docs/features/economizer.md. Default ECON_TIER_SAFE. */
+   int economizer_tier;
 
    /* Pluggable-module enablement (`modules:` block). The canonical, user-facing surface for
     * enabling/disabling the pipeline modules — memory (request stage), governance (response
@@ -2089,11 +2096,24 @@ int config_autonomy_lookup(const char *env_name, long *out);
  * and internally by config_reload. Ordinary readers should use config_load. */
 int config_load_file(config_t *cfg);
 
-/* Two-tier economizer resolution (P3) — compute EFFECTIVE lever states without mutating
- * config_t (so config_save always round-trips the raw user values). Precedence:
- * master-kill (economizer.enabled) > aggressive-tier ceiling > individual reduce.* default. */
-int econ_reduction_master_on(const config_t *cfg); /* economizer.enabled (measure is exempt) */
-int econ_gateway_mutate_on(const config_t *cfg);   /* enabled && aggressive && gateway_mutate */
+/* The economizer tier — the single user control. See docs/features/economizer.md. */
+enum
+{
+   ECON_TIER_OFF = 0,   /* verbatim passthrough: no caching, no reduction */
+   ECON_TIER_SAFE = 1,  /* lossless: Anthropic caching + frozen tool condensation; OpenAI recall */
+   ECON_TIER_AGGRESSIVE = 2 /* + lossy fold/compress; OpenAI live mutation */
+};
+
+/* Resolve the economizer tier (ECON_TIER_*). The single point that decides
+ * off/safe/aggressive; every economizer predicate routes through it. */
+int econ_tier(const config_t *cfg);
+const char *econ_tier_name(int tier); /* "off"/"safe"/"aggressive" */
+int econ_tier_parse(const char *s);   /* string -> ECON_TIER_* (default SAFE on unknown) */
+
+/* Economizer resolution — compute EFFECTIVE gates from the tier without mutating config_t
+ * (so config_save round-trips the raw user value). */
+int econ_reduction_master_on(const config_t *cfg); /* tier != off */
+int econ_gateway_mutate_on(const config_t *cfg);   /* tier == aggressive (OpenAI-only at call site) */
 
 /* Resolve whether a pluggable module is enabled, from the layered enablement surface. This is
  * the ONE place module enablement is decided; every wire site calls it with the module's tristate

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -799,16 +799,26 @@ native_provider_http:
             /* P3 master-kill: economizer.enabled=false forces the MUTATING levers off but
              * leaves the block reachable, so measure_only shadow accounting keeps running
              * (reports zero reductions — proof the kill works, per the two-tier contract). */
-            int econ_master = econ_reduction_master_on(&ecfg);
+            int econ_master = econ_reduction_master_on(&ecfg); /* tier != off */
+            int aggressive = econ_tier(&ecfg) == ECON_TIER_AGGRESSIVE;
+            /* history_fold is the SAFE-tier lever: recall-restorable (non-destructive) and
+             * freeze-guarded, so it is cache-favorable even on Anthropic (frozen on first
+             * send). Runs on safe+aggressive. (!chatgpt: the Responses builder can't take
+             * folded turns yet — a separate constraint, not a tier decision.) */
             rcfg.history_fold = econ_master && ecfg.reduce_history_fold && !chatgpt;
-            /* Compress only shrinks tool-result BODIES in place — the message
-             * shape (role/type, ids, typed items) is preserved — so its output is
-             * valid for ALL builders INCLUDING chatgpt/Responses. Not gated off. */
-            rcfg.compress = econ_master && ecfg.reduce_compress;
+            /* Compress LOSSILY shrinks tool-result bodies in place -> the AGGRESSIVE tier
+             * only. Shape (role/type, ids, typed items) is preserved, so it is valid for
+             * all builders including chatgpt/Responses. */
+            rcfg.compress = aggressive && ecfg.reduce_compress;
             rcfg.measure_only =
                 !(rcfg.history_fold || rcfg.compress); /* a lever on -> mutate; else shadow */
-            rcfg.freeze_guard_enabled = ecfg.reduce_freeze_guard_enabled; /* Slice 5 guardrail */
-            rcfg.freeze_guard_horizon = ecfg.reduce_freeze_guard_horizon;
+            /* Tier model: fold is ALWAYS freeze-guarded (cache-favorability gated). This is
+             * what makes fold cache-safe on Anthropic -- the folded prefix is frozen on
+             * first send and only re-folded when the savings beat the cache-write cost over
+             * the horizon, so a cache miss never costs more than it saves. Not togglable. */
+            rcfg.freeze_guard_enabled = 1;
+            rcfg.freeze_guard_horizon =
+                ecfg.reduce_freeze_guard_horizon > 0 ? ecfg.reduce_freeze_guard_horizon : 1;
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
             rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
             rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;

--- a/src/server/aimee_backend_anthropic.c
+++ b/src/server/aimee_backend_anthropic.c
@@ -46,10 +46,27 @@ static void strip_cache_control(cJSON *arr)
    }
 }
 
+/* The economizer's SAFE/AGGRESSIVE caching is on by default; the server flips it to 0
+ * when economizer=off (a pure verbatim passthrough with no cache markers). Kept as a
+ * server-set flag so the pure backend TU stays free of config linkage; minimal-link
+ * tests get the default (caching on), matching the cross-protocol byte-identity gate. */
+/* volatile: written on the server main loop (config reload), read on request threads.
+ * A single aligned 0/1 int -- volatile prevents the compiler caching a stale value; no
+ * torn reads are possible for the width, so no heavier atomic is warranted. */
+static volatile int g_anthropic_cache_enabled = 1;
+
+void aimee_backend_anthropic_set_cache_enabled(int on)
+{
+   g_anthropic_cache_enabled = on ? 1 : 0;
+}
+
 static void mark_cache_prefix(cJSON *arr)
 {
+   /* Always strip client/leaked markers so the egress is source-independent and
+    * deterministic; only ADD the aimee breakpoint when caching is enabled. When off,
+    * the request carries no cache_control at all (verbatim, uncached, still stable). */
    strip_cache_control(arr);
-   if (!cJSON_IsArray(arr))
+   if (!g_anthropic_cache_enabled || !cJSON_IsArray(arr))
       return;
    int n = cJSON_GetArraySize(arr);
    if (n <= 0)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -20,8 +20,9 @@
 #include "wfe_native_gate.h" /* wfe_shell_invokes_git — the shell-git classifier */
 #include "turn_registry.h"
 #include "server_http.h"
-#include "server_tls.h" /* server_http_api_status_report */
-#include "config.h"     /* config_t / config_load for api.status, api.enable */
+#include "server_tls.h"    /* server_http_api_status_report */
+#include "config.h"        /* config_t / config_load for api.status, api.enable */
+#include "aimee_backend.h" /* aimee_backend_anthropic_set_cache_enabled (economizer tier) */
 #include "delegate_backend_docker.h"
 #include "workspace_provider.h" /* the shared provider: probe docker for the sandbox posture */
 #include "workspace_turn.h"     /* the ONE workspace bound, shared with the delegate turn */
@@ -2317,8 +2318,19 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
    server_vault_bootstrap();
    return 0;
 }
+/* Push the economizer tier's runtime effects that live outside config_t readers -- the
+ * Anthropic-egress caching gate (off -> no cache markers). Called at startup and after
+ * every config reload so `economizer` takes effect live. */
+static void server_sync_economizer_runtime(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) == 0)
+      aimee_backend_anthropic_set_cache_enabled(econ_tier(&cfg) != ECON_TIER_OFF);
+}
+
 int server_run(server_ctx_t *ctx)
 {
+   server_sync_economizer_runtime(); /* apply economizer=off caching gate at startup */
    /* enforce-delegate-only: register the delegate-availability provider so the
     * gateway strips provider-native sub-agent tools whenever usable delegates
     * exist (CORE gateway_policy can't read agent state itself). */
@@ -2354,6 +2366,7 @@ int server_run(server_ctx_t *ctx)
          int rc = config_reload();
          aimee_log(rc < 0 ? LOG_WARN : LOG_INFO, "config", "SIGHUP config reload: %s",
                    rc > 0 ? "applied" : (rc == 0 ? "no change" : "rejected (kept running config)"));
+         server_sync_economizer_runtime();
          /* Also live-reload the TLS cert (re-read cert/key + swap SSL_CTX) so a renewed cert
           * is picked up on SIGHUP without dropping the listener (live-config-reload). */
          (void)server_tls_reload();
@@ -2364,8 +2377,12 @@ int server_run(server_ctx_t *ctx)
        * written. No-op tick when the file is unchanged. */
       int cfg_rc = config_reload_if_changed();
       if (cfg_rc != 0)
+      {
          aimee_log(cfg_rc < 0 ? LOG_WARN : LOG_INFO, "config", "config file change: %s",
                    cfg_rc > 0 ? "reloaded" : "rejected (kept running config)");
+         if (cfg_rc > 0)
+            server_sync_economizer_runtime();
+      }
    }
    return 0;
 }

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -25,37 +25,39 @@ static void test_two_tier_resolution(void)
 {
    config_t c;
    memset(&c, 0, sizeof c);
-   c.module_economizer = -1; /* config_load default: unspecified -> legacy economizer.enabled */
-
-   /* back-compat: defaults (enabled=1, aggressive=0) => effective == raw individual */
-   c.economizer_enabled = 1;
-   c.economizer_aggressive = 0;
+   c.module_economizer = -1;      /* unspecified -> tier is authoritative */
    c.reduce_command_filter = 1;
-   c.reduce_history_fold = 1;
-   c.reduce_compress = 1;
-   c.reduce_gateway_mutate = 0;
-   assert(econ_reduction_master_on(&c) == 1);
-   assert(cf_effective(&c) == 1);           /* command_filter on, as pre-P3 */
-   assert(econ_gateway_mutate_on(&c) == 0); /* off, as pre-P3 */
 
-   /* master-kill: enabled=0 forces reduction off even with every lever set... */
-   c.economizer_enabled = 0;
-   c.reduce_gateway_mutate = 1;
-   c.economizer_aggressive = 1;
+   /* OFF tier: no economization at all. */
+   c.economizer_tier = ECON_TIER_OFF;
+   assert(econ_tier(&c) == ECON_TIER_OFF);
    assert(econ_reduction_master_on(&c) == 0);
-   assert(cf_effective(&c) == 0);           /* command_filter suppressed */
-   assert(econ_gateway_mutate_on(&c) == 0); /* mutate suppressed by master */
+   assert(cf_effective(&c) == 0);           /* command_filter suppressed with reduction off */
+   assert(econ_gateway_mutate_on(&c) == 0);
 
-   /* aggressive ceiling: gateway_mutate needs ALL THREE (enabled && aggressive && lever) */
-   c.economizer_enabled = 1;
-   c.economizer_aggressive = 1;
-   c.reduce_gateway_mutate = 1;
+   /* SAFE tier: reduction on, but no live gateway mutation. */
+   c.economizer_tier = ECON_TIER_SAFE;
+   assert(econ_reduction_master_on(&c) == 1);
+   assert(cf_effective(&c) == 1);
+   assert(econ_gateway_mutate_on(&c) == 0); /* live mutation is aggressive-only */
+
+   /* AGGRESSIVE tier: reduction on + live mutation (OpenAI-only enforced at the call site). */
+   c.economizer_tier = ECON_TIER_AGGRESSIVE;
+   assert(econ_reduction_master_on(&c) == 1);
    assert(econ_gateway_mutate_on(&c) == 1);
-   c.economizer_aggressive = 0; /* aggressive off -> suppressed even though lever set */
+
+   /* modules.economizer:false is an authoritative hard-kill over any tier. */
+   c.module_economizer = 0;
+   assert(econ_tier(&c) == ECON_TIER_OFF);
+   assert(econ_reduction_master_on(&c) == 0);
    assert(econ_gateway_mutate_on(&c) == 0);
-   c.economizer_aggressive = 1;
-   c.reduce_gateway_mutate = 0; /* aggressive on but lever off -> still off (no auto-enable) */
-   assert(econ_gateway_mutate_on(&c) == 0);
+
+   /* the tier parser + names round-trip. */
+   assert(econ_tier_parse("off") == ECON_TIER_OFF);
+   assert(econ_tier_parse("safe") == ECON_TIER_SAFE);
+   assert(econ_tier_parse("aggressive") == ECON_TIER_AGGRESSIVE);
+   assert(econ_tier_parse("bogus") == ECON_TIER_SAFE); /* unknown -> safe */
+   assert(strcmp(econ_tier_name(ECON_TIER_AGGRESSIVE), "aggressive") == 0);
 
    /* NULL-safe */
    assert(econ_reduction_master_on(NULL) == 0);
@@ -267,22 +269,26 @@ int main(void)
       assert(config_reduce_validate(&cfg, err, sizeof(err)) != 0);
    }
 
-   /* --- two-tier switches (P3): defaults + save/load round-trip --- */
+   /* --- economizer tier: default + save/load round-trip (string form) --- */
    {
       static config_t cfg;
       memset(&cfg, 0, sizeof(cfg));
       config_load(&cfg);
-      assert(cfg.economizer_enabled == 1);    /* master default ON */
-      assert(cfg.economizer_aggressive == 0); /* aggressive tier default OFF */
-      cfg.economizer_enabled = 0;             /* opt-out the master */
-      cfg.economizer_aggressive = 1;          /* opt-in the aggressive tier */
+      assert(cfg.economizer_tier == ECON_TIER_SAFE); /* default is safe */
+      cfg.economizer_tier = ECON_TIER_AGGRESSIVE;
       assert(config_save(&cfg) == 0);
 
       static config_t cfg2;
       memset(&cfg2, 0, sizeof(cfg2));
       config_load(&cfg2);
-      assert(cfg2.economizer_enabled == 0);    /* opt-out persisted */
-      assert(cfg2.economizer_aggressive == 1); /* opt-in persisted */
+      assert(cfg2.economizer_tier == ECON_TIER_AGGRESSIVE); /* persisted as economizer: aggressive */
+
+      /* off also round-trips (non-default); safe is the default and is not persisted. */
+      cfg.economizer_tier = ECON_TIER_OFF;
+      assert(config_save(&cfg) == 0);
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.economizer_tier == ECON_TIER_OFF);
    }
 
    /* --- modules.* tristate: defaults are -1 (unspecified) and are NOT persisted; an explicit
@@ -322,20 +328,18 @@ int main(void)
       assert(config_module_enabled(cfg3.module_memory, 1) == 1);     /* -1 -> env default ON */
       assert(config_module_enabled(cfg3.module_memory, 0) == 0);     /* -1 -> env default OFF */
 
-      /* economizer master gate honors modules.economizer AUTHORITATIVELY over the legacy
-       * economizer.enabled bool (economizer's "env default" analog). */
+      /* modules.economizer:false is an authoritative hard-kill over the tier; otherwise the
+       * tier decides. */
       config_t ec;
       memset(&ec, 0, sizeof(ec));
-      ec.economizer_enabled = 1; /* legacy master ON... */
-      ec.module_economizer = 0;  /* ...but modules.economizer:false wins */
+      ec.economizer_tier = ECON_TIER_SAFE;
+      ec.module_economizer = 0; /* hard kill regardless of tier */
       assert(econ_reduction_master_on(&ec) == 0);
-      ec.economizer_enabled = 0; /* legacy master OFF... */
-      ec.module_economizer = 1;  /* ...but modules.economizer:true wins */
+      ec.module_economizer = 1; /* not killed -> tier decides */
       assert(econ_reduction_master_on(&ec) == 1);
-      ec.module_economizer = -1; /* unspecified -> fall back to legacy economizer.enabled */
-      ec.economizer_enabled = 1;
+      ec.module_economizer = -1; /* unspecified -> tier decides */
       assert(econ_reduction_master_on(&ec) == 1);
-      ec.economizer_enabled = 0;
+      ec.economizer_tier = ECON_TIER_OFF;
       assert(econ_reduction_master_on(&ec) == 0);
    }
 

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -25,14 +25,14 @@ static void test_two_tier_resolution(void)
 {
    config_t c;
    memset(&c, 0, sizeof c);
-   c.module_economizer = -1;      /* unspecified -> tier is authoritative */
+   c.module_economizer = -1; /* unspecified -> tier is authoritative */
    c.reduce_command_filter = 1;
 
    /* OFF tier: no economization at all. */
    c.economizer_tier = ECON_TIER_OFF;
    assert(econ_tier(&c) == ECON_TIER_OFF);
    assert(econ_reduction_master_on(&c) == 0);
-   assert(cf_effective(&c) == 0);           /* command_filter suppressed with reduction off */
+   assert(cf_effective(&c) == 0); /* command_filter suppressed with reduction off */
    assert(econ_gateway_mutate_on(&c) == 0);
 
    /* SAFE tier: reduction on, but no live gateway mutation. */
@@ -281,7 +281,8 @@ int main(void)
       static config_t cfg2;
       memset(&cfg2, 0, sizeof(cfg2));
       config_load(&cfg2);
-      assert(cfg2.economizer_tier == ECON_TIER_AGGRESSIVE); /* persisted as economizer: aggressive */
+      assert(cfg2.economizer_tier ==
+             ECON_TIER_AGGRESSIVE); /* persisted as economizer: aggressive */
 
       /* off also round-trips (non-default); safe is the default and is not persisted. */
       cfg.economizer_tier = ECON_TIER_OFF;

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -18,7 +18,7 @@ static int g_last_agg = -1;
 static void probe_reapplier(const config_t *o, const config_t *n)
 {
    (void)o;
-   g_last_agg = n->economizer_aggressive;
+   g_last_agg = n->economizer_tier;
    atomic_fetch_add_explicit(&g_reapply_calls, 1, memory_order_relaxed);
 }
 
@@ -32,7 +32,7 @@ static void write_marker(int aggressive, int budget)
    /* keep the config VALID regardless of what a prior (deliberately-invalid) test left on
     * disk, so config_reload's validate-or-keep never rejects a marker write. */
    c.reduce_gateway_session_disable_ttl_ms = 3600000;
-   c.economizer_aggressive = aggressive;
+   c.economizer_tier = aggressive ? ECON_TIER_AGGRESSIVE : ECON_TIER_OFF;
    c.coord_closet_budget_bytes = budget;
    assert(config_save(&c) == 0);
 }
@@ -51,8 +51,8 @@ static void *reader_thread(void *arg)
       if (config_snapshot_get(&c) != 0)
          continue;
       atomic_fetch_add_explicit(&g_reads, 1, memory_order_relaxed);
-      int a = (c.economizer_aggressive == 1 && c.coord_closet_budget_bytes == 1111);
-      int b = (c.economizer_aggressive == 0 && c.coord_closet_budget_bytes == 2222);
+      int a = (c.economizer_tier == ECON_TIER_AGGRESSIVE && c.coord_closet_budget_bytes == 1111);
+      int b = (c.economizer_tier == ECON_TIER_OFF && c.coord_closet_budget_bytes == 2222);
       if (!a && !b)
          atomic_fetch_add_explicit(&g_torn, 1, memory_order_relaxed);
    }
@@ -85,7 +85,7 @@ int main(void)
       config_snapshot_init(&c0);
       config_t got;
       assert(config_snapshot_get(&got) == 0);
-      assert(got.economizer_aggressive == 1);
+      assert(got.economizer_tier == ECON_TIER_AGGRESSIVE);
       assert(got.coord_closet_budget_bytes == 1111);
    }
 
@@ -98,7 +98,7 @@ int main(void)
    {
       config_t got;
       assert(config_snapshot_get(&got) == 0);
-      assert(got.economizer_aggressive == 0);
+      assert(got.economizer_tier == ECON_TIER_OFF);
       assert(got.coord_closet_budget_bytes == 2222);
    }
    /* reloading the same file again is a no-op */
@@ -125,7 +125,7 @@ int main(void)
       write_marker(1, 1111); /* change back to aggressive=1 */
       assert(config_reload() == 1);
       assert(atomic_load_explicit(&g_reapply_calls, memory_order_relaxed) == before + 1);
-      assert(g_last_agg == 1); /* re-applier saw the NEW value */
+      assert(g_last_agg == ECON_TIER_AGGRESSIVE); /* re-applier saw the NEW value */
       /* a no-op reload does NOT fire the re-applier */
       int mid = atomic_load_explicit(&g_reapply_calls, memory_order_relaxed);
       assert(config_reload() == 0);

--- a/src/tests/test_ir_crossproto_egress.c
+++ b/src/tests/test_ir_crossproto_egress.c
@@ -166,6 +166,28 @@ int main(void)
       free(e);
    }
 
+   /* economizer=off: the caching gate is disabled -> the Anthropic egress carries NO
+    * cache_control at all, yet is STILL byte-identical across source protocols (the
+    * verbatim, uncached, deterministic passthrough). Restore caching afterwards. */
+   aimee_backend_anthropic_set_cache_enabled(0);
+   {
+      char *a = egress("{\"model\":\"m\",\"max_tokens\":8,"
+                       "\"system\":[{\"type\":\"text\",\"text\":\"sys\"}],"
+                       "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\","
+                       "\"text\":\"hi\"}]}]}",
+                       0);
+      char *o = egress("{\"model\":\"m\",\"max_tokens\":8,"
+                       "\"messages\":[{\"role\":\"system\",\"content\":\"sys\"},"
+                       "{\"role\":\"user\",\"content\":\"hi\"}]}",
+                       1);
+      assert(a && o && strcmp(a, o) == 0);        /* still cross-source identical */
+      assert(strstr(a, "cache_control") == NULL); /* no markers when economizer=off */
+      free(a);
+      free(o);
+      printf("  economizer-off-disables-cache OK\n");
+   }
+   aimee_backend_anthropic_set_cache_enabled(1); /* restore default (caching on) */
+
    printf("all cross-protocol egress byte-identity checks passed\n");
    return 0;
 }

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -25,14 +25,13 @@ int main(void)
    {
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
-      cfg.module_economizer =
-          -1; /* config_load default: unspecified -> legacy economizer.enabled */
-      assert(tool_condense_enabled(&cfg) == 0);
+      cfg.module_economizer = -1; /* unspecified -> tier decides */
+      assert(tool_condense_enabled(&cfg) == 0); /* tier OFF (memset) -> off */
       cfg.reduce_command_filter = 1;
-      assert(tool_condense_enabled(&cfg) == 0); /* P3 master (economizer.enabled) still off */
-      cfg.economizer_enabled = 1;
-      assert(tool_condense_enabled(&cfg) == 1); /* master + lever both on */
-      cfg.economizer_enabled = 0;               /* master-kill overrides the lever */
+      assert(tool_condense_enabled(&cfg) == 0); /* still tier OFF */
+      cfg.economizer_tier = ECON_TIER_SAFE;
+      assert(tool_condense_enabled(&cfg) == 1); /* tier on + lever on */
+      cfg.economizer_tier = ECON_TIER_OFF;      /* off tier kills the lever */
       assert(tool_condense_enabled(&cfg) == 0);
       assert(tool_condense_enabled(NULL) == 0);
    }
@@ -274,7 +273,7 @@ int main(void)
       assert(tool_condense_apply(&cfg, "pytest -q", 0, big, "/tmp", NULL) == NULL);
 
       cfg.reduce_command_filter = 1;
-      cfg.economizer_enabled = 1; /* P3 master gate */
+      cfg.economizer_tier = ECON_TIER_SAFE; /* master on */
       /* unrecognized command -> passthrough */
       assert(tool_condense_apply(&cfg, "frobnicate", 0, big, "/tmp", NULL) == NULL);
       /* recognized but no spill dir -> passthrough (lossless: never condense without spill) */
@@ -354,7 +353,7 @@ int main(void)
       cfg.module_economizer =
           -1; /* config_load default: unspecified -> legacy economizer.enabled */
       cfg.reduce_command_filter = 1;
-      cfg.economizer_enabled = 1; /* P3 master gate */
+      cfg.economizer_tier = ECON_TIER_SAFE; /* master on */
       char big[8192];
       size_t off = 0;
       for (int k = 0; k < 80; k++)
@@ -383,7 +382,7 @@ int main(void)
       cfg.module_economizer =
           -1; /* config_load default: unspecified -> legacy economizer.enabled */
       cfg.reduce_command_filter = 1;
-      cfg.economizer_enabled = 1; /* P3 master gate */
+      cfg.economizer_tier = ECON_TIER_SAFE; /* master on */
       char big[8192];
       size_t off = 0;
       off += (size_t)snprintf(big + off, sizeof big - off, "==== session ====\n");

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -25,7 +25,7 @@ int main(void)
    {
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
-      cfg.module_economizer = -1; /* unspecified -> tier decides */
+      cfg.module_economizer = -1;               /* unspecified -> tier decides */
       assert(tool_condense_enabled(&cfg) == 0); /* tier OFF (memset) -> off */
       cfg.reduce_command_filter = 1;
       assert(tool_condense_enabled(&cfg) == 0); /* still tier OFF */


### PR DESCRIPTION
Introduces the single `economizer = off | safe | aggressive` control (the working tier model; slices A–C of the consolidation). The old `reduce.*` / `economizer_enabled` / `economizer_aggressive` surface still exists but is now **vestigial** — the tier is authoritative — and is deleted in a follow-up.

## Model (provider-aware)
| Tier | Anthropic egress *(never mutated non-deterministically)* | OpenAI-family egress |
|---|---|---|
| **off** | no `cache_control`, verbatim | no reduction |
| **safe** | prompt caching + deterministic, freeze-guarded tool condensation | recall-restorable fold + condensation (lossless) |
| **aggressive** | prompt caching *(same)* | + lossy compress + live gateway mutation |

## Slices
- **A** — `config_t.economizer_tier` (default SAFE) + `econ_tier`/`_name`/`_parse`; `economizer:` parsed as a string (old object form still accepted → mapped); the `econ_reduction_master_on`/`econ_gateway_mutate_on` accessors resolve from the tier (`!= off` / `== aggressive`); config tests migrated to the tier; an unknown tier string warns.
- **B** — the Anthropic egress prompt-caching is gated on the tier: `mark_cache_prefix` always strips client/leaked `cache_control` (determinism preserved) but only adds the aimee breakpoint when caching is on; `off` → no markers. A server-set flag (synced from config at startup + every reload) keeps the pure backend config-free. Cross-protocol gate gains an `economizer-off` case.
- **C** — lossy `compress` reserved for the aggressive tier; recall+freeze-guarded `history_fold` and deterministic `tool_condense` stay safe-tier; fold is now **always** freeze-guarded so it never breaks Anthropic caching.

## Verified
Full `make unit-tests` + `make build-integrity` green. Cross-protocol byte-identity gate still passes (incl. the new economizer-off case). Live cache behavior already validated on `.254` (13k-token cache read via MiniMax-M3 multi-turn).

## Follow-ups (separate)
- Delete the vestigial `reduce.*` + two-tier config surface, replacing fold/closet tuning with tier-keyed internal presets.
- Finalize `docs/features/economizer.md`; extend #1511's `economizer/stats` to tag by tier + provider.
