### PR TITLE
config: unstrand curator gates + drop duplicate rows in config_fields[]

### DIFF
--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -169,18 +169,13 @@ const config_field_t config_fields[] = {
      sizeof(int), 0, CFG_INT},
     {"memory_maintenance_trigger_secs", offsetof(config_t, memory_maintenance_trigger_secs),
      sizeof(int), 0, CFG_INT},
-    {"memory_rerank_enabled", offsetof(config_t, memory_rerank_enabled), sizeof(int), 0, CFG_BOOL},
+    /* memory_rerank_{enabled,command,top_k} and memory_query_expansion_{mode,k} are already
+     * declared once above (see ~L87-153). The duplicate rows that used to sit here were
+     * shadowed dead weight — config_field_lookup returns the first match — and were removed. */
     {"memory_improve_dedupe_enabled", offsetof(config_t, memory_improve_dedupe_enabled),
      sizeof(int), 0, CFG_BOOL},
     {"memory_improve_summarise_enabled", offsetof(config_t, memory_improve_summarise_enabled),
      sizeof(int), 0, CFG_BOOL},
-    {"memory_rerank_command", offsetof(config_t, memory_rerank_command),
-     sizeof(((config_t *)0)->memory_rerank_command), 0, CFG_STRING},
-    {"memory_rerank_top_k", offsetof(config_t, memory_rerank_top_k), sizeof(int), 0, CFG_INT},
-    {"memory_query_expansion_mode", offsetof(config_t, memory_query_expansion_mode),
-     sizeof(((config_t *)0)->memory_query_expansion_mode), 0, CFG_STRING},
-    {"memory_query_expansion_k", offsetof(config_t, memory_query_expansion_k), sizeof(int), 0,
-     CFG_INT},
     {"memory_profile_cards_enabled", offsetof(config_t, memory_profile_cards_enabled), sizeof(int),
      0, CFG_BOOL},
     {"memory_profile_cards_min_obs", offsetof(config_t, memory_profile_cards_min_obs), sizeof(int),
@@ -374,10 +369,12 @@ const config_field_t config_fields[] = {
     {"autonomy.unit_retry", offsetof(config_t, autonomy_unit_retry), sizeof(int), 0, CFG_INT},
     {"autonomy.unit_max", offsetof(config_t, autonomy_unit_max), sizeof(int), 0, CFG_INT},
     {"autonomy.ci_retry_max", offsetof(config_t, autonomy_ci_retry_max), sizeof(int), 0, CFG_INT},
-    {NULL, 0, 0, 0, CFG_STRING},
     /* Curator pipeline stage gates (kb.curator.*) — exposed so the GUI pipeline editor
      * can toggle stages. Flat config_t fields; config_save reserializes them into the
-     * nested kb.curator.* YAML the KB reads on its next load. */
+     * nested kb.curator.* YAML the KB reads on its next load. These MUST stay ahead of the
+     * {NULL} terminator below: every consumer (config.show/get/set, the CLI key listing)
+     * iterates until the first NULL key, so a terminator placed before them makes them
+     * unreachable — the bug this array previously had. */
     {"kb_curator_extract_docs_enabled", offsetof(config_t, kb_curator_extract_docs_enabled),
      sizeof(int), 0, CFG_BOOL},
     {"kb_curator_extract_docs_workers", offsetof(config_t, kb_curator_extract_docs_workers),
@@ -414,6 +411,7 @@ const config_field_t config_fields[] = {
      sizeof(int), 0, CFG_BOOL},
     {"kb_evidence_embed_enabled", offsetof(config_t, kb_evidence_embed_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {NULL, 0, 0, 0, CFG_STRING},
 };
 #pragma GCC diagnostic pop
 

--- a/src/tests/test_cmd_config.c
+++ b/src/tests/test_cmd_config.c
@@ -128,6 +128,13 @@ static void test_config_fields_helpers(void)
    assert(config_field_lookup("autonomous") != NULL);
    assert(config_field_lookup("no_such_key") == NULL);
 
+   /* Regression guard: the kb_curator_* / kb_evidence_embed_enabled gates are the LAST
+    * entries in config_fields[]. They were once stranded behind a stray {NULL} terminator
+    * placed mid-array, which made config_field_lookup (and config.show/get/set) stop before
+    * reaching them. Assert the tail of the table is reachable so that bug cannot return. */
+   assert(config_field_lookup("kb_curator_synthesize_enabled") != NULL);
+   assert(config_field_lookup("kb_evidence_embed_enabled") != NULL);
+
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
 


### PR DESCRIPTION
First slice of the config-option cleanup (cull-before-consolidate). Scoped to **`src/config_fields.c` only** so it does not collide with #1516's economizer-tier work (which never touches this file).

## What & why
`config_fields[]` had a `{NULL}` terminator buried **mid-array**, immediately before the 16 `kb_curator_*` / `kb_evidence_embed_enabled` gate entries. Every consumer iterates `for (i=0; config_fields[i].key; i++)`, so `config.show`, `config.get`, `config.set`, and the CLI key listing all stopped at that terminator and never reached those entries.

Consequences fixed:
- Those gates were **invisible to the Web GUI** (which renders whatever `config.show` returns) and `config set <curator key>` returned `"unknown key"`.
- The **Settings → Pipeline editor page was silently broken** — every curator stage rendered stuck-OFF and every toggle/preset/save was rejected.

The underlying `config_t` fields are read normally and already round-trip through `config_save_kb_curator()`, so only the typed config surface was blind. Moving the terminator to the true end of the array makes all gates reachable — no frontend change needed.

Also removed the **5 shadowed duplicate rows** (`memory_rerank_{enabled,command,top_k}`, `memory_query_expansion_{mode,k}`); `config_field_lookup` returns the first match, so the second copies were dead weight.

## Test
Added a regression assertion in `test_cmd_config` so a terminator placed ahead of the tail entries fails the build. Verified green: `unit-test-cmd-config`, `unit-test-config-snapshot`, `unit-test-config-surface`, `unit-test-config-economizer`.

## Not in this PR (follow-ups)
- Struct-level removal of genuinely dead fields (`llm_*_host/gpu`, `llm_synth_model`, `ecomode`, `memory_kb_neighbour_expand`, `memory_scenes_min_cluster_size/top_m`) — these touch `config.h`/`config.c`/`config_save.c`, which #1516 also edits; sequence after it lands.
- Guardrails-semantic enum collapse (+ fix `advisory_only` missing from `config_fields[]`).
- The `reduce.*` / `economizer_*` merge is owned by #1516 + its follow-up.
