### PR TITLE
feat(autonomy): make WFE run caps + auto-resume policy GUI-tunable

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -240,7 +240,7 @@ Internal dogfood/QA knobs; not part of the user surface.
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`; a key shown as a bare name that is itself a nested object is noted in the section description (see *Coverage & limitations*).
 
 - **`aimee`** — _Core API/runtime settings._ Keys: `api`
-- **`autonomy`** — `ci_retry_max`, `fanout`, `skeptics`, `unit_max`, `unit_retry`
+- **`autonomy`** — `auto_resume_cap_parks`, `ci_retry_max`, `concurrency`, `fanout`, `max_resumes`, `max_turns`, `max_wall_secs`, `skeptics`, `stale_abandon_secs`, `unit_max`, `unit_retry`
 - **`auxiliary`** — _Auxiliary (cheap/background) model used for side tasks._ Keys: `default_max_tokens`, `default_model`, `default_provider`, `enabled`, `tasks`
 - **`cache_shaping`** — _Prompt-cache shaping._ Keys: `enabled`, `min_chars`
 - **`charter`** — _Operating charter: values, constraints, safety axioms, tone._ Keys: `hard_constraints`, `safety_axioms`, `tone_boundaries`, `values`, `working_profile_drift_limit`
@@ -302,7 +302,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 181 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 179 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -505,7 +505,7 @@ The binaries read 181 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_CONCURRENCY`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_STALE_ABANDON_SECS`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_EVAL_URL`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DELEGATE_SANDBOX`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_RESP_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_KB_HARDENED`, `AIMEE_KB_OIDC_MAX_TOKEN_AGE`, `AIMEE_MGMT_AUDIENCE`, `AIMEE_MGMT_CAP`, `AIMEE_MGMT_ISSUER`, `AIMEE_MGMT_JWKS`, `AIMEE_OCR_URL`, `AIMEE_ORCH_DELEGATES`, `AIMEE_ORCH_WORKFLOWS`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_SANDBOX_HOST_MOUNTS`, `AIMEE_STAGE_GOVERNANCE`, `AIMEE_STAGE_MEMORY`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_VAULT_KMS_HELPER`, `AIMEE_VAULT_KMS_HWM_DOMAIN`, `AIMEE_VAULT_KMS_HWM_PUBKEY`, `AIMEE_VAULT_KMS_KEY_ID`, `AIMEE_VAULT_PKCS11_LABEL`, `AIMEE_VAULT_PKCS11_MODULE`, `AIMEE_VAULT_PKCS11_PIN`, `AIMEE_VAULT_PKCS11_SLOT`, `AIMEE_VAULT_TPM2_BLOB_PATH`, `AIMEE_VAULT_TPM2_NV_INDEX`, `AIMEE_VAULT_TPM2_TCTI`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
+`AIMEE_ALLOW_MAIN_CHECKOUT`, `AIMEE_API_BEARER_TOKEN`, `AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CI_WEBHOOK_SECRET`, `AIMEE_CLIENT_TYPE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_EVAL_URL`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DELEGATE_SANDBOX`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_IR_PATH`, `AIMEE_IR_RESP_PATH`, `AIMEE_IR_SHADOW`, `AIMEE_IR_STREAM_RELAY`, `AIMEE_KB_HARDENED`, `AIMEE_KB_OIDC_MAX_TOKEN_AGE`, `AIMEE_MGMT_AUDIENCE`, `AIMEE_MGMT_CAP`, `AIMEE_MGMT_ISSUER`, `AIMEE_MGMT_JWKS`, `AIMEE_OCR_URL`, `AIMEE_ORCH_DELEGATES`, `AIMEE_ORCH_WORKFLOWS`, `AIMEE_PANEL_SEAT_WAIT_SECS`, `AIMEE_PRIMARY_CLI_INGESTOR`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_SANDBOX_HOST_MOUNTS`, `AIMEE_STAGE_GOVERNANCE`, `AIMEE_STAGE_MEMORY`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_CN`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_TSR_URL`, `AIMEE_VAULT_KMS_HELPER`, `AIMEE_VAULT_KMS_HWM_DOMAIN`, `AIMEE_VAULT_KMS_HWM_PUBKEY`, `AIMEE_VAULT_KMS_KEY_ID`, `AIMEE_VAULT_PKCS11_LABEL`, `AIMEE_VAULT_PKCS11_MODULE`, `AIMEE_VAULT_PKCS11_PIN`, `AIMEE_VAULT_PKCS11_SLOT`, `AIMEE_VAULT_TPM2_BLOB_PATH`, `AIMEE_VAULT_TPM2_NV_INDEX`, `AIMEE_VAULT_TPM2_TCTI`, `AIMEE_WFE_WORKTREE_GC_GRACE_SECS`, `AIMEE_WORKFLOW_AUTONOMOUS_ROUTER`, `AIMEE_WORKFLOW_BRANCH`, `AIMEE_WORKFLOW_ENFORCE_STAGE`, `AIMEE_WORKFLOW_LEASE_TTL_SECS`
 
 ## External & provider environment
 

--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Panel, Badge, Spinner, InlineStatus, EmptyState, Button } from "@rakuensoftware/smoothgui";
 import type { BadgeVariant } from "@rakuensoftware/smoothgui";
 import { renderMd } from "./chat/markdown";
+import { loadConfig, saveConfigValue } from "../setup/configApi";
 
 /* ---- API types (mirror the enriched /api/workflow/items* envelopes) ---- */
 
@@ -463,6 +464,7 @@ export default function WorkflowActions() {
           open={triggersOpen}
           onToggle={() => setTriggersOpen((v) => !v)}
         />
+        <RunPolicyPanel />
         <div style={{ marginTop: 8 }}>
           {items.length === 0 && (
             <EmptyState message="No proposals yet." inline />
@@ -605,6 +607,129 @@ export default function WorkflowActions() {
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+// Run policy: the autonomy safety caps + auto-resume toggle that govern how far an
+// autonomous run drives on its own (trigger -> PR). These are the autonomy.* config
+// keys; kept here under Workflows because that is exactly what they tune. Config-backed
+// + live, so a change applies to the next workflow (no restart); an exported
+// AIMEE_AUTONOMY_* env var still overrides.
+const AUTONOMY_FIELDS: { key: string; label: string; help: string; kind: "int" | "bool" }[] = [
+  {
+    key: "autonomy.auto_resume_cap_parks",
+    label: "Auto-resume wall-cap parks",
+    kind: "bool",
+    help: "When on (default), a run that hits its per-resume wall-clock window is resumed so it keeps going instead of being abandoned. Bounded by max auto-resumes.",
+  },
+  {
+    key: "autonomy.max_wall_secs",
+    label: "Max wall seconds / resume",
+    kind: "int",
+    help: "Per-resume wall-clock cap in seconds. On breach the run parks and (if auto-resume is on) is given a fresh window. Default 1800.",
+  },
+  {
+    key: "autonomy.max_turns",
+    label: "Max turns / run",
+    kind: "int",
+    help: "Cumulative per-run turn cap — the ultimate runaway backstop (auto-resume does not reset it). Default 300.",
+  },
+  {
+    key: "autonomy.max_resumes",
+    label: "Max auto-resumes / run",
+    kind: "int",
+    help: "How many times a run may auto-resume before the reaper is allowed to abandon it. Default 50. 0 = never auto-resume.",
+  },
+  {
+    key: "autonomy.stale_abandon_secs",
+    label: "Stale-abandon grace (s)",
+    kind: "int",
+    help: "Grace before a stuck/capped park is reaped -> abandoned. Default 3600. 0 disables the reaper.",
+  },
+  {
+    key: "autonomy.concurrency",
+    label: "Concurrency",
+    kind: "int",
+    help: "Max autonomous runs driven concurrently per scheduler sweep. Default 8.",
+  },
+];
+
+// Collapsible run-policy editor: loads the autonomy.* config on first open and writes
+// each change back via the same /api/config/set the Settings page uses.
+function RunPolicyPanel() {
+  const [open, setOpen] = useState(false);
+  const [cfg, setCfg] = useState<Record<string, unknown> | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  useEffect(() => {
+    if (open && cfg === null) loadConfig().then(setCfg);
+  }, [open, cfg]);
+  const save = async (key: string, value: unknown) => {
+    setSaving(key);
+    setErr(null);
+    const r = await saveConfigValue(key, value);
+    setSaving(null);
+    if (r.ok) setCfg((c) => ({ ...(c || {}), [key]: r.value }));
+    else setErr(`${key}: ${r.error}`);
+  };
+  return (
+    <div style={{ marginTop: 10, borderTop: "1px solid #eee", paddingTop: 8 }}>
+      <div
+        onClick={() => setOpen((v) => !v)}
+        style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", userSelect: "none" }}
+      >
+        <span style={{ fontSize: 11, color: "#999", width: 10 }}>{open ? "▾" : "▸"}</span>
+        <span style={{ fontWeight: 600, fontSize: 13 }}>⚙ Run policy</span>
+        <span style={{ marginLeft: "auto", fontSize: 11, color: "#aaa" }}>autonomy caps</span>
+      </div>
+      {open && (
+        <div style={{ marginTop: 6 }}>
+          {cfg === null ? (
+            <div style={{ fontSize: 12, color: "#999" }}>Loading…</div>
+          ) : (
+            <>
+              <div style={{ fontSize: 11, color: "#999", lineHeight: 1.4, marginBottom: 6 }}>
+                Safety caps + auto-resume for autonomous runs. Applies to the next workflow (no
+                restart); an exported <code>AIMEE_AUTONOMY_*</code> env var overrides.
+              </div>
+              {AUTONOMY_FIELDS.map((f) => (
+                <div
+                  key={f.key}
+                  title={f.help}
+                  style={{ display: "flex", alignItems: "center", gap: 8, padding: "3px 0" }}
+                >
+                  <span style={{ fontSize: 12, width: 190 }}>{f.label}</span>
+                  {f.kind === "bool" ? (
+                    <input
+                      type="checkbox"
+                      checked={!!cfg?.[f.key]}
+                      onChange={(e) => save(f.key, e.target.checked)}
+                    />
+                  ) : (
+                    <input
+                      type="number"
+                      defaultValue={Number(cfg?.[f.key] ?? 0)}
+                      style={{
+                        width: 90,
+                        fontFamily: "ui-monospace, monospace",
+                        fontSize: 12,
+                        padding: "2px 4px",
+                      }}
+                      onBlur={(e) => {
+                        const v = parseInt(e.target.value, 10);
+                        if (!Number.isNaN(v) && v !== Number(cfg?.[f.key])) save(f.key, v);
+                      }}
+                    />
+                  )}
+                  {saving === f.key && <span style={{ fontSize: 11, color: "#999" }}>saving…</span>}
+                </div>
+              ))}
+              {err && <div style={{ fontSize: 11, color: "#c00", marginTop: 4 }}>{err}</div>}
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -40,6 +40,19 @@ export const SECTION_HELP: Record<string, string> = {
 
 // One line per config key. Plain language, states the default.
 export const FIELD_HELP: Record<string, string> = {
+  // Autonomous workflow — run safety caps + auto-resume (live; env override wins)
+  "autonomy.max_turns":
+    "Cumulative per-run turn cap (persisted audit events) before a run is parked as a runaway backstop. Default 300. Raise for long multi-slice runs; this is the ultimate bound on total run length (auto-resume does NOT reset it).",
+  "autonomy.max_wall_secs":
+    "Per-resume wall-clock cap in seconds. A run that hits it is parked 'wall_cap_exceeded'; with auto-resume on it gets a fresh window. Default 1800 (30 min).",
+  "autonomy.stale_abandon_secs":
+    "Grace period before a run parked in a cap/stuck backstop is reaped → abandoned. Default 3600 (1 h). 0 disables the reaper.",
+  "autonomy.concurrency":
+    "Max autonomous runs driven concurrently per scheduler sweep. Default 8.",
+  "autonomy.auto_resume_cap_parks":
+    "When on (default), the scheduler auto-resumes a wall-cap park to give a long run a fresh wall window instead of leaving it to be reaped — so autonomous runs drive to completion unattended. Bounded by max_resumes. Turn-cap parks are never auto-resumed (raise max_turns instead).",
+  "autonomy.max_resumes":
+    "Max auto-resumes per run before the reaper is allowed to abandon it. Default 50. Bounds a genuinely-wedged run so auto-resume can't loop forever. 0 = never auto-resume.",
   // Knowledge curation — curator pipeline stage gates (see the Pipeline tab)
   kb_curator_extract_docs_enabled:
     "Curator: extract structured claims and entities from ingested documents (LLM). The entry stage for document knowledge; feeds claim indexing and contradiction detection.",

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -629,6 +629,16 @@ static void config_set_defaults(config_t *cfg)
    cfg->autonomy_unit_retry = 2;
    cfg->autonomy_unit_max = 16;
    cfg->autonomy_ci_retry_max = 2;
+   /* Run caps + auto-resume: defaults match the historical AIMEE_AUTONOMY_* env defaults
+    * (max_turns 300, max_wall 1800s, stale-abandon 3600s, concurrency 8). Auto-resume of
+    * wall-cap parks defaults ON so a long autonomous run drives to completion in fresh
+    * wall windows instead of being reaped; bounded by max_resumes. */
+   cfg->autonomy_max_turns = 300;
+   cfg->autonomy_max_wall_secs = 1800;
+   cfg->autonomy_stale_abandon_secs = 3600;
+   cfg->autonomy_concurrency = 8;
+   cfg->autonomy_auto_resume_cap_parks = 1;
+   cfg->autonomy_max_resumes = 50;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;
@@ -1953,10 +1963,22 @@ int config_autonomy_lookup(const char *env_name, long *out)
       snap = have ? c.autonomy_unit_max : 0;
    else if (strcmp(env_name, "AIMEE_AUTONOMY_CI_RETRY_MAX") == 0)
       snap = have ? c.autonomy_ci_retry_max : 0;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_MAX_TURNS") == 0)
+      snap = have ? c.autonomy_max_turns : 0;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_MAX_WALL_SECS") == 0)
+      snap = have ? c.autonomy_max_wall_secs : 0;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_STALE_ABANDON_SECS") == 0)
+      snap = have ? c.autonomy_stale_abandon_secs : 0;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_CONCURRENCY") == 0)
+      snap = have ? c.autonomy_concurrency : 0;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_AUTO_RESUME_CAP_PARKS") == 0)
+      snap = have ? c.autonomy_auto_resume_cap_parks : 0, boolish = 1;
+   else if (strcmp(env_name, "AIMEE_AUTONOMY_MAX_RESUMES") == 0)
+      snap = have ? c.autonomy_max_resumes : 0;
    else
       is_autonomy = 0;
    if (!is_autonomy)
-      return 0; /* not a config-backed autonomy var (e.g. MAX_TURNS) -> caller falls back */
+      return 0; /* not a config-backed autonomy var (e.g. USD_PER_SEC) -> caller falls back */
 
    const char *e = getenv(env_name);
    if (e && e[0]) /* operator override — VALIDATED (a garbage value falls through to snapshot) */

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -287,11 +287,11 @@ typedef struct config
    char workspace_sandbox_image[64][256];
    int workspace_count;
    char guardrail_mode[16];
-   int subagent_ban_enabled;        /* default ON: when set AND usable delegates are configured,
-                                       block the primary agent's own sub-agent tools (Task/Agent/
-                                       spawn_agent/RemoteTrigger) and redirect to `aimee delegate`.
-                                       Explicit `subagent_ban_enabled: false` allows provider-native
-                                       sub-agents. */
+   int subagent_ban_enabled; /* default ON: when set AND usable delegates are configured,
+                                block the primary agent's own sub-agent tools (Task/Agent/
+                                spawn_agent/RemoteTrigger) and redirect to `aimee delegate`.
+                                Explicit `subagent_ban_enabled: false` allows provider-native
+                                sub-agents. */
    char provider[16];
    /* Durable default persona: the persona a fresh primary session starts as, and
     * the persona draft roundtable panelists author with when none is set. Width =
@@ -1164,8 +1164,8 @@ typedef struct config
     * defaults, so behavior is unchanged until an operator changes them.
     * autonomy_max_turns: cumulative persisted-turn cap per run (runaway backstop).
     * autonomy_max_wall_secs: per-resume wall-clock cap in seconds.
-    * autonomy_stale_abandon_secs: grace before a cap/stuck park is reaped -> abandoned (0 disables).
-    * autonomy_concurrency: max concurrently-driven autonomous runs.
+    * autonomy_stale_abandon_secs: grace before a cap/stuck park is reaped -> abandoned (0
+    * disables). autonomy_concurrency: max concurrently-driven autonomous runs.
     * autonomy_auto_resume_cap_parks: 1 = scheduler auto-resumes a wall-cap park (giving it a
     *   fresh wall window) instead of leaving it to be reaped; bounded by autonomy_max_resumes.
     * autonomy_max_resumes: max auto-resumes per run before the reaper is allowed to win. */

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -1158,6 +1158,23 @@ typedef struct config
    int autonomy_unit_retry;
    int autonomy_unit_max;
    int autonomy_ci_retry_max;
+   /* Run safety caps + auto-resume policy — historically env-only (AIMEE_AUTONOMY_*);
+    * now config-backed + live via config_autonomy_lookup so they are tunable from the web
+    * Settings GUI (an exported env var still overrides). Defaults match the historical env
+    * defaults, so behavior is unchanged until an operator changes them.
+    * autonomy_max_turns: cumulative persisted-turn cap per run (runaway backstop).
+    * autonomy_max_wall_secs: per-resume wall-clock cap in seconds.
+    * autonomy_stale_abandon_secs: grace before a cap/stuck park is reaped -> abandoned (0 disables).
+    * autonomy_concurrency: max concurrently-driven autonomous runs.
+    * autonomy_auto_resume_cap_parks: 1 = scheduler auto-resumes a wall-cap park (giving it a
+    *   fresh wall window) instead of leaving it to be reaped; bounded by autonomy_max_resumes.
+    * autonomy_max_resumes: max auto-resumes per run before the reaper is allowed to win. */
+   int autonomy_max_turns;
+   int autonomy_max_wall_secs;
+   int autonomy_stale_abandon_secs;
+   int autonomy_concurrency;
+   int autonomy_auto_resume_cap_parks;
+   int autonomy_max_resumes;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned

--- a/src/modules/config/config_fields.c
+++ b/src/modules/config/config_fields.c
@@ -384,6 +384,17 @@ const config_field_t config_fields[] = {
     {"autonomy.unit_retry", offsetof(config_t, autonomy_unit_retry), sizeof(int), 0, CFG_INT},
     {"autonomy.unit_max", offsetof(config_t, autonomy_unit_max), sizeof(int), 0, CFG_INT},
     {"autonomy.ci_retry_max", offsetof(config_t, autonomy_ci_retry_max), sizeof(int), 0, CFG_INT},
+    /* Run safety caps + auto-resume policy — config-backed + live via config_autonomy_lookup
+     * (an exported AIMEE_AUTONOMY_* still overrides). Surfaced in the web Settings GUI. */
+    {"autonomy.max_turns", offsetof(config_t, autonomy_max_turns), sizeof(int), 0, CFG_INT},
+    {"autonomy.max_wall_secs", offsetof(config_t, autonomy_max_wall_secs), sizeof(int), 0,
+     CFG_INT},
+    {"autonomy.stale_abandon_secs", offsetof(config_t, autonomy_stale_abandon_secs), sizeof(int),
+     0, CFG_INT},
+    {"autonomy.concurrency", offsetof(config_t, autonomy_concurrency), sizeof(int), 0, CFG_INT},
+    {"autonomy.auto_resume_cap_parks", offsetof(config_t, autonomy_auto_resume_cap_parks),
+     sizeof(int), 1, CFG_BOOL},
+    {"autonomy.max_resumes", offsetof(config_t, autonomy_max_resumes), sizeof(int), 0, CFG_INT},
     /* Curator pipeline stage gates (kb.curator.*) — exposed so the GUI pipeline editor
      * can toggle stages. Flat config_t fields; config_save reserializes them into the
      * nested kb.curator.* YAML the KB reads on its next load. These MUST stay ahead of the

--- a/src/modules/config/config_fields.c
+++ b/src/modules/config/config_fields.c
@@ -385,12 +385,12 @@ const config_field_t config_fields[] = {
     {"autonomy.unit_max", offsetof(config_t, autonomy_unit_max), sizeof(int), 0, CFG_INT},
     {"autonomy.ci_retry_max", offsetof(config_t, autonomy_ci_retry_max), sizeof(int), 0, CFG_INT},
     /* Run safety caps + auto-resume policy — config-backed + live via config_autonomy_lookup
-     * (an exported AIMEE_AUTONOMY_* still overrides). Surfaced in the web Settings GUI. */
+     * (an exported AIMEE_AUTONOMY_* still overrides). Surfaced in the Workflows GUI's Run
+     * policy panel. */
     {"autonomy.max_turns", offsetof(config_t, autonomy_max_turns), sizeof(int), 0, CFG_INT},
-    {"autonomy.max_wall_secs", offsetof(config_t, autonomy_max_wall_secs), sizeof(int), 0,
+    {"autonomy.max_wall_secs", offsetof(config_t, autonomy_max_wall_secs), sizeof(int), 0, CFG_INT},
+    {"autonomy.stale_abandon_secs", offsetof(config_t, autonomy_stale_abandon_secs), sizeof(int), 0,
      CFG_INT},
-    {"autonomy.stale_abandon_secs", offsetof(config_t, autonomy_stale_abandon_secs), sizeof(int),
-     0, CFG_INT},
     {"autonomy.concurrency", offsetof(config_t, autonomy_concurrency), sizeof(int), 0, CFG_INT},
     {"autonomy.auto_resume_cap_parks", offsetof(config_t, autonomy_auto_resume_cap_parks),
      sizeof(int), 1, CFG_BOOL},

--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1124,9 +1124,13 @@ int config_save(const config_t *cfg)
       cJSON_AddStringToObject(root, "economizer", econ_tier_name(cfg->economizer_tier));
 
    /* Autonomous-dev knobs — persist only non-defaults (defaults: skeptics 0, fanout off,
-    * unit_retry 2, unit_max 16, ci_retry_max 2). */
+    * unit_retry 2, unit_max 16, ci_retry_max 2; caps: max_turns 300, max_wall 1800,
+    * stale_abandon 3600, concurrency 8, auto_resume ON, max_resumes 50). */
    if (cfg->autonomy_skeptics != 0 || cfg->autonomy_fanout != 0 || cfg->autonomy_unit_retry != 2 ||
-       cfg->autonomy_unit_max != 16 || cfg->autonomy_ci_retry_max != 2)
+       cfg->autonomy_unit_max != 16 || cfg->autonomy_ci_retry_max != 2 ||
+       cfg->autonomy_max_turns != 300 || cfg->autonomy_max_wall_secs != 1800 ||
+       cfg->autonomy_stale_abandon_secs != 3600 || cfg->autonomy_concurrency != 8 ||
+       cfg->autonomy_auto_resume_cap_parks != 1 || cfg->autonomy_max_resumes != 50)
    {
       cJSON *autonomy = cJSON_AddObjectToObject(root, "autonomy");
       if (cfg->autonomy_skeptics != 0)
@@ -1139,6 +1143,19 @@ int config_save(const config_t *cfg)
          cJSON_AddNumberToObject(autonomy, "unit_max", cfg->autonomy_unit_max);
       if (cfg->autonomy_ci_retry_max != 2)
          cJSON_AddNumberToObject(autonomy, "ci_retry_max", cfg->autonomy_ci_retry_max);
+      if (cfg->autonomy_max_turns != 300)
+         cJSON_AddNumberToObject(autonomy, "max_turns", cfg->autonomy_max_turns);
+      if (cfg->autonomy_max_wall_secs != 1800)
+         cJSON_AddNumberToObject(autonomy, "max_wall_secs", cfg->autonomy_max_wall_secs);
+      if (cfg->autonomy_stale_abandon_secs != 3600)
+         cJSON_AddNumberToObject(autonomy, "stale_abandon_secs", cfg->autonomy_stale_abandon_secs);
+      if (cfg->autonomy_concurrency != 8)
+         cJSON_AddNumberToObject(autonomy, "concurrency", cfg->autonomy_concurrency);
+      if (cfg->autonomy_auto_resume_cap_parks != 1)
+         cJSON_AddBoolToObject(autonomy, "auto_resume_cap_parks",
+                               cfg->autonomy_auto_resume_cap_parks);
+      if (cfg->autonomy_max_resumes != 50)
+         cJSON_AddNumberToObject(autonomy, "max_resumes", cfg->autonomy_max_resumes);
    }
 
    /* Session/worktree cleanup policy (only save if non-default) */

--- a/src/modules/config/config_sections.c
+++ b/src/modules/config/config_sections.c
@@ -828,6 +828,26 @@ void config_parse_autonomy_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(autonomy, "ci_retry_max");
    if (cJSON_IsNumber(item))
       cfg->autonomy_ci_retry_max = clampi(item->valueint, 0, 20);
+   /* Run safety caps + auto-resume policy. Clamped to sane bounds; the wfe readers
+    * additionally fall back to their historical default on a non-positive value. */
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "max_turns");
+   if (cJSON_IsNumber(item)) /* must be positive — a run needs at least a few turns */
+      cfg->autonomy_max_turns = clampi(item->valueint, 1, 100000);
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "max_wall_secs");
+   if (cJSON_IsNumber(item)) /* >=30s: below that a run can't make useful progress per window */
+      cfg->autonomy_max_wall_secs = clampi(item->valueint, 30, 86400);
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "stale_abandon_secs");
+   if (cJSON_IsNumber(item)) /* 0 disables the stale-park reaper entirely */
+      cfg->autonomy_stale_abandon_secs = clampi(item->valueint, 0, 604800);
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "concurrency");
+   if (cJSON_IsNumber(item))
+      cfg->autonomy_concurrency = clampi(item->valueint, 1, 128);
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "auto_resume_cap_parks");
+   if (cJSON_IsBool(item))
+      cfg->autonomy_auto_resume_cap_parks = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(autonomy, "max_resumes");
+   if (cJSON_IsNumber(item)) /* 0 = never auto-resume (equivalent to the policy being off) */
+      cfg->autonomy_max_resumes = clampi(item->valueint, 0, 100000);
 }
 
 /* Bridge the autonomy config knobs to the AIMEE_AUTONOMY_* env vars the wfe library

--- a/src/modules/workflows/wfe_autonomy.c
+++ b/src/modules/workflows/wfe_autonomy.c
@@ -10,6 +10,7 @@
 #include <time.h>
 
 #include "cJSON.h"
+#include "config.h" /* config_autonomy_lookup: live autonomy.* caps (env > snapshot) */
 #include "wfe_store.h"
 #include "wfe_approval.h"
 #include "wfe_blocks.h"
@@ -207,9 +208,13 @@ int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
     * cumulative turn cap. On breach -> park with the accurate cap reason
     * (turn_cap_exceeded / wall_cap_exceeded); never silently continue. These are
     * runaway backstops, NOT the dollar cost cap (which parks budget_exceeded).
-    * Env-overridable; a bad override falls back to the default. */
-   long max_turns = wfe_env_long("AIMEE_AUTONOMY_MAX_TURNS", 300);
-   long max_wall = wfe_env_long("AIMEE_AUTONOMY_MAX_WALL_SECS", 1800);
+    * Config-backed + live (env override > autonomy.* snapshot); a missing/bad value falls
+    * back to the historical default. Tunable from the web Settings GUI. */
+   long max_turns = 300, max_wall = 1800, lv;
+   if (config_autonomy_lookup("AIMEE_AUTONOMY_MAX_TURNS", &lv) && lv > 0)
+      max_turns = lv;
+   if (config_autonomy_lookup("AIMEE_AUTONOMY_MAX_WALL_SECS", &lv) && lv > 0)
+      max_wall = lv;
    struct timespec ts0;
    clock_gettime(CLOCK_MONOTONIC, &ts0); /* monotonic: immune to NTP/clock jumps */
 

--- a/src/modules/workflows/wfe_scheduler.c
+++ b/src/modules/workflows/wfe_scheduler.c
@@ -8,6 +8,7 @@
  * DB transaction safety across workers is the db1 txn gate. */
 #include "wfe_scheduler.h"
 
+#include "config.h" /* config_autonomy_lookup: live autonomy.* caps + auto-resume policy */
 #include "log.h"
 #include "wfe_autonomy.h"
 #include "wfe_blocks.h" /* wfe_worktree_cleanup (terminal) + wfe_worktree_orphan_gc (age-based) */
@@ -44,14 +45,11 @@ static int g_notified;
  * itself holds no transaction (see wfe_engine_advance). */
 static long wfe_sched_concurrency(void)
 {
-   const char *v = getenv("AIMEE_AUTONOMY_CONCURRENCY");
-   if (v && v[0])
-   {
-      char *end = NULL;
-      long k = strtol(v, &end, 10);
-      if (end && *end == '\0' && k >= 1 && k <= 64)
-         return k;
-   }
+   /* Config-backed + live (env override > autonomy.concurrency snapshot); tunable from
+    * the web Settings GUI. Out-of-range / unavailable -> historical default 8. */
+   long k;
+   if (config_autonomy_lookup("AIMEE_AUTONOMY_CONCURRENCY", &k) && k >= 1 && k <= 64)
+      return k;
    return 8;
 }
 
@@ -83,6 +81,54 @@ static int wfe_sched_driveable(const char *pause_reason)
           strcmp(pause_reason, "panel_degraded") == 0 ||
           strcmp(pause_reason, "panel_unreachable") == 0 ||
           strcmp(pause_reason, "slices_running") == 0;
+}
+
+/* Auto-resume policy for wall-cap parks. A wall_cap_exceeded park is a long run
+ * hitting its per-resume wall window (a legitimate checkpoint, not a runaway), so
+ * when autonomy.auto_resume_cap_parks is on, give it a fresh window instead of
+ * leaving it for the reaper — this is what drives an autonomous run to completion
+ * across multiple wall windows. Bounded by autonomy.max_resumes, counted from this
+ * item's own prior auto-resume events, so a genuinely wedged run still ends up
+ * reaped once the budget is spent. A turn_cap park (CUMULATIVE turn count) is
+ * deliberately NOT auto-resumed: that cap IS the runaway backstop — raise
+ * autonomy.max_turns to give a run more total budget. All knobs are config-backed
+ * + live (env override honored), tunable from the web Settings GUI. */
+static void wfe_sched_try_auto_resume(const db1_work_item_t *it)
+{
+   long on = 0;
+   if (!(config_autonomy_lookup("AIMEE_AUTONOMY_AUTO_RESUME_CAP_PARKS", &on) && on))
+      return; /* policy off (or snapshot unavailable) -> leave it for the reaper */
+   long maxr = 50, lv;
+   if (config_autonomy_lookup("AIMEE_AUTONOMY_MAX_RESUMES", &lv) && lv >= 0)
+      maxr = lv;
+   if (maxr <= 0)
+      return; /* budget 0 -> effectively off */
+
+   /* Count prior auto-resumes (our own marker) so max_resumes bounds the loop; a
+    * manual operator resume uses a different actor and is not counted. */
+   db1_lifecycle_event_t *evs = NULL;
+   int nev = db1_lifecycle_event_list(it->work_item_id, &evs);
+   int resumes = 0;
+   for (int i = 0; i < nev; i++)
+      if (strcmp(evs[i].kind, "resume") == 0 && strcmp(evs[i].actor, "autonomy-sched") == 0)
+         resumes++;
+   free(evs);
+   if (resumes >= maxr)
+      return; /* auto-resume budget spent -> let the stale-park reaper abandon it */
+
+   /* Compare-and-clear: resume only while it still equals (wall_cap_exceeded, stage),
+    * so a manual resume or state change racing this sweep is not double-applied. */
+   if (db1_work_item_clear_pause_if(it->work_item_id, "wall_cap_exceeded", it->current_stage) != 1)
+      return;
+   /* Deliberately do NOT reset the per-stage attempt counter: a wall-cap park is a
+    * time-box (the run mid-execution ran out of wall window), not a loop-back, so the
+    * stage's max_attempts -> 'stuck' backstop must keep counting genuine loop-backs
+    * across wall windows rather than being re-armed each one. (A human resume re-arms
+    * it deliberately; an automatic wall-window continuation should not.) */
+   db1_lifecycle_event_add(it->work_item_id, it->current_stage, "resume", "autonomy-sched",
+                           "auto-resume (wall-cap): fresh wall window", "", 0);
+   aimee_log(LOG_INFO, "wfe-sched", "auto-resumed %s (wall-cap park; resume %d/%ld)",
+             it->work_item_id, resumes + 1, maxr);
 }
 
 /* Stage class for sweep priority: LOWER runs first. Downstream-first ("drain
@@ -151,15 +197,10 @@ void wfe_scheduler_run_once(void)
     * operator_paused) are never reaped. Default 1h; AIMEE_AUTONOMY_STALE_ABANDON_SECS
     * overrides, 0 disables. */
    {
-      long grace = 3600;
-      const char *g = getenv("AIMEE_AUTONOMY_STALE_ABANDON_SECS");
-      if (g && g[0])
-      {
-         char *end = NULL;
-         long v = strtol(g, &end, 10);
-         if (end && *end == '\0' && v >= 0)
-            grace = v;
-      }
+      /* Config-backed + live (env override > autonomy.stale_abandon_secs); 0 disables. */
+      long grace = 3600, gv;
+      if (config_autonomy_lookup("AIMEE_AUTONOMY_STALE_ABANDON_SECS", &gv) && gv >= 0)
+         grace = gv;
       int reaped = db1_work_item_reap_stale_parks(grace);
       if (reaped > 0)
          aimee_log(LOG_INFO, "wfe-sched", "reaped %d stale-parked run(s) -> abandoned", reaped);
@@ -196,6 +237,13 @@ void wfe_scheduler_run_once(void)
          continue; /* any other non-terminal state: leave it (don't reap its worktree) */
       if (strcmp(items[i].mode, "autonomous") != 0)
          continue; /* interactive items are human-driven in the webchat */
+      /* A wall-cap park is a long run's checkpoint: auto-resume it (policy-gated,
+       * bounded) so it keeps making progress. Cleared here, it is driven next sweep
+       * (this snapshot still reads wall_cap_exceeded, so it stays non-driveable now).
+       * clear_pause_if bumps updated_at, so the reaper (which ran earlier this sweep,
+       * before the list snapshot) will not catch the freshly-resumed run next sweep. */
+      if (strcmp(items[i].pause_reason, "wall_cap_exceeded") == 0)
+         wfe_sched_try_auto_resume(&items[i]);
       if (!wfe_sched_driveable(items[i].pause_reason))
          continue; /* parked on a human/dead gate: no agent, just waits (a gate/resume
                     * API or the reaper moves it) — driving it only starves runnable runs */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1931,6 +1931,7 @@ $(TESTPREFIX)/unit-test-wfe-sliced-build: $(OBJDIR)/tests/test_wfe_sliced_build.
 $(TESTPREFIX)/unit-test-wfe-autonomy: $(OBJDIR)/tests/test_wfe_autonomy.o \
                                       $(OBJDIR)/modules/workflows/wfe_autonomy.o $(OBJDIR)/modules/workflows/wfe_approval.o \
                                       $(OBJDIR)/tests/support/log_stub.o \
+                                      $(OBJDIR)/tests/support/config_autonomy_stub.o \
                                       $(OBJDIR)/modules/workflows/wfe_roundtable.o $(OBJDIR)/modules/workflows/wfe_verdict.o \
                                       $(OBJDIR)/modules/workflows/wfe_engine.o $(OBJDIR)/db1/db1_init.o \
                                       $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/wfe_store.o \

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -136,8 +136,8 @@ int main(void)
    {
       long v;
       /* a non-config autonomy var -> 0 so the caller uses its own env/default */
-      platform_unsetenv("AIMEE_AUTONOMY_MAX_TURNS");
-      assert(config_autonomy_lookup("AIMEE_AUTONOMY_MAX_TURNS", &v) == 0);
+      platform_unsetenv("AIMEE_AUTONOMY_USD_PER_SEC");
+      assert(config_autonomy_lookup("AIMEE_AUTONOMY_USD_PER_SEC", &v) == 0);
       /* operator env override wins */
       platform_setenv("AIMEE_AUTONOMY_SKEPTICS", "7");
       assert(config_autonomy_lookup("AIMEE_AUTONOMY_SKEPTICS", &v) == 1 && v == 7);
@@ -150,6 +150,23 @@ int main(void)
       assert(config_save(&sc) == 0);
       assert(config_reload() == 1);
       assert(config_autonomy_lookup("AIMEE_AUTONOMY_SKEPTICS", &v) == 1 && v == 9);
+
+      /* Run-safety caps are now config-backed + live too (GUI-tunable). Env override
+       * wins; otherwise the live snapshot; a config.set applies without a restart. */
+      platform_setenv("AIMEE_AUTONOMY_MAX_WALL_SECS", "5400");
+      assert(config_autonomy_lookup("AIMEE_AUTONOMY_MAX_WALL_SECS", &v) == 1 && v == 5400);
+      platform_unsetenv("AIMEE_AUTONOMY_MAX_WALL_SECS");
+      platform_unsetenv("AIMEE_AUTONOMY_MAX_TURNS");
+      memset(&sc, 0, sizeof sc);
+      config_load(&sc);
+      sc.autonomy_max_turns = 1234;
+      sc.autonomy_max_wall_secs = 7200;
+      sc.autonomy_auto_resume_cap_parks = 0; /* flip the default (ON) so the read is meaningful */
+      assert(config_save(&sc) == 0);
+      assert(config_reload() == 1);
+      assert(config_autonomy_lookup("AIMEE_AUTONOMY_MAX_TURNS", &v) == 1 && v == 1234);
+      assert(config_autonomy_lookup("AIMEE_AUTONOMY_MAX_WALL_SECS", &v) == 1 && v == 7200);
+      assert(config_autonomy_lookup("AIMEE_AUTONOMY_AUTO_RESUME_CAP_PARKS", &v) == 1 && v == 0);
    }
 
    /* --- concurrent torn-read stress: readers spin while the writer toggles + reloads --- */


### PR DESCRIPTION
## Why

The autonomous-run safety caps (`max_turns`, `max_wall_secs`, `stale_abandon_secs`, `concurrency`) were **env-only** (`AIMEE_AUTONOMY_*`), and a long run that hit its per-resume wall-clock cap was **never auto-resumed** — the stale-park reaper eventually abandoned it. So long autonomous runs (trigger → PR) died before reaching `final_pr`, and the only way to tune the caps was SSH/env.

This makes all of it tunable from the **web Settings GUI**, and adds an **auto-resume policy** so long runs drive to completion unattended.

## What

**Config** (mirrors the existing `autonomy.skeptics` plumbing — config-backed + live via `config_autonomy_lookup`, so a Settings change applies to the next workflow with **no restart**, and an exported `AIMEE_AUTONOMY_*` still overrides):
- `autonomy.max_turns` (300), `autonomy.max_wall_secs` (1800), `autonomy.stale_abandon_secs` (3600), `autonomy.concurrency` (8)
- `autonomy.auto_resume_cap_parks` (bool, **default ON**)
- `autonomy.max_resumes` (50)

Defaults match the historical env defaults, so **behavior is unchanged until an operator changes a knob**. The readers in `wfe_autonomy.c` (turn/wall caps) and `wfe_scheduler.c` (concurrency, stale-abandon grace) now read the live value.

**Auto-resume policy**: the scheduler sweep resumes a `wall_cap_exceeded` park (giving the run a fresh wall window) instead of leaving it to be reaped — bounded by `max_resumes`, counted from the run's own prior auto-resume events (compare-and-clear so a manual resume racing the sweep isn't double-applied). A `turn_cap` park (cumulative turn count) is deliberately **not** auto-resumed — that cap is the runaway backstop; raise `max_turns` for more total budget. The per-stage `stuck` attempt counter is intentionally **not** reset on a wall-cap resume (a time-box, not a loop-back), preserving stuck detection.

**Frontend**: an "Autonomous workflow" Settings section (`Settings.tsx` category) with per-field help (`settingsHelp.ts`); fields render automatically from the config allowlist.

## Verification
- `make -j all server` + full `make unit-tests` green (530 tests), incl. extended `test_config_snapshot.c` (env-override + live-snapshot + save round-trip for the new caps).
- Regenerated `docs/gen/configuration.md`.
- Adversarial review of the scheduler auto-resume logic: no correctness/memory/race issues; bound is monotonic and race-free; reaper interaction safe.