### PR TITLE
fix(wfe): review supplied artifacts without diff noise

### DIFF
--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -37,6 +37,12 @@ type DelegateRequest struct {
 	// must evaluate. It is carried structurally so runner collaborators and test
 	// doubles never need to recover authority from prompt prose.
 	ArtifactStage string
+	// ProvidedTarget tells the resource-plane transport that Prompt already
+	// contains the complete artifact under review. It suppresses unrelated
+	// worktree-diff evidence. Only true emits the strict JSON boolean opt-in;
+	// false omits it and preserves automatic evidence. This is a deliberate wire
+	// field; DurableSlot and RetryTag are Go-local and must never be sent.
+	ProvidedTarget bool
 	// acceptPartial is reserved for native branch-producing blocks whose worktree output
 	// is independently committed and verified by the Go native runner. Structured
 	// and prose blocks must receive a complete resource-plane result.
@@ -163,6 +169,9 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 		return DelegateResult{}, errors.New("delegate role, persona, and prompt are required")
 	}
 	payload := map[string]any{"role": request.Role, "persona": request.Persona, "prompt": request.Prompt, "cwd": request.Workdir, "tools": request.Tools}
+	if request.ProvidedTarget {
+		payload["provided_target"] = true
+	}
 	// Empty means ordinary eligibility routing. A non-empty delegate is an
 	// explicit positive pin from the workflow, never an exclusion list.
 	if request.Delegate != "" {

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -63,6 +63,9 @@ func TestHTTPAgentClientDurableSlotsLaunchDistinctJobs(t *testing.T) {
 		case "/v1/delegate/run":
 			var payload map[string]any
 			_ = json.NewDecoder(r.Body).Decode(&payload)
+			if provided, ok := payload["provided_target"].(bool); !ok || !provided {
+				t.Errorf("provided review target missing from payload %v", payload)
+			}
 			for _, localOnly := range []string{"durable_slot", "DurableSlot", "durableslot", "retry_tag", "RetryTag"} {
 				if _, leaked := payload[localOnly]; leaked {
 					t.Errorf("local durable-key field %q leaked in payload %v", localOnly, payload)
@@ -82,7 +85,7 @@ func TestHTTPAgentClientDurableSlotsLaunchDistinctJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 	request := DelegateRequest{Role: "review", Persona: "qa", Prompt: "review complete artifact",
-		WorkItemID: "wi_slots", Stage: "gate", ExecutionVersion: "v1"}
+		WorkItemID: "wi_slots", Stage: "gate", ExecutionVersion: "v1", ProvidedTarget: true}
 	for _, slot := range []string{"panel:gate:round:1:seat:0", "panel:gate:round:1:seat:1"} {
 		request.DurableSlot = slot
 		if _, err := client.Delegate(t.Context(), request); err != nil {
@@ -91,6 +94,32 @@ func TestHTTPAgentClientDurableSlotsLaunchDistinctJobs(t *testing.T) {
 	}
 	if launches.Load() != 2 {
 		t.Fatalf("distinct durable slots launched %d jobs", launches.Load())
+	}
+}
+
+func TestHTTPAgentClientOmitsProvidedTargetByDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			var payload map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			if _, present := payload["provided_target"]; present {
+				t.Errorf("ordinary delegate request claimed a provided target: %v", payload)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 1})
+		case "/v1/delegate/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "done", "result": "complete"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, PollEvery: time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Delegate(t.Context(), DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review worktree"}); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -576,13 +576,16 @@ func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats
 			// Repeated persona/agent pairs must not collide and reuse one remote
 			// result, so each capacity seat carries a distinct durable slot.
 			seatSlot := panelSeatDurableSlot(req, panelRound, seat.ordinal)
-			res, err := r.delegate(ctx, req, DelegateRequest{Role: roundtableDelegateRole, Persona: seat.persona, Delegate: seat.delegate, Prompt: prompt, Workdir: req.WorkItem.Worktree, DurableSlot: seatSlot, ArtifactStage: artifactStage})
+			request := DelegateRequest{Role: roundtableDelegateRole, Persona: seat.persona, Delegate: seat.delegate, Prompt: prompt, Workdir: req.WorkItem.Worktree, DurableSlot: seatSlot, ArtifactStage: artifactStage, ProvidedTarget: true}
+			res, err := r.delegate(ctx, req, request)
 			if err != nil && !seat.pinned && seat.delegate != "" {
 				// Capacity assignments are routing hints for this panel run, not UI
 				// pins. If the assigned subscription is temporarily unavailable,
 				// retry through ordinary live eligibility after that failed slot has
 				// released its lease. Never persist the failure as an exclusion.
-				res, err = r.delegate(ctx, req, DelegateRequest{Role: roundtableDelegateRole, Persona: seat.persona, Prompt: prompt, Workdir: req.WorkItem.Worktree, RetryTag: fmt.Sprintf("eligible-fallback:%d:%s", seat.ordinal, seat.delegate), DurableSlot: seatSlot, ArtifactStage: artifactStage})
+				request.Delegate = ""
+				request.RetryTag = fmt.Sprintf("eligible-fallback:%d:%s", seat.ordinal, seat.delegate)
+				res, err = r.delegate(ctx, req, request)
 			}
 			if err != nil {
 				ch <- outcome{seat: seat, err: err}

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -284,6 +284,9 @@ func TestNativeRunnerUsesCompleteArtifactsAndOnlyPositiveUIPins(t *testing.T) {
 	}
 	foundPin, foundDynamicQA := false, false
 	for _, request := range agents.requests {
+		if request.Role == "review" && !request.ProvidedTarget {
+			t.Fatalf("roundtable request did not declare its inline artifact: %+v", request)
+		}
 		requestMarker := "ORIGINAL REQUEST:\n" + proposal
 		if request.Role == "review" {
 			requestMarker = "BEGIN_ORIGINAL_REQUEST_DATA\n" + proposal + "\nEND_ORIGINAL_REQUEST_DATA"
@@ -360,6 +363,9 @@ func TestPanelCapacitySeatsHaveDistinctDurableJobKeys(t *testing.T) {
 		wantSlots[panelSeatDurableSlot(req, 1, ordinal)] = true
 	}
 	for _, request := range agents.requests {
+		if !request.ProvidedTarget {
+			t.Fatalf("roundtable request did not declare its inline artifact: %+v", request)
+		}
 		key := delegateJobKey(request)
 		if seen[key] {
 			t.Fatalf("capacity seats collapsed onto durable key %q: %+v", key, agents.requests)
@@ -517,7 +523,7 @@ func TestPanelCapacityAssignmentFallsBackWithoutWeakeningExplicitPin(t *testing.
 		t.Fatalf("dynamic assignment did not recover: approvals=%d voters=%d unreachable=%q feedback=%+v", approvals, voters, unreachable, feedback)
 	}
 	wantSlot := panelSeatDurableSlot(req, 1, 0)
-	if len(agents.requests) != 2 || agents.requests[0].Delegate != "kimi" || agents.requests[0].DurableSlot != wantSlot || agents.requests[1].Delegate != "" || agents.requests[1].RetryTag != "eligible-fallback:0:kimi" || agents.requests[1].DurableSlot != wantSlot {
+	if len(agents.requests) != 2 || agents.requests[0].Delegate != "kimi" || agents.requests[0].DurableSlot != wantSlot || !agents.requests[0].ProvidedTarget || agents.requests[1].Delegate != "" || agents.requests[1].RetryTag != "eligible-fallback:0:kimi" || agents.requests[1].DurableSlot != wantSlot || !agents.requests[1].ProvidedTarget {
 		t.Fatalf("requests=%+v", agents.requests)
 	}
 

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -655,6 +655,7 @@ void delegate_worker(void *arg)
    cJSON *jmaxturns = cJSON_GetObjectItemCaseSensitive(req, "max_turns");
    cJSON *jhandoff = cJSON_GetObjectItemCaseSensitive(req, "handoff_json");
    cJSON *jtools = cJSON_GetObjectItemCaseSensitive(req, "tools");
+   cJSON *jprovided_target = cJSON_GetObjectItemCaseSensitive(req, "provided_target");
    cJSON *jtier = cJSON_GetObjectItemCaseSensitive(req, "tier");
    cJSON *jvia = cJSON_GetObjectItemCaseSensitive(req, "via");
    cJSON *jprovider = cJSON_GetObjectItemCaseSensitive(req, "provider");
@@ -674,6 +675,9 @@ void delegate_worker(void *arg)
    int timeout_ms = cJSON_IsNumber(jtimeout) ? (int)jtimeout->valuedouble : 0;
    int max_turns = cJSON_IsNumber(jmaxturns) ? (int)jmaxturns->valuedouble : -1;
    int handoff_json = cJSON_IsTrue(jhandoff);
+   /* Only the JSON boolean literal true opts out; absent, false, and malformed
+    * values preserve automatic evidence grounding. */
+   int caller_provided_target = cJSON_IsTrue(jprovided_target);
    const char *toolset_override =
        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(req, "toolset"));
    int tier_override = cJSON_IsNumber(jtier) ? (int)jtier->valuedouble : -1;
@@ -1089,7 +1093,12 @@ void delegate_worker(void *arg)
        delegate_assemble_system_prompt(system_prompt, role, prompt, cwd, persona_override,
                                        delegate_worktree_path, &template_sys_prompt);
 
-   /* Ground read-only inspection roles in parent diff evidence. */
+   /* This is delegate_worker's sole parent-diff evidence injection point.
+    * Ground read-only inspection roles in parent diff evidence unless the
+    * caller supplied the complete review target inline. In that case an
+    * unrelated current-worktree diff is competing evidence and can make a
+    * plan reviewer incorrectly demand implementation. */
+   if (!caller_provided_target)
    {
       char *evidence = delegate_prepend_parent_diff_evidence(prompt, role, delegate_allows_writes,
                                                              cwd, deleg_id);

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -2435,8 +2435,7 @@ static void test_provided_review_target_suppresses_worktree_evidence(void)
    conn->fd = fds[1];
    g_agent_response = "Plan review complete";
    g_git_repo_root_rc = 0;
-   snprintf(g_git_repo_root_value, sizeof(g_git_repo_root_value), "%s",
-            "/tmp/aimee-parent-repo");
+   snprintf(g_git_repo_root_value, sizeof(g_git_repo_root_value), "%s", "/tmp/aimee-parent-repo");
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "role", "review");

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -2424,6 +2424,51 @@ static void test_read_only_delegate_uses_parent_workspace(void)
    printf("  PASS: test_read_only_delegate_uses_parent_workspace\n");
 }
 
+static void test_provided_review_target_suppresses_worktree_evidence(void)
+{
+   reset_last_response();
+   int fds[2];
+   assert(pipe(fds) == 0);
+   server_ctx_t *ctx = calloc(1, sizeof(*ctx));
+   server_conn_t *conn = calloc(1, sizeof(*conn));
+   assert(ctx != NULL && conn != NULL);
+   conn->fd = fds[1];
+   g_agent_response = "Plan review complete";
+   g_git_repo_root_rc = 0;
+   snprintf(g_git_repo_root_value, sizeof(g_git_repo_root_value), "%s",
+            "/tmp/aimee-parent-repo");
+
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "role", "review");
+   cJSON_AddStringToObject(req, "persona", "reviewer");
+   cJSON_AddStringToObject(req, "prompt",
+                           "BEGIN_ARTIFACT_DATA (plan)\nPLAN_TARGET_MARKER\nEND_ARTIFACT_DATA");
+   cJSON_AddStringToObject(req, "cwd", "/tmp/aimee-parent-repo");
+   cJSON_AddBoolToObject(req, "provided_target", 1);
+   assert(handle_delegate(ctx, conn, req) == 0);
+   assert(g_submitted_fn == delegate_worker);
+   g_submitted_fn(g_submitted_arg);
+   g_submitted_arg = NULL;
+   close(fds[1]);
+   char buf[256];
+   assert(read(fds[0], buf, sizeof(buf)) >= 0);
+   close(fds[0]);
+
+   assert(strstr(g_last_agent_prompt,
+                 "BEGIN_ARTIFACT_DATA (plan)\nPLAN_TARGET_MARKER\nEND_ARTIFACT_DATA") != NULL);
+   assert(strstr(g_last_agent_prompt, "Validation Evidence Bundle") == NULL);
+   assert(strstr(g_last_agent_prompt, "Parent Worktree Diff Evidence") == NULL);
+   db1_agent_job_t job;
+   assert(delegate_current_job(&job) == 0);
+   assert(strcmp(job.status, "done") == 0);
+   db1_agent_job_free(&job);
+   cJSON_Delete(req);
+   reset_last_response();
+   free(conn);
+   free(ctx);
+   printf("  PASS: test_provided_review_target_suppresses_worktree_evidence\n");
+}
+
 static void test_read_only_branch_delegate_rejected(void)
 {
    reset_last_response();
@@ -3048,6 +3093,7 @@ int main(void)
    test_readonly_refactor_delegate_disables_write_enforce();
    test_direct_delegate_max_turns_override();
    test_read_only_delegate_uses_parent_workspace();
+   test_provided_review_target_suppresses_worktree_evidence();
    test_read_only_branch_delegate_rejected();
    test_inspection_roles_get_evidence_bundle();
    test_delegate_worker_restores_caller_context();


### PR DESCRIPTION
Fixes the live plan-gate failure where WFE supplies a complete plan inline but the C resource plane appends an empty worktree diff, causing reviewers to demand implementation from a plan-stage artifact.

- WFE marks roundtable prompts as caller-provided targets
- the wire sends a strict `provided_target: true` opt-in
- the C transport suppresses only its automatic parent-diff bundle for opted-in calls
- ordinary review/validate/diagnose callers retain automatic diff grounding

Verification: full Go tests, engine race test, vet, focused C server-compute suite, diff check; two roundtable review cycles.