### PR TITLE
Expose trigger admission cap in Workflows run policy

### DIFF
--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -611,12 +611,17 @@ export default function WorkflowActions() {
   );
 }
 
-// Run policy: the autonomy safety caps + auto-resume toggle that govern how far an
-// autonomous run drives on its own (trigger -> PR). These are the autonomy.* config
-// keys; kept here under Workflows because that is exactly what they tune. Config-backed
-// + live, so a change applies to the next workflow (no restart); an exported
-// AIMEE_AUTONOMY_* env var still overrides.
-const AUTONOMY_FIELDS: { key: string; label: string; help: string; kind: "int" | "bool" }[] = [
+// Run policy: trigger admission plus the autonomy safety caps that govern how many
+// workflows start and how far each one drives (trigger -> PR). Kept here under
+// Workflows because that is exactly what they tune. Config-backed + live; exported
+// AIMEE_AUTONOMY_* values still override the matching autonomy fields.
+const RUN_POLICY_FIELDS: { key: string; label: string; help: string; kind: "int" | "bool" }[] = [
+  {
+    key: "trigger.max_concurrent",
+    label: "Trigger admission cap",
+    kind: "int",
+    help: "Maximum active runs admitted across configured triggers. New proposals remain queued for a later scheduler pass when the cap is reached. Default 2. 0 = uncapped.",
+  },
   {
     key: "autonomy.auto_resume_cap_parks",
     label: "Auto-resume wall-cap parks",
@@ -681,7 +686,7 @@ function RunPolicyPanel() {
       >
         <span style={{ fontSize: 11, color: "#999", width: 10 }}>{open ? "▾" : "▸"}</span>
         <span style={{ fontWeight: 600, fontSize: 13 }}>⚙ Run policy</span>
-        <span style={{ marginLeft: "auto", fontSize: 11, color: "#aaa" }}>autonomy caps</span>
+        <span style={{ marginLeft: "auto", fontSize: 11, color: "#aaa" }}>admission + autonomy caps</span>
       </div>
       {open && (
         <div style={{ marginTop: 6 }}>
@@ -690,10 +695,11 @@ function RunPolicyPanel() {
           ) : (
             <>
               <div style={{ fontSize: 11, color: "#999", lineHeight: 1.4, marginBottom: 6 }}>
-                Safety caps + auto-resume for autonomous runs. Applies to the next workflow (no
-                restart); an exported <code>AIMEE_AUTONOMY_*</code> env var overrides.
+                Admission, safety caps, and auto-resume for autonomous runs. Changes apply live;
+                an exported <code>AIMEE_AUTONOMY_*</code> env var overrides matching autonomy
+                fields.
               </div>
-              {AUTONOMY_FIELDS.map((f) => (
+              {RUN_POLICY_FIELDS.map((f) => (
                 <div
                   key={f.key}
                   title={f.help}

--- a/frontend/src/pages/settingsHelp.ts
+++ b/frontend/src/pages/settingsHelp.ts
@@ -40,6 +40,9 @@ export const SECTION_HELP: Record<string, string> = {
 
 // One line per config key. Plain language, states the default.
 export const FIELD_HELP: Record<string, string> = {
+  // Workflow trigger admission (live)
+  "trigger.max_concurrent":
+    "Maximum active runs admitted across all configured triggers. When the cap is reached, new proposals stay pending and are reconsidered on a later scheduler pass. Default 2. 0 or less means uncapped.",
   // Autonomous workflow — run safety caps + auto-resume (live; env override wins)
   "autonomy.max_turns":
     "Cumulative per-run turn cap (persisted audit events) before a run is parked as a runaway backstop. Default 300. Raise for long multi-slice runs; this is the ultimate bound on total run length (auto-resume does NOT reset it).",

--- a/src/modules/config/config_fields.c
+++ b/src/modules/config/config_fields.c
@@ -371,6 +371,9 @@ const config_field_t config_fields[] = {
      offsetof(config_t, roundtable_pipeline_parked_releases_slot), sizeof(int), 1, CFG_BOOL},
     {"roundtable.pipeline_unknown_context_tokens",
      offsetof(config_t, roundtable_pipeline_unknown_context_tokens), sizeof(int), 0, CFG_INT},
+    /* Trigger admission policy. The scheduler reads this from the live config snapshot on
+     * every sweep, so GUI changes take effect without a restart. */
+    {"trigger.max_concurrent", offsetof(config_t, trigger_max_concurrent), sizeof(int), 0, CFG_INT},
     /* The economizer is a SINGLE tiered control: get/set as an "off|safe|aggressive" string
      * (CFG_ECON_TIER stores the int enum). The old per-lever reduce.* / economizer.enabled|
      * aggressive keys were removed; the per-tier lever values are internal presets (econ_preset).

--- a/src/tests/test_cmd_config.c
+++ b/src/tests/test_cmd_config.c
@@ -164,6 +164,13 @@ static void test_config_fields_helpers(void)
    assert(cJSON_IsNumber(v) && v->valueint == 42);
    cJSON_Delete(v);
 
+   /* nested trigger admission policy is GUI/config.set writable */
+   const config_field_t *trigger_cap = config_field_lookup("trigger.max_concurrent");
+   assert(trigger_cap && config_field_set_value(&cfg, trigger_cap, "7") == 0);
+   v = config_field_value_json(&cfg, trigger_cap);
+   assert(cJSON_IsNumber(v) && v->valueint == 7);
+   cJSON_Delete(v);
+
    /* float — including a threshold field that used to be mistyped CFG_STRING */
    const config_field_t *thr = config_field_lookup("guardrails_semantic_warn_threshold");
    assert(thr && config_field_set_value(&cfg, thr, "0.25") == 0);


### PR DESCRIPTION
## What changed

- expose `trigger.max_concurrent` through the live config get/set allowlist
- add a **Trigger admission cap** control to Workflows → Run policy
- document that proposals remain pending and are reconsidered when capacity opens
- add a focused config-field regression test

## Why

The Workflows GUI already exposes per-run autonomy caps, but the separate trigger admission cap was YAML-only. Operators need to tune how many triggered runs may be active without editing the appliance config by hand.

## Impact

Changes apply live through the existing config API. `0` or less remains the existing uncapped behavior; the backend default remains `2`.

## Validation

- `src/build/obj/tests/unit-test-cmd-config`
- `npm run check`
- `npm test -- --run` (93 tests)
- `npm run build`
- `clang-format-19 --dry-run -Werror` on changed C files
- `git diff --check`
