### PR TITLE
fix(wfe): lease all unassigned delegate states

### DIFF
--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -240,15 +240,18 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 			// when the status plane later fails so a retry cannot overlap the job.
 			return DelegateResult{}, err
 		}
-		// Pending with no assigned agent is not progress. Bound that resource-plane
-		// state while leaving assigned/running and terminal jobs untouched.
-		if status.JobStatus == "pending" && strings.TrimSpace(status.Agent) == "" {
+		// Any nonterminal status without an assigned agent is not progress. The
+		// resource plane can mark a job running before admission assigns an agent,
+		// so status alone cannot end the unassigned lease.
+		assigned := strings.TrimSpace(status.Agent) != ""
+		terminal := isTerminalDelegateStatus(status.JobStatus)
+		if !assigned && !terminal {
 			if unassignedSince.IsZero() {
 				unassignedSince = time.Now()
 			} else if time.Since(unassignedSince) >= c.delegatePendingTimeout() {
 				return DelegateResult{}, c.expireUnassigned(launched.JobID, key, unassignedSince)
 			}
-		} else if strings.TrimSpace(status.Agent) != "" || isTerminalDelegateStatus(status.JobStatus) {
+		} else {
 			unassignedSince = time.Time{}
 		}
 		switch status.JobStatus {

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -417,6 +417,48 @@ func TestHTTPAgentClientExpiresUnassignedPendingJob(t *testing.T) {
 	}
 }
 
+func TestHTTPAgentClientExpiresUnassignedRunningJob(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var launches atomic.Int32
+	var cancellations atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/delegate/run":
+			launches.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_id": 20})
+		case "/v1/delegate/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"job_status": "running", "agent_name": ""})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
+		PollEvery: time.Millisecond, PendingTimeout: 20 * time.Millisecond,
+		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+			cancellations.Add(1)
+			return true, nil
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review",
+		WorkItemID: "wi_running", Stage: "gate", ExecutionVersion: "v1"}
+	if _, err := client.Delegate(t.Context(), request); err == nil || !errors.Is(err, ErrDelegateUnassignedExpired) {
+		t.Fatalf("unassigned running job did not return structured expiry: %v", err)
+	}
+	if launches.Load() != 1 || cancellations.Load() != 1 {
+		t.Fatalf("launches=%d cancellations=%d", launches.Load(), cancellations.Load())
+	}
+	if _, err := store.DelegateJob(t.Context(), delegateJobKey(request)); err == nil {
+		t.Fatal("expired running job retained its durable mapping")
+	}
+}
+
 func TestHTTPAgentClientDoesNotExpireAssignedJob(t *testing.T) {
 	var polls atomic.Int32
 	var cancellations atomic.Int32


### PR DESCRIPTION
## Summary
- treat every nonterminal delegate job without an assigned agent as unassigned
- expire and cancel resource-plane jobs that report `running` before an agent owns them
- preserve assigned and terminal behavior

## Live failure
Jobs 4302 and 4304 reported `running` with an empty `agent_name`, escaping the pending-only admission lease and holding an otherwise-complete WFE roundtable until outer workflow recovery.

## Verification
- `go test ./internal/engine`
- `go test -race ./internal/engine`
- `go test ./...`
- roundtable review to convergence in progress: `oprun_g6a6056a23b3fd9c8_1784700410_5`