### PR TITLE
economizer: remove the vestigial reduce.* / economizer.enabled|aggressive surface

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -19,7 +19,7 @@ request), unless noted otherwise below.
   is the only network hop; there are no server changes per field.
 - **Control inference:** the control type is inferred from the value's JSON type: a
   **boolean → toggle**, a **number → number field**, a **string → text field**. Grouping is
-  by the dotted key prefix (e.g. everything under `reduce.` forms one section).
+  by the dotted key prefix (e.g. everything under `autonomy.` forms one section).
 - **Quick panel:** a smaller gear dropdown in the top bar (`SettingsPanel`) surfaces the
   five most-used toggles (autonomous mode, cross-verify, eco mode, reasoning cap, max
   iterations). The full page is the comprehensive home for everything else.
@@ -33,28 +33,25 @@ request), unless noted otherwise below.
 
 ## Option groups added recently
 
-### Context economizer: two-tier switches (`economizer.*`) + levers (`reduce.*`)
+### Context economizer: the single `economizer` tier
 
-The economizer has two **tier switches** that gate the individual `reduce.*` levers, plus the
-levers themselves. All are booleans except the two numeric tuning knobs. Defaults in
-parentheses.
+The economizer is controlled by **one** provider-aware setting, `economizer`, with three
+values. It replaces the old `economizer.enabled`/`economizer.aggressive` switches and the
+per-lever `reduce.*` booleans — the tier now decides each reducer's behavior internally.
 
-| Setting | Default | What it does |
-| --- | --- | --- |
-| **`economizer.enabled`** | **on** | **Master switch.** Off = one kill-switch: every reducer is forced off (measurement keeps running and reports zero, proving the kill). The safe tier stays on under it by the levers' own defaults. |
-| `economizer.aggressive` | off | **Opt-in ceiling for the aggressive tier** (live **primary** `/v1` mutation). `reduce.gateway_mutate` activates only with **`economizer.enabled` AND `economizer.aggressive` AND** the lever itself; the aggressive flag alone never turns on a live-traffic mutator. |
-| **`reduce.command_filter`** | **on** | **Tool-output condensation**: deterministically condense recognized command output (test-runner failures kept, passes elided; compiler diagnostics kept, progress dropped) with the full output spilled for recovery. See [Tool-output condensation](features/tool-output-condensation.md). |
-| `reduce.gateway_mutate` | off | Apply the economizer to the live inbound `/v1` request so the **primary** agent's tokens are reduced too. See [Economizer gateway mutation](features/economizer-gateway-mutation.md). |
-| `reduce.compress` | on | Size-based compression of oversized tool-result bodies. |
-| `reduce.history_fold` | on | Fold old turn history into a rolling skeleton. |
-| `reduce.delegate_seam` | on | Run the economizer at the delegate turn loop. |
-| `reduce.measure` | on | Collect the baseline/opportunity token ledger. |
-| `reduce.freeze_guard` | on | Pin the fold boundary only when the cache-read savings beat the cache-write cost. |
-| `reduce.gateway_session_disable_ttl_ms` | 3600000 | Gateway-mutation circuit-breaker window (ms). Must be > 0. |
-| `reduce.freeze_guard_horizon` | 1 | Expected reuse turns for the freeze break-even estimate. |
+| `economizer` | What it does |
+| --- | --- |
+| `off` | Verbatim passthrough: no prompt caching, no reduction. |
+| `safe` **(default)** | Lossless. Anthropic prompt caching + deterministic freeze-on-first-send tool-output condensation; OpenAI recall-restorable history fold. |
+| `aggressive` | Everything in `safe`, plus lossy body compression and live OpenAI `/v1` gateway mutation (primary-agent token reduction, behind a per-session circuit breaker). |
 
-`reduce.gateway_seam` is intentionally **not** on the page. It is synthesized from
-`gateway_mutate` and its persistence is explicit-gated; toggle `gateway_mutate` instead.
+```yaml
+economizer: safe   # off | safe | aggressive
+```
+
+`modules.economizer: false` is an authoritative hard-kill that forces the tier to `off`
+regardless of its value. A deprecated `economizer: {enabled, aggressive}` object form is still
+accepted and mapped onto the tier for back-compat.
 
 ### Autonomous-development pipeline: `autonomy.*`
 
@@ -75,32 +72,21 @@ per-turn toggles). Values are clamped to sane bounds.
 
 ---
 
-## Turning on tool-output condensation
+## Tool-output condensation
 
-The most common new toggle. In the web UI:
+Deterministic command-aware tool-output condensation is part of the **`safe`** tier — it is on
+whenever `economizer` is `safe` or `aggressive` (i.e. not `off`). There is no separate toggle;
+set `economizer: off` to disable all reduction including condensation.
 
-1. Open **⚙️ Settings** (left nav) and filter for `command_filter` (or scroll to the
-   **`reduce`** group).
-2. Flip **`reduce.command_filter`** **on** and **Save**.
-
-Or from the CLI / config file:
-
-```yaml
-reduce:
-  command_filter: true
-```
-
-When on, a delegate's recognized command output is condensed before it enters context, with
-the full output spilled under `<aimee_home>/tool-spills/` and a recovery pointer in the
-condensed result. When off, output is byte-identical to today (it falls through to the
-size-based `reduce.compress`). See
-[features/tool-output-condensation.md](features/tool-output-condensation.md) for the full
-behavior, safety contract, and observability.
+A delegate's recognized command output is condensed before it enters context, with the full
+output spilled under `<aimee_home>/tool-spills/` and a recovery pointer in the condensed
+result. See [features/tool-output-condensation.md](features/tool-output-condensation.md) for
+the full behavior, safety contract, and observability.
 
 ## When a change takes effect
 
-- **Immediately (next turn):** the economizer `reduce.*` levers and most other fields. The
-  server reloads config per request.
+- **Immediately (next turn):** the `economizer` tier and most other fields. The server
+  reloads config per request.
 - **On next server start:** the `autonomy.*` knobs: they are bridged to `AIMEE_AUTONOMY_*`
   environment variables at startup so the workflow engine (which reads them across a module
   boundary) sees them; an explicitly-set env var always wins.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -214,7 +214,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 
 > **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `audit_action_enabled`, `code_trust_actuation_enabled`, `kb_client_bearer_token`, `kb_client_url`, `kb_curator_cross_repo_graph_enabled`, `kb_curator_custom_stages`, `kb_curator_detect_contradictions_enabled`, `kb_curator_extract_code_enabled`, `kb_curator_extract_code_workers`, `kb_curator_extract_docs_enabled`, `kb_curator_extract_docs_workers`, `kb_curator_index_claims_enabled`, `kb_curator_index_code_unit_enabled`, `kb_curator_index_narrative_enabled`, `kb_curator_link_artifacts_enabled`, `kb_curator_projection_graph_enabled`, `kb_curator_promote_entity_enabled`, `kb_curator_resolve_entities_enabled`, `kb_curator_stage_order`, `kb_curator_synthesize_enabled`, `kb_curator_user_presets`, `kb_evidence_embed_enabled`, `kb_mode`, `llm_embed_backend`, `llm_embed_gpu`, `llm_embed_host`, `llm_embed_tier`, `llm_rerank_backend`, `llm_rerank_endpoint`, `llm_rerank_gpu`, `llm_rerank_host`, `llm_rerank_tier`, `llm_synth_backend`, `llm_synth_endpoint`, `llm_synth_gpu`, `llm_synth_host`, `llm_synth_model`, `llm_synth_tier`, `wfe_proposals_autoscan_enabled`
 
-## Config-file sections (53)
+## Config-file sections (52)
 
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`; a key shown as a bare name that is itself a nested object is noted in the section description (see *Coverage & limitations*).
 
@@ -257,7 +257,6 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `command_filter`, `compress`, `delegate_seam`, `freeze_guard`, `freeze_guard_horizon`, `gateway_mutate`, `gateway_seam`, `gateway_session_disable_ttl_ms`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `default`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/src/config.c
+++ b/src/config.c
@@ -377,7 +377,9 @@ static const config_schema_entry_t config_schema[] = {
     {"compact", SCHEMA_OBJECT, 0},
     {"fold", SCHEMA_OBJECT, 0},
     {"reduce", SCHEMA_OBJECT, 0},
-    {"economizer", SCHEMA_OBJECT, 0},
+    {"economizer", SCHEMA_STRING, 0}, /* canonical: `economizer: off|safe|aggressive`. The
+                                       * deprecated {enabled,aggressive} object form still parses
+                                       * (config_sections.c) but warns here as a migration nudge. */
     {"sessions", SCHEMA_OBJECT, 0},
     {"sandbox", SCHEMA_OBJECT, 0},
     {"ecomode", SCHEMA_BOOL, 0},
@@ -593,34 +595,14 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_freeze_tail_cap_msgs = 0;
    cfg->fold_recall_enabled = 0; /* fold §4: default-off */
    cfg->fold_recall_ttl_turns = 0;
-   /* Context economizer: DEFAULT-ON on the delegate seam (the implemented, tested
-    * reduction path). measure + delegate_seam + history_fold + compress all on.
-    * Lossy reduction stays recoverable: both levers only touch messages BEFORE the
-    * retained tail (the most recent retained_msgs stay full), and the Coordinate
-    * Closet (also default-on) conserves the exact identifiers so the agent can
-    * re-issue a tool call to recover an elided body. history_fold is converted to a
-    * live fold ONLY at agent_runtime.c (rcfg.history_fold = reduce_history_fold &&
-    * !chatgpt) — it reaches the Responses builder on ZERO paths; compress is
-    * shape-preserving and runs for all providers. */
-   cfg->reduce_measure_enabled = 1;
-   cfg->reduce_delegate_seam = 1;
-   cfg->reduce_history_fold = 1;
-   cfg->reduce_compress = 1;
-   /* GATEWAY seam (primary-agent /v1 path) stays off: shadow-only until its
-    * request-mutation + 400-retry-from-pristine circuit breaker are built. */
-   cfg->reduce_gateway_seam = 0;
-   cfg->reduce_freeze_guard_enabled = 1; /* safety: on for the default-on economizer freeze */
-   cfg->reduce_freeze_guard_horizon = 1; /* conservative break-even: one reuse pays the write */
-   /* Gateway MUTATION (primary-agent reduction) is the whole feature default-OFF; the
-    * session-disable TTL is a live-path breaker window (1h) that must stay > 0. */
-   cfg->reduce_gateway_mutate = 0;
-   cfg->reduce_gateway_session_disable_ttl_ms = 3600000;
-   cfg->reduce_gateway_seam_explicit = 0;
-   /* Two-tier economizer switches (P3): master ON (measure exempt), aggressive tier OFF. With
-    * these defaults every effective lever equals its pre-P3 value (back-compat). */
-   cfg->economizer_enabled = 1;
-   cfg->economizer_aggressive = 0;
-   cfg->economizer_tier = ECON_TIER_SAFE; /* the single control; default lossless */
+   /* Context economizer: the SAFE tier is the default. It drives the delegate-seam reducers
+    * (measure + history_fold + command-filter condensation; compress is aggressive-only) via
+    * the econ_* accessors — no per-lever booleans. Lossy reduction stays recoverable: the
+    * reducers only touch messages BEFORE the retained tail, and the Coordinate Closet
+    * (default-on) conserves the exact identifiers so the agent can re-issue a tool call to
+    * recover an elided body. history_fold reaches the chatgpt Responses builder on ZERO paths
+    * (agent_runtime.c gates it on !chatgpt); compress is shape-preserving and runs for all. */
+   cfg->economizer_tier = ECON_TIER_SAFE; /* the single economizer control; default lossless */
    /* Pluggable-module toggles default to -1 (unspecified) so the resolver falls back to each
     * module's deprecated env toggle / default-ON until an operator writes the `modules:` block. */
    cfg->module_memory = -1;
@@ -628,12 +610,6 @@ static void config_set_defaults(config_t *cfg)
    cfg->module_delegates = -1;
    cfg->module_workflows = -1;
    cfg->module_economizer = -1;
-   /* command-aware tool-output condensation: DEFAULT-ON (P1c). Safe-tier lever — it passes
-    * the deterministic gate: lossless-on-demand (full output spilled), fail-open (any
-    * miss/decline -> raw), and a no-over-reduction audit (failures/diagnostics + their
-    * detail block are kept in the condensed view, not just the spill). It replaces the old
-    * lossy 32 KB read-cap truncation with lossless-recoverable condensation. */
-   cfg->reduce_command_filter = 1;
    /* Autonomous-dev knobs — defaults match the historical AIMEE_AUTONOMY_* env defaults
     * (adversarial + fan-out tiers OFF; retry/unit caps at their wfe defaults). */
    cfg->autonomy_skeptics = 0;
@@ -1484,7 +1460,6 @@ int config_load_file(config_t *cfg)
    config_parse_fold_section(cfg, root);
    config_parse_modules_section(cfg, root);
    config_parse_reduce_section(cfg, root);
-   config_apply_reduce_consistency(cfg); /* mutate=1 -> auto-enable shadow seam in memory + WARN */
    config_parse_autonomy_section(cfg, root);
 
    config_parse_memory_section(cfg, root);
@@ -1899,12 +1874,6 @@ int config_reload(void)
    {
       pthread_mutex_unlock(&g_snap_wlock);
       return -1; /* parse failure -> keep the running snapshot */
-   }
-   char err[256];
-   if (config_reduce_validate(&fresh, err, sizeof err) != 0)
-   {
-      pthread_mutex_unlock(&g_snap_wlock);
-      return -1; /* invalid -> keep the running snapshot (validate-or-keep) */
    }
    uint64_t tok = config_snapshot_token(&fresh);
    if (atomic_load_explicit(&g_snap_inited, memory_order_acquire) && tok == g_snap_token)

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -347,25 +347,12 @@ const config_field_t config_fields[] = {
      offsetof(config_t, roundtable_pipeline_parked_releases_slot), sizeof(int), 1, CFG_BOOL},
     {"roundtable.pipeline_unknown_context_tokens",
      offsetof(config_t, roundtable_pipeline_unknown_context_tokens), sizeof(int), 0, CFG_INT},
-    /* Context economizer (context_reduce). Already config_t fields, parsed + saved under
-     * the "reduce" yaml object; exposed here so the typed config surface + web Settings
-     * can toggle them. gateway_seam is intentionally omitted (it is synthesized from
-     * gateway_mutate and its persistence is explicit-gated — gateway_mutate is the
-     * user-facing toggle). */
-    {"reduce.measure", offsetof(config_t, reduce_measure_enabled), sizeof(int), 1, CFG_BOOL},
-    {"reduce.delegate_seam", offsetof(config_t, reduce_delegate_seam), sizeof(int), 1, CFG_BOOL},
-    {"reduce.history_fold", offsetof(config_t, reduce_history_fold), sizeof(int), 1, CFG_BOOL},
-    {"reduce.compress", offsetof(config_t, reduce_compress), sizeof(int), 1, CFG_BOOL},
-    {"reduce.gateway_mutate", offsetof(config_t, reduce_gateway_mutate), sizeof(int), 1, CFG_BOOL},
-    {"reduce.command_filter", offsetof(config_t, reduce_command_filter), sizeof(int), 1, CFG_BOOL},
-    {"economizer.enabled", offsetof(config_t, economizer_enabled), sizeof(int), 1, CFG_BOOL},
-    {"economizer.aggressive", offsetof(config_t, economizer_aggressive), sizeof(int), 1, CFG_BOOL},
-    {"reduce.gateway_session_disable_ttl_ms",
-     offsetof(config_t, reduce_gateway_session_disable_ttl_ms), sizeof(int), 0, CFG_INT},
-    {"reduce.freeze_guard", offsetof(config_t, reduce_freeze_guard_enabled), sizeof(int), 1,
-     CFG_BOOL},
-    {"reduce.freeze_guard_horizon", offsetof(config_t, reduce_freeze_guard_horizon), sizeof(int), 0,
-     CFG_INT},
+    /* The economizer is controlled by the single `economizer: off|safe|aggressive` tier key
+     * (parsed in config_sections.c into economizer_tier). It is intentionally NOT in this flat
+     * table: the tier is an enum surfaced as a string, which this scalar get/set machinery does
+     * not model. The old reduce.* / economizer.enabled|aggressive rows were removed with the
+     * vestigial lever surface. TODO(A): expose the tier in the typed/GUI surface once the config
+     * table grows enum-as-string support. */
     /* Autonomous-development pipeline knobs (Phase-C). New config_t fields bridged to the
      * AIMEE_AUTONOMY_* env vars at startup (a set env var still overrides); a change
      * applies on the next server start. */

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -306,22 +306,6 @@ static const char *config_save_default_db1_path(void)
    return path;
 }
 
-/* Does the unified context economizer hold any non-default value worth persisting?
- * Centralized so each new reduce.* key is accounted for in exactly one place (the
- * save gate + this predicate stay in sync). freeze_guard defaults ON and horizon
- * defaults 1, so those count as non-default only when changed away from that. */
-static int reduce_has_non_default(const config_t *cfg)
-{
-   return !cfg->reduce_measure_enabled || !cfg->reduce_delegate_seam || !cfg->reduce_history_fold ||
-          !cfg->reduce_compress ||
-          (cfg->reduce_gateway_seam && cfg->reduce_gateway_seam_explicit) ||
-          !cfg->reduce_freeze_guard_enabled ||
-          (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1) ||
-          cfg->reduce_gateway_mutate || !cfg->reduce_command_filter /* default-ON (P1c) */ ||
-          (cfg->reduce_gateway_session_disable_ttl_ms != 3600000 &&
-           cfg->reduce_gateway_session_disable_ttl_ms > 0);
-}
-
 int config_save(const config_t *cfg)
 {
    ensure_config_dir();
@@ -1100,43 +1084,6 @@ int config_save(const config_t *cfg)
          if (cfg->fold_recall_ttl_turns)
             cJSON_AddNumberToObject(recall, "ttl_turns", cfg->fold_recall_ttl_turns);
       }
-   }
-
-   /* Unified context economizer (only save if non-default). freeze_guard defaults ON
-    * and horizon defaults 1, so they are emitted only when an operator changed them. */
-   if (reduce_has_non_default(cfg))
-   {
-      cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
-      /* measure/delegate_seam/history_fold/compress default ON -> persist only the
-       * non-default OFF state so an operator opt-out round-trips. gateway_seam stays
-       * default-OFF -> persist only when enabled. */
-      if (!cfg->reduce_measure_enabled)
-         cJSON_AddBoolToObject(reduce, "measure", 0);
-      if (!cfg->reduce_delegate_seam)
-         cJSON_AddBoolToObject(reduce, "delegate_seam", 0);
-      if (!cfg->reduce_history_fold)
-         cJSON_AddBoolToObject(reduce, "history_fold", 0);
-      if (!cfg->reduce_compress)
-         cJSON_AddBoolToObject(reduce, "compress", 0);
-      /* gateway_seam: persist ONLY when the operator set it explicitly, never when
-       * config_load synthesized it from gateway_mutate=1 (that stays an in-memory
-       * normalization, re-applied each load). */
-      if (cfg->reduce_gateway_seam && cfg->reduce_gateway_seam_explicit)
-         cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
-      if (!cfg->reduce_freeze_guard_enabled) /* default-on -> persist only when disabled */
-         cJSON_AddBoolToObject(reduce, "freeze_guard", 0);
-      if (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1)
-         cJSON_AddNumberToObject(reduce, "freeze_guard_horizon", cfg->reduce_freeze_guard_horizon);
-      /* gateway_mutate defaults OFF -> persist only when enabled. TTL defaults 1h ->
-       * persist only a non-default positive override (a bad <=0 is never written). */
-      if (cfg->reduce_gateway_mutate)
-         cJSON_AddBoolToObject(reduce, "gateway_mutate", cfg->reduce_gateway_mutate);
-      if (!cfg->reduce_command_filter) /* default-ON (P1c) -> persist only the opt-out */
-         cJSON_AddBoolToObject(reduce, "command_filter", 0);
-      if (cfg->reduce_gateway_session_disable_ttl_ms != 3600000 &&
-          cfg->reduce_gateway_session_disable_ttl_ms > 0)
-         cJSON_AddNumberToObject(reduce, "gateway_session_disable_ttl_ms",
-                                 cfg->reduce_gateway_session_disable_ttl_ms);
    }
 
    /* The economizer tier -- persist as a string only when non-default (default: safe). */

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -764,10 +764,10 @@ void config_parse_modules_section(config_t *cfg, cJSON *root)
    }
 }
 
-/* Unified context economizer (src/context_reduce.c). Orchestration gates for the
- * single reduction subsystem. Only knobs the current code honors are parsed here;
- * each lever / the gateway seam / min_gain is added by the slice that implements
- * it, so an exposed flag is never silently inert. All default-off. */
+/* Unified context economizer (src/modules/economizer/context_reduce.c). Parses the single
+ * `economizer: off|safe|aggressive` tier control (canonical string form, plus a deprecated
+ * {enabled,aggressive} object mapped to the tier). The old per-lever `reduce:` block is no
+ * longer parsed — the tier drives every reducer. */
 void config_parse_reduce_section(config_t *cfg, cJSON *root)
 {
    /* The economizer control — parsed FIRST (before the reduce early-return). The canonical
@@ -787,62 +787,22 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    }
    else if (cJSON_IsObject(econ))
    {
+      /* Deprecated object form {enabled, aggressive} -> tier. Absent sub-keys default to
+       * enabled=ON, aggressive=OFF (i.e. the SAFE tier), matching the historical defaults. */
+      int enabled = 1, aggressive = 0;
       cJSON *e = cJSON_GetObjectItemCaseSensitive(econ, "enabled");
       if (cJSON_IsBool(e))
-         cfg->economizer_enabled = cJSON_IsTrue(e) ? 1 : 0;
+         enabled = cJSON_IsTrue(e) ? 1 : 0;
       e = cJSON_GetObjectItemCaseSensitive(econ, "aggressive");
       if (cJSON_IsBool(e))
-         cfg->economizer_aggressive = cJSON_IsTrue(e) ? 1 : 0;
-      cfg->economizer_tier = !cfg->economizer_enabled     ? ECON_TIER_OFF
-                             : cfg->economizer_aggressive ? ECON_TIER_AGGRESSIVE
-                                                          : ECON_TIER_SAFE;
+         aggressive = cJSON_IsTrue(e) ? 1 : 0;
+      cfg->economizer_tier =
+          !enabled ? ECON_TIER_OFF : aggressive ? ECON_TIER_AGGRESSIVE : ECON_TIER_SAFE;
    }
 
-   cJSON *reduce = cJSON_GetObjectItemCaseSensitive(root, "reduce");
-   if (!cJSON_IsObject(reduce))
-      return;
-   cJSON *item = cJSON_GetObjectItemCaseSensitive(reduce, "measure");
-   if (cJSON_IsBool(item))
-      cfg->reduce_measure_enabled = cJSON_IsTrue(item) ? 1 : 0;
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "delegate_seam");
-   if (cJSON_IsBool(item))
-      cfg->reduce_delegate_seam = cJSON_IsTrue(item) ? 1 : 0;
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "history_fold");
-   if (cJSON_IsBool(item))
-      cfg->reduce_history_fold = cJSON_IsTrue(item) ? 1 : 0;
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "compress");
-   if (cJSON_IsBool(item))
-      cfg->reduce_compress = cJSON_IsTrue(item) ? 1 : 0;
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_seam");
-   if (cJSON_IsBool(item))
-   {
-      cfg->reduce_gateway_seam = cJSON_IsTrue(item) ? 1 : 0;
-      cfg->reduce_gateway_seam_explicit = 1; /* operator set it -> config_save may persist it */
-   }
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_mutate");
-   if (cJSON_IsBool(item))
-      cfg->reduce_gateway_mutate = cJSON_IsTrue(item) ? 1 : 0;
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_session_disable_ttl_ms");
-   if (cJSON_IsNumber(item))
-      /* Use cJSON's pre-narrowed valueint (clamped to INT_MIN..INT_MAX at parse) —
-       * casting an out-of-range valuedouble to int is UB, and a fractional value
-       * truncates. A resulting <=0 (incl. a truncated 0.x) is caught startup-fatal
-       * by config_reduce_validate(). */
-      cfg->reduce_gateway_session_disable_ttl_ms = item->valueint;
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "command_filter");
-   if (cJSON_IsBool(item))
-      cfg->reduce_command_filter = cJSON_IsTrue(item) ? 1 : 0;
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard");
-   if (cJSON_IsBool(item))
-      cfg->reduce_freeze_guard_enabled = cJSON_IsTrue(item) ? 1 : 0;
-   item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard_horizon");
-   if (cJSON_IsNumber(item) && item->valuedouble > 0)
-   {
-      int h = (int)item->valuedouble;
-      if (h > FREEZE_GUARD_MAX_HORIZON)
-         h = FREEZE_GUARD_MAX_HORIZON; /* clamp at parse so on-disk == runtime */
-      cfg->reduce_freeze_guard_horizon = h;
-   }
+   /* The reduce.* per-lever surface was removed: the economizer tier drives every reducer
+    * directly (see the econ_* accessors). A legacy `reduce:` block in aimee.yaml is now
+    * silently ignored for back-compat — no parse error, no behavior. */
 }
 
 /* Clamp an integer to [lo, hi]. */
@@ -890,45 +850,6 @@ void config_parse_autonomy_section(config_t *cfg, cJSON *root)
  * autonomy.* live from the config snapshot via config_autonomy_lookup (thread-safe), so there
  * is no cross-thread setenv. An operator-exported AIMEE_AUTONOMY_* still overrides. */
 
-/* Normalize economizer gateway-mutation invariants IN MEMORY after parse. mutate=1
- * requires the shadow seam so the validation gates always have a same-payload
- * baseline: auto-enable reduce_gateway_seam in memory (never rewriting the file)
- * and WARN. config_load is mtime-cached, so this runs (and warns) once per uncached
- * load; a config left at seam=0,mutate=1 repeats the WARN each fresh start until
- * corrected. Synthesizing the seam also FORCES reduce_gateway_seam_explicit=0 so
- * config_save never persists the synthesized value — even when the file explicitly
- * set gateway_seam:false alongside mutate:true (mutate wins in memory, but the
- * operator's on-disk false is not silently rewritten to true). */
-void config_apply_reduce_consistency(config_t *cfg)
-{
-   if (cfg->reduce_gateway_mutate && !cfg->reduce_gateway_seam)
-   {
-      cfg->reduce_gateway_seam = 1;
-      cfg->reduce_gateway_seam_explicit = 0; /* synthesized -> not persistable */
-      fprintf(stderr,
-              "aimee: config warning: reduce.gateway_mutate=1 requires reduce.gateway_seam; "
-              "auto-enabling the shadow seam in memory (set reduce.gateway_seam: true to "
-              "silence this)\n");
-   }
-}
-
-/* Startup-fatal validation for the live gateway-mutation path (see config.h). The
- * disable-window TTL must be > 0; 0/negative would make a circuit-broken session a
- * permanent pin (or, negative, an immediately-expired no-op breaker) on live client
- * traffic, which the design rejects rather than silently clamps. */
-int config_reduce_validate(const config_t *cfg, char *err, size_t errlen)
-{
-   if (cfg->reduce_gateway_session_disable_ttl_ms <= 0)
-   {
-      if (err && errlen)
-         snprintf(err, errlen,
-                  "reduce.gateway_session_disable_ttl_ms must be > 0 (got %d); 0/negative is a "
-                  "permanent-pin/disabled breaker on the live /v1 path",
-                  cfg->reduce_gateway_session_disable_ttl_ms);
-      return 1;
-   }
-   return 0;
-}
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)
 {

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1072,83 +1072,21 @@ typedef struct config
    int fold_recall_enabled;
    int fold_recall_ttl_turns;
 
-   /* Unified context economizer (src/context_reduce.c). The single reduction
-    * subsystem invoked at every request-assembly seam. All default-off. Knobs are
-    * added here as each slice implements them, so an exposed flag is always
-    * honored. Currently the measurement engine (delegate seam, measure-only):
-    * reduce_measure_enabled: collect baseline/opportunity ledger rows (no
-    *   mutation) — the shadow mode that powers the cost numbers.
-    * reduce_delegate_seam: enable the economizer at the delegate turn loop.
-    * reduce_history_fold: actually fold old history (rolling skeleton + Coordinate
-    *   Closet) at the delegate seam — the first real reduction lever (default-off).
-    * reduce_compress: boundary-free tool-result BODY compression at the delegate
-    *   seam (Slice 4). Shrinks oversized tool-result bodies in place (identifiers
-    *   conserved in the Coordinate Closet) WITHOUT needing a clean-user-turn
-    *   boundary, so it engages on autonomous tool-loops where history_fold can't.
-    *   Provider-native output (valid for all builders incl. chatgpt). Default-off.
-    * reduce_gateway_seam: enable the economizer at the inbound /v1 gateway seam.
-    *   Shadow-mode only in this slice (measure_only is forced on at the gateway, so
-    *   it NEVER mutates the live client request) — collects baselines on live
-    *   ingress traffic with zero behavior change.
-    * reduce_freeze_guard_enabled: freeze cost guardrail (Slice 5). Pin the fold
-    *   boundary (cache-warm reduced prefix) only when the estimated cache-read
-    *   savings over reduce_freeze_guard_horizon reuses cover the one-time cache-write
-    *   churn; otherwise re-derive without pinning. Default-ON, but only acts when the
-    *   (default-off) economizer freeze is live, so no default-path behavior change.
-    * reduce_freeze_guard_horizon: expected reuse turns for the break-even estimate
-    *   (0 -> 1; clamped to FREEZE_GUARD_MAX_HORIZON).
-    * reduce_gateway_mutate: APPLY the reduction to the live inbound /v1 request (the
-    *   primary-agent path) instead of only measuring it — compress-only, behind a
-    *   per-session circuit breaker (msg_session_disable), buffered 4xx-restore-resend +
-    *   streaming disable-subsequent-turns. Default-OFF (the whole gateway-mutation
-    *   feature). mutate=1 implies gateway_seam=1: config_load auto-enables the shadow
-    *   seam IN MEMORY (never rewriting the file) + logs one WARN, so the shadow baseline
-    *   the validation gates compare against always exists.
-    * reduce_gateway_session_disable_ttl_ms: how long a circuit-broken session stays
-    *   disabled (default 3600000 = 1h). MUST be > 0 — 0/negative is a startup-fatal
-    *   config error (a permanent-pin/breaker-off knob on a live path is disproportionate
-    *   runtime risk); validated by config_reduce_validate() at server startup.
-    * (Other per-lever gates and min_gain land in later slices.) */
-   int reduce_measure_enabled;
-   int reduce_delegate_seam;
-   int reduce_history_fold;
-   int reduce_compress;
-   int reduce_gateway_seam;
-   int reduce_freeze_guard_enabled;
-   int reduce_freeze_guard_horizon;
-   int reduce_gateway_mutate;
-   int reduce_gateway_session_disable_ttl_ms;
-   /* reduce_command_filter: deterministic command-aware tool-output condensation lever.
-    * DEFAULT-ON (unified-economizer P1c): a safe-tier lever — lossless-on-demand (full
-    * output spilled), fail-open, and no-over-reduction (failures/diagnostics + their detail
-    * block kept in the condensed view). When on, tool_bash captures up to TOOL_CONDENSE_
-    * CEILING (2 MB) so the full output reaches the lever, replacing the old lossy 32 KB
-    * read-cap truncation. Set reduce.command_filter=false to opt out. */
-   int reduce_command_filter;
-   /* Runtime-only (NOT parsed as a key, NOT persisted): 1 iff the operator set the
-    * reduce.gateway_seam key explicitly. Lets config_save persist gateway_seam only
-    * when the user chose it, never when config_load synthesized it from mutate=1. */
-   int reduce_gateway_seam_explicit;
-
-   /* Unified-economizer TWO-TIER switches (P3). These GATE the individual reduce.* levers
-    * without mutating them (resolved by the econ_* accessors, never surprising config_save):
-    *   economizer.enabled   — MASTER for all reduction ACTIONS. DEFAULT-ON. false = one
-    *                          off-switch: every reducer is forced off, but measure/telemetry
-    *                          keeps running (reports zero — proving the kill works). The safe
-    *                          tier (delegate-seam: command_filter/history_fold/compress) is on
-    *                          under it by their own defaults.
-    *   economizer.aggressive — opt-in ceiling for the AGGRESSIVE tier (live PRIMARY /v1
-    *                          mutation: gateway_mutate). DEFAULT-OFF. gateway_mutate requires
-    *                          enabled && aggressive && reduce.gateway_mutate (all three) — the
-    *                          aggressive flag alone never activates a live-traffic mutator. */
-   int economizer_enabled;
-   int economizer_aggressive;
-   /* The SINGLE economizer control (supersedes economizer_enabled/aggressive + the
-    * reduce.* levers, which are being removed). One of ECON_TIER_*. Selects a
-    * provider-aware strategy: OFF = verbatim passthrough; SAFE = Anthropic prompt
-    * caching + deterministic freeze-on-first-send tool condensation, OpenAI
-    * recall-restorable reduction; AGGRESSIVE = + lossy fold/compress (OpenAI live
-    * mutation). See docs/features/economizer.md. Default ECON_TIER_SAFE. */
+   /* Unified context economizer (src/modules/economizer/context_reduce.c). A single
+    * provider-aware reduction subsystem invoked at every request-assembly seam, driven
+    * entirely by economizer_tier below. The old per-lever reduce.* booleans
+    * (measure/delegate_seam/history_fold/compress/gateway_seam/gateway_mutate/
+    * command_filter/freeze_guard[_horizon]/gateway_session_disable_ttl_ms) and the
+    * economizer_enabled/aggressive two-tier switches were removed — the tier now decides
+    * each behavior at the reducer call sites via the econ_* accessors (config.c).
+    *
+    * economizer_tier: the SINGLE economizer control. One of ECON_TIER_*. Provider-aware:
+    *   OFF        = verbatim passthrough (no caching, no reduction);
+    *   SAFE       = Anthropic prompt caching + deterministic freeze-on-first-send tool
+    *                condensation; OpenAI recall-restorable reduction (lossless);
+    *   AGGRESSIVE = + lossy fold/compress and live OpenAI /v1 gateway mutation.
+    * Default ECON_TIER_SAFE. modules.economizer:false is an authoritative hard-kill over
+    * the tier (resolved in econ_tier()). See docs/features/economizer.md. */
    int economizer_tier;
 
    /* Pluggable-module enablement (`modules:` block). The canonical, user-facing surface for
@@ -1172,9 +1110,9 @@ typedef struct config
    int module_governance;
    int module_delegates;
    int module_workflows;
-   /* economizer's env-default analog is the legacy economizer.enabled bool (not an AIMEE_*
-    * env), so its resolver call is config_module_enabled(module_economizer, economizer_enabled)
-    * inside econ_reduction_master_on(). */
+   /* modules.economizer is an authoritative hard-kill over economizer_tier: when set to 0 it
+    * forces econ_tier() to OFF regardless of the tier value (resolved in econ_tier()). -1
+    * (unspecified) leaves the tier in effect. */
    int module_economizer;
 
    /* Autonomous-development pipeline knobs (Phase-C). These were env-var-only
@@ -2124,15 +2062,6 @@ int econ_gateway_mutate_on(const config_t *cfg); /* tier == aggressive (OpenAI-o
  *   3. deprecated env default (`env_default`, already the module's env-or-default-ON value).
  * `config_tristate` is one of cfg->module_* (-1 = unspecified). Pure: reads its args only. */
 int config_module_enabled(int config_tristate, int env_default);
-
-/* Validate the economizer gateway-mutation invariants that are STARTUP-FATAL (as
- * opposed to the in-memory normalizations config_load already applied). Currently:
- * reduce_gateway_session_disable_ttl_ms must be > 0. Returns 0 if valid, non-zero
- * if the live gateway-mutation path must not start; on failure writes a human
- * message into err (when err != NULL). Called at server startup so a bad value
- * refuses to bring up the live /v1 path, without breaking unrelated CLI callers
- * of config_load. Pure (reads cfg only). */
-int config_reduce_validate(const config_t *cfg, char *err, size_t errlen);
 
 /* Resolve the effective operating mode (engineer/novel) for the running
  * process. Precedence: the AIMEE_MODE environment variable (the propagation

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -24,7 +24,6 @@ void config_parse_fold_section(config_t *cfg, cJSON *root);
 void config_parse_modules_section(config_t *cfg, cJSON *root);
 void config_parse_reduce_section(config_t *cfg, cJSON *root);
 void config_parse_autonomy_section(config_t *cfg, cJSON *root);
-void config_apply_reduce_consistency(config_t *cfg);
 void config_parse_memory_section(config_t *cfg, cJSON *root);
 void config_parse_cross_verify_section(config_t *cfg, cJSON *root);
 void config_parse_retry_section(config_t *cfg, cJSON *root);

--- a/src/modules/economizer/context_reduce.h
+++ b/src/modules/economizer/context_reduce.h
@@ -97,6 +97,14 @@ extern "C"
  * cannot justify an unbounded cache-write bet on a single run. */
 #define FREEZE_GUARD_MAX_HORIZON 5
 
+/* Fixed freeze-guard horizon (reuse turns for the break-even estimate). Formerly the
+ * reduce.freeze_guard_horizon knob (default 1); the tier model bakes it as a constant. */
+#define ECON_FREEZE_GUARD_HORIZON 1
+
+/* How long a circuit-broken /v1 session stays disabled by the aggressive-tier gateway
+ * mutator (1h). Formerly reduce.gateway_session_disable_ttl_ms; now a fixed constant. */
+#define ECON_GATEWAY_SESSION_DISABLE_TTL_MS 3600000
+
    /* Per-CONVERSATION reducer state, owned by the caller and persisted across
     * turns within one conversation (e.g. a stack local spanning the turn loop).
     * NOT shared across agents/sessions (cross-session sharing would leak context).

--- a/src/modules/economizer/gateway_mutate_wire.c
+++ b/src/modules/economizer/gateway_mutate_wire.c
@@ -7,6 +7,7 @@
 
 #include "agent_protocol.h" /* message_history_repair */
 #include "config.h"
+#include "context_reduce.h" /* ECON_GATEWAY_SESSION_DISABLE_TTL_MS */
 #include "gateway_mutate.h"
 #include "gw_mutate_stats.h"
 
@@ -80,9 +81,9 @@ void gw_buffered_mutate(cJSON *container, const char *key, const char *model,
    if (config_load(&cfg) != 0)
       return;
    if (!econ_gateway_mutate_on(&cfg))
-      return; /* dark by default; needs enabled && aggressive && gateway_mutate (P3) */
+      return; /* dark unless the economizer tier is aggressive */
    ctx->mutate_on = 1;
-   ctx->ttl_ms = cfg.reduce_gateway_session_disable_ttl_ms;
+   ctx->ttl_ms = ECON_GATEWAY_SESSION_DISABLE_TTL_MS;
 
    /* Resolve a per-identity session key; an identity-less request is a pristine
     * passthrough with NO disable state written (§2.4). */

--- a/src/modules/economizer/gateway_mutate_wire.h
+++ b/src/modules/economizer/gateway_mutate_wire.h
@@ -2,7 +2,7 @@
  * gateway mutation (proposal §2.5, buffered). Sits above the pure decision helpers
  * (gateway_mutate.h): resolves the per-session key from the thread-local request
  * identity, honors the per-session circuit breaker, snapshots + reduces + replaces
- * the messages array under the default-OFF reduce_gateway_mutate flag, and after the
+ * the messages array under the aggressive economizer tier, and after the
  * upstream status handles the 4xx-restore-resend / 5xx-disable contract. Shared by
  * the Anthropic (/v1/messages) and OpenAI (/v1/responses) buffered paths. Provider-
  * agnostic: it operates on a cJSON `container` and the message-array `key` within
@@ -35,9 +35,9 @@ extern "C"
    void gw_mutate_ctx_init(gw_mutate_ctx_t *ctx);
    void gw_mutate_ctx_free(gw_mutate_ctx_t *ctx);
 
-   /* Cheap (mtime-cached config_load) check of reduce_gateway_mutate, so a caller can
-    * skip the system-prompt flattening + the mutate attempt entirely on the default-
-    * OFF hot path. gw_buffered_mutate re-checks internally (defense in depth). */
+   /* Cheap (mtime-cached config_load) check of econ_gateway_mutate_on (tier==aggressive),
+    * so a caller can skip the system-prompt flattening + the mutate attempt entirely on the
+    * default hot path. gw_buffered_mutate re-checks internally (defense in depth). */
    int gw_mutate_is_enabled(void);
 
    /* Provider-gated enable: gateway wire-mutation is OpenAI-only. Returns true only when
@@ -47,7 +47,7 @@ extern "C"
     * caller's driver_is_anthropic()/parity signal. */
    int gw_mutate_upstream_ok(int upstream_is_anthropic);
 
-   /* Pre-send: under reduce_gateway_mutate, resolve the session key from the thread-
+   /* Pre-send: under the aggressive economizer tier, resolve the session key from the thread-
     * local request identity; if the session is not disabled, snapshot container[key],
     * run the compress-only economizer, and — when gw_should_apply passes — replace
     * container[key] with the reduced array (marking provenance) so the provider body

--- a/src/modules/economizer/tool_condense.c
+++ b/src/modules/economizer/tool_condense.c
@@ -51,9 +51,10 @@ void tool_condense_stats_reset(void)
 
 int tool_condense_enabled(const config_t *cfg)
 {
-   /* safe-tier lever, gated by the P3 master switch: master off = one kill. Resolve the master
-    * through econ_reduction_master_on so the modules.economizer toggle is honored here too. */
-   return econ_reduction_master_on(cfg) && cfg->reduce_command_filter ? 1 : 0;
+   /* Deterministic command-aware condensation is a SAFE-tier behavior: on whenever the
+    * economizer tier is not off (resolved through econ_reduction_master_on so the
+    * modules.economizer hard-kill is honored here too). */
+   return econ_reduction_master_on(cfg) ? 1 : 0;
 }
 
 /* ---- command recognition (Slice 2) ---- */

--- a/src/modules/economizer/tool_condense.h
+++ b/src/modules/economizer/tool_condense.h
@@ -16,7 +16,7 @@
  * being truncated at the old 32 KB read cap, and it bounds fail-open blast radius. */
 #define TOOL_CONDENSE_CEILING (2 * 1024 * 1024)
 
-/* 1 iff the command-filter lever is enabled (reduce_command_filter). */
+/* 1 iff deterministic command-aware condensation is active (economizer tier != off). */
 int tool_condense_enabled(const config_t *cfg);
 
 /* ---- command recognition (Slice 2) ---- */

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -784,8 +784,7 @@ native_provider_http:
       int reduce_active = 0; /* 1 once a real reduction replaced the message array */
       {
          config_t ecfg;
-         if (config_load(&ecfg) == 0 && ecfg.reduce_delegate_seam &&
-             (ecfg.reduce_measure_enabled || ecfg.reduce_history_fold || ecfg.reduce_compress))
+         if (config_load(&ecfg) == 0)
          {
             reduce_config_t rcfg;
             memset(&rcfg, 0, sizeof(rcfg));
@@ -796,20 +795,20 @@ native_provider_http:
              * top-level typed items, so feeding it folded turns is unverified.
              * Keep the Responses path measure-only here; fold it in a later slice
              * once verified live. */
-            /* P3 master-kill: economizer.enabled=false forces the MUTATING levers off but
-             * leaves the block reachable, so measure_only shadow accounting keeps running
-             * (reports zero reductions — proof the kill works, per the two-tier contract). */
+            /* Tier OFF (or modules.economizer:false) forces the MUTATING levers off but leaves
+             * the block reachable, so measure_only shadow accounting keeps running (reports zero
+             * reductions — proof the kill works). */
             int econ_master = econ_reduction_master_on(&ecfg); /* tier != off */
             int aggressive = econ_tier(&ecfg) == ECON_TIER_AGGRESSIVE;
             /* history_fold is the SAFE-tier lever: recall-restorable (non-destructive) and
              * freeze-guarded, so it is cache-favorable even on Anthropic (frozen on first
              * send). Runs on safe+aggressive. (!chatgpt: the Responses builder can't take
              * folded turns yet — a separate constraint, not a tier decision.) */
-            rcfg.history_fold = econ_master && ecfg.reduce_history_fold && !chatgpt;
+            rcfg.history_fold = econ_master && !chatgpt;
             /* Compress LOSSILY shrinks tool-result bodies in place -> the AGGRESSIVE tier
              * only. Shape (role/type, ids, typed items) is preserved, so it is valid for
              * all builders including chatgpt/Responses. */
-            rcfg.compress = aggressive && ecfg.reduce_compress;
+            rcfg.compress = aggressive;
             rcfg.measure_only =
                 !(rcfg.history_fold || rcfg.compress); /* a lever on -> mutate; else shadow */
             /* Tier model: fold is ALWAYS freeze-guarded (cache-favorability gated). This is
@@ -817,8 +816,7 @@ native_provider_http:
              * first send and only re-folded when the savings beat the cache-write cost over
              * the horizon, so a cache miss never costs more than it saves. Not togglable. */
             rcfg.freeze_guard_enabled = 1;
-            rcfg.freeze_guard_horizon =
-                ecfg.reduce_freeze_guard_horizon > 0 ? ecfg.reduce_freeze_guard_horizon : 1;
+            rcfg.freeze_guard_horizon = ECON_FREEZE_GUARD_HORIZON;
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
             rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
             rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -928,7 +928,8 @@ char *tool_bash(const char *command, int timeout_ms)
       }
       return safe_strdup("{\"stdout\":\"\",\"stderr\":\"fork failed\",\"exit_code\":-1}");
    }
-   /* command-aware condensation (P1b): when reduce_command_filter is on, `rawcap` (the
+   /* command-aware condensation (P1b): when tool_condense is active (economizer tier != off),
+    * `rawcap` (the
     * MAXIMUM we'll capture) rises to the 2 MB ceiling so tool_condense sees the FULL output
     * (the old 32 KB read cap truncated the input before the lever could condense + spill it).
     * Default-off keeps the 32 KB cap — byte-identical. Per-call config load, reused for both
@@ -1088,7 +1089,7 @@ char *tool_bash(const char *command, int timeout_ms)
    out_buf[out_len] = '\0';
    err_buf[err_len] = '\0';
 
-   /* Command-aware condensation (reduce_command_filter, default off): for a RECOGNIZED
+   /* Command-aware condensation (safe-tier, active when economizer tier != off): for a RECOGNIZED
     * command, deterministically condense the output (test failures kept, passes elided)
     * and spill the full raw so the delegate can read it back. Fail-open: any miss/decline
     * returns NULL and we fall through to the size-based agent_compress_tool_result. */

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -310,7 +310,7 @@ static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *dr
     * (config-load, array, free) and context_reduce hard-bypasses on any internal
     * error, so this can never perturb the client response. Reuses the loaded pcfg;
     * cheap mtime-cached load keeps it dark by default. */
-   if (cfg_ok && pcfg.reduce_gateway_seam)
+   if (cfg_ok && econ_gateway_mutate_on(&pcfg))
    {
       char *sys_text = anthropic_system_to_text(req); /* flatten string|array system */
       const cJSON *cmodel = cJSON_GetObjectItemCaseSensitive(req, "model");
@@ -511,7 +511,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
     * req["messages"] in place (compress-only) BEFORE translate/build so the provider
     * body is assembled from the reduced array; on a bad reduction the upstream 4xx is
     * caught below (restore-resend), the session is circuit-broken, and provenance is
-    * cleared. A dark no-op when reduce_gateway_mutate is off. */
+    * cleared. A dark no-op unless the economizer tier is aggressive. */
    if (gw_mutate_upstream_ok(parity))
    {
       char *mut_sys = anthropic_system_to_text(req);

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -928,7 +928,7 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
     * Cheap mtime-cached config load keeps it dark by default. */
    {
       config_t ecfg;
-      if (config_load(&ecfg) == 0 && ecfg.reduce_gateway_seam)
+      if (config_load(&ecfg) == 0 && econ_gateway_mutate_on(&ecfg))
       {
          reduce_result_t gw_res;
          if (gw_economizer_measure(messages, system_prompt, agent->model, ecfg.fold_retained_msgs,

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -186,30 +186,6 @@ static int run_server(const char *socket_path, log_level_t log_level)
     * operator-exported AIMEE_AUTONOMY_* still overrides), so a config.set applies without a
     * restart and without an unsafe cross-thread setenv. */
 
-   /* Startup-fatal validation for the live gateway-mutation path: an invalid
-    * session-disable TTL (<=0) must refuse to bring up the /v1 server rather than
-    * pin/disable the breaker on live client traffic. Scoped to server startup so
-    * unrelated CLI callers of config_load are unaffected. */
-   {
-      char cfg_err[256];
-      if (config_reduce_validate(&cfg, cfg_err, sizeof(cfg_err)) != 0)
-      {
-         fprintf(stderr, "aimee: fatal config error: %s\n", cfg_err);
-         return 1;
-      }
-   }
-
-   /* P3: surface suppressed intent — an explicit lever the two-tier switches override, so an
-    * operator is never silently ignored (per the two-tier design's startup-WARN ruling). */
-   if (!econ_reduction_master_on(&cfg) &&
-       (cfg.reduce_history_fold || cfg.reduce_compress || cfg.reduce_command_filter))
-      aimee_log(LOG_WARN, "economizer",
-                "economizer.enabled=false MASTER-KILL: all reduction is off (measure still "
-                "runs); individual reduce.* levers are suppressed");
-   if (cfg.reduce_gateway_mutate && !econ_gateway_mutate_on(&cfg))
-      aimee_log(LOG_WARN, "economizer",
-                "reduce.gateway_mutate=true is SUPPRESSED: the live-primary mutator needs "
-                "economizer.enabled && economizer.aggressive (both) to activate");
 
    /* Remote aimee-kb: when a kb_client_url is configured (this host uses a
     * remote kb rather than a local sidecar), export it into our own env so the

--- a/src/tests/support/ir_ingress_stubs.c
+++ b/src/tests/support/ir_ingress_stubs.c
@@ -242,7 +242,7 @@ __attribute__((weak)) int gw_response_governance_enabled(void)
 }
 
 /* Context-economizer gateway-seam symbols. messages_run_request_pipeline calls these inside a
- * block gated by cfg.reduce_gateway_seam (0 under the tests' stubbed config, so NEVER entered
+ * block gated by econ_gateway_mutate_on (false under the tests' stubbed config, so NEVER entered
  * at runtime). LTO used to dead-code-eliminate the block, but that decision is fragile (any new
  * read of the loaded cfg in that function can retain it, and it differs across gcc versions), so
  * resolve the symbols with inert weak stubs. Real context_reduce.o / agent_exec.o win when a
@@ -268,7 +268,7 @@ __attribute__((weak)) void context_reduce_result_free(reduce_result_t *out)
    (void)out;
 }
 /* Shadow gateway-measure wrapper: anthropic_http.c / openai_chat.c call this inside the
- * cfg.reduce_gateway_seam block (0 under the tests' stubbed config, so NEVER entered at
+ * econ_gateway_mutate_on block (false under the tests' stubbed config, so NEVER entered at
  * runtime); the inert weak stub only resolves the link. Mirrors the real no-op contract:
  * zero `out` so the caller's context_reduce_result_free is safe, return 1 ("did nothing").
  * Real gateway_mutate_wire.o wins when a test links it. */
@@ -283,6 +283,15 @@ __attribute__((weak)) int gw_economizer_measure(cJSON *messages, const char *sys
    if (out)
       memset(out, 0, sizeof(*out));
    return 1;
+}
+/* The gateway-seam gate itself: messages_run_request_pipeline / anthropic_http.c now gate the
+ * shadow-measure + mutation block on econ_gateway_mutate_on (was a plain cfg field read). Inert
+ * weak stub returns 0 (dark), so the block is never entered under a stubbed config. Real
+ * config.o wins when a test links it. */
+__attribute__((weak)) int econ_gateway_mutate_on(const config_t *cfg)
+{
+   (void)cfg;
+   return 0;
 }
 __attribute__((weak)) void agent_record_reduce_ledger(const struct reduce_result_s *r,
                                                       const char *model, const char *agent_name,

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -361,11 +361,6 @@ int main(void)
                "--background-index");
       cfg.lsp_servers[0].extension_count = 1;
       snprintf(cfg.lsp_servers[0].extensions[0], sizeof(cfg.lsp_servers[0].extensions[0]), "c");
-      /* economizer freeze guardrail: default-on bool + default-1 horizon. Flip the
-       * bool OFF and the horizon to a non-default so both must round-trip (regression
-       * class: a default-on save-guard that emits only the non-default state). */
-      cfg.reduce_freeze_guard_enabled = 0;
-      cfg.reduce_freeze_guard_horizon = 3;
       /* require_aimee_git (default ON) + delegate_sandbox (default OFF): both are
        * enforcement dials, so a value that does not survive save+reload is a guard
        * silently in the wrong state after every restart. */
@@ -397,8 +392,6 @@ int main(void)
       assert(cfg2.server_api_rate_limit_per_min == 60);
       assert(cfg2.server_api_max_event_streams == 512);
       assert(strcmp(cfg2.server_api_client_transport, "http") == 0);
-      assert(cfg2.reduce_freeze_guard_enabled == 0); /* default-on bool persisted off */
-      assert(cfg2.reduce_freeze_guard_horizon == 3); /* non-default horizon persisted */
       /* regression: remote_writes used to be parsed but never written by config_save,
        * so any save silently reset it to off. */
       assert(cfg2.server_api_remote_writes == SERVER_REMOTE_WRITES_FULL);

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -1,6 +1,7 @@
 /* test_config_economizer.c: defaults + save/load round-trip for the context
- * economizer (reduce.*) and Coordinate Closet config. Kept separate from
- * test_config.c, which is at the build-integrity line-count limit. */
+ * economizer (the `economizer` tier control) and the Coordinate Closet config.
+ * The old per-lever reduce.* surface was removed — the tier drives every reducer.
+ * Kept separate from test_config.c, which is at the build-integrity line limit. */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,33 +13,23 @@
 #include "platform_path.h"
 #include "platform_test_util.h"
 
-/* Effective safe-tier lever (command_filter): master && individual. Mirrors
- * tool_condense_enabled without pulling the CORE object into this test's link set. */
-static int cf_effective(const config_t *c)
-{
-   return econ_reduction_master_on(c) && c->reduce_command_filter;
-}
-
-/* P3 two-tier resolution: master-kill, aggressive ceiling, and BACK-COMPAT (default
- * switches must reproduce pre-P3 effective values). Pure — no file I/O. */
-static void test_two_tier_resolution(void)
+/* Tier resolution: OFF/SAFE/AGGRESSIVE map to the econ_* accessors, modules.economizer:false
+ * is an authoritative hard-kill, and the string parser/name round-trips. Pure — no file I/O. */
+static void test_tier_resolution(void)
 {
    config_t c;
    memset(&c, 0, sizeof c);
    c.module_economizer = -1; /* unspecified -> tier is authoritative */
-   c.reduce_command_filter = 1;
 
    /* OFF tier: no economization at all. */
    c.economizer_tier = ECON_TIER_OFF;
    assert(econ_tier(&c) == ECON_TIER_OFF);
    assert(econ_reduction_master_on(&c) == 0);
-   assert(cf_effective(&c) == 0); /* command_filter suppressed with reduction off */
    assert(econ_gateway_mutate_on(&c) == 0);
 
    /* SAFE tier: reduction on, but no live gateway mutation. */
    c.economizer_tier = ECON_TIER_SAFE;
    assert(econ_reduction_master_on(&c) == 1);
-   assert(cf_effective(&c) == 1);
    assert(econ_gateway_mutate_on(&c) == 0); /* live mutation is aggressive-only */
 
    /* AGGRESSIVE tier: reduction on + live mutation (OpenAI-only enforced at the call site). */
@@ -67,8 +58,8 @@ static void test_two_tier_resolution(void)
 /* live-config-reload P2: reload-class classification + verdict. */
 static void test_reload_class(void)
 {
-   const config_field_t *hot = config_field_lookup("economizer.aggressive");
-   const config_field_t *rst = config_field_lookup("db2_url"); /* startup: pg pool */
+   const config_field_t *hot = config_field_lookup("autonomous"); /* live via snapshot: HOT */
+   const config_field_t *rst = config_field_lookup("db2_url");    /* startup: pg pool */
    const config_field_t *aut =
        config_field_lookup("autonomy.skeptics"); /* live via snapshot: HOT */
    assert(hot && hot->reload_class == RELOAD_HOT);
@@ -81,7 +72,7 @@ static void test_reload_class(void)
 int main(void)
 {
    printf("config_economizer: ");
-   test_two_tier_resolution();
+   test_tier_resolution();
    test_reload_class();
 
    char tmpdir[512];
@@ -94,61 +85,23 @@ int main(void)
    platform_unsetenv("AIMEE_HOME");
    platform_setenv("AIMEE_NO_CACHE", "1");
 
-   /* --- defaults: economizer DEFAULT-ON on the delegate seam, gateway OFF --- */
+   /* --- defaults: SAFE tier + Coordinate Closet on --- */
    {
       static config_t cfg;
       memset(&cfg, 0, sizeof(cfg));
       config_load(&cfg); /* missing file -> defaults */
-      assert(cfg.reduce_measure_enabled == 1);
-      assert(cfg.reduce_delegate_seam == 1);
-      assert(cfg.reduce_history_fold == 1);
-      assert(cfg.reduce_compress == 1);
+      assert(cfg.economizer_tier == ECON_TIER_SAFE);
       assert(cfg.coord_closet_enabled == 1);
-      assert(cfg.reduce_gateway_seam == 0); /* primary path off pending mutation build */
-      assert(cfg.reduce_freeze_guard_enabled == 1);
-      assert(cfg.reduce_freeze_guard_horizon == 1);
+      assert(cfg.module_economizer == -1); /* unspecified -> tier authoritative */
    }
 
-   /* --- bulk opt-out: every default-ON lever + closet flipped OFF must round-trip
-    * (config_save persists only the non-default OFF state) --- */
+   /* --- Coordinate Closet round-trip: off-state + tuned (budget/ratio/denylist) must
+    * persist byte-equal. The closet is a separate config family from the economizer tier;
+    * it survives the reduce.* removal untouched. --- */
    {
       static config_t cfg;
       memset(&cfg, 0, sizeof(cfg));
       config_load(&cfg);
-      cfg.reduce_measure_enabled = 0;
-      cfg.reduce_delegate_seam = 0;
-      cfg.reduce_history_fold = 0;
-      cfg.reduce_compress = 0;
-      cfg.coord_closet_enabled = 0;
-      cfg.reduce_freeze_guard_enabled = 0;
-      cfg.reduce_freeze_guard_horizon = 3;
-      assert(config_save(&cfg) == 0);
-
-      static config_t cfg2;
-      memset(&cfg2, 0, sizeof(cfg2));
-      config_load(&cfg2);
-      assert(cfg2.reduce_measure_enabled == 0);
-      assert(cfg2.reduce_delegate_seam == 0);
-      assert(cfg2.reduce_history_fold == 0);
-      assert(cfg2.reduce_compress == 0);
-      assert(cfg2.coord_closet_enabled == 0);
-      assert(cfg2.reduce_freeze_guard_enabled == 0);
-      assert(cfg2.reduce_freeze_guard_horizon == 3);
-   }
-
-   /* --- partial opt-out + closet tuning: one lever OFF with siblings at default ON,
-    * closet ON but tuned (budget/ratio/denylist) must round-trip byte-equal --- */
-   {
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      config_load(&cfg);
-      /* pin siblings ON deterministically (config_load reads the prior block's file) */
-      cfg.reduce_measure_enabled = 1;
-      cfg.reduce_delegate_seam = 1;
-      cfg.reduce_history_fold = 0; /* the single opt-out */
-      cfg.reduce_compress = 1;
-      cfg.reduce_freeze_guard_enabled = 1;
-      cfg.reduce_freeze_guard_horizon = 1;
       cfg.coord_closet_enabled = 1;
       cfg.coord_closet_budget_bytes = 4096;
       cfg.coord_closet_max_ratio_pct = 15;
@@ -158,115 +111,10 @@ int main(void)
       static config_t cfg2;
       memset(&cfg2, 0, sizeof(cfg2));
       config_load(&cfg2);
-      assert(cfg2.reduce_history_fold == 0);    /* the single opt-out survived */
-      assert(cfg2.reduce_measure_enabled == 1); /* siblings stayed on */
-      assert(cfg2.reduce_delegate_seam == 1);
-      assert(cfg2.reduce_compress == 1);
-      assert(cfg2.coord_closet_enabled == 1); /* closet on while tuned */
+      assert(cfg2.coord_closet_enabled == 1);
       assert(cfg2.coord_closet_budget_bytes == 4096);
       assert(cfg2.coord_closet_max_ratio_pct == 15);
       assert(strcmp(cfg2.coord_closet_denylist, "secretword") == 0);
-   }
-
-   /* --- gateway mutation: defaults --- */
-   {
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      config_load(&cfg);
-      assert(cfg.reduce_gateway_mutate == 0);
-      assert(cfg.reduce_gateway_session_disable_ttl_ms == 3600000);
-      assert(cfg.reduce_gateway_seam_explicit == 0);
-   }
-
-   /* --- mutate=1 auto-enables the shadow seam IN MEMORY + does NOT persist the
-    * synthesized gateway_seam: save {mutate:1} (no seam), reload, and confirm seam
-    * was re-synthesized (==1) while seam_explicit stayed 0 (proving the key was not
-    * written to disk — a persisted key would set explicit on parse). --- */
-   {
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      config_load(&cfg);
-      cfg.reduce_gateway_mutate = 1;
-      cfg.reduce_gateway_seam = 0;
-      cfg.reduce_gateway_seam_explicit = 0;
-      assert(config_save(&cfg) == 0);
-
-      static config_t cfg2;
-      memset(&cfg2, 0, sizeof(cfg2));
-      config_load(&cfg2);
-      assert(cfg2.reduce_gateway_mutate == 1);        /* mutate persisted */
-      assert(cfg2.reduce_gateway_seam == 1);          /* auto-enabled in memory */
-      assert(cfg2.reduce_gateway_seam_explicit == 0); /* synthesized, NOT persisted */
-   }
-
-   /* --- an explicitly-set gateway_seam DOES persist (and carries explicit=1) --- */
-   {
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      config_load(&cfg);
-      cfg.reduce_gateway_mutate = 0;
-      cfg.reduce_gateway_seam = 1;
-      cfg.reduce_gateway_seam_explicit = 1;
-      assert(config_save(&cfg) == 0);
-
-      static config_t cfg2;
-      memset(&cfg2, 0, sizeof(cfg2));
-      config_load(&cfg2);
-      assert(cfg2.reduce_gateway_seam == 1);
-      assert(cfg2.reduce_gateway_seam_explicit == 1);
-   }
-
-   /* --- non-default disable TTL round-trips; default (1h) is not persisted --- */
-   {
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      config_load(&cfg);
-      cfg.reduce_gateway_session_disable_ttl_ms = 7200000; /* 2h override */
-      assert(config_save(&cfg) == 0);
-      static config_t cfg2;
-      memset(&cfg2, 0, sizeof(cfg2));
-      config_load(&cfg2);
-      assert(cfg2.reduce_gateway_session_disable_ttl_ms == 7200000);
-   }
-
-   /* --- consistency hook is a pure in-memory normalization --- */
-   {
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      cfg.reduce_gateway_mutate = 1;
-      cfg.reduce_gateway_seam = 0;
-      cfg.reduce_gateway_seam_explicit = 0;
-      config_apply_reduce_consistency(&cfg);
-      assert(cfg.reduce_gateway_seam == 1);
-      assert(cfg.reduce_gateway_seam_explicit == 0);
-      /* idempotent + no downgrade when mutate is off */
-      memset(&cfg, 0, sizeof(cfg));
-      cfg.reduce_gateway_mutate = 0;
-      cfg.reduce_gateway_seam = 0;
-      config_apply_reduce_consistency(&cfg);
-      assert(cfg.reduce_gateway_seam == 0);
-      /* seam:false + mutate:true — synthesis must CLEAR explicit so config_save
-       * never rewrites the operator's on-disk false to true. */
-      memset(&cfg, 0, sizeof(cfg));
-      cfg.reduce_gateway_mutate = 1;
-      cfg.reduce_gateway_seam = 0;
-      cfg.reduce_gateway_seam_explicit = 1; /* operator wrote gateway_seam: false */
-      config_apply_reduce_consistency(&cfg);
-      assert(cfg.reduce_gateway_seam == 1);          /* mutate wins in memory */
-      assert(cfg.reduce_gateway_seam_explicit == 0); /* but not persistable */
-   }
-
-   /* --- startup-fatal TTL validation: <=0 rejected, >0 accepted --- */
-   {
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      char err[256];
-      cfg.reduce_gateway_session_disable_ttl_ms = 3600000;
-      assert(config_reduce_validate(&cfg, err, sizeof(err)) == 0);
-      cfg.reduce_gateway_session_disable_ttl_ms = 0;
-      assert(config_reduce_validate(&cfg, err, sizeof(err)) != 0);
-      cfg.reduce_gateway_session_disable_ttl_ms = -5;
-      assert(config_reduce_validate(&cfg, err, sizeof(err)) != 0);
    }
 
    /* --- economizer tier: default + save/load round-trip (string form) --- */
@@ -290,6 +138,31 @@ int main(void)
       memset(&cfg2, 0, sizeof(cfg2));
       config_load(&cfg2);
       assert(cfg2.economizer_tier == ECON_TIER_OFF);
+   }
+
+   /* --- deprecated object form {enabled,aggressive} maps onto the tier (back-compat).
+    * Asserted directly on the pure parser — config_save always writes the canonical string
+    * form, so this is the only path that still exercises the object mapping. --- */
+   {
+      config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      cfg.economizer_tier = ECON_TIER_SAFE;
+      cJSON *root = cJSON_CreateObject();
+      cJSON *e = cJSON_AddObjectToObject(root, "economizer");
+      cJSON_AddBoolToObject(e, "enabled", 1);
+      cJSON_AddBoolToObject(e, "aggressive", 1);
+      config_parse_reduce_section(&cfg, root);
+      assert(cfg.economizer_tier == ECON_TIER_AGGRESSIVE); /* enabled+aggressive -> AGGRESSIVE */
+      cJSON_Delete(root);
+
+      memset(&cfg, 0, sizeof(cfg));
+      root = cJSON_CreateObject();
+      e = cJSON_AddObjectToObject(root, "economizer");
+      cJSON_AddBoolToObject(e, "enabled", 0);
+      cJSON_AddBoolToObject(e, "aggressive", 1);
+      config_parse_reduce_section(&cfg, root);
+      assert(cfg.economizer_tier == ECON_TIER_OFF); /* enabled:false -> OFF regardless */
+      cJSON_Delete(root);
    }
 
    /* --- modules.* tristate: defaults are -1 (unspecified) and are NOT persisted; an explicit

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -31,7 +31,6 @@ static void write_marker(int aggressive, int budget)
    config_load(&c);
    /* keep the config VALID regardless of what a prior (deliberately-invalid) test left on
     * disk, so config_reload's validate-or-keep never rejects a marker write. */
-   c.reduce_gateway_session_disable_ttl_ms = 3600000;
    c.economizer_tier = aggressive ? ECON_TIER_AGGRESSIVE : ECON_TIER_OFF;
    c.coord_closet_budget_bytes = budget;
    assert(config_save(&c) == 0);
@@ -104,15 +103,19 @@ int main(void)
    /* reloading the same file again is a no-op */
    assert(config_reload() == 0);
 
-   /* --- validate-or-keep: an INVALID file -> reload -1, snapshot unchanged --- */
+   /* --- validate-or-keep: an INVALID file -> reload -1, snapshot unchanged. In strict mode a
+    * schema type error (int key given a string) is fatal, so config_load_file returns -1 and
+    * config_reload keeps the last good snapshot. --- */
    {
+      extern int g_config_strict;
       const char *path = config_default_path();
       FILE *fp = fopen(path, "w");
       assert(fp);
-      /* ttl <= 0 is startup-fatal per config_reduce_validate */
-      fputs("reduce:\n  gateway_session_disable_ttl_ms: 0\n", fp);
+      fputs("db2_pool_size: \"not-a-number\"\n", fp); /* SCHEMA_INT given a string */
       fclose(fp);
+      g_config_strict = 1;
       assert(config_reload() == -1); /* kept */
+      g_config_strict = 0;
       config_t got;
       assert(config_snapshot_get(&got) == 0);
       assert(got.coord_closet_budget_bytes == 2222); /* still the last GOOD snapshot */
@@ -163,7 +166,6 @@ int main(void)
       static config_t sc;
       memset(&sc, 0, sizeof sc);
       config_load(&sc); /* snapshot base */
-      sc.reduce_gateway_session_disable_ttl_ms = 3600000;
       sc.autonomy_skeptics = 9;
       assert(config_save(&sc) == 0);
       assert(config_reload() == 1);

--- a/src/tests/test_gateway_mutate_wire.c
+++ b/src/tests/test_gateway_mutate_wire.c
@@ -131,7 +131,7 @@ static void test_dark_default_and_identityless(void)
    cJSON *c = container_with("orig");
    gw_mutate_ctx_t ctx;
 
-   /* default config -> reduce_gateway_mutate off -> dark no-op */
+   /* default config -> economizer tier not aggressive -> dark no-op */
    gw_buffered_mutate(c, "messages", "some-model", NULL, NULL, NULL, NULL, &ctx);
    assert(ctx.mutated == 0);
    assert(ctx.mutate_on == 0); /* flag off */
@@ -233,7 +233,7 @@ static void test_token_delta_sampling(void)
 
 static void test_no_behavior_change_when_off(void)
 {
-   /* With reduce_gateway_mutate off (default config in this test's HOME), the buffered
+   /* With economizer tier not aggressive (default config in this test's HOME), the buffered
     * mutate short-circuits at the flag gate BEFORE inspecting the payload, so the
     * container is a byte-identical no-op for ANY input regardless of size/shape. */
    cJSON *c = container_with("payload");
@@ -290,7 +290,7 @@ static void test_stat_json(void)
 int main(void)
 {
    printf("gateway_mutate_wire: ");
-   /* Deterministic defaults for config_load (no aimee.yaml -> reduce_gateway_mutate off). */
+   /* Deterministic defaults for config_load (no aimee.yaml -> economizer tier not aggressive). */
    char tmpdir[512];
    snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-test-gwwire-XXXXXX", platform_tmpdir());
    if (platform_mkdtemp(tmpdir))

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -27,10 +27,8 @@ int main(void)
       memset(&cfg, 0, sizeof cfg);
       cfg.module_economizer = -1;               /* unspecified -> tier decides */
       assert(tool_condense_enabled(&cfg) == 0); /* tier OFF (memset) -> off */
-      cfg.reduce_command_filter = 1;
-      assert(tool_condense_enabled(&cfg) == 0); /* still tier OFF */
       cfg.economizer_tier = ECON_TIER_SAFE;
-      assert(tool_condense_enabled(&cfg) == 1); /* tier on + lever on */
+      assert(tool_condense_enabled(&cfg) == 1); /* safe tier -> condensation on */
       cfg.economizer_tier = ECON_TIER_OFF;      /* off tier kills the lever */
       assert(tool_condense_enabled(&cfg) == 0);
       assert(tool_condense_enabled(NULL) == 0);
@@ -272,7 +270,6 @@ int main(void)
       /* disabled -> passthrough */
       assert(tool_condense_apply(&cfg, "pytest -q", 0, big, "/tmp", NULL) == NULL);
 
-      cfg.reduce_command_filter = 1;
       cfg.economizer_tier = ECON_TIER_SAFE; /* master on */
       /* unrecognized command -> passthrough */
       assert(tool_condense_apply(&cfg, "frobnicate", 0, big, "/tmp", NULL) == NULL);
@@ -352,7 +349,6 @@ int main(void)
       memset(&cfg, 0, sizeof cfg);
       cfg.module_economizer =
           -1; /* config_load default: unspecified -> legacy economizer.enabled */
-      cfg.reduce_command_filter = 1;
       cfg.economizer_tier = ECON_TIER_SAFE; /* master on */
       char big[8192];
       size_t off = 0;
@@ -381,7 +377,6 @@ int main(void)
       memset(&cfg, 0, sizeof cfg);
       cfg.module_economizer =
           -1; /* config_load default: unspecified -> legacy economizer.enabled */
-      cfg.reduce_command_filter = 1;
       cfg.economizer_tier = ECON_TIER_SAFE; /* master on */
       char big[8192];
       size_t off = 0;


### PR DESCRIPTION
Follow-up to #1516. That PR introduced the single `economizer = off|safe|aggressive` tier and made it authoritative, but layered it **on top of** the old per-lever booleans instead of removing them. This deletes that vestigial surface so the tier is the only economizer control — the cleanup #1516 explicitly deferred.

## What's removed
13 `config_t` fields (struct + parse + save + `config_fields[]` + defaults): `economizer_enabled`, `economizer_aggressive`, `reduce_measure_enabled`, `reduce_delegate_seam`, `reduce_history_fold`, `reduce_compress`, `reduce_gateway_mutate`, `reduce_command_filter`, `reduce_freeze_guard_enabled`, `reduce_freeze_guard_horizon`, `reduce_gateway_seam` (+`_explicit`), `reduce_gateway_session_disable_ttl_ms`.

Plus the now-dead helpers `config_apply_reduce_consistency` (gateway-seam synthesis) and `config_reduce_validate` (TTL guard), their callers/decls, the `reduce:` save block, and the two startup WARN blocks.

## Behavior-preserving derivation
Every removed lever defaulted **ON**, so each call site collapses to the tier condition:
- delegate seam always runs (measure at minimum); `history_fold = tier!=off && !chatgpt`; `compress = tier==aggressive` (`agent_runtime.c`)
- `tool_condense = tier!=off` (`tool_condense.c`)
- gateway shadow-measure + live mutation = `tier==aggressive` via `econ_gateway_mutate_on` (`openai_chat.c`, `anthropic_http.c`, `gateway_mutate_wire.c`)
- freeze-guard horizon (1) and gateway session-disable TTL (1h) are now fixed constants in `context_reduce.h`

Default tier is `safe`, so default runtime behavior is byte-identical to before.

## Back-compat
- The deprecated `economizer: {enabled, aggressive}` object form still parses and maps onto the tier.
- A legacy `reduce:` block is silently ignored (still schema-known → no error).
- Fixed the `economizer` schema entry to `SCHEMA_STRING` (was `SCHEMA_OBJECT` — #1516 left it, so the now-canonical string form warned on every load).

## Not in scope
The tier isn't yet in the flat `config_fields[]` table — it's an enum surfaced as a string, which that scalar get/set machinery doesn't model. Set it via the `economizer:` YAML key. `TODO(A)` marks exposing it in the typed/GUI surface once the table grows enum-as-string support. (The separate `fold.*` / `compact.*` / `coord_closet.*` tuning knobs are untouched — a distinct later follow-up.)

## Test
`test_config_economizer` rewritten to the tier model; `test_tool_condense`, `test_config`, `test_config_snapshot`, `test_gateway_mutate_wire`, and `ir_ingress_stubs` adjusted (added a weak `econ_gateway_mutate_on` stub for tests that link the ingress path without `config.o`). Full `make unit-tests` green, including `unit-test-ir-crossproto-egress` (the egress byte-identity / determinism gate). Net **−405 lines**.
