### PR TITLE
fix(triggers): reconcile legacy proposal intake

### DIFF
--- a/src/server/trigger_scheduler.c
+++ b/src/server/trigger_scheduler.c
@@ -350,10 +350,57 @@ static void trigger_trim_line(char *s)
       s[--n] = '\0';
 }
 
+/* A proposal rule names a branch in `schedule`. Keep the watched remote-tracking
+ * ref fresh without checking it out or modifying the operator's working tree.
+ * The conservative character set is enough for ordinary Git branch names; an
+ * unusual ref simply falls back to the pre-existing local-ref behavior. */
+static int trigger_remote_branch(const char *schedule, char *out, size_t n)
+{
+   const char *branch = schedule ? schedule : "";
+   if (strncmp(branch, "origin/", 7) == 0)
+      branch += 7;
+   if (!branch[0] || branch[0] == '-' || branch[0] == '.' || strstr(branch, "..") ||
+       strstr(branch, "//"))
+      return 0;
+   size_t len = strlen(branch);
+   if (len + 1 > n || branch[len - 1] == '/' || branch[len - 1] == '.' ||
+       (len >= 5 && strcmp(branch + len - 5, ".lock") == 0))
+      return 0;
+   for (size_t i = 0; i < len; i++)
+      if (!(isalnum((unsigned char)branch[i]) || branch[i] == '-' || branch[i] == '_' ||
+            branch[i] == '.' || branch[i] == '/'))
+         return 0;
+   snprintf(out, n, "%s", branch);
+   return 1;
+}
+
+static int trigger_fetch_scheduled_ref(const char *workspace, const char *schedule, char *out,
+                                       size_t n)
+{
+   char branch[256];
+   if (!trigger_remote_branch(schedule, branch, sizeof(branch)))
+      return 0;
+   char refspec[600];
+   if (snprintf(refspec, sizeof(refspec), "+refs/heads/%s:refs/remotes/origin/%s", branch,
+                branch) >= (int)sizeof(refspec))
+      return 0;
+   const char *const fetch_argv[] = {"git", "fetch", "--quiet", "origin", refspec, NULL};
+   char *fetch_out = NULL;
+   int rc = trigger_git_capture(fetch_argv, workspace, &fetch_out);
+   free(fetch_out);
+   if (rc != 0)
+      return 0; /* offline/local-only repositories retain the old local-ref path */
+   if (snprintf(out, n, "origin/%s", branch) >= (int)n)
+      return 0;
+   return 1;
+}
+
 static void trigger_resolve_ref(const char *workspace, const char *schedule, char *out, size_t n)
 {
    if (schedule && schedule[0])
    {
+      if (trigger_fetch_scheduled_ref(workspace, schedule, out, n))
+         return;
       snprintf(out, n, "%s", schedule);
       return;
    }
@@ -536,10 +583,12 @@ static int trigger_file_run(const trigger_rule_t *rule, const char *artifact_pat
    return 0;
 }
 
-/* Count ACTIVE work items that were filed by the proposals trigger (their
+/* Count ACTIVE AUTONOMOUS work items that were filed by the proposals trigger (their
  * proposal artifact lives under <home>/triggers/proposals/), across all rules —
  * trigger.max_concurrent is a GLOBAL cap on concurrently-executing triggered
- * runs. Returns the count, or -1 on a DB read failure (caller fails closed:
+ * runs. Interactive/legacy watch rows cannot execute under the autonomy
+ * scheduler and therefore must never consume its admission slots. Returns the
+ * count, or -1 on a DB read failure (caller fails closed:
  * files nothing this pass rather than overshooting the cap). */
 static int trigger_active_filed_runs(const char *home)
 {
@@ -556,7 +605,7 @@ static int trigger_active_filed_runs(const char *home)
    int active = 0;
    size_t plen = strlen(prefix);
    for (int i = 0; i < n; i++)
-      if (strcmp(items[i].state, "active") == 0 &&
+      if (strcmp(items[i].state, "active") == 0 && strcmp(items[i].mode, "autonomous") == 0 &&
           strncmp(items[i].proposal_path, prefix, plen) == 0)
          active++;
    free(items);
@@ -583,6 +632,57 @@ static int proposal_name_matches(const char *entry_name, const char *want)
       if (wl == bl - 3 && strncmp(base, want, wl) == 0) /* basename minus the .md suffix */
          return 1;
    }
+   return 0;
+}
+
+static void trigger_path_segment(const char *src, char *out, size_t n)
+{
+   size_t j = 0;
+   for (size_t i = 0; src && src[i] && j + 1 < n; i++)
+   {
+      unsigned char c = (unsigned char)src[i];
+      out[j++] = (char)((isalnum(c) || c == '-' || c == '_' || c == '.') ? c : '_');
+   }
+   out[j] = '\0';
+   if (!out[0] && n > 1)
+      snprintf(out, n, "default");
+}
+
+/* The original artifact identity was only the proposal blob SHA. Preserve that
+ * stable key for completed/current runs, but let a different workflow lane or
+ * execution mode supersede a legacy binding. The lane-scoped key is deterministic,
+ * so subsequent scans still deduplicate normally. */
+static int trigger_proposal_artifact_path(const trigger_rule_t *rule, const char *home,
+                                          const char *sha, char *out, size_t n)
+{
+   if (snprintf(out, n, "%s/triggers/proposals/%s.md", home, sha) >= (int)n)
+      return -1;
+   char existing[80];
+   int found = db1_work_item_id_by_proposal(rule->workspace, out, existing, sizeof(existing));
+   if (found <= 0)
+      return found < 0 ? -1 : 0;
+
+   db1_work_item_t wi;
+   const char *mode = rule->mode[0] ? rule->mode : "autonomous";
+   if (db1_work_item_get(existing, &wi) != 1)
+      return -1;
+   if (strcmp(wi.workflow_name, rule->pipeline_template) == 0 && strcmp(wi.mode, mode) == 0)
+      return 1; /* already filed by this lane */
+
+   char workflow[80], run_mode[32];
+   trigger_path_segment(rule->pipeline_template, workflow, sizeof(workflow));
+   trigger_path_segment(mode, run_mode, sizeof(run_mode));
+   if (snprintf(out, n, "%s/triggers/proposals/%s.%s.%s.md", home, sha, workflow, run_mode) >=
+       (int)n)
+      return -1;
+   found = db1_work_item_id_by_proposal(rule->workspace, out, existing, sizeof(existing));
+   if (found == 1)
+      return 1;
+   if (found < 0)
+      return -1;
+   aimee_log(LOG_INFO, "trigger.sched",
+             "proposals: superseding legacy binding id=%s workflow=%s mode=%s with %s/%s",
+             wi.work_item_id, wi.workflow_name, wi.mode, rule->pipeline_template, mode);
    return 0;
 }
 
@@ -701,13 +801,9 @@ static int scan_proposals_ex(const trigger_rule_t *rule, int max_concurrent, con
          break;
       }
       char proposal_path[1200];
-      if (snprintf(proposal_path, sizeof(proposal_path), "%s/triggers/proposals/%s.md", home,
-                   entries[i].sha) >= (int)sizeof(proposal_path))
-         continue;
-
-      char existing[80];
-      if (db1_work_item_id_by_proposal(rule->workspace, proposal_path, existing,
-                                       sizeof(existing)) == 1)
+      int artifact = trigger_proposal_artifact_path(rule, home, entries[i].sha, proposal_path,
+                                                    sizeof(proposal_path));
+      if (artifact != 0) /* 1 = already filed; -1 = DB/path error (fail closed) */
          continue;
 
       const char *const cat_argv[] = {"git", "cat-file", "blob", entries[i].sha, NULL};

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -112,6 +112,8 @@ static char g_symref_out[256];      /* canned `git symbolic-ref` stdout ("" -> r
 static char g_lstree_out[8192];     /* canned `git ls-tree` stdout */
 static char g_lstree_ref[256];      /* captured ref arg passed to ls-tree */
 static char g_lstree_pathspec[512]; /* captured pathspec arg passed to ls-tree */
+static char g_fetch_branch[256];    /* captured remote refspec branch */
+static int g_fetch_rc;              /* 0 lets a scheduled-ref refresh succeed */
 static struct
 {
    char sha[41];
@@ -132,7 +134,9 @@ static int g_notify_count; /* wfe_scheduler_notify() invocations */
 
 static void trig_stub_reset(void)
 {
-   g_symref_out[0] = g_lstree_out[0] = g_lstree_ref[0] = g_lstree_pathspec[0] = '\0';
+   g_symref_out[0] = g_lstree_out[0] = g_lstree_ref[0] = g_lstree_pathspec[0] = g_fetch_branch[0] =
+       '\0';
+   g_fetch_rc = 1;
    g_nblobs = 0;
    g_ncreated = 0;
    g_notify_count = 0;
@@ -156,7 +160,7 @@ int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd,
    if (!argv || !argv[0])
       return 1;
 
-   int is_lstree = 0, is_catfile = 0, is_symref = 0, dashdash = -1;
+   int is_lstree = 0, is_catfile = 0, is_symref = 0, is_fetch = 0, dashdash = -1;
    const char *sha = NULL, *ref = NULL;
    for (int i = 0; argv[i]; i++)
    {
@@ -170,8 +174,19 @@ int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd,
          is_catfile = 1;
       if (strcmp(argv[i], "symbolic-ref") == 0)
          is_symref = 1;
+      if (strcmp(argv[i], "fetch") == 0)
+         is_fetch = 1;
       if (strcmp(argv[i], "--") == 0)
          dashdash = i;
+   }
+   if (is_fetch)
+   {
+      for (int i = 0; argv[i]; i++)
+         if (strncmp(argv[i], "+refs/heads/", 12) == 0)
+            snprintf(g_fetch_branch, sizeof g_fetch_branch, "%s", argv[i]);
+      if (out)
+         *out = strdup("");
+      return g_fetch_rc;
    }
    if (is_symref)
    {
@@ -217,12 +232,27 @@ int db1_work_item_id_by_proposal(const char *repo, const char *proposal_path, ch
       if (strcmp(g_created[i].repo, repo) == 0 && strcmp(g_created[i].path, proposal_path) == 0)
       {
          if (out_id && out_id_len > 0)
-            snprintf(out_id, out_id_len, "wi_existing");
+            snprintf(out_id, out_id_len, "wi_%d", i + 1);
          return 1;
       }
    if (out_id && out_id_len > 0)
       out_id[0] = '\0';
    return 0;
+}
+
+int db1_work_item_get(const char *work_item_id, db1_work_item_t *out)
+{
+   int idx = work_item_id && strncmp(work_item_id, "wi_", 3) == 0 ? atoi(work_item_id + 3) - 1 : -1;
+   if (!out || idx < 0 || idx >= g_ncreated)
+      return 0;
+   memset(out, 0, sizeof(*out));
+   snprintf(out->work_item_id, sizeof out->work_item_id, "wi_%d", idx + 1);
+   snprintf(out->repo, sizeof out->repo, "%s", g_created[idx].repo);
+   snprintf(out->proposal_path, sizeof out->proposal_path, "%s", g_created[idx].path);
+   snprintf(out->workflow_name, sizeof out->workflow_name, "%s", g_created[idx].wf);
+   snprintf(out->mode, sizeof out->mode, "%s", g_created[idx].mode);
+   snprintf(out->state, sizeof out->state, "%s", g_created[idx].state);
+   return 1;
 }
 
 int wfe_work_item_create(const char *workflow_name, const char *repo, const char *proposal_path,
@@ -272,6 +302,8 @@ int db1_work_item_list(db1_work_item_t **out)
       snprintf(items[i].work_item_id, sizeof items[i].work_item_id, "wi_%d", i + 1);
       snprintf(items[i].proposal_path, sizeof items[i].proposal_path, "%s", g_created[i].path);
       snprintf(items[i].state, sizeof items[i].state, "%s", g_created[i].state);
+      snprintf(items[i].workflow_name, sizeof items[i].workflow_name, "%s", g_created[i].wf);
+      snprintf(items[i].mode, sizeof items[i].mode, "%s", g_created[i].mode);
    }
    *out = items;
    return g_ncreated;
@@ -931,6 +963,24 @@ static void test_scan_proposals_custom_event_and_schedule(void)
    printf("  PASS: test_scan_proposals_custom_event_and_schedule\n");
 }
 
+static void test_scheduled_ref_refreshes_origin(void)
+{
+   trig_stub_reset();
+   g_fetch_rc = 0;
+   char ref[256];
+   trigger_resolve_ref("/repo/aimee", "testing", ref, sizeof(ref));
+   assert(strcmp(ref, "origin/testing") == 0);
+   assert(strcmp(g_fetch_branch, "+refs/heads/testing:refs/remotes/origin/testing") == 0);
+
+   /* Unsafe/unusual schedules are never interpolated into a fetch refspec. */
+   trig_stub_reset();
+   g_fetch_rc = 0;
+   trigger_resolve_ref("/repo/aimee", "bad:ref", ref, sizeof(ref));
+   assert(strcmp(ref, "bad:ref") == 0);
+   assert(g_fetch_branch[0] == '\0');
+   printf("  PASS: test_scheduled_ref_refreshes_origin\n");
+}
+
 static void test_scan_proposals_rejects_unsafe_ref_and_path(void)
 {
    snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-%d", (int)getpid());
@@ -1096,6 +1146,47 @@ static void test_scan_proposals_enforces_max_concurrent(void)
    printf("  PASS: test_scan_proposals_enforces_max_concurrent\n");
 }
 
+/* A pre-autonomy trigger row must neither occupy an autonomous slot nor
+ * permanently deduplicate the proposal for the current workflow lane. */
+static void test_scan_proposals_supersedes_legacy_interactive_binding(void)
+{
+   trig_stub_reset();
+   snprintf(g_home, sizeof g_home, "/tmp/aimee-trigtest-legacy-%d", (int)getpid());
+   mkdir(g_home, 0700);
+   snprintf(g_symref_out, sizeof g_symref_out, "origin/testing");
+   snprintf(g_blobs[0].sha, sizeof g_blobs[0].sha, "0123456789abcdef0123456789abcdef01234567");
+   snprintf(g_blobs[0].content, sizeof g_blobs[0].content, "# A\n");
+   g_nblobs = 1;
+   snprintf(g_lstree_out, sizeof g_lstree_out,
+            "100644 blob 0123456789abcdef0123456789abcdef01234567\t"
+            "docs/proposals/pending/a.md\n");
+
+   snprintf(g_created[0].wf, sizeof g_created[0].wf, "build-triggered");
+   snprintf(g_created[0].repo, sizeof g_created[0].repo, "/repo/aimee");
+   snprintf(g_created[0].path, sizeof g_created[0].path, "%s/triggers/proposals/%s.md", g_home,
+            g_blobs[0].sha);
+   snprintf(g_created[0].mode, sizeof g_created[0].mode, "interactive");
+   snprintf(g_created[0].state, sizeof g_created[0].state, "active");
+   g_ncreated = 1;
+
+   trigger_rule_t rule;
+   memset(&rule, 0, sizeof rule);
+   snprintf(rule.source, sizeof rule.source, "proposals");
+   snprintf(rule.workspace, sizeof rule.workspace, "/repo/aimee");
+   snprintf(rule.pipeline_template, sizeof rule.pipeline_template, "build");
+
+   scan_proposals(&rule, 1);
+   assert(g_ncreated == 2);
+   assert(strcmp(g_created[1].wf, "build") == 0);
+   assert(strcmp(g_created[1].mode, "autonomous") == 0);
+   assert(strstr(g_created[1].path, ".build.autonomous.md") != NULL);
+
+   /* The deterministic lane-scoped replacement deduplicates subsequent scans. */
+   scan_proposals(&rule, 1);
+   assert(g_ncreated == 2);
+   printf("  PASS: test_scan_proposals_supersedes_legacy_interactive_binding\n");
+}
+
 /* The trigger-source registry: rules dispatch by source name; a scanner source
  * is due on every pass, cron only on a schedule match, and an unknown source
  * is skipped (no registry row -> no fire). */
@@ -1186,10 +1277,12 @@ int main(void)
    test_scan_proposals_honors_explicit_mode();
    test_scan_proposals_requires_workspace_and_workflow();
    test_scan_proposals_custom_event_and_schedule();
+   test_scheduled_ref_refreshes_origin();
    test_scan_proposals_rejects_unsafe_ref_and_path();
    test_scan_proposals_notifies_scheduler();
    test_scan_proposals_applies_cost_cap();
    test_scan_proposals_enforces_max_concurrent();
+   test_scan_proposals_supersedes_legacy_interactive_binding();
    test_trigger_source_registry();
    test_proposal_name_matches();
    printf("All tests passed.\n");


### PR DESCRIPTION
Normal pending proposals could be starved indefinitely when legacy interactive trigger rows consumed the global autonomous admission cap. Their original blob-only dedup bindings also prevented the current autonomous lane from filing replacements, while scheduled scans could read a stale local branch.

This change:
- counts only active autonomous proposal runs against trigger.max_concurrent
- deterministically supersedes bindings created by a different workflow or mode
- fetches a safe configured branch into origin/<branch> before scanning, without touching the checkout
- adds regressions for legacy admission, deterministic dedup, and remote ref refresh

Validated locally with the trigger unit suite, trigger E2E (proposal -> autonomous run -> accepted, twice), clang-format Werror, diff checks, and a full production server build.