### PR TITLE
feat: add P5 mTLS server heartbeat ingress

### DIFF
--- a/src/kb/http/kb_tls_serve.c
+++ b/src/kb/http/kb_tls_serve.c
@@ -18,6 +18,7 @@
 #include "cJSON.h"
 #include "kb_enroll.h"  /* KB_ENROLL_SCOPE_MAX */
 #include "kb_http.h"    /* kb_http_route_ex */
+#include "../../db2/server_registry.h"
 #include "kb_ingress.h" /* B5 identity-header ingress guard */
 #include "kb_reqctx.h"
 #include "log.h"             /* LOG_WARN */
@@ -52,6 +53,24 @@ static const char *http_reason(int status)
    default:
       return "OK";
    }
+}
+
+/* Certificate-bound server heartbeat. The server_id is untrusted input but the
+ * DB update is keyed by both server_id and the verified peer cert CN, so a
+ * certificate cannot refresh another registry row. */
+static int mtls_server_heartbeat(const char *cn, const char *body, char *resp, int cap)
+{
+   cJSON *j = body ? cJSON_Parse(body) : NULL;
+   cJSON *sid = j ? cJSON_GetObjectItemCaseSensitive(j, "server_id") : NULL;
+   cJSON *health = j ? cJSON_GetObjectItemCaseSensitive(j, "health") : NULL;
+   cJSON *version = j ? cJSON_GetObjectItemCaseSensitive(j, "version") : NULL;
+   int ok = cJSON_IsString(sid) && cJSON_IsString(health) && cJSON_IsString(version) &&
+            db2_server_registry_heartbeat(cJSON_GetStringValue(sid), cn,
+                                          cJSON_GetStringValue(health),
+                                          cJSON_GetStringValue(version)) == 0;
+   cJSON_Delete(j);
+   snprintf(resp, (size_t)cap, ok ? "{\"ok\":true}" : "{\"error\":\"heartbeat rejected\"}");
+   return ok ? 200 : 403;
 }
 
 /* GET /v1/enroll/ca: return the CA certificate (public trust anchor) so a
@@ -292,6 +311,14 @@ void kb_tls_serve_conn(int fd, SSL_CTX *ctx)
       {
          status = mtls_renew(cn, body, resp, KB_TLS_RESP_MAX);
       }
+   }
+   else if (have_cert && strcmp(cpath, "/v1/server/heartbeat") == 0)
+   {
+      status = (strcmp(method, "POST") == 0)
+                   ? mtls_server_heartbeat(cn, body, resp, KB_TLS_RESP_MAX)
+                   : 405;
+      if (status == 405)
+         snprintf(resp, KB_TLS_RESP_MAX, "{\"error\":\"method not allowed\"}");
    }
    else
    {


### PR DESCRIPTION
Adds POST /v1/server/heartbeat on the mTLS listener, binding updates to verified peer cert CN and registry server_id. Build validated.