### PR TITLE
refactor: bind verifier repository lifetime

### DIFF
--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -11,8 +11,25 @@ that produces the same normalized workload and candidate-target records.
 descriptor-v2 validation, document validation, SSHSIG validation, workload-to-candidate binding,
 replay keys, and publisher-result validation. Its decision engine invokes the deployment's
 cryptographic JWT verifier before normalizing claims. It then invokes the read-only repository
-resolver before opening the resolved candidate commit. Function names alone do not establish those
-properties, so deployment integration tests must exercise invalid signatures, stale keys,
+resolver, which yields the candidate target and keeps the read-only object database live for every
+Git read against it. The resolver context cleans up that database on success and on every failure
+after entry. It must also clean partial resources if acquisition fails before entry. Resolver cleanup
+cannot suppress an active contract or validation failure, and a cleanup error replaces no active
+failure; a cleanup error on a normal exit propagates fail closed. The invocation-scoped validation
+capability exposes only pre-bound candidate and protected-base readers over that one database and one
+decision budget; it cannot open arbitrary revisions.
+Those readers expose no repository path, budget, or cache, and reject every Git operation after
+validation returns. Candidate-policy failures remain active through cleanup and become failure
+results only afterward. Only detached normalized metadata survives cleanup for replay-key and
+publisher-result construction.
+
+Validation-reader operations hold synchronized leases for their full duration. Closing the
+capability rejects new leases and waits for all in-flight operations before repository cleanup
+begins. The same synchronization protects Git-operation and evidence counts, the distinct-blob
+cache, and byte-ceiling accounting from concurrent updates.
+
+Function names alone do not establish those properties, so deployment integration tests must
+exercise invalid signatures, stale keys,
 redirects, repository mismatches, replay, and publisher permissions.
 
 Each decision has explicit ceilings for evidence records, distinct blob bytes, Git operations, and

--- a/scripts/module_doc_contract.py
+++ b/scripts/module_doc_contract.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import base64
 import binascii
-from contextlib import contextmanager
+import copy
+from contextlib import AbstractContextManager, contextmanager
 from contextvars import ContextVar
 from datetime import datetime, timezone
 import hashlib
@@ -24,6 +25,7 @@ import stat
 import subprocess
 import struct
 import tempfile
+import threading
 import time
 from typing import Callable, NamedTuple, NoReturn
 from urllib.parse import urlsplit
@@ -616,27 +618,86 @@ class GitDecisionBudget:
     """Bound and deduplicate all Git work performed for one decision."""
 
     def __init__(self) -> None:
+        self.active = True
+        self._closing = False
+        self._in_flight = 0
+        self._condition = threading.Condition()
+        self._local = threading.local()
         self.git_operations = 0
         self.evidence_references = 0
         self.distinct_blob_bytes = 0
         self.blobs: dict[tuple[str, str, str], bytes] = {}
         self.git_deadline = time.monotonic() + MAX_DECISION_GIT_WALL_SECONDS
 
+    def ensure_active(self) -> None:
+        with self._condition:
+            leased = getattr(self._local, "lease_depth", 0) > 0
+            if not self.active or (self._closing and not leased):
+                fail("git-snapshot-lifetime", "Git snapshot capability is no longer active")
+
+    @contextmanager
+    def operation(self):
+        """Lease the snapshot for one complete validator-facing operation."""
+        outermost = False
+        with self._condition:
+            depth = getattr(self._local, "lease_depth", 0)
+            if depth == 0:
+                if not self.active or self._closing:
+                    fail(
+                        "git-snapshot-lifetime",
+                        "Git snapshot capability is no longer active",
+                    )
+                self._in_flight += 1
+                outermost = True
+            self._local.lease_depth = depth + 1
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._local.lease_depth -= 1
+                if outermost:
+                    self._in_flight -= 1
+                    self._condition.notify_all()
+
+    def close(self) -> None:
+        with self._condition:
+            if not self.active:
+                return
+            if getattr(self._local, "lease_depth", 0) > 0:
+                fail("git-snapshot-lifetime", "cannot close an active operation lease")
+            self._closing = True
+            while self._in_flight:
+                self._condition.wait()
+            self.active = False
+
     def consume_git_operation(self) -> None:
-        self.git_operations += 1
-        if self.git_operations > MAX_DECISION_GIT_OPERATIONS:
-            fail("git-operation-budget", "decision exceeds the Git operation budget")
+        with self._condition:
+            self.ensure_active()
+            self.git_operations += 1
+            if self.git_operations > MAX_DECISION_GIT_OPERATIONS:
+                fail("git-operation-budget", "decision exceeds the Git operation budget")
 
     def consume_evidence_reference(self) -> None:
-        self.evidence_references += 1
-        if self.evidence_references > MAX_DECISION_EVIDENCE_REFERENCES:
-            fail("document-evidence-budget", "decision exceeds the evidence-reference budget")
+        with self._condition:
+            self.ensure_active()
+            self.evidence_references += 1
+            if self.evidence_references > MAX_DECISION_EVIDENCE_REFERENCES:
+                fail("document-evidence-budget", "decision exceeds the evidence-reference budget")
+
+    def cached_blob(self, key: tuple[str, str, str]) -> bytes | None:
+        with self._condition:
+            self.ensure_active()
+            return self.blobs.get(key)
 
     def cache_blob(self, key: tuple[str, str, str], raw: bytes) -> None:
-        self.distinct_blob_bytes += len(raw)
-        if self.distinct_blob_bytes > MAX_DECISION_DISTINCT_BLOB_BYTES:
-            fail("git-byte-budget", "decision exceeds the distinct-blob byte budget")
-        self.blobs[key] = raw
+        with self._condition:
+            self.ensure_active()
+            if key in self.blobs:
+                return
+            self.distinct_blob_bytes += len(raw)
+            if self.distinct_blob_bytes > MAX_DECISION_DISTINCT_BLOB_BYTES:
+                fail("git-byte-budget", "decision exceeds the distinct-blob byte budget")
+            self.blobs[key] = raw
 
 
 _ACTIVE_GIT_BUDGET: ContextVar[GitDecisionBudget | None] = ContextVar(
@@ -647,12 +708,18 @@ _ACTIVE_GIT_BUDGET: ContextVar[GitDecisionBudget | None] = ContextVar(
 class GitBlobReader:
     """Read governed files from one immutable commit, never a working tree."""
 
-    def __init__(self, repository: Path, commit: str):
+    def __init__(
+        self,
+        repository: Path,
+        commit: str,
+        *,
+        budget: GitDecisionBudget | None = None,
+    ):
         if not re.fullmatch(r"[0-9a-f]{40}", commit):
             fail("git-candidate", "candidate must be a full lowercase commit ID")
         self.repository = repository
         self.commit = commit
-        self.budget = _ACTIVE_GIT_BUDGET.get() or GitDecisionBudget()
+        self.budget = budget or _ACTIVE_GIT_BUDGET.get() or GitDecisionBudget()
         resolved = self._git("rev-parse", "--verify", f"{commit}^{{commit}}")
         if resolved.decode("ascii").strip() != commit:
             fail("git-candidate", "candidate does not resolve to itself")
@@ -740,11 +807,12 @@ class GitBlobReader:
             fail("git-path", "path is not canonical")
 
     def read_blob(self, path: str, *, max_bytes: int = MAX_GOVERNED_BLOB_BYTES) -> bytes:
+        self.budget.ensure_active()
         self.canonical_path(path)
         if type(max_bytes) is not int or not 1 <= max_bytes <= MAX_GOVERNED_BLOB_BYTES:
             fail("git-object-size", "requested blob limit is outside the verifier ceiling")
         cache_key = (str(self.repository.resolve()), self.commit, path)
-        cached = self.budget.blobs.get(cache_key)
+        cached = self.budget.cached_blob(cache_key)
         if cached is not None:
             if len(cached) > max_bytes:
                 fail("git-object-size", f"{path!r} exceeds {max_bytes} bytes")
@@ -1058,8 +1126,8 @@ def _validate_v1_preserved(base: object, candidate: dict[str, object], optional:
 
 
 def validate_module_candidate(
-    candidate: GitBlobReader,
-    base: GitBlobReader,
+    candidate: CandidateReader,
+    base: CandidateReader,
     *,
     required_ids: set[str],
     optional_ids: set[str],
@@ -1439,45 +1507,158 @@ class VerificationDecision(NamedTuple):
     publisher_result: dict[str, object]
 
 
+class ResolvedCandidate(NamedTuple):
+    """One candidate target bound to the resolver-owned read-only object database."""
+
+    target: dict[str, object]
+    repository: Path
+
+
+class CandidateReader:
+    """Revocable validator-facing view of one immutable commit."""
+
+    __slots__ = ("__reader", "__budget")
+
+    def __init__(self, reader: GitBlobReader, budget: GitDecisionBudget) -> None:
+        self.__reader = reader
+        self.__budget = budget
+
+    @property
+    def commit(self) -> str:
+        with self.__budget.operation():
+            return self.__reader.commit
+
+    def read_blob(self, path: str, *, max_bytes: int = MAX_GOVERNED_BLOB_BYTES) -> bytes:
+        with self.__budget.operation():
+            return self.__reader.read_blob(path, max_bytes=max_bytes)
+
+    def list_directory(self, path: str) -> dict[str, tuple[str, str]]:
+        with self.__budget.operation():
+            return self.__reader.list_directory(path)
+
+    def resolve_reference(self, reference: str) -> None:
+        with self.__budget.operation():
+            self.__reader.resolve_reference(reference)
+
+    def expand_source_pattern(self, pattern: str, module_id: str) -> tuple[str, ...]:
+        with self.__budget.operation():
+            return self.__reader.expand_source_pattern(pattern, module_id)
+
+
+class CandidateValidationContext:
+    """Invocation-scoped readers over one resolver-owned object database."""
+
+    __slots__ = ("candidate", "base", "__budget")
+
+    def __init__(
+        self,
+        repository: Path,
+        candidate_revision: str,
+        base_revision: str,
+        budget: GitDecisionBudget,
+    ) -> None:
+        self.__budget = budget
+        self.__budget.ensure_active()
+        self.candidate = CandidateReader(
+            GitBlobReader(repository, candidate_revision, budget=budget), budget
+        )
+        self.base = CandidateReader(
+            GitBlobReader(repository, base_revision, budget=budget), budget
+        )
+
+    def close(self) -> None:
+        self.__budget.close()
+
+
+@contextmanager
+def _non_suppressing_resolver(
+    manager: AbstractContextManager[ResolvedCandidate],
+):
+    """Run resolver cleanup without allowing it to hide an active failure."""
+    resolved = manager.__enter__()
+    try:
+        yield resolved
+    except BaseException as primary:
+        try:
+            manager.__exit__(type(primary), primary, primary.__traceback__)
+        except BaseException:
+            pass
+        raise
+    else:
+        try:
+            manager.__exit__(None, None, None)
+        except BaseException:
+            fail("resolver-cleanup", "resolver cleanup failed after validation")
+
+
+class _CandidateRejected(Exception):
+    def __init__(self, error: ContractError) -> None:
+        super().__init__(str(error))
+        self.error = error
+
+
 def evaluate_trigger(
     request_raw: bytes,
     profile_raw: bytes,
     *,
     wall_time: int,
     verify_jwt: Callable[[str, dict[str, object]], dict[str, object]],
-    resolve_target: Callable[[dict[str, object], int], dict[str, object]],
-    validate_candidate: Callable[[GitBlobReader, dict[str, object], dict[str, object]], str],
-    repository: Path,
+    resolve_target: Callable[
+        [dict[str, object], int], AbstractContextManager[ResolvedCandidate]
+    ],
+    validate_candidate: Callable[
+        [CandidateValidationContext, dict[str, object], dict[str, object]], str
+    ],
 ) -> VerificationDecision:
     """Orchestrate a fail-closed external verification decision.
 
     ``verify_jwt`` is the deployment's pinned JOSE implementation and must
     perform JWS/JWKS verification before returning claims. ``resolve_target``
-    uses the read-only repository installation and accepts no candidate
-    coordinates. ``validate_candidate`` reads only through ``GitBlobReader``
-    and returns a human-readable success summary. Publishing and replay-store
-    writes occur only after this pure decision is returned.
+    opens the read-only object database, accepts no candidate coordinates, and
+    keeps that database live through all Git reads and final validation.
+    ``validate_candidate`` receives one invocation-scoped reader capability and
+    returns a human-readable success summary. The capability cannot perform Git
+    work after the callback returns. Publishing and replay-store writes occur
+    only after this pure decision is returned.
     """
     request = strict_json_bytes(request_raw)
     pull_request, token = validate_trigger_request(request)
     profile = validate_oidc_profile(strict_json_bytes(profile_raw))
     verified_claims = verify_jwt(token, profile)
     workload = normalize_verified_oidc_claims(verified_claims, profile, wall_time=wall_time)
-    target = validate_candidate_target(resolve_target(workload, pull_request))
-    bind_workload_to_target(workload, target, pull_request=pull_request)
-    budget_token = _ACTIVE_GIT_BUDGET.set(GitDecisionBudget())
     try:
-        try:
-            reader = GitBlobReader(repository, target["candidate_revision"])
-            summary = validate_candidate(reader, workload, target)
-            if not isinstance(summary, str) or not summary:
-                fail("candidate-validation", "candidate validator returned no summary")
-            conclusion = "success"
-        except ContractError as exc:
-            summary = str(exc)[:4096]
-            conclusion = "failure"
-    finally:
-        _ACTIVE_GIT_BUDGET.reset(budget_token)
+        manager = resolve_target(copy.deepcopy(workload), pull_request)
+        if not isinstance(manager, AbstractContextManager):
+            fail("target-context", "resolver must return a context manager")
+        with _non_suppressing_resolver(manager) as resolved:
+            if not isinstance(resolved, ResolvedCandidate):
+                fail("target-context", "resolver must yield one ResolvedCandidate")
+            target = dict(validate_candidate_target(resolved.target))
+            bind_workload_to_target(workload, target, pull_request=pull_request)
+            budget = GitDecisionBudget()
+            budget_token = _ACTIVE_GIT_BUDGET.set(budget)
+            try:
+                try:
+                    validation = CandidateValidationContext(
+                        resolved.repository,
+                        target["candidate_revision"],
+                        target["protected_base_revision"],
+                        budget,
+                    )
+                    summary = validate_candidate(
+                        validation, copy.deepcopy(workload), copy.deepcopy(target)
+                    )
+                    if not isinstance(summary, str) or not summary:
+                        fail("candidate-validation", "candidate validator returned no summary")
+                    conclusion = "success"
+                except ContractError as exc:
+                    raise _CandidateRejected(exc) from exc
+            finally:
+                budget.close()
+                _ACTIVE_GIT_BUDGET.reset(budget_token)
+    except _CandidateRejected as rejected:
+        summary = str(rejected.error)[:4096]
+        conclusion = "failure"
     result = validate_publisher_result(
         {
             "schema": "aimee.module-doc-check.v1",

--- a/scripts/tests/test_module_doc_contract.py
+++ b/scripts/tests/test_module_doc_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+from contextlib import contextmanager
 from datetime import datetime, timezone
 import importlib.util
 import json
@@ -12,6 +13,7 @@ import shutil
 import subprocess
 import struct
 import tempfile
+import threading
 import time
 import unittest
 from unittest import mock
@@ -430,6 +432,79 @@ class ModuleDocContractTests(unittest.TestCase):
             "git-byte-budget", lambda: budget.cache_blob(("repo", "a" * 40, "x"), b"x")
         )
 
+    def test_snapshot_close_drains_leases_and_serializes_accounting(self) -> None:
+        budget = contract.GitDecisionBudget()
+        started = threading.Event()
+        release = threading.Event()
+        closed = threading.Event()
+
+        def operation() -> None:
+            with budget.operation():
+                started.set()
+                release.wait(timeout=2)
+
+        worker = threading.Thread(target=operation)
+        worker.start()
+        self.assertTrue(started.wait(timeout=1))
+
+        def close_budget() -> None:
+            budget.close()
+            closed.set()
+
+        closer = threading.Thread(target=close_budget)
+        closer.start()
+        self.assertFalse(closed.wait(timeout=0.05))
+        deadline = time.monotonic() + 1
+        while True:
+            try:
+                with budget.operation():
+                    pass
+            except contract.ContractError as exc:
+                self.assertIn("rule=git-snapshot-lifetime", str(exc))
+                break
+            self.assertLess(time.monotonic(), deadline)
+        release.set()
+        worker.join(timeout=1)
+        closer.join(timeout=1)
+        self.assertFalse(worker.is_alive())
+        self.assertFalse(closer.is_alive())
+        self.assertTrue(closed.is_set())
+
+        concurrent = contract.GitDecisionBudget()
+        concurrent.git_operations = contract.MAX_DECISION_GIT_OPERATIONS - 5
+        outcomes: list[str] = []
+        outcome_lock = threading.Lock()
+
+        def consume() -> None:
+            try:
+                concurrent.consume_git_operation()
+                result = "accepted"
+            except contract.ContractError:
+                result = "rejected"
+            with outcome_lock:
+                outcomes.append(result)
+
+        threads = [threading.Thread(target=consume) for _ in range(10)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=1)
+        self.assertEqual(outcomes.count("accepted"), 5)
+        self.assertEqual(outcomes.count("rejected"), 5)
+
+        cached = contract.GitDecisionBudget()
+        cache_threads = [
+            threading.Thread(
+                target=lambda: cached.cache_blob(("repo", "a" * 40, "x"), b"shared")
+            )
+            for _ in range(10)
+        ]
+        for thread in cache_threads:
+            thread.start()
+        for thread in cache_threads:
+            thread.join(timeout=1)
+        self.assertEqual(cached.distinct_blob_bytes, len(b"shared"))
+
     def test_decision_deadline_kills_git_and_prevents_late_spawn(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
@@ -573,6 +648,8 @@ class ModuleDocContractTests(unittest.TestCase):
             profile = oidc_profile()
             token_claims = claims(profile)
             events: list[str] = []
+            retained_readers = []
+            retained_validations = []
 
             def verify(token: str, selected: dict[str, object]) -> dict[str, object]:
                 self.assertEqual(token, "signed.jwt.value")
@@ -580,9 +657,7 @@ class ModuleDocContractTests(unittest.TestCase):
                 events.append("crypto")
                 return token_claims
 
-            def resolve(workload: dict[str, object], pull_request: int) -> dict[str, object]:
-                self.assertEqual(events, ["crypto"])
-                events.append("resolve")
+            def target_for(workload: dict[str, object], pull_request: int):
                 return {
                     "schema": "aimee.candidate-target.v1",
                     "repository_identity": workload["repository_identity"],
@@ -598,10 +673,33 @@ class ModuleDocContractTests(unittest.TestCase):
                     "trigger_check_identity": workload["trigger_check_identity"],
                 }
 
-            def validate(reader, workload, target) -> str:
-                self.assertEqual(events, ["crypto", "resolve"])
+            @contextmanager
+            def owned_candidate(target):
+                events.append("enter")
+                try:
+                    yield contract.ResolvedCandidate(target, repo)
+                finally:
+                    events.append("exit")
+
+            def resolve(workload: dict[str, object], pull_request: int):
+                self.assertEqual(events, ["crypto"])
+                events.append("resolve")
+                return owned_candidate(target_for(workload, pull_request))
+
+            def validate(validation, workload, target) -> str:
+                self.assertEqual(events, ["crypto", "resolve", "enter"])
                 events.append("candidate")
-                self.assertEqual(reader.read_blob("evidence.txt"), b"governed\n")
+                candidate = validation.candidate
+                base = validation.base
+                self.assertFalse(hasattr(validation, "reader"))
+                for hidden in ("repository", "budget", "blobs"):
+                    self.assertFalse(hasattr(candidate, hidden))
+                self.assertEqual(candidate.read_blob("evidence.txt"), b"governed\n")
+                self.assertEqual(base.read_blob("evidence.txt"), b"governed\n")
+                retained_readers.append(candidate)
+                retained_validations.append(validation)
+                workload["repository_identity"] = "callback-mutation"
+                target["candidate_revision"] = "c" * 40
                 return "All governed artifacts passed."
 
             request = json.dumps({
@@ -609,33 +707,224 @@ class ModuleDocContractTests(unittest.TestCase):
                 "pull_request": 1708,
                 "oidc_token": "signed.jwt.value",
             }, separators=(",", ":")).encode("ascii")
-            decision = contract.evaluate_trigger(
-                request,
-                (json.dumps(profile, separators=(",", ":")) + "\n").encode("ascii"),
-                wall_time=1_800_000_000,
-                verify_jwt=verify,
-                resolve_target=resolve,
-                validate_candidate=validate,
-                repository=repo,
+            profile_raw = (
+                json.dumps(profile, separators=(",", ":")) + "\n"
+            ).encode("ascii")
+
+            def decide(*, resolver=resolve, validator=validate):
+                return contract.evaluate_trigger(
+                    request,
+                    profile_raw,
+                    wall_time=1_800_000_000,
+                    verify_jwt=verify,
+                    resolve_target=resolver,
+                    validate_candidate=validator,
+                )
+
+            decision = decide()
+            self.assertEqual(
+                events, ["crypto", "resolve", "enter", "candidate", "exit"]
             )
-            self.assertEqual(events, ["crypto", "resolve", "candidate"])
+
+            events.clear()
+            read_started = threading.Event()
+            release_read = threading.Event()
+            reader_threads = []
+            reader_errors = []
+            original_read_blob = contract.GitBlobReader.read_blob
+
+            def blocking_read_blob(reader, path, *, max_bytes=contract.MAX_GOVERNED_BLOB_BYTES):
+                read_started.set()
+                release_read.wait(timeout=2)
+                try:
+                    return original_read_blob(reader, path, max_bytes=max_bytes)
+                finally:
+                    events.append("read-finished")
+
+            def concurrent_validate(validation, workload, target):
+                events.append("candidate")
+
+                def read() -> None:
+                    try:
+                        validation.candidate.read_blob("evidence.txt")
+                    except BaseException as exc:
+                        reader_errors.append(exc)
+
+                thread = threading.Thread(target=read)
+                reader_threads.append(thread)
+                thread.start()
+                self.assertTrue(read_started.wait(timeout=1))
+                threading.Timer(0.05, release_read.set).start()
+                return "Concurrent read drained before cleanup."
+
+            with mock.patch.object(
+                contract.GitBlobReader, "read_blob", new=blocking_read_blob
+            ):
+                decide(validator=concurrent_validate)
+            for thread in reader_threads:
+                thread.join(timeout=1)
+            self.assertEqual(reader_errors, [])
+            self.assertEqual(
+                events,
+                [
+                    "crypto", "resolve", "enter", "candidate", "read-finished", "exit"
+                ],
+            )
+
+            events.clear()
+
+            def mismatched_resolve(workload: dict[str, object], pull_request: int):
+                target = target_for(workload, pull_request)
+                target["repository_identity"] = "different-repository"
+                return owned_candidate(target)
+
+            with self.assertRaisesRegex(
+                contract.ContractError, "rule=target-repository-binding"
+            ):
+                decide(resolver=mismatched_resolve)
+            self.assertEqual(events, ["crypto", "enter", "exit"])
+
+            events.clear()
+
+            def malformed_resolve(workload: dict[str, object], pull_request: int):
+                target = target_for(workload, pull_request)
+                target["candidate_revision"] = "abbreviated"
+                return owned_candidate(target)
+
+            with self.assertRaisesRegex(
+                contract.ContractError, "rule=candidate-target-revision"
+            ):
+                decide(resolver=malformed_resolve)
+            self.assertEqual(events, ["crypto", "enter", "exit"])
+
+            events.clear()
+
+            def explode(validation, workload, target) -> str:
+                events.append("candidate")
+                raise RuntimeError("unexpected validator failure")
+
+            class AdversarialContext:
+                def __init__(self, target, *, cleanup_error=False):
+                    self.target = target
+                    self.cleanup_error = cleanup_error
+
+                def __enter__(self):
+                    events.append("enter")
+                    return contract.ResolvedCandidate(self.target, repo)
+
+                def __exit__(self, exc_type, exc, traceback):
+                    events.append("exit")
+                    if self.cleanup_error:
+                        raise RuntimeError("cleanup replacement")
+                    return True
+
+            def adversarial_resolve(workload, pull_request):
+                return AdversarialContext(target_for(workload, pull_request))
+
+            with self.assertRaisesRegex(RuntimeError, "unexpected validator failure"):
+                decide(resolver=adversarial_resolve, validator=explode)
+            self.assertEqual(events, ["crypto", "enter", "candidate", "exit"])
+
+            events.clear()
+
+            def replacing_resolve(workload, pull_request):
+                return AdversarialContext(
+                    target_for(workload, pull_request), cleanup_error=True
+                )
+
+            with self.assertRaisesRegex(RuntimeError, "unexpected validator failure"):
+                decide(resolver=replacing_resolve, validator=explode)
+            self.assertEqual(events, ["crypto", "enter", "candidate", "exit"])
+
+            events.clear()
+
+            def accept(validation, workload, target):
+                events.append("candidate")
+                return "Accepted before cleanup."
+
+            self.assert_rule(
+                "resolver-cleanup",
+                lambda: decide(resolver=replacing_resolve, validator=accept),
+            )
+            self.assertEqual(events, ["crypto", "enter", "candidate", "exit"])
+
+            events.clear()
+            partial = repo / "partial-acquisition"
+
+            def failed_acquisition(workload, pull_request):
+                @contextmanager
+                def acquisition():
+                    partial.mkdir()
+                    try:
+                        raise RuntimeError("acquisition failed")
+                        yield
+                    finally:
+                        partial.rmdir()
+
+                return acquisition()
+
+            with self.assertRaisesRegex(RuntimeError, "acquisition failed"):
+                decide(resolver=failed_acquisition)
+            self.assertFalse(partial.exists())
+            self.assert_rule(
+                "git-snapshot-lifetime",
+                lambda: retained_readers[0].read_blob("evidence.txt"),
+            )
+            self.assert_rule(
+                "git-snapshot-lifetime",
+                lambda: retained_validations[0].base.read_blob("evidence.txt"),
+            )
+            self.assertFalse(hasattr(retained_validations[0], "reader"))
+            for name, callback in (
+                ("commit", lambda: retained_readers[0].commit),
+                ("list", lambda: retained_readers[0].list_directory(".")),
+                (
+                    "reference",
+                    lambda: retained_readers[0].resolve_reference(
+                        "path:evidence.txt#L1"
+                    ),
+                ),
+                (
+                    "source-pattern",
+                    lambda: retained_readers[0].expand_source_pattern(
+                        "src/modules/memory/*.c", "memory"
+                    ),
+                ),
+            ):
+                with self.subTest(revoked_operation=name):
+                    self.assert_rule("git-snapshot-lifetime", callback)
             self.assertEqual(decision.publisher_result["candidate_revision"], commit)
+            self.assertEqual(
+                decision.workload["repository_identity"], "repository-17"
+            )
             self.assertRegex(decision.token_replay_key, r"^[0-9a-f]{64}$")
             self.assertRegex(decision.decision_replay_key, r"^[0-9a-f]{64}$")
             events.clear()
-            def reject(reader, workload, target) -> str:
+
+            def reject(validation, workload, target) -> str:
+                events.append("candidate")
                 contract.fail("candidate-rejected", "fixture rejection")
-            rejected = contract.evaluate_trigger(
-                request,
-                (json.dumps(profile, separators=(",", ":")) + "\n").encode("ascii"),
-                wall_time=1_800_000_000,
-                verify_jwt=verify,
-                resolve_target=resolve,
-                validate_candidate=reject,
-                repository=repo,
+
+            rejected = decide(validator=reject)
+            self.assertEqual(
+                events, ["crypto", "resolve", "enter", "candidate", "exit"]
             )
             self.assertEqual(rejected.publisher_result["conclusion"], "failure")
             self.assertIn("rule=candidate-rejected", rejected.publisher_result["summary"])
+
+            events.clear()
+            rejected = decide(resolver=replacing_resolve, validator=reject)
+            self.assertEqual(events, ["crypto", "enter", "candidate", "exit"])
+            self.assertEqual(rejected.publisher_result["conclusion"], "failure")
+            self.assertIn("rule=candidate-rejected", rejected.publisher_result["summary"])
+
+            events.clear()
+
+            with self.assertRaisesRegex(RuntimeError, "unexpected validator failure"):
+                decide(validator=explode)
+            self.assertEqual(
+                events, ["crypto", "resolve", "enter", "candidate", "exit"]
+            )
 
     def test_atomic_candidate_validator_with_two_real_signers(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- make repository resolution yield one target plus resolver-owned immutable object database
- expose only pre-bound candidate/base readers through an invocation-scoped capability
- revoke new work and drain in-flight reads before repository cleanup
- synchronize Git/evidence ceilings and blob-cache accounting
- preserve candidate-policy errors across resolver cleanup while keeping acquisition/cleanup failures fail closed
- document and test the complete ownership, cleanup, mutation, concurrency, and exception contract

This is a provider-neutral prerequisite for the repository acquisition adapter. It does not add GitHub-specific behavior, expose a verifier endpoint, verify compact OIDC tokens, add durable replay storage, activate the workflow, or constitute a deployment.

## Validation

- `python3 -I scripts/tests/test_module_doc_contract.py -v` (23 tests)
- `python3 -I scripts/tests/test_sign_module_docs.py -v` (9 tests)
- `git diff --check`
- technical-writer review completed
- roundtable iterated through resolver lifetime, exception precedence, capability scope, and concurrency; final focused review reported no issues