### PR TITLE
test(audit): cross-engine WORM-chain drift test + shared-contract docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -139,6 +139,19 @@ Key consequences of the split:
   appears in the server or a `db1_*`/`sqlite3_*` symbol appears in KB.
   `scripts/check_tier_deps.sh` enforces that code outside a tier calls only the
   typed public API, never a tier's storage handles.
+- **One sanctioned cross-tier code edge: the WORM hash chain.** The append-only
+  audit chain must produce byte-identical row hashes and checkpoint MACs whether
+  a row is written by the server's SQLite store (`src/modules/audit/audit_worm.c`)
+  or the KB's Postgres store (`src/db2/kb_audit_worm.c`). Both therefore share the
+  engine-agnostic hash primitives in `src/modules/audit/audit_worm_chain.{c,h}` —
+  a deliberate `db2/ → modules/audit/` include edge that does **not** breach the
+  tier boundary. The edge is permitted **only as long as
+  `src/modules/audit/audit_worm_chain.{c,h}` stays pure hashing** — SHA-256 only,
+  no storage handle, `sqlite3`- and `libpq`-free, and header-self-contained.
+  Reintroducing a storage-engine dependency there would re-create the layering
+  violation this section exists to prevent, so it is forbidden.
+  `src/tests/test_audit_worm_chain.c` pins the cross-engine hash vector against
+  the real primitive so the two stores cannot silently drift.
 
 The server reaches DB2 exclusively through the **KB client** (`src/server/
 kb_client*.c`): a set of typed RPC wrappers that talk to `aimee-kb` over a Unix

--- a/docs/proposals/pending/governance-attestable-enforcement.md
+++ b/docs/proposals/pending/governance-attestable-enforcement.md
@@ -28,7 +28,7 @@ MCP dispatch (`src/server/server.c:924`, `src/server/server_compute_async.c:206`
 the gateway rewrites the primary's LLM traffic in aimee's own process
 (`src/gateway_policy.c`), workflow gates are engine-owned and HMAC-non-forgeable
 (`src/workflow/wfe_approval.c`), and a hash-chained, MAC-checkpointed WORM store
-exists and verifies (`src/audit_worm.c`, `src/audit_worm_chain.c`). What is missing
+exists and verifies (`src/modules/audit/audit_worm.c`, `src/modules/audit/audit_worm_chain.c`). What is missing
 is the last mile that turns "we log verdicts" into "we can attest verdicts":
 
 1. the tamper-evident chain is **default-off** (`audit_worm_enabled` has no
@@ -77,8 +77,8 @@ datatracker.ietf.org draft-sharif-agent-audit-trail.
 | Piece | Where | Status |
 | --- | --- | --- |
 | Per-tool-call verdict + exactly-once audit emit | `pre_tool_check` wrapper, `src/guardrails_action_audit.c:90-146` (fail-open post-verdict; actor primary/delegate; keyed-HMAC `args_hash`) | shipped, default-on to `audit.log` |
-| Hash-chained WORM store, MAC checkpoints, green/amber/red verify | `src/audit_worm.c`, `src/audit_worm_chain.c`; dedicated chain key `.audit-chain-key` | shipped, **default-off dual-write** |
-| Sealing to kernel-immutable segments (crypto-only degrade) | `src/audit_worm.c` (`VACUUM INTO` + `FS_IMMUTABLE_FL`) | shipped; sealer runs in-process, sidecar deferred |
+| Hash-chained WORM store, MAC checkpoints, green/amber/red verify | `src/modules/audit/audit_worm.c`, `src/modules/audit/audit_worm_chain.c`; dedicated chain key `.audit-chain-key` | shipped, **default-off dual-write** |
+| Sealing to kernel-immutable segments (crypto-only degrade) | `src/modules/audit/audit_worm.c` (`VACUUM INTO` + `FS_IMMUTABLE_FL`) | shipped; sealer runs in-process, sidecar deferred |
 | Decision records (status / supersedes / revisit / linked policy, one-active-per-scope) | `decision_log`, `db2_decision_log_record()` | shipped |
 | Vault write audit (append-only, key fingerprints) | `src/server/server_vault.c:185-214` | shipped, separate unchained log |
 | kb-side WORM twin (`kb_audit_event`, byte-identical chain code) | db2, plpgsql WORM triggers | shipped, default-off |

--- a/docs/proposals/pending/operator-audit-activity-surface.md
+++ b/docs/proposals/pending/operator-audit-activity-surface.md
@@ -25,7 +25,7 @@ already exist, with no new write path.
 - **Provenance columns.** `operator_id` is on shareable rows across
   `src/db2/` (`fidelity.c`, `corpus_structural.c`, `artifacts.c`, memory rows,
   …), alongside `content_hash` + timestamps.
-- **WORM ledger.** `src/audit_ledger.c` + `src/db2/kb_audit_worm.c` record
+- **WORM ledger.** `src/modules/audit/audit_ledger.c` + `src/db2/kb_audit_worm.c` record
   privileged/append-only actions with a verify chain.
 - **The CLI verb exists but is integrity-only.** `cmd_audit`
   (`{"audit", "Verify/checkpoint the WORM audit store …"}`) has `verify` +

--- a/docs/proposals/pending/tiered-llm-p7-hardened-kb-vault.md
+++ b/docs/proposals/pending/tiered-llm-p7-hardened-kb-vault.md
@@ -273,7 +273,7 @@ a core dump. Keep the existing `OPENSSL_cleanse`-on-free discipline.
 ## §6 WORM-audited key use
 
 Every decrypt/use of an org key writes an entry to the existing WORM audit ledger
-(`src/audit_ledger.c`, `src/db2/kb_audit_worm.c`) — **one shared Postgres ledger
+(`src/modules/audit/audit_ledger.c`, `src/db2/kb_audit_worm.c`) — **one shared Postgres ledger
 across all instances** (invariant #9), so key-use history is complete regardless of
 which instance served the call: identity/team, timestamp,
 `provider:cred`, and request id — **never the secret or a fingerprint of it**.

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -84,7 +84,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-toolset-thread-scope $(TESTPREFIX)/unit-test-workspace-provider-container $(TESTPREFIX)/unit-test-mcp-native-surface $(TESTPREFIX)/unit-test-mcp-native-dispatch $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-roundtable-preset $(TESTPREFIX)/unit-test-roundtable-seat-resolve $(TESTPREFIX)/unit-test-audit-worm $(TESTPREFIX)/unit-test-kb-audit-worm $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-snapshot $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-roundtable-preset $(TESTPREFIX)/unit-test-roundtable-seat-resolve $(TESTPREFIX)/unit-test-audit-worm $(TESTPREFIX)/unit-test-audit-worm-chain $(TESTPREFIX)/unit-test-kb-audit-worm $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-snapshot $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -1094,6 +1094,12 @@ $(TESTPREFIX)/unit-test-roundtable-seat-resolve: $(OBJDIR)/tests/test_roundtable
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-audit-worm: $(OBJDIR)/tests/test_audit_worm.o $(OBJDIR)/modules/audit/audit_worm.o $(OBJDIR)/modules/audit/audit_worm_chain.o \
+                      $(OBJDIR)/workflow/wfe_canonical.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Pure-primitive drift/golden test for the shared WORM chain (no storage engine):
+# the single source of truth for the cross-engine hash contract.
+$(TESTPREFIX)/unit-test-audit-worm-chain: $(OBJDIR)/tests/test_audit_worm_chain.o $(OBJDIR)/modules/audit/audit_worm_chain.o \
                       $(OBJDIR)/workflow/wfe_canonical.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_audit_worm_chain.c
+++ b/src/tests/test_audit_worm_chain.c
@@ -1,0 +1,147 @@
+/* test_audit_worm_chain.c — golden-vector + drift test for the engine-agnostic
+ * WORM chain primitives (modules/audit/audit_worm_chain.c).
+ *
+ * These primitives are shared VERBATIM by the aimee-server SQLite store
+ * (modules/audit/audit_worm.c) and the aimee-kb Postgres store
+ * (db2/kb_audit_worm.c), so both must produce byte-identical row hashes and
+ * checkpoint MACs. This test is the single source of truth for that cross-engine
+ * contract: it pins the canonical hash of a known row (the same literal asserted
+ * from each store's side in test_audit_worm.c / test_kb_audit_worm.c) and locks
+ * the canonicalization structure both engines depend on, so a change to either
+ * store's hashing is caught here rather than silently splitting the two chains.
+ *
+ * Unlike the two store tests, this exercises only the pure primitives — no SQLite
+ * or Postgres — so it is a fast, dependency-light unit test.
+ *
+ * The pinned hash/MAC literals are the canonical values on the standard build
+ * host (little-endian x86_64), matching the identical vector pinned in the two
+ * store tests. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "audit_worm_chain.h"
+
+/* hex32 uses hand-verifiable vectors (no SHA needed): sequential bytes map to
+ * their own two-hex-digit values, and all-zero bytes are the genesis prev. */
+static void test_hex32(void)
+{
+   unsigned char in[32];
+   char out[65];
+
+   for (int i = 0; i < 32; i++)
+      in[i] = (unsigned char)i;
+   audit_worm_hex32(in, out);
+   assert(strcmp(out, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f") == 0);
+
+   memset(in, 0, sizeof in);
+   audit_worm_hex32(in, out);
+   assert(strcmp(out, AUDIT_WORM_GENESIS_PREV) == 0);
+
+   printf("  test_hex32: ok\n");
+}
+
+/* THE cross-engine contract vector. This literal is asserted independently from
+ * each store's side (test_audit_worm.c::test_cross_engine_vector and
+ * test_kb_audit_worm.c::test_cross_engine_vector); all three must stay identical
+ * or the two engines' chains diverge. */
+static void test_genesis_row_hash(void)
+{
+   char h[65];
+   audit_worm_row_hash(1, "primary", "u", "tool.read", "v1-1", "allow", "", "{}",
+                       AUDIT_WORM_GENESIS_PREV, h);
+   assert(strcmp(h, "3c2adf68ae8f1b704780ffedd32522e06468e34a69205240fbb358a7122ff986") == 0);
+   printf("  test_genesis_row_hash: ok\n");
+}
+
+/* row_hash must be deterministic and depend on every field (an injective,
+ * length-prefixed encoding), and must chain via prev_hash. These properties are
+ * what guarantee two engines that feed the same logical row get the same hash. */
+static void test_row_hash_field_sensitivity(void)
+{
+   char base[65], v[65];
+   audit_worm_row_hash(1, "primary", "u", "tool.read", "v1-1", "allow", "", "{}",
+                       AUDIT_WORM_GENESIS_PREV, base);
+
+   /* deterministic */
+   audit_worm_row_hash(1, "primary", "u", "tool.read", "v1-1", "allow", "", "{}",
+                       AUDIT_WORM_GENESIS_PREV, v);
+   assert(strcmp(base, v) == 0);
+
+/* Each single-field change must move the hash. */
+#define DIFF(...)                                                                                  \
+   do                                                                                              \
+   {                                                                                               \
+      audit_worm_row_hash(__VA_ARGS__, v);                                                         \
+      assert(strcmp(base, v) != 0);                                                                \
+   } while (0)
+   DIFF(2, "primary", "u", "tool.read", "v1-1", "allow", "", "{}",
+        AUDIT_WORM_GENESIS_PREV); /* seq */
+   DIFF(1, "backup", "u", "tool.read", "v1-1", "allow", "", "{}",
+        AUDIT_WORM_GENESIS_PREV); /* role */
+   DIFF(1, "primary", "x", "tool.read", "v1-1", "allow", "", "{}",
+        AUDIT_WORM_GENESIS_PREV); /* principal */
+   DIFF(1, "primary", "u", "tool.write", "v1-1", "allow", "", "{}",
+        AUDIT_WORM_GENESIS_PREV); /* action */
+   DIFF(1, "primary", "u", "tool.read", "v2-1", "allow", "", "{}",
+        AUDIT_WORM_GENESIS_PREV); /* subject */
+   DIFF(1, "primary", "u", "tool.read", "v1-1", "block", "", "{}",
+        AUDIT_WORM_GENESIS_PREV); /* verdict */
+   DIFF(1, "primary", "u", "tool.read", "v1-1", "allow", "k1", "{}",
+        AUDIT_WORM_GENESIS_PREV); /* key_id */
+   DIFF(1, "primary", "u", "tool.read", "v1-1", "allow", "", "{\"a\":1}",
+        AUDIT_WORM_GENESIS_PREV); /* detail */
+   {
+      char altprev[65];
+      memcpy(altprev, AUDIT_WORM_GENESIS_PREV, sizeof altprev);
+      altprev[0] = '1'; /* different prev_hash -> different row_hash (the chain link) */
+      DIFF(1, "primary", "u", "tool.read", "v1-1", "allow", "", "{}", altprev);
+   }
+#undef DIFF
+
+   /* Length-prefixing must make the field encoding injective: moving a character
+    * across a field boundary must not collide. */
+   char x[65], y[65];
+   audit_worm_row_hash(1, "ab", "", "act", "", "", "", "", AUDIT_WORM_GENESIS_PREV, x);
+   audit_worm_row_hash(1, "a", "b", "act", "", "", "", "", AUDIT_WORM_GENESIS_PREV, y);
+   assert(strcmp(x, y) != 0);
+
+   printf("  test_row_hash_field_sensitivity: ok\n");
+}
+
+/* Checkpoint MAC must be deterministic and bound to the key, the attested head
+ * (hash + seq), and the key_id. */
+static void test_ckpt_mac(void)
+{
+   const char *head = "3c2adf68ae8f1b704780ffedd32522e06468e34a69205240fbb358a7122ff986";
+   unsigned char k1[32], k2[32];
+   char m[65], v[65];
+   memset(k1, 0x01, sizeof k1);
+   memset(k2, 0x02, sizeof k2);
+
+   audit_worm_ckpt_mac(k1, head, 1, "kid0", m);
+
+   audit_worm_ckpt_mac(k1, head, 1, "kid0", v);
+   assert(strcmp(m, v) == 0); /* deterministic */
+   audit_worm_ckpt_mac(k2, head, 1, "kid0", v);
+   assert(strcmp(m, v) != 0); /* key-bound */
+   audit_worm_ckpt_mac(k1, head, 2, "kid0", v);
+   assert(strcmp(m, v) != 0); /* head-seq-bound */
+   audit_worm_ckpt_mac(k1, "0000000000000000000000000000000000000000000000000000000000000000", 1,
+                       "kid0", v);
+   assert(strcmp(m, v) != 0); /* head-hash-bound */
+   audit_worm_ckpt_mac(k1, head, 1, "kid1", v);
+   assert(strcmp(m, v) != 0); /* key_id-bound */
+
+   printf("  test_ckpt_mac: ok\n");
+}
+
+int main(void)
+{
+   test_hex32();
+   test_genesis_row_hash();
+   test_row_hash_field_sensitivity();
+   test_ckpt_mac();
+   printf("all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
Non-blocking follow-ups from the audit modularization review (#1538).

## What

- **New drift test** (`src/tests/test_audit_worm_chain.c`): a fast, storage-engine-free unit test for the shared WORM chain primitives (`modules/audit/audit_worm_chain.c`). It is the **single source of truth** for the cross-engine hash contract that the aimee-server SQLite store (`audit_worm.c`) and the aimee-kb Postgres store (`db2/kb_audit_worm.c`) both depend on:
  - Pins the canonical `row_hash` of a known genesis row — the *same literal* independently asserted from each store's side in `test_audit_worm.c` and `test_kb_audit_worm.c` (all three must stay identical or the chains diverge).
  - Pins hand-verifiable `hex32` vectors (sequential bytes, all-zero genesis).
  - Locks the canonicalization structure both engines rely on: per-field sensitivity, length-prefix injectivity, and checkpoint-MAC binding to key / head-hash / head-seq / key_id.
  - Wired into `TEST_TARGETS` + a recipe in `src/tests/Rules.mk` (links only the pure primitive — no SQLite/Postgres).
- **Architecture doc**: records the sanctioned `db2/ → modules/audit/` cross-tier code edge in `docs/ARCHITECTURE.md` §3 — the WORM chain is deliberately shared across the DB1/DB2 tier boundary because it is pure hashing (SHA-256 only, `sqlite3`/`libpq`-free), and points at the new test as the drift guard.
- **Proposal docs**: refresh stale `src/audit_*.c` paths → `src/modules/audit/` in the three in-flight `docs/proposals/pending/` audit proposals.

## Already-satisfied review items (no change needed)

- The `KB_CORE_SRCS` `filter-out` comment already explains the WORM-store isolation rationale and already references the new `modules/audit/` path.
- `audit_worm_chain.h` already carries its "shared by both stores" contract comment, and is confirmed **self-contained** (only `#include <stddef.h>`, no `static inline`, no macro required from the `.c`).

## Verification (local, worktree off `origin/testing`)

- `make all` ✅ · `make build-integrity module-boundary-check` ✅ · `make unit-tests` ✅ (incl. new `unit-test-audit-worm-chain`) · `make lint` ✅

---
### Review resolution (roundtable, 2 rounds)

- **Drift test is load-bearing (proven).** The recipe links the real `build/obj/modules/audit/audit_worm_chain.o`; the test TU defines no hashing itself. Perturbation experiment: mutating `AUDIT_WORM_DOMAIN` in the real header (`aimee.audit.worm.v1` → other) makes `test_genesis_row_hash` **abort (RC=134)**; restoring returns it green — so the pinned `3c2adf68…` vector is the live output of the production primitive, enforced on every `make unit-tests` run.
- **ARCHITECTURE §3 hardened** to name `audit_worm_chain.{c,h}` and state the forbidding invariant (must stay pure-hashing, `sqlite3`/`libpq`-free, self-contained).
- Golden literals are host-canonical (little-endian x86_64), matching the existing store-test vectors.