### PR TITLE
feat: acquire immutable Git snapshots

### DIFF
--- a/.github/module-doc-attestation/README.md
+++ b/.github/module-doc-attestation/README.md
@@ -122,6 +122,69 @@ The app credential belongs in the deployed service vault. Its permissions are li
 pull-request and Git objects and creating its named check. It must not push, merge, administer the
 repository, or create another app's check.
 
+## Immutable snapshot acquisition
+
+`scripts/module_doc_git_snapshot.py` supplies the Git acquisition boundary used by a future
+repository resolver. It is provider-neutral because it depends on Git Smart HTTP and full refs, not
+on a provider API or webhook format. A trusted provider adapter supplies an HTTPS repository URL,
+opaque full source refs, exact full lowercase SHA-1 commit IDs, and one owned authorization-header
+`bytearray`. The module does not select an OIDC issuer, interpret pull requests, call a provider API,
+or decide which refs and commits are authorized. Production callers must establish those facts
+before calling it. They must also pass a nonempty operator-configured allowlist of canonical HTTPS
+origins; the repository origin must match one entry exactly, including any non-default port.
+Canonical origins use a lowercase host, omit the default port, and contain no path, query, fragment,
+credentials, percent encoding, whitespace, or dot segments.
+
+Production acquisition is Linux-only and fails closed without `memfd_create` and `/proc/self/fd`.
+The authorization header uses the exact canonical field spelling `Authorization`, an arbitrary
+provider-neutral auth scheme, and token68 credentials. It exists in an anonymous, sealed,
+mode-`0600` Git-config descriptor only for the single atomic fetch. Its `extraHeader` setting is
+scoped to the canonical repository URL. The header is not placed in a subprocess command line, an
+environment value, or a named filesystem entry. The descriptor is closed and both the caller's buffer and the
+derived mutable buffers are overwritten before commit validation can begin or a repository handle
+is returned. Every reference to the caller's passed `bytearray` observes that overwrite. Callers must
+not create a separate copy if they require the same lifetime guarantee because the module cannot
+overwrite an object it was not given. Core dumps, swap, and other kernel-mediated copies are outside
+this process-level guarantee and must be controlled by the deployment. Authenticated fetch failures
+return a fixed diagnostic rather than remote-controlled stderr. Authenticated stdout and stderr are
+drained into wipeable buffers and discarded, preventing a server from retaining reflected credential
+fragments in process capture or an error. The subprocess environment is built from a fixed allowlist, so
+caller-provided `GIT_TRACE*`, proxy, and Git configuration variables are not inherited.
+
+Each acquisition creates a fresh bare repository and accepts local destination refs only when they
+match `refs/aimee-snapshot/[a-z][a-z0-9-]{0,63}`; invalid destinations are rejected before fetch. It
+disables redirects and interactive credentials, fetches atomically without tags or `FETCH_HEAD`, and
+retains the fetched refs for the handle's lifetime. It resolves each ref with `^{commit}`, rejects a
+non-commit target, compares the full object ID with the adapter's expected value, and runs
+`git fsck --full --strict --no-reflogs --unreachable` before returning. Any unreachable object rejects
+the snapshot, preventing a server from retaining reflected credentials in an extra object. All later Git commands use isolated
+non-network configuration. The returned repository tree is owner-read-only and exposes no configured
+remote. A
+context-managed handle removes the tree after the body returns or raises any `BaseException`;
+callers that do not use the context manager must call `close()`.
+
+Subprocess time, stdout, stderr, fetch count, and ref length have explicit module constants. Bounded
+tree scans while each subprocess runs detect repository growth, but they are not a storage quota;
+production requires an operator-enforced storage quota on the dedicated temporary parent. The
+operator creates that parent as mode `0700`, owned by the isolated worker UID; the module does not
+create or change ownership of it. Linux
+process-session support is also required: timeout handling terminates the Git process group before
+cleanup. The caller must run the acquisition worker in process isolation without unrelated concurrent
+forks; the module does not enforce that deployment boundary. Python passes the otherwise
+close-on-exec descriptor only to the fetch process, whose Git transport child must also inherit it.
+A host `SIGKILL` can still leave an orphaned snapshot containing the authorized source because no
+process can run cleanup afterward. Deployment therefore
+requires an operator-owned reclaimer for the dedicated temporary parent, with age and ownership
+checks, before this boundary is production-ready. Mode-based read-only state is an accidental-write
+guard, not protection from another process running as the same UID; deployment process isolation is
+the security boundary. The private local-file transport exists only for tests, assumes a
+non-adversarial fixture tree, is confined to a real caller-supplied fixture root, and rejects
+symlinks observed during validation.
+
+This primitive does not make the external verifier deployable. Provider API authorization,
+OIDC-backed workload normalization, durable replay, the publisher, process isolation, and the
+orphaned-snapshot reclaimer remain external deployment prerequisites.
+
 ## Activation order
 
 1. Deploy the reviewed verifier release and a provider-neutral issuer profile.

--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -131,6 +131,7 @@ jobs:
           command -v ssh-agent
           command -v ssh-add
           python3 -I scripts/tests/test_module_doc_contract.py -v
+          python3 -I scripts/tests/test_module_doc_git_snapshot.py -v
           python3 -I scripts/tests/test_sign_module_docs.py -v
 
   proposal-ordering:

--- a/scripts/module_doc_git_snapshot.py
+++ b/scripts/module_doc_git_snapshot.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""Provider-neutral, bounded acquisition of immutable Git snapshots.
+
+Production acquisition is Linux-only and accepts HTTPS remotes.  Provider
+adapters supply already-authorized refs and expected commit IDs; this module
+does not interpret CI identity, pull requests, or provider APIs.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass
+import errno
+import fcntl
+import os
+from pathlib import Path
+import re
+import selectors
+import shutil
+import signal
+import stat
+import subprocess
+import tempfile
+import time
+from typing import Callable, Sequence
+from urllib.parse import urlsplit
+
+import module_doc_contract as contract
+
+
+MAX_HEADER_BYTES = 8_192
+MAX_FETCH_SPECS = 8
+MAX_REF_BYTES = 255
+MAX_ORIGIN_BYTES = 512
+MAX_ORIGINS_BYTES = 8_192
+MAX_OUTPUT_BYTES = 65_536
+MAX_TREE_ENTRIES = 100_000
+MAX_TREE_SCAN_SECONDS = 0.1
+MIN_DISK_BYTES = 1_048_576
+MAX_DISK_BYTES = 8_589_934_592
+DEFAULT_DISK_BYTES = 536_870_912
+MIN_TIMEOUT_SECONDS = 1
+MAX_TIMEOUT_SECONDS = 300
+GIT = Path("/usr/bin/git")
+LOCAL_REF_RE = re.compile(r"^refs/aimee-snapshot/[a-z][a-z0-9-]{0,63}$")
+HEX_40_RE = re.compile(r"^[0-9a-f]{40}$")
+TOKEN68_RE = re.compile(
+    rb"^Authorization: [A-Za-z][A-Za-z0-9._~-]{0,31} "
+    rb"[A-Za-z0-9._~+/-]+={0,2}$"
+)
+
+
+@dataclass(frozen=True)
+class FetchSpec:
+    source_ref: str
+    local_ref: str
+    expected_commit: str
+
+
+class RepositoryHandle:
+    """Own a read-only snapshot until explicit or context-managed close."""
+
+    def __init__(self, root: Path, repository: Path) -> None:
+        self._root = root
+        self.repository = repository
+        self._closed = False
+
+    def __enter__(self) -> Path:
+        if self._closed:
+            contract.fail("snapshot-lifetime", "snapshot handle is closed")
+        return self.repository
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        _remove_root(self._root)
+        self._closed = True
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        if exc is None:
+            self.close()
+            return
+        try:
+            self.close()
+        except BaseException as cleanup_error:
+            exc.add_note(f"snapshot cleanup also failed: {cleanup_error}")
+
+
+def _wipe(value: bytearray) -> None:
+    value[:] = b"\0" * len(value)
+
+
+def _sanitize(raw: bytes) -> str:
+    printable = bytes(byte for byte in raw if byte in (9, 10, 13) or 32 <= byte <= 126)
+    return printable.decode("ascii")[:MAX_OUTPUT_BYTES]
+
+
+def _tree_bytes(root: Path) -> int:
+    total = 0
+    entries = 0
+    deadline = time.monotonic() + MAX_TREE_SCAN_SECONDS
+    for directory, _, files in os.walk(root):
+        for name in files:
+            entries += 1
+            if entries > MAX_TREE_ENTRIES or time.monotonic() >= deadline:
+                contract.fail("snapshot-disk", "snapshot tree scan exceeds its budget")
+            with suppress(OSError):
+                total += (Path(directory) / name).stat().st_size
+    return total
+
+
+def _terminate(process: subprocess.Popen[bytes]) -> None:
+    with suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGTERM)
+    if process.poll() is None:
+        try:
+            process.wait(timeout=0.2)
+        except subprocess.TimeoutExpired:
+            pass
+    with suppress(ProcessLookupError):
+        os.killpg(process.pid, 0)
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+    if process.poll() is None:
+        process.wait()
+
+
+def _run(
+    arguments: Sequence[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout_seconds: int,
+    pass_fds: tuple[int, ...] = (),
+    monitor_root: Path | None = None,
+    max_disk_bytes: int = DEFAULT_DISK_BYTES,
+    sensitive_output: bool = False,
+) -> bytes:
+    process = subprocess.Popen(
+        list(arguments),
+        cwd=cwd,
+        env=env,
+        shell=False,
+        bufsize=0,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+        pass_fds=pass_fds,
+    )
+    assert process.stdout is not None and process.stderr is not None
+    selector = selectors.DefaultSelector()
+    selector.register(process.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(process.stderr, selectors.EVENT_READ, "stderr")
+    output = bytearray()
+    errors = bytearray()
+    scratch = bytearray(MAX_OUTPUT_BYTES)
+    counts = {"stdout": 0, "stderr": 0}
+    deadline = time.monotonic() + timeout_seconds
+    next_disk_check = 0.0
+    try:
+        while selector.get_map():
+            now = time.monotonic()
+            if now >= deadline:
+                _terminate(process)
+                contract.fail("snapshot-timeout", "Git operation timed out")
+            if monitor_root is not None and now >= next_disk_check:
+                if _tree_bytes(monitor_root) > max_disk_bytes:
+                    _terminate(process)
+                    contract.fail("snapshot-disk", "snapshot exceeds its disk ceiling")
+                next_disk_check = now + 0.05
+            events = selector.select(min(0.05, deadline - now))
+            for key, _ in events:
+                count = key.fileobj.readinto(scratch)
+                if not count:
+                    selector.unregister(key.fileobj)
+                    continue
+                counts[key.data] += count
+                if counts[key.data] > MAX_OUTPUT_BYTES:
+                    _terminate(process)
+                    contract.fail(
+                        "snapshot-output", f"Git {key.data} exceeds its output ceiling"
+                    )
+                if not sensitive_output:
+                    sink = output if key.data == "stdout" else errors
+                    sink.extend(memoryview(scratch)[:count])
+                scratch[:count] = b"\0" * count
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _terminate(process)
+            contract.fail("snapshot-timeout", "Git operation timed out")
+        try:
+            returncode = process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            _terminate(process)
+            contract.fail("snapshot-timeout", "Git operation timed out")
+        if monitor_root is not None and _tree_bytes(monitor_root) > max_disk_bytes:
+            contract.fail("snapshot-disk", "snapshot exceeds its disk ceiling")
+        if returncode != 0:
+            detail = (
+                "authenticated Git operation failed"
+                if sensitive_output else _sanitize(bytes(errors)) or "Git operation failed"
+            )
+            contract.fail("snapshot-git", detail)
+        return b"" if sensitive_output else bytes(output)
+    finally:
+        _wipe(output)
+        _wipe(errors)
+        _wipe(scratch)
+        selector.close()
+        if process.poll() is None:
+            _terminate(process)
+        process.stdout.close()
+        process.stderr.close()
+
+
+def _base_env(home: Path, *, config: str = "/dev/null") -> dict[str, str]:
+    return {
+        "GIT_CONFIG_GLOBAL": config,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+        "HOME": str(home),
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PATH": "/usr/bin:/bin",
+    }
+
+
+def _validate_common(
+    specs: Sequence[FetchSpec], authorization: bytearray, timeout_seconds: int,
+    max_disk_bytes: int,
+) -> tuple[FetchSpec, ...]:
+    if not isinstance(authorization, bytearray):
+        contract.fail("snapshot-credential", "authorization must be an owned bytearray")
+    if not 1 <= len(authorization) <= MAX_HEADER_BYTES:
+        contract.fail("snapshot-credential", "authorization size is outside the allowed range")
+    if not TOKEN68_RE.fullmatch(authorization):
+        contract.fail(
+            "snapshot-credential",
+            "authorization must be one canonical token68 header",
+        )
+    if (
+        type(timeout_seconds) is not int
+        or not MIN_TIMEOUT_SECONDS <= timeout_seconds <= MAX_TIMEOUT_SECONDS
+    ):
+        contract.fail("snapshot-timeout", "timeout is outside the allowed range")
+    if type(max_disk_bytes) is not int or not MIN_DISK_BYTES <= max_disk_bytes <= MAX_DISK_BYTES:
+        contract.fail("snapshot-disk", "disk ceiling is outside the allowed range")
+    if not isinstance(specs, Sequence) or not 1 <= len(specs) <= MAX_FETCH_SPECS:
+        contract.fail("snapshot-specs", "snapshot requires one to eight fetch specs")
+    result = tuple(specs)
+    if not all(isinstance(item, FetchSpec) for item in result):
+        contract.fail("snapshot-specs", "every fetch spec must use the canonical type")
+    if len({item.source_ref for item in result}) != len(result) or len(
+        {item.local_ref for item in result}
+    ) != len(result):
+        contract.fail("snapshot-specs", "source and local refs must be unique")
+    for item in result:
+        if not all(
+            isinstance(value, str)
+            for value in (item.source_ref, item.local_ref, item.expected_commit)
+        ):
+            contract.fail("snapshot-specs", "fetch spec fields must be strings")
+        for ref in (item.source_ref, item.local_ref):
+            if (
+                not ref.startswith("refs/") or not ref.isascii()
+                or not 1 <= len(ref) <= MAX_REF_BYTES
+            ):
+                contract.fail("snapshot-ref", "refs must be bounded full ASCII refs")
+        if not LOCAL_REF_RE.fullmatch(item.local_ref):
+            contract.fail("snapshot-ref", "local ref is outside refs/aimee-snapshot")
+        if not HEX_40_RE.fullmatch(item.expected_commit):
+            contract.fail("snapshot-commit", "expected commit must be a full lowercase SHA-1")
+    return result
+
+
+def _validate_https_url(value: str) -> tuple[str, str]:
+    if (
+        not isinstance(value, str) or not value.isascii()
+        or any(ord(character) < 33 or ord(character) > 126 for character in value)
+    ):
+        contract.fail("snapshot-url", "repository URL must be visible ASCII")
+    parsed = urlsplit(value)
+    try:
+        port = parsed.port
+    except ValueError:
+        contract.fail("snapshot-url", "repository URL port is invalid")
+    if (
+        parsed.scheme != "https" or not parsed.hostname or parsed.username is not None
+        or parsed.password is not None or parsed.query or parsed.fragment
+        or "@" in parsed.netloc
+    ):
+        contract.fail("snapshot-url", "production repository URL must be canonical HTTPS")
+    if (
+        parsed.hostname != parsed.hostname.lower() or parsed.hostname.endswith(".")
+        or "%" in value or "\\" in value or '"' in value or "//" in parsed.path
+        or any(component in (".", "..") for component in parsed.path.split("/"))
+        or port in (0, 443)
+    ):
+        contract.fail("snapshot-url", "repository URL is ambiguous")
+    host = parsed.hostname
+    rendered_host = f"[{host}]" if ":" in host else host
+    origin = f"https://{rendered_host}" + (f":{port}" if port is not None else "")
+    if parsed.netloc != origin.removeprefix("https://"):
+        contract.fail("snapshot-url", "repository URL is not canonical")
+    return value, origin
+
+
+def _validate_allowed_origins(origin: str, allowed_origins: Sequence[str]) -> None:
+    if not isinstance(allowed_origins, Sequence) or isinstance(
+        allowed_origins, (str, bytes, bytearray)
+    ):
+        contract.fail("snapshot-origin", "allowed origins must be a sequence")
+    allowed = tuple(allowed_origins)
+    if not 1 <= len(allowed) <= 32 or not all(isinstance(item, str) for item in allowed):
+        contract.fail("snapshot-origin", "one to 32 canonical allowed origins are required")
+    if any(len(item.encode("utf-8")) > MAX_ORIGIN_BYTES for item in allowed) or sum(
+        len(item.encode("utf-8")) for item in allowed
+    ) > MAX_ORIGINS_BYTES:
+        contract.fail("snapshot-origin", "allowed origins exceed their byte ceiling")
+    if len(set(allowed)) != len(allowed) or any(
+        _validate_https_url(f"{item}/repository")[1] != item for item in allowed
+    ):
+        contract.fail("snapshot-origin", "allowed origins must be unique and canonical")
+    if origin not in allowed:
+        contract.fail("snapshot-origin", "repository origin is not allowed")
+
+
+def _validate_fixture_remote(remote: Path, fixture_root: Path) -> str:
+    root_input = fixture_root.absolute()
+    if root_input.is_symlink() or not root_input.is_dir():
+        contract.fail("snapshot-test-remote", "fixture root must be a real directory")
+    root = root_input.resolve(strict=True)
+    try:
+        relative = remote.absolute().relative_to(root_input)
+    except ValueError:
+        contract.fail("snapshot-test-remote", "test remote escapes fixture root")
+    current = root_input
+    for component in relative.parts:
+        current = current / component
+        if current.is_symlink():
+            contract.fail("snapshot-test-remote", "test remote contains a symlink")
+    candidate = current.resolve(strict=True)
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        contract.fail("snapshot-test-remote", "test remote escapes fixture root")
+    return candidate.as_uri()
+
+
+def _validate_refs(specs: Sequence[FetchSpec], *, home: Path, timeout: int) -> None:
+    for item in specs:
+        for ref in (item.source_ref, item.local_ref):
+            _run(
+                [str(GIT), "check-ref-format", ref],
+                cwd=home,
+                env=_base_env(home),
+                timeout_seconds=timeout,
+            )
+
+
+def _credential_config(scope_url: str, authorization: bytearray) -> tuple[int, bytearray]:
+    if not callable(getattr(os, "memfd_create", None)) or not Path("/proc/self/fd").is_dir():
+        contract.fail("snapshot-platform", "anonymous Git configuration requires Linux memfd")
+    fd = os.memfd_create(
+        "aimee-git-credential", flags=os.MFD_CLOEXEC | os.MFD_ALLOW_SEALING
+    )
+    config = bytearray()
+    try:
+        os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        config.extend(b'[http "')
+        config.extend(scope_url.encode("ascii"))
+        config.extend(b'"]\n\textraHeader = "')
+        config.extend(authorization)
+        config.extend(
+            b"\"\n\tfollowRedirects = false\n[credential]\n\thelper =\n"
+        )
+        view = memoryview(config)
+        try:
+            written = 0
+            while written < len(view):
+                try:
+                    count = os.write(fd, view[written:])
+                except InterruptedError:
+                    continue
+                if count <= 0:
+                    contract.fail(
+                        "snapshot-credential", "credential config write was incomplete"
+                    )
+                written += count
+        finally:
+            view.release()
+        os.fsync(fd)
+        seals = fcntl.F_SEAL_SEAL | fcntl.F_SEAL_SHRINK | fcntl.F_SEAL_GROW | fcntl.F_SEAL_WRITE
+        fcntl.fcntl(fd, fcntl.F_ADD_SEALS, seals)
+        actual_seals = fcntl.fcntl(fd, fcntl.F_GET_SEALS)
+        if seals & ~actual_seals:
+            contract.fail("snapshot-credential", "credential config sealing failed")
+        os.lseek(fd, 0, os.SEEK_SET)
+        return fd, config
+    except BaseException:
+        os.close(fd)
+        _wipe(config)
+        raise
+
+
+def _make_read_only(root: Path) -> None:
+    for directory, directories, files in os.walk(root):
+        path = Path(directory)
+        path.chmod(stat.S_IRUSR | stat.S_IXUSR)
+        for name in directories:
+            (path / name).chmod(stat.S_IRUSR | stat.S_IXUSR)
+        for name in files:
+            (path / name).chmod(stat.S_IRUSR)
+
+
+def _make_owner_writable(root: Path) -> None:
+    if not root.exists():
+        return
+    for directory, directories, files in os.walk(root):
+        path = Path(directory)
+        with suppress(OSError):
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        for name in directories:
+            with suppress(OSError):
+                (path / name).chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        for name in files:
+            with suppress(OSError):
+                (path / name).chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+def _remove_root(root: Path) -> None:
+    last_error: OSError | None = None
+    for _ in range(2):
+        _make_owner_writable(root)
+        try:
+            shutil.rmtree(root)
+            return
+        except OSError as error:
+            last_error = error
+    contract.fail("snapshot-cleanup", f"snapshot cleanup failed: {last_error}")
+
+
+def _acquire(
+    remote_url: str,
+    specs: Sequence[FetchSpec],
+    authorization: bytearray,
+    *,
+    timeout_seconds: int,
+    max_disk_bytes: int,
+    temp_parent: Path | None,
+    observer: Callable[[Sequence[str], dict[str, str], tuple[int, ...]], None] | None = None,
+) -> RepositoryHandle:
+    validated = _validate_common(specs, authorization, timeout_seconds, max_disk_bytes)
+    parent = temp_parent.resolve() if temp_parent is not None else None
+    root = Path(tempfile.mkdtemp(prefix="aimee-snapshot-", dir=parent))
+    try:
+        root.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        repository = root / "repository.git"
+        home = root / "home"
+        home.mkdir(mode=0o700)
+        _validate_refs(validated, home=home, timeout=timeout_seconds)
+        _run(
+            [str(GIT), "init", "--bare", str(repository)],
+            cwd=root,
+            env=_base_env(home),
+            timeout_seconds=timeout_seconds,
+            monitor_root=root,
+            max_disk_bytes=max_disk_bytes,
+        )
+        fd = -1
+        config = bytearray()
+        try:
+            fd, config = _credential_config(remote_url, authorization)
+            fd_path = f"/proc/self/fd/{fd}"
+            env = _base_env(home, config=fd_path)
+            arguments = [
+                str(GIT), "-c", "protocol.version=2", "-c", "fetch.fsckObjects=true",
+                "-c", "transfer.fsckObjects=true", "fetch", "--atomic", "--no-tags",
+                "--no-force", "--no-write-fetch-head", remote_url,
+                *(f"{item.source_ref}:{item.local_ref}" for item in validated),
+            ]
+            if observer is not None:
+                observer(arguments, env, (fd,))
+            _run(
+                arguments,
+                cwd=repository,
+                env=env,
+                timeout_seconds=timeout_seconds,
+                pass_fds=(fd,),
+                monitor_root=root,
+                max_disk_bytes=max_disk_bytes,
+                sensitive_output=True,
+            )
+        finally:
+            if fd >= 0:
+                os.close(fd)
+                try:
+                    os.fstat(fd)
+                except OSError as error:
+                    if error.errno != errno.EBADF:
+                        raise
+                else:
+                    contract.fail("snapshot-credential", "credential descriptor remained open")
+            _wipe(config)
+            _wipe(authorization)
+
+        env = _base_env(home)
+        for item in validated:
+            resolved = _run(
+                [str(GIT), "rev-parse", "--verify", f"{item.local_ref}^{{commit}}"],
+                cwd=repository, env=env, timeout_seconds=timeout_seconds,
+            ).decode("ascii").strip()
+            kind = _run(
+                [str(GIT), "cat-file", "-t", resolved],
+                cwd=repository, env=env, timeout_seconds=timeout_seconds,
+            ).decode("ascii").strip()
+            if kind != "commit" or resolved != item.expected_commit:
+                contract.fail("snapshot-commit", "fetched ref does not match expected commit")
+        unreachable = _run(
+            [
+                str(GIT), "fsck", "--full", "--strict", "--no-reflogs",
+                "--unreachable",
+            ],
+            cwd=repository,
+            env=env,
+            timeout_seconds=timeout_seconds,
+            monitor_root=root,
+            max_disk_bytes=max_disk_bytes,
+        )
+        if unreachable:
+            contract.fail("snapshot-object-closure", "snapshot contains unreachable objects")
+        if _tree_bytes(root) > max_disk_bytes:
+            contract.fail("snapshot-disk", "snapshot exceeds its disk ceiling")
+        _make_read_only(root)
+        return RepositoryHandle(root, repository)
+    except BaseException as active_error:
+        try:
+            _remove_root(root)
+        except BaseException as cleanup_error:
+            active_error.add_note(f"snapshot cleanup also failed: {cleanup_error}")
+        raise
+
+
+def acquire_snapshot(
+    repository_url: str,
+    specs: Sequence[FetchSpec],
+    authorization: bytearray,
+    *,
+    allowed_origins: Sequence[str],
+    timeout_seconds: int = 60,
+    max_disk_bytes: int = DEFAULT_DISK_BYTES,
+    temp_parent: Path | None = None,
+) -> RepositoryHandle:
+    """Consume authorization and acquire one bounded HTTPS Git snapshot."""
+    try:
+        canonical_url, origin = _validate_https_url(repository_url)
+        _validate_allowed_origins(origin, allowed_origins)
+        return _acquire(
+            canonical_url, specs, authorization,
+            timeout_seconds=timeout_seconds, max_disk_bytes=max_disk_bytes,
+            temp_parent=temp_parent,
+        )
+    finally:
+        if isinstance(authorization, bytearray):
+            _wipe(authorization)
+
+
+def _acquire_test_snapshot(
+    remote: Path,
+    fixture_root: Path,
+    specs: Sequence[FetchSpec],
+    authorization: bytearray,
+    *,
+    timeout_seconds: int = 60,
+    max_disk_bytes: int = DEFAULT_DISK_BYTES,
+    temp_parent: Path | None = None,
+    observer: Callable[[Sequence[str], dict[str, str], tuple[int, ...]], None] | None = None,
+) -> RepositoryHandle:
+    try:
+        return _acquire(
+            _validate_fixture_remote(remote, fixture_root), specs, authorization,
+            timeout_seconds=timeout_seconds, max_disk_bytes=max_disk_bytes,
+            temp_parent=temp_parent, observer=observer,
+        )
+    finally:
+        if isinstance(authorization, bytearray):
+            _wipe(authorization)

--- a/scripts/tests/test_module_doc_git_snapshot.py
+++ b/scripts/tests/test_module_doc_git_snapshot.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Offline tests for provider-neutral immutable Git snapshot acquisition."""
+
+from __future__ import annotations
+
+import importlib.util
+import fcntl
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+contract = load("module_doc_contract", REPO_ROOT / "scripts/module_doc_contract.py")
+snapshot = load(
+    "module_doc_git_snapshot", REPO_ROOT / "scripts/module_doc_git_snapshot.py"
+)
+
+
+class GitSnapshotTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.fixture_root = self.root / "fixtures"
+        self.fixture_root.mkdir()
+        self.remote = self.fixture_root / "remote.git"
+        self.work = self.root / "work"
+        self.snapshots = self.root / "snapshots"
+        self.snapshots.mkdir()
+        subprocess.run(["git", "init", "-q", "--bare", str(self.remote)], check=True)
+        subprocess.run(["git", "init", "-q", str(self.work)], check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "fixture@example.invalid"],
+            cwd=self.work, check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Fixture"], cwd=self.work, check=True
+        )
+        (self.work / "evidence.txt").write_text("base\n", encoding="ascii")
+        subprocess.run(["git", "add", "evidence.txt"], cwd=self.work, check=True)
+        subprocess.run(["git", "commit", "-qm", "base"], cwd=self.work, check=True)
+        self.base = self.git("rev-parse", "HEAD")
+        (self.work / "evidence.txt").write_text("candidate\n", encoding="ascii")
+        subprocess.run(["git", "commit", "-qam", "candidate"], cwd=self.work, check=True)
+        self.candidate = self.git("rev-parse", "HEAD")
+        subprocess.run(
+            [
+                "git", "push", str(self.remote),
+                f"{self.base}:refs/heads/base",
+                f"{self.candidate}:refs/heads/candidate",
+            ], cwd=self.work, check=True, stdout=subprocess.DEVNULL,
+        )
+        self.specs = (
+            snapshot.FetchSpec("refs/heads/base", "refs/aimee-snapshot/base", self.base),
+            snapshot.FetchSpec(
+                "refs/heads/candidate", "refs/aimee-snapshot/candidate", self.candidate
+            ),
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def git(self, *arguments: str) -> str:
+        return subprocess.check_output(
+            ["git", *arguments], cwd=self.work, text=True
+        ).strip()
+
+    def acquire(self, authorization: bytearray, **kwargs):
+        return snapshot._acquire_test_snapshot(
+            self.remote,
+            self.fixture_root,
+            self.specs,
+            authorization,
+            temp_parent=self.snapshots,
+            **kwargs,
+        )
+
+    def assert_rule(self, rule: str, callback) -> None:
+        with self.assertRaisesRegex(contract.ContractError, f"rule={rule}"):
+            callback()
+
+    def test_acquires_exact_read_only_snapshot_without_secret_residue(self) -> None:
+        secret = b"Authorization: Basic SECRET-VALUE-XXXXXXXX"
+        authorization = bytearray(secret)
+        observed = {}
+
+        def observe(arguments, env, pass_fds):
+            rendered = repr((arguments, env)).encode("utf-8")
+            self.assertNotIn(secret, rendered)
+            self.assertEqual(
+                set(env),
+                {
+                    "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM", "GIT_TERMINAL_PROMPT",
+                    "HOME", "LANG", "LC_ALL", "PATH",
+                },
+            )
+            self.assertEqual(len(pass_fds), 1)
+            fd = pass_fds[0]
+            observed["fd"] = fd
+            self.assertEqual(stat.S_IMODE(os.fstat(fd).st_mode), 0o600)
+            required_seals = (
+                fcntl.F_SEAL_SEAL | fcntl.F_SEAL_SHRINK
+                | fcntl.F_SEAL_GROW | fcntl.F_SEAL_WRITE
+            )
+            self.assertEqual(fcntl.fcntl(fd, fcntl.F_GET_SEALS), required_seals)
+            os.lseek(fd, 0, os.SEEK_SET)
+            config = os.read(fd, snapshot.MAX_HEADER_BYTES + 1024)
+            self.assertIn(secret, config)
+            self.assertIn(self.remote.as_uri().encode("ascii"), config)
+            self.assertNotIn(b"[http]\n", config)
+            os.lseek(fd, 0, os.SEEK_SET)
+
+        handle = snapshot._acquire_test_snapshot(
+            self.remote,
+            self.fixture_root,
+            self.specs,
+            authorization,
+            temp_parent=self.snapshots,
+            observer=observe,
+        )
+        self.assertEqual(authorization, bytearray(len(secret)))
+        self.assertFalse(Path(f"/proc/self/fd/{observed['fd']}").exists())
+        repository = handle.repository
+        self.assertFalse(handle._root.stat().st_mode & stat.S_IWUSR)
+        self.assertFalse(repository.stat().st_mode & stat.S_IWUSR)
+        self.assertEqual(
+            contract.GitBlobReader(repository, self.base).read_blob("evidence.txt"),
+            b"base\n",
+        )
+        self.assertEqual(
+            contract.GitBlobReader(repository, self.candidate).read_blob("evidence.txt"),
+            b"candidate\n",
+        )
+        refs = subprocess.check_output(
+            ["git", "for-each-ref", "--format=%(refname)", "refs/aimee-snapshot"],
+            cwd=repository, text=True,
+        ).splitlines()
+        self.assertEqual(
+            refs, ["refs/aimee-snapshot/base", "refs/aimee-snapshot/candidate"]
+        )
+        self.assertEqual(
+            subprocess.check_output(["git", "remote"], cwd=repository), b""
+        )
+        handle.close()
+        handle.close()
+        self.assertFalse(repository.exists())
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+    def test_wrong_or_missing_ref_fails_atomically_and_redacts(self) -> None:
+        secret = b"Authorization: Basic SECRET-WRONG-SHA"
+        authorization = bytearray(secret)
+        wrong = (
+            snapshot.FetchSpec(
+                "refs/heads/base", "refs/aimee-snapshot/base", "f" * 40
+            ),
+        )
+        with self.assertRaises(contract.ContractError) as captured:
+            snapshot._acquire_test_snapshot(
+                self.remote, self.fixture_root, wrong, authorization,
+                temp_parent=self.snapshots,
+            )
+        self.assertNotIn(secret.decode(), str(captured.exception))
+        self.assertEqual(authorization, bytearray(len(secret)))
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+        missing_secret = bytearray(b"Authorization: Basic SECRET-MISSING")
+        missing = self.specs + (
+            snapshot.FetchSpec(
+                "refs/heads/absent", "refs/aimee-snapshot/absent", "a" * 40
+            ),
+        )
+        self.assert_rule(
+            "snapshot-git",
+            lambda: snapshot._acquire_test_snapshot(
+                self.remote, self.fixture_root, missing, missing_secret,
+                temp_parent=self.snapshots,
+            ),
+        )
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+    def test_blob_ref_is_not_accepted_as_a_commit(self) -> None:
+        blob = subprocess.check_output(
+            ["git", "hash-object", "-w", "evidence.txt"], cwd=self.work, text=True
+        ).strip()
+        subprocess.run(
+            ["git", "update-ref", "refs/test/blob", blob], cwd=self.work, check=True
+        )
+        subprocess.run(
+            ["git", "push", str(self.remote), "refs/test/blob:refs/test/blob"],
+            cwd=self.work, check=True, stdout=subprocess.DEVNULL,
+        )
+        specs = (
+            snapshot.FetchSpec("refs/test/blob", "refs/aimee-snapshot/blob", blob),
+        )
+        self.assert_rule(
+            "snapshot-git",
+            lambda: snapshot._acquire_test_snapshot(
+                self.remote, self.fixture_root, specs,
+                bytearray(b"Authorization: Basic SECRET-BLOB"),
+                temp_parent=self.snapshots,
+            ),
+        )
+
+    def test_invalid_inputs_fail_before_subprocess_or_repository_creation(self) -> None:
+        cases = (
+            (
+                "http://example.invalid/repo", self.specs,
+                bytearray(b"Authorization: Bearer x"), "snapshot-url",
+            ),
+            (
+                "https://example.invalid/repo", self.specs,
+                bytearray(b"Authorization: x\nEvil: y"), "snapshot-credential",
+            ),
+            (
+                "https://example.invalid/repo",
+                (snapshot.FetchSpec("refs/heads/base", "refs/heads/bad", self.base),),
+                bytearray(b"Authorization: Bearer x"),
+                "snapshot-ref",
+            ),
+            (
+                "https://example.invalid/repo",
+                (snapshot.FetchSpec("refs/heads/base", "refs/aimee-snapshot/base", "abc"),),
+                bytearray(b"Authorization: Bearer x"),
+                "snapshot-commit",
+            ),
+        )
+        for url, specs, authorization, rule in cases:
+            original_length = len(authorization)
+            with self.subTest(rule=rule), mock.patch.object(snapshot.subprocess, "Popen") as popen:
+                self.assert_rule(
+                    rule,
+                    lambda url=url, specs=specs, auth=authorization: (
+                        snapshot.acquire_snapshot(
+                            url, specs, auth,
+                            allowed_origins=("https://example.invalid",),
+                            temp_parent=self.snapshots,
+                        )
+                    ),
+                )
+                popen.assert_not_called()
+                self.assertEqual(authorization, bytearray(original_length))
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+    def test_fixture_transport_rejects_escape_and_symlink(self) -> None:
+        outside = self.root / "outside.git"
+        outside.mkdir()
+        self.assert_rule(
+            "snapshot-test-remote",
+            lambda: snapshot._validate_fixture_remote(outside, self.fixture_root),
+        )
+        link = self.fixture_root / "link.git"
+        link.symlink_to(self.remote, target_is_directory=True)
+        self.assert_rule(
+            "snapshot-test-remote",
+            lambda: snapshot._validate_fixture_remote(link, self.fixture_root),
+        )
+        root_link = self.root / "fixture-link"
+        root_link.symlink_to(self.fixture_root, target_is_directory=True)
+        self.assert_rule(
+            "snapshot-test-remote",
+            lambda: snapshot._validate_fixture_remote(self.remote, root_link),
+        )
+
+    def test_production_url_is_canonical_and_origin_is_explicitly_allowed(self) -> None:
+        rejected = (
+            "https://EXAMPLE.invalid/repo",
+            "https://example.invalid:443/repo",
+            "https://example.invalid/a/../repo",
+            "https://example.invalid/a%2frepo",
+            "https://example.invalid/repo ",
+            "https://example.invalid:0/repo",
+            "https://user@example.invalid/repo",
+            'https://example.invalid/repo"name',
+        )
+        for url in rejected:
+            with self.subTest(url=url):
+                self.assert_rule("snapshot-url", lambda url=url: snapshot._validate_https_url(url))
+
+        url, origin = snapshot._validate_https_url(
+            "https://git.example.invalid:8443/repository"
+        )
+        self.assertEqual(url, "https://git.example.invalid:8443/repository")
+        self.assertEqual(origin, "https://git.example.invalid:8443")
+        snapshot._validate_allowed_origins(origin, (origin,))
+        self.assert_rule(
+            "snapshot-origin",
+            lambda: snapshot._validate_allowed_origins(
+                "https://169.254.169.254", ("https://git.example.invalid",)
+            ),
+        )
+        self.assert_rule(
+            "snapshot-origin",
+            lambda: snapshot._validate_allowed_origins(
+                origin, ("https://" + "a" * snapshot.MAX_ORIGIN_BYTES,)
+            ),
+        )
+
+    def test_short_memfd_write_fails_closed_and_cleanup_is_retryable(self) -> None:
+        authorization = bytearray(b"Authorization: Bearer SECRET-SHORT-WRITE")
+        with mock.patch.object(snapshot.os, "write", return_value=0):
+            self.assert_rule("snapshot-credential", lambda: self.acquire(authorization))
+        self.assertEqual(authorization, bytearray(len(authorization)))
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+        real_write = snapshot.os.write
+        calls = 0
+
+        def fragmented_write(fd, value):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return real_write(fd, value[:7])
+            if calls == 2:
+                raise InterruptedError
+            return real_write(fd, value)
+
+        with mock.patch.object(snapshot.os, "write", side_effect=fragmented_write):
+            fragmented = self.acquire(
+                bytearray(b"Authorization: Bearer SECRET-FRAGMENTED")
+            )
+        fragmented.close()
+        self.assertGreaterEqual(calls, 3)
+
+        handle = self.acquire(bytearray(b"Authorization: Bearer SECRET-CLEANUP"))
+        repository = handle.repository
+        with mock.patch.object(snapshot.shutil, "rmtree", side_effect=OSError("busy")) as remove:
+            self.assert_rule("snapshot-cleanup", handle.close)
+            self.assertEqual(remove.call_count, 2)
+        self.assertTrue(repository.exists())
+        handle.close()
+        self.assertFalse(repository.exists())
+
+    def test_platform_output_timeout_and_disk_bounds(self) -> None:
+        with mock.patch.object(snapshot.os, "memfd_create", None):
+            authorization = bytearray(b"Authorization: Basic SECRET-PLATFORM")
+            self.assert_rule("snapshot-platform", lambda: self.acquire(authorization))
+            self.assertEqual(authorization, bytearray(len(authorization)))
+
+        env = snapshot._base_env(self.root)
+        self.assert_rule(
+            "snapshot-output",
+            lambda: snapshot._run(
+                ["/usr/bin/python3", "-c", f"print('x'*{snapshot.MAX_OUTPUT_BYTES + 1})"],
+                cwd=self.root, env=env, timeout_seconds=2,
+            ),
+        )
+        self.assert_rule(
+            "snapshot-timeout",
+            lambda: snapshot._run(
+                ["/usr/bin/python3", "-c", "import time; time.sleep(5)"],
+                cwd=self.root, env=env, timeout_seconds=1,
+            ),
+        )
+        started = time.monotonic()
+        self.assert_rule(
+            "snapshot-timeout",
+            lambda: snapshot._run(
+                [
+                    "/usr/bin/python3", "-c",
+                    "import os,time; p=os.fork(); "
+                    "os._exit(0) if p else time.sleep(5)",
+                ],
+                cwd=self.root, env=env, timeout_seconds=1,
+            ),
+        )
+        self.assertLess(time.monotonic() - started, 2)
+        large = self.root / "large"
+        large.mkdir()
+        (large / "data").write_bytes(b"x" * (snapshot.MIN_DISK_BYTES + 1))
+        self.assert_rule(
+            "snapshot-disk",
+            lambda: snapshot._run(
+                ["/usr/bin/python3", "-c", "import time; time.sleep(.2)"],
+                cwd=self.root, env=env, timeout_seconds=2,
+                monitor_root=large, max_disk_bytes=snapshot.MIN_DISK_BYTES,
+            ),
+        )
+
+    def test_sensitive_output_is_discarded_and_failure_is_fixed(self) -> None:
+        secret = "Authorization: Bearer REFLECTED-SECRET"
+        env = snapshot._base_env(self.root)
+        output = snapshot._run(
+            ["/usr/bin/python3", "-c", f"print({secret!r})"],
+            cwd=self.root, env=env, timeout_seconds=2, sensitive_output=True,
+        )
+        self.assertEqual(output, b"")
+        with self.assertRaises(contract.ContractError) as captured:
+            snapshot._run(
+                [
+                    "/usr/bin/python3", "-c",
+                    f"import sys; print({secret!r}, file=sys.stderr); sys.exit(1)",
+                ],
+                cwd=self.root, env=env, timeout_seconds=2, sensitive_output=True,
+            )
+        self.assertEqual(
+            str(captured.exception),
+            "rule=snapshot-git: authenticated Git operation failed",
+        )
+        self.assertNotIn("REFLECTED-SECRET", str(captured.exception))
+
+    def test_initialization_failures_and_unreachable_objects_fail_closed(self) -> None:
+        authorization = bytearray(b"Authorization: Bearer SECRET-CHMOD")
+        with mock.patch.object(snapshot.Path, "chmod", side_effect=OSError("mode")):
+            with self.assertRaisesRegex(OSError, "mode"):
+                self.acquire(authorization)
+        self.assertEqual(authorization, bytearray(len(authorization)))
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+        authorization = bytearray(b"Authorization: Bearer SECRET-MKDIR")
+        with mock.patch.object(snapshot.Path, "mkdir", side_effect=OSError("mkdir")):
+            with self.assertRaisesRegex(OSError, "mkdir"):
+                self.acquire(authorization)
+        self.assertEqual(authorization, bytearray(len(authorization)))
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+        real_run = snapshot._run
+        injected = False
+
+        def inject_unreachable(arguments, **kwargs):
+            nonlocal injected
+            if "rev-parse" in arguments and not injected:
+                injected = True
+                subprocess.run(
+                    ["git", "hash-object", "-w", "--stdin"],
+                    cwd=kwargs["cwd"], input=b"reflected credential", check=True,
+                    stdout=subprocess.DEVNULL,
+                )
+            return real_run(arguments, **kwargs)
+
+        with mock.patch.object(snapshot, "_run", side_effect=inject_unreachable):
+            self.assert_rule(
+                "snapshot-object-closure",
+                lambda: self.acquire(
+                    bytearray(b"Authorization: Bearer SECRET-UNREACHABLE")
+                ),
+            )
+        self.assertTrue(injected)
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+    def test_subprocess_environment_is_a_fixed_allowlist(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {
+                "GIT_DIR": "/attacker",
+                "GIT_OBJECT_DIRECTORY": "/attacker/objects",
+                "GIT_TRACE": "1",
+                "HTTPS_PROXY": "https://attacker.invalid",
+            },
+        ):
+            env = snapshot._base_env(self.root)
+        self.assertEqual(
+            set(env),
+            {
+                "GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM", "GIT_TERMINAL_PROMPT",
+                "HOME", "LANG", "LC_ALL", "PATH",
+            },
+        )
+
+
+    def test_context_body_failure_cleans_repository(self) -> None:
+        handle = self.acquire(bytearray(b"Authorization: Basic SECRET-BODY"))
+        repository = handle.repository
+        with self.assertRaisesRegex(RuntimeError, "body failed"):
+            with handle:
+                raise RuntimeError("body failed")
+        self.assertFalse(repository.exists())
+        self.assertEqual(list(self.snapshots.iterdir()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a provider-neutral, Linux-only immutable Git snapshot acquisition boundary
- scope authorization to an explicitly allowlisted canonical origin using a sealed anonymous Git config
- enforce exact commit binding, reachable-object closure, bounded process output/time/tree scans, and retryable cleanup
- document the remaining deployment prerequisites and add the snapshot suite to the required module-doc contract check

## Validation

- `python3 -I scripts/tests/test_module_doc_contract.py -v` (23 tests)
- `python3 -I scripts/tests/test_module_doc_git_snapshot.py -v` (12 tests)
- `python3 -I scripts/tests/test_sign_module_docs.py -v` (9 tests)
- `git diff --check`
- technical-writer review completed and incorporated
- exact-diff roundtable: approved (`oprun_g6a5fa9b13dfe551_1784658391_36`)

## Scope

This is a provider-neutral primitive, not a deployable external verifier. Provider API authorization, OIDC normalization, durable replay, publisher integration, process isolation, storage quota, and orphan reclamation remain explicit prerequisites.