### PR TITLE
fix(delegate): run WFE slice delegates in a writable container

### DIFF
--- a/src/modules/delegates/delegate_run_phases.c
+++ b/src/modules/delegates/delegate_run_phases.c
@@ -333,6 +333,14 @@ void delegate_resolve_worktree(const char *cwd, const char *deleg_id, const char
       }
       else
       {
+         /* An aimee worktree with no managed git-root marker is a WFE per-slice
+          * tree ($AIMEE_HOME/wfe-worktrees/wi_<id>): the delegate OWNS it
+          * exclusively (one implement delegate per slice tree, nothing else looks
+          * at it). It is NOT a shared session tree, so it must be mounted
+          * read-WRITE in a container and carry no host write guard — mark it
+          * DEDICATED. git_root stays empty: the engine reads the delegate's tree
+          * directly, so apply-back/sibling-cleanup are skipped exactly as for the
+          * shared case. */
          char wt_cmd[MAX_PATH_LEN + 64];
          snprintf(wt_cmd, sizeof(wt_cmd), "git -C '%s' rev-parse --show-toplevel 2>/dev/null",
                   anchor);
@@ -343,8 +351,8 @@ void delegate_resolve_worktree(const char *cwd, const char *deleg_id, const char
             wt_out[strcspn(wt_out, "\r\n")] = '\0';
             snprintf(out->worktree_path, sizeof(out->worktree_path), "%s", wt_out);
             out->git_root[0] = '\0';
-            out->shared = 1;
-            aimee_log(LOG_INFO, "delegate", "delegate sharing session worktree %s",
+            out->dedicated = 1;
+            aimee_log(LOG_INFO, "delegate", "delegate owns dedicated worktree %s (read-write)",
                       out->worktree_path);
          }
          free(wt_out);

--- a/src/modules/delegates/delegate_run_phases.h
+++ b/src/modules/delegates/delegate_run_phases.h
@@ -35,6 +35,11 @@ typedef struct
    char work_name[32];
    int attempted; /* a sibling worktree creation was attempted */
    int shared;    /* the delegate shares the parent/session worktree */
+   int dedicated; /* the delegate EXCLUSIVELY owns this pre-existing worktree (a WFE
+                   * per-slice tree, $AIMEE_HOME/wfe-worktrees/wi_<id>): mount it
+                   * read-WRITE in a container and apply no host write guard — nothing
+                   * else looks at that tree. Distinct from a sibling worktree (which
+                   * has a git_root for apply-back) and from shared (read-only). */
 } delegate_worktree_t;
 
 /* Decide and (for write delegates that need isolation) create the delegate's

--- a/src/modules/workspace/workspace_turn.c
+++ b/src/modules/workspace/workspace_turn.c
@@ -3,6 +3,7 @@
  * the detached provider + its runner queue (registry), via the thread-local
  * active-provider seam the file/exec tools resolve through. */
 #include "workspace_turn.h"
+#include "aimee_home.h" /* aimee_home — authorize aimee's own managed worktrees */
 #include "config.h"
 #include "forge_credentials.h"
 #include "git_cred_inject.h"
@@ -319,6 +320,32 @@ int workspace_turn_workspace_authorized(const char *workspace, char *out, size_t
       LOG_ERROR("delegate-sandbox", "workspace '%s' does not resolve (%s)", workspace,
                 strerror(errno));
       return 0;
+   }
+   /* Aimee's OWN managed worktrees — a WFE per-slice tree under
+    * $AIMEE_HOME/wfe-worktrees, or a session worktree under $AIMEE_HOME/.aimee/
+    * worktrees — are isolation trees aimee itself created to hand a delegate, not an
+    * operator directory that must be pre-registered. Authorize a path that resolves
+    * under one of those aimee-owned roots (checked against the canonical AIMEE_HOME,
+    * so an unrelated operator path merely CONTAINING the marker is not authorized),
+    * so a write-capable WFE slice delegate runs in a container instead of falling
+    * back to the in-process host path. */
+   {
+      const char *home = aimee_home();
+      char home_real[MAX_PATH_LEN];
+      if (home && home[0] && realpath(home, home_real))
+      {
+         static const char *const aimee_roots[] = {"wfe-worktrees", ".aimee/worktrees"};
+         for (size_t i = 0; i < sizeof(aimee_roots) / sizeof(aimee_roots[0]); i++)
+         {
+            char root[MAX_PATH_LEN];
+            snprintf(root, sizeof(root), "%s/%s", home_real, aimee_roots[i]);
+            if (cwd_in_workspace(real, root))
+            {
+               snprintf(out, out_cap, "%s", real);
+               return 1;
+            }
+         }
+      }
    }
    config_t cfg;
    config_load(&cfg);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1026,6 +1026,7 @@ void delegate_worker(void *arg)
     * (worktree path/git_root/work_name are hoisted for delegate_fail: cleanup.) */
    int delegate_worktree_attempted = 0;
    int delegate_shared_worktree = 0;
+   int delegate_dedicated_worktree = 0;
    {
       delegate_worktree_t wt;
       delegate_resolve_worktree(cwd, deleg_id, branch, delegate_allows_writes,
@@ -1035,6 +1036,7 @@ void delegate_worker(void *arg)
       snprintf(delegate_work_name, sizeof(delegate_work_name), "%s", wt.work_name);
       delegate_worktree_attempted = wt.attempted;
       delegate_shared_worktree = wt.shared;
+      delegate_dedicated_worktree = wt.dedicated;
    }
 
    if (delegate_allows_writes && delegate_worktree_attempted && !delegate_worktree_path[0])
@@ -1320,9 +1322,13 @@ void delegate_worker(void *arg)
     * bearing alone. */
    const char *container_ws = NULL;
    int container_ws_ro = 1;
-   if (delegate_worktree_path[0] && !delegate_shared_worktree)
+   if (delegate_worktree_path[0] && (delegate_dedicated_worktree || !delegate_shared_worktree))
    {
-      container_ws = delegate_worktree_path; /* this delegate's own tree */
+      /* This delegate's own tree — a sibling worktree, or a WFE per-slice tree it
+       * owns exclusively (dedicated). Either way nothing else looks at it, so mount
+       * it read-WRITE: the delegate's edits land in the tree the engine then diffs
+       * and commits. */
+      container_ws = delegate_worktree_path;
       container_ws_ro = 0;
    }
    else if (cwd[0] == '/' && !delegate_allows_writes)
@@ -1357,11 +1363,11 @@ void delegate_worker(void *arg)
     * above: the intent there is to run IN-PROCESS under the write guard, NOT to hand
     * the delegate a scratch sandbox. Binding with a NULL workspace mints an EMPTY
     * scratch tree and mounts THAT, so the delegate edits files the engine never sees
-    * ("write role reported success but produced no diff") — which stalls every WFE
-    * implement slice (its cwd already IS a dedicated worktree; it needs no sibling
-    * tree, so delegate_needs_worktree is false and container_ws stays NULL). Only
-    * bind a container when there is a real tree to mount; otherwise run in-process in
-    * cwd so writes land where the engine diffs and commits them. */
+    * ("write role reported success but produced no diff"). A WFE implement slice is
+    * NOT this case: its cwd already IS a dedicated per-slice worktree it owns, so
+    * delegate_resolve_worktree marks it dedicated and container_ws points at that
+    * tree read-write (above). Only bind a container when there is a real tree to
+    * mount; otherwise run in-process in cwd so writes land where the engine diffs. */
    int container_bound =
        (detached_bound || !container_ws || !container_ws[0])
            ? 0
@@ -1380,6 +1386,16 @@ void delegate_worker(void *arg)
    }
    else
    {
+      /* Inside a container the mount IS the isolation boundary: the delegate's
+       * writes go through the provider into its own RW-mounted tree, which nothing
+       * else on the host can see. The host-side parent-write guard exists only for
+       * the in-process (same-host) path; here it is redundant and would only risk
+       * blocking a legitimate write, so drop it once a container is actually bound. */
+      if (container_bound > 0)
+      {
+         agent_tools_parent_write_guard_clear();
+         parent_write_guard_active = 0;
+      }
       server_delegate_heartbeat_begin(cctx->background_job_id);
       rc = delegate_run_with_credential_retry(&acfg, target_agent, role, system_prompt, run_prompt,
                                               max_tokens, force_tools, delegate_allows_writes,


### PR DESCRIPTION
## Problem

A WFE `implement` slice runs its delegate in a per-slice worktree at `$AIMEE_HOME/wfe-worktrees/wi_<id>`. That tree is the delegate's **own, sole-writer, isolated** worktree — but `delegate_resolve_worktree` classified it as `shared`, because `worktree_managed_git_root` only recognizes the `/.aimee/worktrees/` marker, not `/wfe-worktrees/`.

A `shared` tree is mounted **read-only** (and a write-capable delegate with a shared tree is left to run in-process under a write guard). Either way the delegate's edits never land in the tree the engine diffs and commits, so every implement slice loops to `max_iters` with *"write role reported success but produced no diff"* — WFEs never reach a PR.

## Fix

Model the tree correctly and let the container be the isolation boundary:

- **`delegate_worktree_t.dedicated`** — a new flag meaning "the delegate exclusively owns this pre-existing worktree." Distinct from a *sibling* worktree (which carries a `git_root` for apply-back) and from *shared* (read-only). `delegate_resolve_worktree` marks a WFE per-slice tree `dedicated` instead of `shared`.
- **Writable mount** — `server_compute` mounts a dedicated tree read-**write** in the container, so the delegate's writes land where the engine reads them.
- **Authorization** — `workspace_turn_workspace_authorized` accepts aimee's *own* managed worktrees (`is_aimee_worktree_path` resolving under `$AIMEE_HOME`) without requiring the operator to pre-register them, so the writable container actually binds for a WFE slice.
- **Drop the host guard in a container** — once a container is bound, the mount is the boundary; the parent-write guard (which exists only for the in-process same-host path) is cleared so it cannot block a legitimate write.

## Testing

- Local syntax check (gcc `-fsyntax-only`) + `clang-format-19 --Werror` clean on all four files. No cmake on the dev host; CI performs the full build + unit suite.
- No existing test asserts the old `shared=1` classification for a `/wfe-worktrees/` path (`test_server_compute.c` stubs `is_aimee_worktree_path` to 0; the seam test covers worktree lifecycle, not resolution). `worktree_managed_git_root` / `is_aimee_worktree_path` primitives remain covered by `test_workspace.c` / `test_agent.c`.
- Behavioral acceptance is the end-to-end WFE run on the deploy host (writable container + landed diff → open PR), validated post-deploy.
