### PR TITLE
Document optional execution and benchmark modules

### DIFF
--- a/docs/modules/benchmarks.md
+++ b/docs/modules/benchmarks.md
@@ -1,0 +1,101 @@
+# benchmarks module
+
+## Purpose and non-goals
+
+`benchmarks` is an optional quality-measurement module that owns offline benchmark harnesses, suites,
+corpora, scoring, baselines, result aggregation, and benchmark cadence. It is not named `evals` and does
+not own runtime agent assessment, production verification, routing/policy decisions, roundtable
+verification, workflow approval, memory behavior, or general telemetry.
+
+## Public contracts
+
+The target module directory currently contains only `src/modules/benchmarks/module.yaml`. Existing
+physical contracts remain distributed through `src/modules/agent_eval/agent_eval.h`, `memory.benchmark`,
+`eval.run`, benchmark scripts/catalogs, regression baselines, and CI smoke gates. Treating those as
+benchmark ownership is a target classification, not evidence that relocation or optional isolation is
+complete.
+
+## Dependencies and consumers
+
+- `config`: supplies benchmark provider, corpus, arm, threshold, and execution settings.
+- `ir`: supplies canonical inputs/results suitable for comparable scoring and attribution.
+- `memory`: exposes retrieval behavior and benchmark-only scratch seams without transferring ownership.
+- `module-runtime`: supplies optional lifecycle, capability, and readiness contracts.
+- `routing`: selects benchmarked providers/arms without allowing benchmark code to change live routing.
+
+Consumers include developers, CI, `aimee agent eval`, `aimee memory benchmark`, `eval.run`, optimize
+comparison gates, dashboards, and research scripts. Runtime KB ranker promotion gates consume benchmark
+results but remain owned by learning/memory, not this optional harness module.
+
+## Providers and readiness
+
+Providers include C agent/memory harnesses, Python coding/reasoning/memory/ingest suites, external
+datasets such as `LoCoMo` and LongMemEval, scratch DB providers, CI smoke jobs, and stored baselines.
+Readiness must report harness presence, dataset/license/download state, provider credentials, scratch
+isolation, deterministic seed/arm, metric support, and result destination separately.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; the descriptor is `enabled_by_default: false`, so the target module is selected before startup rather than hot-toggled.
+
+No `modules.benchmarks` activation field or target-module registration was found. The legacy
+`src/modules/agent_eval` objects are included in `AGENT_SRCS`, and server/CLI benchmark routes remain
+available in ordinary builds. Descriptor-declared optionality is therefore `not present` at the current
+physical/build boundary; this slice documents the mismatch without changing it.
+
+## Surfaces
+
+Surfaces include `aimee agent eval`, `eval.run`, `aimee memory benchmark`, `memory.benchmark`, optimize
+run/compare, benchmark scripts, dataset provision/download scripts, baseline/result files, dashboard
+summaries, and `bench-smoke.yml`. Names may retain legacy `eval` compatibility during migration, but the
+module taxonomy and new ownership language use `benchmarks`.
+
+## Data and migrations
+
+Data includes task suites, corpora, expected answers/relevance, arm matrices, model/provider metadata,
+latency/cost/quality metrics, miss traces, progress, baselines, result JSON/`JSONL`/text, and temporary
+isolated DBs. Results require provenance for code/data/config/model versions. Moving legacy agent-eval
+storage or APIs requires explicit aliases and must not rewrite historical benchmark evidence.
+
+## Security and privacy
+
+Datasets, repositories, prompts, model output, credentials, result artifacts, and third-party licenses
+are untrusted or sensitive. `benchmarks` must use scratch stores and bounded subprocess/network access,
+redact secrets and private examples, prevent result contamination, and never mutate production memory,
+routing, policy, or provider configuration as a side effect of a measurement run.
+
+## Supported journeys
+
+An operator selects a committed suite/arm and provider; `benchmarks` validates prerequisites, creates an
+isolated run, executes comparable cases, records per-case evidence, aggregates metrics, compares an
+optional baseline, and emits a provenance-bearing report. CI may fail on a declared regression, but the
+module does not make per-request production decisions or participate in roundtable consensus.
+
+## Tests and failure behavior
+
+Benchmark inventory/LLM tests, the extensive `benchmarks/tests` suites, agent/memory evaluation tests,
+server memory-benchmark tests, corpus validators, and smoke workflows cover current harnesses. Missing
+dataset/provider, invalid case, scratch-store failure, timeout, incomplete sample, or baseline mismatch
+must be explicit; skipped/incomparable cases cannot be silently scored as passes.
+
+## Operational diagnostics
+
+Report `benchmark` suite/case/arm, corpus and code revision, provider/model, seed, sample/skip/error count,
+metrics, latency/cost, baseline delta, scratch isolation, and result path. Exclude credentials, private
+dataset rows, raw prompts/responses, and production memory contents. Distinguish harness absence,
+provider failure, invalid corpus, incomplete run, and measured regression.
+
+## Compatibility
+
+Suite/task schemas, CLI/API aliases, metric definitions, thresholds, arm names, dataset versions,
+baseline/result formats, provenance, and exit semantics are compatibility contracts. Legacy `eval.run`
+and `agent_eval_*` names may be transitional aliases, but they cannot preserve a separate `evals` module
+or imply runtime evaluation authority.
+
+## Extension and removal
+
+New suites register offline harness/data/metric contracts without adding runtime decision hooks.
+`src/modules/agent_eval`, `server_eval.c`, benchmark routes, and distributed scripts are `relocate` or
+compatibility-alias candidates for a later source slice. Stale corpora, duplicate runners, committed
+sample results, and self-tested-only harnesses are candidates, not confirmed dead; removal requires
+consumer, CI, reproducibility, licensing, and liveness evidence.

--- a/docs/modules/roundtable.md
+++ b/docs/modules/roundtable.md
@@ -1,0 +1,102 @@
+# roundtable module
+
+## Purpose and non-goals
+
+`roundtable` is an optional multi-agent deliberation module that owns panel/seat formation, chair
+behavior, roundtable-specific review/verification, iterative authoring pipelines, and composition of
+panel findings. It is not a workflow engine, generic router, delegate runtime, benchmark authority, or
+replacement for core `response-composition`.
+
+## Public contracts
+
+Current contracts include delegate ensemble execution/results, panel eligibility and seat resolution,
+`roundtable_chair_apply`, preset load/save/apply, pipeline capture/chunk/evaluation, and verification.
+Roundtable-specific composition must preserve attributed panel evidence and verdict semantics before
+handing the result to general response composition or a consuming workflow.
+
+## Dependencies and consumers
+
+- `audit`: records panel selection, model calls, verification, chair decisions, and outcomes.
+- `config`: supplies presets, seats, rounds, budgets, pipeline, chair, and provider settings.
+- `delegates`: invokes panelists and the chair through core credential/routing seams.
+- `ir`: carries canonical prompts, contributions, findings, and results.
+- `module-runtime`: supplies optional lifecycle, capability, and readiness contracts.
+- `response-composition`: renders the final user-facing response after roundtable semantics are resolved.
+- `routing`: selects eligible delegate providers/models without owning panel policy.
+
+Consumers include `ensemble` CLI/MCP/API routes, server authoring pipelines, sweep/review flows, optional
+workflow roundtable gates, and the frontend Roundtable surface. Workflows may await a result, but retains
+its own durable state, triggers, approvals, and scheduling.
+
+## Providers and readiness
+
+Panel providers are resolved from configured agents, `roundtable_preset` eligibility/authorization/availability filters,
+seat presets, and random-seat rules; chair and verifier calls use delegate providers. Readiness must
+separate activation, usable seats, provider credentials/health, budget, preset validity, capture store,
+and pipeline state. A compiled route or saved preset is not proof of an executable panel.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; the descriptor is `enabled_by_default: false`, so activation is selected before startup rather than hot-toggled.
+
+Configuration covers reference seats/models, consensus rounds/turns, personas, chair behavior, cost and
+token bounds, pipeline passes/attempts/gates, capture, and named presets. Unlike workflows, no
+`modules.roundtable` activation field was found in `config_parse_modules_section`; server routes and
+roundtable objects are compiled directly. Descriptor-declared optionality is therefore not fully
+enforced by current configuration/build wiring.
+
+## Surfaces
+
+Surfaces include `aimee ensemble roundtable`, ensemble review/start/status/pause/advance/list tools,
+roundtable presets, authoring-pipeline APIs, frontend authoring controls, sweep review, and workflow
+roundtable/panel blocks. Generic delegate calls belong to delegates; generic output rendering belongs to
+response composition; only panel deliberation semantics belong here.
+
+## Data and migrations
+
+State includes named JSON presets, DB1 ensemble/session records, panel assignments and contributions,
+round/pass/attempt/gate state, captured prompts/results, costs, verdicts, and pipeline worktrees/artifacts.
+Filesystem paths under `$AIMEE_HOME/roundtables` and `roundtable_pipeline` are physical providers.
+Migrations must preserve attribution, ordering, resumability, verdict identity, and redacted evidence.
+
+## Security and privacy
+
+Prompts, diffs, panel output, model metadata, presets, repository context, and captured artifacts are
+untrusted and may be sensitive. `delegates`, vault, routing, and audit retain their core authority.
+Authorization/availability filters, bounded turns/costs/context, output parsing, secret redaction, and
+workspace isolation must fail closed without allowing one panelist or chair to forge another's evidence.
+
+## Supported journeys
+
+A caller submits a bounded task; `roundtable` resolves eligible seats, invokes panelists, normalizes and
+deduplicates findings, optionally runs iterative review or a chair, verifies convergence, and returns an
+attributed result to the caller. In a workflow gate, that result advances or blocks the workflow through
+the workflow provider seam; roundtable never owns the work item's durable lifecycle.
+
+## Tests and failure behavior
+
+`test_delegate_ensemble` and chair, preset, seat-resolution, pipeline capture/chunk/eval, panel composition, verification,
+MCP, HTTP, and workflow-gate suites cover current behavior. No eligible/available seats, provider error,
+invalid model output, budget/turn exhaustion, failed quorum, capture failure, or non-convergence must
+produce a typed incomplete/failure result rather than invented consensus.
+
+## Operational diagnostics
+
+Report `roundtable` mode, preset, seat/provider identity, eligibility/availability reason, round/pass,
+quorum/convergence, chair use, bounded token/cost totals, capture identifier, and safe failure class.
+Exclude prompts, diffs, private panel content, credentials, and raw model responses. Diagnostics must
+distinguish descriptor-disabled, provider-unready, non-converged, and workflow-consumer failures.
+
+## Compatibility
+
+Tool/API names, preset shapes, seat aliases, panel result/finding schemas, quorum and verification
+semantics, chair contracts, pipeline state, attribution, and workflow provider results are compatibility
+contracts. Roundtable-specific result composition may depend on `response-composition` but cannot replace
+or redefine its general memory-grounded response contract.
+
+## Extension and removal
+
+New panel/chair/verifier providers use delegate/routing seams and preserve attributed IR. Distributed
+server pipeline/routes and workflow panel adapters are `relocate` candidates. Legacy `session_*` tool
+aliases, overlapping review pipelines, unused preset fields, or self-tested-only stages are candidates,
+not confirmed dead; consolidation requires surface, config, caller, persistence, and runtime evidence.

--- a/docs/modules/workflows.md
+++ b/docs/modules/workflows.md
@@ -1,0 +1,108 @@
+# workflows module
+
+## Purpose and non-goals
+
+`workflows` is an optional orchestration module that owns workflow definitions, triggers as workflow
+intake, durable run state, advancement, approvals, scheduling, and workflow-specific integrations. It
+does not own generic routing, delegates, skills, tools, policy decisions, audit, workspace authority, or
+roundtable panel semantics merely because a workflow invokes them.
+
+## Public contracts
+
+The current contracts include `wfe_def_parse`, `wfe_def_validate`, `wfe_work_item_create`,
+`wfe_engine_run`, `wfe_autonomy_run`, `wfe_advance_request_run`, block-executor registration, scheduler
+notification, and trigger dispatch through `gw_orch_workflows_run`. Definitions and state transitions
+must remain deterministic and versioned; provider seams perform effects without owning the lifecycle.
+
+## Dependencies and consumers
+
+- `audit`: records workflow intake, decisions, effects, state transitions, and terminal outcomes.
+- `config`: supplies module activation, trigger, autonomy, forge, approval, and scheduler settings.
+- `delegates`: executes delegated workflow blocks through a bounded provider seam.
+- `execution-policy`: authorizes tool, shell, Git, delivery, and externalization effects.
+- `ir`: carries canonical request/result records across workflow steps.
+- `module-runtime`: supplies optional lifecycle, capability, and readiness contracts.
+- `routing`: selects a workflow without owning its intake or durable state.
+- `skills`: supplies reusable instructions requested by workflow blocks.
+- `tools`: exposes typed effects requested by workflow execution.
+- `workspace`: supplies authorized roots and per-run worktrees.
+
+Consumers include trigger/interactive/dev-submit intake, server workflow APIs, delegates, optional
+roundtable gates, and operator dashboards. Trigger delivery is an integration; workflows owns how a
+trigger becomes a run and how that run advances.
+
+## Providers and readiness
+
+Definitions may be built-in, YAML, or custom-block backed; executor providers include delegates,
+verification, judge, forge, foreach, human gates, and roundtable gates. Readiness must report definition
+validity, store/scheduler state, activation, registered providers, workspace availability, and missing
+effect capabilities independently. `registered` does not imply the optional module is enabled.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; the descriptor is `enabled_by_default: false`, so activation is selected before startup rather than hot-toggled.
+
+`modules.workflows` is the canonical activation field used by trigger dispatch, with a deprecated
+environment fallback. Trigger rules, cron jobs, concurrency/cost ceilings, autonomy, live forge, custom
+commands, and proposal autoscan are separate settings. Current server startup still calls
+`wfe_autonomy_register` and `wfe_scheduler_init` unconditionally; complete disabled-profile isolation is
+`not present` and must be proven by a later source/build slice.
+
+## Surfaces
+
+Surfaces include workflow definitions, `trigger.*` and workflow API/CLI operations, `wfe_advance`,
+interactive/dev-submit intake, scheduled/armed trigger blocks, dashboards, and provider callbacks.
+Triggers are part of workflows: cron, proposal, manual, or adapter code may detect an event, but the
+workflow module owns admission, materialized intake, durable identity, advancement, and terminal state.
+
+## Data and migrations
+
+Durable data includes definitions and canonical versions, work items, events, node attempts, artifacts,
+approvals, leases, pause/resume state, trigger runs/materialized inputs, costs, and per-run workspace/PR
+references. DB1 `wfe_store`/trigger stores and filesystem definitions are current physical providers. Schema or
+definition migrations must preserve replay, idempotency, CAS/lease behavior, and observable history.
+
+## Security and privacy
+
+Workflow YAML, triggers, artifacts, prompts, repository content, provider results, commands, and
+approval tokens are untrusted. `execution-policy` gates effects, workspace bounds paths, vault retains
+credentials, and audit receives privacy-bounded evidence. Native/shell externalization gates, protected
+branch checks, signed approval content, cost limits, and bounded retries must fail closed without logging
+secrets or silently advancing state.
+
+## Supported journeys
+
+A trigger or explicit request selects a definition, files one durable work item, and notifies the
+`wfe_scheduler`; the engine leases the item, executes the current block through a registered provider,
+persists output/transition evidence, and advances, pauses for approval, retries, or terminates. A
+roundtable block awaits a roundtable result while workflows retains run state and scheduling ownership.
+
+## Tests and failure behavior
+
+WFE definition, validation, blocks, engine, safety, manager-flow, scheduler, trigger,
+`gw_orch_workflows`, approval, native-gate, replay-worktree, and live-provider suites exercise current
+behavior. Disabled intake returns capability absence instead of filing; invalid graphs fail before
+execution; lease/CAS conflict, missing provider, denied effect, budget exhaustion, or failed verification
+must preserve an inspectable non-success state rather than silently complete.
+
+## Operational diagnostics
+
+Report `workflow`, version, work-item ID, intake source, trigger identity, activation, current node/state,
+attempt/lease, provider readiness, approval/pause reason, cost/budget, workspace, and safe error class.
+Exclude prompt/artifact bodies, approval keys, credentials, and raw provider output. Distinguish a
+registered-but-disabled module from a scheduler or provider failure.
+
+## Compatibility
+
+Workflow/block names such as `trigger.watch-dir`, definition grammar, canonical version hashes, state/event shapes, trigger intake,
+API/tool schemas, approval semantics, retry/CAS rules, provider interfaces, and terminal outcomes are
+compatibility contracts. Triggers cannot be split into an independent module, and roundtable integration
+cannot make either module the lifecycle owner of the other.
+
+## Extension and removal
+
+New triggers enter through the workflow intake contract; new blocks register typed executors and declare
+effects/dependencies. Distributed server trigger/scheduler/provider code is a `relocate` candidate for a
+later source slice. Registrations with no reachable activated journey, duplicate router/gate logic, and
+self-tested-only blocks are candidates, not confirmed dead; removal requires build, config, caller,
+state, and runtime-liveness evidence.

--- a/docs/validation/core-modularization-slice-18.md
+++ b/docs/validation/core-modularization-slice-18.md
@@ -1,0 +1,131 @@
+# Core modularization slice 18: optional execution and quality documentation
+
+## Diff scope precondition
+
+The slice-start commit is `185ce22539168243fedc0509aca853621f2ba243`. Allowed close paths are the
+three module documents, this validation record, the documentation-status partition, and the cleanup
+ledger. Production source, descriptors, build/package files, schemas, GUI, generated artifacts,
+checkers, tests, and the deferred `control-web`, `governance`, and `runtime-web` documents are excluded.
+
+## Outcome and method
+
+This slice promotes exactly optional `workflows`, `roundtable`, and `benchmarks`. Three documentation
+debts remain: `control-web`, `governance`, and `runtime-web`. Inspection covered descriptors, physical
+inventory, headers/entry points, config parsing/defaults, build lists, registrations/startup, routes,
+callers, stores, tests, benchmark corpora/scripts, and prior proposals. Aimee memory and index were
+queried first; the configured index points at a different workspace and returned no symbol matches, so
+nearby source inspection supplied the evidence.
+
+Static references prove compilation, registration, and callers, not deployed activation. Runtime
+liveness remains a hypothesis, unverified unless an explicit reachable path is cited. Candidate labels
+do not confirm dead code, and discrepancies are deferred rather than fixed in this docs-only slice.
+
+## Inventory and activation evidence
+
+### Workflows
+
+`src/modules/workflows` contains 45 C/header files plus `module.yaml`, including definition,
+validation, engine, advancement, approval, autonomy, scheduler, providers, trigger block, roundtable
+gate, and orchestration-seam implementations. The descriptor declares ten dependencies,
+`enabled_by_default: false`, and no runtime toggle. `config.c:623` defaults `module_workflows` to
+inherit/unset and `config_sections.c:747` parses `modules.workflows`; `trigger_scheduler.c:512` resolves
+that gate before `gw_orch_workflows_run`. Yet `server.c:2302` calls `wfe_autonomy_register` and
+`:2330` calls `wfe_scheduler_init` unconditionally. Current liveness is compiled, registered,
+configurable at trigger intake, instantiated at server startup, reachable through trigger/workflow APIs,
+and extensively tested; complete disabled build/runtime isolation is absent.
+
+Triggers are workflow intake. `wfe_def.c` defines `trigger.watch-dir`; `wfe_validate.c:256` constrains a
+trigger block to workflow start; `wfe_blocks.c:1129` executes its already-fired run-time form;
+`trigger_scheduler.c:492` materializes and files runs through the workflow orchestration seam. Detection
+may remain in a server adapter, but definition semantics, admission, durable run, and advancement belong
+to workflows.
+
+### Roundtable
+
+`src/modules/roundtable` contains ensemble, chair, preset, seat-resolution, pipeline capture/chunk/eval,
+review, verify, and type files plus its descriptor. The descriptor declares seven dependencies,
+`enabled_by_default: false`, and no runtime toggle. Server pipeline, MCP/HTTP/preset, sweep, compute, and
+workflow provider code directly consume these symbols, and `SERVER_SRCS` directly includes roundtable
+objects. No `modules.roundtable` entry exists in `config_parse_modules_section`. Current liveness is
+compiled, registered/reachable/configurable through feature-specific fields and presets, and tested;
+descriptor-level optional activation/isolation is absent.
+
+Workflow integration is explicit: `wfe_roundtable.c` and `wfe_live_panel.c` provide workflow block seams,
+while `delegate_ensemble*`, `roundtable_chair*`, and `roundtable_verify*` retain panel semantics.
+Workflows owns the awaiting work-item state; roundtable owns seat/panel/chair/findings/convergence.
+
+### Benchmarks
+
+`src/modules/benchmarks` contains only `module.yaml`, which declares five dependencies,
+`enabled_by_default: false`, and no runtime toggle. Physical benchmark behavior is distributed across
+`benchmarks/`, `bench/`, scripts, CI, `server_eval.c`, server memory-benchmark routes,
+`src/modules/agent_eval/*`, platform task loaders, CLI code, DB scratch/eval support, and tests.
+`AGENT_SRCS` directly includes four `agent_eval` objects, while ordinary server/CLI dispatch exposes
+`eval.run` and `memory.benchmark`. No `modules.benchmarks` config field or target-module registration was
+found. The target module is descriptor-only; legacy harnesses are compiled/reachable/tested but are not
+optional at that boundary.
+
+The taxonomy name is `benchmarks`, not `evals`. Legacy `agent_eval`, `eval.run`, `mem_eval_*`, and file
+names are compatibility/movement debt. Offline scoring cannot own runtime verification, roundtable
+consensus, workflow approvals, or live routing/policy. KB ranker benchmark gates remain learning/memory
+consumers of evidence, not authority transferred to this optional module.
+
+## Dependency reconciliation
+
+| Module/dependency | Evidence classification | Boundary |
+|---|---|---|
+| workflows → audit/config/module-runtime | declared and observed | event/config/lifecycle providers; distributed registration remains |
+| workflows → delegates/policy/skills/tools/workspace | declared and observed | effect providers and authority, not workflow ownership |
+| workflows → ir/routing | declared and observed | canonical records and selection; routing does not own intake |
+| roundtable → audit/config/delegates/ir/routing | declared and observed | evidence/config/invocation/record/provider seams |
+| roundtable → response-composition | declared, boundary observed | general rendering remains core; panel composition remains roundtable |
+| roundtable → module-runtime | descriptor-only at activation boundary | no effective module gate found |
+| benchmarks → config/ir/memory/routing | declared; distributed legacy behavior observed | harness inputs/providers; no runtime authority |
+| benchmarks → module-runtime | descriptor-only | no registration or activation field found |
+
+No declared edge is classified stale from static evidence. Module-runtime edges for roundtable and
+benchmarks are unresolved implementation gaps rather than unused descriptor text.
+
+## Cross-module overlap and liveness matrix
+
+| Capability | Owner | Integrator/consumer | Evidence | State / ambiguity |
+|---|---|---|---|---|
+| Trigger-to-run intake | workflows | server trigger adapter, routing | `trigger_scheduler.c:492`; `gw_orch_workflows.c`; `wfe_def.c:38` | implemented/reachable/tested; physical adapter distributed |
+| Workflow effect authorization | execution-policy | workflows | `wfe_enforce.*`, `wfe_native_gate.*`, provider calls | implemented/tested; policy remains core |
+| Delegate/skill/tool execution | delegates/skills/tools | workflows | `wfe_live_delegate.c:481`; `wfe_blocks.c` | registered/reachable/tested |
+| Per-run resource authority | workspace | workflows | `wfe_replay_worktree.*`, worktree blocks | implemented/tested |
+| Workflow audit/config | audit/config | workflows | descriptor plus config/action call sites | implemented; disabled isolation incomplete |
+| Roundtable workflow gate | roundtable panel; workflows lifecycle | each consumes the other seam | `wfe_roundtable.c:217`; `wfe_live_panel.c:370` | implemented/tested; ownership intentionally split |
+| Panel invocation | roundtable | delegates/routing providers | `delegate_ensemble.*`, seat resolve | implemented/reachable/tested |
+| Final generic response rendering | response-composition | roundtable | descriptor and composed result handoff | declared/implemented boundary; no ownership transfer |
+| Roundtable audit/config | audit/config | roundtable | presets/config and call paths | implemented; module activation absent |
+| Benchmark cadence | benchmarks | CI/manual workflow scheduling | `.github/workflows/bench-smoke.yml`, pending cadence proposal | smoke implemented; standing cadence remains prospective |
+| Roundtable verification | roundtable | benchmarks has no role | `roundtable_verify.*`, pipeline eval tests | implemented; benchmark authority absent |
+| Runtime agent quality gate | runtime owners | benchmarks has no role | ordinary runtime callers do not require benchmark module | absent by contract; KB learning gates are separate |
+
+## Overlap and cleanup findings
+
+- `src/modules/agent_eval` is a `relocate` candidate into the benchmarks ownership boundary, with legacy
+  API aliases preserved; it is live code, not dead code.
+- Unconditional WFE startup registration versus gated trigger intake is an optionality contradiction,
+  deferred to a workflow profile/source slice.
+- Direct roundtable build/routes without `modules.roundtable` activation is an optionality contradiction,
+  deferred to a roundtable profile/source slice.
+- Workflow roundtable adapters and server roundtable pipelines are integrations, not duplicate owners.
+- Benchmark scripts cover multiple domains and contain apparent overlapping runners; none is confirmed
+  duplicated or dead without corpus/provider/result parity and CI/consumer evidence.
+
+No `unreachable`, `superseded`, `configuration-only`, or `test-only` candidate met the deletion
+threshold. Descriptor-only target ownership does not make the distributed implementation dead.
+
+## Verification
+
+- `python3 -I -S scripts/check_module_docs.py`
+- `python3 -I scripts/tests/test_check_module_docs.py -v`
+- `python3 -I -S scripts/check_module_source_ownership.py`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+- `python3 -I -S scripts/refactor_baselines.py`
+- `make -C src lint`
+- close-time changed-path and diff-stat scope checks
+- technical-writer review and exact final-diff roundtable approval
+- feature-branch pull-request CI

--- a/tests/baselines/modules/documentation-status.yaml
+++ b/tests/baselines/modules/documentation-status.yaml
@@ -20,14 +20,14 @@
     "tools",
     "git",
     "config",
-    "audit"
+    "audit",
+    "workflows",
+    "roundtable",
+    "benchmarks"
   ],
   "debt": [
-    "benchmarks",
     "control-web",
     "governance",
-    "roundtable",
-    "runtime-web",
-    "workflows"
+    "runtime-web"
   ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -210,6 +210,23 @@
       "blast_radius": "No runtime surface changes; the strict module-doc gate and close-time path check constrain the slice to two docs, status, validation, and ledger accounting.",
       "independent_review": "Technical-writing and exact-diff roundtable review are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-17.md", "docs/modules/config.md", "docs/modules/audit.md"]
+    },
+    {
+      "slice": 18,
+      "state": "present_and_verified",
+      "disposition": "Documented optional workflows, roundtable, and benchmarks with a shared ownership/liveness matrix; triggers remain workflow intake, workflow/roundtable integration preserves split ownership, and legacy eval names do not create an evals module or runtime benchmark authority.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["three control-plane module documents remain explicit status debt", "workflow and roundtable optionality is not fully enforced by current startup/build wiring", "the benchmarks target directory remains descriptor-only while live harnesses remain distributed under legacy names"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice adds documentation and baseline accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Treating descriptor optionality as implemented or renaming every legacy eval symbol in a docs slice would hide current liveness and compatibility constraints.",
+        "revisit": "Profile/source slices must add effective activation, move ownership, preserve aliases and data contracts, and prove disabled residue plus supported journeys."
+      },
+      "consumers": ["module maintainers", "technical writers", "future optional execution and benchmark source slices"],
+      "blast_radius": "No runtime surface changes; close-time path checks constrain the slice to three docs, one validation record, status, and ledger accounting.",
+      "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-18.md", "docs/modules/workflows.md", "docs/modules/roundtable.md", "docs/modules/benchmarks.md"]
     }
   ]
 }


### PR DESCRIPTION
## What changed

- document optional `workflows`, including triggers as workflow intake and its current activation/startup mismatch
- document optional `roundtable`, preserving its panel/chair ownership boundary with workflows and response composition
- document optional `benchmarks`, mapping the descriptor-only target to distributed legacy `agent_eval` and benchmark harnesses
- promote those three documents and record the shared overlap/liveness analysis

## Why

The modularization effort needs honest ownership contracts before source movement. These documents make declared optionality and current implementation liveness visible instead of treating descriptors as proof: workflows still registers startup components, roundtable lacks an effective module gate, and the benchmarks target path has not yet absorbed the live legacy harnesses.

## Impact

Documentation and baseline accounting only. No production source, descriptors, build/package files, schemas, GUI, generated artifacts, checkers, tests, or runtime behavior changed.

## Validation

- strict module-documentation checker and unit tests
- module source-ownership, cleanup-ledger, and refactor-baseline checks
- `make -C src lint`
- technical-writer approval
- exact staged-diff roundtable approval after two converged rounds
