### PR TITLE
economizer: reject unpriced remote token counts

### DIFF
--- a/docs/features/economizer.md
+++ b/docs/features/economizer.md
@@ -39,18 +39,27 @@ also does not add, remove, or move OpenAI or Anthropic cache controls.
 ## Why the planners are provider-specific
 
 OpenAI and Anthropic both reward stable cacheable prefixes, but their cache breakpoints, write/read
-prices, long-context rules, and response accounting differ. Neither API exposes enough pre-dispatch
-settlement information to let a generic compressor safely infer cache residency or hidden
-breakpoints.
+prices, long-context rules, and response accounting differ. GPT-5.6 exposes explicit breakpoints and
+an exact remote input count, but the counting call has no published finite price bound. Anthropic's
+free remote count is explicitly an estimate with no published numerical error bound. Neither API
+therefore exposes enough pre-dispatch cost evidence to authorize a generic compressor safely.
 
 The OpenAI and Anthropic planners therefore use separate signed pricing and cache-semantics
-contracts. They operate only on local evidence and fully serialized alternatives. Remote token-count
-calls, cache probes, predicted cache hits, and post-response usage fields cannot authorize a change.
+contracts. They operate only on local evidence and fully serialized alternatives. An OpenAI remote
+exact count is rejected as `remote_token_count_unpriced`; an Anthropic remote estimate is rejected as
+`remote_token_count`. Cache probes, predicted cache hits, and post-response usage fields likewise
+cannot authorize a change.
 
 The planners can return a proof for reviewed fixtures, but they are not yet connected to a live
 transform because the production registry has no entries. A future transform needs its own lossless
 semantic contract, exact tokenizer/model compatibility, provenance rules, and converged review
 before it can enter that registry.
+
+This is an activation decision, not a claim that savings are impossible. With the current provider
+contracts, no OpenAI or Anthropic tuple has a complete worst-case monetary proof. Both production
+registries therefore remain empty; unsupported, unknown, or incomplete evidence sends exactly the
+original request without a counting preflight or economizer retry. A damaged signature or unexpected
+nonempty registry fails the wire fence and sends no provider request.
 
 ## Configuration migration
 

--- a/docs/proposals/pending/economizer-lossless-json-live-transform.md
+++ b/docs/proposals/pending/economizer-lossless-json-live-transform.md
@@ -46,16 +46,18 @@ subset of the signed cache/pricing outcomes.
 
 | Required proof fact | OpenAI GPT-5.6 | Anthropic Claude | Activation |
 |---|---|---|---|
-| exact final request count | token-count endpoint is documented as exact; local request-structure tokenization is not | token-count endpoint is documented as an estimate; tokenizer may change | blocked |
-| economizer preflight cost | count-endpoint billing is not authoritatively stated as zero | count endpoint is documented as free | OpenAI blocked; Anthropic insufficient alone |
-| immutable model/tokenizer binding | public aliases and model pages do not establish an immutable tokenizer contract | no exact public tokenizer contract | blocked |
+| exact final request count | `/v1/responses/input_tokens` is documented as the exact count received by the model; local request-structure tokenization is not exact | token-count endpoint is documented as an estimate; tokenizer may change | OpenAI count eligible only with bounded preflight cost; Anthropic blocked |
+| economizer preflight cost | count-endpoint billing is not authoritatively stated as zero or given a finite maximum | count endpoint is documented as free | OpenAI blocked; Anthropic insufficient alone |
+| immutable model/tokenizer binding | `gpt-5.6` is an alias for Sol and the public Sol page does not publish a dated snapshot/tokenizer contract | no exact public tokenizer contract | blocked |
 | finite counting error | none needed for an exact response, but the remote preflight itself must be included | no finite error bound is documented | blocked |
-| cache boundary/state | explicit controls are documented; implicit behavior must be disabled and all protected bytes preserved | explicit markers are documented; automatic top-level placement and lookback must be excluded | eligible only for explicit-only layouts |
+| cache boundary/state | GPT-5.6 documents `prompt_cache_options.mode: explicit`; no-marker requests disable caching, and marked prefixes are explicit, but all protected rendered content still must be proven identical | explicit markers are documented; automatic top-level placement, server-tool breakpoints, and lookback must be excluded | eligible only for explicit-only layouts |
 | complete-call output bound | preserved client limit or documented hard maximum, priced at the worst applicable rate | same | request-dependent |
 | long-context threshold | strict `>272000`; full-request multipliers apply | model- and contract-specific | only after exact pinned counts |
 
-OpenAI remote counting is not used on the live path unless its own marginal charge is authoritatively
-known and included and the safety specification is amended to permit that preflight. Anthropic's free
+OpenAI remote counting is exact token evidence, but exact tokens alone are not a cost proof. It is not
+used on the live path unless its own marginal charge is authoritatively bounded and included in every
+candidate scenario and the safety specification is amended to permit that preflight. The planner
+models this current state explicitly as `remote_token_count_unpriced` and rejects it. Anthropic's free
 estimate cannot authorize a strict inequality without a finite error bound. Returned usage is
 settlement evidence for the request sent, not proof of the counterfactual pristine request.
 
@@ -107,9 +109,51 @@ Validation completed on the merged-forward branch includes:
 - fresh Optane-backed Debian 13 CT 265 builds and the complete focused suite;
 - fresh provider CT 266 byte capture showing identical off/proof-gated OpenAI and Anthropic request
   bodies on their production routes;
-- a real GPT-5.6 paired canary returning identical output and provider-reported usage: 403 prompt
-  tokens and 7 completion tokens in both modes.
+- a real GPT-5.6 paired canary through the configured ChatGPT/Codex delegate transport returning
+  identical output and provider-reported usage: 403 prompt tokens and 7 completion tokens in both
+  modes. This is pass-through evidence, not OpenAI API billing or `/responses/input_tokens` evidence.
 
 No real Anthropic billing canary was available from the configured credentials. That is not an
 activation exception: the Anthropic registry remains empty, so the production behavior is pristine
 pass-through and makes no savings claim.
+
+## Provider-contract refresh, 2026-07-23
+
+The activation matrix was rechecked against the then-current official provider documentation. The
+important OpenAI change is that GPT-5.6 now documents both explicit cache breakpoints and an exact
+input-token endpoint. Those facts resolve the earlier questions of whether a breakpoint can be
+identified and whether a complete structured request can be counted exactly. They do not resolve
+the monetary proof: OpenAI does not document the count endpoint as free and publishes no finite
+maximum charge for it, while the public Sol model page does not expose a dated immutable snapshot or
+tokenizer identity. Anthropic still documents its free count as an estimate with no numerical error
+bound. The signed production registry therefore remains empty.
+
+Authoritative references checked for this refresh:
+
+- <https://developers.openai.com/api/docs/guides/token-counting>
+- <https://developers.openai.com/api/docs/guides/prompt-caching>
+- <https://developers.openai.com/api/docs/models/gpt-5.6-sol>
+- <https://platform.claude.com/docs/en/build-with-claude/token-counting>
+- <https://platform.claude.com/docs/en/build-with-claude/prompt-caching>
+
+### Activation decision
+
+No OpenAI or Anthropic production tuple is authorized by the evidence above. The signed production
+registry must remain empty, and `proof_gated` must remain byte-identical pristine pass-through, until
+the complete-call inequality can be proved for every supported request. In particular:
+
+- OpenAI remote input counting is qualification-only. It must not be added to the production request
+  path unless OpenAI publishes a binding zero-cost contract or finite maximum charge for that call
+  and that cost is included in both sides of the proof.
+- Anthropic remote input counting cannot authorize a production transform until Anthropic publishes
+  an exact applicable tokenizer contract or a finite numerical error bound that is included in the
+  proof.
+- Provider documentation, canaries, and remote counting experiments are evidence-gathering work.
+  They cannot populate or sign the production registry by themselves.
+- Reconsidering activation also requires an immutable model/tokenizer binding, protected cache-byte
+  identity, complete request/output bounds, exhaustive pricing scenarios, and signed fixture proofs.
+
+Failing any planner requirement is not a degraded economization mode. It selects the original request
+with no economizer preflight, retry, cache mutation, or transform. A damaged registry signature or an
+unexpected nonempty production registry instead fails the wire fence before provider dispatch, so it
+cannot add provider cost.

--- a/src/modules/economizer/economizer_openai.c
+++ b/src/modules/economizer/economizer_openai.c
@@ -161,17 +161,22 @@ static int parse_layout(const char *json, const char *model, econ_openai_endpoin
    return ok ? 0 : -1;
 }
 
-static int evidence_valid(const econ_token_evidence_t *evidence,
-                          const econ_openai_context_t *context, const char *json,
-                          econ_openai_endpoint_t endpoint)
+static econ_reason_t evidence_reason(const econ_token_evidence_t *evidence,
+                                     const econ_openai_context_t *context, const char *json,
+                                     econ_openai_endpoint_t endpoint)
 {
-   return evidence && context && json && evidence->cookie == ECON_TOKEN_EVIDENCE_COOKIE &&
-          evidence->provider == ECON_PROVIDER_OPENAI &&
-          evidence->endpoint_id == (uint32_t)endpoint &&
-          evidence->model_snapshot_id == context->model_snapshot_id &&
-          evidence->tokenizer_id == context->tokenizer_id &&
-          evidence->source == ECON_TOKEN_SOURCE_LOCAL_EXACT &&
-          evidence->serialized_buffer == json && evidence->serialized_size == strlen(json);
+   if (!evidence || !context || !json || evidence->cookie != ECON_TOKEN_EVIDENCE_COOKIE ||
+       evidence->provider != ECON_PROVIDER_OPENAI || evidence->endpoint_id != (uint32_t)endpoint ||
+       evidence->model_snapshot_id != context->model_snapshot_id ||
+       evidence->tokenizer_id != context->tokenizer_id || evidence->serialized_buffer != json ||
+       evidence->serialized_size != strlen(json))
+      return ECON_REASON_TOKENIZER_NOT_LOCAL_EXACT;
+   if (evidence->source == ECON_TOKEN_SOURCE_REMOTE_EXACT_UNPRICED)
+      return ECON_REASON_REMOTE_TOKEN_COUNT_UNPRICED;
+   if (evidence->source == ECON_TOKEN_SOURCE_REMOTE_ESTIMATE)
+      return ECON_REASON_REMOTE_TOKEN_COUNT;
+   return evidence->source == ECON_TOKEN_SOURCE_LOCAL_EXACT ? ECON_REASON_NONE
+                                                            : ECON_REASON_TOKENIZER_NOT_LOCAL_EXACT;
 }
 
 static int prices_valid(const econ_openai_prices_t *prices)
@@ -227,9 +232,14 @@ econ_openai_plan_t econ_openai_gpt56_plan(const econ_openai_plan_input_t *input)
       return plan_result(ECON_REASON_INVALID_IDENTITY);
    if (input->endpoint != ECON_OPENAI_RESPONSES && input->endpoint != ECON_OPENAI_CHAT_COMPLETIONS)
       return plan_result(ECON_REASON_UNSUPPORTED_ENDPOINT);
-   if (!evidence_valid(input->baseline_tokens, context, input->baseline_json, input->endpoint) ||
-       !evidence_valid(input->candidate_tokens, context, input->candidate_json, input->endpoint))
-      return plan_result(ECON_REASON_TOKENIZER_NOT_LOCAL_EXACT);
+   econ_reason_t baseline_evidence =
+       evidence_reason(input->baseline_tokens, context, input->baseline_json, input->endpoint);
+   econ_reason_t candidate_evidence =
+       evidence_reason(input->candidate_tokens, context, input->candidate_json, input->endpoint);
+   if (baseline_evidence != ECON_REASON_NONE)
+      return plan_result(baseline_evidence);
+   if (candidate_evidence != ECON_REASON_NONE)
+      return plan_result(candidate_evidence);
    if (!prices_valid(&context->prices) || context->safety_margin < 0)
       return plan_result(ECON_REASON_PRICING_UNAVAILABLE);
 

--- a/src/modules/economizer/economizer_proof.c
+++ b/src/modules/economizer/economizer_proof.c
@@ -335,6 +335,8 @@ const char *econ_reason_str(econ_reason_t reason)
       return "tokenizer_not_local_exact";
    case ECON_REASON_REMOTE_TOKEN_COUNT:
       return "remote_token_count";
+   case ECON_REASON_REMOTE_TOKEN_COUNT_UNPRICED:
+      return "remote_token_count_unpriced";
    case ECON_REASON_INVALID_REQUEST_SHAPE:
       return "invalid_request_shape";
    case ECON_REASON_UNSUPPORTED_CACHE_LAYOUT:

--- a/src/modules/economizer/economizer_proof.h
+++ b/src/modules/economizer/economizer_proof.h
@@ -45,6 +45,7 @@ extern "C"
       ECON_REASON_MODEL_NOT_PINNED,
       ECON_REASON_TOKENIZER_NOT_LOCAL_EXACT,
       ECON_REASON_REMOTE_TOKEN_COUNT,
+      ECON_REASON_REMOTE_TOKEN_COUNT_UNPRICED,
       ECON_REASON_INVALID_REQUEST_SHAPE,
       ECON_REASON_UNSUPPORTED_CACHE_LAYOUT,
       ECON_REASON_INVALID_CACHE_CONTROL,
@@ -65,7 +66,12 @@ extern "C"
    {
       ECON_TOKEN_SOURCE_NONE = 0,
       ECON_TOKEN_SOURCE_LOCAL_EXACT,
-      ECON_TOKEN_SOURCE_REMOTE_ESTIMATE
+      ECON_TOKEN_SOURCE_REMOTE_ESTIMATE,
+      /* The provider says the returned request count is exact, but does not
+       * publish a finite monetary upper bound for the counting call itself.
+       * Exact tokens are insufficient to authorize a transform when obtaining
+       * them may add an unknown cost to the candidate path. */
+      ECON_TOKEN_SOURCE_REMOTE_EXACT_UNPRICED
    } econ_token_source_t;
 
    typedef struct

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -40,6 +40,7 @@ static int g_stream_status = 200;
 static const char *g_stream_payload;
 static const char *g_response_body = NULL;
 static int g_response_status = 200;
+static int g_proof_gated = 0;
 
 static void reset_capture(void)
 {
@@ -51,6 +52,7 @@ static void reset_capture(void)
    g_stream_payload = NULL;
    g_response_body = NULL;
    g_response_status = 200;
+   g_proof_gated = 0;
 }
 
 int agent_load_config(agent_config_t *cfg)
@@ -332,6 +334,8 @@ int config_load(config_t *cfg)
       /* -1 = unspecified: memset-0 would read as user-disabled and gate the modules. */
       cfg->module_memory = cfg->module_governance = -1;
       cfg->module_delegates = cfg->module_workflows = -1;
+      cfg->module_economizer = 1;
+      cfg->economizer_mode = g_proof_gated ? ECON_MODE_PROOF_GATED : ECON_MODE_OFF;
    }
    return 0;
 }
@@ -896,6 +900,53 @@ static void test_messages_preinject_appends_system_block(void)
    PASS("messages_preinject_appends_system_block");
 }
 
+static void test_proof_gated_ingress_wire_parity(void)
+{
+   const char *request = "{\"model\":\"ignored\",\"max_tokens\":64,"
+                         "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}";
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   const delegate_driver_t openai = {.name = "openai", .build_request = openai_driver_build};
+   char resp[4096];
+   char *off_body;
+   emit_capture_t cap;
+
+   reset_capture();
+   g_driver = &anthropic;
+   assert(messages_buffered(request, resp, sizeof(resp)) == 200);
+   off_body = strdup(g_last_body);
+   assert(off_body != NULL);
+   g_proof_gated = 1;
+   assert(messages_buffered(request, resp, sizeof(resp)) == 200);
+   assert(strcmp(g_last_body, off_body) == 0);
+   free(off_body);
+
+   reset_capture();
+   memset(&cap, 0, sizeof(cap));
+   g_driver = &anthropic;
+   g_stream_payload = "event: message_stop\n"
+                      "data: {\"type\":\"message_stop\"}\n\n";
+   assert(messages_stream(request, cap_emit, &cap) == 0);
+   off_body = strdup(g_last_body);
+   assert(off_body != NULL);
+   g_proof_gated = 1;
+   memset(&cap, 0, sizeof(cap));
+   assert(messages_stream(request, cap_emit, &cap) == 0);
+   assert(strcmp(g_last_body, off_body) == 0);
+   free(off_body);
+
+   reset_capture();
+   g_driver = &openai;
+   assert(messages_buffered(request, resp, sizeof(resp)) == 200);
+   off_body = strdup(g_last_body);
+   assert(off_body != NULL);
+   g_proof_gated = 1;
+   assert(messages_buffered(request, resp, sizeof(resp)) == 200);
+   assert(strcmp(g_last_body, off_body) == 0);
+   free(off_body);
+   reset_capture();
+   PASS("proof_gated_ingress_wire_parity");
+}
+
 int main(void)
 {
    test_translate_request_anthropic_passthrough();
@@ -913,6 +964,7 @@ int main(void)
    test_messages_buffered_system_prompt_capability_no_duplicate_system();
    test_messages_stream_openai_family_translates();
    test_messages_stream_chatgpt_buffered_replays_responses();
+   test_proof_gated_ingress_wire_parity();
    printf("anthropic_http: OK\n");
    return 0;
 }

--- a/src/tests/test_economizer_openai.c
+++ b/src/tests/test_economizer_openai.c
@@ -24,7 +24,7 @@ typedef struct
 
 static fixture_t fixture_make_endpoint(const char *baseline, uint64_t baseline_tokens,
                                        const char *candidate, uint64_t candidate_tokens,
-                                       econ_openai_endpoint_t endpoint)
+                                       econ_openai_endpoint_t endpoint, econ_token_source_t source)
 {
    fixture_t f;
    memset(&f, 0, sizeof(f));
@@ -35,10 +35,10 @@ static fixture_t fixture_make_endpoint(const char *baseline, uint64_t baseline_t
        .output_per_token = 60,
    };
    f.context = econ_test_openai_context_create("gpt-5.6-sol-snapshot", prices, 0, 1);
-   f.baseline_evidence = econ_test_token_evidence_create(
-       ECON_PROVIDER_OPENAI, endpoint, baseline, baseline_tokens, ECON_TOKEN_SOURCE_LOCAL_EXACT);
-   f.candidate_evidence = econ_test_token_evidence_create(
-       ECON_PROVIDER_OPENAI, endpoint, candidate, candidate_tokens, ECON_TOKEN_SOURCE_LOCAL_EXACT);
+   f.baseline_evidence = econ_test_token_evidence_create(ECON_PROVIDER_OPENAI, endpoint, baseline,
+                                                         baseline_tokens, source);
+   f.candidate_evidence = econ_test_token_evidence_create(ECON_PROVIDER_OPENAI, endpoint, candidate,
+                                                          candidate_tokens, source);
    f.input.baseline_json = baseline;
    f.input.candidate_json = candidate;
    f.input.context = f.context;
@@ -52,7 +52,7 @@ static fixture_t fixture_make(const char *baseline, uint64_t baseline_tokens, co
                               uint64_t candidate_tokens)
 {
    return fixture_make_endpoint(baseline, baseline_tokens, candidate, candidate_tokens,
-                                ECON_OPENAI_RESPONSES);
+                                ECON_OPENAI_RESPONSES, ECON_TOKEN_SOURCE_LOCAL_EXACT);
 }
 
 static void fixture_free(fixture_t *f)
@@ -72,6 +72,18 @@ static void test_threshold_crossing_cost_evidence_is_not_authority(void)
    assert(plan.scenario.candidate_upper == 4600000);
    fixture_free(&f);
    PASS("threshold_crossing_cost_evidence_is_not_authority");
+}
+
+static void test_remote_exact_count_is_unpriced_not_authority(void)
+{
+   fixture_t f =
+       fixture_make_endpoint(baseline_no_cache, 300000, candidate_no_cache, 200000,
+                             ECON_OPENAI_RESPONSES, ECON_TOKEN_SOURCE_REMOTE_EXACT_UNPRICED);
+   econ_openai_plan_t plan = econ_openai_gpt56_plan(&f.input);
+   assert(plan.cost_verdict == ECON_COST_INDETERMINATE);
+   assert(plan.reason == ECON_REASON_REMOTE_TOKEN_COUNT_UNPRICED);
+   fixture_free(&f);
+   PASS("remote_exact_count_is_unpriced_not_authority");
 }
 
 static void test_strict_threshold_and_guard(void)
@@ -155,8 +167,8 @@ static void test_chat_shape_and_cache_intent(void)
        "{\"model\":\"gpt-5.6-sol-snapshot\",\"max_completion_tokens\":10000,"
        "\"prompt_cache_key\":\"stable-key\",\"prompt_cache_options\":{\"mode\":\"explicit\"},"
        "\"messages\":[{\"role\":\"user\",\"content\":\"small\"}]}";
-   fixture_t f =
-       fixture_make_endpoint(baseline, 300000, candidate, 200000, ECON_OPENAI_CHAT_COMPLETIONS);
+   fixture_t f = fixture_make_endpoint(baseline, 300000, candidate, 200000,
+                                       ECON_OPENAI_CHAT_COMPLETIONS, ECON_TOKEN_SOURCE_LOCAL_EXACT);
    assert(econ_openai_gpt56_plan(&f.input).cost_verdict == ECON_COST_PROVEN);
    fixture_free(&f);
 
@@ -164,7 +176,8 @@ static void test_chat_shape_and_cache_intent(void)
        "{\"model\":\"gpt-5.6-sol-snapshot\",\"max_completion_tokens\":10000,"
        "\"prompt_cache_key\":\"changed-key\",\"prompt_cache_options\":{\"mode\":\"explicit\"},"
        "\"messages\":[{\"role\":\"user\",\"content\":\"small\"}]}";
-   f = fixture_make_endpoint(baseline, 300000, changed_key, 200000, ECON_OPENAI_CHAT_COMPLETIONS);
+   f = fixture_make_endpoint(baseline, 300000, changed_key, 200000, ECON_OPENAI_CHAT_COMPLETIONS,
+                             ECON_TOKEN_SOURCE_LOCAL_EXACT);
    assert(econ_openai_gpt56_plan(&f.input).reason == ECON_REASON_UNSUPPORTED_CACHE_LAYOUT);
    fixture_free(&f);
    PASS("chat_shape_and_cache_intent");
@@ -174,6 +187,7 @@ int main(void)
 {
    printf("economizer_openai tests:\n");
    test_threshold_crossing_cost_evidence_is_not_authority();
+   test_remote_exact_count_is_unpriced_not_authority();
    test_strict_threshold_and_guard();
    test_implicit_and_breakpoint_cache_are_denied();
    test_evidence_is_bound_to_buffer_and_duplicates_rejected();

--- a/src/tests/test_economizer_wire_snapshot.c
+++ b/src/tests/test_economizer_wire_snapshot.c
@@ -54,18 +54,23 @@ static void test_off_bypasses_snapshot(void)
    assert(selected.len == 2);
 }
 
-static void test_proof_gated_empty_registry_is_byte_identical(void)
+static void test_proof_gated_empty_registry_is_byte_identical_on_every_route(void)
 {
    const unsigned char body[] = {'{', ' ', '"', 'x', '"', ':', ' ', '1', ' ', '}'};
-   econ_wire_snapshot_t *snapshot = NULL;
-   econ_wire_bytes_t selected = {0};
-   assert(econ_wire_select(1, ECON_WIRE_OPENAI_CHAT, body, sizeof(body), &snapshot, &selected) ==
-          0);
-   assert(snapshot != NULL);
-   assert(selected.len == sizeof(body));
-   assert(memcmp(selected.data, body, sizeof(body)) == 0);
-   assert(selected.data != body);
-   econ_wire_snapshot_destroy(snapshot);
+   const econ_wire_route_t routes[] = {ECON_WIRE_OPENAI_CHAT, ECON_WIRE_OPENAI_RESPONSES,
+                                       ECON_WIRE_ANTHROPIC_MESSAGES};
+   for (size_t i = 0; i < sizeof(routes) / sizeof(routes[0]); i++)
+   {
+      econ_wire_snapshot_t *snapshot = NULL;
+      econ_wire_bytes_t selected = {0};
+      assert(econ_wire_select(1, routes[i], body, sizeof(body), &snapshot, &selected) == 0);
+      assert(snapshot != NULL);
+      assert(selected.len == sizeof(body));
+      assert(memcmp(selected.data, body, sizeof(body)) == 0);
+      assert(selected.data != body);
+      assert(econ_wire_snapshot_route(snapshot) == routes[i]);
+      econ_wire_snapshot_destroy(snapshot);
+   }
 }
 
 int main(void)
@@ -74,7 +79,7 @@ int main(void)
    test_explicit_length_preserves_embedded_nul();
    test_invalid_inputs_fail_without_snapshot();
    test_off_bypasses_snapshot();
-   test_proof_gated_empty_registry_is_byte_identical();
+   test_proof_gated_empty_registry_is_byte_identical_on_every_route();
    puts("economizer_wire_snapshot: ALL PASS");
    return 0;
 }


### PR DESCRIPTION
## What changed

- Model OpenAI's exact-but-unpriced remote input count as explicit non-authority.
- Reject that evidence before pricing with `remote_token_count_unpriced`.
- Keep the signed production registry empty and document the current OpenAI/Anthropic activation blockers.
- Add all-route immutable-wire parity and buffered/streaming ingress parity coverage.

## Why

GPT-5.6 now exposes explicit prompt-cache breakpoints and exact structured input counting, but OpenAI does not publish a finite monetary bound for the counting call. Anthropic's free count remains an estimate without a numerical error bound. Neither provider therefore supplies enough evidence for Aimee's strict guarantee that intervention costs less in every scenario.

This change makes that missing proof explicit and preserves pristine pass-through. It does not claim economization is impossible; it prevents an unproved optimization from costing users more.

## Validation

- `make lint`
- focused OpenAI, Anthropic, proof, wire-snapshot, and Anthropic ingress tests
- live-surface reachability test
- roundtable convergence: approved, zero findings, 2/2 participants, not degraded
- fresh Optane CT267/268 builds and provider captures
- byte-identical off/proof-gated bodies for delegate OpenAI/Anthropic routes, server OpenAI chat, and Anthropic buffered/streaming ingress
