### PR TITLE
Enforce governance capability ownership

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -127,6 +127,12 @@ jobs:
             --check-schema src/modules
       - name: Test descriptor failure modes and taxonomy convergence
         run: python3 -I scripts/tests/test_validate_module_descriptors.py -v
+      - name: Enforce governance capability ownership
+        run: python3 -I -S scripts/check_capability_ownership.py --config-root "$GITHUB_WORKSPACE"
+      - name: Validate governance ownership from a non-repository working directory
+        run: cd /tmp && python3 -I -S "$GITHUB_WORKSPACE/scripts/check_capability_ownership.py" --config-root "$GITHUB_WORKSPACE"
+      - name: Test governance capability ownership failure modes
+        run: python3 -I scripts/tests/test_check_capability_ownership.py -v
 
   module-doc-contract:
     name: module-doc-contract

--- a/docs/validation/core-modularization-slice-20.md
+++ b/docs/validation/core-modularization-slice-20.md
@@ -1,0 +1,48 @@
+# Core modularization slice 20: governance capability ownership
+
+## Scope
+
+The slice starts from `46eeb6dc475bb3ade8a029207679bf461b03eedc` and implements only binding
+check 6's governance ownership artifact, deterministic checker, focused mutation tests, CI invocation,
+baseline instructions, validation record, and cleanup accounting. It changes no production source,
+descriptor, build graph, package, profile, runtime toggle, route, configuration, schema, or GUI behavior.
+
+## Contract
+
+`tests/baselines/modules/governance-ownership.yaml` is strict JSON-compatible YAML and has exact semantic
+equality with the fenced block parsed directly from the approved proposal. It assigns thirteen organizational capabilities to optional
+`governance`, pins six forbidden core shadows, eleven required dependencies, and the forbidden
+core-to-governance edge. Canonical module classification and live dependency edges remain sourced from
+`canonical-inventory.yaml` and `src/modules/*/module.yaml`; they are not duplicated as new authority.
+
+`scripts/check_capability_ownership.py` treats the proposal block as authority and rejects unknown keys, aliases, duplicate keys/entries, missing or
+extra capabilities, unknown owners, core shadows, normative-list drift, missing governance dependency
+edges, and required-core dependencies on governance. It rejects non-JSON constants, YAML anchors/aliases,
+ambient root redirection, and descriptor path escapes. It resolves the repository independently of the
+current working directory, emits stable diagnostics, and uses only the Python standard library.
+
+## Dependency and security boundary
+
+This gate makes `governance` the sole optional owner of OIDC/SSO federation, organizational roles/policy,
+governance approvals/records/posture/attestation, governance identity/fleet records, and artifact
+signing/trust. It forbids governance from shadowing core `execution-policy`, audit ledger, vault custody,
+gateway authentication, or protocol authentication. Every required descriptor remains forbidden from
+depending on governance.
+
+The artifact does not establish broad source/header/test/docs/build/config/route/data ownership and does
+not claim that distributed OIDC or response-policy code has moved. Those remain later descriptor,
+profile, and source slices.
+
+## Completed local verification
+
+- `python3 -I -S scripts/check_capability_ownership.py`
+- `cd /tmp && python3 -I -S "$WORKTREE/scripts/check_capability_ownership.py"`
+- `python3 -I scripts/tests/test_check_capability_ownership.py -v`
+- `python3 -I -S scripts/validate_module_descriptors.py --check-schema src/modules`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+- `make -C src lint`
+
+## Close-time gates
+
+- technical-writer review and exact final-diff roundtable approval
+- feature-branch pull-request CI

--- a/scripts/check_capability_ownership.py
+++ b/scripts/check_capability_ownership.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Enforce the proposal-authored governance capability-ownership boundary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+from typing import NoReturn
+
+
+REPO = Path(__file__).resolve().parent.parent
+POLICY = Path("tests/baselines/modules/governance-ownership.yaml")
+INVENTORY = Path("tests/baselines/modules/canonical-inventory.yaml")
+DESCRIPTORS = Path("src/modules")
+PROPOSAL = Path("docs/proposals/pending/module-runtime-source-ownership-and-build.md")
+PROPOSAL_MARKER = "The following is the normative semantic content of that future artifact"
+MODULE_ID = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+CONTRACT_KEY = re.compile(r"^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$")
+MAX_BYTES = 1_048_576
+POLICY_KEYS = {
+    "schema_version",
+    "module",
+    "capabilities",
+    "forbidden_core_shadows",
+    "required_dependencies",
+    "forbidden_dependencies_from_core",
+}
+
+
+class OwnershipError(ValueError):
+    """A deterministic, operator-readable ownership failure."""
+
+
+def fail(rule: str, detail: str, path: Path | None = None) -> NoReturn:
+    prefix = f"{path}: " if path else ""
+    raise OwnershipError(f"{prefix}rule={rule}: {detail}")
+
+
+def root_path(root: Path, relative: Path) -> Path:
+    resolved_root = root.resolve()
+    if not (resolved_root / ".git").exists():
+        fail("config-root", f"not a repository root: {resolved_root}")
+    candidate = (resolved_root / relative).resolve()
+    try:
+        candidate.relative_to(resolved_root)
+    except ValueError:
+        fail("path-escape", f"{relative} escapes {resolved_root}")
+    return candidate
+
+
+def read_bytes(path: Path) -> bytes:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        fail("input", f"cannot read: {exc}", path)
+    if len(raw) > MAX_BYTES:
+        fail("input-size", f"exceeds {MAX_BYTES} bytes", path)
+    return raw
+
+
+def decode(path: Path) -> str:
+    try:
+        return read_bytes(path).decode("utf-8", "strict")
+    except UnicodeDecodeError as exc:
+        fail("encoding", f"not strict UTF-8: {exc}", path)
+
+
+def load_json(path: Path) -> object:
+    def no_duplicates(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                fail("duplicate-key", f"duplicate object key {key!r}", path)
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> NoReturn:
+        fail("parse", f"non-JSON constant {value!r}", path)
+
+    try:
+        return json.loads(
+            decode(path), object_pairs_hook=no_duplicates, parse_constant=reject_constant
+        )
+    except json.JSONDecodeError as exc:
+        fail("parse", f"strict JSON-compatible YAML required at {exc.lineno}:{exc.colno}", path)
+
+
+def string_list(value: object, name: str, path: Path) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        fail("structure", f"{name} must be an array of strings", path)
+    if len(value) != len(set(value)):
+        fail("duplicate-entry", f"{name} contains a duplicate", path)
+    return value
+
+
+def parse_proposal_contract(path: Path) -> dict[str, object]:
+    text = decode(path)
+    marker = text.find(PROPOSAL_MARKER)
+    if marker < 0:
+        fail("proposal-block", "normative marker is missing", path)
+    start = text.find("```yaml\n", marker)
+    if start < 0:
+        fail("proposal-block", "normative YAML fence is missing", path)
+    start += len("```yaml\n")
+    end = text.find("\n```", start)
+    if end < 0:
+        fail("proposal-block", "normative YAML fence is unterminated", path)
+    block = text[start:end]
+
+    result: dict[str, object] = {}
+    section = ""
+    for line_no, line in enumerate(block.splitlines(), 1):
+        if not line.strip():
+            continue
+        if line.startswith("  - "):
+            if section not in {
+                "forbidden_core_shadows",
+                "required_dependencies",
+                "forbidden_dependencies_from_core",
+            }:
+                fail("proposal-parse", f"unexpected list item at block line {line_no}", path)
+            item = line[4:]
+            if not CONTRACT_KEY.fullmatch(item):
+                fail("proposal-parse", f"invalid list item {item!r} at block line {line_no}", path)
+            assert isinstance(result[section], list)
+            result[section].append(item)
+            continue
+        if line.startswith("  "):
+            if section != "capabilities" or not line.startswith("  "):
+                fail("proposal-parse", f"unexpected indentation at block line {line_no}", path)
+            match = re.fullmatch(r"  ([a-z][a-z0-9]*(?:[.-][a-z0-9]+)*): ([a-z][a-z0-9-]*)", line)
+            if not match:
+                fail("proposal-parse", f"invalid capability at block line {line_no}", path)
+            key, owner = match.groups()
+            assert isinstance(result[section], dict)
+            if key in result[section]:
+                fail("proposal-parse", f"duplicate capability {key!r}", path)
+            result[section][key] = owner
+            continue
+        scalar = re.fullmatch(r"([a-z_]+): (.+)", line)
+        empty = re.fullmatch(r"([a-z_]+):", line)
+        if empty:
+            section = empty.group(1)
+            if section in result:
+                fail("proposal-parse", f"duplicate section {section!r}", path)
+            result[section] = {} if section == "capabilities" else []
+            continue
+        if not scalar:
+            fail("proposal-parse", f"invalid top-level line {line_no}", path)
+        key, raw = scalar.groups()
+        if key in result:
+            fail("proposal-parse", f"duplicate key {key!r}", path)
+        if key == "schema_version" and raw == "1":
+            result[key] = 1
+        elif key == "module" and MODULE_ID.fullmatch(raw):
+            result[key] = raw
+        else:
+            fail("proposal-parse", f"invalid scalar {key!r} at block line {line_no}", path)
+        section = ""
+    if set(result) != POLICY_KEYS:
+        fail("proposal-structure", f"keys mismatch: {sorted(result)}", path)
+    return result
+
+
+def inventory(root: Path) -> tuple[set[str], set[str]]:
+    path = root_path(root, INVENTORY)
+    value = load_json(path)
+    if not isinstance(value, dict) or set(value) != {"schema_version", "required", "optional"}:
+        fail("inventory-structure", "canonical inventory has an invalid envelope", path)
+    if type(value["schema_version"]) is not int or value["schema_version"] != 1:
+        fail("inventory-version", "canonical inventory version must be 1", path)
+    required = string_list(value["required"], "required", path)
+    optional = string_list(value["optional"], "optional", path)
+    for identifier in required + optional:
+        if not MODULE_ID.fullmatch(identifier):
+            fail("module-id", f"invalid canonical module ID {identifier!r}", path)
+    if set(required) & set(optional):
+        fail("inventory-overlap", "required and optional modules overlap", path)
+    return set(required), set(optional)
+
+
+def descriptors(root: Path, canonical: set[str]) -> dict[str, set[str]]:
+    resolved_root = root.resolve()
+    base = root_path(root, DESCRIPTORS)
+    result: dict[str, set[str]] = {}
+    for discovered in sorted(base.glob("*/module.yaml")):
+        path = discovered.resolve()
+        try:
+            path.relative_to(resolved_root)
+        except ValueError:
+            fail("path-escape", f"descriptor escapes repository: {discovered}")
+        value = load_json(path)
+        if not isinstance(value, dict):
+            fail("descriptor-structure", "descriptor must be an object", path)
+        identifier = value.get("id")
+        dependencies = value.get("dependencies")
+        if not isinstance(identifier, str) or not MODULE_ID.fullmatch(identifier):
+            fail("descriptor-id", f"invalid module ID {identifier!r}", path)
+        if identifier not in canonical:
+            fail("unknown-module", f"descriptor references {identifier!r}", path)
+        if identifier in result:
+            fail("duplicate-module", f"duplicate descriptor for {identifier!r}", path)
+        parsed = string_list(dependencies, "dependencies", path)
+        unknown = sorted(set(parsed) - canonical)
+        if unknown:
+            fail("unknown-module", f"{identifier!r} depends on {unknown[0]!r}", path)
+        result[identifier] = set(parsed)
+    missing = sorted(canonical - set(result))
+    if missing:
+        fail("missing-descriptor", f"missing descriptor for {missing[0]!r}")
+    return result
+
+
+def validate(root: Path) -> None:
+    expected = parse_proposal_contract(root_path(root, PROPOSAL))
+    required, optional = inventory(root)
+    if expected["module"] not in optional or expected["module"] in required:
+        fail("classification", f"{expected['module']} must be canonical optional")
+    canonical = required | optional
+    graph = descriptors(root, canonical)
+    path = root_path(root, POLICY)
+    value = load_json(path)
+    if not isinstance(value, dict):
+        fail("structure", "policy must be an object", path)
+    if set(value) != POLICY_KEYS:
+        missing = sorted(POLICY_KEYS - set(value))
+        unknown = sorted(set(value) - POLICY_KEYS)
+        fail("structure", f"missing={missing}, unknown={unknown}", path)
+    if value["schema_version"] != expected["schema_version"] or type(value["schema_version"]) is not int:
+        fail("schema-version", f"expected {expected['schema_version']!r}", path)
+    if value["module"] != expected["module"]:
+        fail("module", f"expected owner module {expected['module']!r}", path)
+
+    capabilities = value["capabilities"]
+    expected_capabilities = expected["capabilities"]
+    if not isinstance(capabilities, dict) or not isinstance(expected_capabilities, dict) or not all(
+        isinstance(key, str) and isinstance(owner, str) for key, owner in capabilities.items()
+    ):
+        fail("capability-structure", "capabilities must map strings to module IDs", path)
+    missing_caps = sorted(set(expected_capabilities) - set(capabilities))
+    extra_caps = sorted(set(capabilities) - set(expected_capabilities))
+    if missing_caps:
+        fail("capability-missing", missing_caps[0], path)
+    if extra_caps:
+        fail("capability-extra", extra_caps[0], path)
+    for capability in sorted(expected_capabilities):
+        owner = capabilities[capability]
+        if owner not in canonical:
+            fail("unknown-module", f"{capability!r} owner {owner!r}", path)
+        if owner != expected_capabilities[capability]:
+            rule = "core-shadow" if owner in required else "capability-owner"
+            fail(rule, f"{capability!r}: expected {expected_capabilities[capability]}, actual {owner}", path)
+
+    list_fields = (
+        "forbidden_core_shadows",
+        "required_dependencies",
+        "forbidden_dependencies_from_core",
+    )
+    for name in list_fields:
+        actual = string_list(value[name], name, path)
+        if actual != expected[name]:
+            fail("semantic-equality", f"{name}: expected={expected[name]!r}, actual={actual!r}", path)
+
+    owner = str(expected["module"])
+    required_dependencies = string_list(expected["required_dependencies"], "required_dependencies", root_path(root, PROPOSAL))
+    missing_edges = sorted(set(required_dependencies) - graph[owner])
+    if missing_edges:
+        fail("required-dependency", f"{owner} -> {missing_edges[0]}")
+    forbidden_targets = set(string_list(expected["forbidden_dependencies_from_core"], "forbidden_dependencies_from_core", root_path(root, PROPOSAL)))
+    for module in sorted(required):
+        forbidden = sorted(graph[module] & forbidden_targets)
+        if forbidden:
+            fail("core-to-governance", f"{module} -> {forbidden[0]}")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--config-root", type=Path, default=REPO)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        validate(args.config_root)
+    except OwnershipError as exc:
+        print(f"check_capability_ownership: error: {exc}", file=sys.stderr)
+        return 1
+    expected = parse_proposal_contract(root_path(args.config_root, PROPOSAL))
+    print(f"check_capability_ownership: ok ({len(expected['capabilities'])} governance capabilities)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_capability_ownership.py
+++ b/scripts/tests/test_check_capability_ownership.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Mutation tests for the governance capability-ownership contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[2]
+CHECKER = REPO / "scripts/check_capability_ownership.py"
+SPEC = importlib.util.spec_from_file_location("capability_ownership", CHECKER)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = checker
+SPEC.loader.exec_module(checker)
+
+
+class CapabilityOwnershipTests(unittest.TestCase):
+    def fixture(self, root: Path) -> None:
+        (root / ".git").mkdir()
+        for relative in (checker.POLICY, checker.INVENTORY, checker.PROPOSAL):
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO / relative, target)
+        for source in (REPO / checker.DESCRIPTORS).glob("*/module.yaml"):
+            target = root / source.relative_to(REPO)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+
+    def json_value(self, root: Path, relative: Path) -> dict[str, object]:
+        value = json.loads((root / relative).read_text())
+        assert isinstance(value, dict)
+        return value
+
+    def write_json(self, root: Path, relative: Path, value: object) -> None:
+        (root / relative).write_text(json.dumps(value, indent=2) + "\n")
+
+    def mutate_policy(self, root: Path, change) -> None:
+        value = self.json_value(root, checker.POLICY)
+        change(value)
+        self.write_json(root, checker.POLICY, value)
+
+    def rejected(self, mutate, rule: str) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.fixture(root)
+            mutate(root)
+            with self.assertRaisesRegex(checker.OwnershipError, f"rule={rule}"):
+                checker.validate(root)
+
+    def policy_rejected(self, change, rule: str) -> None:
+        self.rejected(lambda root: self.mutate_policy(root, change), rule)
+
+    def test_repository_fixture_and_real_cwd_independence_pass(self) -> None:
+        checker.validate(REPO)
+        with tempfile.TemporaryDirectory() as tmp:
+            completed = subprocess.run(
+                [sys.executable, "-I", "-S", str(CHECKER)], cwd=tmp,
+                text=True, capture_output=True, check=False,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout.strip(),
+                         "check_capability_ownership: ok (13 governance capabilities)")
+
+    def test_policy_key_order_is_irrelevant_but_normative_list_order_is_not(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.fixture(root)
+            value = self.json_value(root, checker.POLICY)
+            self.write_json(root, checker.POLICY, dict(reversed(list(value.items()))))
+            checker.validate(root)
+        for field in ("forbidden_core_shadows", "required_dependencies"):
+            with self.subTest(field=field):
+                self.policy_rejected(lambda v, name=field: v[name].reverse(),
+                                     "semantic-equality")
+
+    def test_proposal_is_the_authority(self) -> None:
+        def mutate(root: Path) -> None:
+            path = root / checker.PROPOSAL
+            path.write_text(path.read_text().replace(
+                "  oidc-federation: governance", "  oidc-federation: workflows", 1
+            ))
+        self.rejected(mutate, "capability-owner")
+
+    def test_missing_extra_and_duplicate_capabilities_fail(self) -> None:
+        self.policy_rejected(lambda v: v["capabilities"].pop("oidc-federation"),
+                             "capability-missing")
+        self.policy_rejected(lambda v: v["capabilities"].update(
+            {"provider-mode": "governance"}), "capability-extra")
+        def duplicate(root: Path) -> None:
+            path = root / checker.POLICY
+            path.write_text(path.read_text().replace(
+                '"oidc-federation": "governance",',
+                '"oidc-federation": "governance",\n    "oidc-federation": "governance",',
+            ))
+        self.rejected(duplicate, "duplicate-key")
+
+    def test_unknown_core_and_optional_owners_fail_distinctly(self) -> None:
+        self.policy_rejected(lambda v: v["capabilities"].update(
+            {"oidc-federation": "unknown"}), "unknown-module")
+        self.policy_rejected(lambda v: v["capabilities"].update(
+            {"oidc-federation": "config"}), "core-shadow")
+        self.policy_rejected(lambda v: v["capabilities"].update(
+            {"oidc-federation": "workflows"}), "capability-owner")
+
+    def test_normative_lists_require_membership_order_and_uniqueness(self) -> None:
+        for field in ("forbidden_core_shadows", "required_dependencies",
+                      "forbidden_dependencies_from_core"):
+            with self.subTest(field=field, mutation="missing"):
+                self.policy_rejected(lambda v, name=field: v[name].pop(),
+                                     "semantic-equality")
+            with self.subTest(field=field, mutation="duplicate"):
+                self.policy_rejected(lambda v, name=field: v[name].append(v[name][0]),
+                                     "duplicate-entry")
+
+    def test_schema_module_and_classification_failures(self) -> None:
+        self.policy_rejected(lambda v: v.update({"schema_version": 2}), "schema-version")
+        self.policy_rejected(lambda v: v.update({"module": "workflows"}), "module")
+        def classification(root: Path) -> None:
+            value = self.json_value(root, checker.INVENTORY)
+            value["optional"].remove("governance")
+            self.write_json(root, checker.INVENTORY, value)
+        self.rejected(classification, "classification")
+
+    def test_descriptor_structure_unknown_edge_and_missing_descriptor_fail(self) -> None:
+        def descriptor_mutation(module: str, change):
+            def mutate(root: Path) -> None:
+                relative = checker.DESCRIPTORS / module / "module.yaml"
+                value = self.json_value(root, relative)
+                change(value)
+                self.write_json(root, relative, value)
+            return mutate
+        self.rejected(descriptor_mutation("config", lambda v: v.pop("dependencies")),
+                      "structure")
+        self.rejected(descriptor_mutation("config", lambda v: v["dependencies"].append(1)),
+                      "structure")
+        self.rejected(descriptor_mutation("config", lambda v: v["dependencies"].append(
+            "unknown-module")), "unknown-module")
+        self.rejected(lambda root: (root / checker.DESCRIPTORS /
+                                    "config/module.yaml").unlink(), "missing-descriptor")
+
+    def test_required_governance_and_forbidden_core_edges_fail(self) -> None:
+        def missing(root: Path) -> None:
+            relative = checker.DESCRIPTORS / "governance/module.yaml"
+            value = self.json_value(root, relative)
+            value["dependencies"].remove("vault")
+            self.write_json(root, relative, value)
+        self.rejected(missing, "required-dependency")
+        def core_edge(root: Path) -> None:
+            relative = checker.DESCRIPTORS / "config/module.yaml"
+            value = self.json_value(root, relative)
+            value["dependencies"].append("governance")
+            self.write_json(root, relative, value)
+        self.rejected(core_edge, "core-to-governance")
+
+    def test_unknown_keys_non_json_constants_and_yaml_aliases_fail(self) -> None:
+        self.policy_rejected(lambda v: v.update({"aliases": []}), "structure")
+        def nan(root: Path) -> None:
+            path = root / checker.POLICY
+            path.write_text(path.read_text().replace('"schema_version": 1',
+                                                     '"schema_version": NaN'))
+        self.rejected(nan, "parse")
+        def alias(root: Path) -> None:
+            path = root / checker.POLICY
+            path.write_text(
+                "schema_version: 1\nmodule: governance\ncapabilities:\n"
+                "  oidc-federation: &owner governance\n"
+                "  sso-federation: *owner\n"
+            )
+        self.rejected(alias, "parse")
+
+    def test_cli_failure_is_nonzero_and_deterministic(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.fixture(root)
+            self.mutate_policy(root, lambda v: v["capabilities"].pop("oidc-federation"))
+            command = [sys.executable, "-I", "-S", str(CHECKER),
+                       "--config-root", str(root)]
+            first = subprocess.run(command, text=True, capture_output=True, check=False)
+            second = subprocess.run(command, text=True, capture_output=True, check=False)
+        self.assertEqual(first.returncode, 1)
+        self.assertEqual(first.stdout, "")
+        self.assertEqual(first.stderr, second.stderr)
+        self.assertIn("rule=capability-missing: oidc-federation", first.stderr)
+
+    @unittest.skipIf(os.name == "nt", "symlink permissions vary on Windows")
+    def test_symlinked_descriptor_escape_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as outside:
+            root = Path(tmp)
+            self.fixture(root)
+            target = root / checker.DESCRIPTORS / "config/module.yaml"
+            target.unlink()
+            target.symlink_to(Path(outside) / "module.yaml")
+            (Path(outside) / "module.yaml").write_text('{}')
+            with self.assertRaisesRegex(checker.OwnershipError, "rule=path-escape"):
+                checker.validate(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/baselines/modules/README.md
+++ b/tests/baselines/modules/README.md
@@ -7,3 +7,16 @@ YAML object construction. Do not add YAML-only syntax, comments, aliases, or tag
 Schema version 1 contains exactly 18 required IDs and 8 optional IDs. `git` is pinned as required.
 Run `scripts/check_module_inventory.sh` to validate the artifact; focused failure-mode tests live in
 `scripts/tests/test_check_module_inventory.py`.
+
+`governance-ownership.yaml` is the machine-readable provider-neutral ownership projection for optional governance
+plane. It is also strict JSON-compatible YAML. It deliberately duplicates no general module metadata:
+module classification comes from `canonical-inventory.yaml`, and dependency edges come from
+`src/modules/*/module.yaml`. The normative fenced block in
+`docs/proposals/pending/module-runtime-source-ownership-and-build.md` is authoritative; the checker parses
+that block and requires this artifact to match its capability map, forbidden core shadows, required
+dependency list, and forbidden core-to-governance edge exactly.
+
+Run `python3 -I -S scripts/check_capability_ownership.py` from any directory. Update the artifact only
+with the proposal's normative block, then update its mutation tests in the same change. This contract
+does not establish source, header, test, documentation, build, configuration, route, or data ownership;
+later descriptor and profile slices own those inventories.

--- a/tests/baselines/modules/governance-ownership.yaml
+++ b/tests/baselines/modules/governance-ownership.yaml
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "module": "governance",
+  "capabilities": {
+    "oidc-federation": "governance",
+    "sso-federation": "governance",
+    "organizational-roles": "governance",
+    "policy-authoring": "governance",
+    "policy-distribution": "governance",
+    "governance-approvals": "governance",
+    "governance-decision-records": "governance",
+    "posture-profiles": "governance",
+    "attestation-exports": "governance",
+    "agent-delegation-governance-identity": "governance",
+    "fleet-governance-records": "governance",
+    "artifact-signing": "governance",
+    "artifact-trust": "governance"
+  },
+  "forbidden_core_shadows": [
+    "execution-policy",
+    "policy.enforce",
+    "audit.ledger",
+    "vault.custody",
+    "gateway.auth",
+    "protocols.auth"
+  ],
+  "required_dependencies": [
+    "module-runtime",
+    "config",
+    "ir",
+    "gateway",
+    "protocols",
+    "vault",
+    "execution-policy",
+    "audit",
+    "routing",
+    "delegates",
+    "tools"
+  ],
+  "forbidden_dependencies_from_core": [
+    "governance"
+  ]
+}

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -244,6 +244,23 @@
       "blast_radius": "No runtime surface changes; close-time path checks constrain the slice to three docs, one validation record, status, and ledger accounting, while the validation matrix records tenant, custody, identity, and disabled-profile boundaries.",
       "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-19.md", "docs/modules/control-web.md", "docs/modules/governance.md", "docs/modules/runtime-web.md"]
+    },
+    {
+      "slice": 20,
+      "state": "present_and_verified",
+      "disposition": "Added the exact governance capability-ownership artifact and deterministic CI gate before descriptor enrichment or distributed governance source movement.",
+      "production": {"added": [], "deleted": [], "consolidated": ["one proposal-authored governance block projects into one machine-readable ownership artifact"]},
+      "fallbacks": ["distributed governance and OIDC production code has not moved", "broad source/header/test/docs/build/config/route/data ownership is not yet described by descriptors"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice adds repository validation and documentation only, not shipped production code.",
+        "rejected_simpler_alternative": "Starting source movement without a binding ownership contract would leave optional governance and core safety boundaries unenforced.",
+        "revisit": "Extend descriptor ownership fields in focused families, then generate build profiles before moving distributed governance code."
+      },
+      "consumers": ["descriptor validation CI", "future governance/profile/source slices", "module maintainers"],
+      "blast_radius": "The checker reads only the proposal's normative governance block, its machine-readable projection, canonical inventory, and module descriptors; mutation tests cover capability, owner, classification, dependency, alias, parser, path, ordering, and CLI failures without changing runtime behavior.",
+      "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-20.md", "tests/baselines/modules/governance-ownership.yaml", "scripts/check_capability_ownership.py", "scripts/tests/test_check_capability_ownership.py"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add the proposal-authored, provider-neutral governance capability ownership projection
- enforce exact proposal parity, canonical optional classification, required dependency edges, forbidden core shadows, and no required-core-to-governance dependency
- add fail-closed parsing, deterministic diagnostics, mutation tests, CWD-independent execution, and CI wiring

## Scope

CI, tests, and documentation only. No production source, descriptors, build/profile behavior, runtime toggles, OIDC routes, web code, or source movement changes.

## Validation

- `python3 -I -S scripts/check_capability_ownership.py --config-root "$PWD"`
- non-repository CWD invocation
- `python3 -I scripts/tests/test_check_capability_ownership.py -v`
- descriptor, cleanup-ledger, and refactor-baseline checks
- `make -C src lint`
- technical-writer approval
- exact-diff roundtable: initial rejection corrected; final three-round review approved
