### PR TITLE
feat(v1): guard against order-dependent /v1 route shadowing

### DIFF
--- a/scripts/check-v1-route-order.py
+++ b/scripts/check-v1-route-order.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Guard: the /v1 route table's first-match dispatch stays order-correct.
+
+`server_http_routes.c` resolves a request by scanning `g_v1_routes[]` top-to-
+bottom and returning the FIRST row whose verb+path match (RM_EXACT exact, or
+RM_PREFIX by `strncmp` + a single `{id}` segment + optional suffix). When two
+rows can both match one request, ARRAY ORDER silently decides the winner — e.g.
+`GET /v1/workflow/items/all` (exact) vs the `GET /v1/workflow/items/` prefix
+(which would treat "all" as an {id}). The exact row must appear first, or the
+dedicated endpoint is shadowed by the generic one.
+
+This check makes that ordering constraint explicit and machine-checked:
+  1. parse g_v1_routes[] in source order,
+  2. replicate the C matcher,
+  3. probe one representative request per route,
+  4. for every request that matches >1 row, require the FIRST match to be the
+     MOST SPECIFIC row (exact > prefix+suffix > bare prefix; longer path wins).
+
+It fails if a new overlapping route is added in the wrong order, or an existing
+overlap is reordered so the generic row shadows the specific one. It is also the
+prerequisite for ever generating g_v1_routes from the route descriptor: a
+generator can only be trusted to emit rows in a safe order once "safe order" is
+defined and enforced here.
+
+Run:  scripts/check-v1-route-order.py   (exit 0 = ok, 1 = order hazard)
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+REGISTRY = ROOT / "src" / "server" / "server_http_routes.c"
+
+ROW_RE = re.compile(
+    r'\{\s*'
+    r'"(GET|POST|PUT|DELETE)"\s*,\s*'      # verb
+    r'"([^"]+)"\s*,\s*'                    # path
+    r'(NULL|"[^"]*")\s*,\s*'               # suffix
+    r'(RM_EXACT|RM_PREFIX)\s*,\s*'         # match kind
+    r'(?:NULL|"[^"]*")\s*,\s*'             # op (unused here)
+    r'[^,}]+?\s*,\s*'                      # caps (unused here)
+    r'(?:NULL|rh_\w+)\s*\}'                # handler (unused here)
+)
+
+
+def _array_body(text):
+    start = text.index("g_v1_routes[] = {")
+    open_brace = text.index("{", start)
+    depth = 0
+    for i in range(open_brace, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_brace + 1:i]
+    raise SystemExit("check-v1-route-order: unterminated g_v1_routes[] array")
+
+
+def _routes():
+    body = _array_body(REGISTRY.read_text(encoding="utf-8"))
+    out = []
+    for verb, path, suffix, kind in ROW_RE.findall(body):
+        out.append({
+            "verb": verb,
+            "path": path,
+            "suffix": None if suffix == "NULL" else suffix[1:-1],
+            "exact": kind == "RM_EXACT",
+        })
+    return out
+
+
+def matches(verb, path, r):
+    """Faithful port of the C matcher in server_http_routes.c."""
+    if verb != r["verb"]:
+        return False
+    if r["exact"]:
+        return path == r["path"]
+    if not path.startswith(r["path"]):
+        return False
+    rest = path[len(r["path"]):]
+    slash = rest.find("/")
+    if r["suffix"] is not None:
+        return slash != -1 and rest[slash:] == r["suffix"]
+    return bool(rest) and slash == -1
+
+
+def specificity(r):
+    """Lower = more specific: exact < prefix+suffix < bare prefix; longer path wins."""
+    tier = 0 if r["exact"] else (1 if r["suffix"] is not None else 2)
+    return (tier, -len(r["path"]), -len(r["suffix"] or ""))
+
+
+def probe_request(r):
+    """A representative request path that this route matches.
+
+    One probe per route is sufficient because a route's match decision depends
+    only on (verb, prefix string, slash structure, suffix string) — never on the
+    id's characters — so a single fixed-token id fully characterizes the route's
+    structural match class. This holds while every suffix is a single segment
+    (as they all are: /gate, /events, /proposal, ...). A *multi-segment* suffix
+    (one containing an embedded '/…/') could in theory create an overlap that
+    neither participant's canonical probe lands in; add cross-probing here if
+    such a suffix is ever introduced."""
+    if r["exact"]:
+        return r["verb"], r["path"]
+    return r["verb"], r["path"] + "PROBEID" + (r["suffix"] or "")
+
+
+def main():
+    routes = _routes()
+    overlaps = []
+    failures = []
+    for r in routes:
+        verb, path = probe_request(r)
+        hits = [i for i, rt in enumerate(routes) if matches(verb, path, rt)]
+        if len(hits) <= 1:
+            continue
+        winner = routes[hits[0]]
+        best = min((routes[i] for i in hits), key=specificity)
+        entry = (verb, path, [routes[i] for i in hits])
+        # De-dupe: an overlap surfaces from each participant's probe.
+        key = (verb, tuple(sorted(hits)))
+        overlaps.append((key, entry))
+        if specificity(winner) != specificity(best):
+            failures.append((verb, path, winner, best))
+
+    seen = set()
+    uniq = []
+    for key, entry in overlaps:
+        if key in seen:
+            continue
+        seen.add(key)
+        uniq.append(entry)
+
+    if failures:
+        print("check-v1-route-order: FAIL — a generic route shadows a more-specific "
+              "one (first-match wins, but a more-specific row appears later):",
+              file=sys.stderr)
+        for verb, path, winner, best in failures:
+            print(f"  {verb} {path}: matched {winner['path']!r} first, but "
+                  f"{best['path']!r} is more specific — move it earlier.",
+                  file=sys.stderr)
+        sys.exit(1)
+
+    detail = "; ".join(
+        f"{v} {p} -> {hits[0]['path']!r} (over {len(hits)} matches)"
+        for v, p, hits in uniq) or "none"
+    print(f"check-v1-route-order: ok ({len(routes)} routes, "
+          f"{len(uniq)} order-dependent overlap(s), all specific-first: {detail})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Makefile
+++ b/src/Makefile
@@ -575,7 +575,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(MCP_GIT_OBJS) $
            $(CLI_OBJS) $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(KB_OBJS) $(GATEWAY_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(PLATFORM_OBJS) $(PLATFORM_AGENT_OBJS)
 DEPS = $(ALL_OBJS:.o=.d)
 
-.PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
+.PHONY: all clean install inc-check forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check curator-sidecar-parse-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_WEBCHAT) $(SERVER) $(KB) $(GATEWAY) $(FORWARDER)
 
@@ -1152,6 +1152,13 @@ v1-method-coverage-check:
 cli-v1-routes-check:
 	@python3 ../scripts/check-cli-v1-routes.py
 
+# CI gate: the /v1 route table's first-match dispatch stays order-correct — a
+# more-specific route (e.g. the exact /v1/workflow/items/all) must never be
+# shadowed by a later generic prefix ({id}) route. Makes the ordering constraint
+# explicit and is the prerequisite for safely generating g_v1_routes.
+v1-route-order-check:
+	@python3 ../scripts/check-v1-route-order.py
+
 # CI gate: every routed thin-client command has a client_help[] entry, so
 # `aimee help <cmd>` cannot answer "Unknown command" for a command that works.
 cli-help-coverage-check:
@@ -1248,7 +1255,7 @@ clean:
 # you genuinely need a different binary.
 CLANG_FORMAT ?= clang-format-19
 
-lint: native-tool-parity-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check
+lint: native-tool-parity-check inc-check line-check curator-sidecar-parse-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check v1-route-order-check cli-help-coverage-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check sanitizer-callsites-check lessons-isolation-check md-store-retired-check
 
 # aimee's own agents must not fall behind aimee's MCP surface. A tool added to the
 # MCP table reaches every external client (Claude Code, thin clients) and silently


### PR DESCRIPTION
The order-safety prerequisite for the route-SoT inversion track — and a standalone correctness guard.

## The hazard

`server_http_routes.c` resolves a request by scanning `g_v1_routes[]` top-to-bottom and returning the **first** verb+path match (RM_EXACT exact; RM_PREFIX by `strncmp` + a single `{id}` segment + optional suffix). When two rows can both match one request, **array order silently decides the winner**.

Concrete live case: `GET /v1/workflow/items/all` (exact) must sit **before** the `GET /v1/workflow/items/` prefix — otherwise the prefix treats `all` as an `{id}` and the dedicated list-all endpoint (`rh_wf_items_all`) is shadowed by the generic get-one (`rh_wf_item`). That constraint was implicit and unchecked: a reorder, or a newly-added overlapping route, would break routing with no signal. (This is exactly the bug a naive "generate g_v1_routes from the sorted descriptor" would have introduced — the descriptor sorts `items/` before `items/all`.)

## The guard

`scripts/check-v1-route-order.py` (wired into `make lint` as `v1-route-order-check`):

1. parses `g_v1_routes[]` **in source order**,
2. replicates the C matcher faithfully,
3. probes one representative request per route,
4. for every request that matches >1 row, requires the **first** match to be the **most specific** row (exact > prefix+suffix > bare prefix; longer path wins).

Fails if a generic route shadows a more-specific one.

## Why now

This makes the ordering constraint **explicit and machine-checked**, and is the **prerequisite for ever generating `g_v1_routes` from the descriptor safely** — a generator can only be trusted to emit a safe order once "safe order" is defined and enforced. It also caught and documents the one existing overlap (`/v1/workflow/items/all`) as correctly ordered.

## Verification

- Passes on the current table: `ok (322 routes, 1 order-dependent overlap, all specific-first)`.
- **Plant test**: reordering the exact row after the prefix makes it fail with `a generic route shadows a more-specific one … move it earlier` (rc=1).
- No C changed → `unit-tests` unaffected. Green: `make all`, `make lint` (incl. `v1-route-order-check`).