### PR TITLE
refactor(provider): extract agent_ingress_record_cost() from 7 duplicated blocks

### DIFF
--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -147,6 +147,16 @@ void agent_record_token_audit(const agent_result_t *result, const char *role, co
  * dropping them when the provider stream errors mid-flight. */
 void agent_record_token_audit_kind(const agent_result_t *result, const char *role,
                                    const char *source, const char *usage_kind);
+/* Build a token-audit row for a provider ingress path from raw usage counts and
+ * record it, folding the memset+snprintf+field-copy boilerplate the provider
+ * ingress handlers otherwise repeat per call site. requested_model/stop_reason
+ * tolerate NULL (stored as ""). kind==NULL records via agent_record_token_audit
+ * (i.e. "realized"); a non-NULL kind ("realized"/"partial"/...) routes through
+ * agent_record_token_audit_kind. The caller owns the enable/threshold guard. */
+void agent_ingress_record_cost(const char *agent_name, const char *agent_model,
+                               const char *requested_model, const char *stop_reason,
+                               int prompt_tokens, int completion_tokens, int cache_write_tokens,
+                               int cache_read_tokens, const char *source, const char *kind);
 /* Record a context-economizer ledger row (usage_kind="avoided", FORECAST-only —
  * see context_reduce.h). Forward-declared struct so this broad header need not
  * pull in context_reduce.h; the caller includes it for the full type. */

--- a/src/server/agent_logging.c
+++ b/src/server/agent_logging.c
@@ -209,6 +209,28 @@ void agent_record_token_audit(const agent_result_t *result, const char *role, co
    agent_record_token_audit_kind(result, role, source, "realized");
 }
 
+void agent_ingress_record_cost(const char *agent_name, const char *agent_model,
+                               const char *requested_model, const char *stop_reason,
+                               int prompt_tokens, int completion_tokens, int cache_write_tokens,
+                               int cache_read_tokens, const char *source, const char *kind)
+{
+   agent_result_t ar;
+   memset(&ar, 0, sizeof(ar));
+   snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", agent_name ? agent_name : "");
+   snprintf(ar.model, sizeof(ar.model), "%s", agent_model ? agent_model : "");
+   snprintf(ar.requested_model, sizeof(ar.requested_model), "%s",
+            requested_model ? requested_model : "");
+   snprintf(ar.stop_reason, sizeof(ar.stop_reason), "%s", stop_reason ? stop_reason : "");
+   ar.prompt_tokens = prompt_tokens;
+   ar.completion_tokens = completion_tokens;
+   ar.cache_write_tokens = cache_write_tokens;
+   ar.cache_read_tokens = cache_read_tokens;
+   if (kind)
+      agent_record_token_audit_kind(&ar, "", source, kind);
+   else
+      agent_record_token_audit(&ar, "", source);
+}
+
 void agent_record_token_audit_kind(const agent_result_t *result, const char *role,
                                    const char *source, const char *usage_kind)
 {

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -635,20 +635,11 @@ static int messages_buffered(const char *body, char *resp, int cap)
       /* Cost accounting: the Anthropic /v1/messages ingress is a raw provider
        * proxy (no agent_log_call), so record this turn's spend, billed against
        * the served model and tagged as ingress. */
-      agent_result_t ar;
-      memset(&ar, 0, sizeof(ar));
-      snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
-      snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
-      /* Claude Code's requested model is recorded separately; aimee serves its
-       * configured primary, so requested and served typically differ. */
-      snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model ? model : "");
-      snprintf(ar.stop_reason, sizeof(ar.stop_reason), "%s", parsed.stop_reason);
-      ar.prompt_tokens = parsed.prompt_tokens;
-      ar.completion_tokens = parsed.completion_tokens;
-      ar.cache_write_tokens = parsed.cache_write_tokens;
-      ar.cache_read_tokens = parsed.cache_read_tokens;
       if (agent_ingress_accounting_enabled())
-         agent_record_token_audit(&ar, "", "anthropic-ingress");
+         agent_ingress_record_cost(ag->name, ag->model, model, parsed.stop_reason,
+                                   parsed.prompt_tokens, parsed.completion_tokens,
+                                   parsed.cache_write_tokens, parsed.cache_read_tokens,
+                                   "anthropic-ingress", NULL);
    }
 
    mint_msg_id(msg_id, sizeof(msg_id));
@@ -1064,19 +1055,10 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
             /* Cost accounting (mirror the buffered path). */
             if ((parsed.prompt_tokens > 0 || parsed.completion_tokens > 0) &&
                 agent_ingress_accounting_enabled())
-            {
-               agent_result_t ar;
-               memset(&ar, 0, sizeof(ar));
-               snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
-               snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
-               snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model ? model : "");
-               snprintf(ar.stop_reason, sizeof(ar.stop_reason), "%s", parsed.stop_reason);
-               ar.prompt_tokens = parsed.prompt_tokens;
-               ar.completion_tokens = parsed.completion_tokens;
-               ar.cache_write_tokens = parsed.cache_write_tokens;
-               ar.cache_read_tokens = parsed.cache_read_tokens;
-               agent_record_token_audit(&ar, "", "anthropic-ingress");
-            }
+               agent_ingress_record_cost(ag->name, ag->model, model, parsed.stop_reason,
+                                         parsed.prompt_tokens, parsed.completion_tokens,
+                                         parsed.cache_write_tokens, parsed.cache_read_tokens,
+                                         "anthropic-ingress", NULL);
             agent_free_parsed_response(&parsed);
          }
          else
@@ -1095,20 +1077,10 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                /* Cost accounting (mirror the buffered path). */
                if ((parsed.prompt_tokens > 0 || parsed.completion_tokens > 0) &&
                    agent_ingress_accounting_enabled())
-               {
-                  agent_result_t ar;
-                  memset(&ar, 0, sizeof(ar));
-                  snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
-                  snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
-                  snprintf(ar.requested_model, sizeof(ar.requested_model), "%s",
-                           model ? model : "");
-                  snprintf(ar.stop_reason, sizeof(ar.stop_reason), "%s", parsed.stop_reason);
-                  ar.prompt_tokens = parsed.prompt_tokens;
-                  ar.completion_tokens = parsed.completion_tokens;
-                  ar.cache_write_tokens = parsed.cache_write_tokens;
-                  ar.cache_read_tokens = parsed.cache_read_tokens;
-                  agent_record_token_audit(&ar, "", "anthropic-ingress");
-               }
+                  agent_ingress_record_cost(ag->name, ag->model, model, parsed.stop_reason,
+                                            parsed.prompt_tokens, parsed.completion_tokens,
+                                            parsed.cache_write_tokens, parsed.cache_read_tokens,
+                                            "anthropic-ingress", NULL);
                agent_free_parsed_response(&parsed);
             }
             else
@@ -1171,19 +1143,10 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
        * aborted stream that still observed usage is recorded as partial so the
        * observed tokens are not silently lost. */
       if ((relay.input_tokens > 0 || relay.output_tokens > 0) && agent_ingress_accounting_enabled())
-      {
-         agent_result_t ar;
-         memset(&ar, 0, sizeof(ar));
-         snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
-         snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
-         snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model ? model : "");
-         ar.prompt_tokens = relay.input_tokens;
-         ar.completion_tokens = relay.output_tokens;
-         ar.cache_write_tokens = relay.cache_write_tokens;
-         ar.cache_read_tokens = relay.cache_read_tokens;
-         agent_record_token_audit_kind(&ar, "", "anthropic-ingress",
-                                       stream_status == 200 ? "realized" : "partial");
-      }
+         agent_ingress_record_cost(ag->name, ag->model, model, NULL, relay.input_tokens,
+                                   relay.output_tokens, relay.cache_write_tokens,
+                                   relay.cache_read_tokens, "anthropic-ingress",
+                                   stream_status == 200 ? "realized" : "partial");
       sse_parser_free(&relay.parser);
       free(relay.data);
       goto cleanup;
@@ -1237,17 +1200,9 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
        * the legacy translator's estimate basis), output tapped from the IR
        * TURN_STOP delta. */
       if ((input_est > 0 || pc.ir_usage_out > 0) && agent_ingress_accounting_enabled())
-      {
-         agent_result_t ar;
-         memset(&ar, 0, sizeof(ar));
-         snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
-         snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
-         snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model ? model : "");
-         ar.prompt_tokens = input_est;
-         ar.completion_tokens = (int)pc.ir_usage_out;
-         agent_record_token_audit_kind(&ar, "", "anthropic-ingress",
-                                       ir_status == 200 ? "realized" : "partial");
-      }
+         agent_ingress_record_cost(ag->name, ag->model, model, NULL, input_est,
+                                   (int)pc.ir_usage_out, 0, 0, "anthropic-ingress",
+                                   ir_status == 200 ? "realized" : "partial");
       goto cleanup;
    }
 
@@ -1279,16 +1234,9 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
       anthropic_stream_get_usage(xl, &in_tok, &out_tok, &cr_tok);
       if ((in_tok > 0 || out_tok > 0) && agent_ingress_accounting_enabled())
       {
-         agent_result_t ar;
-         memset(&ar, 0, sizeof(ar));
-         snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
-         snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
-         snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model ? model : "");
-         ar.prompt_tokens = in_tok;
-         ar.completion_tokens = out_tok;
-         ar.cache_read_tokens = cr_tok;
-         agent_record_token_audit_kind(&ar, "", "anthropic-ingress",
-                                       xlate_status == 200 ? "realized" : "partial");
+         agent_ingress_record_cost(ag->name, ag->model, model, NULL, in_tok, out_tok, 0, cr_tok,
+                                   "anthropic-ingress",
+                                   xlate_status == 200 ? "realized" : "partial");
       }
    }
 

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1245,18 +1245,11 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
       /* Cost accounting: streaming /v1/responses runs the provider call directly.
        * agent_execute_messages returns a parsed_response_t (no model/agent name),
        * so synthesize the fields the audit needs from the served agent. */
-      agent_result_t ar;
-      memset(&ar, 0, sizeof(ar));
-      snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
-      snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
-      snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model);
-      ar.prompt_tokens = parsed.prompt_tokens;
-      ar.completion_tokens = parsed.completion_tokens;
-      ar.cache_write_tokens = parsed.cache_write_tokens;
-      ar.cache_read_tokens = parsed.cache_read_tokens;
-      snprintf(ar.stop_reason, sizeof(ar.stop_reason), "%s", parsed.stop_reason);
       if (agent_ingress_accounting_enabled())
-         agent_record_token_audit(&ar, "", "openai-ingress");
+         agent_ingress_record_cost(ag->name, ag->model, model, parsed.stop_reason,
+                                   parsed.prompt_tokens, parsed.completion_tokens,
+                                   parsed.cache_write_tokens, parsed.cache_read_tokens,
+                                   "openai-ingress", NULL);
    }
 
    if (erc == 0 && parsed.is_tool_call && parsed.call_count > 0)

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -278,6 +278,22 @@ void agent_record_token_audit_kind(const agent_result_t *result, const char *rol
    (void)source;
    (void)usage_kind;
 }
+void agent_ingress_record_cost(const char *agent_name, const char *agent_model,
+                               const char *requested_model, const char *stop_reason,
+                               int prompt_tokens, int completion_tokens, int cache_write_tokens,
+                               int cache_read_tokens, const char *source, const char *kind)
+{
+   (void)agent_name;
+   (void)agent_model;
+   (void)requested_model;
+   (void)stop_reason;
+   (void)prompt_tokens;
+   (void)completion_tokens;
+   (void)cache_write_tokens;
+   (void)cache_read_tokens;
+   (void)source;
+   (void)kind;
+}
 /* Enable accounting in this unit so the tap/record path is exercised. */
 int agent_ingress_accounting_enabled(void)
 {

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -284,6 +284,22 @@ void agent_record_reduce_ledger(const struct reduce_result_s *r, const char *mod
    (void)agent_name;
    (void)role;
 }
+void agent_ingress_record_cost(const char *agent_name, const char *agent_model,
+                               const char *requested_model, const char *stop_reason,
+                               int prompt_tokens, int completion_tokens, int cache_write_tokens,
+                               int cache_read_tokens, const char *source, const char *kind)
+{
+   (void)agent_name;
+   (void)agent_model;
+   (void)requested_model;
+   (void)stop_reason;
+   (void)prompt_tokens;
+   (void)completion_tokens;
+   (void)cache_write_tokens;
+   (void)cache_read_tokens;
+   (void)source;
+   (void)kind;
+}
 /* Enable accounting in this unit so the tap/record path is exercised. */
 int agent_ingress_accounting_enabled(void)
 {

--- a/src/tests/test_anthropic_http_streaming_p2c.c
+++ b/src/tests/test_anthropic_http_streaming_p2c.c
@@ -278,6 +278,22 @@ void agent_record_reduce_ledger(const struct reduce_result_s *r, const char *mod
    (void)agent_name;
    (void)role;
 }
+void agent_ingress_record_cost(const char *agent_name, const char *agent_model,
+                               const char *requested_model, const char *stop_reason,
+                               int prompt_tokens, int completion_tokens, int cache_write_tokens,
+                               int cache_read_tokens, const char *source, const char *kind)
+{
+   (void)agent_name;
+   (void)agent_model;
+   (void)requested_model;
+   (void)stop_reason;
+   (void)prompt_tokens;
+   (void)completion_tokens;
+   (void)cache_write_tokens;
+   (void)cache_read_tokens;
+   (void)source;
+   (void)kind;
+}
 int agent_ingress_accounting_enabled(void)
 {
    return 1;


### PR DESCRIPTION
## What

Extracts a single `agent_ingress_record_cost()` helper from **7 copies** of the same cost-accounting boilerplate across the provider ingress paths. Behavior-preserving dedup.

## The duplication

Each provider ingress path hand-rolled the same ~11 lines:

```c
agent_result_t ar;
memset(&ar, 0, sizeof(ar));
snprintf(ar.agent_name, ...);
snprintf(ar.model, ...);
snprintf(ar.requested_model, ...);
snprintf(ar.stop_reason, ...);           // (some copies)
ar.prompt_tokens = ...;
ar.completion_tokens = ...;
ar.cache_write_tokens = ...;             // (some copies)
ar.cache_read_tokens = ...;
agent_record_token_audit[_kind](&ar, "", source[, kind]);
```

7 copies: **6 in `anthropic_http.c`** (buffered, two IR-parse branches, native relay, IR-relay, OpenAI-via-translator streaming) and **1 in `openai_chat.c`** (`/v1/responses` streaming).

## The helper

```c
void agent_ingress_record_cost(const char *agent_name, const char *agent_model,
                               const char *requested_model, const char *stop_reason,
                               int prompt_tokens, int completion_tokens, int cache_write_tokens,
                               int cache_read_tokens, const char *source, const char *kind);
```

Lives in `agent_logging.c` next to `agent_record_token_audit`. `requested_model`/`stop_reason` tolerate NULL; `kind == NULL` records via `agent_record_token_audit` (i.e. "realized"), a non-NULL kind ("realized"/"partial") via `agent_record_token_audit_kind`. Every call site collapses to one call.

## Why it's behavior-preserving

- Each site passes **exactly** the values it filled before. Copies that never set `stop_reason` pass `NULL` → `""`; copies that never set a cache field pass `0`. Both match the prior `memset`-zeroed struct — identical audit row.
- The per-site **enable/threshold guards are unchanged** — they differ across sites (some check `prompt>0||completion>0`, some only `accounting_enabled()`), so they stay at the call sites; only the fill+record folds into the helper.
- The four `openai_chat.c` audits that pass a fully-populated `agent_result_t` (the real execution result, not a synthesized ingress row) are **left as-is** — they are not this boilerplate.

## Tests

The three `anthropic-http` unit tests stub the audit sink as no-ops (they validate the SSE usage tap, not audit-row content). Added a matching no-op stub for the new helper in each, preserving their exact prior behavior. `test_token_audit` continues to cover the underlying `agent_record_token_audit(_kind)`.

## Not included

The live-vs-buffered Anthropic SSE frame-builder dedup flagged in the same audit (larger, separate refactor). The `stop_sequence` drift in those builders was already fixed in #1570.

## Verification (local, all green, real exit codes checked)

`make all` · `make build-integrity` · `make module-boundary-check` · `make unit-tests` · `make lint`
