### PR TITLE
docs: make OIDC provider-neutral and split signed module docs

### DIFF
--- a/docs/proposals/pending/product-governance-web-and-config.md
+++ b/docs/proposals/pending/product-governance-web-and-config.md
@@ -39,6 +39,22 @@ tenant-scoped local reference authenticator, but exposes no OIDC or organization
 surface through CLI, environment/configuration, API, or web. Its audit projection remains a
 deterministic read-only view sourced directly from the core audit ledger.
 
+OIDC is a provider-neutral governance contract. Control manages named issuer profiles rather than
+shipping provider-specific modes. A profile declares standards-based issuer discovery or explicit
+authorization, token, user-info, JWKS, and end-session endpoints; client identity; a vault-backed
+client-secret reference; redirect URIs; scopes; PKCE and nonce policy; accepted signing algorithms;
+and mappings from namespaced claims to Aimee tenant, principal, group, and role attributes. GitHub,
+Entra ID, Okta, Keycloak, Auth0, or another conforming issuer may be configured through the same
+contract; none is compiled in, privileged, or selected by a provider enum.
+
+When `governance` is selected, issuer profiles are configurable from Aimee Control Plane's
+governance UI and the equivalent CLI, environment/configuration, and non-web API surfaces. The UI
+renders effective fields from the same descriptor/config metadata and stores secrets only through
+`vault`; it never embeds a client secret in rendered config or browser state. With `control-web`
+disabled, every OIDC operation remains available headlessly. With `governance` absent, issuer
+profiles and every OIDC setting are absent from advertised GUI, CLI, environment catalog, config
+schema, and API surfaces; accepted legacy input, if any, is migration-only and never advertised.
+
 Core contracts remain product-neutral. Runtime and Control choose deployment topology and custody:
 Runtime hosts per-user memory and enforcement instances; Control hosts multi-tenant shared-memory
 instances, distributes policy artifacts consumed by core `execution-policy`, and projects the core

--- a/docs/proposals/pending/tiered-llm-p5-oidc-control-plane.md
+++ b/docs/proposals/pending/tiered-llm-p5-oidc-control-plane.md
@@ -10,13 +10,16 @@ Every aimee-server already depends on aimee-kb for org egress (P2), so kb is the
 
 ## Goal
 
-1. aimee-kb (and kb-console) connect to the org IdP via OIDC (operator SSO).
+1. aimee-kb (and kb-console) connect to a user-configured OIDC issuer (operator SSO).
 2. aimee-servers enroll into a kb **server registry**; kb can list them and read their status and health.
 3. From the OIDC-authenticated console, an operator reaches a server's existing admin API (agents, config, health) through kb, with the OIDC identity carried to the server — not collapsed to a shared bearer.
 
 ## §0 What already exists (and the gap)
 
-- **OIDC verifier + console SSO** — `src/kb/auth_oidc.c`, `kb-console/auth.go` (RS256/JWKS, break-glass path). "Connect kb to OIDC" is largely built for humans already.
+- **OIDC verifier + console SSO** — `src/kb/auth_oidc.c` and `kb-console/auth.go` currently provide
+  RS256/JWKS and break-glass foundations. They are implementation evidence, not the target provider
+  contract. Migration replaces implicit provider assumptions with named, standards-based issuer
+  profiles owned by optional `governance` and managed by Control.
 - **PKI + enrollment** — `src/kb/enroll.c`, `src/kb/pki.c`: single-use `aimee://` tokens, CSR→CA-signed `cert:CN`. Enrollment today flows **client→KB**; P5 reuses this machinery to enroll **servers into a registry**.
 - **Server admin API, per-server** — `src/server/server_http_routes.c:1770+`: `/v1/agents`, `/v1/agent/{add,remove,enable,disable,set,…}`, `/v1/config/{get,set}`, health, delegate, cron — gated by bearer/scope/`remote_writes`.
 - **Three real gaps** (from the control-plane survey):
@@ -24,9 +27,37 @@ Every aimee-server already depends on aimee-kb for org egress (P2), so kb is the
   2. **OIDC identity terminates at the console** — `kb-console/proxy.go` forwards only the shared `console-admin` bearer ("the browser's own token is never forwarded"); it never reaches a server.
   3. **kb-console's allowlist is KB-only, deny-by-default** (`kb-console/acl.go` + `src/kb/http/kb_route_acl.c`) — it cannot address a server route.
 
+## §0.1 Provider-neutral issuer configuration
+
+OIDC is configured as named issuer profiles, not a provider enum. The canonical profile supports
+OpenID Provider discovery from an HTTPS issuer and, for issuers that require it, an explicit
+standards-based endpoint set. It contains issuer and endpoint URLs, client ID, a `vault` secret
+reference, redirect URI set, scopes, response mode, PKCE and nonce requirements, accepted JWS
+algorithms, clock-skew and token-age bounds, logout behavior, and namespaced claim mappings. Tenant
+bindings select an enabled profile and map composite `(iss, sub)` identities plus configured group
+claims into Aimee principals and roles. A bare `sub`, email address, or provider-specific username is
+never globally authoritative.
+
+The verifier requires exact issuer equality, audience and authorized-party checks, state, nonce,
+PKCE, signature, expiry, issued-at, and maximum-token-age validation. Discovery, JWKS, and user-info
+fetches use the governance egress policy, reject redirects or resolved addresses outside the
+configured allow policy, and use bounded refresh with unknown-`kid` retry and fail-closed stale-key
+behavior. Claim mappings are explicit and namespaced; unknown claims grant no role. Issuer-specific
+differences are expressed as validated profile data and may not introduce executable provider
+branches or widen the canonical verifier.
+
+Profiles are created, tested, enabled, disabled, rotated, and removed through the Aimee Control
+Plane governance interface, including the `control-web` UI when that optional module is active.
+The same operations and effective-field catalog exist through CLI, environment/configuration, and
+non-web APIs. Secret values enter `vault` through write-only inputs and are returned only as secret
+references. The GUI is generated from effective config metadata, so it exposes OIDC only while
+`governance` is selected and never invents provider-specific fields. GitHub is a valid configured
+issuer when its standards behavior and user-supplied profile satisfy this contract; it receives no
+hardcoded path or special authority.
+
 ## §1 Server registry (kb-side)
 
-A `server` registry table in DB2: `{server_id, cert_cn, mgmt_cert_cn, owner (OIDC sub, nullable), team_id, last_seen, health, version, endpoint}`. **Every aimee-server has its own individual, role-scoped mTLS credentials** — issued from kb's CA via the existing `aimee://` flow (`kb_enroll_mint` / `kb_enroll_redeem_csr`), each with a unique `cert:CN` and independently revocable (`cert.revoke`). Because the fleet uses TLS in *both* directions with distinct EKU profiles (`clientAuth` vs `serverAuth` — see P8 §0), the roles do **not** share one certificate: a server holds a **`clientAuth` leaf** for its server→kb egress/heartbeat calls (`cert_cn`, the registry key) and a **`serverAuth` leaf** for the management listener kb dials (`mgmt_cert_cn`, §2); kb in turn holds its own **`clientAuth` leaf** for calling servers. Each role cert is issued through the enrollment CA with its **own CSR + proof-of-possession** (the server proves control of the corresponding private key): the `clientAuth` leaf via the existing `aimee://`→CSR flow, and the `serverAuth` management-listener leaf via a parallel CSR carrying a `serverAuth` EKU request — distinct key material and distinct PoP, so neither role's key can stand in for the other. The redeemed `clientAuth` `cert:CN` is the server's identity and the registry key; redemption inserts the registry row and records both role CNs. No shared/fleet cert and no dual-purpose cert spanning both TLS roles — revoking or rotating one server (or one role) never touches another. Servers heartbeat over mTLS, reusing the existing server→kb `/v1/health` client in `kb_client.c`, to keep `last_seen`/`health`/`version` fresh. The `owner` (OIDC sub) is recorded when OIDC is configured and left null otherwise — the registry does not depend on OIDC. The registry is a Postgres/DB2 table (invariant #9): any of the N stateless kb instances serves registry reads and accepts heartbeats, and Postgres is the single authoritative view of the fleet — no instance holds registry state locally. It is a **tenant table under invariant #10**: RLS / team-scoped predicates apply to registry CRUD **and** fleet-management reads — an org-admin sees the whole fleet, a team-lead sees and manages only its own team's servers, and a cross-team registry read/write is denied at the DB layer. Heartbeat writes and **authorization-sensitive registry reads** go to the **primary**. kb selects a server's `endpoint`, its `mgmt_cert_cn`, **and** its revocation status in a **single consistent primary read** (one snapshot) — no TOCTOU between choosing the target and validating it, so it cannot dial a decommissioned endpoint with a stale pin. And there is **no trust-on-first-use**: the `mgmt_cert_cn` is fixed at **enrollment** (the serverAuth CSR + proof-of-possession, above), so kb pins the enrolled cert, never whatever answers the first handshake; the endpoint also passes address-policy validation and the revocation check **before kb's first dial**. Only non-authorization fleet dashboards may read replicas. The registry `owner` field is descriptive metadata only — egress and every authorization decision resolve identity via P1's composite contract, never the registry `owner`. The "single consistent read" is a `REPEATABLE READ`/`SERIALIZABLE` transaction (or one row-returning query) so `endpoint`/`mgmt_cert_cn`/revocation cannot skew. The registry is `FORCE ROW LEVEL SECURITY` under the non-owner runtime role (P1 §1). Enrollment is **idempotent, not falsely atomic** (a DB transaction cannot make external CA signing + two-cert issuance atomic): a `pending` registry row is inserted first under a uniqueness constraint on `(server_id)` and the redeemed CSRs' `(cert_issuer, cert_serial)`, the two role certs are signed (retryable by the same single-use token), and the row is finalized — a partial failure leaves a `pending` row that a retry completes or a sweep expires, never a half-built ambiguous active row. The single-use enrollment token also **binds the team/owner grant at mint time** (an org-admin mints it for a specific team), so a redeemer cannot choose another team's assignment. Each kb **instance** obtains its own per-instance management `clientAuth` leaf by **auto-enrolling at boot via its platform workload identity** (the same identity that unseals the vault) — no shared fleet key, no manual per-instance step; the leaf is individually revocable.
+A `server` registry table in DB2: `{server_id, cert_cn, mgmt_cert_cn, owner_identity (composite OIDC (iss, sub), nullable), team_id, last_seen, health, version, endpoint}`. **Every aimee-server has its own individual, role-scoped mTLS credentials** — issued from kb's CA via the existing `aimee://` flow (`kb_enroll_mint` / `kb_enroll_redeem_csr`), each with a unique `cert:CN` and independently revocable (`cert.revoke`). Because the fleet uses TLS in *both* directions with distinct EKU profiles (`clientAuth` vs `serverAuth` — see P8 §0), the roles do **not** share one certificate: a server holds a **`clientAuth` leaf** for its server→kb egress/heartbeat calls (`cert_cn`, the registry key) and a **`serverAuth` leaf** for the management listener kb dials (`mgmt_cert_cn`, §2); kb in turn holds its own **`clientAuth` leaf** for calling servers. Each role cert is issued through the enrollment CA with its **own CSR + proof-of-possession** (the server proves control of the corresponding private key): the `clientAuth` leaf via the existing `aimee://`→CSR flow, and the `serverAuth` management-listener leaf via a parallel CSR carrying a `serverAuth` EKU request — distinct key material and distinct PoP, so neither role's key can stand in for the other. The redeemed `clientAuth` `cert:CN` is the server's identity and the registry key; redemption inserts the registry row and records both role CNs. No shared/fleet cert and no dual-purpose cert spanning both TLS roles — revoking or rotating one server (or one role) never touches another. Servers heartbeat over mTLS, reusing the existing server→kb `/v1/health` client in `kb_client.c`, to keep `last_seen`/`health`/`version` fresh. The `owner_identity` composite `(iss, sub)` is recorded when product OIDC is configured and left null otherwise — the registry does not depend on OIDC. The registry is a Postgres/DB2 table (invariant #9): any of the N stateless kb instances serves registry reads and accepts heartbeats, and Postgres is the single authoritative view of the fleet — no instance holds registry state locally. It is a **tenant table under invariant #10**: RLS / team-scoped predicates apply to registry CRUD **and** fleet-management reads — an org-admin sees the whole fleet, a team-lead sees and manages only its own team's servers, and a cross-team registry read/write is denied at the DB layer. Heartbeat writes and **authorization-sensitive registry reads** go to the **primary**. kb selects a server's `endpoint`, its `mgmt_cert_cn`, **and** its revocation status in a **single consistent primary read** (one snapshot) — no TOCTOU between choosing the target and validating it, so it cannot dial a decommissioned endpoint with a stale pin. And there is **no trust-on-first-use**: the `mgmt_cert_cn` is fixed at **enrollment** (the serverAuth CSR + proof-of-possession, above), so kb pins the enrolled cert, never whatever answers the first handshake; the endpoint also passes address-policy validation and the revocation check **before kb's first dial**. Only non-authorization fleet dashboards may read replicas. The registry `owner_identity` field is descriptive metadata only — egress and every authorization decision resolve identity via P1's composite contract, never the registry `owner_identity`. The "single consistent read" is a `REPEATABLE READ`/`SERIALIZABLE` transaction (or one row-returning query) so `endpoint`/`mgmt_cert_cn`/revocation cannot skew. The registry is `FORCE ROW LEVEL SECURITY` under the non-owner runtime role (P1 §1). Enrollment is **idempotent, not falsely atomic** (a DB transaction cannot make external CA signing + two-cert issuance atomic): a `pending` registry row is inserted first under a uniqueness constraint on `(server_id)` and the redeemed CSRs' `(cert_issuer, cert_serial)`, the two role certs are signed (retryable by the same single-use token), and the row is finalized — a partial failure leaves a `pending` row that a retry completes or a sweep expires, never a half-built ambiguous active row. The single-use enrollment token also **binds the team/owner grant at mint time** (an org-admin mints it for a specific team), so a redeemer cannot choose another team's assignment. Each kb **instance** obtains its own per-instance management `clientAuth` leaf by **auto-enrolling at boot via its platform workload identity** (the same identity that unseals the vault) — no shared fleet key, no manual per-instance step; the leaf is individually revocable.
 
 ## §2 kb→server management channel
 
@@ -42,9 +73,16 @@ Extend the console allowlist (`acl.go` + `kb_route_acl.c`) with a **server-scope
 
 ## Acceptance criteria
 
-- A server enrolls and appears in the registry with its `cert:CN`, owner, team, version, and a fresh heartbeat.
+- A server enrolls and appears in the registry with its `cert:CN`, composite owner identity, team,
+  version, and a fresh heartbeat.
 - A server presents a `clientAuth` cert to kb (server→kb) and a distinct `serverAuth` cert on its management listener (kb→server); neither certificate is accepted in the other TLS role.
 - An OIDC-authenticated operator lists the fleet and reads a server's agents/health through kb.
+- Two different conforming OIDC issuers pass the same profile, login, claim-mapping, and supported
+  session-lifecycle contract without provider-specific server or UI branches. GitHub may be used as
+  either profile when the user's configured issuer satisfies that contract; it is not mandatory.
+- With `governance` omitted, OIDC profile fields and operations are absent from GUI, CLI, advertised
+  environment/configuration, and API catalogs. With `control-web` omitted, the same profile
+  lifecycle remains fully operable through headless surfaces.
 - A management action reaches the server as the operator's propagated identity and is recorded as that actor in the server audit log — not as `console-admin`.
 - A server with `remote_writes: off` refuses a management write even from kb (server stays authoritative over its own policy).
 - Break-glass console login still works if OIDC is down (existing path preserved).

--- a/docs/validation/core-modularization-slice-7-plan.md
+++ b/docs/validation/core-modularization-slice-7-plan.md
@@ -1,0 +1,298 @@
+# Core modularization slice 7 plan: descriptor v2 and module documentation
+
+## Scope and sequence
+
+This work lands as two ordered PRs because a candidate cannot establish the verifier that authorizes
+itself.
+
+Slice 7a lands the provider-neutral CI OIDC policy schema, external protected verifier, deterministic
+module-document parser, SSHSIG verifier, fixtures, protected trigger workflow, and check-publisher
+contract. After 7a merges, administrators deploy the verifier, install its repository-scoped check-
+publisher app, pin that app as the required-check source, and enroll real owner and reviewer SSH
+public keys in a separate protected-base policy change. This requires repository administration,
+not organization `admin:org` or an Enterprise required-workflow rule.
+
+Slice 7b then atomically migrates all twenty-six canonical descriptors to version 2, adds one
+substantive document per module, and adds two human SSHSIG signatures per document. It cannot merge
+until the 7a verifier is deployed, the publisher app is pinned as the required-check source, and
+real human owner and reviewer SSH public keys are enrolled in the protected-base trust policy.
+
+Descriptor v2 is metadata-only. It does not claim complete source migration, surface ownership,
+build inclusion, runtime registration, provider readiness, or generated-profile coverage. V1
+dependency, default-selection, and runtime-toggle semantics remain unchanged.
+
+## OIDC boundary
+
+There are two separate OIDC consumers and neither chooses an identity provider in code.
+
+Product OIDC belongs to optional `governance`. Users manage named issuer profiles from Aimee Control
+Plane, currently `aimee-kb`, with equivalent headless config, CLI, environment, and API operations.
+GitHub, Keycloak, Entra ID, Okta, or another conforming issuer is user configuration, not a provider
+enum or privileged implementation. That contract is normative in
+`product-governance-web-and-config.md` and `tiered-llm-p5-oidc-control-plane.md`.
+
+This slice's CI OIDC token authenticates a protected trigger to the external documentation verifier.
+It uses the same provider-neutral design principle but a separate repository policy: an issuer
+profile declares issuer, JWKS trust, audience, standard claim names, optional namespaced claim
+mappings, and predicates that bind a protected workflow to immutable repository, run, and trigger-
+check identities. The external verifier resolves base and candidate objects independently through
+its read-only repository installation. It contains no GitHub issuer URL or GitHub claim name. The
+current deployment may configure a GitHub Actions profile; another CI system can supply another
+profile without changing verification code or document subjects.
+
+OIDC does not authenticate the document authors. SSHSIG authenticates the human owner and reviewer.
+OIDC supplies a short-lived, independently signed workload identity and verification time for the
+required check.
+
+## Descriptor v2
+
+Every v2 descriptor adds exactly four fields:
+
+- `docs`: exact path `docs/modules/<id>.md`;
+- `sources`: sorted unique repository-relative source patterns;
+- `public_headers`: sorted unique repository-relative public-header patterns; and
+- `surfaces`: required sorted unique arrays named `routes`, `commands`, `protocols`, and `stages`.
+
+Mixed versions, unknown keys, partial coverage, changed v1 semantics, and missing documents fail.
+Empty ownership arrays mean migration is incomplete, not that an implementation does not exist.
+
+All four v2 surface arrays must be empty. No protected canonical surface inventory exists yet, so
+the candidate cannot claim or classify surfaces. Any item fails with `v2-surfaces-deferred`.
+Documents record known legacy registrations as migration gaps. A later generated-registration
+slice establishes the protected inventory and advances the descriptor schema atomically.
+
+## Immutable Git inputs and ownership patterns
+
+Validation receives an explicit forty-hex candidate commit. It reads governed entries through
+`git ls-tree -z` and `git cat-file`, never through the candidate working tree. Descriptors,
+documents, claimed sources and headers, subjects, signatures, and index entries must be mode
+`100644` Git blobs. Symlinks, executables, gitlinks, trees, missing paths, duplicate entries, and
+other modes fail before parsing or hashing.
+
+Governed JSON is strict UTF-8 without BOM. The parser rejects duplicate keys before schema checks,
+unknown keys, floats, non-finite values, lone surrogates, and invalid encodings. SHA-256 always
+covers exact blob bytes after mode validation.
+
+A source pattern is printable ASCII and has exactly one form:
+
+```text
+src/modules/<id>/*.c
+src/modules/<id>/*.h
+src/modules/<id>/<literal>/*.c
+src/modules/<id>/<literal>/*.h
+```
+
+`<literal>` matches `^[a-z][a-z0-9_-]*$`. No other glob metacharacter, recursion, range, negation,
+escaping, Unicode, dot-entry, or platform behavior exists. Expansion enumerates direct Git-tree
+children and sorts by unsigned ASCII bytes. Every pattern matches at least one `100644` blob;
+overlap, duplicate claims, and cross-module claims fail.
+
+`sources` contains `.c` implementation and private `.h` files physically beneath the module.
+`public_headers` accepts only `.h` files beneath
+`src/modules/<id>/include/aimee/<id>/`. That final public-header layout does not yet exist, so all
+v2 public-header arrays are empty. Legacy headers are evidence, not claimed ownership.
+
+## Deterministic document language
+
+Module documents use printable ASCII plus LF only. CR, tab, control bytes, BOM, Unicode, HTML,
+links, images, tables, Setext headings, inline markup, code fences, and indented code are forbidden.
+The grammar accepts only one exact H1, the exact H2 lines below, blank lines, ordinary prose lines,
+`- ` prose list items, and the metadata/evidence productions defined here. Slice 7a commits the
+byte-level grammar and positive/negative fixtures; the protected parser is its single authority.
+
+The H1 is `# <id> module`. These H2s occur exactly once in this order:
+
+1. `## Purpose and non-goals`
+2. `## Classification and lifecycle`
+3. `## Public contracts`
+4. `## Dependencies and consumers`
+5. `## Providers and readiness`
+6. `## Configuration and activation`
+7. `## Routes, commands, protocols, and stages`
+8. `## Data and migrations`
+9. `## Security and privacy`
+10. `## Supported journeys`
+11. `## Tests and failure behavior`
+12. `## Operational diagnostics`
+13. `## Compatibility aliases`
+14. `## Extension and removal rules`
+
+Every section has this exact record order: its H2 line; one `State:` line; the three none-state lines
+when applicable; the projection block when applicable; one or more prose records; and one or more
+evidence records. A single blank line may separate records; leading, trailing, or consecutive blank
+lines fail. No record may occur twice unless its production explicitly says one-or-more.
+
+`State: present` or `State: none` occurs exactly once on the line immediately after the H2, with no
+blank line between them. This describes the section topic and is not inferred from a descriptor
+field. `State: none` is followed on consecutive lines by exactly one `Reason: <prose>`,
+`Implication: <prose>`, and `Evidence: <reference>` record in that order. `<prose>` uses the ordinary
+prose production below. Those three labels are forbidden for `State: present`.
+
+Descriptor projections are separate and exact. They occur once, immediately after the state block
+and before prose, only in the named sections:
+
+- Purpose contains `Sources: none` or all source patterns joined by `, `.
+- Public contracts contains `Public headers: none` or all header patterns joined by `, `.
+- The surfaces section contains `Routes: none`, `Commands: none`, `Protocols: none`, and
+  `Stages: none` in that order.
+
+An ordinary prose record matches
+`^[A-Za-z0-9][A-Za-z0-9 ,.;:()'/_-]*[A-Za-z0-9.)]$`. A prose list record is `- ` followed by the same
+production. An evidence record is `Evidence: <reference>` for the none-state block or
+`- Evidence: <reference>` in the section body. A reference is exactly `path:<repo-path>`,
+`path:<repo-path>#L<positive-decimal>`, or `module:<canonical-id>`. Paths resolve to `100644`
+candidate blobs and lines cannot exceed the LF-delimited line count. This slice validates paths and
+lines, not inferred symbols. Slice 7a's committed grammar is byte-equal to these productions; its
+fixtures cover every production, ordering boundary, cardinality, and malformed prefix.
+
+The parser excludes headings, blank lines, metadata, evidence, and list markers from prose counts.
+It counts non-overlapping tokens matching `[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*`. Each H2 requires 25
+prose tokens and the document 600. It rejects the case-insensitive whole words `TODO`, `TBD`, and
+`placeholder`, plus the exact phrase `coming soon`. Diagnostics include stable rule ID, module,
+candidate SHA, path, line, expected, and actual.
+
+Mechanical length is only a floor. A technical writer and roundtable must approve actual clarity,
+specificity, evidence, migration gaps, and the truth of each state claim.
+
+## SSHSIG human attestation
+
+For each module, `docs/modules/attestations/<id>.subject.json` is the exact fixed-key canonical JSON
+serialization plus one LF of:
+
+```json
+{
+  "descriptor_sha256": "<64 lowercase hex>",
+  "document_sha256": "<64 lowercase hex>",
+  "module_id": "<id>",
+  "owner_identity": "<trust-policy identity>",
+  "reviewer_identity": "<different trust-policy identity>",
+  "schema": "aimee.module-doc-attestation.v1",
+  "signed_at": "<YYYY-MM-DDTHH:MM:SSZ>"
+}
+```
+
+The serializer accepts ASCII values matching field-specific regexes and emits exactly the shown
+order, indentation, separators, escaping rules, and LF. Golden vectors independently verify this
+project-specific deterministic serialization. It is not described as RFC 8785/JCS because its
+required indentation and trailing LF are outside the JCS representation. Descriptor and document
+hashes cover exact mode-checked candidate blobs.
+
+`<id>.owner.sig` and `<id>.reviewer.sig` are standard ASCII-armored SSHSIG files over the same
+subject bytes, namespace `aimee.module-doc.v1`, Ed25519 keys, and SHA-512. Slice 7a pins the OpenSSH
+toolchain image by immutable digest and the `ssh-keygen` binary by SHA-256. The verifier rejects any
+other armor, namespace, hash, key type, leading/trailing bytes, CR, or missing final LF.
+
+The protected-base trust policy is strict canonical JSON with schema version and monotonically
+increasing epoch. Each identity has exact identity, role (`owner` or `reviewer`), Ed25519 public key,
+`not_before`, `not_after`, and optional `revoked_at`. Duplicate identities or keys fail. Owner and
+reviewer must be distinct and authorized for their roles.
+
+`signed_at` matches `^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$`, denotes a real UTC
+Gregorian time, and forbids leap-second `60`. It is signed audit metadata, not the authorization
+clock. The authoritative CI OIDC profile maps a verified standard `iat`; `signed_at` must be within
+the preceding 24 hours and not after that `iat`. Both SSH identities must be enrolled, in role and
+valid, and not revoked at OIDC `iat`. Backdating cannot revive a removed, expired, or revoked key.
+
+The sorted `attestations/index.json` has set equality with all twenty-six module IDs and subject
+files. It records `{module_id, subject_sha256}` only. Missing, extra, duplicate, stale, or misordered
+subjects, signatures, or entries fail. The index grants no authorization.
+
+The human helper uses no shell and never reads raw private-key bytes. It accepts only public keys
+whose matching private keys are available through a user-owned SSH agent or hardware token, invokes
+the pinned `ssh-keygen` with a sanitized environment, and builds all subjects and fifty-two
+signatures in an outside mode-`0700` temporary directory. It independently verifies every result
+before atomically replacing the whole attestation directory. Cancellation, unavailable keys,
+identity or role mismatch, partial signing, malformed prior state, or self-test failure leaves the
+repository and Git history unchanged. Renewal uses the same full replacement.
+
+## Provider-neutral CI OIDC verification
+
+Slice 7a defines a strict issuer-profile schema. It contains exact issuer and audience, JWKS trust
+or pinned discovery metadata, allowed JWS algorithms, maximum token lifetime and clock skew,
+required standard claims, optional namespaced claim mappings, and predicates over normalized
+workload fields. Duplicate JSON keys, unknown fields, redirecting discovery, unpinned trust, stale
+JWKS, algorithm substitution, issuer or audience mismatch, and missing claims fail closed.
+
+The profile-driven verifier creates two typed records. `workload_identity` contains issuer, subject,
+audience, issued-at, not-before, expiry, token ID, repository identity, workflow identity, workflow
+revision, run identity, attempt, trigger-check identity, event type, actor identity, and runner class;
+each field is derived from a verified standard or profile-mapped token claim. `candidate_target`
+contains the API-resolved protected-base revision, candidate revision, base and head refs, and pull-
+request identity. The external verifier obtains every field through its read-only repository
+installation, keyed by the token-bound repository, run, and trigger-check identity plus the pull-
+request number in the request. It ignores request-supplied SHAs and refs. The profile declares the
+HTTPS endpoint and strict response schema; redirects, write operations, and unmapped fields fail. A
+profile cannot omit a field required by either record.
+
+The trigger request carries only pull-request number and the OIDC token; the token itself carries
+the profile-mapped trigger-check identity, so the request does not duplicate that identifier.
+Candidate processes never run in the protected-base trigger job. The external verifier validates
+`workload_identity` first, uses its installation credential to fetch `candidate_target`, then
+requires repository, workflow, run, attempt, and trigger-check identities from the token to match
+the API-resolved pull request. The API-resolved base and candidate revisions must match the trigger
+check's recorded Git object. It requires
+`nbf <= wall_time <= exp`, `abs(wall_time - iat) <= 60 seconds`, and
+`0 < exp - iat <= 10 minutes`. Reuse is replay-safe rather than falsely one-time: a token can produce
+only the same deterministic decision for its exact repository, run, trigger check, pull request,
+base, and candidate tuple; any changed tuple fails. The publisher posts the result as a new check on
+the resolved candidate SHA. Missing issuer/JWKS/provider API access, mapping ambiguity, clock
+failure, or mismatch fails closed.
+
+The current deployment may instantiate this schema for GitHub Actions, including its namespaced custom
+claims. That profile is configuration stored on the protected base. It is not the OIDC contract,
+does not affect product OIDC, and can be replaced by another CI profile without changing verifier
+code or SSH subjects.
+
+## Protected workflow and merge binding
+
+The trigger check is the protected-base workflow run that requests OIDC. The required check is the
+separate `module-doc-attestation` result the external publisher posts on the candidate SHA. They are
+linked by pull-request number and the token's trigger-check identity; the required check's
+`external_id` records that trigger-check identity. They are never treated as the same check run.
+
+The external service runs verifier, parser, OIDC profile, trust policy, grammar, fixtures, and pinned
+tools from the already-deployed 7a release. It fetches the current protected base and candidate by
+immutable object ID through its read-only repository installation. It reads candidate and base Git
+objects directly; the trigger never transmits candidate content, file bytes, or diffs. Candidate
+versions cannot alter the service or authorize the candidate containing them. Trust-policy or
+verifier changes land, deploy, and become the configured service release before later candidates
+use them.
+
+The repository's protected-base `pull_request_target` trigger requests an OIDC token and sends only
+that token plus pull-request number to the service. It has no repository secret, never checks out or
+executes candidate content, and is accepted only when its workflow identity and revision match the
+configured CI issuer profile. The external service owns a repository-scoped publisher credential
+stored in its vault; that credential can read pull-request and Git objects and create only its named
+check. It cannot merge, push, administer the repository, change rules, or issue another app's check.
+
+When the CI issuer profile is configured for GitHub Actions, its claim mappings and predicates bind
+`workflow_ref` and `workflow_sha` to the protected-base trigger workflow and require
+`job_workflow_ref` and `job_workflow_sha` to be absent unless the profile explicitly names a reusable
+called workflow. If one is configured, caller and called fields are separately pinned according to
+their documented meanings. The profile also binds repository IDs, run, attempt, trigger-check ID,
+actor, event, runner environment, and token ID. No profile treats caller and called claims
+interchangeably.
+
+Classic branch protection pins the required `module-doc-attestation` context to the installed
+publisher app, requires the PR head to include the current base, dismisses results on head or base
+change, blocks direct and force pushes, and allows only ordinary merge commits. It has no bypass
+actor for this check. A candidate workflow cannot impersonate the publisher app even if it uses the
+same display name. Merge queue batching is disabled.
+
+The external publisher posts its check only on the independently resolved candidate SHA, so all
+required checks refer to the exact PR head. Because that head already contains the current base, the
+ordinary merge has the protected base as first parent, the checked head as second parent, and a root
+tree equal to the PR head tree. A protected post-merge audit verifies those IDs and tree equality.
+Squash, rebase, batch merge, stale head, conflict-resolution tree changes, direct push, and bypass
+are policy violations.
+
+## Delivery and human boundary
+
+Slice 7a can be implemented, tested, reviewed, and merged autonomously under existing branch rules.
+Installing the repository-scoped publisher app, pinning its required-check context, and enrolling
+the real human SSH identities require repository administrators and signers; agents cannot invent
+them. No organization `admin:org` grant is required. Slice 7b can then be implemented and brought to
+a draft PR autonomously. Its final green check requires the two genuine human signatures per module.
+
+No bot, provider account label, CODEOWNERS approval, roundtable output, CI OIDC identity, or agent-
+generated SSH key substitutes for the human owner and reviewer SSHSIG signatures.


### PR DESCRIPTION
## Summary

- define product OIDC as named, provider-neutral issuer profiles managed by Aimee Control Plane and equivalent headless surfaces
- keep GitHub and every other issuer as user configuration rather than a provider enum
- separate product OIDC, CI workload OIDC, and SSHSIG human module-document attestation
- split descriptor-v2 delivery into 7a protected verifier/check-publisher infrastructure and 7b signed descriptors plus 26 module documents
- use a repository-scoped external required-check publisher on GitHub Team without requesting `admin:org`

## Review

- technical-writer approval: delegate job 1582
- roundtable approval: `oprun_g6a5f4f772fc0a887_1784631421_2` (best artifact: no issues; replay rejected all tentative findings)

## Verification

- `git diff --check`
- `python3 -I scripts/tests/test_check_proposal_reconcile.py -v`
- `python3 -I scripts/tests/test_check_proposal_ordering.py -v`
- `python3 -I -S scripts/check_proposal_ordering.py`
