### PR TITLE
Document core execution authority modules

### DIFF
--- a/docs/modules/execution-policy.md
+++ b/docs/modules/execution-policy.md
@@ -1,0 +1,104 @@
+# execution-policy module
+
+## Purpose and non-goals
+
+`execution-policy` is required core and makes fail-closed authorization decisions for delegate,
+tool, filesystem, process, network, credential, and repository actions. It owns the decision
+contract and denial reasons, not the action implementation, secret store, workspace resolver,
+optional governance policy authoring, or append-only audit ledger.
+
+## Public contracts
+
+The target public contract is represented by `src/modules/execution-policy/module.yaml`. The
+`pre_tool_check` path at `src/modules/guardrails/guardrails_action_audit.c:136`, policy loading at
+`src/server/agent_policy.c:395`, and discovery interception are relocation candidates. Schema and
+argument validation such as `tool_validate` stays with `tools`; gateway request policing stays a
+gateway enforcement point that consumes the canonical decision vocabulary. This is not one engine yet.
+
+## Dependencies and consumers
+
+- `config`: supplies effective local authorization, guardrail, approval, and enforcement settings.
+- `ir`: supplies typed requests, tool calls, and action facts evaluated by policy.
+- `module-runtime`: supplies required lifecycle and readiness contracts for the policy service.
+
+Consumers include [delegates](delegates.md), [gateway](gateway.md), `tools`, `git`, `workspace`, and
+the optional workflows and governance modules. Governance may author or distribute organizational
+policy, but core execution-policy remains the final local enforcement boundary when governance is absent.
+These names are consumers or consolidation evidence, not undeclared dependencies of execution-policy.
+
+## Providers and readiness
+
+The required reference provider is the local deterministic policy path built from `guardrails`,
+agent policy, gateway policy, and configuration. Optional semantic classifiers may advise it, but
+readiness requires a local decision for every supported action class; timeout, malformed input, or
+missing policy material must produce a typed denial rather than an unfiltered execution fallback.
+Classifier output is advisory and cannot independently produce an allow or override a core denial.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; the required module cannot be hot-disabled, while individual policy inputs remain configurable.
+
+### Config touchpoint
+
+The module consumes `guardrail_mode` (`src/modules/config/config_fields.c:33`), the `guardrails`
+section (`src/modules/config/config_sections.c:1216`), delegate/tool restrictions, approval
+rules, and related effective settings. `config` owns parsing and truthful projection; policy owns
+interpretation at decision time. Ambiguous duplicated parsing is deferred to the config slice.
+
+## Surfaces
+
+Policy appears through preflight errors, approval prompts, denied tool results, gateway policing,
+guardrail diagnostics, and action audit records. The `aimee guardrails` surface exposes evidence;
+protocol, delegate, Git, and tool commands remain owned by their modules even when a policy decision
+determines whether the requested action proceeds.
+
+## Data and migrations
+
+Current state includes external policy JSON, `session_state_t` guardrail evidence, configuration,
+approval state, and audit references spread across owners. Migration into the module must preserve
+policy version, principal, action class, input digest, decision, reason, approval identity, and
+enforcement point without turning transient secrets or raw untrusted output into policy storage.
+
+## Security and privacy
+
+Inputs include untrusted repository content, tool output, subprocess arguments/environments, and
+configuration. Authorization must precede mutation and secret release; an undecidable action fails
+closed. `execution-policy` may inspect bounded metadata or secret references but must not become a
+secret cache, log raw credentials, or treat optional governance availability as a safety prerequisite.
+Full runtime non-bypass across dynamically constructed calls is a **hypothesis, unverified**.
+
+## Supported journeys
+
+A typed action from [delegates](delegates.md), `tools`, `git`, or `workspace` is normalized with its
+principal, target, capability, and workspace facts; core policy evaluates it; an approval seam runs
+when permitted; and the owning executor receives allow or a concrete denial. Gateway-local policing
+uses the same canonical action vocabulary without transferring gateway ownership into this module.
+
+## Tests and failure behavior
+
+Coverage is distributed across `test_guardrails.c`, `test_agent_policy_intercept.c`,
+`test_gateway_policy.c`, tool-validation tests, Git guard tests, and workflow native-gate tests.
+Malformed actions, missing principal/workspace facts, classifier failure, or unavailable approval
+must deny safely; warning-only modes must remain explicit and cannot masquerade as enforcement.
+
+## Operational diagnostics
+
+Diagnostics must report `policy_version`, principal, canonical action/tool name, target class,
+workspace, enforcement point, decision, and redacted reason. Operators must be able to distinguish
+configuration absence, invalid input, explicit denial, approval timeout, and auxiliary-classifier
+failure without logging command environments, repository contents, or credential values.
+Cross-module citations and limits are collected in the [Slice 16 validation record](../validation/core-modularization-slice-16.md).
+
+## Compatibility
+
+Decision codes, canonical action names, approval semantics, and pre/post-tool enforcement ordering
+are compatibility contracts. Moving guardrails or policy fragments under `execution-policy` must
+preserve CLI/API results and audit correlation; a compatibility shim cannot authorize independently
+or silently translate a denial into an allow.
+
+## Extension and removal
+
+New policy sources plug into one fail-closed decision contract and may strengthen, not bypass, local
+enforcement. `agent_policy`, `gateway_policy`, workflow gates, and guardrails with similarly named
+checks require caller and behavior comparison before consolidation. A self-tested policy island with
+no production enforcement point is a dead-code candidate, not evidence that the module is optional.

--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -1,0 +1,113 @@
+# git module
+
+## Purpose and non-goals
+
+`git` is required core and owns repository state/history access, repository mutation, verification,
+forge operations, and provenance-bearing repository records submitted through memory's public ingest
+boundary. It does not own workspace path authority, code-intelligence storage/indexing/retrieval,
+federated OIDC governance, generic tool dispatch, or secret custody.
+
+## Public contracts
+
+`src/modules/git` owns `git_ops`, MCP `handle_git_*` operations beginning at
+`src/modules/git/mcp_git_query.c:321` and `src/modules/git/mcp_git_write.c:53`, verification, host/remote resolution,
+projects, forge credentials/API, OAuth device flows, and SSH-agent setup. The approved target contract
+is `memory.repository-record.ingest.v1`: Git is submit-only, while [memory](memory.md) retains schema,
+redaction acceptance, persistence, embedding, reranking, and code intelligence.
+
+## Dependencies and consumers
+
+- `audit`: records repository reads, mutations, provenance, policy decisions, and outcomes.
+- `config`: supplies verification, forge, credential, identity, and repository-operation settings.
+- `execution-policy`: authorizes repository, network, credential, hook, and subprocess effects.
+- `memory`: exclusively owns code-intelligence persistence and accepts redacted repository records.
+- `module-runtime`: supplies required lifecycle and readiness contracts for repository capability.
+- `vault`: supplies principal-scoped forge tokens, SSH keys, and credential references.
+- `workspace`: supplies the authorized root, worktree lifecycle, and process/filesystem provider.
+
+Consumers include `tools`, [delegates](delegates.md), [protocols](protocols.md), memory ingest, and
+optional workflows. A non-Git workspace remains usable; Git-only requests return typed
+`capability_absent` without disabling the workspace or core runtime.
+
+## Providers and readiness
+
+Local `git` CLI operations are the required reference path; forge HTTP, OAuth, SSH, and organization/PR
+helpers are provider-specific capabilities beneath the module. Core readiness does not require a forge
+account, but repository operations must report whether local Git, a repository, credentials, signing,
+or a requested forge capability is absent instead of claiming a generic ready state.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; repository capability is core while repositories, forges, credentials, and verification policy are configurable.
+
+### Config touchpoint
+
+The module consumes project verification config, Git identity, forge/provider credentials, live-forge
+gates registered at `src/modules/config/config_fields.c:146`,
+gates, and shell-Git restrictions; `config` owns general parsing and projection. OAuth-for-forge settings
+belong to Git providers. Federated OIDC/SSO settings belong to optional governance and must not appear as
+a required Git configuration dependency.
+
+## Surfaces
+
+Surfaces include native/MCP `git_status`, diff, log, branch, commit, push, pull, fetch, clone, restore,
+reset, stash, tag, issue, PR, and `aimee git verify` operations plus project/forge credential flows.
+Protocol and tools modules expose these operations, but Git owns their repository semantics, credential
+containment, verification gates, and mutation results.
+
+## Data and migrations
+
+Git state includes repository index/refs/commits, verify configuration/state, `git_project` mappings, host
+credential references, OAuth device state, PR/CI results, and signed provenance. Repository-derived
+records are assembled, secret-redacted, principal-scoped, and submitted to memory; Git may not write a
+memory-owned code-intelligence namespace or persist partial pre-redaction records.
+
+## Security and privacy
+
+Repositories, hooks, configs, submodules, forge responses, tool output, argv/environment, and config are
+untrusted. Policy gates mutations and network use; workspace constrains paths; vault retains custody.
+`git_cred_inject_build_env` at `src/modules/git/git_cred_inject.c:235` and SSH/askpass seams handle raw values and therefore must bound inheritance,
+avoid argv/logging, strip child environments, and fail closed when principal or scope is missing.
+
+## Supported journeys
+
+Tools or a delegate request a repository operation; workspace resolves the authorized root;
+execution-policy approves the typed effect; vault supplies a scoped credential only when needed; Git
+performs the local or forge operation and returns a bounded result with audit evidence. Repository
+ingest additionally requires distinct producer/repository provenance and complete pre-ingest redaction.
+
+### Working-tree boundary
+
+`workspace` creates/removes Aimee worktrees, owns their path layout and transient mappings, and isolates
+concurrent sessions. Git owns `.git`-adjacent index, refs, ignore behavior, commits, and repository
+mutations within the selected root. Git must not delete a workspace to recover from repository failure;
+locking outside Git/worktree primitives is a hypothesis, unverified.
+
+## Tests and failure behavior
+
+`test_mcp_git.c`, git ops/project/host/credential/OAuth/SSH/PR/verify suites, guardrail Git tests, and
+integration tool calls cover current behavior. Missing repository, denied mutation, dirty/conflicting
+state, invalid ref/path, failed signature/redaction, absent credential, forge error, or failed verify step
+must return typed failure; non-Git base workspace operations continue normally.
+
+## Operational diagnostics
+
+Report safe repository identity, workspace/principal, `git` operation, branch/ref, dirty state, verification
+step, credential reference/scope, forge host/provider, PR/CI state, provenance verification, redaction,
+and bounded stderr. Diagnostics must exclude tokens, SSH private keys, credential environments, private
+source bytes, and complete forge response bodies unless explicitly redacted.
+Cross-module Git/workspace evidence is collected in the [Slice 16 validation record](../validation/core-modularization-slice-16.md).
+
+## Compatibility
+
+Git tool names and schemas, verify contracts, repository result shapes, project/host resolution,
+credential injection, PR/CI grading, non-Git `capability_absent`, and memory-ingest invariants are
+compatibility contracts. Provider aliases may translate forge APIs but cannot make GitHub-specific
+OAuth equivalent to generic OIDC governance or bypass the canonical repository boundary.
+
+## Extension and removal
+
+New forge or credential providers implement bounded Git seams without expanding the module taxonomy.
+Provider-specific OAuth remains distinct from optional governance OIDC. Shell wrappers, duplicate tool
+schemas, and forge helpers with no caller beyond registration/tests are `configuration-only`, `test-only`,
+or `duplicated-by-adjacent-module` candidates; deletion requires later runtime liveness evidence.

--- a/docs/modules/tools.md
+++ b/docs/modules/tools.md
@@ -1,0 +1,105 @@
+# tools module
+
+## Purpose and non-goals
+
+`tools` is required core and owns typed capability discovery, schemas, argument validation, visibility,
+authorization handoff, dispatch, cancellation, and bounded result handling. It does not own policy
+decisions, raw workspace authority, stored credentials, Git semantics, protocol encoding, or the
+domain behavior of every capability it exposes.
+
+## Public contracts
+
+The target `src/modules/tools` directory is descriptor-only. Current contracts are distributed across
+`agent_tools.h`, `agent_tools.c`, platform `agent_tools*`, `toolset.c`, DB2 `tool_registry`, argument/
+schema helpers, and MCP native dispatch. `build_tools_array*`, `tool_validate`, and
+`dispatch_tool_call_ctx` at `src/posix/agent_tools_dispatch.c:1884` are the principal
+discovery-validation-dispatch seam to consider for consolidation in a later source slice.
+
+## Dependencies and consumers
+
+- `audit`: records authorized tool calls, effects, evidence, and outcomes.
+- `config`: supplies tool visibility, toolsets, output limits, and execution settings.
+- `execution-policy`: authorizes each proposed capability and effect before dispatch.
+- `ir`: supplies canonical tool definitions, calls, results, and streaming events.
+- `module-runtime`: supplies required lifecycle plus optional tool-provider registration contracts.
+- `vault`: supplies scoped secret references or bounded values required by a tool implementation.
+- `workspace`: supplies the selected resource provider and filesystem/process context.
+
+Consumers include [delegates](delegates.md), [protocols](protocols.md), [gateway](gateway.md), skills,
+and optional workflows/plugins. Protocol exposure and delegate loops consume the catalog; neither is
+an alternate owner of schema validation or native dispatch.
+
+## Providers and readiness
+
+Native built-ins and the local `dispatch_tool_call_ctx` platform dispatcher form the required provider. MCP and optional plugins
+may register additional tools through bounded registries. Readiness requires a consistent catalog,
+valid schemas, one dispatch target for every advertised name, and a usable local reference capability;
+advertised-but-unbound tools are an error, not a capability.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; the tool contract is required while individual capabilities and providers are configurable.
+
+### Config touchpoint
+
+The module consumes toolsets, role visibility, output caps (`src/modules/config/config_fields.c:107`),
+compaction thresholds (`src/modules/config/config_sections.c:655`), sandbox/tool policy,
+and provider registration settings. `config` parses and projects values; tools interprets catalog and
+dispatch behavior. A GUI field is valid only when its named tool/provider has a live consumer path.
+
+## Surfaces
+
+Surfaces include model-visible tool schemas, MCP/ACP tool listing and calls, `aimee toolset`, tool events,
+native result envelopes, output retrieval, and diagnostics. Git operations exposed as tools delegate to
+`git`; memory/code search delegates to [memory](memory.md); filesystem/process operations execute through
+`workspace`; naming them in the catalog does not transfer domain ownership.
+
+## Data and migrations
+
+`tool_registry` definitions, prompts, schemas, availability, provider identity, side-effect/idempotence metadata,
+toolset membership, and bounded output references span code, configuration, DB1/DB2, and runtime state.
+Migration must preserve canonical names, schema bytes, visibility, dispatch target, result correlation,
+and cancellation while treating raw outputs, environments, and credential values as transient.
+
+## Security and privacy
+
+Repository content, arguments, tool output, subprocess argv/environment, and configuration are untrusted.
+Every effect passes `execution-policy` and `workspace` containment before invocation. Raw secrets may
+reach a bounded tool provider only through vault-authorized injection and must not enter schemas, model-
+visible errors, output storage, logs, or child environments beyond the explicitly authorized operation.
+
+## Supported journeys
+
+[Delegates](delegates.md) request a catalog filtered by role, provider, and policy; the model emits an
+IR tool call; arguments are coerced and validated; execution-policy authorizes it; workspace and vault
+bind resources; `dispatch_tool_call_ctx` invokes one provider; output is capped/normalized and returned
+as correlated IR plus audit evidence before the next turn.
+
+## Tests and failure behavior
+
+`test_toolset.c`, tool validation/schema/args/output/prompt suites, MCP native surface/dispatch tests,
+script runner, server compute, and agent role-policy tests cover the distributed implementation.
+Unknown, hidden, malformed, cancelled, unauthorized, unbound, or oversized calls fail concretely;
+provider failure cannot fall through to shell execution or return an uncorrelated success result.
+
+## Operational diagnostics
+
+Report canonical tool name, catalog source, `toolset`/role visibility, schema version, provider/dispatch
+target, policy result, workspace binding, duration, cancellation, output size/cap, and redacted status.
+Operators must distinguish absent, hidden, invalid, denied, unavailable, timed-out, and failed tools
+without logging arguments or results that contain secrets or private repository content.
+Cross-module dispatch evidence is collected in the [Slice 16 validation record](../validation/core-modularization-slice-16.md).
+
+## Compatibility
+
+Tool names, schemas, toolset semantics, provider registration, call/result correlation, result envelopes,
+and cancellation are compatibility contracts. Consolidation under `src/modules/tools` must keep native,
+MCP, ACP, and delegate behavior aligned; forwarding code may translate protocol shapes but cannot maintain
+a second catalog or skip common validation.
+
+## Extension and removal
+
+New providers register against the core catalog and dispatch seam with explicit ownership and tests.
+Files named tool that implement Git, memory, gateway messaging, or protocol adapters remain with their
+domain owners. Duplicate schemas/dispatch tables and definitions consumed only by their own tests are
+`duplicated-by-adjacent-module` or `test-only` candidates for a later liveness and consolidation slice.

--- a/docs/modules/vault.md
+++ b/docs/modules/vault.md
@@ -1,0 +1,102 @@
+# vault module
+
+## Purpose and non-goals
+
+`vault` is required core and owns principal-scoped secret custody, encryption, controlled retrieval
+and injection, sealing, rotation, and custody-provider binding. It does not own provider login flows,
+Git or forge protocols, optional OIDC governance, tool execution, workspace selection, or the policy
+that decides whether a caller may request a credential.
+
+## Public contracts
+
+Canonical implementation lives in `src/modules/vault`: the server-wrap retrieval path begins at
+`src/modules/vault/vault_service.c:60`, unlock at line 150, and set/get at lines 265/294;
+`vault_store_*` is the storage facade, `vault_server_key` manages sealing, `vault_principal` binds
+attested identities, and `vault_capability` limits delegated access. Direct calls to internal vault
+implementations outside these facades are boundary violations rather than alternate public APIs.
+
+## Dependencies and consumers
+
+- `config`: supplies selected custody provider and provider-specific effective settings.
+- `execution-policy`: authorizes credential creation, lookup, injection, rotation, and administration.
+- `module-runtime`: supplies required lifecycle and readiness contracts for credential custody.
+
+Consumers include [delegates](delegates.md), `tools`, `git`, `workspace`, provider clients, and server
+vault handlers. Optional governance consumes principal and custody contracts for organizational
+identity; its absence cannot remove local principal isolation or secret protection.
+
+## Providers and readiness
+
+`vault_store_backend_t` supports the local encrypted store and PostgreSQL binding, while
+`vault_custody_provider_t` has file/software, KMS, PKCS#11, and TPM2 implementations. Readiness
+requires exactly one selected usable storage/custody path and a valid seal state; configured hardware
+that cannot attest or unseal must fail concretely rather than downgrade to an undeclared provider.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; credential custody is required while the storage backend and custody provider are selectable.
+
+### Config touchpoint
+
+The module interprets `vault.custody` and `vault.tpm2.*` as registered at
+`src/modules/config/config_fields.c:156`; `config` parses and projects those values.
+Environment/bootstrap credential import and per-provider names are input surfaces, not ownership of
+the secret lifecycle. Provider fields with no compiled and selected consumer must remain hidden.
+
+## Surfaces
+
+Surfaces include `aimee vault`, server vault routes, unlock/lock/rekey/seal operations, credential
+presence checks, provider bootstrap, and scoped injection into delegates or Git operations. Lists
+and health output expose references and state only; protocol clients and GUI forms must never receive
+stored secret values merely to display whether a credential exists.
+
+## Data and migrations
+
+Encrypted records carry principal, agent/provider, credential name, wrapped data key, ciphertext,
+salt, and format/version metadata in file or PostgreSQL stores. `vault_store_rekey` and server-wrap
+migration preserve principal ownership and atomic recoverability. Plaintext, KEKs, unlock passwords,
+and transient injection buffers are never migration payloads.
+
+## Security and privacy
+
+Secret references may cross into `git`, `tools`, and [delegates](delegates.md); raw values
+cross through bounded buffers in `vault_service_get*`, `vault_service_inject_api_key`, Git credential
+environment construction, and provider request setup. Those consumers must zero/free or contain the
+value, avoid argv/log persistence, and remain policy- and principal-scoped; static evidence cannot
+prove every dynamic sink, so full runtime non-leakage remains a hypothesis, unverified.
+
+## Supported journeys
+
+An attested principal unlocks or uses an already authorized server wrap; execution-policy approves a
+credential request; `vault_service_get*` resolves the named secret through the selected custody and
+store providers; the consumer injects it into one bounded operation; and audit records only reference,
+principal, decision, and outcome metadata before transient plaintext is discarded.
+
+## Tests and failure behavior
+
+`test_vault_service.c`, `test_vault_store.c`, `test_vault_seam.c`, capability, principal, bootstrap,
+seal, rotation, PostgreSQL, KMS, PKCS#11, and TPM2 suites cover the layered contracts. Wrong principal,
+locked/sealed state, corrupt ciphertext, missing entry, expired capability, or custody failure must
+return typed failure and never expose partial plaintext or select a weaker backend silently.
+
+## Operational diagnostics
+
+Report selected provider, readiness, sealed/locked state, principal class, credential reference,
+rotation generation, cache count, and redacted status from `vault_status_str`. Logs and metrics must
+exclude ciphertext when unnecessary and always exclude plaintext, passwords, KEKs, tokens, private
+keys, injected environments, and replayable attestation material such as signatures or nonces.
+Cross-module raw-secret evidence is collected in the [Slice 16 validation record](../validation/core-modularization-slice-16.md).
+
+## Compatibility
+
+`vault_service_*`, principal syntax, status values, encrypted record versions, provider seams, and
+seal/rekey recovery are compatibility contracts. Store changes must support explicit migration and
+rollback; legacy secret locations may be imported once but cannot remain an independently readable
+fallback that bypasses principal, policy, or custody checks.
+
+## Extension and removal
+
+New store or custody providers implement the existing internal vtables and prove failure, rotation,
+and non-downgrade behavior. Forge OAuth belongs to `git`, while federated OIDC/SSO belongs to optional
+governance; neither should be absorbed because it handles credentials. Core vault cannot be removed,
+and wrapper paths used only by their own tests are candidates for a later liveness audit.

--- a/docs/modules/workspace.md
+++ b/docs/modules/workspace.md
@@ -1,0 +1,111 @@
+# workspace module
+
+## Purpose and non-goals
+
+`workspace` is required core and owns scoped resource identity, path containment, provider binding,
+working-tree lifecycle, per-turn filesystem/process context, and local coding-agent resource access.
+It does not own Git repository semantics, tool schemas, action authorization, credentials, memory
+scope semantics, or optional workflow orchestration.
+
+## Public contracts
+
+`src/modules/workspace` owns `workspace_active_root` at `src/modules/workspace/workspace.c:117`,
+worktree creation at line 1175, manifests and handles,
+`workspace_provider_t`, per-turn binding, detached/container providers, mirrors, runner queues, and
+`ws_scope_*` containment. The duplicated worktree declarations in `guardrails.h` are a
+compatibility/ownership seam to consolidate, not a second workspace implementation.
+
+## Dependencies and consumers
+
+- `config`: supplies workspace registrations, provider metadata, mirrors, and sandbox overrides.
+- `execution-policy`: authorizes filesystem, process, network, and lifecycle effects within a workspace.
+- `module-runtime`: supplies required lifecycle and readiness contracts for resource access.
+- `vault`: supplies attested principal identity and scoped credentials used by remote resource paths.
+
+Consumers include [delegates](delegates.md), `tools`, `git`, [memory](memory.md), server sessions,
+and optional workflows. A consumer receives a scoped handle/provider; it must not infer authority
+from an arbitrary current directory or replace a requested isolated provider with host execution.
+
+## Providers and readiness
+
+The shared local `workspace_provider_shared` provider is the required reference implementation; detached, mirror, and container
+paths bind through their specialized lifecycle contracts. Readiness requires one provider appropriate
+to the selected workspace and supported operation. A missing detached runner or container handle must
+fail closed; generic kind resolution must not silently defeat an explicit isolation requirement.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; scoped resource access is required while individual workspaces and providers are configurable.
+
+### Config touchpoint
+
+The module consumes `workspaces[]`, provider, VCS remote/head, sandbox image, and workspace-root
+fields declared at `src/modules/config/config.h:270` and parsed at `src/modules/config/config.c:1572`;
+`config` owns parsing and persistence. Workspace interprets registrations into bounded
+handles. Fields for detached, mirror, or container behavior are truthful only when that live provider
+path is registered and usable.
+
+## Surfaces
+
+Surfaces include `aimee workspace add|list|remove|serve`, `/v1/workspaces` handles and runner polling,
+worktree/session isolation, manifests, mirror drift notices, and provider diagnostics. File and process
+tools use the active provider but remain `tools` surfaces; Git status, commits, refs, and forge actions
+remain `git` surfaces.
+
+## Data and migrations
+
+Workspace state includes configured registrations, provider/VCS metadata, `workspace_manifest` records, runner queues,
+mirror state, session-to-worktree mappings, and transient provider bindings. Migration must preserve
+stable workspace identity, principal scope, provider kind, root containment, VCS head, and cleanup
+ownership; queue payloads and live container handles are ephemeral rather than durable authority.
+
+## Security and privacy
+
+`ws_scope_*` validates principal/project components and uses openat-family beneath/no-symlink opens,
+including `O_NOFOLLOW`, where required.
+Repository content, manifests, tool output, runner responses, subprocess argv/environment, and config
+are untrusted. Provider binding and policy checks precede raw I/O; paths, secrets, and private file
+contents must be redacted from diagnostics, and isolation requests cannot degrade to shared host access.
+
+## Supported journeys
+
+A principal selects a registered workspace; `workspace_turn_bind_active` validates its root and binds
+the correct provider; execution-policy authorizes each operation; tools or delegates perform bounded
+I/O; Git may mutate repository state inside the same root; and turn teardown clears bindings and
+reconciles or cleans transient worktrees according to explicit ownership and dirty-state rules.
+
+### Working-tree boundary
+
+Workspace creates, names, reuses, locks through its lifecycle, and removes Aimee worktrees; `git` owns
+index, refs, commits, ignore interpretation, and repository mutations inside them. Workspace owns
+transient mapping/runner state, while Git owns tracked state. Concurrent access is mediated by distinct
+session/delegate worktrees and registries; locking outside Git/worktree primitives is a hypothesis, unverified.
+
+## Tests and failure behavior
+
+`test_workspace.c`, handle, manifest, mirror, provider, detached/container, runner queue/registry,
+scope, and turn suites cover the implementation. Invalid or foreign roots, traversal/symlink escape,
+missing runner, drift, provider mismatch, and dirty cleanup must surface explicitly. A failed isolated
+binding must never retry through the shared host provider.
+
+## Operational diagnostics
+
+Report `workspace_id`, safe root identity, principal class, provider kind, binding/runner state, mirror
+head and drift category, worktree/session identity, dirty status, and cleanup result. Diagnostics must
+distinguish unregistered, unauthorized, unreachable, divergent, and provider-unavailable states while
+redacting credentials, private file bytes, and runner request environments.
+Cross-module working-tree evidence is collected in the [Slice 16 validation record](../validation/core-modularization-slice-16.md).
+
+## Compatibility
+
+Workspace IDs, registration shape, `workspace_provider_t`, handle manifests, per-turn binding, path
+containment, worktree naming, and cleanup behavior are compatibility contracts. Moving duplicate
+guardrail helpers or platform shims must preserve call semantics and avoid parallel registries; provider
+aliases cannot silently change an isolated workspace into a shared one.
+
+## Extension and removal
+
+New resource providers implement the narrow `workspace_provider_t` raw-I/O interface; they make no
+policy decision because authorization and path validation remain above it. Mirror, detached, and container implementations must each prove a live acquisition-to-release
+journey; registry-only or self-test-only paths are dead-code candidates. Workspace cannot be optional
+because every delegate/tool execution requires bounded resource authority, including non-Git directories.

--- a/docs/validation/core-modularization-slice-16.md
+++ b/docs/validation/core-modularization-slice-16.md
@@ -1,0 +1,188 @@
+# Core modularization slice 16: execution-authority documentation
+
+## Diff scope precondition
+
+The slice-start commit is `610851a04f08ce210c17a65c7b1c98d2ad424326`. The allowed close diff is
+limited to these five module documents, the closed documentation-status partition, this validation
+record, and the existing cleanup ledger:
+
+- `docs/modules/execution-policy.md`
+- `docs/modules/vault.md`
+- `docs/modules/workspace.md`
+- `docs/modules/tools.md`
+- `docs/modules/git.md`
+- `tests/baselines/modules/documentation-status.yaml`
+- `docs/validation/core-modularization-slice-16.md`
+- `tests/baselines/refactor/cleanup-ledger.json`
+
+Close-time `git diff --cached --numstat` includes eight files, 747 insertions, and
+7 deletions. All seven deletions are in the status partition: five
+promoted IDs plus two surviving list lines reserialized to add or remove a trailing comma.
+
+No production source, descriptor, build graph, route, configuration behavior, database, GUI, checker,
+or runtime profile changes are allowed. The close-time `git diff --name-only` and `git diff --stat`
+checks enforce this path set; no exception channel is used.
+
+## Outcome
+
+This slice promotes exactly `execution-policy`, `vault`, `workspace`, `tools`, and `git` from
+documentation debt. They form the required execution-authority family: policy authorizes effects,
+vault mediates secret custody, workspace supplies bounded resource authority, tools exposes and
+dispatches typed capabilities, and Git owns repository semantics. This is a documentation/baseline
+classification, not a claim that physical consolidation or the future executable core proof is complete.
+
+The eight remaining documentation-debt entries are `audit`, `benchmarks`, `config`, `control-web`,
+`governance`, `roundtable`, `runtime-web`, and `workflows`.
+Within this closed debt set, `audit` is required-core deferred; the other seven entries are optional.
+
+## Slice 16 Reconciled Appendix
+
+### Method and limits
+
+The inspection used descriptor dependencies, definitions/references, CLI/API surfaces, configuration
+readers, test targets, and the already approved Git/core contracts. Each module document retains the
+13-section schema enforced by `scripts/check_module_docs.py`; requested ownership, effect, credential,
+workspace, and config-touchpoint evidence is embedded in those canonical sections rather than creating
+a competing template.
+
+The review was static. It can identify definitions, compiled tests, registrations, and visible callers,
+but it cannot prove runtime reachability, absence of dynamically constructed calls, secret erasure on
+every failure path, or cross-process locking. Such claims are labeled **hypothesis, unverified**. A
+dead-code **candidate, not confirmed** requires no static import/reference and no configuration or
+registration reference in the inspected surface. Candidate vocabulary is restricted to `unreachable`,
+`superseded`, `configuration-only`, `test-only`, and `duplicated-by-adjacent-module`.
+
+The threat model covers untrusted repository files, hooks, configs and submodule pointers; untrusted
+tool output and structured results; untrusted subprocess argv/environment; and untrusted configuration.
+Network-position attackers, dependency supply-chain compromise, side channels, and physical access are
+outside this slice's static boundary claims.
+
+Deferred modules were inspected only at their boundary touchpoints: `audit` action calls, workflow native
+gates/forge calls, governance dependencies, and config readers. Their internal architectures and final
+ownership are not asserted here. The GUI modules, benchmarks, and roundtable required no deeper inspection.
+
+### Inspected inventory and evidence
+
+### Execution policy
+
+Owned/target evidence includes `src/modules/execution-policy/module.yaml`; the distributed
+`src/modules/guardrails/*`; `src/server/agent_policy.c`; `src/server/agent_policy_intercept.c` and its
+header; and `src/gateway_policy.c` and its header. Key entry points are
+`pre_tool_check` (`src/modules/guardrails/guardrails_action_audit.c:136`), `pre_tool_check_inner`
+(`src/modules/guardrails/guardrails_orchestrator.c:1197`), `tool_validate`
+(`src/server/agent_policy.c:252`), `policy_load` (`src/server/agent_policy.c:395`), and
+`gateway_policy_apply_request` (`src/gateway_policy.c:94`). Tests inspected include guardrails,
+gateway-policy, agent-policy-intercept, tool-validation, and workflow native-gate suites.
+
+### Vault
+
+Owned evidence includes all `src/modules/vault/*`; storage provider `src/db2/vault_pg.*`; server entry
+points in `src/server/server_vault*.c`; and KB rewrap/binding touchpoints. The service boundary begins at
+`vault_service_unlock` (`src/modules/vault/vault_service.c:150`), set/get at lines 265/294, injection at
+line 360, principal resolution at `src/modules/vault/vault_principal.c:31`, storage binding at
+`src/modules/vault/vault_store.c:995`, and server-key readiness at
+`src/modules/vault/vault_server_key.c:461`. Vault service/store/seam, audit, capability, custody,
+principal, seal, rotation, bootstrap, and PostgreSQL tests were inspected.
+
+Static raw-secret consumers outside vault are: provider credential buffers in
+`src/server/agent_config.c:334`; delegate retry/injection in
+`src/modules/delegates/delegate_credential_retry.c:39`; forge token/SSH-key buffers in
+`src/modules/git/git_forge_vault.c:15`; Git credential resolution at
+`src/modules/git/git_cred_inject.c:166`; Git SSH-agent key loading in
+`src/modules/git/git_ssh_agent.c:134`; server OAuth client material in `src/server/oauth_tokens.c:57`;
+and PKI key material in `src/server/pki.c:554`. The repository-scoped environment builder starts at
+line 177, its compatibility wrapper at line 235, and cleanup zeroes the token environment through
+`git_cred_inject_free_env` at line 265. Complete dynamic non-logging and non-persistence across every consumer is
+a **hypothesis, unverified**. Log/persistence inspection covered those consumers, `vault_service.c`,
+`vault_store.c`, server vault handlers, and delegate credential retry; no runtime trace was collected.
+
+### Workspace
+
+Owned evidence includes all `src/modules/workspace/*`, platform provider implementations under
+`src/posix` and `src/windows`, CLI workspace dispatch in `src/cli_main.c`, server workspace/runner routes,
+and config registration readers. Key boundaries are `workspace_active_root`
+(`src/modules/workspace/workspace.c:117`), worktree creation (line 1175),
+`workspace_turn_bind_active` (`src/modules/workspace/workspace_turn.c:249`), runner registry creation
+(`src/modules/workspace/workspace_runner_registry.c:31`), and TOCTOU-safe project open
+(`src/modules/workspace/workspace_scope.c:343`). Workspace, handle, manifest, mirror, provider,
+detached/container, runner, scope, and turn tests were inspected.
+
+### Tools
+
+The target `src/modules/tools` directory currently contains only its descriptor. Distributed owned
+candidates include `src/headers/agent_tools.h`, `src/server/agent_tools.c`, platform `agent_tools*`,
+`src/toolset.c`, `src/headers/toolset.h`, `src/db2/tool_registry.*`, tool argument/schema helpers,
+`src/cmd_toolset.c`, and `src/tool_prompts/*`. The live seams are `build_tools_array`
+(`src/server/agent_tools.c:1492`), Git-provider registration (line 1344),
+`dispatch_tool_call_ctx` (`src/posix/agent_tools_dispatch.c:1884`), effective toolsets
+(`src/toolset.c:534`), and DB2 lookup (`src/db2/tool_registry.c:10`). Toolset, validation, schema,
+arguments, output, prompts, MCP native dispatch/surface, script-runner, and server-compute tests were inspected.
+
+### Git
+
+Owned evidence includes all `src/modules/git/*`, Git route wiring in
+`src/server/server_http_routes_git.c`, the approved `git-core-contract.md`, and native/MCP/CLI consumers.
+Key effects are status (`src/modules/git/mcp_git_query.c:321`), commit/push
+(`src/modules/git/mcp_git_write.c:53` and `:211`), verification
+(`src/modules/git/git_verify.c:1409`), credential environment construction
+(`src/modules/git/git_cred_inject.c:177`), and project remote resolution
+(`src/modules/git/git_project.c:1305`). MCP Git, ops, project, credential, OAuth, SSH, PR/CI, verify,
+guardrail, and webchat leak tests were inspected.
+
+### Authority-flow matrix
+
+| Verified operation | Authorizes | Exposes capability | Supplies credentials | Selects workspace | Mutates repository state |
+|---|---|---|---|---|---|
+| Native file/process tool call | `execution-policy` | `tools` via protocols/delegates | `vault` when explicitly required | `workspace` | no Git metadata mutation; workspace may change working-tree bytes |
+| Git commit or push tool | `execution-policy` | `tools`/protocols | `vault` through Git injection | `workspace` | `git` owns index, refs, commit, and remote mutation |
+| Delegate provider invocation | `execution-policy` | [delegates](../modules/delegates.md) | `vault` | `workspace` | none unless the delegate invokes a Git capability |
+| Vault set, unlock, or rotate | `execution-policy` | `vault` CLI/API | `vault` owns custody | no workspace required | none |
+| Detached workspace file operation | `execution-policy` | `tools` or Slice-15 `delegates` | `vault` supplies principal/remote material where required | `workspace` | no index/ref mutation unless routed to `git` |
+| Repository-record ingest | `execution-policy` | `git` submits to [memory](../modules/memory.md) | `vault` supplies scoped signing/transport material | `workspace` | `git` reads state; `memory` alone persists code intelligence |
+
+This matrix describes verified ownership, not a guaranteed runtime call order. Descriptor dependencies
+remain authoritative and do not form the narrative chain as a simple topological sequence.
+
+### Working-tree boundary
+
+`workspace` selects roots, validates containment, creates/reuses/cleans Aimee worktrees, binds providers,
+and owns transient session/runner mappings. `git` owns repository index, refs, commits, ignore semantics,
+remote operations, and verification of Git state inside that root. File tools may change working-tree
+bytes through workspace authority but do not thereby own Git metadata. Concurrent delegates receive
+separate session/work-name worktrees; Git and worktree primitives mediate known collisions. Locking
+outside those primitives is a **hypothesis, unverified**.
+
+### Overlap and liveness findings
+
+| Pair | Evidence | Class | Disposition |
+|---|---|---|---|
+| `execution-policy::pre_tool_check` ↔ `tools::dispatch_tool_call_ctx` | `guardrails_action_audit.c:136`; `agent_tools_dispatch.c:1884` | boundary handoff, not duplicate | `retain`; relocate only in a source slice |
+| `execution-policy::policy_is_source_discovery` ↔ [memory code intelligence](../modules/memory.md) | `src/server/agent_policy_intercept.c:113`; `src/cli_main.c:1986` | policy/command ownership boundary, not duplicate | `relocate` the classifier only in an execution-policy source slice |
+| `execution-policy::gateway_policy_apply_request` ↔ [gateway policy](../modules/gateway.md) | `src/gateway_policy.c:94`; `src/server/anthropic_http.c:345` | overlap with a documented execution module | `defer` to an execution-policy source slice |
+| `tools::agent_tools Git schemas/providers` ↔ `git::mcp_git handlers` | `src/server/agent_tools.c:807`; `src/modules/git/mcp_git_query.c:321` | `duplicated-by-adjacent-module` candidate, not confirmed | `defer` schema/dispatch consolidation |
+| `workspace::worktree_* declarations` ↔ `execution-policy::guardrails.h worktree declarations` | `src/modules/workspace/workspace.h:67`; `src/modules/guardrails/guardrails.h:219` | `duplicated-by-adjacent-module` candidate, not confirmed | `relocate` in a workspace source slice after comparison |
+| `tools::tool_git_* platform readers` ↔ `git::mcp_git_query` | `src/posix/agent_tools.c:1817`; `src/modules/git/mcp_git_query.c:321` | `duplicated-by-adjacent-module` candidate, not confirmed | `defer` behavior/caller comparison before deletion |
+| `vault::vault_store_backend_t` ↔ `db2::vault_pg_backend` | `src/modules/vault/vault_internal.h:27`; `src/db2/vault_pg.c:745` | provider implementation, not duplicate authority | `retain` behind the vault facade |
+
+No `unreachable`, `superseded`, `configuration-only`, or `test-only` candidate met the static threshold.
+Each substantial provider family has a non-test definition/reference, route, registry, or configuration
+touchpoint. That is not runtime liveness proof; dynamic reachability remains for later source slices.
+
+### Deferred touchpoints
+
+- `config`: parsing/projection stays deferred; each module doc includes one `Config touchpoint` subsection.
+- `audit`: required core event ownership will be documented later; this slice records it only as a dependency.
+- `workflows`: native gates and live-forge calls are consumers, not execution-policy or Git owners here.
+- `governance`: owns federated OIDC/SSO and organizational policy; local enforcement and custody stay core.
+- `benchmarks`, `roundtable`, `control-web`, `runtime-web`: no ownership decision is made in this slice.
+
+## Verification
+
+- `python3 -I -S scripts/check_module_docs.py`
+- `python3 -I scripts/tests/test_check_module_docs.py -v`
+- `python3 -I -S scripts/check_module_source_ownership.py`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+- `python3 -I -S scripts/refactor_baselines.py`
+- `make -C src lint`
+- close-time changed-path and diff-stat scope checks
+- feature-branch pull-request CI

--- a/tests/baselines/modules/documentation-status.yaml
+++ b/tests/baselines/modules/documentation-status.yaml
@@ -13,21 +13,21 @@
     "response-composition",
     "routing",
     "skills",
-    "translation"
+    "translation",
+    "execution-policy",
+    "vault",
+    "workspace",
+    "tools",
+    "git"
   ],
   "debt": [
     "audit",
     "benchmarks",
     "config",
     "control-web",
-    "execution-policy",
-    "git",
     "governance",
     "roundtable",
     "runtime-web",
-    "tools",
-    "vault",
-    "workflows",
-    "workspace"
+    "workflows"
   ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -176,6 +176,23 @@
       "blast_radius": "No runtime surface changes; the documentation gate verifies dependencies, activation claims, and the exact debt partition.",
       "independent_review": "Technical-writing and exact-diff roundtable review are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-15.md", "docs/modules/ir.md", "docs/modules/translation.md", "docs/modules/routing.md", "docs/modules/gateway.md", "docs/modules/protocols.md", "docs/modules/delegates.md"]
+    },
+    {
+      "slice": 16,
+      "state": "present_and_verified",
+      "disposition": "Documented the five required execution-authority modules against current source, including policy, raw-secret, workspace, tool-dispatch, Git's submit-to-memory boundary, and working-tree claims with hypothesis-unverified markers preserved; three duplicated-by-adjacent-module candidates are deferred or referred for relocation, and no dead-code candidate is confirmed.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["eight module documents remain explicit status debt", "distributed execution-policy and tools source remains for focused liveness and movement slices"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice adds documentation and baseline accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "A second documentation schema or speculative source move would duplicate gates and overstate static reachability evidence.",
+        "revisit": "The validation record refers duplicated-by-adjacent-module candidates to later source slices with runtime liveness and behavior comparison."
+      },
+      "consumers": ["module maintainers", "technical writers", "future execution-authority source slices"],
+      "blast_radius": "No runtime surface changes; the strict module-doc gate and close-time path check constrain the slice to five docs, status, validation, and ledger accounting.",
+      "independent_review": "Technical-writing and exact-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-16.md", "docs/modules/execution-policy.md", "docs/modules/vault.md", "docs/modules/workspace.md", "docs/modules/tools.md", "docs/modules/git.md"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- document required core `execution-policy`, `vault`, `workspace`, `tools`, and `git` against current source
- record authority flow, raw-secret consumers, Git/workspace ownership, config touchpoints, and overlap/liveness candidates
- promote exactly those five modules in the closed documentation-status partition and add Slice 16 cleanup evidence

## Scope

Documentation and baseline accounting only: eight files, 747 insertions, 7 deletions, with no production, descriptor, build, route, config, database, GUI, checker, or runtime-profile change.

## Review

- technical-writer packet reviews approved after grounded corrections
- boundary/reconciled plan approved by roundtable
- exact staged diff approved by roundtable after resolving all eight findings

## Verification

- `python3 -I -S scripts/check_module_docs.py`
- `python3 -I scripts/tests/test_check_module_docs.py -v`
- `python3 -I -S scripts/check_module_source_ownership.py`
- `python3 -I -S scripts/check_cleanup_ledger.py`
- `python3 -I -S scripts/refactor_baselines.py`
- `make -C src lint`
- exact eight-path scope check
- `git diff --cached --check`