### PR TITLE
Pilot module-runtime descriptor ownership

### DIFF
--- a/docs/modules/module-runtime.md
+++ b/docs/modules/module-runtime.md
@@ -28,6 +28,13 @@ the shared logging primitive. Production consumers include `src/server/agent_run
 optional plugin-loader contract; focused consumers are `src/tests/test_plugin.c` and
 `src/tests/test_plugin_c_hook.c`.
 
+As the ownership-descriptor pilot, `module.yaml` also declares this module's two implementation
+sources, two public headers, focused C-hook test, and canonical module document. The descriptor
+validator rejects symlinked paths before claiming them and rejects duplicate normalized lexical
+paths within or across descriptors, then emits a deterministic declared-ownership report. Build
+inputs are still maintained by Make and CMake in this slice; descriptor-driven build generation
+remains a later step, so these ownership fields are documentation and validation only.
+
 ## Providers and readiness
 
 `module-runtime` is its own required reference implementation and has no replaceable provider.

--- a/docs/validation/core-modularization-slice-21.md
+++ b/docs/validation/core-modularization-slice-21.md
@@ -1,0 +1,49 @@
+# Core modularization slice 21: module-runtime ownership pilot
+
+## Scope
+
+This slice starts from `46e78ffeb4631b5fd052a183e101e79d4fa9dfd8` and pilots four optional,
+per-descriptor ownership fields on required `module-runtime`: `sources`, `public_headers`, `tests`,
+and `docs`. Each field is independently optional; a descriptor may declare any subset, including
+none, without failing validation. This slice does not move files, generate build inputs, alter
+module selection, enrich another descriptor, or change runtime behavior.
+
+## Contract
+
+Each declared path is a normalized repository-relative path to an existing regular file. Sources
+must remain below the declaring module, public headers below its canonical installed-header tree,
+tests below `src/tests` with the `test_` convention, and docs at the module's single canonical
+document. Absolute paths, traversal, declared paths whose real path differs from their lexical path
+(symlinks rejected before claim), wrong roles or extensions, within-role duplicates, cross-role
+claims, and reuse of the same normalized lexical path by different descriptors fail closed with a
+stable rule and JSON pointer.
+
+Per-descriptor optionality is a deliberate migration concession. The `--emit-ownership` projection
+emits a byte-stable JSON report that lists every descriptor and every ownership role, sorts
+descriptors by module ID, and preserves declared role-list order within each module. An empty role
+appears in the report and means only that the descriptor has not yet been enriched; it is not a
+claim of complete ownership.
+
+## DRY and build boundary
+
+One shared validator owns path normalization, containment, role, existence, duplicate, and report
+rules. The pilot inventory names the already-canonical `module-runtime` sources and headers and the
+focused C-hook test; it does not claim the mixed plugin-loader test. Make and CMake remain
+authoritative build-input lists until a later slice can replace both with one generated projection.
+Until then, the four ownership fields are documentation and validation only: the build does not read
+them, and they do not change what is compiled or installed.
+
+## Completed local verification
+
+- `python3 -I -S scripts/validate_module_descriptors.py --check-schema src/modules`
+- `python3 -I -S scripts/validate_module_descriptors.py --check-schema --emit-ownership src/modules`
+- `python3 -I scripts/tests/test_validate_module_descriptors.py -v`
+- `python3 -I -S scripts/check_capability_ownership.py`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+- `python3 -I -S scripts/refactor_baselines.py`
+- `make -C src lint`
+
+## Close-time gates
+
+- technical-writer review and exact-final-diff roundtable approval
+- feature-branch pull-request CI

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -4,12 +4,16 @@
 from __future__ import annotations
 
 import copy
+import errno
 import importlib.util
 import json
 from pathlib import Path
 import shutil
+import subprocess
+import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -18,6 +22,25 @@ SPEC = importlib.util.spec_from_file_location("validate_module_descriptors", CHE
 assert SPEC and SPEC.loader
 validator = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(validator)
+
+
+def production_repo() -> tempfile.TemporaryDirectory[str]:
+    tmp = tempfile.TemporaryDirectory()
+    repo = Path(tmp.name)
+    inventory = repo / validator.INVENTORY_PATH
+    inventory.parent.mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / validator.INVENTORY_PATH, inventory)
+    for source in (REPO_ROOT / "src/modules").glob("*/module.yaml"):
+        target = repo / "src/modules" / source.parent.name / "module.yaml"
+        target.parent.mkdir(parents=True)
+        shutil.copy2(source, target)
+        descriptor = json.loads(source.read_text(encoding="utf-8"))
+        for field in validator.OWNERSHIP_FIELDS:
+            for relative in descriptor.get(field, []):
+                owned_target = repo / relative
+                owned_target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(REPO_ROOT / relative, owned_target)
+    return tmp
 
 
 class DescriptorTests(unittest.TestCase):
@@ -42,16 +65,7 @@ class DescriptorTests(unittest.TestCase):
         return validator.load_inventory(REPO_ROOT)
 
     def production_repo(self) -> tempfile.TemporaryDirectory[str]:
-        tmp = tempfile.TemporaryDirectory()
-        repo = Path(tmp.name)
-        inventory = repo / validator.INVENTORY_PATH
-        inventory.parent.mkdir(parents=True)
-        shutil.copy2(REPO_ROOT / validator.INVENTORY_PATH, inventory)
-        for source in (REPO_ROOT / "src/modules").glob("*/module.yaml"):
-            target = repo / "src/modules" / source.parent.name / "module.yaml"
-            target.parent.mkdir(parents=True)
-            shutil.copy2(source, target)
-        return tmp
+        return production_repo()
 
     def mutate_descriptor(self, repo: Path, identifier: str, mutate) -> None:
         path = repo / "src/modules" / identifier / "module.yaml"
@@ -185,6 +199,211 @@ class DescriptorTests(unittest.TestCase):
         runtime_empty = self.required()
         runtime_empty["runtime_toggle"] = {}
         self.assert_rule(runtime_empty, "runtime-toggle-shape")
+
+    def test_ownership_is_optional_and_report_preserves_declared_order(self) -> None:
+        report = validator.ownership_report(REPO_ROOT, [Path("src/modules")])
+        self.assertEqual(report["schema_version"], 1)
+        self.assertEqual(report["result"], "PASS")
+        descriptors = report["descriptors"]
+        self.assertEqual([item["id"] for item in descriptors], sorted(item["id"] for item in descriptors))
+        runtime = next(item for item in descriptors if item["id"] == "module-runtime")
+        self.assertEqual(runtime["module_root"], "src/modules/module-runtime")
+        self.assertEqual(
+            [item["path"] for item in runtime["ownership"]["sources"]],
+            [
+                "src/modules/module-runtime/extension.c",
+                "src/modules/module-runtime/pre_llm_hook.c",
+            ],
+        )
+        self.assertEqual(
+            runtime["ownership"]["docs"],
+            [{"path": "docs/modules/module-runtime.md", "result": "PASS"}],
+        )
+        memory = next(item for item in descriptors if item["id"] == "memory")
+        self.assertEqual(memory["ownership"], {field: [] for field in validator.OWNERSHIP_FIELDS})
+
+    def test_ownership_report_sorts_descriptors_independent_of_root_order(self) -> None:
+        root = Path("tests/fixtures/modules/positive")
+        roots = [root / "runtime-web", root / "memory", root / "control-web"]
+        forward = validator.ownership_report(REPO_ROOT, roots)
+        reverse = validator.ownership_report(REPO_ROOT, list(reversed(roots)))
+        self.assertEqual(forward, reverse)
+        self.assertEqual(
+            [item["id"] for item in forward["descriptors"]],
+            ["control-web", "memory", "runtime-web"],
+        )
+
+    def test_each_ownership_role_is_validated(self) -> None:
+        descriptor = json.loads(
+            (REPO_ROOT / "src/modules/module-runtime/module.yaml").read_text(encoding="utf-8")
+        )
+        report = validator.validate_ownership(REPO_ROOT, "module-runtime", descriptor)
+        self.assertEqual(
+            {field: len(report["ownership"][field]) for field in validator.OWNERSHIP_FIELDS},
+            {"sources": 2, "public_headers": 2, "tests": 1, "docs": 1},
+        )
+
+    def test_ownership_duplicate_and_cross_role_mutations(self) -> None:
+        descriptor = json.loads(
+            (REPO_ROOT / "src/modules/module-runtime/module.yaml").read_text(encoding="utf-8")
+        )
+        duplicate = copy.deepcopy(descriptor)
+        duplicate["sources"].append(duplicate["sources"][0])
+        with self.assertRaisesRegex(validator.DescriptorError, "rule=ownership-duplicate"):
+            validator.validate_ownership(REPO_ROOT, "module-runtime", duplicate)
+
+        cross_role = copy.deepcopy(descriptor)
+        cross_role["tests"] = [cross_role["sources"][0]]
+        with self.assertRaisesRegex(validator.DescriptorError, "rule=ownership-cross-role"):
+            validator.validate_ownership(REPO_ROOT, "module-runtime", cross_role)
+
+    def test_cross_descriptor_duplicate_includes_prior_location(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            memory = self.required()
+            memory["tests"] = ["src/tests/test_plugin_c_hook.c"]
+            config = {
+                "descriptor_version": 1,
+                "id": "config",
+                "dependencies": ["module-runtime"],
+                "runtime_toggle": {"supported": False},
+                "tests": ["src/tests/test_plugin_c_hook.c"],
+            }
+            for name, descriptor in (("one", memory), ("two", config)):
+                path = root / name / "module.yaml"
+                path.parent.mkdir()
+                path.write_text(json.dumps(descriptor), encoding="utf-8")
+            with self.assertRaisesRegex(
+                validator.DescriptorError,
+                r"rule=ownership-cross-descriptor.*memory tests at /tests/0",
+            ):
+                validator.validate_roots(REPO_ROOT, [root])
+
+    def test_role_policy_must_cover_every_ownership_field(self) -> None:
+        descriptor = self.required()
+        original = validator.ROLE_EXTENSIONS.pop("sources")
+        try:
+            with self.assertRaisesRegex(validator.DescriptorError, "rule=ownership-role-undefined"):
+                validator.validate_ownership(REPO_ROOT, "memory", descriptor)
+        finally:
+            validator.ROLE_EXTENSIONS["sources"] = original
+
+    def test_ownership_path_and_role_mutations(self) -> None:
+        descriptor = json.loads(
+            (REPO_ROOT / "src/modules/module-runtime/module.yaml").read_text(encoding="utf-8")
+        )
+        cases = (
+            ("sources", "/tmp/extension.c", "ownership-path-normalized"),
+            ("sources", "src/modules/module-runtime/../config/config.c", "ownership-path-normalized"),
+            ("sources", "src/modules/config/config.c", "ownership-role-boundary"),
+            ("sources", "src/modules/module-runtime/module.yaml", "ownership-role"),
+            ("public_headers", "src/modules/module-runtime/module.yaml", "ownership-role-boundary"),
+            ("tests", "src/tests/Rules.mk", "ownership-role"),
+            ("docs", "docs/modules/config.md", "ownership-doc-canonical"),
+            ("docs", "docs/modules/module-runtime.txt", "ownership-doc-canonical"),
+            ("sources", "src/modules/module-runtime/missing.c", "ownership-file"),
+        )
+        for field, path, rule in cases:
+            mutated = copy.deepcopy(descriptor)
+            mutated[field] = [path]
+            with self.subTest(field=field, path=path), self.assertRaisesRegex(
+                validator.DescriptorError, f"rule={rule}"
+            ):
+                validator.validate_ownership(REPO_ROOT, "module-runtime", mutated)
+
+        for value, rule in (("not-an-array", "ownership-field-type"), ([7], "ownership-path-type")):
+            mutated = copy.deepcopy(descriptor)
+            mutated["sources"] = value
+            with self.subTest(value=value), self.assertRaisesRegex(
+                validator.DescriptorError, f"rule={rule}"
+            ):
+                validator.validate_ownership(REPO_ROOT, "module-runtime", mutated)
+
+    def test_ownership_nonregular_and_symlink_escape_mutations(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            directory = repo / "src/modules/module-runtime/not-a-file.c"
+            directory.mkdir()
+            self.mutate_descriptor(
+                repo, "module-runtime", lambda value: value.__setitem__(
+                    "sources", ["src/modules/module-runtime/not-a-file.c"]
+                )
+            )
+            with self.assertRaisesRegex(validator.DescriptorError, "rule=ownership-file"):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+        tmp = self.production_repo()
+        outside = Path(tmp.name).parent / f"{Path(tmp.name).name}-outside.c"
+        try:
+            repo = Path(tmp.name)
+            outside.write_text("outside\n", encoding="utf-8")
+            link = repo / "src/modules/module-runtime/escape.c"
+            link.symlink_to(outside)
+            self.mutate_descriptor(
+                repo, "module-runtime", lambda value: value.__setitem__(
+                    "sources", ["src/modules/module-runtime/escape.c"]
+                )
+            )
+            with self.assertRaisesRegex(validator.DescriptorError, "rule=ownership-path-escape"):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            outside.unlink(missing_ok=True)
+            tmp.cleanup()
+
+    def test_inward_and_self_referential_symlinks_fail_stably(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            link = repo / "src/modules/module-runtime/alias.c"
+            link.symlink_to(repo / "src/modules/module-runtime/extension.c")
+            self.mutate_descriptor(
+                repo, "module-runtime", lambda value: value.__setitem__(
+                    "sources", ["src/modules/module-runtime/alias.c"]
+                )
+            )
+            with self.assertRaisesRegex(
+                validator.DescriptorError, r"rule=ownership-path-symlink pointer=/sources/0"
+            ):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+    def test_resolve_errors_are_classified_without_masking_io(self) -> None:
+        path = Path("owned.c")
+        with mock.patch.object(Path, "resolve", side_effect=OSError(errno.ELOOP, "loop")):
+            with self.assertRaisesRegex(validator.DescriptorError, "rule=ownership-file"):
+                validator._resolve_owned(path, "/sources/0")
+        with mock.patch.object(
+            Path, "resolve", side_effect=OSError(errno.ENAMETOOLONG, "long")
+        ):
+            with self.assertRaisesRegex(
+                validator.DescriptorError, "rule=ownership-path-normalized"
+            ):
+                validator._resolve_owned(path, "/sources/0")
+        with mock.patch.object(Path, "resolve", side_effect=OSError(errno.EACCES, "denied")):
+            with self.assertRaises(OSError):
+                validator._resolve_owned(path, "/sources/0")
+
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            link = repo / "src/modules/module-runtime/loop.c"
+            link.symlink_to(link)
+            self.mutate_descriptor(
+                repo, "module-runtime", lambda value: value.__setitem__(
+                    "sources", ["src/modules/module-runtime/loop.c"]
+                )
+            )
+            with self.assertRaisesRegex(
+                validator.DescriptorError, r"rule=ownership-file pointer=/sources/0"
+            ):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
 
     def test_duplicate_module_id_fails_across_roots(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -372,6 +591,60 @@ class DescriptorTests(unittest.TestCase):
         try:
             with self.assertRaisesRegex(validator.DescriptorError, "json-surrogate"):
                 validator.load_json(path)
+        finally:
+            tmp.cleanup()
+
+
+class OwnershipCliTests(unittest.TestCase):
+    def run_checker(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-I", "-S", str(CHECKER), *args],
+            cwd=REPO_ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def test_emit_ownership_is_one_complete_json_report(self) -> None:
+        result = self.run_checker("--check-schema", "--emit-ownership", "src/modules")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["result"], "PASS")
+        self.assertEqual(len(payload["descriptors"]), 26)
+        for descriptor in payload["descriptors"]:
+            self.assertEqual(
+                set(descriptor), {"id", "module_root", "ownership", "result"}
+            )
+
+    def test_emit_flags_are_mutually_exclusive(self) -> None:
+        result = self.run_checker(
+            "--emit-schema", "--emit-ownership", "src/modules"
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("rule=cli-flag-conflict pointer=/args", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+    def test_emit_ownership_failure_has_stable_rule_without_json(self) -> None:
+        tmp = production_repo()
+        try:
+            repo = Path(tmp.name)
+            descriptor_path = repo / "src/modules/module-runtime/module.yaml"
+            descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+            descriptor["sources"] = ["src/modules/module-runtime/loop.c"]
+            descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
+            link = repo / "src/modules/module-runtime/loop.c"
+            link.symlink_to(link)
+            result = self.run_checker(
+                "--config-root", str(repo), "--emit-ownership", "src/modules"
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+            self.assertIn("rule=ownership-file pointer=/sources/0", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
         finally:
             tmp.cleanup()
 

--- a/scripts/validate_module_descriptors.py
+++ b/scripts/validate_module_descriptors.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 from pathlib import Path
+from pathlib import PurePosixPath
 import re
 import sys
 import unicodedata
@@ -22,7 +24,14 @@ MAX_DEPTH = 32
 MAX_ARRAY = 256
 ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 BASE_KEYS = {"descriptor_version", "id", "dependencies", "runtime_toggle"}
+OWNERSHIP_FIELDS = ("sources", "public_headers", "tests", "docs")
 DEFAULT_ON = {"runtime-web", "control-web"}
+ROLE_EXTENSIONS = {
+    "sources": {".c", ".cpp", ".S", ".s"},
+    "public_headers": {".h", ".hpp"},
+    "tests": {".c", ".cpp", ".py", ".sh"},
+    "docs": {".md"},
+}
 
 
 class DescriptorError(ValueError):
@@ -147,6 +156,14 @@ def schema() -> dict[str, object]:
                 "required": ["supported"],
                 "properties": {"supported": {"type": "boolean"}},
             },
+            **{
+                field: {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "uniqueItems": True,
+                }
+                for field in OWNERSHIP_FIELDS
+            },
         },
     }
 
@@ -171,12 +188,13 @@ def validate_descriptor(value: object, required: set[str], optional: set[str]) -
     identifier = module_id(raw_id, "/id")
     if identifier not in required | optional:
         fail("module-unknown", f"unknown module ID {identifier!r}", "/id")
-    expected_keys = BASE_KEYS | ({"enabled_by_default"} if identifier in optional else set())
-    if set(value) != expected_keys:
+    required_keys = BASE_KEYS | ({"enabled_by_default"} if identifier in optional else set())
+    allowed_keys = required_keys | set(OWNERSHIP_FIELDS)
+    if not required_keys <= set(value) or not set(value) <= allowed_keys:
         fail(
             "descriptor-keys",
-            f"keys mismatch; missing={sorted(expected_keys-set(value))}, "
-            f"unknown={sorted(set(value)-expected_keys)}",
+            f"keys mismatch; missing={sorted(required_keys-set(value))}, "
+            f"unknown={sorted(set(value)-allowed_keys)}",
         )
     if type(value["descriptor_version"]) is not int or value["descriptor_version"] != VERSION:
         fail(
@@ -231,6 +249,131 @@ def validate_descriptor(value: object, required: set[str], optional: set[str]) -
     return identifier
 
 
+def _contained(path: Path, boundary: Path) -> bool:
+    try:
+        path.relative_to(boundary)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_owned(path: Path, pointer: str) -> Path:
+    """Resolve an ownership path while keeping symlink-loop diagnostics stable."""
+    try:
+        return path.resolve()
+    except RuntimeError as exc:
+        fail("ownership-file", f"cannot resolve ownership path: {exc}", pointer)
+    except OSError as exc:
+        if exc.errno == errno.ELOOP:
+            fail("ownership-file", f"cannot resolve ownership path: {exc}", pointer)
+        if exc.errno == errno.ENAMETOOLONG:
+            fail("ownership-path-normalized", f"ownership path is too long: {exc}", pointer)
+        raise
+
+
+def validate_owned_path(repo: Path, identifier: str, field: str, raw: object,
+                        pointer: str) -> dict[str, str]:
+    """Validate one declared ownership path through the shared role table."""
+    if not isinstance(raw, str):
+        fail("ownership-path-type", "ownership path must be a string", pointer)
+    if not raw or "\\" in raw or raw.endswith("/"):
+        fail("ownership-path-normalized", f"path is not normalized: {raw!r}", pointer)
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or "." in pure.parts or ".." in pure.parts or pure.as_posix() != raw:
+        fail("ownership-path-normalized", f"path is not repository-relative: {raw!r}", pointer)
+
+    role_prefixes = {
+        "sources": PurePosixPath("src/modules") / identifier,
+        "public_headers": PurePosixPath("src/modules") / identifier / "include/aimee" / identifier,
+        "tests": PurePosixPath("src/tests"),
+        "docs": PurePosixPath("docs/modules"),
+    }
+    prefix = role_prefixes[field]
+    try:
+        pure.relative_to(prefix)
+    except ValueError:
+        fail("ownership-role-boundary", f"{field} path is outside {prefix}: {raw}", pointer)
+
+    resolved_repo = repo.resolve()
+    lexical = resolved_repo.joinpath(*pure.parts)
+    resolved = _resolve_owned(lexical, pointer)
+    if not _contained(resolved, resolved_repo):
+        fail("ownership-path-escape", f"path escapes repository: {raw}", pointer)
+    if resolved != lexical:
+        fail("ownership-path-symlink", f"ownership path must not traverse a symlink: {raw}", pointer)
+
+    module_root = _resolve_owned(resolved_repo / "src/modules" / identifier, pointer)
+    boundaries = {
+        "sources": module_root,
+        "public_headers": _resolve_owned(module_root / "include/aimee" / identifier, pointer),
+        "tests": _resolve_owned(resolved_repo / "src/tests", pointer),
+        "docs": _resolve_owned(resolved_repo / "docs/modules", pointer),
+    }
+    boundary = boundaries[field]
+    if not _contained(resolved, boundary):
+        fail("ownership-role-boundary", f"{field} path is outside {boundary}: {raw}", pointer)
+    if field == "tests" and not PurePosixPath(raw).name.startswith("test_"):
+        fail("ownership-role", f"test path must use the test_ convention: {raw}", pointer)
+    if field == "docs" and raw != f"docs/modules/{identifier}.md":
+        fail("ownership-doc-canonical", f"expected docs/modules/{identifier}.md, actual {raw}",
+             pointer)
+    if PurePosixPath(raw).suffix not in ROLE_EXTENSIONS[field]:
+        fail("ownership-role", f"extension does not match {field}: {raw}", pointer)
+    if not resolved.is_file():
+        fail("ownership-file", f"path is not an existing regular file: {raw}", pointer)
+    return {"path": raw, "result": "PASS"}
+
+
+def validate_ownership(
+    repo: Path,
+    identifier: str,
+    value: dict[str, object],
+    cross_claims: dict[str, tuple[str, str, str]] | None = None,
+) -> dict[str, object]:
+    """Validate all optional roles without reordering their declared entries."""
+    for field in OWNERSHIP_FIELDS:
+        if field not in ROLE_EXTENSIONS:
+            fail("ownership-role-undefined", f"no role policy exists for {field}", f"/{field}")
+    report: dict[str, object] = {
+        "id": identifier,
+        "module_root": f"src/modules/{identifier}",
+        "ownership": {},
+        "result": "PASS",
+    }
+    ownership = report["ownership"]
+    assert isinstance(ownership, dict)
+    claimed: dict[str, str] = {}
+    for field in OWNERSHIP_FIELDS:
+        raw_entries = value.get(field, [])
+        if not isinstance(raw_entries, list):
+            fail("ownership-field-type", f"{field} must be an array", f"/{field}")
+        seen: set[str] = set()
+        entries: list[dict[str, str]] = []
+        for index, raw in enumerate(raw_entries):
+            pointer = f"/{field}/{index}"
+            if not isinstance(raw, str):
+                fail("ownership-path-type", "ownership path must be a string", pointer)
+            if raw in seen:
+                fail("ownership-duplicate", f"duplicate {field} path: {raw}", pointer)
+            if raw in claimed:
+                fail("ownership-cross-role", f"{raw} is already declared in {claimed[raw]}",
+                     pointer)
+            if cross_claims is not None and raw in cross_claims:
+                prior_id, prior_field, prior_pointer = cross_claims[raw]
+                fail(
+                    "ownership-cross-descriptor",
+                    f"{raw} is already declared by {prior_id} {prior_field} at {prior_pointer}",
+                    pointer,
+                )
+            seen.add(raw)
+            claimed[raw] = field
+            entries.append(validate_owned_path(repo, identifier, field, raw, pointer))
+            if cross_claims is not None:
+                cross_claims[raw] = (identifier, field, pointer)
+        ownership[field] = entries
+    return report
+
+
 def discover(root: Path) -> list[Path]:
     if not root.is_dir():
         fail("root", f"descriptor root is not a directory: {root}")
@@ -276,13 +419,15 @@ def validate_graph(descriptors: dict[str, tuple[Path, list[str]]],
             visit(identifier)
 
 
-def validate_roots(repo: Path, roots: list[Path]) -> int:
+def validate_roots(repo: Path, roots: list[Path],
+                   ownership_reports: list[dict[str, object]] | None = None) -> int:
     required, optional = load_inventory(repo)
     production_root = (repo / "src/modules").resolve()
     unresolved_roots = [root if root.is_absolute() else repo / root for root in roots]
     resolved_roots = [root.resolve() for root in unresolved_roots]
     seen: dict[str, Path] = {}
     graph: dict[str, tuple[Path, list[str]]] = {}
+    cross_claims: dict[str, tuple[str, str, str]] = {}
     count = 0
     for root, resolved in zip(roots, resolved_roots, strict=True):
         files = discover(resolved)
@@ -301,6 +446,9 @@ def validate_roots(repo: Path, roots: list[Path]) -> int:
                 )
             seen[identifier] = path
             graph[identifier] = (path, list(value["dependencies"]))
+            ownership = validate_ownership(repo, identifier, value, cross_claims)
+            if ownership_reports is not None:
+                ownership_reports.append(ownership)
             count += 1
     if resolved_roots == [production_root]:
         expected = required | optional
@@ -336,26 +484,40 @@ def validate_roots(repo: Path, roots: list[Path]) -> int:
     return count
 
 
+def ownership_report(repo: Path, roots: list[Path]) -> dict[str, object]:
+    reports: list[dict[str, object]] = []
+    validate_roots(repo, roots, reports)
+    reports.sort(key=lambda report: str(report["id"]))
+    return {"schema_version": 1, "descriptors": reports, "result": "PASS"}
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("roots", nargs="*", type=Path)
     parser.add_argument("--config-root", type=Path)
     parser.add_argument("--check-schema", action="store_true")
     parser.add_argument("--emit-schema", action="store_true")
+    parser.add_argument("--emit-ownership", action="store_true")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
-    if args.emit_schema:
-        sys.stdout.buffer.write(schema_bytes())
-        return 0
-    repo = Path(os.path.realpath(args.config_root or REPO_ROOT))
     try:
+        if args.emit_schema and args.emit_ownership:
+            fail("cli-flag-conflict", "--emit-schema and --emit-ownership are mutually exclusive",
+                 "/args")
+        if args.emit_schema:
+            sys.stdout.buffer.write(schema_bytes())
+            return 0
+        repo = Path(os.path.realpath(args.config_root or REPO_ROOT))
         if args.check_schema:
             check_schema(repo)
         if not args.roots:
             fail("root", "at least one descriptor root is required")
+        if args.emit_ownership:
+            print(json.dumps(ownership_report(repo, args.roots), indent=2, ensure_ascii=False))
+            return 0
         count = validate_roots(repo, args.roots)
     except (DescriptorError, OSError, UnicodeError, ValueError) as exc:
         print(f"validate_module_descriptors: error: {exc}", file=sys.stderr)

--- a/src/modules/module-runtime/module.yaml
+++ b/src/modules/module-runtime/module.yaml
@@ -4,5 +4,19 @@
   "dependencies": [],
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/module-runtime/extension.c",
+    "src/modules/module-runtime/pre_llm_hook.c"
+  ],
+  "public_headers": [
+    "src/modules/module-runtime/include/aimee/module-runtime/extension.h",
+    "src/modules/module-runtime/include/aimee/module-runtime/pre_llm_hook.h"
+  ],
+  "tests": [
+    "src/tests/test_plugin_c_hook.c"
+  ],
+  "docs": [
+    "docs/modules/module-runtime.md"
+  ]
 }

--- a/src/modules/module.schema.json
+++ b/src/modules/module.schema.json
@@ -15,12 +15,26 @@
     "descriptor_version": {
       "const": 1
     },
+    "docs": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
     "enabled_by_default": {
       "type": "boolean"
     },
     "id": {
       "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
       "type": "string"
+    },
+    "public_headers": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
     },
     "runtime_toggle": {
       "additionalProperties": false,
@@ -33,6 +47,20 @@
         "supported"
       ],
       "type": "object"
+    },
+    "sources": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "tests": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
     }
   },
   "required": [

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -261,6 +261,23 @@
       "blast_radius": "The checker reads only the proposal's normative governance block, its machine-readable projection, canonical inventory, and module descriptors; mutation tests cover capability, owner, classification, dependency, alias, parser, path, ordering, and CLI failures without changing runtime behavior.",
       "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-20.md", "tests/baselines/modules/governance-ownership.yaml", "scripts/check_capability_ownership.py", "scripts/tests/test_check_capability_ownership.py"]
+    },
+    {
+      "slice": 21,
+      "state": "present_and_verified",
+      "disposition": "Piloted optional source, public-header, test, and documentation ownership fields on required module-runtime with one shared fail-closed validator and deterministic declared-ownership report.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["Make and CMake retain separate build-input lists until descriptor-driven generation", "the remaining twenty-five descriptors omit ownership fields pending focused family slices", "mixed plugin-loader test ownership remains deliberately unclaimed by module-runtime"],
+      "net_growth": {
+        "status": "justified",
+        "rationale": "The slice extends repository validation, schema, tests, and documentation without adding shipped runtime code.",
+        "rejected_simpler_alternative": "Bulk-populating every descriptor before proving role and containment rules would turn unverified path guesses into apparent authority.",
+        "revisit": "Enrich one ownership family at a time, then replace duplicate Make and CMake lists with a single generated projection after profile parity is proven."
+      },
+      "consumers": ["descriptor validation CI", "module maintainers", "future generated-build and source-movement slices"],
+      "blast_radius": "Only optional descriptor vocabulary and module-runtime inventory change; mutation tests cover each role, order, omission, missing and nonregular files, normalization, traversal, symlink rejection, local and cross-descriptor duplicates, cross-role claims, CLI output, and unrelated docs.",
+      "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-21.md", "src/modules/module-runtime/module.yaml", "src/modules/module.schema.json", "scripts/validate_module_descriptors.py", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add optional source, public-header, test, and docs ownership fields to module descriptors
- populate and validate the required module-runtime inventory with lexical role, symlink, duplicate, and file checks
- emit deterministic declared-ownership JSON while keeping build generation explicitly deferred

## Validation
- technical-writer approved
- exact staged-diff roundtable approved after one correction cycle
- `python3 -I -S scripts/validate_module_descriptors.py --check-schema src/modules`
- `python3 -I scripts/tests/test_validate_module_descriptors.py -v` (32 tests)
- cleanup, governance-ownership, refactor-baseline, and `make -C src lint` gates pass

## Scope
This is Slice 21 of the core-modularization feature effort. It moves no files and changes no runtime or build inputs; only module-runtime is enriched in this pilot.