### PR TITLE
docs(config): memory_negation_enabled default is now 1 (graduated)

### DIFF
--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -710,7 +710,8 @@ typedef struct config
    int kb_search_max_results;
 
    /* Negation and explicit-absence memory.
-    * memory_negation_enabled: 0 = disabled (default), 1 = enabled.
+    * memory_negation_enabled: 0 = disabled, 1 = enabled (default; graduated
+    *   from Bucket 3 after the negation A/B — see benchmarks/bucket3-defaults).
     *   When enabled, insert/update computes not_<token> synthetic terms and
     *   writes them to the negation_tokens column; negated queries also use
     *   negation lexical matching for negative facts. */


### PR DESCRIPTION
Trivial doc-drift fix. The `config.h` comment for `memory_negation_enabled` still read `0 = disabled (default)` after the flag graduated to default-on (`config.c:674` sets it to `1`). Corrects the comment to match the shipped default and points at `benchmarks/bucket3-defaults` for the A/B that graduated it. Comment-only; no behavior change.