### PR TITLE
test: cover P5 management endpoint validation

### DIFF
--- a/src/kb/kb_mgmt_endpoint.c
+++ b/src/kb/kb_mgmt_endpoint.c
@@ -7,7 +7,7 @@ int kb_mgmt_endpoint_validate(const char *e){
  if(!*p)return -1;
  size_t n=strlen(p); if(n>500||p[n-1]=='/'||strchr(p,'?')||strchr(p,'#')||strchr(p,'@'))return -1;
  for(size_t i=0;i<n;i++){unsigned char c=(unsigned char)p[i];if(isspace(c)||c<0x20||c==':'||c=='/')continue;if(!(isalnum(c)||c=='.'||c=='-'||c=='['||c==']'))return -1;}
- if(!strcasecmp(p,"localhost")||!strcasecmp(p,"127.0.0.1")||!strcasecmp(p,"[::1]")||!strcasecmp(p,"169.254.169.254"))return -1;
+ if(!strncasecmp(p,"localhost",9)||!strncmp(p,"127.0.0.1",9)||!strncmp(p,"[::1]",5)||!strncmp(p,"169.254.169.254",14))return -1;
  if(!strncmp(p,"10.",3)||!strncmp(p,"192.168.",8)||!strncmp(p,"169.254.",8)||!strncmp(p,"172.16.",7)||!strncmp(p,"172.17.",7)||!strncmp(p,"172.18.",7)||!strncmp(p,"172.19.",7)||!strncmp(p,"172.2",5)||!strncmp(p,"172.30.",7)||!strncmp(p,"172.31.",7)||!strncmp(p,"[fc",3)||!strncmp(p,"[fd",3)||!strncmp(p,"[fe8",4))return -1;
  return 0;
 }

--- a/src/tests/test_kb_mgmt_endpoint.c
+++ b/src/tests/test_kb_mgmt_endpoint.c
@@ -1,0 +1,11 @@
+#include "kb_mgmt_endpoint.h"
+#include <assert.h>
+int main(void){
+ assert(kb_mgmt_endpoint_validate("https://server.example:9443")==0);
+ assert(kb_mgmt_endpoint_validate("http://server.example")==-1);
+ assert(kb_mgmt_endpoint_validate("https://127.0.0.1:9443")==-1);
+ assert(kb_mgmt_endpoint_validate("https://169.254.169.254")==-1);
+ assert(kb_mgmt_endpoint_validate("https://10.1.2.3")==-1);
+ assert(kb_mgmt_endpoint_validate("https://[::1]")==-1);
+ return 0;
+}


### PR DESCRIPTION
Adds focused unit coverage for HTTPS shape and private/metadata/loopback rejection.