### PR TITLE
Document memory-family module boundaries

### DIFF
--- a/docs/modules/kb-synthesis.md
+++ b/docs/modules/kb-synthesis.md
@@ -1,0 +1,101 @@
+# kb-synthesis module
+
+## Purpose and non-goals
+
+`kb-synthesis` is an optional, default-off, heavyweight knowledge-curation module. It uses a capable LLM or
+substantial GPU to reason across already-ingested evidence, resolve higher-order relationships, and write
+cited narrative artifacts such as topic synthesis. It is not normal response-composition, required
+embedding/reranking, code indexing, basic memory recall, or the deterministic Tier-A ingest/index lane.
+
+## Public contracts
+
+Current contracts include `src/kb/kb_curator_synthesize.h`, `kb_curator_provider.h`, curator pipeline
+stages, serve endpoints, and DB2 artifact/link APIs. The descriptor directory currently has no source;
+implementation is distributed across `src/kb`, `src/db2`, root curator profile/config, and HTTP/CLI code.
+That placement is migration debt and should be narrowed only after separating required ingestion stages.
+
+## Dependencies and consumers
+
+- `config`: supplies explicit enablement, capable provider/sidecar selection, limits, and prompt versions.
+- `ir`: supplies provider-neutral request/response shapes for model-backed curation work.
+- `memory`: supplies embedded evidence and receives cited narrative artifacts and links.
+- `module-runtime`: will supply lifecycle and extension contracts when the target optional boundary is physically separated.
+- `response-composition`: supplies canonical model-result assembly without making KB synthesis part of every answer.
+
+Consumers include KB curator workers, `/v1/synthesize`, curator CLI/status surfaces, narrative indexing and
+search, and memory retrieval that may later surface committed artifacts. Core memory remains a valid
+consumer even when no synthesized artifact exists.
+
+## Providers and readiness
+
+Tier-B stages require an explicitly configured capable provider through `tier_b.*` or a synthesis sidecar;
+`kb_curator_provider_for_stage` deliberately provides no Tier-A environment fallback. Readiness is idle,
+not degraded core, when disabled or unconfigured. It is ready only when storage, source evidence, provider,
+prompt/version policy, and bounded worker lane are all operational.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; the target optional boundary is profile-gated at build/startup, not hot-toggled in a live process, and separation from Tier-A stages remains implementation work.
+
+The descriptor sets `enabled_by_default` to false. Current concrete gates include
+`kb.curator.synthesize.enabled`, command/provider settings, source count, worker scheduling, and related
+Tier-B stage controls. A future profile that excludes the physical module must hide this family from web
+configuration and expose it only on the KB management GUI when the module is selected.
+
+## Surfaces
+
+Surfaces include KB curator health/status, `aimee kb curator`, curator synthesis commands and routes,
+`/v1/synthesize`, logs under `kb.curator.synth`, and committed synthesis artifacts with `about` and
+`cites` links. These belong to the KB management plane; the runtime/user GUI must not present them as
+ordinary response controls.
+
+## Data and migrations
+
+The module reads entities, claims, evidence, and embeddings, then writes versioned `synthesis` artifacts,
+features, vector rows, and provenance links through DB2/PostgreSQL. Migrations must preserve prompt/model
+version, topic identity, citations, artifact state, and suppression of duplicate work; generated
+syntheses are rebuildable only when their complete source evidence and version policy remain available.
+
+## Security and privacy
+
+Only evidence within the authorized KB scope may enter a synthesis request, and outputs must retain `cites`
+provenance so generated claims can be audited. Provider credentials stay in vault/config ownership; logs
+and sidecar errors must not echo keys or full sensitive documents. Model output is untrusted until parsed,
+bounded, linked, and accepted under artifact policy.
+
+## Supported journeys
+
+When currently enabled, the curator selects an eligible high-centrality topic, gathers top-K linked evidence, sends
+a grounded `synthesize_topic` request to the capable Tier-B provider, validates the response, writes a
+`synthesis` artifact, and links it about the topic and to its cited sources. Acceptance for the future
+optional profile requires ingest, embedding, reranking, code intelligence, memory search, and normal
+answers to remain operational when this module is omitted.
+
+## Tests and failure behavior
+
+`test_curator_synthesize.c`, `test_curator_serve.c`, `test_kb_curator_provider.c`,
+`test_curator_pipeline.c`, and curator queue/index tests cover selection, provider separation, persistence,
+serving, and scheduling. Disabled/unconfigured providers and no eligible topic are clean idle results;
+malformed output, provider failure, or artifact-write failure must not mark a topic successfully synthesized.
+
+## Operational diagnostics
+
+Operators use curator health, queue depth, stage/provider readiness, prompt/model version, worker logs,
+artifact/link queries, and `/v1/synthesize` results. Diagnostics must preserve decoded process/HTTP/database
+errors and distinguish Tier-B unavailable, no eligible evidence, parse rejection, and persistence failure;
+core memory health must not fail merely because `kb-synthesis` is idle.
+
+## Compatibility
+
+Curator route envelopes, stage names, artifact kinds/states, `about`/`cites` provenance, prompt versions,
+and provider-tier isolation are compatibility contracts. Moving files into
+`src/modules/kb-synthesis` must not pull Tier-A extraction, embedding, indexing, or core response assembly
+with them, and stored artifacts require explicit migration if their schema or semantics change.
+
+## Extension and removal
+
+Additional heavyweight reasoning passes belong here only when they consume established KB evidence,
+retain provenance, share provider/readiness policy, and have a real management journey and consumer.
+Self-only curator experiments should be deleted after liveness review. After the Tier-A/Tier-B split, the
+target module must be wholly omittable: exclusion must hide its `config`, routes, GUI, and workers while
+preserving all required memory journeys.

--- a/docs/modules/learning.md
+++ b/docs/modules/learning.md
@@ -1,0 +1,97 @@
+# learning module
+
+## Purpose and non-goals
+
+Learning is required core because Aimee must improve from a user's corrections, choices, and repeated
+work rather than behave as a stateless router. The module turns supported signals into reviewable and
+bounded changes through `learning_router_record_signal`; it does not grant an LLM permission to rewrite
+configuration, memories, skills, rules, or workflows without the applicable evidence and policy gates.
+
+## Public contracts
+
+`src/modules/learning/learning.h` defines signal inputs, dispatch results, proposals, actions, metrics,
+and the router API. `learning_implicit.h`, `learning_bundle.h`, and `learning_evidence.h` cover detection,
+evidence assembly, and candidate generation, while DB2 persistence currently remains in
+`src/db2/db2_learning.h` and related source files as explicit physical-ownership debt.
+
+## Dependencies and consumers
+
+- `config`: supplies learning thresholds, limits, synthesis provider settings, and policy gates.
+- `ir`: supplies provider-neutral turn content from which supported implicit signals can be detected.
+- `memory`: supplies evidence and receives approved durable improvements where the selected sink permits it.
+- `module-runtime`: supplies required lifecycle contracts for the always-present learning capability.
+
+Consumers include `cmd_learning.c`, `cmd_rules.c`, server/KB learning routes, the KB drain's candidate
+synthesis lane, review workflows, dashboards, and agent execution that records explicit or implicit
+feedback through the typed `learning_signal_input_t` contract.
+
+## Providers and readiness
+
+The deterministic router and proposal store are required; optional model-backed candidate generation
+may be idle when its configured provider is unavailable. `learning_router_enabled` reflects operational
+configuration for signal intake, but disabling one detector or sink is not equivalent to removing the
+core learning module or its review/history contracts.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; learning remains part of core even when individual detectors or sinks are gated.
+
+Settings under `learning.*` tune implicit detection, corroboration, caps, expiry, and synthesis commands.
+The web configuration must expose a setting only when its detector, sink, or provider is compiled and
+used, and must distinguish a temporarily idle provider from removal of required `learning` capability.
+
+## Surfaces
+
+User and operator surfaces include `aimee learning list|status|accept|reject|metrics`, KB/server learning
+routes, proposal review, and dashboard metrics derived from `learning_metrics_commit_ratio` and
+`learning_metrics_per_sink_caps`. Internal signal ingestion is also a surface because rules, turns, and
+delegates rely on its result states and evidence references.
+
+## Data and migrations
+
+`DB2` tables store learning signals, proposals, evidence references, state transitions, and synthesis
+work; schema and queries currently live under `src/db2`. Migrations must preserve proposal IDs, sink,
+target, corroboration, expiry, and audit history so an old unresolved action cannot be replayed as an
+unreviewed committed change after an upgrade.
+
+## Security and privacy
+
+Learning data can reveal preferences, mistakes, and working habits, so scope, identity, retention, and
+memory PII controls apply before durable use. Actions parsed from `action_json` must pass sink-specific
+authorization and caps; evidence is provenance for review, not authority to mutate another user's or
+project's state.
+
+## Supported journeys
+
+An explicit correction or supported implicit event becomes a typed signal, is deduplicated and routed
+to bounded sink proposals, and is then accepted, rejected, expired, or committed with evidence.
+Operational metrics show whether `reranker`, `supersede`, `rule`, and `workflow` sinks are producing
+useful changes without silently exceeding their weekly limits.
+
+## Tests and failure behavior
+
+`test_learning_bundle.c`, `test_learning_metrics.c`, `learning_implicit_replay.c`,
+`test_learning_synth.c`, and `test_learning_version.c` cover evidence, detection, proposals, metrics,
+candidate synthesis, and version behavior. Invalid signals and unavailable storage fail closed; optional
+synthesis failure leaves evidence/proposals inspectable and must not fabricate an accepted action.
+
+## Operational diagnostics
+
+The `aimee learning metrics` surface reports commit ratios, per-sink cap utilization, and router/detector
+latency from `learning_router_metrics`. Operators should correlate those counters with proposal states,
+KB drain logs, provider readiness, and evidence references to distinguish no useful signal from a broken
+ingestion or synthesis path.
+
+## Compatibility
+
+The `learning_signal_input_t`, proposal JSON, CLI verbs, route envelopes, sink names, and persisted state
+machine are compatibility contracts. Relocating DB2 and root command code into the module must retain
+those meanings; renaming a sink or reinterpreting `high_confidence` requires migration, tests, and a
+surface-baseline decision.
+
+## Extension and removal
+
+Add a detector or sink by extending the typed router, evidence rules, caps, review journey, metrics, and
+tests together. Self-contained experiments with no production caller should be deleted rather than
+declared as learning. The core `learning` module cannot be removed; model-heavy candidate generation can
+remain provider-gated without splitting the user-learning contract into a second optional subsystem.

--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -1,0 +1,97 @@
+# memory module
+
+## Purpose and non-goals
+
+Memory is required core: it recalls, ranks, assembles, stores, and maintains information that makes
+Aimee useful across turns and repositories. It includes code intelligence, embedding, and reranking;
+`kb-synthesis` is not part of this module. Current ownership is split between `src/modules/memory`,
+`src/db2`, KB services, clients, and root command files, which is migration debt rather than a second
+memory subsystem.
+
+## Public contracts
+
+The current C contract is principally `src/headers/memory.h`, with platform seams in
+`src/modules/memory/memory_platform.h` and provider seams in
+`src/modules/memory/memory_provider.h`. Code-index operations in `src/db2/code_index_ops.c`, vector
+search, `memory_assemble`, and `gw_stage_memory` are one required capability family even though their
+physical paths have not all reached the module directory.
+
+## Dependencies and consumers
+
+- `config`: supplies embedding, reranking, recall, retention, and safety policy used by memory paths.
+- `ir`: supplies the provider-neutral request and response shapes used for recall and context injection.
+- `module-runtime`: supplies the required lifecycle and extension contracts used by every core profile.
+
+Consumers include `src/server/agent_runtime.c`, the universal gateway memory stage, the `aimee memory`
+and `aimee kb` commands, learning, skills, response-composition, and KB ingestion/search services.
+
+## Providers and readiness
+
+Memory is ready only when durable storage can open and the configured embedding path has a compatible
+dimension; semantic ranking additionally requires the reranking path selected by `config_t`.
+Lexical fallbacks may preserve a degraded lookup journey, but they do not make a deployment compliant
+with the required embedding-and-reranking capability boundary.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; memory is required and cannot be removed from a running profile.
+
+Individual policies such as `AIMEE_STAGE_MEMORY`, embedding commands, dimensions, recall limits, and
+rerank modes tune journeys rather than disabling ownership. Configuration surfaces must describe the
+actual provider readiness and must not imply that core `memory` itself is optional.
+
+## Surfaces
+
+Operator surfaces include the `aimee memory` command family, server-to-KB memory routes, health and
+benchmark output, and context injection through `gw_stage_memory` and `ir_stage_memory`. The current
+code-intelligence HTTP/CLI surfaces are also memory surfaces because indexed symbols and blast-radius
+evidence are recalled from the same required knowledge capability.
+
+## Data and migrations
+
+Durable state spans DB1 memory records and DB2/PostgreSQL memory, embedding, code-index, graph, and
+artifact relations; their concrete schemas live under `src/db1` and `src/db2`. Embedding dimension and
+model-version migrations must keep text, vector rows, provenance, and active-version metadata coherent;
+deleting vectors is safe only where the source records are demonstrably regenerable.
+
+## Security and privacy
+
+Before persistence, memory applies sensitivity, ephemeral-content, evidence, and PII gates such as
+`gate_check_sensitive` and the implementations in `memory_pii_gate.c`. Recall must preserve scope and
+identity boundaries, and injected `<aimee-context>` content remains untrusted evidence rather than
+authorization or executable instruction.
+
+## Supported journeys
+
+A normal turn extracts a query from `aimee_request_t`, retrieves scoped lexical/vector candidates,
+reranks them, assembles a bounded evidence envelope, and gives response-composition that context.
+Repository ingestion creates code units and embeddings so symbol lookup, semantic code search, and
+blast-radius analysis participate in the same required memory journey.
+
+## Tests and failure behavior
+
+Focused coverage includes `test_memory.c`, `test_memory_retrieval_eval.c`,
+`test_memory_embed_dim_guard.c`, `test_memory_ranker_boundary.c`, `test_gw_stage_memory.c`, and the code
+curator/index tests. Provider, database, dimension, and corruption failures must surface as degraded or
+failed readiness; an empty recall is a valid no-op, while silently bypassing required ranking is not.
+
+## Operational diagnostics
+
+Use memory and KB health output, embedding counts/version state, rerank benchmark deltas, queue status,
+and `memory_health` diagnostics to separate empty knowledge from provider or index failure. Logs must
+retain the concrete database, sidecar, and HTTP error rather than collapsing every failure into a generic
+`index unavailable` message.
+
+## Compatibility
+
+Public `memory_*`, KB-client JSON, CLI, route, schema, and embedding-version contracts remain stable
+during physical relocation. The target `src/modules/memory` boundary permits path and include cleanup,
+but any changed response, ranking, persistence, or context bytes require an explicit compatibility and
+baseline decision.
+
+## Extension and removal
+
+New recall sources must enter through the shared candidate, ranking, scope, and evidence contracts, not
+an independent store-and-inject path. The root and `src/db2` implementation inventory is a relocation
+queue; each move must prove consumers and delete duplicate glue. Removing `memory`, embedding, reranking,
+or code intelligence would break the core product and is not an allowed optional profile.

--- a/docs/modules/response-composition.md
+++ b/docs/modules/response-composition.md
@@ -1,0 +1,100 @@
+# response-composition module
+
+## Purpose and non-goals
+
+Response-composition is required core: it turns a routed model/delegate result plus recalled evidence,
+tool results, and policy state into the assistant response delivered to the user. It owns ordinary answer
+assembly and provider-neutral response semantics; it does not own heavyweight cross-document knowledge
+curation, which belongs to optional `kb-synthesis`, or roundtable-specific panel aggregation.
+
+## Public contracts
+
+The target contract is represented today by response-side `aimee_response_t` and helpers such as
+`aimee_ir_response_from_text` in `src/headers/aimee_ir.h`, plus assembly and finalization paths spread
+through server, gateway, delegate, and translation code. The descriptor is ahead of physical ownership:
+`src/modules/response-composition` contains no implementation yet, a tracked relocation gap rather than
+evidence that core composition is absent.
+
+## Dependencies and consumers
+
+- `config`: supplies response limits, provider and presentation policies used during composition.
+- `ir`: supplies canonical response blocks, stop reasons, tool calls, and usage independent of wire format.
+- `memory`: supplies scoped evidence and context that ground normal responses.
+- `module-runtime`: supplies required lifecycle and extension contracts around the composition path.
+- `skills`: supplies selected user/project instructions that shape the response journey.
+
+Consumers are gateway/protocol serializers, agent and delegate runtimes, workflow delivery, CLI/TUI
+clients, and optional modules such as roundtable and plugin-loader that add inputs without owning the
+final provider-neutral answer contract.
+
+## Providers and readiness
+
+Composition itself is deterministic core and is ready when IR construction/finalization and the selected
+delivery serializer are available. A routed inference provider supplies content but is not a replaceable
+composition implementation; provider failure can prevent an answer, while omission of `kb-synthesis`
+must leave ordinary memory-backed response composition fully functional.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; every supported interactive or agent profile requires response composition.
+
+Configuration tunes limits, caching placement, liveness, streaming, and delivery behavior rather than
+turning composition off. The eventual canonical module must consume those keys through `config` and
+remove duplicate per-ingress choices; GUI fields are valid only where the compiled response path reads
+them.
+
+## Surfaces
+
+Surfaces include canonical IR response blocks and deltas, OpenAI/Anthropic wire responses, delegate final
+messages, streamed events, CLI/TUI output, and workflow/channel delivery. Roundtable synthesis and KB
+narrative endpoints are consumers or separate modules; their specialized prompts and artifacts must not
+be relabeled as the universal `response-composition` surface.
+
+## Data and migrations
+
+Normal composition is primarily per-turn `aimee_response_t` state and owns no independent durable database schema today;
+transcripts, tool results, and usage are persisted by their owning modules. Relocation must preserve block
+ordering, thinking/text separation, tool-call identity, stop reason, usage, streaming boundaries, and
+serialized bytes where parity baselines require them.
+
+## Security and privacy
+
+Composition must keep reasoning blocks distinct from user-visible `TEXT`, preserve provenance and scope
+on recalled context, and never treat memory or skill text as authorization. Before delivery it must honor
+execution policy, redaction, route identity, and channel constraints; diagnostics may describe structure
+without leaking hidden reasoning, credentials, or private context.
+
+## Supported journeys
+
+For a normal request, routing selects execution, memory supplies grounded context, skills shape behavior,
+the provider produces canonical deltas/blocks, and response-composition emits one coherent final answer
+or tool continuation. `aimee_ir_response_from_text` also normalizes flat CLI/TUI results so downstream
+consumers receive the same `aimee_response_t` contract.
+
+## Tests and failure behavior
+
+IR shape, OpenAI/Anthropic shape, gateway mutation/wire, streaming, liveness, and `agent-runtime` tests are
+the current distributed coverage for composition. Allocation, malformed provider output, invalid tool
+blocks, and empty terminal responses must fail or invoke bounded liveness behavior; hidden reasoning must
+never be substituted as an answer merely to make a response non-empty.
+
+## Operational diagnostics
+
+Use route/provider logs, canonical stop reason and usage, streaming terminal events, liveness notices, and
+wire-shape tests to locate a composition failure. Diagnostics should say whether failure occurred during
+provider parsing, IR assembly, tool continuation, finalization, translation, or delivery instead of using
+the ambiguous label `synthesis` for all of them.
+
+## Compatibility
+
+`aimee_response_t`, block order/types, stop reasons, tool IDs/arguments, usage, stream termination, and
+wire serializers are compatibility contracts. Consolidation into the module may delete duplicated glue,
+but output bytes governed by parity and public route/CLI baselines cannot change without an explicit
+compatibility record and consumer migration.
+
+## Extension and removal
+
+Move distributed finalization code behind one provider-neutral contract in small slices, proving each
+consumer and deleting old branches as it moves. Specialized aggregators should contribute canonical IR
+instead of cloning final-answer logic. Response-composition cannot be removed from core; optional
+`kb-synthesis` may enrich memory independently and must not become a required answer-path dependency.

--- a/docs/modules/skills.md
+++ b/docs/modules/skills.md
@@ -1,0 +1,98 @@
+# skills module
+
+## Purpose and non-goals
+
+Skills are required core instructions and supporting resources that teach Aimee how to perform recurring
+work under explicit project or user control. The module resolves, loads, validates, injects, reviews, and
+maintains `SKILL.md`-style content; it is not an optional extension loader, a tool implementation, or an
+unbounded mechanism for downloaded text to bypass routing, policy, or user approval.
+
+## Public contracts
+
+The current contract is `src/modules/skill/skill.h`, implemented by `skill.c`, `skill_review.c`, and
+`skill_rollback.c`, with CLI orchestration in `src/cmd_skill.c`. The singular physical directory and the
+plural descriptor ID `skills` are an acknowledged naming/ownership mismatch to resolve during source
+movement, without creating forwarding APIs or a parallel skill registry.
+
+## Dependencies and consumers
+
+- `config`: supplies dispatch, index, lifecycle, and evaluation policy for skills.
+- `ir`: supplies the provider-neutral conversation context in which skill instructions are applied.
+- `memory`: records skill evidence and usage needed for retrieval, learning, and review.
+- `module-runtime`: supplies the required lifecycle contracts shared by all core modules.
+- `tools`: supplies the capability registry against which skills can declare and cover operations.
+
+Consumers include `cmd_agent_delegate.c`, session briefing, `cmd_review.c`, `cmd_skill.c`, workflow and
+delegate execution, client integration installers, and capability autostub logic. They must use the same
+`skill_path`, `skill_load`, lint, usage, and management contracts.
+
+## Providers and readiness
+
+The filesystem-backed resolver is the required provider and searches project then user scopes according
+to `skill_path`; absence of a named skill is a normal lookup miss. Evaluation or proposal generation may
+use other modules, but core readiness requires deterministic parsing, linting, bounded loading, and
+injection even when no optional plugin or web GUI is present.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; skills are core while individual dispatch and lifecycle policies remain configurable.
+
+Settings such as `skills_dispatch_enabled`, index limits, evaluation threshold, and stale/archive windows
+tune automated journeys. Disabling dispatch must not remove manual `aimee skill` management or the
+underlying contracts, and GUI controls must be hidden when their actual consumer is absent.
+
+## Surfaces
+
+The primary user surface is `aimee skill` with list, show, lint, eval, create, edit, patch, archive,
+export, import, rollback, lifecycle, autostub, pin, and unpin verbs. Project `.aimee/skills`, user skill
+directories, delegate prompt injection, session briefings, and review payloads are also supported
+surfaces with bounded content and stable precedence.
+
+## Data and migrations
+
+Skill bodies and support files are filesystem data; usage, state, snapshots, and review records use
+sidecars or repository databases according to the current implementation. A move from
+`src/modules/skill` to `src/modules/skills` changes source ownership only and must not change project-over-
+user precedence, archive behavior, size limits, or rollback snapshot interpretation.
+
+## Security and privacy
+
+Skill names and support paths must pass `skill_name_is_valid` and containment checks so content cannot
+escape approved project/user roots. Loaded instructions are untrusted input subject to execution policy,
+tool authorization, and review gates; pinning protects automation state but does not grant the skill
+additional capabilities or access to secrets.
+
+## Supported journeys
+
+A user can author and lint a project skill, review it, activate it explicitly or through bounded dispatch,
+and have `skill_inject` add its instructions to the appropriate delegate prompt. Usage telemetry supports
+lifecycle decisions, while evaluation gates and rollback preserve a recoverable path for automated skill
+changes derived from learning or uncovered tools.
+
+## Tests and failure behavior
+
+`test_skill.c` covers discovery, loading, validation, management, injection, lifecycle, and telemetry;
+`test_skill_review.c` covers review and rollback behavior. Invalid names, oversized content, unsafe
+support paths, failed lint/evaluation, and write errors fail closed; a missing requested skill leaves the
+base prompt usable rather than inventing instructions.
+
+## Operational diagnostics
+
+Use `aimee skill list|show|lint|eval`, review records, lifecycle result counts, and `skill_metrics` to
+diagnose precedence, malformed content, stale state, or failed automation. Diagnostics should include the
+resolved source class and safe path context while avoiding logging full private skill bodies or injected
+secrets.
+
+## Compatibility
+
+CLI verbs, `skill_*` C signatures, project/user lookup precedence, frontmatter interpretation, file size
+limits, and snapshot semantics are compatibility contracts. Canonicalizing the directory to
+`src/modules/skills` must update build graphs and includes atomically while keeping stored skill files and
+the external `SKILL.md` convention readable.
+
+## Extension and removal
+
+New lifecycle or authoring features must extend the single resolver/management implementation and add
+tests for scope, safety, review, and rollback. Duplicate client-specific skill engines should be folded
+into `skills`; an isolated feature with no production consumer is deletion evidence. Removing skills is
+not an allowed core profile because delegates and learning depend on durable, user-controlled guidance.

--- a/docs/validation/core-modularization-slice-14.md
+++ b/docs/validation/core-modularization-slice-14.md
@@ -1,0 +1,47 @@
+# Core modularization slice 14: memory-family documentation
+
+## Outcome
+
+This slice promotes five related descriptors from documentation debt: required `memory`, `learning`,
+`skills`, and `response-composition`, plus optional default-off `kb-synthesis`. Each document uses the
+individual-module contract introduced in slice 13 and grounds ownership in current C sources, routes,
+configuration, data, tests, and failure behavior.
+
+The review confirms the intended boundary while making current placement debt explicit. Memory owns
+code intelligence, embedding, reranking, recall, and assembly. Learning and skills are required parts of
+the adaptive user experience. Response-composition owns the normal final-answer contract but has not yet
+been physically consolidated under its descriptor directory. KB-synthesis owns heavyweight Tier-B
+knowledge reasoning, not required Tier-A extraction/indexing or ordinary response composition.
+
+## Deep-dive findings
+
+- `src/modules/memory` already contains a large coherent implementation, while DB1/DB2, KB services,
+  root commands, clients, and routes remain relocation candidates that require schema and surface care.
+- `src/modules/learning` has a typed router implementation; its command, persistence, KB worker, and
+  review surfaces remain distributed. Optional candidate synthesis does not make core learning optional.
+- the `skills` descriptor and `src/modules/skill` implementation use different directory plurality. The
+  cleanup target is one canonical plural module, not a forwarding layer or duplicate registry.
+- `src/modules/response-composition` contains only `module.yaml`; canonical IR response construction and
+  finalization are currently spread across IR, server, gateway, delegates, translation, and delivery.
+- `src/modules/kb-synthesis` also contains only its descriptor. The existing curator tree mixes required
+  ingestion/indexing with optional Tier-B reasoning. A later source-movement slice must split by function
+  before relocation instead of moving the curator wholesale.
+
+No feature is declared dead from a name-only search. The documents identify removal/consolidation rules,
+and later implementation slices must pair definition/reference inventories with supported-journey tests.
+
+## Cleanup and scope
+
+This is documentation and baseline accounting only. It changes no production source, descriptor,
+dependency, build graph, route, configuration behavior, database, GUI, or runtime profile. The status
+baseline shrinks by exactly five entries; the remaining nineteen module documents stay explicit debt.
+
+## Verification
+
+- `python3 -I -S scripts/check_module_docs.py`
+- `python3 -I scripts/tests/test_check_module_docs.py -v`
+- `python3 -I -S scripts/check_module_source_ownership.py`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+- `python3 -I -S scripts/refactor_baselines.py`
+- `make -C src lint`
+- feature-branch pull-request CI

--- a/tests/baselines/modules/documentation-status.yaml
+++ b/tests/baselines/modules/documentation-status.yaml
@@ -1,8 +1,13 @@
 {
   "schema_version": 1,
   "substantive": [
+    "kb-synthesis",
+    "learning",
+    "memory",
     "module-runtime",
-    "plugin-loader"
+    "plugin-loader",
+    "response-composition",
+    "skills"
   ],
   "debt": [
     "audit",
@@ -15,15 +20,10 @@
     "git",
     "governance",
     "ir",
-    "kb-synthesis",
-    "learning",
-    "memory",
     "protocols",
-    "response-composition",
     "roundtable",
     "routing",
     "runtime-web",
-    "skills",
     "tools",
     "translation",
     "vault",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -138,6 +138,27 @@
       "blast_radius": "Documentation and repository validation only; no production source, descriptor, build, route, config, or runtime behavior changes.",
       "independent_review": "Technical-writing and exact-diff roundtable review are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-13.md", "docs/modules/module-runtime.md", "docs/modules/plugin-loader.md"]
+    },
+    {
+      "slice": 14,
+      "state": "present_and_verified",
+      "disposition": "Documented the memory, learning, skills, response-composition, and KB-synthesis family against current source and made physical-ownership gaps explicit.",
+      "production": {
+        "added": [],
+        "deleted": [],
+        "consolidated": []
+      },
+      "fallbacks": ["nineteen module documents remain explicit status debt", "distributed source ownership remains for later behavior-preserving slices"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice adds documentation and baseline accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Placeholder documents would hide the actual split between target ownership and current physical placement.",
+        "revisit": "Each documented relocation candidate requires a focused liveness, consumer, surface, and compatibility audit before movement."
+      },
+      "consumers": ["module maintainers", "technical writers", "modular-refactor CI", "future source-movement slices"],
+      "blast_radius": "No runtime surface changes; the documentation gate verifies descriptor dependencies, activation claims, and the exact debt partition.",
+      "independent_review": "Technical-writing and exact-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-14.md", "docs/modules/memory.md", "docs/modules/learning.md", "docs/modules/skills.md", "docs/modules/response-composition.md", "docs/modules/kb-synthesis.md"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- document required memory, learning, skills, and response-composition modules
- document optional default-off KB synthesis and distinguish its target boundary from the current mixed curator tree
- promote exactly five module documents from tracked debt and record Slice 14 cleanup evidence

## Review
- technical-writer review: approved
- exact-diff roundtable: approved after correcting future-boundary language and cleanup accounting

## Validation
- `python3 -I -S scripts/check_module_docs.py`
- `python3 -I scripts/tests/test_check_module_docs.py -v`
- `python3 -I -S scripts/check_module_source_ownership.py`
- `python3 -I -S scripts/check_cleanup_ledger.py`
- `python3 -I -S scripts/refactor_baselines.py`
- `make -C src lint`
- `git diff --check`