### PR TITLE
fix(wfe): satisfy required persona from filled seats

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -609,16 +609,20 @@ func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats
 	feedback := wfe.ReviewFeedback{SchemaVersion: 1, ArtifactHash: artifactHash}
 	approvals, voters := 0, len(seats)
 	var cost float64
-	var unreachable []string
+	type requiredFailure struct {
+		seat panelSeat
+		err  error
+	}
+	var requiredFailures []requiredFailure
+	validPersona := make(map[string]bool)
 	for range seats {
 		o := <-ch
 		cost += o.cost
 		if o.err != nil {
 			if o.seat.required {
-				unreachable = append(unreachable, o.seat.persona+": "+o.err.Error())
-			} else {
-				voters--
+				requiredFailures = append(requiredFailures, requiredFailure{seat: o.seat, err: o.err})
 			}
+			voters--
 			continue
 		}
 		echoStage, echoOK := normalizeRoundtableStage(o.result.ArtifactStage)
@@ -628,6 +632,7 @@ func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats
 		}
 		alignment := strings.ToLower(strings.TrimSpace(o.result.OriginalRequestAlignment.Status))
 		alignmentOK := alignment == "aligned"
+		alignmentRecognized := alignmentOK || alignment == "drifted" || alignment == "unclear"
 		if !alignmentOK {
 			if alignment != "drifted" && alignment != "unclear" {
 				alignment = "unclear"
@@ -648,6 +653,7 @@ func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats
 			// The feedback finding already prevents advancement; also exclude this
 			// vote from quorum so the fail-closed invariant is local and explicit.
 			if alignmentOK {
+				validPersona[o.seat.persona] = true
 				approvals++
 			}
 			continue
@@ -656,9 +662,23 @@ func (r *NativeRunner) runPanelRound(ctx context.Context, req StepRequest, seats
 			feedback.Findings = append(feedback.Findings, wfe.Finding{ID: o.seat.persona + "-malformed", Persona: o.seat.persona, Severity: "blocking", Summary: "reviewer returned a contradictory or incomplete verdict", Recommendation: "return approve with no findings, or changes with actionable findings"})
 			continue
 		}
+		if alignmentRecognized {
+			validPersona[o.seat.persona] = true
+		}
 		for i, f := range o.result.Findings {
 			feedback.Findings = append(feedback.Findings, wfe.Finding{ID: firstNonempty(f.ID, fmt.Sprintf("%s-%d", o.seat.persona, i+1)), Persona: o.seat.persona, Severity: firstNonempty(f.Severity, "blocking"), Location: f.Location, Summary: f.Summary, Recommendation: f.Recommendation})
 		}
+	}
+	var unreachable []string
+	for _, failure := range requiredFailures {
+		// Required config names a review lens, not an exclusive agent. Capacity
+		// fill repeats those lenses, so any valid duplicate satisfies an unpinned
+		// required persona when its initially assigned slot loses admission. An
+		// explicit positive pin remains strict and cannot be substituted.
+		if !failure.seat.pinned && validPersona[failure.seat.persona] {
+			continue
+		}
+		unreachable = append(unreachable, failure.seat.persona+": "+failure.err.Error())
 	}
 	return feedback, approvals, voters, cost, strings.Join(unreachable, "; ")
 }

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -51,6 +51,21 @@ type scriptedReviewAgents struct {
 	responses []string
 }
 
+type firstPanelSeatUnavailableAgents struct {
+	response string
+}
+
+func (a firstPanelSeatUnavailableAgents) Delegate(_ context.Context, request DelegateRequest) (DelegateResult, error) {
+	if strings.HasSuffix(request.DurableSlot, "seat:0") {
+		return DelegateResult{}, errors.New("admission unavailable")
+	}
+	response := a.response
+	if response == "" {
+		response = `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`
+	}
+	return DelegateResult{Response: response}, nil
+}
+
 func (a *scriptedReviewAgents) Delegate(_ context.Context, _ DelegateRequest) (DelegateResult, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -540,6 +555,58 @@ func TestPanelCapacityAssignmentFallsBackWithoutWeakeningExplicitPin(t *testing.
 		[]panelSeat{{persona: "qa", delegate: "kimi", required: true, pinned: true}}, "review", "hash", "plan", 1)
 	if unreachable == "" || len(agents.requests) != 1 {
 		t.Fatalf("explicit pin was silently weakened: requests=%+v unreachable=%q", agents.requests, unreachable)
+	}
+}
+
+func TestRequiredPersonaCanUseSuccessfulCapacityDuplicate(t *testing.T) {
+	runner := &NativeRunner{agents: firstPanelSeatUnavailableAgents{}}
+	req := StepRequest{WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"}, Node: wfe.Node{ID: "gate"}}
+	seats := []panelSeat{
+		{persona: "security", delegate: "codex", required: true, ordinal: 0},
+		{persona: "security", delegate: "minimax", ordinal: 1},
+	}
+	feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), req, seats, "review", "hash", "plan", 1)
+	if unreachable != "" || approvals != 1 || voters != 1 || len(feedback.Findings) != 0 {
+		t.Fatalf("successful duplicate did not satisfy required persona: approvals=%d voters=%d unreachable=%q feedback=%+v", approvals, voters, unreachable, feedback)
+	}
+}
+
+func TestRequiredPinnedAgentCannotUseSuccessfulPersonaDuplicate(t *testing.T) {
+	runner := &NativeRunner{agents: firstPanelSeatUnavailableAgents{}}
+	req := StepRequest{WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"}, Node: wfe.Node{ID: "gate"}}
+	seats := []panelSeat{
+		{persona: "security", delegate: "codex", required: true, pinned: true, ordinal: 0},
+		{persona: "security", delegate: "minimax", ordinal: 1},
+	}
+	_, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), req, seats, "review", "hash", "plan", 1)
+	if unreachable == "" || approvals != 1 || voters != 1 {
+		t.Fatalf("explicit pin was substituted: approvals=%d voters=%d unreachable=%q", approvals, voters, unreachable)
+	}
+}
+
+func TestMalformedCapacityDuplicateCannotSatisfyRequiredPersona(t *testing.T) {
+	runner := &NativeRunner{agents: firstPanelSeatUnavailableAgents{response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned"},"verdict":"approve","findings":[{"id":"contradiction","summary":"approve with finding"}]}`}}
+	req := StepRequest{WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"}, Node: wfe.Node{ID: "gate"}}
+	seats := []panelSeat{
+		{persona: "security", delegate: "codex", required: true, ordinal: 0},
+		{persona: "security", delegate: "minimax", ordinal: 1},
+	}
+	_, _, voters, _, unreachable := runner.runPanelRound(context.Background(), req, seats, "review", "hash", "plan", 1)
+	if unreachable == "" || voters != 1 {
+		t.Fatalf("malformed duplicate satisfied required persona: voters=%d unreachable=%q", voters, unreachable)
+	}
+}
+
+func TestValidChangesDuplicateSatisfiesRequiredPersona(t *testing.T) {
+	runner := &NativeRunner{agents: firstPanelSeatUnavailableAgents{response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"direction is right"},"verdict":"changes","findings":[{"id":"detail","severity":"blocking","summary":"add detail","recommendation":"specify the step"}]}`}}
+	req := StepRequest{WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"}, Node: wfe.Node{ID: "gate"}}
+	seats := []panelSeat{
+		{persona: "security", delegate: "codex", required: true, ordinal: 0},
+		{persona: "security", delegate: "minimax", ordinal: 1},
+	}
+	feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), req, seats, "review", "hash", "plan", 1)
+	if unreachable != "" || approvals != 0 || voters != 1 || len(feedback.Findings) != 1 {
+		t.Fatalf("valid changes did not satisfy required persona: approvals=%d voters=%d unreachable=%q feedback=%+v", approvals, voters, unreachable, feedback)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow a valid duplicate capacity seat to satisfy the same unpinned required persona
- remove every failed seat from quorum accounting
- preserve strict failure semantics for explicit positive agent pins

## Live failure
A normal WFE `rt_gate` completed 15 of 16 seats. The only missing seat was an unassigned required capacity assignment; another filled seat with the same configured persona succeeded, but the runner discarded that evidence and parked the whole panel as unreachable.

## Verification
- focused required-persona and pin tests
- `go test ./internal/engine`
- `go test -race ./internal/engine`
- roundtable convergence: `oprun_g6a606180116fc947_1784702637_13`