### PR TITLE
refactor(db2): rename db2/learning.h to retire basename collision

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -92,7 +92,7 @@ endif
 # would fail trying to write .d dependency files into non-existent subdirectories.
 _DUMMY := $(shell mkdir -p $(OBJDIR) $(OBJDIR)/posix $(OBJDIR)/linux $(OBJDIR)/mac $(OBJDIR)/windows $(OBJDIR)/tests $(OBJDIR)/db1 $(OBJDIR)/db2)
 
-C_FLAGS = -Os -flto -ffunction-sections -fdata-sections -Wl,--gc-sections -s -Wall -Wextra -Werror -Wno-unused-parameter -Wno-format-truncation -Wno-unused-result -MMD -MP -I. -Iheaders -Ivendor/headers -Imodules/learning -Idb1 -Idb2 -Imodules/config -Imodules/economizer -Imodules/roadmap -Imodules/sandbox -Imodules/lsp -Imodules/skill -Imodules/css -Imodules/webuser -Imodules/memory -Imodules/governance -Imodules/delegates -Imodules/workflows -Imodules/vault -Imodules/git -Imodules/workspace -Imodules/guardrails -Imodules/roundtable -Imodules/audit -Imodules/kb_client -Imodules/agent_eval -Ipipeline -Imodules/protocols/mcp -Imodules/protocols/acp $(VERSION_FLAGS) $(EXTRA_C_FLAGS)
+C_FLAGS = -Os -flto -ffunction-sections -fdata-sections -Wl,--gc-sections -s -Wall -Wextra -Werror -Wno-unused-parameter -Wno-format-truncation -Wno-unused-result -MMD -MP -I. -Iheaders -Ivendor/headers -Idb1 -Idb2 -Imodules/config -Imodules/economizer -Imodules/learning -Imodules/roadmap -Imodules/sandbox -Imodules/lsp -Imodules/skill -Imodules/css -Imodules/webuser -Imodules/memory -Imodules/governance -Imodules/delegates -Imodules/workflows -Imodules/vault -Imodules/git -Imodules/workspace -Imodules/guardrails -Imodules/roundtable -Imodules/audit -Imodules/kb_client -Imodules/agent_eval -Ipipeline -Imodules/protocols/mcp -Imodules/protocols/acp $(VERSION_FLAGS) $(EXTRA_C_FLAGS)
 
 # DB2 client flags are discovered with pkg-config because provider headers are
 # not always installed under the compiler default include path. See

--- a/src/db2/db2_learning.h
+++ b/src/db2/db2_learning.h
@@ -1,9 +1,9 @@
-/* db2/learning.h: learning_signals + learning_proposals primitives.
+/* db2/db2_learning.h: learning_signals + learning_proposals primitives.
  *
  * Owns SQL for the explicit-signal-capture / proposal-gate pipeline
  * documented in docs/proposals/done/learning-signals-router-phase-*.
  * The learning_signal_input_t / learning_proposal_t types live in
- * modules/learning/learning.h (shared basename; see the note there); callers
+ * modules/learning/learning.h (the ensemble-learning types); callers
  * include "learning.h" before this. */
 #ifndef DEC_DB2_LEARNING_H
 #define DEC_DB2_LEARNING_H 1

--- a/src/db2/kb_service_backend_agent.c
+++ b/src/db2/kb_service_backend_agent.c
@@ -17,7 +17,7 @@
 #include "collab_rules.h"
 #include "decision_log.h"
 #include "entity_edges.h"
-#include "learning.h"
+#include "db2_learning.h"
 #include "learning_evidence.h" /* learning_evidence_write_event — session_summary emission */
 #include "learning_implicit.h"
 #include "memory.h"

--- a/src/db2/learning.c
+++ b/src/db2/learning.c
@@ -1,7 +1,7 @@
 /* db2/learning.c: learning_signals + learning_proposals primitives —
  * Postgres via libpq. */
 
-#include "learning.h"
+#include "db2_learning.h"
 #include "db2.h"
 #include "db2_internal.h"
 #include "db_postgres.h"

--- a/src/kb/kb_mining.c
+++ b/src/kb/kb_mining.c
@@ -11,7 +11,7 @@
 #include "cJSON.h"
 #include "config.h"
 #include "db2/artifacts.h"
-#include "db2/learning.h"
+#include "db2/db2_learning.h"
 #include "learning.h"
 #include "db2/db2_internal.h"
 #include "db2/db_postgres.h"

--- a/src/modules/learning/learning.h
+++ b/src/modules/learning/learning.h
@@ -1,14 +1,10 @@
 #ifndef DEC_LEARNING_H
 #define DEC_LEARNING_H 1
 
-/* NOTE: this basename (learning.h) is shared with src/db2/learning.h — a DIFFERENT
- * header (the DB2 SQL layer, guard DEC_DB2_LEARNING_H). Resolution is unambiguous:
- * files under db2/ pick up db2/learning.h via C's same-directory quote-include rule,
- * while everyone else gets THIS header because -Imodules/learning is ordered ahead of
- * -Idb1/-Idb2 in C_FLAGS. The distinct include guards are the safety net: if the wrong
- * header is ever resolved, the expected types go missing and the build fails loudly.
- * Keep -Imodules/learning before -Idb1/-Idb2. Renaming db2/learning.h to
- * db2/db2_learning.h would retire the collision outright (tracked follow-up). */
+/* Ensemble-learning signal/proposal types. The DB2 SQL layer that persists these
+ * lives in db2/db2_learning.h (formerly db2/learning.h; renamed to remove the
+ * basename collision with this header, so -Imodules/learning no longer needs a
+ * special position relative to -Idb1/-Idb2). */
 
 #include <stdint.h>
 

--- a/src/modules/learning/learning_router.c
+++ b/src/modules/learning/learning_router.c
@@ -4,7 +4,7 @@
 #include "db1.h"
 #include "db2/artifacts.h"
 #include "db2/collab_rules.h"
-#include "db2/learning.h"
+#include "db2/db2_learning.h"
 #include "dogfood.h"
 #endif
 #include "cJSON.h"

--- a/src/tests/test_kb_mining.c
+++ b/src/tests/test_kb_mining.c
@@ -1,7 +1,7 @@
 /* test_kb_mining.c: KB continuous mining scheduler/jobs. */
 
 #include "artifacts.h"
-#include "db2/learning.h"
+#include "db2/db2_learning.h"
 #include "db2_test_shim.h"
 #include "db_postgres.h"
 #include "db2_internal.h"


### PR DESCRIPTION
## What

Retires the `learning.h` basename collision surfaced in the Tier-3 modularization review (PR #1557, finding F1 — "correct today, latent-by-design"). Renames the DB2 SQL persistence header `db2/learning.h` → `db2/db2_learning.h` so it no longer shares a basename with the ensemble-learning types header `modules/learning/learning.h`.

## Why

Two different `learning.h` files in the tree forced an invisible, hand-maintained ordering constraint: `-Imodules/learning` had to precede `-Idb1 -Idb2` in the Makefile **and** in 6 CMake `target_include_directories` lists, so that a bare `#include "learning.h"` resolved to the module and not the DB2 header. Nothing enforced that ordering at compile time — a future contributor reordering the flags (or a `compile_commands.json`-driven tool with different search semantics) would silently pick the wrong header.

The reviewers' preferred fix (over a documented-banner workaround) was the rename. This does it.

## Change

- `git mv db2/learning.h db2/db2_learning.h` (distinct basename → collision impossible).
- Repoint the 5 consumers of the DB2 header to `"db2/db2_learning.h"`:
  `db2/learning.c`, `db2/kb_service_backend_agent.c`, `kb/kb_mining.c`,
  `modules/learning/learning_router.c`, `tests/test_kb_mining.c`.
- Normalize `-Imodules/learning` out of its special before-`db1`/`db2` slot into the module group in `src/Makefile` C_FLAGS. Bare `"learning.h"` now unambiguously means the module header everywhere.
- Replace the obsolete collision banner in `modules/learning/learning.h` with a note that the ordering constraint is gone.

Diff is 8 files, +12/−16 — a pure rename plus include repoints and the flag normalization.

## Verification (local, all green)

```
make all                              # full link
make build-integrity                  # output-hash stability
make module-boundary-check            # header provenance
make unit-tests                       # full Rules.mk object set + run
make lint                             # tier-deps, docs-gen, clang-format, boundary
```

Post-rename sweep confirming no straggler references to the old path:

```
$ git grep -n '#include.*"db2/learning\.h"' -- '*.c' '*.h'
(empty)
```

## Scope notes (deliberately NOT in this PR)

- **CMake source-subset gap** (`config_server_api.c`, `config_mode.c`, `config_fields.c` omitted from the `aimee` CMake target) — pre-existing, flagged in the #1561 review as a follow-up. Left out here: the Make build (CI-primary) already compiles them; adding them to the CMake target is unverifiable without a CMake build and risks a link break if those files reference symbols absent from that target. Tracked separately.
- The `-Imodules/learning` **precedence README note** proposed in the #1557 review is now **moot** — there is no ordering constraint left to document.
