### PR TITLE
refactor(module-runtime): complete module ownership

### DIFF
--- a/docs/modules/module-runtime.md
+++ b/docs/modules/module-runtime.md
@@ -28,12 +28,29 @@ the shared logging primitive. Production consumers include `src/server/agent_run
 optional plugin-loader contract; focused consumers are `src/tests/test_plugin.c` and
 `src/tests/test_plugin_c_hook.c`.
 
+Consumption is asymmetric by design. The host tree consumes the pre-LLM registry only as a reader:
+`src/server/agent_runtime.c` calls `plugin_chook_apply_pre_llm` per turn, and no host-side source
+calls `plugin_chook_register_pre_llm`. The registration entry points are producer-facing ABI for
+in-process extensions, so an unfired hook path in a plain host build is the expected state, not a
+defect. The same holds for the typed registries: `plugin_ctx_t`'s `register_*` callbacks are
+reachable only from a loaded extension's `register()` entry point. Removing or privatizing those
+producer-facing exports is therefore an extension-compatibility decision, not a dead-code cleanup.
+
 As the ownership-descriptor pilot, `module.yaml` also declares this module's two implementation
 sources, two public headers, focused C-hook test, and canonical module document. The descriptor
 validator rejects symlinked paths before claiming them and rejects duplicate normalized lexical
 paths within or across descriptors, then emits a deterministic declared-ownership report. Build
 inputs are still maintained by Make and CMake in this slice; descriptor-driven build generation
 remains a later step, so these ownership fields are documentation and validation only.
+
+The descriptor sets `ownership_complete: true`. That latch exhaustively checks the module-local C
+and private-header files — the module has no private headers — and requires this canonical
+document. Public-header and test entries are explicit audited claims, not auto-discovered
+completeness domains, so the latch does not police the public-header inventory. Completeness is a
+statement about file ownership only: it does not assert that every owned public facility has a
+host-side caller, nor that every declared test runs in every build system. The source liveness,
+build and test membership, adjacent-boundary, and public-surface audit is recorded in
+`docs/validation/core-modularization-slice-35.md`.
 
 Until generation replaces those lists, optional-module build selection is an explicit composition
 contract: both build systems define the same `AIMEE_WITH_<MODULE>` feature macro, omit owner-private
@@ -97,6 +114,17 @@ and populates these required registries rather than creating a parallel registry
 empty state, ordering, error/empty results, bounded capacity, reset, count, and per-turn message
 application. Null or excess registrations fail; a failing callback is skipped and later callbacks
 still run. Output is bounded by the caller-provided buffer.
+
+The descriptor claims only `src/tests/test_plugin_c_hook.c`. `src/tests/test_plugin.c` stays owned by
+[plugin-loader](plugin-loader.md), because its primary subject is loader integration; it is
+complementary coverage of `extension.c` rather than a second owner, and a test is never claimed
+twice. It is nonetheless the only current coverage of the extension context and typed registries.
+
+Test registration is not uniform across build systems. Make registers `unit-test-plugin-c-hook`
+in `src/tests/Rules.mk`; CMake registers no module-runtime test target, so the declared test runs
+only under the Make suite even though both build systems compile both sources. That is recorded
+follow-up debt with a concrete target — CTest must execute the pre-LLM hook test — and is a
+build-membership change rather than an ownership one.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-35.md
+++ b/docs/validation/core-modularization-slice-35.md
@@ -1,0 +1,168 @@
+# Core modularization slice 35: complete module-runtime ownership
+
+## Scope
+
+This slice marks the required `module-runtime` descriptor `ownership_complete: true`. Earlier slices
+already moved the extension ABI and the pre-LLM hook registry into `src/modules/module-runtime`,
+established the canonical public headers, and made this module the ownership-descriptor pilot. This
+slice proves that the descriptor exhaustively covers the validator's module-local C and
+private-header domain, requires the canonical document, and records the audited public headers,
+direct test, build and test membership, and public-surface liveness. It changes metadata,
+validation, documentation, and cleanup accounting only; no production code, public symbol, build
+membership, configuration, storage, or runtime behavior changes.
+
+## Ownership domain
+
+The validator's completeness domain is every module-local file whose suffix matches the `sources` or
+`private_headers` role, excluding `module.yaml` and everything under
+`src/modules/module-runtime/include/aimee/module-runtime/`. The module root contains exactly
+`extension.c`, `pre_llm_hook.c`, `module.yaml`, and the two canonical public headers. There are no
+private headers, so the declared source set already equals the actual set and the latch is exact on
+the checked-in tree. The descriptor's `docs` field equals `["docs/modules/module-runtime.md"]`, as
+the latch requires.
+
+Completeness is a file-ownership statement. It does not assert that every owned public facility has
+a host-side caller, that every declared test runs in every build system, or that the public-header
+inventory is auto-verified; public headers and tests remain explicit audited claims.
+
+## Source liveness and ownership
+
+Both descriptor-owned sources are compiled by both build systems, so this module has no source
+membership asymmetry:
+
+- Make's `CORE_SRCS` in `src/Makefile` lists `modules/module-runtime/extension.c` and
+  `modules/module-runtime/pre_llm_hook.c`, and `C_FLAGS` adds `-Imodules/module-runtime/include`.
+- CMake lists both sources in `CORE_SRCS` and adds the same include root.
+
+- `extension.c` supplies the extension ABI. `plugin_ctx_create` and `plugin_ctx_destroy` are called
+  by `src/modules/plugin-loader/plugin.c`; `plugin_kind_name` is called by `src/cmd_plugin.c` and
+  the loader; `plugin_kind_from_str` and `plugin_permission_from_str` are called by the loader; and
+  `plugin_permission_name` is called by the loader and by
+  `src/modules/protocols/mcp/mcp_tools.c`.
+- `pre_llm_hook.c` supplies the synchronous PRE_LLM_CALL registry. `plugin_chook_apply_pre_llm` is
+  called once per request by `src/server/agent_runtime.c`, which appends any returned ephemeral
+  context to the user message and never to the system prompt.
+
+Whole-tree tracked-file and symbol searches find no second extension-context implementation, typed
+registry, or pre-LLM hook registry. `src/headers/context_engine.h` documents registration through
+`plugin_ctx_t->register_context_engine` and is a consumer-side contract, not a competing registry.
+
+## Producer-facing surface and liveness findings
+
+The module's registration entry points are producer-facing ABI: they exist for in-process extensions
+loaded by plugin-loader, so the absence of a host-side caller is the expected state rather than dead
+code. The audit records which side of that boundary each export sits on.
+
+Reader side, with tracked host-side callers:
+
+- `plugin_chook_apply_pre_llm` — `src/server/agent_runtime.c`.
+- `plugin_kind_name`, `plugin_kind_from_str`, `plugin_permission_name`,
+  `plugin_permission_from_str`, `plugin_ctx_create`, `plugin_ctx_destroy` — plugin-loader, the
+  plugin CLI, and MCP tool projection as listed above.
+
+Producer side, with no host-side caller in the tracked tree:
+
+- `plugin_chook_register_pre_llm` has no host-side caller; its only tracked callers are in
+  `src/tests/test_plugin_c_hook.c`. A host build therefore starts with an empty registry, and the
+  per-request `plugin_chook_apply_pre_llm` call returns `NULL` until a loaded extension registers a
+  hook through the exported API. This is a producer/consumer asymmetry, not proof that the code is
+  unreachable: the export is part of the extension ABI and a dynamically loaded plugin can call it.
+- The `plugin_ctx_t` `register_*` callbacks are installed by `plugin_ctx_create` but invoked only
+  from a loaded extension's `register()` entry point.
+
+Helper exports with no host-side caller: `plugin_chook_reset` is an explicit test hook and
+`plugin_chook_pre_llm_count` is an introspection accessor; both are called only by
+`src/tests/test_plugin_c_hook.c`. `plugin_chook_run_pre_llm` is different in kind: it is the
+internal implementation that `plugin_chook_apply_pre_llm` runs on every request, and it is
+additionally exported so the test can drive it directly with its own output buffer. It is on the
+live production path even though no host-side source calls it by name.
+
+Typed registry state, audited individually:
+
+- `plugin_slash_commands` and `plugin_slash_command_count` are written by
+  `src/modules/plugin-loader/plugin.c` from manifest data and are read only by
+  `src/tests/test_plugin.c`. In production they are write-only.
+- `plugin_delegate_backend_count`, `plugin_platform_adapter_count`, `plugin_context_engine_count`,
+  and `plugin_memory_provider_count` are read by exactly one loader `LOG_INFO` registration summary.
+- `plugin_memory_providers` and `plugin_context_engines` are never written by any tracked code. The
+  loader installs `loader_register_memory_provider` and `loader_register_context_engine` bridges
+  that route to `memory_provider_register` and `context_engine_register` instead, so the two counts
+  reported by that log line are always zero.
+- `plugin_tools`, `plugin_tool_count`, `plugin_hooks`, `plugin_hook_count`,
+  `plugin_cli_subcommands`, `plugin_cli_subcommand_count`, `plugin_model_providers`, and
+  `plugin_model_provider_count` have no non-test reader. MCP plugin-tool exposure does not read the
+  global registry: `src/modules/protocols/mcp/mcp_tools.c` calls the loader's
+  `plugin_collect_tools` over per-plugin manifest data.
+
+These are focused candidates for privatization, activation, deletion, or bridge alignment. Every one
+of them is either exported extension ABI or state written by the optional loader, so changing them
+alters the extension contract and requires a separate compatibility decision. Their containing
+sources remain live.
+
+## Test membership
+
+`src/tests/test_plugin_c_hook.c` is the module's declared direct test and covers empty state,
+ordering, error and empty hook results, bounded capacity, reset, count, null and excess
+registration rejection, the user-message argument, and per-turn application.
+
+`src/tests/test_plugin.c` remains declared by plugin-loader. Its primary subject is loader
+integration, and a test is never claimed by two descriptors; it is complementary coverage of
+`extension.c` — context lifecycle, kind and permission conversion, and the tool, hook, and
+slash-command registries — and is currently the only coverage of those extension surfaces.
+
+Build systems do not register tests uniformly. Make registers `unit-test-plugin-c-hook` in
+`src/tests/Rules.mk`; CMake registers no module-runtime test target, so the declared test executes
+only in the Make suite. This is pre-existing test-execution debt with a concrete verification
+target — CTest must execute the pre-LLM hook test — and is deferred to a build-membership slice
+because it changes build inputs rather than file ownership.
+
+## Regression controls
+
+The descriptor mutation suite removes `extension.c` and `pre_llm_hook.c` individually; each omission
+must fail `rule=ownership-complete` on `/sources`. It plants
+`src/modules/module-runtime/undeclared.c` and `undeclared.h`, which must fail the same rule on
+`/sources` and `/private_headers`. It removes `docs/modules/module-runtime.md` from the descriptor's
+`docs` field, which must fail that rule on `/docs`. A new assertion requires every latched
+descriptor, including `module-runtime`, to still declare `ownership_complete: true`, so silently
+clearing the latch fails directly instead of only weakening the mutation assertions. The unmodified
+descriptor graph must pass. These controls cover the module-local source and private-header domain
+and the canonical document; they do not police the public-header inventory, which the validator
+checks only as declared paths.
+
+## Verification
+
+Run the locally available checks from the repository root; each command must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_header_layout.py
+python3 -m unittest scripts.tests.test_check_module_header_layout
+python3 scripts/check_module_source_ownership.py
+python3 -m unittest scripts.tests.test_check_module_source_ownership
+python3 -m unittest scripts.tests.test_check_module_docs \
+  scripts.tests.test_check_cleanup_ledger scripts.tests.test_refactor_baselines
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-plugin-c-hook build/obj/tests/unit-test-plugin
+src/build/obj/tests/unit-test-plugin-c-hook
+src/build/obj/tests/unit-test-plugin
+```
+
+The local environment used for this slice does not provide `cmake`. In a CMake-capable environment,
+and in the required pull-request CMake job, confirm that both module-runtime sources still compile
+into the core library:
+
+```sh
+cmake -S . -B build/cmake-slice35 -DAIMEE_WITH_UI=OFF
+cmake --build build/cmake-slice35 --target aimee-core -j2
+```
+
+CMake registers no module-runtime test target, so there is no CTest selector to run for this module
+until the deferred test-registration slice lands.
+
+Technical-writer review, exact-final-diff roundtable approval, and every required pull-request
+check, including Windows CMake, are required before merge.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -266,6 +266,8 @@ class DescriptorTests(unittest.TestCase):
             ("audit", "sources", "src/modules/audit/audit_action.c"),
             ("audit", "sources", "src/modules/audit/audit_worm.c"),
             ("audit", "sources", "src/modules/audit/audit_worm_chain.c"),
+            ("module-runtime", "sources", "src/modules/module-runtime/extension.c"),
+            ("module-runtime", "sources", "src/modules/module-runtime/pre_llm_hook.c"),
         )
         for identifier, field, relative in cases:
             tmp = self.production_repo()
@@ -284,7 +286,8 @@ class DescriptorTests(unittest.TestCase):
             finally:
                 tmp.cleanup()
 
-        for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit"):
+        for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
+                           "module-runtime"):
             for name in ("undeclared.c", "undeclared.h"):
                 tmp = self.production_repo()
                 try:
@@ -302,8 +305,21 @@ class DescriptorTests(unittest.TestCase):
                 finally:
                     tmp.cleanup()
 
+    def test_latched_descriptors_declare_complete_ownership(self) -> None:
+        """The latch itself is the control; mutation coverage below assumes it stays set."""
+        for identifier in ("roundtable", "protocols", "ir", "translation", "skills", "audit",
+                           "module-runtime"):
+            descriptor = json.loads(
+                (REPO_ROOT / "src/modules" / identifier / "module.yaml").read_text(
+                    encoding="utf-8"
+                )
+            )
+            with self.subTest(identifier=identifier):
+                self.assertIs(descriptor.get("ownership_complete"), True)
+
     def test_complete_ownership_requires_canonical_doc(self) -> None:
-        for identifier in ("roundtable", "ir", "translation", "skills", "audit"):
+        for identifier in ("roundtable", "ir", "translation", "skills", "audit",
+                           "module-runtime"):
             tmp = self.production_repo()
             try:
                 repo = Path(tmp.name)

--- a/src/modules/module-runtime/module.yaml
+++ b/src/modules/module-runtime/module.yaml
@@ -5,6 +5,7 @@
   "runtime_toggle": {
     "supported": false
   },
+  "ownership_complete": true,
   "sources": [
     "src/modules/module-runtime/extension.c",
     "src/modules/module-runtime/pre_llm_hook.c"

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -452,6 +452,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains audit-specific missing-source, planted-source/header, and missing-document failures.",
       "independent_review": "The decision roundtable required the exact diff, concrete Make/CMake membership, enumerated API candidates, and named mutations before approval; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-34.md", "docs/modules/audit.md", "src/modules/audit/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 35,
+      "state": "present_and_verified",
+      "disposition": "Completed the validator-enforced required-core module-runtime module-root ownership domain after confirming both sources are listed in the Make and CMake core source sets and locally compiling the Make build, recording the two canonical public headers and the single direct test, separating producer-facing extension ABI from host-side readers, and documenting the CMake test-registration gap and the typed-registry liveness gaps. CMake compilation remains pending the required pull-request CMake job.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["CMake registers no module-runtime test target, so the declared pre-LLM hook test executes only in the Make suite; the concrete follow-up target is CTest executing that test", "Make and CMake remain separately maintained build inventories", "producer-facing extension ABI including plugin_chook_register_pre_llm and the plugin_ctx_t register_* callbacks has no host-side caller and remains pending a focused extension-compatibility review", "plugin_memory_providers and plugin_context_engines are never written because the loader routes registration through its own memory and context-engine bridges, and plugin_slash_commands is written but never read outside tests"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes ownership metadata, validation coverage, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Filesystem enumeration alone would hide the CMake test-registration gap, the plugin-loader-owned complementary coverage of extension.c, and the difference between exported extension ABI awaiting a producer and genuinely dead code.",
+        "revisit": "Register the module-runtime test in CMake, then align or retire the unwritten registry bridges and decide the producer-facing export surface in a focused extension-compatibility slice."
+      },
+      "consumers": ["plugin-loader", "server agent runtime pre-LLM path", "plugin CLI", "MCP tool projection", "future descriptor-generated builds"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains module-runtime-specific missing-source, planted-source/header, and missing-document failures plus a latch-cleared failure across every complete descriptor.",
+      "independent_review": "The decision roundtable approved the ownership-only structure and required one correction: the producer-facing pre-LLM registration surface must not be described as unreachable in production, because a dynamically loaded extension can call the exported API. The correction is applied in the module and validation documents; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-35.md", "docs/modules/module-runtime.md", "src/modules/module-runtime/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 35. Sets `ownership_complete: true` on the required `module-runtime` descriptor.

## What changes

- `src/modules/module-runtime/module.yaml`: `ownership_complete: true`. The module root contains exactly `extension.c`, `pre_llm_hook.c`, `module.yaml`, and the two canonical public headers, and has no private headers, so the validator's completeness domain is exact on the checked-in tree.
- `scripts/tests/test_validate_module_descriptors.py`: module-runtime source-removal mutations for both sources, planted `undeclared.c` / `undeclared.h`, and the missing-canonical-doc case. Adds an explicit assertion that every latched descriptor still declares `ownership_complete: true`, so silently clearing the latch fails directly instead of only weakening the mutation assertions.
- `docs/modules/module-runtime.md` and new `docs/validation/core-modularization-slice-35.md`: the audit record.
- `tests/baselines/refactor/cleanup-ledger.json`: slice 35 entry.

Metadata, validation, documentation, and cleanup accounting only. No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

## Audit findings recorded

- **No source membership asymmetry**, unlike slice 34: Make's `CORE_SRCS` and CMake's `CORE_SRCS` both compile both sources.
- **Test registration asymmetry**: Make registers `unit-test-plugin-c-hook`; CMake registers no module-runtime test target, so the declared test runs only under Make. Deferred as build-membership debt with a concrete target — CTest must execute the pre-LLM hook test.
- **Producer vs. reader surface**: `src/server/agent_runtime.c` calls `plugin_chook_apply_pre_llm` per request, and no host-side source calls `plugin_chook_register_pre_llm`. The registration entry points and the `plugin_ctx_t` `register_*` callbacks are producer-facing ABI for in-process extensions, so an unfired hook path in a plain host build is expected. This is explicitly *not* recorded as dead or unreachable code; changing those exports is an extension-compatibility decision.
- **Typed registry liveness gaps**: `plugin_slash_commands` is written by plugin-loader and read only by tests; four counts are read by a single loader `LOG_INFO`; `plugin_memory_providers` and `plugin_context_engines` are never written at all because the loader routes registration through its own bridges; the remaining registries have no non-test reader. MCP plugin-tool projection uses `plugin_collect_tools` over manifest data, not the global registry.
- **Test ownership**: `src/tests/test_plugin.c` stays owned by plugin-loader as complementary coverage of `extension.c`, not claimed twice.

## Validation

All local checks pass: descriptor schema and validation, all descriptor/doc/ledger/header-layout/source-ownership unit suites, `refactor_baselines.py check`, `make -C src`, `make -C src lint`, and both `unit-test-plugin-c-hook` and `unit-test-plugin`. `cmake` is unavailable locally; CMake compilation is covered by the required PR jobs.

Slice-decision roundtable approved the ownership-only structure and required one correction (do not describe the producer-facing pre-LLM surface as unreachable in production), which is applied. Technical-writer review raised three documentation findings, all fixed. The exact-final-diff roundtable returned no issues.