### PR TITLE
fix(provider): anthropic buffered-replay stop_sequence + responses-store eviction

### DIFF
--- a/src/server/anthropic_ingress.c
+++ b/src/server/anthropic_ingress.c
@@ -867,7 +867,9 @@ static cJSON *make_message_delta(const parsed_response_t *p, int n_calls)
    cJSON_AddStringToObject(o, "type", "message_delta");
    cJSON *delta = cJSON_AddObjectToObject(o, "delta");
    cJSON_AddStringToObject(delta, "stop_reason", stop);
-   cJSON_AddStringToObject(delta, "stop_sequence", "");
+   /* null (not "") when no stop sequence triggered — matches the Anthropic API and
+    * the streaming path's message_delta (xlate_finish emits null here too). */
+   cJSON_AddNullToObject(delta, "stop_sequence");
    u = cJSON_AddObjectToObject(o, "usage");
    cJSON_AddNumberToObject(u, "output_tokens", p ? p->completion_tokens : 0);
    if (p && p->cache_read_tokens > 0)

--- a/src/server/openai_responses_store.c
+++ b/src/server/openai_responses_store.c
@@ -14,6 +14,7 @@ static struct
    char *transcript;
 } g_entries[OPENAI_RESPONSES_STORE_MAX];
 static int g_count = 0;
+static int g_evict = 0; /* next slot to reuse once full (oldest-first, round-robin) */
 static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
 
 void openai_responses_store_put(const char *resp_id, const char *transcript)
@@ -31,13 +32,23 @@ void openai_responses_store_put(const char *resp_id, const char *transcript)
          return;
       }
    }
-   int slot = (g_count < OPENAI_RESPONSES_STORE_MAX) ? g_count++ : 0;
-   if (slot < OPENAI_RESPONSES_STORE_MAX)
+   int slot;
+   if (g_count < OPENAI_RESPONSES_STORE_MAX)
    {
-      free(g_entries[slot].transcript);
-      snprintf(g_entries[slot].id, sizeof(g_entries[slot].id), "%s", resp_id);
-      g_entries[slot].transcript = strdup(transcript);
+      slot = g_count++;
    }
+   else
+   {
+      /* Full: evict the oldest entry (round-robin in insertion order), matching
+       * openai_runs_store's oldest-slot reuse. Previously every insert past the
+       * cap clobbered slot 0, so slots 1..MAX-1 went permanently stale and only
+       * the newest transcript plus the 255 oldest stayed retrievable. */
+      slot = g_evict;
+      g_evict = (g_evict + 1) % OPENAI_RESPONSES_STORE_MAX;
+   }
+   free(g_entries[slot].transcript);
+   snprintf(g_entries[slot].id, sizeof(g_entries[slot].id), "%s", resp_id);
+   g_entries[slot].transcript = strdup(transcript);
    pthread_mutex_unlock(&g_lock);
 }
 
@@ -73,5 +84,6 @@ void openai_responses_store_reset(void)
       g_entries[i].id[0] = '\0';
    }
    g_count = 0;
+   g_evict = 0;
    pthread_mutex_unlock(&g_lock);
 }

--- a/src/tests/test_anthropic_ingress.c
+++ b/src/tests/test_anthropic_ingress.c
@@ -558,6 +558,9 @@ static void test_emit_message_as_sse_replays_text_only(void)
    assert(strstr(cap.data[2], "\"hello\"") != NULL);
    /* message_delta carries stop_reason verbatim from parsed (end_turn). */
    assert(strstr(cap.data[4], "\"stop_reason\":\"end_turn\"") != NULL);
+   /* stop_sequence is null (not "") when no stop sequence triggered — matches
+    * the Anthropic API and the live streaming path (xlate_finish). */
+   assert(strstr(cap.data[4], "\"stop_sequence\":null") != NULL);
    /* message_start carries input_tokens = 17, output_tokens not yet (it's
     * in message_delta). */
    assert(strstr(cap.data[0], "\"input_tokens\":17") != NULL);

--- a/src/tests/test_openai_responses_store.c
+++ b/src/tests/test_openai_responses_store.c
@@ -60,6 +60,33 @@ int main(void)
       assert(strncmp(small, "0123456789abcdef", sizeof(small) - 1) == 0);
    }
 
+   /* overflow evicts the OLDEST entry (FIFO), not always slot 0. Fill the store
+    * to capacity, then insert past it and confirm the earliest ids drop out in
+    * insertion order while later ids stay retrievable. */
+   {
+      openai_responses_store_reset();
+      const int cap = 256; /* OPENAI_RESPONSES_STORE_MAX */
+      char id[32];
+      for (int i = 0; i < cap; i++)
+      {
+         snprintf(id, sizeof(id), "of_%04d", i);
+         openai_responses_store_put(id, "x");
+      }
+      /* full: every id 0..cap-1 is present */
+      assert(openai_responses_store_get("of_0000", buf, sizeof(buf)) == 1);
+      assert(openai_responses_store_get("of_0255", buf, sizeof(buf)) == 1);
+      /* one more insert evicts the oldest (of_0000), keeps the rest + the new one */
+      openai_responses_store_put("of_0256", "x");
+      assert(openai_responses_store_get("of_0000", buf, sizeof(buf)) == 0);
+      assert(openai_responses_store_get("of_0001", buf, sizeof(buf)) == 1);
+      assert(openai_responses_store_get("of_0256", buf, sizeof(buf)) == 1);
+      /* next insert evicts the next-oldest (of_0001), in order */
+      openai_responses_store_put("of_0257", "x");
+      assert(openai_responses_store_get("of_0001", buf, sizeof(buf)) == 0);
+      assert(openai_responses_store_get("of_0002", buf, sizeof(buf)) == 1);
+      assert(openai_responses_store_get("of_0257", buf, sizeof(buf)) == 1);
+   }
+
    /* reset drops everything */
    {
       openai_responses_store_reset();


### PR DESCRIPTION
## What

Two provider/HTTP **correctness bug fixes** surfaced by a cross-file audit, each with new test coverage. +50/−6.

## Bug 1 — Anthropic buffered-replay `stop_sequence` drift

`make_message_delta()` in `anthropic_ingress.c` (the path that replays a *buffered* upstream reply as an SSE stream) emitted `delta.stop_sequence` as `""`:

```c
cJSON_AddStringToObject(delta, "stop_sequence", "");   // ← drift
```

Every other `message_delta` emitter uses **`null`** — the three streaming `xlate_*` paths in this same file (lines 471, 621, 735) and `aimee_frontend_anthropic.c:325` — which is what the Anthropic API sends when no stop sequence triggered the stop. So a client that distinguishes `null` from `""` saw a different `stop_sequence` depending on whether the upstream reply happened to be streamed or buffered-then-replayed.

Fixed to `cJSON_AddNullToObject(delta, "stop_sequence")`. Pinned by a new assertion in the existing P2c replay test (`\"stop_sequence\":null` in the captured `message_delta` payload).

## Bug 2 — `openai_responses_store` clobbered slot 0 on overflow

`openai_responses_store_put`, once the store held its 256-entry cap, always reused **slot 0**:

```c
int slot = (g_count < OPENAI_RESPONSES_STORE_MAX) ? g_count++ : 0;   // ← always slot 0 when full
```

So every insert past the cap overwrote whatever was in slot 0 — **not the oldest entry** — leaving slots 1..255 permanently stale. Only the newest transcript plus the 255 oldest stayed retrievable; everything in between was silently dropped. A `/v1/responses` continuation lookup under sustained load could miss a transcript that was neither new nor oldest.

Replaced with round-robin oldest-first (FIFO) eviction via a `g_evict` cursor, matching the sibling `openai_runs_store`'s "reuse the oldest slot" behavior. New test fills the store to capacity and past it, asserting the earliest ids drop out in insertion order while later ids stay retrievable.

## Verification (local, all green, real exit codes checked)

`make all` · `make build-integrity` · `make module-boundary-check` · `make unit-tests` (incl. the two new cases) · `make lint`

## Scope note

The related refactors flagged in the same audit — extracting the duplicated `agent_result_t` cost-accounting block and deduplicating the live-vs-buffered Anthropic SSE frame builders — are **not** in this PR. This change is scoped to the two behavior bugs; those are separate refactors and would dilute the bug-fix review.
