### PR TITLE
fix(wfe): don't loop implement on a no-op that has committed work to verify

### DIFF
--- a/src/modules/workflows/wfe_blocks.c
+++ b/src/modules/workflows/wfe_blocks.c
@@ -1043,10 +1043,21 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
        * a full 4-seat panel on a diff the panel already rejected. Observed
        * live: whole review rounds burned on byte-identical artifacts. Loop so
        * the retry re-dispatches (a $random re-roll picks a different agent). */
-      if (pre_head[0] && commit[0] && strcmp(pre_head, commit) == 0)
+      if (pre_head[0] && commit[0] && strcmp(pre_head, commit) == 0 && feedback[0])
       {
+         /* A no-op is a failed attempt only on a roundtable on_fail RETRY (feedback
+          * present): re-advancing the identical, already-rejected diff would re-run
+          * the 4-seat panel on a byte-identical artifact forever. On the FIRST pass
+          * (no feedback) a no-op instead means a PRIOR implement iteration already
+          * committed the work and advanced HEAD, but its mechanical verify failed
+          * transiently (e.g. the sandbox could not acquire a container) and looped
+          * back; this iteration's delegate correctly finds nothing left to do. Do
+          * NOT loop on that — fall through to the mandatory verify below so a
+          * now-passing committed tree can advance instead of spinning to the attempt
+          * cap. A genuine no-op with no committed work still fails verify there and
+          * loops, so this never advances unverified work. */
          db1_lifecycle_event_add(wfe_ctx_work_item(ctx), node->id, "loop", "engine",
-                                 "impl no-op: delegate made no edits", "", cost);
+                                 "impl no-op: delegate made no edits (post-review)", "", cost);
          return with_cost(wfe_step_looped(), cost);
       }
    }


### PR DESCRIPTION
## Problem

`exec_implement` looped on any delegate dispatch that left HEAD unchanged (`impl no-op: delegate made no edits`). That loop is meant to stop a **roundtable `on_fail` retry** from re-advancing a byte-identical, already-rejected diff into the 4-seat panel forever.

But it also fired on the **first pass**, where a no-op means the opposite: a *prior* implement iteration already committed the work and advanced HEAD, but its mandatory mechanical verify failed **transiently** (the verify sandbox couldn't acquire a container / a flaky image pull) and looped back. The next iteration's delegate correctly finds nothing left to do — and the old code looped on that no-op **without re-running verify**, so a fully committed, now-passing tree spun to the attempt cap and the slice never converged.

Observed live on .254: implement commits the doc change, one verify fails on a transient sandbox error (`could not acquire a container` / a rare `gcc:12`→`12:latest` image glitch), and every subsequent attempt no-ops and loops forever.

## Fix

Gate the no-op loop on `feedback` being present (it is written only on a roundtable `on_fail` retry). On the first pass (no feedback) a no-op **falls through to the mandatory mechanical verify**:
- a committed, now-passing tree **advances**;
- a genuine no-op with no committed work still **fails verify there and loops**, so unverified work never advances.

This makes the implement slice **resilient to a transient verify failure** without weakening the panel-spam protection.

## Testing

- Compiles clean via `src/Makefile` (`-Wall -Wextra -Werror`) + `clang-format-19 --Werror`. `feedback` is already in scope at the check.
- The existing author-no-op test (`test_wfe_delegate_seam` C2) targets `author.proposal`, not `exec_implement` — unaffected. CI runs the full suite.
- Behavioral acceptance: WFE E2E on .254 — implement converges past a transient verify failure and the run advances toward the PR.
