### PR TITLE
fix: own abandoned parallel worker inputs

### DIFF
--- a/src/server/agent_parallel.c
+++ b/src/server/agent_parallel.c
@@ -38,7 +38,51 @@ typedef struct
     * straggler can be abandoned without blocking the join. */
    parallel_sync_t *sync;
    int *done;
+   /* A deadline-bounded caller may return while this worker is still running.
+    * In that path the worker must not retain any caller-owned pointers: the
+    * roundtable's task array is on its stack and its prompt/persona strings are
+    * freed as soon as the barrier returns. */
+   agent_config_t cfg_owned;
+   agent_task_t task_owned;
+   int owns_inputs;
 } parallel_ctx_t;
+
+static void parallel_ctx_release_inputs(parallel_ctx_t *ctx)
+{
+   if (!ctx || !ctx->owns_inputs)
+      return;
+   free((char *)ctx->task_owned.role);
+   free((char *)ctx->task_owned.system_prompt);
+   free((char *)ctx->task_owned.user_prompt);
+   free((char *)ctx->task_owned.agent);
+   memset(&ctx->task_owned, 0, sizeof(ctx->task_owned));
+   ctx->owns_inputs = 0;
+}
+
+static int parallel_ctx_own_inputs(parallel_ctx_t *ctx, const agent_config_t *cfg,
+                                   const agent_task_t *task)
+{
+   if (!ctx || !cfg || !task)
+      return -1;
+   ctx->cfg_owned = *cfg;
+   ctx->task_owned = *task;
+   ctx->task_owned.role = task->role ? strdup(task->role) : NULL;
+   ctx->task_owned.system_prompt = task->system_prompt ? strdup(task->system_prompt) : NULL;
+   ctx->task_owned.user_prompt = task->user_prompt ? strdup(task->user_prompt) : NULL;
+   ctx->task_owned.agent = task->agent ? strdup(task->agent) : NULL;
+   ctx->owns_inputs = 1;
+   if ((task->role && !ctx->task_owned.role) ||
+       (task->system_prompt && !ctx->task_owned.system_prompt) ||
+       (task->user_prompt && !ctx->task_owned.user_prompt) ||
+       (task->agent && !ctx->task_owned.agent))
+   {
+      parallel_ctx_release_inputs(ctx);
+      return -1;
+   }
+   ctx->cfg = &ctx->cfg_owned;
+   ctx->task = &ctx->task_owned;
+   return 0;
+}
 
 static void *parallel_worker(void *arg)
 {
@@ -60,6 +104,7 @@ static void *parallel_worker(void *arg)
    else
       agent_run_ex(ctx->cfg, ctx->task->role, ctx->task->system_prompt, ctx->task->user_prompt,
                    ctx->task->max_tokens, temp, ctx->result);
+   parallel_ctx_release_inputs(ctx);
    if (ctx->sync)
    {
       pthread_mutex_lock(&ctx->sync->mtx);
@@ -125,8 +170,12 @@ static int run_parallel_deadline(agent_config_t *cfg, agent_task_t *tasks, int t
       cells[i] = calloc(1, sizeof(agent_result_t));
       if (!cells[i])
          continue; /* slot stays a failed result; never spawned */
-      ctxs[i].cfg = cfg;
-      ctxs[i].task = &tasks[i];
+      if (parallel_ctx_own_inputs(&ctxs[i], cfg, &tasks[i]) != 0)
+      {
+         free(cells[i]);
+         cells[i] = NULL;
+         continue;
+      }
       ctxs[i].result = cells[i];
       ctxs[i].creds = creds;
       ctxs[i].sync = sync;
@@ -138,6 +187,7 @@ static int run_parallel_deadline(agent_config_t *cfg, agent_task_t *tasks, int t
       }
       else
       {
+         parallel_ctx_release_inputs(&ctxs[i]);
          free(cells[i]);
          cells[i] = NULL;
       }

--- a/src/tests/test_agent_parallel.c
+++ b/src/tests/test_agent_parallel.c
@@ -5,6 +5,7 @@
 #include "agent_config.h"
 #include "agent_exec.h"
 #include <assert.h>
+#include <stdatomic.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,6 +38,7 @@ static void sleep_ms(int ms)
    struct timespec ts = {ms / 1000, (long)(ms % 1000) * 1000000L};
    nanosleep(&ts, NULL);
 }
+static atomic_int g_slow_inputs_intact;
 int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
                     const char *system_prompt, const char *user_prompt, int max_tokens,
                     double temperature, agent_result_t *out)
@@ -49,7 +51,14 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    (void)temperature;
    memset(out, 0, sizeof(*out));
    if (name && strcmp(name, "slow") == 0)
+   {
       sleep_ms(3000);
+      atomic_store(&g_slow_inputs_intact, strcmp(name, "slow") == 0 &&
+                                              strcmp(role, "review") == 0 &&
+                                              strcmp(system_prompt, "system-owned") == 0 &&
+                                              strcmp(user_prompt, "prompt-owned") == 0 &&
+                                              strcmp(cfg->default_agent, "config-owned") == 0);
+   }
    out->response = strdup("ok");
    out->success = 1;
    snprintf(out->agent_name, sizeof(out->agent_name), "%s", name ? name : "");
@@ -117,14 +126,23 @@ static void test_deadline_abandons_hung_worker(void)
    memset(tasks, 0, sizeof(tasks));
    tasks[0].agent = "fast0";
    tasks[0].role = "review";
-   tasks[1].agent = "slow";
-   tasks[1].role = "review";
+   char *slow_name = strdup("slow");
+   char *slow_role = strdup("review");
+   char *slow_system = strdup("system-owned");
+   char *slow_prompt = strdup("prompt-owned");
+   assert(slow_name && slow_role && slow_system && slow_prompt);
+   tasks[1].agent = slow_name;
+   tasks[1].role = slow_role;
+   tasks[1].system_prompt = slow_system;
+   tasks[1].user_prompt = slow_prompt;
    tasks[2].agent = "fast2";
    tasks[2].role = "review";
    agent_result_t out[3];
    memset(out, 0, sizeof(out));
    agent_config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
+   snprintf(cfg.default_agent, sizeof(cfg.default_agent), "%s", "config-owned");
+   atomic_store(&g_slow_inputs_intact, 0);
 
    long t0 = now_ms();
    int succ = agent_run_parallel(&cfg, tasks, 3, out, 200 /* ms deadline */);
@@ -137,6 +155,22 @@ static void test_deadline_abandons_hung_worker(void)
    assert(out[2].success == 1 && out[2].response);
    assert(out[1].success == 0); /* slow worker abandoned -> failed slot */
    assert(out[1].response == NULL);
+   /* Returning at the deadline transfers every borrowed input to the detached
+    * worker. Mutating the caller's task strings and config must not affect the
+    * still-running call. The old implementation retained these pointers and
+    * crashed in strlen/vfprintf once the roundtable freed them. */
+   memset(slow_name, 'x', strlen(slow_name));
+   memset(slow_role, 'x', strlen(slow_role));
+   memset(slow_system, 'x', strlen(slow_system));
+   memset(slow_prompt, 'x', strlen(slow_prompt));
+   snprintf(cfg.default_agent, sizeof(cfg.default_agent), "%s", "mutated");
+   for (int i = 0; i < 40 && !atomic_load(&g_slow_inputs_intact); i++)
+      sleep_ms(100);
+   assert(atomic_load(&g_slow_inputs_intact) == 1);
+   free(slow_name);
+   free(slow_role);
+   free(slow_system);
+   free(slow_prompt);
    free(out[0].response);
    free(out[2].response);
    printf("  test_deadline_abandons_hung_worker: ok (%ldms, %d ok)\n", elapsed, succ);


### PR DESCRIPTION
## Problem

The deadline-bounded parallel runner detached slow workers while leaving them pointed at caller-owned stack tasks, prompt/persona strings, and configuration. Roundtable frees those inputs immediately after the deadline, so a late worker can dereference freed memory. Production cores show SIGSEGV in libc `strlen` from a `%s` formatting path during panel completion.

## Fix

- give every deadline-path worker a private task, strings, and configuration snapshot
- release owned strings in the worker before signaling completion
- preserve the existing private result-cell behavior for abandoned workers
- extend the deadline regression to mutate caller inputs after return and wait for the detached worker to validate its private copies

## Validation

- `make -C src build/obj/tests/unit-test-agent-parallel`
- `./src/build/obj/tests/unit-test-agent-parallel`
- same test under AddressSanitizer
- `make -C src lint`
