### PR TITLE
fix: deduplicate proposal triggers by blob

### DIFF
--- a/server-go/internal/api/server_test.go
+++ b/server-go/internal/api/server_test.go
@@ -183,6 +183,26 @@ nodes:
 	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "already filed") {
 		t.Fatalf("duplicate status=%d body=%s", rec.Code, rec.Body.String())
 	}
+	if err := os.WriteFile(filepath.Join(repo, "unrelated.txt"), []byte("advance watched ref\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "unrelated.txt")
+	runGit(t, repo, "commit", "-m", "advance branch without changing proposal")
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/trigger/fire", bytes.NewReader(body)))
+	if rec.Code != http.StatusConflict || !strings.Contains(rec.Body.String(), "already filed") {
+		t.Fatalf("moving-ref duplicate status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if err := os.WriteFile(filepath.Join(proposalDir, "large.md"), []byte(proposal+"\nchanged blob\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "docs/proposals/pending/large.md")
+	runGit(t, repo, "commit", "-m", "change proposal blob")
+	rec = httptest.NewRecorder()
+	server.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/v1/trigger/fire", bytes.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("changed blob status=%d body=%s", rec.Code, rec.Body.String())
+	}
 	linkedBody := []byte(`{"source":"proposals","proposal":"linked","workspace":` +
 		strconv.Quote(repo) + `,"ref":"HEAD","pipeline":"build","mode":"autonomous"}`)
 	rec = httptest.NewRecorder()

--- a/server-go/internal/api/trigger.go
+++ b/server-go/internal/api/trigger.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -378,8 +379,13 @@ func (s *Server) fileProposal(ctx context.Context, request triggerFireRequest) (
 	if err != nil {
 		return "", "", err
 	}
-	identity := fmt.Sprintf("git:%s:%s:%s:%s:%s", commit, proposalPath, wfe.Hash(content),
-		request.Pipeline, request.Mode)
+	proposalHash := wfe.Hash(content)
+	identity := db1.GitProposalIdentity(proposalHash, request.Pipeline, request.Mode)
+	if existing, findErr := s.db.WorkItemByGitProposal(ctx, workspace, proposalHash, request.Pipeline, request.Mode); findErr == nil {
+		return "", "", fmt.Errorf("proposal already filed as %s", existing.ID)
+	} else if !errors.Is(findErr, sql.ErrNoRows) {
+		return "", "", findErr
+	}
 	workItemID, err := mintWorkItemID()
 	if err != nil {
 		return "", "", err

--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -288,6 +288,29 @@ SELECT work_item_id FROM lifecycle_work_item WHERE repo = ? AND proposal_path = 
 	return s.WorkItem(ctx, id)
 }
 
+func GitProposalIdentity(proposalHash, workflow, mode string) string {
+	return fmt.Sprintf("git:%s:%s:%s", proposalHash, workflow, mode)
+}
+
+// WorkItemByGitProposal finds both the current blob-based trigger identity and
+// the older commit-qualified identity. A proposal that has not changed must not
+// be filed again merely because its watched branch advanced.
+func (s *Store) WorkItemByGitProposal(ctx context.Context, repo, proposalHash, workflow, mode string) (WorkItem, error) {
+	identity := GitProposalIdentity(proposalHash, workflow, mode)
+	legacySuffix := fmt.Sprintf(":%s:%s:%s", proposalHash, workflow, mode)
+	var id string
+	if err := s.db.QueryRowContext(ctx, `
+SELECT work_item_id FROM lifecycle_work_item
+WHERE repo = ? AND parent_id = '' AND
+      (proposal_path = ? OR
+       (substr(proposal_path, 1, 4) = 'git:' AND
+        substr(proposal_path, -length(?)) = ?))
+ORDER BY id LIMIT 1`, repo, identity, legacySuffix, legacySuffix).Scan(&id); err != nil {
+		return WorkItem{}, fmt.Errorf("find work item by git proposal: %w", err)
+	}
+	return s.WorkItem(ctx, id)
+}
+
 func (s *Store) WorkItems(ctx context.Context) ([]WorkItem, error) {
 	rows, err := s.db.QueryContext(ctx, `
 SELECT work_item_id, repo, proposal_path, workflow_name, workflow_version, current_stage,

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -82,6 +82,28 @@ func TestConcurrentRootAdmissionNeverExceedsCap(t *testing.T) {
 	}
 }
 
+func TestWorkItemByGitProposalMatchesCommitQualifiedLegacyIdentity(t *testing.T) {
+	store := newTestStore(t)
+	legacy := "git:" + strings.Repeat("a", 40) + ":docs/proposals/pending/p.md:" + strings.Repeat("b", 64) + ":build:autonomous"
+	if err := store.CreateWorkItem(context.Background(), CreateWorkItem{
+		ID: "wi_legacy_git", Repo: "repo", ProposalPath: legacy,
+		WorkflowName: "build", StartStage: "draft",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	item, err := store.WorkItemByGitProposal(context.Background(), "repo", strings.Repeat("b", 64), "build", "autonomous")
+	if err != nil || item.ID != "wi_legacy_git" {
+		t.Fatalf("legacy lookup item=%+v err=%v", item, err)
+	}
+}
+
+func TestGitProposalIdentityPinsBlobWorkflowAndMode(t *testing.T) {
+	if got, want := GitProposalIdentity(strings.Repeat("b", 64), "build", "autonomous"),
+		"git:"+strings.Repeat("b", 64)+":build:autonomous"; got != want {
+		t.Fatalf("identity=%q want=%q", got, want)
+	}
+}
+
 func TestParkedRootStillConsumesAdmissionCapacity(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- make git proposal trigger identity independent of moving branch commits
- recognize legacy commit-qualified identities already stored on appliances
- keep workflow and mode in the canonical identity
- cover moving-ref dedup and changed-blob admission

## Verification
- go test ./...
- go test -race ./internal/api ./internal/db1
- go vet ./...
- roundtable convergence review: no surviving issues