### PR TITLE
Fix orphaned unassigned delegate leases

### DIFF
--- a/frontend/src/pages/WorkflowActions.tsx
+++ b/frontend/src/pages/WorkflowActions.tsx
@@ -635,7 +635,7 @@ export default function WorkflowActions() {
 // workflows start and how far each one drives (trigger -> PR). Kept here under
 // Workflows because that is exactly what they tune. Config-backed + live; exported
 // Values saved here are the live runtime authority.
-const RUN_POLICY_FIELDS: { key: string; label: string; help: string; kind: "int" | "bool" }[] = [
+const RUN_POLICY_FIELDS: { key: string; label: string; help: string; kind: "int" | "bool"; min?: number; max?: number }[] = [
   {
     key: "trigger.max_concurrent",
     label: "Trigger admission cap",
@@ -683,6 +683,14 @@ const RUN_POLICY_FIELDS: { key: string; label: string; help: string; kind: "int"
     label: "Concurrency",
     kind: "int",
     help: "Max autonomous runs driven concurrently per scheduler sweep. Default 2.",
+  },
+  {
+    key: "autonomy.delegate_pending_secs",
+    label: "Unassigned delegate lease (s)",
+    kind: "int",
+    min: 2,
+    max: 3600,
+    help: "Seconds an admitted delegate job may remain pending without an assigned eligible agent before it is cancelled and safely retried. Live range 2–3600; default 120.",
   },
 ];
 
@@ -739,6 +747,8 @@ function RunPolicyPanel() {
                   ) : (
                     <input
                       type="number"
+                      min={f.min}
+                      max={f.max}
                       defaultValue={Number(cfg?.[f.key] ?? 0)}
                       style={{
                         width: 90,
@@ -748,7 +758,16 @@ function RunPolicyPanel() {
                       }}
                       onBlur={(e) => {
                         const v = parseInt(e.target.value, 10);
-                        if (!Number.isNaN(v) && v !== Number(cfg?.[f.key])) save(f.key, v);
+                        const inRange =
+                          !Number.isNaN(v) &&
+                          (f.min === undefined || v >= f.min) &&
+                          (f.max === undefined || v <= f.max);
+                        if (!inRange) {
+                          setErr(`${f.label} must be between ${f.min ?? 0} and ${f.max ?? "the supported maximum"}.`);
+                          e.currentTarget.value = String(cfg?.[f.key] ?? 0);
+                          return;
+                        }
+                        if (v !== Number(cfg?.[f.key])) save(f.key, v);
                       }}
                     />
                   )}

--- a/server-go/cmd/aimee-server/main.go
+++ b/server-go/cmd/aimee-server/main.go
@@ -102,7 +102,13 @@ func main() {
 			log.Fatal(err)
 		}
 	} else if *agentURL != "" || *agentSocket != "" {
-		agents, clientErr := engine.NewHTTPAgentClient(engine.AgentHTTPConfig{BaseURL: *agentURL, UnixSocket: *agentSocket, Bearer: *agentBearer, Store: store})
+		agents, clientErr := engine.NewHTTPAgentClient(engine.AgentHTTPConfig{
+			BaseURL: *agentURL, UnixSocket: *agentSocket, Bearer: *agentBearer, Store: store,
+			PendingTimeoutSource: func() time.Duration {
+				return time.Duration(configStore.Int("autonomy.delegate_pending_secs", 120)) * time.Second
+			},
+			CancelUnassigned: store.CancelUnassignedDelegateJob,
+		})
 		if clientErr != nil {
 			log.Fatal(clientErr)
 		}

--- a/server-go/internal/config/store.go
+++ b/server-go/internal/config/store.go
@@ -95,6 +95,7 @@ var policyDefaults = map[string]any{
 	"autonomy.max_resumes":           50,
 	"autonomy.stale_abandon_secs":    3600,
 	"autonomy.concurrency":           2,
+	"autonomy.delegate_pending_secs": 120,
 }
 
 var configurableTypes = map[string]string{
@@ -102,7 +103,14 @@ var configurableTypes = map[string]string{
 	"trigger.scan_interval_secs": "int",
 	"autonomy.max_wall_secs":     "int", "autonomy.max_turns": "int",
 	"autonomy.max_resumes": "int", "autonomy.stale_abandon_secs": "int",
-	"autonomy.concurrency": "int",
+	"autonomy.concurrency":           "int",
+	"autonomy.delegate_pending_secs": "int",
+}
+
+type intBounds struct{ min, max int64 }
+
+var configurableIntBounds = map[string]intBounds{
+	"autonomy.delegate_pending_secs": {min: 2, max: 3600},
 }
 
 func (s *Store) Values() (map[string]any, error) {
@@ -322,6 +330,9 @@ func validateKeyValue(key string, value any) error {
 		n, ok := number(value)
 		if !ok || n < 0 {
 			return fmt.Errorf("%s must be a non-negative integer", key)
+		}
+		if bounds, bounded := configurableIntBounds[key]; bounded && (n < bounds.min || n > bounds.max) {
+			return fmt.Errorf("%s must be between %d and %d", key, bounds.min, bounds.max)
 		}
 	case "bool":
 		if _, ok := value.(bool); !ok {

--- a/server-go/internal/config/store_test.go
+++ b/server-go/internal/config/store_test.go
@@ -50,6 +50,15 @@ func TestPolicyProjectionIncludesRuntimeConcurrencyDefault(t *testing.T) {
 	if got := values["autonomy.concurrency"]; got != 2 {
 		t.Fatalf("autonomy.concurrency default=%v, want 2", got)
 	}
+	if got := values["autonomy.delegate_pending_secs"]; got != 120 {
+		t.Fatalf("autonomy.delegate_pending_secs default=%v, want 120", got)
+	}
+	if err := store.Set("autonomy.delegate_pending_secs", 1); err == nil {
+		t.Fatal("delegate lease below minimum accepted")
+	}
+	if err := store.Set("autonomy.delegate_pending_secs", 3601); err == nil {
+		t.Fatal("delegate lease above maximum accepted")
+	}
 }
 
 func TestEditableProjectionAndStructuralConflictsFailClosed(t *testing.T) {

--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -146,6 +146,23 @@ func (s *Store) ForgetDelegateJob(ctx context.Context, key string) error {
 	return err
 }
 
+// CancelUnassignedDelegateJob atomically reaps only a pending resource-plane job
+// that no agent has claimed. The predicate prevents a lease race from cancelling
+// work after assignment.
+func (s *Store) CancelUnassignedDelegateJob(ctx context.Context, jobID int, reason string) (bool, error) {
+	if jobID <= 0 {
+		return false, errors.New("delegate job id is required")
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE agent_jobs
+SET status='cancelled',cancelled_at=datetime('now'),cancel_reason=?,updated_at=datetime('now')
+WHERE id=? AND status='pending' AND trim(agent_name)=''`, reason, jobID)
+	if err != nil {
+		return false, fmt.Errorf("cancel unassigned delegate job: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	return changed == 1, err
+}
+
 func (s *Store) hasWorkItemColumn(ctx context.Context, wanted string) (bool, error) {
 	rows, err := s.db.QueryContext(ctx, `PRAGMA table_info(lifecycle_work_item)`)
 	if err != nil {

--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -155,7 +155,7 @@ func (s *Store) CancelUnassignedDelegateJob(ctx context.Context, jobID int, reas
 	}
 	result, err := s.db.ExecContext(ctx, `UPDATE agent_jobs
 SET status='cancelled',cancelled_at=datetime('now'),cancel_reason=?,updated_at=datetime('now')
-WHERE id=? AND status='pending' AND trim(agent_name)=''`, reason, jobID)
+WHERE id=? AND status='pending' AND agent_name=''`, reason, jobID)
 	if err != nil {
 		return false, fmt.Errorf("cancel unassigned delegate job: %w", err)
 	}

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -294,3 +294,34 @@ func TestChangedPlanOrFeedbackIsPositiveProgress(t *testing.T) {
 		}
 	}
 }
+
+func TestCancelUnassignedDelegateJobIsAtomicAndAssignmentSafe(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.db.Exec(`CREATE TABLE agent_jobs (
+		id INTEGER PRIMARY KEY, agent_name TEXT NOT NULL DEFAULT '', status TEXT NOT NULL,
+		cancelled_at TEXT DEFAULT '', cancel_reason TEXT DEFAULT '', updated_at TEXT DEFAULT '')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO agent_jobs(id,status,agent_name) VALUES
+		(41,'pending',''),(42,'pending','codex'),(43,'running','codex')`); err != nil {
+		t.Fatal(err)
+	}
+	cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), 41, "lease expired")
+	if err != nil || !cancelled {
+		t.Fatalf("cancel pending unassigned: cancelled=%v err=%v", cancelled, err)
+	}
+	for _, id := range []int{42, 43} {
+		cancelled, err = store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired")
+		if err != nil || cancelled {
+			t.Fatalf("job %d assignment guard: cancelled=%v err=%v", id, cancelled, err)
+		}
+	}
+	var status, reason string
+	if err := store.db.QueryRow(`SELECT status,cancel_reason FROM agent_jobs WHERE id=41`).Scan(&status, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if status != "cancelled" || reason != "lease expired" {
+		t.Fatalf("status=%q reason=%q", status, reason)
+	}
+}

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -304,14 +304,14 @@ func TestCancelUnassignedDelegateJobIsAtomicAndAssignmentSafe(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := store.db.Exec(`INSERT INTO agent_jobs(id,status,agent_name) VALUES
-		(41,'pending',''),(42,'pending','codex'),(43,'running','codex')`); err != nil {
+		(41,'pending',''),(42,'pending','codex'),(43,'running','codex'),(44,'pending',' ')`); err != nil {
 		t.Fatal(err)
 	}
 	cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), 41, "lease expired")
 	if err != nil || !cancelled {
 		t.Fatalf("cancel pending unassigned: cancelled=%v err=%v", cancelled, err)
 	}
-	for _, id := range []int{42, 43} {
+	for _, id := range []int{42, 43, 44} {
 		cancelled, err = store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired")
 		if err != nil || cancelled {
 			t.Fatalf("job %d assignment guard: cancelled=%v err=%v", id, cancelled, err)

--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -64,22 +64,35 @@ type AgentRosterClient interface {
 }
 
 type AgentHTTPConfig struct {
-	BaseURL        string
-	UnixSocket     string
-	Bearer         string
-	PollEvery      time.Duration
-	RequestTimeout time.Duration
-	Store          *db1.Store
+	BaseURL              string
+	UnixSocket           string
+	Bearer               string
+	PollEvery            time.Duration
+	RequestTimeout       time.Duration
+	PendingTimeout       time.Duration
+	PendingTimeoutSource func() time.Duration
+	CancelUnassigned     func(context.Context, int, string) (bool, error)
+	Store                *db1.Store
 }
+
+const (
+	MinDelegatePendingTimeout     = 2 * time.Second
+	DefaultDelegatePendingTimeout = 2 * time.Minute
+	MaxDelegatePendingTimeout     = time.Hour
+)
+
+var ErrDelegateUnassignedExpired = errors.New("unassigned delegate lease expired")
 
 // HTTPAgentClient talks to the agent service as a resource plane. It owns no
 // workflow state or transitions; losing it parks the Go-owned run and a later
 // scheduler pass can retry safely.
 type HTTPAgentClient struct {
-	baseURL, bearer string
-	client          *http.Client
-	pollEvery       time.Duration
-	store           *db1.Store
+	baseURL, bearer  string
+	client           *http.Client
+	pollEvery        time.Duration
+	pendingTimeout   func() time.Duration
+	cancelUnassigned func(context.Context, int, string) (bool, error)
+	store            *db1.Store
 }
 
 func NewHTTPAgentClient(cfg AgentHTTPConfig) (*HTTPAgentClient, error) {
@@ -111,8 +124,27 @@ func NewHTTPAgentClient(cfg AgentHTTPConfig) (*HTTPAgentClient, error) {
 	if cfg.RequestTimeout <= 0 {
 		cfg.RequestTimeout = 30 * time.Second
 	}
+	if cfg.PendingTimeout <= 0 {
+		cfg.PendingTimeout = DefaultDelegatePendingTimeout
+	}
+	timeoutSource := func() time.Duration { return cfg.PendingTimeout }
+	if cfg.PendingTimeoutSource != nil {
+		timeoutSource = cfg.PendingTimeoutSource
+	}
 	return &HTTPAgentClient{baseURL: strings.TrimRight(cfg.BaseURL, "/"), bearer: cfg.Bearer,
-		client: &http.Client{Transport: transport, Timeout: cfg.RequestTimeout}, pollEvery: cfg.PollEvery, store: cfg.Store}, nil
+		client: &http.Client{Transport: transport, Timeout: cfg.RequestTimeout}, pollEvery: cfg.PollEvery,
+		pendingTimeout: timeoutSource, cancelUnassigned: cfg.CancelUnassigned, store: cfg.Store}, nil
+}
+
+func (c *HTTPAgentClient) delegatePendingTimeout() time.Duration {
+	timeout := c.pendingTimeout()
+	if timeout < MinDelegatePendingTimeout {
+		timeout = MinDelegatePendingTimeout
+	}
+	if timeout > MaxDelegatePendingTimeout {
+		timeout = MaxDelegatePendingTimeout
+	}
+	return timeout
 }
 
 func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest) (DelegateResult, error) {
@@ -150,7 +182,14 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 	}
 	ticker := time.NewTicker(c.pollEvery)
 	defer ticker.Stop()
+	// A successful launch is initially unassigned until status proves otherwise.
+	// This also bounds jobs whose status endpoint never becomes readable.
+	unassignedSince := time.Now()
 	for {
+		if err := ctx.Err(); err != nil {
+			_ = c.cancelRemote(launched.JobID, ctx)
+			return DelegateResult{}, err
+		}
 		var status struct {
 			JobStatus string  `json:"job_status"`
 			Result    string  `json:"result"`
@@ -160,10 +199,37 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 		}
 		if err := c.doJSON(ctx, http.MethodPost, "/v1/delegate/status", map[string]any{"job_id": launched.JobID, "full_result": true, "result_limit": -1}, &status); err != nil {
 			if ctx.Err() != nil {
-				c.cancelRemote(launched.JobID, ctx)
+				_ = c.cancelRemote(launched.JobID, ctx)
 				return DelegateResult{}, ctx.Err()
 			}
+			// Once the resource plane has acknowledged that a job is waiting
+			// unassigned, transient status failures cannot extend its lease.
+			if !unassignedSince.IsZero() && time.Since(unassignedSince) >= c.delegatePendingTimeout() {
+				return DelegateResult{}, c.expireUnassigned(launched.JobID, key, unassignedSince)
+			}
+			if !unassignedSince.IsZero() {
+				select {
+				case <-ctx.Done():
+					_ = c.cancelRemote(launched.JobID, ctx)
+					return DelegateResult{}, ctx.Err()
+				case <-ticker.C:
+					continue
+				}
+			}
+			// An assigned observation clears the lease. Preserve its durable mapping
+			// when the status plane later fails so a retry cannot overlap the job.
 			return DelegateResult{}, err
+		}
+		// Pending with no assigned agent is not progress. Bound that resource-plane
+		// state while leaving assigned/running and terminal jobs untouched.
+		if status.JobStatus == "pending" && strings.TrimSpace(status.Agent) == "" {
+			if unassignedSince.IsZero() {
+				unassignedSince = time.Now()
+			} else if time.Since(unassignedSince) >= c.delegatePendingTimeout() {
+				return DelegateResult{}, c.expireUnassigned(launched.JobID, key, unassignedSince)
+			}
+		} else if strings.TrimSpace(status.Agent) != "" || isTerminalDelegateStatus(status.JobStatus) {
+			unassignedSince = time.Time{}
 		}
 		switch status.JobStatus {
 		case "done":
@@ -202,11 +268,46 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 			// The remote resource-plane job outlives an HTTP poll unless it is
 			// explicitly cancelled. Wait for the cancellation acknowledgement so
 			// a wall-cap resume cannot overlap the old job in the same worktree.
-			c.cancelRemote(launched.JobID, ctx)
+			_ = c.cancelRemote(launched.JobID, ctx)
 			return DelegateResult{}, ctx.Err()
 		case <-ticker.C:
 		}
 	}
+}
+
+func isTerminalDelegateStatus(status string) bool {
+	switch status {
+	case "done", "partial", "failed", "cancelled", "stopped", "invalid", "not_found":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *HTTPAgentClient) expireUnassigned(jobID int, key string, since time.Time) error {
+	if c.cancelUnassigned != nil {
+		cancelCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cancelled, err := c.cancelUnassigned(cancelCtx, jobID, "unassigned delegate lease expired")
+		cancel()
+		if err != nil {
+			return errors.Join(ErrDelegateUnassignedExpired, fmt.Errorf("cancel expired delegate job %d: %w", jobID, err))
+		}
+		if !cancelled {
+			return errors.Join(ErrDelegateUnassignedExpired,
+				fmt.Errorf("delegate job %d is no longer pending and unassigned; durable mapping retained", jobID))
+		}
+	} else if err := c.cancelRemote(jobID, context.Background()); err != nil {
+		return errors.Join(ErrDelegateUnassignedExpired, fmt.Errorf("cancel expired delegate job %d: %w", jobID, err))
+	}
+	if c.store != nil {
+		forgetCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := c.store.ForgetDelegateJob(forgetCtx, key)
+		cancel()
+		if err != nil {
+			return errors.Join(ErrDelegateUnassignedExpired, fmt.Errorf("forget expired delegate job %d: %w", jobID, err))
+		}
+	}
+	return fmt.Errorf("%w: job %d (%s) remained unassigned for %s", ErrDelegateUnassignedExpired, jobID, key, time.Since(since).Round(time.Millisecond))
 }
 
 func delegateJobKey(request DelegateRequest) string {
@@ -256,11 +357,11 @@ func (c *HTTPAgentClient) EligibleAgents(ctx context.Context, role string) ([]El
 	return eligible, nil
 }
 
-func (c *HTTPAgentClient) cancelRemote(jobID int, parent context.Context) {
+func (c *HTTPAgentClient) cancelRemote(jobID int, parent context.Context) error {
 	cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(parent), 10*time.Second)
 	defer cancel()
 	var ignored map[string]any
-	_ = c.doJSON(cancelCtx, http.MethodPost, "/v1/job/cancel",
+	return c.doJSON(cancelCtx, http.MethodPost, "/v1/job/cancel",
 		map[string]any{"job_id": jobID, "reason": "WFE turn cancelled"}, &ignored)
 }
 

--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -296,8 +296,9 @@ func (c *HTTPAgentClient) expireUnassigned(jobID int, key string, since time.Tim
 			return errors.Join(ErrDelegateUnassignedExpired,
 				fmt.Errorf("delegate job %d is no longer pending and unassigned; durable mapping retained", jobID))
 		}
-	} else if err := c.cancelRemote(jobID, context.Background()); err != nil {
-		return errors.Join(ErrDelegateUnassignedExpired, fmt.Errorf("cancel expired delegate job %d: %w", jobID, err))
+	} else {
+		return errors.Join(ErrDelegateUnassignedExpired,
+			errors.New("Go unassigned-job cancellation authority is not configured; durable mapping retained"))
 	}
 	if c.store != nil {
 		forgetCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -3,9 +3,11 @@ package engine
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -123,6 +125,192 @@ func TestHTTPAgentClientReplaysAcceptedPartialIdempotently(t *testing.T) {
 	}
 	if launches.Load() != 1 {
 		t.Fatalf("accepted partial launched %d overlapping jobs", launches.Load())
+	}
+}
+
+func TestHTTPAgentClientExpiresUnassignedPendingJob(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var launches atomic.Int32
+	var cancellations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			launches.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 17})
+		case "/v1/delegate/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "pending", "agent_name": ""})
+		case "/v1/job/cancel":
+			cancellations.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
+		PollEvery: time.Millisecond, PendingTimeout: 20 * time.Millisecond,
+		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+			cancellations.Add(1)
+			return true, nil
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review",
+		WorkItemID: "wi_pending", Stage: "gate", ExecutionVersion: "v1"}
+	if _, err := client.Delegate(t.Context(), request); err == nil || !errors.Is(err, ErrDelegateUnassignedExpired) || !strings.Contains(err.Error(), "remained unassigned") {
+		t.Fatalf("unassigned pending job did not return structured expiry: %v", err)
+	}
+	if launches.Load() != 1 || cancellations.Load() != 1 {
+		t.Fatalf("launches=%d cancellations=%d", launches.Load(), cancellations.Load())
+	}
+	if _, err := store.DelegateJob(t.Context(), delegateJobKey(request)); err == nil {
+		t.Fatal("expired pending job retained its durable mapping")
+	}
+	if _, err := client.Delegate(t.Context(), request); err == nil {
+		t.Fatal("replayed unassigned pending job did not expire")
+	}
+	if launches.Load() != 2 {
+		t.Fatalf("expired mapping replayed old job; launches=%d", launches.Load())
+	}
+}
+
+func TestHTTPAgentClientDoesNotExpireAssignedJob(t *testing.T) {
+	var polls atomic.Int32
+	var cancellations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 18})
+		case "/v1/delegate/status":
+			switch polls.Add(1) {
+			case 1:
+				_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "pending", "agent_name": ""})
+			case 2:
+				_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "running", "agent_name": "codex"})
+			default:
+				_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "done", "agent_name": "codex", "result": "complete"})
+			}
+		case "/v1/job/cancel":
+			cancellations.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL,
+		PollEvery: time.Millisecond, PendingTimeout: 2 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.Delegate(t.Context(), DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review"})
+	if err != nil || result.Response != "complete" || result.Agent != "codex" {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	if cancellations.Load() != 0 {
+		t.Fatalf("assigned job was cancelled %d times", cancellations.Load())
+	}
+}
+
+func TestHTTPAgentClientExpiresAfterTransientStatusFailures(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var polls atomic.Int32
+	var cancellations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 19})
+		case "/v1/delegate/status":
+			if polls.Add(1) == 1 {
+				_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "pending", "agent_name": ""})
+				return
+			}
+			http.Error(w, "temporary", http.StatusServiceUnavailable)
+		case "/v1/job/cancel":
+			cancellations.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
+		PollEvery: time.Millisecond, PendingTimeout: 20 * time.Millisecond,
+		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+			cancellations.Add(1)
+			return true, nil
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review",
+		WorkItemID: "wi_transient", Stage: "gate", ExecutionVersion: "v1"}
+	if _, err := client.Delegate(t.Context(), request); err == nil || !strings.Contains(err.Error(), "remained unassigned") {
+		t.Fatalf("transient status failures escaped lease: %v", err)
+	}
+	if cancellations.Load() != 1 {
+		t.Fatalf("cancellations=%d, want 1", cancellations.Load())
+	}
+	if _, err := store.DelegateJob(t.Context(), delegateJobKey(request)); err == nil {
+		t.Fatal("expired job retained mapping after transient status failures")
+	}
+}
+
+func TestHTTPAgentClientRetainsMappingWhenExpiryCancellationFails(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/job/cancel" {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
+		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+			return false, errors.New("agent job database unavailable")
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const key = "durable-key"
+	if err := store.SaveDelegateJob(t.Context(), key, 20); err != nil {
+		t.Fatal(err)
+	}
+	if err := client.expireUnassigned(20, key, time.Now()); err == nil || !errors.Is(err, ErrDelegateUnassignedExpired) {
+		t.Fatalf("failed cancellation lost structured expiry: %v", err)
+	}
+	if jobID, err := store.DelegateJob(t.Context(), key); err != nil || jobID != 20 {
+		t.Fatalf("mapping after failed cancel: job=%d err=%v", jobID, err)
+	}
+}
+
+func TestDelegatePendingTimeoutClampsLiveSource(t *testing.T) {
+	timeout := time.Second
+	client := &HTTPAgentClient{pendingTimeout: func() time.Duration { return timeout }}
+	if got := client.delegatePendingTimeout(); got != MinDelegatePendingTimeout {
+		t.Fatalf("minimum clamp=%s", got)
+	}
+	timeout = 2 * time.Hour
+	if got := client.delegatePendingTimeout(); got != MaxDelegatePendingTimeout {
+		t.Fatalf("maximum clamp=%s", got)
+	}
+	timeout = 3 * time.Minute
+	if got := client.delegatePendingTimeout(); got != timeout {
+		t.Fatalf("in-range timeout=%s", got)
 	}
 }
 


### PR DESCRIPTION
Moves unassigned-delegate lease authority into the Go WFE control plane.

- atomically cancels only pending jobs with no assigned agent
- retains durable mappings whenever cancellation is uncertain
- bounds unreadable and unassigned launches with a live GUI-backed 2–3600 second policy
- preserves assigned/running jobs and idempotent replay
- adds Go DB/engine and frontend regression coverage

Roundtable review: multiple two-round passes completed; concrete findings incorporated. Provider subscription/capacity failures degraded seat count without excluding eligible agents.

Verification: go test ./..., go test -race ./internal/db1 ./internal/engine, go vet ./..., npm run check, npm test (93 tests), git diff --check.