### PR TITLE
ci: add provider-neutral module documentation contracts

### DIFF
--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -1,0 +1,53 @@
+# Module document attestation deployment contract
+
+This directory defines the protected repository half of module-document attestation. The verifier
+is an independently deployed service. Pull requests cannot replace its code, issuer profile, trust
+policy, repository credential, or SSHSIG toolchain.
+
+## Provider-neutral OIDC configuration
+
+The service accepts named issuer profiles conforming to `issuer-profile.example.json` and
+`scripts/module_doc_contract.py`. A profile contains an exact issuer, audience, pinned JWKS
+transport, algorithm allowlist, normalized claim mappings, and immutable workload predicates. It
+does not contain a provider enum. An administrator may configure GitHub, Keycloak, Entra ID, Okta,
+or another conforming issuer without changing verifier code.
+
+The example uses reserved `.invalid` endpoints and synthetic claims. It cannot authenticate a real
+deployment. A deployment stores its real profile in the verifier's protected configuration, not in
+a pull-request-controlled branch.
+
+## Repository trigger
+
+`module-doc-attestation-trigger.yml` runs only from the protected base through
+`pull_request_target`. It receives an OIDC token for the configured audience and sends exactly the
+token and pull-request number to the verifier. It never checks out candidate content and has no
+repository credential or secret. The trigger check is not the required attestation check.
+
+The verifier uses its repository-scoped installation to resolve the pull request, protected base,
+candidate commit, refs, run, attempt, and trigger-check identity. It ignores candidate coordinates
+from requests. Its publisher credential may read pull-request and Git objects and create only the
+named `module-doc-attestation` check. It may not push, merge, administer the repository, or create a
+different app's check. The required check is pinned to that publisher app by an administrator.
+
+## Human trust and SSHSIG
+
+Module owners and reviewers are authenticated with distinct Ed25519 SSHSIG signatures in namespace
+`aimee.module-doc.v1`; CI OIDC never substitutes for a human signature. Real identities and public
+keys are enrolled only after this verifier release is deployed. No test key or generated agent key
+is an enrollment candidate.
+
+Before activation, the deployment lock must pin an OpenSSH toolchain image by immutable digest and
+the image's `ssh-keygen` binary by SHA-256. The service verifies both pins before accepting work.
+The repository intentionally does not publish a fabricated image digest or a host-specific binary
+hash; release publication produces those two values and the administrator records them in protected
+service configuration.
+
+## Activation order
+
+1. Deploy the reviewed verifier release and its closed issuer profile.
+2. Install the repository-scoped publisher app without organization `admin:org`.
+3. Configure `MODULE_DOC_VERIFIER_URL` and `MODULE_DOC_VERIFIER_AUDIENCE` as protected repository
+   variables.
+4. Enroll genuine owner and reviewer public keys in the protected service trust policy.
+5. Pin the required `module-doc-attestation` context to the publisher app.
+6. Only then open the descriptor-v2 and signed-document migration PR.

--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -4,6 +4,14 @@ This directory defines the protected repository half of module-document attestat
 is an independently deployed service. Pull requests cannot replace its code, issuer profile, trust
 policy, repository credential, or SSHSIG toolchain.
 
+`scripts/module_doc_contract.py` supplies the deterministic validation and decision engine. The
+deployment supplies a pinned JOSE implementation for JWS/JWKS verification, a read-only repository
+client, a replay store, and the repository-scoped check publisher. The engine calls cryptographic
+verification before claim normalization, then resolves repository coordinates before reading the
+candidate commit. A callback name is not proof of either operation; deployment integration tests
+must exercise invalid signatures, stale keys, redirects, repository mismatches, replay, and check
+publication permissions.
+
 ## Provider-neutral OIDC configuration
 
 The service accepts named issuer profiles conforming to `issuer-profile.example.json` and
@@ -47,7 +55,9 @@ service configuration.
 1. Deploy the reviewed verifier release and its closed issuer profile.
 2. Install the repository-scoped publisher app without organization `admin:org`.
 3. Configure `MODULE_DOC_VERIFIER_URL` and `MODULE_DOC_VERIFIER_AUDIENCE` as protected repository
-   variables.
+   variables. The trigger remains skipped while `MODULE_DOC_ATTESTATION_ENABLED` is absent or not
+   exactly `true`; once the verifier is ready, set it to `true`. An active trigger fails closed when
+   either endpoint variable is absent.
 4. Enroll genuine owner and reviewer public keys in the protected service trust policy.
 5. Pin the required `module-doc-attestation` context to the publisher app.
 6. Only then open the descriptor-v2 and signed-document migration PR.

--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -73,7 +73,10 @@ available through `SSH_AUTH_SOCK`. It invokes no shell, signs every module, veri
 and builds the complete index before changing the attestation directory. A malformed prior directory
 or any signing failure leaves it unchanged. Initial installation uses an atomic rename; renewal uses
 `renameat2(RENAME_EXCHANGE)` and fails without changing the directory when the filesystem lacks that
-operation.
+operation. The helper pins the parent, staging, and existing target directories by open descriptors
+and rechecks their directory-entry identities around installation. It performs no automatic rollback
+or recursive root cleanup: aborted staging trees and the verified prior generation from a renewal
+remain as mode-`0700` quarantine directories for explicit operator inspection and removal.
 
 ## Current GitHub repository binding
 

--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -15,6 +15,12 @@ resolver before opening the resolved candidate commit. Function names alone do n
 properties, so deployment integration tests must exercise invalid signatures, stale keys,
 redirects, repository mismatches, replay, and publisher permissions.
 
+Each decision has explicit ceilings for evidence records, distinct blob bytes, Git operations, and
+Git wall-clock time. Immutable blobs are cached by repository, commit, and path, so repeated evidence
+records cannot multiply object reads. Replay bindings use canonical JSON over every normalized
+workload and candidate-target field; the token identity separately binds the exact issuer and token
+identifier without delimiter ambiguity.
+
 `module-doc-attestation-trigger.yml` is dormant unless the protected repository variable
 `MODULE_DOC_ATTESTATION_ENABLED` is exactly `true`. While active, it fails closed unless the
 verifier URL, audience, and TLS public-key pin are configured. It requests an OIDC token and sends
@@ -48,8 +54,9 @@ deployed. Before activation, operators must provide:
 - a read-only repository client that translates platform API fields into the normalized repository,
   workflow, revision, run, attempt, trigger, pull-request, base, and candidate records;
 - a durable replay store that atomically binds each token replay key to one decision replay key and
-  persisted result before publication. Exact retries reuse that result; a changed tuple for the same
-  token fails;
+  persisted result before publication. The decision key covers the complete normalized workload and
+  candidate-target records. Exact retries reuse that result; any changed field for the same token
+  fails;
 - a repository-scoped publisher authorized only to create the named attestation check;
 - a canonical trust policy containing genuine human owner and reviewer Ed25519 public keys; and
 - an OpenSSH image selected by immutable digest plus a lock containing the SHA-256 of the exact

--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -47,7 +47,9 @@ deployed. Before activation, operators must provide:
   audience, algorithm, and token time before returning claims to the engine;
 - a read-only repository client that translates platform API fields into the normalized repository,
   workflow, revision, run, attempt, trigger, pull-request, base, and candidate records;
-- a durable replay store that permits only one deterministic result for each engine replay key;
+- a durable replay store that atomically binds each token replay key to one decision replay key and
+  persisted result before publication. Exact retries reuse that result; a changed tuple for the same
+  token fails;
 - a repository-scoped publisher authorized only to create the named attestation check;
 - a canonical trust policy containing genuine human owner and reviewer Ed25519 public keys; and
 - an OpenSSH image selected by immutable digest plus a lock containing the SHA-256 of the exact

--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -1,63 +1,91 @@
 # Module document attestation deployment contract
 
-This directory defines the protected repository half of module-document attestation. The verifier
-is an independently deployed service. Pull requests cannot replace its code, issuer profile, trust
-policy, repository credential, or SSHSIG toolchain.
+This contract separates the provider-neutral verifier engine from the current repository trigger.
+`scripts/module_doc_contract.py` contains no issuer selection or provider enum. The workflow in this
+repository is the GitHub Actions binding; another CI platform needs an equivalent protected trigger
+that produces the same normalized workload and candidate-target records.
 
-`scripts/module_doc_contract.py` supplies the deterministic validation and decision engine. The
-deployment supplies a pinned JOSE implementation for JWS/JWKS verification, a read-only repository
-client, a replay store, and the repository-scoped check publisher. The engine calls cryptographic
-verification before claim normalization, then resolves repository coordinates before reading the
-candidate commit. A callback name is not proof of either operation; deployment integration tests
-must exercise invalid signatures, stale keys, redirects, repository mismatches, replay, and check
-publication permissions.
+## Repository guarantees
 
-## Provider-neutral OIDC configuration
+`scripts/module_doc_contract.py` supplies deterministic parsers, immutable Git-object reads,
+descriptor-v2 validation, document validation, SSHSIG validation, workload-to-candidate binding,
+replay keys, and publisher-result validation. Its decision engine invokes the deployment's
+cryptographic JWT verifier before normalizing claims. It then invokes the read-only repository
+resolver before opening the resolved candidate commit. Function names alone do not establish those
+properties, so deployment integration tests must exercise invalid signatures, stale keys,
+redirects, repository mismatches, replay, and publisher permissions.
 
-The service accepts named issuer profiles conforming to `issuer-profile.example.json` and
-`scripts/module_doc_contract.py`. A profile contains an exact issuer, audience, pinned JWKS
-transport, algorithm allowlist, normalized claim mappings, and immutable workload predicates. It
-does not contain a provider enum. An administrator may configure GitHub, Keycloak, Entra ID, Okta,
-or another conforming issuer without changing verifier code.
+`module-doc-attestation-trigger.yml` is dormant unless the protected repository variable
+`MODULE_DOC_ATTESTATION_ENABLED` is exactly `true`. While active, it fails closed unless the
+verifier URL, audience, and TLS public-key pin are configured. It requests an OIDC token and sends
+only the request schema identifier, token, and pull-request number. It does not send candidate
+content, commits, or refs. The workflow grants only `id-token: write`, performs no checkout, and is
+covered by a static contract test that rejects adding `actions/checkout`.
 
-The example uses reserved `.invalid` endpoints and synthetic claims. It cannot authenticate a real
-deployment. A deployment stores its real profile in the verifier's protected configuration, not in
-a pull-request-controlled branch.
+The trigger check and required `module-doc-attestation` check are different checks. The external
+publisher records the trigger identity as the required check's external identifier and targets only
+the candidate commit independently resolved through the repository API.
 
-## Repository trigger
+## Provider-neutral issuer profiles
 
-`module-doc-attestation-trigger.yml` runs only from the protected base through
-`pull_request_target`. It receives an OIDC token for the configured audience and sends exactly the
-token and pull-request number to the verifier. It never checks out candidate content and has no
-repository credential or secret. The trigger check is not the required attestation check.
+Named issuer profiles conform to `issuer-profile.example.json` and
+`scripts/module_doc_contract.py`. A profile contains the exact issuer and audience, pinned JWKS
+transport and keys, an algorithm allowlist, normalized claim mappings, immutable workload
+predicates, and a pinned repository API. It contains no provider enum. Users may configure any
+conforming issuer without changing verifier code.
 
-The verifier uses its repository-scoped installation to resolve the pull request, protected base,
-candidate commit, refs, run, attempt, and trigger-check identity. It ignores candidate coordinates
-from requests. Its publisher credential may read pull-request and Git objects and create only the
-named `module-doc-attestation` check. It may not push, merge, administer the repository, or create a
-different app's check. The required check is pinned to that publisher app by an administrator.
+The committed example uses reserved `.invalid` endpoints, synthetic claims, and unusable pins. It
+cannot authenticate a deployment. Real profiles belong to protected verifier configuration, never
+to a pull-request-controlled branch.
 
-## Human trust and SSHSIG
+## External deployment prerequisites
 
-Module owners and reviewers are authenticated with distinct Ed25519 SSHSIG signatures in namespace
-`aimee.module-doc.v1`; CI OIDC never substitutes for a human signature. Real identities and public
-keys are enrolled only after this verifier release is deployed. No test key or generated agent key
-is an enrollment candidate.
+The repository does not supply service credentials or claim that these prerequisites are already
+deployed. Before activation, operators must provide:
 
-Before activation, the deployment lock must pin an OpenSSH toolchain image by immutable digest and
-the image's `ssh-keygen` binary by SHA-256. The service verifies both pins before accepting work.
-The repository intentionally does not publish a fabricated image digest or a host-specific binary
-hash; release publication produces those two values and the administrator records them in protected
-service configuration.
+- a pinned JOSE implementation that verifies JWS signatures, JWKS key pins and freshness, issuer,
+  audience, algorithm, and token time before returning claims to the engine;
+- a read-only repository client that translates platform API fields into the normalized repository,
+  workflow, revision, run, attempt, trigger, pull-request, base, and candidate records;
+- a durable replay store that permits only one deterministic result for each engine replay key;
+- a repository-scoped publisher authorized only to create the named attestation check;
+- a canonical trust policy containing genuine human owner and reviewer Ed25519 public keys; and
+- an OpenSSH image selected by immutable digest plus a lock containing the SHA-256 of the exact
+  `ssh-keygen` binary. The deployment enforces the image selection; `load_locked_toolchain` verifies
+  the lock shape and binary hash before the engine can perform SSHSIG verification.
+
+OIDC authenticates the protected workload, not document authors. The deployed trust policy must
+reject test keys and agent-generated keys as human enrollments. Each module requires distinct owner
+and reviewer identities and two Ed25519 SSHSIG signatures in namespace `aimee.module-doc.v1`.
+
+`scripts/sign_module_docs.py` is the human signing helper. It accepts canonical public-key files and
+copies only their public bytes into its mode-`0700` staging directory; matching private keys must be
+available through `SSH_AUTH_SOCK`. It invokes no shell, signs every module, verifies every result,
+and builds the complete index before changing the attestation directory. A malformed prior directory
+or any signing failure leaves it unchanged. Initial installation uses an atomic rename; renewal uses
+`renameat2(RENAME_EXCHANGE)` and fails without changing the directory when the filesystem lacks that
+operation.
+
+## Current GitHub repository binding
+
+The current binding uses a protected-base `pull_request_target` workflow and a repository-scoped
+check-publisher app. Branch protection or a repository ruleset, not this source tree, must pin the
+required `module-doc-attestation` context to that app and prohibit bypasses. Installing this
+repository-scoped app does not require organization-wide administration; specifically, it does not
+require GitHub's `admin:org` scope.
+
+The app credential belongs in the deployed service vault. Its permissions are limited to reading
+pull-request and Git objects and creating its named check. It must not push, merge, administer the
+repository, or create another app's check.
 
 ## Activation order
 
-1. Deploy the reviewed verifier release and its closed issuer profile.
-2. Install the repository-scoped publisher app without organization `admin:org`.
-3. Configure `MODULE_DOC_VERIFIER_URL` and `MODULE_DOC_VERIFIER_AUDIENCE` as protected repository
-   variables. The trigger remains skipped while `MODULE_DOC_ATTESTATION_ENABLED` is absent or not
-   exactly `true`; once the verifier is ready, set it to `true`. An active trigger fails closed when
-   either endpoint variable is absent.
+1. Deploy the reviewed verifier release and a provider-neutral issuer profile.
+2. Install the repository-scoped publisher and configure its least-privilege credential.
+3. Configure `MODULE_DOC_VERIFIER_URL`, `MODULE_DOC_VERIFIER_AUDIENCE`, and
+   `MODULE_DOC_VERIFIER_SPKI` as protected repository variables.
 4. Enroll genuine owner and reviewer public keys in the protected service trust policy.
-5. Pin the required `module-doc-attestation` context to the publisher app.
-6. Only then open the descriptor-v2 and signed-document migration PR.
+5. In branch protection or the repository ruleset, pin `module-doc-attestation` to the publisher and
+   prohibit bypasses.
+6. Set `MODULE_DOC_ATTESTATION_ENABLED` to exactly `true` and verify a negative canary PR fails.
+7. Only then open the descriptor-v2 and signed-document migration PR.

--- a/.github/module-doc-attestation/issuer-profile.example.json
+++ b/.github/module-doc-attestation/issuer-profile.example.json
@@ -1,0 +1,42 @@
+{
+  "allowed_algorithms": [
+    "ES256"
+  ],
+  "audience": "aimee-module-doc-verifier",
+  "claim_mappings": {
+    "actor_identity": "ci_actor",
+    "attempt": "ci_attempt",
+    "event_type": "ci_event",
+    "repository_identity": "ci_repository",
+    "run_identity": "ci_run",
+    "runner_class": "ci_runner",
+    "trigger_check_identity": "ci_trigger_check",
+    "workflow_identity": "ci_workflow",
+    "workflow_revision": "ci_workflow_revision"
+  },
+  "clock_skew_seconds": 60,
+  "issuer": "https://issuer.example.invalid",
+  "jwks": {
+    "max_age_seconds": 3600,
+    "tls_spki_sha256": [
+      "1111111111111111111111111111111111111111111111111111111111111111"
+    ],
+    "uri": "https://issuer.example.invalid/jwks"
+  },
+  "max_token_lifetime_seconds": 600,
+  "name": "protected-ci",
+  "predicates": {
+    "event_type": "protected-pull-request",
+    "repository_identity": "repository-17",
+    "workflow_identity": "module-doc-attestation-trigger",
+    "workflow_revision": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "repository_api": {
+    "base_url": "https://repository.example.invalid/api",
+    "response_schema": "aimee.candidate-target.v1",
+    "tls_spki_sha256": [
+      "2222222222222222222222222222222222222222222222222222222222222222"
+    ]
+  },
+  "schema": "aimee.ci-oidc-profile.v1"
+}

--- a/.github/module-doc-attestation/issuer-profile.example.json
+++ b/.github/module-doc-attestation/issuer-profile.example.json
@@ -17,12 +17,12 @@
   "clock_skew_seconds": 60,
   "issuer": "https://issuer.example.invalid",
   "jwks": {
-    "key_thumbprints_sha256": [
-      "3333333333333333333333333333333333333333333333333333333333333333"
+    "jwk_thumbprints_sha256": [
+      "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
     ],
     "max_age_seconds": 3600,
     "tls_spki_sha256": [
-      "1111111111111111111111111111111111111111111111111111111111111111"
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     ],
     "uri": "https://issuer.example.invalid/jwks"
   },
@@ -38,7 +38,7 @@
     "base_url": "https://repository.example.invalid/api",
     "response_schema": "aimee.candidate-target.v1",
     "tls_spki_sha256": [
-      "2222222222222222222222222222222222222222222222222222222222222222"
+      "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="
     ]
   },
   "schema": "aimee.ci-oidc-profile.v1"

--- a/.github/module-doc-attestation/issuer-profile.example.json
+++ b/.github/module-doc-attestation/issuer-profile.example.json
@@ -17,6 +17,9 @@
   "clock_skew_seconds": 60,
   "issuer": "https://issuer.example.invalid",
   "jwks": {
+    "key_thumbprints_sha256": [
+      "3333333333333333333333333333333333333333333333333333333333333333"
+    ],
     "max_age_seconds": 3600,
     "tls_spki_sha256": [
       "1111111111111111111111111111111111111111111111111111111111111111"

--- a/.github/workflows/module-doc-attestation-trigger.yml
+++ b/.github/workflows/module-doc-attestation-trigger.yml
@@ -24,6 +24,7 @@ jobs:
       id-token: write
     env:
       VERIFIER_AUDIENCE: ${{ vars.MODULE_DOC_VERIFIER_AUDIENCE }}
+      VERIFIER_SPKI: ${{ vars.MODULE_DOC_VERIFIER_SPKI }}
       VERIFIER_URL: ${{ vars.MODULE_DOC_VERIFIER_URL }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
@@ -31,14 +32,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "${VERIFIER_AUDIENCE}" || -z "${VERIFIER_URL}" ]]; then
-            echo "::error::MODULE_DOC_VERIFIER_AUDIENCE and MODULE_DOC_VERIFIER_URL must be configured"
+          if [[ -z "${VERIFIER_AUDIENCE}" || -z "${VERIFIER_SPKI}" || -z "${VERIFIER_URL}" ]]; then
+            echo "::error::MODULE_DOC_VERIFIER_AUDIENCE, MODULE_DOC_VERIFIER_SPKI, and MODULE_DOC_VERIFIER_URL must be configured"
             exit 1
           fi
           case "${VERIFIER_URL}" in
             https://*) ;;
             *) echo "::error::MODULE_DOC_VERIFIER_URL must use HTTPS"; exit 1 ;;
           esac
+          if [[ ! "${VERIFIER_SPKI}" =~ ^[A-Za-z0-9+/]{43}=$ ]]; then
+            echo "::error::MODULE_DOC_VERIFIER_SPKI must be one base64 SHA-256 digest"
+            exit 1
+          fi
 
           audience=$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["VERIFIER_AUDIENCE"], safe=""))')
           token_response=$(curl --silent --show-error --fail-with-body --max-redirs 0 \
@@ -51,8 +56,11 @@ jobs:
 
           request=$(OIDC_TOKEN="${oidc_token}" python3 -c \
             'import json, os; print(json.dumps({"schema":"aimee.module-doc-trigger.v1","pull_request":int(os.environ["PR_NUMBER"]),"oidc_token":os.environ["OIDC_TOKEN"]}, separators=(",", ":")))')
-          printf '%s' "${request}" | curl --silent --show-error --fail-with-body --max-redirs 0 \
+          # Transport hardening is part of the repository guarantees documented
+          # in .github/module-doc-attestation/README.md.
+          printf '%s' "${request}" | curl --silent --show-error --fail --max-redirs 0 \
               --proto '=https' --tlsv1.2 \
+              --pinnedpubkey "sha256//${VERIFIER_SPKI}" \
               -H 'Content-Type: application/json' \
               --data-binary @- \
               --output /dev/null \

--- a/.github/workflows/module-doc-attestation-trigger.yml
+++ b/.github/workflows/module-doc-attestation-trigger.yml
@@ -17,6 +17,7 @@ permissions: {}
 jobs:
   request-attestation:
     name: module-doc-attestation-trigger
+    if: ${{ vars.MODULE_DOC_ATTESTATION_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:

--- a/.github/workflows/module-doc-attestation-trigger.yml
+++ b/.github/workflows/module-doc-attestation-trigger.yml
@@ -51,7 +51,7 @@ jobs:
             -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${audience}")
           oidc_token=$(TOKEN_RESPONSE="${token_response}" python3 -c \
-            'import json, os; value=json.loads(os.environ["TOKEN_RESPONSE"]); token=value.get("value"); assert isinstance(token, str) and token; print(token)')
+            'import json, os, sys; value=json.loads(os.environ["TOKEN_RESPONSE"]); token=value.get("value"); (isinstance(token, str) and token) or sys.exit("OIDC response lacks a non-empty token"); print(token)')
           echo "::add-mask::${oidc_token}"
 
           request=$(OIDC_TOKEN="${oidc_token}" python3 -c \

--- a/.github/workflows/module-doc-attestation-trigger.yml
+++ b/.github/workflows/module-doc-attestation-trigger.yml
@@ -1,0 +1,58 @@
+name: Module document attestation trigger
+
+# This protected-base workflow never checks out or executes pull-request code.
+# It authenticates the trigger; the separately deployed verifier resolves Git
+# objects and publishes the required module-doc-attestation check.
+on:
+  pull_request_target:
+    branches: [feature/core-modularization]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: module-doc-attestation-trigger-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  request-attestation:
+    name: module-doc-attestation-trigger
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      id-token: write
+    env:
+      VERIFIER_AUDIENCE: ${{ vars.MODULE_DOC_VERIFIER_AUDIENCE }}
+      VERIFIER_URL: ${{ vars.MODULE_DOC_VERIFIER_URL }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Request protected external verification
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${VERIFIER_AUDIENCE}" || -z "${VERIFIER_URL}" ]]; then
+            echo "::error::MODULE_DOC_VERIFIER_AUDIENCE and MODULE_DOC_VERIFIER_URL must be configured"
+            exit 1
+          fi
+          case "${VERIFIER_URL}" in
+            https://*) ;;
+            *) echo "::error::MODULE_DOC_VERIFIER_URL must use HTTPS"; exit 1 ;;
+          esac
+
+          audience=$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["VERIFIER_AUDIENCE"], safe=""))')
+          token_response=$(curl --silent --show-error --fail-with-body --max-redirs 0 \
+            --proto '=https' --tlsv1.2 \
+            -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${audience}")
+          oidc_token=$(TOKEN_RESPONSE="${token_response}" python3 -c \
+            'import json, os; value=json.loads(os.environ["TOKEN_RESPONSE"]); token=value.get("value"); assert isinstance(token, str) and token; print(token)')
+          echo "::add-mask::${oidc_token}"
+
+          request=$(OIDC_TOKEN="${oidc_token}" python3 -c \
+            'import json, os; print(json.dumps({"schema":"aimee.module-doc-trigger.v1","pull_request":int(os.environ["PR_NUMBER"]),"oidc_token":os.environ["OIDC_TOKEN"]}, separators=(",", ":")))')
+          printf '%s' "${request}" | curl --silent --show-error --fail-with-body --max-redirs 0 \
+              --proto '=https' --tlsv1.2 \
+              -H 'Content-Type: application/json' \
+              --data-binary @- \
+              --output /dev/null \
+              "${VERIFIER_URL}"

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -126,7 +126,9 @@ jobs:
         with:
           python-version: "3.12"
       - name: Test provider-neutral OIDC, document grammar, and SSHSIG contracts
-        run: python3 -I scripts/tests/test_module_doc_contract.py -v
+        run: |
+          python3 -I scripts/tests/test_module_doc_contract.py -v
+          python3 -I scripts/tests/test_sign_module_docs.py -v
 
   proposal-ordering:
     name: proposal-ordering

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -112,6 +112,22 @@ jobs:
       - name: Test descriptor failure modes and taxonomy convergence
         run: python3 -I scripts/tests/test_validate_module_descriptors.py -v
 
+  module-doc-contract:
+    name: module-doc-contract
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Test provider-neutral OIDC, document grammar, and SSHSIG contracts
+        run: python3 -I scripts/tests/test_module_doc_contract.py -v
+
   proposal-ordering:
     name: proposal-ordering
     permissions:

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -127,6 +127,7 @@ jobs:
           python-version: "3.12"
       - name: Test provider-neutral OIDC, document grammar, and SSHSIG contracts
         run: |
+          command -v ssh-keygen
           python3 -I scripts/tests/test_module_doc_contract.py -v
           python3 -I scripts/tests/test_sign_module_docs.py -v
 

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -128,6 +128,8 @@ jobs:
       - name: Test provider-neutral OIDC, document grammar, and SSHSIG contracts
         run: |
           command -v ssh-keygen
+          command -v ssh-agent
+          command -v ssh-add
           python3 -I scripts/tests/test_module_doc_contract.py -v
           python3 -I scripts/tests/test_sign_module_docs.py -v
 

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -19,10 +19,12 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
+import selectors
 import stat
 import subprocess
 import struct
 import tempfile
+import time
 from typing import Callable, NamedTuple, NoReturn
 from urllib.parse import urlsplit
 
@@ -52,6 +54,12 @@ MAX_INDEX_BYTES = 65_536
 MAX_INTEGER_DIGITS = 20
 MAX_TREE_BYTES = 1_048_576
 MAX_TREE_ENTRIES = 4_096
+MAX_DOCUMENT_EVIDENCE_REFERENCES = 64
+MAX_DECISION_EVIDENCE_REFERENCES = 2_048
+MAX_DECISION_DISTINCT_BLOB_BYTES = 67_108_864
+MAX_DECISION_GIT_OPERATIONS = 2_048
+GIT_OPERATION_TIMEOUT_SECONDS = 10
+MAX_GIT_STDERR_BYTES = 65_536
 
 SECTIONS = (
     "Purpose and non-goals",
@@ -476,15 +484,26 @@ def bind_workload_to_target(
 
 
 def replay_binding(workload: dict[str, object], target: dict[str, object]) -> str:
-    fields = (
-        workload["issuer"], workload["token_id"], workload["repository_identity"],
-        workload["run_identity"], workload["attempt"], workload["trigger_check_identity"],
-        str(target["pull_request"]), target["protected_base_revision"],
-        target["candidate_revision"],
-    )
-    if any(not isinstance(item, str) or not item for item in fields):
-        fail("replay-binding", "binding fields must be non-empty strings")
-    return sha256("\0".join(fields).encode("utf-8"))
+    expected_workload = {
+        "issuer", "subject", "audience", "issued_at", "not_before", "expires_at",
+        "token_id", *WORKLOAD_FIELDS,
+    }
+    expected_target = {
+        "schema", "repository_identity", "pull_request", "protected_base_revision",
+        "candidate_revision", "base_ref", "head_ref", "workflow_identity",
+        "workflow_revision", "run_identity", "attempt", "trigger_check_identity",
+    }
+    if set(workload) != expected_workload or set(target) != expected_target:
+        fail("replay-binding", "replay records must have their complete normalized shapes")
+    record = {"target": target, "workload": workload}
+    try:
+        encoded = json.dumps(
+            record, ensure_ascii=True, allow_nan=False, sort_keys=True,
+            separators=(",", ":"),
+        ).encode("ascii")
+    except (TypeError, ValueError, UnicodeEncodeError) as exc:
+        fail("replay-binding", f"replay record is not canonical JSON: {exc}")
+    return sha256(encoded)
 
 
 def replay_token_identity(workload: dict[str, object]) -> str:
@@ -492,7 +511,11 @@ def replay_token_identity(workload: dict[str, object]) -> str:
     token_id = workload.get("token_id")
     if not isinstance(issuer, str) or not issuer or not isinstance(token_id, str) or not token_id:
         fail("replay-binding", "issuer and token ID must be non-empty strings")
-    return sha256(f"{issuer}\0{token_id}".encode("utf-8"))
+    encoded = json.dumps(
+        {"issuer": issuer, "token_id": token_id}, ensure_ascii=True,
+        sort_keys=True, separators=(",", ":"),
+    ).encode("ascii")
+    return sha256(encoded)
 
 
 def validate_v2_metadata(
@@ -558,6 +581,37 @@ class DocumentProjection(NamedTuple):
     public_headers: tuple[str, ...]
 
 
+class GitDecisionBudget:
+    """Bound and deduplicate all Git work performed for one decision."""
+
+    def __init__(self) -> None:
+        self.git_operations = 0
+        self.evidence_references = 0
+        self.distinct_blob_bytes = 0
+        self.blobs: dict[tuple[str, str, str], bytes] = {}
+
+    def consume_git_operation(self) -> None:
+        self.git_operations += 1
+        if self.git_operations > MAX_DECISION_GIT_OPERATIONS:
+            fail("git-operation-budget", "decision exceeds the Git operation budget")
+
+    def consume_evidence_reference(self) -> None:
+        self.evidence_references += 1
+        if self.evidence_references > MAX_DECISION_EVIDENCE_REFERENCES:
+            fail("document-evidence-budget", "decision exceeds the evidence-reference budget")
+
+    def cache_blob(self, key: tuple[str, str, str], raw: bytes) -> None:
+        self.distinct_blob_bytes += len(raw)
+        if self.distinct_blob_bytes > MAX_DECISION_DISTINCT_BLOB_BYTES:
+            fail("git-byte-budget", "decision exceeds the distinct-blob byte budget")
+        self.blobs[key] = raw
+
+
+_ACTIVE_GIT_BUDGET: ContextVar[GitDecisionBudget | None] = ContextVar(
+    "module_doc_git_budget", default=None
+)
+
+
 class GitBlobReader:
     """Read governed files from one immutable commit, never a working tree."""
 
@@ -566,39 +620,70 @@ class GitBlobReader:
             fail("git-candidate", "candidate must be a full lowercase commit ID")
         self.repository = repository
         self.commit = commit
+        self.budget = _ACTIVE_GIT_BUDGET.get() or GitDecisionBudget()
         resolved = self._git("rev-parse", "--verify", f"{commit}^{{commit}}")
         if resolved.decode("ascii").strip() != commit:
             fail("git-candidate", "candidate does not resolve to itself")
 
     def _git(self, *arguments: str) -> bytes:
-        result = subprocess.run(
-            ["git", *arguments], cwd=self.repository, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, check=False,
-            env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/bin"},
-        )
-        if result.returncode != 0:
-            fail("git-object", result.stderr.decode("utf-8", "replace").strip())
-        return result.stdout
+        return self._git_bounded(65_536, *arguments)
 
     def _git_bounded(self, max_bytes: int, *arguments: str) -> bytes:
+        self.budget.consume_git_operation()
         process = subprocess.Popen(
             ["git", *arguments], cwd=self.repository, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/bin"},
         )
         assert process.stdout is not None and process.stderr is not None
+        selector = selectors.DefaultSelector()
+        selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+        selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+        output = bytearray()
+        errors = bytearray()
+        deadline = time.monotonic() + GIT_OPERATION_TIMEOUT_SECONDS
         try:
-            output = process.stdout.read(max_bytes + 1)
-            if len(output) > max_bytes:
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    process.kill()
+                    process.wait()
+                    fail("git-timeout", "Git operation exceeded its wall-clock limit")
+                events = selector.select(remaining)
+                if not events:
+                    continue
+                for key, _ in events:
+                    chunk = os.read(key.fd, 65_536)
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+                    sink = output if key.data == "stdout" else errors
+                    sink.extend(chunk)
+                    ceiling = max_bytes if key.data == "stdout" else MAX_GIT_STDERR_BYTES
+                    if len(sink) > ceiling:
+                        process.kill()
+                        process.wait()
+                        rule = "git-output-size" if key.data == "stdout" else "git-stderr-size"
+                        fail(rule, f"Git {key.data} exceeds {ceiling} bytes")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
                 process.kill()
-                process.communicate()
-                fail("git-tree-size", f"git tree output exceeds {max_bytes} bytes")
-            stderr = process.stderr.read()
-            returncode = process.wait()
+                process.wait()
+                fail("git-timeout", "Git operation exceeded its wall-clock limit")
+            try:
+                returncode = process.wait(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+                fail("git-timeout", "Git operation exceeded its wall-clock limit")
             if returncode != 0:
-                fail("git-object", stderr.decode("utf-8", "replace").strip())
-            return output
+                fail("git-object", bytes(errors).decode("utf-8", "replace").strip())
+            return bytes(output)
         finally:
+            selector.close()
+            if process.poll() is None:
+                process.kill()
+                process.wait()
             process.stdout.close()
             process.stderr.close()
 
@@ -612,6 +697,14 @@ class GitBlobReader:
 
     def read_blob(self, path: str, *, max_bytes: int = MAX_GOVERNED_BLOB_BYTES) -> bytes:
         self.canonical_path(path)
+        if type(max_bytes) is not int or not 1 <= max_bytes <= MAX_GOVERNED_BLOB_BYTES:
+            fail("git-object-size", "requested blob limit is outside the verifier ceiling")
+        cache_key = (str(self.repository.resolve()), self.commit, path)
+        cached = self.budget.blobs.get(cache_key)
+        if cached is not None:
+            if len(cached) > max_bytes:
+                fail("git-object-size", f"{path!r} exceeds {max_bytes} bytes")
+            return cached
         record = self._git("ls-tree", "-z", "--full-tree", self.commit, "--", path)
         entries = [entry for entry in record.split(b"\0") if entry]
         if len(entries) != 1:
@@ -631,13 +724,12 @@ class GitBlobReader:
             size = int(size_raw.decode("ascii").strip())
         except (UnicodeDecodeError, ValueError):
             fail("git-object", f"cannot determine size for {path!r}")
-        if type(max_bytes) is not int or not 1 <= max_bytes <= MAX_GOVERNED_BLOB_BYTES:
-            fail("git-object-size", "requested blob limit is outside the verifier ceiling")
         if size > max_bytes:
             fail("git-object-size", f"{path!r} exceeds {max_bytes} bytes")
-        raw = self._git("cat-file", "blob", object_id.decode("ascii"))
+        raw = self._git_bounded(max_bytes, "cat-file", "blob", object_id.decode("ascii"))
         if len(raw) != size:
             fail("git-object-size", f"{path!r} size changed while reading immutable object")
+        self.budget.cache_blob(cache_key, raw)
         return raw
 
     def list_directory(self, path: str) -> dict[str, tuple[str, str]]:
@@ -662,6 +754,7 @@ class GitBlobReader:
         return result
 
     def resolve_reference(self, reference: str) -> None:
+        self.budget.consume_evidence_reference()
         match = REFERENCE_RE.fullmatch(reference)
         if not match:
             fail("document-evidence", f"invalid evidence reference {reference!r}")
@@ -764,6 +857,18 @@ def parse_module_document(
         fail("document-heading", f"unexpected heading {unexpected[0]!r}")
 
     total_tokens = 0
+    document_evidence_references = 0
+
+    def validate_doc_reference(reference: str, line: int) -> None:
+        nonlocal document_evidence_references
+        document_evidence_references += 1
+        if document_evidence_references > MAX_DOCUMENT_EVIDENCE_REFERENCES:
+            fail(
+                "document-evidence-budget",
+                f"document exceeds {MAX_DOCUMENT_EVIDENCE_REFERENCES} evidence references",
+            )
+        _validate_reference(reference, line=line, resolver=resolve_reference)
+
     for section_index, start in enumerate(positions):
         end = positions[section_index + 1] if section_index + 1 < len(positions) else len(lines)
         body = lines[start + 1:end]
@@ -784,9 +889,7 @@ def parse_module_document(
                 prose = body[1 if prefix.startswith("Reason") else 2][len(prefix):]
                 if not PROSE_RE.fullmatch(prose):
                     fail("document-prose", f"invalid {prefix.strip()} prose")
-            _validate_reference(
-                body[3][len("Evidence: "):], line=start + 5, resolver=resolve_reference
-            )
+            validate_doc_reference(body[3][len("Evidence: "):], start + 5)
             cursor = 4
         elif any(item.startswith(("Reason: ", "Implication: ", "Evidence: ")) for item in body[1:]):
             fail("document-state-label", "none-state labels are forbidden for present state")
@@ -808,9 +911,7 @@ def parse_module_document(
         evidence_started = False
         for record in records:
             if record.startswith("- Evidence: "):
-                _validate_reference(
-                    record[len("- Evidence: "):], line=start + 2, resolver=resolve_reference
-                )
+                validate_doc_reference(record[len("- Evidence: "):], start + 2)
                 evidence_count += 1
                 evidence_started = True
                 continue
@@ -1320,15 +1421,19 @@ def evaluate_trigger(
     workload = normalize_verified_oidc_claims(verified_claims, profile, wall_time=wall_time)
     target = validate_candidate_target(resolve_target(workload, pull_request))
     bind_workload_to_target(workload, target, pull_request=pull_request)
+    budget_token = _ACTIVE_GIT_BUDGET.set(GitDecisionBudget())
     try:
-        reader = GitBlobReader(repository, target["candidate_revision"])
-        summary = validate_candidate(reader, workload, target)
-        if not isinstance(summary, str) or not summary:
-            fail("candidate-validation", "candidate validator returned no summary")
-        conclusion = "success"
-    except ContractError as exc:
-        summary = str(exc)[:4096]
-        conclusion = "failure"
+        try:
+            reader = GitBlobReader(repository, target["candidate_revision"])
+            summary = validate_candidate(reader, workload, target)
+            if not isinstance(summary, str) or not summary:
+                fail("candidate-validation", "candidate validator returned no summary")
+            conclusion = "success"
+        except ContractError as exc:
+            summary = str(exc)[:4096]
+            conclusion = "failure"
+    finally:
+        _ACTIVE_GIT_BUDGET.reset(budget_token)
     result = validate_publisher_result(
         {
             "schema": "aimee.module-doc-check.v1",

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -59,6 +59,7 @@ MAX_DECISION_EVIDENCE_REFERENCES = 2_048
 MAX_DECISION_DISTINCT_BLOB_BYTES = 67_108_864
 MAX_DECISION_GIT_OPERATIONS = 2_048
 GIT_OPERATION_TIMEOUT_SECONDS = 10
+MAX_DECISION_GIT_WALL_SECONDS = 60
 MAX_GIT_STDERR_BYTES = 65_536
 
 SECTIONS = (
@@ -589,6 +590,7 @@ class GitDecisionBudget:
         self.evidence_references = 0
         self.distinct_blob_bytes = 0
         self.blobs: dict[tuple[str, str, str], bytes] = {}
+        self.git_deadline = time.monotonic() + MAX_DECISION_GIT_WALL_SECONDS
 
     def consume_git_operation(self) -> None:
         self.git_operations += 1
@@ -630,10 +632,14 @@ class GitBlobReader:
 
     def _git_bounded(self, max_bytes: int, *arguments: str) -> bytes:
         self.budget.consume_git_operation()
+        remaining_decision = self.budget.git_deadline - time.monotonic()
+        if remaining_decision <= 0:
+            fail("git-timeout", "decision exhausted its Git wall-clock budget")
         process = subprocess.Popen(
             ["git", *arguments], cwd=self.repository, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/bin"},
+            start_new_session=True,
         )
         assert process.stdout is not None and process.stderr is not None
         selector = selectors.DefaultSelector()
@@ -641,13 +647,23 @@ class GitBlobReader:
         selector.register(process.stderr, selectors.EVENT_READ, "stderr")
         output = bytearray()
         errors = bytearray()
-        deadline = time.monotonic() + GIT_OPERATION_TIMEOUT_SECONDS
+        deadline = time.monotonic() + min(
+            GIT_OPERATION_TIMEOUT_SECONDS, remaining_decision
+        )
+
+        def terminate() -> None:
+            if process.poll() is not None:
+                return
+            try:
+                os.killpg(process.pid, 9)
+            except ProcessLookupError:
+                pass
+            process.wait()
         try:
             while selector.get_map():
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    process.kill()
-                    process.wait()
+                    terminate()
                     fail("git-timeout", "Git operation exceeded its wall-clock limit")
                 events = selector.select(remaining)
                 if not events:
@@ -661,20 +677,17 @@ class GitBlobReader:
                     sink.extend(chunk)
                     ceiling = max_bytes if key.data == "stdout" else MAX_GIT_STDERR_BYTES
                     if len(sink) > ceiling:
-                        process.kill()
-                        process.wait()
+                        terminate()
                         rule = "git-output-size" if key.data == "stdout" else "git-stderr-size"
                         fail(rule, f"Git {key.data} exceeds {ceiling} bytes")
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                process.kill()
-                process.wait()
+                terminate()
                 fail("git-timeout", "Git operation exceeded its wall-clock limit")
             try:
                 returncode = process.wait(timeout=remaining)
             except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait()
+                terminate()
                 fail("git-timeout", "Git operation exceeded its wall-clock limit")
             if returncode != 0:
                 fail("git-object", bytes(errors).decode("utf-8", "replace").strip())
@@ -682,8 +695,7 @@ class GitBlobReader:
         finally:
             selector.close()
             if process.poll() is None:
-                process.kill()
-                process.wait()
+                terminate()
             process.stdout.close()
             process.stderr.close()
 

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -49,6 +49,9 @@ MAX_DOCUMENT_BYTES = 262_144
 MAX_SUBJECT_BYTES = 4_096
 MAX_SIGNATURE_BYTES = 16_384
 MAX_INDEX_BYTES = 65_536
+MAX_INTEGER_DIGITS = 20
+MAX_TREE_BYTES = 1_048_576
+MAX_TREE_ENTRIES = 4_096
 
 SECTIONS = (
     "Purpose and non-goals",
@@ -127,6 +130,16 @@ def _reject_number(value: str) -> NoReturn:
     fail("json-number-domain", f"forbidden number {value!r}")
 
 
+def _parse_integer(value: str) -> int:
+    digits = value[1:] if value.startswith("-") else value
+    if len(digits) > MAX_INTEGER_DIGITS:
+        fail("json-integer-range", f"integer exceeds {MAX_INTEGER_DIGITS} digits")
+    try:
+        return int(value)
+    except ValueError:
+        fail("json-integer-range", "invalid integer")
+
+
 def strict_json_bytes(raw: bytes) -> object:
     if len(raw) > MAX_JSON_BYTES:
         fail("json-size", f"JSON exceeds {MAX_JSON_BYTES} bytes")
@@ -140,6 +153,7 @@ def strict_json_bytes(raw: bytes) -> object:
         value = json.loads(
             text,
             object_pairs_hook=_object_without_duplicates,
+            parse_int=_parse_integer,
             parse_float=_reject_number,
             parse_constant=_reject_number,
         )
@@ -362,7 +376,7 @@ def normalize_verified_oidc_claims(
     iat = claims["iat"]
     nbf = claims["nbf"]
     exp = claims["exp"]
-    if nbf > wall_time or wall_time > exp:
+    if nbf > wall_time or wall_time >= exp:
         fail("oidc-validity-window", "token is outside nbf/exp validity")
     if abs(wall_time - iat) > profile["clock_skew_seconds"]:
         fail("oidc-issued-at", "iat is outside the configured clock skew")
@@ -473,6 +487,14 @@ def replay_binding(workload: dict[str, object], target: dict[str, object]) -> st
     return sha256("\0".join(fields).encode("utf-8"))
 
 
+def replay_token_identity(workload: dict[str, object]) -> str:
+    issuer = workload.get("issuer")
+    token_id = workload.get("token_id")
+    if not isinstance(issuer, str) or not issuer or not isinstance(token_id, str) or not token_id:
+        fail("replay-binding", "issuer and token ID must be non-empty strings")
+    return sha256(f"{issuer}\0{token_id}".encode("utf-8"))
+
+
 def validate_v2_metadata(
     value: object, *, optional: bool, known_ids: set[str] | None = None
 ) -> dict[str, object]:
@@ -558,6 +580,28 @@ class GitBlobReader:
             fail("git-object", result.stderr.decode("utf-8", "replace").strip())
         return result.stdout
 
+    def _git_bounded(self, max_bytes: int, *arguments: str) -> bytes:
+        process = subprocess.Popen(
+            ["git", *arguments], cwd=self.repository, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/bin"},
+        )
+        assert process.stdout is not None and process.stderr is not None
+        try:
+            output = process.stdout.read(max_bytes + 1)
+            if len(output) > max_bytes:
+                process.kill()
+                process.communicate()
+                fail("git-tree-size", f"git tree output exceeds {max_bytes} bytes")
+            stderr = process.stderr.read()
+            returncode = process.wait()
+            if returncode != 0:
+                fail("git-object", stderr.decode("utf-8", "replace").strip())
+            return output
+        finally:
+            process.stdout.close()
+            process.stderr.close()
+
     @staticmethod
     def canonical_path(path: str) -> None:
         if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", path):
@@ -598,9 +642,14 @@ class GitBlobReader:
 
     def list_directory(self, path: str) -> dict[str, tuple[str, str]]:
         self.canonical_path(path)
-        record = self._git("ls-tree", "-z", f"{self.commit}:{path}")
+        record = self._git_bounded(
+            MAX_TREE_BYTES, "ls-tree", "-z", f"{self.commit}:{path}"
+        )
         result: dict[str, tuple[str, str]] = {}
-        for entry in (item for item in record.split(b"\0") if item):
+        entries = [item for item in record.split(b"\0") if item]
+        if len(entries) > MAX_TREE_ENTRIES:
+            fail("git-tree-entries", f"directory exceeds {MAX_TREE_ENTRIES} entries")
+        for entry in entries:
             try:
                 metadata, name = entry.split(b"\t", 1)
                 mode, kind, object_id = metadata.split(b" ", 2)
@@ -634,9 +683,14 @@ class GitBlobReader:
         if match.group("literal"):
             directory += f"/{match.group('literal')}"
         suffix = f".{match.group('suffix')}"
-        record = self._git("ls-tree", "-z", f"{self.commit}:{directory}")
+        record = self._git_bounded(
+            MAX_TREE_BYTES, "ls-tree", "-z", f"{self.commit}:{directory}"
+        )
         paths: list[str] = []
-        for entry in (item for item in record.split(b"\0") if item):
+        entries = [item for item in record.split(b"\0") if item]
+        if len(entries) > MAX_TREE_ENTRIES:
+            fail("git-tree-entries", f"directory exceeds {MAX_TREE_ENTRIES} entries")
+        for entry in entries:
             try:
                 metadata, name = entry.split(b"\t", 1)
                 mode, kind, _ = metadata.split(b" ", 2)
@@ -1235,7 +1289,8 @@ def validate_publisher_result(value: object, target: dict[str, object]) -> dict[
 class VerificationDecision(NamedTuple):
     workload: dict[str, object]
     target: dict[str, object]
-    replay_key: str
+    token_replay_key: str
+    decision_replay_key: str
     publisher_result: dict[str, object]
 
 
@@ -1265,22 +1320,33 @@ def evaluate_trigger(
     workload = normalize_verified_oidc_claims(verified_claims, profile, wall_time=wall_time)
     target = validate_candidate_target(resolve_target(workload, pull_request))
     bind_workload_to_target(workload, target, pull_request=pull_request)
-    reader = GitBlobReader(repository, target["candidate_revision"])
-    summary = validate_candidate(reader, workload, target)
-    if not isinstance(summary, str) or not summary:
-        fail("candidate-validation", "candidate validator returned no summary")
+    try:
+        reader = GitBlobReader(repository, target["candidate_revision"])
+        summary = validate_candidate(reader, workload, target)
+        if not isinstance(summary, str) or not summary:
+            fail("candidate-validation", "candidate validator returned no summary")
+        conclusion = "success"
+    except ContractError as exc:
+        summary = str(exc)[:4096]
+        conclusion = "failure"
     result = validate_publisher_result(
         {
             "schema": "aimee.module-doc-check.v1",
             "name": "module-doc-attestation",
             "candidate_revision": target["candidate_revision"],
             "external_id": target["trigger_check_identity"],
-            "conclusion": "success",
+            "conclusion": conclusion,
             "summary": summary,
         },
         target,
     )
-    return VerificationDecision(workload, target, replay_binding(workload, target), result)
+    return VerificationDecision(
+        workload,
+        target,
+        replay_token_identity(workload),
+        replay_binding(workload, target),
+        result,
+    )
 
 
 def verify_sshsig(

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Deterministic contracts for module documentation attestation.
+
+This module deliberately contains no identity-provider constants.  Deployments
+provide a strict CI OIDC issuer profile; the verifier normalizes its claims into
+the provider-independent workload record defined here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import tempfile
+from typing import Callable, NamedTuple, NoReturn
+
+
+MODULE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,254}$")
+CLAIM_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:/-]{0,127}$")
+PROSE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ,.;:()'/_-]*[A-Za-z0-9.)]$")
+TOKEN_RE = re.compile(r"[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*")
+REFERENCE_RE = re.compile(
+    r"^(?:module:(?P<module>[a-z][a-z0-9]*(?:-[a-z0-9]+)*)|"
+    r"path:(?P<path>[A-Za-z0-9][A-Za-z0-9._/-]*)(?:#L(?P<line>[1-9][0-9]*))?)$"
+)
+TIMESTAMP_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+
+SECTIONS = (
+    "Purpose and non-goals",
+    "Classification and lifecycle",
+    "Public contracts",
+    "Dependencies and consumers",
+    "Providers and readiness",
+    "Configuration and activation",
+    "Routes, commands, protocols, and stages",
+    "Data and migrations",
+    "Security and privacy",
+    "Supported journeys",
+    "Tests and failure behavior",
+    "Operational diagnostics",
+    "Compatibility aliases",
+    "Extension and removal rules",
+)
+
+WORKLOAD_FIELDS = (
+    "repository_identity",
+    "workflow_identity",
+    "workflow_revision",
+    "run_identity",
+    "attempt",
+    "trigger_check_identity",
+    "event_type",
+    "actor_identity",
+    "runner_class",
+)
+SOURCE_PATTERN_RE = re.compile(
+    r"^src/modules/(?P<module>[a-z][a-z0-9]*(?:-[a-z0-9]+)*)/"
+    r"(?:(?P<literal>[a-z][a-z0-9_-]*)/)?\*\.(?P<suffix>[ch])$"
+)
+
+
+class ContractError(ValueError):
+    """A fail-closed contract violation with a stable rule identifier."""
+
+
+def fail(rule: str, message: str, *, line: int | None = None) -> NoReturn:
+    location = f" line={line}" if line is not None else ""
+    raise ContractError(f"rule={rule}{location}: {message}")
+
+
+def _object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            fail("json-duplicate-key", f"duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_number(value: str) -> NoReturn:
+    fail("json-number-domain", f"forbidden number {value!r}")
+
+
+def strict_json_bytes(raw: bytes) -> object:
+    if raw.startswith(b"\xef\xbb\xbf"):
+        fail("json-bom", "UTF-8 BOM is forbidden")
+    try:
+        text = raw.decode("utf-8", "strict")
+    except UnicodeDecodeError as exc:
+        fail("json-encoding", str(exc))
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=_object_without_duplicates,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+    except json.JSONDecodeError as exc:
+        fail("json-parse", f"{exc.msg} at {exc.lineno}:{exc.colno}")
+    _reject_surrogates(value)
+    return value
+
+
+def _reject_surrogates(value: object) -> None:
+    if isinstance(value, str):
+        if any(0xD800 <= ord(char) <= 0xDFFF for char in value):
+            fail("json-surrogate", "surrogate code point is forbidden")
+    elif isinstance(value, list):
+        for item in value:
+            _reject_surrogates(item)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            _reject_surrogates(key)
+            _reject_surrogates(item)
+
+
+def _exact_object(value: object, keys: set[str], rule: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        fail(rule, "expected object")
+    if set(value) != keys:
+        fail(rule, f"keys mismatch; missing={sorted(keys-set(value))}, unknown={sorted(set(value)-keys)}")
+    return value
+
+
+def _string(value: object, rule: str) -> str:
+    if not isinstance(value, str) or not value:
+        fail(rule, "expected non-empty string")
+    return value
+
+
+def validate_oidc_profile(value: object) -> dict[str, object]:
+    """Validate a provider-neutral CI issuer profile.
+
+    Cryptographic JWT verification is performed by the deployed verifier.  This
+    function closes the configuration surface that selects trust, algorithms,
+    normalized claims, and immutable workload predicates.
+    """
+    profile = _exact_object(
+        value,
+        {
+            "schema", "name", "issuer", "audience", "jwks", "allowed_algorithms",
+            "max_token_lifetime_seconds", "clock_skew_seconds", "claim_mappings",
+            "predicates", "repository_api",
+        },
+        "oidc-profile-shape",
+    )
+    if profile["schema"] != "aimee.ci-oidc-profile.v1":
+        fail("oidc-profile-schema", "unsupported schema")
+    name = _string(profile["name"], "oidc-profile-name")
+    if not MODULE_ID_RE.fullmatch(name):
+        fail("oidc-profile-name", "name must use canonical identifier syntax")
+    for field in ("issuer", "audience"):
+        text = _string(profile[field], f"oidc-{field}")
+        if field == "issuer" and (not text.startswith("https://") or text.endswith("/")):
+            fail("oidc-issuer", "issuer must be an exact HTTPS URL without trailing slash")
+
+    jwks = _exact_object(
+        profile["jwks"], {"uri", "tls_spki_sha256", "max_age_seconds"}, "oidc-jwks-shape"
+    )
+    if not _string(jwks["uri"], "oidc-jwks-uri").startswith("https://"):
+        fail("oidc-jwks-uri", "JWKS URI must use HTTPS")
+    pins = jwks["tls_spki_sha256"]
+    if not isinstance(pins, list) or not pins or not all(isinstance(pin, str) and HEX_64_RE.fullmatch(pin) for pin in pins):
+        fail("oidc-jwks-pins", "at least one lowercase SHA-256 SPKI pin is required")
+    if pins != sorted(set(pins)):
+        fail("oidc-jwks-pins", "SPKI pins must be sorted and unique")
+    if type(jwks["max_age_seconds"]) is not int or not 1 <= jwks["max_age_seconds"] <= 86400:
+        fail("oidc-jwks-max-age", "max_age_seconds must be an integer in [1, 86400]")
+
+    algorithms = profile["allowed_algorithms"]
+    allowed = {"EdDSA", "ES256", "RS256", "PS256"}
+    if not isinstance(algorithms, list) or not algorithms or algorithms != sorted(set(algorithms)):
+        fail("oidc-algorithms", "allowed_algorithms must be a sorted unique non-empty array")
+    if any(type(item) is not str or item not in allowed for item in algorithms):
+        fail("oidc-algorithms", "algorithm is not in the closed allowlist")
+    lifetime = profile["max_token_lifetime_seconds"]
+    skew = profile["clock_skew_seconds"]
+    if type(lifetime) is not int or not 1 <= lifetime <= 600:
+        fail("oidc-token-lifetime", "maximum token lifetime must be in [1, 600]")
+    if type(skew) is not int or not 0 <= skew <= 60:
+        fail("oidc-clock-skew", "clock skew must be in [0, 60]")
+
+    mappings = _exact_object(profile["claim_mappings"], set(WORKLOAD_FIELDS), "oidc-claim-mappings")
+    for field, claim in mappings.items():
+        if not isinstance(claim, str) or not CLAIM_RE.fullmatch(claim):
+            fail("oidc-claim-name", f"invalid claim mapping for {field}")
+    if len(set(mappings.values())) != len(mappings):
+        fail("oidc-claim-alias", "one token claim cannot populate multiple workload fields")
+
+    predicates = profile["predicates"]
+    if not isinstance(predicates, dict) or not predicates:
+        fail("oidc-predicates", "at least one immutable workload predicate is required")
+    unknown = set(predicates) - set(WORKLOAD_FIELDS)
+    if unknown:
+        fail("oidc-predicates", f"unknown normalized fields: {sorted(unknown)}")
+    required_predicates = {"repository_identity", "workflow_identity", "workflow_revision", "event_type"}
+    if not required_predicates <= set(predicates):
+        fail("oidc-predicates", f"missing immutable predicates: {sorted(required_predicates-set(predicates))}")
+    if any(not isinstance(item, str) or not item for item in predicates.values()):
+        fail("oidc-predicates", "predicate values must be non-empty strings")
+
+    api = _exact_object(
+        profile["repository_api"], {"base_url", "tls_spki_sha256", "response_schema"},
+        "repository-api-shape",
+    )
+    if not _string(api["base_url"], "repository-api-url").startswith("https://"):
+        fail("repository-api-url", "repository API must use HTTPS")
+    if not isinstance(api["tls_spki_sha256"], list) or not api["tls_spki_sha256"]:
+        fail("repository-api-pins", "repository API requires SPKI pins")
+    if any(not isinstance(pin, str) or not HEX_64_RE.fullmatch(pin) for pin in api["tls_spki_sha256"]):
+        fail("repository-api-pins", "invalid repository API SPKI pin")
+    if api["response_schema"] != "aimee.candidate-target.v1":
+        fail("repository-api-schema", "unsupported candidate-target schema")
+    return profile
+
+
+STANDARD_CLAIMS = {"iss", "sub", "aud", "iat", "nbf", "exp", "jti"}
+
+
+def normalize_verified_oidc_claims(
+    claims: object, profile: dict[str, object], *, wall_time: int
+) -> dict[str, object]:
+    """Normalize claims only after the caller verifies the JWT signature.
+
+    The external verifier must reject redirects, select a configured algorithm,
+    validate the pinned JWKS transport, and verify the JWS before calling this
+    function.  Keeping that dependency injection explicit prevents this
+    standard-library contract module from pretending to perform JOSE crypto.
+    """
+    if not isinstance(claims, dict):
+        fail("oidc-claims", "verified claims must be an object")
+    missing = STANDARD_CLAIMS - set(claims)
+    if missing:
+        fail("oidc-standard-claims", f"missing standard claims: {sorted(missing)}")
+    if claims["iss"] != profile["issuer"]:
+        fail("oidc-issuer-mismatch", "issuer does not match the selected profile")
+    audience = claims["aud"]
+    if audience != profile["audience"] and not (
+        isinstance(audience, list) and audience == [profile["audience"]]
+    ):
+        fail("oidc-audience-mismatch", "audience must exactly match the profile")
+    if not isinstance(claims["sub"], str) or not claims["sub"]:
+        fail("oidc-subject", "subject must be a non-empty string")
+    if not isinstance(claims["jti"], str) or not claims["jti"]:
+        fail("oidc-token-id", "token ID must be a non-empty string")
+    for field in ("iat", "nbf", "exp"):
+        if type(claims[field]) is not int:
+            fail("oidc-time-claim", f"{field} must be an integer NumericDate")
+    iat = claims["iat"]
+    nbf = claims["nbf"]
+    exp = claims["exp"]
+    if nbf > wall_time or wall_time > exp:
+        fail("oidc-validity-window", "token is outside nbf/exp validity")
+    if abs(wall_time - iat) > profile["clock_skew_seconds"]:
+        fail("oidc-issued-at", "iat is outside the configured clock skew")
+    if not 0 < exp - iat <= profile["max_token_lifetime_seconds"]:
+        fail("oidc-token-lifetime", "token lifetime is invalid")
+
+    workload: dict[str, object] = {
+        "issuer": claims["iss"],
+        "subject": claims["sub"],
+        "audience": profile["audience"],
+        "issued_at": iat,
+        "not_before": nbf,
+        "expires_at": exp,
+        "token_id": claims["jti"],
+    }
+    mappings = profile["claim_mappings"]
+    assert isinstance(mappings, dict)
+    for field in WORKLOAD_FIELDS:
+        claim_name = mappings[field]
+        if claim_name not in claims:
+            fail("oidc-mapped-claim", f"claim mapped to {field!r} is missing")
+        value = claims[claim_name]
+        if not isinstance(value, (str, int)) or isinstance(value, bool) or value == "":
+            fail("oidc-mapped-claim", f"claim mapped to {field!r} has invalid type")
+        workload[field] = str(value)
+    predicates = profile["predicates"]
+    assert isinstance(predicates, dict)
+    for field, expected in predicates.items():
+        if workload[field] != expected:
+            fail("oidc-workload-predicate", f"normalized field {field!r} does not match policy")
+    return workload
+
+
+def validate_trigger_request(value: object) -> tuple[int, str]:
+    request = _exact_object(value, {"schema", "pull_request", "oidc_token"}, "trigger-request-shape")
+    if request["schema"] != "aimee.module-doc-trigger.v1":
+        fail("trigger-request-schema", "unsupported trigger request schema")
+    if type(request["pull_request"]) is not int or request["pull_request"] < 1:
+        fail("trigger-request-pr", "pull_request must be a positive integer")
+    token = _string(request["oidc_token"], "trigger-request-token")
+    if len(token) > 16384:
+        fail("trigger-request-token", "OIDC token exceeds 16384 bytes")
+    return request["pull_request"], token
+
+
+def validate_candidate_target(value: object) -> dict[str, str]:
+    target = _exact_object(
+        value,
+        {"schema", "repository_identity", "pull_request", "protected_base_revision",
+         "candidate_revision", "base_ref", "head_ref", "trigger_check_identity"},
+        "candidate-target-shape",
+    )
+    if target["schema"] != "aimee.candidate-target.v1":
+        fail("candidate-target-schema", "unsupported candidate-target schema")
+    if type(target["pull_request"]) is not int or target["pull_request"] < 1:
+        fail("candidate-target-pr", "pull_request must be a positive integer")
+    for field in ("protected_base_revision", "candidate_revision"):
+        if not isinstance(target[field], str) or not re.fullmatch(r"[0-9a-f]{40}", target[field]):
+            fail("candidate-target-revision", f"{field} must be a full lowercase commit ID")
+    for field in ("repository_identity", "base_ref", "head_ref", "trigger_check_identity"):
+        if not isinstance(target[field], str) or not target[field]:
+            fail("candidate-target-field", f"{field} must be a non-empty string")
+    return target
+
+
+def bind_workload_to_target(
+    workload: dict[str, object], target: dict[str, object], *, pull_request: int
+) -> None:
+    if target["pull_request"] != pull_request:
+        fail("target-request-binding", "repository API returned a different pull request")
+    if target["repository_identity"] != workload["repository_identity"]:
+        fail("target-repository-binding", "repository identity mismatch")
+    if target["trigger_check_identity"] != workload["trigger_check_identity"]:
+        fail("target-trigger-binding", "trigger check identity mismatch")
+
+
+def validate_v2_metadata(value: object, *, optional: bool) -> dict[str, object]:
+    """Validate descriptor-v2 additions without enabling v2 production yet."""
+    base = {"descriptor_version", "id", "dependencies", "runtime_toggle"}
+    keys = base | {"docs", "sources", "public_headers", "surfaces"}
+    if optional:
+        keys.add("enabled_by_default")
+    descriptor = _exact_object(value, keys, "v2-descriptor-shape")
+    if descriptor["descriptor_version"] != 2 or type(descriptor["descriptor_version"]) is not int:
+        fail("v2-descriptor-version", "descriptor_version must equal 2")
+    module_id = descriptor["id"]
+    if not isinstance(module_id, str) or not MODULE_ID_RE.fullmatch(module_id):
+        fail("v2-module-id", "invalid module ID")
+    if descriptor["docs"] != f"docs/modules/{module_id}.md":
+        fail("v2-doc-path", "docs path must be derived from the module ID")
+    for field in ("sources", "public_headers"):
+        entries = descriptor[field]
+        if not isinstance(entries, list) or entries != sorted(set(entries)):
+            fail("v2-pattern-order", f"{field} must be a sorted unique array")
+        if any(not isinstance(item, str) for item in entries):
+            fail("v2-pattern-type", f"{field} entries must be strings")
+    for pattern in descriptor["sources"]:
+        match = SOURCE_PATTERN_RE.fullmatch(pattern)
+        if not match or match.group("module") != module_id:
+            fail("v2-source-pattern", f"invalid or cross-module source pattern {pattern!r}")
+    if descriptor["public_headers"]:
+        fail("v2-public-headers-deferred", "public headers must remain empty until canonical layout exists")
+    surfaces = _exact_object(
+        descriptor["surfaces"], {"routes", "commands", "protocols", "stages"},
+        "v2-surfaces-shape",
+    )
+    for field, entries in surfaces.items():
+        if entries != []:
+            fail("v2-surfaces-deferred", f"{field} must remain empty until protected inventory exists")
+    return descriptor
+
+
+class DocumentProjection(NamedTuple):
+    sources: tuple[str, ...]
+    public_headers: tuple[str, ...]
+
+
+class GitBlobReader:
+    """Read governed files from one immutable commit, never a working tree."""
+
+    def __init__(self, repository: Path, commit: str):
+        if not re.fullmatch(r"[0-9a-f]{40}", commit):
+            fail("git-candidate", "candidate must be a full lowercase commit ID")
+        self.repository = repository
+        self.commit = commit
+        resolved = self._git("rev-parse", "--verify", f"{commit}^{{commit}}")
+        if resolved.decode("ascii").strip() != commit:
+            fail("git-candidate", "candidate does not resolve to itself")
+
+    def _git(self, *arguments: str) -> bytes:
+        result = subprocess.run(
+            ["git", *arguments], cwd=self.repository, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=False,
+            env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/bin"},
+        )
+        if result.returncode != 0:
+            fail("git-object", result.stderr.decode("utf-8", "replace").strip())
+        return result.stdout
+
+    @staticmethod
+    def canonical_path(path: str) -> None:
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]*", path):
+            fail("git-path", "path contains forbidden bytes")
+        pure = PurePosixPath(path)
+        if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+            fail("git-path", "path is not canonical")
+
+    def read_blob(self, path: str) -> bytes:
+        self.canonical_path(path)
+        record = self._git("ls-tree", "-z", "--full-tree", self.commit, "--", path)
+        entries = [entry for entry in record.split(b"\0") if entry]
+        if len(entries) != 1:
+            fail("git-entry", f"expected one entry for {path!r}, actual {len(entries)}")
+        try:
+            metadata, returned_path = entries[0].split(b"\t", 1)
+            mode, kind, object_id = metadata.split(b" ", 2)
+            decoded_path = returned_path.decode("ascii", "strict")
+        except (ValueError, UnicodeDecodeError):
+            fail("git-entry", f"malformed ls-tree record for {path!r}")
+        if decoded_path != path:
+            fail("git-entry", "repository returned a different path")
+        if mode != b"100644" or kind != b"blob" or not re.fullmatch(rb"[0-9a-f]{40}", object_id):
+            fail("git-mode", f"{path!r} must be a mode 100644 blob")
+        raw = self._git("cat-file", "blob", object_id.decode("ascii"))
+        return raw
+
+    def resolve_reference(self, reference: str) -> None:
+        match = REFERENCE_RE.fullmatch(reference)
+        if not match:
+            fail("document-evidence", f"invalid evidence reference {reference!r}")
+        path = match.group("path")
+        if not path:
+            return
+        raw = self.read_blob(path)
+        if match.group("line") is not None:
+            requested = int(match.group("line"))
+            line_count = len(raw.splitlines())
+            if requested > line_count:
+                fail("document-evidence-line", f"line {requested} exceeds {line_count} lines in {path}")
+
+
+def _validate_reference(
+    reference: str, *, line: int, resolver: Callable[[str], None] | None = None
+) -> None:
+    match = REFERENCE_RE.fullmatch(reference)
+    if not match:
+        fail("document-evidence", f"invalid evidence reference {reference!r}", line=line)
+    path = match.group("path")
+    if path:
+        pure = PurePosixPath(path)
+        if pure.is_absolute() or ".." in pure.parts or "." in pure.parts or "//" in path:
+            fail("document-evidence", "evidence path is not canonical", line=line)
+    if resolver is not None:
+        resolver(reference)
+
+
+def parse_module_document(
+    raw: bytes,
+    module_id: str,
+    projection: DocumentProjection,
+    *,
+    resolve_reference: Callable[[str], None] | None = None,
+) -> None:
+    """Parse the exact module-document language and enforce content floors."""
+    if not MODULE_ID_RE.fullmatch(module_id):
+        fail("document-module-id", "invalid module ID")
+    if not raw or not raw.endswith(b"\n"):
+        fail("document-final-lf", "document must end with one LF")
+    if raw.endswith(b"\n\n"):
+        fail("document-trailing-blank", "trailing blank line is forbidden")
+    if any(byte not in (10,) and not 32 <= byte <= 126 for byte in raw):
+        fail("document-byte-domain", "only printable ASCII and LF are allowed")
+    lines = raw.decode("ascii").splitlines()
+    if not lines or lines[0] != f"# {module_id} module":
+        fail("document-h1", "H1 does not match module ID", line=1)
+    if len(lines) < 2 or lines[1] != "":
+        fail("document-record-spacing", "H1 must be followed by one blank line", line=2)
+
+    positions: list[int] = []
+    for title in SECTIONS:
+        heading = f"## {title}"
+        matches = [index for index, text in enumerate(lines) if text == heading]
+        if len(matches) != 1:
+            fail("document-section-cardinality", f"expected exactly one {heading!r}")
+        positions.append(matches[0])
+    if positions != sorted(positions):
+        fail("document-section-order", "H2 sections are out of order")
+    unexpected = [line for line in lines if line.startswith("#") and line not in {f"# {module_id} module", *(f"## {s}" for s in SECTIONS)}]
+    if unexpected:
+        fail("document-heading", f"unexpected heading {unexpected[0]!r}")
+
+    total_tokens = 0
+    for section_index, start in enumerate(positions):
+        end = positions[section_index + 1] if section_index + 1 < len(positions) else len(lines)
+        body = lines[start + 1:end]
+        if not body or body[0] not in {"State: present", "State: none"}:
+            fail("document-state", "state must immediately follow H2", line=start + 2)
+        if section_index + 1 < len(positions) and (not body or body[-1] != ""):
+            fail("document-record-spacing", "sections must be separated by one blank line", line=end)
+        if body and body[-1] == "":
+            body = body[:-1]
+        if any(body[index] == "" and (index == 0 or index + 1 == len(body) or body[index - 1] == "" or body[index + 1] == "") for index in range(len(body))):
+            fail("document-record-spacing", "blank lines may only separate records")
+        records = [item for item in body if item]
+        state = records.pop(0)
+        if state == "State: none":
+            if len(records) < 3 or not records[0].startswith("Reason: ") or not records[1].startswith("Implication: ") or not records[2].startswith("Evidence: "):
+                fail("document-none-block", "none state requires Reason, Implication, Evidence in order", line=start + 3)
+            for prefix in ("Reason: ", "Implication: "):
+                prose = records[0 if prefix.startswith("Reason") else 1][len(prefix):]
+                if not PROSE_RE.fullmatch(prose):
+                    fail("document-prose", f"invalid {prefix.strip()} prose")
+            _validate_reference(
+                records[2][len("Evidence: "):], line=start + 5, resolver=resolve_reference
+            )
+            records = records[3:]
+        elif any(item.startswith(("Reason: ", "Implication: ", "Evidence: ")) for item in records):
+            fail("document-state-label", "none-state labels are forbidden for present state")
+
+        expected_projection: list[str] = []
+        if section_index == 0:
+            expected_projection.append("Sources: " + (", ".join(projection.sources) or "none"))
+        elif section_index == 2:
+            expected_projection.append("Public headers: " + (", ".join(projection.public_headers) or "none"))
+        elif section_index == 6:
+            expected_projection.extend(("Routes: none", "Commands: none", "Protocols: none", "Stages: none"))
+        if records[:len(expected_projection)] != expected_projection:
+            fail("document-projection", f"projection mismatch in {SECTIONS[section_index]!r}")
+        records = records[len(expected_projection):]
+
+        prose_tokens = 0
+        evidence_count = 0
+        for record in records:
+            if record.startswith("- Evidence: "):
+                _validate_reference(
+                    record[len("- Evidence: "):], line=start + 2, resolver=resolve_reference
+                )
+                evidence_count += 1
+                continue
+            prose = record[2:] if record.startswith("- ") else record
+            if not PROSE_RE.fullmatch(prose):
+                fail("document-prose", f"invalid record {record!r}")
+            lowered = prose.casefold()
+            words = {word.casefold() for word in TOKEN_RE.findall(prose)}
+            if words & {"todo", "tbd", "placeholder"} or "coming soon" in lowered:
+                fail("document-placeholder", "placeholder language is forbidden")
+            prose_tokens += len(TOKEN_RE.findall(prose))
+        if evidence_count < 1:
+            fail("document-evidence-cardinality", "each section requires body evidence")
+        if prose_tokens < 25:
+            fail("document-section-word-floor", f"section has {prose_tokens} prose tokens; expected at least 25")
+        total_tokens += prose_tokens
+    if total_tokens < 600:
+        fail("document-total-word-floor", f"document has {total_tokens} prose tokens; expected at least 600")
+
+
+SUBJECT_KEYS = (
+    "descriptor_sha256", "document_sha256", "module_id", "owner_identity",
+    "reviewer_identity", "schema", "signed_at",
+)
+
+
+def parse_timestamp(value: object, rule: str) -> datetime:
+    if not isinstance(value, str) or not TIMESTAMP_RE.fullmatch(value):
+        fail(rule, "timestamp must be YYYY-MM-DDTHH:MM:SSZ")
+    try:
+        parsed = datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        fail(rule, f"invalid UTC Gregorian time: {exc}")
+    return parsed
+
+
+def canonical_subject(value: object) -> bytes:
+    subject = _exact_object(value, set(SUBJECT_KEYS), "subject-shape")
+    if subject["schema"] != "aimee.module-doc-attestation.v1":
+        fail("subject-schema", "unsupported schema")
+    if not isinstance(subject["module_id"], str) or not MODULE_ID_RE.fullmatch(subject["module_id"]):
+        fail("subject-module", "invalid module ID")
+    for field in ("descriptor_sha256", "document_sha256"):
+        if not isinstance(subject[field], str) or not HEX_64_RE.fullmatch(subject[field]):
+            fail("subject-hash", f"invalid {field}")
+    for field in ("owner_identity", "reviewer_identity"):
+        if not isinstance(subject[field], str) or not IDENTITY_RE.fullmatch(subject[field]):
+            fail("subject-identity", f"invalid {field}")
+    if subject["owner_identity"] == subject["reviewer_identity"]:
+        fail("subject-separation", "owner and reviewer must be distinct")
+    parse_timestamp(subject["signed_at"], "subject-signed-at")
+    ordered = {key: subject[key] for key in SUBJECT_KEYS}
+    return (json.dumps(ordered, indent=2, ensure_ascii=True, separators=(",", ": ")) + "\n").encode("ascii")
+
+
+def validate_trust_policy(value: object, *, at: datetime) -> dict[str, dict[str, object]]:
+    policy = _exact_object(value, {"schema", "epoch", "identities"}, "trust-policy-shape")
+    if policy["schema"] != "aimee.module-doc-trust.v1":
+        fail("trust-policy-schema", "unsupported schema")
+    if type(policy["epoch"]) is not int or policy["epoch"] < 1:
+        fail("trust-policy-epoch", "epoch must be a positive integer")
+    identities = policy["identities"]
+    if not isinstance(identities, list):
+        fail("trust-policy-identities", "identities must be an array")
+    result: dict[str, dict[str, object]] = {}
+    keys: set[str] = set()
+    for entry in identities:
+        item = _exact_object(entry, {"identity", "role", "public_key", "not_before", "not_after", "revoked_at"}, "trust-policy-identity")
+        identity = _string(item["identity"], "trust-policy-identity")
+        if not IDENTITY_RE.fullmatch(identity) or identity in result:
+            fail("trust-policy-identity", "identity is invalid or duplicated")
+        if item["role"] not in {"owner", "reviewer"}:
+            fail("trust-policy-role", "role must be owner or reviewer")
+        public_key = _string(item["public_key"], "trust-policy-key")
+        parts = public_key.split()
+        if len(parts) != 2 or parts[0] != "ssh-ed25519" or public_key in keys:
+            fail("trust-policy-key", "key must be a unique canonical Ed25519 public key")
+        keys.add(public_key)
+        not_before = parse_timestamp(item["not_before"], "trust-policy-not-before")
+        not_after = parse_timestamp(item["not_after"], "trust-policy-not-after")
+        revoked = None if item["revoked_at"] is None else parse_timestamp(item["revoked_at"], "trust-policy-revoked-at")
+        if not_before > at or at > not_after or (revoked is not None and at >= revoked):
+            fail("trust-policy-authorization", f"identity {identity!r} is not authorized at verification time")
+        result[identity] = item
+    return result
+
+
+def authorize_subject(
+    subject: dict[str, object], identities: dict[str, dict[str, object]], *, oidc_iat: int
+) -> None:
+    signed_at = parse_timestamp(subject["signed_at"], "subject-signed-at")
+    verification_time = datetime.fromtimestamp(oidc_iat, tz=timezone.utc)
+    age = (verification_time - signed_at).total_seconds()
+    if age < 0 or age > 86400:
+        fail("subject-freshness", "signed_at must be no later than iat and at most 24 hours old")
+    expected = (("owner_identity", "owner"), ("reviewer_identity", "reviewer"))
+    for field, role in expected:
+        identity = subject[field]
+        if identity not in identities:
+            fail("subject-authorization", f"{field} is not enrolled")
+        if identities[identity]["role"] != role:
+            fail("subject-role", f"{field} is not authorized for role {role}")
+
+
+def validate_toolchain_lock(value: object) -> dict[str, object]:
+    lock = _exact_object(
+        value, {"schema", "image", "ssh_keygen_sha256"}, "toolchain-lock-shape"
+    )
+    if lock["schema"] != "aimee.sshsig-toolchain.v1":
+        fail("toolchain-lock-schema", "unsupported schema")
+    image = _string(lock["image"], "toolchain-image")
+    if not re.fullmatch(r"[a-z0-9./_-]+@sha256:[0-9a-f]{64}", image):
+        fail("toolchain-image", "image must use an immutable sha256 digest")
+    if not isinstance(lock["ssh_keygen_sha256"], str) or not HEX_64_RE.fullmatch(lock["ssh_keygen_sha256"]):
+        fail("toolchain-binary", "ssh-keygen pin must be lowercase SHA-256")
+    return lock
+
+
+def verify_toolchain_binary(lock: dict[str, object], ssh_keygen: Path) -> None:
+    try:
+        actual = sha256(ssh_keygen.read_bytes())
+    except OSError as exc:
+        fail("toolchain-binary", f"cannot read ssh-keygen: {exc}")
+    if actual != lock["ssh_keygen_sha256"]:
+        fail("toolchain-binary", "ssh-keygen binary does not match deployment lock")
+
+
+def validate_publisher_result(value: object, target: dict[str, object]) -> dict[str, object]:
+    result = _exact_object(
+        value,
+        {"schema", "name", "candidate_revision", "external_id", "conclusion", "summary"},
+        "publisher-result-shape",
+    )
+    if result["schema"] != "aimee.module-doc-check.v1" or result["name"] != "module-doc-attestation":
+        fail("publisher-result-identity", "result must name the protected attestation check")
+    if result["candidate_revision"] != target["candidate_revision"]:
+        fail("publisher-result-candidate", "result targets a different candidate")
+    if result["external_id"] != target["trigger_check_identity"]:
+        fail("publisher-result-trigger", "external_id must bind the protected trigger check")
+    if result["conclusion"] not in {"success", "failure"}:
+        fail("publisher-result-conclusion", "conclusion must be success or failure")
+    if not isinstance(result["summary"], str) or not 1 <= len(result["summary"]) <= 4096:
+        fail("publisher-result-summary", "summary must contain 1 to 4096 characters")
+    return result
+
+
+def verify_sshsig(subject: bytes, signature: bytes, identity: str, public_key: str, ssh_keygen: Path) -> None:
+    """Verify one Ed25519 SSHSIG without invoking a shell."""
+    if not signature.startswith(b"-----BEGIN SSH SIGNATURE-----\n") or not signature.endswith(b"-----END SSH SIGNATURE-----\n") or b"\r" in signature:
+        fail("sshsig-armor", "signature must be canonical ASCII armor with final LF")
+    try:
+        signature.decode("ascii", "strict")
+    except UnicodeDecodeError:
+        fail("sshsig-armor", "signature armor must be ASCII")
+    with tempfile.TemporaryDirectory(prefix="aimee-sshsig-") as tmp:
+        root = Path(tmp)
+        allowed = root / "allowed_signers"
+        sig = root / "signature"
+        allowed.write_text(f"{identity} {public_key}\n", encoding="ascii")
+        sig.write_bytes(signature)
+        result = subprocess.run(
+            [str(ssh_keygen), "-Y", "verify", "-f", str(allowed), "-I", identity,
+             "-n", "aimee.module-doc.v1", "-s", str(sig)],
+            input=subject,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/bin"},
+        )
+    if result.returncode != 0:
+        fail("sshsig-verify", result.stderr.decode("utf-8", "replace").strip() or "signature rejected")
+
+
+def sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 
 import base64
 import binascii
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime, timezone
 import hashlib
+import ipaddress
 import json
+import os
 from pathlib import Path, PurePosixPath
 import re
+import stat
 import subprocess
 import struct
 import tempfile
@@ -24,6 +29,8 @@ from urllib.parse import urlsplit
 
 MODULE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 HEX_64_RE = re.compile(r"^[0-9a-f]{64}$")
+SPKI_SHA256_RE = re.compile(r"^[A-Za-z0-9+/]{43}=$")
+JWK_THUMBPRINT_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
 IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,254}$")
 CLAIM_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.:/-]{0,127}$")
 PROSE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ,.;:()'/_-]*[A-Za-z0-9.)]$")
@@ -81,9 +88,30 @@ class ContractError(ValueError):
     """A fail-closed contract violation with a stable rule identifier."""
 
 
+_DIAGNOSTIC_CONTEXT: ContextVar[tuple[str, str, str] | None] = ContextVar(
+    "module_doc_diagnostic", default=None
+)
+
+
+@contextmanager
+def diagnostic_context(module: str, candidate: str, path: str):
+    token = _DIAGNOSTIC_CONTEXT.set((module, candidate, path))
+    try:
+        yield
+    finally:
+        _DIAGNOSTIC_CONTEXT.reset(token)
+
+
 def fail(rule: str, message: str, *, line: int | None = None) -> NoReturn:
-    location = f" line={line}" if line is not None else ""
-    raise ContractError(f"rule={rule}{location}: {message}")
+    context = _DIAGNOSTIC_CONTEXT.get()
+    if context is None:
+        location = f" line={line}" if line is not None else ""
+        raise ContractError(f"rule={rule}{location}: {message}")
+    module, candidate, path = context
+    raise ContractError(
+        f"rule={rule} module={module} candidate={candidate} path={path} "
+        f"line={line or 0} expected={rule}-contract actual={message}"
+    )
 
 
 def _object_without_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
@@ -156,7 +184,13 @@ def _string(value: object, rule: str) -> str:
     return value
 
 
-def _exact_https_url(value: object, rule: str, *, allow_query: bool = False) -> str:
+def _exact_https_url(
+    value: object,
+    rule: str,
+    *,
+    allow_query: bool = False,
+    allow_trailing_slash: bool = False,
+) -> str:
     text = _string(value, rule)
     if not text.isascii() or any(ord(char) < 33 or ord(char) > 126 for char in text):
         fail(rule, "URL must be printable ASCII without whitespace")
@@ -171,11 +205,22 @@ def _exact_https_url(value: object, rule: str, *, allow_query: bool = False) -> 
         fail(rule, "URL userinfo is forbidden")
     if parsed.fragment or (parsed.query and not allow_query):
         fail(rule, "URL query or fragment is forbidden")
-    if any(char.isalpha() and char != char.lower() for char in parsed.netloc) or "%" in text or "//" in parsed.path:
+    hostname = parsed.hostname
+    assert hostname is not None
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        labels = hostname.split(".")
+        if any(
+            not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", label)
+            for label in labels
+        ):
+            fail(rule, "URL hostname is not canonical DNS or IP syntax")
+    if any(char.isalpha() and char != char.lower() for char in parsed.netloc) or "%" in text or "//" in parsed.path or "\\" in text:
         fail(rule, "URL must use a canonical lowercase host and unambiguous path")
     if port is not None and not 1 <= port <= 65535:
         fail(rule, "URL port is invalid")
-    if text.endswith("/"):
+    if text.endswith("/") and not allow_trailing_slash:
         fail(rule, "URL must not end with a slash")
     return text
 
@@ -201,25 +246,29 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
     name = _string(profile["name"], "oidc-profile-name")
     if not MODULE_ID_RE.fullmatch(name):
         fail("oidc-profile-name", "name must use canonical identifier syntax")
-    _exact_https_url(profile["issuer"], "oidc-issuer")
+    _exact_https_url(profile["issuer"], "oidc-issuer", allow_trailing_slash=True)
     _string(profile["audience"], "oidc-audience")
 
     jwks = _exact_object(
         profile["jwks"],
-        {"uri", "tls_spki_sha256", "key_thumbprints_sha256", "max_age_seconds"},
+        {"uri", "tls_spki_sha256", "jwk_thumbprints_sha256", "max_age_seconds"},
         "oidc-jwks-shape",
     )
-    _exact_https_url(jwks["uri"], "oidc-jwks-uri", allow_query=True)
+    _exact_https_url(
+        jwks["uri"], "oidc-jwks-uri", allow_query=True, allow_trailing_slash=True
+    )
     pins = jwks["tls_spki_sha256"]
-    if not isinstance(pins, list) or not pins or not all(isinstance(pin, str) and HEX_64_RE.fullmatch(pin) for pin in pins):
-        fail("oidc-jwks-pins", "at least one lowercase SHA-256 SPKI pin is required")
+    if not isinstance(pins, list) or not pins or not all(
+        isinstance(pin, str) and SPKI_SHA256_RE.fullmatch(pin) for pin in pins
+    ):
+        fail("oidc-jwks-pins", "at least one base64 SHA-256 SPKI pin is required")
     if pins != sorted(set(pins)):
         fail("oidc-jwks-pins", "SPKI pins must be sorted and unique")
-    thumbprints = jwks["key_thumbprints_sha256"]
+    thumbprints = jwks["jwk_thumbprints_sha256"]
     if not isinstance(thumbprints, list) or not thumbprints or not all(
-        isinstance(item, str) and HEX_64_RE.fullmatch(item) for item in thumbprints
+        isinstance(item, str) and JWK_THUMBPRINT_RE.fullmatch(item) for item in thumbprints
     ):
-        fail("oidc-jwks-keys", "at least one lowercase SHA-256 JWK thumbprint is required")
+        fail("oidc-jwks-keys", "at least one RFC 7638 SHA-256 JWK thumbprint is required")
     if thumbprints != sorted(set(thumbprints)):
         fail("oidc-jwks-keys", "JWK thumbprints must be sorted and unique")
     if type(jwks["max_age_seconds"]) is not int or not 1 <= jwks["max_age_seconds"] <= 86400:
@@ -268,7 +317,10 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
     _exact_https_url(api["base_url"], "repository-api-url")
     if not isinstance(api["tls_spki_sha256"], list) or not api["tls_spki_sha256"]:
         fail("repository-api-pins", "repository API requires SPKI pins")
-    if any(not isinstance(pin, str) or not HEX_64_RE.fullmatch(pin) for pin in api["tls_spki_sha256"]):
+    if any(
+        not isinstance(pin, str) or not SPKI_SHA256_RE.fullmatch(pin)
+        for pin in api["tls_spki_sha256"]
+    ):
         fail("repository-api-pins", "invalid repository API SPKI pin")
     if api["response_schema"] != "aimee.candidate-target.v1":
         fail("repository-api-schema", "unsupported candidate-target schema")
@@ -828,87 +880,118 @@ def validate_module_candidate(
 
     for module_id in sorted(module_ids):
         descriptor_path = f"src/modules/{module_id}/module.yaml"
-        descriptor_raw = candidate.read_blob(descriptor_path, max_bytes=MAX_DESCRIPTOR_BYTES)
-        descriptor = strict_json_bytes(descriptor_raw)
-        validated = validate_v2_metadata(
-            descriptor, optional=module_id in optional_ids, known_ids=module_ids
-        )
-        base_descriptor = strict_json_bytes(
-            base.read_blob(descriptor_path, max_bytes=MAX_DESCRIPTOR_BYTES)
-        )
-        _validate_v1_preserved(base_descriptor, validated, module_id in optional_ids)
+        with diagnostic_context(module_id, candidate.commit, descriptor_path):
+            descriptor_raw = candidate.read_blob(
+                descriptor_path, max_bytes=MAX_DESCRIPTOR_BYTES
+            )
+            descriptor = strict_json_bytes(descriptor_raw)
+            validated = validate_v2_metadata(
+                descriptor, optional=module_id in optional_ids, known_ids=module_ids
+            )
+            base_descriptor = strict_json_bytes(
+                base.read_blob(descriptor_path, max_bytes=MAX_DESCRIPTOR_BYTES)
+            )
+            _validate_v1_preserved(
+                base_descriptor, validated, module_id in optional_ids
+            )
 
-        expanded: list[str] = []
-        for pattern in validated["sources"]:
-            for path in candidate.expand_source_pattern(pattern, module_id):
-                if path in claimed_paths:
-                    fail("v2-source-overlap", f"{path!r} is claimed by {claimed_paths[path]!r} and {module_id!r}")
-                claimed_paths[path] = module_id
-                expanded.append(path)
-        if len(expanded) != len(set(expanded)):
-            fail("v2-source-overlap", f"module {module_id!r} has overlapping source patterns")
+            expanded: list[str] = []
+            for pattern in validated["sources"]:
+                for path in candidate.expand_source_pattern(pattern, module_id):
+                    if path in claimed_paths:
+                        fail(
+                            "v2-source-overlap",
+                            f"{path!r} is claimed by {claimed_paths[path]!r} and {module_id!r}",
+                        )
+                    claimed_paths[path] = module_id
+                    expanded.append(path)
+            if len(expanded) != len(set(expanded)):
+                fail(
+                    "v2-source-overlap",
+                    f"module {module_id!r} has overlapping source patterns",
+                )
 
         document_path = validated["docs"]
-        document_raw = candidate.read_blob(document_path, max_bytes=MAX_DOCUMENT_BYTES)
+        with diagnostic_context(module_id, candidate.commit, document_path):
+            document_raw = candidate.read_blob(
+                document_path, max_bytes=MAX_DOCUMENT_BYTES
+            )
 
-        def resolve(reference: str) -> None:
-            match = REFERENCE_RE.fullmatch(reference)
-            assert match is not None
-            referenced_module = match.group("module")
-            if referenced_module is not None and referenced_module not in module_ids:
-                fail("document-evidence-module", f"unknown evidence module {referenced_module!r}")
-            candidate.resolve_reference(reference)
+            def resolve(reference: str) -> None:
+                match = REFERENCE_RE.fullmatch(reference)
+                assert match is not None
+                referenced_module = match.group("module")
+                if referenced_module is not None and referenced_module not in module_ids:
+                    fail(
+                        "document-evidence-module",
+                        f"unknown evidence module {referenced_module!r}",
+                    )
+                candidate.resolve_reference(reference)
 
-        parse_module_document(
-            document_raw,
-            module_id,
-            DocumentProjection(tuple(validated["sources"]), tuple(validated["public_headers"])),
-            resolve_reference=resolve,
-        )
+            parse_module_document(
+                document_raw,
+                module_id,
+                DocumentProjection(
+                    tuple(validated["sources"]), tuple(validated["public_headers"])
+                ),
+                resolve_reference=resolve,
+            )
         subject_path = f"docs/modules/attestations/{module_id}.subject.json"
         expected_attestation_files.add(f"{module_id}.subject.json")
-        subject_raw = candidate.read_blob(subject_path, max_bytes=MAX_SUBJECT_BYTES)
-        subject_value = strict_json_bytes(subject_raw)
-        canonical = canonical_subject(subject_value)
-        if subject_raw != canonical:
-            fail("subject-canonical", f"subject for {module_id!r} is not canonical")
-        assert isinstance(subject_value, dict)
-        if subject_value["module_id"] != module_id:
-            fail("subject-module", "subject module does not match its path")
-        if subject_value["descriptor_sha256"] != sha256(descriptor_raw):
-            fail("subject-descriptor-hash", f"descriptor hash mismatch for {module_id!r}")
-        if subject_value["document_sha256"] != sha256(document_raw):
-            fail("subject-document-hash", f"document hash mismatch for {module_id!r}")
-        authorize_subject(subject_value, identities, oidc_iat=oidc_iat)
+        with diagnostic_context(module_id, candidate.commit, subject_path):
+            subject_raw = candidate.read_blob(
+                subject_path, max_bytes=MAX_SUBJECT_BYTES
+            )
+            subject_value = strict_json_bytes(subject_raw)
+            canonical = canonical_subject(subject_value)
+            if subject_raw != canonical:
+                fail("subject-canonical", f"subject for {module_id!r} is not canonical")
+            assert isinstance(subject_value, dict)
+            if subject_value["module_id"] != module_id:
+                fail("subject-module", "subject module does not match its path")
+            if subject_value["descriptor_sha256"] != sha256(descriptor_raw):
+                fail(
+                    "subject-descriptor-hash",
+                    f"descriptor hash mismatch for {module_id!r}",
+                )
+            if subject_value["document_sha256"] != sha256(document_raw):
+                fail(
+                    "subject-document-hash",
+                    f"document hash mismatch for {module_id!r}",
+                )
+            authorize_subject(subject_value, identities, oidc_iat=oidc_iat)
         for role, field in (("owner", "owner_identity"), ("reviewer", "reviewer_identity")):
             expected_attestation_files.add(f"{module_id}.{role}.sig")
             identity = subject_value[field]
             entry = identities[identity]
-            signature = candidate.read_blob(
-                f"docs/modules/attestations/{module_id}.{role}.sig",
-                max_bytes=MAX_SIGNATURE_BYTES,
-            )
-            verify_sshsig(canonical, signature, identity, entry["public_key"], toolchain)
+            signature_path = f"docs/modules/attestations/{module_id}.{role}.sig"
+            with diagnostic_context(module_id, candidate.commit, signature_path):
+                signature = candidate.read_blob(
+                    signature_path, max_bytes=MAX_SIGNATURE_BYTES
+                )
+                verify_sshsig(
+                    canonical, signature, identity, entry["public_key"], toolchain
+                )
         expected_index.append({"module_id": module_id, "subject_sha256": sha256(subject_raw)})
 
-    actual_attestations = candidate.list_directory("docs/modules/attestations")
-    if set(actual_attestations) != expected_attestation_files:
-        fail(
-            "attestation-files",
-            f"missing={sorted(expected_attestation_files-set(actual_attestations))}, "
-            f"extra={sorted(set(actual_attestations)-expected_attestation_files)}",
+    index_path = "docs/modules/attestations/index.json"
+    with diagnostic_context("attestations", candidate.commit, index_path):
+        actual_attestations = candidate.list_directory("docs/modules/attestations")
+        if set(actual_attestations) != expected_attestation_files:
+            fail(
+                "attestation-files",
+                f"missing={sorted(expected_attestation_files-set(actual_attestations))}, "
+                f"extra={sorted(set(actual_attestations)-expected_attestation_files)}",
+            )
+        invalid_mode = next(
+            (name for name, mode_kind in sorted(actual_attestations.items())
+             if mode_kind != ("100644", "blob")),
+            None,
         )
-    invalid_mode = next(
-        (name for name, mode_kind in sorted(actual_attestations.items())
-         if mode_kind != ("100644", "blob")),
-        None,
-    )
-    if invalid_mode is not None:
-        fail("git-mode", f"attestation {invalid_mode!r} must be a mode 100644 blob")
-    index_raw = candidate.read_blob(
-        "docs/modules/attestations/index.json", max_bytes=MAX_INDEX_BYTES
-    )
-    validate_attestation_index(index_raw, expected_index)
+        if invalid_mode is not None:
+            fail("git-mode", f"attestation {invalid_mode!r} must be a mode 100644 blob")
+        index_raw = candidate.read_blob(index_path, max_bytes=MAX_INDEX_BYTES)
+        validate_attestation_index(index_raw, expected_index)
     return f"Validated {len(module_ids)} descriptor-v2 documents and {len(module_ids) * 2} human SSHSIG attestations."
 
 
@@ -1093,11 +1176,31 @@ class LockedToolchain:
         self.ssh_keygen = ssh_keygen
         self.ssh_keygen_sha256 = ssh_keygen_sha256
 
+    def executable(self) -> Path:
+        try:
+            info = self.ssh_keygen.lstat()
+            actual = sha256(self.ssh_keygen.read_bytes())
+        except OSError as exc:
+            fail("toolchain-binary", f"cannot revalidate ssh-keygen: {exc}")
+        if not stat.S_ISREG(info.st_mode) or not os.access(self.ssh_keygen, os.X_OK):
+            fail("toolchain-binary", "ssh-keygen must remain an executable regular file")
+        if actual != self.ssh_keygen_sha256:
+            fail("toolchain-binary", "ssh-keygen changed after toolchain lock")
+        return self.ssh_keygen
+
 
 def load_locked_toolchain(value: object, ssh_keygen: Path) -> LockedToolchain:
     lock = validate_toolchain_lock(value)
-    if not ssh_keygen.is_absolute() or not ssh_keygen.is_file():
-        fail("toolchain-binary", "ssh-keygen must be an absolute regular-file path")
+    try:
+        info = ssh_keygen.lstat()
+    except OSError as exc:
+        fail("toolchain-binary", f"cannot inspect ssh-keygen: {exc}")
+    if (
+        not ssh_keygen.is_absolute()
+        or not stat.S_ISREG(info.st_mode)
+        or not os.access(ssh_keygen, os.X_OK)
+    ):
+        fail("toolchain-binary", "ssh-keygen must be an absolute executable regular-file path")
     try:
         actual = sha256(ssh_keygen.read_bytes())
     except OSError as exc:
@@ -1206,7 +1309,7 @@ def verify_sshsig(
         allowed.write_text(f"{identity} {public_key}\n", encoding="ascii")
         sig.write_bytes(signature)
         result = subprocess.run(
-            [str(toolchain.ssh_keygen), "-Y", "verify", "-f", str(allowed), "-I", identity,
+            [str(toolchain.executable()), "-Y", "verify", "-f", str(allowed), "-I", identity,
              "-n", "aimee.module-doc.v1", "-s", str(sig)],
             input=subject,
             stdout=subprocess.PIPE,

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -19,6 +19,7 @@ import subprocess
 import struct
 import tempfile
 from typing import Callable, NamedTuple, NoReturn
+from urllib.parse import urlsplit
 
 
 MODULE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
@@ -32,6 +33,15 @@ REFERENCE_RE = re.compile(
     r"path:(?P<path>[A-Za-z0-9][A-Za-z0-9._/-]*)(?:#L(?P<line>[1-9][0-9]*))?)$"
 )
 TIMESTAMP_RE = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+MAX_JSON_BYTES = 1_048_576
+MAX_JSON_DEPTH = 32
+MAX_JSON_ITEMS = 4096
+MAX_GOVERNED_BLOB_BYTES = 2_097_152
+MAX_DESCRIPTOR_BYTES = 65_536
+MAX_DOCUMENT_BYTES = 262_144
+MAX_SUBJECT_BYTES = 4_096
+MAX_SIGNATURE_BYTES = 16_384
+MAX_INDEX_BYTES = 65_536
 
 SECTIONS = (
     "Purpose and non-goals",
@@ -90,6 +100,8 @@ def _reject_number(value: str) -> NoReturn:
 
 
 def strict_json_bytes(raw: bytes) -> object:
+    if len(raw) > MAX_JSON_BYTES:
+        fail("json-size", f"JSON exceeds {MAX_JSON_BYTES} bytes")
     if raw.startswith(b"\xef\xbb\xbf"):
         fail("json-bom", "UTF-8 BOM is forbidden")
     try:
@@ -103,23 +115,31 @@ def strict_json_bytes(raw: bytes) -> object:
             parse_float=_reject_number,
             parse_constant=_reject_number,
         )
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, RecursionError) as exc:
+        if isinstance(exc, RecursionError):
+            fail("json-depth", "JSON nesting exceeds the parser limit")
         fail("json-parse", f"{exc.msg} at {exc.lineno}:{exc.colno}")
     _reject_surrogates(value)
     return value
 
 
-def _reject_surrogates(value: object) -> None:
+def _reject_surrogates(value: object, depth: int = 0) -> None:
+    if depth > MAX_JSON_DEPTH:
+        fail("json-depth", f"JSON nesting exceeds {MAX_JSON_DEPTH}")
     if isinstance(value, str):
         if any(0xD800 <= ord(char) <= 0xDFFF for char in value):
             fail("json-surrogate", "surrogate code point is forbidden")
     elif isinstance(value, list):
+        if len(value) > MAX_JSON_ITEMS:
+            fail("json-items", f"array exceeds {MAX_JSON_ITEMS} entries")
         for item in value:
-            _reject_surrogates(item)
+            _reject_surrogates(item, depth + 1)
     elif isinstance(value, dict):
+        if len(value) > MAX_JSON_ITEMS:
+            fail("json-items", f"object exceeds {MAX_JSON_ITEMS} entries")
         for key, item in value.items():
-            _reject_surrogates(key)
-            _reject_surrogates(item)
+            _reject_surrogates(key, depth + 1)
+            _reject_surrogates(item, depth + 1)
 
 
 def _exact_object(value: object, keys: set[str], rule: str) -> dict[str, object]:
@@ -134,6 +154,30 @@ def _string(value: object, rule: str) -> str:
     if not isinstance(value, str) or not value:
         fail(rule, "expected non-empty string")
     return value
+
+
+def _exact_https_url(value: object, rule: str, *, allow_query: bool = False) -> str:
+    text = _string(value, rule)
+    if not text.isascii() or any(ord(char) < 33 or ord(char) > 126 for char in text):
+        fail(rule, "URL must be printable ASCII without whitespace")
+    try:
+        parsed = urlsplit(text)
+        port = parsed.port
+    except ValueError as exc:
+        fail(rule, f"malformed URL: {exc}")
+    if parsed.scheme != "https" or not parsed.hostname:
+        fail(rule, "URL must use HTTPS with a non-empty authority")
+    if parsed.username is not None or parsed.password is not None:
+        fail(rule, "URL userinfo is forbidden")
+    if parsed.fragment or (parsed.query and not allow_query):
+        fail(rule, "URL query or fragment is forbidden")
+    if any(char.isalpha() and char != char.lower() for char in parsed.netloc) or "%" in text or "//" in parsed.path:
+        fail(rule, "URL must use a canonical lowercase host and unambiguous path")
+    if port is not None and not 1 <= port <= 65535:
+        fail(rule, "URL port is invalid")
+    if text.endswith("/"):
+        fail(rule, "URL must not end with a slash")
+    return text
 
 
 def validate_oidc_profile(value: object) -> dict[str, object]:
@@ -157,18 +201,15 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
     name = _string(profile["name"], "oidc-profile-name")
     if not MODULE_ID_RE.fullmatch(name):
         fail("oidc-profile-name", "name must use canonical identifier syntax")
-    for field in ("issuer", "audience"):
-        text = _string(profile[field], f"oidc-{field}")
-        if field == "issuer" and (not text.startswith("https://") or text.endswith("/")):
-            fail("oidc-issuer", "issuer must be an exact HTTPS URL without trailing slash")
+    _exact_https_url(profile["issuer"], "oidc-issuer")
+    _string(profile["audience"], "oidc-audience")
 
     jwks = _exact_object(
         profile["jwks"],
         {"uri", "tls_spki_sha256", "key_thumbprints_sha256", "max_age_seconds"},
         "oidc-jwks-shape",
     )
-    if not _string(jwks["uri"], "oidc-jwks-uri").startswith("https://"):
-        fail("oidc-jwks-uri", "JWKS URI must use HTTPS")
+    _exact_https_url(jwks["uri"], "oidc-jwks-uri", allow_query=True)
     pins = jwks["tls_spki_sha256"]
     if not isinstance(pins, list) or not pins or not all(isinstance(pin, str) and HEX_64_RE.fullmatch(pin) for pin in pins):
         fail("oidc-jwks-pins", "at least one lowercase SHA-256 SPKI pin is required")
@@ -186,7 +227,11 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
 
     algorithms = profile["allowed_algorithms"]
     allowed = {"EdDSA", "ES256", "RS256", "PS256"}
-    if not isinstance(algorithms, list) or not algorithms or algorithms != sorted(set(algorithms)):
+    if not isinstance(algorithms, list) or not algorithms or not all(
+        isinstance(item, str) for item in algorithms
+    ):
+        fail("oidc-algorithms", "allowed_algorithms must be a non-empty string array")
+    if algorithms != sorted(set(algorithms)):
         fail("oidc-algorithms", "allowed_algorithms must be a sorted unique non-empty array")
     if any(type(item) is not str or item not in allowed for item in algorithms):
         fail("oidc-algorithms", "algorithm is not in the closed allowlist")
@@ -220,8 +265,7 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
         profile["repository_api"], {"base_url", "tls_spki_sha256", "response_schema"},
         "repository-api-shape",
     )
-    if not _string(api["base_url"], "repository-api-url").startswith("https://"):
-        fail("repository-api-url", "repository API must use HTTPS")
+    _exact_https_url(api["base_url"], "repository-api-url")
     if not isinstance(api["tls_spki_sha256"], list) or not api["tls_spki_sha256"]:
         fail("repository-api-pins", "repository API requires SPKI pins")
     if any(not isinstance(pin, str) or not HEX_64_RE.fullmatch(pin) for pin in api["tls_spki_sha256"]):
@@ -289,9 +333,18 @@ def normalize_verified_oidc_claims(
         if claim_name not in claims:
             fail("oidc-mapped-claim", f"claim mapped to {field!r} is missing")
         value = claims[claim_name]
-        if not isinstance(value, (str, int)) or isinstance(value, bool) or value == "":
-            fail("oidc-mapped-claim", f"claim mapped to {field!r} has invalid type")
-        workload[field] = str(value)
+        if field == "attempt":
+            if type(value) is int and value >= 1:
+                normalized = str(value)
+            elif isinstance(value, str) and re.fullmatch(r"[1-9][0-9]*", value):
+                normalized = value
+            else:
+                fail("oidc-attempt", "attempt must be a positive canonical decimal")
+        else:
+            if not isinstance(value, str) or not value:
+                fail("oidc-mapped-claim", f"claim mapped to {field!r} must be a non-empty string")
+            normalized = value
+        workload[field] = normalized
     predicates = profile["predicates"]
     assert isinstance(predicates, dict)
     for field, expected in predicates.items():
@@ -333,6 +386,8 @@ def validate_candidate_target(value: object) -> dict[str, str]:
     ):
         if not isinstance(target[field], str) or not target[field]:
             fail("candidate-target-field", f"{field} must be a non-empty string")
+    if not re.fullmatch(r"[1-9][0-9]*", target["attempt"]):
+        fail("candidate-target-attempt", "attempt must be a positive canonical decimal")
     return target
 
 
@@ -366,7 +421,9 @@ def replay_binding(workload: dict[str, object], target: dict[str, object]) -> st
     return sha256("\0".join(fields).encode("utf-8"))
 
 
-def validate_v2_metadata(value: object, *, optional: bool) -> dict[str, object]:
+def validate_v2_metadata(
+    value: object, *, optional: bool, known_ids: set[str] | None = None
+) -> dict[str, object]:
     """Validate descriptor-v2 additions without enabling v2 production yet."""
     base = {"descriptor_version", "id", "dependencies", "runtime_toggle"}
     keys = base | {"docs", "sources", "public_headers", "surfaces"}
@@ -380,12 +437,32 @@ def validate_v2_metadata(value: object, *, optional: bool) -> dict[str, object]:
         fail("v2-module-id", "invalid module ID")
     if descriptor["docs"] != f"docs/modules/{module_id}.md":
         fail("v2-doc-path", "docs path must be derived from the module ID")
+    dependencies = descriptor["dependencies"]
+    if not isinstance(dependencies, list) or any(
+        not isinstance(item, str) or not MODULE_ID_RE.fullmatch(item) for item in dependencies
+    ):
+        fail("v2-dependencies", "dependencies must be an array of canonical module IDs")
+    if dependencies != sorted(set(dependencies)):
+        fail("v2-dependencies", "dependencies must be sorted and unique")
+    if module_id in dependencies:
+        fail("v2-dependencies", "module cannot depend on itself")
+    if known_ids is not None and any(item not in known_ids for item in dependencies):
+        fail("v2-dependencies", "dependency is absent from the protected inventory")
+    runtime = _exact_object(
+        descriptor["runtime_toggle"], {"supported"}, "v2-runtime-toggle"
+    )
+    if type(runtime["supported"]) is not bool:
+        fail("v2-runtime-toggle", "runtime_toggle.supported must be boolean")
+    if not optional and runtime["supported"]:
+        fail("v2-runtime-toggle", "required modules cannot support runtime disablement")
+    if optional and type(descriptor["enabled_by_default"]) is not bool:
+        fail("v2-default", "optional enabled_by_default must be boolean")
     for field in ("sources", "public_headers"):
         entries = descriptor[field]
-        if not isinstance(entries, list) or entries != sorted(set(entries)):
-            fail("v2-pattern-order", f"{field} must be a sorted unique array")
-        if any(not isinstance(item, str) for item in entries):
+        if not isinstance(entries, list) or any(not isinstance(item, str) for item in entries):
             fail("v2-pattern-type", f"{field} entries must be strings")
+        if entries != sorted(set(entries)):
+            fail("v2-pattern-order", f"{field} must be a sorted unique array")
     for pattern in descriptor["sources"]:
         match = SOURCE_PATTERN_RE.fullmatch(pattern)
         if not match or match.group("module") != module_id:
@@ -437,7 +514,7 @@ class GitBlobReader:
         if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
             fail("git-path", "path is not canonical")
 
-    def read_blob(self, path: str) -> bytes:
+    def read_blob(self, path: str, *, max_bytes: int = MAX_GOVERNED_BLOB_BYTES) -> bytes:
         self.canonical_path(path)
         record = self._git("ls-tree", "-z", "--full-tree", self.commit, "--", path)
         entries = [entry for entry in record.split(b"\0") if entry]
@@ -453,8 +530,35 @@ class GitBlobReader:
             fail("git-entry", "repository returned a different path")
         if mode != b"100644" or kind != b"blob" or not re.fullmatch(rb"[0-9a-f]{40}", object_id):
             fail("git-mode", f"{path!r} must be a mode 100644 blob")
+        size_raw = self._git("cat-file", "-s", object_id.decode("ascii"))
+        try:
+            size = int(size_raw.decode("ascii").strip())
+        except (UnicodeDecodeError, ValueError):
+            fail("git-object", f"cannot determine size for {path!r}")
+        if type(max_bytes) is not int or not 1 <= max_bytes <= MAX_GOVERNED_BLOB_BYTES:
+            fail("git-object-size", "requested blob limit is outside the verifier ceiling")
+        if size > max_bytes:
+            fail("git-object-size", f"{path!r} exceeds {max_bytes} bytes")
         raw = self._git("cat-file", "blob", object_id.decode("ascii"))
+        if len(raw) != size:
+            fail("git-object-size", f"{path!r} size changed while reading immutable object")
         return raw
+
+    def list_directory(self, path: str) -> dict[str, tuple[str, str]]:
+        self.canonical_path(path)
+        record = self._git("ls-tree", "-z", f"{self.commit}:{path}")
+        result: dict[str, tuple[str, str]] = {}
+        for entry in (item for item in record.split(b"\0") if item):
+            try:
+                metadata, name = entry.split(b"\t", 1)
+                mode, kind, object_id = metadata.split(b" ", 2)
+                decoded = name.decode("ascii", "strict")
+            except (ValueError, UnicodeDecodeError):
+                fail("git-entry", f"malformed directory entry beneath {path!r}")
+            if not decoded or "/" in decoded or decoded in result:
+                fail("git-entry", f"non-canonical or duplicate entry beneath {path!r}")
+            result[decoded] = (mode.decode("ascii"), kind.decode("ascii"))
+        return result
 
     def resolve_reference(self, reference: str) -> None:
         match = REFERENCE_RE.fullmatch(reference)
@@ -463,12 +567,40 @@ class GitBlobReader:
         path = match.group("path")
         if not path:
             return
-        raw = self.read_blob(path)
+        raw = self.read_blob(path, max_bytes=MAX_GOVERNED_BLOB_BYTES)
         if match.group("line") is not None:
             requested = int(match.group("line"))
             line_count = len(raw.splitlines())
             if requested > line_count:
                 fail("document-evidence-line", f"line {requested} exceeds {line_count} lines in {path}")
+
+    def expand_source_pattern(self, pattern: str, module_id: str) -> tuple[str, ...]:
+        match = SOURCE_PATTERN_RE.fullmatch(pattern)
+        if not match or match.group("module") != module_id:
+            fail("v2-source-pattern", f"invalid or cross-module source pattern {pattern!r}")
+        directory = f"src/modules/{module_id}"
+        if match.group("literal"):
+            directory += f"/{match.group('literal')}"
+        suffix = f".{match.group('suffix')}"
+        record = self._git("ls-tree", "-z", f"{self.commit}:{directory}")
+        paths: list[str] = []
+        for entry in (item for item in record.split(b"\0") if item):
+            try:
+                metadata, name = entry.split(b"\t", 1)
+                mode, kind, _ = metadata.split(b" ", 2)
+                decoded = name.decode("ascii", "strict")
+            except (ValueError, UnicodeDecodeError):
+                fail("git-entry", f"malformed tree entry beneath {directory!r}")
+            if b"/" in name or not decoded.endswith(suffix):
+                continue
+            path = f"{directory}/{decoded}"
+            if mode != b"100644" or kind != b"blob":
+                fail("git-mode", f"claimed source {path!r} must be a mode 100644 blob")
+            paths.append(path)
+        result = tuple(sorted(paths, key=lambda item: item.encode("ascii")))
+        if not result:
+            fail("v2-source-empty", f"source pattern {pattern!r} matched no blobs")
+        return result
 
 
 def _validate_reference(
@@ -494,6 +626,8 @@ def parse_module_document(
     resolve_reference: Callable[[str], None] | None = None,
 ) -> None:
     """Parse the exact module-document language and enforce content floors."""
+    if len(raw) > MAX_DOCUMENT_BYTES:
+        fail("document-size", f"document exceeds {MAX_DOCUMENT_BYTES} bytes")
     if not MODULE_ID_RE.fullmatch(module_id):
         fail("document-module-id", "invalid module ID")
     if not raw or not raw.endswith(b"\n"):
@@ -517,6 +651,8 @@ def parse_module_document(
         positions.append(matches[0])
     if positions != sorted(positions):
         fail("document-section-order", "H2 sections are out of order")
+    if positions[0] != 2:
+        fail("document-preamble", "the first H2 must immediately follow the H1 separator")
     unexpected = [line for line in lines if line.startswith("#") and line not in {f"# {module_id} module", *(f"## {s}" for s in SECTIONS)}]
     if unexpected:
         fail("document-heading", f"unexpected heading {unexpected[0]!r}")
@@ -533,20 +669,20 @@ def parse_module_document(
             body = body[:-1]
         if any(body[index] == "" and (index == 0 or index + 1 == len(body) or body[index - 1] == "" or body[index + 1] == "") for index in range(len(body))):
             fail("document-record-spacing", "blank lines may only separate records")
-        records = [item for item in body if item]
-        state = records.pop(0)
+        state = body[0]
+        cursor = 1
         if state == "State: none":
-            if len(records) < 3 or not records[0].startswith("Reason: ") or not records[1].startswith("Implication: ") or not records[2].startswith("Evidence: "):
+            if len(body) < 4 or not body[1].startswith("Reason: ") or not body[2].startswith("Implication: ") or not body[3].startswith("Evidence: "):
                 fail("document-none-block", "none state requires Reason, Implication, Evidence in order", line=start + 3)
             for prefix in ("Reason: ", "Implication: "):
-                prose = records[0 if prefix.startswith("Reason") else 1][len(prefix):]
+                prose = body[1 if prefix.startswith("Reason") else 2][len(prefix):]
                 if not PROSE_RE.fullmatch(prose):
                     fail("document-prose", f"invalid {prefix.strip()} prose")
             _validate_reference(
-                records[2][len("Evidence: "):], line=start + 5, resolver=resolve_reference
+                body[3][len("Evidence: "):], line=start + 5, resolver=resolve_reference
             )
-            records = records[3:]
-        elif any(item.startswith(("Reason: ", "Implication: ", "Evidence: ")) for item in records):
+            cursor = 4
+        elif any(item.startswith(("Reason: ", "Implication: ", "Evidence: ")) for item in body[1:]):
             fail("document-state-label", "none-state labels are forbidden for present state")
 
         expected_projection: list[str] = []
@@ -556,19 +692,24 @@ def parse_module_document(
             expected_projection.append("Public headers: " + (", ".join(projection.public_headers) or "none"))
         elif section_index == 6:
             expected_projection.extend(("Routes: none", "Commands: none", "Protocols: none", "Stages: none"))
-        if records[:len(expected_projection)] != expected_projection:
+        if body[cursor:cursor + len(expected_projection)] != expected_projection:
             fail("document-projection", f"projection mismatch in {SECTIONS[section_index]!r}")
-        records = records[len(expected_projection):]
+        cursor += len(expected_projection)
+        records = [item for item in body[cursor:] if item]
 
         prose_tokens = 0
         evidence_count = 0
+        evidence_started = False
         for record in records:
             if record.startswith("- Evidence: "):
                 _validate_reference(
                     record[len("- Evidence: "):], line=start + 2, resolver=resolve_reference
                 )
                 evidence_count += 1
+                evidence_started = True
                 continue
+            if evidence_started:
+                fail("document-record-order", "prose records cannot follow evidence records")
             prose = record[2:] if record.startswith("- ") else record
             if not PROSE_RE.fullmatch(prose):
                 fail("document-prose", f"invalid record {record!r}")
@@ -621,6 +762,156 @@ def canonical_subject(value: object) -> bytes:
     return (json.dumps(ordered, indent=2, ensure_ascii=True, separators=(",", ": ")) + "\n").encode("ascii")
 
 
+def canonical_attestation_index(entries: list[dict[str, str]]) -> bytes:
+    ordered = {
+        "schema": "aimee.module-doc-attestation-index.v1",
+        "modules": [
+            {"module_id": item["module_id"], "subject_sha256": item["subject_sha256"]}
+            for item in entries
+        ],
+    }
+    return (json.dumps(ordered, indent=2, ensure_ascii=True, separators=(",", ": ")) + "\n").encode("ascii")
+
+
+def validate_attestation_index(raw: bytes, expected: list[dict[str, str]]) -> None:
+    value = strict_json_bytes(raw)
+    index = _exact_object(value, {"schema", "modules"}, "attestation-index-shape")
+    if index["schema"] != "aimee.module-doc-attestation-index.v1":
+        fail("attestation-index-schema", "unsupported schema")
+    modules = index["modules"]
+    if not isinstance(modules, list):
+        fail("attestation-index-modules", "modules must be an array")
+    parsed: list[dict[str, str]] = []
+    for entry in modules:
+        item = _exact_object(entry, {"module_id", "subject_sha256"}, "attestation-index-entry")
+        if not isinstance(item["module_id"], str) or not MODULE_ID_RE.fullmatch(item["module_id"]):
+            fail("attestation-index-module", "invalid module ID")
+        if not isinstance(item["subject_sha256"], str) or not HEX_64_RE.fullmatch(item["subject_sha256"]):
+            fail("attestation-index-hash", "invalid subject hash")
+        parsed.append(item)
+    if parsed != expected:
+        fail("attestation-index-set", "index is missing, extra, stale, duplicated, or misordered")
+    if raw != canonical_attestation_index(parsed):
+        fail("attestation-index-canonical", "index bytes are not canonical")
+
+
+def _validate_v1_preserved(base: object, candidate: dict[str, object], optional: bool) -> None:
+    if not isinstance(base, dict):
+        fail("v2-base-descriptor", "base descriptor must be an object")
+    fields = ["id", "dependencies", "runtime_toggle"]
+    if optional:
+        fields.append("enabled_by_default")
+    for field in fields:
+        if base.get(field) != candidate.get(field):
+            fail("v2-v1-semantics", f"descriptor v2 changed v1 field {field!r}")
+
+
+def validate_module_candidate(
+    candidate: GitBlobReader,
+    base: GitBlobReader,
+    *,
+    required_ids: set[str],
+    optional_ids: set[str],
+    trust_policy_raw: bytes,
+    oidc_iat: int,
+    toolchain: "LockedToolchain",
+) -> str:
+    """Validate the complete atomic descriptor-v2 and signed-document migration."""
+    module_ids = required_ids | optional_ids
+    if not required_ids or not optional_ids or required_ids & optional_ids:
+        fail("candidate-inventory", "protected required and optional inventories must be non-empty and disjoint")
+    verification_time = datetime.fromtimestamp(oidc_iat, tz=timezone.utc)
+    identities = load_canonical_trust_policy(trust_policy_raw, at=verification_time)
+    claimed_paths: dict[str, str] = {}
+    expected_index: list[dict[str, str]] = []
+    expected_attestation_files = {"index.json"}
+
+    for module_id in sorted(module_ids):
+        descriptor_path = f"src/modules/{module_id}/module.yaml"
+        descriptor_raw = candidate.read_blob(descriptor_path, max_bytes=MAX_DESCRIPTOR_BYTES)
+        descriptor = strict_json_bytes(descriptor_raw)
+        validated = validate_v2_metadata(
+            descriptor, optional=module_id in optional_ids, known_ids=module_ids
+        )
+        base_descriptor = strict_json_bytes(
+            base.read_blob(descriptor_path, max_bytes=MAX_DESCRIPTOR_BYTES)
+        )
+        _validate_v1_preserved(base_descriptor, validated, module_id in optional_ids)
+
+        expanded: list[str] = []
+        for pattern in validated["sources"]:
+            for path in candidate.expand_source_pattern(pattern, module_id):
+                if path in claimed_paths:
+                    fail("v2-source-overlap", f"{path!r} is claimed by {claimed_paths[path]!r} and {module_id!r}")
+                claimed_paths[path] = module_id
+                expanded.append(path)
+        if len(expanded) != len(set(expanded)):
+            fail("v2-source-overlap", f"module {module_id!r} has overlapping source patterns")
+
+        document_path = validated["docs"]
+        document_raw = candidate.read_blob(document_path, max_bytes=MAX_DOCUMENT_BYTES)
+
+        def resolve(reference: str) -> None:
+            match = REFERENCE_RE.fullmatch(reference)
+            assert match is not None
+            referenced_module = match.group("module")
+            if referenced_module is not None and referenced_module not in module_ids:
+                fail("document-evidence-module", f"unknown evidence module {referenced_module!r}")
+            candidate.resolve_reference(reference)
+
+        parse_module_document(
+            document_raw,
+            module_id,
+            DocumentProjection(tuple(validated["sources"]), tuple(validated["public_headers"])),
+            resolve_reference=resolve,
+        )
+        subject_path = f"docs/modules/attestations/{module_id}.subject.json"
+        expected_attestation_files.add(f"{module_id}.subject.json")
+        subject_raw = candidate.read_blob(subject_path, max_bytes=MAX_SUBJECT_BYTES)
+        subject_value = strict_json_bytes(subject_raw)
+        canonical = canonical_subject(subject_value)
+        if subject_raw != canonical:
+            fail("subject-canonical", f"subject for {module_id!r} is not canonical")
+        assert isinstance(subject_value, dict)
+        if subject_value["module_id"] != module_id:
+            fail("subject-module", "subject module does not match its path")
+        if subject_value["descriptor_sha256"] != sha256(descriptor_raw):
+            fail("subject-descriptor-hash", f"descriptor hash mismatch for {module_id!r}")
+        if subject_value["document_sha256"] != sha256(document_raw):
+            fail("subject-document-hash", f"document hash mismatch for {module_id!r}")
+        authorize_subject(subject_value, identities, oidc_iat=oidc_iat)
+        for role, field in (("owner", "owner_identity"), ("reviewer", "reviewer_identity")):
+            expected_attestation_files.add(f"{module_id}.{role}.sig")
+            identity = subject_value[field]
+            entry = identities[identity]
+            signature = candidate.read_blob(
+                f"docs/modules/attestations/{module_id}.{role}.sig",
+                max_bytes=MAX_SIGNATURE_BYTES,
+            )
+            verify_sshsig(canonical, signature, identity, entry["public_key"], toolchain)
+        expected_index.append({"module_id": module_id, "subject_sha256": sha256(subject_raw)})
+
+    actual_attestations = candidate.list_directory("docs/modules/attestations")
+    if set(actual_attestations) != expected_attestation_files:
+        fail(
+            "attestation-files",
+            f"missing={sorted(expected_attestation_files-set(actual_attestations))}, "
+            f"extra={sorted(set(actual_attestations)-expected_attestation_files)}",
+        )
+    invalid_mode = next(
+        (name for name, mode_kind in sorted(actual_attestations.items())
+         if mode_kind != ("100644", "blob")),
+        None,
+    )
+    if invalid_mode is not None:
+        fail("git-mode", f"attestation {invalid_mode!r} must be a mode 100644 blob")
+    index_raw = candidate.read_blob(
+        "docs/modules/attestations/index.json", max_bytes=MAX_INDEX_BYTES
+    )
+    validate_attestation_index(index_raw, expected_index)
+    return f"Validated {len(module_ids)} descriptor-v2 documents and {len(module_ids) * 2} human SSHSIG attestations."
+
+
 def validate_trust_policy(value: object, *, at: datetime) -> dict[str, dict[str, object]]:
     policy = _exact_object(value, {"schema", "epoch", "identities"}, "trust-policy-shape")
     if policy["schema"] != "aimee.module-doc-trust.v1":
@@ -646,7 +937,7 @@ def validate_trust_policy(value: object, *, at: datetime) -> dict[str, dict[str,
         not_before = parse_timestamp(item["not_before"], "trust-policy-not-before")
         not_after = parse_timestamp(item["not_after"], "trust-policy-not-after")
         revoked = None if item["revoked_at"] is None else parse_timestamp(item["revoked_at"], "trust-policy-revoked-at")
-        if not_before > at or at > not_after or (revoked is not None and at >= revoked):
+        if not_before > at or at >= not_after or (revoked is not None and at >= revoked):
             fail("trust-policy-authorization", f"identity {identity!r} is not authorized at verification time")
         result[identity] = item
     return result
@@ -758,8 +1049,19 @@ def authorize_subject(
         identity = subject[field]
         if identity not in identities:
             fail("subject-authorization", f"{field} is not enrolled")
-        if identities[identity]["role"] != role:
+        entry = identities[identity]
+        if entry["role"] != role:
             fail("subject-role", f"{field} is not authorized for role {role}")
+        not_before = parse_timestamp(entry["not_before"], "trust-policy-not-before")
+        not_after = parse_timestamp(entry["not_after"], "trust-policy-not-after")
+        revoked = (
+            None if entry["revoked_at"] is None
+            else parse_timestamp(entry["revoked_at"], "trust-policy-revoked-at")
+        )
+        if signed_at < not_before or signed_at >= not_after or (
+            revoked is not None and signed_at >= revoked
+        ):
+            fail("subject-signing-authorization", f"{field} was not authorized at signed_at")
 
 
 def validate_toolchain_lock(value: object) -> dict[str, object]:
@@ -776,13 +1078,36 @@ def validate_toolchain_lock(value: object) -> dict[str, object]:
     return lock
 
 
-def verify_toolchain_binary(lock: dict[str, object], ssh_keygen: Path) -> None:
+_LOCKED_TOOLCHAIN_SENTINEL = object()
+
+
+class LockedToolchain:
+    __slots__ = ("image", "ssh_keygen", "ssh_keygen_sha256")
+
+    def __init__(
+        self, image: str, ssh_keygen: Path, ssh_keygen_sha256: str, sentinel: object
+    ):
+        if sentinel is not _LOCKED_TOOLCHAIN_SENTINEL:
+            fail("toolchain-lock", "LockedToolchain must be created by load_locked_toolchain")
+        self.image = image
+        self.ssh_keygen = ssh_keygen
+        self.ssh_keygen_sha256 = ssh_keygen_sha256
+
+
+def load_locked_toolchain(value: object, ssh_keygen: Path) -> LockedToolchain:
+    lock = validate_toolchain_lock(value)
+    if not ssh_keygen.is_absolute() or not ssh_keygen.is_file():
+        fail("toolchain-binary", "ssh-keygen must be an absolute regular-file path")
     try:
         actual = sha256(ssh_keygen.read_bytes())
     except OSError as exc:
         fail("toolchain-binary", f"cannot read ssh-keygen: {exc}")
     if actual != lock["ssh_keygen_sha256"]:
         fail("toolchain-binary", "ssh-keygen binary does not match deployment lock")
+    return LockedToolchain(
+        lock["image"], ssh_keygen, lock["ssh_keygen_sha256"],
+        _LOCKED_TOOLCHAIN_SENTINEL,
+    )
 
 
 def validate_publisher_result(value: object, target: dict[str, object]) -> dict[str, object]:
@@ -804,8 +1129,69 @@ def validate_publisher_result(value: object, target: dict[str, object]) -> dict[
     return result
 
 
-def verify_sshsig(subject: bytes, signature: bytes, identity: str, public_key: str, ssh_keygen: Path) -> None:
+class VerificationDecision(NamedTuple):
+    workload: dict[str, object]
+    target: dict[str, object]
+    replay_key: str
+    publisher_result: dict[str, object]
+
+
+def evaluate_trigger(
+    request_raw: bytes,
+    profile_raw: bytes,
+    *,
+    wall_time: int,
+    verify_jwt: Callable[[str, dict[str, object]], dict[str, object]],
+    resolve_target: Callable[[dict[str, object], int], dict[str, object]],
+    validate_candidate: Callable[[GitBlobReader, dict[str, object], dict[str, object]], str],
+    repository: Path,
+) -> VerificationDecision:
+    """Orchestrate a fail-closed external verification decision.
+
+    ``verify_jwt`` is the deployment's pinned JOSE implementation and must
+    perform JWS/JWKS verification before returning claims. ``resolve_target``
+    uses the read-only repository installation and accepts no candidate
+    coordinates. ``validate_candidate`` reads only through ``GitBlobReader``
+    and returns a human-readable success summary. Publishing and replay-store
+    writes occur only after this pure decision is returned.
+    """
+    request = strict_json_bytes(request_raw)
+    pull_request, token = validate_trigger_request(request)
+    profile = validate_oidc_profile(strict_json_bytes(profile_raw))
+    verified_claims = verify_jwt(token, profile)
+    workload = normalize_verified_oidc_claims(verified_claims, profile, wall_time=wall_time)
+    target = validate_candidate_target(resolve_target(workload, pull_request))
+    bind_workload_to_target(workload, target, pull_request=pull_request)
+    reader = GitBlobReader(repository, target["candidate_revision"])
+    summary = validate_candidate(reader, workload, target)
+    if not isinstance(summary, str) or not summary:
+        fail("candidate-validation", "candidate validator returned no summary")
+    result = validate_publisher_result(
+        {
+            "schema": "aimee.module-doc-check.v1",
+            "name": "module-doc-attestation",
+            "candidate_revision": target["candidate_revision"],
+            "external_id": target["trigger_check_identity"],
+            "conclusion": "success",
+            "summary": summary,
+        },
+        target,
+    )
+    return VerificationDecision(workload, target, replay_binding(workload, target), result)
+
+
+def verify_sshsig(
+    subject: bytes,
+    signature: bytes,
+    identity: str,
+    public_key: str,
+    toolchain: LockedToolchain,
+) -> None:
     """Verify one Ed25519 SSHSIG without invoking a shell."""
+    if len(signature) > MAX_SIGNATURE_BYTES:
+        fail("sshsig-size", f"signature exceeds {MAX_SIGNATURE_BYTES} bytes")
+    if not isinstance(toolchain, LockedToolchain):
+        fail("toolchain-lock", "SSHSIG verification requires a locked toolchain")
     _validate_sshsig_envelope(signature)
     try:
         signature.decode("ascii", "strict")
@@ -813,8 +1199,6 @@ def verify_sshsig(subject: bytes, signature: bytes, identity: str, public_key: s
         fail("sshsig-armor", "signature armor must be ASCII")
     if not IDENTITY_RE.fullmatch(identity) or not _valid_ed25519_public_key(public_key):
         fail("sshsig-signer", "signer identity or public key is invalid")
-    if not ssh_keygen.is_absolute() or not ssh_keygen.is_file():
-        fail("sshsig-tool", "ssh-keygen must be an absolute regular-file path")
     with tempfile.TemporaryDirectory(prefix="aimee-sshsig-") as tmp:
         root = Path(tmp)
         allowed = root / "allowed_signers"
@@ -822,7 +1206,7 @@ def verify_sshsig(subject: bytes, signature: bytes, identity: str, public_key: s
         allowed.write_text(f"{identity} {public_key}\n", encoding="ascii")
         sig.write_bytes(signature)
         result = subprocess.run(
-            [str(ssh_keygen), "-Y", "verify", "-f", str(allowed), "-I", identity,
+            [str(toolchain.ssh_keygen), "-Y", "verify", "-f", str(allowed), "-I", identity,
              "-n", "aimee.module-doc.v1", "-s", str(sig)],
             input=subject,
             stdout=subprocess.PIPE,

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -647,19 +647,22 @@ class GitBlobReader:
         selector.register(process.stderr, selectors.EVENT_READ, "stderr")
         output = bytearray()
         errors = bytearray()
-        deadline = time.monotonic() + min(
-            GIT_OPERATION_TIMEOUT_SECONDS, remaining_decision
+        deadline = min(
+            self.budget.git_deadline,
+            time.monotonic() + GIT_OPERATION_TIMEOUT_SECONDS,
         )
 
         def terminate() -> None:
-            if process.poll() is not None:
-                return
             try:
                 os.killpg(process.pid, 9)
             except ProcessLookupError:
                 pass
-            process.wait()
+            if process.poll() is None:
+                process.wait()
         try:
+            if time.monotonic() >= deadline:
+                terminate()
+                fail("git-timeout", "decision expired while starting a Git operation")
             while selector.get_map():
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
@@ -694,8 +697,7 @@ class GitBlobReader:
             return bytes(output)
         finally:
             selector.close()
-            if process.poll() is None:
-                terminate()
+            terminate()
             process.stdout.close()
             process.stderr.close()
 

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -8,12 +8,15 @@ the provider-independent workload record defined here.
 
 from __future__ import annotations
 
+import base64
+import binascii
 from datetime import datetime, timezone
 import hashlib
 import json
 from pathlib import Path, PurePosixPath
 import re
 import subprocess
+import struct
 import tempfile
 from typing import Callable, NamedTuple, NoReturn
 
@@ -160,7 +163,9 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
             fail("oidc-issuer", "issuer must be an exact HTTPS URL without trailing slash")
 
     jwks = _exact_object(
-        profile["jwks"], {"uri", "tls_spki_sha256", "max_age_seconds"}, "oidc-jwks-shape"
+        profile["jwks"],
+        {"uri", "tls_spki_sha256", "key_thumbprints_sha256", "max_age_seconds"},
+        "oidc-jwks-shape",
     )
     if not _string(jwks["uri"], "oidc-jwks-uri").startswith("https://"):
         fail("oidc-jwks-uri", "JWKS URI must use HTTPS")
@@ -169,6 +174,13 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
         fail("oidc-jwks-pins", "at least one lowercase SHA-256 SPKI pin is required")
     if pins != sorted(set(pins)):
         fail("oidc-jwks-pins", "SPKI pins must be sorted and unique")
+    thumbprints = jwks["key_thumbprints_sha256"]
+    if not isinstance(thumbprints, list) or not thumbprints or not all(
+        isinstance(item, str) and HEX_64_RE.fullmatch(item) for item in thumbprints
+    ):
+        fail("oidc-jwks-keys", "at least one lowercase SHA-256 JWK thumbprint is required")
+    if thumbprints != sorted(set(thumbprints)):
+        fail("oidc-jwks-keys", "JWK thumbprints must be sorted and unique")
     if type(jwks["max_age_seconds"]) is not int or not 1 <= jwks["max_age_seconds"] <= 86400:
         fail("oidc-jwks-max-age", "max_age_seconds must be an integer in [1, 86400]")
 
@@ -304,7 +316,8 @@ def validate_candidate_target(value: object) -> dict[str, str]:
     target = _exact_object(
         value,
         {"schema", "repository_identity", "pull_request", "protected_base_revision",
-         "candidate_revision", "base_ref", "head_ref", "trigger_check_identity"},
+         "candidate_revision", "base_ref", "head_ref", "workflow_identity",
+         "workflow_revision", "run_identity", "attempt", "trigger_check_identity"},
         "candidate-target-shape",
     )
     if target["schema"] != "aimee.candidate-target.v1":
@@ -314,7 +327,10 @@ def validate_candidate_target(value: object) -> dict[str, str]:
     for field in ("protected_base_revision", "candidate_revision"):
         if not isinstance(target[field], str) or not re.fullmatch(r"[0-9a-f]{40}", target[field]):
             fail("candidate-target-revision", f"{field} must be a full lowercase commit ID")
-    for field in ("repository_identity", "base_ref", "head_ref", "trigger_check_identity"):
+    for field in (
+        "repository_identity", "base_ref", "head_ref", "workflow_identity",
+        "workflow_revision", "run_identity", "attempt", "trigger_check_identity",
+    ):
         if not isinstance(target[field], str) or not target[field]:
             fail("candidate-target-field", f"{field} must be a non-empty string")
     return target
@@ -325,10 +341,29 @@ def bind_workload_to_target(
 ) -> None:
     if target["pull_request"] != pull_request:
         fail("target-request-binding", "repository API returned a different pull request")
-    if target["repository_identity"] != workload["repository_identity"]:
-        fail("target-repository-binding", "repository identity mismatch")
-    if target["trigger_check_identity"] != workload["trigger_check_identity"]:
-        fail("target-trigger-binding", "trigger check identity mismatch")
+    bindings = {
+        "repository_identity": "target-repository-binding",
+        "workflow_identity": "target-workflow-binding",
+        "workflow_revision": "target-workflow-binding",
+        "run_identity": "target-run-binding",
+        "attempt": "target-run-binding",
+        "trigger_check_identity": "target-trigger-binding",
+    }
+    for field, rule in bindings.items():
+        if target[field] != workload[field]:
+            fail(rule, f"{field} mismatch")
+
+
+def replay_binding(workload: dict[str, object], target: dict[str, object]) -> str:
+    fields = (
+        workload["issuer"], workload["token_id"], workload["repository_identity"],
+        workload["run_identity"], workload["attempt"], workload["trigger_check_identity"],
+        str(target["pull_request"]), target["protected_base_revision"],
+        target["candidate_revision"],
+    )
+    if any(not isinstance(item, str) or not item for item in fields):
+        fail("replay-binding", "binding fields must be non-empty strings")
+    return sha256("\0".join(fields).encode("utf-8"))
 
 
 def validate_v2_metadata(value: object, *, optional: bool) -> dict[str, object]:
@@ -605,8 +640,7 @@ def validate_trust_policy(value: object, *, at: datetime) -> dict[str, dict[str,
         if item["role"] not in {"owner", "reviewer"}:
             fail("trust-policy-role", "role must be owner or reviewer")
         public_key = _string(item["public_key"], "trust-policy-key")
-        parts = public_key.split()
-        if len(parts) != 2 or parts[0] != "ssh-ed25519" or public_key in keys:
+        if not _valid_ed25519_public_key(public_key) or public_key in keys:
             fail("trust-policy-key", "key must be a unique canonical Ed25519 public key")
         keys.add(public_key)
         not_before = parse_timestamp(item["not_before"], "trust-policy-not-before")
@@ -616,6 +650,99 @@ def validate_trust_policy(value: object, *, at: datetime) -> dict[str, dict[str,
             fail("trust-policy-authorization", f"identity {identity!r} is not authorized at verification time")
         result[identity] = item
     return result
+
+
+TRUST_IDENTITY_KEYS = (
+    "identity", "role", "public_key", "not_before", "not_after", "revoked_at"
+)
+
+
+def canonical_trust_policy(value: object, *, at: datetime) -> bytes:
+    identities = validate_trust_policy(value, at=at)
+    assert isinstance(value, dict)
+    ordered_entries = [
+        {key: identities[identity][key] for key in TRUST_IDENTITY_KEYS}
+        for identity in sorted(identities)
+    ]
+    ordered = {
+        "schema": value["schema"],
+        "epoch": value["epoch"],
+        "identities": ordered_entries,
+    }
+    return (json.dumps(ordered, indent=2, ensure_ascii=True, separators=(",", ": ")) + "\n").encode("ascii")
+
+
+def load_canonical_trust_policy(raw: bytes, *, at: datetime) -> dict[str, dict[str, object]]:
+    value = strict_json_bytes(raw)
+    canonical = canonical_trust_policy(value, at=at)
+    if raw != canonical:
+        fail("trust-policy-canonical", "trust policy bytes are not canonical")
+    return validate_trust_policy(value, at=at)
+
+
+def validate_trust_epoch(previous: object, current: object) -> None:
+    if type(previous) is not int or type(current) is not int or current <= previous:
+        fail("trust-policy-epoch", "a trust-policy change must increase the protected epoch")
+
+
+def _ssh_string(raw: bytes, offset: int) -> tuple[bytes, int]:
+    if offset + 4 > len(raw):
+        fail("sshsig-format", "truncated SSH string length")
+    size = struct.unpack(">I", raw[offset:offset + 4])[0]
+    start = offset + 4
+    end = start + size
+    if end > len(raw):
+        fail("sshsig-format", "truncated SSH string")
+    return raw[start:end], end
+
+
+def _valid_ed25519_public_key(public_key: str) -> bool:
+    parts = public_key.split(" ")
+    if len(parts) != 2 or parts[0] != "ssh-ed25519" or not parts[1]:
+        return False
+    try:
+        decoded = base64.b64decode(parts[1], validate=True)
+        key_type, offset = _ssh_string(decoded, 0)
+        key_bytes, offset = _ssh_string(decoded, offset)
+    except (binascii.Error, ContractError):
+        return False
+    return key_type == b"ssh-ed25519" and len(key_bytes) == 32 and offset == len(decoded)
+
+
+def _validate_sshsig_envelope(signature: bytes) -> None:
+    begin = b"-----BEGIN SSH SIGNATURE-----\n"
+    end = b"-----END SSH SIGNATURE-----\n"
+    if not signature.startswith(begin) or not signature.endswith(end) or b"\r" in signature:
+        fail("sshsig-armor", "signature must be canonical ASCII armor with final LF")
+    encoded = signature[len(begin):-len(end)]
+    lines = encoded.splitlines()
+    if not lines or any(not line or len(line) > 76 for line in lines):
+        fail("sshsig-armor", "signature armor has invalid line wrapping")
+    try:
+        decoded = base64.b64decode(b"".join(lines), validate=True)
+    except binascii.Error:
+        fail("sshsig-armor", "signature armor is not canonical base64")
+    if not decoded.startswith(b"SSHSIG") or len(decoded) < 10:
+        fail("sshsig-format", "missing SSHSIG magic")
+    version = struct.unpack(">I", decoded[6:10])[0]
+    if version != 1:
+        fail("sshsig-format", "unsupported SSHSIG version")
+    offset = 10
+    public_blob, offset = _ssh_string(decoded, offset)
+    namespace, offset = _ssh_string(decoded, offset)
+    reserved, offset = _ssh_string(decoded, offset)
+    hash_algorithm, offset = _ssh_string(decoded, offset)
+    _, offset = _ssh_string(decoded, offset)
+    if offset != len(decoded):
+        fail("sshsig-format", "trailing SSHSIG bytes")
+    key_type, key_offset = _ssh_string(public_blob, 0)
+    key_bytes, key_offset = _ssh_string(public_blob, key_offset)
+    if key_offset != len(public_blob) or key_type != b"ssh-ed25519" or len(key_bytes) != 32:
+        fail("sshsig-key-type", "signature key must be Ed25519")
+    if namespace != b"aimee.module-doc.v1" or reserved != b"":
+        fail("sshsig-namespace", "signature namespace or reserved field is invalid")
+    if hash_algorithm != b"sha512":
+        fail("sshsig-hash", "signature hash algorithm must be SHA-512")
 
 
 def authorize_subject(
@@ -679,12 +806,15 @@ def validate_publisher_result(value: object, target: dict[str, object]) -> dict[
 
 def verify_sshsig(subject: bytes, signature: bytes, identity: str, public_key: str, ssh_keygen: Path) -> None:
     """Verify one Ed25519 SSHSIG without invoking a shell."""
-    if not signature.startswith(b"-----BEGIN SSH SIGNATURE-----\n") or not signature.endswith(b"-----END SSH SIGNATURE-----\n") or b"\r" in signature:
-        fail("sshsig-armor", "signature must be canonical ASCII armor with final LF")
+    _validate_sshsig_envelope(signature)
     try:
         signature.decode("ascii", "strict")
     except UnicodeDecodeError:
         fail("sshsig-armor", "signature armor must be ASCII")
+    if not IDENTITY_RE.fullmatch(identity) or not _valid_ed25519_public_key(public_key):
+        fail("sshsig-signer", "signer identity or public key is invalid")
+    if not ssh_keygen.is_absolute() or not ssh_keygen.is_file():
+        fail("sshsig-tool", "ssh-keygen must be an absolute regular-file path")
     with tempfile.TemporaryDirectory(prefix="aimee-sshsig-") as tmp:
         root = Path(tmp)
         allowed = root / "allowed_signers"

--- a/scripts/sign_module_docs.py
+++ b/scripts/sign_module_docs.py
@@ -149,16 +149,17 @@ def _existing_attestations_are_well_formed(
     path: Path,
     module_ids: set[str],
     *,
+    pinned_fd: int | None = None,
     owner_identity: str,
     owner_key: str,
     reviewer_identity: str,
     reviewer_key: str,
     toolchain: contract.LockedToolchain,
 ) -> None:
-    if not path.exists() and not path.is_symlink():
+    if pinned_fd is None and not path.exists() and not path.is_symlink():
         return
     try:
-        info = path.lstat()
+        info = os.fstat(pinned_fd) if pinned_fd is not None else path.lstat()
     except OSError as exc:
         fail("existing-attestations", str(exc))
     if not stat.S_ISDIR(info.st_mode):
@@ -226,7 +227,7 @@ def _sign(
     identity: str,
     toolchain: contract.LockedToolchain,
     root: Path,
-    parent_fd: int,
+    root_fd: int,
 ) -> bytes:
     public_path = root / f"signer-{contract.sha256(identity.encode())}.pub"
     public_path.write_text(public_key + "\n", encoding="ascii")
@@ -249,7 +250,7 @@ def _sign(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
-        pass_fds=(parent_fd,),
+        pass_fds=(root_fd,),
         env={
             "HOME": os.fspath(isolated_home),
             "LANG": "C",
@@ -305,9 +306,34 @@ def _assert_parent_path(parent: Path, expected: os.stat_result) -> None:
         fail("parent-race", "attestation parent changed during signing")
 
 
-def _staging_directory(parent_fd: int) -> tuple[str, Path]:
-    proc_parent = Path(f"/proc/self/fd/{parent_fd}")
-    if not proc_parent.is_dir():
+def _open_pinned_directory(parent_fd: int, name: str, *, missing_ok: bool) -> int | None:
+    try:
+        return os.open(
+            name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+            dir_fd=parent_fd,
+        )
+    except FileNotFoundError:
+        if missing_ok:
+            return None
+        raise
+    except OSError as exc:
+        fail("directory-pin", f"cannot pin {name!r}: {exc}")
+
+
+def _assert_entry_inode(
+    parent_fd: int, name: str, expected: os.stat_result, *, rule: str
+) -> None:
+    try:
+        current = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        fail(rule, f"pinned directory {name!r} disappeared")
+    if not stat.S_ISDIR(current.st_mode) or not _same_inode(current, expected):
+        fail(rule, f"pinned directory {name!r} changed")
+
+
+def _staging_directory(parent_fd: int) -> tuple[str, int, Path]:
+    if not Path(f"/proc/self/fd/{parent_fd}").is_dir():
         fail("atomic-replace", "pinned /proc directory access is unavailable")
     for _ in range(32):
         name = f".attestations-{secrets.token_hex(12)}"
@@ -315,7 +341,9 @@ def _staging_directory(parent_fd: int) -> tuple[str, Path]:
             os.mkdir(name, mode=0o700, dir_fd=parent_fd)
         except FileExistsError:
             continue
-        return name, proc_parent / name
+        staging_fd = _open_pinned_directory(parent_fd, name, missing_ok=False)
+        assert staging_fd is not None
+        return name, staging_fd, Path(f"/proc/self/fd/{staging_fd}")
     fail("staging", "cannot allocate a unique staging directory")
 
 
@@ -344,7 +372,8 @@ def build_attestations(args: argparse.Namespace) -> None:
     )
     staging: Path | None = None
     staging_name: str | None = None
-    installed = False
+    staging_fd: int | None = None
+    prior_fd: int | None = None
     try:
         try:
             fcntl.flock(parent_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -352,22 +381,25 @@ def build_attestations(args: argparse.Namespace) -> None:
             fail("signing-busy", "another attestation replacement holds the parent lock")
         parent_info = os.fstat(parent_fd)
         _assert_parent_path(target_parent, parent_info)
-        proc_parent = Path(f"/proc/self/fd/{parent_fd}")
-        target = proc_parent / "attestations"
-        _existing_attestations_are_well_formed(
-            target,
-            module_ids,
-            owner_identity=args.owner_identity,
-            owner_key=owner_key,
-            reviewer_identity=args.reviewer_identity,
-            reviewer_key=reviewer_key,
-            toolchain=toolchain,
-        )
-        try:
-            prior_info = os.stat("attestations", dir_fd=parent_fd, follow_symlinks=False)
-        except FileNotFoundError:
+        prior_fd = _open_pinned_directory(parent_fd, "attestations", missing_ok=True)
+        if prior_fd is None:
             prior_info = None
-        staging_name, staging = _staging_directory(parent_fd)
+        else:
+            prior_info = os.fstat(prior_fd)
+            _existing_attestations_are_well_formed(
+                Path(f"/proc/self/fd/{prior_fd}"),
+                module_ids,
+                pinned_fd=prior_fd,
+                owner_identity=args.owner_identity,
+                owner_key=owner_key,
+                reviewer_identity=args.reviewer_identity,
+                reviewer_key=reviewer_key,
+                toolchain=toolchain,
+            )
+            _assert_entry_inode(
+                parent_fd, "attestations", prior_info, rule="target-race"
+            )
+        staging_name, staging_fd, staging = _staging_directory(parent_fd)
         index: list[dict[str, str]] = []
         for module_id in sorted(module_ids):
             descriptor_relative = Path("src/modules") / module_id / "module.yaml"
@@ -411,7 +443,7 @@ def build_attestations(args: argparse.Namespace) -> None:
                 ("reviewer", args.reviewer_identity, reviewer_key),
             ):
                 signature = _sign(
-                    subject_raw, public_key, identity, toolchain, staging, parent_fd
+                    subject_raw, public_key, identity, toolchain, staging, staging_fd
                 )
                 signature_path = staging / f"{module_id}.{role}.sig"
                 signature_path.write_bytes(signature)
@@ -430,6 +462,7 @@ def build_attestations(args: argparse.Namespace) -> None:
         _existing_attestations_are_well_formed(
             staging,
             module_ids,
+            pinned_fd=staging_fd,
             owner_identity=args.owner_identity,
             owner_key=owner_key,
             reviewer_identity=args.reviewer_identity,
@@ -437,38 +470,23 @@ def build_attestations(args: argparse.Namespace) -> None:
             toolchain=toolchain,
         )
         _assert_parent_path(target_parent, parent_info)
-        staged_info = os.stat(staging_name, dir_fd=parent_fd, follow_symlinks=False)
+        staged_info = os.fstat(staging_fd)
+        _assert_entry_inode(parent_fd, staging_name, staged_info, rule="staging-race")
         if prior_info is not None:
-            try:
-                current_prior = os.stat(
-                    "attestations", dir_fd=parent_fd, follow_symlinks=False
-                )
-            except FileNotFoundError:
-                fail("target-race", "validated attestation directory disappeared")
-            if not _same_inode(prior_info, current_prior):
-                fail("target-race", "validated attestation directory changed")
+            _assert_entry_inode(
+                parent_fd, "attestations", prior_info, rule="target-race"
+            )
+            _assert_entry_inode(parent_fd, staging_name, staged_info, rule="staging-race")
             _renameat2(
                 parent_fd, staging_name, parent_fd, "attestations", RENAME_EXCHANGE
             )
-            try:
-                moved_prior = os.stat(
-                    staging_name, dir_fd=parent_fd, follow_symlinks=False
-                )
-                installed_info = os.stat(
-                    "attestations", dir_fd=parent_fd, follow_symlinks=False
-                )
-                _assert_parent_path(target_parent, parent_info)
-                if not _same_inode(prior_info, moved_prior) or not _same_inode(
-                    staged_info, installed_info
-                ):
-                    fail("target-race", "atomic exchange moved unexpected inodes")
-            except Exception:
-                _renameat2(
-                    parent_fd, staging_name, parent_fd, "attestations", RENAME_EXCHANGE
-                )
-                raise
-            installed = True
-            shutil.rmtree(staging, ignore_errors=True)
+            _assert_parent_path(target_parent, parent_info)
+            _assert_entry_inode(
+                parent_fd, staging_name, prior_info, rule="target-race"
+            )
+            _assert_entry_inode(
+                parent_fd, "attestations", staged_info, rule="target-race"
+            )
         else:
             try:
                 os.stat("attestations", dir_fd=parent_fd, follow_symlinks=False)
@@ -479,25 +497,15 @@ def build_attestations(args: argparse.Namespace) -> None:
             _renameat2(
                 parent_fd, staging_name, parent_fd, "attestations", RENAME_NOREPLACE
             )
-            try:
-                installed_info = os.stat(
-                    "attestations", dir_fd=parent_fd, follow_symlinks=False
-                )
-                _assert_parent_path(target_parent, parent_info)
-                if not _same_inode(staged_info, installed_info):
-                    fail("target-race", "atomic install moved an unexpected inode")
-            except Exception:
-                os.rename(
-                    "attestations",
-                    staging_name,
-                    src_dir_fd=parent_fd,
-                    dst_dir_fd=parent_fd,
-                )
-                raise
-            installed = True
+            _assert_parent_path(target_parent, parent_info)
+            _assert_entry_inode(
+                parent_fd, "attestations", staged_info, rule="target-race"
+            )
     finally:
-        if not installed and staging is not None and staging.exists():
-            shutil.rmtree(staging)
+        if prior_fd is not None:
+            os.close(prior_fd)
+        if staging_fd is not None:
+            os.close(staging_fd)
         os.close(parent_fd)
 
 

--- a/scripts/sign_module_docs.py
+++ b/scripts/sign_module_docs.py
@@ -11,15 +11,15 @@ import argparse
 import ctypes
 from datetime import datetime, timezone
 import errno
+import fcntl
 import json
 import os
 from pathlib import Path, PurePosixPath
-import re
+import secrets
 import shutil
 import stat
 import subprocess
 import sys
-import tempfile
 
 import module_doc_contract as contract
 
@@ -29,6 +29,7 @@ INVENTORY_PATH = Path("tests/baselines/modules/canonical-inventory.yaml")
 ATTESTATION_PATH = Path("docs/modules/attestations")
 AT_FDCWD = -100
 RENAME_EXCHANGE = 2
+RENAME_NOREPLACE = 1
 
 
 class SigningError(ValueError):
@@ -225,10 +226,13 @@ def _sign(
     identity: str,
     toolchain: contract.LockedToolchain,
     root: Path,
+    parent_fd: int,
 ) -> bytes:
     public_path = root / f"signer-{contract.sha256(identity.encode())}.pub"
     public_path.write_text(public_key + "\n", encoding="ascii")
     os.chmod(public_path, 0o600)
+    isolated_home = root / ".signing-home"
+    isolated_home.mkdir(mode=0o700, exist_ok=True)
     auth_sock = os.environ.get("SSH_AUTH_SOCK")
     if not auth_sock:
         fail("ssh-agent", "SSH_AUTH_SOCK is required")
@@ -245,15 +249,30 @@ def _sign(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
-        env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/bin", "SSH_AUTH_SOCK": auth_sock},
+        pass_fds=(parent_fd,),
+        env={
+            "HOME": os.fspath(isolated_home),
+            "LANG": "C",
+            "LC_ALL": "C",
+            "PATH": "/usr/bin:/bin",
+            "SSH_AUTH_SOCK": auth_sock,
+        },
     )
     if result.returncode != 0:
         fail("sign", result.stderr.decode("utf-8", "replace").strip() or "ssh-keygen rejected signing")
+    # verify_sshsig parses the envelope namespace/hash/key type, then uses the
+    # exact public key as an allowed-signer binding through the locked binary.
     contract.verify_sshsig(subject, result.stdout, identity, public_key, toolchain)
     return result.stdout
 
 
-def _rename_exchange(old: Path, new: Path) -> None:
+def _renameat2(
+    old_dir_fd: int,
+    old_name: str,
+    new_dir_fd: int,
+    new_name: str,
+    flags: int,
+) -> None:
     libc = ctypes.CDLL(None, use_errno=True)
     renameat2 = getattr(libc, "renameat2", None)
     if renameat2 is None:
@@ -261,12 +280,43 @@ def _rename_exchange(old: Path, new: Path) -> None:
     renameat2.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
     renameat2.restype = ctypes.c_int
     if renameat2(
-        AT_FDCWD, os.fsencode(old), AT_FDCWD, os.fsencode(new), RENAME_EXCHANGE
+        old_dir_fd, os.fsencode(old_name), new_dir_fd, os.fsencode(new_name), flags
     ) != 0:
         error = ctypes.get_errno()
         if error in {errno.ENOSYS, errno.EINVAL, errno.EXDEV}:
-            fail("atomic-replace", "filesystem does not support atomic directory exchange")
+            fail("atomic-replace", "filesystem does not support the required atomic rename")
         fail("atomic-replace", os.strerror(error))
+
+
+def _rename_exchange(old: Path, new: Path) -> None:
+    _renameat2(AT_FDCWD, os.fspath(old), AT_FDCWD, os.fspath(new), RENAME_EXCHANGE)
+
+
+def _same_inode(left: os.stat_result, right: os.stat_result) -> bool:
+    return left.st_dev == right.st_dev and left.st_ino == right.st_ino
+
+
+def _assert_parent_path(parent: Path, expected: os.stat_result) -> None:
+    try:
+        current = parent.lstat()
+    except OSError as exc:
+        fail("parent-race", f"cannot revalidate attestation parent: {exc}")
+    if not stat.S_ISDIR(current.st_mode) or not _same_inode(current, expected):
+        fail("parent-race", "attestation parent changed during signing")
+
+
+def _staging_directory(parent_fd: int) -> tuple[str, Path]:
+    proc_parent = Path(f"/proc/self/fd/{parent_fd}")
+    if not proc_parent.is_dir():
+        fail("atomic-replace", "pinned /proc directory access is unavailable")
+    for _ in range(32):
+        name = f".attestations-{secrets.token_hex(12)}"
+        try:
+            os.mkdir(name, mode=0o700, dir_fd=parent_fd)
+        except FileExistsError:
+            continue
+        return name, proc_parent / name
+    fail("staging", "cannot allocate a unique staging directory")
 
 
 def build_attestations(args: argparse.Namespace) -> None:
@@ -287,21 +337,37 @@ def build_attestations(args: argparse.Namespace) -> None:
         _regular_file(args.toolchain_lock.resolve(), max_bytes=contract.MAX_DESCRIPTOR_BYTES)
     )
     toolchain = contract.load_locked_toolchain(lock, args.ssh_keygen.resolve())
-    target = repo / ATTESTATION_PATH
     target_parent = _repository_directory(repo, ATTESTATION_PATH.parent)
-    _existing_attestations_are_well_formed(
-        target,
-        module_ids,
-        owner_identity=args.owner_identity,
-        owner_key=owner_key,
-        reviewer_identity=args.reviewer_identity,
-        reviewer_key=reviewer_key,
-        toolchain=toolchain,
+    parent_fd = os.open(
+        target_parent,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
     )
-    staging = Path(tempfile.mkdtemp(prefix=".attestations-", dir=target_parent))
-    os.chmod(staging, 0o700)
+    staging: Path | None = None
+    staging_name: str | None = None
     installed = False
     try:
+        try:
+            fcntl.flock(parent_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            fail("signing-busy", "another attestation replacement holds the parent lock")
+        parent_info = os.fstat(parent_fd)
+        _assert_parent_path(target_parent, parent_info)
+        proc_parent = Path(f"/proc/self/fd/{parent_fd}")
+        target = proc_parent / "attestations"
+        _existing_attestations_are_well_formed(
+            target,
+            module_ids,
+            owner_identity=args.owner_identity,
+            owner_key=owner_key,
+            reviewer_identity=args.reviewer_identity,
+            reviewer_key=reviewer_key,
+            toolchain=toolchain,
+        )
+        try:
+            prior_info = os.stat("attestations", dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            prior_info = None
+        staging_name, staging = _staging_directory(parent_fd)
         index: list[dict[str, str]] = []
         for module_id in sorted(module_ids):
             descriptor_relative = Path("src/modules") / module_id / "module.yaml"
@@ -344,31 +410,95 @@ def build_attestations(args: argparse.Namespace) -> None:
                 ("owner", args.owner_identity, owner_key),
                 ("reviewer", args.reviewer_identity, reviewer_key),
             ):
-                signature = _sign(subject_raw, public_key, identity, toolchain, staging)
+                signature = _sign(
+                    subject_raw, public_key, identity, toolchain, staging, parent_fd
+                )
                 signature_path = staging / f"{module_id}.{role}.sig"
                 signature_path.write_bytes(signature)
                 os.chmod(signature_path, 0o644)
             index.append({"module_id": module_id, "subject_sha256": contract.sha256(subject_raw)})
         for public_path in staging.glob("signer-*.pub"):
             public_path.unlink()
+        signing_home = staging / ".signing-home"
+        if signing_home.exists():
+            shutil.rmtree(signing_home)
         index_path = staging / "index.json"
         index_path.write_bytes(contract.canonical_attestation_index(index))
         os.chmod(index_path, 0o644)
-        expected = {"index.json"}
-        for module_id in module_ids:
-            expected.update({f"{module_id}.subject.json", f"{module_id}.owner.sig", f"{module_id}.reviewer.sig"})
-        if {entry.name for entry in staging.iterdir()} != expected:
-            fail("self-test", "staging directory is incomplete")
-        if target.exists():
-            _rename_exchange(staging, target)
+        # Re-read and cryptographically verify the exact bytes that will be
+        # installed, including canonical subjects and the recomputed index.
+        _existing_attestations_are_well_formed(
+            staging,
+            module_ids,
+            owner_identity=args.owner_identity,
+            owner_key=owner_key,
+            reviewer_identity=args.reviewer_identity,
+            reviewer_key=reviewer_key,
+            toolchain=toolchain,
+        )
+        _assert_parent_path(target_parent, parent_info)
+        staged_info = os.stat(staging_name, dir_fd=parent_fd, follow_symlinks=False)
+        if prior_info is not None:
+            try:
+                current_prior = os.stat(
+                    "attestations", dir_fd=parent_fd, follow_symlinks=False
+                )
+            except FileNotFoundError:
+                fail("target-race", "validated attestation directory disappeared")
+            if not _same_inode(prior_info, current_prior):
+                fail("target-race", "validated attestation directory changed")
+            _renameat2(
+                parent_fd, staging_name, parent_fd, "attestations", RENAME_EXCHANGE
+            )
+            try:
+                moved_prior = os.stat(
+                    staging_name, dir_fd=parent_fd, follow_symlinks=False
+                )
+                installed_info = os.stat(
+                    "attestations", dir_fd=parent_fd, follow_symlinks=False
+                )
+                _assert_parent_path(target_parent, parent_info)
+                if not _same_inode(prior_info, moved_prior) or not _same_inode(
+                    staged_info, installed_info
+                ):
+                    fail("target-race", "atomic exchange moved unexpected inodes")
+            except Exception:
+                _renameat2(
+                    parent_fd, staging_name, parent_fd, "attestations", RENAME_EXCHANGE
+                )
+                raise
             installed = True
             shutil.rmtree(staging, ignore_errors=True)
         else:
-            os.replace(staging, target)
+            try:
+                os.stat("attestations", dir_fd=parent_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                pass
+            else:
+                fail("target-race", "attestation directory appeared during signing")
+            _renameat2(
+                parent_fd, staging_name, parent_fd, "attestations", RENAME_NOREPLACE
+            )
+            try:
+                installed_info = os.stat(
+                    "attestations", dir_fd=parent_fd, follow_symlinks=False
+                )
+                _assert_parent_path(target_parent, parent_info)
+                if not _same_inode(staged_info, installed_info):
+                    fail("target-race", "atomic install moved an unexpected inode")
+            except Exception:
+                os.rename(
+                    "attestations",
+                    staging_name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+                raise
             installed = True
     finally:
-        if not installed and staging.exists():
+        if not installed and staging is not None and staging.exists():
             shutil.rmtree(staging)
+        os.close(parent_fd)
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/scripts/sign_module_docs.py
+++ b/scripts/sign_module_docs.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Build and atomically replace module-document SSHSIG attestations.
+
+The helper reads public keys only. Matching private keys must be available
+through SSH_AUTH_SOCK, normally from a user-owned agent or hardware token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+from datetime import datetime, timezone
+import errno
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+
+import module_doc_contract as contract
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INVENTORY_PATH = Path("tests/baselines/modules/canonical-inventory.yaml")
+ATTESTATION_PATH = Path("docs/modules/attestations")
+AT_FDCWD = -100
+RENAME_EXCHANGE = 2
+
+
+class SigningError(ValueError):
+    """A signing-preparation failure that leaves repository content unchanged."""
+
+
+def fail(rule: str, message: str) -> None:
+    raise SigningError(f"rule={rule}: {message}")
+
+
+def _regular_file(path: Path, *, max_bytes: int) -> bytes:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        fail("input", f"cannot inspect {path}: {exc}")
+    if not stat.S_ISREG(info.st_mode) or info.st_mode & 0o111:
+        fail("input-mode", f"{path} must be a non-executable regular file")
+    if info.st_size > max_bytes:
+        fail("input-size", f"{path} exceeds {max_bytes} bytes")
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        fail("input", f"cannot read {path}: {exc}")
+
+
+def _public_key(path: Path) -> str:
+    raw = _regular_file(path, max_bytes=4096)
+    try:
+        text = raw.decode("ascii", "strict").strip("\n")
+    except UnicodeDecodeError as exc:
+        fail("public-key", f"public key is not ASCII: {exc}")
+    if not contract._valid_ed25519_public_key(text):
+        fail("public-key", "public key must be canonical Ed25519 without a comment")
+    return text
+
+
+def _inventory(repo: Path) -> tuple[set[str], set[str]]:
+    value = contract.strict_json_bytes(
+        _regular_file(repo / INVENTORY_PATH, max_bytes=contract.MAX_DESCRIPTOR_BYTES)
+    )
+    if not isinstance(value, dict) or set(value) != {"schema_version", "required", "optional"}:
+        fail("inventory", "canonical inventory has unexpected shape")
+    if value["schema_version"] != 1 or type(value["schema_version"]) is not int:
+        fail("inventory", "canonical inventory schema_version must equal 1")
+    groups: list[set[str]] = []
+    for name in ("required", "optional"):
+        entries = value[name]
+        if not isinstance(entries, list) or not entries or any(
+            not isinstance(item, str) or not contract.MODULE_ID_RE.fullmatch(item)
+            for item in entries
+        ):
+            fail("inventory", f"{name} must contain canonical module IDs")
+        if len(entries) != len(set(entries)):
+            fail("inventory", f"{name} must be unique")
+        groups.append(set(entries))
+    if groups[0] & groups[1]:
+        fail("inventory", "required and optional inventories overlap")
+    return groups[0], groups[1]
+
+
+def _resolve_worktree_reference(repo: Path, module_ids: set[str], reference: str) -> None:
+    match = contract.REFERENCE_RE.fullmatch(reference)
+    if not match:
+        fail("evidence", f"invalid reference {reference!r}")
+    module_id = match.group("module")
+    if module_id is not None:
+        if module_id not in module_ids:
+            fail("evidence", f"unknown module {module_id!r}")
+        return
+    relative = match.group("path")
+    assert relative is not None
+    pure = PurePosixPath(relative)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        fail("evidence", "path is not canonical")
+    path = repo.joinpath(*pure.parts)
+    raw = _regular_file(path, max_bytes=contract.MAX_GOVERNED_BLOB_BYTES)
+    if match.group("line") is not None and int(match.group("line")) > len(raw.splitlines()):
+        fail("evidence", f"line exceeds {relative}")
+
+
+def _existing_attestations_are_well_formed(
+    path: Path,
+    module_ids: set[str],
+    *,
+    owner_identity: str,
+    owner_key: str,
+    reviewer_identity: str,
+    reviewer_key: str,
+    toolchain: contract.LockedToolchain,
+) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        fail("existing-attestations", str(exc))
+    if not stat.S_ISDIR(info.st_mode):
+        fail("existing-attestations", "existing attestation path must be a directory")
+    expected = {"index.json"}
+    for module_id in module_ids:
+        expected.update({
+            f"{module_id}.subject.json", f"{module_id}.owner.sig",
+            f"{module_id}.reviewer.sig",
+        })
+    actual = {entry.name for entry in path.iterdir()}
+    if actual != expected:
+        fail("existing-attestations", "existing directory is missing, extra, or partial")
+    subjects: dict[str, tuple[dict[str, object], bytes]] = {}
+    for entry in path.iterdir():
+        limit = (
+            contract.MAX_INDEX_BYTES if entry.name == "index.json"
+            else contract.MAX_SUBJECT_BYTES if entry.name.endswith(".subject.json")
+            else contract.MAX_SIGNATURE_BYTES
+        )
+        raw = _regular_file(entry, max_bytes=limit)
+        if entry.name == "index.json":
+            contract.strict_json_bytes(raw)
+        elif entry.name.endswith(".subject.json"):
+            value = contract.strict_json_bytes(raw)
+            if raw != contract.canonical_subject(value):
+                fail("existing-attestations", f"{entry.name} is not canonical")
+            assert isinstance(value, dict)
+            module_id = entry.name.removesuffix(".subject.json")
+            if value["module_id"] != module_id:
+                fail("existing-attestations", f"{entry.name} has a mismatched module ID")
+            if value["owner_identity"] != owner_identity or value["reviewer_identity"] != reviewer_identity:
+                fail("existing-attestations", f"{entry.name} does not match the selected signers")
+            subjects[module_id] = (value, raw)
+        else:
+            contract._validate_sshsig_envelope(raw)
+    expected_index: list[dict[str, str]] = []
+    for module_id in sorted(module_ids):
+        _, subject_raw = subjects[module_id]
+        owner_signature = _regular_file(
+            path / f"{module_id}.owner.sig", max_bytes=contract.MAX_SIGNATURE_BYTES
+        )
+        reviewer_signature = _regular_file(
+            path / f"{module_id}.reviewer.sig", max_bytes=contract.MAX_SIGNATURE_BYTES
+        )
+        contract.verify_sshsig(
+            subject_raw, owner_signature, owner_identity, owner_key, toolchain
+        )
+        contract.verify_sshsig(
+            subject_raw, reviewer_signature, reviewer_identity, reviewer_key, toolchain
+        )
+        expected_index.append({
+            "module_id": module_id,
+            "subject_sha256": contract.sha256(subject_raw),
+        })
+    contract.validate_attestation_index(
+        _regular_file(path / "index.json", max_bytes=contract.MAX_INDEX_BYTES),
+        expected_index,
+    )
+
+
+def _sign(
+    subject: bytes,
+    public_key: str,
+    identity: str,
+    toolchain: contract.LockedToolchain,
+    root: Path,
+) -> bytes:
+    public_path = root / f"signer-{contract.sha256(identity.encode())}.pub"
+    public_path.write_text(public_key + "\n", encoding="ascii")
+    os.chmod(public_path, 0o600)
+    auth_sock = os.environ.get("SSH_AUTH_SOCK")
+    if not auth_sock:
+        fail("ssh-agent", "SSH_AUTH_SOCK is required")
+    try:
+        socket_info = os.stat(auth_sock)
+    except OSError as exc:
+        fail("ssh-agent", f"cannot inspect SSH_AUTH_SOCK: {exc}")
+    if not stat.S_ISSOCK(socket_info.st_mode):
+        fail("ssh-agent", "SSH_AUTH_SOCK must name a Unix socket")
+    result = subprocess.run(
+        [str(toolchain.executable()), "-Y", "sign", "-f", str(public_path),
+         "-n", "aimee.module-doc.v1", "-O", "hashalg=sha512"],
+        input=subject,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env={"LANG": "C", "LC_ALL": "C", "PATH": "/usr/bin:/bin", "SSH_AUTH_SOCK": auth_sock},
+    )
+    if result.returncode != 0:
+        fail("sign", result.stderr.decode("utf-8", "replace").strip() or "ssh-keygen rejected signing")
+    contract.verify_sshsig(subject, result.stdout, identity, public_key, toolchain)
+    return result.stdout
+
+
+def _rename_exchange(old: Path, new: Path) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    renameat2 = getattr(libc, "renameat2", None)
+    if renameat2 is None:
+        fail("atomic-replace", "renameat2(RENAME_EXCHANGE) is unavailable")
+    renameat2.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+    renameat2.restype = ctypes.c_int
+    if renameat2(
+        AT_FDCWD, os.fsencode(old), AT_FDCWD, os.fsencode(new), RENAME_EXCHANGE
+    ) != 0:
+        error = ctypes.get_errno()
+        if error in {errno.ENOSYS, errno.EINVAL, errno.EXDEV}:
+            fail("atomic-replace", "filesystem does not support atomic directory exchange")
+        fail("atomic-replace", os.strerror(error))
+
+
+def build_attestations(args: argparse.Namespace) -> None:
+    repo = args.repo.resolve()
+    required, optional = _inventory(repo)
+    module_ids = required | optional
+    owner_key = _public_key(args.owner_public_key.resolve())
+    reviewer_key = _public_key(args.reviewer_public_key.resolve())
+    if args.owner_identity == args.reviewer_identity:
+        fail("identity-separation", "owner and reviewer identities must differ")
+    if owner_key == reviewer_key:
+        fail("key-separation", "owner and reviewer public keys must differ")
+    signed_at = contract.parse_timestamp(args.signed_at, "signed-at")
+    age = (datetime.now(timezone.utc) - signed_at).total_seconds()
+    if age < 0 or age > 86400:
+        fail("signed-at", "signed_at must be no later than now and at most 24 hours old")
+    lock = contract.strict_json_bytes(
+        _regular_file(args.toolchain_lock.resolve(), max_bytes=contract.MAX_DESCRIPTOR_BYTES)
+    )
+    toolchain = contract.load_locked_toolchain(lock, args.ssh_keygen.resolve())
+    target = repo / ATTESTATION_PATH
+    _existing_attestations_are_well_formed(
+        target,
+        module_ids,
+        owner_identity=args.owner_identity,
+        owner_key=owner_key,
+        reviewer_identity=args.reviewer_identity,
+        reviewer_key=reviewer_key,
+        toolchain=toolchain,
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".attestations-", dir=target.parent))
+    os.chmod(staging, 0o700)
+    installed = False
+    try:
+        index: list[dict[str, str]] = []
+        for module_id in sorted(module_ids):
+            descriptor_path = repo / "src/modules" / module_id / "module.yaml"
+            descriptor_raw = _regular_file(descriptor_path, max_bytes=contract.MAX_DESCRIPTOR_BYTES)
+            descriptor = contract.validate_v2_metadata(
+                contract.strict_json_bytes(descriptor_raw),
+                optional=module_id in optional,
+                known_ids=module_ids,
+            )
+            document_path = repo / descriptor["docs"]
+            document_raw = _regular_file(document_path, max_bytes=contract.MAX_DOCUMENT_BYTES)
+            contract.parse_module_document(
+                document_raw,
+                module_id,
+                contract.DocumentProjection(
+                    tuple(descriptor["sources"]), tuple(descriptor["public_headers"])
+                ),
+                resolve_reference=lambda reference: _resolve_worktree_reference(
+                    repo, module_ids, reference
+                ),
+            )
+            subject = {
+                "descriptor_sha256": contract.sha256(descriptor_raw),
+                "document_sha256": contract.sha256(document_raw),
+                "module_id": module_id,
+                "owner_identity": args.owner_identity,
+                "reviewer_identity": args.reviewer_identity,
+                "schema": "aimee.module-doc-attestation.v1",
+                "signed_at": args.signed_at,
+            }
+            subject_raw = contract.canonical_subject(subject)
+            subject_path = staging / f"{module_id}.subject.json"
+            subject_path.write_bytes(subject_raw)
+            os.chmod(subject_path, 0o644)
+            for role, identity, public_key in (
+                ("owner", args.owner_identity, owner_key),
+                ("reviewer", args.reviewer_identity, reviewer_key),
+            ):
+                signature = _sign(subject_raw, public_key, identity, toolchain, staging)
+                signature_path = staging / f"{module_id}.{role}.sig"
+                signature_path.write_bytes(signature)
+                os.chmod(signature_path, 0o644)
+            index.append({"module_id": module_id, "subject_sha256": contract.sha256(subject_raw)})
+        for public_path in staging.glob("signer-*.pub"):
+            public_path.unlink()
+        index_path = staging / "index.json"
+        index_path.write_bytes(contract.canonical_attestation_index(index))
+        os.chmod(index_path, 0o644)
+        expected = {"index.json"}
+        for module_id in module_ids:
+            expected.update({f"{module_id}.subject.json", f"{module_id}.owner.sig", f"{module_id}.reviewer.sig"})
+        if {entry.name for entry in staging.iterdir()} != expected:
+            fail("self-test", "staging directory is incomplete")
+        if target.exists():
+            _rename_exchange(staging, target)
+            installed = True
+            shutil.rmtree(staging, ignore_errors=True)
+        else:
+            os.replace(staging, target)
+            installed = True
+    finally:
+        if not installed and staging.exists():
+            shutil.rmtree(staging)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=REPO_ROOT)
+    parser.add_argument("--owner-identity", required=True)
+    parser.add_argument("--owner-public-key", type=Path, required=True)
+    parser.add_argument("--reviewer-identity", required=True)
+    parser.add_argument("--reviewer-public-key", type=Path, required=True)
+    parser.add_argument("--signed-at", required=True, help="UTC timestamp: YYYY-MM-DDTHH:MM:SSZ")
+    parser.add_argument("--toolchain-lock", type=Path, required=True)
+    parser.add_argument("--ssh-keygen", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        build_attestations(parse_args(sys.argv[1:] if argv is None else argv))
+    except (SigningError, contract.ContractError, OSError, ValueError) as exc:
+        print(f"sign_module_docs: error: {exc}", file=sys.stderr)
+        return 1
+    print("sign_module_docs: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sign_module_docs.py
+++ b/scripts/sign_module_docs.py
@@ -54,6 +54,40 @@ def _regular_file(path: Path, *, max_bytes: int) -> bytes:
         fail("input", f"cannot read {path}: {exc}")
 
 
+def _repository_file(repo: Path, relative: Path | PurePosixPath, *, max_bytes: int) -> bytes:
+    pure = PurePosixPath(relative.as_posix())
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        fail("repository-path", "repository path is not canonical")
+    current = repo
+    for index, part in enumerate(pure.parts):
+        current = current / part
+        try:
+            info = current.lstat()
+        except OSError as exc:
+            fail("repository-path", f"cannot inspect {current}: {exc}")
+        if stat.S_ISLNK(info.st_mode):
+            fail("repository-path", f"symlink component is forbidden: {current}")
+        if index + 1 < len(pure.parts) and not stat.S_ISDIR(info.st_mode):
+            fail("repository-path", f"non-directory path component: {current}")
+    return _regular_file(current, max_bytes=max_bytes)
+
+
+def _repository_directory(repo: Path, relative: Path | PurePosixPath) -> Path:
+    pure = PurePosixPath(relative.as_posix())
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        fail("repository-path", "repository directory is not canonical")
+    current = repo
+    for part in pure.parts:
+        current = current / part
+        try:
+            info = current.lstat()
+        except OSError as exc:
+            fail("repository-path", f"cannot inspect {current}: {exc}")
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            fail("repository-path", f"directory or symlink invariant failed: {current}")
+    return current
+
+
 def _public_key(path: Path) -> str:
     raw = _regular_file(path, max_bytes=4096)
     try:
@@ -67,7 +101,7 @@ def _public_key(path: Path) -> str:
 
 def _inventory(repo: Path) -> tuple[set[str], set[str]]:
     value = contract.strict_json_bytes(
-        _regular_file(repo / INVENTORY_PATH, max_bytes=contract.MAX_DESCRIPTOR_BYTES)
+        _repository_file(repo, INVENTORY_PATH, max_bytes=contract.MAX_DESCRIPTOR_BYTES)
     )
     if not isinstance(value, dict) or set(value) != {"schema_version", "required", "optional"}:
         fail("inventory", "canonical inventory has unexpected shape")
@@ -103,8 +137,9 @@ def _resolve_worktree_reference(repo: Path, module_ids: set[str], reference: str
     pure = PurePosixPath(relative)
     if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
         fail("evidence", "path is not canonical")
-    path = repo.joinpath(*pure.parts)
-    raw = _regular_file(path, max_bytes=contract.MAX_GOVERNED_BLOB_BYTES)
+    raw = _repository_file(
+        repo, pure, max_bytes=contract.MAX_GOVERNED_BLOB_BYTES
+    )
     if match.group("line") is not None and int(match.group("line")) > len(raw.splitlines()):
         fail("evidence", f"line exceeds {relative}")
 
@@ -253,6 +288,7 @@ def build_attestations(args: argparse.Namespace) -> None:
     )
     toolchain = contract.load_locked_toolchain(lock, args.ssh_keygen.resolve())
     target = repo / ATTESTATION_PATH
+    target_parent = _repository_directory(repo, ATTESTATION_PATH.parent)
     _existing_attestations_are_well_formed(
         target,
         module_ids,
@@ -262,22 +298,25 @@ def build_attestations(args: argparse.Namespace) -> None:
         reviewer_key=reviewer_key,
         toolchain=toolchain,
     )
-    target.parent.mkdir(parents=True, exist_ok=True)
-    staging = Path(tempfile.mkdtemp(prefix=".attestations-", dir=target.parent))
+    staging = Path(tempfile.mkdtemp(prefix=".attestations-", dir=target_parent))
     os.chmod(staging, 0o700)
     installed = False
     try:
         index: list[dict[str, str]] = []
         for module_id in sorted(module_ids):
-            descriptor_path = repo / "src/modules" / module_id / "module.yaml"
-            descriptor_raw = _regular_file(descriptor_path, max_bytes=contract.MAX_DESCRIPTOR_BYTES)
+            descriptor_relative = Path("src/modules") / module_id / "module.yaml"
+            descriptor_raw = _repository_file(
+                repo, descriptor_relative, max_bytes=contract.MAX_DESCRIPTOR_BYTES
+            )
             descriptor = contract.validate_v2_metadata(
                 contract.strict_json_bytes(descriptor_raw),
                 optional=module_id in optional,
                 known_ids=module_ids,
             )
-            document_path = repo / descriptor["docs"]
-            document_raw = _regular_file(document_path, max_bytes=contract.MAX_DOCUMENT_BYTES)
+            document_path = Path(descriptor["docs"])
+            document_raw = _repository_file(
+                repo, document_path, max_bytes=contract.MAX_DOCUMENT_BYTES
+            )
             contract.parse_module_document(
                 document_raw,
                 module_id,

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Tests for provider-neutral module-document attestation contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts/module_doc_contract.py"
+SPEC = importlib.util.spec_from_file_location("module_doc_contract", MODULE_PATH)
+assert SPEC and SPEC.loader
+contract = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(contract)
+FIXTURES = REPO_ROOT / "tests/fixtures/module-doc-contract"
+
+
+def oidc_profile() -> dict[str, object]:
+    mappings = {field: f"ci_{field}" for field in contract.WORKLOAD_FIELDS}
+    return {
+        "schema": "aimee.ci-oidc-profile.v1",
+        "name": "protected-ci",
+        "issuer": "https://issuer.example.invalid",
+        "audience": "aimee-module-doc-verifier",
+        "jwks": {
+            "uri": "https://issuer.example.invalid/jwks",
+            "tls_spki_sha256": ["1" * 64],
+            "max_age_seconds": 3600,
+        },
+        "allowed_algorithms": ["ES256", "RS256"],
+        "max_token_lifetime_seconds": 600,
+        "clock_skew_seconds": 60,
+        "claim_mappings": mappings,
+        "predicates": {
+            "repository_identity": "repository-17",
+            "workflow_identity": "module-doc-trigger",
+            "workflow_revision": "0123456789abcdef0123456789abcdef01234567",
+            "event_type": "pull-request-target",
+        },
+        "repository_api": {
+            "base_url": "https://repository.example.invalid/api",
+            "tls_spki_sha256": ["2" * 64],
+            "response_schema": "aimee.candidate-target.v1",
+        },
+    }
+
+
+def claims(profile: dict[str, object], now: int = 1_800_000_000) -> dict[str, object]:
+    value: dict[str, object] = {
+        "iss": profile["issuer"], "sub": "workload:42", "aud": profile["audience"],
+        "iat": now, "nbf": now - 1, "exp": now + 300, "jti": "token-1",
+    }
+    predicates = profile["predicates"]
+    mappings = profile["claim_mappings"]
+    assert isinstance(predicates, dict) and isinstance(mappings, dict)
+    for field, claim_name in mappings.items():
+        value[claim_name] = predicates.get(field, f"value-{field}")
+    return value
+
+
+class ModuleDocContractTests(unittest.TestCase):
+    def assert_rule(self, rule: str, callback) -> None:
+        with self.assertRaisesRegex(contract.ContractError, f"rule={rule}"):
+            callback()
+
+    def test_positive_document_fixture(self) -> None:
+        raw = (FIXTURES / "positive/module.md").read_bytes()
+        contract.parse_module_document(
+            raw, "memory", contract.DocumentProjection(("src/modules/memory/*.c",), ())
+        )
+
+    def test_document_negative_fixtures_have_stable_rules(self) -> None:
+        positive = (FIXTURES / "positive/module.md").read_bytes()
+        cases = {
+            "unicode": (positive.replace(b"Clear", "Cl\u00e9ar".encode()), "document-byte-domain"),
+            "section-order": (positive.replace(
+                b"## Purpose and non-goals", b"## Classification and lifecycle", 1
+            ), "document-section-cardinality"),
+            "placeholder": (positive.replace(b"Clear", b"TODO", 1), "document-placeholder"),
+            "projection": (positive.replace(b"Sources: src/modules/memory/*.c", b"Sources: none", 1), "document-projection"),
+        }
+        for name, (raw, rule) in cases.items():
+            with self.subTest(name=name):
+                self.assert_rule(rule, lambda raw=raw: contract.parse_module_document(
+                    raw, "memory", contract.DocumentProjection(("src/modules/memory/*.c",), ())
+                ))
+
+    def test_profile_is_provider_neutral_and_closed(self) -> None:
+        profile = oidc_profile()
+        self.assertEqual(contract.validate_oidc_profile(profile), profile)
+        example_raw = (
+            REPO_ROOT / ".github/module-doc-attestation/issuer-profile.example.json"
+        ).read_bytes()
+        example = contract.strict_json_bytes(example_raw)
+        self.assertEqual(contract.validate_oidc_profile(example), example)
+        self.assertNotIn(b"github", example_raw.lower())
+        unknown = dict(profile)
+        unknown["provider"] = "github"
+        self.assert_rule("oidc-profile-shape", lambda: contract.validate_oidc_profile(unknown))
+        no_pin = json.loads(json.dumps(profile))
+        no_pin["jwks"]["tls_spki_sha256"] = []
+        self.assert_rule("oidc-jwks-pins", lambda: contract.validate_oidc_profile(no_pin))
+        missing_predicate = json.loads(json.dumps(profile))
+        del missing_predicate["predicates"]["workflow_revision"]
+        self.assert_rule("oidc-predicates", lambda: contract.validate_oidc_profile(missing_predicate))
+
+    def test_verified_claim_normalization_and_binding(self) -> None:
+        profile = contract.validate_oidc_profile(oidc_profile())
+        token_claims = claims(profile)
+        workload = contract.normalize_verified_oidc_claims(token_claims, profile, wall_time=1_800_000_000)
+        target = contract.validate_candidate_target({
+            "schema": "aimee.candidate-target.v1",
+            "repository_identity": workload["repository_identity"],
+            "pull_request": 1708,
+            "protected_base_revision": "a" * 40,
+            "candidate_revision": "b" * 40,
+            "base_ref": "feature/core-modularization",
+            "head_ref": "slice/module-doc-contracts",
+            "trigger_check_identity": workload["trigger_check_identity"],
+        })
+        contract.bind_workload_to_target(workload, target, pull_request=1708)
+        bad = dict(token_claims)
+        bad["iss"] = "https://other.example.invalid"
+        self.assert_rule("oidc-issuer-mismatch", lambda: contract.normalize_verified_oidc_claims(
+            bad, profile, wall_time=1_800_000_000
+        ))
+        stale = dict(token_claims)
+        stale["iat"] = 1_799_999_000
+        self.assert_rule("oidc-issued-at", lambda: contract.normalize_verified_oidc_claims(
+            stale, profile, wall_time=1_800_000_000
+        ))
+
+    def test_trigger_request_has_no_candidate_coordinates(self) -> None:
+        request = {"schema": "aimee.module-doc-trigger.v1", "pull_request": 17, "oidc_token": "a.b.c"}
+        self.assertEqual(contract.validate_trigger_request(request), (17, "a.b.c"))
+        request["candidate_sha"] = "f" * 40
+        self.assert_rule("trigger-request-shape", lambda: contract.validate_trigger_request(request))
+
+    def test_descriptor_v2_metadata_is_closed_and_deferred(self) -> None:
+        descriptor = {
+            "descriptor_version": 2,
+            "id": "memory",
+            "dependencies": ["config"],
+            "runtime_toggle": {"supported": False},
+            "docs": "docs/modules/memory.md",
+            "sources": ["src/modules/memory/*.c", "src/modules/memory/private/*.h"],
+            "public_headers": [],
+            "surfaces": {"routes": [], "commands": [], "protocols": [], "stages": []},
+        }
+        self.assertEqual(contract.validate_v2_metadata(descriptor, optional=False), descriptor)
+        claimed = json.loads(json.dumps(descriptor))
+        claimed["surfaces"]["routes"] = ["GET /v1/memory"]
+        self.assert_rule("v2-surfaces-deferred", lambda: contract.validate_v2_metadata(claimed, optional=False))
+        crossed = json.loads(json.dumps(descriptor))
+        crossed["sources"] = ["src/modules/config/*.c"]
+        self.assert_rule("v2-source-pattern", lambda: contract.validate_v2_metadata(crossed, optional=False))
+
+    def test_git_reader_uses_immutable_mode_checked_objects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Fixture"], cwd=repo, check=True)
+            evidence = repo / "evidence.txt"
+            evidence.write_text("one\ntwo\n", encoding="ascii")
+            subprocess.run(["git", "add", "evidence.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            reader = contract.GitBlobReader(repo, commit)
+            self.assertEqual(reader.read_blob("evidence.txt"), b"one\ntwo\n")
+            reader.resolve_reference("path:evidence.txt#L2")
+            self.assert_rule("document-evidence-line", lambda: reader.resolve_reference("path:evidence.txt#L3"))
+            evidence.unlink()
+            evidence.symlink_to("target")
+            subprocess.run(["git", "add", "evidence.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "symlink"], cwd=repo, check=True)
+            symlink_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            symlink_reader = contract.GitBlobReader(repo, symlink_commit)
+            self.assert_rule("git-mode", lambda: symlink_reader.read_blob("evidence.txt"))
+
+    def test_canonical_subject_matches_golden_vector(self) -> None:
+        value = json.loads((FIXTURES / "positive/subject.json").read_text(encoding="ascii"))
+        actual = contract.canonical_subject(value)
+        self.assertEqual(actual, (FIXTURES / "positive/subject.json").read_bytes())
+        reordered = {key: value[key] for key in reversed(list(value))}
+        self.assertEqual(contract.canonical_subject(reordered), actual)
+
+    def test_trust_policy_roles_and_verification_time(self) -> None:
+        at = datetime(2027, 1, 1, tzinfo=timezone.utc)
+        key_one = "ssh-ed25519 " + "A" * 68
+        key_two = "ssh-ed25519 " + "B" * 68
+        policy = {
+            "schema": "aimee.module-doc-trust.v1", "epoch": 1,
+            "identities": [
+                {"identity": "owner@example", "role": "owner", "public_key": key_one,
+                 "not_before": "2026-01-01T00:00:00Z", "not_after": "2028-01-01T00:00:00Z", "revoked_at": None},
+                {"identity": "reviewer@example", "role": "reviewer", "public_key": key_two,
+                 "not_before": "2026-01-01T00:00:00Z", "not_after": "2028-01-01T00:00:00Z", "revoked_at": None},
+            ],
+        }
+        identities = contract.validate_trust_policy(policy, at=at)
+        self.assertEqual(set(identities), {"owner@example", "reviewer@example"})
+        subject = json.loads((FIXTURES / "positive/subject.json").read_text(encoding="ascii"))
+        contract.authorize_subject(subject, identities, oidc_iat=int(at.timestamp()))
+        swapped = dict(subject)
+        swapped["owner_identity"] = "reviewer@example"
+        swapped["reviewer_identity"] = "owner@example"
+        self.assert_rule("subject-role", lambda: contract.authorize_subject(
+            swapped, identities, oidc_iat=int(at.timestamp())
+        ))
+        policy["identities"][0]["revoked_at"] = "2026-12-31T00:00:00Z"
+        self.assert_rule("trust-policy-authorization", lambda: contract.validate_trust_policy(policy, at=at))
+
+    def test_toolchain_lock_and_publisher_result(self) -> None:
+        executable = Path(shutil.which("ssh-keygen"))
+        lock = {
+            "schema": "aimee.sshsig-toolchain.v1",
+            "image": "registry.example.invalid/aimee/sshsig@sha256:" + "a" * 64,
+            "ssh_keygen_sha256": contract.sha256(executable.read_bytes()),
+        }
+        contract.verify_toolchain_binary(contract.validate_toolchain_lock(lock), executable)
+        bad = dict(lock)
+        bad["image"] = "registry.example.invalid/aimee/sshsig:latest"
+        self.assert_rule("toolchain-image", lambda: contract.validate_toolchain_lock(bad))
+        target = {"candidate_revision": "b" * 40, "trigger_check_identity": "trigger-9"}
+        result = {
+            "schema": "aimee.module-doc-check.v1", "name": "module-doc-attestation",
+            "candidate_revision": "b" * 40, "external_id": "trigger-9",
+            "conclusion": "success", "summary": "All governed artifacts passed.",
+        }
+        self.assertEqual(contract.validate_publisher_result(result, target), result)
+
+    @unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen is required")
+    def test_real_ed25519_sshsig_verification(self) -> None:
+        subject = (FIXTURES / "positive/subject.json").read_bytes()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            key = root / "key"
+            subprocess.run(["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key)], check=True)
+            signed = subprocess.run(
+                ["ssh-keygen", "-Y", "sign", "-f", str(key), "-n", "aimee.module-doc.v1"],
+                input=subject, check=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            )
+            public_key = key.with_suffix(".pub").read_text(encoding="ascii").split()
+            canonical_key = " ".join(public_key[:2])
+            signature = signed.stdout
+            contract.verify_sshsig(subject, signature, "owner@example", canonical_key, Path(shutil.which("ssh-keygen")))
+            self.assert_rule("sshsig-verify", lambda: contract.verify_sshsig(
+                subject + b"x", signature, "owner@example", canonical_key, Path(shutil.which("ssh-keygen"))
+            ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -24,6 +24,19 @@ SPEC.loader.exec_module(contract)
 FIXTURES = REPO_ROOT / "tests/fixtures/module-doc-contract"
 
 
+def locked_toolchain():
+    executable_text = shutil.which("ssh-keygen")
+    if executable_text is None:
+        raise unittest.SkipTest("ssh-keygen is required")
+    executable = Path(executable_text)
+    lock = {
+        "schema": "aimee.sshsig-toolchain.v1",
+        "image": "registry.example.invalid/aimee/sshsig@sha256:" + "a" * 64,
+        "ssh_keygen_sha256": contract.sha256(executable.read_bytes()),
+    }
+    return contract.load_locked_toolchain(lock, executable)
+
+
 def oidc_profile() -> dict[str, object]:
     mappings = {field: f"ci_{field}" for field in contract.WORKLOAD_FIELDS}
     return {
@@ -64,7 +77,7 @@ def claims(profile: dict[str, object], now: int = 1_800_000_000) -> dict[str, ob
     mappings = profile["claim_mappings"]
     assert isinstance(predicates, dict) and isinstance(mappings, dict)
     for field, claim_name in mappings.items():
-        value[claim_name] = predicates.get(field, f"value-{field}")
+        value[claim_name] = predicates.get(field, "1" if field == "attempt" else f"value-{field}")
     return value
 
 
@@ -79,6 +92,14 @@ class ModuleDocContractTests(unittest.TestCase):
             raw, "memory", contract.DocumentProjection(("src/modules/memory/*.c",), ())
         )
 
+    def test_workflow_activation_is_dormant_then_fail_closed(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github/workflows/module-doc-attestation-trigger.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("if: ${{ vars.MODULE_DOC_ATTESTATION_ENABLED == 'true' }}", workflow)
+        self.assertIn("MODULE_DOC_VERIFIER_AUDIENCE and MODULE_DOC_VERIFIER_URL must be configured", workflow)
+        self.assertNotIn("actions/checkout", workflow)
+
     def test_document_negative_fixtures_have_stable_rules(self) -> None:
         positive = (FIXTURES / "positive/module.md").read_bytes()
         cases = {
@@ -88,12 +109,50 @@ class ModuleDocContractTests(unittest.TestCase):
             ), "document-section-cardinality"),
             "placeholder": (positive.replace(b"Clear", b"TODO", 1), "document-placeholder"),
             "projection": (positive.replace(b"Sources: src/modules/memory/*.c", b"Sources: none", 1), "document-projection"),
+            "record-order": (positive.replace(
+                b"Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.\n- Evidence: path:scripts/module_doc_contract.py#L1",
+                b"- Evidence: path:scripts/module_doc_contract.py#L1\nClear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.",
+                1,
+            ), "document-record-order"),
+            "none-consecutive": (positive.replace(
+                b"State: present\nSources:",
+                b"State: none\nReason: Concrete reason.\n\nImplication: Concrete implication.\nEvidence: path:scripts/module_doc_contract.py#L1\nSources:",
+                1,
+            ), "document-none-block"),
+            "preamble": (positive.replace(
+                b"# memory module\n\n", b"# memory module\n\nUnparsed preamble.\n", 1
+            ), "document-preamble"),
+            "duplicate-h1": (positive.replace(
+                b"# memory module\n\n", b"# memory module\n\n# memory module\n", 1
+            ), "document-preamble"),
+            "extra-h1-blank": (positive.replace(
+                b"# memory module\n\n", b"# memory module\n\n\n", 1
+            ), "document-preamble"),
         }
         for name, (raw, rule) in cases.items():
             with self.subTest(name=name):
                 self.assert_rule(rule, lambda raw=raw: contract.parse_module_document(
                     raw, "memory", contract.DocumentProjection(("src/modules/memory/*.c",), ())
                 ))
+        none = positive.replace(
+            b"State: present\nSources:",
+            b"State: none\nReason: Concrete reason.\nImplication: Concrete implication.\nEvidence: path:scripts/module_doc_contract.py#L1\nSources:",
+            1,
+        )
+        contract.parse_module_document(
+            none, "memory", contract.DocumentProjection(("src/modules/memory/*.c",), ())
+        )
+        unknown_module = positive.replace(
+            b"path:scripts/module_doc_contract.py#L1", b"module:absent", 1
+        )
+        def resolve(reference: str) -> None:
+            if reference == "module:absent":
+                contract.fail("document-evidence-module", "unknown evidence module")
+        self.assert_rule("document-evidence-module", lambda: contract.parse_module_document(
+            unknown_module, "memory",
+            contract.DocumentProjection(("src/modules/memory/*.c",), ()),
+            resolve_reference=resolve,
+        ))
 
     def test_profile_is_provider_neutral_and_closed(self) -> None:
         profile = oidc_profile()
@@ -113,6 +172,26 @@ class ModuleDocContractTests(unittest.TestCase):
         missing_predicate = json.loads(json.dumps(profile))
         del missing_predicate["predicates"]["workflow_revision"]
         self.assert_rule("oidc-predicates", lambda: contract.validate_oidc_profile(missing_predicate))
+        self.assert_rule("json-size", lambda: contract.strict_json_bytes(
+            b" " * (contract.MAX_JSON_BYTES + 1)
+        ))
+        malformed = (
+            ("issuer", "https://user@example.invalid", "oidc-issuer"),
+            ("issuer", "https:///missing-host", "oidc-issuer"),
+            ("issuer", "https://issuer.example.invalid/#fragment", "oidc-issuer"),
+            ("issuer", "https://Issuer.example.invalid", "oidc-issuer"),
+            ("jwks.uri", "https://issuer.example.invalid/jwks#fragment", "oidc-jwks-uri"),
+            ("repository_api.base_url", "https://repository.example.invalid/api/", "repository-api-url"),
+        )
+        for field, value, rule in malformed:
+            invalid = json.loads(json.dumps(profile))
+            if "." in field:
+                parent, child = field.split(".")
+                invalid[parent][child] = value
+            else:
+                invalid[field] = value
+            with self.subTest(url_field=field, value=value):
+                self.assert_rule(rule, lambda invalid=invalid: contract.validate_oidc_profile(invalid))
 
     def test_verified_claim_normalization_and_binding(self) -> None:
         profile = contract.validate_oidc_profile(oidc_profile())
@@ -134,6 +213,13 @@ class ModuleDocContractTests(unittest.TestCase):
         })
         contract.bind_workload_to_target(workload, target, pull_request=1708)
         self.assertRegex(contract.replay_binding(workload, target), r"^[0-9a-f]{64}$")
+        for field, rule in (("run_identity", "target-run-binding"), ("attempt", "target-run-binding")):
+            mismatch = dict(target)
+            mismatch[field] = "different"
+            with self.subTest(binding=field):
+                self.assert_rule(rule, lambda mismatch=mismatch: contract.bind_workload_to_target(
+                    workload, mismatch, pull_request=1708
+                ))
         bad = dict(token_claims)
         bad["iss"] = "https://other.example.invalid"
         self.assert_rule("oidc-issuer-mismatch", lambda: contract.normalize_verified_oidc_claims(
@@ -143,6 +229,11 @@ class ModuleDocContractTests(unittest.TestCase):
         stale["iat"] = 1_799_999_000
         self.assert_rule("oidc-issued-at", lambda: contract.normalize_verified_oidc_claims(
             stale, profile, wall_time=1_800_000_000
+        ))
+        bad_attempt = dict(token_claims)
+        bad_attempt[profile["claim_mappings"]["attempt"]] = "01"
+        self.assert_rule("oidc-attempt", lambda: contract.normalize_verified_oidc_claims(
+            bad_attempt, profile, wall_time=1_800_000_000
         ))
 
     def test_trigger_request_has_no_candidate_coordinates(self) -> None:
@@ -169,6 +260,16 @@ class ModuleDocContractTests(unittest.TestCase):
         crossed = json.loads(json.dumps(descriptor))
         crossed["sources"] = ["src/modules/config/*.c"]
         self.assert_rule("v2-source-pattern", lambda: contract.validate_v2_metadata(crossed, optional=False))
+        bad_dependencies = json.loads(json.dumps(descriptor))
+        bad_dependencies["dependencies"] = ["unknown", "config"]
+        self.assert_rule("v2-dependencies", lambda: contract.validate_v2_metadata(
+            bad_dependencies, optional=False, known_ids={"config", "memory"}
+        ))
+        bad_runtime = json.loads(json.dumps(descriptor))
+        bad_runtime["runtime_toggle"] = {"supported": "false"}
+        self.assert_rule("v2-runtime-toggle", lambda: contract.validate_v2_metadata(
+            bad_runtime, optional=False
+        ))
 
     def test_git_reader_uses_immutable_mode_checked_objects(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -192,6 +293,186 @@ class ModuleDocContractTests(unittest.TestCase):
             symlink_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
             symlink_reader = contract.GitBlobReader(repo, symlink_commit)
             self.assert_rule("git-mode", lambda: symlink_reader.read_blob("evidence.txt"))
+
+    def test_git_blob_size_boundary_precedes_read(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Fixture"], cwd=repo, check=True)
+            path = repo / "sized.bin"
+            path.write_bytes(b"1234")
+            subprocess.run(["git", "add", "sized.bin"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "four"], cwd=repo, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            self.assertEqual(contract.GitBlobReader(repo, commit).read_blob("sized.bin", max_bytes=4), b"1234")
+            path.write_bytes(b"12345")
+            subprocess.run(["git", "add", "sized.bin"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "five"], cwd=repo, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            self.assert_rule("git-object-size", lambda: contract.GitBlobReader(
+                repo, commit
+            ).read_blob("sized.bin", max_bytes=4))
+
+    def test_external_decision_orders_crypto_resolution_and_git_reads(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Fixture"], cwd=repo, check=True)
+            (repo / "evidence.txt").write_text("governed\n", encoding="ascii")
+            subprocess.run(["git", "add", "evidence.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            profile = oidc_profile()
+            token_claims = claims(profile)
+            events: list[str] = []
+
+            def verify(token: str, selected: dict[str, object]) -> dict[str, object]:
+                self.assertEqual(token, "signed.jwt.value")
+                self.assertEqual(selected, profile)
+                events.append("crypto")
+                return token_claims
+
+            def resolve(workload: dict[str, object], pull_request: int) -> dict[str, object]:
+                self.assertEqual(events, ["crypto"])
+                events.append("resolve")
+                return {
+                    "schema": "aimee.candidate-target.v1",
+                    "repository_identity": workload["repository_identity"],
+                    "pull_request": pull_request,
+                    "protected_base_revision": commit,
+                    "candidate_revision": commit,
+                    "base_ref": "feature/core-modularization",
+                    "head_ref": "slice/module-doc-contracts",
+                    "workflow_identity": workload["workflow_identity"],
+                    "workflow_revision": workload["workflow_revision"],
+                    "run_identity": workload["run_identity"],
+                    "attempt": workload["attempt"],
+                    "trigger_check_identity": workload["trigger_check_identity"],
+                }
+
+            def validate(reader, workload, target) -> str:
+                self.assertEqual(events, ["crypto", "resolve"])
+                events.append("candidate")
+                self.assertEqual(reader.read_blob("evidence.txt"), b"governed\n")
+                return "All governed artifacts passed."
+
+            request = json.dumps({
+                "schema": "aimee.module-doc-trigger.v1",
+                "pull_request": 1708,
+                "oidc_token": "signed.jwt.value",
+            }, separators=(",", ":")).encode("ascii")
+            decision = contract.evaluate_trigger(
+                request,
+                (json.dumps(profile, separators=(",", ":")) + "\n").encode("ascii"),
+                wall_time=1_800_000_000,
+                verify_jwt=verify,
+                resolve_target=resolve,
+                validate_candidate=validate,
+                repository=repo,
+            )
+            self.assertEqual(events, ["crypto", "resolve", "candidate"])
+            self.assertEqual(decision.publisher_result["candidate_revision"], commit)
+
+    @unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen is required")
+    def test_atomic_candidate_validator_with_two_real_signers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Fixture"], cwd=repo, check=True)
+            modules = {"config": False, "runtime-web": True}
+            for module_id, optional in modules.items():
+                path = repo / "src/modules" / module_id / "module.yaml"
+                path.parent.mkdir(parents=True)
+                base_descriptor = {
+                    "descriptor_version": 1, "id": module_id, "dependencies": [],
+                    "runtime_toggle": {"supported": optional},
+                }
+                if optional:
+                    base_descriptor["enabled_by_default"] = True
+                path.write_text(json.dumps(base_descriptor, indent=2) + "\n", encoding="ascii")
+            (repo / "evidence.txt").write_text("evidence\n", encoding="ascii")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "base"], cwd=repo, check=True)
+            base_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+
+            key_paths = {"owner@example": repo / "owner", "reviewer@example": repo / "reviewer"}
+            public_keys: dict[str, str] = {}
+            for identity, key_path in key_paths.items():
+                subprocess.run(["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key_path)], check=True)
+                public_keys[identity] = " ".join(key_path.with_suffix(".pub").read_text(encoding="ascii").split()[:2])
+            trust = {
+                "schema": "aimee.module-doc-trust.v1", "epoch": 1,
+                "identities": [
+                    {"identity": "owner@example", "role": "owner", "public_key": public_keys["owner@example"],
+                     "not_before": "2026-01-01T00:00:00Z", "not_after": "2028-01-01T00:00:00Z", "revoked_at": None},
+                    {"identity": "reviewer@example", "role": "reviewer", "public_key": public_keys["reviewer@example"],
+                     "not_before": "2026-01-01T00:00:00Z", "not_after": "2028-01-01T00:00:00Z", "revoked_at": None},
+                ],
+            }
+            at = datetime(2027, 1, 1, tzinfo=timezone.utc)
+            trust_raw = contract.canonical_trust_policy(trust, at=at)
+            attestations = repo / "docs/modules/attestations"
+            attestations.mkdir(parents=True)
+            expected_index: list[dict[str, str]] = []
+            template = (FIXTURES / "positive/module.md").read_bytes()
+            template = template.replace(b"Sources: src/modules/memory/*.c", b"Sources: none")
+            template = template.replace(b"path:scripts/module_doc_contract.py#L1", b"path:evidence.txt#L1")
+            for module_id, optional in modules.items():
+                descriptor_path = repo / "src/modules" / module_id / "module.yaml"
+                descriptor = json.loads(descriptor_path.read_text(encoding="ascii"))
+                descriptor.update({
+                    "descriptor_version": 2,
+                    "docs": f"docs/modules/{module_id}.md",
+                    "sources": [], "public_headers": [],
+                    "surfaces": {"routes": [], "commands": [], "protocols": [], "stages": []},
+                })
+                descriptor_path.write_text(json.dumps(descriptor, indent=2) + "\n", encoding="ascii")
+                document = template.replace(b"# memory module", f"# {module_id} module".encode("ascii"), 1)
+                document_path = repo / "docs/modules" / f"{module_id}.md"
+                document_path.parent.mkdir(parents=True, exist_ok=True)
+                document_path.write_bytes(document)
+                subject = {
+                    "descriptor_sha256": contract.sha256(descriptor_path.read_bytes()),
+                    "document_sha256": contract.sha256(document),
+                    "module_id": module_id,
+                    "owner_identity": "owner@example", "reviewer_identity": "reviewer@example",
+                    "schema": "aimee.module-doc-attestation.v1", "signed_at": "2027-01-01T00:00:00Z",
+                }
+                subject_raw = contract.canonical_subject(subject)
+                (attestations / f"{module_id}.subject.json").write_bytes(subject_raw)
+                for role, identity in (("owner", "owner@example"), ("reviewer", "reviewer@example")):
+                    signed = subprocess.run(
+                        ["ssh-keygen", "-Y", "sign", "-f", str(key_paths[identity]),
+                         "-n", "aimee.module-doc.v1"], input=subject_raw, check=True,
+                        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                    )
+                    (attestations / f"{module_id}.{role}.sig").write_bytes(signed.stdout)
+                expected_index.append({"module_id": module_id, "subject_sha256": contract.sha256(subject_raw)})
+            expected_index.sort(key=lambda item: item["module_id"])
+            (attestations / "index.json").write_bytes(contract.canonical_attestation_index(expected_index))
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "candidate"], cwd=repo, check=True)
+            candidate_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            summary = contract.validate_module_candidate(
+                contract.GitBlobReader(repo, candidate_commit),
+                contract.GitBlobReader(repo, base_commit),
+                required_ids={"config"}, optional_ids={"runtime-web"}, trust_policy_raw=trust_raw,
+                oidc_iat=int(at.timestamp()), toolchain=locked_toolchain(),
+            )
+            self.assertIn("2 descriptor-v2 documents", summary)
+            (attestations / "extra.sig").write_text("not governed\n", encoding="ascii")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "extra"], cwd=repo, check=True)
+            extra_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            self.assert_rule("attestation-files", lambda: contract.validate_module_candidate(
+                contract.GitBlobReader(repo, extra_commit),
+                contract.GitBlobReader(repo, base_commit),
+                required_ids={"config"}, optional_ids={"runtime-web"}, trust_policy_raw=trust_raw,
+                oidc_iat=int(at.timestamp()), toolchain=locked_toolchain(),
+            ))
 
     def test_canonical_subject_matches_golden_vector(self) -> None:
         value = json.loads((FIXTURES / "positive/subject.json").read_text(encoding="ascii"))
@@ -234,6 +515,13 @@ class ModuleDocContractTests(unittest.TestCase):
         self.assert_rule("subject-role", lambda: contract.authorize_subject(
             swapped, identities, oidc_iat=int(at.timestamp())
         ))
+        later = datetime(2027, 1, 1, 12, tzinfo=timezone.utc)
+        enrolled_late = json.loads(json.dumps(policy))
+        enrolled_late["identities"][0]["not_before"] = "2027-01-01T01:00:00Z"
+        late_identities = contract.validate_trust_policy(enrolled_late, at=later)
+        self.assert_rule("subject-signing-authorization", lambda: contract.authorize_subject(
+            subject, late_identities, oidc_iat=int(later.timestamp())
+        ))
         policy["identities"][0]["revoked_at"] = "2026-12-31T00:00:00Z"
         self.assert_rule("trust-policy-authorization", lambda: contract.validate_trust_policy(policy, at=at))
 
@@ -244,7 +532,12 @@ class ModuleDocContractTests(unittest.TestCase):
             "image": "registry.example.invalid/aimee/sshsig@sha256:" + "a" * 64,
             "ssh_keygen_sha256": contract.sha256(executable.read_bytes()),
         }
-        contract.verify_toolchain_binary(contract.validate_toolchain_lock(lock), executable)
+        self.assertEqual(contract.load_locked_toolchain(lock, executable).ssh_keygen, executable)
+        wrong_hash = dict(lock)
+        wrong_hash["ssh_keygen_sha256"] = "0" * 64
+        self.assert_rule("toolchain-binary", lambda: contract.load_locked_toolchain(
+            wrong_hash, executable
+        ))
         bad = dict(lock)
         bad["image"] = "registry.example.invalid/aimee/sshsig:latest"
         self.assert_rule("toolchain-image", lambda: contract.validate_toolchain_lock(bad))
@@ -270,9 +563,10 @@ class ModuleDocContractTests(unittest.TestCase):
             public_key = key.with_suffix(".pub").read_text(encoding="ascii").split()
             canonical_key = " ".join(public_key[:2])
             signature = signed.stdout
-            contract.verify_sshsig(subject, signature, "owner@example", canonical_key, Path(shutil.which("ssh-keygen")))
+            toolchain = locked_toolchain()
+            contract.verify_sshsig(subject, signature, "owner@example", canonical_key, toolchain)
             self.assert_rule("sshsig-verify", lambda: contract.verify_sshsig(
-                subject + b"x", signature, "owner@example", canonical_key, Path(shutil.which("ssh-keygen"))
+                subject + b"x", signature, "owner@example", canonical_key, toolchain
             ))
             signed_sha256 = subprocess.run(
                 ["ssh-keygen", "-Y", "sign", "-f", str(key), "-n", "aimee.module-doc.v1", "-O", "hashalg=sha256"],
@@ -280,7 +574,14 @@ class ModuleDocContractTests(unittest.TestCase):
             )
             self.assert_rule("sshsig-hash", lambda: contract.verify_sshsig(
                 subject, signed_sha256.stdout, "owner@example", canonical_key,
-                Path(shutil.which("ssh-keygen")),
+                toolchain,
+            ))
+            self.assert_rule("sshsig-size", lambda: contract.verify_sshsig(
+                subject, b"x" * (contract.MAX_SIGNATURE_BYTES + 1), "owner@example",
+                canonical_key, toolchain,
+            ))
+            self.assert_rule("toolchain-lock", lambda: contract.verify_sshsig(
+                subject, signature, "owner@example", canonical_key, key,
             ))
 
 

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import base64
 from datetime import datetime, timezone
 import importlib.util
 import json
 from pathlib import Path
 import shutil
 import subprocess
+import struct
 import tempfile
 import unittest
 
@@ -32,6 +34,7 @@ def oidc_profile() -> dict[str, object]:
         "jwks": {
             "uri": "https://issuer.example.invalid/jwks",
             "tls_spki_sha256": ["1" * 64],
+            "key_thumbprints_sha256": ["3" * 64],
             "max_age_seconds": 3600,
         },
         "allowed_algorithms": ["ES256", "RS256"],
@@ -123,9 +126,14 @@ class ModuleDocContractTests(unittest.TestCase):
             "candidate_revision": "b" * 40,
             "base_ref": "feature/core-modularization",
             "head_ref": "slice/module-doc-contracts",
+            "workflow_identity": workload["workflow_identity"],
+            "workflow_revision": workload["workflow_revision"],
+            "run_identity": workload["run_identity"],
+            "attempt": workload["attempt"],
             "trigger_check_identity": workload["trigger_check_identity"],
         })
         contract.bind_workload_to_target(workload, target, pull_request=1708)
+        self.assertRegex(contract.replay_binding(workload, target), r"^[0-9a-f]{64}$")
         bad = dict(token_claims)
         bad["iss"] = "https://other.example.invalid"
         self.assert_rule("oidc-issuer-mismatch", lambda: contract.normalize_verified_oidc_claims(
@@ -194,8 +202,12 @@ class ModuleDocContractTests(unittest.TestCase):
 
     def test_trust_policy_roles_and_verification_time(self) -> None:
         at = datetime(2027, 1, 1, tzinfo=timezone.utc)
-        key_one = "ssh-ed25519 " + "A" * 68
-        key_two = "ssh-ed25519 " + "B" * 68
+        def public_key(byte: int) -> str:
+            key_type = b"ssh-ed25519"
+            blob = struct.pack(">I", len(key_type)) + key_type + struct.pack(">I", 32) + bytes([byte]) * 32
+            return "ssh-ed25519 " + base64.b64encode(blob).decode("ascii")
+        key_one = public_key(1)
+        key_two = public_key(2)
         policy = {
             "schema": "aimee.module-doc-trust.v1", "epoch": 1,
             "identities": [
@@ -207,6 +219,13 @@ class ModuleDocContractTests(unittest.TestCase):
         }
         identities = contract.validate_trust_policy(policy, at=at)
         self.assertEqual(set(identities), {"owner@example", "reviewer@example"})
+        canonical = contract.canonical_trust_policy(policy, at=at)
+        self.assertEqual(set(contract.load_canonical_trust_policy(canonical, at=at)), set(identities))
+        self.assert_rule("trust-policy-canonical", lambda: contract.load_canonical_trust_policy(
+            canonical + b"\n", at=at
+        ))
+        contract.validate_trust_epoch(1, 2)
+        self.assert_rule("trust-policy-epoch", lambda: contract.validate_trust_epoch(2, 2))
         subject = json.loads((FIXTURES / "positive/subject.json").read_text(encoding="ascii"))
         contract.authorize_subject(subject, identities, oidc_iat=int(at.timestamp()))
         swapped = dict(subject)
@@ -254,6 +273,14 @@ class ModuleDocContractTests(unittest.TestCase):
             contract.verify_sshsig(subject, signature, "owner@example", canonical_key, Path(shutil.which("ssh-keygen")))
             self.assert_rule("sshsig-verify", lambda: contract.verify_sshsig(
                 subject + b"x", signature, "owner@example", canonical_key, Path(shutil.which("ssh-keygen"))
+            ))
+            signed_sha256 = subprocess.run(
+                ["ssh-keygen", "-Y", "sign", "-f", str(key), "-n", "aimee.module-doc.v1", "-O", "hashalg=sha256"],
+                input=subject, check=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            )
+            self.assert_rule("sshsig-hash", lambda: contract.verify_sshsig(
+                subject, signed_sha256.stdout, "owner@example", canonical_key,
+                Path(shutil.which("ssh-keygen")),
             ))
 
 

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -27,7 +27,7 @@ FIXTURES = REPO_ROOT / "tests/fixtures/module-doc-contract"
 def locked_toolchain():
     executable_text = shutil.which("ssh-keygen")
     if executable_text is None:
-        raise unittest.SkipTest("ssh-keygen is required")
+        raise AssertionError("ssh-keygen is required by the module-doc contract suite")
     executable = Path(executable_text)
     lock = {
         "schema": "aimee.sshsig-toolchain.v1",
@@ -191,6 +191,9 @@ class ModuleDocContractTests(unittest.TestCase):
         self.assert_rule("json-size", lambda: contract.strict_json_bytes(
             b" " * (contract.MAX_JSON_BYTES + 1)
         ))
+        self.assert_rule("json-integer-range", lambda: contract.strict_json_bytes(
+            b'{"value":123456789012345678901}'
+        ))
         malformed = (
             ("issuer", "https://user@example.invalid", "oidc-issuer"),
             ("issuer", "https:///missing-host", "oidc-issuer"),
@@ -230,6 +233,7 @@ class ModuleDocContractTests(unittest.TestCase):
         })
         contract.bind_workload_to_target(workload, target, pull_request=1708)
         self.assertRegex(contract.replay_binding(workload, target), r"^[0-9a-f]{64}$")
+        self.assertRegex(contract.replay_token_identity(workload), r"^[0-9a-f]{64}$")
         for field, rule in (("run_identity", "target-run-binding"), ("attempt", "target-run-binding")):
             mismatch = dict(target)
             mismatch[field] = "different"
@@ -247,6 +251,16 @@ class ModuleDocContractTests(unittest.TestCase):
         self.assert_rule("oidc-issued-at", lambda: contract.normalize_verified_oidc_claims(
             stale, profile, wall_time=1_800_000_000
         ))
+        expires_now = dict(token_claims)
+        expires_now["exp"] = 1_800_000_000
+        self.assert_rule("oidc-validity-window", lambda: contract.normalize_verified_oidc_claims(
+            expires_now, profile, wall_time=1_800_000_000
+        ))
+        starts_now = dict(token_claims)
+        starts_now["nbf"] = 1_800_000_000
+        contract.normalize_verified_oidc_claims(
+            starts_now, profile, wall_time=1_800_000_000
+        )
         bad_attempt = dict(token_claims)
         bad_attempt[profile["claim_mappings"]["attempt"]] = "01"
         self.assert_rule("oidc-attempt", lambda: contract.normalize_verified_oidc_claims(
@@ -331,6 +345,28 @@ class ModuleDocContractTests(unittest.TestCase):
                 repo, commit
             ).read_blob("sized.bin", max_bytes=4))
 
+    def test_git_tree_entry_ceiling(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Fixture"], cwd=repo, check=True)
+            directory = repo / "many"
+            directory.mkdir()
+            for index in range(3):
+                (directory / f"{index}.txt").write_text("x\n", encoding="ascii")
+            subprocess.run(["git", "add", "many"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "many"], cwd=repo, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            previous = contract.MAX_TREE_ENTRIES
+            contract.MAX_TREE_ENTRIES = 2
+            try:
+                self.assert_rule("git-tree-entries", lambda: contract.GitBlobReader(
+                    repo, commit
+                ).list_directory("many"))
+            finally:
+                contract.MAX_TREE_ENTRIES = previous
+
     def test_external_decision_orders_crypto_resolution_and_git_reads(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
@@ -391,8 +427,23 @@ class ModuleDocContractTests(unittest.TestCase):
             )
             self.assertEqual(events, ["crypto", "resolve", "candidate"])
             self.assertEqual(decision.publisher_result["candidate_revision"], commit)
+            self.assertRegex(decision.token_replay_key, r"^[0-9a-f]{64}$")
+            self.assertRegex(decision.decision_replay_key, r"^[0-9a-f]{64}$")
+            events.clear()
+            def reject(reader, workload, target) -> str:
+                contract.fail("candidate-rejected", "fixture rejection")
+            rejected = contract.evaluate_trigger(
+                request,
+                (json.dumps(profile, separators=(",", ":")) + "\n").encode("ascii"),
+                wall_time=1_800_000_000,
+                verify_jwt=verify,
+                resolve_target=resolve,
+                validate_candidate=reject,
+                repository=repo,
+            )
+            self.assertEqual(rejected.publisher_result["conclusion"], "failure")
+            self.assertIn("rule=candidate-rejected", rejected.publisher_result["summary"])
 
-    @unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen is required")
     def test_atomic_candidate_validator_with_two_real_signers(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
@@ -558,6 +609,14 @@ class ModuleDocContractTests(unittest.TestCase):
         bad = dict(lock)
         bad["image"] = "registry.example.invalid/aimee/sshsig:latest"
         self.assert_rule("toolchain-image", lambda: contract.validate_toolchain_lock(bad))
+        with tempfile.TemporaryDirectory() as tmp:
+            copied = Path(tmp) / "ssh-keygen"
+            shutil.copy2(executable, copied)
+            copied_lock = dict(lock)
+            copied_lock["ssh_keygen_sha256"] = contract.sha256(copied.read_bytes())
+            loaded = contract.load_locked_toolchain(copied_lock, copied)
+            copied.write_bytes(copied.read_bytes() + b"changed")
+            self.assert_rule("toolchain-binary", loaded.executable)
         target = {"candidate_revision": "b" * 40, "trigger_check_identity": "trigger-9"}
         result = {
             "schema": "aimee.module-doc-check.v1", "name": "module-doc-attestation",
@@ -566,7 +625,6 @@ class ModuleDocContractTests(unittest.TestCase):
         }
         self.assertEqual(contract.validate_publisher_result(result, target), result)
 
-    @unittest.skipUnless(shutil.which("ssh-keygen"), "ssh-keygen is required")
     def test_real_ed25519_sshsig_verification(self) -> None:
         subject = (FIXTURES / "positive/subject.json").read_bytes()
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -112,6 +112,11 @@ class ModuleDocContractTests(unittest.TestCase):
         self.assertIn("MODULE_DOC_VERIFIER_SPKI", workflow)
         self.assertIn("--pinnedpubkey", workflow)
         self.assertNotIn("actions/checkout", workflow)
+        inventory_workflow = (
+            REPO_ROOT / ".github/workflows/module-inventory.yml"
+        ).read_text(encoding="utf-8")
+        for executable in ("ssh-keygen", "ssh-agent", "ssh-add"):
+            self.assertIn(f"command -v {executable}", inventory_workflow)
 
     def test_document_negative_fixtures_have_stable_rules(self) -> None:
         positive = (FIXTURES / "positive/module.md").read_bytes()
@@ -165,6 +170,12 @@ class ModuleDocContractTests(unittest.TestCase):
             unknown_module, "memory",
             contract.DocumentProjection(("src/modules/memory/*.c",), ()),
             resolve_reference=resolve,
+        ))
+        evidence = b"- Evidence: path:scripts/module_doc_contract.py#L1\n"
+        excessive = positive.replace(evidence, evidence * 52, 1)
+        self.assert_rule("document-evidence-budget", lambda: contract.parse_module_document(
+            excessive, "memory",
+            contract.DocumentProjection(("src/modules/memory/*.c",), ()),
         ))
 
     def test_profile_is_provider_neutral_and_closed(self) -> None:
@@ -234,6 +245,22 @@ class ModuleDocContractTests(unittest.TestCase):
         contract.bind_workload_to_target(workload, target, pull_request=1708)
         self.assertRegex(contract.replay_binding(workload, target), r"^[0-9a-f]{64}$")
         self.assertRegex(contract.replay_token_identity(workload), r"^[0-9a-f]{64}$")
+        original_binding = contract.replay_binding(workload, target)
+        for field, value in workload.items():
+            changed = dict(workload)
+            changed[field] = value + 1 if type(value) is int else f"{value}-changed"
+            with self.subTest(replay_workload_field=field):
+                self.assertNotEqual(original_binding, contract.replay_binding(changed, target))
+        for field, value in target.items():
+            changed = dict(target)
+            changed[field] = value + 1 if type(value) is int else f"{value}-changed"
+            with self.subTest(replay_target_field=field):
+                self.assertNotEqual(original_binding, contract.replay_binding(workload, changed))
+        left = dict(workload, subject="a\0b", audience="c")
+        right = dict(workload, subject="a", audience="b\0c")
+        self.assertNotEqual(
+            contract.replay_binding(left, target), contract.replay_binding(right, target)
+        )
         for field, rule in (("run_identity", "target-run-binding"), ("attempt", "target-run-binding")):
             mismatch = dict(target)
             mismatch[field] = "different"
@@ -315,7 +342,10 @@ class ModuleDocContractTests(unittest.TestCase):
             commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
             reader = contract.GitBlobReader(repo, commit)
             self.assertEqual(reader.read_blob("evidence.txt"), b"one\ntwo\n")
+            operations = reader.budget.git_operations
             reader.resolve_reference("path:evidence.txt#L2")
+            reader.resolve_reference("path:evidence.txt#L2")
+            self.assertEqual(reader.budget.git_operations, operations)
             self.assert_rule("document-evidence-line", lambda: reader.resolve_reference("path:evidence.txt#L3"))
             evidence.unlink()
             evidence.symlink_to("target")
@@ -324,6 +354,19 @@ class ModuleDocContractTests(unittest.TestCase):
             symlink_commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
             symlink_reader = contract.GitBlobReader(repo, symlink_commit)
             self.assert_rule("git-mode", lambda: symlink_reader.read_blob("evidence.txt"))
+
+    def test_git_operation_timeout_is_a_contract_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            previous = contract.GIT_OPERATION_TIMEOUT_SECONDS
+            contract.GIT_OPERATION_TIMEOUT_SECONDS = 0
+            try:
+                self.assert_rule(
+                    "git-timeout", lambda: contract.GitBlobReader(repo, "a" * 40)
+                )
+            finally:
+                contract.GIT_OPERATION_TIMEOUT_SECONDS = previous
 
     def test_git_blob_size_boundary_precedes_read(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -640,6 +683,24 @@ class ModuleDocContractTests(unittest.TestCase):
             signature = signed.stdout
             toolchain = locked_toolchain()
             contract.verify_sshsig(subject, signature, "owner@example", canonical_key, toolchain)
+            other_key = root / "other-key"
+            subprocess.run(
+                ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(other_key)],
+                check=True,
+            )
+            other_public = " ".join(
+                other_key.with_suffix(".pub").read_text(encoding="ascii").split()[:2]
+            )
+            self.assert_rule("sshsig-verify", lambda: contract.verify_sshsig(
+                subject, signature, "owner@example", other_public, toolchain
+            ))
+            wrong_namespace = subprocess.run(
+                ["ssh-keygen", "-Y", "sign", "-f", str(key), "-n", "other.namespace"],
+                input=subject, check=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            )
+            self.assert_rule("sshsig-namespace", lambda: contract.verify_sshsig(
+                subject, wrong_namespace.stdout, "owner@example", canonical_key, toolchain
+            ))
             self.assert_rule("sshsig-verify", lambda: contract.verify_sshsig(
                 subject + b"x", signature, "owner@example", canonical_key, toolchain
             ))

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -392,12 +392,40 @@ class ModuleDocContractTests(unittest.TestCase):
             subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
             commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
             reader = contract.GitBlobReader(repo, commit)
+            real_popen = contract.subprocess.Popen
+            reader.budget.git_deadline = time.monotonic() + 0.02
+            def delayed_popen(*args, **kwargs):
+                time.sleep(0.04)
+                return real_popen(*args, **kwargs)
+            with mock.patch.object(
+                contract.subprocess, "Popen", side_effect=delayed_popen
+            ):
+                self.assert_rule("git-timeout", lambda: reader._git_bounded(
+                    1024, "rev-parse", "HEAD"
+                ))
             reader.budget.git_deadline = time.monotonic() + 0.1
             started = time.monotonic()
             self.assert_rule("git-timeout", lambda: reader._git_bounded(
                 1024, "-c", "alias.wait=!sleep 2", "wait"
             ))
             self.assertLess(time.monotonic() - started, 1.0)
+            child_pid_path = repo / "orphan.pid"
+            reader.budget.git_deadline = time.monotonic() + 0.1
+            self.assert_rule("git-timeout", lambda: reader._git_bounded(
+                1024, "-c",
+                f"alias.orphan=!sh -c 'sleep 5 & echo $! > {child_pid_path}'",
+                "orphan",
+            ))
+            child_pid = int(child_pid_path.read_text(encoding="ascii").strip())
+            state_path = Path(f"/proc/{child_pid}/stat")
+            for _ in range(100):
+                if not state_path.exists() or state_path.read_text().split()[2] == "Z":
+                    break
+                time.sleep(0.01)
+            self.assertTrue(
+                not state_path.exists() or state_path.read_text().split()[2] == "Z",
+                "Git descendant survived process-group timeout",
+            )
             reader.budget.git_deadline = time.monotonic() - 1
             with mock.patch.object(contract.subprocess, "Popen") as popen:
                 self.assert_rule(

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -12,7 +12,9 @@ import shutil
 import subprocess
 import struct
 import tempfile
+import time
 import unittest
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -367,6 +369,77 @@ class ModuleDocContractTests(unittest.TestCase):
                 )
             finally:
                 contract.GIT_OPERATION_TIMEOUT_SECONDS = previous
+
+    def test_decision_budget_boundaries_fail_closed(self) -> None:
+        budget = contract.GitDecisionBudget()
+        budget.git_operations = contract.MAX_DECISION_GIT_OPERATIONS
+        self.assert_rule("git-operation-budget", budget.consume_git_operation)
+        budget.evidence_references = contract.MAX_DECISION_EVIDENCE_REFERENCES
+        self.assert_rule("document-evidence-budget", budget.consume_evidence_reference)
+        budget.distinct_blob_bytes = contract.MAX_DECISION_DISTINCT_BLOB_BYTES
+        self.assert_rule(
+            "git-byte-budget", lambda: budget.cache_blob(("repo", "a" * 40, "x"), b"x")
+        )
+
+    def test_decision_deadline_kills_git_and_prevents_late_spawn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Fixture"], cwd=repo, check=True)
+            (repo / "x").write_text("x\n", encoding="ascii")
+            subprocess.run(["git", "add", "x"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            reader = contract.GitBlobReader(repo, commit)
+            reader.budget.git_deadline = time.monotonic() + 0.1
+            started = time.monotonic()
+            self.assert_rule("git-timeout", lambda: reader._git_bounded(
+                1024, "-c", "alias.wait=!sleep 2", "wait"
+            ))
+            self.assertLess(time.monotonic() - started, 1.0)
+            reader.budget.git_deadline = time.monotonic() - 1
+            with mock.patch.object(contract.subprocess, "Popen") as popen:
+                self.assert_rule(
+                    "git-timeout", lambda: reader._git_bounded(1024, "rev-parse", "HEAD")
+                )
+                popen.assert_not_called()
+            self.assertGreater(
+                contract.GitDecisionBudget().git_deadline, time.monotonic()
+            )
+
+    def test_git_output_ceilings_and_cross_reader_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "fixture@example.invalid"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "Fixture"], cwd=repo, check=True)
+            (repo / "evidence.txt").write_text("shared\n", encoding="ascii")
+            subprocess.run(["git", "add", "evidence.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
+            commit = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip()
+            budget = contract.GitDecisionBudget()
+            token = contract._ACTIVE_GIT_BUDGET.set(budget)
+            try:
+                first = contract.GitBlobReader(repo, commit)
+                second = contract.GitBlobReader(repo, commit)
+                self.assertEqual(first.read_blob("evidence.txt"), b"shared\n")
+                operations = budget.git_operations
+                self.assertEqual(second.read_blob("evidence.txt"), b"shared\n")
+                self.assertEqual(budget.git_operations, operations)
+                self.assert_rule(
+                    "git-output-size", lambda: first._git_bounded(1, "rev-parse", "HEAD")
+                )
+                previous = contract.MAX_GIT_STDERR_BYTES
+                contract.MAX_GIT_STDERR_BYTES = 1
+                try:
+                    self.assert_rule(
+                        "git-stderr-size", lambda: first._git_bounded(1024, "invalid-command")
+                    )
+                finally:
+                    contract.MAX_GIT_STDERR_BYTES = previous
+            finally:
+                contract._ACTIVE_GIT_BUDGET.reset(token)
 
     def test_git_blob_size_boundary_precedes_read(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -46,8 +46,8 @@ def oidc_profile() -> dict[str, object]:
         "audience": "aimee-module-doc-verifier",
         "jwks": {
             "uri": "https://issuer.example.invalid/jwks",
-            "tls_spki_sha256": ["1" * 64],
-            "key_thumbprints_sha256": ["3" * 64],
+            "tls_spki_sha256": ["A" * 43 + "="],
+            "jwk_thumbprints_sha256": ["C" * 43],
             "max_age_seconds": 3600,
         },
         "allowed_algorithms": ["ES256", "RS256"],
@@ -62,7 +62,7 @@ def oidc_profile() -> dict[str, object]:
         },
         "repository_api": {
             "base_url": "https://repository.example.invalid/api",
-            "tls_spki_sha256": ["2" * 64],
+            "tls_spki_sha256": ["B" * 43 + "="],
             "response_schema": "aimee.candidate-target.v1",
         },
     }
@@ -92,12 +92,25 @@ class ModuleDocContractTests(unittest.TestCase):
             raw, "memory", contract.DocumentProjection(("src/modules/memory/*.c",), ())
         )
 
+    def test_protected_diagnostics_are_complete(self) -> None:
+        with self.assertRaises(contract.ContractError) as captured:
+            with contract.diagnostic_context("memory", "a" * 40, "docs/modules/memory.md"):
+                contract.fail("document-test", "bad record", line=7)
+        message = str(captured.exception)
+        for field in (
+            "rule=document-test", "module=memory", f"candidate={'a' * 40}",
+            "path=docs/modules/memory.md", "line=7", "expected=document-test-contract",
+            "actual=bad record",
+        ):
+            self.assertIn(field, message)
+
     def test_workflow_activation_is_dormant_then_fail_closed(self) -> None:
         workflow = (
             REPO_ROOT / ".github/workflows/module-doc-attestation-trigger.yml"
         ).read_text(encoding="utf-8")
         self.assertIn("if: ${{ vars.MODULE_DOC_ATTESTATION_ENABLED == 'true' }}", workflow)
-        self.assertIn("MODULE_DOC_VERIFIER_AUDIENCE and MODULE_DOC_VERIFIER_URL must be configured", workflow)
+        self.assertIn("MODULE_DOC_VERIFIER_SPKI", workflow)
+        self.assertIn("--pinnedpubkey", workflow)
         self.assertNotIn("actions/checkout", workflow)
 
     def test_document_negative_fixtures_have_stable_rules(self) -> None:
@@ -163,6 +176,9 @@ class ModuleDocContractTests(unittest.TestCase):
         example = contract.strict_json_bytes(example_raw)
         self.assertEqual(contract.validate_oidc_profile(example), example)
         self.assertNotIn(b"github", example_raw.lower())
+        trailing_issuer = json.loads(json.dumps(profile))
+        trailing_issuer["issuer"] += "/"
+        self.assertEqual(contract.validate_oidc_profile(trailing_issuer), trailing_issuer)
         unknown = dict(profile)
         unknown["provider"] = "github"
         self.assert_rule("oidc-profile-shape", lambda: contract.validate_oidc_profile(unknown))
@@ -180,6 +196,7 @@ class ModuleDocContractTests(unittest.TestCase):
             ("issuer", "https:///missing-host", "oidc-issuer"),
             ("issuer", "https://issuer.example.invalid/#fragment", "oidc-issuer"),
             ("issuer", "https://Issuer.example.invalid", "oidc-issuer"),
+            ("issuer", "https://issuer.example.invalid\\evil", "oidc-issuer"),
             ("jwks.uri", "https://issuer.example.invalid/jwks#fragment", "oidc-jwks-uri"),
             ("repository_api.base_url", "https://repository.example.invalid/api/", "repository-api-url"),
         )

--- a/scripts/tests/test_sign_module_docs.py
+++ b/scripts/tests/test_sign_module_docs.py
@@ -123,7 +123,7 @@ class SignModuleDocsTests(unittest.TestCase):
                 parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
             )
             try:
-                name, staging = signer._staging_directory(parent_fd)
+                name, staging_fd, staging = signer._staging_directory(parent_fd)
                 self.assertEqual(stat.S_IMODE(staging.stat().st_mode), 0o700)
                 moved = root / "moved-modules"
                 parent.rename(moved)
@@ -133,7 +133,39 @@ class SignModuleDocsTests(unittest.TestCase):
                 (staging / "pinned").write_text("yes", encoding="ascii")
                 self.assertTrue((moved / name / "pinned").is_file())
                 self.assertFalse((attacker / name).exists())
+                os.close(staging_fd)
             finally:
+                os.close(parent_fd)
+
+    def test_pinned_directory_detects_name_substitution(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp)
+            target = parent / "attestations"
+            target.mkdir()
+            (target / "marker").write_text("validated", encoding="ascii")
+            parent_fd = os.open(
+                parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+            )
+            target_fd = signer._open_pinned_directory(
+                parent_fd, "attestations", missing_ok=False
+            )
+            assert target_fd is not None
+            expected = os.fstat(target_fd)
+            try:
+                target.rename(parent / "validated-away")
+                target.mkdir()
+                (target / "marker").write_text("substitution", encoding="ascii")
+                self.assertEqual(
+                    (Path(f"/proc/self/fd/{target_fd}") / "marker").read_text(
+                        encoding="ascii"
+                    ),
+                    "validated",
+                )
+                self.assert_rule("target-race", lambda: signer._assert_entry_inode(
+                    parent_fd, "attestations", expected, rule="target-race"
+                ))
+            finally:
+                os.close(target_fd)
                 os.close(parent_fd)
 
     def test_end_to_end_agent_signing_and_malformed_prior_preservation(self) -> None:

--- a/scripts/tests/test_sign_module_docs.py
+++ b/scripts/tests/test_sign_module_docs.py
@@ -76,6 +76,18 @@ class SignModuleDocsTests(unittest.TestCase):
             ))
             self.assertEqual((target / "index.json").read_bytes(), marker)
 
+    def test_repository_files_reject_symlink_ancestors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            outside = Path(tmp) / "outside"
+            repo.mkdir()
+            outside.mkdir()
+            (outside / "secret").write_text("secret", encoding="ascii")
+            (repo / "linked").symlink_to(outside, target_is_directory=True)
+            self.assert_rule("repository-path", lambda: signer._repository_file(
+                repo, Path("linked/secret"), max_bytes=1024
+            ))
+
     def test_directory_exchange_is_atomic_when_supported(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/scripts/tests/test_sign_module_docs.py
+++ b/scripts/tests/test_sign_module_docs.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 
 import base64
 import importlib.util
+import json
+import os
 from pathlib import Path
+import shutil
+import stat
 import struct
+import subprocess
 import sys
 import tempfile
+import time
 import unittest
+from argparse import Namespace
+from datetime import datetime, timezone
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -106,11 +114,159 @@ class SignModuleDocsTests(unittest.TestCase):
             self.assertEqual((target / "new").read_text(encoding="ascii"), "new")
             self.assertEqual((staged / "old").read_text(encoding="ascii"), "old")
 
+    def test_staging_directory_is_bound_to_open_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            parent = root / "modules"
+            parent.mkdir()
+            parent_fd = os.open(
+                parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+            )
+            try:
+                name, staging = signer._staging_directory(parent_fd)
+                self.assertEqual(stat.S_IMODE(staging.stat().st_mode), 0o700)
+                moved = root / "moved-modules"
+                parent.rename(moved)
+                attacker = root / "attacker"
+                attacker.mkdir()
+                parent.symlink_to(attacker, target_is_directory=True)
+                (staging / "pinned").write_text("yes", encoding="ascii")
+                self.assertTrue((moved / name / "pinned").is_file())
+                self.assertFalse((attacker / name).exists())
+            finally:
+                os.close(parent_fd)
+
+    def test_end_to_end_agent_signing_and_malformed_prior_preservation(self) -> None:
+        for command in ("ssh-keygen", "ssh-agent", "ssh-add"):
+            self.assertIsNotNone(shutil.which(command), f"{command} is required")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            repo.mkdir()
+            inventory = repo / signer.INVENTORY_PATH
+            inventory.parent.mkdir(parents=True)
+            inventory.write_text(json.dumps({
+                "schema_version": 1, "required": ["config"], "optional": ["runtime-web"]
+            }, indent=2) + "\n", encoding="ascii")
+            (repo / "evidence.txt").write_text("evidence\n", encoding="ascii")
+            template = (
+                REPO_ROOT / "tests/fixtures/module-doc-contract/positive/module.md"
+            ).read_bytes()
+            template = template.replace(
+                b"Sources: src/modules/memory/*.c", b"Sources: none"
+            ).replace(
+                b"path:scripts/module_doc_contract.py#L1", b"path:evidence.txt#L1"
+            )
+            for module_id, optional in (("config", False), ("runtime-web", True)):
+                descriptor = {
+                    "descriptor_version": 2,
+                    "id": module_id,
+                    "dependencies": [],
+                    "runtime_toggle": {"supported": optional},
+                    "docs": f"docs/modules/{module_id}.md",
+                    "sources": [],
+                    "public_headers": [],
+                    "surfaces": {"routes": [], "commands": [], "protocols": [], "stages": []},
+                }
+                if optional:
+                    descriptor["enabled_by_default"] = True
+                descriptor_path = repo / "src/modules" / module_id / "module.yaml"
+                descriptor_path.parent.mkdir(parents=True)
+                descriptor_path.write_text(
+                    json.dumps(descriptor, indent=2) + "\n", encoding="ascii"
+                )
+                document_path = repo / "docs/modules" / f"{module_id}.md"
+                document_path.parent.mkdir(parents=True, exist_ok=True)
+                document_path.write_bytes(
+                    template.replace(
+                        b"# memory module", f"# {module_id} module".encode("ascii"), 1
+                    )
+                )
+
+            keys = root / "keys"
+            keys.mkdir()
+            private_paths: list[Path] = []
+            public_paths: list[Path] = []
+            for label in ("owner", "reviewer"):
+                private = keys / label
+                subprocess.run(
+                    ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(private)],
+                    check=True,
+                )
+                canonical = " ".join(
+                    private.with_suffix(".pub").read_text(encoding="ascii").split()[:2]
+                )
+                public = keys / f"canonical-{label}.pub"
+                public.write_text(canonical + "\n", encoding="ascii")
+                private_paths.append(private)
+                public_paths.append(public)
+
+            executable = Path(shutil.which("ssh-keygen"))
+            lock_path = root / "toolchain.json"
+            lock_path.write_text(json.dumps({
+                "schema": "aimee.sshsig-toolchain.v1",
+                "image": "registry.example.invalid/aimee/sshsig@sha256:" + "a" * 64,
+                "ssh_keygen_sha256": contract.sha256(executable.read_bytes()),
+            }, indent=2) + "\n", encoding="ascii")
+            socket_path = root / "agent.sock"
+            agent = subprocess.Popen(
+                ["ssh-agent", "-D", "-a", str(socket_path)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                for _ in range(200):
+                    if socket_path.exists():
+                        break
+                    time.sleep(0.01)
+                self.assertTrue(socket_path.exists(), "ssh-agent socket did not appear")
+                agent_env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "SSH_AUTH_SOCK": str(socket_path)}
+                for private in private_paths:
+                    subprocess.run(
+                        ["ssh-add", str(private)], env=agent_env, check=True,
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    )
+                previous_sock = os.environ.get("SSH_AUTH_SOCK")
+                os.environ["SSH_AUTH_SOCK"] = str(socket_path)
+                try:
+                    args = Namespace(
+                        repo=repo,
+                        owner_identity="owner@example",
+                        owner_public_key=public_paths[0],
+                        reviewer_identity="reviewer@example",
+                        reviewer_public_key=public_paths[1],
+                        signed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        toolchain_lock=lock_path,
+                        ssh_keygen=executable,
+                    )
+                    signer.build_attestations(args)
+                    target = repo / signer.ATTESTATION_PATH
+                    self.assertEqual(len(list(target.iterdir())), 7)
+                    tampered = target / "config.owner.sig"
+                    tampered.write_bytes(tampered.read_bytes() + b"x")
+                    snapshot = {
+                        entry.name: entry.read_bytes() for entry in target.iterdir()
+                    }
+                    self.assert_rule("sshsig-armor", lambda: signer.build_attestations(args))
+                    self.assertEqual(
+                        {entry.name: entry.read_bytes() for entry in target.iterdir()},
+                        snapshot,
+                    )
+                finally:
+                    if previous_sock is None:
+                        os.environ.pop("SSH_AUTH_SOCK", None)
+                    else:
+                        os.environ["SSH_AUTH_SOCK"] = previous_sock
+            finally:
+                agent.terminate()
+                agent.wait(timeout=5)
+
     def test_helper_never_invokes_a_shell_or_accepts_private_key_argument(self) -> None:
         source = (REPO_ROOT / "scripts/sign_module_docs.py").read_text(encoding="utf-8")
         self.assertNotIn("shell=True", source)
         self.assertNotIn("private-key", source)
         self.assertIn('"SSH_AUTH_SOCK": auth_sock', source)
+        self.assertIn('"HOME": os.fspath(isolated_home)', source)
         self.assertIn('public_path.write_text(public_key + "\\n"', source)
 
 

--- a/scripts/tests/test_sign_module_docs.py
+++ b/scripts/tests/test_sign_module_docs.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Tests for the human module-document signing helper."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+from pathlib import Path
+import struct
+import sys
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_SPEC = importlib.util.spec_from_file_location(
+    "module_doc_contract", REPO_ROOT / "scripts/module_doc_contract.py"
+)
+assert CONTRACT_SPEC and CONTRACT_SPEC.loader
+contract = importlib.util.module_from_spec(CONTRACT_SPEC)
+sys.modules["module_doc_contract"] = contract
+CONTRACT_SPEC.loader.exec_module(contract)
+SIGN_SPEC = importlib.util.spec_from_file_location(
+    "sign_module_docs", REPO_ROOT / "scripts/sign_module_docs.py"
+)
+assert SIGN_SPEC and SIGN_SPEC.loader
+signer = importlib.util.module_from_spec(SIGN_SPEC)
+SIGN_SPEC.loader.exec_module(signer)
+
+
+def public_key(byte: int = 1) -> str:
+    key_type = b"ssh-ed25519"
+    blob = struct.pack(">I", len(key_type)) + key_type + struct.pack(">I", 32) + bytes([byte]) * 32
+    return "ssh-ed25519 " + base64.b64encode(blob).decode("ascii")
+
+
+class SignModuleDocsTests(unittest.TestCase):
+    def assert_rule(self, rule: str, callback) -> None:
+        with self.assertRaisesRegex((signer.SigningError, contract.ContractError), f"rule={rule}"):
+            callback()
+
+    def test_committed_inventory_is_the_only_signing_inventory(self) -> None:
+        required, optional = signer._inventory(REPO_ROOT)
+        self.assertEqual(len(required), 18)
+        self.assertEqual(len(optional), 8)
+        self.assertFalse(required & optional)
+
+    def test_public_key_input_cannot_be_a_private_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            valid = root / "owner.pub"
+            valid.write_text(public_key() + "\n", encoding="ascii")
+            self.assertEqual(signer._public_key(valid), public_key())
+            private = root / "owner"
+            private.write_text(
+                "-----BEGIN OPENSSH PRIVATE KEY-----\nnot-a-public-key\n"
+                "-----END OPENSSH PRIVATE KEY-----\n",
+                encoding="ascii",
+            )
+            self.assert_rule("public-key", lambda: signer._public_key(private))
+
+    def test_existing_partial_directory_is_rejected_before_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "attestations"
+            target.mkdir()
+            (target / "index.json").write_text("{}\n", encoding="ascii")
+            marker = (target / "index.json").read_bytes()
+            self.assert_rule("existing-attestations", lambda: signer._existing_attestations_are_well_formed(
+                target,
+                {"memory"},
+                owner_identity="owner@example",
+                owner_key=public_key(1),
+                reviewer_identity="reviewer@example",
+                reviewer_key=public_key(2),
+                toolchain=object(),
+            ))
+            self.assertEqual((target / "index.json").read_bytes(), marker)
+
+    def test_directory_exchange_is_atomic_when_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            staged = root / "staged"
+            target = root / "target"
+            staged.mkdir()
+            target.mkdir()
+            (staged / "new").write_text("new", encoding="ascii")
+            (target / "old").write_text("old", encoding="ascii")
+            try:
+                signer._rename_exchange(staged, target)
+            except signer.SigningError as exc:
+                if "rule=atomic-replace" in str(exc):
+                    self.skipTest(str(exc))
+                raise
+            self.assertEqual((target / "new").read_text(encoding="ascii"), "new")
+            self.assertEqual((staged / "old").read_text(encoding="ascii"), "old")
+
+    def test_helper_never_invokes_a_shell_or_accepts_private_key_argument(self) -> None:
+        source = (REPO_ROOT / "scripts/sign_module_docs.py").read_text(encoding="utf-8")
+        self.assertNotIn("shell=True", source)
+        self.assertNotIn("private-key", source)
+        self.assertIn('"SSH_AUTH_SOCK": auth_sock', source)
+        self.assertIn('public_path.write_text(public_key + "\\n"', source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fixtures/module-doc-contract/positive/module.md
+++ b/tests/fixtures/module-doc-contract/positive/module.md
@@ -1,0 +1,77 @@
+# memory module
+
+## Purpose and non-goals
+State: present
+Sources: src/modules/memory/*.c
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Classification and lifecycle
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Public contracts
+State: present
+Public headers: none
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Dependencies and consumers
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Providers and readiness
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Configuration and activation
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Routes, commands, protocols, and stages
+State: present
+Routes: none
+Commands: none
+Protocols: none
+Stages: none
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Data and migrations
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Security and privacy
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Supported journeys
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Tests and failure behavior
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Operational diagnostics
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Compatibility aliases
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1
+
+## Extension and removal rules
+State: present
+Clear module behavior documents concrete contracts dependencies activation failure handling diagnostics security privacy compatibility migration ownership and removal rules for operators maintainers reviewers implementers callers services deployments tests workflows and supported user journeys while identifying current evidence boundaries known gaps operational consequences stable interfaces data handling readiness states and safe extension expectations.
+- Evidence: path:scripts/module_doc_contract.py#L1

--- a/tests/fixtures/module-doc-contract/positive/subject.json
+++ b/tests/fixtures/module-doc-contract/positive/subject.json
@@ -1,0 +1,9 @@
+{
+  "descriptor_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "document_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "module_id": "memory",
+  "owner_identity": "owner@example",
+  "reviewer_identity": "reviewer@example",
+  "schema": "aimee.module-doc-attestation.v1",
+  "signed_at": "2027-01-01T00:00:00Z"
+}


### PR DESCRIPTION
## What changed

- adds provider-neutral OIDC issuer-profile, workload-normalization, candidate-binding, replay, and publisher-result contracts without selecting an identity provider
- adds strict descriptor-v2/module-document validation and immutable, bounded Git-object reads
- adds Ed25519 SSHSIG owner/reviewer verification plus an fd-pinned human signing helper with atomic installation and retained quarantine generations
- adds a dormant, fail-closed repository trigger and CI coverage for all contract surfaces
- documents repository guarantees, user-configured issuer profiles, external activation prerequisites, and activation order

## Why

This is the first implementation slice of the core modularization effort. It establishes the documentation and attestation boundary needed before moving code from `/src` into module-owned `/src` trees. OIDC remains generic: deployments choose and configure any conforming issuer; GitHub is only the current repository/trigger binding.

## Safety

The trigger remains disabled unless `MODULE_DOC_ATTESTATION_ENABLED` is exactly `true`. Real JOSE verification, repository resolution, replay storage, check publication, trust enrollment, and runtime image enforcement remain explicit external prerequisites before activation.

## Review

- technical-writer jobs 1592 and 1595: APPROVED
- full/focused roundtables: `oprun_g6a5f4f772fc0a887_1784633758_16`, `oprun_g6a5f4f772fc0a887_1784637916_39`
- final roundtable verdict: APPROVED (converged)

## Validation

- 21 module-document contract tests
- 9 signing-helper tests, including real `ssh-agent` end-to-end signing
- 19 descriptor tests
- 27 module-inventory tests
- 27 proposal-ordering tests
- 46 proposal-reconciliation tests
- Python compilation and `git diff --check`
