### PR TITLE
fix(wfe): invoke git verify with supported syntax

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -23,10 +23,17 @@ type Verifier interface {
 
 type CommandVerifier struct{ Command []string }
 
+func defaultVerifyCommand() []string {
+	// `git verify` is a key=value-style infrastructure command. Its machine
+	// format is selected with format=json; `--json` is parsed as a value-taking
+	// long flag and exits 2 before verification runs.
+	return []string{"aimee", "git", "verify", "format=json"}
+}
+
 func (v CommandVerifier) Verify(ctx context.Context, workdir string) error {
 	command := v.Command
 	if len(command) == 0 {
-		command = []string{"aimee", "git", "verify", "--json"}
+		command = defaultVerifyCommand()
 	}
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 	cmd.Dir = workdir

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/JBailes/aimee/server-go/internal/wfe"
 )
 
+func TestDefaultVerifyCommandUsesGitVerifyKeyValueSyntax(t *testing.T) {
+	got := strings.Join(defaultVerifyCommand(), " ")
+	if got != "aimee git verify format=json" {
+		t.Fatalf("default verifier command = %q, want supported git verify syntax", got)
+	}
+}
+
 type temporaryFailureAgents struct {
 	mu       sync.Mutex
 	requests []DelegateRequest


### PR DESCRIPTION
## Summary
- use the supported `format=json` key/value argument for the Go WFE verifier
- lock the production default command with a regression test

## Live reproduction
- `aimee git verify --json` exits 2 with no output in an active slice worktree
- `aimee git verify format=json` passes 2/2 checks in the same worktree

## Verification
- `go test ./internal/engine`
- `go test -race ./internal/engine`
- roundtable review queued: `oprun_g6a6052ff1c403482_1784697947_3`