### PR TITLE
test(p6c): cover native Bedrock streaming dispatch path

### DIFF
--- a/src/tests/test_kb_bedrock_dispatch.c
+++ b/src/tests/test_kb_bedrock_dispatch.c
@@ -37,5 +37,9 @@ int main(void)
    assert(strstr(seen_auth, "Authorization: AWS4-HMAC-SHA256 ") != NULL);
    assert(strstr(seen_auth, "X-Amz-Security-Token: TOKEN") != NULL);
    assert(status == 200 && strstr(out, "ok") != NULL);
+   assert(kb_bedrock_dispatch_https(&t, &ir, 1, "AKID", "SECRET", NULL,
+                                    "20260101T000000Z", "20260101", "CA", NULL,
+                                    out, sizeof(out), &status) == 0);
+   assert(strcmp(seen_path, "/model/demo.model/converse-stream") == 0);
    return 0;
 }


### PR DESCRIPTION
Extend the Bedrock egress seam test to exercise Converse streaming path selection and SigV4 dispatch. Targeted unit build and execution pass.