### PR TITLE
feat: add P5 server registry DB2 APIs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -319,6 +319,7 @@ DB2_SRCS = db2/db2_init.c db2/db2_reembed.c db2/db2_pool.c db2/agent_hints.c db2
            db2/cross_repo_deps.c db2/cross_repo_review.c db2/cross_repo_identity.c \
            db2/cross_repo_route.c db2/cross_repo_build.c \
            db2/vault_pg.c db2/org_model_catalog.c db2/org_spend.c db2/org_budget.c db2/org_rate.c db2/org_telemetry.c db2/org_telemetry_fmt.c
+DB2_SRCS += db2/server_registry.c
 DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # Vault core (P10): the credential-vault crypto/store/service, shared by aimee-server

--- a/src/db2/server_registry.c
+++ b/src/db2/server_registry.c
@@ -1,0 +1,9 @@
+#include "server_registry.h"
+#include "db2_internal.h"
+#include "db2_tenant.h"
+#include "db_postgres.h"
+#include <stdio.h>
+#include <string.h>
+static void cp(char*d,size_t n,const char*s){snprintf(d,n,"%s",s?s:"");}
+int db2_server_registry_list(int64_t team,db2_server_row_t*out,int max){if(db2_tenant_require_pg()!=0||!out||max<=0)return-1;void*c=db2_conn();if(!c)return-1;char e[256];aimee_pg_stmt_t*s=aimee_pg_prepare(c,"SELECT server_id,cert_cn,mgmt_cert_cn,endpoint,status,health,version,team_id FROM kb_server_registry WHERE team_id=?1 ORDER BY server_id",e,sizeof(e));if(!s)return-1;aimee_pg_bind_int64(s,"?1",team);int n=0;while(n<max&&aimee_pg_step(s,e,sizeof(e))==AIMEE_PG_ROW){db2_server_row_t*r=&out[n++];memset(r,0,sizeof(*r));cp(r->server_id,sizeof(r->server_id),aimee_pg_column_text(s,0));cp(r->cert_cn,sizeof(r->cert_cn),aimee_pg_column_text(s,1));cp(r->mgmt_cert_cn,sizeof(r->mgmt_cert_cn),aimee_pg_column_text(s,2));cp(r->endpoint,sizeof(r->endpoint),aimee_pg_column_text(s,3));cp(r->status,sizeof(r->status),aimee_pg_column_text(s,4));cp(r->health,sizeof(r->health),aimee_pg_column_text(s,5));cp(r->version,sizeof(r->version),aimee_pg_column_text(s,6));r->team_id=aimee_pg_column_int64(s,7);}aimee_pg_finalize(s);return n;}
+int db2_server_registry_heartbeat(const char*id,const char*cn,const char*health,const char*version){if(db2_tenant_require_pg()!=0||!id||!cn)return-1;void*c=db2_conn();if(!c)return-1;char e[256];aimee_pg_stmt_t*s=aimee_pg_prepare(c,"UPDATE kb_server_registry SET health=?3,version=?4,last_seen=now(),updated_at=now() WHERE server_id=?1 AND cert_cn=?2 AND status='active'",e,sizeof(e));if(!s)return-1;aimee_pg_bind_text(s,"?1",id);aimee_pg_bind_text(s,"?2",cn);aimee_pg_bind_text(s,"?3",health?health:"");aimee_pg_bind_text(s,"?4",version?version:"");int rc=aimee_pg_step(s,e,sizeof(e))==AIMEE_PG_DONE?0:-1;aimee_pg_finalize(s);return rc;}

--- a/src/db2/server_registry.h
+++ b/src/db2/server_registry.h
@@ -1,0 +1,7 @@
+#ifndef DB2_SERVER_REGISTRY_H
+#define DB2_SERVER_REGISTRY_H
+#include <stdint.h>
+typedef struct { char server_id[128],cert_cn[256],mgmt_cert_cn[256],endpoint[512],status[32],health[128],version[64]; int64_t team_id; } db2_server_row_t;
+int db2_server_registry_list(int64_t,db2_server_row_t*,int);
+int db2_server_registry_heartbeat(const char*,const char*,const char*,const char*);
+#endif


### PR DESCRIPTION
Adds typed PostgreSQL-backed team-scoped registry listing and certificate-bound heartbeat updates. Build validated with make server.