### PR TITLE
fix(roundtable): wait for all seats within deadline

### DIFF
--- a/docs/ENSEMBLE.md
+++ b/docs/ENSEMBLE.md
@@ -69,12 +69,14 @@ rejects them.
 The denominator is the successful seated participants that return a complete,
 valid ballot in that discussion cycle. Abstentions remain in that denominator
 but do not by themselves count as disagreement or extend discussion. The saved
-`deadline_ms` is the overall analysis-plus-discussion budget; an omitted or zero
-legacy value is normalized to 360 seconds.
-The runtime divides that overall budget evenly across the configured analysis,
-Discussion, and Chairman phases. This prevents one slow analysis seat from
-consuming time reserved for a required downstream phase while preserving the
-single overall deadline as the hard upper bound.
+`deadline_ms` is the overall analysis-plus-Discussion-plus-Chairman budget; an
+omitted or zero legacy value is normalized to 360 seconds.
+The runtime treats that overall deadline as one work-conserving budget shared by
+analysis, Discussion, and Chairman. It does not divide the deadline into equal
+phase slices: enabled providers can have materially different normal latency,
+and a healthy seat must not be cancelled before the configured overall deadline
+merely because downstream phases are enabled. Later phases receive the remaining
+budget, and the single overall deadline remains the hard upper bound.
 The C compatibility proxy derives its finite receive timeout from that acquired
 preset deadline and adds only transport grace; it does not impose a shorter
 fixed deadline or wait without a bound.

--- a/docs/ENSEMBLE.md
+++ b/docs/ENSEMBLE.md
@@ -70,7 +70,7 @@ The denominator is the successful seated participants that return a complete,
 valid ballot in that discussion cycle. Abstentions remain in that denominator
 but do not by themselves count as disagreement or extend discussion. The saved
 `deadline_ms` is the overall analysis-plus-Discussion-plus-Chairman budget; an
-omitted or zero legacy value is normalized to 360 seconds.
+omitted or zero value is normalized to 600 seconds.
 The runtime treats that overall deadline as one work-conserving budget shared by
 analysis, Discussion, and Chairman. It does not divide the deadline into equal
 phase slices: enabled providers can have materially different normal latency,

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -130,7 +130,7 @@ backstops, while operator and convergence parks are never auto-resumed.
 Strict majority is measured over successful seats returning a complete valid
 ballot in that cycle; abstentions remain in the denominator but do not alone
 extend discussion. The preset's `deadline_ms` covers analysis, Discussion, and
-Chairman together, with zero/omitted legacy values normalized to 360 seconds.
+Chairman together, with zero/omitted values normalized to 600 seconds.
 That deadline is one work-conserving budget: the runtime waits for every analysis
 seat to return, fail, or reach the configured deadline instead of silently
 dividing it into much shorter phase slices. Later phases receive the remaining

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -129,11 +129,12 @@ new durable execution version. Work-item cost and turn caps remain the safety
 backstops, while operator and convergence parks are never auto-resumed.
 Strict majority is measured over successful seats returning a complete valid
 ballot in that cycle; abstentions remain in the denominator but do not alone
-extend discussion. The preset's `deadline_ms` covers analysis and discussion
-together, with zero/omitted legacy values normalized to 360 seconds.
-That overall budget is divided evenly among enabled analysis, Discussion, and
-Chairman phases so a slow seat cannot consume the time required by a later
-configured phase.
+extend discussion. The preset's `deadline_ms` covers analysis, Discussion, and
+Chairman together, with zero/omitted legacy values normalized to 360 seconds.
+That deadline is one work-conserving budget: the runtime waits for every analysis
+seat to return, fail, or reach the configured deadline instead of silently
+dividing it into much shorter phase slices. Later phases receive the remaining
+time, and the configured deadline remains the hard bound for the whole table.
 The compatibility proxy uses the acquired preset deadline plus bounded
 transport grace, so its socket timeout cannot preempt valid configured work.
 An unavailable independent-analysis seat remains visible as degraded

--- a/frontend/src/pages/Roundtable.tsx
+++ b/frontend/src/pages/Roundtable.tsx
@@ -92,7 +92,7 @@ function emptyPreset(name: string): Preset {
     chairman_enabled: false,
     min_successful: 2,
     max_cost_usd: 0,
-    deadline_ms: 360000,
+    deadline_ms: 600000,
     discussion: false,
     pipeline: { ...DEFAULT_PIPELINE },
   };

--- a/server-go/internal/engine/native_runner.go
+++ b/server-go/internal/engine/native_runner.go
@@ -563,17 +563,12 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 		roundtableCtx, cancel = context.WithTimeout(ctx, time.Duration(panel.DeadlineMS)*time.Millisecond)
 	}
 	defer cancel()
-	phaseCount := 1
-	if panel.Discussion {
-		phaseCount++
-	}
-	if panel.ChairmanEnabled {
-		phaseCount++
-	}
-	analysisCtx, analysisCancel := roundtablePhaseContext(roundtableCtx, panel.DeadlineMS, phaseCount)
-	analysis := r.runPanelAnalysis(analysisCtx, req, seats, basePrompt, reviewed.Hash, stage, 1)
-	deadlineHit := errors.Is(analysisCtx.Err(), context.DeadlineExceeded)
-	analysisCancel()
+	// The configured deadline is one work-conserving budget for the complete
+	// roundtable. Do not divide it into equal phase slices: provider latency is
+	// heterogeneous, and doing so can cancel a healthy slow seat long before the
+	// configured deadline even when ample total budget remains.
+	analysis := r.runPanelAnalysis(roundtableCtx, req, seats, basePrompt, reviewed.Hash, stage, 1)
+	deadlineHit := errors.Is(roundtableCtx.Err(), context.DeadlineExceeded)
 	// A configured minimum is the roundtable's explicit degraded-operation
 	// contract. Every seat was attempted and remains visible in the result, but
 	// one unavailable seat must not discard a usable quorum. Park only when the
@@ -587,10 +582,8 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 	discussionFailed := 0
 	if panel.Discussion {
 		var discussionErr string
-		discussionCtx, discussionCancel := roundtablePhaseContext(roundtableCtx, panel.DeadlineMS, phaseCount)
-		feedback, approvals, totalCost, discussionFailed, discussionErr = r.runPanelDiscussion(discussionCtx, req, panel, analysis, stage)
-		deadlineHit = deadlineHit || errors.Is(discussionCtx.Err(), context.DeadlineExceeded)
-		discussionCancel()
+		feedback, approvals, totalCost, discussionFailed, discussionErr = r.runPanelDiscussion(roundtableCtx, req, panel, analysis, stage)
+		deadlineHit = deadlineHit || errors.Is(roundtableCtx.Err(), context.DeadlineExceeded)
 		if discussionErr != "" {
 			rt := roundtableResult(&feedback, false, false, analysis, len(seats), totalCost)
 			rt.Degraded = rt.Degraded || discussionFailed > 0
@@ -600,10 +593,8 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 	}
 	if panel.ChairmanEnabled {
 		var chairmanErr string
-		chairmanCtx, chairmanCancel := roundtablePhaseContext(roundtableCtx, panel.DeadlineMS, phaseCount)
-		feedback, approvals, totalCost, chairmanErr = r.runPanelChairman(chairmanCtx, req, panel, analysis, feedback, totalCost, stage)
-		deadlineHit = deadlineHit || errors.Is(chairmanCtx.Err(), context.DeadlineExceeded)
-		chairmanCancel()
+		feedback, approvals, totalCost, chairmanErr = r.runPanelChairman(roundtableCtx, req, panel, analysis, feedback, totalCost, stage)
+		deadlineHit = deadlineHit || errors.Is(roundtableCtx.Err(), context.DeadlineExceeded)
 		if chairmanErr != "" {
 			rt := roundtableResult(&feedback, false, false, analysis, len(seats), totalCost)
 			// The chairman is configured roundtable participation even though it
@@ -628,17 +619,6 @@ func (r *NativeRunner) roundtable(ctx context.Context, req StepRequest) (StepRes
 	rt.Degraded = rt.Degraded || discussionFailed > 0
 	rt.DeadlineHit = deadlineHit
 	return StepResult{Status: StepChanges, Feedback: &feedback, CostUSD: totalCost, Roundtable: rt}, nil
-}
-
-func roundtablePhaseContext(parent context.Context, deadlineMS, phaseCount int) (context.Context, context.CancelFunc) {
-	if deadlineMS <= 0 || phaseCount <= 1 {
-		return parent, func() {}
-	}
-	budget := time.Duration(deadlineMS) * time.Millisecond / time.Duration(phaseCount)
-	if budget < time.Millisecond {
-		budget = time.Millisecond
-	}
-	return context.WithTimeout(parent, budget)
 }
 
 func roundtableStageGuidance(stage string) string {

--- a/server-go/internal/engine/native_runner_test.go
+++ b/server-go/internal/engine/native_runner_test.go
@@ -147,6 +147,8 @@ type firstPanelSeatUnavailableAgents struct {
 
 type deadlineSeatAgents struct{}
 
+type slowHealthySeatAgents struct{}
+
 type deadlineDiscussionAgents struct{}
 
 type chairmanFailureAgents struct{}
@@ -160,6 +162,23 @@ func (deadlineSeatAgents) Delegate(ctx context.Context, request DelegateRequest)
 	if strings.HasSuffix(request.DurableSlot, "seat:0") {
 		<-ctx.Done()
 		return DelegateResult{}, ctx.Err()
+	}
+	return DelegateResult{Response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`}, nil
+}
+
+func (slowHealthySeatAgents) Delegate(ctx context.Context, request DelegateRequest) (DelegateResult, error) {
+	if strings.HasPrefix(request.Prompt, "ROUNDTABLE DISCUSSION CYCLE") {
+		return DelegateResult{Response: `{"positions":[]}`}, nil
+	}
+	if request.Persona == "chairman" {
+		return DelegateResult{Response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`}, nil
+	}
+	if strings.HasSuffix(request.DurableSlot, "seat:0") {
+		select {
+		case <-time.After(70 * time.Millisecond):
+		case <-ctx.Done():
+			return DelegateResult{}, ctx.Err()
+		}
 	}
 	return DelegateResult{Response: `{"artifact_stage":"plan","original_request_alignment":{"status":"aligned","summary":"implements the request"},"verdict":"approve","findings":[]}`}, nil
 }
@@ -240,6 +259,10 @@ func (a firstPanelSeatUnavailableAgents) DelegateGroup(ctx context.Context, requ
 }
 
 func (a deadlineSeatAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
+	return testDelegateGroup(ctx, requests, a.Delegate)
+}
+
+func (a slowHealthySeatAgents) DelegateGroup(ctx context.Context, requests []DelegateRequest) []DelegateGroupResult {
 	return testDelegateGroup(ctx, requests, a.Delegate)
 }
 
@@ -438,7 +461,7 @@ func TestConfiguredRoundtableHonorsMinimumWhenASeatIsUnavailable(t *testing.T) {
 	}
 }
 
-func TestConfiguredRoundtableReservesDownstreamPhasesAfterSeatDeadline(t *testing.T) {
+func TestConfiguredRoundtableUsesOverallDeadlineWithoutCancellingSlowHealthySeat(t *testing.T) {
 	dir := t.TempDir()
 	body := `{"name":"default","seats":[{"model":"codex","persona":"security"},{"model":"minimax","persona":"qa"}],"min_successful":1,"discussion":true,"chairman":"codex","chairman_enabled":true,"deadline_ms":120}`
 	if err := os.WriteFile(filepath.Join(dir, "default.json"), []byte(body), 0o600); err != nil {
@@ -448,7 +471,7 @@ func TestConfiguredRoundtableReservesDownstreamPhasesAfterSeatDeadline(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner := &NativeRunner{agents: deadlineSeatAgents{}, roundtables: store}
+	runner := &NativeRunner{agents: slowHealthySeatAgents{}, roundtables: store}
 	reviewed := wfe.Artifact{Type: "plan", Content: []byte("complete implementation plan")}
 	reviewed.Hash = wfe.Hash(reviewed.Content)
 	started := time.Now()
@@ -463,11 +486,11 @@ func TestConfiguredRoundtableReservesDownstreamPhasesAfterSeatDeadline(t *testin
 	if elapsed := time.Since(started); elapsed >= time.Second {
 		t.Fatalf("roundtable did not bound the slow seat: %s", elapsed)
 	}
-	if result.Status != StepAdvanced || result.Roundtable == nil || !result.Roundtable.Approved || !result.Roundtable.Degraded || !result.Roundtable.DeadlineHit {
+	if result.Status != StepAdvanced || result.Roundtable == nil || !result.Roundtable.Approved || result.Roundtable.Degraded || result.Roundtable.DeadlineHit {
 		t.Fatalf("result=%+v", result)
 	}
-	if result.Roundtable.ParticipantsTotal != 2 || result.Roundtable.ParticipantsUsed != 1 || result.Roundtable.ParticipantsFailed != 1 {
-		t.Fatalf("degraded participation was not preserved: %+v", result.Roundtable)
+	if result.Roundtable.ParticipantsTotal != 2 || result.Roundtable.ParticipantsUsed != 2 || result.Roundtable.ParticipantsFailed != 0 {
+		t.Fatalf("slow healthy participation was not preserved: %+v", result.Roundtable)
 	}
 }
 

--- a/server-go/internal/roundtable/store.go
+++ b/server-go/internal/roundtable/store.go
@@ -10,7 +10,7 @@ import (
 )
 
 const DirectMaxSeats = 2
-const DefaultDeadlineMS = 360000
+const DefaultDeadlineMS = 600000
 
 type Seat struct {
 	Persona  string
@@ -149,7 +149,7 @@ func directPanel(lenses []string, pins map[string]string) (Panel, error) {
 		name := strings.TrimSpace(pins[persona])
 		seats = append(seats, Seat{Persona: persona, Selector: name})
 	}
-	return Panel{Seats: seats, MinSuccessful: len(seats)}, nil
+	return Panel{Seats: seats, MinSuccessful: len(seats), DeadlineMS: DefaultDeadlineMS}, nil
 }
 
 // ResolveDirect is the explicit no-roundtable path used by compatibility

--- a/server-go/internal/roundtable/store_test.go
+++ b/server-go/internal/roundtable/store_test.go
@@ -68,8 +68,21 @@ func TestDirectFallbackHardCapsTwoAndLeavesRoutingToDelegate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if panel.Acquired || len(panel.Seats) != 2 || panel.Seats[0].Selector != "" || panel.Seats[1].Selector != "" {
+	if panel.Acquired || len(panel.Seats) != 2 || panel.Seats[0].Selector != "" || panel.Seats[1].Selector != "" || panel.DeadlineMS != 600000 {
 		t.Fatalf("panel=%+v", panel)
+	}
+}
+
+func TestConfiguredRoundtableDefaultsToTenMinuteSafetyBound(t *testing.T) {
+	dir := t.TempDir()
+	writePreset(t, dir, preset{Name: "default", Seats: []presetSeat{{Selector: "$random"}}})
+	store, _ := NewStore(dir, func() (string, error) { return "default", nil })
+	panel, err := store.Resolve("", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if panel.DeadlineMS != 600000 {
+		t.Fatalf("deadline_ms=%d, want 600000", panel.DeadlineMS)
 	}
 }
 

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -909,11 +909,9 @@ static void config_set_defaults(config_t *cfg)
    snprintf(cfg->default_persona, sizeof(cfg->default_persona), "engineer");
    cfg->roundtable_max_rounds = 1;
    cfg->roundtable_converge_threshold = 10;
-   /* Saner default: 6 min (was 10). Long enough for a multi-round reasoning-model
-    * ensemble, short enough that a wedged run fails fast instead of a 10-min
-    * silent block. Overridable via roundtable.deadline_ms. Paired with the
-    * round-boundary progress logging so an in-flight run is observably advancing. */
-   cfg->roundtable_deadline_ms = 360000;
+   /* Ten-minute default safety bound for a complete roundtable. It remains
+    * overridable via roundtable.deadline_ms in GUI and CLI configuration. */
+   cfg->roundtable_deadline_ms = 600000;
    snprintf(cfg->roundtable_turns, sizeof(cfg->roundtable_turns), "parallel");
    snprintf(cfg->roundtable_pipeline_done_bar, sizeof(cfg->roundtable_pipeline_done_bar),
             "zero_blocking");

--- a/src/server/wfe_roundtable_proxy.c
+++ b/src/server/wfe_roundtable_proxy.c
@@ -30,7 +30,7 @@ int wfe_roundtable_proxy(server_conn_t *conn, const cJSON *request)
 #include <sys/un.h>
 #include <unistd.h>
 
-#define GO_ROUNDTABLE_DEFAULT_DEADLINE_MS 360000
+#define GO_ROUNDTABLE_DEFAULT_DEADLINE_MS 600000
 #define GO_ROUNDTABLE_TRANSPORT_GRACE_MS  30000
 #define GO_ROUNDTABLE_SEND_TIMEOUT_SECS   30
 #define GO_ROUNDTABLE_MAX_RESPONSE        (16u * 1024u * 1024u)

--- a/src/tests/test_roundtable_preset.c
+++ b/src/tests/test_roundtable_preset.c
@@ -26,7 +26,7 @@ static const char *PRESET_JSON = "{"
                                  "  \"max_cost_usd\": 1.5,"
                                  "  \"max_rounds\": 3,"
                                  "  \"converge_threshold\": 2,"
-                                 "  \"deadline_ms\": 360000,"
+                                 "  \"deadline_ms\": 600000,"
                                  "  \"discussion\": true,"
                                  "  \"turns\": \"parallel\","
                                  "  \"pipeline\": {"
@@ -58,7 +58,7 @@ static void check_fields(const roundtable_preset_t *p)
    assert(p->max_cost_usd == 1.5);
    assert(p->max_rounds == 3);
    assert(p->converge_threshold == 2);
-   assert(p->deadline_ms == 360000);
+   assert(p->deadline_ms == 600000);
    assert(p->discussion == 1);
    assert(strcmp(p->turns, "parallel") == 0);
    assert(strcmp(p->pipeline_done_bar, "zero_blocking") == 0);
@@ -178,7 +178,7 @@ int main(void)
    assert(cfg.ensemble_min_successful == 2);
    assert(cfg.roundtable_max_rounds == 3);
    assert(cfg.roundtable_converge_threshold == 2);
-   assert(cfg.roundtable_deadline_ms == 360000);
+   assert(cfg.roundtable_deadline_ms == 600000);
    assert(strcmp(cfg.roundtable_turns, "parallel") == 0);
    assert(cfg.roundtable_pipeline_gate_ttl_h == 24);
    assert(strcmp(cfg.roundtable_default, "deep-review") == 0);


### PR DESCRIPTION
## Summary
- use the configured roundtable deadline as one shared, work-conserving safety bound
- wait for every analysis seat to respond, fail, or reach that bound before applying quorum
- standardize the GUI, CLI/direct, Go, and compatibility defaults at 600 seconds
- add regression coverage for a healthy seat slower than the removed equal phase slice

## Verification
- `go test ./...` in `server-go`
- `make build-integrity` in `src`
- `git diff --check`

Frontend typecheck could not run locally because this worktree has no installed frontend dependencies (`tsc: not found`); protected CI will run it.