### PR TITLE
P2b/P5: egress admission hardening and server health isolation

### DIFF
--- a/src/db2/server_registry.c
+++ b/src/db2/server_registry.c
@@ -65,3 +65,28 @@ int db2_server_registry_heartbeat(const char *id, const char *cn, const char *he
    aimee_pg_finalize(s);
    return rc;
 }
+
+int db2_server_registry_get(int64_t team, const char *id, db2_server_row_t *r)
+{
+   if (db2_tenant_require_pg() != 0 || !id || !r) return -1;
+   void *c = db2_conn(); if (!c) return -1;
+   char e[256];
+   aimee_pg_stmt_t *s = aimee_pg_prepare(c,
+      "SELECT server_id,cert_cn,mgmt_cert_cn,endpoint,status,health,version,team_id FROM kb_server_registry WHERE team_id=?1 AND server_id=?2",
+      e, sizeof(e));
+   if (!s) return -1;
+   aimee_pg_bind_int64(s, "?1", team); aimee_pg_bind_text(s, "?2", id);
+   int rc = -1;
+   if (aimee_pg_step(s, e, sizeof(e)) == AIMEE_PG_ROW) {
+      memset(r, 0, sizeof(*r));
+      cp(r->server_id,sizeof(r->server_id),aimee_pg_column_text(s,0));
+      cp(r->cert_cn,sizeof(r->cert_cn),aimee_pg_column_text(s,1));
+      cp(r->mgmt_cert_cn,sizeof(r->mgmt_cert_cn),aimee_pg_column_text(s,2));
+      cp(r->endpoint,sizeof(r->endpoint),aimee_pg_column_text(s,3));
+      cp(r->status,sizeof(r->status),aimee_pg_column_text(s,4));
+      cp(r->health,sizeof(r->health),aimee_pg_column_text(s,5));
+      cp(r->version,sizeof(r->version),aimee_pg_column_text(s,6));
+      r->team_id = aimee_pg_column_int64(s,7); rc = 0;
+   }
+   aimee_pg_finalize(s); return rc;
+}

--- a/src/db2/server_registry.h
+++ b/src/db2/server_registry.h
@@ -8,5 +8,6 @@ typedef struct
    int64_t team_id;
 } db2_server_row_t;
 int db2_server_registry_list(int64_t, db2_server_row_t *, int);
+int db2_server_registry_get(int64_t, const char *, db2_server_row_t *);
 int db2_server_registry_heartbeat(const char *, const char *, const char *, const char *);
 #endif

--- a/src/kb/http/kb_http_servers.c
+++ b/src/kb/http/kb_http_servers.c
@@ -29,8 +29,21 @@ static int q(const char *s, const char *k, char *o, size_t n)
 
 int kb_http_servers_route(const char *m, const char *p, const char *qs, char *out, int cap)
 {
-   if (strcmp(p, "/v1/servers"))
-      return -1;
+   if (!strcmp(p, "/v1/servers")) {
+      /* list route below */
+   } else if (!strncmp(p, "/v1/servers/", 12) && !strcmp(m, "GET")) {
+      const char *id = p + 12, *slash = strstr(id, "/health");
+      char sid[128];
+      if (!slash || slash[7] || slash == id || (size_t)(slash-id) >= sizeof(sid)) return -1;
+      memcpy(sid, id, (size_t)(slash-id)); sid[slash-id] = 0;
+      char t[32], *e; long long team;
+      if (!q(qs, "team", t, sizeof(t))) { snprintf(out,cap,"{\"error\":\"team is required\"}"); return 400; }
+      team = strtoll(t,&e,10); if (!*t || *e || team <= 0) { snprintf(out,cap,"{\"error\":\"invalid team\"}"); return 400; }
+      db2_server_row_t row;
+      if (db2_server_registry_get(team,sid,&row) != 0) { snprintf(out,cap,"{\"error\":\"server not found\"}"); return 404; }
+      snprintf(out,cap,"{\"server_id\":\"%s\",\"status\":\"%s\",\"health\":\"%s\",\"version\":\"%s\"}",row.server_id,row.status,row.health,row.version);
+      return 200;
+   } else return -1;
    if (strcmp(m, "GET"))
       return 405;
    char t[32];

--- a/src/kb/kb_egress_admission.c
+++ b/src/kb/kb_egress_admission.c
@@ -14,7 +14,12 @@ int kb_egress_bedrock_dispatch(const kb_egress_admission_t *a,const kb_bedrock_t
 int kb_egress_admit_dispatch(const kb_egress_admission_t *a, kb_egress_dispatch_fn fn, void *ctx,
                              char *out, size_t cap)
 {
-   if (!a || !fn || !a->origin_cn || !a->request_id || !a->model || !a->reserve_max || !out ||
+   /* The credential slot is authoritative catalog state.  Requiring it at
+    * admission prevents a caller from reaching a dispatch seam with an
+    * unbound/implicit credential (which would otherwise be easy to turn into
+    * a credential-redirection or SSRF bug in a future driver). */
+   if (!a || !fn || !a->origin_cn || !a->request_id || !a->model || !a->cred_slot ||
+       !a->cred_slot[0] || !a->reserve_max || !a->reserve_max[0] || !out ||
        !cap || !kb_vault_live_keys_allowed())
    {
       if (out && cap)


### PR DESCRIPTION
Requires explicit credential slot and reserve_max at egress admission; adds team-scoped server health lookup route. Full server build passes.