### PR TITLE
refactor(cli): fold the config_load+db1_init prolog into cmd_require_db1()

### DIFF
--- a/src/cmd_agent_delegate.c
+++ b/src/cmd_agent_delegate.c
@@ -1373,10 +1373,7 @@ void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
 
    agent_http_init();
    {
-      config_t db1_cfg;
-      config_load(&db1_cfg);
-      if (db1_init(db1_cfg.db1_path) != 0)
-         fatal("cannot open database");
+      cmd_require_db1("cannot open database");
    }
 
    /* Create durable job record if requested */

--- a/src/cmd_autopilot.c
+++ b/src/cmd_autopilot.c
@@ -244,10 +244,7 @@ void cmd_autopilot(app_ctx_t *ctx, int argc, char **argv)
       }
    }
 
-   config_t db1_cfg;
-   config_load(&db1_cfg);
-   if (db1_init(db1_cfg.db1_path) != 0)
-      fatal("autopilot: could not initialize DB1");
+   cmd_require_db1("autopilot: could not initialize DB1");
 
    if (!is_subcmd)
    {

--- a/src/cmd_cancel.c
+++ b/src/cmd_cancel.c
@@ -220,10 +220,7 @@ const subcmd_t *get_cancel_subcmds(void)
 
 void cmd_cancel(app_ctx_t *ctx, int argc, char **argv)
 {
-   config_t db1_cfg;
-   config_load(&db1_cfg);
-   if (db1_init(db1_cfg.db1_path) != 0)
-      fatal("cannot initialize DB1");
+   cmd_require_db1("cannot initialize DB1");
 
    /* No subcommand or flags starting with -- -> default to cancel_all */
    if (argc < 1 || (argv[0][0] == '-'))

--- a/src/cmd_ensemble.c
+++ b/src/cmd_ensemble.c
@@ -261,10 +261,7 @@ const subcmd_t *get_ensemble_subcmds(void)
 
 void cmd_ensemble(app_ctx_t *ctx, int argc, char **argv)
 {
-   config_t db1_cfg;
-   config_load(&db1_cfg);
-   if (db1_init(db1_cfg.db1_path) != 0)
-      fatal("ensemble: could not initialize DB1");
+   cmd_require_db1("ensemble: could not initialize DB1");
 
    const char *sub = (argc > 0) ? argv[0] : NULL;
    if (argc > 0)

--- a/src/cmd_infra.c
+++ b/src/cmd_infra.c
@@ -888,10 +888,7 @@ const subcmd_t *get_session_subcmds(void)
 
 void cmd_session(app_ctx_t *ctx, int argc, char **argv)
 {
-   config_t db1_cfg;
-   config_load(&db1_cfg);
-   if (db1_init(db1_cfg.db1_path) != 0)
-      fatal("session: could not initialize DB1");
+   cmd_require_db1("session: could not initialize DB1");
 
    const char *sub = (argc > 0) ? argv[0] : NULL;
    if (argc > 0)

--- a/src/cmd_job.c
+++ b/src/cmd_job.c
@@ -372,10 +372,7 @@ void cmd_job(app_ctx_t *ctx, int argc, char **argv)
       return;
    }
 
-   config_t db1_cfg;
-   config_load(&db1_cfg);
-   if (db1_init(db1_cfg.db1_path) != 0)
-      fatal("cannot initialize DB1");
+   cmd_require_db1("cannot initialize DB1");
 
    subcmd_dispatch(job_subcmds, argv[0], ctx, argc - 1, argv + 1);
 }

--- a/src/cmd_memory.c
+++ b/src/cmd_memory.c
@@ -255,10 +255,7 @@ void cmd_memory(app_ctx_t *ctx, int argc, char **argv)
    int needs_no_db = (strcmp(sub, "plan") == 0 || strcmp(sub, "pack") == 0);
    if (!needs_no_db)
    {
-      config_t db1_cfg;
-      config_load(&db1_cfg);
-      if (db1_init(db1_cfg.db1_path) != 0)
-         fatal("cannot initialize DB1");
+      cmd_require_db1("cannot initialize DB1");
    }
 
    config_load(&s_mem_cfg);

--- a/src/cmd_util.c
+++ b/src/cmd_util.c
@@ -1,6 +1,22 @@
 /* cmd_util.c: command handler utilities (subcommand dispatch) */
 #include "aimee.h"
 #include "commands.h"
+#include "config.h"
+#include "db1.h"
+
+/* --- cmd_require_db1 --- */
+
+/* Load config and open DB1, aborting with `errmsg` on failure. Folds the
+ * config_t + config_load + db1_init + fatal prolog the CLI command handlers
+ * otherwise repeat verbatim; callers that also need the config keep their own
+ * config_load. */
+void cmd_require_db1(const char *errmsg)
+{
+   config_t cfg;
+   config_load(&cfg);
+   if (db1_init(cfg.db1_path) != 0)
+      fatal("%s", errmsg);
+}
 
 /* --- subcmd_usage --- */
 

--- a/src/cmd_wiki.c
+++ b/src/cmd_wiki.c
@@ -43,10 +43,7 @@ void cmd_wiki(app_ctx_t *ctx, int argc, char **argv)
       exit(1);
    }
 
-   config_t cfg;
-   config_load(&cfg);
-   if (db1_init(cfg.db1_path) != 0)
-      fatal("cannot initialize DB1");
+   cmd_require_db1("cannot initialize DB1");
 
    const char *sub = argv[0];
    argc--;

--- a/src/cmd_wm.c
+++ b/src/cmd_wm.c
@@ -244,10 +244,7 @@ void cmd_wm(app_ctx_t *ctx, int argc, char **argv)
    argc--;
    argv++;
 
-   config_t db1_cfg;
-   config_load(&db1_cfg);
-   if (db1_init(db1_cfg.db1_path) != 0)
-      fatal("cannot initialize DB1");
+   cmd_require_db1("cannot initialize DB1");
 
    if (subcmd_dispatch(wm_subcmds, sub, ctx, argc, argv) != 0)
       fatal("unknown wm subcommand: %s", sub);

--- a/src/headers/commands.h
+++ b/src/headers/commands.h
@@ -20,6 +20,11 @@ int subcmd_dispatch(const subcmd_t *table, const char *name, app_ctx_t *ctx, int
 /* Print subcommand usage for a parent command. */
 void subcmd_usage(const char *parent, const subcmd_t *table);
 
+/* Load config and open DB1, aborting with `errmsg` on failure. Replaces the
+ * repeated config_t + config_load + db1_init + fatal prolog in command handlers
+ * that only need DB1 (not other config fields). */
+void cmd_require_db1(const char *errmsg);
+
 /* cmd_core.c */
 void ensure_mcp_json(const char *dir);
 void ensure_client_integrations(void);


### PR DESCRIPTION
Cleanup of the CLI command-handler boilerplate.

## What

Many command handlers open DB1 with the same four-line prolog:
```c
config_t cfg;
config_load(&cfg);
if (db1_init(cfg.db1_path) != 0)
   fatal("...");
```
This pattern appears **32 times** across `cmd_*.c`. Add a `cmd_require_db1(errmsg)` helper (`config_load` + `db1_init` + `fatal`, message passed through) and convert the **9 sites where the config is used only for `db1_path`** — i.e. the config variable occurs exactly three times in the file (declaration + load + `db1_path`), so it can be dropped entirely. Each site keeps its exact abort message.

Converted: `cmd_agent_delegate`, `cmd_autopilot`, `cmd_cancel`, `cmd_ensemble`, `cmd_infra`, `cmd_job`, `cmd_memory`, `cmd_wiki`, `cmd_wm`.

## Scope (what I investigated and deliberately left out)

- **The 23 db1-init sites that also read other config fields** — their `config_load` stays; routing db1-init through the helper would double-load the config file. Left alone.
- **The ~135 hand-rolled `strcmp(sub, ...)` subcommand chains** — I looked at these (the original "adopt `subcmd_dispatch`" idea). They are **inline dispatch bodies**, not calls to uniform `void(app_ctx_t*, int, char**)` handlers, so adopting the existing `subcmd_t`/`subcmd_dispatch` table would require **extracting each body into a named function first** — a much larger, per-file change than a mechanical sweep, and low value (the inline if/else chains are already readable). Out of scope.

## Safety

Behavior-preserving: the helper does exactly the prior four lines, and each sites exact message is preserved (passed as the argument). The conversion only fires where the config variable has exactly 3 references (no reuse), verified per-block.

Green: `make all` · `make build-integrity` · `make module-boundary-check` · `make unit-tests` · `make lint`.