### PR TITLE
Enforce complete roundtable source ownership

### DIFF
--- a/docs/modules/module-runtime.md
+++ b/docs/modules/module-runtime.md
@@ -35,6 +35,15 @@ paths within or across descriptors, then emits a deterministic declared-ownershi
 inputs are still maintained by Make and CMake in this slice; descriptor-driven build generation
 remains a later step, so these ownership fields are documentation and validation only.
 
+Descriptor v1 also supports `private_headers` and the opt-in `ownership_complete` latch. For a
+complete descriptor, the validator compares the declared source and private-header sets with every
+matching owner-local file and requires the canonical module document. An undeclared new file or a
+stale declaration fails CI. Public headers remain confined to `include/aimee/<module>/`; tests are
+explicit declarations because integration tests can span more than one module. Modules that have not
+set `ownership_complete: true` remain migration debt and must not feed generated build profiles.
+Public headers and tests are validated when declared but are not part of completeness set equality in
+this slice.
+
 ## Providers and readiness
 
 `module-runtime` is its own required reference implementation and has no replaceable provider.

--- a/docs/modules/roundtable.md
+++ b/docs/modules/roundtable.md
@@ -28,6 +28,13 @@ Consumers include `ensemble` CLI/MCP/API routes, server authoring pipelines, swe
 workflow roundtable gates, and the frontend Roundtable surface. Workflows may await a result, but retain
 their own durable state, triggers, approvals, and scheduling.
 
+The descriptor is the checked inventory for all owner-local roundtable translation units and private
+headers. `ownership_complete: true` makes additions, removals, and stale declarations fail validation;
+the descriptor also names the direct ensemble, chair, preset, seat-resolution, pipeline, and verification
+tests plus this canonical module document. Server, workflow, DB, and protocol integration tests remain
+with their composing layers. This inventory does not yet select emitted objects or make the module
+physically absent from a build profile.
+
 ## Providers and readiness
 
 Panel providers are resolved from configured agents, `roundtable_preset` eligibility/authorization/availability filters,
@@ -105,7 +112,7 @@ produce a typed incomplete/failure result rather than invented consensus.
 Report `roundtable` mode, preset, seat/provider identity, eligibility/availability reason, round/pass,
 quorum/convergence, chair use, bounded token/cost totals, capture identifier, and safe failure class.
 Exclude prompts, diffs, private panel content, credentials, and raw model responses. Diagnostics must
-distinguish descriptor-disabled, provider-unready, non-converged, and workflow-consumer failures.
+distinguish startup-config-disabled, provider-unready, non-converged, and workflow-consumer failures.
 
 ## Compatibility
 

--- a/docs/proposals/pending/module-runtime-source-ownership-and-build.md
+++ b/docs/proposals/pending/module-runtime-source-ownership-and-build.md
@@ -1,6 +1,6 @@
 # Proposal: make module ownership drive source, builds, config, and documentation
 
-- **State:** PENDING — roundtable-approved 2026-07-20; slices 27–28 implemented; physical
+- **State:** PENDING — roundtable-approved 2026-07-20; slices 27–29 implemented; physical
   profile omission and the remaining module migrations still await project acceptance
 - **Parent:** [`core-substrate-and-source-module-boundaries.md`](core-substrate-and-source-module-boundaries.md)
 - **Owns:** descriptor schema/validation, physical source ownership, generated Make/CMake and
@@ -24,6 +24,13 @@ objects remain linked. Slice 28 adds startup-only runtime registration: disabled
 are absent from raw method discovery/dispatch and HTTP matching, while disabled roundtable MCP tools are
 absent from served and meta-tool discovery and reject direct invocation. Profile-driven object omission
 remains required before the proposal's physical-absence contract is complete.
+Slice 29 makes the roundtable descriptor a mechanically complete inventory of its owner-local translation
+units and private headers. `ownership_complete: true` enforces set equality against the filesystem and
+requires the canonical module document. As policy, incomplete descriptors must not be used by the future
+generator; mechanical enforcement is deferred to the build-generation slice.
+This slice does not claim generated target membership or object omission. Those remain the next build
+slice, including explicit provider seams for Make-only server composition and parity checks only where
+both build systems own the same target.
 The owner API is `roundtable_module_enabled`; workflows map its disabled result through
 `WFE_PANEL_MODULE_DISABLED` to a permanent step failure rather than a transient provider retry.
 Resuming or redispatching that disabled gate re-evaluates activation and, while still disabled,
@@ -45,11 +52,11 @@ Temporary forwarding headers and root allowlists have owners, expiries, and may 
 
 ## Descriptor contract
 
-Every descriptor declares identity, kind, required/optional state, default selection, runtime
-toggle support, dependencies, required components, providers, source and public-header globs,
-config ownership/read evidence, routes/commands/protocols, data ownership, tests, docs, and
-compatibility aliases. Invalid, duplicate, cyclic, unowned, or incomplete descriptors fail before
-build generation.
+Descriptor v1 currently declares identity, dependencies, activation metadata, explicit source/private-
+header/public-header/test/document paths, and the opt-in completeness latch. The target schema will also
+declare kind, required components, providers, config ownership/read evidence, routes/commands/protocols,
+data ownership, and compatibility aliases. Before build generation consumes that expanded schema,
+invalid, duplicate, cyclic, unowned, or incomplete descriptors must fail validation.
 
 Config read evidence is compiler-derived, not trusted descriptor prose. The inventory maps each key
 to a compiled non-test read expression and its owning object/symbol; nonexistent files/lines,

--- a/docs/validation/core-modularization-slice-29.md
+++ b/docs/validation/core-modularization-slice-29.md
@@ -1,0 +1,55 @@
+# Core modularization slice 29: complete roundtable ownership
+
+## Scope
+
+This slice makes `src/modules/roundtable/module.yaml` the complete checked inventory for the
+roundtable implementation root. It extends descriptor v1 with `private_headers` and the opt-in
+`ownership_complete` latch, then enables that latch for roundtable.
+
+It does not generate Make or CMake fragments, change target membership, or omit roundtable objects.
+Those behaviors require the composition/provider seams and generated build selection planned for the
+next slice.
+
+## Completeness contract
+
+The descriptor validator uses one role-extension policy for declared entries. Completeness scanning
+covers the two owner-local implementation roles:
+
+- `sources`: `.c`, `.cpp`, `.S`, and `.s`;
+- `private_headers`: `.h` and `.hpp` below the module root but outside
+  `include/aimee/<module>/`;
+- `public_headers`: `.h` and `.hpp` only below `include/aimee/<module>/`; these are boundary-checked
+  when declared but are not part of completeness scanning in this slice.
+
+When `ownership_complete` is true, the declared `sources` and `private_headers` must exactly equal the
+matching owner-local files. Missing declarations, stale declarations, symlinks, non-files,
+cross-role/cross-descriptor duplicates, and public headers presented as private all fail with a stable
+rule and JSON pointer. The `docs` field must contain exactly the canonical module document. Public
+headers and tests remain explicit declarations rather than set-equality checks; integration tests can
+span multiple owners.
+
+Descriptors without the latch retain the migration-compatible declared-file validation from earlier
+slices. They are not complete inventories and must not be consumed as authoritative generated-build
+inputs.
+
+## Roundtable inventory
+
+The roundtable descriptor declares all ten owner-local translation units and eleven private headers.
+It declares the direct ensemble, chair, preset, seat-resolution, pipeline capture/chunk/evaluation, and
+verification tests, plus `docs/modules/roundtable.md`. It intentionally declares no public header:
+roundtable headers have not yet moved to a canonical `include/aimee/roundtable/` surface.
+
+## Verification
+
+`scripts/tests/test_validate_module_descriptors.py` covers the production inventory and planted
+failures for:
+
+- omitted declared sources and private headers;
+- undeclared new sources and private headers;
+- invalid types, nonexistent paths, duplicates, and cross-role/cross-descriptor claims;
+- public-header leakage into `private_headers`;
+- a missing canonical module document;
+- schema drift between the Python authority and `src/modules/module.schema.json`.
+
+`scripts/validate_module_descriptors.py --check-schema src/modules` validates the complete production
+graph and generated schema together.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -199,6 +199,9 @@ class DescriptorTests(unittest.TestCase):
         runtime_empty = self.required()
         runtime_empty["runtime_toggle"] = {}
         self.assert_rule(runtime_empty, "runtime-toggle-shape")
+        complete_type = self.required()
+        complete_type["ownership_complete"] = 1
+        self.assert_rule(complete_type, "ownership-complete-type")
 
     def test_ownership_is_optional_and_report_preserves_declared_order(self) -> None:
         report = validator.ownership_report(REPO_ROOT, [Path("src/modules")])
@@ -240,8 +243,124 @@ class DescriptorTests(unittest.TestCase):
         report = validator.validate_ownership(REPO_ROOT, "module-runtime", descriptor)
         self.assertEqual(
             {field: len(report["ownership"][field]) for field in validator.OWNERSHIP_FIELDS},
-            {"sources": 2, "public_headers": 2, "tests": 1, "docs": 1},
+            {"sources": 2, "private_headers": 0, "public_headers": 2, "tests": 1,
+             "docs": 1},
         )
+
+    def test_roundtable_complete_ownership_mutations(self) -> None:
+        cases = (
+            ("sources", "src/modules/roundtable/roundtable_verify.c"),
+            ("private_headers", "src/modules/roundtable/roundtable_verify.h"),
+        )
+        for field, relative in cases:
+            tmp = self.production_repo()
+            try:
+                repo = Path(tmp.name)
+                self.mutate_descriptor(
+                    repo, "roundtable",
+                    lambda value, field=field, relative=relative:
+                        value[field].remove(relative),
+                )
+                with self.subTest(field=field), self.assertRaisesRegex(
+                    validator.DescriptorError,
+                    rf"rule=ownership-complete pointer=/{field}.*missing=.*{Path(relative).name}",
+                ):
+                    validator.validate_roots(repo, [Path("src/modules")])
+            finally:
+                tmp.cleanup()
+
+        for name in ("undeclared.c", "undeclared.h"):
+            tmp = self.production_repo()
+            try:
+                repo = Path(tmp.name)
+                (repo / "src/modules/roundtable" / name).write_text("/* planted */\n",
+                                                                    encoding="utf-8")
+                role = "sources" if name.endswith(".c") else "private_headers"
+                with self.subTest(name=name), self.assertRaisesRegex(
+                    validator.DescriptorError,
+                    rf"rule=ownership-complete pointer=/{role}.*missing=.*{name}",
+                ):
+                    validator.validate_roots(repo, [Path("src/modules")])
+            finally:
+                tmp.cleanup()
+
+    def test_complete_ownership_requires_canonical_doc(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            self.mutate_descriptor(repo, "roundtable",
+                                   lambda value: value.__setitem__("docs", []))
+            with self.assertRaisesRegex(
+                validator.DescriptorError, r"rule=ownership-complete pointer=/docs"
+            ):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+    def test_complete_ownership_excludes_undeclared_public_headers(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            public = repo / "src/modules/roundtable/include/aimee/roundtable/public.h"
+            public.parent.mkdir(parents=True)
+            public.write_text("/* public contract */\n", encoding="utf-8")
+            self.assertEqual(
+                validator.validate_roots(repo, [Path("src/modules")]), 26
+            )
+        finally:
+            tmp.cleanup()
+
+    def test_complete_ownership_rejects_undeclared_symlink(self) -> None:
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            link = repo / "src/modules/roundtable/alias.h"
+            link.symlink_to(repo / "src/modules/roundtable/roundtable_types.h")
+            with self.assertRaisesRegex(
+                validator.DescriptorError,
+                r"rule=ownership-complete-symlink pointer=/private_headers.*alias.h",
+            ):
+                validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+    def test_complete_ownership_symlink_variants_fail_stably(self) -> None:
+        cases = (
+            ("declared.h", "roundtable_types.h", True, "ownership-path-symlink"),
+            ("broken.h", "missing.h", False, "ownership-complete-symlink"),
+            ("directory.h", ".", False, "ownership-complete-symlink"),
+        )
+        for name, target, declared, rule in cases:
+            tmp = self.production_repo()
+            try:
+                repo = Path(tmp.name)
+                relative = f"src/modules/roundtable/{name}"
+                (repo / relative).symlink_to(target)
+                if declared:
+                    self.mutate_descriptor(
+                        repo,
+                        "roundtable",
+                        lambda value, relative=relative:
+                            value["private_headers"].append(relative),
+                    )
+                with self.subTest(name=name), self.assertRaisesRegex(
+                    validator.DescriptorError,
+                    rf"rule={rule} pointer=/private_headers",
+                ):
+                    validator.validate_roots(repo, [Path("src/modules")])
+            finally:
+                tmp.cleanup()
+
+    def test_public_header_cannot_be_declared_private(self) -> None:
+        descriptor = json.loads(
+            (REPO_ROOT / "src/modules/module-runtime/module.yaml").read_text(encoding="utf-8")
+        )
+        descriptor["private_headers"] = [descriptor["public_headers"][0]]
+        with self.assertRaisesRegex(
+            validator.DescriptorError,
+            r"rule=ownership-role-boundary pointer=/private_headers/0",
+        ):
+            validator.validate_ownership(REPO_ROOT, "module-runtime", descriptor)
 
     def test_ownership_duplicate_and_cross_role_mutations(self) -> None:
         descriptor = json.loads(

--- a/scripts/validate_module_descriptors.py
+++ b/scripts/validate_module_descriptors.py
@@ -24,10 +24,11 @@ MAX_DEPTH = 32
 MAX_ARRAY = 256
 ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 BASE_KEYS = {"descriptor_version", "id", "dependencies", "runtime_toggle"}
-OWNERSHIP_FIELDS = ("sources", "public_headers", "tests", "docs")
+OWNERSHIP_FIELDS = ("sources", "private_headers", "public_headers", "tests", "docs")
 DEFAULT_ON = {"runtime-web", "control-web"}
 ROLE_EXTENSIONS = {
     "sources": {".c", ".cpp", ".S", ".s"},
+    "private_headers": {".h", ".hpp"},
     "public_headers": {".h", ".hpp"},
     "tests": {".c", ".cpp", ".py", ".sh"},
     "docs": {".md"},
@@ -150,6 +151,7 @@ def schema() -> dict[str, object]:
                 "uniqueItems": True,
             },
             "enabled_by_default": {"type": "boolean"},
+            "ownership_complete": {"type": "boolean"},
             "runtime_toggle": {
                 "type": "object",
                 "additionalProperties": False,
@@ -189,7 +191,7 @@ def validate_descriptor(value: object, required: set[str], optional: set[str]) -
     if identifier not in required | optional:
         fail("module-unknown", f"unknown module ID {identifier!r}", "/id")
     required_keys = BASE_KEYS | ({"enabled_by_default"} if identifier in optional else set())
-    allowed_keys = required_keys | set(OWNERSHIP_FIELDS)
+    allowed_keys = required_keys | set(OWNERSHIP_FIELDS) | {"ownership_complete"}
     if not required_keys <= set(value) or not set(value) <= allowed_keys:
         fail(
             "descriptor-keys",
@@ -246,6 +248,9 @@ def validate_descriptor(value: object, required: set[str], optional: set[str]) -
         )
     if identifier in optional and type(value["enabled_by_default"]) is not bool:
         fail("default-type", "enabled_by_default must be boolean", "/enabled_by_default")
+    if "ownership_complete" in value and type(value["ownership_complete"]) is not bool:
+        fail("ownership-complete-type", "ownership_complete must be boolean",
+             "/ownership_complete")
     return identifier
 
 
@@ -284,6 +289,7 @@ def validate_owned_path(repo: Path, identifier: str, field: str, raw: object,
 
     role_prefixes = {
         "sources": PurePosixPath("src/modules") / identifier,
+        "private_headers": PurePosixPath("src/modules") / identifier,
         "public_headers": PurePosixPath("src/modules") / identifier / "include/aimee" / identifier,
         "tests": PurePosixPath("src/tests"),
         "docs": PurePosixPath("docs/modules"),
@@ -305,6 +311,7 @@ def validate_owned_path(repo: Path, identifier: str, field: str, raw: object,
     module_root = _resolve_owned(resolved_repo / "src/modules" / identifier, pointer)
     boundaries = {
         "sources": module_root,
+        "private_headers": module_root,
         "public_headers": _resolve_owned(module_root / "include/aimee" / identifier, pointer),
         "tests": _resolve_owned(resolved_repo / "src/tests", pointer),
         "docs": _resolve_owned(resolved_repo / "docs/modules", pointer),
@@ -312,6 +319,10 @@ def validate_owned_path(repo: Path, identifier: str, field: str, raw: object,
     boundary = boundaries[field]
     if not _contained(resolved, boundary):
         fail("ownership-role-boundary", f"{field} path is outside {boundary}: {raw}", pointer)
+    public_boundary = _resolve_owned(module_root / "include/aimee" / identifier, pointer)
+    if field == "private_headers" and _contained(resolved, public_boundary):
+        fail("ownership-role-boundary", f"private header is inside {public_boundary}: {raw}",
+             pointer)
     if field == "tests" and not PurePosixPath(raw).name.startswith("test_"):
         fail("ownership-role", f"test path must use the test_ convention: {raw}", pointer)
     if field == "docs" and raw != f"docs/modules/{identifier}.md":
@@ -322,6 +333,51 @@ def validate_owned_path(repo: Path, identifier: str, field: str, raw: object,
     if not resolved.is_file():
         fail("ownership-file", f"path is not an existing regular file: {raw}", pointer)
     return {"path": raw, "result": "PASS"}
+
+
+def validate_complete_ownership(repo: Path, identifier: str,
+                                value: dict[str, object]) -> None:
+    """Require an opted-in descriptor to enumerate its complete owner-local C surface."""
+    module_root = repo / "src/modules" / identifier
+    public_root = module_root / "include/aimee" / identifier
+    policies = {
+        "sources": ROLE_EXTENSIONS["sources"],
+        "private_headers": ROLE_EXTENSIONS["private_headers"],
+    }
+    for role, extensions in policies.items():
+        actual: set[str] = set()
+        for path in module_root.rglob("*"):
+            if path == module_root / "module.yaml":
+                continue
+            if _contained(path, public_root) or path.suffix not in extensions:
+                continue
+            relative = path.relative_to(repo).as_posix()
+            if path.is_symlink():
+                fail(
+                    "ownership-complete-symlink",
+                    f"{identifier} {role} path must not be a symlink: {relative}",
+                    f"/{role}",
+                )
+            if not path.is_file():
+                fail(
+                    "ownership-complete-file",
+                    f"{identifier} {role} path is not a regular file: {relative}",
+                    f"/{role}",
+                )
+            actual.add(relative)
+        declared = set(value.get(role, []))
+        missing = sorted(actual - declared)
+        extra = sorted(declared - actual)
+        if missing or extra:
+            fail(
+                "ownership-complete",
+                f"{identifier} {role} mismatch for extensions {sorted(extensions)}; "
+                f"missing={missing}, extra={extra}",
+                f"/{role}",
+            )
+    expected_doc = f"docs/modules/{identifier}.md"
+    if value.get("docs") != [expected_doc]:
+        fail("ownership-complete", f"{identifier} docs must equal [{expected_doc!r}]", "/docs")
 
 
 def validate_ownership(
@@ -371,6 +427,8 @@ def validate_ownership(
             if cross_claims is not None:
                 cross_claims[raw] = (identifier, field, pointer)
         ownership[field] = entries
+    if value.get("ownership_complete") is True:
+        validate_complete_ownership(repo, identifier, value)
     return report
 
 

--- a/src/modules/module.schema.json
+++ b/src/modules/module.schema.json
@@ -29,6 +29,16 @@
       "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
       "type": "string"
     },
+    "ownership_complete": {
+      "type": "boolean"
+    },
+    "private_headers": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
     "public_headers": {
       "items": {
         "type": "string"

--- a/src/modules/roundtable/module.yaml
+++ b/src/modules/roundtable/module.yaml
@@ -11,7 +11,46 @@
     "routing"
   ],
   "enabled_by_default": false,
+  "ownership_complete": true,
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/roundtable/delegate_ensemble.c",
+    "src/modules/roundtable/delegate_ensemble_review.c",
+    "src/modules/roundtable/roundtable_activation.c",
+    "src/modules/roundtable/roundtable_chair.c",
+    "src/modules/roundtable/roundtable_pipeline_capture.c",
+    "src/modules/roundtable/roundtable_pipeline_chunk.c",
+    "src/modules/roundtable/roundtable_pipeline_eval.c",
+    "src/modules/roundtable/roundtable_preset.c",
+    "src/modules/roundtable/roundtable_seat_resolve.c",
+    "src/modules/roundtable/roundtable_verify.c"
+  ],
+  "private_headers": [
+    "src/modules/roundtable/delegate_ensemble.h",
+    "src/modules/roundtable/delegate_ensemble_internal.h",
+    "src/modules/roundtable/roundtable_activation.h",
+    "src/modules/roundtable/roundtable_chair.h",
+    "src/modules/roundtable/roundtable_pipeline_capture.h",
+    "src/modules/roundtable/roundtable_pipeline_chunk.h",
+    "src/modules/roundtable/roundtable_pipeline_eval.h",
+    "src/modules/roundtable/roundtable_preset.h",
+    "src/modules/roundtable/roundtable_seat_resolve.h",
+    "src/modules/roundtable/roundtable_types.h",
+    "src/modules/roundtable/roundtable_verify.h"
+  ],
+  "tests": [
+    "src/tests/test_delegate_ensemble.c",
+    "src/tests/test_roundtable_chair.c",
+    "src/tests/test_roundtable_pipeline_capture.c",
+    "src/tests/test_roundtable_pipeline_chunk.c",
+    "src/tests/test_roundtable_pipeline_eval.c",
+    "src/tests/test_roundtable_preset.c",
+    "src/tests/test_roundtable_seat_resolve.c",
+    "src/tests/test_roundtable_verify.c"
+  ],
+  "docs": [
+    "docs/modules/roundtable.md"
+  ]
 }


### PR DESCRIPTION
## What changed

- extend descriptor v1 with `private_headers` and opt-in `ownership_complete`
- enforce exact owner-local source/private-header inventories and canonical module documentation
- reject source-like symlinks and non-regular files with stable validation rules
- make `roundtable` the first mechanically complete module inventory
- document Slice 29 without claiming generated build selection or physical object omission

## Why

Slice 29 establishes a trustworthy descriptor input before generated build profiles can safely consume module ownership. Incomplete descriptors remain migration debt and cannot yet drive generated builds.

## Validation

- technical-writer review: approved (job 8146)
- exact-diff roundtable: approved, 3/3 participants, non-degraded, no findings
- descriptor fixtures and 26-descriptor production graph/schema
- 38 descriptor mutation tests
- public-header layout and 14 mutation tests
- module documentation contract
- cleanup ledger and refactor baselines
- full `make -C src lint`
- `git diff --check`