### PR TITLE
docs: single-container install + wizard updates (quickstart & README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,33 +39,35 @@ Core services are C. Hot paths run in single-digit milliseconds. Nothing phones 
 
 ## Get started
 
-Run the services in Docker, install the `aimee` CLI on each machine.
+One container to start. The browser wizard brings up the rest.
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
 cd aimee
 
-# Simplest: the split stack in one command — server + kb + llm + Postgres, all on
-# CPU, with a short setup wizard (add an agent, connect GitHub, pick workspaces).
-docker compose -f deploy/compose/aimee.yaml up -d
-
-# Or deploy just aimee-server and let the wizard's Deploy step bring up aimee-kb,
-# the LLM, and Postgres (CPU or GPU; mounts the host Docker socket to launch them):
-#   docker compose -f compose.server-managed.yaml up -d
-
-# Confirm it's live (default bearer: aimee-local-dev; -k for the self-signed cert)
-curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
+# Start aimee-server. It mounts the host Docker socket so the wizard can launch
+# aimee-kb, the LLM, and Postgres for you — CPU or GPU. No second compose command.
+docker compose -f compose.server-managed.yaml up -d
 ```
 
-Then point the client at the server and register your tool's hooks:
+Open <https://localhost:8443>, log in as `aimee` / `aimee-local-dev`, and run the setup
+wizard: pick a primary agent, choose CPU or GPU, connect a git host, pick workspaces. Its
+**Deploy** step brings up aimee-kb, the LLM, and Postgres. Change the login (`AIMEE_WEBCHAT_USER`
+/ `AIMEE_WEBCHAT_PASSWORD`) before you put it on a network.
+
+Then install the `aimee` CLI on each dev machine and point it at the server:
 
 ```bash
-aimee remote set https://host:8743 <token>   # set AIMEE_TLS_INSECURE=1 for the self-signed cert
-./configure-hooks.sh
+aimee remote set https://host:8743 <token>   # AIMEE_TLS_INSECURE=1 for the self-signed cert
+aimee status                                  # server, DB1, and kb health
 ```
+
+aimee wires its hooks and MCP server into your AI coding tools on first run — opt out with
+`AIMEE_NO_CLIENT_INTEGRATIONS=1`.
 
 [QUICKSTART.md](docs/QUICKSTART.md) walks the full setup. Every deployment topology and the
 from-source install live in [Deployment and operations](src/README.md#deployment-and-operations).
+Questions? Join the [Discord](https://discord.gg/FjGjvcgAqz).
 
 ```bash
 aimee memory store myhost "PVE at 10.0.0.1"   # a fact the AI keeps across sessions

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,12 +13,9 @@ The model is the same on every developer machine: **the services run in Docker (
 
 ## Part 1, Run the server (in Docker)
 
-Two one-container ways in:
+You start **one container — `aimee-server`** — with the host Docker socket mounted. Everything else is handled in the browser: the setup wizard's **Deploy** step brings up `aimee-kb`, `aimee-llm`, and Postgres (DB2 + pgvector) for you, on CPU or GPU. There is no second compose command.
 
-- **One-command split stack** — `docker compose -f deploy/compose/aimee.yaml up -d`. Brings up `aimee-server` + `aimee-kb` + `aimee-llm` (CPU) + Postgres together. The setup wizard is short: add an agent, connect GitHub, pick workspaces — no KB/LLM/store questions. No Docker socket. Best for getting started fast.
-- **Self-deploying server** — the rest of this section. Deploy just `aimee-server` with the host Docker socket mounted; the wizard's **Deploy** step then brings up `aimee-kb`, `aimee-llm`, and Postgres (CPU or GPU). Best when you want the real split topology or a GPU.
-
-The self-deploying server: deploy one container — `aimee-server` — with the host Docker socket mounted. The setup wizard's **Deploy** step brings up `aimee-kb`, `aimee-llm`, and Postgres (DB2 + pgvector) from there.
+Advanced operators who prefer to run each service as its own long-lived container (the manual split stack — `deploy/compose/aimee.yaml` and friends) still can; see [1.5](#15-managing-the-stack) and [MANUAL.md](../MANUAL.md). This guide takes the self-deploying path.
 
 ### Prerequisites
 
@@ -39,11 +36,7 @@ Starts `aimee-server` only (webchat built in). `/v1` is on `:8743` (native TLS, 
 
 ### 1.2 Run the setup wizard
 
-Open **https://localhost:8443** (accept the self-signed cert) and log in as `aimee` / `aimee-local-dev`.
-
-The browser login is a real PAM account the container creates on startup from **`AIMEE_WEBCHAT_USER`** / **`AIMEE_WEBCHAT_PASSWORD`** (defaults `aimee` / `aimee-local-dev`) — set them in the compose file for anything past local dev. The username must be a valid Linux name: **lowercase letters, digits, `-`, `_`, and not starting with a digit** (so `admin` or `web-user`, not `Admin` or `bob.smith`). For more than one login, set `AIMEE_WEBCHAT_USERS` to a comma-separated `user:password` list. If a login is rejected, check the container logs for `[webchat]` lines — they report exactly which account was created or why it couldn't be.
-
-Each provisioned account is mirrored (username + its `/etc/shadow` hash, never the plaintext) to `AIMEE_HOME/webchat/logins` on the data volume and restored on every start, so browser logins survive a container rebuild or a host reboot even if the runtime stops re-injecting `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD`.
+Open **https://localhost:8443** (accept the self-signed cert) and log in as `aimee` / `aimee-local-dev`. That single account gates the whole browser experience — the setup wizard, webchat, and the dashboards.
 
 The wizard covers:
 
@@ -51,9 +44,16 @@ The wizard covers:
 - **Knowledge base** — a local one (default), or an existing remote `aimee-kb`.
 - **Deploy topology** — where the embedder / reranker / synthesizer run (CPU by default, or a GPU).
 - **Shared store** — the bundled Postgres (default; nothing to enter), or an existing database.
-- **Connection & workspaces** — sign in to your git hosts and clone repos.
+- **Connection** — connect a git host so aimee can clone your repos. Pick one auth method and the wizard shows only its fields: **OAuth sign-in** (GitHub, GitLab, Gitea/Forgejo), an **access token** (HTTPS, any host including Bitbucket), or an **SSH key** (private key for `git@host:owner/repo.git`). Public repos clone without any of them. Optional — you can connect a host later.
+- **Workspaces & projects** — point at an owner/org, list its repos, and bulk-clone them into a workspace.
 
 The final **Deploy** launches `aimee-kb` + `aimee-llm` + Postgres and shows their status. The first run pulls images and the CPU model weights (a few minutes); later boots are fast — state lives in named volumes.
+
+#### Your login account
+
+The browser login is a real PAM account the container creates on startup from **`AIMEE_WEBCHAT_USER`** / **`AIMEE_WEBCHAT_PASSWORD`** (defaults `aimee` / `aimee-local-dev`) — **set your own in the compose file for anything past local dev.** The username must be a valid Linux name: **lowercase letters, digits, `-`, `_`, and not starting with a digit** (so `admin` or `web-user`, not `Admin` or `bob.smith`). For more than one login, set `AIMEE_WEBCHAT_USERS` to a comma-separated `user:password` list. If a login is rejected, check the container logs for `[webchat]` lines — they report exactly which account was created or why it couldn't be.
+
+Each provisioned account is mirrored (username + its `/etc/shadow` hash, never the plaintext) to `AIMEE_HOME/webchat/logins` on the data volume and restored on every start, so browser logins survive a container rebuild or a host reboot even if the runtime stops re-injecting `AIMEE_WEBCHAT_USER`/`AIMEE_WEBCHAT_PASSWORD`.
 
 ### 1.3 Verify it's healthy
 
@@ -138,13 +138,13 @@ Use your real bearer token instead of `aimee-local-dev` if you changed it. The s
 
 ### 2.3 Configure your AI coding tool
 
-From the cloned checkout, register aimee's hooks and MCP server for every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot):
+aimee wires itself into every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot) automatically — the first `aimee` command you run registers the SessionStart / PreToolUse / PostToolUse hooks (which call `aimee`) and the `aimee mcp-serve` MCP server into each tool's user config. To do it explicitly, or from the cloned checkout at install time, run:
 
 ```bash
 ./configure-hooks.sh
 ```
 
-This wires SessionStart / PreToolUse / PostToolUse hooks (which call `aimee`) and the `aimee mcp-serve` MCP server into each tool's config.
+Opt out of the global registration with `AIMEE_NO_CLIENT_INTEGRATIONS=1` (or set `client_integrations_enabled: false` in `aimee.yaml`); per-project wiring via `aimee setup` still works.
 
 ### 2.4 Set up workspaces
 
@@ -222,13 +222,13 @@ Use your real bearer token instead of `aimee-local-dev` if you changed it. The s
 
 ### 3.3 Configure your AI coding tool
 
-From the cloned checkout, register aimee's hooks and MCP server for every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot):
+aimee wires itself into every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot) automatically — the first `aimee.exe` command registers the SessionStart / PreToolUse / PostToolUse hooks (which call `aimee.exe`) and the `aimee mcp-serve` MCP server into each tool's user config. To do it explicitly, run:
 
 ```powershell
 .\configure-hooks.ps1
 ```
 
-This wires SessionStart / PreToolUse / PostToolUse hooks (which call `aimee.exe`) and the `aimee mcp-serve` MCP server into each tool's config.
+Opt out of the global registration with `AIMEE_NO_CLIENT_INTEGRATIONS=1` (or set `client_integrations_enabled: false` in `aimee.yaml`); per-project wiring via `aimee setup` still works.
 
 ### 3.4 Set up workspaces
 
@@ -315,11 +315,13 @@ Both the prebuilt universal binary and a source build speak `https://` with cert
 
 ### 4.3 Configure your AI coding tool
 
+aimee registers its hooks + MCP server into every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot) automatically on the first `aimee` command. To do it explicitly, run:
+
 ```bash
 ./configure-hooks.sh
 ```
 
-Registers aimee's hooks + MCP server for every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot).
+Opt out of the global registration with `AIMEE_NO_CLIENT_INTEGRATIONS=1` (or `client_integrations_enabled: false` in `aimee.yaml`); per-project wiring via `aimee setup` still works.
 
 ### 4.4 Set up workspaces
 


### PR DESCRIPTION
## Summary

Updates the quickstart and root README for the current install experience: **one container to start** — `docker compose -f compose.server-managed.yaml up -d` starts only `aimee-server`, and the browser wizard's **Deploy** step brings up `aimee-kb`, the LLM, and Postgres. Replaces the old "two ways in" split-stack framing.

## QUICKSTART.md
- **Part 1** rewritten to the one-container + wizard-does-the-rest model; the manual split stack (`deploy/compose/aimee.yaml`) demoted to an advanced fallback.
- New **"Your login account"** subsection — the PAM browser login that gates the wizard/webchat/dashboards: defaults, username rules, `AIMEE_WEBCHAT_USERS`, volume persistence.
- **Connection** step documents the new auth-method picker (OAuth / access token / SSH key) from #1418.
- **Configure-your-tool** sections (Linux/Windows/macOS) note hooks + MCP now auto-register on first run, with the `AIMEE_NO_CLIENT_INTEGRATIONS` opt-out.

## README.md
- **Get started** rewritten to the single-container flow, in the terse house voice.
- Discord link added to get-started alongside the existing Community section.

Docs-only; no code changes.
