### PR TITLE
Document core config and audit modules

### DIFF
--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -1,0 +1,108 @@
+# audit module
+
+## Purpose and non-goals
+
+`audit` is required core and owns security-relevant event recording, privacy-bounded governed-action
+evidence, tamper-evident WORM records, verification, checkpoints, sealed snapshots, and audit-ledger
+reads. It does not authorize actions, own general application logging, define retention policy, provide
+immutable hardware/storage, or make a best-effort dual write authoritative.
+
+## Public contracts
+
+`audit_args_hash` and `audit_command_preview` produce bounded action evidence;
+`audit_ledger_read` reads legacy `tool_action` rows; `audit_worm_append`, `audit_worm_verify`,
+`audit_worm_checkpoint`, `audit_worm_seal`, and `audit_worm_read_page` form the server WORM contract.
+`audit_worm_chain.h` is the shared engine-independent canonical hash/MAC boundary also consumed by the
+KB PostgreSQL store.
+
+## Dependencies and consumers
+
+- `config`: supplies the action-audit and WORM capture gates.
+- `module-runtime`: supplies required lifecycle and readiness contracts for audit capability.
+- `vault`: supplies the custody boundary for audit and checkpoint keys.
+
+Consumers include `execution-policy`/guardrails, server management and vault paths, trajectory export,
+audit CLI/API/dashboard readers, KB custody operations, and the separate DB2 KB WORM provider. Producers
+own event meaning; audit owns safe record formation, storage, verification, and diagnostic results.
+
+## Providers and readiness
+
+The legacy provider appends JSON lines to rotating `audit.log`. The server WORM provider is SQLite at
+`$AIMEE_HOME/audit/worm-live.db`; the KB uses a separate PostgreSQL store while sharing chain
+primitives. Readiness reports capture gate, store availability, chain result, checkpoint attestation,
+and sealed-file immutability separately. Legacy logging remains authoritative while WORM dual-write is
+default-off and best-effort.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; audit is required core, while individual capture/storage policies such as `audit_worm_enabled` are configurable.
+
+Governed-action audit is gated by `audit_action_enabled`; WORM dual-write is gated by
+`audit_worm_enabled`. Both cached gates are cleared by a config reload re-applier. Disabling a capture
+path does not remove audit capability or permit a producer to bypass a mandatory higher-level policy;
+the configured authority and loss behavior must remain visible.
+
+## Surfaces
+
+Surfaces include per-tool action emission, general `audit_log` producers, `aimee audit verify`,
+checkpoint, seal, and metric commands, management APIs/dashboard log reads, trajectory export, and KB
+WORM calls. These surfaces must label legacy versus WORM evidence, server versus KB stores, and
+green/amber/red verification without collapsing distinct guarantees into a generic `secure` result.
+
+## Data and migrations
+
+Legacy `audit.log` stores rotated JSON lines. Server WORM rows contain gap-free `seq`, advisory `ts`,
+actor, action, subject, verdict, bounded detail, key ID, previous hash, and row hash. SQLite triggers
+reject update/delete and `synchronous=FULL` protects commits; the SHA-256 chain detects row mutation,
+reordering, and gaps, while keyed checkpoints attest a head. Sealed snapshots use `VACUUM INTO` and a
+best-effort filesystem immutable flag.
+
+Retention, deletion schedules, archival lifecycle, remote replication, legal hold, external timestamping,
+hardware-backed keys, and guaranteed filesystem immutability are `not present`. Append-only triggers,
+`synchronous=FULL` commit synchronization, a hash chain, MAC checkpoints, and a best-effort immutable flag are separate properties
+and must not be represented as one stronger WORM guarantee.
+
+## Security and privacy
+
+Tool arguments, commands, principals, subjects, details, and operator-provided timestamps are untrusted
+and may contain secrets or personal data. Governed-action hashing uses a per-tool allowlist and dedicated
+HMAC key; command previews retain program basenames but no arguments. WORM detail is size-bounded but
+per-action secret scanning is `not present`, so producers must provide privacy-safe detail and audit
+readers require authorization.
+
+## Supported journeys
+
+After `execution-policy` decides a tool verdict, the wrapper emits exactly one legacy action row and,
+when enabled, attempts the corresponding WORM append without changing that verdict. Operators can read
+records, verify linkage/checkpoints, add a checkpoint, and seal a point-in-time snapshot. Server and KB
+stores produce the same canonical row hashes, but remain independently enabled, stored, and operated.
+
+## Tests and failure behavior
+
+`test_audit_action.c`, `test_audit_action_log.c`, `test_audit_ledger.c`, `test_audit_worm.c`,
+`test_audit_worm_chain.c`, `test_kb_audit_worm.c`, and vault/management audit suites cover bounded
+evidence, reads, chains, checkpoints, mutation rejection, and store consumers. Current governed-action
+emission is best-effort: hashing writes a stable sentinel on failure, and WORM loss does not block the
+action while legacy logging is authoritative.
+
+## Operational diagnostics
+
+Report store identity, capture/authority mode, append failure, safe action/verdict metadata, head and
+checkpoint sequence, green/amber/red verification, seal path, and whether the kernel immutable flag was
+actually set. Exclude raw tool arguments, secrets, private keys, full sensitive details, and an
+unbounded principal or subject. `amber` means an intact unattested tail, not corruption.
+
+## Compatibility
+
+The `v1-` args-hash form, per-tool projection, WORM domain and fixed field order, genesis value,
+gap-free sequence, checkpoint MAC contract, verification status meanings, event fields, and legacy
+reader ordering are compatibility contracts. Server SQLite and KB PostgreSQL must remain byte-identical
+at the shared chain seam; storage-engine migrations cannot silently rewrite historical records.
+
+## Extension and removal
+
+New producers use bounded typed event schemas; new stores implement the `audit_worm_chain` canonical
+contract or declare a versioned migration. Legacy/WORM dual paths, server/KB stores, and general/action emitters are
+overlap candidates requiring authority, parity, failure-policy, retention, and reader-liveness evidence.
+No path is confirmed dead; consolidation that weakens privacy, durability, or independent verification
+is outside a behavior-preserving source move.

--- a/docs/modules/config.md
+++ b/docs/modules/config.md
@@ -1,0 +1,108 @@
+# config module
+
+## Purpose and non-goals
+
+`config` is required core and owns configuration defaults, parsing, validation, persistence, effective
+snapshot publication, reload classification, and projections consumed by CLI, API, environment, and GUI
+surfaces. It does not own module behavior, provider selection semantics, secret values, deployment
+orchestration, or a GUI's navigation and presentation.
+
+## Public contracts
+
+`config_load`, `config_load_file`, `config_save`, `config_snapshot_get`, `config_reload`, and
+`config_reload_if_changed` are the current C contracts in `src/modules/config/config.h`. The typed
+`config_fields` allowlist supplies get/set validation, surface grouping, and the `live` or
+`restart_required` verdict. Module/provider owners remain responsible for consuming their values and
+registering a re-applier when bound state can safely change live.
+
+## Dependencies and consumers
+
+- `module-runtime`: supplies the required module identity, lifecycle, and readiness model whose active capabilities constrain configuration surfaces.
+
+Every required and optional module may consume `config`; server startup, the live server loop, CLI
+commands, deployment tooling, runtime and control GUIs, and tests are direct consumers. A dependency on
+config does not transfer ownership of another module's schema or activation semantics into this module.
+
+## Providers and readiness
+
+The reference provider is `aimee.yaml` plus compiled defaults and typed projections. Environment
+overrides are narrow consumer-owned seams, such as `config_apply_db2_url_env_override`, rather than a
+second universal parser. Readiness distinguishes missing files, accepted defaults, rejected invalid
+reloads, persistence failures, and startup-bound values; a syntactically valid snapshot does not prove
+that its selected provider or module is operational.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; configuration is required core and cannot be disabled, while the values it projects may activate optional modules and providers.
+
+Defaults are established before file parsing. Server startup seeds a lock-free snapshot; `config.set`
+performs a disk-based read-modify-save and immediately calls `config_reload`; the main loop also detects
+out-of-band file changes once per tick, while SIGHUP requests reload off the signal path. Invalid reloads
+retain the running snapshot. `RELOAD_RESTART` fields persist immediately but do not claim live effect.
+
+### GUI truthfulness contract
+
+A field shown in the GUI exists only when the currently selected live module/provider consumes it; unused fields are not rendered, not defaulted, and not silently preserved across reload of a module/provider that does not consume them.
+
+The current main Settings page receives every allowlisted field and filters only by runtime/deploy/
+advanced/dev group; the webchat settings panel uses a static allowlist. Dynamic live-consumer filtering
+is `not present`, so the quoted rule is the required target boundary rather than a current guarantee.
+
+## Surfaces
+
+Surfaces include `aimee config show|get|set`, `/v1/config`, `/v1/config/get`, `/v1/config/set`, typed
+`config_t` readers, `aimee.yaml`, narrowly defined environment overrides, and GUI projections. All
+surfaces must derive from one effective contract and expose an accurate reload verdict; a GUI may curate
+or label fields but may not invent defaults, persistence, provider readiness, or activation state.
+
+## Data and migrations
+
+Configuration data comprises compiled defaults, the parsed YAML tree, flat typed `config_t` values, the
+file-identity cache, the published double-buffer snapshot, field metadata, and consumer-specific derived
+state. Save/load round trips are compatibility-sensitive migrations: recognized sections must not be
+silently dropped, unknown or legacy shapes require an explicit policy, and secrets should be stored as
+`vault` references rather than copied into general configuration.
+
+## Security and privacy
+
+Configuration files, environment values, API writes, paths, endpoints, commands, and provider metadata
+are untrusted input. The typed `config_fields` allowlist bounds remote get/set, strict validation rejects invalid
+reloads, and disk reads avoid overwriting unseen edits. Config must not expose secret material through
+GUI/API projections, logs, reload diagnostics, serialized defaults, or an inactive module's stale field.
+
+## Supported journeys
+
+At startup, defaults and a valid file produce the initial effective snapshot before consumers bind
+state. During operation, `config_reload` validates and atomically publishes a typed API write or detected
+file change; hot readers see the next snapshot, registered re-appliers update bounded state, and
+startup-bound consumers continue with an explicit restart requirement. CLI-only reads use the file path
+when no live server snapshot exists.
+
+## Tests and failure behavior
+
+`test_config.c`, `test_cmd_config.c`, `test_config_surface.c`, `test_config_snapshot.c`, config parser
+suites, and frontend setup/settings tests cover defaults, validation, round trips, projections, reload,
+and UI assumptions. Missing files yield defaults; malformed or invalid reload input keeps the running
+snapshot; failed save/set returns an error; unrecognized typed keys are rejected rather than persisted.
+
+## Operational diagnostics
+
+Report the selected config path, validation issue class, reload source, `publication/no-op/rejection`,
+field reload verdict, re-applier failure context, and module/provider readiness without printing values
+that may be secret. SIGHUP and file-watch logs must distinguish a rejected reload from a process restart;
+neither path restarts the server in the current implementation.
+
+## Compatibility
+
+Field names and `config_t` types, defaults, saved YAML shapes, allowlisted API response shapes, environment
+precedence, reload verdicts, and preservation on save are compatibility contracts. Adding a field is not
+enough to make it user-facing: its consuming module/provider, activation condition, secrecy, reload
+class, and live GUI eligibility must also be declared and tested.
+
+## Extension and removal
+
+New configuration belongs with the module/provider that consumes it and is projected through config's
+shared validation and persistence seams. Duplicate parsers, hand-maintained GUI field lists, settings
+with no non-test consumer, and serialize-only values are `configuration-only` or
+`duplicated-by-adjacent-module` candidates, not confirmed dead code; removal requires save/load,
+environment, API, GUI, and runtime-liveness evidence.

--- a/docs/validation/core-modularization-slice-17.md
+++ b/docs/validation/core-modularization-slice-17.md
@@ -1,0 +1,94 @@
+# Core modularization slice 17: config and audit documentation
+
+## Diff scope precondition
+
+The slice-start commit is `dd87702c42d4ec2e8ec9167b375043cbc13650cc`. The allowed close diff is
+limited to `docs/modules/config.md`, `docs/modules/audit.md`, the documentation-status partition, this
+validation record, and the existing cleanup ledger. Production source, descriptors, schemas, generated
+artifacts, build graphs, routes, GUI code, checkers, and optional-module documents are excluded.
+
+## Outcome
+
+This slice promotes exactly required-core `config` and `audit` from documentation debt. Six optional
+documents remain: `benchmarks`, `control-web`, `governance`, `roundtable`, `runtime-web`, and
+`workflows`. Promotion records contracts and distributed physical ownership; it does not claim source
+consolidation, optional profile completion, or dynamic liveness proof.
+
+## Config evidence and gaps
+
+`src/modules/config/module.yaml` declares only `module-runtime` and no runtime toggle. Owned physical
+source is `src/modules/config/*`; distributed consumers include server startup/loop, CLI, deployment,
+modules, webchat, and frontend settings. `config_load` selects the published snapshot after server
+startup and otherwise reads disk (`config.c:1077`); `config_load_file` applies defaults, validates, and
+uses file identity for its cache (`config.c:1084`). Server startup seeds the snapshot
+(`server/server_main.c:185`). `handle_config_set` reads disk, saves, reloads immediately, and returns a
+field verdict (`server/server_config.c:67`). The main loop processes SIGHUP and calls
+`config_reload_if_changed` each tick (`server/server.c:2376`). This is reload, not server restart.
+
+The typed field table classifies hot, re-appliable, and restart-bound values and assigns each field to
+a runtime, deploy, advanced, or dev presentation group. `/v1/config` returns every typed field plus non-runtime
+group metadata (`server/server_config.c:13`). `frontend/src/pages/Settings.tsx` hides non-runtime groups
+by default but does not filter by live module/provider consumption. `webchat/settings.go` maintains a
+static settings allowlist. Therefore the approved GUI truthfulness sentence in `config.md` is normative:
+dynamic consumer filtering is `not present`; no behavior is changed in this documentation-only slice.
+
+The monolithic flat `config_t`, hand-maintained field metadata, distributed section parsers/savers, and
+separate GUI lists are future consolidation/liveness subjects. A field with only parser, serializer,
+default, schema, or self-test evidence is a `configuration-only` candidate, not confirmed dead; proving
+removal requires non-test references, dynamic registration, API/GUI exposure, environment readers,
+round-trip compatibility, and supported-journey evidence.
+
+## Audit evidence and guarantee matrix
+
+`src/modules/audit/module.yaml` declares `config`, `module-runtime`, and `vault` with no runtime toggle.
+Physical source comprises action hashing/preview, the legacy ledger reader, SQLite WORM storage, and the
+shared WORM chain. Consumers include guardrails, server management/state, trajectory export, KB vault
+operations, and `src/db2/kb_audit_worm.c`.
+
+| Property | Current evidence | Limit |
+|---|---|---|
+| Legacy append log | `log.c:219` appends and flushes JSON lines; `log.c:200` rotates by size | no hash chain, retention policy, or immutable storage |
+| SQLite append-only | `audit_worm.c:32` creates update/delete rejection triggers | a writer with database/file authority can remove triggers or replace the file |
+| Commit durability | `audit_worm.c:103` selects WAL and `:104` sets `synchronous=FULL` | not remote replication, hardware durability, or retention |
+| Tamper evidence | `audit_worm_chain.c` hashes fixed length-prefixed fields and prior hash | detects after verification; it does not prevent file replacement or rollback alone |
+| Checkpoint attestation | `audit_worm_checkpoint` uses a dedicated keyed MAC | an uncheckpointed intact tail is amber; key custody and external anchoring remain separate |
+| Sealed snapshot | `audit_worm_seal` checkpoints, `VACUUM INTO`, then tries an FS immutable flag | filesystem immutability is best-effort and may be unavailable |
+| KB parity | `db2/kb_audit_worm.c` consumes `audit_worm_chain.h` | separate store, gate, authority, and failure behavior; byte parity still merits an end-to-end regression |
+
+Retention/deletion schedules, legal hold, external timestamping, remote replication, hardware-backed
+keys, mandatory detail secret scanning, and guaranteed immutable media are `not present`. The legacy
+action log is currently authoritative; WORM dual-write is default-off and best-effort, and an append
+failure does not change the tool verdict (`modules/guardrails/guardrails_action_audit.c:74`).
+
+## Overlap and liveness findings
+
+| Area | Classification | Disposition |
+|---|---|---|
+| `config_fields` metadata and frontend/webchat lists | `duplicated-by-adjacent-module` candidate, not confirmed | derive truthful GUI projections from live module/provider consumers in a later source slice |
+| Config parse/save pairs and flat `config_t` | boundary overlap | audit field consumers and round-trip behavior before moving ownership into module source |
+| Legacy action log and SQLite WORM | dual-write overlap, not dead code | retain until authority, migration, reader parity, and failure policy are explicit |
+| Server SQLite and KB PostgreSQL WORM | storage providers sharing canonical primitives | retain independent stores; add byte-identical end-to-end parity evidence |
+| General `audit_log` and governed `audit_action_log` | distinct producer/evidence contracts | retain; compare caller coverage before any consolidation |
+
+No `unreachable`, `superseded`, or `test-only` candidate met the static threshold. The WORM store is
+configuration-gated but has non-test CLI/API/producer consumers, so it is not configuration-only dead
+code. Runtime liveness and real deployment configuration remain a hypothesis, unverified.
+
+## Deferred cleanup observations
+
+Later audit source work should document the KB build exclusion for the SQLite store, list both consumers
+on `audit_worm_chain.h`, prove byte-identical server/KB rows through their storage paths, record the DB2
+dependency edge, and compile the shared header standalone. These observations do not authorize source,
+build, schema, or test changes in this slice.
+
+## Verification
+
+- `python3 -I -S scripts/check_module_docs.py`
+- `python3 -I scripts/tests/test_check_module_docs.py -v`
+- `python3 -I -S scripts/check_module_source_ownership.py`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+- `python3 -I -S scripts/refactor_baselines.py`
+- `make -C src lint`
+- close-time changed-path and diff-stat scope checks
+- technical-writer review and exact-diff roundtable approval
+- feature-branch pull-request CI

--- a/tests/baselines/modules/documentation-status.yaml
+++ b/tests/baselines/modules/documentation-status.yaml
@@ -18,12 +18,12 @@
     "vault",
     "workspace",
     "tools",
-    "git"
+    "git",
+    "config",
+    "audit"
   ],
   "debt": [
-    "audit",
     "benchmarks",
-    "config",
     "control-web",
     "governance",
     "roundtable",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -193,6 +193,23 @@
       "blast_radius": "No runtime surface changes; the strict module-doc gate and close-time path check constrain the slice to five docs, status, validation, and ledger accounting.",
       "independent_review": "Technical-writing and exact-diff roundtable review are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-16.md", "docs/modules/execution-policy.md", "docs/modules/vault.md", "docs/modules/workspace.md", "docs/modules/tools.md", "docs/modules/git.md"]
+    },
+    {
+      "slice": 17,
+      "state": "present_and_verified",
+      "disposition": "Documented required-core config and audit against current reload, GUI projection, action evidence, legacy ledger, and WORM implementations without overstating restart, retention, or immutable-storage guarantees.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["six optional module documents remain explicit status debt", "dynamic live-consumer filtering for GUI config fields is not present", "distributed config ownership and dual audit stores remain for focused source slices"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice adds documentation and baseline accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Calling all persisted settings live or all audit persistence WORM would conceal verified contract gaps and collapse distinct guarantees.",
+        "revisit": "Source slices must prove consumer liveness, round-trip compatibility, authority migration, privacy, and store parity before consolidation or removal."
+      },
+      "consumers": ["module maintainers", "technical writers", "future config and audit source slices"],
+      "blast_radius": "No runtime surface changes; the strict module-doc gate and close-time path check constrain the slice to two docs, status, validation, and ledger accounting.",
+      "independent_review": "Technical-writing and exact-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-17.md", "docs/modules/config.md", "docs/modules/audit.md"]
     }
   ]
 }


### PR DESCRIPTION
## What changed

- document required-core `config`, including effective snapshots, reload classification, persistence, and GUI projection contracts
- document required-core `audit`, including legacy action evidence and the distinct SQLite WORM guarantees
- promote `config` and `audit` from documentation debt and record Slice 17 cleanup evidence

## Why

The modularization effort needs source-grounded ownership contracts before physical source movement. These documents separate current behavior from target boundaries: config reload does not restart the server, startup-bound fields still report a restart requirement, and GUI settings must eventually be filtered by the selected live module/provider. Audit durability properties are documented independently so append-only triggers, SQLite `synchronous=FULL`, hash chains, MAC checkpoints, and best-effort immutable snapshots are not collapsed into a stronger claim.

## Impact

Documentation and baseline accounting only. No production source, schema, descriptor, route, GUI, build, checker, or runtime behavior changes.

## Validation

- strict module-documentation checker and its unit tests
- module source-ownership checker
- cleanup-ledger and refactor-baseline checkers
- `make -C src lint`
- technical-writer review
- exact staged-diff roundtable approval after three rounds
