### PR TITLE
feat(p5): gate management actions by capability and policy

### DIFF
--- a/src/server/server_mgmt_token.c
+++ b/src/server/server_mgmt_token.c
@@ -40,3 +40,15 @@ int server_mgmt_token_verify_bound(const char *jwt, const char *jwks_json, const
    if(ok){snprintf(cap,cap_n,"%s",cc->valuestring);snprintf(jti,jti_n,"%s",jj->valuestring);}
    cJSON_Delete(p); return ok;
 }
+
+int server_mgmt_action_authorize(const char *jwt, const char *jwks_json, const char *issuer,
+                                 const char *audience, const char *peer_cert_cn, long now,
+                                 int remote_writes, const char *required, kb_verify_result_t *out,
+                                 char *jti, size_t jti_n)
+{
+   if (!remote_writes || !required || !*required || !jti || !jti_n) return 0;
+   char cap[128];
+   if (!server_mgmt_token_verify_bound(jwt, jwks_json, issuer, audience, peer_cert_cn, now,
+                                       out, cap, sizeof(cap), jti, jti_n)) return 0;
+   return strcmp(cap, required) == 0;
+}

--- a/src/server/server_mgmt_token.h
+++ b/src/server/server_mgmt_token.h
@@ -7,4 +7,8 @@ int server_mgmt_token_verify_bound(const char *jwt, const char *jwks_json, const
                                    const char *audience, const char *peer_cert_cn, long now,
                                    kb_verify_result_t *out, char *capability, size_t cap_n,
                                    char *jti, size_t jti_n);
+int server_mgmt_action_authorize(const char *jwt, const char *jwks_json, const char *issuer,
+                                 const char *audience, const char *peer_cert_cn, long now,
+                                 int remote_writes, const char *required_capability,
+                                 kb_verify_result_t *out, char *jti, size_t jti_n);
 #endif


### PR DESCRIPTION
Adds a fail-closed action authorization helper requiring peer-bound JWT verification, exact capability match, non-empty jti, and remote_writes enabled. Build: make -j$(nproc) server.