### PR TITLE
refactor(cli): subcmd_dispatch for skill, memory pack, curiosity

### DIFF
--- a/src/cmd_memory_curiosity.c
+++ b/src/cmd_memory_curiosity.c
@@ -323,6 +323,27 @@ static void sub_transition(app_ctx_t *ctx, int argc, char **argv, const char *to
    cJSON_Delete(upd_resp);
 }
 
+static void sub_suppress(app_ctx_t *ctx, int argc, char **argv)
+{
+   sub_transition(ctx, argc, argv, CURIOSITY_STATE_SUPPRESSED);
+}
+
+static void sub_resolve(app_ctx_t *ctx, int argc, char **argv)
+{
+   sub_transition(ctx, argc, argv, CURIOSITY_STATE_RESOLVED);
+}
+
+static const subcmd_t mem_curiosity_subs[] = {
+    {"list", "list curiosities", sub_list},
+    {"create", "create a curiosity", sub_create},
+    {"sweep", "sweep curiosities", sub_sweep},
+    {"rescore", "rescore curiosities", sub_rescore},
+    {"route", "route curiosities", sub_route},
+    {"suppress", "suppress a curiosity", sub_suppress},
+    {"resolve", "resolve a curiosity", sub_resolve},
+    {NULL, NULL, NULL},
+};
+
 void mem_curiosity(app_ctx_t *ctx, int argc, char **argv)
 {
    if (argc < 1)
@@ -330,20 +351,6 @@ void mem_curiosity(app_ctx_t *ctx, int argc, char **argv)
    const char *sub = argv[0];
    argc--;
    argv++;
-   if (strcmp(sub, "list") == 0)
-      sub_list(ctx, argc, argv);
-   else if (strcmp(sub, "create") == 0)
-      sub_create(ctx, argc, argv);
-   else if (strcmp(sub, "sweep") == 0)
-      sub_sweep(ctx, argc, argv);
-   else if (strcmp(sub, "rescore") == 0)
-      sub_rescore(ctx, argc, argv);
-   else if (strcmp(sub, "route") == 0)
-      sub_route(ctx, argc, argv);
-   else if (strcmp(sub, "suppress") == 0)
-      sub_transition(ctx, argc, argv, CURIOSITY_STATE_SUPPRESSED);
-   else if (strcmp(sub, "resolve") == 0)
-      sub_transition(ctx, argc, argv, CURIOSITY_STATE_RESOLVED);
-   else
+   if (subcmd_dispatch(mem_curiosity_subs, sub, ctx, argc, argv) != 0)
       fatal("unknown curiosity subcommand: %s", sub);
 }

--- a/src/cmd_memory_pack.c
+++ b/src/cmd_memory_pack.c
@@ -8,6 +8,7 @@
 
 #include "aimee.h"
 #include "cmd_memory_internal.h"
+#include "commands.h"
 #include "memory_profile_pack.h"
 #include "cJSON.h"
 #include "json_fluent.h"
@@ -161,6 +162,14 @@ static void pack_use(app_ctx_t *ctx, int argc, char **argv)
    printf("active pack set to: %s\n", name);
 }
 
+static const subcmd_t mem_pack_subs[] = {
+    {"list", "list available packs", pack_list},
+    {"show", "show a pack", pack_show},
+    {"validate", "validate a pack file", pack_validate},
+    {"use", "activate a pack", pack_use},
+    {NULL, NULL, NULL},
+};
+
 void mem_pack(app_ctx_t *ctx, int argc, char **argv)
 {
    if (argc < 1)
@@ -174,14 +183,6 @@ void mem_pack(app_ctx_t *ctx, int argc, char **argv)
    argc--;
    argv++;
 
-   if (strcmp(sub, "list") == 0)
-      pack_list(ctx, argc, argv);
-   else if (strcmp(sub, "show") == 0)
-      pack_show(ctx, argc, argv);
-   else if (strcmp(sub, "validate") == 0)
-      pack_validate(ctx, argc, argv);
-   else if (strcmp(sub, "use") == 0)
-      pack_use(ctx, argc, argv);
-   else
+   if (subcmd_dispatch(mem_pack_subs, sub, ctx, argc, argv) != 0)
       fatal("unknown memory pack subcommand: %s", sub);
 }

--- a/src/cmd_skill.c
+++ b/src/cmd_skill.c
@@ -638,61 +638,41 @@ void cmd_skill(app_ctx_t *ctx, int argc, char **argv)
    argc--;
    argv++;
 
-   if (strcmp(sub, "list") == 0)
-      skill_cmd_list(ctx, argc, argv);
-   else if (strcmp(sub, "show") == 0)
-      skill_cmd_show(ctx, argc, argv);
-   else if (strcmp(sub, "lint") == 0)
-      skill_cmd_lint(ctx, argc, argv);
-   else if (strcmp(sub, "eval") == 0)
-      skill_cmd_eval(ctx, argc, argv);
-   else if (strcmp(sub, "create") == 0)
-      skill_cmd_create(ctx, argc, argv);
-   else if (strcmp(sub, "edit") == 0)
-      skill_cmd_edit(ctx, argc, argv);
-   else if (strcmp(sub, "patch") == 0)
-      skill_cmd_patch(ctx, argc, argv);
-   else if (strcmp(sub, "archive") == 0)
-      skill_cmd_archive(ctx, argc, argv);
-   else if (strcmp(sub, "export") == 0)
-      skill_cmd_export(ctx, argc, argv);
-   else if (strcmp(sub, "import") == 0)
-      skill_cmd_import(ctx, argc, argv);
-   else if (strcmp(sub, "rollback") == 0)
-      skill_cmd_rollback(ctx, argc, argv);
-   else if (strcmp(sub, "lifecycle") == 0)
-      skill_cmd_lifecycle(ctx, argc, argv);
-   else if (strcmp(sub, "autostub") == 0)
-      skill_cmd_autostub(ctx, argc, argv);
-   else if (strcmp(sub, "pin") == 0)
-      skill_cmd_pin(ctx, argc, argv, 1);
-   else if (strcmp(sub, "unpin") == 0)
-      skill_cmd_pin(ctx, argc, argv, 0);
-   else
+   if (subcmd_dispatch(get_skill_subcmds(), sub, ctx, argc, argv) != 0)
    {
       fprintf(stderr, "Unknown skill subcommand: %s\n\n", sub);
       skill_print_help();
    }
 }
 
+static void skill_cmd_pin_sub(app_ctx_t *ctx, int argc, char **argv)
+{
+   skill_cmd_pin(ctx, argc, argv, 1);
+}
+
+static void skill_cmd_unpin_sub(app_ctx_t *ctx, int argc, char **argv)
+{
+   skill_cmd_pin(ctx, argc, argv, 0);
+}
+
 const subcmd_t *get_skill_subcmds(void)
 {
    static const subcmd_t skill_subcmds[] = {
-       {"list", "List available skills", NULL},
-       {"show", "Print a skill body or support file", NULL},
-       {"lint", "Lint skill frontmatter and authoring conventions", NULL},
-       {"eval", "Run skill compliance eval fixtures", NULL},
-       {"create", "Create a project skill from a markdown file", NULL},
-       {"edit", "Replace a project skill from a markdown file", NULL},
-       {"patch", "Patch a project skill by string replacement", NULL},
-       {"archive", "Archive a project skill", NULL},
-       {"export", "Export a skill as SKILL.md markdown", NULL},
-       {"import", "Import a frontmatter SKILL.md markdown file", NULL},
-       {"rollback", "Restore project skills from a snapshot", NULL},
-       {"lifecycle", "Apply stale/archive lifecycle transitions", NULL},
-       {"autostub", "Propose capability skills for uncovered tools", NULL},
-       {"pin", "Pin a skill against automation", NULL},
-       {"unpin", "Unpin a skill", NULL},
+       {"list", "List available skills", skill_cmd_list},
+       {"show", "Print a skill body or support file", skill_cmd_show},
+       {"lint", "Lint skill frontmatter and authoring conventions", skill_cmd_lint},
+       {"eval", "Run skill compliance eval fixtures", skill_cmd_eval},
+       {"create", "Create a project skill from a markdown file", skill_cmd_create},
+       {"edit", "Replace a project skill from a markdown file", skill_cmd_edit},
+       {"patch", "Patch a project skill by string replacement", skill_cmd_patch},
+       {"archive", "Archive a project skill", skill_cmd_archive},
+       {"export", "Export a skill as SKILL.md markdown", skill_cmd_export},
+       {"import", "Import a frontmatter SKILL.md markdown file", skill_cmd_import},
+       {"rollback", "Restore project skills from a snapshot", skill_cmd_rollback},
+       {"lifecycle", "Apply stale/archive lifecycle transitions", skill_cmd_lifecycle},
+       {"autostub", "Propose capability skills for uncovered tools", skill_cmd_autostub},
+       {"pin", "Pin a skill against automation", skill_cmd_pin_sub},
+       {"unpin", "Unpin a skill", skill_cmd_unpin_sub},
        {NULL, NULL, NULL},
    };
    return skill_subcmds;


### PR DESCRIPTION
Fourth batch of the subcmd-dispatch adoption campaign (follows #1590, #1591, #1592).

## What
Replace hand-rolled `strcmp(sub,...)` if-chains with `subcmd_t` tables + `subcmd_dispatch`. All three are **pure table adoption** — handlers were already separate functions; no body movement.

| file | notes |
|---|---|
| cmd_skill.c | The existing `skill_subcmds` table (used by cmd_table.c for help) previously had NULL handlers. Populate its 15 handler pointers and dispatch through it, deleting the 15-branch if-chain. `pin`/`unpin` get thin wrappers around `skill_cmd_pin(...,1/0)`. |
| cmd_memory_pack.c | list/show/validate/use → pack_* table; adds `#include "commands.h"` for subcmd_t. |
| cmd_memory_curiosity.c | list/create/sweep/rescore/route → sub_* table; `suppress`/`resolve` get thin wrappers around `sub_transition(...,STATE)`. |

## Verification
- No handler bodies moved — only dispatch chains replaced and (skill) the doc-table's handler column filled in. Table entries map 1:1 to the original branches (verified name↔handler, including the 4 wrapper mappings).
- Behavior preserved: argc<1 usage (skill→skill_print_help, pack→usage/exit(1), curiosity→fatal) and unknown-subcommand handling (skill prints help, pack/curiosity fatal) unchanged. Only UX delta: `help`/`--help` now prints the subcommand list (shared-pattern behavior).
- Local gates green: make all, build-integrity, module-boundary-check, lint, unit-tests (all RC=0). clang-format-19 clean.

## Campaign status
Remaining convertible (ctx-based): roadmap, identity, learning, infra(cmd_git + others), data(cmd_config + cmd_db), core(cmd_tdd), memory_vector(mem_scene, non-standard argv), roles(non-standard argv), memory_core(mem_queue, single-cmd guard).
Skipped — signature mismatch (`int cmd_X_run`): optimize, workflow, profile, manuscript.