### PR TITLE
guard optional runtime role in schema upgrade

### DIFF
--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -4872,7 +4872,11 @@ BEGIN
        'public.org_catalog_bedrock_upsert(text,text,text,text,text,text,text,text[],text[],text,boolean)')
      IS NOT NULL THEN
     EXECUTE 'REVOKE ALL ON FUNCTION public.org_catalog_bedrock_upsert(text,text,text,text,text,text,text,text[],text[],text,boolean) FROM PUBLIC';
-    EXECUTE 'REVOKE ALL ON FUNCTION public.org_catalog_bedrock_upsert(text,text,text,text,text,text,text,text[],text[],text,boolean) FROM aimee_kb_runtime';
+    -- The runtime role is deliberately absent on dev/single-user tiers. Keep
+    -- this upgrade path idempotent there, just like schema_grants.sql.
+    IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'aimee_kb_runtime') THEN
+      EXECUTE 'REVOKE ALL ON FUNCTION public.org_catalog_bedrock_upsert(text,text,text,text,text,text,text,text[],text[],text,boolean) FROM aimee_kb_runtime';
+    END IF;
     EXECUTE 'DROP FUNCTION public.org_catalog_bedrock_upsert(text,text,text,text,text,text,text,text[],text[],text,boolean)';
   END IF;
 END $drop_obsolete_bedrock_upsert$;

--- a/src/tests/test_schema_subst.c
+++ b/src/tests/test_schema_subst.c
@@ -145,6 +145,24 @@ static void test_all_columns_substituted(void)
    assert(count >= 5);
 }
 
+/* Optional runtime roles must never make owner-schema upgrades fail on the
+ * single-user/dev tier. Pin the guard around the obsolete function's REVOKE;
+ * PostgreSQL errors on REVOKE ... FROM a role that does not exist. */
+static void test_optional_runtime_role_is_guarded(void)
+{
+   const char *sql = apply_with_dim(1024);
+   const char *block = strstr(sql, "DO $drop_obsolete_bedrock_upsert$");
+   assert(block != NULL);
+   const char *guard = strstr(
+       block,
+       "IF EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'aimee_kb_runtime') THEN");
+   const char *revoke =
+       strstr(block, "REVOKE ALL ON FUNCTION "
+                     "public.org_catalog_bedrock_upsert(text,text,text,text,text,text,text,text[],"
+                     "text[],text,boolean) FROM aimee_kb_runtime");
+   assert(guard != NULL && revoke != NULL && guard < revoke);
+}
+
 int main(void)
 {
    test_substitutes_explicit_dim();
@@ -152,6 +170,7 @@ int main(void)
    test_unset_falls_back_to_default();
    test_out_of_range_falls_back_to_default();
    test_all_columns_substituted();
+   test_optional_runtime_role_is_guarded();
    free(g_captured_sql);
    printf("schema_subst: all tests passed\n");
    return 0;


### PR DESCRIPTION
## What changed

- Guard the obsolete Bedrock catalog function's runtime-role `REVOKE` with a PostgreSQL role-existence check.
- Add a generated-schema regression assertion that pins the guard before the `REVOKE`.

## Root cause

`aimee_kb_runtime` is intentionally optional on dev/single-user tiers, and `schema_grants.sql` already skips grants when it is absent. One older-function cleanup block in `schema.sql` unconditionally issued `REVOKE ... FROM aimee_kb_runtime`. PostgreSQL treats a missing grantee role as an error, aborting the entire schema apply and leaving aimee-kb in its startup retry loop.

This reproduced on the `.254` appliance after the KB plugin restart.

## Impact

KB schema upgrades remain idempotent on tiers without a separate runtime role. Existing hardened tiers retain the same revoke behavior.

## Validation

- `unit-test-schema-subst`
- clang-format 19 dry run with `-Werror`
- generated-schema guard ordering regression
