### PR TITLE
fix(wfe): cancel delegates and preserve panel seats

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -146,6 +146,25 @@ func (s *Store) ForgetDelegateJob(ctx context.Context, key string) error {
 	return err
 }
 
+// ForgetDelegateJobIfMatches physically compare-deletes a durable mapping by
+// execution key and job ID. It returns true only when exactly that row was
+// deleted; a later retry under the same logical key is preserved.
+func (s *Store) ForgetDelegateJobIfMatches(ctx context.Context, key string, jobID int) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if key == "" || jobID <= 0 {
+		return false, errors.New("delegate execution key and job id are required")
+	}
+	result, err := s.db.ExecContext(ctx,
+		`DELETE FROM lifecycle_delegate_job WHERE execution_key=? AND job_id=?`, key, jobID)
+	if err != nil {
+		return false, err
+	}
+	changed, err := result.RowsAffected()
+	return changed == 1, err
+}
+
 // CancelUnassignedDelegateJob atomically reaps only a pending resource-plane job
 // that no agent has claimed. The predicate prevents a lease race from cancelling
 // work after assignment.

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -325,3 +325,28 @@ func TestCancelUnassignedDelegateJobIsAtomicAndAssignmentSafe(t *testing.T) {
 		t.Fatalf("status=%q reason=%q", status, reason)
 	}
 }
+
+func TestForgetDelegateJobIfMatchesCannotEraseNewerRetry(t *testing.T) {
+	store := newTestStore(t)
+	const key = "same-logical-seat"
+	if err := store.SaveDelegateJob(t.Context(), key, 51); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveDelegateJob(t.Context(), key, 52); err != nil {
+		t.Fatal(err)
+	}
+	forgot, err := store.ForgetDelegateJobIfMatches(t.Context(), key, 51)
+	if err != nil || forgot {
+		t.Fatalf("stale cleanup forgot=%v err=%v", forgot, err)
+	}
+	if jobID, err := store.DelegateJob(t.Context(), key); err != nil || jobID != 52 {
+		t.Fatalf("newer retry mapping job=%d err=%v", jobID, err)
+	}
+	forgot, err = store.ForgetDelegateJobIfMatches(t.Context(), key, 52)
+	if err != nil || !forgot {
+		t.Fatalf("matching cleanup forgot=%v err=%v", forgot, err)
+	}
+	if _, err := store.DelegateJob(t.Context(), key); err == nil {
+		t.Fatal("matching cleanup retained mapping")
+	}
+}

--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -29,6 +29,10 @@ type DelegateRequest struct {
 	Stage            string
 	ExecutionVersion string
 	RetryTag         string
+	// DurableSlot distinguishes parallel logical consumers of an otherwise
+	// identical request. It participates in the local job key only and is never
+	// sent to the resource plane as routing configuration.
+	DurableSlot string
 	// ArtifactStage is the validated workflow artifact stage a review delegate
 	// must evaluate. It is carried structurally so runner collaborators and test
 	// doubles never need to recover authority from prompt prose.
@@ -83,9 +87,12 @@ const (
 	MinDelegatePendingTimeout     = 2 * time.Second
 	DefaultDelegatePendingTimeout = 2 * time.Minute
 	MaxDelegatePendingTimeout     = time.Hour
+	delegateCancelTimeout         = 10 * time.Second
+	delegateForgetTimeout         = 3 * time.Second
 )
 
 var ErrDelegateUnassignedExpired = errors.New("unassigned delegate lease expired")
+var ErrDelegateCancelUnacknowledged = errors.New("delegate cancellation was not acknowledged")
 
 // HTTPAgentClient talks to the agent service as a resource plane. It owns no
 // workflow state or transitions; losing it parks the Go-owned run and a later
@@ -191,7 +198,7 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 	unassignedSince := time.Now()
 	for {
 		if err := ctx.Err(); err != nil {
-			_ = c.cancelRemote(launched.JobID, ctx)
+			_ = c.cancelRemoteAndForget(launched.JobID, key, ctx)
 			return DelegateResult{}, err
 		}
 		var status struct {
@@ -203,7 +210,7 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 		}
 		if err := c.doJSON(ctx, http.MethodPost, "/v1/delegate/status", map[string]any{"job_id": launched.JobID, "full_result": true, "result_limit": -1}, &status); err != nil {
 			if ctx.Err() != nil {
-				_ = c.cancelRemote(launched.JobID, ctx)
+				_ = c.cancelRemoteAndForget(launched.JobID, key, ctx)
 				return DelegateResult{}, ctx.Err()
 			}
 			// Once the resource plane has acknowledged that a job is waiting
@@ -214,7 +221,7 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 			if !unassignedSince.IsZero() {
 				select {
 				case <-ctx.Done():
-					_ = c.cancelRemote(launched.JobID, ctx)
+					_ = c.cancelRemoteAndForget(launched.JobID, key, ctx)
 					return DelegateResult{}, ctx.Err()
 				case <-ticker.C:
 					continue
@@ -272,7 +279,7 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 			// The remote resource-plane job outlives an HTTP poll unless it is
 			// explicitly cancelled. Wait for the cancellation acknowledgement so
 			// a wall-cap resume cannot overlap the old job in the same worktree.
-			_ = c.cancelRemote(launched.JobID, ctx)
+			_ = c.cancelRemoteAndForget(launched.JobID, key, ctx)
 			return DelegateResult{}, ctx.Err()
 		case <-ticker.C:
 		}
@@ -362,12 +369,32 @@ func (c *HTTPAgentClient) EligibleAgents(ctx context.Context, role string) ([]El
 	return eligible, nil
 }
 
-func (c *HTTPAgentClient) cancelRemote(jobID int, parent context.Context) error {
-	cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(parent), 10*time.Second)
+func (c *HTTPAgentClient) cancelRemoteAndForget(jobID int, key string, parent context.Context) error {
+	cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(parent), delegateCancelTimeout)
 	defer cancel()
-	var ignored map[string]any
-	return c.doJSON(cancelCtx, http.MethodPost, "/v1/job/cancel",
-		map[string]any{"job_id": jobID, "reason": "WFE turn cancelled"}, &ignored)
+	var response struct {
+		Cancelled *bool `json:"cancelled"`
+	}
+	// Delegate jobs live on the plural /v1/jobs resource. The singular
+	// /v1/job/cancel endpoint controls coordinated jobs and can return HTTP 200
+	// while leaving a delegate pending forever.
+	if err := c.doJSON(cancelCtx, http.MethodPost, "/v1/jobs/cancel",
+		map[string]any{"job_id": jobID, "reason": "WFE turn cancelled"}, &response); err != nil {
+		return fmt.Errorf("%w: job %d: %w", ErrDelegateCancelUnacknowledged, jobID, err)
+	}
+	if response.Cancelled == nil || !*response.Cancelled {
+		return fmt.Errorf("%w: job %d", ErrDelegateCancelUnacknowledged, jobID)
+	}
+	if c.store == nil || key == "" {
+		return nil
+	}
+	// /v1/jobs/cancel atomically marks the delegate job cancelled before it
+	// returns cancelled=true. Give local cleanup an independent bounded window;
+	// if it fails, replay remains safe because status observes that terminal row.
+	forgetCtx, forgetCancel := context.WithTimeout(context.WithoutCancel(parent), delegateForgetTimeout)
+	defer forgetCancel()
+	_, err := c.store.ForgetDelegateJobIfMatches(forgetCtx, key, jobID)
+	return err
 }
 
 func (c *HTTPAgentClient) doJSON(ctx context.Context, method, path string, input, output any) error {

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -47,6 +48,214 @@ func TestHTTPAgentClientReusesDurableRemoteJob(t *testing.T) {
 	}
 	if launches.Load() != 1 {
 		t.Fatalf("launches=%d, want durable reuse", launches.Load())
+	}
+}
+
+func TestHTTPAgentClientDurableSlotsLaunchDistinctJobs(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var launches atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			var payload map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			for _, localOnly := range []string{"durable_slot", "DurableSlot", "durableslot", "retry_tag", "RetryTag"} {
+				if _, leaked := payload[localOnly]; leaked {
+					t.Errorf("local durable-key field %q leaked in payload %v", localOnly, payload)
+				}
+			}
+			jobID := launches.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": jobID})
+		case "/v1/delegate/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "done", "result": "complete"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store, PollEvery: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := DelegateRequest{Role: "review", Persona: "qa", Prompt: "review complete artifact",
+		WorkItemID: "wi_slots", Stage: "gate", ExecutionVersion: "v1"}
+	for _, slot := range []string{"panel:gate:round:1:seat:0", "panel:gate:round:1:seat:1"} {
+		request.DurableSlot = slot
+		if _, err := client.Delegate(t.Context(), request); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if launches.Load() != 2 {
+		t.Fatalf("distinct durable slots launched %d jobs", launches.Load())
+	}
+}
+
+func TestHTTPAgentClientPreservesContextCancellationWhenRemoteDoesNotAcknowledge(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	statusStarted := make(chan struct{})
+	statusRelease := make(chan struct{})
+	var statusOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 45})
+		case "/v1/delegate/status":
+			statusOnce.Do(func() { close(statusStarted) })
+			<-statusRelease
+		case "/v1/jobs/cancel":
+			_ = json.NewEncoder(w).Encode(map[string]any{"cancelled": false})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store, PollEvery: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review complete artifact",
+		WorkItemID: "wi_cancel_false", Stage: "gate", ExecutionVersion: "v1"}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, callErr := client.Delegate(ctx, request)
+		done <- callErr
+	}()
+	<-statusStarted
+	cancel()
+	callErr := <-done
+	close(statusRelease)
+	if !errors.Is(callErr, context.Canceled) {
+		t.Fatalf("context cancellation was replaced: %v", callErr)
+	}
+	if jobID, err := store.DelegateJob(t.Context(), delegateJobKey(request)); err != nil || jobID != 45 {
+		t.Fatalf("unacknowledged remote cancellation mapping job=%d err=%v", jobID, err)
+	}
+}
+
+func TestHTTPAgentClientCancelsDelegateResourceAndForgetsAcknowledgedJob(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	statusStarted := make(chan struct{})
+	statusRelease := make(chan struct{})
+	var statusOnce sync.Once
+	var singularCancels atomic.Int32
+	var pluralCancels atomic.Int32
+	var cancelledJobID atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 43})
+		case "/v1/delegate/status":
+			statusOnce.Do(func() { close(statusStarted) })
+			<-statusRelease
+		case "/v1/job/cancel":
+			singularCancels.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"cancelled": true})
+		case "/v1/jobs/cancel":
+			pluralCancels.Add(1)
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if len(body) != 2 || body["reason"] != "WFE turn cancelled" {
+				t.Errorf("cancel body=%v", body)
+			}
+			jobID, _ := body["job_id"].(float64)
+			cancelledJobID.Store(int32(jobID))
+			_ = json.NewEncoder(w).Encode(map[string]any{"cancelled": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store, PollEvery: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review",
+		WorkItemID: "wi_cancel", Stage: "gate", ExecutionVersion: "v1"}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() {
+		_, callErr := client.Delegate(ctx, request)
+		done <- callErr
+	}()
+	<-statusStarted
+	cancel()
+	if callErr := <-done; !errors.Is(callErr, context.Canceled) {
+		t.Fatalf("delegate cancellation error=%v", callErr)
+	}
+	close(statusRelease)
+	if singularCancels.Load() != 0 || pluralCancels.Load() != 1 || cancelledJobID.Load() != 43 {
+		t.Fatalf("singular=%d plural=%d job_id=%d", singularCancels.Load(), pluralCancels.Load(), cancelledJobID.Load())
+	}
+	if _, err := store.DelegateJob(t.Context(), delegateJobKey(request)); err == nil {
+		t.Fatal("acknowledged cancelled delegate retained its durable mapping")
+	}
+}
+
+func TestCancelRemoteRetainsMappingWithoutBooleanAcknowledgement(t *testing.T) {
+	tests := []struct {
+		name, response string
+		status         int
+	}{
+		{name: "explicit false", response: `{"cancelled":false}`},
+		{name: "missing field", response: `{}`},
+		{name: "null field", response: `{"cancelled":null}`},
+		{name: "numeric field", response: `{"cancelled":1}`},
+		{name: "wrong type", response: `{"cancelled":"true"}`},
+		{name: "error status with true body", status: http.StatusInternalServerError, response: `{"cancelled":true}`},
+		{name: "empty body"},
+		{name: "no content", status: http.StatusNoContent},
+		{name: "non json", response: `cancelled`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/jobs/cancel" {
+					http.NotFound(w, r)
+					return
+				}
+				if tc.status != 0 {
+					w.WriteHeader(tc.status)
+				}
+				_, _ = w.Write([]byte(tc.response))
+			}))
+			defer server.Close()
+			client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store})
+			if err != nil {
+				t.Fatal(err)
+			}
+			const key = "cancel-unacknowledged"
+			if err := store.SaveDelegateJob(t.Context(), key, 44); err != nil {
+				t.Fatal(err)
+			}
+			cancelErr := client.cancelRemoteAndForget(44, key, t.Context())
+			if cancelErr == nil {
+				t.Fatal("unacknowledged cancellation returned success")
+			}
+			if !errors.Is(cancelErr, ErrDelegateCancelUnacknowledged) {
+				t.Fatalf("cancel error=%v", cancelErr)
+			}
+			if jobID, err := store.DelegateJob(t.Context(), key); err != nil || jobID != 44 {
+				t.Fatalf("unacknowledged cancellation mapping job=%d err=%v", jobID, err)
+			}
+		})
 	}
 }
 

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -518,7 +519,7 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 		if prior != "" {
 			prompt += "\n\nPRIOR PANEL FINDINGS:\n" + prior + "\n\nReconsider the artifact and the other reviewers' findings. Preserve valid blockers, remove invalid or duplicate blockers, and approve only if no actionable blocker remains."
 		}
-		feedback, approvals, voters, cost, unreachable := r.runPanelRound(ctx, req, seats, prompt, reviewed.Hash, stage)
+		feedback, approvals, voters, cost, unreachable := r.runPanelRound(ctx, req, seats, prompt, reviewed.Hash, stage, round)
 		totalCost += cost
 		if unreachable != "" {
 			return StepResult{Status: StepPending, PauseReason: "panel_unreachable", Detail: unreachable, CostUSD: totalCost}, nil
@@ -561,7 +562,7 @@ func normalizeRoundtableStage(raw string) (string, bool) {
 	}
 }
 
-func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats []panelSeat, prompt, artifactHash, artifactStage string) (wfe.ReviewFeedback, int, int, float64, string) {
+func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats []panelSeat, prompt, artifactHash, artifactStage string, panelRound int) (wfe.ReviewFeedback, int, int, float64, string) {
 	type outcome struct {
 		seat   panelSeat
 		result panelResponse
@@ -572,13 +573,16 @@ func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats
 	for _, seat := range seats {
 		seat := seat
 		go func() {
-			res, err := r.delegate(ctx, req, DelegateRequest{Role: roundtableDelegateRole, Persona: seat.persona, Delegate: seat.delegate, Prompt: prompt, Workdir: req.WorkItem.Worktree, ArtifactStage: artifactStage})
+			// Repeated persona/agent pairs must not collide and reuse one remote
+			// result, so each capacity seat carries a distinct durable slot.
+			seatSlot := panelSeatDurableSlot(req, panelRound, seat.ordinal)
+			res, err := r.delegate(ctx, req, DelegateRequest{Role: roundtableDelegateRole, Persona: seat.persona, Delegate: seat.delegate, Prompt: prompt, Workdir: req.WorkItem.Worktree, DurableSlot: seatSlot, ArtifactStage: artifactStage})
 			if err != nil && !seat.pinned && seat.delegate != "" {
 				// Capacity assignments are routing hints for this panel run, not UI
 				// pins. If the assigned subscription is temporarily unavailable,
 				// retry through ordinary live eligibility after that failed slot has
 				// released its lease. Never persist the failure as an exclusion.
-				res, err = r.delegate(ctx, req, DelegateRequest{Role: roundtableDelegateRole, Persona: seat.persona, Prompt: prompt, Workdir: req.WorkItem.Worktree, RetryTag: fmt.Sprintf("eligible-fallback:%d:%s", seat.ordinal, seat.delegate), ArtifactStage: artifactStage})
+				res, err = r.delegate(ctx, req, DelegateRequest{Role: roundtableDelegateRole, Persona: seat.persona, Prompt: prompt, Workdir: req.WorkItem.Worktree, RetryTag: fmt.Sprintf("eligible-fallback:%d:%s", seat.ordinal, seat.delegate), DurableSlot: seatSlot, ArtifactStage: artifactStage})
 			}
 			if err != nil {
 				ch <- outcome{seat: seat, err: err}
@@ -647,6 +651,14 @@ func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats
 		}
 	}
 	return feedback, approvals, voters, cost, strings.Join(unreachable, "; ")
+}
+
+func panelSeatDurableSlot(req StepRequest, panelRound, ordinal int) string {
+	// Hash the structured identity so delimiters or control bytes in an identifier
+	// cannot alias a different work-item/node tuple. Round and seat stay readable
+	// because they are bounded integers assigned by this runner.
+	identity, _ := json.Marshal([]string{req.WorkItem.ID, req.Node.ID})
+	return fmt.Sprintf("panel:%x:round:%d:seat:%d", sha256.Sum256(identity), panelRound, ordinal)
 }
 
 func (r *NativeRunner) foreach(ctx context.Context, req StepRequest) (StepResult, error) {

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -166,7 +166,7 @@ func TestNativeRoundtableFailsClosedWhenReviewerEvaluatesWrongStage(t *testing.T
 			}
 			agents := &recordingAgents{reviewResponse: `{` + prefix + `"original_request_alignment":{"status":"aligned","summary":"looks related"},"verdict":"approve","findings":[]}`}
 			runner := &NativeRunner{agents: agents}
-			feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), StepRequest{}, []panelSeat{{persona: "qa", required: true}}, "review", "hash", "plan")
+			feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), StepRequest{}, []panelSeat{{persona: "qa", required: true}}, "review", "hash", "plan", 1)
 			if unreachable != "" || approvals != 0 || voters != 1 || len(feedback.Findings) != 1 {
 				t.Fatalf("stage mismatch accounting: approvals=%d voters=%d unreachable=%q feedback=%+v", approvals, voters, unreachable, feedback)
 			}
@@ -179,7 +179,7 @@ func TestNativeRoundtableFailsClosedWhenReviewerEvaluatesWrongStage(t *testing.T
 	for _, echoed := range []string{`"Plan"`, `"PLAN"`, `" plan "`} {
 		agents := &recordingAgents{reviewResponse: `{"artifact_stage":` + echoed + `,"original_request_alignment":{"status":"aligned","summary":"looks related"},"verdict":"approve","findings":[]}`}
 		runner := &NativeRunner{agents: agents}
-		feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), StepRequest{}, []panelSeat{{persona: "qa", required: true}}, "review", "hash", "plan")
+		feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), StepRequest{}, []panelSeat{{persona: "qa", required: true}}, "review", "hash", "plan", 1)
 		if unreachable != "" || approvals != 1 || voters != 1 || len(feedback.Findings) != 0 {
 			t.Fatalf("canonical stage echo %s rejected: approvals=%d voters=%d unreachable=%q feedback=%+v", echoed, approvals, voters, unreachable, feedback)
 		}
@@ -208,7 +208,7 @@ func TestStageMismatchCannotBeOverriddenByAnotherApproval(t *testing.T) {
 		`{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"related"},"verdict":"approve","findings":[]}`,
 	}}
 	runner := &NativeRunner{agents: agents}
-	feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), StepRequest{}, []panelSeat{{persona: "qa", required: true}, {persona: "security", required: true}}, "review", "hash", "plan")
+	feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), StepRequest{}, []panelSeat{{persona: "qa", required: true}, {persona: "security", required: true}}, "review", "hash", "plan", 1)
 	if unreachable != "" || approvals != 1 || voters != 2 || len(feedback.Findings) != 1 || !strings.HasSuffix(feedback.Findings[0].ID, "-artifact-stage") {
 		t.Fatalf("mixed-stage panel could approve: approvals=%d voters=%d unreachable=%q feedback=%+v", approvals, voters, unreachable, feedback)
 	}
@@ -338,6 +338,63 @@ func TestFillPanelCapacityUsesEverySlotWithDiversityFirst(t *testing.T) {
 	}
 }
 
+func TestPanelCapacitySeatsHaveDistinctDurableJobKeys(t *testing.T) {
+	agents := &recordingAgents{}
+	runner := &NativeRunner{agents: agents}
+	req := StepRequest{WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"}, Node: wfe.Node{ID: "gate"}}
+	seats := []panelSeat{
+		{persona: "security", delegate: "codex", ordinal: 0},
+		{persona: "security", delegate: "codex", ordinal: 1},
+		{persona: "security", delegate: "codex", ordinal: 2},
+	}
+	feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), req, seats, "review", "hash", "plan", 1)
+	if unreachable != "" || approvals != 3 || voters != 3 || len(feedback.Findings) != 0 {
+		t.Fatalf("panel result approvals=%d voters=%d unreachable=%q feedback=%+v", approvals, voters, unreachable, feedback)
+	}
+	if len(agents.requests) != 3 {
+		t.Fatalf("requests=%d", len(agents.requests))
+	}
+	seen := map[string]bool{}
+	wantSlots := map[string]bool{}
+	for ordinal := range seats {
+		wantSlots[panelSeatDurableSlot(req, 1, ordinal)] = true
+	}
+	for _, request := range agents.requests {
+		key := delegateJobKey(request)
+		if seen[key] {
+			t.Fatalf("capacity seats collapsed onto durable key %q: %+v", key, agents.requests)
+		}
+		seen[key] = true
+		if !wantSlots[request.DurableSlot] {
+			t.Fatalf("unexpected durable slot=%q want one of %v", request.DurableSlot, wantSlots)
+		}
+	}
+}
+
+func TestPanelSeatDurableSlotCannotAliasDelimitedIdentifiers(t *testing.T) {
+	left := StepRequest{WorkItem: db1.WorkItem{ID: "a:b"}, Node: wfe.Node{ID: "c"}}
+	right := StepRequest{WorkItem: db1.WorkItem{ID: "a"}, Node: wfe.Node{ID: "b:c"}}
+	if got, other := panelSeatDurableSlot(left, 1, 0), panelSeatDurableSlot(right, 1, 0); got == other {
+		t.Fatalf("structured identities aliased: %q", got)
+	}
+}
+
+func TestPanelCapacityRoundsHaveDistinctDurableJobKeys(t *testing.T) {
+	agents := &recordingAgents{}
+	runner := &NativeRunner{agents: agents}
+	req := StepRequest{WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"}, Node: wfe.Node{ID: "gate"}}
+	seats := []panelSeat{{persona: "security", delegate: "codex", ordinal: 0}}
+	for round := 1; round <= 2; round++ {
+		feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), req, seats, "same review", "hash", "plan", round)
+		if unreachable != "" || approvals != 1 || voters != 1 || len(feedback.Findings) != 0 {
+			t.Fatalf("round %d approvals=%d voters=%d unreachable=%q feedback=%+v", round, approvals, voters, unreachable, feedback)
+		}
+	}
+	if len(agents.requests) != 2 || delegateJobKey(agents.requests[0]) == delegateJobKey(agents.requests[1]) {
+		t.Fatalf("panel rounds shared durable key: %+v", agents.requests)
+	}
+}
+
 func TestFillPanelCapacityInterleavesProvidersBeforeFillingAllSeats(t *testing.T) {
 	configured := []panelSeat{{persona: "correctness"}}
 	roster := []EligibleAgent{
@@ -455,18 +512,19 @@ func TestPanelCapacityAssignmentFallsBackWithoutWeakeningExplicitPin(t *testing.
 	runner := &NativeRunner{agents: agents}
 	req := StepRequest{WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"}, Node: wfe.Node{ID: "gate"}}
 	feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), req,
-		[]panelSeat{{persona: "qa", delegate: "kimi", required: true}}, "review", "hash", "plan")
+		[]panelSeat{{persona: "qa", delegate: "kimi", required: true}}, "review", "hash", "plan", 1)
 	if unreachable != "" || approvals != 1 || voters != 1 || len(feedback.Findings) != 0 {
 		t.Fatalf("dynamic assignment did not recover: approvals=%d voters=%d unreachable=%q feedback=%+v", approvals, voters, unreachable, feedback)
 	}
-	if len(agents.requests) != 2 || agents.requests[0].Delegate != "kimi" || agents.requests[1].Delegate != "" || agents.requests[1].RetryTag != "eligible-fallback:0:kimi" {
+	wantSlot := panelSeatDurableSlot(req, 1, 0)
+	if len(agents.requests) != 2 || agents.requests[0].Delegate != "kimi" || agents.requests[0].DurableSlot != wantSlot || agents.requests[1].Delegate != "" || agents.requests[1].RetryTag != "eligible-fallback:0:kimi" || agents.requests[1].DurableSlot != wantSlot {
 		t.Fatalf("requests=%+v", agents.requests)
 	}
 
 	agents = &temporaryFailureAgents{}
 	runner.agents = agents
 	_, _, _, _, unreachable = runner.runPanelRound(context.Background(), req,
-		[]panelSeat{{persona: "qa", delegate: "kimi", required: true, pinned: true}}, "review", "hash", "plan")
+		[]panelSeat{{persona: "qa", delegate: "kimi", required: true, pinned: true}}, "review", "hash", "plan", 1)
 	if unreachable == "" || len(agents.requests) != 1 {
 		t.Fatalf("explicit pin was silently weakened: requests=%+v unreachable=%q", agents.requests, unreachable)
 	}


### PR DESCRIPTION
Fixes two live unattended-WFE failures:

- cancel agent delegate jobs through `/v1/jobs/cancel`, requiring explicit acknowledgement before CAS-forgetting their durable mapping
- assign a distinct local durable identity to every roundtable seat and refinement round so capacity seats cannot collapse onto one remote job

Also preserves caller cancellation semantics, prevents stale cleanup from erasing newer retries, and keeps local identity fields out of the resource-plane payload.

Verification: `go test ./...`, `go test -race ./internal/engine`, `go vet ./...`, `git diff --check`.