### PR TITLE
fix(delegate): preserve JSON through CLI hard wraps

### DIFF
--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -912,9 +912,50 @@ static char *cli_extract_impl(const char *raw, const char *cli_kind, const char 
    return filtered;
 }
 
+/* Claude's TUI hard-wraps long rendered lines itself.  Those rows are not tmux
+ * soft wraps, so capture-pane -J cannot join them.  In ordinary prose the row
+ * break is harmless, but inside a JSON string it turns otherwise-correct model
+ * output into invalid JSON.  Preserve formatting outside strings and replace
+ * only literal control characters inside a response that starts as JSON. */
+static void cli_normalize_json_string_wraps(char *text)
+{
+   if (!text)
+      return;
+   char *p = text;
+   while (*p == ' ' || *p == '\t' || *p == '\r' || *p == '\n')
+      p++;
+   if (*p != '{' && *p != '[')
+      return;
+
+   int in_string = 0, escaped = 0;
+   for (; *p; p++)
+   {
+      if (in_string && (*p == '\n' || *p == '\r' || *p == '\t'))
+      {
+         *p = ' ';
+         escaped = 0;
+         continue;
+      }
+      if (escaped)
+      {
+         escaped = 0;
+         continue;
+      }
+      if (in_string && *p == '\\')
+      {
+         escaped = 1;
+         continue;
+      }
+      if (*p == '"')
+         in_string = !in_string;
+   }
+}
+
 char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline)
 {
-   return cli_extract_impl(raw, cli_kind, baseline, 1);
+   char *response = cli_extract_impl(raw, cli_kind, baseline, 1);
+   cli_normalize_json_string_wraps(response);
+   return response;
 }
 
 /* Recognize the CLI's animated working/status line so the answer extractor can

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -603,6 +603,27 @@ static void test_extract_claude_multiline(void)
    free(r);
 }
 
+/* Claude renders long JSON strings as hard terminal rows.  tmux marks those as
+ * real newlines (not soft wraps), so extraction must make the structured result
+ * valid without flattening pretty-printed newlines between JSON fields. */
+static void test_extract_claude_json_hard_wrap_inside_string(void)
+{
+   const char *pane = "\xe2\x9d\xaf q\n"
+                      "\xe2\x97\x8f {\"status\":\"ok\",\"evidence\":\"long text at the hard\n"
+                      "  terminal wrap\",\n"
+                      "  \"findings\":[]}\n"
+                      "\xe2\x9c\xbb Cooked for 1s\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
+   assert(r != NULL);
+   cJSON *parsed = cJSON_Parse(r);
+   assert(parsed != NULL);
+   cJSON *evidence = cJSON_GetObjectItemCaseSensitive(parsed, "evidence");
+   assert(cJSON_IsString(evidence));
+   assert(strstr(evidence->valuestring, "hard terminal wrap") != NULL);
+   cJSON_Delete(parsed);
+   free(r);
+}
+
 /* Regression (found by live e2e): claude renders its model/effort status with the
  * SAME ● bullet as a real answer ("● high · /effort"); it must be treated as
  * chrome and skipped, not returned as the reply. */
@@ -962,6 +983,10 @@ int main(void)
 
    printf("test_extract_claude_multiline... ");
    test_extract_claude_multiline();
+   printf("OK\n");
+
+   printf("test_extract_claude_json_hard_wrap_inside_string... ");
+   test_extract_claude_json_hard_wrap_inside_string();
    printf("OK\n");
 
    printf("test_extract_claude_skips_effort_status... ");


### PR DESCRIPTION
## Summary
- normalize literal terminal row breaks only when they occur inside JSON strings extracted from CLI TUIs
- preserve pretty-printed JSON structure and ordinary multiline prose
- add a regression that parses a hard-wrapped Claude response as JSON

## Validation
- `make -C src build/obj/tests/unit-test-cli-session -j4`
- `src/build/obj/tests/unit-test-cli-session`
- `make -C src lint`

Live post-deploy testing of #1826 proved prompt echo, missing scrollback, and tmux soft wraps are fixed, but exposed Claude application-level hard wrapping inside JSON strings. This closes that final serialization gap.