### PR TITLE
fix(roundtable): repair malformed seat reports in place

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -638,18 +638,39 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 	}
 	delegated := r.delegateGroup(ctx, req, requests)
 	outcomes := make([]outcome, len(seats))
+	repairIndexes := make([]int, 0, len(seats))
 	for i, call := range delegated {
-		parsed, err := panelResponse{}, call.Err
-		if err == nil {
-			var doc []byte
-			doc, err = extractJSONObject(call.Response)
-			if err == nil {
-				err = json.Unmarshal(doc, &parsed)
-			}
-		}
+		parsed, err := parsePanelResponse(call.Response, call.Err)
 		seat := seats[i]
 		seat.participant = call.Participant
 		outcomes[i] = outcome{seat: seat, result: parsed, cost: call.CostUSD, err: err}
+		if err != nil && call.Err == nil && strings.TrimSpace(call.Participant) != "" {
+			repairIndexes = append(repairIndexes, i)
+		}
+	}
+	if len(repairIndexes) > 0 {
+		repairs := make([]DelegateRequest, len(repairIndexes))
+		for i, outcomeIndex := range repairIndexes {
+			seat := outcomes[outcomeIndex].seat
+			repairs[i] = DelegateRequest{
+				Role:           roundtableDelegateRole,
+				Persona:        seat.persona,
+				Participant:    seat.participant,
+				Prompt:         panelResponseRepairPrompt(artifactStage),
+				Workdir:        req.WorkItem.Worktree,
+				Tools:          false,
+				DurableSlot:    panelSeatDurableSlot(req, panelRound, seat.ordinal) + ":repair:1",
+				ArtifactStage:  artifactStage,
+				ProvidedTarget: true,
+			}
+		}
+		for i, call := range r.delegateGroup(ctx, req, repairs) {
+			outcomeIndex := repairIndexes[i]
+			parsed, err := parsePanelResponse(call.Response, call.Err)
+			outcomes[outcomeIndex].cost += call.CostUSD
+			outcomes[outcomeIndex].result = parsed
+			outcomes[outcomeIndex].err = err
+		}
 	}
 	feedback := wfe.ReviewFeedback{SchemaVersion: 1, ArtifactHash: artifactHash}
 	reports := make([]panelSeatReport, 0, len(seats))
@@ -704,6 +725,36 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 		}
 	}
 	return panelAnalysis{Feedback: feedback, Approvals: approvals, Voters: voters, CostUSD: cost, Unreachable: strings.Join(seatFailures, "; "), Reports: reports}
+}
+
+func parsePanelResponse(response string, delegateErr error) (panelResponse, error) {
+	parsed := panelResponse{}
+	if delegateErr != nil {
+		return parsed, delegateErr
+	}
+	doc, err := extractJSONObject(response)
+	if err != nil {
+		return parsed, err
+	}
+	if err := json.Unmarshal(doc, &parsed); err != nil {
+		return panelResponse{}, err
+	}
+	// A response missing its outer object can still contain a valid nested
+	// alignment or finding object. extractJSONObject correctly recovers that
+	// fragment, but it is not the roundtable report and must be repaired rather
+	// than misclassified as a semantic stage failure.
+	if parsed.ArtifactStage == "" && parsed.Verdict == "" && parsed.Findings == nil {
+		return panelResponse{}, errors.New("delegate returned a JSON fragment instead of the complete roundtable report")
+	}
+	return parsed, nil
+}
+
+func panelResponseRepairPrompt(artifactStage string) string {
+	return "Your preceding roundtable report was not valid JSON. Preserve its analysis and findings; only repair the serialization. " +
+		"Return exactly one JSON object and no prose or markdown. The required shape is " +
+		`{"artifact_stage":"` + artifactStage + `","original_request_alignment":{"status":"aligned|drifted|unclear","summary":"brief reason"},` +
+		`"verdict":"approve|changes","findings":[{"id":"stable id","severity":"foundational|blocking|suggestion|nit","location":"path or section","summary":"issue","recommendation":"action"}]}. ` +
+		"Use approve only with an empty findings array; use changes with at least one actionable finding."
 }
 
 // runPanelRound remains the focused test seam for independent analysis.

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -111,6 +111,33 @@ type scriptedReviewAgents struct {
 	responses []string
 }
 
+type repairingReviewAgents struct {
+	mu       sync.Mutex
+	requests [][]DelegateRequest
+}
+
+func (a *repairingReviewAgents) Delegate(_ context.Context, _ DelegateRequest) (DelegateResult, error) {
+	return DelegateResult{}, errors.New("unexpected direct delegation")
+}
+
+func (a *repairingReviewAgents) DelegateGroup(_ context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.requests = append(a.requests, append([]DelegateRequest(nil), requests...))
+	if len(a.requests) == 1 {
+		return []DelegateGroupResult{{
+			Participant: "opaque-seat-token",
+			Response:    `"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`,
+			CostUSD:     1.25,
+		}}
+	}
+	return []DelegateGroupResult{{
+		Participant: "opaque-seat-token",
+		Response:    `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`,
+		CostUSD:     0.25,
+	}}
+}
+
 type firstPanelSeatUnavailableAgents struct {
 	response string
 }
@@ -440,6 +467,29 @@ func TestPanelCapacitySeatsHaveDistinctDurableJobKeys(t *testing.T) {
 		if !wantSlots[request.DurableSlot] {
 			t.Fatalf("unexpected durable slot=%q want one of %v", request.DurableSlot, wantSlots)
 		}
+	}
+}
+
+func TestPanelRepairsMalformedJSONOnSameParticipantOnce(t *testing.T) {
+	agents := &repairingReviewAgents{}
+	runner := &NativeRunner{agents: agents}
+	req := StepRequest{WorkItem: db1.WorkItem{ID: "wi", Worktree: "/worktree"}, Node: wfe.Node{ID: "gate"}}
+	feedback, approvals, voters, cost, unreachable := runner.runPanelRound(context.Background(), req, []panelSeat{{persona: "architect", ordinal: 0}}, "review", "hash", "plan", 1)
+	if unreachable != "" || approvals != 1 || voters != 1 || len(feedback.Findings) != 0 || cost != 1.5 {
+		t.Fatalf("repaired panel result approvals=%d voters=%d cost=%v unreachable=%q feedback=%+v", approvals, voters, cost, unreachable, feedback)
+	}
+	if len(agents.requests) != 2 || len(agents.requests[0]) != 1 || len(agents.requests[1]) != 1 {
+		t.Fatalf("group calls=%+v", agents.requests)
+	}
+	repair := agents.requests[1][0]
+	if repair.Participant != "opaque-seat-token" || repair.Delegate != "" {
+		t.Fatalf("repair did not preserve opaque participant without rerouting: %+v", repair)
+	}
+	if repair.Tools || !repair.ProvidedTarget || repair.ArtifactStage != "plan" || !strings.HasSuffix(repair.DurableSlot, ":repair:1") {
+		t.Fatalf("repair request was not bounded serialization-only continuation: %+v", repair)
+	}
+	if !strings.Contains(repair.Prompt, "Preserve its analysis and findings") || !strings.Contains(repair.Prompt, "exactly one JSON object") {
+		t.Fatalf("repair prompt=%q", repair.Prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary
- detect provider responses that contain only a nested JSON fragment instead of the complete roundtable report
- issue one bounded serialization-only continuation to the same opaque participant
- preserve seat identity, prevent rerouting or roster-wide fallback, and include repair cost in accounting

## Validation
- `cd server-go && go test ./...`
- `cd src && make lint`

Live appliance reproduction: roundtable `e2efix` filled all three configured seats, but Claude job 8535 omitted the outer JSON object and aborted the panel. This fixes that exact failure mode.