### PR TITLE
feat(p8): complete durable thin-client mTLS ramp

### DIFF
--- a/docs/proposals/done/tiered-llm-p8c-mtls-ramp.plan.md
+++ b/docs/proposals/done/tiered-llm-p8c-mtls-ramp.plan.md
@@ -70,3 +70,6 @@ enrollment protocol or grant network callers new capabilities.
 - CT260: enroll two clients in optional mode, present one (hold), present the
   second (advance), restart, prove bearer-only refusal and both cert handshakes;
   revoke one and prove next request refusal while the other remains accepted.
+- Final CT260 gate also proved cert-only authentication without the shared
+  bearer, invalid-bearer independence, network write denial, and required-mode
+  persistence across restart.

--- a/docs/proposals/pending/tiered-llm-p8c-mtls-ramp.plan.md
+++ b/docs/proposals/pending/tiered-llm-p8c-mtls-ramp.plan.md
@@ -1,0 +1,72 @@
+# P8c: durable thin-client mTLS ramp
+
+## Scope
+
+Complete the bounded `optional` to `required` transition described by
+`tiered-llm-p8-thinclient-mtls.md`. This slice does not change the thin-client
+enrollment protocol or grant network callers new capabilities.
+
+## Durable model
+
+- Extend `pki_certs` with `last_presented_at`. A presentation counts only after
+  the existing per-request durable certificate check returns `VALID`.
+- Add a singleton `pki_mtls_ramp` row containing `ramp_state`, `roster_hash`, and
+  `last_advance_ts`. State is `optional` or `required`.
+- Compute `roster_hash` from the canonical, ordered set of active, unexpired
+  enrollment rows. The hash and readiness decision are made in one SQLite
+  transaction so concurrent issuance or revocation cannot advance a stale
+  roster.
+- Issuance and revocation invalidate readiness by updating the durable roster
+  hash in the same transaction as the roster mutation.
+
+## Transitions
+
+1. Startup ensures/migrates both tables and validates the singleton row. A
+   malformed or unavailable row holds the configured posture; it never weakens
+   `required` to `optional`.
+2. In configured `optional` mode, every valid mTLS request records the leaf
+   serial's first/current presentation durably.
+3. The readiness transaction advances only when the active roster is non-empty,
+   every active row has presented, and its freshly computed hash matches the
+   persisted hash. The update is idempotent and monotonic.
+4. Before the durable commit, the server builds and fully validates a replacement
+   SSL context with `SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT`, without
+   publishing it. After the commit it performs only the infallible pointer swap.
+   Existing connections retain their old context but still face the per-request
+   durable cert check; new bearer-only handshakes fail.
+5. On restart, a durable `required` state overrides a configured `optional`
+   migration posture. A configured `required` posture is never downgraded.
+
+## Seams
+
+- `pki_mtls_ramp_init(configured_mode)` returns the effective startup mode.
+- `pki_mtls_note_presentation(serial, now)` records a verified presentation and
+  returns whether the durable state newly advanced.
+- `pki_mtls_ramp_get` exposes state/hash/timestamp for tests and observability.
+- `server_tls_prepare_required()` builds an unpublished required-mode context
+  from the saved paths; `server_tls_activate_required()` performs the monotonic
+  pointer swap and consumes it.
+
+## Failure and concurrency rules
+
+- All SQLite prepare/bind/step/commit failures hold the ramp and are logged.
+- Empty rosters never auto-advance.
+- Revoked or expired rows do not block the active roster, but cannot count as a
+  valid presentation.
+- A new enrollment after readiness was computed changes the roster hash before
+  any advance commit can succeed.
+- An unreadable client CA is fatal to context construction whenever mTLS is
+  enabled; it must never silently degrade to bearer-only TLS.
+- Context construction precedes the durable commit; the commit precedes the
+  infallible pointer swap. A build failure holds optional state, while a process
+  crash after commit restarts directly in required mode.
+
+## Validation
+
+- Unit: migrations, empty roster, partial roster, complete roster, issuance race,
+  revocation/expiry, malformed state, idempotent replay, restart persistence, and
+  fail-closed SQLite errors.
+- TLS unit: monotonic optional-to-required context swap; never downgrade.
+- CT260: enroll two clients in optional mode, present one (hold), present the
+  second (advance), restart, prove bearer-only refusal and both cert handshakes;
+  revoke one and prove next request refusal while the other remains accepted.

--- a/src/headers/pki.h
+++ b/src/headers/pki.h
@@ -70,6 +70,17 @@ extern "C"
    /* Human-readable label for a pki_cert_status_t, for distinct-cause logging. */
    const char *pki_cert_status_str(pki_cert_status_t s);
 
+   /* Durable optional->required mTLS ramp. Startup returns the effective mode
+    * (never weaker than configured_mode). A valid per-request certificate check
+    * may then record presentation; ready is a read-only preflight, and advance
+    * repeats the same roster/hash test under BEGIN IMMEDIATE before committing
+    * the monotonic state transition. */
+   int pki_mtls_ramp_init(int configured_mode);
+   int pki_mtls_note_presentation(const char *serial, long now);
+   int pki_mtls_ramp_ready(long now);
+   int pki_mtls_ramp_advance(long now);
+   int pki_mtls_ramp_get(int *state_out, char *hash_out, size_t hash_len, long *advanced_at_out);
+
    /* Enumerate issued certs (newest first), invoking cb per row. Returns the row
     * count, or -1 on error. Keeps pki.c free of the JSON layer. */
    int pki_list(void (*cb)(void *ctx, const char *serial, const char *cn, long issued_at,

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -110,6 +110,12 @@ extern "C"
    uint32_t server_http_route_caps(const char *method, const char *path);
    uint32_t server_http_conn_caps(int is_tcp, const char *bearer, int remote_writes);
 
+   /* Effective caps for a request after thin-client mTLS authentication. When
+    * mTLS is enabled, bearer fallback is a query-only floor and a durable cert
+    * gets the authenticated (but not full-trust) set. */
+   uint32_t server_http_effective_conn_caps(int is_tcp, const char *bearer, int remote_writes,
+                                            int mtls_mode, int mtls_authenticated);
+
    /* Parse one HTTP header value (case-insensitive name) from a raw request
     * buffer into out (NUL-terminated, bounded by n). Returns 1 when found, 0
     * otherwise. Shared with the request-context populator. */
@@ -125,6 +131,8 @@ extern "C"
                                              const char *path, uint32_t caps);
    int server_http_route_allowed(int is_tcp, const char *bearer, const char *method,
                                  const char *path, int remote_writes);
+   int server_http_route_allowed_caps(int is_tcp, uint32_t have, const char *method,
+                                      const char *path, int remote_writes);
 
    /* server_http_route_is_local_only: 1 iff the (method,path) route is a
     * data-plane write. Historical name retained: at remote_writes=off these

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -115,6 +115,7 @@ extern "C"
     * gets the authenticated (but not full-trust) set. */
    uint32_t server_http_effective_conn_caps(int is_tcp, const char *bearer, int remote_writes,
                                             int mtls_mode, int mtls_authenticated);
+   int server_http_mtls_transport_allowed(int is_tcp, int mtls_mode, int mtls_authenticated);
 
    /* Parse one HTTP header value (case-insensitive name) from a raw request
     * buffer into out (NUL-terminated, bounded by n). Returns 1 when found, 0

--- a/src/headers/server_tls.h
+++ b/src/headers/server_tls.h
@@ -46,6 +46,14 @@ extern "C"
     * to load keeps the current one. Returns 1 = reloaded, 0 = TLS not enabled, -1 = kept. */
    int server_tls_reload(void);
 
+   /* Build a fully validated required-mTLS context without publishing it. The
+    * caller may durably commit its posture and then pass the context to
+    * server_tls_activate_required, whose pointer swap is infallible. NULL means
+    * TLS is absent/already required, or validation failed. */
+   SSL_CTX *server_tls_prepare_required(void);
+   int server_tls_activate_required(SSL_CTX *prepared);
+   void server_tls_discard_prepared(SSL_CTX *prepared);
+
    /* Per-connection lifecycle for the conn worker: handshake an accepted fd and
     * register its SSL on the conn-io shim (NULL on failure — caller closes fd);
     * and the teardown (unregister + shutdown + free). */

--- a/src/headers/server_tls.h
+++ b/src/headers/server_tls.h
@@ -46,6 +46,11 @@ extern "C"
     * to load keeps the current one. Returns 1 = reloaded, 0 = TLS not enabled, -1 = kept. */
    int server_tls_reload(void);
 
+   /* Current effective mTLS posture (0=off, 1=optional, 2=required). The value
+    * may advance at runtime, so callers use this accessor rather than caching
+    * startup configuration. */
+   int server_tls_mtls_mode(void);
+
    /* Build a fully validated required-mTLS context without publishing it. The
     * caller may durably commit its posture and then pass the context to
     * server_tls_activate_required, whose pointer swap is infallible. NULL means

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -74,6 +74,138 @@ static void db_ensure_tables(void)
                    NULL, NULL, NULL);
 }
 
+static int ramp_tables_ensure(sqlite3 *db)
+{
+   if (!db)
+      return -1;
+   db_ensure_tables();
+   int have_presented = 0;
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, "PRAGMA table_info(pki_certs)", -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   while (sqlite3_step(st) == SQLITE_ROW)
+   {
+      const char *name = (const char *)sqlite3_column_text(st, 1);
+      if (name && strcmp(name, "last_presented_at") == 0)
+         have_presented = 1;
+   }
+   sqlite3_finalize(st);
+   if (!have_presented &&
+       sqlite3_exec(db,
+                    "ALTER TABLE pki_certs ADD COLUMN last_presented_at INTEGER NOT NULL DEFAULT 0",
+                    NULL, NULL, NULL) != SQLITE_OK)
+      return -1;
+   return sqlite3_exec(db,
+                       "CREATE TABLE IF NOT EXISTS pki_mtls_ramp("
+                       "id INTEGER PRIMARY KEY CHECK(id=1),"
+                       "ramp_state INTEGER NOT NULL CHECK(ramp_state IN (1,2)),"
+                       "roster_hash TEXT NOT NULL,"
+                       "last_advance_ts INTEGER NOT NULL DEFAULT 0)",
+                       NULL, NULL, NULL) == SQLITE_OK
+              ? 0
+              : -1;
+}
+
+static int ramp_roster_snapshot(sqlite3 *db, long now, char hash_out[65], int *count_out,
+                                int *ready_out)
+{
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db,
+                          "SELECT serial,cn,issued_at,expires_at,last_presented_at FROM pki_certs "
+                          "WHERE revoked=0 AND (expires_at=0 OR expires_at>?) ORDER BY serial,cn",
+                          -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_int64(st, 1, now);
+   EVP_MD_CTX *md = EVP_MD_CTX_new();
+   if (!md || EVP_DigestInit_ex(md, EVP_sha256(), NULL) != 1)
+   {
+      EVP_MD_CTX_free(md);
+      sqlite3_finalize(st);
+      return -1;
+   }
+   int count = 0, ready = 1, rc;
+   while ((rc = sqlite3_step(st)) == SQLITE_ROW)
+   {
+      const char *serial = (const char *)sqlite3_column_text(st, 0);
+      const char *cn = (const char *)sqlite3_column_text(st, 1);
+      long issued = (long)sqlite3_column_int64(st, 2);
+      long expires = (long)sqlite3_column_int64(st, 3);
+      long presented = (long)sqlite3_column_int64(st, 4);
+      char times[96];
+      int n = snprintf(times, sizeof(times), "%ld:%ld", issued, expires);
+      unsigned char zero = 0;
+      if (!serial || !cn || n < 0 || n >= (int)sizeof(times) ||
+          EVP_DigestUpdate(md, serial, strlen(serial)) != 1 ||
+          EVP_DigestUpdate(md, &zero, 1) != 1 || EVP_DigestUpdate(md, cn, strlen(cn)) != 1 ||
+          EVP_DigestUpdate(md, &zero, 1) != 1 || EVP_DigestUpdate(md, times, (size_t)n) != 1 ||
+          EVP_DigestUpdate(md, &zero, 1) != 1)
+      {
+         rc = SQLITE_ERROR;
+         break;
+      }
+      if (presented <= 0 || presented < issued)
+         ready = 0;
+      count++;
+   }
+   unsigned char digest[EVP_MAX_MD_SIZE];
+   unsigned int digest_len = 0;
+   int ok =
+       rc == SQLITE_DONE && EVP_DigestFinal_ex(md, digest, &digest_len) == 1 && digest_len == 32;
+   EVP_MD_CTX_free(md);
+   sqlite3_finalize(st);
+   if (!ok)
+      return -1;
+   for (unsigned int i = 0; i < digest_len; i++)
+      snprintf(hash_out + i * 2, 3, "%02x", digest[i]);
+   hash_out[64] = '\0';
+   if (count_out)
+      *count_out = count;
+   if (ready_out)
+      *ready_out = count > 0 && ready;
+   return 0;
+}
+
+static int ramp_refresh_hash(sqlite3 *db, long now)
+{
+   char hash[65];
+   if (ramp_roster_snapshot(db, now, hash, NULL, NULL) != 0)
+      return -1;
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, "UPDATE pki_mtls_ramp SET roster_hash=? WHERE id=1", -1, &st, NULL) !=
+       SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(st, 1, hash, -1, SQLITE_TRANSIENT);
+   int ok = sqlite3_step(st) == SQLITE_DONE;
+   sqlite3_finalize(st);
+   return ok ? 0 : -1;
+}
+
+static int persist_cert_row(const char *serial, const char *cn, long issued_at, long expires_at)
+{
+   sqlite3 *db = db1_conn();
+   if (ramp_tables_ensure(db) != 0 || db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
+      return -1;
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db,
+                          "INSERT INTO pki_certs(serial,cn,issued_at,expires_at,revoked,"
+                          "last_presented_at) VALUES(?,?,?,?,0,0)",
+                          -1, &st, NULL) != SQLITE_OK)
+      goto done;
+   sqlite3_bind_text(st, 1, serial, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(st, 2, cn, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_int64(st, 3, issued_at);
+   sqlite3_bind_int64(st, 4, expires_at);
+   int step = sqlite3_step(st);
+   sqlite3_finalize(st);
+   st = NULL;
+   if (step != SQLITE_DONE || ramp_refresh_hash(db, issued_at) != 0)
+      goto done;
+   return db1_txn_end(db, "COMMIT");
+done:
+   db1_txn_end(db, "ROLLBACK");
+   return -1;
+}
+
 /* Add a serial to the in-memory snapshot (caller holds g_mu). */
 static void snapshot_add(const char *serial)
 {
@@ -633,30 +765,14 @@ int pki_issue(const char *cn, int validity_days, char *cert_pem, size_t cert_len
       char *cp = pem_cert(cert), *kp = pem_private_key(key);
       if (cp && kp && strlen(cp) < cert_len && strlen(kp) < key_len)
       {
-         snprintf(cert_pem, cert_len, "%s", cp);
-         snprintf(key_pem, key_len, "%s", kp);
-         snprintf(serial_out, serial_len, "%s", serial);
-         sqlite3 *db = db1_conn();
-         if (db)
+         long now = (long)time(NULL);
+         if (persist_cert_row(serial, san, now, now + (long)validity_days * 24 * 3600) == 0)
          {
-            sqlite3_stmt *stm = NULL;
-            /* Plain INSERT (not REPLACE): a (2^-128, impossible) serial collision
-             * must never overwrite/reset an existing cert's revocation row. */
-            if (sqlite3_prepare_v2(db,
-                                   "INSERT INTO pki_certs(serial,cn,issued_at,"
-                                   "expires_at,revoked) VALUES(?,?,?,?,0)",
-                                   -1, &stm, NULL) == SQLITE_OK)
-            {
-               long now = (long)time(NULL);
-               sqlite3_bind_text(stm, 1, serial, -1, SQLITE_TRANSIENT);
-               sqlite3_bind_text(stm, 2, san, -1, SQLITE_TRANSIENT);
-               sqlite3_bind_int64(stm, 3, now);
-               sqlite3_bind_int64(stm, 4, now + (long)validity_days * 24 * 3600);
-               sqlite3_step(stm);
-               sqlite3_finalize(stm);
-            }
+            snprintf(cert_pem, cert_len, "%s", cp);
+            snprintf(key_pem, key_len, "%s", kp);
+            snprintf(serial_out, serial_len, "%s", serial);
+            rc = 0;
          }
-         rc = 0;
       }
       if (kp)
          OPENSSL_cleanse(kp, strlen(kp));
@@ -715,29 +831,18 @@ int pki_sign_csr(const char *cn, int validity_days, const char *csr_pem, char *c
       goto done_csr;
 
    char *cp = pem_cert(cert);
-   sqlite3 *db = db1_conn();
-   sqlite3_stmt *stm = NULL;
-   if (!cp || strlen(cp) >= cert_len || !db ||
-       sqlite3_prepare_v2(db,
-                          "INSERT INTO pki_certs(serial,cn,issued_at,expires_at,revoked) "
-                          "VALUES(?,?,?,?,0)",
-                          -1, &stm, NULL) != SQLITE_OK)
+   if (!cp || strlen(cp) >= cert_len)
    {
       free(cp);
       goto done_csr;
    }
    long now = (long)time(NULL);
-   sqlite3_bind_text(stm, 1, serial, -1, SQLITE_TRANSIENT);
-   sqlite3_bind_text(stm, 2, san, -1, SQLITE_TRANSIENT);
-   sqlite3_bind_int64(stm, 3, now);
-   sqlite3_bind_int64(stm, 4, now + (long)validity_days * 24 * 3600);
-   if (sqlite3_step(stm) == SQLITE_DONE)
+   if (persist_cert_row(serial, san, now, now + (long)validity_days * 24 * 3600) == 0)
    {
       snprintf(cert_pem, cert_len, "%s", cp);
       snprintf(serial_out, serial_len, "%s", serial);
       rc = 0;
    }
-   sqlite3_finalize(stm);
    free(cp);
 done_csr:
    X509_free(cert);
@@ -755,22 +860,30 @@ int pki_revoke(const char *serial)
    if (!serial || !serial[0])
       return -1;
    sqlite3 *db = db1_conn();
-   if (db)
-   {
-      sqlite3_stmt *st = NULL;
-      if (sqlite3_prepare_v2(db, "UPDATE pki_certs SET revoked=1 WHERE serial=?", -1, &st, NULL) ==
-          SQLITE_OK)
-      {
-         sqlite3_bind_text(st, 1, serial, -1, SQLITE_TRANSIENT);
-         sqlite3_step(st);
-         sqlite3_finalize(st);
-      }
-   }
+   if (ramp_tables_ensure(db) != 0 || db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
+      return -1;
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, "UPDATE pki_certs SET revoked=1 WHERE serial=?", -1, &st, NULL) !=
+       SQLITE_OK)
+      goto revoke_fail;
+   sqlite3_bind_text(st, 1, serial, -1, SQLITE_TRANSIENT);
+   int step = sqlite3_step(st);
+   sqlite3_finalize(st);
+   st = NULL;
+   if (step != SQLITE_DONE || ramp_refresh_hash(db, (long)time(NULL)) != 0)
+      goto revoke_fail;
+   if (db1_txn_end(db, "COMMIT") != 0)
+      return -1;
    pthread_mutex_lock(&g_mu);
    snapshot_add(serial);
    pthread_mutex_unlock(&g_mu);
    aimee_log(LOG_INFO, "pki.audit", "revoked client cert serial=%s", serial);
    return 0;
+revoke_fail:
+   if (st)
+      sqlite3_finalize(st);
+   db1_txn_end(db, "ROLLBACK");
+   return -1;
 }
 
 int pki_is_revoked(const char *serial)
@@ -851,6 +964,206 @@ pki_cert_status_t pki_cert_check(const char *serial, long now)
       status = PKI_CERT_ERROR; /* step failure (lock/IO) -> fail closed */
    sqlite3_finalize(st);
    return status;
+}
+
+int pki_mtls_ramp_init(int configured_mode)
+{
+   if (configured_mode <= 0)
+      return configured_mode;
+   sqlite3 *db = db1_conn();
+   if (ramp_tables_ensure(db) != 0 || db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
+      return configured_mode;
+   char hash[65];
+   int rc = -1, persisted = configured_mode, txn_open = 1;
+   if (ramp_roster_snapshot(db, (long)time(NULL), hash, NULL, NULL) != 0)
+      goto done;
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db,
+                          "INSERT INTO pki_mtls_ramp(id,ramp_state,roster_hash,last_advance_ts) "
+                          "VALUES(1,?,?,?) ON CONFLICT(id) DO NOTHING",
+                          -1, &st, NULL) != SQLITE_OK)
+      goto done;
+   sqlite3_bind_int(st, 1, configured_mode >= 2 ? 2 : 1);
+   sqlite3_bind_text(st, 2, hash, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_int64(st, 3, configured_mode >= 2 ? (long)time(NULL) : 0);
+   int step = sqlite3_step(st);
+   sqlite3_finalize(st);
+   if (step != SQLITE_DONE)
+      goto done;
+   if (sqlite3_prepare_v2(db, "SELECT ramp_state,roster_hash FROM pki_mtls_ramp WHERE id=1", -1,
+                          &st, NULL) != SQLITE_OK)
+      goto done;
+   step = sqlite3_step(st);
+   if (step == SQLITE_ROW)
+   {
+      persisted = sqlite3_column_int(st, 0);
+      const char *stored = (const char *)sqlite3_column_text(st, 1);
+      if ((persisted != 1 && persisted != 2) || !stored || strlen(stored) != 64)
+         persisted = -1;
+   }
+   sqlite3_finalize(st);
+   if (persisted < 0)
+      goto done;
+   if (configured_mode >= 2 && persisted < 2)
+   {
+      if (sqlite3_prepare_v2(db,
+                             "UPDATE pki_mtls_ramp SET ramp_state=2,roster_hash=?,"
+                             "last_advance_ts=? WHERE id=1 AND ramp_state=1",
+                             -1, &st, NULL) != SQLITE_OK)
+         goto done;
+      sqlite3_bind_text(st, 1, hash, -1, SQLITE_TRANSIENT);
+      sqlite3_bind_int64(st, 2, (long)time(NULL));
+      step = sqlite3_step(st);
+      sqlite3_finalize(st);
+      if (step != SQLITE_DONE)
+         goto done;
+      persisted = 2;
+   }
+   else if (persisted == 1 && ramp_refresh_hash(db, (long)time(NULL)) != 0)
+      goto done;
+   rc = db1_txn_end(db, "COMMIT");
+   txn_open = 0;
+done:
+   if (rc != 0)
+   {
+      if (txn_open)
+         db1_txn_end(db, "ROLLBACK");
+      aimee_log(LOG_WARN, "pki.ramp",
+                "mTLS ramp startup self-test failed; holding configured mode");
+      return configured_mode;
+   }
+   return persisted > configured_mode ? persisted : configured_mode;
+}
+
+int pki_mtls_note_presentation(const char *serial, long now)
+{
+   if (!serial || !serial[0])
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (ramp_tables_ensure(db) != 0 || db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
+      return -1;
+   sqlite3_stmt *st = NULL;
+   int rc = -1, txn_open = 1;
+   if (sqlite3_prepare_v2(
+           db,
+           "UPDATE pki_certs SET last_presented_at=CASE WHEN last_presented_at>? THEN "
+           "last_presented_at ELSE ? END WHERE serial=? AND revoked=0 AND "
+           "(expires_at=0 OR expires_at>?)",
+           -1, &st, NULL) != SQLITE_OK)
+      goto done_note;
+   sqlite3_bind_int64(st, 1, now);
+   sqlite3_bind_int64(st, 2, now);
+   sqlite3_bind_text(st, 3, serial, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_int64(st, 4, now);
+   int step = sqlite3_step(st);
+   int changed = sqlite3_changes(db);
+   sqlite3_finalize(st);
+   if (step != SQLITE_DONE || changed != 1)
+      goto done_note;
+   rc = db1_txn_end(db, "COMMIT");
+   txn_open = 0;
+done_note:
+   if (rc != 0 && txn_open)
+      db1_txn_end(db, "ROLLBACK");
+   return rc;
+}
+
+static int ramp_readiness(sqlite3 *db, long now, int advance)
+{
+   char current[65];
+   int count = 0, ready = 0;
+   if (ramp_roster_snapshot(db, now, current, &count, &ready) != 0)
+      return -1;
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, "SELECT ramp_state,roster_hash FROM pki_mtls_ramp WHERE id=1", -1,
+                          &st, NULL) != SQLITE_OK)
+      return -1;
+   int step = sqlite3_step(st), state = 0, matches = 0;
+   if (step == SQLITE_ROW)
+   {
+      state = sqlite3_column_int(st, 0);
+      const char *stored = (const char *)sqlite3_column_text(st, 1);
+      matches = stored && strcmp(stored, current) == 0;
+   }
+   sqlite3_finalize(st);
+   if (step != SQLITE_ROW || (state != 1 && state != 2))
+      return -1;
+   if (state == 2)
+      return 0;
+   if (!ready || count == 0 || !matches)
+      return 0;
+   if (!advance)
+      return 1;
+   if (sqlite3_prepare_v2(db,
+                          "UPDATE pki_mtls_ramp SET ramp_state=2,last_advance_ts=? "
+                          "WHERE id=1 AND ramp_state=1 AND roster_hash=?",
+                          -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_int64(st, 1, now);
+   sqlite3_bind_text(st, 2, current, -1, SQLITE_TRANSIENT);
+   step = sqlite3_step(st);
+   int changed = sqlite3_changes(db);
+   sqlite3_finalize(st);
+   return step == SQLITE_DONE && changed == 1 ? 1 : (step == SQLITE_DONE ? 0 : -1);
+}
+
+int pki_mtls_ramp_ready(long now)
+{
+   sqlite3 *db = db1_conn();
+   if (ramp_tables_ensure(db) != 0 || db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
+      return -1;
+   if (ramp_refresh_hash(db, now) != 0)
+   {
+      db1_txn_end(db, "ROLLBACK");
+      return -1;
+   }
+   int rc = ramp_readiness(db, now, 0);
+   int end = db1_txn_end(db, rc >= 0 ? "COMMIT" : "ROLLBACK");
+   return end == 0 ? rc : -1;
+}
+
+int pki_mtls_ramp_advance(long now)
+{
+   sqlite3 *db = db1_conn();
+   if (ramp_tables_ensure(db) != 0 || db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
+      return -1;
+   if (ramp_refresh_hash(db, now) != 0)
+   {
+      db1_txn_end(db, "ROLLBACK");
+      return -1;
+   }
+   int rc = ramp_readiness(db, now, 1);
+   int end = db1_txn_end(db, rc >= 0 ? "COMMIT" : "ROLLBACK");
+   return end == 0 ? rc : -1;
+}
+
+int pki_mtls_ramp_get(int *state_out, char *hash_out, size_t hash_len, long *advanced_at_out)
+{
+   sqlite3 *db = db1_conn();
+   if (ramp_tables_ensure(db) != 0)
+      return -1;
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(
+           db, "SELECT ramp_state,roster_hash,last_advance_ts FROM pki_mtls_ramp WHERE id=1", -1,
+           &st, NULL) != SQLITE_OK)
+      return -1;
+   int rc = -1;
+   if (sqlite3_step(st) == SQLITE_ROW)
+   {
+      const char *hash = (const char *)sqlite3_column_text(st, 1);
+      if (hash && strlen(hash) == 64)
+      {
+         if (state_out)
+            *state_out = sqlite3_column_int(st, 0);
+         if (hash_out && hash_len)
+            snprintf(hash_out, hash_len, "%s", hash);
+         if (advanced_at_out)
+            *advanced_at_out = (long)sqlite3_column_int64(st, 2);
+         rc = 0;
+      }
+   }
+   sqlite3_finalize(st);
+   return rc;
 }
 
 int pki_list(void (*cb)(void *ctx, const char *serial, const char *cn, long issued_at,

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -972,7 +972,7 @@ int pki_mtls_ramp_init(int configured_mode)
       return configured_mode;
    sqlite3 *db = db1_conn();
    if (ramp_tables_ensure(db) != 0 || db1_txn_begin(db, "BEGIN IMMEDIATE") != 0)
-      return configured_mode;
+      return -1;
    char hash[65];
    int rc = -1, persisted = configured_mode, txn_open = 1;
    if (ramp_roster_snapshot(db, (long)time(NULL), hash, NULL, NULL) != 0)
@@ -1028,9 +1028,8 @@ done:
    {
       if (txn_open)
          db1_txn_end(db, "ROLLBACK");
-      aimee_log(LOG_WARN, "pki.ramp",
-                "mTLS ramp startup self-test failed; holding configured mode");
-      return configured_mode;
+      aimee_log(LOG_WARN, "pki.ramp", "mTLS ramp startup self-test failed; refusing mTLS startup");
+      return -1;
    }
    return persisted > configured_mode ? persisted : configured_mode;
 }

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1617,6 +1617,27 @@ void handle_conn(int fd, int is_tcp)
                 request_id);
             return;
          }
+         long ramp_now = (long)time(NULL);
+         if (pki_mtls_note_presentation(rc_serial, ramp_now) != 0)
+            LOG_WARN("server.http", "mTLS ramp presentation write failed serial=%s", rc_serial);
+         else if (pki_mtls_ramp_ready(ramp_now) == 1)
+         {
+            SSL_CTX *prepared = server_tls_prepare_required();
+            if (!prepared)
+               LOG_WARN("server.http", "mTLS ramp required-context preparation failed");
+            else
+            {
+               int advanced = pki_mtls_ramp_advance(ramp_now);
+               if (advanced == 1)
+                  server_tls_activate_required(prepared);
+               else
+               {
+                  server_tls_discard_prepared(prepared);
+                  if (advanced < 0)
+                     LOG_WARN("server.http", "mTLS ramp durable advance failed");
+               }
+            }
+         }
       }
    }
 

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -349,6 +349,18 @@ uint32_t server_http_conn_caps(int is_tcp, const char *bearer, int remote_writes
    return CAPS_AUTHENTICATED;
 }
 
+uint32_t server_http_effective_conn_caps(int is_tcp, const char *bearer, int remote_writes,
+                                         int mtls_mode, int mtls_authenticated)
+{
+   if (!is_tcp || mtls_mode <= 0)
+      return server_http_conn_caps(is_tcp, bearer, remote_writes);
+   if (mtls_authenticated)
+      return CAPS_AUTHENTICATED;
+   /* Optional-mode bearer fallback is deliberately weaker than a client cert:
+    * query/session reads only, with no compute or mutation capability. */
+   return CAPS_READ_ONLY & ~(uint32_t)CAP_CHAT;
+}
+
 /* Routes deliberately reachable over the TCP listener regardless of
  * aimee.api.remote_writes (still capability-gated): the detached-workspace
  * reverse channel and registry mutations (workspace-resource-plane). The serving
@@ -366,8 +378,8 @@ static int v1_route_tcp_exempt(const char *method, const char *path)
    return 0;
 }
 
-int server_http_route_allowed(int is_tcp, const char *bearer, const char *method, const char *path,
-                              int remote_writes)
+int server_http_route_allowed_caps(int is_tcp, uint32_t have, const char *method, const char *path,
+                                   int remote_writes)
 {
    /* Over the TCP listener, a route that needs any capability beyond the read set
     * (CAPS_READ_ONLY) is "privileged" and denied unless the operator opts in via
@@ -395,8 +407,14 @@ int server_http_route_allowed(int is_tcp, const char *bearer, const char *method
       }
    }
    uint32_t need = server_http_route_caps(method, path);
-   uint32_t have = server_http_conn_caps(is_tcp, bearer, remote_writes);
    return (need & ~have) == 0;
+}
+
+int server_http_route_allowed(int is_tcp, const char *bearer, const char *method, const char *path,
+                              int remote_writes)
+{
+   return server_http_route_allowed_caps(
+       is_tcp, server_http_conn_caps(is_tcp, bearer, remote_writes), method, path, remote_writes);
 }
 
 void server_http_api_status_report(int http_port, int bearer_configured, int rate_limit_per_min,
@@ -1494,12 +1512,6 @@ void handle_conn(int fd, int is_tcp)
                              request_id, sizeof(request_id));
    }
 
-   /* Establish the per-request context (#3) for this worker thread before any
-    * handler runs. Overwritten on every request, so thread reuse cannot leak a
-    * prior request's identity. */
-   server_http_populate_request_context(fd, is_tcp, buf, request_id, method, path,
-                                        server_http_conn_caps(is_tcp, g_bearer, g_remote_writes));
-
    /* A verified mTLS leaf is a first-class TCP authenticator. Re-check its
     * durable roster row before the bearer gate so required-mode clients do not
     * still depend on the shared bearer. This remains authentication only: the
@@ -1548,6 +1560,17 @@ void handle_conn(int fd, int is_tcp)
          }
       }
    }
+
+   int mtls_mode = server_tls_mtls_mode();
+   int effective_remote_writes =
+       is_tcp && mtls_mode > 0 ? SERVER_REMOTE_WRITES_OFF : g_remote_writes;
+   uint32_t effective_caps = server_http_effective_conn_caps(is_tcp, g_bearer, g_remote_writes,
+                                                             mtls_mode, mtls_authenticated);
+
+   /* Establish the per-request context (#3) only after authenticating the
+    * durable certificate, so downstream dispatch sees the same effective caps
+    * as the outer route gate. */
+   server_http_populate_request_context(fd, is_tcp, buf, request_id, method, path, effective_caps);
 
    /* Authorize before reading the body: TCP requires either the durably valid
     * client certificate above or a valid bearer; UDS relies on permissions. */
@@ -1625,7 +1648,8 @@ void handle_conn(int fd, int is_tcp)
     * must be a subset of the connection's effective set. UDS is same-user
     * trusted and exempt. A scoped bearer is read/query-only, so compute/write
     * routes return 403; an unscoped bearer holds CAPS_AUTHENTICATED. */
-   if (is_tcp && !server_http_route_allowed(is_tcp, g_bearer, method, path, g_remote_writes))
+   if (is_tcp && !server_http_route_allowed_caps(is_tcp, effective_caps, method, path,
+                                                 effective_remote_writes))
    {
       send_response(fd, 403,
                     "{\"error\":{\"message\":\"this endpoint requires capabilities beyond the "
@@ -1804,7 +1828,7 @@ void handle_conn(int fd, int is_tcp)
    if (strcmp(method, "POST") == 0 && strcmp(path, "/v1/chat/stream") == 0)
    {
       uint32_t need = server_capability_for_method("chat.send_stream");
-      uint32_t have = server_http_conn_caps(is_tcp, g_bearer, g_remote_writes);
+      uint32_t have = effective_caps;
       if ((need & ~have) != 0)
       {
          send_response(fd, 403, "{\"error\":\"forbidden: chat requires an unscoped credential\"}",
@@ -1885,7 +1909,7 @@ void handle_conn(int fd, int is_tcp)
    /* Expose this connection's effective caps to the dispatch routes (UDS =>
     * CAPS_ALL, TCP => bearer-scoped) so loopback_rpc / server_dispatch re-check
     * per-method capability. Reset to the read-only default afterward. */
-   g_rpc_conn_caps = server_http_conn_caps(is_tcp, g_bearer, g_remote_writes);
+   g_rpc_conn_caps = effective_caps;
    /* WP-C.0 hop 1 of 3: capture the attested vault identity (kernel UDS peer uid,
     * or a server.token-gated webuser assertion) into thread-locals, live until
     * loopback_rpc copies it into the synthesized conn. Cleared after the route so

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1500,9 +1500,57 @@ void handle_conn(int fd, int is_tcp)
    server_http_populate_request_context(fd, is_tcp, buf, request_id, method, path,
                                         server_http_conn_caps(is_tcp, g_bearer, g_remote_writes));
 
-   /* Authorize before reading the body: TCP requires a valid bearer; the UDS
-    * relies on filesystem permissions. A session-scoping key without a
-    * configured bearer is refused on any transport. */
+   /* A verified mTLS leaf is a first-class TCP authenticator. Re-check its
+    * durable roster row before the bearer gate so required-mode clients do not
+    * still depend on the shared bearer. This remains authentication only: the
+    * normal route/capability gates below still deny remote-write surfaces. */
+   int mtls_authenticated = 0;
+   if (server_conn_io_has_ssl(fd))
+   {
+      char rc_cn[256] = "", rc_serial[80] = "";
+      if (server_tls_peer_identity(server_conn_io_get_ssl(fd), rc_cn, sizeof(rc_cn), rc_serial,
+                                   sizeof(rc_serial)) &&
+          rc_serial[0])
+      {
+         pki_cert_status_t cs = pki_cert_check(rc_serial, (long)time(NULL));
+         if (cs != PKI_CERT_VALID)
+         {
+            LOG_INFO("server.http", "%s %s -> 403 (mtls re-check: %s serial=%s) req_id=%s", method,
+                     path, pki_cert_status_str(cs), rc_serial, request_id);
+            send_response(
+                fd, 403,
+                "{\"error\":{\"message\":\"client certificate is no longer valid "
+                "(revoked, expired, or unrecognized)\",\"type\":\"authentication_error\"}}",
+                request_id);
+            return;
+         }
+         mtls_authenticated = 1;
+         long ramp_now = (long)time(NULL);
+         if (pki_mtls_note_presentation(rc_serial, ramp_now) != 0)
+            LOG_WARN("server.http", "mTLS ramp presentation write failed serial=%s", rc_serial);
+         else if (pki_mtls_ramp_ready(ramp_now) == 1)
+         {
+            SSL_CTX *prepared = server_tls_prepare_required();
+            if (!prepared)
+               LOG_WARN("server.http", "mTLS ramp required-context preparation failed");
+            else
+            {
+               int advanced = pki_mtls_ramp_advance(ramp_now);
+               if (advanced == 1)
+                  server_tls_activate_required(prepared);
+               else
+               {
+                  server_tls_discard_prepared(prepared);
+                  if (advanced < 0)
+                     LOG_WARN("server.http", "mTLS ramp durable advance failed");
+               }
+            }
+         }
+      }
+   }
+
+   /* Authorize before reading the body: TCP requires either the durably valid
+    * client certificate above or a valid bearer; UDS relies on permissions. */
    {
       char auth[512] = "";
       char api_key[512] = "";
@@ -1522,8 +1570,9 @@ void handle_conn(int fd, int is_tcp)
        * fresh one below when evidence emission is on. */
       ingress_preinject_set_turn_id("");
       anthropic_http_capture_request_headers(buf); /* parity: per-request anthropic-* hdrs */
-      int az = server_http_authorize(is_tcp, g_bearer, has_auth ? auth : NULL,
-                                     has_api_key ? api_key : NULL, has_skey);
+      int az = mtls_authenticated ? 0
+                                  : server_http_authorize(is_tcp, g_bearer, has_auth ? auth : NULL,
+                                                          has_api_key ? api_key : NULL, has_skey);
       if (az != 0)
       {
          const char *msg = az == 401 ? "{\"error\":{\"message\":\"missing or invalid bearer "
@@ -1584,61 +1633,6 @@ void handle_conn(int fd, int is_tcp)
                     request_id);
       LOG_INFO("server.http", "%s %s -> 403 (caps) req_id=%s", method, path, request_id);
       return;
-   }
-
-   /* P8a (invariant #5): per-request DURABLE client-cert revocation/expiry re-check.
-    * mtls_verify_cb runs ONLY at handshake — OpenSSL cannot re-run it on a keep-alive
-    * connection — so a cert revoked via cert.revoke AFTER its handshake would keep
-    * authorizing on the open connection. This MUST run BEFORE every data-serving
-    * dispatch (the SSE, native streaming-chat, shadow-mirror, and unary route paths
-    * all follow), so it is placed here, right after the auth/caps gates, NOT after
-    * the later identity-capture (which several streaming paths early-return before).
-    * Gate on the actual verified peer cert (server_tls_peer_identity yields a serial),
-    * independent of how identity is later resolved: a bearer/UDS conn has no client
-    * cert and is skipped; a verified client cert is re-checked against the DURABLE DB
-    * row (NOT the g_revoked snapshot) on EVERY request. Non-VALID (revoked/expired/
-    * unknown) or an unavailable authority (ERROR) -> 403 before any dispatch. */
-   if (server_conn_io_has_ssl(fd))
-   {
-      char rc_cn[256] = "", rc_serial[80] = "";
-      if (server_tls_peer_identity(server_conn_io_get_ssl(fd), rc_cn, sizeof(rc_cn), rc_serial,
-                                   sizeof(rc_serial)) &&
-          rc_serial[0])
-      {
-         pki_cert_status_t cs = pki_cert_check(rc_serial, (long)time(NULL));
-         if (cs != PKI_CERT_VALID)
-         {
-            LOG_INFO("server.http", "%s %s -> 403 (mtls re-check: %s serial=%s) req_id=%s", method,
-                     path, pki_cert_status_str(cs), rc_serial, request_id);
-            send_response(
-                fd, 403,
-                "{\"error\":{\"message\":\"client certificate is no longer valid "
-                "(revoked, expired, or unrecognized)\",\"type\":\"authentication_error\"}}",
-                request_id);
-            return;
-         }
-         long ramp_now = (long)time(NULL);
-         if (pki_mtls_note_presentation(rc_serial, ramp_now) != 0)
-            LOG_WARN("server.http", "mTLS ramp presentation write failed serial=%s", rc_serial);
-         else if (pki_mtls_ramp_ready(ramp_now) == 1)
-         {
-            SSL_CTX *prepared = server_tls_prepare_required();
-            if (!prepared)
-               LOG_WARN("server.http", "mTLS ramp required-context preparation failed");
-            else
-            {
-               int advanced = pki_mtls_ramp_advance(ramp_now);
-               if (advanced == 1)
-                  server_tls_activate_required(prepared);
-               else
-               {
-                  server_tls_discard_prepared(prepared);
-                  if (advanced < 0)
-                     LOG_WARN("server.http", "mTLS ramp durable advance failed");
-               }
-            }
-         }
-      }
    }
 
    /* GET /v1/runs/{id}/events takes the SSE path (no body); other run routes

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -361,6 +361,11 @@ uint32_t server_http_effective_conn_caps(int is_tcp, const char *bearer, int rem
    return CAPS_READ_ONLY & ~(uint32_t)CAP_CHAT;
 }
 
+int server_http_mtls_transport_allowed(int is_tcp, int mtls_mode, int mtls_authenticated)
+{
+   return !is_tcp || mtls_mode < 2 || mtls_authenticated;
+}
+
 /* Routes deliberately reachable over the TCP listener regardless of
  * aimee.api.remote_writes (still capability-gated): the detached-workspace
  * reverse channel and registry mutations (workspace-resource-plane). The serving
@@ -1517,6 +1522,7 @@ void handle_conn(int fd, int is_tcp)
     * still depend on the shared bearer. This remains authentication only: the
     * normal route/capability gates below still deny remote-write surfaces. */
    int mtls_authenticated = 0;
+   int mtls_mode = server_tls_mtls_mode();
    if (server_conn_io_has_ssl(fd))
    {
       char rc_cn[256] = "", rc_serial[80] = "";
@@ -1537,31 +1543,49 @@ void handle_conn(int fd, int is_tcp)
             return;
          }
          mtls_authenticated = 1;
-         long ramp_now = (long)time(NULL);
-         if (pki_mtls_note_presentation(rc_serial, ramp_now) != 0)
-            LOG_WARN("server.http", "mTLS ramp presentation write failed serial=%s", rc_serial);
-         else if (pki_mtls_ramp_ready(ramp_now) == 1)
+         /* Presentation writes are migration-only. Once required, the durable
+          * roster is still checked above but the steady-state request path does
+          * not take DB1's write gate or recompute the whole roster hash. */
+         if (mtls_mode == 1)
          {
-            SSL_CTX *prepared = server_tls_prepare_required();
-            if (!prepared)
-               LOG_WARN("server.http", "mTLS ramp required-context preparation failed");
-            else
+            long ramp_now = (long)time(NULL);
+            if (pki_mtls_note_presentation(rc_serial, ramp_now) != 0)
+               LOG_WARN("server.http", "mTLS ramp presentation write failed serial=%s", rc_serial);
+            else if (pki_mtls_ramp_ready(ramp_now) == 1)
             {
-               int advanced = pki_mtls_ramp_advance(ramp_now);
-               if (advanced == 1)
-                  server_tls_activate_required(prepared);
+               SSL_CTX *prepared = server_tls_prepare_required();
+               if (!prepared)
+                  LOG_WARN("server.http", "mTLS ramp required-context preparation failed");
                else
                {
-                  server_tls_discard_prepared(prepared);
-                  if (advanced < 0)
-                     LOG_WARN("server.http", "mTLS ramp durable advance failed");
+                  int advanced = pki_mtls_ramp_advance(ramp_now);
+                  if (advanced == 1)
+                     server_tls_activate_required(prepared);
+                  else
+                  {
+                     server_tls_discard_prepared(prepared);
+                     if (advanced < 0)
+                        LOG_WARN("server.http", "mTLS ramp durable advance failed");
+                  }
                }
             }
          }
       }
    }
 
-   int mtls_mode = server_tls_mtls_mode();
+   /* Promotion applies to connections accepted under the old optional context
+    * too: once durable state is required, a no-cert keep-alive may not retain
+    * bearer fallback merely because its handshake predated the context swap. */
+   mtls_mode = server_tls_mtls_mode();
+   if (!server_http_mtls_transport_allowed(is_tcp, mtls_mode, mtls_authenticated))
+   {
+      send_response(fd, 401,
+                    "{\"error\":{\"message\":\"a valid client certificate is required\","
+                    "\"type\":\"authentication_error\"}}",
+                    request_id);
+      LOG_INFO("server.http", "%s %s -> 401 (mtls required) req_id=%s", method, path, request_id);
+      return;
+   }
    int effective_remote_writes =
        is_tcp && mtls_mode > 0 ? SERVER_REMOTE_WRITES_OFF : g_remote_writes;
    uint32_t effective_caps = server_http_effective_conn_caps(is_tcp, g_bearer, g_remote_writes,

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -226,6 +226,14 @@ int server_tls_reload(void)
    return 1;
 }
 
+int server_tls_mtls_mode(void)
+{
+   pthread_mutex_lock(&g_ctx_mu);
+   int mode = g_mtls_mode;
+   pthread_mutex_unlock(&g_ctx_mu);
+   return mode;
+}
+
 SSL_CTX *server_tls_prepare_required(void)
 {
    pthread_mutex_lock(&g_ctx_mu);

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -138,9 +138,10 @@ static SSL_CTX *tls_build_ctx(const char *cert_path, const char *key_path, int m
       if (SSL_CTX_load_verify_locations(ctx, ca, NULL) != 1)
       {
          aimee_log(LOG_WARN, "server.tls",
-                   "mtls enabled but client CA %s not loadable: %s — "
-                   "mTLS DISABLED (client certs not verified)",
-                   ca, ERR_error_string(ERR_get_error(), NULL));
+                   "mtls enabled but client CA %s not loadable: %s — refusing TLS context", ca,
+                   ERR_error_string(ERR_get_error(), NULL));
+         SSL_CTX_free(ctx);
+         return NULL;
       }
       else
       {
@@ -225,6 +226,54 @@ int server_tls_reload(void)
    return 1;
 }
 
+SSL_CTX *server_tls_prepare_required(void)
+{
+   pthread_mutex_lock(&g_ctx_mu);
+   if (!g_ctx || g_mtls_mode >= 2)
+   {
+      pthread_mutex_unlock(&g_ctx_mu);
+      return NULL;
+   }
+   char cert[MAX_PATH_LEN], key[MAX_PATH_LEN], ca[MAX_PATH_LEN];
+   snprintf(cert, sizeof(cert), "%s", g_cert_path);
+   snprintf(key, sizeof(key), "%s", g_key_path);
+   snprintf(ca, sizeof(ca), "%s", g_client_ca_path);
+   pthread_mutex_unlock(&g_ctx_mu);
+   return tls_build_ctx(cert, key, 2, ca[0] ? ca : NULL);
+}
+
+int server_tls_activate_required(SSL_CTX *prepared)
+{
+   if (!prepared)
+      return -1;
+   pthread_mutex_lock(&g_ctx_mu);
+   if (!g_ctx)
+   {
+      pthread_mutex_unlock(&g_ctx_mu);
+      SSL_CTX_free(prepared);
+      return -1;
+   }
+   if (g_mtls_mode >= 2)
+   {
+      pthread_mutex_unlock(&g_ctx_mu);
+      SSL_CTX_free(prepared);
+      return 0;
+   }
+   SSL_CTX *old = g_ctx;
+   g_ctx = prepared;
+   g_mtls_mode = 2;
+   SSL_CTX_free(old);
+   pthread_mutex_unlock(&g_ctx_mu);
+   aimee_log(LOG_INFO, "server.tls", "mTLS ramp advanced to required");
+   return 1;
+}
+
+void server_tls_discard_prepared(SSL_CTX *prepared)
+{
+   if (prepared)
+      SSL_CTX_free(prepared);
+}
+
 int server_tls_peer_identity(SSL *ssl, char *cn_out, size_t cn_len, char *serial_out,
                              size_t serial_len)
 {
@@ -294,20 +343,25 @@ int server_tls_init_default(void)
    snprintf(key, sizeof(key), "%s/tls/server.key", config_default_dir());
    config_t cfg;
    config_load(&cfg);
+   int effective_mtls = pki_mtls_ramp_init(cfg.server_api_mtls);
+   if (effective_mtls == 1)
+      aimee_log(LOG_WARN, "server.tls",
+                "mTLS migration is optional: bearer-only clients remain accepted until the "
+                "durable roster is fully presented");
    /* Secure-by-default: when a tls_port is configured but no cert exists, the
     * server provisions a self-signed one rather than fall back to a plaintext
     * listener (the remote path now REQUIRES TLS — plaintext /v1 is loopback-only).
     * An operator-supplied cert at the same path is left untouched. mTLS still
     * needs an operator-issued client CA, so this self-signed path is server-TLS
     * only (mtls==0); when mTLS is required the operator must supply the cert. */
-   if (cfg.server_api_mtls == 0)
+   if (effective_mtls == 0)
       pki_ensure_self_signed_server_cert(cert, key);
    /* When mTLS is on, ensure aimee's client CA exists (create-or-load) and the
     * revocation snapshot is loaded BEFORE server_tls_init loads the client CA
     * file and the verify callback starts consulting the snapshot. */
-   if (cfg.server_api_mtls > 0)
-      pki_ca_ensure();
-   return server_tls_init(cert, key, cfg.server_api_mtls, cfg.server_api_mtls_client_ca);
+   if (effective_mtls > 0 && pki_ca_ensure() != 0)
+      return -1;
+   return server_tls_init(cert, key, effective_mtls, cfg.server_api_mtls_client_ca);
 }
 
 SSL *server_tls_begin(int fd)

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -19,6 +19,9 @@
 
 static SSL_CTX *g_ctx = NULL;
 static pthread_mutex_t g_ctx_mu = PTHREAD_MUTEX_INITIALIZER;
+/* Serializes a live cert reload against the prepare -> durable commit -> activate
+ * promotion sequence. Lock order is transition, then g_ctx_mu. */
+static pthread_mutex_t g_transition_mu = PTHREAD_MUTEX_INITIALIZER;
 /* Saved at init so a SIGHUP reload can re-read the SAME cert/key files (live-config-reload). */
 static char g_cert_path[MAX_PATH_LEN];
 static char g_key_path[MAX_PATH_LEN];
@@ -191,10 +194,12 @@ int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
 
 int server_tls_reload(void)
 {
+   pthread_mutex_lock(&g_transition_mu);
    pthread_mutex_lock(&g_ctx_mu);
    if (!g_ctx)
    {
       pthread_mutex_unlock(&g_ctx_mu);
+      pthread_mutex_unlock(&g_transition_mu);
       return 0; /* TLS not enabled -> nothing to reload */
    }
    char cert[MAX_PATH_LEN], key[MAX_PATH_LEN], ca[MAX_PATH_LEN];
@@ -211,6 +216,7 @@ int server_tls_reload(void)
    {
       aimee_log(LOG_WARN, "server.tls",
                 "TLS reload: new cert/key failed to load — keeping the current cert");
+      pthread_mutex_unlock(&g_transition_mu);
       return -1;
    }
    pthread_mutex_lock(&g_ctx_mu);
@@ -222,6 +228,7 @@ int server_tls_reload(void)
     * section closes any window where an accept could observe the pointer being freed. */
    SSL_CTX_free(old);
    pthread_mutex_unlock(&g_ctx_mu);
+   pthread_mutex_unlock(&g_transition_mu);
    aimee_log(LOG_INFO, "server.tls", "TLS cert reloaded (cert %s)", cert);
    return 1;
 }
@@ -236,10 +243,12 @@ int server_tls_mtls_mode(void)
 
 SSL_CTX *server_tls_prepare_required(void)
 {
+   pthread_mutex_lock(&g_transition_mu);
    pthread_mutex_lock(&g_ctx_mu);
    if (!g_ctx || g_mtls_mode >= 2)
    {
       pthread_mutex_unlock(&g_ctx_mu);
+      pthread_mutex_unlock(&g_transition_mu);
       return NULL;
    }
    char cert[MAX_PATH_LEN], key[MAX_PATH_LEN], ca[MAX_PATH_LEN];
@@ -247,7 +256,10 @@ SSL_CTX *server_tls_prepare_required(void)
    snprintf(key, sizeof(key), "%s", g_key_path);
    snprintf(ca, sizeof(ca), "%s", g_client_ca_path);
    pthread_mutex_unlock(&g_ctx_mu);
-   return tls_build_ctx(cert, key, 2, ca[0] ? ca : NULL);
+   SSL_CTX *prepared = tls_build_ctx(cert, key, 2, ca[0] ? ca : NULL);
+   if (!prepared)
+      pthread_mutex_unlock(&g_transition_mu);
+   return prepared;
 }
 
 int server_tls_activate_required(SSL_CTX *prepared)
@@ -259,12 +271,14 @@ int server_tls_activate_required(SSL_CTX *prepared)
    {
       pthread_mutex_unlock(&g_ctx_mu);
       SSL_CTX_free(prepared);
+      pthread_mutex_unlock(&g_transition_mu);
       return -1;
    }
    if (g_mtls_mode >= 2)
    {
       pthread_mutex_unlock(&g_ctx_mu);
       SSL_CTX_free(prepared);
+      pthread_mutex_unlock(&g_transition_mu);
       return 0;
    }
    SSL_CTX *old = g_ctx;
@@ -272,6 +286,7 @@ int server_tls_activate_required(SSL_CTX *prepared)
    g_mtls_mode = 2;
    SSL_CTX_free(old);
    pthread_mutex_unlock(&g_ctx_mu);
+   pthread_mutex_unlock(&g_transition_mu);
    aimee_log(LOG_INFO, "server.tls", "mTLS ramp advanced to required");
    return 1;
 }
@@ -279,7 +294,10 @@ int server_tls_activate_required(SSL_CTX *prepared)
 void server_tls_discard_prepared(SSL_CTX *prepared)
 {
    if (prepared)
+   {
       SSL_CTX_free(prepared);
+      pthread_mutex_unlock(&g_transition_mu);
+   }
 }
 
 int server_tls_peer_identity(SSL *ssl, char *cn_out, size_t cn_len, char *serial_out,
@@ -352,6 +370,8 @@ int server_tls_init_default(void)
    config_t cfg;
    config_load(&cfg);
    int effective_mtls = pki_mtls_ramp_init(cfg.server_api_mtls);
+   if (effective_mtls < 0)
+      return -1;
    if (effective_mtls == 1)
       aimee_log(LOG_WARN, "server.tls",
                 "mTLS migration is optional: bearer-only clients remain accepted until the "

--- a/src/tests/test_pki.c
+++ b/src/tests/test_pki.c
@@ -415,6 +415,7 @@ int main(void)
     * (handle_conn) refuses 403 on ERROR just as on REVOKED/EXPIRED/UNKNOWN. */
    db1_shutdown();
    assert(pki_cert_check("any-serial", (long)time(NULL)) == PKI_CERT_ERROR);
+   assert(pki_mtls_ramp_init(1) == -1); /* never fall back to optional on DB failure */
    printf("pki: P8a authority-down -> ERROR (fail-closed) ok\n");
 
    snprintf(cmd, sizeof(cmd), "rm -rf %s", home);

--- a/src/tests/test_pki.c
+++ b/src/tests/test_pki.c
@@ -367,6 +367,48 @@ int main(void)
    printf("pki: existing server cert authoritative (kept across identity change; minted only when "
           "absent) ok\n");
 
+   /* P8c durable optional->required ramp. Isolate the authoritative roster by
+    * retiring all earlier test certs before initializing the singleton. */
+   sqlite3 *rdb = db1_conn();
+   assert(rdb);
+   assert(sqlite3_exec(rdb, "UPDATE pki_certs SET revoked=1", NULL, NULL, NULL) == SQLITE_OK);
+   assert(pki_mtls_ramp_init(1) == 1);
+   int ramp_state = 0;
+   char roster_hash[65] = "";
+   long advanced_at = -1;
+   assert(pki_mtls_ramp_get(&ramp_state, roster_hash, sizeof(roster_hash), &advanced_at) == 0);
+   assert(ramp_state == 1 && strlen(roster_hash) == 64 && advanced_at == 0);
+   assert(pki_mtls_ramp_ready(p8_now) == 0); /* empty rosters never advance */
+
+   char r1c[8192] = "", r1k[4096] = "", r1s[64] = "";
+   char r2c[8192] = "", r2k[4096] = "", r2s[64] = "";
+   assert(pki_issue("ramp-client-1", 30, r1c, sizeof(r1c), r1k, sizeof(r1k), r1s, sizeof(r1s)) ==
+          0);
+   assert(pki_issue("ramp-client-2", 30, r2c, sizeof(r2c), r2k, sizeof(r2k), r2s, sizeof(r2s)) ==
+          0);
+   long ramp_now = (long)time(NULL);
+   assert(pki_mtls_ramp_ready(ramp_now) == 0);
+   assert(pki_mtls_note_presentation(r1s, ramp_now) == 0);
+   assert(pki_mtls_ramp_ready(ramp_now) == 0); /* partial roster holds */
+   assert(pki_mtls_note_presentation(r2s, ramp_now) == 0);
+   assert(pki_mtls_ramp_ready(ramp_now) == 1);
+
+   /* A new enrollment after preflight changes the transactional roster hash and
+    * invalidates the stale readiness result until that client presents. */
+   char r3c[8192] = "", r3k[4096] = "", r3s[64] = "";
+   assert(pki_issue("ramp-client-3", 30, r3c, sizeof(r3c), r3k, sizeof(r3k), r3s, sizeof(r3s)) ==
+          0);
+   ramp_now = (long)time(NULL);
+   assert(pki_mtls_ramp_ready(ramp_now) == 0);
+   assert(pki_mtls_note_presentation(r3s, ramp_now) == 0);
+   assert(pki_mtls_ramp_ready(ramp_now) == 1);
+   assert(pki_mtls_ramp_advance(ramp_now) == 1);
+   assert(pki_mtls_ramp_advance(ramp_now + 1) == 0); /* idempotent + monotonic */
+   assert(pki_mtls_ramp_get(&ramp_state, roster_hash, sizeof(roster_hash), &advanced_at) == 0);
+   assert(ramp_state == 2 && advanced_at == ramp_now);
+   assert(pki_mtls_ramp_init(1) == 2); /* restart preserves required posture */
+   printf("pki: P8c durable mTLS ramp + stale-roster race gate ok\n");
+
    /* (g) Authority-down path: with DB1 shut down, db1_conn() is NULL, so the
     * durable read cannot answer -> PKI_CERT_ERROR (fail-closed, NOT a misleading
     * UNKNOWN). Done last, as it tears down the shared :memory: DB. The caller

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -941,6 +941,23 @@ int main(void)
       assert(server_http_conn_caps(1, "plain", SERVER_REMOTE_WRITES_DATA) == CAPS_AUTHENTICATED);
       assert(server_http_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL) == CAPS_ALL);
 
+      /* P8 thin-client posture is independent of the operator's generic TCP
+       * remote_writes setting: bearer fallback is query-only and a cert gains
+       * authenticated session capabilities, never CAPS_ALL. */
+      uint32_t fallback = CAPS_READ_ONLY & ~(uint32_t)CAP_CHAT;
+      assert(server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL, 1, 0) ==
+             fallback);
+      assert(server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL, 1, 1) ==
+             CAPS_AUTHENTICATED);
+      assert(server_http_route_allowed_caps(1, fallback, "POST", "/v1/memory/store",
+                                            SERVER_REMOTE_WRITES_OFF) == 0);
+      assert(server_http_route_allowed_caps(1, CAPS_AUTHENTICATED, "POST", "/v1/memory/store",
+                                            SERVER_REMOTE_WRITES_OFF) == 0);
+      assert(server_http_route_allowed_caps(1, fallback, "POST", "/v1/chat/completions",
+                                            SERVER_REMOTE_WRITES_OFF) == 0);
+      assert(server_http_route_allowed_caps(1, CAPS_AUTHENTICATED, "POST", "/v1/chat/completions",
+                                            SERVER_REMOTE_WRITES_OFF) == 1);
+
       /* UDS is always full, independent of the level. */
       assert(server_http_conn_caps(0, NULL, SERVER_REMOTE_WRITES_OFF) == CAPS_ALL);
    }

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -949,6 +949,10 @@ int main(void)
              fallback);
       assert(server_http_effective_conn_caps(1, "plain", SERVER_REMOTE_WRITES_FULL, 1, 1) ==
              CAPS_AUTHENTICATED);
+      assert(server_http_mtls_transport_allowed(1, 1, 0) == 1);
+      assert(server_http_mtls_transport_allowed(1, 2, 0) == 0);
+      assert(server_http_mtls_transport_allowed(1, 2, 1) == 1);
+      assert(server_http_mtls_transport_allowed(0, 2, 0) == 1);
       assert(server_http_route_allowed_caps(1, fallback, "POST", "/v1/memory/store",
                                             SERVER_REMOTE_WRITES_OFF) == 0);
       assert(server_http_route_allowed_caps(1, CAPS_AUTHENTICATED, "POST", "/v1/memory/store",


### PR DESCRIPTION
## Summary
- persist and auto-advance the optional-to-required mTLS roster state
- authenticate thin clients by durable client certificate without shared-bearer dependence
- keep bearer fallback query-only and prevent client certs from inheriting remote_writes
- fail closed on revocation, CA/DB startup failure, and serialize TLS reload with promotion

## Validation
- unit-test-pki
- unit-test-server-http
- full server build
- CT260: cert-only 200, client-cert write 403, bare required handshake 000, restart cert 200
- adversarial roundtable findings baked in; final .254 convergence retries timed out after the review service restarted