### PR TITLE
refactor(ir): complete module ownership

### DIFF
--- a/docs/modules/ir.md
+++ b/docs/modules/ir.md
@@ -10,6 +10,14 @@ route work, or define a provider's external JSON contract.
 
 ## Public contracts
 
+`src/modules/ir/module.yaml` is the complete module-local ownership inventory: two production
+translation units, three canonical public headers, three direct contract tests, and
+`docs/modules/ir.md`.
+`ownership_complete: true` makes unlisted module-local C or private-header files and omission of the
+canonical document fail descriptor validation. Canonical public-header placement remains enforced by
+the descriptor-derived header-layout gate. This completeness claim is about physical ownership; it does
+not claim that every exported helper is a live production API.
+
 The canonical implementations are `src/modules/ir/aimee_ir.c` and
 `src/modules/ir/aimee_ir_metrics.c`. Their matching public contracts are
 `src/modules/ir/include/aimee/ir/aimee_ir.h`,
@@ -130,3 +138,8 @@ can preserve or explicitly reject it. Per-provider convenience fields belong in 
 the core type. Duplicate legacy representations should be removed after caller inventories and parity
 tests prove replacement. Removal of the canonical `ir` contract would break every supported execution
 journey and is disallowed.
+
+The [slice 31 liveness audit](../validation/core-modularization-slice-31.md) found both production sources
+in the shipping server build with non-test consumers. It also records three narrower test-support or
+currently test-only API cleanup candidates. Removing or privatizing them requires a separate
+compatibility-focused slice rather than being hidden in an ownership-metadata change.

--- a/docs/validation/core-modularization-slice-31.md
+++ b/docs/validation/core-modularization-slice-31.md
@@ -1,0 +1,78 @@
+# Core modularization slice 31: complete IR ownership
+
+## Scope
+
+This slice marks the required `ir` descriptor `ownership_complete: true`. It changes ownership
+metadata, validation coverage, documentation, and cleanup accounting only. Production source, public
+symbols, build inputs, runtime behavior, and wire behavior do not change.
+
+The descriptor owns exactly:
+
+- `src/modules/ir/aimee_ir.c` and `src/modules/ir/aimee_ir_metrics.c`;
+- `src/modules/ir/include/aimee/ir/aimee_ir.h`, `aimee_ir_metrics.h`, and `panel_result.h`;
+- `src/tests/test_aimee_ir.c`, `src/tests/test_aimee_ir_metrics.c`, and
+  `src/tests/test_panel_ir_contract.c`; and
+- `docs/modules/ir.md`.
+
+Translation remains an independently reviewable follow-up. IR depends only on `module-runtime`, while
+translation depends on IR, so completing IR first follows the descriptor graph without requiring an
+atomic cross-module change.
+
+## Production liveness and ownership
+
+`aimee_ir.c` is a shipping input at `src/Makefile:440`. Its focused Make contract is
+`src/tests/Rules.mk:1656`, its direct CMake test is `src/tests/CMakeLists.txt:160`, and it is exercised by
+the cross-boundary CMake tests at lines 162-166. Production callers include the translation frontends and
+backends, `modules/memory/gw_stage_memory.c`, `server/aimee_ir_serve.c`, `server/aimee_ir_shadow.c`,
+`modules/delegates/aimee_ir_rescue.c`, `posix/agent_ir_parse.c`, and `posix/agent_runtime_tmux.c`. The
+source owns provider-neutral request/response lifecycle, semantic accessors, equality, and transform
+sequencing, and depends only on cJSON and libc.
+
+`aimee_ir_metrics.c` is also a shipping input at `src/Makefile:440`. Its focused Make contract is
+`src/tests/Rules.mk:1668`, its direct CMake test is `src/tests/CMakeLists.txt:161`, and it participates in
+the CMake shadow/serve tests at lines 164-165. Production writers are
+`modules/delegates/aimee_ir_rescue.c`, `server/aimee_ir_serve.c`, `server/aimee_ir_shadow.c`, and
+`server/anthropic_http.c`. `server/server_state.c` reads and exports the names, per-wire counts, and totals
+to dashboard metrics. These counters describe provider-neutral IR parse, build, parity, and stage state,
+so IR is their canonical owner.
+
+The public types are independently live. Translation, memory, server, and POSIX runtime consume
+`aimee_ir.h`; the production writers and dashboard reader consume `aimee_ir_metrics.h`; required delegates,
+optional roundtable, workflows, and server pipeline/compute consume `panel_result.h`. IR owns the latter's
+provider-neutral result layout only, while delegates and optional providers own execution.
+
+Neither production source is self-tested-only, and no duplicate canonical IR implementation was found.
+The Aimee code index still reported the pre-move `src/server` and `src/headers` paths during this audit, so
+the current-worktree build and caller evidence above is authoritative. The cited Make/CMake line references
+were rechecked in that worktree. An exact symbol search across `src` found only direct-test call sites for
+`aimee_ir_response_reasoning`.
+
+## DRY and dead-code findings
+
+Three symbol-level cleanup candidates remain explicit:
+
+- `aimee_ir_request_equal` is a cross-protocol test-support export;
+- `aimee_ir_metrics_reset` is a test-only reset seam; and
+- `aimee_ir_response_reasoning` currently has only direct-test callers.
+
+They do not make either source file dead: both files have shipping consumers. This slice does not delete
+or privatize the symbols because that would change public and test contracts. A later focused API-cleanup
+slice must decide compatibility, move any retained test helper into test support, and prove downstream
+callers before changing them.
+
+## Regression controls
+
+Production descriptor mutation tests now remove `aimee_ir.c`, plant an unlisted C source, plant an
+unlisted private header, and remove the IR canonical document. Each mutation must fail with the stable
+`ownership-complete` rule. The existing header-layout gate continues to enforce declared canonical public
+headers and reject flat shadows or broad source include roots.
+
+## Verification
+
+- descriptor validation and its complete mutation suite;
+- module header-layout, source-ownership, docs, cleanup-ledger, and refactor-baseline checks plus focused
+  mutation suites;
+- full Make build and lint;
+- build and execute `unit-test-aimee-ir`, `unit-test-aimee-ir-metrics`, and
+  `unit-test-panel-ir-contract`; and
+- technical-writer review, exact-final-diff roundtable approval, and all required pull-request checks.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -254,6 +254,7 @@ class DescriptorTests(unittest.TestCase):
             ("protocols", "sources", "src/modules/protocols/acp/acp_server.c"),
             ("protocols", "private_headers",
              "src/modules/protocols/mcp/mcp_tools_gateway.h"),
+            ("ir", "sources", "src/modules/ir/aimee_ir.c"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -272,7 +273,7 @@ class DescriptorTests(unittest.TestCase):
             finally:
                 tmp.cleanup()
 
-        for identifier in ("roundtable", "protocols"):
+        for identifier in ("roundtable", "protocols", "ir"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -291,17 +292,18 @@ class DescriptorTests(unittest.TestCase):
                     tmp.cleanup()
 
     def test_complete_ownership_requires_canonical_doc(self) -> None:
-        tmp = self.production_repo()
-        try:
-            repo = Path(tmp.name)
-            self.mutate_descriptor(repo, "roundtable",
-                                   lambda value: value.__setitem__("docs", []))
-            with self.assertRaisesRegex(
-                validator.DescriptorError, r"rule=ownership-complete pointer=/docs"
-            ):
-                validator.validate_roots(repo, [Path("src/modules")])
-        finally:
-            tmp.cleanup()
+        for identifier in ("roundtable", "ir"):
+            tmp = self.production_repo()
+            try:
+                repo = Path(tmp.name)
+                self.mutate_descriptor(repo, identifier,
+                                       lambda value: value.__setitem__("docs", []))
+                with self.subTest(identifier=identifier), self.assertRaisesRegex(
+                    validator.DescriptorError, r"rule=ownership-complete pointer=/docs"
+                ):
+                    validator.validate_roots(repo, [Path("src/modules")])
+            finally:
+                tmp.cleanup()
 
     def test_complete_ownership_excludes_undeclared_public_headers(self) -> None:
         tmp = self.production_repo()

--- a/src/modules/ir/module.yaml
+++ b/src/modules/ir/module.yaml
@@ -4,6 +4,7 @@
   "dependencies": [
     "module-runtime"
   ],
+  "ownership_complete": true,
   "runtime_toggle": {
     "supported": false
   },

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -384,6 +384,23 @@
       "blast_radius": "Production changes are physical public-header moves and include substitutions; symbols, wire framing, CLI names, routes, runtime defaults, persistence, source inputs, and target object membership remain unchanged.",
       "independent_review": "Aimee technical-writer job 10340 approved the module documentation; exact-final-diff roundtable approval remains required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-30.md", "docs/modules/protocols.md", "src/modules/protocols/module.yaml", "scripts/check_module_header_layout.py", "scripts/tests/test_check_module_header_layout.py", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 31,
+      "state": "present_and_verified",
+      "disposition": "Completed required-core IR module-local ownership after proving both production sources ship with non-test consumers and recording narrower test-support API cleanup candidates.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["translation remains independently incomplete", "aimee_ir_request_equal and aimee_ir_metrics_reset remain test-support exports", "aimee_ir_response_reasoning currently has only test callers"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Marking IR complete from filesystem enumeration alone would hide whether its sources ship or self-consume only; combining translation would weaken the independently green dependency boundary.",
+        "revisit": "Review the three symbol-level candidates in a focused public/test API cleanup, and complete translation as a separate graph-ordered slice."
+      },
+      "consumers": ["IR maintainers", "translation", "memory", "delegates", "server and POSIX runtimes", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, runtime, or wire behavior changes; descriptor validation gains IR-specific missing-source, planted-source/header, and missing-document failures.",
+      "independent_review": "Technical-writer review and exact-final-diff roundtable approval are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-31.md", "docs/modules/ir.md", "src/modules/ir/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- mark required-core IR module-local ownership complete
- record source-level shipping/caller evidence and explicit API cleanup candidates
- add IR-specific ownership mutation coverage and slice cleanup accounting

## Scope

Metadata, validation, and documentation only. No production source, public API, build membership, runtime behavior, or wire behavior changes.

## Validation

- descriptor validator and 38 mutation tests
- 59 module boundary/docs/ledger/refactor tests
- full Make build and lint
- focused IR, IR metrics, and panel IR contract executables
- technical-writer review approved
- exact staged-diff roundtable approved with no findings
