### PR TITLE
fix evidence replay oversized hit handling

### DIFF
--- a/src/headers/evidence_replay.h
+++ b/src/headers/evidence_replay.h
@@ -42,7 +42,9 @@ extern "C"
    } reduced_record_t;
 
    /* Index backend — defaults wrap the real index_*; tests inject a fake.
-    * Each find_* returns count >= 0, or -1 on DB/connection error.
+    * Each find_* returns the total count >= 0, or -1 on DB/connection error.
+    * A backend may return more than `max`, but writes at most the first `max`
+    * rows into `out`; replay preserves the total while hashing that bounded set.
     * project_count returns the number of indexed projects (0 => index empty). */
    typedef struct
    {

--- a/src/server/evidence_replay.c
+++ b/src/server/evidence_replay.c
@@ -203,6 +203,7 @@ replay_status_t evidence_replay_with(const replay_backend_t *be, const review_ev
       return REPLAY_INDEX_UNAVAILABLE;
 
    int n = -1;
+   int captured = 0;
    /* Collect file paths + lines for the idkey from whichever hit type applies. */
    char(*files)[MAX_PATH_LEN] = NULL;
    int *lines = NULL;
@@ -215,10 +216,11 @@ replay_status_t evidence_replay_with(const replay_backend_t *be, const review_ev
       n = be->find_symbol ? be->find_symbol(target, hits, REPLAY_MAX_HITS) : -1;
       if (n > 0)
       {
-         files = calloc((size_t)n, sizeof(*files));
-         lines = calloc((size_t)n, sizeof(*lines));
+         captured = n < REPLAY_MAX_HITS ? n : REPLAY_MAX_HITS;
+         files = calloc((size_t)captured, sizeof(*files));
+         lines = calloc((size_t)captured, sizeof(*lines));
          if (files && lines)
-            for (int i = 0; i < n; i++)
+            for (int i = 0; i < captured; i++)
             {
                snprintf(files[i], MAX_PATH_LEN, "%s", hits[i].file_path);
                lines[i] = hits[i].line;
@@ -234,10 +236,11 @@ replay_status_t evidence_replay_with(const replay_backend_t *be, const review_ev
       n = be->find_callers ? be->find_callers(project, target, hits, REPLAY_MAX_HITS) : -1;
       if (n > 0)
       {
-         files = calloc((size_t)n, sizeof(*files));
-         lines = calloc((size_t)n, sizeof(*lines));
+         captured = n < REPLAY_MAX_HITS ? n : REPLAY_MAX_HITS;
+         files = calloc((size_t)captured, sizeof(*files));
+         lines = calloc((size_t)captured, sizeof(*lines));
          if (files && lines)
-            for (int i = 0; i < n; i++)
+            for (int i = 0; i < captured; i++)
             {
                snprintf(files[i], MAX_PATH_LEN, "%s", hits[i].file_path);
                lines[i] = hits[i].line;
@@ -253,10 +256,11 @@ replay_status_t evidence_replay_with(const replay_backend_t *be, const review_ev
       n = be->code_search ? be->code_search(target, project, hits, REPLAY_MAX_HITS) : -1;
       if (n > 0)
       {
-         files = calloc((size_t)n, sizeof(*files));
-         lines = calloc((size_t)n, sizeof(*lines));
+         captured = n < REPLAY_MAX_HITS ? n : REPLAY_MAX_HITS;
+         files = calloc((size_t)captured, sizeof(*files));
+         lines = calloc((size_t)captured, sizeof(*lines));
          if (files && lines)
-            for (int i = 0; i < n; i++)
+            for (int i = 0; i < captured; i++)
             {
                snprintf(files[i], MAX_PATH_LEN, "%s", hits[i].file_path);
                lines[i] = 0; /* search hits are file-level; line 0 keeps the set stable */
@@ -278,7 +282,7 @@ replay_status_t evidence_replay_with(const replay_backend_t *be, const review_ev
 
    out->count = n;
    if (files && lines)
-      evidence_idkey((const char(*)[MAX_PATH_LEN])files, lines, n, out->idkey);
+      evidence_idkey((const char(*)[MAX_PATH_LEN])files, lines, captured, out->idkey);
    free(files);
    free(lines);
 

--- a/src/tests/test_evidence_replay.c
+++ b/src/tests/test_evidence_replay.c
@@ -221,6 +221,39 @@ static void test_symbol_dberror(void)
    assert(evidence_replay_with(&be, &ev, &r) == REPLAY_INDEX_UNAVAILABLE);
 }
 
+static void test_backend_total_larger_than_hit_buffer(void)
+{
+   replay_backend_t be = fake_backend();
+   review_evidence_t ev;
+   memset(&ev, 0, sizeof(ev));
+   reduced_record_t r;
+   g_pc = 1;
+
+   /* Worktree replay returns the true total while filling only the bounded
+    * output sink. The replay layer must preserve that count without reading
+    * beyond any of its three 256-entry hit buffers. */
+   ev.count = 300;
+
+   ev.kind = EV_SYMBOL;
+   snprintf(ev.target, sizeof(ev.target), "symbol");
+   g_symbol_ret = 300;
+   g_symbol_n = 300;
+   assert(evidence_replay_with(&be, &ev, &r) == REPLAY_MATCH);
+   assert(r.count == 300 && strlen(r.idkey) == 64);
+
+   ev.kind = EV_REFS;
+   g_caller_ret = 300;
+   g_caller_n = 300;
+   assert(evidence_replay_with(&be, &ev, &r) == REPLAY_MATCH);
+   assert(r.count == 300 && strlen(r.idkey) == 64);
+
+   ev.kind = EV_SEARCH;
+   g_search_ret = 300;
+   g_search_n = 300;
+   assert(evidence_replay_with(&be, &ev, &r) == REPLAY_MATCH);
+   assert(r.count == 300 && strlen(r.idkey) == 64);
+}
+
 static void test_claimed_idkey_match_and_mismatch(void)
 {
    replay_backend_t be = fake_backend();
@@ -294,6 +327,7 @@ int main(void)
    test_symbol_exists_or_not();
    test_search_positive_and_dberror();
    test_symbol_dberror();
+   test_backend_total_larger_than_hit_buffer();
    test_claimed_idkey_match_and_mismatch();
    test_idkey_cap_and_dedup();
    test_no_backend_degrades();


### PR DESCRIPTION
## What changed

- Bound all evidence-replay row copies to the 256-entry hit buffers.
- Preserve the backend's true total count while hashing only the safely captured rows.
- Document the backend contract and cover oversized symbol, caller, and search results.

## Root cause

The worktree replay backend intentionally returns the true match count while writing at most `max` rows. `evidence_replay_with()` treated that total as the number of initialized rows. Under WFE load, a lexical query returned 1,602 matches into a 256-entry buffer; replay then read result 871 and crashed in `snprintf`/`strlen`.

A production core from the `.254` appliance confirmed `n = 1602` and loop index `871` at the crash site.

## Impact

Large evidence queries now remain bounded and deterministic instead of reading beyond the hit buffer and terminating `aimee-server`. This removes the recurring crash that abandoned autonomous proposal runs.

## Validation

- evidence replay unit suite
- WFE worktree replay integration suite
- AddressSanitizer regression run
- clang-format 19 dry run with `-Werror`
- full `aimee-server` build
