### PR TITLE
refactor(cli): subcmd_dispatch for dogfood, trajectory, rules

### DIFF
--- a/src/cmd_dogfood.c
+++ b/src/cmd_dogfood.c
@@ -590,6 +590,13 @@ static void dogfood_sub_report(app_ctx_t *ctx, int argc, char **argv)
 
 /* --- dispatch --- */
 
+static const subcmd_t cmd_dogfood_subs[] = {
+    {"tag", "tag a record with outcome/richness", dogfood_sub_tag},
+    {"review", "review a month's dogfood log", dogfood_sub_review},
+    {"report", "report on a month's dogfood outcomes", dogfood_sub_report},
+    {NULL, NULL, NULL},
+};
+
 void cmd_dogfood(app_ctx_t *ctx, int argc, char **argv)
 {
    if (argc < 1)
@@ -597,12 +604,6 @@ void cmd_dogfood(app_ctx_t *ctx, int argc, char **argv)
    const char *sub = argv[0];
    argc--;
    argv++;
-   if (strcmp(sub, "tag") == 0)
-      dogfood_sub_tag(ctx, argc, argv);
-   else if (strcmp(sub, "review") == 0)
-      dogfood_sub_review(ctx, argc, argv);
-   else if (strcmp(sub, "report") == 0)
-      dogfood_sub_report(ctx, argc, argv);
-   else
+   if (subcmd_dispatch(cmd_dogfood_subs, sub, ctx, argc, argv) != 0)
       fatal("unknown dogfood subcommand: %s", sub);
 }

--- a/src/cmd_rules.c
+++ b/src/cmd_rules.c
@@ -8,6 +8,63 @@
 
 /* --- cmd_rules --- */
 
+static void cmd_rules_list(app_ctx_t *ctx, int argc, char **argv)
+{
+   char *json = kb_client_rules_list_json(256);
+   cJSON *resp = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   cJSON *arr = resp ? cJSON_GetObjectItemCaseSensitive(resp, "rules") : NULL;
+   if (ctx->json_output)
+   {
+      cJSON *out = arr ? cJSON_DetachItemViaPointer(resp, arr) : cJSON_CreateArray();
+      emit_json_ctx(out, ctx->json_fields, ctx->response_profile);
+   }
+   cJSON_Delete(resp);
+}
+
+static void cmd_rules_generate(app_ctx_t *ctx, int argc, char **argv)
+{
+   char *json = kb_client_rules_generate_json();
+   cJSON *resp = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   cJSON *content = resp ? cJSON_GetObjectItemCaseSensitive(resp, "content") : NULL;
+   const char *md = cJSON_IsString(content) ? content->valuestring : "";
+   if (ctx->json_output)
+   {
+      cJSON *j = cJSON_CreateObject();
+      cJSON_AddStringToObject(j, "content", md);
+      emit_json_ctx(j, ctx->json_fields, ctx->response_profile);
+   }
+   else if (md[0])
+   {
+      printf("%s", md);
+   }
+   cJSON_Delete(resp);
+}
+
+static void cmd_rules_delete(app_ctx_t *ctx, int argc, char **argv)
+{
+   if (argc < 1)
+      fatal("rules delete requires an id");
+   int id = atoi(argv[0]);
+   kb_client_rules_delete(id);
+   if (ctx->json_output)
+      emit_ok_ctx(ctx->json_fields, ctx->response_profile);
+}
+
+static void cmd_rules_review(app_ctx_t *ctx, int argc, char **argv)
+{
+   cmd_review_surface("rule", ctx, argc, argv);
+}
+
+static const subcmd_t cmd_rules_subs[] = {
+    {"list", "list rules", cmd_rules_list},
+    {"generate", "generate a rules digest", cmd_rules_generate},
+    {"delete", "delete a rule by id", cmd_rules_delete},
+    {"review", "review surfaced rules", cmd_rules_review},
+    {NULL, NULL, NULL},
+};
+
 void cmd_rules(app_ctx_t *ctx, int argc, char **argv)
 {
    if (argc < 1)
@@ -17,55 +74,8 @@ void cmd_rules(app_ctx_t *ctx, int argc, char **argv)
    argc--;
    argv++;
 
-   if (strcmp(sub, "list") == 0)
-   {
-      char *json = kb_client_rules_list_json(256);
-      cJSON *resp = json ? cJSON_Parse(json) : NULL;
-      free(json);
-      cJSON *arr = resp ? cJSON_GetObjectItemCaseSensitive(resp, "rules") : NULL;
-      if (ctx->json_output)
-      {
-         cJSON *out = arr ? cJSON_DetachItemViaPointer(resp, arr) : cJSON_CreateArray();
-         emit_json_ctx(out, ctx->json_fields, ctx->response_profile);
-      }
-      cJSON_Delete(resp);
-   }
-   else if (strcmp(sub, "generate") == 0)
-   {
-      char *json = kb_client_rules_generate_json();
-      cJSON *resp = json ? cJSON_Parse(json) : NULL;
-      free(json);
-      cJSON *content = resp ? cJSON_GetObjectItemCaseSensitive(resp, "content") : NULL;
-      const char *md = cJSON_IsString(content) ? content->valuestring : "";
-      if (ctx->json_output)
-      {
-         cJSON *j = cJSON_CreateObject();
-         cJSON_AddStringToObject(j, "content", md);
-         emit_json_ctx(j, ctx->json_fields, ctx->response_profile);
-      }
-      else if (md[0])
-      {
-         printf("%s", md);
-      }
-      cJSON_Delete(resp);
-   }
-   else if (strcmp(sub, "delete") == 0)
-   {
-      if (argc < 1)
-         fatal("rules delete requires an id");
-      int id = atoi(argv[0]);
-      kb_client_rules_delete(id);
-      if (ctx->json_output)
-         emit_ok_ctx(ctx->json_fields, ctx->response_profile);
-   }
-   else if (strcmp(sub, "review") == 0)
-   {
-      cmd_review_surface("rule", ctx, argc, argv);
-   }
-   else
-   {
+   if (subcmd_dispatch(cmd_rules_subs, sub, ctx, argc, argv) != 0)
       fatal("unknown rules subcommand: %s", sub);
-   }
 }
 
 /* --- cmd_feedback --- */

--- a/src/cmd_trajectory.c
+++ b/src/cmd_trajectory.c
@@ -102,6 +102,12 @@ static void trajectory_batch_cmd(app_ctx_t *ctx, int argc, char **argv)
    (void)ctx;
 }
 
+static const subcmd_t cmd_trajectory_subs[] = {
+    {"export", "export a session trajectory", trajectory_export_cmd},
+    {"batch", "run a batch over a task corpus", trajectory_batch_cmd},
+    {NULL, NULL, NULL},
+};
+
 void cmd_trajectory(app_ctx_t *ctx, int argc, char **argv)
 {
    const char *sub = argc > 0 ? argv[0] : NULL;
@@ -110,10 +116,6 @@ void cmd_trajectory(app_ctx_t *ctx, int argc, char **argv)
       argc--;
       argv++;
    }
-   if (sub && strcmp(sub, "export") == 0)
-      trajectory_export_cmd(ctx, argc, argv);
-   else if (sub && strcmp(sub, "batch") == 0)
-      trajectory_batch_cmd(ctx, argc, argv);
-   else
+   if (!sub || subcmd_dispatch(cmd_trajectory_subs, sub, ctx, argc, argv) != 0)
       trajectory_usage();
 }


### PR DESCRIPTION
Second batch of the subcmd-dispatch adoption campaign (follows #1590 cmd_diagnose).

## What
Replace hand-rolled `strcmp(sub,...)` if-chains with `subcmd_t` tables + `subcmd_dispatch`, matching the ~24 command families already on the pattern.

| file | kind | notes |
|---|---|---|
| cmd_dogfood.c | table adoption | handlers already factored (dogfood_sub_*); no body movement |
| cmd_trajectory.c | table adoption | handlers already factored (trajectory_*_cmd); no body movement |
| cmd_rules.c | body extraction | list/generate/delete/review inline bodies → static cmd_rules_* handlers |

## Verification
- cmd_rules extracted bodies are byte-identical (whitespace-normalized) to the originals; a set-difference confirms **every** original statement survives, only dispatch scaffolding changed.
- Behavior preserved: argc<1 and unknown-subcommand `fatal`s unchanged. Only UX delta: `help`/`--help` now prints the subcommand list instead of hitting the unknown-subcommand fatal. Grep confirms no test/script depends on the prior nonzero help exit.
- Local gates green: `make all`, `build-integrity`, `module-boundary-check`, `lint`, `unit-tests` (all RC=0). clang-format-19 clean.

## Skipped (flagged for manual handling)
- cmd_manuscript.c: handlers are `int ms_*(... json_output)` — signature does not match the `subcmd_t` `void(ctx,argc,argv)` contract; not mechanically convertible.