### PR TITLE
fix(agent): route unpinned work across eligible peers

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -74,8 +74,8 @@ void agent_set_route_health_filter(int (*fn)(const char *agent_name));
  *   flag unreachable for a claude-oauth-as-primary box (the OAuth flow names
  *   the agent "claude", which then equals config.provider), so `primary_only`
  *   is now the sole per-agent gate and unchecking it opts the primary into
- *   self-delegation. Roundtable panels keep their own primary exclusion
- *   (delegate_ensemble.c) so a panel second opinion is never the primary.
+ *   self-delegation. Roundtable panels use explicit role-based eligibility
+ *   (delegate_ensemble.c), with no identity-based exclusion of the primary.
  * The structural rule — a claude-CLI agent that is not server-hosted can never
  * execute as a delegate — is enforced unconditionally in
  * agent_is_available_for_routing, so even filter-less builds (CLI/tests) never

--- a/src/modules/roundtable/delegate_ensemble.c
+++ b/src/modules/roundtable/delegate_ensemble.c
@@ -1266,21 +1266,19 @@ static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const
  * burn a slot on a "failed to build request URL" participant; server-hosting is
  * capability, primary_only is authorization, so both must pass. So a
  * primary-only or disabled claude is never seated, even after a server-side
- * OAuth setup. Other enabled agents are eligible.
+ * OAuth setup. Other enabled agents with the review role are eligible.
  *
- * The PRIMARY agent is also never seated: a roundtable exists for an INDEPENDENT
- * second opinion, so the model the operator runs as primary (config.provider)
- * must not sit on — or aggregate — its own review panel and quietly grade its own
- * work. Any agent that resolves to the primary provider (by agent name — the
- * primary passthrough is named after the provider — or by its provider tag) is
- * excluded, structurally, regardless of what ensemble.reference_models lists. */
+ * Role membership is the operator's inclusion policy.  There is deliberately no
+ * implicit "primary provider" exclusion: if an enabled agent has the review role
+ * and is not marked primary_only, it is a valid unpinned panelist.  Operators
+ * exclude it by removing the role, disabling it, or setting primary_only. */
 int ensemble_panelist_eligible(const config_t *cfg, const agent_t *ag)
 {
+   (void)cfg;
    if (!ag || !ag->enabled || !ag->name[0])
       return 0;
-   if (cfg->provider[0] && (strcasecmp(ag->name, cfg->provider) == 0 ||
-                            (ag->provider[0] && strcasecmp(ag->provider, cfg->provider) == 0)))
-      return 0; /* the primary must never sit on its own panel */
+   if (!agent_has_role(ag, "review") && !agent_is_exec_role(ag, "review"))
+      return 0;
    if (ag->primary_only)
       return 0;
    if (agent_is_claude_cli(ag) && !ag->is_server_hosted)
@@ -1382,13 +1380,14 @@ void ensemble_filter_panel_authorization(config_t *cfg, const agent_config_t *ac
     * ensemble.reference_models list: drop any entry that names a configured agent
     * which is not panel-eligible (an unauthorized / disabled / client-only
     * claude). An entry that is not a configured agent (an ad-hoc model id) is
-    * left as-is. Keeps reference_models and the aggregator consistent. */
+    * dropped: a positive pin must name a configured, eligible agent. Keeps
+    * reference_models and the aggregator consistent. */
    int n = 0;
    for (int i = 0; i < cfg->ensemble_reference_count; i++)
    {
       const char *name = cfg->ensemble_reference_models[i];
       const agent_t *ag = agent_find((agent_config_t *)acfg, name);
-      if (ag && !ensemble_panelist_eligible(cfg, ag))
+      if (!ag || !ensemble_panelist_eligible(cfg, ag))
       {
          aimee_log(LOG_WARN, "delegate.panel",
                    "dropping unauthorized panelist '%s' from the roundtable panel", name);
@@ -1404,7 +1403,7 @@ void ensemble_filter_panel_authorization(config_t *cfg, const agent_config_t *ac
    if (cfg->ensemble_aggregator[0])
    {
       const agent_t *agg = agent_find((agent_config_t *)acfg, cfg->ensemble_aggregator);
-      if (agg && !ensemble_panelist_eligible(cfg, agg))
+      if (!agg || !ensemble_panelist_eligible(cfg, agg))
          cfg->ensemble_aggregator[0] = '\0';
    }
    if (!cfg->ensemble_aggregator[0] && n > 0)
@@ -1420,14 +1419,15 @@ void ensemble_filter_panel_availability(config_t *cfg, const agent_config_t *acf
     * breaker marked DOWN. Otherwise it burns a panel seat on a guaranteed-to-fail
     * participant and silently degrades the round (the bug that left a roundtable
     * "2/3 participants failed" with unkeyed models in the list). An ad-hoc model
-    * id that is not a configured agent is left as-is (we cannot check it). Same
-    * predicate single-delegate routing uses: agent_is_available_for_routing. */
+    * id that is not a configured agent is dropped: pins never create shadow
+    * agents outside agents.json. Same predicate single-delegate routing uses:
+    * agent_is_available_for_routing. */
    int n = 0;
    for (int i = 0; i < cfg->ensemble_reference_count; i++)
    {
       const char *name = cfg->ensemble_reference_models[i];
       const agent_t *ag = agent_find((agent_config_t *)acfg, name);
-      if (ag && !agent_is_available_for_routing(ag))
+      if (!ag || !agent_is_available_for_routing(ag))
       {
          aimee_log(LOG_WARN, "delegate.panel",
                    "dropping unavailable panelist '%s' (no key / unhealthy / command missing)",
@@ -1443,7 +1443,7 @@ void ensemble_filter_panel_availability(config_t *cfg, const agent_config_t *acf
    if (cfg->ensemble_aggregator[0])
    {
       const agent_t *agg = agent_find((agent_config_t *)acfg, cfg->ensemble_aggregator);
-      if (agg && !agent_is_available_for_routing(agg))
+      if (!agg || !agent_is_available_for_routing(agg))
          cfg->ensemble_aggregator[0] = '\0';
    }
    if (!cfg->ensemble_aggregator[0] && n > 0)

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1587,18 +1587,20 @@ agent_t *agent_default_primary(agent_config_t *cfg)
    return NULL;
 }
 
-/* Pick randomly from an array of candidates using monotonic-clock nanoseconds.
- * Thread-safe: no shared mutable state. */
-static agent_t *agent_pick_random(agent_t **candidates, int count)
+/* Pick fairly from an array of equally eligible candidates.  `default_agent` is
+ * the primary-session default, not a hidden delegate pin: letting it win every
+ * unpinned delegation starves every peer at the same tier.  A process-wide
+ * atomic cursor gives those peers round-robin opportunities while explicit
+ * --via pins continue to be handled before this function is reached. */
+static agent_t *agent_pick_balanced(agent_t **candidates, int count)
 {
+   static unsigned cursor;
    if (count <= 0)
       return NULL;
    if (count == 1)
       return candidates[0];
-   struct timespec _ts;
-   clock_gettime(CLOCK_MONOTONIC, &_ts);
-   unsigned int seed = (unsigned int)_ts.tv_nsec ^ (unsigned int)_ts.tv_sec;
-   return candidates[seed % (unsigned int)count];
+   unsigned pick = __atomic_fetch_add(&cursor, 1u, __ATOMIC_RELAXED);
+   return candidates[pick % (unsigned int)count];
 }
 
 int agent_is_claude_cli(const agent_t *agent)
@@ -1692,9 +1694,9 @@ int agent_pick_named_for_role(agent_config_t *cfg, const char *name, const char 
 
 agent_t *agent_route(agent_config_t *cfg, const char *role)
 {
-   agent_t *def = NULL;
-   if (cfg->default_agent[0])
-      def = agent_find(cfg, cfg->default_agent);
+   agent_t *primary_default = NULL;
+   if (agent_routing_primary_turn() && cfg->default_agent[0])
+      primary_default = agent_find(cfg, cfg->default_agent);
 
    /* First pass: find the minimum tier; note if any tmux agent is there
     * (tmux sessions are stateful and always preferred over HTTP peers). */
@@ -1728,21 +1730,17 @@ agent_t *agent_route(agent_config_t *cfg, const char *role)
          continue;
       if (has_tmux && strcmp(ag->backend, AGENT_BACKEND_TMUX_CLI) != 0)
          continue;
-      if (ag == def)
+      if (ag == primary_default)
          return ag;
       if (count < MAX_AGENTS)
          candidates[count++] = ag;
    }
-   return agent_pick_random(candidates, count);
+   return agent_pick_balanced(candidates, count);
 }
 
-/* Route to a randomly selected enabled agent at exactly the given cost_tier. */
+/* Route fairly among enabled agents at exactly the given cost_tier. */
 agent_t *agent_route_at_tier(agent_config_t *cfg, const char *role, int tier)
 {
-   agent_t *def = NULL;
-   if (cfg->default_agent[0])
-      def = agent_find(cfg, cfg->default_agent);
-
    agent_t *candidates[MAX_AGENTS];
    int count = 0;
    for (int i = 0; i < cfg->agent_count; i++)
@@ -1752,12 +1750,10 @@ agent_t *agent_route_at_tier(agent_config_t *cfg, const char *role, int tier)
          continue;
       if (role && !agent_supports_role(ag, role))
          continue;
-      if (ag == def)
-         return ag;
       if (count < MAX_AGENTS)
          candidates[count++] = ag;
    }
-   return agent_pick_random(candidates, count);
+   return agent_pick_balanced(candidates, count);
 }
 
 static int agent_satisfies_required_caps(const agent_t *ag, unsigned required_caps, int min_context)
@@ -1839,9 +1835,9 @@ static agent_t *agent_route_with_caps_inner(agent_config_t *cfg, const char *rol
    if (min_tier < 0)
       return NULL;
 
-   agent_t *def = NULL;
-   if (cfg->default_agent[0])
-      def = agent_find(cfg, cfg->default_agent);
+   agent_t *primary_default = NULL;
+   if (agent_routing_primary_turn() && cfg->default_agent[0])
+      primary_default = agent_find(cfg, cfg->default_agent);
 
    agent_t *candidates[MAX_AGENTS];
    int count = 0;
@@ -1861,12 +1857,12 @@ static agent_t *agent_route_with_caps_inner(agent_config_t *cfg, const char *rol
             continue;
       }
 
-      if (ag == def)
+      if (ag == primary_default)
          return ag;
       if (count < MAX_AGENTS)
          candidates[count++] = ag;
    }
-   return agent_pick_random(candidates, count);
+   return agent_pick_balanced(candidates, count);
 }
 
 agent_t *agent_route_with_caps(agent_config_t *cfg, const char *role, const config_t *sys_cfg,

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1925,9 +1925,9 @@ static int server_agent_route_is_down(const char *agent_name)
  * Only unchecked. Now the flag alone decides: a claude-oauth subscription is
  * pre-flagged primary-only at add time (driving a personal Claude plan as an
  * automated delegate may breach Anthropic's terms), and unchecking it is an
- * explicit operator opt-in to self-delegation. Roundtable panels keep their own
- * primary exclusion (delegate_ensemble.c) so a second opinion is never the
- * primary itself.
+ * explicit operator opt-in to self-delegation. Roundtable panels use this same
+ * explicit agent policy plus review-role membership; they do not invent a
+ * second hidden exclusion based on the configured primary provider.
  * The gate is config-independent (it reads the agent record), so it holds even
  * when config_load would fail. */
 static int server_agent_route_policy_excluded(const agent_t *ag)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -210,8 +210,10 @@ static void test_agent_route_policy_filter(void)
    cfg.agents[1].cost_tier = 1;
    cfg.agents[1].enabled = 1;
 
-   /* Baseline: the default agent is preferred. */
+   /* The default is a primary-session preference, not an unpinned delegate pin. */
+   agent_routing_set_primary_turn(1);
    assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
+   agent_routing_set_primary_turn(0);
 
    /* With the policy filter registered, the excluded agent is unroutable
     * EVERYWHERE — including as the preferred default — and routing falls back
@@ -220,7 +222,7 @@ static void test_agent_route_policy_filter(void)
    assert(agent_is_available_for_routing(&cfg.agents[0]) == 0);
    assert(agent_route(&cfg, "summarize") == &cfg.agents[1]);
    agent_set_route_policy_filter(NULL);
-   assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
+   assert(agent_route(&cfg, "summarize") == &cfg.agents[0]); /* sole cheapest peer */
 }
 
 /* The server's live predicate consults agent_routing_primary_turn() so the
@@ -379,7 +381,13 @@ static void test_agent_route(void)
    cfg.agents[1].enabled = 1;
    assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
    cfg.agents[1].cost_tier = 0;
+   /* Equal eligible peers are both used despite an explicit primary default. */
+   agent_t *first = agent_route(&cfg, "summarize");
+   agent_t *second = agent_route(&cfg, "summarize");
+   assert(first != NULL && second != NULL && first != second);
+   agent_routing_set_primary_turn(1);
    assert(agent_route(&cfg, "summarize") == &cfg.agents[1]);
+   agent_routing_set_primary_turn(0);
    memset(&cfg, 0, sizeof(cfg));
    cfg.agent_count = 2;
    strcpy(cfg.agents[0].name, "missing-cli");

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -273,6 +273,24 @@ agent_t *agent_find(agent_config_t *cfg, const char *name)
          return &cfg->agents[i];
    return NULL;
 }
+int agent_has_role(const agent_t *agent, const char *role)
+{
+   if (!agent || !role)
+      return 0;
+   for (int i = 0; i < agent->role_count; i++)
+      if (strcmp(agent->roles[i], role) == 0 || strcmp(agent->roles[i], "all") == 0)
+         return 1;
+   return 0;
+}
+int agent_is_exec_role(const agent_t *agent, const char *role)
+{
+   if (!agent || !role)
+      return 0;
+   for (int i = 0; i < agent->exec_role_count; i++)
+      if (strcmp(agent->exec_roles[i], role) == 0 || strcmp(agent->exec_roles[i], "all") == 0)
+         return 1;
+   return 0;
+}
 /* Stub: treat the agent literally named "claude" as the CLI-only agent. */
 int agent_is_claude_cli(const agent_t *agent)
 {
@@ -902,15 +920,26 @@ static void test_default_panel_excludes_claude_cli(void)
 {
    agent_config_t acfg;
    memset(&acfg, 0, sizeof(acfg));
-   acfg.agent_count = 3;
+   acfg.agent_count = 4;
    acfg.agents[0].enabled = 1;
    snprintf(acfg.agents[0].name, MAX_AGENT_NAME, "mistral");
+   snprintf(acfg.agents[0].roles[0], sizeof(acfg.agents[0].roles[0]), "review");
+   acfg.agents[0].role_count = 1;
    acfg.agents[1].enabled = 1;
    snprintf(acfg.agents[1].name, MAX_AGENT_NAME, "claude"); /* CLI-only per stub */
+   snprintf(acfg.agents[1].roles[0], sizeof(acfg.agents[1].roles[0]), "review");
+   acfg.agents[1].role_count = 1;
    acfg.agents[2].enabled = 1;
    snprintf(acfg.agents[2].name, MAX_AGENT_NAME, "codex");
+   snprintf(acfg.agents[2].roles[0], sizeof(acfg.agents[2].roles[0]), "review");
+   acfg.agents[2].role_count = 1;
+   acfg.agents[3].enabled = 1;
+   snprintf(acfg.agents[3].name, MAX_AGENT_NAME, "code-only");
+   snprintf(acfg.agents[3].roles[0], sizeof(acfg.agents[3].roles[0]), "code");
+   acfg.agents[3].role_count = 1;
 
-   /* default: claude-CLI is skipped, aggregator defaults to the first seated */
+   /* default: claude-CLI and the enabled-but-wrong-role agent are skipped;
+    * aggregator defaults to the first seated. */
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
    ensemble_default_panel_from_agents(&cfg, &acfg);
@@ -976,22 +1005,25 @@ static void test_panel_filter_drops_unauthorized_claude(void)
    acfg.agent_count = 2;
    acfg.agents[0].enabled = 1;
    snprintf(acfg.agents[0].name, MAX_AGENT_NAME, "mistral");
+   snprintf(acfg.agents[0].roles[0], sizeof(acfg.agents[0].roles[0]), "review");
+   acfg.agents[0].role_count = 1;
    acfg.agents[1].enabled = 1;
    snprintf(acfg.agents[1].name, MAX_AGENT_NAME, "claude"); /* claude-CLI per stub */
+   snprintf(acfg.agents[1].roles[0], sizeof(acfg.agents[1].roles[0]), "review");
+   acfg.agents[1].role_count = 1;
 
-   /* An EXPLICIT reference_models list naming an unauthorized claude drops it,
-    * keeps an ad-hoc (non-agent) model id, and repoints the aggregator. */
+   /* A positive pin must name a configured eligible agent. Unauthorized and
+    * ad-hoc names are both dropped, and the aggregator is repointed. */
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
    cfg.ensemble_reference_count = 3;
    snprintf(cfg.ensemble_reference_models[0], 128, "mistral");
    snprintf(cfg.ensemble_reference_models[1], 128, "claude");
-   snprintf(cfg.ensemble_reference_models[2], 128, "adhoc-model"); /* not an agent -> kept */
+   snprintf(cfg.ensemble_reference_models[2], 128, "adhoc-model"); /* not an agent -> dropped */
    snprintf(cfg.ensemble_aggregator, sizeof(cfg.ensemble_aggregator), "claude");
    ensemble_filter_panel_authorization(&cfg, &acfg);
-   assert(cfg.ensemble_reference_count == 2);
+   assert(cfg.ensemble_reference_count == 1);
    assert(strcmp(cfg.ensemble_reference_models[0], "mistral") == 0);
-   assert(strcmp(cfg.ensemble_reference_models[1], "adhoc-model") == 0);
    assert(strcmp(cfg.ensemble_aggregator, "mistral") == 0); /* repointed off the dropped claude */
 
    /* Authorized (primary_only=0) + server-hosted claude survives the
@@ -1008,66 +1040,66 @@ static void test_panel_filter_drops_unauthorized_claude(void)
    printf("  test_panel_filter_drops_unauthorized_claude: ok\n");
 }
 
-static void test_panel_excludes_primary(void)
+static void test_panel_does_not_implicitly_exclude_primary(void)
 {
-   /* The PRIMARY agent (config.provider) is never seated on — nor allowed to
-    * aggregate — its own review panel, even when it is an authorized,
-    * server-hosted claude that would otherwise pass the claude-CLI gate. Matched
-    * by agent name (the primary passthrough is named after the provider) or by
-    * the agent's provider tag. */
+   /* Primary-provider identity is not a hidden negative roster. If the agents
+    * are enabled, review-capable, and not primary_only, they remain eligible. */
    agent_config_t acfg;
    memset(&acfg, 0, sizeof(acfg));
    acfg.agent_count = 3;
    acfg.agents[0].enabled = 1;
    snprintf(acfg.agents[0].name, MAX_AGENT_NAME, "codex");
    snprintf(acfg.agents[0].provider, sizeof(acfg.agents[0].provider), "openai");
+   snprintf(acfg.agents[0].roles[0], sizeof(acfg.agents[0].roles[0]), "review");
+   acfg.agents[0].role_count = 1;
    acfg.agents[1].enabled = 1;
    acfg.agents[1].is_server_hosted = 1; /* would otherwise be an authorized claude */
    snprintf(acfg.agents[1].name, MAX_AGENT_NAME, "claude"); /* the primary passthrough */
+   snprintf(acfg.agents[1].roles[0], sizeof(acfg.agents[1].roles[0]), "review");
+   acfg.agents[1].role_count = 1;
    acfg.agents[2].enabled = 1;
    snprintf(acfg.agents[2].name, MAX_AGENT_NAME, "claude-api"); /* different name ... */
    snprintf(acfg.agents[2].provider, sizeof(acfg.agents[2].provider),
             "claude"); /* ... primary provider */
+   snprintf(acfg.agents[2].roles[0], sizeof(acfg.agents[2].roles[0]), "review");
+   acfg.agents[2].role_count = 1;
 
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
-   /* claude is authorized by default (primary_only=0); the point of this test is
-    * that the PRIMARY exclusion still applies regardless. */
+   /* claude is authorized by default (primary_only=0). */
    snprintf(cfg.provider, sizeof(cfg.provider), "claude"); /* PRIMARY = claude */
 
    /* per-agent predicate */
    assert(ensemble_panelist_eligible(&cfg, &acfg.agents[0]) == 1); /* codex/openai — seated */
-   assert(ensemble_panelist_eligible(&cfg, &acfg.agents[1]) == 0); /* claude by name — excluded */
-   assert(ensemble_panelist_eligible(&cfg, &acfg.agents[2]) ==
-          0); /* claude by provider — excluded */
+   assert(ensemble_panelist_eligible(&cfg, &acfg.agents[1]) == 1);
+   assert(ensemble_panelist_eligible(&cfg, &acfg.agents[2]) == 1);
 
-   /* explicit reference_models: both primary-provider seats dropped, aggregator repointed */
+   /* Explicit positive pins remain intact. */
    cfg.ensemble_reference_count = 3;
    snprintf(cfg.ensemble_reference_models[0], 128, "codex");
    snprintf(cfg.ensemble_reference_models[1], 128, "claude");
    snprintf(cfg.ensemble_reference_models[2], 128, "claude-api");
    snprintf(cfg.ensemble_aggregator, sizeof(cfg.ensemble_aggregator), "claude");
    ensemble_filter_panel_authorization(&cfg, &acfg);
-   assert(cfg.ensemble_reference_count == 1);
+   assert(cfg.ensemble_reference_count == 3);
    assert(strcmp(cfg.ensemble_reference_models[0], "codex") == 0);
-   assert(strcmp(cfg.ensemble_aggregator, "codex") == 0); /* repointed off the primary */
+   assert(strcmp(cfg.ensemble_aggregator, "claude") == 0);
 
-   /* seeding from enabled agents also never seats the primary */
+   /* Unpinned seeding includes every eligible review agent. */
    config_t seed_cfg;
    memset(&seed_cfg, 0, sizeof(seed_cfg));
    snprintf(seed_cfg.provider, sizeof(seed_cfg.provider), "claude");
    ensemble_default_panel_from_agents(&seed_cfg, &acfg);
-   assert(seed_cfg.ensemble_reference_count == 1); /* only codex */
+   assert(seed_cfg.ensemble_reference_count == 3);
    assert(strcmp(seed_cfg.ensemble_reference_models[0], "codex") == 0);
 
-   printf("  test_panel_excludes_primary: ok\n");
+   printf("  test_panel_does_not_implicitly_exclude_primary: ok\n");
 }
 
 static void test_panel_filter_drops_unavailable(void)
 {
-   /* A configured panelist that is enabled but NOT runtime-usable (a bearer HTTP
-    * agent with no resolvable key) is dropped so it can't degrade the round; an
-    * ad-hoc model id that names no configured agent is left as-is. */
+   /* A configured panelist that is enabled but NOT runtime-usable is dropped;
+    * an ad-hoc name is not a configured agent and is dropped too. */
    agent_config_t acfg;
    memset(&acfg, 0, sizeof(acfg));
    acfg.agent_count = 1;
@@ -1079,12 +1111,11 @@ static void test_panel_filter_drops_unavailable(void)
    memset(&cfg, 0, sizeof(cfg));
    cfg.ensemble_reference_count = 2;
    snprintf(cfg.ensemble_reference_models[0], 128, "unkeyed");     /* configured + no key -> drop */
-   snprintf(cfg.ensemble_reference_models[1], 128, "adhoc-model"); /* not an agent -> kept */
+   snprintf(cfg.ensemble_reference_models[1], 128, "adhoc-model"); /* not an agent -> dropped */
    snprintf(cfg.ensemble_aggregator, sizeof(cfg.ensemble_aggregator), "unkeyed");
    ensemble_filter_panel_availability(&cfg, &acfg);
-   assert(cfg.ensemble_reference_count == 1);
-   assert(strcmp(cfg.ensemble_reference_models[0], "adhoc-model") == 0);
-   assert(strcmp(cfg.ensemble_aggregator, "adhoc-model") == 0); /* repointed off the dropped seat */
+   assert(cfg.ensemble_reference_count == 0);
+   assert(cfg.ensemble_aggregator[0] == '\0');
    printf("  test_panel_filter_drops_unavailable: ok\n");
 }
 
@@ -1520,7 +1551,7 @@ int main(void)
    test_roundtable_review_brief_and_items_return();
    test_default_panel_excludes_claude_cli();
    test_panel_filter_drops_unauthorized_claude();
-   test_panel_excludes_primary();
+   test_panel_does_not_implicitly_exclude_primary();
    test_panel_filter_drops_unavailable();
    test_panel_persona_name_assignment();
    test_roundtable_review_assigns_personas();


### PR DESCRIPTION
## Summary
- balance ordinary unpinned delegation across equally eligible same-tier agents instead of always selecting `default_agent`
- make roundtable eligibility depend on enabled state, review role, and explicit authorization—not implicit primary-provider identity exclusion
- preserve positive agent pins exactly, while requiring them to name a configured eligible agent
- retain `default_agent` as the primary-session preference only

## Why
The testing appliance had Kimi enabled with the correct roles, but ordinary delegates were monopolized by the default MiniMax agent and the live roundtable roster was explicitly pinned to MiniMax/Codex. Provider quota failures already recover through the health-breaker cooldown, so permanently excluding a provider was not the issue.

## GUI behavior
Existing Roundtable preset seats already display a literal pinned agent name, or `$random` for an unpinned role-eligible seat. This behavior is preserved.

## Verification
- full `make -C src -j4`
- `unit-test-agent`
- `unit-test-delegate-ensemble`
- `unit-test-provider-catalog` (including DOWN -> cooldown probe -> healthy)
- repository verify: 2 passed, 0 failed
- `git diff --check`
