### PR TITLE
feat: establish canonical module descriptor graph

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -105,10 +105,10 @@ jobs:
         run: |
           python3 -I -S scripts/validate_module_descriptors.py \
             --check-schema tests/fixtures/modules/positive
-      - name: Prove the deferred production root is intentionally empty
+      - name: Validate the complete production descriptor graph
         run: |
           python3 -I -S scripts/validate_module_descriptors.py \
-            --check-schema --allow-empty src/modules
+            --check-schema src/modules
       - name: Test descriptor failure modes and taxonomy convergence
         run: python3 -I scripts/tests/test_validate_module_descriptors.py -v
 

--- a/docs/validation/core-modularization-slice-6.md
+++ b/docs/validation/core-modularization-slice-6.md
@@ -1,0 +1,58 @@
+# Core modularization slice 6: canonical production descriptor graph
+
+## Decision
+
+This slice makes the canonical inventory's eighteen required and eight optional IDs the first
+complete production descriptor graph. Descriptor v1 records classification-derived selection,
+runtime-toggle support, and target public-contract dependencies. It does not claim current source
+ownership, build inclusion, runtime registration, generated profiles, or readiness.
+
+Classification comes only from the required and optional partitions in
+`tests/baselines/modules/canonical-inventory.yaml`; v1 descriptors contain no classification field.
+Every descriptor has a required, sorted `dependencies` array, including the empty array on the
+dependency root `module-runtime`. Production validation requires exact inventory coverage and the
+path `src/modules/<id>/module.yaml`. Other implementation files may coexist in that module
+directory, but nested descriptors, path aliases, and case variants are forbidden.
+
+## Selection and lifecycle
+
+`runtime-web` and `control-web` are default-on and runtime-toggleable because each GUI has an
+independent configured process lifecycle. `plugin-loader`, `governance`, `workflows`, `roundtable`,
+`kb-synthesis`, and `benchmarks` are default-off and are not yet runtime-toggleable. Required
+modules have no default-selection field and explicitly declare runtime toggling unsupported.
+Future optional IDs default off and non-toggleable until an approved amendment says otherwise.
+
+## Dependency boundary
+
+The committed descriptors are the target public-contract graph. Required modules cannot depend on
+optional modules. Validation uses lexicographically ordered DFS and reports a closed cycle at its
+lexicographically smallest rotation, making diagnostics stable across platforms.
+
+The direct `governance` to `delegates` edge is normative: governance owns delegation governance
+identity and consumes the required delegate contract. `audit` intentionally does not depend on
+`ir`; stage owners translate actions into audit-owned typed events. `skills` intentionally does
+not depend directly on `learning`, `routing`, or `workspace`: those consumers use the skills
+contract, while resource access is mediated by the declared `skills` to `tools` and `tools` to
+`workspace` edges. Physical-edge enforcement must simplify or move current code to this graph;
+widening it requires a separately reviewed amendment.
+
+## Documentation follow-up boundary
+
+Descriptor v2 and substantive individual module documentation are the immediate next
+modularization slice. No intervening slice may add source/surface metadata or placeholder module
+documentation. V2 will atomically migrate all descriptors and add `docs` as one repository-relative
+document path, `sources` and `public_headers` as sorted unique arrays of repository-relative globs,
+and `surfaces` as strict sorted route, command, protocol, and stage ID arrays. Mixed descriptor
+versions will fail validation.
+
+V2 is not acceptable until every descriptor resolves to a substantive `docs/modules/<id>.md` that
+satisfies the approved module-document contract and cites real source/header globs and surface IDs,
+or explicitly justifies an empty category. Empty READMEs, headings-only files, stubs, TODO-only
+content, and invented references cannot satisfy that gate. V1 contains no speculative v2 logic.
+
+## Verification and cleanup
+
+The Python validator remains the single semantic authority and continues to generate the JSON
+schema. CI runs production validation as the blocking graph gate and separately retains fixture and
+mutation tests. The obsolete `--allow-empty` escape hatch is removed. This slice adds no shell
+validator, parallel taxonomy, readiness registry, build generator, or documentation placeholder.

--- a/scripts/tests/test_check_proposal_ordering.py
+++ b/scripts/tests/test_check_proposal_ordering.py
@@ -56,7 +56,9 @@ class ProposalOrderingTests(unittest.TestCase):
         return tmp, repo, cutoff
 
     def test_current_repository_passes(self) -> None:
-        self.assertEqual(ordering.validate_ordering(REPO_ROOT), 0)
+        signal_count = ordering.validate_ordering(REPO_ROOT)
+        self.assertIsInstance(signal_count, int)
+        self.assertGreaterEqual(signal_count, 1)
 
     def test_name_status_parses_all_path_shapes(self) -> None:
         raw = b"M\0one\0R100\0old\0new\0C075\0source\0copy\0D\0gone\0"

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -7,6 +7,7 @@ import copy
 import importlib.util
 import json
 from pathlib import Path
+import shutil
 import tempfile
 import unittest
 
@@ -40,6 +41,24 @@ class DescriptorTests(unittest.TestCase):
     def taxonomy(self) -> tuple[set[str], set[str]]:
         return validator.load_inventory(REPO_ROOT)
 
+    def production_repo(self) -> tempfile.TemporaryDirectory[str]:
+        tmp = tempfile.TemporaryDirectory()
+        repo = Path(tmp.name)
+        inventory = repo / validator.INVENTORY_PATH
+        inventory.parent.mkdir(parents=True)
+        shutil.copy2(REPO_ROOT / validator.INVENTORY_PATH, inventory)
+        for source in (REPO_ROOT / "src/modules").glob("*/module.yaml"):
+            target = repo / "src/modules" / source.parent.name / "module.yaml"
+            target.parent.mkdir(parents=True)
+            shutil.copy2(source, target)
+        return tmp
+
+    def mutate_descriptor(self, repo: Path, identifier: str, mutate) -> None:
+        path = repo / "src/modules" / identifier / "module.yaml"
+        value = json.loads(path.read_text(encoding="utf-8"))
+        mutate(value)
+        path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
     def assert_rule(self, value: object, rule: str) -> None:
         required, optional = self.taxonomy()
         with self.assertRaisesRegex(validator.DescriptorError, f"rule={rule}"):
@@ -53,9 +72,14 @@ class DescriptorTests(unittest.TestCase):
 
     def test_positive_fixture_root_and_exact_count(self) -> None:
         count = validator.validate_roots(
-            REPO_ROOT, [Path("tests/fixtures/modules/positive")], allow_empty=False
+            REPO_ROOT, [Path("tests/fixtures/modules/positive")]
         )
         self.assertEqual(count, 3)
+
+    def test_complete_production_graph(self) -> None:
+        required, optional = self.taxonomy()
+        self.assertEqual(len(required | optional), 26)
+        self.assertEqual(validator.validate_roots(REPO_ROOT, [Path("src/modules")]), 26)
 
     def test_schema_is_generated_byte_for_byte(self) -> None:
         validator.check_schema(REPO_ROOT)
@@ -170,18 +194,134 @@ class DescriptorTests(unittest.TestCase):
                 path.parent.mkdir()
                 path.write_text(json.dumps(self.required()), encoding="utf-8")
             with self.assertRaisesRegex(validator.DescriptorError, "rule=module-duplicate"):
-                validator.validate_roots(REPO_ROOT, [root], allow_empty=False)
+                validator.validate_roots(REPO_ROOT, [root])
 
-    def test_empty_root_requires_explicit_allow_empty(self) -> None:
+    def test_empty_root_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             with self.assertRaisesRegex(validator.DescriptorError, "rule=no-descriptors-found"):
-                validator.validate_roots(REPO_ROOT, [root], allow_empty=False)
-            with self.assertRaisesRegex(validator.DescriptorError, "rule=allow-empty-scope"):
-                validator.validate_roots(REPO_ROOT, [root], allow_empty=True)
-        self.assertEqual(
-            validator.validate_roots(REPO_ROOT, [Path("src/modules")], allow_empty=True), 0
-        )
+                validator.validate_roots(REPO_ROOT, [root])
+
+    def test_production_coverage_and_path_mutations(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            (repo / "src/modules/config/module.yaml").unlink()
+            with self.assertRaisesRegex(validator.DescriptorError, "rule=production-coverage"):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            source = repo / "src/modules/config/module.yaml"
+            target = repo / "src/modules/Config/module.yaml"
+            target.parent.mkdir()
+            source.rename(target)
+            with self.assertRaisesRegex(validator.DescriptorError, "rule=production-path"):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+    def test_production_selection_policy_mutations(self) -> None:
+        required, optional = self.taxonomy()
+        for identifier in sorted(optional):
+            tmp = self.production_repo()
+            try:
+                repo = Path(tmp.name)
+                self.mutate_descriptor(
+                    repo, identifier,
+                    lambda value: value.__setitem__(
+                        "enabled_by_default", not value["enabled_by_default"]
+                    ),
+                )
+                with self.subTest(identifier=identifier, field="enabled_by_default"), \
+                        self.assertRaisesRegex(validator.DescriptorError, "rule=production-default"):
+                    validator.validate_roots(repo, [Path("src/modules")])
+            finally:
+                tmp.cleanup()
+
+        for identifier in sorted(required | optional):
+            tmp = self.production_repo()
+            try:
+                repo = Path(tmp.name)
+                self.mutate_descriptor(
+                    repo, identifier,
+                    lambda value: value["runtime_toggle"].__setitem__(
+                        "supported", not value["runtime_toggle"]["supported"]
+                    ),
+                )
+                rule = (
+                    "required-runtime-toggle"
+                    if identifier in required
+                    else "production-runtime-toggle"
+                )
+                with self.subTest(identifier=identifier, field="runtime_toggle"), \
+                        self.assertRaisesRegex(validator.DescriptorError, f"rule={rule}"):
+                    validator.validate_roots(repo, [Path("src/modules")])
+            finally:
+                tmp.cleanup()
+
+    def test_production_graph_mutations(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            self.mutate_descriptor(
+                repo, "config", lambda value: value.__setitem__(
+                    "dependencies", ["module-runtime", "runtime-web"]
+                )
+            )
+            with self.assertRaisesRegex(validator.DescriptorError, "rule=core-to-optional"):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            self.mutate_descriptor(
+                repo, "module-runtime",
+                lambda value: value.__setitem__("dependencies", ["config"]),
+            )
+            with self.assertRaisesRegex(
+                validator.DescriptorError,
+                r"rule=dependency-cycle.*config -> module-runtime -> config",
+            ):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+    def test_aliased_production_root_cannot_bypass_policy(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            self.mutate_descriptor(
+                repo, "runtime-web",
+                lambda value: value.__setitem__("enabled_by_default", False),
+            )
+            with self.assertRaisesRegex(validator.DescriptorError, "rule=production-default"):
+                validator.validate_roots(repo, [Path("src/modules/../modules")])
+        finally:
+            tmp.cleanup()
+
+    def test_inventory_partition_swap_fails_closed(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            path = repo / validator.INVENTORY_PATH
+            value = json.loads(path.read_text(encoding="utf-8"))
+            value["required"].remove("config")
+            value["required"].append("plugin-loader")
+            value["optional"].remove("plugin-loader")
+            value["optional"].append("config")
+            path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                validator.DescriptorError, r"config/module.yaml.*rule=descriptor-keys"
+            ):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
 
     def test_parser_resource_limits(self) -> None:
         tmp, path = self.write_raw(b" " * (validator.MAX_BYTES + 1))

--- a/scripts/validate_module_descriptors.py
+++ b/scripts/validate_module_descriptors.py
@@ -22,6 +22,7 @@ MAX_DEPTH = 32
 MAX_ARRAY = 256
 ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 BASE_KEYS = {"descriptor_version", "id", "dependencies", "runtime_toggle"}
+DEFAULT_ON = {"runtime-web", "control-web"}
 
 
 class DescriptorError(ValueError):
@@ -236,27 +237,102 @@ def discover(root: Path) -> list[Path]:
     return sorted(root.rglob("module.yaml"))
 
 
-def validate_roots(repo: Path, roots: list[Path], allow_empty: bool) -> int:
+def _normalized_cycle(cycle: list[str]) -> list[str]:
+    open_cycle = cycle[:-1]
+    rotations = [open_cycle[index:] + open_cycle[:index] for index in range(len(open_cycle))]
+    result = min(rotations)
+    return result + [result[0]]
+
+
+def validate_graph(descriptors: dict[str, tuple[Path, list[str]]],
+                   required: set[str], optional: set[str]) -> None:
+    for identifier, (path, dependencies) in sorted(descriptors.items()):
+        if identifier in required:
+            for index, dependency in enumerate(dependencies):
+                if dependency in optional:
+                    fail("core-to-optional", f"required module {identifier!r} depends on optional "
+                         f"module {dependency!r} in {path}", f"/dependencies/{index}")
+
+    state: dict[str, int] = {identifier: 0 for identifier in descriptors}
+    stack: list[str] = []
+
+    def visit(identifier: str) -> None:
+        state[identifier] = 1
+        stack.append(identifier)
+        for dependency in descriptors[identifier][1]:
+            if dependency not in descriptors:
+                continue
+            if state[dependency] == 0:
+                visit(dependency)
+            elif state[dependency] == 1:
+                start = stack.index(dependency)
+                cycle = _normalized_cycle(stack[start:] + [dependency])
+                fail("dependency-cycle", " -> ".join(cycle), "/dependencies")
+        stack.pop()
+        state[identifier] = 2
+
+    for identifier in sorted(descriptors):
+        if state[identifier] == 0:
+            visit(identifier)
+
+
+def validate_roots(repo: Path, roots: list[Path]) -> int:
     required, optional = load_inventory(repo)
-    production_root = repo / "src/modules"
-    resolved_roots = [root if root.is_absolute() else repo / root for root in roots]
-    if allow_empty and resolved_roots != [production_root]:
-        fail("allow-empty-scope", "--allow-empty is restricted to src/modules")
+    production_root = (repo / "src/modules").resolve()
+    unresolved_roots = [root if root.is_absolute() else repo / root for root in roots]
+    resolved_roots = [root.resolve() for root in unresolved_roots]
     seen: dict[str, Path] = {}
+    graph: dict[str, tuple[Path, list[str]]] = {}
     count = 0
     for root, resolved in zip(roots, resolved_roots, strict=True):
         files = discover(resolved)
-        if not files and not allow_empty:
+        if not files:
             fail("no-descriptors-found", f"no module.yaml files under {root}")
         for path in files:
-            identifier = validate_descriptor(load_json(path), required, optional)
+            value = load_json(path)
+            try:
+                identifier = validate_descriptor(value, required, optional)
+            except DescriptorError as exc:
+                raise DescriptorError(f"{path}: {exc}") from exc
             if identifier in seen:
                 fail(
                     "module-duplicate",
                     f"module {identifier!r} also declared by {seen[identifier]}",
                 )
             seen[identifier] = path
+            graph[identifier] = (path, list(value["dependencies"]))
             count += 1
+    if resolved_roots == [production_root]:
+        expected = required | optional
+        actual = set(seen)
+        if actual != expected:
+            fail("production-coverage", f"missing={sorted(expected-actual)}, "
+                 f"extra={sorted(actual-expected)}")
+        casefold_paths: dict[str, Path] = {}
+        for identifier, path in sorted(seen.items()):
+            relative = path.relative_to(production_root)
+            expected_relative = Path(identifier) / "module.yaml"
+            if relative != expected_relative:
+                fail("production-path", f"{path} must be {production_root / expected_relative}")
+            folded = relative.as_posix().casefold()
+            if folded in casefold_paths and casefold_paths[folded] != path:
+                fail("production-case-collision", f"{path} collides with {casefold_paths[folded]}")
+            casefold_paths[folded] = path
+            value = load_json(path)
+            runtime_supported = value["runtime_toggle"]["supported"]
+            if identifier in required:
+                expected_default = None
+                expected_toggle = False
+            else:
+                expected_default = identifier in DEFAULT_ON
+                expected_toggle = identifier in DEFAULT_ON
+            if identifier in optional and value["enabled_by_default"] is not expected_default:
+                fail("production-default", f"{identifier} enabled_by_default must be "
+                     f"{str(expected_default).lower()}", "/enabled_by_default")
+            if runtime_supported is not expected_toggle:
+                fail("production-runtime-toggle", f"{identifier} runtime_toggle.supported must be "
+                     f"{str(expected_toggle).lower()}", "/runtime_toggle/supported")
+        validate_graph(graph, required, optional)
     return count
 
 
@@ -264,7 +340,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("roots", nargs="*", type=Path)
     parser.add_argument("--config-root", type=Path)
-    parser.add_argument("--allow-empty", action="store_true")
     parser.add_argument("--check-schema", action="store_true")
     parser.add_argument("--emit-schema", action="store_true")
     return parser.parse_args(argv)
@@ -281,7 +356,7 @@ def main(argv: list[str] | None = None) -> int:
             check_schema(repo)
         if not args.roots:
             fail("root", "at least one descriptor root is required")
-        count = validate_roots(repo, args.roots, args.allow_empty)
+        count = validate_roots(repo, args.roots)
     except (DescriptorError, OSError, UnicodeError, ValueError) as exc:
         print(f"validate_module_descriptors: error: {exc}", file=sys.stderr)
         return 1

--- a/src/modules/audit/module.yaml
+++ b/src/modules/audit/module.yaml
@@ -1,0 +1,12 @@
+{
+  "descriptor_version": 1,
+  "id": "audit",
+  "dependencies": [
+    "config",
+    "module-runtime",
+    "vault"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/benchmarks/module.yaml
+++ b/src/modules/benchmarks/module.yaml
@@ -1,0 +1,15 @@
+{
+  "descriptor_version": 1,
+  "id": "benchmarks",
+  "dependencies": [
+    "config",
+    "ir",
+    "memory",
+    "module-runtime",
+    "routing"
+  ],
+  "enabled_by_default": false,
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/config/module.yaml
+++ b/src/modules/config/module.yaml
@@ -1,0 +1,10 @@
+{
+  "descriptor_version": 1,
+  "id": "config",
+  "dependencies": [
+    "module-runtime"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/control-web/module.yaml
+++ b/src/modules/control-web/module.yaml
@@ -1,0 +1,14 @@
+{
+  "descriptor_version": 1,
+  "id": "control-web",
+  "dependencies": [
+    "config",
+    "gateway",
+    "module-runtime",
+    "protocols"
+  ],
+  "enabled_by_default": true,
+  "runtime_toggle": {
+    "supported": true
+  }
+}

--- a/src/modules/delegates/module.yaml
+++ b/src/modules/delegates/module.yaml
@@ -1,0 +1,18 @@
+{
+  "descriptor_version": 1,
+  "id": "delegates",
+  "dependencies": [
+    "audit",
+    "config",
+    "execution-policy",
+    "ir",
+    "module-runtime",
+    "routing",
+    "tools",
+    "vault",
+    "workspace"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/execution-policy/module.yaml
+++ b/src/modules/execution-policy/module.yaml
@@ -1,0 +1,12 @@
+{
+  "descriptor_version": 1,
+  "id": "execution-policy",
+  "dependencies": [
+    "config",
+    "ir",
+    "module-runtime"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/gateway/module.yaml
+++ b/src/modules/gateway/module.yaml
@@ -1,0 +1,15 @@
+{
+  "descriptor_version": 1,
+  "id": "gateway",
+  "dependencies": [
+    "config",
+    "execution-policy",
+    "ir",
+    "module-runtime",
+    "protocols",
+    "translation"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/git/module.yaml
+++ b/src/modules/git/module.yaml
@@ -1,0 +1,16 @@
+{
+  "descriptor_version": 1,
+  "id": "git",
+  "dependencies": [
+    "audit",
+    "config",
+    "execution-policy",
+    "memory",
+    "module-runtime",
+    "vault",
+    "workspace"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/governance/module.yaml
+++ b/src/modules/governance/module.yaml
@@ -1,0 +1,21 @@
+{
+  "descriptor_version": 1,
+  "id": "governance",
+  "dependencies": [
+    "audit",
+    "config",
+    "delegates",
+    "execution-policy",
+    "gateway",
+    "ir",
+    "module-runtime",
+    "protocols",
+    "routing",
+    "tools",
+    "vault"
+  ],
+  "enabled_by_default": false,
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/ir/module.yaml
+++ b/src/modules/ir/module.yaml
@@ -1,0 +1,10 @@
+{
+  "descriptor_version": 1,
+  "id": "ir",
+  "dependencies": [
+    "module-runtime"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/kb-synthesis/module.yaml
+++ b/src/modules/kb-synthesis/module.yaml
@@ -1,0 +1,15 @@
+{
+  "descriptor_version": 1,
+  "id": "kb-synthesis",
+  "dependencies": [
+    "config",
+    "ir",
+    "memory",
+    "module-runtime",
+    "response-composition"
+  ],
+  "enabled_by_default": false,
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/learning/module.yaml
+++ b/src/modules/learning/module.yaml
@@ -1,0 +1,13 @@
+{
+  "descriptor_version": 1,
+  "id": "learning",
+  "dependencies": [
+    "config",
+    "ir",
+    "memory",
+    "module-runtime"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/memory/module.yaml
+++ b/src/modules/memory/module.yaml
@@ -1,0 +1,12 @@
+{
+  "descriptor_version": 1,
+  "id": "memory",
+  "dependencies": [
+    "config",
+    "ir",
+    "module-runtime"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/module-runtime/module.yaml
+++ b/src/modules/module-runtime/module.yaml
@@ -1,0 +1,8 @@
+{
+  "descriptor_version": 1,
+  "id": "module-runtime",
+  "dependencies": [],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/plugin-loader/module.yaml
+++ b/src/modules/plugin-loader/module.yaml
@@ -1,0 +1,14 @@
+{
+  "descriptor_version": 1,
+  "id": "plugin-loader",
+  "dependencies": [
+    "audit",
+    "config",
+    "execution-policy",
+    "module-runtime"
+  ],
+  "enabled_by_default": false,
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/protocols/module.yaml
+++ b/src/modules/protocols/module.yaml
@@ -1,0 +1,13 @@
+{
+  "descriptor_version": 1,
+  "id": "protocols",
+  "dependencies": [
+    "config",
+    "ir",
+    "module-runtime",
+    "translation"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/response-composition/module.yaml
+++ b/src/modules/response-composition/module.yaml
@@ -1,0 +1,14 @@
+{
+  "descriptor_version": 1,
+  "id": "response-composition",
+  "dependencies": [
+    "config",
+    "ir",
+    "memory",
+    "module-runtime",
+    "skills"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/roundtable/module.yaml
+++ b/src/modules/roundtable/module.yaml
@@ -1,0 +1,17 @@
+{
+  "descriptor_version": 1,
+  "id": "roundtable",
+  "dependencies": [
+    "audit",
+    "config",
+    "delegates",
+    "ir",
+    "module-runtime",
+    "response-composition",
+    "routing"
+  ],
+  "enabled_by_default": false,
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/routing/module.yaml
+++ b/src/modules/routing/module.yaml
@@ -1,0 +1,14 @@
+{
+  "descriptor_version": 1,
+  "id": "routing",
+  "dependencies": [
+    "config",
+    "ir",
+    "learning",
+    "memory",
+    "module-runtime"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/runtime-web/module.yaml
+++ b/src/modules/runtime-web/module.yaml
@@ -1,0 +1,14 @@
+{
+  "descriptor_version": 1,
+  "id": "runtime-web",
+  "dependencies": [
+    "config",
+    "gateway",
+    "module-runtime",
+    "protocols"
+  ],
+  "enabled_by_default": true,
+  "runtime_toggle": {
+    "supported": true
+  }
+}

--- a/src/modules/skills/module.yaml
+++ b/src/modules/skills/module.yaml
@@ -1,0 +1,14 @@
+{
+  "descriptor_version": 1,
+  "id": "skills",
+  "dependencies": [
+    "config",
+    "ir",
+    "memory",
+    "module-runtime",
+    "tools"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/tools/module.yaml
+++ b/src/modules/tools/module.yaml
@@ -1,0 +1,16 @@
+{
+  "descriptor_version": 1,
+  "id": "tools",
+  "dependencies": [
+    "audit",
+    "config",
+    "execution-policy",
+    "ir",
+    "module-runtime",
+    "vault",
+    "workspace"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/translation/module.yaml
+++ b/src/modules/translation/module.yaml
@@ -1,0 +1,11 @@
+{
+  "descriptor_version": 1,
+  "id": "translation",
+  "dependencies": [
+    "ir",
+    "module-runtime"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/vault/module.yaml
+++ b/src/modules/vault/module.yaml
@@ -1,0 +1,12 @@
+{
+  "descriptor_version": 1,
+  "id": "vault",
+  "dependencies": [
+    "config",
+    "execution-policy",
+    "module-runtime"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/workflows/module.yaml
+++ b/src/modules/workflows/module.yaml
@@ -1,0 +1,20 @@
+{
+  "descriptor_version": 1,
+  "id": "workflows",
+  "dependencies": [
+    "audit",
+    "config",
+    "delegates",
+    "execution-policy",
+    "ir",
+    "module-runtime",
+    "routing",
+    "skills",
+    "tools",
+    "workspace"
+  ],
+  "enabled_by_default": false,
+  "runtime_toggle": {
+    "supported": false
+  }
+}

--- a/src/modules/workspace/module.yaml
+++ b/src/modules/workspace/module.yaml
@@ -1,0 +1,13 @@
+{
+  "descriptor_version": 1,
+  "id": "workspace",
+  "dependencies": [
+    "config",
+    "execution-policy",
+    "module-runtime",
+    "vault"
+  ],
+  "runtime_toggle": {
+    "supported": false
+  }
+}


### PR DESCRIPTION
## Summary

- add the complete 18-required / 8-optional production descriptor-v1 graph
- enforce inventory coverage, canonical paths, identity-specific selection/toggle policy, acyclicity, and the core-to-optional dependency ban
- remove the obsolete empty-production escape hatch and replace CI with the production graph gate
- bind descriptor v2 to the immediate next slice with atomic, substantive per-module documentation

This slice intentionally does not move source, alter linkage, register runtime components, generate profiles, or claim readiness.

## Roundtable

- Initial plan review: `oprun_g6a5f31446db042c_1784624839_8` (revisions requested)
- Revised plan approval: `oprun_g6a5f31446db042c_1784625227_10`
- Initial diff review: `oprun_g6a5f31446db042c_1784625686_11` (canonical-path bypass found)
- Final diff approval: `oprun_g6a5f31446db042c_1784626145_12` (no surviving issues)

## Validation

- production descriptor/schema validation: 26 descriptors
- descriptor mutation suite: 19 tests
- canonical inventory, Git contract, proposal ordering, and curator-absence gates
- proposal ordering after commit: 1 valid post-cutoff Git signal
- `make -C src lint`
- `make -C src unit-tests`
- `git diff --cached --check`