### PR TITLE
refactor(governance): declare module ownership

### DIFF
--- a/docs/modules/governance.md
+++ b/docs/modules/governance.md
@@ -16,6 +16,17 @@ explicit endpoints, client identity, vault-backed secret reference, redirects, s
 accepted algorithms, and namespaced claim mappings. GitHub may be configured if it conforms, but
 `GitHub` is never the governance contract or default provider.
 
+The descriptor's ownership fields describe what lives under `src/modules/governance/` today, which is
+the response-governance stage alone: `gw_stage_governance.c` and its private header
+`gw_stage_governance.h`, tested by `src/tests/test_response_governance_stage.c`. That is narrower than
+the governance plane this document describes — the OIDC, identity, policy-distribution, and console
+surfaces remain distributed across the KB, DB2, management, and console layers and are not yet
+module-local. The descriptor therefore declares its sources, private header, test, and this document but
+does not set `ownership_complete`: the module is mid-migration, and its declared set is not yet its whole
+intended surface. `docs/validation/core-modularization-slice-40.md` records the audit behind these
+declarations. Latching follows in a separate slice once the declarations have been reviewed on their own,
+so no audit blesses claims written in the same change.
+
 ## Dependencies and consumers
 
 - `audit`: records organizational decisions and supplies the canonical ledger for read-only projections.

--- a/docs/validation/core-modularization-slice-40.md
+++ b/docs/validation/core-modularization-slice-40.md
@@ -1,0 +1,117 @@
+# Core modularization slice 40: declare governance ownership
+
+## Scope
+
+This slice declares the `governance` descriptor's `sources`, `private_headers`, `tests`, and `docs`
+fields. It does not set `ownership_complete`. It is the first of the declaration-then-latch pair the
+scoping roundtable required for the nine descriptors that have module-local files no descriptor
+declares: declaring a file is an ownership claim, and that claim is reviewed here on its own so the
+follow-up latch slice does not bless declarations written in the same change. It changes descriptor
+metadata, the test-registration baseline, documentation, and cleanup accounting only; no production
+code, public symbol, build membership, configuration, storage, or runtime behavior changes.
+
+`governance` is the smallest module in this class — one source and one private header — and it is the
+first module in the whole series to carry a private header. The nine already-latched modules have
+none, so the validator's private-header handling has never been exercised against a real declared
+module. Doing governance first confirms it before the larger declarations depend on it.
+
+## What the module owns today
+
+The descriptor now declares what lives under `src/modules/governance/`:
+
+- `src/modules/governance/gw_stage_governance.c` — the response-governance stage. It wraps
+  `gateway_policy_police_parsed_response` in a togglable response-pipeline stage, collapsing the four
+  inline police call sites into one path that config can disable. It exports two functions:
+  `gw_response_governance_enabled` (the `AIMEE_STAGE_GOVERNANCE` env fallback, default-on) and
+  `gw_response_run_governance` (runs the stage over a parsed response when enabled).
+- `src/modules/governance/gw_stage_governance.h` — the private header for those two exports. It is not
+  under `include/aimee/governance/`; consumers include it as `gw_stage_governance.h` via the
+  `-Imodules/governance` search path, which is what makes it a private header rather than a public one.
+- `src/tests/test_response_governance_stage.c` — the direct test, covering the env-toggle parsing, the
+  enabled drop count, the disabled no-op, and the NULL-parsed guard.
+- `docs/modules/governance.md` — the canonical document.
+
+This is narrower than the governance plane the canonical document describes. The OIDC, organizational
+identity, policy-distribution, and console surfaces named there are distributed across
+`src/kb/auth_oidc.c`, DB2 identity tables, management-token code, and the console, and are not
+module-local. The descriptor claims only what is actually under the module root; the rest is future
+migration, which is exactly why this slice declares but does not latch.
+
+## Source liveness and build membership
+
+- `gw_stage_governance.c` is compiled by Make in `DATA_SRCS` and carries the `-Imodules/governance`
+  include path. It has tracked production callers: `gw_response_run_governance` is called by
+  `src/server/anthropic_http.c` (three sites) and `src/server/openai_chat.c`, and
+  `gw_response_governance_enabled` is read by the governance-enabled resolvers in those same two
+  files. `src/modules/delegates/gw_orch_delegates.c` references the pair in a comment describing the
+  seam. The source is live production code, not a test-only or dead island.
+- The private header is included by `src/server/anthropic_http.c`, `src/server/openai_chat.c`, and the
+  direct test.
+- CMake compiles neither this module's source under any target of its own; as with gateway, CMake
+  builds only the thin client plus the unit-test suite. CMake does add `${AIMEE_SRC_DIR}/modules/governance`
+  to several targets' include paths, but no CMake target lists `gw_stage_governance.c` as a source.
+  This is the same intentional profile boundary recorded for gateway in
+  `docs/validation/core-modularization-slice-38.md`, not drift, and it is orthogonal to declaring
+  ownership.
+
+## Test membership
+
+Make registers `unit-test-response-governance-stage` from `src/tests/test_response_governance_stage.c`
+in `src/tests/Rules.mk`; the same source object is also linked into the two
+`unit-test-anthropic-http*-p2c` integration targets, which is complementary coverage, not a second
+owner. CTest does not register the governance test, consistent with the module sitting outside the
+thin-client profile. `scripts/check_module_test_registration.py` now records the governance row
+(`make: true`, `ctest: false`); its baseline is regenerated in this slice, and that regeneration is
+the only reason the baseline file changes.
+
+`src/tests/support/ir_ingress_stubs.c` defines weak `gw_response_governance_enabled` and
+`gw_response_run_governance` symbols so integration binaries that pull the response path but link no
+policing graph stay inert. Those are deliberate test stubs, recorded so a future reader does not read
+them as a second implementation.
+
+## Why declare without latching
+
+The latch asserts that the descriptor exhaustively covers the module root. That assertion is true here
+today — the module root holds exactly the one source and one header now declared — so the latch would
+pass. The roundtable's point is not that the assertion is false; it is that declaring the files and
+asserting completeness are two distinct claims, and collapsing them into one change means the
+completeness audit reviews declarations it just authored. Keeping them separate means the follow-up
+latch slice reviews declarations that were reviewed and merged on their own first. For a one-source
+module the gap is small; the separation is kept anyway because the same pattern governs the eight
+larger Class B modules behind governance, and doing it consistently is the point.
+
+The validator accepts a declared-but-unlatched descriptor: it validates that each declared path exists
+and is within the module, but enforces set equality only when `ownership_complete` is true. So this
+slice leaves `governance` flagged as migration debt, correctly, while pinning what it owns.
+
+## Regression controls
+
+The declaration is covered by the existing descriptor validation: every declared path must exist and
+resolve within the module, and the regenerated test-registration baseline pins the governance test's
+per-suite registration. The empty-domain guard added in slice 39 does not apply, because the module
+root is not empty. The latch-specific mutation coverage — source removal, planted files, cleared latch
+— is deferred to the latch slice, where `ownership_complete` is set and those mutations become
+meaningful.
+
+## Verification
+
+Run from the repository root; each must exit zero:
+
+```sh
+python3 scripts/validate_module_descriptors.py --check-schema src/modules
+python3 -m unittest scripts.tests.test_validate_module_descriptors
+python3 scripts/check_module_docs.py
+python3 scripts/check_cleanup_ledger.py
+python3 scripts/check_module_test_registration.py
+python3 -m unittest scripts.tests.test_check_module_test_registration
+python3 scripts/check_module_source_ownership.py
+python3 scripts/refactor_baselines.py check
+make -C src -j2
+make -C src lint
+make -C src -j2 build/obj/tests/unit-test-response-governance-stage
+src/build/obj/tests/unit-test-response-governance-stage
+```
+
+The follow-up slice sets `ownership_complete: true`, adds the governance latch mutation tests, and
+records the completeness audit. Technical-writer review, exact-final-diff roundtable approval, and
+every required pull-request check are required before merge.

--- a/src/modules/governance/module.yaml
+++ b/src/modules/governance/module.yaml
@@ -17,5 +17,17 @@
   "enabled_by_default": false,
   "runtime_toggle": {
     "supported": false
-  }
+  },
+  "sources": [
+    "src/modules/governance/gw_stage_governance.c"
+  ],
+  "private_headers": [
+    "src/modules/governance/gw_stage_governance.h"
+  ],
+  "tests": [
+    "src/tests/test_response_governance_stage.c"
+  ],
+  "docs": [
+    "docs/modules/governance.md"
+  ]
 }

--- a/tests/baselines/refactor/cleanup-ledger.json
+++ b/tests/baselines/refactor/cleanup-ledger.json
@@ -537,6 +537,23 @@
       "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; descriptor validation gains an empty-domain refusal exercised against all eight unmigrated descriptors.",
       "independent_review": "The scoping roundtable required the guard be unconditional rather than offering an opt-out for a hypothetical header-only module, required its message to read as not-migrated rather than broken, required the unmigrated set be given a tracked record rather than the guard alone, and required that authoring previously-undeclared ownership claims be split from latching them so an audit never reviews declarations it just wrote. All four are applied; technical-writer review and exact-final-diff roundtable approval remain required before merge.",
       "evidence": ["docs/validation/core-modularization-class-a-migration.md", "scripts/validate_module_descriptors.py", "scripts/tests/test_validate_module_descriptors.py", "docs/modules/module-runtime.md"]
+    },
+    {
+      "slice": 40,
+      "state": "present_and_verified",
+      "disposition": "Declared the governance descriptor's sources, private header, test, and document without setting ownership_complete, as the declaration half of the declaration-then-latch split the scoping roundtable required for modules with module-local files no descriptor declares, and confirmed the single source is live production code with a clean build membership.",
+      "production": {"added": [], "deleted": [], "consolidated": []},
+      "fallbacks": ["The descriptor now declares the response-governance stage alone; the OIDC, identity, policy-distribution and console surfaces the canonical document describes remain distributed across kb, DB2, management and console layers and are not yet module-local", "ownership_complete is deliberately left unset so the follow-up latch slice reviews declarations reviewed on their own first", "CMake compiles no governance source under any target of its own, the same intentional thin-client profile boundary recorded for gateway", "The two weak governance symbols in ir_ingress_stubs.c are deliberate test stubs, not a second implementation"],
+      "net_growth": {
+        "status": "none",
+        "rationale": "The slice changes descriptor metadata, the regenerated test-registration baseline, documentation, and cleanup accounting only, not shipped production code.",
+        "rejected_simpler_alternative": "Declaring and latching in one slice was rejected on roundtable direction: it would make the completeness audit review declarations authored in the same change, and doing that across the nine module class would lock in the wrong precedent.",
+        "revisit": "The follow-up latch slice sets ownership_complete, adds the governance latch mutation tests, and records the completeness audit; the broader governance plane remains a later migration."
+      },
+      "consumers": ["server Anthropic and OpenAI response paths", "descriptor-envelope and module-inventory CI", "the governance latch slice", "future Class B declaration slices"],
+      "blast_radius": "No production source, public symbol, build membership, configuration, storage, or runtime behavior changes; the descriptor gains declared ownership fields validated for existence and containment, and the test-registration baseline gains the governance row.",
+      "independent_review": "The scoping roundtable established that declaration and latching are separate acts and that governance is the correct first module because it is smallest and the first to carry a private header, exercising a validator path the nine latched modules never have. Technical-writer review and exact-final-diff roundtable approval remain required before merge.",
+      "evidence": ["docs/validation/core-modularization-slice-40.md", "docs/modules/governance.md", "src/modules/governance/module.yaml", "tests/baselines/refactor/module-test-registration.json"]
     }
   ]
 }

--- a/tests/baselines/refactor/module-test-registration.json
+++ b/tests/baselines/refactor/module-test-registration.json
@@ -56,6 +56,12 @@
       "test": "src/tests/test_gateway_policy.c"
     },
     {
+      "ctest": false,
+      "make": true,
+      "module": "governance",
+      "test": "src/tests/test_response_governance_stage.c"
+    },
+    {
       "ctest": true,
       "make": true,
       "module": "ir",


### PR DESCRIPTION
Core modularization slice 40 — the **declaration** half of the declaration-then-latch pair the scoping roundtable required for the nine descriptors that have module-local files no descriptor declares. Declares the `governance` descriptor's ownership fields; does **not** set `ownership_complete`.

## Why declaration and latching are separate

The scoping roundtable was firm: declaring a file (asserting it belongs to the module) and asserting completeness are two distinct claims. Collapsing them into one slice makes the completeness audit review declarations it just authored. This slice authors and reviews the declarations on their own; a follow-up slice latches against declarations already merged. For a one-source module the gap is small, but the same pattern governs the eight larger Class B modules behind governance, so it is kept consistent.

## Why governance first

It is the smallest module in the class — one source, one private header — and the **first module in the entire series to carry a private header**. The nine already-latched modules have none, so the validator's private-header containment path has never run against a real declared module. Confirming it here, before the larger declarations depend on it, is the point of going governance-first.

## What the module owns today

The descriptor now declares what actually lives under `src/modules/governance/`:

- `gw_stage_governance.c` — the response-governance stage, wrapping `gateway_policy_police_parsed_response` in a togglable pipeline stage. Live production code: `gw_response_run_governance` is called from `src/server/anthropic_http.c` (×3) and `src/server/openai_chat.c`; `gw_response_governance_enabled` is read by both.
- `gw_stage_governance.h` — the private header (included as `gw_stage_governance.h` via `-Imodules/governance`, not under `include/aimee/governance/`).
- `test_response_governance_stage.c` — the direct test.
- `docs/modules/governance.md`.

This is deliberately narrower than the governance plane the document describes: the OIDC, identity, policy-distribution, and console surfaces remain distributed across `src/kb/auth_oidc.c`, DB2, management-token code, and the console, and are not module-local. The descriptor claims only what is under the module root — which is exactly why this slice declares but does not latch.

## Validation

Declaring without latching is a valid intermediate: the validator checks each declared path exists and resolves within the module, but enforces set-equality only when `ownership_complete` is true. So `governance` stays correctly flagged as migration debt while pinning what it owns. The test-registration baseline gains the governance row (`make: true`, `ctest: false`); that regeneration is the only reason the baseline changes.

All local checks pass, including `check_module_test_registration.py` and the governance unit test.

The exact-diff roundtable returned no issues. The completeness audit, `ownership_complete`, and the latch mutation tests come in the follow-up latch slice.