### PR TITLE
Enforce individual module documentation

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -78,6 +78,10 @@ jobs:
         run: python3 -I scripts/tests/test_refactor_baselines.py -v
       - name: Test cleanup-ledger failure modes
         run: python3 -I scripts/tests/test_check_cleanup_ledger.py -v
+      - name: Enforce individual module documentation
+        run: python3 -I -S scripts/check_module_docs.py
+      - name: Test module-documentation failure modes
+        run: python3 -I scripts/tests/test_check_module_docs.py -v
 
   git-core-contract:
     name: git-core-contract

--- a/docs/modules/module-runtime.md
+++ b/docs/modules/module-runtime.md
@@ -1,103 +1,96 @@
-# Module-runtime module
+# module-runtime module
 
-## Purpose and classification
+## Purpose and non-goals
 
-Module-runtime is required core and the dependency root for module contracts. It owns contracts
-that required Aimee execution must provide whether or not any optional module is selected. Its
-extension ABI is implemented at `src/modules/module-runtime/extension.c`, with the canonical header
-`src/modules/module-runtime/include/aimee/module-runtime/extension.h`. Its synchronous pre-LLM hook
-registry is at
-`src/modules/module-runtime/pre_llm_hook.c`, with its public contract at
-`src/modules/module-runtime/include/aimee/module-runtime/pre_llm_hook.h`.
+Module-runtime is required core and the dependency root for module contracts. It owns the extension
+types and bounded in-process registries in `src/modules/module-runtime/extension.c`, plus the
+synchronous pre-LLM hook registry in `src/modules/module-runtime/pre_llm_hook.c`. It does not parse
+plugin manifests, persist plugin state, scan directories, or dynamically load libraries; those
+responsibilities belong to [plugin-loader](plugin-loader.md#purpose-and-non-goals).
 
-It ships in every build profile. The optional `plugin-loader` module defaults to disabled and
-depends on module-runtime; module-runtime has no dependency on plugin-loader.
+## Public contracts
 
-These ownership slices do not change configuration or activation semantics.
-
-## Extension ABI and registries
-
-The required extension contract defines the kind and permission taxonomies, their stable string
-vocabulary, typed contribution records,
-`plugin_ctx_t`, context lifecycle, and process-local registries. `plugin_ctx_create` installs the
-typed registration callbacks, and `plugin_ctx_destroy` runs the registered shutdown callback.
-Tool and hook callbacks write to bounded module-runtime registries instead of the legacy no-op
-placeholders. Memory-provider and context-engine callbacks are deliberately unset by the dependency
-root and are installed by plugin-loader only when it creates a dynamic-plugin context.
-The canonical implementation, optional loader contract, and focused test consume it through
-`src/modules/module-runtime/extension.c`,
-`src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h`, and
-`src/tests/test_plugin.c`.
-
-Module-runtime does not parse manifests, persist installed-plugin state, inspect plugin directories,
-or call `dlopen`. Those optional responsibilities belong to plugin-loader, which depends on this
-contract. The required side has no include or symbol dependency on plugin-loader.
-
-Concurrent registry mutation is unsupported. Extensions register during single-threaded startup,
-and consumers read the process-global typed registries only after initialization. Adding concurrent
-registration requires synchronization or a snapshot API before changing that lifecycle contract.
-Slash and CLI commands use the existing process-global command registries and the same 64-entry
-capacity they had before this ownership move.
-
-## Pre-LLM hook contract
-
-The contract preserves the existing `plugin_chook_*` compatibility symbols:
-
-- `plugin_chook_register_pre_llm` registers a callback and opaque caller value.
-- `plugin_chook_run_pre_llm` runs callbacks in registration order and joins accepted output.
-- `plugin_chook_apply_pre_llm` returns a new user-message buffer only when context was produced.
-- `plugin_chook_reset` clears process-local state for tests.
-- `plugin_chook_pre_llm_count` reports the registered callback count.
-
-The retained names are compatibility vocabulary, not plugin-loader ownership. The canonical include
-is `aimee/module-runtime/pre_llm_hook.h`.
+`src/modules/module-runtime/include/aimee/module-runtime/extension.h` exports `plugin_ctx_create`,
+`plugin_ctx_destroy`, kind/permission conversion, and the typed `plugin_*_register` and
+`plugin_*_count` APIs. The canonical
+`src/modules/module-runtime/include/aimee/module-runtime/pre_llm_hook.h` exports
+`plugin_chook_register_pre_llm`,
+`plugin_chook_run_pre_llm`, `plugin_chook_apply_pre_llm`, `plugin_chook_reset`, and
+`plugin_chook_pre_llm_count`. The `plugin_*` spelling is retained compatibility vocabulary; it does
+not transfer ownership to plugin-loader.
+The optional contract consumer is
+`src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h`.
 
 ## Dependencies and consumers
 
-The implementation uses only the C runtime and required logging. Its production consumer is
-`src/server/agent_runtime.c`; its focused test is `src/tests/test_plugin_c_hook.c`. The implementation
-itself is `src/modules/module-runtime/pre_llm_hook.c`. It does not include or link plugin-loader,
-plugin manifests, `plugin_t`, install state, or dynamic loading.
+The descriptor declares no module dependencies. The implementation uses C runtime allocation and
+the shared logging primitive. Production consumers include `src/server/agent_runtime.c` and the
+optional plugin-loader contract; focused consumers are `src/tests/test_plugin.c` and
+`src/tests/test_plugin_c_hook.c`.
 
-## Lifecycle and concurrency
+## Providers and readiness
 
-The registry is process-local, fixed-capacity state. Registration order is execution order. The
-current implementation provides no locking, unregister operation, or per-session registry, so
-registration and reset must not race hook execution. These are current contract limits, not future
-concurrency guarantees.
+`module-runtime` is its own required reference implementation and has no replaceable provider.
+Registries are ready after process initialization. Registration is single-threaded startup work;
+concurrent mutation and unload are not supported.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; module-runtime is present in every profile and exposes no
+  enable switch.
+
+It owns no configuration keys. The optional loader may populate runtime registries, but disabling
+that loader does not disable this module.
+
+## Surfaces
+
+The module exposes `C` headers and symbols only. It owns no CLI command, HTTP route, protocol
+listener, dashboard, static asset, metric namespace, or background job. Runtime/plugin loading
+management surfaces are documented by [plugin-loader](plugin-loader.md#surfaces).
+
+## Data and migrations
+
+All `module-runtime` state is fixed-capacity, process-local registry state. The module owns no file, database table,
+schema, migration, or durable compatibility record.
 
 ## Security and privacy
 
-Callbacks receive only the current user message, an output buffer, and their opaque value. The
-system prompt is not present in the callback type, is not passed by
-`plugin_chook_apply_pre_llm`, and is not logged by this module. Accepted callback output is appended
-to the user message as ephemeral context; callers remain responsible for treating that text as
-untrusted extension output.
+`plugin_chook_apply_pre_llm` callbacks receive the current user message, an output buffer, and opaque caller data; the
+system prompt is not in the callback type. Accepted output becomes untrusted ephemeral context.
+Callers remain responsible for authorization and for preventing sensitive data from being exposed
+to extensions.
 
-## Failure behavior and diagnostics
+## Supported journeys
 
-Null callbacks and registrations beyond the fixed capacity fail. A callback error or empty output
-is skipped without aborting the remaining callbacks. Output is bounded by caller-provided buffers.
-Registration and capacity failures use the existing module log messages; the ownership move adds no
-new route, command, metric, or configuration key.
+Required startup exposes the typed extension API and registries even when every optional module is
+omitted. Agent execution can then run registered `plugin_chook_*` pre-LLM callbacks in order.
+Callers create `plugin_ctx_t` instances when needed; selected plugin-loader creates such a context
+and populates these required registries rather than creating a parallel registry implementation.
 
-## Tests and compatibility
+## Tests and failure behavior
 
-`unit-test-plugin-c-hook` covers empty state, single and multiple callbacks, empty and error results,
-per-turn behavior, capacity, null registration, user-message delivery, reset, and count. Make and
-CMake continue to compile the implementation unconditionally as required core. All exported symbol
-names and signatures remain unchanged; only the owned source path, header path, object path, and
-in-tree include spelling change.
+`unit-test-plugin` covers context lifecycle and typed registration. `unit-test-plugin-c-hook` covers
+empty state, ordering, error/empty results, bounded capacity, reset, count, and per-turn message
+application. Null or excess registrations fail; a failing callback is skipped and later callbacks
+still run. Output is bounded by the caller-provided buffer.
 
-## Migration status
+## Operational diagnostics
 
-The legacy `src/plugin_c_hook.c` and `src/headers/plugin_c_hook.h` paths are retired without a
-forwarding header because the repository has no installed-header export for this contract. The
-shared guard at `scripts/check_module_source_ownership.py` enforces canonical ownership for this and
-the preceding plugin-loader move without duplicating a checker per module.
+Registration and capacity failures use existing `module-runtime` log messages. There is no module-specific
+health route or metric. Diagnosis therefore relies on startup logs, focused unit tests, and the
+plugin-loader profile absence check.
 
-The legacy `plugin.c`/`plugin.h` mix is split by ownership. The unreferenced `plugin_ctx.c` and
-`plugin_ctx.h` wrapper island was removed after call-site, build-manifest, and installed-header
-inventory found no consumer; the required `plugin_ctx_create` and `plugin_ctx_destroy` symbols remain
-in this module. The plugin-loader profile now omits the optional loader while preserving these
-required contracts.
+## Compatibility
+
+Exported names and signatures remain unchanged from the former root-level plugin contract. The
+legacy `src/plugin_c_hook.c`, `src/headers/plugin_c_hook.h`, `src/plugin_ctx.c`, and
+`src/headers/plugin_ctx.h` paths are retired without forwarding headers because no installed-header
+manifest exported them. `scripts/check_module_source_ownership.py` rejects their reappearance.
+
+## Extension and removal
+
+New registry kinds or callbacks must update the canonical headers, implementation, consumers,
+tests, descriptor, and this document together. The removed `plugin_ctx_*_ex` wrapper island had no
+consumer outside itself and must not be recreated. A future unload path must synchronize registry
+access and invoke shutdown before library unload. Removing module-runtime is impossible without
+breaking the required module architecture and core agent round trip.

--- a/docs/modules/plugin-loader.md
+++ b/docs/modules/plugin-loader.md
@@ -1,131 +1,111 @@
-# Plugin-loader module
+# plugin-loader module
 
 ## Purpose and non-goals
 
-Plugin-loader discovers plugin manifests in bundled, user, and project directories, merges
-same-named entries by precedence, checks required environment variables, and asks the existing
-plugin runtime to load enabled entries. Its owned implementation is
-`src/modules/plugin-loader/plugin_loader.c`; its public discovery header lives at
-`src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h` and is included as
-`aimee/plugin-loader/plugin_loader.h`.
-
-This module does not own the core extension ABI, extension registries, or pre-LLM hook contract.
-It does own optional plugin manifest persistence, management commands, and dynamic loading. The
-manifest implementation is `src/modules/plugin-loader/plugin.c`; its canonical contract is
-`src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h`, included as
-`aimee/plugin-loader/plugin.h`.
-
-## Classification and link profile
-
-The descriptor at `src/modules/plugin-loader/module.yaml` classifies the module as optional and
-default-disabled. Make selects it with `AIMEE_WITH_PLUGIN_LOADER=1` (or omits it with `0`); CMake
-uses `-DAIMEE_WITH_PLUGIN_LOADER=ON|OFF`. Both default to disabled.
-
-The disabled profile omits the loader sources and the plugin-management command and server handler
-translation units. Startup discovery, manifest hook/tool aggregation, CLI/HTTP routes, and dashboard
-surfaces are compiled out, including their generated OpenAPI entries. The web GUI also hides its
-plugin drawer when its capability probe gets the absent-route response. The required extension ABI
-remains available from module-runtime. See `docs/validation/core-modularization-slice-11.md` for the
-complete disabled-surface proof.
+`plugin-loader` is the optional, default-disabled implementation for manifest discovery, installed-state
+management, and dynamic-library loading at `src/modules/plugin-loader/plugin_loader.c` and
+`src/modules/plugin-loader/plugin.c`. It does not own extension types, typed registries, or the
+pre-LLM hook contract; those remain required in
+[module-runtime](module-runtime.md#purpose-and-non-goals). It does not provide runtime unload.
 
 ## Public contracts
 
-The discovery header exports three functions:
-
-- `plugin_loader_set_install_prefix` selects the bundled-plugin prefix.
-- `plugin_loader_scan_dir` parses plugin subdirectories into caller-owned `plugin_t` storage.
-- `plugin_loader_discover_all` discovers, filters, and registers plugins without making individual
-  plugin failures fatal to server startup.
-
-`plugin_load_and_register` is documented under the optional contract in
-`aimee/plugin-loader/plugin.h`; it is the only entry point that installs bridges and invokes
-`on_init`, and it does not invoke `on_shutdown` in this slice.
-
-The discovery header includes the canonical loader contract for `plugin_t`, manifest parsing, and
-load registration. That contract depends one-way on `aimee/module-runtime/extension.h`;
-module-runtime never includes plugin-loader.
+`src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h` exports
+`plugin_loader_set_install_prefix`, `plugin_loader_scan_dir`, and `plugin_loader_discover_all`.
+`src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h` exports manifest parsing,
+installed-registry operations,
+install/enable/remove, hook/tool aggregation, conflict checks, `plugin_manifest_parse`, and
+`plugin_load_and_register`. It consumes the required `plugin_permission_name` and
+`plugin_permission_from_str` vocabulary.
+Loader types consume `aimee/module-runtime/extension.h` one way; module-runtime never includes this
+module.
 
 ## Dependencies and consumers
 
-The implementation consumes configuration, Aimee home-path resolution, logging, manifest parsing,
-load-registration contracts, and the memory-provider/context-engine registration bridges it
-installs on dynamic-plugin contexts. Direct consumers of the relocated header are the implementation
-itself, Aimee Runtime startup in `src/server/server_main.c`, and the focused loader test in
-`src/tests/test_plugin_loader.c`. The server include and discovery call are both guarded by
-`AIMEE_WITH_PLUGIN_LOADER`, so the disabled profile has no required-to-optional compile or link edge.
+- `audit`: records governed plugin-management actions through the core audit contract.
+- `config`: supplies Aimee paths and loader-related environment/config state.
+- `execution-policy`: guards plugin management and execution decisions.
+- `memory`: supplies the memory-provider bridge installed on a dynamic extension context.
+- `module-runtime`: owns the required extension ABI and registries populated by the loader.
+- `response-composition`: supplies the context-engine bridge installed by the loader.
 
-The descriptor therefore declares the required `memory` and `response-composition` dependencies in
-addition to `module-runtime`, configuration, execution policy, and audit.
+Consumers are guarded Runtime startup in `src/server/server_main.c`, guarded CLI/server/dashboard
+management surfaces, and the focused plugin tests. A disabled build has no required-to-optional
+compile or link edge.
+
+## Providers and readiness
+
+The in-tree `plugin-loader` manifest/dynamic-library implementation is the reference provider. Readiness is
+compile-time selection plus successful startup discovery; individual malformed or unloadable
+plugins do not make Runtime startup fail. There is no alternate loader provider or hot-unload
+provider.
 
 ## Configuration and activation
 
-This source move adds no settings and changes no defaults. `AIMEE_INSTALL_PREFIX` remains the
-fallback bundled-plugin prefix. Project-local discovery remains gated by
-`AIMEE_ENABLE_PROJECT_PLUGINS`; a missing or `0` value skips that source. User and bundled discovery
-retain their existing behavior. Individual entries must already be enabled before they are loaded.
+- `runtime_toggle.supported`: `false`; loader selection is compile-time and process-lifetime.
 
-## Discovery order and data
+Make enables it with `AIMEE_WITH_PLUGIN_LOADER=1`; CMake uses
+`-DAIMEE_WITH_PLUGIN_LOADER=ON`. Both default off. `AIMEE_INSTALL_PREFIX` selects the bundled
+prefix, and `AIMEE_ENABLE_PROJECT_PLUGINS` gates project-local discovery. Individual manifest
+entries must also be enabled before loading.
 
-Discovery visits bundled plugins, then user plugins, then project plugins. Later sources replace an
-earlier same-named entry. Plugin manifests and the in-memory `plugin_t` representation are owned
-here; this split does not introduce a new persistence format or migration.
+## Surfaces
+
+When selected, the module provides the `plugin` CLI command, plugin-management HTTP/OpenAPI routes,
+dashboard endpoints, the GUI plugin drawer, and manifest-provided hook/tool registrations. When
+omitted, the disabled profile has none of those surfaces and the GUI hides the drawer after capability probing.
+The exact absence proof is in `docs/validation/core-modularization-slice-11.md`.
+
+## Data and migrations
+
+The module owns plugin manifests and `plugins/installed.json` under the configured Aimee directory.
+Disabling it neither reads nor deletes that state; re-enabling reads it again. Discovery precedence
+is bundled, user, then project, with later same-name entries replacing earlier ones. No schema or
+data migration is introduced by the ownership split.
 
 ## Security and privacy
 
-Project discovery stays opt-in because project content is less trusted than bundled or user-owned
-content. Missing required environment variables cause an entry to be skipped. Dynamic-loading,
-permission, execution-policy, and audit enforcement are not redesigned here. The management entry
-points and their existing server/dashboard authorization guards are unchanged by the source move.
-OIDC and SSHSIG module documentation attestation are separate governance hardening and do not gate
-this physical move.
+`AIMEE_ENABLE_PROJECT_PLUGINS` makes project discovery opt-in because project content is less trusted. Missing required environment
+variables cause an entry to be skipped. Core execution-policy, audit, and required runtime
+contracts remain authoritative; loader omission cannot weaken those core controls. Dynamic plugin
+code shares the Runtime process and must therefore be treated as trusted executable code.
 
-## Failure behavior and diagnostics
+## Supported journeys
 
-An absent discovery directory is an empty result. An allocation failure reports an error and lets
-startup continue without discovered plugins. A malformed manifest is logged and skipped. Missing
-required environment variables and load failures are logged per plugin; discovery continues and
-summarizes load failures for the caller.
+An enabled build discovers manifests, filters disabled or unsatisfied entries, creates a
+module-runtime context, installs memory/context bridges, loads the library, registers contributions,
+and invokes `on_init`. Operators can inspect and manage installed entries through the guarded CLI,
+HTTP, dashboard, and GUI surfaces. A default build runs the unrelated core journeys without any
+loader object or surface.
 
-## Tests
+## Tests and failure behavior
 
-`unit-test-plugin-loader` covers empty and missing directories, manifest discovery, precedence,
-capacity limits, required-environment handling, and project-plugin gating.
-`scripts/check_module_source_ownership.py` separately proves the old source and header are gone,
-the exact canonical files exist, Make and CMake each compile one canonical source, the Make test
-graph uses its canonical object, and every header consumer uses the canonical include.
+`unit-test-plugin-loader` at `src/tests/test_plugin_loader.c` covers missing/empty directories,
+parsing, precedence, capacity,
+environment requirements, and project gating. `unit-test-plugin` covers manifests, persistence,
+context registration, and loader lifecycle behavior in `src/tests/test_plugin.c`. Missing directories are empty results;
+malformed manifests, missing environment, and individual load failures are logged and skipped.
+Allocation failure reports an error while startup continues without discovered plugins.
 
-## Compatibility and migration gap
+## Operational diagnostics
 
-Symbols, function signatures, configuration, discovery order, and error handling are unchanged.
-This slice adds no installed public-header export; there is no forwarding header at
-`src/headers/plugin_loader.h`. Any future export or compatibility shim needs an explicit contract
-decision.
+`plugin-loader` startup logs report skipped manifests and load failures. The enabled/disabled profile gate checks
+objects, symbols, CLI, routes, OpenAPI, dashboards, and GUI capability behavior. There is no
+independent loader health endpoint and no runtime transition from absent to ready.
 
-The contract split is complete: `plugin_manifest_parse`, `plugin_load_and_register`, registry
-persistence, install/enable/remove, manifest hook/tool aggregation, and dynamic loading live here.
-Canonical consumers include `src/modules/plugin-loader/plugin.c`,
-`src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h`, and
-`src/tests/test_plugin.c`.
+## Compatibility
 
-The required runtime co-locates `plugin_permission_name` and `plugin_permission_from_str` with the
-permission enum. Plugin-loader consumes that stable vocabulary when reading and writing manifests.
-For dynamic libraries, plugin-loader sets identity and memory/context bridge callbacks before it
-invokes `register()`. If registration succeeds, plugin-loader invokes the plugin's `on_init`
-against the registered context. `on_shutdown` is the registered shutdown callback that
-`plugin_ctx_destroy` would invoke; in the current build, plugin-loader does not call
-`plugin_ctx_destroy` during normal operation, and plugin contexts and library handles remain alive
-for the process lifetime. No plugin unload path exists in this slice, so bridge code is never
-unloaded while a plugin can call it. A future unload-capable slice must invoke `on_shutdown` before
-destroying the context and calling `dlclose` on the handle.
+Manifest formats, registry paths, discovery order, symbol signatures, and stored state remain
+compatible with the former root-level implementation. No forwarding header exists for
+`src/headers/plugin_loader.h`; repository consumers use the canonical include. Required
+`plugin_*` ABI names live in module-runtime and are not evidence that this optional module is core.
 
-Disabling the loader does not read, migrate, or delete plugin manifests or the
-`plugins/installed.json` registry under the configured Aimee directory. That state remains dormant
-and is read again if a later build enables the loader.
+## Extension and removal
 
-## Extension and removal rules
-
-New discovery sources, public functions, or dependencies require updating the module descriptor,
-this document, `scripts/check_module_source_ownership.py`, and focused tests together. Removal from
-required binaries is not complete until the contract split and build-profile proof land. Ordinary
-module documentation and physical source extraction use normal review and CI; signed descriptor-v2
-attestations remain a separate governance program.
+New discovery sources, public functions, dependencies, settings, or surfaces must update the
+descriptor, both build systems, absence/profile tests, and this document. The loader currently
+keeps contexts and library handles for process lifetime and never calls `plugin_ctx_destroy` during
+normal operation; an unload-capable extension must call shutdown before `dlclose`. The old
+root-level sources and forwarding includes are forbidden by
+`scripts/check_module_source_ownership.py`. Removing this optional module must continue to preserve
+module-runtime and every unrelated core journey.

--- a/docs/validation/core-modularization-slice-13.md
+++ b/docs/validation/core-modularization-slice-13.md
@@ -1,0 +1,31 @@
+# Core modularization slice 13: individual module-documentation gate
+
+## Outcome
+
+This slice makes individual module documentation mechanically accountable without creating 24
+placeholder documents. The 26 production descriptors remain the module-ID authority.
+`tests/baselines/modules/documentation-status.yaml` partitions those IDs into substantive documents
+and explicit debt. The first substantive family is `module-runtime` plus `plugin-loader`.
+
+`scripts/check_module_docs.py` rejects malformed/duplicate descriptors, orphan or symlinked docs,
+status drift, missing or reordered sections, ungrounded/placeholder sections, duplicate bullets,
+path escapes/symlinks, and dependency/runtime-toggle claims (including boolean values) that
+disagree with the descriptor. Its stable report lists every module as `PASS` or `DEBT`.
+A document cannot exist while its module remains debt, so promotion requires a complete document and
+an explicit status change in one review.
+
+## Cleanup and scope
+
+The two existing documents were consolidated into the common thirteen-section contract. Repeated
+ownership prose at the runtime/plugin boundary became cross-links, while current lifecycle limits
+and removal candidates remain explicit. No production source, descriptor, build graph, route,
+configuration, or runtime behavior changes in this slice. The remaining 24 documents are real debt,
+not generated prose or stubs.
+
+## Verification
+
+- `python3 -I -S scripts/check_module_docs.py`
+- `python3 -I scripts/tests/test_check_module_docs.py -v`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+- `make -C src lint`
+- feature-branch pull-request CI

--- a/scripts/check_module_docs.py
+++ b/scripts/check_module_docs.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Validate the descriptor-driven individual module documentation catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MODULES = Path("src/modules")
+DEFAULT_DOCS = Path("docs/modules")
+DEFAULT_STATUS = Path("tests/baselines/modules/documentation-status.yaml")
+MODULE_ID = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+SECTIONS = (
+    "Purpose and non-goals",
+    "Public contracts",
+    "Dependencies and consumers",
+    "Providers and readiness",
+    "Configuration and activation",
+    "Surfaces",
+    "Data and migrations",
+    "Security and privacy",
+    "Supported journeys",
+    "Tests and failure behavior",
+    "Operational diagnostics",
+    "Compatibility",
+    "Extension and removal",
+)
+PLACEHOLDER = re.compile(
+    r"\b(?:TODO|TBD|PLACEHOLDER|pending|coming soon|not (?:yet )?documented|see module owner)\b",
+    re.IGNORECASE,
+)
+
+
+class DocError(ValueError):
+    """A closed module-documentation contract failure."""
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DocError(f"duplicate object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_unique_object)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DocError(f"cannot load {path}: {exc}") from exc
+
+
+def _string_list(value: object, field: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise DocError(f"{field} must be an array of strings")
+    if len(value) != len(set(value)):
+        raise DocError(f"{field} contains duplicates")
+    return value
+
+
+def _safe_path(root: Path, path: Path, label: str) -> Path:
+    absolute = Path(os.path.abspath(path))
+    try:
+        relative = absolute.relative_to(root)
+    except ValueError as exc:
+        raise DocError(f"{label} escapes config root: {absolute}") from exc
+    current = root
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            raise DocError(f"{label} contains symlink component: {current}")
+    return absolute
+
+
+def _reject_symlink_components(path: Path, label: str) -> None:
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        current /= part
+        if current.is_symlink():
+            raise DocError(f"{label} contains symlink component: {current}")
+
+
+def load_descriptors(root: Path, modules_dir: Path) -> dict[str, dict[str, object]]:
+    descriptors: dict[str, dict[str, object]] = {}
+    for path in sorted(modules_dir.glob("*/module.yaml")):
+        _safe_path(root, path, "module descriptor")
+        raw = _load_json(path)
+        if not isinstance(raw, dict):
+            raise DocError(f"{path}: descriptor must be an object")
+        module_id = raw.get("id")
+        if not isinstance(module_id, str) or not MODULE_ID.fullmatch(module_id):
+            raise DocError(f"{path}: invalid or missing module id")
+        if module_id in descriptors:
+            raise DocError(f"duplicate module id {module_id!r}")
+        expected_dir = path.parent.name
+        if module_id != expected_dir:
+            raise DocError(f"{path}: id {module_id!r} must match directory {expected_dir!r}")
+        dependencies = _string_list(raw.get("dependencies"), f"{path}: dependencies")
+        toggle = raw.get("runtime_toggle")
+        if (
+            not isinstance(toggle, dict)
+            or not toggle
+            or not all(isinstance(key, str) and type(value) is bool for key, value in toggle.items())
+        ):
+            raise DocError(f"{path}: runtime_toggle must map string keys to booleans")
+        raw["dependencies"] = dependencies
+        descriptors[module_id] = raw
+    if not descriptors:
+        raise DocError(f"no descriptors found under {modules_dir.relative_to(root)}")
+    return descriptors
+
+
+def load_status(path: Path, descriptor_ids: set[str]) -> tuple[set[str], set[str]]:
+    raw = _load_json(path)
+    if not isinstance(raw, dict) or set(raw) != {"schema_version", "substantive", "debt"}:
+        raise DocError(f"{path}: status keys must be schema_version, substantive, debt")
+    if type(raw["schema_version"]) is not int or raw["schema_version"] != 1:
+        raise DocError(f"{path}: schema_version must be integer 1")
+    substantive = set(_string_list(raw["substantive"], f"{path}: substantive"))
+    debt = set(_string_list(raw["debt"], f"{path}: debt"))
+    if substantive & debt:
+        raise DocError(f"{path}: substantive and debt sets overlap")
+    if substantive | debt != descriptor_ids:
+        missing = sorted(descriptor_ids - substantive - debt)
+        unknown = sorted((substantive | debt) - descriptor_ids)
+        raise DocError(f"{path}: status partition differs: missing={missing}, unknown={unknown}")
+    return substantive, debt
+
+
+def _sections(path: Path, module_id: str) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    first = next((line for line in text.splitlines() if line.strip()), "")
+    if first != f"# {module_id} module":
+        raise DocError(f"{path}: first non-blank line must be '# {module_id} module'")
+    headings = [(match.group(1), match.start(), match.end()) for match in re.finditer(r"^## (.+)$", text, re.MULTILINE)]
+    names = [name for name, _, _ in headings]
+    if names != list(SECTIONS):
+        raise DocError(f"{path}: required H2 sections differ or are out of order: {names}")
+    result = {}
+    for index, (name, _, end) in enumerate(headings):
+        next_start = headings[index + 1][1] if index + 1 < len(headings) else len(text)
+        body = text[end:next_start].strip()
+        compact = "".join(body.split())
+        if len(compact) < 80 or PLACEHOLDER.search(body) or "`" not in body:
+            raise DocError(f"{path}: section {name!r} lacks substantive grounded content")
+        result[name] = body
+    return result
+
+
+def _bullet_ids(body: str) -> list[str]:
+    found = []
+    for line in body.splitlines():
+        match = re.match(r"^- `([^`]+)`(?:\s|:|$)", line)
+        if match:
+            found.append(match.group(1))
+    return found
+
+
+def validate_doc(path: Path, descriptor: dict[str, object]) -> None:
+    module_id = descriptor["id"]
+    sections = _sections(path, module_id)
+    expected_deps = set(descriptor["dependencies"])
+    dependency_bullets = _bullet_ids(sections["Dependencies and consumers"])
+    if len(dependency_bullets) != len(set(dependency_bullets)):
+        raise DocError(f"{path}: duplicate dependency bullet")
+    actual_deps = set(dependency_bullets)
+    if actual_deps != expected_deps:
+        raise DocError(
+            f"{path}: dependency bullets differ: missing={sorted(expected_deps - actual_deps)}, "
+            f"undeclared={sorted(actual_deps - expected_deps)}"
+        )
+    toggle_body = sections["Configuration and activation"]
+    actual_toggles: dict[str, bool] = {}
+    toggle_bullets = re.findall(
+        r"^- `runtime_toggle\.([^`]+)`(.*)$", toggle_body, re.MULTILINE
+    )
+    toggle_keys = [key for key, _ in toggle_bullets]
+    duplicate_key = next((key for key in toggle_keys if toggle_keys.count(key) > 1), None)
+    if duplicate_key is not None:
+        raise DocError(f"{path}: duplicate runtime-toggle bullet {duplicate_key!r}")
+    for key, remainder in toggle_bullets:
+        claim_match = re.match(r"^: (.+)$", remainder)
+        if not claim_match:
+            raise DocError(f"{path}: malformed runtime-toggle value for {key!r}")
+        claim = claim_match.group(1)
+        value_match = re.match(r"`?(true|false)`?(?:[;.,:]|\s|$)", claim)
+        if not value_match:
+            raise DocError(f"{path}: malformed runtime-toggle value for {key!r}")
+        value = value_match.group(1)
+        actual_toggles[key] = value == "true"
+    expected_toggles = descriptor["runtime_toggle"]
+    if actual_toggles != expected_toggles:
+        raise DocError(
+            f"{path}: runtime-toggle bullets differ: expected={expected_toggles}, actual={actual_toggles}"
+        )
+
+
+def run(root: Path, modules: Path, docs: Path, status_path: Path) -> str:
+    root = Path(os.path.abspath(root))
+    _reject_symlink_components(root, "config root")
+    modules = _safe_path(root, modules, "modules path")
+    docs = _safe_path(root, docs, "docs path")
+    status_path = _safe_path(root, status_path, "status path")
+    descriptors = load_descriptors(root, modules)
+    known_ids = set(descriptors)
+    substantive, debt = load_status(status_path, known_ids)
+    doc_paths = sorted(docs.rglob("*.md"))
+    for path in doc_paths:
+        _safe_path(root, path, "module document")
+        if path.parent != docs or path.stem not in known_ids:
+            raise DocError(f"{path}: orphan or non-canonical module document")
+    lines = []
+    for module_id in sorted(known_ids):
+        path = docs / f"{module_id}.md"
+        if module_id in debt:
+            if path.exists():
+                raise DocError(f"{path}: documented module remains in debt status")
+            lines.append(f"DEBT {module_id}")
+            continue
+        if not path.is_file():
+            raise DocError(f"{path}: substantive module document is missing")
+        validate_doc(path, descriptors[module_id])
+        lines.append(f"PASS {module_id}")
+    lines.append("SUMMARY debt=" + ",".join(sorted(debt)))
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config-root", type=Path, default=ROOT)
+    parser.add_argument("--modules", type=Path, default=DEFAULT_MODULES)
+    parser.add_argument("--docs", type=Path, default=DEFAULT_DOCS)
+    parser.add_argument("--status", type=Path, default=DEFAULT_STATUS)
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    root = Path(os.path.abspath(args.config_root))
+    resolve = lambda value: value if value.is_absolute() else root / value
+    try:
+        report = run(root, resolve(args.modules), resolve(args.docs), resolve(args.status))
+    except (DocError, OSError, UnicodeError) as exc:
+        print(f"check_module_docs: error: {exc}", file=sys.stderr)
+        return 1
+    sys.stdout.write(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_module_docs.py
+++ b/scripts/tests/test_check_module_docs.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Failure-mode tests for the module documentation catalog."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/check_module_docs.py"
+SPEC = importlib.util.spec_from_file_location("check_module_docs", SCRIPT)
+assert SPEC and SPEC.loader
+docs = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(docs)
+
+
+def document(dep: str = "beta", toggle: str = "supported") -> str:
+    bodies = {
+        name: (
+            f"Verified `{name}` contract content names its current source owner, observable behavior, "
+            "consumer boundary, and known limitation for this focused module fixture."
+        )
+        for name in docs.SECTIONS
+    }
+    bodies["Dependencies and consumers"] = (
+        f"- `{dep}`: required test dependency with a verified source consumer, an explicit ownership "
+        "boundary, and a documented failure expectation for this fixture."
+    )
+    bodies["Configuration and activation"] = (
+        f"- `runtime_toggle.{toggle}`: `false`; compile-time lifecycle with no runtime enable control, "
+        "no hidden startup switch, and a verified always-present reference path."
+    )
+    return "# alpha module\n\n" + "\n\n".join(
+        f"## {name}\n\n{bodies[name]}" for name in docs.SECTIONS
+    ) + "\n"
+
+
+class ModuleDocTests(unittest.TestCase):
+    def fixture(self, root: Path) -> tuple[Path, Path, Path]:
+        modules = root / "src/modules"
+        catalog = root / "docs/modules"
+        modules.mkdir(parents=True)
+        catalog.mkdir(parents=True)
+        for module_id, deps in (("alpha", ["beta"]), ("beta", [])):
+            directory = modules / module_id
+            directory.mkdir()
+            (directory / "module.yaml").write_text(
+                json.dumps({"descriptor_version": 1, "id": module_id, "dependencies": deps,
+                            "runtime_toggle": {"supported": False}}), encoding="utf-8"
+            )
+        (catalog / "alpha.md").write_text(document(), encoding="utf-8")
+        status = root / "status.json"
+        status.write_text(json.dumps({"schema_version": 1, "substantive": ["alpha"],
+                                      "debt": ["beta"]}), encoding="utf-8")
+        return modules, catalog, status
+
+    def test_valid_report_is_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            modules, catalog, status = self.fixture(root)
+            first = docs.run(root, modules, catalog, status)
+            self.assertEqual(first, docs.run(root, modules, catalog, status))
+            self.assertEqual(first, "PASS alpha\nDEBT beta\nSUMMARY debt=beta\n")
+
+    def test_orphan_doc_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            modules, catalog, status = self.fixture(root)
+            (catalog / "orphan.md").write_text("orphan", encoding="utf-8")
+            with self.assertRaisesRegex(docs.DocError, "orphan"):
+                docs.run(root, modules, catalog, status)
+
+    def test_missing_and_out_of_order_sections_fail(self) -> None:
+        for mutation in (lambda text: text.replace("## Compatibility", "### Compatibility"),
+                         lambda text: text.replace("## Public contracts", "## Zed contracts")):
+            with self.subTest(), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                modules, catalog, status = self.fixture(root)
+                path = catalog / "alpha.md"
+                path.write_text(mutation(path.read_text(encoding="utf-8")), encoding="utf-8")
+                with self.assertRaisesRegex(docs.DocError, "sections differ"):
+                    docs.run(root, modules, catalog, status)
+
+    def test_dependency_and_toggle_mismatches_fail(self) -> None:
+        for replacement, message in (("`beta`", "`alpha`"),
+                                     ("runtime_toggle.supported", "runtime_toggle.unknown")):
+            with self.subTest(), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                modules, catalog, status = self.fixture(root)
+                path = catalog / "alpha.md"
+                path.write_text(path.read_text().replace(replacement, message), encoding="utf-8")
+                with self.assertRaisesRegex(docs.DocError, "bullets differ"):
+                    docs.run(root, modules, catalog, status)
+
+    def test_toggle_values_and_duplicate_bullets_fail(self) -> None:
+        mutations = (
+            ("`false`", "`true`", "runtime-toggle"),
+            ("- `beta`:", "- `beta`:\n- `beta`:", "duplicate dependency"),
+            (
+                "- `runtime_toggle.supported`:",
+                "- `runtime_toggle.supported`: `false`; duplicate\n- `runtime_toggle.supported`:",
+                "duplicate runtime-toggle",
+            ),
+            (
+                "- `runtime_toggle.supported`:",
+                "- `runtime_toggle.supported`: enabled; contradiction\n- `runtime_toggle.supported`:",
+                "duplicate runtime-toggle",
+            ),
+            (
+                "`false`; compile-time",
+                "`false`; compile-time\n- `runtime_toggle.supported`:",
+                "duplicate runtime-toggle",
+            ),
+            (
+                "`false`; compile-time",
+                "`false`; compile-time\n- `runtime_toggle.supported`:enabled",
+                "duplicate runtime-toggle",
+            ),
+        )
+        for old, new, error in mutations:
+            with self.subTest(error=error), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                modules, catalog, status = self.fixture(root)
+                path = catalog / "alpha.md"
+                path.write_text(path.read_text().replace(old, new), encoding="utf-8")
+                with self.assertRaisesRegex(docs.DocError, error):
+                    docs.run(root, modules, catalog, status)
+
+    def test_malformed_toggle_value_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            modules, catalog, status = self.fixture(root)
+            descriptor = modules / "alpha/module.yaml"
+            data = json.loads(descriptor.read_text())
+            data["runtime_toggle"]["supported"] = "maybe"
+            descriptor.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaisesRegex(docs.DocError, "map string keys to booleans"):
+                docs.run(root, modules, catalog, status)
+
+    def test_malformed_descriptor_and_status_partition_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            modules, catalog, status = self.fixture(root)
+            (modules / "alpha/module.yaml").write_text(
+                json.dumps({"id": "alpha", "dependencies": "beta",
+                            "runtime_toggle": {"supported": False}}), encoding="utf-8"
+            )
+            with self.assertRaisesRegex(docs.DocError, "dependencies"):
+                docs.run(root, modules, catalog, status)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            modules, catalog, status = self.fixture(root)
+            status.write_text(json.dumps({"schema_version": 1, "substantive": ["alpha"],
+                                          "debt": []}), encoding="utf-8")
+            with self.assertRaisesRegex(docs.DocError, "partition"):
+                docs.run(root, modules, catalog, status)
+
+    def test_debt_doc_requires_promotion(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            modules, catalog, status = self.fixture(root)
+            (catalog / "beta.md").write_text(document(dep="alpha"), encoding="utf-8")
+            with self.assertRaisesRegex(docs.DocError, "remains in debt"):
+                docs.run(root, modules, catalog, status)
+
+    def test_h1_and_realistic_placeholder_fail(self) -> None:
+        for old, new, error in (
+            ("# alpha module", "# audit module", "first non-blank"),
+            (
+                "Verified `Purpose and non-goals` contract content names its current source owner, observable behavior, consumer boundary, and known limitation for this focused module fixture.",
+                "Documentation pending review for `alpha`; see module owner for details and updates.",
+                "lacks substantive",
+            ),
+        ):
+            with self.subTest(error=error), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                modules, catalog, status = self.fixture(root)
+                path = catalog / "alpha.md"
+                path.write_text(path.read_text().replace(old, new), encoding="utf-8")
+                with self.assertRaisesRegex(docs.DocError, error):
+                    docs.run(root, modules, catalog, status)
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlinks unavailable")
+    def test_symlinked_module_docs_and_status_fail(self) -> None:
+        for target_kind in ("module", "docs", "status"):
+            with self.subTest(target_kind=target_kind), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                modules, catalog, status = self.fixture(root)
+                if target_kind == "module":
+                    original = modules / "alpha"
+                    real = root / "alpha-real"
+                    original.rename(real)
+                    original.symlink_to(real, target_is_directory=True)
+                elif target_kind == "docs":
+                    real = root / "docs-real"
+                    catalog.rename(real)
+                    catalog.symlink_to(real, target_is_directory=True)
+                else:
+                    real = root / "status-real.json"
+                    status.rename(real)
+                    status.symlink_to(real)
+                with self.assertRaisesRegex(docs.DocError, "symlink"):
+                    docs.run(root, modules, catalog, status)
+
+    def test_configured_path_escape_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            outer = Path(directory)
+            root = outer / "repo"
+            root.mkdir()
+            modules, catalog, status = self.fixture(root)
+            with self.assertRaisesRegex(docs.DocError, "escapes config root"):
+                docs.run(root, outer, catalog, status)
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlinks unavailable")
+    def test_symlinked_config_root_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            outer = Path(directory)
+            real_root = outer / "real"
+            real_root.mkdir()
+            modules, catalog, status = self.fixture(real_root)
+            linked_root = outer / "linked"
+            linked_root.symlink_to(real_root, target_is_directory=True)
+            with self.assertRaisesRegex(docs.DocError, "config root contains symlink"):
+                docs.run(
+                    linked_root,
+                    linked_root / modules.relative_to(real_root),
+                    linked_root / catalog.relative_to(real_root),
+                    linked_root / status.relative_to(real_root),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/baselines/modules/documentation-status.yaml
+++ b/tests/baselines/modules/documentation-status.yaml
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "substantive": [
+    "module-runtime",
+    "plugin-loader"
+  ],
+  "debt": [
+    "audit",
+    "benchmarks",
+    "config",
+    "control-web",
+    "delegates",
+    "execution-policy",
+    "gateway",
+    "git",
+    "governance",
+    "ir",
+    "kb-synthesis",
+    "learning",
+    "memory",
+    "protocols",
+    "response-composition",
+    "roundtable",
+    "routing",
+    "runtime-web",
+    "skills",
+    "tools",
+    "translation",
+    "vault",
+    "workflows",
+    "workspace"
+  ]
+}

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -126,6 +126,18 @@
       "blast_radius": "The gate reads repository files only, never a live database, network service, built binary, or ambient toolchain.",
       "independent_review": "The implementation plan and exact diff are reviewed by the modularization roundtable.",
       "evidence": ["docs/validation/core-modularization-slice-12.md", "docs/refactor-baselines.md"]
+    },
+    {
+      "slice": 13,
+      "state": "present_and_verified",
+      "disposition": "Added the strict individual module-documentation catalog and promoted the runtime/loading family without creating placeholder docs.",
+      "production": {"added": [], "deleted": [], "consolidated": ["module-runtime and plugin-loader now share one documentation schema and cross-link their ownership boundary"]},
+      "fallbacks": ["24 module documents remain explicit status debt"],
+      "net_growth": {"status": "none", "rationale": "", "rejected_simpler_alternative": "", "revisit": ""},
+      "consumers": ["module maintainers", "modular-refactor CI"],
+      "blast_radius": "Documentation and repository validation only; no production source, descriptor, build, route, config, or runtime behavior changes.",
+      "independent_review": "Technical-writing and exact-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-13.md", "docs/modules/module-runtime.md", "docs/modules/plugin-loader.md"]
     }
   ]
 }


### PR DESCRIPTION
## Outcome

Introduces the descriptor-driven individual module-documentation gate and promotes the first coherent documentation family.

- keeps all 26 descriptors authoritative for module identity
- marks `module-runtime` and `plugin-loader` substantive
- records the other 24 modules as explicit documentation debt without placeholders
- enforces identity, section order, grounded content, dependency/toggle parity, path safety, and deterministic reporting
- rewrites the two runtime/loading docs around one shared contract and explicit ownership handoff
- changes no production source, descriptor, build, route, config, or runtime behavior

## Verification

- `python3 -I -S scripts/check_module_docs.py`
- `python3 -I scripts/tests/test_check_module_docs.py -v`
- cleanup ledger and refactor baseline checks
- `make -C src lint`
- technical writer: APPROVE
- roundtable: APPROVE after three correction rounds