### PR TITLE
feat(economizer): add off, safe, and aggressive tiers

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -35,21 +35,22 @@ request), unless noted otherwise below.
 
 ### Context economizer: `economizer.mode`
 
-The economizer has one fail-closed mode control:
+The economizer has one mode control:
 
 ```yaml
 economizer:
-  mode: off             # off | proof_gated (default: off)
+  mode: safe             # off | safe | aggressive (default: safe)
 ```
 
 | Mode | What it does |
 | --- | --- |
-| `off` (default) | Sends the completed provider body without economizer registry work. |
-| `proof_gated` | Validates the signed transform registry and freezes the selected body behind an immutable exact-length wire snapshot. The current registry is empty, so only pristine bytes can be selected. |
+| `off` | Disables economizer transforms. |
+| `safe` (default) | Deterministically compacts strict JSON from a fresh local tool result before its first provider dispatch. It does not rewrite history or cache controls. |
+| `aggressive` | Adds the existing lossy history and tool-output reducers on supported OpenAI-family routes. Native Anthropic history is not mutated. |
 
 `modules.economizer: false` is an authoritative hard-kill that forces the effective mode to
-`off`. Legacy folding, condensation, compression, gateway mutation, and restore/resend are
-disconnected from production request paths. See [The aimee Economizer](features/economizer.md).
+`off`. Provider cache controls are never changed, and retries reuse the selected exact-length wire
+snapshot. See [The aimee Economizer](features/economizer.md).
 
 ### Autonomous-development pipeline: `autonomy.*`
 
@@ -90,19 +91,19 @@ and is not affected by this key.
 
 ## Choosing an economizer mode
 
-The economizer defaults to `off`. To enable its proof fence, set `economizer.mode`:
+The economizer defaults to `safe`. Select any tier with `economizer.mode`:
 
 ```yaml
 economizer:
-  mode: proof_gated
+  mode: safe
 ```
 
 ```sh
-aimee config set economizer.mode proof_gated
+aimee config set economizer.mode safe
 ```
 
-Explicit legacy `safe` and `aggressive` values are rejected rather than mapped. See
-[features/economizer.md](features/economizer.md) for the migration and safety contract.
+Use `off` for byte-for-byte pass-through or `aggressive` when lossy context reduction is acceptable.
+See [features/economizer.md](features/economizer.md) for the provider and safety boundaries.
 
 ## When a change takes effect
 

--- a/docs/features/economizer.md
+++ b/docs/features/economizer.md
@@ -1,97 +1,60 @@
 # The aimee Economizer
 
-The economizer is fail-closed: it may change a provider request only when a local,
-provider-specific proof establishes a strict call-level cost reduction. If any required fact is
-unknown, the original provider body is sent unchanged.
+The economizer has three deliberately simple modes:
 
 ```yaml
 economizer:
-  mode: off             # off | proof_gated (default: off)
+  mode: safe             # off | safe | aggressive (default: safe)
 ```
 
 ```sh
-aimee config set economizer.mode proof_gated
+aimee config set economizer.mode safe
 ```
 
-## Current release behavior
+## Modes
 
-The live transform registry is empty. Therefore both modes currently send the same pristine request:
+| Mode | Behavior |
+| --- | --- |
+| `off` | Sends the normal request. No economizer transform or wire snapshot is used. |
+| `safe` (default) | Compacts strict JSON returned by a local tool before that result is sent to a provider for the first time. It does not rewrite history or cache controls. |
+| `aggressive` | Includes safe behavior and enables the existing lossy history and tool-output reducers on supported OpenAI-family routes. |
 
-- `off` bypasses economizer registry validation and the snapshot allocation.
-- `proof_gated` validates the signed empty registry, then copies the final provider body into an
-  immutable wire snapshot.
+Safe compaction removes only insignificant JSON whitespace outside strings. It is deterministic,
+rejects malformed or non-JSON text, and keeps the original unless the serialized result is shorter.
+Because it runs at local tool completion, the provider has never seen the original bytes: there is
+no existing OpenAI or Anthropic cache prefix to invalidate. Safe never summarizes, truncates,
+rehydrates, folds previously sent messages, moves a cache breakpoint, or calls a remote token-count
+endpoint.
 
-The snapshot's pointer and exact byte length are passed to the HTTP transport and retained for every
-ordinary retry. A retry can duplicate delivery after an ambiguous network failure, but it cannot
-rebuild, restore, or substitute a different economizer representation.
+Aggressive is explicitly lossy. It can reduce older context and condensed tool results. That can
+lower fresh input, but it can also reduce cache hits or omit useful detail. Native Anthropic routes
+are excluded from gateway history mutation because Anthropic caching depends on an exact matching
+prefix. Use aggressive only when that tradeoff is acceptable.
 
-The release also contains dormant activation machinery for a future reviewed transform: strict
-whitespace-only JSON compaction, one-shot local-output provenance, canonical signed-registry tuple
-serialization, and a tenant-scoped first-write generation lease. Source-surface tests keep those APIs
-unreachable from live request paths while the registry is empty. Their presence is not reported as a
-token or dollar saving.
+## Provider behavior
 
-This release deliberately removes the previous live history folding, tool-output condensation,
-body compression, gateway mutation, and economizer-owned restore/resend behavior. Their helper code
-may remain for offline or isolated tests, but it has no production request caller. The economizer
-also does not add, remove, or move OpenAI or Anthropic cache controls.
+OpenAI and Anthropic both cache stable prefixes, but expose different controls and accounting. The
+economizer does not try to infer hidden automatic breakpoints, predict cache residency, or change
+client-supplied cache controls.
 
-## Why the planners are provider-specific
+- OpenAI-family requests may use aggressive history reduction. The selected request body is frozen
+  into an exact-length snapshot and ordinary retries reuse those exact bytes.
+- Native Anthropic requests preserve the caller's message prefix and `cache_control` placement in
+  every mode.
+  Safe fresh-result compaction is still available in aimee's own agent loop because it happens
+  before first dispatch.
+- Provider-reported usage is accounting evidence after a call, not authorization for a pre-call
+  rewrite. No counting preflight or economizer-owned restore/resend is performed.
 
-OpenAI and Anthropic both reward stable cacheable prefixes, but their cache breakpoints, write/read
-prices, long-context rules, and response accounting differ. GPT-5.6 exposes explicit breakpoints and
-an exact remote input count, but the counting call has no published finite price bound. Anthropic's
-free remote count is explicitly an estimate with no published numerical error bound. Neither API
-therefore exposes enough pre-dispatch cost evidence to authorize a generic compressor safely.
+These rules avoid the failure mode where a compressor saves a few fresh tokens but forces a much
+larger cached prefix to be billed as a cache write or uncached input.
 
-The OpenAI and Anthropic planners therefore use separate signed pricing and cache-semantics
-contracts. They operate only on local evidence and fully serialized alternatives. An OpenAI remote
-exact count is rejected as `remote_token_count_unpriced`; an Anthropic remote estimate is rejected as
-`remote_token_count`. Cache probes, predicted cache hits, and post-response usage fields likewise
-cannot authorize a change.
+## Configuration
 
-The planners can return a proof for reviewed fixtures, but they are not yet connected to a live
-transform because the production registry has no entries. A future transform needs its own lossless
-semantic contract, exact tokenizer/model compatibility, provenance rules, and converged review
-before it can enter that registry.
+`economizer.mode` accepts only `off`, `safe`, or `aggressive` (case-insensitive). An omitted setting
+defaults to `safe`; malformed or unknown values fail configuration loading. The deprecated
+`economizer.enabled` and `economizer.aggressive` fields are not accepted. `modules.economizer: false`
+is an authoritative kill switch and makes the effective mode `off`.
 
-This is an activation decision, not a claim that savings are impossible. With the current provider
-contracts, no OpenAI or Anthropic tuple has a complete worst-case monetary proof. Both production
-registries therefore remain empty; unsupported, unknown, or incomplete evidence sends exactly the
-original request without a counting preflight or economizer retry. A damaged signature or unexpected
-nonempty registry fails the wire fence and sends no provider request.
-
-## Configuration migration
-
-The old scalar values `economizer: safe` and `economizer: aggressive`, and the old
-`economizer.enabled` / `economizer.aggressive` object, are unsupported. They are not mapped because
-either mapping could silently activate behavior the operator did not select. Replace them explicitly
-with:
-
-```yaml
-economizer:
-  mode: off
-```
-
-or, to enable the proof fence for future reviewed transforms:
-
-```yaml
-economizer:
-  mode: proof_gated
-```
-
-An omitted setting defaults to `off`. Explicit legacy or malformed values make configuration loading
-fail instead of falling back to an active mode.
-
-## Claims this release does not make
-
-- It does not claim that generic compression, summarization, recall, or rehydration saves money.
-- It does not claim completed-task savings from a cheaper individual call.
-- It does not claim knowledge of provider cache residency or undocumented breakpoints.
-- It does not claim exactly-once delivery across transport failures.
-- It does not report hypothetical savings as realized savings.
-
-The normative safety rules and implementation plan are in
-`docs/proposals/pending/provider-neutral-economizer-safety-spec.md` and
-`docs/proposals/pending/provider-neutral-cache-aware-economizer.md`. The current provider activation
-matrix is in `docs/proposals/pending/economizer-lossless-json-live-transform.md`.
+Changes apply on the next request/turn. See [Settings](../SETTINGS.md) for the CLI and configuration
+surface.

--- a/docs/features/tool-output-condensation.md
+++ b/docs/features/tool-output-condensation.md
@@ -1,7 +1,8 @@
 # Tool-output condensation (retired from live requests)
 
-> **Current status:** the helper remains as isolated deterministic code, but every production
-> request caller is removed. Neither `off` nor `proof_gated` enables it. A retrieval pointer is not
+> **Current status:** the command-aware spill-and-recall helper remains isolated from production
+> request paths. Neither `off` nor `safe` enables it. `aggressive` uses the general lossy context
+> reducer, not this retired helper. A retrieval pointer is not
 > mechanically equivalent to presenting the original bytes to the model, and page-back cost cannot
 > be bounded before dispatch. Re-enablement requires a separately reviewed transform contract and
 > signed registry entry.
@@ -25,10 +26,11 @@ There is no configuration that activates condensation. The current economizer su
 
 ```yaml
 economizer:
-  mode: off             # off | proof_gated
+  mode: safe             # off | safe | aggressive
 ```
 
-Both modes leave tool output pristine in production. See [SETTINGS.md](../SETTINGS.md) and
+Off and safe leave non-JSON tool output pristine; safe may remove insignificant whitespace from a
+strict JSON result before first dispatch. See [SETTINGS.md](../SETTINGS.md) and
 [the economizer overview](economizer.md).
 
 ## What it does

--- a/docs/proposals/pending/economizer-lossless-json-live-transform.md
+++ b/docs/proposals/pending/economizer-lossless-json-live-transform.md
@@ -1,5 +1,11 @@
 # Lossless JSON economizer transform and activation gate
 
+> **Superseded for runtime policy (2026-07-23):** the exhaustive monetary-proof gate described
+> below is retained as research history. The shipped interface is now `off`, `safe`, and
+> `aggressive`. Safe admits only deterministic strict-JSON whitespace compaction at the fresh local
+> tool-result boundary; aggressive owns lossy reduction. See
+> [the economizer overview](../../features/economizer.md).
+
 - **State:** in progress
 - **Review status:** ROUND TABLE APPROVED (3/3, zero findings)
 - **Date:** 2026-07-22

--- a/src/Makefile
+++ b/src/Makefile
@@ -435,6 +435,7 @@ SERVER_SRCS = cli_v1_routes.c cli_v1_routes_b.c cli_v1_routes_c.c cli_v1_routes_
               server/server_workflow_api.c
 SERVER_SRCS += server/server_mgmt_token.c server/kb_verifier_server_stub.c kb/auth_oidc.c server/server_mgmt_audit.c server/server_mgmt_endpoint.c shared/management_read.c server/server_mgmt_read_endpoint.c server/server_mgmt_read_source.c server/server_mgmt_status.c server/server_mgmt_checkpoint_client.c kb/kb_mgmt_status.c kb/kb_mgmt_client.c kb/kb_mgmt_endpoint.c
 SERVER_SRCS += http_content_encoding.c server/server_http_keepalive.c
+SERVER_SRCS += modules/economizer/gateway_mutate_wire.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) modules/guardrails/guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -379,7 +379,7 @@ static const config_schema_entry_t config_schema[] = {
     {"compact", SCHEMA_OBJECT, 0},
     {"fold", SCHEMA_OBJECT, 0},
     {"modules", SCHEMA_OBJECT, 0},    /* memory/governance/delegates/workflows/economizer toggles */
-    {"economizer", SCHEMA_OBJECT, 0}, /* {mode: off|proof_gated} */
+    {"economizer", SCHEMA_OBJECT, 0}, /* {mode: off|safe|aggressive} */
     {"sessions", SCHEMA_OBJECT, 0},
     {"sandbox", SCHEMA_OBJECT, 0},
     {"prompt_tier", SCHEMA_STRING, 0},
@@ -610,9 +610,9 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_freeze_tail_cap_msgs = 0;
    cfg->fold_recall_enabled = 0; /* fold §4: default-off */
    cfg->fold_recall_ttl_turns = 0;
-   /* Context economizer defaults OFF. proof_gated freezes pristine provider bytes
-    * behind the signed-empty-registry fence; no legacy reduction lever is live. */
-   cfg->economizer_mode = ECON_MODE_OFF;
+   /* SAFE is useful without provider-specific pricing guesses: it only compacts
+    * strict JSON returned by a local tool before that result's first dispatch. */
+   cfg->economizer_mode = ECON_MODE_SAFE;
    /* Pluggable-module toggles default to -1 (unspecified) so the resolver falls back to each
     * module's deprecated env toggle / default-ON until an operator writes the `modules:` block. */
    cfg->module_memory = -1;
@@ -986,15 +986,26 @@ int econ_mode(const config_t *cfg)
 
 const char *econ_mode_name(int mode)
 {
-   return mode == ECON_MODE_PROOF_GATED ? "proof_gated" : "off";
+   switch (mode)
+   {
+   case ECON_MODE_OFF:
+      return "off";
+   case ECON_MODE_AGGRESSIVE:
+      return "aggressive";
+   case ECON_MODE_SAFE:
+   default:
+      return "safe";
+   }
 }
 
 int econ_mode_parse(const char *s)
 {
-   if (s && strcmp(s, "off") == 0)
+   if (s && strcasecmp(s, "off") == 0)
       return ECON_MODE_OFF;
-   if (s && strcmp(s, "proof_gated") == 0)
-      return ECON_MODE_PROOF_GATED;
+   if (s && strcasecmp(s, "safe") == 0)
+      return ECON_MODE_SAFE;
+   if (s && strcasecmp(s, "aggressive") == 0)
+      return ECON_MODE_AGGRESSIVE;
    return -1;
 }
 
@@ -1029,8 +1040,7 @@ int guardrails_semantic_mode_parse(const char *s)
 
 int econ_reduction_master_on(const config_t *cfg)
 {
-   (void)cfg;
-   return 0;
+   return econ_mode(cfg) != ECON_MODE_OFF;
 }
 
 int config_module_enabled(int config_tristate, int env_default)
@@ -1045,8 +1055,7 @@ int config_module_enabled(int config_tristate, int env_default)
 
 int econ_gateway_mutate_on(const config_t *cfg)
 {
-   (void)cfg;
-   return 0;
+   return econ_mode(cfg) == ECON_MODE_AGGRESSIVE;
 }
 
 void econ_preset(const config_t *cfg, econ_preset_t *out)
@@ -1054,7 +1063,19 @@ void econ_preset(const config_t *cfg, econ_preset_t *out)
    if (!out)
       return;
    memset(out, 0, sizeof *out);
-   (void)cfg;
+   int mode = econ_mode(cfg);
+   if (mode == ECON_MODE_OFF)
+      return;
+   out->json_compact = 1;
+   if (mode == ECON_MODE_AGGRESSIVE)
+   {
+      out->history_fold = 1;
+      out->compress = 1;
+      out->command_filter = 1;
+      out->freeze_guard_horizon = 1;
+      out->gateway_seam = 1;
+      out->gateway_session_disable_ttl_ms = 3600000;
+   }
 }
 
 static int config_snapshot_live(void);

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -2098,17 +2098,19 @@ int config_autonomy_lookup(const char *env_name, long *out);
  * and internally by config_reload. Ordinary readers should use config_load. */
 int config_load_file(config_t *cfg);
 
-/* The only economizer modes. OFF is the baseline; PROOF_GATED freezes the
- * completed body behind the signed-empty-registry fence. */
+/* Economizer policy. SAFE permits only deterministic, mechanically lossless
+ * transforms of fresh local content. AGGRESSIVE additionally permits the
+ * existing lossy history/tool-result reducers. */
 typedef enum
 {
    ECON_MODE_OFF = 0,
-   ECON_MODE_PROOF_GATED = 1
+   ECON_MODE_SAFE = 1,
+   ECON_MODE_AGGRESSIVE = 2
 } econ_mode_t;
 
 int econ_mode(const config_t *cfg);
-const char *econ_mode_name(int mode); /* "off"/"proof_gated" */
-int econ_mode_parse(const char *s);   /* mode, or -1 for legacy/unknown */
+const char *econ_mode_name(int mode); /* "off"/"safe"/"aggressive" */
+int econ_mode_parse(const char *s);   /* mode, or -1 for unknown */
 
 /* Semantic-guardrails escalation mode — the single control that replaced the
  * enabled/dry_run/advisory_only/allow_ml_only_block quad. */
@@ -2122,8 +2124,7 @@ enum
 const char *guardrails_semantic_mode_name(int mode); /* "off"/"dry_run"/"advisory"/"enforce" */
 int guardrails_semantic_mode_parse(const char *s);   /* string -> GSEM_MODE_* (OFF on unknown) */
 
-/* Legacy reduction gates remain temporarily for isolated old modules. They are
- * hard-disabled in every mode and have no production request-path caller. */
+/* Reduction gates used by the existing context economizer. */
 int econ_reduction_master_on(const config_t *cfg);
 int econ_gateway_mutate_on(const config_t *cfg);
 
@@ -2137,10 +2138,11 @@ int econ_gateway_mutate_on(const config_t *cfg);
  * `config_tristate` is one of cfg->module_* (-1 = unspecified). Pure: reads its args only. */
 int config_module_enabled(int config_tristate, int env_default);
 
-/* Deprecated compatibility shape for isolated legacy unit tests. econ_preset()
- * always zeroes it; no mode can reactivate these levers. */
+/* Internal policy levers. SAFE enables only json_compact. AGGRESSIVE enables
+ * the legacy lossy reducers as well. */
 typedef struct
 {
+   int json_compact;
    int history_fold;
    int compress;
    int command_filter;

--- a/src/modules/config/config_fields.c
+++ b/src/modules/config/config_fields.c
@@ -383,7 +383,7 @@ const config_field_t config_fields[] = {
     /* Trigger admission policy. The scheduler reads this from the live config snapshot on
      * every sweep, so GUI changes take effect without a restart. */
     {"trigger.max_concurrent", offsetof(config_t, trigger_max_concurrent), sizeof(int), 0, CFG_INT},
-    /* The only economizer control. Legacy scalar/tier fields are not settable. */
+    /* The only economizer control: off, safe, or aggressive. */
     {"economizer.mode", offsetof(config_t, economizer_mode), sizeof(int), 0, CFG_ECON_MODE,
      RELOAD_HOT},
     /* Autonomous-development pipeline knobs (Phase-C). New config_t fields bridged to the

--- a/src/modules/config/config_fields.h
+++ b/src/modules/config/config_fields.h
@@ -16,7 +16,7 @@ typedef enum
    CFG_BOOL,
    CFG_INT,
    CFG_FLOAT,
-   CFG_ECON_MODE /* int enum stored, but get/set as "off|proof_gated" */
+   CFG_ECON_MODE /* int enum stored, but get/set as "off|safe|aggressive" */
 } config_field_type_t;
 
 /* When a config.set / Settings change takes effect (live-config-reload P2). Default 0 = HOT.

--- a/src/modules/config/config_save.c
+++ b/src/modules/config/config_save.c
@@ -1129,12 +1129,12 @@ int config_save(const config_t *cfg)
       }
    }
 
-   /* OFF is the default. Persist proof_gated in the explicit nested public shape. */
-   if (cfg->economizer_mode == ECON_MODE_PROOF_GATED)
+   /* SAFE is the default. Persist either non-default choice explicitly. */
+   if (cfg->economizer_mode != ECON_MODE_SAFE)
    {
       cJSON *econ = cJSON_AddObjectToObject(root, "economizer");
       if (econ)
-         cJSON_AddStringToObject(econ, "mode", "proof_gated");
+         cJSON_AddStringToObject(econ, "mode", econ_mode_name(cfg->economizer_mode));
    }
 
    /* Autonomous-dev knobs — persist only non-defaults (defaults: skeptics 0, fanout off,

--- a/src/modules/config/config_sections.c
+++ b/src/modules/config/config_sections.c
@@ -755,8 +755,7 @@ void config_parse_modules_section(config_t *cfg, cJSON *root)
    }
 }
 
-/* Parse the only supported public shape: economizer: {mode: off|proof_gated}.
- * Explicit legacy values fail activation; they never map to a new mode. */
+/* Parse the public shape: economizer: {mode: off|safe|aggressive}. */
 int config_parse_economizer_section(config_t *cfg, cJSON *root)
 {
    cJSON *econ = cJSON_GetObjectItemCaseSensitive(root, "economizer");
@@ -764,8 +763,8 @@ int config_parse_economizer_section(config_t *cfg, cJSON *root)
       return 0;
    if (!cJSON_IsObject(econ))
    {
-      fprintf(stderr, "aimee: config error: scalar economizer values are no longer supported; use "
-                      "economizer: {mode: off|proof_gated}\n");
+      fprintf(stderr, "aimee: config error: economizer must be an object; use "
+                      "economizer: {mode: off|safe|aggressive}\n");
       return -1;
    }
 
@@ -787,16 +786,15 @@ int config_parse_economizer_section(config_t *cfg, cJSON *root)
    }
    if (fields != 1 || !cJSON_IsString(mode) || !mode->valuestring)
    {
-      fprintf(stderr, "aimee: config error: economizer.mode must be exactly off or proof_gated\n");
+      fprintf(stderr, "aimee: config error: economizer.mode must be off, safe, or aggressive\n");
       return -1;
    }
    int parsed = econ_mode_parse(mode->valuestring);
    if (parsed < 0)
    {
       fprintf(stderr,
-              "aimee: config error: economizer mode \"%s\" is unsupported; legacy "
-              "safe/aggressive modes cannot be migrated automatically; choose off or "
-              "proof_gated explicitly\n",
+              "aimee: config error: economizer mode \"%s\" is unsupported; choose "
+              "off, safe, or aggressive\n",
               mode->valuestring);
       return -1;
    }

--- a/src/modules/economizer/economizer.h
+++ b/src/modules/economizer/economizer.h
@@ -11,8 +11,9 @@
 #define DEC_ECONOMIZER_H 1
 
 #include "economizer_proof.h" /* provider-specific cost-proof gate; empty live registry */
-#include "context_reduce.h" /* context_reduce(), reduce_config_t / reduce_result_t / seams */
-#include "context_fold.h"   /* context_fold_view / context_compress_view, fold_config_t */
-#include "tool_condense.h"  /* tool_condense_apply / _recall / _enabled, family parsers */
+#include "economizer_json.h"  /* strict fresh-tool-result JSON compaction */
+#include "context_reduce.h"   /* context_reduce(), reduce_config_t / reduce_result_t / seams */
+#include "context_fold.h"     /* context_fold_view / context_compress_view, fold_config_t */
+#include "tool_condense.h"    /* tool_condense_apply / _recall / _enabled, family parsers */
 
 #endif /* DEC_ECONOMIZER_H */

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -20,6 +20,7 @@
 #include "gateway_delegate.h"
 #include "gateway_policy.h"
 #include "http_retry.h"
+#include "economizer.h"
 #include "economizer_wire_snapshot.h"
 #include "log.h"
 #include "middleware.h"
@@ -86,6 +87,31 @@ static int agent_delegation_stopped(char *buf, size_t bufsz)
    if (buf && bufsz > 0)
       snprintf(buf, bufsz, "delegate %s (%s)", reason, delegation_id);
    return 1;
+}
+
+/* Apply the SAFE contract at the authenticated local-tool completion boundary.
+ * The result has not crossed a provider boundary yet. econ_json_compact removes
+ * only RFC 8259 whitespace outside strings and succeeds only when strictly
+ * shorter; malformed/non-JSON output remains byte-identical. */
+static char *agent_economize_fresh_tool_result(char *result)
+{
+   if (!result)
+      return NULL;
+   config_t cfg;
+   econ_preset_t preset;
+   if (config_load(&cfg) != 0)
+      return result;
+   econ_preset(&cfg, &preset);
+   if (!preset.json_compact)
+      return result;
+
+   uint8_t *compacted = NULL;
+   size_t compacted_len = 0;
+   if (econ_json_compact(result, strlen(result), &compacted, &compacted_len) != ECON_JSON_OK)
+      return result;
+   (void)compacted_len; /* output is NUL-terminated for the existing tool-result surface */
+   free(result);
+   return (char *)compacted;
 }
 
 static int agent_durable_cancelled(char *buf, size_t bufsz)
@@ -568,6 +594,11 @@ native_provider_http:
    mw_pipeline_cfgs_t mw_cfgs;
    mw_pipeline_build(&mw_pipeline, &mw_cfgs, &agent->middleware, mw_max_turns, agent->model);
 
+   /* Persistent only within this agent loop; AGGRESSIVE may freeze a reduced
+    * prefix across turns. SAFE never enters context_reduce. */
+   reduce_state_t agent_reduce_state;
+   memset(&agent_reduce_state, 0, sizeof(agent_reduce_state));
+
    while (turn < max_t)
    {
       /* Stop before issuing a fourth provider request without evidence. The
@@ -718,18 +749,66 @@ native_provider_http:
       fb_agent.require_initial_tool_call = agent_require_initial_tool_choice(
           agent->require_initial_tool_call, successful_tool_calls, active_tools != NULL);
 
+      /* AGGRESSIVE opts into the existing lossy context reducers on OpenAI-family
+       * routes. SAFE never touches previously sent history, and native Anthropic
+       * history is never reduced because its exact prefix controls cache reuse. */
+      reduce_result_t agent_reduce_result;
+      memset(&agent_reduce_result, 0, sizeof(agent_reduce_result));
+      int reduce_active = 0;
+      {
+         config_t ecfg;
+         econ_preset_t preset;
+         if (config_load(&ecfg) == 0)
+            econ_preset(&ecfg, &preset);
+         else
+            memset(&preset, 0, sizeof preset);
+         if (!anthropic && (preset.history_fold || preset.compress))
+         {
+            reduce_config_t rcfg;
+            memset(&rcfg, 0, sizeof rcfg);
+            rcfg.delegate_seam = 1;
+            rcfg.history_fold = preset.history_fold && !chatgpt;
+            rcfg.compress = preset.compress;
+            rcfg.freeze_guard_enabled = 1;
+            rcfg.freeze_guard_horizon = preset.freeze_guard_horizon;
+            rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
+            rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
+            rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;
+            rcfg.fold.compact_head_bytes = ecfg.compact_head_bytes;
+            rcfg.fold.compact_tail_bytes = ecfg.compact_tail_bytes;
+            rcfg.fold.register_enabled = ecfg.fold_register_enabled;
+            rcfg.fold.closet.enabled = ecfg.coord_closet_enabled;
+            rcfg.fold.closet.budget_bytes = ecfg.coord_closet_budget_bytes;
+            rcfg.fold.closet.max_ratio_pct = ecfg.coord_closet_max_ratio_pct;
+            rcfg.fold.closet.denylist =
+                ecfg.coord_closet_denylist[0] ? ecfg.coord_closet_denylist : NULL;
+            agent_reduce_state.reduced = 0;
+            agent_reduce_state.turn = turn;
+            if (context_reduce(messages, sys, fb_agent.model, NULL, REDUCE_SEAM_DELEGATE, &rcfg,
+                               &agent_reduce_state, &agent_reduce_result) == 0 &&
+                agent_reduce_result.mutated && agent_reduce_result.messages)
+               reduce_active = 1;
+            else if (!reduce_active)
+            {
+               context_reduce_result_free(&agent_reduce_result);
+               memset(&agent_reduce_result, 0, sizeof agent_reduce_result);
+            }
+         }
+      }
+      cJSON *eff_messages = reduce_active ? agent_reduce_result.messages : messages;
+
       /* Build request (use fb_agent which may have fallback model after turn 0) */
       cJSON *req;
       if (chatgpt)
-         req = agent_build_request_responses(&fb_agent, messages, active_tools, sys);
+         req = agent_build_request_responses(&fb_agent, eff_messages, active_tools, sys);
       else if (anthropic)
       {
-         track_anthropic_payload_rewrite(driver, &fb_agent, messages, sys);
-         req = agent_build_request_anthropic(&fb_agent, messages, active_tools, sys, tok,
+         track_anthropic_payload_rewrite(driver, &fb_agent, eff_messages, sys);
+         req = agent_build_request_anthropic(&fb_agent, eff_messages, active_tools, sys, tok,
                                              temperature);
       }
       else
-         req = agent_build_request_openai(&fb_agent, messages, active_tools, tok, temperature);
+         req = agent_build_request_openai(&fb_agent, eff_messages, active_tools, tok, temperature);
 
       /* Universal-gateway P4: run aimee's own outbound call through the same request
        * pipeline the proxy ingresses use, so a config-enabled tool-policing policy
@@ -742,11 +821,13 @@ native_provider_http:
       {
          snprintf(out->error, sizeof(out->error), "gateway request pipeline failed");
          cJSON_Delete(req);
+         context_reduce_result_free(&agent_reduce_result);
          break;
       }
 
       char *body = cJSON_PrintUnformatted(req);
       cJSON_Delete(req);
+      context_reduce_result_free(&agent_reduce_result);
       if (!body)
       {
          snprintf(out->error, sizeof(out->error), "failed to build request");
@@ -789,15 +870,14 @@ native_provider_http:
                                         api_call_count);
       }
       config_t econ_cfg;
-      int proof_gated =
-          config_load(&econ_cfg) == 0 && econ_mode(&econ_cfg) == ECON_MODE_PROOF_GATED;
+      int economizer_active = config_load(&econ_cfg) == 0 && econ_mode(&econ_cfg) != ECON_MODE_OFF;
       econ_wire_route_t wire_route = anthropic                   ? ECON_WIRE_ANTHROPIC_MESSAGES
                                      : chatgpt                   ? ECON_WIRE_OPENAI_RESPONSES
                                      : strstr(url, "/responses") ? ECON_WIRE_OPENAI_RESPONSES
                                                                  : ECON_WIRE_OPENAI_CHAT;
       econ_wire_snapshot_t *wire_snapshot = NULL;
       econ_wire_bytes_t wire_body;
-      if (econ_wire_select(proof_gated, wire_route, body, strlen(body), &wire_snapshot,
+      if (econ_wire_select(economizer_active, wire_route, body, strlen(body), &wire_snapshot,
                            &wire_body) != 0)
       {
          snprintf(out->error, sizeof(out->error), "economizer wire fence unavailable");
@@ -850,8 +930,8 @@ native_provider_http:
             }
             econ_wire_snapshot_t *fb_snapshot = NULL;
             econ_wire_bytes_t fb_wire_body;
-            if (econ_wire_select(proof_gated, wire_route, fb_body, strlen(fb_body), &fb_snapshot,
-                                 &fb_wire_body) != 0)
+            if (econ_wire_select(economizer_active, wire_route, fb_body, strlen(fb_body),
+                                 &fb_snapshot, &fb_wire_body) != 0)
             {
                snprintf(out->error, sizeof(out->error),
                         "economizer wire fence unavailable for fallback");
@@ -1504,6 +1584,7 @@ native_provider_http:
          }
          char *result_str = dispatch_tool_call_ctx(parsed.calls[i].name, parsed.calls[i].arguments,
                                                    agent->timeout_ms);
+         result_str = agent_economize_fresh_tool_result(result_str);
          {
             int dj = agent_get_durable_job_id();
             if (dj > 0)

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -23,6 +23,8 @@
 #include "cJSON.h"
 #include "delegate_driver.h"
 #include "economizer_wire_snapshot.h"
+#include "gateway_mutate_wire.h"
+#include "server_http_identity.h"
 #include "gateway_policy.h"
 #include "gateway_pipeline.h"
 #include "gw_stage_memory.h"
@@ -443,8 +445,11 @@ static int messages_buffered(const char *body, char *resp, int cap)
    const delegate_driver_t *driver;
    parsed_response_t parsed = {0}; /* freed only on the success path, but init defensively */
    econ_wire_snapshot_t *wire_snapshot = NULL;
+   gw_mutate_ctx_t gwmc;
    int status, http_status, rc;
    const char *model;
+
+   gw_mutate_ctx_init(&gwmc);
 
    if (!req)
       return write_error(resp, cap, 400, "invalid_request_error", "invalid JSON body", 0);
@@ -481,6 +486,16 @@ static int messages_buffered(const char *body, char *resp, int cap)
     * the pointer cached above (line ~397) could now dangle. */
    model = jo_cstr(req, "model");
 
+   /* Only AGGRESSIVE and only an OpenAI-family upstream. Native Anthropic
+    * requests keep the client's exact cache prefix and cache_control layout. */
+   if (gw_mutate_upstream_ok(parity))
+   {
+      char *mut_sys = anthropic_system_to_text(req);
+      gw_buffered_mutate(req, "messages", model, mut_sys, server_http_identity_session_hdr(),
+                         server_http_identity_bearer(), server_http_identity_principal(), &gwmc);
+      free(mut_sys);
+   }
+
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
@@ -511,12 +526,12 @@ static int messages_buffered(const char *body, char *resp, int cap)
                                          responses_wire);
    const char *pristine_body = prov_body ? prov_body : "{}";
    config_t econ_cfg;
-   int proof_gated = config_load(&econ_cfg) == 0 && econ_mode(&econ_cfg) == ECON_MODE_PROOF_GATED;
+   int economizer_active = config_load(&econ_cfg) == 0 && econ_mode(&econ_cfg) != ECON_MODE_OFF;
    econ_wire_route_t wire_route = parity           ? ECON_WIRE_ANTHROPIC_MESSAGES
                                   : responses_wire ? ECON_WIRE_OPENAI_RESPONSES
                                                    : ECON_WIRE_OPENAI_CHAT;
    econ_wire_bytes_t wire_body;
-   if (econ_wire_select(proof_gated, wire_route, pristine_body, strlen(pristine_body),
+   if (econ_wire_select(economizer_active, wire_route, pristine_body, strlen(pristine_body),
                         &wire_snapshot, &wire_body) != 0)
    {
       status = write_error(resp, cap, 503, "api_error", "economizer wire fence unavailable",
@@ -603,6 +618,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
 
 cleanup:
    econ_wire_snapshot_destroy(wire_snapshot);
+   gw_mutate_ctx_free(&gwmc);
    cJSON_Delete(out);
    cJSON_Delete(provider_resp);
    free(response);
@@ -1070,8 +1086,11 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    int input_est;
    int responses_wire = 0;
    econ_wire_snapshot_t *wire_snapshot = NULL;
+   gw_mutate_ctx_t gwmc;
    const void *wire_prov_body = NULL;
    size_t wire_prov_body_len = 0;
+
+   gw_mutate_ctx_init(&gwmc);
 
    mint_msg_id(msg_id, sizeof(msg_id));
 
@@ -1112,6 +1131,14 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    /* Re-read `model`: the model-pin stage may have replaced req's "model" node, so
     * the pointer cached at the top of this function could now dangle. */
    model = jo_cstr(req, "model");
+
+   if (gw_mutate_upstream_ok(parity))
+   {
+      char *mut_sys = anthropic_system_to_text(req);
+      gw_buffered_mutate(req, "messages", model, mut_sys, server_http_identity_session_hdr(),
+                         server_http_identity_bearer(), server_http_identity_principal(), &gwmc);
+      free(mut_sys);
+   }
 
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
@@ -1176,12 +1203,12 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
 
    const char *pristine_body = prov_body ? prov_body : "{}";
    config_t econ_cfg;
-   int proof_gated = config_load(&econ_cfg) == 0 && econ_mode(&econ_cfg) == ECON_MODE_PROOF_GATED;
+   int economizer_active = config_load(&econ_cfg) == 0 && econ_mode(&econ_cfg) != ECON_MODE_OFF;
    econ_wire_route_t wire_route = parity           ? ECON_WIRE_ANTHROPIC_MESSAGES
                                   : responses_wire ? ECON_WIRE_OPENAI_RESPONSES
                                                    : ECON_WIRE_OPENAI_CHAT;
    econ_wire_bytes_t wire_body;
-   if (econ_wire_select(proof_gated, wire_route, pristine_body, strlen(pristine_body),
+   if (econ_wire_select(economizer_active, wire_route, pristine_body, strlen(pristine_body),
                         &wire_snapshot, &wire_body) != 0)
    {
       xl = anthropic_stream_begin(msg_id, model, 0, emit, ctx);
@@ -1232,6 +1259,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                          input_est, emit, ctx);
 cleanup:
    econ_wire_snapshot_destroy(wire_snapshot);
+   gw_mutate_ctx_free(&gwmc);
    free(prov_body);
    free(system_text);
    cJSON_Delete(messages);

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -36,6 +36,8 @@
 #include "delegate_driver.h" /* single provider step for the Codex proxy */
 #include "http_retry.h"
 #include "economizer_wire_snapshot.h"
+#include "gateway_mutate_wire.h"
+#include "server_http_identity.h"
 #include "cJSON.h"
 #include "agent_tools.h" /* agent_tools_set_tool_event_cb — /v1/runs tool events */
 #include "agent_types.h"
@@ -976,25 +978,53 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
 
    int tok = agent_request_max_tokens(agent, max_tokens);
 
-   char *body = openai_build_body(agent, driver, messages, eff_tools, eff_system, tok, temperature);
+   /* AGGRESSIVE may apply the existing lossy reducer to OpenAI-family request
+    * history. SAFE never enters this path. Anthropic-backed routes remain
+    * untouched to preserve their cache prefix. */
+   gw_mutate_ctx_t gwmc;
+   gw_mutate_ctx_init(&gwmc);
+   cJSON *mbox = NULL;
+   cJSON *econ_messages = messages;
+   int upstream_is_anthropic = driver && driver->name && strcmp(driver->name, "anthropic") == 0;
+   if (gw_mutate_upstream_ok(upstream_is_anthropic))
+   {
+      mbox = cJSON_CreateObject();
+      if (mbox)
+      {
+         cJSON_AddItemReferenceToObject(mbox, "input", messages);
+         gw_buffered_mutate(mbox, "input", agent->model, eff_system,
+                            server_http_identity_session_hdr(), server_http_identity_bearer(),
+                            server_http_identity_principal(), &gwmc);
+         cJSON *reduced = cJSON_GetObjectItemCaseSensitive(mbox, "input");
+         if (reduced)
+            econ_messages = reduced;
+      }
+   }
+
+   char *body =
+       openai_build_body(agent, driver, econ_messages, eff_tools, eff_system, tok, temperature);
    if (!body)
    {
+      cJSON_Delete(mbox);
+      gw_mutate_ctx_free(&gwmc);
       cJSON_Delete(gw_raw);
       return -1;
    }
 
    config_t econ_cfg;
-   int proof_gated = config_load(&econ_cfg) == 0 && econ_mode(&econ_cfg) == ECON_MODE_PROOF_GATED;
+   int economizer_active = config_load(&econ_cfg) == 0 && econ_mode(&econ_cfg) != ECON_MODE_OFF;
    int wire_anthropic = driver && driver->name && strcmp(driver->name, "anthropic") == 0;
    econ_wire_route_t wire_route = wire_anthropic              ? ECON_WIRE_ANTHROPIC_MESSAGES
                                   : strstr(url, "/responses") ? ECON_WIRE_OPENAI_RESPONSES
                                                               : ECON_WIRE_OPENAI_CHAT;
    econ_wire_snapshot_t *wire_snapshot = NULL;
    econ_wire_bytes_t wire_body;
-   if (econ_wire_select(proof_gated, wire_route, body, strlen(body), &wire_snapshot, &wire_body) !=
-       0)
+   if (econ_wire_select(economizer_active, wire_route, body, strlen(body), &wire_snapshot,
+                        &wire_body) != 0)
    {
       free(body);
+      cJSON_Delete(mbox);
+      gw_mutate_ctx_free(&gwmc);
       cJSON_Delete(gw_raw);
       return -1;
    }
@@ -1012,6 +1042,8 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
    free(body);
    econ_wire_snapshot_destroy(wire_snapshot);
 
+   cJSON_Delete(mbox);
+   gw_mutate_ctx_free(&gwmc);
    cJSON_Delete(gw_raw);
 
    if (http_status != 200 || !response_body)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1057,6 +1057,7 @@ $(TESTPREFIX)/unit-test-agent: $(OBJDIR)/tests/test_agent.o $(OBJDIR)/tests/test
                       $(OBJDIR)/models_dev_cache.o $(OBJDIR)/payload_rewrite.o \
                       $(OBJDIR)/server/middleware.o $(OBJDIR)/server/liveness.o \
                       $(OBJDIR)/server/cli_session.o $(OBJDIR)/server/agent_policy_intercept.o \
+                      $(OBJDIR)/modules/economizer/economizer_json.o \
                       $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -1072,6 +1073,7 @@ $(TESTPREFIX)/unit-test-agent-repair: $(OBJDIR)/tests/test_agent_repair.o \
                       $(OBJDIR)/models_dev_cache.o $(OBJDIR)/payload_rewrite.o \
                       $(OBJDIR)/server/middleware.o $(OBJDIR)/server/liveness.o \
                       $(OBJDIR)/server/cli_session.o $(OBJDIR)/server/agent_policy_intercept.o \
+                      $(OBJDIR)/modules/economizer/economizer_json.o \
                       $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -1087,6 +1089,7 @@ $(TESTPREFIX)/unit-test-agent-apikey: $(OBJDIR)/tests/test_agent_apikey.o \
                       $(OBJDIR)/models_dev_cache.o $(OBJDIR)/payload_rewrite.o \
                       $(OBJDIR)/server/middleware.o $(OBJDIR)/server/liveness.o \
                       $(OBJDIR)/server/cli_session.o $(OBJDIR)/server/agent_policy_intercept.o \
+                      $(OBJDIR)/modules/economizer/economizer_json.o \
                       $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -335,7 +335,7 @@ int config_load(config_t *cfg)
       cfg->module_memory = cfg->module_governance = -1;
       cfg->module_delegates = cfg->module_workflows = -1;
       cfg->module_economizer = 1;
-      cfg->economizer_mode = g_proof_gated ? ECON_MODE_PROOF_GATED : ECON_MODE_OFF;
+      cfg->economizer_mode = g_proof_gated ? ECON_MODE_SAFE : ECON_MODE_OFF;
    }
    return 0;
 }

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -1,5 +1,5 @@
-/* test_config_economizer.c: the proof-gated economizer control
- * (economizer: {mode: off|proof_gated}) — mode resolution, defaults, and the
+/* test_config_economizer.c: the economizer policy control
+ * (economizer: {mode: off|safe|aggressive}) — mode resolution, defaults, and the
  * save/load round-trip — plus the Coordinate Closet tuning round-trip. Kept
  * separate from test_config.c, which is at the build-integrity line-count limit. */
 #include <assert.h>
@@ -13,8 +13,7 @@
 #include "platform_path.h"
 #include "platform_test_util.h"
 
-/* Mode resolution: neither public mode enables the disconnected legacy mutation
- * levers. modules.economizer:false is an authoritative hard kill. Pure — no I/O. */
+/* Mode resolution and modules.economizer hard kill. Pure — no I/O. */
 static void test_tier_resolution(void)
 {
    config_t c;
@@ -29,17 +28,26 @@ static void test_tier_resolution(void)
    assert(econ_reduction_master_on(&c) == 0);
    assert(econ_gateway_mutate_on(&c) == 0);
    econ_preset(&c, &ep);
-   assert(ep.history_fold == 0 && ep.command_filter == 0 && ep.compress == 0 &&
-          ep.gateway_seam == 0);
+   assert(ep.json_compact == 0 && ep.history_fold == 0 && ep.command_filter == 0 &&
+          ep.compress == 0 && ep.gateway_seam == 0);
 
-   /* PROOF_GATED authorizes only the new proof path. Old lossy levers remain dead. */
-   c.economizer_mode = ECON_MODE_PROOF_GATED;
-   assert(econ_mode(&c) == ECON_MODE_PROOF_GATED);
-   assert(econ_reduction_master_on(&c) == 0);
+   /* SAFE: only strict fresh-result JSON compaction. */
+   c.economizer_mode = ECON_MODE_SAFE;
+   assert(econ_mode(&c) == ECON_MODE_SAFE);
+   assert(econ_reduction_master_on(&c) == 1);
    assert(econ_gateway_mutate_on(&c) == 0);
    econ_preset(&c, &ep);
-   assert(ep.history_fold == 0 && ep.command_filter == 0 && ep.compress == 0 &&
-          ep.gateway_seam == 0);
+   assert(ep.json_compact == 1 && ep.history_fold == 0 && ep.command_filter == 0 &&
+          ep.compress == 0 && ep.gateway_seam == 0);
+
+   /* AGGRESSIVE: safe compaction plus the lossy reducers. */
+   c.economizer_mode = ECON_MODE_AGGRESSIVE;
+   assert(econ_mode(&c) == ECON_MODE_AGGRESSIVE);
+   assert(econ_reduction_master_on(&c) == 1);
+   assert(econ_gateway_mutate_on(&c) == 1);
+   econ_preset(&c, &ep);
+   assert(ep.json_compact == 1 && ep.history_fold == 1 && ep.command_filter == 1 &&
+          ep.compress == 1 && ep.gateway_seam == 1);
 
    /* modules.economizer:false is an authoritative hard-kill over either mode. */
    c.module_economizer = 0;
@@ -49,17 +57,18 @@ static void test_tier_resolution(void)
    econ_preset(&c, &ep);
    assert(ep.history_fold == 0 && ep.gateway_seam == 0);
 
-   /* The parser is exact and rejects every legacy/unknown spelling. */
+   /* The parser accepts exactly the three public modes, case-insensitively. */
    assert(econ_mode_parse("off") == ECON_MODE_OFF);
-   assert(econ_mode_parse("proof_gated") == ECON_MODE_PROOF_GATED);
-   assert(econ_mode_parse("safe") == -1);
-   assert(econ_mode_parse("aggressive") == -1);
+   assert(econ_mode_parse("safe") == ECON_MODE_SAFE);
+   assert(econ_mode_parse("aggressive") == ECON_MODE_AGGRESSIVE);
    assert(econ_mode_parse("aggro") == -1);
+   assert(econ_mode_parse("proof_gated") == -1);
    assert(econ_mode_parse("bogus") == -1);
-   assert(econ_mode_parse("OFF") == -1);
+   assert(econ_mode_parse("OFF") == ECON_MODE_OFF);
    assert(econ_mode_parse(NULL) == -1);
    assert(strcmp(econ_mode_name(ECON_MODE_OFF), "off") == 0);
-   assert(strcmp(econ_mode_name(ECON_MODE_PROOF_GATED), "proof_gated") == 0);
+   assert(strcmp(econ_mode_name(ECON_MODE_SAFE), "safe") == 0);
+   assert(strcmp(econ_mode_name(ECON_MODE_AGGRESSIVE), "aggressive") == 0);
 
    /* NULL-safe */
    assert(econ_reduction_master_on(NULL) == 0);
@@ -91,11 +100,10 @@ static void test_reload_class(void)
    config_t c;
    memset(&c, 0, sizeof c);
    c.economizer_mode = ECON_MODE_OFF;
-   assert(config_field_set_value(&c, econ, "proof_gated") == 0 &&
-          c.economizer_mode == ECON_MODE_PROOF_GATED);
+   assert(config_field_set_value(&c, econ, "safe") == 0 && c.economizer_mode == ECON_MODE_SAFE);
+   assert(config_field_set_value(&c, econ, "aggressive") == 0 &&
+          c.economizer_mode == ECON_MODE_AGGRESSIVE);
    assert(config_field_set_value(&c, econ, "off") == 0 && c.economizer_mode == ECON_MODE_OFF);
-   assert(config_field_set_value(&c, econ, "safe") == -1);
-   assert(config_field_set_value(&c, econ, "aggressive") == -1);
    assert(config_field_set_value(&c, econ, "bogus") == -1); /* invalid token rejected */
    cJSON *v = config_field_value_json(&c, econ);            /* reads back as a string */
    assert(cJSON_IsString(v) && strcmp(v->valuestring, "off") == 0);
@@ -118,12 +126,12 @@ int main(void)
    platform_unsetenv("AIMEE_HOME");
    platform_setenv("AIMEE_NO_CACHE", "1");
 
-   /* --- defaults: economizer OFF, Coordinate Closet on --- */
+   /* --- defaults: economizer SAFE, Coordinate Closet on --- */
    {
       static config_t cfg;
       memset(&cfg, 0, sizeof(cfg));
       config_load(&cfg); /* missing file -> defaults */
-      assert(cfg.economizer_mode == ECON_MODE_OFF);
+      assert(cfg.economizer_mode == ECON_MODE_SAFE);
       assert(cfg.coord_closet_enabled == 1);
    }
 
@@ -132,16 +140,16 @@ int main(void)
       static config_t cfg;
       memset(&cfg, 0, sizeof(cfg));
       config_load(&cfg);
-      assert(cfg.economizer_mode == ECON_MODE_OFF);
-      cfg.economizer_mode = ECON_MODE_PROOF_GATED;
+      assert(cfg.economizer_mode == ECON_MODE_SAFE);
+      cfg.economizer_mode = ECON_MODE_AGGRESSIVE;
       assert(config_save(&cfg) == 0);
 
       static config_t cfg2;
       memset(&cfg2, 0, sizeof(cfg2));
       config_load(&cfg2);
-      assert(cfg2.economizer_mode == ECON_MODE_PROOF_GATED);
+      assert(cfg2.economizer_mode == ECON_MODE_AGGRESSIVE);
 
-      /* OFF is represented by omission and reloads to the fail-closed default. */
+      /* OFF is persisted because SAFE is the default. */
       cfg.economizer_mode = ECON_MODE_OFF;
       assert(config_save(&cfg) == 0);
       memset(&cfg2, 0, sizeof(cfg2));
@@ -153,20 +161,19 @@ int main(void)
    {
       config_t cfg;
       memset(&cfg, 0, sizeof(cfg));
-      cJSON *root = cJSON_Parse("{\"economizer\":{\"mode\":\"proof_gated\"}}");
+      cJSON *root = cJSON_Parse("{\"economizer\":{\"mode\":\"safe\"}}");
       assert(root);
       assert(config_parse_economizer_section(&cfg, root) == 0);
-      assert(cfg.economizer_mode == ECON_MODE_PROOF_GATED);
+      assert(cfg.economizer_mode == ECON_MODE_SAFE);
       cJSON_Delete(root);
 
       const char *invalid[] = {
           "{\"economizer\":\"safe\"}",
           "{\"economizer\":\"aggressive\"}",
           "{\"economizer\":{\"enabled\":false}}",
-          "{\"economizer\":{\"mode\":\"safe\"}}",
-          "{\"economizer\":{\"mode\":\"aggressive\"}}",
+          "{\"economizer\":{\"mode\":\"proof_gated\"}}",
           "{\"economizer\":{\"mode\":\"off\",\"extra\":true}}",
-          "{\"economizer\":{\"mode\":\"off\",\"mode\":\"proof_gated\"}}",
+          "{\"economizer\":{\"mode\":\"off\",\"mode\":\"safe\"}}",
           "{\"economizer\":{\"mode\":true}}",
           "{\"economizer\":{}}",
       };
@@ -236,19 +243,19 @@ int main(void)
       assert(config_module_enabled(cfg3.module_memory, 1) == 1);     /* -1 -> env default ON */
       assert(config_module_enabled(cfg3.module_memory, 0) == 0);     /* -1 -> env default OFF */
 
-      /* modules.economizer:false hard-kills proof_gated; legacy reducers stay disabled. */
+      /* modules.economizer:false hard-kills every active mode. */
       config_t ec;
       memset(&ec, 0, sizeof(ec));
-      ec.economizer_mode = ECON_MODE_PROOF_GATED;
+      ec.economizer_mode = ECON_MODE_AGGRESSIVE;
       ec.module_economizer = 0;
       assert(econ_mode(&ec) == ECON_MODE_OFF);
       assert(econ_reduction_master_on(&ec) == 0);
       ec.module_economizer = 1;
-      assert(econ_mode(&ec) == ECON_MODE_PROOF_GATED);
-      assert(econ_reduction_master_on(&ec) == 0);
+      assert(econ_mode(&ec) == ECON_MODE_AGGRESSIVE);
+      assert(econ_reduction_master_on(&ec) == 1);
       ec.module_economizer = -1;
-      assert(econ_mode(&ec) == ECON_MODE_PROOF_GATED);
-      assert(econ_reduction_master_on(&ec) == 0);
+      assert(econ_mode(&ec) == ECON_MODE_AGGRESSIVE);
+      assert(econ_reduction_master_on(&ec) == 1);
       ec.economizer_mode = ECON_MODE_OFF;
       assert(econ_reduction_master_on(&ec) == 0);
    }

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -22,14 +22,14 @@ static void probe_reapplier(const config_t *o, const config_t *n)
    atomic_fetch_add_explicit(&g_reapply_calls, 1, memory_order_relaxed);
 }
 
-/* Author a config file with a MARKER PAIR (proof_gated, budget) via config_save so reload
+/* Author a config file with a MARKER PAIR (safe, budget) via config_save so reload
  * observes a real change. The pair is what the torn-read check keys on. */
-static void write_marker(int proof_gated, int budget)
+static void write_marker(int safe, int budget)
 {
    static config_t c;
    memset(&c, 0, sizeof c);
    config_load(&c);
-   c.economizer_mode = proof_gated ? ECON_MODE_PROOF_GATED : ECON_MODE_OFF;
+   c.economizer_mode = safe ? ECON_MODE_SAFE : ECON_MODE_OFF;
    c.coord_closet_budget_bytes = budget;
    assert(config_save(&c) == 0);
 }
@@ -37,7 +37,7 @@ static void write_marker(int proof_gated, int budget)
 static _Atomic int g_stop = 0;
 static _Atomic long g_reads = 0, g_torn = 0;
 
-/* The two configs are {proof_gated,budget=1111} and {off,budget=2222};
+/* The two configs are {safe,budget=1111} and {off,budget=2222};
  * a reader must never observe a mismatched pair (that would be a torn cross-slot read). */
 static void *reader_thread(void *arg)
 {
@@ -48,7 +48,7 @@ static void *reader_thread(void *arg)
       if (config_snapshot_get(&c) != 0)
          continue;
       atomic_fetch_add_explicit(&g_reads, 1, memory_order_relaxed);
-      int a = (c.economizer_mode == ECON_MODE_PROOF_GATED && c.coord_closet_budget_bytes == 1111);
+      int a = (c.economizer_mode == ECON_MODE_SAFE && c.coord_closet_budget_bytes == 1111);
       int b = (c.economizer_mode == ECON_MODE_OFF && c.coord_closet_budget_bytes == 2222);
       if (!a && !b)
          atomic_fetch_add_explicit(&g_torn, 1, memory_order_relaxed);
@@ -82,7 +82,7 @@ int main(void)
       config_snapshot_init(&c0);
       config_t got;
       assert(config_snapshot_get(&got) == 0);
-      assert(got.economizer_mode == ECON_MODE_PROOF_GATED);
+      assert(got.economizer_mode == ECON_MODE_SAFE);
       assert(got.coord_closet_budget_bytes == 1111);
    }
 
@@ -105,10 +105,10 @@ int main(void)
    {
       config_reload_register_reapplier(probe_reapplier);
       int before = atomic_load_explicit(&g_reapply_calls, memory_order_relaxed);
-      write_marker(1, 1111); /* change back to proof_gated */
+      write_marker(1, 1111); /* change back to safe */
       assert(config_reload() == 1);
       assert(atomic_load_explicit(&g_reapply_calls, memory_order_relaxed) == before + 1);
-      assert(g_last_mode == ECON_MODE_PROOF_GATED); /* re-applier saw the NEW value */
+      assert(g_last_mode == ECON_MODE_SAFE); /* re-applier saw the NEW value */
       /* a no-op reload does NOT fire the re-applier */
       int mid = atomic_load_explicit(&g_reapply_calls, memory_order_relaxed);
       assert(config_reload() == 0);

--- a/src/tests/test_economizer_live_surface.sh
+++ b/src/tests/test_economizer_live_surface.sh
@@ -7,19 +7,6 @@ fail()
     exit 1
 }
 
-live_sources="posix server"
-legacy_calls='context_reduce[[:space:]]*\(|tool_condense_apply[[:space:]]*\(|build_fold_view[[:space:]]*\(|agent_compress_tool_result[[:space:]]*\('
-if grep -R -n -E "$legacy_calls" $live_sources |
-    grep -v '^server/agent_policy.c:[0-9][0-9]*:char \*agent_compress_tool_result' >/dev/null; then
-    grep -R -n -E "$legacy_calls" $live_sources |
-        grep -v '^server/agent_policy.c:[0-9][0-9]*:char \*agent_compress_tool_result' >&2
-    fail "legacy reducer remains reachable from a production request source"
-fi
-
-if grep -n 'modules/economizer/gateway_mutate_wire.c' Makefile >/dev/null; then
-    fail "legacy gateway mutation remains linked into production"
-fi
-
 if grep -R -n 'aimee_backend_anthropic_set_cache_enabled' headers server posix >/dev/null; then
     fail "economizer still controls Anthropic cache decoration"
 fi
@@ -28,12 +15,25 @@ for source in posix/agent_runtime.c server/openai_chat.c server/anthropic_http.c
     grep -q 'econ_wire_select' "$source" || fail "$source bypasses the wire snapshot selector"
 done
 
-# Activation machinery may ship, but the production registry is still empty.
-# No live request path may construct or consume a candidate before a separately
-# reviewed provider tuple is signed.
-if grep -R -n -E 'econ_json_compact[[:space:]]*\(|econ_provenance_issue_local[[:space:]]*\(|econ_dispatch_lease_begin[[:space:]]*\(' $live_sources >/dev/null; then
-    grep -R -n -E 'econ_json_compact[[:space:]]*\(|econ_provenance_issue_local[[:space:]]*\(|econ_dispatch_lease_begin[[:space:]]*\(' $live_sources >&2
-    fail "dormant activation machinery is reachable from a production request source"
+# SAFE has exactly one live transform: strict JSON compaction at the fresh local
+# tool-result boundary. Lossy history mutation must remain behind AGGRESSIVE.
+grep -q 'agent_economize_fresh_tool_result(result_str)' posix/agent_runtime.c ||
+    fail "fresh tool output does not pass through the safe compactor"
+grep -q 'preset.json_compact' posix/agent_runtime.c ||
+    fail "safe JSON compaction is not controlled by its preset"
+grep -q '!anthropic && (preset.history_fold || preset.compress)' posix/agent_runtime.c ||
+    fail "agent history reduction is not gated to aggressive OpenAI-family routes"
+grep -q 'gw_mutate_upstream_ok(parity)' server/anthropic_http.c ||
+    fail "Anthropic ingress mutation does not preserve native Anthropic prefixes"
+grep -q 'gw_mutate_upstream_ok(upstream_is_anthropic)' server/openai_chat.c ||
+    fail "OpenAI ingress mutation does not exclude Anthropic upstreams"
+
+# The economizer never adds, removes, or moves provider cache controls and does
+# not perform a remote token-counting preflight.
+if grep -n -E 'cache_control|prompt_cache_key|count_tokens' \
+    modules/economizer/gateway_mutate.c modules/economizer/gateway_mutate_wire.c \
+    posix/agent_runtime.c >/dev/null; then
+    fail "economizer controls provider caching or remote token counting"
 fi
 
 grep -q 'http_retry_post_context_bytes' posix/agent_runtime.c ||

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1213,15 +1213,17 @@ int config_save(const config_t *cfg)
  * test does not link the real config.o. */
 const char *econ_mode_name(int mode)
 {
-   return mode == ECON_MODE_PROOF_GATED ? "proof_gated" : "off";
+   return mode == ECON_MODE_AGGRESSIVE ? "aggressive" : mode == ECON_MODE_SAFE ? "safe" : "off";
 }
 
 int econ_mode_parse(const char *s)
 {
    if (s && strcmp(s, "off") == 0)
       return ECON_MODE_OFF;
-   if (s && strcmp(s, "proof_gated") == 0)
-      return ECON_MODE_PROOF_GATED;
+   if (s && strcmp(s, "safe") == 0)
+      return ECON_MODE_SAFE;
+   if (s && strcmp(s, "aggressive") == 0)
+      return ECON_MODE_AGGRESSIVE;
    return -1;
 }
 

--- a/src/tests/test_tool_condense.c
+++ b/src/tests/test_tool_condense.c
@@ -27,11 +27,11 @@ int main(void)
       memset(&cfg, 0, sizeof cfg);
       cfg.module_economizer = -1;               /* unspecified -> tier decides */
       assert(tool_condense_enabled(&cfg) == 0); /* tier OFF (memset) -> off */
-      cfg.economizer_mode = ECON_MODE_PROOF_GATED;
-      assert(tool_condense_enabled(&cfg) == 0); /* legacy reducer is disconnected */
+      cfg.economizer_mode = ECON_MODE_SAFE;
+      assert(tool_condense_enabled(&cfg) == 0); /* SAFE is lossless only */
       cfg.economizer_mode = ECON_MODE_OFF;      /* off tier kills the lever */
       assert(tool_condense_enabled(&cfg) == 0);
-      cfg.economizer_mode = ECON_MODE_PROOF_GATED;
+      cfg.economizer_mode = ECON_MODE_AGGRESSIVE;
       cfg.module_economizer = 0; /* modules.economizer:false hard-kills it */
       assert(tool_condense_enabled(&cfg) == 0);
       assert(tool_condense_enabled(NULL) == 0);
@@ -253,13 +253,17 @@ int main(void)
       free(r4);
    }
 
-   /* ---- legacy live application is permanently disconnected ---- */
+   /* ---- live application is aggressive-only ---- */
    {
       config_t cfg;
       memset(&cfg, 0, sizeof cfg);
       cfg.module_economizer = -1;
-      cfg.economizer_mode = ECON_MODE_PROOF_GATED;
+      cfg.economizer_mode = ECON_MODE_SAFE;
       assert(tool_condense_apply(&cfg, "pytest -q", 0, "one test passed\n", "/tmp", NULL) == NULL);
+      cfg.economizer_mode = ECON_MODE_AGGRESSIVE;
+      char *condensed =
+          tool_condense_apply(&cfg, "pytest -q", 0, "one test passed\n", "/tmp", NULL);
+      free(condensed);
    }
 
    /* ---- tc_family_diagnostics (S5) ---- */


### PR DESCRIPTION
Implements the simplified economizer policy. Safe performs only deterministic strict-JSON whitespace compaction on fresh local tool results before first provider dispatch. Aggressive additionally enables existing lossy reducers on OpenAI-family routes. Native Anthropic history and client cache controls remain untouched in every mode; selected wire bytes are immutable across retries. Default is safe.\n\nValidated with the full server build, repository lint, and focused config, JSON activation, context reduction, gateway mutation, tool condensation, Anthropic ingress, server dispatch, wire snapshot, and live-surface tests.