### PR TITLE
fix(db1): keep agent job status reads read-only

### DIFF
--- a/src/db1/agent_jobs.c
+++ b/src/db1/agent_jobs.c
@@ -39,6 +39,9 @@ static int agent_job_stale_threshold_secs(const char *role, const char *current_
    return in_tool_threshold_secs;
 }
 
+/* Explicit historical maintenance only. This scans and may update the entire
+ * terminal job history, so status get/list hot paths must never call it. New
+ * jobs persist their routed agent through db1_agent_job_set_agent(). */
 int db1_agent_job_backfill_agent_names_from_log(void)
 {
    sqlite3 *db = db1_conn();
@@ -302,7 +305,6 @@ int db1_agent_job_get(int job_id, db1_agent_job_t *out)
    sqlite3 *db = db1_conn();
    if (!db)
       return -1;
-   (void)db1_agent_job_backfill_agent_names_from_log();
 
    sqlite3_stmt *stmt = NULL;
    static const char *sql =
@@ -398,7 +400,6 @@ int db1_agent_job_list_recent(db1_agent_job_t *out, int max, int include_heavy)
    sqlite3 *db = db1_conn();
    if (!db)
       return -1;
-   (void)db1_agent_job_backfill_agent_names_from_log();
 
    sqlite3_stmt *stmt = NULL;
    static const char *sql =

--- a/src/db1/agent_jobs.c
+++ b/src/db1/agent_jobs.c
@@ -254,8 +254,8 @@ int db1_agent_job_classify_stale(int job_id, int idle_threshold_secs, int in_too
 
 int db1_agent_job_get(int job_id, db1_agent_job_t *out)
 {
-   /* Status polling is a read-only hot path. Agent identity is persisted by
-    * create/set_agent and must never be reconstructed here with a global write. */
+   /* Status polling is read-only. Agent identity is persisted by
+    * db1_agent_job_create/db1_agent_job_set_agent. */
    if (!out || job_id <= 0)
       return -1;
    memset(out, 0, sizeof(*out));
@@ -352,7 +352,7 @@ void db1_agent_job_free(db1_agent_job_t *job)
 
 int db1_agent_job_list_recent(db1_agent_job_t *out, int max, int include_heavy)
 {
-   /* This endpoint is polled by every active delegate; keep it read-only. */
+   /* Every active delegate polls this endpoint; keep it read-only. */
    if (!out || max <= 0)
       return 0;
    sqlite3 *db = db1_conn();

--- a/src/db1/agent_jobs.c
+++ b/src/db1/agent_jobs.c
@@ -39,51 +39,6 @@ static int agent_job_stale_threshold_secs(const char *role, const char *current_
    return in_tool_threshold_secs;
 }
 
-/* Explicit historical maintenance only. This scans and may update the entire
- * terminal job history, so status get/list hot paths must never call it. New
- * jobs persist their routed agent through db1_agent_job_set_agent(). */
-int db1_agent_job_backfill_agent_names_from_log(void)
-{
-   sqlite3 *db = db1_conn();
-   if (!db)
-      return -1;
-
-   static const char *sql =
-       "UPDATE agent_jobs"
-       " SET agent_name = ("
-       "   SELECT candidate.agent_name FROM ("
-       "      SELECT al.agent_name, al.id,"
-       "             abs(strftime('%s', al.created_at) -"
-       "                 strftime('%s', CASE WHEN agent_jobs.updated_at <> ''"
-       "                                    THEN agent_jobs.updated_at ELSE agent_jobs.created_at"
-       "                               END)) AS distance"
-       "      FROM agent_log al"
-       "      WHERE al.agent_name <> ''"
-       "        AND al.role = agent_jobs.role"
-       "   ) candidate"
-       "   WHERE candidate.distance <= 900"
-       "   ORDER BY candidate.distance, candidate.id DESC LIMIT 1"
-       " )"
-       " WHERE agent_name = ''"
-       "   AND status IN ('done', 'failed', 'partial', 'cancelled')"
-       "   AND EXISTS ("
-       "      SELECT 1 FROM agent_log al"
-       "      WHERE al.agent_name <> ''"
-       "        AND al.role = agent_jobs.role"
-       "        AND abs(strftime('%s', al.created_at) -"
-       "                strftime('%s', CASE WHEN agent_jobs.updated_at <> ''"
-       "                                   THEN agent_jobs.updated_at ELSE agent_jobs.created_at"
-       "                              END)) <= 900"
-       "   )";
-   sqlite3_stmt *stmt = NULL;
-   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
-      return -1;
-   int rc = sqlite3_step(stmt);
-   int changed = (rc == SQLITE_DONE) ? sqlite3_changes(db) : -1;
-   sqlite3_finalize(stmt);
-   return changed;
-}
-
 int db1_agent_job_create(const char *role, const char *prompt, const char *agent_name,
                          const char *lease_owner)
 {
@@ -299,6 +254,8 @@ int db1_agent_job_classify_stale(int job_id, int idle_threshold_secs, int in_too
 
 int db1_agent_job_get(int job_id, db1_agent_job_t *out)
 {
+   /* Status polling is a read-only hot path. Agent identity is persisted by
+    * create/set_agent and must never be reconstructed here with a global write. */
    if (!out || job_id <= 0)
       return -1;
    memset(out, 0, sizeof(*out));
@@ -395,6 +352,7 @@ void db1_agent_job_free(db1_agent_job_t *job)
 
 int db1_agent_job_list_recent(db1_agent_job_t *out, int max, int include_heavy)
 {
+   /* This endpoint is polled by every active delegate; keep it read-only. */
    if (!out || max <= 0)
       return 0;
    sqlite3 *db = db1_conn();

--- a/src/db1/agent_jobs.h
+++ b/src/db1/agent_jobs.h
@@ -107,7 +107,7 @@ extern "C"
    int db1_agent_job_classify_stale(int job_id, int idle_threshold_secs, int in_tool_threshold_secs,
                                     char *out_state, size_t out_state_cap);
 
-   /* Load by id. Returns 0 on hit, -1 on miss. On hit, out->prompt and
+   /* Read-only. Load by id. Returns 0 on hit, -1 on miss. On hit, out->prompt and
     * out->result are heap-allocated (never NULL) and must be released with
     * db1_agent_job_free. On miss, out is zero-initialized (free is still safe). */
    int db1_agent_job_get(int job_id, db1_agent_job_t *out);
@@ -125,7 +125,7 @@ extern "C"
     * Returns 0 on success, -1 on error. */
    int db1_agent_job_take_lease(int job_id, const char *owner);
 
-   /* List most recent `max` jobs (ORDER BY id DESC). Returns count. Each
+   /* Read-only. List most recent `max` jobs (ORDER BY id DESC). Returns count. Each
     * returned row owns heap prompt/result; free every returned row with
     * db1_agent_job_free. When include_heavy == 0, the (potentially large)
     * prompt/result are returned as empty strings (not loaded) so list callers

--- a/src/db1/agent_jobs.h
+++ b/src/db1/agent_jobs.h
@@ -117,11 +117,6 @@ extern "C"
     * tolerates a zero-initialized struct (a failed get) and double calls. */
    void db1_agent_job_free(db1_agent_job_t *job);
 
-   /* Repair finished job rows created before routed agent metadata was
-    * persisted. Matches blank agent_name rows to nearby agent_log rows with
-    * the same role. Returns rows changed, or -1 on DB error. */
-   int db1_agent_job_backfill_agent_names_from_log(void);
-
    /* Check if a heartbeat_at timestamp is older than `stale_minutes`
     * ago. Returns 1 if stale, 0 if fresh or unparseable. */
    int db1_agent_job_heartbeat_is_stale(const char *heartbeat_at, int stale_minutes);

--- a/src/tests/test_db1_agent_job_heartbeat.c
+++ b/src/tests/test_db1_agent_job_heartbeat.c
@@ -442,6 +442,54 @@ static void test_backfill_agent_name_from_agent_log(void)
    printf("  PASS: test_backfill_agent_name_from_agent_log\n");
 }
 
+static void test_status_reads_do_not_run_global_agent_name_backfill(void)
+{
+   setup_db();
+   int job = db1_agent_job_create("review", "test", "", "owner");
+   assert(job > 0);
+   db1_agent_job_update(job, "done", 1, "ok");
+   db1_agent_log_insert_row_t log_row = {
+       .agent_name = "historical-agent",
+       .role = "review",
+       .success = 1,
+       .turns = 1,
+       .tool_calls = 0,
+       .confidence = 80,
+       .session_id = "test-session",
+   };
+   assert(db1_agent_log_insert(&log_row) > 0);
+
+   db1_agent_job_t row;
+   assert(db1_agent_job_get(job, &row) == 0);
+   assert(row.agent_name[0] == '\0');
+   db1_agent_job_free(&row);
+
+   db1_agent_job_t recent[2];
+   int count = db1_agent_job_list_recent(recent, 2, 0);
+   assert(count >= 1);
+   int found = 0;
+   for (int i = 0; i < count; i++)
+   {
+      if (recent[i].id == job)
+      {
+         found = 1;
+         assert(recent[i].agent_name[0] == '\0');
+      }
+      db1_agent_job_free(&recent[i]);
+   }
+   assert(found);
+
+   /* The historical repair remains available as an explicit maintenance
+    * operation; status polling must never run this global UPDATE. */
+   assert(db1_agent_job_backfill_agent_names_from_log() >= 1);
+   assert(db1_agent_job_get(job, &row) == 0);
+   assert(strcmp(row.agent_name, "historical-agent") == 0);
+   db1_agent_job_free(&row);
+
+   teardown_db();
+   printf("  PASS: test_status_reads_do_not_run_global_agent_name_backfill\n");
+}
+
 int main(void)
 {
    printf("db1_agent_job_heartbeat:\n");
@@ -461,6 +509,7 @@ int main(void)
    test_done_update_wins_cancel_complete_race();
    test_failed_update_does_not_overwrite_cancelled();
    test_backfill_agent_name_from_agent_log();
+   test_status_reads_do_not_run_global_agent_name_backfill();
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_db1_agent_job_heartbeat.c
+++ b/src/tests/test_db1_agent_job_heartbeat.c
@@ -434,29 +434,57 @@ static void test_status_reads_do_not_run_global_agent_name_backfill(void)
 
    sqlite3 *db = db1_conn();
    int changes_before_reads = sqlite3_total_changes(db);
-   db1_agent_job_t row;
-   assert(db1_agent_job_get(job, &row) == 0);
-   assert(row.agent_name[0] == '\0');
-   db1_agent_job_free(&row);
-
-   db1_agent_job_t recent[2];
-   int count = db1_agent_job_list_recent(recent, 2, 0);
-   assert(count >= 1);
-   int found = 0;
-   for (int i = 0; i < count; i++)
+   for (int poll = 0; poll < 100; poll++)
    {
-      if (recent[i].id == job)
+      db1_agent_job_t row;
+      assert(db1_agent_job_get(job, &row) == 0);
+      assert(row.agent_name[0] == '\0');
+      db1_agent_job_free(&row);
+
+      db1_agent_job_t recent[2];
+      int count = db1_agent_job_list_recent(recent, 2, 0);
+      assert(count >= 1);
+      int found = 0;
+      for (int i = 0; i < count; i++)
       {
-         found = 1;
-         assert(recent[i].agent_name[0] == '\0');
+         if (recent[i].id == job)
+         {
+            found = 1;
+            assert(recent[i].agent_name[0] == '\0');
+         }
+         db1_agent_job_free(&recent[i]);
       }
-      db1_agent_job_free(&recent[i]);
+      assert(found);
    }
-   assert(found);
    assert(sqlite3_total_changes(db) == changes_before_reads);
 
    teardown_db();
    printf("  PASS: test_status_reads_do_not_run_global_agent_name_backfill\n");
+}
+
+static void test_routed_agent_name_survives_status_reads(void)
+{
+   setup_db();
+   int job = db1_agent_job_create("review", "test", "routed-agent", "owner");
+   assert(job > 0);
+   db1_agent_job_update(job, "done", 1, "ok");
+
+   sqlite3 *db = db1_conn();
+   int changes_before_reads = sqlite3_total_changes(db);
+   db1_agent_job_t row;
+   assert(db1_agent_job_get(job, &row) == 0);
+   assert(strcmp(row.agent_name, "routed-agent") == 0);
+   db1_agent_job_free(&row);
+
+   db1_agent_job_t recent[1];
+   assert(db1_agent_job_list_recent(recent, 1, 0) == 1);
+   assert(recent[0].id == job);
+   assert(strcmp(recent[0].agent_name, "routed-agent") == 0);
+   db1_agent_job_free(&recent[0]);
+   assert(sqlite3_total_changes(db) == changes_before_reads);
+
+   teardown_db();
+   printf("  PASS: test_routed_agent_name_survives_status_reads\n");
 }
 
 int main(void)
@@ -478,6 +506,7 @@ int main(void)
    test_done_update_wins_cancel_complete_race();
    test_failed_update_does_not_overwrite_cancelled();
    test_status_reads_do_not_run_global_agent_name_backfill();
+   test_routed_agent_name_survives_status_reads();
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_db1_agent_job_heartbeat.c
+++ b/src/tests/test_db1_agent_job_heartbeat.c
@@ -415,33 +415,6 @@ static void test_failed_update_does_not_overwrite_cancelled(void)
    printf("  PASS: test_failed_update_does_not_overwrite_cancelled\n");
 }
 
-static void test_backfill_agent_name_from_agent_log(void)
-{
-   setup_db();
-   int job = db1_agent_job_create("review", "test", "", "owner");
-   assert(job > 0);
-   db1_agent_job_update(job, "done", 4, "ok");
-
-   db1_agent_log_insert_row_t log_row = {
-       .agent_name = "llama-eval",
-       .role = "review",
-       .success = 1,
-       .turns = 4,
-       .tool_calls = 4,
-       .confidence = 80,
-       .session_id = "test-session",
-   };
-   assert(db1_agent_log_insert(&log_row) > 0);
-
-   assert(db1_agent_job_backfill_agent_names_from_log() >= 1);
-   db1_agent_job_t row;
-   assert(db1_agent_job_get(job, &row) == 0);
-   assert(strcmp(row.agent_name, "llama-eval") == 0);
-
-   teardown_db();
-   printf("  PASS: test_backfill_agent_name_from_agent_log\n");
-}
-
 static void test_status_reads_do_not_run_global_agent_name_backfill(void)
 {
    setup_db();
@@ -459,6 +432,8 @@ static void test_status_reads_do_not_run_global_agent_name_backfill(void)
    };
    assert(db1_agent_log_insert(&log_row) > 0);
 
+   sqlite3 *db = db1_conn();
+   int changes_before_reads = sqlite3_total_changes(db);
    db1_agent_job_t row;
    assert(db1_agent_job_get(job, &row) == 0);
    assert(row.agent_name[0] == '\0');
@@ -478,13 +453,7 @@ static void test_status_reads_do_not_run_global_agent_name_backfill(void)
       db1_agent_job_free(&recent[i]);
    }
    assert(found);
-
-   /* The historical repair remains available as an explicit maintenance
-    * operation; status polling must never run this global UPDATE. */
-   assert(db1_agent_job_backfill_agent_names_from_log() >= 1);
-   assert(db1_agent_job_get(job, &row) == 0);
-   assert(strcmp(row.agent_name, "historical-agent") == 0);
-   db1_agent_job_free(&row);
+   assert(sqlite3_total_changes(db) == changes_before_reads);
 
    teardown_db();
    printf("  PASS: test_status_reads_do_not_run_global_agent_name_backfill\n");
@@ -508,7 +477,6 @@ int main(void)
    test_update_does_not_overwrite_cancelled();
    test_done_update_wins_cancel_complete_race();
    test_failed_update_does_not_overwrite_cancelled();
-   test_backfill_agent_name_from_agent_log();
    test_status_reads_do_not_run_global_agent_name_backfill();
    printf("ok\n");
    return 0;


### PR DESCRIPTION
Fixes live WFE scheduler starvation under full roundtable load.

`db1_agent_job_get()` and `db1_agent_job_list_recent()` were each running a global historical agent-name backfill UPDATE. With thousands of jobs/log rows and many panel status polls, that held the SQLite writer long enough for every Go WFE scheduler write to fail with SQLITE_BUSY.

This restores status get/list as read-only operations and removes the obsolete global backfill API entirely. Current jobs persist routed agent names at creation or through `db1_agent_job_set_agent()`; repository-wide audit found no other production writer or caller needing the heuristic. A regression test uses `sqlite3_total_changes()` to prove get/list perform no writes even when a matching historical agent-log row exists.

Verification: focused DB1 agent-job suite and diff check; live reproduction on .254.