### PR TITLE
P8b: sign client-generated enrollment CSRs

### DIFF
--- a/docs/proposals/pending/tiered-llm-p8b-csr-enrollment.plan.md
+++ b/docs/proposals/pending/tiered-llm-p8b-csr-enrollment.plan.md
@@ -1,0 +1,27 @@
+# P8b — thin-client CSR enrollment
+
+## Scope
+
+Add a server-owned enrollment endpoint that accepts a client-generated CSR, verifies
+proof-of-possession, ignores the CSR subject, and issues a `clientAuth`-only leaf under
+the existing server enrollment CA. The private key never crosses the API.
+
+## Invariants
+
+- Only the existing attested operator transports may authorize signing.
+- The server chooses and sanitizes the certificate CN; CSR subject and extensions are
+  never copied.
+- CSR signature verification is mandatory before signing.
+- The issued serial/CN/expiry is inserted into the durable `pki_certs` roster before
+  success is returned.
+- Existing `cert.issue` remains compatibility-only; the new client enrollment path must
+  use CSR signing.
+
+## Validation
+
+- Unit: valid CSR signs; forged or malformed CSR fails; requested CSR subject cannot
+  override the server-selected CN; the leaf has `clientAuth` and not `serverAuth`.
+- Route: unauthorized transports fail; attested operator receives cert and serial but no
+  private key.
+- Integration: generate two independent client keys, sign both CSRs, complete two mTLS
+  handshakes, revoke one serial, and prove the other remains valid.

--- a/src/headers/pki.h
+++ b/src/headers/pki.h
@@ -31,6 +31,9 @@ extern "C"
    int pki_issue(const char *cn, int validity_days, char *cert_pem, size_t cert_len, char *key_pem,
                  size_t key_len, char *serial_out, size_t serial_len);
 
+   int pki_sign_csr(const char *cn, int validity_days, const char *csr_pem, char *cert_pem,
+                    size_t cert_len, char *serial_out, size_t serial_len);
+
    /* Revoke by hex serial (adds to the DB1 denylist + the in-memory snapshot).
     * Returns 0 on success (including already-revoked), -1 on error. */
    int pki_revoke(const char *serial);

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -410,6 +410,7 @@ int handle_vault_delete(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_lock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 /* mTLS client-cert lifecycle (server_cert.c) */
 int handle_cert_issue(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_cert_sign(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_cert_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_cert_revoke(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_jobs_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -675,6 +675,79 @@ done:
    return rc;
 }
 
+int pki_sign_csr(const char *cn, int validity_days, const char *csr_pem, char *cert_pem,
+                 size_t cert_len, char *serial_out, size_t serial_len)
+{
+   char san[VAULT_CERT_CN_MAX + 1];
+   if (!cn || !vault_principal_cert_sanitize(cn, san, sizeof(san)) || !csr_pem || !cert_pem ||
+       !serial_out || cert_len == 0 || serial_len == 0)
+      return -1;
+   if (validity_days <= 0)
+      validity_days = 90;
+   cert_pem[0] = serial_out[0] = '\0';
+   BIO *bio = BIO_new_mem_buf(csr_pem, -1);
+   X509_REQ *req = bio ? PEM_read_bio_X509_REQ(bio, NULL, NULL, NULL) : NULL;
+   if (bio)
+      BIO_free(bio);
+   EVP_PKEY *pub = req ? X509_REQ_get_pubkey(req) : NULL;
+   if (!req || !pub || X509_REQ_verify(req, pub) != 1 || pki_ca_ensure() != 0)
+   {
+      EVP_PKEY_free(pub);
+      X509_REQ_free(req);
+      return -1;
+   }
+
+   pthread_mutex_lock(&g_mu);
+   int rc = -1;
+   X509 *cert = X509_new();
+   char serial[64] = "";
+   if (!cert || X509_set_version(cert, 2) != 1 ||
+       set_random_serial(cert, serial, sizeof(serial)) != 0 ||
+       set_name_cn(X509_get_subject_name(cert), san) != 0 ||
+       X509_set_issuer_name(cert, X509_get_subject_name(g_ca_cert)) != 1 ||
+       !X509_gmtime_adj(X509_getm_notBefore(cert), 0) ||
+       !X509_gmtime_adj(X509_getm_notAfter(cert), (long)validity_days * 24 * 3600) ||
+       X509_set_pubkey(cert, pub) != 1 ||
+       add_ext(cert, g_ca_cert, NID_basic_constraints, "critical,CA:FALSE") != 0 ||
+       add_ext(cert, g_ca_cert, NID_key_usage, "critical,digitalSignature") != 0 ||
+       add_ext(cert, g_ca_cert, NID_ext_key_usage, "clientAuth") != 0 ||
+       X509_sign(cert, g_ca_key, EVP_sha256()) == 0)
+      goto done_csr;
+
+   char *cp = pem_cert(cert);
+   sqlite3 *db = db1_conn();
+   sqlite3_stmt *stm = NULL;
+   if (!cp || strlen(cp) >= cert_len || !db ||
+       sqlite3_prepare_v2(db, "INSERT INTO pki_certs(serial,cn,issued_at,expires_at,revoked) "
+                              "VALUES(?,?,?,?,0)", -1, &stm, NULL) != SQLITE_OK)
+   {
+      free(cp);
+      goto done_csr;
+   }
+   long now = (long)time(NULL);
+   sqlite3_bind_text(stm, 1, serial, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(stm, 2, san, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_int64(stm, 3, now);
+   sqlite3_bind_int64(stm, 4, now + (long)validity_days * 24 * 3600);
+   if (sqlite3_step(stm) == SQLITE_DONE)
+   {
+      snprintf(cert_pem, cert_len, "%s", cp);
+      snprintf(serial_out, serial_len, "%s", serial);
+      rc = 0;
+   }
+   sqlite3_finalize(stm);
+   free(cp);
+done_csr:
+   X509_free(cert);
+   pthread_mutex_unlock(&g_mu);
+   EVP_PKEY_free(pub);
+   X509_REQ_free(req);
+   if (rc == 0)
+      aimee_log(LOG_INFO, "pki.audit", "signed client CSR cn=%s serial=%s days=%d", san, serial,
+                validity_days);
+   return rc;
+}
+
 int pki_revoke(const char *serial)
 {
    if (!serial || !serial[0])

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1577,6 +1577,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"vault.delete", handle_vault_delete},
     {"vault.lock", handle_vault_lock},
     {"cert.issue", handle_cert_issue},
+    {"cert.sign", handle_cert_sign},
     {"cert.list", handle_cert_list},
     {"cert.revoke", handle_cert_revoke},
     {"jobs.list", handle_jobs_list},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -105,6 +105,7 @@ const method_policy_t method_registry[] = {
     {"vault.delete", CAP_DELEGATE, "delete a vault credential"},
     {"vault.lock", CAP_DELEGATE, "lock the credential vault"},
     {"cert.issue", CAP_DELEGATE, "issue an mTLS client cert"},
+    {"cert.sign", CAP_DELEGATE, "sign a client-generated mTLS CSR"},
     {"cert.list", CAP_DELEGATE, "list issued mTLS client certs"},
     {"cert.revoke", CAP_DELEGATE, "revoke an mTLS client cert"},
     {"jobs.list", CAP_DELEGATE, "list delegate jobs"},

--- a/src/server/server_cert.c
+++ b/src/server/server_cert.c
@@ -66,6 +66,41 @@ int handle_cert_issue(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, resp);
 }
 
+/* POST /v1/cert/sign {cn,csr,days?} -> {cn,serial,cert}. The caller generated
+ * and retains the private key; CSR signature verification proves possession. */
+int handle_cert_sign(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   if (!cert_op_allowed(conn))
+      return server_send_error(conn, "cert: signing requires an attested operator connection",
+                               NULL);
+   cJSON *jcn = cJSON_GetObjectItemCaseSensitive(req, "cn");
+   cJSON *jcsr = cJSON_GetObjectItemCaseSensitive(req, "csr");
+   if (!cJSON_IsString(jcn) || !jcn->valuestring[0] || !cJSON_IsString(jcsr) ||
+       !jcsr->valuestring[0])
+      return server_send_error(conn, "cert: 'cn' and 'csr' are required", NULL);
+   int days = 90;
+   cJSON *jd = cJSON_GetObjectItemCaseSensitive(req, "days");
+   if (jd && cJSON_IsNumber(jd))
+   {
+      if (jd->valuedouble < 1 || jd->valuedouble > 3650)
+         return server_send_error(conn, "cert: 'days' must be between 1 and 3650", NULL);
+      days = (int)jd->valuedouble;
+   }
+   char cert[8192] = "", serial[80] = "";
+   if (pki_sign_csr(jcn->valuestring, days, jcsr->valuestring, cert, sizeof(cert), serial,
+                    sizeof(serial)) != 0)
+      return server_send_error(conn, "cert: CSR signing failed", NULL);
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+      return server_send_error(conn, "cert: out of memory", NULL);
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "cn", jcn->valuestring);
+   cJSON_AddStringToObject(resp, "serial", serial);
+   cJSON_AddStringToObject(resp, "cert", cert);
+   return server_send_ok(conn, resp);
+}
+
 /* POST /v1/cert/revoke {serial} -> ok. */
 int handle_cert_revoke(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {

--- a/src/server/server_http_routes.c
+++ b/src/server/server_http_routes.c
@@ -1517,6 +1517,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/vault/delete", NULL, RM_EXACT, "vault.delete", 0, rh_dispatch_op},
     {"POST", "/v1/vault/lock", NULL, RM_EXACT, "vault.lock", 0, rh_dispatch_op},
     {"POST", "/v1/cert/issue", NULL, RM_EXACT, "cert.issue", 0, rh_dispatch_op},
+    {"POST", "/v1/cert/sign", NULL, RM_EXACT, "cert.sign", 0, rh_dispatch_op},
     {"POST", "/v1/cert/list", NULL, RM_EXACT, "cert.list", 0, rh_dispatch_op},
     {"POST", "/v1/cert/revoke", NULL, RM_EXACT, "cert.revoke", 0, rh_dispatch_op},
     /* Background-only over /v1: the thin client forces `background` (returns a

--- a/src/tests/support/vault_handlers_stub.c
+++ b/src/tests/support/vault_handlers_stub.c
@@ -70,6 +70,8 @@ int handle_cert_issue(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    (void)req;
    return vault_stub(conn);
 }
+int handle_cert_sign(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{ (void)ctx; (void)conn; (void)req; return 0; }
 int handle_cert_revoke(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;

--- a/src/tests/test_pki.c
+++ b/src/tests/test_pki.c
@@ -8,11 +8,62 @@
 #include <sqlite3.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+static char *make_csr(const char *subject_cn, int forge)
+{
+   EVP_PKEY_CTX *kctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+   EVP_PKEY *key = NULL;
+   X509_REQ *req = NULL;
+   BIO *bio = NULL;
+   char *out = NULL;
+   if (!kctx || EVP_PKEY_keygen_init(kctx) != 1 ||
+       EVP_PKEY_CTX_set_ec_paramgen_curve_nid(kctx, NID_X9_62_prime256v1) != 1 ||
+       EVP_PKEY_keygen(kctx, &key) != 1 || !(req = X509_REQ_new()) ||
+       X509_REQ_set_version(req, 0) != 1)
+      goto done;
+   X509_NAME *name = X509_REQ_get_subject_name(req);
+   if (!name || X509_NAME_add_entry_by_NID(name, NID_commonName, MBSTRING_ASC,
+                                            (const unsigned char *)subject_cn, -1, -1, 0) != 1 ||
+       X509_REQ_set_pubkey(req, key) != 1 || X509_REQ_sign(req, key, EVP_sha256()) <= 0)
+      goto done;
+   if (forge)
+   {
+      EVP_PKEY_CTX *other_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+      EVP_PKEY *other = NULL;
+      int ok = other_ctx && EVP_PKEY_keygen_init(other_ctx) == 1 &&
+               EVP_PKEY_CTX_set_ec_paramgen_curve_nid(other_ctx, NID_X9_62_prime256v1) == 1 &&
+               EVP_PKEY_keygen(other_ctx, &other) == 1 && X509_REQ_set_pubkey(req, other) == 1;
+      EVP_PKEY_free(other);
+      EVP_PKEY_CTX_free(other_ctx);
+      if (!ok)
+         goto done;
+   }
+   if (!(bio = BIO_new(BIO_s_mem())) || PEM_write_bio_X509_REQ(bio, req) != 1)
+      goto done;
+   BUF_MEM *mem = NULL;
+   BIO_get_mem_ptr(bio, &mem);
+   if (mem)
+   {
+      out = malloc(mem->length + 1);
+      if (out)
+      {
+         memcpy(out, mem->data, mem->length);
+         out[mem->length] = '\0';
+      }
+   }
+done:
+   BIO_free(bio);
+   X509_REQ_free(req);
+   EVP_PKEY_free(key);
+   EVP_PKEY_CTX_free(kctx);
+   return out;
+}
 
 static int verify_chains_to_ca(const char *cert_pem, const char *ca_path)
 {
@@ -116,6 +167,45 @@ int main(void)
    assert(strstr(key, "BEGIN") != NULL && strstr(key, "PRIVATE KEY") != NULL);
    assert(serial[0] != '\0');
    assert(verify_chains_to_ca(cert, ca_path) == 1);
+
+   /* P8b: the client owns the key and sends only a signed CSR. The CSR subject is
+    * ignored; the server-selected CN is authoritative and the roster is durable. */
+   char *csr = make_csr("attacker-chosen-cn", 0);
+   char csr_cert[8192] = "", csr_serial[64] = "";
+   assert(csr != NULL);
+   assert(pki_sign_csr("thin-client-1", 30, csr, csr_cert, sizeof(csr_cert), csr_serial,
+                       sizeof(csr_serial)) == 0);
+   assert(verify_chains_to_ca(csr_cert, ca_path) == 1);
+   assert(pki_cert_check(csr_serial, (long)time(NULL)) == PKI_CERT_VALID);
+   BIO *signed_bio = BIO_new_mem_buf(csr_cert, -1);
+   X509 *signed_cert = signed_bio ? PEM_read_bio_X509(signed_bio, NULL, NULL, NULL) : NULL;
+   char signed_cn[128] = "";
+   assert(signed_cert != NULL);
+   X509_NAME_get_text_by_NID(X509_get_subject_name(signed_cert), NID_commonName, signed_cn,
+                             sizeof(signed_cn));
+   assert(strcmp(signed_cn, "thin-client-1") == 0);
+   EXTENDED_KEY_USAGE *eku = X509_get_ext_d2i(signed_cert, NID_ext_key_usage, NULL, NULL);
+   int have_client = 0, have_server = 0;
+   assert(eku != NULL);
+   for (int i = 0; i < sk_ASN1_OBJECT_num(eku); i++)
+   {
+      int nid = OBJ_obj2nid(sk_ASN1_OBJECT_value(eku, i));
+      have_client |= nid == NID_client_auth;
+      have_server |= nid == NID_server_auth;
+   }
+   assert(have_client && !have_server);
+   EXTENDED_KEY_USAGE_free(eku);
+   X509_free(signed_cert);
+   BIO_free(signed_bio);
+   char bad_cert[8192], bad_serial[64];
+   assert(pki_sign_csr("thin-client-bad", 30, "not a csr", bad_cert, sizeof(bad_cert), bad_serial,
+                       sizeof(bad_serial)) == -1);
+   char *forged_csr = make_csr("forged", 1);
+   assert(forged_csr != NULL);
+   assert(pki_sign_csr("thin-client-forged", 30, forged_csr, bad_cert, sizeof(bad_cert), bad_serial,
+                       sizeof(bad_serial)) == -1);
+   free(forged_csr);
+   free(csr);
 
    /* Revocation: not revoked, then revoked, reflected in the snapshot. */
    assert(pki_is_revoked(serial) == 0);


### PR DESCRIPTION
Adds operator-gated POST /v1/cert/sign. The server verifies CSR proof-of-possession, ignores CSR identity/extensions, stamps its own CN and clientAuth-only EKU, and returns no private key. Durable roster insertion is required before success. Unit PKI suite and full server build pass.