### PR TITLE
fix(wfe): suppress squash commit trailers

### DIFF
--- a/src/modules/git/git_pr_api.c
+++ b/src/modules/git/git_pr_api.c
@@ -509,7 +509,7 @@ int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number
    char path[64];
    snprintf(path, sizeof(path), "pulls/%d/merge", number);
    char *resp = NULL;
-   int st = gh_put(&cx, path, "{\"merge_method\":\"squash\"}", &resp);
+   int st = gh_put(&cx, path, GIT_PR_SQUASH_MERGE_JSON, &resp);
    gh_ctx_done(&cx);
    int res;
    if (st >= 200 && st < 300)

--- a/src/modules/git/git_pr_api.h
+++ b/src/modules/git/git_pr_api.h
@@ -3,6 +3,12 @@
 
 #include <stddef.h>
 
+/* GitHub otherwise synthesizes a squash commit body from the child commits.
+ * That can re-introduce attribution trailers which Aimee already strips from
+ * its own commit/PR text and which protected branches reject. Keep the body
+ * explicitly empty; the PR title remains GitHub's default squash subject. */
+#define GIT_PR_SQUASH_MERGE_JSON "{\"merge_method\":\"squash\",\"commit_message\":\"\"}"
+
 /* git_pr_api — open a GitHub pull request via the REST API, IN-PROCESS, so the
  * forge token rides the Authorization header (aimee-server memory only) and
  * never reaches a child process's environment or argv. This replaces the
@@ -81,8 +87,9 @@ git_pr_ci_t git_pr_ci_grade_json(const char *check_runs_json, const char *combin
  * advance) — only the go/no-go lives here. Pure; unit-tested. */
 int git_pr_ci_permits_merge(git_pr_ci_t ci);
 
-/* Squash-merge PUT /pulls/<n>/merge. Returns 0 merged, 1 already merged,
- * 2 not mergeable (405/409), -1 error. */
+/* Squash-merge PUT /pulls/<n>/merge with an explicitly empty synthesized
+ * commit body. Returns 0 merged, 1 already merged, 2 not mergeable (405/409),
+ * -1 error. */
 int git_pr_merge_via_api(const char *principal, const char *repo_dir, int number, char *err,
                          size_t errlen);
 

--- a/src/tests/test_git_pr_ci_grade.c
+++ b/src/tests/test_git_pr_ci_grade.c
@@ -4,6 +4,7 @@
  * status only when no check runs exist, and NONE when neither reports. */
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "git_pr_api.h"
 
@@ -13,6 +14,12 @@
 int main(void)
 {
    printf("git-pr-ci-grade: ");
+
+   /* Squash merges must suppress GitHub's synthesized commit body. Otherwise
+    * child commit trailers can be copied into the feature commit and fail the
+    * protected no-coauthor-trailers check on the final PR. */
+   assert(strstr(GIT_PR_SQUASH_MERGE_JSON, "\"merge_method\":\"squash\"") != NULL);
+   assert(strstr(GIT_PR_SQUASH_MERGE_JSON, "\"commit_message\":\"\"") != NULL);
 
    /* all completed successfully (neutral/skipped count as green) */
    assert(git_pr_ci_grade_json(RUNS(RUN("completed", "\"success\"") "," RUN(


### PR DESCRIPTION
## Summary

- explicitly set an empty squash commit body in the GitHub merge API request
- prevent child commit attribution trailers from reaching final workflow PRs
- add a regression assertion for the merge payload

## Validation

- src/build/obj/tests/unit-test-git-pr-ci-grade
- production git_pr_api.o compile with -Werror
- clang-format-19 dry run
- git diff --check

Found by unattended WFE proof run wi_e585aa22db0543db15b605e2608e1dbf: final PR #1682 correctly reached final_pr, but its feature squash commit inherited a Co-authored-by trailer and failed the required protected check.