### PR TITLE
Fix WFE full-panel admission contention

### DIFF
--- a/server-go/internal/engine/agent_client.go
+++ b/server-go/internal/engine/agent_client.go
@@ -99,6 +99,7 @@ const (
 
 var ErrDelegateUnassignedExpired = errors.New("unassigned delegate lease expired")
 var ErrDelegateCancelUnacknowledged = errors.New("delegate cancellation was not acknowledged")
+var ErrDelegateNoJobID = errors.New("agent service returned no job id")
 
 // HTTPAgentClient talks to the agent service as a resource plane. It owns no
 // workflow state or transitions; losing it parks the Go-owned run and a later
@@ -191,14 +192,30 @@ func (c *HTTPAgentClient) Delegate(ctx context.Context, request DelegateRequest)
 		if err := c.doJSONKey(ctx, http.MethodPost, "/v1/delegate/run", payload, &launched, key); err != nil {
 			return DelegateResult{}, err
 		}
+		// Validate before SaveDelegateJob: a phantom mapping would make every
+		// retry replay an invalid launch instead of recovering when capacity returns.
+		if launched.JobID <= 0 {
+			detail := strings.TrimSpace(safeDiagnostic(launched.Error))
+			if detail == "" {
+				detail = "empty launch response"
+			} else {
+				var printable strings.Builder
+				for _, r := range detail {
+					if r < ' ' || r == 0x7f {
+						_, _ = fmt.Fprintf(&printable, `\x%02x`, r)
+						continue
+					}
+					printable.WriteRune(r)
+				}
+				detail = printable.String()
+			}
+			return DelegateResult{}, fmt.Errorf("%w: %s", ErrDelegateNoJobID, detail)
+		}
 		if c.store != nil && request.WorkItemID != "" {
 			if err := c.store.SaveDelegateJob(ctx, key, launched.JobID); err != nil {
 				return DelegateResult{}, err
 			}
 		}
-	}
-	if launched.JobID <= 0 {
-		return DelegateResult{}, fmt.Errorf("agent service returned no job id: %s", launched.Error)
 	}
 	ticker := time.NewTicker(c.pollEvery)
 	defer ticker.Stop()

--- a/server-go/internal/engine/agent_client_test.go
+++ b/server-go/internal/engine/agent_client_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -307,6 +308,74 @@ func TestHTTPAgentClientAcceptsNonemptyPartialResult(t *testing.T) {
 	result, err := client.Delegate(t.Context(), DelegateRequest{Role: "code", Persona: "engineer", Prompt: "implement", acceptPartial: true})
 	if err != nil || result.Response != "commit already created" || result.Agent != "minimax" || !result.Partial {
 		t.Fatalf("result=%+v err=%v", result, err)
+	}
+}
+
+func TestHTTPAgentClientRejectsLaunchWithoutJobID(t *testing.T) {
+	store, err := db1.Open(filepath.Join(t.TempDir(), "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var launches atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		launches.Add(1)
+		if r.URL.Path != "/v1/delegate/run" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "no\neligible\tcapacity"})
+	}))
+	defer server.Close()
+	for _, tc := range []struct {
+		name    string
+		store   *db1.Store
+		request DelegateRequest
+	}{
+		{name: "durable", store: store, request: DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review", WorkItemID: "wi_no_capacity", Stage: "gate", ExecutionVersion: "v1"}},
+		{name: "without durable mapping", request: DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, clientErr := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: tc.store})
+			if clientErr != nil {
+				t.Fatal(clientErr)
+			}
+			_, callErr := client.Delegate(t.Context(), tc.request)
+			if !errors.Is(callErr, ErrDelegateNoJobID) || !strings.Contains(callErr.Error(), `no\x0aeligible\x09capacity`) {
+				t.Fatalf("launch error=%v", callErr)
+			}
+		})
+	}
+	request := DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review",
+		WorkItemID: "wi_no_capacity", Stage: "gate", ExecutionVersion: "v1"}
+	if jobID, lookupErr := store.DelegateJob(t.Context(), delegateJobKey(request)); !errors.Is(lookupErr, sql.ErrNoRows) {
+		t.Fatalf("invalid launch mapping job=%d err=%v", jobID, lookupErr)
+	}
+	client, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: server.URL, Store: store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if _, retryErr := client.Delegate(t.Context(), request); !errors.Is(retryErr, ErrDelegateNoJobID) {
+			t.Fatalf("retry error=%v", retryErr)
+		}
+	}
+	// Two subtests above and two explicit retries must each reach the resource
+	// plane; no invalid durable mapping may short-circuit a later attempt.
+	if launches.Load() != 4 {
+		t.Fatalf("launches=%d, want 4", launches.Load())
+	}
+	emptyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer emptyServer.Close()
+	emptyClient, err := NewHTTPAgentClient(AgentHTTPConfig{BaseURL: emptyServer.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = emptyClient.Delegate(t.Context(), DelegateRequest{Role: "review", Persona: "reviewer", Prompt: "review"})
+	if !errors.Is(err, ErrDelegateNoJobID) || !strings.Contains(err.Error(), "empty launch response") {
+		t.Fatalf("empty launch error=%v", err)
 	}
 }
 

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/JBailes/aimee/server-go/internal/db1"
@@ -54,7 +55,14 @@ type NativeRunner struct {
 	forge     Forge
 }
 
-const roundtableDelegateRole = "review"
+const (
+	roundtableDelegateRole   = "review"
+	pauseReasonPanelCapacity = "panel_capacity"
+)
+
+// A roundtable consumes the complete live review roster, so admission belongs
+// to the Go control plane rather than to any workflow or runner instance.
+var fullPanelAdmission = make(chan struct{}, 1)
 
 func (r *NativeRunner) delegate(ctx context.Context, step StepRequest, request DelegateRequest) (DelegateResult, error) {
 	request.WorkItemID = step.WorkItem.ID
@@ -519,6 +527,11 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 	if maxRounds < 1 {
 		maxRounds = 1
 	}
+	release, admitted := tryAcquirePanelAdmission()
+	if !admitted {
+		return StepResult{Status: StepPending, PauseReason: pauseReasonPanelCapacity, Detail: "another full-capacity roundtable is active"}, nil
+	}
+	defer release()
 	var totalCost float64
 	var prior string
 	for round := 1; round <= maxRounds; round++ {
@@ -545,6 +558,23 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 		prior = string(encoded)
 	}
 	return StepResult{}, errors.New("roundtable exhausted without a verdict")
+}
+
+func tryAcquirePanelAdmission() (func(), bool) {
+	select {
+	case fullPanelAdmission <- struct{}{}:
+		var once sync.Once
+		return func() {
+			once.Do(func() {
+				select {
+				case <-fullPanelAdmission:
+				default:
+				}
+			})
+		}, true
+	default:
+		return nil, false
+	}
 }
 
 func roundtableStageGuidance(stage string) string {

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -476,6 +476,23 @@ func TestFillPanelCapacityRepeatsAllRequiredLensesWithoutWeakeningThem(t *testin
 	}
 }
 
+func TestPanelAdmissionIsControlPlaneWide(t *testing.T) {
+	release, admitted := tryAcquirePanelAdmission()
+	if !admitted {
+		t.Fatal("first panel was not admitted")
+	}
+	if _, admitted = tryAcquirePanelAdmission(); admitted {
+		t.Fatal("overlapping full-capacity panel was admitted")
+	}
+	release()
+	release() // The successful acquisition returns an idempotent release closure.
+	release, admitted = tryAcquirePanelAdmission()
+	if !admitted {
+		t.Fatal("panel capacity was not released")
+	}
+	release()
+}
+
 func TestFillPanelCapacityCyclesEveryConfiguredLensInMixedPanel(t *testing.T) {
 	seats, err := fillPanelCapacity([]panelSeat{
 		{persona: "security", required: true},

--- a/server-go/internal/engine/scheduler.go
+++ b/server-go/internal/engine/scheduler.go
@@ -114,7 +114,7 @@ func (s *Scheduler) fill(ctx context.Context) {
 			}
 		}
 	}
-	for reason, backoff := range map[string]time.Duration{"runner_unavailable": 5 * time.Second, "ci_pending": 15 * time.Second, "merge_pending": 15 * time.Second, "panel_unreachable": 60 * time.Second} {
+	for reason, backoff := range map[string]time.Duration{"runner_unavailable": 5 * time.Second, "ci_pending": 15 * time.Second, "merge_pending": 15 * time.Second, "panel_unreachable": 60 * time.Second, pauseReasonPanelCapacity: 15 * time.Second} {
 		if resumed, err := s.db.ResumeTransient(ctx, reason, backoff); err != nil {
 			s.log.Error("resume transient workflows", "reason", reason, "error", err)
 		} else if resumed > 0 {


### PR DESCRIPTION
## What changed

- serialize full-roster WFE roundtables at the Go control-plane boundary
- park losing panels as transient `panel_capacity` work so scheduler slots remain available
- reject no-job-ID delegate launches before durable persistence
- preserve complete provider diagnostics while redacting secrets and reversibly escaping controls
- cover process-wide admission, idempotent release, durable retry, and empty launch responses

## Root cause

Every concurrent WFE roundtable independently expanded to the entire enabled agent roster. Multiple panels therefore launched more seats than live admission could satisfy, timed out required participants, and retried together. A resource-plane 200 response without a job ID could also surface an internal persistence-validation error before the real capacity diagnostic.

## Impact

Only one full-capacity WFE panel runs at once. Other workflows immediately release their worker slot and retry after a transient backoff, allowing unrelated normal proposals to keep entering and advancing.

## Validation

- `go test ./...`
- `go test -race ./internal/engine ./internal/db1`
- `go vet ./...`
- multi-round roundtable review with original-request alignment