### PR TITLE
fix(wfe): WFE verify forces in-scope, decoupling from verify_cross_project

### DIFF
--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -352,6 +352,15 @@ static int wfe_live_verify_run(const char *workdir, char *out_verdict, size_t n)
    cJSON_AddStringToObject(args, "action", "run");
    cJSON_AddBoolToObject(args, "async", 0); /* synchronous: we need the verdict now */
    cJSON_AddStringToObject(args, "format", "json");
+   /* Assert authority over the target: this provider verifies a SPECIFIC work-item
+    * worktree (we pin the run_cmd CWD to it below), so it is the authoritative
+    * in-process caller force_in_scope exists for. Without this, handle_git_verify
+    * falls to verify_project_in_scope(), which reports the WFE repo out-of-scope
+    * whenever it is not the daemon's "current project" -> an "unavailable" verdict
+    * that loops the implement block to its cap. Forcing in-scope here decouples the
+    * WFE verify from the global verify_cross_project flag (a deployment knob that
+    * should not gate whether a slice's own committed tree can be verified). */
+   cJSON_AddBoolToObject(args, "force_in_scope", 1);
    /* handle_git_verify never reads a "path" arg itself — on the MCP route the
     * dispatch layer chdirs the run_cmd thread before the handler runs, and
     * resolve_verify_root() picks the root up from that CWD. Calling the handler


### PR DESCRIPTION
## Why

Diagnosing why autonomous WFE runs on `.254` were dying: every implement slice looped and hit the wall-clock cap. Root cause chain was `wall_cap_exceeded` ← impl loops ~22× ← mandatory verify fails every time ← (partly) the verify falling out-of-scope.

The live WFE verify provider (`wfe_live_verify_run`) verifies a **specific** slice worktree — it pins the `run_cmd` CWD to that worktree before calling `handle_git_verify`. But it didn't pass `force_in_scope`, so on the in-process **fallback** path `handle_git_verify` fell to `verify_project_in_scope()`, which reports the repo **out-of-scope** whenever it isn't the daemon's "current project" → an `"unavailable"` verdict that loops the implement block to its attempt cap.

That made a slice's ability to verify **its own committed tree** depend on the global `verify_cross_project` deployment flag — a blunt knob that also opts every unrelated repo into gating.

## What

Pass `force_in_scope: true` from the WFE verify provider. `force_in_scope` exists precisely for *"an IN-PROCESS caller that is authoritative about the target"* (`git_verify.c`) — exactly this provider, which owns the worktree it's verifying. Now the WFE verify is self-sufficient and a slice can't be wedged by cross-project scoping regardless of the flag.

The primary sandbox path (`wfe_verify_in_sandbox`) already runs steps in the slice worktree with no scope check, so this only affects the fallback.

## Verification
- `make -j all server` clean; clang-format clean.
- Full `make unit-tests` green; the 5 verify-related suites (git-verify-contract/select, verify-hook, mcp-git, roundtable-verify) pass — no regression.
- Integration proof: a live WFE run on `.254` that was stuck in the impl loop recovered and is now advancing `impl → freeze → rt_gate` after this class of fix (plus removing the stale seeded workspace paths that broke the sandbox mount).