### PR TITLE
Document control plane and web module contracts

### DIFF
--- a/docs/modules/control-web.md
+++ b/docs/modules/control-web.md
@@ -1,0 +1,103 @@
+# control-web module
+
+## Purpose and non-goals
+
+`control-web` is the optional browser interface for Aimee Control Plane. It owns the management GUI,
+its dashboard, static assets, browser session shell, web listener, and web-only proxy behavior. It does
+not own shared memory, the core audit ledger, governance policy, OIDC semantics, configuration authority,
+or a separate dashboard module.
+
+## Public contracts
+
+The target lifecycle key is `control.web.enabled`. The module exposes one authenticated Control Plane
+GUI whose dashboard is inseparable from that GUI: there is no dashboard descriptor, enable key,
+standalone listener, or independently active route set. Browser actions consume the same typed Control
+Plane APIs used by headless clients and cannot create a second configuration or authorization contract.
+
+## Dependencies and consumers
+
+- `config`: supplies the effective, activation-filtered configuration catalog and startup lifecycle value.
+- `gateway`: exposes authorized Control Plane APIs without making HTML a core fallback.
+- `module-runtime`: supplies selection, lifecycle, capability, and readiness state.
+- `protocols`: carries typed browser/API requests and responses.
+
+Consumers are Control Plane operators using the dashboard, accounts, governance, fleet, shared-memory,
+and provider-administration pages. Optional pages consume their owning module only when that module is
+selected and active.
+
+## Providers and readiness
+
+The current physical providers are `kb-console` for the Go HTTPS/session proxy and
+`frontend/src/console` for the React SPA. Readiness must distinguish module selection, startup enablement,
+asset availability, listener state, Control Plane API reachability, credential validity, and optional-page
+capabilities. A healthy `aimee-control` API does not imply that the GUI is running.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `true`; the descriptor is `enabled_by_default: true`, but the target web control is evaluated at startup and changing it does not reload or restart a running process.
+
+When `control.web.enabled` is false, the module must not load/register, bind, serve assets or routes, start
+jobs, or emit module metrics. CLI, environment variables, configuration files, and non-web APIs remain
+operable. The current `compose.yaml` instead puts `aimee-kb-console` behind the default-off `console`
+profile, and the executable requires explicit startup; this contradicts the target default and is
+implementation debt. Effective GUI configuration must advertise only active settings with a proven
+production read; disabled or absent module/provider settings are hidden.
+
+## Surfaces
+
+Current surfaces include the `kb-console` HTTPS listener and proxy, `console.html`, `ConsoleApp`,
+`ConsoleDashboard`, Accounts, and Governance pages. Dashboard routes are part of the same console shell.
+OIDC issuer-profile controls appear only when `governance` is selected and active. The GUI may manage
+workflows or other capabilities but cannot register their schedulers.
+
+## Data and migrations
+
+Current web-owned state is the `sessions.db` browser-session store, local TLS material, SPA assets, and
+break-glass presence state under `KB_CONSOLE_HOME`. Canonical Control Plane data, OIDC profiles, audit
+events, policies, and shared memory remain owned by their API modules. Migration must preserve session
+confidentiality while avoiding copies of canonical configuration or secrets in browser/web stores.
+
+## Security and privacy
+
+The console-admin credential is read through `KB_CONSOLE_CRED_FILE` and must remain mode `0600`; inline
+`KB_CONSOLE_CRED` is rejected. Non-loopback binding, TLS verification bypass, browser tokens, CSRF,
+sessions, CSP origins, proxy allowlists, and break-glass access are security boundaries. Client secrets
+belong in `vault`, never rendered configuration or browser state. Disabled and unknown web routes must be
+externally indistinguishable; internal audit may retain `capability_absent`.
+
+## Supported journeys
+
+An operator starts the default-enabled `control-web` GUI, authenticates, views its dashboard, and administers
+available Control Plane capabilities through typed APIs. If governance is active, the same GUI configures
+a provider-neutral issuer profile. An operator can instead disable the entire GUI at cold start and
+complete equivalent supported administration through headless surfaces.
+
+## Tests and failure behavior
+
+Current coverage includes `kb-console` auth, ACL, drift, session, TLS, proxy, rate-limit, and console
+tests; `test_kb_http_routes` covers dashboard and OIDC configuration APIs. Future profile tests must prove
+default-on and independent disable/omission, dashboard co-lifecycle, no disabled residue, headless
+operation, truthful fields, and Make/CMake absence. Missing assets, invalid credentials, unreachable
+Control APIs, or half-configured OIDC must fail closed without starting a misleading partial console.
+
+## Operational diagnostics
+
+Report `control-web` selection, startup-enabled state, listener/address, TLS mode, asset readiness,
+Control API probe, authentication mode, and active page capabilities. Never log bearer values, OIDC
+tokens, session identifiers, client secrets, or raw policy/config payloads. Diagnostics must distinguish
+absent, disabled, starting, ready, degraded, unavailable, and failed states.
+
+## Compatibility
+
+`aimee-kb`, `aimee-kb-console`, `KB_CONSOLE_*`, `/v1/console/*`, and existing console asset locations are
+legacy product/config/package surfaces requiring bounded compatibility records during the
+`aimee-control` rename. A web-route alias exists only while this module is selected and enabled. The
+dashboard remains inseparable throughout migration; compatibility cannot resurrect it in core.
+
+## Extension and removal
+
+New pages declare their owning capability and consume the generated effective catalog; they do not add
+parallel config schemas, auth, data stores, schedulers, or dashboards. `kb-console`,
+`frontend/src/console`, `Dockerfile.kb-console`, and compose/service wiring are `relocate` candidates.
+Legacy duplicate routes, settings, and assets require caller, production-read, profile, and journey
+evidence before consolidation or deletion.

--- a/docs/modules/governance.md
+++ b/docs/modules/governance.md
@@ -1,0 +1,118 @@
+# governance module
+
+## Purpose and non-goals
+
+`governance` is the optional organizational governance plane for Aimee Control Plane. It owns federated
+OIDC/SSO, organizational identities and roles, governance policy authoring/distribution, approvals and
+decision records, posture/evidence views, agent/delegation identity chains, fleet governance, and
+artifact-signing trust policy. It does not make core execution enforcement, audit integrity, vault
+custody, transport authentication, Git, SSH, or SSHSIG optional.
+
+## Public contracts
+
+Governance consumes verified core principals and produces tenant-bound policy/decision artifacts for
+core enforcement. OIDC uses named provider-neutral issuer profiles, not a provider enum: discovery or
+explicit endpoints, client identity, vault-backed secret reference, redirects, scopes, PKCE/nonce,
+accepted algorithms, and namespaced claim mappings. GitHub may be configured if it conforms, but
+`GitHub` is never the governance contract or default provider.
+
+## Dependencies and consumers
+
+- `audit`: records organizational decisions and supplies the canonical ledger for read-only projections.
+- `config`: supplies activation and provider-neutral governance declarations.
+- `delegates`: supplies verified delegate identity/invocation evidence without yielding execution authority.
+- `execution-policy`: reauthorizes distributed policy at the action boundary.
+- `gateway`: admits authorized governance/control requests.
+- `ir`: carries canonical policy, identity, decision, and attestation records.
+- `module-runtime`: supplies optional lifecycle, capability, and readiness state.
+- `protocols`: carries typed governance APIs and adapters.
+- `routing`: selects eligible governed providers without owning governance policy.
+- `tools`: exposes authorized governance operations through core dispatch.
+- `vault`: stores OIDC client secrets, signing material, and protected references.
+
+Consumers include Aimee Control Plane's headless and optional web management surfaces, fleet/runtime
+management, policy distribution, organizational audits, and core enforcement at verified integration
+points.
+
+## Providers and readiness
+
+Current code is distributed across `src/kb/auth_oidc.c`, KB identity/JWKS/enrollment/account routes and
+DB2 tables, management-token code, console Accounts/Governance pages, and
+`src/modules/governance/gw_stage_governance.c`. Readiness must separate module selection, issuer-profile
+validity/discovery, vault secret availability, JWKS freshness/rotation, claim mapping, tenant binding,
+policy distribution, audit appendability, and downstream enforcement. A stored issuer URL is not ready
+OIDC.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `false`; the descriptor is `enabled_by_default: false`, so governance is selected before startup and omitted/disabled surfaces are not advertised.
+
+The current `modules.governance` response-stage gate conflicts with the descriptor: legacy
+`AIMEE_STAGE_GOVERNANCE` falls back default-on and controls only response tool-policing, while OIDC has
+separate environment/file/DB2 routes. The target module selection must gate all organizational
+governance surfaces and leave core fail-closed enforcement intact. Issuer profiles are configurable from
+Control Plane UI and equivalent CLI, environment/config-file, and non-web API surfaces; secrets are vault
+references. With governance absent, OIDC and organizational settings are absent from advertised catalogs.
+
+## Surfaces
+
+Target surfaces include provider-neutral issuer-profile administration, organizational accounts/roles,
+policy and approval authoring, posture/attestation evidence, fleet governance, and signed-artifact trust
+through Control APIs/CLI and optional `control-web`. Current `/v1/config/oidc` accepts issuer, audience,
+`jwks_url`, `admin_claim`, and `admin_values`; it is a partial provider-neutral seed, not the full target
+profile contract. SSHSIG and Git surfaces remain core and merely provide verified evidence to governance.
+
+## Data and migrations
+
+Current stores include `kb_console_oidc`, `kb_oidc_jwks`, admin grants, memberships, enrollment and
+management-token records. Target data adds named issuer profiles, namespaced claim mappings,
+tenant/principal-bound decisions, distribution state, attestations, and signing-key metadata while secrets
+remain in vault. Migrations are append-only, preserve `(iss,sub)` identity and tenant bindings, and
+reauthorize legacy KB policy before distribution.
+
+## Security and privacy
+
+`OIDC` validation is fail-closed for issuer, audience, signature algorithm, nonce/PKCE, token age, JWKS
+rotation/revocation, and claim mapping. Management actions require tenant-qualified identity, capability,
+target/channel binding, replay protection, and audit intent/outcome. OIDC, mTLS, SSH, and SSHSIG are
+distinct evidence mechanisms. Governance may evaluate verified SSHSIG/artifact evidence but cannot replace
+core signature verification or create a repository-specific trust adapter.
+
+## Supported journeys
+
+An operator selects `governance`, configures any conforming OIDC issuer through the Control Plane or
+headless equivalent, stores client secret material in vault, maps claims to tenant roles, authenticates,
+and distributes an authorized policy/management decision whose core enforcement and audit remain intact.
+Without governance, Control continues core shared-memory/management operation with its local reference
+authenticator and exposes no organizational-governance or OIDC surface.
+
+## Tests and failure behavior
+
+Current suites such as `test_kb_auth_oidc` cover OIDC JWT/JWKS verification, issuer-scoped identity, console OIDC config, accounts,
+ACLs, management tokens/endpoints, grants, tenancy, and response-stage policing. Missing discovery/JWKS,
+invalid claims, stale or revoked keys, unavailable vault secrets, ambiguous tenant mapping, replay,
+authorization failure, or audit failure must deny the governed action. Future full-minus-one tests must
+prove governance objects, routes, settings, data initialization, jobs, and web pages are absent.
+
+## Operational diagnostics
+
+Report `governance` selection/readiness, issuer profile identifier (not tokens), discovery/JWKS freshness,
+key generation, claim-mapping outcome class, tenant/principal handle, policy version, distribution state,
+decision correlation, and audit result. Do not log tokens, claims beyond approved identifiers, client
+secrets, signing keys, raw policies, or private attestation payloads.
+
+## Compatibility
+
+`AIMEE_KB_OIDC_*`, `KB_CONSOLE_OIDC_FILE`, `/v1/config/oidc`, single-row
+`kb_console_oidc`, and legacy KB governance/product names require bounded migration records. Accepted
+legacy input may be migration-only and unadvertised. GitHub/GitLab OAuth settings used by core Git are not
+aliases for governance OIDC and must not be migrated into issuer profiles without explicit operator intent.
+
+## Extension and removal
+
+New identity providers implement the same standards-based issuer-profile contract; provider-specific
+branches, enums, or repository adapters are rejected. Distributed OIDC, identity, policy, management,
+console, and response-stage code are `relocate` or `split-owner` candidates. The response-policing stage
+must be reconciled with core `execution-policy`: any non-negotiable action enforcement remains core, while
+organizational policy authoring/decision semantics may move here. Removal requires caller, surface,
+configuration, store, migration, and supported-journey evidence.

--- a/docs/modules/runtime-web.md
+++ b/docs/modules/runtime-web.md
@@ -1,0 +1,102 @@
+# runtime-web module
+
+## Purpose and non-goals
+
+`runtime-web` is the optional browser interface for Aimee Runtime, the per-user interaction boundary. It
+owns chat/session presentation, its dashboard, static assets, browser authentication/session handling,
+the web listener, and web-only adapters. It does not own agents, memory, routing, Git, workflows,
+configuration authority, or a separate dashboard lifecycle.
+
+## Public contracts
+
+The target lifecycle key is `runtime.web.enabled`. The module exposes one Runtime GUI whose dashboard is
+inseparable from the GUI: no dashboard descriptor, enable key, standalone listener, or independently
+active route set is permitted. Browser requests translate to the same Runtime contracts used by CLI,
+MCP/ACP, and non-web APIs; UI convenience must not become a second execution authority.
+
+## Dependencies and consumers
+
+- `config`: supplies effective settings and the startup lifecycle value.
+- `gateway`: exposes authorized Runtime APIs without owning HTML or a fallback dashboard.
+- `module-runtime`: supplies selection, lifecycle, capability, and readiness state.
+- `protocols`: carries typed browser/API requests and responses.
+
+Consumers are individual Runtime users interacting with chat, projects, agents, memory, workflows,
+roundtables, Git, editor, settings, logs, and dashboard projections. Each optional page is conditional on
+the corresponding active capability.
+
+## Providers and readiness
+
+Current providers are the Go service under `webchat`, the React SPA under `frontend/src`, legacy
+`dashboard.c`/`dashboard_kb.c`, server dashboard routes, container entrypoint wiring, and systemd support.
+Readiness must separate module selection, startup enablement, asset availability, listener/auth/session
+health, Runtime transport reachability, and per-page capabilities. A running `aimee-runtime` does not
+imply a running GUI.
+
+## Configuration and activation
+
+- `runtime_toggle.supported`: `true`; the descriptor is `enabled_by_default: true`, while the target lifecycle control is startup-evaluated and restart-class, with no automatic restart or live reload.
+
+When `runtime.web.enabled` is false, no GUI process/listener, assets, web routes, background work, or
+module metrics may start. CLI, environment, config-file, MCP/ACP, and non-web API operation remain.
+Current containers use `AIMEE_WEBCHAT_ENABLED` and `WITH_WEBCHAT`, while ordinary `make all` builds
+`aimee-webchat`; those are legacy lifecycle/build seams awaiting descriptor-driven unification.
+Configuration pages expose only active settings with a real production consumer.
+
+## Surfaces
+
+Current surfaces include `aimee-webchat`, the SPA `App`, Chat, Dashboard, Projects, Agents, Settings,
+Graph, Logs, Workflows, Roundtable, Pipeline, and Editor pages, plus `/api/*` web adapters. The dashboard
+is a Runtime GUI route, not the legacy `aimee dashboard` standalone listener in the target contract.
+Provider-specific Git OAuth controls are Git-provider settings, not OIDC governance.
+
+## Data and migrations
+
+Web-owned data includes the browser/session database at the configured `webchat.db`, CSRF/session state,
+local TLS material, and SPA assets. Runtime DB1, workspaces, vault entries, workflow state, Git state, and
+memory remain owned by core/optional capability modules. Migration must preserve active-session privacy
+and avoid duplicating canonical application data in the web tier.
+
+## Security and privacy
+
+The web proxy's attested `ATTEST_WEBCHAT_TRUSTED` principal, PAM/login boundary, TLS, CSRF, session
+cookies, origin handling, and server token are security-sensitive. The GUI cannot elevate a browser
+identity, bypass core `execution-policy`, or read vault secrets for display. OAuth tokens used by Git
+remain Git/vault data; they do not make the Runtime web module an OIDC provider or governance owner.
+
+## Supported journeys
+
+A user starts default Aimee Runtime, signs into the default-enabled `runtime-web` GUI, chats with agents, inspects the
+dashboard, and uses only pages backed by ready capabilities. A headless user disables the GUI before
+startup and performs the same underlying Runtime work through CLI, MCP/ACP, environment/configuration,
+and non-web APIs without a web process.
+
+## Tests and failure behavior
+
+Current coverage spans `webchat` Go tests, frontend Dashboard/setup/tutorial tests, server HTTP/dashboard
+tests, trusted-web principal/vault tests, and container/build integrity. Future profile tests must prove
+default-on behavior, independent disable/omission, dashboard co-lifecycle, no disabled residue, headless
+journeys, truthful settings, and object/symbol absence. Authentication, transport, asset, or page-provider
+failure must be contained and typed; it cannot start a partial authority or crash unrelated Runtime APIs.
+
+## Operational diagnostics
+
+Report `runtime-web` selection, startup-enabled state, listener/TLS mode, asset version, authentication and
+Runtime-transport readiness, session counts, and page capability states. Exclude credentials, browser
+tokens, prompts, response bodies, repository content, and vault material. Distinguish absent, disabled,
+starting, ready, degraded, unavailable, and failed.
+
+## Compatibility
+
+`aimee-server`, `aimee-webchat`, `AIMEE_WEBCHAT_*`, `WITH_WEBCHAT`, legacy dashboard commands/routes, and
+current web package/asset names require bounded compatibility records during the `aimee-runtime` rename.
+Legacy web aliases are module-owned and unavailable when this module is disabled or omitted; core never
+serves a compatibility dashboard.
+
+## Extension and removal
+
+New pages are capability consumers and must disappear with their inactive owner; they cannot add a
+parallel scheduler, policy engine, data store, or config schema. `webchat`, `frontend/src`, legacy
+dashboard code, server web routes, and packaging/service wiring are `relocate` candidates. Duplicate
+routes, settings, auth helpers, and self-tested-only pages require supported-journey and production-read
+evidence before consolidation or removal.

--- a/docs/validation/core-modularization-slice-19.md
+++ b/docs/validation/core-modularization-slice-19.md
@@ -1,0 +1,140 @@
+# Core modularization slice 19: control-plane, governance, and web documentation
+
+## Diff scope precondition
+
+The slice-start commit is `22a5f63f8f2fd3adbaba4215859fa77a4a724985`. Allowed close paths are the
+three module documents, this validation record, the documentation-status partition, and the cleanup
+ledger. Production source, descriptors, build/package/service files, schemas, GUI, generated artifacts,
+checkers, and tests are excluded.
+
+## Outcome and method
+
+This slice promotes the final three documentation debts: `control-web`, `governance`, and `runtime-web`.
+Every canonical module now has an individual substantive document. Inspection covered descriptors,
+physical inventories, proposal contracts, frontend route shells, Go process entrypoints/configuration,
+container and compose lifecycle, dashboard implementations, OIDC/JWKS/identity routes and stores,
+management tokens, response governance, tests, and compatibility names.
+
+Aimee memory was queried first and returned only generic recent episode facts, so nearby source inspection
+supplied the evidence. Static references prove compilation and reachability, not deployed liveness.
+Descriptor claims and approved target contracts are reported separately from current behavior; this
+docs-only slice does not repair their contradictions.
+
+## Inventory and activation evidence
+
+### Control web
+
+`src/modules/control-web` contains only `module.yaml`: four dependencies, `enabled_by_default: true`, and
+runtime-toggle support. Current implementation is distributed across `kb-console`,
+`frontend/src/console`, `Dockerfile.kb-console`, `compose.yaml`, KB console routes, and tests. The Go
+executable describes itself as default-off, requires a console-admin credential, and the compose service
+is gated by the `console` profile. This contradicts the target default-on module profile. Current OIDC
+config is fetched from `/v1/config/oidc` once at startup when a local file did not configure it.
+
+The React `ConsoleApp` always includes Dashboard, Accounts, and Governance navigation. Dashboard is
+already a page of the GUI, not a separately configured UI component. Governance visibility is currently
+unconditional in the shell, so absent-module page/config filtering remains implementation debt.
+
+### Runtime web
+
+`src/modules/runtime-web` also contains only `module.yaml`, with the same four dependencies,
+`enabled_by_default: true`, and runtime-toggle support. Current implementation spans `webchat`, the main
+`frontend/src` SPA, `dashboard.c`, `dashboard_kb.c`, server dashboard/API routes, `Dockerfile.server`,
+compose entrypoints, systemd, and tests. Ordinary `make all` includes `aimee-webchat`; containers can omit
+it with `WITH_WEBCHAT=0` or suppress startup with `AIMEE_WEBCHAT_ENABLED=0`. These legacy controls are not
+yet generated from `runtime.web.enabled` or the descriptor.
+
+The SPA includes Dashboard in the same route shell as Chat and capability pages. Legacy `aimee
+dashboard` remains a standalone listener and therefore conflicts with the target inseparable-dashboard
+contract. GitHub/GitLab OAuth fields in Runtime compose/web code are Git-provider integration, not
+organizational OIDC governance.
+
+### Governance
+
+`src/modules/governance` contains the descriptor and one response-stage implementation. The descriptor
+declares eleven required dependencies, `enabled_by_default: false`, and no runtime toggle. The response
+stage uses caller-resolved `modules.governance`, but its deprecated `AIMEE_STAGE_GOVERNANCE` fallback is
+default-on and covers only response tool-use policing. Provider-neutral OIDC behavior is separately
+distributed across `src/kb/auth_oidc.c`, identity/JWKS code, DB2 enrollment/grant tables,
+`/v1/config/oidc`, `kb-console`, and management-token code. Descriptor-level selection does not yet omit
+those objects, stores, routes, or settings.
+
+The current OIDC configuration shape—issuer, audience, JWKS URL, admin claim, and admin values—is
+provider-neutral but partial. No provider enum was found. The target named issuer-profile contract adds
+discovery/explicit endpoints, vault secret references, redirects, scopes, PKCE/nonce, accepted
+algorithms, and namespaced claim mapping. Git/SSH/SSHSIG remain core; governance may consume their
+verified evidence but does not own verification or a repository adapter.
+
+## Dependency reconciliation
+
+| Module/dependency | Evidence classification | Boundary |
+|---|---|---|
+| control-web/runtime-web → config | declared; distributed current settings observed | generated effective catalog and startup controls are target gaps |
+| control-web/runtime-web → gateway/protocols | declared; proxy/API routes observed | typed API transport, never core HTML fallback |
+| control-web/runtime-web → module-runtime | descriptor-only at canonical lifecycle boundary | legacy build/env/compose controls remain |
+| governance → audit/config/vault/execution-policy | declared and distributed behavior observed | canonical ledger/config/custody/enforcement remain core |
+| governance → delegates/ir/routing/tools | declared; partial organizational consumers observed | governance consumes identities/records/providers/dispatch without replacing owners |
+| governance → gateway/protocols | declared; OIDC/control routes observed | typed control admission/transport |
+| governance → module-runtime | descriptor selection not enforced across distributed code | full-minus-one omission remains absent |
+
+No declared edge is classified stale from static evidence. The primary gaps are physical ownership,
+selection/lifecycle enforcement, and effective-surface generation.
+
+## Ownership and liveness matrix
+
+| Capability | Owner | Current provider/evidence | State / ambiguity |
+|---|---|---|---|
+| Control GUI and dashboard | control-web | `kb-console`, `frontend/src/console` | reachable/tested; descriptor-only owner; current default-off conflicts |
+| Runtime GUI and dashboard | runtime-web | `webchat`, `frontend/src`, legacy dashboard/server code | reachable/tested/default-on container; lifecycle fragmented |
+| GUI-effective settings | config + owning module metadata | static Settings/Accounts pages and config APIs | active-provider filtering not enforced |
+| Organizational OIDC | governance | KB auth/JWKS/config/routes and console | provider-neutral seed implemented; selection/complete profile absent |
+| Browser/session auth | owning web module | Go console/webchat auth and session stores | implemented/tested; not governance policy ownership |
+| Core action enforcement | execution-policy | response policing and action gates | required core; response-stage split needs reconciliation |
+| SSH/SSHSIG verification | Git/protocol/core trust owners | Git/signature paths and attestations | core evidence source; not OIDC or repository adapter |
+| Audit ledger | audit | legacy/WORM providers | core canonical source; governance/web only project views |
+
+## Target lifecycle and surface truth
+
+`control-web` and `runtime-web` are independently selectable, optional, and enabled by default in their
+product profiles. `control.web.enabled` and `runtime.web.enabled` are startup-evaluated restart-class
+settings: changing them never restarts or reloads a process automatically. Disabled modules do not load,
+register, listen, serve routes/assets, start jobs, emit metrics, or receive symbol calls. Omitted builds
+also lack their objects and symbols. Both products retain CLI, environment/config-file, and non-web API
+operation.
+
+Each dashboard is inseparable from its GUI. The target has no dashboard descriptor, document, setting,
+listener, or routes outside its GUI prefix. GUI settings are activation-filtered projections: a setting
+is advertised only when its owner is selected/active and a non-test production read proves effect.
+Governance absent means organizational and OIDC settings/pages are absent; control-web absent does not
+remove headless governance configuration.
+
+## Overlap and cleanup findings
+
+- Both target web directories are descriptor-only; existing application directories and broad legacy
+  dashboard/server roots are `relocate` or `split-owner` candidates, not dead code.
+- `AIMEE_WEBCHAT_ENABLED`, `WITH_WEBCHAT`, the compose `console` profile, and executable-local flags are
+  compatibility/unification debt for descriptor-driven lifecycle generation.
+- Standalone `aimee dashboard` and dashboard routes outside the owning GUI prefix conflict with the
+  inseparable-dashboard target and require supported-surface compatibility analysis.
+- Governance response policing overlaps core `execution-policy`; non-negotiable enforcement cannot move
+  to an optional module. Organizational policy authoring/decisions may move while core application stays.
+- Current OIDC code is provider-neutral but distributed and only partially models the target issuer
+  profile. GitHub OAuth remains Git integration and is not an OIDC default.
+- Unconditional GUI pages/static config fields can advertise inactive modules and need generated
+  capability/effective-config filtering.
+
+No `unreachable`, `superseded`, `configuration-only`, or `test-only` candidate meets the deletion
+threshold. Source movement requires production journeys, consumers, profile residue, data custody,
+tenant isolation, and compatibility evidence.
+
+## Verification
+
+- `python3 -I -S scripts/check_module_docs.py`
+- `python3 -I scripts/tests/test_check_module_docs.py -v`
+- `python3 -I -S scripts/check_module_source_ownership.py`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+- `python3 -I -S scripts/refactor_baselines.py`
+- `make -C src lint`
+- close-time changed-path and diff-stat scope checks
+- technical-writer review and exact final-diff roundtable approval
+- feature-branch pull-request CI

--- a/tests/baselines/modules/documentation-status.yaml
+++ b/tests/baselines/modules/documentation-status.yaml
@@ -23,11 +23,10 @@
     "audit",
     "workflows",
     "roundtable",
-    "benchmarks"
-  ],
-  "debt": [
+    "benchmarks",
     "control-web",
     "governance",
     "runtime-web"
-  ]
+  ],
+  "debt": []
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -227,6 +227,23 @@
       "blast_radius": "No runtime surface changes; close-time path checks constrain the slice to three docs, one validation record, status, and ledger accounting.",
       "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-18.md", "docs/modules/workflows.md", "docs/modules/roundtable.md", "docs/modules/benchmarks.md"]
+    },
+    {
+      "slice": 19,
+      "state": "present_and_verified",
+      "disposition": "Completed the individual module documentation catalog with the Control Plane, Runtime web, and optional governance contracts; separated target default-on GUI lifecycle from current wiring, made dashboards inseparable, and preserved provider-neutral OIDC plus core SSH/SSHSIG and enforcement boundaries.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["control-web and runtime-web remain descriptor-only while implementations are distributed", "current Control console default-off startup contradicts the target default-on profile", "governance selection does not yet omit distributed OIDC and response-policy code", "effective GUI configuration filtering is not implemented"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice adds documentation and baseline accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Describing target lifecycle as current behavior or treating Git-provider OAuth as organizational OIDC would hide the highest-risk implementation gaps.",
+        "revisit": "Profile/source slices must unify generated lifecycle controls, move owned source, preserve bounded aliases and data custody, and prove headless plus full-minus-one journeys."
+      },
+      "consumers": ["module maintainers", "technical writers", "future product rename, governance, web, and effective-config source slices"],
+      "blast_radius": "No runtime surface changes; close-time path checks constrain the slice to three docs, one validation record, status, and ledger accounting, while the validation matrix records tenant, custody, identity, and disabled-profile boundaries.",
+      "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-19.md", "docs/modules/control-web.md", "docs/modules/governance.md", "docs/modules/runtime-web.md"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- document `control-web` and `runtime-web` as independent optional, default-enabled GUI modules with inseparable dashboards
- document optional, default-off `governance` with provider-neutral OIDC and retained core Git/SSH/SSHSIG/enforcement authority
- close the individual module documentation debt while recording current lifecycle, ownership, and effective-config gaps

## Current-state findings

- both web module directories are descriptor-only while implementations remain distributed
- the Control console currently starts default-off, contrary to the target default-on profile
- legacy Runtime web build/start controls are not descriptor-generated
- governance selection does not yet omit distributed OIDC or response-policy code
- GUI active/effective configuration filtering remains unimplemented

## Validation

- `python3 -I -S scripts/check_module_docs.py`
- `python3 -I scripts/tests/test_check_module_docs.py -v`
- `python3 -I -S scripts/check_module_source_ownership.py`
- `python3 -I -S scripts/check_cleanup_ledger.py`
- `python3 -I -S scripts/refactor_baselines.py`
- `make -C src lint`
- technical-writer approval
- exact staged-diff roundtable approval after three rounds
