### PR TITLE
test(p5): add live management mTLS client harness

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -163,6 +163,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-aimee-backend-bedrock \
                $(TESTPREFIX)/unit-test-kb-bedrock-dispatch \
                $(TESTPREFIX)/unit-test-kb-bedrock-live \
+               $(TESTPREFIX)/unit-test-kb-mgmt-live \
                $(TESTPREFIX)/unit-test-aimee-ir-shadow \
                $(TESTPREFIX)/unit-test-aimee-ir-serve \
                $(TESTPREFIX)/unit-test-aimee-ir-stream \
@@ -1687,6 +1688,12 @@ $(TESTPREFIX)/unit-test-kb-bedrock-live: $(OBJDIR)/tests/test_kb_bedrock_live.o 
                                       $(OBJDIR)/server/aimee_ir.o $(OBJDIR)/cJSON.o \
                                       $(OBJDIR)/modules/aws/aws_sigv4.o \
                                       $(OBJDIR)/modules/aws/aws_eventstream.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-kb-mgmt-live: $(OBJDIR)/tests/test_kb_mgmt_live.o \
+                                      $(OBJDIR)/kb/kb_mgmt_client.o \
+                                      $(OBJDIR)/kb/kb_mgmt_endpoint.o \
+                                      $(OBJDIR)/kb/http/kb_tls.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # Slice 3: IR shadow observer (pure — cJSON only).

--- a/src/tests/test_kb_mgmt_live.c
+++ b/src/tests/test_kb_mgmt_live.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <string.h>
+#include "../kb/kb_mgmt_client.h"
+
+int main(int argc, char **argv)
+{
+   if (argc != 3) {
+      fprintf(stderr, "usage: %s https://host:port ca.pem\n", argv[0]);
+      return 2;
+   }
+   FILE *f = fopen(argv[2], "rb");
+   if (!f) return 2;
+   char ca[65536]; size_t nca = fread(ca, 1, sizeof(ca) - 1, f); fclose(f); ca[nca] = 0;
+   char out[4096]; int status = 0;
+   const char *auth = "Authorization: Bearer management-test\r\n";
+   int rc = kb_mgmt_client_request_auth(argv[1], ca, NULL, NULL, "GET", "/v1/health",
+                                        NULL, auth, out, sizeof(out), &status);
+   if (rc != 0 || status != 200 || !strstr(out, "ok")) return 1;
+   puts("kb_mgmt_live: ok");
+   return 0;
+}


### PR DESCRIPTION
Add a real-network management client harness using the production TLS transport and Authorization propagation. Build passes; it is intended for two-node CT integration validation.