### PR TITLE
fix(wfe): cancel running unassigned delegate jobs

### DIFF
--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -165,19 +165,28 @@ func (s *Store) ForgetDelegateJobIfMatches(ctx context.Context, key string, jobI
 	return changed == 1, err
 }
 
-// CancelUnassignedDelegateJob atomically reaps a nonterminal resource-plane job
-// that no agent has claimed. The C compatibility worker can take its queue lease
-// and mark a row running before an eligible agent is assigned, so status alone is
-// not evidence of admission. The agent-name predicate prevents a lease race from
-// cancelling work after assignment; db1_agent_job_set_agent uses the reciprocal
-// status != 'cancelled' predicate, so whichever atomic update wins closes the race.
-func (s *Store) CancelUnassignedDelegateJob(ctx context.Context, jobID int, reason string) (bool, error) {
+// CancelUnassignedDelegateJob returns true only when this call atomically moves
+// an expired, nonterminal, unassigned job to cancelled. The C compatibility
+// worker can mark a row running before assignment, so status alone is not
+// admission. Its db1_agent_job_set_agent update is reciprocal (`WHERE id = ? AND
+// status != 'cancelled'`): whichever SQLite update wins prevents the other.
+func (s *Store) CancelUnassignedDelegateJob(ctx context.Context, jobID int, reason string, minAge time.Duration) (bool, error) {
 	if jobID <= 0 {
 		return false, errors.New("delegate job id is required")
 	}
+	if minAge <= 0 {
+		return false, errors.New("delegate minimum unassigned age is required")
+	}
+	cutoff := time.Now().UTC().Add(-minAge).Format("2006-01-02 15:04:05")
 	result, err := s.db.ExecContext(ctx, `UPDATE agent_jobs
-SET status='cancelled',cancelled_at=datetime('now'),cancel_reason=?,updated_at=datetime('now')
-WHERE id=? AND status IN ('pending','running') AND trim(agent_name)=''`, reason, jobID)
+SET status='cancelled',
+    cancelled_at=datetime('now'),
+    cancel_reason=?,
+    updated_at=datetime('now')
+WHERE id=?
+  AND status IN ('pending','running')
+  AND trim(agent_name)=''
+  AND COALESCE(NULLIF(heartbeat_at,''),created_at) <= ?`, reason, jobID, cutoff)
 	if err != nil {
 		return false, fmt.Errorf("cancel unassigned delegate job: %w", err)
 	}

--- a/server-go/internal/db1/store.go
+++ b/server-go/internal/db1/store.go
@@ -165,16 +165,19 @@ func (s *Store) ForgetDelegateJobIfMatches(ctx context.Context, key string, jobI
 	return changed == 1, err
 }
 
-// CancelUnassignedDelegateJob atomically reaps only a pending resource-plane job
-// that no agent has claimed. The predicate prevents a lease race from cancelling
-// work after assignment.
+// CancelUnassignedDelegateJob atomically reaps a nonterminal resource-plane job
+// that no agent has claimed. The C compatibility worker can take its queue lease
+// and mark a row running before an eligible agent is assigned, so status alone is
+// not evidence of admission. The agent-name predicate prevents a lease race from
+// cancelling work after assignment; db1_agent_job_set_agent uses the reciprocal
+// status != 'cancelled' predicate, so whichever atomic update wins closes the race.
 func (s *Store) CancelUnassignedDelegateJob(ctx context.Context, jobID int, reason string) (bool, error) {
 	if jobID <= 0 {
 		return false, errors.New("delegate job id is required")
 	}
 	result, err := s.db.ExecContext(ctx, `UPDATE agent_jobs
 SET status='cancelled',cancelled_at=datetime('now'),cancel_reason=?,updated_at=datetime('now')
-WHERE id=? AND status='pending' AND agent_name=''`, reason, jobID)
+WHERE id=? AND status IN ('pending','running') AND trim(agent_name)=''`, reason, jobID)
 	if err != nil {
 		return false, fmt.Errorf("cancel unassigned delegate job: %w", err)
 	}

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -304,25 +304,30 @@ func TestCancelUnassignedDelegateJobIsAtomicAndAssignmentSafe(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := store.db.Exec(`INSERT INTO agent_jobs(id,status,agent_name) VALUES
-		(41,'pending',''),(42,'pending','codex'),(43,'running','codex'),(44,'pending',' ')`); err != nil {
+		(41,'pending',''),(42,'pending','codex'),(43,'running','codex'),(44,'pending',' '),
+		(45,'running',''),(46,'done',''),(47,'failed',''),(48,'cancelled','')`); err != nil {
 		t.Fatal(err)
 	}
-	cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), 41, "lease expired")
-	if err != nil || !cancelled {
-		t.Fatalf("cancel pending unassigned: cancelled=%v err=%v", cancelled, err)
-	}
-	for _, id := range []int{42, 43, 44} {
-		cancelled, err = store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired")
-		if err != nil || cancelled {
-			t.Fatalf("job %d assignment guard: cancelled=%v err=%v", id, cancelled, err)
+	for _, id := range []int{41, 44, 45} {
+		cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired")
+		if err != nil || !cancelled {
+			t.Fatalf("cancel unassigned job %d: cancelled=%v err=%v", id, cancelled, err)
 		}
 	}
-	var status, reason string
-	if err := store.db.QueryRow(`SELECT status,cancel_reason FROM agent_jobs WHERE id=41`).Scan(&status, &reason); err != nil {
-		t.Fatal(err)
+	for _, id := range []int{42, 43, 46, 47, 48} {
+		cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired")
+		if err != nil || cancelled {
+			t.Fatalf("job %d assignment/terminal guard: cancelled=%v err=%v", id, cancelled, err)
+		}
 	}
-	if status != "cancelled" || reason != "lease expired" {
-		t.Fatalf("status=%q reason=%q", status, reason)
+	for _, id := range []int{41, 44, 45} {
+		var status, reason string
+		if err := store.db.QueryRow(`SELECT status,cancel_reason FROM agent_jobs WHERE id=?`, id).Scan(&status, &reason); err != nil {
+			t.Fatal(err)
+		}
+		if status != "cancelled" || reason != "lease expired" {
+			t.Fatalf("job %d status=%q reason=%q", id, status, reason)
+		}
 	}
 }
 

--- a/server-go/internal/db1/store_test.go
+++ b/server-go/internal/db1/store_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func newTestStore(t *testing.T) *Store {
@@ -295,10 +296,11 @@ func TestChangedPlanOrFeedbackIsPositiveProgress(t *testing.T) {
 	}
 }
 
-func TestCancelUnassignedDelegateJobIsAtomicAndAssignmentSafe(t *testing.T) {
+func TestCancelUnassignedDelegateJobPredicateTruthTable(t *testing.T) {
 	store := newTestStore(t)
 	_, err := store.db.Exec(`CREATE TABLE agent_jobs (
 		id INTEGER PRIMARY KEY, agent_name TEXT NOT NULL DEFAULT '', status TEXT NOT NULL,
+		heartbeat_at TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT '',
 		cancelled_at TEXT DEFAULT '', cancel_reason TEXT DEFAULT '', updated_at TEXT DEFAULT '')`)
 	if err != nil {
 		t.Fatal(err)
@@ -308,14 +310,17 @@ func TestCancelUnassignedDelegateJobIsAtomicAndAssignmentSafe(t *testing.T) {
 		(45,'running',''),(46,'done',''),(47,'failed',''),(48,'cancelled','')`); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := store.db.Exec(`UPDATE agent_jobs SET created_at=datetime('now','-2 hours'), heartbeat_at=CASE WHEN status='running' THEN datetime('now','-2 hours') ELSE '' END`); err != nil {
+		t.Fatal(err)
+	}
 	for _, id := range []int{41, 44, 45} {
-		cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired")
+		cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired", time.Hour)
 		if err != nil || !cancelled {
 			t.Fatalf("cancel unassigned job %d: cancelled=%v err=%v", id, cancelled, err)
 		}
 	}
 	for _, id := range []int{42, 43, 46, 47, 48} {
-		cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired")
+		cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired", time.Hour)
 		if err != nil || cancelled {
 			t.Fatalf("job %d assignment/terminal guard: cancelled=%v err=%v", id, cancelled, err)
 		}
@@ -327,6 +332,78 @@ func TestCancelUnassignedDelegateJobIsAtomicAndAssignmentSafe(t *testing.T) {
 		}
 		if status != "cancelled" || reason != "lease expired" {
 			t.Fatalf("job %d status=%q reason=%q", id, status, reason)
+		}
+	}
+}
+
+func TestCancelUnassignedDelegateJobRequiresExpiredLease(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.db.Exec(`CREATE TABLE agent_jobs (
+		id INTEGER PRIMARY KEY, agent_name TEXT NOT NULL DEFAULT '', status TEXT NOT NULL,
+		heartbeat_at TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT (datetime('now')),
+		cancelled_at TEXT DEFAULT '', cancel_reason TEXT DEFAULT '', updated_at TEXT DEFAULT '')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`INSERT INTO agent_jobs(id,status,agent_name,heartbeat_at) VALUES (49,'running','',datetime('now'))`); err != nil {
+		t.Fatal(err)
+	}
+	cancelled, err := store.CancelUnassignedDelegateJob(t.Context(), 49, "lease expired", time.Hour)
+	if err != nil || cancelled {
+		t.Fatalf("fresh running job cancelled=%v err=%v", cancelled, err)
+	}
+}
+
+func TestCancelUnassignedDelegateJobRacesAssignment(t *testing.T) {
+	store := newTestStore(t)
+	_, err := store.db.Exec(`CREATE TABLE agent_jobs (
+		id INTEGER PRIMARY KEY, agent_name TEXT NOT NULL DEFAULT '', status TEXT NOT NULL,
+		heartbeat_at TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL DEFAULT '',
+		cancelled_at TEXT DEFAULT '', cancel_reason TEXT DEFAULT '', updated_at TEXT DEFAULT '')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for id := 100; id < 150; id++ {
+		if _, err := store.db.Exec(`INSERT INTO agent_jobs(id,status,agent_name,heartbeat_at,created_at) VALUES (?,'running','','2000-01-01 00:00:00','2000-01-01 00:00:00')`, id); err != nil {
+			t.Fatal(err)
+		}
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		var cancelled bool
+		var cancelErr, assignErr error
+		var assigned int64
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			cancelled, cancelErr = store.CancelUnassignedDelegateJob(t.Context(), id, "lease expired", time.Hour)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			result, err := store.db.ExecContext(t.Context(), `UPDATE agent_jobs SET agent_name='codex' WHERE id=? AND status != 'cancelled'`, id)
+			assignErr = err
+			if err == nil {
+				assigned, assignErr = result.RowsAffected()
+			}
+		}()
+		close(start)
+		wg.Wait()
+		if cancelErr != nil || assignErr != nil {
+			t.Fatalf("iteration %d cancel_err=%v assign_err=%v", id, cancelErr, assignErr)
+		}
+		if (cancelled && assigned != 0) || (!cancelled && assigned != 1) {
+			t.Fatalf("iteration %d cancelled=%v assigned=%d", id, cancelled, assigned)
+		}
+		var status, agent string
+		if err := store.db.QueryRow(`SELECT status,agent_name FROM agent_jobs WHERE id=?`, id).Scan(&status, &agent); err != nil {
+			t.Fatal(err)
+		}
+		if cancelled && (status != "cancelled" || agent != "") {
+			t.Fatalf("iteration %d cancelled final status=%q agent=%q", id, status, agent)
+		}
+		if !cancelled && (status != "running" || agent != "codex") {
+			t.Fatalf("iteration %d assigned final status=%q agent=%q", id, status, agent)
 		}
 	}
 }

--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -85,7 +85,7 @@ type AgentHTTPConfig struct {
 	RequestTimeout       time.Duration
 	PendingTimeout       time.Duration
 	PendingTimeoutSource func() time.Duration
-	CancelUnassigned     func(context.Context, int, string) (bool, error)
+	CancelUnassigned     func(context.Context, int, string, time.Duration) (bool, error)
 	Store                *db1.Store
 }
 
@@ -108,7 +108,7 @@ type HTTPAgentClient struct {
 	client           *http.Client
 	pollEvery        time.Duration
 	pendingTimeout   func() time.Duration
-	cancelUnassigned func(context.Context, int, string) (bool, error)
+	cancelUnassigned func(context.Context, int, string, time.Duration) (bool, error)
 	store            *db1.Store
 }
 
@@ -310,7 +310,7 @@ func isTerminalDelegateStatus(status string) bool {
 func (c *HTTPAgentClient) expireUnassigned(jobID int, key string, since time.Time) error {
 	if c.cancelUnassigned != nil {
 		cancelCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		cancelled, err := c.cancelUnassigned(cancelCtx, jobID, "unassigned delegate lease expired")
+		cancelled, err := c.cancelUnassigned(cancelCtx, jobID, "unassigned delegate lease expired", c.delegatePendingTimeout())
 		cancel()
 		if err != nil {
 			return errors.Join(ErrDelegateUnassignedExpired, fmt.Errorf("cancel expired delegate job %d: %w", jobID, err))

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -391,7 +391,7 @@ func TestHTTPAgentClientExpiresUnassignedPendingJob(t *testing.T) {
 	defer server.Close()
 	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
 		PollEvery: time.Millisecond, PendingTimeout: 20 * time.Millisecond,
-		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+		CancelUnassigned: func(context.Context, int, string, time.Duration) (bool, error) {
 			cancellations.Add(1)
 			return true, nil
 		}})
@@ -442,7 +442,7 @@ func TestHTTPAgentClientExpiresUnassignedRunningJob(t *testing.T) {
 	defer server.Close()
 	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
 		PollEvery: time.Millisecond, PendingTimeout: 20 * time.Millisecond,
-		CancelUnassigned: func(_ context.Context, jobID int, reason string) (bool, error) {
+		CancelUnassigned: func(_ context.Context, jobID int, reason string, _ time.Duration) (bool, error) {
 			cancellations.Add(1)
 			cancelledJobID.Store(int64(jobID))
 			cancelReasonMu.Lock()
@@ -503,7 +503,7 @@ func TestHTTPAgentClientAssignedObservationClearsUnassignedLease(t *testing.T) {
 	defer server.Close()
 	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
 		PollEvery: time.Millisecond, PendingTimeout: MinDelegatePendingTimeout,
-		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+		CancelUnassigned: func(context.Context, int, string, time.Duration) (bool, error) {
 			cancellations.Add(1)
 			return true, nil
 		}})
@@ -544,7 +544,7 @@ func TestHTTPAgentClientTerminalEmptyAgentDoesNotExpire(t *testing.T) {
 	defer server.Close()
 	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
 		PollEvery: time.Millisecond, PendingTimeout: MinDelegatePendingTimeout,
-		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+		CancelUnassigned: func(context.Context, int, string, time.Duration) (bool, error) {
 			cancellations.Add(1)
 			return true, nil
 		}})
@@ -631,7 +631,7 @@ func TestHTTPAgentClientExpiresAfterTransientStatusFailures(t *testing.T) {
 	defer server.Close()
 	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
 		PollEvery: time.Millisecond, PendingTimeout: 20 * time.Millisecond,
-		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+		CancelUnassigned: func(context.Context, int, string, time.Duration) (bool, error) {
 			cancellations.Add(1)
 			return true, nil
 		}})
@@ -666,7 +666,7 @@ func TestHTTPAgentClientRetainsMappingWhenExpiryCancellationFails(t *testing.T) 
 	}))
 	defer server.Close()
 	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store,
-		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+		CancelUnassigned: func(context.Context, int, string, time.Duration) (bool, error) {
 			return false, errors.New("agent job database unavailable")
 		}})
 	if err != nil {
@@ -692,7 +692,7 @@ func TestHTTPAgentClientRetainsMappingWhenExpiryCancellationRejected(t *testing.
 	defer store.Close()
 	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: "http://127.0.0.1",
 		Store: store,
-		CancelUnassigned: func(context.Context, int, string) (bool, error) {
+		CancelUnassigned: func(context.Context, int, string, time.Duration) (bool, error) {
 			return false, nil
 		}})
 	if err != nil {

--- a/src/Makefile
+++ b/src/Makefile
@@ -1219,6 +1219,11 @@ $(OBJDIR)/server/server_mcp.o: server/server_mcp.c server/server_mcp_call_table.
 	@mkdir -p $(dir $@)
 	$(CC) -c $(C_FLAGS) -o $@ $<
 
+# These translation units include the generated help payload directly too. Keep
+# the dependency explicit so a clean parallel build cannot compile them before
+# agent_help_data.h has been atomically generated.
+$(OBJDIR)/server/server_mcp_call_table.o $(OBJDIR)/server/server_mcp_ast_grep.o: agent_help_data.h
+
 TOOL_PROMPT_FILES := $(sort $(wildcard tool_prompts/*.md))
 
 tool_prompts_data.h: $(TOOL_PROMPT_FILES) gen_tool_prompts.py


### PR DESCRIPTION
## Summary
- cancel expired `running` delegate jobs that still have no assigned agent
- enforce the live configured minimum lease age inside the atomic SQLite transition
- prove assignment/cancellation mutual exclusion with a repeated concurrent regression
- fix the clean parallel Docker-build race for generated `agent_help_data.h`

## Why
The compatibility worker can mark a delegate row `running` before agent assignment. Go classified that state as unassigned, but the old cancellation SQL only accepted `pending`, leaving panels blocked forever after the configured lease. While validating this fix, T2 exposed missing Make prerequisites for two translation units that directly include the generated MCP help header.

## Verification
- `go test ./...`
- `go test -race ./internal/engine ./internal/db1`
- clean absent-header parallel build of both MCP objects
- repository verification: 2 passed, 0 failed
- roundtable convergence rerun after applying its two upheld blockers

Original request alignment: removes indefinite delegate admission and a clean-build race from unattended normal proposal trigger-to-final_pr while advancing Go-owned WFE recovery.