### PR TITLE
fix: derive provider-neutral trigger identity

### DIFF
--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -21,6 +21,21 @@ records cannot multiply object reads. Replay bindings use canonical JSON over ev
 workload and candidate-target field; the token identity separately binds the exact issuer and token
 identifier without delimiter ambiguity.
 
+`trigger_check_identity` is a provider-neutral correlation value, not an OIDC claim or a GitHub
+Checks check-run ID. The contract derives it as a canonical SHA-256 identity from the normalized
+`repository_identity`, `run_identity`, and `attempt`; issuer profiles and repository adapters do not
+supply it. This clarification does not make the overall external verifier deployable.
+
+The derivation preimage is the JSON object with exactly the keys `attempt`, `repository_identity`,
+and `run_identity`, serialized with keys sorted, compact `,` and `:` separators, JSON ASCII escaping,
+and ASCII encoding. Hash those bytes with SHA-256 and prefix the lowercase hex digest with `sha256:`.
+JSON string values are preserved exactly; no Unicode normalization is applied. For example,
+`{"attempt":"2","repository_identity":"repository-\u00e9","run_identity":"run-\"42\""}` produces
+`sha256:d56311b051331f765ff4651d87d88ce9f760aaed7443bd635d0a414d40771821`.
+
+Issuer profiles copied from the earlier example must remove `trigger_check_identity` from
+`claim_mappings`; the closed profile validator now rejects that obsolete mapping.
+
 `module-doc-attestation-trigger.yml` is dormant unless the protected repository variable
 `MODULE_DOC_ATTESTATION_ENABLED` is exactly `true`. While active, it fails closed unless the
 verifier URL, audience, and TLS public-key pin are configured. It requests an OIDC token and sends

--- a/.github/module-doc-attestation/issuer-profile.example.json
+++ b/.github/module-doc-attestation/issuer-profile.example.json
@@ -10,7 +10,6 @@
     "repository_identity": "ci_repository",
     "run_identity": "ci_run",
     "runner_class": "ci_runner",
-    "trigger_check_identity": "ci_trigger_check",
     "workflow_identity": "ci_workflow",
     "workflow_revision": "ci_workflow_revision"
   },

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -90,6 +90,10 @@ WORKLOAD_FIELDS = (
     "actor_identity",
     "runner_class",
 )
+# ``trigger_check_identity`` is derived from normalized fields, not claim-mapped.
+CLAIM_MAPPED_WORKLOAD_FIELDS = tuple(
+    field for field in WORKLOAD_FIELDS if field != "trigger_check_identity"
+)
 SOURCE_PATTERN_RE = re.compile(
     r"^src/modules/(?P<module>[a-z][a-z0-9]*(?:-[a-z0-9]+)*)/"
     r"(?:(?P<literal>[a-z][a-z0-9_-]*)/)?\*\.(?P<suffix>[ch])$"
@@ -314,7 +318,11 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
     if type(skew) is not int or not 0 <= skew <= 60:
         fail("oidc-clock-skew", "clock skew must be in [0, 60]")
 
-    mappings = _exact_object(profile["claim_mappings"], set(WORKLOAD_FIELDS), "oidc-claim-mappings")
+    mappings = _exact_object(
+        profile["claim_mappings"],
+        set(CLAIM_MAPPED_WORKLOAD_FIELDS),
+        "oidc-claim-mappings",
+    )
     for field, claim in mappings.items():
         if not isinstance(claim, str) or not CLAIM_RE.fullmatch(claim):
             fail("oidc-claim-name", f"invalid claim mapping for {field}")
@@ -351,6 +359,25 @@ def validate_oidc_profile(value: object) -> dict[str, object]:
 
 
 STANDARD_CLAIMS = {"iss", "sub", "aud", "iat", "nbf", "exp", "jti"}
+
+
+def derive_trigger_check_identity(
+    repository_identity: str, run_identity: str, attempt: str
+) -> str:
+    """Derive an identity from normalized repository_identity, run_identity, and attempt."""
+    values = {
+        "attempt": attempt,
+        "repository_identity": repository_identity,
+        "run_identity": run_identity,
+    }
+    if not all(isinstance(value, str) and value for value in values.values()):
+        fail("oidc-trigger-identity", "trigger identity inputs must be non-empty strings")
+    if not re.fullmatch(r"[1-9][0-9]*", attempt):
+        fail("oidc-trigger-identity", "attempt must be a positive canonical decimal")
+    encoded = json.dumps(
+        values, ensure_ascii=True, allow_nan=False, sort_keys=True, separators=(",", ":")
+    ).encode("ascii")
+    return f"sha256:{sha256(encoded)}"
 
 
 def normalize_verified_oidc_claims(
@@ -403,7 +430,7 @@ def normalize_verified_oidc_claims(
     }
     mappings = profile["claim_mappings"]
     assert isinstance(mappings, dict)
-    for field in WORKLOAD_FIELDS:
+    for field in CLAIM_MAPPED_WORKLOAD_FIELDS:
         claim_name = mappings[field]
         if claim_name not in claims:
             fail("oidc-mapped-claim", f"claim mapped to {field!r} is missing")
@@ -420,6 +447,9 @@ def normalize_verified_oidc_claims(
                 fail("oidc-mapped-claim", f"claim mapped to {field!r} must be a non-empty string")
             normalized = value
         workload[field] = normalized
+    workload["trigger_check_identity"] = derive_trigger_check_identity(
+        workload["repository_identity"], workload["run_identity"], workload["attempt"]
+    )
     predicates = profile["predicates"]
     assert isinstance(predicates, dict)
     for field, expected in predicates.items():

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -40,7 +40,9 @@ def locked_toolchain():
 
 
 def oidc_profile() -> dict[str, object]:
-    mappings = {field: f"ci_{field}" for field in contract.WORKLOAD_FIELDS}
+    mappings = {
+        field: f"ci_{field}" for field in contract.CLAIM_MAPPED_WORKLOAD_FIELDS
+    }
     return {
         "schema": "aimee.ci-oidc-profile.v1",
         "name": "protected-ci",
@@ -195,6 +197,12 @@ class ModuleDocContractTests(unittest.TestCase):
         unknown = dict(profile)
         unknown["provider"] = "github"
         self.assert_rule("oidc-profile-shape", lambda: contract.validate_oidc_profile(unknown))
+        claimed_trigger = json.loads(json.dumps(profile))
+        claimed_trigger["claim_mappings"]["trigger_check_identity"] = "ci_trigger_check"
+        self.assert_rule(
+            "oidc-claim-mappings",
+            lambda: contract.validate_oidc_profile(claimed_trigger),
+        )
         no_pin = json.loads(json.dumps(profile))
         no_pin["jwks"]["tls_spki_sha256"] = []
         self.assert_rule("oidc-jwks-pins", lambda: contract.validate_oidc_profile(no_pin))
@@ -230,6 +238,16 @@ class ModuleDocContractTests(unittest.TestCase):
         profile = contract.validate_oidc_profile(oidc_profile())
         token_claims = claims(profile)
         workload = contract.normalize_verified_oidc_claims(token_claims, profile, wall_time=1_800_000_000)
+        self.assertNotIn("ci_trigger_check_identity", token_claims)
+        self.assertEqual(
+            workload["trigger_check_identity"],
+            contract.derive_trigger_check_identity(
+                workload["repository_identity"],
+                workload["run_identity"],
+                workload["attempt"],
+            ),
+        )
+        self.assertRegex(workload["trigger_check_identity"], r"^sha256:[0-9a-f]{64}$")
         target = contract.validate_candidate_target({
             "schema": "aimee.candidate-target.v1",
             "repository_identity": workload["repository_identity"],
@@ -295,6 +313,37 @@ class ModuleDocContractTests(unittest.TestCase):
         self.assert_rule("oidc-attempt", lambda: contract.normalize_verified_oidc_claims(
             bad_attempt, profile, wall_time=1_800_000_000
         ))
+
+    def test_trigger_identity_is_derived_from_the_complete_run_attempt(self) -> None:
+        identity = contract.derive_trigger_check_identity("repository-17", "run-42", "2")
+        self.assertEqual(
+            identity,
+            contract.derive_trigger_check_identity("repository-17", "run-42", "2"),
+        )
+        for repository, run, attempt in (
+            ("repository-18", "run-42", "2"),
+            ("repository-17", "run-43", "2"),
+            ("repository-17", "run-42", "3"),
+        ):
+            with self.subTest(repository=repository, run=run, attempt=attempt):
+                self.assertNotEqual(
+                    identity,
+                    contract.derive_trigger_check_identity(repository, run, attempt),
+                )
+        self.assertEqual(
+            contract.derive_trigger_check_identity(
+                "repository-é", 'run-"42"', "2"
+            ),
+            "sha256:d56311b051331f765ff4651d87d88ce9f760aaed7443bd635d0a414d40771821",
+        )
+        for attempt in ("0", "01", "-1", ""):
+            with self.subTest(attempt=attempt):
+                self.assert_rule(
+                    "oidc-trigger-identity",
+                    lambda attempt=attempt: contract.derive_trigger_check_identity(
+                        "repository-17", "run-42", attempt
+                    ),
+                )
 
     def test_trigger_request_has_no_candidate_coordinates(self) -> None:
         request = {"schema": "aimee.module-doc-trigger.v1", "pull_request": 17, "oidc_token": "a.b.c"}


### PR DESCRIPTION
## Summary

- derive `trigger_check_identity` from normalized repository, run, and attempt identities
- remove the unrealizable trigger identity claim from the provider-neutral issuer profile
- document and golden-test the exact canonical derivation
- reject obsolete profiles that still claim-map the derived identity

GitHub OIDC exposes `run_id` and `run_attempt`, but not an independent check-run identity claim. This correction keeps the core contract provider-neutral and gives repository adapters one deterministic value to reproduce.

This does not expose a verifier endpoint, verify compact OIDC tokens, add durable replay storage, activate the workflow, or constitute a completed deployment.

## Validation

- `python3 -I scripts/tests/test_module_doc_contract.py -v`
- `python3 -I scripts/tests/test_sign_module_docs.py -v`
- `git diff --check`
- technical-writer review completed
- roundtable: APPROVE with no blocking findings; follow-up review reported no issues