### PR TITLE
fix(roundtable): preserve CLI transport for report repair

### DIFF
--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -653,12 +653,15 @@ func (r *NativeRunner) runPanelAnalysis(ctx context.Context, req StepRequest, se
 		for i, outcomeIndex := range repairIndexes {
 			seat := outcomes[outcomeIndex].seat
 			repairs[i] = DelegateRequest{
-				Role:           roundtableDelegateRole,
-				Persona:        seat.persona,
-				Participant:    seat.participant,
-				Prompt:         panelResponseRepairPrompt(artifactStage),
-				Workdir:        req.WorkItem.Worktree,
-				Tools:          false,
+				Role:        roundtableDelegateRole,
+				Persona:     seat.persona,
+				Participant: seat.participant,
+				Prompt:      panelResponseRepairPrompt(artifactStage),
+				Workdir:     req.WorkItem.Worktree,
+				// Preserve the review delegate's tool-capable transport. In particular,
+				// CLI-backed agents do not have an HTTP request URL; tools:false would
+				// incorrectly send their continuation through the simple HTTP path.
+				Tools:          true,
 				DurableSlot:    panelSeatDurableSlot(req, panelRound, seat.ordinal) + ":repair:1",
 				ArtifactStage:  artifactStage,
 				ProvidedTarget: true,

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -485,8 +485,8 @@ func TestPanelRepairsMalformedJSONOnSameParticipantOnce(t *testing.T) {
 	if repair.Participant != "opaque-seat-token" || repair.Delegate != "" {
 		t.Fatalf("repair did not preserve opaque participant without rerouting: %+v", repair)
 	}
-	if repair.Tools || !repair.ProvidedTarget || repair.ArtifactStage != "plan" || !strings.HasSuffix(repair.DurableSlot, ":repair:1") {
-		t.Fatalf("repair request was not bounded serialization-only continuation: %+v", repair)
+	if !repair.Tools || !repair.ProvidedTarget || repair.ArtifactStage != "plan" || !strings.HasSuffix(repair.DurableSlot, ":repair:1") {
+		t.Fatalf("repair request did not preserve tool-capable transport as a bounded continuation: %+v", repair)
 	}
 	if !strings.Contains(repair.Prompt, "Preserve its analysis and findings") || !strings.Contains(repair.Prompt, "exactly one JSON object") {
 		t.Fatalf("repair prompt=%q", repair.Prompt)


### PR DESCRIPTION
## Summary
- keep bounded same-participant report repair on the review delegate's tool-capable execution transport
- prevent CLI-backed agents such as Claude from falling into the simple HTTP path, where no request URL exists
- update the regression assertion to pin this transport invariant

## Validation
- `cd server-go && go test ./...`
- live `.254` evidence: initial three-seat panel jobs 8540–8542 completed; malformed Claude job 8542 correctly triggered same-participant repair job 8543, which failed before inference with `failed to build request URL` because the repair request explicitly set `tools:false`.