### PR TITLE
test(p6c): add live Bedrock TLS dispatch harness

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -162,6 +162,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-aimee-backend \
                $(TESTPREFIX)/unit-test-aimee-backend-bedrock \
                $(TESTPREFIX)/unit-test-kb-bedrock-dispatch \
+               $(TESTPREFIX)/unit-test-kb-bedrock-live \
                $(TESTPREFIX)/unit-test-aimee-ir-shadow \
                $(TESTPREFIX)/unit-test-aimee-ir-serve \
                $(TESTPREFIX)/unit-test-aimee-ir-stream \
@@ -1673,6 +1674,15 @@ $(TESTPREFIX)/unit-test-aimee-backend-bedrock: $(OBJDIR)/tests/test_aimee_backen
 
 $(TESTPREFIX)/unit-test-kb-bedrock-dispatch: $(OBJDIR)/tests/test_kb_bedrock_dispatch.o \
                                       $(OBJDIR)/kb/kb_bedrock_egress.o \
+                                      $(OBJDIR)/server/aimee_backend_bedrock.o \
+                                      $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/cJSON.o \
+                                      $(OBJDIR)/modules/aws/aws_sigv4.o \
+                                      $(OBJDIR)/modules/aws/aws_eventstream.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-kb-bedrock-live: $(OBJDIR)/tests/test_kb_bedrock_live.o \
+                                      $(OBJDIR)/kb/kb_bedrock_egress.o \
+                                      $(OBJDIR)/kb/http/kb_tls.o \
                                       $(OBJDIR)/server/aimee_backend_bedrock.o \
                                       $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/cJSON.o \
                                       $(OBJDIR)/modules/aws/aws_sigv4.o \

--- a/src/tests/test_kb_bedrock_live.c
+++ b/src/tests/test_kb_bedrock_live.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include "../kb/kb_bedrock_egress.h"
 
 int main(int argc, char **argv)
@@ -12,10 +13,16 @@ int main(int argc, char **argv)
    aimee_request_t ir = {0};
    ir.model = "live-test";
    kb_bedrock_target_t t = {"live-test", "us-east-1", "aws", argv[1]};
+   FILE *f = fopen(argv[2], "rb");
+   if (!f) return 2;
+   char ca[65536];
+   size_t ca_len = fread(ca, 1, sizeof(ca) - 1, f);
+   fclose(f);
+   ca[ca_len] = 0;
    char response[262144];
    int status = 0;
    int rc = kb_bedrock_dispatch_https(&t, &ir, 0, "AKID", "SECRET", NULL,
-                                      "20260101T000000Z", "20260101", argv[2], NULL,
+                                      "20260101T000000Z", "20260101", ca, NULL,
                                       response, sizeof(response), &status);
    if (rc != 0 || status != 200) {
       fprintf(stderr, "Bedrock mock request failed rc=%d status=%d\n", rc, status);

--- a/src/tests/test_kb_bedrock_live.c
+++ b/src/tests/test_kb_bedrock_live.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../kb/kb_bedrock_egress.h"
+
+int main(int argc, char **argv)
+{
+   if (argc != 3) {
+      fprintf(stderr, "usage: %s https://host:port ca.pem\n", argv[0]);
+      return 2;
+   }
+   aimee_request_t ir = {0};
+   ir.model = "live-test";
+   kb_bedrock_target_t t = {"live-test", "us-east-1", "aws", argv[1]};
+   char response[262144];
+   int status = 0;
+   int rc = kb_bedrock_dispatch_https(&t, &ir, 0, "AKID", "SECRET", NULL,
+                                      "20260101T000000Z", "20260101", argv[2], NULL,
+                                      response, sizeof(response), &status);
+   if (rc != 0 || status != 200) {
+      fprintf(stderr, "Bedrock mock request failed rc=%d status=%d\n", rc, status);
+      return 1;
+   }
+   if (!strstr(response, "200") && !strstr(response, "ok") && !strstr(response, "HTTP"))
+      return 1;
+   puts("kb_bedrock_live: ok");
+   return 0;
+}


### PR DESCRIPTION
Add a real-network Bedrock egress harness for CT260 integration validation. It links the production TLS transport, dispatches signed Converse requests to a supplied HTTPS mock endpoint, and checks HTTP 200.