### PR TITLE
test(p7): validate KMS helper output contract

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -164,6 +164,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-kb-bedrock-dispatch \
                $(TESTPREFIX)/unit-test-kb-bedrock-live \
                $(TESTPREFIX)/unit-test-kb-mgmt-live \
+               $(TESTPREFIX)/unit-test-vault-kms \
                $(TESTPREFIX)/unit-test-aimee-ir-shadow \
                $(TESTPREFIX)/unit-test-aimee-ir-serve \
                $(TESTPREFIX)/unit-test-aimee-ir-stream \
@@ -1694,6 +1695,10 @@ $(TESTPREFIX)/unit-test-kb-mgmt-live: $(OBJDIR)/tests/test_kb_mgmt_live.o \
                                       $(OBJDIR)/kb/kb_mgmt_client.o \
                                       $(OBJDIR)/kb/kb_mgmt_endpoint.o \
                                       $(OBJDIR)/kb/http/kb_tls.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-vault-kms: $(OBJDIR)/tests/test_vault_kms.o \
+                                  $(OBJDIR)/modules/vault/vault_custody_kms.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # Slice 3: IR shadow observer (pure — cJSON only).

--- a/src/tests/test_vault_kms.c
+++ b/src/tests/test_vault_kms.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "../modules/vault/vault_custody_kms.h"
+
+int main(void)
+{
+   const char *path = "/tmp/aimee-kms-test-helper";
+   FILE *f = fopen(path, "w"); assert(f);
+   fputs("#!/bin/sh\nprintf '01234567890123456789012345678901'\n", f); fclose(f);
+   assert(chmod(path, 0700) == 0);
+   setenv("AIMEE_VAULT_KMS_HELPER", path, 1);
+   const vault_custody_provider_t *p = vault_custody_kms_provider();
+   uint8_t k[VAULT_KEK_LEN];
+   assert(p && p->unseal(p->ctx, NULL, 0) == 0);
+   assert(p->get_kek(p->ctx, k) == 0 && k[0] == '0' && k[31] == '1');
+   f = fopen(path, "w"); assert(f); fputs("#!/bin/sh\nprintf short\n", f); fclose(f);
+   assert(p->get_kek(p->ctx, k) != 0);
+   remove(path);
+   puts("vault_kms: ok");
+   return 0;
+}


### PR DESCRIPTION
Exercise the external KMS provider with exact 32-byte output and malformed short output. Local test passes; CT260 validation follows.