### PR TITLE
feat(p7): add fail-closed external KMS custody provider

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -330,7 +330,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 VAULT_CORE_SRCS = modules/vault/vault_crypto.c modules/vault/vault_principal.c \
                   modules/vault/vault_kek_cache.c modules/vault/vault_store.c \
                   modules/vault/vault_service.c modules/vault/vault_server_key.c \
-                  modules/vault/vault_custody_mock.c modules/vault/vault_custody_tpm2.c modules/vault/vault_custody_pkcs11.c \
+                  modules/vault/vault_custody_mock.c modules/vault/vault_custody_tpm2.c modules/vault/vault_custody_pkcs11.c modules/vault/vault_custody_kms.c \
                   modules/vault/vault_capability.c
 KB_VAULT_OBJS = $(VAULT_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o)
 

--- a/src/kb/kb_vault_policy.c
+++ b/src/kb/kb_vault_policy.c
@@ -6,6 +6,7 @@
 #include "vault_custody_mock.h" /* vault_custody_mock_provider */
 #include "vault_custody_tpm2.h" /* vault_custody_tpm2_provider (real or stub) */
 #include "vault_custody_pkcs11.h"
+#include "vault_custody_kms.h"
 #include "vault_internal.h"     /* vault_custody_set_provider */
 #include "vault_server_key.h"   /* vault_is_sealed */
 #include <stdio.h>
@@ -89,13 +90,16 @@ int kb_vault_policy_select(const char *custody, char *errbuf, size_t errlen)
       }
       return 0;
    case KB_CUSTODY_KMS:
-      /* Declared but unimplemented: fail closed — never silently fall back to a
-       * plaintext/file root under a config that asked for an anchor. */
-      if (errbuf && errlen)
-         snprintf(errbuf, errlen,
-                  "vault.custody '%s' not yet implemented; use file (dev) or mock (test)",
-                  custody ? custody : "");
-      return -1;
+      vault_custody_set_provider(vault_custody_kms_provider());
+      g_selected = KB_CUSTODY_KMS;
+      if (vault_unseal(NULL, 0) != 0)
+      {
+         vault_custody_set_provider(NULL);
+         g_selected=KB_CUSTODY_FILE;
+         if(errbuf&&errlen)snprintf(errbuf,errlen,"kms helper unavailable or returned invalid root");
+         return -1;
+      }
+      return 0;
 
    case KB_CUSTODY_UNKNOWN:
    default:

--- a/src/modules/vault/vault_custody_kms.c
+++ b/src/modules/vault/vault_custody_kms.c
@@ -1,0 +1,35 @@
+#include "vault_custody_kms.h"
+#include "vault_crypto.h"
+#include <openssl/crypto.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+
+/* The helper is the cloud-KMS adapter: it receives the operation name and key
+ * id via argv/env and must emit exactly one 32-byte decrypted root to stdout.
+ * No shell is used, output is bounded, and any short/extra output fails closed. */
+typedef struct { int sealed; } kms_ctx;
+static kms_ctx g = {1};
+static int get_kek(void *v, uint8_t out[VAULT_KEK_LEN])
+{
+   kms_ctx *c=v; const char *helper=getenv("AIMEE_VAULT_KMS_HELPER");
+   if (!helper || !*helper) return -1;
+   struct stat st; if (stat(helper,&st)!=0 || !S_ISREG(st.st_mode) || access(helper,X_OK)!=0) return -1;
+   int p[2]; if(pipe(p)!=0)return -1; pid_t pid=fork();
+   if(pid<0){close(p[0]);close(p[1]);return -1;}
+   if(pid==0){dup2(p[1],STDOUT_FILENO);close(p[0]);close(p[1]);execl(helper,helper,"decrypt",(char*)NULL);_exit(127);}
+   close(p[1]); size_t n=0; int bad=0; while(n<VAULT_KEK_LEN){ssize_t r=read(p[0],out+n,VAULT_KEK_LEN-n);if(r<0&&errno==EINTR)continue;if(r<=0){bad=1;break;}n+=(size_t)r;}
+   uint8_t extra; if(!bad&&read(p[0],&extra,1)>0)bad=1; close(p[0]); int ws=0;waitpid(pid,&ws,0);
+   if(bad||n!=VAULT_KEK_LEN||!WIFEXITED(ws)||WEXITSTATUS(ws)!=0){OPENSSL_cleanse(out,VAULT_KEK_LEN);return -1;} c->sealed=0; return 0;
+}
+static int sealed(void*v){return ((kms_ctx*)v)->sealed;}
+static int unseal(void*v,const void*p,size_t n){(void)p;(void)n;uint8_t k[VAULT_KEK_LEN];int r=get_kek(v,k);OPENSSL_cleanse(k,sizeof(k));return r;}
+static int seal(void*v){((kms_ctx*)v)->sealed=1;return 0;}
+static int rotate(void*v,const char*a,int*b,int*c,char*d,size_t e,char*f,size_t g){(void)v;(void)a;(void)b;(void)c;(void)d;(void)e;(void)f;(void)g;return -1;}
+static const vault_custody_provider_t p={"kms",&g,get_kek,rotate,sealed,unseal,seal};
+const vault_custody_provider_t *vault_custody_kms_provider(void){return &p;}

--- a/src/modules/vault/vault_custody_kms.h
+++ b/src/modules/vault/vault_custody_kms.h
@@ -1,0 +1,5 @@
+#ifndef AIMEE_VAULT_CUSTODY_KMS_H
+#define AIMEE_VAULT_CUSTODY_KMS_H
+#include "vault_internal.h"
+const vault_custody_provider_t *vault_custody_kms_provider(void);
+#endif


### PR DESCRIPTION
Add a no-shell external KMS helper provider. The helper must be executable and return exactly 32 bytes; short, extra, nonzero, or missing output fails closed. Wire kms policy selection and preserve existing negative tests.