### PR TITLE
ci: publish testing images for Go server changes

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -18,6 +18,9 @@ on:
     # Only rebuild when something that affects the image changes.
     paths:
       - "src/**"
+      # The Go WFE/API service is compiled into aimee-server. Go-only migration
+      # fixes must publish a deployable testing image just like C server changes.
+      - "server-go/**"
       - "config/**"
       - "deploy/container/**"
       - "scripts/**"


### PR DESCRIPTION
## Summary
- trigger testing image publication for changes under `server-go/**`
- keep Go WFE/API deployments automatic during the Go/Rust migration

## Validation
- parsed workflow YAML and asserted the new path is present
- `git diff --check`
- two-round Aimee roundtable converged with no blocking findings