### PR TITLE
test(p6c): cover signed Bedrock dispatch seam

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -161,6 +161,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-aimee-frontend \
                $(TESTPREFIX)/unit-test-aimee-backend \
                $(TESTPREFIX)/unit-test-aimee-backend-bedrock \
+               $(TESTPREFIX)/unit-test-kb-bedrock-dispatch \
                $(TESTPREFIX)/unit-test-aimee-ir-shadow \
                $(TESTPREFIX)/unit-test-aimee-ir-serve \
                $(TESTPREFIX)/unit-test-aimee-ir-stream \
@@ -1668,6 +1669,14 @@ $(TESTPREFIX)/unit-test-aimee-backend-bedrock: $(OBJDIR)/tests/test_aimee_backen
                                       $(OBJDIR)/server/aimee_backend_bedrock.o \
                                       $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/cJSON.o \
                                       $(OBJDIR)/text.o $(OBJDIR)/util.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-kb-bedrock-dispatch: $(OBJDIR)/tests/test_kb_bedrock_dispatch.o \
+                                      $(OBJDIR)/kb/kb_bedrock_egress.o \
+                                      $(OBJDIR)/server/aimee_backend_bedrock.o \
+                                      $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/cJSON.o \
+                                      $(OBJDIR)/modules/aws/aws_sigv4.o \
+                                      $(OBJDIR)/modules/aws/aws_eventstream.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # Slice 3: IR shadow observer (pure — cJSON only).

--- a/src/tests/test_kb_bedrock_dispatch.c
+++ b/src/tests/test_kb_bedrock_dispatch.c
@@ -1,0 +1,41 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "../kb/kb_bedrock_egress.h"
+
+static char seen_host[512], seen_path[1024], seen_auth[2400];
+static int seen_port;
+
+int kb_tls_client_request_auth(const char *host, int port, const char *ca,
+                               const char *cert, const char *key,
+                               const char *method, const char *path,
+                               const char *body, const char *auth,
+                               char *out, size_t cap, int *status)
+{
+   (void)ca; (void)cert; (void)key; (void)method; (void)body;
+   snprintf(seen_host, sizeof(seen_host), "%s", host);
+   snprintf(seen_path, sizeof(seen_path), "%s", path);
+   snprintf(seen_auth, sizeof(seen_auth), "%s", auth);
+   seen_port = port;
+   snprintf(out, cap, "{\"ok\":true}");
+   if (status) *status = 200;
+   return 0;
+}
+
+int main(void)
+{
+   aimee_request_t ir = {0};
+   ir.model = "demo";
+   kb_bedrock_target_t t = {"demo.model", "us-east-1", "aws", "https://mockbedrock:8443/base"};
+   char out[64]; int status = 0;
+   assert(kb_bedrock_dispatch_https(&t, &ir, 0, "AKID", "SECRET", "TOKEN",
+                                    "20260101T000000Z", "20260101", "CA", NULL,
+                                    out, sizeof(out), &status) == 0);
+   assert(strcmp(seen_host, "mockbedrock") == 0);
+   assert(seen_port == 8443);
+   assert(strcmp(seen_path, "/model/demo.model/converse") == 0);
+   assert(strstr(seen_auth, "Authorization: AWS4-HMAC-SHA256 ") != NULL);
+   assert(strstr(seen_auth, "X-Amz-Security-Token: TOKEN") != NULL);
+   assert(status == 200 && strstr(out, "ok") != NULL);
+   return 0;
+}


### PR DESCRIPTION
Adds a focused TLS seam test asserting endpoint port resolution, Converse path, SigV4 Authorization, and session token propagation.