### PR TITLE
ci: enforce chronological Git proposal ordering

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -3,6 +3,8 @@ name: Module inventory
 on:
   pull_request:
     branches: [feature/core-modularization]
+  pull_request_target:
+    branches: [feature/core-modularization]
   push:
     branches: [feature/core-modularization]
   workflow_dispatch:
@@ -17,6 +19,7 @@ permissions:
 jobs:
   module-inventory:
     name: module-inventory
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -58,6 +61,7 @@ jobs:
 
   git-core-contract:
     name: git-core-contract
+    if: github.event_name != 'pull_request_target'
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -77,8 +81,9 @@ jobs:
       - name: Test Git contract failure modes
         run: python3 -I scripts/tests/test_check_git_core_contract.py -v
 
-  proposal-ordering:
-    name: proposal-ordering
+  proposal-ordering-bootstrap:
+    name: proposal-ordering-bootstrap
+    if: github.event_name != 'pull_request_target'
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -114,3 +119,40 @@ jobs:
           printf '%s\n' "$output" | grep -q 'rule=config-root'
       - name: Test proposal-ordering failure modes
         run: python3 -I scripts/tests/test_check_proposal_ordering.py -v
+
+  proposal-ordering-protected:
+    name: proposal-ordering
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out the protected gate
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted
+      - name: Check out the synthetic merge under review
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: refs/pull/${{ github.event.number }}/merge
+          path: candidate
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Enforce ordering with protected code
+        env:
+          GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          candidate_sha=$(git -C candidate rev-parse HEAD)
+          GITHUB_EVENT_NAME=pull_request \
+          GITHUB_REF=refs/pull/${{ github.event.number }}/merge \
+          GITHUB_SHA="$candidate_sha" \
+            python3 -I -S trusted/scripts/check_proposal_ordering.py \
+              --config-root "$GITHUB_WORKSPACE/candidate"

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -76,3 +76,24 @@ jobs:
         run: cd /tmp && python3 -I -S "$GITHUB_WORKSPACE/scripts/check_git_core_contract.py" --require-status roundtable-approved
       - name: Test Git contract failure modes
         run: python3 -I scripts/tests/test_check_git_core_contract.py -v
+
+  proposal-ordering:
+    name: proposal-ordering
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Enforce Git proposal ordering
+        run: python3 -I -S scripts/check_proposal_ordering.py
+      - name: Enforce from a non-repository working directory
+        run: cd /tmp && python3 -I -S "$GITHUB_WORKSPACE/scripts/check_proposal_ordering.py"
+      - name: Test proposal-ordering failure modes
+        run: python3 -I scripts/tests/test_check_proposal_ordering.py -v

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -93,6 +93,12 @@ jobs:
           python-version: "3.12"
       - name: Enforce Git proposal ordering
         run: python3 -I -S scripts/check_proposal_ordering.py
+      - name: Prove event revision binding
+        env:
+          GITHUB_EVENT_NAME: push
+          GITHUB_REF: refs/heads/feature/core-modularization
+          GITHUB_SHA: ${{ github.sha }}
+        run: python3 -I -S scripts/check_proposal_ordering.py
       - name: Enforce from a non-repository working directory
         run: cd /tmp && python3 -I -S "$GITHUB_WORKSPACE/scripts/check_proposal_ordering.py"
       - name: Test proposal-ordering failure modes

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ github.sha }}
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
@@ -99,7 +100,17 @@ jobs:
           GITHUB_REF: refs/heads/feature/core-modularization
           GITHUB_SHA: ${{ github.sha }}
         run: python3 -I -S scripts/check_proposal_ordering.py
-      - name: Enforce from a non-repository working directory
+      - name: Validate CWD independence
         run: cd /tmp && python3 -I -S "$GITHUB_WORKSPACE/scripts/check_proposal_ordering.py"
+      - name: Reject a non-repository config root
+        run: |
+          root=$(mktemp -d)
+          if output=$(python3 -I -S scripts/check_proposal_ordering.py \
+              --config-root "$root" 2>&1); then
+            echo "::error::non-repository config root unexpectedly passed: $output"
+            exit 1
+          fi
+          echo "$output"
+          printf '%s\n' "$output" | grep -q 'rule=config-root'
       - name: Test proposal-ordering failure modes
         run: python3 -I scripts/tests/test_check_proposal_ordering.py -v

--- a/docs/validation/core-modularization-slice-3.md
+++ b/docs/validation/core-modularization-slice-3.md
@@ -11,20 +11,28 @@ approval-evidence presence, and contract checker from that commit. It executes t
 from a private temporary directory, validates the live contract and handoff, and requires the live
 historical cutoff, invariants, trigger surface, exact paths, and paired claim roots to equal the
 pinned values. Missing, pending, invalid, symlinked, or drifted metadata fails closed. The file
-under review therefore cannot redefine the checker or the changes that trigger it.
+under review therefore cannot redefine the contract checker or the changes that trigger it.
+
+The first merge bootstraps the ordering gate. For subsequent pull requests, the authoritative
+`pull_request_target` job checks out the gate from the protected feature-branch base commit and the
+synthetic merge into a separate candidate directory. Only the protected gate is executed; candidate
+code is treated as data through `--config-root`. The ordinary pull-request job remains as a
+bootstrap and diagnostic check, but it is not the durable trust boundary.
 
 ## Historical ordering
 
 The checker walks the complete commit DAG reachable from `HEAD` but not from the Slice 1 cutoff,
 oldest first in topological order. It compares every commit with that commit's first parent. This
 preserves signal-and-revert pairs on side branches and proposed pull-request branches. A signal is
-valid only when the Slice 2 anchor occurs on the signal's first-parent ancestry before the signal's
-parent; merely merging the anchor as a later, non-first parent does not satisfy ordering.
+valid only when the Slice 2 anchor occurs on the signal's first-parent ancestry strictly before the
+signal's parent. A signal directly after the anchor is intentionally rejected, preserving a commit
+boundary between approval and migration. Merely merging the anchor as a later, non-first parent
+does not satisfy ordering.
 
 On a GitHub pull request, the synthetic merge commit's first parent is the target feature branch and
-its second parent is the proposed branch. The full-DAG walk evaluates both histories as well as the
-synthetic merge. The gate validates this merge-ref shape; squash and rebase results are subsequently
-checked as ordinary commits when pushed to the feature branch.
+its second parent is the proposed branch. The full-DAG walk evaluates both histories and the
+synthetic merge itself. Squash and rebase results are checked as ordinary commits when they later
+appear on the feature branch.
 
 Historical presence of `src/modules/git/` at the cutoff is the declared baseline, not a signal. Any
 later add, modification, deletion, type change, rename, or copy whose source or destination lies
@@ -51,17 +59,18 @@ Currently it contains `git-runtime-ready`. Under a declared root, added whole li
 
 Only `.yaml`, `.yml`, and `.json` files can emit status-claim signals. The checker obtains filenames
 from NUL-delimited Git records and compares UTF-8 blobs directly, so quoted filenames and
-repository-controlled diff attributes cannot hide a claim. A rename or copy into a declared root is
-compared from an empty root-local baseline; a rename out is a removal and does not newly assert
-readiness. Modified lines are considered through their added side. Deleted claims do not newly
-assert readiness. A non-UTF-8 structured blob cannot claim readiness, although a binary file at an
-exact path or under `src/modules/git/` remains a path signal. Markdown and other prose, substrings,
-case variants, false values, commented markers, and lines outside declared roots are inert.
+repository-controlled diff attributes cannot hide a claim. A rename from outside a declared root
+and every copy use an empty root-local baseline; a rename within a root compares the source blob; a
+rename out is a removal and does not newly assert readiness. Modified lines, including a same-line
+false-to-true toggle, are considered through their added side. Deleted claims do not newly assert
+readiness. A non-UTF-8 structured blob cannot claim readiness, although a binary file at an exact
+path or under `src/modules/git/` remains a path signal. Markdown and other prose, substrings, case
+variants, false values, commented markers, and lines outside declared roots are inert.
 
 The formats remain distinct. YAML accepts only the unquoted key and literal lowercase `true`, with
 an optional `#` comment. JSON accepts only the quoted key and literal lowercase `true`, with an
 optional comma. YAML 1.1 alternatives such as `yes`, `True`, and `!!bool true`, block scalars, `%`
-comments, and cross-format forms are inert.
+comments, content inside literal or folded block scalars, and cross-format forms are inert.
 
 ## Event binding
 
@@ -71,7 +80,9 @@ contexts are `push` on the feature branch, `pull_request` on a merge ref whose
 `GITHUB_BASE_REF` is the feature branch and whose `GITHUB_HEAD_REF` is non-empty, and
 `workflow_dispatch` on the feature branch. A partial GitHub environment and every other event/ref
 pair fail closed. A separate negative workflow assertion proves that a non-repository
-`--config-root` is rejected.
+`--config-root` is rejected. The checker also refuses dirty live contract or handoff files and
+requires both inputs to be regular, non-symlinked files, ensuring that pinned validation and local
+metadata comparison observe the same committed bytes.
 
 ## Included
 

--- a/docs/validation/core-modularization-slice-3.md
+++ b/docs/validation/core-modularization-slice-3.md
@@ -1,0 +1,71 @@
+# Core modularization slice 3: chronological Git proposal ordering
+
+## Decision
+
+This slice makes the Git contract's chronological-ordering prerequisite executable. It adds no Git
+implementation, descriptor, build/profile registration, readiness claim, or source move.
+
+The immutable discovery anchor is Slice 2 merge commit
+`a3c4d413b6ce5f674994a6e6c4589ae2383819a4`. The checker reads the canonical contract blob from
+that commit, validates the live child through `check_git_core_contract.py`, and requires its
+historical cutoff, invariants, and trigger surface to remain equal. A missing, pending, invalid, or
+drifted live contract fails unconditionally. This avoids trusting the file under review to define
+which changes should trigger its own validation.
+
+## Historical ordering
+
+The checker examines every commit reachable between the Slice 1 cutoff and the checked-out event
+revision in topological order. Each commit is compared with its first parent. This includes PR-side
+commits as well as their synthetic merge commit, so a signal remains visible when a later commit
+reverts it.
+
+Historical presence of `src/modules/git/` at the cutoff is not a signal. Any later add, modification,
+deletion, type change, rename, or copy whose source or destination lies under that tree is a
+migration signal. Exact descriptor, generated Make/CMake, generated profile, and readiness paths
+from the pinned contract are signals too. Git output is NUL-delimited with explicit rename and copy
+detection. Even low-similarity moves surface as add+delete pairs and trigger. This source-tree sweep
+remains the conservative migration boundary until the deferred descriptor and generated-profile
+checks activate.
+
+Every signal commit must have the Slice 2 merge commit
+`a3c4d413b6ce5f674994a6e6c4589ae2383819a4` as an ancestor of its first parent. This requires
+strict precedence: contract-before-signal passes; signal-before-contract and
+same-commit contract-plus-signal fail. A later revert does not erase the ordering violation.
+
+## Status claims
+
+The marker vocabulary comes only from the pinned contract's `status_claim_roots[*].claim` values.
+Currently it contains `git-runtime-ready`. Under a declared root, added whole lines match only:
+
+- YAML: indentation, exact case-sensitive claim, optional horizontal space, `:`, optional space,
+  `true`, and an optional trailing comment, for example `git-runtime-ready: true # ready`.
+- JSON: indentation, the quoted exact claim, optional horizontal space, `:`, optional space,
+  `true`, and an optional comma, for example `"git-runtime-ready": true,`.
+
+Modified lines are considered through their added side. Deleted claims do not newly assert
+readiness. Binary line diffs do not claim readiness, although a binary file at an exact path or
+under `src/modules/git/` remains a path signal. Prose, substrings, case variants, false values,
+commented markers, and lines outside declared roots are inert.
+
+## Event binding
+
+CI checks out full history with SHA-pinned actions, `persist-credentials: false`, and read-only
+contents permission. The checked-out `HEAD` must equal `GITHUB_SHA`. The only allowed contexts are
+`push` on the feature branch, `pull_request` on its merge ref, and `workflow_dispatch` on the
+feature branch; every other event/ref pair fails closed.
+
+## Included
+
+- `scripts/check_proposal_ordering.py`, with no parallel shell implementation
+- immutable Slice 2 discovery and live-child equality
+- `scripts/tests/test_check_proposal_ordering.py`
+- the `proposal-ordering` feature-branch CI job
+
+## Deferred
+
+- descriptor and generated-profile set equality
+- descriptor schema and Make/CMake generation
+- Git source migration and runtime acceptance fixtures
+- module registration and readiness
+
+Those checks activate in their owning slices.

--- a/docs/validation/core-modularization-slice-3.md
+++ b/docs/validation/core-modularization-slice-3.md
@@ -14,18 +14,19 @@ which changes should trigger its own validation.
 
 ## Historical ordering
 
-The checker examines every commit reachable between the Slice 1 cutoff and the checked-out event
-revision in topological order. Each commit is compared with its first parent. This includes PR-side
-commits as well as their synthetic merge commit, so a signal remains visible when a later commit
-reverts it.
+The checker walks the checked-out revision's first-parent chain between the Slice 1 cutoff and
+`HEAD`, oldest first. Each commit is compared with its first parent. On a pull request, GitHub's
+synthetic merge commit therefore exposes the proposed branch as a net delta from the feature-branch
+parent. On the feature branch, a signal and its later revert remain separate first-parent commits,
+so the revert does not erase the earlier signal.
 
-Historical presence of `src/modules/git/` at the cutoff is not a signal. Any later add, modification,
-deletion, type change, rename, or copy whose source or destination lies under that tree is a
-migration signal. Exact descriptor, generated Make/CMake, generated profile, and readiness paths
-from the pinned contract are signals too. Git output is NUL-delimited with explicit rename and copy
-detection. Even low-similarity moves surface as add+delete pairs and trigger. This source-tree sweep
-remains the conservative migration boundary until the deferred descriptor and generated-profile
-checks activate.
+Historical presence of `src/modules/git/` at the cutoff is not a signal. Any later add,
+modification, deletion, type change, rename, or copy whose source or destination lies under that
+tree is a migration signal. Exact descriptor, generated Make/CMake, generated profile, and
+readiness paths from the pinned contract are signals too. Git output is NUL-delimited with explicit
+rename and copy detection. Even low-similarity moves surface as add+delete pairs and trigger. This
+source-tree sweep remains the conservative migration boundary until the deferred descriptor and
+generated-profile checks activate.
 
 Every signal commit must have the Slice 2 merge commit
 `a3c4d413b6ce5f674994a6e6c4589ae2383819a4` as an ancestor of its first parent. This requires
@@ -42,10 +43,11 @@ Currently it contains `git-runtime-ready`. Under a declared root, added whole li
 - JSON: indentation, the quoted exact claim, optional horizontal space, `:`, optional space,
   `true`, and an optional comma, for example `"git-runtime-ready": true,`.
 
-Modified lines are considered through their added side. Deleted claims do not newly assert
-readiness. Binary line diffs do not claim readiness, although a binary file at an exact path or
-under `src/modules/git/` remains a path signal. Prose, substrings, case variants, false values,
-commented markers, and lines outside declared roots are inert.
+Only `.yaml`, `.yml`, and `.json` files can emit status-claim signals. Modified lines are considered
+through their added side. Deleted claims do not newly assert readiness. Binary line diffs do not
+claim readiness, although a binary file at an exact path or under `src/modules/git/` remains a path
+signal. Markdown and other prose, substrings, case variants, false values, commented markers, and
+lines outside declared roots are inert.
 
 ## Event binding
 

--- a/docs/validation/core-modularization-slice-3.md
+++ b/docs/validation/core-modularization-slice-3.md
@@ -6,27 +6,33 @@ This slice makes the Git contract's chronological-ordering prerequisite executab
 implementation, descriptor, build/profile registration, readiness claim, or source move.
 
 The immutable discovery anchor is Slice 2 merge commit
-`a3c4d413b6ce5f674994a6e6c4589ae2383819a4`. The checker reads the canonical contract blob from
-that commit, validates the live child through `check_git_core_contract.py`, and requires its
-historical cutoff, invariants, and trigger surface to remain equal. A missing, pending, invalid, or
-drifted live contract fails unconditionally. This avoids trusting the file under review to define
-which changes should trigger its own validation.
+`a3c4d413b6ce5f674994a6e6c4589ae2383819a4`. The checker reads the canonical contract, handoff,
+approval-evidence presence, and contract checker from that commit. It executes the pinned checker
+from a private temporary directory, validates the live contract and handoff, and requires the live
+historical cutoff, invariants, trigger surface, exact paths, and paired claim roots to equal the
+pinned values. Missing, pending, invalid, symlinked, or drifted metadata fails closed. The file
+under review therefore cannot redefine the checker or the changes that trigger it.
 
 ## Historical ordering
 
-The checker walks the checked-out revision's first-parent chain between the Slice 1 cutoff and
-`HEAD`, oldest first. Each commit is compared with its first parent. On a pull request, GitHub's
-synthetic merge commit therefore exposes the proposed branch as a net delta from the feature-branch
-parent. On the feature branch, a signal and its later revert remain separate first-parent commits,
-so the revert does not erase the earlier signal.
+The checker walks the complete commit DAG reachable from `HEAD` but not from the Slice 1 cutoff,
+oldest first in topological order. It compares every commit with that commit's first parent. This
+preserves signal-and-revert pairs on side branches and proposed pull-request branches. A signal is
+valid only when the Slice 2 anchor occurs on the signal's first-parent ancestry before the signal's
+parent; merely merging the anchor as a later, non-first parent does not satisfy ordering.
 
-Historical presence of `src/modules/git/` at the cutoff is not a signal. Any later add,
-modification, deletion, type change, rename, or copy whose source or destination lies under that
-tree is a migration signal. Exact descriptor, generated Make/CMake, generated profile, and
-readiness paths from the pinned contract are signals too. Git output is NUL-delimited with explicit
-rename and copy detection. Even low-similarity moves surface as add+delete pairs and trigger. This
-source-tree sweep remains the conservative migration boundary until the deferred descriptor and
-generated-profile checks activate.
+On a GitHub pull request, the synthetic merge commit's first parent is the target feature branch and
+its second parent is the proposed branch. The full-DAG walk evaluates both histories as well as the
+synthetic merge. The gate validates this merge-ref shape; squash and rebase results are subsequently
+checked as ordinary commits when pushed to the feature branch.
+
+Historical presence of `src/modules/git/` at the cutoff is the declared baseline, not a signal. Any
+later add, modification, deletion, type change, rename, or copy whose source or destination lies
+under that tree is a migration signal. Exact descriptor, generated Make/CMake, generated profile,
+and readiness paths from the pinned contract are signals too. Git output is NUL-delimited with
+explicit rename and copy detection. Even low-similarity moves surface as add+delete pairs and
+trigger. This source-tree sweep remains the conservative migration boundary until the deferred
+descriptor and generated-profile checks activate.
 
 Every signal commit must have the Slice 2 merge commit
 `a3c4d413b6ce5f674994a6e6c4589ae2383819a4` as an ancestor of its first parent. This requires
@@ -43,18 +49,29 @@ Currently it contains `git-runtime-ready`. Under a declared root, added whole li
 - JSON: indentation, the quoted exact claim, optional horizontal space, `:`, optional space,
   `true`, and an optional comma, for example `"git-runtime-ready": true,`.
 
-Only `.yaml`, `.yml`, and `.json` files can emit status-claim signals. Modified lines are considered
-through their added side. Deleted claims do not newly assert readiness. Binary line diffs do not
-claim readiness, although a binary file at an exact path or under `src/modules/git/` remains a path
-signal. Markdown and other prose, substrings, case variants, false values, commented markers, and
-lines outside declared roots are inert.
+Only `.yaml`, `.yml`, and `.json` files can emit status-claim signals. The checker obtains filenames
+from NUL-delimited Git records and compares UTF-8 blobs directly, so quoted filenames and
+repository-controlled diff attributes cannot hide a claim. A rename or copy into a declared root is
+compared from an empty root-local baseline; a rename out is a removal and does not newly assert
+readiness. Modified lines are considered through their added side. Deleted claims do not newly
+assert readiness. A non-UTF-8 structured blob cannot claim readiness, although a binary file at an
+exact path or under `src/modules/git/` remains a path signal. Markdown and other prose, substrings,
+case variants, false values, commented markers, and lines outside declared roots are inert.
+
+The formats remain distinct. YAML accepts only the unquoted key and literal lowercase `true`, with
+an optional `#` comment. JSON accepts only the quoted key and literal lowercase `true`, with an
+optional comma. YAML 1.1 alternatives such as `yes`, `True`, and `!!bool true`, block scalars, `%`
+comments, and cross-format forms are inert.
 
 ## Event binding
 
-CI checks out full history with SHA-pinned actions, `persist-credentials: false`, and read-only
-contents permission. The checked-out `HEAD` must equal `GITHUB_SHA`. The only allowed contexts are
-`push` on the feature branch, `pull_request` on its merge ref, and `workflow_dispatch` on the
-feature branch; every other event/ref pair fails closed.
+CI checks out `github.sha` with full history, SHA-pinned actions, `persist-credentials: false`, and
+read-only contents permission. The checked-out `HEAD` must equal `GITHUB_SHA`. The only allowed
+contexts are `push` on the feature branch, `pull_request` on a merge ref whose
+`GITHUB_BASE_REF` is the feature branch and whose `GITHUB_HEAD_REF` is non-empty, and
+`workflow_dispatch` on the feature branch. A partial GitHub environment and every other event/ref
+pair fail closed. A separate negative workflow assertion proves that a non-repository
+`--config-root` is rejected.
 
 ## Included
 

--- a/scripts/check_git_core_contract.py
+++ b/scripts/check_git_core_contract.py
@@ -167,7 +167,12 @@ def extract_contract(path: Path) -> dict[str, object]:
 
 
 def extract_json_fence(path: Path, name: str) -> dict[str, object]:
-    raw = _read_text(path)
+    return extract_json_fence_text(_read_text(path), name, path=path)
+
+
+def extract_json_fence_text(
+    raw: str, name: str, *, path: Path | str
+) -> dict[str, object]:
     opening = re.compile(rf"^```json {re.escape(name)}[ \t]*$", re.MULTILINE)
     matches = list(opening.finditer(raw))
     if len(matches) != 1:
@@ -185,6 +190,28 @@ def extract_json_fence(path: Path, name: str) -> dict[str, object]:
     if not isinstance(value, dict):
         fail("schema", f"{name} must be a JSON object", path=path)
     return value
+
+
+def load_validated_contract(
+    config_root: Path,
+    *,
+    require_status: str,
+    contract_path: Path = DEFAULT_CONTRACT,
+    check_git: bool = True,
+) -> dict[str, object]:
+    """Load the contract and handoff through the same path used by the CLI."""
+    resolved_contract = resolve_under_root(config_root, contract_path, label="contract")
+    contract = extract_contract(resolved_contract)
+    handoff_path = resolve_under_root(config_root, DEFAULT_HANDOFF, label="handoff")
+    validate_handoff(extract_json_fence(handoff_path, "slice3-handoff"), handoff_path)
+    validate_contract(
+        contract,
+        path=resolved_contract,
+        config_root=config_root,
+        require_status=require_status,
+        check_git=check_git,
+    )
+    return contract
 
 
 def validate_handoff(value: dict[str, object], path: Path) -> None:
@@ -839,21 +866,18 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
     try:
-        contract_path = resolve_under_root(config_root, args.contract, label="contract")
-        contract = extract_contract(contract_path)
-        handoff_path = resolve_under_root(config_root, DEFAULT_HANDOFF, label="handoff")
-        validate_handoff(extract_json_fence(handoff_path, "slice3-handoff"), handoff_path)
-        validate_contract(
-            contract,
-            path=contract_path,
-            config_root=config_root,
+        contract = load_validated_contract(
+            config_root,
             require_status=args.require_status,
+            contract_path=args.contract,
             check_git=True,
         )
     except ContractError as exc:
         print(f"check_git_core_contract: error: {exc}", file=sys.stderr)
         return 1
-    print(f"check_git_core_contract: ok ({args.require_status}; {contract_path})")
+    del contract
+    resolved_contract = resolve_under_root(config_root, args.contract, label="contract")
+    print(f"check_git_core_contract: ok ({args.require_status}; {resolved_contract})")
     return 0
 
 

--- a/scripts/check_git_core_contract.py
+++ b/scripts/check_git_core_contract.py
@@ -167,12 +167,7 @@ def extract_contract(path: Path) -> dict[str, object]:
 
 
 def extract_json_fence(path: Path, name: str) -> dict[str, object]:
-    return extract_json_fence_text(_read_text(path), name, path=path)
-
-
-def extract_json_fence_text(
-    raw: str, name: str, *, path: Path | str
-) -> dict[str, object]:
+    raw = _read_text(path)
     opening = re.compile(rf"^```json {re.escape(name)}[ \t]*$", re.MULTILINE)
     matches = list(opening.finditer(raw))
     if len(matches) != 1:
@@ -190,28 +185,6 @@ def extract_json_fence_text(
     if not isinstance(value, dict):
         fail("schema", f"{name} must be a JSON object", path=path)
     return value
-
-
-def load_validated_contract(
-    config_root: Path,
-    *,
-    require_status: str,
-    contract_path: Path = DEFAULT_CONTRACT,
-    check_git: bool = True,
-) -> dict[str, object]:
-    """Load the contract and handoff through the same path used by the CLI."""
-    resolved_contract = resolve_under_root(config_root, contract_path, label="contract")
-    contract = extract_contract(resolved_contract)
-    handoff_path = resolve_under_root(config_root, DEFAULT_HANDOFF, label="handoff")
-    validate_handoff(extract_json_fence(handoff_path, "slice3-handoff"), handoff_path)
-    validate_contract(
-        contract,
-        path=resolved_contract,
-        config_root=config_root,
-        require_status=require_status,
-        check_git=check_git,
-    )
-    return contract
 
 
 def validate_handoff(value: dict[str, object], path: Path) -> None:
@@ -866,18 +839,21 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
     try:
-        contract = load_validated_contract(
-            config_root,
+        contract_path = resolve_under_root(config_root, args.contract, label="contract")
+        contract = extract_contract(contract_path)
+        handoff_path = resolve_under_root(config_root, DEFAULT_HANDOFF, label="handoff")
+        validate_handoff(extract_json_fence(handoff_path, "slice3-handoff"), handoff_path)
+        validate_contract(
+            contract,
+            path=contract_path,
+            config_root=config_root,
             require_status=args.require_status,
-            contract_path=args.contract,
             check_git=True,
         )
     except ContractError as exc:
         print(f"check_git_core_contract: error: {exc}", file=sys.stderr)
         return 1
-    del contract
-    resolved_contract = resolve_under_root(config_root, args.contract, label="contract")
-    print(f"check_git_core_contract: ok ({args.require_status}; {resolved_contract})")
+    print(f"check_git_core_contract: ok ({args.require_status}; {contract_path})")
     return 0
 
 

--- a/scripts/check_proposal_ordering.py
+++ b/scripts/check_proposal_ordering.py
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -145,6 +146,8 @@ def read_live_text(repo: Path, relative: str) -> str:
     if candidate.is_symlink():
         fail("input-symlink", f"{relative} must not be a symlink")
     try:
+        if not stat.S_ISREG(candidate.stat(follow_symlinks=False).st_mode):
+            fail("input-not-regular", f"{relative} must be a regular file")
         return resolved.read_text(encoding="utf-8")
     except (OSError, UnicodeError) as exc:
         fail("input", f"cannot read {relative}: {exc}")
@@ -280,7 +283,11 @@ def validate_discovery(
 
 
 def source_or_exact_signal(path: str, exact_paths: set[str]) -> bool:
-    return path.startswith("src/modules/git/") or path in exact_paths
+    return (
+        path == "src/modules/git"
+        or path.startswith("src/modules/git/")
+        or path in exact_paths
+    )
 
 
 def parse_name_status(raw: bytes) -> list[tuple[str, tuple[str, ...]]]:
@@ -329,16 +336,42 @@ def blob(repo: Path, revision: str, path: str) -> bytes | None:
     return result.stdout
 
 
-def added_claim_signal(before: bytes, after: bytes, claim: str, suffix: str) -> bool:
+def yaml_scalar_lines(lines: list[str]) -> set[int]:
+    """Return line indexes that are content of a YAML block scalar."""
+    scalar_lines: set[int] = set()
+    scalar_indent: int | None = None
+    opening = re.compile(r"^[ \t]*[^#][^:]*:[ \t]*[|>][+-]?[1-9]?[ \t]*(?:#.*)?$")
+    for index, line in enumerate(lines):
+        expanded = line.expandtabs(8)
+        indent = len(expanded) - len(expanded.lstrip(" "))
+        if scalar_indent is not None:
+            if not line.strip() or indent > scalar_indent:
+                scalar_lines.add(index)
+                continue
+            scalar_indent = None
+        if opening.fullmatch(line):
+            scalar_indent = indent
+    return scalar_lines
+
+
+def claim_signal_in_diff(before: bytes, after: bytes, claim: str, suffix: str) -> bool:
+    """Detect new or changed-to-true claims in a structured UTF-8 blob."""
     try:
         old_lines = before.decode("utf-8").splitlines()
         new_lines = after.decode("utf-8").splitlines()
     except UnicodeDecodeError:
         return False
     patterns = claim_patterns(claim, suffix)
-    for line in difflib.ndiff(old_lines, new_lines):
-        if line.startswith("+ ") and any(pattern.fullmatch(line[2:]) for pattern in patterns):
-            return True
+    scalar_lines = yaml_scalar_lines(new_lines) if suffix in {".yaml", ".yml"} else set()
+    matcher = difflib.SequenceMatcher(a=old_lines, b=new_lines, autojunk=False)
+    for tag, _old_start, _old_end, new_start, new_end in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        for index in range(new_start, new_end):
+            if index not in scalar_lines and any(
+                pattern.fullmatch(new_lines[index]) for pattern in patterns
+            ):
+                return True
     return False
 
 
@@ -382,8 +415,10 @@ def commit_signals(
                 continue
             source = paths[0]
             source_in_root = under_root(source, root)
-            before = blob(repo, parent, source) if source_in_root else None
-            if added_claim_signal(before or b"", after, claim, suffix):
+            before = None
+            if not status.startswith("C") and source_in_root:
+                before = blob(repo, parent, source)
+            if claim_signal_in_diff(before or b"", after, claim, suffix):
                 signals.append(("status-claim", f"{root}:{claim}:{destination}"))
     return signals
 
@@ -442,7 +477,7 @@ def enforce_signal_precedence(
     repo: Path, anchor: str, signals: list[tuple[str, str, list[tuple[str, str]]]]
 ) -> None:
     for commit, parent, evidence in signals:
-        if not on_first_parent_chain(repo, anchor, parent):
+        if parent == anchor or not on_first_parent_chain(repo, anchor, parent):
             rendered = ", ".join(f"{kind}:{value}" for kind, value in evidence)
             fail(
                 "git-contract-ordering",
@@ -483,6 +518,18 @@ def validate_event(head: str) -> None:
     fail("event-ref", f"unsupported GitHub event/ref pair {event!r}/{ref!r}")
 
 
+def require_clean_metadata(repo: Path) -> None:
+    for args in (
+        ("diff", "--quiet", "--", CONTRACT_PATH, HANDOFF_PATH),
+        ("diff", "--cached", "--quiet", "--", CONTRACT_PATH, HANDOFF_PATH),
+    ):
+        result = git_run(repo, *args)
+        if result.returncode == 1:
+            fail("live-contract-dirty", "contract or handoff has uncommitted changes")
+        if result.returncode != 0:
+            fail("git-command", f"git {' '.join(args)} failed ({result.returncode})")
+
+
 def validate_ordering(repo: Path) -> int:
     require_repository(repo)
     head = git_text(repo, "rev-parse", "HEAD")
@@ -491,6 +538,7 @@ def validate_ordering(repo: Path) -> int:
     if not is_ancestor(repo, SLICE2_ANCHOR, head):
         fail("slice2-anchor", "approved Slice 2 anchor is not an ancestor of HEAD")
 
+    require_clean_metadata(repo)
     validate_trusted_contract(repo)
     pinned, pinned_handoff = canonical_metadata(repo)
     live, live_handoff = live_metadata(repo)

--- a/scripts/check_proposal_ordering.py
+++ b/scripts/check_proposal_ordering.py
@@ -4,23 +4,43 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
+import difflib
+import json
 import os
 from pathlib import Path
 import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from typing import NoReturn
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-CONTRACT_CHECKER = REPO_ROOT / "scripts/check_git_core_contract.py"
 SLICE2_ANCHOR = "a3c4d413b6ce5f674994a6e6c4589ae2383819a4"
 CONTRACT_PATH = "docs/proposals/pending/git-core-contract.md"
 EVIDENCE_PATH = "docs/validation/roundtable/git-core-contract.json"
 HANDOFF_PATH = "docs/validation/core-modularization-slice-2.md"
+CHECKER_PATH = "scripts/check_git_core_contract.py"
+FEATURE_BRANCH = "feature/core-modularization"
 GIT = shutil.which("git", path="/usr/bin:/bin") or "/usr/bin/git"
+PYTHON = shutil.which("python3", path="/usr/bin:/bin") or "/usr/bin/python3"
+TRIGGER_GROUPS = (
+    "descriptors",
+    "generated_builds",
+    "generated_profiles",
+    "readiness_markers",
+    "status_claim_roots",
+)
+HANDOFF = {
+    "schema_version": 1,
+    "receiver": "slice-3-proposal-ordering-gate",
+    "contract_file": CONTRACT_PATH,
+    "evidence_file": EVIDENCE_PATH,
+    "invariants_source": "git-core-contract.invariants",
+    "ordering_script_baseline": "6ce37f53e1f627c19e15fc01f68959f546a5eded",
+    "trigger_surface_source": "git-core-contract",
+}
 
 
 class OrderingError(ValueError):
@@ -31,28 +51,9 @@ def fail(rule: str, message: str) -> NoReturn:
     raise OrderingError(f"rule={rule}: {message}")
 
 
-def load_contract_checker():
-    expected = REPO_ROOT / "scripts/check_git_core_contract.py"
+def git_run(repo: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
     try:
-        resolved = CONTRACT_CHECKER.resolve(strict=True)
-    except OSError as exc:
-        fail("checker-load", f"cannot resolve contract checker: {exc}")
-    if CONTRACT_CHECKER.is_symlink() or resolved != expected:
-        fail(
-            "checker-load",
-            f"contract checker path is not the trusted repository file: {resolved}",
-        )
-    spec = importlib.util.spec_from_file_location("check_git_core_contract", CONTRACT_CHECKER)
-    if spec is None or spec.loader is None:
-        fail("checker-load", f"cannot load {CONTRACT_CHECKER}")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
-def git(repo: Path, *args: str, check: bool = True) -> bytes:
-    try:
-        result = subprocess.run(
+        return subprocess.run(
             [GIT, *args],
             cwd=repo,
             stdout=subprocess.PIPE,
@@ -61,7 +62,11 @@ def git(repo: Path, *args: str, check: bool = True) -> bytes:
         )
     except OSError as exc:
         fail("git-exec", f"cannot execute {GIT}: {exc}")
-    if check and result.returncode != 0:
+
+
+def git(repo: Path, *args: str) -> bytes:
+    result = git_run(repo, *args)
+    if result.returncode != 0:
         stderr = result.stderr.decode("utf-8", "replace").strip()
         fail("git-command", f"git {' '.join(args)} failed ({result.returncode}): {stderr}")
     return result.stdout
@@ -74,29 +79,188 @@ def git_text(repo: Path, *args: str) -> str:
         fail("git-output", f"git {' '.join(args)} returned invalid UTF-8: {exc}")
 
 
-def canonical_metadata(repo: Path, checker) -> tuple[dict[str, object], dict[str, object]]:
-    for path in (CONTRACT_PATH, EVIDENCE_PATH, HANDOFF_PATH):
-        git(repo, "cat-file", "-e", f"{SLICE2_ANCHOR}:{path}")
-    raw = git(repo, "show", f"{SLICE2_ANCHOR}:{CONTRACT_PATH}")
-    handoff_raw = git(repo, "show", f"{SLICE2_ANCHOR}:{HANDOFF_PATH}")
+def require_repository(repo: Path) -> None:
+    result = git_run(repo, "rev-parse", "--show-toplevel")
+    if result.returncode != 0:
+        fail("config-root", f"{repo} is not a Git repository")
     try:
-        text = raw.decode("utf-8")
-        handoff_text = handoff_raw.decode("utf-8")
+        top = result.stdout.decode("utf-8").strip()
     except UnicodeDecodeError as exc:
-        fail("anchor-contract", f"pinned metadata is not UTF-8: {exc}")
-    contract = checker.extract_json_fence_text(text, "git-core-contract", path=CONTRACT_PATH)
-    handoff = checker.extract_json_fence_text(
-        handoff_text, "slice3-handoff", path=HANDOFF_PATH
+        fail("config-root", f"repository root is not UTF-8: {exc}")
+    if Path(os.path.realpath(top)) != repo:
+        fail("config-root", f"{repo} is not the repository root")
+
+
+def _no_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            fail("json-duplicate-key", f"duplicate object key {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_number(value: str) -> NoReturn:
+    fail("json-number-domain", f"floating, exponent, or non-finite number forbidden: {value}")
+
+
+def loads_strict(raw: str, *, label: str) -> dict[str, object]:
+    try:
+        value = json.loads(
+            raw,
+            object_pairs_hook=_no_duplicate_keys,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except json.JSONDecodeError as exc:
+        fail("json-parse", f"{label}: {exc.msg} at {exc.lineno}:{exc.colno}")
+    if not isinstance(value, dict):
+        fail("contract-shape", f"{label} must be a JSON object")
+    return value
+
+
+def extract_json_fence_text(raw: str, name: str, *, label: str) -> dict[str, object]:
+    opening = re.compile(rf"^```json {re.escape(name)}[ \t]*$", re.MULTILINE)
+    matches = list(opening.finditer(raw))
+    if len(matches) != 1:
+        fail("contract-fence", f"{label}: expected exactly one {name} JSON fence")
+    body = raw[matches[0].end() :]
+    if body.startswith("\r\n"):
+        body = body[2:]
+    elif body.startswith("\n"):
+        body = body[1:]
+    closing = re.search(r"^```[ \t]*$", body, re.MULTILINE)
+    if closing is None:
+        fail("contract-fence", f"{label}: unterminated {name} JSON fence")
+    return loads_strict(body[: closing.start()].rstrip("\r\n"), label=label)
+
+
+def read_live_text(repo: Path, relative: str) -> str:
+    candidate = repo / relative
+    resolved = Path(os.path.realpath(candidate))
+    try:
+        resolved.relative_to(repo)
+    except ValueError:
+        fail("path-containment", f"{relative} escapes repository root")
+    if candidate.is_symlink():
+        fail("input-symlink", f"{relative} must not be a symlink")
+    try:
+        return resolved.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        fail("input", f"cannot read {relative}: {exc}")
+
+
+def anchor_text(repo: Path, relative: str, rule: str) -> str:
+    result = git_run(repo, "show", f"{SLICE2_ANCHOR}:{relative}")
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        fail(rule, f"cannot read {relative} from Slice 2 anchor: {detail}")
+    try:
+        return result.stdout.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        fail(rule, f"{relative} at Slice 2 anchor is not UTF-8: {exc}")
+
+
+def validate_handoff(value: dict[str, object], *, label: str) -> None:
+    if value != HANDOFF:
+        fail("handoff-shape", f"{label} differs from the exact Slice 2 handoff")
+
+
+def validate_trusted_contract(repo: Path) -> None:
+    checker = git(repo, "show", f"{SLICE2_ANCHOR}:{CHECKER_PATH}")
+    with tempfile.TemporaryDirectory(prefix="aimee-ordering-") as directory:
+        checker_path = Path(directory) / "check_git_core_contract.py"
+        checker_path.write_bytes(checker)
+        checker_path.chmod(0o400)
+        try:
+            result = subprocess.run(
+                [
+                    PYTHON,
+                    "-I",
+                    "-S",
+                    str(checker_path),
+                    "--config-root",
+                    str(repo),
+                    "--require-status",
+                    "roundtable-approved",
+                ],
+                cwd=repo,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        except OSError as exc:
+            fail("checker-exec", f"cannot execute trusted contract checker: {exc}")
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        fail("contract-validation", f"trusted Slice 2 checker rejected HEAD: {detail}")
+
+
+def canonical_metadata(repo: Path) -> tuple[dict[str, object], dict[str, object]]:
+    contract = extract_json_fence_text(
+        anchor_text(repo, CONTRACT_PATH, "anchor-contract"),
+        "git-core-contract",
+        label=f"{SLICE2_ANCHOR}:{CONTRACT_PATH}",
     )
+    evidence = git_run(repo, "cat-file", "-e", f"{SLICE2_ANCHOR}:{EVIDENCE_PATH}")
+    if evidence.returncode != 0:
+        fail("anchor-evidence", f"{EVIDENCE_PATH} is absent from the Slice 2 anchor")
+    handoff = extract_json_fence_text(
+        anchor_text(repo, HANDOFF_PATH, "anchor-handoff"),
+        "slice3-handoff",
+        label=f"{SLICE2_ANCHOR}:{HANDOFF_PATH}",
+    )
+    validate_handoff(handoff, label="pinned handoff")
+    return contract, handoff
+
+
+def live_metadata(repo: Path) -> tuple[dict[str, object], dict[str, object]]:
+    contract = extract_json_fence_text(
+        read_live_text(repo, CONTRACT_PATH), "git-core-contract", label=CONTRACT_PATH
+    )
+    handoff = extract_json_fence_text(
+        read_live_text(repo, HANDOFF_PATH), "slice3-handoff", label=HANDOFF_PATH
+    )
+    validate_handoff(handoff, label="live handoff")
     return contract, handoff
 
 
 def discovery_view(contract: dict[str, object]) -> dict[str, object]:
-    return {
-        "historical_cutoff": contract["historical_cutoff"],
-        "invariants": contract["invariants"],
-        "trigger_surface": contract["trigger_surface"],
-    }
+    try:
+        return {
+            "historical_cutoff": contract["historical_cutoff"],
+            "invariants": contract["invariants"],
+            "trigger_surface": contract["trigger_surface"],
+        }
+    except KeyError as exc:
+        fail("contract-shape", f"contract lacks discovery field {exc.args[0]!r}")
+
+
+def path_metadata(contract: dict[str, object]) -> tuple[set[str], list[tuple[str, str]]]:
+    trigger = contract.get("trigger_surface")
+    if not isinstance(trigger, dict):
+        fail("contract-shape", "trigger_surface must be an object")
+    missing = set(TRIGGER_GROUPS) - set(trigger)
+    unknown = set(trigger) - set(TRIGGER_GROUPS)
+    if missing or unknown:
+        fail(
+            "contract-shape",
+            f"trigger_surface keys mismatch; missing={sorted(missing)}, unknown={sorted(unknown)}",
+        )
+    exact: set[str] = set()
+    try:
+        for group in ("descriptors", "generated_builds", "generated_profiles"):
+            exact.update(str(item["path"]).rstrip("/") for item in trigger[group])
+        exact.update(str(item["path"]).rstrip("/") for item in trigger["readiness_markers"])
+        root_claims = [
+            (str(item["path"]).rstrip("/"), str(item["claim"]))
+            for item in trigger["status_claim_roots"]
+        ]
+    except (KeyError, TypeError) as exc:
+        fail("contract-shape", f"malformed trigger_surface record: {exc}")
+    if "" in exact or any(not root or not claim for root, claim in root_claims):
+        fail("contract-shape", "trigger_surface paths and claims must not be empty")
+    return exact, root_claims
 
 
 def validate_discovery(
@@ -106,28 +270,17 @@ def validate_discovery(
     pinned_handoff: dict[str, object],
 ) -> None:
     if discovery_view(live) != discovery_view(pinned):
-        fail("discovery-drift", "HEAD contract discovery metadata differs from Slice 2 anchor")
-    if live_handoff != pinned_handoff:
+        fail("discovery-drift", "HEAD discovery metadata differs from Slice 2 anchor")
+    live_paths, live_roots = path_metadata(live)
+    pinned_paths, pinned_roots = path_metadata(pinned)
+    if live_paths != pinned_paths or live_roots != pinned_roots:
+        fail("discovery-drift", "HEAD trigger paths or claim roots differ from Slice 2 anchor")
+    if json.dumps(live_handoff, sort_keys=True) != json.dumps(pinned_handoff, sort_keys=True):
         fail("discovery-drift", "HEAD handoff differs from Slice 2 anchor")
 
 
-def path_metadata(
-    contract: dict[str, object],
-) -> tuple[set[str], list[tuple[str, str]]]:
-    trigger = contract["trigger_surface"]
-    exact: set[str] = set()
-    for group in ("descriptors", "generated_builds", "generated_profiles"):
-        exact.update(item["path"] for item in trigger[group])
-    exact.update(item["path"] for item in trigger["readiness_markers"])
-    root_claims = [
-        (item["path"].rstrip("/"), item["claim"])
-        for item in trigger["status_claim_roots"]
-    ]
-    return exact, root_claims
-
-
 def source_or_exact_signal(path: str, exact_paths: set[str]) -> bool:
-    return path == "src/modules/git" or path.startswith("src/modules/git/") or path in exact_paths
+    return path.startswith("src/modules/git/") or path in exact_paths
 
 
 def parse_name_status(raw: bytes) -> list[tuple[str, tuple[str, ...]]]:
@@ -145,45 +298,46 @@ def parse_name_status(raw: bytes) -> list[tuple[str, tuple[str, ...]]]:
         path_count = 2 if status.startswith(("R", "C")) else 1
         if index + path_count > len(fields):
             fail("name-status", f"truncated record for status {status!r}")
-        paths: list[str] = []
-        for field in fields[index : index + path_count]:
-            try:
-                paths.append(field.decode("utf-8"))
-            except UnicodeDecodeError as exc:
-                fail("name-status", f"non-UTF-8 path: {exc}")
+        try:
+            paths = tuple(field.decode("utf-8") for field in fields[index : index + path_count])
+        except UnicodeDecodeError as exc:
+            fail("name-status", f"non-UTF-8 path: {exc}")
         index += path_count
-        records.append((status, tuple(paths)))
+        records.append((status, paths))
     return records
 
 
-def claim_patterns(claims: set[str]) -> tuple[re.Pattern[str], ...]:
-    patterns: list[re.Pattern[str]] = []
-    for claim in sorted(claims):
-        escaped = re.escape(claim)
-        patterns.append(re.compile(rf"^[ \t]*{escaped}[ \t]*:[ \t]*true(?:[ \t]+#.*)?[ \t]*$"))
-        patterns.append(re.compile(rf'^[ \t]*"{escaped}"[ \t]*:[ \t]*true[ \t]*,?[ \t]*$'))
-    return tuple(patterns)
+def under_root(path: str, root: str) -> bool:
+    return path == root or path.startswith(root + "/")
 
 
-def added_claim_signal(diff: bytes, patterns: tuple[re.Pattern[str], ...]) -> bool:
+def claim_patterns(claim: str, suffix: str) -> tuple[re.Pattern[str], ...]:
+    escaped = re.escape(claim)
+    if suffix in {".yaml", ".yml"}:
+        return (
+            re.compile(rf"^[ \t]*{escaped}[ \t]*:[ \t]*true(?:[ \t]+#.*)?[ \t]*$"),
+        )
+    if suffix == ".json":
+        return (re.compile(rf'^[ \t]*"{escaped}"[ \t]*:[ \t]*true[ \t]*,?[ \t]*$'),)
+    return ()
+
+
+def blob(repo: Path, revision: str, path: str) -> bytes | None:
+    result = git_run(repo, "show", f"{revision}:{path}")
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def added_claim_signal(before: bytes, after: bytes, claim: str, suffix: str) -> bool:
     try:
-        text = diff.decode("utf-8")
+        old_lines = before.decode("utf-8").splitlines()
+        new_lines = after.decode("utf-8").splitlines()
     except UnicodeDecodeError:
         return False
-    structured_file = False
-    for line in text.splitlines():
-        if line.startswith("+++ "):
-            changed_path = line[4:]
-            if changed_path.startswith("b/"):
-                changed_path = changed_path[2:]
-            structured_file = changed_path.endswith((".json", ".yaml", ".yml"))
-            continue
-        if not structured_file:
-            continue
-        if not line.startswith("+") or line.startswith("+++"):
-            continue
-        candidate = line[1:]
-        if any(pattern.fullmatch(candidate) for pattern in patterns):
+    patterns = claim_patterns(claim, suffix)
+    for line in difflib.ndiff(old_lines, new_lines):
+        if line.startswith("+ ") and any(pattern.fullmatch(line[2:]) for pattern in patterns):
             return True
     return False
 
@@ -208,27 +362,37 @@ def commit_signals(
         commit,
         "--",
     )
+    records = parse_name_status(raw)
     signals: list[tuple[str, str]] = []
-    for status, paths in parse_name_status(raw):
-        for path in paths:
-            if source_or_exact_signal(path, exact_paths):
-                signals.append(("path", f"{status}:{path}"))
-                break
-    for root, claim in root_claims:
-        claim_diff = git(
-            repo,
-            "diff",
-            "--unified=0",
-            "--no-color",
-            "--no-ext-diff",
-            parent,
-            commit,
-            "--",
-            root,
-        )
-        if added_claim_signal(claim_diff, claim_patterns({claim})):
-            signals.append(("status-claim", f"{root}:{claim}"))
+    for status, paths in records:
+        if any(source_or_exact_signal(path, exact_paths) for path in paths):
+            signals.append(("path", f"{status}:{' -> '.join(paths)}"))
+
+        if status.startswith("D"):
+            continue
+        destination = paths[-1]
+        suffix = Path(destination).suffix.lower()
+        if suffix not in {".json", ".yaml", ".yml"}:
+            continue
+        after = blob(repo, commit, destination)
+        if after is None:
+            fail("git-blob", f"cannot read {commit}:{destination}")
+        for root, claim in root_claims:
+            if not under_root(destination, root):
+                continue
+            source = paths[0]
+            source_in_root = under_root(source, root)
+            before = blob(repo, parent, source) if source_in_root else None
+            if added_claim_signal(before or b"", after, claim, suffix):
+                signals.append(("status-claim", f"{root}:{claim}:{destination}"))
     return signals
+
+
+def first_parent(repo: Path, commit: str) -> str:
+    line = git_text(repo, "rev-list", "--parents", "-n", "1", commit).split()
+    if len(line) < 2:
+        fail("git-history", f"commit {commit} has no first parent")
+    return line[1]
 
 
 def scan_history(
@@ -239,13 +403,11 @@ def scan_history(
     exact_paths: set[str],
     root_claims: list[tuple[str, str]],
 ) -> list[tuple[str, str, list[tuple[str, str]]]]:
-    commits_text = git_text(
-        repo, "rev-list", "--first-parent", "--reverse", f"{cutoff}..{head}"
-    )
+    commits_text = git_text(repo, "rev-list", "--topo-order", "--reverse", f"{cutoff}..{head}")
     commits = commits_text.splitlines() if commits_text else []
     found: list[tuple[str, str, list[tuple[str, str]]]] = []
     for commit in commits:
-        parent = git_text(repo, "rev-parse", f"{commit}^1")
+        parent = first_parent(repo, commit)
         signals = commit_signals(
             repo,
             parent,
@@ -259,73 +421,87 @@ def scan_history(
 
 
 def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
-    try:
-        result = subprocess.run(
-            [GIT, "merge-base", "--is-ancestor", ancestor, descendant],
-            cwd=repo,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
-    except OSError as exc:
-        fail("git-exec", f"cannot execute {GIT}: {exc}")
+    result = git_run(repo, "merge-base", "--is-ancestor", ancestor, descendant)
     if result.returncode not in (0, 1):
         fail("git-ancestry", f"cannot compare {ancestor} to {descendant}")
     return result.returncode == 0
+
+
+def on_first_parent_chain(repo: Path, ancestor: str, descendant: str) -> bool:
+    current = descendant
+    while True:
+        if current == ancestor:
+            return True
+        line = git_text(repo, "rev-list", "--parents", "-n", "1", current).split()
+        if len(line) < 2:
+            return False
+        current = line[1]
 
 
 def enforce_signal_precedence(
     repo: Path, anchor: str, signals: list[tuple[str, str, list[tuple[str, str]]]]
 ) -> None:
     for commit, parent, evidence in signals:
-        if not is_ancestor(repo, anchor, parent):
+        if not on_first_parent_chain(repo, anchor, parent):
+            rendered = ", ".join(f"{kind}:{value}" for kind, value in evidence)
             fail(
                 "git-contract-ordering",
-                f"signal at {commit} does not follow approved Slice 2 contract: "
-                f"{evidence[0][0]}:{evidence[0][1]}",
+                f"signal at {commit} does not follow approved Slice 2 contract: {rendered}",
             )
 
 
 def validate_event(head: str) -> None:
-    event = os.environ.get("GITHUB_EVENT_NAME")
-    ref = os.environ.get("GITHUB_REF")
-    event_sha = os.environ.get("GITHUB_SHA")
-    if not event:
-        return
-    if not event_sha:
-        fail("event-head", "GITHUB_SHA is required for GitHub events")
-    if not ref:
-        fail("event-ref", "GITHUB_REF is required for GitHub events")
-    if event_sha != head:
-        fail("event-head", f"GITHUB_SHA {event_sha} differs from checked-out HEAD {head}")
-    allowed = (
-        event == "push" and ref == "refs/heads/feature/core-modularization"
-    ) or (
-        event == "pull_request" and bool(ref and re.fullmatch(r"refs/pull/[0-9]+/merge", ref))
-    ) or (
-        event == "workflow_dispatch" and ref == "refs/heads/feature/core-modularization"
+    keys = (
+        "GITHUB_EVENT_NAME",
+        "GITHUB_REF",
+        "GITHUB_SHA",
+        "GITHUB_BASE_REF",
+        "GITHUB_HEAD_REF",
     )
-    if not allowed:
-        fail("event-ref", f"unsupported GitHub event/ref pair {event!r}/{ref!r}")
+    context = {key: os.environ.get(key, "") for key in keys}
+    if not any(context.values()):
+        return
+    event = context["GITHUB_EVENT_NAME"]
+    ref = context["GITHUB_REF"]
+    event_sha = context["GITHUB_SHA"]
+    if not event:
+        fail("event-name", "GITHUB_EVENT_NAME is required when GitHub context is present")
+    if not ref:
+        fail("event-ref", "GITHUB_REF is required when GitHub context is present")
+    if not event_sha or event_sha != head:
+        fail("event-head", f"GITHUB_SHA {event_sha!r} differs from checked-out HEAD {head}")
+    if event == "pull_request":
+        if not re.fullmatch(r"refs/pull/[0-9]+/merge", ref):
+            fail("event-ref", f"unsupported pull_request ref {ref!r}")
+        if context["GITHUB_BASE_REF"] != FEATURE_BRANCH:
+            fail("event-base", f"pull request must target {FEATURE_BRANCH}")
+        if not context["GITHUB_HEAD_REF"]:
+            fail("event-head-ref", "GITHUB_HEAD_REF is required for pull requests")
+        return
+    if event in {"push", "workflow_dispatch"} and ref == f"refs/heads/{FEATURE_BRANCH}":
+        return
+    fail("event-ref", f"unsupported GitHub event/ref pair {event!r}/{ref!r}")
 
 
 def validate_ordering(repo: Path) -> int:
-    checker = load_contract_checker()
+    require_repository(repo)
     head = git_text(repo, "rev-parse", "HEAD")
     validate_event(head)
     git(repo, "cat-file", "-e", f"{SLICE2_ANCHOR}^{{commit}}")
     if not is_ancestor(repo, SLICE2_ANCHOR, head):
         fail("slice2-anchor", "approved Slice 2 anchor is not an ancestor of HEAD")
 
-    pinned, pinned_handoff = canonical_metadata(repo, checker)
-    live = checker.load_validated_contract(
-        repo, require_status="roundtable-approved", check_git=True
-    )
-    live_handoff_path = repo / HANDOFF_PATH
-    live_handoff = checker.extract_json_fence(live_handoff_path, "slice3-handoff")
+    validate_trusted_contract(repo)
+    pinned, pinned_handoff = canonical_metadata(repo)
+    live, live_handoff = live_metadata(repo)
     validate_discovery(live, pinned, live_handoff, pinned_handoff)
 
-    cutoff = pinned["historical_cutoff"]["commit"]
+    try:
+        cutoff = str(pinned["historical_cutoff"]["commit"])
+    except (KeyError, TypeError) as exc:
+        fail("contract-shape", f"malformed historical cutoff: {exc}")
+    if not is_ancestor(repo, cutoff, SLICE2_ANCHOR):
+        fail("slice2-anchor", "historical cutoff does not precede the Slice 2 anchor")
     exact_paths, root_claims = path_metadata(pinned)
     signals = scan_history(
         repo,
@@ -355,11 +531,14 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
     try:
-        signal_count = validate_ordering(repo)
+        signals_after_anchor = validate_ordering(repo)
     except (OrderingError, OSError, subprocess.SubprocessError, UnicodeError, ValueError) as exc:
         print(f"check_proposal_ordering: error: {exc}", file=sys.stderr)
         return 1
-    print(f"check_proposal_ordering: ok ({signal_count} post-cutoff signal commit(s); {repo})")
+    print(
+        "check_proposal_ordering: ok "
+        f"({signals_after_anchor} post-cutoff signal commit(s); {repo})"
+    )
     return 0
 
 

--- a/scripts/check_proposal_ordering.py
+++ b/scripts/check_proposal_ordering.py
@@ -8,6 +8,7 @@ import importlib.util
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import sys
 from typing import NoReturn
@@ -19,7 +20,7 @@ SLICE2_ANCHOR = "a3c4d413b6ce5f674994a6e6c4589ae2383819a4"
 CONTRACT_PATH = "docs/proposals/pending/git-core-contract.md"
 EVIDENCE_PATH = "docs/validation/roundtable/git-core-contract.json"
 HANDOFF_PATH = "docs/validation/core-modularization-slice-2.md"
-GIT = "/usr/bin/git"
+GIT = shutil.which("git", path="/usr/bin:/bin") or "/usr/bin/git"
 
 
 class OrderingError(ValueError):
@@ -31,6 +32,16 @@ def fail(rule: str, message: str) -> NoReturn:
 
 
 def load_contract_checker():
+    expected = REPO_ROOT / "scripts/check_git_core_contract.py"
+    try:
+        resolved = CONTRACT_CHECKER.resolve(strict=True)
+    except OSError as exc:
+        fail("checker-load", f"cannot resolve contract checker: {exc}")
+    if CONTRACT_CHECKER.is_symlink() or resolved != expected:
+        fail(
+            "checker-load",
+            f"contract checker path is not the trusted repository file: {resolved}",
+        )
     spec = importlib.util.spec_from_file_location("check_git_core_contract", CONTRACT_CHECKER)
     if spec is None or spec.loader is None:
         fail("checker-load", f"cannot load {CONTRACT_CHECKER}")
@@ -63,15 +74,21 @@ def git_text(repo: Path, *args: str) -> str:
         fail("git-output", f"git {' '.join(args)} returned invalid UTF-8: {exc}")
 
 
-def canonical_contract(repo: Path, checker) -> dict[str, object]:
+def canonical_metadata(repo: Path, checker) -> tuple[dict[str, object], dict[str, object]]:
     for path in (CONTRACT_PATH, EVIDENCE_PATH, HANDOFF_PATH):
         git(repo, "cat-file", "-e", f"{SLICE2_ANCHOR}:{path}")
     raw = git(repo, "show", f"{SLICE2_ANCHOR}:{CONTRACT_PATH}")
+    handoff_raw = git(repo, "show", f"{SLICE2_ANCHOR}:{HANDOFF_PATH}")
     try:
         text = raw.decode("utf-8")
+        handoff_text = handoff_raw.decode("utf-8")
     except UnicodeDecodeError as exc:
-        fail("anchor-contract", f"pinned contract is not UTF-8: {exc}")
-    return checker.extract_json_fence_text(text, "git-core-contract", path=CONTRACT_PATH)
+        fail("anchor-contract", f"pinned metadata is not UTF-8: {exc}")
+    contract = checker.extract_json_fence_text(text, "git-core-contract", path=CONTRACT_PATH)
+    handoff = checker.extract_json_fence_text(
+        handoff_text, "slice3-handoff", path=HANDOFF_PATH
+    )
+    return contract, handoff
 
 
 def discovery_view(contract: dict[str, object]) -> dict[str, object]:
@@ -82,15 +99,31 @@ def discovery_view(contract: dict[str, object]) -> dict[str, object]:
     }
 
 
-def path_metadata(contract: dict[str, object]) -> tuple[set[str], set[str], set[str]]:
+def validate_discovery(
+    live: dict[str, object],
+    pinned: dict[str, object],
+    live_handoff: dict[str, object],
+    pinned_handoff: dict[str, object],
+) -> None:
+    if discovery_view(live) != discovery_view(pinned):
+        fail("discovery-drift", "HEAD contract discovery metadata differs from Slice 2 anchor")
+    if live_handoff != pinned_handoff:
+        fail("discovery-drift", "HEAD handoff differs from Slice 2 anchor")
+
+
+def path_metadata(
+    contract: dict[str, object],
+) -> tuple[set[str], list[tuple[str, str]]]:
     trigger = contract["trigger_surface"]
     exact: set[str] = set()
     for group in ("descriptors", "generated_builds", "generated_profiles"):
         exact.update(item["path"] for item in trigger[group])
     exact.update(item["path"] for item in trigger["readiness_markers"])
-    roots = {item["path"].rstrip("/") for item in trigger["status_claim_roots"]}
-    claims = {item["claim"] for item in trigger["status_claim_roots"]}
-    return exact, roots, claims
+    root_claims = [
+        (item["path"].rstrip("/"), item["claim"])
+        for item in trigger["status_claim_roots"]
+    ]
+    return exact, root_claims
 
 
 def source_or_exact_signal(path: str, exact_paths: set[str]) -> bool:
@@ -137,7 +170,16 @@ def added_claim_signal(diff: bytes, patterns: tuple[re.Pattern[str], ...]) -> bo
         text = diff.decode("utf-8")
     except UnicodeDecodeError:
         return False
+    structured_file = False
     for line in text.splitlines():
+        if line.startswith("+++ "):
+            changed_path = line[4:]
+            if changed_path.startswith("b/"):
+                changed_path = changed_path[2:]
+            structured_file = changed_path.endswith((".json", ".yaml", ".yml"))
+            continue
+        if not structured_file:
+            continue
         if not line.startswith("+") or line.startswith("+++"):
             continue
         candidate = line[1:]
@@ -152,9 +194,8 @@ def commit_signals(
     commit: str,
     *,
     exact_paths: set[str],
-    status_roots: set[str],
-    patterns: tuple[re.Pattern[str], ...],
-) -> list[str]:
+    root_claims: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
     raw = git(
         repo,
         "diff",
@@ -167,13 +208,13 @@ def commit_signals(
         commit,
         "--",
     )
-    signals: list[str] = []
+    signals: list[tuple[str, str]] = []
     for status, paths in parse_name_status(raw):
         for path in paths:
             if source_or_exact_signal(path, exact_paths):
-                signals.append(f"{status}:{path}")
+                signals.append(("path", f"{status}:{path}"))
                 break
-    if status_roots:
+    for root, claim in root_claims:
         claim_diff = git(
             repo,
             "diff",
@@ -183,10 +224,10 @@ def commit_signals(
             parent,
             commit,
             "--",
-            *sorted(status_roots),
+            root,
         )
-        if added_claim_signal(claim_diff, patterns):
-            signals.append("status-claim")
+        if added_claim_signal(claim_diff, claim_patterns({claim})):
+            signals.append(("status-claim", f"{root}:{claim}"))
     return signals
 
 
@@ -196,13 +237,13 @@ def scan_history(
     head: str,
     *,
     exact_paths: set[str],
-    status_roots: set[str],
-    claims: set[str],
-) -> list[tuple[str, str, list[str]]]:
-    commits_text = git_text(repo, "rev-list", "--reverse", "--topo-order", f"{cutoff}..{head}")
+    root_claims: list[tuple[str, str]],
+) -> list[tuple[str, str, list[tuple[str, str]]]]:
+    commits_text = git_text(
+        repo, "rev-list", "--first-parent", "--reverse", f"{cutoff}..{head}"
+    )
     commits = commits_text.splitlines() if commits_text else []
-    patterns = claim_patterns(claims)
-    found: list[tuple[str, str, list[str]]] = []
+    found: list[tuple[str, str, list[tuple[str, str]]]] = []
     for commit in commits:
         parent = git_text(repo, "rev-parse", f"{commit}^1")
         signals = commit_signals(
@@ -210,8 +251,7 @@ def scan_history(
             parent,
             commit,
             exact_paths=exact_paths,
-            status_roots=status_roots,
-            patterns=patterns,
+            root_claims=root_claims,
         )
         if signals:
             found.append((commit, parent, signals))
@@ -219,26 +259,30 @@ def scan_history(
 
 
 def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
-    result = subprocess.run(
-        [GIT, "merge-base", "--is-ancestor", ancestor, descendant],
-        cwd=repo,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [GIT, "merge-base", "--is-ancestor", ancestor, descendant],
+            cwd=repo,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError as exc:
+        fail("git-exec", f"cannot execute {GIT}: {exc}")
     if result.returncode not in (0, 1):
         fail("git-ancestry", f"cannot compare {ancestor} to {descendant}")
     return result.returncode == 0
 
 
 def enforce_signal_precedence(
-    repo: Path, anchor: str, signals: list[tuple[str, str, list[str]]]
+    repo: Path, anchor: str, signals: list[tuple[str, str, list[tuple[str, str]]]]
 ) -> None:
     for commit, parent, evidence in signals:
         if not is_ancestor(repo, anchor, parent):
             fail(
                 "git-contract-ordering",
-                f"signal at {commit} does not follow approved Slice 2 contract: {evidence[0]}",
+                f"signal at {commit} does not follow approved Slice 2 contract: "
+                f"{evidence[0][0]}:{evidence[0][1]}",
             )
 
 
@@ -246,10 +290,14 @@ def validate_event(head: str) -> None:
     event = os.environ.get("GITHUB_EVENT_NAME")
     ref = os.environ.get("GITHUB_REF")
     event_sha = os.environ.get("GITHUB_SHA")
-    if event_sha and event_sha != head:
-        fail("event-head", f"GITHUB_SHA {event_sha} differs from checked-out HEAD {head}")
     if not event:
         return
+    if not event_sha:
+        fail("event-head", "GITHUB_SHA is required for GitHub events")
+    if not ref:
+        fail("event-ref", "GITHUB_REF is required for GitHub events")
+    if event_sha != head:
+        fail("event-head", f"GITHUB_SHA {event_sha} differs from checked-out HEAD {head}")
     allowed = (
         event == "push" and ref == "refs/heads/feature/core-modularization"
     ) or (
@@ -269,22 +317,22 @@ def validate_ordering(repo: Path) -> int:
     if not is_ancestor(repo, SLICE2_ANCHOR, head):
         fail("slice2-anchor", "approved Slice 2 anchor is not an ancestor of HEAD")
 
-    pinned = canonical_contract(repo, checker)
+    pinned, pinned_handoff = canonical_metadata(repo, checker)
     live = checker.load_validated_contract(
         repo, require_status="roundtable-approved", check_git=True
     )
-    if discovery_view(live) != discovery_view(pinned):
-        fail("discovery-drift", "HEAD contract discovery metadata differs from Slice 2 anchor")
+    live_handoff_path = repo / HANDOFF_PATH
+    live_handoff = checker.extract_json_fence(live_handoff_path, "slice3-handoff")
+    validate_discovery(live, pinned, live_handoff, pinned_handoff)
 
     cutoff = pinned["historical_cutoff"]["commit"]
-    exact_paths, roots, claims = path_metadata(pinned)
+    exact_paths, root_claims = path_metadata(pinned)
     signals = scan_history(
         repo,
         cutoff,
         head,
         exact_paths=exact_paths,
-        status_roots=roots,
-        claims=claims,
+        root_claims=root_claims,
     )
     enforce_signal_precedence(repo, SLICE2_ANCHOR, signals)
     return len(signals)
@@ -308,7 +356,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     try:
         signal_count = validate_ordering(repo)
-    except (OrderingError, ValueError) as exc:
+    except (OrderingError, OSError, subprocess.SubprocessError, UnicodeError, ValueError) as exc:
         print(f"check_proposal_ordering: error: {exc}", file=sys.stderr)
         return 1
     print(f"check_proposal_ordering: ok ({signal_count} post-cutoff signal commit(s); {repo})")

--- a/scripts/check_proposal_ordering.py
+++ b/scripts/check_proposal_ordering.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Require the approved Git child contract to precede every Git migration signal."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import NoReturn
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTRACT_CHECKER = REPO_ROOT / "scripts/check_git_core_contract.py"
+SLICE2_ANCHOR = "a3c4d413b6ce5f674994a6e6c4589ae2383819a4"
+CONTRACT_PATH = "docs/proposals/pending/git-core-contract.md"
+EVIDENCE_PATH = "docs/validation/roundtable/git-core-contract.json"
+HANDOFF_PATH = "docs/validation/core-modularization-slice-2.md"
+GIT = "/usr/bin/git"
+
+
+class OrderingError(ValueError):
+    """A fail-closed ordering error with a stable rule name."""
+
+
+def fail(rule: str, message: str) -> NoReturn:
+    raise OrderingError(f"rule={rule}: {message}")
+
+
+def load_contract_checker():
+    spec = importlib.util.spec_from_file_location("check_git_core_contract", CONTRACT_CHECKER)
+    if spec is None or spec.loader is None:
+        fail("checker-load", f"cannot load {CONTRACT_CHECKER}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def git(repo: Path, *args: str, check: bool = True) -> bytes:
+    try:
+        result = subprocess.run(
+            [GIT, *args],
+            cwd=repo,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except OSError as exc:
+        fail("git-exec", f"cannot execute {GIT}: {exc}")
+    if check and result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", "replace").strip()
+        fail("git-command", f"git {' '.join(args)} failed ({result.returncode}): {stderr}")
+    return result.stdout
+
+
+def git_text(repo: Path, *args: str) -> str:
+    try:
+        return git(repo, *args).decode("utf-8").strip()
+    except UnicodeDecodeError as exc:
+        fail("git-output", f"git {' '.join(args)} returned invalid UTF-8: {exc}")
+
+
+def canonical_contract(repo: Path, checker) -> dict[str, object]:
+    for path in (CONTRACT_PATH, EVIDENCE_PATH, HANDOFF_PATH):
+        git(repo, "cat-file", "-e", f"{SLICE2_ANCHOR}:{path}")
+    raw = git(repo, "show", f"{SLICE2_ANCHOR}:{CONTRACT_PATH}")
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        fail("anchor-contract", f"pinned contract is not UTF-8: {exc}")
+    return checker.extract_json_fence_text(text, "git-core-contract", path=CONTRACT_PATH)
+
+
+def discovery_view(contract: dict[str, object]) -> dict[str, object]:
+    return {
+        "historical_cutoff": contract["historical_cutoff"],
+        "invariants": contract["invariants"],
+        "trigger_surface": contract["trigger_surface"],
+    }
+
+
+def path_metadata(contract: dict[str, object]) -> tuple[set[str], set[str], set[str]]:
+    trigger = contract["trigger_surface"]
+    exact: set[str] = set()
+    for group in ("descriptors", "generated_builds", "generated_profiles"):
+        exact.update(item["path"] for item in trigger[group])
+    exact.update(item["path"] for item in trigger["readiness_markers"])
+    roots = {item["path"].rstrip("/") for item in trigger["status_claim_roots"]}
+    claims = {item["claim"] for item in trigger["status_claim_roots"]}
+    return exact, roots, claims
+
+
+def source_or_exact_signal(path: str, exact_paths: set[str]) -> bool:
+    return path == "src/modules/git" or path.startswith("src/modules/git/") or path in exact_paths
+
+
+def parse_name_status(raw: bytes) -> list[tuple[str, tuple[str, ...]]]:
+    fields = raw.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    records: list[tuple[str, tuple[str, ...]]] = []
+    index = 0
+    while index < len(fields):
+        try:
+            status = fields[index].decode("ascii")
+        except UnicodeDecodeError as exc:
+            fail("name-status", f"non-ASCII status: {exc}")
+        index += 1
+        path_count = 2 if status.startswith(("R", "C")) else 1
+        if index + path_count > len(fields):
+            fail("name-status", f"truncated record for status {status!r}")
+        paths: list[str] = []
+        for field in fields[index : index + path_count]:
+            try:
+                paths.append(field.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                fail("name-status", f"non-UTF-8 path: {exc}")
+        index += path_count
+        records.append((status, tuple(paths)))
+    return records
+
+
+def claim_patterns(claims: set[str]) -> tuple[re.Pattern[str], ...]:
+    patterns: list[re.Pattern[str]] = []
+    for claim in sorted(claims):
+        escaped = re.escape(claim)
+        patterns.append(re.compile(rf"^[ \t]*{escaped}[ \t]*:[ \t]*true(?:[ \t]+#.*)?[ \t]*$"))
+        patterns.append(re.compile(rf'^[ \t]*"{escaped}"[ \t]*:[ \t]*true[ \t]*,?[ \t]*$'))
+    return tuple(patterns)
+
+
+def added_claim_signal(diff: bytes, patterns: tuple[re.Pattern[str], ...]) -> bool:
+    try:
+        text = diff.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    for line in text.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        candidate = line[1:]
+        if any(pattern.fullmatch(candidate) for pattern in patterns):
+            return True
+    return False
+
+
+def commit_signals(
+    repo: Path,
+    parent: str,
+    commit: str,
+    *,
+    exact_paths: set[str],
+    status_roots: set[str],
+    patterns: tuple[re.Pattern[str], ...],
+) -> list[str]:
+    raw = git(
+        repo,
+        "diff",
+        "--name-status",
+        "-z",
+        "-M",
+        "-C",
+        "--find-copies-harder",
+        parent,
+        commit,
+        "--",
+    )
+    signals: list[str] = []
+    for status, paths in parse_name_status(raw):
+        for path in paths:
+            if source_or_exact_signal(path, exact_paths):
+                signals.append(f"{status}:{path}")
+                break
+    if status_roots:
+        claim_diff = git(
+            repo,
+            "diff",
+            "--unified=0",
+            "--no-color",
+            "--no-ext-diff",
+            parent,
+            commit,
+            "--",
+            *sorted(status_roots),
+        )
+        if added_claim_signal(claim_diff, patterns):
+            signals.append("status-claim")
+    return signals
+
+
+def scan_history(
+    repo: Path,
+    cutoff: str,
+    head: str,
+    *,
+    exact_paths: set[str],
+    status_roots: set[str],
+    claims: set[str],
+) -> list[tuple[str, str, list[str]]]:
+    commits_text = git_text(repo, "rev-list", "--reverse", "--topo-order", f"{cutoff}..{head}")
+    commits = commits_text.splitlines() if commits_text else []
+    patterns = claim_patterns(claims)
+    found: list[tuple[str, str, list[str]]] = []
+    for commit in commits:
+        parent = git_text(repo, "rev-parse", f"{commit}^1")
+        signals = commit_signals(
+            repo,
+            parent,
+            commit,
+            exact_paths=exact_paths,
+            status_roots=status_roots,
+            patterns=patterns,
+        )
+        if signals:
+            found.append((commit, parent, signals))
+    return found
+
+
+def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    result = subprocess.run(
+        [GIT, "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=repo,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        fail("git-ancestry", f"cannot compare {ancestor} to {descendant}")
+    return result.returncode == 0
+
+
+def enforce_signal_precedence(
+    repo: Path, anchor: str, signals: list[tuple[str, str, list[str]]]
+) -> None:
+    for commit, parent, evidence in signals:
+        if not is_ancestor(repo, anchor, parent):
+            fail(
+                "git-contract-ordering",
+                f"signal at {commit} does not follow approved Slice 2 contract: {evidence[0]}",
+            )
+
+
+def validate_event(head: str) -> None:
+    event = os.environ.get("GITHUB_EVENT_NAME")
+    ref = os.environ.get("GITHUB_REF")
+    event_sha = os.environ.get("GITHUB_SHA")
+    if event_sha and event_sha != head:
+        fail("event-head", f"GITHUB_SHA {event_sha} differs from checked-out HEAD {head}")
+    if not event:
+        return
+    allowed = (
+        event == "push" and ref == "refs/heads/feature/core-modularization"
+    ) or (
+        event == "pull_request" and bool(ref and re.fullmatch(r"refs/pull/[0-9]+/merge", ref))
+    ) or (
+        event == "workflow_dispatch" and ref == "refs/heads/feature/core-modularization"
+    )
+    if not allowed:
+        fail("event-ref", f"unsupported GitHub event/ref pair {event!r}/{ref!r}")
+
+
+def validate_ordering(repo: Path) -> int:
+    checker = load_contract_checker()
+    head = git_text(repo, "rev-parse", "HEAD")
+    validate_event(head)
+    git(repo, "cat-file", "-e", f"{SLICE2_ANCHOR}^{{commit}}")
+    if not is_ancestor(repo, SLICE2_ANCHOR, head):
+        fail("slice2-anchor", "approved Slice 2 anchor is not an ancestor of HEAD")
+
+    pinned = canonical_contract(repo, checker)
+    live = checker.load_validated_contract(
+        repo, require_status="roundtable-approved", check_git=True
+    )
+    if discovery_view(live) != discovery_view(pinned):
+        fail("discovery-drift", "HEAD contract discovery metadata differs from Slice 2 anchor")
+
+    cutoff = pinned["historical_cutoff"]["commit"]
+    exact_paths, roots, claims = path_metadata(pinned)
+    signals = scan_history(
+        repo,
+        cutoff,
+        head,
+        exact_paths=exact_paths,
+        status_roots=roots,
+        claims=claims,
+    )
+    enforce_signal_precedence(repo, SLICE2_ANCHOR, signals)
+    return len(signals)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config-root", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    root_value = args.config_root or os.environ.get("AIMEE_CONFIG_ROOT") or REPO_ROOT
+    repo = Path(os.path.realpath(root_value))
+    if not repo.is_dir():
+        print(
+            f"check_proposal_ordering: error: rule=config-root: {repo} is not a directory",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        signal_count = validate_ordering(repo)
+    except (OrderingError, ValueError) as exc:
+        print(f"check_proposal_ordering: error: {exc}", file=sys.stderr)
+        return 1
+    print(f"check_proposal_ordering: ok ({signal_count} post-cutoff signal commit(s); {repo})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_proposal_ordering.py
+++ b/scripts/tests/test_check_proposal_ordering.py
@@ -76,44 +76,52 @@ class ProposalOrderingTests(unittest.TestCase):
         self.assertTrue(ordering.source_or_exact_signal("src/generated/modules.mk", exact))
         self.assertFalse(ordering.source_or_exact_signal("src/modules/memory/a.c", exact))
 
-    def test_claim_patterns_are_closed_whole_line_and_case_sensitive(self) -> None:
-        patterns = ordering.claim_patterns({"git-runtime-ready"})
-        accepted = (
+    def test_claim_patterns_are_format_specific_literal_and_closed(self) -> None:
+        yaml_patterns = ordering.claim_patterns("git-runtime-ready", ".yaml")
+        json_patterns = ordering.claim_patterns("git-runtime-ready", ".json")
+        yaml_accepted = (
             "git-runtime-ready: true",
             "  git-runtime-ready : true # approved",
-            '"git-runtime-ready": true,',
         )
-        rejected = (
+        yaml_rejected = (
             "git-runtime-ready: false",
+            "git-runtime-ready: True",
+            "git-runtime-ready: yes",
+            "git-runtime-ready: !!bool true",
+            "git-runtime-ready: true % comment",
+            "git-runtime-ready: |",
             "Git-runtime-ready: true",
             "git-runtime-ready-extended: true",
             "prose git-runtime-ready: true",
             "# git-runtime-ready: true",
+            '"git-runtime-ready": true,',
         )
-        for line in accepted:
+        for line in yaml_accepted:
             with self.subTest(line=line):
-                self.assertTrue(any(pattern.fullmatch(line) for pattern in patterns))
-        for line in rejected:
+                self.assertTrue(any(pattern.fullmatch(line) for pattern in yaml_patterns))
+        for line in yaml_rejected:
             with self.subTest(line=line):
-                self.assertFalse(any(pattern.fullmatch(line) for pattern in patterns))
+                self.assertFalse(any(pattern.fullmatch(line) for pattern in yaml_patterns))
+        for line in ('"git-runtime-ready": true', '"git-runtime-ready": true,'):
+            with self.subTest(line=line):
+                self.assertTrue(any(pattern.fullmatch(line) for pattern in json_patterns))
+        self.assertFalse(
+            any(pattern.fullmatch("git-runtime-ready: true") for pattern in json_patterns)
+        )
 
     def test_added_claim_ignores_deletion_context_and_binary(self) -> None:
-        patterns = ordering.claim_patterns({"git-runtime-ready"})
         self.assertTrue(
             ordering.added_claim_signal(
-                b"+++ b/status.yaml\n+git-runtime-ready: true\n", patterns
+                b"not ready\n", b"git-runtime-ready: true\n", "git-runtime-ready", ".yaml"
             )
         )
         self.assertFalse(
             ordering.added_claim_signal(
-                b"+++ b/status.yaml\n-git-runtime-ready: true\n", patterns
+                b"git-runtime-ready: true\n", b"not ready\n", "git-runtime-ready", ".yaml"
             )
         )
-        self.assertFalse(ordering.added_claim_signal(b"\xff\x00", patterns))
         self.assertFalse(
-            ordering.added_claim_signal(
-                b"+++ b/status.md\n+git-runtime-ready: true\n", patterns
-            )
+            ordering.added_claim_signal(b"", b"\xff\x00", "git-runtime-ready", ".yaml")
         )
 
     def test_history_records_source_signal_even_after_revert(self) -> None:
@@ -155,7 +163,8 @@ class ProposalOrderingTests(unittest.TestCase):
             )
             self.assertEqual(len(signals), 1)
             self.assertEqual(
-                signals[0][2], [("status-claim", "docs/modules:git-runtime-ready")]
+                signals[0][2],
+                [("status-claim", "docs/modules:git-runtime-ready:docs/modules/git.yaml")],
             )
         finally:
             tmp.cleanup()
@@ -265,6 +274,150 @@ class ProposalOrderingTests(unittest.TestCase):
         finally:
             tmp.cleanup()
 
+    def test_structured_claim_ignores_gitattributes_and_quoted_filename(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            attributes = repo / ".gitattributes"
+            attributes.write_text("*.yaml -diff\n", encoding="utf-8")
+            self.commit(repo, "disable yaml diff driver")
+            doc = repo / 'docs/modules/weird\t"\nname.yaml'
+            doc.parent.mkdir(parents=True)
+            doc.write_text("git-runtime-ready: true\n", encoding="utf-8")
+            head = self.commit(repo, "structured claim")
+            signals = ordering.scan_history(
+                repo,
+                cutoff,
+                head,
+                exact_paths=set(),
+                root_claims=[("docs/modules", "git-runtime-ready")],
+            )
+            claims = [
+                evidence
+                for _, _, entries in signals
+                for kind, evidence in entries
+                if kind == "status-claim"
+            ]
+            self.assertEqual(len(claims), 1)
+            self.assertIn('weird\t"\nname.yaml', claims[0])
+        finally:
+            tmp.cleanup()
+
+    def test_claim_rename_into_root_is_signal_and_rename_out_is_removal(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            outside = repo / "elsewhere/status.yaml"
+            outside.parent.mkdir(parents=True)
+            outside.write_text("git-runtime-ready: true\n", encoding="utf-8")
+            source_commit = self.commit(repo, "outside claim")
+            inside = repo / "docs/modules/status.yaml"
+            inside.parent.mkdir(parents=True)
+            outside.rename(inside)
+            rename_in = self.commit(repo, "rename claim into root")
+            inside.rename(outside)
+            rename_out = self.commit(repo, "rename claim out of root")
+            root_claims = [("docs/modules", "git-runtime-ready")]
+            incoming = ordering.commit_signals(
+                repo,
+                source_commit,
+                rename_in,
+                exact_paths=set(),
+                root_claims=root_claims,
+            )
+            outgoing = ordering.commit_signals(
+                repo,
+                rename_in,
+                rename_out,
+                exact_paths=set(),
+                root_claims=root_claims,
+            )
+            self.assertTrue(any(kind == "status-claim" for kind, _ in incoming))
+            self.assertFalse(any(kind == "status-claim" for kind, _ in outgoing))
+            self.assertTrue(ordering.is_ancestor(repo, cutoff, rename_out))
+        finally:
+            tmp.cleanup()
+
+    def test_complete_dag_scan_keeps_side_branch_signal_and_revert(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            anchor_file = repo / "contract.md"
+            anchor_file.write_text("approved\n", encoding="utf-8")
+            anchor = self.commit(repo, "anchor")
+            self.git(repo, "switch", "-q", "-c", "side")
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("signal\n", encoding="utf-8")
+            self.commit(repo, "side signal")
+            source.unlink()
+            self.commit(repo, "side revert")
+            self.git(repo, "switch", "-q", "master")
+            self.git(
+                repo,
+                "-c",
+                "user.name=Aimee Test",
+                "-c",
+                "user.email=aimee@example.invalid",
+                "merge",
+                "--no-ff",
+                "-m",
+                "merge side",
+                "side",
+            )
+            head = self.git(repo, "rev-parse", "HEAD")
+            signals = ordering.scan_history(
+                repo, cutoff, head, exact_paths=set(), root_claims=[]
+            )
+            self.assertEqual(len(signals), 2)
+            ordering.enforce_signal_precedence(repo, anchor, signals)
+        finally:
+            tmp.cleanup()
+
+    def test_pr_shape_branch_without_anchor_fails_precedence(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            self.git(repo, "switch", "-q", "-c", "proposed")
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("signal\n", encoding="utf-8")
+            self.commit(repo, "pre-anchor signal")
+            self.git(repo, "switch", "-q", "master")
+            anchor_file = repo / "contract.md"
+            anchor_file.write_text("approved\n", encoding="utf-8")
+            anchor = self.commit(repo, "anchor")
+            self.git(
+                repo,
+                "-c",
+                "user.name=Aimee Test",
+                "-c",
+                "user.email=aimee@example.invalid",
+                "merge",
+                "--no-ff",
+                "-m",
+                "synthetic merge",
+                "proposed",
+            )
+            head = self.git(repo, "rev-parse", "HEAD")
+            signals = ordering.scan_history(
+                repo, cutoff, head, exact_paths=set(), root_claims=[]
+            )
+            with self.assertRaisesRegex(ordering.OrderingError, "git-contract-ordering"):
+                ordering.enforce_signal_precedence(repo, anchor, signals)
+        finally:
+            tmp.cleanup()
+
+    def test_all_signal_evidence_is_rendered_on_failure(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            with self.assertRaises(ordering.OrderingError) as caught:
+                ordering.enforce_signal_precedence(
+                    repo,
+                    "f" * 40,
+                    [(cutoff, cutoff, [("path", "one"), ("status-claim", "two")])],
+                )
+            self.assertIn("path:one", str(caught.exception))
+            self.assertIn("status-claim:two", str(caught.exception))
+        finally:
+            tmp.cleanup()
+
     def test_event_binding(self) -> None:
         head = "a" * 40
         with mock.patch.dict(os.environ, {}, clear=True):
@@ -272,9 +425,11 @@ class ProposalOrderingTests(unittest.TestCase):
         with mock.patch.dict(
             os.environ,
             {
-                "GITHUB_EVENT_NAME": "push",
-                "GITHUB_REF": "refs/heads/feature/core-modularization",
+                "GITHUB_EVENT_NAME": "pull_request",
+                "GITHUB_REF": "refs/pull/123/merge",
                 "GITHUB_SHA": head,
+                "GITHUB_BASE_REF": "feature/core-modularization",
+                "GITHUB_HEAD_REF": "slice/example",
             },
             clear=True,
         ):
@@ -300,16 +455,39 @@ class ProposalOrderingTests(unittest.TestCase):
             ):
                 ordering.validate_event(head)
 
-    def test_contract_checker_loader_rejects_symlink(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            target = Path(tmp) / "checker.py"
-            target.write_text("pass\n", encoding="utf-8")
-            link = Path(tmp) / "link.py"
-            link.symlink_to(target)
-            with mock.patch.object(ordering, "CONTRACT_CHECKER", link), self.assertRaisesRegex(
-                ordering.OrderingError, "checker-load"
+        partials = (
+            {"GITHUB_SHA": head},
+            {"GITHUB_REF": "refs/heads/feature/core-modularization"},
+            {"GITHUB_BASE_REF": "feature/core-modularization"},
+        )
+        for env in partials:
+            with (
+                self.subTest(env=env),
+                mock.patch.dict(os.environ, env, clear=True),
+                self.assertRaisesRegex(ordering.OrderingError, "event-"),
             ):
-                ordering.load_contract_checker()
+                ordering.validate_event(head)
+        wrong_base = {
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_REF": "refs/pull/123/merge",
+            "GITHUB_SHA": head,
+            "GITHUB_BASE_REF": "main",
+            "GITHUB_HEAD_REF": "slice/example",
+        }
+        with mock.patch.dict(os.environ, wrong_base, clear=True), self.assertRaisesRegex(
+            ordering.OrderingError, "event-base"
+        ):
+            ordering.validate_event(head)
+
+    def test_live_input_rejects_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            target = repo / "target.md"
+            target.write_text("pass\n", encoding="utf-8")
+            link = repo / "link.md"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(ordering.OrderingError, "input-symlink"):
+                ordering.read_live_text(repo, "link.md")
 
     def test_git_execution_failure_is_fail_closed(self) -> None:
         with mock.patch.object(ordering, "GIT", "/definitely/missing/git"), self.assertRaisesRegex(
@@ -318,17 +496,33 @@ class ProposalOrderingTests(unittest.TestCase):
             ordering.git(REPO_ROOT, "status")
 
     def test_live_discovery_equals_immutable_slice2_blob(self) -> None:
-        contract_checker = ordering.load_contract_checker()
-        pinned, pinned_handoff = ordering.canonical_metadata(REPO_ROOT, contract_checker)
-        live = contract_checker.load_validated_contract(
-            REPO_ROOT, require_status="roundtable-approved", check_git=True
-        )
-        ordering.validate_discovery(live, pinned, pinned_handoff, pinned_handoff)
+        pinned, pinned_handoff = ordering.canonical_metadata(REPO_ROOT)
+        live, live_handoff = ordering.live_metadata(REPO_ROOT)
+        ordering.validate_discovery(live, pinned, live_handoff, pinned_handoff)
 
         drifted_handoff = copy.deepcopy(pinned_handoff)
         drifted_handoff["receiver"] = "changed"
         with self.assertRaisesRegex(ordering.OrderingError, "discovery-drift"):
             ordering.validate_discovery(live, pinned, drifted_handoff, pinned_handoff)
+
+        drifted_contract = copy.deepcopy(live)
+        drifted_contract["trigger_surface"]["status_claim_roots"].append(
+            {"path": "docs/extra", "claim": "git-runtime-ready"}
+        )
+        with self.assertRaisesRegex(ordering.OrderingError, "discovery-drift"):
+            ordering.validate_discovery(
+                drifted_contract, pinned, live_handoff, pinned_handoff
+            )
+
+    def test_contract_shape_failure_has_stable_rule(self) -> None:
+        contract = {"trigger_surface": {group: [] for group in ordering.TRIGGER_GROUPS}}
+        del contract["trigger_surface"]["readiness_markers"]
+        with self.assertRaisesRegex(ordering.OrderingError, "contract-shape"):
+            ordering.path_metadata(contract)
+
+    def test_non_repository_config_root_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(ordering.main(["--config-root", tmp]), 1)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_proposal_ordering.py
+++ b/scripts/tests/test_check_proposal_ordering.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import importlib.util
 import os
 from pathlib import Path
@@ -99,12 +100,21 @@ class ProposalOrderingTests(unittest.TestCase):
     def test_added_claim_ignores_deletion_context_and_binary(self) -> None:
         patterns = ordering.claim_patterns({"git-runtime-ready"})
         self.assertTrue(
-            ordering.added_claim_signal(b"+git-runtime-ready: true\n", patterns)
+            ordering.added_claim_signal(
+                b"+++ b/status.yaml\n+git-runtime-ready: true\n", patterns
+            )
         )
         self.assertFalse(
-            ordering.added_claim_signal(b"-git-runtime-ready: true\n", patterns)
+            ordering.added_claim_signal(
+                b"+++ b/status.yaml\n-git-runtime-ready: true\n", patterns
+            )
         )
         self.assertFalse(ordering.added_claim_signal(b"\xff\x00", patterns))
+        self.assertFalse(
+            ordering.added_claim_signal(
+                b"+++ b/status.md\n+git-runtime-ready: true\n", patterns
+            )
+        )
 
     def test_history_records_source_signal_even_after_revert(self) -> None:
         tmp, repo, cutoff = self.make_repo()
@@ -120,18 +130,17 @@ class ProposalOrderingTests(unittest.TestCase):
                 cutoff,
                 head,
                 exact_paths=set(),
-                status_roots=set(),
-                claims=set(),
+                root_claims=[],
             )
             self.assertEqual(len(signals), 2)
-            self.assertTrue(signals[0][2][0].endswith("src/modules/git/example.c"))
+            self.assertTrue(signals[0][2][0][1].endswith("src/modules/git/example.c"))
         finally:
             tmp.cleanup()
 
     def test_history_records_claim_then_removal(self) -> None:
         tmp, repo, cutoff = self.make_repo()
         try:
-            doc = repo / "docs/modules/git.md"
+            doc = repo / "docs/modules/git.yaml"
             doc.parent.mkdir(parents=True)
             doc.write_text("git-runtime-ready: true\n", encoding="utf-8")
             self.commit(repo, "claim")
@@ -142,11 +151,51 @@ class ProposalOrderingTests(unittest.TestCase):
                 cutoff,
                 head,
                 exact_paths=set(),
-                status_roots={"docs/modules"},
-                claims={"git-runtime-ready"},
+                root_claims=[("docs/modules", "git-runtime-ready")],
             )
             self.assertEqual(len(signals), 1)
-            self.assertEqual(signals[0][2], ["status-claim"])
+            self.assertEqual(
+                signals[0][2], [("status-claim", "docs/modules:git-runtime-ready")]
+            )
+        finally:
+            tmp.cleanup()
+
+    def test_claim_remains_bound_to_its_declared_root(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            doc = repo / "docs/root-b/status.yaml"
+            doc.parent.mkdir(parents=True)
+            doc.write_text("claim-a: true\n", encoding="utf-8")
+            head = self.commit(repo, "wrong-root claim")
+            signals = ordering.scan_history(
+                repo,
+                cutoff,
+                head,
+                exact_paths=set(),
+                root_claims=[("docs/root-a", "claim-a"), ("docs/root-b", "claim-b")],
+            )
+            self.assertEqual(signals, [])
+        finally:
+            tmp.cleanup()
+
+    def test_path_and_claim_are_distinct_signal_classes(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("signal\n", encoding="utf-8")
+            claim = repo / "docs/modules/status.yaml"
+            claim.parent.mkdir(parents=True)
+            claim.write_text("git-runtime-ready: true\n", encoding="utf-8")
+            head = self.commit(repo, "two signals")
+            signals = ordering.scan_history(
+                repo,
+                cutoff,
+                head,
+                exact_paths=set(),
+                root_claims=[("docs/modules", "git-runtime-ready")],
+            )
+            self.assertEqual({item[0] for item in signals[0][2]}, {"path", "status-claim"})
         finally:
             tmp.cleanup()
 
@@ -162,8 +211,7 @@ class ProposalOrderingTests(unittest.TestCase):
                 cutoff,
                 head,
                 exact_paths={"src/modules/git/module.yaml"},
-                status_roots=set(),
-                claims=set(),
+                root_claims=[],
             )
             self.assertEqual(len(signals), 1)
         finally:
@@ -184,8 +232,7 @@ class ProposalOrderingTests(unittest.TestCase):
                 cutoff,
                 head,
                 exact_paths=set(),
-                status_roots=set(),
-                claims=set(),
+                root_claims=[],
             )
             ordering.enforce_signal_precedence(repo, anchor, signals)
             with self.assertRaisesRegex(ordering.OrderingError, "git-contract-ordering"):
@@ -209,11 +256,12 @@ class ProposalOrderingTests(unittest.TestCase):
                 cutoff,
                 head,
                 exact_paths=set(),
-                status_roots=set(),
-                claims=set(),
+                root_claims=[],
             )
             self.assertEqual(len(signals), 1)
-            self.assertTrue(any("src/modules/git/example.c" in item for item in signals[0][2]))
+            self.assertTrue(
+                any("src/modules/git/example.c" in item[1] for item in signals[0][2])
+            )
         finally:
             tmp.cleanup()
 
@@ -237,14 +285,50 @@ class ProposalOrderingTests(unittest.TestCase):
             clear=True,
         ), self.assertRaisesRegex(ordering.OrderingError, "event-ref"):
             ordering.validate_event(head)
+        for missing in ("GITHUB_SHA", "GITHUB_REF"):
+            env = {
+                "GITHUB_EVENT_NAME": "push",
+                "GITHUB_REF": "refs/heads/feature/core-modularization",
+                "GITHUB_SHA": head,
+            }
+            env.pop(missing)
+            expected = "event-head" if missing == "GITHUB_SHA" else "event-ref"
+            with (
+                self.subTest(missing=missing),
+                mock.patch.dict(os.environ, env, clear=True),
+                self.assertRaisesRegex(ordering.OrderingError, expected),
+            ):
+                ordering.validate_event(head)
+
+    def test_contract_checker_loader_rejects_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "checker.py"
+            target.write_text("pass\n", encoding="utf-8")
+            link = Path(tmp) / "link.py"
+            link.symlink_to(target)
+            with mock.patch.object(ordering, "CONTRACT_CHECKER", link), self.assertRaisesRegex(
+                ordering.OrderingError, "checker-load"
+            ):
+                ordering.load_contract_checker()
+
+    def test_git_execution_failure_is_fail_closed(self) -> None:
+        with mock.patch.object(ordering, "GIT", "/definitely/missing/git"), self.assertRaisesRegex(
+            ordering.OrderingError, "git-exec"
+        ):
+            ordering.git(REPO_ROOT, "status")
 
     def test_live_discovery_equals_immutable_slice2_blob(self) -> None:
         contract_checker = ordering.load_contract_checker()
-        pinned = ordering.canonical_contract(REPO_ROOT, contract_checker)
+        pinned, pinned_handoff = ordering.canonical_metadata(REPO_ROOT, contract_checker)
         live = contract_checker.load_validated_contract(
             REPO_ROOT, require_status="roundtable-approved", check_git=True
         )
-        self.assertEqual(ordering.discovery_view(live), ordering.discovery_view(pinned))
+        ordering.validate_discovery(live, pinned, pinned_handoff, pinned_handoff)
+
+        drifted_handoff = copy.deepcopy(pinned_handoff)
+        drifted_handoff["receiver"] = "changed"
+        with self.assertRaisesRegex(ordering.OrderingError, "discovery-drift"):
+            ordering.validate_discovery(live, pinned, drifted_handoff, pinned_handoff)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_proposal_ordering.py
+++ b/scripts/tests/test_check_proposal_ordering.py
@@ -72,6 +72,7 @@ class ProposalOrderingTests(unittest.TestCase):
 
     def test_source_and_exact_path_detection(self) -> None:
         exact = {"src/modules/git/module.yaml", "src/generated/modules.mk"}
+        self.assertTrue(ordering.source_or_exact_signal("src/modules/git", exact))
         self.assertTrue(ordering.source_or_exact_signal("src/modules/git/a.c", exact))
         self.assertTrue(ordering.source_or_exact_signal("src/generated/modules.mk", exact))
         self.assertFalse(ordering.source_or_exact_signal("src/modules/memory/a.c", exact))
@@ -111,18 +112,36 @@ class ProposalOrderingTests(unittest.TestCase):
 
     def test_added_claim_ignores_deletion_context_and_binary(self) -> None:
         self.assertTrue(
-            ordering.added_claim_signal(
+            ordering.claim_signal_in_diff(
                 b"not ready\n", b"git-runtime-ready: true\n", "git-runtime-ready", ".yaml"
             )
         )
         self.assertFalse(
-            ordering.added_claim_signal(
+            ordering.claim_signal_in_diff(
                 b"git-runtime-ready: true\n", b"not ready\n", "git-runtime-ready", ".yaml"
             )
         )
         self.assertFalse(
-            ordering.added_claim_signal(b"", b"\xff\x00", "git-runtime-ready", ".yaml")
+            ordering.claim_signal_in_diff(b"", b"\xff\x00", "git-runtime-ready", ".yaml")
         )
+
+    def test_claim_toggle_and_yaml_block_scalars(self) -> None:
+        self.assertTrue(
+            ordering.claim_signal_in_diff(
+                b"git-runtime-ready: false\n",
+                b"git-runtime-ready: true\n",
+                "git-runtime-ready",
+                ".yaml",
+            )
+        )
+        for marker in ("|", ">-"):
+            after = f"description: {marker}\n  git-runtime-ready: true\nnext: value\n"
+            with self.subTest(marker=marker):
+                self.assertFalse(
+                    ordering.claim_signal_in_diff(
+                        b"", after.encode(), "git-runtime-ready", ".yaml"
+                    )
+                )
 
     def test_history_records_source_signal_even_after_revert(self) -> None:
         tmp, repo, cutoff = self.make_repo()
@@ -232,6 +251,9 @@ class ProposalOrderingTests(unittest.TestCase):
             anchor_file = repo / "contract.md"
             anchor_file.write_text("approved\n", encoding="utf-8")
             anchor = self.commit(repo, "anchor")
+            spacer = repo / "spacer"
+            spacer.write_text("separate approval from signal\n", encoding="utf-8")
+            self.commit(repo, "post-anchor boundary")
             source = repo / "src/modules/git/example.c"
             source.parent.mkdir(parents=True)
             source.write_text("signal\n", encoding="utf-8")
@@ -244,6 +266,9 @@ class ProposalOrderingTests(unittest.TestCase):
                 root_claims=[],
             )
             ordering.enforce_signal_precedence(repo, anchor, signals)
+            direct = [(head, anchor, [("path", "M:src/modules/git/example.c")])]
+            with self.assertRaisesRegex(ordering.OrderingError, "git-contract-ordering"):
+                ordering.enforce_signal_precedence(repo, anchor, direct)
             with self.assertRaisesRegex(ordering.OrderingError, "git-contract-ordering"):
                 ordering.enforce_signal_precedence(repo, head, signals)
         finally:
@@ -271,6 +296,35 @@ class ProposalOrderingTests(unittest.TestCase):
             self.assertTrue(
                 any("src/modules/git/example.c" in item[1] for item in signals[0][2])
             )
+        finally:
+            tmp.cleanup()
+
+    def test_exact_git_tree_root_gitlink_is_signal(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            self.git(
+                repo,
+                "update-index",
+                "--add",
+                "--cacheinfo",
+                f"160000,{cutoff},src/modules/git",
+            )
+            self.git(
+                repo,
+                "-c",
+                "user.name=Aimee Test",
+                "-c",
+                "user.email=aimee@example.invalid",
+                "commit",
+                "-m",
+                "git root gitlink",
+            )
+            head = self.git(repo, "rev-parse", "HEAD")
+            signals = ordering.scan_history(
+                repo, cutoff, head, exact_paths=set(), root_claims=[]
+            )
+            self.assertEqual(len(signals), 1)
+            self.assertIn("src/modules/git", signals[0][2][0][1])
         finally:
             tmp.cleanup()
 
@@ -336,12 +390,36 @@ class ProposalOrderingTests(unittest.TestCase):
         finally:
             tmp.cleanup()
 
+    def test_copy_of_in_root_claim_uses_empty_destination_baseline(self) -> None:
+        tmp, repo, _ = self.make_repo()
+        try:
+            source = repo / "docs/modules/source.yaml"
+            source.parent.mkdir(parents=True)
+            source.write_text("git-runtime-ready: true\n", encoding="utf-8")
+            parent = self.commit(repo, "source claim")
+            destination = repo / "docs/modules/copy.yaml"
+            destination.write_bytes(source.read_bytes())
+            commit = self.commit(repo, "copy claim")
+            signals = ordering.commit_signals(
+                repo,
+                parent,
+                commit,
+                exact_paths=set(),
+                root_claims=[("docs/modules", "git-runtime-ready")],
+            )
+            self.assertTrue(any(kind == "status-claim" for kind, _ in signals))
+        finally:
+            tmp.cleanup()
+
     def test_complete_dag_scan_keeps_side_branch_signal_and_revert(self) -> None:
         tmp, repo, cutoff = self.make_repo()
         try:
             anchor_file = repo / "contract.md"
             anchor_file.write_text("approved\n", encoding="utf-8")
             anchor = self.commit(repo, "anchor")
+            spacer = repo / "spacer"
+            spacer.write_text("post-anchor boundary\n", encoding="utf-8")
+            self.commit(repo, "post-anchor boundary")
             self.git(repo, "switch", "-q", "-c", "side")
             source = repo / "src/modules/git/example.c"
             source.parent.mkdir(parents=True)
@@ -455,11 +533,13 @@ class ProposalOrderingTests(unittest.TestCase):
             ):
                 ordering.validate_event(head)
 
-        partials = (
-            {"GITHUB_SHA": head},
-            {"GITHUB_REF": "refs/heads/feature/core-modularization"},
-            {"GITHUB_BASE_REF": "feature/core-modularization"},
-        )
+        partials = tuple({key: value} for key, value in {
+            "GITHUB_EVENT_NAME": "push",
+            "GITHUB_REF": "refs/heads/feature/core-modularization",
+            "GITHUB_SHA": head,
+            "GITHUB_BASE_REF": "feature/core-modularization",
+            "GITHUB_HEAD_REF": "slice/example",
+        }.items())
         for env in partials:
             with (
                 self.subTest(env=env),
@@ -523,6 +603,22 @@ class ProposalOrderingTests(unittest.TestCase):
     def test_non_repository_config_root_fails_closed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {}, clear=True):
             self.assertEqual(ordering.main(["--config-root", tmp]), 1)
+
+    def test_dirty_contract_or_handoff_fails_closed(self) -> None:
+        tmp, repo, _ = self.make_repo()
+        try:
+            contract = repo / ordering.CONTRACT_PATH
+            handoff = repo / ordering.HANDOFF_PATH
+            contract.parent.mkdir(parents=True)
+            handoff.parent.mkdir(parents=True, exist_ok=True)
+            contract.write_text("contract\n", encoding="utf-8")
+            handoff.write_text("handoff\n", encoding="utf-8")
+            self.commit(repo, "metadata")
+            contract.write_text("dirty\n", encoding="utf-8")
+            with self.assertRaisesRegex(ordering.OrderingError, "live-contract-dirty"):
+                ordering.require_clean_metadata(repo)
+        finally:
+            tmp.cleanup()
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_proposal_ordering.py
+++ b/scripts/tests/test_check_proposal_ordering.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Tests for the chronological Git proposal-ordering gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER_PATH = REPO_ROOT / "scripts/check_proposal_ordering.py"
+SPEC = importlib.util.spec_from_file_location("check_proposal_ordering", CHECKER_PATH)
+assert SPEC and SPEC.loader
+ordering = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ordering)
+
+
+class ProposalOrderingTests(unittest.TestCase):
+    def git(self, repo: Path, *args: str) -> str:
+        result = subprocess.run(
+            [ordering.GIT, *args],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    def commit(self, repo: Path, message: str) -> str:
+        self.git(repo, "add", "-A")
+        self.git(
+            repo,
+            "-c",
+            "user.name=Aimee Test",
+            "-c",
+            "user.email=aimee@example.invalid",
+            "commit",
+            "-m",
+            message,
+        )
+        return self.git(repo, "rev-parse", "HEAD")
+
+    def make_repo(self) -> tuple[tempfile.TemporaryDirectory[str], Path, str]:
+        tmp = tempfile.TemporaryDirectory()
+        repo = Path(tmp.name)
+        self.git(repo, "init", "-q")
+        (repo / "README.md").write_text("base\n", encoding="utf-8")
+        cutoff = self.commit(repo, "base")
+        return tmp, repo, cutoff
+
+    def test_current_repository_passes(self) -> None:
+        self.assertEqual(ordering.validate_ordering(REPO_ROOT), 0)
+
+    def test_name_status_parses_all_path_shapes(self) -> None:
+        raw = b"M\0one\0R100\0old\0new\0C075\0source\0copy\0D\0gone\0"
+        self.assertEqual(
+            ordering.parse_name_status(raw),
+            [
+                ("M", ("one",)),
+                ("R100", ("old", "new")),
+                ("C075", ("source", "copy")),
+                ("D", ("gone",)),
+            ],
+        )
+
+    def test_source_and_exact_path_detection(self) -> None:
+        exact = {"src/modules/git/module.yaml", "src/generated/modules.mk"}
+        self.assertTrue(ordering.source_or_exact_signal("src/modules/git/a.c", exact))
+        self.assertTrue(ordering.source_or_exact_signal("src/generated/modules.mk", exact))
+        self.assertFalse(ordering.source_or_exact_signal("src/modules/memory/a.c", exact))
+
+    def test_claim_patterns_are_closed_whole_line_and_case_sensitive(self) -> None:
+        patterns = ordering.claim_patterns({"git-runtime-ready"})
+        accepted = (
+            "git-runtime-ready: true",
+            "  git-runtime-ready : true # approved",
+            '"git-runtime-ready": true,',
+        )
+        rejected = (
+            "git-runtime-ready: false",
+            "Git-runtime-ready: true",
+            "git-runtime-ready-extended: true",
+            "prose git-runtime-ready: true",
+            "# git-runtime-ready: true",
+        )
+        for line in accepted:
+            with self.subTest(line=line):
+                self.assertTrue(any(pattern.fullmatch(line) for pattern in patterns))
+        for line in rejected:
+            with self.subTest(line=line):
+                self.assertFalse(any(pattern.fullmatch(line) for pattern in patterns))
+
+    def test_added_claim_ignores_deletion_context_and_binary(self) -> None:
+        patterns = ordering.claim_patterns({"git-runtime-ready"})
+        self.assertTrue(
+            ordering.added_claim_signal(b"+git-runtime-ready: true\n", patterns)
+        )
+        self.assertFalse(
+            ordering.added_claim_signal(b"-git-runtime-ready: true\n", patterns)
+        )
+        self.assertFalse(ordering.added_claim_signal(b"\xff\x00", patterns))
+
+    def test_history_records_source_signal_even_after_revert(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("one\n", encoding="utf-8")
+            self.commit(repo, "source signal")
+            source.unlink()
+            head = self.commit(repo, "revert source signal")
+            signals = ordering.scan_history(
+                repo,
+                cutoff,
+                head,
+                exact_paths=set(),
+                status_roots=set(),
+                claims=set(),
+            )
+            self.assertEqual(len(signals), 2)
+            self.assertTrue(signals[0][2][0].endswith("src/modules/git/example.c"))
+        finally:
+            tmp.cleanup()
+
+    def test_history_records_claim_then_removal(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            doc = repo / "docs/modules/git.md"
+            doc.parent.mkdir(parents=True)
+            doc.write_text("git-runtime-ready: true\n", encoding="utf-8")
+            self.commit(repo, "claim")
+            doc.write_text("not ready\n", encoding="utf-8")
+            head = self.commit(repo, "remove claim")
+            signals = ordering.scan_history(
+                repo,
+                cutoff,
+                head,
+                exact_paths=set(),
+                status_roots={"docs/modules"},
+                claims={"git-runtime-ready"},
+            )
+            self.assertEqual(len(signals), 1)
+            self.assertEqual(signals[0][2], ["status-claim"])
+        finally:
+            tmp.cleanup()
+
+    def test_exact_descriptor_path_triggers_without_source_change(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            descriptor = repo / "src/modules/git/module.yaml"
+            descriptor.parent.mkdir(parents=True)
+            descriptor.write_text("module: git\n", encoding="utf-8")
+            head = self.commit(repo, "descriptor")
+            signals = ordering.scan_history(
+                repo,
+                cutoff,
+                head,
+                exact_paths={"src/modules/git/module.yaml"},
+                status_roots=set(),
+                claims=set(),
+            )
+            self.assertEqual(len(signals), 1)
+        finally:
+            tmp.cleanup()
+
+    def test_signal_must_follow_anchor_strictly(self) -> None:
+        tmp, repo, cutoff = self.make_repo()
+        try:
+            anchor_file = repo / "contract.md"
+            anchor_file.write_text("approved\n", encoding="utf-8")
+            anchor = self.commit(repo, "anchor")
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("signal\n", encoding="utf-8")
+            head = self.commit(repo, "signal after anchor")
+            signals = ordering.scan_history(
+                repo,
+                cutoff,
+                head,
+                exact_paths=set(),
+                status_roots=set(),
+                claims=set(),
+            )
+            ordering.enforce_signal_precedence(repo, anchor, signals)
+            with self.assertRaisesRegex(ordering.OrderingError, "git-contract-ordering"):
+                ordering.enforce_signal_precedence(repo, head, signals)
+        finally:
+            tmp.cleanup()
+
+    def test_rename_out_of_historical_git_tree_triggers(self) -> None:
+        tmp, repo, _ = self.make_repo()
+        try:
+            source = repo / "src/modules/git/example.c"
+            source.parent.mkdir(parents=True)
+            source.write_text("historical\n", encoding="utf-8")
+            cutoff = self.commit(repo, "historical git source")
+            destination = repo / "src/elsewhere/example.c"
+            destination.parent.mkdir(parents=True)
+            source.rename(destination)
+            head = self.commit(repo, "rename out")
+            signals = ordering.scan_history(
+                repo,
+                cutoff,
+                head,
+                exact_paths=set(),
+                status_roots=set(),
+                claims=set(),
+            )
+            self.assertEqual(len(signals), 1)
+            self.assertTrue(any("src/modules/git/example.c" in item for item in signals[0][2]))
+        finally:
+            tmp.cleanup()
+
+    def test_event_binding(self) -> None:
+        head = "a" * 40
+        with mock.patch.dict(os.environ, {}, clear=True):
+            ordering.validate_event(head)
+        with mock.patch.dict(
+            os.environ,
+            {
+                "GITHUB_EVENT_NAME": "push",
+                "GITHUB_REF": "refs/heads/feature/core-modularization",
+                "GITHUB_SHA": head,
+            },
+            clear=True,
+        ):
+            ordering.validate_event(head)
+        with mock.patch.dict(
+            os.environ,
+            {"GITHUB_EVENT_NAME": "push", "GITHUB_REF": "refs/heads/other", "GITHUB_SHA": head},
+            clear=True,
+        ), self.assertRaisesRegex(ordering.OrderingError, "event-ref"):
+            ordering.validate_event(head)
+
+    def test_live_discovery_equals_immutable_slice2_blob(self) -> None:
+        contract_checker = ordering.load_contract_checker()
+        pinned = ordering.canonical_contract(REPO_ROOT, contract_checker)
+        live = contract_checker.load_validated_contract(
+            REPO_ROOT, require_status="roundtable-approved", check_git=True
+        )
+        self.assertEqual(ordering.discovery_view(live), ordering.discovery_view(pinned))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a complete-DAG chronological gate for Git migration signals
- execute the durable PR gate from the protected feature-branch base against a separate candidate checkout
- bind trigger discovery to the immutable Slice 2 contract and checker
- cover branch graphs, structured claims, event binding, dirty metadata, quoted paths, copies, renames, and gitlinks

## Verification
- `python3 -I scripts/tests/test_check_proposal_ordering.py -v` (27 passed)
- `python3 -I scripts/tests/test_check_git_core_contract.py -v` (27 passed)
- live proposal-ordering and Git-contract gates pass
- workflow shape validation passes
- roundtable approved: `oprun_g6a5eaa7136447eb5_1784592072_11` (artifact: no issues; items: empty)

Target: `feature/core-modularization`
