### PR TITLE
Declare plugin-loader descriptor ownership

### DIFF
--- a/docs/modules/plugin-loader.md
+++ b/docs/modules/plugin-loader.md
@@ -2,8 +2,8 @@
 
 ## Purpose and non-goals
 
-`plugin-loader` is the optional, default-disabled implementation for manifest discovery, installed-state
-management, and dynamic-library loading at `src/modules/plugin-loader/plugin_loader.c` and
+`plugin-loader` optionally owns default-disabled manifest discovery, installed-state management,
+and dynamic-library loading at `src/modules/plugin-loader/plugin_loader.c` and
 `src/modules/plugin-loader/plugin.c`. It does not own extension types, typed registries, or the
 pre-LLM hook contract; those remain required in
 [module-runtime](module-runtime.md#purpose-and-non-goals). It does not provide runtime unload.
@@ -55,6 +55,8 @@ When selected, the module provides the `plugin` CLI command, plugin-management H
 dashboard endpoints, the GUI plugin drawer, and manifest-provided hook/tool registrations. When
 omitted, the disabled profile has none of those surfaces and the GUI hides the drawer after capability probing.
 The exact absence proof is in `docs/validation/core-modularization-slice-11.md`.
+Slice 22 records the corresponding descriptor ownership and requires that established profile proof
+to remain green.
 
 ## Data and migrations
 
@@ -86,6 +88,10 @@ environment requirements, and project gating. `unit-test-plugin` covers manifest
 context registration, and loader lifecycle behavior in `src/tests/test_plugin.c`. Missing directories are empty results;
 malformed manifests, missing environment, and individual load failures are logged and skipped.
 Allocation failure reports an error while startup continues without discovered plugins.
+
+The descriptor assigns both tests to `plugin-loader` by primary behavior. Module-runtime calls in
+`test_plugin.c` are dependency setup for plugin manifest, persistence, and lifecycle behavior;
+module-runtime's focused ownership remains `src/tests/test_plugin_c_hook.c`.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-22.md
+++ b/docs/validation/core-modularization-slice-22.md
@@ -1,0 +1,41 @@
+# Core modularization slice 22: plugin-loader ownership
+
+## Scope
+
+This slice starts from `3cfff68e95674c0384883b9f6d358ff2f86db2a0` and enriches only the
+optional, default-disabled `plugin-loader` descriptor. It declares two sources, two public headers,
+two focused tests, and the canonical module document. It changes no schema, validator, build input,
+profile, source, test implementation, or runtime behavior.
+
+## Ownership decision
+
+`src/tests/test_plugin.c` belongs to `plugin-loader` because its primary behavior is manifest
+handling, installed-state persistence, context-backed plugin registration, and lifecycle behavior
+implemented by `plugin.c`. Its module-runtime calls are dependency setup, not a second ownership
+claim. `src/tests/test_plugin_c_hook.c` remains owned only by required `module-runtime`.
+
+The other focused test, `src/tests/test_plugin_loader.c`, directly exercises discovery, precedence,
+capacity, environment requirements, and project gating across both plugin-loader sources. No test
+split, dual ownership, checker exception, or inferred directory claim is introduced.
+
+## Liveness and build boundary
+
+The existing enabled profile compiles both sources and runs both declared tests. The default-off
+profile continues to prove the sources, symbols, management surfaces, and dynamic-loading behavior
+are physically absent. Descriptor ownership remains documentation and validation only; Make and
+CMake continue to select build inputs independently in this slice.
+
+## Completed local verification
+
+- `python3 -I -S scripts/validate_module_descriptors.py --check-schema src/modules`
+- `python3 -I -S scripts/validate_module_descriptors.py --emit-ownership src/modules`
+- `python3 -I scripts/tests/test_validate_module_descriptors.py -v`
+- `make -C src AIMEE_WITH_PLUGIN_LOADER=1 build/obj/tests/unit-test-plugin build/obj/tests/unit-test-plugin-loader`
+- `src/build/obj/tests/unit-test-plugin && src/build/obj/tests/unit-test-plugin-loader`
+- `make -C src lint`
+- `python3 -I -S scripts/check_cleanup_ledger.py`
+
+## Close-time gates
+
+- technical-writer review and exact-final-diff roundtable approval
+- feature-branch pull-request CI, including enabled/disabled plugin-loader profiles

--- a/src/modules/plugin-loader/module.yaml
+++ b/src/modules/plugin-loader/module.yaml
@@ -12,5 +12,20 @@
   "enabled_by_default": false,
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/plugin-loader/plugin.c",
+    "src/modules/plugin-loader/plugin_loader.c"
+  ],
+  "public_headers": [
+    "src/modules/plugin-loader/include/aimee/plugin-loader/plugin.h",
+    "src/modules/plugin-loader/include/aimee/plugin-loader/plugin_loader.h"
+  ],
+  "tests": [
+    "src/tests/test_plugin.c",
+    "src/tests/test_plugin_loader.c"
+  ],
+  "docs": [
+    "docs/modules/plugin-loader.md"
+  ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -278,6 +278,23 @@
       "blast_radius": "Only optional descriptor vocabulary and module-runtime inventory change; mutation tests cover each role, order, omission, missing and nonregular files, normalization, traversal, symlink rejection, local and cross-descriptor duplicates, cross-role claims, CLI output, and unrelated docs.",
       "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-21.md", "src/modules/module-runtime/module.yaml", "src/modules/module.schema.json", "scripts/validate_module_descriptors.py", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 22,
+      "state": "present_and_verified",
+      "disposition": "Enriched the optional plugin-loader descriptor with its two sources, two public headers, two primary-behavior tests, and canonical documentation without changing build or runtime behavior.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["Make and CMake remain authoritative build-input lists until descriptor-driven generation", "twenty-four descriptors still omit ownership fields pending focused family slices", "test_plugin.c retains module-runtime setup because no behavior defect justifies a test split"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata and documentation only, not shipped production code.",
+        "rejected_simpler_alternative": "Leaving test_plugin.c unclaimed would hide live plugin.c coverage, while dual ownership or a speculative test split would weaken the one-owner boundary.",
+        "revisit": "Split mixed tests only when a reproduced maintenance or behavior defect justifies changing fixtures and build wiring."
+      },
+      "consumers": ["descriptor validation CI", "plugin-loader maintainers", "future generated-build and ownership-completion slices"],
+      "blast_radius": "Only plugin-loader ownership metadata and its explanatory documentation change; enabled and default-off profile CI continue to prove liveness and physical omission.",
+      "independent_review": "Technical-writing and exact-final-diff roundtable review are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-22.md", "docs/modules/plugin-loader.md", "src/modules/plugin-loader/module.yaml"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- declare the optional plugin-loader sources, public headers, focused tests, and canonical documentation
- assign `test_plugin.c` by primary plugin-loader behavior while retaining `test_plugin_c_hook.c` under module-runtime
- document enabled liveness, default-off physical absence, and the deferred descriptor-driven build boundary

## Validation
- technical-writer approved
- exact staged-diff roundtable approved
- descriptor/schema suite and cleanup accounting pass
- enabled `unit-test-plugin` and `unit-test-plugin-loader` pass
- `make -C src lint` passes

## Scope
Metadata-only Slice 22; no schema, checker, build, source, test implementation, runtime, or profile changes.