### PR TITLE
P5-D2b0: pin active-config snapshot readers

### DIFF
--- a/docs/proposals/done/tiered-llm-p5d2b0-config-snapshot-reader-barrier.plan.md
+++ b/docs/proposals/done/tiered-llm-p5d2b0-config-snapshot-reader-barrier.plan.md
@@ -1,0 +1,88 @@
+# P5-D2b0 active-config snapshot reader barrier
+
+- **State:** terminal done; implemented and validated.
+- **Parent:** `tiered-llm-p5d2b-safe-config-projection.plan.md`.
+- **Purpose:** remove a pre-existing C data race before a management endpoint begins copying the
+  full active `config_t` on demand.
+
+## Defect and boundary
+
+`config_snapshot_get` reads an ordinary `config_t` from a two-slot double buffer and retries when
+the sequence changes. A reader can still be copying old slot 0 while two consecutive publishers
+switch to slot 1 and then begin rewriting slot 0. The final retry detects change but cannot undo
+the overlapping non-atomic read/write and its undefined behavior.
+
+This slice changes only the active snapshot publication/read primitive and its focused tests. It
+does not add management routes, config projection, wire fields, config parsing/saving, reload
+semantics, re-appliers, environment behavior, or a new public configuration source.
+
+## Reserved-slot reader-pinning contract
+
+Keep the existing two slots, writer mutex, sequence counter, active index, content token, and
+public functions. Add one `_Atomic unsigned` state word per slot. The high bit, derived portably
+from `UINT_MAX`, is `WRITER_RESERVED`; remaining bits are a saturating reader count with
+`READER_MAX = WRITER_RESERVED - 1`. A separate count plus later zero check is forbidden: it has a
+TOCTOU window in which a delayed reader can pin after the writer observes zero but before the
+writer makes the sequence odd.
+
+`config_snapshot_get` performs this loop:
+
+1. acquire-load an even sequence and the active slot;
+2. load that slot's state and use compare-exchange to add one only while the reservation bit is
+   clear; if the unreserved state equals `READER_MAX`, return `-1` immediately with `*out` and the
+   state word unchanged; if reserved, restart at step 1;
+3. acquire-load sequence and active slot again;
+4. if either changed or the sequence is odd, unpin and retry without touching the slot payload;
+5. copy the pinned ordinary `config_t` to the caller;
+6. release-decrement the slot state and return success.
+
+The publisher, already serialized by `g_snap_wlock`, chooses the inactive slot and acquire-CASes
+its state from exactly zero to `WRITER_RESERVED`. If the state is nonzero it yields through an
+existing portable abstraction or a portable bounded-spin fallback and retries without holding any
+resource a reader needs to validate or unpin. Only after reservation succeeds may it set the
+sequence odd or write a payload byte. It writes the complete inactive slot, publishes active
+index/token and the final even sequence as today, then release-stores the slot state back to zero.
+A later publisher cannot reuse a prior active slot until every reader that validated a pin on it
+has released the pin.
+
+A delayed reader and writer contend on the same atomic transition. If the reader CAS increments
+first, the writer cannot reserve until unpin. If the writer's zero-to-reserved CAS wins, that
+reader cannot pin and never reaches payload. Sequence validation still determines whether a pin
+belongs to the current generation; reservation supplies the exclusion for ordinary payload
+access. No ordinary slot read overlaps a write. Reload remains rare; bounded writer
+spinning/yielding is acceptable, but it must not hold a resource needed by readers to unpin.
+Readers remain concurrent and take no mutex.
+
+State words rely on static zero initialization and are never reset while publication is live.
+Repeated `config_snapshot_init` uses the same reservation/publication protocol; a test-only reset
+may zero state only after joining all readers/writers and proving quiescence. `config_reload`,
+content-token no-op behavior, and re-applier ordering stay unchanged. Document acquire/release
+ordering at the implementation: successful reader pin has acquire semantics, unpin is release,
+writer reservation is acquire, reservation release is release, and existing final even sequence
+publication/validation remains release/acquire.
+
+## Tests and gates
+
+- Focused deterministic seams cover both races without timing sleeps: pause after first
+  sequence/active observation but before pin CAS and force (a) writer reservation first, proving
+  reader cannot pin/touch payload, and (b) reader pin first, proving writer cannot reserve/write
+  until unpin. A second seam pauses after validated pin, performs one publication, and proves a
+  consecutive publisher cannot rewrite the pinned old slot until release.
+- Stress multiple readers copying the full `config_t` while one writer performs thousands of
+  alternating, distinct publications. Every accepted record equals one complete published image;
+  no mixed tuple is accepted.
+- Run the stress under ThreadSanitizer or the repository's equivalent data-race detector. A plain
+  functional stress is not sufficient.
+- Cover pre-init failure, NULL output with no output touch, same-content no-op reload without
+  reservation/re-appliers, repeated init with and without a pinned old slot, multiple-reader
+  drain/progress, reservation-bit distinction, counter saturation without wrap/mutation, and
+  publication after the last reader drains.
+- The saturation seam asserts return `-1`, byte-unchanged output, state exactly `READER_MAX`, and
+  distinguishes a reserved slot as retryable contention rather than saturation failure.
+- Existing config reload/snapshot tests, production server build, lint, unit and build-integrity
+  gates remain green on Linux and supported compile targets.
+
+## Non-goals
+
+No generic RCU framework, heap generations, config schema change, management endpoint, parser
+change, or performance redesign. D2b consumes the repaired primitive in the following slice.

--- a/docs/proposals/pending/tiered-llm-p5d2b-safe-config-projection.plan.md
+++ b/docs/proposals/pending/tiered-llm-p5d2b-safe-config-projection.plan.md
@@ -1,0 +1,244 @@
+# P5-D2b bounded safe configuration projection and P5 close-out
+
+- **State:** proposed; implementation not started.
+- **Parent:** `tiered-llm-p5-oidc-control-plane.md`, §§2–4.
+- **Depends on:** completed P5-D2a management-read trust core and bounded agents projection, plus
+  P5-D2b0's C-memory-model-safe active-config snapshot reader barrier.
+- **Followed by:** P5 close-out only. Any new selector, management write, bulk read, or fan-out is a
+  new proposal and adversarial roundtable boundary.
+
+## Boundary
+
+Add exactly one second consumer of D2a's management-read primitive:
+
+- external: `GET /v1/servers/{server_id}/config?team=<canonical positive int64>`;
+- management listener: exact empty-body `POST /v1/management/read/config/challenge` followed by
+  `GET /v1/management/read/config`; and
+- console: an OIDC-only, read-only safe-config drill-down.
+
+The response is constructed from five typed policy/posture values that already exist in
+`config_t`. It never returns raw configuration and never redacts a larger object. This is the
+terminal P5 read selector. The closed selector set becomes exactly `{agents,config}`; widening it
+requires a new plan plus an adversarial roundtable even if a future change appears to be only a
+CHECK-constraint edit.
+
+## Frozen projection
+
+Return exactly this envelope, with `additionalProperties: false` at both object levels:
+
+```json
+{
+  "server_id": "server-a",
+  "team": 42,
+  "config": {
+    "mtls": "required",
+    "remote_writes": "off",
+    "client_transport": "socket",
+    "cli_session_forwarding": false,
+    "require_aimee_git": true
+  }
+}
+```
+
+The five config fields and their source mappings are frozen:
+
+| Wire key | Source | Closed wire value |
+|---|---|---|
+| `mtls` | `config_t.server_api_mtls` | `off`, `optional`, or `required` for source 0, 1, or 2 |
+| `remote_writes` | `config_t.server_api_remote_writes` | `off`, `data`, or `full` for source 0, 1, or 2 |
+| `client_transport` | `config_t.server_api_client_transport` | empty or `socket` emits `socket`; otherwise exactly `http` or `auto` |
+| `cli_session_forwarding` | `config_t.server_api_cli_session_forwarding` | JSON boolean; source must be exactly 0 or 1 |
+| `require_aimee_git` | `config_t.require_aimee_git` | JSON boolean; source must be exactly 0 or 1 |
+
+Any unrecognized source enum, unterminated string, non-boolean integer, or config load failure
+fails the complete response as `unavailable`; it never substitutes a default other than the
+documented empty-client-transport=`socket` canonical default. `server_id` retains D2a's exact
+ASCII identifier grammar and team remains a positive signed-64-bit integer. The response is
+encoded completely in memory, capped at 32 KiB, emitted once, and never truncated or streamed.
+JSON member order is the exact order in the example so fixtures are deterministic.
+
+The projector receives a dedicated record containing only the five source values. In the running
+server, the source loader calls the existing `config_load(config_t *)` API. That API is explicitly
+the public active-config read: after `config_snapshot_init` it delegates to
+`config_snapshot_get`, which copies one coherent POD `config_t` slot under the existing seqlock
+and retries if a reload publication races it. It therefore reports the active validated runtime
+configuration, not an independently reread disk file, and does not parse, normalize, resolve
+environment, run commands, mutate globals, traverse a caller path, or publish configuration.
+`config_load_file` is forbidden on this path. Before the server snapshot is initialized the
+management listener is unavailable, so the loader never falls back to file semantics here.
+
+P5-D2b0 must first repair the existing two-slot snapshot implementation: a sequence retry alone
+does not prevent a second consecutive publication from reusing an ordinary `config_t` slot while
+a reader is still copying it, which is a C data race even if the reader later retries. D2b may rely
+on `config_snapshot_get` only after D2b0 adds reader lifetime pinning (or an equivalently reviewed
+RCU/locking design) and a ThreadSanitizer gate with consecutive publishers and full-structure
+readers. This prerequisite is a separate, tightly scoped merge so the concurrency primitive is
+validated independently of the disclosure path.
+
+After the coherent, reader-pinned `config_load` copy succeeds, the loader copies only the five named members into
+the dedicated record and cleanses the local `config_t`. No filename, source selector, reload
+request, or caller-selected input exists in this API. The projector never receives `config_t`, a
+`cJSON` source node, YAML text, a filename, or a generic key/value map. Adding a field to
+`config_t` cannot widen the wire type. Tests race snapshot publication against reads and require
+each result to match one complete before-or-after five-field tuple, never a mixture. They also
+prove the getter cannot cause a publish/reload, file read, command, network call, or environment
+resolution. Canary tests place values in bearer token, client-CA path, provider/model endpoints,
+commands, environment-shaped members, prompts, personas, tool policy, and other source members and
+prove none is reachable through the getter or JSON round trip.
+
+The authoritative source declarations are exactly `config_t.server_api_mtls`,
+`server_api_remote_writes`, `server_api_client_transport[16]`,
+`server_api_cli_session_forwarding`, and `require_aimee_git` in
+`src/modules/config/config.h`. Their parser keys are respectively `aimee.api.mtls`,
+`aimee.api.remote_writes`, `aimee.api.client_transport`,
+`aimee.api.cli_session_forwarding` in `config_parse_server_api`, and top-level
+`require_aimee_git` in `config_load_file`. No nearby listener, bearer, path, generic transport,
+or console setting may substitute for one of them.
+
+Explicitly excluded, including from errors and WORM metadata: bearer tokens, API keys and key
+references, certificate/key material, CA names or paths, endpoints, URLs, hosts, ports, listener
+addresses, commands or argv, environment names or values, headers, cookies, filesystem paths,
+globs, mounts, working directories, provider/model configuration, personas, roles, prompts,
+instructions, tool policy, templates, cron state or jobs, telemetry configuration, raw YAML/JSON,
+and secret-shaped placeholders. Numeric rate/event-stream settings are not in this slice. The
+roundtable's suggested `log_level`, config-level `max_parallel`, feature/cron flags, telemetry
+redaction flag, and HTTP timeout fields do not exist in the authoritative `config_t` contract and
+are rejected rather than invented. A `cron_jobs_present` flag would itself add a side channel and
+is also excluded.
+
+## Reuse of the D2a trust protocol
+
+D2b adds no lighter or parallel authorization path. It reuses, in the same order:
+
+1. composite actor authentication and org-admin/active-team-lead authorization;
+2. one primary snapshot binding actor, team, active target, endpoint, enrolled management cert,
+   revocation state, and this kb installation's admitted management identity;
+3. the pinned no-redirect mTLS session and a same-session 15-second single-use challenge;
+4. a primary immutable `kb_management_read_intent` plus the shared cross-kind namespace;
+5. isolated token-authority admission and retained-byte readback for `remote_reads`;
+6. a fresh nonce-bound primary status proof;
+7. live peer/token/path/digest/team/certificate/generation verification and durable JTI consume;
+8. complete local load, safe projection, and in-memory encoding;
+9. the C3 primary checkpoint immediately before the first response byte; and
+10. one atomic bounded response.
+
+The D2a error envelope, HTTP mapping, failure ordering, deadline, response cap, no reconnect/no
+retry rule, OIDC credential selection, endpoint policy, and first-failure semantics remain
+unchanged. Once the nonce or JTI is consumed it stays consumed even when load, projection,
+checkpoint, or delivery fails. Break-glass, console-admin, missing/restarted OIDC vault state,
+ordinary membership, inactive lead, cross-team access, revoked identity, rollback, replica-only
+state, dependency outage, and malformed authenticated upstream material all preserve D2a's closed
+results and zero-data behavior.
+
+## Selector, purpose, digest, intent, and audit binding
+
+Generalize `server_mgmt_read_digest_input_t` with a closed selector enum containing exactly agents
+and config. The shared encoder derives both selector string and canonical external path from that
+enum; callers cannot provide an arbitrary path. Agents continues to encode the existing string
+`agents` and path `/v1/servers/{validated-id}/agents` byte-for-byte, preserving D2a's 165-byte KAT
+and SHA-256 `c66354428fbcdb9648b532b8de71b748e0d058711cfb441c608f5460564efcbf`.
+Config uses string `config` and path `/v1/servers/{validated-id}/config` in the same existing
+length-prefixed transcript. A checked-in config KAT freezes its full bytes and SHA-256 before
+implementation proceeds. There is no protocol-version bump because the existing transcript
+already contains the selector and path fields; the change only makes the previously closed
+single-value input explicit.
+
+Use the second exact route `POST /v1/management/read/config/challenge`, with no query and exact
+empty body, to issue the config challenge. That route's compile-time constant derives purpose
+`management.read.config.v1` for issuance, status signing, status verification, and nonce
+consumption. The D2a route `POST /v1/management/read/challenge` remains byte-for-byte and derives
+only `management.read.v1` for agents. No body, query, header, selector parameter, or caller-supplied
+purpose selects between them. Encoded/trailing/sibling aliases and non-empty bodies fail before
+nonce issuance. An agents-purpose proof/nonce cannot satisfy config and the inverse cannot satisfy
+agents.
+
+Extend the PostgreSQL read-intent selector CHECK and start/admit/finalize invariants to exactly
+`selector IN ('agents','config')`. Derive the required canonical path from selector inside the
+definer functions and reject every mismatch. Keep capability exactly `remote_reads`, kind exactly
+`read`, and all namespace, lease, database-time, retained-token, key-use, RLS, role, and grant
+semantics unchanged. SQLite remains a shape-only mirror.
+
+Do not add a JWT selector claim: the already-signed `request_sha256` binds the selector, canonical
+external path, nonce, team, both certificate identities, and both generations; the server
+recomputes that digest from the concrete route's closed selector before loading data. A second
+claim would duplicate the same cryptographic fact while changing the shipped D2a token wire shape.
+Focused confusion tests prove a valid agents token/digest fails on config and the inverse fails on
+agents. The WORM key-use record already has `selector`; require and test exact `config` there so
+capability widening is visible to audit without storing response bytes or config values.
+
+## Routes and console
+
+The external kb parser accepts only exact `GET /v1/servers/{id}/config` plus exactly one canonical
+`team` query. Reuse D2a rejection of missing, duplicate, empty, signed, zero/leading-zero,
+overflow, extra, encoded/aliased, overlong, trailing, and sibling forms before authorization or
+network I/O. Register the exact route in the C kb ACL.
+
+The management listener registers only exact empty-body
+`POST /v1/management/read/config/challenge` and exact `GET /v1/management/read/config`, both with
+no query. Generic `/v1/config/*` and the data-plane config routes remain absent from that listener.
+The challenge route selects its purpose by code constant; the endpoint passes its route's closed
+selector into the shared verifier/projector. Neither accepts a selector or arbitrary loader from
+wire input.
+
+Add `/v1/servers/{id}/config` only to console `fleetAllows`, never `consoleAdminAllows`. The Fleet
+drill-down adds a `Load config` action beside `Load agents`, uses only the verified OIDC fleet
+credential, deduplicates an in-flight request, and clears stale data on team/server change. It
+renders a fixed five-row read-only posture view, not recursive JSON. There is no edit control,
+ACK, mutation, fan-out, templating, or fallback credential.
+
+## Implementation packets
+
+1. **Shared/server core:** selector enum, preserved agents KAT plus new config KAT; five-field
+   source record/getter/projector; selector-aware endpoint; config purpose; exact challenge and
+   read management routes.
+2. **Authority/kb runtime:** selector-aware PostgreSQL functions and C DB/runtime records; generic
+   bounded runtime read driven by an internal closed selector; exact external handler and C ACL;
+   strict config response validator; WORM selector assertion.
+3. **Console/docs:** Go ACL and tests, OIDC-only drill-down rendering, OpenAPI and generated route
+   descriptors, delivery-status reconciliation.
+
+The packets form one mergeable D2b branch after the separately merged D2b0 barrier. Avoid duplicating the D2a state machine or copying its
+runtime function wholesale: factor only narrow selector-derived constants while preserving the
+executable ten-step ordering.
+
+## Tests and validation
+
+- Shared KATs prove the agents digest is byte-identical and config differs; mutate every input
+  field, selector, and path component and require a different digest or rejection.
+- Projector fixtures cover all enum values, empty/socket canonicalization, invalid enums and
+  booleans, unterminated input, output-too-small, deterministic exact JSON, and every privacy
+  canary. Fuzz the five-field record and require only closed success or bounded failure under
+  ASAN/UBSAN.
+- Active-snapshot tests initialize two distinct validated configs, race publication/reload with
+  the getter, and accept only a coherent old or new five-field tuple. Assert the getter uses
+  `config_load`/`config_snapshot_get`, never `config_load_file`, performs no publish or global
+  mutation, and triggers no file, environment, command, or network source action.
+- The prerequisite D2b0 gate runs the full-slot reader against multiple consecutive publications
+  under ThreadSanitizer (or an equivalent data-race detector), not only functional tuple checks.
+- Endpoint tests cover wrong selector/purpose/path/capability/digest/team/audience/certificate,
+  invalid proof, generation rollback, JTI replay, loader failure, projector failure, checkpoint
+  race, and zero bytes before the checkpoint.
+- Challenge tests cover the two exact empty-body routes, wrong method/body/query, route aliases,
+  cross-purpose nonce/proof use in both directions, same-session binding, replay, and restart
+  invalidation. No generic purpose/selector input is accepted.
+- Route/ACL tests cover the full D2a hostile grammar matrix, OIDC-only credential selection,
+  break-glass/console-admin denial before upstream I/O, stale-clear, and in-flight dedupe.
+- PostgreSQL 17 tests cover the extended selector CHECK, canonical selector/path enforcement,
+  kind namespace collision, RLS/grants, authority admission/finalization, concurrency, expiry and
+  row-lock equality boundaries, and exact WORM `selector='config'` with no values.
+- CT260/CT262 exercises both selectors over the real pinned two-node mTLS topology: org-admin and
+  active-team-lead success; ordinary member/cross-team/revoked/rollback/outage denial; exact config
+  envelope; canary absence; agents regression; same-connection nonce and durable JTI behavior.
+- Run repository lint/build/unit/integrity gates, production server and kb builds, real PG17 gate,
+  sanitizer/fuzz gates, and an adversarial complete-diff roundtable before PR merge.
+
+## Deferred and P5 completion
+
+No config writes, generic proxying, bulk/fan-out reads, config push, templates, orchestration,
+streaming, SAML, certificate-rotation scheduling, new capability, or new selector. In particular
+`policies`, `secrets`, `tools`, `personas`, `cron`, `telemetry`, and raw `config` are not aliases or
+follow-on enum additions; each is a new disclosure proposal.
+
+P5 closes only when D2a and D2b are merged, the shared OpenAPI/ACL/console/WORM contracts agree,
+both exact selectors pass real PG17 and CT260/CT262 validation, and the final adversarial branch
+review converges. Deferred items do not block P5 and must not be smuggled into its close-out.

--- a/src/modules/config/config.c
+++ b/src/modules/config/config.c
@@ -4,6 +4,8 @@
  * yaml.c shim handles parse/emit so this file's schema-extraction code
  * never sees the format change. */
 #include <pthread.h>
+#include <limits.h>
+#include <sched.h>
 #include <stdarg.h>
 #include <stdatomic.h>
 #include <stdint.h>
@@ -1840,7 +1842,7 @@ int config_load_file(config_t *cfg)
    return 0;
 }
 
-/* ---- live config snapshot: double-buffer + seqlock (live-config-reload P1a) ----
+/* ---- live config snapshot: reader-pinned double buffer (live-config-reload P1a) ----
  *
  * A single writer (config_reload, serialized by g_snap_wlock) publishes a fresh config_t
  * into the inactive slot of a two-slot double buffer and flips the active index; readers
@@ -1850,9 +1852,77 @@ int config_load_file(config_t *cfg)
 static config_t g_snap[2];
 static _Atomic unsigned g_snap_seq = 0;    /* seqlock: even = stable, odd = writing */
 static _Atomic unsigned g_snap_active = 0; /* index (0/1) of the live slot */
-static uint64_t g_snap_token = 0;          /* content-hash of the active snapshot */
-static _Atomic int g_snap_inited = 0;      /* atomic so the config_load wrapper's read is visible */
+/* One atomic admission word closes the delayed-pin TOCTOU that a separate reader
+ * count plus writer zero-check would leave.  The high bit reserves a slot for
+ * its writer; the remaining bits count readers that may touch its ordinary
+ * config_t payload. */
+#define CONFIG_SNAPSHOT_WRITER_RESERVED ((unsigned)(UINT_MAX ^ (UINT_MAX >> 1)))
+#define CONFIG_SNAPSHOT_READER_MAX      (CONFIG_SNAPSHOT_WRITER_RESERVED - 1u)
+static _Atomic unsigned g_snap_state[2] = {0, 0};
+static uint64_t g_snap_token = 0;     /* content-hash of the active snapshot */
+static _Atomic int g_snap_inited = 0; /* atomic so the config_load wrapper's read is visible */
 static pthread_mutex_t g_snap_wlock = PTHREAD_MUTEX_INITIALIZER;
+
+/* Test-only coordination seam.  The focused test links a separately compiled
+ * config object with this macro; production objects contain neither the hook
+ * nor the destructive state controls. */
+#ifdef AIMEE_CONFIG_SNAPSHOT_TESTING
+#include "config_snapshot_test.h"
+static config_snapshot_test_hook_fn g_snap_test_hook;
+static void *g_snap_test_hook_ctx;
+
+static void config_snapshot_test_event(config_snapshot_test_event_t event, unsigned slot)
+{
+   if (g_snap_test_hook)
+      g_snap_test_hook(event, slot, g_snap_test_hook_ctx);
+}
+
+void config_snapshot_test_set_hook(config_snapshot_test_hook_fn hook, void *ctx)
+{
+   g_snap_test_hook = hook;
+   g_snap_test_hook_ctx = ctx;
+}
+
+unsigned config_snapshot_test_writer_reserved(void)
+{
+   return CONFIG_SNAPSHOT_WRITER_RESERVED;
+}
+
+unsigned config_snapshot_test_reader_max(void)
+{
+   return CONFIG_SNAPSHOT_READER_MAX;
+}
+
+int config_snapshot_test_set_slot_state(unsigned slot, unsigned state)
+{
+   if (slot > 1)
+      return -1;
+   atomic_store_explicit(&g_snap_state[slot], state, memory_order_release);
+   return 0;
+}
+
+unsigned config_snapshot_test_get_slot_state(unsigned slot)
+{
+   return slot <= 1 ? atomic_load_explicit(&g_snap_state[slot], memory_order_acquire) : UINT_MAX;
+}
+
+unsigned config_snapshot_test_active_slot(void)
+{
+   return atomic_load_explicit(&g_snap_active, memory_order_acquire);
+}
+#else
+static void config_snapshot_test_event(int event, unsigned slot)
+{
+   (void)event;
+   (void)slot;
+}
+#define CONFIG_SNAPSHOT_TEST_BEFORE_RESERVE    0
+#define CONFIG_SNAPSHOT_TEST_RESERVE_CONTENDED 0
+#define CONFIG_SNAPSHOT_TEST_BEFORE_WRITE      0
+#define CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE     0
+#define CONFIG_SNAPSHOT_TEST_PIN_ACQUIRED      0
+#define CONFIG_SNAPSHOT_TEST_PIN_VALIDATED     0
+#endif
 
 /* Re-applier registry (P3): hooks run after a reload publishes, under g_snap_wlock. */
 #define CONFIG_MAX_REAPPLIERS 16
@@ -1891,13 +1961,37 @@ static uint64_t config_snapshot_token(const config_t *c)
 /* Publish `cfg` into the inactive slot and flip. Caller holds g_snap_wlock (single writer). */
 static void config_snapshot_publish(const config_t *cfg)
 {
+   unsigned current = atomic_load_explicit(&g_snap_active, memory_order_acquire);
+   unsigned nxt = current ^ 1u;
+   unsigned expected = 0;
+   config_snapshot_test_event(CONFIG_SNAPSHOT_TEST_BEFORE_RESERVE, nxt);
+   /* Reserve exactly the drained inactive slot.  Readers admit themselves by
+    * CAS on this same word, so either their pin wins (and we wait for release)
+    * or this reservation wins (and no delayed reader can reach the payload). */
+   unsigned contention_spins = 0;
+   while (!atomic_compare_exchange_weak_explicit(&g_snap_state[nxt], &expected,
+                                                 CONFIG_SNAPSHOT_WRITER_RESERVED,
+                                                 memory_order_acquire, memory_order_relaxed))
+   {
+      config_snapshot_test_event(CONFIG_SNAPSHOT_TEST_RESERVE_CONTENDED, nxt);
+      expected = 0;
+      /* Readers need no writer-held resource to unpin. Bound CPU spinning and
+       * yield the processor so a pinned reader can run its release-decrement. */
+      atomic_signal_fence(memory_order_seq_cst);
+      if (++contention_spins == 64)
+      {
+         sched_yield();
+         contention_spins = 0;
+      }
+   }
+   config_snapshot_test_event(CONFIG_SNAPSHOT_TEST_BEFORE_WRITE, nxt);
    unsigned s = atomic_load_explicit(&g_snap_seq, memory_order_relaxed);
    atomic_store_explicit(&g_snap_seq, s + 1, memory_order_release); /* -> odd (writing) */
-   unsigned nxt = atomic_load_explicit(&g_snap_active, memory_order_relaxed) ^ 1u;
    g_snap[nxt] = *cfg; /* fill the slot no reader is on */
    atomic_store_explicit(&g_snap_active, nxt, memory_order_release);
    g_snap_token = config_snapshot_token(cfg);
    atomic_store_explicit(&g_snap_seq, s + 2, memory_order_release); /* -> even (stable) */
+   atomic_store_explicit(&g_snap_state[nxt], 0, memory_order_release);
    atomic_store_explicit(&g_snap_inited, 1, memory_order_release);
 }
 
@@ -1921,10 +2015,32 @@ int config_snapshot_get(config_t *out)
       if (s0 & 1u)
          continue; /* a publish is in progress */
       unsigned act = atomic_load_explicit(&g_snap_active, memory_order_acquire);
-      *out = g_snap[act]; /* POD copy */
+      config_snapshot_test_event(CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE, act);
+      unsigned state = atomic_load_explicit(&g_snap_state[act], memory_order_acquire);
+      for (;;)
+      {
+         if (state & CONFIG_SNAPSHOT_WRITER_RESERVED)
+            break;
+         if (state == CONFIG_SNAPSHOT_READER_MAX)
+            return -1; /* bounded failure: output and admission word stay unchanged */
+         if (atomic_compare_exchange_weak_explicit(&g_snap_state[act], &state, state + 1,
+                                                   memory_order_acquire, memory_order_relaxed))
+            break;
+      }
+      if (state & CONFIG_SNAPSHOT_WRITER_RESERVED)
+         continue;
+      config_snapshot_test_event(CONFIG_SNAPSHOT_TEST_PIN_ACQUIRED, act);
       unsigned s1 = atomic_load_explicit(&g_snap_seq, memory_order_acquire);
-      if (s0 == s1)
-         return 0; /* stable — no publish raced the copy */
+      unsigned act1 = atomic_load_explicit(&g_snap_active, memory_order_acquire);
+      if (s0 != s1 || (s1 & 1u) || act != act1)
+      {
+         atomic_fetch_sub_explicit(&g_snap_state[act], 1, memory_order_release);
+         continue;
+      }
+      config_snapshot_test_event(CONFIG_SNAPSHOT_TEST_PIN_VALIDATED, act);
+      *out = g_snap[act]; /* reservation excludes writers until the release-unpin below */
+      atomic_fetch_sub_explicit(&g_snap_state[act], 1, memory_order_release);
+      return 0;
    }
 }
 

--- a/src/modules/config/config.h
+++ b/src/modules/config/config.h
@@ -2066,7 +2066,8 @@ int config_load(config_t *cfg);
  * current config for immediate, push-driven reload. config_t is a flat POD, so reads are a
  * lock-free struct copy. Additive in P1a: not yet wired into config_load or a push trigger.
  *   config_snapshot_init  — seed the snapshot from a loaded config (once, at startup).
- *   config_snapshot_get   — copy the live snapshot into `out` (seqlock read). -1 if uninit.
+ *   config_snapshot_get   — copy the live snapshot into `out` under a reader pin. -1 if uninit
+ *                           or the bounded reader counter is saturated.
  *   config_reload         — re-read the file, VALIDATE-or-keep, and publish only if the
  *                           content-hash token changed (self-reload no-op guard).
  *                           Returns 1 = published, 0 = no-op (unchanged), -1 = kept (bad). */

--- a/src/modules/config/config_snapshot_test.h
+++ b/src/modules/config/config_snapshot_test.h
@@ -1,0 +1,27 @@
+#ifndef AIMEE_CONFIG_SNAPSHOT_TEST_H
+#define AIMEE_CONFIG_SNAPSHOT_TEST_H
+
+/* Internal deterministic coordination seam for test_config_snapshot.  Production
+ * leaves the hook unset; state injection is valid only under quiescent test
+ * control. */
+typedef enum
+{
+   CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE = 1,
+   CONFIG_SNAPSHOT_TEST_PIN_ACQUIRED = 2,
+   CONFIG_SNAPSHOT_TEST_PIN_VALIDATED = 3,
+   CONFIG_SNAPSHOT_TEST_BEFORE_WRITE = 4,
+   CONFIG_SNAPSHOT_TEST_BEFORE_RESERVE = 5,
+   CONFIG_SNAPSHOT_TEST_RESERVE_CONTENDED = 6,
+} config_snapshot_test_event_t;
+
+typedef void (*config_snapshot_test_hook_fn)(config_snapshot_test_event_t event, unsigned slot,
+                                             void *ctx);
+
+void config_snapshot_test_set_hook(config_snapshot_test_hook_fn hook, void *ctx);
+unsigned config_snapshot_test_writer_reserved(void);
+unsigned config_snapshot_test_reader_max(void);
+int config_snapshot_test_set_slot_state(unsigned slot, unsigned state);
+unsigned config_snapshot_test_get_slot_state(unsigned slot);
+unsigned config_snapshot_test_active_slot(void);
+
+#endif

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -106,7 +106,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-toolset-thread-scope $(TESTPREFIX)/unit-test-workspace-provider-container $(TESTPREFIX)/unit-test-mcp-native-surface $(TESTPREFIX)/unit-test-mcp-native-dispatch $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-roundtable-preset $(TESTPREFIX)/unit-test-roundtable-seat-resolve $(TESTPREFIX)/unit-test-audit-worm $(TESTPREFIX)/unit-test-audit-worm-chain $(TESTPREFIX)/unit-test-kb-audit-worm $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-snapshot $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-cochange $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-roundtable-preset $(TESTPREFIX)/unit-test-roundtable-seat-resolve $(TESTPREFIX)/unit-test-audit-worm $(TESTPREFIX)/unit-test-audit-worm-chain $(TESTPREFIX)/unit-test-kb-audit-worm $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-snapshot $(TESTPREFIX)/unit-test-config-snapshot-race $(TESTPREFIX)/unit-test-msg-session-disable $(TESTPREFIX)/unit-test-gateway-mutate $(TESTPREFIX)/unit-test-gateway-mutate-wire $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-condense $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-cochange $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -1249,8 +1249,20 @@ $(TESTPREFIX)/unit-test-audit-worm-chain: $(OBJDIR)/tests/test_audit_worm_chain.
 $(TESTPREFIX)/unit-test-config-economizer: $(OBJDIR)/tests/test_config_economizer.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-config-snapshot: $(OBJDIR)/tests/test_config_snapshot.o $(TEST_CORE_OBJS)
+P5D2B0_CONFIG_TEST_OBJS = $(filter-out $(OBJDIR)/modules/config/config.o,$(TEST_CORE_OBJS)) \
+                          $(OBJDIR)/tests/config_snapshot_config.o
+
+$(OBJDIR)/tests/config_snapshot_config.o: modules/config/config.c
+	@mkdir -p $(dir $@)
+	$(CC) -c $(TEST_C_FLAGS) -DAIMEE_CONFIG_SNAPSHOT_TESTING -o $@ $<
+
+$(TESTPREFIX)/unit-test-config-snapshot: $(OBJDIR)/tests/test_config_snapshot.o \
+                                         $(P5D2B0_CONFIG_TEST_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-config-snapshot-race: $(OBJDIR)/tests/test_config_snapshot_race.o \
+                                             $(OBJDIR)/tests/config_snapshot_config.o
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-msg-session-disable: $(OBJDIR)/tests/test_msg_session_disable.o \
                      $(OBJDIR)/server/msg_session_disable.o $(OBJDIR)/server/gw_mutate_stats.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1264,7 +1264,8 @@ $(TESTPREFIX)/unit-test-config-snapshot: $(OBJDIR)/tests/test_config_snapshot.o 
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-config-snapshot-race: $(OBJDIR)/tests/test_config_snapshot_race.o \
-                                             $(OBJDIR)/tests/config_snapshot_config.o
+                                             $(OBJDIR)/tests/config_snapshot_config.o \
+                                             $(OBJDIR)/platform_random.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-msg-session-disable: $(OBJDIR)/tests/test_msg_session_disable.o \

--- a/src/tests/test_config_snapshot.c
+++ b/src/tests/test_config_snapshot.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "aimee.h"
+#include "config_snapshot_test.h"
 #include "config_sections.h"
 #include "platform_path.h"
 #include "platform_test_util.h"
@@ -36,6 +37,119 @@ static void write_marker(int proof_gated, int budget)
 
 static _Atomic int g_stop = 0;
 static _Atomic long g_reads = 0, g_torn = 0;
+
+typedef struct
+{
+   pthread_mutex_t mutex;
+   pthread_cond_t changed;
+   int enabled[7][2];
+   int released[7][2];
+   unsigned hits[7][2];
+} snapshot_gate_t;
+
+typedef struct
+{
+   config_t value;
+   _Atomic int started;
+   _Atomic int done;
+} publish_once_t;
+
+typedef struct
+{
+   config_t value;
+   int result;
+   _Atomic int done;
+} read_once_t;
+
+static void snapshot_gate_hook(config_snapshot_test_event_t event, unsigned slot, void *opaque)
+{
+   snapshot_gate_t *gate = opaque;
+   assert(event > 0 && event < 7 && slot < 2);
+   pthread_mutex_lock(&gate->mutex);
+   gate->hits[event][slot]++;
+   pthread_cond_broadcast(&gate->changed);
+   while (gate->enabled[event][slot] && !gate->released[event][slot])
+      pthread_cond_wait(&gate->changed, &gate->mutex);
+   pthread_mutex_unlock(&gate->mutex);
+}
+
+static void snapshot_gate_init(snapshot_gate_t *gate)
+{
+   memset(gate, 0, sizeof(*gate));
+   assert(pthread_mutex_init(&gate->mutex, NULL) == 0);
+   assert(pthread_cond_init(&gate->changed, NULL) == 0);
+}
+
+static void snapshot_gate_destroy(snapshot_gate_t *gate)
+{
+   pthread_cond_destroy(&gate->changed);
+   pthread_mutex_destroy(&gate->mutex);
+}
+
+static void snapshot_gate_enable(snapshot_gate_t *gate, config_snapshot_test_event_t event,
+                                 unsigned slot)
+{
+   pthread_mutex_lock(&gate->mutex);
+   gate->enabled[event][slot] = 1;
+   gate->released[event][slot] = 0;
+   pthread_mutex_unlock(&gate->mutex);
+}
+
+static void snapshot_gate_wait(snapshot_gate_t *gate, config_snapshot_test_event_t event,
+                               unsigned slot, unsigned count)
+{
+   pthread_mutex_lock(&gate->mutex);
+   while (gate->hits[event][slot] < count)
+      pthread_cond_wait(&gate->changed, &gate->mutex);
+   pthread_mutex_unlock(&gate->mutex);
+}
+
+static unsigned snapshot_gate_hits(snapshot_gate_t *gate, config_snapshot_test_event_t event,
+                                   unsigned slot)
+{
+   pthread_mutex_lock(&gate->mutex);
+   unsigned hits = gate->hits[event][slot];
+   pthread_mutex_unlock(&gate->mutex);
+   return hits;
+}
+
+static void snapshot_gate_release(snapshot_gate_t *gate, config_snapshot_test_event_t event,
+                                  unsigned slot)
+{
+   pthread_mutex_lock(&gate->mutex);
+   gate->released[event][slot] = 1;
+   pthread_cond_broadcast(&gate->changed);
+   pthread_mutex_unlock(&gate->mutex);
+}
+
+static void *read_once_thread(void *opaque)
+{
+   read_once_t *once = opaque;
+   once->result = config_snapshot_get(&once->value);
+   atomic_store_explicit(&once->done, 1, memory_order_release);
+   return NULL;
+}
+
+static void *publish_once_thread(void *opaque)
+{
+   publish_once_t *once = opaque;
+   atomic_store_explicit(&once->started, 1, memory_order_release);
+   config_snapshot_init(&once->value);
+   atomic_store_explicit(&once->done, 1, memory_order_release);
+   return NULL;
+}
+
+static config_t snapshot_image(int marker)
+{
+   config_t image;
+   assert(config_snapshot_get(&image) == 0);
+   image.economizer_mode = marker & 1 ? ECON_MODE_PROOF_GATED : ECON_MODE_OFF;
+   image.coord_closet_budget_bytes = marker * 1009;
+   image.autonomy_max_turns = marker * 17;
+   image.server_api_rate_limit_per_min = marker * 31;
+   image.require_aimee_git = marker & 1;
+   return image;
+}
 
 /* The two configs are {proof_gated,budget=1111} and {off,budget=2222};
  * a reader must never observe a mismatched pair (that would be a torn cross-slot read). */
@@ -167,6 +281,125 @@ int main(void)
       assert(config_autonomy_lookup("AIMEE_AUTONOMY_MAX_TURNS", &v) == 1 && v == 1234);
       assert(config_autonomy_lookup("AIMEE_AUTONOMY_MAX_WALL_SECS", &v) == 1 && v == 7200);
       assert(config_autonomy_lookup("AIMEE_AUTONOMY_AUTO_RESUME_CAP_PARKS", &v) == 1 && v == 0);
+   }
+
+   /* --- bounded saturation + WRITER_RESERVED is retryable contention --- */
+   {
+      unsigned active = config_snapshot_test_active_slot();
+      config_t out, before;
+      memset(&out, 0xa5, sizeof(out));
+      before = out;
+      assert(config_snapshot_test_set_slot_state(active, config_snapshot_test_reader_max()) == 0);
+      assert(config_snapshot_get(&out) == -1);
+      assert(memcmp(&out, &before, sizeof(out)) == 0);
+      assert(config_snapshot_test_get_slot_state(active) == config_snapshot_test_reader_max());
+      assert(config_snapshot_test_set_slot_state(active, 0) == 0);
+
+      snapshot_gate_t gate;
+      snapshot_gate_init(&gate);
+      config_snapshot_test_set_hook(snapshot_gate_hook, &gate);
+      assert(config_snapshot_test_set_slot_state(active, config_snapshot_test_writer_reserved()) ==
+             0);
+      read_once_t reader = {0};
+      pthread_t thread;
+      assert(pthread_create(&thread, NULL, read_once_thread, &reader) == 0);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE, active, 3);
+      assert(!atomic_load_explicit(&reader.done, memory_order_acquire));
+      assert(config_snapshot_test_set_slot_state(active, 0) == 0);
+      pthread_join(thread, NULL);
+      assert(reader.result == 0);
+      config_snapshot_test_set_hook(NULL, NULL);
+      snapshot_gate_destroy(&gate);
+   }
+
+   /* --- delayed reader: writer reservation wins, so the old payload is unreachable --- */
+   {
+      config_t base = snapshot_image(10), next = snapshot_image(11), final = snapshot_image(12);
+      config_snapshot_init(&base);
+      unsigned old = config_snapshot_test_active_slot();
+      snapshot_gate_t gate;
+      snapshot_gate_init(&gate);
+      snapshot_gate_enable(&gate, CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE, old);
+      snapshot_gate_enable(&gate, CONFIG_SNAPSHOT_TEST_BEFORE_WRITE, old);
+      config_snapshot_test_set_hook(snapshot_gate_hook, &gate);
+
+      read_once_t reader = {0};
+      publish_once_t writer = {.value = final};
+      pthread_t read_thread, write_thread;
+      assert(pthread_create(&read_thread, NULL, read_once_thread, &reader) == 0);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE, old, 1);
+      config_snapshot_init(&next); /* first publication makes old the inactive target */
+      assert(pthread_create(&write_thread, NULL, publish_once_thread, &writer) == 0);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_BEFORE_WRITE, old, 1);
+      snapshot_gate_release(&gate, CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE, old);
+      pthread_join(read_thread, NULL);
+      assert(reader.result == 0);
+      assert(snapshot_gate_hits(&gate, CONFIG_SNAPSHOT_TEST_PIN_ACQUIRED, old) == 0);
+      assert(!atomic_load_explicit(&writer.done, memory_order_acquire));
+      snapshot_gate_release(&gate, CONFIG_SNAPSHOT_TEST_BEFORE_WRITE, old);
+      pthread_join(write_thread, NULL);
+      config_snapshot_test_set_hook(NULL, NULL);
+      snapshot_gate_destroy(&gate);
+   }
+
+   /* --- delayed reader: reader pin wins, so the writer cannot reserve early --- */
+   {
+      config_t base = snapshot_image(20), next = snapshot_image(21), final = snapshot_image(22);
+      config_snapshot_init(&base);
+      unsigned old = config_snapshot_test_active_slot();
+      snapshot_gate_t gate;
+      snapshot_gate_init(&gate);
+      snapshot_gate_enable(&gate, CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE, old);
+      snapshot_gate_enable(&gate, CONFIG_SNAPSHOT_TEST_PIN_ACQUIRED, old);
+      snapshot_gate_enable(&gate, CONFIG_SNAPSHOT_TEST_BEFORE_RESERVE, old);
+      config_snapshot_test_set_hook(snapshot_gate_hook, &gate);
+
+      read_once_t reader = {0};
+      publish_once_t writer = {.value = final};
+      pthread_t read_thread, write_thread;
+      assert(pthread_create(&read_thread, NULL, read_once_thread, &reader) == 0);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE, old, 1);
+      config_snapshot_init(&next);
+      assert(pthread_create(&write_thread, NULL, publish_once_thread, &writer) == 0);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_BEFORE_RESERVE, old, 1);
+      snapshot_gate_release(&gate, CONFIG_SNAPSHOT_TEST_AFTER_OBSERVE, old);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_PIN_ACQUIRED, old, 1);
+      snapshot_gate_release(&gate, CONFIG_SNAPSHOT_TEST_BEFORE_RESERVE, old);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_RESERVE_CONTENDED, old, 1);
+      assert(!atomic_load_explicit(&writer.done, memory_order_acquire));
+      snapshot_gate_release(&gate, CONFIG_SNAPSHOT_TEST_PIN_ACQUIRED, old);
+      pthread_join(read_thread, NULL);
+      pthread_join(write_thread, NULL);
+      assert(reader.result == 0);
+      config_snapshot_test_set_hook(NULL, NULL);
+      snapshot_gate_destroy(&gate);
+   }
+
+   /* --- validated old-slot pin blocks the consecutive publisher that would reuse it --- */
+   {
+      config_t base = snapshot_image(30), next = snapshot_image(31), final = snapshot_image(32);
+      config_snapshot_init(&base);
+      unsigned old = config_snapshot_test_active_slot();
+      snapshot_gate_t gate;
+      snapshot_gate_init(&gate);
+      snapshot_gate_enable(&gate, CONFIG_SNAPSHOT_TEST_PIN_VALIDATED, old);
+      config_snapshot_test_set_hook(snapshot_gate_hook, &gate);
+
+      read_once_t reader = {0};
+      publish_once_t writer = {.value = final};
+      pthread_t read_thread, write_thread;
+      assert(pthread_create(&read_thread, NULL, read_once_thread, &reader) == 0);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_PIN_VALIDATED, old, 1);
+      config_snapshot_init(&next);
+      assert(pthread_create(&write_thread, NULL, publish_once_thread, &writer) == 0);
+      snapshot_gate_wait(&gate, CONFIG_SNAPSHOT_TEST_RESERVE_CONTENDED, old, 1);
+      assert(!atomic_load_explicit(&writer.done, memory_order_acquire));
+      snapshot_gate_release(&gate, CONFIG_SNAPSHOT_TEST_PIN_VALIDATED, old);
+      pthread_join(read_thread, NULL);
+      pthread_join(write_thread, NULL);
+      assert(reader.result == 0);
+      config_snapshot_test_set_hook(NULL, NULL);
+      snapshot_gate_destroy(&gate);
    }
 
    /* --- concurrent torn-read stress: readers spin while the writer toggles + reloads --- */

--- a/src/tests/test_config_snapshot_race.c
+++ b/src/tests/test_config_snapshot_race.c
@@ -1,0 +1,177 @@
+#include <assert.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"
+#include "config_snapshot_test.h"
+
+typedef struct
+{
+   pthread_mutex_t mutex;
+   pthread_cond_t changed;
+   int validated;
+   int contended;
+   int release_reader;
+} critical_gate_t;
+
+typedef struct
+{
+   config_t image;
+   int result;
+} critical_call_t;
+
+static _Atomic int stop_readers;
+static _Atomic int writer_running;
+static _Atomic int readers_ready;
+static _Atomic long accepted_reads;
+static _Atomic long overlap_reads;
+static _Atomic long mixed_reads;
+
+static void critical_hook(config_snapshot_test_event_t event, unsigned slot, void *opaque)
+{
+   (void)slot;
+   critical_gate_t *gate = opaque;
+   pthread_mutex_lock(&gate->mutex);
+   if (event == CONFIG_SNAPSHOT_TEST_PIN_VALIDATED && !gate->validated)
+   {
+      gate->validated = 1;
+      pthread_cond_broadcast(&gate->changed);
+      while (!gate->release_reader)
+         pthread_cond_wait(&gate->changed, &gate->mutex);
+   }
+   else if (event == CONFIG_SNAPSHOT_TEST_RESERVE_CONTENDED)
+   {
+      gate->contended = 1;
+      pthread_cond_broadcast(&gate->changed);
+   }
+   pthread_mutex_unlock(&gate->mutex);
+}
+
+static void critical_wait(critical_gate_t *gate, int *condition)
+{
+   pthread_mutex_lock(&gate->mutex);
+   while (!*condition)
+      pthread_cond_wait(&gate->changed, &gate->mutex);
+   pthread_mutex_unlock(&gate->mutex);
+}
+
+static void *critical_read(void *opaque)
+{
+   critical_call_t *call = opaque;
+   call->result = config_snapshot_get(&call->image);
+   return NULL;
+}
+
+static void *critical_publish(void *opaque)
+{
+   critical_call_t *call = opaque;
+   config_snapshot_init(&call->image);
+   return NULL;
+}
+
+static void fill_image(config_t *image, int marker)
+{
+   /* Give every byte, including padding and otherwise-unused members, a
+    * publication-specific value so the oracle detects any torn full copy. */
+   memset(image, (unsigned char)(marker * 131u), sizeof(*image));
+   image->economizer_mode = marker & 1 ? 3 : 0;
+   image->coord_closet_budget_bytes = marker * 1009;
+   image->autonomy_max_turns = marker * 17;
+   image->server_api_rate_limit_per_min = marker * 31;
+   image->require_aimee_git = marker & 1;
+   image->memory_window_radius = marker * 43;
+   snprintf(image->server_api_client_transport, sizeof(image->server_api_client_transport), "m%06d",
+            marker);
+}
+
+static int complete_image(const config_t *image)
+{
+   int marker = image->coord_closet_budget_bytes / 1009;
+   if (marker < 1 || marker > 10000)
+      return 0;
+   config_t expected;
+   fill_image(&expected, marker);
+   return memcmp(image, &expected, sizeof(expected)) == 0;
+}
+
+static void *reader(void *unused)
+{
+   (void)unused;
+   atomic_fetch_add_explicit(&readers_ready, 1, memory_order_release);
+   while (!atomic_load_explicit(&writer_running, memory_order_acquire))
+      sched_yield();
+   while (!atomic_load_explicit(&stop_readers, memory_order_acquire))
+   {
+      config_t image;
+      if (config_snapshot_get(&image) != 0)
+         continue;
+      atomic_fetch_add_explicit(&accepted_reads, 1, memory_order_relaxed);
+      if (atomic_load_explicit(&writer_running, memory_order_acquire))
+         atomic_fetch_add_explicit(&overlap_reads, 1, memory_order_relaxed);
+      if (!complete_image(&image))
+         atomic_fetch_add_explicit(&mixed_reads, 1, memory_order_relaxed);
+   }
+   return NULL;
+}
+
+int main(void)
+{
+   config_t image, untouched;
+   memset(&image, 0xa5, sizeof(image));
+   untouched = image;
+   assert(config_snapshot_get(&image) == -1);
+   assert(memcmp(&image, &untouched, sizeof(image)) == 0);
+
+   fill_image(&image, 1);
+   config_snapshot_init(&image);
+
+   /* Force the original failure schedule under TSan: a reader holds a
+    * validated pin on the old active slot, one publication flips away from
+    * it, and a consecutive publisher reaches reservation contention before
+    * the reader is released to copy and unpin. */
+   critical_gate_t gate = {.mutex = PTHREAD_MUTEX_INITIALIZER, .changed = PTHREAD_COND_INITIALIZER};
+   critical_call_t critical_reader = {0}, critical_writer = {0};
+   pthread_t critical_reader_thread, critical_writer_thread;
+   config_snapshot_test_set_hook(critical_hook, &gate);
+   assert(pthread_create(&critical_reader_thread, NULL, critical_read, &critical_reader) == 0);
+   critical_wait(&gate, &gate.validated);
+   fill_image(&image, 2);
+   config_snapshot_init(&image);
+   fill_image(&critical_writer.image, 3);
+   assert(pthread_create(&critical_writer_thread, NULL, critical_publish, &critical_writer) == 0);
+   critical_wait(&gate, &gate.contended);
+   pthread_mutex_lock(&gate.mutex);
+   gate.release_reader = 1;
+   pthread_cond_broadcast(&gate.changed);
+   pthread_mutex_unlock(&gate.mutex);
+   pthread_join(critical_reader_thread, NULL);
+   pthread_join(critical_writer_thread, NULL);
+   config_snapshot_test_set_hook(NULL, NULL);
+   assert(critical_reader.result == 0 && complete_image(&critical_reader.image));
+   pthread_cond_destroy(&gate.changed);
+   pthread_mutex_destroy(&gate.mutex);
+
+   pthread_t readers[4];
+   for (size_t i = 0; i < sizeof(readers) / sizeof(readers[0]); ++i)
+      assert(pthread_create(&readers[i], NULL, reader, NULL) == 0);
+   while (atomic_load_explicit(&readers_ready, memory_order_acquire) != 4)
+      sched_yield();
+   atomic_store_explicit(&writer_running, 1, memory_order_release);
+   for (int marker = 4; marker <= 10000; ++marker)
+   {
+      fill_image(&image, marker);
+      config_snapshot_init(&image);
+   }
+   atomic_store_explicit(&writer_running, 0, memory_order_release);
+   atomic_store_explicit(&stop_readers, 1, memory_order_release);
+   for (size_t i = 0; i < sizeof(readers) / sizeof(readers[0]); ++i)
+      pthread_join(readers[i], NULL);
+   assert(atomic_load_explicit(&accepted_reads, memory_order_relaxed) > 0);
+   assert(atomic_load_explicit(&overlap_reads, memory_order_relaxed) > 0);
+   assert(atomic_load_explicit(&mixed_reads, memory_order_relaxed) == 0);
+   puts("config snapshot race stress: ok");
+   return 0;
+}


### PR DESCRIPTION
## Summary
- close the two-slot snapshot reuse data race with atomic reader pins and writer reservation
- keep destructive coordination seams out of production objects
- add deterministic consecutive-publication coverage and a focused full-image TSan stress gate
- carry the roundtable-reviewed D2b safe-config plan forward

## Validation
- focused snapshot tests 20x/10x
- GCC ThreadSanitizer on CT260 with deterministic critical schedule
- full unit suite
- production server build
- lint
- adversarial roundtable converged (job 9863)