### PR TITLE
config: drop the dead ecomode toggle (unbuilt cheapest-agent routing)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -439,7 +439,6 @@ corresponding `config_*.c` module.
 | `rewind` | object | Conversation rewind settings. |
 | `search` | object | Search behavior. |
 | `compact` | object | Context compaction (`compact.enabled`). |
-| `ecomode` | bool | Reduced-resource mode. |
 | `lsp_servers` | array | Language servers to launch for diagnostics. |
 | `mcp` / `mcp_clients` | object/array | MCP server transport and downstream MCP clients. |
 | `client_integrations_enabled` | bool | Auto-register aimee's MCP server + hooks into external AI-tool configs (Claude Code, Gemini, Copilot, Codex) on each run (default `true`; set `false` to opt out). See [§25](#25-integrations). |
@@ -1505,8 +1504,8 @@ depend on session history.
 
 Thread pools and concurrency are tunable in `aimee.yaml`
 (`compute_threads`, `worker_threads`, `background_threads`, `concurrency.
-per_model.<model>`). `ecomode: true` reduces resource use. Service-unit memory
-limits cap the server and KB independently.
+per_model.<model>`). Service-unit memory limits cap the server and KB
+independently.
 
 ### 27.5 Scaling and multi-user deployment
 

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (183)
+## CLI-settable keys (182)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -64,7 +64,6 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `dogfood_enabled` | bool | Capture sessions as dogfood training/eval data. |
 | `dogfood_inline_tagging` | bool | Inline-tag dogfood events during the session. |
 | `dogfood_log_dir` | string | Directory for dogfood logs. |
-| `ecomode` | bool | Reduce background compute (eco mode). |
 | `economizer` | string (off\|safe\|aggressive) | Context economizer tier: `off` (verbatim passthrough), `safe` (default; Anthropic prompt caching + lossless, freeze-guarded reduction), or `aggressive` (adds lossy compression + live OpenAI-side mutation; Anthropic context is never mutated). See docs/features/economizer.md. |
 | `embedding_command` | string | Command that produces embeddings (overrides the endpoint). |
 | `embedding_dim` | int | Embedding vector dimension. |

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -48,7 +48,7 @@ function category(key: string): string {
     [/^(ingress|gateway|tool_output|code_span|context|fold|compact)/, "Gateway & context"],
     [/^(audit|governance|decision|guardrail)/, "Audit & governance"],
     [/^(provider|openai|anthropic|model|delegate|agent|roundtable|default_persona|persona)/, "Providers & delegates"],
-    [/^(autonomous|cross_verify|ecomode|max_iterations|reasoning|verify|autopilot|trigger)/, "Agent behavior"],
+    [/^(autonomous|cross_verify|max_iterations|reasoning|verify|autopilot|trigger)/, "Agent behavior"],
     [/^(learning|intelligence|calibrat|bandit)/, "Learning & intelligence"],
     [/^(kb_curator|curator|synth|embed|rerank|extract|index)/, "Knowledge curation"],
   ];

--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -109,7 +109,6 @@ export const FIELD_HELP: Record<string, string> = {
   llm_synth_endpoint: "Endpoint URL for an external synthesizer.",
   llm_synth_model: "Model name the synthesizer serves.",
 
-  ecomode: "Always route to the cheapest capable agent instead of the default one. Off by default.",
   delegate_graph_context_enabled:
     "Prepend the callers and dependencies of the files a delegate task mentions to its prompt. Advisory, off by default.",
 

--- a/src/config.c
+++ b/src/config.c
@@ -381,7 +381,6 @@ static const config_schema_entry_t config_schema[] = {
      0}, /* off|safe|aggressive (deprecated object form still parses) */
     {"sessions", SCHEMA_OBJECT, 0},
     {"sandbox", SCHEMA_OBJECT, 0},
-    {"ecomode", SCHEMA_BOOL, 0},
     {"prompt_tier", SCHEMA_STRING, 0},
     {"prompt_file", SCHEMA_STRING, 0},
     {"delegate_prompt_tier", SCHEMA_STRING, 0},
@@ -1655,10 +1654,6 @@ int config_load_file(config_t *cfg)
    if (cJSON_IsString(item) && item->valuestring[0])
       snprintf(cfg->delegate_prompt_tier, sizeof(cfg->delegate_prompt_tier), "%s",
                item->valuestring);
-
-   item = cJSON_GetObjectItemCaseSensitive(root, "ecomode");
-   if (cJSON_IsBool(item))
-      cfg->ecomode = cJSON_IsTrue(item) ? 1 : 0;
 
    /* LSP server configuration */
    config_parse_lsp_servers_section(cfg, root);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -162,7 +162,6 @@ const config_field_t config_fields[] = {
      CFG_FLOAT},
     {"autonomous", offsetof(config_t, autonomous), sizeof(int), 1, CFG_BOOL},
     {"cross_verify", offsetof(config_t, cross_verify), sizeof(int), 1, CFG_BOOL},
-    {"ecomode", offsetof(config_t, ecomode), sizeof(int), 1, CFG_BOOL},
     {"max_iterations", offsetof(config_t, max_iterations), sizeof(int), 0, CFG_INT},
     {"max_iterations_delegate", offsetof(config_t, max_iterations_delegate), sizeof(int), 0,
      CFG_INT},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1145,10 +1145,6 @@ int config_save(const config_t *cfg)
    if (cfg->delegate_prompt_tier[0])
       cJSON_AddStringToObject(root, "delegate_prompt_tier", cfg->delegate_prompt_tier);
 
-   /* Ecomode (only save when explicitly enabled) */
-   if (cfg->ecomode)
-      cJSON_AddBoolToObject(root, "ecomode", 1);
-
    /* Rewind settings (only save non-default values) */
    if (cfg->rewind_auto_snapshot)
    {

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1144,12 +1144,6 @@ typedef struct config
    char prompt_file[MAX_PATH_LEN];
    char delegate_prompt_tier[16];
 
-   /* Ecomode: prefer lowest-cost agents for all tasks when enabled.
-    * 0 = off (default), 1 = on.
-    * In ecomode, routing skips the default agent and always picks
-    * the cheapest enabled agent capable of the requested role. */
-   int ecomode;
-
    /* Background process management.
     * max_background_processes: concurrent process limit (0 = use PROC_MAX_CONCURRENT = 5). */
    int max_background_processes;

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -72,7 +72,7 @@ static const char *FIXTURE_A =
     "inline_tagging: true\nidentity:\n  working_profile_injection:\n    enabled: true\ncompact:\n  "
     "enabled: true\n  threshold: 1\n  head_bytes: 1\n  tail_bytes: 1\nsessions:\n  "
     "stale_threshold_secs: 1\n  max_sessions: 1\n  max_worktrees: 1\nprompt_tier: "
-    "ZZA_val\nprompt_file: ZZA_val\necomode: true\nmcp:\n  osv:\n    enabled: true\n    offline: "
+    "ZZA_val\nprompt_file: ZZA_val\nmcp:\n  osv:\n    enabled: true\n    offline: "
     "true\n    enforce: true\n    endpoint: ZZA_val\nrewind:\n  auto_snapshot: true\notel:\n  "
     "endpoint: ZZA_val\n  service_name: ZZA_val\nintegrity:\n  enabled: true\n  dry_run: "
     "true\nsession:\n  virtual_context:\n    enabled: true\n    assembly_budget: 1\ntransport:\n  "
@@ -132,7 +132,7 @@ static const char *FIXTURE_B =
     " working_profile_injection:\n    enabled: false\ncompact:\n  enabled: false\n  threshold: "
     "4096\n  head_bytes: 4096\n  tail_bytes: 4096\nsessions:\n  stale_threshold_secs: 4096\n  "
     "max_sessions: 4096\n  max_worktrees: 4096\nprompt_tier: ZZB_val\nprompt_file: "
-    "ZZB_val\necomode: false\nmcp:\n  osv:\n    enabled: false\n    offline: false\n    enforce: "
+    "ZZB_val\nmcp:\n  osv:\n    enabled: false\n    offline: false\n    enforce: "
     "false\n    endpoint: ZZB_val\nrewind:\n  auto_snapshot: false\notel:\n  endpoint: ZZB_val\n  "
     "service_name: ZZB_val\nintegrity:\n  enabled: false\n  dry_run: false\nsession:\n  "
     "virtual_context:\n    enabled: false\n    assembly_budget: 4096\ntransport:\n  "
@@ -288,7 +288,6 @@ int main(void)
    assert(cfgA.max_worktrees != cfgB.max_worktrees);
    assert(strcmp(cfgA.prompt_tier, cfgB.prompt_tier) != 0);
    assert(strcmp(cfgA.prompt_file, cfgB.prompt_file) != 0);
-   assert(cfgA.ecomode == 1 && cfgB.ecomode == 0);
    assert(cfgA.mcp_osv_enabled == 1 && cfgB.mcp_osv_enabled == 0);
    assert(cfgA.mcp_osv_offline == 1 && cfgB.mcp_osv_offline == 0);
    assert(cfgA.mcp_osv_enforce == 1 && cfgB.mcp_osv_enforce == 0);

--- a/webchat/settings.go
+++ b/webchat/settings.go
@@ -25,8 +25,6 @@ var settingsAllow = []settingField{
 		Help: "Agent acts without per-action confirmation."},
 	{Key: "cross_verify", Label: "Cross-verify", Type: "bool",
 		Help: "Double-check work before reporting done."},
-	{Key: "ecomode", Label: "Eco mode", Type: "bool",
-		Help: "Favor cheaper / shorter reasoning."},
 	{Key: "reasoning_cap_enabled", Label: "Cap reasoning by complexity", Type: "bool",
 		Help: "Lower reasoning effort on simple turns."},
 	{Key: "max_iterations", Label: "Max iterations", Type: "int",


### PR DESCRIPTION
Part of the config-option cleanup. Removes `ecomode` end-to-end.

## Why it's dead
`ecomode` was a config bool + gear-dropdown toggle for a "route to the cheapest capable agent" feature that **was never implemented** — no routing code (or any code) reads `cfg->ecomode`. It is unrelated to the operating-mode personas in `config_mode.c` and to the economizer (context reduction). The docs even described it two contradictory ways ("cheapest agent" vs "reduced-resource mode"), confirming it never became real.

## Removed end-to-end
- **C**: `config_t` field + parse + save + schema entry + `config_fields[]` row.
- **Frontend/Go**: the "Eco mode" entry in the webchat gear dropdown (`webchat/settings.go`), the `Settings.tsx` category regex, the `settingsHelp.ts` help text.
- **Docs**: `MANUAL.md` references; regenerated `docs/gen/configuration.md` via `make docs-gen`.
- **Tests**: `test_config_surface` fixtures + assertion.

Full `make unit-tests` green; C and `go build ./...` clean.

## Explicitly NOT dropped: `llm_*_host/gpu`
The earlier plan lumped `ecomode` with the `llm_*_host/gpu` wizard fields as "dead in C but frontend-wired." On inspection they are **not** the same: `DeployTopology.tsx` actively uses `llm_*_host`/`gpu` to seed the host selector and preserve GPU placements (*"otherwise every local role silently resolves to CPU, so a Save would downgrade saved GPU placements"*). That's **unfinished host/GPU-aware deploy scaffolding** the wizard already implements — deleting it would destroy in-progress functionality. The real choice there is "wire the C deploy to honor host/gpu" vs "leave pending", not "delete", so it's left untouched.
