### PR TITLE
fix(delegates): fail over on agent auth exhaustion

### DIFF
--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -291,6 +291,9 @@ typedef struct
    char default_agent[MAX_AGENT_NAME];
    char fallback_chain[MAX_FALLBACK][MAX_AGENT_NAME];
    int fallback_count;
+   /* Transient per-request routing contract: an explicit agent/provider pin
+    * must surface that agent's result and may never substitute a peer. */
+   int route_pinned;
    agent_network_t network;
    agent_tunnel_mgr_t tunnel_mgr;
    agent_ablation_flags_t ablation;

--- a/src/modules/delegates/delegate_routing.c
+++ b/src/modules/delegates/delegate_routing.c
@@ -388,6 +388,7 @@ int delegate_apply_route_overrides(agent_config_t *cfg, const char *role, const 
 
    if (selected)
    {
+      cfg->route_pinned = 1;
       for (int i = 0; i < cfg->agent_count; i++)
       {
          if (&cfg->agents[i] != selected)

--- a/src/modules/delegates/delegate_routing.c
+++ b/src/modules/delegates/delegate_routing.c
@@ -274,6 +274,9 @@ int delegate_apply_route_overrides(agent_config_t *cfg, const char *role, const 
 {
    if (!cfg)
       return 0;
+   /* Callers load a request-local config today, but reset explicitly so a
+    * reused config can never leak a previous request's positive pin. */
+   cfg->route_pinned = 0;
    if (errbuf && errbuf_sz > 0)
       errbuf[0] = '\0';
 
@@ -397,6 +400,8 @@ int delegate_apply_route_overrides(agent_config_t *cfg, const char *role, const 
    }
    else if (selected_tier >= 0)
    {
+      /* A tier is a pool, not a pin: every enabled role-eligible peer in the
+       * selected tier remains a valid substitute. */
       for (int i = 0; i < cfg->agent_count; i++)
       {
          if (cfg->agents[i].cost_tier != selected_tier)

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -29,7 +29,8 @@ int agent_error_is_retryable(const char *error)
            * a retry / fallback usually gets a real completion. Treating it as
            * retryable stops one blank response from degrading a provider or
            * failing a pinned roundtable seat. */
-          strstr(error, "no content in response") != NULL;
+          strstr(error, "no content in response") != NULL ||
+          strstr(error, "no content in final response") != NULL;
 }
 
 /* Should a fallback/retry caller try a DIFFERENT agent for this result? Yes for a

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -43,7 +43,17 @@ int agent_rc_should_try_another(int rc, const char *error)
 {
    if (rc == 0)
       return 0;
-   return rc == AGENT_RC_AT_LIMIT || agent_error_is_retryable(error);
+   if (rc == AGENT_RC_AT_LIMIT || agent_error_is_retryable(error))
+      return 1;
+
+   /* Authentication and subscription failures are hard failures for the
+    * attempted agent, but not for an unpinned delegation. Try another enabled,
+    * role-eligible peer now; provider health still records the failed agent as
+    * a hard error, so it is not selected repeatedly during the same outage. */
+   return error && (strstr(error, "HTTP 401") != NULL || strstr(error, "HTTP 403") != NULL ||
+                    strstr(error, "authentication failed") != NULL ||
+                    strstr(error, "usage limit") != NULL ||
+                    strstr(error, "billing cycle") != NULL || strstr(error, "quota") != NULL);
 }
 
 static int agent_supports_delegate_role(const agent_t *ag, const char *role)

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -33,6 +33,25 @@ int agent_error_is_retryable(const char *error)
           strstr(error, "no content in final response") != NULL;
 }
 
+/* Hard provider failures that should retire the attempted agent for health
+ * purposes but allow an unpinned route to continue with another eligible peer.
+ * Match explicit credential/subscription diagnostics, not bare 401/403 status:
+ * those statuses can also come from proxies, WAFs, or route authorization. */
+static int agent_error_allows_peer_substitution(const char *error)
+{
+   if (!error || !error[0])
+      return 0;
+   return strstr(error, "authentication failed") != NULL ||
+          strstr(error, "invalid_api_key") != NULL || strstr(error, "invalid API key") != NULL ||
+          strstr(error, "incorrect API key") != NULL ||
+          strstr(error, "reached your usage limit") != NULL ||
+          strstr(error, "usage limit for this billing cycle") != NULL ||
+          strstr(error, "insufficient_quota") != NULL || strstr(error, "quota exhausted") != NULL ||
+          strstr(error, "exceeded your current quota") != NULL ||
+          strstr(error, "subscription has lapsed") != NULL ||
+          strstr(error, "payment required") != NULL;
+}
+
 /* Should a fallback/retry caller try a DIFFERENT agent for this result? Yes for a
  * saturation refusal (AGENT_RC_AT_LIMIT — the agent is momentarily at its
  * max_parallel ceiling, so a peer may be free) OR a retryable provider error. A
@@ -47,14 +66,11 @@ int agent_rc_should_try_another(int rc, const char *error)
    if (rc == AGENT_RC_AT_LIMIT || agent_error_is_retryable(error))
       return 1;
 
-   /* Authentication and subscription failures are hard failures for the
-    * attempted agent, but not for an unpinned delegation. Try another enabled,
-    * role-eligible peer now; provider health still records the failed agent as
-    * a hard error, so it is not selected repeatedly during the same outage. */
-   return error &&
-          (strstr(error, "HTTP 401") != NULL || strstr(error, "HTTP 403") != NULL ||
-           strstr(error, "authentication failed") != NULL || strstr(error, "usage limit") != NULL ||
-           strstr(error, "billing cycle") != NULL || strstr(error, "quota") != NULL);
+   /* This helper is consulted only by generic routing. Explicit --via pinning
+    * disables every other agent before dispatch, so it has no substitutable
+    * peer. agent_dispatch_one records this class as a hard health error because
+    * agent_error_is_retryable deliberately remains false for it. */
+   return agent_error_allows_peer_substitution(error);
 }
 
 static int agent_supports_delegate_role(const agent_t *ag, const char *role)

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -97,7 +97,7 @@ int agent_try_same_tier_fallback(agent_config_t *cfg, agent_t **current, const c
    agent_t *ag = current ? *current : NULL;
    /* Proceed for a retryable failure OR a saturation refusal (AGENT_RC_AT_LIMIT):
     * a same-tier peer may be free even if the primary was momentarily at its cap. */
-   if (!cfg || !ag || !out || !agent_rc_should_try_another(rc, out->error))
+   if (!cfg || cfg->route_pinned || !ag || !out || !agent_rc_should_try_another(rc, out->error))
       return rc;
 
    /* Cost-tier fallback: a tier is a pool. Even when fallback_chain is stale

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -63,7 +63,13 @@ int agent_rc_should_try_another(int rc, const char *error)
 {
    if (rc == 0)
       return 0;
-   if (rc == AGENT_RC_AT_LIMIT || agent_error_is_retryable(error))
+   if (rc == AGENT_RC_AT_LIMIT)
+      return 1;
+   /* agent_dispatch_one currently has exactly one provider-failure rc. Do not
+    * silently reinterpret a future control/result code as peer-substitutable. */
+   if (rc != -1)
+      return 0;
+   if (agent_error_is_retryable(error))
       return 1;
 
    /* This helper is consulted only by generic routing. Explicit --via pinning

--- a/src/server/agent_fallback.c
+++ b/src/server/agent_fallback.c
@@ -51,10 +51,10 @@ int agent_rc_should_try_another(int rc, const char *error)
     * attempted agent, but not for an unpinned delegation. Try another enabled,
     * role-eligible peer now; provider health still records the failed agent as
     * a hard error, so it is not selected repeatedly during the same outage. */
-   return error && (strstr(error, "HTTP 401") != NULL || strstr(error, "HTTP 403") != NULL ||
-                    strstr(error, "authentication failed") != NULL ||
-                    strstr(error, "usage limit") != NULL ||
-                    strstr(error, "billing cycle") != NULL || strstr(error, "quota") != NULL);
+   return error &&
+          (strstr(error, "HTTP 401") != NULL || strstr(error, "HTTP 403") != NULL ||
+           strstr(error, "authentication failed") != NULL || strstr(error, "usage limit") != NULL ||
+           strstr(error, "billing cycle") != NULL || strstr(error, "quota") != NULL);
 }
 
 static int agent_supports_delegate_role(const agent_t *ag, const char *role)

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -386,6 +386,8 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
             db1_agent_cache_put(role, user_prompt, out->response);
          return 0;
       }
+      if (cfg->route_pinned)
+         break;
       /* At-limit or a real failure: either way skip this agent and try the next
        * (health already recorded by agent_dispatch_one for a real failure). */
       if (ntried < MAX_AGENTS)
@@ -607,7 +609,7 @@ static int agent_run_with_tools_internal(agent_config_t *cfg, const char *role,
                                0.3, 1 /* use_tools */, out);
    free(enhanced);
 
-   if (agent_rc_should_try_another(rc, out->error) && cfg->fallback_count > 0)
+   if (!cfg->route_pinned && agent_rc_should_try_another(rc, out->error) && cfg->fallback_count > 0)
    {
       aimee_log(LOG_INFO, "agent",
                 "delegate agent '%s' retryable/at-limit, trying fallback chain (%d entries)",

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -222,6 +222,12 @@ int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char
 {
    if (!ag || !out)
       return -1;
+   /* The durable row must describe the agent actually attempted, including a
+    * fallback peer. The CLI creates the row before routing, so its configured
+    * default is only a placeholder until dispatch reaches this choke point. */
+   int durable_job_id = agent_get_durable_job_id();
+   if (durable_job_id > 0)
+      db1_agent_job_set_agent(durable_job_id, ag->name);
    /* Own `out` from the first instruction, exactly like the executors: memset it so
     * EVERY early-return path (at-limit, bad-precondition) leaves a clean result —
     * out->response == NULL — and a caller that frees out->response after a non-zero

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -387,7 +387,11 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
          return 0;
       }
       if (cfg->route_pinned)
+      {
+         free(out->response);
+         out->response = NULL;
          break;
+      }
       /* At-limit or a real failure: either way skip this agent and try the next
        * (health already recorded by agent_dispatch_one for a real failure). */
       if (ntried < MAX_AGENTS)
@@ -641,8 +645,9 @@ static int agent_run_with_tools_internal(agent_config_t *cfg, const char *role,
       }
    }
 
-   rc = agent_try_same_tier_fallback(cfg, &ag, role, system_prompt, user_prompt, max_tokens,
-                                     enforce_writes, out, rc);
+   if (!cfg->route_pinned)
+      rc = agent_try_same_tier_fallback(cfg, &ag, role, system_prompt, user_prompt, max_tokens,
+                                        enforce_writes, out, rc);
 
    /* health is recorded per-turn inside agent_dispatch_one (main + fallbacks +
     * same-tier), so no final record_success here. */

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -222,12 +222,6 @@ int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char
 {
    if (!ag || !out)
       return -1;
-   /* The durable row must describe the agent actually attempted, including a
-    * fallback peer. The CLI creates the row before routing, so its configured
-    * default is only a placeholder until dispatch reaches this choke point. */
-   int durable_job_id = agent_get_durable_job_id();
-   if (durable_job_id > 0)
-      db1_agent_job_set_agent(durable_job_id, ag->name);
    /* Own `out` from the first instruction, exactly like the executors: memset it so
     * EVERY early-return path (at-limit, bad-precondition) leaves a clean result —
     * out->response == NULL — and a caller that frees out->response after a non-zero
@@ -277,6 +271,12 @@ int agent_dispatch_one(const agent_t *ag, const agent_network_t *net, const char
                ag->max_parallel, aimee_err_slug(AIMEE_ERR_CONCURRENCY_LIMIT));
       return AGENT_RC_AT_LIMIT;
    }
+   /* The durable id is thread-local (agent_tasks.c), so overlapping workers
+    * cannot cross-attribute jobs. Persist only after admission: this agent is
+    * now actually being attempted, rather than merely considered or saturated. */
+   int durable_job_id = agent_get_durable_job_id();
+   if (durable_job_id > 0)
+      db1_agent_job_set_agent(durable_job_id, ag->name);
    int rc = use_tools ? agent_execute_with_tools_for_role(ag, net, role, system_prompt, user_prompt,
                                                           max_tokens, temperature, out)
                       : agent_execute(ag, system_prompt, user_prompt, max_tokens, temperature, out);

--- a/src/tests/test_agent_error_retryable.c
+++ b/src/tests/test_agent_error_retryable.c
@@ -34,10 +34,18 @@ int main(void)
 
    /* A hard credential/subscription failure must remain a hard health signal
     * for that agent while still allowing an unpinned delegation to try a peer. */
-   assert(agent_rc_should_try_another(-1, "HTTP 401 unauthorized") == 1);
+   assert(agent_rc_should_try_another(-1, "HTTP 401 invalid_api_key") == 1);
    assert(agent_rc_should_try_another(-1, "HTTP 403 authentication failed") == 1);
-   assert(agent_rc_should_try_another(-1, "usage limit for this billing cycle") == 1);
+   assert(agent_rc_should_try_another(-1, "reached your usage limit for this billing cycle") == 1);
    assert(agent_rc_should_try_another(-1, "provider quota exhausted") == 1);
+   assert(agent_rc_should_try_another(-1, NULL) == 0);
+   assert(agent_rc_should_try_another(AGENT_RC_AT_LIMIT, NULL) == 1);
+   /* Bare infrastructure auth statuses and benign prose must not fan out across
+    * the provider fleet. */
+   assert(agent_rc_should_try_another(-1, "HTTP 401 unauthorized") == 0);
+   assert(agent_rc_should_try_another(-1, "HTTP 403 from ingress policy") == 0);
+   assert(agent_rc_should_try_another(-1, "no usage limit configured") == 0);
+   assert(agent_rc_should_try_another(-1, "job quota exceeded") == 0);
    assert(agent_rc_should_try_another(-1, "HTTP 400 invalid request") == 0);
 
    /* Saturation is NOT a retryable provider error. agent_dispatch_one signals it

--- a/src/tests/test_agent_error_retryable.c
+++ b/src/tests/test_agent_error_retryable.c
@@ -16,6 +16,7 @@ int main(void)
    /* Empty completion on an otherwise-successful HTTP 200 -> retryable. */
    assert(agent_error_is_retryable("no content in response") == 1);
    assert(agent_error_is_retryable("no content in response stream") == 1);
+   assert(agent_error_is_retryable("no content in final response") == 1);
 
    /* Existing transient classes stay retryable. */
    assert(agent_error_is_retryable("HTTP 429 rate limit") == 1);

--- a/src/tests/test_agent_error_retryable.c
+++ b/src/tests/test_agent_error_retryable.c
@@ -48,6 +48,27 @@ int main(void)
    assert(agent_rc_should_try_another(-1, "job quota exceeded") == 0);
    assert(agent_rc_should_try_another(-1, "HTTP 400 invalid request") == 0);
 
+   /* Every peer-substitutable credential/subscription diagnostic remains a
+    * hard provider-health signal. The two classifiers must stay disjoint. */
+   static const char *const hard_peer_failures[] = {
+       "HTTP 403 authentication failed",
+       "invalid_api_key",
+       "invalid API key",
+       "incorrect API key",
+       "reached your usage limit",
+       "usage limit for this billing cycle",
+       "insufficient_quota",
+       "quota exhausted",
+       "exceeded your current quota",
+       "subscription has lapsed",
+       "payment required",
+   };
+   for (size_t i = 0; i < sizeof(hard_peer_failures) / sizeof(hard_peer_failures[0]); i++)
+   {
+      assert(agent_error_is_retryable(hard_peer_failures[i]) == 0);
+      assert(agent_rc_should_try_another(-1, hard_peer_failures[i]) == 1);
+   }
+
    /* Saturation is NOT a retryable provider error. agent_dispatch_one signals it
     * out-of-band via AGENT_RC_AT_LIMIT and callers key off that rc (never this
     * string), so the "at concurrency limit" message must stay non-retryable — else

--- a/src/tests/test_agent_error_retryable.c
+++ b/src/tests/test_agent_error_retryable.c
@@ -31,6 +31,14 @@ int main(void)
    assert(agent_error_is_retryable("HTTP 401 unauthorized") == 0);
    assert(agent_error_is_retryable("model refused the request") == 0);
 
+   /* A hard credential/subscription failure must remain a hard health signal
+    * for that agent while still allowing an unpinned delegation to try a peer. */
+   assert(agent_rc_should_try_another(-1, "HTTP 401 unauthorized") == 1);
+   assert(agent_rc_should_try_another(-1, "HTTP 403 authentication failed") == 1);
+   assert(agent_rc_should_try_another(-1, "usage limit for this billing cycle") == 1);
+   assert(agent_rc_should_try_another(-1, "provider quota exhausted") == 1);
+   assert(agent_rc_should_try_another(-1, "HTTP 400 invalid request") == 0);
+
    /* Saturation is NOT a retryable provider error. agent_dispatch_one signals it
     * out-of-band via AGENT_RC_AT_LIMIT and callers key off that rc (never this
     * string), so the "at concurrency limit" message must stay non-retryable — else

--- a/src/tests/test_agent_error_retryable.c
+++ b/src/tests/test_agent_error_retryable.c
@@ -40,6 +40,7 @@ int main(void)
    assert(agent_rc_should_try_another(-1, "provider quota exhausted") == 1);
    assert(agent_rc_should_try_another(-1, NULL) == 0);
    assert(agent_rc_should_try_another(AGENT_RC_AT_LIMIT, NULL) == 1);
+   assert(agent_rc_should_try_another(-3, "quota exhausted") == 0);
    /* Bare infrastructure auth statuses and benign prose must not fan out across
     * the provider fleet. */
    assert(agent_rc_should_try_another(-1, "HTTP 401 unauthorized") == 0);

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -864,6 +864,11 @@ static void test_via_override_rejects_role_mismatch(void)
    assert(cfg.agents[0].enabled == 1);
    assert(cfg.agents[1].enabled == 0);
    assert(cfg.route_pinned == 1);
+
+   /* A later unpinned request cannot inherit the positive pin bit. */
+   assert(delegate_apply_route_overrides(&cfg, "code", NULL, -1, NULL, NULL, errbuf,
+                                         sizeof(errbuf)) == 0);
+   assert(cfg.route_pinned == 0);
    printf("  PASS: test_via_override_rejects_role_mismatch\n");
 }
 

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -863,6 +863,7 @@ static void test_via_override_rejects_role_mismatch(void)
    assert(errbuf[0] == '\0');
    assert(cfg.agents[0].enabled == 1);
    assert(cfg.agents[1].enabled == 0);
+   assert(cfg.route_pinned == 1);
    printf("  PASS: test_via_override_rejects_role_mismatch\n");
 }
 


### PR DESCRIPTION
Fixes live WFE implementation churn when an eligible agent has exhausted a recurring subscription.

Authentication, quota, and billing-cycle failures remain hard health failures for the attempted agent, but an unpinned delegation now continues to another enabled role-eligible peer instead of failing the whole WFE turn. Specifically pinned execution remains non-substitutable because it does not use this peer-fallback path.

The durable job row is also updated at the single dispatch choke point so GUI/status attribution follows the agent actually attempted, including fallback peers, rather than retaining the pre-routing default-agent placeholder.

Live reproduction: jobs persisted as mimo-v2.5-pro repeatedly failed with Kimi HTTP 403 usage-limit errors every ~13 seconds.

Verification: agent fallback classification test, server-compute suite, direct agent_runtime compile, diff check.