### PR TITLE
fix(p7): bind KMS custody to key id and safe helper mode

### DIFF
--- a/src/modules/vault/vault_custody_kms.c
+++ b/src/modules/vault/vault_custody_kms.c
@@ -18,8 +18,9 @@ static kms_ctx g = {1};
 static int get_kek(void *v, uint8_t out[VAULT_KEK_LEN])
 {
    kms_ctx *c=v; const char *helper=getenv("AIMEE_VAULT_KMS_HELPER");
-   if (!helper || !*helper) return -1;
-   struct stat st; if (stat(helper,&st)!=0 || !S_ISREG(st.st_mode) || access(helper,X_OK)!=0) return -1;
+   const char *key_id=getenv("AIMEE_VAULT_KMS_KEY_ID");
+   if (!helper || !*helper || !key_id || !*key_id) return -1;
+   struct stat st; if (stat(helper,&st)!=0 || !S_ISREG(st.st_mode) || (st.st_mode & 022) || access(helper,X_OK)!=0) return -1;
    int p[2]; if(pipe(p)!=0)return -1; pid_t pid=fork();
    if(pid<0){close(p[0]);close(p[1]);return -1;}
    if(pid==0){dup2(p[1],STDOUT_FILENO);close(p[0]);close(p[1]);execl(helper,helper,"decrypt",(char*)NULL);_exit(127);}

--- a/src/tests/test_vault_kms.c
+++ b/src/tests/test_vault_kms.c
@@ -12,6 +12,7 @@ int main(void)
    fputs("#!/bin/sh\nprintf '01234567890123456789012345678901'\n", f); fclose(f);
    assert(chmod(path, 0700) == 0);
    setenv("AIMEE_VAULT_KMS_HELPER", path, 1);
+   setenv("AIMEE_VAULT_KMS_KEY_ID", "test-key", 1);
    const vault_custody_provider_t *p = vault_custody_kms_provider();
    uint8_t k[VAULT_KEK_LEN];
    assert(p && p->unseal(p->ctx, NULL, 0) == 0);


### PR DESCRIPTION
Require AIMEE_VAULT_KMS_KEY_ID and reject group/world-writable helper binaries. Positive and malformed-output KMS tests pass locally.