### PR TITLE
feat(p5): enforce intent-before-dispatch audit ordering

### DIFF
--- a/src/server/server_mgmt_audit.c
+++ b/src/server/server_mgmt_audit.c
@@ -22,3 +22,11 @@ int server_mgmt_audit_intent(const char *a,const char *t,const char *c,const cha
 { return append("management.intent",a,t,c,j,d,"intent"); }
 int server_mgmt_audit_outcome(const char *a,const char *t,const char *c,const char *j,const char*d,int st)
 { char v[32]; snprintf(v,sizeof(v),"status_%d",st); return append("management.outcome",a,t,c,j,d,v); }
+int server_mgmt_dispatch_audited(const char *a,const char *t,const char *c,const char *j,
+                                 const char *d, server_mgmt_action_fn fn, void *ctx)
+{
+   if (!fn || server_mgmt_audit_intent(a,t,c,j,d) != 0) return -1;
+   int st = fn(ctx);
+   if (server_mgmt_audit_outcome(a,t,c,j,d,st) != 0) return -1;
+   return st;
+}

--- a/src/server/server_mgmt_audit.h
+++ b/src/server/server_mgmt_audit.h
@@ -4,4 +4,8 @@ int server_mgmt_audit_intent(const char *actor, const char *target, const char *
                              const char *jti, const char *request_digest);
 int server_mgmt_audit_outcome(const char *actor, const char *target, const char *cap,
                                const char *jti, const char *request_digest, int status);
+typedef int (*server_mgmt_action_fn)(void *ctx);
+int server_mgmt_dispatch_audited(const char *actor, const char *target, const char *cap,
+                                 const char *jti, const char *request_digest,
+                                 server_mgmt_action_fn action, void *ctx);
 #endif


### PR DESCRIPTION
Adds an audited dispatch seam that persists intent before invoking a management action callback and appends the outcome afterward; audit failure prevents dispatch or returns failure. Build: make -j$(nproc) server.