### PR TITLE
feat(p5): verify management JWTs on server

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -413,6 +413,7 @@ SERVER_SRCS = cli_v1_routes.c cli_v1_routes_b.c cli_v1_routes_c.c cli_v1_routes_
               modules/workflows/wfe_engine.c modules/workflows/wfe_blocks.c modules/workflows/wfe_approval.c \
               modules/workflows/wfe_verdict.c modules/workflows/wfe_roundtable.c modules/workflows/wfe_autonomy.c \
               server/server_workflow_api.c
+SERVER_SRCS += server/server_mgmt_token.c server/kb_verifier_server_stub.c kb/auth_oidc.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) modules/guardrails/guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/server/kb_verifier_server_stub.c
+++ b/src/server/kb_verifier_server_stub.c
@@ -1,0 +1,3 @@
+#include "kb_verifier.h"
+int kb_verifier_register(const char *n, kb_verifier_fn f, void *c)
+{ (void)n; (void)f; (void)c; return -1; }

--- a/src/server/server_mgmt_token.c
+++ b/src/server/server_mgmt_token.c
@@ -1,0 +1,14 @@
+#include "server_mgmt_token.h"
+#include "kb_auth_oidc.h"
+#include <stdio.h>
+#include <string.h>
+int server_mgmt_token_verify(const char *jwt, const char *jwks_json, const char *issuer,
+                             const char *audience, long now, kb_verify_result_t *out)
+{
+   if (!jwt || !jwks_json || !*jwks_json || !out) return 0;
+   kb_oidc_config_t c; memset(&c, 0, sizeof(c));
+   if (issuer) snprintf(c.issuer, sizeof(c.issuer), "%s", issuer);
+   if (audience) snprintf(c.audience, sizeof(c.audience), "%s", audience);
+   snprintf(c.jwks_json, sizeof(c.jwks_json), "%s", jwks_json);
+   return kb_oidc_verify_jwt(jwt, &c, now, out);
+}

--- a/src/server/server_mgmt_token.h
+++ b/src/server/server_mgmt_token.h
@@ -1,0 +1,6 @@
+#ifndef AIMEE_SERVER_MGMT_TOKEN_H
+#define AIMEE_SERVER_MGMT_TOKEN_H
+#include "kb_verifier.h"
+int server_mgmt_token_verify(const char *jwt, const char *jwks_json, const char *issuer,
+                             const char *audience, long now, kb_verify_result_t *out);
+#endif


### PR DESCRIPTION
Reuses the existing RS256/JWKS verifier in the server binary and exposes a fail-closed server_mgmt_token_verify API enforcing issuer, audience, expiry, and signature. Build: make -j$(nproc) server.