### PR TITLE
feat(p2b): wire admitted Bedrock dispatch

### DIFF
--- a/src/kb/kb_egress_admission.c
+++ b/src/kb/kb_egress_admission.c
@@ -4,6 +4,12 @@
 #include "kb_vault_policy.h"
 #include <stdio.h>
 #include <string.h>
+typedef struct { const kb_bedrock_target_t *target; const aimee_request_t *ir; int stream;
+                 const char *ak,*sk,*tok,*amz,*date,*ca,*cc; char *out; size_t cap; int *status; } bedrock_ctx;
+static int bedrock_cb(void *v,char *out,size_t cap,char *err,size_t errlen)
+{ bedrock_ctx *c=v; int rc=kb_bedrock_dispatch_https(c->target,c->ir,c->stream,c->ak,c->sk,c->tok,c->amz,c->date,c->ca,c->cc,out,cap,c->status); if(rc!=0&&err&&errlen)snprintf(err,errlen,"bedrock dispatch failed"); return rc; }
+int kb_egress_bedrock_dispatch(const kb_egress_admission_t *a,const kb_bedrock_target_t*t,const aimee_request_t*ir,int stream,const char*ak,const char*sk,const char*tok,const char*amz,const char*date,const char*ca,const char*cc,char*out,size_t cap,int*status)
+{ if(!t||!ir||!ak||!sk||!amz||!date||!ca||!out||!cap)return -1; bedrock_ctx c={t,ir,stream,ak,sk,tok,amz,date,ca,cc,out,cap,status}; return kb_egress_admit_dispatch(a,bedrock_cb,&c,out,cap); }
 int kb_egress_admit_dispatch(const kb_egress_admission_t *a, kb_egress_dispatch_fn fn, void *ctx,
                              char *out, size_t cap)
 {

--- a/src/kb/kb_egress_admission.h
+++ b/src/kb/kb_egress_admission.h
@@ -2,6 +2,7 @@
 #define KB_EGRESS_ADMISSION_H
 #include <stdint.h>
 #include <stddef.h>
+#include "kb_bedrock_egress.h"
 typedef struct
 {
    const char *origin_cn, *request_id, *model, *cred_slot;
@@ -13,4 +14,8 @@ typedef struct
 typedef int (*kb_egress_dispatch_fn)(void *, char *, size_t, char *, size_t);
 int kb_egress_admit_dispatch(const kb_egress_admission_t *, kb_egress_dispatch_fn, void *, char *,
                              size_t);
+int kb_egress_bedrock_dispatch(const kb_egress_admission_t *, const kb_bedrock_target_t *,
+                               const aimee_request_t *, int, const char *, const char *,
+                               const char *, const char *, const char *, const char *,
+                               const char *, char *, size_t, int *);
 #endif


### PR DESCRIPTION
Adds a concrete P2b wrapper that reserves rate/budget admission before invoking signed Bedrock HTTPS dispatch and settles through the existing admission callback.