### PR TITLE
feat(p7): add guarded PKCS11 custody provider

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -330,7 +330,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 VAULT_CORE_SRCS = modules/vault/vault_crypto.c modules/vault/vault_principal.c \
                   modules/vault/vault_kek_cache.c modules/vault/vault_store.c \
                   modules/vault/vault_service.c modules/vault/vault_server_key.c \
-                  modules/vault/vault_custody_mock.c modules/vault/vault_custody_tpm2.c \
+                  modules/vault/vault_custody_mock.c modules/vault/vault_custody_tpm2.c modules/vault/vault_custody_pkcs11.c \
                   modules/vault/vault_capability.c
 KB_VAULT_OBJS = $(VAULT_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o)
 
@@ -345,6 +345,13 @@ KB_TPM2_LDLIBS := $(shell pkg-config --libs tss2-esys 2>/dev/null) -ltss2-mu -lt
 else
 KB_TPM2_CFLAGS :=
 KB_TPM2_LDLIBS :=
+endif
+ifeq ($(WITH_PKCS11),1)
+KB_PKCS11_CFLAGS := -DWITH_PKCS11 $(shell pkg-config --cflags p11-kit-1 2>/dev/null || echo -I/usr/include/p11-kit-1)
+KB_PKCS11_LDLIBS := -ldl
+else
+KB_PKCS11_CFLAGS :=
+KB_PKCS11_LDLIBS :=
 endif
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
@@ -964,7 +971,7 @@ $(SERVER): $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(AGENT_OBJS) $(SERVER_DATA_O
 # util (openssl + platform_random only), so the kb sidecar links it directly.
 $(KB): $(KB_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_VAULT_OBJS) $(KB_PLATFORM_OBJS) $(TS_VENDOR_OBJS)
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
-	$(CC) -o $@ $^ $(L_KB) $(KB_TPM2_LDLIBS)
+	$(CC) -o $@ $^ $(L_KB) $(KB_TPM2_LDLIBS) $(KB_PKCS11_LDLIBS)
 
 # Standalone libpq memory-negation eval driver (dev tool, not part of `all`): the
 # aimee-kb object set with kb_main() swapped for a corpus-eval main() plus the
@@ -1033,7 +1040,7 @@ $(OBJDIR)/kb_client_tool_registry.o: modules/kb_client/kb_client_tool_registry.c
 # kb object is harmless and keeps the WITH_TPM2 switch in one place (P7-tpm2a).
 $(OBJDIR)/kb/%.o: %.c
 	@mkdir -p $(dir $@)
-	$(CC) -c $(C_FLAGS) $(KB_TPM2_CFLAGS) -DAIMEE_DB1_DISABLED -DAIMEE_DISABLE_DB2_SQLITE_SHIM -o $@ $<
+	$(CC) -c $(C_FLAGS) $(KB_TPM2_CFLAGS) $(KB_PKCS11_CFLAGS) -DAIMEE_DB1_DISABLED -DAIMEE_DISABLE_DB2_SQLITE_SHIM -o $@ $<
 
 $(OBJDIR)/server/%.o: %.c
 	@mkdir -p $(dir $@)

--- a/src/kb/kb_vault_policy.c
+++ b/src/kb/kb_vault_policy.c
@@ -5,6 +5,7 @@
 #include "kb_vault_policy.h"
 #include "vault_custody_mock.h" /* vault_custody_mock_provider */
 #include "vault_custody_tpm2.h" /* vault_custody_tpm2_provider (real or stub) */
+#include "vault_custody_pkcs11.h"
 #include "vault_internal.h"     /* vault_custody_set_provider */
 #include "vault_server_key.h"   /* vault_is_sealed */
 #include <stdio.h>
@@ -75,6 +76,9 @@ int kb_vault_policy_select(const char *custody, char *errbuf, size_t errlen)
       return 0;
 
    case KB_CUSTODY_PKCS11:
+      vault_custody_set_provider(vault_custody_pkcs11_provider());
+      g_selected = KB_CUSTODY_PKCS11;
+      return 0;
    case KB_CUSTODY_KMS:
       /* Declared but unimplemented: fail closed — never silently fall back to a
        * plaintext/file root under a config that asked for an anchor. */

--- a/src/modules/vault/vault_custody_pkcs11.c
+++ b/src/modules/vault/vault_custody_pkcs11.c
@@ -15,10 +15,13 @@ static int open_token(pk11_ctx *c)
   unsigned long slot=slot_s?strtoul(slot_s,NULL,10):0; if(!pin||!*pin)return -1;
   c->dl=dlopen(mod,RTLD_NOW|RTLD_LOCAL); if(!c->dl)return -1;
   CK_C_GetFunctionList get=(CK_C_GetFunctionList)dlsym(c->dl,"C_GetFunctionList"); if(!get||get(&c->f)!=CKR_OK)return -1;
-  if(c->f->C_Initialize(NULL_PTR)!=CKR_OK)return -1; CK_ULONG n=8; CK_SLOT_ID slots[8];
-  if(c->f->C_GetSlotList(CK_TRUE,slots,&n)!=CKR_OK||!n)return -1; if(slot_s&&slot>=n) return -1; slot=slot_s?slots[slot]:slots[0];
+  if(c->f->C_Initialize(NULL_PTR)!=CKR_OK)return -1;
+  CK_ULONG n=8; CK_SLOT_ID slots[8];
+  if(c->f->C_GetSlotList(CK_TRUE,slots,&n)!=CKR_OK||!n)return -1;
+  if(slot_s&&slot>=n) return -1; slot=slot_s?slots[slot]:slots[0];
   if(c->f->C_OpenSession(slot,CKF_SERIAL_SESSION|CKF_RW_SESSION,NULL,NULL,&c->s)!=CKR_OK)return -1;
-  if(c->f->C_Login(c->s,CKU_USER,(CK_UTF8CHAR_PTR)pin,(CK_ULONG)strlen(pin))!=CKR_OK)return -1; c->sealed=0; return 0;
+  if(c->f->C_Login(c->s,CKU_USER,(CK_UTF8CHAR_PTR)pin,(CK_ULONG)strlen(pin))!=CKR_OK)return -1;
+  c->sealed=0; return 0;
 }
 static int get_kek(void *v,uint8_t out[VAULT_KEK_LEN])
 { pk11_ctx*c=v; pthread_mutex_lock(&c->mu); if(c->sealed&&open_token(c)!=0){pthread_mutex_unlock(&c->mu);return -1;} const char *label=getenv("AIMEE_VAULT_PKCS11_LABEL"); if(!label||!*label)label="aimee-kek"; CK_UTF8CHAR lab[128]; memcpy(lab,label,strlen(label)); CK_ULONG ll=strlen(label); CK_ATTRIBUTE q={CKA_LABEL,lab,ll}; if(c->f->C_FindObjectsInit(c->s,&q,1)!=CKR_OK){pthread_mutex_unlock(&c->mu);return -1;} CK_OBJECT_HANDLE o=0; CK_ULONG n=0; CK_RV r=c->f->C_FindObjects(c->s,&o,1,&n); c->f->C_FindObjectsFinal(c->s); if(r!=CKR_OK||n!=1){pthread_mutex_unlock(&c->mu);return -1;} CK_ULONG len=VAULT_KEK_LEN; CK_ATTRIBUTE a={CKA_VALUE,out,len}; r=c->f->C_GetAttributeValue(c->s,o,&a,1); pthread_mutex_unlock(&c->mu); return r==CKR_OK&&a.ulValueLen==VAULT_KEK_LEN?0:-1; }

--- a/src/modules/vault/vault_custody_pkcs11.c
+++ b/src/modules/vault/vault_custody_pkcs11.c
@@ -18,7 +18,8 @@ static int open_token(pk11_ctx *c)
   if(c->f->C_Initialize(NULL_PTR)!=CKR_OK)return -1;
   CK_ULONG n=8; CK_SLOT_ID slots[8];
   if(c->f->C_GetSlotList(CK_TRUE,slots,&n)!=CKR_OK||!n)return -1;
-  if(slot_s&&slot>=n) return -1; slot=slot_s?slots[slot]:slots[0];
+  if(slot_s&&slot>=n) return -1;
+  slot=slot_s?slots[slot]:slots[0];
   if(c->f->C_OpenSession(slot,CKF_SERIAL_SESSION|CKF_RW_SESSION,NULL,NULL,&c->s)!=CKR_OK)return -1;
   if(c->f->C_Login(c->s,CKU_USER,(CK_UTF8CHAR_PTR)pin,(CK_ULONG)strlen(pin))!=CKR_OK)return -1;
   c->sealed=0; return 0;

--- a/src/modules/vault/vault_custody_pkcs11.c
+++ b/src/modules/vault/vault_custody_pkcs11.c
@@ -2,6 +2,7 @@
 #include "vault_crypto.h"
 #include <string.h>
 #include <stdlib.h>
+#include <pthread.h>
 #ifdef WITH_PKCS11
 #include <dlfcn.h>
 #include <p11-kit/pkcs11.h>

--- a/src/modules/vault/vault_custody_pkcs11.c
+++ b/src/modules/vault/vault_custody_pkcs11.c
@@ -1,0 +1,32 @@
+#include "vault_custody_pkcs11.h"
+#include "vault_crypto.h"
+#include <string.h>
+#include <stdlib.h>
+#ifdef WITH_PKCS11
+#include <dlfcn.h>
+#include <p11-kit/pkcs11.h>
+typedef struct { pthread_mutex_t mu; void *dl; CK_FUNCTION_LIST_PTR f; CK_SESSION_HANDLE s; int sealed; } pk11_ctx;
+static pk11_ctx g = { PTHREAD_MUTEX_INITIALIZER, NULL, NULL, 0, 1 };
+static int open_token(pk11_ctx *c)
+{
+  const char *mod=getenv("AIMEE_VAULT_PKCS11_MODULE"); if(!mod||!*mod) mod="/usr/lib/softhsm/libsofthsm2.so";
+  const char *pin=getenv("AIMEE_VAULT_PKCS11_PIN"); const char *slot_s=getenv("AIMEE_VAULT_PKCS11_SLOT");
+  unsigned long slot=slot_s?strtoul(slot_s,NULL,10):0; if(!pin||!*pin)return -1;
+  c->dl=dlopen(mod,RTLD_NOW|RTLD_LOCAL); if(!c->dl)return -1;
+  CK_C_GetFunctionList get=(CK_C_GetFunctionList)dlsym(c->dl,"C_GetFunctionList"); if(!get||get(&c->f)!=CKR_OK)return -1;
+  if(c->f->C_Initialize(NULL_PTR)!=CKR_OK)return -1; CK_ULONG n=8; CK_SLOT_ID slots[8];
+  if(c->f->C_GetSlotList(CK_TRUE,slots,&n)!=CKR_OK||!n)return -1; if(slot_s&&slot>=n) return -1; slot=slot_s?slots[slot]:slots[0];
+  if(c->f->C_OpenSession(slot,CKF_SERIAL_SESSION|CKF_RW_SESSION,NULL,NULL,&c->s)!=CKR_OK)return -1;
+  if(c->f->C_Login(c->s,CKU_USER,(CK_UTF8CHAR_PTR)pin,(CK_ULONG)strlen(pin))!=CKR_OK)return -1; c->sealed=0; return 0;
+}
+static int get_kek(void *v,uint8_t out[VAULT_KEK_LEN])
+{ pk11_ctx*c=v; pthread_mutex_lock(&c->mu); if(c->sealed&&open_token(c)!=0){pthread_mutex_unlock(&c->mu);return -1;} const char *label=getenv("AIMEE_VAULT_PKCS11_LABEL"); if(!label||!*label)label="aimee-kek"; CK_UTF8CHAR lab[128]; memcpy(lab,label,strlen(label)); CK_ULONG ll=strlen(label); CK_ATTRIBUTE q={CKA_LABEL,lab,ll}; if(c->f->C_FindObjectsInit(c->s,&q,1)!=CKR_OK){pthread_mutex_unlock(&c->mu);return -1;} CK_OBJECT_HANDLE o=0; CK_ULONG n=0; CK_RV r=c->f->C_FindObjects(c->s,&o,1,&n); c->f->C_FindObjectsFinal(c->s); if(r!=CKR_OK||n!=1){pthread_mutex_unlock(&c->mu);return -1;} CK_ULONG len=VAULT_KEK_LEN; CK_ATTRIBUTE a={CKA_VALUE,out,len}; r=c->f->C_GetAttributeValue(c->s,o,&a,1); pthread_mutex_unlock(&c->mu); return r==CKR_OK&&a.ulValueLen==VAULT_KEK_LEN?0:-1; }
+static int sealed(void*v){return ((pk11_ctx*)v)->sealed;}
+static int unseal(void*v,const void*p,size_t n){(void)p;(void)n;pk11_ctx*c=v;pthread_mutex_lock(&c->mu);int r=open_token(c);pthread_mutex_unlock(&c->mu);return r;}
+static int seal(void*v){((pk11_ctx*)v)->sealed=1;return 0;}
+static int rotate(void*v,const char*a,int*b,int*c,char*d,size_t e,char*f,size_t g){(void)v;(void)a;(void)b;(void)c;(void)d;(void)e;(void)f;(void)g;return -1;}
+static const vault_custody_provider_t p={"pkcs11",&g,get_kek,rotate,sealed,unseal,seal};
+#else
+static int fail(void*v,uint8_t k[VAULT_KEK_LEN]){(void)v;(void)k;return -1;} static int yes(void*v){(void)v;return 1;} static int no(void*v,const void*p,size_t n){(void)v;(void)p;(void)n;return -1;} static int no_seal(void*v){(void)v;return -1;} static int rot(void*v,const char*a,int*b,int*c,char*d,size_t e,char*f,size_t g){(void)v;(void)a;(void)b;(void)c;(void)d;(void)e;(void)f;(void)g;return -1;} static const vault_custody_provider_t p={"pkcs11",NULL,fail,rot,yes,no,no_seal};
+#endif
+const vault_custody_provider_t *vault_custody_pkcs11_provider(void){return &p;}

--- a/src/modules/vault/vault_custody_pkcs11.h
+++ b/src/modules/vault/vault_custody_pkcs11.h
@@ -1,0 +1,5 @@
+#ifndef AIMEE_VAULT_CUSTODY_PKCS11_H
+#define AIMEE_VAULT_CUSTODY_PKCS11_H
+#include "vault_internal.h"
+const vault_custody_provider_t *vault_custody_pkcs11_provider(void);
+#endif


### PR DESCRIPTION
Adds a fail-closed default and WITH_PKCS11 token-backed provider with login, label lookup, and KEK retrieval. Wires policy selection and build/link flags.