### PR TITLE
bench(bucket3): deterministic validation corpora for blast_radius + delegate_graph

### DIFF
--- a/benchmarks/bucket3-defaults/VALIDATION.md
+++ b/benchmarks/bucket3-defaults/VALIDATION.md
@@ -91,23 +91,29 @@ harness exist) · **⬜ needed** (must be authored).
 - **Pass bar:** ≥ 0.9 precision on the labeled traces with no false-fire on the negative controls,
   per detector, before any is considered for default-on.
 
-## guardrails_blast_radius_advisory_enabled  — 🟡 partial (deterministic)
+## guardrails_blast_radius_advisory_enabled  — ✅ built (deterministic)
 
 - **What it gates:** surfaces the code-graph structural blast radius (dependent files) before an
   edit; advisory and fail-open.
-- **Corpus:** deterministic — a fixture repo + a set of `(edited file → expected dependent-file
-  set)` pairs. Extend `benchmarks/graph` / the code-audit graph fixtures.
+- **Corpus:** [`blast_radius_corpus.json`](blast_radius_corpus.json) — 4 fixtures / 6 cases, each a
+  small code graph (files with exports + imports) with the ground-truth `(edited file → expected
+  dependents + dependencies)`. Faithful to `db2_code_index_blast_radius` (src/db2/code_index.c):
+  covers the basic importer set, the `has_exports` gate (no exports ⇒ no dependents), the hub
+  threshold, and direct-vs-transitive (only direct importers advised).
 - **A/B / metric:** it either lists the true dependent set or not; **precision/recall of the
   advised dependent files** vs the graph ground truth. No LLM in the loop, so this is a clean
   deterministic gate.
 - **Pass bar:** recall = 1.0 (never miss a real dependent) with precision ≥ 0.8 (few spurious
   files) on the fixture set.
 
-## delegate_graph_context_enabled  — ⬜ needed (deterministic)
+## delegate_graph_context_enabled  — ✅ built (deterministic)
 
 - **What it gates:** prepends code-graph structural context to a delegate prompt; fail-open.
-- **Corpus:** deterministic — `(repo, target symbol/role) → expected structural context block`.
-  ~10 fixtures across a small sample repo.
+- **Corpus:** [`delegate_graph_corpus.json`](delegate_graph_corpus.json) — 2 fixtures / 4 cases.
+  `delegate_inject_graph_context` builds its block from the same `kb_client_index_blast_radius`
+  computation, so this shares the blast-radius graph: each case is a delegate prompt referencing a
+  file with the neighbours the injected block must contain, plus fail-open cases (isolated file /
+  no referenced path ⇒ no block) and a must-not-contain (transitive file) control.
 - **A/B / metric:** assert the injected context contains the true neighbours (callers/callees,
   defining file) and stays within the budget. Since it's fail-open and advisory, the gate is
   "context is correct + bounded", not a downstream quality metric.

--- a/benchmarks/bucket3-defaults/blast_radius_corpus.json
+++ b/benchmarks/bucket3-defaults/blast_radius_corpus.json
@@ -1,0 +1,70 @@
+{
+  "version": 1,
+  "flag": "guardrails_blast_radius_advisory_enabled",
+  "description": "Deterministic validation corpus for the code-graph blast-radius advisory (db2_code_index_blast_radius, src/db2/code_index.c). No LLM in the loop: each fixture is a small code graph (files with their exports + imports), and each case is an edited file with the ground-truth dependent + dependency sets. A harness loads a fixture into an isolated temp schema (INSERT into files / file_exports / file_imports), runs db2_code_index_blast_radius(project, edited_file), and scores precision/recall of the advised dependents against `expected_dependents`.",
+  "computation_notes": [
+    "DEPENDENTS = other files whose file_imports.name LIKE '%<edited_file_path>%', but ONLY when the edited file itself has >=1 row in file_exports (the has_exports gate). A file with no exports yields NO dependents even if others import it.",
+    "The edited file is excluded from its own dependent list.",
+    "DEPENDENCIES = DISTINCT file_imports.name for the edited file (raw import strings, not resolved to files).",
+    "Import names are matched by substring against the edited path, so an import must contain the edited file's path to count as a dependent edge."
+  ],
+  "pass_bar": "recall(dependents) = 1.0 (never miss a real dependent) AND precision(dependents) >= 0.8, aggregated across all cases.",
+  "fixtures": [
+    {
+      "project": "br_basic",
+      "description": "core.c is imported by api.c and cli.c (dependents); it imports util.h (dependency). util.c has exports but nobody imports 'src/util.c'. lonely.c is isolated.",
+      "files": [
+        {"path": "src/core.c", "exports": ["core_init", "core_run"], "imports": ["src/util.h"]},
+        {"path": "src/api.c", "exports": ["api_serve"], "imports": ["src/core.c", "src/util.h"]},
+        {"path": "src/cli.c", "exports": ["cli_main"], "imports": ["src/core.c"]},
+        {"path": "src/util.c", "exports": ["util_help"], "imports": []},
+        {"path": "src/lonely.c", "exports": ["lonely"], "imports": []}
+      ],
+      "cases": [
+        {"edited": "src/core.c", "expected_dependents": ["src/api.c", "src/cli.c"], "expected_dependencies": ["src/util.h"], "notes": "two importers; one dependency"},
+        {"edited": "src/lonely.c", "expected_dependents": [], "expected_dependencies": [], "notes": "isolated: no importers, no imports"},
+        {"edited": "src/api.c", "expected_dependents": [], "expected_dependencies": ["src/core.c", "src/util.h"], "notes": "a leaf consumer: imported by nobody, imports two"}
+      ]
+    },
+    {
+      "project": "br_no_exports_gate",
+      "description": "helper.c has NO exports but IS imported by two files. The has_exports gate must suppress its dependents (advisory only fires for files that export a public surface).",
+      "files": [
+        {"path": "src/helper.c", "exports": [], "imports": []},
+        {"path": "src/one.c", "exports": ["one"], "imports": ["src/helper.c"]},
+        {"path": "src/two.c", "exports": ["two"], "imports": ["src/helper.c"]}
+      ],
+      "cases": [
+        {"edited": "src/helper.c", "expected_dependents": [], "expected_dependencies": [], "notes": "no exports -> gate suppresses dependents despite two importers"}
+      ]
+    },
+    {
+      "project": "br_hub",
+      "description": "shared.c is a hub imported by six files -> exercises the BR_ADVISORY_HUB_THRESHOLD 'hub' note in the formatter.",
+      "files": [
+        {"path": "src/shared.c", "exports": ["shared_api"], "imports": []},
+        {"path": "src/m1.c", "exports": ["m1"], "imports": ["src/shared.c"]},
+        {"path": "src/m2.c", "exports": ["m2"], "imports": ["src/shared.c"]},
+        {"path": "src/m3.c", "exports": ["m3"], "imports": ["src/shared.c"]},
+        {"path": "src/m4.c", "exports": ["m4"], "imports": ["src/shared.c"]},
+        {"path": "src/m5.c", "exports": ["m5"], "imports": ["src/shared.c"]},
+        {"path": "src/m6.c", "exports": ["m6"], "imports": ["src/shared.c"]}
+      ],
+      "cases": [
+        {"edited": "src/shared.c", "expected_dependents": ["src/m1.c", "src/m2.c", "src/m3.c", "src/m4.c", "src/m5.c", "src/m6.c"], "expected_dependencies": [], "expected_hub": true, "notes": "6 dependents -> hub advisory"}
+      ]
+    },
+    {
+      "project": "br_transitive",
+      "description": "Confirms the advisory is DIRECT-importers only (not transitive). db.c is imported by store.c; store.c is imported by app.c. Editing db.c must advise store.c ONLY, not app.c (app.c imports store.c, not db.c).",
+      "files": [
+        {"path": "src/db.c", "exports": ["db_open"], "imports": []},
+        {"path": "src/store.c", "exports": ["store_get"], "imports": ["src/db.c"]},
+        {"path": "src/app.c", "exports": ["app_main"], "imports": ["src/store.c"]}
+      ],
+      "cases": [
+        {"edited": "src/db.c", "expected_dependents": ["src/store.c"], "expected_dependencies": [], "notes": "direct importer only; app.c is transitive and must NOT appear"}
+      ]
+    }
+  ]
+}

--- a/benchmarks/bucket3-defaults/delegate_graph_corpus.json
+++ b/benchmarks/bucket3-defaults/delegate_graph_corpus.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "flag": "delegate_graph_context_enabled",
+  "description": "Deterministic validation corpus for graph-informed delegation (delegate_inject_graph_context, src/modules/delegates/delegate_prompt.c). It prepends a structural-context block built ONLY from the deterministic code graph (kb_client_index_blast_radius) — the callers/callees of files the prompt references. No LLM in the loop. Each fixture is a small code graph (shared with blast_radius_corpus.json); each case is a delegate prompt that references a file, plus the ground-truth structural neighbours the injected block must contain and the budget it must not exceed. Harness: load the fixture graph into an isolated temp schema, call delegate_inject_graph_context(prompt, cwd), assert the returned block contains every expected neighbour and stays within budget; fail-open (NULL) is correct only when there are no referenced indexed paths.",
+  "computation_notes": [
+    "The injected neighbours for a referenced file are its blast-radius dependents + dependencies (see blast_radius_corpus.json computation_notes: dependents gated on has_exports; dependencies are the file's imports).",
+    "FAIL-OPEN: NULL block is expected when the flag is off, the prompt references no indexed path, or the file has no structural edges. A case with expect_block=false asserts the fail-open path.",
+    "The block is bounded; assert length <= budget_chars (the configured assembly budget) so a hub file cannot blow the prompt."
+  ],
+  "pass_bar": "For every expect_block=true case the injected block contains ALL expected_neighbours and never exceeds budget_chars; every expect_block=false case returns no block (fail-open). 100% on both.",
+  "shared_graph": "Reuses the br_basic / br_transitive fixtures from blast_radius_corpus.json.",
+  "fixtures": [
+    {
+      "project": "dg_basic",
+      "files": [
+        {"path": "src/core.c", "exports": ["core_init", "core_run"], "imports": ["src/util.h"]},
+        {"path": "src/api.c", "exports": ["api_serve"], "imports": ["src/core.c", "src/util.h"]},
+        {"path": "src/cli.c", "exports": ["cli_main"], "imports": ["src/core.c"]},
+        {"path": "src/util.c", "exports": ["util_help"], "imports": []},
+        {"path": "src/isolated.c", "exports": ["iso"], "imports": []}
+      ],
+      "cases": [
+        {"id": "dg01", "prompt": "Refactor the retry logic in src/core.c to use exponential backoff.", "references": "src/core.c", "expect_block": true, "expected_neighbours": ["src/api.c", "src/cli.c", "src/util.h"], "notes": "dependents api.c/cli.c + dependency util.h"},
+        {"id": "dg02", "prompt": "Update src/isolated.c to fix the off-by-one.", "references": "src/isolated.c", "expect_block": false, "notes": "no structural edges -> fail-open, no block"},
+        {"id": "dg03", "prompt": "Add a health endpoint (no file referenced yet).", "references": null, "expect_block": false, "notes": "no indexed path referenced -> fail-open"}
+      ]
+    },
+    {
+      "project": "dg_transitive",
+      "files": [
+        {"path": "src/db.c", "exports": ["db_open"], "imports": []},
+        {"path": "src/store.c", "exports": ["store_get"], "imports": ["src/db.c"]},
+        {"path": "src/app.c", "exports": ["app_main"], "imports": ["src/store.c"]}
+      ],
+      "cases": [
+        {"id": "dg04", "prompt": "Change the connection pooling in src/db.c.", "references": "src/db.c", "expect_block": true, "expected_neighbours": ["src/store.c"], "must_not_contain": ["src/app.c"], "notes": "direct importer store.c only; app.c is transitive and must NOT be injected"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Deterministic Bucket-3 validation corpora: blast_radius + delegate_graph

Builds the two **deterministic (no-LLM)** Bucket-3 corpora that `benchmarks/bucket3-defaults/VALIDATION.md` flagged as the cheapest to finish (no baseline-drift management). Completes the corpus half of the deferred bucket-3 task; `memory_negation` was the first Bucket-3 flag graduated this way.

- **`blast_radius_corpus.json`** (4 fixtures / 6 cases) — each a small code graph (files with exports + imports) with ground-truth `(edited file → expected dependents + dependencies)`, faithful to `db2_code_index_blast_radius`. Covers the basic importer set, the `has_exports` gate (no exports ⇒ no dependents), the hub threshold, and **direct-vs-transitive** (only direct importers advised).
- **`delegate_graph_corpus.json`** (2 fixtures / 4 cases) — `delegate_inject_graph_context` builds its block from the *same* `kb_client_index_blast_radius`, so this shares the graph: a prompt references a file → the injected block must contain the true neighbours; plus **fail-open** cases (isolated file / no referenced path ⇒ no block) and a **must-not-contain** transitive control.

Both are faithful to the actual graph computation (documented in each corpus's `computation_notes`) and specify the pass bar. **Harness** — load a fixture into the isolated temp-store (INSERT `files`/`file_exports`/`file_imports`, run the graph fn, score precision/recall), reusing the negation-eval temp-store infra — is the runnable follow-on (it needs a disposable Postgres; the box's docker access is currently intermittent post-OS-update).
