### PR TITLE
refactor(skills): complete module ownership

### DIFF
--- a/docs/modules/skills.md
+++ b/docs/modules/skills.md
@@ -16,6 +16,15 @@ and `skill_rollback.c` in `src/modules/skills`, with CLI orchestration in `src/c
 use the `aimee/skills` include namespace. The former singular source directory is retired without a
 forwarding API or parallel skill registry.
 
+`src/modules/skills/module.yaml` declares ownership of the three production sources above, both
+canonical public headers, two direct unit tests, and this document; the module has no private headers.
+Its `ownership_complete: true` latch exhaustively checks module-local C and private-header files and
+requires this canonical document. Public-header and test entries are explicit ownership claims, but the
+completeness latch does not discover undeclared public headers or tests. Command, server, protocol, and
+configuration files with skill surfaces remain orchestration or consumer boundaries rather than
+duplicate skill implementations. The source-level liveness and public-API cleanup audit is recorded in
+`docs/validation/core-modularization-slice-33.md`.
+
 ## Dependencies and consumers
 
 - `config`: supplies dispatch, index, lifecycle, and evaluation policy for skills.
@@ -81,10 +90,9 @@ usable rather than inventing instructions.
 
 ## Operational diagnostics
 
-Use `aimee skill list|show|lint|eval`, review records, lifecycle result counts, and `skill_metrics` to
-diagnose precedence, malformed content, stale state, or failed automation. Diagnostics should include the
-resolved source class and safe path context while avoiding logging full private skill bodies or injected
-secrets.
+Use `aimee skill list|show|lint|eval`, review records, and lifecycle result counts to diagnose
+precedence, malformed content, stale state, or failed automation. Diagnostics should include the resolved
+source class and safe path context while avoiding logging full private skill bodies or injected secrets.
 
 ## Compatibility
 

--- a/docs/validation/core-modularization-slice-33.md
+++ b/docs/validation/core-modularization-slice-33.md
@@ -1,0 +1,86 @@
+# Core modularization slice 33: complete skills ownership
+
+## Scope
+
+This slice marks the required `skills` descriptor `ownership_complete: true`. Slice 25 already moved
+the implementation and public contracts from the retired singular root into `src/modules/skills`; this
+slice proves that the descriptor exhaustively covers the validator's module-local C and private-header
+domain, requires the canonical module document, and records the audited public headers and direct tests.
+It changes metadata, validation, documentation, and cleanup accounting only. Production code, public
+symbols, build inputs, configuration, stored skill data, and runtime behavior do not change.
+
+Skills depend on required core services and cannot be disabled as a module. Individual dispatch and
+lifecycle policies remain configuration, but the resolver, validation, injection, review, management,
+and rollback contracts remain available to every profile.
+
+## Source liveness and ownership
+
+`src/Makefile` and the root `CMakeLists.txt` both compile all three descriptor-owned sources:
+
+- `skill.c` implements resolution, loading, validation, injection, management, telemetry, lifecycle,
+  and capability coverage. Production consumers include `cmd_skill.c`, `cmd_agent_delegate.c`,
+  `session_briefing.c`, `server/server_skill.c`, `server/server_mcp_skill.c`, and the guardrails
+  orchestrator.
+- `skill_rollback.c` implements `skill_rollback_snapshot`, called by the `aimee skill rollback` path in
+  `cmd_skill.c`.
+- `skill_review.c` implements `skill_review_should_fire`, called by the live review-nudge path in
+  `server/server.c`.
+
+The public contracts live only under `src/modules/skills/include/aimee/skills`. Tracked-file, directory,
+legacy-include, and build-input searches find no retired `src/skill` implementation, flat forwarding
+header, or alternate resolver/lifecycle implementation. `cmd_skill.c`, `server/server_skill*.c`,
+`modules/protocols/mcp/mcp_skill_tools.*`, and `modules/config/config_skills.c` are user, protocol, job,
+or configuration boundaries that consume the module; they do not implement a second skill engine.
+
+The descriptor-owned `test_skill.c` exercises the resolver, management, validation, injection,
+lifecycle, rollback, and telemetry contracts. `test_skill_review.c` directly covers the review predicate
+and poison-check path. Wider server, protocol, delegate, session, and guardrails tests remain owned by
+their respective composition boundaries.
+
+## DRY and dead-code findings
+
+No complete source file is self-tested-only, and no duplicate canonical skills implementation was
+found. Exact symbol searches do identify four public declarations without a caller outside the module
+or its direct tests:
+
+- `skill_trigger_matches_content` and `skill_name_is_valid` are used internally and exposed for direct
+  unit testing, so their public exposure is a privatization or test-contract candidate;
+- `skill_record_activation` is exercised directly but is not wired to a shipping activation caller; and
+- `skill_metrics` exposes the associated activation counter only to the unit test.
+
+The latter pair is also an activation-or-deletion candidate: self-contained implementation and tests do
+not establish a live feature. Removing or wiring these symbols requires a focused telemetry/API slice;
+doing so here would mix behavior with an ownership-metadata change.
+
+## Regression controls
+
+Production descriptor mutations remove each of the three skills sources in turn, plant an undeclared C
+source and private header, and remove the canonical skills document. Each mutation must fail with the
+stable `ownership-complete` rule. Existing header-layout and source-ownership checks continue to reject
+the retired singular root, flat headers, basename includes, and legacy build spellings.
+
+## Verification
+
+Run these commands from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_header_layout.py
+python3 -m unittest scripts.tests.test_check_module_header_layout
+python3 scripts/check_module_source_ownership.py
+python3 -m unittest scripts.tests.test_check_module_source_ownership
+python3 -m unittest scripts.tests.test_check_module_docs \
+  scripts.tests.test_check_cleanup_ledger scripts.tests.test_refactor_baselines
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-skill build/obj/tests/unit-test-skill-review
+src/build/obj/tests/unit-test-skill
+src/build/obj/tests/unit-test-skill-review
+```
+
+The focused binaries must report `All skill tests passed.` and `PASS`, respectively. Technical-writer
+review, exact-final-diff roundtable approval, and all required pull-request checks are also required.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -260,6 +260,9 @@ class DescriptorTests(unittest.TestCase):
             ("translation", "sources",
              "src/modules/translation/aimee_backend_openai.c"),
             ("translation", "sources", "src/modules/translation/aimee_ir_stream.c"),
+            ("skills", "sources", "src/modules/skills/skill.c"),
+            ("skills", "sources", "src/modules/skills/skill_rollback.c"),
+            ("skills", "sources", "src/modules/skills/skill_review.c"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -278,7 +281,7 @@ class DescriptorTests(unittest.TestCase):
             finally:
                 tmp.cleanup()
 
-        for identifier in ("roundtable", "protocols", "ir", "translation"):
+        for identifier in ("roundtable", "protocols", "ir", "translation", "skills"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -297,7 +300,7 @@ class DescriptorTests(unittest.TestCase):
                     tmp.cleanup()
 
     def test_complete_ownership_requires_canonical_doc(self) -> None:
-        for identifier in ("roundtable", "ir", "translation"):
+        for identifier in ("roundtable", "ir", "translation", "skills"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/skills/module.yaml
+++ b/src/modules/skills/module.yaml
@@ -11,6 +11,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/skills/skill.c",
     "src/modules/skills/skill_review.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -418,6 +418,23 @@
       "blast_radius": "No production source, public symbol, build membership, runtime, or wire behavior changes; descriptor validation gains translation source-family, planted-file, and missing-document failures.",
       "independent_review": "Technical-writer review and exact-final-diff roundtable approval are required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-32.md", "docs/modules/translation.md", "src/modules/translation/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 33,
+      "state": "present_and_verified",
+      "disposition": "Completed the validator-enforced required-core skills module-root ownership domain after proving all three sources have shipping consumers, recording the two canonical public headers and two direct tests, and separating four test-facing public declarations as focused API or activation cleanup candidates.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["Make and CMake retain separate source inventories until descriptor-driven generation", "skill_trigger_matches_content and skill_name_is_valid remain public test contracts despite internal production use", "skill_record_activation and skill_metrics remain unwired telemetry exports pending activation-or-deletion review"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Filesystem enumeration alone would hide whether the three sources ship and whether their public surface contains self-tested-only features.",
+        "revisit": "Privatize test-facing helpers where possible and either wire or delete activation telemetry in a focused behavior and compatibility slice."
+      },
+      "consumers": ["skill CLI and server surfaces", "delegates", "session briefing", "guardrails", "protocol adapters", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, stored data, or runtime behavior changes; descriptor validation gains skills-specific missing-source, planted-source/header, and missing-document failures.",
+      "independent_review": "The slice decision roundtable approved the bounded ownership-completion plan without findings; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-33.md", "docs/modules/skills.md", "src/modules/skills/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- mark the required-core skills module ownership-complete after source-level liveness and whole-tree ownership audit
- extend reusable descriptor mutation coverage for all three skills sources, planted module files, and canonical documentation
- document the exact ownership contract, consumer boundaries, and four focused public-API/telemetry cleanup candidates

## Validation
- decision roundtable: approved with no findings
- technical writer: approved after precision corrections
- exact-final-diff roundtable: approved with no findings
- descriptor validator and 38 descriptor tests
- 59 module ownership/docs/ledger/refactor mutation tests
- full Make build and lint
- unit-test-skill and unit-test-skill-review binaries

No production source, public symbol, build membership, configuration, stored data, or runtime behavior changes.