### PR TITLE
refactor(cli): subcmd_dispatch for webchat and workspace

### DIFF
--- a/src/cmd_infra.c
+++ b/src/cmd_infra.c
@@ -1119,28 +1119,42 @@ static void webchat_status(void)
    free(out);
 }
 
+static void webchat_enable_cmd(app_ctx_t *ctx, int argc, char **argv)
+{
+   webchat_enable();
+}
+
+static void webchat_disable_cmd(app_ctx_t *ctx, int argc, char **argv)
+{
+   webchat_disable();
+}
+
+static void webchat_status_cmd(app_ctx_t *ctx, int argc, char **argv)
+{
+   webchat_status();
+}
+
+static const subcmd_t cmd_webchat_subs[] = {
+    {"enable", "enable webchat", webchat_enable_cmd},
+    {"disable", "disable webchat", webchat_disable_cmd},
+    {"status", "show webchat status", webchat_status_cmd},
+    {NULL, NULL, NULL},
+};
+
 void cmd_webchat(app_ctx_t *ctx, int argc, char **argv)
 {
-   (void)ctx;
-
-   if (argc >= 1 && strcmp(argv[0], "enable") == 0)
+   const char *sub = argc > 0 ? argv[0] : NULL;
+   if (argc > 0)
    {
-      webchat_enable();
-      return;
-   }
-   if (argc >= 1 && strcmp(argv[0], "disable") == 0)
-   {
-      webchat_disable();
-      return;
-   }
-   if (argc >= 1 && strcmp(argv[0], "status") == 0)
-   {
-      webchat_status();
-      return;
+      argc--;
+      argv++;
    }
 
-   fprintf(stderr, "usage: aimee webchat <enable|disable|status>\n");
-   fprintf(stderr, "       to run the server directly: aimee-webchat --port <port>\n");
+   if (!sub || subcmd_dispatch(cmd_webchat_subs, sub, ctx, argc, argv) != 0)
+   {
+      fprintf(stderr, "usage: aimee webchat <enable|disable|status>\n");
+      fprintf(stderr, "       to run the server directly: aimee-webchat --port <port>\n");
+   }
 }
 
 /* --- cmd_env --- */
@@ -1430,6 +1444,13 @@ static void workspace_cmd_remove(app_ctx_t *ctx, int argc, char **argv)
       fprintf(stderr, "workspace: removed %s\n", target);
 }
 
+static const subcmd_t cmd_workspace_subs[] = {
+    {"add", "add a workspace", workspace_cmd_add},
+    {"list", "list workspaces", workspace_cmd_list},
+    {"remove", "remove a workspace", workspace_cmd_remove},
+    {NULL, NULL, NULL},
+};
+
 void cmd_workspace(app_ctx_t *ctx, int argc, char **argv)
 {
    if (argc < 1)
@@ -1442,13 +1463,7 @@ void cmd_workspace(app_ctx_t *ctx, int argc, char **argv)
    argc--;
    argv++;
 
-   if (strcmp(sub, "add") == 0)
-      workspace_cmd_add(ctx, argc, argv);
-   else if (strcmp(sub, "list") == 0)
-      workspace_cmd_list(ctx, argc, argv);
-   else if (strcmp(sub, "remove") == 0)
-      workspace_cmd_remove(ctx, argc, argv);
-   else
+   if (subcmd_dispatch(cmd_workspace_subs, sub, ctx, argc, argv) != 0)
    {
       fprintf(stderr, "Unknown workspace subcommand: %s\n", sub);
       fprintf(stderr, "Usage: aimee workspace <add|list|remove> [options]\n");


### PR DESCRIPTION
Ninth batch of the subcmd-dispatch adoption campaign (follows #1590–#1597). Both dispatchers live in cmd_infra.c.

## What
| dispatcher | kind | notes |
|---|---|---|
| cmd_workspace | table adoption | add/list/remove were already workspace_cmd_* functions; no body movement |
| cmd_webchat | wrappers | enable/disable/status call the no-arg webchat_* helpers; each gets a thin (ctx,argc,argv) wrapper |

Intentionally left as-is in cmd_infra.c:
- cmd_session — already on subcmd_dispatch.
- cmd_dashboard — a `cors` special-case plus a default `dashboard_serve` action; not a subcommand dispatch chain.
- cmd_git — a 578-line, 16-branch inline dispatcher; deferred to its own follow-up batch to keep this one small and reviewable.

## Verification
- No handler bodies moved (workspace) / trivial no-arg wrappers (webchat). Table entries map 1:1 to the original branches.
- Behavior preserved: cmd_workspace argc<1 usage + unknown message unchanged; cmd_webchat no-arg and unknown both still print the two-line usage (`!sub || dispatch != 0` guard). Only UX delta: `help`/`--help` prints the subcommand list.
- Brace balance 215/215. Local gates green on a tree rebased onto latest testing (incl. #1597): make all, build-integrity, module-boundary-check, lint, unit-tests (all RC=0). clang-format-19 clean.

## Campaign status
Remaining: cmd_git (cmd_infra.c, 16 inline branches, ~578 lines) — final batch.
Skipped: optimize/workflow/profile/manuscript (`int cmd_X_run`), cmd_tdd (shared prolog state), mem_queue (single-cmd guard), cmd_dashboard (not a dispatch chain).