### PR TITLE
fix(delegate): let a container-bound delegate run git in its own sandbox

### DIFF
--- a/src/modules/workspace/workspace_turn.c
+++ b/src/modules/workspace/workspace_turn.c
@@ -464,6 +464,11 @@ int workspace_turn_bind_container(const char *task_id, const char *image, const 
    return 1;
 }
 
+int workspace_turn_container_bound(void)
+{
+   return t_turn_container_backend != NULL;
+}
+
 void workspace_turn_unbind_active(void)
 {
    if (t_turn_bound)

--- a/src/modules/workspace/workspace_turn.h
+++ b/src/modules/workspace/workspace_turn.h
@@ -56,6 +56,15 @@ int workspace_turn_workspace_authorized(const char *workspace, char *out, size_t
 int workspace_turn_bind_container(const char *task_id, const char *image, const char *workspace,
                                   int workspace_read_only);
 
+/* Returns 1 when this thread's turn is bound to a delegate's OWN container
+ * (workspace_turn_bind_container succeeded and has not yet been unbound), 0
+ * otherwise. Callers use it to relax host-oriented restrictions that do not
+ * apply once file/exec run inside the delegate's isolated sandbox — e.g. the
+ * shell-git gate, whose purpose is to keep raw git off aimee-server's own
+ * filesystem, is moot when git runs against the container's mounted worktree.
+ * Valid only between bind and unbind, on the binding thread. */
+int workspace_turn_container_bound(void);
+
 /* Clear any provider bound for this thread by workspace_turn_bind_active.
  * Safe to call unconditionally (no-op if nothing was bound). */
 void workspace_turn_unbind_active(void);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1976,6 +1976,20 @@ static int server_shell_git_blocked(const char *command, const char *cwd)
 {
    if (!command || !command[0] || !wfe_shell_invokes_git("bash", command))
       return 0; /* not a git command — the overwhelmingly common case, stays silent */
+   /* The gate exists to keep raw shell git off aimee-server's OWN filesystem and
+    * push it through the credential-holding git_* tools. A delegate bound to its
+    * own container runs its shell — including git — INSIDE that sandbox, against
+    * the container's mounted worktree, not the host: the delegate is meant to
+    * commit there and aimee collects the diff (push/PR still go through aimee at
+    * the deliver stage). Blocking its local git is the "limitation on a container
+    * delegate" this seam must not impose; allow it. */
+   if (workspace_turn_container_bound())
+   {
+      aimee_log(LOG_DEBUG, "shell-git-gate",
+                "allow: delegate is container-bound — git runs in its sandbox worktree, not on "
+                "the host");
+      return 0;
+   }
    config_t cfg;
    if (config_load(&cfg) == 0 && !cfg.require_aimee_git)
    {

--- a/src/tests/test_workspace_turn.c
+++ b/src/tests/test_workspace_turn.c
@@ -205,11 +205,15 @@ int main(void)
          c.delegate_sandbox = 1;
          assert(config_save(&c) == 0);
          g_acquires = g_releases = 0;
+         assert(workspace_turn_container_bound() == 0); /* nothing bound yet */
          assert(workspace_turn_bind_container("deleg-2", NULL, NULL, 0) == 1);
          assert(g_acquires == 1);
          const workspace_provider_t *p = workspace_provider_active();
          assert(p != shared);
          assert(p->kind == WS_PROVIDER_CONTAINER);
+         /* The container-bound predicate the shell-git gate keys off: true while
+          * bound, false once released. */
+         assert(workspace_turn_container_bound() == 1);
 
          /* Unbind must RELEASE the container, not just drop the pointer: a leaked
           * container outlives its turn and pins its workspace. And the active
@@ -218,6 +222,7 @@ int main(void)
          workspace_turn_unbind_active();
          assert(g_releases == 1);
          assert(workspace_provider_active() == shared);
+         assert(workspace_turn_container_bound() == 0); /* cleared on unbind */
       }
 
       /* The tree reaches the backend. Without this the backend mints an EMPTY


### PR DESCRIPTION
The shell-git gate denies every git command a delegate runs via bash, redirecting to aimee's git_* tools — to keep raw git off aimee-server's host filesystem. But a container-bound delegate runs its shell (including git) INSIDE its sandbox against the mounted worktree, not the host. The WFE implement slice relies on this: the delegate commits in its writable worktree and aimee collects the diff (push/PR still go through aimee at deliver). With the gate active, the delegate's git status/add/commit/config were all DENIED, so every implement turn produced no diff and the slice looped to cap (observed live on .254).

Adds `workspace_turn_container_bound()` (true between bind and unbind on the binding thread) and short-circuits the gate to allow when it holds. Host path unchanged. Unit-tested in test_workspace_turn.