### PR TITLE
refactor(translation): complete module ownership

### DIFF
--- a/docs/modules/translation.md
+++ b/docs/modules/translation.md
@@ -9,6 +9,13 @@ HTTP retries, authorize tool calls, or own the external protocol listener.
 
 ## Public contracts
 
+`src/modules/translation/module.yaml` is the complete module-local ownership inventory: eight shipping
+translation units, three canonical public headers, five direct tests, and this module document.
+`ownership_complete: true` rejects an unlisted module-local C or private-header file and omission of the
+canonical document. Canonical public-header placement remains enforced by the descriptor-derived
+header-layout gate. This physical ownership claim does not imply that every exported adapter helper is
+selected by a production journey.
+
 The canonical ingress adapters are
 `src/modules/translation/aimee_frontend_anthropic.c`,
 `src/modules/translation/aimee_frontend_openai.c`, and
@@ -129,3 +136,9 @@ Add an adapter through the shared IR conversion interface and capability contrac
 ingress handler. The parallel legacy and typed builders in `anthropic_http.c` and `openai_chat.c` are
 consolidation candidates, not automatically dead code; parity and mutation branches must be traced first.
 Translation cannot be removed while Aimee supports more than one external/provider wire.
+
+The [slice 32 liveness audit](../validation/core-modularization-slice-32.md) proves that every owned source
+ships and that each translation unit contains a production path. It separately records seven helpers
+whose exact current-worktree callers are tests only. Removing, privatizing, or activating those intended
+egress and Bedrock-streaming contracts requires focused compatibility/readiness slices; they are not
+silently treated as live merely because their source files ship.

--- a/docs/validation/core-modularization-slice-32.md
+++ b/docs/validation/core-modularization-slice-32.md
@@ -1,0 +1,79 @@
+# Core modularization slice 32: complete translation ownership
+
+## Scope
+
+This slice marks the required `translation` descriptor `ownership_complete: true`. The existing
+descriptor already owns all eight module-local C sources, three canonical public headers, five direct
+tests, and `docs/modules/translation.md`. The change is metadata, validation, documentation, and cleanup
+accounting only: production source, public symbols, build inputs, runtime behavior, and wire behavior do
+not change.
+
+Translation depends on the ownership-complete `ir` module and `module-runtime`; the already-complete
+`protocols` module depends on translation. Completing translation independently therefore closes the
+declared IR-to-protocol ownership chain in graph order.
+
+## Source liveness and ownership
+
+All eight sources are shipping inputs in `src/Makefile:440`, and every source contains at least one
+production-selected path:
+
+- `aimee_frontend_anthropic.c`: `anthropic_frontend_parse` is called by `server/aimee_ir_serve.c` and
+  `server/aimee_ir_shadow.c`.
+- `aimee_frontend_openai.c`: `openai_frontend_parse` is called by `server/aimee_ir_serve.c`.
+- `aimee_frontend_responses.c`: `responses_frontend_parse` is called by `server/aimee_ir_serve.c`.
+- `aimee_backend_anthropic.c`: build, parse, and cache-control entrypoints are called by
+  `server/agent_request_build.c`, `server/server.c`, POSIX agent parsing/runtime, and
+  `server/aimee_ir_shadow.c`.
+- `aimee_backend_openai.c`: build and parse entrypoints are called by request building, IR serve/shadow,
+  POSIX agent parsing/runtime, and `server/anthropic_http.c`.
+- `aimee_backend_responses.c`: build and parse entrypoints are called by request building, IR serve,
+  POSIX agent parsing, `server/agent_bridge.c`, and IR shadow.
+- `aimee_backend_bedrock.c`: `bedrock_converse_build` is called by `kb/kb_bedrock_egress.c`, and
+  `converse_stop_reason` is shared with the stream implementation.
+- `aimee_ir_stream.c`: OpenAI stream parsing and split Anthropic emission are called by
+  `server/aimee_ir_serve.c` and `server/anthropic_http.c`.
+
+These files translate only between provider/client wire shapes and provider-neutral IR. Their public
+headers are consumed by the production callers above, so `translation` is the correct owner. The five
+descriptor-owned tests cover frontend parsing/rendering, backend building/parsing, Bedrock Converse,
+OpenAI/Anthropic streaming, and Bedrock ConverseStream. Adjacent server/parity tests remain consumer-owned.
+
+## DRY and dead-code findings
+
+No complete source file is self-tested-only, and no duplicate canonical adapter implementation was found.
+Exact symbol searches in the merged feature-branch worktree found only test callers for:
+
+- `anthropic_frontend_render`, `openai_frontend_render`, and `responses_frontend_render`;
+- `bedrock_converse_parse`;
+- `converse_stream_state_init` and `bedrock_converse_stream_to_deltas`; and
+- `anthropic_delta_render`.
+
+These are explicit API cleanup or activation candidates, not evidence that their containing source is
+dead. They model intended buffered egress or Bedrock streaming behavior and require separate compatibility
+and readiness decisions before deletion, privatization, or activation.
+
+The first decision roundtable cited `src/kb/http/kb_http_egress.c:321` and lines 1200-1481 of
+`src/kb/kb_bedrock_egress.c` as production callers. Those references are stale: the first path is absent
+from the merged worktree, the second file has 111 lines, and exact searches under `src/kb` find none of
+the four cited symbols. Current-worktree evidence therefore controls this ownership audit.
+
+Legacy serve/shadow and direct wire translators remain outside module-local ownership pending their own
+parity-backed behavior-separation slices. Their existence does not create a second canonical adapter API.
+
+## Regression controls
+
+Production descriptor mutations remove one frontend source, one backend source, and the stream source;
+plant an undeclared source and private header; and remove the canonical translation document. Each must
+fail with the stable `ownership-complete` rule. The existing header-layout and source-ownership gates
+continue to reject retired flat paths, basename includes, and broad source include roots.
+
+## Verification
+
+- descriptor validation and its complete production mutation suite;
+- module header-layout, source-ownership, docs, cleanup-ledger, and refactor-baseline checks plus focused
+  mutation suites;
+- full Make build and lint;
+- build and execute `unit-test-aimee-frontend`, `unit-test-aimee-backend`,
+  `unit-test-aimee-backend-bedrock`, `unit-test-aimee-ir-stream`, and
+  `unit-test-aimee-converse-stream`; and
+- technical-writer review, exact-final-diff roundtable approval, and all required pull-request checks.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -255,6 +255,11 @@ class DescriptorTests(unittest.TestCase):
             ("protocols", "private_headers",
              "src/modules/protocols/mcp/mcp_tools_gateway.h"),
             ("ir", "sources", "src/modules/ir/aimee_ir.c"),
+            ("translation", "sources",
+             "src/modules/translation/aimee_frontend_anthropic.c"),
+            ("translation", "sources",
+             "src/modules/translation/aimee_backend_openai.c"),
+            ("translation", "sources", "src/modules/translation/aimee_ir_stream.c"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -273,7 +278,7 @@ class DescriptorTests(unittest.TestCase):
             finally:
                 tmp.cleanup()
 
-        for identifier in ("roundtable", "protocols", "ir"):
+        for identifier in ("roundtable", "protocols", "ir", "translation"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -292,7 +297,7 @@ class DescriptorTests(unittest.TestCase):
                     tmp.cleanup()
 
     def test_complete_ownership_requires_canonical_doc(self) -> None:
-        for identifier in ("roundtable", "ir"):
+        for identifier in ("roundtable", "ir", "translation"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/translation/module.yaml
+++ b/src/modules/translation/module.yaml
@@ -5,6 +5,7 @@
     "ir",
     "module-runtime"
   ],
+  "ownership_complete": true,
   "runtime_toggle": {
     "supported": false
   },

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -401,6 +401,23 @@
       "blast_radius": "No production source, public symbol, build membership, runtime, or wire behavior changes; descriptor validation gains IR-specific missing-source, planted-source/header, and missing-document failures.",
       "independent_review": "Technical-writer review and exact-final-diff roundtable approval are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-31.md", "docs/modules/ir.md", "src/modules/ir/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 32,
+      "state": "present_and_verified",
+      "disposition": "Completed required-core translation module-local ownership after proving every source contains a shipping path and separating seven test-only adapter helpers as explicit cleanup or activation candidates.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["legacy serve, shadow, and direct wire translators remain outside module ownership pending parity-backed separation", "seven intended buffered-egress or Bedrock-streaming helpers currently have test callers only"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Filesystem enumeration alone would hide test-only exported helpers, while deleting them inside a metadata slice would skip compatibility and readiness decisions.",
+        "revisit": "Audit each test-only helper family for focused activation, privatization, or deletion, and separate legacy translators only after parity evidence."
+      },
+      "consumers": ["translation maintainers", "IR serve and shadow", "agent runtimes", "KB Bedrock egress", "protocols", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, runtime, or wire behavior changes; descriptor validation gains translation source-family, planted-file, and missing-document failures.",
+      "independent_review": "Technical-writer review and exact-final-diff roundtable approval are required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-32.md", "docs/modules/translation.md", "src/modules/translation/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- mark required-core translation module-local ownership complete
- prove every owned translation unit contains a shipping path
- record seven currently test-only helper contracts for focused cleanup/readiness decisions
- add source-family ownership mutation coverage and slice accounting

## Scope

Metadata, validation, and documentation only. No production source, public API, build membership, runtime behavior, or wire behavior changes.

## Validation

- descriptor validator and full mutation suite
- module header/source/docs/ledger/refactor checks
- full Make build and lint
- five focused frontend/backend/stream translation executables
- diff-only technical-writer approval
- exact staged-diff roundtable approval with no findings
