### PR TITLE
feat(p5): add management intent and outcome audit contract

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -413,7 +413,7 @@ SERVER_SRCS = cli_v1_routes.c cli_v1_routes_b.c cli_v1_routes_c.c cli_v1_routes_
               modules/workflows/wfe_engine.c modules/workflows/wfe_blocks.c modules/workflows/wfe_approval.c \
               modules/workflows/wfe_verdict.c modules/workflows/wfe_roundtable.c modules/workflows/wfe_autonomy.c \
               server/server_workflow_api.c
-SERVER_SRCS += server/server_mgmt_token.c server/kb_verifier_server_stub.c kb/auth_oidc.c
+SERVER_SRCS += server/server_mgmt_token.c server/kb_verifier_server_stub.c kb/auth_oidc.c server/server_mgmt_audit.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) modules/guardrails/guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/server/server_mgmt_audit.c
+++ b/src/server/server_mgmt_audit.c
@@ -1,0 +1,24 @@
+#include "server_mgmt_audit.h"
+#include "audit_worm.h"
+#include <stdio.h>
+#include <string.h>
+
+static int valid(const char *s)
+{
+   if (!s || strlen(s) > 256) return 0;
+   for (; *s; s++) if ((unsigned char)*s < 0x20) return 0;
+   return 1;
+}
+static int append(const char *action, const char *actor, const char *target, const char *cap,
+                  const char *jti, const char *digest, const char *verdict)
+{
+   if (!valid(actor)||!valid(target)||!valid(cap)||!valid(jti)||!valid(digest)) return -1;
+   char detail[1400];
+   snprintf(detail,sizeof(detail),"actor=%s target=%s capability=%s jti=%s request_digest=%s",
+            actor,target,cap,jti,digest);
+   return audit_worm_append("management",actor,action,target,verdict,detail);
+}
+int server_mgmt_audit_intent(const char *a,const char *t,const char *c,const char *j,const char*d)
+{ return append("management.intent",a,t,c,j,d,"intent"); }
+int server_mgmt_audit_outcome(const char *a,const char *t,const char *c,const char *j,const char*d,int st)
+{ char v[32]; snprintf(v,sizeof(v),"status_%d",st); return append("management.outcome",a,t,c,j,d,v); }

--- a/src/server/server_mgmt_audit.h
+++ b/src/server/server_mgmt_audit.h
@@ -1,0 +1,7 @@
+#ifndef AIMEE_SERVER_MGMT_AUDIT_H
+#define AIMEE_SERVER_MGMT_AUDIT_H
+int server_mgmt_audit_intent(const char *actor, const char *target, const char *cap,
+                             const char *jti, const char *request_digest);
+int server_mgmt_audit_outcome(const char *actor, const char *target, const char *cap,
+                               const char *jti, const char *request_digest, int status);
+#endif


### PR DESCRIPTION
Adds bounded management intent/outcome audit helpers backed by the existing fsync-durable audit WORM chain. Rejects controls/oversized fields and records only actor, target, capability, jti, digest, and status. Build: make -j$(nproc) server.