### PR TITLE
Assign audit test ownership

### DIFF
--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -82,15 +82,34 @@ stores produce the same canonical row hashes, but remain independently enabled, 
 
 ## Tests and failure behavior
 
-`test_audit_action.c`, `test_audit_action_log.c`, `test_audit_ledger.c`, `test_audit_worm.c`,
-`test_audit_worm_chain.c`, `test_kb_audit_worm.c`, and vault/management audit suites cover bounded
-evidence, reads, chains, checkpoints, mutation rejection, and store consumers. Current governed-action
-emission is best-effort: hashing writes a stable sentinel on failure, and WORM loss does not block the
-action while legacy logging is authoritative.
+The descriptor owns the four tests that directly exercise audit module implementations. Similarly
+named tests remain with their actual subsystem or integration boundary; a filename containing
+`audit` is not ownership evidence.
 
-The descriptor records an explicit empty test list as deferred cross-boundary ownership, tracked by
-issue #1753 across server, KB, vault, management, and storage integration tests; it does not imply
-that audit lacks live test coverage.
+| Test | Boundary exercised | Audit ownership |
+| --- | --- | --- |
+| `test_audit_action.c` | `audit_args_hash`, key provisioning, HMAC vectors, and bounded command previews from `audit_action.c` | Owned |
+| `test_audit_ledger.c` | `audit_ledger_read` parsing, ordering, rotation, filtering, and malformed-input handling from `audit_ledger.c` | Owned |
+| `test_audit_worm.c` | SQLite append/read, mutation rejection, checkpoints, sealing, paging, and verification from `audit_worm.c`; consumes the shared chain | Owned |
+| `test_audit_worm_chain.c` | Engine-independent row serialization, hashing, hex encoding, and checkpoint MAC invariants from `audit_worm_chain.c` | Owned |
+| `test_audit_action_log.c` | The core `log.c` JSON-line writer and `audit_action_log` API | Not assigned; no audit module implementation is under test |
+| `test_code_audit.c` | The independent CLI code-audit feature | Not assigned; code-health analysis is not the audit evidence module |
+| `test_code_audit_graph.c` | The independent code-audit graph algorithms | Not assigned; code-health analysis is not the audit evidence module |
+| `test_db2_code_audit.c` | DB2 code-audit assembly and PostgreSQL query shims | Not assigned; this is a DB2 code-intelligence test |
+| `test_harness_memory_audit.c` | Memory-interception JSONL logging through `hmem_audit` | Not assigned; this is a memory harness test |
+| `test_kb_audit_worm.c` | The KB PostgreSQL store and artifact capture seam, using the shared chain contract | Not assigned; this is a mixed KB/store integration test |
+| `test_kb_audit_worm_pg.c` | SQL and C append parity against a real PostgreSQL KB store | Not assigned; this is a mixed KB/PostgreSQL integration test |
+| `test_token_audit.c` | DB1 token accounting and agent ingress attribution | Not assigned; this is a DB1/agent-accounting test |
+| `test_token_audit_load.c` | Concurrent DB1 token writes and asynchronous ingress recording | Not assigned; this is a DB1/agent-ingress load test |
+| `test_vault_audit.c` | Vault-to-server audit emission through the core log | Not assigned; this is a vault/server/log integration test |
+
+The direct tests deliberately separate the shared chain primitive from the SQLite store that consumes
+it. That is complementary coverage, not duplicate ownership. The CMake suite registers the action and
+ledger tests; the Make unit-test suite registers the WORM store and chain tests. Issue #1753 records the
+evidence used to resolve this classification.
+
+Current governed-action emission is best-effort: hashing writes a stable sentinel on failure, and WORM
+loss does not block the action while legacy logging is authoritative.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-24.md
+++ b/docs/validation/core-modularization-slice-24.md
@@ -1,0 +1,108 @@
+# Core modularization slice 24: audit test ownership
+
+## Scope
+
+This slice starts from `913fbdbcf94e8defc45df2d220582fe95846e6d5` and resolves issue #1753 by
+assigning one canonical owner to the tests that directly exercise the required `audit` module. It
+changes ownership metadata and documentation only. No production source, public header, test source,
+build registration, runtime behavior, storage behavior, configuration, route, schema, or module
+dependency changes.
+
+`src/modules/audit/module.yaml` now claims exactly these four existing tests:
+
+- `src/tests/test_audit_action.c`
+- `src/tests/test_audit_ledger.c`
+- `src/tests/test_audit_worm.c`
+- `src/tests/test_audit_worm_chain.c`
+
+The first two directly exercise `audit_action.c` and `audit_ledger.c`. The WORM-chain test pins the
+engine-independent serialization, hash, and checkpoint-MAC primitives, while the WORM test exercises
+the SQLite store's append, read, checkpoint, seal, tamper, paging, and verification behavior. The
+store consumes the chain, but the two tests protect distinct contracts.
+
+## Complete filename audit
+
+The on-disk inventory command
+
+```text
+find src/tests -maxdepth 1 -type f -name '*audit*.c' -print | sort
+```
+
+returned these 14 files, all represented in `docs/modules/audit.md`:
+
+1. `src/tests/test_audit_action.c` — audit-owned action primitive
+2. `src/tests/test_audit_action_log.c` — core log writer
+3. `src/tests/test_audit_ledger.c` — audit-owned ledger reader
+4. `src/tests/test_audit_worm.c` — audit-owned SQLite WORM store
+5. `src/tests/test_audit_worm_chain.c` — audit-owned shared chain primitive
+6. `src/tests/test_code_audit.c` — independent CLI code-audit feature
+7. `src/tests/test_code_audit_graph.c` — independent code-audit graph feature
+8. `src/tests/test_db2_code_audit.c` — DB2 code-audit assembly
+9. `src/tests/test_harness_memory_audit.c` — memory interception logging
+10. `src/tests/test_kb_audit_worm.c` — mixed KB/store integration
+11. `src/tests/test_kb_audit_worm_pg.c` — mixed KB/PostgreSQL integration
+12. `src/tests/test_token_audit.c` — DB1 token accounting and agent ingress
+13. `src/tests/test_token_audit_load.c` — DB1 token/ingress concurrency
+14. `src/tests/test_vault_audit.c` — vault/server/log integration
+
+Only items 1, 3, 4, and 5 are assigned to the audit descriptor. The other filenames use “audit” in a
+different subsystem or cross a storage/runtime integration boundary; they are not dual-claimed.
+
+## Existing enforcement and build evidence
+
+No new checker is needed. `scripts/validate_module_descriptors.py` already requires each test claim to
+be a normalized, repository-relative, existing regular file below `src/tests`, with the `test_`
+convention and an allowed test extension. It also rejects duplicates within a descriptor, cross-role
+claims, and duplicate ownership across descriptors. Its existing failure-mode suite covers those
+rules.
+
+Build registration is unchanged:
+
+- `src/tests/CMakeLists.txt` registers `test_audit_action` and `test_audit_ledger` through
+  `aimee_add_test`.
+- `src/tests/Rules.mk` registers `unit-test-audit-worm` and `unit-test-audit-worm-chain`, and both are
+  members of the Make `unit-tests` set.
+
+The local environment does not provide `cmake` or `ctest`. The action and ledger executables therefore
+remain mandatory CMake/CTest pull-request checks rather than claimed local results. The two focused
+Make targets are run locally and the full Make and CMake suites remain pull-request gates.
+
+## Aimee code-index observation
+
+Code intelligence was attempted before using build and source evidence:
+
+```text
+$ aimee index scan --force
+indexing project: aimee
+ingested 3443 file(s) from /home/virant/dev/aimee (61 batches)
+$ aimee index overview
+No indexed projects.
+$ aimee index find audit_worm_row_hash
+No matches.
+```
+
+The scan resolved the linked checkout rather than this isolated worktree and did not expose a project
+or symbols afterward. These results mean index evidence was unavailable; they are not evidence that
+the audit APIs or tests are dead. Direct calls, compile/link inputs, runtime boundaries, and storage
+boundaries supplied the ownership evidence for this slice.
+
+## Completed local verification
+
+- `python3 -I -S scripts/validate_module_descriptors.py --check-schema src/modules`
+- `python3 -I -S scripts/validate_module_descriptors.py --emit-ownership src/modules`
+- `python3 -I scripts/tests/test_validate_module_descriptors.py -v`
+- Make targets and binaries for `unit-test-audit-worm` and `unit-test-audit-worm-chain`
+- `python3 -I -S scripts/check_cleanup_ledger.py` and its nine failure-mode tests
+- `python3 -I -S scripts/refactor_baselines.py` and its seven failure-mode tests
+- the existing module-documentation, module-header-layout, and source-ownership checks
+- `git diff --name-status 913fbdbcf94e8defc45df2d220582fe95846e6d5`
+
+The descriptor validator passed for all 26 descriptors, and all 32 descriptor failure-mode tests
+passed. Its ownership report contains exactly the four audit test paths. Both focused Make binaries
+built and passed. The 14-file inventory matched the 14 documentation rows. The cleanup-ledger and
+refactor-baseline checks passed without drift, so no baseline freeze or index update was required.
+The staged name-status diff contains only the audit descriptor, audit documentation, this validation
+record, and cleanup-ledger metadata.
+
+Technical-writer job 7234 approved the four-file artifact without edits. Close issue #1753 only after
+exact-final-diff roundtable approval, all 22 pull-request checks pass, and the slice merges.

--- a/src/modules/audit/module.yaml
+++ b/src/modules/audit/module.yaml
@@ -21,7 +21,12 @@
     "src/modules/audit/include/aimee/audit/audit_worm.h",
     "src/modules/audit/include/aimee/audit/audit_worm_chain.h"
   ],
-  "tests": [],
+  "tests": [
+    "src/tests/test_audit_action.c",
+    "src/tests/test_audit_ledger.c",
+    "src/tests/test_audit_worm.c",
+    "src/tests/test_audit_worm_chain.c"
+  ],
   "docs": [
     "docs/modules/audit.md"
   ]

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -312,6 +312,23 @@
       "blast_radius": "Production changes are physical header moves plus include substitutions; public names, prototypes, source inputs, target visibility, storage behavior, and runtime behavior remain unchanged.",
       "independent_review": "Aimee technical-writing review was satisfied on 2026-07-22 with its wording corrections applied; exact-final-diff roundtable review remains required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-23.md", "docs/modules/audit.md", "src/modules/audit/module.yaml", "scripts/check_module_header_layout.py", "scripts/tests/test_check_module_header_layout.py"]
+    },
+    {
+      "slice": 24,
+      "state": "present_and_verified",
+      "disposition": "Assigned audit's four direct unit tests to the audit descriptor and documented every audit-named test without dual-claiming cross-boundary integrations.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["Make and CMake retain separate test registrations until descriptor-driven generation", "KB, vault, log, DB1, DB2, code-audit, and memory-harness integration tests remain outside audit ownership"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata and documentation only, not shipped production code or test behavior.",
+        "rejected_simpler_alternative": "Assigning tests by filename would falsely dual-claim mixed integration tests; leaving all tests unclaimed would hide four direct module contracts.",
+        "revisit": "Reassign a mixed integration test only after its production boundary has one canonical owner or a reproduced maintenance defect justifies splitting the test."
+      },
+      "consumers": ["audit maintainers", "descriptor validation CI", "future generated test projections"],
+      "blast_radius": "Only the audit descriptor, audit documentation, validation record, and cleanup ledger change; production sources, public headers, test sources, build registrations, storage behavior, and runtime behavior remain unchanged.",
+      "independent_review": "Aimee technical-writer job 7234 approved the artifact without edits; exact-final-diff roundtable review remains required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-24.md", "docs/modules/audit.md", "src/modules/audit/module.yaml"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- assign the four direct audit unit tests to the audit module descriptor
- classify all 14 audit-named tests by their real subsystem or integration boundary
- resolve the deferred ownership audit from #1753 without production, test, or build changes
- record local validation, the Aimee index limitation, and cleanup accounting

## Validation

- `validate_module_descriptors.py --check-schema src/modules`
- 32 descriptor failure-mode tests
- focused Make WORM store and chain binaries
- cleanup ledger, refactor baseline, module docs, header layout, and source ownership gates
- technical-writer job 7234: approved
- exact staged-diff roundtable: approved

Local `cmake`/`ctest` are unavailable; PR CI is the mandatory action/ledger CTest gate.

Closes #1753