### PR TITLE
refactor(modules): break the roundtable<->delegates header cycle

### DIFF
--- a/src/modules/delegates/delegate_ensemble.h
+++ b/src/modules/delegates/delegate_ensemble.h
@@ -7,15 +7,14 @@
 
 #include "agent_config.h"
 #include "config.h"
+#include "roundtable_types.h" /* roundtable_opts_t / roundtable_result_t (owned by the roundtable module) */
 
 /* Max panelists in a roundtable/ensemble fan-out. Must match the
  * ensemble_reference_models / ensemble_reference_personas array dims in config.h
  * (a _Static_assert in delegate_ensemble.c enforces this). The fan-out arrays
  * (agent_result_t results[N] ~1.4KB each, etc.) live on the compute-pool worker
  * stack, which is 32 MB — so 32 panelists (~50KB frame) is well within budget. */
-#define ENSEMBLE_MAX_REFS           32
-#define ROUNDTABLE_MAX_REVIEW_ITEMS 128
-#define ROUNDTABLE_MAX_QUESTIONS    16
+#define ENSEMBLE_MAX_REFS 32
 
 typedef struct
 {
@@ -40,121 +39,12 @@ double delegate_ensemble_cost_usd(const delegate_ensemble_result_t *r);
 double delegate_cost_estimate_usd(const char *provider, const char *model, int prompt_tokens,
                                   int completion_tokens);
 
-typedef enum
-{
-   ROUNDTABLE_DRAFT = 0,
-   ROUNDTABLE_REVIEW = 1
-} roundtable_mode_t;
-
-typedef enum
-{
-   ROUNDTABLE_PARALLEL = 0,
-   ROUNDTABLE_SEQUENTIAL = 1
-} roundtable_turns_t;
-
-typedef struct
-{
-   roundtable_mode_t mode;
-   roundtable_turns_t turns;
-   int max_rounds;
-   int converge_threshold;
-   int deadline_ms;
-   int apply_review;
-   const char *brief;
-   int brief_truncated;
-   /* Optional pre-assembled read-only context (aimee memory recall + code-graph
-    * snippets) injected into every panelist prompt — a useful SEED, no longer the
-    * only window: REVIEW-mode panelists now run with aimee's index-only toolset
-    * (`review_indexed`) and can look things up themselves. Drafting panelists are
-    * still tool-less, so for them this remains the only view of memory and the code
-    * graph. The caller owns the string for the duration of the run; NULL = none. */
-   const char *context;
-   const char **questions;
-   int question_count;
-   int (*cancel_requested)(void *ctx);
-   void *cancel_ctx;
-   /* Originating session: panel + aggregator runs fold their cost onto it via
-    * db1_cost_fold_record, so the ensemble is accounted like a delegate. */
-   const char *parent_session_id;
-} roundtable_opts_t;
-
-/* Replay-verification evidence (Part A of the replayable-verification proposal).
- * A panelist attaches a STRUCTURED query — never a free-form command — so a fresh
- * verifier can replay it deterministically over the read-only code index
- * (index_find / index_find_callers / index_code_search) and re-ground the claim.
- * Plain (no pointers): memset-zeroing and struct copy stay valid. */
-typedef enum
-{
-   EV_NONE = 0, /* no replayable evidence -> item is interpretive (caps at concern) */
-   EV_SYMBOL,   /* does symbol `target` exist? -> index_find */
-   EV_REFS,     /* how many call sites of `target`? -> index_find_callers (the workhorse) */
-   EV_SEARCH    /* lexical code search for `target` -> index_code_search */
-} ev_kind_t;
-
-typedef struct
-{
-   ev_kind_t kind;
-   char target[256];  /* symbol (EV_SYMBOL/EV_REFS) or search query (EV_SEARCH) */
-   char project[128]; /* index project scope ("" = all indexed projects) */
-   int count;         /* the count the panelist claims (EV_REFS/EV_SEARCH) */
-   char idkey[65];    /* sha256-hex[:64] of sorted "file:line", or "" if unset */
-   int factual;       /* 1 = replayable claim; 0 = interpretive (caps at concern) */
-} review_evidence_t;
-
-typedef struct
-{
-   char severity[16];
-   char category[32];
-   char location[128];
-   char summary[256];
-   char recommendation[256];
-   char identity_key[128];
-   char sources[256];
-   int count;
-   review_evidence_t evidence; /* Part A: structured replay evidence (zeroed = EV_NONE) */
-} roundtable_review_item_t;
-
-typedef struct
-{
-   char question[512];
-   char answer[1024];
-   char evidence[512];
-   int answered;
-} roundtable_answered_question_t;
-
-typedef struct
-{
-   char *artifact;
-   int rounds_run;
-   int converged;
-   int degraded;
-   int truncated;
-   int cost_capped;
-   int deadline_hit;
-   int cancelled;
-   int best_round;
-   int participants_total;  /* reference models per round (panel size) */
-   int participants_failed; /* participants that returned no usable response in the final round run
-                             */
-   double cost_usd;
-   roundtable_review_item_t items[ROUNDTABLE_MAX_REVIEW_ITEMS];
-   int item_count;
-   int items_round;
-   int artifact_round;
-   roundtable_answered_question_t answered_questions[ROUNDTABLE_MAX_QUESTIONS];
-   int answered_question_count;
-   char coverage_gaps[ROUNDTABLE_MAX_QUESTIONS][512];
-   int coverage_gap_count;
-   /* Replay verification (Part A). Items whose structured evidence did not
-    * reproduce against the code index are moved here (not silently dropped), with
-    * a parallel reason code. Fixed arrays (no heap; no change to result_free). */
-   roundtable_review_item_t rejected[ROUNDTABLE_MAX_REVIEW_ITEMS];
-   char rejected_reason[ROUNDTABLE_MAX_REVIEW_ITEMS][24];
-   int rejected_count;
-   int verified_count; /* kept items whose factual evidence reproduced */
-   int degraded_count; /* kept but unverified (index unavailable) */
-   int capped_count;   /* interpretive items capped at suggestion */
-} roundtable_result_t;
+/* roundtable_opts_t, roundtable_result_t and their review-item / evidence /
+ * answered-question types (plus ROUNDTABLE_MAX_*) now live in the roundtable
+ * module's roundtable_types.h, included above. They were moved out of this
+ * delegates header to break the header cycle with the roundtable module (whose
+ * chair/verify headers need the result type). The delegate_roundtable_* entry
+ * points below still produce and free those types. */
 
 int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const char *task,
                             const roundtable_opts_t *opts, roundtable_result_t *out);

--- a/src/modules/roundtable/roundtable_chair.c
+++ b/src/modules/roundtable/roundtable_chair.c
@@ -1,6 +1,6 @@
 /* roundtable_chair.c: the reasoning-refutation pass. See roundtable_chair.h. */
 
-#include "aimee.h" /* MAX_PATH_LEN (pulled by delegate_ensemble.h -> agent_types.h) */
+#include "aimee.h" /* MAX_PATH_LEN */
 
 #include "roundtable_chair.h"
 

--- a/src/modules/roundtable/roundtable_chair.h
+++ b/src/modules/roundtable/roundtable_chair.h
@@ -17,7 +17,7 @@
  * rationale). This bounds the risk of adding a second fallible model to the very step
  * meant to curb fallible over-flagging. */
 
-#include "delegate_ensemble.h" /* roundtable_result_t */
+#include "roundtable_types.h" /* roundtable_result_t */
 
 /* Build the chair adjudication prompt from the surviving items in `out` (an items
  * digest + the demote/drop-only contract). Returns a malloc'd string (caller frees),

--- a/src/modules/roundtable/roundtable_pipeline_eval.h
+++ b/src/modules/roundtable/roundtable_pipeline_eval.h
@@ -13,7 +13,7 @@ extern "C"
 {
 #endif
 
-/* ROUNDTABLE_MAX_QUESTIONS in delegate_ensemble.h is 16; the questions-answered
+/* ROUNDTABLE_MAX_QUESTIONS in roundtable_types.h is 16; the questions-answered
  * done-bar refuses a brief with more accepted questions than this (#14). */
 #define RTP_MAX_BRIEF_QUESTIONS 16
 

--- a/src/modules/roundtable/roundtable_types.h
+++ b/src/modules/roundtable/roundtable_types.h
@@ -1,0 +1,139 @@
+/* roundtable_types.h: the plain-data result and options types produced by an
+ * ensemble roundtable run and consumed by the roundtable module (chair, verify,
+ * pipeline). These were previously defined inside delegate_ensemble.h, which
+ * forced the roundtable module's headers to include a delegates header purely for
+ * these types — a roundtable -> delegates header edge that, combined with
+ * delegates including the roundtable headers, formed a header cycle between the
+ * two modules. Owning them here (the roundtable module) breaks that cycle: both
+ * delegate_ensemble.h and the roundtable headers now include this leaf header, so
+ * the only cross-module edge is delegates -> roundtable.
+ *
+ * These are all plain data (fixed char arrays / ints; no pointers into other
+ * modules), so this header depends on nothing.
+ *
+ * LEAF HEADER: it must not #include any other project header. Keeping it
+ * dependency-free is exactly what keeps the delegates<->roundtable cycle broken;
+ * adding a project include here risks re-creating it. */
+#ifndef AIMEE_ROUNDTABLE_TYPES_H
+#define AIMEE_ROUNDTABLE_TYPES_H 1
+
+#define ROUNDTABLE_MAX_REVIEW_ITEMS 128
+#define ROUNDTABLE_MAX_QUESTIONS    16
+
+typedef enum
+{
+   ROUNDTABLE_DRAFT = 0,
+   ROUNDTABLE_REVIEW = 1
+} roundtable_mode_t;
+
+typedef enum
+{
+   ROUNDTABLE_PARALLEL = 0,
+   ROUNDTABLE_SEQUENTIAL = 1
+} roundtable_turns_t;
+
+typedef struct
+{
+   roundtable_mode_t mode;
+   roundtable_turns_t turns;
+   int max_rounds;
+   int converge_threshold;
+   int deadline_ms;
+   int apply_review;
+   const char *brief;
+   int brief_truncated;
+   /* Optional pre-assembled read-only context (aimee memory recall + code-graph
+    * snippets) injected into every panelist prompt — a useful SEED, no longer the
+    * only window: REVIEW-mode panelists now run with aimee's index-only toolset
+    * (`review_indexed`) and can look things up themselves. Drafting panelists are
+    * still tool-less, so for them this remains the only view of memory and the code
+    * graph. The caller owns the string for the duration of the run; NULL = none. */
+   const char *context;
+   const char **questions;
+   int question_count;
+   int (*cancel_requested)(void *ctx);
+   void *cancel_ctx;
+   /* Originating session: panel + aggregator runs fold their cost onto it via
+    * db1_cost_fold_record, so the ensemble is accounted like a delegate. */
+   const char *parent_session_id;
+} roundtable_opts_t;
+
+/* Replay-verification evidence (Part A of the replayable-verification proposal).
+ * A panelist attaches a STRUCTURED query — never a free-form command — so a fresh
+ * verifier can replay it deterministically over the read-only code index
+ * (index_find / index_find_callers / index_code_search) and re-ground the claim.
+ * Plain (no pointers): memset-zeroing and struct copy stay valid. */
+typedef enum
+{
+   EV_NONE = 0, /* no replayable evidence -> item is interpretive (caps at concern) */
+   EV_SYMBOL,   /* does symbol `target` exist? -> index_find */
+   EV_REFS,     /* how many call sites of `target`? -> index_find_callers (the workhorse) */
+   EV_SEARCH    /* lexical code search for `target` -> index_code_search */
+} ev_kind_t;
+
+typedef struct
+{
+   ev_kind_t kind;
+   char target[256];  /* symbol (EV_SYMBOL/EV_REFS) or search query (EV_SEARCH) */
+   char project[128]; /* index project scope ("" = all indexed projects) */
+   int count;         /* the count the panelist claims (EV_REFS/EV_SEARCH) */
+   char idkey[65];    /* sha256-hex[:64] of sorted "file:line", or "" if unset */
+   int factual;       /* 1 = replayable claim; 0 = interpretive (caps at concern) */
+} review_evidence_t;
+
+typedef struct
+{
+   char severity[16];
+   char category[32];
+   char location[128];
+   char summary[256];
+   char recommendation[256];
+   char identity_key[128];
+   char sources[256];
+   int count;
+   review_evidence_t evidence; /* Part A: structured replay evidence (zeroed = EV_NONE) */
+} roundtable_review_item_t;
+
+typedef struct
+{
+   char question[512];
+   char answer[1024];
+   char evidence[512];
+   int answered;
+} roundtable_answered_question_t;
+
+typedef struct
+{
+   char *artifact;
+   int rounds_run;
+   int converged;
+   int degraded;
+   int truncated;
+   int cost_capped;
+   int deadline_hit;
+   int cancelled;
+   int best_round;
+   int participants_total;  /* reference models per round (panel size) */
+   int participants_failed; /* participants that returned no usable response in the final round run
+                             */
+   double cost_usd;
+   roundtable_review_item_t items[ROUNDTABLE_MAX_REVIEW_ITEMS];
+   int item_count;
+   int items_round;
+   int artifact_round;
+   roundtable_answered_question_t answered_questions[ROUNDTABLE_MAX_QUESTIONS];
+   int answered_question_count;
+   char coverage_gaps[ROUNDTABLE_MAX_QUESTIONS][512];
+   int coverage_gap_count;
+   /* Replay verification (Part A). Items whose structured evidence did not
+    * reproduce against the code index are moved here (not silently dropped), with
+    * a parallel reason code. Fixed arrays (no heap; no change to result_free). */
+   roundtable_review_item_t rejected[ROUNDTABLE_MAX_REVIEW_ITEMS];
+   char rejected_reason[ROUNDTABLE_MAX_REVIEW_ITEMS][24];
+   int rejected_count;
+   int verified_count; /* kept items whose factual evidence reproduced */
+   int degraded_count; /* kept but unverified (index unavailable) */
+   int capped_count;   /* interpretive items capped at suggestion */
+} roundtable_result_t;
+
+#endif /* AIMEE_ROUNDTABLE_TYPES_H */

--- a/src/modules/roundtable/roundtable_verify.h
+++ b/src/modules/roundtable/roundtable_verify.h
@@ -13,7 +13,7 @@
 #define DEC_ROUNDTABLE_VERIFY_H 1
 
 #include "evidence_replay.h" /* pulls aimee.h (MAX_PATH_LEN) + index types first */
-#include "delegate_ensemble.h"
+#include "roundtable_types.h"
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
Deferred follow-up from the roundtable modularization review (#1537).

## The cycle

`modules/roundtable/roundtable_chair.h` and `roundtable_verify.h` included `delegate_ensemble.h` **solely** to obtain `roundtable_result_t` / `roundtable_opts_t`, while `modules/delegates` (`delegate_ensemble.c`, `delegate_ensemble_review.c`) includes the roundtable headers — a header cycle between the two modules.

## The fix

`roundtable_result_t` and its companions (`roundtable_opts_t`, `roundtable_review_item_t`, `review_evidence_t`, `roundtable_answered_question_t`, the `roundtable_mode_t`/`roundtable_turns_t`/`ev_kind_t` enums, and the `ROUNDTABLE_MAX_*` bounds) are the **result/options of a roundtable run** and are **plain data** — fixed char arrays and ints, no pointers into other modules. They were misplaced inside the delegates header.

Move them into a new **roundtable-owned leaf header**, `modules/roundtable/roundtable_types.h`, which depends on nothing:

- `delegate_ensemble.h` now `#include`s it (its `delegate_roundtable_run` / `_result_free` entry points still produce/free those types).
- `roundtable_chair.h` / `roundtable_verify.h` `#include` it instead of `delegate_ensemble.h`.

The only remaining cross-module edge is **delegates → roundtable**. No behavioral change: every other TU that included `delegate_ensemble.h` still gets the types transitively.

## Cycle-broken proof

`gcc -H` header-include trace:
- `roundtable_chair.h` closure → just `roundtable_types.h` (no `delegate_ensemble.h`).
- `roundtable_verify.h` closure → **0** occurrences of `delegate_ensemble.h`.

## "Both directions" coverage

The existing unit tests exercise both sides of the (now-decoupled) boundary and all pass: `unit-test-roundtable-chair`, `-verify`, `-brief` (roundtable consuming a result) and the delegate-ensemble tests (delegates producing one). A dedicated new test isn't warranted — the structural decoupling is proven by the header trace above, and the interaction is covered by the existing suite.

## Verification (local, worktree off `origin/testing`)

- `make all` ✅ · `make build-integrity module-boundary-check` ✅ · `make unit-tests` ✅ · `make lint` ✅