### PR TITLE
fix(delegate): wait for CLI assistant response

### DIFF
--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -1014,6 +1014,8 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
    long long start = mono_ms();
    int err_active = 0;      /* 1 once the pane is in a provider-error state */
    long long err_start = 0; /* mono_ms when that state began (valid iff err_active) */
+   int saw_answer = 0;
+   int marker_cli = strstr(s->cli_kind, "claude") != NULL || strstr(s->cli_kind, "codex") != NULL;
    free(s->stream_emitted);
    s->stream_emitted = strdup("");
 
@@ -1101,6 +1103,18 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
       if (cli_session_capture(s, cap, sizeof(cap)) != 0)
          continue;
 
+      /* A freshly pasted prompt can leave the pane static for several polls
+       * before the CLI begins inference. It is user/composer text, not a reply.
+       * Remember whether a known TUI has ever rendered a new assistant marker;
+       * completion below must not return the baseline delta until that happens.
+       * Once seen, the marker may scroll off a long answer, so retain the bit. */
+      if (marker_cli && !saw_answer)
+      {
+         char *marked = cli_extract_impl(cap, s->cli_kind, s->baseline, 0);
+         saw_answer = marked && marked[0];
+         free(marked);
+      }
+
       /* Stream the clean answer's growth as it is produced: extract this turn's
        * response so far and emit only the newly appended suffix. */
       if (g_stream_cb)
@@ -1187,6 +1201,11 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
             }
             else
             {
+               if (marker_cli && !saw_answer)
+               {
+                  stable = 0;
+                  continue;
+               }
                char *resp = cli_session_extract_response(cap, s->cli_kind, s->baseline);
                snprintf(out, out_max, "%s", resp ? resp : "");
                free(resp);

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -57,8 +57,10 @@ static void install_fake_tmux(void)
     * line (never stabilises); `banner_retry` animates a │-prefixed box line whose
     * prose contains "Retrying in" (mimics the welcome banner — must NOT be read as
     * a provider error); `busy_tool` returns a STATIC pane whose footer still shows
-    * "esc to interrupt" (a long-running tool — recv must NOT finalize it); anything
-    * else returns a static pane. send-keys is logged so the cancel/error tests can
+    * "esc to interrupt" (a long-running tool — recv must NOT finalize it);
+    * `prompt_then_answer` holds a pasted prompt static past the stability threshold
+    * before rendering a Claude assistant bullet; anything else returns a static
+    * pane. send-keys is logged so the cancel/error tests can
     * assert the interrupt key. */
    fprintf(f,
            "#!/bin/sh\n"
@@ -80,13 +82,18 @@ static void install_fake_tmux(void)
            "      c=0; [ -f '%s' ] && c=$(cat '%s'); c=$((c+1)); echo \"$c\" > '%s';\n"
            "      echo '\xe2\x94\x82 stream-stall hint now reads Retrying in seconds frame "
            "'\"$c\"' end';\n"
+           "    elif [ \"$FAKE_TMUX_MODE\" = prompt_then_answer ]; then\n"
+           "      c=0; [ -f '%s' ] && c=$(cat '%s'); c=$((c+1)); echo \"$c\" > '%s';\n"
+           "      if [ \"$c\" -le 6 ]; then echo '\xe2\x9d\xaf pasted repair prompt'; "
+           "else printf '%%s\\n' '\xe2\x9d\xaf pasted repair prompt' "
+           "'\xe2\x97\x8f {\"ok\":true}' '\xe2\x9c\xbb Baked for 1s'; fi;\n"
            "    else echo 'STATIC OUTPUT'; fi; exit 0 ;;\n"
            "  send-keys) shift; echo \"$*\" >> '%s'; exit 0 ;;\n"
            "  new-session) shift; for a in \"$@\"; do echo \"ARG:[$a]\" >> '%s'; done; exit 0 ;;\n"
            "  *) exit 0 ;;\n"
            "esac\n",
-           counter, counter, counter, counter, counter, counter, counter, counter, counter,
-           g_sendlog, g_createlog);
+           counter, counter, counter, counter, counter, counter, counter, counter, counter, counter,
+           counter, counter, g_sendlog, g_createlog);
    fclose(f);
    assert(chmod(script, 0700) == 0);
 
@@ -185,6 +192,20 @@ static void test_recv_ok_on_stable_pane(void)
    int rc = cli_session_recv(&s, buf, sizeof(buf), 10000);
    assert(rc == 0);
    assert(strstr(buf, "STATIC OUTPUT") != NULL);
+}
+
+static void test_recv_does_not_return_static_prompt_as_answer(void)
+{
+   setenv("FAKE_TMUX_MODE", "prompt_then_answer", 1);
+   char counter[300];
+   snprintf(counter, sizeof(counter), "%s/counter", g_fake_dir);
+   unlink(counter);
+   cli_session_t s = fake_session();
+   cli_session_set_kind(&s, "claude");
+   char buf[8192];
+   int rc = cli_session_recv(&s, buf, sizeof(buf), 10000);
+   assert(rc == 0);
+   assert(strcmp(buf, "{\"ok\":true}") == 0);
 }
 
 static void test_recv_dead_session(void)
@@ -1034,6 +1055,10 @@ int main(void)
 
    printf("test_recv_ok_on_stable_pane... ");
    test_recv_ok_on_stable_pane();
+   printf("OK\n");
+
+   printf("test_recv_does_not_return_static_prompt_as_answer... ");
+   test_recv_does_not_return_static_prompt_as_answer();
    printf("OK\n");
 
    printf("test_recv_dead_session... ");


### PR DESCRIPTION
## Summary
- prevent the tmux CLI delegate driver from treating a temporarily static pasted prompt as the model response
- require a newly rendered assistant marker before known Claude/Codex TUIs can finalize a turn
- retain the marker once seen so long responses can still finish after it scrolls off-screen

## Validation
- `cd src && make build/obj/tests/unit-test-cli-session && ./build/obj/tests/unit-test-cli-session`
- `cd src && make lint`

## Live evidence
Roundtable repair job 8547 reached the same Claude participant successfully, but returned the pasted repair prompt and `paste again to expand` instead of an answer. The regression fixture deliberately holds a pasted prompt static beyond the existing stability threshold, then renders a Claude assistant bullet; the driver now waits and returns only the assistant JSON.