### PR TITLE
fix(wfe): foreach parent parks slices_running (driveable), not pending_human

### DIFF
--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -18,7 +18,7 @@ typedef struct
    char pause_reason[32]; /* "" | pending_human | panel_degraded | budget_exceeded |
                              panel_unreachable | ci_pending | merge_pending |
                              turn_cap_exceeded | wall_cap_exceeded | stuck |
-                             operator_paused */
+                             slices_running | operator_paused */
    char paused_state[64];
    char content_hash[72];
    /* The forge ref returned by g_forge->open (PR number/url), opaque to the

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -65,7 +65,11 @@ static long wfe_sched_concurrency(void)
  * driveable:
  *   - un-parked (pause_reason empty): the next step is ready to run;
  *   - a SELF-RESOLVING park the sweep exists to re-check: ci_pending / merge_pending
- *     re-poll the forge, panel_degraded / panel_unreachable retry a flaky panel.
+ *     re-poll the forge, panel_degraded / panel_unreachable retry a flaky panel,
+ *     slices_running re-aggregates a foreach parent's children (advance once all
+ *     merged). A foreach parent MUST stay driveable while its slices run: the
+ *     fan-in aggregation only happens when the parent is re-driven, so parking it
+ *     non-driveably would wedge the whole fan-out.
  * Every other park either waits for a HUMAN (pending_human, operator_paused) or is
  * a runaway/failure backstop only a human (or the stale-run reaper) clears (stuck,
  * turn_cap_exceeded, wall_cap_exceeded, budget_exceeded, max_attempts, failed).
@@ -77,7 +81,8 @@ static int wfe_sched_driveable(const char *pause_reason)
       return 1;
    return strcmp(pause_reason, "ci_pending") == 0 || strcmp(pause_reason, "merge_pending") == 0 ||
           strcmp(pause_reason, "panel_degraded") == 0 ||
-          strcmp(pause_reason, "panel_unreachable") == 0;
+          strcmp(pause_reason, "panel_unreachable") == 0 ||
+          strcmp(pause_reason, "slices_running") == 0;
 }
 
 /* Stage class for sweep priority: LOWER runs first. Downstream-first ("drain

--- a/src/tests/test_wfe_foreach.c
+++ b/src/tests/test_wfe_foreach.c
@@ -105,7 +105,8 @@ int main(void)
 
    db1_work_item_t wi;
 
-   /* (1) spawner creates 2 children -> park (slices running, nothing merged yet). */
+   /* (1) spawner creates 2 children -> park slices_running (a self-resolving wait,
+    * NOT a human gate: the sweep re-drives it to re-aggregate as slices merge). */
    wfe_set_foreach_provider(&MOCK);
    g_spawn_n = 2;
    g_spawn_err = 0;
@@ -113,7 +114,7 @@ int main(void)
    run_fe("r/one", "p/one", &wi, NULL);
    assert(g_spawned == 1);
    assert(strcmp(wi.state, "active") == 0);
-   assert(strcmp(wi.pause_reason, "pending_human") == 0);
+   assert(strcmp(wi.pause_reason, "slices_running") == 0);
 
    /* (2) spawner reports 0 packets -> advance straight through (nothing to slice). */
    g_spawn_n = 0;
@@ -174,7 +175,7 @@ int main(void)
       }
    }
 
-   /* (7) GAP-2: a foreach parent parked pending_human while its children run is
+   /* (7) GAP-2: a foreach parent parked slices_running while its children run is
     * AUTO-RESUMED by the autonomy driver once EVERY child has merged — with no
     * operator resume. The fix lives in wfe_autonomy_run's pause-dispatch block,
     * so drive it there (not wfe_engine_run). */
@@ -193,14 +194,14 @@ int main(void)
       wfe_set_foreach_provider(&MOCK); /* children pre-exist -> must NOT be called */
       g_spawned = 0;
 
-      /* first pass: runs u->sp->fe, foreach sees 2 active children -> park. */
+      /* first pass: runs u->sp->fe, foreach sees 2 active children -> park slices_running. */
       assert(wfe_autonomy_run(id, err, sizeof err) == 0);
       assert(db1_work_item_get(id, &wi) == 1);
-      assert(strcmp(wi.pause_reason, "pending_human") == 0);
+      assert(strcmp(wi.pause_reason, "slices_running") == 0);
       /* a sweep with children STILL active must leave it parked (no premature redrive). */
       assert(wfe_autonomy_run(id, err, sizeof err) == 0);
       assert(db1_work_item_get(id, &wi) == 1);
-      assert(strcmp(wi.pause_reason, "pending_human") == 0);
+      assert(strcmp(wi.pause_reason, "slices_running") == 0);
       /* mark every child merged; the NEXT sweep auto-clears the fan-in park and
        * advances past `fe` — no operator resume. */
       assert(db1_work_item_set_terminal(c0, "accepted") == 0);
@@ -218,6 +219,35 @@ int main(void)
             rd++;
       free(evs);
       assert(rd == 1); /* exactly one redrive: the all-merged transition */
+   }
+
+   /* (7b) a slices_running parent CONVERTS to a pending_human park the moment a
+    * slice fails: the driveable wait becomes a human gate so an operator resolves
+    * the dead slice. Exercises the slices_running arm's failed>0 fall-through. */
+   {
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("fe", "r/g2x", "p/g2x", "autonomous", id, err, sizeof err) == 0);
+      char c0[80], c1[80], cp[96];
+      snprintf(c0, sizeof c0, "%s.x0", id);
+      snprintf(cp, sizeof cp, "xp/%s/0", id);
+      assert(db1_work_item_create(c0, "r/g2x", cp, "slice", "v1", "impl", "autonomous") == 0);
+      assert(db1_work_item_set_parent(c0, id) == 0);
+      snprintf(c1, sizeof c1, "%s.x1", id);
+      snprintf(cp, sizeof cp, "xp/%s/1", id);
+      assert(db1_work_item_create(c1, "r/g2x", cp, "slice", "v1", "impl", "autonomous") == 0);
+      assert(db1_work_item_set_parent(c1, id) == 0);
+      wfe_set_foreach_provider(&MOCK); /* children pre-exist -> must NOT be called */
+
+      /* both children active -> park slices_running. */
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.pause_reason, "slices_running") == 0);
+      /* one slice fails -> the next sweep converts the wait to a human park. */
+      assert(db1_work_item_set_terminal(c0, "rejected") == 0);
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "active") == 0);
+      assert(strcmp(wi.pause_reason, "pending_human") == 0);
    }
 
    /* (8) GAP-2 guard: a foreach parent with a FAILED child stays parked for a

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -345,6 +345,39 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
             /* pause cleared + poll durably recorded -> fall through: the advance
              * loop re-runs exec_gate_ci for a fresh CI read. */
          }
+         else if (strcmp(wi0.pause_reason, "slices_running") == 0)
+         {
+            /* A foreach.workflow parent parks slices_running while its child
+             * slices run — a SELF-resolving wait, not a human gate. Re-aggregate
+             * from the cheap local child tally and only clear the pause + re-run
+             * the node when the block can make progress: every child merged
+             * (accepted >= total) -> the advance loop re-runs exec_foreach_workflow
+             * and advances past `slices`; a FAILED slice -> exec_foreach_workflow
+             * re-parks pending_human for a human to resolve. While slices are still
+             * running with none failed, stay parked WITHOUT re-running the block or
+             * writing an event, so a long fan-out neither spams the audit log nor
+             * inflates the turn cap. A lost compare-and-clear just retries next
+             * sweep. This is the driveable analog of the pending_human foreach arm
+             * below (which handles a run parked before a slice failed, or resumed
+             * after a human fixed one). */
+            int total = 0, accepted = 0, failed = 0;
+            if (db1_work_item_child_counts(work_item_id, &total, &accepted, &failed) != 0 ||
+                total <= 0)
+               return 0;
+            if (failed == 0 && accepted < total)
+               return 0; /* slices still running, none failed -> stay parked */
+            if (db1_work_item_clear_pause_if(work_item_id, "slices_running", wi0.current_stage) !=
+                1)
+               return 0;
+            db1_lifecycle_event_add(work_item_id, wi0.current_stage, "foreach_redrive", "engine",
+                                    accepted >= total
+                                        ? "all children merged; re-aggregating"
+                                        : "a slice failed; re-aggregating to park for a human",
+                                    "", 0);
+            /* pause cleared -> fall through: the advance loop re-runs
+             * exec_foreach_workflow, which advances (all merged) or parks
+             * pending_human (a slice failed). */
+         }
          else if (strcmp(wi0.pause_reason, "pending_human") == 0)
          {
             /* A foreach.workflow parent (the `slices` node) parks pending_human

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -2003,12 +2003,17 @@ void wfe_set_foreach_provider(const wfe_foreach_provider_t *p)
  * parking until every child has merged into the feature branch. Aggregation is keyed
  * off the DB parent<->child linkage; only SPAWNING is delegated to the seam. With no
  * spawn provider installed (and no children yet) it parks pending_human (fail closed).
- *   - no children yet    -> spawn (park while they run); no provider -> park
- *   - any child FAILED    -> a slice will not merge (rejected/abandoned) -> park for a human
+ *   - no children yet    -> spawn (park slices_running while they run); no provider ->
+ * pending_human
+ *   - any child FAILED    -> a slice will not merge (rejected/abandoned) -> park pending_human
  *   - all children accepted -> advance (feature branch carries every merged slice)
- *   - else                -> children still running -> park, re-drive later
- * Trouble always PARKS (pending_human), never a silent advance and never a hard
- * run-fail: a human resolves the failed slice, then the run resumes. */
+ *   - else                -> children still running -> park slices_running, re-drive later
+ * "Children still running" parks slices_running -- a SELF-RESOLVING wait the sweep
+ * re-drives (see wfe_sched_driveable); it is NOT a human gate. Only a genuine human
+ * wait (no spawner, fan-out failed, or a FAILED slice) parks pending_human, so the
+ * autonomous run reaches a human exactly once: the final PR. A pending_human park
+ * here would wedge the parent, since pending_human is non-driveable and the fan-in
+ * aggregation only runs when the parent is re-driven. */
 static wfe_step_result_t exec_foreach_workflow(wfe_ctx *ctx, const wfe_node_t *node)
 {
    const char *wi = wfe_ctx_work_item(ctx);
@@ -2050,7 +2055,7 @@ static wfe_step_result_t exec_foreach_workflow(wfe_ctx *ctx, const wfe_node_t *n
          snprintf(handle, sizeof handle, "%s.out", node->id);
          return wfe_step_advanced(handle, "", 0.0);
       }
-      return wfe_step_pending(WFE_PAUSE_PENDING_HUMAN); /* spawned; run + re-drive */
+      return wfe_step_pending(WFE_PAUSE_SLICES_RUNNING); /* spawned; run + re-drive */
    }
 
    if (failed > 0)
@@ -2063,7 +2068,7 @@ static wfe_step_result_t exec_foreach_workflow(wfe_ctx *ctx, const wfe_node_t *n
       snprintf(handle, sizeof handle, "%s.out", node->id);
       return wfe_step_advanced(handle, "", 0.0);
    }
-   return wfe_step_pending(WFE_PAUSE_PENDING_HUMAN); /* slices still running -> re-drive */
+   return wfe_step_pending(WFE_PAUSE_SLICES_RUNNING); /* slices still running -> re-drive */
 }
 
 /* Register just the foreach.workflow executor over any prior (stub) registration --

--- a/src/workflow/wfe_engine.c
+++ b/src/workflow/wfe_engine.c
@@ -187,6 +187,8 @@ static const char *pause_name(wfe_pause_reason_t r)
       return "turn_cap_exceeded";
    case WFE_PAUSE_WALL_CAP:
       return "wall_cap_exceeded";
+   case WFE_PAUSE_SLICES_RUNNING:
+      return "slices_running";
    default:
       return "";
    }
@@ -212,6 +214,8 @@ static wfe_pause_reason_t pause_from_name(const char *s)
       return WFE_PAUSE_TURN_CAP;
    if (strcmp(s, "wall_cap_exceeded") == 0)
       return WFE_PAUSE_WALL_CAP;
+   if (strcmp(s, "slices_running") == 0)
+      return WFE_PAUSE_SLICES_RUNNING;
    return WFE_PAUSE_NONE;
 }
 

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -98,8 +98,13 @@ typedef enum
                              * be determined (transient/unknown) -- re-drive later */
    WFE_PAUSE_TURN_CAP,      /* autonomy runaway backstop: cumulative audit-event
                              * (turn) cap reached -- NOT a spend issue */
-   WFE_PAUSE_WALL_CAP       /* autonomy runaway backstop: this resume exceeded its
+   WFE_PAUSE_WALL_CAP,      /* autonomy runaway backstop: this resume exceeded its
                              * wall-clock ceiling -- NOT a spend issue */
+   WFE_PAUSE_SLICES_RUNNING /* foreach.workflow: children spawned and still running --
+                             * a SELF-RESOLVING wait, NOT a human gate. Each sweep
+                             * re-drives the parent to re-aggregate child state and
+                             * advances once every slice has merged. Must stay
+                             * driveable (see wfe_sched_driveable). */
 } wfe_pause_reason_t;
 
 /* Failure taxonomy (Phase-C Q4): how the autonomy run loop should react to a


### PR DESCRIPTION
## Problem

A `foreach.workflow` parent parked `pending_human` the instant it entered the `slices` node — before any child slice could pass or fail — as its "waiting for children" state. That collided with the autonomy scheduler's driveable filter (#1519): `pending_human` is correctly non-driveable, so the scheduler skipped the parent, its fan-in aggregation never re-ran, and the whole fan-out wedged forever even after every slice merged. It also mislabeled a routine wait as a human gate, when the only legitimate human stop in an autonomous build is the final PR.

## Fix

Introduce `WFE_PAUSE_SLICES_RUNNING` (`"slices_running"`): a self-resolving, driveable park for the two "children still running" cases in `exec_foreach_workflow`.

- `wfe_autonomy_run` re-aggregates a `slices_running` parent from the cheap local child tally each sweep — advancing once every slice merges, or converting to `pending_human` the moment a slice fails so an operator resolves the dead slice. It does *not* re-run the block or write an audit event while slices are merely still running, so a long fan-out neither spams the audit log nor inflates the turn cap.
- `pending_human` now covers only genuine human waits: no spawner, a fan-out failure, or a failed slice.
- `wfe_sched_driveable` drives `slices_running` so the parent is re-checked every sweep.

## Tests

`test_wfe_foreach` now asserts the running parent parks `slices_running` and auto-resumes once all children merge; adds a `slices_running -> pending_human` failure-transition case. `test_wfe_autonomy` unchanged and passing. `make lint` green.
