### PR TITLE
fix(git): allow advanced long-lived PR branches

### DIFF
--- a/src/modules/git/mcp_git_query.c
+++ b/src/modules/git/mcp_git_query.c
@@ -269,8 +269,11 @@ static int mcp_git_is_managed_worktree_root(const char *path)
 
 /* --- Merged-PR detection --- */
 
-/* Check if the given branch has a merged PR. Returns 1 if merged, 0 if not.
- * Skips the check for main/master. */
+/* Check if the given branch is still at the head of its latest merged PR.
+ * Returns 1 only when reusing the branch would mutate an already-merged line
+ * with no new commits. Long-lived integration branches (for example testing)
+ * may accumulate new commits and open another promotion PR. Skips the check
+ * for main/master. */
 int check_branch_has_merged_pr_for(const char *branch)
 {
    if (!branch || !branch[0])
@@ -280,7 +283,8 @@ int check_branch_has_merged_pr_for(const char *branch)
 
    char cmd[512];
    snprintf(cmd, sizeof(cmd),
-            "gh pr list --head '%s' --state merged --json number --limit 1 2>/dev/null", branch);
+            "gh pr list --head '%s' --state merged --json number,headRefOid --limit 1 2>/dev/null",
+            branch);
 
    int rc;
    char *out = mcp_git_run(cmd, &rc);
@@ -290,9 +294,38 @@ int check_branch_has_merged_pr_for(const char *branch)
       return 0; /* gh not available or failed -- don't block */
    }
 
-   int has_merged = (strstr(out, "\"number\"") != NULL);
+   cJSON *prs = cJSON_Parse(out);
    free(out);
-   return has_merged;
+   if (!prs || !cJSON_IsArray(prs) || cJSON_GetArraySize(prs) == 0)
+   {
+      cJSON_Delete(prs);
+      return 0;
+   }
+
+   cJSON *latest = cJSON_GetArrayItem(prs, 0);
+   cJSON *merged_head = cJSON_GetObjectItemCaseSensitive(latest, "headRefOid");
+   if (!cJSON_IsString(merged_head) || !merged_head->valuestring[0])
+   {
+      cJSON_Delete(prs);
+      return 1; /* A merged PR exists but its head is unavailable: fail closed. */
+   }
+
+   char merged_head_oid[128];
+   snprintf(merged_head_oid, sizeof(merged_head_oid), "%s", merged_head->valuestring);
+   cJSON_Delete(prs);
+
+   char *current_head = mcp_git_run("git rev-parse HEAD 2>/dev/null", &rc);
+   if (rc != 0 || !current_head)
+   {
+      free(current_head);
+      return 1;
+   }
+   char *nl = strchr(current_head, '\n');
+   if (nl)
+      *nl = '\0';
+   int unchanged_since_merge = (strcmp(current_head, merged_head_oid) == 0);
+   free(current_head);
+   return unchanged_since_merge;
 }
 
 /* --- Branch helper --- */

--- a/src/tests/test_mcp_git.c
+++ b/src/tests/test_mcp_git.c
@@ -1480,7 +1480,7 @@ static void test_verify_prepare_pr_blocks_branch_with_merged_pr(void)
 {
    char tmpdir[256], fake_home[256], fake_bin_dir[256];
    const char fake_gh_script[] = "if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n"
-                                 "  printf '[{\"number\":537}]\\n'\n"
+                                 "  printf '[{\"number\":537,\"headRefOid\":\"merged-head\"}]\\n'\n"
                                  "  exit 0\n"
                                  "fi\n"
                                  "exit 1\n";
@@ -1488,6 +1488,10 @@ static void test_verify_prepare_pr_blocks_branch_with_merged_pr(void)
        "if [ \"$1\" = \"rev-parse\" ] && [ \"$2\" = \"--abbrev-ref\" ] && "
        "[ \"$3\" = \"HEAD\" ]; then\n"
        "  printf 'feature-reused\\n'\n"
+       "  exit 0\n"
+       "fi\n"
+       "if [ \"$1\" = \"rev-parse\" ] && [ \"$2\" = \"HEAD\" ]; then\n"
+       "  printf 'merged-head\\n'\n"
        "  exit 0\n"
        "fi\n"
        "exit 1\n";
@@ -1514,6 +1518,60 @@ static void test_verify_prepare_pr_blocks_branch_with_merged_pr(void)
    assert(text != NULL);
    assert(strstr(text, "Branch Reuse: BLOCKED") != NULL);
    assert(strstr(text, "already has a merged PR") != NULL);
+   cJSON_Delete(resp);
+   cJSON_Delete(args);
+
+   assert(chdir(saved_cwd) == 0);
+
+   {
+      char cmd[1024];
+      snprintf(cmd, sizeof(cmd), "rm -rf '%s'", fake_bin_dir);
+      system(cmd);
+   }
+   verify_test_teardown(tmpdir, fake_home);
+}
+
+static void test_verify_prepare_pr_allows_reused_branch_with_new_head(void)
+{
+   char tmpdir[256], fake_home[256], fake_bin_dir[256];
+   const char fake_gh_script[] = "if [ \"$1\" = \"pr\" ] && [ \"$2\" = \"list\" ]; then\n"
+                                 "  printf '[{\"number\":537,\"headRefOid\":\"merged-head\"}]\\n'\n"
+                                 "  exit 0\n"
+                                 "fi\n"
+                                 "exit 1\n";
+   const char fake_git_script[] =
+       "if [ \"$1\" = \"rev-parse\" ] && [ \"$2\" = \"--abbrev-ref\" ] && "
+       "[ \"$3\" = \"HEAD\" ]; then\n"
+       "  printf 'testing\\n'\n"
+       "  exit 0\n"
+       "fi\n"
+       "if [ \"$1\" = \"rev-parse\" ] && [ \"$2\" = \"HEAD\" ]; then\n"
+       "  printf 'new-testing-head\\n'\n"
+       "  exit 0\n"
+       "fi\n"
+       "exit 1\n";
+   verify_test_setup_repo(tmpdir, sizeof(tmpdir), "aimee-test-verify-reused-pr-new-head");
+   verify_test_write_yaml(tmpdir, fake_home, sizeof(fake_home),
+                          "verify:\n"
+                          "  enforce: false\n"
+                          "  steps:\n"
+                          "    - name: verify-local\n"
+                          "      run: echo ok\n");
+   verify_test_set_fake_path(fake_bin_dir, sizeof(fake_bin_dir));
+   verify_test_write_fake_gh(fake_bin_dir, fake_gh_script);
+   verify_test_write_fake_git(fake_bin_dir, fake_git_script);
+
+   char saved_cwd[4096];
+   assert(getcwd(saved_cwd, sizeof(saved_cwd)) != NULL);
+   assert(chdir(tmpdir) == 0);
+
+   cJSON *args = cJSON_CreateObject();
+   cJSON_AddStringToObject(args, "action", "prepare-pr");
+   cJSON_AddStringToObject(args, "base", "main");
+   cJSON *resp = handle_git_verify(NULL, args, NULL);
+   char *text = get_mcp_text(resp);
+   assert(text != NULL);
+   assert(strstr(text, "Branch Reuse: BLOCKED") == NULL);
    cJSON_Delete(resp);
    cJSON_Delete(args);
 
@@ -2354,6 +2412,7 @@ int main(void)
    test_verify_load_config_falls_back_to_verify_local();
    test_verify_load_config_old_flat_format_ignored();
    test_verify_prepare_pr_blocks_branch_with_merged_pr();
+   test_verify_prepare_pr_allows_reused_branch_with_new_head();
 
    /* Verify gate enforcement tests */
    test_verify_gate_not_enforced_without_enforce_flag();


### PR DESCRIPTION
## What changed

- Treat a branch as exhausted only when its current HEAD matches the head commit recorded on its latest merged PR.
- Allow long-lived integration branches such as `testing` to open another promotion PR after receiving new commits.
- Keep the existing fail-closed behavior when GitHub reports a merged PR but does not provide its head OID.
- Add regressions covering both unchanged merged branches and advanced long-lived branches.

## Root cause

The MCP Git guard asked only whether a branch name had ever appeared on a merged PR. That is correct for disposable feature branches but incorrectly blocks reusable integration branches. Aimee's workspace guard already recognizes this distinction, so the MCP surface had drifted from established behavior.

This was reproduced while promoting SmoothNAS: `testing` received the namespace-visibility fix after its previous stable promotion, but Aimee rejected the new `testing` → `main` PR solely because an older promotion PR had merged.

## Validation

- Red baseline: the new long-lived-branch test failed with `Branch Reuse: BLOCKED` before the implementation change.
- `make -j2 build/obj/tests/unit-test-mcp-git`
- `build/obj/tests/unit-test-mcp-git`
- `clang-format-19 --dry-run -Werror src/modules/git/mcp_git_query.c src/tests/test_mcp_git.c`
