### PR TITLE
fix(roundtable): preserve tools and guarantee Codex synthesis

### DIFF
--- a/src/headers/agent_runtime_messages.h
+++ b/src/headers/agent_runtime_messages.h
@@ -10,7 +10,8 @@
 int agent_session_retry_final_tool_violation(cJSON *messages, const char *attempted_action,
                                              int *turn, int *max_t, int initial_max_t,
                                              int *retry_count, char *error, size_t error_len);
-int agent_session_retry_degenerate_response(cJSON *messages, int *turn, int *retry_count);
+int agent_session_retry_degenerate_response(cJSON *messages, int *turn, int *retry_count,
+                                            int *force_text_only_retry);
 void agent_session_append_final_message(cJSON *messages, const char *content);
 void agent_session_append_final_instruction(cJSON *messages);
 void agent_session_append_final_retry_instruction(cJSON *messages, const char *attempted_action);

--- a/src/modules/roundtable/delegate_ensemble.c
+++ b/src/modules/roundtable/delegate_ensemble.c
@@ -658,8 +658,14 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
        mode == ROUNDTABLE_REVIEW
            ? "You have no filesystem, git, shell, or write access in this review. The SHARED "
              "ARTIFACT is the authoritative change under review; use the offered read-only Aimee "
-             "index tools for surrounding repository facts. Never claim to have read files or run "
-             "git — and "
+             "tools for surrounding repository facts. Never claim to have read files or run git "
+             "unless an offered tool returned that evidence. A source-level wiring claim is not "
+             "verified merely because the artifact calls or edits a named function: use Aimee "
+             "tools to trace which build target and implementation actually ship, and where "
+             "possible inspect or exercise the packaged/runtime path. If that production-path "
+             "trace is unavailable, label the claim unverified and report the missing evidence. "
+             "Do not infer shipped behavior from a diff in isolation. "
+             "Also "
              "never report a finding like \"the change is not applied / not in the tree\" (you "
              "cannot observe the tree; the artifact is the change). "
              "First compare the proposed direction to the ORIGINAL REQUEST in TASK. A useful "
@@ -730,17 +736,16 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
    }
 
    /* Read-only aimee context (memory recall + code-graph snippets), assembled by
-    * the server-side caller. Panelists have no tools, so this block is the only
-    * way they see aimee memory and the code graph; it is authoritative reference,
-    * not something they can re-query. */
+    * the server-side caller. It is useful seed evidence, but tool-enabled review
+    * panelists may and should re-query facts whose production wiring matters. */
    const char *context_block = "";
    char *owned_context_block = NULL;
    if (context && context[0])
    {
-      owned_context_block =
-          xasprintf3("AIMEE CONTEXT (read-only reference — aimee memory + code graph):\n", context,
-                     "\nUse this context as grounding; it is authoritative reference you cannot "
-                     "re-query.\n\n");
+      owned_context_block = xasprintf3(
+          "AIMEE CONTEXT (read-only reference — aimee memory + code graph):\n", context,
+          "\nUse this context as grounding and re-query checkable claims with the offered "
+          "read-only tools when production wiring matters.\n\n");
       if (!owned_context_block)
       {
          free(owned_brief_block);

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -611,6 +611,12 @@ native_provider_http:
    int final_instruction_added = 0;
    int final_tool_retry_count = 0;
    int degenerate_retry_count = 0;
+   /* A provider may emit a reasoning-only/empty turn while tools are offered
+    * even though it has finished investigating (observed with Codex review
+    * seats). Retrying with the identical tool contract can repeat forever and
+    * discard an otherwise healthy panelist. Preserve tools for the normal run,
+    * but make the one bounded degenerate-response retry a synthesis-only turn. */
+   int force_text_only_retry = 0;
    int tok = agent_request_max_tokens(agent, max_tokens);
    int max_t = agent_resolve_max_turns(agent, role);
    int initial_max_t = max_t;
@@ -763,8 +769,11 @@ native_provider_http:
        * can always send another message.  Pass max_turns=0 so HARD never fires. */
       liveness_final_response_mode_t final_mode =
           liveness_final_response_mode(turn, role ? max_t : 0, total_calls, final_after_turns);
-      int final_instruction_turn = final_mode != LIVENESS_FINAL_RESPONSE_NONE;
-      int final_text_only_turn = !liveness_final_response_allows_tools(final_mode);
+      int final_instruction_turn =
+          force_text_only_retry || final_mode != LIVENESS_FINAL_RESPONSE_NONE;
+      int final_text_only_turn =
+          force_text_only_retry || !liveness_final_response_allows_tools(final_mode);
+      force_text_only_retry = 0;
       if (final_instruction_turn && !final_instruction_added)
       {
          agent_session_append_final_instruction(messages);
@@ -1268,8 +1277,9 @@ native_provider_http:
          {
             if (liveness_is_degenerate_response(parsed.content))
             {
-               if (total_calls == 0 && agent_session_retry_degenerate_response(
-                                           messages, &turn, &degenerate_retry_count))
+               if (total_calls == 0 &&
+                   agent_session_retry_degenerate_response(messages, &turn, &degenerate_retry_count,
+                                                           &force_text_only_retry))
                {
                   agent_free_parsed_response(&parsed);
                   continue;
@@ -1299,7 +1309,8 @@ native_provider_http:
              * reasoning-only content. The final-tool retry below is mutually
              * exclusive because it requires total_calls > 0. */
             if (total_calls == 0 &&
-                agent_session_retry_degenerate_response(messages, &turn, &degenerate_retry_count))
+                agent_session_retry_degenerate_response(messages, &turn, &degenerate_retry_count,
+                                                        &force_text_only_retry))
             {
                agent_free_parsed_response(&parsed);
                continue;

--- a/src/posix/agent_runtime_messages.c
+++ b/src/posix/agent_runtime_messages.c
@@ -95,13 +95,15 @@ int agent_session_retry_final_tool_violation(cJSON *messages, const char *attemp
    return 1;
 }
 
-int agent_session_retry_degenerate_response(cJSON *messages, int *turn, int *retry_count)
+int agent_session_retry_degenerate_response(cJSON *messages, int *turn, int *retry_count,
+                                            int *force_text_only_retry)
 {
-   if (!messages || !turn || !retry_count)
+   if (!messages || !turn || !retry_count || !force_text_only_retry)
       return 0;
    if (*retry_count >= AGENT_DEGENERATE_RESPONSE_RETRY_LIMIT)
       return 0;
    (*retry_count)++;
+   *force_text_only_retry = 1;
    agent_session_append_degenerate_retry_instruction(messages);
    (*turn)++;
    return 1;

--- a/src/tests/test_agent_runtime_messages.c
+++ b/src/tests/test_agent_runtime_messages.c
@@ -88,15 +88,21 @@ static void test_degenerate_retry_budget(void)
    cJSON *messages = cJSON_CreateArray();
    int turn = 0;
    int retry_count = 0;
+   int force_text_only_retry = 0;
 
-   assert(agent_session_retry_degenerate_response(messages, &turn, &retry_count) == 1);
+   assert(agent_session_retry_degenerate_response(messages, &turn, &retry_count,
+                                                  &force_text_only_retry) == 1);
    assert(turn == 1);
    assert(retry_count == 1);
+   assert(force_text_only_retry == 1);
    assert(cJSON_GetArraySize(messages) == 1);
 
-   assert(agent_session_retry_degenerate_response(messages, &turn, &retry_count) == 0);
+   force_text_only_retry = 0;
+   assert(agent_session_retry_degenerate_response(messages, &turn, &retry_count,
+                                                  &force_text_only_retry) == 0);
    assert(turn == 1);
    assert(retry_count == 1);
+   assert(force_text_only_retry == 0);
    assert(cJSON_GetArraySize(messages) == 1);
 
    cJSON_Delete(messages);

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -1415,6 +1415,12 @@ static void test_roundtable_review_assigns_personas(void)
    assert(strcmp(g_captured_personas[0], "original-request") == 0);
    assert(strcmp(g_captured_personas[1], "security") == 0);
    assert(strcmp(g_captured_personas[2], "architect") == 0);
+   /* A tool-capable panel must verify production wiring against what actually
+    * ships, rather than treating a source-diff call site as runtime evidence. */
+   assert(strstr(g_last_parallel_prompt, "which build target and implementation actually ship") !=
+          NULL);
+   assert(strstr(g_last_parallel_prompt, "label the claim unverified") != NULL);
+   assert(strstr(g_last_parallel_prompt, "Do not infer shipped behavior from a diff") != NULL);
    delegate_roundtable_result_free(&result);
    printf("  test_roundtable_review_assigns_personas: ok\n");
 }


### PR DESCRIPTION
## Summary
- keep roundtable review seats tool-enabled for their normal investigative turns
- force the single bounded retry after an empty/reasoning-only provider response to be synthesis-only
- require production-wiring claims to trace the build/implementation that actually ships, or be labeled unverified
- add regression coverage for the retry-state handoff and shipped-path review prompt

## Live diagnosis
On `.254` at `testing-9406596`, two concurrent marker reviews remained artifact-isolated, but both Codex seats degraded. Server logs showed successful Codex HTTP 200 responses followed by `no content in final response`; the Responses path emitted reasoning-only turns while tools remained offered. The bounded retry repeated the same contract instead of requiring synthesis.

## Verification
- `make -C src -j2 build/obj/tests/unit-test-agent-runtime-messages build/obj/tests/unit-test-delegate-ensemble build/obj/posix/agent_runtime.o`
- `src/build/obj/tests/unit-test-agent-runtime-messages`
- `src/build/obj/tests/unit-test-delegate-ensemble`
- `git diff --check`
- configured roundtable review: aligned, no actionable issues (degraded because this patch fixes the currently deployed Codex finalization defect)
