### PR TITLE
eval: validation corpus + recipes for the bucket-3 default-off flags

### DIFF
--- a/benchmarks/bucket3-defaults/VALIDATION.md
+++ b/benchmarks/bucket3-defaults/VALIDATION.md
@@ -1,0 +1,129 @@
+# Bucket-3 default-flag validation recipes
+
+These are the experimental feature flags that the default-on review put in **Bucket 3
+("keep OFF: needs a validation corpus first")**. Each one changes retrieval / learning /
+advisory behavior, and the codebase docs mark them Tier C/S "needs harness / corpus". This
+file records, per flag, the concrete recipe to earn a default-on decision: **which harness,
+the A/B method, the metric, the pass bar, and the data status**.
+
+The method is always the same shape — an **A/B**: run the flag OFF (baseline) and ON against a
+labeled corpus, and require ON to beat OFF on the target metric *without regressing a control
+set*. A flag is only a default-on candidate once its A/B is green and repeatable.
+
+Data status legend: **✅ built** (corpus in this repo) · **🟡 partial** (some fixtures /
+harness exist) · **⬜ needed** (must be authored).
+
+---
+
+## memory_negation_enabled  — ✅ built
+
+- **What it gates:** extracts `not_<token>` negation tokens from memory content + queries
+  (`memory_core_helpers_b.c`, `memory_core_search_c.c`) so negative facts ("X is not Y") are
+  retrievable.
+- **Corpus:** [`tests/eval/memory_negation_corpus.json`](../../tests/eval/memory_negation_corpus.json)
+  — 19 fixtures / 20 cases. Every negated fact is paired with a positive distractor stating the
+  opposite (`n001` "redis WITHOUT persistence" ⇔ `n101` "redis persists via AOF"), plus positive
+  controls. This is what makes the metric discriminating: a negation-blind retriever scores both
+  members of a pair highly on a negation query.
+- **A/B:** load the corpus through the memory-retrieval eval (`mem_eval_load_corpus`,
+  `server/agent_eval_memory_support.c`) with `memory_negation_enabled` false then true.
+- **Metric:** recall@5 on the `neg*` + `dis*` cases (negation + discrimination). **Control:**
+  recall@5 on the `pos*` cases must not drop.
+- **Pass bar:** ON raises negation/discrimination recall by ≥ 10 points absolute with **zero**
+  regression on the positive controls.
+- **Why separate from the golden:** the gated `memory_retrieval_corpus.json` has a baked
+  `n_cases`/baseline with a 5% regression gate; adding hard negation cases there would break it.
+  This corpus is standalone and run explicitly for the A/B.
+
+## memory_abstain_enabled  — ⬜ needed (harness extension)
+
+- **What it gates:** a confidence/abstention gate that returns *nothing* when no memory is
+  relevant, instead of surfacing a weak top-k.
+- **Corpus needed:** answerable queries (expected = a real fid) **and** unanswerable queries
+  (expected = `[]`, nothing in the corpus should match). The existing ndcg/recall harness has no
+  abstention metric — it needs a small extension.
+- **A/B / metric:** OFF vs ON; **abstention precision** = of the unanswerable queries, fraction
+  correctly returning empty; **answerable recall** must not drop (no over-abstention).
+- **Pass bar:** abstention precision ≥ 0.9 on unanswerable queries with < 2% answerable-recall
+  loss. Reuse the negation corpus's fixtures as the "haystack" and add ~15 out-of-corpus queries.
+
+## memory_scenes_enabled  — ⬜ needed (session-structured corpus)
+
+- **What it gates:** clusters conversation turns into scenes and boosts within-scene retrieval.
+- **Corpus needed:** multi-turn **session** transcripts with labeled scene boundaries (the flat
+  `{fixtures,cases}` shape can't express this — needs a session/turn corpus). ~6–10 sessions,
+  each 15–40 turns spanning 2–4 topic scenes, with per-query the expected in-scene turns.
+- **A/B / metric:** scene boost OFF vs ON; **precision@5 of in-scene results** for a query issued
+  mid-scene; **control:** cross-scene recall must not collapse.
+- **Pass bar:** in-scene precision up ≥ 8 points with no cross-scene recall regression.
+
+## memory_fetch_budget_enabled  — 🟡 partial (mem_eval + cost)
+
+- **What it gates:** dynamic sizing of how many candidates to fetch before rerank.
+- **Corpus:** reuse the golden `memory_retrieval_corpus.json` (no new labels needed) but capture
+  **cost** (candidates fetched / tokens) alongside recall.
+- **A/B / metric:** budget OFF (fixed k) vs ON; plot **recall@10 vs mean candidates fetched**.
+- **Pass bar:** ON holds recall within 1% while cutting mean fetch by ≥ 20% (a cost win), OR
+  raises recall at equal fetch. This is a cost/quality A/B, not a pass/fail correctness gate.
+
+## code_trust_actuation_enabled  — 🟡 partial (code-vector-graph bench)
+
+- **What it gates:** applies earned per-file "trust" as an RRF tie-break in code hybrid fusion.
+- **Corpus:** extend `benchmarks/code-vector-graph` with code-search queries whose relevant files
+  have accumulated trust signals (prior successful edits) vs cold files.
+- **A/B / metric:** OFF vs ON; **MRR / ndcg@5** on code-search queries where trust should break
+  ties toward the proven file. **Control:** queries with no trust signal must be unchanged.
+- **Pass bar:** ndcg@5 up on the trust-relevant subset, flat on the control subset.
+
+## learning_implicit_repeat_question / _repeated_correction / _workflow_repetition / _retrieval_outcome  — 🟡 partial
+
+- **What they gate:** implicit-learning detectors that emit proposals from live turn patterns.
+  These are **stateful and not replayable** without a live router, per `config.h` / the Tier-C
+  notes — the hardest to corpus.
+- **Existing harness:** `tools/learning_eval.py`, `src/tests/learning_implicit_replay.c`, and
+  `src/tests/test_retrieval_outcome_bridge.c` already replay some detector fixtures.
+- **Corpus needed:** labeled multi-turn traces per detector — e.g. for `_repeat_question`, a
+  session where the user re-asks a question and the detector should fire exactly once; negative
+  traces (paraphrase that is *not* a repeat) as controls.
+- **A/B / metric:** replay traces with the detector OFF vs ON; **precision** (fired only on true
+  positives) and **recall** (fired on all true positives). Because these feed the live proposal
+  router, the bar is precision-first.
+- **Pass bar:** ≥ 0.9 precision on the labeled traces with no false-fire on the negative controls,
+  per detector, before any is considered for default-on.
+
+## guardrails_blast_radius_advisory_enabled  — 🟡 partial (deterministic)
+
+- **What it gates:** surfaces the code-graph structural blast radius (dependent files) before an
+  edit; advisory and fail-open.
+- **Corpus:** deterministic — a fixture repo + a set of `(edited file → expected dependent-file
+  set)` pairs. Extend `benchmarks/graph` / the code-audit graph fixtures.
+- **A/B / metric:** it either lists the true dependent set or not; **precision/recall of the
+  advised dependent files** vs the graph ground truth. No LLM in the loop, so this is a clean
+  deterministic gate.
+- **Pass bar:** recall = 1.0 (never miss a real dependent) with precision ≥ 0.8 (few spurious
+  files) on the fixture set.
+
+## delegate_graph_context_enabled  — ⬜ needed (deterministic)
+
+- **What it gates:** prepends code-graph structural context to a delegate prompt; fail-open.
+- **Corpus:** deterministic — `(repo, target symbol/role) → expected structural context block`.
+  ~10 fixtures across a small sample repo.
+- **A/B / metric:** assert the injected context contains the true neighbours (callers/callees,
+  defining file) and stays within the budget. Since it's fail-open and advisory, the gate is
+  "context is correct + bounded", not a downstream quality metric.
+- **Pass bar:** injected context includes the ground-truth structural neighbours for every
+  fixture and never exceeds the configured budget.
+
+---
+
+## Running the memory_negation A/B (worked example)
+
+The negation corpus is the one that's fully built. Load it through the same eval entrypoint the
+golden corpus uses (`aimee eval memory-retrieval` / `mem_eval_load_corpus`), once with
+`memory_negation_enabled: false` and once `true`, and compare recall on the `neg*`/`dis*` cases
+against the `pos*` controls. Green + repeatable ⇒ `memory_negation_enabled` graduates from
+Bucket 3 to a default-on candidate.
+
+The remaining flags graduate the same way as their corpora are built out (status column above).
+Deterministic ones (`guardrails_blast_radius_advisory`, `delegate_graph_context`) are the next
+cheapest to finish because they need no LLM and no baseline drift management.

--- a/tests/eval/memory_negation_corpus.json
+++ b/tests/eval/memory_negation_corpus.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "description": "Validation corpus for the memory_negation feature (config: memory_negation_enabled). Each negated fact is paired with a positive distractor stating the OPPOSITE, so retrieval must be negation-aware to separate them: a naive lexical/semantic retriever scores both members of a pair highly on a negation query. Run the memory-retrieval eval with memory_negation OFF vs ON; the ON run should raise recall on the negation + discrimination cases WITHOUT regressing the positive controls. Kept OUT of the gated golden (memory_retrieval_corpus.json) so it never perturbs that regression baseline.",
+  "fixtures": [
+    {"fid": "n001", "tier": "L2", "kind": "fact", "key": "redis persistence staging", "content": "In staging, Redis is configured WITHOUT persistence; all data is in-memory and lost on restart."},
+    {"fid": "n002", "tier": "L2", "kind": "fact", "key": "postgres local ssl", "content": "The local Postgres connection does NOT use SSL; it runs over a trusted unix socket only."},
+    {"fid": "n003", "tier": "L2", "kind": "fact", "key": "metrics endpoint auth", "content": "The public metrics endpoint requires NO authentication and is exposed read-only."},
+    {"fid": "n004", "tier": "L2", "kind": "fact", "key": "job retry policy", "content": "Failed background jobs are NEVER retried automatically; a human must requeue them."},
+    {"fid": "n005", "tier": "L2", "kind": "fact", "key": "cdn purge on deploy", "content": "The CDN cache is never purged on deploy; entries expire only by their TTL."},
+    {"fid": "n006", "tier": "L2", "kind": "fact", "key": "staging email delivery", "content": "The staging environment does not send real emails; all mail is captured by a local sink."},
+    {"fid": "n007", "tier": "L2", "kind": "fact", "key": "embedder gpu use", "content": "The embedder runs on CPU only; no GPU is used in the default deployment."},
+    {"fid": "n008", "tier": "L2", "kind": "fact", "key": "backup encryption", "content": "Nightly backups are stored unencrypted on the local disk."},
+
+    {"fid": "n101", "tier": "L2", "kind": "fact", "key": "redis persistence prod", "content": "In production, Redis persists to disk via AOF fsync every second and survives restarts."},
+    {"fid": "n102", "tier": "L2", "kind": "fact", "key": "postgres prod ssl", "content": "The production Postgres connection enforces SSL with full certificate verification."},
+    {"fid": "n103", "tier": "L2", "kind": "fact", "key": "admin endpoint auth", "content": "The admin endpoint requires both an API key and a bearer token for every request."},
+    {"fid": "n104", "tier": "L2", "kind": "fact", "key": "payment webhook retry", "content": "Failed payment webhooks are retried automatically with exponential backoff up to five times."},
+    {"fid": "n105", "tier": "L2", "kind": "fact", "key": "asset cache purge", "content": "The asset cache is purged on every deploy so clients always fetch the newest bundle."},
+    {"fid": "n106", "tier": "L2", "kind": "fact", "key": "prod email delivery", "content": "The production environment sends real emails through the SES transactional provider."},
+    {"fid": "n107", "tier": "L2", "kind": "fact", "key": "reranker gpu use", "content": "The reranker runs on a dedicated GPU in the default production deployment."},
+    {"fid": "n108", "tier": "L2", "kind": "fact", "key": "snapshot encryption", "content": "Nightly database snapshots are encrypted at rest with a KMS-managed key."},
+
+    {"fid": "n201", "tier": "L2", "kind": "fact", "key": "log retention", "content": "Application logs rotate daily and are retained for fourteen days."},
+    {"fid": "n202", "tier": "L2", "kind": "fact", "key": "timestamp timezone", "content": "All stored timestamps are in UTC regardless of the client locale."},
+    {"fid": "n203", "tier": "L2", "kind": "fact", "key": "python version", "content": "The service requires Python 3.11 or newer for its typing features."}
+  ],
+  "cases": [
+    {"id": "neg01", "query": "which service is configured without persistence", "expected": ["n001"], "difficulty": "hard", "notes": "negation: no persistence"},
+    {"id": "neg02", "query": "database connection that does not use SSL", "expected": ["n002"], "difficulty": "hard", "notes": "negation: not SSL"},
+    {"id": "neg03", "query": "endpoint that requires no authentication", "expected": ["n003"], "difficulty": "hard", "notes": "negation: no auth"},
+    {"id": "neg04", "query": "what is never retried automatically", "expected": ["n004"], "difficulty": "hard", "notes": "negation: never retried"},
+    {"id": "neg05", "query": "cache that is never purged on deploy", "expected": ["n005"], "difficulty": "hard", "notes": "negation: never purged"},
+    {"id": "neg06", "query": "environment that does not send real email", "expected": ["n006"], "difficulty": "hard", "notes": "negation: no real email"},
+    {"id": "neg07", "query": "component that runs without a GPU", "expected": ["n007"], "difficulty": "hard", "notes": "negation: no GPU"},
+    {"id": "neg08", "query": "backups that are not encrypted", "expected": ["n008"], "difficulty": "hard", "notes": "negation: unencrypted"},
+
+    {"id": "dis01", "query": "the redis that keeps no data across restarts", "expected": ["n001"], "difficulty": "hard", "notes": "discriminate n001 (no persistence) from n101 (persistent)"},
+    {"id": "dis02", "query": "postgres connection with no SSL", "expected": ["n002"], "difficulty": "hard", "notes": "discriminate n002 from n102 (SSL enforced)"},
+    {"id": "dis03", "query": "endpoint with no auth required", "expected": ["n003"], "difficulty": "hard", "notes": "discriminate n003 from n103 (key + bearer)"},
+    {"id": "dis04", "query": "jobs that are not retried", "expected": ["n004"], "difficulty": "hard", "notes": "discriminate n004 from n104 (retried with backoff)"},
+    {"id": "dis05", "query": "cache that is not purged on deploy", "expected": ["n005"], "difficulty": "hard", "notes": "discriminate n005 from n105 (purged each deploy)"},
+    {"id": "dis06", "query": "environment with no real email sending", "expected": ["n006"], "difficulty": "hard", "notes": "discriminate n006 from n106 (sends via SES)"},
+    {"id": "dis07", "query": "inference component not using a GPU", "expected": ["n007"], "difficulty": "hard", "notes": "discriminate n007 from n107 (GPU reranker)"},
+    {"id": "dis08", "query": "backups without encryption", "expected": ["n008"], "difficulty": "hard", "notes": "discriminate n008 from n108 (encrypted snapshots)"},
+
+    {"id": "pos01", "query": "which redis persists to disk across restarts", "expected": ["n101"], "difficulty": "easy", "notes": "positive control: must still find the affirmative fact"},
+    {"id": "pos02", "query": "connection that enforces SSL with cert verification", "expected": ["n102"], "difficulty": "easy", "notes": "positive control"},
+    {"id": "pos03", "query": "endpoint requiring an API key and bearer token", "expected": ["n103"], "difficulty": "easy", "notes": "positive control"},
+    {"id": "pos04", "query": "webhooks retried with exponential backoff", "expected": ["n104"], "difficulty": "easy", "notes": "positive control"}
+  ]
+}


### PR DESCRIPTION
Follow-up to the default-on review (#1530). The review left ~10 experimental flags in **Bucket 3 — "keep OFF until a validation corpus exists"**. Each changes retrieval/learning/advisory behavior and the code docs mark it Tier C/S "needs harness/corpus". This starts closing that gap so the flags can graduate to default-on candidates via a repeatable A/B.

## What's here
- **`tests/eval/memory_negation_corpus.json`** — a real, schema-valid corpus (19 fixtures / 20 cases) for `memory_negation_enabled`, the one fully built out. Every negated fact is paired with a positive distractor stating the opposite (`n001` "redis WITHOUT persistence" ⇔ `n101` "redis persists via AOF"), plus positive controls. That pairing is what makes the metric discriminating — a negation-blind retriever scores *both* members of a pair highly on a negation query, so only a negation-aware retrieval separates them. Kept **out** of the gated golden corpus so it never perturbs that 5%-regression baseline.
- **`benchmarks/bucket3-defaults/VALIDATION.md`** — per-flag validation recipes for the whole bucket: which harness, the A/B method (flag OFF vs ON), the metric, the pass bar, and a data-status column (✅ built / 🟡 partial / ⬜ needed). `memory_negation` is the worked example; the rest map to existing harnesses (`mem_eval`, `tools/learning_eval.py`, `benchmarks/{code-vector-graph,graph}`, `learning_implicit_replay`) with the specific fixtures each still needs.

## Scope / honesty
A genuine labeled corpus for **all** of Bucket 3 is a large per-feature effort (scenes need multi-turn session fixtures, abstain needs a new abstention metric, the `learning_implicit_*` detectors are stateful and not replayable without a live router). This PR delivers the **one fully-built corpus + the actionable plan for the rest**, rather than shallow fake corpora for ten heterogeneous features. The deterministic ones (`guardrails_blast_radius_advisory`, `delegate_graph_context`) are flagged as the cheapest to finish next.

Additive only — the eval corpus path is hardcoded to the golden file, so the new corpus is inert until explicitly run for an A/B. No build/test/lint impact.
