### PR TITLE
fix(modularization): correct slice 35/36 CTest registration claims

### DIFF
--- a/.github/workflows/module-inventory.yml
+++ b/.github/workflows/module-inventory.yml
@@ -86,6 +86,10 @@ jobs:
         run: python3 -I -S scripts/check_module_docs.py
       - name: Test module-documentation failure modes
         run: python3 -I scripts/tests/test_check_module_docs.py -v
+      - name: Enforce descriptor-declared module test registration
+        run: python3 -I -S scripts/check_module_test_registration.py
+      - name: Test module test-registration failure modes
+        run: python3 -I scripts/tests/test_check_module_test_registration.py -v
 
   git-core-contract:
     name: git-core-contract

--- a/docs/modules/module-runtime.md
+++ b/docs/modules/module-runtime.md
@@ -120,11 +120,12 @@ The descriptor claims only `src/tests/test_plugin_c_hook.c`. `src/tests/test_plu
 complementary coverage of `extension.c` rather than a second owner, and a test is never claimed
 twice. It is nonetheless the only current coverage of the extension context and typed registries.
 
-Test registration is not uniform across build systems. Make registers `unit-test-plugin-c-hook`
-in `src/tests/Rules.mk`; CMake registers no module-runtime test target, so the declared test runs
-only under the Make suite even though both build systems compile both sources. That is recorded
-follow-up debt with a concrete target — CTest must execute the pre-LLM hook test — and is a
-build-membership change rather than an ownership one.
+Both build systems register the declared test. Make builds `unit-test-plugin-c-hook` from
+`src/tests/Rules.mk`, and `src/tests/CMakeLists.txt` registers `test_plugin_c_hook` as a CTest case.
+`scripts/check_module_test_registration.py` derives that from the build files, bound to the
+declared source path rather than to a target name, and pins it to
+`tests/baselines/refactor/module-test-registration.json`, so a change in build-file registration
+fails until the baseline is regenerated and re-reviewed.
 
 ## Operational diagnostics
 

--- a/docs/modules/plugin-loader.md
+++ b/docs/modules/plugin-loader.md
@@ -122,11 +122,13 @@ module-runtime's focused ownership remains `src/tests/test_plugin_c_hook.c`.
 here.
 
 Test registration is not uniform across build systems. Make registers `unit-test-plugin` and
-`unit-test-plugin-loader` in `src/tests/Rules.mk`; neither is registered with CTest, so Make's is
-the only tracked build registration that runs them, even though both build systems compile both
-sources under the feature flag. That is recorded follow-up debt with a concrete target — CTest must
-execute both plugin tests in an enabled profile — and is a build-membership change rather than an
-ownership one.
+`unit-test-plugin-loader` in `src/tests/Rules.mk`; `src/tests/CMakeLists.txt` registers
+`test_plugin_loader` as a CTest case but not `test_plugin`, which therefore runs only under Make.
+That single gap is recorded follow-up debt with a concrete target — CTest must also execute
+`test_plugin` — and is a build-membership change rather than an ownership one.
+`scripts/check_module_test_registration.py` pins each declared test's build-file registration to a
+reviewed baseline, binding it to the declared source path rather than to a target name, so a change
+surfaces as a baseline diff.
 
 ## Operational diagnostics
 

--- a/docs/validation/core-modularization-slice-35.md
+++ b/docs/validation/core-modularization-slice-35.md
@@ -110,11 +110,18 @@ integration, and a test is never claimed by two descriptors; it is complementary
 `extension.c` — context lifecycle, kind and permission conversion, and the tool, hook, and
 slash-command registries — and is currently the only coverage of those extension surfaces.
 
-Build systems do not register tests uniformly. Make registers `unit-test-plugin-c-hook` in
-`src/tests/Rules.mk`; CMake registers no module-runtime test target, so the declared test executes
-only in the Make suite. This is pre-existing test-execution debt with a concrete verification
-target — CTest must execute the pre-LLM hook test — and is deferred to a build-membership slice
-because it changes build inputs rather than file ownership.
+Both build systems register the declared test. Make builds `unit-test-plugin-c-hook` from
+`src/tests/Rules.mk`, and `src/tests/CMakeLists.txt` registers `test_plugin_c_hook` as a CTest case.
+
+> **Correction (slice 37).** As merged, this section and the verification note below claimed that
+> CMake registered no module-runtime test target and that the declared test executed only in the
+> Make suite. That was wrong. The audit read only the top-level `CMakeLists.txt` and missed
+> `src/tests/CMakeLists.txt`, which `add_subdirectory(src/tests)` pulls in and which registers
+> `test_plugin_c_hook`. Slice 37 corrected the text and added
+> `scripts/check_module_test_registration.py`, which derives per-test registration from the build
+> files and pins it to `tests/baselines/refactor/module-test-registration.json`, so a future change
+> in registration surfaces as a reviewed baseline diff instead of being rediscovered by hand. No other finding in this document depended on the mistaken claim, and the ownership latch
+> is unaffected.
 
 ## Regression controls
 
@@ -161,8 +168,13 @@ cmake -S . -B build/cmake-slice35 -DAIMEE_WITH_UI=OFF
 cmake --build build/cmake-slice35 --target aimee-core -j2
 ```
 
-CMake registers no module-runtime test target, so there is no CTest selector to run for this module
-until the deferred test-registration slice lands.
+The declared test is also a registered CTest case. Configuring registers it but does not build it,
+so build the test target before invoking CTest:
+
+```sh
+cmake --build build/cmake-slice35 --target test_plugin_c_hook -j2
+ctest --test-dir build/cmake-slice35 -R '^test_plugin_c_hook$' --output-on-failure
+```
 
 Technical-writer review, exact-final-diff roundtable approval, and every required pull-request
 check, including Windows CMake, are required before merge.

--- a/docs/validation/core-modularization-slice-36.md
+++ b/docs/validation/core-modularization-slice-36.md
@@ -117,15 +117,24 @@ tool aggregation, conflict checks, discovery precedence, capacity, required-envi
 and project gating.
 
 Build systems do not register tests uniformly. Make registers `unit-test-plugin` and
-`unit-test-plugin-loader` in `src/tests/Rules.mk`; neither is registered with CTest. So the only
-tracked build registration that runs them is Make's, even though both build systems compile both
-sources under the feature flag. Nothing prevents another script or a direct invocation from
-building and running the binaries — the verification section below does exactly that — but no CMake
-target selects them. This is pre-existing test-registration debt with a concrete verification
-target —
-CTest must execute both plugin tests in an enabled profile — and is deferred to a build-membership
-slice because it changes build inputs rather than file ownership. It is the same gap recorded for
-module-runtime in `docs/validation/core-modularization-slice-35.md`.
+`unit-test-plugin-loader` in `src/tests/Rules.mk`; `src/tests/CMakeLists.txt` registers
+`test_plugin_loader` as a CTest case but not `test_plugin`, which therefore runs only under Make.
+
+> **Correction (slice 37).** As merged, this section and the verification note below claimed that
+> neither plugin test was registered with CTest. That was wrong for `test_plugin_loader`, which
+> `src/tests/CMakeLists.txt` registers with an explicit `add_executable` plus `add_test`. The audit
+> read only the top-level `CMakeLists.txt` and missed the test subdirectory. The remaining gap is
+> real but narrower than recorded: `test_plugin` alone lacks CTest registration. Slice 37 corrected
+> the text and added `scripts/check_module_test_registration.py`, which pins per-test build-file
+> registration to a reviewed baseline. No other finding in this document depended on the
+> mistaken claim, and the ownership latch is unaffected.
+
+This remaining single-test gap is pre-existing test-registration debt with a concrete verification
+target — CTest must also execute `test_plugin` in an enabled profile — and is deferred to a
+build-membership slice because it changes build inputs rather than file ownership.
+`scripts/check_module_test_registration.py` pins the build-file registration of every
+descriptor-declared test, bound to the declared source path rather than to a target name, so a
+change to this gap surfaces as a baseline diff.
 
 ## Regression controls
 
@@ -176,9 +185,16 @@ cmake -S . -B build/cmake-slice36 -DAIMEE_WITH_UI=OFF -DAIMEE_WITH_PLUGIN_LOADER
 cmake --build build/cmake-slice36 --target aimee-core -j2
 ```
 
-CMake registers no plugin test target, so there is no CTest selector to run for this module until
-the deferred test-registration slice lands. The omitted-profile proof remains the
-`plugin-loader-profiles` CI job.
+`test_plugin_loader` is a registered CTest case. Configuring registers it but does not build it, so
+build the test target before invoking CTest:
+
+```sh
+cmake --build build/cmake-slice36 --target test_plugin_loader -j2
+ctest --test-dir build/cmake-slice36 -R '^test_plugin_loader$' --output-on-failure
+```
+
+`test_plugin` has no CTest selector until the deferred test-registration slice lands. The
+omitted-profile proof remains the `plugin-loader-profiles` CI job.
 
 Technical-writer review, exact-final-diff roundtable approval, and every required pull-request
 check, including Windows CMake, are required before merge.

--- a/scripts/check_module_test_registration.py
+++ b/scripts/check_module_test_registration.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Report which build systems register each descriptor-declared module test.
+
+Slices 35 and 36 recorded, in prose, that CMake registered no test target for
+module-runtime and plugin-loader. That was wrong: the audit read only the
+top-level CMakeLists.txt and missed src/tests/CMakeLists.txt, which
+add_subdirectory() pulls in and which registers most CTest cases. Prose alone
+cannot keep that straight, so registration is derived from the build files
+themselves and pinned to a baseline: any change to what Make and CTest
+statically register for a declared test fails until the baseline is regenerated
+and re-reviewed.
+
+Registration is bound to the declared source *path*, not to a matching target
+name. A CTest case counts only when the executable named by its COMMAND is built
+from the descriptor-declared file, so re-pointing a registered target at another
+source — even one with the same basename in a different directory — is drift.
+
+This reports registration, not execution. It says what the build files declare,
+not that any suite ran the test, and it does not read documentation, so prose can
+still describe an unchanged baseline incorrectly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULES = Path("src/modules")
+TESTS_DIR = "src/tests"
+CMAKE_TESTS = Path(f"{TESTS_DIR}/CMakeLists.txt")
+MAKE_RULES = Path(f"{TESTS_DIR}/Rules.mk")
+BASELINE = Path("tests/baselines/refactor/module-test-registration.json")
+
+# aimee_add_test(<name> <sources...>) wraps add_executable + add_test; the
+# hand-written form is add_executable(<name> <sources...>) plus
+# add_test(NAME <case> COMMAND <target> ...).
+CALL = re.compile(r"\b(aimee_add_test|add_executable|add_test)\s*\(")
+# CMake bracket comments (#[[ ... ]], #[=[ ... ]=]) span lines, so strip them
+# before ordinary line comments — otherwise their contents tokenize as arguments.
+BRACKET_COMMENT = re.compile(r"#\[(=*)\[.*?\]\1\]", re.DOTALL)
+LINE_COMMENT = re.compile(r"#[^\n]*")
+
+
+class RegistrationError(ValueError):
+    """A closed, operator-readable registration validation failure."""
+
+
+def _read(root: Path, relative: Path) -> str:
+    path = root / relative
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RegistrationError(f"cannot read {relative.as_posix()}: {exc}") from exc
+
+
+def _calls(text: str) -> list[tuple[str, list[str]]]:
+    """(command, argument tokens) per recognized call, comments stripped."""
+    text = LINE_COMMENT.sub("", BRACKET_COMMENT.sub("", text))
+    found: list[tuple[str, list[str]]] = []
+    for match in CALL.finditer(text):
+        depth, index = 1, match.end()
+        while index < len(text) and depth:
+            if text[index] == "(":
+                depth += 1
+            elif text[index] == ")":
+                depth -= 1
+            index += 1
+        if depth:
+            raise RegistrationError(
+                f"unbalanced {match.group(1)}( at offset {match.start()} in "
+                f"{CMAKE_TESTS.as_posix()}"
+            )
+        found.append((match.group(1), text[match.end() : index - 1].split()))
+    return found
+
+
+def _test_relative(token: str) -> str:
+    """Normalize a source token, written relative to src/tests, to a repo path."""
+    return posixpath.normpath(posixpath.join(TESTS_DIR, token))
+
+
+def ctest_sources(root: Path) -> set[str]:
+    """Repo-relative sources built by an executable that a CTest case runs.
+
+    Keyed by source path rather than target name, so re-pointing a registered
+    target at a different file is visible as drift.
+    """
+    target_sources: dict[str, set[str]] = {}
+    registered_targets: set[str] = set()
+    for command, args in _calls(_read(root, CMAKE_TESTS)):
+        if not args:
+            continue
+        if command == "add_test":
+            # add_test(NAME <case> COMMAND <target> ...) — bind to the target the
+            # case actually runs, which need not share the case's name.
+            if "COMMAND" in args:
+                index = args.index("COMMAND")
+                if index + 1 < len(args):
+                    registered_targets.add(args[index + 1])
+            continue
+        target, rest = args[0], args[1:]
+        if command == "aimee_add_test":
+            registered_targets.add(target)
+        target_sources.setdefault(target, set()).update(
+            _test_relative(item) for item in rest if item.endswith(".c")
+        )
+    # The aimee_add_test function body expands ${test_name}/${ARGN}; those
+    # placeholder tokens never normalize to a declared source path.
+    return {source for target in registered_targets for source in target_sources.get(target, ())}
+
+
+def make_sources(root: Path) -> set[str]:
+    """Repo-relative sources whose object the Make unit-test rules link.
+
+    Make derives tests/<stem>.o from src/tests/<stem>.c by pattern rule, so the
+    object path names the source unambiguously.
+    """
+    text = _read(root, MAKE_RULES)
+    return {
+        _test_relative(f"{stem}.c")
+        for stem in re.findall(r"\$\(OBJDIR\)/tests/([A-Za-z0-9_]+)\.o", text)
+    }
+
+
+def declared_tests(root: Path) -> list[tuple[str, str]]:
+    """(module id, declared test path) for every descriptor, in a stable order."""
+    found: list[tuple[str, str]] = []
+    for descriptor in sorted((root / MODULES).glob("*/module.yaml")):
+        identifier = descriptor.parent.name
+        try:
+            value = json.loads(descriptor.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise RegistrationError(f"cannot read {identifier} descriptor: {exc}") from exc
+        for relative in value.get("tests", []):
+            found.append((identifier, relative))
+    return sorted(found)
+
+
+def report(root: Path) -> dict[str, object]:
+    ctest = ctest_sources(root)
+    make = make_sources(root)
+    entries = []
+    for identifier, relative in declared_tests(root):
+        normalized = posixpath.normpath(relative)
+        entries.append(
+            {
+                "module": identifier,
+                "test": relative,
+                "make": normalized in make,
+                "ctest": normalized in ctest,
+            }
+        )
+    return {"schema_version": 1, "tests": entries}
+
+
+def _format(value: dict[str, object]) -> str:
+    return json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def check(root: Path) -> None:
+    actual = report(root)
+    path = root / BASELINE
+    try:
+        recorded = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RegistrationError(f"cannot read {BASELINE.as_posix()}: {exc}") from exc
+    except ValueError as exc:
+        raise RegistrationError(f"{BASELINE.as_posix()} is not valid JSON: {exc}") from exc
+    if recorded == actual:
+        return
+    recorded_rows = {(row.get("module"), row.get("test")): row for row in recorded.get("tests", [])}
+    actual_rows = {(row["module"], row["test"]): row for row in actual["tests"]}
+    lines = []
+    for key in sorted(set(recorded_rows) | set(actual_rows)):
+        before, after = recorded_rows.get(key), actual_rows.get(key)
+        if before == after:
+            continue
+        lines.append(f"  {key[0]} {key[1]}: recorded={before} actual={after}")
+    raise RegistrationError(
+        "module test registration drifted from "
+        f"{BASELINE.as_posix()}; regenerate with --write and re-review:\n" + "\n".join(lines)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=str(ROOT), help="repository root")
+    parser.add_argument("--write", action="store_true", help="regenerate the baseline")
+    args = parser.parse_args(argv)
+    root = Path(args.root).resolve()
+    try:
+        if args.write:
+            (root / BASELINE).write_text(_format(report(root)), encoding="utf-8")
+            print(f"module-test-registration: wrote {BASELINE.as_posix()}")
+            return 0
+        check(root)
+    except RegistrationError as exc:
+        print(f"module-test-registration: error: {exc}", file=sys.stderr)
+        return 1
+    print(f"module-test-registration: ok ({BASELINE.as_posix()})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_module_test_registration.py
+++ b/scripts/tests/test_check_module_test_registration.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Tests for the descriptor-declared module test registration baseline."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "scripts/check_module_test_registration.py"
+SPEC = importlib.util.spec_from_file_location("check_module_test_registration", CHECKER)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+class RegistrationTests(unittest.TestCase):
+    def repo(self) -> tempfile.TemporaryDirectory[str]:
+        tmp = tempfile.TemporaryDirectory()
+        root = Path(tmp.name)
+        for relative in (checker.CMAKE_TESTS, checker.MAKE_RULES, checker.BASELINE):
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO_ROOT / relative, target)
+        for source in (REPO_ROOT / checker.MODULES).glob("*/module.yaml"):
+            target = root / checker.MODULES / source.parent.name / "module.yaml"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+        return tmp
+
+    def test_production_tree_matches_its_baseline(self) -> None:
+        checker.check(REPO_ROOT)
+
+    def test_report_is_deterministic_and_sorted(self) -> None:
+        report = checker.report(REPO_ROOT)
+        self.assertEqual(report["schema_version"], 1)
+        keys = [(row["module"], row["test"]) for row in report["tests"]]
+        self.assertEqual(keys, sorted(keys))
+        self.assertEqual(len(keys), len(set(keys)))
+        self.assertEqual(report, checker.report(REPO_ROOT))
+
+    def test_known_registration_facts(self) -> None:
+        """The exact facts slices 35 and 36 originally got wrong."""
+        rows = {(r["module"], Path(r["test"]).stem): r for r in checker.report(REPO_ROOT)["tests"]}
+        self.assertTrue(rows[("module-runtime", "test_plugin_c_hook")]["ctest"])
+        self.assertTrue(rows[("plugin-loader", "test_plugin_loader")]["ctest"])
+        self.assertFalse(rows[("plugin-loader", "test_plugin")]["ctest"])
+
+    def test_ctest_registration_is_read_from_the_test_subdirectory(self) -> None:
+        """The original audit error was reading only the top-level CMakeLists.txt."""
+        sources = checker.ctest_sources(REPO_ROOT)
+        self.assertIn("src/tests/test_plugin_c_hook.c", sources)
+        self.assertIn("src/tests/test_plugin_loader.c", sources)
+        self.assertNotIn("src/tests/test_plugin.c", sources)
+
+    def test_registration_is_bound_to_the_source_not_the_target_name(self) -> None:
+        """Re-pointing a registered target at another source must count as drift."""
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CMAKE_TESTS
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)",
+                    "aimee_add_test(test_plugin_c_hook test_something_else.c)",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "test_plugin_c_hook"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_same_basename_in_another_directory_is_not_the_declared_source(self) -> None:
+        """Source identity is the path, not the basename."""
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CMAKE_TESTS
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)",
+                    "aimee_add_test(test_plugin_c_hook ../other/test_plugin_c_hook.c)",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "test_plugin_c_hook"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_a_bracket_commented_source_does_not_count(self) -> None:
+        """CMake bracket comments span lines; their contents are not arguments."""
+        for opener, closer in (("#[[", "]]"), ("#[=[", "]=]")):
+            tmp = self.repo()
+            try:
+                root = Path(tmp.name)
+                path = root / checker.CMAKE_TESTS
+                path.write_text(
+                    path.read_text(encoding="utf-8").replace(
+                        "aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)",
+                        f"aimee_add_test(test_plugin_c_hook\n"
+                        f"    {opener}\n    test_plugin_c_hook.c\n    {closer}\n"
+                        f"    test_something_else.c)",
+                    ),
+                    encoding="utf-8",
+                )
+                with self.subTest(opener=opener), self.assertRaisesRegex(
+                    checker.RegistrationError, "test_plugin_c_hook"
+                ):
+                    checker.check(root)
+            finally:
+                tmp.cleanup()
+
+    def test_a_commented_out_source_does_not_count(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CMAKE_TESTS
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)",
+                    "aimee_add_test(test_plugin_c_hook\n"
+                    "    # test_plugin_c_hook.c\n"
+                    "    test_something_else.c)",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "test_plugin_c_hook"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_a_case_running_another_target_binds_to_that_target(self) -> None:
+        """add_test COMMAND names the target; the case name need not match it."""
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CMAKE_TESTS
+            path.write_text(
+                path.read_text(encoding="utf-8")
+                + "\nadd_executable(plugin_bin test_plugin.c)\n"
+                + "add_test(NAME unrelated_case COMMAND plugin_bin)\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "test_plugin.c"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_an_executable_without_add_test_is_not_registered(self) -> None:
+        """Building a test binary is not registering it as a CTest case."""
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CMAKE_TESTS
+            path.write_text(
+                path.read_text(encoding="utf-8") + "\nadd_executable(test_plugin test_plugin.c)\n",
+                encoding="utf-8",
+            )
+            checker.check(root)
+            path.write_text(
+                path.read_text(encoding="utf-8")
+                + "add_test(NAME test_plugin COMMAND test_plugin)\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "test_plugin"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_unbalanced_call_is_a_closed_error(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CMAKE_TESTS
+            path.write_text(
+                path.read_text(encoding="utf-8") + "\nadd_executable(broken broken.c\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "unbalanced"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_dropping_a_ctest_registration_fails(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CMAKE_TESTS
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)", ""
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "drifted"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_adding_a_ctest_registration_fails(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.CMAKE_TESTS
+            path.write_text(
+                path.read_text(encoding="utf-8") + "\naimee_add_test(test_plugin test_plugin.c)\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "test_plugin"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_dropping_a_make_registration_fails(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.MAKE_RULES
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "$(OBJDIR)/tests/test_gateway_policy.o", "$(OBJDIR)/tests/removed.o"
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(checker.RegistrationError, "test_gateway_policy"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_declaring_a_new_test_fails_until_the_baseline_is_regenerated(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            path = root / checker.MODULES / "gateway/module.yaml"
+            value = json.loads(path.read_text(encoding="utf-8"))
+            value["tests"].append("src/tests/test_gateway_unregistered.c")
+            path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+            with self.assertRaisesRegex(checker.RegistrationError, "test_gateway_unregistered"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_missing_or_malformed_baseline_is_a_closed_error(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / checker.BASELINE).unlink()
+            with self.assertRaisesRegex(checker.RegistrationError, "cannot read"):
+                checker.check(root)
+            (root / checker.BASELINE).write_text("{", encoding="utf-8")
+            with self.assertRaisesRegex(checker.RegistrationError, "not valid JSON"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_missing_build_file_is_a_closed_error(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / checker.CMAKE_TESTS).unlink()
+            with self.assertRaisesRegex(checker.RegistrationError, "cannot read"):
+                checker.check(root)
+        finally:
+            tmp.cleanup()
+
+    def test_write_regenerates_a_matching_baseline(self) -> None:
+        tmp = self.repo()
+        try:
+            root = Path(tmp.name)
+            (root / checker.BASELINE).write_text('{"schema_version": 1, "tests": []}\n',
+                                                 encoding="utf-8")
+            with self.assertRaises(checker.RegistrationError):
+                checker.check(root)
+            self.assertEqual(checker.main(["--root", str(root), "--write"]), 0)
+            checker.check(root)
+        finally:
+            tmp.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -486,6 +486,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains plugin-loader-specific missing-source, planted-source/header, missing-document, and cleared-latch failures, all independent of AIMEE_WITH_PLUGIN_LOADER.",
       "independent_review": "The decision roundtable approved the ownership-only structure on the first optional module and required two narrowings: absence of tracked-tree callers must not be stated as absence of callers or as proof the exports are not ABI, and the removed helper must be described as absent from the current tree rather than as never having existed. Both are applied, and the repository history establishing the #1722 removal was audited. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-36.md", "docs/modules/plugin-loader.md", "src/modules/plugin-loader/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 37,
+      "state": "present_and_verified",
+      "disposition": "Corrected a factual error merged by slices 35 and 36, which claimed CMake registered no test target for module-runtime or plugin-loader because the audit read only the top-level CMakeLists.txt and missed src/tests/CMakeLists.txt, and supplemented the corrected prose with a derived control that pins the per-test build-file registration of every descriptor-declared test to a reviewed baseline.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["This entry supersedes the slice 35 fallback claiming CMake registers no module-runtime test target: src/tests/CMakeLists.txt registers test_plugin_c_hook as a CTest case, so module-runtime has no test-registration debt", "This entry supersedes the slice 36 fallback claiming neither plugin test is registered with CTest: test_plugin_loader is registered and only test_plugin is not, so the remaining debt is one test rather than two", "The historical slice 35 and 36 entries are left intact so the record still shows what each slice asserted when it was reviewed and merged", "test_plugin remains the only descriptor-declared test of a latched module that CTest does not register", "test_audit_action and test_audit_ledger are registered with CTest but not with Make, the inverse asymmetry already recorded by slice 34"],
+      "net_growth": {
+        "status": "justified",
+        "rationale": "A prose correction alone cannot prevent the same audit error from recurring, so the slice adds one derived checker, its failure-mode tests, and a generated baseline.",
+        "rejected_simpler_alternative": "Editing the documents and leaving registration facts to future manual greps would repeat the exact mistake that produced the error, since the miss was reading one build file instead of two.",
+        "revisit": "Fold the baseline into descriptor-generated build profiles once those become authoritative, and delete it if registration is then derived rather than pinned."
+      },
+      "consumers": ["module-inventory CI", "future ownership slices asserting build and test membership", "maintainers reading the slice 35 and 36 records"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; module-inventory CI gains a registration-drift failure and its failure-mode tests.",
+      "independent_review": "The slice decision roundtable required that the correction ship separately from the gateway latch, that a regression control be derived from src/tests/CMakeLists.txt rather than the correction resting on prose, and that the merged slice 35 and 36 ledger entries be superseded rather than rewritten in place. All three are applied; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["scripts/check_module_test_registration.py", "scripts/tests/test_check_module_test_registration.py", "tests/baselines/refactor/module-test-registration.json", "docs/validation/core-modularization-slice-35.md", "docs/validation/core-modularization-slice-36.md"]
     }
   ]
 }

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -1,0 +1,227 @@
+{
+  "schema_version": 1,
+  "tests": [
+    {
+      "ctest": true,
+      "make": false,
+      "module": "audit",
+      "test": "src/tests/test_audit_action.c"
+    },
+    {
+      "ctest": true,
+      "make": false,
+      "module": "audit",
+      "test": "src/tests/test_audit_ledger.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "audit",
+      "test": "src/tests/test_audit_worm.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "audit",
+      "test": "src/tests/test_audit_worm_chain.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "delegates",
+      "test": "src/tests/test_aimee_ir_rescue.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "delegates",
+      "test": "src/tests/test_panel_provider.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "gateway",
+      "test": "src/tests/test_gateway_p4_delegate.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "gateway",
+      "test": "src/tests/test_gateway_pipeline.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "gateway",
+      "test": "src/tests/test_gateway_policy.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "ir",
+      "test": "src/tests/test_aimee_ir.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "ir",
+      "test": "src/tests/test_aimee_ir_metrics.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "ir",
+      "test": "src/tests/test_panel_ir_contract.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "module-runtime",
+      "test": "src/tests/test_plugin_c_hook.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "plugin-loader",
+      "test": "src/tests/test_plugin.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "plugin-loader",
+      "test": "src/tests/test_plugin_loader.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "protocols",
+      "test": "src/tests/test_acp_server.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "protocols",
+      "test": "src/tests/test_mcp_client.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "protocols",
+      "test": "src/tests/test_mcp_client_integration.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "protocols",
+      "test": "src/tests/test_mcp_client_registry.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "protocols",
+      "test": "src/tests/test_mcp_client_sse.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "protocols",
+      "test": "src/tests/test_mcp_gateway_tools.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "protocols",
+      "test": "src/tests/test_mcp_native_surface.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "roundtable",
+      "test": "src/tests/test_delegate_ensemble.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "roundtable",
+      "test": "src/tests/test_roundtable_chair.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "roundtable",
+      "test": "src/tests/test_roundtable_pipeline_capture.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "roundtable",
+      "test": "src/tests/test_roundtable_pipeline_chunk.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "roundtable",
+      "test": "src/tests/test_roundtable_pipeline_eval.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "roundtable",
+      "test": "src/tests/test_roundtable_preset.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "roundtable",
+      "test": "src/tests/test_roundtable_seat_resolve.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "roundtable",
+      "test": "src/tests/test_roundtable_verify.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "skills",
+      "test": "src/tests/test_skill.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "skills",
+      "test": "src/tests/test_skill_review.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "translation",
+      "test": "src/tests/test_aimee_backend.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "translation",
+      "test": "src/tests/test_aimee_backend_bedrock.c"
+    },
+    {
+      "ctest": false,
+      "make": true,
+      "module": "translation",
+      "test": "src/tests/test_aimee_converse_stream.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "translation",
+      "test": "src/tests/test_aimee_frontend.c"
+    },
+    {
+      "ctest": true,
+      "make": true,
+      "module": "translation",
+      "test": "src/tests/test_aimee_ir_stream.c"
+    }
+  ]
+}


### PR DESCRIPTION
Core modularization slice 37 — an **erratum slice**. Slices 35 (#1858) and 36 (#1860) merged a false claim.

## What was wrong

Both slices recorded that CMake registers no test target for the module. The audit grepped only the top-level `CMakeLists.txt` and missed `src/tests/CMakeLists.txt`, which `add_subdirectory(src/tests)` pulls in and which registers 66 CTest cases.

Ground truth:

| test | Make | CTest |
|---|---|---|
| `test_plugin_c_hook` (module-runtime) | yes | **yes** |
| `test_plugin_loader` (plugin-loader) | yes | **yes** |
| `test_plugin` (plugin-loader) | yes | no |

So module-runtime has **no** test-registration debt at all, and plugin-loader's is one test, not two.

## What changes

- **Corrected prose** in `docs/modules/module-runtime.md`, `docs/modules/plugin-loader.md`, and both validation documents. Each validation document carries an explicit `> **Correction (slice 37).**` notice stating what was claimed, why it was wrong, and what is now true. The CTest verification snippets also now build the test target before invoking `ctest` — configuring registers a test but does not build it.
- **New regression control**: `scripts/check_module_test_registration.py` derives per-test registration from `src/tests/CMakeLists.txt` and `src/tests/Rules.mk` and pins it to `tests/baselines/refactor/module-test-registration.json`, wired into `module-inventory` CI with 18 failure-mode tests.
- **Cleanup ledger**: appends a slice 37 entry that supersedes the incorrect slice 35 and 36 `fallbacks`. The historical entries are left intact so the record still shows what each slice asserted when it was reviewed and merged.

No production source, public symbol, build membership, configuration, storage, or runtime behavior changes.

## Why a derived control, not just corrected prose

The mistake was reading one build file instead of two — exactly the kind of error that repeats. The checker binds registration to the **declared source path**, not a target name, so all of these surface as drift:

- re-pointing a registered target at a different source
- a same-basename file in another directory (`../other/test_x.c`)
- a line-commented or bracket-commented (`#[[ ]]`, `#[=[ ]=]`) source
- an `add_test` whose `COMMAND` target differs from its case name
- an `add_executable` with no `add_test` (built, but not registered)

It reports registration, not execution, and does not validate prose — stated explicitly in the module docstring so the control is not itself overclaimed.

The baseline also independently corroborates slice 34's separate (correct) finding: `test_audit_action` and `test_audit_ledger` are CTest-registered but not Make-registered — the inverse asymmetry.

## Review

Decision roundtable directed all three structural choices: ship the correction separately from the gateway latch, add a control derived from the build files rather than resting on prose, and supersede rather than rewrite the merged ledger entries.

Technical-writer review and four exact-diff roundtable rounds found, in order: overstated guarantees about the checker; a disposition that said "replaced" where it supplemented; registration matched by target name only; CTest snippets that would not run in a clean tree; `add_test COMMAND` not bound to its target; basename-only source identity; unstripped line comments; and unstripped bracket comments. All fixed. The final round returned "No issues found."