### PR TITLE
fix: recover coordinator tasks after server restart

### DIFF
--- a/src/db1/coord_jobs.c
+++ b/src/db1/coord_jobs.c
@@ -265,6 +265,38 @@ static int task_update_and_refresh(int task_id, const char *sql, const char *val
    return 0;
 }
 
+static int task_update_and_refresh_owned(int task_id, const char *claimed_by, const char *sql,
+                                         const char *value)
+{
+   if (task_id <= 0 || !claimed_by || !claimed_by[0])
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+
+   sqlite3_stmt *stmt = NULL;
+   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(stmt, 1, value ? value : "", -1, SQLITE_TRANSIENT);
+   sqlite3_bind_int(stmt, 2, task_id);
+   sqlite3_bind_text(stmt, 3, claimed_by, -1, SQLITE_TRANSIENT);
+   if (sqlite3_step(stmt) != SQLITE_DONE || sqlite3_changes(db) == 0)
+   {
+      sqlite3_finalize(stmt);
+      return -1;
+   }
+   sqlite3_finalize(stmt);
+
+   static const char *jid_sql = "SELECT job_id FROM coord_job_tasks WHERE id = ?";
+   if (sqlite3_prepare_v2(db, jid_sql, -1, &stmt, NULL) != SQLITE_OK)
+      return 0;
+   sqlite3_bind_int(stmt, 1, task_id);
+   if (sqlite3_step(stmt) == SQLITE_ROW)
+      (void)db1_coord_job_refresh_status(sqlite3_column_int(stmt, 0));
+   sqlite3_finalize(stmt);
+   return 0;
+}
+
 int db1_coord_job_complete_task(int task_id, const char *result)
 {
    static const char *sql = "UPDATE coord_job_tasks SET status = 'done',"
@@ -277,6 +309,22 @@ int db1_coord_job_fail_task(int task_id, const char *error)
    static const char *sql = "UPDATE coord_job_tasks SET status = 'failed',"
                             " error = ? WHERE id = ? AND status IN ('claimed', 'running')";
    return task_update_and_refresh(task_id, sql, error);
+}
+
+int db1_coord_job_complete_task_owned(int task_id, const char *claimed_by, const char *result)
+{
+   static const char *sql = "UPDATE coord_job_tasks SET status = 'done',"
+                            " result = ? WHERE id = ? AND claimed_by = ?"
+                            " AND status IN ('claimed', 'running')";
+   return task_update_and_refresh_owned(task_id, claimed_by, sql, result);
+}
+
+int db1_coord_job_fail_task_owned(int task_id, const char *claimed_by, const char *error)
+{
+   static const char *sql = "UPDATE coord_job_tasks SET status = 'failed',"
+                            " error = ? WHERE id = ? AND claimed_by = ?"
+                            " AND status IN ('claimed', 'running')";
+   return task_update_and_refresh_owned(task_id, claimed_by, sql, error);
 }
 
 int db1_coord_job_release_task(int task_id)
@@ -322,6 +370,94 @@ int db1_coord_job_release_task_bounded(int task_id, int max_requeues)
    int ok = (rc == SQLITE_DONE && sqlite3_changes(db) > 0) ? 0 : -1;
    sqlite3_finalize(stmt);
    return ok;
+}
+
+int db1_coord_job_release_task_bounded_owned(int task_id, const char *claimed_by, int max_requeues)
+{
+   if (task_id <= 0 || !claimed_by || !claimed_by[0] || max_requeues <= 0)
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+
+   sqlite3_stmt *stmt = NULL;
+   static const char *sql = "UPDATE coord_job_tasks SET status = 'pending',"
+                            " claimed_by = '', claimed_at = '', result = '', error = '',"
+                            " preempt_requeues = preempt_requeues + 1"
+                            " WHERE id = ? AND claimed_by = ?"
+                            " AND status IN ('claimed', 'running')"
+                            " AND preempt_requeues < ?";
+   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_int(stmt, 1, task_id);
+   sqlite3_bind_text(stmt, 2, claimed_by, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_int(stmt, 3, max_requeues);
+   int rc = sqlite3_step(stmt);
+   int ok = (rc == SQLITE_DONE && sqlite3_changes(db) > 0) ? 0 : -1;
+   sqlite3_finalize(stmt);
+   return ok;
+}
+
+int db1_coord_job_recover_owner(const char *claimed_by, int max_requeues, int *requeued_out,
+                                int *failed_out)
+{
+   if (!claimed_by || !claimed_by[0] || max_requeues <= 0)
+      return -1;
+   if (requeued_out)
+      *requeued_out = 0;
+   if (failed_out)
+      *failed_out = 0;
+
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+
+   int requeued = 0, failed = 0;
+   for (;;)
+   {
+      sqlite3_stmt *stmt = NULL;
+      static const char *sql = "SELECT t.id, t.preempt_requeues FROM coord_job_tasks t"
+                               " JOIN coord_jobs j ON j.id = t.job_id"
+                               " WHERE t.claimed_by = ? AND t.status IN ('claimed', 'running')"
+                               " AND j.status NOT IN ('cancelled', 'complete', 'failed') LIMIT 1";
+      if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+         return -1;
+      sqlite3_bind_text(stmt, 1, claimed_by, -1, SQLITE_TRANSIENT);
+      int step = sqlite3_step(stmt);
+      if (step == SQLITE_DONE)
+      {
+         sqlite3_finalize(stmt);
+         break;
+      }
+      if (step != SQLITE_ROW)
+      {
+         sqlite3_finalize(stmt);
+         return -1;
+      }
+      int task_id = sqlite3_column_int(stmt, 0);
+      int attempts = sqlite3_column_int(stmt, 1);
+      sqlite3_finalize(stmt);
+
+      if (attempts < max_requeues)
+      {
+         if (db1_coord_job_release_task_bounded_owned(task_id, claimed_by, max_requeues) != 0)
+            return -1;
+         requeued++;
+      }
+      else
+      {
+         if (db1_coord_job_fail_task_owned(
+                 task_id, claimed_by, "previous server exited; crash retry cap exhausted") != 0)
+            return -1;
+         failed++;
+      }
+   }
+
+   if (requeued_out)
+      *requeued_out = requeued;
+   if (failed_out)
+      *failed_out = failed;
+   return 0;
 }
 
 int db1_coord_job_get(int job_id, db1_coord_job_t *out)

--- a/src/db1/coord_jobs.h
+++ b/src/db1/coord_jobs.h
@@ -66,8 +66,18 @@ extern "C"
    int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_task_t *out);
    int db1_coord_job_complete_task(int task_id, const char *result);
    int db1_coord_job_fail_task(int task_id, const char *error);
+   /* Owner-fenced variants for durable workers. A completion/failure from an
+    * earlier claim attempt is rejected after the task has been requeued. */
+   int db1_coord_job_complete_task_owned(int task_id, const char *claimed_by, const char *result);
+   int db1_coord_job_fail_task_owned(int task_id, const char *claimed_by, const char *error);
    int db1_coord_job_release_task(int task_id);
    int db1_coord_job_release_task_bounded(int task_id, int max_requeues);
+   int db1_coord_job_release_task_bounded_owned(int task_id, const char *claimed_by,
+                                                int max_requeues);
+   /* Recover tasks owned by a dispatcher incarnation that can no longer exist.
+    * Claims below max_requeues return to pending; exhausted claims fail. */
+   int db1_coord_job_recover_owner(const char *claimed_by, int max_requeues, int *requeued_out,
+                                   int *failed_out);
    int db1_coord_job_get(int job_id, db1_coord_job_t *out);
    int db1_coord_job_list_tasks(int job_id, db1_coord_task_t *out, int max);
    int db1_coord_job_cancel(int job_id);

--- a/src/headers/server_compute_impl.h
+++ b/src/headers/server_compute_impl.h
@@ -4,6 +4,7 @@
 #define DEC_SERVER_COMPUTE_IMPL_H 1
 
 #include "aimee.h"
+#include "coord_jobs.h"
 #include "server.h"
 #include "cJSON.h"
 #include <pthread.h>
@@ -21,6 +22,7 @@ typedef struct
    int compute_executor_threads;
    int background_job_id;
    int coord_task_id; /* non-zero when this worker is executing a coord task */
+   char coord_claim_owner[DB1_COORD_DELEGATE_LEN]; /* fences stale coord-task completion */
    int async_slot;
    pthread_mutex_t *write_mutex;
    /* The originating connection's capability set, captured at ctx creation.
@@ -97,7 +99,8 @@ int tool_execute_dispatch(server_ctx_t *ctx, compute_ctx_t *cctx);
 /* Dispatch a coord task as a background delegate worker. Returns 0 on success, -1 on failure. */
 int server_compute_dispatch_coord_task(server_ctx_t *ctx, int task_id, const char *role,
                                        const char *prompt, const char *files_json, const char *cwd,
-                                       const char *persona, int require_handoff);
+                                       const char *persona, const char *claim_owner,
+                                       int require_handoff);
 /* Delegate worker thread entry point — non-static so skill_jobs.c can reference it. */
 void delegate_worker(void *arg);
 

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -212,26 +212,28 @@ static void compute_update_coord_task(compute_ctx_t *cctx, cJSON *resp)
    if (strcmp(status_text, "ok") == 0)
    {
       cJSON *r = cJSON_GetObjectItemCaseSensitive(resp, "response");
-      db1_coord_job_complete_task(cctx->coord_task_id, cJSON_IsString(r) ? r->valuestring : "");
+      db1_coord_job_complete_task_owned(cctx->coord_task_id, cctx->coord_claim_owner,
+                                        cJSON_IsString(r) ? r->valuestring : "");
    }
    else if (strcmp(status_text, "preempted") == 0)
    {
       config_t cfg;
       config_load(&cfg);
-      if (db1_coord_job_release_task_bounded(cctx->coord_task_id,
-                                             cfg.concurrency_preempt_requeue_max) == 0)
+      if (db1_coord_job_release_task_bounded_owned(cctx->coord_task_id, cctx->coord_claim_owner,
+                                                   cfg.concurrency_preempt_requeue_max) == 0)
       {
          server_coord_dispatcher_notify();
          return;
       }
-      db1_coord_job_fail_task(cctx->coord_task_id, "preempt requeue cap exhausted");
+      db1_coord_job_fail_task_owned(cctx->coord_task_id, cctx->coord_claim_owner,
+                                    "preempt requeue cap exhausted");
    }
    else
    {
       cJSON *m = cJSON_GetObjectItemCaseSensitive(resp, "message");
-      db1_coord_job_fail_task(cctx->coord_task_id, (cJSON_IsString(m) && m->valuestring[0])
-                                                       ? m->valuestring
-                                                       : "delegate failed");
+      db1_coord_job_fail_task_owned(cctx->coord_task_id, cctx->coord_claim_owner,
+                                    (cJSON_IsString(m) && m->valuestring[0]) ? m->valuestring
+                                                                             : "delegate failed");
    }
    server_coord_dispatcher_notify();
 }

--- a/src/server/server_coord_dispatcher.c
+++ b/src/server/server_coord_dispatcher.c
@@ -14,6 +14,7 @@
 #include "config.h"
 #include "db1.h"
 #include "log.h"
+#include "platform_random.h"
 #include "cJSON.h"
 
 #include <pthread.h>
@@ -29,6 +30,7 @@ typedef struct
 {
    server_ctx_t *server;
    int task_id;
+   const char *claim_owner;
    const char *persona;
    const char *files_json;
    const char *cwd;
@@ -87,6 +89,8 @@ static int coord_spawn_delegate(void *ctx, const char *role, const char *brief)
    cctx->conn_fd = -1;
    cctx->async_slot = -1;
    cctx->coord_task_id = b->task_id;
+   snprintf(cctx->coord_claim_owner, sizeof(cctx->coord_claim_owner), "%s",
+            b->claim_owner ? b->claim_owner : "");
    cctx->req = req;
    /* Coord-task delegates are I/O-bound; run on-demand, not the CPU compute
     * pool (see delegate_spawn_ondemand). */
@@ -117,11 +121,13 @@ static int coord_delegates_enabled(void)
  * caller) rather than in server_compute.c. */
 int server_compute_dispatch_coord_task(server_ctx_t *ctx, int task_id, const char *role,
                                        const char *prompt, const char *files_json, const char *cwd,
-                                       const char *persona, int require_handoff)
+                                       const char *persona, const char *claim_owner,
+                                       int require_handoff)
 {
    if (!ctx || task_id <= 0 || !prompt || !prompt[0])
       return -1;
-   coord_spawn_backing_t backing = {ctx, task_id, persona, files_json, cwd, require_handoff, -1};
+   coord_spawn_backing_t backing = {ctx,        task_id, claim_owner,     persona,
+                                    files_json, cwd,     require_handoff, -1};
    gw_turn_capabilities_t caps = {&backing, coord_spawn_delegate, NULL};
    char turn_id[48];
    snprintf(turn_id, sizeof(turn_id), "coord-task-%d", task_id);
@@ -143,6 +149,54 @@ static volatile int g_stop;
 static pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t g_cond = PTHREAD_COND_INITIALIZER;
 static server_ctx_t *g_ctx;
+static char g_claim_owner[DB1_COORD_DELEGATE_LEN];
+
+#define COORD_BOOT_OWNER_KEY    "coord_dispatcher_boot_owner"
+#define COORD_CRASH_REQUEUE_MAX 3
+
+/* Claims belong to a server incarnation, not the generic dispatcher name. The
+ * previous incarnation's worker threads cannot survive process exit, so its
+ * remaining claims are provably orphaned and safe to retry before this boot
+ * starts dispatching. Persist the new owner only after recovery: if recovery is
+ * interrupted, the next boot retries the same previous owner. */
+static int dispatcher_recover_previous_boot(void)
+{
+   char previous[DB1_COORD_DELEGATE_LEN] = "";
+   if (db1_runtime_state_get(COORD_BOOT_OWNER_KEY, previous, sizeof(previous)) == 0 && previous[0])
+   {
+      int requeued = 0, failed = 0;
+      if (db1_coord_job_recover_owner(previous, COORD_CRASH_REQUEUE_MAX, &requeued, &failed) != 0)
+      {
+         LOG_ERROR("coord_dispatcher", "failed to recover claims from previous boot owner %s",
+                   previous);
+         return -1;
+      }
+      if (requeued || failed)
+         LOG_WARN("coord_dispatcher",
+                  "recovered previous-boot claims owner=%s: requeued=%d failed_at_cap=%d", previous,
+                  requeued, failed);
+   }
+
+   unsigned char rnd[8];
+   if (platform_random_bytes(rnd, sizeof(rnd)) != 0)
+   {
+      struct timespec ts;
+      clock_gettime(CLOCK_REALTIME, &ts);
+      memcpy(rnd, &ts, sizeof(rnd));
+   }
+   snprintf(g_claim_owner, sizeof(g_claim_owner), "coord-%ld-", (long)getpid());
+   size_t used = strlen(g_claim_owner);
+   for (size_t i = 0; i < sizeof(rnd) && used + 2 < sizeof(g_claim_owner); i++)
+      used += (size_t)snprintf(g_claim_owner + used, sizeof(g_claim_owner) - used, "%02x", rnd[i]);
+
+   if (db1_runtime_state_set(COORD_BOOT_OWNER_KEY, g_claim_owner) != 0)
+   {
+      LOG_ERROR("coord_dispatcher", "failed to persist boot claim owner; dispatcher not started");
+      g_claim_owner[0] = '\0';
+      return -1;
+   }
+   return 0;
+}
 
 /* Sweep all coord jobs that have pending tasks and dispatch up to max_concurrent. */
 static int dispatcher_sweep(void)
@@ -177,7 +231,7 @@ static int dispatcher_sweep(void)
       {
          db1_coord_task_t task;
          memset(&task, 0, sizeof(task));
-         int task_id = db1_coord_job_claim_next(job_id, "coord-dispatcher", &task);
+         int task_id = db1_coord_job_claim_next(job_id, g_claim_owner, &task);
          if (task_id < 0)
             break; /* no more claimable tasks for this job */
 
@@ -190,13 +244,15 @@ static int dispatcher_sweep(void)
                                          sizeof(files), cwd, sizeof(cwd), persona,
                                          sizeof(persona)) != 0)
          {
-            db1_coord_job_fail_task(task_id, "dispatcher could not read task dispatch fields");
+            db1_coord_job_fail_task_owned(task_id, g_claim_owner,
+                                          "dispatcher could not read task dispatch fields");
             continue;
          }
 
          if (!prompt[0])
          {
-            db1_coord_job_fail_task(task_id, "task has no stored prompt; cannot dispatch");
+            db1_coord_job_fail_task_owned(task_id, g_claim_owner,
+                                          "task has no stored prompt; cannot dispatch");
             LOG_WARN("coord_dispatcher", "coord task #%d (job #%d) has empty prompt — failing task",
                      task_id, job_id);
             continue;
@@ -207,7 +263,7 @@ static int dispatcher_sweep(void)
           * output that the workflow engine reads raw. */
          int require_handoff = (job.plan_id != WFE_COORD_PLAN_ID);
          if (server_compute_dispatch_coord_task(g_ctx, task_id, role, prompt, files, cwd, persona,
-                                                require_handoff) != 0)
+                                                g_claim_owner, require_handoff) != 0)
          {
             /* Pool full — release the claim and retry next sweep. */
             db1_coord_job_release_task(task_id);
@@ -247,6 +303,8 @@ static void *dispatcher_thread(void *arg)
 void server_coord_dispatcher_init(server_ctx_t *ctx)
 {
    if (g_running)
+      return;
+   if (dispatcher_recover_previous_boot() != 0)
       return;
    g_ctx = ctx;
    g_stop = 0;

--- a/src/tests/test_coord_jobs.c
+++ b/src/tests/test_coord_jobs.c
@@ -396,6 +396,53 @@ static void test_bounded_preempt_release(void)
    printf("  PASS: test_bounded_preempt_release\n");
 }
 
+static void test_previous_boot_recovery_and_fencing(void)
+{
+   sqlite3 *db = setup();
+
+   int plan_id = create_test_plan(db);
+   int job_id = db1_coord_job_create(plan_id, 3);
+   int recover_id = db1_coord_job_add_task(job_id, 0, "[\"src/recover.c\"]", "code", "recover",
+                                           "/wt", "engineer");
+   int live_id =
+       db1_coord_job_add_task(job_id, 0, "[\"src/live.c\"]", "code", "live", "/wt", "engineer");
+   assert(recover_id > 0 && live_id > 0);
+
+   db1_coord_task_t task;
+   assert(db1_coord_job_claim_next(job_id, "coord-old-boot", &task) == recover_id);
+   assert(db1_coord_job_claim_next(job_id, "coord-live-boot", &task) == live_id);
+
+   int requeued = -1, failed = -1;
+   assert(db1_coord_job_recover_owner("coord-old-boot", 1, &requeued, &failed) == 0);
+   assert(requeued == 1 && failed == 0);
+
+   db1_coord_task_t tasks[4];
+   assert(db1_coord_job_list_tasks(job_id, tasks, 4) == 2);
+   assert(strcmp(tasks[0].status, "pending") == 0);
+   assert(tasks[0].preempt_requeues == 1);
+   assert(strcmp(tasks[1].status, "claimed") == 0);
+   assert(strcmp(tasks[1].claimed_by, "coord-live-boot") == 0);
+
+   assert(db1_coord_job_claim_next(job_id, "coord-new-boot", &task) == recover_id);
+   /* A late result from the dead attempt is fenced out; the current owner wins. */
+   assert(db1_coord_job_complete_task_owned(recover_id, "coord-old-boot", "stale") == -1);
+   assert(db1_coord_job_complete_task_owned(recover_id, "coord-new-boot", "fresh") == 0);
+
+   /* A second crash exceeds the configured recovery cap and fails explicitly. */
+   assert(db1_coord_job_recover_owner("coord-live-boot", 1, &requeued, &failed) == 0);
+   assert(requeued == 1 && failed == 0);
+   assert(db1_coord_job_claim_next(job_id, "coord-next-boot", &task) == live_id);
+   assert(db1_coord_job_recover_owner("coord-next-boot", 1, &requeued, &failed) == 0);
+   assert(requeued == 0 && failed == 1);
+
+   assert(db1_coord_job_list_tasks(job_id, tasks, 4) == 2);
+   assert(strcmp(tasks[1].status, "failed") == 0);
+   assert(strstr(tasks[1].error, "crash retry cap exhausted") != NULL);
+
+   teardown(db);
+   printf("  PASS: test_previous_boot_recovery_and_fencing\n");
+}
+
 /* --- Test: cancel job --- */
 
 static void test_cancel_job(void)
@@ -593,6 +640,7 @@ int main(void)
    test_fail_task();
    test_release_claim();
    test_bounded_preempt_release();
+   test_previous_boot_recovery_and_fencing();
    test_cancel_job();
    test_max_concurrent();
    test_default_parallel();


### PR DESCRIPTION
## Summary
- assign coordinator task claims to a unique server-boot owner
- recover only the previous server incarnation's orphaned claims at startup
- fence task completion/failure/requeue updates by claim owner
- bound crash recovery to three requeues and fail explicitly when exhausted

## Why
A server restart could leave coordinator tasks permanently claimed by the old `coord-dispatcher` identity. The replacement process treated those claims as live forever, leaving workflows such as `wi_6cce...` unable to progress.

## Safety
The new boot owner is persisted only after prior-owner recovery completes. A crash during recovery therefore retries the same prior owner on the next boot. A stale worker result cannot complete a task after that task has been reassigned.

## Tests
- `make -C src -j4`
- `make -C src build/obj/tests/unit-test-server-compute -j4 && src/build/obj/tests/unit-test-server-compute`
- `make -C src build/obj/tests/unit-test-coord-jobs -j4 && src/build/obj/tests/unit-test-coord-jobs`
- Aimee verify: 2 passed, 0 failed
