### PR TITLE
feat: bootstrap canonical module inventory

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -46,10 +46,12 @@ jobs:
           data["required"].append("replacement-module")
           path.write_text(json.dumps(data))
           PY
-          if ./scripts/check_module_inventory.sh \
-              --config-root "$root" --inventory inventory.yaml; then
-            echo "::error::mutated inventory unexpectedly passed"
+          if output=$(./scripts/check_module_inventory.sh \
+              --config-root "$root" --inventory inventory.yaml 2>&1); then
+            echo "::error::mutated inventory unexpectedly passed: $output"
             exit 1
           fi
+          echo "$output"
+          printf '%s\n' "$output" | grep -q 'rule=required-classification'
       - name: Test inventory failure modes
         run: python3 -I scripts/tests/test_check_module_inventory.py -v

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -20,11 +20,36 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+      - name: Install test-only YAML parser
+        run: python3 -m pip install --disable-pip-version-check PyYAML==6.0.2
       - name: Validate canonical inventory
         run: ./scripts/check_module_inventory.sh
+      - name: Validate from a non-repository working directory
+        run: cd /tmp && "$GITHUB_WORKSPACE/scripts/check_module_inventory.sh"
+      - name: Prove a mutated inventory fails closed
+        run: |
+          root=$(mktemp -d)
+          cp tests/baselines/modules/canonical-inventory.yaml "$root/inventory.yaml"
+          python3 - "$root/inventory.yaml" <<'PY'
+          import json
+          import pathlib
+          import sys
+          path = pathlib.Path(sys.argv[1])
+          data = json.loads(path.read_text())
+          data["required"].remove("git")
+          data["required"].append("replacement-module")
+          path.write_text(json.dumps(data))
+          PY
+          if ./scripts/check_module_inventory.sh \
+              --config-root "$root" --inventory inventory.yaml; then
+            echo "::error::mutated inventory unexpectedly passed"
+            exit 1
+          fi
       - name: Test inventory failure modes
-        run: python3 -m unittest scripts.tests.test_check_module_inventory -v
+        run: python3 -I scripts/tests/test_check_module_inventory.py -v

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -3,7 +3,13 @@ name: Module inventory
 on:
   pull_request:
     branches: [feature/core-modularization]
+  push:
+    branches: [feature/core-modularization]
   workflow_dispatch:
+
+concurrency:
+  group: module-inventory-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -12,8 +18,12 @@ jobs:
   module-inventory:
     name: module-inventory
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Validate canonical inventory
         run: ./scripts/check_module_inventory.sh
       - name: Test inventory failure modes

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -1,0 +1,20 @@
+name: Module inventory
+
+on:
+  pull_request:
+    branches: [feature/core-modularization]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  module-inventory:
+    name: module-inventory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate canonical inventory
+        run: ./scripts/check_module_inventory.sh
+      - name: Test inventory failure modes
+        run: python3 -m unittest scripts.tests.test_check_module_inventory -v

--- a/docs/validation/core-modularization-slice-1.md
+++ b/docs/validation/core-modularization-slice-1.md
@@ -1,0 +1,33 @@
+# Core modularization slice 1: canonical inventory bootstrap
+
+## Decision
+
+Slice 1 implements only the pre-child taxonomy gate from acceptance id 8 of
+`module-runtime-source-ownership-and-build.md`. The canonical inventory is the sole build/runtime
+list of module IDs and classifications. Its checker validates structure, counts, uniqueness,
+disjointness, ID syntax, and Git's required classification without reading source directories,
+descriptors, profiles, or proposal state.
+
+The existing `src/modules/git/` directory predates this effort. It is historical baseline, not
+evidence that the Git migration slice has begun and not a descriptor or readiness claim. Binding
+Git source to the new module contract is re-decided only after `git-core-contract.md` is accepted.
+
+## Included
+
+- `tests/baselines/modules/canonical-inventory.yaml`
+- a CWD-independent, safe-JSON parser and shell entrypoint
+- mutation-focused failure tests without a second hard-coded module list
+- the `module-inventory` pull-request workflow for `feature/core-modularization`
+
+## Deferred
+
+- `git-core-contract.md` and `check_proposal_ordering.sh`
+- module descriptors, descriptor schema, runtime loading, and generated profiles
+- descriptor/profile equality and readiness checks
+- Git source changes or memory ingest-boundary changes
+- Make/CMake integration and source relocation
+
+The dedicated proposal-ordering checker is the next governance prerequisite and must land before
+any Git descriptor, build/profile registration, readiness, or source-migration slice. Branch
+protection for the `module-inventory` job is an external repository-administration step; this
+program independently refuses to merge a slice until the job is green.

--- a/docs/validation/core-modularization-slice-1.md
+++ b/docs/validation/core-modularization-slice-1.md
@@ -15,7 +15,8 @@ Git source to the new module contract is re-decided only after `git-core-contrac
 ## Included
 
 - `tests/baselines/modules/canonical-inventory.yaml`
-- a CWD-independent, safe-JSON parser and shell entrypoint
+- a CWD-independent, standard-library JSON parser and shell entrypoint; the `.yaml` file is
+  intentionally restricted to JSON-compatible YAML and never loaded through a YAML object loader
 - mutation-focused failure tests without a second hard-coded module list
 - the `module-inventory` pull-request workflow for `feature/core-modularization`
 
@@ -31,3 +32,7 @@ The dedicated proposal-ordering checker is the next governance prerequisite and 
 any Git descriptor, build/profile registration, readiness, or source-migration slice. Branch
 protection for the `module-inventory` job is an external repository-administration step; this
 program independently refuses to merge a slice until the job is green.
+
+Relative inventory paths resolve against `--config-root`, then `AIMEE_CONFIG_ROOT`, then the
+repository root derived from the checker path. This ordering is independent of the caller's current
+working directory.

--- a/scripts/check_module_inventory.py
+++ b/scripts/check_module_inventory.py
@@ -23,46 +23,15 @@ DEFAULT_INVENTORY = Path("tests/baselines/modules/canonical-inventory.yaml")
 ALLOWED_KEYS = {"schema_version", "required", "optional"}
 REQUIRED_COUNT = 18
 OPTIONAL_COUNT = 8
-REQUIRED_CLASSIFICATIONS = {"git"}
-FORBIDDEN_OPTIONAL_CLASSIFICATIONS = {"git"}
+PINNED_CLASSIFICATIONS = {"git": "required"}
 
 
 class InventoryError(ValueError):
     """A closed, operator-readable inventory validation failure."""
 
 
-def _line_for(path: Path, group: str, value: str) -> int | None:
-    needle = json.dumps(value)
-    try:
-        in_group = False
-        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            stripped = line.strip()
-            if not in_group and stripped.startswith(json.dumps(group)) and "[" in stripped:
-                in_group = True
-                continue
-            if in_group and stripped.startswith("]"):
-                return None
-            if in_group and stripped.rstrip(",") == needle:
-                return number
-    except (OSError, UnicodeError):
-        return None
-    return None
-
-
-def _fail(
-    rule: str,
-    message: str,
-    *,
-    path: Path,
-    group: str | None = None,
-    value: str | None = None,
-) -> None:
-    location = str(path)
-    if group is not None and value is not None:
-        line = _line_for(path, group, value)
-        if line is not None:
-            location += f":{line}"
-    raise InventoryError(f"{location}: rule={rule}: {message}")
+def _fail(rule: str, message: str, *, path: Path) -> None:
+    raise InventoryError(f"{path}: rule={rule}: {message}")
 
 
 def _string_list(data: dict[str, object], key: str, path: Path) -> list[str]:
@@ -118,20 +87,13 @@ def load_inventory(path: Path) -> tuple[dict[str, object], list[str], list[str]]
 
 def validate_inventory(
     path: Path,
-    *,
-    schema_version: int,
-    required_count: int,
-    optional_count: int,
-    required_modules: set[str],
-    forbidden_optional: set[str],
-    forbidden_modules: set[str],
 ) -> None:
     data, required, optional = load_inventory(path)
 
-    if type(data["schema_version"]) is not int or data["schema_version"] != schema_version:
+    if type(data["schema_version"]) is not int or data["schema_version"] != 1:
         _fail(
             "schema-version",
-            f"expected {schema_version}, actual {data['schema_version']!r}",
+            f"expected 1, actual {data['schema_version']!r}",
             path=path,
         )
 
@@ -143,20 +105,16 @@ def validate_inventory(
                 "module-id-syntax",
                 f"invalid module ID {invalid!r}",
                 path=path,
-                group=group,
-                value=invalid,
             )
 
     for group, values in (("required", required), ("optional", optional)):
-        duplicates = sorted(module_id for module_id, count in Counter(values).items() if count > 1)
-        if duplicates:
-            duplicate = duplicates[0]
+        counts = Counter(values)
+        duplicate = next((module_id for module_id in values if counts[module_id] > 1), None)
+        if duplicate is not None:
             _fail(
                 "unique-ids",
                 f"duplicate {group} module {duplicate!r}",
                 path=path,
-                group=group,
-                value=duplicate,
             )
 
     overlap = sorted(set(required) & set(optional))
@@ -166,97 +124,72 @@ def validate_inventory(
             "disjoint-sets",
             f"module {module_id!r} is both required and optional",
             path=path,
-            group="optional",
-            value=module_id,
         )
 
-    for module_id in sorted(required_modules):
-        if module_id not in required:
-            actual = "optional" if module_id in optional else "absent"
+    groups = {"required": set(required), "optional": set(optional)}
+    for module_id, expected in PINNED_CLASSIFICATIONS.items():
+        if module_id not in groups[expected]:
+            actual = next((name for name, values in groups.items() if module_id in values), "absent")
             _fail(
                 "required-classification",
-                f"module {module_id!r}: expected required, actual {actual}",
+                f"module {module_id!r}: expected {expected}, actual {actual}",
                 path=path,
-                group="optional" if module_id in optional else None,
-                value=module_id,
-            )
-    for module_id in sorted(forbidden_optional):
-        if module_id in optional:
-            _fail(
-                "optional-classification",
-                f"module {module_id!r}: expected not optional, actual optional",
-                path=path,
-                group="optional",
-                value=module_id,
-            )
-    for module_id in sorted(forbidden_modules):
-        if module_id in all_ids:
-            group = "required" if module_id in required else "optional"
-            _fail(
-                "forbidden-module",
-                f"forbidden module ID {module_id!r}",
-                path=path,
-                group=group,
-                value=module_id,
             )
 
-    if len(required) != required_count:
+    if len(required) != REQUIRED_COUNT:
         _fail(
             "required-count",
-            f"expected {required_count}, actual {len(required)}",
+            f"expected REQUIRED_COUNT={REQUIRED_COUNT}, actual {len(required)}",
             path=path,
         )
-    if len(optional) != optional_count:
+    if len(optional) != OPTIONAL_COUNT:
         _fail(
             "optional-count",
-            f"expected {optional_count}, actual {len(optional)}",
+            f"expected OPTIONAL_COUNT={OPTIONAL_COUNT}, actual {len(optional)}",
             path=path,
         )
-
-
-def _csv(values: list[str]) -> set[str]:
-    return {item for value in values for item in value.split(",") if item}
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--config-root", type=Path)
     parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
-    parser.add_argument("--schema-version", type=int, default=1)
-    parser.add_argument("--required-count", type=int, default=REQUIRED_COUNT)
-    parser.add_argument("--optional-count", type=int, default=OPTIONAL_COUNT)
-    parser.add_argument("--require-required-module", action="append", default=[])
-    parser.add_argument("--forbid-optional-module", action="append", default=[])
-    parser.add_argument("--forbid-module", action="append", default=[])
     return parser.parse_args(argv)
+
+
+def resolve_inventory(args: argparse.Namespace) -> Path:
+    script_root = Path(__file__).resolve().parent.parent
+    root_value = args.config_root or os.environ.get("AIMEE_CONFIG_ROOT") or script_root
+    config_root = Path(root_value).resolve()
+    if not config_root.is_dir():
+        raise InventoryError(
+            f"{config_root}: rule=config-root: expected an existing directory"
+        )
+
+    candidate = args.inventory if args.inventory.is_absolute() else config_root / args.inventory
+    inventory = candidate.resolve(strict=False)
+    try:
+        inventory.relative_to(config_root)
+    except ValueError as exc:
+        raise InventoryError(
+            f"{inventory}: rule=path: inventory must remain under config root {config_root}"
+        ) from exc
+    return inventory
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
-    script_root = Path(__file__).resolve().parent.parent
-    config_root = args.config_root or Path(os.environ.get("AIMEE_CONFIG_ROOT", script_root))
-    config_root = config_root.resolve()
-    inventory = args.inventory if args.inventory.is_absolute() else config_root / args.inventory
 
     try:
-        validate_inventory(
-            inventory,
-            schema_version=args.schema_version,
-            required_count=args.required_count,
-            optional_count=args.optional_count,
-            required_modules=REQUIRED_CLASSIFICATIONS | _csv(args.require_required_module),
-            forbidden_optional=(
-                FORBIDDEN_OPTIONAL_CLASSIFICATIONS | _csv(args.forbid_optional_module)
-            ),
-            forbidden_modules=_csv(args.forbid_module),
-        )
+        inventory = resolve_inventory(args)
+        validate_inventory(inventory)
     except InventoryError as exc:
         print(f"check_module_inventory: error: {exc}", file=sys.stderr)
         return 1
 
     print(
-        f"check_module_inventory: ok ({args.required_count} required, "
-        f"{args.optional_count} optional; {inventory})"
+        f"check_module_inventory: ok ({REQUIRED_COUNT} required, "
+        f"{OPTIONAL_COUNT} optional; {inventory})"
     )
     return 0
 

--- a/scripts/check_module_inventory.py
+++ b/scripts/check_module_inventory.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Validate Aimee's canonical required/optional module inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+MODULE_ID = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+DEFAULT_INVENTORY = Path("tests/baselines/modules/canonical-inventory.yaml")
+ALLOWED_KEYS = {"schema_version", "required", "optional"}
+
+
+class InventoryError(ValueError):
+    """A closed, operator-readable inventory validation failure."""
+
+
+def _line_for(path: Path, value: str) -> int | None:
+    needle = json.dumps(value)
+    try:
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if needle in line:
+                return number
+    except OSError:
+        return None
+    return None
+
+
+def _fail(rule: str, message: str, *, path: Path, value: str | None = None) -> None:
+    location = str(path)
+    if value is not None:
+        line = _line_for(path, value)
+        if line is not None:
+            location += f":{line}"
+    raise InventoryError(f"{location}: rule={rule}: {message}")
+
+
+def _string_list(data: dict[str, object], key: str, path: Path) -> list[str]:
+    value = data.get(key)
+    if not isinstance(value, list):
+        _fail("structure", f"expected {key} to be an array", path=path)
+    if not all(isinstance(item, str) for item in value):
+        _fail("structure", f"expected every {key} entry to be a string", path=path)
+    return value
+
+
+def load_inventory(path: Path) -> tuple[dict[str, object], list[str], list[str]]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise InventoryError(f"{path}: rule=input: cannot read inventory: {exc.strerror}") from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise InventoryError(
+            f"{path}:{exc.lineno}:{exc.colno}: rule=parse: inventory must be safe JSON-compatible YAML: {exc.msg}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        _fail("structure", "expected a top-level object", path=path)
+    unknown = sorted(set(data) - ALLOWED_KEYS)
+    missing = sorted(ALLOWED_KEYS - set(data))
+    if unknown:
+        _fail("structure", f"unknown keys: {', '.join(unknown)}", path=path)
+    if missing:
+        _fail("structure", f"missing keys: {', '.join(missing)}", path=path)
+
+    required = _string_list(data, "required", path)
+    optional = _string_list(data, "optional", path)
+    return data, required, optional
+
+
+def validate_inventory(
+    path: Path,
+    *,
+    schema_version: int,
+    required_count: int,
+    optional_count: int,
+    required_modules: set[str],
+    forbidden_optional: set[str],
+    forbidden_modules: set[str],
+) -> None:
+    data, required, optional = load_inventory(path)
+
+    if data["schema_version"] != schema_version:
+        _fail(
+            "schema-version",
+            f"expected {schema_version}, actual {data['schema_version']!r}",
+            path=path,
+        )
+
+    all_ids = required + optional
+    invalid = next((module_id for module_id in all_ids if not MODULE_ID.fullmatch(module_id)), None)
+    if invalid is not None:
+        _fail("module-id-syntax", f"invalid module ID {invalid!r}", path=path, value=invalid)
+
+    for group, values in (("required", required), ("optional", optional)):
+        duplicates = sorted({module_id for module_id in values if values.count(module_id) > 1})
+        if duplicates:
+            duplicate = duplicates[0]
+            _fail("unique-ids", f"duplicate {group} module {duplicate!r}", path=path, value=duplicate)
+
+    overlap = sorted(set(required) & set(optional))
+    if overlap:
+        module_id = overlap[0]
+        _fail("disjoint-sets", f"module {module_id!r} is both required and optional", path=path, value=module_id)
+
+    for module_id in sorted(required_modules):
+        if module_id not in required:
+            actual = "optional" if module_id in optional else "absent"
+            _fail(
+                "required-classification",
+                f"module {module_id!r}: expected required, actual {actual}",
+                path=path,
+                value=module_id,
+            )
+    for module_id in sorted(forbidden_optional):
+        if module_id in optional:
+            _fail(
+                "optional-classification",
+                f"module {module_id!r}: expected not optional, actual optional",
+                path=path,
+                value=module_id,
+            )
+    for module_id in sorted(forbidden_modules):
+        if module_id in all_ids:
+            _fail("forbidden-module", f"forbidden module ID {module_id!r}", path=path, value=module_id)
+
+    if len(required) != required_count:
+        _fail(
+            "required-count",
+            f"expected {required_count}, actual {len(required)}",
+            path=path,
+        )
+    if len(optional) != optional_count:
+        _fail(
+            "optional-count",
+            f"expected {optional_count}, actual {len(optional)}",
+            path=path,
+        )
+
+
+def _csv(values: list[str]) -> set[str]:
+    return {item for value in values for item in value.split(",") if item}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config-root", type=Path)
+    parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
+    parser.add_argument("--schema-version", type=int, default=1)
+    parser.add_argument("--required-count", type=int, default=18)
+    parser.add_argument("--optional-count", type=int, default=8)
+    parser.add_argument("--require-required-module", action="append", default=["git"])
+    parser.add_argument("--forbid-optional-module", action="append", default=["git"])
+    parser.add_argument("--forbid-module", action="append", default=[])
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    script_root = Path(__file__).resolve().parent.parent
+    config_root = args.config_root or Path(os.environ.get("AIMEE_CONFIG_ROOT", script_root))
+    config_root = config_root.resolve()
+    inventory = args.inventory if args.inventory.is_absolute() else config_root / args.inventory
+
+    try:
+        validate_inventory(
+            inventory,
+            schema_version=args.schema_version,
+            required_count=args.required_count,
+            optional_count=args.optional_count,
+            required_modules=_csv(args.require_required_module),
+            forbidden_optional=_csv(args.forbid_optional_module),
+            forbidden_modules=_csv(args.forbid_module),
+        )
+    except InventoryError as exc:
+        print(f"check_module_inventory: error: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"check_module_inventory: ok ({args.required_count} required, "
+        f"{args.optional_count} optional; {inventory})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_module_inventory.py
+++ b/scripts/check_module_inventory.py
@@ -23,7 +23,7 @@ DEFAULT_INVENTORY = Path("tests/baselines/modules/canonical-inventory.yaml")
 ALLOWED_KEYS = {"schema_version", "required", "optional"}
 REQUIRED_COUNT = 18
 OPTIONAL_COUNT = 8
-PINNED_CLASSIFICATIONS = {"git": "required"}
+PINNED_REQUIRED = {"git"}
 
 
 class InventoryError(ValueError):
@@ -106,8 +106,6 @@ def validate_inventory(
                 f"invalid module ID {invalid!r}",
                 path=path,
             )
-
-    for group, values in (("required", required), ("optional", optional)):
         counts = Counter(values)
         duplicate = next((module_id for module_id in values if counts[module_id] > 1), None)
         if duplicate is not None:
@@ -126,13 +124,12 @@ def validate_inventory(
             path=path,
         )
 
-    groups = {"required": set(required), "optional": set(optional)}
-    for module_id, expected in PINNED_CLASSIFICATIONS.items():
-        if module_id not in groups[expected]:
-            actual = next((name for name, values in groups.items() if module_id in values), "absent")
+    for module_id in PINNED_REQUIRED:
+        if module_id not in required:
+            actual = "optional" if module_id in optional else "absent"
             _fail(
                 "required-classification",
-                f"module {module_id!r}: expected {expected}, actual {actual}",
+                f"module {module_id!r}: expected required, actual {actual}",
                 path=path,
             )
 
@@ -160,14 +157,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def resolve_inventory(args: argparse.Namespace) -> Path:
     script_root = Path(__file__).resolve().parent.parent
     root_value = args.config_root or os.environ.get("AIMEE_CONFIG_ROOT") or script_root
-    config_root = Path(root_value).resolve()
+    config_root = Path(os.path.realpath(root_value))
     if not config_root.is_dir():
         raise InventoryError(
             f"{config_root}: rule=config-root: expected an existing directory"
         )
 
     candidate = args.inventory if args.inventory.is_absolute() else config_root / args.inventory
-    inventory = candidate.resolve(strict=False)
+    inventory = Path(os.path.realpath(candidate))
     try:
         inventory.relative_to(config_root)
     except ValueError as exc:

--- a/scripts/check_module_inventory.py
+++ b/scripts/check_module_inventory.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
-"""Validate Aimee's canonical required/optional module inventory."""
+"""Validate Aimee's canonical required/optional module inventory.
+
+The ``.yaml`` contract is restricted to JSON-compatible YAML and parsed only
+with the standard-library JSON decoder. Relative inventory paths resolve against
+``--config-root``, then ``AIMEE_CONFIG_ROOT``, then the repository root derived
+from this script, in that order.
+"""
 
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import json
 import os
 import re
@@ -14,27 +21,45 @@ from pathlib import Path
 MODULE_ID = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 DEFAULT_INVENTORY = Path("tests/baselines/modules/canonical-inventory.yaml")
 ALLOWED_KEYS = {"schema_version", "required", "optional"}
+REQUIRED_COUNT = 18
+OPTIONAL_COUNT = 8
+REQUIRED_CLASSIFICATIONS = {"git"}
+FORBIDDEN_OPTIONAL_CLASSIFICATIONS = {"git"}
 
 
 class InventoryError(ValueError):
     """A closed, operator-readable inventory validation failure."""
 
 
-def _line_for(path: Path, value: str) -> int | None:
+def _line_for(path: Path, group: str, value: str) -> int | None:
     needle = json.dumps(value)
     try:
+        in_group = False
         for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            if needle in line:
+            stripped = line.strip()
+            if not in_group and stripped.startswith(json.dumps(group)) and "[" in stripped:
+                in_group = True
+                continue
+            if in_group and stripped.startswith("]"):
+                return None
+            if in_group and stripped.rstrip(",") == needle:
                 return number
-    except OSError:
+    except (OSError, UnicodeError):
         return None
     return None
 
 
-def _fail(rule: str, message: str, *, path: Path, value: str | None = None) -> None:
+def _fail(
+    rule: str,
+    message: str,
+    *,
+    path: Path,
+    group: str | None = None,
+    value: str | None = None,
+) -> None:
     location = str(path)
-    if value is not None:
-        line = _line_for(path, value)
+    if group is not None and value is not None:
+        line = _line_for(path, group, value)
         if line is not None:
             location += f":{line}"
     raise InventoryError(f"{location}: rule={rule}: {message}")
@@ -43,20 +68,35 @@ def _fail(rule: str, message: str, *, path: Path, value: str | None = None) -> N
 def _string_list(data: dict[str, object], key: str, path: Path) -> list[str]:
     value = data.get(key)
     if not isinstance(value, list):
-        _fail("structure", f"expected {key} to be an array", path=path)
-    if not all(isinstance(item, str) for item in value):
+        _fail(
+            "structure",
+            f"expected {key} to be an array, actual {type(value).__name__}",
+            path=path,
+        )
+    elif not all(isinstance(item, str) for item in value):
         _fail("structure", f"expected every {key} entry to be a string", path=path)
     return value
+
+
+def _object_without_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise InventoryError(f"rule=structure: duplicate object key {key!r}")
+        result[key] = value
+    return result
 
 
 def load_inventory(path: Path) -> tuple[dict[str, object], list[str], list[str]]:
     try:
         raw = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise InventoryError(f"{path}: rule=input: cannot read inventory: {exc.strerror}") from exc
+    except (OSError, UnicodeError) as exc:
+        raise InventoryError(f"{path}: rule=input: cannot read inventory: {exc}") from exc
 
     try:
-        data = json.loads(raw)
+        data = json.loads(raw, object_pairs_hook=_object_without_duplicate_keys)
+    except InventoryError as exc:
+        raise InventoryError(f"{path}: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise InventoryError(
             f"{path}:{exc.lineno}:{exc.colno}: rule=parse: inventory must be safe JSON-compatible YAML: {exc.msg}"
@@ -88,7 +128,7 @@ def validate_inventory(
 ) -> None:
     data, required, optional = load_inventory(path)
 
-    if data["schema_version"] != schema_version:
+    if type(data["schema_version"]) is not int or data["schema_version"] != schema_version:
         _fail(
             "schema-version",
             f"expected {schema_version}, actual {data['schema_version']!r}",
@@ -96,20 +136,39 @@ def validate_inventory(
         )
 
     all_ids = required + optional
-    invalid = next((module_id for module_id in all_ids if not MODULE_ID.fullmatch(module_id)), None)
-    if invalid is not None:
-        _fail("module-id-syntax", f"invalid module ID {invalid!r}", path=path, value=invalid)
+    for group, values in (("required", required), ("optional", optional)):
+        invalid = next((module_id for module_id in values if not MODULE_ID.fullmatch(module_id)), None)
+        if invalid is not None:
+            _fail(
+                "module-id-syntax",
+                f"invalid module ID {invalid!r}",
+                path=path,
+                group=group,
+                value=invalid,
+            )
 
     for group, values in (("required", required), ("optional", optional)):
-        duplicates = sorted({module_id for module_id in values if values.count(module_id) > 1})
+        duplicates = sorted(module_id for module_id, count in Counter(values).items() if count > 1)
         if duplicates:
             duplicate = duplicates[0]
-            _fail("unique-ids", f"duplicate {group} module {duplicate!r}", path=path, value=duplicate)
+            _fail(
+                "unique-ids",
+                f"duplicate {group} module {duplicate!r}",
+                path=path,
+                group=group,
+                value=duplicate,
+            )
 
     overlap = sorted(set(required) & set(optional))
     if overlap:
         module_id = overlap[0]
-        _fail("disjoint-sets", f"module {module_id!r} is both required and optional", path=path, value=module_id)
+        _fail(
+            "disjoint-sets",
+            f"module {module_id!r} is both required and optional",
+            path=path,
+            group="optional",
+            value=module_id,
+        )
 
     for module_id in sorted(required_modules):
         if module_id not in required:
@@ -118,6 +177,7 @@ def validate_inventory(
                 "required-classification",
                 f"module {module_id!r}: expected required, actual {actual}",
                 path=path,
+                group="optional" if module_id in optional else None,
                 value=module_id,
             )
     for module_id in sorted(forbidden_optional):
@@ -126,11 +186,19 @@ def validate_inventory(
                 "optional-classification",
                 f"module {module_id!r}: expected not optional, actual optional",
                 path=path,
+                group="optional",
                 value=module_id,
             )
     for module_id in sorted(forbidden_modules):
         if module_id in all_ids:
-            _fail("forbidden-module", f"forbidden module ID {module_id!r}", path=path, value=module_id)
+            group = "required" if module_id in required else "optional"
+            _fail(
+                "forbidden-module",
+                f"forbidden module ID {module_id!r}",
+                path=path,
+                group=group,
+                value=module_id,
+            )
 
     if len(required) != required_count:
         _fail(
@@ -155,16 +223,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--config-root", type=Path)
     parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
     parser.add_argument("--schema-version", type=int, default=1)
-    parser.add_argument("--required-count", type=int, default=18)
-    parser.add_argument("--optional-count", type=int, default=8)
-    parser.add_argument("--require-required-module", action="append", default=["git"])
-    parser.add_argument("--forbid-optional-module", action="append", default=["git"])
+    parser.add_argument("--required-count", type=int, default=REQUIRED_COUNT)
+    parser.add_argument("--optional-count", type=int, default=OPTIONAL_COUNT)
+    parser.add_argument("--require-required-module", action="append", default=[])
+    parser.add_argument("--forbid-optional-module", action="append", default=[])
     parser.add_argument("--forbid-module", action="append", default=[])
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = parse_args(argv or sys.argv[1:])
+    args = parse_args(sys.argv[1:] if argv is None else argv)
     script_root = Path(__file__).resolve().parent.parent
     config_root = args.config_root or Path(os.environ.get("AIMEE_CONFIG_ROOT", script_root))
     config_root = config_root.resolve()
@@ -176,8 +244,10 @@ def main(argv: list[str] | None = None) -> int:
             schema_version=args.schema_version,
             required_count=args.required_count,
             optional_count=args.optional_count,
-            required_modules=_csv(args.require_required_module),
-            forbidden_optional=_csv(args.forbid_optional_module),
+            required_modules=REQUIRED_CLASSIFICATIONS | _csv(args.require_required_module),
+            forbidden_optional=(
+                FORBIDDEN_OPTIONAL_CLASSIFICATIONS | _csv(args.forbid_optional_module)
+            ),
             forbidden_modules=_csv(args.forbid_module),
         )
     except InventoryError as exc:

--- a/scripts/check_module_inventory.sh
+++ b/scripts/check_module_inventory.sh
@@ -2,4 +2,8 @@
 set -eu
 
 script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+command -v python3 >/dev/null 2>&1 || {
+    echo "check_module_inventory: error: python3 is required" >&2
+    exit 1
+}
 exec python3 "$script_dir/check_module_inventory.py" "$@"

--- a/scripts/check_module_inventory.sh
+++ b/scripts/check_module_inventory.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec python3 "$script_dir/check_module_inventory.py" "$@"

--- a/scripts/check_module_inventory.sh
+++ b/scripts/check_module_inventory.sh
@@ -6,4 +6,5 @@ command -v python3 >/dev/null 2>&1 || {
     echo "check_module_inventory: error: python3 is required" >&2
     exit 1
 }
+# Isolated, site-free execution prevents PYTHONPATH/sitecustomize from changing the gate.
 exec python3 -I -S "$script_dir/check_module_inventory.py" "$@"

--- a/scripts/check_module_inventory.sh
+++ b/scripts/check_module_inventory.sh
@@ -6,4 +6,4 @@ command -v python3 >/dev/null 2>&1 || {
     echo "check_module_inventory: error: python3 is required" >&2
     exit 1
 }
-exec python3 "$script_dir/check_module_inventory.py" "$@"
+exec python3 -I -S "$script_dir/check_module_inventory.py" "$@"

--- a/scripts/tests/test_check_module_inventory.py
+++ b/scripts/tests/test_check_module_inventory.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Focused tests for the canonical module-inventory gate."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "scripts" / "check_module_inventory.sh"
+BASELINE = ROOT / "tests" / "baselines" / "modules" / "canonical-inventory.yaml"
+
+
+class ModuleInventoryTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+
+    def run_checker(self, content: str | dict[str, object], *, cwd: Path | None = None):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            inventory = root / "inventory.yaml"
+            if isinstance(content, str):
+                inventory.write_text(content, encoding="utf-8")
+            else:
+                inventory.write_text(json.dumps(content, indent=2), encoding="utf-8")
+            return subprocess.run(
+                [str(CHECKER), "--inventory", str(inventory)],
+                cwd=cwd or ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def changed(self) -> dict[str, object]:
+        return copy.deepcopy(self.baseline)
+
+    def assert_failed(self, result: subprocess.CompletedProcess[str], *needles: str) -> None:
+        self.assertNotEqual(result.returncode, 0, result.stdout)
+        for needle in needles:
+            self.assertIn(needle, result.stderr)
+
+    def test_valid_baseline_from_unrelated_cwd(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            result = subprocess.run(
+                [str(CHECKER)],
+                cwd=temporary,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("18 required, 8 optional", result.stdout)
+
+    def test_missing_inventory_fails_closed(self):
+        result = subprocess.run(
+            [str(CHECKER), "--inventory", "/definitely/missing/inventory.yaml"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assert_failed(result, "rule=input", "cannot read inventory")
+
+    def test_malformed_inventory_fails_closed(self):
+        self.assert_failed(self.run_checker("{not-json"), "rule=parse")
+
+    def test_unsafe_yaml_tag_is_not_executed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            marker = Path(temporary) / "executed"
+            payload = f"!!python/object/apply:os.system ['touch {marker}']\n"
+            self.assert_failed(self.run_checker(payload), "rule=parse", "safe JSON-compatible YAML")
+            self.assertFalse(marker.exists())
+
+    def test_required_count_drift(self):
+        data = self.changed()
+        data["required"].append("unexpected-module")
+        self.assert_failed(self.run_checker(data), "rule=required-count", "expected 18", "actual 19")
+
+    def test_optional_count_drift(self):
+        data = self.changed()
+        data["optional"].pop()
+        self.assert_failed(self.run_checker(data), "rule=optional-count", "expected 8", "actual 7")
+
+    def test_duplicate_id(self):
+        data = self.changed()
+        data["required"][-1] = data["required"][0]
+        self.assert_failed(self.run_checker(data), "rule=unique-ids", data["required"][0])
+
+    def test_required_optional_overlap(self):
+        data = self.changed()
+        data["optional"][0] = data["required"][0]
+        self.assert_failed(self.run_checker(data), "rule=disjoint-sets", data["required"][0])
+
+    def test_git_missing(self):
+        data = self.changed()
+        index = data["required"].index("git")
+        data["required"][index] = "replacement-module"
+        self.assert_failed(self.run_checker(data), "rule=required-classification", "git", "actual absent")
+
+    def test_git_reclassified_optional(self):
+        data = self.changed()
+        required_index = data["required"].index("git")
+        optional_index = 0
+        data["required"][required_index], data["optional"][optional_index] = (
+            data["optional"][optional_index],
+            "git",
+        )
+        self.assert_failed(self.run_checker(data), "rule=required-classification", "git", "actual optional")
+
+    def test_invalid_module_id(self):
+        data = self.changed()
+        data["optional"][0] = "Bad(Module)"
+        self.assert_failed(self.run_checker(data), "rule=module-id-syntax", "Bad(Module)")
+
+    def test_unknown_key(self):
+        data = self.changed()
+        data["historical"] = ["git"]
+        self.assert_failed(self.run_checker(data), "rule=structure", "unknown keys", "historical")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_module_inventory.py
+++ b/scripts/tests/test_check_module_inventory.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import importlib.util
 import json
 import os
 import subprocess
@@ -11,18 +12,30 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError:  # Local stdlib-only runs may omit this CI-only dependency.
+    yaml = None
 
 
 ROOT = Path(__file__).resolve().parents[2]
 CHECKER = ROOT / "scripts" / "check_module_inventory.sh"
 BASELINE = ROOT / "tests" / "baselines" / "modules" / "canonical-inventory.yaml"
+CHECKER_SOURCE = ROOT / "scripts" / "check_module_inventory.py"
+
+SPEC = importlib.util.spec_from_file_location("module_inventory_checker", CHECKER_SOURCE)
+CHECKER_MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER_MODULE)
 
 
 class ModuleInventoryTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
+
+    def test_checker_constants_match_committed_inventory(self):
+        self.assertEqual(CHECKER_MODULE.REQUIRED_COUNT, len(self.baseline["required"]))
+        self.assertEqual(CHECKER_MODULE.OPTIONAL_COUNT, len(self.baseline["optional"]))
 
     def run_checker(self, content: bytes | str | dict[str, object], *, cwd: Path | None = None):
         with tempfile.TemporaryDirectory() as temporary:
@@ -107,6 +120,36 @@ class ModuleInventoryTest(unittest.TestCase):
             )
         self.assert_failed(result, "rule=path", "must remain under config root")
 
+    def test_symlink_escape_outside_config_root_is_rejected(self):
+        with tempfile.TemporaryDirectory() as root_temp, tempfile.TemporaryDirectory() as outside_temp:
+            root = Path(root_temp)
+            outside = Path(outside_temp) / "inventory.yaml"
+            outside.write_text(json.dumps(self.baseline), encoding="utf-8")
+            (root / "inventory.yaml").symlink_to(outside)
+            result = subprocess.run(
+                [str(CHECKER), "--config-root", str(root), "--inventory", "inventory.yaml"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assert_failed(result, "rule=path", "must remain under config root")
+
+    def test_environment_config_root_from_unrelated_cwd(self):
+        with tempfile.TemporaryDirectory() as root_temp, tempfile.TemporaryDirectory() as cwd_temp:
+            root = Path(root_temp)
+            (root / "inventory.yaml").write_text(json.dumps(self.baseline), encoding="utf-8")
+            environment = os.environ.copy()
+            environment["AIMEE_CONFIG_ROOT"] = str(root)
+            result = subprocess.run(
+                [str(CHECKER), "--inventory", "inventory.yaml"],
+                cwd=cwd_temp,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_missing_inventory_fails_closed(self):
         with tempfile.TemporaryDirectory() as temporary:
             result = subprocess.run(
@@ -172,9 +215,10 @@ class ModuleInventoryTest(unittest.TestCase):
             self.assertFalse(marker.exists())
 
     def test_checker_has_no_yaml_loader_import(self):
-        source = (ROOT / "scripts" / "check_module_inventory.py").read_text(encoding="utf-8")
+        source = CHECKER_SOURCE.read_text(encoding="utf-8")
         self.assertNotRegex(source, r"(?m)^\s*(?:from|import)\s+(?:yaml|ruamel|pyyaml)\b")
 
+    @unittest.skipUnless(yaml is not None, "requires PyYAML")
     def test_committed_inventory_is_valid_yaml_with_json_equivalence(self):
         raw = BASELINE.read_text(encoding="utf-8")
         self.assertEqual(json.loads(raw), yaml.safe_load(raw))

--- a/scripts/tests/test_check_module_inventory.py
+++ b/scripts/tests/test_check_module_inventory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import subprocess
 import tempfile
 import unittest
@@ -21,11 +22,13 @@ class ModuleInventoryTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.baseline = json.loads(BASELINE.read_text(encoding="utf-8"))
 
-    def run_checker(self, content: str | dict[str, object], *, cwd: Path | None = None):
+    def run_checker(self, content: bytes | str | dict[str, object], *, cwd: Path | None = None):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             inventory = root / "inventory.yaml"
-            if isinstance(content, str):
+            if isinstance(content, bytes):
+                inventory.write_bytes(content)
+            elif isinstance(content, str):
                 inventory.write_text(content, encoding="utf-8")
             else:
                 inventory.write_text(json.dumps(content, indent=2), encoding="utf-8")
@@ -55,7 +58,46 @@ class ModuleInventoryTest(unittest.TestCase):
                 check=False,
             )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("18 required, 8 optional", result.stdout)
+        self.assertIn(f"{len(self.baseline['required'])} required", result.stdout)
+        self.assertIn(f"{len(self.baseline['optional'])} optional", result.stdout)
+
+    def test_config_root_precedence_and_relative_inventory(self):
+        with tempfile.TemporaryDirectory() as cli_temp, tempfile.TemporaryDirectory() as env_temp:
+            cli_root = Path(cli_temp)
+            env_root = Path(env_temp)
+            relative = Path("nested") / "inventory.yaml"
+            (cli_root / relative.parent).mkdir()
+            (env_root / relative.parent).mkdir()
+            text = json.dumps(self.baseline)
+            (cli_root / relative).write_text(text, encoding="utf-8")
+            (env_root / relative).write_text("invalid", encoding="utf-8")
+            environment = os.environ.copy()
+            environment["AIMEE_CONFIG_ROOT"] = str(env_root)
+            result = subprocess.run(
+                [str(CHECKER), "--config-root", str(cli_root), "--inventory", str(relative)],
+                cwd=env_root,
+                env=environment,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_parent_traversal_is_resolved_from_config_root(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            child = root / "child"
+            child.mkdir()
+            inventory = root / "inventory.yaml"
+            inventory.write_text(json.dumps(self.baseline), encoding="utf-8")
+            result = subprocess.run(
+                [str(CHECKER), "--config-root", str(child), "--inventory", "../inventory.yaml"],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_missing_inventory_fails_closed(self):
         result = subprocess.run(
@@ -68,6 +110,35 @@ class ModuleInventoryTest(unittest.TestCase):
 
     def test_malformed_inventory_fails_closed(self):
         self.assert_failed(self.run_checker("{not-json"), "rule=parse")
+
+    def test_invalid_utf8_fails_closed(self):
+        self.assert_failed(self.run_checker(b"{\xff}"), "rule=input", "cannot read inventory")
+
+    def test_duplicate_object_key_fails_closed(self):
+        raw = '{"schema_version": 1, "schema_version": 1, "required": [], "optional": []}'
+        self.assert_failed(self.run_checker(raw), "rule=structure", "duplicate object key")
+
+    def test_schema_version_requires_exact_integer(self):
+        for value in (True, 1.0, "1", None):
+            with self.subTest(value=value):
+                data = self.changed()
+                data["schema_version"] = value
+                self.assert_failed(self.run_checker(data), "rule=schema-version")
+
+    def test_missing_key(self):
+        data = self.changed()
+        del data["optional"]
+        self.assert_failed(self.run_checker(data), "rule=structure", "missing keys", "optional")
+
+    def test_non_array_group(self):
+        data = self.changed()
+        data["required"] = None
+        self.assert_failed(self.run_checker(data), "rule=structure", "actual NoneType")
+
+    def test_non_string_entry(self):
+        data = self.changed()
+        data["optional"][0] = 7
+        self.assert_failed(self.run_checker(data), "rule=structure", "every optional entry")
 
     def test_unsafe_yaml_tag_is_not_executed(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -88,13 +159,20 @@ class ModuleInventoryTest(unittest.TestCase):
 
     def test_duplicate_id(self):
         data = self.changed()
-        data["required"][-1] = data["required"][0]
+        data["required"].append(data["required"][0])
         self.assert_failed(self.run_checker(data), "rule=unique-ids", data["required"][0])
 
     def test_required_optional_overlap(self):
         data = self.changed()
-        data["optional"][0] = data["required"][0]
+        data["optional"].append(data["required"][0])
         self.assert_failed(self.run_checker(data), "rule=disjoint-sets", data["required"][0])
+
+    def test_id_syntax_precedes_forbidden_module_rule(self):
+        data = self.changed()
+        data["optional"][0] = "Bad(Module)"
+        result = self.run_checker(data)
+        self.assert_failed(result, "rule=module-id-syntax")
+        self.assertNotIn("rule=forbidden-module", result.stderr)
 
     def test_git_missing(self):
         data = self.changed()

--- a/scripts/tests/test_check_module_inventory.py
+++ b/scripts/tests/test_check_module_inventory.py
@@ -11,6 +11,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[2]
 CHECKER = ROOT / "scripts" / "check_module_inventory.sh"
@@ -33,7 +35,13 @@ class ModuleInventoryTest(unittest.TestCase):
             else:
                 inventory.write_text(json.dumps(content, indent=2), encoding="utf-8")
             return subprocess.run(
-                [str(CHECKER), "--inventory", str(inventory)],
+                [
+                    str(CHECKER),
+                    "--config-root",
+                    str(root),
+                    "--inventory",
+                    inventory.name,
+                ],
                 cwd=cwd or ROOT,
                 text=True,
                 capture_output=True,
@@ -83,7 +91,7 @@ class ModuleInventoryTest(unittest.TestCase):
             )
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_parent_traversal_is_resolved_from_config_root(self):
+    def test_parent_traversal_outside_config_root_is_rejected(self):
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
             child = root / "child"
@@ -97,16 +105,32 @@ class ModuleInventoryTest(unittest.TestCase):
                 capture_output=True,
                 check=False,
             )
-        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_failed(result, "rule=path", "must remain under config root")
 
     def test_missing_inventory_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            result = subprocess.run(
+                [
+                    str(CHECKER),
+                    "--config-root",
+                    temporary,
+                    "--inventory",
+                    "missing.yaml",
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assert_failed(result, "rule=input", "cannot read inventory")
+
+    def test_missing_config_root_fails_closed(self):
         result = subprocess.run(
-            [str(CHECKER), "--inventory", "/definitely/missing/inventory.yaml"],
+            [str(CHECKER), "--config-root", "/definitely/missing/config-root"],
             text=True,
             capture_output=True,
             check=False,
         )
-        self.assert_failed(result, "rule=input", "cannot read inventory")
+        self.assert_failed(result, "rule=config-root", "existing directory")
 
     def test_malformed_inventory_fails_closed(self):
         self.assert_failed(self.run_checker("{not-json"), "rule=parse")
@@ -147,15 +171,33 @@ class ModuleInventoryTest(unittest.TestCase):
             self.assert_failed(self.run_checker(payload), "rule=parse", "safe JSON-compatible YAML")
             self.assertFalse(marker.exists())
 
+    def test_checker_has_no_yaml_loader_import(self):
+        source = (ROOT / "scripts" / "check_module_inventory.py").read_text(encoding="utf-8")
+        self.assertNotRegex(source, r"(?m)^\s*(?:from|import)\s+(?:yaml|ruamel|pyyaml)\b")
+
+    def test_committed_inventory_is_valid_yaml_with_json_equivalence(self):
+        raw = BASELINE.read_text(encoding="utf-8")
+        self.assertEqual(json.loads(raw), yaml.safe_load(raw))
+
     def test_required_count_drift(self):
         data = self.changed()
         data["required"].append("unexpected-module")
-        self.assert_failed(self.run_checker(data), "rule=required-count", "expected 18", "actual 19")
+        self.assert_failed(
+            self.run_checker(data),
+            "rule=required-count",
+            "REQUIRED_COUNT=18",
+            "actual 19",
+        )
 
     def test_optional_count_drift(self):
         data = self.changed()
         data["optional"].pop()
-        self.assert_failed(self.run_checker(data), "rule=optional-count", "expected 8", "actual 7")
+        self.assert_failed(
+            self.run_checker(data),
+            "rule=optional-count",
+            "OPTIONAL_COUNT=8",
+            "actual 7",
+        )
 
     def test_duplicate_id(self):
         data = self.changed()
@@ -167,12 +209,12 @@ class ModuleInventoryTest(unittest.TestCase):
         data["optional"].append(data["required"][0])
         self.assert_failed(self.run_checker(data), "rule=disjoint-sets", data["required"][0])
 
-    def test_id_syntax_precedes_forbidden_module_rule(self):
+    def test_id_syntax_precedes_count_rule(self):
         data = self.changed()
         data["optional"][0] = "Bad(Module)"
         result = self.run_checker(data)
         self.assert_failed(result, "rule=module-id-syntax")
-        self.assertNotIn("rule=forbidden-module", result.stderr)
+        self.assertNotIn("rule=optional-count", result.stderr)
 
     def test_git_missing(self):
         data = self.changed()

--- a/tests/baselines/modules/README.md
+++ b/tests/baselines/modules/README.md
@@ -1,0 +1,9 @@
+# Canonical module inventory
+
+`canonical-inventory.yaml` is deliberately serialized as strict JSON, which is a subset of YAML
+1.2. This keeps the production validator on Python's standard-library JSON decoder and prevents
+YAML object construction. Do not add YAML-only syntax, comments, aliases, or tags.
+
+Schema version 1 contains exactly 18 required IDs and 8 optional IDs. `git` is pinned as required.
+Run `scripts/check_module_inventory.sh` to validate the artifact; focused failure-mode tests live in
+`scripts/tests/test_check_module_inventory.py`.

--- a/tests/baselines/modules/canonical-inventory.yaml
+++ b/tests/baselines/modules/canonical-inventory.yaml
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "required": [
+    "module-runtime",
+    "config",
+    "ir",
+    "translation",
+    "protocols",
+    "gateway",
+    "memory",
+    "learning",
+    "routing",
+    "delegates",
+    "tools",
+    "workspace",
+    "git",
+    "skills",
+    "response-composition",
+    "vault",
+    "execution-policy",
+    "audit"
+  ],
+  "optional": [
+    "plugin-loader",
+    "governance",
+    "workflows",
+    "roundtable",
+    "kb-synthesis",
+    "runtime-web",
+    "control-web",
+    "benchmarks"
+  ]
+}


### PR DESCRIPTION
# Core modularization slice 1: canonical inventory bootstrap

## Decision

Slice 1 implements only the pre-child taxonomy gate from acceptance id 8 of
`module-runtime-source-ownership-and-build.md`. The canonical inventory is the sole build/runtime
list of module IDs and classifications. Its checker validates structure, counts, uniqueness,
disjointness, ID syntax, and Git's required classification without reading source directories,
descriptors, profiles, or proposal state.

The existing `src/modules/git/` directory predates this effort. It is historical baseline, not
evidence that the Git migration slice has begun and not a descriptor or readiness claim. Binding
Git source to the new module contract is re-decided only after `git-core-contract.md` is accepted.

## Included

- `tests/baselines/modules/canonical-inventory.yaml`
- a CWD-independent, standard-library JSON parser and shell entrypoint; the `.yaml` file is
  intentionally restricted to JSON-compatible YAML and never loaded through a YAML object loader
- mutation-focused failure tests without a second hard-coded module list
- the `module-inventory` pull-request workflow for `feature/core-modularization`

## Deferred

- `git-core-contract.md` and `check_proposal_ordering.sh`
- module descriptors, descriptor schema, runtime loading, and generated profiles
- descriptor/profile equality and readiness checks
- Git source changes or memory ingest-boundary changes
- Make/CMake integration and source relocation

The dedicated proposal-ordering checker is the next governance prerequisite and must land before
any Git descriptor, build/profile registration, readiness, or source-migration slice. Branch
protection for the `module-inventory` job is an external repository-administration step; this
program independently refuses to merge a slice until the job is green.

Relative inventory paths resolve against `--config-root`, then `AIMEE_CONFIG_ROOT`, then the
repository root derived from the checker path. This ordering is independent of the caller's current
working directory.
