### PR TITLE
fix(wfe): autonomous runs terminate at dead-ends instead of piling up as zombie pending_human

### DIFF
--- a/src/tests/test_wfe_foreach.c
+++ b/src/tests/test_wfe_foreach.c
@@ -6,7 +6,8 @@
  *   - no children + spawner returns 0    -> advance (no packets, nothing to do)
  *   - no children + no spawner           -> park (fail closed)
  *   - all children accepted              -> advance (every slice merged)
- *   - a child rejected or abandoned      -> park pending_human (a slice will not merge)
+ *   - a child rejected or abandoned      -> autonomous: abandon (dead-end, no human);
+ *                                           interactive: park pending_human
  */
 #include "wfe_test_home.h"
 #include <assert.h>
@@ -122,11 +123,12 @@ int main(void)
    run_fe("r/zero", "p/zero", &wi, NULL);
    assert(strcmp(wi.state, "accepted") == 0);
 
-   /* (3) no spawn provider + no children -> fail closed (park). */
+   /* (3) no spawn provider + no children -> fail closed. An AUTONOMOUS run has no
+    * human to escalate the fail-closed park to, so it terminates (abandoned)
+    * rather than lingering 'active' at pending_human forever. */
    wfe_set_foreach_provider(NULL);
    run_fe("r/none", "p/none", &wi, NULL);
-   assert(strcmp(wi.state, "active") == 0);
-   assert(strcmp(wi.pause_reason, "pending_human") == 0);
+   assert(strcmp(wi.state, "abandoned") == 0);
 
    /* (4) all children accepted BEFORE foreach runs -> advance (every slice merged).
     * Pre-seed children so the executor sees total>0 and never calls spawn. */
@@ -151,8 +153,10 @@ int main(void)
       assert(g_spawned == 0); /* aggregation used the DB, not a re-spawn */
    }
 
-   /* (5)+(6) a child that reached a terminal state OTHER than accepted (rejected, and
-    * separately abandoned) -> the slice will never merge -> park for a human. */
+   /* (5)+(6) a child that reached a terminal state OTHER than accepted (rejected,
+    * and separately abandoned) -> the slice will never merge. An AUTONOMOUS run
+    * has no human to resolve it, so the parent terminates (abandoned); an
+    * INTERACTIVE run parks pending_human for its operator (case 6b below). */
    {
       const char *term[] = {"rejected", "abandoned"};
       const char *repos[] = {"r/rej", "r/aband"};
@@ -170,9 +174,26 @@ int main(void)
          assert(db1_work_item_set_terminal(cid, term[c]) == 0);
          assert(wfe_engine_run(id, err, sizeof err) == 0);
          assert(db1_work_item_get(id, &wi) == 1);
-         assert(strcmp(wi.state, "active") == 0);
-         assert(strcmp(wi.pause_reason, "pending_human") == 0);
+         assert(strcmp(wi.state, "abandoned") == 0);
       }
+   }
+
+   /* (6b) the same failed-slice case but INTERACTIVE: a human CAN resolve it, so
+    * the parent parks pending_human (the autonomous-terminate rule must not fire). */
+   {
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("fe", "r/rej-i", "p/rej-i", "interactive", id, err, sizeof err) ==
+             0);
+      char cid[80];
+      snprintf(cid, sizeof cid, "%s.k0", id);
+      assert(db1_work_item_create(cid, "r/rej-i", "fp/rej-i/0", "slice", "v1", "impl",
+                                  "interactive") == 0);
+      assert(db1_work_item_set_parent(cid, id) == 0);
+      assert(db1_work_item_set_terminal(cid, "rejected") == 0);
+      assert(wfe_engine_run(id, err, sizeof err) == 0);
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "active") == 0);
+      assert(strcmp(wi.pause_reason, "pending_human") == 0);
    }
 
    /* (7) GAP-2: a foreach parent parked slices_running while its children run is
@@ -221,9 +242,9 @@ int main(void)
       assert(rd == 1); /* exactly one redrive: the all-merged transition */
    }
 
-   /* (7b) a slices_running parent CONVERTS to a pending_human park the moment a
-    * slice fails: the driveable wait becomes a human gate so an operator resolves
-    * the dead slice. Exercises the slices_running arm's failed>0 fall-through. */
+   /* (7b) a slices_running parent TERMINATES (abandoned) the moment a slice fails
+    * on an AUTONOMOUS run: the driveable wait resolves to a dead-end with no human
+    * to escalate to. Exercises the slices_running arm's failed>0 fall-through. */
    {
       char id[80] = "", err[256] = "";
       assert(wfe_work_item_create("fe", "r/g2x", "p/g2x", "autonomous", id, err, sizeof err) == 0);
@@ -242,17 +263,16 @@ int main(void)
       assert(wfe_autonomy_run(id, err, sizeof err) == 0);
       assert(db1_work_item_get(id, &wi) == 1);
       assert(strcmp(wi.pause_reason, "slices_running") == 0);
-      /* one slice fails -> the next sweep converts the wait to a human park. */
+      /* one slice fails -> the next sweep abandons the run (autonomous dead-end). */
       assert(db1_work_item_set_terminal(c0, "rejected") == 0);
       assert(wfe_autonomy_run(id, err, sizeof err) == 0);
       assert(db1_work_item_get(id, &wi) == 1);
-      assert(strcmp(wi.state, "active") == 0);
-      assert(strcmp(wi.pause_reason, "pending_human") == 0);
+      assert(strcmp(wi.state, "abandoned") == 0);
    }
 
-   /* (8) GAP-2 guard: a foreach parent with a FAILED child stays parked for a
-    * human (a slice that will not merge). The auto-resume must NOT fire while any
-    * child is non-accepted. */
+   /* (8) GAP-2 guard: a foreach parent with a FAILED child does NOT auto-resume
+    * while any child is non-accepted. On an AUTONOMOUS run that dead-end
+    * terminates (abandoned) rather than parking for a human. */
    {
       char id[80] = "", err[256] = "";
       assert(wfe_work_item_create("fe", "r/g2f", "p/g2f", "autonomous", id, err, sizeof err) == 0);
@@ -270,12 +290,11 @@ int main(void)
 
       assert(wfe_autonomy_run(id, err, sizeof err) == 0);
       assert(db1_work_item_get(id, &wi) == 1);
-      assert(strcmp(wi.state, "active") == 0);
-      assert(strcmp(wi.pause_reason, "pending_human") == 0);
-      /* a further sweep must not auto-clear it either (rejected slice persists). */
+      assert(strcmp(wi.state, "abandoned") == 0);
+      /* a further sweep must not resurrect a terminal run. */
       assert(wfe_autonomy_run(id, err, sizeof err) == 0);
       assert(db1_work_item_get(id, &wi) == 1);
-      assert(strcmp(wi.pause_reason, "pending_human") == 0);
+      assert(strcmp(wi.state, "abandoned") == 0);
    }
 
    /* (9) GAP-1 give-up bound: a ci_pending park whose poll budget is exhausted

--- a/src/workflow/wfe_engine.c
+++ b/src/workflow/wfe_engine.c
@@ -356,11 +356,31 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
       const char *pr = pause_name(r.pause_reason);
       if (!pr[0])
          pr = "unspecified";
-      WFE_CKW(db1_work_item_set_pause(work_item_id, pr, node->id));
-      db1_lifecycle_event_add(work_item_id, node->id, "pause", "engine", pr, r.content_hash,
-                              r.cost_usd);
-      out->pause_reason = r.pause_reason;
-      snprintf(out->next_stage, sizeof out->next_stage, "%s", node->id);
+      /* An AUTONOMOUS run has no operator to satisfy a pending_human wait, so a
+       * block parking pending_human at anything OTHER than a real human gate
+       * (gate.human) is a terminal dead-end — a failed slice, an unrecoverable
+       * escalation. Parking would leave the run 'active' forever (the stale-park
+       * reaper never reaps a human wait), piling up zombie runs. Terminate it
+       * (abandoned) with an audit trail instead. A real gate.human still parks (its
+       * whole purpose is the operator decision); interactive runs are unchanged. */
+      if (r.pause_reason == WFE_PAUSE_PENDING_HUMAN && strcmp(wi.mode, "autonomous") == 0 &&
+          node->block != WFE_BLK_GATE_HUMAN)
+      {
+         WFE_CKW(db1_work_item_set_terminal(work_item_id, "abandoned"));
+         db1_lifecycle_event_add(work_item_id, node->id, "terminal", "engine",
+                                 "abandoned: autonomous dead-end (no human to escalate to)", "",
+                                 r.cost_usd);
+         out->terminal = 1;
+         snprintf(out->state, sizeof out->state, "abandoned");
+      }
+      else
+      {
+         WFE_CKW(db1_work_item_set_pause(work_item_id, pr, node->id));
+         db1_lifecycle_event_add(work_item_id, node->id, "pause", "engine", pr, r.content_hash,
+                                 r.cost_usd);
+         out->pause_reason = r.pause_reason;
+         snprintf(out->next_stage, sizeof out->next_stage, "%s", node->id);
+      }
    }
    else if (r.status == WFE_STEP_FAILED)
    {
@@ -454,7 +474,25 @@ int wfe_engine_advance(const char *work_item_id, wfe_advance_result_t *out, char
                   wfe_def_free(def);
                   return 0;
                }
-               /* WFE_ON_MAX_HUMAN (default): pause for a human. */
+               /* WFE_ON_MAX_HUMAN (default): pause for a human — but an AUTONOMOUS
+                * run has no human to escalate to, so an exhausted loop cap is a
+                * terminal dead-end, not a wait. Parking pending_human would leave it
+                * 'active' forever (the reaper never reaps a human wait) — the very
+                * zombie-accumulation this avoids. Terminate it (abandoned) with an
+                * audit trail; an interactive run still parks for its operator. */
+               if (strcmp(wi.mode, "autonomous") == 0)
+               {
+                  WFE_CKW(db1_work_item_set_terminal(work_item_id, "abandoned"));
+                  db1_lifecycle_event_add(
+                      work_item_id, node->id, "terminal", "engine",
+                      "abandoned: max_iters reached (autonomous, no human to escalate to)", "",
+                      r.cost_usd);
+                  out->terminal = 1;
+                  snprintf(out->state, sizeof out->state, "abandoned");
+                  db1_lifecycle_txn_commit();
+                  wfe_def_free(def);
+                  return 0;
+               }
                WFE_CKW(db1_work_item_set_pause(work_item_id, "pending_human", next));
                db1_lifecycle_event_add(work_item_id, node->id, "pause", "engine", "max_iters", "",
                                        r.cost_usd);


### PR DESCRIPTION
## Problem

Observed live: **22 "active" runs** piled up on the box, several predating the session. An autonomous run that hits a dead-end parks `pending_human` and stays `active` **forever**:
- a node that exhausts its loop cap defaults to `on_max: human` → `pending_human` (e.g. implement `max_iters`, the largest source: 9 runs);
- a `foreach` parent with a failed slice returns `pending_human`.

There is no human to satisfy that wait in autonomous mode, and the stale-park reaper (#1519) **deliberately never reaps a human wait** (legitimate for interactive runs). So they accumulate indefinitely and keep competing for the model roster.

## Fix

For an **autonomous** run, a `pending_human` park at anything other than a real human gate (`gate.human`) is a terminal dead-end → **terminate it (`abandoned`)** with an audit trail instead of parking. Two engine sites:
1. the block-returned pending apply (covers `foreach`-failed and any block that parks `pending_human`);
2. the loop-cap `on_max: human` branch (covers `implement` `max_iters`).

A real `gate.human` still parks (its whole purpose is the operator decision); **interactive runs are unchanged**.

## Tests

`test_wfe_foreach` asserts autonomous failed-slice / no-spawner runs abandon (cases 3, 5/6, 7b, 8), and adds an **interactive** case (6b) that still parks `pending_human`. `test_wfe_autonomy`, `test_wfe_manager_flow`, `test_wfe_sliced_build` pass. `make lint` green.

## Follow-up (noted, not in this PR)

The `wfe_autonomy` ci-poll / panel-retry give-ups also escalate to `pending_human` / linger `panel_degraded` for autonomous runs — a smaller, separate accumulation source in the autonomy driver (not the engine).
