### PR TITLE
fix(roundtable): honor degraded quorum deadlines

### DIFF
--- a/docs/ENSEMBLE.md
+++ b/docs/ENSEMBLE.md
@@ -71,6 +71,19 @@ valid ballot in that discussion cycle. Abstentions remain in that denominator
 but do not by themselves count as disagreement or extend discussion. The saved
 `deadline_ms` is the overall analysis-plus-discussion budget; an omitted or zero
 legacy value is normalized to 360 seconds.
+The runtime divides that overall budget evenly across the configured analysis,
+Discussion, and Chairman phases. This prevents one slow analysis seat from
+consuming time reserved for a required downstream phase while preserving the
+single overall deadline as the hard upper bound.
+The C compatibility proxy derives its finite receive timeout from that acquired
+preset deadline and adds only transport grace; it does not impose a shorter
+fixed deadline or wait without a bound.
+
+An unavailable or unusable independent-analysis seat is recorded as failed and
+makes the result degraded. It parks the roundtable only when the remaining
+complete reports are below the preset's `min_successful`; a satisfied configured
+minimum proceeds to discussion or deterministic synthesis without hiding the
+failed seat.
 
 After deterministic synthesis, a preset may optionally require a **chairman**.
 The chairman is one configured, enabled review agent selected visibly in the

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -131,6 +131,14 @@ Strict majority is measured over successful seats returning a complete valid
 ballot in that cycle; abstentions remain in the denominator but do not alone
 extend discussion. The preset's `deadline_ms` covers analysis and discussion
 together, with zero/omitted legacy values normalized to 360 seconds.
+That overall budget is divided evenly among enabled analysis, Discussion, and
+Chairman phases so a slow seat cannot consume the time required by a later
+configured phase.
+The compatibility proxy uses the acquired preset deadline plus bounded
+transport grace, so its socket timeout cannot preempt valid configured work.
+An unavailable independent-analysis seat remains visible as degraded
+participation, but it parks the gate only when complete reports fall below the
+preset's `min_successful`; meeting that configured minimum continues normally.
 
 An optional configured chairman runs once after deterministic synthesis and
 submits the final structured feedback. The chairman is a positive, visible agent

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -563,41 +563,82 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 		roundtableCtx, cancel = context.WithTimeout(ctx, time.Duration(panel.DeadlineMS)*time.Millisecond)
 	}
 	defer cancel()
-	analysis := r.runPanelAnalysis(roundtableCtx, req, seats, basePrompt, reviewed.Hash, stage, 1)
-	if analysis.Unreachable != "" {
+	phaseCount := 1
+	if panel.Discussion {
+		phaseCount++
+	}
+	if panel.ChairmanEnabled {
+		phaseCount++
+	}
+	analysisCtx, analysisCancel := roundtablePhaseContext(roundtableCtx, panel.DeadlineMS, phaseCount)
+	analysis := r.runPanelAnalysis(analysisCtx, req, seats, basePrompt, reviewed.Hash, stage, 1)
+	deadlineHit := errors.Is(analysisCtx.Err(), context.DeadlineExceeded)
+	analysisCancel()
+	// A configured minimum is the roundtable's explicit degraded-operation
+	// contract. Every seat was attempted and remains visible in the result, but
+	// one unavailable seat must not discard a usable quorum. Park only when the
+	// number of complete reports is actually below that configured minimum.
+	if analysis.Unreachable != "" && len(analysis.Reports) < panel.MinSuccessful {
 		rt := roundtableResult(&analysis.Feedback, false, false, analysis, len(seats), analysis.CostUSD)
-		rt.DeadlineHit = roundtableCtx.Err() != nil
+		rt.DeadlineHit = deadlineHit || errors.Is(roundtableCtx.Err(), context.DeadlineExceeded)
 		return StepResult{Status: StepPending, PauseReason: "panel_unreachable", Detail: analysis.Unreachable, CostUSD: analysis.CostUSD, Roundtable: rt}, nil
 	}
 	feedback, approvals, totalCost := analysis.Feedback, analysis.Approvals, analysis.CostUSD
+	discussionFailed := 0
 	if panel.Discussion {
 		var discussionErr string
-		feedback, approvals, totalCost, discussionErr = r.runPanelDiscussion(roundtableCtx, req, panel, analysis, stage)
+		discussionCtx, discussionCancel := roundtablePhaseContext(roundtableCtx, panel.DeadlineMS, phaseCount)
+		feedback, approvals, totalCost, discussionFailed, discussionErr = r.runPanelDiscussion(discussionCtx, req, panel, analysis, stage)
+		deadlineHit = deadlineHit || errors.Is(discussionCtx.Err(), context.DeadlineExceeded)
+		discussionCancel()
 		if discussionErr != "" {
 			rt := roundtableResult(&feedback, false, false, analysis, len(seats), totalCost)
-			rt.DeadlineHit = roundtableCtx.Err() != nil
+			rt.Degraded = rt.Degraded || discussionFailed > 0
+			rt.DeadlineHit = deadlineHit || errors.Is(roundtableCtx.Err(), context.DeadlineExceeded)
 			return StepResult{Status: StepPending, PauseReason: "roundtable_discussion", Detail: discussionErr, CostUSD: totalCost, Roundtable: rt}, nil
 		}
 	}
 	if panel.ChairmanEnabled {
 		var chairmanErr string
-		feedback, approvals, totalCost, chairmanErr = r.runPanelChairman(roundtableCtx, req, panel, analysis, feedback, totalCost, stage)
+		chairmanCtx, chairmanCancel := roundtablePhaseContext(roundtableCtx, panel.DeadlineMS, phaseCount)
+		feedback, approvals, totalCost, chairmanErr = r.runPanelChairman(chairmanCtx, req, panel, analysis, feedback, totalCost, stage)
+		deadlineHit = deadlineHit || errors.Is(chairmanCtx.Err(), context.DeadlineExceeded)
+		chairmanCancel()
 		if chairmanErr != "" {
 			rt := roundtableResult(&feedback, false, false, analysis, len(seats), totalCost)
-			rt.DeadlineHit = roundtableCtx.Err() != nil
+			// The chairman is configured roundtable participation even though it
+			// is not an analysis seat. Its failure must remain visible on the
+			// parked result just like an unusable analysis or discussion response.
+			rt.Degraded = true
+			rt.DeadlineHit = deadlineHit || errors.Is(roundtableCtx.Err(), context.DeadlineExceeded)
 			return StepResult{Status: StepPending, PauseReason: "roundtable_chairman", Detail: chairmanErr, CostUSD: totalCost, Roundtable: rt}, nil
 		}
 	}
 	quorum := panel.MinSuccessful
 	if approvals >= quorum && len(feedback.Findings) == 0 {
 		rt := roundtableResult(&feedback, true, true, analysis, len(seats), totalCost)
+		rt.Degraded = rt.Degraded || discussionFailed > 0
+		rt.DeadlineHit = deadlineHit
 		return StepResult{Status: StepAdvanced, ArtifactType: "verdict", Artifact: "approved", ContentHash: reviewed.Hash, CostUSD: totalCost, Roundtable: rt}, nil
 	}
 	if len(feedback.Findings) == 0 {
 		feedback.Findings = append(feedback.Findings, wfe.Finding{ID: "quorum", Persona: "panel", Severity: "blocking", Summary: "required approval quorum was not reached", Recommendation: "revise the artifact and reconvene the configured roundtable"})
 	}
 	rt := roundtableResult(&feedback, false, true, analysis, len(seats), totalCost)
+	rt.Degraded = rt.Degraded || discussionFailed > 0
+	rt.DeadlineHit = deadlineHit
 	return StepResult{Status: StepChanges, Feedback: &feedback, CostUSD: totalCost, Roundtable: rt}, nil
+}
+
+func roundtablePhaseContext(parent context.Context, deadlineMS, phaseCount int) (context.Context, context.CancelFunc) {
+	if deadlineMS <= 0 || phaseCount <= 1 {
+		return parent, func() {}
+	}
+	budget := time.Duration(deadlineMS) * time.Millisecond / time.Duration(phaseCount)
+	if budget < time.Millisecond {
+		budget = time.Millisecond
+	}
+	return context.WithTimeout(parent, budget)
 }
 
 func roundtableStageGuidance(stage string) string {

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -145,6 +145,51 @@ type firstPanelSeatUnavailableAgents struct {
 	response string
 }
 
+type deadlineSeatAgents struct{}
+
+type deadlineDiscussionAgents struct{}
+
+type chairmanFailureAgents struct{}
+
+type chairmanDeadlineAgents struct{}
+
+func (deadlineSeatAgents) Delegate(ctx context.Context, request DelegateRequest) (DelegateResult, error) {
+	if strings.HasPrefix(request.Prompt, "ROUNDTABLE DISCUSSION CYCLE") {
+		return DelegateResult{Response: `{"positions":[]}`}, nil
+	}
+	if strings.HasSuffix(request.DurableSlot, "seat:0") {
+		<-ctx.Done()
+		return DelegateResult{}, ctx.Err()
+	}
+	return DelegateResult{Response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`}, nil
+}
+
+func (deadlineDiscussionAgents) Delegate(ctx context.Context, request DelegateRequest) (DelegateResult, error) {
+	if strings.HasPrefix(request.Prompt, "ROUNDTABLE DISCUSSION CYCLE") {
+		if strings.HasSuffix(request.DurableSlot, "seat:0") {
+			<-ctx.Done()
+			return DelegateResult{}, ctx.Err()
+		}
+		return DelegateResult{Response: `{"positions":[]}`}, nil
+	}
+	return DelegateResult{Response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`}, nil
+}
+
+func (chairmanFailureAgents) Delegate(_ context.Context, request DelegateRequest) (DelegateResult, error) {
+	if request.Persona == "chairman" {
+		return DelegateResult{}, errors.New("chairman unavailable")
+	}
+	return DelegateResult{Response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`}, nil
+}
+
+func (chairmanDeadlineAgents) Delegate(ctx context.Context, request DelegateRequest) (DelegateResult, error) {
+	if request.Persona == "chairman" {
+		<-ctx.Done()
+		return DelegateResult{}, ctx.Err()
+	}
+	return DelegateResult{Response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`}, nil
+}
+
 func (a firstPanelSeatUnavailableAgents) Delegate(_ context.Context, request DelegateRequest) (DelegateResult, error) {
 	if strings.HasSuffix(request.DurableSlot, "seat:0") {
 		return DelegateResult{}, errors.New("admission unavailable")
@@ -191,6 +236,22 @@ func (a *scriptedReviewAgents) DelegateGroup(ctx context.Context, requests []Del
 }
 
 func (a firstPanelSeatUnavailableAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	return testDelegateGroup(ctx, requests, a.Delegate)
+}
+
+func (a deadlineSeatAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	return testDelegateGroup(ctx, requests, a.Delegate)
+}
+
+func (a deadlineDiscussionAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	return testDelegateGroup(ctx, requests, a.Delegate)
+}
+
+func (a chairmanFailureAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	return testDelegateGroup(ctx, requests, a.Delegate)
+}
+
+func (a chairmanDeadlineAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
 	return testDelegateGroup(ctx, requests, a.Delegate)
 }
 
@@ -328,6 +389,191 @@ func TestStageMismatchCannotBeOverriddenByAnotherApproval(t *testing.T) {
 	feedback, approvals, voters, _, unreachable := runner.runPanelRound(context.Background(), StepRequest{}, []panelSeat{{persona: "qa"}, {persona: "security"}}, "review", "hash", "plan", 1)
 	if unreachable != "" || approvals != 1 || voters != 2 || len(feedback.Findings) != 1 || !strings.HasSuffix(feedback.Findings[0].ID, "-artifact-stage") {
 		t.Fatalf("mixed-stage panel could approve: approvals=%d voters=%d unreachable=%q feedback=%+v", approvals, voters, unreachable, feedback)
+	}
+}
+
+func TestConfiguredRoundtableHonorsMinimumWhenASeatIsUnavailable(t *testing.T) {
+	tests := []struct {
+		name          string
+		minSuccessful int
+		response      string
+		wantStatus    StepStatus
+		wantPause     string
+		wantUsed      int
+		wantFailed    int
+	}{
+		{name: "degraded-quorum", minSuccessful: 1, wantStatus: StepAdvanced, wantUsed: 1, wantFailed: 1},
+		{name: "below-quorum", minSuccessful: 2, wantStatus: StepPending, wantPause: "panel_unreachable", wantUsed: 1, wantFailed: 1},
+		{name: "unavailable-and-wrong-stage", minSuccessful: 1, response: `{"artifact_stage":"intent","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`, wantStatus: StepPending, wantPause: "panel_unreachable", wantUsed: 0, wantFailed: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			body := fmt.Sprintf(`{"name":"default","seats":[{"model":"codex","persona":"security"},{"model":"minimax","persona":"qa"}],"min_successful":%d}`, tc.minSuccessful)
+			if err := os.WriteFile(filepath.Join(dir, "default.json"), []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			store, err := roundtablecfg.NewStore(dir, func() (string, error) { return "default", nil })
+			if err != nil {
+				t.Fatal(err)
+			}
+			runner := &NativeRunner{agents: firstPanelSeatUnavailableAgents{response: tc.response}, roundtables: store}
+			reviewed := wfe.Artifact{Type: "plan", Content: []byte("complete implementation plan")}
+			reviewed.Hash = wfe.Hash(reviewed.Content)
+			result, err := runner.roundtable(context.Background(), StepRequest{
+				WorkItem: db1.WorkItem{ID: "wi", Repo: "/repo", Worktree: "/worktree"},
+				Node:     wfe.Node{ID: "gate", Block: "gate.roundtable"},
+				Proposal: "implement the requested change", Inputs: map[string]wfe.Artifact{"src": reviewed},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Status != tc.wantStatus || result.PauseReason != tc.wantPause {
+				t.Fatalf("result=%+v", result)
+			}
+			if result.Roundtable == nil || !result.Roundtable.Degraded || result.Roundtable.ParticipantsTotal != 2 || result.Roundtable.ParticipantsUsed != tc.wantUsed || result.Roundtable.ParticipantsFailed != tc.wantFailed {
+				t.Fatalf("degraded participation was not preserved: %+v", result.Roundtable)
+			}
+		})
+	}
+}
+
+func TestConfiguredRoundtableReservesDownstreamPhasesAfterSeatDeadline(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"name":"default","seats":[{"model":"codex","persona":"security"},{"model":"minimax","persona":"qa"}],"min_successful":1,"discussion":true,"chairman":"codex","chairman_enabled":true,"deadline_ms":120}`
+	if err := os.WriteFile(filepath.Join(dir, "default.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := roundtablecfg.NewStore(dir, func() (string, error) { return "default", nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{agents: deadlineSeatAgents{}, roundtables: store}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("complete implementation plan")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	started := time.Now()
+	result, err := runner.roundtable(context.Background(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Repo: "/repo", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Block: "gate.roundtable"},
+		Proposal: "implement the requested change", Inputs: map[string]wfe.Artifact{"src": reviewed},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("roundtable did not bound the slow seat: %s", elapsed)
+	}
+	if result.Status != StepAdvanced || result.Roundtable == nil || !result.Roundtable.Approved || !result.Roundtable.Degraded || !result.Roundtable.DeadlineHit {
+		t.Fatalf("result=%+v", result)
+	}
+	if result.Roundtable.ParticipantsTotal != 2 || result.Roundtable.ParticipantsUsed != 1 || result.Roundtable.ParticipantsFailed != 1 {
+		t.Fatalf("degraded participation was not preserved: %+v", result.Roundtable)
+	}
+}
+
+func TestConfiguredRoundtableHonorsDiscussionQuorumAtPhaseDeadline(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"name":"default","seats":[{"model":"codex","persona":"security"},{"model":"minimax","persona":"qa"}],"min_successful":1,"discussion":true,"deadline_ms":100}`
+	if err := os.WriteFile(filepath.Join(dir, "default.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := roundtablecfg.NewStore(dir, func() (string, error) { return "default", nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{agents: deadlineDiscussionAgents{}, roundtables: store}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("complete implementation plan")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	result, err := runner.roundtable(context.Background(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Repo: "/repo", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Block: "gate.roundtable"},
+		Proposal: "implement the requested change", Inputs: map[string]wfe.Artifact{"src": reviewed},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StepAdvanced || result.Roundtable == nil || !result.Roundtable.Approved || !result.Roundtable.Degraded || !result.Roundtable.DeadlineHit {
+		t.Fatalf("result=%+v", result)
+	}
+}
+
+func TestConfiguredRoundtableReportsEveryPhaseDeadline(t *testing.T) {
+	tests := []struct {
+		name      string
+		preset    string
+		agents    AgentClient
+		wantPause string
+	}{
+		{
+			name:      "analysis",
+			preset:    `{"name":"default","seats":[{"model":"codex","persona":"security"},{"model":"minimax","persona":"qa"}],"min_successful":2,"discussion":true,"deadline_ms":90}`,
+			agents:    deadlineSeatAgents{},
+			wantPause: "panel_unreachable",
+		},
+		{
+			name:      "discussion",
+			preset:    `{"name":"default","seats":[{"model":"codex","persona":"security"},{"model":"minimax","persona":"qa"}],"min_successful":2,"discussion":true,"deadline_ms":90}`,
+			agents:    deadlineDiscussionAgents{},
+			wantPause: "roundtable_discussion",
+		},
+		{
+			name:      "chairman",
+			preset:    `{"name":"default","seats":[{"model":"codex","persona":"security"}],"min_successful":1,"chairman":"codex","chairman_enabled":true,"deadline_ms":80}`,
+			agents:    chairmanDeadlineAgents{},
+			wantPause: "roundtable_chairman",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "default.json"), []byte(tc.preset), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			store, err := roundtablecfg.NewStore(dir, func() (string, error) { return "default", nil })
+			if err != nil {
+				t.Fatal(err)
+			}
+			runner := &NativeRunner{agents: tc.agents, roundtables: store}
+			reviewed := wfe.Artifact{Type: "plan", Content: []byte("complete implementation plan")}
+			reviewed.Hash = wfe.Hash(reviewed.Content)
+			result, err := runner.roundtable(context.Background(), StepRequest{
+				WorkItem: db1.WorkItem{ID: "wi", Repo: "/repo", Worktree: "/worktree"},
+				Node:     wfe.Node{ID: "gate", Block: "gate.roundtable"},
+				Proposal: "implement the requested change", Inputs: map[string]wfe.Artifact{"src": reviewed},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Status != StepPending || result.PauseReason != tc.wantPause || result.Roundtable == nil || !result.Roundtable.DeadlineHit {
+				t.Fatalf("phase deadline was not reported: %+v", result)
+			}
+		})
+	}
+}
+
+func TestConfiguredRoundtableChairmanFailureIsVisiblyDegraded(t *testing.T) {
+	dir := t.TempDir()
+	body := `{"name":"default","seats":[{"model":"codex","persona":"security"}],"min_successful":1,"chairman":"kimi","chairman_enabled":true,"deadline_ms":100}`
+	if err := os.WriteFile(filepath.Join(dir, "default.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := roundtablecfg.NewStore(dir, func() (string, error) { return "default", nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &NativeRunner{agents: chairmanFailureAgents{}, roundtables: store}
+	reviewed := wfe.Artifact{Type: "plan", Content: []byte("complete implementation plan")}
+	reviewed.Hash = wfe.Hash(reviewed.Content)
+	result, err := runner.roundtable(context.Background(), StepRequest{
+		WorkItem: db1.WorkItem{ID: "wi", Repo: "/repo", Worktree: "/worktree"},
+		Node:     wfe.Node{ID: "gate", Block: "gate.roundtable"},
+		Proposal: "implement the requested change", Inputs: map[string]wfe.Artifact{"src": reviewed},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != StepPending || result.PauseReason != "roundtable_chairman" || result.Roundtable == nil || !result.Roundtable.Degraded {
+		t.Fatalf("result=%+v", result)
 	}
 }
 

--- a/server-go/internal/engine/roundtable_discussion.go
+++ b/server-go/internal/engine/roundtable_discussion.go
@@ -42,7 +42,7 @@ type discussionTranscriptReport struct {
 // strict majority. Suggestions, nits, and ordinary blockers can never cause a
 // second cycle. The caller's context/deadline is the only backstop: expiry is
 // returned visibly so the workflow parks instead of inventing consensus.
-func (r *NativeRunner) runPanelDiscussion(ctx context.Context, req StepRequest, panel roundtablecfg.Panel, analysis panelAnalysis, artifactStage string) (wfe.ReviewFeedback, int, float64, string) {
+func (r *NativeRunner) runPanelDiscussion(ctx context.Context, req StepRequest, panel roundtablecfg.Panel, analysis panelAnalysis, artifactStage string) (wfe.ReviewFeedback, int, float64, int, string) {
 	feedback := analysis.Feedback
 	issues := makeDiscussionIssues(feedback.Findings)
 	// The stable ID is the issue's identity everywhere after independent
@@ -53,7 +53,7 @@ func (r *NativeRunner) runPanelDiscussion(ctx context.Context, req StepRequest, 
 		feedback.Findings[issue.feedbackIndex].ID = issue.ID
 	}
 	if len(analysis.Reports) == 0 {
-		return feedback, analysis.Approvals, analysis.CostUSD, "discussion has no successful seated analyses"
+		return feedback, analysis.Approvals, analysis.CostUSD, 0, "discussion has no successful seated analyses"
 	}
 	if len(issues) == 0 {
 		// Agents still compare their reports once even when every independent
@@ -66,6 +66,7 @@ func (r *NativeRunner) runPanelDiscussion(ctx context.Context, req StepRequest, 
 	}
 
 	totalCost := analysis.CostUSD
+	discussionFailed := 0
 	active := issues
 	cycle := 1
 	type issueDecision struct {
@@ -75,16 +76,22 @@ func (r *NativeRunner) runPanelDiscussion(ctx context.Context, req StepRequest, 
 	decisions := make(map[string]issueDecision)
 	for {
 		if err := ctx.Err(); err != nil {
-			return feedback, analysis.Approvals, totalCost, "discussion deadline reached before foundational consensus"
+			return feedback, analysis.Approvals, totalCost, discussionFailed, "discussion deadline reached before foundational consensus"
 		}
 		prompt := buildDiscussionPrompt(cycle, reports, active)
 		votes, successful, cost := r.runDiscussionCycle(ctx, req, analysis.Reports, active, prompt, artifactStage, cycle)
 		totalCost += cost
-		if ctx.Err() != nil {
-			return feedback, analysis.Approvals, totalCost, "discussion deadline reached before foundational consensus"
+		// Degradation is sticky across cycles. A seat that recovers after an
+		// earlier failure must not make the completed roundtable look healthy.
+		cycleFailed := len(analysis.Reports) - successful
+		if cycleFailed > discussionFailed {
+			discussionFailed = cycleFailed
 		}
 		if successful < panel.MinSuccessful {
-			return feedback, analysis.Approvals, totalCost, fmt.Sprintf("discussion quorum %d/%d is below min_successful %d", successful, len(analysis.Reports), panel.MinSuccessful)
+			if ctx.Err() != nil {
+				return feedback, analysis.Approvals, totalCost, discussionFailed, "discussion deadline reached before foundational consensus"
+			}
+			return feedback, analysis.Approvals, totalCost, discussionFailed, fmt.Sprintf("discussion quorum %d/%d is below min_successful %d", successful, len(analysis.Reports), panel.MinSuccessful)
 		}
 		majority := successful/2 + 1
 		var contested []discussionIssue
@@ -118,7 +125,7 @@ func (r *NativeRunner) runPanelDiscussion(ctx context.Context, req StepRequest, 
 	if len(feedback.Findings) == 0 {
 		approvals = len(analysis.Reports)
 	}
-	return feedback, approvals, totalCost, ""
+	return feedback, approvals, totalCost, discussionFailed, ""
 }
 
 func makeDiscussionIssues(findings []wfe.Finding) []discussionIssue {

--- a/server-go/internal/engine/roundtable_discussion_test.go
+++ b/server-go/internal/engine/roundtable_discussion_test.go
@@ -48,7 +48,7 @@ func TestDiscussionNitsHaveExactlyOneCycle(t *testing.T) {
 		return fmt.Sprintf(`{"positions":[{"id":%q,"position":"agree"}]}`, issueID), nil
 	}}
 	runner := &NativeRunner{agents: agents}
-	feedback, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
+	feedback, _, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
 	if errText != "" || len(feedback.Findings) != 1 {
 		t.Fatalf("discussion failed: err=%q feedback=%+v", errText, feedback)
 	}
@@ -72,7 +72,7 @@ func TestDiscussionAbstentionAloneDoesNotExtend(t *testing.T) {
 		return fmt.Sprintf(`{"positions":[{"id":%q,"position":"abstain"}]}`, issueID), nil
 	}}
 	runner := &NativeRunner{agents: agents}
-	feedback, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
+	feedback, _, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
 	if errText != "" || len(feedback.Findings) != 1 || len(agents.requests) != 2 {
 		t.Fatalf("abstention extended or erased issue: calls=%d err=%q feedback=%+v", len(agents.requests), errText, feedback)
 	}
@@ -86,7 +86,7 @@ func TestDiscussionRejectsIncompleteBallots(t *testing.T) {
 		return fmt.Sprintf(`{"positions":[{"id":%q,"position":"agree"}]}`, issueID), nil
 	}}
 	runner := &NativeRunner{agents: agents}
-	_, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
+	_, _, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
 	if !strings.Contains(errText, "discussion quorum 0/2") {
 		t.Fatalf("incomplete ballots counted as successful: %q", errText)
 	}
@@ -103,7 +103,7 @@ func TestDiscussionOrdinaryDisagreementDoesNotExtend(t *testing.T) {
 		return fmt.Sprintf(`{"positions":[{"id":%q,"position":%q}]}`, issueID, position), nil
 	}}
 	runner := &NativeRunner{agents: agents}
-	feedback, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
+	feedback, _, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
 	if errText != "" || len(feedback.Findings) != 1 || len(agents.requests) != 2 {
 		t.Fatalf("ordinary disagreement extended: calls=%d err=%q feedback=%+v", len(agents.requests), errText, feedback)
 	}
@@ -120,9 +120,36 @@ func TestDiscussionFoundationalTieExtendsOnlyUntilMajority(t *testing.T) {
 		return fmt.Sprintf(`{"positions":[{"id":%q,"position":%q}]}`, issueID, position), nil
 	}}
 	runner := &NativeRunner{agents: agents}
-	feedback, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
+	feedback, _, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
 	if errText != "" || len(feedback.Findings) != 1 || len(agents.requests) != 4 {
 		t.Fatalf("foundational consensus: calls=%d err=%q feedback=%+v", len(agents.requests), errText, feedback)
+	}
+}
+
+func TestDiscussionFailureRemainsDegradedAfterSeatRecovers(t *testing.T) {
+	analysis := discussionAnalysis("foundational")
+	analysis.Reports = append(analysis.Reports, panelSeatReport{
+		Seat:     panelSeat{persona: "qa", participant: "participant-c", ordinal: 2},
+		Response: panelResponse{ArtifactStage: "plan", Verdict: "changes"},
+	})
+	issueID := makeDiscussionIssues(analysis.Feedback.Findings)[0].ID
+	agents := &discussionTestAgents{respond: func(request DelegateRequest) (string, error) {
+		if strings.Contains(request.DurableSlot, ":discussion:1:") && strings.HasSuffix(request.DurableSlot, "seat:2") {
+			return "", fmt.Errorf("temporary seat failure")
+		}
+		position := "agree"
+		if strings.Contains(request.DurableSlot, ":discussion:1:") && strings.HasSuffix(request.DurableSlot, "seat:1") {
+			position = "disagree"
+		}
+		return fmt.Sprintf(`{"positions":[{"id":%q,"position":%q}]}`, issueID, position), nil
+	}}
+	runner := &NativeRunner{agents: agents}
+	feedback, _, _, failed, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
+	if errText != "" || len(feedback.Findings) != 1 || len(agents.requests) != 6 {
+		t.Fatalf("seat recovery did not complete consensus: calls=%d err=%q feedback=%+v", len(agents.requests), errText, feedback)
+	}
+	if failed != 1 {
+		t.Fatalf("recovered seat erased degradation: failed=%d, want 1", failed)
 	}
 }
 
@@ -133,7 +160,7 @@ func TestDiscussionFoundationalAgreementHasOneCycle(t *testing.T) {
 		return fmt.Sprintf(`{"positions":[{"id":%q,"position":"agree"}]}`, issueID), nil
 	}}
 	runner := &NativeRunner{agents: agents}
-	_, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
+	_, _, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
 	if errText != "" || len(agents.requests) != 2 {
 		t.Fatalf("unanimous foundational issue extended: calls=%d err=%q", len(agents.requests), errText)
 	}
@@ -146,7 +173,7 @@ func TestDiscussionRejectMajorityDropsIssueDeterministically(t *testing.T) {
 		return fmt.Sprintf(`{"positions":[{"id":%q,"position":"disagree"}]}`, issueID), nil
 	}}
 	runner := &NativeRunner{agents: agents}
-	feedback, approvals, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
+	feedback, approvals, _, _, errText := runner.runPanelDiscussion(context.Background(), StepRequest{WorkItem: db1.WorkItem{ID: "wi"}, Node: wfe.Node{ID: "gate"}}, roundtablecfg.Panel{Discussion: true, MinSuccessful: 2}, analysis, "plan")
 	if errText != "" || len(feedback.Findings) != 0 || approvals != 2 {
 		t.Fatalf("deterministic rejection failed: approvals=%d err=%q feedback=%+v", approvals, errText, feedback)
 	}

--- a/src/server/wfe_roundtable_proxy.c
+++ b/src/server/wfe_roundtable_proxy.c
@@ -1,10 +1,13 @@
 #include "wfe_roundtable_proxy.h"
 
 #include "cJSON.h"
+#include "config.h"
 #include "json_fluent.h"
+#include "roundtable_preset.h"
 #include "util.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -27,8 +30,10 @@ int wfe_roundtable_proxy(server_conn_t *conn, const cJSON *request)
 #include <sys/un.h>
 #include <unistd.h>
 
-#define GO_ROUNDTABLE_IO_TIMEOUT_SECS 420
-#define GO_ROUNDTABLE_MAX_RESPONSE    (16u * 1024u * 1024u)
+#define GO_ROUNDTABLE_DEFAULT_DEADLINE_MS 360000
+#define GO_ROUNDTABLE_TRANSPORT_GRACE_MS  30000
+#define GO_ROUNDTABLE_SEND_TIMEOUT_SECS   30
+#define GO_ROUNDTABLE_MAX_RESPONSE        (16u * 1024u * 1024u)
 
 static int write_all(int fd, const char *data, size_t size)
 {
@@ -83,7 +88,24 @@ static char *decode_chunked(const char *body)
    return out;
 }
 
-static char *post_go_roundtable(const char *body, int *status)
+static int roundtable_receive_timeout_ms(const cJSON *request)
+{
+   config_t cfg;
+   int deadline_ms = GO_ROUNDTABLE_DEFAULT_DEADLINE_MS;
+   if (config_load(&cfg) == 0)
+   {
+      cJSON *preset = cJSON_GetObjectItemCaseSensitive(request, "roundtable");
+      const char *requested = cJSON_IsString(preset) ? preset->valuestring : NULL;
+      if (roundtable_preset_resolve_runtime(requested, &cfg, NULL, 0, NULL, 0) >= 0 &&
+          cfg.roundtable_deadline_ms > 0)
+         deadline_ms = cfg.roundtable_deadline_ms;
+   }
+   if (deadline_ms > INT_MAX - GO_ROUNDTABLE_TRANSPORT_GRACE_MS)
+      return INT_MAX;
+   return deadline_ms + GO_ROUNDTABLE_TRANSPORT_GRACE_MS;
+}
+
+static char *post_go_roundtable(const char *body, int receive_timeout_ms, int *status)
 {
    if (status)
       *status = 0;
@@ -93,9 +115,14 @@ static char *post_go_roundtable(const char *body, int *status)
    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
    if (fd < 0)
       return NULL;
-   struct timeval io_timeout = {.tv_sec = GO_ROUNDTABLE_IO_TIMEOUT_SECS, .tv_usec = 0};
-   if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &io_timeout, sizeof(io_timeout)) != 0 ||
-       setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &io_timeout, sizeof(io_timeout)) != 0)
+   // Derive the receive bound from the same saved preset the Go service
+   // acquires. The transport grace covers response serialization and socket
+   // delivery without replacing the configured roundtable deadline.
+   struct timeval send_timeout = {.tv_sec = GO_ROUNDTABLE_SEND_TIMEOUT_SECS, .tv_usec = 0};
+   struct timeval receive_timeout = {.tv_sec = receive_timeout_ms / 1000,
+                                     .tv_usec = (receive_timeout_ms % 1000) * 1000};
+   if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, sizeof(send_timeout)) != 0 ||
+       setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &receive_timeout, sizeof(receive_timeout)) != 0)
    {
       close(fd);
       return NULL;
@@ -242,7 +269,7 @@ int wfe_roundtable_proxy(server_conn_t *conn, const cJSON *request)
    if (!wire)
       return server_send_error(conn, "out of memory", NULL);
    int status = 0;
-   char *body = post_go_roundtable(wire, &status);
+   char *body = post_go_roundtable(wire, roundtable_receive_timeout_ms(request), &status);
    free(wire);
    if (!body)
       return server_send_error(conn, "Go roundtable service is unreachable", NULL);


### PR DESCRIPTION
## Summary
- continue a configured roundtable when complete reports satisfy its explicit `min_successful`, while preserving unavailable seats as degraded participation
- divide the configured overall deadline across analysis, Discussion, and Chairman so a slow phase cannot starve required downstream phases
- keep Discussion failure/deadline state sticky, expose phase-local deadline hits, and mark Chairman failures degraded
- derive the C compatibility proxy receive timeout from the acquired preset deadline plus finite transport grace instead of the incorrect fixed 420-second cap

## Validation
- `go test ./...` in `server-go`
- `clang-format-19 --dry-run --Werror src/server/wfe_roundtable_proxy.c`
- `make -C src build-integrity`
- `git diff --check`
- configured `e2efix` review: two clean Codex approvals on the final revision; an earlier three-seat review unanimously identified the proxy-bound issue, which this revision corrects. Full post-deploy Discussion/Chairman convergence will be repeated on the fixed runtime because the deployed runtime currently false-parks on any slow seat.