### PR TITLE
fix(console): restore typed-facts ACL parity

### DIFF
--- a/docs/proposals/done/console-typed-facts-acl-parity.plan.md
+++ b/docs/proposals/done/console-typed-facts-acl-parity.plan.md
@@ -1,6 +1,6 @@
 # Console typed-facts ACL parity correction
 
-- **State:** plan review pending.
+- **State:** delivered; plan and frozen-diff reviews converged in jobs 8985 and 8986.
 - **Scope:** restore the existing Go/C console-admin containment invariant.
 
 The C `CONSOLE_ADMIN_ACL` already authorizes the three exact typed-facts console routes, while
@@ -12,3 +12,9 @@ Add exactly `GET /v1/console/typed_facts`, `POST /v1/console/typed_facts/config`
 change credentials, or alter handler authorization. Verify the drift lock, deny-by-default tests,
 Go race tests, and an adversarial focused roundtable. Merge this correction independently before
 P5-D1 so that P5-D1 can keep the pre-existing console-admin allowlist unchanged.
+
+## Outcome
+
+The Go mirror now contains exactly the three literal method/path pairs already present in C. The
+existing drift lock, deny-by-default suite, normal Go tests, and race tests pass. No C ACL,
+credential, route matcher, or handler authorization changed.

--- a/docs/proposals/pending/console-typed-facts-acl-parity.plan.md
+++ b/docs/proposals/pending/console-typed-facts-acl-parity.plan.md
@@ -1,0 +1,14 @@
+# Console typed-facts ACL parity correction
+
+- **State:** plan review pending.
+- **Scope:** restore the existing Go/C console-admin containment invariant.
+
+The C `CONSOLE_ADMIN_ACL` already authorizes the three exact typed-facts console routes, while
+the Go `consoleAdminACL` omits them. As a result, the existing `TestACLNoDriftWithC` fails on
+`testing` and the browser console cannot reach already-authorized typed-facts handlers.
+
+Add exactly `GET /v1/console/typed_facts`, `POST /v1/console/typed_facts/config`, and
+`POST /v1/console/typed_facts/relation` to the Go mirror. Do not add patterns, modify the C ACL,
+change credentials, or alter handler authorization. Verify the drift lock, deny-by-default tests,
+Go race tests, and an adversarial focused roundtable. Merge this correction independently before
+P5-D1 so that P5-D1 can keep the pre-existing console-admin allowlist unchanged.

--- a/kb-console/acl.go
+++ b/kb-console/acl.go
@@ -18,6 +18,9 @@ type aclEntry struct {
 
 var consoleAdminACL = []aclEntry{
 	{"GET", "/v1/console/overview"},
+	{"GET", "/v1/console/typed_facts"},
+	{"POST", "/v1/console/typed_facts/config"},
+	{"POST", "/v1/console/typed_facts/relation"},
 	{"POST", "/v1/enroll"},
 	{"GET", "/v1/enrollments"},
 	{"POST", "/v1/enrollments/{id}/revoke"},


### PR DESCRIPTION
Restores the existing Go/C console-admin containment invariant by adding only the three exact typed-facts routes already present in the C ACL. Go and race suites pass; focused plan and frozen-diff roundtables converged.