### PR TITLE
refactor(audit): complete module ownership

### DIFF
--- a/docs/modules/audit.md
+++ b/docs/modules/audit.md
@@ -15,8 +15,15 @@ immutable hardware/storage, or make a best-effort dual write authoritative.
 The four canonical public headers live under `src/modules/audit/include/aimee/audit/`, and consumers
 include them as `aimee/audit/<header>.h`. `audit_action.h` owns bounded governed-action evidence;
 `audit_ledger.h` owns legacy ledger reads; `audit_worm.h` owns the server store API; and
-`audit_worm_chain.h` is the shared engine-independent canonical hash/MAC boundary also consumed by
-the KB PostgreSQL store.
+`audit_worm_chain.h` owns the engine-independent canonical row-hash and checkpoint-MAC primitives.
+The KB PostgreSQL store consumes `audit_worm_row_hash` at the shared canonical row-hash boundary.
+
+`src/modules/audit/module.yaml` declares ownership of four production sources, four canonical public
+headers, four direct unit tests, and this document; the module has no private headers. Its
+`ownership_complete: true` latch exhaustively checks module-local C and private-header files and requires
+this canonical document. Public-header and test entries are explicit audited claims rather than
+auto-discovered completeness domains. The source liveness, build membership, adjacent-boundary, and
+test-facing API audit is recorded in `docs/validation/core-modularization-slice-34.md`.
 
 ## Dependencies and consumers
 
@@ -31,8 +38,8 @@ own event meaning; audit owns safe record formation, storage, verification, and 
 ## Providers and readiness
 
 The legacy provider appends JSON lines to rotating `audit.log`. The server WORM provider is SQLite at
-`$AIMEE_HOME/audit/worm-live.db`; the KB uses a separate PostgreSQL store while sharing chain
-primitives. Readiness reports capture gate, store availability, chain result, checkpoint attestation,
+`$AIMEE_HOME/audit/worm-live.db`; the KB uses a separate PostgreSQL store while sharing the canonical
+row-hash primitive. Readiness reports capture gate, store availability, chain result, checkpoint attestation,
 and sealed-file immutability separately. Legacy logging remains authoritative while WORM dual-write is
 default-off and best-effort.
 
@@ -97,7 +104,7 @@ named tests remain with their actual subsystem or integration boundary; a filena
 | `test_code_audit_graph.c` | The independent code-audit graph algorithms | Not assigned; code-health analysis is not the audit evidence module |
 | `test_db2_code_audit.c` | DB2 code-audit assembly and PostgreSQL query shims | Not assigned; this is a DB2 code-intelligence test |
 | `test_harness_memory_audit.c` | Memory-interception JSONL logging through `hmem_audit` | Not assigned; this is a memory harness test |
-| `test_kb_audit_worm.c` | The KB PostgreSQL store and artifact capture seam, using the shared chain contract | Not assigned; this is a mixed KB/store integration test |
+| `test_kb_audit_worm.c` | The KB PostgreSQL store and artifact capture seam, using the shared canonical row-hash contract | Not assigned; this is a mixed KB/store integration test |
 | `test_kb_audit_worm_pg.c` | SQL and C append parity against a real PostgreSQL KB store | Not assigned; this is a mixed KB/PostgreSQL integration test |
 | `test_token_audit.c` | DB1 token accounting and agent ingress attribution | Not assigned; this is a DB1/agent-accounting test |
 | `test_token_audit_load.c` | Concurrent DB1 token writes and asynchronous ingress recording | Not assigned; this is a DB1/agent-ingress load test |
@@ -107,6 +114,13 @@ The direct tests deliberately separate the shared chain primitive from the SQLit
 it. That is complementary coverage, not duplicate ownership. The CMake suite registers the action and
 ledger tests; the Make unit-test suite registers the WORM store and chain tests. Issue #1753 records the
 evidence used to resolve this classification.
+
+Build membership is intentionally not uniform today. Make's `CORE_SRCS` contains all four audit sources;
+its KB projection removes only the SQLite-specific `audit_worm.c`, retaining the pure shared chain.
+CMake's `CORE_SRCS`, and therefore the `aimee-core` static library plus its server/KB projections, contains
+only `audit_action.c` and `audit_ledger.c`. The descriptor records canonical source ownership; it does not
+claim that the current Make and CMake products expose identical WORM capabilities. Closing that existing
+build-profile gap requires a separate behavior and dependency slice.
 
 Current governed-action emission is best-effort: hashing writes a stable sentinel on failure, and WORM
 loss does not block the action while legacy logging is authoritative.
@@ -122,8 +136,9 @@ unbounded principal or subject. `amber` means an intact unattested tail, not cor
 
 The `v1-` args-hash form, per-tool projection, WORM domain and fixed field order, genesis value,
 gap-free sequence, checkpoint MAC contract, verification status meanings, event fields, and legacy
-reader ordering are compatibility contracts. Server SQLite and KB PostgreSQL must remain byte-identical
-at the shared chain seam; storage-engine migrations cannot silently rewrite historical records.
+reader ordering are compatibility contracts. Server SQLite and KB PostgreSQL must produce byte-identical
+canonical row hashes at the shared row-hash seam; storage-engine migrations cannot silently rewrite
+historical records. The checkpoint-MAC contract remains a separate compatibility boundary.
 
 ## Extension and removal
 

--- a/docs/validation/core-modularization-slice-34.md
+++ b/docs/validation/core-modularization-slice-34.md
@@ -1,0 +1,97 @@
+# Core modularization slice 34: complete audit ownership
+
+## Scope
+
+This slice marks the required `audit` descriptor `ownership_complete: true`. Slices 23 and 24 already
+moved the implementation and public contracts into `src/modules/audit` and assigned the four direct
+tests. This slice proves that the descriptor exhaustively covers the validator's module-local C and
+private-header domain, requires the canonical document, and records the audited public headers and direct
+tests. It changes metadata, validation, documentation, and cleanup accounting only; no production code,
+public symbol, build membership, configuration, storage, or runtime behavior changes.
+
+## Source liveness and ownership
+
+Make's `CORE_SRCS` compiles all four descriptor-owned sources:
+
+- `audit_action.c`: governed-action hashes and bounded command previews are called by
+  `modules/guardrails/guardrails_action_audit.c`; key provisioning is called by `cmd_hooks.c` and
+  `server/server_main.c`.
+- `audit_ledger.c`: `audit_ledger_read` is called by `trajectory_export.c` and `server/server_state.c`.
+- `audit_worm.c`: append, read, verify, checkpoint, seal, and metric paths are called by guardrails,
+  `cmd_audit.c`, server state/management, and KB vault operations.
+- `audit_worm_chain.c`: the SQLite store consumes its canonical hashing and checkpoint primitives, while
+  `db2/kb_audit_worm.c` consumes `audit_worm_row_hash` for byte-identical PostgreSQL rows.
+
+Make derives `KB_CORE_SRCS` from `CORE_SRCS` but removes `audit_worm.c`, the SQLite store, while retaining
+the engine-independent chain for the separate DB2 PostgreSQL implementation. CMake's `CORE_SRCS` contains
+only `audit_action.c` and `audit_ledger.c`; that list feeds `aimee-core`, `SERVER_CORE_SRCS`, and
+`KB_CORE_SRCS`. CMake therefore does not currently ship either WORM source. This pre-existing target
+asymmetry is documented rather than silently normalized in an ownership-only slice: the descriptor owns
+canonical implementations, while build projections decide which product compiles them.
+
+Whole-tree tracked-file and symbol searches classify adjacent audit-named files as consumers,
+server/KB storage composition, or separate code-intelligence, token-accounting, memory-harness, and
+integration-test boundaries. None implements a second governed-action hash, legacy ledger reader,
+SQLite WORM store, or canonical chain algorithm.
+
+## DRY and dead-code findings
+
+No complete module source is self-tested-only. Exact caller searches identify these public declarations
+without an external shipping caller:
+
+- `audit_hmac_sha256_testonly` is an explicit unit-test hook;
+- `audit_worm_init_at`, `audit_worm_count`, and `audit_worm_close` are test/embedding or introspection
+  contracts used by `test_audit_worm.c`;
+- `audit_worm_verify_file` currently has only `test_audit_worm.c` callers;
+- `audit_worm_verify_chain` is called inside `audit_worm.c` and directly by its test;
+- `audit_worm_hex32`, `audit_worm_ckpt_mac`, and `audit_worm_chain_key_load` are module-internal helpers,
+  with direct vector coverage for the first two.
+
+These are focused public-surface privatization, activation, or deletion candidates. Their containing
+sources remain live, and changing linkage or removing intended embedding/verification contracts requires
+a separate compatibility decision.
+
+## Regression controls
+
+The descriptor mutation suite removes `audit_action.c`, `audit_worm.c`, and `audit_worm_chain.c`
+individually; each omission must fail `rule=ownership-complete` on `/sources`. It also plants
+`src/modules/audit/undeclared.c` and `undeclared.h`, which must fail the same rule on `/sources` and
+`/private_headers`, and removes `docs/modules/audit.md` from the descriptor's `docs` field, which must
+fail it on `/docs`. The unmodified 26-descriptor graph must pass.
+
+## Verification
+
+Run the locally available checks from the repository root; each command must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_header_layout.py
+python3 -m unittest scripts.tests.test_check_module_header_layout
+python3 scripts/check_module_source_ownership.py
+python3 -m unittest scripts.tests.test_check_module_source_ownership
+python3 -m unittest scripts.tests.test_check_module_docs \
+  scripts.tests.test_check_cleanup_ledger scripts.tests.test_refactor_baselines
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-audit-worm \
+  build/obj/tests/unit-test-audit-worm-chain
+src/build/obj/tests/unit-test-audit-worm
+src/build/obj/tests/unit-test-audit-worm-chain
+```
+
+The local environment used for this slice does not provide `cmake`. In a CMake-capable environment, and
+in the required pull-request CMake job, configure and execute the two registered direct tests with:
+
+```sh
+cmake -S . -B build/cmake-slice34 -DAIMEE_WITH_UI=OFF
+cmake --build build/cmake-slice34 --target test_audit_action test_audit_ledger -j2
+ctest --test-dir build/cmake-slice34 \
+  -R '^(test_audit_action|test_audit_ledger)$' --output-on-failure
+```
+
+Technical-writer review, exact-final-diff roundtable approval, and every required pull-request check,
+including Windows CMake, are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -263,6 +263,9 @@ class DescriptorTests(unittest.TestCase):
             ("skills", "sources", "src/modules/skills/skill.c"),
             ("skills", "sources", "src/modules/skills/skill_rollback.c"),
             ("skills", "sources", "src/modules/skills/skill_review.c"),
+            ("audit", "sources", "src/modules/audit/audit_action.c"),
+            ("audit", "sources", "src/modules/audit/audit_worm.c"),
+            ("audit", "sources", "src/modules/audit/audit_worm_chain.c"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -281,7 +284,7 @@ class DescriptorTests(unittest.TestCase):
             finally:
                 tmp.cleanup()
 
-        for identifier in ("roundtable", "protocols", "ir", "translation", "skills"):
+        for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -300,7 +303,7 @@ class DescriptorTests(unittest.TestCase):
                     tmp.cleanup()
 
     def test_complete_ownership_requires_canonical_doc(self) -> None:
-        for identifier in ("roundtable", "ir", "translation", "skills"):
+        for identifier in ("roundtable", "ir", "translation", "skills", "audit"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/audit/module.yaml
+++ b/src/modules/audit/module.yaml
@@ -9,6 +9,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/audit/audit_action.c",
     "src/modules/audit/audit_ledger.c",

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -435,6 +435,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, stored data, or runtime behavior changes; descriptor validation gains skills-specific missing-source, planted-source/header, and missing-document failures.",
       "independent_review": "The slice decision roundtable approved the bounded ownership-completion plan without findings; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-33.md", "docs/modules/skills.md", "src/modules/skills/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 34,
+      "state": "present_and_verified",
+      "disposition": "Completed the validator-enforced required-core audit module-root ownership domain after proving all four sources have shipping Make consumers, recording the four canonical public headers and four direct tests, and documenting the narrower existing CMake membership and test-facing API candidates.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["CMake retains its pre-existing action-and-ledger-only audit source membership while Make ships the full server WORM store and the chain source used for canonical KB row hashing", "Make and CMake remain separately maintained build inventories", "nine test-facing, embedding, verification, or internal helper exports remain pending focused compatibility review"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Filesystem enumeration alone would hide the CMake capability gap, the shared KB row-hash consumer, and public helpers whose tests do not establish external production use.",
+        "revisit": "Resolve CMake WORM capability intentionally, then privatize, activate, or delete test-facing and module-internal exports in a focused API slice."
+      },
+      "consumers": ["guardrails and execution policy", "audit CLI and server management", "trajectory export", "KB vault operations", "DB2 PostgreSQL WORM storage", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains audit-specific missing-source, planted-source/header, and missing-document failures.",
+      "independent_review": "The decision roundtable required the exact diff, concrete Make/CMake membership, enumerated API candidates, and named mutations before approval; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-34.md", "docs/modules/audit.md", "src/modules/audit/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- complete the validator-enforced required-core audit module-root ownership domain
- document exact Make/CMake target asymmetry and the KB canonical row-hash seam without changing build membership
- add named liveness/dead-code/API evidence plus reusable descriptor mutations and cleanup accounting

## Validation
- technical writer: approved after boundary precision corrections
- exact-final-diff roundtable: approved with no findings
- descriptor validator and 38 descriptor tests
- 59 module ownership/docs/ledger/refactor mutation tests
- audit WORM and chain binaries
- full Make build and lint
- PR Windows-CMake check required because local cmake is unavailable

No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.