### PR TITLE
fix(benchmark): reject --corpus on live-memory suites instead of silently ignoring it

### DIFF
--- a/src/server/server_memory_benchmark.c
+++ b/src/server/server_memory_benchmark.c
@@ -292,6 +292,22 @@ int handle_memory_benchmark(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (strcmp(suite, "memory") == 0 || strcmp(suite, "corpus") == 0 ||
        strcmp(suite, "memory-retrieval") == 0 || strcmp(suite, "live") == 0)
    {
+      /* These suites evaluate the LIVE stored memory (per query through the real
+       * retrieval path); they do NOT ingest a labelled corpus FILE. The `corpus`
+       * request field is honored only by the code-graph-fusion suite. Historically
+       * `--corpus` was accepted here and silently dropped, which is a footgun: the
+       * caller thinks they benchmarked their file when they benchmarked live memory.
+       * Fail loudly instead, and point at the harness that does read a corpus file. */
+      const char *corpus_file = jo_str(req, "corpus", NULL);
+      if (corpus_file && corpus_file[0])
+         return server_send_error(
+             conn,
+             "the memory/corpus/memory-retrieval/live benchmark suites evaluate the LIVE stored "
+             "memory and do not accept a --corpus file (only the code-graph-fusion suite does). "
+             "To evaluate a labelled corpus FILE, use the retrieval-eval harness: "
+             "`make memory-retrieval-eval-check` or "
+             "`unit-test-memory-retrieval-eval --corpus <path> --baseline <path>`.",
+             NULL);
       const char *fstate = jo_str(req, "fusion_state", NULL);
       int max_cases = jo_int(req, "max_cases", jo_int(req, "limit", 100));
       return bench_live_eval_corpus(conn, suite, fstate, max_cases);

--- a/src/tests/test_server_memory_benchmark.c
+++ b/src/tests/test_server_memory_benchmark.c
@@ -144,6 +144,24 @@ static void test_live_corpus_suite(void)
    reset_capture();
 }
 
+/* A --corpus FILE passed to a live-memory suite must be REJECTED, not silently
+ * dropped (which used to make the caller think they benchmarked their file when
+ * they benchmarked live memory). */
+static void test_live_suite_rejects_corpus_file(void)
+{
+   server_ctx_t ctx = {0};
+   server_conn_t conn = {0};
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "suite", "memory-retrieval");
+   cJSON_AddStringToObject(req, "corpus", "/tmp/some_corpus.json");
+   assert(handle_memory_benchmark(&ctx, &conn, req) == 0);
+   assert(g_last_error[0] != '\0');                /* errored loudly ... */
+   assert(g_last_response == NULL);                /* ... instead of emitting an ok result */
+   assert(strstr(g_last_error, "corpus") != NULL); /* actionable message */
+   cJSON_Delete(req);
+   reset_capture();
+}
+
 static void test_code_graph_suite(void)
 {
    server_ctx_t ctx = {0};
@@ -194,6 +212,7 @@ int main(void)
 {
    printf("server_memory_benchmark: ");
    test_live_corpus_suite();
+   test_live_suite_rejects_corpus_file();
    test_code_graph_suite();
    test_async_only_and_unknown();
    printf("all tests passed\n");


### PR DESCRIPTION
## The bug
`aimee memory benchmark {memory,corpus,memory-retrieval,live} --corpus <file>` marshals the corpus path into the request, but `handle_memory_benchmark`'s live-memory branch never reads it — it always evaluates the **live stored memory** via `bench_live_eval_corpus`. So `--corpus` is **silently dropped**: the caller thinks they benchmarked their labelled corpus file when they actually benchmarked live memory. (Found while trying to run a memory-retrieval A/B against a corpus — the silent drop sent the investigation down a wrong path.)

Only the `code-graph-fusion` suite honors the `corpus` field. The corpus-*file* retrieval eval is a different harness (`mem_eval_load_corpus`, exercised by `make memory-retrieval-eval-check` / `unit-test-memory-retrieval-eval --corpus <path>`), not this live RPC.

## The fix
When a live-memory suite is given a non-empty `corpus`, return a clear, actionable error pointing at the correct harness, instead of misleading the caller. Regression test added to `test_server_memory_benchmark` (passes).

Server-side only — no routes, config, or generated docs change.

## Noted, not fixed here (larger gap)
The corpus-file eval only runs on the **sqlite db2 shim** (`db2_eval_open_temp_store` returns `-1` in shim-disabled production builds). So **Postgres-only retrieval features cannot be validated against a corpus file by any current harness** — notably `memory_negation`, whose `memory_negation_fts_tsv` GENERATED-column FTS projection doesn't exist in the shim. That's the real reason a `memory_negation` corpus A/B can't be run today; closing it needs real-Postgres corpus-eval infrastructure and is worth its own effort.