### PR TITLE
feat: pool server-to-KB mTLS connections

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -171,6 +171,13 @@ It accepts only strict HTTP/1.1 responses with one `Content-Length`, a head no
 larger than 64 KiB, and a body smaller than the caller's bounded buffer; it reads
 that body exactly and never treats EOF as a successful response delimiter.
 
+The resident server→KB transport pools by its single enrolled endpoint and
+identity generation: at most 8 total connections, 2 idle, 64 waiting borrowers,
+a 30-second idle lifetime, 10-minute maximum age, and 1,000 requests per
+connection. Only one replacement handshake runs at once. Certificate rotation
+invalidates the generation, and `kb_client_mtls_pool_stats()` reports aggregate
+total/idle/busy/waiter occupancy without identity labels.
+
 ### Overview
 
 This document captures the current benchmark baseline for aimee’s latency-sensitive paths. The focus is the work that sits directly between a primary agent and useful execution: hook checks, memory access, session initialization, and delegate routing data.

--- a/src/modules/kb_client/kb_client_mtls.c
+++ b/src/modules/kb_client/kb_client_mtls.c
@@ -12,8 +12,10 @@
 #include "cJSON.h"
 
 #include <pthread.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 /* The enrolled identity, established once on first use. Immutable after init
  * (guarded by g_lock during enrollment), so request-time reads need no lock. */
@@ -25,6 +27,160 @@ static char g_ca[8192];
 static char g_cert[8192];
 static char g_key[8192];
 
+#define KB_POOL_TOTAL_MAX   8
+#define KB_POOL_IDLE_MAX    2
+#define KB_POOL_WAITERS_MAX 64
+#define KB_POOL_IDLE_SECS   30
+#define KB_POOL_AGE_SECS    (10 * 60)
+#define KB_POOL_REQ_MAX     1000
+
+typedef struct
+{
+   kb_tls_client_conn_t *conn;
+   unsigned generation;
+   unsigned requests;
+   time_t created_at;
+   time_t last_used_at;
+   int busy;
+} kb_pool_entry_t;
+
+static kb_pool_entry_t g_pool[KB_POOL_TOTAL_MAX];
+static pthread_cond_t g_pool_cv = PTHREAD_COND_INITIALIZER;
+static unsigned g_identity_generation = 1;
+static int g_pool_waiters = 0;
+static int g_pool_connecting = 0;
+static unsigned long g_pool_borrow_exhausted_total = 0;
+
+static time_t monotonic_seconds(void)
+{
+   struct timespec ts;
+   return clock_gettime(CLOCK_MONOTONIC, &ts) == 0 ? ts.tv_sec : 0;
+}
+
+static void pool_close_entry_locked(kb_pool_entry_t *entry)
+{
+   kb_tls_client_conn_t *conn = entry->conn;
+   memset(entry, 0, sizeof(*entry));
+   /* SSL shutdown is bounded by the socket deadline. Keeping this under the
+    * lock makes entry ownership simple; the pool contains at most eight. */
+   kb_tls_client_conn_close(conn);
+}
+
+static void pool_expire_idle_locked(time_t now)
+{
+   for (int i = 0; i < KB_POOL_TOTAL_MAX; i++)
+      if (g_pool[i].conn && !g_pool[i].busy &&
+          (g_pool[i].generation != g_identity_generation ||
+           now - g_pool[i].last_used_at >= KB_POOL_IDLE_SECS ||
+           now - g_pool[i].created_at >= KB_POOL_AGE_SECS || g_pool[i].requests >= KB_POOL_REQ_MAX))
+         pool_close_entry_locked(&g_pool[i]);
+}
+
+static kb_pool_entry_t *pool_borrow(int *pool_error)
+{
+   if (pool_error)
+      *pool_error = -1;
+   pthread_mutex_lock(&g_lock);
+   for (;;)
+   {
+      time_t now = monotonic_seconds();
+      pool_expire_idle_locked(now);
+      int total = 0;
+      for (int i = 0; i < KB_POOL_TOTAL_MAX; i++)
+      {
+         if (g_pool[i].conn)
+         {
+            total++;
+            if (!g_pool[i].busy && g_pool[i].generation == g_identity_generation)
+            {
+               g_pool[i].busy = 1;
+               pthread_mutex_unlock(&g_lock);
+               return &g_pool[i];
+            }
+         }
+      }
+
+      if (total + g_pool_connecting < KB_POOL_TOTAL_MAX && !g_pool_connecting)
+      {
+         char host[sizeof(g_host)], ca[sizeof(g_ca)], cert[sizeof(g_cert)], key[sizeof(g_key)];
+         int port = g_port;
+         unsigned generation = g_identity_generation;
+         snprintf(host, sizeof(host), "%s", g_host);
+         snprintf(ca, sizeof(ca), "%s", g_ca);
+         snprintf(cert, sizeof(cert), "%s", g_cert);
+         snprintf(key, sizeof(key), "%s", g_key);
+         g_pool_connecting = 1;
+         pthread_mutex_unlock(&g_lock);
+         kb_tls_client_conn_t *conn = kb_tls_client_conn_open(host, port, ca, cert, key);
+         pthread_mutex_lock(&g_lock);
+         g_pool_connecting = 0;
+         pthread_cond_broadcast(&g_pool_cv);
+         if (!conn || generation != g_identity_generation)
+         {
+            kb_tls_client_conn_close(conn);
+            pthread_mutex_unlock(&g_lock);
+            return NULL;
+         }
+         for (int i = 0; i < KB_POOL_TOTAL_MAX; i++)
+            if (!g_pool[i].conn)
+            {
+               g_pool[i].conn = conn;
+               g_pool[i].generation = generation;
+               g_pool[i].created_at = monotonic_seconds();
+               g_pool[i].last_used_at = g_pool[i].created_at;
+               g_pool[i].busy = 1;
+               pthread_mutex_unlock(&g_lock);
+               return &g_pool[i];
+            }
+         kb_tls_client_conn_close(conn);
+         pthread_mutex_unlock(&g_lock);
+         return NULL;
+      }
+
+      if (g_pool_waiters >= KB_POOL_WAITERS_MAX)
+      {
+         g_pool_borrow_exhausted_total++;
+         if (pool_error)
+            *pool_error = KB_CLIENT_ERR_POOL_EXHAUSTED;
+         pthread_mutex_unlock(&g_lock);
+         return NULL;
+      }
+      struct timespec deadline;
+      clock_gettime(CLOCK_REALTIME, &deadline);
+      deadline.tv_sec += 30;
+      g_pool_waiters++;
+      int wait_rc = pthread_cond_timedwait(&g_pool_cv, &g_lock, &deadline);
+      g_pool_waiters--;
+      if (wait_rc == ETIMEDOUT)
+      {
+         g_pool_borrow_exhausted_total++;
+         if (pool_error)
+            *pool_error = KB_CLIENT_ERR_POOL_EXHAUSTED;
+         pthread_mutex_unlock(&g_lock);
+         return NULL;
+      }
+   }
+}
+
+static void pool_return(kb_pool_entry_t *entry, int reusable)
+{
+   pthread_mutex_lock(&g_lock);
+   entry->requests++;
+   entry->last_used_at = monotonic_seconds();
+   int idle = 0;
+   for (int i = 0; i < KB_POOL_TOTAL_MAX; i++)
+      if (g_pool[i].conn && !g_pool[i].busy)
+         idle++;
+   if (!reusable || entry->generation != g_identity_generation ||
+       entry->requests >= KB_POOL_REQ_MAX ||
+       entry->last_used_at - entry->created_at >= KB_POOL_AGE_SECS || idle >= KB_POOL_IDLE_MAX)
+      pool_close_entry_locked(entry);
+   else
+      entry->busy = 0;
+   pthread_cond_signal(&g_pool_cv);
+   pthread_mutex_unlock(&g_lock);
+}
+
 int kb_client_mtls_configured(void)
 {
    const char *c = getenv("AIMEE_KB_CONN");
@@ -35,8 +191,6 @@ int kb_client_mtls_configured(void)
  * Returns 0 if enrolled (already or now), -1 on failure. */
 static int ensure_enrolled(void)
 {
-   if (g_enrolled)
-      return 0;
    int rc = -1;
    pthread_mutex_lock(&g_lock);
    if (g_enrolled)
@@ -64,8 +218,6 @@ static int ensure_enrolled(void)
 
 static void maybe_renew(void)
 {
-   if (kb_tls_cert_expires_within(g_cert, KB_CLIENT_MTLS_RENEW_WINDOW) != 1)
-      return;
    pthread_mutex_lock(&g_lock);
    if (g_enrolled && kb_tls_cert_expires_within(g_cert, KB_CLIENT_MTLS_RENEW_WINDOW) == 1)
    {
@@ -74,6 +226,8 @@ static void maybe_renew(void)
       {
          snprintf(g_cert, sizeof(g_cert), "%s", nc);
          snprintf(g_key, sizeof(g_key), "%s", nk);
+         g_identity_generation++;
+         pthread_cond_broadcast(&g_pool_cv);
       }
    }
    pthread_mutex_unlock(&g_lock);
@@ -88,40 +242,66 @@ char *kb_client_mtls_request(const char *method, const char *path, const char *b
       return NULL;
    maybe_renew();
 
-   /* Snapshot the identity under the lock so a concurrent renew cannot mutate it
-    * mid-request. */
-   char host[sizeof(g_host)];
-   char *ca, *cert, *key;
-   int port;
-   pthread_mutex_lock(&g_lock);
-   snprintf(host, sizeof(host), "%s", g_host);
-   port = g_port;
-   ca = strdup(g_ca);
-   cert = strdup(g_cert);
-   key = strdup(g_key);
-   pthread_mutex_unlock(&g_lock);
-   if (!ca || !cert || !key)
-   {
-      free(ca);
-      free(cert);
-      free(key);
-      return NULL;
-   }
-
    size_t cap = 1u << 20; /* 1 MiB — covers kb /v1 responses (status/search/etc.) */
    char *resp = malloc(cap);
+   int pool_error = -1;
+   kb_pool_entry_t *entry = resp ? pool_borrow(&pool_error) : NULL;
+   if (!entry)
+   {
+      free(resp);
+      if (status_out)
+         *status_out = pool_error;
+      return NULL;
+   }
    int status = -1;
-   int rc = resp ? kb_tls_client_request(host, port, ca, cert, key, method, path,
-                                         (body && body[0]) ? body : NULL, resp, cap, &status)
-                 : -1;
-   free(ca);
-   free(cert);
-   free(key);
+   int reusable = 0;
+   int rc = kb_tls_client_conn_request(entry->conn, method, path, (body && body[0]) ? body : NULL,
+                                       NULL, 0, resp, cap, &status, &reusable);
+   pool_return(entry, rc == 0 && reusable);
    if (status_out)
       *status_out = status;
    char *out = (rc == 0 && status >= 200 && status < 300) ? strdup(resp) : NULL;
    free(resp);
    return out;
+}
+
+void kb_client_mtls_pool_stats(int *total_out, int *idle_out, int *busy_out, int *waiters_out,
+                               unsigned long *borrow_exhausted_total_out)
+{
+   int total = 0, idle = 0, busy = 0;
+   pthread_mutex_lock(&g_lock);
+   pool_expire_idle_locked(monotonic_seconds());
+   for (int i = 0; i < KB_POOL_TOTAL_MAX; i++)
+      if (g_pool[i].conn)
+      {
+         total++;
+         if (g_pool[i].busy)
+            busy++;
+         else
+            idle++;
+      }
+   if (total_out)
+      *total_out = total;
+   if (idle_out)
+      *idle_out = idle;
+   if (busy_out)
+      *busy_out = busy;
+   if (waiters_out)
+      *waiters_out = g_pool_waiters;
+   if (borrow_exhausted_total_out)
+      *borrow_exhausted_total_out = g_pool_borrow_exhausted_total;
+   pthread_mutex_unlock(&g_lock);
+}
+
+void kb_client_mtls_pool_reset(void)
+{
+   pthread_mutex_lock(&g_lock);
+   g_identity_generation++;
+   for (int i = 0; i < KB_POOL_TOTAL_MAX; i++)
+      if (g_pool[i].conn && !g_pool[i].busy)
+         pool_close_entry_locked(&g_pool[i]);
+   pthread_cond_broadcast(&g_pool_cv);
+   pthread_mutex_unlock(&g_lock);
 }
 
 int kb_client_mtls_heartbeat(const char *server_id, const char *health, const char *version)

--- a/src/modules/kb_client/kb_client_mtls.h
+++ b/src/modules/kb_client/kb_client_mtls.h
@@ -5,6 +5,8 @@
 #ifndef DEC_KB_CLIENT_MTLS_H
 #define DEC_KB_CLIENT_MTLS_H 1
 
+#define KB_CLIENT_ERR_POOL_EXHAUSTED (-2)
+
 /* 1 when AIMEE_KB_CONN holds an aimee:// connection string (a remote kb), else 0. */
 int kb_client_mtls_configured(void);
 
@@ -19,5 +21,11 @@ char *kb_client_mtls_request(const char *method, const char *path, const char *b
  * The kb authorizes immutable issuer/serial/fingerprint metadata from TLS; the
  * caller-supplied server_id is only a selector and cannot refresh another row. */
 int kb_client_mtls_heartbeat(const char *server_id, const char *health, const char *version);
+
+/* Pool observability and lifecycle. reset closes idle entries immediately and
+ * makes borrowed entries drain on return. Output pointers may be NULL. */
+void kb_client_mtls_pool_stats(int *total_out, int *idle_out, int *busy_out, int *waiters_out,
+                               unsigned long *borrow_exhausted_total_out);
+void kb_client_mtls_pool_reset(void);
 
 #endif /* DEC_KB_CLIENT_MTLS_H */

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -2249,6 +2249,36 @@ static int mtls_read_response(SSL *ssl, char *resp, size_t cap)
    return -1;
 }
 
+typedef struct
+{
+   pthread_mutex_t lock;
+   pthread_cond_t cv;
+   int ready;
+   int go;
+} mtls_pool_gate_t;
+
+typedef struct
+{
+   mtls_pool_gate_t *gate;
+   int ok;
+} mtls_pool_request_arg_t;
+
+static void *mtls_pool_request_thread(void *opaque)
+{
+   mtls_pool_request_arg_t *arg = opaque;
+   pthread_mutex_lock(&arg->gate->lock);
+   arg->gate->ready++;
+   pthread_cond_broadcast(&arg->gate->cv);
+   while (!arg->gate->go)
+      pthread_cond_wait(&arg->gate->cv, &arg->gate->lock);
+   pthread_mutex_unlock(&arg->gate->lock);
+   int status = -1;
+   char *response = kb_client_mtls_request("GET", "/v1/health", NULL, &status);
+   arg->ok = status == 200 && response && strstr(response, "\"status\":\"ok\"");
+   free(response);
+   return NULL;
+}
+
 static void test_mtls_serve(void)
 {
    extern void test_kb_enrollment_authority_set(int status);
@@ -2501,11 +2531,11 @@ static void test_mtls_listener(void)
 
    setenv("AIMEE_KB_MTLS_MAX_CONNECTIONS", "0", 1);
    assert(kb_mtls_start(0, cfg, "localhost") == -1);
-   setenv("AIMEE_KB_MTLS_MAX_CONNECTIONS", "4", 1);
+   setenv("AIMEE_KB_MTLS_MAX_CONNECTIONS", "8", 1);
    assert(kb_mtls_start(0, cfg, "localhost") == 0);
    int connection_limit = 0, connections_live = -1, connections_queued = -1;
    kb_mtls_connection_stats(&connection_limit, &connections_live, &connections_queued);
-   assert(connection_limit == 4);
+   assert(connection_limit == 8);
    assert(connections_live == 0);
    assert(connections_queued == 0);
    int port = kb_mtls_bound_port();
@@ -2643,6 +2673,47 @@ static void test_mtls_listener(void)
       assert(kb_client_mtls_heartbeat("srv-delta", "ready", "test") == 0);
       assert(strcmp(g_test_registry_server_id, "srv-delta") == 0);
       g_test_registry_heartbeat_allow = 0;
+      int pool_total = 0, pool_idle = 0, pool_busy = -1, pool_waiters = -1;
+      unsigned long pool_exhausted = 1;
+      kb_client_mtls_pool_stats(&pool_total, &pool_idle, &pool_busy, &pool_waiters,
+                                &pool_exhausted);
+      assert(pool_total == 1 && pool_idle == 1 && pool_busy == 0 && pool_waiters == 0);
+      assert(pool_exhausted == 0);
+
+      enum
+      {
+         POOL_TEST_CLIENTS = 16
+      };
+      mtls_pool_gate_t gate = {PTHREAD_MUTEX_INITIALIZER, PTHREAD_COND_INITIALIZER, 0, 0};
+      pthread_t pool_threads[POOL_TEST_CLIENTS];
+      mtls_pool_request_arg_t pool_args[POOL_TEST_CLIENTS];
+      for (int i = 0; i < POOL_TEST_CLIENTS; i++)
+      {
+         pool_args[i] = (mtls_pool_request_arg_t){.gate = &gate, .ok = 0};
+         assert(pthread_create(&pool_threads[i], NULL, mtls_pool_request_thread, &pool_args[i]) ==
+                0);
+      }
+      pthread_mutex_lock(&gate.lock);
+      while (gate.ready != POOL_TEST_CLIENTS)
+         pthread_cond_wait(&gate.cv, &gate.lock);
+      gate.go = 1;
+      pthread_cond_broadcast(&gate.cv);
+      pthread_mutex_unlock(&gate.lock);
+      for (int i = 0; i < POOL_TEST_CLIENTS; i++)
+      {
+         pthread_join(pool_threads[i], NULL);
+         assert(pool_args[i].ok);
+      }
+      pthread_cond_destroy(&gate.cv);
+      pthread_mutex_destroy(&gate.lock);
+      kb_client_mtls_pool_stats(&pool_total, &pool_idle, &pool_busy, &pool_waiters,
+                                &pool_exhausted);
+      assert(pool_total >= 1 && pool_total <= 2 && pool_total == pool_idle && pool_busy == 0 &&
+             pool_waiters == 0);
+      kb_client_mtls_pool_reset();
+      kb_client_mtls_pool_stats(&pool_total, &pool_idle, &pool_busy, &pool_waiters,
+                                &pool_exhausted);
+      assert(pool_total == 0 && pool_idle == 0);
       unsetenv("AIMEE_KB_CONN");
       assert(kb_client_mtls_configured() == 0);
       remove(store2);


### PR DESCRIPTION
## Summary
- pool resident server-to-KB connections with 8-total, 2-idle, 64-waiter hard bounds
- enforce 30-second idle, 10-minute age, 1,000-request retirement, and one concurrent replacement handshake
- invalidate by identity generation on certificate rotation and expose aggregate occupancy/exhaustion telemetry

## Verification
- focused listener/client route suite, including 16 concurrent pooled callers
- `make -C src lint`
- `git diff --check`