### PR TITLE
fix(wfe): recover transient roundtable phases

### DIFF
--- a/docs/ENSEMBLE.md
+++ b/docs/ENSEMBLE.md
@@ -63,8 +63,8 @@ A foundational finding also stops after one cycle when the seats agree or one
 position already has a strict majority. Only an explicitly disputed
 foundational finding may continue to another cycle, and subsequent cycles carry
 only those contested stable issue IDs. Discussion ends when a strict majority
-forms; deadline or quorum loss parks the workflow visibly rather than fabricating
-consensus. Deterministic synthesis retains findings unless a strict majority
+forms; deadline or quorum loss parks the workflow visibly for scheduler retry
+rather than fabricating consensus. Deterministic synthesis retains findings unless a strict majority
 rejects them.
 The denominator is the successful seated participants that return a complete,
 valid ballot in that discussion cycle. Abstentions remain in that denominator
@@ -77,8 +77,10 @@ The chairman is one configured, enabled review agent selected visibly in the
 Roundtable GUI. It receives the original request, reviewed artifact, independent
 reports, and deterministic feedback, then submits one final structured verdict.
 There is no chairman retry across the roster: an unavailable chairman, malformed
-verdict, stage mismatch, or missing original-request alignment parks the workflow
-visibly. With the chairman disabled, deterministic synthesis is final.
+verdict, stage mismatch, or contradictory verdict parks the workflow visibly for
+scheduler retry with a new execution version. A valid `changes` verdict with
+`drifted` or `unclear` alignment is refinement feedback, not an execution failure.
+With the chairman disabled, deterministic synthesis is final.
 
 Every review must explicitly report `original_request_alignment` as `aligned`,
 `drifted`, or `unclear`, with a comparison to the originating request. A useful

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -123,7 +123,10 @@ If Discussion mode is enabled on that preset, all successful seats compare the
 independent reports once. Nits, suggestions, and ordinary defects cannot extend
 discussion beyond that cycle. Only disagreement about a foundational issue may
 continue, carrying just the contested stable issue IDs until a strict majority
-forms. Deadline or quorum loss parks the gate instead of inventing consensus.
+forms. Deadline or quorum loss parks the gate instead of inventing consensus;
+the scheduler retries that execution-owned pause after a bounded backoff with a
+new durable execution version. Work-item cost and turn caps remain the safety
+backstops, while operator and convergence parks are never auto-resumed.
 Strict majority is measured over successful seats returning a complete valid
 ballot in that cycle; abstentions remain in the denominator but do not alone
 extend discussion. The preset's `deadline_ms` covers analysis and discussion
@@ -131,9 +134,11 @@ together, with zero/omitted legacy values normalized to 360 seconds.
 
 An optional configured chairman runs once after deterministic synthesis and
 submits the final structured feedback. The chairman is a positive, visible agent
-selection, not an exclusion rule. Failure, malformed output, wrong artifact
-stage, or missing original-request alignment parks the gate; it never triggers a
-roster-wide fallback. When disabled, deterministic synthesis is final.
+selection, not an exclusion rule. Transport failure, malformed output, wrong
+artifact stage, or a contradictory verdict parks the gate for scheduler retry;
+it never triggers a roster-wide fallback. A valid `changes` verdict with
+`drifted` or `unclear` alignment becomes structured refinement feedback rather
+than an execution pause. When disabled, deterministic synthesis is final.
 
 Roundtable presets are execution policy. Agents and automation may read and use
 them, but create, edit, delete, and default-selection operations require the

--- a/server-go/internal/engine/engine.go
+++ b/server-go/internal/engine/engine.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/JBailes/aimee/server-go/internal/db1"
@@ -269,7 +270,13 @@ func (e *Engine) Advance(ctx context.Context, workItemID string) (AdvanceResult,
 		if reason == "" {
 			reason = "runner_pending"
 		}
-		if err := e.db.Park(ctx, item.ID, node.ID, reason, step.CostUSD); err != nil {
+		detail := strings.TrimSpace(step.Detail)
+		if detail == "" {
+			detail = reason
+		} else {
+			detail = reason + ": " + safeDiagnostic(detail)
+		}
+		if err := e.db.ParkWithDetail(ctx, item.ID, node.ID, reason, detail, step.CostUSD); err != nil {
 			return out, err
 		}
 		out.Parked, out.PauseReason = true, reason

--- a/server-go/internal/engine/native_e2e_test.go
+++ b/server-go/internal/engine/native_e2e_test.go
@@ -64,6 +64,24 @@ type passVerifier struct{}
 
 func (passVerifier) Verify(context.Context, string) error { return nil }
 
+type transientGateRunner struct {
+	mu       sync.Mutex
+	next     Runner
+	failures []string
+}
+
+func (r *transientGateRunner) Run(ctx context.Context, request StepRequest) (StepResult, error) {
+	r.mu.Lock()
+	if request.Node.ID == "plan_gate" && len(r.failures) > 0 {
+		reason := r.failures[0]
+		r.failures = r.failures[1:]
+		r.mu.Unlock()
+		return StepResult{Status: StepPending, PauseReason: reason, Detail: "injected transient " + reason}, nil
+	}
+	r.mu.Unlock()
+	return r.next.Run(ctx, request)
+}
+
 type e2eForge struct{}
 
 func (e2eForge) Push(ctx context.Context, _, workdir, branch string) error {
@@ -251,13 +269,18 @@ nodes:
 	if err != nil {
 		t.Fatal(err)
 	}
-	eng, err := New(store, artifacts, workflowDir, runner)
+	recoveringRunner := &transientGateRunner{next: runner, failures: []string{"roundtable_discussion", "roundtable_chairman"}}
+	eng, err := New(store, artifacts, workflowDir, recoveringRunner)
 	if err != nil {
 		t.Fatal(err)
 	}
 	scheduler := NewScheduler(store, eng, 2, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	scheduler.pollEvery = 20 * time.Millisecond
+	scheduler.transientPauses = []transientPause{
+		{reason: "roundtable_discussion", backoff: 100 * time.Millisecond},
+		{reason: "roundtable_chairman", backoff: 100 * time.Millisecond},
+	}
 	done := make(chan struct{})
 	go func() { scheduler.Run(ctx); close(done) }()
 	shutdown := func() { cancel(); <-done }
@@ -274,6 +297,27 @@ nodes:
 		if item.State == "accepted" {
 			if item.PRRef == "" {
 				t.Fatal("final PR ref was not persisted")
+			}
+			recoveringRunner.mu.Lock()
+			remainingFailures := len(recoveringRunner.failures)
+			recoveringRunner.mu.Unlock()
+			if remainingFailures != 0 {
+				t.Fatalf("%d transient roundtable failures were not exercised", remainingFailures)
+			}
+			events, err := store.Events(context.Background(), rootID, 0, 1000)
+			if err != nil {
+				t.Fatal(err)
+			}
+			seen := map[string]bool{}
+			for _, event := range events {
+				if event.Kind == "pause" {
+					seen[event.Detail] = true
+				}
+			}
+			for _, reason := range []string{"roundtable_discussion: injected transient roundtable_discussion", "roundtable_chairman: injected transient roundtable_chairman"} {
+				if !seen[reason] {
+					t.Fatalf("missing transient recovery event %q: %+v", reason, events)
+				}
 			}
 			shutdown = func() {}
 			cancel()

--- a/server-go/internal/engine/roundtable_chairman.go
+++ b/server-go/internal/engine/roundtable_chairman.go
@@ -52,20 +52,41 @@ func (r *NativeRunner) runPanelChairman(ctx context.Context, req StepRequest, pa
 	if !stageOK || stage != artifactStage {
 		return feedback, analysis.Approvals, cost, "chairman did not evaluate the declared artifact stage"
 	}
-	if strings.ToLower(strings.TrimSpace(final.OriginalRequestAlignment.Status)) != "aligned" {
-		return feedback, analysis.Approvals, cost, "chairman did not confirm original-request alignment"
+	alignment := strings.ToLower(strings.TrimSpace(final.OriginalRequestAlignment.Status))
+	if alignment != "aligned" && alignment != "drifted" && alignment != "unclear" {
+		return feedback, analysis.Approvals, cost, "chairman did not provide a valid original-request alignment"
 	}
 	switch strings.ToLower(strings.TrimSpace(final.Verdict)) {
 	case "approve":
 		if len(final.Findings) != 0 {
 			return feedback, analysis.Approvals, cost, "chairman returned approve with findings"
 		}
+		if alignment != "aligned" {
+			return feedback, analysis.Approvals, cost, "chairman returned approve without confirming original-request alignment"
+		}
 		return wfe.ReviewFeedback{SchemaVersion: 1, ArtifactHash: feedback.ArtifactHash}, len(analysis.Reports), cost, ""
 	case "changes":
 		if len(final.Findings) == 0 {
 			return feedback, analysis.Approvals, cost, "chairman returned changes without findings"
 		}
-		out := wfe.ReviewFeedback{SchemaVersion: 1, ArtifactHash: feedback.ArtifactHash, Findings: make([]wfe.Finding, 0, len(final.Findings))}
+		capacity := len(final.Findings)
+		if alignment != "aligned" {
+			capacity++
+		}
+		out := wfe.ReviewFeedback{SchemaVersion: 1, ArtifactHash: feedback.ArtifactHash, Findings: make([]wfe.Finding, 0, capacity)}
+		if alignment != "aligned" {
+			summary := strings.TrimSpace(final.OriginalRequestAlignment.Summary)
+			if summary == "" {
+				summary = "chairman did not establish that the artifact follows the original request"
+			}
+			out.Findings = append(out.Findings, wfe.Finding{
+				ID:             "chairman-original-request-alignment",
+				Persona:        "chairman",
+				Severity:       "blocking",
+				Summary:        "original-request alignment is " + alignment + ": " + summary,
+				Recommendation: "revise the artifact so it directly serves the original request, then reconvene the configured roundtable",
+			})
+		}
 		for i, finding := range final.Findings {
 			out.Findings = append(out.Findings, wfe.Finding{ID: firstNonempty(finding.ID, fmt.Sprintf("chairman-%d", i+1)), Persona: "chairman", Severity: firstNonempty(finding.Severity, "blocking"), Location: finding.Location, Summary: finding.Summary, Recommendation: finding.Recommendation})
 		}

--- a/server-go/internal/engine/roundtable_chairman_test.go
+++ b/server-go/internal/engine/roundtable_chairman_test.go
@@ -43,6 +43,21 @@ func TestChairmanChangesReceiveStableFinalIDs(t *testing.T) {
 	}
 }
 
+func TestChairmanDriftedChangesBecomeActionableFeedback(t *testing.T) {
+	agents := &discussionTestAgents{respond: func(DelegateRequest) (string, error) {
+		return `{"artifact_stage":"plan","original_request_alignment":{"status":"drifted","summary":"the plan substitutes a different outcome"},"verdict":"changes","findings":[{"id":"scope","severity":"blocking","location":"objective","summary":"wrong outcome","recommendation":"restore the requested outcome"}]}`, nil
+	}}
+	runner := &NativeRunner{agents: agents}
+	analysis := discussionAnalysis("blocking")
+	feedback, approvals, _, errText := runner.runPanelChairman(context.Background(), chairmanRequest(), roundtablecfg.Panel{ChairmanEnabled: true, Chairman: "codex"}, analysis, analysis.Feedback, 0, "plan")
+	if errText != "" || approvals != 0 || len(feedback.Findings) != 2 {
+		t.Fatalf("drifted changes did not reach refinement: approvals=%d err=%q feedback=%+v", approvals, errText, feedback)
+	}
+	if feedback.Findings[0].Persona != "chairman" || !strings.Contains(feedback.Findings[0].Summary, "alignment is drifted") {
+		t.Fatalf("missing alignment feedback: %+v", feedback.Findings)
+	}
+}
+
 func TestChairmanFailsClosedOnMalformedFinalVerdict(t *testing.T) {
 	for _, response := range []string{
 		`{"artifact_stage":"plan","original_request_alignment":{"status":"aligned"},"verdict":"approve","findings":[{"id":"x"}]}`,

--- a/server-go/internal/engine/scheduler.go
+++ b/server-go/internal/engine/scheduler.go
@@ -17,12 +17,31 @@ type Scheduler struct {
 	concurrencySource func() int
 	policySource      func() RunPolicy
 	pollEvery         time.Duration
+	transientPauses   []transientPause
 	log               *slog.Logger
 
 	mu      sync.Mutex
 	running map[string]struct{}
 	cancels map[string]context.CancelFunc
 	wake    chan struct{}
+}
+
+type transientPause struct {
+	reason  string
+	backoff time.Duration
+}
+
+// Scheduler-owned pauses describe unavailable execution machinery, not a
+// lifecycle decision. Retrying them creates a new execution version, so
+// cancelled or malformed durable delegate results cannot poison every future
+// attempt. Work-item cost and turn caps remain the bounded safety backstops.
+var schedulerTransientPauses = []transientPause{
+	{reason: "runner_unavailable", backoff: 5 * time.Second},
+	{reason: "ci_pending", backoff: 15 * time.Second},
+	{reason: "merge_pending", backoff: 15 * time.Second},
+	{reason: "panel_unreachable", backoff: 60 * time.Second},
+	{reason: "roundtable_discussion", backoff: 60 * time.Second},
+	{reason: "roundtable_chairman", backoff: 60 * time.Second},
 }
 
 func (s *Scheduler) SetConcurrencySource(source func() int) {
@@ -54,7 +73,8 @@ func NewScheduler(db *db1.Store, engine *Engine, concurrency int, logger *slog.L
 		logger = slog.Default()
 	}
 	return &Scheduler{db: db, engine: engine, concurrency: concurrency,
-		pollEvery: time.Second, log: logger, running: make(map[string]struct{}),
+		pollEvery: time.Second, transientPauses: append([]transientPause(nil), schedulerTransientPauses...),
+		log: logger, running: make(map[string]struct{}),
 		cancels: make(map[string]context.CancelFunc), wake: make(chan struct{}, 1)}
 }
 
@@ -114,11 +134,11 @@ func (s *Scheduler) fill(ctx context.Context) {
 			}
 		}
 	}
-	for reason, backoff := range map[string]time.Duration{"runner_unavailable": 5 * time.Second, "ci_pending": 15 * time.Second, "merge_pending": 15 * time.Second, "panel_unreachable": 60 * time.Second} {
-		if resumed, err := s.db.ResumeTransient(ctx, reason, backoff); err != nil {
-			s.log.Error("resume transient workflows", "reason", reason, "error", err)
+	for _, pause := range s.transientPauses {
+		if resumed, err := s.db.ResumeTransient(ctx, pause.reason, pause.backoff); err != nil {
+			s.log.Error("resume transient workflows", "reason", pause.reason, "error", err)
 		} else if resumed > 0 {
-			s.log.Info("resumed transient workflows", "reason", reason, "count", resumed)
+			s.log.Info("resumed transient workflows", "reason", pause.reason, "count", resumed)
 		}
 	}
 	if resumed, err := s.db.ResumeReadyParents(ctx); err != nil {

--- a/server-go/internal/engine/scheduler_test.go
+++ b/server-go/internal/engine/scheduler_test.go
@@ -2,8 +2,10 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +16,24 @@ import (
 type blockingRunner struct {
 	started chan string
 	release chan struct{}
+}
+
+type transientRoundtableRunner struct {
+	mu       sync.Mutex
+	reasons  map[string]string
+	versions map[string]string
+}
+
+func (r *transientRoundtableRunner) Run(_ context.Context, request StepRequest) (StepResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if first, ok := r.versions[request.WorkItem.ID]; !ok {
+		r.versions[request.WorkItem.ID] = request.WorkItem.UpdatedAt
+		return StepResult{Status: StepPending, PauseReason: r.reasons[request.WorkItem.ID], Detail: "temporary roundtable phase failure"}, nil
+	} else if first == request.WorkItem.UpdatedAt {
+		return StepResult{}, errors.New("scheduler retry reused the parked execution version")
+	}
+	return StepResult{Status: StepAdvanced}, nil
 }
 
 func (r *blockingRunner) Run(ctx context.Context, request StepRequest) (StepResult, error) {
@@ -97,6 +117,83 @@ func waitStarted(t *testing.T, started <-chan string) string {
 		t.Fatal("workflow did not start")
 		return ""
 	}
+}
+
+func TestSchedulerRecoversRoundtablePhasePausesWithNewExecutionVersion(t *testing.T) {
+	root := t.TempDir()
+	workflowDir := filepath.Join(root, "workflows")
+	if err := os.MkdirAll(workflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	definition := []byte("name: one\nstart: work\nnodes:\n  - id: work\n    block: author.proposal\n")
+	if err := os.WriteFile(filepath.Join(workflowDir, "one.yaml"), definition, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	def, err := wfe.ParseDefinition(definition)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := db1.Open(filepath.Join(root, "aimee.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	artifacts, err := wfe.NewArtifactStore(filepath.Join(root, "artifacts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reasons := map[string]string{
+		"wi_discussion": "roundtable_discussion",
+		"wi_chairman":   "roundtable_chairman",
+	}
+	for id := range reasons {
+		if err := artifacts.PutProposal(id, []byte("proposal")); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.CreateWorkItem(t.Context(), db1.CreateWorkItem{
+			ID: id, Repo: "repo", ProposalPath: id, WorkflowName: "one",
+			WorkflowVersion: def.Version, StartStage: "work", Mode: "autonomous",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runner := &transientRoundtableRunner{reasons: reasons, versions: make(map[string]string)}
+	workflowEngine, err := New(store, artifacts, workflowDir, runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewScheduler(store, workflowEngine, 2, nil)
+	scheduler.pollEvery = 10 * time.Millisecond
+	scheduler.transientPauses = []transientPause{
+		{reason: "roundtable_discussion", backoff: time.Second},
+		{reason: "roundtable_chairman", backoff: time.Second},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go scheduler.Run(ctx)
+
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		accepted := 0
+		for id := range reasons {
+			item, err := store.WorkItem(t.Context(), id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if item.State == "accepted" {
+				accepted++
+			}
+		}
+		if accepted == len(reasons) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	for id, reason := range reasons {
+		item, _ := store.WorkItem(t.Context(), id)
+		t.Logf("%s (%s): state=%s pause=%s updated=%s", id, reason, item.State, item.PauseReason, item.UpdatedAt)
+	}
+	t.Fatal("roundtable phase pauses did not recover through the scheduler")
 }
 
 func TestSchedulerCancelCannotAdvancePausedWorkflow(t *testing.T) {


### PR DESCRIPTION
## Summary
- route valid chairman `changes` verdicts with drifted/unclear alignment back into structured artifact refinement
- auto-resume transient discussion/chairman execution pauses with a fresh durable execution version
- retain redacted phase diagnostics in lifecycle events
- document the recovery contract

## Verification
- `cd server-go && go test ./...`
- `cd src && make build-integrity`
- production-shaped scheduler E2E injects both `roundtable_discussion` and `roundtable_chairman`, then reaches `final_pr` with a persisted PR ref

## Live evidence
The three appliance WFE roots had successful plan refinement, then permanently parked on these two phase reasons. Their delegate rows show valid chairman `changes` results and discussion jobs cancelled at the shared deadline. This patch makes those execution failures recoverable without auto-resuming operator or convergence parks.