### PR TITLE
fix(delegate): write-capable delegate with no own worktree runs in-process, not a scratch sandbox

### DIFF
--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1353,8 +1353,17 @@ void delegate_worker(void *arg)
         delegate_sandbox_resolve_image(container_ws, sbx_image, sizeof(sbx_image)) == 0)
            ? sbx_image
            : NULL;
+   /* container_ws == NULL is the write-capable-but-no-own-worktree case resolved
+    * above: the intent there is to run IN-PROCESS under the write guard, NOT to hand
+    * the delegate a scratch sandbox. Binding with a NULL workspace mints an EMPTY
+    * scratch tree and mounts THAT, so the delegate edits files the engine never sees
+    * ("write role reported success but produced no diff") — which stalls every WFE
+    * implement slice (its cwd already IS a dedicated worktree; it needs no sibling
+    * tree, so delegate_needs_worktree is false and container_ws stays NULL). Only
+    * bind a container when there is a real tree to mount; otherwise run in-process in
+    * cwd so writes land where the engine diffs and commits them. */
    int container_bound =
-       detached_bound
+       (detached_bound || !container_ws || !container_ws[0])
            ? 0
            : workspace_turn_bind_container(deleg_id, sbx_image_arg, container_ws, container_ws_ro);
 


### PR DESCRIPTION
## Problem

Every WFE `implement` slice stalls: the slice delegate runs, reports success, but commits nothing — `delegate ... no-op — write role 'code' reported success but produced no diff`. The autonomous build loops to `max_iters` and never reaches a PR. Confirmed live on the .254 test appliance.

## Root cause

In `server_compute.c`, after deciding whether a delegate gets a container sandbox, `container_ws` is set to the delegate's own sibling worktree (rw), the shared parent tree (ro), or left **NULL** for a write-capable delegate with no worktree of its own. The comment for the NULL case says it should run **in-process** under the write guard. But the code still called `workspace_turn_bind_container(deleg_id, image, NULL, ro)`, which mints an **empty scratch tree** and mounts it as `/workspace`. The delegate edits the throwaway dir, reports success, and the engine diffs the untouched real tree → "produced no diff".

A WFE slice delegate's `cwd` already **is** a dedicated per-slice worktree, so `delegate_needs_worktree` is false, no sibling tree is resolved, and `container_ws` stays NULL — hitting exactly this path.

## Fix

Only bind a container when `container_ws` is a real, non-empty path; otherwise `container_bound = 0` and the delegate runs in-process in `cwd` (pinned via `run_cmd_set_cwd`), so writes land where the engine diffs and commits them. This matches the code's documented intent and the "only verify is sandboxed; implement runs on the worktree" design. The sandboxed cases (own-worktree rw, shared-parent ro) are unchanged.
