### PR TITLE
fix(delegate): mount disjoint linked worktrees in the sandbox container

### DIFF
--- a/src/modules/delegates/delegate_backend_docker.c
+++ b/src/modules/delegates/delegate_backend_docker.c
@@ -462,28 +462,62 @@ static int docker_build_mounts(docker_state_t *st, const char *real, int read_on
    memcpy(repo, gitdir, rlen);
    repo[rlen] = '\0';
 
-   /* The worktree and its gitdir must live under that repo root, or the nested
-    * overlay does not apply and we would be mounting unrelated trees. */
+   /* Is the worktree physically nested under its repo root? A normal delegate
+    * sibling worktree (under <repo>/.aimee/worktrees/) is; a WFE per-slice
+    * worktree is NOT — it lives outside the repo, under $AIMEE_HOME/wfe-worktrees.
+    * Nesting is not actually required by the mounts below: docker binds each of
+    * the three paths at its own absolute host path, so when they are disjoint they
+    * are simply separate mounts rather than an overlay. What nesting DID provide,
+    * for free, was evidence that the worktree belongs to the repo. For the disjoint
+    * case we cannot lean on physical containment, so prove the two-way git link
+    * explicitly before mounting an out-of-repo tree: the repo's per-worktree admin
+    * dir carries a `gitdir` file that must point back at <real>/.git. Together with
+    * the forward gitlink read above (real/.git -> gitdir under <repo>/.git/worktrees)
+    * this defeats a spoofed .git aimed at an unrelated repo. (`real` is already
+    * realpath-canonicalized and workspace-authorized by the caller.) */
    size_t plen = strlen(repo);
-   if (strncmp(real, repo, plen) != 0 || (real[plen] != '/' && real[plen] != '\0'))
+   int nested = (strncmp(real, repo, plen) == 0 && (real[plen] == '/' || real[plen] == '\0'));
+   if (!nested)
    {
-      aimee_log(LOG_ERROR, "delegate-backend-docker",
-                "workspace '%s' is not inside its repo root '%s'; refusing (the nested "
-                "read-only overlay would not apply)",
-                real, repo);
-      return -1;
+      char backlink[MAX_PATH_LEN], expect[MAX_PATH_LEN], got[MAX_PATH_LEN] = "";
+      if ((size_t)snprintf(backlink, sizeof(backlink), "%s/gitdir", gitdir) >= sizeof(backlink) ||
+          (size_t)snprintf(expect, sizeof(expect), "%s/.git", real) >= sizeof(expect))
+         return -1;
+      FILE *bf = fopen(backlink, "r");
+      if (bf)
+      {
+         if (fgets(got, sizeof(got), bf))
+         {
+            size_t n = strlen(got);
+            while (n && (got[n - 1] == '\n' || got[n - 1] == '\r' || got[n - 1] == ' ' ||
+                         got[n - 1] == '\t'))
+               got[--n] = '\0';
+         }
+         fclose(bf);
+      }
+      if (strcmp(got, expect) != 0)
+      {
+         aimee_log(LOG_ERROR, "delegate-backend-docker",
+                   "workspace '%s' is outside repo root '%s' and its worktree backlink '%s' does "
+                   "not point back to it (got '%s', want '%s'); refusing",
+                   real, repo, backlink, got[0] ? got : "<none>", expect);
+         return -1;
+      }
    }
 
    snprintf(st->workdir, sizeof(st->workdir), "%s", real);
-   /* Order matters: the repo first, then the writable parts nested over it. */
+   /* Order matters when nested: the repo first (read-only base + object store),
+    * then the writable worktree and its gitdir over it. When disjoint the order is
+    * immaterial, but the same three mounts apply. git commit inside still writes to
+    * the :ro object store and fails — intended: commits run server-side. */
    if (docker_add_mount(st, repo, repo, 1) != 0 ||
        docker_add_mount(st, real, real, read_only) != 0 ||
        docker_add_mount(st, gitdir, gitdir, read_only) != 0)
       return -1;
    aimee_log(LOG_INFO, "delegate-backend-docker",
-             "linked worktree '%s': mounting repo '%s' read-only with the worktree and its gitdir "
-             "%s over it",
-             real, repo, read_only ? "read-only" : "writable");
+             "%s worktree '%s': mounting repo '%s' read-only with the worktree and its gitdir %s",
+             nested ? "linked" : "disjoint linked (verified backlink)", real, repo,
+             read_only ? "read-only" : "writable");
    return 0;
 }
 

--- a/src/tests/test_delegate_backend_docker.c
+++ b/src/tests/test_delegate_backend_docker.c
@@ -718,6 +718,60 @@ static void test_docker_workspace_validation_refusals(void)
    free(log);
    b->release(b, state, 0);
 
+   /* A DISJOINT linked worktree — one that lives OUTSIDE its repo root, as a WFE
+    * per-slice worktree does ($AIMEE_HOME/wfe-worktrees/...) — is MOUNTED when its
+    * two-way git link checks out: the repo goes read-only at its own path, and the
+    * worktree and its gitdir are separate writable mounts (no nesting needed). */
+   char drepo[300], dwt[300];
+   snprintf(drepo, sizeof(drepo), "%s/drepo", base);
+   snprintf(dwt, sizeof(dwt), "%s/dwt", base); /* sibling of drepo, NOT nested under it */
+   char dwtadmin[500];
+   snprintf(dwtadmin, sizeof(dwtadmin), "%s/.git/worktrees/s0", drepo);
+   char dcmd[900];
+   snprintf(dcmd, sizeof(dcmd), "mkdir -p %s %s", dwtadmin, dwt);
+   (void)system(dcmd);
+   char dgit[400]; /* forward gitlink: <worktree>/.git -> admin dir under <repo>/.git */
+   snprintf(dgit, sizeof(dgit), "%s/.git", dwt);
+   FILE *dg = fopen(dgit, "w");
+   assert(dg != NULL);
+   fprintf(dg, "gitdir: %s\n", dwtadmin);
+   fclose(dg);
+   char dback[600]; /* backlink: <repo>/.git/worktrees/s0/gitdir -> <worktree>/.git */
+   snprintf(dback, sizeof(dback), "%s/gitdir", dwtadmin);
+   FILE *dbk = fopen(dback, "w");
+   assert(dbk != NULL);
+   fprintf(dbk, "%s\n", dgit);
+   fclose(dbk);
+
+   cfg.workspace = dwt;
+   cfg.workspace_read_only = 0;
+   assert(b->acquire(b, "task-disjoint", &cfg, &state) == 0);
+   {
+      char *l = read_fake_docker_create_argv();
+      assert(l != NULL);
+      char m_repo[700];
+      snprintf(m_repo, sizeof(m_repo), "%s:%s:ro", drepo, drepo);
+      assert(strstr(l, m_repo) != NULL); /* repo read-only at its own path */
+      char m_wt[700];
+      snprintf(m_wt, sizeof(m_wt), "%s:%s", dwt, dwt);
+      assert(strstr(l, m_wt) != NULL); /* worktree writable — a separate, non-nested mount */
+      char m_gd[900];
+      snprintf(m_gd, sizeof(m_gd), "%s:%s", dwtadmin, dwtadmin);
+      assert(strstr(l, m_gd) != NULL); /* per-worktree gitdir writable */
+      free(l);
+   }
+   b->release(b, state, 0);
+
+   /* The SAME disjoint worktree but with a BROKEN backlink (points elsewhere): the
+    * backend cannot prove the worktree belongs to the repo, so it refuses rather
+    * than mount an out-of-repo tree on a one-way gitlink alone. */
+   FILE *dbk2 = fopen(dback, "w");
+   assert(dbk2 != NULL);
+   fprintf(dbk2, "%s/somewhere-else/.git\n", base);
+   fclose(dbk2);
+   cfg.workspace = dwt;
+   assert(b->acquire(b, "task-disjoint-bad", &cfg, &state) == -1);
+
    snprintf(cmd, sizeof(cmd), "rm -rf %s", base);
    (void)system(cmd);
    teardown_fake_docker();


### PR DESCRIPTION
## Problem

Follow-up to #1554. That PR made a WFE per-slice worktree request a **writable container mount** (confirmed engaging in production: `delegate owns dedicated worktree ...s0 (read-write)`). But the container never actually binds, because the docker sandbox backend refuses it one layer down.

`docker_build_mounts` mounts `<repo>:ro` and overlays `<worktree>:rw` + `<gitdir>:rw`, and it treated **"the worktree is nested under its repo root"** as a hard precondition. A WFE per-slice worktree is a legitimate linked worktree but lives **outside** the repo (`$AIMEE_HOME/wfe-worktrees/wi_<id>.s<n>`, while the repo is a registered workspace elsewhere). So the backend refused → the delegate fell back to **in-process, unsandboxed** → its edits never landed in the tree the engine diffs → every implement slice looped to `max_iters`. WFEs never reached a PR.

## Fix (Option A, roundtable-vetted)

Nesting isn't actually required by the mounts — docker binds each of the three paths at its own absolute host path, so disjoint paths are just separate mounts, no overlay needed. What nesting provided *for free* was **evidence the worktree belongs to the repo**. For the disjoint case, prove that link explicitly instead:

- The repo's per-worktree admin dir (`<repo>/.git/worktrees/<name>/gitdir`) carries a **backlink** that must point back at `<worktree>/.git`. Combined with the forward gitlink already read (`<worktree>/.git → <repo>/.git/worktrees/<name>`), this is a **two-way link check** that defeats a spoofed `.git` aimed at an unrelated repo. `real` is already realpath-canonicalized and workspace-authorized by the caller.
- Then mount the same three paths (`repo:ro`, `worktree:rw`, `gitdir:rw`) — separate mounts when disjoint, the existing nested overlay when nested.

The **nested case is unchanged** (physical containment stands as its own evidence; no backlink read there). `git commit` inside the container still fails against the `:ro` object store — intended: commits run server-side.

## Design review

Consulted the roundtable panel on Option A vs relocating WFE worktrees inside the repo (Option B). Panel verdict: no blocking issues. Key points incorporated: the gitdir stays nested (it *is* inside the repo), `repo:ro` exposure is identical to today's scheme, and the containment check must be replaced by an explicit link proof rather than simply removed — which this does via the backlink verification.

## Testing

- `test_delegate_backend_docker`: added a disjoint-worktree case — valid backlink mounts `repo:ro` + separate `worktree:rw` + `gitdir:rw`; broken backlink is refused. Nested case unchanged.
- Local `gcc -fsyntax-only` + `clang-format-19 --Werror` clean. CI runs the full build + suite.
- Behavioral acceptance: WFE E2E on the deploy host (writable container binds → diff lands → PR), validated post-deploy.
