### PR TITLE
fix(modularization): refuse ownership_complete on an unmigrated module

### DIFF
--- a/docs/modules/module-runtime.md
+++ b/docs/modules/module-runtime.md
@@ -63,7 +63,12 @@ configuration rather than silently applying a partial feature closure.
 Descriptor v1 also supports `private_headers` and the opt-in `ownership_complete` latch. For a
 complete descriptor, the validator compares the declared source and private-header sets with every
 matching owner-local file and requires the canonical module document. An undeclared new file or a
-stale declaration fails CI. Public headers remain confined to `include/aimee/<module>/`; tests are
+stale declaration fails CI. The latch is also refused outright when the module root holds no source
+and no private header: set equality would hold vacuously, so the assertion would mean nothing for a
+module whose implementation has never been moved under `src/modules/<id>/`. That rule is
+`ownership-empty-domain`, it is unconditional, and its message points at
+`docs/validation/core-modularization-class-a-migration.md`, which registers the eight descriptors
+currently in that state. Public headers remain confined to `include/aimee/<module>/`; tests are
 explicit declarations because integration tests can span more than one module. Modules that have not
 set `ownership_complete: true` remain migration debt and must not feed generated build profiles.
 Public headers and tests are validated when declared but are not part of completeness set equality in

--- a/docs/validation/core-modularization-class-a-migration.md
+++ b/docs/validation/core-modularization-class-a-migration.md
@@ -1,0 +1,73 @@
+# Core modularization: the unmigrated module register
+
+## What this records
+
+Nine module descriptors carry `ownership_complete: true`. Seventeen do not, and they are not one
+group. This document tracks the eight whose module root contains nothing but `module.yaml` — no
+implementation has ever been moved under `src/modules/<id>/`. It exists so that gap is recorded in
+one place rather than inferred by re-measuring the tree, and so `rule=ownership-empty-domain` has
+somewhere to point.
+
+The other nine unlatched descriptors have implementation files in their module root that the
+descriptor does not declare. They are a different problem — declaration, then latching — and are not
+tracked here.
+
+## Why an empty root cannot be latched
+
+`validate_complete_ownership` compares the declared source and private-header sets against every
+matching file under the module root. For these eight, both actual sets are empty, so set equality
+holds vacuously and the latch would pass on the source and private-header rules. Until slice 39 the
+only thing preventing it was the separate `docs == ["docs/modules/<id>.md"]` requirement, which none
+of them satisfies — one field away from a descriptor asserting completeness for a module that has not
+been migrated at all.
+
+`docs/modules/module-runtime.md` states that modules without the latch "remain migration debt and
+must not feed generated build profiles." Latching an empty root would silently clear that debt for
+the eight modules furthest from done, and would do it for the eight where the assertion is least
+true. Slice 39 therefore rejects `ownership_complete: true` whenever the module-local domain is
+empty, with `rule=ownership-empty-domain`.
+
+The rule is unconditional. A module that genuinely owned no module-local C — a header-only or
+pure-aggregation module — would also be rejected, and that is the intended behaviour: the right
+response to such a module would be to extend the completeness domain to cover what it actually owns,
+not to weaken the guard on the domain that exists. No current descriptor is a candidate, so that
+design question stays open rather than being pre-answered by an opt-out.
+
+The failure message says the module is not migrated rather than broken. These descriptors are valid;
+they are early.
+
+## The eight
+
+Locations below are what each module's own canonical document names. They are a starting inventory
+for a future migration slice, not an ownership assignment: no audit has confirmed that these files
+are the module's, exclusively or at all. A migration slice must establish that itself.
+
+| module | canonical document names | notes |
+|---|---|---|
+| `benchmarks` | `src/modules/agent_eval/` (`agent_eval.h`) | Adjacent to an existing non-descriptor module directory. |
+| `control-web` | nothing | The document describes the Control Plane GUI, dashboard, assets, listener and proxy behaviour without naming a source location. |
+| `execution-policy` | `src/server/agent_policy.c`, `src/modules/guardrails/guardrails_action_audit.c`, `src/modules/config/config_fields.c`, `src/modules/config/config_sections.c` | Named locations span server, guardrails and config; the policy surface is distributed rather than sited. |
+| `kb-synthesis` | `src/kb/` (`kb_curator_synthesize.h`), `src/db2` | Lives with the KB and its PostgreSQL store. |
+| `response-composition` | `src/modules/ir/include/aimee/ir/aimee_ir.h` | Only an IR contract is named; no implementation site. |
+| `routing` | `src/server/agent_config.c`, `src/headers/agent_config.h`, `src/modules/delegates/delegate_routing.c` | Split across server config and the delegates module. |
+| `runtime-web` | nothing | As with `control-web`, the document specifies the surface and lifecycle key but no source location. |
+| `tools` | `src/posix/agent_tools_dispatch.c`, `src/modules/config/config_fields.c`, `src/modules/config/config_sections.c` | Dispatch is platform-sited under `src/posix`. |
+
+Two observations worth carrying forward:
+
+- `control-web` and `runtime-web` have canonical documents that identify no implementation location
+  at all — not a path, not a bare filename. Both specify their surface and lifecycle key and stop
+  there. A migration slice for either starts with locating the code, not moving it. (`workflows.md`
+  is the only other module document naming neither, and `workflows` is not in this class: its module
+  root holds 30 sources and 24 private headers that its descriptor does not yet declare.)
+- `execution-policy`, `routing` and `tools` are each named across two or more directories, and each is
+  declared as a dependency by several other descriptors — ten, six and five respectively. Their
+  migration is a decomposition question — which of the named files is the module and which is a
+  consumer — not a file move.
+
+## What would change this document
+
+A migration slice that moves one of these implementations under `src/modules/<id>/` should update the
+row, and the module becomes a declaration-then-latch candidate like the other nine unlatched
+descriptors. When the last row is gone this document should be deleted rather than left as an empty
+table.

--- a/scripts/tests/test_validate_module_descriptors.py
+++ b/scripts/tests/test_validate_module_descriptors.py
@@ -322,6 +322,70 @@ class DescriptorTests(unittest.TestCase):
             with self.subTest(identifier=identifier):
                 self.assertIs(descriptor.get("ownership_complete"), True)
 
+    def test_empty_module_root_cannot_be_latched(self) -> None:
+        """An unmigrated module must not satisfy the latch vacuously."""
+        empty = (
+            "benchmarks", "control-web", "execution-policy", "kb-synthesis",
+            "response-composition", "routing", "runtime-web", "tools",
+        )
+        for identifier in empty:
+            tmp = self.production_repo()
+            try:
+                repo = Path(tmp.name)
+                document = f"docs/modules/{identifier}.md"
+                self.mutate_descriptor(
+                    repo, identifier,
+                    lambda value, document=document: value.update(
+                        {"ownership_complete": True, "docs": [document]}
+                    ),
+                )
+                (repo / document).parent.mkdir(parents=True, exist_ok=True)
+                (repo / document).write_text("placeholder\n", encoding="utf-8")
+                with self.subTest(identifier=identifier), self.assertRaisesRegex(
+                    validator.DescriptorError,
+                    r"rule=ownership-empty-domain pointer=/ownership_complete",
+                ):
+                    validator.validate_roots(repo, [Path("src/modules")])
+            finally:
+                tmp.cleanup()
+
+    def test_a_single_module_local_file_is_enough_domain_to_latch(self) -> None:
+        """The guard rejects an empty domain, not a small one."""
+        tmp = self.production_repo()
+        try:
+            repo = Path(tmp.name)
+            source = repo / "src/modules/routing/routing_stub.c"
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text("/* planted */\n", encoding="utf-8")
+            document = "docs/modules/routing.md"
+            self.mutate_descriptor(
+                repo, "routing",
+                lambda value: value.update(
+                    {
+                        "ownership_complete": True,
+                        "docs": [document],
+                        "sources": ["src/modules/routing/routing_stub.c"],
+                    }
+                ),
+            )
+            (repo / document).parent.mkdir(parents=True, exist_ok=True)
+            (repo / document).write_text("placeholder\n", encoding="utf-8")
+            validator.validate_roots(repo, [Path("src/modules")])
+        finally:
+            tmp.cleanup()
+
+    def test_latched_modules_all_have_a_non_empty_domain(self) -> None:
+        """Derived from the graph, so latching a tenth module needs no edit here."""
+        latched = 0
+        for path in sorted((REPO_ROOT / "src/modules").glob("*/module.yaml")):
+            descriptor = json.loads(path.read_text(encoding="utf-8"))
+            if descriptor.get("ownership_complete") is not True:
+                continue
+            latched += 1
+            with self.subTest(identifier=path.parent.name):
+                self.assertTrue(descriptor.get("sources") or descriptor.get("private_headers"))
+        self.assertTrue(latched, "no latched descriptor found; the guard would be untested")
+
     def test_complete_ownership_requires_canonical_doc(self) -> None:
         for identifier in ("roundtable", "ir", "translation", "skills", "audit",
                            "module-runtime", "plugin-loader", "gateway"):

--- a/scripts/validate_module_descriptors.py
+++ b/scripts/validate_module_descriptors.py
@@ -344,6 +344,7 @@ def validate_complete_ownership(repo: Path, identifier: str,
         "sources": ROLE_EXTENSIONS["sources"],
         "private_headers": ROLE_EXTENSIONS["private_headers"],
     }
+    found: dict[str, set[str]] = {}
     for role, extensions in policies.items():
         actual: set[str] = set()
         for path in module_root.rglob("*"):
@@ -365,6 +366,7 @@ def validate_complete_ownership(repo: Path, identifier: str,
                     f"/{role}",
                 )
             actual.add(relative)
+        found[role] = actual
         declared = set(value.get(role, []))
         missing = sorted(actual - declared)
         extra = sorted(declared - actual)
@@ -375,6 +377,19 @@ def validate_complete_ownership(repo: Path, identifier: str,
                 f"missing={missing}, extra={extra}",
                 f"/{role}",
             )
+    if not any(found.values()):
+        # An empty module root satisfies set equality vacuously, so the latch would
+        # assert completeness for a module whose implementation has never been moved
+        # under src/modules/<id>. That is migration debt, not completion. Keep this
+        # ahead of the canonical-document check so an unmigrated module reports why it
+        # cannot be latched rather than which field to add next.
+        fail(
+            "ownership-empty-domain",
+            f"{identifier} has no module-local source or private header, so "
+            "ownership_complete would be vacuous; the module is not migrated rather "
+            "than broken. See docs/validation/core-modularization-class-a-migration.md",
+            "/ownership_complete",
+        )
     expected_doc = f"docs/modules/{identifier}.md"
     if value.get("docs") != [expected_doc]:
         fail("ownership-complete", f"{identifier} docs must equal [{expected_doc!r}]", "/docs")

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -520,6 +520,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains gateway-specific missing-source, planted-source/header, missing-document, and cleared-latch failures, all independent of any build profile.",
       "independent_review": "The decision roundtable approved the ownership-only structure and required that the intentional CMake thin-client boundary not be collapsed with the latent aimee-agent dependency-closure gap, and that the latter be labeled an inference from source lists plus green CI rather than a reproduced result. Both are applied; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-slice-38.md", "docs/modules/gateway.md", "src/modules/gateway/module.yaml", "scripts/tests/test_validate_module_descriptors.py"]
+    },
+    {
+      "slice": 39,
+      "state": "present_and_verified",
+      "disposition": "Closed the vacuous-latch hole by refusing ownership_complete on a module root that holds no source and no private header, where set equality would hold trivially, and registered the eight descriptors currently in that state together with the implementation locations their own canonical documents name.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["Eight descriptors remain unmigrated with an empty module root; the guard prevents them being marked complete but does not schedule their migration", "control-web and runtime-web have canonical documents that name no implementation location at all, so migrating either begins by locating the code", "execution-policy, routing and tools are each named across three or more directories and are decomposition questions rather than file moves", "The register records locations named by module documents, not audited ownership assignments", "Nine further descriptors have module-local files that no descriptor declares and are tracked separately as declaration-then-latch work"],
+      "net_growth": {
+        "status": "justified",
+        "rationale": "The slice adds one validator rule, its mutation tests, and a tracking document; without the rule a single docs field stands between an unmigrated module and an assertion that it is complete.",
+        "rejected_simpler_alternative": "Relying on the existing canonical-document requirement to block empty-root latching was rejected: it blocks by accident rather than by intent, and it would stop blocking the moment a descriptor declared its document.",
+        "revisit": "Delete the register when its last row is migrated; revisit the guard only if a module is designed that genuinely owns no module-local C, in which case extend the completeness domain rather than weaken the rule."
+      },
+      "consumers": ["descriptor-envelope CI", "future migration and declaration slices", "maintainers reading the descriptor graph against the real source layout"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains an empty-domain refusal exercised against all eight unmigrated descriptors.",
+      "independent_review": "The scoping roundtable required the guard be unconditional rather than offering an opt-out for a hypothetical header-only module, required its message to read as not-migrated rather than broken, required the unmigrated set be given a tracked record rather than the guard alone, and required that authoring previously-undeclared ownership claims be split from latching them so an audit never reviews declarations it just wrote. All four are applied; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-class-a-migration.md", "scripts/validate_module_descriptors.py", "scripts/tests/test_validate_module_descriptors.py", "docs/modules/module-runtime.md"]
     }
   ]
 }


### PR DESCRIPTION
Core modularization slice 39. Closes a hole that would let an unmigrated module assert ownership completeness, and registers the eight modules in that state.

## The hole

Nine descriptors are latched; seventeen are not. Measuring the remaining seventeen against the validator's completeness domain shows they are two different problems:

- **Eight have an empty module root** — `benchmarks`, `control-web`, `execution-policy`, `kb-synthesis`, `response-composition`, `routing`, `runtime-web`, `tools` contain nothing but `module.yaml`. Their implementations have never been moved under `src/modules/<id>/`.
- **Nine have module-local files no descriptor declares**, from `governance` (1 source, 1 private header) to `memory` (32 sources, 12 private headers).

For the first eight, `validate_complete_ownership` computes an empty actual set and an empty declared set, so source and private-header equality holds **vacuously**. The only thing preventing the latch was the separate `docs == ["docs/modules/<id>.md"]` requirement — one field away from a descriptor asserting completeness for a module that has not been migrated at all. `docs/modules/module-runtime.md` says unlatched modules "remain migration debt and must not feed generated build profiles"; latching an empty root would silently clear that debt for the eight modules furthest from done.

## What changes

- **`rule=ownership-empty-domain`** in `validate_module_descriptors.py`: refuses `ownership_complete: true` whenever the module-local domain is empty. Ordered ahead of the canonical-document check so an unmigrated module reports *why* it cannot be latched rather than which field to add next.
- **`docs/validation/core-modularization-class-a-migration.md`**: registers the eight, with the implementation locations each module's own canonical document names — marked explicitly as a starting inventory, not an audited ownership assignment.
- Mutation tests over all eight, a negative control proving one module-local file is enough domain to latch, and a derived assertion that every latched descriptor has a non-empty domain.

No production source, public symbol, build membership, configuration, storage, or runtime behavior changes. No descriptor in the tree is currently in the refused state *and* latched, so CI behaviour on the working tree is unchanged.

## The guard is unconditional

A header-only or pure-aggregation module owning no module-local C would also be refused. That is intended: the right response would be to extend the completeness domain to cover what such a module actually owns, not to weaken the guard on the domain that exists. No current descriptor is a candidate, so an opt-out would be designing for a hypothetical while eight real modules wait.

The failure message reads as *not migrated* rather than *broken*. These descriptors are valid; they are early.

## Two findings from the register

- `control-web` and `runtime-web` have canonical documents naming no implementation location at all — not a path, not a bare filename. Migrating either starts with locating the code.
- `execution-policy`, `routing` and `tools` are each named across two or more directories and are depended on by ten, six and five other descriptors respectively. Their migration is a decomposition question, not a file move.

## Review

The scoping roundtable set four requirements, all applied: make the guard unconditional rather than offering a hypothetical opt-out; word the failure as not-migrated; give the unmigrated set a tracked record rather than the guard alone; and **split authoring previously-undeclared ownership claims from latching them**, so an audit never reviews declarations it just wrote. That last one shapes the next slices: each of the nine Class B modules becomes declare-then-latch, starting with `governance` — the smallest, and the first module in the series with private headers, which the completeness domain has never exercised against a real module.

Technical-writer review found an overclaimed directory count and a false claim about other module documents; both fixed. The exact-diff roundtable found no blocking issues and two low ones — a hardcoded list of latched modules (now derived from the graph) and a missing ordering note on the guard (now present).