### PR TITLE
Fix delegate restart reconciliation

### DIFF
--- a/src/db1/agent_jobs.c
+++ b/src/db1/agent_jobs.c
@@ -440,6 +440,28 @@ int db1_agent_job_cancel_by_id(int job_id, const char *reason)
    return changed;
 }
 
+int db1_agent_job_cancel_nonterminal_on_restart(const char *reason)
+{
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+
+   static const char *sql =
+       "UPDATE agent_jobs SET status = 'cancelled', cancelled_at = datetime('now'),"
+       " cancel_reason = ?, result = CASE WHEN result = '' THEN 'cancelled: ' || ? ELSE result END,"
+       " updated_at = datetime('now') WHERE status IN ('pending', 'running')";
+   sqlite3_stmt *stmt = NULL;
+   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+      return -1;
+   const char *cancel_reason = (reason && reason[0]) ? reason : "orphaned by server restart";
+   sqlite3_bind_text(stmt, 1, cancel_reason, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(stmt, 2, cancel_reason, -1, SQLITE_TRANSIENT);
+   int rc = sqlite3_step(stmt);
+   int changed = (rc == SQLITE_DONE) ? sqlite3_changes(db) : -1;
+   sqlite3_finalize(stmt);
+   return changed;
+}
+
 int db1_agent_job_cancel_stale(int threshold_seconds, const char *reason)
 {
    sqlite3 *db = db1_conn();

--- a/src/db1/agent_jobs.h
+++ b/src/db1/agent_jobs.h
@@ -139,6 +139,11 @@ extern "C"
    /* Cancel one job by id with a reason. Returns rows changed (0/1). */
    int db1_agent_job_cancel_by_id(int job_id, const char *reason);
 
+   /* Cancel every pending/running delegate row left by an earlier server
+    * process. Call once during server startup, before any worker can exist.
+    * Empty results receive the cancellation reason; existing results remain. */
+   int db1_agent_job_cancel_nonterminal_on_restart(const char *reason);
+
    /* Cancel all 'running' jobs older than `threshold_seconds`, with a
     * fixed reason. Returns rows changed. */
    int db1_agent_job_cancel_stale(int threshold_seconds, const char *reason);

--- a/src/modules/delegates/delegate_backend_docker.c
+++ b/src/modules/delegates/delegate_backend_docker.c
@@ -231,6 +231,40 @@ static int run_docker(const char *const argv[])
 
 #define DOCKER_PROBE_TIMEOUT_MS 15000
 
+int delegate_backend_docker_remove_orphans(void)
+{
+   const char *list_argv[] = {resolve_docker_bin(),    "ps", "-aq", "--filter",
+                              "name=^aimee-delegate-", NULL};
+   char *out = NULL;
+   if (safe_exec_capture_cwd_env_timeout(list_argv, NULL, NULL, &out, 1 << 20,
+                                         DOCKER_PROBE_TIMEOUT_MS) != 0)
+   {
+      free(out);
+      return -1;
+   }
+   int removed = 0;
+   char *save = NULL;
+   for (char *id = strtok_r(out, "\r\n", &save); id; id = strtok_r(NULL, "\r\n", &save))
+   {
+      size_t len = strlen(id);
+      int valid = len >= 12 && len <= 64;
+      for (size_t i = 0; valid && i < len; i++)
+         valid = isxdigit((unsigned char)id[i]) != 0;
+      if (!valid)
+      {
+         LOG_WARN("delegate-sandbox", "refusing invalid orphan container id from docker: %s", id);
+         continue;
+      }
+      const char *remove_argv[] = {resolve_docker_bin(), "rm", "-f", id, NULL};
+      if (run_docker(remove_argv) == 0)
+         removed++;
+      else
+         LOG_WARN("delegate-sandbox", "failed to remove orphan container %s", id);
+   }
+   free(out);
+   return removed;
+}
+
 /* Determine whether the running sandbox `container` was actually isolated by the
  * runtime, i.e. whether `--network none` was honoured. Asks the HOST daemon (not a
  * binary inside the untrusted image, so distroless/scratch images are fine) for the

--- a/src/modules/delegates/delegate_backend_docker.h
+++ b/src/modules/delegates/delegate_backend_docker.h
@@ -40,6 +40,11 @@ extern "C"
     * task_id or undersized buffer. */
    int delegate_backend_docker_container_name(const char *task_id, char *out, size_t outsz);
 
+   /* Remove delegate containers left running by an earlier server process.
+    * Server startup calls this before its worker pools exist, so every matching
+    * container is necessarily orphaned. Returns removed count or -1. */
+   int delegate_backend_docker_remove_orphans(void);
+
    /* Build the docker exec command-string used by exec(). Pure
     * string assembly. Shape:
     *   docker exec -i <container_name> bash -c '<base64-encoded-script>'

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -2190,9 +2190,22 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
    else
    {
       db1_apply_server_pragmas();
+      int orphaned = db1_agent_job_cancel_nonterminal_on_restart("orphaned by server restart");
+      if (orphaned < 0)
+         LOG_WARN("server", "failed to reconcile delegate jobs from the prior process");
+      else if (orphaned > 0)
+         LOG_INFO("server", "cancelled %d delegate jobs orphaned by the prior process", orphaned);
       if (server_mgmt_status_init() != 0)
          LOG_WARN("server", "management status nonce initialization failed");
    }
+   /* Container cleanup is independent of DB availability. No worker pool exists
+    * yet, so a matching container cannot belong to this server generation. */
+   int orphan_containers = delegate_backend_docker_remove_orphans();
+   if (orphan_containers < 0)
+      LOG_WARN("server", "could not reconcile delegate containers from the prior process");
+   else if (orphan_containers > 0)
+      LOG_INFO("server", "removed %d delegate containers orphaned by the prior process",
+               orphan_containers);
    /* Seed personas + role templates so config (not code) is the source of truth. */
    server_seed_config_defaults();
    int compute_threads = aimee_resolve_compute_threads(cfg.compute_threads);

--- a/src/tests/test_db1_agent_job_heartbeat.c
+++ b/src/tests/test_db1_agent_job_heartbeat.c
@@ -378,6 +378,83 @@ static void test_update_does_not_overwrite_cancelled(void)
    printf("  PASS: test_update_does_not_overwrite_cancelled\n");
 }
 
+static void test_restart_reconciliation_cancels_only_nonterminal_jobs(void)
+{
+   setup_db();
+   int pending = db1_agent_job_create("review", "pending", "", "owner");
+   int running = db1_agent_job_create("code", "running", "codex", "owner");
+   int running_partial = db1_agent_job_create("code", "running partial", "codex", "owner");
+   int done = db1_agent_job_create("review", "done", "codex", "owner");
+   int failed = db1_agent_job_create("review", "failed", "codex", "owner");
+   int cancelled = db1_agent_job_create("review", "cancelled", "codex", "owner");
+   assert(pending > 0 && running > 0 && running_partial > 0 && done > 0 && failed > 0 &&
+          cancelled > 0);
+   db1_agent_job_update(running, "running", 2, NULL);
+   db1_agent_job_update(running_partial, "running", 2, "partial output");
+   db1_agent_job_update(done, "done", 3, "complete");
+   db1_agent_job_update(failed, "failed", 3, "failed result");
+   db1_agent_job_update(cancelled, "cancelled", 3, "cancelled result");
+
+   /* Larger than the removed fixed buffer, proving restart reasons are lossless. */
+   const size_t reason_len = 2048;
+   char *reason = malloc(reason_len + 1);
+   assert(reason != NULL);
+   memset(reason, 'r', reason_len);
+   reason[reason_len] = '\0';
+   assert(db1_agent_job_cancel_nonterminal_on_restart(reason) == 3);
+   assert(db1_agent_job_cancel_nonterminal_on_restart("second restart") == 0);
+
+   db1_agent_job_t row;
+   assert(db1_agent_job_get(pending, &row) == 0);
+   assert(strcmp(row.status, "cancelled") == 0);
+   assert(strlen(row.result) == strlen("cancelled: ") + reason_len);
+   assert(strncmp(row.result, "cancelled: ", strlen("cancelled: ")) == 0);
+   assert(strcmp(row.result + strlen("cancelled: "), reason) == 0);
+   db1_agent_job_free(&row);
+   assert(db1_agent_job_get(running, &row) == 0);
+   assert(strcmp(row.status, "cancelled") == 0);
+   db1_agent_job_free(&row);
+   assert(db1_agent_job_get(running_partial, &row) == 0);
+   assert(strcmp(row.status, "cancelled") == 0);
+   assert(strcmp(row.result, "partial output") == 0);
+   db1_agent_job_free(&row);
+   assert(db1_agent_job_get(done, &row) == 0);
+   assert(strcmp(row.status, "done") == 0);
+   assert(strcmp(row.result, "complete") == 0);
+   db1_agent_job_free(&row);
+   assert(db1_agent_job_get(failed, &row) == 0);
+   assert(strcmp(row.status, "failed") == 0);
+   assert(strcmp(row.result, "failed result") == 0);
+   db1_agent_job_free(&row);
+   assert(db1_agent_job_get(cancelled, &row) == 0);
+   assert(strcmp(row.status, "cancelled") == 0);
+   assert(strcmp(row.result, "cancelled result") == 0);
+   db1_agent_job_free(&row);
+
+   sqlite3_stmt *stmt = NULL;
+   assert(sqlite3_prepare_v2(db1_conn(),
+                             "SELECT cancel_reason, cancelled_at FROM agent_jobs WHERE id = ?", -1,
+                             &stmt, NULL) == SQLITE_OK);
+   sqlite3_bind_int(stmt, 1, pending);
+   assert(sqlite3_step(stmt) == SQLITE_ROW);
+   const char *stored_reason = (const char *)sqlite3_column_text(stmt, 0);
+   const char *cancelled_at = (const char *)sqlite3_column_text(stmt, 1);
+   assert(stored_reason != NULL && strcmp(stored_reason, reason) == 0);
+   assert(cancelled_at != NULL && cancelled_at[0] != '\0');
+   sqlite3_finalize(stmt);
+   free(reason);
+
+   int default_reason = db1_agent_job_create("review", "new pending", "", "owner");
+   assert(default_reason > 0);
+   assert(db1_agent_job_cancel_nonterminal_on_restart(NULL) == 1);
+   assert(db1_agent_job_get(default_reason, &row) == 0);
+   assert(strcmp(row.result, "cancelled: orphaned by server restart") == 0);
+   db1_agent_job_free(&row);
+
+   teardown_db();
+   printf("  PASS: test_restart_reconciliation_cancels_only_nonterminal_jobs\n");
+}
+
 static void test_done_update_wins_cancel_complete_race(void)
 {
    setup_db();
@@ -502,6 +579,7 @@ int main(void)
    test_classify_final_response_uses_idle_threshold();
    test_classify_model_wait_does_not_use_tool_threshold();
    test_is_cancelled_round_trip();
+   test_restart_reconciliation_cancels_only_nonterminal_jobs();
    test_update_does_not_overwrite_cancelled();
    test_done_update_wins_cancel_complete_race();
    test_failed_update_does_not_overwrite_cancelled();

--- a/src/tests/test_delegate_backend_docker.c
+++ b/src/tests/test_delegate_backend_docker.c
@@ -154,6 +154,7 @@ static void test_docker_list_dir_returns_entries(void)
  *   docker start <name>           -> exit 0 if .exists flag present, else 1
  *   docker create --name N ...    -> touch .exists flag, exit 0
  *   docker stop <name>            -> exit 0 (we don't track running state)
+ *   docker ps -aq --filter ...    -> print names of .exists state files
  *   docker rm -f <name>           -> remove the .exists flag
  *   docker exec -i N bash -c CMD  -> exec bash -c "CMD" locally so the
  *                                    test exercises the full exec path
@@ -192,6 +193,14 @@ static const char *write_fake_docker_fixture(void)
            "  stop)\n"
            "    exit 0\n"
            "    ;;\n"
+           "  ps)\n"
+           "    for path in \"$STATE_DIR\"/*.exists; do\n"
+           "      [ -e \"$path\" ] || continue\n"
+           "      name=\"${path##*/}\"\n"
+           "      printf '%%s\\n' \"${name%%.exists}\"\n"
+           "    done\n"
+           "    exit 0\n"
+           "    ;;\n"
            "  rm)\n"
            "    name=\"${@: -1}\"\n"
            "    rm -f \"$STATE_DIR/$name.exists\"\n"
@@ -228,6 +237,44 @@ static int fake_container_exists(const char *container_name)
             container_name);
    struct stat s;
    return stat(p, &s) == 0;
+}
+
+static void test_remove_orphans_accepts_only_container_ids(void)
+{
+   const char *fixture = write_fake_docker_fixture();
+   setenv("AIMEE_DOCKER_BIN", fixture, 1);
+
+   char valid_path[512], valid_long_path[512], invalid_path[512];
+   snprintf(valid_path, sizeof(valid_path), "/tmp/aimee-fake-docker-state-%d/0123456789ab.exists",
+            (int)getpid());
+   snprintf(valid_long_path, sizeof(valid_long_path),
+            "/tmp/aimee-fake-docker-state-%d/"
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.exists",
+            (int)getpid());
+   snprintf(invalid_path, sizeof(invalid_path),
+            "/tmp/aimee-fake-docker-state-%d/"
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0.exists",
+            (int)getpid());
+   FILE *f = fopen(valid_path, "w");
+   assert(f != NULL);
+   fclose(f);
+   f = fopen(valid_long_path, "w");
+   assert(f != NULL);
+   fclose(f);
+   f = fopen(invalid_path, "w");
+   assert(f != NULL);
+   fclose(f);
+
+   assert(delegate_backend_docker_remove_orphans() == 2);
+   assert(!fake_container_exists("0123456789ab"));
+   assert(
+       !fake_container_exists("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"));
+   assert(
+       fake_container_exists("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"));
+
+   teardown_fake_docker();
+   unsetenv("AIMEE_DOCKER_BIN");
+   printf("  PASS: test_remove_orphans_accepts_only_container_ids\n");
 }
 
 /* Did the last `docker create` argv (captured by the fixture) contain `needle`? */
@@ -781,6 +828,7 @@ static void test_docker_workspace_validation_refusals(void)
 
 int main(void)
 {
+   test_remove_orphans_accepts_only_container_ids();
    printf("delegate_backend_docker:\n");
    test_register_puts_docker_in_registry();
    test_file_ops_reject_null_state();


### PR DESCRIPTION
## Summary

- atomically cancel `pending` and `running` delegate rows during server startup, before any worker pool can exist
- remove prior-generation `aimee-delegate-*` containers using Docker's name filter and validated exact container IDs
- preserve terminal job history and avoid fixed-byte cancellation-result truncation
- cover database idempotence/metadata/long reasons and Docker cleanup validation

This is a transitional resource-plane reliability repair while provider execution continues moving out of C; it does not assign new ownership to C.

## Validation

- `make -C src unit-tests -j8`
- `clang-format-19 --dry-run --Werror` on all changed C/header files
- `git diff --check`
- roundtable review explicitly checked original-request alignment, lifecycle ordering, cleanup safety, and truncation
