### PR TITLE
config: default-on four low-risk ingress/cost flags

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -755,10 +755,10 @@ static void config_set_defaults(config_t *cfg)
    cfg->cost_reward_lambda_pct = 30;
    cfg->cost_reward_ref_usd_milli = 500;
    cfg->reasoning_cap_enabled = 0;
-   cfg->dedup_enabled = 0;
-   cfg->cache_shaping_enabled = 0;
-   cfg->ingress_usage_accounting_enabled = 0;
-   cfg->ingress_audit_async = 0;
+   cfg->dedup_enabled = 1;         /* default-ON: only acts on caller Idempotency-Key requests */
+   cfg->cache_shaping_enabled = 1; /* default-ON: cost win, marks aimee's own Anthropic prefix */
+   cfg->ingress_usage_accounting_enabled = 1; /* default-ON: begin ingress cost accounting */
+   cfg->ingress_audit_async = 1; /* default-ON: keep the cost-row write off the response path */
    cfg->ingress_trusted_proxy_secret[0] = '\0';
    cfg->dedup_window_seconds = 5;
    cfg->cache_min_chars = 0;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -476,19 +476,20 @@ int config_save(const config_t *cfg)
       cJSON *rcap = cJSON_AddObjectToObject(root, "reasoning_cap");
       cJSON_AddBoolToObject(rcap, "enabled", cfg->reasoning_cap_enabled ? 1 : 0);
    }
-   if (cfg->dedup_enabled || cfg->dedup_window_seconds != 5)
+   if (!cfg->dedup_enabled || cfg->dedup_window_seconds != 5) /* default-on: persist the opt-out */
    {
       cJSON *ddp = cJSON_AddObjectToObject(root, "dedup");
       cJSON_AddBoolToObject(ddp, "enabled", cfg->dedup_enabled ? 1 : 0);
       cJSON_AddNumberToObject(ddp, "window_seconds", cfg->dedup_window_seconds);
    }
-   if (cfg->cache_shaping_enabled || cfg->cache_min_chars != 0)
+   if (!cfg->cache_shaping_enabled || cfg->cache_min_chars != 0) /* default-on: persist opt-out */
    {
       cJSON *csh = cJSON_AddObjectToObject(root, "cache_shaping");
       cJSON_AddBoolToObject(csh, "enabled", cfg->cache_shaping_enabled ? 1 : 0);
       cJSON_AddNumberToObject(csh, "min_chars", cfg->cache_min_chars);
    }
-   if (cfg->ingress_usage_accounting_enabled || cfg->ingress_audit_async ||
+   /* usage_accounting + audit_async are default-on: persist only an opt-out of either. */
+   if (!cfg->ingress_usage_accounting_enabled || !cfg->ingress_audit_async ||
        cfg->ingress_trusted_proxy_secret[0])
    {
       cJSON *ing = cJSON_AddObjectToObject(root, "ingress");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1276,7 +1276,7 @@ typedef struct config
    int reasoning_cap_enabled;
 
    /* Short-window response dedup for buffered ingress (response_dedup.*; §4).
-    * dedup_enabled: 0 = off (default), 1 = on. When on, a re-sent identical
+    * dedup_enabled: 1 = on (default), 0 = off. When on, a re-sent identical
     * buffered, non-streaming, tool-free completion carrying an explicit
     * Idempotency-Key is served from a small TTL cache instead of paying for the
     * provider call again; the avoided call is recorded as usage_kind=avoided
@@ -1285,7 +1285,7 @@ typedef struct config
    int dedup_enabled;
 
    /* Cache-aware request shaping for the aimee-owned Anthropic path (§3).
-    * cache_shaping_enabled: 0 = off (default), 1 = on. When on, the tool-bearing
+    * cache_shaping_enabled: 1 = on (default), 0 = off. When on, the tool-bearing
     * Anthropic request builder marks the aimee-owned system prefix cacheable
     * (cache_control: ephemeral content block), matching the no-tools path, so the
     * provider caches the stable system prompt across calls. Anthropic-only; never
@@ -1293,11 +1293,12 @@ typedef struct config
    int cache_shaping_enabled;
 
    /* Ingress cost-accounting rollout knobs (ingress.*; §2/§4/#3).
-    * ingress_usage_accounting_enabled: 0 = off (default), 1 = on. Master gate for
+    * ingress_usage_accounting_enabled: 1 = on (default), 0 = off. Master gate for
     *   writing ingress cost rows (OpenAI/Codex + Anthropic /v1/messages + /v1/runs).
-    *   Off by default per the flag-rollout program; flip to begin accounting.
-    * ingress_audit_async: 0 = write the cost row inline (default), 1 = hand it to
-    *   a background writer so the response is not blocked on the DB insert.
+    *   Default-on so accounting runs out of the box; set false to opt out.
+    * ingress_audit_async: 1 = hand the cost row to a background writer so the response
+    *   is not blocked on the DB insert (default); 0 = write inline. Pairs with
+    *   usage_accounting so the default-on accounting write stays off the response path.
     * ingress_trusted_proxy_secret: shared secret that authorises a front proxy to
     *   stamp X-Aimee-Principal / X-Aimee-Source on a request. EMPTY (default) means
     *   NO client-supplied principal/source is ever trusted — the server derives the

--- a/src/tests/test_agent_request_build.c
+++ b/src/tests/test_agent_request_build.c
@@ -65,13 +65,17 @@ int main(void)
    /* Anthropic Messages wire: system + user as typed text blocks, max_tokens, then
     * temperature (from model_sampling). This is the HARD byte-identity surface. The
     * system block carries the uniform aimee cache_control policy (mark_cache_prefix):
-    * the canonical Anthropic egress caches the stable system prefix on every source. */
+    * the canonical Anthropic egress caches the stable system prefix on every source.
+    * With cache_shaping_enabled default-ON, the builder re-splits + re-marks the system
+    * at the <aimee-context> boundary (agent_request_build.c), which re-adds `system`
+    * after `messages` — a deterministic, byte-stable layout; key order is not
+    * semantically significant to Anthropic and the cache_control content is unchanged. */
    golden("anthropic", "claude-3-5-sonnet",
           "{\"model\":\"claude-3-5-sonnet\",\"max_tokens\":100,"
-          "\"system\":[{\"type\":\"text\",\"text\":\"You are helpful.\","
-          "\"cache_control\":{\"type\":\"ephemeral\"}}],"
           "\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\","
-          "\"text\":\"deploy the release\"}]}],\"temperature\":0.7}");
+          "\"text\":\"deploy the release\"}]}],"
+          "\"system\":[{\"type\":\"text\",\"text\":\"You are helpful.\","
+          "\"cache_control\":{\"type\":\"ephemeral\"}}],\"temperature\":0.7}");
 
    /* OpenAI Chat Completions wire. */
    golden("openai", "gpt-4o-mini",

--- a/src/tests/test_token_audit.c
+++ b/src/tests/test_token_audit.c
@@ -302,6 +302,9 @@ static void test_record_token_audit_ingress_source(void)
    r.completion_tokens = 1000;
    r.success = 1;
    agent_record_token_audit(&r, "", "openai-ingress");
+   /* ingress_audit_async defaults ON, so the row is enqueued to the background writer;
+    * drain it before reading back (the server drains the same queue at shutdown). */
+   agent_audit_async_flush();
 
    /* requested model recorded separately from served; stop_reason captured;
     * usage_kind defaults to "realized". */
@@ -338,6 +341,7 @@ static void test_ingress_source_override(void)
    r.completion_tokens = 50;
    agent_record_token_audit(&r, "execute", "agent"); /* caller passes "agent" */
    agent_set_ingress_source("");                     /* clear for later tests */
+   agent_audit_async_flush(); /* drain the async ingress row before read-back */
 
    assert(count_where("tool_name", "runbot") == 1);
    sqlite3_stmt *st = NULL;
@@ -590,6 +594,7 @@ static void test_trusted_source_overrides_ingress(void)
    agent_record_token_audit(&internal, "", "agent"); /* internal -> stays agent */
 
    request_context_clear();
+   agent_audit_async_flush(); /* drain the async ingress row before read-back */
 
    /* The ingress row took the trusted source; the agent row did not. */
    sqlite3_stmt *st = NULL;
@@ -625,6 +630,7 @@ static void test_ingress_session_attribution(void)
    r.prompt_tokens = 10;
    agent_record_token_audit(&r, "", "openai-ingress");
    request_context_clear();
+   agent_audit_async_flush(); /* drain the async ingress row before read-back */
 
    sqlite3_stmt *st = NULL;
    assert(sqlite3_prepare_v2(db1_conn(),


### PR DESCRIPTION
From the default-on review (Part C). Flips four deliberately-conservative default-off flags to ON. All are low blast-radius; each consumer was verified behavior-safe and the full `make unit-tests` suite passes.

| Flag | What flipping buys | Why it's safe on |
|---|---|---|
| `cache_shaping_enabled` | Marks aimee's own Anthropic system prefix cacheable → cache-read savings | Anthropic-only; never touches the stateless proxy or other providers |
| `dedup_enabled` | Idempotency-key TTL dedup for buffered ingress | Only acts on a **caller-supplied** `Idempotency-Key` (non-streaming, tool-free); strictly per-principal |
| `ingress_usage_accounting_enabled` | Begins ingress cost accounting | Designed to be flipped; adds a per-turn DB write (kept off the response path by audit_async) — measurement, not correctness |
| `ingress_audit_async` | Cost-row write handed to a background writer | Fail-safe: inline fallback if the ring is full; shutdown drains the queue. Pairs with the accounting flip |

`config_save` now persists the **opt-out** for each (writes the key only when disabled), mirroring the `wfe_live_forge` default-on pattern.

## The "test them" payoff — two real catches
The full suite caught two consequences of the flip, both fixed:
1. **`test_agent_request_build` anthropic golden**: with `cache_shaping` on, the builder re-splits + re-marks the system at the `<aimee-context>` boundary, re-adding `system` after `messages`. Deterministic + byte-stable; `cache_control` content unchanged; key order isn't semantically significant to Anthropic. Golden updated; `ir-crossproto-egress` still passes.
2. **`test_token_audit`**: with `audit_async` default-on, ingress rows are enqueued to the background writer, so immediate read-backs raced the queue. Added `agent_audit_async_flush()` after each ingress record (the same drain the server runs at shutdown).

## NOT flipped
`reasoning_cap_enabled` — the one genuine behavior change (lowers reasoning effort on turns classified "simple"). It needs a quality A/B, not a default flip.
